### PR TITLE
[SR-4075] Promote shared exprs across drivers to their pipeline

### DIFF
--- a/be/src/exec/pipeline/exchange/exchange_merge_sort_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_merge_sort_source_operator.cpp
@@ -126,4 +126,14 @@ Status ExchangeMergeSortSourceOperator::get_next_merging(RuntimeState* state, Ch
     return Status::OK();
 }
 
+Status ExchangeMergeSortSourceOperatorFactory::prepare(RuntimeState* state, MemTracker* mem_tracker) {
+    RETURN_IF_ERROR(_sort_exec_exprs->prepare(state, _row_desc, _row_desc, mem_tracker));
+    RETURN_IF_ERROR(_sort_exec_exprs->open(state));
+    return Status::OK();
+}
+
+void ExchangeMergeSortSourceOperatorFactory::close(RuntimeState* state) {
+    _sort_exec_exprs->close(state);
+}
+
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/exchange/exchange_merge_sort_source_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_merge_sort_source_operator.h
@@ -81,6 +81,9 @@ public:
                                                                  _limit);
     }
 
+    Status prepare(RuntimeState* state, MemTracker* mem_tracker) override;
+    void close(RuntimeState* state) override;
+
 private:
     int32_t _num_sender;
     const RowDescriptor& _row_desc;

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.h
@@ -148,6 +148,10 @@ public:
 
     OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override;
 
+    Status prepare(RuntimeState* state, MemTracker* mem_tracker) override;
+
+    void close(RuntimeState* state) override;
+
 private:
     std::shared_ptr<SinkBuffer> _buffer;
 

--- a/be/src/exec/pipeline/fragment_context.h
+++ b/be/src/exec/pipeline/fragment_context.h
@@ -24,6 +24,7 @@ class FragmentContext {
 public:
     FragmentContext() : _cancel_flag(false) {}
     ~FragmentContext() {
+        close_all_pipelines();
         if (_plan != nullptr) {
             _plan->close(_runtime_state.get());
         }
@@ -83,6 +84,19 @@ public:
     bool is_canceled() { return _cancel_flag.load(std::memory_order_acquire) == true; }
 
     MorselQueueMap& morsel_queues() { return _morsel_queues; }
+
+    Status prepare_all_pipelines() {
+        for (auto& pipe : _pipelines) {
+            RETURN_IF_ERROR(pipe->prepare(_runtime_state.get(), _mem_tracker.get()));
+        }
+        return Status::OK();
+    }
+
+    void close_all_pipelines() {
+        for (auto& pipe : _pipelines) {
+            pipe->close(_runtime_state.get());
+        }
+    }
 
 private:
     // Id of this query

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -148,6 +148,7 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
         _convert_data_sink_to_operator(params, &context, sink.get());
     }
 
+    RETURN_IF_ERROR(_fragment_ctx->prepare_all_pipelines());
     Drivers drivers;
     const auto& pipelines = _fragment_ctx->pipelines();
     const size_t num_pipelines = pipelines.size();

--- a/be/src/exec/pipeline/operator.h
+++ b/be/src/exec/pipeline/operator.h
@@ -77,6 +77,8 @@ public:
     virtual OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) = 0;
     virtual bool is_source() const { return false; }
     int32_t plan_node_id() const { return _plan_node_id; }
+    virtual Status prepare(RuntimeState* state, MemTracker* mem_tracker) { return Status::OK(); }
+    virtual void close(RuntimeState* state) {}
 
 protected:
     int32_t _id = 0;

--- a/be/src/exec/pipeline/pipeline.h
+++ b/be/src/exec/pipeline/pipeline.h
@@ -37,6 +37,19 @@ public:
         return down_cast<SourceOperatorFactory*>(_op_factories[0].get());
     }
 
+    Status prepare(RuntimeState* state, MemTracker* mem_tracker) {
+        for (auto& op : _op_factories) {
+            RETURN_IF_ERROR(op->prepare(state, mem_tracker));
+        }
+        return Status::OK();
+    }
+
+    void close(RuntimeState* state) {
+        for (auto& op : _op_factories) {
+            op->close(state);
+        }
+    }
+
 private:
     uint32_t _id = 0;
     OpFactories _op_factories;

