### PR TITLE
Refactor `olap_scan_prepare.h`  conjuncts parse and push down 

### DIFF
--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -137,6 +137,11 @@ public:
     }
 
     template <PrimitiveType Type>
+    static inline RunTimeCppType<Type>* get_cpp_data(const ColumnPtr& value) {
+        return cast_to_raw<Type>(value)->get_data().data();
+    }
+
+    template <PrimitiveType Type>
     static inline RunTimeCppType<Type> get_const_value(const ColumnPtr& col) {
         const ColumnPtr& c = as_raw_column<ConstColumn>(col)->data_column();
         return cast_to_raw<Type>(c)->get_data()[0];

--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -64,6 +64,7 @@ set(EXEC_FILES
     vectorized/csv_scanner.cpp
     vectorized/tablet_scanner.cpp
     vectorized/olap_scan_node.cpp
+    vectorized/olap_scan_prepare.cpp
     vectorized/olap_meta_scanner.cpp
     vectorized/olap_meta_scan_node.cpp
     vectorized/hash_join_node.cpp

--- a/be/src/exec/pipeline/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/olap_chunk_source.cpp
@@ -21,28 +21,16 @@ using namespace vectorized;
 Status OlapChunkSource::prepare(RuntimeState* state) {
     _runtime_state = state;
     _scan_profile = state->runtime_profile();
-
-    for (const auto& ctx_iter : _conjunct_ctxs) {
-        // if conjunct is constant, compute direct and set eos = true
-        if (ctx_iter->root()->is_constant()) {
-            ColumnPtr value = ctx_iter->root()->evaluate_const(ctx_iter);
-
-            if (value == nullptr || value->only_null() || value->is_null(0)) {
-                _status = Status::EndOfFile("conjuncts evaluated to null");
-            } else if (value->is_constant() && !vectorized::ColumnHelper::get_const_value<TYPE_BOOLEAN>(value)) {
-                _status = Status::EndOfFile("conjuncts evaluated to false");
-            }
-        }
-    }
-
     const TupleDescriptor* tuple_desc = state->desc_tbl().get_tuple_descriptor(_tuple_id);
     _slots = &tuple_desc->slots();
-    // 1. Convert conjuncts to ColumnValueRange in each column
-    RETURN_IF_ERROR(details::normalize_conjuncts(*_slots, _obj_pool, _conjunct_ctxs, _normalized_conjuncts,
-                                                 _runtime_filters, _is_null_vector, _column_value_ranges, &_status));
 
-    // 2. Using ColumnValueRange to Build StorageEngine filters
-    RETURN_IF_ERROR(details::build_olap_filters(_column_value_ranges, _olap_filter));
+    OlapScanConjunctsManager::eval_const_conjuncts(_conjunct_ctxs, &_status);
+    OlapScanConjunctsManager& cm = _conjuncts_manager;
+    cm.conjunct_ctxs_ptr = &_conjunct_ctxs;
+    cm.tuple_desc = tuple_desc;
+    cm.obj_pool = &_obj_pool;
+    cm.key_column_names = &_key_column_names;
+    cm.runtime_filters = &_runtime_filters;
 
     const TQueryOptions& query_options = state->query_options();
     int32_t max_scan_key_num;
@@ -52,9 +40,9 @@ Status OlapChunkSource::prepare(RuntimeState* state) {
         max_scan_key_num = config::doris_max_scan_key_num;
     }
 
-    // 3. Using `Key Column`'s ColumnValueRange to split ScanRange to sererval `Sub ScanRange`
-    RETURN_IF_ERROR(
-            details::build_scan_key(_key_column_names, _column_value_ranges, _scan_keys, true, max_scan_key_num));
+    cm.normalize_conjuncts();
+    cm.build_olap_filters();
+    cm.build_scan_keys(true, max_scan_key_num);
 
     // 4. Build olap scanner range
     RETURN_IF_ERROR(_build_scan_range(_runtime_state));
@@ -65,29 +53,21 @@ Status OlapChunkSource::prepare(RuntimeState* state) {
 }
 
 Status OlapChunkSource::_build_scan_range(RuntimeState* state) {
-    RETURN_IF_ERROR(_scan_keys.get_key_range(&_cond_ranges));
-    if (_cond_ranges.empty()) {
-        _cond_ranges.emplace_back(new OlapScanRange());
-    }
-
-    DCHECK_EQ(_conjunct_ctxs.size(), _normalized_conjuncts.size());
-    for (size_t i = 0; i < _normalized_conjuncts.size(); i++) {
-        if (!_normalized_conjuncts[i]) {
-            _un_push_down_conjuncts.push_back(_conjunct_ctxs[i]);
-        }
-    }
+    std::vector<std::unique_ptr<OlapScanRange>> key_ranges;
+    RETURN_IF_ERROR(_conjuncts_manager.get_key_ranges(&key_ranges));
+    _conjuncts_manager.get_not_push_down_conjuncts(&_not_push_down_conjuncts);
 
     // FixMe(kks): Ensure this logic is right.
     int scanners_per_tablet = 64;
-    int num_ranges = _cond_ranges.size();
+    int num_ranges = key_ranges.size();
     int ranges_per_scanner = std::max(1, num_ranges / scanners_per_tablet);
     for (int i = 0; i < num_ranges;) {
-        _scanner_ranges.push_back(_cond_ranges[i].get());
+        _scanner_ranges.push_back(key_ranges[i].get());
         i++;
-        for (int j = 1; i < num_ranges && j < ranges_per_scanner &&
-                        _cond_ranges[i]->end_include == _cond_ranges[i - 1]->end_include;
+        for (int j = 1;
+             i < num_ranges && j < ranges_per_scanner && key_ranges[i]->end_include == key_ranges[i - 1]->end_include;
              ++j, ++i) {
-            _scanner_ranges.push_back(_cond_ranges[i].get());
+            _scanner_ranges.push_back(key_ranges[i].get());
         }
     }
     return Status::OK();
@@ -122,25 +102,14 @@ Status OlapChunkSource::_init_reader_params(const std::vector<OlapScanRange*>& k
     params->chunk_size = config::vector_chunk_size;
 
     PredicateParser parser(_tablet->tablet_schema());
-
-    // Condition
-    for (auto& filter : _olap_filter) {
-        vectorized::ColumnPredicate* p = parser.parse(filter);
-        p->set_index_filter_only(filter.is_index_filter_only);
+    std::vector<vectorized::ColumnPredicate*> preds;
+    _conjuncts_manager.parse_to_column_predicates(&parser, &preds);
+    for (auto* p : preds) {
         _predicate_free_pool.emplace_back(p);
         if (parser.can_pushdown(p)) {
             params->predicates.push_back(p);
         } else {
-            _un_push_down_predicates.add(p);
-        }
-    }
-    for (auto& is_null_str : _is_null_vector) {
-        vectorized::ColumnPredicate* p = parser.parse(is_null_str);
-        _predicate_free_pool.emplace_back(p);
-        if (parser.can_pushdown(p)) {
-            params->predicates.push_back(p);
-        } else {
-            _un_push_down_predicates.add(p);
+            _not_push_down_predicates.add(p);
         }
     }
 
@@ -219,7 +188,7 @@ Status OlapChunkSource::_init_olap_reader(RuntimeState* runtime_state) {
         _prj_iter = new_projection_iterator(output_schema, _reader);
     }
 
-    if (!_un_push_down_conjuncts.empty() || !_un_push_down_predicates.empty()) {
+    if (!_not_push_down_conjuncts.empty() || !_not_push_down_predicates.empty()) {
         _expr_filter_timer = ADD_TIMER(_scan_profile, "ExprFilterTime");
     }
     RETURN_IF_ERROR(_reader->prepare());
@@ -269,20 +238,20 @@ Status OlapChunkSource::_read_chunk_from_storage(RuntimeState* state, vectorized
             chunk->set_slot_id_to_index(slot->id(), column_index);
         }
 
-        if (!_un_push_down_predicates.empty()) {
+        if (!_not_push_down_predicates.empty()) {
             int64_t old_mem_usage = chunk->memory_usage();
             SCOPED_TIMER(_expr_filter_timer);
             size_t nrows = chunk->num_rows();
             _selection.resize(nrows);
-            _un_push_down_predicates.evaluate(chunk, _selection.data(), 0, nrows);
+            _not_push_down_predicates.evaluate(chunk, _selection.data(), 0, nrows);
             chunk->filter(_selection);
             CurrentMemTracker::consume((int64_t)chunk->memory_usage() - old_mem_usage);
             DCHECK_CHUNK(chunk);
         }
-        if (!_un_push_down_conjuncts.empty()) {
+        if (!_not_push_down_conjuncts.empty()) {
             int64_t old_mem_usage = chunk->memory_usage();
             SCOPED_TIMER(_expr_filter_timer);
-            ExecNode::eval_conjuncts(_un_push_down_conjuncts, chunk);
+            ExecNode::eval_conjuncts(_not_push_down_conjuncts, chunk);
             CurrentMemTracker::consume((int64_t)chunk->memory_usage() - old_mem_usage);
             DCHECK_CHUNK(chunk);
         }

--- a/be/src/exec/pipeline/olap_chunk_source.h
+++ b/be/src/exec/pipeline/olap_chunk_source.h
@@ -7,6 +7,7 @@
 #include "exec/olap_common.h"
 #include "exec/olap_utils.h"
 #include "exec/pipeline/chunk_source.h"
+#include "exec/vectorized/olap_scan_prepare.h"
 #include "exprs/expr.h"
 #include "exprs/expr_context.h"
 #include "gen_cpp/InternalService_types.h"
@@ -69,26 +70,19 @@ private:
 
     Status _status = Status::OK();
     StatusOr<vectorized::ChunkUniquePtr> _chunk;
-    // Same size with |_conjunct_ctxs|, indicate which element has been normalized.
-    std::vector<bool> _normalized_conjuncts;
     // The conjuncts couldn't push down to storage engine
-    std::vector<ExprContext*> _un_push_down_conjuncts;
-    vectorized::ConjunctivePredicates _un_push_down_predicates;
+    std::vector<ExprContext*> _not_push_down_conjuncts;
+    vectorized::ConjunctivePredicates _not_push_down_predicates;
     std::vector<uint8_t> _selection;
 
     ObjectPool _obj_pool;
     TabletSharedPtr _tablet;
     int64_t _version = 0;
 
-    // Constructed from params
     RuntimeState* _runtime_state = nullptr;
     const std::vector<SlotDescriptor*>* _slots = nullptr;
     std::vector<OlapScanRange*> _scanner_ranges;
-    std::map<std::string, ColumnValueRangeType> _column_value_ranges;
-    OlapScanKeys _scan_keys;
-    std::vector<std::unique_ptr<OlapScanRange>> _cond_ranges;
-    std::vector<TCondition> _olap_filter;
-    std::vector<TCondition> _is_null_vector;
+    vectorized::OlapScanConjunctsManager _conjuncts_manager;
 
     std::shared_ptr<vectorized::TabletReader> _reader;
     // projection iterator, doing the job of choosing |_scanner_columns| from |_reader_columns|.

--- a/be/src/exec/pipeline/olap_chunk_source.h
+++ b/be/src/exec/pipeline/olap_chunk_source.h
@@ -81,6 +81,7 @@ private:
 
     RuntimeState* _runtime_state = nullptr;
     const std::vector<SlotDescriptor*>* _slots = nullptr;
+    std::vector<std::unique_ptr<OlapScanRange>> _key_ranges;
     std::vector<OlapScanRange*> _scanner_ranges;
     vectorized::OlapScanConjunctsManager _conjuncts_manager;
 

--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -34,14 +34,6 @@ OlapScanNode::OlapScanNode(ObjectPool* pool, const TPlanNode& tnode, const Descr
 Status OlapScanNode::init(const TPlanNode& tnode, RuntimeState* state) {
     RETURN_IF_ERROR(ExecNode::init(tnode, state));
     DCHECK(!tnode.olap_scan_node.__isset.sort_column) << "sorted result not supported any more";
-
-    const TQueryOptions& query_options = state->query_options();
-    if (query_options.__isset.max_scan_key_num && query_options.max_scan_key_num > 0) {
-        _max_scan_key_num = query_options.max_scan_key_num;
-    } else {
-        _max_scan_key_num = config::doris_max_scan_key_num;
-    }
-
     return Status::OK();
 }
 
@@ -71,18 +63,9 @@ Status OlapScanNode::open(RuntimeState* state) {
     RETURN_IF_ERROR(ExecNode::open(state));
     CurrentThread::set_mem_tracker(mem_tracker());
 
-    for (const auto& ctx_iter : _conjunct_ctxs) {
-        // if conjunct is constant, compute direct and set eos = true
-        if (ctx_iter->root()->is_constant()) {
-            ColumnPtr value = ctx_iter->root()->evaluate_const(ctx_iter);
-
-            if (value == nullptr || value->only_null() || value->is_null(0)) {
-                _update_status(Status::EndOfFile("conjuncts evaluated to null"));
-            } else if (value->is_constant() && !ColumnHelper::get_const_value<TYPE_BOOLEAN>(value)) {
-                _update_status(Status::EndOfFile("conjuncts evaluated to false"));
-            }
-        }
-    }
+    Status status;
+    OlapScanConjunctsManager::eval_const_conjuncts(_conjunct_ctxs, &status);
+    _update_status(status);
     return Status::OK();
 }
 
@@ -339,21 +322,25 @@ Status OlapScanNode::collect_query_statistics(QueryStatistics* statistics) {
 Status OlapScanNode::_start_scan(RuntimeState* state) {
     RETURN_IF_CANCELLED(state);
 
-    // 1. Convert conjuncts to ColumnValueRange in each column
-    Status status;
-    RETURN_IF_ERROR(details::normalize_conjuncts(_tuple_desc->slots(), _obj_pool, _conjunct_ctxs, _normalized_conjuncts,
-                                                 _runtime_filter_collector, _is_null_vector, _column_value_ranges,
-                                                 &status));
-    if (!status.ok()) {
-        _update_status(status);
+    OlapScanConjunctsManager& cm = _conjuncts_manager;
+    cm.conjunct_ctxs_ptr = &_conjunct_ctxs;
+    cm.tuple_desc = _tuple_desc;
+    cm.obj_pool = &_obj_pool;
+    cm.key_column_names = &_olap_scan_node.key_column_name;
+    cm.runtime_filters = &_runtime_filter_collector;
+
+    const TQueryOptions& query_options = state->query_options();
+    int32_t max_scan_key_num;
+    if (query_options.__isset.max_scan_key_num && query_options.max_scan_key_num > 0) {
+        max_scan_key_num = query_options.max_scan_key_num;
+    } else {
+        max_scan_key_num = config::doris_max_scan_key_num;
     }
+    bool no_limit = (limit() == -1);
 
-    // 2. Using ColumnValueRange to Build StorageEngine filters
-    RETURN_IF_ERROR(details::build_olap_filters(_column_value_ranges, _olap_filter));
-
-    // 4. Using `Key Column`'s ColumnValueRange to split ScanRange to sererval `Sub ScanRange`
-    RETURN_IF_ERROR(details::build_scan_key(_olap_scan_node.key_column_name, _column_value_ranges, _scan_keys,
-                                            limit() == -1, _max_scan_key_num));
+    cm.normalize_conjuncts();
+    cm.build_olap_filters();
+    cm.build_scan_keys(no_limit, max_scan_key_num);
 
     RETURN_IF_ERROR(_start_scan_thread(state));
 
@@ -458,39 +445,29 @@ Status OlapScanNode::_start_scan_thread(RuntimeState* state) {
         return Status::OK();
     }
 
-    std::vector<std::unique_ptr<OlapScanRange>> cond_ranges;
-    RETURN_IF_ERROR(_scan_keys.get_key_range(&cond_ranges));
-    if (cond_ranges.empty()) {
-        cond_ranges.emplace_back(new OlapScanRange());
-    }
-
-    // vector of ExprContext that has not been normalized.
-    std::vector<ExprContext*> predicates;
-    DCHECK_EQ(_conjunct_ctxs.size(), _normalized_conjuncts.size());
-    for (size_t i = 0; i < _normalized_conjuncts.size(); i++) {
-        if (!_normalized_conjuncts[i]) {
-            predicates.push_back(_conjunct_ctxs[i]);
-        }
-    }
+    std::vector<std::unique_ptr<OlapScanRange>> key_ranges;
+    RETURN_IF_ERROR(_conjuncts_manager.get_key_ranges(&key_ranges));
+    std::vector<ExprContext*> conjunct_ctxs;
+    _conjuncts_manager.get_not_push_down_conjuncts(&conjunct_ctxs);
 
     int scanners_per_tablet = std::max(1, 64 / (int)_scan_ranges.size());
     for (auto& scan_range : _scan_ranges) {
-        int num_ranges = cond_ranges.size();
+        int num_ranges = key_ranges.size();
         int ranges_per_scanner = std::max(1, num_ranges / scanners_per_tablet);
         for (int i = 0; i < num_ranges;) {
-            std::vector<OlapScanRange*> scanner_ranges;
-            scanner_ranges.push_back(cond_ranges[i].get());
+            std::vector<OlapScanRange*> agg_key_ranges;
+            agg_key_ranges.push_back(key_ranges[i].get());
             i++;
             for (int j = 1; i < num_ranges && j < ranges_per_scanner &&
-                            cond_ranges[i]->end_include == cond_ranges[i - 1]->end_include;
+                            key_ranges[i]->end_include == key_ranges[i - 1]->end_include;
                  ++j, ++i) {
-                scanner_ranges.push_back(cond_ranges[i].get());
+                agg_key_ranges.push_back(key_ranges[i].get());
             }
 
             TabletScannerParams scanner_params;
             scanner_params.scan_range = scan_range.get();
-            scanner_params.key_ranges = &scanner_ranges;
-            scanner_params.conjunct_ctxs = &predicates;
+            scanner_params.key_ranges = &agg_key_ranges;
+            scanner_params.conjunct_ctxs = &conjunct_ctxs;
             scanner_params.skip_aggregation = _olap_scan_node.is_preaggregation;
             scanner_params.need_agg_finalize = true;
             auto* scanner = _obj_pool.add(new TabletScanner(this));

--- a/be/src/exec/vectorized/olap_scan_node.h
+++ b/be/src/exec/vectorized/olap_scan_node.h
@@ -10,6 +10,7 @@
 #include "column/chunk.h"
 #include "exec/olap_common.h"
 #include "exec/scan_node.h"
+#include "exec/vectorized/olap_scan_prepare.h"
 #include "exec/vectorized/tablet_scanner.h"
 
 namespace starrocks {
@@ -105,26 +106,16 @@ private:
     void _close_pending_scanners();
     int _compute_priority(int32_t num_submitted_tasks);
 
-    // params
     TOlapScanNode _olap_scan_node;
     std::vector<std::unique_ptr<TInternalScanRange>> _scan_ranges;
     RuntimeState* _runtime_state = nullptr;
-
-    // constructed from params
-    const TupleDescriptor* _tuple_desc = nullptr;                     // from _runtime_state
-    std::map<std::string, ColumnValueRangeType> _column_value_ranges; // from expr
-    OlapScanKeys _scan_keys;                                          // from _column_value_ranges
-    std::vector<TCondition> _olap_filter;                             // from _column_value_ranges
-    std::vector<TCondition> _is_null_vector;                          // from expr
-
+    const TupleDescriptor* _tuple_desc = nullptr;
+    OlapScanConjunctsManager _conjuncts_manager;
+    const Schema* _chunk_schema = nullptr;
     ObjectPool _obj_pool;
 
-    const Schema* _chunk_schema = nullptr;
-    // same size with |_conjunct_ctxs|, indicate which element has been normalized.
-    std::vector<bool> _normalized_conjuncts;
     int32_t _num_scanners = 0;
     int32_t _chunks_per_scanner = 10;
-    int32_t _max_scan_key_num = 1024;
     bool _start = false;
 
     mutable SpinLock _status_mutex;

--- a/be/src/exec/vectorized/olap_scan_prepare.cpp
+++ b/be/src/exec/vectorized/olap_scan_prepare.cpp
@@ -1,0 +1,739 @@
+
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#include "exec/vectorized/olap_scan_prepare.h"
+
+#include "exprs/vectorized/in_const_predicate.hpp"
+#include "gutil/map_util.h"
+#include "storage/vectorized/column_predicate.h"
+#include "storage/vectorized/predicate_parser.h"
+
+namespace starrocks {
+namespace vectorized {
+
+static bool ignore_cast(const SlotDescriptor& slot, const Expr& expr) {
+    if (slot.type().is_date_type() && expr.type().is_date_type()) {
+        return true;
+    }
+    return slot.type().is_string_type() && expr.type().is_string_type();
+}
+
+template <typename ValueType>
+static bool get_predicate_value(ObjectPool* obj_pool, const SlotDescriptor& slot, const Expr* expr, ExprContext* ctx,
+                                ValueType* value, SQLFilterOp* op, Status* status) {
+    if (expr->get_num_children() != 2) {
+        return false;
+    }
+
+    Expr* l = expr->get_child(0);
+    Expr* r = expr->get_child(1);
+
+    // 1. ensure |l| points to a slot ref and |r| points to a const expression.
+    bool reverse_op = false;
+    if (!r->is_constant()) {
+        reverse_op = true;
+        std::swap(l, r);
+    }
+
+    // TODO(zhuming): DATE column may be casted to double.
+    if (l->type().type != slot.type().type && !ignore_cast(slot, *l)) {
+        return false;
+    }
+
+    // when query on a `DATE` column with predicate, both the `DATE`
+    // column and the operand of predicate will be casted to timestamp.
+    if constexpr (std::is_same_v<ValueType, DateValue>) {
+        if (l->op() == TExprOpcode::CAST) {
+            l = l->get_child(0);
+        }
+    }
+
+    if ((l->node_type() != TExprNodeType::SLOT_REF) || !r->is_constant()) {
+        return false;
+    }
+
+    std::vector<SlotId> slot_ids;
+    if (l->get_slot_ids(&slot_ids) != 1 || slot_ids[0] != slot.id()) {
+        return false;
+    }
+
+    // 3. extract the const value from |r|.
+    ColumnPtr column_ptr = ctx->evaluate(r, nullptr);
+    if (column_ptr == nullptr) {
+        return false;
+    }
+
+    DCHECK_EQ(1u, column_ptr->size());
+    if (column_ptr->only_null() || column_ptr->is_null(0)) {
+        return false;
+    }
+
+    // check column type, as not all exprs return a const column.
+    ColumnPtr data = column_ptr;
+    if (column_ptr->is_nullable()) {
+        data = down_cast<NullableColumn*>(column_ptr.get())->data_column();
+    } else if (column_ptr->is_constant()) {
+        data = down_cast<ConstColumn*>(column_ptr.get())->data_column();
+    } else { // defensive check.
+        DCHECK(false) << "unreachable path: unknown column type of expr evaluate result";
+        return false;
+    }
+
+    if (expr->op() == TExprOpcode::EQ || expr->op() == TExprOpcode::NE) {
+        *op = to_olap_filter_type(expr->op(), false);
+    } else {
+        *op = to_olap_filter_type(expr->op(), reverse_op);
+    }
+
+    if constexpr (std::is_same_v<ValueType, DateValue>) {
+        if (data->is_timestamp()) {
+            TimestampValue ts = down_cast<TimestampColumn*>(data.get())->get(0).get_timestamp();
+            *value = implicit_cast<DateValue>(ts);
+            if (implicit_cast<TimestampValue>(*value) != ts) {
+                // |ts| has nonzero time, rewrite predicate.
+                switch (*op) {
+                case FILTER_LARGER_OR_EQUAL:
+                    // rewrite (c >= '2020-01-01 01:00:00') to (c > '2020-01-01').
+                    *op = FILTER_LARGER;
+                    break;
+                case FILTER_LESS:
+                    // rewrite (c < '2020-01-01 01:00:00') to (c <= '2020-01-01').
+                    *op = FILTER_LESS_OR_EQUAL;
+                    break;
+                case FILTER_LARGER:
+                    [[fallthrough]];
+                case FILTER_LESS_OR_EQUAL:
+                    // Just ignore the time value.
+                    break;
+                case FILTER_IN:
+                    *status = Status::EndOfFile("predicate for date always false");
+                    return false;
+                case FILTER_NOT_IN:
+                    // TODO(zhuming): Should be rewrote to `NOT NULL`.
+                    return false;
+                }
+            }
+        } else {
+            DCHECK(data->is_date());
+            *value = down_cast<DateColumn*>(data.get())->get(0).get_date();
+        }
+    } else if constexpr (std::is_same_v<ValueType, Slice>) {
+        // |column_ptr| will be released after this method return, have to ensure that
+        // the corresponding external storage will not be deallocated while the slice
+        // still been used.
+        const Slice* slice = reinterpret_cast<const Slice*>(data->raw_data());
+        std::string* str = obj_pool->add(new std::string(slice->data, slice->size));
+        *value = *str;
+    } else {
+        *value = *reinterpret_cast<const ValueType*>(data->raw_data());
+    }
+    return true;
+}
+
+template <PrimitiveType SlotType, typename RangeValueType>
+void OlapScanConjunctsManager::normalize_in_or_equal_predicate(const SlotDescriptor& slot,
+                                                               ColumnValueRange<RangeValueType>* range) {
+    Status status;
+    const auto& conjunct_ctxs = (*conjunct_ctxs_ptr);
+    for (size_t i = 0; i < conjunct_ctxs.size(); i++) {
+        if (normalized_conjuncts[i]) {
+            continue;
+        }
+
+        const Expr* root_expr = conjunct_ctxs[i]->root();
+
+        // 1. Normalize in conjuncts like 'where col in (v1, v2, v3)'
+        if (TExprOpcode::FILTER_IN == root_expr->op()) {
+            const Expr* l = root_expr->get_child(0);
+
+            if ((l->node_type() != TExprNodeType::SLOT_REF) ||
+                (l->type().type != slot.type().type && !ignore_cast(slot, *l))) {
+                continue;
+            }
+            std::vector<SlotId> slot_ids;
+            if (1 == l->get_slot_ids(&slot_ids) && slot_ids[0] == slot.id()) {
+                const auto* pred = down_cast<const VectorizedInConstPredicate<SlotType>*>(root_expr);
+                // join in runtime filter  will handle by `_normalize_join_runtime_filter`
+                if (pred->is_join_runtime_filter()) {
+                    continue;
+                }
+
+                if (pred->is_not_in() || pred->null_in_set() ||
+                    pred->hash_set().size() > config::max_pushdown_conditions_per_column) {
+                    continue;
+                }
+
+                std::set<RangeValueType> values;
+                for (const auto& value : pred->hash_set()) {
+                    values.insert(value);
+                }
+                if (range->add_fixed_values(FILTER_IN, values).ok()) {
+                    normalized_conjuncts[i] = true;
+                }
+            }
+        }
+
+        // 2. Normalize eq conjuncts like 'where col = value'
+        if (TExprNodeType::BINARY_PRED == root_expr->node_type() &&
+            FILTER_IN == to_olap_filter_type(root_expr->op(), false)) {
+            using ValueType = typename RunTimeTypeTraits<SlotType>::CppType;
+            SQLFilterOp op;
+            ValueType value;
+            bool ok = get_predicate_value(obj_pool, slot, root_expr, conjunct_ctxs[i], &value, &op, &status);
+            if (ok && range->add_fixed_values(FILTER_IN, std::set<RangeValueType>{value}).ok()) {
+                normalized_conjuncts[i] = true;
+            }
+        }
+    }
+    return;
+}
+
+// explicit specialization for DATE.
+template <>
+void OlapScanConjunctsManager::normalize_in_or_equal_predicate<starrocks::TYPE_DATE, DateValue>(
+        const SlotDescriptor& slot, ColumnValueRange<DateValue>* range) {
+    Status status;
+    const auto& conjunct_ctxs = (*conjunct_ctxs_ptr);
+
+    for (size_t i = 0; i < conjunct_ctxs.size(); i++) {
+        if (normalized_conjuncts[i]) {
+            continue;
+        }
+
+        const Expr* root_expr = conjunct_ctxs[i]->root();
+
+        // 1. Normalize in conjuncts like 'where col in (v1, v2, v3)'
+        if (TExprOpcode::FILTER_IN == root_expr->op()) {
+            const Expr* l = root_expr->get_child(0);
+            // TODO(zhuming): DATE column may be casted to double.
+            if (l->type().type != starrocks::TYPE_DATE && l->type().type != starrocks::TYPE_DATETIME) {
+                continue;
+            }
+
+            PrimitiveType pred_type = l->type().type;
+            // ignore the cast on DATE.
+            if (l->op() == TExprOpcode::CAST) {
+                l = l->get_child(0);
+            }
+            if (l->node_type() != TExprNodeType::SLOT_REF) {
+                continue;
+            }
+            std::vector<SlotId> slot_ids;
+            if (1 == l->get_slot_ids(&slot_ids) && slot_ids[0] == slot.id()) {
+                std::set<DateValue> values;
+
+                if (pred_type == starrocks::TYPE_DATETIME) {
+                    const auto* pred =
+                            down_cast<const VectorizedInConstPredicate<starrocks::TYPE_DATETIME>*>(root_expr);
+                    // join in runtime filter  will handle by `_normalize_join_runtime_filter`
+                    if (pred->is_join_runtime_filter()) {
+                        continue;
+                    }
+
+                    if (pred->is_not_in() || pred->null_in_set() ||
+                        pred->hash_set().size() > config::max_pushdown_conditions_per_column) {
+                        continue;
+                    }
+
+                    for (const TimestampValue& ts : pred->hash_set()) {
+                        DateValue date = implicit_cast<DateValue>(ts);
+                        if (implicit_cast<TimestampValue>(date) == ts) {
+                            values.insert(date);
+                        }
+                    }
+                } else if (pred_type == starrocks::TYPE_DATE) {
+                    const auto* pred = down_cast<const VectorizedInConstPredicate<starrocks::TYPE_DATE>*>(root_expr);
+                    if (pred->is_not_in() || pred->null_in_set() ||
+                        pred->hash_set().size() > config::max_pushdown_conditions_per_column) {
+                        continue;
+                    }
+                    for (const DateValue& date : pred->hash_set()) {
+                        values.insert(date);
+                    }
+                }
+                if (values.empty()) {
+                    status = Status::EndOfFile("const false predicate result");
+                    continue;
+                }
+                if (range->add_fixed_values(FILTER_IN, values).ok()) {
+                    normalized_conjuncts[i] = true;
+                }
+            }
+        }
+
+        // 2. Normalize eq conjuncts like 'where col = value'
+        if (TExprNodeType::BINARY_PRED == root_expr->node_type() &&
+            FILTER_IN == to_olap_filter_type(root_expr->op(), false)) {
+            SQLFilterOp op;
+            DateValue value{0};
+            bool ok = get_predicate_value(obj_pool, slot, root_expr, conjunct_ctxs[i], &value, &op, &status);
+            if (ok && range->add_fixed_values(FILTER_IN, std::set<DateValue>{value}).ok()) {
+                normalized_conjuncts[i] = true;
+            }
+        }
+    }
+}
+
+template <PrimitiveType SlotType, typename RangeValueType>
+void OlapScanConjunctsManager::normalize_binary_predicate(const SlotDescriptor& slot,
+                                                          ColumnValueRange<RangeValueType>* range) {
+    Status status;
+    DCHECK((SlotType == slot.type().type) || (SlotType == TYPE_VARCHAR && slot.type().type == TYPE_CHAR));
+    const auto& conjunct_ctxs = (*conjunct_ctxs_ptr);
+
+    for (size_t i = 0; i < conjunct_ctxs.size(); i++) {
+        if (normalized_conjuncts[i]) {
+            continue;
+        }
+
+        Expr* root_expr = conjunct_ctxs[i]->root();
+        if (TExprNodeType::BINARY_PRED != root_expr->node_type()) {
+            continue;
+        }
+
+        using ValueType = typename vectorized::RunTimeTypeTraits<SlotType>::CppType;
+
+        SQLFilterOp op;
+        ValueType value;
+        bool ok = get_predicate_value(obj_pool, slot, root_expr, conjunct_ctxs[i], &value, &op, &status);
+        if (ok && range->add_range(op, static_cast<RangeValueType>(value)).ok()) {
+            normalized_conjuncts[i] = true;
+        }
+    }
+    return;
+}
+
+template <PrimitiveType SlotType, typename RangeValueType>
+void OlapScanConjunctsManager::normalize_join_runtime_filter(const SlotDescriptor& slot,
+                                                             ColumnValueRange<RangeValueType>* range) {
+    // in runtime filter
+    const auto& conjunct_ctxs = (*conjunct_ctxs_ptr);
+
+    for (size_t i = 0; i < conjunct_ctxs.size(); i++) {
+        if (normalized_conjuncts[i]) {
+            continue;
+        }
+
+        const Expr* root_expr = conjunct_ctxs[i]->root();
+        if (TExprOpcode::FILTER_IN == root_expr->op()) {
+            const Expr* l = root_expr->get_child(0);
+            if ((l->node_type() != TExprNodeType::SLOT_REF) ||
+                (l->type().type != slot.type().type && !ignore_cast(slot, *l))) {
+                continue;
+            }
+            std::vector<SlotId> slot_ids;
+            if (1 == l->get_slot_ids(&slot_ids) && slot_ids[0] == slot.id()) {
+                const auto* pred = down_cast<const VectorizedInConstPredicate<SlotType>*>(root_expr);
+
+                if (!pred->is_join_runtime_filter()) {
+                    continue;
+                }
+
+                // Ensure we don't compute this conjuncts again in olap scanner
+                normalized_conjuncts[i] = true;
+
+                if (pred->is_not_in() || pred->null_in_set() ||
+                    pred->hash_set().size() > config::max_pushdown_conditions_per_column) {
+                    continue;
+                }
+
+                std::set<RangeValueType> values;
+                for (const auto& value : pred->hash_set()) {
+                    values.insert(value);
+                }
+                range->add_fixed_values(FILTER_IN, values);
+            }
+        }
+    }
+
+    // bloom runtime filter
+    for (const auto it : runtime_filters->descriptors()) {
+        const RuntimeFilterProbeDescriptor* desc = it.second;
+        const JoinRuntimeFilter* rf = desc->runtime_filter();
+        using ValueType = typename vectorized::RunTimeTypeTraits<SlotType>::CppType;
+        SlotId slot_id;
+
+        // runtime filter existed and does not have null.
+        if (rf == nullptr || rf->has_null()) continue;
+        // probe expr is slot ref and slot id matches.
+        if (!desc->is_probe_slot_ref(&slot_id) || slot_id != slot.id()) continue;
+
+        const RuntimeBloomFilter<SlotType>* filter = down_cast<const RuntimeBloomFilter<SlotType>*>(rf);
+        // For some cases such as in bucket shuffle, some hash join node may not have any input chunk from right table.
+        // Runtime filter does not have any min/max values in this case.
+        if (!filter->has_min_max()) continue;
+        // If this column doesn't have other filter, we use join runtime filter
+        // to fast comput row range in storage engine
+        if (range->is_init_state()) {
+            range->set_index_filter_only(true);
+        }
+
+        SQLFilterOp min_op = to_olap_filter_type(TExprOpcode::GE, false);
+        ValueType min_value = filter->min_value();
+        range->add_range(min_op, static_cast<RangeValueType>(min_value));
+
+        SQLFilterOp max_op = to_olap_filter_type(TExprOpcode::LE, false);
+        ValueType max_value = filter->max_value();
+        range->add_range(max_op, static_cast<RangeValueType>(max_value));
+    }
+}
+
+template <PrimitiveType SlotType, typename RangeValueType>
+void OlapScanConjunctsManager::normalize_not_in_or_not_equal_predicate(const SlotDescriptor& slot,
+                                                                       ColumnValueRange<RangeValueType>* range) {
+    Status status;
+    DCHECK((SlotType == slot.type().type) || (SlotType == TYPE_VARCHAR && slot.type().type == TYPE_CHAR));
+    const auto& conjunct_ctxs = (*conjunct_ctxs_ptr);
+
+    // handle not equal.
+    for (size_t i = 0; i < conjunct_ctxs.size(); i++) {
+        if (normalized_conjuncts[i]) {
+            continue;
+        }
+        Expr* root_expr = conjunct_ctxs[i]->root();
+        if (root_expr->node_type() != TExprNodeType::BINARY_PRED) {
+            continue;
+        }
+        if (root_expr->op() != TExprOpcode::NE) {
+            continue;
+        }
+
+        using ValueType = typename vectorized::RunTimeTypeTraits<SlotType>::CppType;
+
+        SQLFilterOp op;
+        ValueType value;
+        bool ok = get_predicate_value(obj_pool, slot, root_expr, conjunct_ctxs[i], &value, &op, &status);
+        if (ok && range->add_fixed_values(FILTER_NOT_IN, std::set<RangeValueType>{value}).ok()) {
+            normalized_conjuncts[i] = true;
+        }
+    }
+    // TODO(zhuming): handle not-in predicate.
+}
+
+void OlapScanConjunctsManager::normalize_is_null_predicate(const SlotDescriptor& slot) {
+    const auto& conjunct_ctxs = (*conjunct_ctxs_ptr);
+
+    for (size_t i = 0; i < conjunct_ctxs.size(); i++) {
+        if (normalized_conjuncts[i]) {
+            continue;
+        }
+        Expr* root_expr = conjunct_ctxs[i]->root();
+        if (TExprNodeType::FUNCTION_CALL == root_expr->node_type()) {
+            std::string is_null_str;
+            if (root_expr->is_null_scalar_function(is_null_str)) {
+                Expr* e = root_expr->get_child(0);
+                if (e->node_type() != TExprNodeType::SLOT_REF) {
+                    continue;
+                }
+                std::vector<SlotId> slot_ids;
+                if (1 != e->get_slot_ids(&slot_ids) || slot_ids[0] != slot.id()) {
+                    continue;
+                }
+                TCondition is_null;
+                is_null.column_name = slot.col_name();
+                is_null.condition_op = "is";
+                is_null.condition_values.push_back(is_null_str);
+                is_null_vector.push_back(is_null);
+                normalized_conjuncts[i] = true;
+            }
+        }
+    }
+}
+
+template <PrimitiveType SlotType, typename RangeValueType>
+void OlapScanConjunctsManager::normalize_predicate(const SlotDescriptor& slot,
+                                                   ColumnValueRange<RangeValueType>* range) {
+    normalize_in_or_equal_predicate<SlotType, RangeValueType>(slot, range);
+    normalize_binary_predicate<SlotType, RangeValueType>(slot, range);
+    normalize_not_in_or_not_equal_predicate<SlotType, RangeValueType>(slot, range);
+    normalize_is_null_predicate(slot);
+    // Must handle join runtime filter last
+    normalize_join_runtime_filter<SlotType, RangeValueType>(slot, range);
+}
+
+Status OlapScanConjunctsManager::normalize_conjuncts() {
+    // Note: _normalized_conjuncts size must be equal to _conjunct_ctxs size,
+    // but HashJoinNode will push down predicate to OlapScanNode's _conjunct_ctxs,
+    // So _conjunct_ctxs will change after OlapScanNode prepare,
+    // So we couldn't resize _normalized_conjuncts when OlapScanNode init or prepare
+    const auto& conjunct_ctxs = (*conjunct_ctxs_ptr);
+    normalized_conjuncts.assign(conjunct_ctxs.size(), false);
+
+    // TODO(zhuming): if any of the normalized column range is empty, we can know that
+    // no row will be selected anymore and can return EOF directly.
+    for (auto& slot : tuple_desc->slots()) {
+        const std::string& col_name = slot->col_name();
+        PrimitiveType type = slot->type().type;
+        switch (type) {
+        case TYPE_TINYINT: {
+            // TYPE_TINYINT use int32_t to present
+            // because it's easy to be converted to string when building Olap fetch Query
+            using RangeType = ColumnValueRange<int32_t>;
+            RangeType full_range(col_name, type, std::numeric_limits<int8_t>::lowest(),
+                                 std::numeric_limits<int8_t>::max());
+            ColumnValueRangeType& v = LookupOrInsert(&column_value_ranges, col_name, full_range);
+            RangeType& range = boost::get<ColumnValueRange<int32_t>>(v);
+            normalize_predicate<TYPE_TINYINT, int32_t>(*slot, &range);
+            break;
+        }
+        case TYPE_BOOLEAN: {
+            // TYPE_BOOLEAN use int32_t to present
+            // because it's easy to be converted to string when building Olap fetch Query
+            using RangeType = ColumnValueRange<int32_t>;
+            RangeType full_range(col_name, type, 0, 1);
+            ColumnValueRangeType& v = LookupOrInsert(&column_value_ranges, col_name, full_range);
+            RangeType& range = boost::get<ColumnValueRange<int32_t>>(v);
+            normalize_predicate<TYPE_BOOLEAN, int32_t>(*slot, &range);
+            break;
+        }
+        case TYPE_SMALLINT: {
+            using RangeType = ColumnValueRange<int16_t>;
+            RangeType full_range(col_name, type, std::numeric_limits<int16_t>::lowest(),
+                                 std::numeric_limits<int16_t>::max());
+            ColumnValueRangeType& v = LookupOrInsert(&column_value_ranges, col_name, full_range);
+            RangeType& range = boost::get<ColumnValueRange<int16_t>>(v);
+            normalize_predicate<TYPE_SMALLINT, int16_t>(*slot, &range);
+            break;
+        }
+        case TYPE_INT: {
+            using RangeType = ColumnValueRange<int32_t>;
+            RangeType full_range(col_name, type, std::numeric_limits<int32_t>::lowest(),
+                                 std::numeric_limits<int32_t>::max());
+            ColumnValueRangeType& v = LookupOrInsert(&column_value_ranges, col_name, full_range);
+            RangeType& range = boost::get<ColumnValueRange<int32_t>>(v);
+            normalize_predicate<TYPE_INT, int32_t>(*slot, &range);
+            break;
+        }
+        case TYPE_BIGINT: {
+            using RangeType = ColumnValueRange<int64_t>;
+            RangeType full_range(col_name, type, std::numeric_limits<int64_t>::lowest(),
+                                 std::numeric_limits<int64_t>::max());
+            ColumnValueRangeType& v = LookupOrInsert(&column_value_ranges, col_name, full_range);
+            RangeType& range = boost::get<ColumnValueRange<int64_t>>(v);
+            normalize_predicate<TYPE_BIGINT, int64_t>(*slot, &range);
+            break;
+        }
+        case TYPE_LARGEINT: {
+            using RangeType = ColumnValueRange<int128_t>;
+            RangeType full_range(col_name, type, MIN_INT128, MAX_INT128);
+            ColumnValueRangeType& v = LookupOrInsert(&column_value_ranges, col_name, full_range);
+            RangeType& range = boost::get<ColumnValueRange<int128_t>>(v);
+            normalize_predicate<TYPE_LARGEINT, int128_t>(*slot, &range);
+            break;
+        }
+        case TYPE_CHAR:
+            // for a CHAR column, its `in` predicate will be represented as a
+            // `InConstPredicate<PrimitiveType::TYPE_VARCHAR>`, so here we mapping CHAR as VARCHAR.
+            [[fallthrough]];
+        case TYPE_VARCHAR: {
+            using RangeType = ColumnValueRange<Slice>;
+            static char min_char = 0x00;
+            static char max_char = (char)0xff;
+            RangeType full_range(col_name, type, Slice(&min_char, 0), Slice(&max_char, 1));
+            ColumnValueRangeType& v = LookupOrInsert(&column_value_ranges, col_name, full_range);
+            RangeType& range = boost::get<ColumnValueRange<Slice>>(v);
+            normalize_predicate<TYPE_VARCHAR, Slice>(*slot, &range);
+            break;
+        }
+        case TYPE_DATE: {
+            using RangeType = ColumnValueRange<DateValue>;
+            RangeType full_range(col_name, type, DateValue::MIN_DATE_VALUE, DateValue::MAX_DATE_VALUE);
+            ColumnValueRangeType& v = LookupOrInsert(&column_value_ranges, col_name, full_range);
+            RangeType& range = boost::get<ColumnValueRange<DateValue>>(v);
+            normalize_predicate<TYPE_DATE, DateValue>(*slot, &range);
+            break;
+        }
+        case TYPE_DATETIME: {
+            using RangeType = ColumnValueRange<TimestampValue>;
+            RangeType full_range(col_name, type, TimestampValue::MIN_TIMESTAMP_VALUE,
+                                 TimestampValue::MAX_TIMESTAMP_VALUE);
+            ColumnValueRangeType& v = LookupOrInsert(&column_value_ranges, col_name, full_range);
+            RangeType& range = boost::get<ColumnValueRange<TimestampValue>>(v);
+            normalize_predicate<TYPE_DATETIME, TimestampValue>(*slot, &range);
+            break;
+        }
+        case TYPE_DECIMALV2: {
+            using RangeType = ColumnValueRange<DecimalV2Value>;
+            RangeType full_range(col_name, type, DecimalV2Value::get_min_decimal(), DecimalV2Value::get_max_decimal());
+            ColumnValueRangeType& v = LookupOrInsert(&column_value_ranges, col_name, full_range);
+            RangeType& range = boost::get<ColumnValueRange<DecimalV2Value>>(v);
+            normalize_predicate<TYPE_DECIMALV2, DecimalV2Value>(*slot, &range);
+            break;
+        }
+        case TYPE_DECIMAL32: {
+            using DecimalValueType = int32_t;
+            using RangeType = ColumnValueRange<DecimalValueType>;
+            RangeType full_range(col_name, type, get_min_decimal<DecimalValueType>(),
+                                 get_max_decimal<DecimalValueType>());
+            full_range.set_precision(slot->type().precision);
+            full_range.set_scale(slot->type().scale);
+            ColumnValueRangeType& v = LookupOrInsert(&column_value_ranges, col_name, full_range);
+            RangeType& range = boost::get<RangeType>(v);
+            range.set_precision(slot->type().precision);
+            range.set_scale(slot->type().scale);
+            normalize_predicate<TYPE_DECIMAL32, DecimalValueType>(*slot, &range);
+            break;
+        }
+        case TYPE_DECIMAL64: {
+            using DecimalValueType = int64_t;
+            using RangeType = ColumnValueRange<DecimalValueType>;
+            RangeType full_range(col_name, type, get_min_decimal<DecimalValueType>(),
+                                 get_max_decimal<DecimalValueType>());
+            full_range.set_precision(slot->type().precision);
+            full_range.set_scale(slot->type().scale);
+            ColumnValueRangeType& v = LookupOrInsert(&column_value_ranges, col_name, full_range);
+            RangeType& range = boost::get<RangeType>(v);
+            range.set_precision(slot->type().precision);
+            range.set_scale(slot->type().scale);
+            normalize_predicate<TYPE_DECIMAL64, DecimalValueType>(*slot, &range);
+            break;
+        }
+        case TYPE_DECIMAL128: {
+            using DecimalValueType = int128_t;
+            using RangeType = ColumnValueRange<DecimalValueType>;
+            RangeType full_range(col_name, type, get_min_decimal<DecimalValueType>(),
+                                 get_max_decimal<DecimalValueType>());
+            full_range.set_precision(slot->type().precision);
+            full_range.set_scale(slot->type().scale);
+            ColumnValueRangeType& v = LookupOrInsert(&column_value_ranges, col_name, full_range);
+            RangeType& range = boost::get<RangeType>(v);
+            range.set_precision(slot->type().precision);
+            range.set_scale(slot->type().scale);
+            normalize_predicate<TYPE_DECIMAL128, DecimalValueType>(*slot, &range);
+            break;
+        }
+        case INVALID_TYPE:
+        case TYPE_NULL:
+        case TYPE_FLOAT:
+        case TYPE_DOUBLE:
+        case TYPE_BINARY:
+        case TYPE_DECIMAL:
+        case TYPE_STRUCT:
+        case TYPE_ARRAY:
+        case TYPE_MAP:
+        case TYPE_HLL:
+        case TYPE_TIME:
+        case TYPE_OBJECT:
+        case TYPE_PERCENTILE:
+            break;
+        }
+    }
+    return Status::OK();
+}
+
+// ======================================================================================
+
+class ToOlapFilterVisitor : public boost::static_visitor<std::string> {
+public:
+    template <class T, class P>
+    std::string operator()(T& v, P& v2) const {
+        return v.to_olap_filter(v2);
+    }
+};
+
+Status OlapScanConjunctsManager::build_olap_filters() {
+    olap_filters.clear();
+
+    for (auto iter : column_value_ranges) {
+        ToOlapFilterVisitor visitor;
+        boost::variant<std::list<TCondition>> filters;
+        boost::apply_visitor(visitor, iter.second, filters);
+
+        std::list<TCondition> new_filters = boost::get<std::list<TCondition>>(filters);
+        if (new_filters.empty()) {
+            continue;
+        }
+
+        for (const auto& filter : new_filters) {
+            olap_filters.push_back(filter);
+        }
+    }
+
+    return Status::OK();
+}
+
+// Try to convert the ranges predicates applied on key columns to in predicates to increase
+// the scan concurrency, i.e, the number of OlapScanners.
+// For example, if the original query is `select * from t where c0 between 1 and 3 and c1 between 12 and 13`,
+// where c0 is the first key column and c1 is the second key column, this routine will convert the predicates
+// to `where c0 in (1,2,3) and c1 in (12,13)`, which is equivalent to the following disjunctive predicates:
+// `where (c0=1 and c1=12)
+//     OR (c0=1 and c1=13)
+//     OR (c0=2 and c1=12)
+//     OR (c0=2 and c1=13)
+//     OR (c0=3 and c1=12)
+//     OR (c0=3 and c1=13)
+// `.
+// By doing so, we can then create six instances of OlapScanner and assign each one with one of the disjunctive
+// predicates and run the OlapScanners concurrently.
+
+class ExtendScanKeyVisitor : public boost::static_visitor<Status> {
+public:
+    ExtendScanKeyVisitor(OlapScanKeys* scan_keys, int32_t max_scan_key_num)
+            : _scan_keys(scan_keys), _max_scan_key_num(max_scan_key_num) {}
+
+    template <class T>
+    Status operator()(T& v) {
+        return _scan_keys->extend_scan_key(v, _max_scan_key_num);
+    }
+
+private:
+    OlapScanKeys* _scan_keys;
+    int32_t _max_scan_key_num;
+};
+
+Status OlapScanConjunctsManager::build_scan_keys(bool no_limit, int32_t max_scan_key_num) {
+    int conditional_key_columns = 0;
+    scan_keys.set_is_convertible(no_limit);
+    const std::vector<std::string>& ref_key_column_names = *key_column_names;
+
+    for (const auto& key_column_name : ref_key_column_names) {
+        if (column_value_ranges.count(key_column_name) == 0) {
+            break;
+        }
+        conditional_key_columns++;
+    }
+    if (conditional_key_columns > 1) {
+        for (int i = 0; i < conditional_key_columns && !scan_keys.has_range_value(); ++i) {
+            ExtendScanKeyVisitor visitor(&scan_keys, max_scan_key_num);
+            if (!boost::apply_visitor(visitor, column_value_ranges[ref_key_column_names[i]]).ok()) {
+                break;
+            }
+        }
+    }
+    return Status::OK();
+}
+
+void OlapScanConjunctsManager::parse_to_column_predicates(PredicateParser* parser,
+                                                          std::vector<ColumnPredicate*>* preds) {
+    for (auto& f : olap_filters) {
+        vectorized::ColumnPredicate* p = parser->parse(f);
+        p->set_index_filter_only(f.is_index_filter_only);
+        preds->push_back(p);
+    }
+    for (auto& f : is_null_vector) {
+        vectorized::ColumnPredicate* p = parser->parse(f);
+        preds->push_back(p);
+    }
+}
+
+void OlapScanConjunctsManager::eval_const_conjuncts(const std::vector<ExprContext*>& conjunct_ctxs, Status* status) {
+    *status = Status::OK();
+    for (const auto& ctx_iter : conjunct_ctxs) {
+        // if conjunct is constant, compute direct and set eos = true
+        if (ctx_iter->root()->is_constant()) {
+            ColumnPtr value = ctx_iter->root()->evaluate_const(ctx_iter);
+
+            if (value == nullptr || value->only_null() || value->is_null(0)) {
+                *status = Status::EndOfFile("conjuncts evaluated to null");
+                break;
+            } else if (value->is_constant() && !ColumnHelper::get_const_value<TYPE_BOOLEAN>(value)) {
+                *status = Status::EndOfFile("conjuncts evaluated to false");
+                break;
+            }
+        }
+    }
+}
+
+} // namespace vectorized
+} // namespace starrocks

--- a/be/src/exec/vectorized/olap_scan_prepare.h
+++ b/be/src/exec/vectorized/olap_scan_prepare.h
@@ -2,733 +2,81 @@
 
 #pragma once
 
-#include "column/const_column.h"
-#include "column/type_traits.h"
 #include "common/status.h"
 #include "exec/olap_common.h"
 #include "exprs/expr.h"
 #include "exprs/expr_context.h"
-#include "exprs/slot_ref.h"
-#include "exprs/vectorized/in_const_predicate.hpp"
-#include "exprs/vectorized/runtime_filter_bank.h"
-#include "gutil/map_util.h"
 
 namespace starrocks {
 namespace vectorized {
 
-namespace details {
+class RuntimeFilterProbeCollector;
+class PredicateParser;
+class ColumnPredicate;
 
-static bool ignore_cast(const SlotDescriptor& slot, const Expr& expr) {
-    if (slot.type().is_date_type() && expr.type().is_date_type()) {
-        return true;
-    }
-    return slot.type().is_string_type() && expr.type().is_string_type();
-}
-
-template <typename ValueType>
-static bool get_predicate_value(ObjectPool& obj_pool, const SlotDescriptor& slot, const Expr* expr, ExprContext* ctx,
-                                ValueType* value, SQLFilterOp* op, Status* status) {
-    if (expr->get_num_children() != 2) {
-        return false;
-    }
-
-    Expr* l = expr->get_child(0);
-    Expr* r = expr->get_child(1);
-
-    // 1. ensure |l| points to a slot ref and |r| points to a const expression.
-    bool reverse_op = false;
-    if (!r->is_constant()) {
-        reverse_op = true;
-        std::swap(l, r);
-    }
-
-    // TODO(zhuming): DATE column may be casted to double.
-    if (l->type().type != slot.type().type && !ignore_cast(slot, *l)) {
-        return false;
-    }
-
-    // when query on a `DATE` column with predicate, both the `DATE`
-    // column and the operand of predicate will be casted to timestamp.
-    if constexpr (std::is_same_v<ValueType, DateValue>) {
-        if (l->op() == TExprOpcode::CAST) {
-            l = l->get_child(0);
-        }
-    }
-
-    if ((l->node_type() != TExprNodeType::SLOT_REF) || !r->is_constant()) {
-        return false;
-    }
-
-    std::vector<SlotId> slot_ids;
-    if (l->get_slot_ids(&slot_ids) != 1 || slot_ids[0] != slot.id()) {
-        return false;
-    }
-
-    // 3. extract the const value from |r|.
-    ColumnPtr column_ptr = ctx->evaluate(r, nullptr);
-    if (column_ptr == nullptr) {
-        return false;
-    }
-
-    DCHECK_EQ(1u, column_ptr->size());
-    if (column_ptr->only_null() || column_ptr->is_null(0)) {
-        return false;
-    }
-
-    // check column type, as not all exprs return a const column.
-    ColumnPtr data = column_ptr;
-    if (column_ptr->is_nullable()) {
-        data = down_cast<NullableColumn*>(column_ptr.get())->data_column();
-    } else if (column_ptr->is_constant()) {
-        data = down_cast<ConstColumn*>(column_ptr.get())->data_column();
-    } else { // defensive check.
-        DCHECK(false) << "unreachable path: unknown column type of expr evaluate result";
-        return false;
-    }
-
-    if (expr->op() == TExprOpcode::EQ || expr->op() == TExprOpcode::NE) {
-        *op = to_olap_filter_type(expr->op(), false);
-    } else {
-        *op = to_olap_filter_type(expr->op(), reverse_op);
-    }
-
-    if constexpr (std::is_same_v<ValueType, DateValue>) {
-        if (data->is_timestamp()) {
-            TimestampValue ts = down_cast<TimestampColumn*>(data.get())->get(0).get_timestamp();
-            *value = implicit_cast<DateValue>(ts);
-            if (implicit_cast<TimestampValue>(*value) != ts) {
-                // |ts| has nonzero time, rewrite predicate.
-                switch (*op) {
-                case FILTER_LARGER_OR_EQUAL:
-                    // rewrite (c >= '2020-01-01 01:00:00') to (c > '2020-01-01').
-                    *op = FILTER_LARGER;
-                    break;
-                case FILTER_LESS:
-                    // rewrite (c < '2020-01-01 01:00:00') to (c <= '2020-01-01').
-                    *op = FILTER_LESS_OR_EQUAL;
-                    break;
-                case FILTER_LARGER:
-                    [[fallthrough]];
-                case FILTER_LESS_OR_EQUAL:
-                    // Just ignore the time value.
-                    break;
-                case FILTER_IN:
-                    *status = Status::EndOfFile("predicate for date always false");
-                    return false;
-                case FILTER_NOT_IN:
-                    // TODO(zhuming): Should be rewrote to `NOT NULL`.
-                    return false;
-                }
-            }
-        } else {
-            DCHECK(data->is_date());
-            *value = down_cast<DateColumn*>(data.get())->get(0).get_date();
-        }
-    } else if constexpr (std::is_same_v<ValueType, Slice>) {
-        // |column_ptr| will be released after this method return, have to ensure that
-        // the corresponding external storage will not be deallocated while the slice
-        // still been used.
-        const Slice* slice = reinterpret_cast<const Slice*>(data->raw_data());
-        std::string* str = obj_pool.add(new std::string(slice->data, slice->size));
-        *value = *str;
-    } else {
-        *value = *reinterpret_cast<const ValueType*>(data->raw_data());
-    }
-    return true;
-}
-
-template <PrimitiveType SlotType, typename RangeValueType>
-static void normalize_in_or_equal_predicate(const SlotDescriptor& slot, ObjectPool& obj_pool,
-                                            const std::vector<ExprContext*>& conjunct_ctxs,
-                                            std::vector<bool>& normalized_conjuncts,
-                                            ColumnValueRange<RangeValueType>* range, Status* status) {
-    for (size_t i = 0; i < conjunct_ctxs.size(); i++) {
-        if (normalized_conjuncts[i]) {
-            continue;
-        }
-
-        const Expr* root_expr = conjunct_ctxs[i]->root();
-
-        // 1. Normalize in conjuncts like 'where col in (v1, v2, v3)'
-        if (TExprOpcode::FILTER_IN == root_expr->op()) {
-            const Expr* l = root_expr->get_child(0);
-
-            if ((l->node_type() != TExprNodeType::SLOT_REF) ||
-                (l->type().type != slot.type().type && !ignore_cast(slot, *l))) {
-                continue;
-            }
-            std::vector<SlotId> slot_ids;
-            if (1 == l->get_slot_ids(&slot_ids) && slot_ids[0] == slot.id()) {
-                const auto* pred = down_cast<const VectorizedInConstPredicate<SlotType>*>(root_expr);
-                // join in runtime filter  will handle by `_normalize_join_runtime_filter`
-                if (pred->is_join_runtime_filter()) {
-                    continue;
-                }
-
-                if (pred->is_not_in() || pred->null_in_set() ||
-                    pred->hash_set().size() > config::max_pushdown_conditions_per_column) {
-                    continue;
-                }
-
-                std::set<RangeValueType> values;
-                for (const auto& value : pred->hash_set()) {
-                    values.insert(value);
-                }
-                if (range->add_fixed_values(FILTER_IN, values).ok()) {
-                    normalized_conjuncts[i] = true;
-                }
-            }
-        }
-
-        // 2. Normalize eq conjuncts like 'where col = value'
-        if (TExprNodeType::BINARY_PRED == root_expr->node_type() &&
-            FILTER_IN == to_olap_filter_type(root_expr->op(), false)) {
-            using ValueType = typename RunTimeTypeTraits<SlotType>::CppType;
-            SQLFilterOp op;
-            ValueType value;
-            bool ok = get_predicate_value(obj_pool, slot, root_expr, conjunct_ctxs[i], &value, &op, status);
-            if (ok && range->add_fixed_values(FILTER_IN, std::set<RangeValueType>{value}).ok()) {
-                normalized_conjuncts[i] = true;
-            }
-        }
-    }
-}
-
-// explicit specialization for DATE.
-template <>
-void normalize_in_or_equal_predicate<starrocks::TYPE_DATE, DateValue>(const SlotDescriptor& slot, ObjectPool& obj_pool,
-                                                                      const std::vector<ExprContext*>& conjunct_ctxs,
-                                                                      std::vector<bool>& normalized_conjuncts,
-                                                                      ColumnValueRange<DateValue>* range,
-                                                                      Status* status) {
-    for (size_t i = 0; i < conjunct_ctxs.size(); i++) {
-        if (normalized_conjuncts[i]) {
-            continue;
-        }
-
-        const Expr* root_expr = conjunct_ctxs[i]->root();
-
-        // 1. Normalize in conjuncts like 'where col in (v1, v2, v3)'
-        if (TExprOpcode::FILTER_IN == root_expr->op()) {
-            const Expr* l = root_expr->get_child(0);
-            // TODO(zhuming): DATE column may be casted to double.
-            if (l->type().type != starrocks::TYPE_DATE && l->type().type != starrocks::TYPE_DATETIME) {
-                continue;
-            }
-
-            PrimitiveType pred_type = l->type().type;
-            // ignore the cast on DATE.
-            if (l->op() == TExprOpcode::CAST) {
-                l = l->get_child(0);
-            }
-            if (l->node_type() != TExprNodeType::SLOT_REF) {
-                continue;
-            }
-            std::vector<SlotId> slot_ids;
-            if (1 == l->get_slot_ids(&slot_ids) && slot_ids[0] == slot.id()) {
-                std::set<DateValue> values;
-
-                if (pred_type == starrocks::TYPE_DATETIME) {
-                    const auto* pred =
-                            down_cast<const VectorizedInConstPredicate<starrocks::TYPE_DATETIME>*>(root_expr);
-                    // join in runtime filter  will handle by `_normalize_join_runtime_filter`
-                    if (pred->is_join_runtime_filter()) {
-                        continue;
-                    }
-
-                    if (pred->is_not_in() || pred->null_in_set() ||
-                        pred->hash_set().size() > config::max_pushdown_conditions_per_column) {
-                        continue;
-                    }
-
-                    for (const TimestampValue& ts : pred->hash_set()) {
-                        DateValue date = implicit_cast<DateValue>(ts);
-                        if (implicit_cast<TimestampValue>(date) == ts) {
-                            values.insert(date);
-                        }
-                    }
-                } else if (pred_type == starrocks::TYPE_DATE) {
-                    const auto* pred = down_cast<const VectorizedInConstPredicate<starrocks::TYPE_DATE>*>(root_expr);
-                    if (pred->is_not_in() || pred->null_in_set() ||
-                        pred->hash_set().size() > config::max_pushdown_conditions_per_column) {
-                        continue;
-                    }
-                    for (const DateValue& date : pred->hash_set()) {
-                        values.insert(date);
-                    }
-                }
-                if (values.empty()) {
-                    *status = Status::EndOfFile("const false predicate result");
-                    continue;
-                }
-                if (range->add_fixed_values(FILTER_IN, values).ok()) {
-                    normalized_conjuncts[i] = true;
-                }
-            }
-        }
-
-        // 2. Normalize eq conjuncts like 'where col = value'
-        if (TExprNodeType::BINARY_PRED == root_expr->node_type() &&
-            FILTER_IN == to_olap_filter_type(root_expr->op(), false)) {
-            SQLFilterOp op;
-            DateValue value{0};
-            bool ok = get_predicate_value(obj_pool, slot, root_expr, conjunct_ctxs[i], &value, &op, status);
-            if (ok && range->add_fixed_values(FILTER_IN, std::set<DateValue>{value}).ok()) {
-                normalized_conjuncts[i] = true;
-            }
-        }
-    }
-}
-
-template <PrimitiveType SlotType, typename RangeValueType>
-static void normalize_binary_predicate(const SlotDescriptor& slot, ObjectPool& obj_pool,
-                                       const std::vector<ExprContext*>& conjunct_ctxs,
-                                       std::vector<bool>& normalized_conjuncts, ColumnValueRange<RangeValueType>* range,
-                                       Status* status) {
-    DCHECK((SlotType == slot.type().type) || (SlotType == TYPE_VARCHAR && slot.type().type == TYPE_CHAR));
-    for (size_t i = 0; i < conjunct_ctxs.size(); i++) {
-        if (normalized_conjuncts[i]) {
-            continue;
-        }
-
-        Expr* root_expr = conjunct_ctxs[i]->root();
-        if (TExprNodeType::BINARY_PRED != root_expr->node_type()) {
-            continue;
-        }
-
-        using ValueType = typename vectorized::RunTimeTypeTraits<SlotType>::CppType;
-
-        SQLFilterOp op;
-        ValueType value;
-        bool ok = get_predicate_value(obj_pool, slot, root_expr, conjunct_ctxs[i], &value, &op, status);
-        if (ok && range->add_range(op, static_cast<RangeValueType>(value)).ok()) {
-            normalized_conjuncts[i] = true;
-        }
-    }
-}
-
-template <PrimitiveType SlotType, typename RangeValueType>
-static void normalize_join_runtime_filter(const SlotDescriptor& slot, const std::vector<ExprContext*>& conjunct_ctxs,
-                                          std::vector<bool>& normalized_conjuncts,
-                                          const RuntimeFilterProbeCollector& runtime_filters,
-                                          ColumnValueRange<RangeValueType>* range) {
-    // in runtime filter
-    for (size_t i = 0; i < conjunct_ctxs.size(); i++) {
-        if (normalized_conjuncts[i]) {
-            continue;
-        }
-
-        const Expr* root_expr = conjunct_ctxs[i]->root();
-        if (TExprOpcode::FILTER_IN == root_expr->op()) {
-            const Expr* l = root_expr->get_child(0);
-            if ((l->node_type() != TExprNodeType::SLOT_REF) ||
-                (l->type().type != slot.type().type && !ignore_cast(slot, *l))) {
-                continue;
-            }
-            std::vector<SlotId> slot_ids;
-            if (1 == l->get_slot_ids(&slot_ids) && slot_ids[0] == slot.id()) {
-                const auto* pred = down_cast<const VectorizedInConstPredicate<SlotType>*>(root_expr);
-
-                if (!pred->is_join_runtime_filter()) {
-                    continue;
-                }
-
-                // Ensure we don't compute this conjuncts again in olap scanner
-                normalized_conjuncts[i] = true;
-
-                if (pred->is_not_in() || pred->null_in_set() ||
-                    pred->hash_set().size() > config::max_pushdown_conditions_per_column) {
-                    continue;
-                }
-
-                std::set<RangeValueType> values;
-                for (const auto& value : pred->hash_set()) {
-                    values.insert(value);
-                }
-                range->add_fixed_values(FILTER_IN, values);
-            }
-        }
-    }
-
-    // bloom runtime filter
-    for (const auto it : runtime_filters.descriptors()) {
-        const RuntimeFilterProbeDescriptor* desc = it.second;
-        const JoinRuntimeFilter* rf = desc->runtime_filter();
-        using ValueType = typename vectorized::RunTimeTypeTraits<SlotType>::CppType;
-        SlotId slot_id;
-
-        // runtime filter existed and does not have null.
-        if (rf == nullptr || rf->has_null()) continue;
-        // probe expr is slot ref and slot id matches.
-        if (!desc->is_probe_slot_ref(&slot_id) || slot_id != slot.id()) continue;
-
-        const RuntimeBloomFilter<SlotType>* filter = down_cast<const RuntimeBloomFilter<SlotType>*>(rf);
-        // For some cases such as in bucket shuffle, some hash join node may not have any input chunk from right table.
-        // Runtime filter does not have any min/max values in this case.
-        if (!filter->has_min_max()) continue;
-        // If this column doesn't have other filter, we use join runtime filter
-        // to fast comput row range in storage engine
-        if (range->is_init_state()) {
-            range->set_index_filter_only(true);
-        }
-
-        SQLFilterOp min_op = to_olap_filter_type(TExprOpcode::GE, false);
-        ValueType min_value = filter->min_value();
-        range->add_range(min_op, static_cast<RangeValueType>(min_value));
-
-        SQLFilterOp max_op = to_olap_filter_type(TExprOpcode::LE, false);
-        ValueType max_value = filter->max_value();
-        range->add_range(max_op, static_cast<RangeValueType>(max_value));
-    }
-}
-
-template <PrimitiveType SlotType, typename RangeValueType>
-static void normalize_not_in_or_not_equal_predicate(const SlotDescriptor& slot, ObjectPool& obj_pool,
-                                                    const std::vector<ExprContext*>& conjunct_ctxs,
-                                                    std::vector<bool>& normalized_conjuncts,
-                                                    ColumnValueRange<RangeValueType>* range, Status* status) {
-    DCHECK((SlotType == slot.type().type) || (SlotType == TYPE_VARCHAR && slot.type().type == TYPE_CHAR));
-    // handle not equal.
-    for (size_t i = 0; i < conjunct_ctxs.size(); i++) {
-        if (normalized_conjuncts[i]) {
-            continue;
-        }
-        Expr* root_expr = conjunct_ctxs[i]->root();
-        if (root_expr->node_type() != TExprNodeType::BINARY_PRED) {
-            continue;
-        }
-        if (root_expr->op() != TExprOpcode::NE) {
-            continue;
-        }
-
-        using ValueType = typename vectorized::RunTimeTypeTraits<SlotType>::CppType;
-
-        SQLFilterOp op;
-        ValueType value;
-        bool ok = get_predicate_value(obj_pool, slot, root_expr, conjunct_ctxs[i], &value, &op, status);
-        if (ok && range->add_fixed_values(FILTER_NOT_IN, std::set<RangeValueType>{value}).ok()) {
-            normalized_conjuncts[i] = true;
-        }
-    }
-    // TODO(zhuming): handle not-in predicate.
-}
-
-static void normalize_is_null_predicate(const SlotDescriptor& slot, const std::vector<ExprContext*>& conjunct_ctxs,
-                                        std::vector<bool>& normalized_conjuncts,
-                                        std::vector<TCondition>& is_null_vector) {
-    for (size_t i = 0; i < conjunct_ctxs.size(); i++) {
-        if (normalized_conjuncts[i]) {
-            continue;
-        }
-        Expr* root_expr = conjunct_ctxs[i]->root();
-        if (TExprNodeType::FUNCTION_CALL == root_expr->node_type()) {
-            std::string is_null_str;
-            if (root_expr->is_null_scalar_function(is_null_str)) {
-                Expr* e = root_expr->get_child(0);
-                if (e->node_type() != TExprNodeType::SLOT_REF) {
-                    continue;
-                }
-                std::vector<SlotId> slot_ids;
-                if (1 != e->get_slot_ids(&slot_ids) || slot_ids[0] != slot.id()) {
-                    continue;
-                }
-                TCondition is_null;
-                is_null.column_name = slot.col_name();
-                is_null.condition_op = "is";
-                is_null.condition_values.push_back(is_null_str);
-                is_null_vector.push_back(is_null);
-                normalized_conjuncts[i] = true;
-            }
-        }
-    }
-}
-
-template <PrimitiveType SlotType, typename RangeType>
-static void normalize_predicate(const SlotDescriptor& slot, ObjectPool& obj_pool,
-                                const std::vector<ExprContext*>& conjunct_ctxs, std::vector<bool>& normalized_conjuncts,
-                                const RuntimeFilterProbeCollector& runtime_filters,
-                                std::vector<TCondition>& is_null_vector, ColumnValueRange<RangeType>* range,
-                                Status* status) {
-    normalize_in_or_equal_predicate<SlotType, RangeType>(slot, obj_pool, conjunct_ctxs, normalized_conjuncts, range,
-                                                         status);
-    normalize_binary_predicate<SlotType, RangeType>(slot, obj_pool, conjunct_ctxs, normalized_conjuncts, range, status);
-    normalize_not_in_or_not_equal_predicate<SlotType, RangeType>(slot, obj_pool, conjunct_ctxs, normalized_conjuncts,
-                                                                 range, status);
-    normalize_is_null_predicate(slot, conjunct_ctxs, normalized_conjuncts, is_null_vector);
-    // Must handle join runtime filter last
-    normalize_join_runtime_filter<SlotType, RangeType>(slot, conjunct_ctxs, normalized_conjuncts, runtime_filters,
-                                                       range);
-}
-
-static Status normalize_conjuncts(const std::vector<SlotDescriptor*>& slots, ObjectPool& obj_pool,
-                                  const std::vector<ExprContext*>& conjunct_ctxs,
-                                  std::vector<bool>& normalized_conjuncts,
-                                  const RuntimeFilterProbeCollector& runtime_filters,
-                                  std::vector<TCondition>& is_null_vector,
-                                  std::map<std::string, ColumnValueRangeType>& column_value_ranges, Status* status) {
-    // Note: _normalized_conjuncts size must be equal to _conjunct_ctxs size,
-    // but HashJoinNode will push down predicate to OlapScanNode's _conjunct_ctxs,
-    // So _conjunct_ctxs will change after OlapScanNode prepare,
-    // So we couldn't resize _normalized_conjuncts when OlapScanNode init or prepare
-    normalized_conjuncts.resize(conjunct_ctxs.size(), false);
-
-    // TODO(zhuming): if any of the normalized column range is empty, we can know that
-    // no row will be selected anymore and can return EOF directly.
-    for (auto& slot : slots) {
-        const std::string& col_name = slot->col_name();
-        PrimitiveType type = slot->type().type;
-        switch (type) {
-        case TYPE_TINYINT: {
-            // TYPE_TINYINT use int32_t to present
-            // because it's easy to be converted to string when building Olap fetch Query
-            using RangeType = ColumnValueRange<int32_t>;
-            RangeType full_range(col_name, type, std::numeric_limits<int8_t>::lowest(),
-                                 std::numeric_limits<int8_t>::max());
-            ColumnValueRangeType& v = LookupOrInsert(&column_value_ranges, col_name, full_range);
-            RangeType& range = boost::get<ColumnValueRange<int32_t>>(v);
-            normalize_predicate<TYPE_TINYINT, int32_t>(*slot, obj_pool, conjunct_ctxs, normalized_conjuncts,
-                                                       runtime_filters, is_null_vector, &range, status);
-            break;
-        }
-        case TYPE_BOOLEAN: {
-            // TYPE_BOOLEAN use int32_t to present
-            // because it's easy to be converted to string when building Olap fetch Query
-            using RangeType = ColumnValueRange<int32_t>;
-            RangeType full_range(col_name, type, 0, 1);
-            ColumnValueRangeType& v = LookupOrInsert(&column_value_ranges, col_name, full_range);
-            RangeType& range = boost::get<ColumnValueRange<int32_t>>(v);
-            normalize_predicate<TYPE_BOOLEAN, int32_t>(*slot, obj_pool, conjunct_ctxs, normalized_conjuncts,
-                                                       runtime_filters, is_null_vector, &range, status);
-            break;
-        }
-        case TYPE_SMALLINT: {
-            using RangeType = ColumnValueRange<int16_t>;
-            RangeType full_range(col_name, type, std::numeric_limits<int16_t>::lowest(),
-                                 std::numeric_limits<int16_t>::max());
-            ColumnValueRangeType& v = LookupOrInsert(&column_value_ranges, col_name, full_range);
-            RangeType& range = boost::get<ColumnValueRange<int16_t>>(v);
-            normalize_predicate<TYPE_SMALLINT, int16_t>(*slot, obj_pool, conjunct_ctxs, normalized_conjuncts,
-                                                        runtime_filters, is_null_vector, &range, status);
-            break;
-        }
-        case TYPE_INT: {
-            using RangeType = ColumnValueRange<int32_t>;
-            RangeType full_range(col_name, type, std::numeric_limits<int32_t>::lowest(),
-                                 std::numeric_limits<int32_t>::max());
-            ColumnValueRangeType& v = LookupOrInsert(&column_value_ranges, col_name, full_range);
-            RangeType& range = boost::get<ColumnValueRange<int32_t>>(v);
-            normalize_predicate<TYPE_INT, int32_t>(*slot, obj_pool, conjunct_ctxs, normalized_conjuncts,
-                                                   runtime_filters, is_null_vector, &range, status);
-            break;
-        }
-        case TYPE_BIGINT: {
-            using RangeType = ColumnValueRange<int64_t>;
-            RangeType full_range(col_name, type, std::numeric_limits<int64_t>::lowest(),
-                                 std::numeric_limits<int64_t>::max());
-            ColumnValueRangeType& v = LookupOrInsert(&column_value_ranges, col_name, full_range);
-            RangeType& range = boost::get<ColumnValueRange<int64_t>>(v);
-            normalize_predicate<TYPE_BIGINT, int64_t>(*slot, obj_pool, conjunct_ctxs, normalized_conjuncts,
-                                                      runtime_filters, is_null_vector, &range, status);
-            break;
-        }
-        case TYPE_LARGEINT: {
-            using RangeType = ColumnValueRange<int128_t>;
-            RangeType full_range(col_name, type, MIN_INT128, MAX_INT128);
-            ColumnValueRangeType& v = LookupOrInsert(&column_value_ranges, col_name, full_range);
-            RangeType& range = boost::get<ColumnValueRange<int128_t>>(v);
-            normalize_predicate<TYPE_LARGEINT, int128_t>(*slot, obj_pool, conjunct_ctxs, normalized_conjuncts,
-                                                         runtime_filters, is_null_vector, &range, status);
-            break;
-        }
-        case TYPE_CHAR:
-            // for a CHAR column, its `in` predicate will be represented as a
-            // `InConstPredicate<PrimitiveType::TYPE_VARCHAR>`, so here we mapping CHAR as VARCHAR.
-            [[fallthrough]];
-        case TYPE_VARCHAR: {
-            using RangeType = ColumnValueRange<Slice>;
-            static char min_char = 0x00;
-            static char max_char = (char)0xff;
-            RangeType full_range(col_name, type, Slice(&min_char, 0), Slice(&max_char, 1));
-            ColumnValueRangeType& v = LookupOrInsert(&column_value_ranges, col_name, full_range);
-            RangeType& range = boost::get<ColumnValueRange<Slice>>(v);
-            normalize_predicate<TYPE_VARCHAR, Slice>(*slot, obj_pool, conjunct_ctxs, normalized_conjuncts,
-                                                     runtime_filters, is_null_vector, &range, status);
-            break;
-        }
-        case TYPE_DATE: {
-            using RangeType = ColumnValueRange<DateValue>;
-            RangeType full_range(col_name, type, DateValue::MIN_DATE_VALUE, DateValue::MAX_DATE_VALUE);
-            ColumnValueRangeType& v = LookupOrInsert(&column_value_ranges, col_name, full_range);
-            RangeType& range = boost::get<ColumnValueRange<DateValue>>(v);
-            normalize_predicate<TYPE_DATE, DateValue>(*slot, obj_pool, conjunct_ctxs, normalized_conjuncts,
-                                                      runtime_filters, is_null_vector, &range, status);
-            break;
-        }
-        case TYPE_DATETIME: {
-            using RangeType = ColumnValueRange<TimestampValue>;
-            RangeType full_range(col_name, type, TimestampValue::MIN_TIMESTAMP_VALUE,
-                                 TimestampValue::MAX_TIMESTAMP_VALUE);
-            ColumnValueRangeType& v = LookupOrInsert(&column_value_ranges, col_name, full_range);
-            RangeType& range = boost::get<ColumnValueRange<TimestampValue>>(v);
-            normalize_predicate<TYPE_DATETIME, TimestampValue>(*slot, obj_pool, conjunct_ctxs, normalized_conjuncts,
-                                                               runtime_filters, is_null_vector, &range, status);
-            break;
-        }
-        case TYPE_DECIMALV2: {
-            using RangeType = ColumnValueRange<DecimalV2Value>;
-            RangeType full_range(col_name, type, DecimalV2Value::get_min_decimal(), DecimalV2Value::get_max_decimal());
-            ColumnValueRangeType& v = LookupOrInsert(&column_value_ranges, col_name, full_range);
-            RangeType& range = boost::get<ColumnValueRange<DecimalV2Value>>(v);
-            normalize_predicate<TYPE_DECIMALV2, DecimalV2Value>(*slot, obj_pool, conjunct_ctxs, normalized_conjuncts,
-                                                                runtime_filters, is_null_vector, &range, status);
-            break;
-        }
-        case TYPE_DECIMAL32: {
-            using DecimalValueType = int32_t;
-            using RangeType = ColumnValueRange<DecimalValueType>;
-            RangeType full_range(col_name, type, get_min_decimal<DecimalValueType>(),
-                                 get_max_decimal<DecimalValueType>());
-            full_range.set_precision(slot->type().precision);
-            full_range.set_scale(slot->type().scale);
-            ColumnValueRangeType& v = LookupOrInsert(&column_value_ranges, col_name, full_range);
-            RangeType& range = boost::get<RangeType>(v);
-            range.set_precision(slot->type().precision);
-            range.set_scale(slot->type().scale);
-            normalize_predicate<TYPE_DECIMAL32, DecimalValueType>(*slot, obj_pool, conjunct_ctxs, normalized_conjuncts,
-                                                                  runtime_filters, is_null_vector, &range, status);
-            break;
-        }
-        case TYPE_DECIMAL64: {
-            using DecimalValueType = int64_t;
-            using RangeType = ColumnValueRange<DecimalValueType>;
-            RangeType full_range(col_name, type, get_min_decimal<DecimalValueType>(),
-                                 get_max_decimal<DecimalValueType>());
-            full_range.set_precision(slot->type().precision);
-            full_range.set_scale(slot->type().scale);
-            ColumnValueRangeType& v = LookupOrInsert(&column_value_ranges, col_name, full_range);
-            RangeType& range = boost::get<RangeType>(v);
-            range.set_precision(slot->type().precision);
-            range.set_scale(slot->type().scale);
-            normalize_predicate<TYPE_DECIMAL64, DecimalValueType>(*slot, obj_pool, conjunct_ctxs, normalized_conjuncts,
-                                                                  runtime_filters, is_null_vector, &range, status);
-            break;
-        }
-        case TYPE_DECIMAL128: {
-            using DecimalValueType = int128_t;
-            using RangeType = ColumnValueRange<DecimalValueType>;
-            RangeType full_range(col_name, type, get_min_decimal<DecimalValueType>(),
-                                 get_max_decimal<DecimalValueType>());
-            full_range.set_precision(slot->type().precision);
-            full_range.set_scale(slot->type().scale);
-            ColumnValueRangeType& v = LookupOrInsert(&column_value_ranges, col_name, full_range);
-            RangeType& range = boost::get<RangeType>(v);
-            range.set_precision(slot->type().precision);
-            range.set_scale(slot->type().scale);
-            normalize_predicate<TYPE_DECIMAL128, DecimalValueType>(*slot, obj_pool, conjunct_ctxs, normalized_conjuncts,
-                                                                   runtime_filters, is_null_vector, &range, status);
-            break;
-        }
-        case INVALID_TYPE:
-        case TYPE_NULL:
-        case TYPE_FLOAT:
-        case TYPE_DOUBLE:
-        case TYPE_BINARY:
-        case TYPE_DECIMAL:
-        case TYPE_STRUCT:
-        case TYPE_ARRAY:
-        case TYPE_MAP:
-        case TYPE_HLL:
-        case TYPE_TIME:
-        case TYPE_OBJECT:
-        case TYPE_PERCENTILE:
-            break;
-        }
-    }
-    return Status::OK();
-}
-
-class ExtendScanKeyVisitor : public boost::static_visitor<Status> {
+class OlapScanConjunctsManager {
 public:
-    ExtendScanKeyVisitor(OlapScanKeys* scan_keys, int32_t max_scan_key_num)
-            : _scan_keys(scan_keys), _max_scan_key_num(max_scan_key_num) {}
-
-    template <class T>
-    Status operator()(T& v) {
-        return _scan_keys->extend_scan_key(v, _max_scan_key_num);
-    }
+    // fields from olap scan node
+    const std::vector<ExprContext*>* conjunct_ctxs_ptr;
+    const TupleDescriptor* tuple_desc;
+    ObjectPool* obj_pool;
+    const std::vector<std::string>* key_column_names;
+    const RuntimeFilterProbeCollector* runtime_filters;
 
 private:
-    OlapScanKeys* _scan_keys;
-    int32_t _max_scan_key_num;
-};
+    // fields generated by parsing conjunct ctxs.
+    // same size with |_conjunct_ctxs|, indicate which element has been normalized.
+    std::vector<bool> normalized_conjuncts;
+    std::map<std::string, ColumnValueRangeType> column_value_ranges; // from conjunct_ctxs
+    OlapScanKeys scan_keys;                                          // from _column_value_ranges
+    std::vector<TCondition> olap_filters;                            // from _column_value_ranges
+    std::vector<TCondition> is_null_vector;                          // from conjunct_ctxs
 
-class ToOlapFilterVisitor : public boost::static_visitor<std::string> {
 public:
-    template <class T, class P>
-    std::string operator()(T& v, P& v2) const {
-        return v.to_olap_filter(v2);
-    }
-};
+    static void eval_const_conjuncts(const std::vector<ExprContext*>& conjunct_ctxs, Status* status);
 
-static Status build_olap_filters(const std::map<std::string, ColumnValueRangeType>& column_value_ranges,
-                                 std::vector<TCondition>& olap_filter) {
-    olap_filter.clear();
+    void parse_to_column_predicates(PredicateParser* parser, std::vector<ColumnPredicate*>* preds);
 
-    for (auto iter : column_value_ranges) {
-        ToOlapFilterVisitor visitor;
-        boost::variant<std::list<TCondition>> filters;
-        boost::apply_visitor(visitor, iter.second, filters);
-
-        std::list<TCondition> new_filters = boost::get<std::list<TCondition>>(filters);
-        if (new_filters.empty()) {
-            continue;
+    Status get_key_ranges(std::vector<std::unique_ptr<OlapScanRange>>* key_ranges) {
+        Status st = scan_keys.get_key_range(key_ranges);
+        if (!st.ok()) return st;
+        if (key_ranges->empty()) {
+            key_ranges->emplace_back(new OlapScanRange());
         }
-
-        for (const auto& filter : new_filters) {
-            olap_filter.push_back(filter);
-        }
+        return st;
     }
 
-    return Status::OK();
-}
-
-// Try to convert the ranges predicates applied on key columns to in predicates to increase
-// the scan concurrency, i.e, the number of OlapScanners.
-// For example, if the original query is `select * from t where c0 between 1 and 3 and c1 between 12 and 13`,
-// where c0 is the first key column and c1 is the second key column, this routine will convert the predicates
-// to `where c0 in (1,2,3) and c1 in (12,13)`, which is equivalent to the following disjunctive predicates:
-// `where (c0=1 and c1=12)
-//     OR (c0=1 and c1=13)
-//     OR (c0=2 and c1=12)
-//     OR (c0=2 and c1=13)
-//     OR (c0=3 and c1=12)
-//     OR (c0=3 and c1=13)
-// `.
-// By doing so, we can then create six instances of OlapScanner and assign each one with one of the disjunctive
-// predicates and run the OlapScanners concurrently.
-static Status build_scan_key(const std::vector<std::string>& key_column_names,
-                             std::map<std::string, ColumnValueRangeType>& column_value_ranges, OlapScanKeys& scan_keys,
-                             bool no_limit, int32_t max_scan_key_num) {
-    int conditional_key_columns = 0;
-    scan_keys.set_is_convertible(no_limit);
-    for (const auto& key_column_name : key_column_names) {
-        if (column_value_ranges.count(key_column_name) == 0) {
-            break;
-        }
-        conditional_key_columns++;
-    }
-    if (conditional_key_columns > 1) {
-        for (int i = 0; i < conditional_key_columns && !scan_keys.has_range_value(); ++i) {
-            ExtendScanKeyVisitor visitor(&scan_keys, max_scan_key_num);
-            if (!boost::apply_visitor(visitor, column_value_ranges[key_column_names[i]]).ok()) {
-                break;
+    void get_not_push_down_conjuncts(std::vector<ExprContext*>* predicates) {
+        DCHECK_EQ(conjunct_ctxs_ptr->size(), normalized_conjuncts.size());
+        for (size_t i = 0; i < normalized_conjuncts.size(); i++) {
+            if (!normalized_conjuncts[i]) {
+                predicates->push_back(conjunct_ctxs_ptr->at(i));
             }
         }
     }
-    return Status::OK();
-}
 
-} // namespace details
+    Status normalize_conjuncts();
+    Status build_olap_filters();
+    Status build_scan_keys(bool no_limit, int32_t max_scan_key_num);
+
+private:
+    template <PrimitiveType SlotType, typename RangeValueType>
+    void normalize_predicate(const SlotDescriptor& slot, ColumnValueRange<RangeValueType>* range);
+
+    template <PrimitiveType SlotType, typename RangeValueType>
+    void normalize_in_or_equal_predicate(const SlotDescriptor& slot, ColumnValueRange<RangeValueType>* range);
+
+    template <PrimitiveType SlotType, typename RangeValueType>
+    void normalize_binary_predicate(const SlotDescriptor& slot, ColumnValueRange<RangeValueType>* range);
+
+    template <PrimitiveType SlotType, typename RangeValueType>
+    void normalize_join_runtime_filter(const SlotDescriptor& slot, ColumnValueRange<RangeValueType>* range);
+
+    template <PrimitiveType SlotType, typename RangeValueType>
+    void normalize_not_in_or_not_equal_predicate(const SlotDescriptor& slot, ColumnValueRange<RangeValueType>* range);
+
+    void normalize_is_null_predicate(const SlotDescriptor& slot);
+};
 
 } // namespace vectorized
 } // namespace starrocks

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -129,6 +129,7 @@ add_library(Olap STATIC
     vectorized/column_not_in_predicate.cpp
     vectorized/column_null_predicate.cpp
     vectorized/column_or_predicate.cpp
+    vectorized/column_expr_predicate.cpp
     vectorized/conjunctive_predicates.cpp
     vectorized/convert_helper.cpp
     vectorized/delete_predicates.cpp

--- a/be/src/storage/vectorized/column_expr_predicate.cpp
+++ b/be/src/storage/vectorized/column_expr_predicate.cpp
@@ -1,0 +1,110 @@
+
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#include "column/column_helper.h"
+#include "exprs/expr.h"
+#include "exprs/expr_context.h"
+#include "runtime/primitive_type.h"
+#include "storage/vectorized/column_predicate.h"
+
+namespace starrocks::vectorized {
+
+using starrocks::ExprContext;
+
+class ColumnExprPredicate : public ColumnPredicate {
+public:
+    ColumnExprPredicate(TypeInfoPtr type_info, ColumnId column_id, ExprContext* expr_ctx, SlotId slot_id)
+            : ColumnPredicate(type_info, column_id), _expr_ctx(expr_ctx), _slot_id(slot_id) {}
+    ~ColumnExprPredicate() override = default;
+
+    void evaluate(const Column* column, uint8_t* selection, uint16_t from, uint16_t to) const override {
+        Chunk chunk;
+        ColumnPtr column_ptr(const_cast<Column*>(column));
+        chunk.update_column(column_ptr, _slot_id);
+        ColumnPtr bits = _expr_ctx->evaluate(&chunk);
+
+        // deal with constant.
+        if (bits->is_constant()) {
+            uint8_t value = 0;
+            // if null, we don't select it.
+            if (!bits->has_null()) {
+                value = ColumnHelper::get_const_value<TYPE_BOOLEAN>(bits);
+            }
+            memcpy(selection + from, &value, (to - from));
+            return;
+        }
+
+        // deal with nullable.
+        if (bits->is_nullable()) {
+            NullableColumn* null_column = ColumnHelper::as_raw_column<NullableColumn>(bits);
+            uint8_t* null_value = null_column->null_column_data().data();
+            uint8_t* data_value = ColumnHelper::get_cpp_data<TYPE_BOOLEAN>(null_column->data_column());
+            for (uint16_t i = from; i < to; i++) {
+                selection[i] = (!null_value[i]) & (data_value[i]);
+            }
+            return;
+        }
+
+        // deal with non-nullable.
+        uint8_t* data_value = ColumnHelper::get_cpp_data<TYPE_BOOLEAN>(bits);
+        memcpy(selection + from, data_value, (to - from));
+        return;
+    }
+
+    void evaluate_and(const Column* column, uint8_t* sel, uint16_t from, uint16_t to) const override {
+        uint16_t size = to - from;
+        std::vector<uint8_t> tmp_sel(size);
+        uint8_t* tmp = tmp_sel.data();
+        evaluate(column, tmp, 0, size);
+        for (uint16_t i = 0; i < size; i++) {
+            sel[i + from] &= tmp[i];
+        }
+    }
+
+    void evaluate_or(const Column* column, uint8_t* sel, uint16_t from, uint16_t to) const override {
+        uint16_t size = to - from;
+        std::vector<uint8_t> tmp_sel(size);
+        uint8_t* tmp = tmp_sel.data();
+        evaluate(column, tmp, 0, size);
+        for (uint16_t i = 0; i < size; i++) {
+            sel[i + from] |= tmp[i];
+        }
+    }
+
+    bool zone_map_filter(const Datum& min, const Datum& max) const override {
+        // todo(yan): once expr supports is_monotonic.
+        return true;
+    }
+
+    Status seek_bitmap_dictionary(segment_v2::BitmapIndexIterator* iter, SparseRange* range) const override {
+        range->clear();
+        return Status::OK();
+    }
+
+    bool support_bloom_filter() const override { return false; }
+    PredicateType type() const override { return PredicateType::kExpr; }
+    bool can_vectorized() const override { return true; }
+
+    Status convert_to(const ColumnPredicate** output, const TypeInfoPtr& target_type_info,
+                      ObjectPool* obj_pool) const override {
+        // todo(yan): do we really need convert to.
+        return Status::NotSupported("ColumnExprPredicate does not support `convert_to`");
+    }
+
+    std::string debug_string() const override {
+        std::stringstream ss;
+        ss << "(ColumnExprPredicate: " << _expr_ctx->root()->debug_string() << ")";
+        return ss.str();
+    }
+
+private:
+    ExprContext* _expr_ctx;
+    SlotId _slot_id;
+};
+
+ColumnPredicate* new_column_expr_predicate(const TypeInfoPtr& type, ColumnId column_id, ExprContext* expr_ctx,
+                                           SlotId slot_id) {
+    return new ColumnExprPredicate(type, column_id, expr_ctx, slot_id);
+}
+
+} // namespace starrocks::vectorized

--- a/be/src/storage/vectorized/column_predicate.h
+++ b/be/src/storage/vectorized/column_predicate.h
@@ -23,6 +23,7 @@ namespace starrocks {
 class BloomFilter;
 class Slice;
 class ObjectPool;
+class ExprContext;
 } // namespace starrocks
 
 namespace starrocks::segment_v2 {
@@ -46,6 +47,7 @@ enum class PredicateType {
     kNotNull = 9,
     kAnd = 10,
     kOr = 11,
+    kExpr = 12,
 };
 
 template <typename T>
@@ -270,6 +272,7 @@ ColumnPredicate* new_column_in_predicate(const TypeInfoPtr& type, ColumnId id,
 ColumnPredicate* new_column_not_in_predicate(const TypeInfoPtr& type, ColumnId id,
                                              const std::vector<std::string>& operands);
 ColumnPredicate* new_column_null_predicate(const TypeInfoPtr& type, ColumnId, bool is_null);
+ColumnPredicate* new_column_expr_predicate(const TypeInfoPtr& type, ColumnId, ExprContext* expr_ctx, SlotId slot_id);
 
 template <FieldType field_type, template <FieldType> typename Predicate, typename NewColumnPredicateFunc>
 Status predicate_convert_to(Predicate<field_type> const& input_predicate,


### PR DESCRIPTION
Ref: #803 

In this pr, I do two things:
1. Refactor `olap_scan_prepare.h`.  I move some fields related to conjuncts out from `OlapScanNode`, and into another class `OlapScanConjunctsManager`. And in this class, we focus on parsing conjuncts and managing predicates etc.
2. Add class `ColumnExprPredicate`, which essentially is a proxy of `ExprContexr`, but with the interface of `ColumnPredicate`. 