### PR TITLE
[SparkConnector] Support fast decimal

### DIFF
--- a/be/src/util/arrow/row_batch.cpp
+++ b/be/src/util/arrow/row_batch.cpp
@@ -86,6 +86,11 @@ Status convert_to_arrow_type(const TypeDescriptor& type, std::shared_ptr<arrow::
     case TYPE_DECIMALV2:
         *result = std::make_shared<arrow::Decimal128Type>(27, 9);
         break;
+    case TYPE_DECIMAL32:
+    case TYPE_DECIMAL64:
+    case TYPE_DECIMAL128:
+        *result = std::make_shared<arrow::Decimal128Type>(type.precision, type.scale);
+        break;
     default:
         return Status::InvalidArgument(strings::Substitute("Unknown primitive type($0)", type.type));
     }


### PR DESCRIPTION
Add StarRocks Decimal32/64/128 to arrow::Decimal128Type conversion.