### PR TITLE
Optimization for aggregation function using key words "__restrict"

### DIFF
--- a/be/src/exec/vectorized/aggregator.cpp
+++ b/be/src/exec/vectorized/aggregator.cpp
@@ -540,14 +540,16 @@ vectorized::Columns Aggregator::_create_group_by_columns() {
     return group_by_columns;
 }
 
-void Aggregator::_serialize_to_chunk(vectorized::ConstAggDataPtr state, const vectorized::Columns& agg_result_columns) {
+void Aggregator::_serialize_to_chunk(vectorized::ConstAggDataPtr __restrict state,
+                                     const vectorized::Columns& agg_result_columns) {
     for (size_t i = 0; i < _agg_fn_ctxs.size(); i++) {
         _agg_functions[i]->serialize_to_column(_agg_fn_ctxs[i], state + _agg_states_offsets[i],
                                                agg_result_columns[i].get());
     }
 }
 
-void Aggregator::_finalize_to_chunk(vectorized::ConstAggDataPtr state, const vectorized::Columns& agg_result_columns) {
+void Aggregator::_finalize_to_chunk(vectorized::ConstAggDataPtr __restrict state,
+                                    const vectorized::Columns& agg_result_columns) {
     for (size_t i = 0; i < _agg_fn_ctxs.size(); i++) {
         _agg_functions[i]->finalize_to_column(_agg_fn_ctxs[i], state + _agg_states_offsets[i],
                                               agg_result_columns[i].get());

--- a/be/src/exec/vectorized/aggregator.h
+++ b/be/src/exec/vectorized/aggregator.h
@@ -457,8 +457,10 @@ private:
     vectorized::Columns _create_agg_result_columns();
     vectorized::Columns _create_group_by_columns();
 
-    void _serialize_to_chunk(vectorized::ConstAggDataPtr state, const vectorized::Columns& agg_result_columns);
-    void _finalize_to_chunk(vectorized::ConstAggDataPtr state, const vectorized::Columns& agg_result_columns);
+    void _serialize_to_chunk(vectorized::ConstAggDataPtr __restrict state,
+                             const vectorized::Columns& agg_result_columns);
+    void _finalize_to_chunk(vectorized::ConstAggDataPtr __restrict state,
+                            const vectorized::Columns& agg_result_columns);
 
     void _evaluate_group_by_exprs(vectorized::Chunk* chunk);
     void _evaluate_agg_fn_exprs(vectorized::Chunk* chunk);

--- a/be/src/exec/vectorized/analytor.h
+++ b/be/src/exec/vectorized/analytor.h
@@ -210,7 +210,7 @@ private:
 // Helper class that properly invokes destructor when state goes out of scope.
 class ManagedFunctionStates {
 public:
-    ManagedFunctionStates(vectorized::AggDataPtr agg_states, Analytor* agg_node)
+    ManagedFunctionStates(vectorized::AggDataPtr __restrict agg_states, Analytor* agg_node)
             : _agg_states(agg_states), _agg_node(agg_node) {
         for (int i = 0; i < _agg_node->_agg_functions.size(); i++) {
             _agg_node->_agg_functions[i]->create(_agg_states + _agg_node->_agg_states_offsets[i]);

--- a/be/src/exprs/agg/aggregate.h
+++ b/be/src/exprs/agg/aggregate.h
@@ -25,30 +25,32 @@ public:
     virtual ~AggregateFunction() = default;
 
     // Reset the aggregation state, for aggregate window functions
-    virtual void reset(FunctionContext* ctx, const Columns& args, AggDataPtr state) const {}
+    virtual void reset(FunctionContext* ctx, const Columns& args, AggDataPtr __restrict state) const {}
 
     // Update the aggregation state
     // columns points to columns containing arguments of aggregation function.
     // row_num is number of row which should be updated.
-    virtual void update(FunctionContext* ctx, const Column** columns, AggDataPtr state, size_t row_num) const = 0;
+    virtual void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
+                        size_t row_num) const = 0;
 
     // Merge the aggregation state
     // columns points to columns containing merge input,
     // We maybe need deserialize input data firstly.
     // row_num is number of row which should be merged.
-    virtual void merge(FunctionContext* ctx, const Column* column, AggDataPtr state, size_t row_num) const = 0;
+    virtual void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state,
+                       size_t row_num) const = 0;
 
     // When transmit data over network, we need to serialize agg data.
     // We serialize the agg data to |to| column
     // @param[out] to: maybe nullable
-    virtual void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr state, Column* to) const = 0;
+    virtual void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const = 0;
 
     // batch serialize aggregate state to reduce virtual function call
     virtual void batch_serialize(size_t batch_size, const Buffer<AggDataPtr>& agg_states, size_t state_offsets,
                                  Column* to) const = 0;
 
     // Change the aggregation state to final result if necessary
-    virtual void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr state, Column* to) const = 0;
+    virtual void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const = 0;
 
     // batch finalize aggregate state to reduce virtual function call
     virtual void batch_finalize(FunctionContext* ctx, size_t batch_size, const Buffer<AggDataPtr>& agg_states,
@@ -59,15 +61,16 @@ public:
 
     // Insert current aggregation state into dst column from start to end
     // For aggregation window functions
-    virtual void get_values(FunctionContext* ctx, ConstAggDataPtr state, Column* dst, size_t start, size_t end) const {}
+    virtual void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,
+                            size_t end) const {}
 
     virtual std::string get_name() const = 0;
 
     // State management methods:
     virtual size_t size() const = 0;
     virtual size_t alignof_size() const = 0;
-    virtual void create(AggDataPtr ptr) const = 0;
-    virtual void destroy(AggDataPtr ptr) const = 0;
+    virtual void create(AggDataPtr __restrict ptr) const = 0;
+    virtual void destroy(AggDataPtr __restrict ptr) const = 0;
 
     // Contains a loop with calls to "update" function.
     // You can collect arguments into array "states"
@@ -82,12 +85,12 @@ public:
 
     // update result to single state
     virtual void update_batch_single_state(FunctionContext* ctx, size_t batch_size, const Column** columns,
-                                           AggDataPtr state) const = 0;
+                                           AggDataPtr __restrict state) const = 0;
 
     // For window functions
     // A peer group is all of the rows that are peers within the specified ordering.
     // Rows are peers if they compare equal to each other using the specified ordering expression.
-    virtual void update_batch_single_state(FunctionContext* ctx, AggDataPtr state, const Column** columns,
+    virtual void update_batch_single_state(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
                                            int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
                                            int64_t frame_end) const {}
 
@@ -104,19 +107,19 @@ public:
 
     // merge result to single state
     virtual void merge_batch_single_state(FunctionContext* ctx, size_t batch_size, const Column* column,
-                                          AggDataPtr state) const = 0;
+                                          AggDataPtr __restrict state) const = 0;
 };
 
 template <typename State>
 class AggregateFunctionStateHelper : public AggregateFunction {
 protected:
-    static State& data(AggDataPtr place) { return *reinterpret_cast<State*>(place); }
-    static const State& data(ConstAggDataPtr place) { return *reinterpret_cast<const State*>(place); }
+    static State& data(AggDataPtr __restrict place) { return *reinterpret_cast<State*>(place); }
+    static const State& data(ConstAggDataPtr __restrict place) { return *reinterpret_cast<const State*>(place); }
 
 public:
-    void create(AggDataPtr ptr) const final { new (ptr) State; }
+    void create(AggDataPtr __restrict ptr) const final { new (ptr) State; }
 
-    void destroy(AggDataPtr ptr) const final { data(ptr).~State(); }
+    void destroy(AggDataPtr __restrict ptr) const final { data(ptr).~State(); }
 
     size_t size() const final { return sizeof(State); }
 
@@ -143,7 +146,7 @@ class AggregateFunctionBatchHelper : public AggregateFunctionStateHelper<State> 
     }
 
     void update_batch_single_state(FunctionContext* ctx, size_t batch_size, const Column** columns,
-                                   AggDataPtr state) const override {
+                                   AggDataPtr __restrict state) const override {
         for (size_t i = 0; i < batch_size; ++i) {
             static_cast<const Derived*>(this)->update(ctx, columns, state, i);
         }
@@ -167,7 +170,7 @@ class AggregateFunctionBatchHelper : public AggregateFunctionStateHelper<State> 
     }
 
     void merge_batch_single_state(FunctionContext* ctx, size_t batch_size, const Column* column,
-                                  AggDataPtr state) const override {
+                                  AggDataPtr __restrict state) const override {
         for (size_t i = 0; i < batch_size; ++i) {
             static_cast<const Derived*>(this)->merge(ctx, column, state, i);
         }

--- a/be/src/exprs/agg/aggregate.h
+++ b/be/src/exprs/agg/aggregate.h
@@ -20,6 +20,12 @@ using ConstAggDataPtr = const uint8_t*;
 // Aggregate function instances don't contain aggregation state, the aggregation state is stored in
 // other objects
 // Aggregate function instances contain aggregate function description and state management methods
+// Keyword __restrict is added everywhere AggDataPtr appears, which used to solve the problem of
+// pointer aliasing and improve the performance of auto-vectorization. For better understanding,
+// some micro-benchmark results are listed as follows
+//      1. https://quick-bench.com/q/ZQoR7xloXdKcqLC-rPFLhSuHEf0
+//      2. https://quick-bench.com/q/E5SfW3gn2IjJl4q0YIVMBPW8Ja8
+//      3. https://quick-bench.com/q/yniGOh4CIz6YRGj85HFwu4WoHME
 class AggregateFunction {
 public:
     virtual ~AggregateFunction() = default;

--- a/be/src/exprs/agg/bitmap_intersect.h
+++ b/be/src/exprs/agg/bitmap_intersect.h
@@ -29,7 +29,7 @@ public:
         }
     }
 
-    void merge(FunctionContext* ctx, const Column* column, AggDataPtr state, size_t row_num) const override {
+    void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
         const BitmapColumn* col = down_cast<const BitmapColumn*>(column);
         DCHECK(col->is_object());
         if (!this->data(state).initial) {
@@ -40,7 +40,7 @@ public:
         }
     }
 
-    void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr state, Column* to) const override {
+    void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         BitmapColumn* col = down_cast<BitmapColumn*>(to);
         BitmapValue& bitmap = const_cast<BitmapValue&>(this->data(state).bitmap);
         col->append(std::move(bitmap));
@@ -50,7 +50,7 @@ public:
         *dst = src[0];
     }
 
