### PR TITLE
[SR-3695] Fix tablet version published in disorder sequence

### DIFF
--- a/be/src/agent/CMakeLists.txt
+++ b/be/src/agent/CMakeLists.txt
@@ -29,5 +29,6 @@ add_library(Agent STATIC
     agent_server.cpp
     heartbeat_server.cpp
     task_worker_pool.cpp
+    multi_worker_pool.cpp
     utils.cpp
 )

--- a/be/src/agent/multi_worker_pool.cpp
+++ b/be/src/agent/multi_worker_pool.cpp
@@ -1,0 +1,42 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#include "multi_worker_pool.h"
+
+namespace starrocks {
+
+MultiWorkerPool::MultiWorkerPool(const TaskWorkerType worker_type, ExecEnv* env, const TMasterInfo& master_info,
+                                 int worker_num)
+        : TaskWorkerPool(worker_type, env, master_info, worker_num) {
+    DCHECK(worker_num > 0);
+    for (int i = 0; i < worker_num; i++) {
+        auto pool = std::make_shared<TaskWorkerPool>(worker_type, env, master_info, 1);
+        _pools.push_back(pool);
+    }
+}
+
+void MultiWorkerPool::start() {
+    for (auto pool : _pools) {
+        pool->start();
+    }
+}
+
+void MultiWorkerPool::submit_publish_version_task(const TAgentTaskRequest& task) {
+    auto req = task.publish_version_req;
+    for (auto& partition : req.partition_version_infos) {
+        auto pool_id = partition.partition_id % _pools.size();
+        auto pool = _pools[pool_id];
+        pool->submit_task(task);
+    }
+}
+
+void MultiWorkerPool::submit_task(const TAgentTaskRequest& task) {
+    switch (task.task_type) {
+    case ::starrocks::TTaskType::PUBLISH_VERSION:
+        submit_publish_version_task(task);
+        break;
+    default:
+        LOG(INFO) << "task type " << task.task_type << " is not supported current";
+        return;
+    }
+}
+} // namespace starrocks

--- a/be/src/agent/multi_worker_pool.h
+++ b/be/src/agent/multi_worker_pool.h
@@ -1,0 +1,29 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#pragma once
+
+#include "task_worker_pool.h"
+
+namespace starrocks {
+
+// MultiWorkerPool contains multiple task pool. Each pool processed by one single worker thread.
+// We create MultiWorkerPool for processing publish version task, these tasks are
+// submitted to one task pool according to its partition id, so the tasks belong to
+// the same partition will be processed by the same worker thread.
+class MultiWorkerPool : public TaskWorkerPool {
+public:
+    MultiWorkerPool(const TaskWorkerType worker_type, ExecEnv* env, const TMasterInfo& master_info, int worker_num);
+
+    virtual ~MultiWorkerPool(){};
+
+    virtual void start();
+
+    // submit task to queue and wait to be executed
+    virtual void submit_task(const TAgentTaskRequest& task);
+
+private:
+    void submit_publish_version_task(const TAgentTaskRequest& task);
+
+    std::vector<std::shared_ptr<TaskWorkerPool>> _pools;
+};
+} // namespace starrocks

--- a/be/src/agent/task_worker_pool.h
+++ b/be/src/agent/task_worker_pool.h
@@ -73,7 +73,7 @@ public:
 
     typedef void* (*CALLBACK_FUNCTION)(void*);
 
-    TaskWorkerPool(const TaskWorkerType task_worker_type, ExecEnv* env, const TMasterInfo& master_info);
+    TaskWorkerPool(const TaskWorkerType task_worker_type, ExecEnv* env, const TMasterInfo& master_info, int worker_num);
     virtual ~TaskWorkerPool();
 
     // Start the task worker callback thread


### PR DESCRIPTION
Create multiple task worker pools for publish version task and create
a work thread for each pool. The task belongs to the same partition
will be put into the same pool, so that tablet version will be published sequentially.