### PR TITLE
Support replication join's query plan and query schedule

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/ExchangeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ExchangeNode.java
@@ -225,4 +225,9 @@ public class ExchangeNode extends PlanNode {
         return accept;
     }
 
+    @Override
+    public boolean canDoReplicatedJoin() {
+        return false;
+    }
+
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HashJoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HashJoinNode.java
@@ -75,7 +75,7 @@ public class HashJoinNode extends PlanNode {
     // the flag for runtime bucket shuffle join
     private boolean isShuffleHashBucket = false;
 
-    private List<RuntimeFilterDescription> buildRuntimeFilters = Lists.newArrayList();
+    private final List<RuntimeFilterDescription> buildRuntimeFilters = Lists.newArrayList();
 
     public List<RuntimeFilterDescription> getBuildRuntimeFilters() {
         return buildRuntimeFilters;
@@ -251,7 +251,6 @@ public class HashJoinNode extends PlanNode {
         createDefaultSmap(analyzer);
 
         computeStats(analyzer);
-        //assignedConjuncts = analyzr.getAssignedConjuncts();
 
         ExprSubstitutionMap combinedChildSmap = getCombinedChildWithoutTupleIsNullSmap();
         List<Expr> newEqJoinConjuncts =
@@ -308,15 +307,6 @@ public class HashJoinNode extends PlanNode {
                 continue;
             }
             long numDistinct = stats.getNumDistinctValues();
-            // TODO rownum
-            //Table rhsTbl = slotDesc.getParent().getTableFamilyGroup().getBaseTable();
-            // if (rhsTbl != null && rhsTbl.getNumRows() != -1) {
-            // we can't have more distinct values than rows in the table, even though
-            // the metastore stats may think so
-            // LOG.info(
-            //   "#distinct=" + numDistinct + " #rows=" + Long.toString(rhsTbl.getNumRows()));
-            // numDistinct = Math.min(numDistinct, rhsTbl.getNumRows());
-            // }
             maxNumDistinct = Math.max(maxNumDistinct, numDistinct);
             LOG.debug("min slotref: {}, #distinct: {}", rhsSlotRef.toSql(), numDistinct);
         }
@@ -533,7 +523,8 @@ public class HashJoinNode extends PlanNode {
         // The hash algorithms of the two bucket shuffle ways are different
         LOCAL_HASH_BUCKET("BUCKET_SHUFFLE"),
         SHUFFLE_HASH_BUCKET("BUCKET_SHUFFLE(S)"),
-        COLOCATE("COLOCATE");
+        COLOCATE("COLOCATE"),
+        REPLICATED("REPLICATED");
 
         private final String description;
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -29,7 +29,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
 import com.starrocks.analysis.Analyzer;
-import com.starrocks.analysis.BaseTableRef;
 import com.starrocks.analysis.BinaryPredicate;
 import com.starrocks.analysis.CastExpr;
 import com.starrocks.analysis.Expr;
@@ -62,6 +61,7 @@ import com.starrocks.common.UserException;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.service.FrontendOptions;
+import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.system.Backend;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.thrift.TInternalScanRange;
@@ -92,7 +92,7 @@ import java.util.stream.Collectors;
 public class OlapScanNode extends ScanNode {
     private static final Logger LOG = LogManager.getLogger(OlapScanNode.class);
 
-    private List<TScanRangeLocations> result = new ArrayList<>();
+    private final List<TScanRangeLocations> result = new ArrayList<>();
     /*
      * When the field value is ON, the storage engine can return the data directly without pre-aggregation.
      * When the field value is OFF, the storage engine needs to aggregate the data before returning to scan node.
@@ -127,7 +127,7 @@ public class OlapScanNode extends ScanNode {
     private ArrayList<Long> scanTabletIds = Lists.newArrayList();
     private boolean isFinalized = false;
 
-    private HashSet<Long> scanBackendIds = new HashSet<>();
+    private final HashSet<Long> scanBackendIds = new HashSet<>();
 
     private Map<Long, Integer> tabletId2BucketSeq = Maps.newHashMap();
     // a bucket seq may map to many tablets, and each tablet has a TScanRangeLocations.
@@ -201,14 +201,13 @@ public class OlapScanNode extends ScanNode {
         if (selectedIndexId == this.selectedIndexId && isPreAggregation == this.isPreAggregation) {
             return;
         }
-        StringBuilder stringBuilder = new StringBuilder("The new selected index id ")
-                .append(selectedIndexId)
-                .append(", pre aggregation tag ").append(isPreAggregation)
-                .append(", reason ").append(reasonOfDisable == null ? "null" : reasonOfDisable)
-                .append(". The old selected index id ").append(this.selectedIndexId)
-                .append(" pre aggregation tag ").append(this.isPreAggregation)
-                .append(" reason ").append(this.reasonOfPreAggregation == null ? "null" : this.reasonOfPreAggregation);
-        String scanRangeInfo = stringBuilder.toString();
+        String scanRangeInfo = "The new selected index id " +
+                selectedIndexId +
+                ", pre aggregation tag " + isPreAggregation +
+                ", reason " + (reasonOfDisable == null ? "null" : reasonOfDisable) +
+                ". The old selected index id " + this.selectedIndexId +
+                " pre aggregation tag " + this.isPreAggregation +
+                " reason " + (this.reasonOfPreAggregation == null ? "null" : this.reasonOfPreAggregation);
         String situation;
         boolean update;
         CHECK:
@@ -231,7 +230,6 @@ public class OlapScanNode extends ScanNode {
             }
             situation = "The key type of table is aggregated.";
             update = false;
-            break CHECK;
         }
 
         if (update) {
@@ -458,7 +456,7 @@ public class OlapScanNode extends ScanNode {
     private void computePartitionInfo() throws AnalysisException {
         long start = System.currentTimeMillis();
         // Step1: compute partition ids
-        PartitionNames partitionNames = ((BaseTableRef) desc.getRef()).getPartitionNames();
+        PartitionNames partitionNames = desc.getRef().getPartitionNames();
         PartitionInfo partitionInfo = olapTable.getPartitionInfo();
         if (partitionInfo.getType() == PartitionType.RANGE) {
             selectedPartitionIds = partitionPrune((RangePartitionInfo) partitionInfo, partitionNames);
@@ -749,9 +747,7 @@ public class OlapScanNode extends ScanNode {
         }
         if (expr instanceof BinaryPredicate) {
             final BinaryPredicate predicate = (BinaryPredicate) expr;
-            if (predicate.getOp().isEquivalence()) {
-                return true;
-            }
+            return predicate.getOp().isEquivalence();
         }
         return false;
     }
@@ -859,5 +855,10 @@ public class OlapScanNode extends ScanNode {
 
     public void setTotalTabletsNum(long totalTabletsNum) {
         this.totalTabletsNum = totalTabletsNum;
+    }
+
+    @Override
+    public boolean canDoReplicatedJoin() {
+        return Utils.canDoReplicatedJoin(olapTable, selectedIndexId, selectedPartitionIds, scanTabletIds);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanNode.java
@@ -124,7 +124,9 @@ abstract public class PlanNode extends TreeNode<PlanNode> {
     // we should generate nullable columns for group by columns
     protected boolean hasNullableGenerateChild = false;
 
-    protected boolean isColocate = false; //the flag for colocate join
+    protected boolean isColocate = false; // the flag for colocate join
+
+    protected boolean isReplicated = false; // the flag for replication join
 
     // Runtime filters be consumed by this node.
     protected List<RuntimeFilterDescription> probeRuntimeFilters = Lists.newArrayList();
@@ -276,6 +278,14 @@ abstract public class PlanNode extends TreeNode<PlanNode> {
             return;
         }
         this.conjuncts.addAll(conjuncts);
+    }
+
+    public boolean isReplicated() {
+        return isReplicated;
+    }
+
+    public void setReplicated(boolean replicated) {
+        isReplicated = replicated;
     }
 
     public void transferConjuncts(PlanNode recipient) {
@@ -822,5 +832,15 @@ abstract public class PlanNode extends TreeNode<PlanNode> {
             return true;
         }
         return false;
+    }
+
+    public boolean canDoReplicatedJoin() {
+        if (children.size() == 1) {
+            return getChild(0).canDoReplicatedJoin();
+        } else if (children.size() == 2){
+            return getChild(1).canDoReplicatedJoin();
+        } else {
+            return false;
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/RuntimeFilterDescription.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/RuntimeFilterDescription.java
@@ -74,10 +74,7 @@ public class RuntimeFilterDescription {
             return false;
         }
         float sel = (1.0f - buildCardinality * 1.0f / card);
-        if (sel < ProbeMinSelectivity) {
-            return false;
-        }
-        return true;
+        return !(sel < ProbeMinSelectivity);
     }
 
     public void enterExchangeNode() {
@@ -123,7 +120,8 @@ public class RuntimeFilterDescription {
     public boolean isLocalApplicable() {
         return joinMode.equals(HashJoinNode.DistributionMode.BROADCAST) ||
                 joinMode.equals(HashJoinNode.DistributionMode.COLOCATE) ||
-                joinMode.equals(HashJoinNode.DistributionMode.LOCAL_HASH_BUCKET);
+                joinMode.equals(HashJoinNode.DistributionMode.LOCAL_HASH_BUCKET) ||
+                joinMode.equals(HashJoinNode.DistributionMode.REPLICATED);
     }
 
     public boolean isBroadcastJoin() {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/SetOperationNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/SetOperationNode.java
@@ -512,4 +512,9 @@ public abstract class SetOperationNode extends PlanNode {
             node.setUseVectorized(flag);
         }
     }
+
+    @Override
+    public boolean canDoReplicatedJoin() {
+        return false;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -162,6 +162,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String CBO_ENABLE_DP_JOIN_REORDER = "cbo_enable_dp_join_reorder";
     public static final String CBO_MAX_REORDER_NODE_USE_DP = "cbo_max_reorder_node_use_dp";
     public static final String CBO_ENABLE_GREEDY_JOIN_REORDER = "cbo_enable_greedy_join_reorder";
+    public static final String CBO_ENABLE_REPLICATED_JOIN = "cbo_enable_replicated_join";
     // --------  New planner session variables end --------
 
     // Type of compression of transmitted data
@@ -302,6 +303,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = DISABLE_COLOCATE_JOIN)
     private boolean disableColocateJoin = false;
+
+    @VariableMgr.VarAttr(name = CBO_ENABLE_REPLICATED_JOIN)
+    private boolean enableReplicationJoin = true;
 
     @VariableMgr.VarAttr(name = PREFER_JOIN_METHOD)
     private String preferJoinMethod = "broadcast";
@@ -720,6 +724,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean isEnablePipelineEngine() {
         return enablePipelineEngine;
+    }
+
+    public boolean isEnableReplicationJoin() {
+        return enableReplicationJoin;
+    }
+
+    public void setEnableReplicationJoin(boolean enableReplicationJoin) {
+        this.enableReplicationJoin = enableReplicationJoin;
     }
 
     // Serialize to thrift object

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ChildPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ChildPropertyDeriver.java
@@ -122,7 +122,7 @@ public class ChildPropertyDeriver extends OperatorVisitor<Void, ExpressionContex
                         Lists.newArrayList(new PhysicalPropertySet(), rightBroadcastProperty)));
             }
             // If child has limit, only do broadcast join
-            return visitJoinRequirements(node, context);
+            return visitJoinRequirements(node, context, false);
         } else {
             outputInputProps.add(new Pair<>(PhysicalPropertySet.EMPTY,
                     Lists.newArrayList(new PhysicalPropertySet(), rightBroadcastProperty)));
@@ -137,7 +137,8 @@ public class ChildPropertyDeriver extends OperatorVisitor<Void, ExpressionContex
         if (node.getJoinType().isCrossJoin() || JoinOperator.NULL_AWARE_LEFT_ANTI_JOIN.equals(node.getJoinType())
                 || (node.getJoinType().isInnerJoin() && equalOnPredicate.isEmpty())
                 || "BROADCAST".equalsIgnoreCase(hint)) {
-            return visitJoinRequirements(node, context);
+            tryReplicatedCrossJoin(context);
+            return visitJoinRequirements(node, context, false);
         }
 
         if (node.getJoinType().isRightJoin() || node.getJoinType().isFullOuterJoin()
@@ -161,24 +162,26 @@ public class ChildPropertyDeriver extends OperatorVisitor<Void, ExpressionContex
 
         // Respect use join hint
         if ("SHUFFLE".equalsIgnoreCase(hint)) {
-            return visitJoinRequirements(node, context);
+            return visitJoinRequirements(node, context, false);
         }
 
+        tryReplicatedHashJoin(context, node.getJoinType(), leftDistribution);
         // Colocate join and bucket shuffle join only support column to column binary predicate
         if (equalOnPredicate.stream().anyMatch(p -> !isColumnToColumnBinaryPredicate(p))) {
-            return visitJoinRequirements(node, context);
+            return visitJoinRequirements(node, context, false);
         }
 
+        boolean canDoColocatedJoin = false;
         // 3 For colocate join
         if (!"BUCKET".equalsIgnoreCase(hint)) {
-            tryColocate(leftDistribution, rightDistribution);
+            canDoColocatedJoin = tryColocate(leftDistribution, rightDistribution);
         }
 
         // 4 For bucket shuffle join
         tryBucketShuffle(node, leftDistribution, rightDistribution);
 
         // 5 resolve requirements
-        return visitJoinRequirements(node, context);
+        return visitJoinRequirements(node, context, canDoColocatedJoin);
     }
 
     private void doHashShuffle(List<BinaryPredicateOperator> equalOnPredicate, HashDistributionSpec leftDistribution,
@@ -269,22 +272,22 @@ public class ChildPropertyDeriver extends OperatorVisitor<Void, ExpressionContex
      *        s1    s2       s3     s4
      *
      * */
-    private void tryColocate(HashDistributionSpec leftShuffleDistribution,
+    private boolean tryColocate(HashDistributionSpec leftShuffleDistribution,
                              HashDistributionSpec rightShuffleDistribution) {
         if (Config.disable_colocate_join || ConnectContext.get().getSessionVariable().isDisableColocateJoin()) {
-            return;
+            return false;
         }
 
         Optional<LogicalOlapScanOperator> leftTable = findLogicalOlapScanOperator(leftShuffleDistribution);
         if (!leftTable.isPresent()) {
-            return;
+            return false;
         }
 
         LogicalOlapScanOperator left = leftTable.get();
 
         Optional<LogicalOlapScanOperator> rightTable = findLogicalOlapScanOperator(rightShuffleDistribution);
         if (!rightTable.isPresent()) {
-            return;
+            return false;
         }
 
         LogicalOlapScanOperator right = rightTable.get();
@@ -295,25 +298,25 @@ public class ChildPropertyDeriver extends OperatorVisitor<Void, ExpressionContex
                 !colocateIndex.isSameGroup(left.getTable().getId(), right.getTable().getId())) {
             if (!left.getSelectedPartitionId().equals(right.getSelectedPartitionId())
                     || left.getSelectedPartitionId().size() > 1) {
-                return;
+                return false;
             }
 
             PhysicalPropertySet rightLocalProperty = createPropertySetByDistribution(
                     createLocalByByHashColumns(rightShuffleDistribution.getShuffleColumns()));
             PhysicalPropertySet leftLocalProperty = createPropertySetByDistribution(
                     createLocalByByHashColumns(leftShuffleDistribution.getShuffleColumns()));
-
             outputInputProps.add(new Pair<>(PhysicalPropertySet.EMPTY,
                     Lists.newArrayList(leftLocalProperty, rightLocalProperty)));
+            return true;
         } else {
             // colocate group
             if (!colocateIndex.isSameGroup(left.getTable().getId(), right.getTable().getId())) {
-                return;
+                return false;
             }
 
             ColocateTableIndex.GroupId groupId = colocateIndex.getGroup(left.getTable().getId());
             if (colocateIndex.isGroupUnstable(groupId)) {
-                return;
+                return false;
             }
 
             HashDistributionSpec leftScanDistribution = left.getDistributionSpec();
@@ -323,11 +326,11 @@ public class ChildPropertyDeriver extends OperatorVisitor<Void, ExpressionContex
                     rightScanDistribution.getShuffleColumns().size());
 
             if (!leftShuffleDistribution.getShuffleColumns().containsAll(leftScanDistribution.getShuffleColumns())) {
-                return;
+                return false;
             }
 
             if (!rightShuffleDistribution.getShuffleColumns().containsAll(rightScanDistribution.getShuffleColumns())) {
-                return;
+                return false;
             }
 
             // check orders of predicate columns is right
@@ -340,7 +343,7 @@ public class ChildPropertyDeriver extends OperatorVisitor<Void, ExpressionContex
                 int rightIndex = rightShuffleDistribution.getShuffleColumns().indexOf(rightScanColumnId);
 
                 if (leftIndex != rightIndex) {
-                    return;
+                    return false;
                 }
             }
 
@@ -351,6 +354,77 @@ public class ChildPropertyDeriver extends OperatorVisitor<Void, ExpressionContex
 
             outputInputProps.add(new Pair<>(PhysicalPropertySet.EMPTY,
                     Lists.newArrayList(leftLocalProperty, rightLocalProperty)));
+            return true;
+        }
+    }
+
+    private void tryReplicatedCrossJoin(ExpressionContext context) {
+        if (!ConnectContext.get().getSessionVariable().isEnableReplicationJoin()) {
+            return;
+        }
+
+        // For simplicity, only support replicated join when left child has one olap scan
+        GroupExpression leftChild = context.getChildGroupExpression(0);
+        List<LogicalOlapScanOperator> leftScanLists = Lists.newArrayList();
+        Utils.extractOlapScanOperator(leftChild, leftScanLists);
+        if (leftScanLists.size() != 1) {
+            return;
+        }
+
+        GroupExpression rightChild = context.getChildGroupExpression(1);
+        List<LogicalOlapScanOperator> rightScanLists = Lists.newArrayList();
+        Utils.extractOlapScanOperator(rightChild, rightScanLists);
+        if (rightScanLists.size() != 1) {
+            return;
+        }
+
+        LogicalOlapScanOperator rightScan = rightScanLists.get(0);
+        if (rightScan.canDoReplicatedJoin()) {
+            generatePropertiesForReplicated(leftScanLists.get(0), rightScan);
+        }
+    }
+
+    private void generatePropertiesForReplicated(LogicalOlapScanOperator leftScan,
+                                                 LogicalOlapScanOperator rightScan) {
+        HashDistributionSpec leftScanDistribution = leftScan.getDistributionSpec();
+        HashDistributionSpec rightScanDistribution = rightScan.getDistributionSpec();
+        PhysicalPropertySet leftLocalProperty = createPropertySetByDistribution(
+                createLocalByByHashColumns(leftScanDistribution.getShuffleColumns()));
+        PhysicalPropertySet rightLocalProperty = createPropertySetByDistribution(
+                createLocalByByHashColumns(rightScanDistribution.getShuffleColumns()));
+        // For query schedule, we need left is hash local
+        outputInputProps.add(new Pair<>(PhysicalPropertySet.EMPTY,
+                Lists.newArrayList(leftLocalProperty, rightLocalProperty)));
+    }
+
+    private void tryReplicatedHashJoin(ExpressionContext context,
+                                       JoinOperator joinType,
+                                       HashDistributionSpec leftShuffleDistribution) {
+        if (!ConnectContext.get().getSessionVariable().isEnableReplicationJoin()) {
+            return;
+        }
+
+        // Right join or full outer join couldn't do replicated join
+        if (joinType.isRightJoin() || joinType.isFullOuterJoin()) {
+            return;
+        }
+
+        Optional<LogicalOlapScanOperator> leftTable = findLogicalOlapScanOperator(leftShuffleDistribution);
+        if (!leftTable.isPresent()) {
+            return;
+        }
+
+        GroupExpression rightChild = context.getChildGroupExpression(1);
+        List<LogicalOlapScanOperator> scanLists = Lists.newArrayList();
+        Utils.extractOlapScanOperator(rightChild, scanLists);
+
+        if (scanLists.size() != 1) {
+            return;
+        }
+
+        LogicalOlapScanOperator right = scanLists.get(0);
+        if (right.canDoReplicatedJoin()) {
+            generatePropertiesForReplicated(leftTable.get(), right);
         }
     }
 
@@ -499,7 +573,8 @@ public class ChildPropertyDeriver extends OperatorVisitor<Void, ExpressionContex
         return visitOperator(node, context);
     }
 
-    private Void visitJoinRequirements(PhysicalHashJoinOperator node, ExpressionContext context) {
+    private Void visitJoinRequirements(PhysicalHashJoinOperator node, ExpressionContext context,
+                                       boolean canDoColocated) {
         //require property is gather
         Optional<GatherDistributionSpec> requiredGatherDistribution = getRequiredGatherDesc();
         if (requiredGatherDistribution.isPresent()) {
@@ -550,6 +625,12 @@ public class ChildPropertyDeriver extends OperatorVisitor<Void, ExpressionContex
                 }
             }
         } else {
+            // Could only requiredLocalColumnsFromRight for colocated join
+            if (!canDoColocated) {
+                outputInputProps.clear();
+                return visitOperator(node, context);
+            }
+
             for (Pair<PhysicalPropertySet, List<PhysicalPropertySet>> outputInputProp : outputInputProps) {
                 PhysicalPropertySet right = outputInputProp.second.get(1);
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ExpressionContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ExpressionContext.java
@@ -2,6 +2,7 @@
 
 package com.starrocks.sql.optimizer;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.base.LogicalProperty;
@@ -110,12 +111,9 @@ public class ExpressionContext {
         }
     }
 
-    public ExpressionContext getChildContext(int index) {
-        if (expression != null) {
-            return new ExpressionContext(expression.getInputs().get(index));
-        } else {
-            return new ExpressionContext(groupExpression.getInputs().get(index).getFirstLogicalExpression());
-        }
+    public GroupExpression getChildGroupExpression(int index) {
+        Preconditions.checkNotNull(groupExpression);
+        return groupExpression.getInputs().get(index).getFirstLogicalExpression();
     }
 
     public Statistics getStatistics() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -5,6 +5,11 @@ package com.starrocks.sql.optimizer;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import com.starrocks.catalog.Catalog;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.Type;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorType;
@@ -20,6 +25,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.BitSet;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -342,5 +348,31 @@ public class Utils {
             }
         }
         return smallestColumnRef;
+    }
+
+    public static boolean canDoReplicatedJoin(OlapTable table, long selectedIndexId,
+                                              Collection<Long> selectedPartitionId,
+                                              Collection<Long> selectedTabletId) {
+        int backendSize = Catalog.getCurrentSystemInfo().backendSize();
+        int aliveBackendSize = Catalog.getCurrentSystemInfo().getBackendIds(true).size();
+        int schemaHash = table.getSchemaHashByIndexId(selectedIndexId);
+        for (Long partitionId : selectedPartitionId) {
+            Partition partition = table.getPartition(partitionId);
+            if (partition.getReplicaCount() < backendSize) {
+                return false;
+            }
+            long visibleVersion = partition.getVisibleVersion();
+            long visibleVersionHash = partition.getVisibleVersionHash();
+            MaterializedIndex materializedIndex = partition.getIndex(selectedIndexId);
+            for (Long id : selectedTabletId) {
+                Tablet tablet = materializedIndex.getTablet(id);
+                Preconditions.checkNotNull(tablet);
+                if (tablet.getQueryableReplicasSize(visibleVersion, visibleVersionHash, schemaHash)
+                        != aliveBackendSize) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalHiveScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalHiveScanOperator.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import java.util.Set;
 
 public class LogicalHiveScanOperator extends LogicalScanOperator {
-    private Table.TableType tableType;
+    private final Table.TableType tableType;
     // id -> partition key
     private final Map<Long, PartitionKey> idToPartitionKey = Maps.newHashMap();
     private Collection<Long> selectedPartitionIds = Lists.newArrayList();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalOlapScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalOlapScanOperator.java
@@ -11,6 +11,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.DistributionInfo;
 import com.starrocks.catalog.HashDistributionInfo;
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.base.DistributionSpec;
 import com.starrocks.sql.optimizer.base.HashDistributionDesc;
 import com.starrocks.sql.optimizer.base.HashDistributionSpec;
@@ -116,6 +117,10 @@ public final class LogicalOlapScanOperator extends LogicalScanOperator {
         HashDistributionDesc leftHashDesc =
                 new HashDistributionDesc(columnList, HashDistributionDesc.SourceType.LOCAL);
         return DistributionSpec.createHashDistributionSpec(leftHashDesc);
+    }
+
+    public boolean canDoReplicatedJoin() {
+        return Utils.canDoReplicatedJoin((OlapTable) table, selectedIndexId, selectedPartitionId, selectedTabletId);
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/OptimizerTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/OptimizerTaskTest.java
@@ -76,6 +76,7 @@ public class OptimizerTaskTest {
     public void init() throws Exception {
         ctx = UtFrameUtils.createDefaultCtx();
         ctx.getSessionVariable().setMaxTransformReorderJoins(8);
+        ctx.getSessionVariable().setEnableReplicationJoin(false);
         ctx.setDumpInfo(new MockDumpInfo());
         call = new CallOperator("sum", Type.BIGINT, Lists.newArrayList(ConstantOperator.createBigint(1)));
         new Expectations(call) {{
@@ -185,8 +186,6 @@ public class OptimizerTaskTest {
                 columnRefFactory);
 
         Memo memo = optimizer.getContext().getMemo();
-        //        assertEquals(7, memo.getGroups().size());
-        //        assertEquals(30, memo.getGroupExpressions().size());
 
         assertEquals(memo.getGroups().get(0).getLogicalExpressions().size(), 1);
         assertEquals(memo.getGroups().get(0).getPhysicalExpressions().size(), 1);
@@ -266,13 +265,6 @@ public class OptimizerTaskTest {
         Optimizer optimizer = new Optimizer();
         optimizer.optimize(ctx, topJoin, new PhysicalPropertySet(), new ColumnRefSet(),
                 columnRefFactory);
-
-        //        Memo memo = optimizer.getContext().getMemo();
-        //        assertEquals(15, memo.getGroups().size());
-        //        assertEquals(108, memo.getGroupExpressions().size());
-        //
-        //        MemoStatusChecker checker = new MemoStatusChecker(memo, 4, new ColumnRefSet());
-        //        checker.checkStatus();
     }
 
     @Test
@@ -324,13 +316,6 @@ public class OptimizerTaskTest {
         Optimizer optimizer = new Optimizer();
         optimizer.optimize(ctx, topJoin, new PhysicalPropertySet(), new ColumnRefSet(),
                 columnRefFactory);
-
-        //        Memo memo = optimizer.getContext().getMemo();
-        //        assertEquals(31, memo.getGroups().size());
-        //        assertEquals(370, memo.getGroupExpressions().size());
-        //
-        //        MemoStatusChecker checker = new MemoStatusChecker(memo, 5, new ColumnRefSet());
-        //        checker.checkStatus();
     }
 
     @Test
@@ -409,13 +394,6 @@ public class OptimizerTaskTest {
         Optimizer optimizer = new Optimizer();
         optimizer.optimize(ctx, topJoin, new PhysicalPropertySet(), new ColumnRefSet(),
                 columnRefFactory);
-        //        Memo memo = optimizer.getContext().getMemo();
-        //
-        //        assertEquals(255, memo.getGroups().size());
-        //        assertEquals(12116, memo.getGroupExpressions().size());
-        //
-        //        MemoStatusChecker checker = new MemoStatusChecker(memo, 8, new ColumnRefSet());
-        //        checker.checkStatus();
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestBase.java
@@ -60,11 +60,12 @@ public class PlanTestBase {
         starRocksAssert = new StarRocksAssert(connectContext);
         String DB_NAME = "test";
         starRocksAssert.withDatabase(DB_NAME).useDatabase(DB_NAME);
+        starRocksAssert.enableNewPlanner();
 
         connectContext.getCatalog().setStatisticStorage(new MockTpchStatisticStorage(1));
         connectContext.getSessionVariable().setMaxTransformReorderJoins(8);
-        starRocksAssert.enableNewPlanner();
         connectContext.getSessionVariable().setOptimizerExecuteTimeout(10000000000L);
+        connectContext.getSessionVariable().setEnableReplicationJoin(false);
 
         starRocksAssert.withTable("CREATE TABLE `t0` (\n" +
                 "  `v1` bigint NULL COMMENT \"\",\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -21,6 +21,7 @@
 
 package com.starrocks.utframe;
 
+import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
@@ -297,6 +298,10 @@ public class UtFrameUtils {
 
     public static int findValidPort() {
         String starRocksHome = System.getenv("STARROCKS_HOME");
+        File portDir = new File(starRocksHome + "/fe/ut_ports");
+        if (!portDir.exists()){
+            Preconditions.checkState(portDir.mkdirs());
+        }
         for (int i = 0; i < 10; i++) {
             try (ServerSocket socket = new ServerSocket(0)) {
                 socket.setReuseAddress(true);


### PR DESCRIPTION
For broadcast join，If each BE has a replication of the right table， we could do replicated join.

In order to support replicated join, we need to change the query plan and query schedule，
For query plan， the core logic in `tryReplicatedCrossJoin` and `tryReplicatedHashJoin`，we need to ensure  the right  scan node could do replicated join
For query schedule，the core logic in `RelicatedBackendSelector`, we need to select all tablet  for every fragment instance 