### PR TITLE
Be compatible with old RPC

### DIFF
--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -93,7 +93,7 @@ private:
 
     PUniqueId _finst_id;
 
-    PBackendService_Stub* _brpc_stub = nullptr;
+    doris::PBackendService_Stub* _brpc_stub = nullptr;
 
     size_t _current_request_bytes = 0;
 

--- a/be/src/exec/pipeline/exchange/sink_buffer.h
+++ b/be/src/exec/pipeline/exchange/sink_buffer.h
@@ -12,7 +12,7 @@ namespace starrocks::pipeline {
 
 struct TransmitChunkInfo {
     PTransmitChunkParams params;
-    PBackendService_Stub* brpc_stub;
+    doris::PBackendService_Stub* brpc_stub;
 };
 
 class SinkBuffer {

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -14,7 +14,7 @@
 #include "exec/pipeline/result_sink_operator.h"
 #include "exec/pipeline/scan_operator.h"
 #include "exec/scan_node.h"
-#include "gen_cpp/starrocks_internal_service.pb.h"
+#include "gen_cpp/doris_internal_service.pb.h"
 #include "gutil/casts.h"
 #include "gutil/map_util.h"
 #include "runtime/data_stream_sender.h"

--- a/be/src/exec/tablet_sink.h
+++ b/be/src/exec/tablet_sink.h
@@ -35,6 +35,7 @@
 #include "exec/tablet_info.h"
 #include "exec/vectorized/tablet_info.h"
 #include "gen_cpp/Types_types.h"
+#include "gen_cpp/doris_internal_service.pb.h"
 #include "gen_cpp/internal_service.pb.h"
 #include "util/bitmap.h"
 #include "util/ref_count_closure.h"
@@ -239,7 +240,7 @@ private:
     std::atomic<int> _pending_batches_num{0};
     size_t _max_pending_batches_num = 16;
 
-    PBackendService_Stub* _stub = nullptr;
+    doris::PBackendService_Stub* _stub = nullptr;
     RefCountClosure<PTabletWriterOpenResult>* _open_closure = nullptr;
     ReusableClosure<PTabletWriterAddBatchResult>* _add_batch_closure = nullptr;
 

--- a/be/src/gen_cpp/CMakeLists.txt
+++ b/be/src/gen_cpp/CMakeLists.txt
@@ -77,7 +77,7 @@ set(SRC_FILES
     ${GEN_CPP_DIR}/data.pb.cc
     ${GEN_CPP_DIR}/descriptors.pb.cc
     ${GEN_CPP_DIR}/internal_service.pb.cc
-    ${GEN_CPP_DIR}/starrocks_internal_service.pb.cc
+    ${GEN_CPP_DIR}/doris_internal_service.pb.cc
     ${GEN_CPP_DIR}/types.pb.cc
     ${GEN_CPP_DIR}/snapshot.pb.cc
     ${GEN_CPP_DIR}/status.pb.cc

--- a/be/src/runtime/data_stream_mgr.h
+++ b/be/src/runtime/data_stream_mgr.h
@@ -31,7 +31,7 @@
 #include "common/object_pool.h"
 #include "common/status.h"
 #include "gen_cpp/Types_types.h" // for TUniqueId
-#include "gen_cpp/starrocks_internal_service.pb.h"
+#include "gen_cpp/doris_internal_service.pb.h"
 #include "runtime/descriptors.h" // for PlanNodeId
 #include "runtime/mem_tracker.h"
 #include "runtime/query_statistics.h"

--- a/be/src/runtime/data_stream_sender.cpp
+++ b/be/src/runtime/data_stream_sender.cpp
@@ -222,7 +222,7 @@ private:
 
     size_t _current_request_bytes = 0;
 
-    PBackendService_Stub* _brpc_stub = nullptr;
+    doris::PBackendService_Stub* _brpc_stub = nullptr;
     RefCountClosure<PTransmitDataResult>* _closure = nullptr;
 
     int32_t _brpc_timeout_ms = 500;

--- a/be/src/runtime/data_stream_sender.h
+++ b/be/src/runtime/data_stream_sender.h
@@ -31,6 +31,7 @@
 #include "common/status.h"
 #include "exec/data_sink.h"
 #include "gen_cpp/data.pb.h" // for PRowBatch
+#include "gen_cpp/doris_internal_service.pb.h"
 #include "gen_cpp/internal_service.pb.h"
 #include "util/raw_container.h"
 #include "util/runtime_profile.h"

--- a/be/src/runtime/runtime_filter_worker.cpp
+++ b/be/src/runtime/runtime_filter_worker.cpp
@@ -4,6 +4,7 @@
 
 #include "exprs/vectorized/runtime_filter_bank.h"
 #include "gen_cpp/PlanNodes_types.h"
+#include "gen_cpp/doris_internal_service.pb.h"
 #include "gen_cpp/internal_service.pb.h"
 #include "runtime/exec_env.h"
 #include "runtime/fragment_mgr.h"
@@ -23,8 +24,8 @@ public:
 
 static const int default_send_rpc_runtime_filter_timeout_ms = 1000;
 
-static void send_rpc_runtime_filter(PBackendService_Stub* stub, RuntimeFilterRpcClosure* rpc_closure, int timeout_ms,
-                                    const PTransmitRuntimeFilterParams& request) {
+static void send_rpc_runtime_filter(doris::PBackendService_Stub* stub, RuntimeFilterRpcClosure* rpc_closure,
+                                    int timeout_ms, const PTransmitRuntimeFilterParams& request) {
     if (rpc_closure->seq != 0) {
         brpc::Join(rpc_closure->cntl.call_id());
     }
@@ -286,7 +287,7 @@ void RuntimeFilterMerger::_send_total_runtime_filter(int32_t filter_id, RuntimeF
     while (index < size) {
         auto& t = targets[index];
         bool is_local = (local == t.first);
-        PBackendService_Stub* stub = _exec_env->brpc_stub_cache()->get_stub(t.first);
+        doris::PBackendService_Stub* stub = _exec_env->brpc_stub_cache()->get_stub(t.first);
         request.clear_probe_finst_ids();
         request.clear_forward_targets();
         for (const auto& inst : t.second) {
@@ -431,7 +432,7 @@ void RuntimeFilterWorker::_receive_total_runtime_filter(PTransmitRuntimeFilterPa
         TNetworkAddress addr;
         addr.hostname = t.host();
         addr.port = t.port();
-        PBackendService_Stub* stub = _exec_env->brpc_stub_cache()->get_stub(addr);
+        doris::PBackendService_Stub* stub = _exec_env->brpc_stub_cache()->get_stub(addr);
 
         request.clear_probe_finst_ids();
         request.clear_forward_targets();
@@ -511,7 +512,7 @@ void RuntimeFilterWorker::execute() {
 
         case SEND_PART_RF: {
             for (const auto& addr : ev.transmit_addrs) {
-                PBackendService_Stub* stub = _exec_env->brpc_stub_cache()->get_stub(addr);
+                doris::PBackendService_Stub* stub = _exec_env->brpc_stub_cache()->get_stub(addr);
                 send_rpc_runtime_filter(stub, rpc_closure, ev.transmit_timeout_ms, ev.transmit_rf_request);
             }
             break;

--- a/be/src/service/brpc_service.cpp
+++ b/be/src/service/brpc_service.cpp
@@ -46,8 +46,8 @@ BRpcService::~BRpcService() = default;
 
 Status BRpcService::start(int port) {
     // Add service
-    _server->AddService(new PInternalServiceImpl<PBackendService>(_exec_env), brpc::SERVER_OWNS_SERVICE);
-    _server->AddService(new PInternalServiceImpl<starrocks::PInternalService>(_exec_env), brpc::SERVER_OWNS_SERVICE);
+    _server->AddService(new PInternalServiceImpl<PInternalService>(_exec_env), brpc::SERVER_OWNS_SERVICE);
+    _server->AddService(new PInternalServiceImpl<doris::PBackendService>(_exec_env), brpc::SERVER_OWNS_SERVICE);
     // start service
     brpc::ServerOptions options;
     if (config::brpc_num_threads != -1) {

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -375,7 +375,7 @@ void PInternalServiceImpl<T>::get_info(google::protobuf::RpcController* controll
     Status::OK().to_protobuf(response->mutable_status());
 }
 
-template class PInternalServiceImpl<PBackendService>;
-template class PInternalServiceImpl<starrocks::PInternalService>;
+template class PInternalServiceImpl<PInternalService>;
+template class PInternalServiceImpl<doris::PBackendService>;
 
 } // namespace starrocks

--- a/be/src/service/internal_service.h
+++ b/be/src/service/internal_service.h
@@ -22,8 +22,8 @@
 #pragma once
 
 #include "common/status.h"
+#include "gen_cpp/doris_internal_service.pb.h"
 #include "gen_cpp/internal_service.pb.h"
-#include "gen_cpp/starrocks_internal_service.pb.h"
 #include "util/priority_thread_pool.hpp"
 
 namespace brpc {

--- a/be/src/util/brpc_stub_cache.h
+++ b/be/src/util/brpc_stub_cache.h
@@ -25,8 +25,8 @@
 #include <mutex>
 
 #include "gen_cpp/Types_types.h" // TNetworkAddress
+#include "gen_cpp/doris_internal_service.pb.h"
 #include "gen_cpp/internal_service.pb.h"
-#include "gen_cpp/starrocks_internal_service.pb.h"
 #include "service/brpc.h"
 #include "util/spinlock.h"
 #include "util/starrocks_metrics.h"
@@ -49,7 +49,7 @@ public:
         }
     }
 
-    PBackendService_Stub* get_stub(const butil::EndPoint& endpoint) {
+    doris::PBackendService_Stub* get_stub(const butil::EndPoint& endpoint) {
         std::lock_guard<SpinLock> l(_lock);
         auto stub_ptr = _stub_map.seek(endpoint);
         if (stub_ptr != nullptr) {
@@ -61,12 +61,12 @@ public:
         if (channel->Init(endpoint, &options)) {
             return nullptr;
         }
-        auto stub = new PBackendService_Stub(channel.release(), google::protobuf::Service::STUB_OWNS_CHANNEL);
+        auto stub = new doris::PBackendService_Stub(channel.release(), google::protobuf::Service::STUB_OWNS_CHANNEL);
         _stub_map.insert(endpoint, stub);
         return stub;
     }
 
-    PBackendService_Stub* get_stub(const TNetworkAddress& taddr) {
+    doris::PBackendService_Stub* get_stub(const TNetworkAddress& taddr) {
         butil::EndPoint endpoint;
         if (str2endpoint(taddr.hostname.c_str(), taddr.port, &endpoint)) {
             LOG(WARNING) << "unknown endpoint, hostname=" << taddr.hostname;
@@ -75,7 +75,7 @@ public:
         return get_stub(endpoint);
     }
 
-    PBackendService_Stub* get_stub(const std::string& host, int port) {
+    doris::PBackendService_Stub* get_stub(const std::string& host, int port) {
         butil::EndPoint endpoint;
         if (str2endpoint(host.c_str(), port, &endpoint)) {
             LOG(WARNING) << "unknown endpoint, hostname=" << host;
@@ -86,7 +86,7 @@ public:
 
 private:
     SpinLock _lock;
-    butil::FlatMap<butil::EndPoint, PBackendService_Stub*> _stub_map;
+    butil::FlatMap<butil::EndPoint, doris::PBackendService_Stub*> _stub_map;
 };
 
 } // namespace starrocks

--- a/gensrc/proto/doris_internal_service.proto
+++ b/gensrc/proto/doris_internal_service.proto
@@ -1,6 +1,6 @@
 // This file is made available under Elastic License 2.0
 // This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/gensrc/proto/starrocks_internal_service.proto
+//   https://github.com/apache/incubator-doris/blob/master/gensrc/proto/palo_internal_service.proto
 
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
@@ -25,12 +25,12 @@ syntax="proto2";
 
 import "internal_service.proto";
 
-package starrocks;
+package doris;
 option java_package = "com.starrocks.proto";
 
 option cc_generic_services = true;
 
-service PInternalService {
+service PBackendService {
     rpc transmit_data(starrocks.PTransmitDataParams) returns (starrocks.PTransmitDataResult);
     rpc exec_plan_fragment(starrocks.PExecPlanFragmentRequest) returns (starrocks.PExecPlanFragmentResult);
     rpc cancel_plan_fragment(starrocks.PCancelPlanFragmentRequest) returns (starrocks.PCancelPlanFragmentResult);

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -278,8 +278,8 @@ message PProxyResult {
 };
 
 // NOTE(zc): If you want to add new method here,
-// you MUST add same method to starrocks_internal_service.proto
-service PBackendService {
+// you MUST add same method to doris_internal_service.proto
+service PInternalService {
     rpc transmit_data(PTransmitDataParams) returns (PTransmitDataResult);
     rpc exec_plan_fragment(PExecPlanFragmentRequest) returns (PExecPlanFragmentResult);
     rpc cancel_plan_fragment(PCancelPlanFragmentRequest) returns (PCancelPlanFragmentResult);


### PR DESCRIPTION
Add doris.PBackendService to can communicate with clients at old release.
To solve the name conflict, rename the starrocks.PBackendService to
starrocks.PInternalService