### PR TITLE
[SR-4881] Remove re-use operators and fix close expr

### DIFF
--- a/be/src/exec/pipeline/pipeline_builder.cpp
+++ b/be/src/exec/pipeline/pipeline_builder.cpp
@@ -6,7 +6,7 @@
 
 namespace starrocks::pipeline {
 
-void PipelineBuilderContext::maybe_interpolate_local_exchange(OpFactories& pred_operators) {
+OpFactories PipelineBuilderContext::maybe_interpolate_local_exchange(OpFactories& pred_operators) {
     // predecessor pipeline has multiple drivers that will produce multiple output streams, but sort operator is
     // not parallelized now and can not accept multiple streams as input, so add a LocalExchange to gather multiple
     // streams and produce one output stream piping into the sort operator.
@@ -22,11 +22,15 @@ void PipelineBuilderContext::maybe_interpolate_local_exchange(OpFactories& pred_
         pred_operators.emplace_back(std::move(local_exchange_sink));
         // predecessor pipeline comes to end.
         add_pipeline(pred_operators);
+
+        OpFactories operators_source_with_local_exchange;
         // Multiple LocalChangeSinkOperators pipe into one LocalChangeSourceOperator.
         local_exchange_source->set_degree_of_parallelism(1);
-        // pred_operators is re-used, and a new pipeline is created, LocalExchangeSourceOperator is added as the
-        // head of the pipeline.
-        pred_operators.emplace_back(local_exchange_source);
+        // A new pipeline is created, LocalExchangeSourceOperator is added as the head of the pipeline.
+        operators_source_with_local_exchange.emplace_back(std::move(local_exchange_source));
+        return operators_source_with_local_exchange;
+    } else {
+        return pred_operators;
     }
 }
 

--- a/be/src/exec/pipeline/pipeline_builder.h
+++ b/be/src/exec/pipeline/pipeline_builder.h
@@ -22,7 +22,7 @@ public:
         _pipelines.emplace_back(std::make_unique<Pipeline>(next_pipe_id(), operators));
     }
 
-    void maybe_interpolate_local_exchange(OpFactories& pred_operators);
+    OpFactories maybe_interpolate_local_exchange(OpFactories& pred_operators);
 
     uint32_t next_pipe_id() { return _next_pipeline_id++; }
 

--- a/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
@@ -139,7 +139,7 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > AggregateBlockingNode::
         pipeline::PipelineBuilderContext* context) {
     using namespace pipeline;
     OpFactories operators_with_sink = _children[0]->decompose_to_pipeline(context);
-    context->maybe_interpolate_local_exchange(operators_with_sink);
+    operators_with_sink = context->maybe_interpolate_local_exchange(operators_with_sink);
 
     // shared by sink operator and source operator
     AggregatorPtr aggregator = std::make_shared<Aggregator>(_tnode, child(0)->row_desc());

--- a/be/src/exec/vectorized/aggregate/aggregate_streaming_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_streaming_node.cpp
@@ -222,7 +222,7 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > AggregateStreamingNode:
         pipeline::PipelineBuilderContext* context) {
     using namespace pipeline;
     OpFactories operators_with_sink = _children[0]->decompose_to_pipeline(context);
-    context->maybe_interpolate_local_exchange(operators_with_sink);
+    operators_with_sink = context->maybe_interpolate_local_exchange(operators_with_sink);
 
     // shared by sink operator and source operator
     AggregatorPtr aggregator = std::make_shared<Aggregator>(_tnode, child(0)->row_desc());

--- a/be/src/exec/vectorized/aggregate/distinct_blocking_node.cpp
+++ b/be/src/exec/vectorized/aggregate/distinct_blocking_node.cpp
@@ -124,7 +124,7 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > DistinctBlockingNode::d
         pipeline::PipelineBuilderContext* context) {
     using namespace pipeline;
     OpFactories operators_with_sink = _children[0]->decompose_to_pipeline(context);
-    context->maybe_interpolate_local_exchange(operators_with_sink);
+    operators_with_sink = context->maybe_interpolate_local_exchange(operators_with_sink);
 
     // shared by sink operator and source operator
     AggregatorPtr aggregator = std::make_shared<Aggregator>(_tnode, child(0)->row_desc());

--- a/be/src/exec/vectorized/aggregate/distinct_streaming_node.cpp
+++ b/be/src/exec/vectorized/aggregate/distinct_streaming_node.cpp
@@ -208,7 +208,7 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > DistinctStreamingNode::
         pipeline::PipelineBuilderContext* context) {
     using namespace pipeline;
     OpFactories operators_with_sink = _children[0]->decompose_to_pipeline(context);
-    context->maybe_interpolate_local_exchange(operators_with_sink);
+    operators_with_sink = context->maybe_interpolate_local_exchange(operators_with_sink);
 
     // shared by sink operator and source operator
     AggregatorPtr aggregator = std::make_shared<Aggregator>(_tnode, child(0)->row_desc());

--- a/be/src/exec/vectorized/topn_node.cpp
+++ b/be/src/exec/vectorized/topn_node.cpp
@@ -223,7 +223,7 @@ pipeline::OpFactories TopNNode::decompose_to_pipeline(pipeline::PipelineBuilderC
     // step 0: construct pipeline end with sort operator.
     // get operators before sort operator
     OpFactories operators_sink_with_sort = _children[0]->decompose_to_pipeline(context);
-    context->maybe_interpolate_local_exchange(operators_sink_with_sort);
+    operators_sink_with_sort = context->maybe_interpolate_local_exchange(operators_sink_with_sort);
 
     static const uint SIZE_OF_CHUNK_FOR_TOPN = 3000;
     static const uint SIZE_OF_CHUNK_FOR_FULL_SORT = 5000;


### PR DESCRIPTION
- Remove operators re-use in maybe_interpolate_local_exchange.
- Close _conjunct_ctxs only once.