### PR TITLE
Fix null result while reading column values from path specified by regular expression for spark load

### DIFF
--- a/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/dpp/SparkDpp.java
+++ b/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/dpp/SparkDpp.java
@@ -610,6 +610,11 @@ public final class SparkDpp implements java.io.Serializable {
         return dataframe;
     }
 
+    /**
+     * Note: parameter fileUrl cannot contain any wildcards to prevent output of wrong results.
+     * For example, if fileUrl is specified by regular expression like hdfs://some/p1=*", column value will be extracted as "*" in {@link DppUtils#parseColumnsFromPath},
+     * then "*" will likely be cast to wrong output according to its field type such as NULL for INT in {@link this#convertSrcDataframeToDstDataframe}
+     */
     private Dataset<Row> loadDataFromPath(SparkSession spark,
                                           EtlJobConfig.EtlFileGroup fileGroup,
                                           String fileUrl,

--- a/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/dpp/SparkDpp.java
+++ b/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/dpp/SparkDpp.java
@@ -612,8 +612,10 @@ public final class SparkDpp implements java.io.Serializable {
 
     /**
      * Note: parameter fileUrl cannot contain any wildcards to prevent output of wrong results.
-     * For example, if fileUrl is specified by regular expression like hdfs://some/p1=*", column value will be extracted as "*" in {@link DppUtils#parseColumnsFromPath},
-     * then "*" will likely be cast to wrong output according to its field type such as NULL for INT in {@link this#convertSrcDataframeToDstDataframe}
+     * For example, if fileUrl is specified by regular expression like hdfs://some/p1=*",
+     * column value will be extracted as "*" in {@link DppUtils#parseColumnsFromPath},
+     * then "*" will likely be cast to wrong output according to its field type such as NULL for INT
+     * in {@link this#convertSrcDataframeToDstDataframe}
      */
     private Dataset<Row> loadDataFromPath(SparkSession spark,
                                           EtlJobConfig.EtlFileGroup fileGroup,


### PR DESCRIPTION
If data path is specified by regular expression like `DATA INFILE("hdfs://some/cr_returned_date_sk=*/*")` while using spark load with `COLUMNS FROM PATH AS (cr_returned_date_sk)`, its column value will be parsed as `*` in `DppUtils.parseColumnsFromPath`, then it will likely be cast to wrong final output according to its type such as `NULL` for `INT` in `SparkDpp.convertSrcDataframeToDstDataframe`.
