### PR TITLE
Support recover primary key tablet from trash directory

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -1372,7 +1372,6 @@ void* TaskWorkerPool::_make_snapshot_thread_callback(void* arg_this) {
         std::vector<std::string> snapshot_files;
         Status st = SnapshotManager::instance()->make_snapshot(snapshot_request, &snapshot_path);
         if (!st.ok()) {
-            status_code = st.code();
             LOG(WARNING) << "Fail to make_snapshot, tablet_id=" << snapshot_request.tablet_id
                          << " schema_hash=" << snapshot_request.schema_hash << " version=" << snapshot_request.version
                          << " version_hash=" << snapshot_request.version_hash << " status=" << st.to_string();

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -1372,6 +1372,7 @@ void* TaskWorkerPool::_make_snapshot_thread_callback(void* arg_this) {
         std::vector<std::string> snapshot_files;
         Status st = SnapshotManager::instance()->make_snapshot(snapshot_request, &snapshot_path);
         if (!st.ok()) {
+            status_code = st.code();
             LOG(WARNING) << "Fail to make_snapshot, tablet_id=" << snapshot_request.tablet_id
                          << " schema_hash=" << snapshot_request.schema_hash << " version=" << snapshot_request.version
                          << " version_hash=" << snapshot_request.version_hash << " status=" << st.to_string();

--- a/be/src/http/action/restore_tablet_action.cpp
+++ b/be/src/http/action/restore_tablet_action.cpp
@@ -38,6 +38,7 @@
 #include "runtime/exec_env.h"
 #include "storage/data_dir.h"
 #include "storage/olap_define.h"
+#include "storage/snapshot_manager.h"
 #include "storage/storage_engine.h"
 #include "storage/tablet_meta.h"
 #include "storage/utils.h"
@@ -113,15 +114,14 @@ Status RestoreTabletAction::_reload_tablet(const std::string& key, const std::st
     clone_req.__set_tablet_id(tablet_id);
     clone_req.__set_schema_hash(schema_hash);
     OLAPStatus res = OLAPStatus::OLAP_SUCCESS;
-    res = _exec_env->storage_engine()->load_header(shard_path, clone_req, /*restore=*/true);
+    res = _exec_env->storage_engine()->load_header(shard_path, clone_req, /*restore=*/true, _is_primary_key);
     if (res != OLAPStatus::OLAP_SUCCESS) {
         LOG(WARNING) << "load header failed. status: " << res << ", signature: " << tablet_id;
         // remove tablet data path in data path
-        // path: /roo_path/data/shard/tablet_id
+        // path: /root_path/data/shard/tablet_id
         std::string tablet_path = strings::Substitute("$0/$1/$2", shard_path, tablet_id, schema_hash);
         LOG(INFO) << "remove tablet_path:" << tablet_path;
-        Status s = FileUtils::remove_all(tablet_path);
-        if (!s.ok()) {
+        if (!FileUtils::remove_all(tablet_path).ok()) {
             LOG(WARNING) << "remove invalid tablet schema hash path:" << tablet_path << " failed";
         }
         return Status::InternalError("command executor load header failed");
@@ -132,28 +132,38 @@ Status RestoreTabletAction::_reload_tablet(const std::string& key, const std::st
             std::lock_guard<std::mutex> l(_tablet_restore_lock);
             trash_tablet_schema_hash_dir = _tablet_path_map[key];
         }
-        LOG(INFO) << "load header success. status: " << res << ", signature: " << tablet_id
+        LOG(INFO) << "load header success, signature: " << tablet_id
                   << ", from trash path:" << trash_tablet_schema_hash_dir << " to shard path:" << shard_path;
-
         return Status::OK();
     }
 }
 
 Status RestoreTabletAction::_restore(const std::string& key, int64_t tablet_id, int32_t schema_hash) {
-    // get latest tablet path in trash
     std::string latest_tablet_path;
-    bool ret = _get_latest_tablet_path_from_trash(tablet_id, schema_hash, &latest_tablet_path);
-    if (!ret) {
+    if (!_get_latest_tablet_path_from_trash(tablet_id, schema_hash, &latest_tablet_path)) {
         LOG(WARNING) << "can not find tablet:" << tablet_id << ", schema hash:" << schema_hash;
-        return Status::InternalError("can find tablet path in trash");
+        return Status::InternalError("can not find tablet path in trash");
     }
     LOG(INFO) << "tablet path in trash:" << latest_tablet_path;
     std::string original_header_path = latest_tablet_path + "/" + std::to_string(tablet_id) + ".hdr";
+    std::string original_meta_path = latest_tablet_path + "/meta.primary";
     auto mem_tracker = std::make_unique<MemTracker>();
     TabletMeta tablet_meta(mem_tracker.get());
-    if (Status load_status = tablet_meta.create_from_file(original_header_path); !load_status.ok()) {
-        LOG(WARNING) << "header load and init error, header path:" << original_header_path;
-        return Status::InternalError(load_status.to_string());
+    if (FileUtils::check_exist(original_header_path)) {
+        DCHECK(!FileUtils::check_exist(original_meta_path));
+        if (Status load_status = tablet_meta.create_from_file(original_header_path); !load_status.ok()) {
+            LOG(WARNING) << "header load and init error, header path:" << original_header_path;
+            return Status::InternalError(load_status.to_string());
+        }
+    } else if (FileUtils::check_exist(original_meta_path)) {
+        DCHECK(!FileUtils::check_exist(original_header_path));
+        _is_primary_key = true;
+        auto snapshot_meta = SnapshotManager::instance()->parse_snapshot_meta(original_meta_path);
+        if (!snapshot_meta.ok()) {
+            LOG(WARNING) << "Fail to parse " << original_meta_path << ": " << snapshot_meta.status();
+            return snapshot_meta.status();
+        }
+        tablet_meta.init_from_pb(&snapshot_meta->tablet_meta());
     }
     // latest_tablet_path: /root_path/trash/time_label/tablet_id/schema_hash
     {
@@ -161,9 +171,8 @@ Status RestoreTabletAction::_restore(const std::string& key, int64_t tablet_id, 
         std::lock_guard<std::mutex> l(_tablet_restore_lock);
         _tablet_path_map[key] = latest_tablet_path;
     }
-
-    std::string root_path = DataDir::get_root_path_from_schema_hash_path_in_trash(latest_tablet_path);
-    DataDir* store = StorageEngine::instance()->get_store(root_path);
+    DataDir* store = StorageEngine::instance()->get_store(
+            DataDir::get_root_path_from_schema_hash_path_in_trash(latest_tablet_path));
     std::string restore_schema_hash_path =
             store->get_absolute_tablet_path(tablet_meta.shard_id(), tablet_meta.tablet_id(), tablet_meta.schema_hash());
     Status s = FileUtils::create_dir(restore_schema_hash_path);
@@ -178,8 +187,7 @@ Status RestoreTabletAction::_restore(const std::string& key, int64_t tablet_id, 
         return s;
     }
     std::string restore_shard_path = store->get_absolute_shard_path(tablet_meta.shard_id());
-    Status status = _reload_tablet(key, restore_shard_path, tablet_id, schema_hash);
-    return status;
+    return _reload_tablet(key, restore_shard_path, tablet_id, schema_hash);
 }
 
 Status RestoreTabletAction::_create_hard_link_recursive(const std::string& src, const std::string& dst) {
@@ -205,8 +213,7 @@ Status RestoreTabletAction::_create_hard_link_recursive(const std::string& src, 
 bool RestoreTabletAction::_get_latest_tablet_path_from_trash(int64_t tablet_id, int32_t schema_hash,
                                                              std::string* path) {
     std::vector<std::string> tablet_paths;
-    std::vector<DataDir*> stores = StorageEngine::instance()->get_stores();
-    for (auto& store : stores) {
+    for (auto& store : StorageEngine::instance()->get_stores()) {
         store->find_tablet_in_trash(tablet_id, &tablet_paths);
     }
     if (tablet_paths.empty()) {
@@ -216,8 +223,7 @@ bool RestoreTabletAction::_get_latest_tablet_path_from_trash(int64_t tablet_id, 
     std::vector<std::string> schema_hash_paths;
     for (auto& tablet_path : tablet_paths) {
         std::string schema_hash_path = tablet_path + "/" + std::to_string(schema_hash);
-        bool exist = FileUtils::check_exist(schema_hash_path);
-        if (exist) {
+        if (FileUtils::check_exist(schema_hash_path)) {
             schema_hash_paths.emplace_back(std::move(schema_hash_path));
         }
     }

--- a/be/src/http/action/restore_tablet_action.cpp
+++ b/be/src/http/action/restore_tablet_action.cpp
@@ -146,7 +146,7 @@ Status RestoreTabletAction::_restore(const std::string& key, int64_t tablet_id, 
     }
     LOG(INFO) << "tablet path in trash:" << latest_tablet_path;
     std::string original_header_path = latest_tablet_path + "/" + std::to_string(tablet_id) + ".hdr";
-    std::string original_meta_path = latest_tablet_path + "/meta.primary";
+    std::string original_meta_path = latest_tablet_path + "/meta";
     auto mem_tracker = std::make_unique<MemTracker>();
     TabletMeta tablet_meta(mem_tracker.get());
     if (FileUtils::check_exist(original_header_path)) {

--- a/be/src/http/action/restore_tablet_action.h
+++ b/be/src/http/action/restore_tablet_action.h
@@ -64,7 +64,8 @@ private:
     // key: tablet_id + schema_hash
     // value: "" or tablet path in trash
     std::map<std::string, std::string> _tablet_path_map;
-}; // end class RestoreTabletAction
+    bool _is_primary_key = false;
+};
 
 } // end namespace starrocks
 #endif // STARROCKS_BE_SRC_HTTP_RESTORE_TABLET_ACTION_H

--- a/be/src/http/download_action.cpp
+++ b/be/src/http/download_action.cpp
@@ -123,7 +123,7 @@ void DownloadAction::handle(HttpRequest* req) {
         handle_normal(req, file_path);
     }
 
-    LOG(INFO) << "deal with download requesst finished! ";
+    LOG(INFO) << "deal with download request finished! ";
 }
 
 Status DownloadAction::check_token(HttpRequest* req) {

--- a/be/src/http/download_action.cpp
+++ b/be/src/http/download_action.cpp
@@ -123,7 +123,7 @@ void DownloadAction::handle(HttpRequest* req) {
         handle_normal(req, file_path);
     }
 
-    LOG(INFO) << "deal with download request finished! ";
+    LOG(INFO) << "deal with download request finished!";
 }
 
 Status DownloadAction::check_token(HttpRequest* req) {

--- a/be/src/storage/data_dir.cpp
+++ b/be/src/storage/data_dir.cpp
@@ -401,16 +401,19 @@ void DataDir::find_tablet_in_trash(int64_t tablet_id, std::vector<std::string>* 
             continue;
         }
         std::string tablet_path = sub_path + "/" + std::to_string(tablet_id);
-        bool exist = FileUtils::check_exist(tablet_path);
-        if (exist) {
+        if (FileUtils::check_exist(tablet_path)) {
             paths->emplace_back(std::move(tablet_path));
         }
     }
 }
 
 std::string DataDir::get_root_path_from_schema_hash_path_in_trash(const std::string& schema_hash_dir_in_trash) {
-    std::filesystem::path schema_hash_path_in_trash(schema_hash_dir_in_trash);
-    return schema_hash_path_in_trash.parent_path().parent_path().parent_path().parent_path().string();
+    return std::filesystem::path(schema_hash_dir_in_trash)
+            .parent_path()
+            .parent_path()
+            .parent_path()
+            .parent_path()
+            .string();
 }
 
 // TODO(ygl): deal with rowsets and tablets when load failed

--- a/be/src/storage/snapshot_manager.cpp
+++ b/be/src/storage/snapshot_manager.cpp
@@ -325,7 +325,7 @@ StatusOr<std::string> SnapshotManager::snapshot_incremental(const TabletSharedPt
         return Status::RuntimeError("empty snapshot_id_path");
     }
     std::string snapshot_dir = get_schema_hash_full_path(tablet, snapshot_id_path);
-    (void)FileUtils::remove_all(snapshot_dir);
+    FileUtils::remove_all(snapshot_dir);
     RETURN_IF_ERROR(FileUtils::create_dir(snapshot_dir));
 
     // 3. Link files to snapshot directory.
@@ -334,7 +334,7 @@ StatusOr<std::string> SnapshotManager::snapshot_incremental(const TabletSharedPt
         auto st = rowset->link_files_to(snapshot_dir, rowset->rowset_id());
         if (!st.ok()) {
             LOG(WARNING) << "Fail to link rowset file:" << st;
-            (void)FileUtils::remove_all(snapshot_id_path);
+            FileUtils::remove_all(snapshot_id_path);
             return st;
         }
         snapshot_rowset_metas.emplace_back(rowset->rowset_meta());
@@ -347,7 +347,7 @@ StatusOr<std::string> SnapshotManager::snapshot_incremental(const TabletSharedPt
         std::string header_path = _get_header_full_path(tablet, snapshot_dir);
         if (Status st = snapshot_tablet_meta->save(header_path); !st.ok()) {
             LOG(WARNING) << "Fail to save tablet meta to " << header_path;
-            (void)FileUtils::remove_all(snapshot_id_path);
+            FileUtils::remove_all(snapshot_id_path);
             return Status::RuntimeError("Fail to save tablet meta to header file");
         }
         return snapshot_id_path;
@@ -355,7 +355,7 @@ StatusOr<std::string> SnapshotManager::snapshot_incremental(const TabletSharedPt
         auto st = build_snapshot_meta(SNAPSHOT_TYPE_INCREMENTAL, snapshot_dir, tablet, snapshot_rowset_metas,
                                       0 /*snapshot_version, unused*/, g_Types_constants.TSNAPSHOT_REQ_VERSION2);
         if (!st.ok()) {
-            (void)FileUtils::remove_all(snapshot_id_path);
+            FileUtils::remove_all(snapshot_id_path);
             return st;
         }
         return snapshot_id_path;
@@ -385,7 +385,7 @@ StatusOr<std::string> SnapshotManager::snapshot_full(const TabletSharedPtr& tabl
         return Status::RuntimeError("empty snapshot_id_path");
     }
     std::string snapshot_dir = get_schema_hash_full_path(tablet, snapshot_id_path);
-    (void)FileUtils::remove_all(snapshot_dir);
+    FileUtils::remove_all(snapshot_dir);
     RETURN_IF_ERROR(FileUtils::create_dir(snapshot_dir));
 
     // 3. Link files to snapshot directory.
@@ -394,7 +394,7 @@ StatusOr<std::string> SnapshotManager::snapshot_full(const TabletSharedPtr& tabl
         auto st = snapshot_rowset->link_files_to(snapshot_dir, snapshot_rowset->rowset_id());
         if (!st.ok()) {
             LOG(WARNING) << "Fail to link rowset file:" << st;
-            (void)FileUtils::remove_all(snapshot_id_path);
+            FileUtils::remove_all(snapshot_id_path);
             return st;
         }
         snapshot_rowset_metas.emplace_back(snapshot_rowset->rowset_meta());
@@ -407,7 +407,7 @@ StatusOr<std::string> SnapshotManager::snapshot_full(const TabletSharedPtr& tabl
         std::string header_path = _get_header_full_path(tablet, snapshot_dir);
         if (Status st = snapshot_tablet_meta->save(header_path); !st.ok()) {
             LOG(WARNING) << "Fail to save tablet meta to " << header_path;
-            (void)FileUtils::remove_all(snapshot_id_path);
+            FileUtils::remove_all(snapshot_id_path);
             return Status::RuntimeError("Fail to save tablet meta to header file");
         }
         return snapshot_id_path;
@@ -415,7 +415,7 @@ StatusOr<std::string> SnapshotManager::snapshot_full(const TabletSharedPtr& tabl
         auto st = build_snapshot_meta(SNAPSHOT_TYPE_FULL, snapshot_dir, tablet, snapshot_rowset_metas, snapshot_version,
                                       g_Types_constants.TSNAPSHOT_REQ_VERSION2);
         if (!st.ok()) {
-            (void)FileUtils::remove_all(snapshot_id_path);
+            FileUtils::remove_all(snapshot_id_path);
             return st;
         }
         return snapshot_id_path;
@@ -437,7 +437,7 @@ Status SnapshotManager::write_meta_snapshot(const TabletSharedPtr& tablet) {
     auto st = build_snapshot_meta(SNAPSHOT_TYPE_FULL, meta_path, tablet, snapshot_rowset_metas, snapshot_version,
                                   g_Types_constants.TSNAPSHOT_REQ_VERSION2);
     if (!st.ok()) {
-        (void)FileUtils::remove(meta_path);
+        FileUtils::remove(meta_path);
         return st;
     }
     return Status::OK();

--- a/be/src/storage/snapshot_manager.cpp
+++ b/be/src/storage/snapshot_manager.cpp
@@ -276,7 +276,7 @@ std::string SnapshotManager::_calc_snapshot_id_path(const TabletSharedPtr& table
     }
 
     std::stringstream snapshot_id_path_stream;
-    std::lock_guard auto_lock(_snapshot_mutex);
+    std::lock_guard l(_snapshot_mutex);
     snapshot_id_path_stream << tablet->data_dir()->path() << SNAPSHOT_PREFIX << "/" << time_str << "."
                             << _snapshot_base_id++ << "." << timeout_s;
     return snapshot_id_path_stream.str();
@@ -286,9 +286,7 @@ std::string SnapshotManager::get_schema_hash_full_path(const TabletSharedPtr& ta
                                                        const std::string& location) const {
     std::stringstream schema_full_path_stream;
     schema_full_path_stream << location << "/" << tablet->tablet_id() << "/" << tablet->schema_hash();
-    string schema_full_path = schema_full_path_stream.str();
-
-    return schema_full_path;
+    return schema_full_path_stream.str();
 }
 
 std::string SnapshotManager::_get_header_full_path(const TabletSharedPtr& tablet,
@@ -392,14 +390,14 @@ StatusOr<std::string> SnapshotManager::snapshot_full(const TabletSharedPtr& tabl
 
     // 3. Link files to snapshot directory.
     snapshot_rowset_metas.reserve(snapshot_rowsets.size());
-    for (const auto& rowset : snapshot_rowsets) {
-        auto st = rowset->link_files_to(snapshot_dir, rowset->rowset_id());
+    for (const auto& snapshot_rowset : snapshot_rowsets) {
+        auto st = snapshot_rowset->link_files_to(snapshot_dir, snapshot_rowset->rowset_id());
         if (!st.ok()) {
             LOG(WARNING) << "Fail to link rowset file:" << st;
             (void)FileUtils::remove_all(snapshot_id_path);
             return st;
         }
-        snapshot_rowset_metas.emplace_back(rowset->rowset_meta());
+        snapshot_rowset_metas.emplace_back(snapshot_rowset->rowset_meta());
     }
 
     // 4. Build snapshot header/meta file.
@@ -424,6 +422,43 @@ StatusOr<std::string> SnapshotManager::snapshot_full(const TabletSharedPtr& tabl
     }
 }
 
+StatusOr<std::string> SnapshotManager::snapshot_trash(const TabletSharedPtr& tablet, int64_t snapshot_version,
+                                                      int64_t timeout_s) {
+    std::vector<RowsetSharedPtr> snapshot_rowsets;
+    // 1. Check whether the snapshot version exist.
+    std::shared_lock rdlock(tablet->get_header_lock());
+    if (snapshot_version == 0) {
+        snapshot_version = tablet->max_version().second;
+    }
+    RETURN_IF_ERROR(tablet->capture_consistent_rowsets(Version(0, snapshot_version), &snapshot_rowsets));
+    rdlock.unlock();
+
+    // 2. Create snapshot directory.
+    std::string snapshot_id_path = _calc_snapshot_id_path(tablet, timeout_s);
+    if (UNLIKELY(snapshot_id_path.empty())) {
+        return Status::RuntimeError("empty snapshot_id_path");
+    }
+    std::string snapshot_dir = tablet->tablet_path() + "/" + SNAPSHOT_PREFIX + "/" +
+                               std::filesystem::path(snapshot_id_path).filename().string();
+    (void)FileUtils::remove_all(snapshot_dir);
+    RETURN_IF_ERROR(FileUtils::create_dir(snapshot_dir));
+
+    std::vector<RowsetMetaSharedPtr> snapshot_rowset_metas;
+    snapshot_rowset_metas.reserve(snapshot_rowsets.size());
+    for (const auto& snapshot_rowset : snapshot_rowsets) {
+        snapshot_rowset_metas.emplace_back(snapshot_rowset->rowset_meta());
+    }
+
+    // 3. Build snapshot meta file.
+    auto st = build_snapshot_meta(SNAPSHOT_TYPE_FULL, snapshot_dir, tablet, snapshot_rowset_metas, snapshot_version,
+                                  g_Types_constants.TSNAPSHOT_REQ_VERSION2);
+    if (!st.ok()) {
+        (void)FileUtils::remove_all(snapshot_id_path);
+        return st;
+    }
+    return snapshot_id_path;
+}
+
 Status SnapshotManager::build_snapshot_meta(SnapshotTypePB snapshot_type, const std::string& snapshot_dir,
                                             const TabletSharedPtr& tablet,
                                             const std::vector<RowsetMetaSharedPtr>& rowset_metas,
@@ -434,33 +469,32 @@ Status SnapshotManager::build_snapshot_meta(SnapshotTypePB snapshot_type, const 
     if (tablet->updates() == nullptr) {
         return Status::InternalError("build_snapshot_meta only support updatable tablet");
     }
-    const TTabletId tablet_id = tablet->tablet_id();
 
     SnapshotMeta snapshot_meta;
     snapshot_meta.set_snapshot_format(snapshot_format);
     snapshot_meta.set_snapshot_type(snapshot_type);
     snapshot_meta.set_snapshot_version(snapshot_version);
     snapshot_meta.rowset_metas().reserve(rowset_metas.size());
-    for (const auto& m : rowset_metas) {
+    for (const auto& rowset_meta : rowset_metas) {
         RowsetMetaPB& meta_pb = snapshot_meta.rowset_metas().emplace_back();
-        m->to_rowset_pb(&meta_pb);
+        rowset_meta->to_rowset_pb(&meta_pb);
     }
     if (snapshot_type == SNAPSHOT_TYPE_FULL) {
         auto meta_store = tablet->data_dir()->get_meta();
         uint32_t new_rsid = 0;
-        for (auto& rm : snapshot_meta.rowset_metas()) {
-            const uint32_t old_rsid = rm.rowset_seg_id();
-            for (int i = 0; i < rm.num_segments(); i++) {
+        for (auto& rowset_meta_pb : snapshot_meta.rowset_metas()) {
+            const uint32_t old_rsid = rowset_meta_pb.rowset_seg_id();
+            for (int i = 0; i < rowset_meta_pb.num_segments(); i++) {
                 int64_t dummy;
                 const uint32_t old_segment_id = old_rsid + i;
                 const uint32_t new_segment_id = new_rsid + i;
                 CHECK(snapshot_meta.delete_vectors().count(new_segment_id) == 0);
                 DelVector* delvec = &snapshot_meta.delete_vectors()[new_segment_id];
-                RETURN_IF_ERROR(TabletMetaManager::get_del_vector(meta_store, tablet_id, old_segment_id,
+                RETURN_IF_ERROR(TabletMetaManager::get_del_vector(meta_store, tablet->tablet_id(), old_segment_id,
                                                                   snapshot_version, delvec, &dummy /*latest_version*/));
             }
-            rm.set_rowset_seg_id(new_rsid);
-            new_rsid += std::max<uint32_t>(rm.num_segments(), 1);
+            rowset_meta_pb.set_rowset_seg_id(new_rsid);
+            new_rsid += std::max<uint32_t>(rowset_meta_pb.num_segments(), 1);
         }
     }
 
@@ -475,9 +509,9 @@ Status SnapshotManager::build_snapshot_meta(SnapshotTypePB snapshot_type, const 
         version->mutable_version()->set_major(snapshot_version);
         version->mutable_version()->set_minor(0);
         version->set_creation_time(time(nullptr));
-        for (const auto& rm : snapshot_meta.rowset_metas()) {
-            auto rsid = rm.rowset_seg_id();
-            next_segment_id = std::max<uint32_t>(next_segment_id, rsid + std::max(1L, rm.num_segments()));
+        for (const auto& rowset_meta_pb : snapshot_meta.rowset_metas()) {
+            auto rsid = rowset_meta_pb.rowset_seg_id();
+            next_segment_id = std::max<uint32_t>(next_segment_id, rsid + std::max(1L, rowset_meta_pb.num_segments()));
             version->add_rowsets(rsid);
         }
         meta_pb.mutable_updates()->set_next_rowset_id(next_segment_id);
@@ -504,24 +538,24 @@ StatusOr<SnapshotMeta> SnapshotManager::parse_snapshot_meta(const std::string& f
 }
 
 Status SnapshotManager::assign_new_rowset_id(SnapshotMeta* snapshot_meta, const std::string& clone_dir) {
-    for (auto& rm : snapshot_meta->rowset_metas()) {
+    for (auto& rowset_meta_pb : snapshot_meta->rowset_metas()) {
         RowsetId old_rowset_id;
         RowsetId new_rowset_id = StorageEngine::instance()->next_rowset_id();
-        old_rowset_id.init(rm.rowset_id_v2());
+        old_rowset_id.init(rowset_meta_pb.rowset_id_v2());
 
-        LOG(INFO) << "Replacing rowset id " << rm.rowset_id_v2() << " with " << new_rowset_id;
+        LOG(INFO) << "Replacing rowset id " << rowset_meta_pb.rowset_id_v2() << " with " << new_rowset_id;
 
-        for (int seg_id = 0; seg_id < rm.num_segments(); seg_id++) {
+        for (int seg_id = 0; seg_id < rowset_meta_pb.num_segments(); seg_id++) {
             auto old_path = BetaRowset::segment_file_path(clone_dir, old_rowset_id, seg_id);
             auto new_path = BetaRowset::segment_file_path(clone_dir, new_rowset_id, seg_id);
             RETURN_IF_ERROR(Env::Default()->link_file(old_path, new_path));
         }
-        for (int del_id = 0; del_id < rm.num_delete_files(); del_id++) {
+        for (int del_id = 0; del_id < rowset_meta_pb.num_delete_files(); del_id++) {
             auto old_path = BetaRowset::segment_del_file_path(clone_dir, old_rowset_id, del_id);
             auto new_path = BetaRowset::segment_del_file_path(clone_dir, new_rowset_id, del_id);
             RETURN_IF_ERROR(Env::Default()->link_file(old_path, new_path));
         }
-        rm.set_rowset_id_v2(new_rowset_id.to_string());
+        rowset_meta_pb.set_rowset_id_v2(new_rowset_id.to_string());
     }
     return Status::OK();
 }

--- a/be/src/storage/snapshot_manager.h
+++ b/be/src/storage/snapshot_manager.h
@@ -68,9 +68,10 @@ public:
     //  - |tablet| is a updatable tablet, i.e, tablet->keys_type() is PRIMARY_KEYS
     //  - |snapshot_dir| is an existing directory with write permission.
     //  - |snapshot_version| will NOT be removed until end of this method.
-    Status build_snapshot_meta(SnapshotTypePB snapshot_type, const std::string& snapshot_dir,
-                               const TabletSharedPtr& tablet, const std::vector<RowsetMetaSharedPtr>& rowset_metas,
-                               int64_t snapshot_version, int32_t snapshot_format);
+    Status make_snapshot_on_tablet_meta(SnapshotTypePB snapshot_type, const std::string& snapshot_dir,
+                                        const TabletSharedPtr& tablet,
+                                        const std::vector<RowsetMetaSharedPtr>& rowset_metas, int64_t snapshot_version,
+                                        int32_t snapshot_format);
 
     StatusOr<SnapshotMeta> parse_snapshot_meta(const std::string& filename);
 
@@ -81,7 +82,7 @@ public:
     // On success, return the absolute path of the root directory of snapshot.
     StatusOr<std::string> snapshot_full(const TabletSharedPtr& tablet, int64_t snapshot_version, int64_t timeout_s);
 
-    Status build_latest_full_snapshot_meta(const TabletSharedPtr& tablet);
+    Status make_snapshot_on_tablet_meta(const TabletSharedPtr& tablet);
 
     Status assign_new_rowset_id(SnapshotMeta* snapshot_meta, const std::string& clone_dir);
 

--- a/be/src/storage/snapshot_manager.h
+++ b/be/src/storage/snapshot_manager.h
@@ -81,8 +81,7 @@ public:
     // On success, return the absolute path of the root directory of snapshot.
     StatusOr<std::string> snapshot_full(const TabletSharedPtr& tablet, int64_t snapshot_version, int64_t timeout_s);
 
-    // On success, return the absolute path of the root directory of snapshot.
-    StatusOr<std::string> snapshot_trash(const TabletSharedPtr& tablet, int64_t snapshot_version, int64_t timeout_s);
+    Status write_meta_snapshot(const TabletSharedPtr& tablet);
 
     Status assign_new_rowset_id(SnapshotMeta* snapshot_meta, const std::string& clone_dir);
 

--- a/be/src/storage/snapshot_manager.h
+++ b/be/src/storage/snapshot_manager.h
@@ -81,6 +81,9 @@ public:
     // On success, return the absolute path of the root directory of snapshot.
     StatusOr<std::string> snapshot_full(const TabletSharedPtr& tablet, int64_t snapshot_version, int64_t timeout_s);
 
+    // On success, return the absolute path of the root directory of snapshot.
+    StatusOr<std::string> snapshot_trash(const TabletSharedPtr& tablet, int64_t snapshot_version, int64_t timeout_s);
+
     Status assign_new_rowset_id(SnapshotMeta* snapshot_meta, const std::string& clone_dir);
 
 private:

--- a/be/src/storage/snapshot_manager.h
+++ b/be/src/storage/snapshot_manager.h
@@ -81,7 +81,7 @@ public:
     // On success, return the absolute path of the root directory of snapshot.
     StatusOr<std::string> snapshot_full(const TabletSharedPtr& tablet, int64_t snapshot_version, int64_t timeout_s);
 
-    Status write_meta_snapshot(const TabletSharedPtr& tablet);
+    Status build_latest_full_snapshot_meta(const TabletSharedPtr& tablet);
 
     Status assign_new_rowset_id(SnapshotMeta* snapshot_meta, const std::string& clone_dir);
 

--- a/be/src/storage/snapshot_meta.cpp
+++ b/be/src/storage/snapshot_meta.cpp
@@ -47,9 +47,9 @@ Status SnapshotMeta::serialize_to_file(WritableFile* file) {
     footer.set_format_version(_format_version);
     footer.set_snapshot_type(_snapshot_type);
     footer.set_snapshot_version(_snapshot_version);
-    for (const auto& m : _rowset_metas) {
+    for (const auto& rowset_meta : _rowset_metas) {
         footer.add_rowset_meta_offsets(static_cast<int64_t>(stream.size()));
-        if (!m.SerializeToOstream(&stream)) {
+        if (!rowset_meta.SerializeToOstream(&stream)) {
             return Status::IOError("fail to serialize rowset meta to file");
         }
     }

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -854,9 +854,8 @@ OLAPStatus StorageEngine::obtain_shard_path(TStorageMedium::type storage_medium,
     return res;
 }
 
-OLAPStatus StorageEngine::load_header(const string& shard_path, const TCloneReq& request, bool restore) {
-    OLAPStatus res = OLAP_SUCCESS;
-
+OLAPStatus StorageEngine::load_header(const string& shard_path, const TCloneReq& request, bool restore,
+                                      bool is_primary_key) {
     DataDir* store = nullptr;
     {
         // TODO(zc)
@@ -876,24 +875,22 @@ OLAPStatus StorageEngine::load_header(const string& shard_path, const TCloneReq&
     std::stringstream schema_hash_path_stream;
     schema_hash_path_stream << shard_path << "/" << request.tablet_id << "/" << request.schema_hash;
     // not surely, reload and restore tablet action call this api
-    // reset tablet uid here
-
-    string header_path = TabletMeta::construct_header_file_path(schema_hash_path_stream.str(), request.tablet_id);
-    res = TabletMeta::reset_tablet_uid(header_path).ok() ? OLAP_SUCCESS : OLAP_ERR_OTHER_ERROR;
-    if (res != OLAP_SUCCESS) {
-        LOG(WARNING) << "Fail to reset tablet uid, "
-                     << "tablet_id=" << request.tablet_id << " file path=" << header_path << " res=" << res;
-        return res;
+    Status st;
+    if (!is_primary_key) {
+        st = _tablet_manager->load_tablet_from_dir(store, request.tablet_id, request.schema_hash,
+                                                   schema_hash_path_stream.str(), false, restore);
+    } else {
+        st = _tablet_manager->create_tablet_from_snapshot(store, request.tablet_id, request.schema_hash,
+                                                          schema_hash_path_stream.str(), is_primary_key);
     }
-    Status st = _tablet_manager->load_tablet_from_dir(store, request.tablet_id, request.schema_hash,
-                                                      schema_hash_path_stream.str(), false, restore);
+
     if (!st.ok()) {
         LOG(WARNING) << "Fail to load headers, "
-                     << "tablet_id=" << request.tablet_id << " res=" << st.to_string();
+                     << "tablet_id=" << request.tablet_id << " status=" << st;
         return OLAP_ERR_TABLE_NOT_FOUND;
     }
     LOG(INFO) << "Loaded headers tablet_id=" << request.tablet_id << " schema_hash=" << request.schema_hash;
-    return res;
+    return OLAP_SUCCESS;
 }
 
 OLAPStatus StorageEngine::execute_task(EngineTask* task) {

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -880,8 +880,8 @@ OLAPStatus StorageEngine::load_header(const string& shard_path, const TCloneReq&
         st = _tablet_manager->load_tablet_from_dir(store, request.tablet_id, request.schema_hash,
                                                    schema_hash_path_stream.str(), false, restore);
     } else {
-        st = _tablet_manager->create_tablet_from_primary_snapshot(store, request.tablet_id, request.schema_hash,
-                                                                  schema_hash_path_stream.str(), true);
+        st = _tablet_manager->create_primary_tablet_from_meta_snapshot(store, request.tablet_id, request.schema_hash,
+                                                                       schema_hash_path_stream.str(), true);
     }
 
     if (!st.ok()) {

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -880,8 +880,8 @@ OLAPStatus StorageEngine::load_header(const string& shard_path, const TCloneReq&
         st = _tablet_manager->load_tablet_from_dir(store, request.tablet_id, request.schema_hash,
                                                    schema_hash_path_stream.str(), false, restore);
     } else {
-        st = _tablet_manager->create_tablet_from_snapshot(store, request.tablet_id, request.schema_hash,
-                                                          schema_hash_path_stream.str(), is_primary_key);
+        st = _tablet_manager->create_tablet_from_primary_snapshot(store, request.tablet_id, request.schema_hash,
+                                                                  schema_hash_path_stream.str(), true);
     }
 
     if (!st.ok()) {

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -880,8 +880,8 @@ OLAPStatus StorageEngine::load_header(const string& shard_path, const TCloneReq&
         st = _tablet_manager->load_tablet_from_dir(store, request.tablet_id, request.schema_hash,
                                                    schema_hash_path_stream.str(), false, restore);
     } else {
-        st = _tablet_manager->create_primary_tablet_from_meta_snapshot(store, request.tablet_id, request.schema_hash,
-                                                                       schema_hash_path_stream.str(), true);
+        st = _tablet_manager->create_tablet_from_meta_snapshot(store, request.tablet_id, request.schema_hash,
+                                                               schema_hash_path_stream.str(), true);
     }
 
     if (!st.ok()) {

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -117,7 +117,8 @@ public:
     // @param [in] request specify new tablet info
     // @param [in] restore whether we're restoring a tablet from trash
     // @return OLAP_SUCCESS if load tablet success
-    OLAPStatus load_header(const std::string& shard_path, const TCloneReq& request, bool restore = false);
+    OLAPStatus load_header(const std::string& shard_path, const TCloneReq& request, bool restore = false,
+                           bool is_primary_key = false);
 
     // To trigger a disk-stat and tablet report
     void trigger_report() {

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -1023,9 +1023,6 @@ Status TabletManager::start_trash_sweep() {
                         if (!st.ok()) {
                             LOG(WARNING) << "Fail to snapshot_trash, tablet_id=" << tablet->tablet_id()
                                          << " schema_hash=" << tablet->schema_hash() << ", status=" << st.to_string();
-                        } else {
-                            LOG(INFO) << "Created snapshot tablet_id=" << tablet->tablet_id()
-                                      << " schema_hash=" << tablet->schema_hash();
                         }
                     } else {
                         // take snapshot of tablet meta

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -1408,9 +1408,8 @@ TabletManager::tablets_shard& TabletManager::_get_tablets_shard(TTabletId tablet
     return _tablets_shards[tabletId & _tablets_shards_mask];
 }
 
-Status TabletManager::create_primary_tablet_from_meta_snapshot(DataDir* store, TTabletId tablet_id,
-                                                               SchemaHash schema_hash, const string& schema_hash_path,
-                                                               bool restore) {
+Status TabletManager::create_tablet_from_meta_snapshot(DataDir* store, TTabletId tablet_id, SchemaHash schema_hash,
+                                                       const string& schema_hash_path, bool restore) {
     LOG(INFO) << "Loading tablet " << tablet_id << " from snapshot " << schema_hash_path;
     auto meta_path = strings::Substitute("$0/meta", schema_hash_path);
     auto shard_path = path_util::dir_name(path_util::dir_name(path_util::dir_name(meta_path)));

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -1022,11 +1022,11 @@ Status TabletManager::start_trash_sweep() {
                         StatusOr<std::string> st = SnapshotManager::instance()->snapshot_trash(tablet, 0, 180);
                         if (!st.ok()) {
                             LOG(WARNING) << "Fail to snapshot_trash, tablet_id=" << tablet->tablet_id()
-                                         << " schema_hash="
-                                         << tablet->schema_hash(); // << " status=" << st.to_string();
+                                         << " schema_hash=" << tablet->schema_hash()
+                                         << ", status=" << st.status().to_string();
                         } else {
-                            LOG(INFO) << "Created snapshot tablet_id=" << tablet->tablet_id() << " schema_hash="
-                                      << tablet->schema_hash(); // << " snapshot_path=" << snapshot_path;
+                            LOG(INFO) << "Created snapshot tablet_id=" << tablet->tablet_id()
+                                      << " schema_hash=" << tablet->schema_hash();
                         }
                     } else {
                         // take snapshot of tablet meta

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -1019,11 +1019,10 @@ Status TabletManager::start_trash_sweep() {
                 std::string tablet_path = tablet->tablet_path();
                 if (Env::Default()->path_exists(tablet_path).ok()) {
                     if (tablet->keys_type() == KeysType::PRIMARY_KEYS) {
-                        StatusOr<std::string> st = SnapshotManager::instance()->snapshot_trash(tablet, 0, 180);
+                        Status st = SnapshotManager::instance()->write_meta_snapshot(tablet);
                         if (!st.ok()) {
                             LOG(WARNING) << "Fail to snapshot_trash, tablet_id=" << tablet->tablet_id()
-                                         << " schema_hash=" << tablet->schema_hash()
-                                         << ", status=" << st.status().to_string();
+                                         << " schema_hash=" << tablet->schema_hash() << ", status=" << st.to_string();
                         } else {
                             LOG(INFO) << "Created snapshot tablet_id=" << tablet->tablet_id()
                                       << " schema_hash=" << tablet->schema_hash();

--- a/be/src/storage/tablet_manager.h
+++ b/be/src/storage/tablet_manager.h
@@ -104,8 +104,8 @@ public:
     Status load_tablet_from_dir(DataDir* data_dir, TTabletId tablet_id, SchemaHash schema_hash,
                                 const std::string& schema_hash_path, bool force = false, bool restore = false);
 
-    Status create_tablet_from_snapshot(DataDir* data_dir, TTabletId tablet_id, SchemaHash schema_hash,
-                                       const std::string& schema_hash_path, bool is_primary_key = false);
+    Status create_tablet_from_primary_snapshot(DataDir* data_dir, TTabletId tablet_id, SchemaHash schema_hash,
+                                               const std::string& schema_hash_path, bool restore = false);
 
     void release_schema_change_lock(TTabletId tablet_id);
 

--- a/be/src/storage/tablet_manager.h
+++ b/be/src/storage/tablet_manager.h
@@ -105,7 +105,7 @@ public:
                                 const std::string& schema_hash_path, bool force = false, bool restore = false);
 
     Status create_tablet_from_snapshot(DataDir* data_dir, TTabletId tablet_id, SchemaHash schema_hash,
-                                       const std::string& schema_hash_path);
+                                       const std::string& schema_hash_path, bool is_primary_key = false);
 
     void release_schema_change_lock(TTabletId tablet_id);
 

--- a/be/src/storage/tablet_manager.h
+++ b/be/src/storage/tablet_manager.h
@@ -104,8 +104,8 @@ public:
     Status load_tablet_from_dir(DataDir* data_dir, TTabletId tablet_id, SchemaHash schema_hash,
                                 const std::string& schema_hash_path, bool force = false, bool restore = false);
 
-    Status create_primary_tablet_from_meta_snapshot(DataDir* data_dir, TTabletId tablet_id, SchemaHash schema_hash,
-                                                    const std::string& schema_hash_path, bool restore = false);
+    Status create_tablet_from_meta_snapshot(DataDir* data_dir, TTabletId tablet_id, SchemaHash schema_hash,
+                                            const std::string& schema_hash_path, bool restore = false);
 
     void release_schema_change_lock(TTabletId tablet_id);
 

--- a/be/src/storage/tablet_manager.h
+++ b/be/src/storage/tablet_manager.h
@@ -104,8 +104,8 @@ public:
     Status load_tablet_from_dir(DataDir* data_dir, TTabletId tablet_id, SchemaHash schema_hash,
                                 const std::string& schema_hash_path, bool force = false, bool restore = false);
 
-    Status create_tablet_from_primary_snapshot(DataDir* data_dir, TTabletId tablet_id, SchemaHash schema_hash,
-                                               const std::string& schema_hash_path, bool restore = false);
+    Status create_primary_tablet_from_meta_snapshot(DataDir* data_dir, TTabletId tablet_id, SchemaHash schema_hash,
+                                                    const std::string& schema_hash_path, bool restore = false);
 
     void release_schema_change_lock(TTabletId tablet_id);
 

--- a/be/src/storage/tablet_meta.cpp
+++ b/be/src/storage/tablet_meta.cpp
@@ -497,7 +497,7 @@ void TabletMeta::to_meta_pb(TabletMetaPB* tablet_meta_pb) {
     tablet_meta_pb->set_shard_id(shard_id());
     tablet_meta_pb->set_creation_time(creation_time());
     tablet_meta_pb->set_cumulative_layer_point(cumulative_layer_point());
-    *(tablet_meta_pb->mutable_tablet_uid()) = tablet_uid().to_proto();
+    *tablet_meta_pb->mutable_tablet_uid() = tablet_uid().to_proto();
     tablet_meta_pb->set_tablet_type(_tablet_type);
     switch (tablet_state()) {
     case TABLET_NOTREADY:

--- a/be/src/storage/task/engine_clone_task.cpp
+++ b/be/src/storage/task/engine_clone_task.cpp
@@ -159,7 +159,8 @@ Status EngineCloneTask::_do_clone(Tablet* tablet) {
             }
         } else if (FileUtils::check_exist(clone_meta_file)) {
             DCHECK(!FileUtils::check_exist(clone_header_file));
-            status = tablet_manager->create_tablet_from_snapshot(store, tablet_id, schema_hash, schema_hash_dir);
+            status =
+                    tablet_manager->create_tablet_from_primary_snapshot(store, tablet_id, schema_hash, schema_hash_dir);
             if (!status.ok()) {
                 LOG(WARNING) << "Fail to load tablet from snapshot: " << status
                              << ". schema_hash_dir=" << schema_hash_dir << " signature=" << _signature;

--- a/be/src/storage/task/engine_clone_task.cpp
+++ b/be/src/storage/task/engine_clone_task.cpp
@@ -159,8 +159,8 @@ Status EngineCloneTask::_do_clone(Tablet* tablet) {
             }
         } else if (FileUtils::check_exist(clone_meta_file)) {
             DCHECK(!FileUtils::check_exist(clone_header_file));
-            status =
-                    tablet_manager->create_tablet_from_primary_snapshot(store, tablet_id, schema_hash, schema_hash_dir);
+            status = tablet_manager->create_primary_tablet_from_meta_snapshot(store, tablet_id, schema_hash,
+                                                                              schema_hash_dir);
             if (!status.ok()) {
                 LOG(WARNING) << "Fail to load tablet from snapshot: " << status
                              << ". schema_hash_dir=" << schema_hash_dir << " signature=" << _signature;
@@ -429,7 +429,7 @@ Status EngineCloneTask::_download_files(DataDir* data_dir, const std::string& re
 Status EngineCloneTask::_finish_clone(Tablet* tablet, const string& clone_dir, int64_t committed_version,
                                       bool incremental_clone) {
     if (tablet->updates() != nullptr) {
-        return _finish_clone_updatable(tablet, clone_dir);
+        return _finish_clone_primary(tablet, clone_dir);
     }
     Status res;
     std::vector<std::string> linked_success_files;
@@ -637,7 +637,7 @@ Status EngineCloneTask::_clone_full_data(Tablet* tablet, TabletMeta* cloned_tabl
     return st;
 }
 
-Status EngineCloneTask::_finish_clone_updatable(Tablet* tablet, const std::string& clone_dir) {
+Status EngineCloneTask::_finish_clone_primary(Tablet* tablet, const std::string& clone_dir) {
     auto meta_file = strings::Substitute("$0/meta", clone_dir);
     auto res = SnapshotManager::instance()->parse_snapshot_meta(meta_file);
     if (!res.ok()) {

--- a/be/src/storage/task/engine_clone_task.cpp
+++ b/be/src/storage/task/engine_clone_task.cpp
@@ -672,10 +672,11 @@ Status EngineCloneTask::_finish_clone_updatable(Tablet* tablet, const std::strin
         local_files.erase(fname);
     }
 
+    auto env = Env::Default();
     for (const std::string& filename : clone_files) {
         std::string from = clone_dir + "/" + filename;
         std::string to = tablet_dir + "/" + filename;
-        RETURN_IF_ERROR(Env::Default()->link_file(from, to));
+        RETURN_IF_ERROR(env->link_file(from, to));
         LOG(INFO) << "Linked " << from << " to " << to;
     }
     // Note that |snapshot_meta| may be modified by `load_snapshot`.

--- a/be/src/storage/task/engine_clone_task.cpp
+++ b/be/src/storage/task/engine_clone_task.cpp
@@ -159,8 +159,7 @@ Status EngineCloneTask::_do_clone(Tablet* tablet) {
             }
         } else if (FileUtils::check_exist(clone_meta_file)) {
             DCHECK(!FileUtils::check_exist(clone_header_file));
-            status = tablet_manager->create_primary_tablet_from_meta_snapshot(store, tablet_id, schema_hash,
-                                                                              schema_hash_dir);
+            status = tablet_manager->create_tablet_from_meta_snapshot(store, tablet_id, schema_hash, schema_hash_dir);
             if (!status.ok()) {
                 LOG(WARNING) << "Fail to load tablet from snapshot: " << status
                              << ". schema_hash_dir=" << schema_hash_dir << " signature=" << _signature;

--- a/be/src/storage/task/engine_clone_task.h
+++ b/be/src/storage/task/engine_clone_task.h
@@ -67,7 +67,7 @@ private:
 
     Status _release_snapshot(const std::string& ip, int port, const std::string& snapshot_path);
 
-    Status _finish_clone_updatable(Tablet* tablet, const std::string& clone_dir);
+    Status _finish_clone_primary(Tablet* tablet, const std::string& clone_dir);
 
 private:
     MemTracker* _tablet_meta_mem_tracker = nullptr;

--- a/be/src/storage/task/engine_clone_task.h
+++ b/be/src/storage/task/engine_clone_task.h
@@ -67,8 +67,7 @@ private:
 
     Status _release_snapshot(const std::string& ip, int port, const std::string& snapshot_path);
 
-    Status _finish_clone_updatable(Tablet* tablet, const std::string& clone_dir, int64_t committed_version,
-                                   bool incremental_clone);
+    Status _finish_clone_updatable(Tablet* tablet, const std::string& clone_dir);
 
 private:
     MemTracker* _tablet_meta_mem_tracker = nullptr;

--- a/be/src/storage/utils.cpp
+++ b/be/src/storage/utils.cpp
@@ -90,9 +90,7 @@ OLAPStatus move_to_trash(const std::filesystem::path& schema_hash_root, const st
     // 1. get timestamp string
     string time_str;
     if ((res = gen_timestamp_string(&time_str)) != OLAP_SUCCESS) {
-        LOG(WARNING) << "failed to generate time_string when move file to trash."
-                        " err code="
-                     << res;
+        LOG(WARNING) << "failed to generate time_string when move file to trash. err code=" << res;
         return res;
     }
 
@@ -128,7 +126,7 @@ OLAPStatus move_to_trash(const std::filesystem::path& schema_hash_root, const st
     std::set<std::string> sub_dirs, sub_files;
 
     RETURN_CODE_IF_ERROR_WITH_WARN(FileUtils::list_dirs_files(source_parent_dir, &sub_dirs, &sub_files, Env::Default()),
-                                   OLAP_SUCCESS, "access dir failed. [dir=" + source_parent_dir);
+                                   OLAP_SUCCESS, "access dir failed. [dir=" + source_parent_dir + "].");
 
     if (sub_dirs.empty() && sub_files.empty()) {
         LOG(INFO) << "remove empty dir " << source_parent_dir;

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -161,7 +161,7 @@ public:
         DeferOp defer1([&]() { (void)FileUtils::remove_all(*snapshot_dir); });
 
         auto meta_dir = SnapshotManager::instance()->get_schema_hash_full_path(source_tablet, *snapshot_dir);
-        auto snapshot_meta = SnapshotManager::instance()->parse_snapshot_meta(meta_dir + "/meta.primary");
+        auto snapshot_meta = SnapshotManager::instance()->parse_snapshot_meta(meta_dir + "/meta");
         CHECK(snapshot_meta.ok()) << snapshot_meta.status();
 
         RETURN_IF_ERROR(SnapshotManager::instance()->assign_new_rowset_id(&(*snapshot_meta), meta_dir));
@@ -169,7 +169,7 @@ public:
         std::set<std::string> files;
         auto st = FileUtils::list_dirs_files(meta_dir, NULL, &files, Env::Default());
         CHECK(st.ok()) << st;
-        files.erase("meta.primary");
+        files.erase("meta");
 
         for (const auto& f : files) {
             std::string src = meta_dir + "/" + f;
@@ -203,7 +203,7 @@ public:
         DeferOp defer1([&]() { (void)FileUtils::remove_all(*snapshot_dir); });
 
         auto meta_dir = SnapshotManager::instance()->get_schema_hash_full_path(source_tablet, *snapshot_dir);
-        auto meta_file = meta_dir + "/meta.primary";
+        auto meta_file = meta_dir + "/meta";
         auto snapshot_meta = SnapshotManager::instance()->parse_snapshot_meta(meta_file);
         CHECK(snapshot_meta.ok()) << snapshot_meta.status();
 
@@ -237,8 +237,8 @@ public:
         }
 
         auto tablet_manager = StorageEngine::instance()->tablet_manager();
-        auto st = tablet_manager->create_tablet_from_snapshot(store, new_tablet_id, new_schema_hash, new_tablet_path,
-                                                              true);
+        auto st = tablet_manager->create_tablet_from_primary_snapshot(store, new_tablet_id, new_schema_hash,
+                                                                      new_tablet_path);
         CHECK(st.ok()) << st;
         return tablet_manager->get_tablet(new_tablet_id, new_schema_hash);
     }
@@ -790,13 +790,13 @@ TEST_F(TabletUpdatesTest, load_snapshot_incremental) {
     DeferOp defer1([&]() { (void)FileUtils::remove_all(*snapshot_dir); });
 
     auto meta_dir = SnapshotManager::instance()->get_schema_hash_full_path(tablet0, *snapshot_dir);
-    auto snapshot_meta = SnapshotManager::instance()->parse_snapshot_meta(meta_dir + "/meta.primary");
+    auto snapshot_meta = SnapshotManager::instance()->parse_snapshot_meta(meta_dir + "/meta");
     ASSERT_TRUE(snapshot_meta.ok()) << snapshot_meta.status();
 
     std::set<std::string> files;
     auto st = FileUtils::list_dirs_files(meta_dir, NULL, &files, Env::Default());
     ASSERT_TRUE(st.ok()) << st;
-    files.erase("meta.primary");
+    files.erase("meta");
 
     for (const auto& f : files) {
         std::string src = meta_dir + "/" + f;
@@ -854,13 +854,13 @@ TEST_F(TabletUpdatesTest, load_snapshot_incremental_ignore_already_committed_ver
     DeferOp defer1([&]() { (void)FileUtils::remove_all(*snapshot_dir); });
 
     auto meta_dir = SnapshotManager::instance()->get_schema_hash_full_path(tablet0, *snapshot_dir);
-    auto snapshot_meta = SnapshotManager::instance()->parse_snapshot_meta(meta_dir + "/meta.primary");
+    auto snapshot_meta = SnapshotManager::instance()->parse_snapshot_meta(meta_dir + "/meta");
     ASSERT_TRUE(snapshot_meta.ok()) << snapshot_meta.status();
 
     std::set<std::string> files;
     auto st = FileUtils::list_dirs_files(meta_dir, NULL, &files, Env::Default());
     ASSERT_TRUE(st.ok()) << st;
-    files.erase("meta.primary");
+    files.erase("meta");
 
     for (const auto& f : files) {
         std::string src = meta_dir + "/" + f;
@@ -918,13 +918,13 @@ TEST_F(TabletUpdatesTest, load_snapshot_incremental_mismatched_tablet_id) {
     DeferOp defer1([&]() { (void)FileUtils::remove_all(*snapshot_dir); });
 
     auto meta_dir = SnapshotManager::instance()->get_schema_hash_full_path(tablet0, *snapshot_dir);
-    auto snapshot_meta = SnapshotManager::instance()->parse_snapshot_meta(meta_dir + "/meta.primary");
+    auto snapshot_meta = SnapshotManager::instance()->parse_snapshot_meta(meta_dir + "/meta");
     ASSERT_TRUE(snapshot_meta.ok()) << snapshot_meta.status();
 
     std::set<std::string> files;
     auto st = FileUtils::list_dirs_files(meta_dir, NULL, &files, Env::Default());
     ASSERT_TRUE(st.ok()) << st;
-    files.erase("meta.primary");
+    files.erase("meta");
 
     for (const auto& f : files) {
         std::string src = meta_dir + "/" + f;
@@ -969,13 +969,13 @@ TEST_F(TabletUpdatesTest, load_snapshot_incremental_data_file_not_exist) {
     DeferOp defer1([&]() { (void)FileUtils::remove_all(*snapshot_dir); });
 
     auto meta_dir = SnapshotManager::instance()->get_schema_hash_full_path(tablet0, *snapshot_dir);
-    auto snapshot_meta = SnapshotManager::instance()->parse_snapshot_meta(meta_dir + "/meta.primary");
+    auto snapshot_meta = SnapshotManager::instance()->parse_snapshot_meta(meta_dir + "/meta");
     ASSERT_TRUE(snapshot_meta.ok()) << snapshot_meta.status();
 
     std::set<std::string> files;
     auto st = FileUtils::list_dirs_files(meta_dir, NULL, &files, Env::Default());
     ASSERT_TRUE(st.ok()) << st;
-    files.erase("meta.primary");
+    files.erase("meta");
 
     // Pretend that tablet0 is a peer replica of tablet1
     snapshot_meta->tablet_meta().set_tablet_id(tablet1->tablet_id());
@@ -1022,13 +1022,13 @@ TEST_F(TabletUpdatesTest, load_snapshot_incremental_incorrect_version) {
     DeferOp defer1([&]() { (void)FileUtils::remove_all(*snapshot_dir); });
 
     auto meta_dir = SnapshotManager::instance()->get_schema_hash_full_path(tablet0, *snapshot_dir);
-    auto snapshot_meta = SnapshotManager::instance()->parse_snapshot_meta(meta_dir + "/meta.primary");
+    auto snapshot_meta = SnapshotManager::instance()->parse_snapshot_meta(meta_dir + "/meta");
     ASSERT_TRUE(snapshot_meta.ok()) << snapshot_meta.status();
 
     std::set<std::string> files;
     auto st = FileUtils::list_dirs_files(meta_dir, NULL, &files, Env::Default());
     ASSERT_TRUE(st.ok()) << st;
-    files.erase("meta.primary");
+    files.erase("meta");
 
     for (const auto& f : files) {
         std::string src = meta_dir + "/" + f;
@@ -1115,13 +1115,13 @@ TEST_F(TabletUpdatesTest, load_snapshot_full_file_not_exist) {
     DeferOp defer1([&]() { (void)FileUtils::remove_all(*snapshot_dir); });
 
     auto meta_dir = SnapshotManager::instance()->get_schema_hash_full_path(tablet0, *snapshot_dir);
-    auto snapshot_meta = SnapshotManager::instance()->parse_snapshot_meta(meta_dir + "/meta.primary");
+    auto snapshot_meta = SnapshotManager::instance()->parse_snapshot_meta(meta_dir + "/meta");
     ASSERT_TRUE(snapshot_meta.ok()) << snapshot_meta.status();
 
     std::set<std::string> files;
     auto st = FileUtils::list_dirs_files(meta_dir, NULL, &files, Env::Default());
     ASSERT_TRUE(st.ok()) << st;
-    files.erase("meta.primary");
+    files.erase("meta");
 
     // Pretend that tablet0 is a peer replica of tablet1
     snapshot_meta->tablet_meta().set_tablet_id(tablet1->tablet_id());
@@ -1175,13 +1175,13 @@ TEST_F(TabletUpdatesTest, load_snapshot_full_mismatched_tablet_id) {
     DeferOp defer1([&]() { (void)FileUtils::remove_all(*snapshot_dir); });
 
     auto meta_dir = SnapshotManager::instance()->get_schema_hash_full_path(tablet0, *snapshot_dir);
-    auto snapshot_meta = SnapshotManager::instance()->parse_snapshot_meta(meta_dir + "/meta.primary");
+    auto snapshot_meta = SnapshotManager::instance()->parse_snapshot_meta(meta_dir + "/meta");
     ASSERT_TRUE(snapshot_meta.ok()) << snapshot_meta.status();
 
     std::set<std::string> files;
     auto st = FileUtils::list_dirs_files(meta_dir, NULL, &files, Env::Default());
     ASSERT_TRUE(st.ok()) << st;
-    files.erase("meta.primary");
+    files.erase("meta");
 
     for (const auto& f : files) {
         std::string src = meta_dir + "/" + f;

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -161,7 +161,7 @@ public:
         DeferOp defer1([&]() { (void)FileUtils::remove_all(*snapshot_dir); });
 
         auto meta_dir = SnapshotManager::instance()->get_schema_hash_full_path(source_tablet, *snapshot_dir);
-        auto snapshot_meta = SnapshotManager::instance()->parse_snapshot_meta(meta_dir + "/meta");
+        auto snapshot_meta = SnapshotManager::instance()->parse_snapshot_meta(meta_dir + "/meta.primary");
         CHECK(snapshot_meta.ok()) << snapshot_meta.status();
 
         RETURN_IF_ERROR(SnapshotManager::instance()->assign_new_rowset_id(&(*snapshot_meta), meta_dir));
@@ -169,7 +169,7 @@ public:
         std::set<std::string> files;
         auto st = FileUtils::list_dirs_files(meta_dir, NULL, &files, Env::Default());
         CHECK(st.ok()) << st;
-        files.erase("meta");
+        files.erase("meta.primary");
 
         for (const auto& f : files) {
             std::string src = meta_dir + "/" + f;
@@ -203,7 +203,7 @@ public:
         DeferOp defer1([&]() { (void)FileUtils::remove_all(*snapshot_dir); });
 
         auto meta_dir = SnapshotManager::instance()->get_schema_hash_full_path(source_tablet, *snapshot_dir);
-        auto meta_file = meta_dir + "/meta";
+        auto meta_file = meta_dir + "/meta.primary";
         auto snapshot_meta = SnapshotManager::instance()->parse_snapshot_meta(meta_file);
         CHECK(snapshot_meta.ok()) << snapshot_meta.status();
 
@@ -237,7 +237,8 @@ public:
         }
 
         auto tablet_manager = StorageEngine::instance()->tablet_manager();
-        auto st = tablet_manager->create_tablet_from_snapshot(store, new_tablet_id, new_schema_hash, new_tablet_path);
+        auto st = tablet_manager->create_tablet_from_snapshot(store, new_tablet_id, new_schema_hash, new_tablet_path,
+                                                              true);
         CHECK(st.ok()) << st;
         return tablet_manager->get_tablet(new_tablet_id, new_schema_hash);
     }
@@ -789,13 +790,13 @@ TEST_F(TabletUpdatesTest, load_snapshot_incremental) {
     DeferOp defer1([&]() { (void)FileUtils::remove_all(*snapshot_dir); });
 
     auto meta_dir = SnapshotManager::instance()->get_schema_hash_full_path(tablet0, *snapshot_dir);
-    auto snapshot_meta = SnapshotManager::instance()->parse_snapshot_meta(meta_dir + "/meta");
+    auto snapshot_meta = SnapshotManager::instance()->parse_snapshot_meta(meta_dir + "/meta.primary");
     ASSERT_TRUE(snapshot_meta.ok()) << snapshot_meta.status();
 
     std::set<std::string> files;
     auto st = FileUtils::list_dirs_files(meta_dir, NULL, &files, Env::Default());
     ASSERT_TRUE(st.ok()) << st;
-    files.erase("meta");
+    files.erase("meta.primary");
 
     for (const auto& f : files) {
         std::string src = meta_dir + "/" + f;
@@ -853,13 +854,13 @@ TEST_F(TabletUpdatesTest, load_snapshot_incremental_ignore_already_committed_ver
     DeferOp defer1([&]() { (void)FileUtils::remove_all(*snapshot_dir); });
 
     auto meta_dir = SnapshotManager::instance()->get_schema_hash_full_path(tablet0, *snapshot_dir);
-    auto snapshot_meta = SnapshotManager::instance()->parse_snapshot_meta(meta_dir + "/meta");
+    auto snapshot_meta = SnapshotManager::instance()->parse_snapshot_meta(meta_dir + "/meta.primary");
     ASSERT_TRUE(snapshot_meta.ok()) << snapshot_meta.status();
 
     std::set<std::string> files;
     auto st = FileUtils::list_dirs_files(meta_dir, NULL, &files, Env::Default());
     ASSERT_TRUE(st.ok()) << st;
-    files.erase("meta");
+    files.erase("meta.primary");
 
     for (const auto& f : files) {
         std::string src = meta_dir + "/" + f;
@@ -917,13 +918,13 @@ TEST_F(TabletUpdatesTest, load_snapshot_incremental_mismatched_tablet_id) {
     DeferOp defer1([&]() { (void)FileUtils::remove_all(*snapshot_dir); });
 
     auto meta_dir = SnapshotManager::instance()->get_schema_hash_full_path(tablet0, *snapshot_dir);
-    auto snapshot_meta = SnapshotManager::instance()->parse_snapshot_meta(meta_dir + "/meta");
+    auto snapshot_meta = SnapshotManager::instance()->parse_snapshot_meta(meta_dir + "/meta.primary");
     ASSERT_TRUE(snapshot_meta.ok()) << snapshot_meta.status();
 
     std::set<std::string> files;
     auto st = FileUtils::list_dirs_files(meta_dir, NULL, &files, Env::Default());
     ASSERT_TRUE(st.ok()) << st;
-    files.erase("meta");
+    files.erase("meta.primary");
 
     for (const auto& f : files) {
         std::string src = meta_dir + "/" + f;
@@ -968,13 +969,13 @@ TEST_F(TabletUpdatesTest, load_snapshot_incremental_data_file_not_exist) {
     DeferOp defer1([&]() { (void)FileUtils::remove_all(*snapshot_dir); });
 
     auto meta_dir = SnapshotManager::instance()->get_schema_hash_full_path(tablet0, *snapshot_dir);
-    auto snapshot_meta = SnapshotManager::instance()->parse_snapshot_meta(meta_dir + "/meta");
+    auto snapshot_meta = SnapshotManager::instance()->parse_snapshot_meta(meta_dir + "/meta.primary");
     ASSERT_TRUE(snapshot_meta.ok()) << snapshot_meta.status();
 
     std::set<std::string> files;
     auto st = FileUtils::list_dirs_files(meta_dir, NULL, &files, Env::Default());
     ASSERT_TRUE(st.ok()) << st;
-    files.erase("meta");
+    files.erase("meta.primary");
 
     // Pretend that tablet0 is a peer replica of tablet1
     snapshot_meta->tablet_meta().set_tablet_id(tablet1->tablet_id());
@@ -1021,13 +1022,13 @@ TEST_F(TabletUpdatesTest, load_snapshot_incremental_incorrect_version) {
     DeferOp defer1([&]() { (void)FileUtils::remove_all(*snapshot_dir); });
 
     auto meta_dir = SnapshotManager::instance()->get_schema_hash_full_path(tablet0, *snapshot_dir);
-    auto snapshot_meta = SnapshotManager::instance()->parse_snapshot_meta(meta_dir + "/meta");
+    auto snapshot_meta = SnapshotManager::instance()->parse_snapshot_meta(meta_dir + "/meta.primary");
     ASSERT_TRUE(snapshot_meta.ok()) << snapshot_meta.status();
 
     std::set<std::string> files;
     auto st = FileUtils::list_dirs_files(meta_dir, NULL, &files, Env::Default());
     ASSERT_TRUE(st.ok()) << st;
-    files.erase("meta");
+    files.erase("meta.primary");
 
     for (const auto& f : files) {
         std::string src = meta_dir + "/" + f;
@@ -1114,13 +1115,13 @@ TEST_F(TabletUpdatesTest, load_snapshot_full_file_not_exist) {
     DeferOp defer1([&]() { (void)FileUtils::remove_all(*snapshot_dir); });
 
     auto meta_dir = SnapshotManager::instance()->get_schema_hash_full_path(tablet0, *snapshot_dir);
-    auto snapshot_meta = SnapshotManager::instance()->parse_snapshot_meta(meta_dir + "/meta");
+    auto snapshot_meta = SnapshotManager::instance()->parse_snapshot_meta(meta_dir + "/meta.primary");
     ASSERT_TRUE(snapshot_meta.ok()) << snapshot_meta.status();
 
     std::set<std::string> files;
     auto st = FileUtils::list_dirs_files(meta_dir, NULL, &files, Env::Default());
     ASSERT_TRUE(st.ok()) << st;
-    files.erase("meta");
+    files.erase("meta.primary");
 
     // Pretend that tablet0 is a peer replica of tablet1
     snapshot_meta->tablet_meta().set_tablet_id(tablet1->tablet_id());
@@ -1174,13 +1175,13 @@ TEST_F(TabletUpdatesTest, load_snapshot_full_mismatched_tablet_id) {
     DeferOp defer1([&]() { (void)FileUtils::remove_all(*snapshot_dir); });
 
     auto meta_dir = SnapshotManager::instance()->get_schema_hash_full_path(tablet0, *snapshot_dir);
-    auto snapshot_meta = SnapshotManager::instance()->parse_snapshot_meta(meta_dir + "/meta");
+    auto snapshot_meta = SnapshotManager::instance()->parse_snapshot_meta(meta_dir + "/meta.primary");
     ASSERT_TRUE(snapshot_meta.ok()) << snapshot_meta.status();
 
     std::set<std::string> files;
     auto st = FileUtils::list_dirs_files(meta_dir, NULL, &files, Env::Default());
     ASSERT_TRUE(st.ok()) << st;
-    files.erase("meta");
+    files.erase("meta.primary");
 
     for (const auto& f : files) {
         std::string src = meta_dir + "/" + f;

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -237,8 +237,8 @@ public:
         }
 
         auto tablet_manager = StorageEngine::instance()->tablet_manager();
-        auto st = tablet_manager->create_primary_tablet_from_meta_snapshot(store, new_tablet_id, new_schema_hash,
-                                                                           new_tablet_path);
+        auto st = tablet_manager->create_tablet_from_meta_snapshot(store, new_tablet_id, new_schema_hash,
+                                                                   new_tablet_path);
         CHECK(st.ok()) << st;
         return tablet_manager->get_tablet(new_tablet_id, new_schema_hash);
     }

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -237,8 +237,8 @@ public:
         }
 
         auto tablet_manager = StorageEngine::instance()->tablet_manager();
-        auto st = tablet_manager->create_tablet_from_primary_snapshot(store, new_tablet_id, new_schema_hash,
-                                                                      new_tablet_path);
+        auto st = tablet_manager->create_primary_tablet_from_meta_snapshot(store, new_tablet_id, new_schema_hash,
+                                                                           new_tablet_path);
         CHECK(st.ok()) << st;
         return tablet_manager->get_tablet(new_tablet_id, new_schema_hash);
     }


### PR DESCRIPTION
support trash mechanism for update.
when drop tablet, build the latest full snapshot meta, and move it to trash, snapshot manager do snapshot for clone mechanism for now, it can be reuse to create meta file, and reuse trash mechanism in the meanwhile.
the primary key meta named "meta", the same as the clone mechanism, the other key meta keep the name "$tablet.hdr". when call the restore procedure, distinguish files by name.
so we can restore the meta from trash by restore_action API, like
```
curl -X POST "http://be_host:be_webserver_port/api/restore_tablet?tablet_id=11111\&schema_hash=12345"
```
resolve #623 