### PR TITLE
[SR-4392] Fix when query state is ok does not print warn log.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1159,7 +1159,9 @@ public class StmtExecutor {
             DdlExecutor.execute(context.getCatalog(), (DdlStmt) parsedStmt);
             context.getState().setOk();
         } catch (QueryStateException e) {
-            LOG.warn("DDL statement(" + originStmt.originStmt + ") process failed.", e);
+            if (e.getQueryState().getStateType() != MysqlStateType.OK) {
+                LOG.warn("DDL statement(" + originStmt.originStmt + ") process failed.", e);
+            }
             context.setState(e.getQueryState());
         } catch (UserException e) {
             LOG.warn("DDL statement(" + originStmt.originStmt + ") process failed.", e);


### PR DESCRIPTION
when broker load table does not exists，although the client returned an error message.
but if the user does not log error, it is not easy to chase the problem.
that why add this log before.

but for delete it need to use QueryStateException to transfer information about VISIBLE.
so every delete statement will log this for useless here . we add a judgment that does not log the OK case.