-    void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr state, Column* to) const override {
+    void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         BitmapValue& bitmap = const_cast<BitmapValue&>(this->data(state).bitmap);
         BitmapColumn* col = down_cast<BitmapColumn*>(to);
         col->append(std::move(bitmap));

--- a/be/src/exprs/agg/bitmap_union.h
+++ b/be/src/exprs/agg/bitmap_union.h
@@ -18,13 +18,13 @@ public:
         this->data(state) |= *(col->get_object(row_num));
     }
 
-    void merge(FunctionContext* ctx, const Column* column, AggDataPtr state, size_t row_num) const override {
+    void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
         const BitmapColumn* col = down_cast<const BitmapColumn*>(column);
         DCHECK(col->is_object());
         this->data(state) |= *(col->get_object(row_num));
     }
 
-    void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr state, Column* to) const override {
+    void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         BitmapColumn* col = down_cast<BitmapColumn*>(to);
         BitmapValue& bitmap = const_cast<BitmapValue&>(this->data(state));
         col->append(std::move(bitmap));
@@ -34,7 +34,7 @@ public:
         *dst = src[0];
     }
 
-    void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr state, Column* to) const override {
+    void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         BitmapColumn* col = down_cast<BitmapColumn*>(to);
         BitmapValue& bitmap = const_cast<BitmapValue&>(this->data(state));
         col->append(std::move(bitmap));

--- a/be/src/exprs/agg/bitmap_union_count.h
+++ b/be/src/exprs/agg/bitmap_union_count.h
@@ -18,12 +18,12 @@ public:
         this->data(state) |= *(col->get_object(row_num));
     }
 
-    void merge(FunctionContext* ctx, const Column* column, AggDataPtr state, size_t row_num) const override {
+    void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
         const BitmapColumn* col = down_cast<const BitmapColumn*>(column);
         this->data(state) |= *(col->get_object(row_num));
     }
 
-    void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr state, Column* to) const override {
+    void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         BitmapColumn* col = down_cast<BitmapColumn*>(to);
         auto& value = const_cast<BitmapValue&>(this->data(state));
         col->append(std::move(value));
@@ -33,7 +33,7 @@ public:
         *dst = src[0];
     }
 
-    void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr state, Column* to) const override {
+    void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         DCHECK(to->is_numeric());
         down_cast<Int64Column*>(to)->append(this->data(state).cardinality());
     }

--- a/be/src/exprs/agg/bitmap_union_int.h
+++ b/be/src/exprs/agg/bitmap_union_int.h
@@ -23,13 +23,13 @@ public:
         }
     }
 
-    void merge(FunctionContext* ctx, const Column* column, AggDataPtr state, size_t row_num) const override {
+    void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
         DCHECK(column->is_object());
         const BitmapColumn* col = down_cast<const BitmapColumn*>(column);
         this->data(state) |= *(col->get_object(row_num));
     }
 
-    void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr state, Column* to) const override {
+    void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         BitmapColumn* col = down_cast<BitmapColumn*>(to);
         auto& value = const_cast<BitmapValue&>(this->data(state));
         col->append(std::move(value));
@@ -46,7 +46,7 @@ public:
         }
     }
 
-    void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr state, Column* to) const override {
+    void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         DCHECK(to->is_numeric());
         down_cast<Int64Column*>(to)->append(this->data(state).cardinality());
     }

--- a/be/src/exprs/agg/count.h
+++ b/be/src/exprs/agg/count.h
@@ -20,28 +20,30 @@ public:
         this->data(state).count = 0;
     }
 
