### PR TITLE
[SR-4697]Fix bug UnsupportedOperationException when colocate clone and drop pa…

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -4772,7 +4772,7 @@ public class Catalog {
     }
 
     public Collection<Partition> getPartitionsIncludeRecycleBin(OlapTable table) {
-        Collection<Partition> partitions = table.getPartitions();
+        Collection<Partition> partitions = new ArrayList<>(table.getPartitions());
         partitions.addAll(recycleBin.getPartitions(table.getId()));
         return partitions;
     }


### PR DESCRIPTION
…rtition at the same time

table.getPartitions() it return HashMap's value 
this value can not support addAll Operation will throw an UnsupportedOperationException
it will cause colocate stable status can not update forever.