### PR TITLE
Provide Cross Join Operator

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -138,6 +138,8 @@ set(EXEC_FILES
     pipeline/project_operator.cpp
     pipeline/result_sink_operator.cpp
     pipeline/scan_operator.cpp
+    pipeline/crossjoin/cross_join_right_sink_operator.cpp
+    pipeline/crossjoin/cross_join_left_operator.cpp
     pipeline/sort/sort_sink_operator.cpp
     pipeline/sort/sort_source_operator.cpp
     pipeline/pipeline_driver_dispatcher.cpp

--- a/be/src/exec/pipeline/crossjoin/cross_join_context.h
+++ b/be/src/exec/pipeline/crossjoin/cross_join_context.h
@@ -10,6 +10,15 @@ class CrossJoinContext {
 public:
     CrossJoinContext() : _build_chunk(std::make_shared<vectorized::Chunk>()), _right_table_complete(false) {}
 
+    const vectorized::ChunkPtr& get_build_chunk() { return _build_chunk; }
+
+    void set_build_chunk(const vectorized::ChunkPtr& build_chunk) { _build_chunk = build_chunk; }
+
+    bool is_right_complete() { return _right_table_complete; }
+
+    void set_right_complete() { _right_table_complete = true; }
+
+private:
     // Used in operators to reference right table's datas.
     vectorized::ChunkPtr _build_chunk;
     // used in operators to mark that the right table has been constructed.

--- a/be/src/exec/pipeline/crossjoin/cross_join_context.h
+++ b/be/src/exec/pipeline/crossjoin/cross_join_context.h
@@ -14,9 +14,9 @@ public:
 
     void set_build_chunk(const vectorized::ChunkPtr& build_chunk) { _build_chunk = build_chunk; }
 
-    bool is_right_complete() { return _right_table_complete; }
+    bool is_right_complete() { return _right_table_complete.load(std::memory_order_acquire); }
 
-    void set_right_complete() { _right_table_complete = true; }
+    void set_right_complete() { _right_table_complete.store(true, std::memory_order_release); }
 
 private:
     // Used in operators to reference right table's datas.

--- a/be/src/exec/pipeline/crossjoin/cross_join_context.h
+++ b/be/src/exec/pipeline/crossjoin/cross_join_context.h
@@ -1,0 +1,20 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#pragma once
+
+#include "column/vectorized_fwd.h"
+
+namespace starrocks {
+namespace pipeline {
+class CrossJoinContext {
+public:
+    CrossJoinContext() : _build_chunk(std::make_shared<vectorized::Chunk>()), _right_table_complete(false) {}
+
+    // Used in operators to reference right table's datas.
+    vectorized::ChunkPtr _build_chunk;
+    // used in operators to mark that the right table has been constructed.
+    std::atomic<bool> _right_table_complete;
+};
+
+} // namespace pipeline
+} // namespace starrocks

--- a/be/src/exec/pipeline/crossjoin/cross_join_left_operator.cpp
+++ b/be/src/exec/pipeline/crossjoin/cross_join_left_operator.cpp
@@ -1,0 +1,404 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#include "exec/pipeline/crossjoin/cross_join_left_operator.h"
+
+#include "column/chunk.h"
+#include "column/column_helper.h"
+#include "column/nullable_column.h"
+#include "exec/exec_node.h"
+#include "exprs/expr.h"
+#include "exprs/vectorized/column_ref.h"
+#include "runtime/runtime_state.h"
+
+namespace starrocks::pipeline {
+
+void CrossJoinLeftOperator::_init_row_desc() {
+    for (auto& tuple_desc : _left_row_desc.tuple_descriptors()) {
+        for (auto& slot : tuple_desc->slots()) {
+            _col_types.emplace_back(slot);
+            _probe_column_count++;
+        }
+        if (_row_descriptor.get_tuple_idx(tuple_desc->id()) != RowDescriptor::INVALID_IDX) {
+            _output_probe_tuple_ids.emplace_back(tuple_desc->id());
+        }
+    }
+    for (auto& tuple_desc : _right_row_desc.tuple_descriptors()) {
+        for (auto& slot : tuple_desc->slots()) {
+            _col_types.emplace_back(slot);
+            _build_column_count++;
+        }
+        if (_row_descriptor.get_tuple_idx(tuple_desc->id()) != RowDescriptor::INVALID_IDX) {
+            _output_build_tuple_ids.emplace_back(tuple_desc->id());
+        }
+    }
+}
+
+Status CrossJoinLeftOperator::prepare(RuntimeState* state) {
+    Operator::prepare(state);
+    _init_row_desc();
+    return Status::OK();
+}
+
+Status CrossJoinLeftOperator::close(RuntimeState* state) {
+    Operator::close(state);
+    return Status::OK();
+}
+
+void CrossJoinLeftOperator::_init_chunk(vectorized::ChunkPtr* chunk) {
+    vectorized::ChunkPtr new_chunk = std::make_shared<vectorized::Chunk>();
+
+    // init columns for the new chunk from _probe_chunk and (*_build_chunk_ptr)
+    for (size_t i = 0; i < _probe_column_count; ++i) {
+        SlotDescriptor* slot = _col_types[i];
+        vectorized::ColumnPtr& src_col = _probe_chunk->get_column_by_slot_id(slot->id());
+        auto new_col = vectorized::ColumnHelper::create_column(slot->type(), src_col->is_nullable());
+        new_chunk->append_column(std::move(new_col), slot->id());
+    }
+    for (size_t i = 0; i < _build_column_count; ++i) {
+        SlotDescriptor* slot = _col_types[_probe_column_count + i];
+        vectorized::ColumnPtr& src_col = (*_build_chunk_ptr)->get_column_by_slot_id(slot->id());
+        vectorized::ColumnPtr new_col = vectorized::ColumnHelper::create_column(slot->type(), src_col->is_nullable());
+        new_chunk->append_column(std::move(new_col), slot->id());
+    }
+
+    for (int tuple_id : _output_probe_tuple_ids) {
+        if (_probe_chunk->is_tuple_exist(tuple_id)) {
+            vectorized::ColumnPtr dest_col = vectorized::BooleanColumn::create();
+            new_chunk->append_tuple_column(dest_col, tuple_id);
+        }
+    }
+    for (int tuple_id : _output_build_tuple_ids) {
+        if ((*_build_chunk_ptr)->is_tuple_exist(tuple_id)) {
+            vectorized::ColumnPtr dest_col = vectorized::BooleanColumn::create();
+            new_chunk->append_tuple_column(dest_col, tuple_id);
+        }
+    }
+
+    *chunk = std::move(new_chunk);
+    (*chunk)->reserve(config::vector_chunk_size);
+}
+
+void CrossJoinLeftOperator::_copy_joined_rows_with_index_base_probe(vectorized::ChunkPtr& chunk, size_t row_count,
+                                                                    size_t probe_index, size_t build_index) {
+    for (size_t i = 0; i < _probe_column_count; i++) {
+        SlotDescriptor* slot = _col_types[i];
+        vectorized::ColumnPtr& dest_col = chunk->get_column_by_slot_id(slot->id());
+        vectorized::ColumnPtr& src_col = _probe_chunk->get_column_by_slot_id(slot->id());
+        _copy_probe_rows_with_index_base_probe(dest_col, src_col, probe_index, row_count);
+    }
+
+    for (size_t i = 0; i < _build_column_count; i++) {
+        SlotDescriptor* slot = _col_types[i + _probe_column_count];
+        vectorized::ColumnPtr& dest_col = chunk->get_column_by_slot_id(slot->id());
+        vectorized::ColumnPtr& src_col = (*_build_chunk_ptr)->get_column_by_slot_id(slot->id());
+        _copy_build_rows_with_index_base_probe(dest_col, src_col, build_index, row_count);
+    }
+
+    for (int tuple_id : _output_probe_tuple_ids) {
+        if (_probe_chunk->is_tuple_exist(tuple_id)) {
+            vectorized::ColumnPtr& src_col = _probe_chunk->get_tuple_column_by_id(tuple_id);
+            auto& src_data = vectorized::ColumnHelper::as_raw_column<vectorized::BooleanColumn>(src_col)->get_data();
+            vectorized::ColumnPtr& dest_col = chunk->get_tuple_column_by_id(tuple_id);
+            auto& dest_data = vectorized::ColumnHelper::as_raw_column<vectorized::BooleanColumn>(dest_col)->get_data();
+            for (size_t i = 0; i < row_count; i++) {
+                dest_data.emplace_back(src_data[probe_index]);
+            }
+        }
+    }
+
+    for (int tuple_id : _output_build_tuple_ids) {
+        if ((*_build_chunk_ptr)->is_tuple_exist(tuple_id)) {
+            vectorized::ColumnPtr& src_col = (*_build_chunk_ptr)->get_tuple_column_by_id(tuple_id);
+            auto& src_data = vectorized::ColumnHelper::as_raw_column<vectorized::BooleanColumn>(src_col)->get_data();
+            vectorized::ColumnPtr& dest_col = chunk->get_tuple_column_by_id(tuple_id);
+            auto& dest_data = vectorized::ColumnHelper::as_raw_column<vectorized::BooleanColumn>(dest_col)->get_data();
+
+            for (size_t i = 0; i < row_count; i++) {
+                dest_data.emplace_back(src_data[build_index + i]);
+            }
+        }
+    }
+}
+
+void CrossJoinLeftOperator::_copy_joined_rows_with_index_base_build(vectorized::ChunkPtr& chunk, size_t row_count,
+                                                                    size_t probe_index, size_t build_index) {
+    for (size_t i = 0; i < _probe_column_count; i++) {
+        SlotDescriptor* slot = _col_types[i];
+        vectorized::ColumnPtr& dest_col = chunk->get_column_by_slot_id(slot->id());
+        vectorized::ColumnPtr& src_col = _probe_chunk->get_column_by_slot_id(slot->id());
+        _copy_probe_rows_with_index_base_build(dest_col, src_col, probe_index, row_count);
+    }
+
+    for (size_t i = 0; i < _build_column_count; i++) {
+        SlotDescriptor* slot = _col_types[i + _probe_column_count];
+        vectorized::ColumnPtr& dest_col = chunk->get_column_by_slot_id(slot->id());
+        vectorized::ColumnPtr& src_col = (*_build_chunk_ptr)->get_column_by_slot_id(slot->id());
+        _copy_build_rows_with_index_base_build(dest_col, src_col, build_index, row_count);
+    }
+
+    for (int tuple_id : _output_probe_tuple_ids) {
+        if (_probe_chunk->is_tuple_exist(tuple_id)) {
+            vectorized::ColumnPtr& src_col = _probe_chunk->get_tuple_column_by_id(tuple_id);
+            auto& src_data = vectorized::ColumnHelper::as_raw_column<vectorized::BooleanColumn>(src_col)->get_data();
+            vectorized::ColumnPtr& dest_col = chunk->get_tuple_column_by_id(tuple_id);
+            auto& dest_data = vectorized::ColumnHelper::as_raw_column<vectorized::BooleanColumn>(dest_col)->get_data();
+            for (size_t i = 0; i < row_count; i++) {
+                dest_data.emplace_back(src_data[probe_index + i]);
+            }
+        }
+    }
+
+    for (int tuple_id : _output_build_tuple_ids) {
+        if ((*_build_chunk_ptr)->is_tuple_exist(tuple_id)) {
+            vectorized::ColumnPtr& src_col = (*_build_chunk_ptr)->get_tuple_column_by_id(tuple_id);
+            auto& src_data = vectorized::ColumnHelper::as_raw_column<vectorized::BooleanColumn>(src_col)->get_data();
+            vectorized::ColumnPtr& dest_col = chunk->get_tuple_column_by_id(tuple_id);
+            auto& dest_data = vectorized::ColumnHelper::as_raw_column<vectorized::BooleanColumn>(dest_col)->get_data();
+
+            for (size_t i = 0; i < row_count; i++) {
+                dest_data.emplace_back(src_data[build_index]);
+            }
+        }
+    }
+}
+
+void CrossJoinLeftOperator::_copy_probe_rows_with_index_base_probe(vectorized::ColumnPtr& dest_col,
+                                                                   vectorized::ColumnPtr& src_col, size_t start_row,
+                                                                   size_t copy_number) {
+    if (src_col->is_nullable()) {
+        if (src_col->is_constant()) {
+            // current can't reach here
+            dest_col->append_nulls(copy_number);
+        } else {
+            // repeat the value from probe table for copy_number times
+            dest_col->append_value_multiple_times(*src_col.get(), start_row, copy_number);
+        }
+    } else {
+        if (src_col->is_constant()) {
+            // current can't reach here
+            auto* const_col = vectorized::ColumnHelper::as_raw_column<vectorized::ConstColumn>(src_col);
+            // repeat the constant value from probe table for copy_number times
+            _buf_selective.assign(copy_number, 0);
+            dest_col->append_selective(*const_col->data_column(), &_buf_selective[0], 0, copy_number);
+        } else {
+            // repeat the value from probe table for copy_number times
+            dest_col->append_value_multiple_times(*src_col.get(), start_row, copy_number);
+        }
+    }
+}
+
+void CrossJoinLeftOperator::_copy_probe_rows_with_index_base_build(vectorized::ColumnPtr& dest_col,
+                                                                   vectorized::ColumnPtr& src_col, size_t start_row,
+                                                                   size_t copy_number) {
+    if (src_col->is_nullable()) {
+        if (src_col->is_constant()) {
+            // current can't reach here
+            dest_col->append_nulls(copy_number);
+        } else {
+            // repeat the value from probe table for copy_number times
+            dest_col->append(*src_col.get(), start_row, copy_number);
+        }
+    } else {
+        if (src_col->is_constant()) {
+            // current can't reach here
+            auto* const_col = vectorized::ColumnHelper::as_raw_column<vectorized::ConstColumn>(src_col);
+            // repeat the constant value from probe table for copy_number times
+            _buf_selective.assign(copy_number, 0);
+            dest_col->append_selective(*const_col->data_column(), &_buf_selective[0], 0, copy_number);
+        } else {
+            // repeat the value from probe table for copy_number times
+            dest_col->append(*src_col.get(), start_row, copy_number);
+        }
+    }
+}
+
+void CrossJoinLeftOperator::_copy_build_rows_with_index_base_probe(vectorized::ColumnPtr& dest_col,
+                                                                   vectorized::ColumnPtr& src_col, size_t start_row,
+                                                                   size_t row_count) {
+    if (!src_col->is_nullable()) {
+        if (src_col->is_constant()) {
+            // current can't reach here
+            auto* const_col = vectorized::ColumnHelper::as_raw_column<vectorized::ConstColumn>(src_col);
+            // repeat the constant value for copy_number times
+            _buf_selective.assign(row_count, 0);
+            dest_col->append_selective(*const_col->data_column(), &_buf_selective[0], 0, row_count);
+        } else {
+            dest_col->append(*src_col.get(), start_row, row_count);
+        }
+    } else {
+        if (src_col->is_constant()) {
+            // current can't reach here
+            dest_col->append_nulls(row_count);
+        } else {
+            dest_col->append(*src_col.get(), start_row, row_count);
+        }
+    }
+}
+
+void CrossJoinLeftOperator::_copy_build_rows_with_index_base_build(vectorized::ColumnPtr& dest_col,
+                                                                   vectorized::ColumnPtr& src_col, size_t start_row,
+                                                                   size_t row_count) {
+    if (!src_col->is_nullable()) {
+        if (src_col->is_constant()) {
+            // current can't reach here
+            auto* const_col = vectorized::ColumnHelper::as_raw_column<vectorized::ConstColumn>(src_col);
+            // repeat the constant value for copy_number times
+            _buf_selective.assign(row_count, 0);
+            dest_col->append_selective(*const_col->data_column(), &_buf_selective[0], 0, row_count);
+        } else {
+            dest_col->append_value_multiple_times(*src_col.get(), start_row, row_count);
+        }
+    } else {
+        if (src_col->is_constant()) {
+            // current can't reach here
+            dest_col->append_nulls(row_count);
+        } else {
+            dest_col->append_value_multiple_times(*src_col.get(), start_row, row_count);
+        }
+    }
+}
+
+/* 
+ * This algorithm is the same as that CrossJoinNode, 
+ * and pull_chunk, need_input, push_chunk is splited from CrossJoinNode's get_next.
+ */
+StatusOr<vectorized::ChunkPtr> CrossJoinLeftOperator::pull_chunk(RuntimeState* state) {
+    vectorized::ChunkPtr chunk = nullptr;
+    for (;;) {
+        if (chunk == nullptr) {
+            // we need a valid probe chunk to initialize the new chunk.
+            _init_chunk(&chunk);
+        }
+
+        // need row_count to fill in chunk.
+        size_t row_count = config::vector_chunk_size - chunk->num_rows();
+
+        // means we have scan all chunks of right tables.
+        // we should scan all remain rows of right table.
+        // once _probe_chunk_index == _probe_chunk->num_rows() is true,
+        // this condition will always true for this _probe_chunk,
+        // Until _probe_chunk be done.
+        if (_probe_chunk_index == _probe_chunk->num_rows()) {
+            // step 2:
+            // if left chunk is bigger than right, we shuld scan left based on right.
+            if (_probe_chunk_index > _number_of_build_rows - _build_chunks_size) {
+                if (row_count > _probe_chunk_index - _probe_rows_index) {
+                    row_count = _probe_chunk_index - _probe_rows_index;
+                }
+
+                _copy_joined_rows_with_index_base_build(chunk, row_count, _probe_rows_index, _build_rows_index);
+                _probe_rows_index += row_count;
+
+                if (_probe_rows_index == _probe_chunk_index) {
+                    ++_build_rows_index;
+                    _probe_rows_index = 0;
+                }
+
+                // _probe_chunk is done with _build_chunk.
+                if (_build_rows_index >= _number_of_build_rows) {
+                    _probe_chunk = nullptr;
+                }
+            } else {
+                // if remain rows of right is bigger than left, we should scan right based on left.
+                if (row_count > _number_of_build_rows - _build_rows_index) {
+                    row_count = _number_of_build_rows - _build_rows_index;
+                }
+
+                _copy_joined_rows_with_index_base_probe(chunk, row_count, _probe_rows_index, _build_rows_index);
+                _build_rows_index += row_count;
+
+                if (_build_rows_index == _number_of_build_rows) {
+                    ++_probe_rows_index;
+                    _build_rows_index = _build_chunks_size;
+                }
+
+                // _probe_chunk is done with _build_chunk.
+                if (_probe_rows_index >= _probe_chunk_index) {
+                    _probe_chunk = nullptr;
+                }
+            }
+        } else if (_build_chunks_index < _build_chunks_size) {
+            // step 1:
+            // we scan all chunks of right table.
+            if (row_count > _build_chunks_size - _build_chunks_index) {
+                row_count = _build_chunks_size - _build_chunks_index;
+            }
+
+            _copy_joined_rows_with_index_base_probe(chunk, row_count, _probe_chunk_index, _build_chunks_index);
+            _build_chunks_index += row_count;
+        } else {
+            // step policy decision:
+            DCHECK_EQ(_build_chunks_index, _build_chunks_size);
+
+            if (_build_chunks_size != 0) {
+                // scan right chunk_size rows for next row of left chunk.
+                ++_probe_chunk_index;
+                if (_probe_chunk_index < _probe_chunk->num_rows()) {
+                    _build_chunks_index = 0;
+                } else {
+                    // if right table is all about chunks, means _probe_chunk is done.
+                    if (_build_chunks_size == _number_of_build_rows) {
+                        _probe_chunk = nullptr;
+                    } else {
+                        _build_rows_index = _build_chunks_size;
+                        _probe_rows_index = 0;
+                    }
+                }
+            } else {
+                // optimized for smaller right table < 4096 rows.
+                _probe_chunk_index = _probe_chunk->num_rows();
+                _build_rows_index = _build_chunks_size;
+                _probe_rows_index = 0;
+            }
+            continue;
+        }
+
+        if (chunk->num_rows() < config::vector_chunk_size && _probe_chunk != nullptr) {
+            continue;
+        }
+
+        ExecNode::eval_conjuncts(_conjunct_ctxs, chunk.get());
+
+        // we get result chunk.
+        break;
+    }
+
+    return chunk;
+}
+
+// (_probe_chunk == nullptr || _probe_chunk->num_rows() == 0) means that
+// need take next chunk from left table.
+bool CrossJoinLeftOperator::need_input() const {
+    DCHECK((*_right_table_complete_ptr) && (*_build_chunk_ptr));
+    return _number_of_build_rows > 0 && (_probe_chunk == nullptr || _probe_chunk->num_rows() == 0);
+}
+
+bool CrossJoinLeftOperator::is_ready() {
+    // woke from blocking througth cross join right sink operator by shared _right_table_complete_ptr.
+    bool is_complete = *_right_table_complete_ptr;
+    if (is_complete) {
+        DCHECK(*_build_chunk_ptr);
+        if ((*_build_chunk_ptr)->num_rows() > 0) {
+            // Set fields for left table.
+            _number_of_build_rows = (*_build_chunk_ptr)->num_rows();
+            _build_chunks_size = (_number_of_build_rows / config::vector_chunk_size) * config::vector_chunk_size;
+        }
+    }
+
+    return is_complete;
+}
+
+Status CrossJoinLeftOperator::push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) {
+    _probe_chunk = chunk;
+    _build_chunks_index = 0;
+    _probe_chunk_index = 0;
+    return Status::OK();
+}
+
+Status CrossJoinLeftOperatorFactory::prepare(RuntimeState* state, MemTracker* mem_tracker) {
+    return Status::OK();
+}
+
+void CrossJoinLeftOperatorFactory::close(RuntimeState* state) {}
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/crossjoin/cross_join_left_operator.cpp
+++ b/be/src/exec/pipeline/crossjoin/cross_join_left_operator.cpp
@@ -26,7 +26,7 @@ Status CrossJoinLeftOperator::close(RuntimeState* state) {
 void CrossJoinLeftOperator::_init_chunk(vectorized::ChunkPtr* chunk) {
     vectorized::ChunkPtr new_chunk = std::make_shared<vectorized::Chunk>();
 
-    // init columns for the new chunk from _probe_chunk and _cross_join_context->_build_chunk
+    // init columns for the new chunk from _probe_chunk and _cross_join_context->get_build_chunk()
     for (size_t i = 0; i < _probe_column_count; ++i) {
         SlotDescriptor* slot = _col_types[i];
         vectorized::ColumnPtr& src_col = _probe_chunk->get_column_by_slot_id(slot->id());
@@ -35,7 +35,7 @@ void CrossJoinLeftOperator::_init_chunk(vectorized::ChunkPtr* chunk) {
     }
     for (size_t i = 0; i < _build_column_count; ++i) {
         SlotDescriptor* slot = _col_types[_probe_column_count + i];
-        vectorized::ColumnPtr& src_col = _cross_join_context->_build_chunk->get_column_by_slot_id(slot->id());
+        vectorized::ColumnPtr& src_col = _cross_join_context->get_build_chunk()->get_column_by_slot_id(slot->id());
         vectorized::ColumnPtr new_col = vectorized::ColumnHelper::create_column(slot->type(), src_col->is_nullable());
         new_chunk->append_column(std::move(new_col), slot->id());
     }
@@ -47,7 +47,7 @@ void CrossJoinLeftOperator::_init_chunk(vectorized::ChunkPtr* chunk) {
         }
     }
     for (int tuple_id : _output_build_tuple_ids) {
-        if (_cross_join_context->_build_chunk->is_tuple_exist(tuple_id)) {
+        if (_cross_join_context->get_build_chunk()->is_tuple_exist(tuple_id)) {
             vectorized::ColumnPtr dest_col = vectorized::BooleanColumn::create();
             new_chunk->append_tuple_column(dest_col, tuple_id);
         }
@@ -69,7 +69,7 @@ void CrossJoinLeftOperator::_copy_joined_rows_with_index_base_probe(vectorized::
     for (size_t i = 0; i < _build_column_count; i++) {
         SlotDescriptor* slot = _col_types[i + _probe_column_count];
         vectorized::ColumnPtr& dest_col = chunk->get_column_by_slot_id(slot->id());
-        vectorized::ColumnPtr& src_col = _cross_join_context->_build_chunk->get_column_by_slot_id(slot->id());
+        vectorized::ColumnPtr& src_col = _cross_join_context->get_build_chunk()->get_column_by_slot_id(slot->id());
         _copy_build_rows_with_index_base_probe(dest_col, src_col, build_index, row_count);
     }
 
@@ -86,8 +86,8 @@ void CrossJoinLeftOperator::_copy_joined_rows_with_index_base_probe(vectorized::
     }
 
     for (int tuple_id : _output_build_tuple_ids) {
-        if (_cross_join_context->_build_chunk->is_tuple_exist(tuple_id)) {
-            vectorized::ColumnPtr& src_col = _cross_join_context->_build_chunk->get_tuple_column_by_id(tuple_id);
+        if (_cross_join_context->get_build_chunk()->is_tuple_exist(tuple_id)) {
+            vectorized::ColumnPtr& src_col = _cross_join_context->get_build_chunk()->get_tuple_column_by_id(tuple_id);
             auto& src_data = vectorized::ColumnHelper::as_raw_column<vectorized::BooleanColumn>(src_col)->get_data();
             vectorized::ColumnPtr& dest_col = chunk->get_tuple_column_by_id(tuple_id);
             auto& dest_data = vectorized::ColumnHelper::as_raw_column<vectorized::BooleanColumn>(dest_col)->get_data();
@@ -111,7 +111,7 @@ void CrossJoinLeftOperator::_copy_joined_rows_with_index_base_build(vectorized::
     for (size_t i = 0; i < _build_column_count; i++) {
         SlotDescriptor* slot = _col_types[i + _probe_column_count];
         vectorized::ColumnPtr& dest_col = chunk->get_column_by_slot_id(slot->id());
-        vectorized::ColumnPtr& src_col = _cross_join_context->_build_chunk->get_column_by_slot_id(slot->id());
+        vectorized::ColumnPtr& src_col = _cross_join_context->get_build_chunk()->get_column_by_slot_id(slot->id());
         _copy_build_rows_with_index_base_build(dest_col, src_col, build_index, row_count);
     }
 
@@ -128,8 +128,8 @@ void CrossJoinLeftOperator::_copy_joined_rows_with_index_base_build(vectorized::
     }
 
     for (int tuple_id : _output_build_tuple_ids) {
-        if (_cross_join_context->_build_chunk->is_tuple_exist(tuple_id)) {
-            vectorized::ColumnPtr& src_col = _cross_join_context->_build_chunk->get_tuple_column_by_id(tuple_id);
+        if (_cross_join_context->get_build_chunk()->is_tuple_exist(tuple_id)) {
+            vectorized::ColumnPtr& src_col = _cross_join_context->get_build_chunk()->get_tuple_column_by_id(tuple_id);
             auto& src_data = vectorized::ColumnHelper::as_raw_column<vectorized::BooleanColumn>(src_col)->get_data();
             vectorized::ColumnPtr& dest_col = chunk->get_tuple_column_by_id(tuple_id);
             auto& dest_data = vectorized::ColumnHelper::as_raw_column<vectorized::BooleanColumn>(dest_col)->get_data();
@@ -361,13 +361,13 @@ bool CrossJoinLeftOperator::need_input() const {
 }
 
 bool CrossJoinLeftOperator::is_ready() const {
-    // woke from blocking througth cross join right sink operator by shared _right_table_complete_ptr.
-    bool is_complete = _cross_join_context->_right_table_complete;
+    // woke from blocking througth cross join right sink operator by shared _cross_join_context.
+    bool is_complete = _cross_join_context->is_right_complete();
     if (is_complete) {
         _is_right_complete = true;
-        if (_cross_join_context->_build_chunk->num_rows() > 0) {
+        if (_cross_join_context->get_build_chunk()->num_rows() > 0) {
             // Set fields for left table.
-            _total_build_rows = _cross_join_context->_build_chunk->num_rows();
+            _total_build_rows = _cross_join_context->get_build_chunk()->num_rows();
             _build_rows_threshold = (_total_build_rows / config::vector_chunk_size) * config::vector_chunk_size;
             _build_rows_remainder = _total_build_rows - _build_rows_threshold;
         }

--- a/be/src/exec/pipeline/crossjoin/cross_join_left_operator.cpp
+++ b/be/src/exec/pipeline/crossjoin/cross_join_left_operator.cpp
@@ -401,9 +401,14 @@ void CrossJoinLeftOperatorFactory::_init_row_desc() {
 
 Status CrossJoinLeftOperatorFactory::prepare(RuntimeState* state, MemTracker* mem_tracker) {
     _init_row_desc();
+    RowDescriptor row_desc;
+    RETURN_IF_ERROR(Expr::prepare(_conjunct_ctxs, state, row_desc, mem_tracker));
+    RETURN_IF_ERROR(Expr::open(_conjunct_ctxs, state));
     return Status::OK();
 }
 
-void CrossJoinLeftOperatorFactory::close(RuntimeState* state) {}
+void CrossJoinLeftOperatorFactory::close(RuntimeState* state) {
+    Expr::close(_conjunct_ctxs, state);
+}
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/crossjoin/cross_join_left_operator.cpp
+++ b/be/src/exec/pipeline/crossjoin/cross_join_left_operator.cpp
@@ -272,7 +272,7 @@ StatusOr<vectorized::ChunkPtr> CrossJoinLeftOperator::pull_chunk(RuntimeState* s
                     _copy_joined_rows_with_index_base_build(chunk, row_count, _probe_rows_index,
                                                             _beyond_threshold_build_rows_index);
                     _probe_rows_index += row_count;
-                    // if _probe_rows_index is equal with probe_chunk_size, 
+                    // if _probe_rows_index is equal with probe_chunk_size,
                     // means left chunk is done with the right row, so we get next right row.
                     if (_probe_rows_index == probe_chunk_size) {
                         ++_beyond_threshold_build_rows_index;

--- a/be/src/exec/pipeline/crossjoin/cross_join_left_operator.h
+++ b/be/src/exec/pipeline/crossjoin/cross_join_left_operator.h
@@ -90,7 +90,7 @@ private:
 
     const std::vector<ExprContext*>& _conjunct_ctxs;
 
-    // Decompose all rows into multiples of 4096 rows and remainder of 4096 rows.
+    // Decompose right table rows into multiples of 4096 rows and remainder of 4096 rows.
     size_t mutable _total_build_rows = 0;
     // multiples of 4096
     size_t mutable _build_rows_threshold = 0;

--- a/be/src/exec/pipeline/crossjoin/cross_join_left_operator.h
+++ b/be/src/exec/pipeline/crossjoin/cross_join_left_operator.h
@@ -1,0 +1,148 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#pragma once
+
+#include "column/vectorized_fwd.h"
+#include "exec/pipeline/operator_with_dependency.h"
+#include "runtime/descriptors.h"
+
+namespace starrocks {
+class ExprContext;
+namespace pipeline {
+class CrossJoinLeftOperator final : public OperatorWithDependency {
+public:
+    CrossJoinLeftOperator(int32_t id, int32_t plan_node_id, const RowDescriptor& row_descriptor,
+                          const RowDescriptor& left_row_desc, const RowDescriptor& right_row_desc,
+                          const std::vector<ExprContext*>& conjunct_ctxs, vectorized::ChunkPtr* build_chunk_ptr,
+                          std::atomic<bool>* right_table_complete_ptr)
+            : OperatorWithDependency(id, "cross_join_left", plan_node_id),
+              _row_descriptor(row_descriptor),
+              _left_row_desc(left_row_desc),
+              _right_row_desc(right_row_desc),
+              _conjunct_ctxs(conjunct_ctxs),
+              _build_chunk_ptr(build_chunk_ptr),
+              _right_table_complete_ptr(right_table_complete_ptr) {}
+
+    ~CrossJoinLeftOperator() override = default;
+
+    void _copy_joined_rows_with_index_base_build(vectorized::ChunkPtr& chunk, size_t row_count, size_t probe_index,
+                                                 size_t build_index);
+    void _copy_joined_rows_with_index_base_probe(vectorized::ChunkPtr& chunk, size_t row_count, size_t probe_index,
+                                                 size_t build_index);
+
+    void _copy_probe_rows_with_index_base_build(vectorized::ColumnPtr& dest_col, vectorized::ColumnPtr& src_col,
+                                                size_t start_row, size_t copy_number);
+    void _copy_probe_rows_with_index_base_probe(vectorized::ColumnPtr& dest_col, vectorized::ColumnPtr& src_col,
+                                                size_t start_row, size_t copy_number);
+
+    void _copy_build_rows_with_index_base_build(vectorized::ColumnPtr& dest_col, vectorized::ColumnPtr& src_col,
+                                                size_t start_row, size_t row_count);
+    void _copy_build_rows_with_index_base_probe(vectorized::ColumnPtr& dest_col, vectorized::ColumnPtr& src_col,
+                                                size_t start_row, size_t row_count);
+
+    void _init_row_desc();
+    void _init_chunk(vectorized::ChunkPtr* chunk);
+    Status prepare(RuntimeState* state) override;
+
+    Status close(RuntimeState* state) override;
+
+    bool has_output() const override { return _probe_chunk != nullptr; }
+
+    bool need_input() const override;
+
+    bool is_finished() const override { return _is_finished && _probe_chunk == nullptr; }
+
+    void finish(RuntimeState* state) override { _is_finished = true; }
+
+    bool is_ready() override;
+
+    StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
+
+    Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override;
+
+private:
+    const RowDescriptor& _row_descriptor;
+    const RowDescriptor& _left_row_desc;
+    const RowDescriptor& _right_row_desc;
+
+    // previsou saved chunk.
+    vectorized::ChunkPtr _pre_output_chunk = nullptr;
+
+    // used when scan rows in [0, _build_chunks_size) rows.
+    size_t _build_chunks_index = 0;
+    // used when scan rows in [_build_chunks_size, _number_of_built_rows) rows.
+    size_t _build_rows_index = 0;
+
+    // used as left table's chunk.
+    // _probe_chunk about one chunk_size(maybe 4096) of left table.
+    vectorized::ChunkPtr _probe_chunk = nullptr;
+    // used when scan chunks in right table based on one row of left table.
+    //  _probe_chunk_index is a local index in _probe_chunk.
+    size_t _probe_chunk_index = 0;
+    // used when scan rows in right table.
+    // _probe_rows_index is a local index in _probe_chunk.
+    // And is used when _probe_chunk_index == _probe_chunk->num_rows().
+    size_t _probe_rows_index = 0;
+
+    vectorized::Buffer<SlotDescriptor*> _col_types;
+    vectorized::Buffer<TupleId> _output_build_tuple_ids;
+    vectorized::Buffer<TupleId> _output_probe_tuple_ids;
+    size_t _probe_column_count = 0;
+    size_t _build_column_count = 0;
+
+    const std::vector<ExprContext*>& _conjunct_ctxs;
+
+    // Reference right table's data
+    vectorized::ChunkPtr* _build_chunk_ptr = nullptr;
+    // Used to mark that the right table has been constructed
+    std::atomic<bool>* _right_table_complete_ptr = nullptr;
+
+    size_t _number_of_build_rows = 0;
+    size_t _build_chunks_size = 0;
+
+    bool _is_finished = false;
+    vectorized::ChunkPtr _cur_chunk = nullptr;
+
+    std::vector<uint32_t> _buf_selective;
+};
+
+class CrossJoinLeftOperatorFactory final : public OperatorWithDependencyFactory {
+public:
+    CrossJoinLeftOperatorFactory(int32_t id, int32_t plan_node_id, const RowDescriptor& row_descriptor,
+                                 const RowDescriptor& left_row_desc, const RowDescriptor& right_row_desc,
+                                 const std::vector<ExprContext*>& conjunct_ctxs, vectorized::ChunkPtr* build_chunk_ptr,
+                                 std::atomic<bool>* right_table_complete_ptr)
+            : OperatorWithDependencyFactory(id, "cross_join_left", plan_node_id),
+              _row_descriptor(row_descriptor),
+              _left_row_desc(left_row_desc),
+              _right_row_desc(right_row_desc),
+              _conjunct_ctxs(conjunct_ctxs),
+              _build_chunk_ptr(build_chunk_ptr),
+              _right_table_complete_ptr(right_table_complete_ptr) {}
+
+    ~CrossJoinLeftOperatorFactory() override = default;
+
+    OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override {
+        return std::make_shared<CrossJoinLeftOperator>(_id, _plan_node_id, _row_descriptor, _left_row_desc,
+                                                       _right_row_desc, _conjunct_ctxs, _build_chunk_ptr,
+                                                       _right_table_complete_ptr);
+    }
+
+    Status prepare(RuntimeState* state, MemTracker* mem_tracker) override;
+    void close(RuntimeState* state) override;
+
+private:
+    const RowDescriptor& _row_descriptor;
+    const RowDescriptor& _left_row_desc;
+    const RowDescriptor& _right_row_desc;
+
+    const std::vector<ExprContext*>& _conjunct_ctxs;
+
+    // Reference right table's data
+    vectorized::ChunkPtr* _build_chunk_ptr = nullptr;
+    // Used to mark that the right table has been constructed
+    std::atomic<bool>* _right_table_complete_ptr = nullptr;
+};
+
+} // namespace pipeline
+} // namespace starrocks

--- a/be/src/exec/pipeline/crossjoin/cross_join_left_operator.h
+++ b/be/src/exec/pipeline/crossjoin/cross_join_left_operator.h
@@ -52,7 +52,13 @@ public:
 
     bool need_input() const override;
 
-    bool is_finished() const override { return _is_finished && _probe_chunk == nullptr; }
+    bool is_finished() const override {
+        if (_is_right_complete && !_total_build_rows) {
+            return true;
+        }
+
+        return _is_finished && _probe_chunk == nullptr;
+    }
 
     void finish(RuntimeState* state) override { _is_finished = true; }
 
@@ -112,13 +118,13 @@ public:
     CrossJoinLeftOperatorFactory(int32_t id, int32_t plan_node_id, const RowDescriptor& row_descriptor,
                                  const RowDescriptor& left_row_desc, const RowDescriptor& right_row_desc,
                                  std::vector<ExprContext*>&& conjunct_ctxs,
-                                 std::shared_ptr<CrossJoinContext> cross_join_context)
+                                 std::shared_ptr<CrossJoinContext>&& cross_join_context)
             : OperatorWithDependencyFactory(id, "cross_join_left", plan_node_id),
               _row_descriptor(row_descriptor),
               _left_row_desc(left_row_desc),
               _right_row_desc(right_row_desc),
               _conjunct_ctxs(std::move(conjunct_ctxs)),
-              _cross_join_context(cross_join_context) {}
+              _cross_join_context(std::move(cross_join_context)) {}
 
     ~CrossJoinLeftOperatorFactory() override = default;
 

--- a/be/src/exec/pipeline/crossjoin/cross_join_left_operator.h
+++ b/be/src/exec/pipeline/crossjoin/cross_join_left_operator.h
@@ -90,12 +90,14 @@ private:
 
     const std::vector<ExprContext*>& _conjunct_ctxs;
 
-    // Decompose all rows into multiples of 4096 and remainder of 4096
+    // Decompose all rows into multiples of 4096 rows and remainder of 4096 rows.
     size_t mutable _total_build_rows = 0;
     // multiples of 4096
     size_t mutable _build_rows_threshold = 0;
     // remainder of 4096
     size_t mutable _build_rows_remainder = 0;
+    // means right table is constructed completely.
+    bool mutable _is_right_complete = false;
 
     bool _is_finished = false;
     vectorized::ChunkPtr _cur_chunk = nullptr;

--- a/be/src/exec/pipeline/crossjoin/cross_join_left_operator.h
+++ b/be/src/exec/pipeline/crossjoin/cross_join_left_operator.h
@@ -109,13 +109,13 @@ class CrossJoinLeftOperatorFactory final : public OperatorWithDependencyFactory 
 public:
     CrossJoinLeftOperatorFactory(int32_t id, int32_t plan_node_id, const RowDescriptor& row_descriptor,
                                  const RowDescriptor& left_row_desc, const RowDescriptor& right_row_desc,
-                                 const std::vector<ExprContext*>& conjunct_ctxs,
+                                 std::vector<ExprContext*>&& conjunct_ctxs,
                                  std::shared_ptr<CrossJoinContext> cross_join_context)
             : OperatorWithDependencyFactory(id, "cross_join_left", plan_node_id),
               _row_descriptor(row_descriptor),
               _left_row_desc(left_row_desc),
               _right_row_desc(right_row_desc),
-              _conjunct_ctxs(conjunct_ctxs),
+              _conjunct_ctxs(std::move(conjunct_ctxs)),
               _cross_join_context(cross_join_context) {}
 
     ~CrossJoinLeftOperatorFactory() override = default;
@@ -141,7 +141,7 @@ private:
     size_t _probe_column_count = 0;
     size_t _build_column_count = 0;
 
-    const std::vector<ExprContext*>& _conjunct_ctxs;
+    std::vector<ExprContext*> _conjunct_ctxs;
 
     std::shared_ptr<CrossJoinContext> _cross_join_context;
 };

--- a/be/src/exec/pipeline/crossjoin/cross_join_left_operator.h
+++ b/be/src/exec/pipeline/crossjoin/cross_join_left_operator.h
@@ -66,10 +66,10 @@ private:
     // previsou saved chunk.
     vectorized::ChunkPtr _pre_output_chunk = nullptr;
 
-    // used when scan rows in [0, _build_chunks_size) rows.
-    size_t _build_chunks_index = 0;
-    // used when scan rows in [_build_chunks_size, _number_of_built_rows) rows.
-    size_t _build_rows_index = 0;
+    // used when scan rows in [0, _build_rows_threshold) rows.
+    size_t _within_threshold_build_rows_index = 0;
+    // used when scan rows in [_build_rows_threshold, _number_of_built_rows) rows.
+    size_t _beyond_threshold_build_rows_index = 0;
 
     // used as left table's chunk.
     // _probe_chunk about one chunk_size(maybe 4096) of left table.
@@ -90,8 +90,12 @@ private:
 
     const std::vector<ExprContext*>& _conjunct_ctxs;
 
-    size_t mutable _number_of_build_rows = 0;
-    size_t mutable _build_chunks_size = 0;
+    // Decompose all rows into multiples of 4096 and remainder of 4096
+    size_t mutable _total_build_rows = 0;
+    // multiples of 4096
+    size_t mutable _build_rows_threshold = 0;
+    // remainder of 4096
+    size_t mutable _build_rows_remainder = 0;
 
     bool _is_finished = false;
     vectorized::ChunkPtr _cur_chunk = nullptr;

--- a/be/src/exec/pipeline/crossjoin/cross_join_right_sink_operator.cpp
+++ b/be/src/exec/pipeline/crossjoin/cross_join_right_sink_operator.cpp
@@ -30,13 +30,13 @@ Status CrossJoinRightSinkOperator::push_chunk(RuntimeState* state, const vectori
     if (chunk) {
         const size_t row_number = chunk->num_rows();
         if (row_number > 0) {
-            if (_cross_join_context->_build_chunk->num_rows() == 0) {
-                _cross_join_context->_build_chunk = chunk;
+            if (_cross_join_context->get_build_chunk()->num_rows() == 0) {
+                _cross_join_context->set_build_chunk(chunk);
             } else {
                 // merge chunks from right table.
                 size_t col_number = chunk->num_columns();
                 for (size_t col = 0; col < col_number; ++col) {
-                    _cross_join_context->_build_chunk->get_column_by_index(col)->append(
+                    _cross_join_context->get_build_chunk()->get_column_by_index(col)->append(
                             *(chunk->get_column_by_index(col).get()), 0, row_number);
                 }
             }
@@ -49,7 +49,7 @@ Status CrossJoinRightSinkOperator::push_chunk(RuntimeState* state, const vectori
 void CrossJoinRightSinkOperator::finish(RuntimeState* state) {
     if (!_is_finished) {
         // Used to notify cross_join_left_operator.
-        _cross_join_context->_right_table_complete = true;
+        _cross_join_context->set_right_complete();
         _is_finished = true;
     }
 }

--- a/be/src/exec/pipeline/crossjoin/cross_join_right_sink_operator.cpp
+++ b/be/src/exec/pipeline/crossjoin/cross_join_right_sink_operator.cpp
@@ -1,0 +1,65 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#include "exec/pipeline/crossjoin/cross_join_right_sink_operator.h"
+
+#include "column/chunk.h"
+#include "column/column_helper.h"
+
+using namespace starrocks::vectorized;
+
+namespace starrocks::pipeline {
+Status CrossJoinRightSinkOperator::prepare(RuntimeState* state) {
+    Operator::prepare(state);
+    return Status::OK();
+}
+
+Status CrossJoinRightSinkOperator::close(RuntimeState* state) {
+    return Operator::close(state);
+}
+
+StatusOr<vectorized::ChunkPtr> CrossJoinRightSinkOperator::pull_chunk(RuntimeState* state) {
+    CHECK(false) << "Shouldn't pull chunk from result sink operator";
+}
+
+bool CrossJoinRightSinkOperator::need_input() const {
+    return !is_finished();
+}
+
+Status CrossJoinRightSinkOperator::push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) {
+    if (chunk) {
+        const size_t row_number = chunk->num_rows();
+        if (row_number > 0) {
+            DCHECK(*_build_chunk_ptr);
+            if ((*_build_chunk_ptr)->num_rows() == 0) {
+                *_build_chunk_ptr = chunk;
+            } else {
+                // merge chunks from right table.
+                size_t col_number = chunk->num_columns();
+                for (size_t col = 0; col < col_number; ++col) {
+                    (*_build_chunk_ptr)
+                            ->get_column_by_index(col)
+                            ->append(*(chunk->get_column_by_index(col).get()), 0, row_number);
+                }
+            }
+        }
+    }
+
+    return Status::OK();
+}
+
+void CrossJoinRightSinkOperator::finish(RuntimeState* state) {
+    if (!_is_finished) {
+        DCHECK(*_build_chunk_ptr);
+        // Used to notify cross_join_left_operator.
+        *_right_table_complete_ptr = true;
+        _is_finished = true;
+    }
+}
+
+Status CrossJoinRightSinkOperatorFactory::prepare(RuntimeState* state, MemTracker* mem_tracker) {
+    return Status::OK();
+}
+
+void CrossJoinRightSinkOperatorFactory::close(RuntimeState* state) {}
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/crossjoin/cross_join_right_sink_operator.cpp
+++ b/be/src/exec/pipeline/crossjoin/cross_join_right_sink_operator.cpp
@@ -4,6 +4,7 @@
 
 #include "column/chunk.h"
 #include "column/column_helper.h"
+#include "exec/pipeline/crossjoin/cross_join_context.h"
 
 using namespace starrocks::vectorized;
 
@@ -29,16 +30,14 @@ Status CrossJoinRightSinkOperator::push_chunk(RuntimeState* state, const vectori
     if (chunk) {
         const size_t row_number = chunk->num_rows();
         if (row_number > 0) {
-            DCHECK(*_build_chunk_ptr);
-            if ((*_build_chunk_ptr)->num_rows() == 0) {
-                *_build_chunk_ptr = chunk;
+            if (_cross_join_context->_build_chunk->num_rows() == 0) {
+                _cross_join_context->_build_chunk = chunk;
             } else {
                 // merge chunks from right table.
                 size_t col_number = chunk->num_columns();
                 for (size_t col = 0; col < col_number; ++col) {
-                    (*_build_chunk_ptr)
-                            ->get_column_by_index(col)
-                            ->append(*(chunk->get_column_by_index(col).get()), 0, row_number);
+                    _cross_join_context->_build_chunk->get_column_by_index(col)->append(
+                            *(chunk->get_column_by_index(col).get()), 0, row_number);
                 }
             }
         }
@@ -49,9 +48,8 @@ Status CrossJoinRightSinkOperator::push_chunk(RuntimeState* state, const vectori
 
 void CrossJoinRightSinkOperator::finish(RuntimeState* state) {
     if (!_is_finished) {
-        DCHECK(*_build_chunk_ptr);
         // Used to notify cross_join_left_operator.
-        *_right_table_complete_ptr = true;
+        _cross_join_context->_right_table_complete = true;
         _is_finished = true;
     }
 }

--- a/be/src/exec/pipeline/crossjoin/cross_join_right_sink_operator.h
+++ b/be/src/exec/pipeline/crossjoin/cross_join_right_sink_operator.h
@@ -8,15 +8,6 @@
 #include "exec/pipeline/operator.h"
 
 namespace starrocks {
-class BufferControlBlock;
-class ExprContext;
-class ResultWriter;
-class ExecNode;
-
-namespace vectorized {
-class ChunksSorter;
-}
-
 namespace pipeline {
 class CrossJoinContext;
 class CrossJoinRightSinkOperator final : public Operator {

--- a/be/src/exec/pipeline/crossjoin/cross_join_right_sink_operator.h
+++ b/be/src/exec/pipeline/crossjoin/cross_join_right_sink_operator.h
@@ -1,0 +1,82 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#pragma once
+
+#include <utility>
+
+#include "column/vectorized_fwd.h"
+#include "exec/pipeline/operator.h"
+
+namespace starrocks {
+class BufferControlBlock;
+class ExprContext;
+class ResultWriter;
+class ExecNode;
+
+namespace vectorized {
+class ChunksSorter;
+}
+
+namespace pipeline {
+class CrossJoinRightSinkOperator final : public Operator {
+public:
+    CrossJoinRightSinkOperator(int32_t id, int32_t plan_node_id, vectorized::ChunkPtr* build_chunk_ptr,
+                               std::atomic<bool>* right_table_complete_ptr)
+            : Operator(id, "cross_join_right_sink", plan_node_id),
+              _build_chunk_ptr(build_chunk_ptr),
+              _right_table_complete_ptr(right_table_complete_ptr) {}
+
+    ~CrossJoinRightSinkOperator() override = default;
+
+    Status prepare(RuntimeState* state) override;
+
+    Status close(RuntimeState* state) override;
+
+    bool has_output() const override { return false; }
+
+    bool need_input() const override;
+
+    bool is_finished() const override { return _is_finished; }
+
+    StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
+
+    Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override;
+
+    void finish(RuntimeState* state) override;
+
+private:
+    bool _is_finished = false;
+    // Reference right table's data
+    vectorized::ChunkPtr* _build_chunk_ptr = nullptr;
+    // Used to mark that the right table has been constructed
+    std::atomic<bool>* _right_table_complete_ptr = nullptr;
+};
+
+class CrossJoinRightSinkOperatorFactory final : public OperatorFactory {
+public:
+    CrossJoinRightSinkOperatorFactory(int32_t id, int32_t plan_node_id, vectorized::ChunkPtr* build_chunk_ptr,
+                                      std::atomic<bool>* right_table_complete_ptr)
+            : OperatorFactory(id, "cross_join_right_sink", plan_node_id),
+              _build_chunk_ptr(build_chunk_ptr),
+              _right_table_complete_ptr(right_table_complete_ptr) {}
+
+    ~CrossJoinRightSinkOperatorFactory() override = default;
+
+    OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override {
+        auto ope = std::make_shared<CrossJoinRightSinkOperator>(_id, _plan_node_id, _build_chunk_ptr,
+                                                                _right_table_complete_ptr);
+        return ope;
+    }
+
+    Status prepare(RuntimeState* state, MemTracker* mem_tracker) override;
+    void close(RuntimeState* state) override;
+
+private:
+    // Reference right table's data
+    vectorized::ChunkPtr* _build_chunk_ptr = nullptr;
+    // Used to mark that the right table has been constructed
+    std::atomic<bool>* _right_table_complete_ptr = nullptr;
+};
+
+} // namespace pipeline
+} // namespace starrocks

--- a/be/src/exec/pipeline/operator_with_dependency.h
+++ b/be/src/exec/pipeline/operator_with_dependency.h
@@ -32,7 +32,7 @@ public:
     OperatorWithDependency(int32_t id, const std::string& name, int32_t plan_node_id);
     ~OperatorWithDependency() = default;
     // return true if the corresponding right operator is full materialized, otherwise return false.
-    virtual bool is_ready() = 0;
+    virtual bool is_ready() const = 0;
 };
 
 class OperatorWithDependencyFactory : public OperatorFactory {

--- a/be/src/exec/pipeline/operator_with_dependency.h
+++ b/be/src/exec/pipeline/operator_with_dependency.h
@@ -32,7 +32,7 @@ public:
     OperatorWithDependency(int32_t id, const std::string& name, int32_t plan_node_id);
     ~OperatorWithDependency() = default;
     // return true if the corresponding right operator is full materialized, otherwise return false.
-    virtual bool is_ready() const = 0;
+    virtual bool is_ready() = 0;
 };
 
 class OperatorWithDependencyFactory : public OperatorFactory {

--- a/be/src/exec/vectorized/cross_join_node.cpp
+++ b/be/src/exec/vectorized/cross_join_node.cpp
@@ -536,6 +536,7 @@ pipeline::OpFactories CrossJoinNode::decompose_to_pipeline(pipeline::PipelineBui
 
     // step 0: construct pipeline end with cross join right operator.
     OpFactories operator_before_cross_join_right = _children[1]->decompose_to_pipeline(context);
+    operator_before_cross_join_right = context->maybe_interpolate_local_exchange(operator_before_cross_join_right);
 
     // communication with CrossJoinLeft through shared_datas.
     auto right_factory =
@@ -546,6 +547,7 @@ pipeline::OpFactories CrossJoinNode::decompose_to_pipeline(pipeline::PipelineBui
 
     // step 1: construct pipeline end with cross join left operator(cross join left maybe not sink operator).
     OpFactories operator_before_cross_join_left = _children[0]->decompose_to_pipeline(context);
+    operator_before_cross_join_left = context->maybe_interpolate_local_exchange(operator_before_cross_join_left);
 
     // communication with CrossJoioRight through shared_datas.
     auto left_factory = std::make_shared<CrossJoinLeftOperatorFactory>(

--- a/be/src/exec/vectorized/cross_join_node.cpp
+++ b/be/src/exec/vectorized/cross_join_node.cpp
@@ -552,7 +552,7 @@ pipeline::OpFactories CrossJoinNode::decompose_to_pipeline(pipeline::PipelineBui
     // communication with CrossJoioRight through shared_datas.
     auto left_factory = std::make_shared<CrossJoinLeftOperatorFactory>(
             context->next_operator_id(), id(), _row_descriptor, child(0)->row_desc(), child(1)->row_desc(),
-            _conjunct_ctxs, cross_join_context);
+            std::move(_conjunct_ctxs), cross_join_context);
     operator_before_cross_join_left.emplace_back(std::move(left_factory));
 
     // return as the following pipeline

--- a/be/src/exec/vectorized/cross_join_node.cpp
+++ b/be/src/exec/vectorized/cross_join_node.cpp
@@ -552,7 +552,7 @@ pipeline::OpFactories CrossJoinNode::decompose_to_pipeline(pipeline::PipelineBui
     // communication with CrossJoioRight through shared_datas.
     auto left_factory = std::make_shared<CrossJoinLeftOperatorFactory>(
             context->next_operator_id(), id(), _row_descriptor, child(0)->row_desc(), child(1)->row_desc(),
-            std::move(_conjunct_ctxs), cross_join_context);
+            std::move(_conjunct_ctxs), std::move(cross_join_context));
     operator_before_cross_join_left.emplace_back(std::move(left_factory));
 
     // return as the following pipeline

--- a/be/src/exec/vectorized/cross_join_node.cpp
+++ b/be/src/exec/vectorized/cross_join_node.cpp
@@ -4,6 +4,7 @@
 
 #include "column/chunk.h"
 #include "column/column_helper.h"
+#include "exec/pipeline/crossjoin/cross_join_context.h"
 #include "exec/pipeline/crossjoin/cross_join_left_operator.h"
 #include "exec/pipeline/crossjoin/cross_join_right_sink_operator.h"
 #include "exec/pipeline/operator.h"
@@ -531,14 +532,14 @@ void CrossJoinNode::_init_chunk(ChunkPtr* chunk) {
 pipeline::OpFactories CrossJoinNode::decompose_to_pipeline(pipeline::PipelineBuilderContext* context) {
     using namespace pipeline;
 
-    _build_chunk_for_pipeline = std::make_shared<vectorized::Chunk>();
+    std::shared_ptr<pipeline::CrossJoinContext> cross_join_context = std::make_shared<pipeline::CrossJoinContext>();
 
     // step 0: construct pipeline end with cross join right operator.
     OpFactories operator_before_cross_join_right = _children[1]->decompose_to_pipeline(context);
 
     // communication with CrossJoinLeft through shared_datas.
-    auto right_factory = std::make_shared<CrossJoinRightSinkOperatorFactory>(
-            context->next_operator_id(), id(), &_build_chunk_for_pipeline, &_right_table_complete);
+    auto right_factory =
+            std::make_shared<CrossJoinRightSinkOperatorFactory>(context->next_operator_id(), id(), cross_join_context);
     operator_before_cross_join_right.emplace_back(std::move(right_factory));
     // cross_join_right as sink operator
     context->add_pipeline(operator_before_cross_join_right);
@@ -549,7 +550,7 @@ pipeline::OpFactories CrossJoinNode::decompose_to_pipeline(pipeline::PipelineBui
     // communication with CrossJoioRight through shared_datas.
     auto left_factory = std::make_shared<CrossJoinLeftOperatorFactory>(
             context->next_operator_id(), id(), _row_descriptor, child(0)->row_desc(), child(1)->row_desc(),
-            _conjunct_ctxs, &_build_chunk_for_pipeline, &_right_table_complete);
+            _conjunct_ctxs, cross_join_context);
     operator_before_cross_join_left.emplace_back(std::move(left_factory));
 
     // return as the following pipeline

--- a/be/src/exec/vectorized/cross_join_node.h
+++ b/be/src/exec/vectorized/cross_join_node.h
@@ -21,6 +21,9 @@ public:
     Status get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) override;
     Status close(RuntimeState* state) override;
 
+    std::vector<std::shared_ptr<pipeline::OperatorFactory>> decompose_to_pipeline(
+            pipeline::PipelineBuilderContext* context) override;
+
 private:
     Status _build(RuntimeState* state);
     Status _get_next_probe_chunk(RuntimeState* state);
@@ -44,6 +47,11 @@ private:
 
     void _init_row_desc();
     void _init_chunk(ChunkPtr* chunk);
+
+    // Used in operators to reference right table's datas.
+    ChunkPtr _build_chunk_for_pipeline;
+    // used in operators to mark that the right table has been constructed.
+    std::atomic<bool> _right_table_complete = false;
 
     // previsou saved chunk.
     ChunkPtr _pre_output_chunk = nullptr;

--- a/be/src/exec/vectorized/cross_join_node.h
+++ b/be/src/exec/vectorized/cross_join_node.h
@@ -5,7 +5,8 @@
 #include "column/chunk.h"
 #include "exec/exec_node.h"
 
-namespace starrocks::vectorized {
+namespace starrocks {
+namespace vectorized {
 class CrossJoinNode : public ExecNode {
 public:
     CrossJoinNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs);
@@ -48,11 +49,6 @@ private:
     void _init_row_desc();
     void _init_chunk(ChunkPtr* chunk);
 
-    // Used in operators to reference right table's datas.
-    ChunkPtr _build_chunk_for_pipeline;
-    // used in operators to mark that the right table has been constructed.
-    std::atomic<bool> _right_table_complete = false;
-
     // previsou saved chunk.
     ChunkPtr _pre_output_chunk = nullptr;
     // used as right table's chunk.
@@ -93,4 +89,5 @@ private:
 
     std::vector<uint32_t> _buf_selective;
 };
-} // namespace starrocks::vectorized
+} // namespace vectorized
+} // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/planner/CrossJoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/CrossJoinNode.java
@@ -124,4 +124,9 @@ public class CrossJoinNode extends PlanNode {
 
         return true;
     }
+
+    @Override
+    public boolean canUsePipeLine() {
+        return getChildren().stream().allMatch(PlanNode::canUsePipeLine);
+    }
 }


### PR DESCRIPTION
- CrossJoinNode is split into CrossJoinLeftOperator and CrossJoinRightSinkOperator, algorithm is remain unchanged.
- We use _build_chunk_for_pipeline and _right_table_complete of CrossJoinNode to communicate between CrossJoinRightSinkOperator and CrossJoinLeftOperator.
- CrossJoinLeftOperator inherited from OperatorWithDependency to build dependency with CrossJoinRightSinkOperator.
- Many _copy_ functions is the same as that in CrossJoinNode, we used a separate copy.

For https://github.com/StarRocks/starrocks/issues/711