### PR TITLE
Add metrics for slow query and meta log count

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -1510,6 +1510,7 @@ public class Catalog {
         Preconditions.checkState(remoteChecksum == checksum, remoteChecksum + " vs. " + checksum);
 
         long loadImageEndTime = System.currentTimeMillis();
+        MetricRepo.GAUGE_IMAGE_JOURNAL_ID.setValue(storage.getImageJournalId());
         LOG.info("finished to load image in " + (loadImageEndTime - loadImageStartTime) + " ms");
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -269,6 +269,8 @@ import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -269,8 +269,6 @@ import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.Future;
-import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -431,6 +429,8 @@ public class Catalog {
     private AnalyzeManager analyzeManager;
 
     private StatisticStorage statisticStorage;
+
+    private long imageJournalId;
 
     public List<Frontend> getFrontends(FrontendNodeType nodeType) {
         if (nodeType == null) {
@@ -1510,7 +1510,7 @@ public class Catalog {
         Preconditions.checkState(remoteChecksum == checksum, remoteChecksum + " vs. " + checksum);
 
         long loadImageEndTime = System.currentTimeMillis();
-        MetricRepo.GAUGE_IMAGE_JOURNAL_ID.setValue(storage.getImageJournalId());
+        this.imageJournalId = storage.getImageJournalId();
         LOG.info("finished to load image in " + (loadImageEndTime - loadImageStartTime) + " ms");
     }
 
@@ -7259,5 +7259,12 @@ public class Catalog {
         }
     }
 
+    public long getImageJournalId() {
+        return imageJournalId;
+    }
+
+    public void setImageJournalId(long imageJournalId) {
+        this.imageJournalId = imageJournalId;
+    }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/http/meta/MetaService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/meta/MetaService.java
@@ -31,7 +31,6 @@ import com.starrocks.http.BaseRequest;
 import com.starrocks.http.BaseResponse;
 import com.starrocks.http.IllegalArgException;
 import com.starrocks.master.MetaHelper;
-import com.starrocks.metric.MetricRepo;
 import com.starrocks.persist.MetaCleaner;
 import com.starrocks.persist.Storage;
 import com.starrocks.persist.StorageInfo;

--- a/fe/fe-core/src/main/java/com/starrocks/http/meta/MetaService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/meta/MetaService.java
@@ -31,6 +31,7 @@ import com.starrocks.http.BaseRequest;
 import com.starrocks.http.BaseResponse;
 import com.starrocks.http.IllegalArgException;
 import com.starrocks.master.MetaHelper;
+import com.starrocks.metric.MetricRepo;
 import com.starrocks.persist.MetaCleaner;
 import com.starrocks.persist.Storage;
 import com.starrocks.persist.StorageInfo;
@@ -214,6 +215,8 @@ public class MetaService {
                 writeResponse(request, response, HttpResponseStatus.INTERNAL_SERVER_ERROR);
                 return;
             }
+
+            MetricRepo.GAUGE_IMAGE_JOURNAL_ID.setValue(version);
 
             // Delete old image files
             MetaCleaner cleaner = new MetaCleaner(Config.meta_dir + "/image");

--- a/fe/fe-core/src/main/java/com/starrocks/http/meta/MetaService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/meta/MetaService.java
@@ -216,7 +216,7 @@ public class MetaService {
                 return;
             }
 
-            MetricRepo.GAUGE_IMAGE_JOURNAL_ID.setValue(version);
+            Catalog.getCurrentCatalog().setImageJournalId(version);
 
             // Delete old image files
             MetaCleaner cleaner = new MetaCleaner(Config.meta_dir + "/image");

--- a/fe/fe-core/src/main/java/com/starrocks/master/Checkpoint.java
+++ b/fe/fe-core/src/main/java/com/starrocks/master/Checkpoint.java
@@ -112,8 +112,8 @@ public class Checkpoint extends MasterDaemon {
             replayedJournalId = catalog.getReplayedJournalId();
             if (MetricRepo.isInit) {
                 MetricRepo.COUNTER_IMAGE_WRITE.increase(1L);
-                MetricRepo.GAUGE_IMAGE_JOURNAL_ID.setValue(checkPointVersion);
             }
+            Catalog.getServingCatalog().setImageJournalId(checkPointVersion);
             LOG.info("checkpoint finished save image.{}", replayedJournalId);
         } catch (Exception e) {
             e.printStackTrace();

--- a/fe/fe-core/src/main/java/com/starrocks/master/Checkpoint.java
+++ b/fe/fe-core/src/main/java/com/starrocks/master/Checkpoint.java
@@ -112,6 +112,7 @@ public class Checkpoint extends MasterDaemon {
             replayedJournalId = catalog.getReplayedJournalId();
             if (MetricRepo.isInit) {
                 MetricRepo.COUNTER_IMAGE_WRITE.increase(1L);
+                MetricRepo.GAUGE_IMAGE_JOURNAL_ID.setValue(checkPointVersion);
             }
             LOG.info("checkpoint finished save image.{}", replayedJournalId);
         } catch (Exception e) {

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricCalculator.java
@@ -59,10 +59,10 @@ public class MetricCalculator extends TimerTask {
         long interval = (currentTs - lastTs) / 1000 + 1;
 
         // qps
-        long currenQueryCounter = MetricRepo.COUNTER_QUERY_ALL.getValue();
-        double qps = (double) (currenQueryCounter - lastQueryCounter) / interval;
+        long currentQueryCounter = MetricRepo.COUNTER_QUERY_ALL.getValue();
+        double qps = (double) (currentQueryCounter - lastQueryCounter) / interval;
         MetricRepo.GAUGE_QUERY_PER_SECOND.setValue(qps < 0 ? 0.0 : qps);
-        lastQueryCounter = currenQueryCounter;
+        lastQueryCounter = currentQueryCounter;
 
         // rps
         long currentRequestCounter = MetricRepo.COUNTER_REQUEST_ALL.getValue();

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
@@ -41,7 +41,6 @@ import com.starrocks.metric.Metric.MetricType;
 import com.starrocks.metric.Metric.MetricUnit;
 import com.starrocks.monitor.jvm.JvmService;
 import com.starrocks.monitor.jvm.JvmStats;
-import com.starrocks.persist.EditLog;
 import com.starrocks.service.ExecuteEnv;
 import com.starrocks.system.Backend;
 import com.starrocks.system.SystemInfoService;
@@ -104,9 +103,6 @@ public final class MetricRepo {
     public static GaugeMetricImpl<Double> GAUGE_QUERY_LATENCY_P99;
     public static GaugeMetricImpl<Double> GAUGE_QUERY_LATENCY_P999;
     public static GaugeMetricImpl<Long> GAUGE_MAX_TABLET_COMPACTION_SCORE;
-
-    // metrics for image journal id
-    public static GaugeMetricImpl<Long> GAUGE_IMAGE_JOURNAL_ID;
 
     private static ScheduledThreadPoolExecutor metricTimer =
             ThreadPoolManager.newDaemonScheduledThreadPool(1, "Metric-Timer-Pool", true);
@@ -196,7 +192,7 @@ public final class MetricRepo {
                 "meta_log_count", MetricUnit.NOUNIT, "meta log total count") {
             @Override
             public Long getValue() {
-                return Catalog.getCurrentCatalog().getMaxJournalId() - GAUGE_IMAGE_JOURNAL_ID.getValue();
+                return Catalog.getCurrentCatalog().getMaxJournalId() - Catalog.getCurrentCatalog().getImageJournalId();
             }
         };
         STARROCKS_METRIC_REGISTER.addMetric(metaLogCount);
@@ -291,12 +287,6 @@ public final class MetricRepo {
         GAUGE_QUERY_LATENCY_P999.addLabel(new MetricLabel("type", "999_quantile"));
         GAUGE_QUERY_LATENCY_P999.setValue(0.0);
         STARROCKS_METRIC_REGISTER.addMetric(GAUGE_QUERY_LATENCY_P999);
-
-        // NOTE: we do not register this to STARROCKS_METRIC_REGISTER, cause we do not need to show this metrics.
-        // it is used to calculate the meta_log_count metrics
-        GAUGE_IMAGE_JOURNAL_ID =
-                new GaugeMetricImpl<>("image_journal_id", MetricUnit.NOUNIT, "image journal id");
-        GAUGE_IMAGE_JOURNAL_ID.setValue(0L);
 
         // 2. counter
         COUNTER_REQUEST_ALL = new LongCounterMetric("request_total", MetricUnit.REQUESTS, "total request");

--- a/fe/fe-core/src/main/java/com/starrocks/persist/Storage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/Storage.java
@@ -112,7 +112,7 @@ public class Storage {
             for (File child : children) {
                 String name = child.getName();
                 try {
-                    if (name.startsWith(IMAGE) && name.contains(".")) {
+                    if (!name.equals(IMAGE_NEW) && name.startsWith(IMAGE) && name.contains(".")) {
                         imageJournalId = Math.max(Long.parseLong(name.substring(name.lastIndexOf('.') + 1)), imageJournalId);
                     }
                 } catch (Exception e) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -33,6 +33,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
 import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
@@ -152,6 +153,9 @@ public class ConnectProcessor {
                 // ok query
                 MetricRepo.COUNTER_QUERY_SUCCESS.increase(1L);
                 MetricRepo.HISTO_QUERY_LATENCY.update(elapseMs);
+                if (elapseMs > Config.qe_slow_log_ms) {
+                    MetricRepo.COUNTER_SLOW_QUERY.increase(1L);
+                }
             }
             ctx.getAuditEventBuilder().setIsQuery(true);
         } else {


### PR DESCRIPTION
add metrics:
1. slow_query: total slow query count whose execute time is bigger than Config.qe_slow_log_ms.
2. meta_log_count: total meta log count in bdb je, these log will be replayed when fe restarts.