### PR TITLE
[branch-mem] [Memory] remove mem_tracker from Segment/Rowset/Tablet/TabletMeta

### DIFF
--- a/be/src/http/action/meta_action.cpp
+++ b/be/src/http/action/meta_action.cpp
@@ -59,8 +59,7 @@ Status MetaAction::_handle_header(HttpRequest* req, std::string* json_meta) {
         LOG(WARNING) << "no tablet for tablet_id:" << tablet_id << " schema hash:" << schema_hash;
         return Status::InternalError("no tablet exist");
     }
-    auto mem_tracker = std::make_unique<MemTracker>();
-    TabletMetaSharedPtr tablet_meta(new TabletMeta(mem_tracker.get()));
+    TabletMetaSharedPtr tablet_meta(new TabletMeta());
     tablet->generate_tablet_meta_copy(tablet_meta);
     json2pb::Pb2JsonOptions json_options;
     json_options.pretty_json = true;

--- a/be/src/http/action/restore_tablet_action.cpp
+++ b/be/src/http/action/restore_tablet_action.cpp
@@ -149,8 +149,7 @@ Status RestoreTabletAction::_restore(const std::string& key, int64_t tablet_id, 
     }
     LOG(INFO) << "tablet path in trash:" << latest_tablet_path;
     std::string original_header_path = latest_tablet_path + "/" + std::to_string(tablet_id) + ".hdr";
