### PR TITLE
Add enable_cbo session variable temporarily

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -366,6 +366,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = DISABLE_JOIN_REORDER)
     private boolean disableJoinReorder = false;
 
+    // TODO(kks): Remove this variable after 2021-10-07
+    @VariableMgr.VarAttr(name = "enable_cbo")
+    private boolean enableCbo = true;
+
     @VariableMgr.VarAttr(name = CBO_MAX_REORDER_NODE_USE_EXHAUSTIVE)
     private int cboMaxReorderNodeUseExhaustive = 4;
 


### PR DESCRIPTION
```
02:35:10 ERROR 1064 (HY000) at line 1: Unknown system variable 'enable_cbo'
```
Our daily test still use `enable_cbo` variable