### PR TITLE
[ISSUE-821] Decompose HashJoinNode into pipelines

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -67,6 +67,7 @@ set(EXEC_FILES
     vectorized/olap_scan_prepare.cpp
     vectorized/olap_meta_scanner.cpp
     vectorized/olap_meta_scan_node.cpp
+    vectorized/hash_joiner.cpp
     vectorized/hash_join_node.cpp
     vectorized/join_hash_map.cpp
     vectorized/topn_node.cpp
@@ -166,6 +167,8 @@ set(EXEC_FILES
     pipeline/assert_num_rows_operator.cpp
     pipeline/set/union_passthrough_operator.cpp
     pipeline/set/union_const_source_operator.cpp
+    pipeline/hashjoin/hash_join_build_operator.cpp
+    pipeline/hashjoin/hash_join_probe_operator.cpp
 )
 
 set(EXEC_FILES

--- a/be/src/exec/exec_node.h
+++ b/be/src/exec/exec_node.h
@@ -29,6 +29,7 @@
 
 #include "column/vectorized_fwd.h"
 #include "common/status.h"
+#include "exec/pipeline/operator.h"
 #include "exprs/vectorized/runtime_filter_bank.h"
 #include "gen_cpp/PlanNodes_types.h"
 #include "runtime/descriptors.h"
@@ -192,8 +193,7 @@ public:
     virtual void debug_string(int indentation_level, std::stringstream* out) const;
 
     // Convert old exec node tree to new pipeline
-    virtual std::vector<std::shared_ptr<pipeline::OperatorFactory>> decompose_to_pipeline(
-            pipeline::PipelineBuilderContext* context);
+    virtual pipeline::OpFactories decompose_to_pipeline(pipeline::PipelineBuilderContext* context);
 
     const std::vector<ExprContext*>& conjunct_ctxs() const { return _conjunct_ctxs; }
 

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -180,6 +180,7 @@ Status ExchangeSinkOperator::Channel::send_chunk_request(PTransmitChunkParams* p
     params->set_be_number(_parent->_be_number);
 
     params->set_eos(false);
+    // TODO (by satanson): eliminate redundant copy in broadcast scenarios
     TransmitChunkInfo info = {this->_channel_id, *params, _brpc_stub};
     _parent->_buffer->add_request(info);
 

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -172,13 +172,13 @@ Status ExchangeSinkOperator::Channel::send_one_chunk(const vectorized::Chunk* ch
 }
 
 Status ExchangeSinkOperator::Channel::send_chunk_request(PTransmitChunkParams* params, const butil::IOBuf& attachment) {
-    params->set_allocated_finst_id(&_finst_id);
+    params->mutable_finst_id()->CopyFrom(_finst_id);
     params->set_node_id(_dest_node_id);
     params->set_sender_id(_parent->_sender_id);
     params->set_be_number(_parent->_be_number);
 
     params->set_eos(false);
-    TransmitChunkInfo info = {std::move(*params), _brpc_stub};
+    TransmitChunkInfo info = {*params, _brpc_stub};
     _parent->_buffer->add_request(info);
 
     // The original design is bad, we must release_finst_id here!

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.h
@@ -135,14 +135,7 @@ public:
     ExchangeSinkOperatorFactory(int32_t id, int32_t plan_node_id, std::shared_ptr<SinkBuffer> buffer,
                                 TPartitionType::type part_type,
                                 const std::vector<TPlanFragmentDestination>& destinations, int sender_id,
-                                PlanNodeId dest_node_id, std::vector<ExprContext*> partition_expr_ctxs)
-            : OperatorFactory(id, "exchange_sink", plan_node_id),
-              _buffer(std::move(buffer)),
-              _part_type(part_type),
-              _destinations(destinations),
-              _sender_id(sender_id),
-              _dest_node_id(dest_node_id),
-              _partition_expr_ctxs(std::move(partition_expr_ctxs)) {}
+                                PlanNodeId dest_node_id, std::vector<ExprContext*> partition_expr_ctxs);
 
     ~ExchangeSinkOperatorFactory() override = default;
 

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -66,6 +66,8 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
     } else {
         _query_ctx->set_expire_seconds(300);
     }
+    // initialize query's deadline
+    _query_ctx->extend_lifetime();
 
     _fragment_ctx = _query_ctx->fragment_mgr()->get_or_register(fragment_instance_id);
     _fragment_ctx->set_query_id(query_id);

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -225,7 +225,8 @@ void FragmentExecutor::_convert_data_sink_to_operator(const TPlanFragmentExecPar
         _fragment_ctx->pipelines().back()->add_op_factory(op);
     } else if (typeid(*datasink) == typeid(starrocks::DataStreamSender)) {
         starrocks::DataStreamSender* sender = down_cast<starrocks::DataStreamSender*>(datasink);
-        std::shared_ptr<SinkBuffer> sink_buffer = std::make_shared<SinkBuffer>(sender->get_destinations_size());
+        auto dop = _fragment_ctx->pipelines().back()->source_operator_factory()->degree_of_parallelism();
+        std::shared_ptr<SinkBuffer> sink_buffer = std::make_shared<SinkBuffer>(sender->get_destinations_size(), dop);
 
         OpFactoryPtr exchange_sink = std::make_shared<ExchangeSinkOperatorFactory>(
                 context->next_operator_id(), -1, sink_buffer, sender->get_partition_type(), params.destinations,

--- a/be/src/exec/pipeline/hashjoin/hash_join_build_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/hash_join_build_operator.cpp
@@ -1,0 +1,45 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#include "exec/pipeline/hashjoin/hash_join_build_operator.h"
+
+namespace starrocks {
+namespace pipeline {
+
+HashJoinBuildOperator::HashJoinBuildOperator(int32_t id, const string& name, int32_t plan_node_id,
+                                             HashJoiner* hash_joiner)
+        : Operator(id, name, plan_node_id), _hash_joiner(hash_joiner) {}
+Status HashJoinBuildOperator::push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) {
+    return _hash_joiner->append_chunk_to_ht(state, chunk);
+}
+
+StatusOr<vectorized::ChunkPtr> HashJoinBuildOperator::pull_chunk(RuntimeState* state) {
+    const char* msg = "pull_chunk not supported in HashJoinBuildOperator";
+    CHECK(false) << msg;
+    return Status::NotSupported(msg);
+}
+
+void HashJoinBuildOperator::finish(RuntimeState* state) {
+    if (!_is_finished) {
+        _hash_joiner->build_ht(state);
+        _is_finished = true;
+    }
+}
+
+HashJoinBuildOperatorFactory::HashJoinBuildOperatorFactory(int32_t id, int32_t plan_node_id, HashJoiner* hash_joiner)
+        : OperatorFactory(id, "hash_join_build", plan_node_id), _hash_joiner(hash_joiner) {}
+
+Status HashJoinBuildOperatorFactory::prepare(RuntimeState* state, MemTracker* mem_tracker) {
+    RETURN_IF_ERROR(OperatorFactory::prepare(state, mem_tracker));
+    return _hash_joiner->prepare(state);
+}
+
+void HashJoinBuildOperatorFactory::close(RuntimeState* state) {
+    _hash_joiner->close(state);
+    OperatorFactory::close(state);
+}
+
+OperatorPtr HashJoinBuildOperatorFactory::create(int32_t degree_of_parallelism, int32_t driver_sequence) {
+    return std::make_shared<HashJoinBuildOperator>(_id, _name, _plan_node_id, _hash_joiner);
+}
+} // namespace pipeline
+} // namespace starrocks

--- a/be/src/exec/pipeline/hashjoin/hash_join_build_operator.h
+++ b/be/src/exec/pipeline/hashjoin/hash_join_build_operator.h
@@ -1,0 +1,50 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#pragma once
+#include "exec/pipeline/operator.h"
+#include "exec/pipeline/pipeline_fwd.h"
+#include "exec/vectorized/hash_joiner.h"
+#include "exprs/expr.h"
+#include "runtime/descriptors.h"
+#include "runtime/mem_tracker.h"
+
+namespace starrocks {
+namespace pipeline {
+using HashJoiner = starrocks::vectorized::HashJoiner;
+class HashJoinBuildOperator final : public Operator {
+public:
+    HashJoinBuildOperator(int32_t id, const string& name, int32_t plan_node_id, HashJoiner* hash_joiner);
+    ~HashJoinBuildOperator() = default;
+    Status prepare(RuntimeState* state) override { return Status::OK(); };
+    Status close(RuntimeState* state) override { return Status::OK(); };
+
+    bool has_output() const override {
+        CHECK(false) << "has_output not supported in HashJoinBuildOperator";
+        return false;
+    }
+
+    bool need_input() const override { return !is_finished(); }
+
+    bool is_finished() const override { return _is_finished; }
+
+    Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override;
+    StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
+    void finish(RuntimeState* state) override;
+
+private:
+    HashJoiner* _hash_joiner;
+    bool _is_finished = false;
+};
+class HashJoinBuildOperatorFactory final : public OperatorFactory {
+public:
+    HashJoinBuildOperatorFactory(int32_t id, int32_t plan_node_id, HashJoiner* hash_joiner);
+    ~HashJoinBuildOperatorFactory() = default;
+    Status prepare(RuntimeState* state, MemTracker* mem_tracker) override;
+    void close(RuntimeState* state) override;
+    OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override;
+
+private:
+    HashJoiner* _hash_joiner;
+};
+} // namespace pipeline
+} // namespace starrocks

--- a/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.cpp
@@ -17,7 +17,7 @@ bool HashJoinProbeOperator::need_input() const {
 }
 
 bool HashJoinProbeOperator::is_finished() const {
-    return _is_finished && _hash_joiner->is_done();
+    return _hash_joiner->is_done();
 }
 
 Status HashJoinProbeOperator::push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) {

--- a/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.cpp
@@ -1,0 +1,59 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#include "exec/pipeline/hashjoin/hash_join_probe_operator.h"
+
+namespace starrocks {
+namespace pipeline {
+HashJoinProbeOperator::HashJoinProbeOperator(int32_t id, const string& name, int32_t plan_node_id,
+                                             HashJoiner* hash_joiner)
+        : OperatorWithDependency(id, name, plan_node_id), _hash_joiner(hash_joiner) {}
+
+bool HashJoinProbeOperator::has_output() const {
+    return _hash_joiner->has_output();
+}
+
+bool HashJoinProbeOperator::need_input() const {
+    return _hash_joiner->need_input();
+}
+
+bool HashJoinProbeOperator::is_finished() const {
+    return _is_finished && _hash_joiner->is_done();
+}
+
+Status HashJoinProbeOperator::push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) {
+    _hash_joiner->push_chunk(state, std::move(const_cast<vectorized::ChunkPtr&>(chunk)));
+    return Status::OK();
+}
+
+StatusOr<vectorized::ChunkPtr> HashJoinProbeOperator::pull_chunk(RuntimeState* state) {
+    return _hash_joiner->pull_chunk(state);
+}
+
+void HashJoinProbeOperator::finish(RuntimeState* state) {
+    if (!_is_finished) {
+        _hash_joiner->enter_post_probe_phase();
+        _is_finished = true;
+    }
+}
+
+bool HashJoinProbeOperator::is_ready() const {
+    return _hash_joiner->is_build_done();
+}
+
+HashJoinProbeOperatorFactory::HashJoinProbeOperatorFactory(int32_t id, int32_t plan_node_id,
+                                                           std::unique_ptr<HashJoiner>&& hash_joiner)
+        : OperatorFactory(id, "hash_join_probe", plan_node_id), _hash_joiner(std::move(hash_joiner)) {}
+
+Status HashJoinProbeOperatorFactory::prepare(RuntimeState* state, MemTracker* mem_tracker) {
+    return OperatorFactory::prepare(state, mem_tracker);
+}
+void HashJoinProbeOperatorFactory::close(RuntimeState* state) {
+    OperatorFactory::close(state);
+}
+
+OperatorPtr HashJoinProbeOperatorFactory::create(int32_t degree_of_parallelism, int32_t driver_sequence) {
+    return std::make_shared<HashJoinProbeOperator>(_id, _name, _plan_node_id, _hash_joiner.get());
+}
+
+} // namespace pipeline
+} // namespace starrocks

--- a/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.h
+++ b/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.h
@@ -1,0 +1,49 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#pragma once
+
+#include "exec/pipeline/operator.h"
+#include "exec/pipeline/operator_with_dependency.h"
+#include "exec/pipeline/pipeline_fwd.h"
+#include "exec/vectorized/hash_joiner.h"
+namespace starrocks {
+namespace pipeline {
+using HashJoiner = starrocks::vectorized::HashJoiner;
+class HashJoinProbeOperator final : public OperatorWithDependency {
+public:
+    HashJoinProbeOperator(int32_t id, const string& name, int32_t plan_node_id, HashJoiner* hash_joiner);
+    ~HashJoinProbeOperator() = default;
+
+    Status prepare(RuntimeState* state) override { return OperatorWithDependency::prepare(state); }
+
+    Status close(RuntimeState* state) override { return OperatorWithDependency::close(state); }
+
+    bool has_output() const override;
+    bool need_input() const override;
+    bool is_finished() const override;
+    Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk);
+    StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state);
+    void finish(RuntimeState* state) override;
+    bool is_ready() const override;
+
+private:
+    HashJoiner* _hash_joiner;
+    bool _is_finished = false;
+};
+
+class HashJoinProbeOperatorFactory final : public OperatorFactory {
+public:
+    HashJoinProbeOperatorFactory(int32_t id, int32_t plan_node_id, std::unique_ptr<HashJoiner>&& hash_joiner);
+
+    ~HashJoinProbeOperatorFactory() = default;
+
+    Status prepare(RuntimeState* state, MemTracker* mem_tracker) override;
+    void close(RuntimeState* state) override;
+
+    OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override;
+
+private:
+    std::unique_ptr<HashJoiner> _hash_joiner;
+};
+} // namespace pipeline
+} // namespace starrocks