--- a/be/src/exec/pipeline/project_operator.cpp
+++ b/be/src/exec/pipeline/project_operator.cpp
@@ -12,19 +12,11 @@
 namespace starrocks::pipeline {
 Status ProjectOperator::prepare(RuntimeState* state) {
     Operator::prepare(state);
-    RowDescriptor row_desc;
-    RETURN_IF_ERROR(Expr::prepare(_expr_ctxs, state, row_desc, get_memtracker()));
-    RETURN_IF_ERROR(Expr::prepare(_common_sub_expr_ctxs, state, row_desc, get_memtracker()));
-
-    RETURN_IF_ERROR(Expr::open(_expr_ctxs, state));
-    RETURN_IF_ERROR(Expr::open(_common_sub_expr_ctxs, state));
 
     return Status::OK();
 }
 
 Status ProjectOperator::close(RuntimeState* state) {
-    Expr::close(_expr_ctxs, state);
-    Expr::close(_common_sub_expr_ctxs, state);
     Operator::close(state);
     return Status::OK();
 }
@@ -71,5 +63,20 @@ Status ProjectOperator::push_chunk(RuntimeState* state, const vectorized::ChunkP
     }
     DCHECK_CHUNK(_cur_chunk);
     return Status::OK();
+}
+
+Status ProjectOperatorFactory::prepare(RuntimeState* state, MemTracker* mem_tracker) {
+    RowDescriptor row_desc;
+    RETURN_IF_ERROR(Expr::prepare(_expr_ctxs, state, row_desc, mem_tracker));
+    RETURN_IF_ERROR(Expr::prepare(_common_sub_expr_ctxs, state, row_desc, mem_tracker));
+
+    RETURN_IF_ERROR(Expr::open(_expr_ctxs, state));
+    RETURN_IF_ERROR(Expr::open(_common_sub_expr_ctxs, state));
+    return Status::OK();
+}
+
+void ProjectOperatorFactory::close(RuntimeState* state) {
+    Expr::close(_expr_ctxs, state);
+    Expr::close(_common_sub_expr_ctxs, state);
 }
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/project_operator.h
+++ b/be/src/exec/pipeline/project_operator.h
@@ -70,6 +70,9 @@ public:
                                                  _common_sub_column_ids, _common_sub_expr_ctxs);
     }
 
+    Status prepare(RuntimeState* state, MemTracker* mem_tracker);
+    void close(RuntimeState* state);
+
 private:
     std::vector<int32_t> _column_ids;
     std::vector<ExprContext*> _expr_ctxs;

--- a/be/src/exec/pipeline/result_sink_operator.cpp
+++ b/be/src/exec/pipeline/result_sink_operator.cpp
@@ -17,11 +17,6 @@ Status ResultSinkOperator::prepare(RuntimeState* state) {
     // Create profile
     _profile = std::make_unique<RuntimeProfile>("result sink");
 
-    // Create and prepare result exprs.
-    RETURN_IF_ERROR(Expr::create_expr_trees(state->obj_pool(), _t_output_expr, &_output_expr_ctxs));
-    RowDescriptor row_desc;
-    RETURN_IF_ERROR(Expr::prepare(_output_expr_ctxs, state, row_desc, get_memtracker()));
-
     // Create sender
     RETURN_IF_ERROR(state->exec_env()->result_mgr()->create_sender(state->fragment_instance_id(), 1024, &_sender));
 
@@ -56,7 +51,6 @@ Status ResultSinkOperator::close(RuntimeState* state) {
     state->exec_env()->result_mgr()->cancel_at_time(time(nullptr) + config::result_buffer_cancelled_interval_time,
                                                     state->fragment_instance_id());
 
-    Expr::close(_output_expr_ctxs, state);
     Operator::close(state);
     return Status::OK();
 }
@@ -96,5 +90,14 @@ Status ResultSinkOperator::push_chunk(RuntimeState* state, const vectorized::Chu
         return status.status();
     }
 }
+Status ResultSinkOperatorFactory::prepare(RuntimeState* state, MemTracker* mem_tracker) {
+    RETURN_IF_ERROR(Expr::create_expr_trees(state->obj_pool(), _t_output_expr, &_output_expr_ctxs));
+    RowDescriptor row_desc;
+    RETURN_IF_ERROR(Expr::prepare(_output_expr_ctxs, state, row_desc, mem_tracker));
+    return Status::OK();
+}
 
+void ResultSinkOperatorFactory::close(RuntimeState* state) {
+    Expr::close(_output_expr_ctxs, state);
+}
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/result_sink_operator.h
+++ b/be/src/exec/pipeline/result_sink_operator.h
@@ -16,8 +16,8 @@ namespace pipeline {
 class ResultSinkOperator final : public Operator {
 public:
     ResultSinkOperator(int32_t id, int32_t plan_node_id, TResultSinkType::type sink_type,
-                       const std::vector<TExpr>& t_output_expr)
-            : Operator(id, "result_sink", plan_node_id), _sink_type(sink_type), _t_output_expr(t_output_expr) {}
+                       const std::vector<ExprContext*>& output_expr_ctxs)
+            : Operator(id, "result_sink", plan_node_id), _sink_type(sink_type), _output_expr_ctxs(output_expr_ctxs) {}
 
     ~ResultSinkOperator() override = default;
 
@@ -41,8 +41,6 @@ public:
 
 private:
     TResultSinkType::type _sink_type;
-    const std::vector<TExpr>& _t_output_expr;
-
     std::vector<ExprContext*> _output_expr_ctxs;
     std::shared_ptr<BufferControlBlock> _sender;
     std::shared_ptr<ResultWriter> _writer;
@@ -61,12 +59,17 @@ public:
     ~ResultSinkOperatorFactory() override = default;
 
     OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override {
-        return std::make_shared<ResultSinkOperator>(_id, _plan_node_id, _sink_type, _t_output_expr);
+        return std::make_shared<ResultSinkOperator>(_id, _plan_node_id, _sink_type, _output_expr_ctxs);
     }
+
+    Status prepare(RuntimeState* state, MemTracker* mem_tracker) override;
+
+    void close(RuntimeState* state) override;
 
 private:
     TResultSinkType::type _sink_type;
     std::vector<TExpr> _t_output_expr;
+    std::vector<ExprContext*> _output_expr_ctxs;
 };
 
 } // namespace pipeline

