### PR TITLE
opt: use memcpy and update sizes after memcpy in serialize_batch

### DIFF
--- a/be/src/column/fixed_length_column_base.cpp
+++ b/be/src/column/fixed_length_column_base.cpp
@@ -80,22 +80,29 @@ int FixedLengthColumnBase<T>::compare_at(size_t left, size_t right, const Column
 
 template <typename T>
 uint32_t FixedLengthColumnBase<T>::serialize(size_t idx, uint8_t* pos) {
-    strings::memcpy_inlined(pos, &_data[idx], sizeof(T));
+    memcpy(pos, &_data[idx], sizeof(T));
     return sizeof(T);
 }
 
 template <typename T>
 uint32_t FixedLengthColumnBase<T>::serialize_default(uint8_t* pos) {
     ValueType value{};
-    strings::memcpy_inlined(pos, &value, sizeof(T));
+    memcpy(pos, &value, sizeof(T));
     return sizeof(T);
 }
 
 template <typename T>
-void FixedLengthColumnBase<T>::serialize_batch(uint8_t* dst, Buffer<uint32_t>& slice_sizes, size_t chunk_size,
-                                               uint32_t max_one_row_size) {
+void FixedLengthColumnBase<T>::serialize_batch(uint8_t* __restrict__ dst, Buffer<uint32_t>& slice_sizes,
+                                               size_t chunk_size, uint32_t max_one_row_size) {
+    uint32_t* sizes = slice_sizes.data();
+    T* __restrict__ src = _data.data();
+
     for (size_t i = 0; i < chunk_size; ++i) {
-        slice_sizes[i] += serialize(i, dst + i * max_one_row_size + slice_sizes[i]);
+        memcpy(dst + i * max_one_row_size + sizes[i], src + i, sizeof(T));
+    }
+
+    for (size_t i = 0; i < chunk_size; i++) {
+        sizes[i] += sizeof(T);
     }
 }
 
@@ -115,7 +122,7 @@ size_t FixedLengthColumnBase<T>::serialize_batch_at_interval(uint8_t* dst, size_
 template <typename T>
 const uint8_t* FixedLengthColumnBase<T>::deserialize_and_append(const uint8_t* pos) {
     T value{};
-    strings::memcpy_inlined(&value, pos, sizeof(T));
+    memcpy(&value, pos, sizeof(T));
     _data.emplace_back(value);
     return pos + sizeof(T);
 }
@@ -124,7 +131,7 @@ template <typename T>
 void FixedLengthColumnBase<T>::deserialize_and_append_batch(std::vector<Slice>& srcs, size_t batch_size) {
     raw::make_room(&_data, batch_size);
     for (size_t i = 0; i < batch_size; ++i) {
-        strings::memcpy_inlined(&_data[i], srcs[i].data, sizeof(T));
+        memcpy(&_data[i], srcs[i].data, sizeof(T));
         srcs[i].data = srcs[i].data + sizeof(T);
     }
 }


### PR DESCRIPTION
optimize `FixedLengthColumnBase<T>::serialize_batch`
- use `memcpy` to replace `strings::memcpy_inlined` when the copied size is `sizeof(T)`.
- update `sizes` after `memcpy`.

----
The information of benchmark test is as follows:
- Dataset: [New York Taxi Data](https://clickhouse.com/docs/en/getting-started/example-datasets/nyc-taxi/).
- The number of rows: 12_9897_9494.
- Query SQL:
``` SQL
-- Q3
SELECT passenger_count, year(pickup_date) AS year_, count(*) 
FROM trips_mergetree 
GROUP BY passenger_count, year_;

-- Q4
SELECT passenger_count, year(pickup_date) AS year_, round(trip_distance) AS distance, count(*) 
FROM trips_mergetree 
GROUP BY passenger_count, year_, distance 
ORDER BY year_, count(*) DESC;
```

`passenger_count` is `int8`, `trip_distance` is `float64`, and the  return type of `year()` is nullable `int32`.



The followings are the cost time before and after the optimization:

Q3:
| Parallel | Before (ms) | After (ms) |
| -------- | ----------- | ---------- |
| 1        | 7323        | 6958       |
| 2        | 3757        | 3558       |
| 4        | 2005        | 1913       |
| 8        | 1463        | 1321       |
| 16       | 1131        | 1037        |

Q4:
| Parallel | Before (ms) | After (ms) |
| -------- | ----------- | ---------- |
| 1        | 9751        | 9489       |
| 2        | 4976        | 4870       |
| 4        | 2679        | 2700       |
| 8        | 2048        | 1899       |
| 16       | 1650        | 1578       |

And the cost time rate of `FixedLengthColumnBase<T>::serialize_batch` before and after the optimization are 18.75% and 10.55%, respectively.


</byte-sheet-html-origin>
