### PR TITLE
Dont use min/max values they are absent in runtime filter

### DIFF
--- a/be/src/exec/vectorized/olap_scan_prepare.h
+++ b/be/src/exec/vectorized/olap_scan_prepare.h
@@ -363,7 +363,9 @@ static void normalize_join_runtime_filter(const SlotDescriptor& slot, const std:
         if (!desc->is_probe_slot_ref(&slot_id) || slot_id != slot.id()) continue;
 
         const RuntimeBloomFilter<SlotType>* filter = down_cast<const RuntimeBloomFilter<SlotType>*>(rf);
-
+        // For some cases such as in bucket shuffle, some hash join node may not have any input chunk from right table.
+        // Runtime filter does not have any min/max values in this case.
+        if (!filter->has_min_max()) continue;
         // If this column doesn't have other filter, we use join runtime filter
         // to fast comput row range in storage engine
         if (range->is_init_state()) {

--- a/be/src/exprs/vectorized/runtime_filter.h
+++ b/be/src/exprs/vectorized/runtime_filter.h
@@ -251,27 +251,9 @@ public:
 
     RuntimeBloomFilter* create_empty(ObjectPool* pool) override { return pool->add(new RuntimeBloomFilter()); };
 
-    static constexpr bool is_support_min_max() {
-        if constexpr (IsSlice<CppType>) {
-            return true;
-        } else if constexpr (std::is_integral_v<CppType>) {
-            return true;
-        } else if constexpr (std::is_floating_point_v<CppType>) {
-            return true;
-        } else if constexpr (IsDate<CppType>) {
-            return true;
-        } else if constexpr (IsTimestamp<CppType>) {
-            return true;
-        } else if constexpr (IsDecimal<CppType>) {
-            return true;
-        }
-        return false;
-    }
-
     void init_min_max() {
         _has_min_max = false;
 
-        // note: be sure following types are consistent to `is_support_min_max`
         if constexpr (IsSlice<CppType>) {
             _min = Slice::max_value();
             _max = Slice::min_value();
@@ -319,11 +301,9 @@ public:
         size_t hash = compute_hash(*value);
         _bf.insert_hash(hash);
 
-        if constexpr (is_support_min_max()) {
-            _min = std::min(*value, _min);
-            _max = std::max(*value, _max);
-            _has_min_max = true;
-        }
+        _min = std::min(*value, _min);
+        _max = std::max(*value, _max);
+        _has_min_max = true;
     }
 
     CppType min_value() const { return _min; }


### PR DESCRIPTION
ref: #712 

For some cases such as in bucket shuffle, some hash join nodes may not have any input chunk from the right table. So in that case, the runtime filter does not have any min/max information, and we can not use min/max on scan node zonemap. 
