### PR TITLE
bugfix: failed to insert DATETIME in non-vectorized mode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/Planner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/Planner.java
@@ -210,13 +210,7 @@ public class Planner {
 
         // vectorized engine selector
         if (analyzer.getContext().getSessionVariable().useVectorizedEngineEnable()) {
-            if (statement instanceof InsertStmt) {
-                if (analyzer.getContext().getSessionVariable().isVectorizedInsertEnable()) {
-                    insertAdapterNodeToFragment(fragments, plannerContext);
-                }
-            } else {
-                insertAdapterNodeToFragment(fragments, plannerContext);
-            }
+            insertAdapterNodeToFragment(fragments, plannerContext);
         }
 
         if (queryStmt instanceof SelectStmt) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -182,7 +182,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private boolean enablePipelineEngine = false;
 
     // use vectorized insert
-    @VariableMgr.VarAttr(name = ENABLE_VECTORIZED_INSERT, alias = "vectorized_insert_enable")
+    @VariableMgr.VarAttr(name = ENABLE_VECTORIZED_INSERT, alias = "vectorized_insert_enable", flag = VariableMgr.INVISIBLE)
     private boolean vectorizedInsertEnable = true;
 
     // max memory used on every backend.


### PR DESCRIPTION
How to reproduce the case: 

```sql
set enable_cbo = false;
drop database test_compatibility_db_1633997338193;
admin show frontend config like 'enable_decimal_v3';
admin set frontend config("enable_decimal_v3" = "false");
create database test_compatibility_db_1633997338193;
use test_compatibility_db_1633997338193
create table t0(c0 DATETIME) duplicate key(c0)
                distributed by hash(c0) buckets 1 properties('replication_num'='1');
set enable_vectorized_insert=false;
insert into t0 values(NULL),(20200102030405),("2020-02-03 04:05:06");
```