### PR TITLE
[ISSUE-661]Pipeline dependencies in multi-input ExecNode's decomposition

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -129,6 +129,7 @@ set(EXEC_FILES
     pipeline/exchange/local_exchange_source_operator.cpp
     pipeline/fragment_executor.cpp
     pipeline/operator.cpp
+    pipeline/operator_with_dependency.cpp
     pipeline/limit_operator.cpp
     pipeline/olap_chunk_source.cpp
     pipeline/pipeline_builder.cpp

--- a/be/src/exec/pipeline/operator_with_dependency.cpp
+++ b/be/src/exec/pipeline/operator_with_dependency.cpp
@@ -1,0 +1,15 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+#include "exec/pipeline/operator_with_dependency.h"
+
+#include "exec/pipeline/pipeline_fwd.h"
+
+namespace starrocks {
+namespace pipeline {
+
+OperatorWithDependency::OperatorWithDependency(int32_t id, const std::string& name, int32_t plan_node_id)
+        : Operator(id, name, plan_node_id) {}
+
+OperatorWithDependencyFactory::OperatorWithDependencyFactory(int32_t id, const std::string& name, int32_t plan_node_id)
+        : OperatorFactory(id, name, plan_node_id) {}
+} // namespace pipeline
+} // namespace starrocks

--- a/be/src/exec/pipeline/operator_with_dependency.h
+++ b/be/src/exec/pipeline/operator_with_dependency.h
@@ -10,19 +10,19 @@
 namespace starrocks {
 namespace pipeline {
 // OperatorWithDependency is used to decompose multi-input ExecNode, such as HashJoinNode, CrossJoinNode and etc.
-// In multi-input ExecNode, left child is evaluated in ExecNode::open() at first, then chunks are pulled from
-// right child one by one in ExecNode::get_next(). Every multi-input ExecNode(e.g. HashJoinNode) is decomposed into
+// In multi-input ExecNode, right child is evaluated in ExecNode::open() at first, then chunks are pulled from
+// left child one by one in ExecNode::get_next(). Every multi-input ExecNode(e.g. HashJoinNode) is decomposed into
 // two operators (HashJoinProbeOperator and HashJoinBuildOperator) for both sides. The operators corresponding
 // left side and right side are denoted as left operator(HashJoinProbeOperator) and right operator(HashJoinBuildOperator)
 // respectively. The right operator(HashJoinBuildOperator) should be full materialized, so it is used as the SinkOperator
 // of a pipeline, The left operator(HashJoinProbeOperator) can work in streaming-style, so it can appear in the middle
 // of another pipeline. Denotes pipeline contains left operator and right operator as left pipeline and right pipeline
 // respectively, so left pipeline always has a data dependency on right pipeline, left pipeline can be scheduled to
-// execute on core until left pipeline has finished. For a left pipeline, it shall get stuck in left operator.
+// execute on core until right pipeline has finished. For a left pipeline, it shall get stuck in left operator.
 // OperatorWithDependency is introduced so that left operators should inherit from it. When a left pipeline get stuck
-// in left operator, it should be guarded by PipelineDriverPoller thread that will inspect std::vector<OperatorWithDependency*>
-// PipelineDriver::_dependencies to to ensure that left pipeline is put back into multi-level feedback queue after all
-// left operators has been ready, i.e. OperatorWithDependency::is_ready() returns true.
+// in left operators, it should be guarded by PipelineDriverPoller thread that will inspect std::vector<OperatorWithDependency*>
+// PipelineDriver::_dependencies to ensure that left pipeline is put back into multi-level feedback queue after all
+// right operators have been ready, i.e. OperatorWithDependency::is_ready() returns true.
 class OperatorWithDependency;
 using DriverDependencyPtr = OperatorWithDependency*;
 using DriverDependencies = std::vector<DriverDependencyPtr>;

--- a/be/src/exec/pipeline/operator_with_dependency.h
+++ b/be/src/exec/pipeline/operator_with_dependency.h
@@ -1,0 +1,45 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#pragma once
+#include <string>
+#include <vector>
+
+#include "exec/pipeline/operator.h"
+#include "exec/pipeline/pipeline_fwd.h"
+
+namespace starrocks {
+namespace pipeline {
+// OperatorWithDependency is used to decompose multi-input ExecNode, such as HashJoinNode, CrossJoinNode and etc.
+// In multi-input ExecNode, left child is evaluated in ExecNode::open() at first, then chunks are pulled from
+// right child one by one in ExecNode::get_next(). Every multi-input ExecNode(e.g. HashJoinNode) is decomposed into
+// two operators (HashJoinProbeOperator and HashJoinBuildOperator) for both sides. The operators corresponding
+// left side and right side are denoted as left operator(HashJoinProbeOperator) and right operator(HashJoinBuildOperator)
+// respectively. The right operator(HashJoinBuildOperator) should be full materialized, so it is used as the SinkOperator
+// of a pipeline, The left operator(HashJoinProbeOperator) can work in streaming-style, so it can appear in the middle
+// of another pipeline. Denotes pipeline contains left operator and right operator as left pipeline and right pipeline
+// respectively, so left pipeline always has a data dependency on right pipeline, left pipeline can be scheduled to
+// execute on core until left pipeline has finished. For a left pipeline, it shall get stuck in left operator.
+// OperatorWithDependency is introduced so that left operators should inherit from it. When a left pipeline get stuck
+// in left operator, it should be guarded by PipelineDriverPoller thread that will inspect std::vector<OperatorWithDependency*>
+// PipelineDriver::_dependencies to to ensure that left pipeline is put back into multi-level feedback queue after all
+// left operators has been ready, i.e. OperatorWithDependency::is_ready() returns true.
+class OperatorWithDependency;
+using DriverDependencyPtr = OperatorWithDependency*;
+using DriverDependencies = std::vector<DriverDependencyPtr>;
+
+class OperatorWithDependency : public Operator {
+public:
+    OperatorWithDependency(int32_t id, const std::string& name, int32_t plan_node_id);
+    ~OperatorWithDependency() = default;
+    // return true if the corresponding right operator is full materialized, otherwise return false.
+    virtual bool is_ready() const = 0;
+};
+
+class OperatorWithDependencyFactory : public OperatorFactory {
+public:
+    OperatorWithDependencyFactory(int32_t id, const std::string& name, int32_t plan_node_id);
+    ~OperatorWithDependencyFactory() = default;
+};
+
+} // namespace pipeline
+} // namespace starrocks

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -135,9 +135,9 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state) {
             driver_acct().increment_schedule_times();
             driver_acct().update_last_chunks_moved(total_chunks_moved);
             driver_acct().update_last_time_spent(time_spent);
-            if (dependencies_stuck()) {
-                _state = DriverState::DEPENDENCIES_STUCK;
-                return DriverState::DEPENDENCIES_STUCK;
+            if (dependencies_block()) {
+                _state = DriverState::DEPENDENCIES_BLOCK;
+                return DriverState::DEPENDENCIES_BLOCK;
             } else if (!sink_operator()->is_finished() && !sink_operator()->need_input()) {
                 _state = DriverState::OUTPUT_FULL;
                 return DriverState::OUTPUT_FULL;

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -30,7 +30,7 @@ enum DriverState : uint32_t {
     RUNNING = 2,
     INPUT_EMPTY = 3,
     OUTPUT_FULL = 4,
-    DEPENDENCIES_STUCK = 5,
+    DEPENDENCIES_BLOCK = 5,
     FINISH = 6,
     CANCELED = 7,
     INTERNAL_ERROR = 8,
@@ -52,8 +52,8 @@ static inline std::string ds_to_string(DriverState ds) {
         return "INPUT_EMPTY";
     case OUTPUT_FULL:
         return "OUTPUT_FULL";
-    case DEPENDENCIES_STUCK:
-        return "DEPENDENCIES_STUCK";
+    case DEPENDENCIES_BLOCK:
+        return "DEPENDENCIES_BLOCK";
     case FINISH:
         return "FINISH";
     case CANCELED:
@@ -142,8 +142,8 @@ public:
                _state == DriverState::INTERNAL_ERROR;
     }
     bool pending_finish() { return _state == DriverState::PENDING_FINISH; }
-    // return true if all the dependencies are ready, otherwise return false.
-    bool dependencies_stuck() {
+    // return false if all the dependencies are ready, otherwise return true.
+    bool dependencies_block() {
         if (_all_dependencies_ready) {
             return false;
         }
@@ -153,8 +153,8 @@ public:
     }
 
     bool is_not_blocked() {
-        if (UNLIKELY(_state == DriverState::DEPENDENCIES_STUCK)) {
-            return !dependencies_stuck();
+        if (UNLIKELY(_state == DriverState::DEPENDENCIES_BLOCK)) {
+            return !dependencies_block();
         } else if (_state == DriverState::OUTPUT_FULL) {
             return sink_operator()->need_input() || sink_operator()->is_finished();
         } else if (_state == DriverState::INPUT_EMPTY) {

--- a/be/src/exec/pipeline/pipeline_driver_dispatcher.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_dispatcher.cpp
@@ -77,6 +77,7 @@ void GlobalDriverDispatcher::run() {
             finalize_driver(driver, runtime_state, driver->driver_state());
             continue;
         }
+
         // query context has ready drivers to run, so extend its lifetime.
         query_ctx->extend_lifetime();
         auto status = driver->process(runtime_state);
@@ -114,7 +115,8 @@ void GlobalDriverDispatcher::run() {
         }
         case INPUT_EMPTY:
         case OUTPUT_FULL:
-        case PENDING_FINISH: {
+        case PENDING_FINISH:
+        case DEPENDENCIES_STUCK: {
             VLOG_ROW << strings::Substitute("[Driver] Blocked, source=$0, state=$1",
                                             driver->source_operator()->get_name(), ds_to_string(driver_state));
             _blocked_driver_poller->add_blocked_driver(driver);

--- a/be/src/exec/pipeline/pipeline_driver_dispatcher.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_dispatcher.cpp
@@ -116,7 +116,7 @@ void GlobalDriverDispatcher::run() {
         case INPUT_EMPTY:
         case OUTPUT_FULL:
         case PENDING_FINISH:
-        case DEPENDENCIES_STUCK: {
+        case DEPENDENCIES_BLOCK: {
             VLOG_ROW << strings::Substitute("[Driver] Blocked, source=$0, state=$1",
                                             driver->source_operator()->get_name(), ds_to_string(driver_state));
             _blocked_driver_poller->add_blocked_driver(driver);


### PR DESCRIPTION
For a multi-input ExecNode, such as HashJoinNode, CrossJoinNode and etc. Right child is evaluated in ExecNode::open() at first, then chunks are pulled from left child one by one in ExecNode::get_next(). When a multi-input ExecNode(e.g. HashJoinNode) is decomposed into pipelines, it is parted into two operators (HashJoinProbeOperator and HashJoinBuildOperator) for both sides. The operators corresponding left side and right side are denoted as left operator(HashJoinProbeOperator) and right operator(HashJoinBuildOperator) respectively. The right operator(HashJoinBuildOperator) should be full materialized, so it is used as the SinkOperator of a pipeline, The left operator(HashJoinProbeOperator) can work in streaming-style, so it can appear in the middle of another pipeline. Denotes pipeline contains left operator and right operator as left pipeline and right pipeline respectively, so left pipeline always has a data dependency on right pipeline, the left pipeline can be scheduled to execute on core until the right pipeline has finished.

For a left pipeline, it shall get stuck in left operator. OperatorWithDependency is introduced so that left operators should inherit from it. When a left pipeline get stuck in left operator, it should be guarded by PipelineDriverPoller thread that will inspect std::vector<OperatorWithDependency*> PipelineDriver::_dependencies to to ensure that left pipeline can be put back into multi-level feedback queue after all right operators have been ready, i.e. OperatorWithDependency::is_ready() returns true.