### PR TITLE
Reduce the number of disk accesses while parsing segment footer

### DIFF
--- a/be/src/storage/rowset/beta_rowset.cpp
+++ b/be/src/storage/rowset/beta_rowset.cpp
@@ -82,7 +82,7 @@ Status BetaRowset::do_load() {
         std::string seg_path = segment_file_path(_rowset_path, rowset_id(), seg_id);
         auto res = segment_v2::Segment::open(mem_tracker, block_mgr, seg_path, seg_id, _schema, &footer_size_hint);
         if (!res.ok()) {
-            LOG(WARNING) << "Fail to open segment=" << seg_path << " of rowset=" << unique_id() << ", " << res.status();
+            LOG(WARNING) << "Fail to open " << seg_path << ": " << res.status();
             return res.status();
         }
         _segments.push_back(std::move(res).value());

--- a/be/src/storage/rowset/beta_rowset.cpp
+++ b/be/src/storage/rowset/beta_rowset.cpp
@@ -42,7 +42,6 @@
 #include "storage/vectorized/merge_iterator.h"
 #include "storage/vectorized/projection_iterator.h"
 #include "storage/vectorized/union_iterator.h"
-#include "util/raw_container.h"
 
 namespace starrocks {
 

--- a/be/src/storage/rowset/beta_rowset.cpp
+++ b/be/src/storage/rowset/beta_rowset.cpp
@@ -46,8 +46,6 @@
 
 namespace starrocks {
 
-constexpr size_t kDefaultFooterReadBytes = 8192;
-
 std::string BetaRowset::segment_file_path(const std::string& dir, const RowsetId& rowset_id, int segment_id) {
     return strings::Substitute("$0/$1_$2.dat", dir, rowset_id.to_string(), segment_id);
 }

--- a/be/src/storage/rowset/beta_rowset_writer.cpp
+++ b/be/src/storage/rowset/beta_rowset_writer.cpp
@@ -261,9 +261,7 @@ Status BetaRowsetWriter::_final_merge() {
         auto segment_ptr = segment_v2::Segment::open(&tracker, fs::fs_util::block_manager(), tmp_segment_file, seg_id,
                                                      _context.tablet_schema);
         if (!segment_ptr.ok()) {
-            LOG(WARNING) << "Fail to open segment=" << tmp_segment_file
-                         << " of rowset=" << _context.rowset_path_prefix + "/" + _context.rowset_id.to_string() << ", "
-                         << segment_ptr.status();
+            LOG(WARNING) << "Fail to open " << tmp_segment_file << ": " << segment_ptr.status();
             return segment_ptr.status();
         }
         if ((*segment_ptr)->num_rows() == 0) {

--- a/be/src/storage/rowset/beta_rowset_writer.cpp
+++ b/be/src/storage/rowset/beta_rowset_writer.cpp
@@ -257,20 +257,19 @@ Status BetaRowsetWriter::_final_merge() {
     for (int seg_id = 0; seg_id < _num_segment; ++seg_id) {
         std::string tmp_segment_file =
                 BetaRowset::segment_temp_file_path(_context.rowset_path_prefix, _context.rowset_id, seg_id);
-        std::shared_ptr<segment_v2::Segment> segment;
 
-        auto s = segment_v2::Segment::open(&tracker, fs::fs_util::block_manager(), tmp_segment_file, seg_id,
-                                           _context.tablet_schema, &segment);
-        if (!s.ok()) {
+        auto segment_ptr = segment_v2::Segment::open(&tracker, fs::fs_util::block_manager(), tmp_segment_file, seg_id,
+                                                     _context.tablet_schema);
+        if (!segment_ptr.ok()) {
             LOG(WARNING) << "Fail to open segment=" << tmp_segment_file
                          << " of rowset=" << _context.rowset_path_prefix + "/" + _context.rowset_id.to_string() << ", "
-                         << s.to_string();
-            return s;
+                         << segment_ptr.status();
+            return segment_ptr.status();
         }
-        if (segment->num_rows() == 0) {
+        if ((*segment_ptr)->num_rows() == 0) {
             continue;
         }
-        auto res = segment->new_iterator(schema, seg_options);
+        auto res = (*segment_ptr)->new_iterator(schema, seg_options);
         if (res.status().is_end_of_file()) {
             continue;
         } else if (!res.ok()) {

--- a/be/src/storage/rowset/segment_v2/segment.cpp
+++ b/be/src/storage/rowset/segment_v2/segment.cpp
@@ -21,10 +21,8 @@
 
 #include "storage/rowset/segment_v2/segment.h"
 
-#include <butil/iobuf.h>
 #include <google/protobuf/io/zero_copy_stream_impl.h>
 
-#include <boost/container/small_vector.hpp>
 #include <memory>
 
 #include "column/schema.h"

--- a/be/src/storage/rowset/segment_v2/segment.h
+++ b/be/src/storage/rowset/segment_v2/segment.h
@@ -36,10 +36,6 @@
 #include "util/faststring.h"
 #include "util/once.h"
 
-namespace butil {
-class IOBuf;
-}
-
 namespace starrocks {
 
 class TabletSchema;

--- a/be/src/storage/rowset/segment_v2/segment.h
+++ b/be/src/storage/rowset/segment_v2/segment.h
@@ -36,6 +36,10 @@
 #include "util/faststring.h"
 #include "util/once.h"
 
+namespace butil {
+class IOBuf;
+}
+
 namespace starrocks {
 
 class TabletSchema;
@@ -73,9 +77,16 @@ using ChunkIteratorPtr = std::shared_ptr<vectorized::ChunkIterator>;
 // is changed, this segment can not be used any more. For example, after a schema
 // change finished, client should disable all cached Segment for old TabletSchema.
 class Segment : public std::enable_shared_from_this<Segment> {
+    struct private_type;
+
 public:
-    static Status open(MemTracker* mem_tracker, fs::BlockManager* blk_mgr, std::string filename, uint32_t segment_id,
-                       const TabletSchema* tablet_schema, std::shared_ptr<Segment>* output);
+    static StatusOr<std::shared_ptr<Segment>> open(MemTracker* mem_tracker, fs::BlockManager* blk_mgr,
+                                                   const std::string& filename, uint32_t segment_id,
+                                                   const TabletSchema* tablet_schema,
+                                                   size_t* footer_length_hint = nullptr);
+
+    Segment(const private_type&, MemTracker* mem_tracker, fs::BlockManager* blk_mgr, std::string fname,
+            uint32_t segment_id, const TabletSchema* tablet_schema);
 
     ~Segment();
 
@@ -128,11 +139,14 @@ public:
 
 private:
     DISALLOW_COPY_AND_ASSIGN(Segment);
-    Segment(MemTracker* mem_tracker, fs::BlockManager* blk_mgr, std::string fname, uint32_t segment_id,
-            const TabletSchema* tablet_schema);
+
+    struct private_type {
+        explicit private_type(int) {}
+    };
+
     // open segment file and read the minimum amount of necessary information (footer)
-    Status _open();
-    Status _parse_footer();
+    Status _open(size_t* footer_length_hint);
+    Status _parse_footer(size_t* footer_length_hint);
     Status _create_column_readers();
     // Load and decode short key index.
     // May be called multiple times, subsequent calls will no op.

--- a/be/test/storage/rowset/beta_rowset_test.cpp
+++ b/be/test/storage/rowset/beta_rowset_test.cpp
@@ -716,13 +716,9 @@ TEST_F(BetaRowsetTest, FinalMergeTest) {
 
         std::string segment_file =
                 BetaRowset::segment_file_path(writer_context.rowset_path_prefix, writer_context.rowset_id, 0);
-        std::shared_ptr<segment_v2::Segment> segment;
 
-        auto s = segment_v2::Segment::open(&tracker, fs::fs_util::block_manager(), segment_file, 0, &tablet_schema,
-                                           &segment);
-        ASSERT_TRUE(s.ok()) << "Fail to open segment=" << segment_file << " of rowset="
-                            << writer_context.rowset_path_prefix + "/" + writer_context.rowset_id.to_string() << ", "
-                            << s.to_string();
+        auto segment =
+                *segment_v2::Segment::open(&tracker, fs::fs_util::block_manager(), segment_file, 0, &tablet_schema);
         ASSERT_NE(segment->num_rows(), 0);
         auto res = segment->new_iterator(schema, seg_options);
         ASSERT_FALSE(res.status().is_end_of_file() || !res.ok() || res.value() == nullptr);

--- a/be/test/storage/rowset/segment_v2/segment_test.cpp
+++ b/be/test/storage/rowset/segment_v2/segment_test.cpp
@@ -137,7 +137,7 @@ protected:
         uint64_t file_size, index_size;
         ASSERT_OK(writer.finalize(&file_size, &index_size));
 
-        ASSERT_OK(Segment::open(_mem_tracker.get(), _block_mgr, filename, 0, &query_schema, res));
+        *res = *Segment::open(_mem_tracker.get(), _block_mgr, filename, 0, &query_schema);
         ASSERT_EQ(nrows, (*res)->num_rows());
     }
 
@@ -823,8 +823,7 @@ TEST_F(SegmentReaderWriterTest, TestStringDict) {
     ASSERT_OK(writer.finalize(&file_size, &index_size));
 
     {
-        std::shared_ptr<Segment> segment;
-        ASSERT_OK(Segment::open(_mem_tracker.get(), _block_mgr, fname, 0, tablet_schema.get(), &segment));
+        auto segment = *Segment::open(_mem_tracker.get(), _block_mgr, fname, 0, tablet_schema.get());
         ASSERT_EQ(4096, segment->num_rows());
         Schema schema(*tablet_schema);
         OlapReaderStatistics stats;


### PR DESCRIPTION
Issue Number #129

Reduce the number of disk accesses by passing a hint value of the segment footer length, when parsing the segment footer. The hint value is based on the length of the previous segment footer of the same rowset.

In the best case, this implementation only needs one disk access to complete the footer parsing, but in the worst case, it may fall back to two disk accesses.