### PR TITLE
[SR-4073] Query making no progress for a long time is expired

### DIFF
--- a/be/src/exec/pipeline/exec_state_reporter.cpp
+++ b/be/src/exec/pipeline/exec_state_reporter.cpp
@@ -169,9 +169,9 @@ void ExecStateReporter::submit(FragmentContext* fragment_ctx, const Status& stat
         }
         if (clean) {
             auto query_id = fragment_ctx->query_id();
-            FragmentContextManager::instance()->unregister(fragment_ctx->fragment_instance_id());
-            auto* query_ctx = QueryContextManager::instance()->get_raw(query_id);
-            DCHECK(query_ctx != nullptr);
+            auto&& query_ctx = QueryContextManager::instance()->get(query_id);
+            DCHECK(query_ctx);
+            query_ctx->fragment_mgr()->unregister(fragment_ctx->fragment_instance_id());
             if (query_ctx->count_down_fragment()) {
                 QueryContextManager::instance()->unregister(query_id);
             }

--- a/be/src/exec/pipeline/fragment_context.h
+++ b/be/src/exec/pipeline/fragment_context.h
@@ -112,12 +112,19 @@ private:
     std::atomic<bool> _cancel_flag;
 };
 class FragmentContextManager {
-    DECLARE_SINGLETON(FragmentContextManager);
-
 public:
+    FragmentContextManager() = default;
+    ~FragmentContextManager() = default;
+
+    FragmentContextManager(const FragmentContextManager&) = delete;
+    FragmentContextManager(FragmentContextManager&&) = delete;
+    FragmentContextManager& operator=(const FragmentContextManager&) = delete;
+    FragmentContextManager& operator=(FragmentContextManager&&) = delete;
+
     FragmentContext* get_or_register(const TUniqueId& fragment_id);
-    FragmentContext* get(const TUniqueId& fragment_id);
+    FragmentContextPtr get(const TUniqueId& fragment_id);
     void unregister(const TUniqueId& fragment_id);
+    void cancel(const Status& status);
 
 private:
     std::mutex _lock;

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -8,6 +8,7 @@
 #include "exec/pipeline/exchange/exchange_sink_operator.h"
 #include "exec/pipeline/exchange/local_exchange_source_operator.h"
 #include "exec/pipeline/exchange/sink_buffer.h"
+#include "exec/pipeline/fragment_context.h"
 #include "exec/pipeline/morsel.h"
 #include "exec/pipeline/pipeline_builder.h"
 #include "exec/pipeline/result_sink_operator.h"
@@ -35,13 +36,28 @@ Morsels convert_scan_range_to_morsel(const std::vector<TScanRangeParams>& scan_r
 
 Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParams& request) {
     const TPlanFragmentExecParams& params = request.params;
-    auto& query_id = params.query_id;
-    auto& fragment_id = params.fragment_instance_id;
+    const auto& query_id = params.query_id;
+    const auto& fragment_id = params.fragment_instance_id;
+
+    // prevent an identical fragment instance from multiple execution
+    auto&& existing_query_ctx = QueryContextManager::instance()->get(query_id);
+    if (existing_query_ctx) {
+        auto&& existing_fragment_ctx = existing_query_ctx->fragment_mgr()->get(fragment_id);
+        if (existing_fragment_ctx) {
+            return Status::OK();
+        }
+    }
+
     _query_ctx = QueryContextManager::instance()->get_or_register(query_id);
     if (params.__isset.instances_number) {
-        _query_ctx->set_num_fragments(params.instances_number);
+        _query_ctx->set_total_fragments(params.instances_number);
     }
-    _fragment_ctx = FragmentContextManager::instance()->get_or_register(fragment_id);
+    if (request.query_options.__isset.pipeline_query_expire_seconds) {
+        _query_ctx->set_expire_seconds(std::max<int>(request.query_options.pipeline_query_expire_seconds, 1));
+    } else {
+        _query_ctx->set_expire_seconds(300);
+    }
+    _fragment_ctx = _query_ctx->fragment_mgr()->get_or_register(fragment_id);
     _fragment_ctx->set_query_id(query_id);
     _fragment_ctx->set_fragment_instance_id(fragment_id);
     _fragment_ctx->set_fe_addr(request.coord);

--- a/be/src/exec/pipeline/pipeline_driver_poller.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_poller.cpp
@@ -48,9 +48,9 @@ void PipelineDriverPoller::run_internal() {
                 // driver->pending_finish() return true means that when a driver's sink operator is finished,
                 // but its source operator still has pending io task that executed in io threads and has
                 // reference to object outside(such as desc_tbl) owned by FragmentContext. So an driver in
-                // PENDING_FINISH state should should wait for pending io task's completion, then turn into
-                // FINISH state, otherwise, pending tasks shall reference to destructed objects in
-                // FragmentContext since FragmentContext is unregistered prematurely.
+                // PENDING_FINISH state should wait for pending io task's completion, then turn into FINISH state,
+                // otherwise, pending tasks shall reference to destructed objects in FragmentContext since
+                // FragmentContext is unregistered prematurely.
                 driver->set_driver_state(DriverState::FINISH);
                 _dispatch_queue->put_back(*driver_it);
                 local_blocked_drivers.erase(driver_it++);

--- a/be/src/exec/pipeline/pipeline_driver_poller.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_poller.cpp
@@ -43,19 +43,37 @@ void PipelineDriverPoller::run_internal() {
         auto driver_it = local_blocked_drivers.begin();
         while (driver_it != local_blocked_drivers.end()) {
             auto& driver = *driver_it;
-            // driver->pending_finish() return true means that when a driver's sink operator is finished,
-            // but its source operator still has pending io task that executed in io threads and has
-            // reference to object outside(such as desc_tbl) owned by FragmentContext. So an driver in
-            // PENDING_FINISH state should should wait for pending io task's completion, then turn into
-            // FINISH state, otherwise, pending tasks shall reference to destructed objects in
-            // FragmentContext since FragmentContext is unregistered prematurely.
+
             if (driver->pending_finish() && !driver->source_operator()->pending_finish()) {
+                // driver->pending_finish() return true means that when a driver's sink operator is finished,
+                // but its source operator still has pending io task that executed in io threads and has
+                // reference to object outside(such as desc_tbl) owned by FragmentContext. So an driver in
+                // PENDING_FINISH state should should wait for pending io task's completion, then turn into
+                // FINISH state, otherwise, pending tasks shall reference to destructed objects in
+                // FragmentContext since FragmentContext is unregistered prematurely.
                 driver->set_driver_state(DriverState::FINISH);
                 _dispatch_queue->put_back(*driver_it);
                 local_blocked_drivers.erase(driver_it++);
             } else if (driver->is_finished()) {
                 local_blocked_drivers.erase(driver_it++);
-            } else if (driver->fragment_ctx()->is_canceled() || driver->is_not_blocked()) {
+            } else if (driver->query_ctx()->is_expired()) {
+                // there are not any drivers belonging to a query context can make progress for a expiration period
+                // indicates that some fragments are missing because of failed exec_plan_fragment invocation. in
+                // this situation, query is failed finally, so drivers are marked PENDING_FINISH/FINISH.
+                if (driver->source_operator()->pending_finish()) {
+                    driver->set_driver_state(DriverState::PENDING_FINISH);
+                    ++driver_it;
+                } else {
+                    driver->set_driver_state(DriverState::FINISH);
+                    _dispatch_queue->put_back(*driver_it);
+                    local_blocked_drivers.erase(driver_it++);
+                }
+            } else if (driver->fragment_ctx()->is_canceled()) {
+                driver->set_driver_state(DriverState::CANCELED);
+                _dispatch_queue->put_back(*driver_it);
+                local_blocked_drivers.erase(driver_it++);
+            } else if (driver->is_not_blocked()) {
+                driver->set_driver_state(DriverState::READY);
                 _dispatch_queue->put_back(*driver_it);
                 local_blocked_drivers.erase(driver_it++);
             } else {

--- a/be/src/exec/pipeline/pipeline_fwd.h
+++ b/be/src/exec/pipeline/pipeline_fwd.h
@@ -10,6 +10,8 @@ class QueryContext;
 using QueryContextPtr = std::shared_ptr<QueryContext>;
 class FragmentContext;
 using FragmentContextPtr = std::shared_ptr<FragmentContext>;
+class FragmentContextManager;
+using FragmentContextManagerPtr = std::unique_ptr<FragmentContextManager>;
 class FragmentExecutor;
 class Pipeline;
 using PipelinePtr = std::shared_ptr<Pipeline>;

--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -1,30 +1,36 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
 #include "exec/pipeline/query_context.h"
+
+#include "exec/pipeline/fragment_context.h"
+
 namespace starrocks {
 namespace pipeline {
+QueryContext::QueryContext()
+        : _fragment_mgr(new FragmentContextManager()), _num_fragments(0), _num_active_fragments(0) {}
+
+FragmentContextManager* QueryContext::fragment_mgr() {
+    return _fragment_mgr.get();
+}
+
+void QueryContext::cancel(const Status& status) {
+    _fragment_mgr->cancel(status);
+}
+
 QueryContextManager::QueryContextManager() {}
 QueryContextManager::~QueryContextManager() {}
 QueryContext* QueryContextManager::get_or_register(const TUniqueId& query_id) {
     std::lock_guard lock(_lock);
     auto iter = _contexts.find(query_id);
     if (iter != _contexts.end()) {
+        iter->second->increment_num_fragments();
         return iter->second.get();
     }
 
     auto&& ctx = std::make_unique<QueryContext>();
     auto* ctx_raw_ptr = ctx.get();
+    ctx_raw_ptr->increment_num_fragments();
     _contexts.emplace(query_id, std::move(ctx));
     return ctx_raw_ptr;
-}
-
-QueryContext* QueryContextManager::get_raw(const TUniqueId& query_id) {
-    std::lock_guard lock(_lock);
-    auto it = _contexts.find(query_id);
-    if (it != _contexts.end()) {
-        return it->second.get();
-    } else {
-        return nullptr;
-    }
 }
 
 QueryContextPtr QueryContextManager::get(const TUniqueId& query_id) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -122,6 +122,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String PIPELINE_SCAN_MODE = "pipeline_scan_mode";
 
+    public static final String PIPELINE_QUERY_EXPIRE_SECONDS = "pipeline_query_expire_seconds";
+
     // vectorized insert flag
     public static final String ENABLE_VECTORIZED_INSERT = "enable_vectorized_insert";
 
@@ -319,6 +321,11 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // 1 means that ScanOperators use async io, otherwise, use sync io instead.
     @VariableMgr.VarAttr(name = PIPELINE_SCAN_MODE)
     private int pipelineScanMode = 1;
+
+    // a query that can not make any progress for more than pipelineQueryExpireSeconds
+    // (300s in default) will be canceled.
+    @VariableMgr.VarAttr(name = PIPELINE_QUERY_EXPIRE_SECONDS)
+    private int pipelineQueryExpireSeconds = 300;
 
     @VariableMgr.VarAttr(name = ENABLE_INSERT_STRICT)
     private boolean enableInsertStrict = true;
@@ -779,6 +786,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         tResult.setRuntime_filter_send_timeout_ms(global_runtime_filter_rpc_timeout);
         tResult.setQuery_threads(pipelineQueryThreads);
         tResult.setPipeline_scan_mode(pipelineScanMode);
+        tResult.setPipeline_query_expire_seconds(pipelineQueryExpireSeconds);
         return tResult;
     }
 

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -208,6 +208,7 @@ message PCancelPlanFragmentRequest {
     required PUniqueId finst_id = 1;
     optional PPlanFragmentCancelReason cancel_reason = 2;
     optional bool is_pipeline = 10;
+    optional PUniqueId query_id = 11;
 };
 
 message PCancelPlanFragmentResult {

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -152,6 +152,8 @@ struct TQueryOptions {
   54: optional i32 query_threads;
   // For pipeline query engine
   55: optional i32 pipeline_scan_mode;
+  // For query context expired period
+  56: optional i32 pipeline_query_expire_seconds
 }
 
 


### PR DESCRIPTION
## Changes

Add a feature that a query that makes no progress for a long time(i.e. 300s) is considered to be expired, so its drivers shall be cancel and QueryContext, FragmentContext shall be cleaned.  here making progress means that some drivers belonging to the query is ready to be executed by execution thread pool continuously. In a corner case, some Fragment instances is delivered to BE successfuly, while some is missing (this scenario results from FE restart), partial drivers on BE have no predecessor to produce input chunks or no sucessor to consume output chunks, then these drivers will be blocked and stay in PipelineDriverPoller forever, in such a situation, query makes no progress and their drivers never ready, so query expiration mechanism is introduced to resolve this problem.

The expiration mechanism behaviors as following:
1. QueryContext uses _deadline to keep lifetime.
2. extends the lifetime of the QueryContext before a ready driver is put on execution thread to execute.
3. QueryContext is expired if its lifetime terminates.
4. In PipelineDriverPoller thread, shutdown drivers belongs to the expired QueryContext.
5. An expired QueryContext is cleaned after all drivers shutdown.
