### PR TITLE
[SR-4884] fix: modernize-avoid-bind by clang-tidy and don't capture this in lambda for Counter

### DIFF
--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -218,8 +218,9 @@ Status ExecNode::prepare(RuntimeState* state) {
     _rows_returned_counter = ADD_COUNTER(_runtime_profile, "RowsReturned", TUnit::UNIT);
     _rows_returned_rate = runtime_profile()->add_derived_counter(
             ROW_THROUGHPUT_COUNTER, TUnit::UNIT_PER_SECOND,
-            std::bind<int64_t>(&RuntimeProfile::units_per_second, _rows_returned_counter,
-                               runtime_profile()->total_time_counter()),
+            [this, capture0 = runtime_profile()->total_time_counter()] {
+                return RuntimeProfile::units_per_second(_rows_returned_counter, capture0);
+            },
             "");
     _mem_tracker.reset(
             new MemTracker(_runtime_profile.get(), -1, _runtime_profile->name(), state->instance_mem_tracker()));

--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -218,8 +218,8 @@ Status ExecNode::prepare(RuntimeState* state) {
     _rows_returned_counter = ADD_COUNTER(_runtime_profile, "RowsReturned", TUnit::UNIT);
     _rows_returned_rate = runtime_profile()->add_derived_counter(
             ROW_THROUGHPUT_COUNTER, TUnit::UNIT_PER_SECOND,
-            [this, capture0 = runtime_profile()->total_time_counter()] {
-                return RuntimeProfile::units_per_second(_rows_returned_counter, capture0);
+            [capture0 = _rows_returned_counter, capture1 = runtime_profile()->total_time_counter()] {
+                return RuntimeProfile::units_per_second(capture0, capture1);
             },
             "");
     _mem_tracker.reset(

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -269,8 +269,8 @@ Status ExchangeSinkOperator::prepare(RuntimeState* state) {
     _wait_response_timer = ADD_TIMER(profile(), "WaitResponseTime");
     _overall_throughput = profile()->add_derived_counter(
             "OverallThroughput", TUnit::BYTES_PER_SECOND,
-            [this, capture0 = profile()->total_time_counter()] {
-                return RuntimeProfile::units_per_second(_bytes_sent_counter, capture0);
+            [capture0 = _bytes_sent_counter, capture1 = profile()->total_time_counter()] {
+                return RuntimeProfile::units_per_second(capture0, capture1);
             },
             "");
     for (int i = 0; i < _channels.size(); ++i) {

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -269,7 +269,9 @@ Status ExchangeSinkOperator::prepare(RuntimeState* state) {
     _wait_response_timer = ADD_TIMER(profile(), "WaitResponseTime");
     _overall_throughput = profile()->add_derived_counter(
             "OverallThroughput", TUnit::BYTES_PER_SECOND,
-            std::bind<int64_t>(&RuntimeProfile::units_per_second, _bytes_sent_counter, profile()->total_time_counter()),
+            [this, capture0 = profile()->total_time_counter()] {
+                return RuntimeProfile::units_per_second(_bytes_sent_counter, capture0);
+            },
             "");
     for (int i = 0; i < _channels.size(); ++i) {
         RETURN_IF_ERROR(_channels[i]->init(state));

--- a/be/src/exec/scan_node.cpp
+++ b/be/src/exec/scan_node.cpp
@@ -56,7 +56,7 @@ Status ScanNode::prepare(RuntimeState* state) {
             ADD_CHILD_TIMER(runtime_profile(), _s_materialize_tuple_timer, _s_scanner_thread_total_wallclock_time);
     _per_read_thread_throughput_counter = runtime_profile()->add_derived_counter(
             _s_per_read_thread_throughput_counter, TUnit::BYTES_PER_SECOND,
-            std::bind<int64_t>(&RuntimeProfile::units_per_second, _bytes_read_counter, _read_timer), "");
+            [this] { return RuntimeProfile::units_per_second(_bytes_read_counter, _read_timer); }, "");
     _num_disks_accessed_counter = ADD_COUNTER(runtime_profile(), _s_num_disks_accessed_counter, TUnit::UNIT);
 
     return Status::OK();

--- a/be/src/exec/scan_node.cpp
+++ b/be/src/exec/scan_node.cpp
@@ -56,7 +56,10 @@ Status ScanNode::prepare(RuntimeState* state) {
             ADD_CHILD_TIMER(runtime_profile(), _s_materialize_tuple_timer, _s_scanner_thread_total_wallclock_time);
     _per_read_thread_throughput_counter = runtime_profile()->add_derived_counter(
             _s_per_read_thread_throughput_counter, TUnit::BYTES_PER_SECOND,
-            [this] { return RuntimeProfile::units_per_second(_bytes_read_counter, _read_timer); }, "");
+            [capture0 = _bytes_read_counter, capture1 = _read_timer] {
+                return RuntimeProfile::units_per_second(capture0, capture1);
+            },
+            "");
     _num_disks_accessed_counter = ADD_COUNTER(runtime_profile(), _s_num_disks_accessed_counter, TUnit::UNIT);
 
     return Status::OK();

--- a/be/src/http/default_path_handlers.cpp
+++ b/be/src/http/default_path_handlers.cpp
@@ -191,11 +191,17 @@ void add_default_path_handlers(WebPageHandler* web_page_handler, MemTracker* pro
     web_page_handler->register_page("/varz", "Configs", config_handler, true /* is_on_nav_bar */);
     web_page_handler->register_page(
             "/memz", "Memory",
-            std::bind<void>(&mem_usage_handler, process_mem_tracker, std::placeholders::_1, std::placeholders::_2),
+            [process_mem_tracker](auto&& PH1, auto&& PH2) {
+                return mem_usage_handler(process_mem_tracker, std::forward<decltype(PH1)>(PH1),
+                                         std::forward<decltype(PH2)>(PH2));
+            },
             true /* is_on_nav_bar */);
     web_page_handler->register_page(
             "/mem_tracker", "MemTracker",
-            std::bind<void>(&mem_tracker_handler, process_mem_tracker, std::placeholders::_1, std::placeholders::_2),
+            [process_mem_tracker](auto&& PH1, auto&& PH2) {
+                return mem_tracker_handler(process_mem_tracker, std::forward<decltype(PH1)>(PH1),
+                                           std::forward<decltype(PH2)>(PH2));
+            },
             true);
 }
 

--- a/be/src/runtime/bufferpool/buffer_allocator.cc
+++ b/be/src/runtime/bufferpool/buffer_allocator.cc
@@ -714,7 +714,9 @@ std::string BufferPool::FreeBufferArena::DebugString() {
            << " free buffers: " << lists.num_free_buffers.load(std::memory_order_acquire)
            << " low water mark: " << lists.low_water_mark
            << " clean pages: " << lists.num_clean_pages.load(std::memory_order_acquire) << " ";
-        lists.clean_pages.iterate(std::bind<bool>(Page::DebugStringCallback, &ss, std::placeholders::_1));
+        lists.clean_pages.iterate([capture0 = &ss](auto&& PH1) {
+            return Page::DebugStringCallback(capture0, std::forward<decltype(PH1)>(PH1));
+        });
 
         ss << "\n";
     }

--- a/be/src/runtime/bufferpool/buffer_pool.cc
+++ b/be/src/runtime/bufferpool/buffer_pool.cc
@@ -691,11 +691,17 @@ string BufferPool::Client::DebugString() {
        << " in_flight_write_bytes: " << in_flight_write_pages_.bytes()
        << " reservation: " << reservation_.DebugString();
     ss << "\n  " << pinned_pages_.size() << " pinned pages: ";
-    pinned_pages_.iterate(std::bind<bool>(Page::DebugStringCallback, &ss, std::placeholders::_1));
+    pinned_pages_.iterate([capture0 = &ss](auto&& PH1) {
+        return Page::DebugStringCallback(capture0, std::forward<decltype(PH1)>(PH1));
+    });
     ss << "\n  " << dirty_unpinned_pages_.size() << " dirty unpinned pages: ";
-    dirty_unpinned_pages_.iterate(std::bind<bool>(Page::DebugStringCallback, &ss, std::placeholders::_1));
+    dirty_unpinned_pages_.iterate([capture0 = &ss](auto&& PH1) {
+        return Page::DebugStringCallback(capture0, std::forward<decltype(PH1)>(PH1));
+    });
     ss << "\n  " << in_flight_write_pages_.size() << " in flight write pages: ";
-    in_flight_write_pages_.iterate(std::bind<bool>(Page::DebugStringCallback, &ss, std::placeholders::_1));
+    in_flight_write_pages_.iterate([capture0 = &ss](auto&& PH1) {
+        return Page::DebugStringCallback(capture0, std::forward<decltype(PH1)>(PH1));
+    });
     return ss.str();
 }
 

--- a/be/src/runtime/data_stream_sender.cpp
+++ b/be/src/runtime/data_stream_sender.cpp
@@ -616,8 +616,8 @@ Status DataStreamSender::prepare(RuntimeState* state) {
     _shuffle_hash_timer = ADD_TIMER(profile(), "ShuffleHashTime");
     _overall_throughput = profile()->add_derived_counter(
             "OverallThroughput", TUnit::BYTES_PER_SECOND,
-            [this, capture0 = profile()->total_time_counter()] {
-                return RuntimeProfile::units_per_second(_bytes_sent_counter, capture0);
+            [capture0 = _bytes_sent_counter, capture1 = profile()->total_time_counter()] {
+                return RuntimeProfile::units_per_second(capture0, capture1);
             },
             "");
     for (int i = 0; i < _channels.size(); ++i) {

--- a/be/src/runtime/data_stream_sender.cpp
+++ b/be/src/runtime/data_stream_sender.cpp
@@ -616,7 +616,9 @@ Status DataStreamSender::prepare(RuntimeState* state) {
     _shuffle_hash_timer = ADD_TIMER(profile(), "ShuffleHashTime");
     _overall_throughput = profile()->add_derived_counter(
             "OverallThroughput", TUnit::BYTES_PER_SECOND,
-            std::bind<int64_t>(&RuntimeProfile::units_per_second, _bytes_sent_counter, profile()->total_time_counter()),
+            [this, capture0 = profile()->total_time_counter()] {
+                return RuntimeProfile::units_per_second(_bytes_sent_counter, capture0);
+            },
             "");
     for (int i = 0; i < _channels.size(); ++i) {
         RETURN_IF_ERROR(_channels[i]->init(state));

--- a/be/src/runtime/disk_io_mgr.cc
+++ b/be/src/runtime/disk_io_mgr.cc
@@ -378,7 +378,8 @@ Status DiskIoMgr::init(MemTracker* process_mem_tracker) {
             ss << "work-loop(Disk: " << i << ", Thread: " << j << ")";
             // _disk_thread_group.AddThread(new Thread("disk-io-mgr", ss.str(),
             //             &DiskIoMgr::work_loop, this, _disk_queues[i]));
-            _disk_thread_group.add_thread(new boost::thread(std::bind(&DiskIoMgr::work_loop, this, _disk_queues[i])));
+            _disk_thread_group.add_thread(
+                    new boost::thread([this, capture0 = _disk_queues[i]] { work_loop(capture0); }));
         }
     }
     _request_context_cache = std::make_unique<RequestContextCache>(this);

--- a/be/src/runtime/routine_load/data_consumer.cpp
+++ b/be/src/runtime/routine_load/data_consumer.cpp
@@ -49,7 +49,7 @@ Status KafkaDataConsumer::init(StreamLoadContext* ctx) {
 
     // conf has to be deleted finally
     auto conf_deleter = [conf]() { delete conf; };
-    DeferOp delete_conf(std::bind<void>(conf_deleter));
+    DeferOp delete_conf([conf_deleter] { return conf_deleter(); });
 
     std::stringstream ss;
     ss << BackendOptions::get_localhost() << "_";
@@ -148,7 +148,7 @@ Status KafkaDataConsumer::assign_topic_partitions(const std::map<int32_t, int64_
         std::for_each(topic_partitions.begin(), topic_partitions.end(),
                       [](RdKafka::TopicPartition* tp1) { delete tp1; });
     };
-    DeferOp delete_tp(std::bind<void>(tp_deleter));
+    DeferOp delete_tp([tp_deleter] { return tp_deleter(); });
 
     // assign partition
     RdKafka::ErrorCode err = _k_consumer->assign(topic_partitions);
@@ -259,7 +259,7 @@ Status KafkaDataConsumer::get_partition_meta(std::vector<int32_t>* partition_ids
     // create topic conf
     RdKafka::Conf* tconf = RdKafka::Conf::create(RdKafka::Conf::CONF_TOPIC);
     auto conf_deleter = [tconf]() { delete tconf; };
-    DeferOp delete_conf(std::bind<void>(conf_deleter));
+    DeferOp delete_conf([conf_deleter] { return conf_deleter(); });
 
     // create topic
     std::string errstr;
@@ -271,7 +271,7 @@ Status KafkaDataConsumer::get_partition_meta(std::vector<int32_t>* partition_ids
         return Status::InternalError(ss.str());
     }
     auto topic_deleter = [topic]() { delete topic; };
-    DeferOp delete_topic(std::bind<void>(topic_deleter));
+    DeferOp delete_topic([topic_deleter] { return topic_deleter(); });
 
     // get topic metadata
     RdKafka::Metadata* metadata = nullptr;
@@ -283,7 +283,7 @@ Status KafkaDataConsumer::get_partition_meta(std::vector<int32_t>* partition_ids
         return Status::InternalError(ss.str());
     }
     auto meta_deleter = [metadata]() { delete metadata; };
-    DeferOp delete_meta(std::bind<void>(meta_deleter));
+    DeferOp delete_meta([meta_deleter] { return meta_deleter(); });
 
     // get partition ids
     RdKafka::Metadata::TopicMetadataIterator it;

--- a/be/src/runtime/routine_load/data_consumer_group.cpp
+++ b/be/src/runtime/routine_load/data_consumer_group.cpp
@@ -70,20 +70,20 @@ Status KafkaDataConsumerGroup::start_all(StreamLoadContext* ctx) {
     Status result_st = Status::OK();
     // start all consumers
     for (auto& consumer : _consumers) {
-        if (!_thread_pool.offer(std::bind<void>(
-                    &KafkaDataConsumerGroup::actual_consume, this, consumer, &_queue, ctx->max_interval_s * 1000,
-                    [this, &result_st](const Status& st) {
-                        std::unique_lock<std::mutex> lock(_mutex);
-                        _counter--;
-                        VLOG(1) << "group counter is: " << _counter << ", grp: " << _grp_id;
-                        if (_counter == 0) {
-                            _queue.shutdown();
-                            LOG(INFO) << "all consumers are finished. shutdown queue. group id: " << _grp_id;
-                        }
-                        if (result_st.ok() && !st.ok()) {
-                            result_st = st;
-                        }
-                    }))) {
+        if (!_thread_pool.offer([this, consumer, capture0 = &_queue, capture1 = ctx->max_interval_s * 1000,
+                                 capture2 = [this, &result_st](const Status& st) {
+                                     std::unique_lock<std::mutex> lock(_mutex);
+                                     _counter--;
+                                     VLOG(1) << "group counter is: " << _counter << ", grp: " << _grp_id;
+                                     if (_counter == 0) {
+                                         _queue.shutdown();
+                                         LOG(INFO)
+                                                 << "all consumers are finished. shutdown queue. group id: " << _grp_id;
+                                     }
+                                     if (result_st.ok() && !st.ok()) {
+                                         result_st = st;
+                                     }
+                                 }] { actual_consume(consumer, capture0, capture1, capture2); })) {
             LOG(WARNING) << "failed to submit data consumer: " << consumer->id() << ", group id: " << _grp_id;
             return Status::InternalError("failed to submit data consumer");
         } else {

--- a/be/src/runtime/routine_load/routine_load_task_executor.cpp
+++ b/be/src/runtime/routine_load/routine_load_task_executor.cpp
@@ -185,17 +185,15 @@ Status RoutineLoadTaskExecutor::submit_task(const TRoutineLoadTask& task) {
     _task_map[ctx->id] = ctx;
 
     // offer the task to thread pool
-    if (!_thread_pool.offer(std::bind<void>(&RoutineLoadTaskExecutor::exec_task, this, ctx, &_data_consumer_pool,
-                                            [this](StreamLoadContext* ctx) {
-                                                std::unique_lock<std::mutex> l(_lock);
-                                                _task_map.erase(ctx->id);
-                                                LOG(INFO) << "finished routine load task " << ctx->brief()
-                                                          << ", status: " << ctx->status.get_error_msg()
-                                                          << ", current tasks num: " << _task_map.size();
-                                                if (ctx->unref()) {
-                                                    delete ctx;
-                                                }
-                                            }))) {
+    if (!_thread_pool.offer([this, ctx, capture0 = &_data_consumer_pool, capture1 = [this](StreamLoadContext* ctx) {
+            std::unique_lock<std::mutex> l(_lock);
+            _task_map.erase(ctx->id);
+            LOG(INFO) << "finished routine load task " << ctx->brief() << ", status: " << ctx->status.get_error_msg()
+                      << ", current tasks num: " << _task_map.size();
+            if (ctx->unref()) {
+                delete ctx;
+            }
+        }] { exec_task(ctx, capture0, capture1); })) {
         // failed to submit task, clear and return
         LOG(WARNING) << "failed to submit routine load task: " << ctx->brief();
         _task_map.erase(ctx->id);
@@ -307,7 +305,7 @@ void RoutineLoadTaskExecutor::exec_task(StreamLoadContext* ctx, DataConsumerPool
             std::for_each(topic_partitions.begin(), topic_partitions.end(),
                           [](RdKafka::TopicPartition* tp1) { delete tp1; });
         };
-        DeferOp delete_tp(std::bind<void>(tp_deleter));
+        DeferOp delete_tp([tp_deleter] { return tp_deleter(); });
     } break;
     default:
         return;

--- a/be/src/runtime/runtime_filter_worker.cpp
+++ b/be/src/runtime/runtime_filter_worker.cpp
@@ -351,8 +351,7 @@ public:
 
 static_assert(std::is_move_assignable<RuntimeFilterWorkerEvent>::value);
 
-RuntimeFilterWorker::RuntimeFilterWorker(ExecEnv* env)
-        : _exec_env(env), _thread(std::bind<void>(&RuntimeFilterWorker::execute, this)) {}
+RuntimeFilterWorker::RuntimeFilterWorker(ExecEnv* env) : _exec_env(env), _thread([this] { execute(); }) {}
 
 RuntimeFilterWorker::~RuntimeFilterWorker() {
     _queue.shutdown();

--- a/be/src/storage/memtable_flush_executor.cpp
+++ b/be/src/storage/memtable_flush_executor.cpp
@@ -43,7 +43,7 @@ std::ostream& operator<<(std::ostream& os, const FlushStatistic& stat) {
 // its reference count is not 0.
 OLAPStatus FlushToken::submit(const std::shared_ptr<MemTable>& memtable) {
     RETURN_NOT_OK(_flush_status.load());
-    _flush_token->submit_func(std::bind(&FlushToken::_flush_memtable, this, memtable));
+    _flush_token->submit_func([this, memtable] { _flush_memtable(memtable); });
     return OLAP_SUCCESS;
 }
 
@@ -53,7 +53,7 @@ Status FlushToken::submit(const std::shared_ptr<vectorized::MemTable>& memtable)
         ss << "tablet_id = " << memtable->tablet_id() << " flush_status error ";
         return Status::InternalError(ss.str());
     }
-    _flush_token->submit_func(std::bind(&FlushToken::_flush_vectorized_memtable, this, memtable));
+    _flush_token->submit_func([this, memtable] { _flush_vectorized_memtable(memtable); });
     return Status::OK();
 }
 

--- a/be/src/util/mysql_load_error_hub.cpp
+++ b/be/src/util/mysql_load_error_hub.cpp
@@ -74,7 +74,7 @@ Status MysqlLoadErrorHub::write_mysql() {
         return st;
     }
 
-    DeferOp close_mysql_conn(std::bind<void>(&mysql_close, my_conn));
+    DeferOp close_mysql_conn([my_conn] { return mysql_close(my_conn); });
 
     Status status;
     std::stringstream sql_stream;

--- a/be/src/util/starrocks_metrics.cpp
+++ b/be/src/util/starrocks_metrics.cpp
@@ -169,7 +169,7 @@ StarRocksMetrics::StarRocksMetrics() : _metrics(_s_registry_name) {
     REGISTER_STARROCKS_METRIC(tcmalloc_pageheap_unmapped_bytes);
     REGISTER_STARROCKS_METRIC(tcmalloc_bytes_in_use);
 
-    _metrics.register_hook(_s_hook_name, std::bind(&StarRocksMetrics::_update, this));
+    _metrics.register_hook(_s_hook_name, [this] { _update(); });
 
     REGISTER_STARROCKS_METRIC(readable_blocks_total);
     REGISTER_STARROCKS_METRIC(writable_blocks_total);


### PR DESCRIPTION
Replace `bind` with `lambda` by clang-tidy.

Don't capture `this` of Operator in `lambda` for `RuntimeProfile::units_per_second`, because sometimes the life cycle of `Counter` in an Operator is different from this Operator.
`Counter` is maintained by `RuntimeState`, and can be used after deallocated it's Operator.
