### PR TITLE
Ignore the in-memory property of the tablet

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -806,7 +806,7 @@ void* TaskWorkerPool::_update_tablet_meta_worker_thread_callback(void* arg_this)
                     tablet->set_partition_id(tablet_meta_info.partition_id);
                     break;
                 case TTabletMetaType::INMEMORY:
-                    CHECK(false) << "in-memory tablet not supported";
+                    // This property is no longer supported.
                     break;
                 }
             }

--- a/be/src/storage/tablet_meta.cpp
+++ b/be/src/storage/tablet_meta.cpp
@@ -320,9 +320,10 @@ TabletMeta::TabletMeta(MemTracker* mem_tracker, int64_t table_id, int64_t partit
         schema->set_bf_fpp(tablet_schema.bloom_filter_fpp);
     }
 
-    if (tablet_schema.__isset.is_in_memory) {
-        schema->set_is_in_memory(tablet_schema.is_in_memory);
-    }
+    // NOTE: The in-memory property is no longer supported
+    // if (tablet_schema.__isset.is_in_memory) {
+    //     schema->set_is_in_memory(tablet_schema.is_in_memory);
+    // }
 
     init_from_pb(&tablet_meta_pb);
 }

--- a/be/src/storage/tablet_schema.cpp
+++ b/be/src/storage/tablet_schema.cpp
@@ -423,7 +423,6 @@ void TabletSchema::init_from_pb(const TabletSchemaPB& schema) {
         _has_bf_fpp = false;
         _bf_fpp = BLOOM_FILTER_DEFAULT_FPP;
     }
-    DCHECK(!schema.is_in_memory()) << "in-memory tablet not supported";
 }
 
 void TabletSchema::to_schema_pb(TabletSchemaPB* tablet_schema_pb) const {

--- a/be/src/storage/tablet_schema.h
+++ b/be/src/storage/tablet_schema.h
@@ -239,6 +239,9 @@ public:
     KeysType keys_type() const { return static_cast<KeysType>(_keys_type); }
     CompressKind compress_kind() const { return static_cast<CompressKind>(_compress_kind); }
     size_t next_column_unique_id() const { return _next_column_unique_id; }
+
+    // The in-memory property is no longer supported, but leave this API for compatibility.
+    // Newly-added code should not rely on this method, it may be removed at any time.
     bool is_in_memory() const { return false; }
 
     bool contains_format_v1_column() const;

--- a/be/test/storage/tablet_meta_manager_test.cpp
+++ b/be/test/storage/tablet_meta_manager_test.cpp
@@ -46,7 +46,6 @@ TEST_F(TabletMetaManagerTest, test_save_load_tablet_meta) {
     meta_pb.set_tablet_type(TabletTypePB::TABLET_TYPE_DISK);
     meta_pb.set_tablet_state(PB_RUNNING);
     meta_pb.mutable_schema()->set_keys_type(DUP_KEYS);
-    meta_pb.mutable_schema()->set_is_in_memory(false);
     auto c0 = meta_pb.mutable_schema()->add_column();
     c0->set_name("c0");
     c0->set_is_key(true);

--- a/be/test/storage/vectorized/memtable_test.cpp
+++ b/be/test/storage/vectorized/memtable_test.cpp
@@ -51,7 +51,6 @@ static shared_ptr<TabletSchema> create_tablet_schema(const string& desc, int nke
     tspb.set_keys_type(key_type);
     tspb.set_next_column_unique_id(cid);
     tspb.set_num_short_key_columns(nkey);
-    tspb.set_is_in_memory(false);
     shared_ptr<TabletSchema> ts(new TabletSchema());
     ts->init_from_pb(tspb);
     return ts;

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -182,7 +182,7 @@ message TabletSchemaPB {
     optional CompressKind compress_kind = 5; // OLAPHeaderMessage.compress_kind
     optional double bf_fpp = 6; // OLAPHeaderMessage.bf_fpp
     optional uint32 next_column_unique_id = 7; // OLAPHeaderMessage.next_column_unique_id
-    optional bool is_in_memory = 8 [default=false];
+    optional bool DEPRECATED_is_in_memory = 8 [default=false];
     optional int64 id = 9;
 }
 


### PR DESCRIPTION
The in-memory property of the tablet is no longer supported, the 
value of it will be ignored, but its interfaces are kept for compatibility. 
