### PR TITLE
Fix create view on select * sql throw fail bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/SelectStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/SelectStmt.java
@@ -1753,7 +1753,10 @@ public class SelectStmt extends QueryStmt {
             originalExpr = Expr.cloneList(resultExprs);
         }
 
-        if (!resultExprs.isEmpty()) {
+        if (needToSql && selectList.getItems().stream().allMatch(SelectListItem::isStar)) {
+            strBuilder.append(selectList.getItems().stream().map(SelectListItem::toSql)
+                    .collect(Collectors.joining(", ")));
+        } else if (!resultExprs.isEmpty()) {
             for (int i = 0; i < resultExprs.size(); ++i) {
                 // strBuilder.append(selectList.getItems().get(i).toSql());
                 // strBuilder.append((i + 1 != selectList.getItems().size()) ? ", " : "");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ViewPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ViewPlanTest.java
@@ -1514,4 +1514,16 @@ public class ViewPlanTest extends PlanTestBase {
         sql = "select array_sum(v3) from tarray";
         testView(sql);
     }
+
+    @Test
+    public void testWithSelectStar() throws Exception {
+        String sql = "with xx1 as (select v1 + 1, v2 + 2 from t0) select * from xx1";
+        testView(sql);
+
+        sql = "with xx1 as (select * from t0) select * from xx1";
+        testView(sql);
+
+        sql = "with xx1 as (select v1, v2 from t0) select * from xx1";
+        testView(sql);
+    }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5609319/138652980-f5958902-9ed5-4c22-9508-86a88665b7c5.png)

Will fail if select clause not contains alias witch sql in with statment and select * from with statement