### PR TITLE
a porposal that to change std hash with seed

### DIFF
--- a/be/src/column/column_hash.h
+++ b/be/src/column/column_hash.h
@@ -210,13 +210,27 @@ public:
 template <class T>
 class StdHash {
 public:
-    std::size_t operator()(T value) const { return phmap_mix<sizeof(size_t)>()(std::hash<T>()(value)); }
+    std::size_t operator()(T value) const {
+        size_t t = std::hash<T>()(value);
+        if constexpr (sizeof(T) <= 4) {
+            return phmap_mix<4>()(t);
+        } else {
+            return phmap_mix<8>()(t);
+        }
+    }
 };
 
 template <class T, PhmapSeed seed>
 class StdHashWithSeed {
 public:
-    std::size_t operator()(T value) const { return phmap_mix_with_seed<sizeof(size_t), seed>()(std::hash<T>()(value)); }
+    std::size_t operator()(T value) const {
+        size_t t = std::hash<T>()(value);
+        if constexpr (sizeof(T) <= 4) {
+            return phmap_mix_with_seed<4, seed>()(t);
+        } else {
+            return phmap_mix_with_seed<8, seed>()(t);
+        }
+    }
 };
 
 } // namespace starrocks::vectorized


### PR DESCRIPTION
Right now implementation is following:
```
phmap_mix<sizeof(size_t)>()(std::hash<T>()(value));


template <>
class phmap_mix<4> {
public:
    inline size_t operator()(size_t a) const {
        static constexpr uint64_t kmul = 0xcc9e2d51UL;
        uint64_t l = a * kmul;
        return static_cast<size_t>(l ^ (l >> 32u));
    }
};

template <>
class phmap_mix<8> {
public:
    // Very fast mixing (similar to Abseil)
    inline size_t operator()(size_t a) const {
        static constexpr uint64_t k = 0xde5fb9d2630458e9ULL;
        uint64_t h;
        uint64_t l = umul128(a, k, &h);
        return static_cast<size_t>(h + l);
    }
};

```

Since `std::hash<T>()` just return the original value, so if `sizeof(T) = 4`, high 32 bits are all zeros or all ones. I SUSPECT that we don't need to use `phmap_mix<4>` as hash function, because operations are much simpler. It's just a proposal or discussion now, since I don't have much benchmark data.

