### PR TITLE
[SR-4698] Optimize getting block locations with a batch api

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaClient.java
@@ -444,9 +444,9 @@ public class HiveMetaClient {
     private List<HdfsFileDesc> getHdfsFileDescs(String dirPath) throws Exception {
         URI uri = new URI(dirPath);
         FileSystem fileSystem = getFileSystem(uri);
-        // fileSystem.listLocatedStatus is a batch api include fileSystem.listStatus
-        // and fileSystem.getFileBlockLocations two api's information.
-        // the performance is well in get many file located information scenario.
+        // fileSystem.listLocatedStatus is an api to list all statuses and
+        // block locations of the files in the given path in one operation.
+        // The performance is better than getting status and block location one by one.
         RemoteIterator<LocatedFileStatus> blockIterator = fileSystem.listLocatedStatus(new Path(uri.getPath()));
         List<HdfsFileDesc> fileDescs = Lists.newArrayList();
 

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaClient.java
@@ -18,7 +18,9 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.hive.common.FileUtils;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaHookLoader;
@@ -68,8 +70,6 @@ public class HiveMetaClient {
     private long storageId = 0;
     private final int UNKNOWN_STORAGE_ID = -1;
     private final AtomicLong partitionIdGen = new AtomicLong(0L);
-
-    private long baseEventId;
 
     // Required for creating an instance of RetryingMetaStoreClient.
     private static final HiveMetaHookLoader dummyHookLoader = tbl -> null;
@@ -444,17 +444,18 @@ public class HiveMetaClient {
     private List<HdfsFileDesc> getHdfsFileDescs(String dirPath) throws Exception {
         URI uri = new URI(dirPath);
         FileSystem fileSystem = getFileSystem(uri);
-        FileStatus[] files = fileSystem.listStatus(new Path(uri.getPath()));
+        RemoteIterator<LocatedFileStatus> blockIterator = fileSystem.listLocatedStatus(new Path(uri.getPath()));
         List<HdfsFileDesc> fileDescs = Lists.newArrayList();
 
-        for (FileStatus fileStatus : files) {
-            if (!isValidDataFile(fileStatus)) {
+        while (blockIterator.hasNext()) {
+            LocatedFileStatus locatedFileStatus = blockIterator.next();
+            if (!isValidDataFile(locatedFileStatus)) {
                 continue;
             }
-            String fileName = Utils.getSuffixName(dirPath, fileStatus.getPath().toString());
-            BlockLocation[] blockLocations = fileSystem.getFileBlockLocations(fileStatus, 0, fileStatus.getLen());
+            String fileName = Utils.getSuffixName(dirPath, locatedFileStatus.getPath().toString());
+            BlockLocation[] blockLocations = locatedFileStatus.getBlockLocations();
             List<HdfsFileBlockDesc> fileBlockDescs = getHdfsFileBlockDescs(blockLocations);
-            fileDescs.add(new HdfsFileDesc(fileName, "", fileStatus.getLen(), ImmutableList.copyOf(fileBlockDescs)));
+            fileDescs.add(new HdfsFileDesc(fileName, "", locatedFileStatus.getLen(), ImmutableList.copyOf(fileBlockDescs)));
         }
         return fileDescs;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaClient.java
@@ -445,7 +445,7 @@ public class HiveMetaClient {
         URI uri = new URI(dirPath);
         FileSystem fileSystem = getFileSystem(uri);
         // fileSystem.listLocatedStatus is a batch api include fileSystem.listStatus
-        // and ileSystem.getFileBlockLocations two api's information.
+        // and fileSystem.getFileBlockLocations two api's information.
         // the performance is well in get many file located information scenario.
         RemoteIterator<LocatedFileStatus> blockIterator = fileSystem.listLocatedStatus(new Path(uri.getPath()));
         List<HdfsFileDesc> fileDescs = Lists.newArrayList();

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaClient.java
@@ -444,6 +444,9 @@ public class HiveMetaClient {
     private List<HdfsFileDesc> getHdfsFileDescs(String dirPath) throws Exception {
         URI uri = new URI(dirPath);
         FileSystem fileSystem = getFileSystem(uri);
+        // fileSystem.listLocatedStatus is a batch api include fileSystem.listStatus
+        // and ileSystem.getFileBlockLocations two api's information.
+        // the performance is well in get many file located information scenario.
         RemoteIterator<LocatedFileStatus> blockIterator = fileSystem.listLocatedStatus(new Path(uri.getPath()));
         List<HdfsFileDesc> fileDescs = Lists.newArrayList();
 


### PR DESCRIPTION
listLocatedStatus is an api to list all statuses and block locations of the files in the given path in one operation. 
The performance is better than getting status and block location one by one.
Performance test indicate that the the latency can be reduced by 68%(30s -> 9.5s) to get metadata of 92 partitions.
Every partition stores 1000 files.
before:
![image](https://user-images.githubusercontent.com/4392280/134798562-fe837030-33a3-4145-9834-10895aa0c0c0.png)
after:
![image](https://user-images.githubusercontent.com/4392280/134798565-f19f6522-088b-4dca-8cab-04ca29732bf0.png)

Because we get metadata in a cache. we take the time of the first query minus the time of the second query as the metadata query time.
therefore it is about 30s -> 9.5s about latency reduced by 68% for getting metadata.