### PR TITLE
Enhancement: share TabletSchema to reduce memory usage

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -806,7 +806,7 @@ void* TaskWorkerPool::_update_tablet_meta_worker_thread_callback(void* arg_this)
                     tablet->set_partition_id(tablet_meta_info.partition_id);
                     break;
                 case TTabletMetaType::INMEMORY:
-                    tablet->tablet_meta()->mutable_tablet_schema()->set_is_in_memory(tablet_meta_info.is_in_memory);
+                    CHECK(false) << "in-memory tablet not supported";
                     break;
                 }
             }

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -74,6 +74,7 @@ add_library(Olap STATIC
     tablet_meta.cpp
     tablet_meta_manager.cpp
     tablet_schema.cpp
+    tablet_schema_map.cpp
     tablet_updates.cpp
     txn_manager.cpp
     types.cpp

--- a/be/src/storage/snapshot_manager.cpp
+++ b/be/src/storage/snapshot_manager.cpp
@@ -163,8 +163,7 @@ Status SnapshotManager::convert_rowset_ids(const string& clone_dir, int64_t tabl
     // equal to tablet id in meta
     new_tablet_meta_pb.set_tablet_id(tablet_id);
     new_tablet_meta_pb.set_schema_hash(schema_hash);
-    TabletSchema tablet_schema;
-    tablet_schema.init_from_pb(new_tablet_meta_pb.schema());
+    TabletSchema tablet_schema(new_tablet_meta_pb.schema());
 
     std::unordered_map<Version, RowsetMetaPB*, HashOfVersion> rs_version_map;
     for (const auto& visible_rowset : cloned_tablet_meta_pb.rs_metas()) {

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -141,7 +141,7 @@ Status Tablet::revise_tablet_meta(const std::vector<RowsetMetaSharedPtr>& rowset
         generate_tablet_meta_copy_unlocked(new_tablet_meta);
         // Segment store the pointer of TabletSchema, so don't release the TabletSchema of old TabletMeta
         // Shared the pointer of TabletSchema to the new TabletMeta
-        new_tablet_meta->set_tablet_schema(_tablet_meta->mutable_tablet_schema());
+        new_tablet_meta->set_tablet_schema(_tablet_meta->tablet_schema_ptr());
 
         // delete versions from new local tablet_meta
         for (const Version& version : versions_to_delete) {

--- a/be/src/storage/tablet_meta.cpp
+++ b/be/src/storage/tablet_meta.cpp
@@ -27,9 +27,9 @@
 
 #include "gutil/strings/substitute.h"
 #include "storage/olap_common.h"
-#include "storage/olap_define.h"
 #include "storage/protobuf_file.h"
 #include "storage/tablet_meta_manager.h"
+#include "storage/tablet_schema_map.h"
 #include "storage/tablet_updates.h"
 #include "util/uid_util.h"
 #include "util/url_coding.h"
@@ -251,7 +251,7 @@ TabletMeta::TabletMeta(MemTracker* mem_tracker, int64_t table_id, int64_t partit
     tablet_meta_pb.set_partition_id(partition_id);
     tablet_meta_pb.set_tablet_id(tablet_id);
     tablet_meta_pb.set_schema_hash(schema_hash);
-    tablet_meta_pb.set_shard_id(shard_id);
+    tablet_meta_pb.set_shard_id((int32_t)shard_id);
     tablet_meta_pb.set_creation_time(time(nullptr));
     tablet_meta_pb.set_cumulative_layer_point(-1);
     tablet_meta_pb.set_tablet_state(PB_RUNNING);
@@ -259,6 +259,9 @@ TabletMeta::TabletMeta(MemTracker* mem_tracker, int64_t table_id, int64_t partit
     tablet_meta_pb.set_tablet_type(tabletType == TTabletType::TABLET_TYPE_MEMORY ? TabletTypePB::TABLET_TYPE_MEMORY
                                                                                  : TabletTypePB::TABLET_TYPE_DISK);
     TabletSchemaPB* schema = tablet_meta_pb.mutable_schema();
+    if (tablet_schema.__isset.schema_id) {
+        schema->set_id(tablet_schema.schema_id);
+    }
     schema->set_num_short_key_columns(tablet_schema.short_key_column_count);
     schema->set_num_rows_per_row_block(config::default_num_rows_per_column_file_block);
     switch (tablet_schema.keys_type) {
@@ -291,10 +294,10 @@ TabletMeta::TabletMeta(MemTracker* mem_tracker, int64_t table_id, int64_t partit
     bool has_bf_columns = false;
     for (TColumn tcolumn : tablet_schema.columns) {
         convert_to_new_version(&tcolumn);
-        uint32_t unique_id = col_ordinal_to_unique_id.at(col_ordinal++);
+        uint32_t col_unique_id = col_ordinal_to_unique_id.at(col_ordinal++);
         ColumnPB* column = schema->add_column();
 
-        TColumn2ColumnPB(unique_id, tcolumn, field_version, column);
+        TColumn2ColumnPB(col_unique_id, tcolumn, field_version, column);
 
         key_count += column->is_key();
         has_bf_columns |= column->is_bf_column();
@@ -449,9 +452,13 @@ void TabletMeta::init_from_pb(TabletMetaPB* ptablet_meta_pb) {
     }
 
     // init _schema
-    _schema = std::make_shared<TabletSchema>();
-    _schema->init_from_pb(tablet_meta_pb.schema());
-    _mem_tracker->consume(_schema->mem_usage());
+    if (tablet_meta_pb.schema().has_id() && tablet_meta_pb.schema().id() != TabletSchema::invalid_id()) {
+        // Does not collect the memory usage of |_schema|.
+        _schema = GlobalTabletSchemaMap::Instance()->emplace(tablet_meta_pb.schema()).first;
+    } else {
+        _schema = std::make_shared<const TabletSchema>(tablet_meta_pb.schema());
+        _mem_tracker->consume(_schema->mem_usage());
+    }
 
     // init _rs_metas
     for (auto& it : tablet_meta_pb.rs_metas()) {

--- a/be/src/storage/tablet_meta.cpp
+++ b/be/src/storage/tablet_meta.cpp
@@ -259,8 +259,8 @@ TabletMeta::TabletMeta(MemTracker* mem_tracker, int64_t table_id, int64_t partit
     tablet_meta_pb.set_tablet_type(tabletType == TTabletType::TABLET_TYPE_MEMORY ? TabletTypePB::TABLET_TYPE_MEMORY
                                                                                  : TabletTypePB::TABLET_TYPE_DISK);
     TabletSchemaPB* schema = tablet_meta_pb.mutable_schema();
-    if (tablet_schema.__isset.schema_id) {
-        schema->set_id(tablet_schema.schema_id);
+    if (tablet_schema.__isset.id) {
+        schema->set_id(tablet_schema.id);
     }
     schema->set_num_short_key_columns(tablet_schema.short_key_column_count);
     schema->set_num_rows_per_row_block(config::default_num_rows_per_column_file_block);

--- a/be/src/storage/tablet_meta.h
+++ b/be/src/storage/tablet_meta.h
@@ -164,15 +164,15 @@ public:
 
     inline const TabletSchema& tablet_schema() const;
 
-    inline void set_tablet_schema(const std::shared_ptr<TabletSchema>& tablet_schema) {
-        if (_schema != nullptr) {
+    inline void set_tablet_schema(const std::shared_ptr<const TabletSchema>& tablet_schema) {
+        if (_schema != nullptr && !_schema->shared()) {
             _mem_tracker->release(_schema->mem_usage());
         }
         _schema = tablet_schema;
-        _mem_tracker->consume(_schema->mem_usage());
+        _mem_tracker->consume(_schema->shared() ? 0 : _schema->mem_usage());
     }
 
-    inline std::shared_ptr<TabletSchema>& mutable_tablet_schema() { return _schema; }
+    inline std::shared_ptr<const TabletSchema>& tablet_schema_ptr() { return _schema; }
 
     inline const std::vector<RowsetMetaSharedPtr>& all_rs_metas() const;
     Status add_rs_meta(const RowsetMetaSharedPtr& rs_meta);
@@ -247,7 +247,7 @@ private:
     TabletState _tablet_state = TABLET_NOTREADY;
     // Note: Segment store the pointer of TabletSchema,
     // so this point should never change
-    std::shared_ptr<TabletSchema> _schema = nullptr;
+    std::shared_ptr<const TabletSchema> _schema = nullptr;
 
     std::vector<RowsetMetaSharedPtr> _rs_metas;
     std::vector<RowsetMetaSharedPtr> _inc_rs_metas;

--- a/be/src/storage/tablet_meta_manager.cpp
+++ b/be/src/storage/tablet_meta_manager.cpp
@@ -308,7 +308,7 @@ Status TabletMetaManager::get_json_meta(DataDir* store, TTabletId tablet_id, TSc
     TabletMetaSharedPtr tablet_meta(new TabletMeta(&mem_tracker));
     RETURN_IF_ERROR(get_tablet_meta(store, tablet_id, schema_hash, tablet_meta));
 
-    if (tablet_meta->mutable_tablet_schema()->keys_type() != PRIMARY_KEYS) {
+    if (tablet_meta->tablet_schema_ptr()->keys_type() != PRIMARY_KEYS) {
         json2pb::Pb2JsonOptions json_options;
         json_options.pretty_json = true;
         tablet_meta->to_json(json_meta, json_options);

--- a/be/src/storage/tablet_schema.cpp
+++ b/be/src/storage/tablet_schema.cpp
@@ -25,6 +25,7 @@
 #include <cctype>
 #include <vector>
 
+#include "storage/tablet_schema_map.h"
 #include "storage/vectorized/type_utils.h"
 
 namespace starrocks {
@@ -388,10 +389,20 @@ bool TabletColumn::is_format_v2_column() const {
     return TypeUtils::specific_type_of_format_v2(_type);
 }
 
+/******************************************************************
+ * TabletSchema
+ ******************************************************************/
+
+TabletSchema::~TabletSchema() {
+    if (_schema_map != nullptr) {
+        _schema_map->erase(_id);
+    }
+}
+
 void TabletSchema::init_from_pb(const TabletSchemaPB& schema) {
-    _keys_type = schema.keys_type();
+    _id = schema.has_id() ? schema.id() : invalid_id();
+    _keys_type = static_cast<uint8_t>(schema.keys_type());
     _num_key_columns = 0;
-    _num_null_columns = 0;
     _cols.clear();
     for (auto& column_pb : schema.column()) {
         TabletColumn column;
@@ -400,13 +411,10 @@ void TabletSchema::init_from_pb(const TabletSchemaPB& schema) {
         if (column.is_key()) {
             _num_key_columns++;
         }
-        if (column.is_nullable()) {
-            _num_null_columns++;
-        }
     }
     _num_short_key_columns = schema.num_short_key_columns();
     _num_rows_per_row_block = schema.num_rows_per_row_block();
-    _compress_kind = schema.compress_kind();
+    _compress_kind = static_cast<uint8_t>(schema.compress_kind());
     _next_column_unique_id = schema.next_column_unique_id();
     if (schema.has_bf_fpp()) {
         _has_bf_fpp = true;
@@ -415,23 +423,25 @@ void TabletSchema::init_from_pb(const TabletSchemaPB& schema) {
         _has_bf_fpp = false;
         _bf_fpp = BLOOM_FILTER_DEFAULT_FPP;
     }
-    _is_in_memory = schema.is_in_memory();
+    DCHECK(!schema.is_in_memory()) << "in-memory tablet not supported";
 }
 
-void TabletSchema::to_schema_pb(TabletSchemaPB* tablet_meta_pb) const {
-    tablet_meta_pb->set_keys_type(_keys_type);
+void TabletSchema::to_schema_pb(TabletSchemaPB* tablet_schema_pb) const {
+    if (_id != invalid_id()) {
+        tablet_schema_pb->set_id(_id);
+    }
+    tablet_schema_pb->set_keys_type(static_cast<KeysType>(_keys_type));
     for (auto& col : _cols) {
-        ColumnPB* column = tablet_meta_pb->add_column();
+        ColumnPB* column = tablet_schema_pb->add_column();
         col.to_schema_pb(column);
     }
-    tablet_meta_pb->set_num_short_key_columns(_num_short_key_columns);
-    tablet_meta_pb->set_num_rows_per_row_block(_num_rows_per_row_block);
-    tablet_meta_pb->set_compress_kind(_compress_kind);
+    tablet_schema_pb->set_num_short_key_columns(_num_short_key_columns);
+    tablet_schema_pb->set_num_rows_per_row_block(_num_rows_per_row_block);
+    tablet_schema_pb->set_compress_kind(static_cast<CompressKind>(_compress_kind));
     if (_has_bf_fpp) {
-        tablet_meta_pb->set_bf_fpp(_bf_fpp);
+        tablet_schema_pb->set_bf_fpp(_bf_fpp);
     }
-    tablet_meta_pb->set_next_column_unique_id(_next_column_unique_id);
-    tablet_meta_pb->set_is_in_memory(_is_in_memory);
+    tablet_schema_pb->set_next_column_unique_id(_next_column_unique_id);
 }
 
 bool TabletSchema::contains_format_v1_column() const {
@@ -460,8 +470,7 @@ std::unique_ptr<TabletSchema> TabletSchema::convert_to_format(DataFormatVersion 
             col_pb->set_index_length(type_info->size());
         }
     }
-    auto schema = std::make_unique<TabletSchema>();
-    schema->init_from_pb(schema_pb);
+    auto schema = std::make_unique<TabletSchema>(schema_pb);
     return schema;
 }
 
@@ -531,7 +540,6 @@ bool operator==(const TabletSchema& a, const TabletSchema& b) {
         if (a._cols[i] != b._cols[i]) return false;
     }
     if (a._num_key_columns != b._num_key_columns) return false;
-    if (a._num_null_columns != b._num_null_columns) return false;
     if (a._num_short_key_columns != b._num_short_key_columns) return false;
     if (a._num_rows_per_row_block != b._num_rows_per_row_block) return false;
     if (a._compress_kind != b._compress_kind) return false;
@@ -540,7 +548,6 @@ bool operator==(const TabletSchema& a, const TabletSchema& b) {
     if (a._has_bf_fpp) {
         if (std::abs(a._bf_fpp - b._bf_fpp) > 1e-6) return false;
     }
-    if (a._is_in_memory != b._is_in_memory) return false;
     return true;
 }
 
@@ -570,10 +577,9 @@ std::string TabletSchema::debug_string() const {
         ss << _cols[i].debug_string();
     }
     ss << "],keys_type=" << _keys_type << ",num_columns=" << num_columns() << ",num_key_columns=" << _num_key_columns
-       << ",num_null_columns=" << _num_null_columns << ",num_short_key_columns=" << _num_short_key_columns
-       << ",num_rows_per_row_block=" << _num_rows_per_row_block << ",compress_kind=" << _compress_kind
-       << ",next_column_unique_id=" << _next_column_unique_id << ",has_bf_fpp=" << _has_bf_fpp << ",bf_fpp=" << _bf_fpp
-       << ",is_in_memory=" << _is_in_memory;
+       << ",num_short_key_columns=" << _num_short_key_columns << ",num_rows_per_row_block=" << _num_rows_per_row_block
+       << ",compress_kind=" << _compress_kind << ",next_column_unique_id=" << _next_column_unique_id
+       << ",has_bf_fpp=" << _has_bf_fpp << ",bf_fpp=" << _bf_fpp;
     return ss.str();
 }
 

--- a/be/src/storage/tablet_schema.h
+++ b/be/src/storage/tablet_schema.h
@@ -35,6 +35,8 @@
 
 namespace starrocks {
 
+class TabletSchemaMap;
+
 namespace segment_v2 {
 class SegmentReaderWriterTest;
 class SegmentReaderWriterTest_estimate_segment_size_Test;
@@ -206,9 +208,26 @@ bool operator!=(const TabletColumn& a, const TabletColumn& b);
 
 class TabletSchema {
 public:
+    using SchemaId = int64_t;
+
+    // Must be consistent with MaterializedIndexMeta.INVALID_SCHEMA_ID defined in
+    // file ./fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndexMeta.java
+    constexpr static SchemaId invalid_id() { return 0; }
+
     TabletSchema() = default;
+    explicit TabletSchema(const TabletSchemaPB& schema_pb) { init_from_pb(schema_pb); }
+    // Does NOT take ownership of |schema_map| and |schema_map| must outlive TabletSchema.
+    TabletSchema(const TabletSchemaPB& schema_pb, TabletSchemaMap* schema_map) : _schema_map(schema_map) {
+        init_from_pb(schema_pb);
+    }
+
+    ~TabletSchema();
+
     void init_from_pb(const TabletSchemaPB& schema);
     void to_schema_pb(TabletSchemaPB* tablet_meta_pb) const;
+
+    // Caller should always check the returned value with `invalid_id()`.
+    SchemaId id() const { return _id; }
     size_t row_size() const;
     size_t field_index(const std::string& field_name) const;
     const TabletColumn& column(size_t ordinal) const;
@@ -217,11 +236,10 @@ public:
     size_t num_key_columns() const { return _num_key_columns; }
     size_t num_short_key_columns() const { return _num_short_key_columns; }
     size_t num_rows_per_row_block() const { return _num_rows_per_row_block; }
-    KeysType keys_type() const { return _keys_type; }
-    CompressKind compress_kind() const { return _compress_kind; }
+    KeysType keys_type() const { return static_cast<KeysType>(_keys_type); }
+    CompressKind compress_kind() const { return static_cast<CompressKind>(_compress_kind); }
     size_t next_column_unique_id() const { return _next_column_unique_id; }
-    bool is_in_memory() const { return _is_in_memory; }
-    void set_is_in_memory(bool is_in_memory) { _is_in_memory = is_in_memory; }
+    bool is_in_memory() const { return false; }
 
     bool contains_format_v1_column() const;
     bool contains_format_v2_column() const;
@@ -238,6 +256,8 @@ public:
         return mem_usage;
     }
 
+    bool shared() const { return _schema_map != nullptr; }
+
 private:
     friend class segment_v2::SegmentReaderWriterTest;
     FRIEND_TEST(segment_v2::SegmentReaderWriterTest, estimate_segment_size);
@@ -246,21 +266,23 @@ private:
     friend bool operator==(const TabletSchema& a, const TabletSchema& b);
     friend bool operator!=(const TabletSchema& a, const TabletSchema& b);
 
+    SchemaId _id = invalid_id();
+    TabletSchemaMap* _schema_map = nullptr;
+
     double _bf_fpp = 0;
 
     std::vector<TabletColumn> _cols;
     size_t _num_rows_per_row_block = 0;
     size_t _next_column_unique_id = 0;
 
-    CompressKind _compress_kind = COMPRESS_NONE;
-    KeysType _keys_type = DUP_KEYS;
-
     uint16_t _num_key_columns = 0;
-    uint16_t _num_null_columns = 0;
     uint16_t _num_short_key_columns = 0;
 
+    // Using `uint8_t` instead of `CompressKind` and `KeysType` for less memory usage.
+    uint8_t _compress_kind = static_cast<uint8_t>(COMPRESS_NONE);
+    uint8_t _keys_type = static_cast<uint8_t>(DUP_KEYS);
+
     bool _has_bf_fpp = false;
-    bool _is_in_memory = false;
 };
 
 bool operator==(const TabletSchema& a, const TabletSchema& b);

--- a/be/src/storage/tablet_schema_map.cpp
+++ b/be/src/storage/tablet_schema_map.cpp
@@ -1,0 +1,70 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#include "storage/tablet_schema_map.h"
+
+#include <bvar/bvar.h>
+
+namespace starrocks {
+
+static void get_stats(std::ostream& os, void*) {
+    TabletSchemaMap::Stats stats = GlobalTabletSchemaMap::Instance()->stats();
+    os << stats.num_items << "/" << stats.memory_usage << "/" << stats.saved_memory_usage;
+}
+
+// NOLINTNEXTLINE
+bvar::PassiveStatus<std::string> g_schema_map_stats("tablet_schema_map", get_stats, NULL);
+
+std::pair<TabletSchemaMap::TabletSchemaPtr, bool> TabletSchemaMap::emplace(const TabletSchemaPB& arg) {
+    SchemaId id = arg.id();
+    DCHECK_NE(TabletSchema::invalid_id(), id);
+    MapShard* shard = get_shard(id);
+    std::unique_lock l(shard->mtx);
+
+    auto it = shard->map.find(id);
+    if (it == shard->map.end()) {
+        auto ptr = std::make_shared<const TabletSchema>(arg, this);
+        shard->map.emplace(id, ptr);
+        return std::make_pair(ptr, true);
+    } else {
+        std::shared_ptr<const TabletSchema> ptr = it->second.lock();
+        if (UNLIKELY(!ptr)) {
+            ptr = std::make_shared<const TabletSchema>(arg, this);
+            it->second = std::weak_ptr<const TabletSchema>(ptr);
+            return std::make_pair(ptr, true);
+        } else {
+            return std::make_pair(ptr, false);
+        }
+    }
+}
+
+size_t TabletSchemaMap::erase(SchemaId id) {
+    MapShard* shard = get_shard(id);
+    std::lock_guard l(shard->mtx);
+    return shard->map.erase(id);
+}
+
+bool TabletSchemaMap::contains(SchemaId id) const {
+    const MapShard* shard = get_shard(id);
+    std::lock_guard l(shard->mtx);
+    return shard->map.contains(id);
+}
+
+TabletSchemaMap::Stats TabletSchemaMap::stats() const {
+    Stats stats;
+    for (const auto& shard : _map_shards) {
+        std::lock_guard l(shard.mtx);
+        stats.num_items += shard.map.size();
+        for (const auto& [_, weak_ptr] : shard.map) {
+            if (auto schema_ptr = weak_ptr.lock(); schema_ptr) {
+                auto use_cnt = schema_ptr.use_count();
+                auto schema_size = schema_ptr->mem_usage();
+                // The temporary variable schema_ptr took one reference, should exclude it.
+                stats.memory_usage += use_cnt >= 2 ? schema_size : 0;
+                stats.saved_memory_usage += (use_cnt >= 2) ? (use_cnt - 2) * schema_size : 0;
+            }
+        }
+    }
+    return stats;
+}
+
+} // namespace starrocks

--- a/be/src/storage/tablet_schema_map.h
+++ b/be/src/storage/tablet_schema_map.h
@@ -1,0 +1,86 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#pragma once
+
+#include <memory>
+#include <mutex>
+
+#include "storage/tablet_schema.h"
+#include "util/phmap/phmap.h"
+
+namespace starrocks {
+
+// TabletSchemaMap is a map from 64 bits integer to std::shared_ptr<const TabletSchema>.
+// This class is used to share the same TabletSchema object among all tablets with the same schema to reduce
+// memory usage.
+// Use `GlobalTabletSchemaMap::Instance()` to access the global object.
+class TabletSchemaMap {
+public:
+    using SchemaId = TabletSchema::SchemaId;
+    using TabletSchemaPtr = std::shared_ptr<const TabletSchema>;
+
+    struct Stats {
+        // The total number of items stored in the map.
+        size_t num_items = 0;
+        // How many bytes occupied by the items stored in this map.
+        size_t memory_usage = 0;
+        // How many bytes saved by using the TabletSchemaMap.
+        size_t saved_memory_usage = 0;
+    };
+
+    TabletSchemaMap() = default;
+
+    // Inserts a new TabletSchema into the container constructed with the given arg if there is no TabletSchema with
+    // the the id of arg in the container.
+    //
+    // Only `unique_id()` of the arg will be compared to determine whether the schema already exist, it's the caller's
+    // duty to ensure that no two different TabletSchemaPB`s have the same `unique_id()`.
+    //
+    // REQUIRE: arg.unique_id() != TabletSchema::invalid_id()
+    //
+    // Returns a pair consisting of a pointer to the inserted element, or the already-existing element if no insertion
+    // happened, and a bool denoting whether the insertion took place (true if insertion happened, false if it did not).
+    // [thread-safe]
+    std::pair<TabletSchemaPtr, bool> emplace(const TabletSchemaPB& arg);
+
+    // Removes the TabletSchema (if one exists) with the id equivalent to id.
+    //
+    // Returns number of elements removed (0 or 1).
+    // [thread-safe]
+    size_t erase(SchemaId id);
+
+    // Checks if there is an element with unique id equivalent to id in the container.
+    //
+    // Returns true if there is such an element, otherwise false.
+    bool contains(SchemaId id) const;
+
+    // NOTE: time complexity of method is high, don't call this method too often.
+    // [thread-safe]
+    Stats stats() const;
+
+private:
+    constexpr static int kShardSize = 16;
+
+    struct MapShard {
+        mutable std::mutex mtx;
+        phmap::flat_hash_map<SchemaId, std::weak_ptr<const TabletSchema>> map;
+    };
+
+    MapShard* get_shard(SchemaId id) { return &_map_shards[id % kShardSize]; }
+    const MapShard* get_shard(SchemaId id) const { return &_map_shards[id % kShardSize]; }
+
+    MapShard _map_shards[kShardSize];
+};
+
+class GlobalTabletSchemaMap final : public TabletSchemaMap {
+public:
+    static GlobalTabletSchemaMap* Instance() {
+        static GlobalTabletSchemaMap instance;
+        return &instance;
+    }
+
+private:
+    GlobalTabletSchemaMap() = default;
+};
+
+} // namespace starrocks

--- a/be/src/storage/tablet_schema_map.h
+++ b/be/src/storage/tablet_schema_map.h
@@ -31,17 +31,17 @@ public:
     TabletSchemaMap() = default;
 
     // Inserts a new TabletSchema into the container constructed with the given arg if there is no TabletSchema with
-    // the the id of arg in the container.
+    // the id of schema_pb in the container.
     //
-    // Only `unique_id()` of the arg will be compared to determine whether the schema already exist, it's the caller's
-    // duty to ensure that no two different TabletSchemaPB`s have the same `unique_id()`.
+    // Only `id()` of the schema_pb will be compared to determine whether the schema already exist, it's the caller's
+    // duty to ensure that no two different TabletSchemaPB`s have the same `id()`.
     //
-    // REQUIRE: arg.unique_id() != TabletSchema::invalid_id()
+    // REQUIRE: schema_pb.id() != TabletSchema::invalid_id()
     //
     // Returns a pair consisting of a pointer to the inserted element, or the already-existing element if no insertion
     // happened, and a bool denoting whether the insertion took place (true if insertion happened, false if it did not).
     // [thread-safe]
-    std::pair<TabletSchemaPtr, bool> emplace(const TabletSchemaPB& arg);
+    std::pair<TabletSchemaPtr, bool> emplace(const TabletSchemaPB& schema_pb);
 
     // Removes the TabletSchema (if one exists) with the id equivalent to id.
     //

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -117,6 +117,7 @@ set(EXEC_FILES
         ./storage/file_utils_test.cpp
         ./storage/fs/file_block_manager_test.cpp
         ./storage/generic_iterators_test.cpp
+        ./storage/tablet_schema_map_test.cpp
         ./storage/hll_test.cpp
         ./storage/in_list_predicate_test.cpp
         ./storage/key_coder_test.cpp

--- a/be/test/storage/tablet_schema_map_test.cpp
+++ b/be/test/storage/tablet_schema_map_test.cpp
@@ -1,0 +1,80 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#include "storage/tablet_schema_map.h"
+
+#include <gtest/gtest.h>
+
+namespace starrocks {
+
+// NOLINTNEXTLINE
+TEST(TabletSchemaMapTest, test_all) {
+    TabletSchemaPB schema_pb;
+    schema_pb.set_keys_type(UNIQUE_KEYS);
+    schema_pb.set_num_short_key_columns(1);
+    schema_pb.set_id(123);
+    auto c0 = schema_pb.add_column();
+    c0->set_unique_id(1);
+    c0->set_name("c0");
+    c0->set_type("INT");
+    c0->set_is_key(true);
+    c0->set_is_nullable(true);
+
+    TabletSchemaMap schema_map;
+
+    auto stats0 = schema_map.stats();
+    ASSERT_EQ(0, stats0.num_items);
+    ASSERT_EQ(0, stats0.memory_usage);
+    ASSERT_EQ(0, stats0.saved_memory_usage);
+
+    ASSERT_FALSE(schema_map.contains(schema_pb.id()));
+    auto [schema0, inserted0] = schema_map.emplace(schema_pb);
+    ASSERT_TRUE(inserted0);
+    ASSERT_TRUE(schema0 != nullptr);
+    ASSERT_EQ(schema_pb.id(), schema0->id());
+    ASSERT_EQ(schema_pb.keys_type(), schema0->keys_type());
+    ASSERT_TRUE(schema0->shared());
+
+    auto stats1 = schema_map.stats();
+    ASSERT_EQ(1, stats1.num_items);
+    ASSERT_EQ(schema0->mem_usage(), stats1.memory_usage);
+    ASSERT_EQ(0, stats1.saved_memory_usage);
+
+    auto [schema1, inserted1] = schema_map.emplace(schema_pb);
+    ASSERT_FALSE(inserted1);
+    ASSERT_EQ(schema0.get(), schema1.get());
+
+    auto stats2 = schema_map.stats();
+    ASSERT_EQ(1, stats2.num_items);
+    ASSERT_EQ(schema0->mem_usage(), stats2.memory_usage);
+    ASSERT_EQ(schema0->mem_usage(), stats2.saved_memory_usage);
+
+    TabletSchemaPB schema_pb2 = schema_pb;
+    schema_pb2.set_id(456);
+    auto [schema2, inserted2] = schema_map.emplace(schema_pb2);
+    ASSERT_TRUE(inserted2);
+    ASSERT_NE(schema0.get(), schema2.get());
+    auto stats3 = schema_map.stats();
+    ASSERT_EQ(2, stats3.num_items);
+    ASSERT_EQ(schema0->mem_usage() + schema2->mem_usage(), stats3.memory_usage);
+    ASSERT_EQ(schema0->mem_usage(), stats3.saved_memory_usage);
+
+    schema0.reset();
+    auto stats4 = schema_map.stats();
+    ASSERT_EQ(2, stats4.num_items);
+    ASSERT_EQ(schema1->mem_usage() + schema2->mem_usage(), stats4.memory_usage);
+    ASSERT_EQ(0, stats4.saved_memory_usage);
+
+    schema1.reset();
+    auto stats5 = schema_map.stats();
+    ASSERT_EQ(1, stats5.num_items);
+    ASSERT_EQ(schema2->mem_usage(), stats5.memory_usage);
+    ASSERT_EQ(0, stats5.saved_memory_usage);
+
+    ASSERT_EQ(1, schema_map.erase(schema2->id()));
+    auto stats6 = schema_map.stats();
+    ASSERT_EQ(0, stats6.num_items);
+    ASSERT_EQ(0, stats6.memory_usage);
+    ASSERT_EQ(0, stats6.saved_memory_usage);
+}
+
+} // namespace starrocks

--- a/be/test/storage/vectorized/base_compaction_test.cpp
+++ b/be/test/storage/vectorized/base_compaction_test.cpp
@@ -177,8 +177,7 @@ TEST_F(BaseCompactionTest, test_init_succeeded) {
 TEST_F(BaseCompactionTest, test_input_rowsets_LE_1) {
     TabletSchemaPB schema_pb;
     schema_pb.set_keys_type(KeysType::DUP_KEYS);
-    auto schema = std::make_shared<TabletSchema>();
-    schema->init_from_pb(schema_pb);
+    auto schema = std::make_shared<const TabletSchema>(schema_pb);
     TabletMetaSharedPtr tablet_meta(new TabletMeta(_tablet_meta_mem_tracker.get()));
     tablet_meta->set_tablet_schema(schema);
 

--- a/be/test/storage/vectorized/cumulative_compaction_test.cpp
+++ b/be/test/storage/vectorized/cumulative_compaction_test.cpp
@@ -178,9 +178,7 @@ TEST_F(CumulativeCompactionTest, test_candidate_rowsets_empty) {
     TabletSchemaPB schema_pb;
     schema_pb.set_keys_type(KeysType::DUP_KEYS);
 
-    auto schema = std::make_shared<TabletSchema>();
-    schema->init_from_pb(schema_pb);
-
+    auto schema = std::make_shared<const TabletSchema>(schema_pb);
     TabletMetaSharedPtr tablet_meta(new TabletMeta(_tablet_meta_mem_tracker.get()));
     tablet_meta->set_tablet_schema(schema);
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/RollupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/RollupJob.java
@@ -753,7 +753,7 @@ public class RollupJob extends AlterJob {
                 } // end for partitions
 
                 // set index's info
-                olapTable.setIndexMeta(rollupIndexId, rollupIndexName, rollupSchema, 0, rollupSchemaHash,
+                olapTable.setIndexMeta(rollupIndexId, rollupIndexName, rollupIndexId, rollupSchema, 0, rollupSchemaHash,
                         rollupShortKeyColumnCount, rollupStorageType, KeysType.fromThrift(rollupKeysType));
                 Preconditions.checkState(olapTable.getState() == OlapTableState.ROLLUP);
 
@@ -888,7 +888,7 @@ public class RollupJob extends AlterJob {
                 }
             }
 
-            olapTable.setIndexMeta(rollupIndexId, rollupIndexName, rollupSchema, 0, rollupSchemaHash,
+            olapTable.setIndexMeta(rollupIndexId, rollupIndexName, rollupIndexId, rollupSchema, 0, rollupSchemaHash,
                     rollupShortKeyColumnCount, rollupStorageType, KeysType.fromThrift(rollupKeysType));
         } finally {
             db.writeUnlock();

--- a/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
@@ -235,7 +235,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
                         // version will be updated by following load process, or when rollup task finished.
                         CreateReplicaTask createReplicaTask = new CreateReplicaTask(
                                 backendId, dbId, tableId, partitionId, rollupIndexId, rollupTabletId,
-                                rollupShortKeyColumnCount, rollupSchemaHash,
+                                rollupShortKeyColumnCount, rollupIndexId, rollupSchemaHash,
                                 Partition.PARTITION_INIT_VERSION, Partition.PARTITION_INIT_VERSION_HASH,
                                 rollupKeysType, TStorageType.COLUMN, storageMedium,
                                 rollupSchema, tbl.getCopiedBfColumns(), tbl.getBfFpp(), countDownLatch,
@@ -318,7 +318,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
             partition.createRollupIndex(rollupIndex);
         }
 
-        tbl.setIndexMeta(rollupIndexId, rollupIndexName, rollupSchema, 0 /* init schema version */,
+        tbl.setIndexMeta(rollupIndexId, rollupIndexName, rollupIndexId, rollupSchema, 0 /* initial schema version */,
                 rollupSchemaHash, rollupShortKeyColumnCount, TStorageType.COLUMN, rollupKeysType, origStmt);
         tbl.rebuildFullSchema();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -1156,6 +1156,7 @@ public class SchemaChangeHandler extends AlterHandler {
             // generate schema hash for new index has to generate a new schema hash not equal to current schema hash
             int currentSchemaHash = currentIndexMeta.getSchemaHash();
             int newSchemaHash = Util.generateSchemaHash();
+            long newSchemaId = catalog.getNextId();
             while (currentSchemaHash == newSchemaHash) {
                 newSchemaHash = Util.generateSchemaHash();
             }
@@ -1230,8 +1231,8 @@ public class SchemaChangeHandler extends AlterHandler {
 
                 schemaChangeJob.addPartitionShadowIndex(partitionId, shadowIndexId, shadowIndex);
             } // end for partition
-            schemaChangeJob.addIndexSchema(shadowIndexId, originIndexId, newIndexName, newSchemaVersion, newSchemaHash,
-                    newShortKeyColumnCount, entry.getValue());
+            schemaChangeJob.addIndexSchema(shadowIndexId, originIndexId, newIndexName, newSchemaId, newSchemaVersion,
+                    newSchemaHash, newShortKeyColumnCount, entry.getValue());
         } // end for index
 
         // set table state

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJob.java
@@ -37,6 +37,7 @@ import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndex.IndexExtState;
 import com.starrocks.catalog.MaterializedIndex.IndexState;
+import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.OlapTable.OlapTableState;
 import com.starrocks.catalog.Partition;
@@ -847,8 +848,8 @@ public class SchemaChangeJob extends AlterJob {
                     int schemaVersion = changedIndexIdToSchemaVersion.get(indexId);
                     int schemaHash = changedIndexIdToSchemaHash.get(indexId);
                     short shortKeyColumnCount = changedIndexIdToShortKeyColumnCount.get(indexId);
-                    olapTable.setIndexMeta(indexId, null, entry.getValue(), schemaVersion, schemaHash,
-                            shortKeyColumnCount, newStorageType, null);
+                    olapTable.setIndexMeta(indexId, null, MaterializedIndexMeta.INVALID_SCHEMA_ID, entry.getValue(),
+                            schemaVersion, schemaHash, shortKeyColumnCount, newStorageType, null);
                 }
 
                 // 3. update base schema if changed
@@ -1012,8 +1013,8 @@ public class SchemaChangeJob extends AlterJob {
                 int schemaVersion = getSchemaVersionByIndexId(indexId);
                 int schemaHash = getSchemaHashByIndexId(indexId);
                 short shortKeyColumnCount = getShortKeyColumnCountByIndexId(indexId);
-                olapTable.setIndexMeta(indexId, null, entry.getValue(), schemaVersion, schemaHash,
-                        shortKeyColumnCount, newStorageType, null);
+                olapTable.setIndexMeta(indexId, null, MaterializedIndexMeta.INVALID_SCHEMA_ID, entry.getValue(),
+                        schemaVersion, schemaHash, shortKeyColumnCount, newStorageType, null);
 
                 if (indexId == olapTable.getBaseIndexId()) {
                     olapTable.setNewFullSchema(entry.getValue());

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -37,6 +37,7 @@ import com.starrocks.catalog.Index;
 import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndex.IndexState;
+import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.OlapTable.OlapTableState;
 import com.starrocks.catalog.Partition;
@@ -106,6 +107,8 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
     // shadow index id -> shadow index short key count
     @SerializedName(value = "indexShortKeyMap")
     private Map<Long, Short> indexShortKeyMap = Maps.newHashMap();
+    @SerializedName(value = "indexSchemaIdMap")
+    private Map<Long, Long> indexSchemaIdMap = Maps.newHashMap();
 
     // bloom filter info
     @SerializedName(value = "hasBfChange")
@@ -151,11 +154,12 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
         partitionIndexMap.put(partitionId, shadowIdxId, shadowIdx);
     }
 
-    public void addIndexSchema(long shadowIdxId, long originIdxId,
-                               String shadowIndexName, int shadowSchemaVersion, int shadowSchemaHash,
-                               short shadowIdxShortKeyCount, List<Column> shadowIdxSchema) {
+    public void addIndexSchema(long shadowIdxId, long originIdxId, String shadowIndexName, long newSchemaId,
+                               int shadowSchemaVersion, int shadowSchemaHash, short shadowIdxShortKeyCount,
+                               List<Column> shadowIdxSchema) {
         indexIdMap.put(shadowIdxId, originIdxId);
         indexIdToName.put(shadowIdxId, shadowIndexName);
+        indexSchemaIdMap.put(shadowIdxId, newSchemaId);
         indexSchemaVersionAndHashMap.put(shadowIdxId, new SchemaVersionAndHash(shadowSchemaVersion, shadowSchemaHash));
         indexShortKeyMap.put(shadowIdxId, shadowIdxShortKeyCount);
         indexSchemaMap.put(shadowIdxId, shadowIdxSchema);
@@ -240,6 +244,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                     short shadowShortKeyColumnCount = indexShortKeyMap.get(shadowIdxId);
                     List<Column> shadowSchema = indexSchemaMap.get(shadowIdxId);
                     int shadowSchemaHash = indexSchemaVersionAndHashMap.get(shadowIdxId).schemaHash;
+                    long shadowSchemaId = indexSchemaIdMap.getOrDefault(shadowIdxId, MaterializedIndexMeta.INVALID_SCHEMA_ID);
                     long originIndexId = indexIdMap.get(shadowIdxId);
                     int originSchemaHash = tbl.getSchemaHashByIndexId(originIndexId);
                     KeysType originKeysType = tbl.getKeysTypeByIndexId(originIndexId);
@@ -252,7 +257,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                             countDownLatch.addMark(backendId, shadowTabletId);
                             CreateReplicaTask createReplicaTask = new CreateReplicaTask(
                                     backendId, dbId, tableId, partitionId, shadowIdxId, shadowTabletId,
-                                    shadowShortKeyColumnCount, shadowSchemaHash,
+                                    shadowShortKeyColumnCount, shadowSchemaId, shadowSchemaHash,
                                     Partition.PARTITION_INIT_VERSION, Partition.PARTITION_INIT_VERSION_HASH,
                                     originKeysType, TStorageType.COLUMN, storageMedium,
                                     shadowSchema, bfColumns, bfFpp, countDownLatch, indexes,
@@ -344,7 +349,9 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
         }
 
         for (long shadowIdxId : indexIdMap.keySet()) {
-            tbl.setIndexMeta(shadowIdxId, indexIdToName.get(shadowIdxId), indexSchemaMap.get(shadowIdxId),
+            tbl.setIndexMeta(shadowIdxId, indexIdToName.get(shadowIdxId),
+                    indexSchemaIdMap.getOrDefault(shadowIdxId, MaterializedIndexMeta.INVALID_SCHEMA_ID),
+                    indexSchemaMap.get(shadowIdxId),
                     indexSchemaVersionAndHashMap.get(shadowIdxId).schemaVersion,
                     indexSchemaVersionAndHashMap.get(shadowIdxId).schemaHash,
                     indexShortKeyMap.get(shadowIdxId), TStorageType.COLUMN,
@@ -893,6 +900,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
             indexSchemaMap.put(shadowIndexId, schema);
             indexSchemaVersionAndHashMap.put(shadowIndexId, schemaVersionAndHash);
             indexShortKeyMap.put(shadowIndexId, shortKeyCount);
+            indexSchemaIdMap.put(shadowIndexId, MaterializedIndexMeta.INVALID_SCHEMA_ID);
         }
 
         // bloom filter
@@ -946,6 +954,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
             indexIdMap.put(shadowIndexId, originIndexId);
             indexIdToName.put(shadowIndexId, indexName);
             indexSchemaVersionAndHashMap.put(shadowIndexId, schemaVersionAndHash);
+            indexSchemaIdMap.put(shadowIndexId, MaterializedIndexMeta.INVALID_SCHEMA_ID);
         }
 
         // bloom filter

--- a/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
@@ -781,7 +781,7 @@ public class RestoreJob extends AbstractJob {
                     Catalog.getCurrentInvertedIndex().addReplica(restoreTablet.getId(), restoreReplica);
                     CreateReplicaTask task = new CreateReplicaTask(restoreReplica.getBackendId(), dbId,
                             localTbl.getId(), restorePart.getId(), restoredIdx.getId(),
-                            restoreTablet.getId(), indexMeta.getShortKeyColumnCount(),
+                            restoreTablet.getId(), indexMeta.getShortKeyColumnCount(), indexMeta.getSchemaId(),
                             indexMeta.getSchemaHash(), restoreReplica.getVersion(),
                             restoreReplica.getVersionHash(), indexMeta.getKeysType(), TStorageType.COLUMN,
                             TStorageMedium.HDD /* all restored replicas will be saved to HDD */,

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -3710,6 +3710,7 @@ public class Catalog {
                         index.getId(),
                         tablet.getId(),
                         indexMeta.getShortKeyColumnCount(),
+                        indexMeta.getSchemaId(),
                         indexMeta.getSchemaHash(),
                         partition.getVisibleVersion(),
                         partition.getVisibleVersionHash(),
@@ -3964,7 +3965,7 @@ public class Catalog {
             throw new DdlException(e.getMessage());
         }
         int schemaHash = Util.schemaHash(schemaVersion, baseSchema, bfColumns, bfFpp);
-        olapTable.setIndexMeta(baseIndexId, tableName, baseSchema, schemaVersion, schemaHash,
+        olapTable.setIndexMeta(baseIndexId, tableName, baseIndexId, baseSchema, schemaVersion, schemaHash,
                 shortKeyColumnCount, baseIndexStorageType, keysType);
 
         for (AlterClause alterClause : stmt.getRollupAlterClauseList()) {
@@ -3987,7 +3988,7 @@ public class Catalog {
                     Catalog.calcShortKeyColumnCount(rollupColumns, alterClause.getProperties());
             int rollupSchemaHash = Util.schemaHash(schemaVersion, rollupColumns, bfColumns, bfFpp);
             long rollupIndexId = getCurrentCatalog().getNextId();
-            olapTable.setIndexMeta(rollupIndexId, addRollupClause.getRollupName(), rollupColumns, schemaVersion,
+            olapTable.setIndexMeta(rollupIndexId, addRollupClause.getRollupName(), rollupIndexId, rollupColumns, schemaVersion,
                     rollupSchemaHash, rollupShortKeyColumnCount, rollupIndexStorageType, keysType);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ExternalOlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ExternalOlapTable.java
@@ -421,7 +421,7 @@ public class ExternalOlapTable extends OlapTable {
                     }
                     columns.add(column);
                 }
-                MaterializedIndexMeta index = new MaterializedIndexMeta(indexMeta.getIndex_id(), columns,
+                MaterializedIndexMeta index = new MaterializedIndexMeta(indexMeta.getIndex_id(), indexMeta.getIndex_id(), columns,
                                                                         indexMeta.getSchema_meta().getSchema_version(),
                                                                         indexMeta.getSchema_meta().getSchema_hash(),
                                                                         indexMeta.getSchema_meta().getShort_key_col_count(),

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndexMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndexMeta.java
@@ -47,6 +47,8 @@ import java.util.Map;
 public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
     @SerializedName(value = "indexId")
     private long indexId;
+    @SerializedName(value = "schemaId")
+    private long schemaId = INVALID_SCHEMA_ID;
     @SerializedName(value = "schema")
     private List<Column> schema = Lists.newArrayList();
     @SerializedName(value = "schemaVersion")
@@ -62,10 +64,13 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
     @SerializedName(value = "defineStmt")
     private OriginStatement defineStmt;
 
-    public MaterializedIndexMeta(long indexId, List<Column> schema, int schemaVersion, int schemaHash,
+    public static final long INVALID_SCHEMA_ID = 0;
+
+    public MaterializedIndexMeta(long indexId, long schemaId, List<Column> schema, int schemaVersion, int schemaHash,
                                  short shortKeyColumnCount, TStorageType storageType, KeysType keysType,
                                  OriginStatement defineStmt) {
         this.indexId = indexId;
+        this.schemaId = schemaId;
         Preconditions.checkState(schema != null);
         Preconditions.checkState(schema.size() != 0);
         this.schema = schema;
@@ -97,6 +102,10 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
 
     public List<Column> getSchema() {
         return schema;
+    }
+
+    public long getSchemaId() {
+        return schemaId;
     }
 
     public int getSchemaHash() {
@@ -146,6 +155,9 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
         }
         MaterializedIndexMeta indexMeta = (MaterializedIndexMeta) obj;
         if (indexMeta.indexId != this.indexId) {
+            return false;
+        }
+        if (indexMeta.schemaId != this.schemaId) {
             return false;
         }
         if (indexMeta.schema.size() != this.schema.size() || !indexMeta.schema.containsAll(this.schema)) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -271,14 +271,14 @@ public class OlapTable extends Table {
         return indexNameToId.containsKey(indexName);
     }
 
-    public void setIndexMeta(long indexId, String indexName, List<Column> schema, int schemaVersion, int schemaHash,
-                             short shortKeyColumnCount, TStorageType storageType, KeysType keysType) {
-        setIndexMeta(indexId, indexName, schema, schemaVersion, schemaHash, shortKeyColumnCount, storageType, keysType,
+    public void setIndexMeta(long indexId, String indexName, long schemaId, List<Column> schema, int schemaVersion,
+                             int schemaHash, short shortKeyColumnCount, TStorageType storageType, KeysType keysType) {
+        setIndexMeta(indexId, indexName, schemaId, schema, schemaVersion, schemaHash, shortKeyColumnCount, storageType, keysType,
                 null);
     }
 
-    public void setIndexMeta(long indexId, String indexName, List<Column> schema, int schemaVersion, int schemaHash,
-                             short shortKeyColumnCount, TStorageType storageType, KeysType keysType,
+    public void setIndexMeta(long indexId, String indexName, long schemaId, List<Column> schema, int schemaVersion,
+                             int schemaHash, short shortKeyColumnCount, TStorageType storageType, KeysType keysType,
                              OriginStatement origStmt) {
         // Nullable when meta comes from schema change log replay.
         // The replay log only save the index id, so we need to get name by id.
@@ -301,7 +301,7 @@ public class OlapTable extends Table {
             Preconditions.checkState(storageType == TStorageType.COLUMN);
         }
 
-        MaterializedIndexMeta indexMeta = new MaterializedIndexMeta(indexId, schema, schemaVersion,
+        MaterializedIndexMeta indexMeta = new MaterializedIndexMeta(indexId, schemaId, schema, schemaVersion,
                 schemaHash, shortKeyColumnCount, storageType, keysType, origStmt);
         indexIdToMeta.put(indexId, indexMeta);
         indexNameToId.put(indexName, indexId);
@@ -1086,8 +1086,8 @@ public class OlapTable extends Table {
                 short shortKeyColumnCount = in.readShort();
 
                 // The keys type in here is incorrect
-                MaterializedIndexMeta indexMeta = new MaterializedIndexMeta(indexId, schema,
-                        schemaVersion, schemaHash, shortKeyColumnCount, storageType, KeysType.AGG_KEYS, null);
+                MaterializedIndexMeta indexMeta = new MaterializedIndexMeta(indexId, indexId, schema, schemaVersion, schemaHash,
+                        shortKeyColumnCount, storageType, KeysType.AGG_KEYS, null);
                 tmpIndexMetaList.add(indexMeta);
             } else {
                 MaterializedIndexMeta indexMeta = MaterializedIndexMeta.read(in);

--- a/fe/fe-core/src/main/java/com/starrocks/master/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/master/ReportHandler.java
@@ -599,7 +599,7 @@ public class ReportHandler extends Daemon {
                                     double bfFpp = olapTable.getBfFpp();
                                     CreateReplicaTask createReplicaTask = new CreateReplicaTask(backendId, dbId,
                                             tableId, partitionId, indexId, tabletId, indexMeta.getShortKeyColumnCount(),
-                                            indexMeta.getSchemaHash(), partition.getVisibleVersion(),
+                                            indexMeta.getSchemaHash(), indexMeta.getSchemaHash(), partition.getVisibleVersion(),
                                             partition.getVisibleVersionHash(), indexMeta.getKeysType(),
                                             TStorageType.COLUMN,
                                             TStorageMedium.HDD, indexMeta.getSchema(), bfColumns, bfFpp, null,

--- a/fe/fe-core/src/main/java/com/starrocks/task/CreateReplicaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/CreateReplicaTask.java
@@ -170,7 +170,7 @@ public class CreateReplicaTask extends AgentTask {
         tSchema.setSchema_hash(schemaHash);
         tSchema.setKeys_type(keysType.toThrift());
         tSchema.setStorage_type(storageType);
-        tSchema.setUnique_id(schemaId);
+        tSchema.setSchema_id(schemaId);
 
         List<TColumn> tColumns = new ArrayList<TColumn>();
         for (Column column : columns) {

--- a/fe/fe-core/src/main/java/com/starrocks/task/CreateReplicaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/CreateReplicaTask.java
@@ -50,6 +50,7 @@ public class CreateReplicaTask extends AgentTask {
 
     private short shortKeyColumnCount;
     private int schemaHash;
+    private long schemaId;
 
     private long version;
     private long versionHash;
@@ -86,7 +87,7 @@ public class CreateReplicaTask extends AgentTask {
     private boolean isRecoverTask = false;
 
     public CreateReplicaTask(long backendId, long dbId, long tableId, long partitionId, long indexId, long tabletId,
-                             short shortKeyColumnCount, int schemaHash, long version, long versionHash,
+                             short shortKeyColumnCount, long schemaId, int schemaHash, long version, long versionHash,
                              KeysType keysType, TStorageType storageType,
                              TStorageMedium storageMedium, List<Column> columns,
                              Set<String> bfColumns, double bfFpp, MarkedCountDownLatch<Long, Long> latch,
@@ -97,6 +98,7 @@ public class CreateReplicaTask extends AgentTask {
 
         this.shortKeyColumnCount = shortKeyColumnCount;
         this.schemaHash = schemaHash;
+        this.schemaId = schemaId;
 
         this.version = version;
         this.versionHash = versionHash;
@@ -168,6 +170,7 @@ public class CreateReplicaTask extends AgentTask {
         tSchema.setSchema_hash(schemaHash);
         tSchema.setKeys_type(keysType.toThrift());
         tSchema.setStorage_type(storageType);
+        tSchema.setUnique_id(schemaId);
 
         List<TColumn> tColumns = new ArrayList<TColumn>();
         for (Column column : columns) {

--- a/fe/fe-core/src/main/java/com/starrocks/task/CreateReplicaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/CreateReplicaTask.java
@@ -170,7 +170,7 @@ public class CreateReplicaTask extends AgentTask {
         tSchema.setSchema_hash(schemaHash);
         tSchema.setKeys_type(keysType.toThrift());
         tSchema.setStorage_type(storageType);
-        tSchema.setSchema_id(schemaId);
+        tSchema.setId(schemaId);
 
         List<TColumn> tColumns = new ArrayList<TColumn>();
         for (Column column : columns) {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AccessTestUtil.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AccessTestUtil.java
@@ -105,7 +105,7 @@ public class AccessTestUtil {
             baseSchema.add(column);
             OlapTable table = new OlapTable(30000, "testTbl", baseSchema,
                     KeysType.AGG_KEYS, new SinglePartitionInfo(), distributionInfo, catalog.getClusterId(), null);
-            table.setIndexMeta(baseIndex.getId(), "testTbl", baseSchema, 0, 1, (short) 1,
+            table.setIndexMeta(baseIndex.getId(), "testTbl", baseIndex.getId(), baseSchema, 0, 1, (short) 1,
                     TStorageType.COLUMN, KeysType.AGG_KEYS);
             table.addPartition(partition);
             table.setBaseIndexId(baseIndex.getId());

--- a/fe/fe-core/src/test/java/com/starrocks/backup/CatalogMocker.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/CatalogMocker.java
@@ -258,7 +258,7 @@ public class CatalogMocker {
         tablet0.addReplica(replica1);
         tablet0.addReplica(replica2);
 
-        olapTable.setIndexMeta(TEST_TBL_ID, TEST_TBL_NAME, TEST_TBL_BASE_SCHEMA, 0, SCHEMA_HASH, (short) 1,
+        olapTable.setIndexMeta(TEST_TBL_ID, TEST_TBL_NAME, TEST_TBL_ID, TEST_TBL_BASE_SCHEMA, 0, SCHEMA_HASH, (short) 1,
                 TStorageType.COLUMN, KeysType.AGG_KEYS);
         olapTable.addPartition(partition);
         db.createTable(olapTable);
@@ -342,7 +342,7 @@ public class CatalogMocker {
         baseTabletP2.addReplica(replica7);
         baseTabletP2.addReplica(replica8);
 
-        olapTable2.setIndexMeta(TEST_TBL2_ID, TEST_TBL2_NAME, TEST_TBL_BASE_SCHEMA, 0, SCHEMA_HASH, (short) 1,
+        olapTable2.setIndexMeta(TEST_TBL2_ID, TEST_TBL2_NAME, TEST_TBL2_ID, TEST_TBL_BASE_SCHEMA, 0, SCHEMA_HASH, (short) 1,
                 TStorageType.COLUMN, KeysType.AGG_KEYS);
         olapTable2.addPartition(partition1);
         olapTable2.addPartition(partition2);
@@ -380,7 +380,7 @@ public class CatalogMocker {
 
         partition2.createRollupIndex(rollupIndexP2);
 
-        olapTable2.setIndexMeta(TEST_ROLLUP_ID, TEST_ROLLUP_NAME, TEST_ROLLUP_SCHEMA, 0, ROLLUP_SCHEMA_HASH,
+        olapTable2.setIndexMeta(TEST_ROLLUP_ID, TEST_ROLLUP_NAME, TEST_ROLLUP_ID, TEST_ROLLUP_SCHEMA, 0, ROLLUP_SCHEMA_HASH,
                 (short) 1, TStorageType.COLUMN, KeysType.AGG_KEYS);
         db.createTable(olapTable2);
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogTestUtil.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogTestUtil.java
@@ -220,7 +220,7 @@ public class CatalogTestUtil {
         OlapTable table = new OlapTable(tableId, testTable1, columns, KeysType.AGG_KEYS, partitionInfo,
                 distributionInfo);
         table.addPartition(partition);
-        table.setIndexMeta(indexId, testIndex1, columns, 0, testSchemaHash1, (short) 1,
+        table.setIndexMeta(indexId, testIndex1, indexId, columns, 0, testSchemaHash1, (short) 1,
                 TStorageType.COLUMN, KeysType.AGG_KEYS);
         table.setBaseIndexId(indexId);
         // db

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/DatabaseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/DatabaseTest.java
@@ -179,13 +179,13 @@ public class DatabaseTest {
         OlapTable table = new OlapTable(1000, "table", columns, KeysType.AGG_KEYS,
                 new SinglePartitionInfo(), new RandomDistributionInfo(10));
         short shortKeyColumnCount = 1;
-        table.setIndexMeta(1000, "group1", columns, 1, 1, shortKeyColumnCount, TStorageType.COLUMN, KeysType.AGG_KEYS);
+        table.setIndexMeta(1000, "group1", 1000, columns, 1, 1, shortKeyColumnCount, TStorageType.COLUMN, KeysType.AGG_KEYS);
 
         List<Column> column = Lists.newArrayList();
         column.add(column2);
-        table.setIndexMeta(new Long(1), "test", column, 1, 1, shortKeyColumnCount,
+        table.setIndexMeta(1, "test", 1, column, 1, 1, shortKeyColumnCount,
                 TStorageType.COLUMN, KeysType.AGG_KEYS);
-        table.setIndexMeta(new Long(1), "test", column, 1, 1, shortKeyColumnCount, TStorageType.COLUMN,
+        table.setIndexMeta(1, "test", 1, column, 1, 1, shortKeyColumnCount, TStorageType.COLUMN,
                 KeysType.AGG_KEYS);
         Deencapsulation.setField(table, "baseIndexId", 1);
         table.addPartition(partition);

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedIndexMetaTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedIndexMetaTest.java
@@ -83,7 +83,7 @@ public class MaterializedIndexMetaTest {
         schema.add(new Column("v1", Type.INT, false, AggregateType.SUM, true, "1", ""));
         schema.add(new Column(mvColumnName, Type.BITMAP, false, AggregateType.BITMAP_UNION, false, "1", ""));
         short shortKeyColumnCount = 1;
-        MaterializedIndexMeta indexMeta = new MaterializedIndexMeta(1, schema, 1, 1, shortKeyColumnCount,
+        MaterializedIndexMeta indexMeta = new MaterializedIndexMeta(1, 1, schema, 1, 1, shortKeyColumnCount,
                 TStorageType.COLUMN, KeysType.DUP_KEYS, new OriginStatement(
                 "create materialized view test as select k1, k2, k3, k4, k5, k6, k7, k8, k9, k10, k11, k12, sum(v1), "
                         + "bitmap_union(to_bitmap(k1)) from test group by k1, k2, k3, k4, k5, "

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TableTest.java
@@ -80,11 +80,11 @@ public class TableTest {
         OlapTable table1 = new OlapTable(1000L, "group1", columns, KeysType.AGG_KEYS,
                 new SinglePartitionInfo(), new RandomDistributionInfo(10));
         short shortKeyColumnCount = 1;
-        table1.setIndexMeta(1000, "group1", columns, 1, 1, shortKeyColumnCount, TStorageType.COLUMN, KeysType.AGG_KEYS);
+        table1.setIndexMeta(1000, "group1", 1000, columns, 1, 1, shortKeyColumnCount, TStorageType.COLUMN, KeysType.AGG_KEYS);
         List<Column> column = Lists.newArrayList();
         column.add(column2);
 
-        table1.setIndexMeta(new Long(2), "test", column, 1, 1, shortKeyColumnCount, TStorageType.COLUMN,
+        table1.setIndexMeta(2, "test", 2, column, 1, 1, shortKeyColumnCount, TStorageType.COLUMN,
                 KeysType.AGG_KEYS);
         Deencapsulation.setField(table1, "baseIndexId", 1000);
         table1.write(dos);

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/UnitTestUtil.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/UnitTestUtil.java
@@ -113,7 +113,7 @@ public class UnitTestUtil {
                 KeysType.AGG_KEYS, partitionInfo, distributionInfo);
         Deencapsulation.setField(table, "baseIndexId", indexId);
         table.addPartition(partition);
-        table.setIndexMeta(indexId, TABLE_NAME, columns, 0, SCHEMA_HASH, (short) 1, TStorageType.COLUMN,
+        table.setIndexMeta(indexId, TABLE_NAME,indexId, columns, 0, SCHEMA_HASH, (short) 1, TStorageType.COLUMN,
                 KeysType.AGG_KEYS);
 
         // db

--- a/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
@@ -164,8 +164,8 @@ abstract public class StarRocksHttpTestCase {
         OlapTable table = new OlapTable(testTableId, name, columns, KeysType.AGG_KEYS, partitionInfo,
                 distributionInfo);
         table.addPartition(partition);
-        table.setIndexMeta(testIndexId, "testIndex", columns, 0, testSchemaHash, (short) 1, TStorageType.COLUMN,
-                KeysType.AGG_KEYS);
+        table.setIndexMeta(testIndexId, "testIndex", testIndexId, columns, 0, testSchemaHash, (short) 1,
+                TStorageType.COLUMN, KeysType.AGG_KEYS);
         table.setBaseIndexId(testIndexId);
         return table;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/persist/CreateTableInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/CreateTableInfoTest.java
@@ -96,11 +96,11 @@ public class CreateTableInfoTest {
         OlapTable table = new OlapTable(1000L, "table", columns, KeysType.AGG_KEYS,
                 new SinglePartitionInfo(), distributionInfo);
         short shortKeyColumnCount = 1;
-        table.setIndexMeta(1000, "group1", columns, 1, 1, shortKeyColumnCount, TStorageType.COLUMN, KeysType.AGG_KEYS);
+        table.setIndexMeta(1000, "group1", 1000, columns, 1, 1, shortKeyColumnCount, TStorageType.COLUMN, KeysType.AGG_KEYS);
 
         List<Column> column = Lists.newArrayList();
         column.add(column2);
-        table.setIndexMeta(new Long(1), "test", column, 1, 1, shortKeyColumnCount,
+        table.setIndexMeta(1, "test", 1, column, 1, 1, shortKeyColumnCount,
                 TStorageType.COLUMN, KeysType.AGG_KEYS);
         Deencapsulation.setField(table, "baseIndexId", 1000);
         table.addPartition(partition);

--- a/fe/fe-core/src/test/java/com/starrocks/task/AgentTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/task/AgentTaskTest.java
@@ -113,7 +113,7 @@ public class AgentTaskTest {
 
         // create
         createReplicaTask = new CreateReplicaTask(backendId1, dbId, tableId, partitionId,
-                indexId1, tabletId1, shortKeyNum, schemaHash1,
+                indexId1, tabletId1, shortKeyNum, indexId1, schemaHash1,
                 version, versionHash, KeysType.AGG_KEYS,
                 storageType, TStorageMedium.SSD,
                 columns, null, 0, latch, null,

--- a/gensrc/proto/olap_common.proto
+++ b/gensrc/proto/olap_common.proto
@@ -46,6 +46,8 @@ message ColumnMessage {
     optional bool has_bitmap_index = 16 [default=false]; // ColumnPB.has_bitmap_index
 }
 
+// Please keep the defined value less than 256, because the enum will be casted to uint8_t in some
+// cases.
 enum CompressKind {
     COMPRESS_NONE = 0;
     COMPRESS_LZO = 1;

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -114,6 +114,8 @@ enum DataFileType {
     COLUMN_ORIENTED_FILE = 1;
 }
 
+// Please keep the defined value less than 256, bacause this enum will be casted to uint8_t
+// in some cases.
 enum KeysType {
     DUP_KEYS = 0;
     UNIQUE_KEYS = 1;
@@ -181,6 +183,7 @@ message TabletSchemaPB {
     optional double bf_fpp = 6; // OLAPHeaderMessage.bf_fpp
     optional uint32 next_column_unique_id = 7; // OLAPHeaderMessage.next_column_unique_id
     optional bool is_in_memory = 8 [default=false];
+    optional int64 id = 9;
 }
 
 enum TabletStatePB {

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -38,6 +38,7 @@ struct TTabletSchema {
     6: optional double bloom_filter_fpp
     7: optional list<Descriptors.TOlapTableIndex> indexes
     8: optional bool is_in_memory
+    9: optional i64 schema_id;
 }
 
 // this enum stands for different storage format in src_backends

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -38,7 +38,7 @@ struct TTabletSchema {
     6: optional double bloom_filter_fpp
     7: optional list<Descriptors.TOlapTableIndex> indexes
     8: optional bool is_in_memory
-    9: optional i64 schema_id;
+    9: optional i64 id;
 }
 
 // this enum stands for different storage format in src_backends


### PR DESCRIPTION
Close issue #807

A 64 bits integer field named `id` is added in `TabletSchemaPB` ,with its
value assigned by the master FE node, and the following properties
are ensured by the master FE:
- all tablets from the same table or materialized view will have the same `id`
- tablets from different tables or materialized views will have different `id`.

On each BE node, a global hash map was created to map from the `id` to
`std::shared_ptr<TabletSchema>`. When creating a new tablet or loading
already exists tablets from disk after the restart, the `id` will be checked
and only one `TabletSchema` will be created for all tablets with the same
 `id`.

Please note that this patch only works for newly-created tablets. For those
already-created tablets, their `TabletShema`s will not be shared among each other.