### PR TITLE
Fix bug when encounter is null predicate in schema change (#725)

### DIFF
--- a/be/src/storage/delete_handler.cpp
+++ b/be/src/storage/delete_handler.cpp
@@ -231,7 +231,13 @@ bool DeleteHandler::parse_condition(const std::string& condition_str, TCondition
     }
 
     condition->column_name = what[1].str();
-    condition->condition_op = what[2].str();
+    // 'is' predicate will be parsed as ' is ' which has extra space
+    // remove extra space and set op as 'is'
+    if (what[2].str().size() == 4 && strcasecmp(what[2].str().c_str(), " is ") == 0) {
+        condition->condition_op = "IS";
+    } else {
+        condition->condition_op = what[2].str();
+    }
     condition->condition_values.push_back(what[3].str());
 
     return true;


### PR DESCRIPTION
Is null predicate has empty space in string. The empty space is also stored in meta.
When parsing the predicate in schema change, the empty space will cause misunderstanding and error.
So this pull request is to eliminate the empty space when parsing.