### PR TITLE
Bugfix: MemTracker causes be's crash when concurrent queries(dop>1) are issued in pipeline mode

### DIFF
--- a/be/src/exec/pipeline/fragment_context.h
+++ b/be/src/exec/pipeline/fragment_context.h
@@ -26,6 +26,7 @@ class FragmentContext {
 public:
     FragmentContext() : _cancel_flag(false) {}
     ~FragmentContext() {
+        _drivers.clear();
         close_all_pipelines();
         if (_plan != nullptr) {
             _plan->close(_runtime_state.get());

--- a/be/src/exec/pipeline/operator.cpp
+++ b/be/src/exec/pipeline/operator.cpp
@@ -2,6 +2,7 @@
 
 #include "exec/pipeline/operator.h"
 
+#include "gutil/strings/substitute.h"
 #include "runtime/mem_tracker.h"
 #include "runtime/runtime_state.h"
 #include "util/runtime_profile.h"
@@ -9,15 +10,12 @@
 namespace starrocks::pipeline {
 Operator::Operator(int32_t id, const std::string& name, int32_t plan_node_id)
         : _id(id), _name(name), _plan_node_id(plan_node_id) {
-    std::stringstream ss;
-    ss << name << " (id=" << _id << ")";
-    _runtime_profile = std::make_shared<RuntimeProfile>(ss.str());
+    _runtime_profile = std::make_shared<RuntimeProfile>(strings::Substitute("$0 (id=$1)", name, _id));
     _runtime_profile->set_metadata(_id);
 }
 
 Status Operator::prepare(RuntimeState* state) {
-    _mem_tracker = std::make_shared<MemTracker>(_runtime_profile.get(), -1, _runtime_profile->name(),
-                                                state->instance_mem_tracker());
+    _mem_tracker = std::make_shared<MemTracker>(_runtime_profile.get(), -1, _runtime_profile->name(), nullptr);
     return Status::OK();
 }
 

--- a/be/src/exec/pipeline/pipeline_driver_dispatcher.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_dispatcher.cpp
@@ -38,7 +38,6 @@ void GlobalDriverDispatcher::finalize_driver(DriverRawPtr driver, RuntimeState* 
     if (driver->query_ctx()->is_finished()) {
         auto query_id = driver->query_ctx()->query_id();
         DCHECK(!driver->source_operator()->pending_finish());
-        driver.reset();
         QueryContextManager::instance()->remove(query_id);
     }
 }

--- a/be/src/exec/pipeline/pipeline_driver_dispatcher.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_dispatcher.cpp
@@ -37,6 +37,8 @@ void GlobalDriverDispatcher::finalize_driver(DriverRawPtr driver, RuntimeState* 
     driver->finalize(runtime_state, state);
     if (driver->query_ctx()->is_finished()) {
         auto query_id = driver->query_ctx()->query_id();
+        DCHECK(!driver->source_operator()->pending_finish());
+        driver.reset();
         QueryContextManager::instance()->remove(query_id);
     }
 }


### PR DESCRIPTION
## Bugfix
When queries are issued concurrently and each query's dop is more than one,  Be will crash after several queries have been executed. There are some concurrent bugs exist in root MemTracker of MemTracker tree in pipeline engine, a transient solution is that remove parent MemTrackers in operator-specifiic MemTrackers, a test lasting for 15 hours has verified this bugfix. After new version memory management is developed, a final and robust fix will be proposed.