### PR TITLE
Use raw ptr instead of shared_ptr

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -203,7 +203,7 @@ Status FragmentExecutor::execute(ExecEnv* exec_env) {
         RETURN_IF_ERROR(driver->prepare(_fragment_ctx->runtime_state()));
     }
     for (const auto& driver : _fragment_ctx->drivers()) {
-        exec_env->driver_dispatcher()->dispatch(driver);
+        exec_env->driver_dispatcher()->dispatch(driver.get());
     }
     return Status::OK();
 }

--- a/be/src/exec/pipeline/pipeline_driver_dispatcher.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_dispatcher.cpp
@@ -28,12 +28,11 @@ void GlobalDriverDispatcher::change_num_threads(int32_t num_threads) {
     }
 }
 
-void GlobalDriverDispatcher::finalize_driver(DriverPtr& driver, RuntimeState* runtime_state, DriverState state) {
+void GlobalDriverDispatcher::finalize_driver(DriverRawPtr driver, RuntimeState* runtime_state, DriverState state) {
     DCHECK(driver);
     driver->finalize(runtime_state, state);
     if (driver->query_ctx()->is_finished()) {
         auto query_id = driver->query_ctx()->query_id();
-        driver.reset();
         QueryContextManager::instance()->remove(query_id);
     }
 }
@@ -52,7 +51,7 @@ void GlobalDriverDispatcher::run() {
         auto* runtime_state = fragment_ctx->runtime_state();
 
         if (fragment_ctx->is_canceled()) {
-            VLOG_ROW << "[Driver] Canceled: driver=" << driver.get()
+            VLOG_ROW << "[Driver] Canceled: driver=" << driver
                      << ", error=" << fragment_ctx->final_status().to_string();
             driver->cancel(runtime_state);
             if (driver->source_operator()->pending_finish()) {
@@ -117,7 +116,7 @@ void GlobalDriverDispatcher::run() {
     }
 }
 
-void GlobalDriverDispatcher::dispatch(DriverPtr driver) {
+void GlobalDriverDispatcher::dispatch(DriverRawPtr driver) {
     this->_driver_queue->put_back(driver);
 }
 

--- a/be/src/exec/pipeline/pipeline_driver_dispatcher.h
+++ b/be/src/exec/pipeline/pipeline_driver_dispatcher.h
@@ -27,7 +27,7 @@ public:
     virtual ~DriverDispatcher() = default;
     virtual void initialize(int32_t num_threads) {}
     virtual void change_num_threads(int32_t num_threads) {}
-    virtual void dispatch(DriverPtr driver){};
+    virtual void dispatch(DriverRawPtr driver){};
 
     // When all the root drivers (the drivers have no successors in the same fragment) have finished,
     // just notify FE timely the completeness of fragment via invocation of report_exec_state, but
@@ -43,12 +43,12 @@ public:
     ~GlobalDriverDispatcher() override = default;
     void initialize(int32_t num_threads) override;
     void change_num_threads(int32_t num_threads) override;
-    void dispatch(DriverPtr driver) override;
+    void dispatch(DriverRawPtr driver) override;
     void report_exec_state(FragmentContext* fragment_ctx, const Status& status, bool done) override;
 
 private:
     void run();
-    void finalize_driver(DriverPtr& driver, RuntimeState* runtime_state, DriverState state);
+    void finalize_driver(DriverRawPtr driver, RuntimeState* runtime_state, DriverState state);
 
 private:
     LimitSetter _num_threads_setter;

--- a/be/src/exec/pipeline/pipeline_driver_poller.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_poller.cpp
@@ -103,7 +103,7 @@ void PipelineDriverPoller::run_internal() {
     }
 }
 
-void PipelineDriverPoller::add_blocked_driver(const DriverPtr& driver) {
+void PipelineDriverPoller::add_blocked_driver(const DriverRawPtr driver) {
     std::unique_lock<std::mutex> lock(this->_mutex);
     this->_blocked_drivers.push_back(driver);
     this->_cond.notify_one();

--- a/be/src/exec/pipeline/pipeline_driver_poller.h
+++ b/be/src/exec/pipeline/pipeline_driver_poller.h
@@ -23,14 +23,14 @@ public:
               _is_polling_thread_initialized(false),
               _is_shutdown(false) {}
 
-    using DriverList = std::list<DriverPtr>;
+    using DriverList = std::list<DriverRawPtr>;
     ~PipelineDriverPoller() = default;
     // start poller thread
     void start();
     // shutdown poller thread
     void shutdown();
     // add blocked driver to poller
-    void add_blocked_driver(const DriverPtr& driver);
+    void add_blocked_driver(const DriverRawPtr driver);
 
 private:
     void run_internal();

--- a/be/src/exec/pipeline/pipeline_driver_queue.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_queue.cpp
@@ -4,7 +4,7 @@
 
 #include "gutil/strings/substitute.h"
 namespace starrocks::pipeline {
-void QuerySharedDriverQueue::put_back(const DriverPtr& driver) {
+void QuerySharedDriverQueue::put_back(const DriverRawPtr driver) {
     int level = driver->driver_acct().get_level();
     {
         std::unique_lock<std::mutex> lock(_global_mutex);
@@ -16,11 +16,11 @@ void QuerySharedDriverQueue::put_back(const DriverPtr& driver) {
     }
 }
 
-DriverPtr QuerySharedDriverQueue::take(size_t* queue_index) {
+DriverRawPtr QuerySharedDriverQueue::take(size_t* queue_index) {
     // -1 means no candidates; else has candidate.
     int queue_idx = -1;
     double target_accu_time = 0;
-    DriverPtr driver_ptr;
+    DriverRawPtr driver_ptr;
 
     {
         std::unique_lock<std::mutex> lock(_global_mutex);

--- a/be/src/exec/pipeline/pipeline_driver_queue.h
+++ b/be/src/exec/pipeline/pipeline_driver_queue.h
@@ -13,13 +13,13 @@ using DriverQueuePtr = std::unique_ptr<DriverQueue>;
 
 class SubQuerySharedDriverQueue {
 public:
-    void update_accu_time(const DriverPtr& driver) {
+    void update_accu_time(const DriverRawPtr driver) {
         _accu_consume_time.fetch_add(driver->driver_acct().get_last_time_spent());
     }
 
     double accu_time_after_divisor() { return _accu_consume_time.load() / factor_for_normal; }
 
-    std::queue<DriverPtr> queue;
+    std::queue<DriverRawPtr> queue;
     // factor for normalization
     double factor_for_normal = 0;
 
@@ -29,8 +29,8 @@ private:
 
 class DriverQueue {
 public:
-    virtual void put_back(const DriverPtr& driver) = 0;
-    virtual DriverPtr take(size_t* queue_index) = 0;
+    virtual void put_back(const DriverRawPtr driver) = 0;
+    virtual DriverRawPtr take(size_t* queue_index) = 0;
     virtual ~DriverQueue() = default;
     ;
     virtual SubQuerySharedDriverQueue* get_sub_queue(size_t) = 0;
@@ -55,8 +55,8 @@ public:
     static const size_t QUEUE_SIZE = 8;
     // maybe other value for ratio.
     static constexpr double RATIO_OF_ADJACENT_QUEUE = 1.7;
-    void put_back(const DriverPtr& driver) override;
-    DriverPtr take(size_t* queue_index) override;
+    void put_back(const DriverRawPtr driver) override;
+    DriverRawPtr take(size_t* queue_index) override;
     SubQuerySharedDriverQueue* get_sub_queue(size_t) override;
 
 private:

--- a/be/src/exec/pipeline/pipeline_fwd.h
+++ b/be/src/exec/pipeline/pipeline_fwd.h
@@ -18,6 +18,7 @@ using PipelinePtr = std::shared_ptr<Pipeline>;
 using Pipelines = std::vector<PipelinePtr>;
 class PipelineDriver;
 using DriverPtr = std::shared_ptr<PipelineDriver>;
+using DriverRawPtr = PipelineDriver*;
 using Drivers = std::vector<DriverPtr>;
 class DriverDispatcher;
 using DriverDispatcherPtr = std::shared_ptr<DriverDispatcher>;


### PR DESCRIPTION
- Because PipelineDriver is destructed with FragmentContext, So we use DriverRawPtr instead of DriverPtr when executing query.