### PR TITLE
[SR-4489] Fixup IN predicate overflow decimal string convertion failure

### DIFF
--- a/be/src/storage/vectorized/column_in_predicate.cpp
+++ b/be/src/storage/vectorized/column_in_predicate.cpp
@@ -365,7 +365,6 @@ template <template <typename, size_t...> typename Set, size_t... Args>
 ColumnPredicate* new_column_in_predicate_generic(const TypeInfoPtr& type_info, ColumnId id,
                                                  const std::vector<std::string>& strs) {
     auto type = type_info->type();
-    auto precision = type_info->precision();
     auto scale = type_info->scale();
     switch (type) {
     case OLAP_FIELD_TYPE_BOOL: {
@@ -410,17 +409,17 @@ ColumnPredicate* new_column_in_predicate_generic(const TypeInfoPtr& type_info, C
     }
     case OLAP_FIELD_TYPE_DECIMAL32: {
         using SetType = Set<CppTypeTraits<OLAP_FIELD_TYPE_DECIMAL32>::CppType, (Args)...>;
-        SetType values = predicate_internal::strings_to_decimal_set<OLAP_FIELD_TYPE_DECIMAL32>(precision, scale, strs);
+        SetType values = predicate_internal::strings_to_decimal_set<OLAP_FIELD_TYPE_DECIMAL32>(scale, strs);
         return new ColumnInPredicate<OLAP_FIELD_TYPE_DECIMAL32, SetType>(type_info, id, std::move(values));
     }
     case OLAP_FIELD_TYPE_DECIMAL64: {
         using SetType = Set<CppTypeTraits<OLAP_FIELD_TYPE_DECIMAL64>::CppType, (Args)...>;
-        SetType values = predicate_internal::strings_to_decimal_set<OLAP_FIELD_TYPE_DECIMAL64>(precision, scale, strs);
+        SetType values = predicate_internal::strings_to_decimal_set<OLAP_FIELD_TYPE_DECIMAL64>(scale, strs);
         return new ColumnInPredicate<OLAP_FIELD_TYPE_DECIMAL64, SetType>(type_info, id, std::move(values));
     }
     case OLAP_FIELD_TYPE_DECIMAL128: {
         using SetType = Set<CppTypeTraits<OLAP_FIELD_TYPE_DECIMAL128>::CppType, (Args)...>;
-        SetType values = predicate_internal::strings_to_decimal_set<OLAP_FIELD_TYPE_DECIMAL128>(precision, scale, strs);
+        SetType values = predicate_internal::strings_to_decimal_set<OLAP_FIELD_TYPE_DECIMAL128>(scale, strs);
         return new ColumnInPredicate<OLAP_FIELD_TYPE_DECIMAL128, SetType>(type_info, id, std::move(values));
     }
     case OLAP_FIELD_TYPE_CHAR:

--- a/be/src/storage/vectorized/column_not_in_predicate.cpp
+++ b/be/src/storage/vectorized/column_not_in_predicate.cpp
@@ -328,24 +328,21 @@ ColumnPredicate* new_column_not_in_predicate(const TypeInfoPtr& type_info, Colum
     case OLAP_FIELD_TYPE_DECIMAL_V2:
         return new ColumnNotInPredicate<OLAP_FIELD_TYPE_DECIMAL_V2>(type_info, id, strs);
     case OLAP_FIELD_TYPE_DECIMAL32: {
-        const auto precision = type_info->precision();
         const auto scale = type_info->scale();
         using SetType = ItemHashSet<CppTypeTraits<OLAP_FIELD_TYPE_DECIMAL32>::CppType>;
-        SetType values = predicate_internal::strings_to_decimal_set<OLAP_FIELD_TYPE_DECIMAL32>(precision, scale, strs);
+        SetType values = predicate_internal::strings_to_decimal_set<OLAP_FIELD_TYPE_DECIMAL32>(scale, strs);
         return new ColumnNotInPredicate<OLAP_FIELD_TYPE_DECIMAL32>(type_info, id, std::move(values));
     }
     case OLAP_FIELD_TYPE_DECIMAL64: {
-        const auto precision = type_info->precision();
         const auto scale = type_info->scale();
         using SetType = ItemHashSet<CppTypeTraits<OLAP_FIELD_TYPE_DECIMAL64>::CppType>;
-        SetType values = predicate_internal::strings_to_decimal_set<OLAP_FIELD_TYPE_DECIMAL64>(precision, scale, strs);
+        SetType values = predicate_internal::strings_to_decimal_set<OLAP_FIELD_TYPE_DECIMAL64>(scale, strs);
         return new ColumnNotInPredicate<OLAP_FIELD_TYPE_DECIMAL64>(type_info, id, std::move(values));
     }
     case OLAP_FIELD_TYPE_DECIMAL128: {
-        const auto precision = type_info->precision();
         const auto scale = type_info->scale();
         using SetType = ItemHashSet<CppTypeTraits<OLAP_FIELD_TYPE_DECIMAL128>::CppType>;
-        SetType values = predicate_internal::strings_to_decimal_set<OLAP_FIELD_TYPE_DECIMAL128>(precision, scale, strs);
+        SetType values = predicate_internal::strings_to_decimal_set<OLAP_FIELD_TYPE_DECIMAL128>(scale, strs);
         return new ColumnNotInPredicate<OLAP_FIELD_TYPE_DECIMAL128>(type_info, id, std::move(values));
     }
     case OLAP_FIELD_TYPE_CHAR:

--- a/be/src/storage/vectorized/in_predicate_utils.h
+++ b/be/src/storage/vectorized/in_predicate_utils.h
@@ -103,13 +103,13 @@ inline Converter<typename CppTypeTraits<field_type>::CppType> strings_to_set(con
 
 template <FieldType field_type>
 inline Converter<typename CppTypeTraits<field_type>::CppType> strings_to_decimal_set(
-        int precision, int scale, const std::vector<std::string>& strings) {
+        int scale, const std::vector<std::string>& strings) {
     using CppType = typename CppTypeTraits<field_type>::CppType;
     Converter<CppType> result;
     for (const auto& s : strings) {
         CppType v;
-        auto st = DecimalV3Cast::from_string<CppType>(&v, precision, scale, s.data(), s.size());
-        CHECK_EQ(OLAP_SUCCESS, st);
+        auto st = DecimalV3Cast::from_string_with_overflow_allowed<CppType>(&v, scale, s.data(), s.size());
+        CHECK_EQ(false, st);
         result.push_back(v);
     }
     return result;


### PR DESCRIPTION
## Bugfix

If a decimal string is too large so that it can not be represented in decimal, then try to convert it into double value, and the double value shall be greater than the integer part of max decimal or less than the integer part of min decimal, in such situations, (max decimal + 1) and (min decimal - 1) are final result respectively. this function is used in `IN` predicates and for the purpose that convert sets of decimal strings into valid decimal values, in these scenarios, that overflow values are handled as max + 1 or min - 1 values is accepted.  for an example, decimal(7,2)'s max and min value are 99999.99 and -99999.99, when `IN` predicate is col_decimal32p7s2 in ('123456.78', '-3.14E307'), both '123456.78' and '3.14E307' overflows, so 1000000.00 and -1000000.00 are used instead.