### PR TITLE
[branch-mem] [Memory] Modify MemTracker for new memory statistics framework

### DIFF
--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -358,10 +358,6 @@ Status ExecNode::close(RuntimeState* state) {
         _expr_mem_pool->free_all();
     }
 
-    if (_mem_tracker != nullptr) {
-        _mem_tracker->close();
-    }
-
     return result;
 }
 

--- a/be/src/exec/pipeline/operator.cpp
+++ b/be/src/exec/pipeline/operator.cpp
@@ -20,9 +20,6 @@ Status Operator::prepare(RuntimeState* state) {
 }
 
 Status Operator::close(RuntimeState* state) {
-    if (_mem_tracker != nullptr) {
-        _mem_tracker->close();
-    }
     return Status::OK();
 }
 

--- a/be/src/runtime/current_thread.h
+++ b/be/src/runtime/current_thread.h
@@ -5,8 +5,8 @@
 #include <string>
 
 #include "gen_cpp/Types_types.h"
-#include "runtime/mem_tracker.h"
 #include "runtime/exec_env.h"
+#include "runtime/mem_tracker.h"
 #include "util/uid_util.h"
 
 namespace starrocks {

--- a/be/src/runtime/current_thread.h
+++ b/be/src/runtime/current_thread.h
@@ -6,6 +6,7 @@
 
 #include "gen_cpp/Types_types.h"
 #include "runtime/mem_tracker.h"
+#include "runtime/exec_env.h"
 #include "util/uid_util.h"
 
 namespace starrocks {
@@ -18,8 +19,9 @@ public:
     ~CurrentThread() { commit(); }
 
     void commit() {
-        if (_cache_size != 0 && _mem_tracker != nullptr) {
-            _mem_tracker->release(_cache_size);
+        MemTracker* cur_tracker = mem_tracker();
+        if (_cache_size != 0 && cur_tracker != nullptr) {
+            cur_tracker->consume(_cache_size);
             _cache_size = 0;
         }
     }
@@ -34,38 +36,48 @@ public:
 
     // Return prev memory tracker.
     starrocks::MemTracker* set_mem_tracker(starrocks::MemTracker* mem_tracker) {
+        commit();
         auto* prev = _mem_tracker;
         _mem_tracker = mem_tracker;
         return prev;
     }
 
-    starrocks::MemTracker* mem_tracker() { return _mem_tracker; }
+    starrocks::MemTracker* mem_tracker() {
+        if (UNLIKELY(_mem_tracker == nullptr)) {
+            _mem_tracker = ExecEnv::GetInstance()->process_mem_tracker();
+        }
+        return _mem_tracker;
+    }
 
     void mem_consume(int64_t size) {
+        MemTracker* cur_tracker = mem_tracker();
         _cache_size += size;
-        if (_mem_tracker != nullptr && _cache_size >= BATCH_SIZE) {
-            _mem_tracker->consume(_cache_size);
+        if (cur_tracker != nullptr && _cache_size >= BATCH_SIZE) {
+            cur_tracker->consume(_cache_size);
             _cache_size = 0;
         }
     }
 
     void mem_consume_without_cache(int64_t size) {
-        if (_mem_tracker != nullptr && size != 0) {
-            _mem_tracker->consume(size);
+        MemTracker* cur_tracker = mem_tracker();
+        if (cur_tracker != nullptr && size != 0) {
+            cur_tracker->consume(size);
         }
     }
 
     void mem_release(int64_t size) {
+        MemTracker* cur_tracker = mem_tracker();
         _cache_size -= size;
-        if (_mem_tracker != nullptr && _cache_size <= -1 * BATCH_SIZE) {
-            _mem_tracker->release(_cache_size);
+        if (cur_tracker != nullptr && _cache_size <= -BATCH_SIZE) {
+            cur_tracker->release(-_cache_size);
             _cache_size = 0;
         }
     }
 
     void mem_release_without_cache(int64_t size) {
-        if (_mem_tracker != nullptr && size != 0) {
-            _mem_tracker->release(size);
+        MemTracker* cur_tracker = mem_tracker();
+        if (cur_tracker != nullptr && size != 0) {
+            cur_tracker->release(size);
         }
     }
 

--- a/be/src/runtime/data_stream_recvr.cc
+++ b/be/src/runtime/data_stream_recvr.cc
@@ -696,7 +696,6 @@ void DataStreamRecvr::close() {
     _mgr->deregister_recvr(fragment_instance_id(), dest_node_id());
     _mgr = nullptr;
     _chunks_merger.reset();
-    _mem_tracker->close();
     _mem_tracker.reset();
 }
 

--- a/be/src/runtime/mem_tracker.cpp
+++ b/be/src/runtime/mem_tracker.cpp
@@ -96,13 +96,9 @@ void MemTracker::Init() {
     DCHECK_EQ(_all_trackers[0], this);
 }
 
-// TODO chenhao , set MemTracker close state
-void MemTracker::close() {}
-
 MemTracker::~MemTracker() {
-    DCHECK_EQ(0, consumption()) << tls_thread_status.query_id_string();
-    if (UNLIKELY(consumption() > 0)) {
-        release(consumption());
+    if (consumption() != 0) {
+        release_without_root(consumption());
     }
     if (_auto_unregister && parent()) {
         unregister_from_parent();

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -119,20 +119,6 @@ RuntimeState::~RuntimeState() {
     if (_exec_env != nullptr && _exec_env->thread_mgr() != nullptr) {
         _exec_env->thread_mgr()->unregister_pool(_resource_pool);
     }
-
-#ifndef BE_TEST
-    // LogUsage() walks the MemTracker tree top-down when the memory limit is exceeded.
-    // Break the link between the instance_mem_tracker and its parent (_query_mem_tracker)
-    // before the _instance_mem_tracker and its children are destroyed.
-    if (_instance_mem_tracker != nullptr) {
-        // May be NULL if InitMemTrackers() is not called, for example from tests.
-        _instance_mem_tracker->close();
-    }
-
-    if (_query_mem_tracker != nullptr) {
-        _query_mem_tracker->close();
-    }
-#endif
 }
 
 Status RuntimeState::init(const TUniqueId& fragment_instance_id, const TQueryOptions& query_options,


### PR DESCRIPTION
for #703 

* remove MemTracker::close()
* if not set thread local mem_tracker, use default process mem_tracker
* Under the current memory statistics framework, the statistical value of MemTracker may not be 0 when it is destructed. Here you need to return these statistics to RootMemTracker
* If MemTracker deallocate, return the memory stastics to process mem_tracker