### PR TITLE
[SR-4075] add config properties for pipeline engine

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -622,7 +622,12 @@ CONF_Int64(pipeline_yield_max_chunks_moved, "100");
 // yield PipelineDriver when maximum time in nano-seconds has spent
 // in current execution round.
 CONF_Int64(pipeline_yield_max_time_spent, "100000000");
-
+// the number of io threads pipeline engine.
+CONF_Int64(pipeline_io_thread_pool_thread_num, "3");
+// queue size of io thread pool for pipeline engine.
+CONF_Int64(pipeline_io_thread_pool_queue_size, "102400");
+// the number of execution threads for pipeline engine.
+CONF_Int64(pipeline_exec_thread_pool_thread_num, "3");
 // bitmap serialize version
 CONF_Int16(bitmap_serialize_version, "1");
 

--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -131,6 +131,9 @@ public:
     static Status VersionAlreadyMerged(const Slice& msg, int16_t precise_code = -1, const Slice& msg2 = Slice()) {
         return Status(TStatusCode::OLAP_ERR_VERSION_ALREADY_MERGED, msg, precise_code, msg2);
     }
+    static Status DuplicateRpcInvocation(const Slice& msg, int16_t precise_code = -1, const Slice& msg2 = Slice()) {
+        return Status(TStatusCode::DUPLICATE_RPC_INVOCATION, msg, precise_code, msg2);
+    }
 
     bool ok() const { return _state == nullptr; }
 
@@ -158,6 +161,8 @@ public:
     bool is_data_quality_error() const { return code() == TStatusCode::DATA_QUALITY_ERROR; }
 
     bool is_version_already_merged() const { return code() == TStatusCode::OLAP_ERR_VERSION_ALREADY_MERGED; }
+
+    bool is_duplicate_rpc_invocation() const { return code() == TStatusCode::DUPLICATE_RPC_INVOCATION; }
 
     // Convert into TStatus. Call this if 'status_container' contains an optional
     // TStatus field named 'status'. This also sets __isset.status.

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -45,7 +45,7 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
     if (existing_query_ctx) {
         auto&& existing_fragment_ctx = existing_query_ctx->fragment_mgr()->get(fragment_id);
         if (existing_fragment_ctx) {
-            return Status::OK();
+            return Status::DuplicateRpcInvocation("Duplicate invocations of exec_plan_fragment");
         }
     }
 

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -243,8 +243,12 @@ Status PInternalServiceImpl<T>::_exec_plan_fragment(brpc::Controller* cntl) {
               << is_pipeline;
     if (is_pipeline) {
         auto fragment_executor = std::make_unique<starrocks::pipeline::FragmentExecutor>();
-        RETURN_IF_ERROR(fragment_executor->prepare(_exec_env, t_request));
-        return fragment_executor->execute(_exec_env);
+        auto status = fragment_executor->prepare(_exec_env, t_request);
+        if (status.ok()) {
+            return fragment_executor->execute(_exec_env);
+        } else {
+            return status.is_duplicate_rpc_invocation() ? Status::OK() : status;
+        }
     } else {
         return _exec_env->fragment_mgr()->exec_plan_fragment(t_request);
     }

--- a/gensrc/thrift/Status.thrift
+++ b/gensrc/thrift/Status.thrift
@@ -79,6 +79,7 @@ enum TStatusCode {
     INCOMPLETE          = 44,
     OLAP_ERR_VERSION_ALREADY_MERGED = 45,
     DATA_QUALITY_ERROR  = 46,
+    DUPLICATE_RPC_INVOCATION        = 47,
 
     UNKNOWN = 50
 }


### PR DESCRIPTION
## Changes
1. Add some config properties for pipeline engine to control the number of io threads and execution threads.
2. Bugfix duplicate invocation of exec_plan_fragment.