-    void update(FunctionContext* ctx, const Column** columns, AggDataPtr state, size_t row_num) const override {
+    void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
+                size_t row_num) const override {
         ++this->data(state).count;
     }
 
     void update_batch_single_state(FunctionContext* ctx, size_t batch_size, const Column** columns,
-                                   AggDataPtr state) const override {
+                                   AggDataPtr __restrict state) const override {
         this->data(state).count += batch_size;
     }
 
-    void update_batch_single_state(FunctionContext* ctx, AggDataPtr state, const Column** columns,
+    void update_batch_single_state(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
                                    int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
                                    int64_t frame_end) const override {
         this->data(state).count += (frame_end - frame_start);
     }
 
-    void merge(FunctionContext* ctx, const Column* column, AggDataPtr state, size_t row_num) const override {
+    void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
         DCHECK(column->is_numeric());
         const auto* input_column = down_cast<const Int64Column*>(column);
         data(state).count += input_column->get_data()[row_num];
     }
 
-    void get_values(FunctionContext* ctx, ConstAggDataPtr state, Column* dst, size_t start, size_t end) const override {
+    void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,
+                    size_t end) const override {
         DCHECK_GT(end, start);
         Int64Column* column = down_cast<Int64Column*>(dst);
         for (size_t i = start; i < end; ++i) {
@@ -49,7 +51,7 @@ public:
         }
     }
 
-    void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr state, Column* to) const override {
+    void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         DCHECK(to->is_numeric());
         down_cast<Int64Column*>(to)->append(this->data(state).count);
     }
@@ -63,7 +65,7 @@ public:
         }
     }
 
-    void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr state, Column* to) const override {
+    void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         DCHECK(to->is_numeric());
         down_cast<Int64Column*>(to)->append(this->data(state).count);
     }
@@ -85,16 +87,17 @@ public:
 class CountNullableAggregateFunction final
         : public AggregateFunctionBatchHelper<AggregateFunctionCountData, CountNullableAggregateFunction> {
 public:
-    void reset(FunctionContext* ctx, const Columns& args, AggDataPtr state) const override {
+    void reset(FunctionContext* ctx, const Columns& args, AggDataPtr __restrict state) const override {
         this->data(state).count = 0;
     }
 
-    void update(FunctionContext* ctx, const Column** columns, AggDataPtr state, size_t row_num) const override {
+    void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
+                size_t row_num) const override {
         this->data(state).count += !columns[0]->is_null(row_num);
     }
 
     void update_batch_single_state(FunctionContext* ctx, size_t batch_size, const Column** columns,
-                                   AggDataPtr state) const override {
+                                   AggDataPtr __restrict state) const override {
         if (columns[0]->is_nullable()) {
             const auto* nullable_column = down_cast<const NullableColumn*>(columns[0]);
             if (nullable_column->has_null()) {
@@ -110,7 +113,7 @@ public:
         }
     }
 
-    void update_batch_single_state(FunctionContext* ctx, AggDataPtr state, const Column** columns,
+    void update_batch_single_state(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
                                    int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
                                    int64_t frame_end) const override {
         if (columns[0]->is_nullable()) {
@@ -128,13 +131,14 @@ public:
         }
     }
 
-    void merge(FunctionContext* ctx, const Column* column, AggDataPtr state, size_t row_num) const override {
+    void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
         DCHECK(column->is_numeric());
         const auto* input_column = down_cast<const Int64Column*>(column);
         data(state).count += input_column->get_data()[row_num];
     }
 
-    void get_values(FunctionContext* ctx, ConstAggDataPtr state, Column* dst, size_t start, size_t end) const override {
+    void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,
+                    size_t end) const override {
         DCHECK_GT(end, start);
         Int64Column* column = down_cast<Int64Column*>(dst);
         for (size_t i = start; i < end; ++i) {
@@ -142,7 +146,7 @@ public:
         }
     }
 
-    void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr state, Column* to) const override {
+    void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         DCHECK(to->is_numeric());
         down_cast<Int64Column*>(to)->append(this->data(state).count);
     }
@@ -156,7 +160,7 @@ public:
         }
     }
 
-    void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr state, Column* to) const override {
+    void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         DCHECK(to->is_numeric());
         down_cast<Int64Column*>(to)->append(this->data(state).count);
     }

--- a/be/src/exprs/agg/distinct.h
+++ b/be/src/exprs/agg/distinct.h
@@ -278,7 +278,7 @@ public:
     // We have found out that by precomputing and prefetching hash values, we can boost peformance of hash table by a lot.
     // And this is a quite useful pattern for phmap::flat_hash_table.
     void update_batch_single_state(FunctionContext* ctx, size_t batch_size, const Column** columns,
-                                   AggDataPtr state) const override {
+                                   AggDataPtr __restrict state) const override {
         const ColumnType* column = down_cast<const ColumnType*>(columns[0]);
         size_t mem_usage = 0;
         auto& agg_state = this->data(state);
@@ -342,7 +342,7 @@ public:
         ctx->impl()->add_mem_usage(mem_usage);
     }
 
-    void merge(FunctionContext* ctx, const Column* column, AggDataPtr state, size_t row_num) const override {
+    void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
         DCHECK(column->is_binary());
         const auto* input_column = down_cast<const BinaryColumn*>(column);
         Slice slice = input_column->get_slice(row_num);
@@ -365,7 +365,7 @@ public:
         ctx->impl()->add_mem_usage(mem_usage);
     }
 
-    void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr state, Column* to) const override {
+    void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         auto* column = down_cast<BinaryColumn*>(to);
         size_t old_size = column->get_bytes().size();
         size_t new_size = old_size + this->data(state).serialize_size();
@@ -413,7 +413,7 @@ public:
         }
     }
 
