### PR TITLE
Resolve aggregate shuffle hang problem

### DIFF
--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -474,11 +474,8 @@ OperatorPtr ExchangeSinkOperatorFactory::create(int32_t degree_of_parallelism, i
                                                       _sender_id, _dest_node_id, _partition_expr_ctxs);
     } else if (_part_type == TPartitionType::HASH_PARTITIONED ||
                _part_type == TPartitionType::BUCKET_SHFFULE_HASH_PARTITIONED) {
-        // For shuffle, one ExchangeSinkOperator has one destination
-        std::vector<TPlanFragmentDestination> destination;
-        destination.emplace_back(_destinations[driver_sequence]);
-        return std::make_shared<ExchangeSinkOperator>(_id, _plan_node_id, _buffer, _part_type, destination, _sender_id,
-                                                      _dest_node_id, _partition_expr_ctxs);
+        return std::make_shared<ExchangeSinkOperator>(_id, _plan_node_id, _buffer, _part_type, _destinations,
+                                                      _sender_id, _dest_node_id, _partition_expr_ctxs);
     } else {
         DCHECK(false) << " Shouldn't reach here!";
         return nullptr;

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -141,6 +141,7 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state) {
 }
 
 void PipelineDriver::finalize(RuntimeState* runtime_state, DriverState state) {
+    VLOG_ROW << "[Driver] finalize, driver=" << this;
     if (state == DriverState::FINISH || state == DriverState::CANCELED || state == DriverState::INTERNAL_ERROR) {
         auto num_operators = _operators.size();
         for (auto i = _first_unfinished; i < num_operators; ++i) {


### PR DESCRIPTION
Conditions
1. be with 3 copies
2. aggregate through non-partition column

Aggregate streaming operator' output should be shuffled to all the be copies, not just one of the copy, since each be will start a pipeline(including exchange source operator and aggregate blocking operator) waiting for shuffle input. Even if no data to send, exchange sink operator should send a event to wake up the blocking io theads