### PR TITLE
Compatible with the old global dict table in spark dpp

### DIFF
--- a/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/dpp/GlobalDictBuilder.java
+++ b/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/dpp/GlobalDictBuilder.java
@@ -134,6 +134,20 @@ public class GlobalDictBuilder {
         spark.sql("use " + starrocksHiveDB);
     }
 
+    /**
+     * Check if doris global dict table already exist.
+     * If exist, use old name for compatibility.
+     *
+     * @param dorisGlobalDictTableName old global dict table name in previous version
+     */
+    public void checkGlobalDictTableName(String dorisGlobalDictTableName) {
+        Dataset<Row> result = spark.sql("show tables like '" + dorisGlobalDictTableName + "'");
+        if (result.count() > 0) {
+            globalDictTableName = dorisGlobalDictTableName;
+        }
+        LOG.info("global dict table name: " + globalDictTableName);
+    }
+
     public void createHiveIntermediateTable() throws AnalysisException {
         Map<String, String> sourceHiveTableColumn = spark.catalog()
                 .listColumns(sourceHiveDBTableName)

--- a/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/etl/EtlJobConfig.java
+++ b/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/etl/EtlJobConfig.java
@@ -133,6 +133,8 @@ import java.util.Map;
 public class EtlJobConfig implements Serializable {
     // global dict
     public static final String GLOBAL_DICT_TABLE_NAME = "starrocks_global_dict_table_%d";
+    // Compatible with old global dict table name in previous version
+    public static final String DORIS_GLOBAL_DICT_TABLE_NAME = "doris_global_dict_table_%d";
     public static final String DISTINCT_KEY_TABLE_NAME = "starrocks_distinct_key_table_%d_%s";
     public static final String STARROCKS_INTERMEDIATE_HIVE_TABLE_NAME = "starrocks_intermediate_hive_table_%d_%s";
 

--- a/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/etl/SparkEtlJob.java
+++ b/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/etl/SparkEtlJob.java
@@ -158,6 +158,7 @@ public class SparkEtlJob {
         String starrocksHiveDB = sourceHiveDBTableName.split("\\.")[0];
         String taskId = etlJobConfig.outputPath.substring(etlJobConfig.outputPath.lastIndexOf("/") + 1);
         String globalDictTableName = String.format(EtlJobConfig.GLOBAL_DICT_TABLE_NAME, tableId);
+        String dorisGlobalDictTableName = String.format(EtlJobConfig.DORIS_GLOBAL_DICT_TABLE_NAME, tableId);
         String distinctKeyTableName = String.format(EtlJobConfig.DISTINCT_KEY_TABLE_NAME, tableId, taskId);
         String starrocksIntermediateHiveTable =
                 String.format(EtlJobConfig.STARROCKS_INTERMEDIATE_HIVE_TABLE_NAME, tableId, taskId);
@@ -182,6 +183,7 @@ public class SparkEtlJob {
                     sourceHiveFilter, starrocksHiveDB, distinctKeyTableName, globalDictTableName,
                     starrocksIntermediateHiveTable,
                     buildConcurrency, veryHighCardinalityColumn, veryHighCardinalityColumnSplitNum, spark);
+            globalDictBuilder.checkGlobalDictTableName(dorisGlobalDictTableName);
             globalDictBuilder.createHiveIntermediateTable();
             globalDictBuilder.extractDistinctColumn();
             globalDictBuilder.buildGlobalDict();


### PR DESCRIPTION
The previous version name is doris_global_dict_table_xxx,
but the new version name is starrocks_global_dict_table_xxx,
if the table with old name exists, use the old name.