--- a/be/src/exec/pipeline/operator.h
+++ b/be/src/exec/pipeline/operator.h
@@ -58,7 +58,11 @@ public:
 
     RuntimeProfile* get_runtime_profile() const { return _runtime_profile.get(); }
 
-    std::string get_name() const { return _name + "_" + std::to_string(_id); }
+    std::string get_name() const {
+        std::stringstream ss;
+        ss << _name + "_" << this;
+        return ss.str();
+    }
 
 protected:
     int32_t _id = 0;

--- a/be/src/exec/pipeline/pipeline_driver_dispatcher.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_dispatcher.cpp
@@ -129,7 +129,12 @@ void GlobalDriverDispatcher::run() {
 }
 
 void GlobalDriverDispatcher::dispatch(DriverRawPtr driver) {
-    this->_driver_queue->put_back(driver);
+    if (driver->dependencies_block()) {
+        driver->set_driver_state(DriverState::DEPENDENCIES_BLOCK);
+        this->_blocked_driver_poller->add_blocked_driver(driver);
+    } else {
+        this->_driver_queue->put_back(driver);
+    }
 }
 
 void GlobalDriverDispatcher::report_exec_state(FragmentContext* fragment_ctx, const Status& status, bool done) {

--- a/be/src/exec/vectorized/hash_join_node.h
+++ b/be/src/exec/vectorized/hash_join_node.h
@@ -31,6 +31,7 @@ public:
     Status get_next(RuntimeState* state, RowBatch* row_batch, bool* eos) override;
     Status get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) override;
     Status close(RuntimeState* state) override;
