### PR TITLE
Support reading orc/parquet file from path for spark load

### DIFF
--- a/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/dpp/SparkDpp.java
+++ b/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/dpp/SparkDpp.java
@@ -656,8 +656,8 @@ public final class SparkDpp implements java.io.Serializable {
         HashSet<String> schemaSet = new HashSet<>(Arrays.asList(sourceData.schema().fieldNames()));
         schemaSet.addAll(Arrays.asList(srcSchema.fieldNames()));
         if (sourceData.schema().size() != schemaSet.size()) {
-            throw new SparkDppException("The schema of file and load statement must be equal. " +
-                    "file schema: " + srcSchema.treeString() + ", table schema: " + sourceData.schema().treeString());
+            throw new SparkDppException("The schema of file and table must be equal. " +
+                    "file schema: " + sourceData.schema().treeString() + ", table schema: " + srcSchema.treeString());
         }
         scannedRowsAcc.add(sourceData.count());
         // TODO: data quality check for orc/parquet load

--- a/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/dpp/SparkDpp.java
+++ b/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/dpp/SparkDpp.java
@@ -688,7 +688,7 @@ public final class SparkDpp implements java.io.Serializable {
         }
         StructType srcSchema = constructSrcSchema(fileGroup, baseIndex);
         JavaRDD<String> sourceDataRdd = spark.read().textFile(fileUrl).toJavaRDD();
-        int columnSize = fileGroup.fileFieldNames.size();
+        int columnSize = srcSchema.size() - columnValueFromPath.size();
         List<ColumnParser> parsers = new ArrayList<>();
         for (EtlJobConfig.EtlColumn column : baseIndex.columns) {
             parsers.add(ColumnParser.create(column));

--- a/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/dpp/SparkDpp.java
+++ b/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/dpp/SparkDpp.java
@@ -625,7 +625,7 @@ public final class SparkDpp implements java.io.Serializable {
         if (fileGroup.columnsFromPath != null) {
             srcColumnsWithColumnsFromPath.addAll(fileGroup.columnsFromPath);
         }
-        return createScrSchema(srcColumnsWithColumnsFromPath);
+        return createSrcSchema(srcColumnsWithColumnsFromPath);
     }
 
     /**
@@ -770,7 +770,7 @@ public final class SparkDpp implements java.io.Serializable {
         return dataframe;
     }
 
-    private StructType createScrSchema(List<String> srcColumns) {
+    private StructType createSrcSchema(List<String> srcColumns) {
         List<StructField> fields = new ArrayList<>();
         for (String srcColumn : srcColumns) {
             // user StringType to load source data


### PR DESCRIPTION
Add a support to read orc/parquet file from path for spark load.
File format defaults to CSV when `FORMAT AS` is not specified.