### PR TITLE
[SR-3574] optimizing some object columnp agg-function performance and b…

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -611,6 +611,7 @@ CONF_mInt32(sys_minidump_interval, "600");
 // requests will fail.
 CONF_Int16(tablet_max_versions, "1000");
 
+// will remove
 CONF_mBool(enable_bitmap_union_disk_format_with_set, "false");
 
 // yield PipelineDriver when maximum number of chunks has been moved
@@ -619,6 +620,10 @@ CONF_Int64(pipeline_yield_max_chunks_moved, "100");
 // yield PipelineDriver when maximum time in nano-seconds has spent
 // in current execution round.
 CONF_Int64(pipeline_yield_max_time_spent, "100000000");
+
+// bitmap serialize version
+CONF_Int16(bitmap_serialize_version, "1");
+
 } // namespace config
 
 } // namespace starrocks

--- a/be/src/exec/es/es_predicate.cpp
+++ b/be/src/exec/es/es_predicate.cpp
@@ -683,7 +683,7 @@ Status EsPredicate::_build_in_predicate(const Expr* conjunct, bool* handled) {
         }
 
         std::vector<ExtLiteral*> in_pred_values;
-        const Predicate* pred = static_cast<const InPredicate*>(conjunct);
+        const Predicate* pred = static_cast<const Predicate*>(conjunct);
 
         const Expr* expr = Expr::expr_without_cast(pred->get_child(0));
         if (expr->node_type() != TExprNodeType::SLOT_REF) {

--- a/be/src/exprs/agg/bitmap_intersect.h
+++ b/be/src/exprs/agg/bitmap_intersect.h
@@ -41,9 +41,9 @@ public:
     }
 
     void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr state, Column* to) const override {
-        BitmapValue bitmap = this->data(state).bitmap;
         BitmapColumn* col = down_cast<BitmapColumn*>(to);
-        col->append(&bitmap);
+        BitmapValue& bitmap = const_cast<BitmapValue&>(this->data(state).bitmap);
+        col->append(std::move(bitmap));
     }
 
     void convert_to_serialize_format(const Columns& src, size_t chunk_size, ColumnPtr* dst) const override {
@@ -51,9 +51,9 @@ public:
     }
 
     void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr state, Column* to) const override {
-        BitmapValue bitmap = this->data(state).bitmap;
+        BitmapValue& bitmap = const_cast<BitmapValue&>(this->data(state).bitmap);
         BitmapColumn* col = down_cast<BitmapColumn*>(to);
-        col->append(&bitmap);
+        col->append(std::move(bitmap));
     }
 
     std::string get_name() const override { return "bitmap_intersect"; }

--- a/be/src/exprs/agg/bitmap_union.h
+++ b/be/src/exprs/agg/bitmap_union.h
@@ -45,7 +45,8 @@ public:
 
     void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr state, Column* to) const override {
         BitmapColumn* col = down_cast<BitmapColumn*>(to);
-        col->append(&(this->data(state)));
+        BitmapValue& bitmap = const_cast<BitmapValue&>(this->data(state));
+        col->append(std::move(bitmap));
     }
 
     void convert_to_serialize_format(const Columns& src, size_t chunk_size, ColumnPtr* dst) const override {
@@ -54,7 +55,8 @@ public:
 
     void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr state, Column* to) const override {
         BitmapColumn* col = down_cast<BitmapColumn*>(to);
-        col->append(&this->data(state));
+        BitmapValue& bitmap = const_cast<BitmapValue&>(this->data(state));
+        col->append(std::move(bitmap));
     }
 
     std::string get_name() const override { return "bitmap_union"; }

--- a/be/src/exprs/agg/bitmap_union_count.h
+++ b/be/src/exprs/agg/bitmap_union_count.h
@@ -44,7 +44,8 @@ public:
 
     void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr state, Column* to) const override {
         BitmapColumn* col = down_cast<BitmapColumn*>(to);
-        col->append(&(this->data(state)));
+        auto& value = const_cast<BitmapValue&>(this->data(state));
+        col->append(std::move(value));
     }
 
     void convert_to_serialize_format(const Columns& src, size_t chunk_size, ColumnPtr* dst) const override {

--- a/be/src/exprs/agg/bitmap_union_int.h
+++ b/be/src/exprs/agg/bitmap_union_int.h
@@ -50,7 +50,8 @@ public:
 
     void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr state, Column* to) const override {
         BitmapColumn* col = down_cast<BitmapColumn*>(to);
-        col->append(&(this->data(state)));
+        auto& value = const_cast<BitmapValue&>(this->data(state));
+        col->append(std::move(value));
     }
 
     void convert_to_serialize_format(const Columns& src, size_t chunk_size, ColumnPtr* dst) const override {
@@ -59,7 +60,7 @@ public:
             const auto* src_column = static_cast<const InputColumnType*>(src[0].get());
             for (size_t i = 0; i < chunk_size; ++i) {
                 BitmapValue bitmap(src_column->get_data()[i]);
-                dst_column->append(&bitmap);
+                dst_column->append(std::move(bitmap));
             }
         }
     }

