### PR TITLE
[SR-4075] Refactor report exec status in pipeline

### DIFF
--- a/be/src/exec/pipeline/exec_state_reporter.h
+++ b/be/src/exec/pipeline/exec_state_reporter.h
@@ -22,7 +22,7 @@ public:
                                                                     bool done);
     static Status report_exec_status(const TReportExecStatusParams& params, ExecEnv* exec_env, TNetworkAddress fe_addr);
     ExecStateReporter();
-    void submit(FragmentContext* fragment_ctx, const Status& status, bool done, bool clean);
+    void submit(std::function<void()>&& report_task);
 
 private:
     std::unique_ptr<ThreadPool> _thread_pool;

--- a/be/src/exec/pipeline/fragment_context.h
+++ b/be/src/exec/pipeline/fragment_context.h
@@ -91,6 +91,8 @@ private:
     TUniqueId _fragment_instance_id;
     TNetworkAddress _fe_addr;
 
+    // never adjust the order of _mem_tracker, _runtime_state, _plan, _pipelines and _drivers, since
+    // _plan depends on _runtime_state and _drivers depends on _mem_tracker and _runtime_state.
     std::unique_ptr<MemTracker> _mem_tracker = nullptr;
     std::shared_ptr<RuntimeState> _runtime_state = nullptr;
     ExecNode* _plan = nullptr; // lives in _runtime_state->obj_pool()

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -161,16 +161,16 @@ void PipelineDriver::finalize(RuntimeState* runtime_state, DriverState state) {
             _fragment_ctx->finish();
             auto status = _fragment_ctx->final_status();
             _fragment_ctx->runtime_state()->exec_env()->driver_dispatcher()->report_exec_state(_fragment_ctx, status,
-                                                                                               true, false);
+                                                                                               true);
         }
     }
     // last finished driver notify FE the fragment's completion again and
     // unregister the FragmentContext.
     if (_fragment_ctx->count_down_drivers()) {
         auto status = _fragment_ctx->final_status();
+        auto fragment_id = _fragment_ctx->fragment_instance_id();
         VLOG_ROW << "[Driver] Last driver finished: final_status=" << status.to_string();
-        _fragment_ctx->runtime_state()->exec_env()->driver_dispatcher()->report_exec_state(_fragment_ctx, status, true,
-                                                                                           true);
+        _query_ctx->count_down_fragments();
     }
 }
 

--- a/be/src/exec/pipeline/pipeline_driver_dispatcher.h
+++ b/be/src/exec/pipeline/pipeline_driver_dispatcher.h
@@ -33,13 +33,8 @@ public:
     // just notify FE timely the completeness of fragment via invocation of report_exec_state, but
     // the FragmentContext is not unregistered until all the drivers has finished, because some
     // non-root drivers maybe has pending io task executed in io threads asynchronously has reference
-    // to objects owned by FragmentContext. so here:
-    // 1. for the first time report_exec_state, clean is false, means not unregister FragmentContext
-    // when all root drivers has finished.
-    //
-    // 2. for the second time report_exec_state, clean is true means that all the drivers has finished,
-    // so now FragmentContext can be unregistered safely.
-    virtual void report_exec_state(FragmentContext* fragment_ctx, const Status& status, bool done, bool clean) = 0;
+    // to objects owned by FragmentContext.
+    virtual void report_exec_state(FragmentContext* fragment_ctx, const Status& status, bool done) = 0;
 };
 
 class GlobalDriverDispatcher final : public FactoryMethod<DriverDispatcher, GlobalDriverDispatcher> {
@@ -49,10 +44,11 @@ public:
     void initialize(int32_t num_threads) override;
     void change_num_threads(int32_t num_threads) override;
     void dispatch(DriverPtr driver) override;
-    void report_exec_state(FragmentContext* fragment_ctx, const Status& status, bool done, bool clean) override;
+    void report_exec_state(FragmentContext* fragment_ctx, const Status& status, bool done) override;
 
 private:
     void run();
+    void finalize_driver(DriverPtr& driver, RuntimeState* runtime_state, DriverState state);
 
 private:
     LimitSetter _num_threads_setter;

--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -26,8 +26,9 @@ QueryContext* QueryContextManager::get_or_register(const TUniqueId& query_id) {
         return iter->second.get();
     }
 
-    auto&& ctx = std::make_unique<QueryContext>();
+    auto&& ctx = std::make_shared<QueryContext>();
     auto* ctx_raw_ptr = ctx.get();
+    ctx_raw_ptr->set_query_id(query_id);
     ctx_raw_ptr->increment_num_fragments();
     _contexts.emplace(query_id, std::move(ctx));
     return ctx_raw_ptr;
@@ -43,9 +44,16 @@ QueryContextPtr QueryContextManager::get(const TUniqueId& query_id) {
     }
 }
 
-void QueryContextManager::unregister(const TUniqueId& query_id) {
+QueryContextPtr QueryContextManager::remove(const TUniqueId& query_id) {
     std::lock_guard lock(_lock);
-    _contexts.erase(query_id);
+    auto it = _contexts.find(query_id);
+    if (it != _contexts.end()) {
+        auto ctx = std::move(it->second);
+        _contexts.erase(it);
+        return ctx;
+    } else {
+        return nullptr;
+    }
 }
 
 } // namespace pipeline


### PR DESCRIPTION
## Changes

Refactor report_exec_status logic.
1. invoke report_exec_status once when fragment instance is finished.
2. ensure that FragmentContext is destructed after all the drivers belonging to this FragmentContext are destructed and QueryContext is destructed after all the FragmentContexts belonging to this QueryContext are destructed.