### PR TITLE
support runtime modify be config doris_scanner_thread_pool_thread_num

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -178,7 +178,7 @@ CONF_mInt32(status_report_interval, "5");
 // Local directory to copy UDF libraries from HDFS into
 CONF_String(local_library_dir, "${UDF_RUNTIME_DIR}");
 // number of olap scanner thread pool size
-CONF_Int32(doris_scanner_thread_pool_thread_num, "48");
+CONF_mInt32(doris_scanner_thread_pool_thread_num, "48");
 // number of olap scanner thread pool size
 CONF_Int32(doris_scanner_thread_pool_queue_size, "102400");
 // number of etl thread pool size

--- a/be/src/http/action/update_config_action.h
+++ b/be/src/http/action/update_config_action.h
@@ -21,17 +21,27 @@
 
 #pragma once
 
+#include <functional>
+#include <mutex>
+#include <unordered_map>
+
 #include "http/http_handler.h"
+#include "runtime/exec_env.h"
 
 namespace starrocks {
 
 // Update BE config.
 class UpdateConfigAction : public HttpHandler {
 public:
-    UpdateConfigAction() = default;
+    UpdateConfigAction(ExecEnv* exec_env) : _exec_env(exec_env) {}
     ~UpdateConfigAction() override = default;
 
     void handle(HttpRequest* req) override;
+
+private:
+    ExecEnv* _exec_env;
+    std::once_flag _once_flag;
+    std::unordered_map<std::string, std::function<void()>> _config_callback;
 };
 
 } // namespace starrocks

--- a/be/src/service/http_service.cpp
+++ b/be/src/service/http_service.cpp
@@ -114,7 +114,7 @@ Status HttpService::start() {
     CompactionAction* run_compaction_action = new CompactionAction(CompactionActionType::RUN_COMPACTION);
     _ev_http_server->register_handler(HttpMethod::POST, "/api/compaction/run", run_compaction_action);
 
-    UpdateConfigAction* update_config_action = new UpdateConfigAction();
+    UpdateConfigAction* update_config_action = new UpdateConfigAction(_env);
     _ev_http_server->register_handler(HttpMethod::POST, "/api/update_config", update_config_action);
 
     RETURN_IF_ERROR(_ev_http_server->start());

--- a/be/src/util/priority_thread_pool.hpp
+++ b/be/src/util/priority_thread_pool.hpp
@@ -161,6 +161,7 @@ private:
     }
 
     void remove_thread(int tid) {
+        std::lock_guard<std::mutex> l(_lock);
         auto res = std::find_if(_threads_holder.begin(), _threads_holder.end(),
                                 [=](const auto& val) { return tid == val.second; });
         if (res != _threads_holder.end()) {

--- a/be/src/util/priority_thread_pool.hpp
+++ b/be/src/util/priority_thread_pool.hpp
@@ -143,10 +143,8 @@ private:
     }
 
     void decrease_thr(int num_thread) {
-        std::lock_guard<std::mutex> l(_lock);
-        for (int i = 0; i < num_thread; ++i) {
-            _should_decrease++;
-        }
+        _should_decrease += num_thread;
+
         for (int i = 0; i < num_thread; ++i) {
             PriorityThreadPool::Task empty_task = {0, []() {}};
             _work_queue.try_put(empty_task);

--- a/be/src/util/priority_thread_pool.hpp
+++ b/be/src/util/priority_thread_pool.hpp
@@ -22,6 +22,8 @@
 #ifndef STARROCKS_BE_SRC_COMMON_UTIL_PRIORITY_THREAD_POOL_HPP
 #define STARROCKS_BE_SRC_COMMON_UTIL_PRIORITY_THREAD_POOL_HPP
 
+#include <algorithm>
+#include <atomic>
 #include <boost/thread.hpp>
 #include <functional>
 
@@ -58,7 +60,7 @@ public:
     //  -- work_function: the function to run every time an item is consumed from the queue
     PriorityThreadPool(uint32_t num_threads, uint32_t queue_size) : _work_queue(queue_size), _shutdown(false) {
         for (int i = 0; i < num_threads; ++i) {
-            _threads.create_thread(std::bind<void>(std::mem_fn(&PriorityThreadPool::work_thread), this, i));
+            new_thread(++_current_thread_id);
         }
     }
 
@@ -123,7 +125,50 @@ public:
         join();
     }
 
+    void set_num_thread(int num_thread) {
+        size_t num_thread_in_pool = _threads.size();
+        if (num_thread > num_thread_in_pool) {
+            increase_thr(num_thread - num_thread_in_pool);
+        } else if (num_thread < num_thread_in_pool) {
+            decrease_thr(num_thread_in_pool - num_thread);
+        }
+    }
+
 private:
+    void increase_thr(int num_thread) {
+        std::lock_guard<std::mutex> l(_lock);
+        for (int i = 0; i < num_thread; ++i) {
+            new_thread(++_current_thread_id);
+        }
+    }
+
+    void decrease_thr(int num_thread) {
+        std::lock_guard<std::mutex> l(_lock);
+        for (int i = 0; i < num_thread; ++i) {
+            _should_decrease++;
+        }
+        for (int i = 0; i < num_thread; ++i) {
+            PriorityThreadPool::Task empty_task = {0, []() {}};
+            _work_queue.try_put(empty_task);
+        }
+    }
+
+    // not thread safe
+    // we need acquire _lock before call this function
+    void new_thread(int tid) {
+        auto* thr = _threads.create_thread(std::bind<void>(std::mem_fn(&PriorityThreadPool::work_thread), this, tid));
+        _threads_holder.emplace_back(thr, tid);
+    }
+
+    void remove_thread(int tid) {
+        auto res = std::find_if(_threads_holder.begin(), _threads_holder.end(),
+                                [=](const auto& val) { return tid == val.second; });
+        if (res != _threads_holder.end()) {
+            _threads.remove_thread(res->first);
+            _threads_holder.erase(res);
+        }
+    }
+
     // Driver method for each thread in the pool. Continues to read work from the queue
     // until the pool is shutdown.
     void work_thread(int thread_id) {
@@ -135,6 +180,23 @@ private:
             if (_work_queue.get_size() == 0) {
                 _empty_cv.notify_all();
             }
+            if (_should_decrease) {
+                bool need_destroy = true;
+                int32_t expect;
+                int32_t target;
+                do {
+                    expect = _should_decrease;
+                    target = expect - 1;
+                    if (expect == 0) {
+                        need_destroy = false;
+                        break;
+                    }
+                } while (!_should_decrease.compare_exchange_weak(expect, target));
+                if (need_destroy) {
+                    remove_thread(thread_id);
+                    break;
+                }
+            }
         }
     }
 
@@ -143,6 +205,9 @@ private:
         std::lock_guard<std::mutex> l(_lock);
         return _shutdown;
     }
+    // thread pointer
+    // tid
+    std::vector<std::pair<boost::thread*, int>> _threads_holder;
 
     // Queue on which work items are held until a thread is available to process them in
     // FIFO order.
@@ -159,6 +224,10 @@ private:
 
     // Signalled when the queue becomes empty
     std::condition_variable _empty_cv;
+
+    std::atomic<int32_t> _should_decrease = 0;
+
+    std::atomic<int32_t> _current_thread_id = 0;
 };
 
 } // namespace starrocks


### PR DESCRIPTION
We need to support performance testing with different resources.
Frequent restarting of BE to modify parameters is not necessary

will close #567 