-    void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr state, Column* to) const override {
+    void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         DCHECK(!to->is_nullable());
         if constexpr (DistinctType == AggDistinctType::COUNT) {
             down_cast<Int64Column*>(to)->append(this->data(state).disctint_count());
@@ -445,12 +445,13 @@ struct DictMergeState : DistinctAggregateStateV2<TYPE_VARCHAR> {
 class DictMergeAggregateFunction final
         : public AggregateFunctionBatchHelper<DictMergeState, DictMergeAggregateFunction> {
 public:
-    void update(FunctionContext* ctx, const Column** columns, AggDataPtr state, size_t row_num) const override {
+    void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
+                size_t row_num) const override {
         DCHECK(false) << "this method shouldn't be called";
     }
 
     void update_batch_single_state(FunctionContext* ctx, size_t batch_size, const Column** columns,
-                                   AggDataPtr state) const override {
+                                   AggDataPtr __restrict state) const override {
         size_t mem_usage = 0;
         auto& agg_state = this->data(state);
         const auto* column = down_cast<const ArrayColumn*>(columns[0]);
@@ -475,7 +476,7 @@ public:
         }
     }
 
-    void merge(FunctionContext* ctx, const Column* column, AggDataPtr state, size_t row_num) const override {
+    void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
         const auto* input_column = down_cast<const BinaryColumn*>(column);
         Slice slice = input_column->get_slice(row_num);
         size_t mem_usage = 0;
@@ -484,7 +485,7 @@ public:
         ctx->impl()->add_mem_usage(mem_usage);
     }
 
-    void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr state, Column* to) const override {
+    void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         auto* column = down_cast<BinaryColumn*>(to);
         size_t old_size = column->get_bytes().size();
         size_t new_size = old_size + this->data(state).serialize_size();
@@ -497,7 +498,7 @@ public:
         DCHECK(false) << "this method shouldn't be called";
     }
 
-    void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr state, Column* to) const override {
+    void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         if (this->data(state).set.size() == 0) {
             to->append_default();
             return;

--- a/be/src/exprs/agg/group_concat.h
+++ b/be/src/exprs/agg/group_concat.h
@@ -35,7 +35,8 @@ public:
         this->data(state).initial = false;
     }
 
-    void update(FunctionContext* ctx, const Column** columns, AggDataPtr state, size_t row_num) const override {
+    void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
+                size_t row_num) const override {
         DCHECK(columns[0]->is_binary());
         if (ctx->get_num_args() > 1) {
             auto const_column_sep = ctx->get_constant_column(1);
@@ -98,7 +99,7 @@ public:
     }
 
     void update_batch_single_state(FunctionContext* ctx, size_t batch_size, const Column** columns,
-                                   AggDataPtr state) const override {
+                                   AggDataPtr __restrict state) const override {
         if (ctx->get_num_args() > 1) {
             const InputColumnType* column_val = down_cast<const InputColumnType*>(columns[0]);
             auto const_column_sep = ctx->get_constant_column(1);
@@ -121,7 +122,7 @@ public:
         }
     }
 
-    void update_batch_single_state(FunctionContext* ctx, AggDataPtr state, const Column** columns,
+    void update_batch_single_state(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
                                    int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
                                    int64_t frame_end) const override {
         for (size_t i = frame_start; i < frame_end; ++i) {
@@ -129,7 +130,7 @@ public:
         }
     }
 
-    void merge(FunctionContext* ctx, const Column* column, AggDataPtr state, size_t row_num) const override {
+    void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
         Slice slice = column->get(row_num).get_slice();
         char* data = slice.data;
         uint32_t size_value = *reinterpret_cast<uint32_t*>(data);
@@ -145,7 +146,7 @@ public:
         }
     }
 
-    void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr state, Column* to) const override {
+    void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         DCHECK(to->is_binary());
 
         auto* column = down_cast<BinaryColumn*>(to);
@@ -258,7 +259,7 @@ public:
         }
     }
 
-    void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr state, Column* to) const override {
+    void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         const std::string& value = this->data(state).intermediate_string;
         // Remove first sep_length.
         const char* data = value.data();

--- a/be/src/exprs/agg/hll_ndv.h
+++ b/be/src/exprs/agg/hll_ndv.h
@@ -25,7 +25,8 @@ public:
         this->data(state).clear();
     }
 
-    void update(FunctionContext* ctx, const Column** columns, AggDataPtr state, size_t row_num) const override {
+    void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
+                size_t row_num) const override {
         uint64_t value = 0;
         const ColumnType* column = down_cast<const ColumnType*>(columns[0]);
 
@@ -42,7 +43,7 @@ public:
         }
     }
 
-    void update_batch_single_state(FunctionContext* ctx, AggDataPtr state, const Column** columns,
+    void update_batch_single_state(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
                                    int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
                                    int64_t frame_end) const override {
         const ColumnType* column = down_cast<const ColumnType*>(columns[0]);
@@ -70,7 +71,7 @@ public:
         }
     }
 
-    void merge(FunctionContext* ctx, const Column* column, AggDataPtr state, size_t row_num) const override {
+    void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
         DCHECK(column->is_binary());
 
         const BinaryColumn* hll_column = down_cast<const BinaryColumn*>(column);
@@ -78,7 +79,8 @@ public:
         this->data(state).merge(hll);
     }
 
-    void get_values(FunctionContext* ctx, ConstAggDataPtr state, Column* dst, size_t start, size_t end) const override {
+    void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,
+                    size_t end) const override {
         DCHECK_GT(end, start);
         Int64Column* column = down_cast<Int64Column*>(dst);
         int64_t result = this->data(state).estimate_cardinality();
@@ -88,7 +90,7 @@ public:
         }
     }
 
-    void serialize_to_column(FunctionContext* ctx __attribute__((unused)), ConstAggDataPtr state,
+    void serialize_to_column(FunctionContext* ctx __attribute__((unused)), ConstAggDataPtr __restrict state,
                              Column* to) const override {
         DCHECK(to->is_binary());
 
@@ -132,7 +134,7 @@ public:
         }
     }
 
-    void finalize_to_column(FunctionContext* ctx __attribute__((unused)), ConstAggDataPtr state,
+    void finalize_to_column(FunctionContext* ctx __attribute__((unused)), ConstAggDataPtr __restrict state,
                             Column* to) const override {
         DCHECK(to->is_numeric());
 

--- a/be/src/exprs/agg/hll_union.h
+++ b/be/src/exprs/agg/hll_union.h
@@ -20,12 +20,13 @@ public:
         this->data(state).clear();
     }
 
-    void update(FunctionContext* ctx, const Column** columns, AggDataPtr state, size_t row_num) const override {
+    void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
+                size_t row_num) const override {
         const HyperLogLogColumn* column = down_cast<const HyperLogLogColumn*>(columns[0]);
         this->data(state).merge(*(column->get_object(row_num)));
     }
 
-    void update_batch_single_state(FunctionContext* ctx, AggDataPtr state, const Column** columns,
+    void update_batch_single_state(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
                                    int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
                                    int64_t frame_end) const override {
         const HyperLogLogColumn* column = down_cast<const HyperLogLogColumn*>(columns[0]);
@@ -34,14 +35,15 @@ public:
         }
     }
 
-    void merge(FunctionContext* ctx, const Column* column, AggDataPtr state, size_t row_num) const override {
+    void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
         DCHECK(column->is_object());
 
         const HyperLogLogColumn* hll_column = down_cast<const HyperLogLogColumn*>(column);
         this->data(state).merge(*(hll_column->get_object(row_num)));
     }
 
-    void get_values(FunctionContext* ctx, ConstAggDataPtr state, Column* dst, size_t start, size_t end) const override {
+    void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,
+                    size_t end) const override {
         DCHECK_GT(end, start);
         DCHECK(dst->is_object());
         auto* column = down_cast<HyperLogLogColumn*>(dst);
@@ -51,7 +53,7 @@ public:
         }
     }
 