-    auto mem_tracker = std::make_unique<MemTracker>();
-    TabletMeta tablet_meta(mem_tracker.get());
+    TabletMeta tablet_meta;
     if (Status load_status = tablet_meta.create_from_file(original_header_path); !load_status.ok()) {
         LOG(WARNING) << "header load and init error, header path:" << original_header_path;
         return Status::InternalError(load_status.to_string());

--- a/be/src/storage/base_tablet.cpp
+++ b/be/src/storage/base_tablet.cpp
@@ -26,11 +26,8 @@
 
 namespace starrocks {
 
-BaseTablet::BaseTablet(MemTracker* mem_tracker, const TabletMetaSharedPtr& tablet_meta, DataDir* data_dir)
-        : _mem_tracker(mem_tracker),
-          _state(tablet_meta->tablet_state()),
-          _tablet_meta(tablet_meta),
-          _data_dir(data_dir) {
+BaseTablet::BaseTablet(const TabletMetaSharedPtr& tablet_meta, DataDir* data_dir)
+        : _state(tablet_meta->tablet_state()), _tablet_meta(tablet_meta), _data_dir(data_dir) {
     _gen_tablet_path();
 }
 

--- a/be/src/storage/base_tablet.h
+++ b/be/src/storage/base_tablet.h
@@ -38,7 +38,7 @@ class DataDir;
 // storage engine evolves.
 class BaseTablet : public std::enable_shared_from_this<BaseTablet> {
 public:
-    BaseTablet(MemTracker* mem_tracker, const TabletMetaSharedPtr& tablet_meta, DataDir* data_dir);
+    BaseTablet(const TabletMetaSharedPtr& tablet_meta, DataDir* data_dir);
     virtual ~BaseTablet() = default;
 
     inline DataDir* data_dir() const;
@@ -66,14 +66,10 @@ public:
     // properties encapsulated in TabletSchema
     inline const TabletSchema& tablet_schema() const;
 
-    inline MemTracker* mem_tracker() { return _mem_tracker; }
-
 protected:
     virtual void on_shutdown() {}
 
     void _gen_tablet_path();
-
-    MemTracker* _mem_tracker = nullptr;
 
     TabletState _state;
     TabletMetaSharedPtr _tablet_meta;

--- a/be/src/storage/data_dir.cpp
+++ b/be/src/storage/data_dir.cpp
@@ -507,9 +507,7 @@ OLAPStatus DataDir::load() {
         }
         RowsetSharedPtr rowset;
         OLAPStatus create_status =
-                RowsetFactory::create_rowset(_tablet_manager->tablet_meta_mem_tracker(), &tablet->tablet_schema(),
-                                             tablet->tablet_path(), rowset_meta, &rowset)
-                                .ok()
+                RowsetFactory::create_rowset(&tablet->tablet_schema(), tablet->tablet_path(), rowset_meta, &rowset).ok()
                         ? OLAP_SUCCESS
                         : OLAP_ERR_OTHER_ERROR;
         if (create_status != OLAP_SUCCESS) {

--- a/be/src/storage/rowset/beta_rowset.h
+++ b/be/src/storage/rowset/beta_rowset.h
@@ -43,9 +43,8 @@ class KVStore;
 
 class BetaRowset : public Rowset {
 public:
-    BetaRowset(MemTracker* mem_tracker, const TabletSchema* schema, std::string rowset_path,
-               RowsetMetaSharedPtr rowset_meta);
-    ~BetaRowset() override { _mem_tracker->release(_mem_tracker->consumption()); }
+    BetaRowset(const TabletSchema* schema, std::string rowset_path, RowsetMetaSharedPtr rowset_meta);
+    ~BetaRowset() override {}
 
     OLAPStatus create_reader(RowsetReaderSharedPtr* result) override;
 

--- a/be/src/storage/rowset/beta_rowset_writer.cpp
+++ b/be/src/storage/rowset/beta_rowset_writer.cpp
@@ -258,7 +258,7 @@ Status BetaRowsetWriter::_final_merge() {
         std::string tmp_segment_file =
                 BetaRowset::segment_temp_file_path(_context.rowset_path_prefix, _context.rowset_id, seg_id);
 
-        auto segment_ptr = segment_v2::Segment::open(&tracker, fs::fs_util::block_manager(), tmp_segment_file, seg_id,
+        auto segment_ptr = segment_v2::Segment::open(fs::fs_util::block_manager(), tmp_segment_file, seg_id,
                                                      _context.tablet_schema);
         if (!segment_ptr.ok()) {
             LOG(WARNING) << "Fail to open " << tmp_segment_file << ": " << segment_ptr.status();
@@ -377,8 +377,7 @@ RowsetSharedPtr BetaRowsetWriter::build() {
 
     RowsetSharedPtr rowset;
     auto status =
-            RowsetFactory::create_rowset(ExecEnv::GetInstance()->tablet_meta_mem_tracker(), _context.tablet_schema,
-                                         _context.rowset_path_prefix, _rowset_meta, &rowset);
+            RowsetFactory::create_rowset(_context.tablet_schema, _context.rowset_path_prefix, _rowset_meta, &rowset);
     if (!status.ok()) {
         LOG(WARNING) << "Fail to create rowset: " << status;
         return nullptr;

--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -21,19 +21,15 @@
 
 #include "storage/rowset/rowset.h"
 
-#include <runtime/mem_tracker.h>
 #include <util/time.h>
 
 namespace starrocks {
 
-Rowset::Rowset(MemTracker* mem_tracker, const TabletSchema* schema, std::string rowset_path,
-               RowsetMetaSharedPtr rowset_meta)
+Rowset::Rowset(const TabletSchema* schema, std::string rowset_path, RowsetMetaSharedPtr rowset_meta)
         : _schema(schema),
           _rowset_path(std::move(rowset_path)),
           _rowset_meta(std::move(rowset_meta)),
-          _refs_by_reader(0) {
-    _mem_tracker = std::make_unique<MemTracker>(-1, "", mem_tracker, true);
-}
+          _refs_by_reader(0) {}
 
 Status Rowset::load() {
     // if the state is ROWSET_UNLOADING it means close() is called

--- a/be/src/storage/rowset/rowset.h
+++ b/be/src/storage/rowset/rowset.h
@@ -30,7 +30,6 @@
 #include "gen_cpp/olap_file.pb.h"
 #include "gutil/macros.h"
 #include "gutil/strings/substitute.h"
-#include "runtime/mem_tracker.h"
 #include "storage/rowset/rowset_meta.h"
 #include "storage/vectorized/chunk_iterator.h"
 
@@ -268,8 +267,7 @@ protected:
     Rowset(const Rowset&) = delete;
     const Rowset& operator=(const Rowset&) = delete;
     // this is non-public because all clients should use RowsetFactory to obtain pointer to initialized Rowset
-    Rowset(MemTracker* mem_tracker, const TabletSchema* schema, std::string rowset_path,
-           RowsetMetaSharedPtr rowset_meta);
+    Rowset(const TabletSchema* schema, std::string rowset_path, RowsetMetaSharedPtr rowset_meta);
 
     // this is non-public because all clients should use RowsetFactory to obtain pointer to initialized Rowset
     virtual OLAPStatus init() = 0;
@@ -282,8 +280,6 @@ protected:
 
     // allow subclass to add custom logic when rowset is being published
     virtual void make_visible_extra(Version version, VersionHash version_hash) {}
-
-    std::unique_ptr<MemTracker> _mem_tracker = nullptr;
 
     const TabletSchema* _schema;
     std::string _rowset_path;

--- a/be/src/storage/rowset/rowset_factory.cpp
+++ b/be/src/storage/rowset/rowset_factory.cpp
@@ -32,10 +32,10 @@
 
 namespace starrocks {
 
-Status RowsetFactory::create_rowset(MemTracker* mem_tracker, const TabletSchema* schema, const std::string& rowset_path,
+Status RowsetFactory::create_rowset(const TabletSchema* schema, const std::string& rowset_path,
                                     const RowsetMetaSharedPtr& rowset_meta, RowsetSharedPtr* rowset) {
     if (rowset_meta->rowset_type() == BETA_ROWSET) {
-        *rowset = std::make_shared<BetaRowset>(mem_tracker, schema, rowset_path, rowset_meta);
+        *rowset = std::make_shared<BetaRowset>(schema, rowset_path, rowset_meta);
         return (*rowset)->init() == OLAP_SUCCESS ? Status::OK() : Status::InternalError("fail to init rowset");
     }
     return Status::NotSupported("unsupported rowset type");

--- a/be/src/storage/rowset/rowset_factory.h
+++ b/be/src/storage/rowset/rowset_factory.h
@@ -35,7 +35,7 @@ class RowsetFactory {
 public:
     // return OK on success and set inited rowset in `*rowset`.
     // return error if failed to create or init rowset.
-    static Status create_rowset(MemTracker* mem_tracker, const TabletSchema* schema, const std::string& rowset_path,
+    static Status create_rowset(const TabletSchema* schema, const std::string& rowset_path,
                                 const RowsetMetaSharedPtr& rowset_meta, RowsetSharedPtr* rowset);
 
     // create and init rowset writer.

--- a/be/src/storage/rowset/segment_v2/segment.h
+++ b/be/src/storage/rowset/segment_v2/segment.h
@@ -76,13 +76,12 @@ class Segment : public std::enable_shared_from_this<Segment> {
     struct private_type;
 
 public:
-    static StatusOr<std::shared_ptr<Segment>> open(MemTracker* mem_tracker, fs::BlockManager* blk_mgr,
-                                                   const std::string& filename, uint32_t segment_id,
-                                                   const TabletSchema* tablet_schema,
+    static StatusOr<std::shared_ptr<Segment>> open(fs::BlockManager* blk_mgr, const std::string& filename,
+                                                   uint32_t segment_id, const TabletSchema* tablet_schema,
                                                    size_t* footer_length_hint = nullptr);
 
-    Segment(const private_type&, MemTracker* mem_tracker, fs::BlockManager* blk_mgr, std::string fname,
-            uint32_t segment_id, const TabletSchema* tablet_schema);
+    Segment(const private_type&, fs::BlockManager* blk_mgr, std::string fname, uint32_t segment_id,
+            const TabletSchema* tablet_schema);
 
     ~Segment();
 
@@ -159,8 +158,6 @@ private:
 
     friend class SegmentIterator;
     friend class vectorized::SegmentIterator;
-
-    MemTracker* _mem_tracker = nullptr;
 
     fs::BlockManager* _block_mgr;
     std::string _fname;

--- a/be/src/storage/snapshot_manager.cpp
+++ b/be/src/storage/snapshot_manager.cpp
@@ -145,8 +145,7 @@ Status SnapshotManager::convert_rowset_ids(const string& clone_dir, int64_t tabl
     if (has_meta_file) {
         return Status::OK();
     } else {
-        MemTracker mem_tracker;
-        TabletMeta cloned_tablet_meta(&mem_tracker);
+        TabletMeta cloned_tablet_meta;
         if (Status st = cloned_tablet_meta.create_from_file(cloned_header_file); !st.ok()) {
             LOG(WARNING) << "Fail to create rowset meta from " << cloned_header_file << ": " << st;
             return Status::RuntimeError("fail to load cloned header file");
@@ -217,9 +216,7 @@ Status SnapshotManager::_rename_rowset_id(const RowsetMetaPB& rs_meta_pb, const 
     RowsetMetaSharedPtr rowset_meta(new RowsetMeta());
     rowset_meta->init_from_pb(rs_meta_pb);
     RowsetSharedPtr org_rowset;
-    if (!RowsetFactory::create_rowset(ExecEnv::GetInstance()->tablet_meta_mem_tracker(), &tablet_schema, new_path,
-                                      rowset_meta, &org_rowset)
-                 .ok()) {
+    if (!RowsetFactory::create_rowset(&tablet_schema, new_path, rowset_meta, &org_rowset).ok()) {
         return Status::RuntimeError("fail to create rowset");
     }
     // do not use cache to load index
@@ -301,8 +298,7 @@ std::string SnapshotManager::_get_header_full_path(const TabletSharedPtr& tablet
 StatusOr<std::string> SnapshotManager::snapshot_incremental(const TabletSharedPtr& tablet,
                                                             const std::vector<int64_t>& delta_versions,
                                                             int64_t timeout_s) {
-    MemTracker mem_tracker;
-    TabletMetaSharedPtr snapshot_tablet_meta = std::make_shared<TabletMeta>(&mem_tracker);
+    TabletMetaSharedPtr snapshot_tablet_meta = std::make_shared<TabletMeta>();
     std::vector<RowsetSharedPtr> snapshot_rowsets;
     std::vector<RowsetMetaSharedPtr> snapshot_rowset_metas;
 
@@ -366,8 +362,7 @@ StatusOr<std::string> SnapshotManager::snapshot_incremental(const TabletSharedPt
 
 StatusOr<std::string> SnapshotManager::snapshot_full(const TabletSharedPtr& tablet, int64_t snapshot_version,
                                                      int64_t timeout_s) {
-    MemTracker mem_tracker;
-    TabletMetaSharedPtr snapshot_tablet_meta = std::make_shared<TabletMeta>(&mem_tracker);
+    TabletMetaSharedPtr snapshot_tablet_meta = std::make_shared<TabletMeta>();
     std::vector<RowsetSharedPtr> snapshot_rowsets;
     std::vector<RowsetMetaSharedPtr> snapshot_rowset_metas;
 

--- a/be/src/storage/tablet.h
+++ b/be/src/storage/tablet.h
@@ -64,10 +64,9 @@ using ChunkIteratorPtr = std::shared_ptr<vectorized::ChunkIterator>;
 
 class Tablet : public BaseTablet {
 public:
-    static TabletSharedPtr create_tablet_from_meta(MemTracker* mem_tracker, const TabletMetaSharedPtr& tablet_meta,
-                                                   DataDir* data_dir = nullptr);
+    static TabletSharedPtr create_tablet_from_meta(const TabletMetaSharedPtr& tablet_meta, DataDir* data_dir = nullptr);
 
-    Tablet(MemTracker* mem_tracker, TabletMetaSharedPtr tablet_meta, DataDir* data_dir);
+    Tablet(TabletMetaSharedPtr tablet_meta, DataDir* data_dir);
 
     ~Tablet() override;
 

--- a/be/src/storage/tablet_meta.h
+++ b/be/src/storage/tablet_meta.h
@@ -110,17 +110,17 @@ using AlterTabletTaskSharedPtr = std::shared_ptr<AlterTabletTask>;
 // The concurrency control is handled in Tablet Class, not in this class.
 class TabletMeta {
 public:
-    static Status create(MemTracker* mem_tracker, const TCreateTabletReq& request, const TabletUid& tablet_uid,
-                         uint64_t shard_id, uint32_t next_unique_id,
+    static Status create(const TCreateTabletReq& request, const TabletUid& tablet_uid, uint64_t shard_id,
+                         uint32_t next_unique_id,
                          const std::unordered_map<uint32_t, uint32_t>& col_ordinal_to_unique_id,
                          RowsetTypePB rowset_type, TabletMetaSharedPtr* tablet_meta);
 
-    explicit TabletMeta(MemTracker* mem_tracker);
-    TabletMeta(MemTracker* mem_tracker, int64_t table_id, int64_t partition_id, int64_t tablet_id, int32_t schema_hash,
-               uint64_t shard_id, const TTabletSchema& tablet_schema, uint32_t next_unique_id,
+    explicit TabletMeta();
+    TabletMeta(int64_t table_id, int64_t partition_id, int64_t tablet_id, int32_t schema_hash, uint64_t shard_id,
+               const TTabletSchema& tablet_schema, uint32_t next_unique_id,
                const std::unordered_map<uint32_t, uint32_t>& col_ordinal_to_unique_id, const TabletUid& tablet_uid,
                TTabletType::type tabletType, RowsetTypePB roset_type);
-    virtual ~TabletMeta() { _mem_tracker->release(_mem_tracker->consumption()); }
+    virtual ~TabletMeta() {}
 
     // Function create_from_file is used to be compatible with previous tablet_meta.
     // Previous tablet_meta is a physical file in tablet dir, which is not stored in rocksdb.
@@ -164,13 +164,7 @@ public:
 
     inline const TabletSchema& tablet_schema() const;
 
-    inline void set_tablet_schema(const std::shared_ptr<TabletSchema>& tablet_schema) {
-        if (_schema != nullptr) {
-            _mem_tracker->release(_schema->mem_usage());
-        }
-        _schema = tablet_schema;
-        _mem_tracker->consume(_schema->mem_usage());
-    }
+    inline void set_tablet_schema(const std::shared_ptr<TabletSchema>& tablet_schema) { _schema = tablet_schema; }
 
     inline std::shared_ptr<TabletSchema>& mutable_tablet_schema() { return _schema; }
 
@@ -231,8 +225,6 @@ private:
     // _del_pred_array is ignored to compare.
     friend bool operator==(const TabletMeta& a, const TabletMeta& b);
     friend bool operator!=(const TabletMeta& a, const TabletMeta& b);
-
-    std::unique_ptr<MemTracker> _mem_tracker = nullptr;
 
     int64_t _table_id = 0;
     int64_t _partition_id = 0;

--- a/be/src/storage/tablet_meta_manager.cpp
+++ b/be/src/storage/tablet_meta_manager.cpp
@@ -304,8 +304,7 @@ Status TabletMetaManager::get_tablet_meta(DataDir* store, TTabletId tablet_id, T
 
 Status TabletMetaManager::get_json_meta(DataDir* store, TTabletId tablet_id, TSchemaHash schema_hash,
                                         std::string* json_meta) {
-    MemTracker mem_tracker;
-    TabletMetaSharedPtr tablet_meta(new TabletMeta(&mem_tracker));
+    TabletMetaSharedPtr tablet_meta(new TabletMeta());
     RETURN_IF_ERROR(get_tablet_meta(store, tablet_id, schema_hash, tablet_meta));
 
     if (tablet_meta->mutable_tablet_schema()->keys_type() != PRIMARY_KEYS) {

--- a/be/src/storage/tablet_meta_manager.h
+++ b/be/src/storage/tablet_meta_manager.h
@@ -24,6 +24,7 @@
 
 #include <string>
 
+#include "rapidjson/document.h"
 #include "storage/data_dir.h"
 #include "storage/kv_store.h"
 #include "storage/olap_define.h"

--- a/be/src/storage/task/engine_clone_task.cpp
+++ b/be/src/storage/task/engine_clone_task.cpp
@@ -440,11 +440,10 @@ Status EngineCloneTask::_finish_clone(Tablet* tablet, const string& clone_dir, i
 
     tablet->obtain_push_lock();
     tablet->obtain_header_wrlock();
-    MemTracker mem_tracker;
     do {
         // load src header
         std::string header_file = strings::Substitute("$0/$1.hdr", clone_dir, tablet->tablet_id());
-        TabletMeta cloned_tablet_meta(&mem_tracker);
+        TabletMeta cloned_tablet_meta;
         res = cloned_tablet_meta.create_from_file(header_file);
         if (!res.ok()) {
             LOG(WARNING) << "Fail to load load tablet meta from " << header_file;
@@ -624,8 +623,8 @@ Status EngineCloneTask::_clone_full_data(Tablet* tablet, TabletMeta* cloned_tabl
     // but some rowset is useless, so that remove them here
     for (auto& rs_meta_ptr : rs_metas_found_in_src) {
         RowsetSharedPtr rowset_to_remove;
-        if (auto s = RowsetFactory::create_rowset(_tablet_meta_mem_tracker, &(cloned_tablet_meta->tablet_schema()),
-                                                  tablet->tablet_path(), rs_meta_ptr, &rowset_to_remove);
+        if (auto s = RowsetFactory::create_rowset(&(cloned_tablet_meta->tablet_schema()), tablet->tablet_path(),
+                                                  rs_meta_ptr, &rowset_to_remove);
             !s.ok()) {
             LOG(WARNING) << "failed to init rowset to remove: " << rs_meta_ptr->rowset_id().to_string();
             continue;

--- a/be/src/storage/task/engine_storage_migration_task.cpp
+++ b/be/src/storage/task/engine_storage_migration_task.cpp
@@ -132,8 +132,7 @@ OLAPStatus EngineStorageMigrationTask::_storage_migrate(TabletSharedPtr tablet) 
             return OLAP_ERR_FILE_ALREADY_EXIST;
         }
 
-        auto mem_tracker = std::make_unique<MemTracker>();
-        TabletMetaSharedPtr new_tablet_meta(new (std::nothrow) TabletMeta(mem_tracker.get()));
+        TabletMetaSharedPtr new_tablet_meta(new (std::nothrow) TabletMeta());
         Status st = TabletMetaManager::get_tablet_meta(_dest_store, _tablet_id, _schema_hash, new_tablet_meta);
         if (st.ok()) {
             LOG(WARNING) << "tablet_meta already exists. data_dir:" << _dest_store->path()
@@ -184,8 +183,7 @@ OLAPStatus EngineStorageMigrationTask::_storage_migrate(TabletSharedPtr tablet) 
             break;
         }
 
-        auto mem_tracker = std::make_unique<MemTracker>();
-        TabletMetaSharedPtr new_tablet_meta(new (std::nothrow) TabletMeta(mem_tracker.get()));
+        TabletMetaSharedPtr new_tablet_meta(new (std::nothrow) TabletMeta());
         Status st = TabletMetaManager::get_tablet_meta(_dest_store, _tablet_id, _schema_hash, new_tablet_meta);
         if (st.ok()) {
             LOG(WARNING) << "tablet_meta already exists. data_dir:" << _dest_store->path()

--- a/be/src/tools/meta_tool.cpp
+++ b/be/src/tools/meta_tool.cpp
@@ -35,7 +35,6 @@
 #include "gutil/strings/split.h"
 #include "gutil/strings/substitute.h"
 #include "json2pb/pb_to_json.h"
-#include "runtime/mem_tracker.h"
 #include "storage/data_dir.h"
 #include "storage/olap_define.h"
 #include "storage/options.h"
@@ -109,8 +108,7 @@ std::string get_usage(const std::string& progname) {
 }
 
 void show_meta() {
-    auto mem_tracker = std::make_unique<MemTracker>();
-    TabletMeta tablet_meta(mem_tracker.get());
+    TabletMeta tablet_meta;
     Status s = tablet_meta.create_from_file(FLAGS_pb_meta_path);
     if (!s.ok()) {
         std::cout << "load pb meta file:" << FLAGS_pb_meta_path << " failed"

--- a/be/test/storage/rowset/beta_rowset_test.cpp
+++ b/be/test/storage/rowset/beta_rowset_test.cpp
@@ -691,14 +691,10 @@ TEST_F(BetaRowsetTest, FinalMergeTest) {
         seg_options.block_mgr = fs::fs_util::block_manager();
         seg_options.stats = &_stats;
 
-        MemTracker tracker;
-        DeferOp memory_tracker_releaser([&tracker] { return tracker.release(tracker.consumption()); });
-
         std::string segment_file =
                 BetaRowset::segment_file_path(writer_context.rowset_path_prefix, writer_context.rowset_id, 0);
 
-        auto segment =
-                *segment_v2::Segment::open(&tracker, fs::fs_util::block_manager(), segment_file, 0, &tablet_schema);
+        auto segment = *segment_v2::Segment::open(fs::fs_util::block_manager(), segment_file, 0, &tablet_schema);
         ASSERT_NE(segment->num_rows(), 0);
         auto res = segment->new_iterator(schema, seg_options);
         ASSERT_FALSE(res.status().is_end_of_file() || !res.ok() || res.value() == nullptr);

--- a/be/test/storage/rowset/segment_v2/column_reader_writer_test.cpp
+++ b/be/test/storage/rowset/segment_v2/column_reader_writer_test.cpp
@@ -34,7 +34,6 @@
 #include "gen_cpp/segment_v2.pb.h"
 #include "runtime/date_value.h"
 #include "runtime/mem_pool.h"
-#include "runtime/mem_tracker.h"
 #include "storage/column_block.h"
 #include "storage/decimal12.h"
 #include "storage/field.h"
@@ -62,7 +61,7 @@ public:
 protected:
     void SetUp() override {}
 
-    void TearDown() override { _tracker.release(_tracker.consumption()); }
+    void TearDown() override {}
 
     template <FieldType type, EncodingTypePB encoding, uint32_t version, bool adaptive = true>
     void test_nullable_data(const vectorized::Column& src) {
@@ -130,7 +129,7 @@ protected:
             reader_opts.storage_format_version = version;
             reader_opts.block_mgr = block_mgr.get();
             std::unique_ptr<ColumnReader> reader;
-            auto st = ColumnReader::create(&_tracker, reader_opts, meta, num_rows, fname, &reader);
+            auto st = ColumnReader::create(reader_opts, meta, num_rows, fname, &reader);
             ASSERT_TRUE(st.ok());
 
             ColumnIterator* iter = nullptr;
@@ -380,7 +379,6 @@ protected:
         test_nullable_data<type, BIT_SHUFFLE, 2>(*col);
     }
 
-    MemTracker _tracker;
     MemPool _pool;
 };
 
@@ -555,7 +553,7 @@ TEST_F(ColumnReaderWriterTest, test_array_int) {
         reader_opts.block_mgr = block_mgr.get();
         reader_opts.storage_format_version = 2;
         std::unique_ptr<ColumnReader> reader;
-        auto st = ColumnReader::create(&_tracker, reader_opts, meta, num_rows, fname, &reader);
+        auto st = ColumnReader::create(reader_opts, meta, num_rows, fname, &reader);
         ASSERT_TRUE(st.ok());
 
         ColumnIterator* iter = nullptr;

--- a/be/test/storage/rowset/segment_v2/segment_test.cpp
+++ b/be/test/storage/rowset/segment_v2/segment_test.cpp
@@ -136,7 +136,7 @@ protected:
         uint64_t file_size, index_size;
         ASSERT_OK(writer.finalize(&file_size, &index_size));
 
-        *res = *Segment::open(_mem_tracker.get(), _block_mgr, filename, 0, &query_schema);
+        *res = *Segment::open(_block_mgr, filename, 0, &query_schema);
         ASSERT_EQ(nrows, (*res)->num_rows());
     }
 
@@ -819,7 +819,7 @@ TEST_F(SegmentReaderWriterTest, TestStringDict) {
     ASSERT_OK(writer.finalize(&file_size, &index_size));
 
     {
-        auto segment = *Segment::open(_mem_tracker.get(), _block_mgr, fname, 0, tablet_schema.get());
+        auto segment = *Segment::open(_block_mgr, fname, 0, tablet_schema.get());
         ASSERT_EQ(4096, segment->num_rows());
         Schema schema(*tablet_schema);
         OlapReaderStatistics stats;

--- a/be/test/storage/tablet_meta_manager_test.cpp
+++ b/be/test/storage/tablet_meta_manager_test.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include <filesystem>
+#include <thread>
 
 #include "storage/del_vector.h"
 
@@ -53,12 +54,11 @@ TEST_F(TabletMetaManagerTest, test_save_load_tablet_meta) {
     c0->set_type("INT");
     c0->set_index_length(4);
 
-    MemTracker tracker;
-    auto meta = std::make_shared<TabletMeta>(&tracker);
+    auto meta = std::make_shared<TabletMeta>();
     meta->init_from_pb(&meta_pb);
 
     ASSERT_TRUE(TabletMetaManager::save(_data_dir.get(), meta->tablet_id(), meta->schema_hash(), meta).ok());
-    auto load_meta = std::make_shared<TabletMeta>(&tracker);
+    auto load_meta = std::make_shared<TabletMeta>();
     ASSERT_TRUE(TabletMetaManager::get_tablet_meta(_data_dir.get(), meta->tablet_id(), meta->schema_hash(), load_meta)
                         .ok());
     ASSERT_EQ(1, load_meta->table_id());
@@ -74,7 +74,7 @@ TEST_F(TabletMetaManagerTest, test_save_load_tablet_meta) {
     ASSERT_EQ(true, load_meta->tablet_schema().column(0).is_key());
     ASSERT_EQ(OLAP_FIELD_TYPE_INT, load_meta->tablet_schema().column(0).type());
 
-    load_meta.reset(new TabletMeta(&tracker));
+    load_meta.reset(new TabletMeta());
     auto visit_func = [&](long tablet_id, long schema_hash, const std::string& meta) -> bool {
         CHECK(load_meta->deserialize(meta).ok());
         return true;

--- a/be/test/storage/tablet_meta_test.cpp
+++ b/be/test/storage/tablet_meta_test.cpp
@@ -103,11 +103,9 @@ TEST(TabletMetaTest, test_create) {
     col_ordinal_to_unique_id[2] = 10002;
     col_ordinal_to_unique_id[3] = 10003;
 
-    auto mem_tracker = std::make_unique<MemTracker>();
     TabletMetaSharedPtr tablet_meta;
-    Status st = TabletMeta::create(mem_tracker.get(), request, TabletUid(321, 456), 987 /*shared_id*/,
-                                   20000 /*next_unique_id*/, col_ordinal_to_unique_id, RowsetTypePB::BETA_ROWSET,
-                                   &tablet_meta);
+    Status st = TabletMeta::create(request, TabletUid(321, 456), 987 /*shared_id*/, 20000 /*next_unique_id*/,
+                                   col_ordinal_to_unique_id, RowsetTypePB::BETA_ROWSET, &tablet_meta);
     ASSERT_TRUE(st.ok());
     ASSERT_TRUE(tablet_meta != nullptr);
 

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -260,11 +260,11 @@ static TabletSharedPtr load_same_tablet_from_store(const TabletSharedPtr& tablet
     CHECK(st.ok()) << st;
 
     // Parse tablet meta.
-    auto tablet_meta = std::make_shared<TabletMeta>(tablet->mem_tracker());
+    auto tablet_meta = std::make_shared<TabletMeta>();
     CHECK(tablet_meta->deserialize(serialized_meta).ok());
 
     // Create a new tablet instance from the latest snapshot.
-    auto tablet1 = Tablet::create_tablet_from_meta(tablet->mem_tracker(), tablet_meta, data_dir);
+    auto tablet1 = Tablet::create_tablet_from_meta(tablet_meta, data_dir);
     CHECK(tablet1 != nullptr);
     CHECK(tablet1->init().ok());
     CHECK(tablet1->init_succeeded());

--- a/be/test/storage/vectorized/base_compaction_test.cpp
+++ b/be/test/storage/vectorized/base_compaction_test.cpp
@@ -146,7 +146,6 @@ public:
         _schema_hash_path = tablet_path + "/1111";
         ASSERT_TRUE(FileUtils::create_dir(_schema_hash_path).ok());
 
-        _tablet_meta_mem_tracker.reset(new MemTracker(-1));
         _mem_pool.reset(new MemPool());
 
         _compaction_mem_tracker.reset(new MemTracker(-1));
@@ -162,14 +161,13 @@ protected:
     std::unique_ptr<TabletSchema> _tablet_schema;
     RowsetTypePB _rowset_type = BETA_ROWSET;
     std::string _schema_hash_path;
-    std::unique_ptr<MemTracker> _tablet_meta_mem_tracker;
     std::unique_ptr<MemTracker> _compaction_mem_tracker;
     std::unique_ptr<MemPool> _mem_pool;
 };
 
 TEST_F(BaseCompactionTest, test_init_succeeded) {
-    TabletMetaSharedPtr tablet_meta(new TabletMeta(_tablet_meta_mem_tracker.get()));
-    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(_tablet_meta_mem_tracker.get(), tablet_meta, nullptr);
+    TabletMetaSharedPtr tablet_meta(new TabletMeta());
+    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(tablet_meta, nullptr);
     BaseCompaction base_compaction(_compaction_mem_tracker.get(), tablet);
     ASSERT_FALSE(base_compaction.compact().ok());
 }
@@ -179,10 +177,10 @@ TEST_F(BaseCompactionTest, test_input_rowsets_LE_1) {
     schema_pb.set_keys_type(KeysType::DUP_KEYS);
     auto schema = std::make_shared<TabletSchema>();
     schema->init_from_pb(schema_pb);
-    TabletMetaSharedPtr tablet_meta(new TabletMeta(_tablet_meta_mem_tracker.get()));
+    TabletMetaSharedPtr tablet_meta(new TabletMeta());
     tablet_meta->set_tablet_schema(schema);
 
-    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(_tablet_meta_mem_tracker.get(), tablet_meta, nullptr);
+    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(tablet_meta, nullptr);
     tablet->init();
     BaseCompaction base_compaction(_compaction_mem_tracker.get(), tablet);
     ASSERT_FALSE(base_compaction.compact().ok());
@@ -206,7 +204,7 @@ TEST_F(BaseCompactionTest, test_input_rowsets_EQ_2) {
     ASSERT_EQ(src_rowset_id, src_rowset->rowset_id());
     ASSERT_EQ(1024, src_rowset->num_rows());
 
-    TabletMetaSharedPtr tablet_meta(new TabletMeta(_tablet_meta_mem_tracker.get()));
+    TabletMetaSharedPtr tablet_meta(new TabletMeta());
     create_tablet_meta(tablet_meta.get());
     tablet_meta->add_rs_meta(src_rowset->rowset_meta());
 
@@ -231,7 +229,7 @@ TEST_F(BaseCompactionTest, test_input_rowsets_EQ_2) {
         tablet_meta->add_rs_meta(src_rowset->rowset_meta());
     }
 
-    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(_tablet_meta_mem_tracker.get(), tablet_meta, nullptr);
+    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(tablet_meta, nullptr);
     tablet->init();
     tablet->calculate_cumulative_point();
 
@@ -259,7 +257,7 @@ TEST_F(BaseCompactionTest, test_compact_succeed) {
     ASSERT_EQ(src_rowset_id, src_rowset->rowset_id());
     ASSERT_EQ(1024, src_rowset->num_rows());
 
-    TabletMetaSharedPtr tablet_meta(new TabletMeta(_tablet_meta_mem_tracker.get()));
+    TabletMetaSharedPtr tablet_meta(new TabletMeta());
     create_tablet_meta(tablet_meta.get());
     tablet_meta->add_rs_meta(src_rowset->rowset_meta());
 
@@ -305,9 +303,8 @@ TEST_F(BaseCompactionTest, test_compact_succeed) {
         tablet_meta->add_rs_meta(src_rowset->rowset_meta());
     }
 
-    TabletSharedPtr tablet =
-            Tablet::create_tablet_from_meta(_tablet_meta_mem_tracker.get(), tablet_meta,
-                                            starrocks::ExecEnv::GetInstance()->storage_engine()->get_stores()[0]);
+    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(
+            tablet_meta, starrocks::ExecEnv::GetInstance()->storage_engine()->get_stores()[0]);
     tablet->init();
     tablet->calculate_cumulative_point();
 

--- a/be/test/storage/vectorized/cumulative_compaction_test.cpp
+++ b/be/test/storage/vectorized/cumulative_compaction_test.cpp
@@ -168,8 +168,8 @@ protected:
 };
 
 TEST_F(CumulativeCompactionTest, test_init_succeeded) {
-    TabletMetaSharedPtr tablet_meta(new TabletMeta(_tablet_meta_mem_tracker.get()));
-    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(_tablet_meta_mem_tracker.get(), tablet_meta, nullptr);
+    TabletMetaSharedPtr tablet_meta(new TabletMeta());
+    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(tablet_meta, nullptr);
     CumulativeCompaction cumulative_compaction(_compaction_mem_tracker.get(), tablet);
     ASSERT_FALSE(cumulative_compaction.compact().ok());
 }
@@ -181,10 +181,10 @@ TEST_F(CumulativeCompactionTest, test_candidate_rowsets_empty) {
     auto schema = std::make_shared<TabletSchema>();
     schema->init_from_pb(schema_pb);
 
-    TabletMetaSharedPtr tablet_meta(new TabletMeta(_tablet_meta_mem_tracker.get()));
+    TabletMetaSharedPtr tablet_meta(new TabletMeta());
     tablet_meta->set_tablet_schema(schema);
 
-    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(_tablet_meta_mem_tracker.get(), tablet_meta, nullptr);
+    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(tablet_meta, nullptr);
     tablet->init();
     CumulativeCompaction cumulative_compaction(_compaction_mem_tracker.get(), tablet);
     ASSERT_FALSE(cumulative_compaction.compact().ok());
@@ -209,7 +209,7 @@ TEST_F(CumulativeCompactionTest, test_compact_succeed) {
     ASSERT_EQ(src_rowset_id, src_rowset->rowset_id());
     ASSERT_EQ(1024, src_rowset->num_rows());
 
-    TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>(_tablet_meta_mem_tracker.get());
+    TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
     create_tablet_meta(tablet_meta.get());
     tablet_meta->add_rs_meta(src_rowset->rowset_meta());
 
@@ -234,9 +234,8 @@ TEST_F(CumulativeCompactionTest, test_compact_succeed) {
         tablet_meta->add_rs_meta(src_rowset->rowset_meta());
     }
 
-    TabletSharedPtr tablet =
-            Tablet::create_tablet_from_meta(_tablet_meta_mem_tracker.get(), tablet_meta,
-                                            starrocks::ExecEnv::GetInstance()->storage_engine()->get_stores()[0]);
+    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(
+            tablet_meta, starrocks::ExecEnv::GetInstance()->storage_engine()->get_stores()[0]);
     tablet->init();
 
     config::cumulative_compaction_skip_window_seconds = -2;


### PR DESCRIPTION
for #703 

Under the new memory mechanism, there is no need to set up MemTracker separately when constructing metadata-related data structures