### PR TITLE
[minor refactor] move specialized hashset to user class

### DIFF
--- a/be/src/column/hash_set.h
+++ b/be/src/column/hash_set.h
@@ -67,17 +67,4 @@ using SliceHashSet = phmap::flat_hash_set<SliceWithHash, HashOnSliceWithHash, Eq
 
 using SliceNormalHashSet = phmap::flat_hash_set<Slice, SliceHash, SliceNormalEqual>;
 
-template <typename T>
-struct PhSetTraits {
-    using SetType = HashSet<T>;
-};
-
-template <>
-struct PhSetTraits<Slice> {
-    using SetType = SliceNormalHashSet;
-};
-
-template <typename T>
-using PhSet = typename PhSetTraits<T>::SetType;
-
 } // namespace starrocks::vectorized

--- a/be/src/exprs/vectorized/in_const_predicate.hpp
+++ b/be/src/exprs/vectorized/in_const_predicate.hpp
@@ -12,6 +12,7 @@
 namespace starrocks {
 namespace vectorized {
 
+namespace in_const_pred_detail {
 template <PrimitiveType Type, typename Enable = void>
 struct PHashSet {
     using PType = HashSet<RunTimeCppType<Type>>;
@@ -24,6 +25,7 @@ struct PHashSet<Type, std::enable_if_t<isSlicePT<Type>>> {
 
 template <PrimitiveType Type>
 using PHashSetType = typename PHashSet<Type>::PType;
+} // in_const_pred_detail
 
 /**
  * Support In predicate which right-values only contains const value.
@@ -218,7 +220,7 @@ public:
         }
     }
 
-    const PHashSetType<Type>& hash_set() const { return _hash_set; }
+    const in_const_pred_detail::PHashSetType<Type>& hash_set() const { return _hash_set; }
 
     bool is_not_in() const { return _is_not_in; }
 
@@ -237,7 +239,7 @@ private:
     bool _is_join_runtime_filter = false;
     bool _eq_null = false;
 
-    PHashSetType<Type> _hash_set;
+    in_const_pred_detail::PHashSetType<Type> _hash_set;
     // Ensure the string memory don't early free
     std::vector<ColumnPtr> _string_values;
 };

--- a/be/src/storage/vectorized/in_predicate_utils.h
+++ b/be/src/storage/vectorized/in_predicate_utils.h
@@ -8,9 +8,24 @@
 
 namespace starrocks::vectorized {
 
+namespace in_pred_utils_detail {
 template <typename T>
-struct ItemHashSet : public PhSet<T> {
-    bool contains(const T& v) const { return PhSet<T>::contains(v); }
+struct PHashSetTraits {
+    using SetType = HashSet<T>;
+};
+
+template <>
+struct PHashSetTraits<Slice> {
+    using SetType = SliceNormalHashSet;
+};
+
+template <typename T>
+using PHashSet = typename PHashSetTraits<T>::SetType;
+} // namespace in_pred_utils_detail
+
+template <typename T>
+struct ItemHashSet : public in_pred_utils_detail::PHashSet<T> {
+    bool contains(const T& v) const { return in_pred_utils_detail::PHashSet<T>::contains(v); }
 };
 
 template <typename T, size_t N>


### PR DESCRIPTION
Right now there are many specialized hashset used by several classes. It's better to put those specialized hashset to user class file, instead of in `column/hash_set.h` file.