### PR TITLE
Unlock _store_lock before calling TabletManager::drop_tablets_on_error_root_path

### DIFF
--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -424,18 +424,20 @@ bool StorageEngine::_delete_tablets_on_unused_root_path() {
     uint32_t unused_root_path_num = 0;
     uint32_t total_root_path_num = 0;
 
-    std::lock_guard<std::mutex> l(_store_lock);
-    if (_store_map.size() == 0) {
-        return false;
-    }
-
-    for (auto& it : _store_map) {
-        ++total_root_path_num;
-        if (it.second->is_used()) {
-            continue;
+    {
+        std::lock_guard<std::mutex> l(_store_lock);
+        if (_store_map.size() == 0) {
+            return false;
         }
-        it.second->clear_tablets(&tablet_info_vec);
-        ++unused_root_path_num;
+
+        for (auto& it : _store_map) {
+            ++total_root_path_num;
+            if (it.second->is_used()) {
+                continue;
+            }
+            it.second->clear_tablets(&tablet_info_vec);
+            ++unused_root_path_num;
+        }
     }
 
     if (too_many_disks_are_failed(unused_root_path_num, total_root_path_num)) {

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -516,6 +516,9 @@ Status TabletManager::_drop_tablet_unlocked(TTabletId tablet_id, SchemaHash sche
 }
 
 Status TabletManager::drop_tablets_on_error_root_path(const std::vector<TabletInfo>& tablet_info_vec) {
+    if (tablet_info_vec.empty()) {
+        return Status::OK();
+    }
     for (int32 i = 0; i < _tablets_shards_size; i++) {
         std::unique_lock wlock(*_tablets_shards[i].lock);
         for (const TabletInfo& tablet_info : tablet_info_vec) {


### PR DESCRIPTION
…r_root_path

No need to call TabletManager::drop_tablets_on_error_root_path() inside the lock scope of `_store_lock`.