+    pipeline::OpFactories decompose_to_pipeline(pipeline::PipelineBuilderContext* context) override;
 
 private:
     static bool _has_null(const ColumnPtr& column);
@@ -69,7 +70,9 @@ private:
     static std::string _get_join_type_str(TJoinOp::type join_type);
 
     friend ExecNode;
-
+    // _hash_join_node is used to construct HashJoiner, the reference is sound since
+    // it's only used in FragmentExecutor::prepare function.
+    const THashJoinNode& _hash_join_node;
     std::vector<ExprContext*> _probe_expr_ctxs;
     std::vector<ExprContext*> _build_expr_ctxs;
     std::vector<ExprContext*> _other_join_conjunct_ctxs;

--- a/be/src/exec/vectorized/hash_joiner.cpp
+++ b/be/src/exec/vectorized/hash_joiner.cpp
@@ -1,0 +1,495 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#include "exec/vectorized/hash_joiner.h"
+
+#include <runtime/runtime_state.h>
+
+#include <memory>
+
+#include "column/column_helper.h"
+#include "column/fixed_length_column.h"
+#include "column/vectorized_fwd.h"
+#include "exprs/expr.h"
+#include "exprs/vectorized/column_ref.h"
+#include "exprs/vectorized/in_const_predicate.hpp"
+#include "exprs/vectorized/runtime_filter_bank.h"
+#include "gutil/strings/substitute.h"
+#include "runtime/runtime_filter_worker.h"
+#include "simd/simd.h"
+#include "util/runtime_profile.h"
+namespace starrocks::vectorized {
+
+HashJoiner::HashJoiner(const THashJoinNode& hash_join_node, TPlanNodeId node_id, TPlanNodeType::type node_type,
+                       int64_t limit, std::vector<bool>&& is_null_safes, std::vector<ExprContext*>&& build_expr_ctxs,
+                       std::vector<ExprContext*>&& probe_expr_ctxs,
+                       std::vector<ExprContext*>&& other_join_conjunct_ctxs, std::vector<ExprContext*>&& conjunct_ctxs,
+                       const RowDescriptor& build_row_descriptor, const RowDescriptor& probe_row_descriptor,
+                       const RowDescriptor& row_descriptor)
+        : _join_type(hash_join_node.join_op),
+          _limit(limit),
+          _num_rows_returned(0),
+          _is_null_safes(is_null_safes),
+          _build_expr_ctxs(std::move(build_expr_ctxs)),
+          _probe_expr_ctxs(std::move(probe_expr_ctxs)),
+          _other_join_conjunct_ctxs(std::move(other_join_conjunct_ctxs)),
+          _conjunct_ctxs(std::move(conjunct_ctxs)),
+          _build_row_descriptor(build_row_descriptor),
+          _probe_row_descriptor(probe_row_descriptor),
+          _row_descriptor(row_descriptor) {
+    _is_push_down = hash_join_node.is_push_down;
+    if (_join_type == TJoinOp::LEFT_ANTI_JOIN && hash_join_node.is_rewritten_from_not_in) {
+        _join_type = TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN;
+    }
+
+    _build_runtime_filters_from_planner = false;
+    if (hash_join_node.__isset.build_runtime_filters_from_planner) {
+        _build_runtime_filters_from_planner = hash_join_node.build_runtime_filters_from_planner;
+    }
+
+    _expr_mem_tracker.reset(new MemTracker(-1, "Exprs", nullptr));
+
+    std::string name = strings::Substitute("$0 (id=$1)", print_plan_node_type(node_type), node_id);
+    _runtime_profile.reset(new RuntimeProfile(std::move(name)));
+    _runtime_profile->set_metadata(node_id);
+
+    if (hash_join_node.__isset.sql_join_predicates) {
+        _runtime_profile->add_info_string("JoinPredicates", hash_join_node.sql_join_predicates);
+    }
+    if (hash_join_node.__isset.sql_predicates) {
+        _runtime_profile->add_info_string("Predicates", hash_join_node.sql_predicates);
+    }
+}
+
+Status HashJoiner::prepare(RuntimeState* state) {
+    _build_timer = ADD_TIMER(_runtime_profile, "BuildTime");
+
+    _copy_right_table_chunk_timer = ADD_CHILD_TIMER(_runtime_profile, "1-CopyRightTableChunkTime", "BuildTime");
+    _build_ht_timer = ADD_CHILD_TIMER(_runtime_profile, "2-BuildHashTableTime", "BuildTime");
+    _build_push_down_expr_timer = ADD_CHILD_TIMER(_runtime_profile, "3-BuildPushDownExprTime", "BuildTime");
+    _build_conjunct_evaluate_timer = ADD_CHILD_TIMER(_runtime_profile, "4-BuildConjunctEvaluateTime", "BuildTime");
+
+    _probe_timer = ADD_TIMER(_runtime_profile, "ProbeTime");
+    _merge_input_chunk_timer = ADD_CHILD_TIMER(_runtime_profile, "1-MergeInputChunkTimer", "ProbeTime");
+    _search_ht_timer = ADD_CHILD_TIMER(_runtime_profile, "2-SearchHashTableTimer", "ProbeTime");
+    _output_build_column_timer = ADD_CHILD_TIMER(_runtime_profile, "3-OutputBuildColumnTimer", "ProbeTime");
+    _output_probe_column_timer = ADD_CHILD_TIMER(_runtime_profile, "4-OutputProbeColumnTimer", "ProbeTime");
+    _output_tuple_column_timer = ADD_CHILD_TIMER(_runtime_profile, "5-OutputTupleColumnTimer", "ProbeTime");
+    _probe_conjunct_evaluate_timer = ADD_CHILD_TIMER(_runtime_profile, "6-ProbeConjunctEvaluateTime", "ProbeTime");
+    _other_join_conjunct_evaluate_timer =
+            ADD_CHILD_TIMER(_runtime_profile, "7-OtherJoinConjunctEvaluateTime", "ProbeTime");
+    _where_conjunct_evaluate_timer = ADD_CHILD_TIMER(_runtime_profile, "8-WhereConjunctEvaluateTime", "ProbeTime");
+
+    _probe_rows_counter = ADD_COUNTER(_runtime_profile, "ProbeRows", TUnit::UNIT);
+    _build_rows_counter = ADD_COUNTER(_runtime_profile, "BuildRows", TUnit::UNIT);
+    _build_buckets_counter = ADD_COUNTER(_runtime_profile, "BuildBuckets", TUnit::UNIT);
+    _push_down_expr_num = ADD_COUNTER(_runtime_profile, "PushDownExprNum", TUnit::UNIT);
+    _avg_input_probe_chunk_size = ADD_COUNTER(_runtime_profile, "AvgInputProbeChunkSize", TUnit::UNIT);
+    _avg_output_chunk_size = ADD_COUNTER(_runtime_profile, "AvgOutputChunkSize", TUnit::UNIT);
+    _runtime_profile->add_info_string("JoinType", _get_join_type_str(_join_type));
+
+    RETURN_IF_ERROR(Expr::prepare(_build_expr_ctxs, state, _build_row_descriptor, _expr_mem_tracker.get()));
+    RETURN_IF_ERROR(Expr::prepare(_probe_expr_ctxs, state, _probe_row_descriptor, _expr_mem_tracker.get()));
+    RETURN_IF_ERROR(Expr::prepare(_other_join_conjunct_ctxs, state, _row_descriptor, _expr_mem_tracker.get()));
+    RETURN_IF_ERROR(Expr::prepare(_conjunct_ctxs, state, _row_descriptor, _expr_mem_tracker.get()));
+    RETURN_IF_ERROR(Expr::open(_build_expr_ctxs, state));
+    RETURN_IF_ERROR(Expr::open(_probe_expr_ctxs, state));
+    RETURN_IF_ERROR(Expr::open(_other_join_conjunct_ctxs, state));
+    RETURN_IF_ERROR(Expr::open(_conjunct_ctxs, state));
+
+    HashTableParam param;
+    _init_hash_table_param(&param);
+    _ht.create(param);
+
+    _probe_column_count = _ht.get_probe_column_count();
+    _build_column_count = _ht.get_build_column_count();
+
+    return Status::OK();
+}
+
+void HashJoiner::_init_hash_table_param(HashTableParam* param) {
+    param->with_other_conjunct = !_other_join_conjunct_ctxs.empty();
+    param->join_type = _join_type;
+    param->row_desc = &_row_descriptor;
+    param->mem_tracker = _expr_mem_tracker.get();
+    param->build_row_desc = &_build_row_descriptor;
+    param->probe_row_desc = &_probe_row_descriptor;
+    param->search_ht_timer = _search_ht_timer;
+    param->output_build_column_timer = _output_build_column_timer;
+    param->output_probe_column_timer = _output_probe_column_timer;
+    param->output_tuple_column_timer = _output_tuple_column_timer;
+
+    for (auto i = 0; i < _probe_expr_ctxs.size(); i++) {
+        param->join_keys.emplace_back(JoinKeyDesc{_probe_expr_ctxs[i]->root()->type().type, _is_null_safes[i]});
+    }
+}
+Status HashJoiner::append_chunk_to_ht(RuntimeState* state, const ChunkPtr& chunk) {
+    DCHECK(_phase == HashJoinPhase::BUILD);
+    if (!chunk || chunk->is_empty()) {
+        return Status::OK();
+    }
+    if (UNLIKELY(_ht.get_row_count() + chunk->num_rows() >= UINT32_MAX)) {
+        return Status::NotSupported(strings::Substitute("row count of right table in hash join > $0", UINT32_MAX));
+    }
+    {
+        // copy chunk of right table
+        SCOPED_TIMER(_copy_right_table_chunk_timer);
+        RETURN_IF_ERROR(_ht.append_chunk(state, chunk));
+    }
+    return Status::OK();
+}
+
+Status HashJoiner::build_ht(RuntimeState* state) {
+    DCHECK(_phase == HashJoinPhase::BUILD);
+    RETURN_IF_ERROR(_build(state));
+    COUNTER_SET(_build_rows_counter, static_cast<int64_t>(_ht.get_row_count()));
+    COUNTER_SET(_build_buckets_counter, static_cast<int64_t>(_ht.get_bucket_size()));
+    _phase = HashJoinPhase::PROBE;
+    _short_circuit_break();
+    return Status::OK();
+}
+
+bool HashJoiner::need_input() const {
+    // when _buffered_chunk accumulates several chunks to form into a large enough chunk, it is moved into
+    // _probe_chunk for probe operations.
+    return _phase == HashJoinPhase::PROBE && _probe_input_chunk == nullptr;
+}
+
+bool HashJoiner::has_output() const {
+    if (_phase == HashJoinPhase::BUILD) {
+        return false;
+    } else if (_phase == HashJoinPhase::PROBE) {
+        return _probe_input_chunk != nullptr;
+    } else if (_phase == HashJoinPhase::POST_PROBE) {
+        // Only RIGHT ANTI-JOIN, RIGHT SEMI-JOIN, FULL OUTER-JOIN has HashJoinPhase::POST_PROBE,
+        // in this phase, has_output() returns true until HashJoiner enters into HashJoinPhase::DONE.
+        return true;
+    } else if (_phase == HashJoinPhase::EOS) {
+        return _buffered_probe_output_chunk != nullptr || _buffered_result_chunk != nullptr;
+    } else {
+        return false;
+    }
+}
+
+void HashJoiner::push_chunk(RuntimeState* state, ChunkPtr&& chunk) {
+    DCHECK(chunk && !chunk->is_empty());
+    DCHECK(!_probe_input_chunk);
+    _merge_probe_input_chunk(state, std::move(chunk));
+    if (_probe_input_chunk) {
+        _ht_has_remain = true;
+        _prepare_key_columns();
+    }
+}
+
+StatusOr<ChunkPtr> HashJoiner::pull_chunk(RuntimeState* state) {
+    ChunkPtr chunk;
+    if (_phase == HashJoinPhase::PROBE || _phase == HashJoinPhase::POST_PROBE) {
+        auto&& maybe_chunk = _pull_probe_output_chunk(state);
+        if (UNLIKELY(!maybe_chunk.ok())) {
+            return std::move(maybe_chunk);
+        }
+        chunk = std::move(maybe_chunk.value());
+        if (chunk->is_empty()) {
+            return chunk;
+        }
+        _filter_probe_output_chunk(chunk);
+    } else if (_phase == HashJoinPhase::EOS) {
+        // after all joined chunk is generated, last _pilling_joined_chunk or _buffered_output_chunk
+        // may be non-empty and less than half
+        if (_buffered_probe_output_chunk) {
+            // _buffered_join_chunk should be filtered
+            chunk = std::move(_buffered_probe_output_chunk);
+            _filter_probe_output_chunk(chunk);
+        } else if (_buffered_result_chunk) {
+            return std::move(_buffered_result_chunk);
+        } else {
+            DCHECK(false);
+        }
+    } else {
+        DCHECK(false);
+    }
+
+    if (!chunk || chunk->is_empty()) {
+        return chunk;
+    }
+
+    auto num_rows = chunk->num_rows();
+    _num_rows_returned += num_rows;
+    if (_reached_limit()) {
+        chunk->set_num_rows(num_rows - (_num_rows_returned - _limit));
+        _num_rows_returned = _limit;
+        _phase = HashJoinPhase::EOS;
+        // _ht is useless in this point, so deallocate its memory.
+        _ht.close();
+        _buffered_probe_output_chunk = nullptr;
+        return std::move(chunk);
+    }
+    _merge_result_chunk(state, std::move(chunk));
+    if (_result_chunk) {
+        return std::move(_result_chunk);
+    } else {
+        return std::make_shared<Chunk>();
+    }
+}
+
+StatusOr<ChunkPtr> HashJoiner::_pull_probe_output_chunk(RuntimeState* state) {
+    DCHECK(_phase != HashJoinPhase::BUILD);
+    auto chunk = std::make_shared<Chunk>();
+    if (_phase == HashJoinPhase::PROBE) {
+        DCHECK(_ht_has_remain && _probe_input_chunk);
+        RETURN_IF_ERROR(_ht.probe(_key_columns, &_probe_input_chunk, &chunk, &_ht_has_remain));
+        if (!_ht_has_remain) {
+            _probe_input_chunk = nullptr;
+        }
+        _merge_probe_output_chunk(state, std::move(chunk));
+        if (_probe_output_chunk) {
+            return std::move(_probe_output_chunk);
+        }
+    }
+
+    if (_phase == HashJoinPhase::POST_PROBE) {
+        // check if _buffered_probe_chunk have rows, if so, then move it into _probe_chunk.
+        if (_buffered_probe_input_chunk && !_probe_input_chunk) {
+            _probe_input_chunk = std::move(_buffered_probe_input_chunk);
+            _ht_has_remain = true;
+            _prepare_key_columns();
+        }
+        // _probe_chunk has remain rows to be processed, so go on probing ht.
+        if (_probe_input_chunk) {
+            RETURN_IF_ERROR(_ht.probe(_key_columns, &_probe_input_chunk, &chunk, &_ht_has_remain));
+            if (!_ht_has_remain) {
+                _probe_input_chunk = nullptr;
+            }
+            _merge_probe_output_chunk(state, std::move(chunk));
+            if (_probe_output_chunk) {
+                return std::move(_probe_output_chunk);
+            }
+        }
+        // cached _buffered_probe_chunk and _probe_chunk have been exhausted, so now entries of ht should be processed
+        // for RIGHT ANTI-JOIN, RIGHT SEMI-JOIN, FULL OUTER-JOIN.
+        if (!_buffered_probe_input_chunk && !_probe_input_chunk) {
+            RETURN_IF_ERROR(_post_probe(state));
+            if (_probe_output_chunk) {
+                return std::move(_probe_output_chunk);
+            }
+        }
+    }
+
+    // process last less-than-half-sized _buffered_joined_chunk if it exists.
+    if (_phase == HashJoinPhase::EOS && _buffered_probe_output_chunk) {
+        DCHECK(!_probe_output_chunk);
+        return std::move(_buffered_probe_output_chunk);
+    }
+    return std::make_shared<Chunk>();
+}
+
+void HashJoiner::close(RuntimeState* state) {
+    if (!_is_closed) {
+        _ht.close();
+        Expr::close(_conjunct_ctxs, state);
+        Expr::close(_other_join_conjunct_ctxs, state);
+        Expr::close(_probe_expr_ctxs, state);
+        Expr::close(_build_expr_ctxs, state);
+        _is_closed = true;
+    }
+}
+
+bool HashJoiner::_has_null(const ColumnPtr& column) {
+    if (column->is_nullable()) {
+        const auto& null_column = ColumnHelper::as_raw_column<NullableColumn>(column)->null_column();
+        DCHECK_GT(null_column->size(), 0);
+        return null_column->contain_value(1, null_column->size(), 1);
+    }
+    return false;
+}
+
+Status HashJoiner::_build(RuntimeState* state) {
+    {
+        SCOPED_TIMER(_build_conjunct_evaluate_timer);
+        // Currently, in order to implement simplicity, HashJoiner uses BigChunk,
+        // Splice the Chunks from Scan on the right table into a big Chunk
+        // In some scenarios, such as when the left and right tables are selected incorrectly
+        // or when the large table is joined, the (BinaryColumn) in the Chunk exceeds the range of uint32_t,
+        // which will cause the output of wrong data.
+        // Currently, a defense needs to be added.
+        // After a better solution is available, the BigChunk mechanism can be removed.
+        if (_ht.get_build_chunk()->reach_capacity_limit()) {
+            return Status::InternalError("Total size of single column exceed the limit of hash join");
+        }
+
+        for (auto& _build_expr_ctx : _build_expr_ctxs) {
+            const TypeDescriptor& data_type = _build_expr_ctx->root()->type();
+            ColumnPtr column_ptr = _build_expr_ctx->evaluate(_ht.get_build_chunk().get());
+            if (column_ptr->is_nullable() && column_ptr->is_constant()) {
+                ColumnPtr column = ColumnHelper::create_column(data_type, true);
+                column->append_nulls(_ht.get_build_chunk()->num_rows());
+                _ht.get_key_columns().emplace_back(column);
+            } else if (column_ptr->is_constant()) {
+                auto* const_column = ColumnHelper::as_raw_column<ConstColumn>(column_ptr);
+                const_column->data_column()->assign(_ht.get_build_chunk()->num_rows(), 0);
+                _ht.get_key_columns().emplace_back(const_column->data_column());
+            } else {
+                _ht.get_key_columns().emplace_back(column_ptr);
+            }
+        }
+    }
+
+    {
+        SCOPED_TIMER(_build_ht_timer);
+        RETURN_IF_ERROR(_ht.build(state));
+    }
+
+    return Status::OK();
+}
+
+void HashJoiner::_calc_filter_for_other_conjunct(ChunkPtr* chunk, Column::Filter& filter, bool& filter_all,
+                                                 bool& hit_all) {
+    filter_all = false;
+    hit_all = false;
+    filter.assign((*chunk)->num_rows(), 1);
+
+    for (auto* ctx : _other_join_conjunct_ctxs) {
+        ColumnPtr column = ctx->evaluate((*chunk).get());
+        size_t true_count = ColumnHelper::count_true_with_notnull(column);
+
+        if (true_count == column->size()) {
+            // all hit, skip
+            continue;
+        } else if (0 == true_count) {
+            // all not hit, return
+            filter_all = true;
+            filter.assign((*chunk)->num_rows(), 0);
+            break;
+        } else {
+            bool all_zero = false;
+            ColumnHelper::merge_two_filters(column, &filter, &all_zero);
+            if (all_zero) {
+                filter_all = true;
+                break;
+            }
+        }
+    }
+
+    if (!filter_all) {
+        int zero_count = SIMD::count_zero(filter.data(), filter.size());
+        if (zero_count == 0) {
+            hit_all = true;
+        }
+    }
+}
+
+void HashJoiner::_process_row_for_other_conjunct(ChunkPtr* chunk, size_t start_column, size_t column_count,
+                                                 bool filter_all, bool hit_all, const Column::Filter& filter) {
+    if (filter_all) {
+        for (size_t i = start_column; i < start_column + column_count; i++) {
+            auto* null_column = ColumnHelper::as_raw_column<NullableColumn>((*chunk)->columns()[i]);
+            auto& null_data = null_column->mutable_null_column()->get_data();
+            for (size_t j = 0; j < (*chunk)->num_rows(); j++) {
+                null_data[j] = 1;
+                null_column->set_has_null(true);
+            }
+        }
+    } else {
+        if (hit_all) {
+            return;
+        }
+
+        for (size_t i = start_column; i < start_column + column_count; i++) {
+            auto* null_column = ColumnHelper::as_raw_column<NullableColumn>((*chunk)->columns()[i]);
+            auto& null_data = null_column->mutable_null_column()->get_data();
+            for (size_t j = 0; j < filter.size(); j++) {
+                if (filter[j] == 0) {
+                    null_data[j] = 1;
+                    null_column->set_has_null(true);
+                }
+            }
+        }
+    }
+}
+
+void HashJoiner::_process_outer_join_with_other_conjunct(ChunkPtr* chunk, size_t start_column, size_t column_count) {
+    bool filter_all = false;
+    bool hit_all = false;
+    Column::Filter filter;
+
+    _calc_filter_for_other_conjunct(chunk, filter, filter_all, hit_all);
+    _process_row_for_other_conjunct(chunk, start_column, column_count, filter_all, hit_all, filter);
+
+    _ht.remove_duplicate_index(&filter);
+    (*chunk)->filter(filter);
+}
+
+void HashJoiner::_process_semi_join_with_other_conjunct(ChunkPtr* chunk) {
+    bool filter_all = false;
+    bool hit_all = false;
+    Column::Filter filter;
+
+    _calc_filter_for_other_conjunct(chunk, filter, filter_all, hit_all);
+
+    _ht.remove_duplicate_index(&filter);
+    (*chunk)->filter(filter);
+}
+
+void HashJoiner::_process_right_anti_join_with_other_conjunct(ChunkPtr* chunk) {
+    bool filter_all = false;
+    bool hit_all = false;
+    Column::Filter filter;
+
+    _calc_filter_for_other_conjunct(chunk, filter, filter_all, hit_all);
+
+    _ht.remove_duplicate_index(&filter);
+    (*chunk)->set_num_rows(0);
+}
+
+void HashJoiner::_process_other_conjunct(ChunkPtr* chunk) {
+    switch (_join_type) {
+    case TJoinOp::LEFT_OUTER_JOIN:
+    case TJoinOp::FULL_OUTER_JOIN:
+        _process_outer_join_with_other_conjunct(chunk, _probe_column_count, _build_column_count);
+        break;
+    case TJoinOp::RIGHT_OUTER_JOIN:
+    case TJoinOp::LEFT_SEMI_JOIN:
+    case TJoinOp::LEFT_ANTI_JOIN:
+    case TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN:
+    case TJoinOp::RIGHT_SEMI_JOIN:
+        _process_semi_join_with_other_conjunct(chunk);
+        break;
+    case TJoinOp::RIGHT_ANTI_JOIN:
+        _process_right_anti_join_with_other_conjunct(chunk);
+        break;
+    default:
+        // the other join conjunct for inner join will be convert to other predicate
+        // so can't reach here
+        ExecNode::eval_conjuncts(_other_join_conjunct_ctxs, (*chunk).get());
+    }
+}
+
+std::string HashJoiner::_get_join_type_str(TJoinOp::type join_type) {
+    switch (join_type) {
+    case TJoinOp::INNER_JOIN:
+        return "InnerJoin";
+    case TJoinOp::LEFT_OUTER_JOIN:
+        return "LeftOuterJoin";
+    case TJoinOp::LEFT_SEMI_JOIN:
+        return "LeftSemiJoin";
+    case TJoinOp::RIGHT_OUTER_JOIN:
+        return "RightOuterJoin";
+    case TJoinOp::FULL_OUTER_JOIN:
+        return "FullOuterJoin";
+    case TJoinOp::CROSS_JOIN:
+        return "CrossJoin";
+    case TJoinOp::MERGE_JOIN:
+        return "MergeJoin";
+    case TJoinOp::RIGHT_SEMI_JOIN:
+        return "RightSemiJoin";
+    case TJoinOp::LEFT_ANTI_JOIN:
+        return "LeftAntiJoin";
+    case TJoinOp::RIGHT_ANTI_JOIN:
+        return "RightAntiJoin";
+    case TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN:
+        return "NullAwareLeftAntiJoin";
+    default:
+        return "";
+    }
+}
+
+} // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/hash_joiner.h
+++ b/be/src/exec/vectorized/hash_joiner.h
@@ -1,0 +1,269 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#pragma once
+
+#include "column/chunk.h"
+#include "column/fixed_length_column.h"
+#include "common/statusor.h"
+#include "exec/exec_node.h"
+#include "exec/vectorized/hash_join_node.h"
+#include "exec/vectorized/join_hash_map.h"
+#include "util/phmap/phmap.h"
+
+namespace starrocks {
+
+class ObjectPool;
+class TPlanNode;
+class DescriptorTbl;
+class RuntimeState;
+class ExprContext;
+
+namespace vectorized {
+class ColumnRef;
+class RuntimeFilterBuildDescriptor;
+
+// HashJoiner works in four consecutive phases, each phase has its own allowed operations.
+// 1.BUILD: building ht from right child is outstanding, and probe operations is disallowed. EOS from right child
+//   indicates that building ht should be finalized.
+// 2.PROBE: building ht is done, and probe operations can be conducted as chunks is pulled one by one from left child.
+//   EOS from left child indicates that PROBE phase is done.
+// 3.POST_PROBE: for RIGHT ANTI-JOIN, RIGHT SEMI-JOIN, FULL OUTER-JOIN, probe-missing/probe-hitting tuples should be
+//   processed.
+// 4.DONE: all input streams have been processed.
+//
+enum HashJoinPhase {
+    BUILD = 0,
+    PROBE = 1,
+    POST_PROBE = 2,
+    EOS = 3,
+};
+class HashJoiner {
+public:
+    HashJoiner(const THashJoinNode& hash_join_node, TPlanNodeId node_id, TPlanNodeType::type node_type, int64_t limit,
+               std::vector<bool>&& is_null_safes, std::vector<ExprContext*>&& build_expr_ctxs,
+               std::vector<ExprContext*>&& probe_expr_ctxs, std::vector<ExprContext*>&& other_join_conjunct_ctxs,
+               std::vector<ExprContext*>&& conjunct_ctxs, const RowDescriptor& build_row_descriptor,
+               const RowDescriptor& probe_row_descriptor, const RowDescriptor& row_descriptor);
+
+    ~HashJoiner() = default;
+    Status prepare(RuntimeState* state);
+    void close(RuntimeState* state);
+    bool need_input() const;
+    bool has_output() const;
+    bool is_build_done() const { return _phase != HashJoinPhase::BUILD; }
+    bool is_done() const {
+        return _phase == HashJoinPhase::EOS && _buffered_probe_output_chunk == nullptr &&
+               _buffered_result_chunk == nullptr;
+    }
+    void enter_post_probe_phase() {
+        if (_phase != HashJoinPhase::EOS) {
+            _phase = HashJoinPhase::POST_PROBE;
+        }
+    }
+    // build phase
+    Status append_chunk_to_ht(RuntimeState* state, const ChunkPtr& chunk);
+    Status build_ht(RuntimeState* state);
+    // probe phase
+    void push_chunk(RuntimeState* state, ChunkPtr&& chunk);
+    StatusOr<ChunkPtr> pull_chunk(RuntimeState* state);
+
+private:
+    static bool _has_null(const ColumnPtr& column);
+
+    StatusOr<ChunkPtr> _pull_probe_output_chunk(RuntimeState* state);
+
+    void _init_hash_table_param(HashTableParam* param);
+
+    bool _reached_limit() { return _limit != -1 && _num_rows_returned >= _limit; }
+    static void merge_chunk(RuntimeState* state, ChunkPtr& buffered_chunk, ChunkPtr& result_chunk, ChunkPtr&& chunk) {
+        const size_t half_vector_chunk_size = config::vector_chunk_size >> 1;
+        if (!chunk || chunk->is_empty()) {
+            return;
+        }
+        // try to pile chunk with buffered_chunk to form a large enough chunk.
+        if (!buffered_chunk) {
+            buffered_chunk = std::move(chunk);
+        } else if (buffered_chunk->num_rows() + chunk->num_rows() <= config::vector_chunk_size) {
+            buffered_chunk->append(*chunk, 0, chunk->num_rows());
+        } else if (chunk->num_rows() >= half_vector_chunk_size) {
+            result_chunk = std::move(chunk);
+        } else {
+            result_chunk = std::move(buffered_chunk);
+            buffered_chunk = std::move(chunk);
+        }
+        // _buffered_chunk is piled up to exceed half of vector_chunk_size, it's bigger enough so that it can be moved
+        // into result_chunk.
+        if (buffered_chunk && !result_chunk && buffered_chunk->num_rows() >= half_vector_chunk_size) {
+            result_chunk = std::move(buffered_chunk);
+        }
+    }
+
+    void _merge_probe_input_chunk(RuntimeState* state, ChunkPtr&& chunk) {
+        merge_chunk(state, _buffered_probe_input_chunk, _probe_input_chunk, std::move(chunk));
+    }
+
+    void _merge_probe_output_chunk(RuntimeState* state, ChunkPtr&& chunk) {
+        merge_chunk(state, _buffered_probe_output_chunk, _probe_output_chunk, std::move(chunk));
+    }
+
+    void _filter_probe_output_chunk(ChunkPtr& chunk) {
+        _process_other_conjunct(&chunk);
+        if (chunk && !chunk->is_empty()) {
+            ExecNode::eval_conjuncts(_conjunct_ctxs, chunk.get());
+        }
+    }
+
+    void _merge_result_chunk(RuntimeState* state, ChunkPtr&& chunk) {
+        merge_chunk(state, _buffered_result_chunk, _result_chunk, std::move(chunk));
+    }
+
+    void _prepare_key_columns() {
+        _key_columns.resize(0);
+        for (auto& probe_expr_ctx : _probe_expr_ctxs) {
+            ColumnPtr column_ptr = probe_expr_ctx->evaluate(_probe_input_chunk.get());
+            if (column_ptr->is_nullable() && column_ptr->is_constant()) {
+                ColumnPtr column = ColumnHelper::create_column(probe_expr_ctx->root()->type(), true);
+                column->append_nulls(_probe_input_chunk->num_rows());
+                _key_columns.emplace_back(column);
+            } else if (column_ptr->is_constant()) {
+                auto* const_column = ColumnHelper::as_raw_column<ConstColumn>(column_ptr);
+                const_column->data_column()->assign(_probe_input_chunk->num_rows(), 0);
+                _key_columns.emplace_back(const_column->data_column());
+            } else {
+                _key_columns.emplace_back(column_ptr);
+            }
+        }
+    }
+
+    bool _need_post_probe() const {
+        return _join_type == TJoinOp::RIGHT_OUTER_JOIN || _join_type == TJoinOp::RIGHT_ANTI_JOIN ||
+               _join_type == TJoinOp::FULL_OUTER_JOIN;
+    }
+
+    Status _post_probe(RuntimeState* state) {
+        DCHECK(_phase == HashJoinPhase::POST_PROBE);
+        if (!_need_post_probe()) {
+            _phase = HashJoinPhase::EOS;
+            _ht.close();
+            return Status::OK();
+        }
+        auto chunk = std::make_shared<Chunk>();
+        bool eos = false;
+        DCHECK(!_probe_output_chunk);
+        while (true) {
+            RETURN_IF_ERROR(_ht.probe_remain(&chunk, &eos));
+            _merge_probe_output_chunk(state, std::move(chunk));
+            if (eos) {
+                _phase = HashJoinPhase::EOS;
+                _ht.close();
+                return Status::OK();
+            }
+            if (_probe_output_chunk) {
+                return Status::OK();
+            }
+        }
+    }
+
+    void _short_circuit_break() {
+        // special cases of short-circuit break.
+        if (_ht.get_row_count() == 0 && (_join_type == TJoinOp::INNER_JOIN || _join_type == TJoinOp::LEFT_SEMI_JOIN)) {
+            _phase = HashJoinPhase::EOS;
+        }
+
+        if (_ht.get_row_count() > 0) {
+            if (_join_type == TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN && _ht.get_key_columns().size() == 1 &&
+                _has_null(_ht.get_key_columns()[0])) {
+                // The current implementation of HashTable will reserve a row for judging the end of the linked list.
+                // When performing expression calculations (such as cast string to int),
+                // it is possible that this reserved row will generate Null,
+                // so Column::has_null() cannot be used to judge whether there is Null in the right table.
+                // TODO: This reserved field will be removed in the implementation mechanism in the future.
+                // at that time, you can directly use Column::has_null() to judge
+                _phase = HashJoinPhase::EOS;
+            }
+        }
+    }
+
+    Status _build(RuntimeState* state);
+    Status _probe(RuntimeState* state, ScopedTimer<MonotonicStopWatch>& probe_timer, ChunkPtr* chunk, bool& eos);
+
+    void _calc_filter_for_other_conjunct(ChunkPtr* chunk, Column::Filter& filter, bool& filter_all, bool& hit_all);
+    static void _process_row_for_other_conjunct(ChunkPtr* chunk, size_t start_column, size_t column_count,
+                                                bool filter_all, bool hit_all, const Column::Filter& filter);
+
+    void _process_outer_join_with_other_conjunct(ChunkPtr* chunk, size_t start_column, size_t column_count);
+    void _process_semi_join_with_other_conjunct(ChunkPtr* chunk);
+    void _process_right_anti_join_with_other_conjunct(ChunkPtr* chunk);
+    void _process_other_conjunct(ChunkPtr* chunk);
+
+    static std::string _get_join_type_str(TJoinOp::type join_type);
+
+    TJoinOp::type _join_type = TJoinOp::INNER_JOIN;
+    const int64_t _limit; // -1: no limit
+    int64_t _num_rows_returned;
+    HashJoinPhase _phase = HashJoinPhase::BUILD;
+    std::shared_ptr<RuntimeProfile> _runtime_profile;
+    bool _is_closed = false;
+
+    ChunkPtr _buffered_probe_input_chunk;
+    ChunkPtr _probe_input_chunk;
+
+    ChunkPtr _buffered_probe_output_chunk;
+    ChunkPtr _probe_output_chunk;
+
+    ChunkPtr _buffered_result_chunk;
+    ChunkPtr _result_chunk;
+
+    std::vector<bool> _is_null_safes;
+    std::unique_ptr<MemTracker> _expr_mem_tracker;
+    std::vector<ExprContext*> _build_expr_ctxs;
+    std::vector<ExprContext*> _probe_expr_ctxs;
+    std::vector<ExprContext*> _other_join_conjunct_ctxs;
+    std::vector<ExprContext*> _conjunct_ctxs;
+    RowDescriptor _build_row_descriptor;
+    RowDescriptor _probe_row_descriptor;
+    RowDescriptor _row_descriptor;
+
+    std::list<ExprContext*> _runtime_in_filters;
+    std::list<RuntimeFilterBuildDescriptor*> _build_runtime_filters;
+    bool _build_runtime_filters_from_planner;
+
+    bool _is_push_down = false;
+
+    JoinHashTable _ht;
+
+    Columns _key_columns;
+    size_t _probe_column_count = 0;
+    size_t _build_column_count = 0;
+    size_t _probe_chunk_count = 0;
+    size_t _output_chunk_count = 0;
+
+    bool _eos = false;
+    // hash table doesn't have reserved data
+    bool _ht_has_remain = false;
+    // right table have not output data for right outer join/right semi join/right anti join/full outer join
+
+    RuntimeProfile::Counter* _build_timer = nullptr;
+    RuntimeProfile::Counter* _build_ht_timer = nullptr;
+    RuntimeProfile::Counter* _copy_right_table_chunk_timer = nullptr;
+    RuntimeProfile::Counter* _build_push_down_expr_timer = nullptr;
+    RuntimeProfile::Counter* _merge_input_chunk_timer = nullptr;
+    RuntimeProfile::Counter* _probe_timer = nullptr;
+    RuntimeProfile::Counter* _search_ht_timer = nullptr;
+    RuntimeProfile::Counter* _output_build_column_timer = nullptr;
+    RuntimeProfile::Counter* _output_probe_column_timer = nullptr;
+    RuntimeProfile::Counter* _output_tuple_column_timer = nullptr;
+    RuntimeProfile::Counter* _build_rows_counter = nullptr;
+    RuntimeProfile::Counter* _probe_rows_counter = nullptr;
+    RuntimeProfile::Counter* _build_buckets_counter = nullptr;
+    RuntimeProfile::Counter* _push_down_expr_num = nullptr;
+    RuntimeProfile::Counter* _avg_input_probe_chunk_size = nullptr;
+    RuntimeProfile::Counter* _avg_output_chunk_size = nullptr;
+    RuntimeProfile::Counter* _build_conjunct_evaluate_timer = nullptr;
+    RuntimeProfile::Counter* _probe_conjunct_evaluate_timer = nullptr;
+    RuntimeProfile::Counter* _other_join_conjunct_evaluate_timer = nullptr;
+    RuntimeProfile::Counter* _where_conjunct_evaluate_timer = nullptr;
+};
+
+} // namespace vectorized
+} // namespace starrocks

