### PR TITLE
Import leveldbjni-all-1.8.jar/commons-crypto-1.0.0.jar to aarch64

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -80,11 +80,18 @@ under the License.
             </activation>
 
             <repositories>
+                <!-- for leveldbjni-all-1.8.jar,commons-crypto-1.0.0.jar on aarch64-->
+                <repository>
+                    <id>kunpeng</id>
+                    <url>https://mirror.iscas.ac.cn/kunpeng/maven/</url>
+                </repository>
+
                 <repository>
                     <id>central</id>
                     <name>central maven repo https</name>
                     <url>https://repo.maven.apache.org/maven2</url>
                 </repository>
+
                 <!-- for java-cup -->
                 <repository>
                     <id>cloudera-public</id>


### PR DESCRIPTION
Following jars may be problematic with aarch64, which are needed by `org.apache.spark`.
```
leveldbjni-all-1.8.jar
commons-crypto-1.0.0.jar
```
Hence, we import jar provided by `kunpeng` to replace the original.