### PR TITLE
[Bug][ES-Extern] fix type convert error while get value from es-exter…

### DIFF
--- a/be/src/exec/vectorized/es_http_components.cpp
+++ b/be/src/exec/vectorized/es_http_components.cpp
@@ -222,7 +222,8 @@ Status ScrollParser::fill_chunk(ChunkPtr* chunk, bool* line_eos) {
                 bool is_null = (pure_doc_value && col.IsArray() && col[0].IsNull()) || col.IsNull();
                 if (!is_null) {
                     // append value from ES to column
-                    _append_value_from_json_val(column.get(), slot_desc->type().type, col, pure_doc_value);
+                    RETURN_IF_ERROR(
+                            _append_value_from_json_val(column.get(), slot_desc->type().type, col, pure_doc_value));
                     continue;
                 }
                 // handle null col


### PR DESCRIPTION
…n table

Schema Type: tinyint
ES Table Type: string, ES Table Value: 65536

value:
```
0
```


expect:
```
Expected value of type: INT; but found type: Varchar/Char; Docuemnt source slice is : "char65536"
```