### PR TITLE
Refactor: use index id as schema id

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/RollupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/RollupJob.java
@@ -753,7 +753,7 @@ public class RollupJob extends AlterJob {
                 } // end for partitions
 
                 // set index's info
-                olapTable.setIndexMeta(rollupIndexId, rollupIndexName, rollupIndexId, rollupSchema, 0, rollupSchemaHash,
+                olapTable.setIndexMeta(rollupIndexId, rollupIndexName, rollupSchema, 0, rollupSchemaHash,
                         rollupShortKeyColumnCount, rollupStorageType, KeysType.fromThrift(rollupKeysType));
                 Preconditions.checkState(olapTable.getState() == OlapTableState.ROLLUP);
 
@@ -888,7 +888,7 @@ public class RollupJob extends AlterJob {
                 }
             }
 
-            olapTable.setIndexMeta(rollupIndexId, rollupIndexName, rollupIndexId, rollupSchema, 0, rollupSchemaHash,
+            olapTable.setIndexMeta(rollupIndexId, rollupIndexName, rollupSchema, 0, rollupSchemaHash,
                     rollupShortKeyColumnCount, rollupStorageType, KeysType.fromThrift(rollupKeysType));
         } finally {
             db.writeUnlock();

--- a/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
@@ -235,7 +235,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
                         // version will be updated by following load process, or when rollup task finished.
                         CreateReplicaTask createReplicaTask = new CreateReplicaTask(
                                 backendId, dbId, tableId, partitionId, rollupIndexId, rollupTabletId,
-                                rollupShortKeyColumnCount, rollupIndexId, rollupSchemaHash,
+                                rollupShortKeyColumnCount, rollupSchemaHash,
                                 Partition.PARTITION_INIT_VERSION, Partition.PARTITION_INIT_VERSION_HASH,
                                 rollupKeysType, TStorageType.COLUMN, storageMedium,
                                 rollupSchema, tbl.getCopiedBfColumns(), tbl.getBfFpp(), countDownLatch,
@@ -318,7 +318,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
             partition.createRollupIndex(rollupIndex);
         }
 
-        tbl.setIndexMeta(rollupIndexId, rollupIndexName, rollupIndexId, rollupSchema, 0 /* initial schema version */,
+        tbl.setIndexMeta(rollupIndexId, rollupIndexName, rollupSchema, 0 /* initial schema version */,
                 rollupSchemaHash, rollupShortKeyColumnCount, TStorageType.COLUMN, rollupKeysType, origStmt);
         tbl.rebuildFullSchema();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -1230,8 +1230,8 @@ public class SchemaChangeHandler extends AlterHandler {
 
                 schemaChangeJob.addPartitionShadowIndex(partitionId, shadowIndexId, shadowIndex);
             } // end for partition
-            schemaChangeJob.addIndexSchema(shadowIndexId, originIndexId, newIndexName, shadowIndexId, newSchemaVersion,
-                    newSchemaHash, newShortKeyColumnCount, entry.getValue());
+            schemaChangeJob.addIndexSchema(shadowIndexId, originIndexId, newIndexName, newSchemaVersion, newSchemaHash,
+                    newShortKeyColumnCount, entry.getValue());
         } // end for index
 
         // set table state

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -1156,7 +1156,6 @@ public class SchemaChangeHandler extends AlterHandler {
             // generate schema hash for new index has to generate a new schema hash not equal to current schema hash
             int currentSchemaHash = currentIndexMeta.getSchemaHash();
             int newSchemaHash = Util.generateSchemaHash();
-            long newSchemaId = catalog.getNextId();
             while (currentSchemaHash == newSchemaHash) {
                 newSchemaHash = Util.generateSchemaHash();
             }
@@ -1231,7 +1230,7 @@ public class SchemaChangeHandler extends AlterHandler {
 
                 schemaChangeJob.addPartitionShadowIndex(partitionId, shadowIndexId, shadowIndex);
             } // end for partition
-            schemaChangeJob.addIndexSchema(shadowIndexId, originIndexId, newIndexName, newSchemaId, newSchemaVersion,
+            schemaChangeJob.addIndexSchema(shadowIndexId, originIndexId, newIndexName, shadowIndexId, newSchemaVersion,
                     newSchemaHash, newShortKeyColumnCount, entry.getValue());
         } // end for index
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJob.java
@@ -37,7 +37,6 @@ import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndex.IndexExtState;
 import com.starrocks.catalog.MaterializedIndex.IndexState;
-import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.OlapTable.OlapTableState;
 import com.starrocks.catalog.Partition;
@@ -848,8 +847,8 @@ public class SchemaChangeJob extends AlterJob {
                     int schemaVersion = changedIndexIdToSchemaVersion.get(indexId);
                     int schemaHash = changedIndexIdToSchemaHash.get(indexId);
                     short shortKeyColumnCount = changedIndexIdToShortKeyColumnCount.get(indexId);
-                    olapTable.setIndexMeta(indexId, null, MaterializedIndexMeta.INVALID_SCHEMA_ID, entry.getValue(),
-                            schemaVersion, schemaHash, shortKeyColumnCount, newStorageType, null);
+                    olapTable.setIndexMeta(indexId, null, entry.getValue(), schemaVersion, schemaHash,
+                            shortKeyColumnCount, newStorageType, null);
                 }
 
                 // 3. update base schema if changed
@@ -1013,8 +1012,8 @@ public class SchemaChangeJob extends AlterJob {
                 int schemaVersion = getSchemaVersionByIndexId(indexId);
                 int schemaHash = getSchemaHashByIndexId(indexId);
                 short shortKeyColumnCount = getShortKeyColumnCountByIndexId(indexId);
-                olapTable.setIndexMeta(indexId, null, MaterializedIndexMeta.INVALID_SCHEMA_ID, entry.getValue(),
-                        schemaVersion, schemaHash, shortKeyColumnCount, newStorageType, null);
+                olapTable.setIndexMeta(indexId, null, entry.getValue(), schemaVersion, schemaHash, shortKeyColumnCount,
+                        newStorageType, null);
 
                 if (indexId == olapTable.getBaseIndexId()) {
                     olapTable.setNewFullSchema(entry.getValue());

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -151,9 +151,8 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
         partitionIndexMap.put(partitionId, shadowIdxId, shadowIdx);
     }
 
-    public void addIndexSchema(long shadowIdxId, long originIdxId, String shadowIndexName, long newSchemaId,
-                               int shadowSchemaVersion, int shadowSchemaHash, short shadowIdxShortKeyCount,
-                               List<Column> shadowIdxSchema) {
+    public void addIndexSchema(long shadowIdxId, long originIdxId, String shadowIndexName, int shadowSchemaVersion,
+                               int shadowSchemaHash, short shadowIdxShortKeyCount, List<Column> shadowIdxSchema) {
         indexIdMap.put(shadowIdxId, originIdxId);
         indexIdToName.put(shadowIdxId, shadowIndexName);
         indexSchemaVersionAndHashMap.put(shadowIdxId, new SchemaVersionAndHash(shadowSchemaVersion, shadowSchemaHash));

--- a/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
@@ -781,7 +781,7 @@ public class RestoreJob extends AbstractJob {
                     Catalog.getCurrentInvertedIndex().addReplica(restoreTablet.getId(), restoreReplica);
                     CreateReplicaTask task = new CreateReplicaTask(restoreReplica.getBackendId(), dbId,
                             localTbl.getId(), restorePart.getId(), restoredIdx.getId(),
-                            restoreTablet.getId(), indexMeta.getShortKeyColumnCount(), indexMeta.getSchemaId(),
+                            restoreTablet.getId(), indexMeta.getShortKeyColumnCount(),
                             indexMeta.getSchemaHash(), restoreReplica.getVersion(),
                             restoreReplica.getVersionHash(), indexMeta.getKeysType(), TStorageType.COLUMN,
                             TStorageMedium.HDD /* all restored replicas will be saved to HDD */,

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -3710,7 +3710,6 @@ public class Catalog {
                         index.getId(),
                         tablet.getId(),
                         indexMeta.getShortKeyColumnCount(),
-                        indexMeta.getSchemaId(),
                         indexMeta.getSchemaHash(),
                         partition.getVisibleVersion(),
                         partition.getVisibleVersionHash(),
@@ -3965,7 +3964,7 @@ public class Catalog {
             throw new DdlException(e.getMessage());
         }
         int schemaHash = Util.schemaHash(schemaVersion, baseSchema, bfColumns, bfFpp);
-        olapTable.setIndexMeta(baseIndexId, tableName, baseIndexId, baseSchema, schemaVersion, schemaHash,
+        olapTable.setIndexMeta(baseIndexId, tableName, baseSchema, schemaVersion, schemaHash,
                 shortKeyColumnCount, baseIndexStorageType, keysType);
 
         for (AlterClause alterClause : stmt.getRollupAlterClauseList()) {
@@ -3988,7 +3987,7 @@ public class Catalog {
                     Catalog.calcShortKeyColumnCount(rollupColumns, alterClause.getProperties());
             int rollupSchemaHash = Util.schemaHash(schemaVersion, rollupColumns, bfColumns, bfFpp);
             long rollupIndexId = getCurrentCatalog().getNextId();
-            olapTable.setIndexMeta(rollupIndexId, addRollupClause.getRollupName(), rollupIndexId, rollupColumns, schemaVersion,
+            olapTable.setIndexMeta(rollupIndexId, addRollupClause.getRollupName(), rollupColumns, schemaVersion,
                     rollupSchemaHash, rollupShortKeyColumnCount, rollupIndexStorageType, keysType);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ExternalOlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ExternalOlapTable.java
@@ -421,7 +421,7 @@ public class ExternalOlapTable extends OlapTable {
                     }
                     columns.add(column);
                 }
-                MaterializedIndexMeta index = new MaterializedIndexMeta(indexMeta.getIndex_id(), indexMeta.getIndex_id(), columns,
+                MaterializedIndexMeta index = new MaterializedIndexMeta(indexMeta.getIndex_id(), columns,
                                                                         indexMeta.getSchema_meta().getSchema_version(),
                                                                         indexMeta.getSchema_meta().getSchema_hash(),
                                                                         indexMeta.getSchema_meta().getShort_key_col_count(),

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndexMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndexMeta.java
@@ -47,8 +47,6 @@ import java.util.Map;
 public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
     @SerializedName(value = "indexId")
     private long indexId;
-    @SerializedName(value = "schemaId")
-    private long schemaId = INVALID_SCHEMA_ID;
     @SerializedName(value = "schema")
     private List<Column> schema = Lists.newArrayList();
     @SerializedName(value = "schemaVersion")
@@ -64,13 +62,10 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
     @SerializedName(value = "defineStmt")
     private OriginStatement defineStmt;
 
-    public static final long INVALID_SCHEMA_ID = 0;
-
-    public MaterializedIndexMeta(long indexId, long schemaId, List<Column> schema, int schemaVersion, int schemaHash,
+    public MaterializedIndexMeta(long indexId, List<Column> schema, int schemaVersion, int schemaHash,
                                  short shortKeyColumnCount, TStorageType storageType, KeysType keysType,
                                  OriginStatement defineStmt) {
         this.indexId = indexId;
-        this.schemaId = schemaId;
         Preconditions.checkState(schema != null);
         Preconditions.checkState(schema.size() != 0);
         this.schema = schema;
@@ -102,10 +97,6 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
 
     public List<Column> getSchema() {
         return schema;
-    }
-
-    public long getSchemaId() {
-        return schemaId;
     }
 
     public int getSchemaHash() {
@@ -155,9 +146,6 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
         }
         MaterializedIndexMeta indexMeta = (MaterializedIndexMeta) obj;
         if (indexMeta.indexId != this.indexId) {
-            return false;
-        }
-        if (indexMeta.schemaId != this.schemaId) {
             return false;
         }
         if (indexMeta.schema.size() != this.schema.size() || !indexMeta.schema.containsAll(this.schema)) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -271,13 +271,13 @@ public class OlapTable extends Table {
         return indexNameToId.containsKey(indexName);
     }
 
-    public void setIndexMeta(long indexId, String indexName, long schemaId, List<Column> schema, int schemaVersion,
+    public void setIndexMeta(long indexId, String indexName, List<Column> schema, int schemaVersion,
                              int schemaHash, short shortKeyColumnCount, TStorageType storageType, KeysType keysType) {
-        setIndexMeta(indexId, indexName, schemaId, schema, schemaVersion, schemaHash, shortKeyColumnCount, storageType, keysType,
+        setIndexMeta(indexId, indexName, schema, schemaVersion, schemaHash, shortKeyColumnCount, storageType, keysType,
                 null);
     }
 
-    public void setIndexMeta(long indexId, String indexName, long schemaId, List<Column> schema, int schemaVersion,
+    public void setIndexMeta(long indexId, String indexName, List<Column> schema, int schemaVersion,
                              int schemaHash, short shortKeyColumnCount, TStorageType storageType, KeysType keysType,
                              OriginStatement origStmt) {
         // Nullable when meta comes from schema change log replay.
@@ -301,7 +301,7 @@ public class OlapTable extends Table {
             Preconditions.checkState(storageType == TStorageType.COLUMN);
         }
 
-        MaterializedIndexMeta indexMeta = new MaterializedIndexMeta(indexId, schemaId, schema, schemaVersion,
+        MaterializedIndexMeta indexMeta = new MaterializedIndexMeta(indexId, schema, schemaVersion,
                 schemaHash, shortKeyColumnCount, storageType, keysType, origStmt);
         indexIdToMeta.put(indexId, indexMeta);
         indexNameToId.put(indexName, indexId);
@@ -1086,7 +1086,7 @@ public class OlapTable extends Table {
                 short shortKeyColumnCount = in.readShort();
 
                 // The keys type in here is incorrect
-                MaterializedIndexMeta indexMeta = new MaterializedIndexMeta(indexId, indexId, schema, schemaVersion, schemaHash,
+                MaterializedIndexMeta indexMeta = new MaterializedIndexMeta(indexId, schema, schemaVersion, schemaHash,
                         shortKeyColumnCount, storageType, KeysType.AGG_KEYS, null);
                 tmpIndexMetaList.add(indexMeta);
             } else {

--- a/fe/fe-core/src/main/java/com/starrocks/master/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/master/ReportHandler.java
@@ -599,7 +599,7 @@ public class ReportHandler extends Daemon {
                                     double bfFpp = olapTable.getBfFpp();
                                     CreateReplicaTask createReplicaTask = new CreateReplicaTask(backendId, dbId,
                                             tableId, partitionId, indexId, tabletId, indexMeta.getShortKeyColumnCount(),
-                                            indexMeta.getSchemaHash(), indexMeta.getSchemaHash(), partition.getVisibleVersion(),
+                                            indexMeta.getSchemaHash(), partition.getVisibleVersion(),
                                             partition.getVisibleVersionHash(), indexMeta.getKeysType(),
                                             TStorageType.COLUMN,
                                             TStorageMedium.HDD, indexMeta.getSchema(), bfColumns, bfFpp, null,

--- a/fe/fe-core/src/main/java/com/starrocks/task/CreateReplicaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/CreateReplicaTask.java
@@ -87,7 +87,7 @@ public class CreateReplicaTask extends AgentTask {
     private boolean isRecoverTask = false;
 
     public CreateReplicaTask(long backendId, long dbId, long tableId, long partitionId, long indexId, long tabletId,
-                             short shortKeyColumnCount, long schemaId, int schemaHash, long version, long versionHash,
+                             short shortKeyColumnCount, int schemaHash, long version, long versionHash,
                              KeysType keysType, TStorageType storageType,
                              TStorageMedium storageMedium, List<Column> columns,
                              Set<String> bfColumns, double bfFpp, MarkedCountDownLatch<Long, Long> latch,
@@ -98,7 +98,6 @@ public class CreateReplicaTask extends AgentTask {
 
         this.shortKeyColumnCount = shortKeyColumnCount;
         this.schemaHash = schemaHash;
-        this.schemaId = schemaId;
 
         this.version = version;
         this.versionHash = versionHash;
@@ -170,7 +169,7 @@ public class CreateReplicaTask extends AgentTask {
         tSchema.setSchema_hash(schemaHash);
         tSchema.setKeys_type(keysType.toThrift());
         tSchema.setStorage_type(storageType);
-        tSchema.setId(schemaId);
+        tSchema.setId(indexId); // use index id as the schema id. assume schema change will assign a new index id.
 
         List<TColumn> tColumns = new ArrayList<TColumn>();
         for (Column column : columns) {

--- a/fe/fe-core/src/main/java/com/starrocks/task/CreateReplicaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/CreateReplicaTask.java
@@ -50,7 +50,6 @@ public class CreateReplicaTask extends AgentTask {
 
     private short shortKeyColumnCount;
     private int schemaHash;
-    private long schemaId;
 
     private long version;
     private long versionHash;

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AccessTestUtil.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AccessTestUtil.java
@@ -105,7 +105,7 @@ public class AccessTestUtil {
             baseSchema.add(column);
             OlapTable table = new OlapTable(30000, "testTbl", baseSchema,
                     KeysType.AGG_KEYS, new SinglePartitionInfo(), distributionInfo, catalog.getClusterId(), null);
-            table.setIndexMeta(baseIndex.getId(), "testTbl", baseIndex.getId(), baseSchema, 0, 1, (short) 1,
+            table.setIndexMeta(baseIndex.getId(), "testTbl", baseSchema, 0, 1, (short) 1,
                     TStorageType.COLUMN, KeysType.AGG_KEYS);
             table.addPartition(partition);
             table.setBaseIndexId(baseIndex.getId());

--- a/fe/fe-core/src/test/java/com/starrocks/backup/CatalogMocker.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/CatalogMocker.java
@@ -258,7 +258,7 @@ public class CatalogMocker {
         tablet0.addReplica(replica1);
         tablet0.addReplica(replica2);
 
-        olapTable.setIndexMeta(TEST_TBL_ID, TEST_TBL_NAME, TEST_TBL_ID, TEST_TBL_BASE_SCHEMA, 0, SCHEMA_HASH, (short) 1,
+        olapTable.setIndexMeta(TEST_TBL_ID, TEST_TBL_NAME, TEST_TBL_BASE_SCHEMA, 0, SCHEMA_HASH, (short) 1,
                 TStorageType.COLUMN, KeysType.AGG_KEYS);
         olapTable.addPartition(partition);
         db.createTable(olapTable);
@@ -342,7 +342,7 @@ public class CatalogMocker {
         baseTabletP2.addReplica(replica7);
         baseTabletP2.addReplica(replica8);
 
-        olapTable2.setIndexMeta(TEST_TBL2_ID, TEST_TBL2_NAME, TEST_TBL2_ID, TEST_TBL_BASE_SCHEMA, 0, SCHEMA_HASH, (short) 1,
+        olapTable2.setIndexMeta(TEST_TBL2_ID, TEST_TBL2_NAME, TEST_TBL_BASE_SCHEMA, 0, SCHEMA_HASH, (short) 1,
                 TStorageType.COLUMN, KeysType.AGG_KEYS);
         olapTable2.addPartition(partition1);
         olapTable2.addPartition(partition2);
@@ -380,7 +380,7 @@ public class CatalogMocker {
 
         partition2.createRollupIndex(rollupIndexP2);
 
-        olapTable2.setIndexMeta(TEST_ROLLUP_ID, TEST_ROLLUP_NAME, TEST_ROLLUP_ID, TEST_ROLLUP_SCHEMA, 0, ROLLUP_SCHEMA_HASH,
+        olapTable2.setIndexMeta(TEST_ROLLUP_ID, TEST_ROLLUP_NAME, TEST_ROLLUP_SCHEMA, 0, ROLLUP_SCHEMA_HASH,
                 (short) 1, TStorageType.COLUMN, KeysType.AGG_KEYS);
         db.createTable(olapTable2);
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogTestUtil.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogTestUtil.java
@@ -220,8 +220,7 @@ public class CatalogTestUtil {
         OlapTable table = new OlapTable(tableId, testTable1, columns, KeysType.AGG_KEYS, partitionInfo,
                 distributionInfo);
         table.addPartition(partition);
-        table.setIndexMeta(indexId, testIndex1, indexId, columns, 0, testSchemaHash1, (short) 1,
-                TStorageType.COLUMN, KeysType.AGG_KEYS);
+        table.setIndexMeta(indexId, testIndex1, columns, 0, testSchemaHash1, (short) 1, TStorageType.COLUMN, KeysType.AGG_KEYS);
         table.setBaseIndexId(indexId);
         // db
         Database db = new Database(dbId, testDb1);

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/DatabaseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/DatabaseTest.java
@@ -179,13 +179,13 @@ public class DatabaseTest {
         OlapTable table = new OlapTable(1000, "table", columns, KeysType.AGG_KEYS,
                 new SinglePartitionInfo(), new RandomDistributionInfo(10));
         short shortKeyColumnCount = 1;
-        table.setIndexMeta(1000, "group1", 1000, columns, 1, 1, shortKeyColumnCount, TStorageType.COLUMN, KeysType.AGG_KEYS);
+        table.setIndexMeta(1000, "group1", columns, 1, 1, shortKeyColumnCount, TStorageType.COLUMN, KeysType.AGG_KEYS);
 
         List<Column> column = Lists.newArrayList();
         column.add(column2);
-        table.setIndexMeta(1, "test", 1, column, 1, 1, shortKeyColumnCount,
+        table.setIndexMeta(1, "test", column, 1, 1, shortKeyColumnCount,
                 TStorageType.COLUMN, KeysType.AGG_KEYS);
-        table.setIndexMeta(1, "test", 1, column, 1, 1, shortKeyColumnCount, TStorageType.COLUMN,
+        table.setIndexMeta(1, "test", column, 1, 1, shortKeyColumnCount, TStorageType.COLUMN,
                 KeysType.AGG_KEYS);
         Deencapsulation.setField(table, "baseIndexId", 1);
         table.addPartition(partition);

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedIndexMetaTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedIndexMetaTest.java
@@ -83,7 +83,7 @@ public class MaterializedIndexMetaTest {
         schema.add(new Column("v1", Type.INT, false, AggregateType.SUM, true, "1", ""));
         schema.add(new Column(mvColumnName, Type.BITMAP, false, AggregateType.BITMAP_UNION, false, "1", ""));
         short shortKeyColumnCount = 1;
-        MaterializedIndexMeta indexMeta = new MaterializedIndexMeta(1, 1, schema, 1, 1, shortKeyColumnCount,
+        MaterializedIndexMeta indexMeta = new MaterializedIndexMeta(1, schema, 1, 1, shortKeyColumnCount,
                 TStorageType.COLUMN, KeysType.DUP_KEYS, new OriginStatement(
                 "create materialized view test as select k1, k2, k3, k4, k5, k6, k7, k8, k9, k10, k11, k12, sum(v1), "
                         + "bitmap_union(to_bitmap(k1)) from test group by k1, k2, k3, k4, k5, "

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TableTest.java
@@ -80,11 +80,11 @@ public class TableTest {
         OlapTable table1 = new OlapTable(1000L, "group1", columns, KeysType.AGG_KEYS,
                 new SinglePartitionInfo(), new RandomDistributionInfo(10));
         short shortKeyColumnCount = 1;
-        table1.setIndexMeta(1000, "group1", 1000, columns, 1, 1, shortKeyColumnCount, TStorageType.COLUMN, KeysType.AGG_KEYS);
+        table1.setIndexMeta(1000, "group1", columns, 1, 1, shortKeyColumnCount, TStorageType.COLUMN, KeysType.AGG_KEYS);
         List<Column> column = Lists.newArrayList();
         column.add(column2);
 
-        table1.setIndexMeta(2, "test", 2, column, 1, 1, shortKeyColumnCount, TStorageType.COLUMN,
+        table1.setIndexMeta(2, "test", column, 1, 1, shortKeyColumnCount, TStorageType.COLUMN,
                 KeysType.AGG_KEYS);
         Deencapsulation.setField(table1, "baseIndexId", 1000);
         table1.write(dos);

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/UnitTestUtil.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/UnitTestUtil.java
@@ -113,7 +113,7 @@ public class UnitTestUtil {
                 KeysType.AGG_KEYS, partitionInfo, distributionInfo);
         Deencapsulation.setField(table, "baseIndexId", indexId);
         table.addPartition(partition);
-        table.setIndexMeta(indexId, TABLE_NAME,indexId, columns, 0, SCHEMA_HASH, (short) 1, TStorageType.COLUMN,
+        table.setIndexMeta(indexId, TABLE_NAME, columns, 0, SCHEMA_HASH, (short) 1, TStorageType.COLUMN,
                 KeysType.AGG_KEYS);
 
         // db

--- a/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
@@ -164,7 +164,7 @@ abstract public class StarRocksHttpTestCase {
         OlapTable table = new OlapTable(testTableId, name, columns, KeysType.AGG_KEYS, partitionInfo,
                 distributionInfo);
         table.addPartition(partition);
-        table.setIndexMeta(testIndexId, "testIndex", testIndexId, columns, 0, testSchemaHash, (short) 1,
+        table.setIndexMeta(testIndexId, "testIndex", columns, 0, testSchemaHash, (short) 1,
                 TStorageType.COLUMN, KeysType.AGG_KEYS);
         table.setBaseIndexId(testIndexId);
         return table;

--- a/fe/fe-core/src/test/java/com/starrocks/persist/CreateTableInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/CreateTableInfoTest.java
@@ -96,11 +96,11 @@ public class CreateTableInfoTest {
         OlapTable table = new OlapTable(1000L, "table", columns, KeysType.AGG_KEYS,
                 new SinglePartitionInfo(), distributionInfo);
         short shortKeyColumnCount = 1;
-        table.setIndexMeta(1000, "group1", 1000, columns, 1, 1, shortKeyColumnCount, TStorageType.COLUMN, KeysType.AGG_KEYS);
+        table.setIndexMeta(1000, "group1", columns, 1, 1, shortKeyColumnCount, TStorageType.COLUMN, KeysType.AGG_KEYS);
 
         List<Column> column = Lists.newArrayList();
         column.add(column2);
-        table.setIndexMeta(1, "test", 1, column, 1, 1, shortKeyColumnCount,
+        table.setIndexMeta(1, "test", column, 1, 1, shortKeyColumnCount,
                 TStorageType.COLUMN, KeysType.AGG_KEYS);
         Deencapsulation.setField(table, "baseIndexId", 1000);
         table.addPartition(partition);

--- a/fe/fe-core/src/test/java/com/starrocks/task/AgentTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/task/AgentTaskTest.java
@@ -113,7 +113,7 @@ public class AgentTaskTest {
 
         // create
         createReplicaTask = new CreateReplicaTask(backendId1, dbId, tableId, partitionId,
-                indexId1, tabletId1, shortKeyNum, indexId1, schemaHash1,
+                indexId1, tabletId1, shortKeyNum, schemaHash1,
                 version, versionHash, KeysType.AGG_KEYS,
                 storageType, TStorageMedium.SSD,
                 columns, null, 0, latch, null,


### PR DESCRIPTION
I thought the index id will keep unchanged after schema change, but it turns out a new index id will be generated after schema change, so it's ok to just use the index id as the schema id.