### PR TITLE
[SR-3811] fix possible compiler optimization error

### DIFF
--- a/be/src/exprs/agg/distinct.h
+++ b/be/src/exprs/agg/distinct.h
@@ -176,13 +176,11 @@ struct DistinctAggregateStateV2<PT, FixedLengthPTGuard<PT>> {
 
         size_t old_size = set.size();
         src += sizeof(size);
-        const T* data = reinterpret_cast<const T*>(src);
-        static const size_t prefetch_dist = 4;
         for (size_t i = 0; i < size; i++) {
-            if ((i + prefetch_dist) < size) {
-                set.prefetch(data[i + prefetch_dist]);
-            }
-            set.insert(data[i]);
+            T key;
+            memcpy(&key, src, sizeof(T));
+            set.insert(key);
+            src += sizeof(T);
         }
         size_t new_size = set.size();
         return (new_size - old_size) * item_size;
@@ -267,7 +265,8 @@ public:
             if (slice.size > 16) {
                 mem_usage += this->data(state).deserialize_and_merge((const uint8_t*)slice.data, slice.size);
             } else {
-                T key = *reinterpret_cast<T*>(slice.data);
+                T key;
+                memcpy(&key, slice.data, sizeof(T));
                 mem_usage += this->data(state).update(key);
             }
         }


### PR DESCRIPTION
ref: #211 

`vmovdqa` requires mem address to be 32 bytes aligned, but `$rbx % 32 != 0`.  I guess the root cause is to`reinterpret_cast` brings undefined behavior. To eliminate that, we use `memcpy` here instead.

And since I'm not quite sure if prefetch has real benefit or, it's better not to use it here unless we can be sure about that.

![image](https://user-images.githubusercontent.com/1081215/133201111-58a251d9-3cb4-4e1d-b9c3-49a0871d6621.png)
