### PR TITLE
Optimize reading bitshuffle decode by reducing memory copy

### DIFF
--- a/be/src/column/array_column.cpp
+++ b/be/src/column/array_column.cpp
@@ -24,6 +24,10 @@ size_t ArrayColumn::size() const {
     return _offsets->size() - 1;
 }
 
+size_t ArrayColumn::capacity() const {
+    return _offsets->capacity() - 1;
+}
+
 const uint8_t* ArrayColumn::raw_data() const {
     return _elements->raw_data();
 }

--- a/be/src/column/array_column.h
+++ b/be/src/column/array_column.h
@@ -50,7 +50,6 @@ public:
     // Return number of values in column.
     size_t size() const override;
 
-    // Return number of values in column.
     size_t capacity() const override;
 
     size_t type_size() const override { return sizeof(DatumArray); }

--- a/be/src/column/array_column.h
+++ b/be/src/column/array_column.h
@@ -50,6 +50,9 @@ public:
     // Return number of values in column.
     size_t size() const override;
 
+    // Return number of values in column.
+    size_t capacity() const override;
+
     size_t type_size() const override { return sizeof(DatumArray); }
 
     // Size of column data in memory (may be approximate). Zero, if could not be determined.

--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -79,6 +79,8 @@ public:
 
     size_t size() const override { return _offsets.size() - 1; }
 
+    size_t capacity() const override { return _offsets.capacity() - 1; }
+
     size_t type_size() const override { return sizeof(Slice); }
 
     size_t byte_size() const override { return _bytes.size() * sizeof(uint8_t) + _offsets.size() * sizeof(Offset); }

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -81,6 +81,8 @@ public:
     // Return number of values in column.
     virtual size_t size() const = 0;
 
+    virtual size_t capacity() const = 0;
+
     bool empty() const { return size() == 0; }
 
     virtual size_t type_size() const = 0;

--- a/be/src/column/const_column.h
+++ b/be/src/column/const_column.h
@@ -54,6 +54,8 @@ public:
 
     size_t size() const override { return _size; }
 
+    size_t capacity() const override { return UINT32_MAX; }
+
     size_t type_size() const override { return _data->type_size(); }
 
     size_t byte_size() const override { return _data->byte_size() + sizeof(_size); }

--- a/be/src/column/fixed_length_column_base.h
+++ b/be/src/column/fixed_length_column_base.h
@@ -66,6 +66,8 @@ public:
 
     size_t size() const override { return _data.size(); }
 
+    size_t capacity() const override { return _data.capacity(); }
+
     size_t byte_size() const override { return _data.size() * sizeof(ValueType); }
 
     size_t byte_size(size_t idx __attribute__((unused))) const override { return sizeof(ValueType); }

--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -79,9 +79,7 @@ public:
         return _data_column->size();
     }
 
-    size_t capacity() const override {
-        return _data_column->capacity();
-    }
+    size_t capacity() const override { return _data_column->capacity(); }
 
     size_t type_size() const override { return _data_column->type_size() + _null_column->type_size(); }
 

--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -79,6 +79,10 @@ public:
         return _data_column->size();
     }
 
+    size_t capacity() const override {
+        return _data_column->capacity();
+    }
+
     size_t type_size() const override { return _data_column->type_size() + _null_column->type_size(); }
 
     size_t byte_size() const override { return byte_size(0, size()); }

--- a/be/src/column/object_column.h
+++ b/be/src/column/object_column.h
@@ -58,6 +58,8 @@ public:
 
     size_t size() const override { return _pool.size(); }
 
+    size_t capacity() const override { return _pool.capacity(); }
+
     size_t type_size() const override { return sizeof(T); }
 
     size_t byte_size() const override { return byte_size(0, size()); }

--- a/be/src/storage/rowset/segment_v2/bitshuffle_page.h
+++ b/be/src/storage/rowset/segment_v2/bitshuffle_page.h
@@ -376,6 +376,10 @@ private:
         if (_num_elements > 0) {
             _decoded.resize(_num_element_after_padding * _size_of_element);
             RETURN_IF_ERROR(_decode_to(_decoded.data()));
+            // release original memory
+            if (_options.page_handle) {
+                _options.page_handle->release_memory();
+            }
         }
         _is_decoded = true;
         return Status::OK();

--- a/be/src/storage/rowset/segment_v2/bitshuffle_page.h
+++ b/be/src/storage/rowset/segment_v2/bitshuffle_page.h
@@ -421,7 +421,8 @@ inline Status BitShufflePageDecoder<Type>::next_batch(size_t* count, vectorized:
         *count = 0;
         return Status::OK();
     }
