### PR TITLE
Provide Repeat Operator

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -155,6 +155,7 @@ set(EXEC_FILES
     pipeline/aggregate/aggregate_distinct_blocking_source_operator.cpp
     pipeline/aggregate/aggregate_distinct_streaming_sink_operator.cpp
     pipeline/aggregate/aggregate_distinct_streaming_source_operator.cpp
+    pipeline/aggregate/repeat/repeat_operator.cpp
     pipeline/analysis/analytic_sink_operator.cpp
     pipeline/analysis/analytic_source_operator.cpp
 )

--- a/be/src/exec/pipeline/aggregate/repeat/repeat_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/repeat/repeat_operator.cpp
@@ -1,0 +1,99 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#include "exec/pipeline/aggregate/repeat/repeat_operator.h"
+
+#include "column/chunk.h"
+#include "runtime/descriptors.h"
+
+namespace starrocks::pipeline {
+
+Status RepeatOperator::prepare(RuntimeState* state) {
+    RETURN_IF_ERROR(Operator::prepare(state));
+    return Status::OK();
+}
+
+bool RepeatOperator::is_finished() const {
+    // _repeat_times_last >= _repeat_times_required means there has no output.
+    return _is_finished && _repeat_times_last >= _repeat_times_required;
+}
+
+void RepeatOperator::finish(RuntimeState* state) {
+    if (_is_finished) {
+        return;
+    }
+    _is_finished = true;
+}
+
+bool RepeatOperator::has_output() const {
+    return _repeat_times_last < _repeat_times_required;
+}
+
+StatusOr<vectorized::ChunkPtr> RepeatOperator::pull_chunk(RuntimeState* state) {
+    if (_repeat_times_last > 0) {
+        Columns columns = _curr_columns;
+        // get a suitable chunk.
+        _curr_chunk->set_columns(columns);
+
+        // unneed to extend, because columns has been extended at first access.
+        // update virtual columns for gourping_id and grouping()/grouping_id() columns.
+        for (int i = 0; i < _grouping_list.size(); ++i) {
+            auto grouping_column =
+                    (_curr_chunk->num_rows() == config::vector_chunk_size)
+                            ? _grouping_columns[i][_repeat_times_last]
+                            : generate_repeat_column(_grouping_list[i][_repeat_times_last], _curr_chunk->num_rows());
+
+            _curr_chunk->update_column(grouping_column, _tuple_desc->slots()[i]->id());
+        }
+
+        // update columns for unneed columns.
+        const std::vector<SlotId>& null_slot_ids = _null_slot_ids[_repeat_times_last];
+        for (auto slot_id : null_slot_ids) {
+            auto null_column = (_curr_chunk->num_rows() == config::vector_chunk_size)
+                                       ? _column_null
+                                       : generate_null_column(_curr_chunk->num_rows());
+
+            _curr_chunk->update_column(null_column, slot_id);
+        }
+
+        // tranform to the next.
+        ++_repeat_times_last;
+        return _curr_chunk;
+    } else {
+        // extend virtual columns for gourping_id and grouping()/grouping_id() columns.
+        for (int i = 0; i < _grouping_list.size(); ++i) {
+            auto grouping_column =
+                    (_curr_chunk->num_rows() == config::vector_chunk_size)
+                            ? _grouping_columns[i][_repeat_times_last]
+                            : generate_repeat_column(_grouping_list[i][_repeat_times_last], _curr_chunk->num_rows());
+
+            _curr_chunk->append_column(grouping_column, _tuple_desc->slots()[i]->id());
+        }
+
+        // save original exgtended columns.
+        _curr_columns = _curr_chunk->columns();
+
+        // update columns for unneed columns.
+        const std::vector<SlotId>& null_slot_ids = _null_slot_ids[_repeat_times_last];
+        for (auto slot_id : null_slot_ids) {
+            auto null_column = (_curr_chunk->num_rows() == config::vector_chunk_size)
+                                       ? _column_null
+                                       : generate_null_column(_curr_chunk->num_rows());
+
+            _curr_chunk->update_column(null_column, slot_id);
+        }
+
+        // tranform to the next.
+        ++_repeat_times_last;
+        return _curr_chunk;
+    }
+}
+
+Status RepeatOperator::push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) {
+    // get new chunk.
+    _curr_chunk = chunk;
+
+    // set _repeat_times_last to 0 drive to use this new chunk(_curr_chunk).
+    _repeat_times_last = 0;
+    return Status::OK();
+}
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/aggregate/repeat/repeat_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/repeat/repeat_operator.cpp
@@ -35,8 +35,9 @@ StatusOr<vectorized::ChunkPtr> RepeatOperator::pull_chunk(RuntimeState* state) {
         _curr_chunk->set_columns(columns);
 
         // unneed to extend, because columns has been extended at first access.
-        // update virtual columns for gourping_id and grouping()/grouping_id() columns.
+        // update virtual columns for grouping_id and grouping()/grouping_id() columns.
         for (int i = 0; i < _grouping_list.size(); ++i) {
+            // _grouping_columns needs to be referenced more than once, so it cannot be moved.
             auto grouping_column =
                     (_curr_chunk->num_rows() == config::vector_chunk_size)
                             ? _grouping_columns[i][_repeat_times_last]
@@ -48,9 +49,10 @@ StatusOr<vectorized::ChunkPtr> RepeatOperator::pull_chunk(RuntimeState* state) {
         // update columns for unneed columns.
         const std::vector<SlotId>& null_slot_ids = _null_slot_ids[_repeat_times_last];
         for (auto slot_id : null_slot_ids) {
+            // _column_null needs to be referenced more than once, so it cannot be moved.
             auto null_column = (_curr_chunk->num_rows() == config::vector_chunk_size)
                                        ? _column_null
-                                       : generate_null_column(_curr_chunk->num_rows());
+                                       : ColumnHelper::create_const_null_column(_curr_chunk->num_rows());
 
             _curr_chunk->update_column(null_column, slot_id);
         }
@@ -59,8 +61,9 @@ StatusOr<vectorized::ChunkPtr> RepeatOperator::pull_chunk(RuntimeState* state) {
         ++_repeat_times_last;
         return _curr_chunk;
     } else {
-        // extend virtual columns for gourping_id and grouping()/grouping_id() columns.
+        // extend virtual columns for grouping_id and grouping()/grouping_id() columns.
         for (int i = 0; i < _grouping_list.size(); ++i) {
+            // _grouping_columns needs to be referenced more than once, so it cannot be moved.
             auto grouping_column =
                     (_curr_chunk->num_rows() == config::vector_chunk_size)
                             ? _grouping_columns[i][_repeat_times_last]
@@ -75,9 +78,10 @@ StatusOr<vectorized::ChunkPtr> RepeatOperator::pull_chunk(RuntimeState* state) {
         // update columns for unneed columns.
         const std::vector<SlotId>& null_slot_ids = _null_slot_ids[_repeat_times_last];
         for (auto slot_id : null_slot_ids) {
+            // _column_null needs to be referenced more than once, so it cannot be moved.
             auto null_column = (_curr_chunk->num_rows() == config::vector_chunk_size)
                                        ? _column_null
-                                       : generate_null_column(_curr_chunk->num_rows());
+                                       : ColumnHelper::ColumnHelper::create_const_null_column(_curr_chunk->num_rows());
 
             _curr_chunk->update_column(null_column, slot_id);
         }

--- a/be/src/exec/pipeline/aggregate/repeat/repeat_operator.h
+++ b/be/src/exec/pipeline/aggregate/repeat/repeat_operator.h
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#include <utility>
-
 #include "column/column_helper.h"
 #include "column/vectorized_fwd.h"
 #include "common/global_types.h"
@@ -51,16 +49,10 @@ public:
     Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override;
 
 private:
-    static ColumnPtr generate_null_column(int64_t num_rows) {
-        auto nullable_column = NullableColumn::create(Int8Column::create(), NullColumn::create());
-        nullable_column->append_nulls(1);
-        return ConstColumn::create(nullable_column, num_rows);
-    }
-
     static ColumnPtr generate_repeat_column(int64_t value, int64_t num_rows) {
-        auto ptr = RunTimeColumnType<TYPE_BIGINT>::create();
-        ptr->append_datum(Datum(value));
-        return ConstColumn::create(ptr, num_rows);
+        auto column = RunTimeColumnType<TYPE_BIGINT>::create();
+        column->append_datum(Datum(value));
+        return ConstColumn::create(column, num_rows);
     }
 
     /*
@@ -97,7 +89,7 @@ private:
     // An integer bitmap list, it indicates the bit position of the exprs not null.
     const std::vector<int64_t>& _repeat_id_list;
     // needed repeat times
-    uint64_t _repeat_times_required;
+    const uint64_t _repeat_times_required;
     // repeat timer for chunk. 0 <=  _repeat_times_last < _repeat_times_required.
     uint64_t _repeat_times_last;
     // only null columns for reusing, It has config::vector_chunk_size rows.
@@ -105,7 +97,7 @@ private:
     // column for grouping_id and virtual columns for grouping()/grouping_id() for reusing.
     // It has config::vector_chunk_size rows.
     const std::vector<std::vector<ColumnPtr>>& _grouping_columns;
-    // _grouping_list for gourping_id'value and grouping()/grouping_id()'s value.
+    // _grouping_list for grouping_id'value and grouping()/grouping_id()'s value.
     // It's a two dimensional array.
     // first is grouping index and second is repeat index.
     const std::vector<std::vector<int64_t>>& _grouping_list;
@@ -154,7 +146,7 @@ private:
     std::set<SlotId> _all_slot_ids;
     std::vector<std::vector<SlotId>> _null_slot_ids;
     std::vector<int64_t> _repeat_id_list;
-    uint64_t _repeat_times_required;
+    const uint64_t _repeat_times_required;
     uint64_t _repeat_times_last;
     ColumnPtr _column_null;
     std::vector<std::vector<ColumnPtr>> _grouping_columns;

--- a/be/src/exec/pipeline/aggregate/repeat/repeat_operator.h
+++ b/be/src/exec/pipeline/aggregate/repeat/repeat_operator.h
@@ -1,0 +1,166 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#pragma once
+
+#include <utility>
+
+#include "column/column_helper.h"
+#include "column/vectorized_fwd.h"
+#include "common/global_types.h"
+#include "exec/pipeline/operator.h"
+
+namespace starrocks {
+class TupleDescriptor;
+namespace pipeline {
+using namespace vectorized;
+class RepeatOperator : public Operator {
+public:
+    RepeatOperator(int32_t id, int32_t plan_node_id, const std::vector<std::set<SlotId>>& slot_id_set_list,
+                   const std::set<SlotId>& all_slot_ids, const std::vector<std::vector<SlotId>>& null_slot_ids,
+                   const std::vector<int64_t>& repeat_id_list, uint64_t repeat_times_required,
+                   uint64_t repeat_times_last, const ColumnPtr& column_null,
+                   const std::vector<std::vector<ColumnPtr>>& grouping_columns,
+                   const std::vector<std::vector<int64_t>>& grouping_list, const TupleId& output_tuple_id,
+                   const TupleDescriptor* tuple_desc)
+            : Operator(id, "repeat", plan_node_id),
+              _slot_id_set_list(slot_id_set_list),
+              _all_slot_ids(all_slot_ids),
+              _null_slot_ids(null_slot_ids),
+              _repeat_id_list(repeat_id_list),
+              _repeat_times_required(repeat_times_required),
+              _repeat_times_last(repeat_times_last),
+              _column_null(column_null),
+              _grouping_columns(grouping_columns),
+              _grouping_list(grouping_list),
+              _output_tuple_id(output_tuple_id),
+              _tuple_desc(tuple_desc) {}
+    ~RepeatOperator() override = default;
+
+    bool has_output() const override;
+    bool need_input() const override {
+        // For every chunk, we could produce _repeat_times_required copys,
+        // _repeat_times_last >= _repeat_times_required means should get next chunk.
+        return _repeat_times_last >= _repeat_times_required;
+    }
+    bool is_finished() const override;
+    void finish(RuntimeState* state) override;
+
+    Status prepare(RuntimeState* state) override;
+
+    StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
+    Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override;
+
+private:
+    static ColumnPtr generate_null_column(int64_t num_rows) {
+        auto nullable_column = NullableColumn::create(Int8Column::create(), NullColumn::create());
+        nullable_column->append_nulls(1);
+        return ConstColumn::create(nullable_column, num_rows);
+    }
+
+    static ColumnPtr generate_repeat_column(int64_t value, int64_t num_rows) {
+        auto ptr = RunTimeColumnType<TYPE_BIGINT>::create();
+        ptr->append_datum(Datum(value));
+        return ConstColumn::create(ptr, num_rows);
+    }
+
+    /*
+     * _curr_chunk
+     * _curr_columns
+     * This 2 fields is used privately.
+     */
+    // accessing chunk.
+    ChunkPtr _curr_chunk;
+    // original columns for accessing chunk.
+    Columns _curr_columns;
+
+    /*
+     * _slot_id_set_list
+     * _all_slot_ids
+     * _null_slot_ids
+     * _repeat_id_list
+     * _repeat_times_required
+     * _repeat_times_last
+     * _column_null
+     * _grouping_columns
+     * _grouping_list
+     * _output_tuple_id
+     * _tuple_desc
+     * 
+     * This 11 fields is referenced from factory, and that is moved from RepeatNode.
+     */
+
+    // Slot id set used to indicate those slots need to set to null.
+    const std::vector<std::set<SlotId>>& _slot_id_set_list;
+    // all slot id
+    const std::set<SlotId>& _all_slot_ids;
+    const std::vector<std::vector<SlotId>>& _null_slot_ids;
+    // An integer bitmap list, it indicates the bit position of the exprs not null.
+    const std::vector<int64_t>& _repeat_id_list;
+    // needed repeat times
+    uint64_t _repeat_times_required;
+    // repeat timer for chunk. 0 <=  _repeat_times_last < _repeat_times_required.
+    uint64_t _repeat_times_last;
+    // only null columns for reusing, It has config::vector_chunk_size rows.
+    const ColumnPtr& _column_null;
+    // column for grouping_id and virtual columns for grouping()/grouping_id() for reusing.
+    // It has config::vector_chunk_size rows.
+    const std::vector<std::vector<ColumnPtr>>& _grouping_columns;
+    // _grouping_list for gourping_id'value and grouping()/grouping_id()'s value.
+    // It's a two dimensional array.
+    // first is grouping index and second is repeat index.
+    const std::vector<std::vector<int64_t>>& _grouping_list;
+    // Tulple id used for output, it has new slots.
+    const TupleId& _output_tuple_id;
+    const TupleDescriptor* _tuple_desc;
+
+    // Whether prev operator has no output
+    bool _is_finished = false;
+};
+
+class RepeatOperatorFactory final : public OperatorFactory {
+public:
+    RepeatOperatorFactory(int32_t id, int32_t plan_node_id, std::vector<std::set<SlotId>>&& slot_id_set_list,
+                          std::set<SlotId>&& all_slot_ids, std::vector<std::vector<SlotId>>&& null_slot_ids,
+                          std::vector<int64_t>&& repeat_id_list, uint64_t repeat_times_required,
+                          uint64_t repeat_times_last, ColumnPtr&& column_null,
+                          std::vector<std::vector<ColumnPtr>>&& grouping_columns,
+                          std::vector<std::vector<int64_t>>&& grouping_list, TupleId&& output_tuple_id,
+                          const TupleDescriptor* tuple_desc)
+            : OperatorFactory(id, "repeat", plan_node_id),
+              _slot_id_set_list(std::move(slot_id_set_list)),
+              _all_slot_ids(std::move(all_slot_ids)),
+              _null_slot_ids(std::move(null_slot_ids)),
+              _repeat_id_list(std::move(repeat_id_list)),
+              _repeat_times_required(repeat_times_required),
+              _repeat_times_last(repeat_times_last),
+              _column_null(std::move(column_null)),
+              _grouping_columns(std::move(grouping_columns)),
+              _grouping_list(std::move(grouping_list)),
+              _output_tuple_id(std::move(output_tuple_id)),
+              _tuple_desc(tuple_desc) {}
+
+    ~RepeatOperatorFactory() override = default;
+
+    OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override {
+        return std::make_shared<RepeatOperator>(_id, _plan_node_id, _slot_id_set_list, _all_slot_ids, _null_slot_ids,
+                                                _repeat_id_list, _repeat_times_required, _repeat_times_last,
+                                                _column_null, _grouping_columns, _grouping_list, _output_tuple_id,
+                                                _tuple_desc);
+    }
+
+private:
+    // Fields moved from RepeatNode.
+    std::vector<std::set<SlotId>> _slot_id_set_list;
+    std::set<SlotId> _all_slot_ids;
+    std::vector<std::vector<SlotId>> _null_slot_ids;
+    std::vector<int64_t> _repeat_id_list;
+    uint64_t _repeat_times_required;
+    uint64_t _repeat_times_last;
+    ColumnPtr _column_null;
+    std::vector<std::vector<ColumnPtr>> _grouping_columns;
+    std::vector<std::vector<int64_t>> _grouping_list;
+    TupleId _output_tuple_id;
+    const TupleDescriptor* _tuple_desc;
+};
+} // namespace pipeline
+} // namespace starrocks

--- a/be/src/exec/vectorized/repeat_node.cpp
+++ b/be/src/exec/vectorized/repeat_node.cpp
@@ -13,7 +13,6 @@ RepeatNode::RepeatNode(ObjectPool* pool, const TPlanNode& tnode, const Descripto
           _repeat_id_list(tnode.repeat_node.repeat_id_list),
           _repeat_times_required(_repeat_id_list.size()),
           _repeat_times_last(_repeat_times_required),
-          _curr_columns(_all_slot_ids.size()),
           _grouping_list(tnode.repeat_node.grouping_list),
           _output_tuple_id(tnode.repeat_node.output_tuple_id),
           _tuple_desc(descs.get_tuple_descriptor(_output_tuple_id)) {

--- a/be/src/exec/vectorized/repeat_node.cpp
+++ b/be/src/exec/vectorized/repeat_node.cpp
@@ -231,7 +231,6 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > RepeatNode::decompose_t
     using namespace pipeline;
 
     OpFactories operators = _children[0]->decompose_to_pipeline(context);
-    operators = context->maybe_interpolate_local_exchange(operators);
 
     operators.emplace_back(std::make_shared<RepeatOperatorFactory>(
             context->next_operator_id(), id(), std::move(_slot_id_set_list), std::move(_all_slot_ids),

--- a/be/src/exec/vectorized/repeat_node.cpp
+++ b/be/src/exec/vectorized/repeat_node.cpp
@@ -2,6 +2,9 @@
 
 #include "exec/vectorized/repeat_node.h"
 
+#include "exec/pipeline/aggregate/repeat/repeat_operator.h"
+#include "exec/pipeline/operator.h"
+#include "exec/pipeline/pipeline_builder.h"
 #include "exprs/expr.h"
 #include "runtime/runtime_state.h"
 
@@ -72,23 +75,36 @@ Status RepeatNode::get_next(RuntimeState* state, RowBatch* row_batch, bool* eos)
     return Status::NotSupported("get_next for row_batch is not supported");
 }
 
-// for new chunk A.
-// step 1:
-// Extend columns of A, with virtual columns
-// for gourping_id and grouping()/grouping_id() columns.
-//
-// step 2:
-// save current chunk of A.
-//
-// step 3:
-// set null columns of A for unneed columns
-// and return reulst chunk to parent.
-//
-// step 4:
-// for every rest of the group by
-// obtain original chunk from step 2, and
-// do step 1 with update columns instead of append columns.
-// do step 3.
+/*
+ * for new chunk A.
+ * It used as first time and non-first time:
+ * 
+ * first time(_repeat_times_last == 0):
+ * step 1:
+ * save A as _curr_chunk.
+ *
+ * step 2:
+ * Extend multiple virtual columns for A,
+ * virtual columns is consist of gourping_id and grouping()/grouping_id() columns.
+ * save _curr_chunk->columns() as _curr_columns(it used for subsequent calls).
+ * 
+ * step 3:
+ * update columns for unneed columns,
+ * and return reulst chunk to parent.
+ *
+ * 
+ * non-first time, it measn _repeat_times_last in [1, _repeat_times_required):
+ * step 1:
+ * use _curr_columns to construct _curr_chunk.
+ * 
+ * step 2:
+ * update virtual columns for gourping_id and grouping()/grouping_id() columns.
+ * 
+ * step 3:
+ * update columns for unneed columns,
+ * and return reulst chunk to parent.
+ * 
+ */
 Status RepeatNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) {
     SCOPED_TIMER(_runtime_profile->total_time_counter());
     DCHECK_EQ(_children.size(), 1);
@@ -208,6 +224,22 @@ Status RepeatNode::close(RuntimeState* state) {
         return Status::OK();
     }
     return ExecNode::close(state);
+}
+
+std::vector<std::shared_ptr<pipeline::OperatorFactory> > RepeatNode::decompose_to_pipeline(
+        pipeline::PipelineBuilderContext* context) {
+    using namespace pipeline;
+
+    OpFactories operators = _children[0]->decompose_to_pipeline(context);
+    operators = context->maybe_interpolate_local_exchange(operators);
+
+    operators.emplace_back(std::make_shared<RepeatOperatorFactory>(
+            context->next_operator_id(), id(), std::move(_slot_id_set_list), std::move(_all_slot_ids),
+            std::move(_null_slot_ids), std::move(_repeat_id_list), _repeat_times_required, _repeat_times_last,
+            std::move(_column_null), std::move(_grouping_columns), std::move(_grouping_list),
+            std::move(_output_tuple_id), _tuple_desc));
+
+    return operators;
 }
 
 } // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/repeat_node.h
+++ b/be/src/exec/vectorized/repeat_node.h
@@ -22,6 +22,9 @@ public:
     Status get_next(RuntimeState* state, ChunkPtr* row_batch, bool* eos) override;
     Status close(RuntimeState* state) override;
 
+    std::vector<std::shared_ptr<pipeline::OperatorFactory>> decompose_to_pipeline(
+            pipeline::PipelineBuilderContext* context) override;
+
 private:
     static ColumnPtr generate_null_column(int64_t num_rows) {
         auto nullable_column = NullableColumn::create(Int8Column::create(), NullColumn::create());

--- a/be/src/exec/vectorized/repeat_node.h
+++ b/be/src/exec/vectorized/repeat_node.h
@@ -71,8 +71,6 @@ private:
     TupleId _output_tuple_id;
     const TupleDescriptor* _tuple_desc;
 
-    bool _child_eos = false;
-    int _repeat_id_idx = 0;
     RuntimeState* _runtime_state = nullptr;
 
     // time to append columns for grouping_id column and grouping()/grouping_id()'s virtual columns.

--- a/fe/fe-core/src/main/java/com/starrocks/planner/RepeatNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/RepeatNode.java
@@ -236,4 +236,9 @@ public class RepeatNode extends PlanNode {
 
         return true;
     }
+
+    @Override
+    public boolean canUsePipeLine() {
+        return getChildren().stream().allMatch(PlanNode::canUsePipeLine);
+    }
 }


### PR DESCRIPTION
RepeatNode is used for sql like "group by cube/rollup/grouping sets...", it just produce multiple rows for one row, and it could work in streaming mode, when we disassemble the RepeatNode into operators, we actually made the following changes:

- Will get_next split into push_chunk and pull_chunk.
- Drive push_chunk through condition in need_input.
- Drive pull_chunk through condition in has_output.
- No exprs need to transmit.

We integrate the logic of data generation into pipeline driver.

For https://github.com/StarRocks/starrocks/issues/797