--- a/be/src/exec/pipeline/scan_operator.h
+++ b/be/src/exec/pipeline/scan_operator.h
@@ -76,6 +76,9 @@ public:
     // ScanOperator needs to attach MorselQueue.
     bool with_morsels() const override { return true; }
 
+    Status prepare(RuntimeState* state, MemTracker* mem_tracker) override;
+    void close(RuntimeState* state) override;
+
 private:
     TOlapScanNode _olap_scan_node;
     std::vector<ExprContext*> _conjunct_ctxs;

--- a/be/src/exec/pipeline/sort/sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/sort_sink_operator.cpp
@@ -19,16 +19,10 @@ using namespace starrocks::vectorized;
 namespace starrocks::pipeline {
 Status SortSinkOperator::prepare(RuntimeState* state) {
     Operator::prepare(state);
-    // call prepare and open at exprs, Maintain the same procedure as topnnode.
-    RETURN_IF_ERROR(
-            _sort_exec_exprs.prepare(state, _parent_node_row_desc, _parent_node_child_row_desc, get_memtracker()));
-    RETURN_IF_ERROR(_sort_exec_exprs.open(state));
     return Status::OK();
 }
 
 Status SortSinkOperator::close(RuntimeState* state) {
-    // call close exprs, Maintain the same procedure as topnnode.
-    _sort_exec_exprs.close(state);
     return Operator::close(state);
 }
 
@@ -104,6 +98,16 @@ vectorized::ChunkPtr SortSinkOperator::_materialize_chunk_before_sort(vectorized
 void SortSinkOperator::finish(RuntimeState* state) {
     _chunks_sorter->finish(state);
     _is_finished = true;
+}
+
+Status SortSinkOperatorFactory::prepare(RuntimeState* state, MemTracker* mem_tracker) {
+    RETURN_IF_ERROR(_sort_exec_exprs.prepare(state, _parent_node_row_desc, _parent_node_child_row_desc, mem_tracker));
+    RETURN_IF_ERROR(_sort_exec_exprs.open(state));
+    return Status::OK();
+}
+
+void SortSinkOperatorFactory::close(RuntimeState* state) {
+    _sort_exec_exprs.close(state);
 }
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/sort/sort_sink_operator.h
+++ b/be/src/exec/pipeline/sort/sort_sink_operator.h
@@ -76,8 +76,9 @@ private:
 
 class SortSinkOperatorFactory final : public OperatorFactory {
 public:
-    SortSinkOperatorFactory(int32_t id, int32_t plan_node_id, std::shared_ptr<vectorized::ChunksSorter> chunks_sorter,
-                            const SortExecExprs& sort_exec_exprs, const std::vector<OrderByType>& order_by_types,
+    SortSinkOperatorFactory(int32_t id, int32_t plan_node_id,
+                            const std::shared_ptr<vectorized::ChunksSorter>& chunks_sorter,
+                            SortExecExprs& sort_exec_exprs, const std::vector<OrderByType>& order_by_types,
                             TupleDescriptor* materialized_tuple_desc, const RowDescriptor& parent_node_row_desc,
                             const RowDescriptor& parent_node_child_row_desc)
             : OperatorFactory(id, plan_node_id),
@@ -97,11 +98,14 @@ public:
         return ope;
     }
 
+    Status prepare(RuntimeState* state, MemTracker* mem_tracker) override;
+    void close(RuntimeState* state) override;
+
 private:
     std::shared_ptr<vectorized::ChunksSorter> _chunks_sorter;
 
     // _sort_exec_exprs contains the ordering expressions
-    const SortExecExprs& _sort_exec_exprs;
+    SortExecExprs& _sort_exec_exprs;
     const std::vector<OrderByType>& _order_by_types;
 
     // Cached descriptor for the materialized tuple. Assigned in Prepare().


### PR DESCRIPTION
## Changes

When session varialbe 'query_threads` set to more than 1, the same number of drivers is created for this pipeline, Expr tree from original ExecNode is shared across drivers, some expr should be prepared/closed only once, such as predicate_like/pad. some expr are time-consuming to clone a private duplicate. so we promote this expr from Operators to Pipeline, prepare them only once before drivers' execution and close them only once after drivers' execution.