--- a/be/src/exprs/agg/hll_union.h
+++ b/be/src/exprs/agg/hll_union.h
@@ -74,8 +74,8 @@ public:
                              Column* to) const override {
         DCHECK(to->is_object());
         auto* column = down_cast<HyperLogLogColumn*>(to);
-
-        column->append(&this->data(state));
+        auto& hll_value = const_cast<HyperLogLog&>(this->data(state));
+        column->append(std::move(hll_value));
     }
 
     void convert_to_serialize_format(const Columns& src, size_t chunk_size, ColumnPtr* dst) const override {
@@ -86,8 +86,8 @@ public:
                             Column* to) const override {
         DCHECK(to->is_object());
         auto* column = down_cast<HyperLogLogColumn*>(to);
-
-        column->append(&this->data(state));
+        auto& hll_value = const_cast<HyperLogLog&>(this->data(state));
+        column->append(std::move(hll_value));
     }
 
     std::string get_name() const override { return "hll_union"; }

--- a/be/src/exprs/agg/hll_union_count.h
+++ b/be/src/exprs/agg/hll_union_count.h
@@ -76,8 +76,8 @@ public:
                              Column* to) const override {
         DCHECK(to->is_object());
         auto* column = down_cast<HyperLogLogColumn*>(to);
-
-        column->append(&this->data(state));
+        auto& hll_value = const_cast<HyperLogLog&>(this->data(state));
+        column->append(std::move(hll_value));
     }
 
     void convert_to_serialize_format(const Columns& src, size_t chunk_size, ColumnPtr* dst) const override {

--- a/be/src/exprs/agg/percentile_union.h
+++ b/be/src/exprs/agg/percentile_union.h
@@ -35,8 +35,8 @@ public:
     void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr state, Column* to) const override {
         DCHECK(to->is_object());
         auto* column = down_cast<PercentileColumn*>(to);
-
-        column->append(&this->data(state));
+        auto& percentile_value = const_cast<PercentileValue&>(this->data(state));
+        column->append(std::move(percentile_value));
     }
 
     void convert_to_serialize_format(const Columns& src, size_t chunk_size, ColumnPtr* dst) const override {
@@ -46,8 +46,8 @@ public:
     void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr state, Column* to) const override {
         DCHECK(to->is_object());
         auto* column = down_cast<PercentileColumn*>(to);
-
-        column->append(&this->data(state));
+        auto& percentile_value = const_cast<PercentileValue&>(this->data(state));
+        column->append(std::move(percentile_value));
     }
 
     std::string get_name() const override { return "percentile_union"; }

--- a/be/src/util/bitmap_value.h
+++ b/be/src/util/bitmap_value.h
@@ -1643,16 +1643,21 @@ public:
             break;
         }
         case SET:
+            int pos = 0;
+            int64_t values[_set.size()];
+            for (const auto value : _set) {
+                values[pos++] = value;
+            }
             bool first = true;
-            for (const auto& value : _set) {
+            std::sort(values, values + pos);
+            for (int i = 0; i < pos; ++i) {
                 if (!first) {
                     ss << ",";
                 } else {
                     first = false;
                 }
-                ss << value;
+                ss << values[i];
             }
-
             break;
         }
         return ss.str();

