### PR TITLE
Fix FE ut does not work after upgrade jprotobuf

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -282,7 +282,7 @@ under the License.
             <dependency>
                 <groupId>com.baidu</groupId>
                 <artifactId>jprotobuf-rpc-common</artifactId>
-                <version>1.8</version>
+                <version>1.9</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
this because new version jprotobuf use async.
it is not in jprotobuf-rpc-common 1.8.