### PR TITLE
Return zero in allocate_rows() when _swap_row_block is a nullptr

### DIFF
--- a/be/src/storage/schema_change.cpp
+++ b/be/src/storage/schema_change.cpp
@@ -61,7 +61,7 @@ public:
     virtual ~RowBlockSorter();
 
     bool sort(RowBlock** row_block);
-    size_t allocated_rows() { return _swap_row_block->capacity(); }
+    size_t allocated_rows() { return (_swap_row_block == nullptr) ? 0 : _swap_row_block->capacity(); }
 
 private:
     static bool _row_cursor_comparator(const RowCursor* a, const RowCursor* b) { return compare_row(*a, *b) < 0; }


### PR DESCRIPTION
return zero when _swap_row_block is nullptr