### PR TITLE
[SR-3845] add defense for large binary column in right table of hash join

### DIFF
--- a/be/src/column/array_column.h
+++ b/be/src/column/array_column.h
@@ -221,6 +221,10 @@ public:
 
     std::string debug_string() const override;
 
+    bool exceed_capacity_limit() const override {
+        return _elements->exceed_capacity_limit() || _offsets->exceed_capacity_limit();
+    }
+
 private:
     ColumnPtr _elements;
     // Offsets column will store the start position of every array element.

--- a/be/src/column/array_column.h
+++ b/be/src/column/array_column.h
@@ -221,8 +221,8 @@ public:
 
     std::string debug_string() const override;
 
-    bool exceed_capacity_limit() const override {
-        return _elements->exceed_capacity_limit() || _offsets->exceed_capacity_limit();
+    bool reach_capacity_limit() const override {
+        return _elements->reach_capacity_limit() || _offsets->reach_capacity_limit();
     }
 
 private:

--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -272,7 +272,7 @@ public:
         return ss.str();
     }
 
-    bool exceed_capacity_limit() const override {
+    bool reach_capacity_limit() const override {
         return _bytes.size() >= UINT32_MAX || _offsets.size() >= UINT32_MAX || _slices.size() >= UINT32_MAX;
     }
 

--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -272,6 +272,10 @@ public:
         return ss.str();
     }
 
+    bool exceed_capacity_limit() const override {
+        return _bytes.size() >= UINT32_MAX || _offsets.size() >= UINT32_MAX || _slices.size() >= UINT32_MAX;
+    }
+
 private:
     void _build_slices() const;
 

--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -273,7 +273,8 @@ public:
     }
 
     bool reach_capacity_limit() const override {
-        return _bytes.size() >= UINT32_MAX || _offsets.size() >= UINT32_MAX || _slices.size() >= UINT32_MAX;
+        return _bytes.size() >= Column::MAX_CAPACITY_LIMIT || _offsets.size() >= Column::MAX_CAPACITY_LIMIT ||
+               _slices.size() >= Column::MAX_CAPACITY_LIMIT;
     }
 
 private:

--- a/be/src/column/chunk.h
+++ b/be/src/column/chunk.h
@@ -234,9 +234,9 @@ public:
 
     std::string debug_row(uint32_t index) const;
 
-    bool exceed_capacity_limit() const {
+    bool reach_capacity_limit() const {
         for (const auto& column : _columns) {
-            if (column->exceed_capacity_limit()) {
+            if (column->reach_capacity_limit()) {
                 return true;
             }
         }

--- a/be/src/column/chunk.h
+++ b/be/src/column/chunk.h
@@ -234,6 +234,15 @@ public:
 
     std::string debug_row(uint32_t index) const;
 
+    bool exceed_capacity_limit() const {
+        for (const auto& column : _columns) {
+            if (column->exceed_capacity_limit()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
 private:
     void rebuild_cid_index();
 

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -305,6 +305,8 @@ public:
 
     virtual void reset_column() { _delete_state = DEL_NOT_SATISFIED; }
 
+    virtual bool exceed_capacity_limit() const = 0;
+
 protected:
     DelCondSatisfied _delete_state = DEL_NOT_SATISFIED;
 };

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -37,6 +37,8 @@ public:
     // From the result, we can see when fixed length is 128, we can get speed up for column read.
     enum { APPEND_OVERFLOW_MAX_SIZE = 128 };
 
+    static const uint32_t MAX_CAPACITY_LIMIT = UINT32_MAX;
+
     // mutable operations cannot be applied to shared data when concurrent
     using Ptr = std::shared_ptr<Column>;
     // mutable means you could modify the data safely

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -305,7 +305,7 @@ public:
 
     virtual void reset_column() { _delete_state = DEL_NOT_SATISFIED; }
 
-    virtual bool exceed_capacity_limit() const = 0;
+    virtual bool reach_capacity_limit() const = 0;
 
 protected:
     DelCondSatisfied _delete_state = DEL_NOT_SATISFIED;

--- a/be/src/column/const_column.h
+++ b/be/src/column/const_column.h
@@ -217,6 +217,8 @@ public:
         return ss.str();
     }
 
+    bool exceed_capacity_limit() const override { return false; }
+
 private:
     ColumnPtr _data;
     size_t _size;

--- a/be/src/column/const_column.h
+++ b/be/src/column/const_column.h
@@ -217,7 +217,7 @@ public:
         return ss.str();
     }
 
-    bool exceed_capacity_limit() const override { return _data->exceed_capacity_limit(); }
+    bool reach_capacity_limit() const override { return _data->reach_capacity_limit(); }
 
 private:
     ColumnPtr _data;

--- a/be/src/column/const_column.h
+++ b/be/src/column/const_column.h
@@ -217,7 +217,7 @@ public:
         return ss.str();
     }
 
-    bool exceed_capacity_limit() const override { return false; }
+    bool exceed_capacity_limit() const override { return _data->exceed_capacity_limit(); }
 
 private:
     ColumnPtr _data;

--- a/be/src/column/fixed_length_column_base.h
+++ b/be/src/column/fixed_length_column_base.h
@@ -183,7 +183,7 @@ public:
         _data.clear();
     }
 
-    bool reach_capacity_limit() const override { return _data.size() >= UINT32_MAX; }
+    bool reach_capacity_limit() const override { return _data.size() >= Column::MAX_CAPACITY_LIMIT; }
 
 protected:
     Container _data;

--- a/be/src/column/fixed_length_column_base.h
+++ b/be/src/column/fixed_length_column_base.h
@@ -183,6 +183,10 @@ public:
         _data.clear();
     }
 
