### PR TITLE
[SR-3676] Export supports specified columns

### DIFF
--- a/be/src/runtime/export_sink.cpp
+++ b/be/src/runtime/export_sink.cpp
@@ -308,7 +308,7 @@ Status ExportSink::send_chunk(RuntimeState* state, vectorized::Chunk* chunk) {
         if (!root->is_slotref()) {
             return Status::InternalError("Not slot ref column");
         }
-        auto column_ref = ((vectorized::ColumnRef*) root);
+        auto column_ref = ((vectorized::ColumnRef*)root);
         columns_raw_ptr.emplace_back(chunk->get_column_by_slot_id(column_ref->slot_id()).get());
     }
 

--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -1304,12 +1304,12 @@ help_stmt ::=
 
 // Export statement
 export_stmt ::=
-    KW_EXPORT KW_TABLE base_table_ref:tblRef
+    KW_EXPORT KW_TABLE base_table_ref:tblRef opt_col_list:cols
     KW_TO STRING_LITERAL:path
     opt_properties:properties
     opt_broker:broker
     {:
-        RESULT = new ExportStmt(tblRef, path, properties, broker);
+        RESULT = new ExportStmt(tblRef, cols, path, properties, broker);
     :}
     ;
 

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/ExportStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/ExportStmt.java
@@ -241,26 +241,19 @@ public class ExportStmt extends StatementBase {
                     throw new AnalysisException("Columns is empty.");
                 }
 
-                Map<String, Integer> tableColumnToIndex = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
+                Set<String> tableColumns = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
                 int index = 0;
                 for (Column column : table.getBaseSchema()) {
-                    tableColumnToIndex.put(column.getName(), index++);
+                    tableColumns.add(column.getName());
                 }
                 Set<String> uniqColumnNames = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