--- a/be/test/util/bitmap_value_test.cpp
+++ b/be/test/util/bitmap_value_test.cpp
@@ -137,6 +137,13 @@ std::string convert_bitmap_to_string(BitmapValue& bitmap) {
 }
 
 TEST(BitmapValueTest, bitmap_serde) {
+    bool use_v1 = config::bitmap_serialize_version == 1;
+    BitmapTypeCode::type type_bitmap32 = BitmapTypeCode::BITMAP32_SERIV2;
+    BitmapTypeCode::type type_bitmap64 = BitmapTypeCode::BITMAP64_SERIV2;
+    if (use_v1) {
+        type_bitmap32 = BitmapTypeCode::BITMAP32;
+        type_bitmap64 = BitmapTypeCode::BITMAP64;
+    }
     { // EMPTY
         BitmapValue empty;
         std::string buffer = convert_bitmap_to_string(empty);
@@ -165,9 +172,9 @@ TEST(BitmapValueTest, bitmap_serde) {
         Roaring roaring;
         roaring.add(0);
         roaring.add(UINT32_MAX);
-        std::string expect_buffer(1, BitmapTypeCode::BITMAP32_SERIV2);
-        expect_buffer.resize(1 + roaring.getSizeInBytes(false));
-        roaring.write(&expect_buffer[1], false);
+        std::string expect_buffer(1, type_bitmap32);
+        expect_buffer.resize(1 + roaring.getSizeInBytes(use_v1));
+        roaring.write(&expect_buffer[1], use_v1);
         ASSERT_EQ(expect_buffer, buffer);
 
         BitmapValue out(buffer.data());
@@ -193,13 +200,13 @@ TEST(BitmapValueTest, bitmap_serde) {
 
         Roaring roaring;
         roaring.add(0);
-        std::string expect_buffer(1, BitmapTypeCode::BITMAP64_SERIV2);
+        std::string expect_buffer(1, type_bitmap64);
         put_varint64(&expect_buffer, 2); // map size
         for (uint32_t i = 0; i < 2; ++i) {
             std::string map_entry;
             put_fixed32_le(&map_entry, i); // map key
-            map_entry.resize(sizeof(uint32_t) + roaring.getSizeInBytes(false));
-            roaring.write(&map_entry[4], false); // map value
+            map_entry.resize(sizeof(uint32_t) + roaring.getSizeInBytes(use_v1));
+            roaring.write(&map_entry[4], use_v1); // map value
 
             expect_buffer.append(map_entry);
         }
@@ -229,9 +236,9 @@ TEST(BitmapValueTest, Roaring64Map) {
     }
     ASSERT_TRUE(r1.contains((uint64_t)14000000000000000500ull));
     ASSERT_EQ(1800, r1.cardinality());
-    size_t size_before = r1.getSizeInBytes();
+    size_t size_before = r1.getSizeInBytes(config::bitmap_serialize_version);
     r1.runOptimize();
-    size_t size_after = r1.getSizeInBytes();
+    size_t size_after = r1.getSizeInBytes(config::bitmap_serialize_version);
     ASSERT_LT(size_after, size_before);
 
     Roaring64Map r2 = Roaring64Map::bitmapOf(5, 1ull, 2ull, 234294967296ull, 195839473298ull, 14000000000000000100ull);
@@ -273,9 +280,9 @@ TEST(BitmapValueTest, Roaring64Map) {
     ASSERT_EQ(1, i1_2.cardinality());
 
     // we can write a bitmap to a pointer and recover it later
-    uint32_t expectedsize = r1.getSizeInBytes();
+    uint32_t expectedsize = r1.getSizeInBytes(config::bitmap_serialize_version);
     char* serializedbytes = new char[expectedsize];
-    r1.write(serializedbytes);
+    r1.write(serializedbytes, config::bitmap_serialize_version);
     Roaring64Map t = Roaring64Map::read(serializedbytes);
     ASSERT_TRUE(r1 == t);
     delete[] serializedbytes;
@@ -321,9 +328,9 @@ TEST(BitmapValueTest, bitmap_single_convert) {
     ASSERT_EQ(BitmapValue::SINGLE, bitmap._type);
 
     bitmap_u.add(2);
-    ASSERT_EQ(BitmapValue::BITMAP, bitmap_u._type);
+    ASSERT_EQ(BitmapValue::SET, bitmap_u._type);
 
     bitmap |= bitmap_u;
-    ASSERT_EQ(BitmapValue::BITMAP, bitmap._type);
+    ASSERT_EQ(BitmapValue::SET, bitmap._type);
 }
 } // namespace starrocks

--- a/be/test/util/bitmap_value_test.cpp
+++ b/be/test/util/bitmap_value_test.cpp
@@ -165,7 +165,7 @@ TEST(BitmapValueTest, bitmap_serde) {
         Roaring roaring;
         roaring.add(0);
         roaring.add(UINT32_MAX);
-        std::string expect_buffer(1, BitmapTypeCode::BITMAP32);
+        std::string expect_buffer(1, BitmapTypeCode::BITMAP32_SERIV2);
         expect_buffer.resize(1 + roaring.getSizeInBytes());
         roaring.write(&expect_buffer[1]);
         ASSERT_EQ(expect_buffer, buffer);
@@ -193,7 +193,7 @@ TEST(BitmapValueTest, bitmap_serde) {
 
         Roaring roaring;
         roaring.add(0);
-        std::string expect_buffer(1, BitmapTypeCode::BITMAP64);
+        std::string expect_buffer(1, BitmapTypeCode::BITMAP64_SERIV2);
         put_varint64(&expect_buffer, 2); // map size
         for (uint32_t i = 0; i < 2; ++i) {
             std::string map_entry;

--- a/be/test/util/bitmap_value_test.cpp
+++ b/be/test/util/bitmap_value_test.cpp
@@ -166,8 +166,8 @@ TEST(BitmapValueTest, bitmap_serde) {
         roaring.add(0);
         roaring.add(UINT32_MAX);
         std::string expect_buffer(1, BitmapTypeCode::BITMAP32_SERIV2);
-        expect_buffer.resize(1 + roaring.getSizeInBytes());
-        roaring.write(&expect_buffer[1]);
+        expect_buffer.resize(1 + roaring.getSizeInBytes(false));
+        roaring.write(&expect_buffer[1], false);
         ASSERT_EQ(expect_buffer, buffer);
 
         BitmapValue out(buffer.data());
@@ -198,8 +198,8 @@ TEST(BitmapValueTest, bitmap_serde) {
         for (uint32_t i = 0; i < 2; ++i) {
             std::string map_entry;
             put_fixed32_le(&map_entry, i); // map key
-            map_entry.resize(sizeof(uint32_t) + roaring.getSizeInBytes());
-            roaring.write(&map_entry[4]); // map value
+            map_entry.resize(sizeof(uint32_t) + roaring.getSizeInBytes(false));
+            roaring.write(&map_entry[4], false); // map value
 
             expect_buffer.append(map_entry);
         }


### PR DESCRIPTION
…itmap serializing

TEST-1

```
set new_planner_agg_stage=2;

before:
mysql> select bitmap_union_count(v) from bitmap_64;
ERROR 1064 (HY000): The input size for compression should be less than 2113929216

after:
mysql> select bitmap_union_count(v) from bitmap_64;
+-------------------------+
| bitmap_union_count(`v`) |
+-------------------------+
|               100000000 |
+-------------------------+
1 row in set (3 min 35.40 sec)

- UncompressedBytes: 1.21 GB
```

TEST-2

```
set new_planner_agg_stage=2;
mysql> select bitmap_union_count(v) from bitmap_64 < 6;
before Profile:
        DataStreamSender (dst_id=3, dst_fragments=[48252baf120311ec-b3fd00163e04d4c4]):(Active: 40s231ms[40231686641ns], % non-child: 37.30%)
           - PartType: UNPARTITIONED
           - BytesSent: 587.38 MB
           - CompressTime: 2s851ms
           - IgnoreRows: 0
           - OverallThroughput: 14.599884033203125 MB/sec
           - PeakMemoryUsage: 8.00 KB
           - SendRequestTime: 127.595ms
           - SerializeBatchTime: 12s998ms
           - ShuffleDispatchTime: 0ns
           - ShuffleHashTime: 0ns
           - UncompressedBytes: 1.23 GB
           - WaitResponseTime: 23s901ms

after Profile:
        DataStreamSender (dst_id=3, dst_fragments=[3c98f20f120711ec-b3fd00163e04d4c4]):(Active: 39s701ms[39701869028ns], % non-child: 37.20%)
           - PartType: UNPARTITIONED
           - BytesSent: 465.94 MB
           - CompressTime: 1s604ms
           - IgnoreRows: 0
           - OverallThroughput: 11.735963821411133 MB/sec
           - PeakMemoryUsage: 8.00 KB
           - SendRequestTime: 84.157ms
           - SerializeBatchTime: 11s991ms
           - ShuffleDispatchTime: 0ns
           - ShuffleHashTime: 0ns
           - UncompressedBytes: 743.87 MB
           - WaitResponseTime: 25s737ms
```

Agg Function Performance:

```
before:
 AGGREGATION_NODE (id=2):(Active: 1m3s[63909309092ns], % non-child: 33.81%)
           - AggregateFunctions: bitmap_union_count(2: v)
           - AggComputeTime: 25s21ms
           - ExprComputeTime: 972ns
           - ExprReleaseTime: 797ns
           - GetResultsTime: 11s65ms #

AGGREGATION_NODE (id=2):(Active: 56s378ms[56378032377ns], % non-child: 27.49%)
           - AggregateFunctions: bitmap_union_count(2: v)
           - AggComputeTime: 26s763ms
           - ExprComputeTime: 409ns
           - ExprReleaseTime: 463ns
           - GetResultsTime: 35.125us
```