### PR TITLE
Improve create table performance by create partitions concurrently (#532)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -629,6 +629,10 @@ public class OlapTable extends Table {
         return partitionColumnNames;
     }
 
+    public void setDefaultDistributionInfo(DistributionInfo distributionInfo) {
+        defaultDistributionInfo = distributionInfo;
+    }
+
     public DistributionInfo getDefaultDistributionInfo() {
         return defaultDistributionInfo;
     }
@@ -804,6 +808,10 @@ public class OlapTable extends Table {
     // get all partitions' name except the temp partitions
     public Set<String> getPartitionNames() {
         return Sets.newHashSet(nameToPartition.keySet());
+    }
+
+    public Set<String> getBfColumns() {
+        return bfColumns;
     }
 
     public Set<String> getCopiedBfColumns() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Partition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Partition.java
@@ -298,6 +298,23 @@ public class Partition extends MetaObject implements Writable {
         return indices;
     }
 
+    public int getMaterializedIndicesCount(IndexExtState extState) {
+        switch (extState) {
+            case ALL:
+                return 1 + idToVisibleRollupIndex.size() + idToShadowIndex.size();
+            case VISIBLE:
+                return 1 + idToVisibleRollupIndex.size();
+            case SHADOW:
+                return idToVisibleRollupIndex.size();
+            default:
+                return 0;
+        }
+    }
+
+    public int getVisibleMaterializedIndicesCount() {
+        return getMaterializedIndicesCount(IndexExtState.VISIBLE);
+    }
+
     public long getDataSize() {
         long dataSize = 0;
         for (MaterializedIndex mIndex : getMaterializedIndices(IndexExtState.VISIBLE)) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/io/DeepCopy.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/io/DeepCopy.java
@@ -43,6 +43,8 @@ public class DeepCopy {
     // the param "c" is the implementation class of "dest".
     // And the "dest" class must has method "readFields(DataInput)"
     public static boolean copy(Writable orig, Writable dest, Class c) {
+        // Backup the current MetaContext before assigning a new one.
+        MetaContext oldContext = MetaContext.get();
         MetaContext metaContext = new MetaContext();
         metaContext.setMetaVersion(FeConstants.meta_version);
         metaContext.setStarRocksMetaVersion(FeConstants.starrocks_meta_version);
@@ -65,7 +67,12 @@ public class DeepCopy {
             LOG.warn("failed to copy object.", e);
             return false;
         } finally {
-            MetaContext.remove();
+            // Restore the old MetaContext.
+            if (oldContext != null) {
+                oldContext.setThreadLocalInfo();
+            } else {
+                MetaContext.remove();
+            }
         }
         return true;
     }


### PR DESCRIPTION
When creating a table with multiple partitions, if the average number of
replicas on each `BE` is greater than 500 and more than 3 `BE`s exist,
partitions will be created concurrently and AgentBatchTask will also be
sent to multiple BEs concurrently.

Benchmark result:
 On a cluster with 5 BE nodes, each with one SATA HDD, serial partition
 creation took more than 9 minutes, while by creating partitions in
 parallel, the time improved to less than 3 minutes.