### PR TITLE
Fix starrocks env get error : catalog.java [796]

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -793,7 +793,7 @@ public class Catalog {
         // 1. check and create dirs and files
         File meta = new File(metaDir);
         if (!meta.exists()) {
-            String oldMetaDir = System.getenv("DORIS_HOME") + "/doris-meta";
+            String oldMetaDir = System.getenv("STARROCKS_HOME") + "/doris-meta";
             File oldMeta = new File(oldMetaDir);
             if (oldMeta.exists()) {
                 // For backward compatible


### PR DESCRIPTION
If the meta-directory used by my cluster of the old version is doris-meta, upgrade to the new version and check whether the metadata directory exists. If it does not, metadata information will be read from the metadata directory of the old version. However, the current code gets the old metadata directory through DORIS_HOME, which causes fe startup failures