### PR TITLE
[SR-3574] Optimizing bitmap deserialization performance

### DIFF
--- a/be/src/util/bitmap_value.h
+++ b/be/src/util/bitmap_value.h
@@ -608,7 +608,7 @@ public:
 
         if (*buf == BitmapTypeCode::BITMAP32) {
             Roaring read = Roaring::read(buf + 1);
-            result.emplaceOrInsert(0, read);
+            result.emplace(0, std::move(read));
             return result;
         }
 
@@ -626,9 +626,9 @@ public:
             buf += sizeof(uint32_t);
             // read map value Roaring
             Roaring read = Roaring::read(buf);
-            result.emplaceOrInsert(key, read);
             // forward buffer past the last Roaring Bitmap
             buf += read.getSizeInBytes();
+            result.emplace(key, std::move(read));
         }
         return result;
     }
@@ -830,6 +830,8 @@ private:
         roarings.emplace(std::make_pair(key, value));
 #endif
     }
+
+    void emplace(const uint32_t key, Roaring&& value) { roarings.emplace(key, std::move(value)); }
 };
 
 // Forked from https://github.com/RoaringBitmap/CRoaring/blob/v0.2.60/cpp/roaring64map.hh


### PR DESCRIPTION
use right value instead of copy value

before:
mysql> select bitmap_union_count(v) from bitmap_r50E_x;
+-------------------------+
| bitmap_union_count(`v`) |
+-------------------------+
|               100000000 |
+-------------------------+
1 row in set (8.88 sec)

after:
mysql> select bitmap_union_count(v) from bitmap_r50E_x;
+-------------------------+
| bitmap_union_count(`v`) |
+-------------------------+
|               100000000 |
+-------------------------+
1 row in set (5.70 sec)