### PR TITLE
fix: logic at driver is pending_finish and the fragment is cancelled

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -135,7 +135,7 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state) {
         _first_unfinished = _new_first_unfinished;
 
         if (sink_operator()->is_finished()) {
-            cancel(_fragment_ctx->runtime_state());
+            cancel(runtime_state);
             _state = source_operator()->pending_finish() ? DriverState::PENDING_FINISH : DriverState::FINISH;
             return _state;
         }

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -65,14 +65,7 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state) {
                     continue;
                 }
 
-                // check whether fragment is finished beforehand before pull_chunk
-                if (_fragment_ctx->is_canceled()) {
-                    cancel(_fragment_ctx->runtime_state());
-                    if (source_operator()->pending_finish()) {
-                        _state = DriverState::PENDING_FINISH;
-                    } else {
-                        _state = _fragment_ctx->final_status().ok() ? DriverState::FINISH : DriverState::CANCELED;
-                    }
+                if (_check_fragment_is_canceled(runtime_state)) {
                     return _state;
                 }
 
@@ -85,14 +78,7 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state) {
                     return status;
                 }
 
-                // check whether fragment is finished beforehand before push_chunk
-                if (_fragment_ctx->is_canceled()) {
-                    cancel(_fragment_ctx->runtime_state());
-                    if (source_operator()->pending_finish()) {
-                        _state = DriverState::PENDING_FINISH;
-                    } else {
-                        _state = _fragment_ctx->final_status().ok() ? DriverState::FINISH : DriverState::CANCELED;
-                    }
+                if (_check_fragment_is_canceled(runtime_state)) {
                     return _state;
                 }
 
@@ -135,14 +121,14 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state) {
         _first_unfinished = _new_first_unfinished;
 
         if (sink_operator()->is_finished()) {
-            cancel(runtime_state);
+            cancel_if_necessary(runtime_state);
             _state = source_operator()->pending_finish() ? DriverState::PENDING_FINISH : DriverState::FINISH;
             return _state;
         }
 
         // no chunk moved in current round means that the driver is blocked.
-        // should yield means that the CPU core is occupied the driver for the
-        // a very long time so that the driver should switch off the core and
+        // should yield means that the CPU core is occupied the driver for a
+        // very long time so that the driver should switch off the core and
         // give chance for another ready driver to run.
         if (num_chunk_moved == 0 || should_yield) {
             driver_acct().increment_schedule_times();
@@ -165,7 +151,7 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state) {
     }
 }
 
