### PR TITLE
Reject request with no SQL in TableQueryPlanAction

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/TableQueryPlanAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/TableQueryPlanAction.java
@@ -119,7 +119,7 @@ public class TableQueryPlanAction extends RestBaseAction {
             } catch (JSONException e) {
                 throw new StarRocksHttpException(HttpResponseStatus.BAD_REQUEST, "malformed json [ " + postContent + " ]");
             }
-            sql = String.valueOf(jsonObject.opt("sql"));
+            sql = jsonObject.optString("sql");
             if (Strings.isNullOrEmpty(sql)) {
                 throw new StarRocksHttpException(HttpResponseStatus.BAD_REQUEST,
                         "POST body must contains [sql] root object");

--- a/fe/fe-core/src/test/java/com/starrocks/http/TableQueryPlanActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/TableQueryPlanActionTest.java
@@ -85,6 +85,27 @@ public class TableQueryPlanActionTest extends StarRocksHttpTestCase {
     }
 
     @Test
+    public void testNoSqlFailure() throws IOException {
+        RequestBody body = RequestBody
+            .create(JSON, "{}");
+        Request request = new Request.Builder()
+            .post(body)
+            .addHeader("Authorization", rootAuth)
+            .url(URI + PATH_URI)
+            .build();
+        Response response = networkClient.newCall(request).execute();
+        String respStr = Objects.requireNonNull(response.body()).string();
+        System.out.println(respStr);
+        Assert.assertNotNull(respStr);
+        expectThrowsNoException(() -> new JSONObject(respStr));
+        JSONObject jsonObject = new JSONObject(respStr);
+        Assert.assertEquals(400, jsonObject.getInt("status"));
+        String exception = jsonObject.getString("exception");
+        Assert.assertNotNull(exception);
+        Assert.assertEquals("POST body must contains [sql] root object", exception);
+    }
+
+    @Test
     public void testInconsistentResource() throws IOException {
         RequestBody body = RequestBody
                 .create(JSON, "{ \"sql\" :  \" select k1,k2 from " + DB_NAME + "." + TABLE_NAME + 1 + " \" }");


### PR DESCRIPTION
For #643

String.valueOf() returns string "null" with null input, in which case requests with no SQL will be accepted by TableQueryPlanAction unexpectedly with potential risk.