+    bool exceed_capacity_limit() const override {
+        return _data.size() >= UINT32_MAX;
+    }
+
 protected:
     Container _data;
 };

--- a/be/src/column/fixed_length_column_base.h
+++ b/be/src/column/fixed_length_column_base.h
@@ -183,7 +183,7 @@ public:
         _data.clear();
     }
 
-    bool exceed_capacity_limit() const override {
+    bool reach_capacity_limit() const override {
         return _data.size() >= UINT32_MAX;
     }
 

--- a/be/src/column/fixed_length_column_base.h
+++ b/be/src/column/fixed_length_column_base.h
@@ -183,9 +183,7 @@ public:
         _data.clear();
     }
 
-    bool reach_capacity_limit() const override {
-        return _data.size() >= UINT32_MAX;
-    }
+    bool reach_capacity_limit() const override { return _data.size() >= UINT32_MAX; }
 
 protected:
     Container _data;

--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -274,7 +274,7 @@ public:
     }
 
     bool exceed_capacity_limit() const override {
-        return _data_column->size() >= UINT32_MAX || _null_column->size() >= UINT32_MAX;
+        return _data_column->exceed_capacity_limit() || _null_column->exceed_capacity_limit();
     }
 
 private:

--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -273,8 +273,8 @@ public:
         return ss.str();
     }
 
-    bool exceed_capacity_limit() const override {
-        return _data_column->exceed_capacity_limit() || _null_column->exceed_capacity_limit();
+    bool reach_capacity_limit() const override {
+        return _data_column->reach_capacity_limit() || _null_column->reach_capacity_limit();
     }
 
 private:

--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -273,6 +273,10 @@ public:
         return ss.str();
     }
 
+    bool exceed_capacity_limit() const override {
+        return _data_column->size() >= UINT32_MAX || _null_column->size() >= UINT32_MAX;
+    }
+
 private:
     ColumnPtr _data_column;
     NullColumnPtr _null_column;

--- a/be/src/column/object_column.h
+++ b/be/src/column/object_column.h
@@ -191,6 +191,11 @@ public:
         return ss.str();
     }
 
+    bool exceed_capacity_limit() const override {
+        return _pool.size() >= UINT32_MAX || _cache->size() >= UINT32_MAX || _slices.size() >= UINT32_MAX ||
+               _buffer.size() >= UINT32_MAX;
+    }
+
 private:
     void _build_cache() const {
         if (_cache_ok) {

--- a/be/src/column/object_column.h
+++ b/be/src/column/object_column.h
@@ -192,7 +192,7 @@ public:
     }
 
     bool exceed_capacity_limit() const override {
-        return _pool.size() >= UINT32_MAX || _cache->size() >= UINT32_MAX || _slices.size() >= UINT32_MAX ||
+        return _pool.size() >= UINT32_MAX || _cache.size() >= UINT32_MAX || _slices.size() >= UINT32_MAX ||
                _buffer.size() >= UINT32_MAX;
     }
 

--- a/be/src/column/object_column.h
+++ b/be/src/column/object_column.h
@@ -192,8 +192,8 @@ public:
     }
 
     bool reach_capacity_limit() const override {
-        return _pool.size() >= UINT32_MAX || _cache.size() >= UINT32_MAX || _slices.size() >= UINT32_MAX ||
-               _buffer.size() >= UINT32_MAX;
+        return _pool.size() >= Column::MAX_CAPACITY_LIMIT || _cache.size() >= Column::MAX_CAPACITY_LIMIT ||
+               _slices.size() >= Column::MAX_CAPACITY_LIMIT || _buffer.size() >= Column::MAX_CAPACITY_LIMIT;
     }
 
 private:

