### PR TITLE
[SR-4698] Obtain hive metadata of the partitions in parallel

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
@@ -281,10 +281,10 @@ public class HiveTable extends Table {
             LOG.warn("table {} gets partitions stats failed.", name, e);
         }
 
-        int i = 0;
-        for (HivePartitionStats partitionStats : partitionsStats) {
-            long partNumRows = partitionStats.getNumRows();
-            long partTotalFileBytes = partitionStats.getTotalFileBytes();
+
+        for (int i = 0; i < partitionsStats.size(); i++) {
+            long partNumRows = partitionsStats.get(i).getNumRows();
+            long partTotalFileBytes = partitionsStats.get(i).getTotalFileBytes();
             // -1: missing stats
             if (partNumRows > -1) {
                 if (numRows == -1) {
@@ -295,7 +295,6 @@ public class HiveTable extends Table {
                 LOG.debug("table {} partition {} stats abnormal. num rows: {}, total file bytes: {}",
                         name, partitions.get(i), partNumRows, partTotalFileBytes);
             }
-            i++;
         }
         return numRows;
     }
@@ -476,15 +475,13 @@ public class HiveTable extends Table {
             return null;
         }
 
-        int i = 0;
-        for (HivePartition hivePartition : hivePartitions) {
-            // HiveRepository.getPartitions future to ensure an orderly
+        for (int i = 0; i < hivePartitions.size(); i++) {
             ReferencedPartitionInfo info = partitions.get(i);
             PartitionKey key = info.getKey();
             long partitionId = info.getId();
 
             THdfsPartition tPartition = new THdfsPartition();
-            tPartition.setFile_format(hivePartition.getFormat().toThrift());
+            tPartition.setFile_format(hivePartitions.get(i).getFormat().toThrift());
 
             List<LiteralExpr> keys = key.getKeys();
             keys.forEach(v -> v.setUseVectorized(true));
@@ -492,10 +489,9 @@ public class HiveTable extends Table {
 
             THdfsPartitionLocation tPartitionLocation = new THdfsPartitionLocation();
             tPartitionLocation.setPrefix_index(-1);
-            tPartitionLocation.setSuffix(hivePartition.getFullPath());
+            tPartitionLocation.setSuffix(hivePartitions.get(i).getFullPath());
             tPartition.setLocation(tPartitionLocation);
             tHdfsTable.putToPartitions(partitionId, tPartition);
-            i++;
         }
 
         TTableDescriptor tTableDescriptor = new TTableDescriptor(id, TTableType.HDFS_TABLE, fullSchema.size(),

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
@@ -156,10 +156,10 @@ public class HiveTable extends Table {
                 .getPartition(resourceName, hiveDb, hiveTable, partitionKey);
     }
 
-    public List<HivePartition> getPartitions(List<PartitionKey> partitionInfos)
+    public List<HivePartition> getPartitions(List<PartitionKey> partitionKeys)
             throws DdlException {
         return Catalog.getCurrentCatalog().getHiveRepository()
-                .getPartitions(resourceName, hiveDb, hiveTable, partitionInfos);
+                .getPartitions(resourceName, hiveDb, hiveTable, partitionKeys);
     }
 
     public HiveTableStats getTableStats() throws DdlException {
@@ -281,6 +281,7 @@ public class HiveTable extends Table {
             LOG.warn("table {} gets partitions stats failed.", name, e);
         }
 
+        int i = 0;
         for (HivePartitionStats partitionStats : partitionsStats) {
             long partNumRows = partitionStats.getNumRows();
             long partTotalFileBytes = partitionStats.getTotalFileBytes();
@@ -292,8 +293,9 @@ public class HiveTable extends Table {
                 numRows += partNumRows;
             } else {
                 LOG.debug("table {} partition {} stats abnormal. num rows: {}, total file bytes: {}",
-                        name, partitionStats.getKey(), partNumRows, partTotalFileBytes);
+                        name, partitions.get(i), partNumRows, partTotalFileBytes);
             }
+            i++;
         }
         return numRows;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -306,6 +306,12 @@ public class Config extends ConfigBase {
     public static int max_agent_task_threads_num = 4096;
 
     /**
+     * num of thread to handle hive meta load concurrency.
+     */
+    @ConfField(masterOnly = true)
+    public static int hive_meta_load_concurrency = 4;
+
+    /**
      * the max txn number which bdbje can rollback when trying to rejoin the group
      */
     @ConfField

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -308,7 +308,7 @@ public class Config extends ConfigBase {
     /**
      * num of thread to handle hive meta load concurrency.
      */
-    @ConfField(masterOnly = true)
+    @ConfField
     public static int hive_meta_load_concurrency = 4;
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HivePartition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HivePartition.java
@@ -3,11 +3,13 @@
 package com.starrocks.external.hive;
 
 import com.google.common.collect.ImmutableList;
+import com.starrocks.analysis.DescriptorTable;
 
 public class HivePartition {
     private HdfsFileFormat format;
     private ImmutableList<HdfsFileDesc> files;
     private String fullPath;
+    private DescriptorTable.ReferencedPartitionInfo partitionInfo;
 
     public HivePartition(HdfsFileFormat format, ImmutableList<HdfsFileDesc> files, String fullPath) {
         this.format = format;
@@ -30,4 +32,13 @@ public class HivePartition {
     public String getFullPath() {
         return fullPath;
     }
+
+    public DescriptorTable.ReferencedPartitionInfo getPartitionInfo() {
+        return partitionInfo;
+    }
+
+    public void setPartitionInfo(DescriptorTable.ReferencedPartitionInfo partitionInfo) {
+        this.partitionInfo = partitionInfo;
+    }
+
 }

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HivePartition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HivePartition.java
@@ -3,13 +3,11 @@
 package com.starrocks.external.hive;
 
 import com.google.common.collect.ImmutableList;
-import com.starrocks.analysis.DescriptorTable;
 
 public class HivePartition {
     private HdfsFileFormat format;
     private ImmutableList<HdfsFileDesc> files;
     private String fullPath;
-    private DescriptorTable.ReferencedPartitionInfo partitionInfo;
 
     public HivePartition(HdfsFileFormat format, ImmutableList<HdfsFileDesc> files, String fullPath) {
         this.format = format;
@@ -31,14 +29,6 @@ public class HivePartition {
 
     public String getFullPath() {
         return fullPath;
-    }
-
-    public DescriptorTable.ReferencedPartitionInfo getPartitionInfo() {
-        return partitionInfo;
-    }
-
-    public void setPartitionInfo(DescriptorTable.ReferencedPartitionInfo partitionInfo) {
-        this.partitionInfo = partitionInfo;
     }
 
 }

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HivePartitionStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HivePartitionStats.java
@@ -2,12 +2,18 @@
 
 package com.starrocks.external.hive;
 
+import com.starrocks.analysis.LiteralExpr;
+
+import java.util.List;
+
 public class HivePartitionStats {
     // -1: unknown
     // from partition parameters
     private long numRows;
     // the size (in bytes) of all the files inside this partition
     private long totalFileBytes;
+    // the key for this hive partition;
+    private List<LiteralExpr> key;
 
     public HivePartitionStats(long numRows) {
         this.numRows = numRows;
@@ -23,5 +29,13 @@ public class HivePartitionStats {
 
     public long getTotalFileBytes() {
         return totalFileBytes;
+    }
+
+    public List<LiteralExpr> getKey() {
+        return key;
+    }
+
+    public void setKey(List<LiteralExpr> key) {
+        this.key = key;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HivePartitionStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HivePartitionStats.java
@@ -2,18 +2,12 @@
 
 package com.starrocks.external.hive;
 
-import com.starrocks.analysis.LiteralExpr;
-
-import java.util.List;
-
 public class HivePartitionStats {
     // -1: unknown
     // from partition parameters
     private long numRows;
     // the size (in bytes) of all the files inside this partition
     private long totalFileBytes;
-    // the key for this hive partition;
-    private List<LiteralExpr> key;
 
     public HivePartitionStats(long numRows) {
         this.numRows = numRows;
@@ -29,13 +23,5 @@ public class HivePartitionStats {
 
     public long getTotalFileBytes() {
         return totalFileBytes;
-    }
-
-    public List<LiteralExpr> getKey() {
-        return key;
-    }
-
-    public void setKey(List<LiteralExpr> key) {
-        this.key = key;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveRepository.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveRepository.java
@@ -140,6 +140,7 @@ public class HiveRepository {
                 result.add(future.get());
             } catch (InterruptedException | ExecutionException e) {
                 LOG.warn("get table {}.{} partition meta info failed.", dbName, tableName,  e);
+                throw new DdlException("get table " + dbName + "." + tableName + " partition meta info failed.", e);
             }
         }
         return result;
@@ -162,11 +163,7 @@ public class HiveRepository {
         List<Future<HivePartitionStats>> futures = Lists.newArrayList();
         for (PartitionKey partitionKey : partitionKeys) {
             Future<HivePartitionStats> future = partitionDaemonExecutor.
-                    submit(() -> {
-                        HivePartitionStats partitionStats = metaCache.getPartitionStats(dbName, tableName, partitionKey);
-                        partitionStats.setKey(partitionKey.getKeys());
-                        return partitionStats;
-                    });
+                    submit(() -> metaCache.getPartitionStats(dbName, tableName, partitionKey));
             futures.add(future);
         }
         List<HivePartitionStats> result = Lists.newArrayList();
@@ -175,6 +172,7 @@ public class HiveRepository {
                 result.add(future.get());
             } catch (InterruptedException | ExecutionException e) {
                 LOG.warn("get table {}.{} partition stats meta info failed.", dbName, tableName,  e);
+                throw new DdlException("get table " + dbName + "." + tableName + " partition meta info failed.", e);
             }
         }
         return result;

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveRepository.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveRepository.java
@@ -39,9 +39,9 @@ public class HiveRepository {
 
     Executor executor = Executors.newFixedThreadPool(100);
     private static final Logger LOG = LogManager.getLogger(HiveRepository.class);
-    private ExecutorService partitionDaemonExecutor =
+    private final ExecutorService partitionDaemonExecutor =
             ThreadPoolManager.newDaemonFixedThreadPool(Config.hive_meta_load_concurrency,
-                    10000, "hive-meta-concurrency-pool", true);
+                    Integer.MAX_VALUE, "hive-meta-concurrency-pool", true);
 
     public HiveMetaClient getClient(String resourceName) throws DdlException {
         HiveMetaClient client;

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveRepository.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveRepository.java
@@ -3,20 +3,29 @@
 package com.starrocks.external.hive;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.starrocks.analysis.DescriptorTable;
 import com.starrocks.catalog.Catalog;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.HiveResource;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Resource;
 import com.starrocks.catalog.Resource.ResourceType;
+import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.ThreadPoolManager;
 import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -30,6 +39,10 @@ public class HiveRepository {
     ReadWriteLock metaCachesLock = new ReentrantReadWriteLock();
 
     Executor executor = Executors.newFixedThreadPool(100);
+    private static final Logger LOG = LogManager.getLogger(HiveRepository.class);
+    private ExecutorService partitionDaemonExecutor =
+            ThreadPoolManager.newDaemonFixedThreadPool(Config.hive_meta_load_concurrency,
+                    10000, "hive-meta-concurrency-pool", true);
 
     public HiveMetaClient getClient(String resourceName) throws DdlException {
         HiveMetaClient client;
@@ -112,6 +125,31 @@ public class HiveRepository {
         return metaCache.getPartition(dbName, tableName, partitionKey);
     }
 
+    public List<HivePartition> getPartitions(String resourceName, String dbName, String tableName,
+                                             List<DescriptorTable.ReferencedPartitionInfo> partitionInfos)
+            throws DdlException {
+        HiveMetaCache metaCache = getMetaCache(resourceName);
+        List<Future<HivePartition>> futures = Lists.newArrayList();
+        for (DescriptorTable.ReferencedPartitionInfo partitionInfo : partitionInfos) {
+            Future<HivePartition> future = partitionDaemonExecutor.
+                    submit(() -> {
+                        HivePartition partition = metaCache.getPartition(dbName, tableName, partitionInfo.getKey());
+                        partition.setPartitionInfo(partitionInfo);
+                        return partition;
+                    });
+            futures.add(future);
+        }
+        List<HivePartition> result = Lists.newArrayList();
+        for (Future<HivePartition> future : futures) {
+            try {
+                result.add(future.get());
+            } catch (InterruptedException | ExecutionException e) {
+                LOG.warn("get table {}.{} partition meta info failed.", dbName, tableName,  e);
+            }
+        }
+        return result;
+    }
+
     public HiveTableStats getTableStats(String resourceName, String dbName, String tableName) throws DdlException {
         HiveMetaCache metaCache = getMetaCache(resourceName);
         return metaCache.getTableStats(dbName, tableName);
@@ -121,6 +159,30 @@ public class HiveRepository {
                                                 String tableName, PartitionKey partitionKey) throws DdlException {
         HiveMetaCache metaCache = getMetaCache(resourceName);
         return metaCache.getPartitionStats(dbName, tableName, partitionKey);
+    }
+
+    public List<HivePartitionStats> getPartitionsStats(String resourceName, String dbName,
+                                                String tableName, List<PartitionKey> partitionKeys) throws DdlException {
+        HiveMetaCache metaCache = getMetaCache(resourceName);
+        List<Future<HivePartitionStats>> futures = Lists.newArrayList();
+        for (PartitionKey partitionKey : partitionKeys) {
+            Future<HivePartitionStats> future = partitionDaemonExecutor.
+                    submit(() -> {
+                        HivePartitionStats partitionStats = metaCache.getPartitionStats(dbName, tableName, partitionKey);
+                        partitionStats.setKey(partitionKey.getKeys());
+                        return partitionStats;
+                    });
+            futures.add(future);
+        }
+        List<HivePartitionStats> result = Lists.newArrayList();
+        for (Future<HivePartitionStats> future : futures) {
+            try {
+                result.add(future.get());
+            } catch (InterruptedException | ExecutionException e) {
+                LOG.warn("get table {}.{} partition stats meta info failed.", dbName, tableName,  e);
+            }
+        }
+        return result;
     }
 
     public ImmutableMap<String, HiveColumnStats> getTableLevelColumnStats(String resourceName, String dbName,

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
@@ -358,20 +358,18 @@ public class HdfsScanNode extends ScanNode {
         }
         List<HivePartition> hivePartitions = hiveTable.getPartitions(partitionKeys);
 
-        int i = 0;
-        for (HivePartition hivePartition : hivePartitions) {
-            // HiveRepository.getPartitions future to ensure an orderly
+        for (int i = 0; i < hivePartitions.size(); i++) {
             descTbl.addReferencedPartitions(hiveTable, partitionInfos.get(i));
-            for (HdfsFileDesc fileDesc : hivePartition.getFiles()) {
+            for (HdfsFileDesc fileDesc : hivePartitions.get(i).getFiles()) {
                 totalBytes += fileDesc.getLength();
                 for (HdfsFileBlockDesc blockDesc : fileDesc.getBlockDescs()) {
-                    addScanRangeLocations(partitionInfos.get(i).getId(), fileDesc, blockDesc, hivePartition.getFormat());
+                    addScanRangeLocations(partitionInfos.get(i).getId(), fileDesc, blockDesc,
+                            hivePartitions.get(i).getFormat());
                     LOG.debug("add scan range success. partition: {}, file: {}, block: {}-{}",
-                            hivePartition.getFullPath(), fileDesc.getFileName(), blockDesc.getOffset(),
+                            hivePartitions.get(i).getFullPath(), fileDesc.getFileName(), blockDesc.getOffset(),
                             blockDesc.getLength());
                 }
             }
-            i++;
         }
         LOG.debug("get {} scan range locations cost: {} ms", result.size(), (System.currentTimeMillis() - start));
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -463,11 +463,7 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
             return 0;
         }
 
-        List<PartitionKey> partitionInfos = Lists.newArrayList();
-        for (long partitionId : selectedPartitionIds) {
-            partitionInfos.add(idToPartitionKey.get(partitionId));
-        }
-        List<HivePartition> hivePartitions = hiveTable.getPartitions(partitionInfos);
+        List<HivePartition> hivePartitions = hiveTable.getPartitions(partitions);
         for (HivePartition hivePartition : hivePartitions) {
             for (HdfsFileDesc fileDesc : hivePartition.getFiles()) {
                 totalBytes += fileDesc.getLength();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -7,7 +7,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
 import com.starrocks.analysis.DateLiteral;
-import com.starrocks.analysis.DescriptorTable;
 import com.starrocks.analysis.JoinOperator;
 import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.catalog.Catalog;
@@ -464,10 +463,9 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
             return 0;
         }
 
-        List<DescriptorTable.ReferencedPartitionInfo> partitionInfos = Lists.newArrayList();
+        List<PartitionKey> partitionInfos = Lists.newArrayList();
         for (long partitionId : selectedPartitionIds) {
-            partitionInfos.add(new DescriptorTable.ReferencedPartitionInfo(partitionId,
-                    idToPartitionKey.get(partitionId)));
+            partitionInfos.add(idToPartitionKey.get(partitionId));
         }
         List<HivePartition> hivePartitions = hiveTable.getPartitions(partitionInfos);
         for (HivePartition hivePartition : hivePartitions) {

--- a/fe/fe-core/src/test/java/com/starrocks/planner/HdfsScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/HdfsScanNodeTest.java
@@ -94,12 +94,13 @@ public class HdfsScanNodeTest {
         partitionCols.add(partitionCol);
 
         Map<PartitionKey, Long> partitionKeys = Maps.newHashMap();
-        partitionKeys.put(PartitionKey.createPartitionKey(Lists.newArrayList(new PartitionValue("1")), partitionCols),
-                0L);
+        PartitionKey partitionKey = PartitionKey.createPartitionKey(Lists.newArrayList(new PartitionValue("1")), partitionCols);
+        partitionKeys.put(partitionKey, 0L);
 
         HdfsFileBlockDesc blockDesc = new HdfsFileBlockDesc(0, 100, new long[] {0}, null, client);
         HdfsFileDesc fileDesc = new HdfsFileDesc("/00000_0", "", 100, ImmutableList.of(blockDesc));
         HivePartition p0 = new HivePartition(HdfsFileFormat.PARQUET, ImmutableList.of(fileDesc), "path/part_col=1");
+        p0.setPartitionInfo(new DescriptorTable.ReferencedPartitionInfo(1, partitionKey));
 
         new Expectations() {
             {
@@ -109,8 +110,8 @@ public class HdfsScanNodeTest {
                 result = partitionCols;
                 table.getPartitionKeys();
                 result = partitionKeys;
-                table.getPartition((PartitionKey) any);
-                result = p0;
+                table.getPartitions((List< DescriptorTable.ReferencedPartitionInfo >) any);
+                result = Lists.newArrayList(p0);
                 table.getExtrapolatedRowCount(anyLong);
                 result = -1;
                 table.getPartitionStatsRowCount((List<PartitionKey>) any);
@@ -156,7 +157,9 @@ public class HdfsScanNodeTest {
         HdfsFileDesc fileDesc1 = new HdfsFileDesc("/00000_1", "", 200, ImmutableList.of(blockDesc, blockDesc1));
         HivePartition p2 = new HivePartition(HdfsFileFormat.PARQUET, ImmutableList.of(fileDesc, fileDesc1),
                 "path/part_col=2");
+        p2.setPartitionInfo(new DescriptorTable.ReferencedPartitionInfo(2, key2));
         HivePartition p3 = new HivePartition(HdfsFileFormat.PARQUET, ImmutableList.of(fileDesc), "path/part_col=3");
+        p3.setPartitionInfo(new DescriptorTable.ReferencedPartitionInfo(3, key3));
 
         SlotDescriptor partColSlotDesc = new SlotDescriptor(new SlotId(0), tupleDesc);
         partColSlotDesc.setColumn(partitionCol);
@@ -174,10 +177,8 @@ public class HdfsScanNodeTest {
                 result = partitionCols;
                 table.getPartitionKeys();
                 result = partitionKeys;
-                table.getPartition(key2);
-                result = p2;
-                table.getPartition(key3);
-                result = p3;
+                table.getPartitions((List< DescriptorTable.ReferencedPartitionInfo >) any);
+                result = Lists.newArrayList(p2, p3);
                 table.getExtrapolatedRowCount(400);
                 result = 50;
             }
@@ -208,12 +209,13 @@ public class HdfsScanNodeTest {
         partitionCols.add(partitionCol);
 
         Map<PartitionKey, Long> partitionKeys = Maps.newHashMap();
-        partitionKeys.put(PartitionKey.createPartitionKey(Lists.newArrayList(new PartitionValue("1")), partitionCols),
-                0L);
+        PartitionKey partitionKey = PartitionKey.createPartitionKey(Lists.newArrayList(new PartitionValue("1")), partitionCols);
+        partitionKeys.put(partitionKey, 0L);
 
         HdfsFileBlockDesc blockDesc = new HdfsFileBlockDesc(0, 100, new long[] {0}, null, client);
         HdfsFileDesc fileDesc = new HdfsFileDesc("/00000_0", "", 100, ImmutableList.of(blockDesc));
         HivePartition p0 = new HivePartition(HdfsFileFormat.PARQUET, ImmutableList.of(fileDesc), "path/part_col=1");
+        p0.setPartitionInfo(new DescriptorTable.ReferencedPartitionInfo(1, partitionKey));
 
         SlotDescriptor partColSlotDesc = new SlotDescriptor(new SlotId(0), tupleDesc);
         partColSlotDesc.setColumn(partitionCol);
@@ -238,8 +240,8 @@ public class HdfsScanNodeTest {
                 result = partitionCols;
                 table.getPartitionKeys();
                 result = partitionKeys;
-                table.getPartition((PartitionKey) any);
-                result = p0;
+                table.getPartitions((List< DescriptorTable.ReferencedPartitionInfo >) any);
+                result = Lists.newArrayList(p0);
                 table.getExtrapolatedRowCount(anyLong);
                 result = -1;
                 table.getPartitionStatsRowCount((List<PartitionKey>) any);

--- a/fe/fe-core/src/test/java/com/starrocks/planner/HdfsScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/HdfsScanNodeTest.java
@@ -100,7 +100,6 @@ public class HdfsScanNodeTest {
         HdfsFileBlockDesc blockDesc = new HdfsFileBlockDesc(0, 100, new long[] {0}, null, client);
         HdfsFileDesc fileDesc = new HdfsFileDesc("/00000_0", "", 100, ImmutableList.of(blockDesc));
         HivePartition p0 = new HivePartition(HdfsFileFormat.PARQUET, ImmutableList.of(fileDesc), "path/part_col=1");
-        p0.setPartitionInfo(new DescriptorTable.ReferencedPartitionInfo(1, partitionKey));
 
         new Expectations() {
             {
@@ -110,7 +109,7 @@ public class HdfsScanNodeTest {
                 result = partitionCols;
                 table.getPartitionKeys();
                 result = partitionKeys;
-                table.getPartitions((List< DescriptorTable.ReferencedPartitionInfo >) any);
+                table.getPartitions((List<PartitionKey>) any);
                 result = Lists.newArrayList(p0);
                 table.getExtrapolatedRowCount(anyLong);
                 result = -1;
@@ -157,9 +156,7 @@ public class HdfsScanNodeTest {
         HdfsFileDesc fileDesc1 = new HdfsFileDesc("/00000_1", "", 200, ImmutableList.of(blockDesc, blockDesc1));
         HivePartition p2 = new HivePartition(HdfsFileFormat.PARQUET, ImmutableList.of(fileDesc, fileDesc1),
                 "path/part_col=2");
-        p2.setPartitionInfo(new DescriptorTable.ReferencedPartitionInfo(2, key2));
         HivePartition p3 = new HivePartition(HdfsFileFormat.PARQUET, ImmutableList.of(fileDesc), "path/part_col=3");
-        p3.setPartitionInfo(new DescriptorTable.ReferencedPartitionInfo(3, key3));
 
         SlotDescriptor partColSlotDesc = new SlotDescriptor(new SlotId(0), tupleDesc);
         partColSlotDesc.setColumn(partitionCol);
@@ -177,7 +174,7 @@ public class HdfsScanNodeTest {
                 result = partitionCols;
                 table.getPartitionKeys();
                 result = partitionKeys;
-                table.getPartitions((List< DescriptorTable.ReferencedPartitionInfo >) any);
+                table.getPartitions((List<PartitionKey>) any);
                 result = Lists.newArrayList(p2, p3);
                 table.getExtrapolatedRowCount(400);
                 result = 50;
@@ -215,7 +212,6 @@ public class HdfsScanNodeTest {
         HdfsFileBlockDesc blockDesc = new HdfsFileBlockDesc(0, 100, new long[] {0}, null, client);
         HdfsFileDesc fileDesc = new HdfsFileDesc("/00000_0", "", 100, ImmutableList.of(blockDesc));
         HivePartition p0 = new HivePartition(HdfsFileFormat.PARQUET, ImmutableList.of(fileDesc), "path/part_col=1");
-        p0.setPartitionInfo(new DescriptorTable.ReferencedPartitionInfo(1, partitionKey));
 
         SlotDescriptor partColSlotDesc = new SlotDescriptor(new SlotId(0), tupleDesc);
         partColSlotDesc.setColumn(partitionCol);
@@ -240,7 +236,7 @@ public class HdfsScanNodeTest {
                 result = partitionCols;
                 table.getPartitionKeys();
                 result = partitionKeys;
-                table.getPartitions((List< DescriptorTable.ReferencedPartitionInfo >) any);
+                table.getPartitions((List<PartitionKey>) any);
                 result = Lists.newArrayList(p0);
                 table.getExtrapolatedRowCount(anyLong);
                 result = -1;


### PR DESCRIPTION
Currently, we obtain Hive metadata in serial mode.
like Impala and Presto, their implementations are default 4 concurrent fetched at the partition level.
concurrent fetch performance improves.

before:
![image](https://user-images.githubusercontent.com/4392280/134868792-5e2985ac-9852-4ca8-b606-994f59632b67.png)
after:
![image](https://user-images.githubusercontent.com/4392280/134868880-02a67155-0b15-4352-89a9-38b0f3979e9c.png)

after 4 concurrent optimizations, multiple tests showed an average of about a 2x improvement in performance.
As shown in figure, about
(49.41-40.15) / (44.49-40.19) = 2.13x improvement for get metadata phrase.