### PR TITLE
[SR-4409] Provide aggregate operators for pipeline engine

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -181,6 +181,10 @@ set(EXEC_FILES
     pipeline/aggregate/aggregate_blocking_source_operator.cpp
     pipeline/aggregate/aggregate_streaming_sink_operator.cpp
     pipeline/aggregate/aggregate_streaming_source_operator.cpp
+    pipeline/aggregate/aggregate_distinct_blocking_sink_operator.cpp
+    pipeline/aggregate/aggregate_distinct_blocking_source_operator.cpp
+    pipeline/aggregate/aggregate_distinct_streaming_sink_operator.cpp
+    pipeline/aggregate/aggregate_distinct_streaming_source_operator.cpp
 )
 
 if (WITH_MYSQL)

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.cpp
@@ -22,7 +22,7 @@ void AggregateBlockingSinkOperator::finish(RuntimeState* state) {
     }
     _is_finished = true;
 
-    if (!_aggregator->is_none_group_by_exprs()) {
+    if (!_aggregator->group_by_expr_ctxs().empty()) {
         COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_map_variant().size());
         // If hash map is empty, we don't need to return value
         if (_aggregator->hash_map_variant().size() == 0) {
@@ -36,7 +36,7 @@ void AggregateBlockingSinkOperator::finish(RuntimeState* state) {
             _aggregator->hash_map_variant().NAME->hash_map.begin();
         APPLY_FOR_VARIANT_ALL(HASH_MAP_METHOD)
 #undef HASH_MAP_METHOD
-    } else if (_aggregator->is_none_group_by_exprs()) {
+    } else if (_aggregator->group_by_expr_ctxs().empty()) {
         // for aggregate no group by, if _num_input_rows is 0,
         // In update phase, we directly return empty chunk.
         // In merge phase, we will handle it.
@@ -58,7 +58,7 @@ Status AggregateBlockingSinkOperator::push_chunk(RuntimeState* state, const vect
     _aggregator->evaluate_exprs(chunk.get());
 
     SCOPED_TIMER(_aggregator->agg_compute_timer());
-    if (!_aggregator->is_none_group_by_exprs()) {
+    if (!_aggregator->group_by_expr_ctxs().empty()) {
         if (false) {
         }
 #define HASH_MAP_METHOD(NAME)                                                                          \
@@ -71,7 +71,7 @@ Status AggregateBlockingSinkOperator::push_chunk(RuntimeState* state, const vect
         RETURN_IF_ERROR(_aggregator->check_hash_map_memory_usage(state));
         _aggregator->try_convert_to_two_level_map();
     }
-    if (_aggregator->is_none_group_by_exprs()) {
+    if (_aggregator->group_by_expr_ctxs().empty()) {
         _aggregator->compute_single_agg_state(chunk->num_rows());
     } else {
         _aggregator->compute_batch_agg_states(chunk->num_rows());

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.h
@@ -9,7 +9,7 @@ namespace starrocks::pipeline {
 class AggregateBlockingSinkOperator : public Operator {
 public:
     AggregateBlockingSinkOperator(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
-            : Operator(id, "aggregate_blocking_sink_operator", plan_node_id), _aggregator(aggregator) {
+            : Operator(id, "aggregate_blocking_sink", plan_node_id), _aggregator(aggregator) {
         _aggregator->set_aggr_phase(AggrPhase2);
     }
     ~AggregateBlockingSinkOperator() = default;

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.cpp
@@ -54,7 +54,6 @@ StatusOr<vectorized::ChunkPtr> AggregateBlockingSourceOperator::pull_chunk(Runti
     // ExecNode::eval_conjuncts(_conjunct_ctxs, chunk.get());
     _aggregator->update_num_rows_returned(-(old_size - chunk->num_rows()));
 
-    _aggregator->process_limit(&chunk);
     DCHECK_CHUNK(chunk);
 
     return std::move(chunk);

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.cpp
@@ -25,14 +25,12 @@ Status AggregateBlockingSourceOperator::close(RuntimeState* state) {
 
 StatusOr<vectorized::ChunkPtr> AggregateBlockingSourceOperator::pull_chunk(RuntimeState* state) {
     SCOPED_TIMER(_runtime_profile->total_time_counter());
-    // TODO(hcf) force annotation
-    // RETURN_IF_ERROR(exec_debug_action(TExecNodePhase::GETNEXT));
     RETURN_IF_CANCELLED(state);
 
     int32_t chunk_size = config::vector_chunk_size;
     vectorized::ChunkPtr chunk = std::make_shared<vectorized::Chunk>();
 
-    if (_aggregator->group_by_expr_ctxs().empty()) {
+    if (_aggregator->is_none_group_by_exprs()) {
         SCOPED_TIMER(_aggregator->get_results_timer());
         _aggregator->convert_to_chunk_no_groupby(&chunk);
     } else {

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.cpp
@@ -32,7 +32,7 @@ StatusOr<vectorized::ChunkPtr> AggregateBlockingSourceOperator::pull_chunk(Runti
     int32_t chunk_size = config::vector_chunk_size;
     vectorized::ChunkPtr chunk = std::make_shared<vectorized::Chunk>();
 
-    if (_aggregator->is_none_group_by_exprs()) {
+    if (_aggregator->group_by_expr_ctxs().empty()) {
         SCOPED_TIMER(_aggregator->get_results_timer());
         _aggregator->convert_to_chunk_no_groupby(&chunk);
     } else {

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.h
@@ -9,7 +9,7 @@ namespace starrocks::pipeline {
 class AggregateBlockingSourceOperator : public SourceOperator {
 public:
     AggregateBlockingSourceOperator(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
-            : SourceOperator(id, "aggregate_blocking_source_operator", plan_node_id), _aggregator(aggregator) {}
+            : SourceOperator(id, "aggregate_blocking_source", plan_node_id), _aggregator(aggregator) {}
     ~AggregateBlockingSourceOperator() = default;
 
     bool has_output() const override;

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.h
@@ -23,7 +23,7 @@ public:
 private:
     // It is used to perform aggregation algorithms
     // shared by AggregateBlockingSinkOperator
-    AggregatorPtr _aggregator;
+    AggregatorPtr _aggregator = nullptr;
     // Whether prev operator has no output
     bool _is_finished = false;
 };
@@ -40,6 +40,6 @@ public:
     }
 
 private:
-    AggregatorPtr _aggregator;
+    AggregatorPtr _aggregator = nullptr;
 };
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.h
@@ -28,10 +28,10 @@ private:
     bool _is_finished = false;
 };
 
-class AggregateBlockingSourceOperatorFactory final : public OperatorFactory {
+class AggregateBlockingSourceOperatorFactory final : public SourceOperatorFactory {
 public:
     AggregateBlockingSourceOperatorFactory(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
-            : OperatorFactory(id, plan_node_id), _aggregator(aggregator) {}
+            : SourceOperatorFactory(id, plan_node_id), _aggregator(aggregator) {}
 
     ~AggregateBlockingSourceOperatorFactory() override = default;
 

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.cpp
@@ -1,0 +1,80 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#include "aggregate_distinct_blocking_sink_operator.h"
+
+namespace starrocks::pipeline {
+
+Status AggregateDistinctBlockingSinkOperator::prepare(RuntimeState* state) {
+    RETURN_IF_ERROR(Operator::prepare(state));
+    // _aggregator is shared by sink operator and source operator
+    // we must only prepare it at sink operator
+    RETURN_IF_ERROR(
+            _aggregator->prepare(state, state->obj_pool(), get_memtracker(), get_memtracker(), get_runtime_profile()));
+    return _aggregator->open(state);
+}
+
+bool AggregateDistinctBlockingSinkOperator::is_finished() const {
+    return _is_finished;
+}
+
+void AggregateDistinctBlockingSinkOperator::finish(RuntimeState* state) {
+    if (_is_finished) {
+        return;
+    }
+    _is_finished = true;
+
+    COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_set_variant().size());
+
+    // If hash set is empty, we don't need to return value
+    if (_aggregator->hash_set_variant().size() == 0) {
+        _aggregator->set_ht_eos();
+    }
+
+    if (false) {
+    }
+#define HASH_SET_METHOD(NAME)                                                                                         \
+    else if (_aggregator->hash_set_variant().type == vectorized::HashSetVariant::Type::NAME) _aggregator->it_hash() = \
+            _aggregator->hash_set_variant().NAME->hash_set.begin();
+    APPLY_FOR_VARIANT_ALL(HASH_SET_METHOD)
+#undef HASH_SET_METHOD
+
+    COUNTER_SET(_aggregator->input_row_count(), _aggregator->num_input_rows());
+
+    _aggregator->sink_complete();
+}
+
+StatusOr<vectorized::ChunkPtr> AggregateDistinctBlockingSinkOperator::pull_chunk(RuntimeState* state) {
+    return Status::InternalError("Not support");
+}
+
+Status AggregateDistinctBlockingSinkOperator::push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) {
+    DCHECK_LE(chunk->num_rows(), config::vector_chunk_size);
+    _aggregator->evaluate_exprs(chunk.get());
+
+    {
+        SCOPED_TIMER(_aggregator->agg_compute_timer());
+        bool limit_with_no_agg = _aggregator->limit() != -1;
+
+        if (false) {
+        }
+#define HASH_SET_METHOD(NAME)                                                                          \
+    else if (_aggregator->hash_set_variant().type == vectorized::HashSetVariant::Type::NAME)           \
+            _aggregator->build_hash_set<decltype(_aggregator->hash_set_variant().NAME)::element_type>( \
+                    *_aggregator->hash_set_variant().NAME, chunk->num_rows());
+        APPLY_FOR_VARIANT_ALL(HASH_SET_METHOD)
+#undef HASH_SET_METHOD
+
+        _aggregator->update_num_input_rows(chunk->num_rows());
+        if (limit_with_no_agg) {
+            auto size = _aggregator->hash_set_variant().size();
+            if (size >= _aggregator->limit()) {
+                // TODO(hcf) do something
+            }
+        }
+
+        RETURN_IF_ERROR(_aggregator->check_hash_set_memory_usage(state));
+    }
+
+    return Status::OK();
+}
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.h
@@ -9,7 +9,7 @@ namespace starrocks::pipeline {
 class AggregateDistinctBlockingSinkOperator : public Operator {
 public:
     AggregateDistinctBlockingSinkOperator(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
-            : Operator(id, "aggregate_distinct_blocking_sink_operator", plan_node_id), _aggregator(aggregator) {
+            : Operator(id, "aggregate_distinct_blocking_sink", plan_node_id), _aggregator(aggregator) {
         _aggregator->set_aggr_phase(AggrPhase2);
     }
     ~AggregateDistinctBlockingSinkOperator() = default;

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.h
@@ -6,13 +6,13 @@
 #include "exec/vectorized/aggregator.h"
 
 namespace starrocks::pipeline {
-class AggregateBlockingSinkOperator : public Operator {
+class AggregateDistinctBlockingSinkOperator : public Operator {
 public:
-    AggregateBlockingSinkOperator(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
-            : Operator(id, "aggregate_blocking_sink_operator", plan_node_id), _aggregator(aggregator) {
+    AggregateDistinctBlockingSinkOperator(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
+            : Operator(id, "aggregate_distinct_blocking_sink_operator", plan_node_id), _aggregator(aggregator) {
         _aggregator->set_aggr_phase(AggrPhase2);
     }
-    ~AggregateBlockingSinkOperator() = default;
+    ~AggregateDistinctBlockingSinkOperator() = default;
 
     bool has_output() const override { return false; }
     bool need_input() const override { return true; }
@@ -32,15 +32,15 @@ private:
     bool _is_finished = false;
 };
 
-class AggregateBlockingSinkOperatorFactory final : public OperatorFactory {
+class AggregateDistinctBlockingSinkOperatorFactory final : public OperatorFactory {
 public:
-    AggregateBlockingSinkOperatorFactory(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
+    AggregateDistinctBlockingSinkOperatorFactory(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
             : OperatorFactory(id, plan_node_id), _aggregator(aggregator) {}
 
-    ~AggregateBlockingSinkOperatorFactory() override = default;
+    ~AggregateDistinctBlockingSinkOperatorFactory() override = default;
 
     OperatorPtr create(int32_t driver_instance_count, int32_t driver_sequence) override {
-        return std::make_shared<AggregateBlockingSinkOperator>(_id, _plan_node_id, _aggregator);
+        return std::make_shared<AggregateDistinctBlockingSinkOperator>(_id, _plan_node_id, _aggregator);
     }
 
 private:

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.cpp
@@ -1,0 +1,57 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#include "aggregate_distinct_blocking_source_operator.h"
+
+namespace starrocks::pipeline {
+
+bool AggregateDistinctBlockingSourceOperator::has_output() const {
+    return _aggregator->is_sink_complete() && !_aggregator->is_ht_eos();
+}
+
+bool AggregateDistinctBlockingSourceOperator::is_finished() const {
+    return _aggregator->is_sink_complete() && _aggregator->is_ht_eos();
+}
+
+void AggregateDistinctBlockingSourceOperator::finish(RuntimeState* state) {
+    _is_finished = true;
+}
+
+Status AggregateDistinctBlockingSourceOperator::close(RuntimeState* state) {
+    // _aggregator is shared by sink operator and source operator
+    // we must only close it at source operator
+    RETURN_IF_ERROR(_aggregator->close(state));
+    return SourceOperator::close(state);
+}
+
+StatusOr<vectorized::ChunkPtr> AggregateDistinctBlockingSourceOperator::pull_chunk(RuntimeState* state) {
+    SCOPED_TIMER(_runtime_profile->total_time_counter());
+    RETURN_IF_CANCELLED(state);
+
+    int32_t chunk_size = config::vector_chunk_size;
+    vectorized::ChunkPtr chunk = std::make_shared<vectorized::Chunk>();
+
+    if (false) {
+    }
+#define HASH_SET_METHOD(NAME)                                                                                     \
+    else if (_aggregator->hash_set_variant().type == vectorized::HashSetVariant::Type::NAME)                      \
+            _aggregator->convert_hash_set_to_chunk<decltype(_aggregator->hash_set_variant().NAME)::element_type>( \
+                    *_aggregator->hash_set_variant().NAME, chunk_size, &chunk);
+    APPLY_FOR_VARIANT_ALL(HASH_SET_METHOD)
+#undef HASH_SET_METHOD
+
+    // TODO(hcf) force annotation
+    // eval_join_runtime_filters(chunk->get());
+
+    // For having
+    size_t old_size = chunk->num_rows();
+
+    // TODO(hcf) force annotation
+    // ExecNode::eval_conjuncts(_conjunct_ctxs, (*chunk).get());
+    _aggregator->update_num_rows_returned(-(old_size - chunk->num_rows()));
+
+    _aggregator->process_limit(&chunk);
+
+    DCHECK_CHUNK(chunk);
+    return std::move(chunk);
+}
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.cpp
@@ -49,8 +49,6 @@ StatusOr<vectorized::ChunkPtr> AggregateDistinctBlockingSourceOperator::pull_chu
     // ExecNode::eval_conjuncts(_conjunct_ctxs, (*chunk).get());
     _aggregator->update_num_rows_returned(-(old_size - chunk->num_rows()));
 
-    _aggregator->process_limit(&chunk);
-
     DCHECK_CHUNK(chunk);
     return std::move(chunk);
 }

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.h
@@ -28,10 +28,10 @@ private:
     bool _is_finished = false;
 };
 
-class AggregateDistinctBlockingSourceOperatorFactory final : public OperatorFactory {
+class AggregateDistinctBlockingSourceOperatorFactory final : public SourceOperatorFactory {
 public:
     AggregateDistinctBlockingSourceOperatorFactory(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
-            : OperatorFactory(id, plan_node_id), _aggregator(aggregator) {}
+            : SourceOperatorFactory(id, plan_node_id), _aggregator(aggregator) {}
 
     ~AggregateDistinctBlockingSourceOperatorFactory() override = default;
 

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.h
@@ -9,8 +9,7 @@ namespace starrocks::pipeline {
 class AggregateDistinctBlockingSourceOperator : public SourceOperator {
 public:
     AggregateDistinctBlockingSourceOperator(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
-            : SourceOperator(id, "aggregate_distinct_blocking_source_operator", plan_node_id),
-              _aggregator(aggregator) {}
+            : SourceOperator(id, "aggregate_distinct_blocking_source", plan_node_id), _aggregator(aggregator) {}
     ~AggregateDistinctBlockingSourceOperator() = default;
 
     bool has_output() const override;

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.h
@@ -6,11 +6,12 @@
 #include "exec/vectorized/aggregator.h"
 
 namespace starrocks::pipeline {
-class AggregateStreamingSourceOperator : public SourceOperator {
+class AggregateDistinctBlockingSourceOperator : public SourceOperator {
 public:
-    AggregateStreamingSourceOperator(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
-            : SourceOperator(id, "aggregate_streaming_source_operator", plan_node_id), _aggregator(aggregator) {}
-    ~AggregateStreamingSourceOperator() = default;
+    AggregateDistinctBlockingSourceOperator(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
+            : SourceOperator(id, "aggregate_distinct_blocking_source_operator", plan_node_id),
+              _aggregator(aggregator) {}
+    ~AggregateDistinctBlockingSourceOperator() = default;
 
     bool has_output() const override;
     bool is_finished() const override;
@@ -21,24 +22,22 @@ public:
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 
 private:
-    void _output_chunk_from_hash_map(vectorized::ChunkPtr* chunk);
-
     // It is used to perform aggregation algorithms
-    // shared by AggregateStreamingSinkOperator
+    // shared by AggregateBlockingSinkOperator
     AggregatorPtr _aggregator = nullptr;
     // Whether prev operator has no output
     bool _is_finished = false;
 };
 
-class AggregateStreamingSourceOperatorFactory final : public OperatorFactory {
+class AggregateDistinctBlockingSourceOperatorFactory final : public OperatorFactory {
 public:
-    AggregateStreamingSourceOperatorFactory(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
+    AggregateDistinctBlockingSourceOperatorFactory(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
             : OperatorFactory(id, plan_node_id), _aggregator(aggregator) {}
 
-    ~AggregateStreamingSourceOperatorFactory() override = default;
+    ~AggregateDistinctBlockingSourceOperatorFactory() override = default;
 
     OperatorPtr create(int32_t driver_instance_count, int32_t driver_sequence) override {
-        return std::make_shared<AggregateStreamingSourceOperator>(_id, _plan_node_id, _aggregator);
+        return std::make_shared<AggregateDistinctBlockingSourceOperator>(_id, _plan_node_id, _aggregator);
     }
 
 private:

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.cpp
@@ -1,11 +1,11 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
 
-#include "aggregate_streaming_sink_operator.h"
+#include "aggregate_distinct_streaming_sink_operator.h"
 
 #include "simd/simd.h"
 namespace starrocks::pipeline {
 
-Status AggregateStreamingSinkOperator::prepare(RuntimeState* state) {
+Status AggregateDistinctStreamingSinkOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(Operator::prepare(state));
     // _aggregator is shared by sink operator and source operator
     // we must only prepare it at sink operator
@@ -14,25 +14,25 @@ Status AggregateStreamingSinkOperator::prepare(RuntimeState* state) {
     return _aggregator->open(state);
 }
 
-bool AggregateStreamingSinkOperator::is_finished() const {
+bool AggregateDistinctStreamingSinkOperator::is_finished() const {
     return _is_finished;
 }
 
-void AggregateStreamingSinkOperator::finish(RuntimeState* state) {
+void AggregateDistinctStreamingSinkOperator::finish(RuntimeState* state) {
     _is_finished = true;
     _aggregator->sink_complete();
 }
 
-StatusOr<vectorized::ChunkPtr> AggregateStreamingSinkOperator::pull_chunk(RuntimeState* state) {
+StatusOr<vectorized::ChunkPtr> AggregateDistinctStreamingSinkOperator::pull_chunk(RuntimeState* state) {
     return Status::InternalError("Not support");
 }
 
-Status AggregateStreamingSinkOperator::push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) {
+Status AggregateDistinctStreamingSinkOperator::push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) {
     size_t chunk_size = chunk->num_rows();
 
     _aggregator->update_num_input_rows(chunk_size);
     COUNTER_SET(_aggregator->input_row_count(), _aggregator->num_input_rows());
-    RETURN_IF_ERROR(_aggregator->check_hash_map_memory_usage(state));
+    RETURN_IF_ERROR(_aggregator->check_hash_set_memory_usage(state));
 
     _aggregator->evaluate_exprs(chunk.get());
 
@@ -45,7 +45,7 @@ Status AggregateStreamingSinkOperator::push_chunk(RuntimeState* state, const vec
     }
 }
 
-Status AggregateStreamingSinkOperator::_push_chunk_by_force_streaming() {
+Status AggregateDistinctStreamingSinkOperator::_push_chunk_by_force_streaming() {
     SCOPED_TIMER(_aggregator->streaming_timer());
     vectorized::ChunkPtr chunk = std::make_shared<vectorized::Chunk>();
     _aggregator->output_chunk_by_streaming(&chunk);
@@ -53,71 +53,69 @@ Status AggregateStreamingSinkOperator::_push_chunk_by_force_streaming() {
     return Status::OK();
 }
 
-Status AggregateStreamingSinkOperator::_push_chunk_by_force_preaggregation(const size_t chunk_size) {
+Status AggregateDistinctStreamingSinkOperator::_push_chunk_by_force_preaggregation(const size_t chunk_size) {
     SCOPED_TIMER(_aggregator->agg_compute_timer());
     if (false) {
     }
 #define HASH_MAP_METHOD(NAME)                                                                          \
-    else if (_aggregator->hash_map_variant().type == vectorized::HashMapVariant::Type::NAME)           \
-            _aggregator->build_hash_map<decltype(_aggregator->hash_map_variant().NAME)::element_type>( \
-                    *_aggregator->hash_map_variant().NAME, chunk_size);
+    else if (_aggregator->hash_set_variant().type == vectorized::HashSetVariant::Type::NAME)           \
+            _aggregator->build_hash_set<decltype(_aggregator->hash_set_variant().NAME)::element_type>( \
+                    *_aggregator->hash_set_variant().NAME, chunk_size);
     APPLY_FOR_VARIANT_ALL(HASH_MAP_METHOD)
 #undef HASH_MAP_METHOD
     else {
         DCHECK(false);
     }
 
-    if (_aggregator->is_none_group_by_exprs()) {
+    if (_aggregator->group_by_expr_ctxs().empty()) {
         _aggregator->compute_single_agg_state(chunk_size);
     } else {
         _aggregator->compute_batch_agg_states(chunk_size);
     }
 
-    _aggregator->try_convert_to_two_level_map();
-    COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_map_variant().size());
+    COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_set_variant().size());
     return Status::OK();
 }
 
-Status AggregateStreamingSinkOperator::_push_chunk_by_auto(const size_t chunk_size) {
+Status AggregateDistinctStreamingSinkOperator::_push_chunk_by_auto(const size_t chunk_size) {
     // TODO: calc the real capacity of hashtable, will add one interface in the class of habletable
-    size_t real_capacity = _aggregator->hash_map_variant().capacity() - _aggregator->hash_map_variant().capacity() / 8;
-    size_t remain_size = real_capacity - _aggregator->hash_map_variant().size();
+    size_t real_capacity = _aggregator->hash_set_variant().capacity() - _aggregator->hash_set_variant().capacity() / 8;
+    size_t remain_size = real_capacity - _aggregator->hash_set_variant().size();
     bool ht_needs_expansion = remain_size < chunk_size;
     if (!ht_needs_expansion ||
         // TODO(hcf) first param
         _aggregator->should_expand_preagg_hash_tables(0, chunk_size, _aggregator->mem_pool()->total_allocated_bytes(),
-                                                      _aggregator->hash_map_variant().size())) {
+                                                      _aggregator->hash_set_variant().size())) {
         // hash table is not full or allow expand the hash table according reduction rate
         SCOPED_TIMER(_aggregator->agg_compute_timer());
         if (false) {
         }
 #define HASH_MAP_METHOD(NAME)                                                                          \
-    else if (_aggregator->hash_map_variant().type == vectorized::HashMapVariant::Type::NAME)           \
-            _aggregator->build_hash_map<decltype(_aggregator->hash_map_variant().NAME)::element_type>( \
-                    *_aggregator->hash_map_variant().NAME, chunk_size);
+    else if (_aggregator->hash_set_variant().type == vectorized::HashSetVariant::Type::NAME)           \
+            _aggregator->build_hash_set<decltype(_aggregator->hash_set_variant().NAME)::element_type>( \
+                    *_aggregator->hash_set_variant().NAME, chunk_size);
         APPLY_FOR_VARIANT_ALL(HASH_MAP_METHOD)
 #undef HASH_MAP_METHOD
         else {
             DCHECK(false);
         }
 
-        if (_aggregator->is_none_group_by_exprs()) {
+        if (_aggregator->group_by_expr_ctxs().empty()) {
             _aggregator->compute_single_agg_state(chunk_size);
         } else {
             _aggregator->compute_batch_agg_states(chunk_size);
         }
 
-        _aggregator->try_convert_to_two_level_map();
-        COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_map_variant().size());
+        COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_set_variant().size());
     } else {
         {
             SCOPED_TIMER(_aggregator->agg_compute_timer());
             if (false) {
             }
 #define HASH_MAP_METHOD(NAME)                                                                                       \
-    else if (_aggregator->hash_map_variant().type == vectorized::HashMapVariant::Type::NAME) _aggregator            \
-            ->build_hash_map_with_selection<typename decltype(_aggregator->hash_map_variant().NAME)::element_type>( \
-                    *_aggregator->hash_map_variant().NAME, chunk_size);
+    else if (_aggregator->hash_set_variant().type == vectorized::HashSetVariant::Type::NAME) _aggregator            \
+            ->build_hash_set_with_selection<typename decltype(_aggregator->hash_set_variant().NAME)::element_type>( \
+                    *_aggregator->hash_set_variant().NAME, chunk_size);
             APPLY_FOR_VARIANT_ALL(HASH_MAP_METHOD)
 #undef HASH_MAP_METHOD
             else {
@@ -125,33 +123,21 @@ Status AggregateStreamingSinkOperator::_push_chunk_by_auto(const size_t chunk_si
             }
         }
 
-        size_t zero_count = SIMD::count_zero(_aggregator->streaming_selection());
-        // very poor aggregation
-        if (zero_count == 0) {
+        {
             SCOPED_TIMER(_aggregator->streaming_timer());
-            vectorized::ChunkPtr chunk = std::make_shared<vectorized::Chunk>();
-            _aggregator->output_chunk_by_streaming(&chunk);
-            _aggregator->offer_chunk_to_buffer(chunk);
-        }
-        // very high aggregation
-        else if (zero_count == _aggregator->streaming_selection().size()) {
-            SCOPED_TIMER(_aggregator->agg_compute_timer());
-            _aggregator->compute_batch_agg_states(chunk_size);
-        } else {
-            // middle cases, first aggregate locally and output by stream
-            {
-                SCOPED_TIMER(_aggregator->agg_compute_timer());
-                _aggregator->compute_batch_agg_states_with_selection(chunk_size);
-            }
-            {
-                SCOPED_TIMER(_aggregator->streaming_timer());
+            size_t zero_count = SIMD::count_zero(_aggregator->streaming_selection());
+            if (zero_count == 0) {
                 vectorized::ChunkPtr chunk = std::make_shared<vectorized::Chunk>();
                 _aggregator->output_chunk_by_streaming(&chunk);
+                _aggregator->offer_chunk_to_buffer(chunk);
+            } else if (zero_count != _aggregator->streaming_selection().size()) {
+                vectorized::ChunkPtr chunk = std::make_shared<vectorized::Chunk>();
+                _aggregator->output_chunk_by_streaming_with_selection(&chunk);
                 _aggregator->offer_chunk_to_buffer(chunk);
             }
         }
 
-        COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_map_variant().size());
+        COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_set_variant().size());
     }
 
     return Status::OK();

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.h
@@ -9,7 +9,7 @@ namespace starrocks::pipeline {
 class AggregateDistinctStreamingSinkOperator : public Operator {
 public:
     AggregateDistinctStreamingSinkOperator(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
-            : Operator(id, "aggregate_distinct_streaming_sink_operator", plan_node_id), _aggregator(aggregator) {
+            : Operator(id, "aggregate_distinct_streaming_sink", plan_node_id), _aggregator(aggregator) {
         _aggregator->set_aggr_phase(AggrPhase1);
     }
     ~AggregateDistinctStreamingSinkOperator() = default;

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.h
@@ -6,13 +6,13 @@
 #include "exec/vectorized/aggregator.h"
 
 namespace starrocks::pipeline {
-class AggregateStreamingSinkOperator : public Operator {
+class AggregateDistinctStreamingSinkOperator : public Operator {
 public:
-    AggregateStreamingSinkOperator(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
-            : Operator(id, "aggregate_streaming_sink_operator", plan_node_id), _aggregator(aggregator) {
+    AggregateDistinctStreamingSinkOperator(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
+            : Operator(id, "aggregate_distinct_streaming_sink_operator", plan_node_id), _aggregator(aggregator) {
         _aggregator->set_aggr_phase(AggrPhase1);
     }
-    ~AggregateStreamingSinkOperator() = default;
+    ~AggregateDistinctStreamingSinkOperator() = default;
 
     bool has_output() const override { return false; }
     bool need_input() const override { return true; }
@@ -41,15 +41,15 @@ private:
     bool _is_finished = false;
 };
 
-class AggregateStreamingSinkOperatorFactory final : public OperatorFactory {
+class AggregateDistinctStreamingSinkOperatorFactory final : public OperatorFactory {
 public:
-    AggregateStreamingSinkOperatorFactory(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
+    AggregateDistinctStreamingSinkOperatorFactory(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
             : OperatorFactory(id, plan_node_id), _aggregator(aggregator) {}
 
-    ~AggregateStreamingSinkOperatorFactory() override = default;
+    ~AggregateDistinctStreamingSinkOperatorFactory() override = default;
 
     OperatorPtr create(int32_t driver_instance_count, int32_t driver_sequence) override {
-        return std::make_shared<AggregateStreamingSinkOperator>(_id, _plan_node_id, _aggregator);
+        return std::make_shared<AggregateDistinctStreamingSinkOperator>(_id, _plan_node_id, _aggregator);
     }
 
 private:

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.cpp
@@ -47,7 +47,6 @@ StatusOr<vectorized::ChunkPtr> AggregateDistinctStreamingSourceOperator::pull_ch
 
     vectorized::ChunkPtr chunk = std::make_shared<vectorized::Chunk>();
     _output_chunk_from_hash_set(&chunk);
-    _aggregator->process_limit(&chunk);
     DCHECK_CHUNK(chunk);
     return std::move(chunk);
 }

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.cpp
@@ -1,10 +1,10 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
 
-#include "aggregate_streaming_source_operator.h"
+#include "aggregate_distinct_streaming_source_operator.h"
 
 namespace starrocks::pipeline {
 
-bool AggregateStreamingSourceOperator::has_output() const {
+bool AggregateDistinctStreamingSourceOperator::has_output() const {
     // There are two cases where chunk buffer is not null
     // case1：streaming mode is 'FORCE_STREAMING'
     // case2：streaming mode is 'AUTO'
@@ -22,61 +22,62 @@ bool AggregateStreamingSourceOperator::has_output() const {
     return _aggregator->is_sink_complete() && !_aggregator->is_ht_eos();
 }
 
-bool AggregateStreamingSourceOperator::is_finished() const {
+bool AggregateDistinctStreamingSourceOperator::is_finished() const {
     // since there are two behavior of streaming operator
     // case 1: chunk-at-a-time, so we check whether the chunk buffer is empty
     // case 2: local aggregate, so we check whether hash table is eos
     return _aggregator->is_sink_complete() && _aggregator->is_chunk_buffer_empty() && _aggregator->is_ht_eos();
 }
 
-void AggregateStreamingSourceOperator::finish(RuntimeState* state) {
+void AggregateDistinctStreamingSourceOperator::finish(RuntimeState* state) {
     _is_finished = true;
 }
 
-Status AggregateStreamingSourceOperator::close(RuntimeState* state) {
+Status AggregateDistinctStreamingSourceOperator::close(RuntimeState* state) {
     // _aggregator is shared by sink operator and source operator
     // we must only close it at source operator
     RETURN_IF_ERROR(_aggregator->close(state));
     return SourceOperator::close(state);
 }
 
-StatusOr<vectorized::ChunkPtr> AggregateStreamingSourceOperator::pull_chunk(RuntimeState* state) {
+StatusOr<vectorized::ChunkPtr> AggregateDistinctStreamingSourceOperator::pull_chunk(RuntimeState* state) {
     if (!_aggregator->is_chunk_buffer_empty()) {
         return std::move(_aggregator->poll_chunk_buffer());
     }
 
     vectorized::ChunkPtr chunk = std::make_shared<vectorized::Chunk>();
-    _output_chunk_from_hash_map(&chunk);
+    _output_chunk_from_hash_set(&chunk);
     _aggregator->process_limit(&chunk);
     DCHECK_CHUNK(chunk);
     return std::move(chunk);
 }
 
-void AggregateStreamingSourceOperator::_output_chunk_from_hash_map(vectorized::ChunkPtr* chunk) {
+void AggregateDistinctStreamingSourceOperator::_output_chunk_from_hash_set(vectorized::ChunkPtr* chunk) {
     if (!_aggregator->it_hash().has_value()) {
         if (false) {
         }
 #define HASH_MAP_METHOD(NAME)                                                                                         \
-    else if (_aggregator->hash_map_variant().type == vectorized::HashMapVariant::Type::NAME) _aggregator->it_hash() = \
-            _aggregator->hash_map_variant().NAME->hash_map.begin();
+    else if (_aggregator->hash_set_variant().type == vectorized::HashSetVariant::Type::NAME) _aggregator->it_hash() = \
+            _aggregator->hash_set_variant().NAME->hash_set.begin();
         APPLY_FOR_VARIANT_ALL(HASH_MAP_METHOD)
 #undef HASH_MAP_METHOD
         else {
             DCHECK(false);
         }
-        COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_map_variant().size());
+        COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_set_variant().size());
     }
 
     if (false) {
     }
 #define HASH_MAP_METHOD(NAME)                                                                                     \
-    else if (_aggregator->hash_map_variant().type == vectorized::HashMapVariant::Type::NAME)                      \
-            _aggregator->convert_hash_map_to_chunk<decltype(_aggregator->hash_map_variant().NAME)::element_type>( \
-                    *_aggregator->hash_map_variant().NAME, config::vector_chunk_size, chunk);
+    else if (_aggregator->hash_set_variant().type == vectorized::HashSetVariant::Type::NAME)                      \
+            _aggregator->convert_hash_set_to_chunk<decltype(_aggregator->hash_set_variant().NAME)::element_type>( \
+                    *_aggregator->hash_set_variant().NAME, config::vector_chunk_size, chunk);
     APPLY_FOR_VARIANT_ALL(HASH_MAP_METHOD)
 #undef HASH_MAP_METHOD
     else {
         DCHECK(false);
     }
 }
+
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.h
@@ -6,11 +6,12 @@
 #include "exec/vectorized/aggregator.h"
 
 namespace starrocks::pipeline {
-class AggregateStreamingSourceOperator : public SourceOperator {
+class AggregateDistinctStreamingSourceOperator : public SourceOperator {
 public:
-    AggregateStreamingSourceOperator(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
-            : SourceOperator(id, "aggregate_streaming_source_operator", plan_node_id), _aggregator(aggregator) {}
-    ~AggregateStreamingSourceOperator() = default;
+    AggregateDistinctStreamingSourceOperator(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
+            : SourceOperator(id, "aggregate_distinct_streaming_source_operator", plan_node_id),
+              _aggregator(aggregator) {}
+    ~AggregateDistinctStreamingSourceOperator() = default;
 
     bool has_output() const override;
     bool is_finished() const override;
@@ -21,7 +22,7 @@ public:
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 
 private:
-    void _output_chunk_from_hash_map(vectorized::ChunkPtr* chunk);
+    void _output_chunk_from_hash_set(vectorized::ChunkPtr* chunk);
 
     // It is used to perform aggregation algorithms
     // shared by AggregateStreamingSinkOperator
@@ -30,15 +31,15 @@ private:
     bool _is_finished = false;
 };
 
-class AggregateStreamingSourceOperatorFactory final : public OperatorFactory {
+class AggregateDistinctStreamingSourceOperatorFactory final : public OperatorFactory {
 public:
-    AggregateStreamingSourceOperatorFactory(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
+    AggregateDistinctStreamingSourceOperatorFactory(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
             : OperatorFactory(id, plan_node_id), _aggregator(aggregator) {}
 
-    ~AggregateStreamingSourceOperatorFactory() override = default;
+    ~AggregateDistinctStreamingSourceOperatorFactory() override = default;
 
     OperatorPtr create(int32_t driver_instance_count, int32_t driver_sequence) override {
-        return std::make_shared<AggregateStreamingSourceOperator>(_id, _plan_node_id, _aggregator);
+        return std::make_shared<AggregateDistinctStreamingSourceOperator>(_id, _plan_node_id, _aggregator);
     }
 
 private:

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.h
@@ -30,10 +30,10 @@ private:
     bool _is_finished = false;
 };
 
-class AggregateDistinctStreamingSourceOperatorFactory final : public OperatorFactory {
+class AggregateDistinctStreamingSourceOperatorFactory final : public SourceOperatorFactory {
 public:
     AggregateDistinctStreamingSourceOperatorFactory(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
-            : OperatorFactory(id, plan_node_id), _aggregator(aggregator) {}
+            : SourceOperatorFactory(id, plan_node_id), _aggregator(aggregator) {}
 
     ~AggregateDistinctStreamingSourceOperatorFactory() override = default;
 

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.h
@@ -9,8 +9,7 @@ namespace starrocks::pipeline {
 class AggregateDistinctStreamingSourceOperator : public SourceOperator {
 public:
     AggregateDistinctStreamingSourceOperator(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
-            : SourceOperator(id, "aggregate_distinct_streaming_source_operator", plan_node_id),
-              _aggregator(aggregator) {}
+            : SourceOperator(id, "aggregate_distinct_streaming_source", plan_node_id), _aggregator(aggregator) {}
     ~AggregateDistinctStreamingSourceOperator() = default;
 
     bool has_output() const override;

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
@@ -67,7 +67,7 @@ Status AggregateStreamingSinkOperator::_push_chunk_by_force_preaggregation(const
         DCHECK(false);
     }
 
-    if (_aggregator->is_none_group_by_exprs()) {
+    if (_aggregator->group_by_expr_ctxs().empty()) {
         _aggregator->compute_single_agg_state(chunk_size);
     } else {
         _aggregator->compute_batch_agg_states(chunk_size);
@@ -100,7 +100,7 @@ Status AggregateStreamingSinkOperator::_push_chunk_by_auto(const size_t chunk_si
             DCHECK(false);
         }
 
-        if (_aggregator->is_none_group_by_exprs()) {
+        if (_aggregator->group_by_expr_ctxs().empty()) {
             _aggregator->compute_single_agg_state(chunk_size);
         } else {
             _aggregator->compute_batch_agg_states(chunk_size);

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.h
@@ -9,7 +9,7 @@ namespace starrocks::pipeline {
 class AggregateStreamingSinkOperator : public Operator {
 public:
     AggregateStreamingSinkOperator(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
-            : Operator(id, "aggregate_streaming_sink_operator", plan_node_id), _aggregator(aggregator) {
+            : Operator(id, "aggregate_streaming_sink", plan_node_id), _aggregator(aggregator) {
         _aggregator->set_aggr_phase(AggrPhase1);
     }
     ~AggregateStreamingSinkOperator() = default;

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.cpp
@@ -47,7 +47,6 @@ StatusOr<vectorized::ChunkPtr> AggregateStreamingSourceOperator::pull_chunk(Runt
 
     vectorized::ChunkPtr chunk = std::make_shared<vectorized::Chunk>();
     _output_chunk_from_hash_map(&chunk);
-    _aggregator->process_limit(&chunk);
     DCHECK_CHUNK(chunk);
     return std::move(chunk);
 }

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.h
@@ -9,7 +9,7 @@ namespace starrocks::pipeline {
 class AggregateStreamingSourceOperator : public SourceOperator {
 public:
     AggregateStreamingSourceOperator(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
-            : SourceOperator(id, "aggregate_streaming_source_operator", plan_node_id), _aggregator(aggregator) {}
+            : SourceOperator(id, "aggregate_streaming_source", plan_node_id), _aggregator(aggregator) {}
     ~AggregateStreamingSourceOperator() = default;
 
     bool has_output() const override;

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.h
@@ -30,10 +30,10 @@ private:
     bool _is_finished = false;
 };
 
-class AggregateStreamingSourceOperatorFactory final : public OperatorFactory {
+class AggregateStreamingSourceOperatorFactory final : public SourceOperatorFactory {
 public:
     AggregateStreamingSourceOperatorFactory(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
-            : OperatorFactory(id, plan_node_id), _aggregator(aggregator) {}
+            : SourceOperatorFactory(id, plan_node_id), _aggregator(aggregator) {}
 
     ~AggregateStreamingSourceOperatorFactory() override = default;
 

--- a/be/src/exec/pipeline/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/olap_chunk_source.cpp
@@ -20,6 +20,7 @@ namespace starrocks::pipeline {
 using namespace vectorized;
 Status OlapChunkSource::prepare(RuntimeState* state) {
     _runtime_state = state;
+    _scan_profile = state->runtime_profile();
 
     for (const auto& ctx_iter : _conjunct_ctxs) {
         // if conjunct is constant, compute direct and set eos = true

--- a/be/src/exec/vectorized/aggregate/aggregate_base_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_base_node.cpp
@@ -8,21 +8,23 @@
 namespace starrocks::vectorized {
 
 AggregateBaseNode::AggregateBaseNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs)
-        : ExecNode(pool, tnode, descs), _tnode(tnode), _aggregator(std::make_shared<Aggregator>(tnode)) {}
+        : ExecNode(pool, tnode, descs), _tnode(tnode) {}
 
 AggregateBaseNode::~AggregateBaseNode() = default;
 
 Status AggregateBaseNode::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(ExecNode::prepare(state));
-    return _aggregator->prepare(state, _pool, mem_tracker(), expr_mem_tracker(), &(child(0)->row_desc()),
-                                runtime_profile());
+    _aggregator = std::make_shared<Aggregator>(_tnode, child(0)->row_desc());
+    return _aggregator->prepare(state, _pool, mem_tracker(), expr_mem_tracker(), runtime_profile());
 }
 
 Status AggregateBaseNode::close(RuntimeState* state) {
     if (is_closed()) {
         return Status::OK();
     }
-    _aggregator->close(state);
+    if (_aggregator != nullptr) {
+        _aggregator->close(state);
+    }
     return ExecNode::close(state);
 }
 

--- a/be/src/exec/vectorized/aggregate/aggregate_base_node.h
+++ b/be/src/exec/vectorized/aggregate/aggregate_base_node.h
@@ -23,7 +23,7 @@ public:
 
 protected:
     const TPlanNode _tnode;
-    AggregatorPtr _aggregator;
+    AggregatorPtr _aggregator = nullptr;
     bool _child_eos = false;
 };
 

--- a/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
@@ -149,8 +149,10 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > AggregateBlockingNode::
     context->add_pipeline(operators_with_sink);
 
     OpFactories operators_with_source;
-    operators_with_source.emplace_back(
-            std::make_shared<AggregateBlockingSourceOperatorFactory>(context->next_operator_id(), id(), aggregator));
+    auto source_operator =
+            std::make_shared<AggregateBlockingSourceOperatorFactory>(context->next_operator_id(), id(), aggregator);
+    source_operator->set_num_driver_instances(1);
+    operators_with_source.push_back(std::move(source_operator));
     return operators_with_source;
 }
 

--- a/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
@@ -21,13 +21,6 @@ Status AggregateBlockingNode::open(RuntimeState* state) {
     SCOPED_TIMER(_runtime_profile->total_time_counter());
     RETURN_IF_ERROR(ExecNode::open(state));
     RETURN_IF_ERROR(_aggregator->open(state));
-
-    // Initial for FunctionContext of every aggregate functions
-    for (int i = 0; i < _aggregator->agg_fn_ctxs().size(); ++i) {
-        // initial const columns for i'th FunctionContext.
-        _aggregator->evaluate_const_columns(i);
-    }
-
     RETURN_IF_ERROR(_children[0]->open(state));
 
     ChunkPtr chunk;

--- a/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
@@ -112,7 +112,11 @@ Status AggregateBlockingNode::get_next(RuntimeState* state, ChunkPtr* chunk, boo
     }
     int32_t chunk_size = config::vector_chunk_size;
 
+<<<<<<< HEAD
     if (_aggregator->is_none_group_by_exprs()) {
+=======
+    if (_aggregator->group_by_expr_ctxs().empty()) {
+>>>>>>> 5541db1e1 ([SR-4475] AggregateNode reuse Aggregator)
         SCOPED_TIMER(_aggregator->get_results_timer());
         _aggregator->convert_to_chunk_no_groupby(chunk);
     } else {

--- a/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
@@ -151,6 +151,8 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > AggregateBlockingNode::
     OpFactories operators_with_source;
     auto source_operator =
             std::make_shared<AggregateBlockingSourceOperatorFactory>(context->next_operator_id(), id(), aggregator);
+
+    // The merge-aggregation phase cannot be parallel, so we set the degree of parallism to 1
     source_operator->set_num_driver_instances(1);
     operators_with_source.push_back(std::move(source_operator));
     return operators_with_source;

--- a/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
@@ -139,8 +139,8 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > AggregateBlockingNode::
         pipeline::PipelineBuilderContext* context) {
     using namespace pipeline;
     OpFactories operators_with_sink = _children[0]->decompose_to_pipeline(context);
-
     context->maybe_interpolate_local_exchange(operators_with_sink);
+
     // shared by sink operator and source operator
     AggregatorPtr aggregator = std::make_shared<Aggregator>(_tnode, child(0)->row_desc());
 

--- a/be/src/exec/vectorized/aggregate/aggregate_blocking_node.h
+++ b/be/src/exec/vectorized/aggregate/aggregate_blocking_node.h
@@ -12,9 +12,9 @@ namespace starrocks::vectorized {
 class AggregateBlockingNode final : public AggregateBaseNode {
 public:
     AggregateBlockingNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs)
-            : AggregateBaseNode(pool, tnode, descs) {
-        _aggregator->set_aggr_phase(AggrPhase2);
-    };
+            : AggregateBaseNode(pool, tnode, descs) {}
+
+    Status prepare(RuntimeState* state) override;
     Status open(RuntimeState* state) override;
     Status get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) override;
 

--- a/be/src/exec/vectorized/aggregate/aggregate_streaming_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_streaming_node.cpp
@@ -21,15 +21,7 @@ Status AggregateStreamingNode::open(RuntimeState* state) {
     SCOPED_TIMER(_runtime_profile->total_time_counter());
     RETURN_IF_ERROR(ExecNode::open(state));
     RETURN_IF_ERROR(_aggregator->open(state));
-
-    // Initial for FunctionContext of every aggregate functions
-    for (int i = 0; i < _aggregator->agg_fn_ctxs().size(); ++i) {
-        // initial const columns for i'th FunctionContext.
-        _aggregator->evaluate_const_columns(i);
-    }
-
-    RETURN_IF_ERROR(_children[0]->open(state));
-    return Status::OK();
+    return _children[0]->open(state);
 }
 
 Status AggregateStreamingNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) {

--- a/be/src/exec/vectorized/aggregate/aggregate_streaming_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_streaming_node.cpp
@@ -223,6 +223,7 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > AggregateStreamingNode:
     using namespace pipeline;
     OpFactories operators_with_sink = _children[0]->decompose_to_pipeline(context);
     context->maybe_interpolate_local_exchange(operators_with_sink);
+
     // shared by sink operator and source operator
     AggregatorPtr aggregator = std::make_shared<Aggregator>(_tnode, child(0)->row_desc());
 

--- a/be/src/exec/vectorized/aggregate/aggregate_streaming_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_streaming_node.cpp
@@ -234,6 +234,9 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > AggregateStreamingNode:
     OpFactories operators_with_source;
     auto source_operator =
             std::make_shared<AggregateStreamingSourceOperatorFactory>(context->next_operator_id(), id(), aggregator);
+
+    // TODO(hcf) Currently, the shared data structure aggregator does not support concurrency.
+    // So the degree of parallism must set to 1, we'll fix it later
     source_operator->set_num_driver_instances(1);
     operators_with_source.push_back(std::move(source_operator));
     return operators_with_source;

--- a/be/src/exec/vectorized/aggregate/aggregate_streaming_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_streaming_node.cpp
@@ -10,15 +10,17 @@
 
 namespace starrocks::vectorized {
 
+Status AggregateStreamingNode::prepare(RuntimeState* state) {
+    RETURN_IF_ERROR(AggregateBaseNode::prepare(state));
+    _aggregator->set_aggr_phase(AggrPhase1);
+    return Status::OK();
+}
+
 Status AggregateStreamingNode::open(RuntimeState* state) {
     RETURN_IF_ERROR(exec_debug_action(TExecNodePhase::OPEN));
     SCOPED_TIMER(_runtime_profile->total_time_counter());
     RETURN_IF_ERROR(ExecNode::open(state));
-    RETURN_IF_ERROR(Expr::open(_aggregator->group_by_expr_ctxs(), state));
-
-    for (int i = 0; i < _aggregator->agg_fn_ctxs().size(); ++i) {
-        RETURN_IF_ERROR(Expr::open(_aggregator->agg_expr_ctxs()[i], state));
-    }
+    RETURN_IF_ERROR(_aggregator->open(state));
 
     // Initial for FunctionContext of every aggregate functions
     for (int i = 0; i < _aggregator->agg_fn_ctxs().size(); ++i) {
@@ -230,7 +232,7 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > AggregateStreamingNode:
     OpFactories operators_with_sink = _children[0]->decompose_to_pipeline(context);
     context->maybe_interpolate_local_exchange(operators_with_sink);
     // shared by sink operator and source operator
-    AggregatorPtr aggregator = std::make_shared<Aggregator>(_tnode);
+    AggregatorPtr aggregator = std::make_shared<Aggregator>(_tnode, child(0)->row_desc());
 
     operators_with_sink.emplace_back(
             std::make_shared<AggregateStreamingSinkOperatorFactory>(context->next_operator_id(), id(), aggregator));

--- a/be/src/exec/vectorized/aggregate/aggregate_streaming_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_streaming_node.cpp
@@ -232,8 +232,10 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > AggregateStreamingNode:
     context->add_pipeline(operators_with_sink);
 
     OpFactories operators_with_source;
-    operators_with_source.emplace_back(
-            std::make_shared<AggregateStreamingSourceOperatorFactory>(context->next_operator_id(), id(), aggregator));
+    auto source_operator =
+            std::make_shared<AggregateStreamingSourceOperatorFactory>(context->next_operator_id(), id(), aggregator);
+    source_operator->set_num_driver_instances(1);
+    operators_with_source.push_back(std::move(source_operator));
     return operators_with_source;
 }
 

--- a/be/src/exec/vectorized/aggregate/aggregate_streaming_node.h
+++ b/be/src/exec/vectorized/aggregate/aggregate_streaming_node.h
@@ -11,9 +11,9 @@ namespace starrocks::vectorized {
 class AggregateStreamingNode final : public AggregateBaseNode {
 public:
     AggregateStreamingNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs)
-            : AggregateBaseNode(pool, tnode, descs) {
-        _aggregator->set_aggr_phase(AggrPhase1);
-    };
+            : AggregateBaseNode(pool, tnode, descs) {}
+
+    Status prepare(RuntimeState* state) override;
     Status open(RuntimeState* state) override;
     Status get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) override;
 

--- a/be/src/exec/vectorized/aggregate/distinct_blocking_node.cpp
+++ b/be/src/exec/vectorized/aggregate/distinct_blocking_node.cpp
@@ -124,6 +124,7 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > DistinctBlockingNode::d
         pipeline::PipelineBuilderContext* context) {
     using namespace pipeline;
     OpFactories operators_with_sink = _children[0]->decompose_to_pipeline(context);
+    context->maybe_interpolate_local_exchange(operators_with_sink);
 
     // shared by sink operator and source operator
     AggregatorPtr aggregator = std::make_shared<Aggregator>(_tnode, child(0)->row_desc());

--- a/be/src/exec/vectorized/aggregate/distinct_blocking_node.cpp
+++ b/be/src/exec/vectorized/aggregate/distinct_blocking_node.cpp
@@ -136,6 +136,8 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > DistinctBlockingNode::d
     OpFactories operators_with_source;
     auto source_operator = std::make_shared<AggregateDistinctBlockingSourceOperatorFactory>(context->next_operator_id(),
                                                                                             id(), aggregator);
+
+    // The merge-aggregation phase cannot be parallel, so we set the degree of parallism to 1
     source_operator->set_num_driver_instances(1);
     operators_with_source.push_back(std::move(source_operator));
     return operators_with_source;

--- a/be/src/exec/vectorized/aggregate/distinct_blocking_node.cpp
+++ b/be/src/exec/vectorized/aggregate/distinct_blocking_node.cpp
@@ -134,8 +134,10 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > DistinctBlockingNode::d
     context->add_pipeline(operators_with_sink);
 
     OpFactories operators_with_source;
-    operators_with_source.emplace_back(std::make_shared<AggregateDistinctBlockingSourceOperatorFactory>(
-            context->next_operator_id(), id(), aggregator));
+    auto source_operator = std::make_shared<AggregateDistinctBlockingSourceOperatorFactory>(context->next_operator_id(),
+                                                                                            id(), aggregator);
+    source_operator->set_num_driver_instances(1);
+    operators_with_source.push_back(std::move(source_operator));
     return operators_with_source;
 }
 

--- a/be/src/exec/vectorized/aggregate/distinct_blocking_node.h
+++ b/be/src/exec/vectorized/aggregate/distinct_blocking_node.h
@@ -10,10 +10,13 @@ namespace starrocks::vectorized {
 class DistinctBlockingNode final : public AggregateBaseNode {
 public:
     DistinctBlockingNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs)
-            : AggregateBaseNode(pool, tnode, descs) {
-        _aggregator->set_aggr_phase(AggrPhase2);
-    };
+            : AggregateBaseNode(pool, tnode, descs) {}
+
+    Status prepare(RuntimeState* state) override;
     Status open(RuntimeState* state) override;
     Status get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) override;
+
+    std::vector<std::shared_ptr<pipeline::OperatorFactory>> decompose_to_pipeline(
+            pipeline::PipelineBuilderContext* context) override;
 };
 } // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/aggregate/distinct_streaming_node.cpp
+++ b/be/src/exec/vectorized/aggregate/distinct_streaming_node.cpp
@@ -2,15 +2,26 @@
 
 #include "exec/vectorized/aggregate/distinct_streaming_node.h"
 
+#include "exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.h"
+#include "exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.h"
+#include "exec/pipeline/operator.h"
+#include "exec/pipeline/pipeline_builder.h"
+#include "exec/vectorized/aggregator.h"
 #include "simd/simd.h"
 
 namespace starrocks::vectorized {
+
+Status DistinctStreamingNode::prepare(RuntimeState* state) {
+    RETURN_IF_ERROR(AggregateBaseNode::prepare(state));
+    _aggregator->set_aggr_phase(AggrPhase1);
+    return Status::OK();
+}
 
 Status DistinctStreamingNode::open(RuntimeState* state) {
     RETURN_IF_ERROR(exec_debug_action(TExecNodePhase::OPEN));
     SCOPED_TIMER(_runtime_profile->total_time_counter());
     RETURN_IF_ERROR(ExecNode::open(state));
-    RETURN_IF_ERROR(Expr::open(_aggregator->group_by_expr_ctxs(), state));
+    RETURN_IF_ERROR(_aggregator->open(state));
     RETURN_IF_ERROR(_children[0]->open(state));
     return Status::OK();
 }
@@ -191,6 +202,24 @@ void DistinctStreamingNode::_output_chunk_from_hash_set(ChunkPtr* chunk) {
     else {
         DCHECK(false);
     }
+}
+
+std::vector<std::shared_ptr<pipeline::OperatorFactory> > DistinctStreamingNode::decompose_to_pipeline(
+        pipeline::PipelineBuilderContext* context) {
+    using namespace pipeline;
+    OpFactories operators_with_sink = _children[0]->decompose_to_pipeline(context);
+
+    // shared by sink operator and source operator
+    AggregatorPtr aggregator = std::make_shared<Aggregator>(_tnode, child(0)->row_desc());
+
+    operators_with_sink.emplace_back(std::make_shared<AggregateDistinctStreamingSinkOperatorFactory>(
+            context->next_operator_id(), id(), aggregator));
+    context->add_pipeline(operators_with_sink);
+
+    OpFactories operators_with_source;
+    operators_with_source.emplace_back(std::make_shared<AggregateDistinctStreamingSourceOperatorFactory>(
+            context->next_operator_id(), id(), aggregator));
+    return operators_with_source;
 }
 
 } // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/aggregate/distinct_streaming_node.cpp
+++ b/be/src/exec/vectorized/aggregate/distinct_streaming_node.cpp
@@ -220,6 +220,9 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > DistinctStreamingNode::
     OpFactories operators_with_source;
     auto source_operator = std::make_shared<AggregateDistinctStreamingSourceOperatorFactory>(
             context->next_operator_id(), id(), aggregator);
+
+    // TODO(hcf) Currently, the shared data structure aggregator does not support concurrency.
+    // So the degree of parallism must set to 1, we'll fix it later
     source_operator->set_num_driver_instances(1);
     operators_with_source.push_back(std::move(source_operator));
     return operators_with_source;

--- a/be/src/exec/vectorized/aggregate/distinct_streaming_node.cpp
+++ b/be/src/exec/vectorized/aggregate/distinct_streaming_node.cpp
@@ -208,6 +208,7 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > DistinctStreamingNode::
         pipeline::PipelineBuilderContext* context) {
     using namespace pipeline;
     OpFactories operators_with_sink = _children[0]->decompose_to_pipeline(context);
+    context->maybe_interpolate_local_exchange(operators_with_sink);
 
     // shared by sink operator and source operator
     AggregatorPtr aggregator = std::make_shared<Aggregator>(_tnode, child(0)->row_desc());

--- a/be/src/exec/vectorized/aggregate/distinct_streaming_node.cpp
+++ b/be/src/exec/vectorized/aggregate/distinct_streaming_node.cpp
@@ -218,8 +218,10 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > DistinctStreamingNode::
     context->add_pipeline(operators_with_sink);
 
     OpFactories operators_with_source;
-    operators_with_source.emplace_back(std::make_shared<AggregateDistinctStreamingSourceOperatorFactory>(
-            context->next_operator_id(), id(), aggregator));
+    auto source_operator = std::make_shared<AggregateDistinctStreamingSourceOperatorFactory>(
+            context->next_operator_id(), id(), aggregator);
+    source_operator->set_num_driver_instances(1);
+    operators_with_source.push_back(std::move(source_operator));
     return operators_with_source;
 }
 

--- a/be/src/exec/vectorized/aggregate/distinct_streaming_node.h
+++ b/be/src/exec/vectorized/aggregate/distinct_streaming_node.h
@@ -11,11 +11,14 @@ namespace starrocks::vectorized {
 class DistinctStreamingNode final : public AggregateBaseNode {
 public:
     DistinctStreamingNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs)
-            : AggregateBaseNode(pool, tnode, descs) {
-        _aggregator->set_aggr_phase(AggrPhase1);
-    };
+            : AggregateBaseNode(pool, tnode, descs) {}
+
+    Status prepare(RuntimeState* state) override;
     Status open(RuntimeState* state) override;
     Status get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) override;
+
+    std::vector<std::shared_ptr<pipeline::OperatorFactory>> decompose_to_pipeline(
+            pipeline::PipelineBuilderContext* context) override;
 
 private:
     void _output_chunk_from_hash_set(ChunkPtr* chunk);

--- a/be/src/exec/vectorized/aggregator.cpp
+++ b/be/src/exec/vectorized/aggregator.cpp
@@ -6,20 +6,28 @@
 
 namespace starrocks {
 
-Aggregator::Aggregator(const TPlanNode& tnode)
-        : _tnode(tnode),
-          _needs_finalize(tnode.agg_node.need_finalize),
-          _streaming_preaggregation_mode(tnode.agg_node.streaming_preaggregation_mode),
-          _intermediate_tuple_id(tnode.agg_node.intermediate_tuple_id),
-          _intermediate_tuple_desc(nullptr),
-          _output_tuple_id(tnode.agg_node.output_tuple_id),
-          _output_tuple_desc(nullptr) {}
+Aggregator::Aggregator(const TPlanNode& tnode, const RowDescriptor& child_row_desc)
+        : _tnode(tnode), _child_row_desc(child_row_desc) {}
+
+Status Aggregator::open(RuntimeState* state) {
+    RETURN_IF_ERROR(Expr::open(_group_by_expr_ctxs, state));
+    for (int i = 0; i < _agg_fn_ctxs.size(); ++i) {
+        RETURN_IF_ERROR(Expr::open(_agg_expr_ctxs[i], state));
+    }
+    return Status::OK();
+}
 
 Status Aggregator::prepare(RuntimeState* state, ObjectPool* pool, MemTracker* mem_tracker, MemTracker* expr_mem_tracker,
-                           const RowDescriptor* child_row_desc, RuntimeProfile* runtime_profile) {
+                           RuntimeProfile* runtime_profile) {
     _pool = pool;
     _mem_tracker = mem_tracker;
     _runtime_profile = runtime_profile;
+
+    _limit = _tnode.limit;
+    _needs_finalize = _tnode.agg_node.need_finalize;
+    _streaming_preaggregation_mode = _tnode.agg_node.streaming_preaggregation_mode;
+    _intermediate_tuple_id = _tnode.agg_node.intermediate_tuple_id;
+    _output_tuple_id = _tnode.agg_node.output_tuple_id;
 
     _rows_returned_counter = ADD_COUNTER(_runtime_profile, "RowsReturned", TUnit::UNIT);
 
@@ -162,12 +170,10 @@ Status Aggregator::prepare(RuntimeState* state, ObjectPool* pool, MemTracker* me
     _output_tuple_desc = state->desc_tbl().get_tuple_descriptor(_output_tuple_id);
     DCHECK_EQ(_intermediate_tuple_desc->slots().size(), _output_tuple_desc->slots().size());
 
-    if (child_row_desc != nullptr) {
-        RETURN_IF_ERROR(Expr::prepare(_group_by_expr_ctxs, state, *child_row_desc, expr_mem_tracker));
+    RETURN_IF_ERROR(Expr::prepare(_group_by_expr_ctxs, state, _child_row_desc, expr_mem_tracker));
 
-        for (const auto& ctx : _agg_expr_ctxs) {
-            RETURN_IF_ERROR(Expr::prepare(ctx, state, *child_row_desc, expr_mem_tracker));
-        }
+    for (const auto& ctx : _agg_expr_ctxs) {
+        RETURN_IF_ERROR(Expr::prepare(ctx, state, _child_row_desc, expr_mem_tracker));
     }
 
     _mem_pool = std::make_unique<MemPool>(_mem_tracker);


### PR DESCRIPTION
Provide aggregate operators for pipeline engine

- AggregateDistinctBlockingSinkOperator
- AggregateDistinctBlockingSourceOperator

Roadmap

- [x] stage1: support AggregateBlockingOperator and AggregateStreamingOperator
- [x] stage2: split AggregateBlockingOperator/AggregateStreamingOperator into sink-source operator pair
- [x] stage3: support AggregateDistinctBlockingSinkOperator and AggregateDistinctBlockingSourceOperator(this pull request)
- [x] stage4: support AggregateDistinctStreamingSinkOperator and AggregateDistinctStreamingSourceOperator(this pull request)
- [ ] stage5: use LocalExchagneOperator to increase the degree of parallelism of aggregation