### PR TITLE
[SR-4661] Cbo optimizer introduces wildcard decimal into ArithmeticExpr

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -252,10 +252,11 @@ public class ExpressionAnalyzer {
                     Type lhsType = node.getChild(0).getType();
                     Type rhsType = node.getChild(1).getType();
                     Type resultType = node.getType();
-                    Function fn = Expr.getBuiltinFunction(op.getName(), new Type[] {lhsType, rhsType},
-                            Function.CompareMode.IS_IDENTICAL);
+                    Type[] args = {lhsType, rhsType};
+                    Function fn = Expr.getBuiltinFunction(op.getName(), args, Function.CompareMode.IS_IDENTICAL);
+                    Function newFn = new Function(fn.getFunctionName(), args, resultType, fn.hasVarArgs());
                     node.setType(resultType);
-                    node.setFn(fn);
+                    node.setFn(newFn);
                     return null;
                 }
                 // Find result type of this operator

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -254,6 +254,10 @@ public class ExpressionAnalyzer {
                     Type resultType = node.getType();
                     Type[] args = {lhsType, rhsType};
                     Function fn = Expr.getBuiltinFunction(op.getName(), args, Function.CompareMode.IS_IDENTICAL);
+                    // In resolved function instance, it's argTypes and resultType are wildcard decimal type
+                    // (both precision and and scale are -1, only used in function instance resolution), it's
+                    // illegal for a function and expression to has a wildcard decimal type as its type in BE,
+                    // so here substitute wildcard decimal types with real decimal types.
                     Function newFn = new Function(fn.getFunctionName(), args, resultType, fn.hasVarArgs());
                     node.setType(resultType);
                     node.setFn(newFn);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorEvaluator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorEvaluator.java
@@ -9,6 +9,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.starrocks.catalog.Catalog;
 import com.starrocks.catalog.Function;
+import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
@@ -27,6 +28,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Use for execute constant functions
@@ -241,14 +243,20 @@ public enum ScalarOperatorEvaluator {
             }
 
             ScalarOperatorEvaluator.FunctionSignature signature = (ScalarOperatorEvaluator.FunctionSignature) o;
-            return Objects.equals(name, signature.name)
-                    && argTypes.equals(signature.argTypes)
-                    && Objects.equals(returnType, signature.returnType);
+
+            List<PrimitiveType> primitiveTypes =
+                    argTypes.stream().map(Type::getPrimitiveType).collect(Collectors.toList());
+            List<PrimitiveType> sigPrimitiveTypes =
+                    signature.argTypes.stream().map(Type::getPrimitiveType).collect(Collectors.toList());
+            return Objects.equals(name, signature.name) &&
+                    primitiveTypes.equals(sigPrimitiveTypes) &&
+                    returnType.matchesType(signature.returnType);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(name, argTypes, returnType);
+            List<PrimitiveType> primitiveTypes = argTypes.stream().map(Type::getPrimitiveType).collect(Collectors.toList());
+            return Objects.hash(name, primitiveTypes, returnType.getPrimitiveType());
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ImplicitCastRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ImplicitCastRule.java
@@ -2,6 +2,7 @@
 
 package com.starrocks.sql.optimizer.rewrite.scalar;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.ArrayType;
 import com.starrocks.catalog.Function;
@@ -19,6 +20,7 @@ import com.starrocks.sql.optimizer.operator.scalar.LikePredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriteContext;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -51,6 +53,8 @@ public class ImplicitCastRule extends TopDownScalarOperatorRewriteRule {
                 }
             }
         } else {
+            Preconditions.checkArgument(Arrays.stream(fn.getArgs()).noneMatch(Type::isWildcardDecimal),
+                    String.format("Resolved function %s has wildcard decimal as argument type", fn.functionName()));
             for (int i = 0; i < fn.getNumArgs(); i++) {
                 Type type = fn.getArgs()[i];
                 ScalarOperator child = call.getChild(i);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ImplicitCastRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ImplicitCastRule.java
@@ -6,6 +6,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.ArrayType;
 import com.starrocks.catalog.Function;
+import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.Type;
 import com.starrocks.sql.common.TypeManager;
 import com.starrocks.sql.optimizer.operator.scalar.BetweenPredicateOperator;
@@ -53,7 +54,9 @@ public class ImplicitCastRule extends TopDownScalarOperatorRewriteRule {
                 }
             }
         } else {
-            Preconditions.checkArgument(Arrays.stream(fn.getArgs()).noneMatch(Type::isWildcardDecimal),
+            Preconditions.checkArgument(
+                    fn.functionName().equalsIgnoreCase(FunctionSet.COUNT) ||
+                            Arrays.stream(fn.getArgs()).noneMatch(Type::isWildcardDecimal),
                     String.format("Resolved function %s has wildcard decimal as argument type", fn.functionName()));
             for (int i = 0; i < fn.getNumArgs(); i++) {
                 Type type = fn.getArgs()[i];

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithDecimalTypesNewPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithDecimalTypesNewPlannerTest.java
@@ -121,5 +121,24 @@ public class SelectStmtWithDecimalTypesNewPlannerTest {
         System.out.println(thrift);
         Assert.assertTrue(thrift.contains(expectString));
     }
+
+    @Test
+    public void testMultiply() throws Exception {
+        String sql = "select col_decimal128p20s3 * 3.14 from db1.decimal_table";
+        String expectString = "TExprNode(node_type:ARITHMETIC_EXPR, type:TTypeDesc(types:[TTypeNode(type:SCALAR, " +
+                "scalar_type:TScalarType(type:DECIMAL128, precision:38, scale:5))]), opcode:MULTIPLY, num_children:2," +
+                " output_scale:-1, output_column:-1, use_vectorized:true, has_nullable_child:true, is_nullable:true)," +
+                " TExprNode(node_type:SLOT_REF, type:TTypeDesc(types:[TTypeNode(type:SCALAR, scalar_type:TScalarType" +
+                "(type:DECIMAL128, precision:20, scale:3))]), num_children:0, slot_ref:TSlotRef(slot_id:3, tuple_id:0)," +
+                " output_scale:-1, output_column:-1, use_vectorized:true, has_nullable_child:false, is_nullable:true)," +
+                " TExprNode(node_type:DECIMAL_LITERAL, type:TTypeDesc(types:[TTypeNode(type:SCALAR, scalar_type:" +
+                "TScalarType(type:DECIMAL128, precision:38, scale:2))]), num_children:0, decimal_literal:" +
+                "TDecimalLiteral(value:3.14), output_scale:-1, use_vectorized:true, has_nullable_child:false," +
+                " is_nullable:false)";
+
+        String thrift = UtFrameUtils.getPlanThriftStringForNewPlanner(ctx, sql);
+        System.out.println(thrift);
+        Assert.assertTrue(thrift.contains(expectString));
+    }
 }
 


### PR DESCRIPTION
## Bigfix

Wildcard decimals is used as placeholders in function registery and it can only be used to resolve function instance. it's illegal for a function or expression to has a  wildcard decimal as its type in BE.  In CBO optimizer, after function has been resolved in ArithmeticExpr, subsitituting wildcard decimals with expected decimal types is missing, so fix it.