### PR TITLE
Remove stdout appender from broker log4j conf

### DIFF
--- a/fs_brokers/apache_hdfs_broker/conf/log4j.properties
+++ b/fs_brokers/apache_hdfs_broker/conf/log4j.properties
@@ -1,13 +1,7 @@
-log4j.rootLogger = INFO,stdout,D
-
-log4j.appender.stdout = org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.Target = System.out
-log4j.appender.stdout.layout = org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern = [%-5p] %d{yyyy-MM-dd HH:mm:ss,SSS} method:%l%n%m%n
+log4j.rootLogger = INFO,D
 
 log4j.appender.D = org.apache.log4j.DailyRollingFileAppender
 log4j.appender.D.File = ${BROKER_LOG_DIR}/apache_hdfs_broker.log
 log4j.appender.D.Append = true
-log4j.appender.D.Threshold = INFO
 log4j.appender.D.layout = org.apache.log4j.PatternLayout
 log4j.appender.D.layout.ConversionPattern = %-d{yyyy-MM-dd HH:mm:ss}  [ %t:%r ] - [ %p ]  %m%n


### PR DESCRIPTION
#534 
In order to prevent the broker log from being repeatedly
printed in the log and out files