### PR TITLE
[SR-4078] Fix for single source

### DIFF
--- a/be/src/runtime/data_stream_recvr.cc
+++ b/be/src/runtime/data_stream_recvr.cc
@@ -232,6 +232,7 @@ bool DataStreamRecvr::SenderQueue::has_chunk() {
     return true;
 }
 
+// try_get_chunk will only be used when has_chunk return true(explicitly or implicitly).
 bool DataStreamRecvr::SenderQueue::try_get_chunk(vectorized::Chunk** chunk) {
     std::unique_lock<std::mutex> l(_lock);
     if (_is_cancelled) {

--- a/be/src/runtime/vectorized/sorted_chunks_merger.cpp
+++ b/be/src/runtime/vectorized/sorted_chunks_merger.cpp
@@ -180,7 +180,11 @@ Status SortedChunksMerger::get_next_for_pipeline(ChunkPtr* chunk, std::atomic<bo
     // single source
     if (_single_probe_supplier) {
         Chunk* tmp_chunk = nullptr;
-        *eos = !_single_probe_supplier(&tmp_chunk);
+        if (_single_has_supplier()) {
+            *eos = !_single_probe_supplier(&tmp_chunk);
+        } else {
+            *should_exit = true;
+        }
         (*chunk).reset(tmp_chunk);
         return Status::OK();
     }


### PR DESCRIPTION


Fix: we should first judge whether there is data, and then grab blocks.