### PR TITLE
Bugfix: remove version hash comparation when relocating tablet for decommission

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -585,9 +585,7 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
                 continue;
             }
 
-            if (replica.getLastFailedVersion() <= 0
-                    && ((replica.getVersion() == visibleVersion && replica.getVersionHash() == visibleVersionHash)
-                    || replica.getVersion() > visibleVersion)) {
+            if (replica.getLastFailedVersion() <= 0 && replica.getVersion() >= visibleVersion) {
                 // skip healthy replica
                 continue;
             }


### PR DESCRIPTION
Version hash of the cloned tablet is 0. If the backend under decommission
contains these tablets, and the version hash comparation will be failed, fe
will treate the clone task as version missing and repeat this operation
continuously. This will case backend decommission unable to complete.

Version hash has been deprecated, so remove version hash comparation
when relocating tablet.