### PR TITLE
Remove unused macro for mysql_global.h in case of redefinition warning.

### DIFF
--- a/be/src/util/mysql_global.h
+++ b/be/src/util/mysql_global.h
@@ -38,26 +38,14 @@ typedef unsigned char uchar;
     } while (0)
 #define int8store(T, A) *((int64_t*)(T)) = (uint64_t)(A)
 
-#define MY_ALIGN(A, L) (((A) + (L)-1) & ~((L)-1))
-#define SIZEOF_CHARP 8
-
-#define MAX_TINYINT_WIDTH 3     /* Max width for a TINY w.o. sign */
-#define MAX_SMALLINT_WIDTH 5    /* Max width for a SHORT w.o. sign */
-#define MAX_MEDIUMINT_WIDTH 8   /* Max width for a INT24 w.o. sign */
-#define MAX_INT_WIDTH 10        /* Max width for a LONG w.o. sign */
-#define MAX_BIGINT_WIDTH 20     /* Max width for a LONGLONG */
-#define MAX_CHAR_WIDTH 255      /* Max length for a CHAR colum */
-#define MAX_BLOB_WIDTH 16777216 /* Default width for blob */
-
-#define MAX_DECPT_FOR_F_FORMAT DBL_DIG
-#define MAX_DATETIME_WIDTH 19 /* YYYY-MM-DD HH:MM:SS */
+#define MAX_TINYINT_WIDTH 3  /* Max width for a TINY w.o. sign */
+#define MAX_SMALLINT_WIDTH 5 /* Max width for a SHORT w.o. sign */
+#define MAX_INT_WIDTH 10     /* Max width for a LONG w.o. sign */
+#define MAX_BIGINT_WIDTH 20  /* Max width for a LONGLONG */
 
 /* -[digits].E+## */
 #define MAX_FLOAT_STR_LENGTH 24 // see gutil/strings/numbers.h kFloatToBufferSize
 /* -[digits].E+### */
 #define MAX_DOUBLE_STR_LENGTH 32 // see gutil/strings/numbers.h kDoubleToBufferSize
-
-/* -[digits].[frac] */
-#define MAX_DECIMAL_STR_LENGTH 29
 
 } // namespace starrocks


### PR DESCRIPTION
see more in #265 