### PR TITLE
optimize null flags encoding (#757)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -583,7 +583,13 @@ CONF_Bool(bitmap_filter_enable_not_equal, "false");
 // When storage_format_version is 2, DATE_V2, TIMESTAMP and DECIMAL_V2 will be used as
 // storage format.
 CONF_mInt16(storage_format_version, "2");
-CONF_mInt16(default_page_format, "3");
+
+// IMPORTANT NOTE: changing 0 from 1 must require all BEs to be upgraded to new versions,
+// which support this config.
+// DO NOT change this config unless you known how.
+// 0 for bitshuffle
+// 1 for lz4
+CONF_mInt16(null_flag_version, "0");
 
 // do pre-aggregate if effect great than the factor, factor range:[1-100].
 CONF_Int16(pre_aggregate_factor, "80");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -583,6 +583,7 @@ CONF_Bool(bitmap_filter_enable_not_equal, "false");
 // When storage_format_version is 2, DATE_V2, TIMESTAMP and DECIMAL_V2 will be used as
 // storage format.
 CONF_mInt16(storage_format_version, "2");
+CONF_mInt16(default_page_format, "3");
 
 // do pre-aggregate if effect great than the factor, factor range:[1-100].
 CONF_Int16(pre_aggregate_factor, "80");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -584,12 +584,12 @@ CONF_Bool(bitmap_filter_enable_not_equal, "false");
 // storage format.
 CONF_mInt16(storage_format_version, "2");
 
-// IMPORTANT NOTE: changing 0 from 1 must require all BEs to be upgraded to new versions,
+// IMPORTANT NOTE: changing this config to 1 must require all BEs to be upgraded to new version,
 // which support this config.
 // DO NOT change this config unless you known how.
-// 0 for bitshuffle
-// 1 for lz4
-CONF_mInt16(null_flag_version, "0");
+// 0 for BITSHUFFLE_NULL
+// 1 for LZ4_NULL
+CONF_mInt16(null_format, "0");
 
 // do pre-aggregate if effect great than the factor, factor range:[1-100].
 CONF_Int16(pre_aggregate_factor, "80");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -589,7 +589,7 @@ CONF_mInt16(storage_format_version, "2");
 // DO NOT change this config unless you known how.
 // 0 for BITSHUFFLE_NULL
 // 1 for LZ4_NULL
-CONF_mInt16(null_format, "0");
+CONF_mInt16(null_encoding, "0");
 
 // do pre-aggregate if effect great than the factor, factor range:[1-100].
 CONF_Int16(pre_aggregate_factor, "80");

--- a/be/src/storage/rowset/segment_v2/column_writer.cpp
+++ b/be/src/storage/rowset/segment_v2/column_writer.cpp
@@ -135,8 +135,6 @@ public:
 
     OwnedSlice finish() {
         if (_null_flag_version == 0) {
-            LOG(INFO) << "use bitsshuffle to encoding null flag, _null_flag_version:" << _null_flag_version;
-            std::cout << " use bitsshuffle to encoding null flag, _null_flag_version:" << _null_flag_version << std::endl;
             size_t old_size = _null_map.size();
             _null_map.resize(ALIGN_UP(_null_map.size(), 8u));
             memset(_null_map.data() + old_size, 0, _null_map.size() - old_size);
@@ -148,8 +146,6 @@ public:
             }
             return _encode_buf.build();
         } else if (_null_flag_version == 1) {
-            LOG(INFO) << "use bitsshuffle to encoding null flag, _null_flag_version:" << _null_flag_version;
-            std::cout << "use bitsshuffle to encoding null flag, _null_flag_version:" << _null_flag_version << std::endl;
             const BlockCompressionCodec* codec = nullptr;
             CompressionTypePB type = CompressionTypePB::LZ4;
             Status status = get_block_compression_codec(type, &codec);
@@ -188,9 +184,7 @@ public:
     }
 
     // add this api for config::null_flag_version can be modified online
-    int16_t null_flag_version() {
-        return _null_flag_version;
-    }
+    int16_t null_flag_version() { return _null_flag_version; }
 
 private:
     bool _has_null{false};
@@ -556,8 +550,6 @@ Status ScalarColumnWriter::finish_current_page() {
     data_page_footer->set_format_version(_curr_page_format);
     data_page_footer->set_corresponding_element_ordinal(_element_ordinal);
     if (is_nullable() && (_curr_page_format == 2)) {
-        LOG(INFO) << "set null flag version in footer:" << _null_map_builder_v2->null_flag_version();
-        std::cout << "set null flag version in footer:" << _null_map_builder_v2->null_flag_version() << std::endl;
         data_page_footer->set_null_flag_version(_null_map_builder_v2->null_flag_version());
     }
     // trying to compress page body

--- a/be/src/storage/rowset/segment_v2/column_writer.cpp
+++ b/be/src/storage/rowset/segment_v2/column_writer.cpp
@@ -123,7 +123,7 @@ private:
 
 class NullFlagsBuilder {
 public:
-    NullFlagsBuilder() : _null_map(32 * 1024) {}
+    NullFlagsBuilder() : _null_map(32 * 1024), _null_flag_version(config::null_flag_version) {}
 
     explicit NullFlagsBuilder(size_t reserve_bits) : _has_null(false), _null_map(reserve_bits) {}
 
@@ -133,8 +133,10 @@ public:
 
     ALWAYS_INLINE void set_has_null(bool has_null) { _has_null = has_null; }
 
-    OwnedSlice finish(uint32_t page_format) {
-        if (page_format == 2) {
+    OwnedSlice finish() {
+        if (_null_flag_version == 0) {
+            LOG(INFO) << "use bitsshuffle to encoding null flag, _null_flag_version:" << _null_flag_version;
+            std::cout << " use bitsshuffle to encoding null flag, _null_flag_version:" << _null_flag_version << std::endl;
             size_t old_size = _null_map.size();
             _null_map.resize(ALIGN_UP(_null_map.size(), 8u));
             memset(_null_map.data() + old_size, 0, _null_map.size() - old_size);
@@ -145,7 +147,9 @@ public:
                 LOG(FATAL) << "bitshuffle compress failed: " << bitshuffle_error_msg(r);
             }
             return _encode_buf.build();
-        } else if (page_format == 3) {
+        } else if (_null_flag_version == 1) {
+            LOG(INFO) << "use bitsshuffle to encoding null flag, _null_flag_version:" << _null_flag_version;
+            std::cout << "use bitsshuffle to encoding null flag, _null_flag_version:" << _null_flag_version << std::endl;
             const BlockCompressionCodec* codec = nullptr;
             CompressionTypePB type = CompressionTypePB::LZ4;
             Status status = get_block_compression_codec(type, &codec);
@@ -162,7 +166,7 @@ public:
             _encode_buf.resize(compressed_slice.get_size());
             return _encode_buf.build();
         } else {
-            LOG(FATAL) << "invalid page format:" << page_format;
+            LOG(FATAL) << "invalid null flag version:" << _null_flag_version;
             _encode_buf.resize(0);
             return _encode_buf.build();
         }
@@ -183,10 +187,16 @@ public:
         return SIMD::count_zero(_null_map.data(), _null_map.size());
     }
 
+    // add this api for config::null_flag_version can be modified online
+    int16_t null_flag_version() {
+        return _null_flag_version;
+    }
+
 private:
     bool _has_null{false};
     faststring _null_map;
     faststring _encode_buf;
+    int16_t _null_flag_version;
 };
 
 class StringColumnWriter final : public ColumnWriter {
@@ -526,11 +536,11 @@ Status ScalarColumnWriter::finish_current_page() {
             nullmap = _null_map_builder_v1->finish();
             body.push_back(nullmap.slice());
         }
-    } else if (is_nullable() && (_curr_page_format == 2 || _curr_page_format == 3)) {
+    } else if (is_nullable() && (_curr_page_format == 2)) {
         DCHECK_EQ(_page_builder->count(), _null_map_builder_v2->size());
         DCHECK_EQ(_null_map_builder_v2->size(), _next_rowid - _first_rowid);
         if (_null_map_builder_v2->has_null()) {
-            nullmap = _null_map_builder_v2->finish(_curr_page_format);
+            nullmap = _null_map_builder_v2->finish();
             body.push_back(nullmap.slice());
         }
     }
@@ -545,6 +555,11 @@ Status ScalarColumnWriter::finish_current_page() {
     data_page_footer->set_nullmap_size(nullmap.slice().size);
     data_page_footer->set_format_version(_curr_page_format);
     data_page_footer->set_corresponding_element_ordinal(_element_ordinal);
+    if (is_nullable() && (_curr_page_format == 2)) {
+        LOG(INFO) << "set null flag version in footer:" << _null_map_builder_v2->null_flag_version();
+        std::cout << "set null flag version in footer:" << _null_map_builder_v2->null_flag_version() << std::endl;
+        data_page_footer->set_null_flag_version(_null_map_builder_v2->null_flag_version());
+    }
     // trying to compress page body
     faststring compressed_body;
     RETURN_IF_ERROR(
@@ -568,7 +583,7 @@ Status ScalarColumnWriter::finish_current_page() {
         size_t num_null = data_page_footer->num_values() - num_data;
         // If more than 80% of the current page is NULL records, using format 1 for the next page,
         // otherwise using format 2.
-        _curr_page_format = (num_null > 4 * num_data) ? 1 : config::default_page_format;
+        _curr_page_format = (num_null > 4 * num_data) ? 1 : 2;
     }
     if (is_nullable()) {
         _null_map_builder_v1->reset();
@@ -658,7 +673,7 @@ Status ScalarColumnWriter::append(const uint8_t* data, const uint8_t* null_flags
         bool page_full = false;
         bool has_null_in_page = false;
         size_t num_written = 0;
-        if (_curr_page_format == 2 || _curr_page_format == 3) {
+        if (_curr_page_format == 2) {
             num_written = _page_builder->add(data, remaining);
             page_full = num_written < remaining;
             if (_null_map_builder_v2 != nullptr) {

--- a/be/src/storage/rowset/segment_v2/column_writer.cpp
+++ b/be/src/storage/rowset/segment_v2/column_writer.cpp
@@ -559,11 +559,9 @@ Status ScalarColumnWriter::finish_current_page() {
     data_page_footer->set_nullmap_size(nullmap.slice().size);
     data_page_footer->set_format_version(_curr_page_format);
     data_page_footer->set_corresponding_element_ordinal(_element_ordinal);
-    if (is_nullable()) {
-        // page format v1, set null encoding to RLE_NULL
-        // for other page format, use the encoding type of config::null_encoding
-        _curr_page_format == 1 ? data_page_footer->set_null_encoding(NullEncodingPB::RLE_NULL)
-                               : data_page_footer->set_null_encoding(_null_map_builder_v2->null_encoding());
+    if (is_nullable() && _curr_page_format >= 2) {
+        // for page format v2 or above, use the encoding type of config::null_encoding
+        data_page_footer->set_null_encoding(_null_map_builder_v2->null_encoding());
     }
     // trying to compress page body
     faststring compressed_body;

--- a/be/src/storage/rowset/segment_v2/column_writer.cpp
+++ b/be/src/storage/rowset/segment_v2/column_writer.cpp
@@ -559,8 +559,11 @@ Status ScalarColumnWriter::finish_current_page() {
     data_page_footer->set_nullmap_size(nullmap.slice().size);
     data_page_footer->set_format_version(_curr_page_format);
     data_page_footer->set_corresponding_element_ordinal(_element_ordinal);
-    if (is_nullable() && (_curr_page_format == 2)) {
-        data_page_footer->set_null_encoding(_null_map_builder_v2->null_encoding());
+    if (is_nullable()) {
+        // page format v1, set null encoding to RLE_NULL
+        // for other page format, use the encoding type of config::null_encoding
+        _curr_page_format == 1 ? data_page_footer->set_null_encoding(NullEncodingPB::RLE_NULL)
+                               : data_page_footer->set_null_encoding(_null_map_builder_v2->null_encoding());
     }
     // trying to compress page body
     faststring compressed_body;

--- a/be/src/storage/rowset/segment_v2/column_writer.h
+++ b/be/src/storage/rowset/segment_v2/column_writer.h
@@ -71,7 +71,7 @@ struct ColumnWriterOptions {
 class BitmapIndexWriter;
 class EncodingInfo;
 class NullMapRLEBuilder;
-class NullMapBitshuffleBuilder;
+class NullFlagsBuilder;
 class OrdinalIndexWriter;
 class PageBuilder;
 class BloomFilterIndexWriter;
@@ -224,7 +224,8 @@ private:
     std::unique_ptr<NullMapRLEBuilder> _null_map_builder_v1;
 
     // Used when _opts.page_format == 2, using bitshuffle encoding to build the null map.
-    std::unique_ptr<NullMapBitshuffleBuilder> _null_map_builder_v2;
+    // Used when _opts.page_format == 3, using lz4 encoding to build the null map.
+    std::unique_ptr<NullFlagsBuilder> _null_map_builder_v2;
 
     std::unique_ptr<OrdinalIndexWriter> _ordinal_index_builder;
     std::unique_ptr<ZoneMapIndexWriter> _zone_map_index_builder;

--- a/be/src/storage/rowset/segment_v2/parsed_page.cpp
+++ b/be/src/storage/rowset/segment_v2/parsed_page.cpp
@@ -299,8 +299,12 @@ Status parse_page_v2(std::unique_ptr<ParsedPage>* result, PageHandle handle, con
     auto null_size = footer.nullmap_size();
     if (null_size > 0) {
         Slice null_flags(body.data + body.size - null_size, null_size);
-        NullFormatPB null_format = footer.has_null_format() ? footer.null_format() : NullFormatPB::BITSHUFFLE_NULL;
-        if (null_format == NullFormatPB::BITSHUFFLE_NULL) {
+        // The historical segment file do not null_encoding field in page footer, it use BITSHUFFLE to encode null flags.
+        // For compatibility, if has_null_encoding returns false, set null_encoding to BITSHUFFLE_NULL
+        // for new segments, footer.null_encoding() will be set by config::null_encoding
+        NullEncodingPB null_encoding =
+                footer.has_null_encoding() ? footer.null_encoding() : NullEncodingPB::BITSHUFFLE_NULL;
+        if (null_encoding == NullEncodingPB::BITSHUFFLE_NULL) {
             // bitshuffle format null flags
             size_t elements = footer.num_values();
             size_t elements_pad = ALIGN_UP(elements, 8u);
@@ -311,7 +315,7 @@ Status parse_page_v2(std::unique_ptr<ParsedPage>* result, PageHandle handle, con
                 return Status::Corruption("bitshuffle decompress failed: " + bitshuffle_error_msg(r));
             }
             page->_null_flags.resize(elements);
-        } else if (null_format == NullFormatPB::LZ4_NULL) {
+        } else if (null_encoding == NullEncodingPB::LZ4_NULL) {
             // decompress null flags by lz4
             size_t elements = footer.num_values();
             page->_null_flags.resize(elements * sizeof(uint8_t));
@@ -321,7 +325,7 @@ Status parse_page_v2(std::unique_ptr<ParsedPage>* result, PageHandle handle, con
             Slice decompressed_slice(page->_null_flags.data(), elements);
             RETURN_IF_ERROR(codec->decompress(null_flags, &decompressed_slice));
         } else {
-            return Status::Corruption(fmt::format("invalid null format: {}", null_format));
+            return Status::Corruption(fmt::format("invalid null encoding: {}", null_encoding));
         }
     }
 

--- a/be/src/storage/rowset/segment_v2/parsed_page.cpp
+++ b/be/src/storage/rowset/segment_v2/parsed_page.cpp
@@ -32,8 +32,8 @@
 #include "storage/rowset/segment_v2/encoding_info.h"
 #include "storage/rowset/segment_v2/options.h"
 #include "storage/rowset/segment_v2/page_handle.h"
-#include "util/rle_encoding.h"
 #include "util/block_compression.h"
+#include "util/rle_encoding.h"
 
 namespace starrocks::segment_v2 {
 
@@ -296,17 +296,8 @@ Status parse_page_v2(std::unique_ptr<ParsedPage>* result, PageHandle handle, con
 
     auto null_size = footer.nullmap_size();
     if (null_size > 0) {
-        LOG(INFO) << "footer.has_null_flag_version():" << footer.has_null_flag_version();
-        std::cout << "footer.has_null_flag_version():" << footer.has_null_flag_version() << std::endl;
-        if (footer.has_null_flag_version()) {
-            LOG(INFO) << "footer.null_flag_version():" << footer.null_flag_version();
-            std::cout << "footer.null_flag_version():" << footer.null_flag_version() << std::endl;
-        }
         uint32_t null_flag_version = footer.has_null_flag_version() ? footer.null_flag_version() : 0;
         if (null_flag_version == 0) {
-            LOG(INFO) << "parse null flag use bitshuffle";
-            std::cout << "parse null flag use bitshuffle" << std::endl;
-            Slice null_flags(body.data + body.size - null_size, null_size);
             size_t elements = footer.num_values();
             size_t elements_pad = ALIGN_UP(elements, 8u);
             page->_null_flags.resize(elements_pad * sizeof(uint8_t));
@@ -317,8 +308,6 @@ Status parse_page_v2(std::unique_ptr<ParsedPage>* result, PageHandle handle, con
             }
             page->_null_flags.resize(elements);
         } else if (null_flag_version == 1) {
-            LOG(INFO) << "parse null flag use lz4";
-            std::cout << "parse null flag use lz4" << std::endl;
             // decompress null flags by lz4
             Slice null_flags(body.data + body.size - null_size, null_size);
             size_t elements = footer.num_values();

--- a/be/src/storage/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/storage/rowset/segment_v2/segment_writer.cpp
@@ -78,7 +78,7 @@ Status SegmentWriter::init(uint32_t write_mbytes_per_sec __attribute__((unused))
     _column_writers.reserve(_tablet_schema->columns().size());
     for (const auto& column : _tablet_schema->columns()) {
         ColumnWriterOptions opts;
-        opts.page_format = (_opts.storage_format_version == 1) ? 1 : config::default_page_format;
+        opts.page_format = (_opts.storage_format_version == 1) ? 1 : 2;
         opts.adaptive_page_format = (_opts.storage_format_version > 1);
         opts.meta = _footer.add_columns();
 

--- a/be/src/storage/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/storage/rowset/segment_v2/segment_writer.cpp
@@ -78,7 +78,7 @@ Status SegmentWriter::init(uint32_t write_mbytes_per_sec __attribute__((unused))
     _column_writers.reserve(_tablet_schema->columns().size());
     for (const auto& column : _tablet_schema->columns()) {
         ColumnWriterOptions opts;
-        opts.page_format = (_opts.storage_format_version == 1) ? 1 : 2;
+        opts.page_format = (_opts.storage_format_version == 1) ? 1 : config::default_page_format;
         opts.adaptive_page_format = (_opts.storage_format_version > 1);
         opts.meta = _footer.add_columns();
 

--- a/be/src/util/slice.h
+++ b/be/src/util/slice.h
@@ -314,6 +314,8 @@ public:
         swap(_slice, rhs._slice);
     }
 
+    bool is_loaded() { return _slice.get_data() && (_slice.get_size() > 0); }
+
 private:
     friend void swap(OwnedSlice& s1, OwnedSlice& s2);
 

--- a/be/test/storage/rowset/segment_v2/column_reader_writer_test.cpp
+++ b/be/test/storage/rowset/segment_v2/column_reader_writer_test.cpp
@@ -66,7 +66,6 @@ protected:
 
     template <FieldType type, EncodingTypePB encoding, uint32_t version, bool adaptive = true>
     void test_nullable_data(const vectorized::Column& src, const std::string null_flag_version = "0") {
-
         config::set_config("null_flag_version", null_flag_version);
 
         using Type = typename TypeTraits<type>::CppType;
@@ -269,9 +268,8 @@ protected:
 
     template <uint32_t version>
     void test_int_array(std::string null_flag_version = "0") {
-        
         config::set_config("null_flag_version", null_flag_version);
-        
+
         auto env = std::make_unique<EnvMemory>();
         auto block_mgr = std::make_unique<fs::FileBlockManager>(env.get(), fs::BlockManagerOptions());
         ASSERT_TRUE(env->create_dir(TEST_DIR).ok());

--- a/be/test/storage/rowset/segment_v2/column_reader_writer_test.cpp
+++ b/be/test/storage/rowset/segment_v2/column_reader_writer_test.cpp
@@ -264,6 +264,122 @@ protected:
         }
     }
 
+    template <uint32_t version>
+    void test_int_array() {
+        auto env = std::make_unique<EnvMemory>();
+        auto block_mgr = std::make_unique<fs::FileBlockManager>(env.get(), fs::BlockManagerOptions());
+        ASSERT_TRUE(env->create_dir(TEST_DIR).ok());
+
+        TabletColumn array_column = create_array(0, true, sizeof(Collection));
+        TabletColumn int_column = create_int_value(0, OLAP_FIELD_AGGREGATION_NONE, true);
+        array_column.add_sub_column(int_column);
+
+        auto src_offsets = vectorized::UInt32Column::create();
+        auto src_elements = vectorized::Int32Column::create();
+        vectorized::ColumnPtr src_column = vectorized::ArrayColumn::create(src_elements, src_offsets);
+
+        // insert [1, 2, 3], [4, 5, 6]
+        src_elements->append(1);
+        src_elements->append(2);
+        src_elements->append(3);
+        src_offsets->append(3);
+
+        src_elements->append(4);
+        src_elements->append(5);
+        src_elements->append(6);
+        src_offsets->append(6);
+
+        int num_rows = src_column->size();
+
+        TypeInfoPtr type_info = get_type_info(array_column);
+        ColumnMetaPB meta;
+
+        // delete test file.
+        const std::string fname = TEST_DIR + "/test_array_int.data";
+        // write data
+        {
+            std::unique_ptr<fs::WritableBlock> wblock;
+            fs::CreateBlockOptions opts({fname});
+            Status st = block_mgr->create_block(opts, &wblock);
+            ASSERT_TRUE(st.ok()) << st.get_error_msg();
+
+            ColumnWriterOptions writer_opts;
+            writer_opts.page_format = version;
+            writer_opts.meta = &meta;
+            writer_opts.meta->set_column_id(0);
+            writer_opts.meta->set_unique_id(0);
+            writer_opts.meta->set_type(OLAP_FIELD_TYPE_ARRAY);
+            writer_opts.meta->set_length(0);
+            writer_opts.meta->set_encoding(DEFAULT_ENCODING);
+            writer_opts.meta->set_compression(starrocks::LZ4_FRAME);
+            writer_opts.meta->set_is_nullable(false);
+            writer_opts.need_zone_map = false;
+
+            // init integer sub column
+            ColumnMetaPB* element_meta = writer_opts.meta->add_children_columns();
+            element_meta->set_column_id(0);
+            element_meta->set_unique_id(0);
+            element_meta->set_type(int_column.type());
+            element_meta->set_length(int_column.length());
+            element_meta->set_encoding(DEFAULT_ENCODING);
+            element_meta->set_compression(LZ4_FRAME);
+            element_meta->set_is_nullable(false);
+
+            std::unique_ptr<ColumnWriter> writer;
+            ColumnWriter::create(writer_opts, &array_column, wblock.get(), &writer);
+            st = writer->init();
+            ASSERT_TRUE(st.ok()) << st.to_string();
+
+            ASSERT_TRUE(writer->append(*src_column).ok());
+
+            ASSERT_TRUE(writer->finish().ok());
+            ASSERT_TRUE(writer->write_data().ok());
+            ASSERT_TRUE(writer->write_ordinal_index().ok());
+
+            // close the file
+            ASSERT_TRUE(wblock->close().ok());
+        }
+
+        // read and check
+        {
+            ColumnReaderOptions reader_opts;
+            reader_opts.block_mgr = block_mgr.get();
+            reader_opts.storage_format_version = 2;
+            std::unique_ptr<ColumnReader> reader;
+            auto st = ColumnReader::create(&_tracker, reader_opts, meta, num_rows, fname, &reader);
+            ASSERT_TRUE(st.ok());
+
+            ColumnIterator* iter = nullptr;
+            ASSERT_TRUE(reader->new_iterator(&iter).ok());
+            std::unique_ptr<ColumnIterator> guard(iter);
+            std::unique_ptr<fs::ReadableBlock> rblock;
+            block_mgr->open_block(fname, &rblock);
+
+            ColumnIteratorOptions iter_opts;
+            OlapReaderStatistics stats;
+            iter_opts.stats = &stats;
+            iter_opts.rblock = rblock.get();
+            ASSERT_TRUE(iter->init(iter_opts).ok());
+
+            // sequence read
+            {
+                st = iter->seek_to_first();
+                ASSERT_TRUE(st.ok()) << st.to_string();
+
+                auto dst_offsets = vectorized::UInt32Column::create();
+                auto dst_elements = vectorized::Int32Column::create();
+                auto dst_column = vectorized::ArrayColumn::create(dst_elements, dst_offsets);
+                size_t rows_read = src_column->size();
+                st = iter->next_batch(&rows_read, dst_column.get());
+                ASSERT_TRUE(st.ok());
+                ASSERT_EQ(src_column->size(), rows_read);
+
+                ASSERT_EQ("[1, 2, 3]", dst_column->debug_item(0));
+                ASSERT_EQ("[4, 5, 6]", dst_column->debug_item(1));
+            }
+        }
+    }
+
     template <FieldType type>
     vectorized::ColumnPtr numeric_data(int null_ratio) {
         using CppType = typename CppTypeTraits<type>::CppType;
@@ -372,14 +488,17 @@ protected:
         auto col = numeric_data<type>(1);
         test_nullable_data<type, BIT_SHUFFLE, 1>(*col);
         test_nullable_data<type, BIT_SHUFFLE, 2>(*col);
+        test_nullable_data<type, BIT_SHUFFLE, 3>(*col);
 
         col = numeric_data<type>(4);
         test_nullable_data<type, BIT_SHUFFLE, 1>(*col);
         test_nullable_data<type, BIT_SHUFFLE, 2>(*col);
+        test_nullable_data<type, BIT_SHUFFLE, 3>(*col);
 
         col = numeric_data<type>(10000);
         test_nullable_data<type, BIT_SHUFFLE, 1>(*col);
         test_nullable_data<type, BIT_SHUFFLE, 2>(*col);
+        test_nullable_data<type, BIT_SHUFFLE, 3>(*col);
     }
 
     MemTracker _tracker;
@@ -401,6 +520,7 @@ TEST_F(ColumnReaderWriterTest, test_date) {
     auto col = date_values(100);
     test_nullable_data<OLAP_FIELD_TYPE_DATE_V2, BIT_SHUFFLE, 1>(*col);
     test_nullable_data<OLAP_FIELD_TYPE_DATE_V2, BIT_SHUFFLE, 2>(*col);
+    test_nullable_data<OLAP_FIELD_TYPE_DATE_V2, BIT_SHUFFLE, 3>(*col);
 }
 
 // NOLINTNEXTLINE
@@ -408,6 +528,7 @@ TEST_F(ColumnReaderWriterTest, test_datetime) {
     auto col = datetime_values(100);
     test_nullable_data<OLAP_FIELD_TYPE_TIMESTAMP, BIT_SHUFFLE, 1>(*col);
     test_nullable_data<OLAP_FIELD_TYPE_TIMESTAMP, BIT_SHUFFLE, 2>(*col);
+    test_nullable_data<OLAP_FIELD_TYPE_TIMESTAMP, BIT_SHUFFLE, 3>(*col);
 }
 
 // NOLINTNEXTLINE
@@ -415,16 +536,20 @@ TEST_F(ColumnReaderWriterTest, test_binary) {
     auto c = low_cardinality_strings(10000);
     test_nullable_data<OLAP_FIELD_TYPE_VARCHAR, DICT_ENCODING, 1>(*c);
     test_nullable_data<OLAP_FIELD_TYPE_VARCHAR, DICT_ENCODING, 2>(*c);
+    test_nullable_data<OLAP_FIELD_TYPE_VARCHAR, DICT_ENCODING, 3>(*c);
 
     test_nullable_data<OLAP_FIELD_TYPE_CHAR, DICT_ENCODING, 1>(*c);
     test_nullable_data<OLAP_FIELD_TYPE_CHAR, DICT_ENCODING, 2>(*c);
+    test_nullable_data<OLAP_FIELD_TYPE_CHAR, DICT_ENCODING, 3>(*c);
 
     c = high_cardinality_strings(100);
     test_nullable_data<OLAP_FIELD_TYPE_VARCHAR, DICT_ENCODING, 1>(*c);
     test_nullable_data<OLAP_FIELD_TYPE_VARCHAR, DICT_ENCODING, 2>(*c);
+    test_nullable_data<OLAP_FIELD_TYPE_VARCHAR, DICT_ENCODING, 3>(*c);
 
     test_nullable_data<OLAP_FIELD_TYPE_CHAR, DICT_ENCODING, 1>(*c);
     test_nullable_data<OLAP_FIELD_TYPE_CHAR, DICT_ENCODING, 2>(*c);
+    test_nullable_data<OLAP_FIELD_TYPE_CHAR, DICT_ENCODING, 3>(*c);
 }
 
 // NOLINTNEXTLINE
@@ -477,118 +602,8 @@ TEST_F(ColumnReaderWriterTest, test_default_value) {
 
 // test array<int>, and nullable
 TEST_F(ColumnReaderWriterTest, test_array_int) {
-    auto env = std::make_unique<EnvMemory>();
-    auto block_mgr = std::make_unique<fs::FileBlockManager>(env.get(), fs::BlockManagerOptions());
-    ASSERT_TRUE(env->create_dir(TEST_DIR).ok());
-
-    TabletColumn array_column = create_array(0, true, sizeof(Collection));
-    TabletColumn int_column = create_int_value(0, OLAP_FIELD_AGGREGATION_NONE, true);
-    array_column.add_sub_column(int_column);
-
-    auto src_offsets = vectorized::UInt32Column::create();
-    auto src_elements = vectorized::Int32Column::create();
-    vectorized::ColumnPtr src_column = vectorized::ArrayColumn::create(src_elements, src_offsets);
-
-    // insert [1, 2, 3], [4, 5, 6]
-    src_elements->append(1);
-    src_elements->append(2);
-    src_elements->append(3);
-    src_offsets->append(3);
-
-    src_elements->append(4);
-    src_elements->append(5);
-    src_elements->append(6);
-    src_offsets->append(6);
-
-    int num_rows = src_column->size();
-
-    TypeInfoPtr type_info = get_type_info(array_column);
-    ColumnMetaPB meta;
-
-    // delete test file.
-    const std::string fname = TEST_DIR + "/test_array_int.data";
-    // write data
-    {
-        std::unique_ptr<fs::WritableBlock> wblock;
-        fs::CreateBlockOptions opts({fname});
-        Status st = block_mgr->create_block(opts, &wblock);
-        ASSERT_TRUE(st.ok()) << st.get_error_msg();
-
-        ColumnWriterOptions writer_opts;
-        writer_opts.page_format = 2;
-        writer_opts.meta = &meta;
-        writer_opts.meta->set_column_id(0);
-        writer_opts.meta->set_unique_id(0);
-        writer_opts.meta->set_type(OLAP_FIELD_TYPE_ARRAY);
-        writer_opts.meta->set_length(0);
-        writer_opts.meta->set_encoding(DEFAULT_ENCODING);
-        writer_opts.meta->set_compression(starrocks::LZ4_FRAME);
-        writer_opts.meta->set_is_nullable(false);
-        writer_opts.need_zone_map = false;
-
-        // init integer sub column
-        ColumnMetaPB* element_meta = writer_opts.meta->add_children_columns();
-        element_meta->set_column_id(0);
-        element_meta->set_unique_id(0);
-        element_meta->set_type(int_column.type());
-        element_meta->set_length(int_column.length());
-        element_meta->set_encoding(DEFAULT_ENCODING);
-        element_meta->set_compression(LZ4_FRAME);
-        element_meta->set_is_nullable(false);
-
-        std::unique_ptr<ColumnWriter> writer;
-        ColumnWriter::create(writer_opts, &array_column, wblock.get(), &writer);
-        st = writer->init();
-        ASSERT_TRUE(st.ok()) << st.to_string();
-
-        ASSERT_TRUE(writer->append(*src_column).ok());
-
-        ASSERT_TRUE(writer->finish().ok());
-        ASSERT_TRUE(writer->write_data().ok());
-        ASSERT_TRUE(writer->write_ordinal_index().ok());
-
-        // close the file
-        ASSERT_TRUE(wblock->close().ok());
-    }
-
-    // read and check
-    {
-        ColumnReaderOptions reader_opts;
-        reader_opts.block_mgr = block_mgr.get();
-        reader_opts.storage_format_version = 2;
-        std::unique_ptr<ColumnReader> reader;
-        auto st = ColumnReader::create(&_tracker, reader_opts, meta, num_rows, fname, &reader);
-        ASSERT_TRUE(st.ok());
-
-        ColumnIterator* iter = nullptr;
-        ASSERT_TRUE(reader->new_iterator(&iter).ok());
-        std::unique_ptr<ColumnIterator> guard(iter);
-        std::unique_ptr<fs::ReadableBlock> rblock;
-        block_mgr->open_block(fname, &rblock);
-
-        ColumnIteratorOptions iter_opts;
-        OlapReaderStatistics stats;
-        iter_opts.stats = &stats;
-        iter_opts.rblock = rblock.get();
-        ASSERT_TRUE(iter->init(iter_opts).ok());
-
-        // sequence read
-        {
-            st = iter->seek_to_first();
-            ASSERT_TRUE(st.ok()) << st.to_string();
-
-            auto dst_offsets = vectorized::UInt32Column::create();
-            auto dst_elements = vectorized::Int32Column::create();
-            auto dst_column = vectorized::ArrayColumn::create(dst_elements, dst_offsets);
-            size_t rows_read = src_column->size();
-            st = iter->next_batch(&rows_read, dst_column.get());
-            ASSERT_TRUE(st.ok());
-            ASSERT_EQ(src_column->size(), rows_read);
-
-            ASSERT_EQ("[1, 2, 3]", dst_column->debug_item(0));
-            ASSERT_EQ("[4, 5, 6]", dst_column->debug_item(1));
-        }
-    }
+    test_int_array<2>();
+    test_int_array<3>();
 }
 
 } // namespace starrocks::segment_v2

--- a/be/test/storage/rowset/segment_v2/column_reader_writer_test.cpp
+++ b/be/test/storage/rowset/segment_v2/column_reader_writer_test.cpp
@@ -65,8 +65,8 @@ protected:
     void TearDown() override { _tracker.release(_tracker.consumption()); }
 
     template <FieldType type, EncodingTypePB encoding, uint32_t version, bool adaptive = true>
-    void test_nullable_data(const vectorized::Column& src, const std::string null_flag_version = "0") {
-        config::set_config("null_flag_version", null_flag_version);
+    void test_nullable_data(const vectorized::Column& src, const std::string null_format = "0") {
+        config::set_config("null_format", null_format);
 
         using Type = typename TypeTraits<type>::CppType;
         TypeInfoPtr type_info = get_type_info(type);
@@ -267,9 +267,8 @@ protected:
     }
 
     template <uint32_t version>
-    void test_int_array(std::string null_flag_version = "0") {
-        config::set_config("null_flag_version", null_flag_version);
-
+    void test_int_array(std::string null_format = "0") {
+        config::set_config("null_format", null_format);
         auto env = std::make_unique<EnvMemory>();
         auto block_mgr = std::make_unique<fs::FileBlockManager>(env.get(), fs::BlockManagerOptions());
         ASSERT_TRUE(env->create_dir(TEST_DIR).ok());

--- a/be/test/storage/rowset/segment_v2/column_reader_writer_test.cpp
+++ b/be/test/storage/rowset/segment_v2/column_reader_writer_test.cpp
@@ -65,8 +65,8 @@ protected:
     void TearDown() override { _tracker.release(_tracker.consumption()); }
 
     template <FieldType type, EncodingTypePB encoding, uint32_t version, bool adaptive = true>
-    void test_nullable_data(const vectorized::Column& src, const std::string null_format = "0") {
-        config::set_config("null_format", null_format);
+    void test_nullable_data(const vectorized::Column& src, const std::string null_encoding = "0") {
+        config::set_config("null_encoding", null_encoding);
 
         using Type = typename TypeTraits<type>::CppType;
         TypeInfoPtr type_info = get_type_info(type);
@@ -267,8 +267,8 @@ protected:
     }
 
     template <uint32_t version>
-    void test_int_array(std::string null_format = "0") {
-        config::set_config("null_format", null_format);
+    void test_int_array(std::string null_encoding = "0") {
+        config::set_config("null_encoding", null_encoding);
         auto env = std::make_unique<EnvMemory>();
         auto block_mgr = std::make_unique<fs::FileBlockManager>(env.get(), fs::BlockManagerOptions());
         ASSERT_TRUE(env->create_dir(TEST_DIR).ok());

--- a/be/test/storage/rowset/segment_v2/column_reader_writer_test.cpp
+++ b/be/test/storage/rowset/segment_v2/column_reader_writer_test.cpp
@@ -65,7 +65,10 @@ protected:
     void TearDown() override { _tracker.release(_tracker.consumption()); }
 
     template <FieldType type, EncodingTypePB encoding, uint32_t version, bool adaptive = true>
-    void test_nullable_data(const vectorized::Column& src) {
+    void test_nullable_data(const vectorized::Column& src, const std::string null_flag_version = "0") {
+
+        config::set_config("null_flag_version", null_flag_version);
+
         using Type = typename TypeTraits<type>::CppType;
         TypeInfoPtr type_info = get_type_info(type);
         int num_rows = src.size();
@@ -265,7 +268,10 @@ protected:
     }
 
     template <uint32_t version>
-    void test_int_array() {
+    void test_int_array(std::string null_flag_version = "0") {
+        
+        config::set_config("null_flag_version", null_flag_version);
+        
         auto env = std::make_unique<EnvMemory>();
         auto block_mgr = std::make_unique<fs::FileBlockManager>(env.get(), fs::BlockManagerOptions());
         ASSERT_TRUE(env->create_dir(TEST_DIR).ok());
@@ -488,17 +494,17 @@ protected:
         auto col = numeric_data<type>(1);
         test_nullable_data<type, BIT_SHUFFLE, 1>(*col);
         test_nullable_data<type, BIT_SHUFFLE, 2>(*col);
-        test_nullable_data<type, BIT_SHUFFLE, 3>(*col);
+        test_nullable_data<type, BIT_SHUFFLE, 2>(*col, "1");
 
         col = numeric_data<type>(4);
         test_nullable_data<type, BIT_SHUFFLE, 1>(*col);
         test_nullable_data<type, BIT_SHUFFLE, 2>(*col);
-        test_nullable_data<type, BIT_SHUFFLE, 3>(*col);
+        test_nullable_data<type, BIT_SHUFFLE, 2>(*col, "1");
 
         col = numeric_data<type>(10000);
         test_nullable_data<type, BIT_SHUFFLE, 1>(*col);
         test_nullable_data<type, BIT_SHUFFLE, 2>(*col);
-        test_nullable_data<type, BIT_SHUFFLE, 3>(*col);
+        test_nullable_data<type, BIT_SHUFFLE, 2>(*col, "1");
     }
 
     MemTracker _tracker;
@@ -520,7 +526,7 @@ TEST_F(ColumnReaderWriterTest, test_date) {
     auto col = date_values(100);
     test_nullable_data<OLAP_FIELD_TYPE_DATE_V2, BIT_SHUFFLE, 1>(*col);
     test_nullable_data<OLAP_FIELD_TYPE_DATE_V2, BIT_SHUFFLE, 2>(*col);
-    test_nullable_data<OLAP_FIELD_TYPE_DATE_V2, BIT_SHUFFLE, 3>(*col);
+    test_nullable_data<OLAP_FIELD_TYPE_DATE_V2, BIT_SHUFFLE, 2>(*col, "1");
 }
 
 // NOLINTNEXTLINE
@@ -528,7 +534,7 @@ TEST_F(ColumnReaderWriterTest, test_datetime) {
     auto col = datetime_values(100);
     test_nullable_data<OLAP_FIELD_TYPE_TIMESTAMP, BIT_SHUFFLE, 1>(*col);
     test_nullable_data<OLAP_FIELD_TYPE_TIMESTAMP, BIT_SHUFFLE, 2>(*col);
-    test_nullable_data<OLAP_FIELD_TYPE_TIMESTAMP, BIT_SHUFFLE, 3>(*col);
+    test_nullable_data<OLAP_FIELD_TYPE_TIMESTAMP, BIT_SHUFFLE, 2>(*col, "1");
 }
 
 // NOLINTNEXTLINE
@@ -536,20 +542,20 @@ TEST_F(ColumnReaderWriterTest, test_binary) {
     auto c = low_cardinality_strings(10000);
     test_nullable_data<OLAP_FIELD_TYPE_VARCHAR, DICT_ENCODING, 1>(*c);
     test_nullable_data<OLAP_FIELD_TYPE_VARCHAR, DICT_ENCODING, 2>(*c);
-    test_nullable_data<OLAP_FIELD_TYPE_VARCHAR, DICT_ENCODING, 3>(*c);
+    test_nullable_data<OLAP_FIELD_TYPE_VARCHAR, DICT_ENCODING, 2>(*c, "1");
 
     test_nullable_data<OLAP_FIELD_TYPE_CHAR, DICT_ENCODING, 1>(*c);
     test_nullable_data<OLAP_FIELD_TYPE_CHAR, DICT_ENCODING, 2>(*c);
-    test_nullable_data<OLAP_FIELD_TYPE_CHAR, DICT_ENCODING, 3>(*c);
+    test_nullable_data<OLAP_FIELD_TYPE_CHAR, DICT_ENCODING, 2>(*c, "1");
 
     c = high_cardinality_strings(100);
     test_nullable_data<OLAP_FIELD_TYPE_VARCHAR, DICT_ENCODING, 1>(*c);
     test_nullable_data<OLAP_FIELD_TYPE_VARCHAR, DICT_ENCODING, 2>(*c);
-    test_nullable_data<OLAP_FIELD_TYPE_VARCHAR, DICT_ENCODING, 3>(*c);
+    test_nullable_data<OLAP_FIELD_TYPE_VARCHAR, DICT_ENCODING, 2>(*c, "1");
 
     test_nullable_data<OLAP_FIELD_TYPE_CHAR, DICT_ENCODING, 1>(*c);
     test_nullable_data<OLAP_FIELD_TYPE_CHAR, DICT_ENCODING, 2>(*c);
-    test_nullable_data<OLAP_FIELD_TYPE_CHAR, DICT_ENCODING, 3>(*c);
+    test_nullable_data<OLAP_FIELD_TYPE_CHAR, DICT_ENCODING, 2>(*c, "1");
 }
 
 // NOLINTNEXTLINE
@@ -603,7 +609,7 @@ TEST_F(ColumnReaderWriterTest, test_default_value) {
 // test array<int>, and nullable
 TEST_F(ColumnReaderWriterTest, test_array_int) {
     test_int_array<2>();
-    test_int_array<3>();
+    test_int_array<2>("1");
 }
 
 } // namespace starrocks::segment_v2

--- a/gensrc/proto/segment_v2.proto
+++ b/gensrc/proto/segment_v2.proto
@@ -56,7 +56,7 @@ enum PageTypePB {
     SHORT_KEY_PAGE = 4;
 }
 
-enum NullFormatPB {
+enum NullEncodingPB {
     BITSHUFFLE_NULL = 0;
     LZ4_NULL = 1;
 }
@@ -82,9 +82,7 @@ message DataPageFooterPB {
     // another difference is that the format 1 use Run-Length encoding to encode the null map,
     // while format 2 use the bitshuffle.
     optional uint32 format_version = 20;
-    // 0 for bitshuffle
-    // 1 for lz4
-    optional NullFormatPB null_format = 21;
+    optional NullEncodingPB null_encoding = 21;
 }
 
 message IndexPageFooterPB {

--- a/gensrc/proto/segment_v2.proto
+++ b/gensrc/proto/segment_v2.proto
@@ -56,6 +56,11 @@ enum PageTypePB {
     SHORT_KEY_PAGE = 4;
 }
 
+enum NullFormatPB {
+    BITSHUFFLE_NULL = 0;
+    LZ4_NULL = 1;
+}
+
 message DataPageFooterPB {
     // required: ordinal of the first value
     optional uint64 first_ordinal = 1;
@@ -79,7 +84,7 @@ message DataPageFooterPB {
     optional uint32 format_version = 20;
     // 0 for bitshuffle
     // 1 for lz4
-    optional uint32 null_flag_version = 21;
+    optional NullFormatPB null_format = 21;
 }
 
 message IndexPageFooterPB {

--- a/gensrc/proto/segment_v2.proto
+++ b/gensrc/proto/segment_v2.proto
@@ -59,6 +59,7 @@ enum PageTypePB {
 enum NullEncodingPB {
     BITSHUFFLE_NULL = 0;
     LZ4_NULL = 1;
+    RLE_NULL = 2;
 }
 
 message DataPageFooterPB {

--- a/gensrc/proto/segment_v2.proto
+++ b/gensrc/proto/segment_v2.proto
@@ -77,6 +77,9 @@ message DataPageFooterPB {
     // another difference is that the format 1 use Run-Length encoding to encode the null map,
     // while format 2 use the bitshuffle.
     optional uint32 format_version = 20;
+    // 0 for bitshuffle
+    // 1 for lz4
+    optional uint32 null_flag_version = 21;
 }
 
 message IndexPageFooterPB {


### PR DESCRIPTION
use lz4 to compress null flags for better compression ratio and decompression speed. In my test, Bitshuffle has no compression ratio for null flags.  In a test with 266882552 records, the compressed data size and decompression time is as following:
                  bitshuffle          lz4          rle
size            268MB             30MB      20MB
time            246ms             119ms      262ms
Add config::null_encoding to decide the default encoding type of null flags. Make sure to upgrade all BEs before change
the config.