### PR TITLE
reduce thrift object copy of pipeline engine

### DIFF
--- a/be/src/exec/pipeline/fragment_context.h
+++ b/be/src/exec/pipeline/fragment_context.h
@@ -39,7 +39,7 @@ public:
         _fragment_instance_id = fragment_instance_id;
     }
     void set_fe_addr(const TNetworkAddress& fe_addr) { _fe_addr = fe_addr; }
-    TNetworkAddress fe_addr() { return _fe_addr; }
+    const TNetworkAddress& fe_addr() { return _fe_addr; }
     FragmentFuture finish_future() { return _finish_promise.get_future(); }
     MemTracker* mem_tracker() const { return _mem_tracker.get(); }
     void set_mem_tracker(std::unique_ptr<MemTracker> mem_tracker) { _mem_tracker = std::move(mem_tracker); }

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -35,15 +35,23 @@ Morsels convert_scan_range_to_morsel(const std::vector<TScanRangeParams>& scan_r
 }
 
 Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParams& request) {
-    const TPlanFragmentExecParams& params = request.params;
+    DCHECK(request.__isset.desc_tbl);
+    DCHECK(request.__isset.fragment);
+    const auto& params = request.params;
     const auto& query_id = params.query_id;
-    const auto& fragment_id = params.fragment_instance_id;
+    const auto& fragment_instance_id = params.fragment_instance_id;
+    const auto& coord = request.coord;
+    const auto& query_options = request.query_options;
+    const auto& query_globals = request.query_globals;
+    const auto& backend_num = request.backend_num;
+    const auto& t_desc_tbl = request.desc_tbl;
+    const auto& fragment = request.fragment;
 
     // prevent an identical fragment instance from multiple execution caused by FE's
     // duplicate invocations of rpc exec_plan_fragment.
     auto&& existing_query_ctx = QueryContextManager::instance()->get(query_id);
     if (existing_query_ctx) {
-        auto&& existing_fragment_ctx = existing_query_ctx->fragment_mgr()->get(fragment_id);
+        auto&& existing_fragment_ctx = existing_query_ctx->fragment_mgr()->get(fragment_instance_id);
         if (existing_fragment_ctx) {
             return Status::DuplicateRpcInvocation("Duplicate invocations of exec_plan_fragment");
         }
@@ -53,25 +61,25 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
     if (params.__isset.instances_number) {
         _query_ctx->set_total_fragments(params.instances_number);
     }
-    if (request.query_options.__isset.pipeline_query_expire_seconds) {
-        _query_ctx->set_expire_seconds(std::max<int>(request.query_options.pipeline_query_expire_seconds, 1));
+    if (query_options.__isset.pipeline_query_expire_seconds) {
+        _query_ctx->set_expire_seconds(std::max<int>(query_options.pipeline_query_expire_seconds, 1));
     } else {
         _query_ctx->set_expire_seconds(300);
     }
-    _fragment_ctx = _query_ctx->fragment_mgr()->get_or_register(fragment_id);
+
+    _fragment_ctx = _query_ctx->fragment_mgr()->get_or_register(fragment_instance_id);
     _fragment_ctx->set_query_id(query_id);
-    _fragment_ctx->set_fragment_instance_id(fragment_id);
-    _fragment_ctx->set_fe_addr(request.coord);
+    _fragment_ctx->set_fragment_instance_id(fragment_instance_id);
+    _fragment_ctx->set_fe_addr(coord);
 
     LOG(INFO) << "Prepare(): query_id=" << print_id(query_id)
-              << " fragment_instance_id=" << print_id(params.fragment_instance_id)
-              << " backend_num=" << request.backend_num;
+              << " fragment_instance_id=" << print_id(params.fragment_instance_id) << " backend_num=" << backend_num;
 
     _fragment_ctx->set_runtime_state(
-            std::make_unique<RuntimeState>(request, request.query_options, request.query_globals, exec_env));
+            std::make_unique<RuntimeState>(query_id, fragment_instance_id, query_options, query_globals, exec_env));
     auto* runtime_state = _fragment_ctx->runtime_state();
 
-    int64_t bytes_limit = request.query_options.mem_limit;
+    int64_t bytes_limit = query_options.mem_limit;
     // NOTE: this MemTracker only for olap
     _fragment_ctx->set_mem_tracker(
             std::make_unique<MemTracker>(bytes_limit, "fragment mem-limit", exec_env->query_pool_mem_tracker(), true));
@@ -79,7 +87,7 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
 
     runtime_state->set_batch_size(config::vector_chunk_size);
     RETURN_IF_ERROR(runtime_state->init_mem_trackers(query_id));
-    runtime_state->set_be_number(request.backend_num);
+    runtime_state->set_be_number(backend_num);
     runtime_state->set_fragment_mem_tracker(mem_tracker);
 
     LOG(INFO) << "Using query memory limit: " << PrettyPrinter::print(bytes_limit, TUnit::BYTES);
@@ -87,13 +95,11 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
     // Set up desc tbl
     auto* obj_pool = runtime_state->obj_pool();
     DescriptorTbl* desc_tbl = nullptr;
-    DCHECK(request.__isset.desc_tbl);
-    RETURN_IF_ERROR(DescriptorTbl::create(obj_pool, request.desc_tbl, &desc_tbl));
+    RETURN_IF_ERROR(DescriptorTbl::create(obj_pool, t_desc_tbl, &desc_tbl));
     runtime_state->set_desc_tbl(desc_tbl);
     // Set up plan
     ExecNode* plan = nullptr;
-    DCHECK(request.__isset.fragment);
-    RETURN_IF_ERROR(ExecNode::create_tree(runtime_state, obj_pool, request.fragment.plan, *desc_tbl, &plan));
+    RETURN_IF_ERROR(ExecNode::create_tree(runtime_state, obj_pool, fragment.plan, *desc_tbl, &plan));
     runtime_state->set_fragment_root_id(plan->id());
     _fragment_ctx->set_plan(plan);
 
@@ -106,16 +112,16 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
     }
 
     int32_t degree_of_parallelism = 1;
-    if (request.query_options.__isset.query_threads) {
-        degree_of_parallelism = std::max<int32_t>(request.query_options.query_threads, degree_of_parallelism);
+    if (query_options.__isset.query_threads) {
+        degree_of_parallelism = std::max<int32_t>(query_options.query_threads, degree_of_parallelism);
     }
 
     // pipeline scan mode
     // 0: use sync io
     // 1: use async io and exec->thread_pool()
     int32_t pipeline_scan_mode = 1;
-    if (request.query_options.__isset.pipeline_scan_mode) {
-        pipeline_scan_mode = request.query_options.pipeline_scan_mode;
+    if (query_options.__isset.pipeline_scan_mode) {
+        pipeline_scan_mode = query_options.pipeline_scan_mode;
     }
 
     // set scan ranges
@@ -137,10 +143,10 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
     _fragment_ctx->set_pipelines(builder.build(*_fragment_ctx, plan));
     // Set up sink, if required
     std::unique_ptr<DataSink> sink;
-    if (request.fragment.__isset.output_sink) {
+    if (fragment.__isset.output_sink) {
         RowDescriptor row_desc;
-        RETURN_IF_ERROR(DataSink::create_data_sink(obj_pool, request.fragment.output_sink,
-                                                   request.fragment.output_exprs, params, row_desc, &sink));
+        RETURN_IF_ERROR(DataSink::create_data_sink(obj_pool, fragment.output_sink, fragment.output_exprs, params,
+                                                   row_desc, &sink));
         RuntimeProfile* sink_profile = sink->profile();
         if (sink_profile != nullptr) {
             runtime_state->runtime_profile()->add_child(sink_profile, true, nullptr);

--- a/be/src/exec/pipeline/scan_operator.h
+++ b/be/src/exec/pipeline/scan_operator.h
@@ -80,7 +80,7 @@ public:
     void close(RuntimeState* state) override;
 
 private:
-    TOlapScanNode _olap_scan_node;
+    const TOlapScanNode& _olap_scan_node;
     std::vector<ExprContext*> _conjunct_ctxs;
     vectorized::RuntimeFilterProbeCollector _runtime_filters;
 };

--- a/be/src/exec/vectorized/aggregate/aggregate_base_node.h
+++ b/be/src/exec/vectorized/aggregate/aggregate_base_node.h
@@ -20,7 +20,7 @@ public:
                                        vectorized::RuntimeFilterProbeCollector* collector) override;
 
 protected:
-    const TPlanNode _tnode;
+    const TPlanNode& _tnode;
     AggregatorPtr _aggregator = nullptr;
     bool _child_eos = false;
 };

--- a/be/src/exec/vectorized/aggregator.h
+++ b/be/src/exec/vectorized/aggregator.h
@@ -149,9 +149,8 @@ public:
 #endif
 
 private:
-    // used to init
-    const TPlanNode _tnode;
-    const RowDescriptor _child_row_desc;
+    const TPlanNode& _tnode;
+    const RowDescriptor& _child_row_desc;
 
     ObjectPool* _pool;
     std::unique_ptr<MemPool> _mem_pool;

--- a/be/src/exec/vectorized/analytor.h
+++ b/be/src/exec/vectorized/analytor.h
@@ -125,8 +125,8 @@ public:
 #endif
 
 private:
-    const TPlanNode _tnode;
-    const RowDescriptor _child_row_desc;
+    const TPlanNode& _tnode;
+    const RowDescriptor& _child_row_desc;
     const TupleDescriptor* _result_tuple_desc;
     ObjectPool* _pool;
     MemTracker* _mem_tracker;

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -71,7 +71,8 @@ Status PlanFragmentExecutor::prepare(const TExecPlanFragmentParams& request) {
               << " fragment_instance_id=" << print_id(params.fragment_instance_id)
               << " backend_num=" << request.backend_num;
 
-    _runtime_state = std::make_unique<RuntimeState>(request, request.query_options, request.query_globals, _exec_env);
+    _runtime_state = std::make_unique<RuntimeState>(params.query_id, params.fragment_instance_id, request.query_options,
+                                                    request.query_globals, _exec_env);
 
     if (_is_vectorized) {
         _runtime_state->set_batch_size(config::vector_chunk_size);

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -64,11 +64,11 @@ RuntimeState::RuntimeState(const TUniqueId& fragment_instance_id, const TQueryOp
     DCHECK(status.ok());
 }
 
-RuntimeState::RuntimeState(const TExecPlanFragmentParams& fragment_params, const TQueryOptions& query_options,
-                           const TQueryGlobals& query_globals, ExecEnv* exec_env)
-        : _profile("Fragment " + print_id(fragment_params.params.fragment_instance_id)),
+RuntimeState::RuntimeState(const TUniqueId& query_id, const TUniqueId& fragment_instance_id,
+                           const TQueryOptions& query_options, const TQueryGlobals& query_globals, ExecEnv* exec_env)
+        : _profile("Fragment " + print_id(fragment_instance_id)),
           _unreported_error_idx(0),
-          _query_id(fragment_params.params.query_id),
+          _query_id(query_id),
           _obj_pool(new ObjectPool()),
           _is_cancelled(false),
           _per_fragment_instance_idx(0),
@@ -76,8 +76,9 @@ RuntimeState::RuntimeState(const TExecPlanFragmentParams& fragment_params, const
           _num_rows_load_total(0),
           _num_rows_load_filtered(0),
           _num_rows_load_unselected(0),
+
           _num_print_error_rows(0) {
-    Status status = init(fragment_params.params.fragment_instance_id, query_options, query_globals, exec_env);
+    Status status = init(fragment_instance_id, query_options, query_globals, exec_env);
     DCHECK(status.ok());
 }
 

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -67,7 +67,7 @@ public:
     RuntimeState(const TUniqueId& fragment_instance_id, const TQueryOptions& query_options,
                  const TQueryGlobals& query_globals, ExecEnv* exec_env);
 
-    RuntimeState(const TExecPlanFragmentParams& fragment_params, const TQueryOptions& query_options,
+    RuntimeState(const TUniqueId& query_id, const TUniqueId& fragment_instance_id, const TQueryOptions& query_options,
                  const TQueryGlobals& query_globals, ExecEnv* exec_env);
 
     // RuntimeState for executing expr in fe-support.

--- a/be/src/runtime/test_env.cc
+++ b/be/src/runtime/test_env.cc
@@ -69,7 +69,8 @@ RuntimeState* TestEnv::create_runtime_state(int64_t query_id) {
     TExecPlanFragmentParams plan_params = TExecPlanFragmentParams();
     plan_params.params.query_id.hi = 0;
     plan_params.params.query_id.lo = query_id;
-    return new RuntimeState(plan_params, TQueryOptions(), TQueryGlobals(), _exec_env.get());
+    return new RuntimeState(plan_params.params.query_id, plan_params.params.fragment_instance_id, TQueryOptions(),
+                            TQueryGlobals(), _exec_env.get());
 }
 
 Status TestEnv::create_query_state(int64_t query_id, int max_buffers, int block_size, RuntimeState** runtime_state) {

--- a/be/src/storage/push_handler.cpp
+++ b/be/src/storage/push_handler.cpp
@@ -469,7 +469,8 @@ OLAPStatus PushBrokerReader::init(const Schema* schema, const TBrokerScanRange& 
     TQueryOptions query_options;
     TQueryGlobals query_globals;
     _runtime_state =
-            std::make_unique<RuntimeState>(fragment_params, query_options, query_globals, ExecEnv::GetInstance());
+            std::make_unique<RuntimeState>(fragment_params.params.query_id, fragment_params.params.fragment_instance_id,
+                                           query_options, query_globals, ExecEnv::GetInstance());
     DescriptorTbl* desc_tbl = nullptr;
     Status status = DescriptorTbl::create(_runtime_state->obj_pool(), t_desc_tbl, &desc_tbl);
     if (UNLIKELY(!status.ok())) {

--- a/be/src/storage/vectorized/push_handler.cpp
+++ b/be/src/storage/vectorized/push_handler.cpp
@@ -31,7 +31,8 @@ Status PushBrokerReader::init(const TBrokerScanRange& t_scan_range, const TDescr
     TQueryOptions query_options;
     TQueryGlobals query_globals;
     _runtime_state =
-            std::make_unique<RuntimeState>(fragment_params, query_options, query_globals, ExecEnv::GetInstance());
+            std::make_unique<RuntimeState>(fragment_params.params.query_id, fragment_params.params.fragment_instance_id,
+                                           query_options, query_globals, ExecEnv::GetInstance());
 
     DescriptorTbl* desc_tbl = nullptr;
     RETURN_IF_ERROR(DescriptorTbl::create(_runtime_state->obj_pool(), t_desc_tbl, &desc_tbl));

--- a/be/test/exec/pipeline/pipeline_test_base.cpp
+++ b/be/test/exec/pipeline/pipeline_test_base.cpp
@@ -37,7 +37,8 @@ void PipelineTestBase::_prepare() {
     _fragment_ctx->set_query_id(query_id);
     _fragment_ctx->set_fragment_instance_id(fragment_id);
     _fragment_ctx->set_runtime_state(
-            std::make_unique<RuntimeState>(_request, _request.query_options, _request.query_globals, _exec_env));
+            std::make_unique<RuntimeState>(_request.params.query_id, _request.params.fragment_instance_id,
+                                           _request.query_options, _request.query_globals, _exec_env));
 
     _fragment_future = _fragment_ctx->finish_future();
     _runtime_state = _fragment_ctx->runtime_state();


### PR DESCRIPTION
reduce thrift object(create and destroy in io thread) copy for pipeline engine, here are two situations:

1. if thrift object is used in prepare state (synchronously invokde), reference is just fine cause thrift obj is still alive 
2. if thirft object is used in execution state (Asynchronously invoked), copy is inevitable cause thrift obj is already dead