### PR TITLE
[SR-4395] Bugfix: show export failed with NumberFormatException error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/ExportJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/ExportJob.java
@@ -371,7 +371,7 @@ public class ExportJob implements Writable {
             Coordinator coord = new Coordinator(
                     id, queryId, desc, Lists.newArrayList(fragment), Lists.newArrayList(scanNode), clusterName,
                     TimeUtils.DEFAULT_TIME_ZONE);
-            coord.setExecMemoryLimit(getExecMemLimit());
+            coord.setExecMemoryLimit(getMemLimit());
             this.coordList.add(coord);
             LOG.info("split export job to tasks. job id: {}, task idx: {}, task query id: {}",
                     id, i, DebugUtil.printId(queryId));
@@ -419,8 +419,13 @@ public class ExportJob implements Writable {
         return this.rowDelimiter;
     }
 
-    public long getExecMemLimit() {
-        return Long.parseLong(properties.get(LoadStmt.LOAD_MEM_LIMIT));
+    public long getMemLimit() {
+        // The key is exec_mem_limit before version 1.18, check first
+        if (properties.containsKey(LoadStmt.LOAD_MEM_LIMIT)) {
+            return Long.parseLong(properties.get(LoadStmt.LOAD_MEM_LIMIT));
+        } else {
+            return 0;
+        }
     }
 
     public int getTimeoutSecond() {

--- a/fe/fe-core/src/main/java/com/starrocks/load/ExportMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/ExportMgr.java
@@ -242,7 +242,7 @@ public class ExportMgr {
                 infoMap.put("broker", job.getBrokerDesc().getName());
                 infoMap.put("column separator", job.getColumnSeparator());
                 infoMap.put("row delimiter", job.getRowDelimiter());
-                infoMap.put("exec mem limit", job.getExecMemLimit());
+                infoMap.put("mem limit", job.getMemLimit());
                 infoMap.put("coord num", job.getCoordList().size());
                 infoMap.put("tablet num", job.getTabletLocations() == null ? -1 : job.getTabletLocations().size());
                 jobInfo.add(new Gson().toJson(infoMap));


### PR DESCRIPTION
The export job memory limit property was changed from exec_mem_limit
to load_mem_limit in version 1.18, and show export will report an error
because the property key load_mem_limit cannot be found in historical jobs.