-    if (_options.enable_direct_copy && !_is_decoded && *count >= _num_elements && _cur_index <= 0 && dst->capacity() - dst->size() >= _num_elements) {
+    if (_options.enable_direct_copy && !_is_decoded && *count >= _num_elements && _cur_index <= 0 &&
+        dst->capacity() - dst->size() >= _num_elements) {
         // if the page is not decoded and to read the whole page data
         // decode the page directly to dst to save mem copy from _decoded to dst
         // Now this can be used to optimize compaction

--- a/be/src/storage/rowset/segment_v2/bitshuffle_page.h
+++ b/be/src/storage/rowset/segment_v2/bitshuffle_page.h
@@ -231,12 +231,13 @@ public:
     BitShufflePageDecoder(Slice data, const PageDecoderOptions& options)
             : _data(data),
               _options(options),
-              _parsed(false),
               _num_elements(0),
               _compressed_size(0),
               _num_element_after_padding(0),
               _size_of_element(0),
-              _cur_index(0) {}
+              _cur_index(0),
+              _parsed(false),
+              _is_decoded(false) {}
 
     Status init() override {
         CHECK(!_parsed);
@@ -289,7 +290,6 @@ public:
             return Status::InternalError(ss.str());
         }
 
-        RETURN_IF_ERROR(_decode());
         _parsed = true;
         return Status::OK();
     }
@@ -301,6 +301,7 @@ public:
             return Status::InvalidArgument("invalid pos");
         }
 
+        RETURN_IF_ERROR(_decode());
         DCHECK_LE(pos, _num_elements);
         _cur_index = pos;
         return Status::OK();
@@ -312,6 +313,7 @@ public:
         if (_num_elements == 0) {
             return Status::NotFound("page is empty");
         }
+        RETURN_IF_ERROR(_decode());
 
         size_t left = 0;
         size_t right = _num_elements;
