### PR TITLE
Refine impl of TabletColumn to reduce memory usage

### DIFF
--- a/be/src/storage/field.h
+++ b/be/src/storage/field.h
@@ -583,7 +583,7 @@ public:
             case OLAP_FIELD_TYPE_VARCHAR:
                 return new VarcharField(column);
             case OLAP_FIELD_TYPE_ARRAY: {
-                std::unique_ptr<Field> item_field(FieldFactory::create(column.get_sub_column(0)));
+                std::unique_ptr<Field> item_field(FieldFactory::create(column.subcolumn(0)));
                 auto* local = new Field(column);
                 local->add_sub_field(std::move(item_field));
                 return local;
@@ -616,7 +616,7 @@ public:
             case OLAP_FIELD_TYPE_VARCHAR:
                 return new VarcharField(column);
             case OLAP_FIELD_TYPE_ARRAY: {
-                std::unique_ptr<Field> item_field(FieldFactory::create(column.get_sub_column(0)));
+                std::unique_ptr<Field> item_field(FieldFactory::create(column.subcolumn(0)));
                 auto* local = new Field(column);
                 local->add_sub_field(std::move(item_field));
                 return local;

--- a/be/src/storage/row_cursor.cpp
+++ b/be/src/storage/row_cursor.cpp
@@ -153,7 +153,7 @@ OLAPStatus RowCursor::init_scan_key(const TabletSchema& schema, const std::vecto
         if (type == OLAP_FIELD_TYPE_VARCHAR) {
             _variable_len += scan_keys[cid].length();
         } else if (type == OLAP_FIELD_TYPE_CHAR) {
-            _variable_len += std::max(scan_keys[cid].length(), column.length());
+            _variable_len += std::max<size_t>(scan_keys[cid].length(), column.length());
         }
     }
 
@@ -178,7 +178,7 @@ OLAPStatus RowCursor::init_scan_key(const TabletSchema& schema, const std::vecto
         } else if (type == OLAP_FIELD_TYPE_CHAR) {
             Slice* slice = reinterpret_cast<Slice*>(fixed_ptr + 1);
             slice->data = variable_ptr;
-            slice->size = std::max(scan_keys[cid].length(), column.length());
+            slice->size = std::max<size_t>(scan_keys[cid].length(), column.length());
             variable_ptr += slice->size;
         }
     }

--- a/be/src/storage/rowset/beta_rowset.cpp
+++ b/be/src/storage/rowset/beta_rowset.cpp
@@ -272,7 +272,7 @@ Status BetaRowset::get_segment_iterators(const vectorized::Schema& schema, const
     seg_options.delete_predicates.get_column_ids(&delete_columns);
     for (ColumnId cid : delete_columns) {
         const TabletColumn& col = options.tablet_schema->column(cid);
-        if (segment_schema.get_field_by_name(col.name()) == nullptr) {
+        if (segment_schema.get_field_by_name(std::string(col.name())) == nullptr) {
             auto f = vectorized::ChunkHelper::convert_field_to_format_v2(cid, col);
             segment_schema.append(std::make_shared<vectorized::Field>(std::move(f)));
         }

--- a/be/src/storage/rowset/segment_v2/column_writer.cpp
+++ b/be/src/storage/rowset/segment_v2/column_writer.cpp
@@ -244,8 +244,8 @@ Status ColumnWriter::create(const ColumnWriterOptions& opts, const TabletColumn*
     } else {
         switch (column->type()) {
         case FieldType::OLAP_FIELD_TYPE_ARRAY: {
-            DCHECK(column->get_subtype_count() == 1);
-            const TabletColumn& element_column = column->get_sub_column(0);
+            DCHECK(column->subcolumn_count() == 1);
+            const TabletColumn& element_column = column->subcolumn(0);
             ColumnWriterOptions element_options;
             element_options.meta = opts.meta->mutable_children_columns(0);
             element_options.need_zone_map = false;

--- a/be/src/storage/rowset/segment_v2/segment.cpp
+++ b/be/src/storage/rowset/segment_v2/segment.cpp
@@ -21,6 +21,7 @@
 
 #include "storage/rowset/segment_v2/segment.h"
 
+#include <fmt/core.h>
 #include <google/protobuf/io/zero_copy_stream_impl.h>
 
 #include <memory>
@@ -322,7 +323,7 @@ Status Segment::new_column_iterator(uint32_t cid, ColumnIterator** iter) {
         const TabletColumn& tablet_column = _tablet_schema->column(cid);
         if (!tablet_column.has_default_value() && !tablet_column.is_nullable()) {
             return Status::InternalError(
-                    Substitute("invalid nonexistent column($0) without default value.", tablet_column.name()));
+                    fmt::format("invalid nonexistent column({}) without default value.", tablet_column.name()));
         }
         const TypeInfoPtr& type_info = get_type_info(tablet_column);
         std::unique_ptr<DefaultValueColumnIterator> default_value_iter(new DefaultValueColumnIterator(

--- a/be/src/storage/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/storage/rowset/segment_v2/segment_writer.cpp
@@ -64,10 +64,8 @@ void SegmentWriter::_init_column_meta(ColumnMetaPB* meta, uint32_t* column_id, c
     meta->set_encoding(DEFAULT_ENCODING);
     meta->set_compression(LZ4_FRAME);
     meta->set_is_nullable(column.is_nullable());
-    if (column.get_subtype_count() > 0) {
-        for (uint32_t i = 0; i < column.get_subtype_count(); ++i) {
-            _init_column_meta(meta->add_children_columns(), column_id, column.get_sub_column(i));
-        }
+    for (uint32_t i = 0; i < column.subcolumn_count(); ++i) {
+        _init_column_meta(meta->add_children_columns(), column_id, column.subcolumn(i));
     }
 }
 

--- a/be/src/storage/schema_change.cpp
+++ b/be/src/storage/schema_change.cpp
@@ -1947,7 +1947,7 @@ OLAPStatus SchemaChangeHandler::_parse_request(
     // set column mapping
     for (int i = 0, new_schema_size = new_tablet->tablet_schema().num_columns(); i < new_schema_size; ++i) {
         const TabletColumn& new_column = new_tablet->tablet_schema().column(i);
-        const string& column_name = new_column.name();
+        string column_name = std::string(new_column.name());
         ColumnMapping* column_mapping = rb_changer->get_mutable_column_mapping(i);
 
         if (materialized_function_map.find(column_name) != materialized_function_map.end()) {

--- a/be/src/storage/schema_change.cpp
+++ b/be/src/storage/schema_change.cpp
@@ -1950,21 +1950,6 @@ OLAPStatus SchemaChangeHandler::_parse_request(
         const string& column_name = new_column.name();
         ColumnMapping* column_mapping = rb_changer->get_mutable_column_mapping(i);
 
-        if (new_column.has_reference_column()) {
-            int32_t column_index = base_tablet->field_index(new_column.referenced_column());
-
-            if (column_index < 0) {
-                LOG(WARNING) << "referenced column was missing. "
-                             << "[column=" << column_name << " referenced_column=" << column_index << "]";
-                return OLAP_ERR_CE_CMD_PARAMS_ERROR;
-            }
-
-            column_mapping->ref_column = column_index;
-            VLOG(3) << "A column refered to existed column will be added after schema changing."
-                    << "column=" << column_name << ", ref_column=" << column_index;
-            continue;
-        }
-
         if (materialized_function_map.find(column_name) != materialized_function_map.end()) {
             AlterMaterializedViewParam mvParam = materialized_function_map.find(column_name)->second;
             column_mapping->materialized_function = mvParam.mv_expr;

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -1296,7 +1296,7 @@ Status TabletManager::_create_tablet_meta_unlocked(const TCreateTabletReq& reque
             //    to the new column
             size_t old_col_idx = 0;
             for (old_col_idx = 0; old_col_idx < old_num_columns; ++old_col_idx) {
-                const std::string& old_name = base_tablet->tablet_schema().column(old_col_idx).name();
+                auto old_name = base_tablet->tablet_schema().column(old_col_idx).name();
                 if (old_name == column.column_name) {
                     uint32_t old_unique_id = base_tablet->tablet_schema().column(old_col_idx).unique_id();
                     col_idx_to_unique_id[new_col_idx] = old_unique_id;

--- a/be/src/storage/tablet_schema.cpp
+++ b/be/src/storage/tablet_schema.cpp
@@ -306,7 +306,7 @@ TabletColumn& TabletColumn::operator=(TabletColumn&& rhs) {
 
 void TabletColumn::init_from_pb(const ColumnPB& column) {
     _unique_id = column.unique_id();
-    _col_name = column.name();
+    _col_name.assign(column.name());
     _type = TabletColumn::get_field_type_by_string(column.type());
 
     _set_flag(kIsKeyShift, column.is_key());
@@ -346,8 +346,8 @@ void TabletColumn::init_from_pb(const ColumnPB& column) {
 }
 
 void TabletColumn::to_schema_pb(ColumnPB* column) const {
+    column->mutable_name()->assign(_col_name.value());
     column->set_unique_id(_unique_id);
-    column->set_name(_col_name);
     column->set_type(get_string_by_field_type(_type));
     column->set_is_key(is_key());
     column->set_is_nullable(is_nullable());
@@ -544,7 +544,7 @@ bool operator==(const TabletSchema& a, const TabletSchema& b) {
 
 std::string TabletColumn::debug_string() const {
     std::stringstream ss;
-    ss << "(unique_id=" << _unique_id << ",name=" << _col_name << ",type=" << _type << ",is_key=" << is_key()
+    ss << "(unique_id=" << _unique_id << ",name=" << _col_name.value() << ",type=" << _type << ",is_key=" << is_key()
        << ",aggregation=" << _aggregation << ",is_nullable=" << is_nullable()
        << ",default_value=" << (has_default_value() ? default_value() : "N/A")
        << ",precision=" << (has_precision() ? std::to_string(_precision) : "N/A")

--- a/be/src/storage/tablet_schema.cpp
+++ b/be/src/storage/tablet_schema.cpp
@@ -280,16 +280,17 @@ TabletColumn::~TabletColumn() {
 }
 
 void TabletColumn::swap(TabletColumn* rhs) {
-    std::swap(_col_name, rhs->_col_name);
-    std::swap(_unique_id, rhs->_unique_id);
-    std::swap(_length, rhs->_length);
-    std::swap(_aggregation, rhs->_aggregation);
-    std::swap(_type, rhs->_type);
-    std::swap(_index_length, rhs->_index_length);
-    std::swap(_precision, rhs->_precision);
-    std::swap(_scale, rhs->_scale);
-    std::swap(_flags, rhs->_flags);
-    std::swap(_extra_fields, rhs->_extra_fields);
+    using std::swap;
+    swap(_col_name, rhs->_col_name);
+    swap(_unique_id, rhs->_unique_id);
+    swap(_length, rhs->_length);
+    swap(_aggregation, rhs->_aggregation);
+    swap(_type, rhs->_type);
+    swap(_index_length, rhs->_index_length);
+    swap(_precision, rhs->_precision);
+    swap(_scale, rhs->_scale);
+    swap(_flags, rhs->_flags);
+    swap(_extra_fields, rhs->_extra_fields);
 }
 
 TabletColumn& TabletColumn::operator=(const TabletColumn& rhs) {

--- a/be/src/storage/tablet_schema.cpp
+++ b/be/src/storage/tablet_schema.cpp
@@ -346,7 +346,7 @@ void TabletColumn::init_from_pb(const ColumnPB& column) {
 }
 
 void TabletColumn::to_schema_pb(ColumnPB* column) const {
-    column->mutable_name()->assign(_col_name.value());
+    column->mutable_name()->assign(_col_name.data(), _col_name.size());
     column->set_unique_id(_unique_id);
     column->set_type(get_string_by_field_type(_type));
     column->set_is_key(is_key());
@@ -544,7 +544,7 @@ bool operator==(const TabletSchema& a, const TabletSchema& b) {
 
 std::string TabletColumn::debug_string() const {
     std::stringstream ss;
-    ss << "(unique_id=" << _unique_id << ",name=" << _col_name.value() << ",type=" << _type << ",is_key=" << is_key()
+    ss << "(unique_id=" << _unique_id << ",name=" << _col_name << ",type=" << _type << ",is_key=" << is_key()
        << ",aggregation=" << _aggregation << ",is_nullable=" << is_nullable()
        << ",default_value=" << (has_default_value() ? default_value() : "N/A")
        << ",precision=" << (has_precision() ? std::to_string(_precision) : "N/A")

--- a/be/src/storage/tablet_schema.cpp
+++ b/be/src/storage/tablet_schema.cpp
@@ -232,74 +232,116 @@ uint32_t TabletColumn::get_field_length_by_type(FieldType type, uint32_t string_
 
 TabletColumn::TabletColumn() {}
 
-TabletColumn::TabletColumn(FieldAggregationMethod agg, FieldType type) {
-    _aggregation = agg;
-    _type = type;
+TabletColumn::TabletColumn(FieldAggregationMethod agg, FieldType type) : _aggregation(agg), _type(type) {}
+
+TabletColumn::TabletColumn(FieldAggregationMethod agg, FieldType type, bool is_nullable)
+        : _aggregation(agg), _type(type) {
+    _length = get_type_info(type)->size();
+    _set_flag(kIsNullableShift, is_nullable);
 }
 
-TabletColumn::TabletColumn(FieldAggregationMethod agg, FieldType field_type, bool is_nullable) {
-    _aggregation = agg;
-    _type = field_type;
-    _length = get_type_info(field_type)->size();
-    _is_nullable = is_nullable;
+TabletColumn::TabletColumn(FieldAggregationMethod agg, FieldType type, bool is_nullable, int32_t unique_id,
+                           size_t length)
+        : _unique_id(unique_id), _length(length), _aggregation(agg), _type(type) {
+    _set_flag(kIsNullableShift, is_nullable);
 }
 
-TabletColumn::TabletColumn(FieldAggregationMethod agg, FieldType field_type, bool is_nullable, int32_t unique_id,
-                           size_t length) {
-    _aggregation = agg;
-    _type = field_type;
-    _is_nullable = is_nullable;
-    _unique_id = unique_id;
-    _length = length;
+TabletColumn::TabletColumn(const TabletColumn& rhs)
+        : _col_name(rhs._col_name),
+          _unique_id(rhs._unique_id),
+          _length(rhs._length),
+          _aggregation(rhs._aggregation),
+          _type(rhs._type),
+          _index_length(rhs._index_length),
+          _precision(rhs._precision),
+          _scale(rhs._scale),
+          _flags(rhs._flags) {
+    if (rhs._extra_fields != nullptr) {
+        _extra_fields = new ExtraFields(*rhs._extra_fields);
+    }
+}
+
+TabletColumn::TabletColumn(TabletColumn&& rhs)
+        : _col_name(std::move(rhs._col_name)),
+          _unique_id(rhs._unique_id),
+          _length(rhs._length),
+          _aggregation(rhs._aggregation),
+          _type(rhs._type),
+          _index_length(rhs._index_length),
+          _precision(rhs._precision),
+          _scale(rhs._scale),
+          _flags(rhs._flags),
+          _extra_fields(rhs._extra_fields) {
+    rhs._extra_fields = nullptr;
+}
+
+TabletColumn::~TabletColumn() {
+    delete _extra_fields;
+}
+
+void TabletColumn::swap(TabletColumn* rhs) {
+    std::swap(_col_name, rhs->_col_name);
+    std::swap(_unique_id, rhs->_unique_id);
+    std::swap(_length, rhs->_length);
+    std::swap(_aggregation, rhs->_aggregation);
+    std::swap(_type, rhs->_type);
+    std::swap(_index_length, rhs->_index_length);
+    std::swap(_precision, rhs->_precision);
+    std::swap(_scale, rhs->_scale);
+    std::swap(_flags, rhs->_flags);
+    std::swap(_extra_fields, rhs->_extra_fields);
+}
+
+TabletColumn& TabletColumn::operator=(const TabletColumn& rhs) {
+    TabletColumn tmp(rhs);
+    swap(&tmp);
+    return *this;
+}
+
+TabletColumn& TabletColumn::operator=(TabletColumn&& rhs) {
+    TabletColumn tmp(std::move(rhs));
+    swap(&tmp);
+    return *this;
 }
 
 void TabletColumn::init_from_pb(const ColumnPB& column) {
     _unique_id = column.unique_id();
     _col_name = column.name();
     _type = TabletColumn::get_field_type_by_string(column.type());
-    _is_key = column.is_key();
-    _is_nullable = column.is_nullable();
 
-    _has_default_value = column.has_default_value();
-    if (_has_default_value) {
-        _default_value = column.default_value();
-    }
+    _set_flag(kIsKeyShift, column.is_key());
+    _set_flag(kIsNullableShift, column.is_nullable());
+    _set_flag(kIsBfColumnShift, column.is_bf_column());
+    _set_flag(kHasBitmapIndexShift, column.has_bitmap_index());
+    _set_flag(kHasPrecisionShift, column.has_precision());
+    _set_flag(kHasScaleShift, column.has_frac());
+
+    _length = column.length();
 
     if (column.has_precision()) {
-        _is_decimal = true;
+        DCHECK_LE(column.precision(), UINT8_MAX);
         _precision = column.precision();
-    } else {
-        _is_decimal = false;
     }
     if (column.has_frac()) {
+        DCHECK_LE(column.frac(), UINT8_MAX);
         _scale = column.frac();
     }
-    _length = column.length();
-    _index_length = column.index_length();
-    if (column.has_is_bf_column()) {
-        _is_bf_column = column.is_bf_column();
-    } else {
-        _is_bf_column = false;
-    }
-    if (column.has_has_bitmap_index()) {
-        _has_bitmap_index = column.has_bitmap_index();
-    } else {
-        _has_bitmap_index = false;
-    }
-    _has_referenced_column = column.has_referenced_column_id();
-    if (_has_referenced_column) {
-        _referenced_column_id = column.referenced_column_id();
+    if (column.has_index_length()) {
+        DCHECK_LE(column.index_length(), UINT8_MAX);
+        _index_length = column.index_length();
     }
     if (column.has_aggregation()) {
         _aggregation = get_aggregation_type_by_string(column.aggregation());
     }
-    if (column.has_visible()) {
-        _visible = column.visible();
+    if (column.has_default_value()) {
+        ExtraFields* extra = _get_or_alloc_extra_fields();
+        extra->has_default_value = true;
+        extra->default_value = column.default_value();
     }
     for (size_t i = 0; i < column.children_columns_size(); ++i) {
         TabletColumn sub_column;
         sub_column.init_from_pb(column.children_columns(i));
-        add_sub_column(sub_column);
+        add_sub_column(std::move(sub_column));
     }
 }
 
@@ -307,35 +349,33 @@ void TabletColumn::to_schema_pb(ColumnPB* column) const {
     column->set_unique_id(_unique_id);
     column->set_name(_col_name);
     column->set_type(get_string_by_field_type(_type));
-    column->set_is_key(_is_key);
-    column->set_is_nullable(_is_nullable);
-    if (_has_default_value) {
-        column->set_default_value(_default_value);
+    column->set_is_key(is_key());
+    column->set_is_nullable(is_nullable());
+    if (has_default_value()) {
+        column->set_default_value(default_value());
     }
-    if (_is_decimal) {
+    if (has_precision()) {
         column->set_precision(_precision);
+    }
+    if (has_scale()) {
         column->set_frac(_scale);
     }
     column->set_length(_length);
     column->set_index_length(_index_length);
-    if (_is_bf_column) {
-        column->set_is_bf_column(_is_bf_column);
-    }
+    column->set_is_bf_column(is_bf_column());
     column->set_aggregation(get_string_by_aggregation_type(_aggregation));
-    if (_has_referenced_column) {
-        column->set_referenced_column_id(_referenced_column_id);
-    }
-    if (_has_bitmap_index) {
-        column->set_has_bitmap_index(_has_bitmap_index);
-    }
-    for (const auto& sub_column : _sub_columns) {
-        sub_column.to_schema_pb(column->add_children_columns());
+    column->set_has_bitmap_index(has_bitmap_index());
+    for (int i = 0; i < subcolumn_count(); i++) {
+        subcolumn(i).to_schema_pb(column->add_children_columns());
     }
 }
 
-void TabletColumn::add_sub_column(TabletColumn& sub_column) {
-    _sub_columns.push_back(sub_column);
-    sub_column._parent = this;
+void TabletColumn::add_sub_column(const TabletColumn& sub_column) {
+    _get_or_alloc_extra_fields()->sub_columns.push_back(sub_column);
+}
+
+void TabletColumn::add_sub_column(TabletColumn&& sub_column) {
+    _get_or_alloc_extra_fields()->sub_columns.emplace_back(std::move(sub_column));
 }
 
 bool TabletColumn::is_format_v1_column() const {
@@ -348,7 +388,6 @@ bool TabletColumn::is_format_v2_column() const {
 
 void TabletSchema::init_from_pb(const TabletSchemaPB& schema) {
     _keys_type = schema.keys_type();
-    _num_columns = 0;
     _num_key_columns = 0;
     _num_null_columns = 0;
     _cols.clear();
@@ -356,7 +395,6 @@ void TabletSchema::init_from_pb(const TabletSchemaPB& schema) {
         TabletColumn column;
         column.init_from_pb(column_pb);
         _cols.push_back(column);
-        _num_columns++;
         if (column.is_key()) {
             _num_key_columns++;
         }
@@ -430,7 +468,7 @@ size_t TabletSchema::row_size() const {
     for (auto& column : _cols) {
         size += column.length();
     }
-    size += (_num_columns + 7) / 8;
+    size += (num_columns() + 7) / 8;
 
     return size;
 }
@@ -453,35 +491,30 @@ const std::vector<TabletColumn>& TabletSchema::columns() const {
 }
 
 const TabletColumn& TabletSchema::column(size_t ordinal) const {
-    DCHECK(ordinal < _num_columns) << "ordinal:" << ordinal << ", _num_columns:" << _num_columns;
+    DCHECK(ordinal < num_columns()) << "ordinal:" << ordinal << ", num_columns:" << num_columns();
     return _cols[ordinal];
 }
 
 bool operator==(const TabletColumn& a, const TabletColumn& b) {
+    if (a._flags != b._flags) return false;
     if (a._unique_id != b._unique_id) return false;
     if (a._col_name != b._col_name) return false;
     if (a._type != b._type) return false;
-    if (a._is_key != b._is_key) return false;
     if (a._aggregation != b._aggregation) return false;
-    if (a._is_nullable != b._is_nullable) return false;
-    if (a._has_default_value != b._has_default_value) return false;
-    if (a._has_default_value) {
-        if (a._default_value != b._default_value) return false;
+    if (a.has_default_value() != b.has_default_value()) return false;
+    if (a.has_default_value()) {
+        if (a.default_value() != b.default_value()) return false;
     }
-    if (a._is_decimal != b._is_decimal) return false;
-    if (a._is_decimal) {
+    if (a.has_precision() != b.has_precision()) return false;
+    if (a.has_precision()) {
         if (a._precision != b._precision) return false;
+    }
+    if (a.has_scale() != b.has_scale()) return false;
+    if (a.has_scale()) {
         if (a._scale != b._scale) return false;
     }
     if (a._length != b._length) return false;
     if (a._index_length != b._index_length) return false;
-    if (a._is_bf_column != b._is_bf_column) return false;
-    if (a._has_referenced_column != b._has_referenced_column) return false;
-    if (a._has_referenced_column) {
-        if (a._referenced_column_id != b._referenced_column_id) return false;
-        if (a._referenced_column != b._referenced_column) return false;
-    }
-    if (a._has_bitmap_index != b._has_bitmap_index) return false;
     return true;
 }
 
@@ -495,7 +528,6 @@ bool operator==(const TabletSchema& a, const TabletSchema& b) {
     for (int i = 0; i < a._cols.size(); ++i) {
         if (a._cols[i] != b._cols[i]) return false;
     }
-    if (a._num_columns != b._num_columns) return false;
     if (a._num_key_columns != b._num_key_columns) return false;
     if (a._num_null_columns != b._num_null_columns) return false;
     if (a._num_short_key_columns != b._num_short_key_columns) return false;
@@ -512,13 +544,13 @@ bool operator==(const TabletSchema& a, const TabletSchema& b) {
 
 std::string TabletColumn::debug_string() const {
     std::stringstream ss;
-    ss << "(unique_id=" << _unique_id << ",name=" << _col_name << ",type=" << _type << ",is_key=" << _is_key
-       << ",aggregation=" << _aggregation << ",is_nullable=" << _is_nullable
-       << ",has_default_value=" << _has_default_value << ",default_value=" << _default_value
-       << ",is_decimal=" << _is_decimal << ",precision=" << _precision << ",frac=" << _scale << ",length=" << _length
-       << ",index_length=" << _index_length << ",is_bf_column=" << _is_bf_column
-       << ",has_reference_column=" << _has_referenced_column << ",referenced_column_id=" << _referenced_column_id
-       << ",referenced_column=" << _referenced_column << ",has_bitmap_index=" << _has_bitmap_index << ")";
+    ss << "(unique_id=" << _unique_id << ",name=" << _col_name << ",type=" << _type << ",is_key=" << is_key()
+       << ",aggregation=" << _aggregation << ",is_nullable=" << is_nullable()
+       << ",default_value=" << (has_default_value() ? default_value() : "N/A")
+       << ",precision=" << (has_precision() ? std::to_string(_precision) : "N/A")
+       << ",frac=" << (has_scale() ? std::to_string(_scale) : "N/A") << ",length=" << _length
+       << ",index_length=" << _index_length << ",is_bf_column=" << is_bf_column()
+       << ",has_bitmap_index=" << has_bitmap_index() << ")";
     return ss.str();
 }
 
@@ -535,7 +567,7 @@ std::string TabletSchema::debug_string() const {
         }
         ss << _cols[i].debug_string();
     }
-    ss << "],keys_type=" << _keys_type << ",num_columns=" << _num_columns << ",num_key_columns=" << _num_key_columns
+    ss << "],keys_type=" << _keys_type << ",num_columns=" << num_columns() << ",num_key_columns=" << _num_key_columns
        << ",num_null_columns=" << _num_null_columns << ",num_short_key_columns=" << _num_short_key_columns
        << ",num_rows_per_row_block=" << _num_rows_per_row_block << ",compress_kind=" << _compress_kind
        << ",next_column_unique_id=" << _next_column_unique_id << ",has_bf_fpp=" << _has_bf_fpp << ",bf_fpp=" << _bf_fpp

--- a/be/src/storage/tablet_schema.h
+++ b/be/src/storage/tablet_schema.h
@@ -40,35 +40,95 @@ class SegmentReaderWriterTest_TestStringDict_Test;
 } // namespace segment_v2
 
 class TabletColumn {
+    struct ExtraFields {
+        std::string default_value;
+        std::vector<TabletColumn> sub_columns;
+        bool has_default_value = false;
+    };
+
 public:
+    // To developers: if you changed the typedefs, don't forget to reorder class members to
+    // minimize the memory space of TabletColumn, i.e, sizeof(TabletColumn)
+    typedef int32_t unique_id_type;
+    typedef int32_t length_type;
+    typedef uint8_t index_length_type;
+    typedef uint8_t precision_type;
+    typedef uint8_t scale_type;
+
     TabletColumn();
     TabletColumn(FieldAggregationMethod agg, FieldType type);
-    TabletColumn(FieldAggregationMethod agg, FieldType field_type, bool is_nullable);
-    TabletColumn(FieldAggregationMethod agg, FieldType field_type, bool is_nullable, int32_t unique_id, size_t length);
+    TabletColumn(FieldAggregationMethod agg, FieldType type, bool is_nullable);
+    TabletColumn(FieldAggregationMethod agg, FieldType type, bool is_nullable, int32_t unique_id, size_t length);
+
+    ~TabletColumn();
+
+    TabletColumn(const TabletColumn& rhs);
+    TabletColumn(TabletColumn&& rhs);
+
+    TabletColumn& operator=(const TabletColumn& rhs);
+    TabletColumn& operator=(TabletColumn&& rhs);
+
+    void swap(TabletColumn* rhs);
+
     void init_from_pb(const ColumnPB& column);
     void to_schema_pb(ColumnPB* column) const;
 
-    inline int32_t unique_id() const { return _unique_id; }
-    inline std::string name() const { return _col_name; }
-    inline FieldType type() const { return _type; }
-    inline bool is_key() const { return _is_key; }
-    inline bool is_nullable() const { return _is_nullable; }
-    inline bool is_bf_column() const { return _is_bf_column; }
-    inline bool has_bitmap_index() const { return _has_bitmap_index; }
-    bool has_default_value() const { return _has_default_value; }
-    std::string default_value() const { return _default_value; }
-    bool has_reference_column() const { return _has_referenced_column; }
-    int32_t referenced_column_id() const { return _referenced_column_id; }
-    std::string referenced_column() const { return _referenced_column; }
-    size_t length() const { return _length; }
-    size_t index_length() const { return _index_length; }
+    unique_id_type unique_id() const { return _unique_id; }
+    void set_unique_id(unique_id_type unique_id) { _unique_id = unique_id; }
+
+    const std::string& name() const { return _col_name; }
+    void set_name(std::string name) { _col_name = std::move(name); }
+
+    FieldType type() const { return _type; }
+    void set_type(FieldType type) { _type = type; }
+
+    bool is_key() const { return _check_flag(kIsKeyShift); }
+    void set_is_key(bool value) { _set_flag(kIsKeyShift, value); }
+
+    bool is_nullable() const { return _check_flag(kIsNullableShift); }
+    void set_is_nullable(bool value) { _set_flag(kIsNullableShift, value); }
+
+    bool is_bf_column() const { return _check_flag(kIsBfColumnShift); }
+    void set_is_bf_column(bool value) { _set_flag(kIsBfColumnShift, value); }
+
+    bool has_bitmap_index() const { return _check_flag(kHasBitmapIndexShift); }
+    void set_has_bitmap_index(bool value) { _set_flag(kHasBitmapIndexShift, value); }
+
+    length_type length() const { return _length; }
+    void set_length(length_type length) { _length = length; }
+
     FieldAggregationMethod aggregation() const { return _aggregation; }
-    int precision() const { return _precision; }
-    int scale() const { return _scale; }
-    bool visible() const { return _visible; }
-    void add_sub_column(TabletColumn& sub_column);
-    uint32_t get_subtype_count() const { return _sub_columns.size(); }
-    const TabletColumn& get_sub_column(uint32_t i) const { return _sub_columns[i]; }
+    void set_aggregation(FieldAggregationMethod agg) { _aggregation = agg; }
+
+    bool has_precision() const { return _check_flag(kHasPrecisionShift); }
+    precision_type precision() const { return _precision; }
+    void set_precision(precision_type precision) {
+        _precision = precision;
+        _set_flag(kHasPrecisionShift, true);
+    }
+
+    bool has_scale() const { return _check_flag(kHasScaleShift); }
+    scale_type scale() const { return _scale; }
+    void set_scale(scale_type scale) {
+        _scale = scale;
+        _set_flag(kHasScaleShift, true);
+    }
+
+    index_length_type index_length() const { return _index_length; }
+    void set_index_length(index_length_type index_length) { _index_length = index_length; }
+
+    bool has_default_value() const { return _extra_fields && _extra_fields->has_default_value; }
+    std::string default_value() const { return _extra_fields ? _extra_fields->default_value : ""; }
+    void set_default_value(std::string value) {
+        ExtraFields* ext = _get_or_alloc_extra_fields();
+        ext->has_default_value = true;
+        ext->default_value = std::move(value);
+    }
+
+    void add_sub_column(const TabletColumn& sub_column);
+    void add_sub_column(TabletColumn&& sub_column);
+    uint32_t subcolumn_count() const { return _extra_fields ? _extra_fields->sub_columns.size() : 0; }
+    const TabletColumn& subcolumn(uint32_t i) const { return _extra_fields->sub_columns[i]; }
 
     friend bool operator==(const TabletColumn& a, const TabletColumn& b);
     friend bool operator!=(const TabletColumn& a, const TabletColumn& b);
@@ -85,45 +145,57 @@ public:
     bool is_format_v2_column() const;
 
     int64_t mem_usage() const {
-        int64_t mem_usage =
-                sizeof(TabletColumn) + _col_name.length() + _default_value.length() + _referenced_column.length();
-        for (const auto& col : _sub_columns) {
-            mem_usage += col.mem_usage();
+        int64_t mem_usage = sizeof(TabletColumn) + _col_name.capacity() + default_value().capacity();
+        for (int i = 0; i < subcolumn_count(); i++) {
+            mem_usage += subcolumn(i).mem_usage();
         }
         return mem_usage;
     }
 
 private:
-    int32_t _unique_id;
+    constexpr static uint8_t kIsKeyShift = 0;
+    constexpr static uint8_t kIsNullableShift = 1;
+    constexpr static uint8_t kIsBfColumnShift = 2;
+    constexpr static uint8_t kHasBitmapIndexShift = 3;
+    constexpr static uint8_t kHasPrecisionShift = 4;
+    constexpr static uint8_t kHasScaleShift = 5;
+
+    ExtraFields* _get_or_alloc_extra_fields() {
+        if (_extra_fields == nullptr) {
+            _extra_fields = new ExtraFields();
+        }
+        return _extra_fields;
+    }
+
+    void _set_flag(uint8_t pos, bool value) {
+        assert(pos < sizeof(_flags) * 8);
+        if (value) {
+            _flags |= (1 << pos);
+        } else {
+            _flags &= ~(1 << pos);
+        }
+    }
+
+    bool _check_flag(uint8_t pos) const {
+        assert(pos < sizeof(_flags) * 8);
+        return _flags & (1 << pos);
+    }
+
+    // To developers: try to order the class members in a way to minimize the required memory space.
+
     std::string _col_name;
-    FieldType _type;
-    bool _is_key = false;
-    FieldAggregationMethod _aggregation{OLAP_FIELD_AGGREGATION_NONE};
-    bool _is_nullable = false;
+    unique_id_type _unique_id = 0;
+    length_type _length = 0;
+    FieldAggregationMethod _aggregation = OLAP_FIELD_AGGREGATION_NONE;
+    FieldType _type = OLAP_FIELD_TYPE_UNKNOWN;
 
-    bool _has_default_value = false;
-    std::string _default_value;
+    index_length_type _index_length = 0;
+    precision_type _precision = 0;
+    scale_type _scale = 0;
 
-    bool _is_decimal = false;
-    int32_t _precision;
-    int32_t _scale;
+    uint8_t _flags = 0;
 
-    int32_t _length;
-    int32_t _index_length;
-
-    bool _is_bf_column = false;
-
-    bool _has_referenced_column = false;
-    int32_t _referenced_column_id;
-    std::string _referenced_column;
-
-    bool _has_bitmap_index = false;
-
-    // for hidded column, which is transparent to user
-    bool _visible = true;
-
-    TabletColumn* _parent = nullptr;
-    std::vector<TabletColumn> _sub_columns;
+    ExtraFields* _extra_fields = nullptr;
 };
 
 bool operator==(const TabletColumn& a, const TabletColumn& b);
@@ -138,15 +210,15 @@ public:
     size_t field_index(const std::string& field_name) const;
     const TabletColumn& column(size_t ordinal) const;
     const std::vector<TabletColumn>& columns() const;
-    inline size_t num_columns() const { return _num_columns; }
-    inline size_t num_key_columns() const { return _num_key_columns; }
-    inline size_t num_short_key_columns() const { return _num_short_key_columns; }
-    inline size_t num_rows_per_row_block() const { return _num_rows_per_row_block; }
-    inline KeysType keys_type() const { return _keys_type; }
-    inline CompressKind compress_kind() const { return _compress_kind; }
-    inline size_t next_column_unique_id() const { return _next_column_unique_id; }
-    inline bool is_in_memory() const { return _is_in_memory; }
-    inline void set_is_in_memory(bool is_in_memory) { _is_in_memory = is_in_memory; }
+    size_t num_columns() const { return _cols.size(); }
+    size_t num_key_columns() const { return _num_key_columns; }
+    size_t num_short_key_columns() const { return _num_short_key_columns; }
+    size_t num_rows_per_row_block() const { return _num_rows_per_row_block; }
+    KeysType keys_type() const { return _keys_type; }
+    CompressKind compress_kind() const { return _compress_kind; }
+    size_t next_column_unique_id() const { return _next_column_unique_id; }
+    bool is_in_memory() const { return _is_in_memory; }
+    void set_is_in_memory(bool is_in_memory) { _is_in_memory = is_in_memory; }
 
     bool contains_format_v1_column() const;
     bool contains_format_v2_column() const;
@@ -171,18 +243,20 @@ private:
     friend bool operator==(const TabletSchema& a, const TabletSchema& b);
     friend bool operator!=(const TabletSchema& a, const TabletSchema& b);
 
-    KeysType _keys_type = DUP_KEYS;
+    double _bf_fpp = 0;
+
     std::vector<TabletColumn> _cols;
-    size_t _num_columns = 0;
-    size_t _num_key_columns = 0;
-    size_t _num_null_columns = 0;
-    size_t _num_short_key_columns = 0;
     size_t _num_rows_per_row_block = 0;
-    CompressKind _compress_kind = COMPRESS_NONE;
     size_t _next_column_unique_id = 0;
 
+    CompressKind _compress_kind = COMPRESS_NONE;
+    KeysType _keys_type = DUP_KEYS;
+
+    uint16_t _num_key_columns = 0;
+    uint16_t _num_null_columns = 0;
+    uint16_t _num_short_key_columns = 0;
+
     bool _has_bf_fpp = false;
-    double _bf_fpp = 0;
     bool _is_in_memory = false;
 };
 

--- a/be/src/storage/types.cpp
+++ b/be/src/storage/types.cpp
@@ -136,7 +136,7 @@ TypeInfoPtr get_type_info(const segment_v2::ColumnMetaPB& column_meta_pb) {
 TypeInfoPtr get_type_info(const TabletColumn& col) {
     TypeInfoPtr type_info;
     if (col.type() == OLAP_FIELD_TYPE_ARRAY) {
-        const TabletColumn& child = col.get_sub_column(0);
+        const TabletColumn& child = col.subcolumn(0);
         TypeInfoPtr child_type_info = get_type_info(child);
         type_info.reset(new ArrayTypeInfo(child_type_info));
         return type_info;

--- a/be/src/storage/vectorized/chunk_helper.cpp
+++ b/be/src/storage/vectorized/chunk_helper.cpp
@@ -13,7 +13,7 @@ namespace starrocks::vectorized {
 
 vectorized::Field ChunkHelper::convert_field(ColumnId id, const TabletColumn& c) {
     TypeInfoPtr type_info = get_type_info(c);
-    starrocks::vectorized::Field f(id, c.name(), type_info, c.is_nullable());
+    starrocks::vectorized::Field f(id, std::string(c.name()), type_info, c.is_nullable());
     f.set_is_key(c.is_key());
     f.set_short_key_length(c.index_length());
     f.set_aggregate_method(c.aggregation());
@@ -42,7 +42,7 @@ starrocks::vectorized::Field ChunkHelper::convert_field_to_format_v2(ColumnId id
     } else {
         type_info = get_type_info(type);
     }
-    starrocks::vectorized::Field f(id, c.name(), type_info, c.is_nullable());
+    starrocks::vectorized::Field f(id, std::string(c.name()), type_info, c.is_nullable());
     f.set_is_key(c.is_key());
 
     if (type == OLAP_FIELD_TYPE_ARRAY) {

--- a/be/src/storage/vectorized/chunk_helper.cpp
+++ b/be/src/storage/vectorized/chunk_helper.cpp
@@ -46,7 +46,7 @@ starrocks::vectorized::Field ChunkHelper::convert_field_to_format_v2(ColumnId id
     f.set_is_key(c.is_key());
 
     if (type == OLAP_FIELD_TYPE_ARRAY) {
-        const TabletColumn& sub_column = c.get_sub_column(0);
+        const TabletColumn& sub_column = c.subcolumn(0);
         auto sub_field = convert_field_to_format_v2(id, sub_column);
         f.add_sub_field(sub_field);
     }

--- a/be/src/util/c_string.h
+++ b/be/src/util/c_string.h
@@ -19,6 +19,8 @@ namespace starrocks {
 // Time complexity of empty() is O(1).
 // Time complexity of size() is O(n), where n is the length of string.
 class CString {
+    friend void swap(CString& lhs, CString& rhs);
+
 public:
     CString() {}
     ~CString() { _dealloc_if_needed(); }
@@ -58,6 +60,8 @@ public:
         return *this;
     }
 
+    void swap(CString* rhs) { std::swap(_data, rhs->_data); }
+
     const char* data() const { return _data; }
 
     size_t size() const { return std::strlen(_data); }
@@ -90,6 +94,10 @@ private:
 
 inline std::ostream& operator<<(std::ostream& os, const CString& s) {
     return os << s.data();
+}
+
+inline void swap(CString& lhs, CString& rhs) {
+    lhs.swap(&rhs);
 }
 
 } // namespace starrocks

--- a/be/src/util/c_string.h
+++ b/be/src/util/c_string.h
@@ -1,0 +1,95 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#pragma once
+
+#include <cstring>
+#include <iostream>
+#include <string_view>
+
+namespace starrocks {
+
+// A wrapper around c-style string, with some convenient APIs like `size()`, `==`.
+//
+// The main advantage over std::string is that CString has a smaller value of `sizeof`.
+//
+// Unlike std::string, NO reserved space will be allocated. This implies that every time
+// you assign a new string to CString, the previously allocated heap memory will be freed
+// and a new heap memory is allocated.
+//
+// Time complexity of empty() is O(1).
+// Time complexity of size() is O(n), where n is the length of string.
+class CString {
+public:
+    CString() {}
+    ~CString() { _dealloc_if_needed(); }
+
+    // Copy ctor
+    CString(const CString& rhs) { assign(rhs.data(), rhs.size()); }
+
+    // Move ctor
+    CString(CString&& rhs) : _data(rhs._data) { rhs._data = &kStaticStorage; }
+
+    // Copy assignment
+    CString& operator=(const CString& rhs) {
+        assign(rhs.data(), rhs.size());
+        return *this;
+    }
+
+    // Move assignment
+    CString& operator=(CString&& rhs) {
+        _dealloc_if_needed();
+        _data = rhs._data;
+        rhs._data = &kStaticStorage;
+        return *this;
+    }
+
+    // NOTE: it's caller's duty to ensure that the no zero character exist in |s|, otherwize
+    // size() may return a value different from |s.size()|.
+    CString& assign(const std::string_view& s) { return assign(s.data(), s.size()); }
+
+    // NOTE: it's caller's duty to ensure that the no zero character exist in data[0...len), otherwize
+    // size() may return a value different from |len|.
+    CString& assign(const char* data, uint16_t len) {
+        _dealloc_if_needed();
+        char* p = new char[len + 1];
+        memcpy(p, data, len);
+        p[len] = '\0';
+        _data = p;
+        return *this;
+    }
+
+    const char* data() const { return _data; }
+
+    size_t size() const { return std::strlen(_data); }
+
+    size_t length() const { return size(); }
+
+    bool empty() const { return _data[0] == '\0'; }
+
+    char operator[](size_t pos) const { return _data[pos]; }
+
+    bool operator==(const CString& rhs) const { return std::strcmp(_data, rhs._data) == 0; }
+    bool operator!=(const CString& rhs) const { return std::strcmp(_data, rhs._data) != 0; }
+    bool operator<(const CString& rhs) const { return std::strcmp(_data, rhs._data) < 0; }
+    bool operator<=(const CString& rhs) const { return std::strcmp(_data, rhs._data) <= 0; }
+    bool operator>(const CString& rhs) const { return std::strcmp(_data, rhs._data) > 0; }
+    bool operator>=(const CString& rhs) const { return std::strcmp(_data, rhs._data) >= 0; }
+
+private:
+    constexpr static char kStaticStorage = 0;
+
+    void _dealloc_if_needed() {
+        if (_data != &kStaticStorage) {
+            delete[] _data;
+            _data = &kStaticStorage;
+        }
+    }
+
+    const char* _data = &kStaticStorage;
+};
+
+inline std::ostream& operator<<(std::ostream& os, const CString& s) {
+    return os << s.data();
+}
+
+} // namespace starrocks

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -208,6 +208,7 @@ set(EXEC_FILES
         ./util/block_compression_test.cpp
         ./util/blocking_queue_test.cpp
         ./util/brpc_stub_cache_test.cpp
+        ./util/c_string_test.cpp
         ./util/cidr_test.cpp
         ./util/coding_test.cpp
         ./util/core_local_test.cpp

--- a/be/test/storage/comparison_predicate_test.cpp
+++ b/be/test/storage/comparison_predicate_test.cpp
@@ -111,8 +111,8 @@ static std::string to_datetime_string(uint64_t& datetime_value) {
             column->set_is_nullable(is_allow_null);                                                               \
             column->set_length(length);                                                                           \
             column->set_aggregation(aggregation);                                                                 \
-            column->set_precision(1000);                                                                          \
-            column->set_frac(1000);                                                                               \
+            column->set_precision(5);                                                                             \
+            column->set_frac(10);                                                                                 \
             column->set_is_bf_column(false);                                                                      \
             tablet_schema->init_from_pb(tablet_schema_pb);                                                        \
         }                                                                                                         \

--- a/be/test/storage/in_list_predicate_test.cpp
+++ b/be/test/storage/in_list_predicate_test.cpp
@@ -112,8 +112,8 @@ public:
         column->set_is_nullable(is_allow_null);
         column->set_length(length);
         column->set_aggregation(aggregation);
-        column->set_precision(1000);
-        column->set_frac(1000);
+        column->set_precision(5);
+        column->set_frac(10);
         column->set_is_bf_column(false);
 
         tablet_schema->init_from_pb(tablet_schema_pb);

--- a/be/test/storage/kv_store_test.cpp
+++ b/be/test/storage/kv_store_test.cpp
@@ -46,7 +46,8 @@ public:
         FileUtils::create_dir(_root_path);
 
         _kv_store = new KVStore(_root_path);
-        ASSERT_TRUE(_kv_store->init().ok());
+        Status st = _kv_store->init();
+        ASSERT_TRUE(st.ok()) << st;
         ASSERT_TRUE(std::filesystem::exists(_root_path + "/meta"));
     }
 

--- a/be/test/storage/null_predicate_test.cpp
+++ b/be/test/storage/null_predicate_test.cpp
@@ -74,7 +74,6 @@ public:
         TabletSchemaPB tablet_schema_pb;
         static int id = 0;
         ColumnPB* column = tablet_schema_pb.add_column();
-        ;
         column->set_unique_id(++id);
         column->set_name(name);
         column->set_type(type);
@@ -82,8 +81,8 @@ public:
         column->set_is_nullable(is_allow_null);
         column->set_length(length);
         column->set_aggregation(aggregation);
-        column->set_precision(1000);
-        column->set_frac(1000);
+        column->set_precision(5);
+        column->set_frac(10);
         column->set_is_bf_column(false);
         tablet_schema->init_from_pb(tablet_schema_pb);
     }

--- a/be/test/storage/rowset/segment_v2/segment_test.cpp
+++ b/be/test/storage/rowset/segment_v2/segment_test.cpp
@@ -103,7 +103,6 @@ protected:
             }
             res._cols.push_back(col);
         }
-        res._num_columns = columns.size();
         res._num_key_columns = num_key_columns;
         res._num_short_key_columns = num_short_key_columns != -1 ? num_short_key_columns : num_key_columns;
         return res;
@@ -611,7 +610,6 @@ TEST_F(SegmentReaderWriterTest, estimate_segment_size) {
     size_t num_rows_per_block = 10;
 
     std::shared_ptr<TabletSchema> tablet_schema(new TabletSchema());
-    tablet_schema->_num_columns = 4;
     tablet_schema->_num_key_columns = 3;
     tablet_schema->_num_short_key_columns = 2;
     tablet_schema->_num_rows_per_row_block = num_rows_per_block;
@@ -780,7 +778,6 @@ TEST_F(SegmentReaderWriterTest, TestStringDict) {
     MemPool pool(&tracker);
 
     std::shared_ptr<TabletSchema> tablet_schema(new TabletSchema());
-    tablet_schema->_num_columns = 4;
     tablet_schema->_num_key_columns = 3;
     tablet_schema->_num_short_key_columns = 2;
     tablet_schema->_num_rows_per_row_block = num_rows_per_block;

--- a/be/test/storage/short_key_index_test.cpp
+++ b/be/test/storage/short_key_index_test.cpp
@@ -103,7 +103,6 @@ TEST_F(ShortKeyIndexTest, enocde) {
     tablet_schema._cols.push_back(create_int_key(1));
     tablet_schema._cols.push_back(create_int_key(2));
     tablet_schema._cols.push_back(create_int_value(3));
-    tablet_schema._num_columns = 4;
     tablet_schema._num_key_columns = 3;
     tablet_schema._num_short_key_columns = 3;
 

--- a/be/test/storage/tablet_meta_test.cpp
+++ b/be/test/storage/tablet_meta_test.cpp
@@ -141,8 +141,7 @@ TEST(TabletMetaTest, test_create) {
     ASSERT_EQ(sizeof(int32_t), c0.length());
     ASSERT_EQ(sizeof(int32_t), c0.index_length());
     ASSERT_EQ(OLAP_FIELD_AGGREGATION_NONE, c0.aggregation());
-    ASSERT_TRUE(c0.visible());
-    ASSERT_EQ(0, c0.get_subtype_count());
+    ASSERT_EQ(0, c0.subcolumn_count());
 
     // check c1.
     ASSERT_EQ(col_ordinal_to_unique_id[1], c1.unique_id());
@@ -156,18 +155,18 @@ TEST(TabletMetaTest, test_create) {
     ASSERT_EQ(24, c1.length());
     ASSERT_EQ(24, c1.index_length());
     ASSERT_EQ(OLAP_FIELD_AGGREGATION_NONE, c1.aggregation());
-    ASSERT_EQ(1, c1.get_subtype_count());
+    ASSERT_EQ(1, c1.subcolumn_count());
 
-    ASSERT_EQ("_c1_1", c1.get_sub_column(0).name());
-    ASSERT_EQ(kInvalidUniqueId, c1.get_sub_column(0).unique_id());
-    ASSERT_EQ(OLAP_FIELD_TYPE_DECIMAL_V2, c1.get_sub_column(0).type());
-    ASSERT_FALSE(c1.get_sub_column(0).is_key());
-    ASSERT_FALSE(c1.get_sub_column(0).is_bf_column());
-    ASSERT_TRUE(c1.get_sub_column(0).is_nullable());
-    ASSERT_FALSE(c1.get_sub_column(0).has_bitmap_index());
-    ASSERT_FALSE(c1.get_sub_column(0).has_default_value());
-    ASSERT_EQ(sizeof(DecimalV2Value), c1.get_sub_column(0).length());
-    ASSERT_EQ(sizeof(DecimalV2Value), c1.get_sub_column(0).index_length());
+    ASSERT_EQ("_c1_1", c1.subcolumn(0).name());
+    ASSERT_EQ(kInvalidUniqueId, c1.subcolumn(0).unique_id());
+    ASSERT_EQ(OLAP_FIELD_TYPE_DECIMAL_V2, c1.subcolumn(0).type());
+    ASSERT_FALSE(c1.subcolumn(0).is_key());
+    ASSERT_FALSE(c1.subcolumn(0).is_bf_column());
+    ASSERT_TRUE(c1.subcolumn(0).is_nullable());
+    ASSERT_FALSE(c1.subcolumn(0).has_bitmap_index());
+    ASSERT_FALSE(c1.subcolumn(0).has_default_value());
+    ASSERT_EQ(sizeof(DecimalV2Value), c1.subcolumn(0).length());
+    ASSERT_EQ(sizeof(DecimalV2Value), c1.subcolumn(0).index_length());
 
     // check c2.
     ASSERT_EQ(col_ordinal_to_unique_id[2], c2.unique_id());
@@ -181,32 +180,32 @@ TEST(TabletMetaTest, test_create) {
     ASSERT_EQ(24, c2.length());
     ASSERT_EQ(24, c2.index_length());
     ASSERT_EQ(OLAP_FIELD_AGGREGATION_NONE, c2.aggregation());
-    ASSERT_EQ(1, c2.get_subtype_count());
+    ASSERT_EQ(1, c2.subcolumn_count());
 
-    ASSERT_EQ("_c2_1", c2.get_sub_column(0).name());
-    ASSERT_EQ(kInvalidUniqueId, c2.get_sub_column(0).unique_id());
-    ASSERT_EQ(OLAP_FIELD_TYPE_ARRAY, c2.get_sub_column(0).type());
-    ASSERT_FALSE(c2.get_sub_column(0).is_key());
-    ASSERT_FALSE(c2.get_sub_column(0).is_bf_column());
-    ASSERT_TRUE(c2.get_sub_column(0).is_nullable());
-    ASSERT_FALSE(c2.get_sub_column(0).has_bitmap_index());
-    ASSERT_FALSE(c2.get_sub_column(0).has_default_value());
-    ASSERT_EQ(24, c2.get_sub_column(0).length());
-    ASSERT_EQ(24, c2.get_sub_column(0).index_length());
-    ASSERT_EQ(1, c2.get_sub_column(0).get_subtype_count());
+    ASSERT_EQ("_c2_1", c2.subcolumn(0).name());
+    ASSERT_EQ(kInvalidUniqueId, c2.subcolumn(0).unique_id());
+    ASSERT_EQ(OLAP_FIELD_TYPE_ARRAY, c2.subcolumn(0).type());
+    ASSERT_FALSE(c2.subcolumn(0).is_key());
+    ASSERT_FALSE(c2.subcolumn(0).is_bf_column());
+    ASSERT_TRUE(c2.subcolumn(0).is_nullable());
+    ASSERT_FALSE(c2.subcolumn(0).has_bitmap_index());
+    ASSERT_FALSE(c2.subcolumn(0).has_default_value());
+    ASSERT_EQ(24, c2.subcolumn(0).length());
+    ASSERT_EQ(24, c2.subcolumn(0).index_length());
+    ASSERT_EQ(1, c2.subcolumn(0).subcolumn_count());
 
-    const TabletColumn& c2_1 = c2.get_sub_column(0);
-    ASSERT_EQ("_c2_2", c2_1.get_sub_column(0).name());
-    ASSERT_EQ(kInvalidUniqueId, c2_1.get_sub_column(0).unique_id());
-    ASSERT_EQ(OLAP_FIELD_TYPE_VARCHAR, c2_1.get_sub_column(0).type());
-    ASSERT_FALSE(c2_1.get_sub_column(0).is_key());
-    ASSERT_FALSE(c2_1.get_sub_column(0).is_bf_column());
-    ASSERT_TRUE(c2_1.get_sub_column(0).is_nullable());
-    ASSERT_FALSE(c2_1.get_sub_column(0).has_bitmap_index());
-    ASSERT_FALSE(c2_1.get_sub_column(0).has_default_value());
-    ASSERT_EQ(10 + sizeof(OLAP_STRING_MAX_LENGTH), c2_1.get_sub_column(0).length());
-    ASSERT_EQ(10, c2_1.get_sub_column(0).index_length());
-    ASSERT_EQ(0, c2_1.get_sub_column(0).get_subtype_count());
+    const TabletColumn& c2_1 = c2.subcolumn(0);
+    ASSERT_EQ("_c2_2", c2_1.subcolumn(0).name());
+    ASSERT_EQ(kInvalidUniqueId, c2_1.subcolumn(0).unique_id());
+    ASSERT_EQ(OLAP_FIELD_TYPE_VARCHAR, c2_1.subcolumn(0).type());
+    ASSERT_FALSE(c2_1.subcolumn(0).is_key());
+    ASSERT_FALSE(c2_1.subcolumn(0).is_bf_column());
+    ASSERT_TRUE(c2_1.subcolumn(0).is_nullable());
+    ASSERT_FALSE(c2_1.subcolumn(0).has_bitmap_index());
+    ASSERT_FALSE(c2_1.subcolumn(0).has_default_value());
+    ASSERT_EQ(10 + sizeof(OLAP_STRING_MAX_LENGTH), c2_1.subcolumn(0).length());
+    ASSERT_EQ(10, c2_1.subcolumn(0).index_length());
+    ASSERT_EQ(0, c2_1.subcolumn(0).subcolumn_count());
 }
 
 } // namespace starrocks

--- a/be/test/storage/tablet_schema_helper.h
+++ b/be/test/storage/tablet_schema_helper.h
@@ -31,15 +31,15 @@ namespace starrocks {
 inline TabletColumn create_int_key(int32_t id, bool is_nullable = true, bool is_bf_column = false,
                                    bool has_bitmap_index = false) {
     TabletColumn column;
-    column._unique_id = id;
-    column._col_name = std::to_string(id);
-    column._type = OLAP_FIELD_TYPE_INT;
-    column._is_key = true;
-    column._is_nullable = is_nullable;
-    column._length = 4;
-    column._index_length = 4;
-    column._is_bf_column = is_bf_column;
-    column._has_bitmap_index = has_bitmap_index;
+    column.set_unique_id(id);
+    column.set_name(std::to_string(id));
+    column.set_type(OLAP_FIELD_TYPE_INT);
+    column.set_is_key(true);
+    column.set_is_nullable(is_nullable);
+    column.set_length(4);
+    column.set_index_length(4);
+    column.set_is_bf_column(is_bf_column);
+    column.set_has_bitmap_index(has_bitmap_index);
     return column;
 }
 
@@ -47,68 +47,66 @@ inline TabletColumn create_int_value(int32_t id, FieldAggregationMethod agg_meth
                                      bool is_nullable = true, const std::string default_value = "",
                                      bool is_bf_column = false, bool has_bitmap_index = false) {
     TabletColumn column;
-    column._unique_id = id;
-    column._col_name = std::to_string(id);
-    column._type = OLAP_FIELD_TYPE_INT;
-    column._is_key = false;
-    column._aggregation = agg_method;
-    column._is_nullable = is_nullable;
-    column._length = 4;
-    column._index_length = 4;
+    column.set_unique_id(id);
+    column.set_name(std::to_string(id));
+    column.set_type(OLAP_FIELD_TYPE_INT);
+    column.set_is_key(false);
+    column.set_aggregation(agg_method);
+    column.set_is_nullable(is_nullable);
+    column.set_length(4);
+    column.set_index_length(4);
     if (default_value != "") {
-        column._has_default_value = true;
-        column._default_value = default_value;
+        column.set_default_value(default_value);
     }
-    column._is_bf_column = is_bf_column;
-    column._has_bitmap_index = has_bitmap_index;
+    column.set_is_bf_column(is_bf_column);
+    column.set_has_bitmap_index(has_bitmap_index);
     return column;
 }
 
 inline TabletColumn create_char_key(int32_t id, bool is_nullable = true, int length = 8) {
     TabletColumn column;
-    column._unique_id = id;
-    column._col_name = std::to_string(id);
-    column._type = OLAP_FIELD_TYPE_CHAR;
-    column._is_key = true;
-    column._is_nullable = is_nullable;
-    column._length = length;
-    column._index_length = 1;
+    column.set_unique_id(id);
+    column.set_name(std::to_string(id));
+    column.set_type(OLAP_FIELD_TYPE_CHAR);
+    column.set_is_key(true);
+    column.set_is_nullable(is_nullable);
+    column.set_length(length);
+    column.set_index_length(1);
     return column;
 }
 
 inline TabletColumn create_varchar_key(int32_t id, bool is_nullable = true, int length = 8) {
     TabletColumn column;
-    column._unique_id = id;
-    column._col_name = std::to_string(id);
-    column._type = OLAP_FIELD_TYPE_VARCHAR;
-    column._is_key = true;
-    column._is_nullable = is_nullable;
-    column._length = length;
-    column._index_length = 4;
+    column.set_unique_id(id);
+    column.set_name(std::to_string(id));
+    column.set_type(OLAP_FIELD_TYPE_VARCHAR);
+    column.set_is_key(true);
+    column.set_is_nullable(is_nullable);
+    column.set_length(length);
+    column.set_index_length(4);
     return column;
 }
 
 inline TabletColumn create_array(int32_t id, bool is_nullable = true, int length = 24) {
     TabletColumn column;
-    column._unique_id = id;
-    column._col_name = std::to_string(id);
-    column._type = OLAP_FIELD_TYPE_ARRAY;
-    column._is_key = true;
-    column._is_nullable = is_nullable;
-    column._length = length;
-    column._index_length = length;
+    column.set_unique_id(id);
+    column.set_name(std::to_string(id));
+    column.set_type(OLAP_FIELD_TYPE_ARRAY);
+    column.set_is_key(true);
+    column.set_is_nullable(is_nullable);
+    column.set_length(length);
+    column.set_index_length(length);
     return column;
 }
 
 template <FieldType type>
 inline TabletColumn create_with_default_value(std::string default_value) {
     TabletColumn column;
-    column._type = type;
-    column._is_nullable = true;
-    column._aggregation = OLAP_FIELD_AGGREGATION_NONE;
-    column._has_default_value = true;
-    column._default_value = default_value;
-    column._length = 4;
+    column.set_type(type);
+    column.set_is_nullable(true);
+    column.set_aggregation(OLAP_FIELD_AGGREGATION_NONE);
+    column.set_default_value(default_value);
+    column.set_length(4);
     return column;
 }
 

--- a/be/test/util/c_string_test.cpp
+++ b/be/test/util/c_string_test.cpp
@@ -1,0 +1,71 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#include "util/c_string.h"
+
+#include <gtest/gtest.h>
+
+namespace starrocks {
+
+TEST(CStringTest, test_all) {
+    CString s1;
+    CString s2;
+    EXPECT_TRUE(s1.empty());
+    EXPECT_EQ(0, s1.size());
+    EXPECT_TRUE(s1.data() != nullptr);
+    EXPECT_EQ(s1, s2);
+    EXPECT_LE(s1, s2);
+    EXPECT_GE(s1, s2);
+    EXPECT_FALSE(s1 != s2);
+    EXPECT_FALSE(s1 > s2);
+    EXPECT_FALSE(s1 < s2);
+
+    s2.assign("", 0);
+    EXPECT_EQ(s1, s2);
+    EXPECT_EQ(0, s2.size());
+    EXPECT_TRUE(s2.empty());
+    EXPECT_EQ(s1, s2);
+    EXPECT_LE(s1, s2);
+    EXPECT_GE(s1, s2);
+    EXPECT_FALSE(s1 != s2);
+    EXPECT_FALSE(s1 > s2);
+    EXPECT_FALSE(s1 < s2);
+
+    s2.assign("string 1", 8);
+    EXPECT_FALSE(s2.empty());
+    EXPECT_EQ("string 1", std::string_view(s2.data(), s2.size()));
+    EXPECT_FALSE(s1 == s2);
+    EXPECT_TRUE(s1 != s2);
+    EXPECT_TRUE(s1 < s2);
+    EXPECT_TRUE(s1 <= s2);
+    EXPECT_FALSE(s1 > s2);
+    EXPECT_FALSE(s1 >= s2);
+
+    // copy ctor/copy assign
+    CString s3(s2);
+    EXPECT_NE(s2.data(), s3.data());
+    EXPECT_EQ("string 1", std::string_view(s3.data(), s3.size()));
+    EXPECT_EQ(s2, s3);
+
+    CString s4;
+    s4 = s2;
+    EXPECT_NE(s2.data(), s4.data());
+    EXPECT_EQ("string 1", std::string_view(s4.data(), s4.size()));
+    EXPECT_EQ(s2, s4);
+    EXPECT_EQ(s3, s4);
+
+    // move ctor/move assign
+    CString s5(std::move(s3));
+    EXPECT_EQ(0, s3.size());
+    EXPECT_TRUE(s3.empty());
+    EXPECT_TRUE(s3.data() != nullptr);
+    EXPECT_EQ("string 1", std::string_view(s5.data(), s5.size()));
+
+    CString s6;
+    s6 = std::move(s5);
+    EXPECT_EQ(0, s5.size());
+    EXPECT_TRUE(s5.empty());
+    EXPECT_TRUE(s5.data() != nullptr);
+    EXPECT_EQ("string 1", std::string_view(s6.data(), s6.size()));
+}
+
+} // namespace starrocks


### PR DESCRIPTION
Close issue #607

With this optimization, the memory usage of 73000 tablets, each of which contains 1500 columns
of type VARCHAR, dropped from 23.5GB to 7.6GB.