### PR TITLE
[SR-4363] Add SM3 Cryptographic Hash Algorithm

### DIFF
--- a/be/src/exprs/vectorized/string_functions.h
+++ b/be/src/exprs/vectorized/string_functions.h
@@ -380,6 +380,13 @@ public:
      * Get the string of this hexadecimal representation represents
      */
     DEFINE_VECTORIZED_FN(unhex);
+    /**
+     * @param: [StringColumn]
+     * @return: StringColumn
+     * Get the hexadecimal representation of SM3 hash value
+     *
+     */
+    DEFINE_VECTORIZED_FN(sm3);
 
 private:
     static int index_of(const char* source, int source_count, const char* target, int target_count, int from_index);

--- a/be/src/util/CMakeLists.txt
+++ b/be/src/util/CMakeLists.txt
@@ -84,6 +84,7 @@ set(UTIL_FILES
   thrift_rpc_helper.cpp
   faststring.cc
   slice.cpp
+  sm3.cpp
   frame_of_reference_coding.cpp
   minizip/ioapi.c
   minizip/unzip.c

--- a/be/src/util/sm3.cpp
+++ b/be/src/util/sm3.cpp
@@ -1,0 +1,241 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#include "util/sm3.h"
+
+#include "common/logging.h"
+
+namespace starrocks {
+// IS LITTLE ENDIAN?
+bool Sm3::is_little_endian = (*(char*)&Sm3::ENDIAN_TEST_VALUE == 1) ? true : false;
+
+// Cyclic shift left k-bit operation
+unsigned int Sm3::left_rotate(unsigned int word, int k) {
+    return (word) << (k) | (word) >> (WORD_BITS - (k));
+}
+
+// is_little_endian:true, reverse word because the word should stored in big endian format.
+unsigned int* Sm3::reverse_word(unsigned int* word) {
+    unsigned char *byte, temp;
+
+    byte = (unsigned char*)word;
+    temp = byte[0];
+    byte[0] = byte[3];
+    byte[3] = temp;
+
+    temp = byte[1];
+    byte[1] = byte[2];
+    byte[2] = temp;
+    return word;
+}
+
+// is_little_endian:true, reverse words(8 bytes) because the word should stored in big endian format.
+unsigned long* Sm3::reverse_double_word(unsigned long* word) {
+    unsigned char *byte, temp;
+
+    byte = (unsigned char*)word;
+    temp = byte[0];
+    byte[0] = byte[7];
+    byte[7] = temp;
+
+    temp = byte[1];
+    byte[1] = byte[6];
+    byte[6] = temp;
+
+    temp = byte[2];
+    byte[2] = byte[5];
+    byte[5] = temp;
+
+    temp = byte[3];
+    byte[3] = byte[4];
+    byte[4] = temp;
+
+    return word;
+}
+
+// It's defined by 4.2 of Sm3 algorithm
+unsigned int Sm3::T(int i) {
+    if (i >= 0 && i <= 15)
+        return 0x79CC4519;
+    else if (i >= 16 && i <= 63)
+        return 0x7A879D8A;
+    else
+        return 0;
+}
+
+// It's defined by 4.3 of Sm3 algorithm
+unsigned int Sm3::FF(unsigned int X, unsigned int Y, unsigned int Z, int i) {
+    if (i >= 0 && i <= 15)
+        return X ^ Y ^ Z;
+    else if (i >= 16 && i <= 63)
+        return (X & Y) | (X & Z) | (Y & Z);
+    else
+        return 0;
+}
+
+// It's defined by 4.3 of Sm3 algorithm
+unsigned int Sm3::GG(unsigned int X, unsigned int Y, unsigned int Z, int i) {
+    if (i >= 0 && i <= 15)
+        return X ^ Y ^ Z;
+    else if (i >= 16 && i <= 63)
+        return (X & Y) | (~X & Z);
+    else
+        return 0;
+}
+
+// It's defined by 4.4 of Sm3 algorithm
+unsigned int Sm3::P0(unsigned int X) {
+    return X ^ Sm3::left_rotate(X, 9) ^ Sm3::left_rotate(X, 17);
+}
+
+// It's defined by 4.4 of Sm3 algorithm
+unsigned int Sm3::P1(unsigned int X) {
+    return X ^ Sm3::left_rotate(X, 15) ^ Sm3::left_rotate(X, 23);
+}
+
+void Sm3::init(Sm3Context* context) {
+    // 0x7380166F - 0xB0FB0E4E is used as initial value from Sm3's definition.
+    context->intermediate_hash[0] = 0x7380166F;
+    context->intermediate_hash[1] = 0x4914B2B9;
+    context->intermediate_hash[2] = 0x172442D7;
+    context->intermediate_hash[3] = 0xDA8A0600;
+    context->intermediate_hash[4] = 0xA96F30BC;
+    context->intermediate_hash[5] = 0x163138AA;
+    context->intermediate_hash[6] = 0xE38DEE4D;
+    context->intermediate_hash[7] = 0xB0FB0E4E;
+}
+
+void Sm3::process_message_block(Sm3Context* context) {
+    int i;
+    unsigned int W[68];
+    unsigned int W_[64];
+    unsigned int A, B, C, D, E, F, G, H, SS1, SS2, TT1, TT2;
+
+    // for every message_block(512 bits),
+    // we copy values in message_block and use it as W[0-15],
+    // W[0-15] is 16 words.
+    for (i = 0; i < 16; i++) {
+        W[i] = *(unsigned int*)(context->message_block + i * 4);
+        // should modify input from little endian to big endian.
+        if (Sm3::is_little_endian) {
+            Sm3::reverse_word(W + i);
+        }
+    }
+
+    // for W[16-67],
+    // It is generated from W[0-15] with bit shift operation.
+    // It's defined from 5.3.2 of sm3.
+    for (i = 16; i < 68; i++) {
+        W[i] = Sm3::P1(W[i - 16] ^ W[i - 9] ^ Sm3::left_rotate(W[i - 3], 15)) ^ Sm3::left_rotate(W[i - 13], 7) ^
+               W[i - 6];
+    }
+
+    // for W_[0-63],
+    // It is generated from W[0-67] with bit shift operation.
+    // It's defined from 5.3.2 of sm3.
+    for (i = 0; i < 64; i++) {
+        W_[i] = W[i] ^ W[i + 4];
+    }
+
+    // get A-H from intermediate_hash.
+    A = context->intermediate_hash[0];
+    B = context->intermediate_hash[1];
+    C = context->intermediate_hash[2];
+    D = context->intermediate_hash[3];
+    E = context->intermediate_hash[4];
+    F = context->intermediate_hash[5];
+    G = context->intermediate_hash[6];
+    H = context->intermediate_hash[7];
+
+    // We use W[0-67] and W_[0-63] to generate temporary value of (A-H).
+    // It's defined at 5.3.3 of sm3.
+    for (i = 0; i < 64; i++) {
+        SS1 = Sm3::left_rotate((Sm3::left_rotate(A, 12) + E + Sm3::left_rotate(T(i), i)), 7);
+        SS2 = SS1 ^ Sm3::left_rotate(A, 12);
+        TT1 = Sm3::FF(A, B, C, i) + D + SS2 + W_[i];
+        TT2 = Sm3::GG(E, F, G, i) + H + SS1 + W[i];
+        D = C;
+        C = Sm3::left_rotate(B, 9);
+        B = A;
+        A = TT1;
+        H = G;
+        G = Sm3::left_rotate(F, 19);
+        F = E;
+        E = Sm3::P0(TT2);
+    }
+
+    // update intermediate_hash[0-7] through A-H.
+    context->intermediate_hash[0] ^= A;
+    context->intermediate_hash[1] ^= B;
+    context->intermediate_hash[2] ^= C;
+    context->intermediate_hash[3] ^= D;
+    context->intermediate_hash[4] ^= E;
+    context->intermediate_hash[5] ^= F;
+    context->intermediate_hash[6] ^= G;
+    context->intermediate_hash[7] ^= H;
+}
+
+/*
+ * message: bytes as input.
+ * message_len: message' size.
+ * digest: It's a allocated 256 bits(32 bytes) value.
+ */
+unsigned char* Sm3::sm3_compute(const unsigned char* message, unsigned long message_len,
+                                unsigned char digest[SM3_HASH_SIZE]) {
+    Sm3Context context;
+    unsigned int i, remainder;
+    unsigned long bit_len;
+    Sm3::init(&context);
+
+    // sm3 is processed based on block(512 bits) at a time.
+    // so if message's size > 512 bits(64 bytes), we should compute based on
+    // this blocks first.
+    for (i = 0; i < message_len / 64; i++) {
+        // copy 64 bytes into message_block.
+        memcpy(context.message_block, message + i * 64, 64);
+        // compute based on message_block and result in intermediate_hash[0-7].
+        Sm3::process_message_block(&context);
+    }
+
+    // message's size as bits.
+    bit_len = message_len * 8;
+
+    // should modify input from little endian to big endian.
+    if (is_little_endian) {
+        Sm3::reverse_double_word(&bit_len);
+    }
+    remainder = message_len % 64;
+    // copy the remaining bytes into message_block.
+    memcpy(context.message_block, message + i * 64, remainder);
+
+    // 0x80 Corresponding binary "10000000".
+    // It's a step to populate message.
+    context.message_block[remainder] = 0x80;
+
+    // if remaining bytes is <= 55, because length of message need 8 bytes,
+    // so total bytes is not exceeded 64 bytes, so we can process in one block.
+    if (remainder <= WRAP_AROUND_THRESHOLD) {
+        memset(context.message_block + remainder + 1, 0, 64 - remainder - 1 - 8);
+        memcpy(context.message_block + 64 - 8, &bit_len, 8);
+        Sm3::process_message_block(&context);
+    } else {
+        // else we need wrap around to append "bit_len",
+        // so we process the front part first.
+        memset(context.message_block + remainder + 1, 0, 64 - remainder - 1);
+        Sm3::process_message_block(&context);
+
+        // then we process the backend part that end with "bit_len".
+        memset(context.message_block, 0, 64 - 8);
+        memcpy(context.message_block + 64 - 8, &bit_len, 8);
+        Sm3::process_message_block(&context);
+    }
+
+    // should modify result from little endian to big endian.
+    if (is_little_endian) {
+        for (i = 0; i < 8; i++) Sm3::reverse_word(context.intermediate_hash + i);
+    }
+    memcpy(digest, context.intermediate_hash, SM3_HASH_SIZE);
+
+    return digest;
+}
+
+} // namespace starrocks

--- a/be/src/util/sm3.h
+++ b/be/src/util/sm3.h
@@ -1,0 +1,43 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#pragma once
+
+#include <memory.h>
+#include <stdio.h>
+
+namespace starrocks {
+// SM3 Cryptographic Hash Algorithm is define by http://www.oscca.gov.cn/sca/xxgk/2010-12/17/content_1002389.shtml .
+// and http://www.oscca.gov.cn/sca/xxgk/2010-12/17/1002389/files/302a3ada057c4a73830536d03e683110.pdf.
+// Our implementation is based on https://blog.csdn.net/a344288106/article/details/80094878 .
+class Sm3 {
+    static constexpr int ENDIAN_TEST_VALUE = 1;
+    static bool is_little_endian;
+    static constexpr int WRAP_AROUND_THRESHOLD = 55;
+    static constexpr int WORD_BITS = 32;
+    static constexpr int SM3_HASH_SIZE = 32;
+
+    struct Sm3Context {
+        // 256 bits as output of sm3 hash algorithm.
+        unsigned int intermediate_hash[SM3_HASH_SIZE / 4];
+        // 512 bits, used to accept block bits of input.
+        unsigned char message_block[64];
+    };
+
+    // every parameter is the unsigned version because we use logical shift.
+    static unsigned int left_rotate(unsigned int word, int bits);
+    static unsigned int* reverse_word(unsigned int* word);
+    static unsigned long* reverse_double_word(unsigned long* word);
+    static unsigned int T(int i);
+    static unsigned int FF(unsigned int X, unsigned int Y, unsigned int Z, int i);
+    static unsigned int GG(unsigned int X, unsigned int Y, unsigned int Z, int i);
+    static unsigned int P0(unsigned int X);
+    static unsigned int P1(unsigned int X);
+    static void init(Sm3Context* context);
+    static void process_message_block(Sm3Context* context);
+
+public:
+    static unsigned char* sm3_compute(const unsigned char* message, unsigned long messageLen,
+                                      unsigned char digest[SM3_HASH_SIZE]);
+};
+
+} // namespace starrocks

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -83,6 +83,7 @@ set(EXEC_FILES
         ./exprs/vectorized/string_fn_pad_test.cpp
         ./exprs/vectorized/string_fn_repeat_test.cpp
         ./exprs/vectorized/string_fn_reverse_test.cpp
+        ./exprs/vectorized/string_fn_sm3_test.cpp
         ./exprs/vectorized/string_fn_space_test.cpp
         ./exprs/vectorized/string_fn_substr_test.cpp
         ./exprs/vectorized/string_fn_test.cpp

--- a/be/test/exprs/vectorized/string_fn_sm3_test.cpp
+++ b/be/test/exprs/vectorized/string_fn_sm3_test.cpp
@@ -1,0 +1,130 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+#include <gtest/gtest.h>
+
+#include "exprs/vectorized/string_functions.h"
+
+namespace starrocks {
+namespace vectorized {
+
+class StringFunctionSm3Test : public ::testing::Test {};
+TEST_F(StringFunctionSm3Test, abcA1Test) {
+    std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
+
+    Columns columns;
+    auto str = BinaryColumn::create();
+    columns.emplace_back(str);
+    str->append("abc");
+
+    ColumnPtr result = StringFunctions::sm3(ctx.get(), columns);
+    auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
+
+    std::string s = "66c7f0f4 62eeedd9 d1f2d46b dc10e4e2 4167c487 5cf2f7a2 297da02b 8f4ba8e0";
+    ASSERT_EQ(s, v->get_data()[0].to_string());
+}
+
+TEST_F(StringFunctionSm3Test, abcA2Test) {
+    std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
+
+    Columns columns;
+    auto str = BinaryColumn::create();
+    columns.emplace_back(str);
+    str->append("abcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
+    
+    ColumnPtr result = StringFunctions::sm3(ctx.get(), columns);
+    auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
+
+    std::string s = "debe9ff9 2275b8a1 38604889 c18e5a4d 6fdb70e5 387e5765 293dcba3 9c0c5732";
+    ASSERT_EQ(s, v->get_data()[0].to_string());
+}
+
+TEST_F(StringFunctionSm3Test, abcConstTest) {
+    std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
+
+    Columns columns;
+    auto str = BinaryColumn::create();
+    str->append("abcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
+    columns.emplace_back(ConstColumn::create(str, 1));
+    ColumnPtr result = StringFunctions::sm3(ctx.get(), columns);
+    auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(ColumnHelper::as_raw_column<ConstColumn>(result)->data_column());
+
+    std::string s = "debe9ff9 2275b8a1 38604889 c18e5a4d 6fdb70e5 387e5765 293dcba3 9c0c5732";
+    ASSERT_EQ(s, v->get_data()[0].to_string());
+}
+
+TEST_F(StringFunctionSm3Test, abcNull1Test) {
+    std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
+
+    Columns columns;
+    auto str1 = BinaryColumn::create();
+    auto null = NullColumn::create();
+    for (int j = 0; j < 20; ++j) {
+        str1->append("abc");
+        null->append(j % 2 == 0);
+    }
+    columns.emplace_back(NullableColumn::create(str1, null));
+    ColumnPtr result = StringFunctions::sm3(ctx.get(), columns);
+    auto nullable_column = ColumnHelper::as_raw_column<NullableColumn>(result);
+    auto data_column = ColumnHelper::cast_to<TYPE_VARCHAR>(nullable_column->data_column());
+
+    for (int j = 0; j < 20; ++j) {
+        if (j % 2 != 0) {
+            std::string s = "66c7f0f4 62eeedd9 d1f2d46b dc10e4e2 4167c487 5cf2f7a2 297da02b 8f4ba8e0";
+            ASSERT_EQ(s, data_column->get_data()[0].to_string());
+        } else {
+            ASSERT_TRUE(nullable_column->is_null(j));
+        }
+    }
+}
+
+TEST_F(StringFunctionSm3Test, abcNull2Test) {
+    std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
+
+    Columns columns;
+    auto str1 = BinaryColumn::create();
+    auto null = NullColumn::create();
+    for (int j = 0; j < 20; ++j) {
+        str1->append("abcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
+        null->append(j % 2 == 0);
+    }
+    columns.emplace_back(NullableColumn::create(str1, null));
+    ColumnPtr result = StringFunctions::sm3(ctx.get(), columns);
+    auto nullable_column = ColumnHelper::as_raw_column<NullableColumn>(result);
+    auto data_column = ColumnHelper::cast_to<TYPE_VARCHAR>(nullable_column->data_column());
+
+    for (int j = 0; j < 20; ++j) {
+        if (j % 2 != 0) {
+            std::string s = "debe9ff9 2275b8a1 38604889 c18e5a4d 6fdb70e5 387e5765 293dcba3 9c0c5732";
+            ASSERT_EQ(s, data_column->get_data()[0].to_string());
+        } else {
+            ASSERT_TRUE(nullable_column->is_null(j));
+        }
+    }
+}
+
+TEST_F(StringFunctionSm3Test, abcNullLiteralTest) {
+    std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
+
+    Columns columns;
+    auto str1 = BinaryColumn::create();
+    auto null = NullColumn::create();
+    for (int j = 0; j < 20; ++j) {
+        str1->append("");
+        null->append(j % 2 == 0);
+    }
+    columns.emplace_back(NullableColumn::create(str1, null));
+    ColumnPtr result = StringFunctions::sm3(ctx.get(), columns);
+    auto nullable_column = ColumnHelper::as_raw_column<NullableColumn>(result);
+    auto data_column = ColumnHelper::cast_to<TYPE_VARCHAR>(nullable_column->data_column());
+
+    for (int j = 0; j < 20; ++j) {
+        if (j % 2 != 0) {
+            std::string s = "";
+            ASSERT_EQ(s, data_column->get_data()[0].to_string());
+        } else {
+            ASSERT_TRUE(nullable_column->is_null(j));
+        }
+    }
+}
+
+} // namespace vectorized
+} // namespace starrocks

--- a/gensrc/script/vectorized/vectorized_functions.py
+++ b/gensrc/script/vectorized/vectorized_functions.py
@@ -153,6 +153,7 @@ vectorized_functions = [
     [10312, "hex", "VARCHAR", ['BIGINT'], "StringFunctions::hex_int"],
     [10313, "hex", "VARCHAR", ['VARCHAR'], "StringFunctions::hex_string"],
     [10314, "unhex", "VARCHAR", ['VARCHAR'], "StringFunctions::unhex"],
+    [10315, "sm3", "VARCHAR", ['VARCHAR'], "StringFunctions::sm3"],
 
     [10320, "conv", "VARCHAR", ["BIGINT", "TINYINT", "TINYINT"], "MathFunctions::conv_int"],
     [10321, "conv", "VARCHAR", ["VARCHAR", "TINYINT", "TINYINT"], "MathFunctions::conv_string"],


### PR DESCRIPTION
- Add sm3 expr for get SM3 hash value for any string as 8 words as hexadecimal seperate by ' '.
- Implement SM3 Cryptographic Hash Algorithm
http://www.oscca.gov.cn/sca/xxgk/2010-12/17/content_1002389.shtml
https://cloud.tencent.com/developer/article/1634816
https://blog.csdn.net/a344288106/article/details/80094878
https://github.com/guanzhi/GmSSL
https://github.com/NEWPLAN/SMx