### PR TITLE
Do not compare versionHash when looking up replica for backup

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupJob.java
@@ -401,7 +401,7 @@ public class BackupJob extends AbstractJob {
                         int schemaHash = tbl.getSchemaHashByIndexId(index.getId());
                         List<Tablet> tablets = index.getTablets();
                         for (Tablet tablet : tablets) {
-                            Replica replica = chooseReplica(tablet, visibleVersion, visibleVersionHash);
+                            Replica replica = chooseReplica(tablet, visibleVersion);
                             if (replica == null) {
                                 status = new Status(ErrCode.COMMON_ERROR,
                                         "faild to choose replica to make snapshot for tablet " + tablet.getId()
@@ -670,7 +670,7 @@ public class BackupJob extends AbstractJob {
      * Choose a replica order by replica id.
      * This is to expect to choose the same replica at each backup job.
      */
-    private Replica chooseReplica(Tablet tablet, long visibleVersion, long visibleVersionHash) {
+    private Replica chooseReplica(Tablet tablet, long visibleVersion) {
         List<Long> replicaIds = Lists.newArrayList();
         for (Replica replica : tablet.getReplicas()) {
             replicaIds.add(replica.getId());
@@ -679,8 +679,7 @@ public class BackupJob extends AbstractJob {
         Collections.sort(replicaIds);
         for (Long replicaId : replicaIds) {
             Replica replica = tablet.getReplicaById(replicaId);
-            if (replica.getLastFailedVersion() < 0 && (replica.getVersion() > visibleVersion
-                    || (replica.getVersion() == visibleVersion && replica.getVersionHash() == visibleVersionHash))) {
+            if (replica.getLastFailedVersion() < 0 && (replica.getVersion() >= visibleVersion)) {
                 return replica;
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupJob.java
@@ -666,8 +666,8 @@ public class BackupJob extends AbstractJob {
     }
 
     /*
-     * Choose a replica order by replica id.
-     * This is to expect to choose the same replica at each backup job.
+     * Choose a replica whose version >= visibleVersion and dose not have failed version.
+     * Iterate replica order by replica id, the reason is to choose the same replica at each backup job.
      */
     private Replica chooseReplica(Tablet tablet, long visibleVersion) {
         List<Long> replicaIds = Lists.newArrayList();

--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupJob.java
@@ -404,9 +404,8 @@ public class BackupJob extends AbstractJob {
                             Replica replica = chooseReplica(tablet, visibleVersion);
                             if (replica == null) {
                                 status = new Status(ErrCode.COMMON_ERROR,
-                                        "faild to choose replica to make snapshot for tablet " + tablet.getId()
-                                                + ". visible version: " + visibleVersion
-                                                + ", visible version hash: " + visibleVersionHash);
+                                        "failed to choose replica to make snapshot for tablet " + tablet.getId()
+                                                + ". visible version: " + visibleVersion);
                                 return;
                             }
                             SnapshotTask task = new SnapshotTask(null, replica.getBackendId(), tablet.getId(),


### PR DESCRIPTION
Fix #580 
VersionHash has been deprecated.
Do not compare versionHash when looking up replica for backup.