### PR TITLE
remove fragment mem tracker from RuntimeState

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -83,12 +83,10 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
     // NOTE: this MemTracker only for olap
     _fragment_ctx->set_mem_tracker(
             std::make_unique<MemTracker>(bytes_limit, "fragment mem-limit", exec_env->query_pool_mem_tracker(), true));
-    auto mem_tracker = _fragment_ctx->mem_tracker();
 
     runtime_state->set_batch_size(config::vector_chunk_size);
     RETURN_IF_ERROR(runtime_state->init_mem_trackers(query_id));
     runtime_state->set_be_number(backend_num);
-    runtime_state->set_fragment_mem_tracker(mem_tracker);
 
     LOG(INFO) << "Using query memory limit: " << PrettyPrinter::print(bytes_limit, TUnit::BYTES);
 

--- a/be/src/exec/vectorized/hdfs_scan_node.cpp
+++ b/be/src/exec/vectorized/hdfs_scan_node.cpp
@@ -65,7 +65,7 @@ Status HdfsScanNode::init(const TPlanNode& tnode, RuntimeState* state) {
         _hive_column_names = tnode.hdfs_scan_node.hive_column_names;
     }
 
-    _mem_pool = std::make_unique<MemPool>(state->fragment_mem_tracker());
+    _mem_pool = std::make_unique<MemPool>(state->instance_mem_tracker());
 
     return Status::OK();
 }

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -119,10 +119,6 @@ Status PlanFragmentExecutor::prepare(const TExecPlanFragmentParams& request) {
                      << ". Using process memory limit instead";
         bytes_limit = _exec_env->query_pool_mem_tracker()->limit();
     }
-    // NOTE: this MemTracker only for olap
-    _mem_tracker =
-            std::make_unique<MemTracker>(bytes_limit, "fragment mem-limit", _exec_env->query_pool_mem_tracker(), true);
-    _runtime_state->set_fragment_mem_tracker(_mem_tracker.get());
 
     LOG(INFO) << "Using query memory limit: " << PrettyPrinter::print(bytes_limit, TUnit::BYTES);
 

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -104,8 +104,6 @@ public:
     const TUniqueId& query_id() const { return _query_id; }
     const TUniqueId& fragment_instance_id() const { return _fragment_instance_id; }
     ExecEnv* exec_env() { return _exec_env; }
-    std::vector<MemTracker*>* mem_trackers() { return &_mem_trackers; }
-    MemTracker* fragment_mem_tracker() { return _fragment_mem_tracker; }
     MemTracker* instance_mem_tracker() { return _instance_mem_tracker.get(); }
     ThreadResourceMgr::ResourcePool* resource_pool() { return _resource_pool; }
     RuntimeFilterPort* runtime_filter_port() { return _runtime_filter_port; }
@@ -122,13 +120,6 @@ public:
         std::lock_guard<std::mutex> l(_process_status_lock);
         return _process_status;
     };
-
-    // Sets the fragment memory limit and adds it to _mem_trackers
-    void set_fragment_mem_tracker(MemTracker* limit) {
-        DCHECK(_fragment_mem_tracker == nullptr);
-        _fragment_mem_tracker = limit;
-        _mem_trackers.push_back(limit);
-    }
 
     // Appends error to the _error_log if there is space
     bool log_error(const std::string& error);
@@ -312,12 +303,6 @@ private:
     // Thread resource management object for this fragment's execution.  The runtime
     // state is responsible for returning this pool to the thread mgr.
     ThreadResourceMgr::ResourcePool* _resource_pool = nullptr;
-
-    // all mem limits that apply to this query
-    std::vector<MemTracker*> _mem_trackers;
-
-    // Fragment memory limit.  Also contained in _mem_trackers
-    MemTracker* _fragment_mem_tracker = nullptr;
 
     // MemTracker that is shared by all fragment instances running on this host.
     // The query mem tracker must be released after the _instance_mem_tracker.

--- a/be/test/exec/pipeline/pipeline_test_base.cpp
+++ b/be/test/exec/pipeline/pipeline_test_base.cpp
@@ -47,12 +47,9 @@ void PipelineTestBase::_prepare() {
     _fragment_ctx->set_mem_tracker(std::make_unique<MemTracker>(bytes_limit, "pipeline test mem-limit",
                                                                 _exec_env->query_pool_mem_tracker(), true));
 
-    auto mem_tracker = _fragment_ctx->mem_tracker();
-
     _runtime_state->set_batch_size(config::vector_chunk_size);
     ASSERT_TRUE(_runtime_state->init_mem_trackers(query_id).ok());
     _runtime_state->set_be_number(_request.backend_num);
-    _runtime_state->set_fragment_mem_tracker(mem_tracker);
 
     _obj_pool = _runtime_state->obj_pool();
 


### PR DESCRIPTION
for #627 

Currently in RuntimeState, FragmentMemTracker and InstanceMemTracker have the same function.

remove FragmentMemTracker