### PR TITLE
UT: fromUnixTime2 of ScalarOperatorFunctionsTest should ignore TimeZone information

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
@@ -621,6 +621,6 @@ public class ScalarOperatorFunctionsTest {
     public void fromUnixTime2() throws AnalysisException {
         ConstantOperator date =
                 ScalarOperatorFunctions.fromUnixTime(O_INT_10, ConstantOperator.createVarchar("%Y-%m-%d %H:%i:%s"));
-        assertEquals("1970-01-01 08:00:10", date.toString());
+        assertTrue(date.toString().matches("1970-01-01 0.*:00:10"));
     }
 }


### PR DESCRIPTION
We may run ut on ET or others