### PR TITLE
function year() returns int16 instead of int32 and use bit fields in date cache

### DIFF
--- a/be/src/column/fixed_length_column_base.cpp
+++ b/be/src/column/fixed_length_column_base.cpp
@@ -79,7 +79,7 @@ int FixedLengthColumnBase<T>::compare_at(size_t left, size_t right, const Column
 }
 
 template <typename T>
-uint32_t FixedLengthColumnBase<T>::serialize(size_t idx, uint8_t* pos) {
+inline uint32_t FixedLengthColumnBase<T>::serialize(size_t idx, uint8_t* pos) {
     strings::memcpy_inlined(pos, &_data[idx], sizeof(T));
     return sizeof(T);
 }

--- a/be/src/exprs/vectorized/time_functions.cpp
+++ b/be/src/exprs/vectorized/time_functions.cpp
@@ -300,10 +300,10 @@ ColumnPtr TimeFunctions::curdate(FunctionContext* context, const Columns& column
 DEFINE_UNARY_FN_WITH_IMPL(yearImpl, v) {
     int y, m, d;
     ((DateValue)v).to_date(&y, &m, &d);
-    return y;
+    return static_cast<int16_t>(y);
 }
 
-DEFINE_TIME_UNARY_FN(year, TYPE_DATETIME, TYPE_INT);
+DEFINE_TIME_UNARY_FN(year, TYPE_DATETIME, TYPE_SMALLINT);
 
 // quarter
 DEFINE_UNARY_FN_WITH_IMPL(quarterImpl, v) {

--- a/be/src/runtime/vectorized/time_types.cpp
+++ b/be/src/runtime/vectorized/time_types.cpp
@@ -16,17 +16,17 @@ const uint64_t LOG_10_INT[] = {1,         10,         100,         1000,        
 
 struct JulianToDateEntry {
     // 14 bits
-    uint16_t year;
+    uint16_t year: 14;
 
     // 4 bits
-    uint8_t month;
+    uint8_t month: 4;
 
     // 5 bits
-    uint8_t day;
+    uint8_t day: 5;
 
     // 1-53, Base on 6 bits
-    uint8_t week_th_of_year;
-};
+    uint8_t week_th_of_year: 6;
+} __attribute__((packed));
 
 // Date Cache
 static const uint32_t CACHE_JULIAN_DAYS = 200 * 366;

--- a/be/src/runtime/vectorized/time_types.cpp
+++ b/be/src/runtime/vectorized/time_types.cpp
@@ -16,16 +16,16 @@ const uint64_t LOG_10_INT[] = {1,         10,         100,         1000,        
 
 struct JulianToDateEntry {
     // 14 bits
-    uint16_t year: 14;
+    uint16_t year : 14;
 
     // 4 bits
-    uint8_t month: 4;
+    uint8_t month : 4;
 
     // 5 bits
-    uint8_t day: 5;
+    uint8_t day : 5;
 
     // 1-53, Base on 6 bits
-    uint8_t week_th_of_year: 6;
+    uint8_t week_th_of_year : 6;
 } __attribute__((packed));
 
 // Date Cache

--- a/be/test/exprs/vectorized/time_functions_test.cpp
+++ b/be/test/exprs/vectorized/time_functions_test.cpp
@@ -57,7 +57,7 @@ TEST_F(TimeFunctionsTest, yearTest) {
     ASSERT_TRUE(result->is_numeric());
     ASSERT_FALSE(result->is_nullable());
 
-    auto v = ColumnHelper::cast_to<TYPE_INT>(result);
+    auto v = ColumnHelper::cast_to<TYPE_SMALLINT>(result);
     for (int k = 0; k < 20; ++k) {
         ASSERT_EQ(2000 + k, v->get_data()[k]);
     }
@@ -158,7 +158,7 @@ TEST_F(TimeFunctionsTest, monthTest) {
     ASSERT_TRUE(result->is_numeric());
     ASSERT_FALSE(result->is_nullable());
 
-    auto year_values = ColumnHelper::cast_to<TYPE_INT>(years);
+    auto year_values = ColumnHelper::cast_to<TYPE_SMALLINT>(years);
     auto month_values = ColumnHelper::cast_to<TYPE_INT>(result);
     for (size_t j = 0; j < tc->size(); ++j) {
         ASSERT_EQ(2000 + (j / 12), year_values->get_data()[j]);

--- a/fe/fe-core/src/main/java/com/starrocks/rewrite/FEFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rewrite/FEFunctions.java
@@ -171,9 +171,9 @@ public class FEFunctions {
         return secondsAdd(date, new IntLiteral(-(int) second.getLongValue()));
     }
 
-    @FEFunction(name = "year", argTypes = {"DATETIME"}, returnType = "INT")
+    @FEFunction(name = "year", argTypes = {"DATETIME"}, returnType = "SMALLINT")
     public static IntLiteral year(LiteralExpr arg) throws AnalysisException {
-        return new IntLiteral(((DateLiteral) arg).getYear(), Type.INT);
+        return new IntLiteral(((DateLiteral) arg).getYear(), Type.SMALLINT);
     }
 
     @FEFunction(name = "month", argTypes = {"DATETIME"}, returnType = "INT")

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
@@ -166,7 +166,7 @@ public class ScalarOperatorFunctions {
 
     @FEFunction(name = "year", argTypes = {"DATETIME"}, returnType = "SMALLINT")
     public static ConstantOperator year(ConstantOperator arg) {
-        return ConstantOperator.createSmallInt((short)arg.getDatetime().getYear());
+        return ConstantOperator.createSmallInt((short) arg.getDatetime().getYear());
     }
 
     @FEFunction(name = "month", argTypes = {"DATETIME"}, returnType = "INT")

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
@@ -164,9 +164,9 @@ public class ScalarOperatorFunctions {
         return ConstantOperator.createDatetime(date.getDatetime().minusSeconds(second.getInt()));
     }
 
-    @FEFunction(name = "year", argTypes = {"DATETIME"}, returnType = "INT")
+    @FEFunction(name = "year", argTypes = {"DATETIME"}, returnType = "SMALLINT")
     public static ConstantOperator year(ConstantOperator arg) {
-        return ConstantOperator.createInt(arg.getDatetime().getYear());
+        return ConstantOperator.createSmallInt((short)arg.getDatetime().getYear());
     }
 
     @FEFunction(name = "month", argTypes = {"DATETIME"}, returnType = "INT")

--- a/gensrc/script/starrocks_builtins_functions.py
+++ b/gensrc/script/starrocks_builtins_functions.py
@@ -137,7 +137,7 @@ visible_functions = [
     [['to_days'], 'INT', ['DATE'],
         '_ZN9starrocks18TimestampFunctions7to_daysEPN13starrocks_udf15FunctionContextERKNS1_11DateTimeValE'],
 
-    [['year'], 'INT', ['DATETIME'],
+    [['year'], 'SMALLINT', ['DATETIME'],
         '_ZN9starrocks18TimestampFunctions4yearEPN13starrocks_udf15FunctionContextERKNS1_11DateTimeValE'],
     [['month'], 'INT', ['DATETIME'],
         '_ZN9starrocks18TimestampFunctions5monthEPN13starrocks_udf15FunctionContextERKNS1_11DateTimeValE'],

--- a/gensrc/script/vectorized/vectorized_functions.py
+++ b/gensrc/script/vectorized/vectorized_functions.py
@@ -254,7 +254,7 @@ vectorized_functions = [
      'StringFunctions::parse_url_prepare', 'StringFunctions::parse_url_close'],
 
     # 50xxx: timestamp functions
-    [50010, 'year', 'INT', ['DATETIME'], 'TimeFunctions::year'],
+    [50010, 'year', 'SMALLINT', ['DATETIME'], 'TimeFunctions::year'],
     [50020, 'month', 'INT', ['DATETIME'], 'TimeFunctions::month'],
     [50030, 'quarter', 'INT', ['DATETIME'], 'TimeFunctions::quarter'],
     [50040, 'dayofweek', 'INT', ['DATETIME'], 'TimeFunctions::day_of_week'],


### PR DESCRIPTION
Optimize function `year()`:
- function `year()` returns int16 instead of int32.
- use bit fields in `JulianToDateEntry`.
- inline `FixedLengthColumnBase<T>::serialize`.