-                int prevIndex = -1;
-                int currentIndex = -1;
                 for (String columnName : columnNames) {
                     if (!uniqColumnNames.add(columnName)) {
                         throw new AnalysisException("Duplicated column [" + columnName + "]");
                     }
-                    if (!tableColumnToIndex.containsKey(columnName)) {
+                    if (!tableColumns.contains(columnName)) {
                         throw new AnalysisException("Column [" + columnName + "] does not exist in table.");
                     }
-                    currentIndex = tableColumnToIndex.get(columnName);
-                    if (prevIndex > currentIndex) {
-                        throw new AnalysisException("Columns order should be same with the schema.");
-                    }
-                    prevIndex = currentIndex;
                 }
             }
         } finally {

--- a/fe/fe-core/src/main/java/com/starrocks/load/ExportMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/ExportMgr.java
@@ -239,6 +239,8 @@ public class ExportMgr {
                 infoMap.put("db", job.getTableName().getDb());
                 infoMap.put("tbl", job.getTableName().getTbl());
                 infoMap.put("partitions", partitions);
+                List<String> columns = job.getColumnNames() == null ? Lists.newArrayList("*") : job.getColumnNames();
+                infoMap.put("columns", job.isReplayed() ? "N/A" : columns);
                 infoMap.put("broker", job.getBrokerDesc().getName());
                 infoMap.put("column separator", job.getColumnSeparator());
                 infoMap.put("row delimiter", job.getRowDelimiter());

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ExportStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ExportStmtTest.java
@@ -1,0 +1,136 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+package com.starrocks.analysis;
+
+import com.starrocks.catalog.BrokerMgr;
+import com.starrocks.catalog.Catalog;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.FsBroker;
+import com.starrocks.catalog.ScalarType;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.common.UserException;
+import com.starrocks.mysql.privilege.Auth;
+import com.starrocks.mysql.privilege.PrivPredicate;
+import com.starrocks.qe.ConnectContext;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+import mockit.Expectations;
+import mockit.Mock;
+import mockit.Mocked;
+import mockit.MockUp;
+
+import com.starrocks.qe.SessionVariable;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+public class ExportStmtTest {
+    private String path;
+    private BrokerDesc brokerDesc;
+    @Mocked
+    private TableRef tableRef;
+    @Mocked
+    private Catalog catalog;
+    @Mocked
+    private Auth auth;
+    @Mocked
+    private Analyzer analyzer;
+    @Mocked
+    private ConnectContext connectContext;
+    @Mocked
+    private BrokerMgr brokerMgr;
+    @Mocked
+    private Database db;
+    @Mocked
+    private Table table;
+
+    @Before
+    public void setUp() throws AnalysisException {
+        path = "hdfs://127.0.0.1:9002/export/";
+        brokerDesc = new BrokerDesc("broker", null);
+        FsBroker fsBroker = new FsBroker("127.0.0.1", 99999);
+
+        String dbName = "db1";
+        String tableName = "tbl1";
+        List<Column> columns = Lists.newArrayList();
+        columns.add(new Column("k1", ScalarType.createCharType(10), true, null, "", ""));
+        columns.add(new Column("k2", ScalarType.INT, true, null, "", ""));
+
+        new MockUp<StatementBase>() {
+            @Mock
+            public void analyze(Analyzer analyzer) {
+                return;
+            }
+        };
+
+        new Expectations() {
+            {
+                tableRef.getName();
+                result = new TableName(dbName, tableName);
+                tableRef.getPartitionNames();
+                result = null;
+                Catalog.getCurrentCatalog();
+                result = catalog;
+                catalog.getAuth();
+                result = auth;
+                auth.checkTblPriv((ConnectContext) any, anyString, anyString, (PrivPredicate) any);
+                result = true;
+                analyzer.getCatalog();
+                result = catalog;
+                catalog.getDb(dbName);
+                result = db;
+                db.getTable(tableName);
+                result = table;
+                table.getBaseSchema();
+                result = columns;
+
+                catalog.getBrokerMgr();
+                minTimes = 0;
+                result = brokerMgr;
+                brokerMgr.containsBroker(brokerDesc.getName());
+                minTimes = 0;
+                result = true;
+                brokerMgr.getAnyBroker(brokerDesc.getName());
+                minTimes = 0;
+                result = fsBroker;
+                ConnectContext.get();
+                minTimes = 0;
+                result = connectContext;
+                connectContext.getSessionVariable();
+                minTimes = 0;
+                result = new SessionVariable();
+            }
+        };
+    }
+
+    @Test
+    public void testExportColumns() throws UserException {
+        List<String> columnNames = Lists.newArrayList("K1", "k2");
+        ExportStmt stmt = new ExportStmt(tableRef, columnNames, path, Maps.newHashMap(), brokerDesc);
+        stmt.analyze(analyzer);
+        Assert.assertEquals(2, stmt.getColumnNames().size());
+        Assert.assertEquals(columnNames, stmt.getColumnNames());
+    }
+
+    @Test(expected = AnalysisException.class)
+    public void testExportDuplicatedColumn() throws UserException {
+        List<String> columnNames = Lists.newArrayList("k1", "k1");
+        ExportStmt stmt = new ExportStmt(tableRef, columnNames, path, Maps.newHashMap(), brokerDesc);
+        stmt.analyze(analyzer);
+        Assert.fail("No exception throws.");
+    }
+
+    @Test(expected = AnalysisException.class)
+    public void testExportNotExistColumn() throws UserException {
+        List<String> columnNames = Lists.newArrayList("k1", "k_not_exist");
+        ExportStmt stmt = new ExportStmt(tableRef, columnNames, path, Maps.newHashMap(), brokerDesc);
+        stmt.analyze(analyzer);
+        Assert.fail("No exception throws.");
+    }
+}


### PR DESCRIPTION
Not support duplicated column.

```
EXPORT TABLE t1 
(v, k1) 
TO "hdfs://host:port/export/" 
PROPERTIES ( "column_separator" = "|", "line_delimiter" = "\n" ) 
WITH BROKER "broker0"
```