--- a/be/src/exprs/vectorized/runtime_filter_bank.h
+++ b/be/src/exprs/vectorized/runtime_filter_bank.h
@@ -68,6 +68,7 @@ public:
 
 private:
     friend class HashJoinNode;
+    friend class HashJoiner;
     int32_t _filter_id;
 
     ExprContext* _build_expr_ctx = nullptr;
@@ -108,6 +109,7 @@ public:
 
 private:
     friend class HashJoinNode;
+    friend class hashJoiner;
     int32_t _filter_id;
     ExprContext* _probe_expr_ctx = nullptr;
     std::atomic<const JoinRuntimeFilter*> _runtime_filter;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HashJoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HashJoinNode.java
@@ -520,4 +520,9 @@ public class HashJoinNode extends PlanNode {
             return description;
         }
     }
+
+    @Override
+    public boolean canUsePipeLine() {
+        return getChildren().stream().allMatch(PlanNode::canUsePipeLine);
+    }
 }


### PR DESCRIPTION
## Changes

HashJoinNode has two sub-tree as children, the right child is used to build ht, the left child is used to probe ht and generate output result, in pipeline engine, each pipeline consists of operators each of which only has at most one input stream and one output stream. so HashJoinNode is parted into two pipelines, one is for the right-side and contains HashJoinBuildOperator to build ht, the other is for the right side and contains HashJoinProbeOperator to probe the ht. and the latter depends on the former's full materialization, so the latter inherits from OperatorWithDependency and it will consume input stream until its' is_ready() function return true.

New optimization as follows:
1. probe output chunks is merged into a output chunk of more than half full, then it is filtered by conjucts.