### PR TITLE
UT: set user.timezone as Asia/Shanghai

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -579,7 +579,7 @@ under the License.
                     <!-->not reuse forked jvm, so that each unit test will run in separate jvm. to avoid singleton confict<-->
                     <reuseForks>false</reuseForks>
                     <argLine>
-                        -javaagent:${settings.localRepository}/org/jmockit/jmockit/1.48/jmockit-1.48.jar -Xmx2048m
+                        -javaagent:${settings.localRepository}/org/jmockit/jmockit/1.48/jmockit-1.48.jar -Xmx2048m -Duser.timezone=Asia/Shanghai
                     </argLine>
                     <!-- Set maven to use independent class loading to avoid unit test failure due to the early shutdown of the JVM -->
                     <useSystemClassLoader>false</useSystemClassLoader>


### PR DESCRIPTION
Since we may run unit test at UTC environment, we should set user.timezone as  Asia/Shanghai in case of failures related with timezone. For example:
ConstantExpressionTest
```
testFragmentPlanContainsConstExpr(
                "select UNIX_TIMESTAMP(\"1970-01-01 08:00:01\");",
                "1");
```