### PR TITLE
make agg sum vectorized

### DIFF
--- a/be/src/exprs/agg/sum.h
+++ b/be/src/exprs/agg/sum.h
@@ -53,9 +53,11 @@ public:
                                    AggDataPtr state) const override {
         const auto* column = down_cast<const InputColumnType*>(columns[0]);
         const auto* data = column->get_data().data();
+        ResultType local_sum{};
         for (size_t i = 0; i < batch_size; ++i) {
-            this->data(state).sum += data[i];
+            local_sum += data[i];
         }
+        this->data(state).sum += local_sum;
     }
 
     void update_batch_single_state(FunctionContext* ctx, AggDataPtr state, const Column** columns,


### PR DESCRIPTION
gcc couldn't vectorize the sum loop if accumulator is class member instead of local variable.

eg: https://godbolt.org/z/hh84jP9f8

```sql
select sum(LO_CUSTKEY+1),sum(LO_CUSTKEY+2),sum(LO_CUSTKEY+3),sum(LO_CUSTKEY+4),sum(LO_CUSTKEY+5) from lineorder_flat;
```

before:
3.98
after:
2.63
