### PR TITLE
Improve pre-aggregation for olap scan node with join node

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/PreAggregateTurnOnRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/PreAggregateTurnOnRule.java
@@ -304,7 +304,10 @@ public class PreAggregateTurnOnRule {
                 return visit(optExpression, context);
             }
 
-            // For other types of joins, only one side can turn on pre aggregation
+            // For other types of joins, only one side can turn on pre aggregation which side has aggregation.
+            // The columns used by the aggregate functions can only be the columns of one of the children,
+            // the olap scan node will turn off pre aggregation if aggregation function used both sides columns,
+            // this can be guaranteed by checkAggregations in visitPhysicalOlapScan.
             ColumnRefSet aggregationColumns = new ColumnRefSet();
             List<ScalarOperator> leftGroupOperator = Lists.newArrayList();
             List<ScalarOperator> rightGroupOperator = Lists.newArrayList();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggTableTest.java
@@ -117,7 +117,7 @@ public class AggTableTest extends PlanTestBase {
     @Test
     public void testSingleAgg16() throws Exception {
         String sql = getFragmentPlan("select SUM(v3) from test_agg, t1 group by k1");
-        assertTestAggOFF(sql, "Has Join");
+        assertTestAggOFF(sql, "Has can not pre-aggregation Join");
     }
 
     @Test


### PR DESCRIPTION
#245 
1. Cross join cannot pre-aggregation
2. For other types of join, only one side can be pre-aggregation