### PR TITLE
set output column of VALUES to nullable if expr of any row is nullable

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/ValuesTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/ValuesTransformer.java
@@ -57,6 +57,15 @@ public class ValuesTransformer {
             subqueriesIndex.set(i, !tmp.isEmpty());
             ColumnRefOperator output = columnRefFactory
                     .create(expr, node.getRelationFields().getFieldByIndex(i).getType(), expr.isNullable());
+            if (!output.isNullable()) {
+                // The output column should be nullable, if the expression of any row is nullable.
+                for (List<Expr> row : node.getRows()) {
+                    if (row.get(i).isNullable()) {
+                        output.setNullable(true);
+                        break;
+                    }
+                }
+            }
             outputColumns.add(output);
             if (tmp.isEmpty()) {
                 valuesOutputColumns.add(output);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSetOperationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSetOperationTest.java
@@ -1,12 +1,20 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
 package com.starrocks.sql.analyzer;
 
+import com.starrocks.catalog.Type;
+import com.starrocks.sql.analyzer.relation.QueryRelation;
+import com.starrocks.sql.optimizer.base.ColumnRefFactory;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.transformer.LogicalPlan;
+import com.starrocks.sql.optimizer.transformer.RelationTransformer;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.File;
+import java.util.List;
 import java.util.UUID;
 
 import static com.starrocks.sql.analyzer.AnalyzeTestUtil.analyzeFail;
@@ -67,5 +75,19 @@ public class AnalyzeSetOperationTest {
     public void testValues() {
         analyzeFail("(SELECT 1 AS c1, 2 AS c2) UNION ALL SELECT * FROM (VALUES (10, 1006), (NULL)) tmp",
                 "Values have unequal number of columns");
+
+        // column_0 should be non-nullable VARCHAR, and column_1 should be nullable TINYINT.
+        String sql = "SELECT * FROM (VALUES (1,  2), (3, 4), ('10', NULL)) t;";
+        QueryRelation queryRelation = analyzeSuccess(sql);
+
+        ColumnRefFactory columnRefFactory = new ColumnRefFactory();
+        LogicalPlan logicalPlan = new RelationTransformer(columnRefFactory).transform(queryRelation);
+        List<ColumnRefOperator> outColumns = logicalPlan.getOutputColumn();
+
+        Assert.assertEquals(2, outColumns.size());
+        Assert.assertEquals(Type.VARCHAR, outColumns.get(0).getType());
+        Assert.assertFalse(outColumns.get(0).isNullable());
+        Assert.assertEquals(Type.TINYINT, outColumns.get(1).getType());
+        Assert.assertTrue(outColumns.get(1).isNullable());
     }
 }


### PR DESCRIPTION
If the query SQL sorts the rows of `VALUES`, the output chunk of `UnionNode` will input to the `SortNode` directly without sink and exchange. 

The output column type of const `UnionNode` is always non-nullable. Each row of `VLAUES` output a chunk in `UnionNode`, and `nullable` of the output chunk 's real output column is `true`, if the output column type or the evaluation result of the `VALUES` expression is `true`.
The SortNode uses the first output chunk columns from `UnionNode` as the base columns object.

Therefore, if there is a `NULL` value in any row which is not the first row of `VALUES`, the result will be incorrect. 

An example is as follows.

- The SQL query:
```sql
SELECT * FROM (VALUES (1,  2), (3, 4), (10, NULL)) t ORDER BY column_0;
```

- The result:
```
+----------+----------+
| column_0 | column_1 |
+----------+----------+
|        1 |        2 |
|        3 |        4 |
|       10 |     -104 |
+----------+----------+
```

- The execution plan:
```
+-------------------------------------+
| Explain String                      |
+-------------------------------------+
| WORK ON CBO OPTIMIZER               |
| PLAN FRAGMENT 0                     |
|  OUTPUT EXPRS:1: expr | 2: expr     |
|   PARTITION: UNPARTITIONED          |
|                                     |
|   RESULT SINK                       |
|                                     |
|   2:MERGING-EXCHANGE                |
|      use vectorized: true           |
|                                     |
| PLAN FRAGMENT 1                     |
|  OUTPUT EXPRS:                      |
|   PARTITION: UNPARTITIONED          |
|                                     |
|   STREAM DATA SINK                  |
|     EXCHANGE ID: 02                 |
|     UNPARTITIONED                   |
|                                     |
|   1:SORT                            |
|   |  order by: <slot 1> 1: expr ASC |
|   |  offset: 0                      |
|   |  use vectorized: true           |
|   |                                 |
|   0:UNION                           |
|      constant exprs:                |
|          1 | 2                      |
|          3 | 4                      |
|          10 | NULL                  |
|      use vectorized: true           |
+-------------------------------------+
```


