### PR TITLE
[SR-4810] fix asan error in orc broker load case

### DIFF
--- a/be/src/formats/orc/apache-orc/c++/src/ColumnReader.cc
+++ b/be/src/formats/orc/apache-orc/c++/src/ColumnReader.cc
@@ -757,6 +757,8 @@ void StringDictionaryColumnReader::next(ColumnVectorBatch& rowBatch, uint64_t nu
             } else {
                 // use largest index.
                 codes[i] = static_cast<int64_t>(dictionaryCount);
+                outputStarts[i] = nullptr;
+                outputLengths[i] = 0;
             }
         }
     } else {

--- a/be/src/formats/orc/apache-orc/c++/test/CreateTestFiles.cc
+++ b/be/src/formats/orc/apache-orc/c++/test/CreateTestFiles.cc
@@ -46,20 +46,20 @@ void writeCustomOrcFile(const std::string& filename, const orc::proto::Metadata&
         exit(1);
     }
     orc::proto::PostScript ps;
-    ps.set_footerlength(static_cast<uint64_t>(footer.ByteSize()));
+    ps.set_footerlength(static_cast<uint64_t>(footer.ByteSizeLong()));
     ps.set_compression(orc::proto::NONE);
     ps.set_compressionblocksize(64 * 1024);
     for (size_t i = 0; i < version.size(); ++i) {
         ps.add_version(version[i]);
     }
-    ps.set_metadatalength(static_cast<uint64_t>(metadata.ByteSize()));
+    ps.set_metadatalength(static_cast<uint64_t>(metadata.ByteSizeLong()));
     ps.set_writerversion(writerVersion);
     ps.set_magic("ORC");
     if (!ps.SerializeToOstream(&output)) {
         std::cerr << "Failed to write postscript for " << filename << "\n";
         exit(1);
     }
-    output.put(static_cast<char>(ps.ByteSize()));
+    output.put(static_cast<char>(ps.ByteSizeLong()));
 }
 
 /**

--- a/be/src/formats/orc/apache-orc/c++/test/TestBufferedOutputStream.cc
+++ b/be/src/formats/orc/apache-orc/c++/test/TestBufferedOutputStream.cc
@@ -113,7 +113,7 @@ TEST(BufferedOutputStream, protobuff_serialization) {
 
     EXPECT_TRUE(ps.SerializeToZeroCopyStream(&bufStream));
     bufStream.flush();
-    EXPECT_EQ(ps.ByteSize(), memStream.getLength());
+    EXPECT_EQ(ps.ByteSizeLong(), memStream.getLength());
 
     proto::PostScript ps2;
     ps2.ParseFromArray(memStream.getData(), static_cast<int>(memStream.getLength()));

--- a/be/src/formats/orc/apache-orc/tools/test/TestFileScan.cc
+++ b/be/src/formats/orc/apache-orc/tools/test/TestFileScan.cc
@@ -141,8 +141,7 @@ void checkForError(const std::string& filename, const std::string& error_msg) {
 }
 
 TEST(TestFileScan, testErrorHandling) {
-    checkForError(findExample("corrupt/stripe_footer_bad_column_encodings.orc"),
-                  "bad number of ColumnEncodings in StripeFooter: expected=6, actual=0");
+    checkForError(findExample("corrupt/stripe_footer_bad_column_encodings.orc"), "bad StripeFooter from zlib");
     checkForError(findExample("corrupt/negative_dict_entry_lengths.orc"), "Negative dictionary entry length");
     checkForError(findExample("corrupt/missing_length_stream_in_string_dict.orc"),
                   "LENGTH stream not found in StringDictionaryColumn");


### PR DESCRIPTION
The root cause is, we don't set a default value if the element is null. 

Because in ORCScanner, we use value first anyway, and check if it's null later. If we don't set default value in stringColumnReader, we may copy freed data.