### PR TITLE
Errors during mysql connection establishment should be warned (#680)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/mysql/nio/AcceptListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/nio/AcceptListener.java
@@ -82,9 +82,13 @@ public class AcceptListener implements ChannelListener<AcceptingChannel<StreamCo
                     // do not need to print log for this kind of exception.
                     // just clean up the context;
                     context.cleanup();
-                } catch (Exception e) {
-                    // should be unexpected exception, so print warn log
-                    LOG.warn("connect processor exception because ", e);
+                } catch (Throwable e) {
+                    if (e instanceof Error) {
+                        LOG.error("connect processor exception because ", e);
+                    } else {
+                        // should be unexpected exception, so print warn log
+                        LOG.warn("connect processor exception because ", e);
+                    }
                     context.cleanup();
                 } finally {
                     ConnectContext.remove();


### PR DESCRIPTION
The log of fe cannot print errors during the establishment of the mysql connection. We should print it as an error log for quick troubleshooting.
For example, we started a fe instance and tried to add a backend to it, but we encountered an exception below.
```
[root@xxx ~]# mysql -h127.0.0.1  -P 9030 -uroot
ERROR 2013 (HY000): Lost connection to MySQL server at 'reading initial communication packet', system error: 0
```
We can find the root cause immediately through this patch. Which caused by jdk version mismatch.
```
[AcceptListener.lambda$handleEvent$1():83] connect processor exception because
java.lang.NoSuchMethodError: java.nio.ByteBuffer.limit(I)Ljava/nio/ByteBuffer;
```