### PR TITLE
Bugfix: retry when getting spark etl job status timeout

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/TimeoutException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/TimeoutException.java
@@ -1,0 +1,12 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+package com.starrocks.common;
+
+/**
+ * Exception for timeout, like Util.executeCommand
+ */
+public class TimeoutException extends UserException {
+    public TimeoutException(String msg) {
+        super(msg);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadManager.java
@@ -35,6 +35,7 @@ import com.starrocks.common.DataQualityException;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.LabelAlreadyUsedException;
 import com.starrocks.common.MetaNotFoundException;
+import com.starrocks.common.TimeoutException;
 import com.starrocks.common.UserException;
 import com.starrocks.common.io.Writable;
 import com.starrocks.common.util.LogBuilder;
@@ -326,6 +327,9 @@ public class LoadManager implements Writable {
                         job.cancelJobWithoutCheck(new FailMsg(FailMsg.CancelType.ETL_QUALITY_UNSATISFIED,
                                         DataQualityException.QUALITY_FAIL_MSG),
                                 true, true);
+                    } catch (TimeoutException e) {
+                        // timeout, retry next time
+                        LOG.warn("update load job etl status failed. job id: {}", job.getId(), e);
                     } catch (UserException e) {
                         LOG.warn("update load job etl status failed. job id: {}", job.getId(), e);
                         job.cancelJobWithoutCheck(new FailMsg(CancelType.ETL_RUN_FAIL, e.getMessage()), true, true);

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkEtlJobHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkEtlJobHandler.java
@@ -190,7 +190,7 @@ public class SparkEtlJobHandler {
     }
 
     public EtlStatus getEtlJobStatus(SparkLoadAppHandle handle, String appId, long loadJobId, String etlOutputPath,
-                                     SparkResource resource, BrokerDesc brokerDesc) throws LoadException {
+                                     SparkResource resource, BrokerDesc brokerDesc) throws UserException {
         EtlStatus status = new EtlStatus();
 
         Preconditions.checkState(appId != null && !appId.isEmpty());
@@ -272,7 +272,7 @@ public class SparkEtlJobHandler {
     }
 
     public void killEtlJob(SparkLoadAppHandle handle, String appId, long loadJobId, SparkResource resource)
-            throws LoadException {
+            throws UserException {
         if (resource.isYarnMaster()) {
             // The appId may be empty when the load job is in PENDING phase. This is because the appId is
             // parsed from the spark launcher process's output (spark launcher process submit job and then


### PR DESCRIPTION
#842 

Need to distinguish whether Util.executeCommand is timeout or failed.
If timeout, retry instead of cancelling the job.