-    void serialize_to_column(FunctionContext* ctx __attribute__((unused)), ConstAggDataPtr state,
+    void serialize_to_column(FunctionContext* ctx __attribute__((unused)), ConstAggDataPtr __restrict state,
                              Column* to) const override {
         DCHECK(to->is_object());
         auto* column = down_cast<HyperLogLogColumn*>(to);
@@ -63,7 +65,7 @@ public:
         *dst = src[0];
     }
 
-    void finalize_to_column(FunctionContext* ctx __attribute__((unused)), ConstAggDataPtr state,
+    void finalize_to_column(FunctionContext* ctx __attribute__((unused)), ConstAggDataPtr __restrict state,
                             Column* to) const override {
         DCHECK(to->is_object());
         auto* column = down_cast<HyperLogLogColumn*>(to);

--- a/be/src/exprs/agg/hll_union_count.h
+++ b/be/src/exprs/agg/hll_union_count.h
@@ -22,12 +22,13 @@ public:
         this->data(state).clear();
     }
 
-    void update(FunctionContext* ctx, const Column** columns, AggDataPtr state, size_t row_num) const override {
+    void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
+                size_t row_num) const override {
         const HyperLogLogColumn* column = down_cast<const HyperLogLogColumn*>(columns[0]);
         this->data(state).merge(*(column->get_object(row_num)));
     }
 
-    void update_batch_single_state(FunctionContext* ctx, AggDataPtr state, const Column** columns,
+    void update_batch_single_state(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
                                    int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
                                    int64_t frame_end) const override {
         const HyperLogLogColumn* column = down_cast<const HyperLogLogColumn*>(columns[0]);
@@ -36,14 +37,15 @@ public:
         }
     }
 
-    void merge(FunctionContext* ctx, const Column* column, AggDataPtr state, size_t row_num) const override {
+    void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
         DCHECK(column->is_object());
 
         const HyperLogLogColumn* hll_column = down_cast<const HyperLogLogColumn*>(column);
         this->data(state).merge(*(hll_column->get_object(row_num)));
     }
 
-    void get_values(FunctionContext* ctx, ConstAggDataPtr state, Column* dst, size_t start, size_t end) const override {
+    void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,
+                    size_t end) const override {
         DCHECK_GT(end, start);
         Int64Column* column = down_cast<Int64Column*>(dst);
         int64_t result = this->data(state).estimate_cardinality();
@@ -53,7 +55,7 @@ public:
         }
     }
 
-    void serialize_to_column(FunctionContext* ctx __attribute__((unused)), ConstAggDataPtr state,
+    void serialize_to_column(FunctionContext* ctx __attribute__((unused)), ConstAggDataPtr __restrict state,
                              Column* to) const override {
         DCHECK(to->is_object());
         auto* column = down_cast<HyperLogLogColumn*>(to);
@@ -65,7 +67,7 @@ public:
         *dst = src[0];
     }
 
-    void finalize_to_column(FunctionContext* ctx __attribute__((unused)), ConstAggDataPtr state,
+    void finalize_to_column(FunctionContext* ctx __attribute__((unused)), ConstAggDataPtr __restrict state,
                             Column* to) const override {
         DCHECK(to->is_numeric());
 

--- a/be/src/exprs/agg/intersect_count.h
+++ b/be/src/exprs/agg/intersect_count.h
@@ -53,7 +53,8 @@ public:
 
     void reset(FunctionContext* ctx, const Columns& args, AggDataPtr state) const override {}
 
-    void update(FunctionContext* ctx, const Column** columns, AggDataPtr state, size_t row_num) const override {
+    void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
+                size_t row_num) const override {
         DCHECK(columns[0]->is_object());
 
         auto& intersect = this->data(state).intersect;
@@ -87,13 +88,13 @@ public:
         }
     }
 
-    void merge(FunctionContext* ctx, const Column* column, AggDataPtr state, size_t row_num) const override {
+    void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
         auto& intersect = this->data(state).intersect;
         Slice slice = column->get(row_num).get_slice();
         intersect.merge(BitmapIntersect<T>((char*)slice.data));
     }
 
-    void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr state, Column* to) const override {
+    void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         DCHECK(to->is_binary());
         auto& intersect = this->data(state).intersect;
 
@@ -167,7 +168,7 @@ public:
         }
     }
 
-    void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr state, Column* to) const override {
+    void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         auto& intersect = this->data(state).intersect;
         down_cast<ResultColumnType*>(to)->append(intersect.intersect_count());
     }

--- a/be/src/exprs/agg/percentile_approx.h
+++ b/be/src/exprs/agg/percentile_approx.h
@@ -43,7 +43,7 @@ public:
         data(state).is_null = false;
     }
 
-    void merge(FunctionContext* ctx, const Column* column, AggDataPtr state, size_t row_num) const override {
+    void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
         Slice src;
         if (column->is_nullable()) {
             if (column->is_null(row_num)) {
@@ -67,7 +67,7 @@ public:
         data(state).is_null = false;
     }
 
-    void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr state, Column* to) const override {
+    void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         size_t size = data(state).percentile->serialize_size();
         uint8_t result[size + sizeof(double)];
         memcpy(result, &(data(state).targetQuantile), sizeof(double));
@@ -141,7 +141,7 @@ public:
         }
     }
 
-    void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr state, Column* to) const override {
+    void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         if (to->is_nullable()) {
             auto* nullable_column = down_cast<NullableColumn*>(to);
             if (data(state).is_null) {

--- a/be/src/exprs/agg/percentile_union.h
+++ b/be/src/exprs/agg/percentile_union.h
@@ -16,7 +16,7 @@ public:
         this->data(state).merge(column->get_object(row_num));
     }
 
-    void update_batch_single_state(FunctionContext* ctx, AggDataPtr state, const Column** columns,
+    void update_batch_single_state(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
                                    int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
                                    int64_t frame_end) const override {
         const PercentileColumn* column = down_cast<const PercentileColumn*>(columns[0]);
@@ -25,14 +25,14 @@ public:
         }
     }
 
-    void merge(FunctionContext* ctx, const Column* column, AggDataPtr state, size_t row_num) const override {
+    void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
         DCHECK(column->is_object());
 
         const PercentileColumn* percentile_column = down_cast<const PercentileColumn*>(column);
         this->data(state).merge(percentile_column->get_object(row_num));
     }
 
-    void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr state, Column* to) const override {
+    void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         DCHECK(to->is_object());
         auto* column = down_cast<PercentileColumn*>(to);
         auto& percentile_value = const_cast<PercentileValue&>(this->data(state));
@@ -43,7 +43,7 @@ public:
         *dst = src[0];
     }
 
-    void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr state, Column* to) const override {
+    void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         DCHECK(to->is_object());
         auto* column = down_cast<PercentileColumn*>(to);
         auto& percentile_value = const_cast<PercentileValue&>(this->data(state));

--- a/be/src/exprs/agg/sum.h
+++ b/be/src/exprs/agg/sum.h
@@ -43,14 +43,15 @@ public:
         this->data(state).sum = {};
     }
 
-    void update(FunctionContext* ctx, const Column** columns, AggDataPtr state, size_t row_num) const override {
+    void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
+                size_t row_num) const override {
         DCHECK(columns[0]->is_numeric() || columns[0]->is_decimal());
         const auto& column = down_cast<const InputColumnType&>(*columns[0]);
         this->data(state).sum += column.get_data()[row_num];
     }
 
     void update_batch_single_state(FunctionContext* ctx, size_t batch_size, const Column** columns,
-                                   AggDataPtr state) const override {
+                                   AggDataPtr __restrict state) const override {
         const auto* column = down_cast<const InputColumnType*>(columns[0]);
         const auto* data = column->get_data().data();
         ResultType local_sum{};
@@ -60,7 +61,7 @@ public:
         this->data(state).sum += local_sum;
     }
 
