### PR TITLE
Bugfix: fail to capture rowset for version xxx

### DIFF
--- a/be/src/exec/pipeline/olap_chunk_source.h
+++ b/be/src/exec/pipeline/olap_chunk_source.h
@@ -9,6 +9,7 @@
 #include "exprs/expr_context.h"
 #include "gen_cpp/InternalService_types.h"
 #include "runtime/runtime_state.h"
+#include "storage/tablet.h"
 #include "storage/vectorized/conjunctive_predicates.h"
 #include "storage/vectorized/reader.h"
 #include "storage/vectorized/reader_params.h"

--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -365,8 +365,7 @@ void OlapScanNode::_init_counter(RuntimeState* state) {
 
     _scan_profile = _runtime_profile->create_child("SCAN", true, false);
 
-    _reader_init_timer = ADD_TIMER(_scan_profile, "ReaderInit");
-    _capture_rowset_timer = ADD_CHILD_TIMER(_scan_profile, "CaptureRowset", "ReaderInit");
+    _create_seg_iter_timer = ADD_TIMER(_scan_profile, "CreateSegmentIter");
 
     _read_compressed_counter = ADD_COUNTER(_scan_profile, "CompressedBytesRead", TUnit::BYTES);
     _read_uncompressed_counter = ADD_COUNTER(_scan_profile, "UncompressedBytesRead", TUnit::BYTES);

--- a/be/src/exec/vectorized/olap_scan_node.h
+++ b/be/src/exec/vectorized/olap_scan_node.h
@@ -146,9 +146,8 @@ private:
     RuntimeProfile* _scan_profile = nullptr;
 
     RuntimeProfile::Counter* _scan_timer = nullptr;
-    RuntimeProfile::Counter* _capture_rowset_timer = nullptr;
+    RuntimeProfile::Counter* _create_seg_iter_timer = nullptr;
     RuntimeProfile::Counter* _tablet_counter = nullptr;
-    RuntimeProfile::Counter* _reader_init_timer = nullptr;
     RuntimeProfile::Counter* _io_timer = nullptr;
     RuntimeProfile::Counter* _read_compressed_counter = nullptr;
     RuntimeProfile::Counter* _decompress_timer = nullptr;

--- a/be/src/exec/vectorized/olap_scanner.h
+++ b/be/src/exec/vectorized/olap_scanner.h
@@ -11,6 +11,7 @@
 #include "exprs/expr_context.h"
 #include "gen_cpp/InternalService_types.h"
 #include "runtime/runtime_state.h"
+#include "storage/tablet.h"
 #include "storage/vectorized/conjunctive_predicates.h"
 #include "storage/vectorized/reader.h"
 #include "storage/vectorized/reader_params.h"

--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -374,7 +374,7 @@ using KeyRange = std::pair<WrapperField*, WrapperField*>;
 
 // ReaderStatistics used to collect statistics when scan data from storage
 struct OlapReaderStatistics {
-    int64_t capture_rowset_ns = 0;
+    int64_t create_segment_iter_ns = 0;
     int64_t io_ns = 0;
     int64_t compressed_bytes_read = 0;
 

--- a/be/src/storage/rowset/vectorized/rowset_options.h
+++ b/be/src/storage/rowset/vectorized/rowset_options.h
@@ -42,10 +42,6 @@ public:
     // whether rowset should return rows in sorted order.
     bool sorted = true;
 
-    // columns to load bloom filter index
-    // including columns in "=" or "in" conditions
-    const std::set<uint32_t>* load_bf_columns = nullptr;
-
     const DeletePredicates* delete_predicates = nullptr;
 
     const TabletSchema* tablet_schema = nullptr;

--- a/be/src/storage/tablet.h
+++ b/be/src/storage/tablet.h
@@ -127,6 +127,7 @@ public:
     bool check_version_exist(const Version& version) const;
     void list_versions(std::vector<Version>* versions) const;
 
+    // REQUIRE: `obtain_header_rdlock()`ed
     OLAPStatus capture_consistent_rowsets(const Version& spec_version, vector<RowsetSharedPtr>* rowsets) const;
     OLAPStatus capture_rs_readers(const Version& spec_version, vector<RowsetReaderSharedPtr>* rs_readers) const;
     OLAPStatus capture_rs_readers(const vector<Version>& version_path, vector<RowsetReaderSharedPtr>* rs_readers) const;

--- a/be/src/storage/tablet_meta.h
+++ b/be/src/storage/tablet_meta.h
@@ -114,7 +114,7 @@ public:
                              const std::unordered_map<uint32_t, uint32_t>& col_ordinal_to_unique_id,
                              RowsetTypePB rowset_type, TabletMetaSharedPtr* tablet_meta);
 
-    TabletMeta(MemTracker* mem_tracker);
+    explicit TabletMeta(MemTracker* mem_tracker);
     TabletMeta(MemTracker* mem_tracker, int64_t table_id, int64_t partition_id, int64_t tablet_id, int32_t schema_hash,
                uint64_t shard_id, const TTabletSchema& tablet_schema, uint32_t next_unique_id,
                const std::unordered_map<uint32_t, uint32_t>& col_ordinal_to_unique_id, const TabletUid& tablet_uid,

--- a/be/src/storage/vectorized/reader_params.cpp
+++ b/be/src/storage/vectorized/reader_params.cpp
@@ -6,19 +6,13 @@
 
 namespace starrocks::vectorized {
 
-ReaderParams::ReaderParams() : version(-1, 0) {}
-
-void ReaderParams::check_validation() const {
-    if (version.first == -1) {
-        LOG(FATAL) << "verison is not set. tablet=" << tablet->full_name();
-    }
-}
+ReaderParams::ReaderParams() {}
 
 std::string ReaderParams::to_string() const {
     std::stringstream ss;
 
-    ss << "tablet=" << tablet->full_name() << " reader_type=" << reader_type << " skip_aggregation=" << skip_aggregation
-       << " version=" << version.first << "-" << version.second << " range=" << range << " end_range=" << end_range;
+    ss << "reader_type=" << reader_type << " skip_aggregation=" << skip_aggregation << " range=" << range
+       << " end_range=" << end_range;
 
     for (auto& key : start_key) {
         ss << " keys=" << key;

--- a/be/src/storage/vectorized/reader_params.h
+++ b/be/src/storage/vectorized/reader_params.h
@@ -6,7 +6,6 @@
 #include <vector>
 
 #include "storage/olap_common.h"
-#include "storage/tablet.h"
 #include "storage/tuple.h"
 #include "storage/vectorized/chunk_iterator.h"
 
@@ -23,8 +22,6 @@ class ColumnPredicate;
 struct ReaderParams {
     ReaderParams();
 
-    Version version;
-    TabletSharedPtr tablet;
     ReaderType reader_type = READER_QUERY;
 
     bool skip_aggregation = false;
@@ -48,7 +45,6 @@ struct ReaderParams {
 
     RuntimeProfile* profile = nullptr;
 
-    void check_validation() const;
     std::string to_string() const;
     int chunk_size = 1024;
 };


### PR DESCRIPTION
Issue number #227

The `Tablet::capture_consistent_rowset()` method is used in
`Reader::prepare()` method to get rowsets of specified version.
`Tablet::capture_consistent_rowset()` will check the _stale_rs_meta_map,
so rowsets that have been compacted but not yet been deleted can still be found.

This PR also splits the original `Reader::init` function into two functions:
`Reader::prepare` and `Reader::open`.
`Reader::prepare` is used to fetch specific version of rowsets, while the
`Reader::open` is used to open those rowsets.

The `Reader::prepare` method is usually called before query processing begins, while
the `Reader::open` method is usually called during query processing.

A single query may involve multiple tablets and may take a long time to execute. By
fetching all the rowsets of the tablets sequentially before the query execution, it is
ensured that these rowsets will not be deleted during the execution, while the open
function can be called by multiple threads during the query execution to reduce the
latency of rowset opening.