### PR TITLE
Access data in Apache Hive through S3 protocol

### DIFF
--- a/be/src/exec/vectorized/hdfs_scan_node.cpp
+++ b/be/src/exec/vectorized/hdfs_scan_node.cpp
@@ -566,6 +566,10 @@ Status HdfsScanNode::_find_and_insert_hdfs_file(const THdfsScanRange& scan_range
         _hdfs_files.emplace_back(hdfs_file_desc);
     }
 
+    if (namenode.rfind("s3a://", 0) == 0) {
+        _is_hdfs_fs = false;
+    }
+
     return Status::OK();
 }
 

--- a/be/src/exec/vectorized/hdfs_scan_node.h
+++ b/be/src/exec/vectorized/hdfs_scan_node.h
@@ -144,6 +144,7 @@ private:
     mutable SpinLock _status_mutex;
     Status _status;
     RuntimeState* _runtime_state = nullptr;
+    bool _is_hdfs_fs = true;
 
     std::atomic<int32_t> _scanner_submit_count = 0;
     std::atomic<int32_t> _running_threads = 0;

--- a/be/src/exec/vectorized/hdfs_scanner.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner.cpp
@@ -170,6 +170,8 @@ void HdfsScanner::update_counter() {
 #ifndef BE_TEST
     HdfsReadStats hdfs_stats;
     auto hdfs_file = down_cast<HdfsRandomAccessFile*>(_scanner_params.fs.get())->hdfs_file();
+    // Hdfslib only supports obtaining statistics of hdfs file system. 
+    // For other systems such as s3, calling this function will cause be crash.
     if (_scanner_params.parent->_is_hdfs_fs) {
         get_hdfs_statistics(hdfs_file, &hdfs_stats);
     }

--- a/be/src/exec/vectorized/hdfs_scanner.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner.cpp
@@ -170,7 +170,9 @@ void HdfsScanner::update_counter() {
 #ifndef BE_TEST
     HdfsReadStats hdfs_stats;
     auto hdfs_file = down_cast<HdfsRandomAccessFile*>(_scanner_params.fs.get())->hdfs_file();
-    get_hdfs_statistics(hdfs_file, &hdfs_stats);
+    if (_scanner_params.parent->_is_hdfs_fs) {
+        get_hdfs_statistics(hdfs_file, &hdfs_stats);
+    }
 
     COUNTER_UPDATE(_scanner_params.parent->_bytes_total_read, hdfs_stats.bytes_total_read);
     COUNTER_UPDATE(_scanner_params.parent->_bytes_read_local, hdfs_stats.bytes_read_local);

--- a/be/src/exec/vectorized/hdfs_scanner.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner.cpp
@@ -170,7 +170,7 @@ void HdfsScanner::update_counter() {
 #ifndef BE_TEST
     HdfsReadStats hdfs_stats;
     auto hdfs_file = down_cast<HdfsRandomAccessFile*>(_scanner_params.fs.get())->hdfs_file();
-    // Hdfslib only supports obtaining statistics of hdfs file system. 
+    // Hdfslib only supports obtaining statistics of hdfs file system.
     // For other systems such as s3, calling this function will cause be crash.
     if (_scanner_params.parent->_is_hdfs_fs) {
         get_hdfs_statistics(hdfs_file, &hdfs_stats);

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -483,7 +483,7 @@ under the License.
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
-            <version>2.10.1</version>
+            <version>3.3.0</version>
             <exclusions>
                 <exclusion>
                     <artifactId>zookeeper</artifactId>
@@ -496,6 +496,12 @@ under the License.
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client</artifactId>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-aws -->
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-aws</artifactId>
         </dependency>
     </dependencies>
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1278,6 +1278,12 @@ public class Config extends ConfigBase {
     public static long hive_meta_store_timeout_s = 10L;
 
     /**
+     * Used to split object storage files into smaller blocks for hive external table
+     */
+    @ConfField(mutable = true)
+    public static long object_storage_block_size = 64L * 1024L * 1024L;
+
+    /**
      * fe will call es api to get es index shard info every es_state_sync_interval_secs
      */
     @ConfField

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaClient.java
@@ -39,6 +39,7 @@ import org.apache.logging.log4j.Logger;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -56,6 +57,12 @@ public class HiveMetaClient {
     public static final String PARTITION_NULL_VALUE = "__HIVE_DEFAULT_PARTITION__";
     // Maximum number of idle metastore connections in the connection pool at any point.
     private static final int MAX_HMS_CONNECTION_POOL_SIZE = 32;
+
+    private static final String SCHEME_S3A = "s3a://";
+    private static final String SCHEME_S3 = "s3://";
+    private static final String SCHEME_S3N = "s3n://";
+    private static final String SCHEME_S3_PREFIX = "s3";
+
     private final LinkedList<AutoCloseClient> clientPool = new LinkedList<>();
     private final Object clientPoolLock = new Object();
 
@@ -87,7 +94,6 @@ public class HiveMetaClient {
         private final IMetaStoreClient hiveClient;
 
         private AutoCloseClient(HiveConf conf) throws MetaException {
-            System.out.println("new AutoCloseClient called");
             hiveClient = RetryingMetaStoreClient.getProxy(conf, dummyHookLoader,
                     HiveMetaStoreThriftClient.class.getName());
         }
@@ -131,6 +137,7 @@ public class HiveMetaClient {
         try (AutoCloseClient client = getClient()) {
             return client.hiveClient.getTable(dbName, tableName);
         } catch (Exception e) {
+            LOG.warn("get hive table failed", e);
             throw new DdlException("get hive table from meta store failed: " + e.getMessage());
         }
     }
@@ -155,6 +162,7 @@ public class HiveMetaClient {
                 return partitionKeys;
             }
         } catch (Exception e) {
+            LOG.warn("get partition keys failed", e);
             throw new DdlException("get hive partition keys from meta store failed: " + e.getMessage());
         }
     }
@@ -163,6 +171,7 @@ public class HiveMetaClient {
         try (AutoCloseClient client = getClient()) {
             return client.hiveClient.partitionNameToVals(partName);
         } catch (Exception e) {
+            LOG.warn("convert partitionName to vals failed", e);
             throw new DdlException("convert partition name to vals failed: " + e.getMessage());
         }
     }
@@ -182,8 +191,9 @@ public class HiveMetaClient {
                 throw new DdlException("unsupported file format [" + sd.getInputFormat() + "]");
             }
 
-            List<HdfsFileDesc> fileDescs = getHdfsFileDescs(sd.getLocation());
-            return new HivePartition(format, ImmutableList.copyOf(fileDescs), sd.getLocation());
+            String path = formatObjectStoragePath(sd.getLocation());
+            List<HdfsFileDesc> fileDescs = getHdfsFileDescs(path);
+            return new HivePartition(format, ImmutableList.copyOf(fileDescs), path);
         } catch (NoSuchObjectException e) {
             throw new DdlException("get hive partition meta data failed: "
                     + "partition not exists, partValues: "
@@ -194,12 +204,24 @@ public class HiveMetaClient {
         }
     }
 
+    private String formatObjectStoragePath(String path) {
+        if (path.startsWith(SCHEME_S3)) {
+            return SCHEME_S3A + path.substring(5);
+        }
+        if (path.startsWith(SCHEME_S3N)) {
+            return SCHEME_S3A + path.substring(6);
+        }
+
+        return path;
+    }
+
     public HiveTableStats getTableStats(String dbName, String tableName) throws DdlException {
         try (AutoCloseClient client = getClient()) {
             Table table = client.hiveClient.getTable(dbName, tableName);
             Map<String, String> parameters = table.getParameters();
             return new HiveTableStats(Utils.getRowCount(parameters), Utils.getTotalSize(parameters));
         } catch (Exception e) {
+            LOG.warn("get table stats failed", e);
             throw new DdlException("get hive table stats from meta store failed: " + e.getMessage());
         }
     }
@@ -217,6 +239,7 @@ public class HiveMetaClient {
             }
             return new HivePartitionStats(Utils.getRowCount(parameters));
         } catch (Exception e) {
+            LOG.warn("get partition stats failed", e);
             throw new DdlException("get hive partition stats from hive metastore failed: " + e.getMessage());
         }
     }
@@ -244,6 +267,7 @@ public class HiveMetaClient {
             }
             return statsMap;
         } catch (Exception e) {
+            LOG.warn("get table level column stats for unpartition table failed", e);
             throw new DdlException("get table column statistics from hive metastore failed: " + e.getMessage());
         }
     }
@@ -269,6 +293,7 @@ public class HiveMetaClient {
         try (AutoCloseClient client = getClient()) {
             partitions = client.hiveClient.getPartitionsByNames(dbName, tableName, partNames);
         } catch (Exception e) {
+            LOG.warn("get table level column stats for partition table failed", e);
             throw new DdlException("get partitions from hive metastore failed: " + e.getMessage());
         }
         for (Partition partition : partitions) {
@@ -458,7 +483,7 @@ public class HiveMetaClient {
                 }
                 String fileName = Utils.getSuffixName(dirPath, locatedFileStatus.getPath().toString());
                 BlockLocation[] blockLocations = locatedFileStatus.getBlockLocations();
-                List<HdfsFileBlockDesc> fileBlockDescs = getHdfsFileBlockDescs(blockLocations);
+                List<HdfsFileBlockDesc> fileBlockDescs = getHdfsFileBlockDescs(blockLocations, isObjectStorage(dirPath));
                 fileDescs.add(new HdfsFileDesc(fileName, "", locatedFileStatus.getLen(),
                         ImmutableList.copyOf(fileBlockDescs)));
             }
@@ -466,6 +491,10 @@ public class HiveMetaClient {
             // hive empty partition may not create directory
         }
         return fileDescs;
+    }
+
+    private boolean isObjectStorage(String path) {
+        return path.startsWith(SCHEME_S3_PREFIX);
     }
 
     private boolean isValidDataFile(FileStatus fileStatus) {
@@ -478,24 +507,83 @@ public class HiveMetaClient {
                 lcFileName.endsWith(".copying") || lcFileName.endsWith(".tmp"));
     }
 
-    private List<HdfsFileBlockDesc> getHdfsFileBlockDescs(BlockLocation[] blockLocations) throws IOException {
+    private List<HdfsFileBlockDesc> getHdfsFileBlockDescs(BlockLocation[] blockLocations,
+                                                          boolean isObjectStorage) throws IOException {
         List<HdfsFileBlockDesc> fileBlockDescs = Lists.newArrayList();
         for (BlockLocation blockLocation : blockLocations) {
-            String[] hostNames = blockLocation.getNames();
-            long[] replicaHostIds = new long[hostNames.length];
-            for (int j = 0; j < hostNames.length; j++) {
-                String name = hostNames[j];
-                replicaHostIds[j] = getHostId(name);
+            if (isObjectStorage) {
+                // For object storage, the blockLocation size is always the full file size
+                // We should split into smaller blocks to increase the degree of parallelism
+                fileBlockDescs.addAll(splitObjectStorageBlock(blockLocation));
+            } else {
+                fileBlockDescs.add(buildHdfsFileBlockDesc(
+                        blockLocation.getOffset(),
+                        blockLocation.getLength(),
+                        getReplicaHostIds(blockLocation.getNames()))
+                );
             }
-            fileBlockDescs.add(new HdfsFileBlockDesc(blockLocation.getOffset(),
-                    blockLocation.getLength(),
-                    replicaHostIds,
-                    // TODO get storageId through blockStorageLocation.getVolumeIds()
-                    // because this function is a rpc call, we give a fake value now.
-                    // Set it to real value, when planner needs this param.
-                    new long[] {UNKNOWN_STORAGE_ID},
-                    this));
         }
+        return fileBlockDescs;
+    }
+
+    private long[] getReplicaHostIds(String[] hostNames) {
+        long[] replicaHostIds = new long[hostNames.length];
+        for (int j = 0; j < hostNames.length; j++) {
+            String name = hostNames[j];
+            replicaHostIds[j] = getHostId(name);
+        }
+        return replicaHostIds;
+    }
+
+    private HdfsFileBlockDesc buildHdfsFileBlockDesc(long offset, long length, long[] replicaHostIds) {
+        return new HdfsFileBlockDesc(offset,
+                length,
+                replicaHostIds,
+                // TODO get storageId through blockStorageLocation.getVolumeIds()
+                // because this function is a rpc call, we give a fake value now.
+                // Set it to real value, when planner needs this param.
+                new long[] {UNKNOWN_STORAGE_ID},
+                this
+        );
+    }
+
+    private List<HdfsFileBlockDesc> splitObjectStorageBlock(BlockLocation blockLocation) throws IOException {
+        List<HdfsFileBlockDesc> fileBlockDescs = new ArrayList<>();
+        long remainingBytes = blockLocation.getLength();
+        // NOTE: Config.object_storage_block_size should be extracted to a local variable,
+        // because it may be changed in the loop
+        long blockSize = Config.object_storage_block_size;
+        do {
+            if (remainingBytes <= blockSize) {
+                fileBlockDescs.add(buildHdfsFileBlockDesc(
+                        blockLocation.getOffset() + blockLocation.getLength() - remainingBytes,
+                        remainingBytes,
+                        getReplicaHostIds(blockLocation.getNames())
+                ));
+                remainingBytes = 0;
+            } else if (remainingBytes <= 2 * blockSize) {
+                long mid = (remainingBytes + 1) / 2;
+                fileBlockDescs.add(buildHdfsFileBlockDesc(
+                        blockLocation.getOffset() + blockLocation.getLength() - remainingBytes,
+                        mid,
+                        getReplicaHostIds(blockLocation.getNames())
+                ));
+                fileBlockDescs.add(buildHdfsFileBlockDesc(
+                        blockLocation.getOffset() + blockLocation.getLength() - remainingBytes + mid,
+                        remainingBytes - mid,
+                        getReplicaHostIds(blockLocation.getNames())
+                ));
+                remainingBytes = 0;
+            } else {
+                fileBlockDescs.add(buildHdfsFileBlockDesc(
+                        blockLocation.getOffset() + blockLocation.getLength() - remainingBytes,
+                        blockSize,
+                        getReplicaHostIds(blockLocation.getNames())
+                ));
+                remainingBytes -= blockSize;
+            }
+        } while (remainingBytes > 0);
+
         return fileBlockDescs;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Auth.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Auth.java
@@ -23,6 +23,7 @@ package com.starrocks.mysql.privilege;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.starrocks.analysis.AlterUserStmt;
@@ -53,7 +54,6 @@ import com.starrocks.persist.PrivInfo;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TFetchResourceResult;
-import org.apache.directory.api.util.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -498,7 +498,7 @@ public class Auth implements Writable {
     // create user
     public void createUser(CreateUserStmt stmt) throws DdlException {
         AuthPlugin authPlugin = null;
-        if (!Strings.isEmpty(stmt.getAuthPlugin())) {
+        if (!Strings.isNullOrEmpty(stmt.getAuthPlugin())) {
             authPlugin = AuthPlugin.valueOf(stmt.getAuthPlugin());
         }
         createUserInternal(stmt.getUserIdent(), stmt.getQualifiedRole(),
@@ -508,7 +508,7 @@ public class Auth implements Writable {
     // alter user
     public void alterUser(AlterUserStmt stmt) throws DdlException {
         AuthPlugin authPlugin = null;
-        if (!Strings.isEmpty(stmt.getAuthPlugin())) {
+        if (Strings.isNullOrEmpty(stmt.getAuthPlugin())) {
             authPlugin = AuthPlugin.valueOf(stmt.getAuthPlugin());
         }
         // alter user only support change password till now
@@ -1199,7 +1199,7 @@ public class Auth implements Writable {
                     userAuthInfo.add(password.getAuthPlugin().name());
                 }
 
-                if (Strings.isEmpty(password.getUserForAuthPlugin())) {
+                if (Strings.isNullOrEmpty(password.getUserForAuthPlugin())) {
                     userAuthInfo.add(FeConstants.null_string);
                 } else {
                     userAuthInfo.add(password.getUserForAuthPlugin());

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Auth.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Auth.java
@@ -508,7 +508,7 @@ public class Auth implements Writable {
     // alter user
     public void alterUser(AlterUserStmt stmt) throws DdlException {
         AuthPlugin authPlugin = null;
-        if (Strings.isNullOrEmpty(stmt.getAuthPlugin())) {
+        if (!Strings.isNullOrEmpty(stmt.getAuthPlugin())) {
             authPlugin = AuthPlugin.valueOf(stmt.getAuthPlugin());
         }
         // alter user only support change password till now

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Password.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Password.java
@@ -2,13 +2,13 @@
 
 package com.starrocks.mysql.privilege;
 
+import com.google.common.base.Strings;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.mysql.MysqlPassword;
 import com.starrocks.mysql.security.LdapSecurity;
 import com.starrocks.persist.gson.GsonUtils;
-import org.apache.directory.api.util.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -97,7 +97,7 @@ public class Password implements Writable {
             if (remotePassword[remotePassword.length - 1] == 0) {
                 clearPassword = Arrays.copyOf(remotePassword, remotePassword.length - 1);
             }
-            if (Strings.isNotEmpty(userForAuthPlugin)) {
+            if (Strings.isNullOrEmpty(userForAuthPlugin)) {
                 return LdapSecurity.checkPassword(userForAuthPlugin, new String(clearPassword, StandardCharsets.UTF_8));
             } else {
                 return LdapSecurity.checkPasswordByRoot(remoteUser, new String(clearPassword, StandardCharsets.UTF_8));
@@ -117,7 +117,7 @@ public class Password implements Writable {
         if (authPlugin == null || authPlugin == AuthPlugin.MYSQL_NATIVE_PASSWORD) {
             return MysqlPassword.checkPlainPass(password, remotePassword);
         } else if (authPlugin == AuthPlugin.AUTHENTICATION_LDAP_SIMPLE) {
-            if (Strings.isNotEmpty(userForAuthPlugin)) {
+            if (Strings.isNullOrEmpty(userForAuthPlugin)) {
                 return LdapSecurity.checkPassword(userForAuthPlugin, remotePassword);
             } else {
                 return LdapSecurity.checkPasswordByRoot(remoteUser, remotePassword);

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Password.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Password.java
@@ -97,7 +97,7 @@ public class Password implements Writable {
             if (remotePassword[remotePassword.length - 1] == 0) {
                 clearPassword = Arrays.copyOf(remotePassword, remotePassword.length - 1);
             }
-            if (Strings.isNullOrEmpty(userForAuthPlugin)) {
+            if (!Strings.isNullOrEmpty(userForAuthPlugin)) {
                 return LdapSecurity.checkPassword(userForAuthPlugin, new String(clearPassword, StandardCharsets.UTF_8));
             } else {
                 return LdapSecurity.checkPasswordByRoot(remoteUser, new String(clearPassword, StandardCharsets.UTF_8));
@@ -117,7 +117,7 @@ public class Password implements Writable {
         if (authPlugin == null || authPlugin == AuthPlugin.MYSQL_NATIVE_PASSWORD) {
             return MysqlPassword.checkPlainPass(password, remotePassword);
         } else if (authPlugin == AuthPlugin.AUTHENTICATION_LDAP_SIMPLE) {
-            if (Strings.isNullOrEmpty(userForAuthPlugin)) {
+            if (!Strings.isNullOrEmpty(userForAuthPlugin)) {
                 return LdapSecurity.checkPassword(userForAuthPlugin, remotePassword);
             } else {
                 return LdapSecurity.checkPasswordByRoot(remoteUser, remotePassword);

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -573,7 +573,7 @@ under the License.
             <dependency>
                 <groupId>org.apache.hadoop</groupId>
                 <artifactId>hadoop-common</artifactId>
-                <version>2.6.5</version>
+                <version>3.3.0</version>
                 <scope>provided</scope>
                 <exclusions>
                     <exclusion>
@@ -675,7 +675,7 @@ under the License.
             <dependency>
                 <groupId>org.apache.hadoop</groupId>
                 <artifactId>hadoop-client</artifactId>
-                <version>2.10.1</version>
+                <version>3.3.0</version>
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/com.fasterxml.uuid/java-uuid-generator -->
@@ -683,6 +683,13 @@ under the License.
                 <groupId>com.fasterxml.uuid</groupId>
                 <artifactId>java-uuid-generator</artifactId>
                 <version>4.0</version>
+            </dependency>
+
+            <!-- https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-aws -->
+            <dependency>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>hadoop-aws</artifactId>
+                <version>3.3.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/thirdparty/vars-aarch64.sh
+++ b/thirdparty/vars-aarch64.sh
@@ -13,7 +13,7 @@
 HADOOP_DOWNLOAD="https://cdn-thirdparty.starrocks.com/hadoop-3.3.0-aarch64.tar.gz"
 HADOOP_NAME="hadoop-3.3.0-aarch64.tar.gz"
 HADOOP_SOURCE="hadoop-3.3.0-aarch64"
-HADOOP_MD5SUM="4e2e3e0dc8a1d80e1940565bbf6199a4"
+HADOOP_MD5SUM="c84cfa985175341d3df0b2b57521eec9"
 
 # OPEN JDK FOR aarch64, provided by huawei kunpeng (https://www.hikunpeng.com/zh/developer/devkit/compiler)
 JDK_DOWNLOAD="https://mirror.iscas.ac.cn/kunpeng/archive/compiler/bisheng_jdk/bisheng-jdk-8u262-linux-aarch64.tar.gz"

--- a/thirdparty/vars-x86_64.sh
+++ b/thirdparty/vars-x86_64.sh
@@ -13,7 +13,7 @@
 HADOOP_DOWNLOAD="https://cdn-thirdparty.starrocks.com/hadoop-3.3.0.tar.gz"
 HADOOP_NAME="hadoop-3.3.0.tar.gz"
 HADOOP_SOURCE="hadoop-3.3.0"
-HADOOP_MD5SUM="c4ba5155ec44abcb63d183d2dbe38df9"
+HADOOP_MD5SUM="46c5004739df0c452610d5946eb8ce28"
 
 # OPEN JDK
 JDK_DOWNLOAD="https://cdn-thirdparty.starrocks.com/java-se-8u41-ri.tar.gz"


### PR DESCRIPTION
Access Apache Hive installed on S3 through hadoop-aws client. The user needs to specify the three parameters fs.s3a.access.key、fs.s3a.secret.key and fs.s3a.endpoint in the core-site.xml of FE and BE. If we find that the read performance cannot meet the demand, we can directly access through the native S3 client.