-    void update_batch_single_state(FunctionContext* ctx, AggDataPtr state, const Column** columns,
+    void update_batch_single_state(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
                                    int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
                                    int64_t frame_end) const override {
         const auto* column = down_cast<const InputColumnType*>(columns[0]);
@@ -70,13 +71,14 @@ public:
         }
     }
 
-    void merge(FunctionContext* ctx, const Column* column, AggDataPtr state, size_t row_num) const override {
+    void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
         DCHECK(column->is_numeric() || column->is_decimal());
         const auto* input_column = down_cast<const ResultColumnType*>(column);
         this->data(state).sum += input_column->get_data()[row_num];
     }
 
-    void get_values(FunctionContext* ctx, ConstAggDataPtr state, Column* dst, size_t start, size_t end) const override {
+    void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,
+                    size_t end) const override {
         DCHECK_GT(end, start);
         ResultType result = this->data(state).sum;
         ResultColumnType* column = down_cast<ResultColumnType*>(dst);
@@ -85,7 +87,7 @@ public:
         }
     }
 
-    void serialize_to_column(FunctionContext* ctx __attribute__((unused)), ConstAggDataPtr state,
+    void serialize_to_column(FunctionContext* ctx __attribute__((unused)), ConstAggDataPtr __restrict state,
                              Column* to) const override {
         DCHECK(to->is_numeric() || to->is_decimal());
         down_cast<ResultColumnType*>(to)->append(this->data(state).sum);
@@ -100,7 +102,7 @@ public:
         }
     }
 
-    void finalize_to_column(FunctionContext* ctx __attribute__((unused)), ConstAggDataPtr state,
+    void finalize_to_column(FunctionContext* ctx __attribute__((unused)), ConstAggDataPtr __restrict state,
                             Column* to) const override {
         DCHECK(to->is_numeric() || to->is_decimal());
         down_cast<ResultColumnType*>(to)->append(this->data(state).sum);

--- a/be/src/exprs/agg/sum.h
+++ b/be/src/exprs/agg/sum.h
@@ -54,11 +54,9 @@ public:
                                    AggDataPtr __restrict state) const override {
         const auto* column = down_cast<const InputColumnType*>(columns[0]);
         const auto* data = column->get_data().data();
-        ResultType local_sum{};
         for (size_t i = 0; i < batch_size; ++i) {
-            local_sum += data[i];
+            this->data(state).sum += data[i];
         }
-        this->data(state).sum += local_sum;
     }
 
     void update_batch_single_state(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,

--- a/be/src/exprs/agg/variance.h
+++ b/be/src/exprs/agg/variance.h
@@ -46,7 +46,8 @@ public:
         this->data(state).count = 0;
     }
 
-    void update(FunctionContext* ctx, const Column** columns, AggDataPtr state, size_t row_num) const override {
+    void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
+                size_t row_num) const override {
         DCHECK(columns[0]->is_numeric() || columns[0]->is_decimal());
 
         const InputColumnType* column = down_cast<const InputColumnType*>(columns[0]);
@@ -77,7 +78,7 @@ public:
         this->data(state).count = temp;
     }
 
-    void update_batch_single_state(FunctionContext* ctx, AggDataPtr state, const Column** columns,
+    void update_batch_single_state(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
                                    int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
                                    int64_t frame_end) const override {
         for (size_t i = frame_start; i < frame_end; ++i) {
@@ -85,7 +86,7 @@ public:
         }
     }
 
-    void merge(FunctionContext* ctx, const Column* column, AggDataPtr state, size_t row_num) const override {
+    void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
         DCHECK(column->is_binary());
         Slice slice = column->get(row_num).get_slice();
 
@@ -125,7 +126,7 @@ public:
         }
     }
 
-    void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr state, Column* to) const override {
+    void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         DCHECK(to->is_binary());
         auto* column = down_cast<BinaryColumn*>(to);
         Bytes& bytes = column->get_bytes();
@@ -182,7 +183,7 @@ public:
     using ResultColumnType =
             typename DevFromAveAggregateFunction<PT, is_sample, T, ResultPT, TResult>::ResultColumnType;
 
-    void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr state, Column* to) const override {
+    void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         DCHECK(to->is_numeric() || to->is_decimal());
 
         int64_t count = this->data(state).count;
@@ -233,7 +234,8 @@ public:
         }
     }
 
-    void get_values(FunctionContext* ctx, ConstAggDataPtr state, Column* dst, size_t start, size_t end) const override {
+    void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,
+                    size_t end) const override {
         DCHECK_GT(end, start);
 
         TResult result;
@@ -298,7 +300,7 @@ public:
     using ResultColumnType =
             typename DevFromAveAggregateFunction<PT, is_sample, T, ResultPT, TResult>::ResultColumnType;
 
-    void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr state, Column* to) const override {
+    void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         DCHECK(to->is_numeric() || to->is_decimal());
 
         int64_t count = this->data(state).count;
@@ -359,7 +361,8 @@ public:
         }
     }
 
-    void get_values(FunctionContext* ctx, ConstAggDataPtr state, Column* dst, size_t start, size_t end) const override {
+    void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,
+                    size_t end) const override {
         DCHECK_GT(end, start);
 
         TResult result;

--- a/be/src/exprs/agg/window.h
+++ b/be/src/exprs/agg/window.h
@@ -24,11 +24,12 @@ class WindowFunction : public AggregateFunctionStateHelper<State> {
     }
 
     void merge_batch_single_state(FunctionContext* ctx, size_t batch_size, const Column* column,
-                                  AggDataPtr state) const override {
+                                  AggDataPtr __restrict state) const override {
         DCHECK(false) << "Shouldn't call this method for window function!";
     }
 
-    void update(FunctionContext* ctx, const Column** columns, AggDataPtr state, size_t row_num) const override {
+    void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
+                size_t row_num) const override {
         DCHECK(false) << "Shouldn't call this method for window function!";
     }
 
@@ -43,15 +44,15 @@ class WindowFunction : public AggregateFunctionStateHelper<State> {
     }
 
     void update_batch_single_state(FunctionContext* ctx, size_t batch_size, const Column** columns,
-                                   AggDataPtr state) const override {
+                                   AggDataPtr __restrict state) const override {
         DCHECK(false) << "Shouldn't call this method for window function!";
     }
 
-    void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr state, Column* to) const override {
+    void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         DCHECK(false) << "Shouldn't call this method for window function!";
     }
 
-    void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr state, Column* to) const override {
+    void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         DCHECK(false) << "Shouldn't call this method for window function!";
     }
 
