### PR TITLE
Support bucket shuffle on multiple partition join

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/HashJoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HashJoinNode.java
@@ -68,9 +68,9 @@ public class HashJoinNode extends PlanNode {
     private DistributionMode distrMode;
     private String colocateReason = ""; // if can not do colocate join, set reason here
     // the flag for local bucket shuffle join
-    private boolean isLocalBucketShuffle = false;
+    private boolean isLocalHashBucket = false;
     // the flag for runtime bucket shuffle join
-    private boolean isRuntimeBucketShuffle = false;
+    private boolean isShuffleHashBucket = false;
 
     private List<RuntimeFilterDescription> buildRuntimeFilters = Lists.newArrayList();
 
@@ -160,7 +160,7 @@ public class HashJoinNode extends PlanNode {
             return;
         }
 
-        if (distrMode.equals(DistributionMode.PARTITIONED) || distrMode.equals(DistributionMode.BUCKET_SHUFFLE)) {
+        if (distrMode.equals(DistributionMode.PARTITIONED) || distrMode.equals(DistributionMode.LOCAL_HASH_BUCKET)) {
             // if it's partitioned join and we can not get correct ndv
             // then it's hard to estimate right bloom filter size or it's too big
             // so we'd better to skip this global runtime filter.
@@ -219,12 +219,12 @@ public class HashJoinNode extends PlanNode {
         this.distrMode = distrMode;
     }
 
-    public boolean isLocalBucketShuffle() {
-        return isLocalBucketShuffle;
+    public boolean isLocalHashBucket() {
+        return isLocalHashBucket;
     }
 
-    public boolean isRuntimeBucketShuffle() {
-        return isRuntimeBucketShuffle;
+    public boolean isShuffleHashBucket() {
+        return isShuffleHashBucket;
     }
 
     public void setColocate(boolean colocate, String reason) {
@@ -232,12 +232,12 @@ public class HashJoinNode extends PlanNode {
         colocateReason = reason;
     }
 
-    public void setLocalBucketShuffle(boolean localBucketShuffle) {
-        isLocalBucketShuffle = localBucketShuffle;
+    public void setLocalHashBucket(boolean localHashBucket) {
+        isLocalHashBucket = localHashBucket;
     }
 
-    public void setRuntimeBucketShuffle(boolean runtimeBucketShuffle) {
-        isRuntimeBucketShuffle = runtimeBucketShuffle;
+    public void setShuffleHashBucket(boolean runtimeBucketShuffle) {
+        isShuffleHashBucket = runtimeBucketShuffle;
     }
 
     @Override
@@ -527,14 +527,15 @@ public class HashJoinNode extends PlanNode {
         NONE("NONE"),
         BROADCAST("BROADCAST"),
         PARTITIONED("PARTITIONED"),
-        BUCKET_SHUFFLE("BUCKET_SHUFFLE"),
-        RUNTIME_BUCKET_SHUFFLE("RUNTIME_BUCKET_SHUFFLE"),
+        // The hash algorithms of the two bucket shuffle ways are different
+        LOCAL_HASH_BUCKET("BUCKET_SHUFFLE"),
+        SHUFFLE_HASH_BUCKET("BUCKET_SHUFFLE(S)"),
         COLOCATE("COLOCATE");
 
         private final String description;
 
-        private DistributionMode(String descr) {
-            this.description = descr;
+        DistributionMode(String desc) {
+            this.description = desc;
         }
 
         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HashJoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HashJoinNode.java
@@ -67,7 +67,10 @@ public class HashJoinNode extends PlanNode {
     private boolean isPushDown;
     private DistributionMode distrMode;
     private String colocateReason = ""; // if can not do colocate join, set reason here
-    private boolean isBucketShuffle = false; // the flag for bucket shuffle join
+    // the flag for local bucket shuffle join
+    private boolean isLocalBucketShuffle = false;
+    // the flag for runtime bucket shuffle join
+    private boolean isRuntimeBucketShuffle = false;
 
     private List<RuntimeFilterDescription> buildRuntimeFilters = Lists.newArrayList();
 
@@ -216,8 +219,12 @@ public class HashJoinNode extends PlanNode {
         this.distrMode = distrMode;
     }
 
-    public boolean isBucketShuffle() {
-        return isBucketShuffle;
+    public boolean isLocalBucketShuffle() {
+        return isLocalBucketShuffle;
+    }
+
+    public boolean isRuntimeBucketShuffle() {
+        return isRuntimeBucketShuffle;
     }
 
     public void setColocate(boolean colocate, String reason) {
@@ -225,8 +232,12 @@ public class HashJoinNode extends PlanNode {
         colocateReason = reason;
     }
 
-    public void setBucketShuffle(boolean bucketShuffle) {
-        isBucketShuffle = bucketShuffle;
+    public void setLocalBucketShuffle(boolean localBucketShuffle) {
+        isLocalBucketShuffle = localBucketShuffle;
+    }
+
+    public void setRuntimeBucketShuffle(boolean runtimeBucketShuffle) {
+        isRuntimeBucketShuffle = runtimeBucketShuffle;
     }
 
     @Override
@@ -517,6 +528,7 @@ public class HashJoinNode extends PlanNode {
         BROADCAST("BROADCAST"),
         PARTITIONED("PARTITIONED"),
         BUCKET_SHUFFLE("BUCKET_SHUFFLE"),
+        RUNTIME_BUCKET_SHUFFLE("RUNTIME_BUCKET_SHUFFLE"),
         COLOCATE("COLOCATE");
 
         private final String description;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/RuntimeFilterDescription.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/RuntimeFilterDescription.java
@@ -123,7 +123,7 @@ public class RuntimeFilterDescription {
     public boolean isLocalApplicable() {
         return joinMode.equals(HashJoinNode.DistributionMode.BROADCAST) ||
                 joinMode.equals(HashJoinNode.DistributionMode.COLOCATE) ||
-                joinMode.equals(HashJoinNode.DistributionMode.BUCKET_SHUFFLE);
+                joinMode.equals(HashJoinNode.DistributionMode.LOCAL_HASH_BUCKET);
     }
 
     public boolean isBroadcastJoin() {
@@ -141,7 +141,7 @@ public class RuntimeFilterDescription {
         // because data are shuffled base on multiple columns
         // and we can not probe with only one column.
         if (joinMode.equals(HashJoinNode.DistributionMode.PARTITIONED) ||
-                joinMode.equals(HashJoinNode.DistributionMode.BUCKET_SHUFFLE)) {
+                joinMode.equals(HashJoinNode.DistributionMode.LOCAL_HASH_BUCKET)) {
             return equalCount == 1;
         }
         return false;
@@ -191,7 +191,7 @@ public class RuntimeFilterDescription {
         assert (joinMode != HashJoinNode.DistributionMode.NONE);
         if (joinMode.equals(HashJoinNode.DistributionMode.BROADCAST)) {
             t.setBuild_join_mode(TRuntimeFilterBuildJoinMode.BORADCAST);
-        } else if (joinMode.equals(HashJoinNode.DistributionMode.BUCKET_SHUFFLE)) {
+        } else if (joinMode.equals(HashJoinNode.DistributionMode.LOCAL_HASH_BUCKET)) {
             t.setBuild_join_mode(TRuntimeFilterBuildJoinMode.BUCKET_SHUFFLE);
         } else if (joinMode.equals(HashJoinNode.DistributionMode.PARTITIONED)) {
             t.setBuild_join_mode(TRuntimeFilterBuildJoinMode.PARTITIONED);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -967,10 +967,10 @@ public class Coordinator {
         return maxParallelismExecParams;
     }
 
-    private boolean hasRuntimeBucketShuffleJoin(PlanNode node) {
+    private boolean hasShuffleHashBucketJoin(PlanNode node) {
         if (node instanceof HashJoinNode) {
             HashJoinNode hashJoinNode = (HashJoinNode) node;
-            if (hashJoinNode.isRuntimeBucketShuffle()) {
+            if (hashJoinNode.isShuffleHashBucket()) {
                 return true;
             }
         }
@@ -978,7 +978,7 @@ public class Coordinator {
             return false;
         }
         for (PlanNode child : node.getChildren()) {
-            if (hasRuntimeBucketShuffleJoin(child)) {
+            if (hasShuffleHashBucketJoin(child)) {
                 return true;
             }
         }
@@ -1037,8 +1037,8 @@ public class Coordinator {
                 PlanFragmentId inputFragmentId = fragment.getChild(inputFragmentIndex).getFragmentId();
                 FragmentExecParams maxParallelismFragmentExecParams = fragmentExecParamsMap.get(inputFragmentId);
 
-                boolean hasRuntimeBucketShuffleJoinInFragment = hasRuntimeBucketShuffleJoin(fragment.getPlanRoot());
-                if (hasRuntimeBucketShuffleJoinInFragment) {
+                boolean hasShuffleHashBucketJoinInFragment = hasShuffleHashBucketJoin(fragment.getPlanRoot());
+                if (hasShuffleHashBucketJoinInFragment) {
                     FragmentExecParams execParams = getMaxParallelismScanFragmentExecParams();
                     if (execParams != null) {
                         maxParallelismFragmentExecParams = execParams;
@@ -1059,7 +1059,7 @@ public class Coordinator {
                         hostSet.add(execParams.host);
                     }
                     List<TNetworkAddress> hosts = Lists.newArrayList(hostSet);
-                    if (!hasRuntimeBucketShuffleJoinInFragment) {
+                    if (!hasShuffleHashBucketJoinInFragment) {
                         Collections.shuffle(hosts, instanceRandom);
                     }
                     for (int index = 0; index < exchangeInstances; index++) {
@@ -1077,7 +1077,7 @@ public class Coordinator {
                 // When group by cardinality is smaller than number of backend, only some backends always
                 // process while other has no data to process.
                 // So we shuffle instances to make different backends handle different queries.
-                if (!hasRuntimeBucketShuffleJoinInFragment) {
+                if (!hasShuffleHashBucketJoinInFragment) {
                     Collections.shuffle(params.instanceExecParams, instanceRandom);
                 }
 
@@ -1188,7 +1188,7 @@ public class Coordinator {
         // One fragment could only have one HashJoinNode
         if (node instanceof HashJoinNode) {
             HashJoinNode joinNode = (HashJoinNode) node;
-            if (joinNode.isLocalBucketShuffle()) {
+            if (joinNode.isLocalHashBucket()) {
                 bucketShuffleFragmentIds.add(joinNode.getFragmentId().asInt());
                 return true;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -116,6 +116,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
 
 public class Coordinator {
     private static final Logger LOG = LogManager.getLogger(Coordinator.class);
@@ -949,6 +950,41 @@ public class Coordinator {
         return new TNetworkAddress(backend.getHost(), backend.getBrpcPort());
     }
 
+    private FragmentExecParams getMaxParallelismScanFragmentExecParams() {
+        List<FragmentExecParams> scanNodePlanFragmentParams =
+                this.scanNodes.stream().map(node -> fragmentExecParamsMap.get(node.getFragment().getFragmentId()))
+                        .collect(Collectors.toList());
+        int maxParallelism = 0;
+        FragmentExecParams maxParallelismExecParams = null;
+
+        for (FragmentExecParams params : scanNodePlanFragmentParams) {
+            int currentChildFragmentParallelism = params.instanceExecParams.size();
+            if (currentChildFragmentParallelism > maxParallelism) {
+                maxParallelism = currentChildFragmentParallelism;
+                maxParallelismExecParams = params;
+            }
+        }
+        return maxParallelismExecParams;
+    }
+
+    private boolean hasRuntimeBucketShuffleJoin(PlanNode node) {
+        if (node instanceof HashJoinNode) {
+            HashJoinNode hashJoinNode = (HashJoinNode) node;
+            if (hashJoinNode.isRuntimeBucketShuffle()) {
+                return true;
+            }
+        }
+        if (node instanceof ExchangeNode) {
+            return false;
+        }
+        for (PlanNode child : node.getChildren()) {
+            if (hasRuntimeBucketShuffleJoin(child)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     // For each fragment in fragments, computes hosts on which to run the instances
     // and stores result in fragmentExecParams.hosts.
     private void computeFragmentHosts() throws Exception {
@@ -987,7 +1023,6 @@ public class Coordinator {
                 // (Case B)
                 // there is no leftmost scan; we assign the same hosts as those of our
                 //  input fragment which has a higher instance_number
-
                 int inputFragmentIndex = 0;
                 int maxParallelism = 0;
                 for (int j = 0; j < fragment.getChildren().size(); j++) {
@@ -1000,30 +1035,40 @@ public class Coordinator {
                 }
 
                 PlanFragmentId inputFragmentId = fragment.getChild(inputFragmentIndex).getFragmentId();
+                FragmentExecParams maxParallelismFragmentExecParams = fragmentExecParamsMap.get(inputFragmentId);
+
+                boolean hasRuntimeBucketShuffleJoinInFragment = hasRuntimeBucketShuffleJoin(fragment.getPlanRoot());
+                if (hasRuntimeBucketShuffleJoinInFragment) {
+                    FragmentExecParams execParams = getMaxParallelismScanFragmentExecParams();
+                    if (execParams != null) {
+                        maxParallelismFragmentExecParams = execParams;
+                    }
+                }
+
                 // AddAll() soft copy()
                 int exchangeInstances = -1;
                 if (ConnectContext.get() != null && ConnectContext.get().getSessionVariable() != null) {
                     exchangeInstances = ConnectContext.get().getSessionVariable().getExchangeInstanceParallel();
                 }
                 if (exchangeInstances > 0 &&
-                        fragmentExecParamsMap.get(inputFragmentId).instanceExecParams.size() > exchangeInstances) {
+                        maxParallelismFragmentExecParams.instanceExecParams.size() > exchangeInstances) {
                     // random select some instance
                     // get distinct host,  when parallel_fragment_exec_instance_num > 1, single host may execute severval instances
                     Set<TNetworkAddress> hostSet = Sets.newHashSet();
-                    for (FInstanceExecParam execParams : fragmentExecParamsMap
-                            .get(inputFragmentId).instanceExecParams) {
+                    for (FInstanceExecParam execParams : maxParallelismFragmentExecParams.instanceExecParams) {
                         hostSet.add(execParams.host);
                     }
                     List<TNetworkAddress> hosts = Lists.newArrayList(hostSet);
-                    Collections.shuffle(hosts, instanceRandom);
+                    if (!hasRuntimeBucketShuffleJoinInFragment) {
+                        Collections.shuffle(hosts, instanceRandom);
+                    }
                     for (int index = 0; index < exchangeInstances; index++) {
                         FInstanceExecParam instanceParam =
                                 new FInstanceExecParam(null, hosts.get(index % hosts.size()), 0, params);
                         params.instanceExecParams.add(instanceParam);
                     }
                 } else {
-                    for (FInstanceExecParam execParams : fragmentExecParamsMap
-                            .get(inputFragmentId).instanceExecParams) {
+                    for (FInstanceExecParam execParams : maxParallelismFragmentExecParams.instanceExecParams) {
                         FInstanceExecParam instanceParam = new FInstanceExecParam(null, execParams.host, 0, params);
                         params.instanceExecParams.add(instanceParam);
                     }
@@ -1032,7 +1077,9 @@ public class Coordinator {
                 // When group by cardinality is smaller than number of backend, only some backends always
                 // process while other has no data to process.
                 // So we shuffle instances to make different backends handle different queries.
-                Collections.shuffle(params.instanceExecParams, instanceRandom);
+                if (!hasRuntimeBucketShuffleJoinInFragment) {
+                    Collections.shuffle(params.instanceExecParams, instanceRandom);
+                }
 
                 // TODO: switch to unpartitioned/coord execution if our input fragment
                 // is executed that way (could have been downgraded from distributed)
@@ -1141,7 +1188,7 @@ public class Coordinator {
         // One fragment could only have one HashJoinNode
         if (node instanceof HashJoinNode) {
             HashJoinNode joinNode = (HashJoinNode) node;
-            if (joinNode.isBucketShuffle()) {
+            if (joinNode.isLocalBucketShuffle()) {
                 bucketShuffleFragmentIds.add(joinNode.getFragmentId().asInt());
                 return true;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ChildPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ChildPropertyDeriver.java
@@ -156,7 +156,7 @@ public class ChildPropertyDeriver extends OperatorVisitor<Void, ExpressionContex
         HashDistributionSpec rightDistribution = DistributionSpec.createHashDistributionSpec(
                 new HashDistributionDesc(rightOnPredicateColumns, HashDistributionDesc.SourceType.SHUFFLE_JOIN));
 
-        tryHashShuffle(leftDistribution, rightDistribution);
+        doHashShuffle(leftDistribution, rightDistribution);
 
         // Respect use join hint
         if ("SHUFFLE".equalsIgnoreCase(hint)) {
@@ -180,7 +180,8 @@ public class ChildPropertyDeriver extends OperatorVisitor<Void, ExpressionContex
         return visitJoinRequirements(node, context);
     }
 
-    private void tryHashShuffle(HashDistributionSpec leftDistribution, HashDistributionSpec rightDistribution) {
+    private void doHashShuffle(HashDistributionSpec leftDistribution, HashDistributionSpec rightDistribution) {
+        // shuffle
         PhysicalPropertySet leftInputProperty = createPropertySetByDistribution(leftDistribution);
         PhysicalPropertySet rightInputProperty = createPropertySetByDistribution(rightDistribution);
 
@@ -191,6 +192,7 @@ public class ChildPropertyDeriver extends OperatorVisitor<Void, ExpressionContex
             return;
         }
 
+        // try shuffle_hash_bucket
         HashDistributionDesc requiredDesc = requiredShuffleDesc.get();
 
         List<Integer> leftColumns = leftDistribution.getShuffleColumns();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/HashDistributionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/HashDistributionDesc.java
@@ -12,6 +12,8 @@ public class HashDistributionDesc {
         LOCAL, // hash property from scan node
         SHUFFLE_JOIN, // hash property from shuffle join
         BUCKET_JOIN, // hash property from bucket join
+        // @Todo: It's a temporary solution
+        FORCE_SHUFFLE_JOIN, // hash property from shuffle join if contains expression in on clause
         SHUFFLE_AGG, // hash property from shuffle agg,
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/HashDistributionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/HashDistributionDesc.java
@@ -11,7 +11,8 @@ public class HashDistributionDesc {
     public enum SourceType {
         LOCAL, // hash property from scan node
         SHUFFLE_JOIN, // hash property from shuffle join
-        SHUFFLE_AGG, // hash property from shuffle agg
+        BUCKET_JOIN, // hash property from bucket join
+        SHUFFLE_AGG, // hash property from shuffle agg,
     }
 
     private final List<Integer> columns;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -46,6 +46,7 @@ import com.starrocks.planner.IntersectNode;
 import com.starrocks.planner.MysqlScanNode;
 import com.starrocks.planner.OlapScanNode;
 import com.starrocks.planner.PlanFragment;
+import com.starrocks.planner.PlanNode;
 import com.starrocks.planner.PlannerContext;
 import com.starrocks.planner.ProjectNode;
 import com.starrocks.planner.RepeatNode;
@@ -314,7 +315,8 @@ public class PlanFragmentBuilder {
                 }
                 scanNode.setTotalTabletsNum(totalTabletsNum);
             } catch (UserException e) {
-                throw new StarRocksPlannerException("Build Exec OlapScanNode fail, scan info is invalid," + e.getMessage(),
+                throw new StarRocksPlannerException(
+                        "Build Exec OlapScanNode fail, scan info is invalid," + e.getMessage(),
                         INTERNAL_ERROR);
             }
 
@@ -1069,6 +1071,8 @@ public class PlanFragmentBuilder {
                 } else if (!(leftFragment.getPlanRoot() instanceof ExchangeNode) &&
                         !(rightFragment.getPlanRoot() instanceof ExchangeNode)) {
                     distributionMode = HashJoinNode.DistributionMode.COLOCATE;
+                } else if (isRuntimeBucketShuffle(leftFragment.getPlanRoot(), rightFragment.getPlanRoot())) {
+                    distributionMode = HashJoinNode.DistributionMode.RUNTIME_BUCKET_SHUFFLE;
                 } else {
                     distributionMode = HashJoinNode.DistributionMode.BUCKET_SHUFFLE;
                 }
@@ -1203,6 +1207,22 @@ public class PlanFragmentBuilder {
                     context.getFragments().remove(leftFragment);
                     context.getFragments().add(leftFragment);
                     return leftFragment;
+                } else if (distributionMode.equals(HashJoinNode.DistributionMode.RUNTIME_BUCKET_SHUFFLE)) {
+                    List<Integer> leftOnPredicateColumns = new ArrayList<>();
+                    List<Integer> rightOnPredicateColumns = new ArrayList<>();
+                    JoinPredicateUtils.getJoinOnPredicatesColumns(eqOnPredicates, leftChildColumns, rightChildColumns,
+                            leftOnPredicateColumns, rightOnPredicateColumns);
+                    setJoinPushDown(hashJoinNode);
+
+                    // distributionMode is RUNTIME_BUCKET_SHUFFLE
+                    if (leftFragment.getPlanRoot() instanceof ExchangeNode &&
+                            !(rightFragment.getPlanRoot() instanceof ExchangeNode)) {
+                        return computeRunTimeBucketShufflePlanFragment(context, leftOnPredicateColumns, rightFragment,
+                                leftFragment, hashJoinNode);
+                    } else {
+                        return computeRunTimeBucketShufflePlanFragment(context, rightOnPredicateColumns, leftFragment,
+                                rightFragment, hashJoinNode);
+                    }
                 } else {
                     List<Integer> leftOnPredicateColumns = new ArrayList<>();
                     List<Integer> rightOnPredicateColumns = new ArrayList<>();
@@ -1223,12 +1243,66 @@ public class PlanFragmentBuilder {
             }
         }
 
+        public boolean isShuffleJoin(HashJoinNode node) {
+            if (node.getChild(0) instanceof ExchangeNode && ((ExchangeNode) node.getChild(0)).getDistributionType()
+                    .equals(DistributionSpec.DistributionType.SHUFFLE) &&
+                    node.getChild(1) instanceof ExchangeNode && ((ExchangeNode) node.getChild(1)).getDistributionType()
+                    .equals(DistributionSpec.DistributionType.SHUFFLE)) {
+                return true;
+            }
+            return false;
+        }
+
+        public boolean isRuntimeBucketShuffle(PlanNode left, PlanNode right) {
+            if (left instanceof ProjectNode) {
+                return isRuntimeBucketShuffle(left.getChild(0), right);
+            }
+            if (left instanceof HashJoinNode) {
+                HashJoinNode hashJoinNode = (HashJoinNode) left;
+                if (hashJoinNode.isLocalBucketShuffle()) {
+                    return false;
+                }
+                if (hashJoinNode.isRuntimeBucketShuffle() || isShuffleJoin(hashJoinNode)) {
+                    return true;
+                }
+            }
+            // left is not hashJoinNode
+            if (right instanceof ProjectNode) {
+                return isRuntimeBucketShuffle(left, right.getChild(0));
+            }
+            if (right instanceof HashJoinNode) {
+                return true;
+            }
+            return false;
+        }
+
         public PlanFragment computeBucketShufflePlanFragment(ExecPlan context, List<Integer> columns,
                                                              PlanFragment stayFragment,
                                                              PlanFragment removeFragment, HashJoinNode hashJoinNode) {
-            hashJoinNode.setBucketShuffle(true);
+            hashJoinNode.setLocalBucketShuffle(true);
             removeFragment.getChild(0)
                     .setOutputPartition(new DataPartition(TPartitionType.BUCKET_SHFFULE_HASH_PARTITIONED,
+                            removeFragment.getDataPartition().getPartitionExprs()));
+
+            // Currently, we always generate new fragment for PhysicalDistribution.
+            // So we need to remove exchange node only fragment for Join.
+            context.getFragments().remove(removeFragment);
+
+            context.getFragments().remove(stayFragment);
+            context.getFragments().add(stayFragment);
+
+            stayFragment.setPlanRoot(hashJoinNode);
+            stayFragment.addChild(removeFragment.getChild(0));
+            return stayFragment;
+        }
+
+        public PlanFragment computeRunTimeBucketShufflePlanFragment(ExecPlan context, List<Integer> columns,
+                                                                    PlanFragment stayFragment,
+                                                                    PlanFragment removeFragment,
+                                                                    HashJoinNode hashJoinNode) {
+            hashJoinNode.setRuntimeBucketShuffle(true);
+            removeFragment.getChild(0)
+                    .setOutputPartition(new DataPartition(TPartitionType.HASH_PARTITIONED,
                             removeFragment.getDataPartition().getPartitionExprs()));
 
             // Currently, we always generate new fragment for PhysicalDistribution.

--- a/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorTest.java
@@ -160,13 +160,13 @@ public class CoordinatorTest extends Coordinator {
         // the fragment id is different from hash join node
         hashJoinNode.setFragment(new PlanFragment(new PlanFragmentId(-2), hashJoinNode,
                 new DataPartition(TPartitionType.BUCKET_SHFFULE_HASH_PARTITIONED, testJoinexprs)));
-        hashJoinNode.setDistributionMode(HashJoinNode.DistributionMode.BUCKET_SHUFFLE);
+        hashJoinNode.setDistributionMode(HashJoinNode.DistributionMode.LOCAL_HASH_BUCKET);
         Assert.assertEquals(false,
                 Deencapsulation.invoke(coordinator, "isBucketShuffleJoin", -1, hashJoinNode));
 
         hashJoinNode.setFragment(new PlanFragment(new PlanFragmentId(-1), hashJoinNode,
                 new DataPartition(TPartitionType.BUCKET_SHFFULE_HASH_PARTITIONED, testJoinexprs)));
-        Deencapsulation.setField(hashJoinNode, "isLocalBucketShuffle", true);
+        Deencapsulation.setField(hashJoinNode, "isLocalHashBucket", true);
         Assert.assertEquals(true,
                 Deencapsulation.invoke(coordinator, "isBucketShuffleJoin", -1, hashJoinNode));
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorTest.java
@@ -166,7 +166,7 @@ public class CoordinatorTest extends Coordinator {
 
         hashJoinNode.setFragment(new PlanFragment(new PlanFragmentId(-1), hashJoinNode,
                 new DataPartition(TPartitionType.BUCKET_SHFFULE_HASH_PARTITIONED, testJoinexprs)));
-        Deencapsulation.setField(hashJoinNode, "isBucketShuffle", true);
+        Deencapsulation.setField(hashJoinNode, "isLocalBucketShuffle", true);
         Assert.assertEquals(true,
                 Deencapsulation.invoke(coordinator, "isBucketShuffleJoin", -1, hashJoinNode));
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -3691,7 +3691,7 @@ public class PlanFragmentTest extends PlanTestBase {
                 "left join join2 as c on join1.id = c.id \n" +
                 "where b.id > 1;";
         starRocksAssert.query(sql).explainContains("7:HASH JOIN\n" +
-                        "  |  join op: LEFT OUTER JOIN (RUNTIME_BUCKET_SHUFFLE)\n" +
+                        "  |  join op: LEFT OUTER JOIN (BUCKET_SHUFFLE(S))\n" +
                         "  |  hash predicates:\n" +
                         "  |  colocate: false, reason: \n" +
                         "  |  equal join conjunct: 2: id = 8: id",
@@ -4311,25 +4311,25 @@ public class PlanFragmentTest extends PlanTestBase {
     }
 
     @Test
-    public void testRuntimeBucketShuffle() throws Exception {
+    public void testShuffleHashBucket() throws Exception {
         String sql = "SELECT COUNT(*)\n" +
                 "FROM lineitem JOIN [shuffle] orders o1 ON l_orderkey = o1.o_orderkey\n" +
                 "JOIN [shuffle] orders o2 ON l_orderkey = o2.o_orderkey";
         String plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("join op: INNER JOIN (RUNTIME_BUCKET_SHUFFLE)"));
+        Assert.assertTrue(plan.contains("join op: INNER JOIN (BUCKET_SHUFFLE(S))"));
     }
 
     @Test
-    public void testRuntimeBucketShuffle2() throws Exception {
+    public void testShuffleHashBucket2() throws Exception {
         String sql = "select count(1) from lineitem t1 join [shuffle] orders t2 on " +
                 "t1.l_orderkey = t2.o_orderkey and t2.O_ORDERDATE = t1.L_SHIPDATE join [shuffle] orders t3 " +
                 "on t1.l_orderkey = t3.o_orderkey and t3.O_ORDERDATE = t1.L_SHIPDATE join [shuffle] orders t4 on\n" +
                 "t1.l_orderkey = t4.o_orderkey and t4.O_ORDERDATE = t1.L_SHIPDATE;";
         String plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("12:HASH JOIN\n" +
-                "  |  join op: INNER JOIN (RUNTIME_BUCKET_SHUFFLE)"));
+                "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))"));
         Assert.assertTrue(plan.contains("8:HASH JOIN\n" +
-                "  |  join op: INNER JOIN (RUNTIME_BUCKET_SHUFFLE)"));
+                "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))"));
         Assert.assertTrue(plan.contains("4:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (PARTITIONED)"));
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -2710,9 +2710,10 @@ public class PlanFragmentTest extends PlanTestBase {
                 "OUTPUT EXPRS:1: id | 2: id2"
         );
 
-        starRocksAssert.query("select count(id2) from test.bitmap_table;").explainContains("OUTPUT EXPRS:3: count(2: id2)",
-                "1:AGGREGATE (update finalize)", "output: count(2: id2)", "group by:", "0:OlapScanNode",
-                "PREAGGREGATION: OFF. Reason: Aggregate Operator not match: COUNT <--> BITMAP_UNION");
+        starRocksAssert.query("select count(id2) from test.bitmap_table;")
+                .explainContains("OUTPUT EXPRS:3: count(2: id2)",
+                        "1:AGGREGATE (update finalize)", "output: count(2: id2)", "group by:", "0:OlapScanNode",
+                        "PREAGGREGATION: OFF. Reason: Aggregate Operator not match: COUNT <--> BITMAP_UNION");
 
         starRocksAssert.query("select group_concat(id2) from test.bitmap_table;")
                 .analysisError(
@@ -2787,7 +2788,8 @@ public class PlanFragmentTest extends PlanTestBase {
         starRocksAssert.query(sql).explainContains();
 
         sql = "select count(distinct id2) from test.bitmap_table having count(distinct id2) > 0";
-        starRocksAssert.query(sql).explainContains("bitmap_union_count(2: id2)", "having: 3: count(distinct 2: id2) > 0");
+        starRocksAssert.query(sql)
+                .explainContains("bitmap_union_count(2: id2)", "having: 3: count(distinct 2: id2) > 0");
 
         sql = "select count(distinct id2) from test.bitmap_table order by count(distinct id2)";
         starRocksAssert.query(sql).explainContains("3: count(distinct 2: id2)", "3:MERGING-EXCHANGE",
@@ -3688,24 +3690,24 @@ public class PlanFragmentTest extends PlanTestBase {
         sql = "select * from join1 left join join2 as b on join1.id = b.id\n" +
                 "left join join2 as c on join1.id = c.id \n" +
                 "where b.id > 1;";
-        starRocksAssert.query(sql).explainContains("  6:HASH JOIN\n" +
-                        "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
+        starRocksAssert.query(sql).explainContains("7:HASH JOIN\n" +
+                        "  |  join op: LEFT OUTER JOIN (RUNTIME_BUCKET_SHUFFLE)\n" +
                         "  |  hash predicates:\n" +
                         "  |  colocate: false, reason: \n" +
                         "  |  equal join conjunct: 2: id = 8: id",
-                "  3:HASH JOIN\n" +
-                        "  |  join op: INNER JOIN (BROADCAST)\n" +
+                "4:HASH JOIN\n" +
+                        "  |  join op: INNER JOIN (PARTITIONED)\n" +
                         "  |  hash predicates:\n" +
                         "  |  colocate: false, reason: \n" +
-                        "  |  equal join conjunct: 2: id = 5: id",
-                "  0:OlapScanNode\n" +
-                        "     TABLE: join1\n" +
-                        "     PREAGGREGATION: ON\n" +
-                        "     PREDICATES: 2: id > 1",
-                "  1:OlapScanNode\n" +
+                        "  |  equal join conjunct: 5: id = 2: id",
+                "0:OlapScanNode\n" +
                         "     TABLE: join2\n" +
                         "     PREAGGREGATION: ON\n" +
-                        "     PREDICATES: 5: id > 1");
+                        "     PREDICATES: 5: id > 1",
+                "2:OlapScanNode\n" +
+                        "     TABLE: join1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     PREDICATES: 2: id > 1");
 
         sql = "select * from join1 left join join2 as b on join1.id = b.id\n" +
                 "left join join2 as c on join1.id = c.id \n" +
@@ -4306,5 +4308,29 @@ public class PlanFragmentTest extends PlanTestBase {
                 "  1:OlapScanNode\n" +
                 "     TABLE: t1"));
         FeConstants.runningUnitTest = false;
+    }
+
+    @Test
+    public void testRuntimeBucketShuffle() throws Exception {
+        String sql = "SELECT COUNT(*)\n" +
+                "FROM lineitem JOIN [shuffle] orders o1 ON l_orderkey = o1.o_orderkey\n" +
+                "JOIN [shuffle] orders o2 ON l_orderkey = o2.o_orderkey";
+        String plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("join op: INNER JOIN (RUNTIME_BUCKET_SHUFFLE)"));
+    }
+
+    @Test
+    public void testRuntimeBucketShuffle2() throws Exception {
+        String sql = "select count(1) from lineitem t1 join [shuffle] orders t2 on " +
+                "t1.l_orderkey = t2.o_orderkey and t2.O_ORDERDATE = t1.L_SHIPDATE join [shuffle] orders t3 " +
+                "on t1.l_orderkey = t3.o_orderkey and t3.O_ORDERDATE = t1.L_SHIPDATE join [shuffle] orders t4 on\n" +
+                "t1.l_orderkey = t4.o_orderkey and t4.O_ORDERDATE = t1.L_SHIPDATE;";
+        String plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("12:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (RUNTIME_BUCKET_SHUFFLE)"));
+        Assert.assertTrue(plan.contains("8:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (RUNTIME_BUCKET_SHUFFLE)"));
+        Assert.assertTrue(plan.contains("4:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (PARTITIONED)"));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -152,10 +152,10 @@ public class ReplayFromDumpTest {
         SessionVariable replaySessionVariable = replayPair.first.getSessionVariable();
         Assert.assertEquals(replaySessionVariable.getParallelExecInstanceNum(), 4);
         System.out.println(replayPair.second);
-        Assert.assertTrue(replayPair.second.contains("|----24:EXCHANGE\n" +
+        Assert.assertTrue(replayPair.second.contains("|----25:EXCHANGE\n" +
                 "  |       cardinality: 73049\n" +
                 "  |    \n" +
-                "  18:UNION\n" +
+                "  19:UNION\n" +
                 "  |  child exprs: \n" +
                 "  |      [143, INT, true] | [164, DECIMAL(7,2), true]\n" +
                 "  |      [179, INT, true] | [200, DECIMAL(7,2), true]"));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -152,14 +152,10 @@ public class ReplayFromDumpTest {
         SessionVariable replaySessionVariable = replayPair.first.getSessionVariable();
         Assert.assertEquals(replaySessionVariable.getParallelExecInstanceNum(), 4);
         System.out.println(replayPair.second);
-        Assert.assertTrue(replayPair.second.contains("26:HASH JOIN\n" +
-                "  |  join op: INNER JOIN (BROADCAST)\n" +
-                "  |  equal join conjunct: [175: ws_sold_date_sk, INT, true] = [211: d_date_sk, INT, false]"));
-
-        Assert.assertTrue(replayPair.second.contains("|----25:EXCHANGE\n" +
+        Assert.assertTrue(replayPair.second.contains("|----24:EXCHANGE\n" +
                 "  |       cardinality: 73049\n" +
                 "  |    \n" +
-                "  19:UNION\n" +
+                "  18:UNION\n" +
                 "  |  child exprs: \n" +
                 "  |      [143, INT, true] | [164, DECIMAL(7,2), true]\n" +
                 "  |      [179, INT, true] | [200, DECIMAL(7,2), true]"));


### PR DESCRIPTION
When there are multiple joins, such as A join B join C, will shuffle A and B together first, then reshuffle the result and C again. The purpose of this PR is to directly shuffle A, B, and C together, reducing an extra shuffle operator in the middle