### PR TITLE
[SR-4075] LocalExchangeSinkOperator call finish exactly once

### DIFF
--- a/be/src/exec/pipeline/exchange/local_exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange_sink_operator.cpp
@@ -21,8 +21,10 @@ StatusOr<vectorized::ChunkPtr> LocalExchangeSinkOperator::pull_chunk(RuntimeStat
 }
 
 void LocalExchangeSinkOperator::finish(RuntimeState* state) {
-    _is_finished = true;
-    _exchanger->finish(state);
+    if (!_is_finished) {
+        _is_finished = true;
+        _exchanger->finish(state);
+    }
 }
 
 Status LocalExchangeSinkOperator::push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) {

--- a/be/src/exec/pipeline/pipeline_driver_dispatcher.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_dispatcher.cpp
@@ -53,7 +53,8 @@ void GlobalDriverDispatcher::run() {
         auto* runtime_state = fragment_ctx->runtime_state();
 
         if (fragment_ctx->is_canceled()) {
-            VLOG_ROW << "[Driver] Canceled: error=" << fragment_ctx->final_status().to_string();
+            VLOG_ROW << "[Driver] Canceled: driver=" << driver.get()
+                     << ", error=" << fragment_ctx->final_status().to_string();
             driver->cancel(runtime_state);
             if (driver->source_operator()->pending_finish()) {
                 driver->set_driver_state(DriverState::PENDING_FINISH);


### PR DESCRIPTION
## Changes
In mulitple LocalExchangeSinkOperator and one LocalExchangeSourceOperator, LocalExchangeSourceOperator receive EOS only after all LocalExchangeSinkOperators invoke its finish function, this function should be called exactly once.