### PR TITLE
[SR-4391] add more log when be can not startup

### DIFF
--- a/be/src/http/ev_http_server.cpp
+++ b/be/src/http/ev_http_server.cpp
@@ -143,7 +143,8 @@ Status EvHttpServer::_bind() {
     if (_server_fd < 0) {
         char buf[64];
         std::stringstream ss;
-        ss << "tcp listen failed, errno=" << errno << ", errmsg=webserver_port:"  << _port << ". " << strerror_r(errno, buf, sizeof(buf));
+        ss << "tcp listen failed, errno=" << errno << ", errmsg=webserver_port:" << _port << ". "
+           << strerror_r(errno, buf, sizeof(buf));
         return Status::InternalError(ss.str());
     }
     if (_port == 0) {

--- a/be/src/http/ev_http_server.cpp
+++ b/be/src/http/ev_http_server.cpp
@@ -143,7 +143,7 @@ Status EvHttpServer::_bind() {
     if (_server_fd < 0) {
         char buf[64];
         std::stringstream ss;
-        ss << "tcp listen failed, errno=" << errno << ", errmsg=" << strerror_r(errno, buf, sizeof(buf));
+        ss << "tcp listen failed, errno=" << errno << ", errmsg=webserver_port:"  << _port << ". " << strerror_r(errno, buf, sizeof(buf));
         return Status::InternalError(ss.str());
     }
     if (_port == 0) {

--- a/be/src/service/starrocks_main.cpp
+++ b/be/src/service/starrocks_main.cpp
@@ -226,7 +226,7 @@ int main(int argc, char** argv) {
         exit(1);
     }
 
-    // 2. bprc service
+    // 2. brpc service
     starrocks::BRpcService brpc_service(exec_env);
     status = brpc_service.start(starrocks::config::brpc_port);
     if (!status.ok()) {
@@ -240,6 +240,7 @@ int main(int argc, char** argv) {
                                         starrocks::config::webserver_num_workers);
     status = http_service.start();
     if (!status.ok()) {
+        LOG(ERROR) << "Internal Error:" << status.message();
         LOG(ERROR) << "StarRocks Be http service did not start correctly, exiting";
         starrocks::shutdown_logging();
         exit(1);


### PR DESCRIPTION
port collisions are a very common problem. 
but user can not figure out from log 
so add more log for more easy to find this problem.