--- a/be/src/column/object_column.h
+++ b/be/src/column/object_column.h
@@ -191,7 +191,7 @@ public:
         return ss.str();
     }
 
-    bool exceed_capacity_limit() const override {
+    bool reach_capacity_limit() const override {
         return _pool.size() >= UINT32_MAX || _cache.size() >= UINT32_MAX || _slices.size() >= UINT32_MAX ||
                _buffer.size() >= UINT32_MAX;
     }

--- a/be/src/exec/vectorized/hash_join_node.cpp
+++ b/be/src/exec/vectorized/hash_join_node.cpp
@@ -350,7 +350,7 @@ bool HashJoinNode::_has_null(const ColumnPtr& column) {
 Status HashJoinNode::_build(RuntimeState* state) {
     {
         SCOPED_TIMER(_build_conjunct_evaluate_timer);
-        // Currently, in order to achieve simplicity, HashJoinNode uses BigChunk,
+        // Currently, in order to implement simplicity, HashJoinNode uses BigChunk,
         // Splice the Chunks from Scan on the right table into a big Chunk
         // In some scenarios, such as when the left and right tables are selected incorrectly
         // or when the large table is joined, the (BinaryColumn) in the Chunk exceeds the range of uint32_t,

--- a/be/src/exec/vectorized/hash_join_node.cpp
+++ b/be/src/exec/vectorized/hash_join_node.cpp
@@ -350,6 +350,13 @@ bool HashJoinNode::_has_null(const ColumnPtr& column) {
 Status HashJoinNode::_build(RuntimeState* state) {
     {
         SCOPED_TIMER(_build_conjunct_evaluate_timer);
+        // Currently, in order to achieve simplicity, HashJoinNode uses BigChunk,
+        // Splice the Chunks from Scan on the right table into a big Chunk
+        // In some scenarios, such as when the left and right tables are selected incorrectly
+        // or when the large table is joined, the (BinaryColumn) in the Chunk exceeds the range of uint32_t,
+        // which will cause the output of wrong data.
+        // Currently, a defense needs to be added.
+        // After a better solution is available, the BigChunk mechanism can be removed.
         if (_ht.get_build_chunk()->exceed_capacity_limit()) {
             return Status::InternalError("Total size of single column exceed the limit of hash join");
         }

--- a/be/src/exec/vectorized/hash_join_node.cpp
+++ b/be/src/exec/vectorized/hash_join_node.cpp
@@ -350,6 +350,10 @@ bool HashJoinNode::_has_null(const ColumnPtr& column) {
 Status HashJoinNode::_build(RuntimeState* state) {
     {
         SCOPED_TIMER(_build_conjunct_evaluate_timer);
+        if (_ht.get_build_chunk()->exceed_capacity_limit()) {
+            return Status::InternalError("Total size of single column exceed the limit of hash join");
+        }
+
         for (auto& _build_expr_ctx : _build_expr_ctxs) {
             const TypeDescriptor& data_type = _build_expr_ctx->root()->type();
             ColumnPtr column_ptr = _build_expr_ctx->evaluate(_ht.get_build_chunk().get());

--- a/be/src/exec/vectorized/hash_join_node.cpp
+++ b/be/src/exec/vectorized/hash_join_node.cpp
@@ -357,7 +357,7 @@ Status HashJoinNode::_build(RuntimeState* state) {
         // which will cause the output of wrong data.
         // Currently, a defense needs to be added.
         // After a better solution is available, the BigChunk mechanism can be removed.
-        if (_ht.get_build_chunk()->exceed_capacity_limit()) {
+        if (_ht.get_build_chunk()->reach_capacity_limit()) {
             return Status::InternalError("Total size of single column exceed the limit of hash join");
         }
 


### PR DESCRIPTION
#77 

Currently, in order to achieve simplicity, HashJoinNode uses BigChunk,
Splice the Chunks from Scan on the right table into a big Chunk
In some scenarios, such as when the left and right tables are selected incorrectly or when the large table is joined, the (BinaryColumn) in the Chunk exceeds the range of uint32_t, which will cause the output of wrong data.

Currently, a defense needs to be added. After a better solution is available, the BigChunk mechanism can be removed.