### PR TITLE
use lambda instead of std::function

### DIFF
--- a/be/src/util/defer_op.h
+++ b/be/src/util/defer_op.h
@@ -28,9 +28,9 @@
 namespace starrocks {
 
 // This class is used to defer a function when this object is deconstruct
+template <class DeferFunction>
 class DeferOp {
 public:
-    typedef std::function<void()> DeferFunction;
     explicit DeferOp(DeferFunction func) : _func(std::move(func)) {}
 
     ~DeferOp() { _func(); };


### PR DESCRIPTION
Our current defer operation is based on std:: function But in most C + + standard libraries, when creating a function, there will be a new overhead, which is not necessary for the defer operation. But in fact, if we pass in a lambda expression, we can determine it during compilation, so we can avoid a new / delete overhead during the defer operation

STL std::funcional implement
```c++ 
private:
  static void
  _M_init_functor(_Any_data& __functor, _Functor&& __f, true_type)
  { ::new (__functor._M_access()) _Functor(std::move(__f)); }

  static void
  _M_init_functor(_Any_data& __functor, _Functor&& __f, false_type)
  { __functor._M_access<_Functor*>() = new _Functor(std::move(__f)); }
```

we could use this code instread of DeferOP
```c++
template <class T>
class Defer {
public:
    Defer(T closure) : _closure(std::move(closure)) {}
    ~Defer() { _closure(); }

private:
    T& _closure;
};
```


Here was the online bench mark: https://quick-bench.com/q/4IKpxAA5VEbXVziV1G2Po-ZupSE