### PR TITLE
Setting JAVA_HOME for yarn execution

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkEtlJobHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkEtlJobHandler.java
@@ -202,7 +202,7 @@ public class SparkEtlJobHandler {
             // command: yarn --config configDir application -status appId
             String yarnStatusCmd = String.format(YARN_STATUS_CMD, yarnClient, configDir, appId);
             LOG.info(yarnStatusCmd);
-            String[] envp = {"LC_ALL=" + Config.locale};
+            String[] envp = {"LC_ALL=" + Config.locale, "JAVA_HOME=" + System.getProperty("java.home")};
             CommandResult result = Util.executeCommand(yarnStatusCmd, envp, EXEC_CMD_TIMEOUT_MS);
             if (result.getReturnCode() != 0) {
                 String stderr = result.getStderr();
@@ -292,7 +292,7 @@ public class SparkEtlJobHandler {
             // command: yarn --config configDir application -kill appId
             String yarnKillCmd = String.format(YARN_KILL_CMD, yarnClient, configDir, appId);
             LOG.info(yarnKillCmd);
-            String[] envp = {"LC_ALL=" + Config.locale};
+            String[] envp = {"LC_ALL=" + Config.locale, "JAVA_HOME=" + System.getProperty("java.home")};
             CommandResult result = Util.executeCommand(yarnKillCmd, envp, EXEC_CMD_TIMEOUT_MS);
             LOG.info("yarn application -kill {}, output: {}", appId, result.getStdout());
             if (result.getReturnCode() != 0) {


### PR DESCRIPTION
Background:  
All environment variables for yarn cmd execution are provided by `envp` that contains only one element `LC_ALL` in `getEtlJobStatus` and `killEtlJob` currently, but JAVA_HOME is required by yarn command while loading data using spark. 

How to fix: 
Add JAVA_HOME environment variable same as FE's to `envp`.