### PR TITLE
[SR-4075] ExchangeMergeSortSourceOperator hangs because of multiple empty input streams.

### DIFF
--- a/be/src/runtime/data_stream_recvr.cc
+++ b/be/src/runtime/data_stream_recvr.cc
@@ -535,8 +535,9 @@ void DataStreamRecvr::SenderQueue::decrement_senders(int be_number) {
     _sender_eos_set.insert(be_number);
     DCHECK_GT(_num_remaining_senders, 0);
     _num_remaining_senders--;
-    VLOG_FILE << "decremented senders: fragment_instance_id=" << _recvr->fragment_instance_id()
-              << " node_id=" << _recvr->dest_node_id() << " #senders=" << _num_remaining_senders;
+    VLOG_FILE << "decremented senders: fragment_instance_id=" << print_id(_recvr->fragment_instance_id())
+              << " node_id=" << _recvr->dest_node_id() << " #senders=" << _num_remaining_senders
+              << " be_number=" << be_number;
     if (_num_remaining_senders == 0) {
         _data_arrival_cv.notify_one();
     }

--- a/be/src/runtime/vectorized/sorted_chunks_merger.cpp
+++ b/be/src/runtime/vectorized/sorted_chunks_merger.cpp
@@ -74,7 +74,15 @@ bool SortedChunksMerger::is_data_ready() {
             if (_wait_for_data) {
                 return _cursor->has_next() || _cursor->chunk_has_supplier();
             } else {
-                return !_min_heap.empty();
+                // when _wait_for_data is false, min heap is ready to produce output.
+                // case 1: min heap is empty, EOS has arrived.
+                // case 2: min heap is not emtpy, each cursor in min heap must satisfy one of properties following:
+                //     property 1: the current chunk is the cursor is not exhausted, or
+                //     property 2: the SenderQueue of the cursor has chunks ready for processing, or
+                //     property 3: the SenderQueue of the cursor has received the EOS.
+                //
+                // so in conclusion, in such situations, min_heap is always ready.
+                return true;
             }
         }
     }


### PR DESCRIPTION
## Bugfix

For an ExchageMergeSortSourceOperator,  a empty min heap will be built if streams from mulitple ways are empy. is such a situatoins, SortedChunksMerger::is_data_ready should return true and give ExchageMergeSortSourceOperator a chance to produce EOS in pull_chunk's invocation.