### PR TITLE
Optimize the disk selection strategy for be tablet clone

### DIFF
--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -107,9 +107,14 @@ public:
 
     // Obtain shard path for new tablet.
     //
-    // @param [out] shard_path choose an available root_path to clone new tablet
+    // @param [in] storage_medium specify medium needed
+    // @param [in] path_hash: If path_hash is not -1, get store by path hash.
+    //                        Else get store randomly by the specified medium.
+    // @param [out] shard_path choose an available shard_path to clone new tablet
+    // @param [out] store choose an available root_path to clone new tablet
     // @return error code
-    OLAPStatus obtain_shard_path(TStorageMedium::type storage_medium, std::string* shared_path, DataDir** store);
+    OLAPStatus obtain_shard_path(TStorageMedium::type storage_medium, int64_t path_hash, std::string* shared_path,
+                                 DataDir** store);
 
     // Load new tablet to make it effective.
     //

--- a/be/src/storage/task/engine_clone_task.cpp
+++ b/be/src/storage/task/engine_clone_task.cpp
@@ -128,13 +128,19 @@ Status EngineCloneTask::_do_clone(Tablet* tablet) {
                   << " by clone. committed_version=" << _clone_req.committed_version << " signature=" << _signature;
         std::string shard_path;
         DataDir* store = nullptr;
-        auto ost = StorageEngine::instance()->obtain_shard_path(_clone_req.storage_medium, &shard_path, &store);
+        int64_t dest_path_hash = -1;
+        if (_clone_req.__isset.dest_path_hash) {
+            dest_path_hash = _clone_req.dest_path_hash;
+        }
+        auto ost = StorageEngine::instance()->obtain_shard_path(_clone_req.storage_medium, dest_path_hash, &shard_path,
+                                                                &store);
         if (ost != OLAP_SUCCESS) {
             LOG(WARNING) << "Fail to obtain shard path. tablet_id=" << _clone_req.tablet_id
                          << " signature=" << _signature;
             _error_msgs->push_back("fail to obtain shard path");
             return Status::InternalError("fail to obtain shard path");
         }
+
         auto tablet_manager = StorageEngine::instance()->tablet_manager();
         auto tablet_id = _clone_req.tablet_id;
         auto schema_hash = _clone_req.schema_hash;


### PR DESCRIPTION
BE directly uses the dest disk selected by fe according to the strategy
instead of randomly selecting.