### PR TITLE
Fix right outer join with limit error plan

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/CrossJoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/CrossJoinNode.java
@@ -98,7 +98,7 @@ public class CrossJoinNode extends PlanNode {
         if (!conjuncts.isEmpty()) {
             output.append(detailPrefix + "predicates: ").append(getExplainString(conjuncts) + "\n");
         } else {
-            output.append(detailPrefix + "predicates is NULL.");
+            output.append(detailPrefix + "predicates is NULL.\n");
         }
         return output.toString();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ChildPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ChildPropertyDeriver.java
@@ -32,6 +32,7 @@ import com.starrocks.sql.optimizer.operator.physical.PhysicalHashAggregateOperat
 import com.starrocks.sql.optimizer.operator.physical.PhysicalHashJoinOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalHiveScanOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalIntersectOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalLimitOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalMetaScanOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalMysqlScanOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalOlapScanOperator;
@@ -110,25 +111,8 @@ public class ChildPropertyDeriver extends OperatorVisitor<Void, ExpressionContex
         // 1 For broadcast join
         PhysicalPropertySet rightBroadcastProperty =
                 new PhysicalPropertySet(new DistributionProperty(DistributionSpec.createReplicatedDistributionSpec()));
-
-        LogicalOperator leftChild = (LogicalOperator) context.getChildOperator(0);
-        LogicalOperator rightChild = (LogicalOperator) context.getChildOperator(1);
-        // If child has limit, we need to gather data to one instance
-        if ((leftChild.hasLimit() || rightChild.hasLimit()) &&
-                !(node.getJoinType().isRightJoin() || node.getJoinType().isFullOuterJoin())) {
-            if (leftChild.hasLimit()) {
-                outputInputProps.add(new Pair<>(PhysicalPropertySet.EMPTY,
-                        Lists.newArrayList(createLimitGatherProperty(leftChild.getLimit()), rightBroadcastProperty)));
-            } else {
-                outputInputProps.add(new Pair<>(PhysicalPropertySet.EMPTY,
-                        Lists.newArrayList(new PhysicalPropertySet(), rightBroadcastProperty)));
-            }
-            // If child has limit, only do broadcast join
-            return visitJoinRequirements(node, context, false);
-        } else {
-            outputInputProps.add(new Pair<>(PhysicalPropertySet.EMPTY,
-                    Lists.newArrayList(new PhysicalPropertySet(), rightBroadcastProperty)));
-        }
+        outputInputProps.add(new Pair<>(PhysicalPropertySet.EMPTY,
+                Lists.newArrayList(new PhysicalPropertySet(), rightBroadcastProperty)));
 
         ColumnRefSet leftChildColumns = context.getChildOutputColumns(0);
         ColumnRefSet rightChildColumns = context.getChildOutputColumns(1);
@@ -1016,6 +1000,17 @@ public class ChildPropertyDeriver extends OperatorVisitor<Void, ExpressionContex
             return visitOperator(node, context);
         }
         outputInputProps.add(new Pair<>(PhysicalPropertySet.EMPTY, Lists.newArrayList(PhysicalPropertySet.EMPTY)));