@@ -340,6 +342,7 @@ public:
 
     Status next_batch(size_t* n, ColumnBlockView* dst) override {
         DCHECK(_parsed);
+        RETURN_IF_ERROR(_decode());
         if (PREDICT_FALSE(*n == 0 || _cur_index >= _num_elements)) {
             *n = 0;
             return Status::OK();
@@ -367,17 +370,26 @@ private:
     }
 
     Status _decode() {
-        if (_num_elements > 0) {
-            int64_t bytes;
-            _decoded.resize(_num_element_after_padding * _size_of_element);
-            char* in = const_cast<char*>(&_data[BITSHUFFLE_PAGE_HEADER_SIZE]);
-            bytes = bitshuffle::decompress_lz4(in, _decoded.data(), _num_element_after_padding, _size_of_element, 0);
-            if (PREDICT_FALSE(bytes < 0)) {
-                // Ideally, this should not happen.
-                LOG(ERROR) << "bitshuffle decompress failed: " << bitshuffle_error_msg(bytes);
-                return Status::RuntimeError("Unshuffle Process failed");
-            }
+        if (_is_decoded) {
+            return Status::OK();
         }
+        if (_num_elements > 0) {
+            _decoded.resize(_num_element_after_padding * _size_of_element);
+            RETURN_IF_ERROR(_decode_to(_decoded.data()));
+        }
+        _is_decoded = true;
+        return Status::OK();
+    }
+
+    Status _decode_to(uint8_t* to) {
+        char* in = const_cast<char*>(&_data[BITSHUFFLE_PAGE_HEADER_SIZE]);
+        int64_t bytes = bitshuffle::decompress_lz4(in, to, _num_element_after_padding, _size_of_element, 0);
+        if (PREDICT_FALSE(bytes < 0)) {
+            // Ideally, this should not happen.
+            LOG(ERROR) << "bitshuffle decompress failed: " << bitshuffle_error_msg(bytes);
+            return Status::RuntimeError("Unshuffle Process failed");
+        }
+
         return Status::OK();
     }
 
@@ -387,14 +399,15 @@ private:
 
     Slice _data;
     PageDecoderOptions _options;
-    bool _parsed;
+    faststring _decoded;
     size_t _num_elements;
     size_t _compressed_size;
     size_t _num_element_after_padding;
 
     int _size_of_element;
     size_t _cur_index;
-    faststring _decoded;
+    bool _parsed;
+    bool _is_decoded;
 };
 
 template <FieldType Type>
@@ -404,6 +417,19 @@ inline Status BitShufflePageDecoder<Type>::next_batch(size_t* count, vectorized:
         *count = 0;
         return Status::OK();
     }
+    if (!_is_decoded && *count >= _num_elements && _cur_index <= 0) {
+        // if the page is not decoded and to read the whole page data
+        // decode the page directly to dst to save mem copy from _decoded to dst
+        // Now this can be used to optimize compaction
+        size_t old_size = dst->size();
+        uint8_t* dst_buffer = dst->mutable_raw_data() + dst->type_size() * old_size;
+        RETURN_IF_ERROR(_decode_to(dst_buffer));
+        dst->resize_uninitialized(old_size + _num_elements);
+        *count = _num_elements;
+        return Status::OK();
+    }
+
+    RETURN_IF_ERROR(_decode());
     *count = std::min(*count, static_cast<size_t>(_num_elements - _cur_index));
     int n = dst->append_numbers(&_decoded[_cur_index * SIZE_OF_TYPE], *count * SIZE_OF_TYPE);
     DCHECK_EQ(*count, n);

--- a/be/src/storage/rowset/segment_v2/column_writer.cpp
+++ b/be/src/storage/rowset/segment_v2/column_writer.cpp
@@ -254,8 +254,6 @@ Status ColumnWriter::create(const ColumnWriterOptions& opts, const TabletColumn*
             element_options.need_zone_map = false;
             element_options.need_bloom_filter = element_column.is_bf_column();
             element_options.need_bitmap_index = element_column.has_bitmap_index();
-            element_options.page_format = opts.page_format;
-            element_options.adaptive_page_format = opts.adaptive_page_format;
             if (element_column.type() == FieldType::OLAP_FIELD_TYPE_ARRAY) {
                 if (element_options.need_bloom_filter) {
                     return Status::NotSupported("Do not support bloom filter for array type");
@@ -279,8 +277,6 @@ Status ColumnWriter::create(const ColumnWriterOptions& opts, const TabletColumn*
                 null_options.meta->set_encoding(DEFAULT_ENCODING);
                 null_options.meta->set_compression(LZ4);
                 null_options.meta->set_is_nullable(false);
-                null_options.page_format = opts.page_format;
-                null_options.adaptive_page_format = opts.adaptive_page_format;
                 std::unique_ptr<Field> bool_field(FieldFactory::create_by_type(FieldType::OLAP_FIELD_TYPE_BOOL));
                 null_writer = new ScalarColumnWriter(null_options, std::move(bool_field), _wblock);
             }
@@ -297,8 +293,6 @@ Status ColumnWriter::create(const ColumnWriterOptions& opts, const TabletColumn*
             array_size_options.need_zone_map = false;
             array_size_options.need_bloom_filter = false;
             array_size_options.need_bitmap_index = false;
-            array_size_options.page_format = opts.page_format;
-            array_size_options.adaptive_page_format = opts.adaptive_page_format;
             std::unique_ptr<Field> bigint_field(FieldFactory::create_by_type(FieldType::OLAP_FIELD_TYPE_INT));
             ScalarColumnWriter* offset_writer =
                     new ScalarColumnWriter(array_size_options, std::move(bigint_field), _wblock);

--- a/be/src/storage/rowset/segment_v2/column_writer.cpp
+++ b/be/src/storage/rowset/segment_v2/column_writer.cpp
@@ -254,6 +254,8 @@ Status ColumnWriter::create(const ColumnWriterOptions& opts, const TabletColumn*
             element_options.need_zone_map = false;
             element_options.need_bloom_filter = element_column.is_bf_column();
             element_options.need_bitmap_index = element_column.has_bitmap_index();
+            element_options.page_format = opts.page_format;
+            element_options.adaptive_page_format = opts.adaptive_page_format;
             if (element_column.type() == FieldType::OLAP_FIELD_TYPE_ARRAY) {
                 if (element_options.need_bloom_filter) {
                     return Status::NotSupported("Do not support bloom filter for array type");
@@ -277,6 +279,8 @@ Status ColumnWriter::create(const ColumnWriterOptions& opts, const TabletColumn*
                 null_options.meta->set_encoding(DEFAULT_ENCODING);
                 null_options.meta->set_compression(LZ4);
                 null_options.meta->set_is_nullable(false);
+                null_options.page_format = opts.page_format;
+                null_options.adaptive_page_format = opts.adaptive_page_format;
                 std::unique_ptr<Field> bool_field(FieldFactory::create_by_type(FieldType::OLAP_FIELD_TYPE_BOOL));
                 null_writer = new ScalarColumnWriter(null_options, std::move(bool_field), _wblock);
             }
@@ -293,6 +297,8 @@ Status ColumnWriter::create(const ColumnWriterOptions& opts, const TabletColumn*
             array_size_options.need_zone_map = false;
             array_size_options.need_bloom_filter = false;
             array_size_options.need_bitmap_index = false;
+            array_size_options.page_format = opts.page_format;
+            array_size_options.adaptive_page_format = opts.adaptive_page_format;
             std::unique_ptr<Field> bigint_field(FieldFactory::create_by_type(FieldType::OLAP_FIELD_TYPE_INT));
             ScalarColumnWriter* offset_writer =
                     new ScalarColumnWriter(array_size_options, std::move(bigint_field), _wblock);

--- a/be/src/storage/rowset/segment_v2/options.h
+++ b/be/src/storage/rowset/segment_v2/options.h
@@ -38,7 +38,7 @@ public:
 
 class PageDecoderOptions {
 public:
-    PageHandle* page_handle;
+    PageHandle* page_handle = nullptr;
 };
 
 } // namespace segment_v2

--- a/be/src/storage/rowset/segment_v2/options.h
+++ b/be/src/storage/rowset/segment_v2/options.h
@@ -23,6 +23,7 @@
 
 #include <cstddef>
 
+#include "storage/rowset/segment_v2/page_handle.h"
 namespace starrocks {
 namespace segment_v2 {
 
@@ -37,6 +38,7 @@ public:
 
 class PageDecoderOptions {
 public:
+    PageHandle* page_handle;
 };
 
 } // namespace segment_v2

--- a/be/src/storage/rowset/segment_v2/options.h
+++ b/be/src/storage/rowset/segment_v2/options.h
@@ -39,6 +39,7 @@ public:
 class PageDecoderOptions {
 public:
     PageHandle* page_handle = nullptr;
+    bool enable_direct_copy = false;
 };
 
 } // namespace segment_v2

--- a/be/src/storage/rowset/segment_v2/parsed_page.cpp
+++ b/be/src/storage/rowset/segment_v2/parsed_page.cpp
@@ -319,11 +319,6 @@ Status parse_page_v2(std::unique_ptr<ParsedPage>* result, PageHandle handle, con
     page->_page_index = page_index;
     page->_corresponding_element_ordinal = footer.corresponding_element_ordinal();
 
-    if (encoding->encoding() == EncodingTypePB::BIT_SHUFFLE) {
-        // When using BIT_SHUFFLE encoding, the original data is not used after decoded.
-        // So the memory can be released to reduce the memory usage.
-        page->_page_handle.release_memory();
-    }
     *result = std::move(page);
     return Status::OK();
 }

--- a/be/src/storage/rowset/segment_v2/parsed_page.cpp
+++ b/be/src/storage/rowset/segment_v2/parsed_page.cpp
@@ -273,6 +273,7 @@ Status parse_page_v1(std::unique_ptr<ParsedPage>* result, PageHandle handle, con
     Slice data_slice(body.data, body.size - null_size);
     PageDecoder* decoder = nullptr;
     PageDecoderOptions opts;
+    opts.page_handle = &(page->_page_handle);
     RETURN_IF_ERROR(encoding->create_page_decoder(data_slice, opts, &decoder));
     page->_data_decoder.reset(decoder);
     RETURN_IF_ERROR(page->_data_decoder->init());
@@ -310,6 +311,7 @@ Status parse_page_v2(std::unique_ptr<ParsedPage>* result, PageHandle handle, con
     Slice data_slice(body.data, body.size - null_size);
     PageDecoder* decoder = nullptr;
     PageDecoderOptions opts;
+    opts.page_handle = &(page->_page_handle);
     RETURN_IF_ERROR(encoding->create_page_decoder(data_slice, opts, &decoder));
     page->_data_decoder.reset(decoder);
     RETURN_IF_ERROR(page->_data_decoder->init());

--- a/be/src/storage/rowset/segment_v2/parsed_page.cpp
+++ b/be/src/storage/rowset/segment_v2/parsed_page.cpp
@@ -273,7 +273,6 @@ Status parse_page_v1(std::unique_ptr<ParsedPage>* result, PageHandle handle, con
     Slice data_slice(body.data, body.size - null_size);
     PageDecoder* decoder = nullptr;
     PageDecoderOptions opts;
-    opts.page_handle = &(page->_page_handle);
     RETURN_IF_ERROR(encoding->create_page_decoder(data_slice, opts, &decoder));
     page->_data_decoder.reset(decoder);
     RETURN_IF_ERROR(page->_data_decoder->init());
@@ -312,6 +311,7 @@ Status parse_page_v2(std::unique_ptr<ParsedPage>* result, PageHandle handle, con
     PageDecoder* decoder = nullptr;
     PageDecoderOptions opts;
     opts.page_handle = &(page->_page_handle);
+    opts.enable_direct_copy = true;
     RETURN_IF_ERROR(encoding->create_page_decoder(data_slice, opts, &decoder));
     page->_data_decoder.reset(decoder);
     RETURN_IF_ERROR(page->_data_decoder->init());

--- a/be/test/storage/rowset/segment_v2/bitshuffle_page_test.cpp
+++ b/be/test/storage/rowset/segment_v2/bitshuffle_page_test.cpp
@@ -25,11 +25,13 @@
 
 #include <memory>
 
+#include "column/datum_convert.h"
 #include "runtime/mem_pool.h"
 #include "runtime/mem_tracker.h"
 #include "storage/rowset/segment_v2/options.h"
 #include "storage/rowset/segment_v2/page_builder.h"
 #include "storage/rowset/segment_v2/page_decoder.h"
+#include "storage/vectorized/chunk_helper.h"
 #include "util/logging.h"
 
 using starrocks::segment_v2::PageBuilderOptions;
@@ -109,6 +111,71 @@ public:
             CppType ret;
             copy_one<Type, PageDecoderType>(&page_decoder, &ret);
             EXPECT_EQ(decoded[seek_off], ret);
+        }
+    }
+
+    template <FieldType Type, class PageBuilderType, class PageDecoderType>
+    void test_encode_decode_page_vectorize() {
+        using CppType = typename CppTypeTraits<Type>::CppType;
+        auto src = vectorized::ChunkHelper::column_from_field_type(Type, false);
+        CppType value = 0;
+        size_t count = 64 * 1024 / sizeof(CppType);
+        src->reserve(count);
+        for (size_t i = 0; i < count; ++i) {
+            (void)src->append_numbers(&value, sizeof(CppType));
+            value = value + 1;
+        }
+
+        PageBuilderOptions options;
+        options.data_page_size = 64 * 1024;
+        PageBuilderType page_builder(options);
+        size_t added = page_builder.add(reinterpret_cast<const uint8_t*>(src->raw_data()), count);
+        ASSERT_EQ(count, added);
+        OwnedSlice s = page_builder.finish()->build();
+
+        Slice encoded_data = s.slice();
+        {
+            // read whole the page
+            segment_v2::PageDecoderOptions decoder_options;
+            PageDecoderType page_decoder(encoded_data, decoder_options);
+            Status status = page_decoder.init();
+            ASSERT_TRUE(status.ok());
+            ASSERT_EQ(0, page_decoder.current_index());
+
+            auto dst = vectorized::ChunkHelper::column_from_field_type(Type, false);
+            dst->reserve(count);
+            size_t size = count;
+            status = page_decoder.next_batch(&size, dst.get());
+            ASSERT_TRUE(status.ok());
+            ASSERT_EQ(size, count);
+            TypeInfoPtr type_info = get_type_info(Type);
+            for (int i = 0; i < count; ++i) {
+                ASSERT_EQ(0, type_info->cmp(src->get(i), dst->get(i)))
+                        << " row " << i << ": " << datum_to_string(type_info.get(), src->get(i)) << " vs "
+                        << datum_to_string(type_info.get(), dst->get(i));
+            }
+        }
+
+        {
+            // read half of the page
+            segment_v2::PageDecoderOptions decoder_options;
+            PageDecoderType page_decoder(encoded_data, decoder_options);
+            Status status = page_decoder.init();
+            ASSERT_TRUE(status.ok());
+            ASSERT_EQ(0, page_decoder.current_index());
+
+            auto dst = vectorized::ChunkHelper::column_from_field_type(Type, false);
+            size_t size = count / 2;
+            dst->reserve(size);
+            status = page_decoder.next_batch(&size, dst.get());
+            ASSERT_TRUE(status.ok());
+            ASSERT_EQ(size, count / 2);
+            TypeInfoPtr type_info = get_type_info(Type);
+            for (int i = 0; i < size; ++i) {
+                ASSERT_EQ(0, type_info->cmp(src->get(i), dst->get(i)))
+                        << " row " << i << ": " << datum_to_string(type_info.get(), src->get(i)) << " vs "
+                        << datum_to_string(type_info.get(), dst->get(i));
+            }
         }
     }
 
@@ -357,6 +424,17 @@ TEST_F(BitShufflePageTest, TestReserveHead) {
 
     test_encode_decode_page_template<OLAP_FIELD_TYPE_INT, segment_v2::BitshufflePageBuilder<OLAP_FIELD_TYPE_INT>,
                                      segment_v2::BitShufflePageDecoder<OLAP_FIELD_TYPE_INT>, 4>(ints.get(), size);
+}
+
+TEST_F(BitShufflePageTest, TestDecodeVectorized) {
+    test_encode_decode_page_vectorize<OLAP_FIELD_TYPE_TINYINT, segment_v2::BitshufflePageBuilder<OLAP_FIELD_TYPE_TINYINT>,
+                                     segment_v2::BitShufflePageDecoder<OLAP_FIELD_TYPE_TINYINT>>();
+    test_encode_decode_page_vectorize<OLAP_FIELD_TYPE_SMALLINT, segment_v2::BitshufflePageBuilder<OLAP_FIELD_TYPE_SMALLINT>,
+                                     segment_v2::BitShufflePageDecoder<OLAP_FIELD_TYPE_SMALLINT>>();
+    test_encode_decode_page_vectorize<OLAP_FIELD_TYPE_INT, segment_v2::BitshufflePageBuilder<OLAP_FIELD_TYPE_INT>,
+                                     segment_v2::BitShufflePageDecoder<OLAP_FIELD_TYPE_INT>>();
+    test_encode_decode_page_vectorize<OLAP_FIELD_TYPE_BIGINT, segment_v2::BitshufflePageBuilder<OLAP_FIELD_TYPE_BIGINT>,
+                                     segment_v2::BitShufflePageDecoder<OLAP_FIELD_TYPE_BIGINT>>();
 }
 
 } // namespace starrocks

--- a/be/test/storage/rowset/segment_v2/bitshuffle_page_test.cpp
+++ b/be/test/storage/rowset/segment_v2/bitshuffle_page_test.cpp
@@ -239,7 +239,7 @@ TEST_F(BitShufflePageTest, TestBitShuffleInt32BlockEncoderRandom) {
     }
 
     test_encode_decode_page_template<OLAP_FIELD_TYPE_INT, segment_v2::BitshufflePageBuilder<OLAP_FIELD_TYPE_INT>,
-                                     segment_v2::BitShufflePageDecoder<OLAP_FIELD_TYPE_INT> >(ints.get(), size);
+                                     segment_v2::BitShufflePageDecoder<OLAP_FIELD_TYPE_INT>>(ints.get(), size);
 }
 
 // NOLINTNEXTLINE
@@ -252,7 +252,7 @@ TEST_F(BitShufflePageTest, TestBitShuffleInt64BlockEncoderRandom) {
     }
 
     test_encode_decode_page_template<OLAP_FIELD_TYPE_BIGINT, segment_v2::BitshufflePageBuilder<OLAP_FIELD_TYPE_BIGINT>,
-                                     segment_v2::BitShufflePageDecoder<OLAP_FIELD_TYPE_BIGINT> >(ints.get(), size);
+                                     segment_v2::BitShufflePageDecoder<OLAP_FIELD_TYPE_BIGINT>>(ints.get(), size);
 }
 
 // NOLINTNEXTLINE
@@ -265,7 +265,7 @@ TEST_F(BitShufflePageTest, TestBitShuffleFloatBlockEncoderRandom) {
     }
 
     test_encode_decode_page_template<OLAP_FIELD_TYPE_FLOAT, segment_v2::BitshufflePageBuilder<OLAP_FIELD_TYPE_FLOAT>,
-                                     segment_v2::BitShufflePageDecoder<OLAP_FIELD_TYPE_FLOAT> >(floats.get(), size);
+                                     segment_v2::BitShufflePageDecoder<OLAP_FIELD_TYPE_FLOAT>>(floats.get(), size);
 }
 
 // NOLINTNEXTLINE
@@ -278,7 +278,7 @@ TEST_F(BitShufflePageTest, TestBitShuffleDoubleBlockEncoderRandom) {
     }
 
     test_encode_decode_page_template<OLAP_FIELD_TYPE_DOUBLE, segment_v2::BitshufflePageBuilder<OLAP_FIELD_TYPE_DOUBLE>,
-                                     segment_v2::BitShufflePageDecoder<OLAP_FIELD_TYPE_DOUBLE> >(doubles.get(), size);
+                                     segment_v2::BitShufflePageDecoder<OLAP_FIELD_TYPE_DOUBLE>>(doubles.get(), size);
 }
 
 // NOLINTNEXTLINE
@@ -291,7 +291,7 @@ TEST_F(BitShufflePageTest, TestBitShuffleDoubleBlockEncoderEqual) {
     }
 
     test_encode_decode_page_template<OLAP_FIELD_TYPE_DOUBLE, segment_v2::BitshufflePageBuilder<OLAP_FIELD_TYPE_DOUBLE>,
-                                     segment_v2::BitShufflePageDecoder<OLAP_FIELD_TYPE_DOUBLE> >(doubles.get(), size);
+                                     segment_v2::BitShufflePageDecoder<OLAP_FIELD_TYPE_DOUBLE>>(doubles.get(), size);
 }
 
 // NOLINTNEXTLINE
@@ -307,7 +307,7 @@ TEST_F(BitShufflePageTest, TestBitShuffleDoubleBlockEncoderSequence) {
     }
 
     test_encode_decode_page_template<OLAP_FIELD_TYPE_DOUBLE, segment_v2::BitshufflePageBuilder<OLAP_FIELD_TYPE_DOUBLE>,
-                                     segment_v2::BitShufflePageDecoder<OLAP_FIELD_TYPE_DOUBLE> >(doubles.get(), size);
+                                     segment_v2::BitShufflePageDecoder<OLAP_FIELD_TYPE_DOUBLE>>(doubles.get(), size);
 }
 
 // NOLINTNEXTLINE
@@ -320,7 +320,7 @@ TEST_F(BitShufflePageTest, TestBitShuffleInt32BlockEncoderEqual) {
     }
 
     test_encode_decode_page_template<OLAP_FIELD_TYPE_INT, segment_v2::BitshufflePageBuilder<OLAP_FIELD_TYPE_INT>,
-                                     segment_v2::BitShufflePageDecoder<OLAP_FIELD_TYPE_INT> >(ints.get(), size);
+                                     segment_v2::BitShufflePageDecoder<OLAP_FIELD_TYPE_INT>>(ints.get(), size);
 }
 
 // NOLINTNEXTLINE
@@ -333,7 +333,7 @@ TEST_F(BitShufflePageTest, TestBitShuffleInt32BlockEncoderMaxNumberEqual) {
     }
 
     test_encode_decode_page_template<OLAP_FIELD_TYPE_INT, segment_v2::BitshufflePageBuilder<OLAP_FIELD_TYPE_INT>,
-                                     segment_v2::BitShufflePageDecoder<OLAP_FIELD_TYPE_INT> >(ints.get(), size);
+                                     segment_v2::BitShufflePageDecoder<OLAP_FIELD_TYPE_INT>>(ints.get(), size);
 }
 
 // NOLINTNEXTLINE
@@ -347,7 +347,7 @@ TEST_F(BitShufflePageTest, TestBitShuffleInt32BlockEncoderSequence) {
     }
 
     test_encode_decode_page_template<OLAP_FIELD_TYPE_INT, segment_v2::BitshufflePageBuilder<OLAP_FIELD_TYPE_INT>,
-                                     segment_v2::BitShufflePageDecoder<OLAP_FIELD_TYPE_INT> >(ints.get(), size);
+                                     segment_v2::BitShufflePageDecoder<OLAP_FIELD_TYPE_INT>>(ints.get(), size);
 }
 
 // NOLINTNEXTLINE
