### PR TITLE
Improve materialized view match rule

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -38,9 +38,6 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class Utils {
-    public static int combineHash(int hash, int value) {
-        return hash * 37 + value;
-    }
 
     public static List<ScalarOperator> extractConjuncts(ScalarOperator root) {
         if (null == root) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRule.java
@@ -57,6 +57,7 @@ public class MaterializedViewRule extends Rule {
     private final Map<Integer, Set<Integer>> columnIdsInPredicates = Maps.newHashMap();
     private final Map<Integer, Set<Integer>> columnIdsInGrouping = Maps.newHashMap();
     private final Map<Integer, Set<CallOperator>> aggFunctions = Maps.newHashMap();
+    private final ColumnRefSet columnIdsInAggregate = new ColumnRefSet();
     private final Map<Integer, Set<Integer>> columnIdsInQueryOutput = Maps.newHashMap();
     private final Map<Integer, Map<String, Integer>> columnNameToIds = Maps.newHashMap();
     private final List<LogicalOlapScanOperator> scanOperators = Lists.newArrayList();
@@ -323,6 +324,12 @@ public class MaterializedViewRule extends Rule {
 
     private void collectGroupByAndAggFunction(List<ScalarOperator> groupBys,
                                               List<CallOperator> aggs) {
+        if (groupBys.stream().map(ScalarOperator::getUsedColumns).anyMatch(columnIdsInAggregate::isIntersect) ||
+                aggs.stream().map(ScalarOperator::getUsedColumns).anyMatch(columnIdsInAggregate::isIntersect)) {
+            // Has been collect from other aggregate
+            return;
+        }
+
         for (ScalarOperator groupBy : groupBys) {
             ColumnRefSet columns = groupBy.getUsedColumns();
             for (int columnId : columns.getColumnIds()) {
@@ -354,6 +361,9 @@ public class MaterializedViewRule extends Rule {
                 disableSPJQueries(table);
             }
         }
+
+        groupBys.stream().map(ScalarOperator::getUsedColumns).forEach(columnIdsInAggregate::union);
+        aggs.stream().map(ScalarOperator::getUsedColumns).forEach(columnIdsInAggregate::union);
     }
 
     public void collectColumns(LogicalOlapScanOperator scanOperator,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRule.java
@@ -326,7 +326,7 @@ public class MaterializedViewRule extends Rule {
                                               List<CallOperator> aggs) {
         if (groupBys.stream().map(ScalarOperator::getUsedColumns).anyMatch(columnIdsInAggregate::isIntersect) ||
                 aggs.stream().map(ScalarOperator::getUsedColumns).anyMatch(columnIdsInAggregate::isIntersect)) {
-            // Has been collect from other aggregate
+            // Has been collect from other aggregate, only check aggregate node which is closest to scan node
             return;
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVRewriteTest.java
@@ -1087,4 +1087,14 @@ public class MVRewriteTest {
         query = "select approx_count_distinct(salary) from emps left outer join depts on emps.time = depts.time";
         starRocksAssert.query(query).explainContains("emps_mv");
     }
+
+    @Test
+    public void testMultipleAggregate() throws Exception {
+        String createEmpsMVSQL = "create materialized view " + EMPS_MV_NAME + " as select empid, deptno, sum(salary) "
+                + "from " + EMPS_TABLE_NAME + " group by empid, deptno;";
+        String query = "select deptno, sum(salary) as ssalary from " + EMPS_TABLE_NAME + " group by deptno";
+        starRocksAssert.withMaterializedView(createEmpsMVSQL).query(query).explainContains(QUERY_USE_EMPS_MV);
+        query = "select count(distinct deptno), MAX(ssalary) from (" + query + ") as zxcv123 group by deptno";
+        starRocksAssert.query(query).explainContains(QUERY_USE_EMPS_MV);
+    }
 }


### PR DESCRIPTION
For improve case:

```
create materialized view xx as select v1, sum(v2), sum(v3) from t0;
```

```
select count(distinct v1), sum(vvv2) from (select v1, sum(v2) as vvv2 from t0 group by v1) as xx1 group by v1
```
but the query can't hint materialized view xx