### PR TITLE
Fix bug create table like the number of replicate is inconsistent

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/SingleRangePartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/SingleRangePartitionDesc.java
@@ -111,6 +111,10 @@ public class SingleRangePartitionDesc extends PartitionDesc {
         partitionKeyDesc.analyze(partColNum);
 
         if (otherProperties != null) {
+            // The priority of the partition attribute is higher than that of the table
+            for (String key : properties.keySet()) {
+                otherProperties.put(key, properties.get(key));
+            }
             this.properties = otherProperties;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/SingleRangePartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/SingleRangePartitionDesc.java
@@ -24,6 +24,7 @@ package com.starrocks.analysis;
 import com.google.common.base.Joiner;
 import com.google.common.base.Joiner.MapJoiner;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
 import com.starrocks.analysis.PartitionKeyDesc.PartitionRangeType;
 import com.starrocks.catalog.DataProperty;
 import com.starrocks.common.AnalysisException;
@@ -32,6 +33,7 @@ import com.starrocks.common.FeNameFormat;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.PrintableMap;
 import com.starrocks.common.util.PropertyAnalyzer;
+import com.starrocks.sql.optimizer.base.Property;
 import com.starrocks.thrift.TTabletType;
 
 import java.util.Map;
@@ -110,14 +112,21 @@ public class SingleRangePartitionDesc extends PartitionDesc {
 
         partitionKeyDesc.analyze(partColNum);
 
+
         if (otherProperties != null) {
-            // The priority of the partition attribute is higher than that of the table
-            if (properties != null) {
-                for (String key : properties.keySet()) {
-                    otherProperties.put(key, properties.get(key));
+            if (properties == null) {
+                this.properties = otherProperties;
+            } else {
+                // The priority of the partition attribute is higher than that of the table
+                Map<String, String> partitionProperties = Maps.newHashMap();
+                for (String key : otherProperties.keySet()) {
+                    partitionProperties.put(key, properties.get(key));
                 }
+                for (String key : properties.keySet()) {
+                    partitionProperties.put(key, properties.get(key));
+                }
+                this.properties = partitionProperties;
             }
-            this.properties = otherProperties;
         }
 
         // analyze data property

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/SingleRangePartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/SingleRangePartitionDesc.java
@@ -120,7 +120,7 @@ public class SingleRangePartitionDesc extends PartitionDesc {
                 // The priority of the partition attribute is higher than that of the table
                 Map<String, String> partitionProperties = Maps.newHashMap();
                 for (String key : otherProperties.keySet()) {
-                    partitionProperties.put(key, properties.get(key));
+                    partitionProperties.put(key, otherProperties.get(key));
                 }
                 for (String key : properties.keySet()) {
                     partitionProperties.put(key, properties.get(key));

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/SingleRangePartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/SingleRangePartitionDesc.java
@@ -112,8 +112,10 @@ public class SingleRangePartitionDesc extends PartitionDesc {
 
         if (otherProperties != null) {
             // The priority of the partition attribute is higher than that of the table
-            for (String key : properties.keySet()) {
-                otherProperties.put(key, properties.get(key));
+            if (properties != null) {
+                for (String key : properties.keySet()) {
+                    otherProperties.put(key, properties.get(key));
+                }
             }
             this.properties = otherProperties;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/RangePartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/RangePartitionInfo.java
@@ -29,6 +29,7 @@ import com.starrocks.analysis.PartitionKeyDesc;
 import com.starrocks.analysis.SingleRangePartitionDesc;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.FeConstants;
 import com.starrocks.common.FeMetaVersion;
 import com.starrocks.common.util.RangeUtils;
 import org.apache.logging.log4j.LogManager;
@@ -387,6 +388,12 @@ public class RangePartitionInfo extends PartitionInfo {
         Collections.sort(entries, RangeUtils.RANGE_MAP_ENTRY_COMPARATOR);
 
         idx = 0;
+        PartitionInfo tblPartitionInfo = table.getPartitionInfo();
+        short replicationNum = Short.parseShort(table.getTableProperty().getProperties().get("replication_num"));
+        if (table.getTableProperty().getProperties().get("replication_num") == null) {
+            replicationNum = FeConstants.default_replication_num;
+        }
+
         for (Map.Entry<Long, Range<PartitionKey>> entry : entries) {
             Partition partition = table.getPartition(entry.getKey());
             String partitionName = partition.getName();
@@ -401,7 +408,10 @@ public class RangePartitionInfo extends PartitionInfo {
                 partitionId.add(entry.getKey());
                 break;
             }
-
+            short curPartitionReplicationNum = tblPartitionInfo.getReplicationNum(entry.getKey());
+            if(curPartitionReplicationNum != replicationNum) {
+                sb.append("(").append("\"replication_num\" = \"").append(curPartitionReplicationNum).append("\")");
+            }
             if (idx != entries.size() - 1) {
                 sb.append(",\n");
             }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/RangePartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/RangePartitionInfo.java
@@ -409,7 +409,7 @@ public class RangePartitionInfo extends PartitionInfo {
                 break;
             }
             short curPartitionReplicationNum = tblPartitionInfo.getReplicationNum(entry.getKey());
-            if(curPartitionReplicationNum != replicationNum) {
+            if (curPartitionReplicationNum != replicationNum) {
                 sb.append("(").append("\"replication_num\" = \"").append(curPartitionReplicationNum).append("\")");
             }
             if (idx != entries.size() - 1) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/RangePartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/RangePartitionInfo.java
@@ -389,9 +389,13 @@ public class RangePartitionInfo extends PartitionInfo {
 
         idx = 0;
         PartitionInfo tblPartitionInfo = table.getPartitionInfo();
-        short replicationNum = Short.parseShort(table.getTableProperty().getProperties().get("replication_num"));
-        if (table.getTableProperty().getProperties().get("replication_num") == null) {
+
+        String replicationNumStr = table.getTableProperty().getProperties().get("replication_num");
+        short replicationNum;
+        if (replicationNumStr == null) {
             replicationNum = FeConstants.default_replication_num;
+        } else {
+            replicationNum = Short.parseShort(replicationNumStr);
         }
 
         for (Map.Entry<Long, Range<PartitionKey>> entry : entries) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/PartitionsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/PartitionsProcDir.java
@@ -151,7 +151,7 @@ public class PartitionsProcDir implements ProcDirInterface {
             filterPartitionInfos = Lists.newArrayList();
             for (List<Comparable> partitionInfo : partitionInfos) {
                 if (partitionInfo.size() != TITLE_NAMES.size()) {
-                    throw new AnalysisException("ParttitionInfos.size() " + partitionInfos.size()
+                    throw new AnalysisException("PartitionInfos.size() " + partitionInfos.size()
                             + " not equal TITLE_NAMES.size() " + TITLE_NAMES.size());
                 }
                 boolean isNeed = true;


### PR DESCRIPTION
Fix #588
create table like implement is convert to DDL SQL and then parse the statement to create same table.
but for a table it is DDL not describe info about replicate_num.
so we should add this information for some partition is not the same as table replicate_num。
and pass to the create phrase to create different replicate_num for a table.