### PR TITLE
[Bug][QSXQ-602] fix late materialize error in array column

### DIFF
--- a/be/src/storage/rowset/segment_v2/column_writer.cpp
+++ b/be/src/storage/rowset/segment_v2/column_writer.cpp
@@ -586,12 +586,12 @@ Status ScalarColumnWriter::append_array_offsets(const vectorized::Column& column
 
         _next_rowid += num_written;
         raw_data += field_size * num_written;
+        _previous_ordinal += data[offset_ordinal + num_written] - data[offset_ordinal];
+        offset_ordinal += num_written;
         if (page_full) {
             RETURN_IF_ERROR(finish_current_page());
             _element_ordinal = _previous_ordinal;
         }
-        _previous_ordinal += data[offset_ordinal + num_written] - data[offset_ordinal];
-        offset_ordinal += num_written;
         remaining -= num_written;
     }
     return Status::OK();


### PR DESCRIPTION
if page size was 1024,1024,1024
_element_ordinal Sequence in flush page was 0,0,1024
but our Expectations result was 0,1024,2048


will close #474 