### PR TITLE
optimize NullableColumn::serialize_batch for FixedLengthColumnBase

### DIFF
--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -211,8 +211,26 @@ public:
         return 0;
     };
 
-    virtual void serialize_batch_with_null_vector(uint8_t* dst, Buffer<uint32_t>& slice_sizes, size_t chunk_size,
-                                                  uint32_t max_one_row_size, uint8_t* null_vector) {}
+    virtual void serialize_batch_with_null_masks(uint8_t* dst, Buffer<uint32_t>& slice_sizes, size_t chunk_size,
+                                                 uint32_t max_one_row_size, uint8_t* null_masks, bool has_null) {
+        uint32_t* sizes = slice_sizes.data();
+
+        if (!has_null) {
+            for (size_t i = 0; i < chunk_size; ++i) {
+                memcpy(dst + i * max_one_row_size + sizes[i], &has_null, sizeof(bool));
+                sizes[i] += 1 + serialize(i, dst + i * max_one_row_size + sizes[i]);
+            }
+        } else {
+            for (size_t i = 0; i < chunk_size; ++i) {
+                memcpy(dst + i * max_one_row_size + sizes[i], null_masks + i, sizeof(bool));
+                sizes[i] += 1;
+
+                if (null_masks[i]) {
+                    sizes[i] += serialize(i, dst + i * max_one_row_size + sizes[i]);
+                }
+            }
+        }
+    }
 
     // deserialize one data and append to this column
     virtual const uint8_t* deserialize_and_append(const uint8_t* pos) = 0;

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -211,6 +211,9 @@ public:
         return 0;
     };
 
+    virtual void serialize_batch_with_null_vector(uint8_t* dst, Buffer<uint32_t>& slice_sizes, size_t chunk_size,
+                                                  uint32_t max_one_row_size, uint8_t* null_vector) {}
+
     // deserialize one data and append to this column
     virtual const uint8_t* deserialize_and_append(const uint8_t* pos) = 0;
 

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -211,6 +211,7 @@ public:
         return 0;
     };
 
