### PR TITLE
Fix bug of meta incompatibility between starrocks-1.18 and starrocks-1.19

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MetaVersion.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MetaVersion.java
@@ -43,10 +43,10 @@ public class MetaVersion implements Writable {
     public void write(DataOutput out) throws IOException {
         JsonObject jsonObject = new JsonObject();
         jsonObject.addProperty(KEY_COMMUNITY_VERSION, communityVersion);
-        jsonObject.addProperty(KEY_STARROCKS_VERSION, starrocksVersion);
 
         // For rollback compatibility, save the starrocksVersion both to
         // KEY_STARROCKS_VERSION and KEY_DORISDB_VERSION
+        jsonObject.addProperty(KEY_STARROCKS_VERSION, starrocksVersion);
         jsonObject.addProperty(KEY_DORISDB_VERSION, starrocksVersion);
         Text.writeString(out, jsonObject.toString());
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MetaVersion.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MetaVersion.java
@@ -2,20 +2,24 @@
 
 package com.starrocks.catalog;
 
-import com.google.gson.annotations.SerializedName;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
-import com.starrocks.persist.gson.GsonUtils;
 
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 
 public class MetaVersion implements Writable {
+    private static final String KEY_COMMUNITY_VERSION = "communityVersion";
 
-    @SerializedName(value = "communityVersion")
+    // Before version 1.19, the json key for storing starrocksVersion is KEY_DORISDB_VERSION,
+    // and the later versions are KEY_STARROCKS_VERSION
+    private static final String KEY_STARROCKS_VERSION = "starrocksVersion";
+    private static final String KEY_DORISDB_VERSION = "dorisDBVersion";
+
     private int communityVersion;
-    @SerializedName(value = "starrocksVersion")
     private int starrocksVersion;
 
     public MetaVersion() {
@@ -37,12 +41,27 @@ public class MetaVersion implements Writable {
 
     @Override
     public void write(DataOutput out) throws IOException {
-        String jsonStr = GsonUtils.GSON.toJson(this);
-        Text.writeString(out, jsonStr);
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty(KEY_COMMUNITY_VERSION, communityVersion);
+        jsonObject.addProperty(KEY_STARROCKS_VERSION, starrocksVersion);
+
+        // For rollback compatibility, save the starrocksVersion both to
+        // KEY_STARROCKS_VERSION and KEY_DORISDB_VERSION
+        jsonObject.addProperty(KEY_DORISDB_VERSION, starrocksVersion);
+        Text.writeString(out, jsonObject.toString());
     }
 
     public static MetaVersion read(DataInput in) throws IOException {
         String json = Text.readString(in);
-        return GsonUtils.GSON.fromJson(json, MetaVersion.class);
+        JsonObject jsonObject = JsonParser.parseString(json).getAsJsonObject();
+        int communityVersion = jsonObject.getAsJsonPrimitive(KEY_COMMUNITY_VERSION).getAsInt();
+        int starrocksVersion;
+        // For compatibility, the json key before 1.19 version is KEY_DORISDB_VERSION
+        if (jsonObject.has(KEY_DORISDB_VERSION)) {
+            starrocksVersion = jsonObject.getAsJsonPrimitive(KEY_DORISDB_VERSION).getAsInt();
+        } else {
+            starrocksVersion = jsonObject.getAsJsonPrimitive(KEY_STARROCKS_VERSION).getAsInt();
+        }
+        return new MetaVersion(communityVersion, starrocksVersion);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MetaVersion.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MetaVersion.java
@@ -56,11 +56,11 @@ public class MetaVersion implements Writable {
         JsonObject jsonObject = JsonParser.parseString(json).getAsJsonObject();
         int communityVersion = jsonObject.getAsJsonPrimitive(KEY_COMMUNITY_VERSION).getAsInt();
         int starrocksVersion;
-        // For compatibility, the json key before 1.19 version is KEY_DORISDB_VERSION
-        if (jsonObject.has(KEY_DORISDB_VERSION)) {
-            starrocksVersion = jsonObject.getAsJsonPrimitive(KEY_DORISDB_VERSION).getAsInt();
-        } else {
+        if (jsonObject.has(KEY_STARROCKS_VERSION)) {
             starrocksVersion = jsonObject.getAsJsonPrimitive(KEY_STARROCKS_VERSION).getAsInt();
+        } else {
+            // For compatibility, the json key before 1.19 version is KEY_DORISDB_VERSION
+            starrocksVersion = jsonObject.getAsJsonPrimitive(KEY_DORISDB_VERSION).getAsInt();
         }
         return new MetaVersion(communityVersion, starrocksVersion);
     }


### PR DESCRIPTION
Fix #825 #824
Before starrocks-1.19, the meta key stored in json is dorisDBVersion. In the starrocks-1.19, the meta key changed to starrocksVersion. The upgrading is not compatible between starrocks-1.18 and starrocks-1.19. As a result, the upgrading will be crash. In this pull request, I change the logic. By double reading meta according to the two meta key, it can guarantee the meta can be read rightly in any case.