### PR TITLE
Remove unused code of non-vectorized runtime engine from ExchangeNode and DataStreamRecvr

### DIFF
--- a/be/src/exec/exchange_node.h
+++ b/be/src/exec/exchange_node.h
@@ -28,7 +28,6 @@
 
 namespace starrocks {
 
-class RowBatch;
 class RuntimeProfile;
 
 // Receiver node for data streams. The data stream receiver is created in Prepare()
@@ -73,12 +72,7 @@ protected:
 private:
     // Implements GetNext() for the case where _is_merging is true. Delegates the GetNext()
     // call to the underlying DataStreamRecvr.
-    Status get_next_merging(RuntimeState* state, RowBatch* output_batch, bool* eos);
     Status get_next_merging(RuntimeState* state, ChunkPtr* chunk, bool* eos);
-
-    // Resets _input_batch to the next batch from the from _stream_recvr's queue.
-    // Only used when _is_merging is false.
-    Status fill_input_row_batch(RuntimeState* state);
 
     int _num_senders; // needed for _stream_recvr construction
 
@@ -88,24 +82,8 @@ private:
     // our input rows are a prefix of the rows we produce
     RowDescriptor _input_row_desc;
 
-    // the size of our input batches does not necessarily match the capacity
-    // of our output batches, which means that we need to buffer the input
-    // Current batch of rows from the receiver queue being processed by this node.
-    // Only valid if _is_merging is false. (If _is_merging is true, GetNext() is
-    // delegated to the receiver). Owned by the stream receiver.
-    // std::unique_ptr<RowBatch> _input_batch;
-    RowBatch* _input_batch = nullptr;
-
     std::unique_ptr<vectorized::Chunk> _input_chunk;
     bool _is_finished = false;
-
-    // Next row to copy from _input_batch. For non-merging exchanges, _input_batch
-    // is retrieved directly from the sender queue in the stream recvr, and rows from
-    // _input_batch must be copied to the output batch in GetNext().
-    int _next_row_idx;
-
-    // time spent reconstructing received rows
-    RuntimeProfile::Counter* _convert_row_batch_timer = nullptr;
 
     // True if this is a merging exchange node. If true, GetNext() is delegated to the
     // underlying _stream_recvr, and _input_batch is not used/valid.

--- a/be/src/runtime/data_stream_recvr.cc
+++ b/be/src/runtime/data_stream_recvr.cc
@@ -66,7 +66,6 @@ public:
     // The call blocks until another batch arrives or all senders close
     // their channels. The returned batch is owned by the sender queue. The caller
     // must acquire data from the returned batch before the next call to get_batch().
-    Status get_batch(RowBatch** next_batch);
     Status get_chunk(vectorized::Chunk** chunk);
 
     // check if data has come, work with try_get_chunk.
@@ -142,7 +141,6 @@ private:
     typedef std::list<std::pair<int, ChunkUniquePtr>> ChunkQueue;
     ChunkQueue _chunk_queue;
     vectorized::RuntimeChunkMeta _chunk_meta;
-    vectorized::Buffer<uint8_t> _uncompressed_chunk_data;
 
     // The batch that was most recently returned via get_batch(), i.e. the current batch
     // from this queue being processed by a consumer. Is destroyed when the next batch
@@ -163,53 +161,6 @@ DataStreamRecvr::SenderQueue::SenderQueue(DataStreamRecvr* parent_recvr, int num
           _is_cancelled(false),
           _num_remaining_senders(num_senders),
           _received_first_batch(false) {}
-
-Status DataStreamRecvr::SenderQueue::get_batch(RowBatch** next_batch) {
-    std::unique_lock<std::mutex> l(_lock);
-    // wait until something shows up or we know we're done
-    while (!_is_cancelled && _batch_queue.empty() && _num_remaining_senders > 0) {
-        VLOG_ROW << "wait arrival fragment_instance_id=" << _recvr->fragment_instance_id()
-                 << " node=" << _recvr->dest_node_id();
-        // Don't count time spent waiting on the sender as active time.
-        CANCEL_SAFE_SCOPED_TIMER(_recvr->_data_arrival_timer, &_is_cancelled);
-        CANCEL_SAFE_SCOPED_TIMER(_received_first_batch ? nullptr : _recvr->_first_batch_wait_total_timer,
-                                 &_is_cancelled);
-        _data_arrival_cv.wait(l);
-    }
-
-    // _cur_batch must be replaced with the returned batch.
-    _current_batch.reset();
-    *next_batch = nullptr;
-    if (_is_cancelled) {
-        return Status::Cancelled("Cancelled SenderQueue::get_batch");
-    }
-
-    if (_batch_queue.empty()) {
-        DCHECK_EQ(_num_remaining_senders, 0);
-        return Status::OK();
-    }
-
-    _received_first_batch = true;
-
-    DCHECK(!_batch_queue.empty());
-    RowBatch* result = _batch_queue.front().second;
-    _recvr->_num_buffered_bytes -= _batch_queue.front().first;
-    VLOG_ROW << "fetched #rows=" << result->num_rows();
-    _batch_queue.pop_front();
-    _current_batch.reset(result);
-    *next_batch = _current_batch.get();
-
-    if (!_pending_closures.empty()) {
-        auto closure_pair = _pending_closures.front();
-        closure_pair.first->Run();
-        _pending_closures.pop_front();
-
-        closure_pair.second.stop();
-        _recvr->_buffer_full_total_timer->update(closure_pair.second.elapsed_time());
-    }
-
-    return Status::OK();
-}
 
 bool DataStreamRecvr::SenderQueue::has_output() const {
     std::lock_guard<std::mutex> l(_lock);
@@ -588,22 +539,6 @@ void DataStreamRecvr::SenderQueue::close() {
     _current_batch.reset();
 }
 
-Status DataStreamRecvr::create_merger(const TupleRowComparator& less_than) {
-    DCHECK(_is_merging);
-    vector<SortedRunMerger::RunBatchSupplier> input_batch_suppliers;
-    input_batch_suppliers.reserve(_sender_queues.size());
-
-    // Create the merger that will a single stream of sorted rows.
-    _merger = std::make_unique<SortedRunMerger>(less_than, &_row_desc, _profile.get(), false);
-
-    for (SenderQueue* q : _sender_queues) {
-        auto f = [q](RowBatch** batch) -> Status { return q->get_batch(batch); };
-        input_batch_suppliers.emplace_back(std::move(f));
-    }
-    RETURN_IF_ERROR(_merger->prepare(input_batch_suppliers));
-    return Status::OK();
-}
-
 Status DataStreamRecvr::create_merger(const SortExecExprs* exprs, const std::vector<bool>* is_asc,
                                       const std::vector<bool>* is_null_first) {
     DCHECK(_is_merging);
@@ -717,11 +652,6 @@ DataStreamRecvr::DataStreamRecvr(DataStreamMgr* stream_mgr, MemTracker* parent_t
     _sender_wait_lock_timer = ADD_TIMER(_profile, "SenderWaitLockTime");
 }
 
-Status DataStreamRecvr::get_next(RowBatch* output_batch, bool* eos) {
-    DCHECK(_merger.get() != nullptr);
-    return _merger->get_next(output_batch, eos);
-}
-
 Status DataStreamRecvr::get_next(vectorized::ChunkPtr* chunk, bool* eos) {
     DCHECK(_chunks_merger.get() != nullptr);
     return _chunks_merger->get_next(chunk, eos);
@@ -775,7 +705,6 @@ void DataStreamRecvr::close() {
     // TODO: log error msg
     _mgr->deregister_recvr(fragment_instance_id(), dest_node_id());
     _mgr = nullptr;
-    _merger.reset();
     _chunks_merger.reset();
     _mem_tracker->close();
     _mem_tracker.reset();
@@ -783,12 +712,6 @@ void DataStreamRecvr::close() {
 
 DataStreamRecvr::~DataStreamRecvr() {
     DCHECK(_mgr == nullptr) << "Must call close()";
-}
-
-Status DataStreamRecvr::get_batch(RowBatch** next_batch) {
-    DCHECK(!_is_merging);
-    DCHECK_EQ(_sender_queues.size(), 1);
-    return _sender_queues[0]->get_batch(next_batch);
 }
 
 Status DataStreamRecvr::get_chunk(std::unique_ptr<vectorized::Chunk>* chunk) {

--- a/be/src/runtime/data_stream_recvr.h
+++ b/be/src/runtime/data_stream_recvr.h
@@ -43,7 +43,6 @@ class SortedChunksMerger;
 }
 
 class DataStreamMgr;
-class SortedRunMerger;
 class MemTracker;
 class RowBatch;
 class RuntimeProfile;
@@ -78,14 +77,6 @@ class DataStreamRecvr {
 public:
     ~DataStreamRecvr();
 
-    // Returns next row batch in data stream; blocks if there aren't any.
-    // Retains ownership of the returned batch. The caller must acquire data from the
-    // returned batch before the next call to get_batch(). A NULL returned batch indicated
-    // eos. Must only be called if _is_merging is false.
-    // TODO: This is currently only exposed to the non-merging version of the exchange.
-    // Refactor so both merging and non-merging exchange use get_next(RowBatch*, bool* eos).
-    Status get_batch(RowBatch** next_batch);
-
     Status get_chunk(std::unique_ptr<vectorized::Chunk>* chunk);
 
     // Deregister from DataStreamMgr instance, which shares ownership of this instance.
@@ -94,7 +85,6 @@ public:
     // Create a SortedRunMerger instance to merge rows from multiple sender according to the
     // specified row comparator. Fetches the first batches from the individual sender
     // queues. The exprs used in less_than must have already been prepared and opened.
-    Status create_merger(const TupleRowComparator& less_than);
     Status create_merger(const SortExecExprs* exprs, const std::vector<bool>* is_asc,
                          const std::vector<bool>* is_null_first);
     Status create_merger_for_pipeline(const SortExecExprs* exprs, const std::vector<bool>* is_asc,
@@ -102,7 +92,6 @@ public:
 
     // Fill output_batch with the next batch of rows obtained by merging the per-sender
     // input streams. Must only be called if _is_merging is true.
-    Status get_next(RowBatch* output_batch, bool* eos);
     Status get_next(vectorized::ChunkPtr* chunk, bool* eos);
     Status get_next_for_pipeline(vectorized::ChunkPtr* chunk, std::atomic<bool>* eos, bool* should_exit);
 
@@ -183,8 +172,6 @@ private:
     // receiver and placed in _sender_queue_pool.
     std::vector<SenderQueue*> _sender_queues;
 
-    // SortedRunMerger used to merge rows from different senders.
-    std::unique_ptr<SortedRunMerger> _merger;
     // vectorized::SortedChunksMerger merges chunks from different senders.
     std::unique_ptr<vectorized::SortedChunksMerger> _chunks_merger;
 


### PR DESCRIPTION
for #627 

Remove unused code of non-vectorized runtime engine from ExchangeNode and DataStreamRecvr