+    // A dedicated serialization method used by NullableColumn to serialize data columns with null_masks.
     virtual void serialize_batch_with_null_masks(uint8_t* dst, Buffer<uint32_t>& slice_sizes, size_t chunk_size,
                                                  uint32_t max_one_row_size, uint8_t* null_masks, bool has_null) {
         uint32_t* sizes = slice_sizes.data();

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -219,14 +219,14 @@ public:
         if (!has_null) {
             for (size_t i = 0; i < chunk_size; ++i) {
                 memcpy(dst + i * max_one_row_size + sizes[i], &has_null, sizeof(bool));
-                sizes[i] += 1 + serialize(i, dst + i * max_one_row_size + sizes[i]);
+                sizes[i] += sizeof(bool) + serialize(i, dst + i * max_one_row_size + sizes[i] + sizeof(bool));
             }
         } else {
             for (size_t i = 0; i < chunk_size; ++i) {
                 memcpy(dst + i * max_one_row_size + sizes[i], null_masks + i, sizeof(bool));
-                sizes[i] += 1;
+                sizes[i] += sizeof(bool);
 
-                if (null_masks[i]) {
+                if (!null_masks[i]) {
                     sizes[i] += serialize(i, dst + i * max_one_row_size + sizes[i]);
                 }
             }

--- a/be/src/column/fixed_length_column_base.cpp
+++ b/be/src/column/fixed_length_column_base.cpp
@@ -115,12 +115,13 @@ void FixedLengthColumnBase<T>::serialize_batch_with_null_vector(uint8_t* __restr
 
     for (size_t i = 0; i < chunk_size; ++i) {
         memcpy(dst + i * max_one_row_size + sizes[i], null_vector + i, sizeof(bool));
-        sizes[i] += 1;
-
         if (!null_vector[i]) {
-            memcpy(dst + i * max_one_row_size + sizes[i], src + i, sizeof(T));
-            sizes[i] += sizeof(T);
+            memcpy(dst + i * max_one_row_size + sizes[i] + 1, src + i, sizeof(T));
         }
+    }
+
+    for (size_t i = 0; i < chunk_size; ++i) {
+        sizes[i] += (1 - null_vector[i]) * sizeof(T) + 1;
     }
 }
 

--- a/be/src/column/fixed_length_column_base.cpp
+++ b/be/src/column/fixed_length_column_base.cpp
@@ -116,22 +116,22 @@ void FixedLengthColumnBase<T>::serialize_batch_with_null_masks(uint8_t* __restri
     if (!has_null) {
         for (size_t i = 0; i < chunk_size; ++i) {
             memcpy(dst + i * max_one_row_size + sizes[i], &has_null, sizeof(bool));
-            memcpy(dst + i * max_one_row_size + sizes[i] + 1, src + i, sizeof(T));
+            memcpy(dst + i * max_one_row_size + sizes[i] + sizeof(bool), src + i, sizeof(T));
         }
 
         for (size_t i = 0; i < chunk_size; ++i) {
-            sizes[i] += 1 + sizeof(T);
+            sizes[i] += sizeof(bool) + sizeof(T);
         }
     } else {
         for (size_t i = 0; i < chunk_size; ++i) {
             memcpy(dst + i * max_one_row_size + sizes[i], null_masks + i, sizeof(bool));
             if (!null_masks[i]) {
-                memcpy(dst + i * max_one_row_size + sizes[i] + 1, src + i, sizeof(T));
+                memcpy(dst + i * max_one_row_size + sizes[i] + sizeof(bool), src + i, sizeof(T));
             }
         }
 
         for (size_t i = 0; i < chunk_size; ++i) {
-            sizes[i] += 1 + (1 - null_masks[i]) * sizeof(T);
+            sizes[i] += sizeof(bool) + (1 - null_masks[i]) * sizeof(T);
         }
     }
 }

--- a/be/src/column/fixed_length_column_base.cpp
+++ b/be/src/column/fixed_length_column_base.cpp
@@ -107,6 +107,24 @@ void FixedLengthColumnBase<T>::serialize_batch(uint8_t* __restrict__ dst, Buffer
 }
 
 template <typename T>
+void FixedLengthColumnBase<T>::serialize_batch_with_null_vector(uint8_t* __restrict__ dst,
+                                                                Buffer<uint32_t>& slice_sizes, size_t chunk_size,
+                                                                uint32_t max_one_row_size, uint8_t* null_vector) {
+    uint32_t* sizes = slice_sizes.data();
+    T* __restrict__ src = _data.data();
+
+    for (size_t i = 0; i < chunk_size; ++i) {
+        memcpy(dst + i * max_one_row_size + sizes[i], null_vector + i, sizeof(bool));
+        sizes[i] += 1;
+
+        if (!null_vector[i]) {
+            memcpy(dst + i * max_one_row_size + sizes[i], src + i, sizeof(T));
+            sizes[i] += sizeof(T);
+        }
+    }
+}
+
+template <typename T>
 size_t FixedLengthColumnBase<T>::serialize_batch_at_interval(uint8_t* dst, size_t byte_offset, size_t byte_interval,
                                                              size_t start, size_t count) {
     const size_t value_size = sizeof(T);

--- a/be/src/column/fixed_length_column_base.h
+++ b/be/src/column/fixed_length_column_base.h
@@ -130,8 +130,8 @@ public:
     void serialize_batch(uint8_t* dst, Buffer<uint32_t>& slice_sizes, size_t chunk_size,
                          uint32_t max_one_row_size) override;
 
-    void serialize_batch_with_null_vector(uint8_t* dst, Buffer<uint32_t>& slice_sizes, size_t chunk_size,
-                                          uint32_t max_one_row_size, uint8_t* null_vector) override;
+    void serialize_batch_with_null_masks(uint8_t* dst, Buffer<uint32_t>& slice_sizes, size_t chunk_size,
+                                         uint32_t max_one_row_size, uint8_t* null_masks, bool has_null) override;
 
     size_t serialize_batch_at_interval(uint8_t* dst, size_t byte_offset, size_t byte_interval, size_t start,
                                        size_t count) override;

--- a/be/src/column/fixed_length_column_base.h
+++ b/be/src/column/fixed_length_column_base.h
@@ -130,6 +130,9 @@ public:
     void serialize_batch(uint8_t* dst, Buffer<uint32_t>& slice_sizes, size_t chunk_size,
                          uint32_t max_one_row_size) override;
 
+    void serialize_batch_with_null_vector(uint8_t* dst, Buffer<uint32_t>& slice_sizes, size_t chunk_size,
+                                          uint32_t max_one_row_size, uint8_t* null_vector) override;
+
     size_t serialize_batch_at_interval(uint8_t* dst, size_t byte_offset, size_t byte_interval, size_t start,
                                        size_t count) override;
 

--- a/be/src/column/nullable_column.cpp
+++ b/be/src/column/nullable_column.cpp
@@ -213,8 +213,8 @@ size_t NullableColumn::serialize_batch_at_interval(uint8_t* dst, size_t byte_off
 
 void NullableColumn::serialize_batch(uint8_t* dst, Buffer<uint32_t>& slice_sizes, size_t chunk_size,
                                      uint32_t max_one_row_size) {
-    _data_column->serialize_batch_with_null_vector(dst, slice_sizes, chunk_size, max_one_row_size,
-                                                   _null_column->get_data().data());
+    _data_column->serialize_batch_with_null_masks(dst, slice_sizes, chunk_size, max_one_row_size,
+                                                  _null_column->get_data().data(), _has_null);
 }
 
 const uint8_t* NullableColumn::deserialize_and_append(const uint8_t* pos) {

--- a/be/src/column/nullable_column.cpp
+++ b/be/src/column/nullable_column.cpp
@@ -213,9 +213,8 @@ size_t NullableColumn::serialize_batch_at_interval(uint8_t* dst, size_t byte_off
 
 void NullableColumn::serialize_batch(uint8_t* dst, Buffer<uint32_t>& slice_sizes, size_t chunk_size,
                                      uint32_t max_one_row_size) {
-    for (size_t i = 0; i < chunk_size; ++i) {
-        slice_sizes[i] += serialize(i, dst + i * max_one_row_size + slice_sizes[i]);
-    }
+    _data_column->serialize_batch_with_null_vector(dst, slice_sizes, chunk_size, max_one_row_size,
+                                                   _null_column->get_data().data());
 }
 
 const uint8_t* NullableColumn::deserialize_and_append(const uint8_t* pos) {


### PR DESCRIPTION
Add `serialize_batch_with_null_vector` to base class `Column`, and implement an optimized version for `FixedLengthColumnBase`.

Close #619.

----
The information of benchmark test is as follows:
- Dataset: [New York Taxi Data](https://clickhouse.com/docs/en/getting-started/example-datasets/nyc-taxi/).
- The number of rows: 12_9897_9494.
- Query SQL:
``` SQL
-- Q3
SELECT passenger_count, year(pickup_date) AS year_, count(*) 
FROM trips_mergetree 
GROUP BY passenger_count, year_;

-- Q4
SELECT passenger_count, year(pickup_date) AS year_, round(trip_distance) AS distance, count(*) 
FROM trips_mergetree 
GROUP BY passenger_count, year_, distance 
ORDER BY year_, count(*) DESC;
```

`passenger_count` is `int8`, `trip_distance` is `float64`, and the  return type of `year()` is nullable `int32`.



The followings are the cost time before and after the optimization:

Q3:
| Parallel | Before (ms) | After (ms) |
| -------- | ----------- | ---------- |
| 1        | 6989        | 6271       |
| 2        | 3558        | 3253       |
| 4        | 1913        | 1676       |
| 8        | 1321        | 1256       |
| 16       | 1037        | 936        |

Q4:
| Parallel | Before (ms) | After (ms) |
| -------- | ----------- | ---------- |
| 1        | 7860        | 8017       |
| 2        | 4143        | 4159       |
| 4        | 2148        | 2191       |
| 8        | 1673        | 1623       |
| 16       | 1417        | 1381       |

And the cost time rate of `NullableColumn<T>::serialize_batch` before and after the optimization are 9.36% and 5.42%, respectively.