### PR TITLE
[SR-4407] Provide aggregate operators for pipeline engine

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -173,6 +173,9 @@ set(EXEC_FILES
     pipeline/exec_state_reporter.cpp
     pipeline/fragment_context.cpp
     pipeline/query_context.cpp
+    pipeline/aggregate_base_operator.cpp
+    pipeline/aggregate_blocking_operator.cpp
+    pipeline/aggregate_streaming_operator.cpp
 )
 
 if (WITH_MYSQL)

--- a/be/src/exec/pipeline/aggregate_base_operator.cpp
+++ b/be/src/exec/pipeline/aggregate_base_operator.cpp
@@ -491,7 +491,7 @@ void AggregateBaseOperator::_convert_to_chunk_no_groupby(vectorized::ChunkPtr* c
     }
     ++_num_rows_returned;
     *chunk = std::move(result_chunk);
-    _is_finished = true;
+    _is_hash_table_eos = true;
 }
 
 void AggregateBaseOperator::_serialize_to_chunk(vectorized::ConstAggDataPtr state,

--- a/be/src/exec/pipeline/aggregate_base_operator.cpp
+++ b/be/src/exec/pipeline/aggregate_base_operator.cpp
@@ -491,7 +491,7 @@ void AggregateBaseOperator::_convert_to_chunk_no_groupby(vectorized::ChunkPtr* c
     }
     ++_num_rows_returned;
     *chunk = std::move(result_chunk);
-    _is_hash_table_eos = true;
+    _is_ht_done = true;
 }
 
 void AggregateBaseOperator::_serialize_to_chunk(vectorized::ConstAggDataPtr state,

--- a/be/src/exec/pipeline/aggregate_base_operator.cpp
+++ b/be/src/exec/pipeline/aggregate_base_operator.cpp
@@ -1,14 +1,13 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
 
-#include "exec/vectorized/aggregate/aggregate_base_node.h"
+#include "aggregate_base_operator.h"
 
 #include "exprs/anyval_util.h"
 #include "gutil/strings/substitute.h"
+namespace starrocks::pipeline {
 
-namespace starrocks::vectorized {
-
-AggregateBaseNode::AggregateBaseNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs)
-        : ExecNode(pool, tnode, descs),
+AggregateBaseOperator::AggregateBaseOperator(int32_t id, std::string name, int32_t plan_node_id, const TPlanNode& tnode)
+        : Operator(id, name, plan_node_id),
           _tnode(tnode),
           _needs_finalize(tnode.agg_node.need_finalize),
           _streaming_preaggregation_mode(tnode.agg_node.streaming_preaggregation_mode),
@@ -17,27 +16,31 @@ AggregateBaseNode::AggregateBaseNode(ObjectPool* pool, const TPlanNode& tnode, c
           _output_tuple_id(tnode.agg_node.output_tuple_id),
           _output_tuple_desc(nullptr) {}
 
-AggregateBaseNode::~AggregateBaseNode() = default;
+Status AggregateBaseOperator::prepare(RuntimeState* state) {
+    RETURN_IF_ERROR(Operator::prepare(state));
 
-Status AggregateBaseNode::init(const TPlanNode& tnode, RuntimeState* state) {
-    RETURN_IF_ERROR(ExecNode::init(tnode, state));
-    RETURN_IF_ERROR(Expr::create_expr_trees(_pool, tnode.agg_node.grouping_exprs, &_group_by_expr_ctxs));
+    // TODO(hcf) which obj pool should I use
+    _pool = state->obj_pool();
+    _rows_returned_counter = ADD_COUNTER(get_runtime_profile(), "RowsReturned", TUnit::UNIT);
+
+    // TODO(hcf) following copy from AggregateBaseNode::init
+    RETURN_IF_ERROR(Expr::create_expr_trees(_pool, _tnode.agg_node.grouping_exprs, &_group_by_expr_ctxs));
     // add profile attributes
-    if (tnode.agg_node.__isset.sql_grouping_keys) {
-        _runtime_profile->add_info_string("GroupingKeys", tnode.agg_node.sql_grouping_keys);
+    if (_tnode.agg_node.__isset.sql_grouping_keys) {
+        get_runtime_profile()->add_info_string("GroupingKeys", _tnode.agg_node.sql_grouping_keys);
     }
-    if (tnode.agg_node.__isset.sql_aggregate_functions) {
-        _runtime_profile->add_info_string("AggregateFunctions", tnode.agg_node.sql_aggregate_functions);
+    if (_tnode.agg_node.__isset.sql_aggregate_functions) {
+        get_runtime_profile()->add_info_string("AggregateFunctions", _tnode.agg_node.sql_aggregate_functions);
     }
 
-    bool has_outer_join_child = tnode.agg_node.__isset.has_outer_join_child && tnode.agg_node.has_outer_join_child;
+    bool has_outer_join_child = _tnode.agg_node.__isset.has_outer_join_child && _tnode.agg_node.has_outer_join_child;
     VLOG_ROW << "has_outer_join_child " << has_outer_join_child;
 
     size_t group_by_size = _group_by_expr_ctxs.size();
     _group_by_columns.resize(group_by_size);
     _group_by_types.resize(group_by_size);
     for (size_t i = 0; i < group_by_size; ++i) {
-        TExprNode expr = tnode.agg_node.grouping_exprs[i].nodes[0];
+        TExprNode expr = _tnode.agg_node.grouping_exprs[i].nodes[0];
         _group_by_types[i].result_type = TypeDescriptor::from_thrift(expr.type);
         _group_by_types[i].is_nullable = expr.is_nullable || has_outer_join_child;
         _has_nullable_key = _has_nullable_key || _group_by_types[i].is_nullable;
@@ -48,7 +51,7 @@ Status AggregateBaseNode::init(const TPlanNode& tnode, RuntimeState* state) {
 
     _tmp_agg_states.resize(config::vector_chunk_size);
 
-    size_t agg_size = tnode.agg_node.aggregate_functions.size();
+    size_t agg_size = _tnode.agg_node.aggregate_functions.size();
     _agg_fn_ctxs.resize(agg_size);
     _agg_functions.resize(agg_size);
     _agg_expr_ctxs.resize(agg_size);
@@ -59,16 +62,16 @@ Status AggregateBaseNode::init(const TPlanNode& tnode, RuntimeState* state) {
     _is_merge_funcs.resize(agg_size);
 
     for (int i = 0; i < agg_size; ++i) {
-        const TExpr& desc = tnode.agg_node.aggregate_functions[i];
+        const TExpr& desc = _tnode.agg_node.aggregate_functions[i];
         const TFunction& fn = desc.nodes[0].fn;
-        _is_merge_funcs[i] = tnode.agg_node.aggregate_functions[i].nodes[0].agg_expr.is_merge_agg;
+        _is_merge_funcs[i] = _tnode.agg_node.aggregate_functions[i].nodes[0].agg_expr.is_merge_agg;
         VLOG_ROW << fn.name.function_name << " is arg nullable " << desc.nodes[0].has_nullable_child;
         VLOG_ROW << fn.name.function_name << " is result nullable " << desc.nodes[0].is_nullable;
         if (fn.name.function_name == "count") {
             {
                 bool is_input_nullable =
                         !fn.arg_types.empty() && (has_outer_join_child || desc.nodes[0].has_nullable_child);
-                auto* func = get_aggregate_function("count", TYPE_BIGINT, TYPE_BIGINT, is_input_nullable);
+                auto* func = vectorized::get_aggregate_function("count", TYPE_BIGINT, TYPE_BIGINT, is_input_nullable);
                 _agg_functions[i] = func;
             }
             std::vector<FunctionContext::TypeDesc> arg_typedescs;
@@ -95,8 +98,8 @@ Status AggregateBaseNode::init(const TPlanNode& tnode, RuntimeState* state) {
             }
 
             bool is_input_nullable = has_outer_join_child || desc.nodes[0].has_nullable_child;
-            auto* func =
-                    get_aggregate_function(fn.name.function_name, arg_type.type, return_type.type, is_input_nullable);
+            auto* func = vectorized::get_aggregate_function(fn.name.function_name, arg_type.type, return_type.type,
+                                                            is_input_nullable);
             if (func == nullptr) {
                 return Status::InternalError(
                         strings::Substitute("Invalid agg function plan: $0", fn.name.function_name));
@@ -137,171 +140,35 @@ Status AggregateBaseNode::init(const TPlanNode& tnode, RuntimeState* state) {
 
     _is_only_group_by_columns = _agg_expr_ctxs.empty() && !_group_by_expr_ctxs.empty();
 
-    return Status::OK();
-}
-
-void AggregateBaseNode::_evaluate_const_columns(int i) {
-    // used for const columns.
-    std::vector<ColumnPtr> const_columns;
-    const_columns.reserve(_agg_expr_ctxs[i].size());
-    for (int j = 0; j < _agg_expr_ctxs[i].size(); ++j) {
-        const_columns.emplace_back(_agg_expr_ctxs[i][j]->root()->evaluate_const(_agg_expr_ctxs[i][j]));
-    }
-    _agg_fn_ctxs[i]->impl()->set_constant_columns(const_columns);
-}
-
-template <typename HashVariantType>
-void AggregateBaseNode::_init_agg_hash_variant(HashVariantType& hash_variant) {
-    auto type = _aggr_phase == AggrPhase1 ? HashVariantType::Type::phase1_slice : HashVariantType::Type::phase2_slice;
-    if (_has_nullable_key) {
-        switch (_group_by_expr_ctxs.size()) {
-        case 0:
-            break;
-        case 1: {
-            auto group_by_expr = _group_by_expr_ctxs[0];
-            switch (group_by_expr->root()->type().type) {
-            case TYPE_TINYINT: {
-                type = _aggr_phase == AggrPhase1 ? HashVariantType::Type::phase1_null_int8
-                                                 : HashVariantType::Type::phase2_null_int8;
-                break;
-            }
-            case TYPE_SMALLINT: {
-                type = _aggr_phase == AggrPhase1 ? HashVariantType::Type::phase1_null_int16
-                                                 : HashVariantType::Type::phase2_null_int16;
-                break;
-            }
-            case TYPE_INT: {
-                type = _aggr_phase == AggrPhase1 ? HashVariantType::Type::phase1_null_int32
-                                                 : HashVariantType::Type::phase2_null_int32;
-                break;
-            }
-            case TYPE_BIGINT: {
-                type = _aggr_phase == AggrPhase1 ? HashVariantType::Type::phase1_null_int64
-                                                 : HashVariantType::Type::phase2_null_int64;
-                break;
-            }
-            case TYPE_DATE: {
-                type = _aggr_phase == AggrPhase1 ? HashVariantType::Type::phase1_null_date
-                                                 : HashVariantType::Type::phase2_null_date;
-                break;
-            }
-            case TYPE_DATETIME: {
-                type = _aggr_phase == AggrPhase1 ? HashVariantType::Type::phase1_null_timestamp
-                                                 : HashVariantType::Type::phase2_null_timestamp;
-                break;
-            }
-            case TYPE_CHAR:
-            case TYPE_VARCHAR: {
-                type = _aggr_phase == AggrPhase1 ? HashVariantType::Type::phase1_null_string
-                                                 : HashVariantType::Type::phase2_null_string;
-                break;
-            }
-            default: {
-                type = _aggr_phase == AggrPhase1 ? HashVariantType::Type::phase1_slice
-                                                 : HashVariantType::Type::phase2_slice;
-                break;
-            }
-            }
-            break;
-        }
-        default: {
-            type = _aggr_phase == AggrPhase1 ? HashVariantType::Type::phase1_slice
-                                             : HashVariantType::Type::phase2_slice;
-            break;
-        }
-        }
-    } else {
-        switch (_group_by_expr_ctxs.size()) {
-        case 0:
-            break;
-        case 1: {
-            auto group_by_expr = _group_by_expr_ctxs[0];
-            switch (group_by_expr->root()->type().type) {
-            case TYPE_TINYINT: {
-                type = _aggr_phase == AggrPhase1 ? HashVariantType::Type::phase1_int8
-                                                 : HashVariantType::Type::phase2_int8;
-                break;
-            }
-            case TYPE_SMALLINT: {
-                type = _aggr_phase == AggrPhase1 ? HashVariantType::Type::phase1_int16
-                                                 : HashVariantType::Type::phase2_int16;
-                break;
-            }
-            case TYPE_INT: {
-                type = _aggr_phase == AggrPhase1 ? HashVariantType::Type::phase1_int32
-                                                 : HashVariantType::Type::phase2_int32;
-                break;
-            }
-            case TYPE_BIGINT: {
-                type = _aggr_phase == AggrPhase1 ? HashVariantType::Type::phase1_int64
-                                                 : HashVariantType::Type::phase2_int64;
-                break;
-            }
-            case TYPE_DATE: {
-                type = _aggr_phase == AggrPhase1 ? HashVariantType::Type::phase1_date
-                                                 : HashVariantType::Type::phase2_date;
-                break;
-            }
-            case TYPE_DATETIME: {
-                type = _aggr_phase == AggrPhase1 ? HashVariantType::Type::phase1_timestamp
-                                                 : HashVariantType::Type::phase2_timestamp;
-                break;
-            }
-            case TYPE_CHAR:
-            case TYPE_VARCHAR: {
-                type = _aggr_phase == AggrPhase1 ? HashVariantType::Type::phase1_string
-                                                 : HashVariantType::Type::phase2_string;
-                break;
-            }
-            default: {
-                type = _aggr_phase == AggrPhase1 ? HashVariantType::Type::phase1_slice
-                                                 : HashVariantType::Type::phase2_slice;
-                break;
-            }
-            }
-            break;
-        }
-        default: {
-            type = _aggr_phase == AggrPhase1 ? HashVariantType::Type::phase1_slice
-                                             : HashVariantType::Type::phase2_slice;
-            break;
-        }
-        }
-    }
-    VLOG_ROW << "hash type is "
-             << static_cast<typename std::underlying_type<typename HashVariantType::Type>::type>(type);
-    hash_variant.init(type);
-}
-
-Status AggregateBaseNode::prepare(RuntimeState* state) {
-    RETURN_IF_ERROR(ExecNode::prepare(state));
-    _get_results_timer = ADD_TIMER(runtime_profile(), "GetResultsTime");
-    _iter_timer = ADD_TIMER(runtime_profile(), "ResultIteratorTime");
-    _agg_append_timer = ADD_TIMER(runtime_profile(), "ResultAggAppendTime");
-    _group_by_append_timer = ADD_TIMER(runtime_profile(), "ResultGroupByAppendTime");
+    // TODO(hcf) following copy from AggregateBaseNode::prepare
+    _get_results_timer = ADD_TIMER(get_runtime_profile(), "GetResultsTime");
+    _iter_timer = ADD_TIMER(get_runtime_profile(), "ResultIteratorTime");
+    _agg_append_timer = ADD_TIMER(get_runtime_profile(), "ResultAggAppendTime");
+    _group_by_append_timer = ADD_TIMER(get_runtime_profile(), "ResultGroupByAppendTime");
     //TODO: split agg_compute_timer to cunstruct_ht_time + agg_func_compute_time
-    _agg_compute_timer = ADD_TIMER(runtime_profile(), "AggComputeTime");
-    _streaming_timer = ADD_TIMER(runtime_profile(), "StreamingTime");
-    _expr_compute_timer = ADD_TIMER(runtime_profile(), "ExprComputeTime");
-    _expr_release_timer = ADD_TIMER(runtime_profile(), "ExprReleaseTime");
+    _agg_compute_timer = ADD_TIMER(get_runtime_profile(), "AggComputeTime");
+    _streaming_timer = ADD_TIMER(get_runtime_profile(), "StreamingTime");
+    _expr_compute_timer = ADD_TIMER(get_runtime_profile(), "ExprComputeTime");
+    _expr_release_timer = ADD_TIMER(get_runtime_profile(), "ExprReleaseTime");
 
-    _input_row_count = ADD_COUNTER(runtime_profile(), "InputRowCount", TUnit::UNIT);
-    _hash_table_size = ADD_COUNTER(runtime_profile(), "HashTableSize", TUnit::UNIT);
-    _pass_through_row_count = ADD_COUNTER(runtime_profile(), "PassThroughRowCount", TUnit::UNIT);
+    _input_row_count = ADD_COUNTER(get_runtime_profile(), "InputRowCount", TUnit::UNIT);
+    _hash_table_size = ADD_COUNTER(get_runtime_profile(), "HashTableSize", TUnit::UNIT);
+    _pass_through_row_count = ADD_COUNTER(get_runtime_profile(), "PassThroughRowCount", TUnit::UNIT);
 
-    SCOPED_TIMER(_runtime_profile->total_time_counter());
+    SCOPED_TIMER(get_runtime_profile()->total_time_counter());
 
     _intermediate_tuple_desc = state->desc_tbl().get_tuple_descriptor(_intermediate_tuple_id);
     _output_tuple_desc = state->desc_tbl().get_tuple_descriptor(_output_tuple_id);
     DCHECK_EQ(_intermediate_tuple_desc->slots().size(), _output_tuple_desc->slots().size());
-    RETURN_IF_ERROR(Expr::prepare(_group_by_expr_ctxs, state, child(0)->row_desc(), expr_mem_tracker()));
 
-    for (const auto& ctx : _agg_expr_ctxs) {
-        RETURN_IF_ERROR(Expr::prepare(ctx, state, child(0)->row_desc(), expr_mem_tracker()));
-    }
+    // TODO(hcf) force annotation
+    // RETURN_IF_ERROR(Expr::prepare(_group_by_expr_ctxs, state, child(0)->row_desc(), expr_mem_tracker()));
 
-    // Note: ExecNode init mem_tracker when ExecNode::prepare
-    _mem_pool = std::make_unique<MemPool>(mem_tracker());
+    // for (const auto& ctx : _agg_expr_ctxs) {
+    //     RETURN_IF_ERROR(Expr::prepare(ctx, state, child(0)->row_desc(), expr_mem_tracker()));
+    // }
+
+    _mem_pool = std::make_unique<MemPool>(get_memtracker());
 
     // Initial for FunctionContext of every aggregate functions
     for (int i = 0; i < _agg_fn_ctxs.size(); ++i) {
@@ -329,22 +196,144 @@ Status AggregateBaseNode::prepare(RuntimeState* state) {
         _init_agg_hash_variant(_hash_map_variant);
     }
 
-    if (_group_by_expr_ctxs.empty()) {
-        _compute_agg_states = &AggregateBaseNode::_compute_single_agg_state;
-    } else {
-        _compute_agg_states = &AggregateBaseNode::_compute_batch_agg_states;
-    }
-
-    // determine serialize or finalize function
-    if (_needs_finalize) {
-        _serialize_or_finalize = &AggregateBaseNode::_finalize_to_chunk;
-    } else {
-        _serialize_or_finalize = &AggregateBaseNode::_serialize_to_chunk;
-    }
     return Status::OK();
 }
 
-void AggregateBaseNode::_compute_single_agg_state(size_t chunk_size) {
+void AggregateBaseOperator::_evaluate_const_columns(int i) {
+    // used for const columns.
+    std::vector<ColumnPtr> const_columns;
+    const_columns.reserve(_agg_expr_ctxs[i].size());
+    for (int j = 0; j < _agg_expr_ctxs[i].size(); ++j) {
+        const_columns.emplace_back(_agg_expr_ctxs[i][j]->root()->evaluate_const(_agg_expr_ctxs[i][j]));
+    }
+    _agg_fn_ctxs[i]->impl()->set_constant_columns(const_columns);
+}
+
+template <typename HashVariantType>
+void AggregateBaseOperator::_init_agg_hash_variant(HashVariantType& hash_variant) {
+    auto type = _aggr_phase == vectorized::AggrPhase1 ? HashVariantType::Type::phase1_slice
+                                                      : HashVariantType::Type::phase2_slice;
+    if (_has_nullable_key) {
+        switch (_group_by_expr_ctxs.size()) {
+        case 0:
+            break;
+        case 1: {
+            auto group_by_expr = _group_by_expr_ctxs[0];
+            switch (group_by_expr->root()->type().type) {
+            case TYPE_TINYINT: {
+                type = _aggr_phase == vectorized::AggrPhase1 ? HashVariantType::Type::phase1_null_int8
+                                                             : HashVariantType::Type::phase2_null_int8;
+                break;
+            }
+            case TYPE_SMALLINT: {
+                type = _aggr_phase == vectorized::AggrPhase1 ? HashVariantType::Type::phase1_null_int16
+                                                             : HashVariantType::Type::phase2_null_int16;
+                break;
+            }
+            case TYPE_INT: {
+                type = _aggr_phase == vectorized::AggrPhase1 ? HashVariantType::Type::phase1_null_int32
+                                                             : HashVariantType::Type::phase2_null_int32;
+                break;
+            }
+            case TYPE_BIGINT: {
+                type = _aggr_phase == vectorized::AggrPhase1 ? HashVariantType::Type::phase1_null_int64
+                                                             : HashVariantType::Type::phase2_null_int64;
+                break;
+            }
+            case TYPE_DATE: {
+                type = _aggr_phase == vectorized::AggrPhase1 ? HashVariantType::Type::phase1_null_date
+                                                             : HashVariantType::Type::phase2_null_date;
+                break;
+            }
+            case TYPE_DATETIME: {
+                type = _aggr_phase == vectorized::AggrPhase1 ? HashVariantType::Type::phase1_null_timestamp
+                                                             : HashVariantType::Type::phase2_null_timestamp;
+                break;
+            }
+            case TYPE_CHAR:
+            case TYPE_VARCHAR: {
+                type = _aggr_phase == vectorized::AggrPhase1 ? HashVariantType::Type::phase1_null_string
+                                                             : HashVariantType::Type::phase2_null_string;
+                break;
+            }
+            default: {
+                type = _aggr_phase == vectorized::AggrPhase1 ? HashVariantType::Type::phase1_slice
+                                                             : HashVariantType::Type::phase2_slice;
+                break;
+            }
+            }
+            break;
+        }
+        default: {
+            type = _aggr_phase == vectorized::AggrPhase1 ? HashVariantType::Type::phase1_slice
+                                                         : HashVariantType::Type::phase2_slice;
+            break;
+        }
+        }
+    } else {
+        switch (_group_by_expr_ctxs.size()) {
+        case 0:
+            break;
+        case 1: {
+            auto group_by_expr = _group_by_expr_ctxs[0];
+            switch (group_by_expr->root()->type().type) {
+            case TYPE_TINYINT: {
+                type = _aggr_phase == vectorized::AggrPhase1 ? HashVariantType::Type::phase1_int8
+                                                             : HashVariantType::Type::phase2_int8;
+                break;
+            }
+            case TYPE_SMALLINT: {
+                type = _aggr_phase == vectorized::AggrPhase1 ? HashVariantType::Type::phase1_int16
+                                                             : HashVariantType::Type::phase2_int16;
+                break;
+            }
+            case TYPE_INT: {
+                type = _aggr_phase == vectorized::AggrPhase1 ? HashVariantType::Type::phase1_int32
+                                                             : HashVariantType::Type::phase2_int32;
+                break;
+            }
+            case TYPE_BIGINT: {
+                type = _aggr_phase == vectorized::AggrPhase1 ? HashVariantType::Type::phase1_int64
+                                                             : HashVariantType::Type::phase2_int64;
+                break;
+            }
+            case TYPE_DATE: {
+                type = _aggr_phase == vectorized::AggrPhase1 ? HashVariantType::Type::phase1_date
+                                                             : HashVariantType::Type::phase2_date;
+                break;
+            }
+            case TYPE_DATETIME: {
+                type = _aggr_phase == vectorized::AggrPhase1 ? HashVariantType::Type::phase1_timestamp
+                                                             : HashVariantType::Type::phase2_timestamp;
+                break;
+            }
+            case TYPE_CHAR:
+            case TYPE_VARCHAR: {
+                type = _aggr_phase == vectorized::AggrPhase1 ? HashVariantType::Type::phase1_string
+                                                             : HashVariantType::Type::phase2_string;
+                break;
+            }
+            default: {
+                type = _aggr_phase == vectorized::AggrPhase1 ? HashVariantType::Type::phase1_slice
+                                                             : HashVariantType::Type::phase2_slice;
+                break;
+            }
+            }
+            break;
+        }
+        default: {
+            type = _aggr_phase == vectorized::AggrPhase1 ? HashVariantType::Type::phase1_slice
+                                                         : HashVariantType::Type::phase2_slice;
+            break;
+        }
+        }
+    }
+    VLOG_ROW << "hash type is "
+             << static_cast<typename std::underlying_type<typename HashVariantType::Type>::type>(type);
+    hash_variant.init(type);
+}
+
+void AggregateBaseOperator::_compute_single_agg_state(size_t chunk_size) {
     for (size_t i = 0; i < _agg_fn_ctxs.size(); i++) {
         if (!_is_merge_funcs[i]) {
             _agg_functions[i]->update_batch_single_state(_agg_fn_ctxs[i], chunk_size, _agg_input_raw_columns[i].data(),
@@ -357,7 +346,7 @@ void AggregateBaseNode::_compute_single_agg_state(size_t chunk_size) {
     }
 }
 
-void AggregateBaseNode::_compute_batch_agg_states(size_t chunk_size) {
+void AggregateBaseOperator::_compute_batch_agg_states(size_t chunk_size) {
     for (size_t i = 0; i < _agg_fn_ctxs.size(); i++) {
         if (!_is_merge_funcs[i]) {
             _agg_functions[i]->update_batch(_agg_fn_ctxs[i], chunk_size, _agg_states_offsets[i],
@@ -370,7 +359,7 @@ void AggregateBaseNode::_compute_batch_agg_states(size_t chunk_size) {
     }
 }
 
-void AggregateBaseNode::_compute_batch_agg_states(size_t chunk_size, const std::vector<uint8_t>& selection) {
+void AggregateBaseOperator::_compute_batch_agg_states(size_t chunk_size, const std::vector<uint8_t>& selection) {
     for (size_t i = 0; i < _agg_fn_ctxs.size(); i++) {
         _agg_functions[i]->update_batch_selectively(_agg_fn_ctxs[i], chunk_size, _agg_states_offsets[i],
                                                     _agg_input_raw_columns[i].data(), _tmp_agg_states.data(),
@@ -378,113 +367,112 @@ void AggregateBaseNode::_compute_batch_agg_states(size_t chunk_size, const std::
     }
 }
 
-Status AggregateBaseNode::get_next(RuntimeState* state, RowBatch* row_batch, bool* eos) {
-    return Status::NotSupported("Vector query engine don't support row_batch");
-}
+void AggregateBaseOperator::_evaluate_group_by_exprs(vectorized::Chunk* chunk) {
+    SCOPED_TIMER(_expr_release_timer);
+    for (size_t i = 0; i < _group_by_expr_ctxs.size(); i++) {
+        _group_by_columns[i] = nullptr;
+    }
 
-void AggregateBaseNode::_evaluate_exprs(Chunk* chunk) {
-    {
-        SCOPED_TIMER(_expr_release_timer);
-        for (size_t i = 0; i < _group_by_expr_ctxs.size(); i++) {
-            _group_by_columns[i] = nullptr;
+    for (size_t i = 0; i < _agg_fn_ctxs.size(); i++) {
+        for (size_t j = 0; j < _agg_expr_ctxs[i].size(); j++) {
+            _agg_intput_columns[i][j] = nullptr;
+            _agg_input_raw_columns[i][j] = nullptr;
         }
-
-        for (size_t i = 0; i < _agg_fn_ctxs.size(); i++) {
-            for (size_t j = 0; j < _agg_expr_ctxs[i].size(); j++) {
-                _agg_intput_columns[i][j] = nullptr;
-                _agg_input_raw_columns[i][j] = nullptr;
+    }
+}
+void AggregateBaseOperator::_evaluate_agg_fn_exprs(vectorized::Chunk* chunk) {
+    SCOPED_TIMER(_expr_compute_timer);
+    // Compute group by columns
+    for (size_t i = 0; i < _group_by_expr_ctxs.size(); i++) {
+        _group_by_columns[i] = _group_by_expr_ctxs[i]->evaluate(chunk);
+        DCHECK(_group_by_columns[i] != nullptr);
+        if (_group_by_columns[i]->is_constant()) {
+            // If group by column is constant, we disable streaming aggregate.
+            // Because we don't want to send const column to exchange node
+            _streaming_preaggregation_mode = TStreamingPreaggregationMode::FORCE_PREAGGREGATION;
+            // All hash table could handle only null, and we don't know the real data
+            // type for only null column, so we don't unpack it.
+            if (!_group_by_columns[i]->only_null()) {
+                vectorized::ConstColumn* const_column =
+                        static_cast<vectorized::ConstColumn*>(_group_by_columns[i].get());
+                const_column->data_column()->assign(chunk->num_rows(), 0);
+                _group_by_columns[i] = const_column->data_column();
             }
+        }
+        // Scalar function compute will return non-nullable column
+        // for nullable column when the real whole chunk data all not-null.
+        if (_group_by_types[i].is_nullable && !_group_by_columns[i]->is_nullable()) {
+            // TODO: optimized the memory usage
+            _group_by_columns[i] = vectorized::NullableColumn::create(
+                    _group_by_columns[i], vectorized::NullColumn::create(_group_by_columns[i]->size(), 0));
         }
     }
 
-    {
-        SCOPED_TIMER(_expr_compute_timer);
-        // Compute group by columns
-        for (size_t i = 0; i < _group_by_expr_ctxs.size(); i++) {
-            _group_by_columns[i] = _group_by_expr_ctxs[i]->evaluate(chunk);
-            DCHECK(_group_by_columns[i] != nullptr);
-            if (_group_by_columns[i]->is_constant()) {
-                // If group by column is constant, we disable streaming aggregate.
-                // Because we don't want to send const column to exchange node
-                _streaming_preaggregation_mode = TStreamingPreaggregationMode::FORCE_PREAGGREGATION;
-                // All hash table could handle only null, and we don't know the real data
-                // type for only null column, so we don't unpack it.
-                if (!_group_by_columns[i]->only_null()) {
-                    ConstColumn* const_column = static_cast<ConstColumn*>(_group_by_columns[i].get());
-                    const_column->data_column()->assign(chunk->num_rows(), 0);
-                    _group_by_columns[i] = const_column->data_column();
-                }
+    // Compute agg function columns
+    for (size_t i = 0; i < _agg_fn_ctxs.size(); i++) {
+        for (size_t j = 0; j < _agg_expr_ctxs[i].size(); j++) {
+            // For simplicity and don't change the overall processing flow,
+            // We handle const column as normal data column
+            // TODO(kks): improve const column aggregate later
+            if (j == 0) {
+                _agg_intput_columns[i][j] = vectorized::ColumnHelper::unpack_and_duplicate_const_column(
+                        chunk->num_rows(), _agg_expr_ctxs[i][j]->evaluate(chunk));
+            } else {
+                _agg_intput_columns[i][j] = _agg_expr_ctxs[i][j]->evaluate(chunk);
             }
-            // Scalar function compute will return non-nullable column
-            // for nullable column when the real whole chunk data all not-null.
-            if (_group_by_types[i].is_nullable && !_group_by_columns[i]->is_nullable()) {
-                // TODO: optimized the memory usage
-                _group_by_columns[i] = NullableColumn::create(_group_by_columns[i],
-                                                              NullColumn::create(_group_by_columns[i]->size(), 0));
-            }
-        }
-
-        // Compute agg function columns
-        for (size_t i = 0; i < _agg_fn_ctxs.size(); i++) {
-            for (size_t j = 0; j < _agg_expr_ctxs[i].size(); j++) {
-                // For simplicity and don't change the overall processing flow,
-                // We handle const column as normal data column
-                // TODO(kks): improve const column aggregate later
-                if (j == 0) {
-                    _agg_intput_columns[i][j] = ColumnHelper::unpack_and_duplicate_const_column(
-                            chunk->num_rows(), _agg_expr_ctxs[i][j]->evaluate(chunk));
-                } else {
-                    _agg_intput_columns[i][j] = _agg_expr_ctxs[i][j]->evaluate(chunk);
-                }
-                _agg_input_raw_columns[i][j] = _agg_intput_columns[i][j].get();
-            }
+            _agg_input_raw_columns[i][j] = _agg_intput_columns[i][j].get();
         }
     }
 }
 
 // When need finalize, create column by result type
 // otherwise, create column by serde type
-Columns AggregateBaseNode::_create_agg_result_columns() {
-    Columns agg_result_columns(_agg_fn_types.size());
+vectorized::Columns AggregateBaseOperator::_create_agg_result_columns() {
+    vectorized::Columns agg_result_columns(_agg_fn_types.size());
     if (_needs_finalize) {
         for (size_t i = 0; i < _agg_fn_types.size(); ++i) {
             // For count, count distinct, bitmap_union_int such as never return null function,
             // we need to create a not-nullable column.
-            agg_result_columns[i] = ColumnHelper::create_column(
+            agg_result_columns[i] = vectorized::ColumnHelper::create_column(
                     _agg_fn_types[i].result_type, _agg_fn_types[i].has_nullable_child & _agg_fn_types[i].is_nullable);
             agg_result_columns[i]->reserve(config::vector_chunk_size);
         }
     } else {
         for (size_t i = 0; i < _agg_fn_types.size(); ++i) {
-            agg_result_columns[i] =
-                    ColumnHelper::create_column(_agg_fn_types[i].serde_type, _agg_fn_types[i].has_nullable_child);
+            agg_result_columns[i] = vectorized::ColumnHelper::create_column(_agg_fn_types[i].serde_type,
+                                                                            _agg_fn_types[i].has_nullable_child);
             agg_result_columns[i]->reserve(config::vector_chunk_size);
         }
     }
     return agg_result_columns;
 }
 
-Columns AggregateBaseNode::_create_group_by_columns() {
-    Columns group_by_columns(_group_by_types.size());
+vectorized::Columns AggregateBaseOperator::_create_group_by_columns() {
+    vectorized::Columns group_by_columns(_group_by_types.size());
     for (size_t i = 0; i < _group_by_types.size(); ++i) {
         group_by_columns[i] =
-                ColumnHelper::create_column(_group_by_types[i].result_type, _group_by_types[i].is_nullable);
+                vectorized::ColumnHelper::create_column(_group_by_types[i].result_type, _group_by_types[i].is_nullable);
         group_by_columns[i]->reserve(config::vector_chunk_size);
     }
     return group_by_columns;
 }
 
-void AggregateBaseNode::_convert_to_chunk_no_groupby(ChunkPtr* chunk) {
+void AggregateBaseOperator::_convert_to_chunk_no_groupby(vectorized::ChunkPtr* chunk) {
     // TODO(kks): we should approve memory allocate here
-    Columns agg_result_column = _create_agg_result_columns();
-    (this->*_serialize_or_finalize)(_single_agg_state, agg_result_column);
+    vectorized::Columns agg_result_column = _create_agg_result_columns();
+
+    if (_needs_finalize) {
+        _finalize_to_chunk(_single_agg_state, agg_result_column);
+    } else {
+        _serialize_to_chunk(_single_agg_state, agg_result_column);
+    }
 
     // For agg function column is non-nullable and table is empty
     // sum(zero_row) should be null, not 0.
     if (UNLIKELY(_num_input_rows == 0 && _group_by_expr_ctxs.empty() && _needs_finalize)) {
         for (size_t i = 0; i < _agg_fn_types.size(); i++) {
             if (_agg_fn_types[i].is_nullable) {
-                agg_result_column[i] = ColumnHelper::create_column(_agg_fn_types[i].result_type, true);
+                agg_result_column[i] = vectorized::ColumnHelper::create_column(_agg_fn_types[i].result_type, true);
                 agg_result_column[i]->append_default();
             }
         }
@@ -497,7 +485,7 @@ void AggregateBaseNode::_convert_to_chunk_no_groupby(ChunkPtr* chunk) {
         tuple_desc = _intermediate_tuple_desc;
     }
 
-    ChunkPtr result_chunk = std::make_shared<Chunk>();
+    ChunkPtr result_chunk = std::make_shared<vectorized::Chunk>();
     for (size_t i = 0; i < agg_result_column.size(); i++) {
         result_chunk->append_column(std::move(agg_result_column[i]), tuple_desc->slots()[i]->id());
     }
@@ -506,32 +494,29 @@ void AggregateBaseNode::_convert_to_chunk_no_groupby(ChunkPtr* chunk) {
     _is_finished = true;
 }
 
-void AggregateBaseNode::_serialize_to_chunk(ConstAggDataPtr state, const Columns& agg_result_columns) {
+void AggregateBaseOperator::_serialize_to_chunk(vectorized::ConstAggDataPtr state,
+                                                const vectorized::Columns& agg_result_columns) {
     for (size_t i = 0; i < _agg_fn_ctxs.size(); i++) {
         _agg_functions[i]->serialize_to_column(_agg_fn_ctxs[i], state + _agg_states_offsets[i],
                                                agg_result_columns[i].get());
     }
 }
 
-void AggregateBaseNode::_finalize_to_chunk(ConstAggDataPtr state, const Columns& agg_result_columns) {
+void AggregateBaseOperator::_finalize_to_chunk(vectorized::ConstAggDataPtr state,
+                                               const vectorized::Columns& agg_result_columns) {
     for (size_t i = 0; i < _agg_fn_ctxs.size(); i++) {
         _agg_functions[i]->finalize_to_column(_agg_fn_ctxs[i], state + _agg_states_offsets[i],
                                               agg_result_columns[i].get());
     }
 }
 
-Status AggregateBaseNode::close(RuntimeState* state) {
-    if (is_closed()) {
-        return Status::OK();
-    }
-
+Status AggregateBaseOperator::close(RuntimeState* state) {
     for (auto ctx : _agg_fn_ctxs) {
         if (ctx != nullptr && ctx->impl()) {
             ctx->impl()->close();
         }
     }
 
-    // Note: we must explicit free memory before ExecNode::close
     // _mem_pool is nullptr means prepare phase failed
     if (_mem_pool != nullptr) {
         // Note: we must free agg_states object before _mem_pool free_all;
@@ -542,8 +527,8 @@ Status AggregateBaseNode::close(RuntimeState* state) {
         } else if (!_is_only_group_by_columns) {
             if (false) {
             }
-#define HASH_MAP_METHOD(NAME)                                      \
-    else if (_hash_map_variant.type == HashMapVariant::Type::NAME) \
+#define HASH_MAP_METHOD(NAME)                                                  \
+    else if (_hash_map_variant.type == vectorized::HashMapVariant::Type::NAME) \
             _release_agg_memory<decltype(_hash_map_variant.NAME)::element_type>(*_hash_map_variant.NAME);
             APPLY_FOR_VARIANT_ALL(HASH_MAP_METHOD)
 #undef HASH_MAP_METHOD
@@ -552,25 +537,25 @@ Status AggregateBaseNode::close(RuntimeState* state) {
         _mem_pool->free_all();
     }
 
-    mem_tracker()->release(_last_agg_func_memory_usage);
-    mem_tracker()->release(_last_ht_memory_usage);
+    get_memtracker()->release(_last_agg_func_memory_usage);
+    get_memtracker()->release(_last_ht_memory_usage);
 
     Expr::close(_group_by_expr_ctxs, state);
     for (const auto& i : _agg_expr_ctxs) {
         Expr::close(i, state);
     }
 
-    return ExecNode::close(state);
+    return Operator::close(state);
 }
 
-void AggregateBaseNode::_output_chunk_by_streaming(ChunkPtr* chunk) {
-    ChunkPtr result_chunk = std::make_shared<Chunk>();
+void AggregateBaseOperator::_output_chunk_by_streaming(vectorized::ChunkPtr* chunk) {
+    ChunkPtr result_chunk = std::make_shared<vectorized::Chunk>();
     for (size_t i = 0; i < _group_by_columns.size(); i++) {
         result_chunk->append_column(_group_by_columns[i], _intermediate_tuple_desc->slots()[i]->id());
     }
 
     if (!_agg_fn_ctxs.empty()) {
-        Columns agg_result_column = _create_agg_result_columns();
+        vectorized::Columns agg_result_column = _create_agg_result_columns();
         for (size_t i = 0; i < _agg_fn_ctxs.size(); i++) {
             size_t id = _group_by_columns.size() + i;
             _agg_functions[i]->convert_to_serialize_format(_agg_intput_columns[i], result_chunk->num_rows(),
@@ -584,7 +569,8 @@ void AggregateBaseNode::_output_chunk_by_streaming(ChunkPtr* chunk) {
     COUNTER_SET(_pass_through_row_count, _num_pass_through_rows);
 }
 
-void AggregateBaseNode::_output_chunk_by_streaming(ChunkPtr* chunk, const std::vector<uint8_t>& filter) {
+void AggregateBaseOperator::_output_chunk_by_streaming(vectorized::ChunkPtr* chunk,
+                                                       const std::vector<uint8_t>& filter) {
     // Streaming aggregate at least has one group by column
     size_t chunk_size = _group_by_columns[0]->size();
     for (auto& _group_by_column : _group_by_columns) {
@@ -616,17 +602,17 @@ void AggregateBaseNode::_output_chunk_by_streaming(ChunkPtr* chunk, const std::v
     _output_chunk_by_streaming(chunk);
 }
 
-Status AggregateBaseNode::_check_hash_map_memory_usage(RuntimeState* state) {
+Status AggregateBaseOperator::_check_hash_map_memory_usage(RuntimeState* state) {
     if ((_num_input_rows & memory_check_batch_size) < config::vector_chunk_size) {
         int64_t delta_memory_usage = static_cast<int64_t>(_hash_map_variant.memory_usage()) - _last_ht_memory_usage;
-        mem_tracker()->consume(delta_memory_usage);
+        get_memtracker()->consume(delta_memory_usage);
         _last_ht_memory_usage = _hash_map_variant.memory_usage();
 
         int64_t agg_func_memory_usage = 0;
         for (auto& _agg_fn_ctx : _agg_fn_ctxs) {
             agg_func_memory_usage += _agg_fn_ctx->impl()->mem_usage();
         }
-        mem_tracker()->consume(agg_func_memory_usage - _last_agg_func_memory_usage);
+        get_memtracker()->consume(agg_func_memory_usage - _last_agg_func_memory_usage);
         _last_agg_func_memory_usage = agg_func_memory_usage;
 
         RETURN_IF_ERROR(state->check_query_state("Aggregation Node"));
@@ -634,10 +620,10 @@ Status AggregateBaseNode::_check_hash_map_memory_usage(RuntimeState* state) {
     return Status::OK();
 }
 
-Status AggregateBaseNode::_check_hash_set_memory_usage(RuntimeState* state) {
+Status AggregateBaseOperator::_check_hash_set_memory_usage(RuntimeState* state) {
     if ((_num_input_rows & memory_check_batch_size) < config::vector_chunk_size) {
         int64_t delta_memory_usage = static_cast<int64_t>(_hash_set_variant.memory_usage()) - _last_ht_memory_usage;
-        mem_tracker()->consume(delta_memory_usage);
+        get_memtracker()->consume(delta_memory_usage);
         _last_ht_memory_usage = _hash_set_variant.memory_usage();
 
         RETURN_IF_ERROR(state->check_query_state("Aggregation Node"));
@@ -645,10 +631,11 @@ Status AggregateBaseNode::_check_hash_set_memory_usage(RuntimeState* state) {
     return Status::OK();
 }
 
-void AggregateBaseNode::_try_convert_to_two_level_map() {
+void AggregateBaseOperator::_try_convert_to_two_level_map() {
     if (_last_ht_memory_usage > two_level_memory_threshold) {
-        if (_hash_map_variant.type == HashMapVariant::Type::phase1_slice) {
-            _hash_map_variant.phase1_slice_two_level = std::make_unique<SerializedKeyTwoLevelAggHashMap<PhmapSeed1>>();
+        if (_hash_map_variant.type == vectorized::HashMapVariant::Type::phase1_slice) {
+            _hash_map_variant.phase1_slice_two_level =
+                    std::make_unique<vectorized::SerializedKeyTwoLevelAggHashMap<vectorized::PhmapSeed1>>();
 
             _hash_map_variant.phase1_slice_two_level->hash_map.reserve(
                     _hash_map_variant.phase1_slice->hash_map.capacity());
@@ -656,10 +643,11 @@ void AggregateBaseNode::_try_convert_to_two_level_map() {
             _hash_map_variant.phase1_slice_two_level->hash_map.insert(_hash_map_variant.phase1_slice->hash_map.begin(),
                                                                       _hash_map_variant.phase1_slice->hash_map.end());
 
-            _hash_map_variant.type = HashMapVariant::Type::phase1_slice_two_level;
+            _hash_map_variant.type = vectorized::HashMapVariant::Type::phase1_slice_two_level;
             _hash_map_variant.phase1_slice.reset();
-        } else if (_hash_map_variant.type == HashMapVariant::Type::phase2_slice) {
-            _hash_map_variant.phase2_slice_two_level = std::make_unique<SerializedKeyTwoLevelAggHashMap<PhmapSeed2>>();
+        } else if (_hash_map_variant.type == vectorized::HashMapVariant::Type::phase2_slice) {
+            _hash_map_variant.phase2_slice_two_level =
+                    std::make_unique<vectorized::SerializedKeyTwoLevelAggHashMap<vectorized::PhmapSeed2>>();
 
             _hash_map_variant.phase2_slice_two_level->hash_map.reserve(
                     _hash_map_variant.phase2_slice->hash_map.capacity());
@@ -667,14 +655,14 @@ void AggregateBaseNode::_try_convert_to_two_level_map() {
             _hash_map_variant.phase2_slice_two_level->hash_map.insert(_hash_map_variant.phase2_slice->hash_map.begin(),
                                                                       _hash_map_variant.phase2_slice->hash_map.end());
 
-            _hash_map_variant.type = HashMapVariant::Type::phase2_slice_two_level;
+            _hash_map_variant.type = vectorized::HashMapVariant::Type::phase2_slice_two_level;
             _hash_map_variant.phase2_slice.reset();
         }
     }
 }
 
-bool AggregateBaseNode::_should_expand_preagg_hash_tables(size_t input_chunk_size, int64_t ht_mem,
-                                                          int64_t ht_rows) const {
+bool AggregateBaseOperator::_should_expand_preagg_hash_tables(size_t input_chunk_size, int64_t ht_mem,
+                                                              int64_t ht_rows) const {
     // Need some rows in tables to have valid statistics.
     if (ht_rows == 0) {
         return true;
@@ -682,15 +670,16 @@ bool AggregateBaseNode::_should_expand_preagg_hash_tables(size_t input_chunk_siz
 
     // Find the appropriate reduction factor in our table for the current hash table sizes.
     int cache_level = 0;
-    while (cache_level + 1 < STREAMING_HT_MIN_REDUCTION_SIZE &&
-           ht_mem >= STREAMING_HT_MIN_REDUCTION[cache_level + 1].min_ht_mem) {
+    while (cache_level + 1 < vectorized::STREAMING_HT_MIN_REDUCTION_SIZE &&
+           ht_mem >= vectorized::STREAMING_HT_MIN_REDUCTION[cache_level + 1].min_ht_mem) {
         cache_level++;
     }
 
     // Compare the number of rows in the hash table with the number of input rows that
     // were aggregated into it. Exclude passed through rows from this calculation since
     // they were not in hash tables.
-    const int64_t input_rows = _children[0]->rows_returned() - input_chunk_size;
+    // TODO(hcf) remove this logic of _prev_num_rows_returned
+    const int64_t input_rows = _prev_num_rows_returned - input_chunk_size;
     const int64_t aggregated_input_rows = input_rows - _num_rows_returned;
     double current_reduction = static_cast<double>(aggregated_input_rows) / ht_rows;
 
@@ -703,53 +692,7 @@ bool AggregateBaseNode::_should_expand_preagg_hash_tables(size_t input_chunk_siz
     // set, N is the number of input rows, excluding passed-through rows, and n is the
     // number of rows inserted or merged into the hash tables. This is a very rough
     // approximation but is good enough to be useful.
-    double min_reduction = STREAMING_HT_MIN_REDUCTION[cache_level].streaming_ht_min_reduction;
+    double min_reduction = vectorized::STREAMING_HT_MIN_REDUCTION[cache_level].streaming_ht_min_reduction;
     return current_reduction > min_reduction;
 }
-
-void AggregateBaseNode::push_down_join_runtime_filter(RuntimeState* state,
-                                                      vectorized::RuntimeFilterProbeCollector* collector) {
-    // accept runtime filters from parent if possible.
-    _runtime_filter_collector.push_down(collector, _tuple_ids);
-
-    // check to see if runtime filters can be rewritten
-    auto& descriptors = _runtime_filter_collector.descriptors();
-    RuntimeFilterProbeCollector pushdown_collector;
-
-    auto iter = descriptors.begin();
-    while (iter != descriptors.end()) {
-        RuntimeFilterProbeDescriptor* rf_desc = iter->second;
-        SlotId slot_id;
-        // bound to this tuple and probe expr is slot ref.
-        if (!rf_desc->is_bound(_tuple_ids) || !rf_desc->is_probe_slot_ref(&slot_id)) {
-            ++iter;
-            continue;
-        }
-
-        bool match = false;
-        for (ExprContext* group_expr_ctx : _group_by_expr_ctxs) {
-            if (group_expr_ctx->root()->is_slotref()) {
-                auto* slot = down_cast<ColumnRef*>(group_expr_ctx->root());
-                if (slot->slot_id() == slot_id) {
-                    match = true;
-                    break;
-                }
-            }
-        }
-
-        if (match) {
-            pushdown_collector.add_descriptor(rf_desc);
-            iter = descriptors.erase(iter);
-        } else {
-            ++iter;
-        }
-    }
-
-    // push down rewritten runtime filters to children
-    if (!pushdown_collector.empty()) {
-        push_down_join_runtime_filter_to_children(state, &pushdown_collector);
-        pushdown_collector.close(state);
-    }
-};
-
-} // namespace starrocks::vectorized
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/aggregate_base_operator.h
+++ b/be/src/exec/pipeline/aggregate_base_operator.h
@@ -146,11 +146,11 @@ protected:
             }
         }
 
-        _is_hash_table_eos = (it == end);
+        _is_ht_done = (it == end);
 
         // If there is null key, output it last
         if constexpr (HashMapWithKey::has_single_null_key) {
-            if (_is_hash_table_eos && hash_map_with_key.null_key_data != nullptr) {
+            if (_is_ht_done && hash_map_with_key.null_key_data != nullptr) {
                 // The output chunk size couldn't larger than config::vector_chunk_size
                 if (read_index < config::vector_chunk_size) {
                     // For multi group by key, we don't need to special handle null key
@@ -167,7 +167,7 @@ protected:
                     ++read_index;
                 } else {
                     // Output null key in next round
-                    _is_hash_table_eos = false;
+                    _is_ht_done = false;
                 }
             }
         }
@@ -221,11 +221,11 @@ protected:
             hash_set.insert_keys_to_columns(hash_set.results, group_by_columns, read_index);
         }
 
-        _is_hash_table_eos = (it == end);
+        _is_ht_done = (it == end);
 
         // IF there is null key, output it last
         if constexpr (HashSetWithKey::has_single_null_key) {
-            if (_is_hash_table_eos && hash_set.has_null_key) {
+            if (_is_ht_done && hash_set.has_null_key) {
                 // The output chunk size couldn't larger than config::vector_chunk_size
                 if (read_index < config::vector_chunk_size) {
                     // For multi group by key, we don't need to special handle null key
@@ -235,7 +235,7 @@ protected:
                     ++read_index;
                 } else {
                     // Output null key in next round
-                    _is_hash_table_eos = false;
+                    _is_ht_done = false;
                 }
             }
         }
@@ -262,7 +262,7 @@ protected:
             int64_t num_rows_over = _num_rows_returned - _limit;
             (*chunk)->set_num_rows((*chunk)->num_rows() - num_rows_over);
             COUNTER_SET(_rows_returned_counter, _limit);
-            _is_hash_table_eos = true;
+            _is_ht_done = true;
             LOG(INFO) << "Aggregate Node ReachedLimit " << _limit;
         }
     }
@@ -318,7 +318,7 @@ protected:
     // a finalize step.
     bool _needs_finalize;
     // Indicate whether data of the hash table has been taken out or reach limit
-    bool _is_hash_table_eos = false;
+    bool _is_ht_done = false;
     bool _is_only_group_by_columns = false;
     // At least one group by column is nullable
     bool _has_nullable_key = false;

--- a/be/src/exec/pipeline/aggregate_blocking_operator.cpp
+++ b/be/src/exec/pipeline/aggregate_blocking_operator.cpp
@@ -1,0 +1,124 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#include "aggregate_blocking_operator.h"
+
+#include "column/chunk.h"
+#include "column/column.h"
+#include "column/column_helper.h"
+#include "column/const_column.h"
+#include "config.h"
+#include "exprs/expr_context.h"
+#include "runtime/runtime_state.h"
+
+namespace starrocks::pipeline {
+
+void AggregateBlockingOperator::finish(RuntimeState* state) {
+    if (_is_pre_finished) return;
+    _is_pre_finished = true;
+
+    if (!_group_by_expr_ctxs.empty()) {
+        COUNTER_SET(_hash_table_size, (int64_t)_hash_map_variant.size());
+        // If hash map is empty, we don't need to return value
+        if (_hash_map_variant.size() == 0) {
+            _is_finished = true;
+        }
+
+        if (false) {
+        }
+#define HASH_MAP_METHOD(NAME)                                                             \
+    else if (_hash_map_variant.type == vectorized::HashMapVariant::Type::NAME) _it_hash = \
+            _hash_map_variant.NAME->hash_map.begin();
+        APPLY_FOR_VARIANT_ALL(HASH_MAP_METHOD)
+#undef HASH_MAP_METHOD
+    } else if (_group_by_expr_ctxs.empty()) {
+        // for aggregate no group by, if _num_input_rows is 0,
+        // In update phase, we directly return empty chunk.
+        // In merge phase, we will handle it.
+        if (_num_input_rows == 0 && !_needs_finalize) {
+            _is_finished = true;
+        }
+    }
+    COUNTER_SET(_input_row_count, _num_input_rows);
+}
+
+StatusOr<vectorized::ChunkPtr> AggregateBlockingOperator::pull_chunk(RuntimeState* state) {
+    SCOPED_TIMER(_runtime_profile->total_time_counter());
+    // TODO(hcf) force annotation
+    // RETURN_IF_ERROR(exec_debug_action(TExecNodePhase::GETNEXT));
+    RETURN_IF_CANCELLED(state);
+
+    if (_is_finished) {
+        COUNTER_SET(_rows_returned_counter, _num_rows_returned);
+        return Status::OK();
+    }
+
+    int32_t chunk_size = config::vector_chunk_size;
+    vectorized::ChunkPtr chunk = std::make_shared<vectorized::Chunk>();
+
+    if (_group_by_expr_ctxs.empty()) {
+        SCOPED_TIMER(_get_results_timer);
+        _convert_to_chunk_no_groupby(&chunk);
+    } else {
+        if (false) {
+        }
+#define HASH_MAP_METHOD(NAME)                                                                                   \
+    else if (_hash_map_variant.type == vectorized::HashMapVariant::Type::NAME)                                  \
+            _convert_hash_map_to_chunk<decltype(_hash_map_variant.NAME)::element_type>(*_hash_map_variant.NAME, \
+                                                                                       chunk_size, &chunk);
+        APPLY_FOR_VARIANT_ALL(HASH_MAP_METHOD)
+#undef HASH_MAP_METHOD
+    }
+
+    // TODO(hcf) force annotation
+    // eval_join_runtime_filters(chunk.get());
+
+    // For having
+    size_t old_size = chunk->num_rows();
+
+    // TODO(hcf) force annotation
+    // ExecNode::eval_conjuncts(_conjunct_ctxs, chunk.get());
+    _num_rows_returned -= (old_size - chunk->num_rows());
+
+    _process_limit(&chunk);
+
+    DCHECK_CHUNK(chunk);
+
+    return chunk;
+}
+
+Status AggregateBlockingOperator::push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) {
+    if (chunk->is_empty()) {
+        return Status::OK();
+    }
+
+    DCHECK_LE(chunk->num_rows(), config::vector_chunk_size);
+    _evaluate_group_by_exprs(chunk.get());
+    _evaluate_agg_fn_exprs(chunk.get());
+
+    {
+        SCOPED_TIMER(_agg_compute_timer);
+        if (!_group_by_expr_ctxs.empty()) {
+            if (false) {
+            }
+#define HASH_MAP_METHOD(NAME)                                                                        \
+    else if (_hash_map_variant.type == vectorized::HashMapVariant::Type::NAME)                       \
+            _build_hash_map<decltype(_hash_map_variant.NAME)::element_type>(*_hash_map_variant.NAME, \
+                                                                            chunk->num_rows());
+            APPLY_FOR_VARIANT_ALL(HASH_MAP_METHOD)
+#undef HASH_MAP_METHOD
+
+            RETURN_IF_ERROR(_check_hash_map_memory_usage(state));
+            _try_convert_to_two_level_map();
+        }
+        if (_group_by_expr_ctxs.empty()) {
+            _compute_single_agg_state(chunk->num_rows());
+        } else {
+            _compute_batch_agg_states(chunk->num_rows());
+        }
+        _num_input_rows += chunk->num_rows();
+    }
+
+    return Status::OK();
+}
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/aggregate_blocking_operator.cpp
+++ b/be/src/exec/pipeline/aggregate_blocking_operator.cpp
@@ -13,7 +13,7 @@
 namespace starrocks::pipeline {
 
 bool AggregateBlockingOperator::has_output() const {
-    return _is_finished && !_is_hash_table_eos;
+    return _is_finished && !_is_ht_done;
 }
 
 bool AggregateBlockingOperator::is_finished() const {
@@ -34,7 +34,7 @@ void AggregateBlockingOperator::finish(RuntimeState* state) {
         COUNTER_SET(_hash_table_size, (int64_t)_hash_map_variant.size());
         // If hash map is empty, we don't need to return value
         if (_hash_map_variant.size() == 0) {
-            _is_hash_table_eos = true;
+            _is_ht_done = true;
         }
 
         if (false) {
@@ -49,7 +49,7 @@ void AggregateBlockingOperator::finish(RuntimeState* state) {
         // In update phase, we directly return empty chunk.
         // In merge phase, we will handle it.
         if (_num_input_rows == 0 && !_needs_finalize) {
-            _is_hash_table_eos = true;
+            _is_ht_done = true;
         }
     }
     COUNTER_SET(_input_row_count, _num_input_rows);

--- a/be/src/exec/pipeline/aggregate_blocking_operator.h
+++ b/be/src/exec/pipeline/aggregate_blocking_operator.h
@@ -1,0 +1,39 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#pragma once
+
+#include "aggregate_base_operator.h"
+
+namespace starrocks::pipeline {
+class AggregateBlockingOperator final : public AggregateBaseOperator {
+public:
+    AggregateBlockingOperator(int32_t id, int32_t plan_node_id, const TPlanNode& tnode)
+            : AggregateBaseOperator(id, "aggregate_blocking", plan_node_id, tnode) {
+        _aggr_phase = vectorized::AggrPhase::AggrPhase2;
+    }
+    ~AggregateBlockingOperator() override = default;
+
+    bool has_output() const override { return _is_pre_finished && !_is_finished; }
+    bool need_input() const override { return true; }
+    bool is_finished() const override { return _is_finished; }
+    void finish(RuntimeState* state) override;
+
+    StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
+    Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override;
+
+private:
+    bool _is_pre_finished = false;
+};
+
+class AggregateBlockingOperatorFactory final : public AggregateBaseOperatorFactory {
+public:
+    AggregateBlockingOperatorFactory(int32_t id, int32_t plan_node_id, const TPlanNode& tnode)
+            : AggregateBaseOperatorFactory(id, plan_node_id, tnode) {}
+
+    ~AggregateBlockingOperatorFactory() override = default;
+
+    OperatorPtr create(int32_t driver_instance_count, int32_t driver_sequence) override {
+        return std::make_shared<AggregateBlockingOperator>(_id, _plan_node_id, _tnode);
+    }
+};
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/aggregate_blocking_operator.h
+++ b/be/src/exec/pipeline/aggregate_blocking_operator.h
@@ -13,16 +13,12 @@ public:
     }
     ~AggregateBlockingOperator() override = default;
 
-    bool has_output() const override { return _is_pre_finished && !_is_finished; }
-    bool need_input() const override { return true; }
-    bool is_finished() const override { return _is_finished; }
+    bool has_output() const override;
+    bool is_finished() const override;
     void finish(RuntimeState* state) override;
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
     Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override;
-
-private:
-    bool _is_pre_finished = false;
 };
 
 class AggregateBlockingOperatorFactory final : public AggregateBaseOperatorFactory {

--- a/be/src/exec/pipeline/aggregate_streaming_operator.cpp
+++ b/be/src/exec/pipeline/aggregate_streaming_operator.cpp
@@ -33,7 +33,7 @@ bool AggregateStreamingOperator::has_output() const {
         return false;
     }
 
-    if (_is_hash_table_eos || _hash_map_variant.size() == 0) {
+    if (_is_ht_done || _hash_map_variant.size() == 0) {
         return false;
     }
 

--- a/be/src/exec/pipeline/aggregate_streaming_operator.cpp
+++ b/be/src/exec/pipeline/aggregate_streaming_operator.cpp
@@ -1,0 +1,233 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#include "aggregate_streaming_operator.h"
+
+#include "column/chunk.h"
+#include "column/column.h"
+#include "column/column_helper.h"
+#include "column/const_column.h"
+#include "common/status.h"
+#include "config.h"
+#include "exprs/expr_context.h"
+#include "runtime/runtime_state.h"
+#include "simd/simd.h"
+
+namespace starrocks::pipeline {
+
+bool AggregateStreamingOperator::has_output() const {
+    // There are two cases where _curr_chunk is not null
+    // case1：streaming mode is 'FORCE_STREAMING'
+    // case2：streaming mode is 'AUTO'
+    //     case 2.1: very poor aggregation
+    //     case 2.2: middle cases, first aggregate locally and output by stream
+    if (_curr_chunk != nullptr) {
+        return true;
+    }
+
+    // There are two cases where _curr_chunk is null,
+    // it will apply local aggregate, so need to wait all the input chunks
+    // case1：streaming mode is 'FORCE_PREAGGREGATION'
+    // case2：streaming mode is 'AUTO'
+    //     case 2.1: very high aggregation
+    if (!_is_pre_finished) {
+        return false;
+    }
+
+    if (_hash_table_eos || _hash_map_variant.size() == 0) {
+        return false;
+    }
+
+    return true;
+}
+
+bool AggregateStreamingOperator::is_finished() const {
+    if (!_is_pre_finished) {
+        return false;
+    }
+
+    return !has_output();
+}
+
+void AggregateStreamingOperator::finish(RuntimeState* state) {
+    if (_is_pre_finished) return;
+    _is_pre_finished = true;
+}
+
+StatusOr<vectorized::ChunkPtr> AggregateStreamingOperator::pull_chunk(RuntimeState* state) {
+    if (_curr_chunk != nullptr) {
+        vectorized::ChunkPtr chunk = std::move(_curr_chunk);
+        _curr_chunk = nullptr;
+        return chunk;
+    }
+
+    vectorized::ChunkPtr chunk = std::make_shared<vectorized::Chunk>();
+    // no data in hash table
+    if (_hash_table_eos || _hash_map_variant.size() == 0) {
+        COUNTER_SET(_rows_returned_counter, _num_rows_returned);
+        return chunk;
+    }
+
+    // data still exists in the hash table
+    _output_chunk_from_hash_map(&chunk);
+    _process_limit(&chunk);
+    DCHECK_CHUNK(chunk);
+    return chunk;
+}
+
+Status AggregateStreamingOperator::push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) {
+    if (chunk->is_empty()) {
+        return Status::OK();
+    }
+
+    size_t chunk_size = chunk->num_rows();
+
+    _num_input_rows += chunk_size;
+    COUNTER_SET(_input_row_count, _num_input_rows);
+    RETURN_IF_ERROR(_check_hash_map_memory_usage(state));
+
+    _evaluate_group_by_exprs(chunk.get());
+    _evaluate_agg_fn_exprs(chunk.get());
+
+    if (_streaming_preaggregation_mode == TStreamingPreaggregationMode::FORCE_STREAMING) {
+        return _push_chunk_by_force_streaming();
+    } else if (_streaming_preaggregation_mode == TStreamingPreaggregationMode::FORCE_PREAGGREGATION) {
+        return _push_chunk_by_force_preaggregation(chunk->num_rows());
+    } else {
+        return _push_chunk_by_auto(chunk->num_rows());
+    }
+}
+
+Status AggregateStreamingOperator::_push_chunk_by_force_streaming() {
+    // force execute streaming
+    SCOPED_TIMER(_streaming_timer);
+    _curr_chunk = std::make_shared<vectorized::Chunk>();
+    _output_chunk_by_streaming(&_curr_chunk);
+    return Status::OK();
+}
+
+Status AggregateStreamingOperator::_push_chunk_by_force_preaggregation(const size_t chunk_size) {
+    SCOPED_TIMER(_agg_compute_timer);
+    if (false) {
+    }
+#define HASH_MAP_METHOD(NAME)                                                  \
+    else if (_hash_map_variant.type == vectorized::HashMapVariant::Type::NAME) \
+            _build_hash_map<decltype(_hash_map_variant.NAME)::element_type>(*_hash_map_variant.NAME, chunk_size);
+    APPLY_FOR_VARIANT_ALL(HASH_MAP_METHOD)
+#undef HASH_MAP_METHOD
+    else {
+        DCHECK(false);
+    }
+
+    if (_group_by_expr_ctxs.empty()) {
+        _compute_single_agg_state(chunk_size);
+    } else {
+        _compute_batch_agg_states(chunk_size);
+    }
+
+    _try_convert_to_two_level_map();
+    COUNTER_SET(_hash_table_size, (int64_t)_hash_map_variant.size());
+    return Status::OK();
+}
+
+Status AggregateStreamingOperator::_push_chunk_by_auto(const size_t chunk_size) {
+    size_t real_capacity = _hash_map_variant.capacity() - _hash_map_variant.capacity() / 8;
+    size_t remain_size = real_capacity - _hash_map_variant.size();
+    bool ht_needs_expansion = remain_size < chunk_size;
+    if (!ht_needs_expansion ||
+        _should_expand_preagg_hash_tables(chunk_size, _mem_pool->total_allocated_bytes(), _hash_map_variant.size())) {
+        // hash table is not full or allow expand the hash table according reduction rate
+        SCOPED_TIMER(_agg_compute_timer);
+        if (false) {
+        }
+#define HASH_MAP_METHOD(NAME)                                                  \
+    else if (_hash_map_variant.type == vectorized::HashMapVariant::Type::NAME) \
+            _build_hash_map<decltype(_hash_map_variant.NAME)::element_type>(*_hash_map_variant.NAME, chunk_size);
+        APPLY_FOR_VARIANT_ALL(HASH_MAP_METHOD)
+#undef HASH_MAP_METHOD
+        else {
+            DCHECK(false);
+        }
+
+        if (_group_by_expr_ctxs.empty()) {
+            _compute_single_agg_state(chunk_size);
+        } else {
+            _compute_batch_agg_states(chunk_size);
+        }
+
+        _try_convert_to_two_level_map();
+        COUNTER_SET(_hash_table_size, (int64_t)_hash_map_variant.size());
+    } else {
+        {
+            SCOPED_TIMER(_agg_compute_timer);
+            if (false) {
+            }
+#define HASH_MAP_METHOD(NAME)                                                         \
+    else if (_hash_map_variant.type == vectorized::HashMapVariant::Type::NAME)        \
+            _build_hash_map<typename decltype(_hash_map_variant.NAME)::element_type>( \
+                    *_hash_map_variant.NAME, chunk_size, &_streaming_selection);
+            APPLY_FOR_VARIANT_ALL(HASH_MAP_METHOD)
+#undef HASH_MAP_METHOD
+            else {
+                DCHECK(false);
+            }
+        }
+
+        size_t zero_count = SIMD::count_zero(_streaming_selection);
+        // very poor aggregation
+        if (zero_count == 0) {
+            SCOPED_TIMER(_streaming_timer);
+            _curr_chunk = std::make_shared<vectorized::Chunk>();
+            _output_chunk_by_streaming(&_curr_chunk);
+        }
+        // very high aggregation
+        else if (zero_count == _streaming_selection.size()) {
+            SCOPED_TIMER(_agg_compute_timer);
+            _compute_batch_agg_states(chunk_size);
+        } else {
+            // middle cases, first aggregate locally and output by stream
+            {
+                SCOPED_TIMER(_agg_compute_timer);
+                _compute_batch_agg_states(chunk_size, _streaming_selection);
+            }
+            {
+                SCOPED_TIMER(_streaming_timer);
+                _curr_chunk = std::make_shared<vectorized::Chunk>();
+                _output_chunk_by_streaming(&_curr_chunk, _streaming_selection);
+            }
+        }
+
+        COUNTER_SET(_hash_table_size, (int64_t)_hash_map_variant.size());
+    }
+
+    return Status::OK();
+}
+
+void AggregateStreamingOperator::_output_chunk_from_hash_map(vectorized::ChunkPtr* chunk) {
+    if (!_it_hash.has_value()) {
+        if (false) {
+        }
+#define HASH_MAP_METHOD(NAME)                                                             \
+    else if (_hash_map_variant.type == vectorized::HashMapVariant::Type::NAME) _it_hash = \
+            _hash_map_variant.NAME->hash_map.begin();
+        APPLY_FOR_VARIANT_ALL(HASH_MAP_METHOD)
+#undef HASH_MAP_METHOD
+        else {
+            DCHECK(false);
+        }
+        COUNTER_SET(_hash_table_size, (int64_t)_hash_map_variant.size());
+    }
+
+    if (false) {
+    }
+#define HASH_MAP_METHOD(NAME)                                                           \
+    else if (_hash_map_variant.type == vectorized::HashMapVariant::Type::NAME)          \
+            _convert_hash_map_to_chunk<decltype(_hash_map_variant.NAME)::element_type>( \
+                    *_hash_map_variant.NAME, config::vector_chunk_size, chunk);
+    APPLY_FOR_VARIANT_ALL(HASH_MAP_METHOD)
+#undef HASH_MAP_METHOD
+    else {
+        DCHECK(false);
+    }
+}
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/aggregate_streaming_operator.h
+++ b/be/src/exec/pipeline/aggregate_streaming_operator.h
@@ -1,0 +1,44 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#pragma once
+
+#include "aggregate_base_operator.h"
+
+namespace starrocks::pipeline {
+
+class AggregateStreamingOperator final : public AggregateBaseOperator {
+public:
+    AggregateStreamingOperator(int32_t id, int32_t plan_node_id, const TPlanNode& tnode)
+            : AggregateBaseOperator(id, "aggregate_streaming", plan_node_id, tnode) {}
+    ~AggregateStreamingOperator() override = default;
+
+    bool has_output() const override;
+    bool need_input() const override { return true; }
+    bool is_finished() const override;
+    void finish(RuntimeState* state) override;
+
+    StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
+    Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override;
+
+private:
+    Status _push_chunk_by_force_streaming();
+    Status _push_chunk_by_force_preaggregation(const size_t chunk_size);
+    Status _push_chunk_by_auto(const size_t chunk_size);
+    void _output_chunk_from_hash_map(vectorized::ChunkPtr* chunk);
+
+    bool _is_pre_finished = false;
+    vectorized::ChunkPtr _curr_chunk = nullptr;
+};
+
+class AggregateStreamingOperatorFactory final : public AggregateBaseOperatorFactory {
+public:
+    AggregateStreamingOperatorFactory(int32_t id, int32_t plan_node_id, const TPlanNode& tnode)
+            : AggregateBaseOperatorFactory(id, plan_node_id, tnode) {}
+
+    ~AggregateStreamingOperatorFactory() override = default;
+
+    OperatorPtr create(int32_t driver_instance_count, int32_t driver_sequence) override {
+        return std::make_shared<AggregateStreamingOperator>(_id, _plan_node_id, _tnode);
+    }
+};
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/aggregate_streaming_operator.h
+++ b/be/src/exec/pipeline/aggregate_streaming_operator.h
@@ -13,7 +13,6 @@ public:
     ~AggregateStreamingOperator() override = default;
 
     bool has_output() const override;
-    bool need_input() const override { return true; }
     bool is_finished() const override;
     void finish(RuntimeState* state) override;
 
@@ -26,7 +25,6 @@ private:
     Status _push_chunk_by_auto(const size_t chunk_size);
     void _output_chunk_from_hash_map(vectorized::ChunkPtr* chunk);
 
-    bool _is_pre_finished = false;
     vectorized::ChunkPtr _curr_chunk = nullptr;
 };
 

--- a/be/src/exec/pipeline/chunk_source.h
+++ b/be/src/exec/pipeline/chunk_source.h
@@ -23,7 +23,7 @@ public:
 
     virtual Status close(RuntimeState* state) = 0;
 
-    virtual bool has_next_chunk() = 0;
+    virtual bool has_next_chunk() const = 0;
 
     virtual StatusOr<vectorized::ChunkUniquePtr> get_next_chunk() = 0;
     virtual void cache_next_chunk_blocking() = 0;

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -220,6 +220,7 @@ ExchangeSinkOperator::ExchangeSinkOperator(int32_t id, int32_t plan_node_id, con
 }
 
 Status ExchangeSinkOperator::prepare(RuntimeState* state) {
+    RETURN_IF_ERROR(Operator::prepare(state));
     _be_number = state->be_number();
 
     // Set compression type according to query options
@@ -288,7 +289,7 @@ bool ExchangeSinkOperator::is_finished() const {
     return _is_finished && _buffer->is_finished();
 }
 
-bool ExchangeSinkOperator::need_input() {
+bool ExchangeSinkOperator::need_input() const {
     return !_is_finished && !_buffer->is_full();
 }
 

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -187,7 +187,7 @@ Status ExchangeSinkOperator::Channel::send_chunk_request(PTransmitChunkParams* p
 }
 
 Status ExchangeSinkOperator::Channel::_close_internal() {
-    RETURN_IF_ERROR(send_one_chunk(nullptr, true));
+    RETURN_IF_ERROR(send_one_chunk(_chunk != nullptr ? _chunk.get() : nullptr, true));
     return Status::OK();
 }
 

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.h
@@ -36,9 +36,9 @@ public:
 
     Status close(RuntimeState* state) override;
 
-    bool has_output() override { return false; }
+    bool has_output() const override { return false; }
 
-    bool need_input() override;
+    bool need_input() const override;
 
     bool is_finished() const override;
 

--- a/be/src/exec/pipeline/exchange/exchange_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_source_operator.cpp
@@ -22,7 +22,7 @@ Status ExchangeSourceOperator::close(RuntimeState* state) {
     return Status::OK();
 }
 
-bool ExchangeSourceOperator::has_output() {
+bool ExchangeSourceOperator::has_output() const {
     return _stream_recvr->has_output();
 }
 

--- a/be/src/exec/pipeline/exchange/exchange_source_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_source_operator.h
@@ -21,7 +21,7 @@ public:
 
     Status close(RuntimeState* state) override;
 
-    bool has_output() override;
+    bool has_output() const override;
 
     bool is_finished() const override;
 

--- a/be/src/exec/pipeline/exchange/local_exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange_sink_operator.cpp
@@ -12,7 +12,7 @@ Status LocalExchangeSinkOperator::prepare(RuntimeState* state) {
     return Status::OK();
 }
 
-bool LocalExchangeSinkOperator::need_input() {
+bool LocalExchangeSinkOperator::need_input() const {
     return !_is_finished && _exchanger->need_input();
 }
 

--- a/be/src/exec/pipeline/exchange/local_exchange_sink_operator.h
+++ b/be/src/exec/pipeline/exchange/local_exchange_sink_operator.h
@@ -15,9 +15,9 @@ public:
 
     Status prepare(RuntimeState* state) override;
 
-    bool has_output() override { return false; }
+    bool has_output() const override { return false; }
 
-    bool need_input() override;
+    bool need_input() const override;
 
     bool is_finished() const override { return _is_finished; }
 

--- a/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
@@ -42,7 +42,7 @@ bool LocalExchangeSourceOperator::is_finished() const {
     return _is_finished && _full_chunk == nullptr;
 }
 
-bool LocalExchangeSourceOperator::has_output() {
+bool LocalExchangeSourceOperator::has_output() const {
     std::lock_guard<std::mutex> l(_chunk_lock);
     return _full_chunk != nullptr;
 }

--- a/be/src/exec/pipeline/exchange/local_exchange_source_operator.h
+++ b/be/src/exec/pipeline/exchange/local_exchange_source_operator.h
@@ -17,7 +17,7 @@ public:
 
     Status add_chunk(vectorized::Chunk* chunk, const uint32_t* indexes, uint32_t from, uint32_t size);
 
-    bool has_output() override;
+    bool has_output() const override;
 
     bool is_finished() const override;
 

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -101,6 +101,14 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
         driver_instance_count = 1;
     }
 
+    // TODO(hcf): We will remove this restriction after complete aggregation
+    // Force driver_instance_count to 1 if this fragment has aggregate node.
+    std::vector<ExecNode*> aggregate_nodes;
+    plan->collect_nodes(TPlanNodeType::AGGREGATION_NODE, &aggregate_nodes);
+    if (!aggregate_nodes.empty()) {
+        driver_instance_count = 1;
+    }
+
     // pipeline scan mode
     // 0: use sync io
     // 1: use async io and exec->thread_pool()

--- a/be/src/exec/pipeline/limit_operator.h
+++ b/be/src/exec/pipeline/limit_operator.h
@@ -13,9 +13,9 @@ public:
 
     ~LimitOperator() override = default;
 
-    bool has_output() override { return _cur_chunk != nullptr; }
+    bool has_output() const override { return _cur_chunk != nullptr; }
 
-    bool need_input() override { return _limit != 0 && _cur_chunk == nullptr; }
+    bool need_input() const override { return _limit != 0 && _cur_chunk == nullptr; }
 
     bool is_finished() const override { return _limit == 0 && _cur_chunk == nullptr; }
 

--- a/be/src/exec/pipeline/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/olap_chunk_source.cpp
@@ -233,7 +233,7 @@ Status OlapChunkSource::_init_olap_reader(RuntimeState* runtime_state) {
     return Status::OK();
 }
 
-bool OlapChunkSource::has_next_chunk() {
+bool OlapChunkSource::has_next_chunk() const {
     // If we need and could get next chunk from storage engine,
     // the _status must be ok.
     return _status.ok();

--- a/be/src/exec/pipeline/olap_chunk_source.h
+++ b/be/src/exec/pipeline/olap_chunk_source.h
@@ -41,7 +41,7 @@ public:
 
     Status close(RuntimeState* state) override;
 
-    bool has_next_chunk() override;
+    bool has_next_chunk() const override;
 
     StatusOr<vectorized::ChunkUniquePtr> get_next_chunk() override;
     void cache_next_chunk_blocking() override;

--- a/be/src/exec/pipeline/operator.h
+++ b/be/src/exec/pipeline/operator.h
@@ -37,6 +37,8 @@ public:
 
     // Notifies the operator that no more input chunk will be added.
     // The operator should finish processing.
+    // The method should be idempotent, because it may be triggered
+    // multiple times in the entire life cycle
     virtual void finish(RuntimeState* state) = 0;
 
     // Pull chunk from this operator

--- a/be/src/exec/pipeline/operator.h
+++ b/be/src/exec/pipeline/operator.h
@@ -26,10 +26,10 @@ public:
     virtual Status close(RuntimeState* state);
 
     // Whether we could pull chunk from this operator
-    virtual bool has_output() = 0;
+    virtual bool has_output() const = 0;
 
     // Whether we could push chunk to this operator
-    virtual bool need_input() = 0;
+    virtual bool need_input() const = 0;
 
     // Is this operator completely finished processing and no more
     // output chunks will be produced
@@ -52,6 +52,8 @@ public:
     int32_t get_plan_node_id() const { return _plan_node_id; }
 
     MemTracker* get_memtracker() const { return _mem_tracker.get(); }
+
+    RuntimeProfile* get_runtime_profile() const { return _runtime_profile.get(); }
 
     std::string get_name() const { return _name + "_" + std::to_string(_id); }
 

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -107,6 +107,7 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state) {
         }
         // close finished operators and update _first_unfinished index
         for (auto i = _first_unfinished; i < _new_first_unfinished; ++i) {
+            VLOG_ROW << "[Driver] " << _operators[i]->get_name() << " finish, driver=" << this;
             _operators[i]->finish(runtime_state);
             RETURN_IF_ERROR(_operators[i]->close(runtime_state));
         }

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -3,10 +3,13 @@
 
 #include "exec/pipeline/pipeline_driver.h"
 
+#include <sstream>
+
 #include "column/chunk.h"
 #include "exec/pipeline/source_operator.h"
 #include "runtime/exec_env.h"
 #include "runtime/runtime_state.h"
+
 namespace starrocks {
 namespace pipeline {
 Status PipelineDriver::prepare(RuntimeState* runtime_state) {
@@ -28,7 +31,8 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state) {
         bool should_yield = false;
         size_t num_operators = _operators.size();
         size_t _new_first_unfinished = _first_unfinished;
-        for (int i = _first_unfinished; i < num_operators - 1; ++i) {
+        VLOG_ROW << "[Driver] " << to_debug_string() << ", driver=" << this;
+        for (size_t i = _first_unfinished; i < num_operators - 1; ++i) {
             {
                 SCOPED_RAW_TIMER(&time_spent);
                 auto& curr_op = _operators[i];
@@ -38,8 +42,10 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state) {
                 if (curr_op->is_finished()) {
                     if (i == 0) {
                         // For source operators
+                        VLOG_ROW << "[Driver] " << curr_op->get_name() << " finish, driver=" << this;
                         curr_op->finish(runtime_state);
                     }
+                    VLOG_ROW << "[Driver] " << next_op->get_name() << " finish, driver=" << this;
                     next_op->finish(runtime_state);
                     _new_first_unfinished = i + 1;
                     continue;
@@ -70,8 +76,9 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state) {
                 }
 
                 if (status.ok()) {
-                    DCHECK(pulled_chunk.value());
                     if (pulled_chunk.value() && pulled_chunk.value()->num_rows() > 0) {
+                        VLOG_ROW << "[Driver] transfer chunk(" << pulled_chunk.value()->num_rows() << ") from "
+                                 << curr_op->get_name() << " to " << next_op->get_name() << ", driver=" << this;
                         next_op->push_chunk(runtime_state, std::move(pulled_chunk.value()));
                     }
                     num_chunk_moved += 1;
@@ -82,8 +89,10 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state) {
                 if (curr_op->is_finished()) {
                     if (i == 0) {
                         // For source operators
+                        VLOG_ROW << "[Driver] " << curr_op->get_name() << " finish, driver=" << this;
                         curr_op->finish(runtime_state);
                     }
+                    VLOG_ROW << "[Driver] " << next_op->get_name() << " finish, driver=" << this;
                     next_op->finish(runtime_state);
                     _new_first_unfinished = i + 1;
                     continue;
@@ -162,6 +171,20 @@ void PipelineDriver::finalize(RuntimeState* runtime_state, DriverState state) {
         _fragment_ctx->runtime_state()->exec_env()->driver_dispatcher()->report_exec_state(_fragment_ctx, status, true,
                                                                                            true);
     }
+}
+
+std::string PipelineDriver::to_debug_string() const {
+    std::stringstream ss;
+    ss << "operator-chain: [";
+    for (size_t i = 0; i < _operators.size(); ++i) {
+        if (i == 0) {
+            ss << _operators[i]->get_name();
+        } else {
+            ss << " -> " << _operators[i]->get_name();
+        }
+    }
+    ss << "]";
+    return ss.str();
 }
 } // namespace pipeline
 } // namespace starrocks

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -150,6 +150,8 @@ public:
 
     bool is_root() const { return _is_root; }
 
+    std::string to_debug_string() const;
+
 private:
     Operators _operators;
     size_t _first_unfinished;

--- a/be/src/exec/pipeline/project_operator.h
+++ b/be/src/exec/pipeline/project_operator.h
@@ -26,9 +26,9 @@ public:
 
     Status close(RuntimeState* state) override;
 
-    bool has_output() override { return _cur_chunk != nullptr; }
+    bool has_output() const override { return _cur_chunk != nullptr; }
 
-    bool need_input() override { return !_is_finished && _cur_chunk == nullptr; }
+    bool need_input() const override { return !_is_finished && _cur_chunk == nullptr; }
 
     bool is_finished() const override { return _is_finished && _cur_chunk == nullptr; }
 

--- a/be/src/exec/pipeline/result_sink_operator.cpp
+++ b/be/src/exec/pipeline/result_sink_operator.cpp
@@ -65,7 +65,7 @@ StatusOr<vectorized::ChunkPtr> ResultSinkOperator::pull_chunk(RuntimeState* stat
     CHECK(false) << "Shouldn't pull chunk from result sink operator";
 }
 
-bool ResultSinkOperator::need_input() {
+bool ResultSinkOperator::need_input() const {
     if (is_finished()) {
         return false;
     }

--- a/be/src/exec/pipeline/result_sink_operator.h
+++ b/be/src/exec/pipeline/result_sink_operator.h
@@ -25,9 +25,9 @@ public:
 
     // Result sink will send result chunk to BufferControlBlock directly,
     // Then FE will pull result from BufferControlBlock
-    bool has_output() override { return false; }
+    bool has_output() const override { return false; }
 
-    bool need_input() override;
+    bool need_input() const override;
 
     bool is_finished() const override { return _is_finished && !_fetch_data_result; }
 

--- a/be/src/exec/pipeline/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan_operator.cpp
@@ -81,12 +81,12 @@ Status ScanOperator::close(RuntimeState* state) {
     return Status::OK();
 }
 
-bool ScanOperator::_has_output_blocking() {
+bool ScanOperator::_has_output_blocking() const {
     DCHECK(_io_threads == nullptr);
     return _chunk_source->has_next_chunk();
 }
 
-bool ScanOperator::_has_output_nonblocking() {
+bool ScanOperator::_has_output_nonblocking() const {
     DCHECK(_io_threads != nullptr);
     // EOS has arrived
     if (_is_finished) {
@@ -101,7 +101,7 @@ bool ScanOperator::_has_output_nonblocking() {
     return true;
 }
 
-bool ScanOperator::has_output() {
+bool ScanOperator::has_output() const {
     if (_io_threads != nullptr) {
         return _has_output_nonblocking();
     } else {

--- a/be/src/exec/pipeline/scan_operator.h
+++ b/be/src/exec/pipeline/scan_operator.h
@@ -29,7 +29,7 @@ public:
 
     Status close(RuntimeState* state) override;
 
-    bool has_output() override;
+    bool has_output() const override;
 
     bool pending_finish() override;
 
@@ -43,8 +43,8 @@ public:
 private:
     void _pickup_morsel(RuntimeState* state);
     void _trigger_read_chunk();
-    bool _has_output_blocking();
-    bool _has_output_nonblocking();
+    bool _has_output_blocking() const;
+    bool _has_output_nonblocking() const;
     StatusOr<vectorized::ChunkPtr> _pull_chunk_blocking(RuntimeState* state);
     StatusOr<vectorized::ChunkPtr> _pull_chunk_nonblocking(RuntimeState* state);
 

--- a/be/src/exec/pipeline/sort/sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/sort_sink_operator.cpp
@@ -36,7 +36,7 @@ StatusOr<vectorized::ChunkPtr> SortSinkOperator::pull_chunk(RuntimeState* state)
     CHECK(false) << "Shouldn't pull chunk from result sink operator";
 }
 
-bool SortSinkOperator::need_input() {
+bool SortSinkOperator::need_input() const {
     return !is_finished();
 }
 

--- a/be/src/exec/pipeline/sort/sort_sink_operator.h
+++ b/be/src/exec/pipeline/sort/sort_sink_operator.h
@@ -40,9 +40,9 @@ public:
 
     Status close(RuntimeState* state) override;
 
-    bool has_output() override { return false; }
+    bool has_output() const override { return false; }
 
-    bool need_input() override;
+    bool need_input() const override;
 
     bool is_finished() const override { return _is_finished; }
 

--- a/be/src/exec/pipeline/sort/sort_source_operator.cpp
+++ b/be/src/exec/pipeline/sort/sort_source_operator.cpp
@@ -33,7 +33,7 @@ void SortSourceOperator::finish(RuntimeState* state) {
     _is_finished = true;
 }
 
-bool SortSourceOperator::has_output() {
+bool SortSourceOperator::has_output() const {
     return _chunks_sorter->sink_complete();
 }
 

--- a/be/src/exec/pipeline/sort/sort_source_operator.h
+++ b/be/src/exec/pipeline/sort/sort_source_operator.h
@@ -26,7 +26,7 @@ public:
 
     ~SortSourceOperator() override = default;
 
-    bool has_output() override;
+    bool has_output() const override;
 
     bool is_finished() const override;
 

--- a/be/src/exec/pipeline/source_operator.h
+++ b/be/src/exec/pipeline/source_operator.h
@@ -15,7 +15,7 @@ public:
     SourceOperator(int32_t id, std::string name, int32_t plan_node_id) : Operator(id, name, plan_node_id) {}
     ~SourceOperator() override = default;
 
-    bool need_input() override { return false; }
+    bool need_input() const override { return false; }
     virtual bool pending_finish() { return false; }
     Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override {
         return Status::InternalError("Shouldn't push chunk to source operator");

--- a/be/src/exec/vectorized/aggregate/aggregate_blocking_node.h
+++ b/be/src/exec/vectorized/aggregate/aggregate_blocking_node.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include "exec/exec_node.h"
+#include "exec/pipeline/operator.h"
 #include "exec/vectorized/aggregate/aggregate_base_node.h"
 
 // Aggregate means this node handle query with aggregate functions.
@@ -15,5 +17,8 @@ public:
     };
     Status open(RuntimeState* state) override;
     Status get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) override;
+
+    std::vector<std::shared_ptr<pipeline::OperatorFactory>> decompose_to_pipeline(
+            pipeline::PipelineBuilderContext* context) override;
 };
 } // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/aggregate/aggregate_streaming_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_streaming_node.cpp
@@ -2,6 +2,9 @@
 
 #include "exec/vectorized/aggregate/aggregate_streaming_node.h"
 
+#include "exec/pipeline/aggregate_streaming_operator.h"
+#include "exec/pipeline/operator.h"
+#include "exec/pipeline/pipeline_builder.h"
 #include "simd/simd.h"
 
 namespace starrocks::vectorized {
@@ -206,6 +209,16 @@ void AggregateStreamingNode::_output_chunk_from_hash_map(ChunkPtr* chunk) {
     else {
         DCHECK(false);
     }
+}
+
+std::vector<std::shared_ptr<pipeline::OperatorFactory> > AggregateStreamingNode::decompose_to_pipeline(
+        pipeline::PipelineBuilderContext* context) {
+    using namespace pipeline;
+    OpFactories operators = _children[0]->decompose_to_pipeline(context);
+
+    operators.emplace_back(
+            std::make_shared<AggregateStreamingOperatorFactory>(context->next_operator_id(), id(), _tnode));
+    return operators;
 }
 
 } // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/aggregate/aggregate_streaming_node.h
+++ b/be/src/exec/vectorized/aggregate/aggregate_streaming_node.h
@@ -17,6 +17,9 @@ public:
     Status open(RuntimeState* state) override;
     Status get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) override;
 
+    std::vector<std::shared_ptr<pipeline::OperatorFactory>> decompose_to_pipeline(
+            pipeline::PipelineBuilderContext* context) override;
+
 private:
     void _output_chunk_from_hash_map(ChunkPtr* chunk);
 };

--- a/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
@@ -426,4 +426,9 @@ public class AggregationNode extends PlanNode {
         }
         return false;
     }
+
+    @Override
+    public boolean canUsePipeLine() {
+        return getChildren().stream().allMatch(PlanNode::canUsePipeLine);
+    }
 }


### PR DESCRIPTION
Provide aggregate operators for pipeline engine

1. AggregateBaseOperator
2. AggregateBlockingOperator
3. AggregateStreamingOperator

Roadmap

- [x] stage1:  support AggregateBlockingOperator and AggregateStreamingOperator(this pull request)
- [ ] stage2:  support AggregateDistinctBlockingOperator and AggregateDistinctStreamingOperator
- [ ] stage3: use LocalExchagneOperator to increase the degree of parallelism of aggregation
