### PR TITLE
[SR-3215] Bugfix: kafka_default_offsets does not take effect in routine load

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/AlterRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/AlterRoutineLoadStmt.java
@@ -33,7 +33,7 @@ import java.util.Map;
 import java.util.Optional;
 
 /**
- * ALTER ROUTINE LOAD db.label
+ * ALTER ROUTINE LOAD FOR db.label
  * PROPERTIES(
  * ...
  * )

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/RoutineLoadDataSourceProperties.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/RoutineLoadDataSourceProperties.java
@@ -104,12 +104,12 @@ public class RoutineLoadDataSourceProperties {
         // check partitions
         final String kafkaPartitionsString = properties.get(CreateRoutineLoadStmt.KAFKA_PARTITIONS_PROPERTY);
         if (kafkaPartitionsString != null) {
-
             if (!properties.containsKey(CreateRoutineLoadStmt.KAFKA_OFFSETS_PROPERTY)) {
                 throw new AnalysisException("Partition and offset must be specified at the same time");
             }
 
-            CreateRoutineLoadStmt.analyzeKafkaPartitionProperty(kafkaPartitionsString, kafkaPartitionOffsets);
+            CreateRoutineLoadStmt.analyzeKafkaPartitionProperty(kafkaPartitionsString, Maps.newHashMap(),
+                    kafkaPartitionOffsets);
         } else {
             if (properties.containsKey(CreateRoutineLoadStmt.KAFKA_OFFSETS_PROPERTY)) {
                 throw new AnalysisException("Missing kafka partition info");
@@ -135,7 +135,7 @@ public class RoutineLoadDataSourceProperties {
         StringBuilder sb = new StringBuilder();
         sb.append("type: ").append(type);
         sb.append(", kafka partition offsets: ").append(kafkaPartitionOffsets);
-        sb.append(", custome properties: ").append(customKafkaProperties);
+        sb.append(", custom properties: ").append(customKafkaProperties);
         return sb.toString();
     }
 }


### PR DESCRIPTION
When creating a routine load job, if kafka_offsets is not specified but kafka_default_offsets is specified, use kafka_default_offsets to assign offsets to the specified partitions.

```
CREATE ROUTINE LOAD label1 ON tbl
    FROM KAFKA
    (
        "kafka_broker_list" = "host:port",
        "kafka_topic" = "topic1",
        "kafka_partitions" = "0,1",
        "property.kafka_default_offsets" = "OFFSET_BEGINNING"
    );
```