@@ -362,7 +362,7 @@ TEST_F(BitShufflePageTest, TestBitShuffleInt32BlockEncoderMaxNumberSequence) {
     }
 
     test_encode_decode_page_template<OLAP_FIELD_TYPE_INT, segment_v2::BitshufflePageBuilder<OLAP_FIELD_TYPE_INT>,
-                                     segment_v2::BitShufflePageDecoder<OLAP_FIELD_TYPE_INT> >(ints.get(), size);
+                                     segment_v2::BitShufflePageDecoder<OLAP_FIELD_TYPE_INT>>(ints.get(), size);
 }
 
 // NOLINTNEXTLINE
@@ -377,7 +377,7 @@ TEST_F(BitShufflePageTest, TestBitShuffleFloatBlockEncoderSeekValue) {
     float bigger_than_biggest = 1111.1;
     test_seek_at_or_after_value_template<OLAP_FIELD_TYPE_FLOAT,
                                          segment_v2::BitshufflePageBuilder<OLAP_FIELD_TYPE_FLOAT>,
-                                         segment_v2::BitShufflePageDecoder<OLAP_FIELD_TYPE_FLOAT> >(
+                                         segment_v2::BitShufflePageDecoder<OLAP_FIELD_TYPE_FLOAT>>(
             floats.get(), size, &small_than_smallest, &bigger_than_biggest);
 }
 
@@ -393,7 +393,7 @@ TEST_F(BitShufflePageTest, TestBitShuffleDoubleBlockEncoderSeekValue) {
     double bigger_than_biggest = 1111.1;
     test_seek_at_or_after_value_template<OLAP_FIELD_TYPE_DOUBLE,
                                          segment_v2::BitshufflePageBuilder<OLAP_FIELD_TYPE_DOUBLE>,
-                                         segment_v2::BitShufflePageDecoder<OLAP_FIELD_TYPE_DOUBLE> >(
+                                         segment_v2::BitShufflePageDecoder<OLAP_FIELD_TYPE_DOUBLE>>(
             doubles.get(), size, &small_than_smallest, &bigger_than_biggest);
 }
 
@@ -409,7 +409,7 @@ TEST_F(BitShufflePageTest, TestBitShuffleDecimal12BlockEncoderSeekValue) {
     decimal12_t bigger_than_biggest = decimal12_t(1111, 1);
     test_seek_at_or_after_value_template<OLAP_FIELD_TYPE_DECIMAL,
                                          segment_v2::BitshufflePageBuilder<OLAP_FIELD_TYPE_DECIMAL>,
-                                         segment_v2::BitShufflePageDecoder<OLAP_FIELD_TYPE_DECIMAL> >(
+                                         segment_v2::BitShufflePageDecoder<OLAP_FIELD_TYPE_DECIMAL>>(
             decimals.get(), size, &small_than_smallest, &bigger_than_biggest);
 }
 
@@ -427,14 +427,17 @@ TEST_F(BitShufflePageTest, TestReserveHead) {
 }
 
 TEST_F(BitShufflePageTest, TestDecodeVectorized) {
-    test_encode_decode_page_vectorized<OLAP_FIELD_TYPE_TINYINT, segment_v2::BitshufflePageBuilder<OLAP_FIELD_TYPE_TINYINT>,
-                                     segment_v2::BitShufflePageDecoder<OLAP_FIELD_TYPE_TINYINT>>();
-    test_encode_decode_page_vectorized<OLAP_FIELD_TYPE_SMALLINT, segment_v2::BitshufflePageBuilder<OLAP_FIELD_TYPE_SMALLINT>,
-                                     segment_v2::BitShufflePageDecoder<OLAP_FIELD_TYPE_SMALLINT>>();
+    test_encode_decode_page_vectorized<OLAP_FIELD_TYPE_TINYINT,
+                                       segment_v2::BitshufflePageBuilder<OLAP_FIELD_TYPE_TINYINT>,
+                                       segment_v2::BitShufflePageDecoder<OLAP_FIELD_TYPE_TINYINT>>();
+    test_encode_decode_page_vectorized<OLAP_FIELD_TYPE_SMALLINT,
+                                       segment_v2::BitshufflePageBuilder<OLAP_FIELD_TYPE_SMALLINT>,
+                                       segment_v2::BitShufflePageDecoder<OLAP_FIELD_TYPE_SMALLINT>>();
     test_encode_decode_page_vectorized<OLAP_FIELD_TYPE_INT, segment_v2::BitshufflePageBuilder<OLAP_FIELD_TYPE_INT>,
-                                     segment_v2::BitShufflePageDecoder<OLAP_FIELD_TYPE_INT>>();
-    test_encode_decode_page_vectorized<OLAP_FIELD_TYPE_BIGINT, segment_v2::BitshufflePageBuilder<OLAP_FIELD_TYPE_BIGINT>,
-                                     segment_v2::BitShufflePageDecoder<OLAP_FIELD_TYPE_BIGINT>>();
+                                       segment_v2::BitShufflePageDecoder<OLAP_FIELD_TYPE_INT>>();
+    test_encode_decode_page_vectorized<OLAP_FIELD_TYPE_BIGINT,
+                                       segment_v2::BitshufflePageBuilder<OLAP_FIELD_TYPE_BIGINT>,
+                                       segment_v2::BitShufflePageDecoder<OLAP_FIELD_TYPE_BIGINT>>();
 }
 
 } // namespace starrocks

--- a/be/test/storage/rowset/segment_v2/bitshuffle_page_test.cpp
+++ b/be/test/storage/rowset/segment_v2/bitshuffle_page_test.cpp
@@ -115,7 +115,7 @@ public:
     }
 
     template <FieldType Type, class PageBuilderType, class PageDecoderType>
-    void test_encode_decode_page_vectorize() {
+    void test_encode_decode_page_vectorized() {
         using CppType = typename CppTypeTraits<Type>::CppType;
         auto src = vectorized::ChunkHelper::column_from_field_type(Type, false);
         CppType value = 0;
@@ -427,13 +427,13 @@ TEST_F(BitShufflePageTest, TestReserveHead) {
 }
 
 TEST_F(BitShufflePageTest, TestDecodeVectorized) {
-    test_encode_decode_page_vectorize<OLAP_FIELD_TYPE_TINYINT, segment_v2::BitshufflePageBuilder<OLAP_FIELD_TYPE_TINYINT>,
+    test_encode_decode_page_vectorized<OLAP_FIELD_TYPE_TINYINT, segment_v2::BitshufflePageBuilder<OLAP_FIELD_TYPE_TINYINT>,
                                      segment_v2::BitShufflePageDecoder<OLAP_FIELD_TYPE_TINYINT>>();
-    test_encode_decode_page_vectorize<OLAP_FIELD_TYPE_SMALLINT, segment_v2::BitshufflePageBuilder<OLAP_FIELD_TYPE_SMALLINT>,
+    test_encode_decode_page_vectorized<OLAP_FIELD_TYPE_SMALLINT, segment_v2::BitshufflePageBuilder<OLAP_FIELD_TYPE_SMALLINT>,
                                      segment_v2::BitShufflePageDecoder<OLAP_FIELD_TYPE_SMALLINT>>();
-    test_encode_decode_page_vectorize<OLAP_FIELD_TYPE_INT, segment_v2::BitshufflePageBuilder<OLAP_FIELD_TYPE_INT>,
+    test_encode_decode_page_vectorized<OLAP_FIELD_TYPE_INT, segment_v2::BitshufflePageBuilder<OLAP_FIELD_TYPE_INT>,
                                      segment_v2::BitShufflePageDecoder<OLAP_FIELD_TYPE_INT>>();
-    test_encode_decode_page_vectorize<OLAP_FIELD_TYPE_BIGINT, segment_v2::BitshufflePageBuilder<OLAP_FIELD_TYPE_BIGINT>,
+    test_encode_decode_page_vectorized<OLAP_FIELD_TYPE_BIGINT, segment_v2::BitshufflePageBuilder<OLAP_FIELD_TYPE_BIGINT>,
                                      segment_v2::BitShufflePageDecoder<OLAP_FIELD_TYPE_BIGINT>>();
 }
 

--- a/be/test/storage/rowset/segment_v2/column_reader_writer_test.cpp
+++ b/be/test/storage/rowset/segment_v2/column_reader_writer_test.cpp
@@ -153,13 +153,15 @@ protected:
                 ASSERT_TRUE(st.ok()) << st.to_string();
 
                 vectorized::ColumnPtr dst = vectorized::ChunkHelper::column_from_field_type(type, true);
+                // will do direct copy to column
                 size_t rows_read = src.size();
+                dst->reserve(rows_read);
                 st = iter->next_batch(&rows_read, dst.get());
                 ASSERT_TRUE(st.ok());
                 ASSERT_EQ(src.size(), rows_read);
 
                 for (size_t i = 0; i < rows_read; i++) {
-                    ASSERT_EQ(0, type_info->cmp(src.get(i), dst->get(i)))
+                    ASSERT_EQ(0, type_info->cmp(src.get(i), dst->get(i))) << " rows_read:" << rows_read
                             << " row " << i << ": " << datum_to_string(type_info.get(), src.get(i)) << " vs "
                             << datum_to_string(type_info.get(), dst->get(i));
                 }

--- a/be/test/storage/rowset/segment_v2/column_reader_writer_test.cpp
+++ b/be/test/storage/rowset/segment_v2/column_reader_writer_test.cpp
@@ -161,7 +161,7 @@ protected:
                 ASSERT_EQ(src.size(), rows_read);
 
                 for (size_t i = 0; i < rows_read; i++) {
-                    ASSERT_EQ(0, type_info->cmp(src.get(i), dst->get(i))) << " rows_read:" << rows_read
+                    ASSERT_EQ(0, type_info->cmp(src.get(i), dst->get(i)))
                             << " row " << i << ": " << datum_to_string(type_info.get(), src.get(i)) << " vs "
                             << datum_to_string(type_info.get(), dst->get(i));
                 }


### PR DESCRIPTION
When read large chunk, the data can be decompressed directly to chunk column's memory,
which can reduce memcpy overload from page to column. In my test, scan 200 Million bigint records, It will improve about 10%.