### PR TITLE
[Thirdparty] Upgrade apache arrow from 0.15.1 to 5.0.0

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -215,9 +215,6 @@ set_target_properties(zstd PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib64/
 add_library(arrow STATIC IMPORTED)
 set_target_properties(arrow PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib64/libarrow.a)
 
-add_library(double-conversion STATIC IMPORTED)
-set_target_properties(double-conversion PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib64/libdouble-conversion.a)
-
 add_library(parquet STATIC IMPORTED)
 set_target_properties(parquet PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib64/libparquet.a)
 
@@ -470,7 +467,6 @@ set(STARROCKS_DEPENDENCIES
     leveldb
     bitshuffle
     roaring
-    double-conversion
     jemalloc
     brotlicommon
     brotlidec

--- a/be/src/exec/parquet_reader.cpp
+++ b/be/src/exec/parquet_reader.cpp
@@ -149,7 +149,11 @@ void ParquetReaderWrap::close() {
 }
 
 Status ParquetReaderWrap::size(int64_t* size) {
-    _parquet->GetSize(size);
+    auto size_res = _parquet->GetSize();
+    if (!size_res.ok()) {
+        return Status::InternalError(size_res.status().ToString());
+    }
+    *size = size_res.ValueOrDie();
     return Status::OK();
 }
 
@@ -556,33 +560,34 @@ bool ParquetFile::closed() const {
     }
 }
 
-arrow::Status ParquetFile::Read(int64_t nbytes, int64_t* bytes_read, void* buffer) {
-    return ReadAt(_pos, nbytes, bytes_read, buffer);
+arrow::Result<int64_t> ParquetFile::Read(int64_t nbytes, void* buffer) {
+    return ReadAt(_pos, nbytes, buffer);
 }
 
-arrow::Status ParquetFile::ReadAt(int64_t position, int64_t nbytes, int64_t* bytes_read, void* out) {
+arrow::Result<int64_t> ParquetFile::ReadAt(int64_t position, int64_t nbytes, void* out) {
     int64_t reads = 0;
+    int64_t bytes_read = 0;
     _pos = position;
     while (nbytes > 0) {
         Status result = _file->readat(_pos, nbytes, &reads, out);
         if (!result.ok()) {
-            *bytes_read = 0;
+            bytes_read = 0;
             return arrow::Status::IOError("Readat failed.");
         }
         if (reads == 0) {
             break;
         }
-        *bytes_read += reads; // total read bytes
+        bytes_read += reads;  // total read bytes
         nbytes -= reads;      // remained bytes
         _pos += reads;
         out = (char*)out + reads;
     }
-    return arrow::Status::OK();
+    return bytes_read;
 }
 
-arrow::Status ParquetFile::GetSize(int64_t* size) {
-    *size = _file->size();
-    return arrow::Status::OK();
+arrow::Result<int64_t> ParquetFile::GetSize() {
+    int64_t size = _file->size();
+    return size;
 }
 
 arrow::Status ParquetFile::Seek(int64_t position) {
@@ -591,23 +596,22 @@ arrow::Status ParquetFile::Seek(int64_t position) {
     return arrow::Status::OK();
 }
 
-arrow::Status ParquetFile::Tell(int64_t* position) const {
-    *position = _pos;
-    return arrow::Status::OK();
+arrow::Result<int64_t> ParquetFile::Tell() const {
+    return _pos;
 }
 
-arrow::Status ParquetFile::Read(int64_t nbytes, std::shared_ptr<arrow::Buffer>* out) {
-    std::shared_ptr<arrow::Buffer> read_buf;
-    ARROW_RETURN_NOT_OK(arrow::AllocateBuffer(arrow::default_memory_pool(), nbytes, &read_buf));
-    int64_t bytes_read = 0;
-    ARROW_RETURN_NOT_OK(ReadAt(_pos, nbytes, &bytes_read, read_buf->mutable_data()));
+arrow::Result<std::shared_ptr<arrow::Buffer>> ParquetFile::Read(int64_t nbytes) {
+    auto buffer_res = arrow::AllocateBuffer(nbytes, arrow::default_memory_pool());
+    ARROW_RETURN_NOT_OK(buffer_res);
+    std::shared_ptr<arrow::Buffer> read_buf = std::move(buffer_res.ValueOrDie());
+    arrow::Result<int64_t> bytes_read_res = ReadAt(_pos, nbytes, read_buf->mutable_data());
+    ARROW_RETURN_NOT_OK(bytes_read_res);
     // If bytes_read is equal with read_buf's capacity, we just assign
-    if (bytes_read == nbytes) {
-        *out = std::move(read_buf);
+    if (bytes_read_res.ValueOrDie() == nbytes) {
+        return std::move(read_buf);
     } else {
-        *out = arrow::SliceBuffer(read_buf, 0, bytes_read);
+        return arrow::SliceBuffer(read_buf, 0, bytes_read_res.ValueOrDie());
     }
-    return arrow::Status::OK();
 }
 
 } // namespace starrocks

--- a/be/src/exec/parquet_reader.cpp
+++ b/be/src/exec/parquet_reader.cpp
@@ -577,8 +577,8 @@ arrow::Result<int64_t> ParquetFile::ReadAt(int64_t position, int64_t nbytes, voi
         if (reads == 0) {
             break;
         }
-        bytes_read += reads;  // total read bytes
-        nbytes -= reads;      // remained bytes
+        bytes_read += reads; // total read bytes
+        nbytes -= reads;     // remained bytes
         _pos += reads;
         out = (char*)out + reads;
     }

--- a/be/src/exec/parquet_reader.h
+++ b/be/src/exec/parquet_reader.h
@@ -56,12 +56,12 @@ class ParquetFile : public arrow::io::RandomAccessFile {
 public:
     ParquetFile(FileReader* file);
     virtual ~ParquetFile();
-    arrow::Status Read(int64_t nbytes, int64_t* bytes_read, void* buffer) override;
-    arrow::Status ReadAt(int64_t position, int64_t nbytes, int64_t* bytes_read, void* out) override;
-    arrow::Status GetSize(int64_t* size) override;
+    arrow::Result<int64_t> Read(int64_t nbytes, void* buffer) override;
+    arrow::Result<int64_t> ReadAt(int64_t position, int64_t nbytes, void* out) override;
+    arrow::Result<int64_t> GetSize() override;
     arrow::Status Seek(int64_t position) override;
-    arrow::Status Read(int64_t nbytes, std::shared_ptr<arrow::Buffer>* out) override;
-    arrow::Status Tell(int64_t* position) const override;
+    arrow::Result<std::shared_ptr<arrow::Buffer>> Read(int64_t nbytes) override;
+    arrow::Result<int64_t> Tell() const override;
     arrow::Status Close() override;
     bool closed() const override;
 

--- a/be/src/exec/parquet_writer.cpp
+++ b/be/src/exec/parquet_writer.cpp
@@ -63,9 +63,8 @@ arrow::Status ParquetOutputStream::Write(const void* data, int64_t nbytes) {
     return arrow::Status::OK();
 }
 
-arrow::Status ParquetOutputStream::Tell(int64_t* position) const {
-    *position = _cur_pos;
-    return arrow::Status::OK();
+arrow::Result<int64_t> ParquetOutputStream::Tell() const {
+    return _cur_pos;
 }
 
 arrow::Status ParquetOutputStream::Close() {

--- a/be/src/exec/parquet_writer.h
+++ b/be/src/exec/parquet_writer.h
@@ -58,7 +58,7 @@ public:
 
     arrow::Status Write(const void* data, int64_t nbytes) override;
     // return the current write position of the stream
-    arrow::Status Tell(int64_t* position) const override;
+    arrow::Result<int64_t> Tell() const override;
     arrow::Status Close() override;
 
     bool closed() const override { return _is_closed; }

--- a/be/src/exec/vectorized/parquet_reader.h
+++ b/be/src/exec/vectorized/parquet_reader.h
@@ -33,12 +33,12 @@ class ParquetChunkFile : public arrow::io::RandomAccessFile {
 public:
     ParquetChunkFile(std::shared_ptr<starrocks::RandomAccessFile> file, uint64_t pos);
     virtual ~ParquetChunkFile();
-    arrow::Status Read(int64_t nbytes, int64_t* bytes_read, void* buffer) override;
-    arrow::Status ReadAt(int64_t position, int64_t nbytes, int64_t* bytes_read, void* out) override;
-    arrow::Status GetSize(int64_t* size) override;
+    arrow::Result<int64_t> Read(int64_t nbytes, void* buffer) override;
+    arrow::Result<int64_t> ReadAt(int64_t position, int64_t nbytes, void* out) override;
+    arrow::Result<int64_t> GetSize() override;
     arrow::Status Seek(int64_t position) override;
-    arrow::Status Read(int64_t nbytes, std::shared_ptr<arrow::Buffer>* out) override;
-    arrow::Status Tell(int64_t* position) const override;
+    arrow::Result<std::shared_ptr<arrow::Buffer>> Read(int64_t nbytes) override;
+    arrow::Result<int64_t> Tell() const override;
     arrow::Status Close() override;
     bool closed() const override;
 

--- a/be/src/http/ev_http_server.cpp
+++ b/be/src/http/ev_http_server.cpp
@@ -139,7 +139,9 @@ Status EvHttpServer::_bind() {
         ss << "convert address failed, host=" << _host << ", port=" << _port;
         return Status::InternalError(ss.str());
     }
-    _server_fd = butil::tcp_listen(point, true);
+    // reuse_addr arg is removed in brpc 0.9.7 and use gflag instead.
+    // default reuse_addr is true and reuse_port is false.
+    _server_fd = butil::tcp_listen(point);
     if (_server_fd < 0) {
         char buf[64];
         std::stringstream ss;

--- a/be/src/util/block_compression.cpp
+++ b/be/src/util/block_compression.cpp
@@ -189,11 +189,13 @@ LZ4F_preferences_t Lz4fBlockCompression::_s_preferences = {
                 LZ4F_noContentChecksum,
                 LZ4F_frame,
                 0,     // unknown content size,
-                {0, 0} // reserved, must be set to 0
+                0,     // 0 == no dictID provided
+                LZ4F_noBlockChecksum
         },
-        0,            // compression level; 0 == default
-        0,            // autoflush
-        {0, 0, 0, 0}, // reserved, must be set to 0
+        0,             // compression level; 0 == default
+        0,             // autoflush
+        1,             // 1: parser favors decompression speed vs compression ratio.
+        {0, 0, 0},     // reserved, must be set to 0
 };
 
 class SnappySlicesSource : public snappy::Source {

--- a/be/src/util/block_compression.cpp
+++ b/be/src/util/block_compression.cpp
@@ -183,19 +183,14 @@ private:
 };
 
 LZ4F_preferences_t Lz4fBlockCompression::_s_preferences = {
-        {
-                LZ4F_max256KB,
-                LZ4F_blockLinked,
-                LZ4F_noContentChecksum,
-                LZ4F_frame,
-                0,     // unknown content size,
-                0,     // 0 == no dictID provided
-                LZ4F_noBlockChecksum
-        },
-        0,             // compression level; 0 == default
-        0,             // autoflush
-        1,             // 1: parser favors decompression speed vs compression ratio.
-        {0, 0, 0},     // reserved, must be set to 0
+        {LZ4F_max256KB, LZ4F_blockLinked, LZ4F_noContentChecksum, LZ4F_frame,
+         0, // unknown content size,
+         0, // 0 == no dictID provided
+         LZ4F_noBlockChecksum},
+        0,         // compression level; 0 == default
+        0,         // autoflush
+        1,         // 1: parser favors decompression speed vs compression ratio.
+        {0, 0, 0}, // reserved, must be set to 0
 };
 
 class SnappySlicesSource : public snappy::Source {

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -305,7 +305,7 @@ build_gtest() {
     cd $TP_SOURCE_DIR/$GTEST_SOURCE
     mkdir -p $BUILD_DIR && cd $BUILD_DIR
     rm -rf CMakeCache.txt CMakeFiles/
-    $CMAKE_CMD -DCMAKE_INSTALL_PREFIX=$TP_INSTALL_DIR \
+    $CMAKE_CMD -DCMAKE_INSTALL_PREFIX=$TP_INSTALL_DIR -DCMAKE_INSTALL_LIBDIR=lib \
     -DCMAKE_POSITION_INDEPENDENT_CODE=On ../
     make -j$PARALLEL && make install
 }
@@ -333,7 +333,6 @@ build_snappy() {
     make -j$PARALLEL && make install
     if [ -f $TP_INSTALL_DIR/lib64/libsnappy.a ]; then
         mkdir -p $TP_INSTALL_DIR/lib && cp $TP_INSTALL_DIR/lib64/libsnappy.a $TP_INSTALL_DIR/lib/libsnappy.a
-
     fi
 
     #build for libarrow.a

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -123,7 +123,7 @@ check_prerequest "libtoolize --version" "libtool"
 # Name of cmake build directory in each thirdpary project.
 # Do not use `build`, because many projects contained a file named `BUILD`
 # and if the filesystem is not case sensitive, `mkdir` will fail.
-BUILD_DIR=starocks_build
+BUILD_DIR=starrocks_build
 
 check_if_source_exist() {
     if [ -z $1 ]; then
@@ -259,8 +259,8 @@ build_protobuf() {
     check_if_source_exist $PROTOBUF_SOURCE
     cd $TP_SOURCE_DIR/$PROTOBUF_SOURCE
     rm -fr gmock
-    mkdir gmock && cd gmock && tar xf ${TP_SOURCE_DIR}/googletest-release-1.8.0.tar.gz \
-    && mv googletest-release-1.8.0 gtest && cd $TP_SOURCE_DIR/$PROTOBUF_SOURCE && ./autogen.sh
+    mkdir gmock && cd gmock && tar xf ${TP_SOURCE_DIR}/$GTEST_NAME \
+    && mv $GTEST_SOURCE gtest && cd $TP_SOURCE_DIR/$PROTOBUF_SOURCE && ./autogen.sh
     CXXFLAGS="-fPIC -O2 -I ${TP_INCLUDE_DIR}" \
     LDFLAGS="-L${TP_LIB_DIR} -static-libstdc++ -static-libgcc" \
     ./configure --prefix=${TP_INSTALL_DIR} --disable-shared --enable-static --with-zlib=${TP_INSTALL_DIR}/include
@@ -445,7 +445,7 @@ build_brpc() {
     $CMAKE_CMD -v -DBUILD_SHARED_LIBS=0 -DCMAKE_INSTALL_PREFIX=$TP_INSTALL_DIR \
     -DBRPC_WITH_GLOG=ON -DWITH_GLOG=ON -DCMAKE_INCLUDE_PATH="$TP_INSTALL_DIR/include" \
     -DCMAKE_LIBRARY_PATH="$TP_INSTALL_DIR/lib;$TP_INSTALL_DIR/lib64" \
-    -DPROTOBUF_PROTOC_EXECUTABLE=$TP_INSTALL_DIR/bin/protoc ..
+    -DProtobuf_PROTOC_EXECUTABLE=$TP_INSTALL_DIR/bin/protoc ..
     make -j$PARALLEL && make install
     if [ -f $TP_INSTALL_DIR/lib/libbrpc.a ]; then
         mkdir -p $TP_INSTALL_DIR/lib64 && cp $TP_INSTALL_DIR/lib/libbrpc.a $TP_INSTALL_DIR/lib64/libbrpc.a

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -380,7 +380,7 @@ build_lz4() {
     cd $TP_SOURCE_DIR/$LZ4_SOURCE
 
     make -j$PARALLEL install PREFIX=$TP_INSTALL_DIR \
-    INCLUDEDIR=$TP_INCLUDE_DIR/lz4/
+    INCLUDEDIR=$TP_INCLUDE_DIR/lz4/ BUILD_SHARED=no
 }
 
 # bzip

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -500,15 +500,18 @@ build_arrow() {
     check_if_source_exist $ARROW_SOURCE
     cd $TP_SOURCE_DIR/$ARROW_SOURCE/cpp && mkdir -p release && cd release
     export ARROW_BROTLI_URL=${TP_SOURCE_DIR}/${BROTLI_NAME}
-    export ARROW_DOUBLE_CONVERSION_URL=${TP_SOURCE_DIR}/${DOUBLE_CONVERSION_NAME}
     export ARROW_GLOG_URL=${TP_SOURCE_DIR}/${GLOG_NAME}
     export ARROW_LZ4_URL=${TP_SOURCE_DIR}/${LZ4_NAME}
+    export ARROW_SNAPPY_URL=${TP_SOURCE_DIR}/${SNAPPY_NAME}
+    export ARROW_ZLIB_URL=${TP_SOURCE_DIR}/${ZLIB_NAME}
     export ARROW_FLATBUFFERS_URL=${TP_SOURCE_DIR}/${FLATBUFFERS_NAME}
     export ARROW_ZSTD_URL=${TP_SOURCE_DIR}/${ZSTD_NAME}
     export ARROW_JEMALLOC_URL=${TP_SOURCE_DIR}/${JEMALLOC_NAME}
     export LDFLAGS="-L${TP_LIB_DIR} -static-libstdc++ -static-libgcc"
 
-    ${CMAKE_CMD} -DARROW_PARQUET=ON -DARROW_IPC=ON -DARROW_USE_GLOG=off -DARROW_BUILD_SHARED=OFF \
+    ${CMAKE_CMD} -DARROW_PARQUET=ON -DARROW_JSON=ON -DARROW_IPC=ON -DARROW_USE_GLOG=OFF -DARROW_BUILD_SHARED=OFF \
+    -DARROW_WITH_BROTLI=ON -DARROW_WITH_LZ4=ON -DARROW_WITH_SNAPPY=ON -DARROW_WITH_ZLIB=ON -DARROW_WITH_ZSTD=ON \
+    -DARROW_WITH_UTF8PROC=OFF -DARROW_WITH_RE2=OFF \
     -DCMAKE_INSTALL_PREFIX=$TP_INSTALL_DIR \
     -DCMAKE_INSTALL_LIBDIR=lib64 \
     -DARROW_BOOST_USE_SHARED=OFF -DARROW_GFLAGS_USE_SHARED=OFF -DBoost_NO_BOOST_CMAKE=ON -DBOOST_ROOT=$TP_INSTALL_DIR \
@@ -531,7 +534,6 @@ build_arrow() {
     fi
     # copy zstd headers
     mkdir -p ${TP_INSTALL_DIR}/include/zstd && cp ./zstd_ep-install/include/* ${TP_INSTALL_DIR}/include/zstd
-    cp -rf ./double-conversion_ep/src/double-conversion_ep/lib/libdouble-conversion.a $TP_INSTALL_DIR/lib64/libdouble-conversion.a
 }
 
 # s2

--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -261,7 +261,7 @@ echo "Finished patching $LIBEVENT_SOURCE"
 
 # lz4 patch to disable shared library
 cd $TP_SOURCE_DIR/$LZ4_SOURCE
-if [ ! -f $PATCHED_MARK ]; then
+if [ ! -f $PATCHED_MARK ] && [ $LZ4_SOURCE == "lz4-1.7.5" ]; then
     patch -p0 < $TP_PATCH_DIR/lz4-1.7.5.patch
     touch $PATCHED_MARK
 fi
@@ -312,7 +312,7 @@ echo "Finished patching $BOOST_SOURCE"
 
 # patch protobuf-3.5.1
 cd $TP_SOURCE_DIR/$PROTOBUF_SOURCE
-if [ ! -f $PATCHED_MARK ]; then
+if [ ! -f $PATCHED_MARK ] && [ $PROTOBUF_SOURCE == "protobuf-3.5.1" ]; then
     patch -p1 < $TP_PATCH_DIR/protobuf-3.5.1.patch
     touch $PATCHED_MARK
 fi

--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -221,12 +221,16 @@ PATCHED_MARK="patched_mark"
 
 # glog patch
 cd $TP_SOURCE_DIR/$GLOG_SOURCE
-if [ ! -f $PATCHED_MARK ]; then
+if [ ! -f $PATCHED_MARK ] && [ $GLOG_SOURCE == "glog-0.3.3" ]; then
     patch -p1 < $TP_PATCH_DIR/glog-0.3.3-vlog-double-lock-bug.patch
     patch -p1 < $TP_PATCH_DIR/glog-0.3.3-for-starrocks2.patch
     patch -p1 < $TP_PATCH_DIR/glog-0.3.3-remove-unwind-dependency.patch
     # patch Makefile.am to make autoreconf work
     patch -p0 < $TP_PATCH_DIR/glog-0.3.3-makefile.patch
+    touch $PATCHED_MARK
+fi
+if [ ! -f $PATCHED_MARK ] && [ $GLOG_SOURCE == "glog-0.4.0" ]; then
+    patch -p1 < $TP_PATCH_DIR/glog-0.4.0-for-starrocks2.patch
     touch $PATCHED_MARK
 fi
 cd -

--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -143,7 +143,7 @@ do
         URL="${REPOSITORY_URL}/${!NAME}"
         download_func ${!NAME} ${URL} $TP_SOURCE_DIR ${!MD5SUM}
         if [ "$?x" == "0x" ]; then
-            #try to download from home 
+            #try to download from home
             URL=$TP_ARCH"_DOWNLOAD"
             download_func ${!NAME} ${!URL} $TP_SOURCE_DIR ${!MD5SUM}
             if [ "$?x" == "0x" ]; then
@@ -235,7 +235,7 @@ echo "Finished patching $GLOG_SOURCE"
 # re2 patch
 cd $TP_SOURCE_DIR/$RE2_SOURCE
 if [ ! -f $PATCHED_MARK ]; then
-    patch -p0 < $TP_PATCH_DIR/re2-2017-05-01.patch 
+    patch -p0 < $TP_PATCH_DIR/re2-2017-05-01.patch
     touch $PATCHED_MARK
 fi
 cd -
@@ -272,6 +272,10 @@ echo "Finished patching $LZ4_SOURCE"
 cd $TP_SOURCE_DIR/$BRPC_SOURCE
 if [ ! -f $PATCHED_MARK ] && [ $BRPC_SOURCE == "incubator-brpc-0.9.5" ]; then
     patch -p1 < $TP_PATCH_DIR/incubator-brpc-0.9.5.patch
+    touch $PATCHED_MARK
+fi
+if [ ! -f $PATCHED_MARK ] && [ $BRPC_SOURCE == "incubator-brpc-0.9.7" ]; then
+    patch -p1 < $TP_PATCH_DIR/incubator-brpc-0.9.7.patch
     touch $PATCHED_MARK
 fi
 cd -

--- a/thirdparty/patches/glog-0.4.0-for-starrocks2.patch
+++ b/thirdparty/patches/glog-0.4.0-for-starrocks2.patch
@@ -1,0 +1,391 @@
+diff --git a/src/glog/logging.h.in b/src/glog/logging.h.in
+index 9968b96..ff7c1c2 100644
+--- a/src/glog/logging.h.in
++++ b/src/glog/logging.h.in
+@@ -330,6 +330,11 @@ typedef unsigned __int64 uint64;
+   using fLS::FLAGS_##name
+ #endif
+ 
++DECLARE_int32(log_filenum_quota);
++
++DECLARE_string(log_split_method);
++
++
+ // Set whether log messages go to stderr instead of logfiles
+ DECLARE_bool(logtostderr);
+ 
+diff --git a/src/logging.cc b/src/logging.cc
+index 0c86cf6..d846a4e 100644
+--- a/src/logging.cc
++++ b/src/logging.cc
+@@ -49,13 +49,17 @@
+ #include <iostream>
+ #include <stdarg.h>
+ #include <stdlib.h>
++#include <dirent.h>
+ #ifdef HAVE_PWD_H
+ # include <pwd.h>
+ #endif
+ #ifdef HAVE_SYSLOG_H
+ # include <syslog.h>
+ #endif
++#include <algorithm>
+ #include <vector>
++#include <list>
++#include <string>
+ #include <errno.h>                   // for errno
+ #include <sstream>
+ #include "base/commandlineflags.h"        // to get the program name
+@@ -172,6 +176,12 @@ GLOG_DEFINE_int32(max_log_size, 1800,
+                   "approx. maximum log file size (in MB). A value of 0 will "
+                   "be silently overridden to 1.");
+ 
++GLOG_DEFINE_string(log_split_method, "day",
++                  "split log by size, day, hour");
++
++GLOG_DEFINE_int32(log_filenum_quota, 10,
++				   "max log file num in log dir");
++
+ GLOG_DEFINE_bool(stop_logging_if_full_disk, false,
+                  "Stop attempting to log to disk if the disk is full.");
+ 
+@@ -394,6 +404,15 @@ base::Logger::~Logger() {
+ 
+ namespace {
+ 
++typedef struct filetime {
++    std::string name;
++    time_t time;
++
++    bool operator < (const struct filetime& o) const {
++        return o.time > time;
++    }
++}Filetime;
++
+ // Encapsulates all file-system related state
+ class LogFileObject : public base::Logger {
+  public:
+@@ -425,6 +444,8 @@ class LogFileObject : public base::Logger {
+   // acquiring lock_.
+   void FlushUnlocked();
+ 
++  void CheckFileNumQuota();
++
+  private:
+   static const uint32 kRolloverAttemptFrequency = 0x20;
+ 
+@@ -440,6 +461,9 @@ class LogFileObject : public base::Logger {
+   uint32 file_length_;
+   unsigned int rollover_attempt_;
+   int64 next_flush_time_;         // cycle count at which to flush log
++  std::list<Filetime> file_list_;
++  bool inited_;
++  struct ::tm tm_time_;
+ 
+   // Actually create a logfile using the value of base_filename_ and the
+   // supplied argument time_pid_string
+@@ -458,7 +482,7 @@ class LogDestination {
+ 
+   // These methods are just forwarded to by their global versions.
+   static void SetLogDestination(LogSeverity severity,
+-				const char* base_filename);
++          const char* base_filename);
+   static void SetLogSymlink(LogSeverity severity,
+                             const char* symlink_basename);
+   static void AddLogSink(LogSink *destination);
+@@ -490,17 +514,17 @@ class LogDestination {
+   // Take a log message of a particular severity and log it to stderr
+   // iff it's of a high enough severity to deserve it.
+   static void MaybeLogToStderr(LogSeverity severity, const char* message,
+-			       size_t len);
++          size_t len);
+ 
+   // Take a log message of a particular severity and log it to email
+   // iff it's of a high enough severity to deserve it.
+   static void MaybeLogToEmail(LogSeverity severity, const char* message,
+-			      size_t len);
++          size_t len);
+   // Take a log message of a particular severity and log it to a file
+   // iff the base filename is not "" (which means "don't log to me")
+   static void MaybeLogToLogfile(LogSeverity severity,
+                                 time_t timestamp,
+-				const char* message, size_t len);
++                                const char* message, size_t len);
+   // Take a log message of a particular severity and log it to the file
+   // for that severity and also for all files with severity less than
+   // this severity.
+@@ -589,7 +613,7 @@ inline void LogDestination::FlushLogFiles(int min_severity) {
+   // all this stuff.
+   MutexLock l(&log_mutex);
+   for (int i = min_severity; i < NUM_SEVERITIES; i++) {
+-    LogDestination* log = log_destination(i);
++    LogDestination* log = log_destinations_[i];
+     if (log != NULL) {
+       log->logger_->Flush();
+     }
+@@ -664,7 +688,7 @@ inline void LogDestination::LogToStderr() {
+ }
+ 
+ inline void LogDestination::SetEmailLogging(LogSeverity min_severity,
+-					    const char* addresses) {
++        const char* addresses) {
+   assert(min_severity >= 0 && min_severity < NUM_SEVERITIES);
+   // Prevent any subtle race conditions by wrapping a mutex lock around
+   // all this stuff.
+@@ -717,7 +741,7 @@ static void WriteToStderr(const char* message, size_t len) {
+ }
+ 
+ inline void LogDestination::MaybeLogToStderr(LogSeverity severity,
+-					     const char* message, size_t len) {
++        const char* message, size_t len) {
+   if ((severity >= FLAGS_stderrthreshold) || FLAGS_alsologtostderr) {
+     ColoredWriteToStderr(severity, message, len);
+ #ifdef OS_WINDOWS
+@@ -756,8 +780,8 @@ inline void LogDestination::MaybeLogToEmail(LogSeverity severity,
+ 
+ inline void LogDestination::MaybeLogToLogfile(LogSeverity severity,
+                                               time_t timestamp,
+-					      const char* message,
+-					      size_t len) {
++                                              const char* message,
++                                              size_t len) {
+   const bool should_flush = severity > FLAGS_logbuflevel;
+   LogDestination* destination = log_destination(severity);
+   destination->logger_->Write(should_flush, timestamp, message, len);
+@@ -771,8 +795,12 @@ inline void LogDestination::LogToAllLogfiles(LogSeverity severity,
+   if ( FLAGS_logtostderr ) {           // global flag: never log to file
+     ColoredWriteToStderr(severity, message, len);
+   } else {
+-    for (int i = severity; i >= 0; --i)
+-      LogDestination::MaybeLogToLogfile(i, timestamp, message, len);
++    if (severity >= 1) {
++        LogDestination::MaybeLogToLogfile(1, timestamp, message, len);
++	LogDestination::MaybeLogToLogfile(0, timestamp, message, len);
++    } else if (severity == 0) {
++        LogDestination::MaybeLogToLogfile(0, timestamp, message, len);
++    } else {}
+   }
+ }
+ 
+@@ -841,7 +869,8 @@ LogFileObject::LogFileObject(LogSeverity severity,
+     dropped_mem_length_(0),
+     file_length_(0),
+     rollover_attempt_(kRolloverAttemptFrequency-1),
+-    next_flush_time_(0) {
++    next_flush_time_(0),
++    inited_(false) {
+   assert(severity >= 0);
+   assert(severity < NUM_SEVERITIES);
+ }
+@@ -906,7 +935,7 @@ bool LogFileObject::CreateLogfile(const string& time_pid_string) {
+   string string_filename = base_filename_+filename_extension_+
+                            time_pid_string;
+   const char* filename = string_filename.c_str();
+-  int fd = open(filename, O_WRONLY | O_CREAT | O_EXCL, FLAGS_logfile_mode);
++  int fd = open(filename, O_WRONLY | O_CREAT /* | O_EXCL */ | O_APPEND, 0664);
+   if (fd == -1) return false;
+ #ifdef HAVE_FCNTL
+   // Mark the file close-on-exec. We don't really care if this fails
+@@ -920,6 +949,10 @@ bool LogFileObject::CreateLogfile(const string& time_pid_string) {
+     return false;
+   }
+ 
++  Filetime ft;
++  ft.name = string_filename;
++  file_list_.push_back(ft);
++
+   // We try to create a symlink called <program_name>.<severity>,
+   // which is easier to use.  (Every time we create a new logfile,
+   // we destroy the old symlink and create a new one, so it always
+@@ -961,6 +994,59 @@ bool LogFileObject::CreateLogfile(const string& time_pid_string) {
+   return true;  // Everything worked
+ }
+ 
++void LogFileObject::CheckFileNumQuota() {
++    struct dirent *entry;
++    DIR *dp;
++
++    const vector<string> & log_dirs = GetLoggingDirectories();
++    if (log_dirs.size() < 1) return;
++
++    //fprintf(stderr, "log dir: %s\n", log_dirs[0].c_str());
++
++    // list file in log dir
++    dp = opendir(log_dirs[0].c_str());
++    if (dp == NULL) {
++        fprintf(stderr, "open log dir %s fail\n", log_dirs[0].c_str());
++        return;
++    }
++
++    file_list_.clear();
++    while ((entry = readdir(dp)) != NULL) {
++        if (DT_DIR == entry->d_type ||
++                DT_LNK == entry->d_type) {
++            continue;
++        }
++        std::string filename = std::string(entry->d_name);
++        //fprintf(stderr, "filename: %s\n", filename.c_str());
++
++        if (filename.find(symlink_basename_ + '.' + LogSeverityNames[severity_]) == 0) {			
++            std::string filepath = log_dirs[0] + "/" + filename;
++
++            struct stat fstat;
++            if (::stat(filepath.c_str(), &fstat) < 0) {
++                fprintf(stderr, "state %s fail\n", filepath.c_str());
++                closedir(dp);
++                return;
++            }
++            //fprintf(stderr, "filepath: %s\n", filepath.c_str());
++
++            Filetime file_time;
++            file_time.time = fstat.st_mtime;
++            file_time.name = filepath;
++            file_list_.push_back(file_time);
++        }
++    }
++    closedir(dp);
++
++    file_list_.sort();
++
++    while (FLAGS_log_filenum_quota > 0 && file_list_.size() >= FLAGS_log_filenum_quota) {
++       // fprintf(stderr, "delete %s\n", file_list_.front().name.c_str());
++        unlink(file_list_.front().name.c_str());
++        file_list_.pop_front();
++    }
++}
++
+ void LogFileObject::Write(bool force_flush,
+                           time_t timestamp,
+                           const char* message,
+@@ -972,14 +1058,55 @@ void LogFileObject::Write(bool force_flush,
+     return;
+   }
+ 
+-  if (static_cast<int>(file_length_ >> 20) >= MaxLogSize() ||
+-      PidHasChanged()) {
++  struct ::tm tm_time;
++
++  bool is_split = false;
++  if ("day" == FLAGS_log_split_method) {
++      localtime_r(&timestamp, &tm_time);
++      if (tm_time.tm_year != tm_time_.tm_year
++              || tm_time.tm_mon != tm_time_.tm_mon
++              || tm_time.tm_mday != tm_time_.tm_mday) {
++          is_split = true;
++      }
++  } else if ("hour" == FLAGS_log_split_method) {
++      localtime_r(&timestamp, &tm_time);
++      if (tm_time.tm_year != tm_time_.tm_year
++              || tm_time.tm_mon != tm_time_.tm_mon
++              || tm_time.tm_mday != tm_time_.tm_mday
++              || tm_time.tm_hour != tm_time_.tm_hour) {
++          is_split = true;
++      }
++  } else if (static_cast<int>(file_length_ >> 20) >= MaxLogSize()) {
++      // PidHasChanged()) {
++      is_split = true;
++  }
++
++  if (is_split) {
+     if (file_ != NULL) fclose(file_);
+     file_ = NULL;
+     file_length_ = bytes_since_flush_ = dropped_mem_length_ = 0;
+     rollover_attempt_ = kRolloverAttemptFrequency-1;
+   }
+ 
++  if ((file_ == NULL) && (!inited_) && (FLAGS_log_split_method == "size")) {
++    CheckFileNumQuota();
++    const char* filename = file_list_.back().name.c_str();
++    int fd = open(filename, O_WRONLY | O_CREAT /* | O_EXCL */ | O_APPEND, 0664);
++    if (fd != -1) {
++#ifdef HAVE_FCNTL
++      // Mark the file close-on-exec. We don't really care if this fails
++      fcntl(fd, F_SETFD, FD_CLOEXEC);
++#endif
++      file_ = fopen(filename, "a+"); // Read and append a FILE*.
++      if (file_ == NULL) {      // Man, we're screwed!, try to create new log file
++        close(fd);
++      }
++      fseek(file_, 0, SEEK_END);
++      file_length_ = bytes_since_flush_ = ftell(file_);
++      inited_ = true;
++    }
++  }
++
+   // If there's no destination file, make one before outputting
+   if (file_ == NULL) {
+     // Try to rollover the log file every 32 log messages.  The only time
+@@ -988,21 +1115,35 @@ void LogFileObject::Write(bool force_flush,
+     if (++rollover_attempt_ != kRolloverAttemptFrequency) return;
+     rollover_attempt_ = 0;
+ 
+-    struct ::tm tm_time;
+-    localtime_r(&timestamp, &tm_time);
++    if (!inited_) {
++        CheckFileNumQuota();
++        inited_ = true;
++    } else {
++        while (FLAGS_log_filenum_quota > 0 && file_list_.size() >= FLAGS_log_filenum_quota) {
++            unlink(file_list_.front().name.c_str());
++            file_list_.pop_front();
++        }
++    }
+ 
++	localtime_r(&timestamp, &tm_time);
+     // The logfile's filename will have the date/time & pid in it
+     ostringstream time_pid_stream;
+     time_pid_stream.fill('0');
+     time_pid_stream << 1900+tm_time.tm_year
+                     << setw(2) << 1+tm_time.tm_mon
+-                    << setw(2) << tm_time.tm_mday
+-                    << '-'
+-                    << setw(2) << tm_time.tm_hour
+-                    << setw(2) << tm_time.tm_min
+-                    << setw(2) << tm_time.tm_sec
+-                    << '.'
+-                    << GetMainThreadPid();
++                    << setw(2) << tm_time.tm_mday;
++
++    if ("hour" == FLAGS_log_split_method) {
++        time_pid_stream << setw(2) << tm_time.tm_hour;
++    } else if ("day" != FLAGS_log_split_method) {
++        time_pid_stream << '-'
++            << setw(2) << tm_time.tm_hour
++            << setw(2) << tm_time.tm_min
++            << setw(2) << tm_time.tm_sec;
++    }
++    
++    tm_time_ = tm_time;
++
+     const string& time_pid_string = time_pid_stream.str();
+ 
+     if (base_filename_selected_) {
+@@ -1036,9 +1177,7 @@ void LogFileObject::Write(bool force_flush,
+       // deadlock. Simply use a name like invalid-user.
+       if (uidname.empty()) uidname = "invalid-user";
+ 
+-      stripped_filename = stripped_filename+'.'+hostname+'.'
+-                          +uidname+".log."
+-                          +LogSeverityNames[severity_]+'.';
++      stripped_filename = stripped_filename + "." + LogSeverityNames[severity_] + ".log.";
+       // We're going to (potentially) try to put logs in several different dirs
+       const vector<string> & log_dirs = GetLoggingDirectories();
+ 
+@@ -1062,7 +1201,8 @@ void LogFileObject::Write(bool force_flush,
+         return;
+       }
+     }
+-
++    
++    /*
+     // Write a header message into the log file
+     ostringstream file_header_stream;
+     file_header_stream.fill('0');
+@@ -1084,6 +1224,7 @@ void LogFileObject::Write(bool force_flush,
+     fwrite(file_header_string.data(), 1, header_len, file_);
+     file_length_ += header_len;
+     bytes_since_flush_ += header_len;
++    */
+   }
+ 
+   // Write to LOG file

--- a/thirdparty/patches/incubator-brpc-0.9.7.patch
+++ b/thirdparty/patches/incubator-brpc-0.9.7.patch
@@ -1,0 +1,61 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3deb7342..13f739c6 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -115,13 +115,13 @@ set(CMAKE_C_FLAGS "${CMAKE_CPP_FLAGS} -O2 -pipe -Wall -W -fPIC -fstrict-aliasing
+ macro(use_cxx11)
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
++        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
+     endif()
+     if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
++        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
+     endif()
+ else()
+-    set(CMAKE_CXX_STANDARD 11)
++    set(CMAKE_CXX_STANDARD 17)
+     set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ endif()
+ endmacro(use_cxx11)
+@@ -134,7 +134,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse4 -msse4.2")
+     elseif((CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64"))
+         # segmentation fault in libcontext
+-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-gcse")
++        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-gcse -w")
+     endif()
+     if(NOT (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0))
+         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-aligned-new")
+@@ -194,6 +194,7 @@ set(DYNAMIC_LIB
+     ${GFLAGS_LIBRARY}
+     ${PROTOBUF_LIBRARIES}
+     ${LEVELDB_LIB}
++    snappy
+     ${PROTOC_LIB}
+     ${CMAKE_THREAD_LIBS_INIT}
+     ${THRIFT_LIB}
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index ee616eb1..b39f8d40 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -62,11 +62,13 @@ add_executable(protoc-gen-mcpack ${protoc_gen_mcpack_SOURCES})
+ target_link_libraries(protoc-gen-mcpack brpc-shared)
+     
+ #install directory
+-install(TARGETS brpc-shared
+-        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-        )
++if(BUILD_SHARED_LIBS)
++    install(TARGETS brpc-shared
++            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
++            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++            )
++endif()
+ 
+ install(TARGETS brpc-static
+         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -97,10 +97,10 @@ GTEST_SOURCE=googletest-release-1.8.0
 GTEST_MD5SUM="16877098823401d1bf2ed7891d7dce36"
 
 # snappy
-SNAPPY_DOWNLOAD="https://github.com/google/snappy/archive/1.1.7.tar.gz"
-SNAPPY_NAME=snappy-1.1.7.tar.gz
-SNAPPY_SOURCE=snappy-1.1.7
-SNAPPY_MD5SUM="ee9086291c9ae8deb4dac5e0b85bf54a"
+SNAPPY_DOWNLOAD="https://github.com/google/snappy/archive/1.1.8.tar.gz"
+SNAPPY_NAME=snappy-1.1.8.tar.gz
+SNAPPY_SOURCE=snappy-1.1.8
+SNAPPY_MD5SUM="70e48cba7fecf289153d009791c9977f"
 
 # gperftools
 GPERFTOOLS_DOWNLOAD="https://github.com/gperftools/gperftools/archive/gperftools-2.7.tar.gz"
@@ -115,10 +115,10 @@ ZLIB_SOURCE=zlib-1.2.11
 ZLIB_MD5SUM="1c9f62f0778697a09d36121ead88e08e"
 
 # lz4
-LZ4_DOWNLOAD="https://github.com/lz4/lz4/archive/v1.7.5.tar.gz"
-LZ4_NAME=lz4-1.7.5.tar.gz
-LZ4_SOURCE=lz4-1.7.5
-LZ4_MD5SUM="c9610c5ce97eb431dddddf0073d919b9"
+LZ4_DOWNLOAD="https://github.com/lz4/lz4/archive/v1.9.3.tar.gz"
+LZ4_NAME=lz4-1.9.3.tar.gz
+LZ4_SOURCE=lz4-1.9.3
+LZ4_MD5SUM="3a1ab1684e14fc1afc66228ce61b2db3"
 
 # bzip
 BZIP_DOWNLOAD="https://fossies.org/linux/misc/bzip2-1.0.8.tar.gz"
@@ -176,10 +176,10 @@ LIBRDKAFKA_SOURCE=librdkafka-1.7.0
 LIBRDKAFKA_MD5SUM="fe3c45deb182bd9c644b6bc6375bffc3"
 
 # zstd
-ZSTD_DOWNLOAD="https://github.com/facebook/zstd/archive/v1.3.7.tar.gz"
-ZSTD_NAME=zstd-1.3.7.tar.gz
-ZSTD_SOURCE=zstd-1.3.7
-ZSTD_MD5SUM="9b89923a360ac85a3b8076fdf495318d"
+ZSTD_DOWNLOAD="https://github.com/facebook/zstd/archive/v1.5.0.tar.gz"
+ZSTD_NAME=zstd-1.5.0.tar.gz
+ZSTD_SOURCE=zstd-1.5.0
+ZSTD_MD5SUM="d5ac89d5df9e81243ce40d0c6a66691d"
 
 # double-conversion
 DOUBLE_CONVERSION_DOWNLOAD="https://github.com/google/double-conversion/archive/v3.1.1.tar.gz"
@@ -188,10 +188,10 @@ DOUBLE_CONVERSION_SOURCE=double-conversion-3.1.1
 DOUBLE_CONVERSION_MD5SUM="befd431c3de3f3ed7926ba2845ee609d"
 
 # brotli
-BROTLI_DOWNLOAD="https://github.com/google/brotli/archive/v1.0.7.tar.gz"
-BROTLI_NAME="brotli-1.0.7.tar.gz"
-BROTLI_SOURCE="brotli-1.0.7"
-BROTLI_MD5SUM="7b6edd4f2128f22794d0ca28c53898a5"
+BROTLI_DOWNLOAD="https://github.com/google/brotli/archive/v1.0.9.tar.gz"
+BROTLI_NAME="brotli-1.0.9.tar.gz"
+BROTLI_SOURCE="brotli-1.0.9"
+BROTLI_MD5SUM="c2274f0c7af8470ad514637c35bcee7d"
 
 # flatbuffers
 FLATBUFFERS_DOWNLOAD="https://github.com/google/flatbuffers/archive/v1.10.0.tar.gz"
@@ -200,10 +200,10 @@ FLATBUFFERS_SOURCE=flatbuffers-1.10.0
 FLATBUFFERS_MD5SUM="f7d19a3f021d93422b0bc287d7148cd2"
 
 # arrow
-ARROW_DOWNLOAD="https://github.com/apache/arrow/archive/apache-arrow-0.15.1.tar.gz"
-ARROW_NAME="arrow-apache-arrow-0.15.1.tar.gz"
-ARROW_SOURCE="arrow-apache-arrow-0.15.1"
-ARROW_MD5SUM="7d822863bbbe409794c6cdec3dcb8e6c"
+ARROW_DOWNLOAD="https://github.com/apache/arrow/archive/apache-arrow-5.0.0.tar.gz"
+ARROW_NAME="arrow-apache-arrow-5.0.0.tar.gz"
+ARROW_SOURCE="arrow-apache-arrow-5.0.0"
+ARROW_MD5SUM="9caf5dbd36ef4972c3a591bcfeaf59c8"
 
 # S2
 S2_DOWNLOAD="https://github.com/google/s2geometry/archive/v0.9.0.tar.gz"

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -73,10 +73,10 @@ THRIFT_SOURCE=thrift-0.13.0
 THRIFT_MD5SUM="38a27d391a2b03214b444cb13d5664f1"
 
 # protobuf
-PROTOBUF_DOWNLOAD="https://github.com/google/protobuf/archive/v3.5.1.tar.gz"
-PROTOBUF_NAME=protobuf-3.5.1.tar.gz
-PROTOBUF_SOURCE=protobuf-3.5.1
-PROTOBUF_MD5SUM="710f1a75983092c9b45ecef207236104"
+PROTOBUF_DOWNLOAD="https://github.com/google/protobuf/archive/v3.14.0.tar.gz"
+PROTOBUF_NAME=protobuf-3.14.0.tar.gz
+PROTOBUF_SOURCE=protobuf-3.14.0
+PROTOBUF_MD5SUM="0c9d2a96f3656ba7ef3b23b533fb6170"
 
 # gflags
 GFLAGS_DOWNLOAD="https://github.com/gflags/gflags/archive/v2.2.2.tar.gz"
@@ -158,10 +158,10 @@ LEVELDB_SOURCE=leveldb-1.20
 LEVELDB_MD5SUM="298b5bddf12c675d6345784261302252"
 
 # brpc
-BRPC_DOWNLOAD="https://github.com/apache/incubator-brpc/archive/0.9.5.tar.gz"
-BRPC_NAME=incubator-brpc-0.9.5.tar.gz
-BRPC_SOURCE=incubator-brpc-0.9.5
-BRPC_MD5SUM="c9f46e4c97a9cd5f836ba2c6c56978dd"
+BRPC_DOWNLOAD="https://github.com/apache/incubator-brpc/archive/0.9.7.tar.gz"
+BRPC_NAME=incubator-brpc-0.9.7.tar.gz
+BRPC_SOURCE=incubator-brpc-0.9.7
+BRPC_MD5SUM="a5b79339d139d1c55d39689c0a69bcef"
 
 # rocksdb
 ROCKSDB_DOWNLOAD="https://github.com/facebook/rocksdb/archive/refs/tags/v6.22.1.zip"

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -73,10 +73,10 @@ THRIFT_SOURCE=thrift-0.13.0
 THRIFT_MD5SUM="38a27d391a2b03214b444cb13d5664f1"
 
 # protobuf
-PROTOBUF_DOWNLOAD="https://github.com/google/protobuf/archive/v3.14.0.tar.gz"
-PROTOBUF_NAME=protobuf-3.14.0.tar.gz
-PROTOBUF_SOURCE=protobuf-3.14.0
-PROTOBUF_MD5SUM="0c9d2a96f3656ba7ef3b23b533fb6170"
+PROTOBUF_DOWNLOAD="https://github.com/google/protobuf/archive/v3.5.1.tar.gz"
+PROTOBUF_NAME=protobuf-3.5.1.tar.gz
+PROTOBUF_SOURCE=protobuf-3.5.1
+PROTOBUF_MD5SUM="710f1a75983092c9b45ecef207236104"
 
 # gflags
 GFLAGS_DOWNLOAD="https://github.com/gflags/gflags/archive/v2.2.2.tar.gz"

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -73,16 +73,16 @@ THRIFT_SOURCE=thrift-0.13.0
 THRIFT_MD5SUM="38a27d391a2b03214b444cb13d5664f1"
 
 # protobuf
-PROTOBUF_DOWNLOAD="https://github.com/google/protobuf/archive/v3.5.1.tar.gz"
-PROTOBUF_NAME=protobuf-3.5.1.tar.gz
-PROTOBUF_SOURCE=protobuf-3.5.1
-PROTOBUF_MD5SUM="710f1a75983092c9b45ecef207236104"
+PROTOBUF_DOWNLOAD="https://github.com/google/protobuf/archive/v3.14.0.tar.gz"
+PROTOBUF_NAME=protobuf-3.14.0.tar.gz
+PROTOBUF_SOURCE=protobuf-3.14.0
+PROTOBUF_MD5SUM="0c9d2a96f3656ba7ef3b23b533fb6170"
 
 # gflags
-GFLAGS_DOWNLOAD="https://github.com/gflags/gflags/archive/v2.2.0.tar.gz"
-GFLAGS_NAME=gflags-2.2.0.tar.gz
-GFLAGS_SOURCE=gflags-2.2.0
-GFLAGS_MD5SUM="b99048d9ab82d8c56e876fb1456c285e"
+GFLAGS_DOWNLOAD="https://github.com/gflags/gflags/archive/v2.2.2.tar.gz"
+GFLAGS_NAME=gflags-2.2.2.tar.gz
+GFLAGS_SOURCE=gflags-2.2.2
+GFLAGS_MD5SUM="1a865b93bacfa963201af3f75b7bd64c"
 
 # glog
 GLOG_DOWNLOAD="https://github.com/google/glog/archive/v0.3.3.tar.gz"
@@ -91,10 +91,10 @@ GLOG_SOURCE=glog-0.3.3
 GLOG_MD5SUM="c1f86af27bd9c73186730aa957607ed0"
 
 # gtest
-GTEST_DOWNLOAD="https://github.com/google/googletest/archive/release-1.8.0.tar.gz"
-GTEST_NAME=googletest-release-1.8.0.tar.gz
-GTEST_SOURCE=googletest-release-1.8.0
-GTEST_MD5SUM="16877098823401d1bf2ed7891d7dce36"
+GTEST_DOWNLOAD="https://github.com/google/googletest/archive/release-1.10.0.tar.gz"
+GTEST_NAME=googletest-release-1.10.0.tar.gz
+GTEST_SOURCE=googletest-release-1.10.0
+GTEST_MD5SUM="ecd1fa65e7de707cd5c00bdac56022cd"
 
 # snappy
 SNAPPY_DOWNLOAD="https://github.com/google/snappy/archive/1.1.8.tar.gz"
@@ -181,12 +181,6 @@ ZSTD_NAME=zstd-1.5.0.tar.gz
 ZSTD_SOURCE=zstd-1.5.0
 ZSTD_MD5SUM="d5ac89d5df9e81243ce40d0c6a66691d"
 
-# double-conversion
-DOUBLE_CONVERSION_DOWNLOAD="https://github.com/google/double-conversion/archive/v3.1.1.tar.gz"
-DOUBLE_CONVERSION_NAME=double-conversion-3.1.1.tar.gz
-DOUBLE_CONVERSION_SOURCE=double-conversion-3.1.1
-DOUBLE_CONVERSION_MD5SUM="befd431c3de3f3ed7926ba2845ee609d"
-
 # brotli
 BROTLI_DOWNLOAD="https://github.com/google/brotli/archive/v1.0.9.tar.gz"
 BROTLI_NAME="brotli-1.0.9.tar.gz"
@@ -266,7 +260,7 @@ JDK_SOURCE="java-se-8u41-ri"
 JDK_MD5SUM="7295b5a3fb90e7aaf80df23d5eac222d"
 
 # RAGEL
-# ragel-6.9+ is used by hypercan, so we build it first
+# ragel-6.9+ is used by hyperscan, so we build it first
 RAGEL_DOWNLOAD="https://www.colm.net/files/ragel/ragel-6.10.tar.gz"
 RAGEL_NAME="ragel-6.10.tar.gz"
 RAGEL_SOURCE="ragel-6.10"
@@ -285,4 +279,4 @@ MARIADB_SOURCE="mariadb-connector-c-3.1.14"
 MARIADB_MD5SUM="86c4052adeb8447900bf33b4e2ddd1f9"
 
 # all thirdparties which need to be downloaded is set in array TP_ARCHIVES
-TP_ARCHIVES="LIBEVENT OPENSSL THRIFT PROTOBUF GFLAGS GLOG GTEST RAPIDJSON SNAPPY GPERFTOOLS ZLIB LZ4 BZIP CURL RE2 BOOST LEVELDB BRPC ROCKSDB LIBRDKAFKA FLATBUFFERS ARROW BROTLI DOUBLE_CONVERSION ZSTD S2 BITSHUFFLE CROARINGBITMAP JEMALLOC CCTZ FMT RYU BREAK_PAD HADOOP JDK RAGEL HYPERSCAN MARIADB"
+TP_ARCHIVES="LIBEVENT OPENSSL THRIFT PROTOBUF GFLAGS GLOG GTEST RAPIDJSON SNAPPY GPERFTOOLS ZLIB LZ4 BZIP CURL RE2 BOOST LEVELDB BRPC ROCKSDB LIBRDKAFKA FLATBUFFERS ARROW BROTLI ZSTD S2 BITSHUFFLE CROARINGBITMAP JEMALLOC CCTZ FMT RYU BREAK_PAD HADOOP JDK RAGEL HYPERSCAN MARIADB"

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -85,10 +85,10 @@ GFLAGS_SOURCE=gflags-2.2.2
 GFLAGS_MD5SUM="1a865b93bacfa963201af3f75b7bd64c"
 
 # glog
-GLOG_DOWNLOAD="https://github.com/google/glog/archive/v0.3.3.tar.gz"
-GLOG_NAME=glog-0.3.3.tar.gz
-GLOG_SOURCE=glog-0.3.3
-GLOG_MD5SUM="c1f86af27bd9c73186730aa957607ed0"
+GLOG_DOWNLOAD="https://github.com/google/glog/archive/v0.4.0.tar.gz"
+GLOG_NAME=glog-0.4.0.tar.gz
+GLOG_SOURCE=glog-0.4.0
+GLOG_MD5SUM="0daea8785e6df922d7887755c3d100d0"
 
 # gtest
 GTEST_DOWNLOAD="https://github.com/google/googletest/archive/release-1.10.0.tar.gz"


### PR DESCRIPTION
Reading parquet file with many columns is much slower in 0.15.1.
https://issues.apache.org/jira/browse/ARROW-7059

Upgrade to 5.0.0, broker load with single be and single replica
can be increased by 4 times.

4k columns duplicate key table, buckets 60, load_parallel_instance_num 4
40w rows/min vs 10w rows/min.

other dependent libs:
protobuf 3.5.1 -> 3.14.0
gflags     2.2.0 -> 2.2.2
glog        0.3.3 -> 0.4.0
gtest       1.8.0 -> 1.10.0
snappy    1.1.7 -> 1.1.8
lz4           1.7.5 -> 1.9.3
brpc        0.9.5 -> 0.9.7
zstd         1.3.7 -> 1.5.0
brotli        1.0.7 -> 1.0.9
arrow       0.15.1 -> 5.0.0
double-conversion  removed