### PR TITLE
[SR-4312] Support multi character column_separator during load

### DIFF
--- a/be/src/exec/broker_scanner.h
+++ b/be/src/exec/broker_scanner.h
@@ -99,7 +99,7 @@ private:
 
     std::unique_ptr<TextConverter> _text_converter;
 
-    char _column_separator;
+    string _column_separator;
     char _row_delimiter;
 
     // Reader

--- a/be/src/exec/vectorized/csv_scanner.h
+++ b/be/src/exec/vectorized/csv_scanner.h
@@ -90,7 +90,7 @@ private:
         using Field = Slice;
         using Fields = std::vector<Field>;
 
-        CSVReader(std::shared_ptr<SequentialFile> file, char record_delimiter, char field_delimiter)
+        CSVReader(std::shared_ptr<SequentialFile> file, char record_delimiter, string field_delimiter)
                 : _file(std::move(file)),
                   _record_delimiter(record_delimiter),
                   _field_delimiter(field_delimiter),
@@ -111,7 +111,7 @@ private:
 
         std::shared_ptr<SequentialFile> _file;
         char _record_delimiter;
-        char _field_delimiter;
+        string _field_delimiter;
         raw::RawVector<char> _storage;
         Buffer _buff;
         size_t _parsed_bytes = 0;
@@ -131,7 +131,7 @@ private:
     const TBrokerScanRange& _scan_range;
     std::vector<Column*> _column_raw_ptrs;
     char _record_delimiter;
-    char _field_delimiter;
+    string _field_delimiter;
     int _num_fields_in_csv = 0;
     int _curr_file_index = -1;
     CSVReaderPtr _curr_reader;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/FileScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FileScanNode.java
@@ -231,8 +231,10 @@ public class FileScanNode extends LoadScanNode {
         byte[] column_separator = fileGroup.getColumnSeparator().getBytes(StandardCharsets.UTF_8);
         byte[] row_delimiter = fileGroup.getRowDelimiter().getBytes(StandardCharsets.UTF_8);
         if (column_separator.length != 1) {
-            throw new UserException(
-                    "invalid column separator '" + fileGroup.getColumnSeparator() + "': must be a single character");
+            if (column_separator.length > 50) {
+                throw new UserException("the column separator is limited to a maximum of 50 bytes");
+            }
+            params.setMulti_column_separator(fileGroup.getColumnSeparator());
         }
         if (row_delimiter.length != 1) {
             throw new UserException(

--- a/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadScanNode.java
@@ -59,6 +59,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
@@ -164,13 +165,20 @@ public class StreamLoadScanNode extends LoadScanNode {
 
         if (streamLoadTask.getColumnSeparator() != null) {
             String sep = streamLoadTask.getColumnSeparator().getColumnSeparator();
-            params.setColumn_separator(sep.getBytes(Charset.forName("UTF-8"))[0]);
+            byte[] setBytes = sep.getBytes(StandardCharsets.UTF_8);
+            params.setColumn_separator(setBytes[0]);
+            if (sep.length() > 50) {
+                throw new UserException("the column separator is limited to a maximum of 50 bytes");
+            }
+            if (setBytes.length > 1) {
+                params.setMulti_column_separator(sep);
+            }
         } else {
             params.setColumn_separator((byte) '\t');
         }
         if (streamLoadTask.getRowDelimiter() != null) {
             String sep = streamLoadTask.getRowDelimiter().getRowDelimiter();
-            params.setRow_delimiter(sep.getBytes(Charset.forName("UTF-8"))[0]);
+            params.setRow_delimiter(sep.getBytes(StandardCharsets.UTF_8)[0]);
         } else {
             params.setRow_delimiter((byte) '\n');
         }

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -172,6 +172,8 @@ struct TBrokerScanRangeParams {
     // strictMode is a boolean
     // if strict mode is true, the incorrect data (the result of cast is null) will not be loaded
     10: optional bool strict_mode
+    // If multi_column_separator is set, column_separator becomes ignore.
+    11: optional string multi_column_separator;
 }
 
 // Broker scan range


### PR DESCRIPTION
Before StarRocks support column_separator with only one character during load.
This pull request is to add feature to supporting column_separator with multiple characters.
The threshold is 50 bytes and also support wide-character like ⊙.