### PR TITLE
[SR-4468] Add LocalExchange to make multiple streams pipe into one sort/aggregation operator

### DIFF
--- a/be/src/exec/pipeline/exchange/exchange_source_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_source_operator.h
@@ -36,10 +36,10 @@ private:
     std::atomic<bool> _is_finishing{false};
 };
 
-class ExchangeSourceOperatorFactory final : public OperatorFactory {
+class ExchangeSourceOperatorFactory final : public SourceOperatorFactory {
 public:
     ExchangeSourceOperatorFactory(int32_t id, int32_t plan_node_id, int32_t num_sender, const RowDescriptor& row_desc)
-            : OperatorFactory(id, plan_node_id), _num_sender(num_sender), _row_desc(row_desc) {}
+            : SourceOperatorFactory(id, plan_node_id), _num_sender(num_sender), _row_desc(row_desc) {}
 
     ~ExchangeSourceOperatorFactory() override = default;
 

--- a/be/src/exec/pipeline/exchange/local_exchange_source_operator.h
+++ b/be/src/exec/pipeline/exchange/local_exchange_source_operator.h
@@ -34,10 +34,10 @@ private:
     const std::shared_ptr<LocalExchangeMemoryManager>& _memory_manager;
 };
 
-class LocalExchangeSourceOperatorFactory final : public OperatorFactory {
+class LocalExchangeSourceOperatorFactory final : public SourceOperatorFactory {
 public:
     LocalExchangeSourceOperatorFactory(int32_t id, const std::shared_ptr<LocalExchangeMemoryManager>& memory_manager)
-            : OperatorFactory(id, -1), _memory_manager(memory_manager) {}
+            : SourceOperatorFactory(id, -1), _memory_manager(memory_manager) {}
 
     ~LocalExchangeSourceOperatorFactory() override = default;
 

--- a/be/src/exec/pipeline/operator.h
+++ b/be/src/exec/pipeline/operator.h
@@ -76,7 +76,6 @@ public:
     // For some operators, when share some status, need to know the the driver_instance_count
     virtual OperatorPtr create(int32_t driver_instance_count, int32_t driver_sequence) = 0;
     virtual bool is_source() const { return false; }
-
     int32_t plan_node_id() const { return _plan_node_id; }
 
 protected:

--- a/be/src/exec/pipeline/pipeline.h
+++ b/be/src/exec/pipeline/pipeline.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "exec/pipeline/operator.h"
+#include "exec/pipeline/source_operator.h"
 
 namespace starrocks {
 class MemTracker;
@@ -14,21 +15,30 @@ using Pipelines = std::vector<PipelinePtr>;
 
 class Pipeline {
 public:
-    Pipeline() = default;
-    Pipeline(uint32_t id, uint32_t driver_instance_count, const OpFactories& op_factories)
-            : _id(id), _driver_instance_count(driver_instance_count), _op_factories(std::move(op_factories)) {}
+    Pipeline() = delete;
+    Pipeline(uint32_t id, const OpFactories& op_factories) : _id(id), _op_factories(std::move(op_factories)) {}
 
     uint32_t get_id() const { return _id; }
-
-    uint32_t get_driver_instance_count() const { return _driver_instance_count; }
 
     OpFactories& get_op_factories() { return _op_factories; }
 
     void add_op_factory(const OpFactoryPtr& op) { _op_factories.emplace_back(op); }
 
+    Operators create_operators(int32_t instance_count, int32_t i) {
+        Operators operators;
+        for (const auto& factory : _op_factories) {
+            operators.emplace_back(factory->create(instance_count, i));
+        }
+        return operators;
+    }
+
+    SourceOperatorFactory* source_operator_factory() {
+        DCHECK(!_op_factories.empty());
+        return down_cast<SourceOperatorFactory*>(_op_factories[0].get());
+    }
+
 private:
     uint32_t _id = 0;
-    uint32_t _driver_instance_count = 1;
     OpFactories _op_factories;
 };
 

--- a/be/src/exec/pipeline/pipeline_builder.cpp
+++ b/be/src/exec/pipeline/pipeline_builder.cpp
@@ -5,9 +5,35 @@
 #include "exec/exec_node.h"
 
 namespace starrocks::pipeline {
+
+void PipelineBuilderContext::maybe_interpolate_local_exchange(OpFactories& pred_operators) {
+    // predecessor pipeline has multiple drivers that will produce multiple output streams, but sort operator is
+    // not parallelized now and can not accept multiple streams as input, so add a LocalExchange to gather multiple
+    // streams and produce one output stream piping into the sort operator.
+    DCHECK(!pred_operators.empty() && pred_operators[0]->is_source());
+    auto* source_operator = down_cast<SourceOperatorFactory*>(pred_operators[0].get());
+    if (source_operator->num_driver_instances() > 1) {
+        auto mem_mgr = std::make_shared<LocalExchangeMemoryManager>(config::vector_chunk_size);
+        auto local_exchange_source = std::make_shared<LocalExchangeSourceOperatorFactory>(next_operator_id(), mem_mgr);
+        auto local_exchange = std::make_shared<PassthroughExchanger>(mem_mgr, local_exchange_source.get());
+        auto local_exchange_sink =
+                std::make_shared<LocalExchangeSinkOperatorFactory>(next_operator_id(), local_exchange);
+        // Add LocalExchangeSinkOperator to predecessor pipeline.
+        pred_operators.emplace_back(std::move(local_exchange_sink));
+        // predecessor pipeline comes to end.
+        add_pipeline(std::move(pred_operators));
+        // Multiple LocalChangeSinkOperators pipe into one LocalChangeSourceOperator.
+        local_exchange_source->set_num_driver_instances(1);
+        // pred_operators is re-used, and a new pipeline is created, LocalExchangeSourceOperator is added as the
+        // head of the pipeline.
+        pred_operators.emplace_back(local_exchange_source);
+    }
+}
+
 Pipelines PipelineBuilder::build(const FragmentContext& fragment, ExecNode* exec_node) {
     pipeline::OpFactories operators = exec_node->decompose_to_pipeline(&_context);
     _context.add_pipeline(std::move(operators));
     return _context.get_pipelines();
 }
+
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/pipeline_builder.cpp
+++ b/be/src/exec/pipeline/pipeline_builder.cpp
@@ -7,7 +7,7 @@
 namespace starrocks::pipeline {
 Pipelines PipelineBuilder::build(const FragmentContext& fragment, ExecNode* exec_node) {
     pipeline::OpFactories operators = exec_node->decompose_to_pipeline(&_context);
-    _context.add_pipeline(operators);
+    _context.add_pipeline(std::move(operators));
     return _context.get_pipelines();
 }
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/pipeline_builder.h
+++ b/be/src/exec/pipeline/pipeline_builder.h
@@ -12,29 +12,29 @@ namespace pipeline {
 
 class PipelineBuilderContext {
 public:
-    PipelineBuilderContext(const FragmentContext& fragment_context, uint32_t driver_instance_count)
+    PipelineBuilderContext(FragmentContext* fragment_context, size_t driver_instance_count)
             : _fragment_context(fragment_context), _driver_instance_count(driver_instance_count) {}
 
     void add_pipeline(const OpFactories& operators) {
-        _pipelines.emplace_back(std::make_unique<Pipeline>(next_pipe_id(), _driver_instance_count, operators));
+        _pipelines.emplace_back(std::make_unique<Pipeline>(next_pipe_id(), operators));
     }
 
     uint32_t next_pipe_id() { return _next_pipeline_id++; }
 
     uint32_t next_operator_id() { return _next_operator_id++; }
 
-    uint32_t driver_instance_count() const { return _driver_instance_count; }
-
-    void set_driver_instance_count(uint32_t driver_instance_count) { _driver_instance_count = driver_instance_count; }
+    size_t driver_instance_count() const { return _driver_instance_count; }
 
     Pipelines get_pipelines() const { return _pipelines; }
 
+    FragmentContext* fragment_context() { return _fragment_context; }
+
 private:
-    const FragmentContext& _fragment_context;
+    FragmentContext* _fragment_context;
     Pipelines _pipelines;
     uint32_t _next_pipeline_id = 0;
     uint32_t _next_operator_id = 0;
-    uint32_t _driver_instance_count = 1;
+    size_t _driver_instance_count = 1;
 };
 
 class PipelineBuilder {

--- a/be/src/exec/pipeline/pipeline_builder.h
+++ b/be/src/exec/pipeline/pipeline_builder.h
@@ -2,6 +2,9 @@
 
 #pragma once
 
+#include "exec/pipeline/exchange/local_exchange.h"
+#include "exec/pipeline/exchange/local_exchange_sink_operator.h"
+#include "exec/pipeline/exchange/local_exchange_source_operator.h"
 #include "exec/pipeline/fragment_context.h"
 #include "exec/pipeline/pipeline.h"
 
@@ -18,6 +21,8 @@ public:
     void add_pipeline(const OpFactories& operators) {
         _pipelines.emplace_back(std::make_unique<Pipeline>(next_pipe_id(), operators));
     }
+
+    void maybe_interpolate_local_exchange(OpFactories& pred_operators);
 
     uint32_t next_pipe_id() { return _next_pipeline_id++; }
 

--- a/be/src/exec/pipeline/scan_operator.h
+++ b/be/src/exec/pipeline/scan_operator.h
@@ -57,12 +57,12 @@ private:
     OptionalChunkSourceFuture _pending_chunk_source_future;
 };
 
-class ScanOperatorFactory final : public OperatorFactory {
+class ScanOperatorFactory final : public SourceOperatorFactory {
 public:
     ScanOperatorFactory(int32_t id, int32_t plan_node_id, const TOlapScanNode& olap_scan_node,
                         std::vector<ExprContext*>&& conjunct_ctxs,
                         vectorized::RuntimeFilterProbeCollector&& runtime_filters)
-            : OperatorFactory(id, plan_node_id),
+            : SourceOperatorFactory(id, plan_node_id),
               _olap_scan_node(olap_scan_node),
               _conjunct_ctxs(std::move(conjunct_ctxs)),
               _runtime_filters(std::move(runtime_filters)) {}
@@ -73,7 +73,7 @@ public:
         return std::make_shared<ScanOperator>(_id, _plan_node_id, _olap_scan_node, _conjunct_ctxs, _runtime_filters);
     }
 
-    bool is_source() const override { return true; }
+    bool with_morsels() const override { return true; }
 
 private:
     TOlapScanNode _olap_scan_node;

--- a/be/src/exec/pipeline/scan_operator.h
+++ b/be/src/exec/pipeline/scan_operator.h
@@ -73,6 +73,7 @@ public:
         return std::make_shared<ScanOperator>(_id, _plan_node_id, _olap_scan_node, _conjunct_ctxs, _runtime_filters);
     }
 
+    // ScanOperator needs to attach MorselQueue.
     bool with_morsels() const override { return true; }
 
 private:

--- a/be/src/exec/pipeline/sort/sort_source_operator.h
+++ b/be/src/exec/pipeline/sort/sort_source_operator.h
@@ -45,11 +45,11 @@ private:
     std::atomic<bool> _is_source_complete = false;
 };
 
-class SortSourceOperatorFactory final : public OperatorFactory {
+class SortSourceOperatorFactory final : public SourceOperatorFactory {
 public:
     SortSourceOperatorFactory(int32_t id, int32_t plan_node_id,
                               std::shared_ptr<vectorized::ChunksSorter>&& chunks_sorter)
-            : OperatorFactory(id, plan_node_id), _chunks_sorter(chunks_sorter) {}
+            : SourceOperatorFactory(id, plan_node_id), _chunks_sorter(chunks_sorter) {}
 
     ~SortSourceOperatorFactory() override = default;
 

--- a/be/src/exec/pipeline/source_operator.h
+++ b/be/src/exec/pipeline/source_operator.h
@@ -27,5 +27,19 @@ protected:
     MorselQueue* _morsel_queue;
     ChunkSourcePtr _chunk_source;
 };
+
+class SourceOperatorFactory : public OperatorFactory {
+public:
+    SourceOperatorFactory(int32_t id, int32_t plan_node_id) : OperatorFactory(id, plan_node_id) {}
+    bool is_source() const override { return true; }
+    virtual bool with_morsels() const { return false; }
+    virtual void set_num_driver_instances(size_t num_driver_instances) {
+        this->_num_driver_instances = num_driver_instances;
+    }
+    virtual size_t num_driver_instances() const { return _num_driver_instances; }
+
+protected:
+    size_t _num_driver_instances = 1;
+};
 } // namespace pipeline
 } // namespace starrocks

--- a/be/src/exec/pipeline/source_operator.h
+++ b/be/src/exec/pipeline/source_operator.h
@@ -32,7 +32,10 @@ class SourceOperatorFactory : public OperatorFactory {
 public:
     SourceOperatorFactory(int32_t id, int32_t plan_node_id) : OperatorFactory(id, plan_node_id) {}
     bool is_source() const override { return true; }
+    // with_morsels returning true means that the SourceOperator needs attach to MorselQueue, only
+    // ScanOperator needs to do so.
     virtual bool with_morsels() const { return false; }
+    // Set the DOP(degree of parallelism) of the SourceOperator, SourceOperator's DOP determine the Pipeline's DOP.
     virtual void set_num_driver_instances(size_t num_driver_instances) {
         this->_num_driver_instances = num_driver_instances;
     }

--- a/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
@@ -138,6 +138,7 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > AggregateBlockingNode::
     using namespace pipeline;
     OpFactories operators_with_sink = _children[0]->decompose_to_pipeline(context);
 
+    context->maybe_interpolate_local_exchange(operators_with_sink);
     // shared by sink operator and source operator
     AggregatorPtr aggregator = std::make_shared<Aggregator>(_tnode);
 

--- a/be/src/exec/vectorized/aggregate/aggregate_streaming_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_streaming_node.cpp
@@ -216,7 +216,7 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > AggregateStreamingNode:
         pipeline::PipelineBuilderContext* context) {
     using namespace pipeline;
     OpFactories operators_with_sink = _children[0]->decompose_to_pipeline(context);
-
+    context->maybe_interpolate_local_exchange(operators_with_sink);
     // shared by sink operator and source operator
     AggregatorPtr aggregator = std::make_shared<Aggregator>(_tnode);
 

--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -551,9 +551,17 @@ void OlapScanNode::_close_pending_scanners() {
 pipeline::OpFactories OlapScanNode::decompose_to_pipeline(pipeline::PipelineBuilderContext* context) {
     using namespace pipeline;
     OpFactories operators;
-    operators.emplace_back(std::make_shared<ScanOperatorFactory>(context->next_operator_id(), id(), _olap_scan_node,
-                                                                 std::move(_conjunct_ctxs),
-                                                                 std::move(_runtime_filter_collector)));
+    auto scan_operator =
+            std::make_shared<ScanOperatorFactory>(context->next_operator_id(), id(), _olap_scan_node,
+                                                  std::move(_conjunct_ctxs), std::move(_runtime_filter_collector));
+    auto& morsel_queues = context->fragment_context()->morsel_queues();
+    auto source_id = scan_operator->plan_node_id();
+    DCHECK(morsel_queues.count(source_id));
+    auto& morsel_queue = morsel_queues[source_id];
+    // ScanOperator's instance_count is not more than the number of morsels
+    const auto instance_count = std::min<size_t>(morsel_queue->num_morsels(), context->driver_instance_count());
+    scan_operator->set_num_driver_instances(instance_count);
+    operators.emplace_back(std::move(scan_operator));
     if (limit() != -1) {
         operators.emplace_back(std::make_shared<LimitOperatorFactory>(context->next_operator_id(), id(), limit()));
     }

--- a/be/src/exec/vectorized/topn_node.cpp
+++ b/be/src/exec/vectorized/topn_node.cpp
@@ -5,6 +5,9 @@
 #include <memory>
 
 #include "column/column_helper.h"
+#include "exec/pipeline/exchange/local_exchange.h"
+#include "exec/pipeline/exchange/local_exchange_sink_operator.h"
+#include "exec/pipeline/exchange/local_exchange_source_operator.h"
 #include "exec/pipeline/pipeline_builder.h"
 #include "exec/pipeline/sort/sort_sink_operator.h"
 #include "exec/pipeline/sort/sort_source_operator.h"
@@ -219,7 +222,26 @@ pipeline::OpFactories TopNNode::decompose_to_pipeline(pipeline::PipelineBuilderC
 
     // step 0: construct pipeline end with sort operator.
     // get operators before sort operator
-    OpFactories operator_sink_with_sort = _children[0]->decompose_to_pipeline(context);
+    OpFactories pred_operators = _children[0]->decompose_to_pipeline(context);
+
+    // predecessor pipeline has multiple drivers that will produce multiple output streams, but sort operator is
+    // not parallelized now and can not accept multiple streams as input, so add a LocalExchange to gather multiple
+    // streams and produce one output stream piping into the sort operator.
+    DCHECK(!pred_operators.empty() && pred_operators[0]->is_source());
+    auto* source_operator = down_cast<SourceOperatorFactory*>(pred_operators[0].get());
+    if (source_operator->num_driver_instances() > 1) {
+        auto mem_mgr = std::make_shared<LocalExchangeMemoryManager>(config::vector_chunk_size);
+        auto local_exchange_source =
+                std::make_shared<LocalExchangeSourceOperatorFactory>(context->next_operator_id(), mem_mgr);
+        auto local_exchange = std::make_shared<PassthroughExchanger>(mem_mgr, local_exchange_source.get());
+        auto local_exchange_sink =
+                std::make_shared<LocalExchangeSinkOperatorFactory>(context->next_operator_id(), local_exchange);
+        pred_operators.emplace_back(std::move(local_exchange_sink));
+        context->add_pipeline(std::move(pred_operators));
+        // Multiple LocalChangeSinkOperators pipe into one LocalChangeSourceOperator.
+        local_exchange_source->set_num_driver_instances(1);
+        pred_operators.emplace_back(local_exchange_source);
+    }
 
     static const uint SIZE_OF_CHUNK_FOR_TOPN = 3000;
     static const uint SIZE_OF_CHUNK_FOR_FULL_SORT = 5000;
@@ -234,21 +256,22 @@ pipeline::OpFactories TopNNode::decompose_to_pipeline(pipeline::PipelineBuilderC
                                                                            SIZE_OF_CHUNK_FOR_FULL_SORT);
     }
 
-    // add sort operator to this pipeline
-    auto ope = std::make_shared<SortSinkOperatorFactory>(context->next_operator_id(), id(), chunks_sorter,
-                                                         _sort_exec_exprs, _order_by_types, _materialized_tuple_desc,
-                                                         child(0)->row_desc(), _row_descriptor);
-    operator_sink_with_sort.emplace_back(std::move(ope));
-    context->add_pipeline(operator_sink_with_sort);
+    // add SortSinkOperator to this pipeline
+    auto sort_sink_operator = std::make_shared<SortSinkOperatorFactory>(
+            context->next_operator_id(), id(), chunks_sorter, _sort_exec_exprs, _order_by_types,
+            _materialized_tuple_desc, child(0)->row_desc(), _row_descriptor);
+    pred_operators.emplace_back(std::move(sort_sink_operator));
+    context->add_pipeline(pred_operators);
 
-    // step 1: costruct pipeline start with sort operator's result.
-    OpFactories operator_source_with_sort;
-    auto ope2 =
+    OpFactories operators;
+    auto sort_source_operator =
             std::make_shared<SortSourceOperatorFactory>(context->next_operator_id(), id(), std::move(chunks_sorter));
-    operator_source_with_sort.emplace_back(std::move(ope2));
+    // SourceSourceOperator's instance count must be 1
+    sort_source_operator->set_num_driver_instances(1);
+    operators.emplace_back(std::move(sort_source_operator));
 
     // return to the following pipeline
-    return operator_source_with_sort;
+    return operators;
 }
 
 } // namespace starrocks::vectorized


### PR DESCRIPTION
## Changes
At present, the sort/aggregation operator in StarRocks is not parallelized, if the pipeline before the sort/aggregation is parallelized to speed up, multiple output streams generated will pipe into sort/aggregation operator, so we add LocalExchange to merge multiple streams into one and pipe into one sort/aggregation operator.

Other modifications as follows:
1. Add SourceOperatorFactory which has _num_driver_instances to designate the DOP(degree of parallelism), and the pipeline's DOP totally depends on its source operator's DOP.
2. Add with_morsels() instead of is_source() inside SourceOperatorFactory to indicate that source operator need attach a morsel queue.