-void PipelineDriver::cancel(RuntimeState* state) {
+void PipelineDriver::cancel_if_necessary(RuntimeState* state) {
     for (auto i = _first_unfinished; i < _operators.size(); ++i) {
         _operators[i]->finish(state);
     }
@@ -219,4 +205,20 @@ std::string PipelineDriver::to_debug_string() const {
     ss << "]";
     return ss.str();
 }
+
+bool PipelineDriver::_check_fragment_is_canceled(RuntimeState* runtime_state) {
+    if (_fragment_ctx->is_canceled()) {
+        cancel_if_necessary(runtime_state);
+        // If the fragment is cancelled after the source operator commits an i/o task to i/o threads,
+        // the driver cannot be finished immediately and should wait for the completion of the pending i/o task.
+        if (source_operator()->pending_finish()) {
+            _state = DriverState::PENDING_FINISH;
+        } else {
+            _state = _fragment_ctx->final_status().ok() ? DriverState::FINISH : DriverState::CANCELED;
+        }
+        return true;
+    }
+    return false;
+}
+
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -134,7 +134,9 @@ public:
     void set_driver_state(DriverState state) { _state = state; }
     SourceOperator* source_operator() { return down_cast<SourceOperator*>(_operators.front().get()); }
 
-    void cancel(RuntimeState* state);
+    // Notify all the unfinished operators to be finished.
+    // It is usually used when the sink operator is finished, or the fragment is cancelled or expired.
+    void cancel_if_necessary(RuntimeState* state);
 
     Operator* sink_operator() { return _operators.back().get(); }
     bool is_finished() {
@@ -168,6 +170,9 @@ public:
     std::string to_debug_string() const;
 
 private:
+    // check whether fragment is cancelled. It is used before pull_chunk and push_chunk.
+    bool _check_fragment_is_canceled(RuntimeState* runtime_state);
+
     Operators _operators;
     DriverDependencies _dependencies;
     bool _all_dependencies_ready = false;

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -136,7 +136,7 @@ public:
 
     // Notify all the unfinished operators to be finished.
     // It is usually used when the sink operator is finished, or the fragment is cancelled or expired.
-    void cancel_if_necessary(RuntimeState* state);
+    void finish_operators(RuntimeState* state);
 
     Operator* sink_operator() { return _operators.back().get(); }
     bool is_finished() {

--- a/be/src/exec/pipeline/pipeline_driver_dispatcher.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_dispatcher.cpp
@@ -63,7 +63,7 @@ void GlobalDriverDispatcher::run() {
         if (fragment_ctx->is_canceled()) {
             VLOG_ROW << "[Driver] Canceled: driver=" << driver
                      << ", error=" << fragment_ctx->final_status().to_string();
-            driver->cancel_if_necessary(runtime_state);
+            driver->finish_operators(runtime_state);
             if (driver->source_operator()->pending_finish()) {
                 driver->set_driver_state(DriverState::PENDING_FINISH);
                 _blocked_driver_poller->add_blocked_driver(driver);
@@ -86,7 +86,7 @@ void GlobalDriverDispatcher::run() {
         if (!status.ok()) {
             VLOG_ROW << "[Driver] Process error: error=" << status.status().to_string();
             query_ctx->cancel(status.status());
-            driver->cancel_if_necessary(runtime_state);
+            driver->finish_operators(runtime_state);
             if (driver->source_operator()->pending_finish()) {
                 driver->set_driver_state(DriverState::PENDING_FINISH);
                 _blocked_driver_poller->add_blocked_driver(driver);

--- a/be/src/exec/pipeline/pipeline_driver_dispatcher.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_dispatcher.cpp
@@ -63,7 +63,7 @@ void GlobalDriverDispatcher::run() {
         if (fragment_ctx->is_canceled()) {
             VLOG_ROW << "[Driver] Canceled: driver=" << driver
                      << ", error=" << fragment_ctx->final_status().to_string();
-            driver->cancel(runtime_state);
+            driver->cancel_if_necessary(runtime_state);
             if (driver->source_operator()->pending_finish()) {
                 driver->set_driver_state(DriverState::PENDING_FINISH);
                 _blocked_driver_poller->add_blocked_driver(driver);
@@ -86,7 +86,7 @@ void GlobalDriverDispatcher::run() {
         if (!status.ok()) {
             VLOG_ROW << "[Driver] Process error: error=" << status.status().to_string();
             query_ctx->cancel(status.status());
-            driver->cancel(runtime_state);
+            driver->cancel_if_necessary(runtime_state);
             if (driver->source_operator()->pending_finish()) {
                 driver->set_driver_state(DriverState::PENDING_FINISH);
                 _blocked_driver_poller->add_blocked_driver(driver);

--- a/be/src/exec/pipeline/pipeline_driver_poller.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_poller.cpp
@@ -65,7 +65,7 @@ void PipelineDriverPoller::run_internal() {
                 //
                 // If the fragment is expired when the source operator is already pending i/o task,
                 // The state of driver shouldn't be changed.
-                driver->cancel_if_necessary(driver->fragment_ctx()->runtime_state());
+                driver->finish_operators(driver->fragment_ctx()->runtime_state());
                 if (driver->source_operator()->pending_finish()) {
                     driver->set_driver_state(DriverState::PENDING_FINISH);
                     ++driver_it;
@@ -77,7 +77,7 @@ void PipelineDriverPoller::run_internal() {
             } else if (!driver->pending_finish() && driver->fragment_ctx()->is_canceled()) {
                 // If the fragment is cancelled when the source operator is already pending i/o task,
                 // The state of driver shouldn't be changed.
-                driver->cancel_if_necessary(driver->fragment_ctx()->runtime_state());
+                driver->finish_operators(driver->fragment_ctx()->runtime_state());
                 if (driver->source_operator()->pending_finish()) {
                     driver->set_driver_state(DriverState::PENDING_FINISH);
                     ++driver_it;

--- a/be/src/exec/pipeline/pipeline_driver_poller.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_poller.cpp
@@ -59,7 +59,7 @@ void PipelineDriverPoller::run_internal() {
             } else if (driver->is_finished()) {
                 local_blocked_drivers.erase(driver_it++);
             } else if (!driver->pending_finish() && driver->query_ctx()->is_expired()) {
-                // there are not any drivers belonging to a query context can make progress for a expiration period
+                // there are not any drivers belonging to a query context can make progress for an expiration period
                 // indicates that some fragments are missing because of failed exec_plan_fragment invocation. in
                 // this situation, query is failed finally, so drivers are marked PENDING_FINISH/FINISH.
                 driver->cancel(driver->fragment_ctx()->runtime_state());

--- a/be/src/exec/pipeline/pipeline_driver_poller.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_poller.cpp
@@ -48,16 +48,17 @@ void PipelineDriverPoller::run_internal() {
             if (driver->pending_finish() && !driver->source_operator()->pending_finish()) {
                 // driver->pending_finish() return true means that when a driver's sink operator is finished,
                 // but its source operator still has pending io task that executed in io threads and has
-                // reference to object outside(such as desc_tbl) owned by FragmentContext. So an driver in
+                // reference to object outside(such as desc_tbl) owned by FragmentContext. So a driver in
                 // PENDING_FINISH state should wait for pending io task's completion, then turn into FINISH state,
                 // otherwise, pending tasks shall reference to destructed objects in FragmentContext since
                 // FragmentContext is unregistered prematurely.
-                driver->set_driver_state(DriverState::FINISH);
+                driver->set_driver_state(driver->fragment_ctx()->is_canceled() ? DriverState::CANCELED
+                                                                               : DriverState::FINISH);
                 _dispatch_queue->put_back(*driver_it);
                 local_blocked_drivers.erase(driver_it++);
             } else if (driver->is_finished()) {
                 local_blocked_drivers.erase(driver_it++);
-            } else if (driver->query_ctx()->is_expired()) {
+            } else if (!driver->pending_finish() && driver->query_ctx()->is_expired()) {
                 // there are not any drivers belonging to a query context can make progress for a expiration period
                 // indicates that some fragments are missing because of failed exec_plan_fragment invocation. in
                 // this situation, query is failed finally, so drivers are marked PENDING_FINISH/FINISH.
@@ -70,10 +71,16 @@ void PipelineDriverPoller::run_internal() {
                     _dispatch_queue->put_back(*driver_it);
                     local_blocked_drivers.erase(driver_it++);
                 }
-            } else if (driver->fragment_ctx()->is_canceled()) {
-                driver->set_driver_state(DriverState::CANCELED);
-                _dispatch_queue->put_back(*driver_it);
-                local_blocked_drivers.erase(driver_it++);
+            } else if (!driver->pending_finish() && driver->fragment_ctx()->is_canceled()) {
+                driver->cancel(driver->fragment_ctx()->runtime_state());
+                if (driver->source_operator()->pending_finish()) {
+                    driver->set_driver_state(DriverState::PENDING_FINISH);
+                    ++driver_it;
+                } else {
+                    driver->set_driver_state(DriverState::CANCELED);
+                    _dispatch_queue->put_back(*driver_it);
+                    local_blocked_drivers.erase(driver_it++);
+                }
             } else if (driver->is_not_blocked()) {
                 driver->set_driver_state(DriverState::READY);
                 _dispatch_queue->put_back(*driver_it);

--- a/be/src/exec/pipeline/source_operator.h
+++ b/be/src/exec/pipeline/source_operator.h
@@ -18,6 +18,12 @@ public:
     ~SourceOperator() override = default;
 
     bool need_input() const override { return false; }
+    // pending_finish returns whether this source operator still has pending i/o task which executed in i/o threads
+    // and has reference to the object outside (such as desc_tbl) owned by FragmentContext.
+    // It can ONLY be called after calling finish().
+    // When a driver's sink operator is finished, the driver should wait for pending i/o task completion.
+    // Otherwise, pending tasks shall reference to destructed objects in FragmentContext,
+    // since FragmentContext is unregistered prematurely after all the drivers are finalized.
     virtual bool pending_finish() { return false; }
     Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override {
         return Status::InternalError("Shouldn't push chunk to source operator");


### PR DESCRIPTION
Fix:
- check whether `SourceOperator` is `pending_finish()` when the fragment is cancelled at running `PipelineDriver::process` and when the fragment is cancelled for a driver in blocked queue.
- Add `driver.cancel()` before checking `pending_finish()`, because `ScanOperator::pending_finish()` must be called after calling `ScanOperator::finish()`.
- set driver state to `CANCELED` when a `PENDING_FINISH` block driver is finished and the fragment is cancelled.