+        return visitOperator(node, context);
+    }
+
+    @Override
+    public Void visitPhysicalLimit(PhysicalLimitOperator node, ExpressionContext context) {
+        if (getRequiredLocalDesc().isPresent()) {
+            return visitOperator(node, context);
+        }
+
+        outputInputProps.add(new Pair<>(createLimitGatherProperty(node.getLimit()),
+                Lists.newArrayList(createLimitGatherProperty(node.getLimit()))));
         return visitOperator(node, context);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ChildPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ChildPropertyDeriver.java
@@ -114,7 +114,8 @@ public class ChildPropertyDeriver extends OperatorVisitor<Void, ExpressionContex
         LogicalOperator leftChild = (LogicalOperator) context.getChildOperator(0);
         LogicalOperator rightChild = (LogicalOperator) context.getChildOperator(1);
         // If child has limit, we need to gather data to one instance
-        if (leftChild.hasLimit() || rightChild.hasLimit()) {
+        if ((leftChild.hasLimit() || rightChild.hasLimit()) &&
+                !(node.getJoinType().isRightJoin() || node.getJoinType().isFullOuterJoin())) {
             if (leftChild.hasLimit()) {
                 outputInputProps.add(new Pair<>(PhysicalPropertySet.EMPTY,
                         Lists.newArrayList(createLimitGatherProperty(leftChild.getLimit()), rightBroadcastProperty)));

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptExpressionVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptExpressionVisitor.java
@@ -168,4 +168,8 @@ public abstract class OptExpressionVisitor<R, C> {
     public R visitPhysicalDecode(OptExpression optExpression, C context) {
         return visit(optExpression, context);
     }
+
+    public R visitPhysicalLimit(OptExpression optExpression, C context) {
+        return visit(optExpression, context);
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -19,6 +19,7 @@ import com.starrocks.sql.optimizer.rule.RuleSetType;
 import com.starrocks.sql.optimizer.rule.implementation.PreAggregateTurnOnRule;
 import com.starrocks.sql.optimizer.rule.join.ReorderJoinRule;
 import com.starrocks.sql.optimizer.rule.mv.MaterializedViewRule;
+import com.starrocks.sql.optimizer.rule.transformation.JoinForceLimitRule;
 import com.starrocks.sql.optimizer.rule.transformation.MergeTwoAggRule;
 import com.starrocks.sql.optimizer.rule.transformation.MergeTwoProjectRule;
 import com.starrocks.sql.optimizer.rule.transformation.PruneEmptyWindowRule;
@@ -102,6 +103,7 @@ public class Optimizer {
         ruleRewriteOnlyOnce(memo, rootTaskContext, RuleSetType.PARTITION_PRUNE);
         ruleRewriteIterative(memo, rootTaskContext, new PruneProjectRule());
         ruleRewriteIterative(memo, rootTaskContext, new ScalarOperatorsReuseRule());
+        ruleRewriteOnlyOnce(memo, rootTaskContext, new JoinForceLimitRule());
 
         // Rewrite maybe produce empty groups, we need to remove them.
         memo.removeAllEmptyGroup();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/OperatorType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/OperatorType.java
@@ -55,6 +55,7 @@ public enum OperatorType {
     PHYSICAL_FILTER,
     PHYSICAL_TABLE_FUNCTION,
     PHYSICAL_DECODE,
+    PHYSICAL_LIMIT,
 
     /**
      * Scalar operator

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/OperatorVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/OperatorVisitor.java
@@ -9,6 +9,7 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalFilterOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalHiveScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalIntersectOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalLimitOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalMetaScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalMysqlScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
@@ -31,6 +32,7 @@ import com.starrocks.sql.optimizer.operator.physical.PhysicalHashAggregateOperat
 import com.starrocks.sql.optimizer.operator.physical.PhysicalHashJoinOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalHiveScanOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalIntersectOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalLimitOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalMetaScanOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalMysqlScanOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalOlapScanOperator;
@@ -136,6 +138,10 @@ public abstract class OperatorVisitor<R, C> {
         return visitOperator(node, context);
     }
 
+    public R visitLogicalLimit(LogicalLimitOperator node, C context) {
+        return visitOperator(node, context);
+    }
+
     public R visitMockOperator(MockOperator node, C context) {
         return visitOperator(node, context);
     }
@@ -220,6 +226,10 @@ public abstract class OperatorVisitor<R, C> {
     }
 
     public R visitPhysicalTableFunction(PhysicalTableFunctionOperator node, C context) {
+        return visitOperator(node, context);
+    }
+
+    public R visitPhysicalLimit(PhysicalLimitOperator node, C context) {
         return visitOperator(node, context);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalLimitOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalLimitOperator.java
@@ -6,6 +6,7 @@ import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.OperatorVisitor;
 
 import java.util.Objects;
 
@@ -39,6 +40,11 @@ public class LogicalLimitOperator extends LogicalOperator {
 
     public <R, C> R accept(OptExpressionVisitor<R, C> visitor, OptExpression optExpression, C context) {
         return visitor.visitLogicalLimit(optExpression, context);
+    }
+
+    @Override
+    public <R, C> R accept(OperatorVisitor<R, C> visitor, C context) {
+        return visitor.visitLogicalLimit(this, context);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalLimitOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalLimitOperator.java
@@ -1,0 +1,50 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+package com.starrocks.sql.optimizer.operator.physical;
+
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptExpressionVisitor;
+import com.starrocks.sql.optimizer.base.GatherDistributionSpec;
+import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.OperatorVisitor;
+
+import java.util.Objects;
+
+public class PhysicalLimitOperator extends PhysicalOperator {
+    private final long offset;
+
+    public PhysicalLimitOperator(long offset, long limit) {
+        super(OperatorType.PHYSICAL_LIMIT, GatherDistributionSpec.createGatherDistributionSpec(limit));
+        this.offset = offset;
+    }
+
+    @Override
+    public <R, C> R accept(OperatorVisitor<R, C> visitor, C context) {
+        return visitor.visitPhysicalLimit(this, context);
+    }
+
+    @Override
+    public <R, C> R accept(OptExpressionVisitor<R, C> visitor, OptExpression optExpression, C context) {
+        return visitor.visitPhysicalLimit(optExpression, context);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        PhysicalLimitOperator that = (PhysicalLimitOperator) o;
+        return offset == that.offset;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), offset);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleSet.java
@@ -13,6 +13,7 @@ import com.starrocks.sql.optimizer.rule.implementation.HashAggImplementationRule
 import com.starrocks.sql.optimizer.rule.implementation.HashJoinImplementationRule;
 import com.starrocks.sql.optimizer.rule.implementation.HiveScanImplementationRule;
 import com.starrocks.sql.optimizer.rule.implementation.IntersectImplementationRule;
+import com.starrocks.sql.optimizer.rule.implementation.LimitImplementationRule;
 import com.starrocks.sql.optimizer.rule.implementation.MetaScanImplementationRule;
 import com.starrocks.sql.optimizer.rule.implementation.MysqlScanImplementationRule;
 import com.starrocks.sql.optimizer.rule.implementation.OlapScanImplementationRule;
@@ -113,7 +114,8 @@ public class RuleSet {
             new ValuesImplementationRule(),
             new RepeatImplementationRule(),
             new FilterImplementationRule(),
-            new TableFunctionImplementationRule()
+            new TableFunctionImplementationRule(),
+            new LimitImplementationRule()
     );
 
     private final List<Rule> transformRules = Lists.newArrayList();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleType.java
@@ -87,6 +87,8 @@ public enum RuleType {
     TF_REWRITE_HLL_COUNT_DISTINCT,
     TF_REWRITE_DUPLICATE_AGGREGATE_FN,
 
+    TF_JOIN_FORCE_LIMIT,
+
     // The following are implementation rules:
     IMP_OLAP_LSCAN_TO_PSCAN,
     IMP_HIVE_LSCAN_TO_PSCAN,
@@ -108,6 +110,7 @@ public enum RuleType {
     IMP_REPEAT,
     IMP_FILTER,
     IMP_TABLE_FUNCTION,
+    IMP_LIMIT,
 
     NUM_RULES;
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/LimitImplementationRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/LimitImplementationRule.java
@@ -1,0 +1,27 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+package com.starrocks.sql.optimizer.rule.implementation;
+
+import com.google.common.collect.Lists;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.logical.LogicalLimitOperator;
+import com.starrocks.sql.optimizer.operator.pattern.Pattern;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalLimitOperator;
+import com.starrocks.sql.optimizer.rule.RuleType;
+
+import java.util.List;
+
+public class LimitImplementationRule extends ImplementationRule {
+    public LimitImplementationRule() {
+        super(RuleType.IMP_LIMIT, Pattern.create(OperatorType.LOGICAL_LIMIT, OperatorType.PATTERN_LEAF));
+    }
+
+    @Override
+    public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
+        LogicalLimitOperator limit = (LogicalLimitOperator) input.getOp();
+        return Lists.newArrayList(OptExpression
+                .create(new PhysicalLimitOperator(limit.getOffset(), limit.getLimit()), input.getInputs()));
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/JoinAssociativityRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/JoinAssociativityRule.java
@@ -37,7 +37,7 @@ public class JoinAssociativityRule extends TransformationRule {
 
     public boolean check(final OptExpression input, OptimizerContext context) {
         LogicalJoinOperator joinOperator = (LogicalJoinOperator) input.getOp();
-        if (!joinOperator.getJoinHint().isEmpty() ||
+        if (!joinOperator.getJoinHint().isEmpty() || input.inputAt(0).getOp().hasLimit() ||
                 !((LogicalJoinOperator) input.inputAt(0).getOp()).getJoinHint().isEmpty()) {
             return false;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/JoinForceLimitRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/JoinForceLimitRule.java
@@ -37,7 +37,8 @@ public class JoinForceLimitRule extends TransformationRule {
         long leftLimit = left.hasLimit() ? left.getLimit() : Long.MAX_VALUE;
         long rightLimit = right.hasLimit() ? right.getLimit() : Long.MAX_VALUE;
 
-        return nodeLimit > leftLimit || nodeLimit > rightLimit;
+        return (nodeLimit > leftLimit && left.getOpType() != OperatorType.LOGICAL_VALUES) ||
+                (nodeLimit > rightLimit && right.getOpType() != OperatorType.LOGICAL_VALUES);
     }
 
     @Override
@@ -53,11 +54,11 @@ public class JoinForceLimitRule extends TransformationRule {
         OptExpression newLeft = input.getInputs().get(0);
         OptExpression newRight = input.getInputs().get(1);
 
-        if (nodeLimit > leftLimit) {
+        if (nodeLimit > leftLimit && left.getOpType() != OperatorType.LOGICAL_VALUES) {
             newLeft = OptExpression.create(new LogicalLimitOperator(left.getLimit()), newLeft);
         }
 
-        if (nodeLimit > rightLimit) {
+        if (nodeLimit > rightLimit && right.getOpType() != OperatorType.LOGICAL_VALUES) {
             newRight = OptExpression.create(new LogicalLimitOperator(right.getLimit()), newRight);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/JoinForceLimitRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/JoinForceLimitRule.java
@@ -1,0 +1,66 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+package com.starrocks.sql.optimizer.rule.transformation;
+
+import com.google.common.collect.Lists;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.operator.Operator;
+import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.logical.LogicalLimitOperator;
+import com.starrocks.sql.optimizer.operator.pattern.Pattern;
+import com.starrocks.sql.optimizer.rule.RuleType;
+
+import java.util.List;
+
+// For case:
+//          Join(limit 1)
+//          /           \
+//   left(limit 2)   right(limit 3)
+//
+// In this case, data must be gather to a HashJoinNode, but the way may inefficient for distributed system,
+// such as left node is large table and right node contains limit for right outer join, so we choose
+// first gather and then re-shuffle, but the ChildPropertyDeriver can't implemented the way, so we
+// use PhysicalLimitOperator to deal with it.
+public class JoinForceLimitRule extends TransformationRule {
+    public JoinForceLimitRule() {
+        super(RuleType.TF_JOIN_FORCE_LIMIT, Pattern.create(OperatorType.LOGICAL_JOIN, OperatorType.PATTERN_MULTI_LEAF));
+    }
+
+    @Override
+    public boolean check(OptExpression input, OptimizerContext context) {
+        Operator join = input.getOp();
+        Operator left = input.getInputs().get(0).getOp();
+        Operator right = input.getInputs().get(1).getOp();
+
+        long nodeLimit = join.hasLimit() ? join.getLimit() : Long.MAX_VALUE;
+        long leftLimit = left.hasLimit() ? left.getLimit() : Long.MAX_VALUE;
+        long rightLimit = right.hasLimit() ? right.getLimit() : Long.MAX_VALUE;
+
+        return nodeLimit > leftLimit || nodeLimit > rightLimit;
+    }
+
+    @Override
+    public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
+        Operator join = input.getOp();
+        Operator left = input.getInputs().get(0).getOp();
+        Operator right = input.getInputs().get(1).getOp();
+
+        long nodeLimit = join.hasLimit() ? join.getLimit() : Long.MAX_VALUE;
+        long leftLimit = left.hasLimit() ? left.getLimit() : Long.MAX_VALUE;
+        long rightLimit = right.hasLimit() ? right.getLimit() : Long.MAX_VALUE;
+
+        OptExpression newLeft = input.getInputs().get(0);
+        OptExpression newRight = input.getInputs().get(1);
+
+        if (nodeLimit > leftLimit) {
+            newLeft = OptExpression.create(new LogicalLimitOperator(left.getLimit()), newLeft);
+        }
+
+        if (nodeLimit > rightLimit) {
+            newRight = OptExpression.create(new LogicalLimitOperator(right.getLimit()), newRight);
+        }
+
+        return Lists.newArrayList(OptExpression.create(input.getOp(), newLeft, newRight));
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -45,6 +45,7 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalFilterOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalHiveScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalIntersectOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalLimitOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalMetaScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalMysqlScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
@@ -65,6 +66,7 @@ import com.starrocks.sql.optimizer.operator.physical.PhysicalHashAggregateOperat
 import com.starrocks.sql.optimizer.operator.physical.PhysicalHashJoinOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalHiveScanOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalIntersectOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalLimitOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalMetaScanOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalMysqlScanOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalOlapScanOperator;
@@ -1108,5 +1110,25 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
             statistics = PredicateStatisticsCalculator.statisticsCalculate(predicate, statistics);
         }
         return statistics;
+    }
+
+    @Override
+    public Void visitLogicalLimit(LogicalLimitOperator node, ExpressionContext context) {
+        Statistics inputStatistics = context.getChildStatistics(0);
+
+        Statistics.Builder builder = Statistics.builder();
+        builder.addColumnStatistics(inputStatistics.getColumnStatistics());
+        builder.setOutputRowCount(node.getLimit());
+        return visitOperator(node, context, builder);
+    }
+
+    @Override
+    public Void visitPhysicalLimit(PhysicalLimitOperator node, ExpressionContext context) {
+        Statistics inputStatistics = context.getChildStatistics(0);
+
+        Statistics.Builder builder = Statistics.builder();
+        builder.addColumnStatistics(inputStatistics.getColumnStatistics());
+        builder.setOutputRowCount(node.getLimit());
+        return visitOperator(node, context, builder);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1665,6 +1665,8 @@ public class PlanFragmentBuilder {
 
         @Override
         public PlanFragment visitPhysicalLimit(OptExpression optExpression, ExecPlan context) {
+            // PhysicalLimit use for enforce gather property, Enforcer will produce more PhysicalDistribution, there
+            // don't need do anything.
             return visit(optExpression.inputAt(0), context);
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1662,5 +1662,10 @@ public class PlanFragmentBuilder {
             inputFragment.setPlanRoot(tableFunctionNode);
             return inputFragment;
         }
+
+        @Override
+        public PlanFragment visitPhysicalLimit(OptExpression optExpression, ExecPlan context) {
+            return visit(optExpression.inputAt(0), context);
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/OperatorStrings.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/OperatorStrings.java
@@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableList;
 import com.starrocks.sql.optimizer.base.HashDistributionDesc;
 import com.starrocks.sql.optimizer.base.HashDistributionSpec;
 import com.starrocks.sql.optimizer.base.Ordering;
+import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalApplyOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalAssertOneRowOperator;
@@ -390,6 +391,11 @@ public class OperatorStrings {
             OperatorStr child = visit(optExpression.getInputs().get(0), step + 1);
             String sb = "Decode ";
             return new OperatorStr(sb, step, Collections.singletonList(child));
+        }
+
+        @Override
+        public OperatorStr visitPhysicalLimit(OptExpression optExpression, Integer step) {
+            return visit(optExpression.getInputs().get(0), step);
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
@@ -402,7 +402,7 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
         String plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("7:CROSS JOIN\n" +
                 "  |  cross join:\n" +
-                "  |  predicates is NULL.  " +
+                "  |  predicates is NULL.\n" +
                 "  |  use vectorized: true\n" +
                 "  |  \n" +
                 "  |----6:EXCHANGE\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
@@ -402,7 +402,8 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
         String plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("7:CROSS JOIN\n" +
                 "  |  cross join:\n" +
-                "  |  predicates is NULL.  |  use vectorized: true\n" +
+                "  |  predicates is NULL.  " +
+                "  |  use vectorized: true\n" +
                 "  |  \n" +
                 "  |----6:EXCHANGE\n" +
                 "  |       use vectorized: true\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/MultiJoinReorderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/MultiJoinReorderTest.java
@@ -39,7 +39,8 @@ public class MultiJoinReorderTest extends PlanTestBase {
         String planFragment = getFragmentPlan(sql);
         Assert.assertTrue(planFragment.contains("4:CROSS JOIN\n" +
                 "  |  cross join:\n" +
-                "  |  predicates is NULL.  |  use vectorized: true\n" +
+                "  |  predicates is NULL.\n" +
+                "  |  use vectorized: true\n" +
                 "  |  \n" +
                 "  |----3:EXCHANGE"));
         Assert.assertTrue(planFragment.contains("9:CROSS JOIN"));
@@ -225,7 +226,8 @@ public class MultiJoinReorderTest extends PlanTestBase {
         // Right sub join tree (a)
         Assert.assertTrue(planFragment.contains("  8:CROSS JOIN\n" +
                 "  |  cross join:\n" +
-                "  |  predicates is NULL.  |  use vectorized: true\n" +
+                "  |  predicates is NULL.\n" +
+                "  |  use vectorized: true\n" +
                 "  |  \n" +
                 "  |----7:EXCHANGE\n" +
                 "  |       use vectorized: true\n" +
@@ -265,7 +267,8 @@ public class MultiJoinReorderTest extends PlanTestBase {
         String planFragment = getFragmentPlan(sql);
         Assert.assertTrue(planFragment.contains("4:CROSS JOIN\n" +
                 "  |  cross join:\n" +
-                "  |  predicates is NULL.  |  use vectorized: true\n" +
+                "  |  predicates is NULL.\n" +
+                "  |  use vectorized: true\n" +
                 "  |  \n" +
                 "  |----3:EXCHANGE"));
         Assert.assertTrue(planFragment.contains("9:CROSS JOIN"));
@@ -453,7 +456,8 @@ public class MultiJoinReorderTest extends PlanTestBase {
         // Right sub join tree (a)
         Assert.assertTrue(planFragment.contains("  8:CROSS JOIN\n" +
                 "  |  cross join:\n" +
-                "  |  predicates is NULL.  |  use vectorized: true\n" +
+                "  |  predicates is NULL.\n" +
+                "  |  use vectorized: true\n" +
                 "  |  \n" +
                 "  |----7:EXCHANGE\n" +
                 "  |       use vectorized: true\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -4336,4 +4336,21 @@ public class PlanFragmentTest extends PlanTestBase {
         String thrift = getThriftPlan(sql);
         Assert.assertTrue(thrift.contains("fid:60010"));
     }
+
+    @Test
+    public void testLimitRightJoin() throws Exception {
+        String sql = "select v1 from t0 right outer join t1 on t0.v1 = t1.v4 limit 100";
+        String plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("  |  join op: RIGHT OUTER JOIN (PARTITIONED)\n" +
+                "  |  hash predicates:\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 1: v1 = 4: v4\n" +
+                "  |  limit: 100"));
+        Assert.assertTrue(plan.contains("  |----3:EXCHANGE\n" +
+                "  |       limit: 100"));
+
+        sql = "select v1 from t0 full outer join t1 on t0.v1 = t1.v4 limit 100";
+        plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("join op: FULL OUTER JOIN (PARTITIONED)"));
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -389,7 +389,8 @@ public class PlanFragmentTest extends PlanTestBase {
         String planFragment = getFragmentPlan(sql);
         Assert.assertTrue(planFragment.contains("  3:CROSS JOIN\n" +
                 "  |  cross join:\n" +
-                "  |  predicates is NULL.  |  use vectorized: true\n" +
+                "  |  predicates is NULL.\n" +
+                "  |  use vectorized: true\n" +
                 "  |  \n" +
                 "  |----2:EXCHANGE\n" +
                 "  |       use vectorized: true\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -1344,10 +1344,11 @@ public class PlanFragmentTest extends PlanTestBase {
         String sql = "select * from (select v1, v2 from t0 limit 10) a join [shuffle] " +
                 "(select v1, v2 from t0 limit 1) b on a.v1 = b.v1";
         String plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("join op: INNER JOIN (BROADCAST)"));
-        Assert.assertTrue(plan.contains("  |----3:EXCHANGE\n" +
+        System.out.println(plan);
+        Assert.assertTrue(plan.contains("join op: INNER JOIN (PARTITIONED)"));
+        Assert.assertTrue(plan.contains("  |----5:EXCHANGE\n" +
                 "  |       limit: 1"));
-        Assert.assertTrue(plan.contains("  1:EXCHANGE\n" +
+        Assert.assertTrue(plan.contains("  2:EXCHANGE\n" +
                 "     limit: 10"));
     }
 
@@ -1356,7 +1357,8 @@ public class PlanFragmentTest extends PlanTestBase {
         String sql = "select * from (select v1, v2 from t0) a join [shuffle] " +
                 "(select v4 from t1 limit 1) b on a.v1 = b.v4";
         String plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("join op: INNER JOIN (BROADCAST)"));
+        System.out.println(plan);
+        Assert.assertTrue(plan.contains("join op: INNER JOIN (PARTITIONED)"));
     }
 
     @Test
@@ -1364,7 +1366,8 @@ public class PlanFragmentTest extends PlanTestBase {
         String sql = "select * from (select v1, v2 from t0 limit 10) a join [shuffle] " +
                 "(select v4 from t1 ) b on a.v1 = b.v4";
         String plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("join op: INNER JOIN (BROADCAST)"));
+        System.out.println(plan);
+        Assert.assertTrue(plan.contains("join op: INNER JOIN (PARTITIONED)"));
     }
 
     @Test
@@ -1528,18 +1531,18 @@ public class PlanFragmentTest extends PlanTestBase {
     public void testJoinLimitLeft() throws Exception {
         String sql = "select * from t0 left outer join t1 on t0.v1 = t1.v4 limit 10";
         String plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("  |  join op: RIGHT OUTER JOIN (BROADCAST)\n"
-                + "  |  hash predicates:\n"
-                + "  |  colocate: false, reason: \n"
-                + "  |  equal join conjunct: 4: v4 = 1: v1\n"
-                + "  |  limit: 10\n"
-                + "  |  use vectorized: true\n"
-                + "  |  \n"
-                + "  |----2:EXCHANGE\n"
-                + "  |       limit: 10\n"
-                + "  |       use vectorized: true\n"
-                + "  |    \n"
-                + "  0:OlapScanNode\n"));
+        System.out.println(plan);
+        Assert.assertTrue(plan.contains("  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
+                "  |  hash predicates:\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 1: v1 = 4: v4\n" +
+                "  |  limit: 10\n" +
+                "  |  use vectorized: true\n" +
+                "  |  \n" +
+                "  |----2:EXCHANGE\n" +
+                "  |       use vectorized: true\n" +
+                "  |    \n" +
+                "  0:OlapScanNode"));
         Assert.assertTrue(plan.contains("     TABLE: t0\n"
                 + "     PREAGGREGATION: ON\n"
                 + "     partitions=0/1\n"
@@ -1559,7 +1562,7 @@ public class PlanFragmentTest extends PlanTestBase {
         sql = "select * from t0 full outer join t1 on t0.v1 = t1.v4 limit 10";
         plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("  4:HASH JOIN\n"
-                + "  |  join op: FULL OUTER JOIN (BROADCAST)\n"
+                + "  |  join op: FULL OUTER JOIN (PARTITIONED)\n"
                 + "  |  hash predicates:\n"
                 + "  |  colocate: false, reason: \n"
                 + "  |  equal join conjunct: 1: v1 = 4: v4\n"
@@ -1576,18 +1579,19 @@ public class PlanFragmentTest extends PlanTestBase {
 
         sql = "select * from t0, t1 limit 10";
         plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("  4:CROSS JOIN\n"
-                + "  |  cross join:\n"
-                + "  |  predicates is NULL.  |  limit: 10\n"
-                + "  |  use vectorized: true\n"
-                + "  |  \n"
-                + "  |----3:EXCHANGE\n"
-                + "  |       limit: 10\n"
-                + "  |       use vectorized: true\n"
-                + "  |    \n"
-                + "  1:EXCHANGE\n"
-                + "     limit: 10\n"
-                + "     use vectorized: true\n"));
+        System.out.println(plan);
+        Assert.assertTrue(plan.contains("3:CROSS JOIN\n" +
+                "  |  cross join:\n" +
+                "  |  predicates is NULL.\n" +
+                "  |  limit: 10\n" +
+                "  |  use vectorized: true\n" +
+                "  |  \n" +
+                "  |----2:EXCHANGE\n" +
+                "  |       limit: 10\n" +
+                "  |       use vectorized: true\n" +
+                "  |    \n" +
+                "  0:OlapScanNode\n" +
+                "     TABLE: t0"));
     }
 
     @Test
@@ -4353,4 +4357,99 @@ public class PlanFragmentTest extends PlanTestBase {
         plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("join op: FULL OUTER JOIN (PARTITIONED)"));
     }
+
+    @Test
+    public void testLimitLeftJoin() throws Exception {
+        String sql = "select v1 from (select * from t0 limit 1) x0 left outer join t1 on x0.v1 = t1.v4";
+        String plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("  |  join op: RIGHT OUTER JOIN (PARTITIONED)\n" +
+                "  |  hash predicates:\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 4: v4 = 1: v1"));
+        Assert.assertTrue(plan.contains("  |----4:EXCHANGE\n" +
+                "  |       limit: 1"));
+
+        sql = "select v1 from (select * from t0 limit 10) x0 left outer join t1 on x0.v1 = t1.v4 limit 1";
+        plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("  3:HASH JOIN\n" +
+                "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
+                "  |  hash predicates:\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 1: v1 = 4: v4\n" +
+                "  |  limit: 1\n" +
+                "  |  use vectorized: true\n" +
+                "  |  \n" +
+                "  |----2:EXCHANGE\n" +
+                "  |       use vectorized: true\n" +
+                "  |    \n" +
+                "  0:OlapScanNode"));
+        Assert.assertTrue(plan.contains("  0:OlapScanNode\n" +
+                "     TABLE: t0\n" +
+                "     PREAGGREGATION: ON\n" +
+                "     partitions=0/1\n" +
+                "     rollup: t0\n" +
+                "     tabletRatio=0/0\n" +
+                "     tabletList=\n" +
+                "     cardinality=1\n" +
+                "     avgRowSize=1.0\n" +
+                "     numNodes=0\n" +
+                "     limit: 1"));
+
+        sql = "select v1 from (select * from t0 limit 10) x0 left outer join t1 on x0.v1 = t1.v4 limit 100";
+        plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("  5:HASH JOIN\n" +
+                "  |  join op: RIGHT OUTER JOIN (PARTITIONED)\n" +
+                "  |  hash predicates:\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 4: v4 = 1: v1\n" +
+                "  |  limit: 100\n" +
+                "  |  use vectorized: true\n" +
+                "  |  \n" +
+                "  |----4:EXCHANGE\n" +
+                "  |       limit: 10\n" +
+                "  |       use vectorized: true\n" +
+                "  |    \n" +
+                "  1:EXCHANGE"));
+        Assert.assertTrue(plan.contains("PLAN FRAGMENT 1\n" +
+                " OUTPUT EXPRS:\n" +
+                "  PARTITION: UNPARTITIONED\n" +
+                "\n" +
+                "  STREAM DATA SINK\n" +
+                "    EXCHANGE ID: 04\n" +
+                "    HASH_PARTITIONED: 1: v1\n" +
+                "\n" +
+                "  3:EXCHANGE\n" +
+                "     limit: 10\n" +
+                "     use vectorized: true\n"));
+
+        sql =
+                "select v1 from (select * from t0 limit 10) x0 left outer join (select * from t1 limit 5) x1 on x0.v1 = x1.v4 limit 7";
+        plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("join op: LEFT OUTER JOIN (BROADCAST)\n" +
+                "  |  hash predicates:\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 1: v1 = 4: v4\n" +
+                "  |  limit: 7\n" +
+                "  |  use vectorized: true\n" +
+                "  |  \n" +
+                "  |----3:EXCHANGE\n" +
+                "  |       limit: 5\n" +
+                "  |       use vectorized: true\n" +
+                "  |    \n" +
+                "  0:OlapScanNode"));
+        Assert.assertTrue(plan.contains("PLAN FRAGMENT 1\n" +
+                " OUTPUT EXPRS:\n" +
+                "  PARTITION: UNPARTITIONED\n" +
+                "\n" +
+                "  STREAM DATA SINK\n" +
+                "    EXCHANGE ID: 03\n" +
+                "    UNPARTITIONED\n" +
+                "\n" +
+                "  2:EXCHANGE\n" +
+                "     limit: 5\n" +
+                "     use vectorized: true\n" +
+                "\n" +
+                "PLAN FRAGMENT 2"));
+    }
+
 }


### PR DESCRIPTION
#741

Fix bug:
* JoinAssociativityRule: can't work if child join contains limit, will cause result error
* Join subquery which with limit, the shuffle way error, will cause result error(right join right child contains limit)