@@ -71,7 +72,7 @@ class WindowFunction : public AggregateFunctionStateHelper<State> {
 
 protected:
     // BinaryColumn column is special, the underlying _bytes and _offsets column don't resize
-    void get_slice_values(ConstAggDataPtr state, Column* dst, size_t start, size_t end) const {
+    void get_slice_values(ConstAggDataPtr __restrict state, Column* dst, size_t start, size_t end) const {
         DCHECK_GT(end, start);
         DCHECK(dst->is_nullable());
         auto* nullable_column = down_cast<NullableColumn*>(dst);
@@ -98,7 +99,7 @@ public:
     using InputColumnType = RunTimeColumnType<PT>;
 
     // The dst column has been resized.
-    void get_values_helper(ConstAggDataPtr state, Column* dst, size_t start, size_t end) const {
+    void get_values_helper(ConstAggDataPtr __restrict state, Column* dst, size_t start, size_t end) const {
         DCHECK_GT(end, start);
         DCHECK(dst->is_nullable());
         auto* nullable_column = down_cast<NullableColumn*>(dst);
@@ -124,17 +125,18 @@ struct RowNumberState {
 };
 
 class RowNumberWindowFunction final : public WindowFunction<RowNumberState> {
-    void reset(FunctionContext* ctx, const Columns& args, AggDataPtr state) const override {
+    void reset(FunctionContext* ctx, const Columns& args, AggDataPtr __restrict state) const override {
         this->data(state).cur_positon = 0;
     }
 
-    void update_batch_single_state(FunctionContext* ctx, AggDataPtr state, const Column** columns,
+    void update_batch_single_state(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
                                    int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
                                    int64_t frame_end) const override {
         this->data(state).cur_positon++;
     }
 
-    void get_values(FunctionContext* ctx, ConstAggDataPtr state, Column* dst, size_t start, size_t end) const override {
+    void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,
+                    size_t end) const override {
         DCHECK_GT(end, start);
         Int64Column* column = down_cast<Int64Column*>(dst);
         column->get_data()[start] = this->data(state).cur_positon;
@@ -150,13 +152,13 @@ struct RankState {
 };
 
 class RankWindowFunction final : public WindowFunction<RankState> {
-    void reset(FunctionContext* ctx, const Columns& args, AggDataPtr state) const override {
+    void reset(FunctionContext* ctx, const Columns& args, AggDataPtr __restrict state) const override {
         this->data(state).rank = 0;
         this->data(state).count = 1;
         this->data(state).peer_group_start = -1;
     }
 
-    void update_batch_single_state(FunctionContext* ctx, AggDataPtr state, const Column** columns,
+    void update_batch_single_state(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
                                    int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
                                    int64_t frame_end) const override {
         int64_t peer_group_count = peer_group_end - peer_group_start;
@@ -167,7 +169,8 @@ class RankWindowFunction final : public WindowFunction<RankState> {
         this->data(state).count = peer_group_count;
     }
 
-    void get_values(FunctionContext* ctx, ConstAggDataPtr state, Column* dst, size_t start, size_t end) const override {
+    void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,
+                    size_t end) const override {
         DCHECK_GT(end, start);
         Int64Column* column = down_cast<Int64Column*>(dst);
         for (size_t i = start; i < end; ++i) {
@@ -184,12 +187,12 @@ struct DenseRankState {
 };
 
 class DenseRankWindowFunction final : public WindowFunction<DenseRankState> {
-    void reset(FunctionContext* ctx, const Columns& args, AggDataPtr state) const override {
+    void reset(FunctionContext* ctx, const Columns& args, AggDataPtr __restrict state) const override {
         this->data(state).rank = 0;
         this->data(state).peer_group_start = -1;
     }
 
-    void update_batch_single_state(FunctionContext* ctx, AggDataPtr state, const Column** columns,
+    void update_batch_single_state(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
                                    int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
                                    int64_t frame_end) const override {
         if (this->data(state).peer_group_start != peer_group_start) {
@@ -198,7 +201,8 @@ class DenseRankWindowFunction final : public WindowFunction<DenseRankState> {
         }
     }
 
-    void get_values(FunctionContext* ctx, ConstAggDataPtr state, Column* dst, size_t start, size_t end) const override {
+    void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,
+                    size_t end) const override {
         DCHECK_GT(end, start);
         Int64Column* column = down_cast<Int64Column*>(dst);
         for (size_t i = start; i < end; ++i) {
@@ -221,13 +225,13 @@ template <PrimitiveType PT, typename T = RunTimeCppType<PT>, typename = guard::G
 class FirstValueWindowFunction final : public ValueWindowFunction<PT, FirstValueState<PT>, T> {
     using InputColumnType = typename ValueWindowFunction<PT, FirstValueState<PT>, T>::InputColumnType;
 
-    void reset(FunctionContext* ctx, const Columns& args, AggDataPtr state) const override {
+    void reset(FunctionContext* ctx, const Columns& args, AggDataPtr __restrict state) const override {
         this->data(state).value = {};
         this->data(state).has_value = false;
         this->data(state).is_null = false;
     }
 
-    void update_batch_single_state(FunctionContext* ctx, AggDataPtr state, const Column** columns,
+    void update_batch_single_state(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
                                    int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
                                    int64_t frame_end) const override {
         if (this->data(state).has_value) {
@@ -246,7 +250,8 @@ class FirstValueWindowFunction final : public ValueWindowFunction<PT, FirstValue
         this->data(state).has_value = true;
     }
 
-    void get_values(FunctionContext* ctx, ConstAggDataPtr state, Column* dst, size_t start, size_t end) const override {
+    void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,
+                    size_t end) const override {
         this->get_values_helper(state, dst, start, end);
     }
 
@@ -264,12 +269,12 @@ template <PrimitiveType PT, typename T = RunTimeCppType<PT>, typename = guard::G
 class LastValueWindowFunction final : public ValueWindowFunction<PT, LastValueState<PT>, T> {
     using InputColumnType = typename ValueWindowFunction<PT, FirstValueState<PT>, T>::InputColumnType;
 
-    void reset(FunctionContext* ctx, const Columns& args, AggDataPtr state) const override {
+    void reset(FunctionContext* ctx, const Columns& args, AggDataPtr __restrict state) const override {
         this->data(state).value = {};
         this->data(state).is_null = false;
     }
 
-    void update_batch_single_state(FunctionContext* ctx, AggDataPtr state, const Column** columns,
+    void update_batch_single_state(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
                                    int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
                                    int64_t frame_end) const override {
         if (columns[0]->is_null(frame_end - 1)) {
@@ -283,7 +288,8 @@ class LastValueWindowFunction final : public ValueWindowFunction<PT, LastValueSt
         this->data(state).value = column->get_data()[frame_end - 1];
     }
 
-    void get_values(FunctionContext* ctx, ConstAggDataPtr state, Column* dst, size_t start, size_t end) const override {
+    void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,
+                    size_t end) const override {
         this->get_values_helper(state, dst, start, end);
     }
 
@@ -303,7 +309,7 @@ template <PrimitiveType PT, typename T = RunTimeCppType<PT>, typename = guard::G
 class LeadLagWindowFunction final : public ValueWindowFunction<PT, LeadLagState<PT>, T> {
     using InputColumnType = typename ValueWindowFunction<PT, FirstValueState<PT>, T>::InputColumnType;
 
-    void reset(FunctionContext* ctx, const Columns& args, AggDataPtr state) const override {
+    void reset(FunctionContext* ctx, const Columns& args, AggDataPtr __restrict state) const override {
         this->data(state).value = {};
         this->data(state).is_null = false;
         const Column* arg2 = args[2].get();
@@ -316,7 +322,7 @@ class LeadLagWindowFunction final : public ValueWindowFunction<PT, LeadLagState<
         }
     }
 
-    void update_batch_single_state(FunctionContext* ctx, AggDataPtr state, const Column** columns,
+    void update_batch_single_state(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
                                    int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
                                    int64_t frame_end) const override {
         // frame_end <= frame_start is for lag function
@@ -341,7 +347,8 @@ class LeadLagWindowFunction final : public ValueWindowFunction<PT, LeadLagState<
         this->data(state).value = column->get_data()[frame_end - 1];
     }
 
-    void get_values(FunctionContext* ctx, ConstAggDataPtr state, Column* dst, size_t start, size_t end) const override {
+    void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,
+                    size_t end) const override {
         this->get_values_helper(state, dst, start, end);
     }
 
@@ -359,13 +366,13 @@ struct FirstValueState<PT, BinaryPTGuard<PT>> {
 
 template <PrimitiveType PT>
 class FirstValueWindowFunction<PT, Slice, BinaryPTGuard<PT>> final : public WindowFunction<FirstValueState<PT>> {
-    void reset(FunctionContext* ctx, const Columns& args, AggDataPtr state) const override {
+    void reset(FunctionContext* ctx, const Columns& args, AggDataPtr __restrict state) const override {
         this->data(state).buffer.clear();
         this->data(state).has_value = false;
         this->data(state).is_null = false;
     }
 
-    void update_batch_single_state(FunctionContext* ctx, AggDataPtr state, const Column** columns,
+    void update_batch_single_state(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
                                    int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
                                    int64_t frame_end) const override {
         if (this->data(state).has_value) {
@@ -386,7 +393,8 @@ class FirstValueWindowFunction<PT, Slice, BinaryPTGuard<PT>> final : public Wind
         this->data(state).has_value = true;
     }
 
-    void get_values(FunctionContext* ctx, ConstAggDataPtr state, Column* dst, size_t start, size_t end) const override {
+    void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,
+                    size_t end) const override {
         this->get_slice_values(state, dst, start, end);
     }
 
@@ -403,12 +411,12 @@ struct LastValueState<PT, BinaryPTGuard<PT>> {
 
 template <PrimitiveType PT>
 class LastValueWindowFunction<PT, Slice, BinaryPTGuard<PT>> final : public WindowFunction<LastValueState<PT>> {
-    void reset(FunctionContext* ctx, const Columns& args, AggDataPtr state) const override {
+    void reset(FunctionContext* ctx, const Columns& args, AggDataPtr __restrict state) const override {
         this->data(state).buffer.clear();
         this->data(state).is_null = false;
     }
 
-    void update_batch_single_state(FunctionContext* ctx, AggDataPtr state, const Column** columns,
+    void update_batch_single_state(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
                                    int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
                                    int64_t frame_end) const override {
         if (columns[0]->is_null(frame_end - 1)) {
@@ -425,7 +433,8 @@ class LastValueWindowFunction<PT, Slice, BinaryPTGuard<PT>> final : public Windo
         this->data(state).buffer.insert(this->data(state).buffer.end(), p, p + slice.size);
     }
 
-    void get_values(FunctionContext* ctx, ConstAggDataPtr state, Column* dst, size_t start, size_t end) const override {
+    void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,
+                    size_t end) const override {
         this->get_slice_values(state, dst, start, end);
     }
 
@@ -444,7 +453,7 @@ struct LeadLagState<PT, BinaryPTGuard<PT>> {
 
 template <PrimitiveType PT>
 class LeadLagWindowFunction<PT, Slice, BinaryPTGuard<PT>> final : public WindowFunction<LeadLagState<PT>> {
-    void reset(FunctionContext* ctx, const Columns& args, AggDataPtr state) const override {
+    void reset(FunctionContext* ctx, const Columns& args, AggDataPtr __restrict state) const override {
         this->data(state).value.clear();
         this->data(state).is_null = false;
         const Column* arg2 = args[2].get();
@@ -460,7 +469,7 @@ class LeadLagWindowFunction<PT, Slice, BinaryPTGuard<PT>> final : public WindowF
         }
     }
 
-    void update_batch_single_state(FunctionContext* ctx, AggDataPtr state, const Column** columns,
+    void update_batch_single_state(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
                                    int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
                                    int64_t frame_end) const override {
         // frame_end <= frame_start is for lag function
@@ -486,7 +495,8 @@ class LeadLagWindowFunction<PT, Slice, BinaryPTGuard<PT>> final : public WindowF
         this->data(state).value.insert(this->data(state).value.end(), p, p + slice.size);
     }
 
-    void get_values(FunctionContext* ctx, ConstAggDataPtr state, Column* dst, size_t start, size_t end) const override {
+    void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,
+                    size_t end) const override {
         this->get_slice_values(state, dst, start, end);
     }
 


### PR DESCRIPTION
1. revert [pr-593](https://github.com/StarRocks/starrocks/pull/593), because __restrict can reach the same performance（[micro-benchmark](https://quick-bench.com/q/YGj_8ozZI8jVdndN4ErVdI-gNXU)）
2. add keyword 「__restrict」, which is used to solve the problem of 「pointer-aliasing」
    * I add the keyword 「__restrict」 everywhere AggDataPtr appears, but only some have optimization effects while it has not side effects
    * To help you better understand this keyword, I do some micro-benchmarks listing as follows:
        * [micro-benchmark-1](https://quick-bench.com/q/ZQoR7xloXdKcqLC-rPFLhSuHEf0)
        * [micro-benchmark-2](https://quick-bench.com/q/E5SfW3gn2IjJl4q0YIVMBPW8Ja8)
        * [micro-benchmark-3](https://quick-bench.com/q/yniGOh4CIz6YRGj85HFwu4WoHME)
3. optimize avg function, for type of integers, using local interger type instead of float to calculate sum

Here are the test information

1. test set: ssb
2. scale factor: 100

```sql
-- Q1
SELECT SUM(lo_orderkey +1), SUM(lo_linenumber*2) FROM lineorder;

-- Q2
SELECT COUNT(lo_linenumber) FROM lineorder;

-- Q3
SELECT AVG(lo_orderkey +1), AVG(lo_linenumber*2) FROM lineorder;

-- Q4
SELECT MIN(lo_orderkey +1), MIN(lo_linenumber*2) FROM lineorder;

-- Q5
SELECT MAX(lo_orderkey +1), MAX(lo_linenumber*2) FROM lineorder;
```

Every single case runs more than 5 times and take the average

|  | before optimize(time usage of aggregate function, not whole sql) | after optimize(time usage of aggregate function, not whole sql) | ratio |
|:--|:--|:--|:--|
| Q1 |  330ms |  330ms | 0% |
| Q2 |  83ms |  84ms | -1% |
| Q3 |  1790ms |  674ms | 62.3% |
| Q4 |  965ms |  960ms | 0% |
| Q5 |  960ms |  790ms | 17.7% |
