### PR TITLE
add `ZoneMapDetail` to expose more info to `ColumnPredicate`

### DIFF
--- a/be/src/storage/rowset/segment_v2/column_reader.h
+++ b/be/src/storage/rowset/segment_v2/column_reader.h
@@ -207,7 +207,8 @@ private:
     static void _parse_zone_map(const ZoneMapPB& zone_map, WrapperField* min_value_container,
                                 WrapperField* max_value_container);
 
-    Status _parse_zone_map(const ZoneMapPB& zm, vectorized::Datum* min, vectorized::Datum* max) const;
+    Status _parse_zone_map(const ZoneMapPB& zm, vectorized::Datum* min, vectorized::Datum* max,
+                           vectorized::ZoneMapDetail* detail) const;
 
     Status _get_filtered_pages(CondColumn* cond_column, CondColumn* delete_conditions,
                                std::unordered_set<uint32_t>* delete_partial_filtered_pages,

--- a/be/src/storage/rowset/segment_v2/column_reader.h
+++ b/be/src/storage/rowset/segment_v2/column_reader.h
@@ -62,6 +62,7 @@ class ReadableBlock;
 namespace vectorized {
 class ColumnPredicate;
 class Column;
+class ZoneMapDetail;
 } // namespace vectorized
 
 namespace segment_v2 {
@@ -207,8 +208,7 @@ private:
     static void _parse_zone_map(const ZoneMapPB& zone_map, WrapperField* min_value_container,
                                 WrapperField* max_value_container);
 
-    Status _parse_zone_map(const ZoneMapPB& zm, vectorized::Datum* min, vectorized::Datum* max,
-                           vectorized::ZoneMapDetail* detail) const;
+    Status _parse_zone_map(const ZoneMapPB& zm, vectorized::ZoneMapDetail* detail) const;
 
     Status _get_filtered_pages(CondColumn* cond_column, CondColumn* delete_conditions,
                                std::unordered_set<uint32_t>* delete_partial_filtered_pages,

--- a/be/src/storage/tablet_schema_map.cpp
+++ b/be/src/storage/tablet_schema_map.cpp
@@ -2,7 +2,10 @@
 
 #include "storage/tablet_schema_map.h"
 
+DIAGNOSTIC_PUSH
+DIAGNOSTIC_IGNORE("-Wclass-memaccess")
 #include <bvar/bvar.h>
+DIAGNOSTIC_POP
 
 namespace starrocks {
 

--- a/be/src/storage/vectorized/column_eq_predicate.cpp
+++ b/be/src/storage/vectorized/column_eq_predicate.cpp
@@ -75,7 +75,9 @@ public:
         }
     }
 
-    bool zone_map_filter(const Datum& min, const Datum& max, ZoneMapDetail* detail) const override {
+    bool zone_map_filter(const ZoneMapDetail& detail) const override {
+        const auto& min = detail.min_or_null_value();
+        const auto& max = detail.max_value();
         const auto type_info = this->type_info();
         return type_info->cmp(Datum(_value), min) >= 0 && type_info->cmp(Datum(_value), max) <= 0;
     }
@@ -216,7 +218,9 @@ public:
         }
     }
 
-    bool zone_map_filter(const Datum& min, const Datum& max, ZoneMapDetail* detail) const override {
+    bool zone_map_filter(const ZoneMapDetail& detail) const override {
+        const auto& min = detail.min_or_null_value();
+        const auto& max = detail.max_value();
         const auto type_info = this->type_info();
         return type_info->cmp(Datum(_value), min) >= 0 && type_info->cmp(Datum(_value), max) <= 0;
     }

--- a/be/src/storage/vectorized/column_eq_predicate.cpp
+++ b/be/src/storage/vectorized/column_eq_predicate.cpp
@@ -75,7 +75,7 @@ public:
         }
     }
 
-    bool zone_map_filter(const Datum& min, const Datum& max) const override {
+    bool zone_map_filter(const Datum& min, const Datum& max, ZoneMapDetail* detail) const override {
         const auto type_info = this->type_info();
         return type_info->cmp(Datum(_value), min) >= 0 && type_info->cmp(Datum(_value), max) <= 0;
     }
@@ -216,7 +216,7 @@ public:
         }
     }
 
-    bool zone_map_filter(const Datum& min, const Datum& max) const override {
+    bool zone_map_filter(const Datum& min, const Datum& max, ZoneMapDetail* detail) const override {
         const auto type_info = this->type_info();
         return type_info->cmp(Datum(_value), min) >= 0 && type_info->cmp(Datum(_value), max) <= 0;
     }

--- a/be/src/storage/vectorized/column_expr_predicate.cpp
+++ b/be/src/storage/vectorized/column_expr_predicate.cpp
@@ -71,7 +71,7 @@ public:
         }
     }
 
-    bool zone_map_filter(const Datum& min, const Datum& max, ZoneMapDetail* detail) const override {
+    bool zone_map_filter(const ZoneMapDetail& detail) const override {
         // todo(yan): once expr supports is_monotonic.
         return true;
     }

--- a/be/src/storage/vectorized/column_expr_predicate.cpp
+++ b/be/src/storage/vectorized/column_expr_predicate.cpp
@@ -71,7 +71,7 @@ public:
         }
     }
 
-    bool zone_map_filter(const Datum& min, const Datum& max) const override {
+    bool zone_map_filter(const Datum& min, const Datum& max, ZoneMapDetail* detail) const override {
         // todo(yan): once expr supports is_monotonic.
         return true;
     }

--- a/be/src/storage/vectorized/column_ge_predicate.cpp
+++ b/be/src/storage/vectorized/column_ge_predicate.cpp
@@ -71,7 +71,8 @@ public:
         }
     }
 
-    bool zone_map_filter(const Datum& min, const Datum& max, ZoneMapDetail* detail) const override {
+    bool zone_map_filter(const ZoneMapDetail& detail) const override {
+        const auto& max = detail.max_value();
         return this->type_info()->cmp(Datum(_value), max) <= 0;
     }
 
@@ -202,7 +203,8 @@ public:
         }
     }
 
-    bool zone_map_filter(const Datum& min, const Datum& max, ZoneMapDetail* detail) const override {
+    bool zone_map_filter(const ZoneMapDetail& detail) const override {
+        const auto& max = detail.max_value();
         return this->type_info()->cmp(Datum(_value), max) <= 0;
     }
 

--- a/be/src/storage/vectorized/column_ge_predicate.cpp
+++ b/be/src/storage/vectorized/column_ge_predicate.cpp
@@ -71,7 +71,7 @@ public:
         }
     }
 
-    bool zone_map_filter(const Datum& min, const Datum& max) const override {
+    bool zone_map_filter(const Datum& min, const Datum& max, ZoneMapDetail* detail) const override {
         return this->type_info()->cmp(Datum(_value), max) <= 0;
     }
 
@@ -202,7 +202,7 @@ public:
         }
     }
 
-    bool zone_map_filter(const Datum& min, const Datum& max) const override {
+    bool zone_map_filter(const Datum& min, const Datum& max, ZoneMapDetail* detail) const override {
         return this->type_info()->cmp(Datum(_value), max) <= 0;
     }
 

--- a/be/src/storage/vectorized/column_gt_predicate.cpp
+++ b/be/src/storage/vectorized/column_gt_predicate.cpp
@@ -71,7 +71,7 @@ public:
         }
     }
 
-    bool zone_map_filter(const Datum& min, const Datum& max) const override {
+    bool zone_map_filter(const Datum& min, const Datum& max, ZoneMapDetail* detail) const override {
         return this->type_info()->cmp(Datum(_value), max) < 0;
     }
 
@@ -201,7 +201,7 @@ public:
         }
     }
 
-    bool zone_map_filter(const Datum& min, const Datum& max) const override {
+    bool zone_map_filter(const Datum& min, const Datum& max, ZoneMapDetail* detail) const override {
         return this->type_info()->cmp(Datum(_value), max) < 0;
     }
 

--- a/be/src/storage/vectorized/column_gt_predicate.cpp
+++ b/be/src/storage/vectorized/column_gt_predicate.cpp
@@ -71,7 +71,8 @@ public:
         }
     }
 
-    bool zone_map_filter(const Datum& min, const Datum& max, ZoneMapDetail* detail) const override {
+    bool zone_map_filter(const ZoneMapDetail& detail) const override {
+        const auto& max = detail.max_value();
         return this->type_info()->cmp(Datum(_value), max) < 0;
     }
 
@@ -201,7 +202,8 @@ public:
         }
     }
 
-    bool zone_map_filter(const Datum& min, const Datum& max, ZoneMapDetail* detail) const override {
+    bool zone_map_filter(const ZoneMapDetail& detail) const override {
+        const auto& max = detail.max_value();
         return this->type_info()->cmp(Datum(_value), max) < 0;
     }
 

--- a/be/src/storage/vectorized/column_in_predicate.cpp
+++ b/be/src/storage/vectorized/column_in_predicate.cpp
@@ -89,7 +89,9 @@ public:
         }
     }
 
-    bool zone_map_filter(const Datum& min, const Datum& max, ZoneMapDetail* detail) const override {
+    bool zone_map_filter(const ZoneMapDetail& detail) const override {
+        const auto& min = detail.min_or_null_value();
+        const auto& max = detail.max_value();
         const auto type_info = this->type_info();
         for (const ValueType& v : _values) {
             if (type_info->cmp(Datum(v), min) >= 0 && type_info->cmp(Datum(v), max) <= 0) {
@@ -286,7 +288,9 @@ public:
         return new_size;
     }
 
-    bool zone_map_filter(const Datum& min, const Datum& max, ZoneMapDetail* detail) const override {
+    bool zone_map_filter(const ZoneMapDetail& detail) const override {
+        const auto& min = detail.min_or_null_value();
+        const auto& max = detail.max_value();
         const auto type_info = this->type_info();
         for (const Slice& v : _slices) {
             if (type_info->cmp(Datum(v), min) >= 0 && type_info->cmp(Datum(v), max) <= 0) {

--- a/be/src/storage/vectorized/column_in_predicate.cpp
+++ b/be/src/storage/vectorized/column_in_predicate.cpp
@@ -89,7 +89,7 @@ public:
         }
     }
 
-    bool zone_map_filter(const Datum& min, const Datum& max) const override {
+    bool zone_map_filter(const Datum& min, const Datum& max, ZoneMapDetail* detail) const override {
         const auto type_info = this->type_info();
         for (const ValueType& v : _values) {
             if (type_info->cmp(Datum(v), min) >= 0 && type_info->cmp(Datum(v), max) <= 0) {
@@ -286,7 +286,7 @@ public:
         return new_size;
     }
 
-    bool zone_map_filter(const Datum& min, const Datum& max) const override {
+    bool zone_map_filter(const Datum& min, const Datum& max, ZoneMapDetail* detail) const override {
         const auto type_info = this->type_info();
         for (const Slice& v : _slices) {
             if (type_info->cmp(Datum(v), min) >= 0 && type_info->cmp(Datum(v), max) <= 0) {

--- a/be/src/storage/vectorized/column_le_predicate.cpp
+++ b/be/src/storage/vectorized/column_le_predicate.cpp
@@ -71,7 +71,7 @@ public:
         }
     }
 
-    bool zone_map_filter(const Datum& min, const Datum& max) const override {
+    bool zone_map_filter(const Datum& min, const Datum& max, ZoneMapDetail* detail) const override {
         return (this->type_info()->cmp(Datum(_value), min) >= 0) & !max.is_null();
     }
 
@@ -201,7 +201,7 @@ public:
         }
     }
 
-    bool zone_map_filter(const Datum& min, const Datum& max) const override {
+    bool zone_map_filter(const Datum& min, const Datum& max, ZoneMapDetail* detail) const override {
         return (this->type_info()->cmp(Datum(_value), min) >= 0) & !max.is_null();
     }
 

--- a/be/src/storage/vectorized/column_le_predicate.cpp
+++ b/be/src/storage/vectorized/column_le_predicate.cpp
@@ -71,7 +71,9 @@ public:
         }
     }
 
-    bool zone_map_filter(const Datum& min, const Datum& max, ZoneMapDetail* detail) const override {
+    bool zone_map_filter(const ZoneMapDetail& detail) const override {
+        const auto& min = detail.min_or_null_value();
+        const auto& max = detail.max_value();
         return (this->type_info()->cmp(Datum(_value), min) >= 0) & !max.is_null();
     }
 
@@ -201,7 +203,9 @@ public:
         }
     }
 
-    bool zone_map_filter(const Datum& min, const Datum& max, ZoneMapDetail* detail) const override {
+    bool zone_map_filter(const ZoneMapDetail& detail) const override {
+        const auto& min = detail.min_or_null_value();
+        const auto& max = detail.max_value();
         return (this->type_info()->cmp(Datum(_value), min) >= 0) & !max.is_null();
     }
 

--- a/be/src/storage/vectorized/column_lt_predicate.cpp
+++ b/be/src/storage/vectorized/column_lt_predicate.cpp
@@ -71,7 +71,9 @@ public:
         }
     }
 
-    bool zone_map_filter(const Datum& min, const Datum& max, ZoneMapDetail* detail) const override {
+    bool zone_map_filter(const ZoneMapDetail& detail) const override {
+        const auto& min = detail.min_or_null_value();
+        const auto& max = detail.max_value();
         return (this->type_info()->cmp(Datum(_value), min) > 0) & !max.is_null();
     }
 
@@ -207,7 +209,9 @@ public:
         }
     }
 
-    bool zone_map_filter(const Datum& min, const Datum& max, ZoneMapDetail* detail) const override {
+    bool zone_map_filter(const ZoneMapDetail& detail) const override {
+        const auto& min = detail.min_or_null_value();
+        const auto& max = detail.max_value();
         const auto type_info = this->type_info();
         return (type_info->cmp(Datum(_value), min) > 0) & !max.is_null();
     }

--- a/be/src/storage/vectorized/column_lt_predicate.cpp
+++ b/be/src/storage/vectorized/column_lt_predicate.cpp
@@ -71,7 +71,7 @@ public:
         }
     }
 
-    bool zone_map_filter(const Datum& min, const Datum& max) const override {
+    bool zone_map_filter(const Datum& min, const Datum& max, ZoneMapDetail* detail) const override {
         return (this->type_info()->cmp(Datum(_value), min) > 0) & !max.is_null();
     }
 
@@ -207,7 +207,7 @@ public:
         }
     }
 
-    bool zone_map_filter(const Datum& min, const Datum& max) const override {
+    bool zone_map_filter(const Datum& min, const Datum& max, ZoneMapDetail* detail) const override {
         const auto type_info = this->type_info();
         return (type_info->cmp(Datum(_value), min) > 0) & !max.is_null();
     }

--- a/be/src/storage/vectorized/column_ne_predicate.cpp
+++ b/be/src/storage/vectorized/column_ne_predicate.cpp
@@ -71,7 +71,7 @@ public:
         }
     }
 
-    bool zone_map_filter(const Datum& min, const Datum& max) const override { return true; }
+    bool zone_map_filter(const Datum& min, const Datum& max, ZoneMapDetail* detail) const override { return true; }
 
     Status seek_bitmap_dictionary(segment_v2::BitmapIndexIterator* iter, SparseRange* range) const override {
         return Status::Cancelled("not-equal predicate not support bitmap index");
@@ -190,7 +190,7 @@ public:
         }
     }
 
-    bool zone_map_filter(const Datum& min, const Datum& max) const override { return true; }
+    bool zone_map_filter(const Datum& min, const Datum& max, ZoneMapDetail* detail) const override { return true; }
 
     Status seek_bitmap_dictionary(segment_v2::BitmapIndexIterator* iter, SparseRange* range) const override {
         return Status::Cancelled("not-equal predicate not support bitmap index");

--- a/be/src/storage/vectorized/column_ne_predicate.cpp
+++ b/be/src/storage/vectorized/column_ne_predicate.cpp
@@ -71,7 +71,7 @@ public:
         }
     }
 
-    bool zone_map_filter(const Datum& min, const Datum& max, ZoneMapDetail* detail) const override { return true; }
+    bool zone_map_filter(const ZoneMapDetail& detail) const override { return true; }
 
     Status seek_bitmap_dictionary(segment_v2::BitmapIndexIterator* iter, SparseRange* range) const override {
         return Status::Cancelled("not-equal predicate not support bitmap index");
@@ -190,7 +190,7 @@ public:
         }
     }
 
-    bool zone_map_filter(const Datum& min, const Datum& max, ZoneMapDetail* detail) const override { return true; }
+    bool zone_map_filter(const ZoneMapDetail& detail) const override { return true; }
 
     Status seek_bitmap_dictionary(segment_v2::BitmapIndexIterator* iter, SparseRange* range) const override {
         return Status::Cancelled("not-equal predicate not support bitmap index");

--- a/be/src/storage/vectorized/column_not_in_predicate.cpp
+++ b/be/src/storage/vectorized/column_not_in_predicate.cpp
@@ -93,7 +93,7 @@ public:
         }
     }
 
-    bool zone_map_filter(const Datum& min, const Datum& max) const override { return true; }
+    bool zone_map_filter(const Datum& min, const Datum& max, ZoneMapDetail* detail) const override { return true; }
 
     Status seek_bitmap_dictionary(segment_v2::BitmapIndexIterator* iter, SparseRange* range) const override {
         return Status::Cancelled("not-equal predicate not support bitmap index");
@@ -262,7 +262,7 @@ public:
         return new_size;
     }
 
-    bool zone_map_filter(const Datum& min, const Datum& max) const override { return true; }
+    bool zone_map_filter(const Datum& min, const Datum& max, ZoneMapDetail* detail) const override { return true; }
 
     Status seek_bitmap_dictionary(segment_v2::BitmapIndexIterator* iter, SparseRange* range) const override {
         return Status::Cancelled("not-equal predicate not support bitmap index");

--- a/be/src/storage/vectorized/column_not_in_predicate.cpp
+++ b/be/src/storage/vectorized/column_not_in_predicate.cpp
@@ -93,7 +93,7 @@ public:
         }
     }
 
-    bool zone_map_filter(const Datum& min, const Datum& max, ZoneMapDetail* detail) const override { return true; }
+    bool zone_map_filter(const ZoneMapDetail& detail) const override { return true; }
 
     Status seek_bitmap_dictionary(segment_v2::BitmapIndexIterator* iter, SparseRange* range) const override {
         return Status::Cancelled("not-equal predicate not support bitmap index");
@@ -262,7 +262,7 @@ public:
         return new_size;
     }
 
-    bool zone_map_filter(const Datum& min, const Datum& max, ZoneMapDetail* detail) const override { return true; }
+    bool zone_map_filter(const ZoneMapDetail& detail) const override { return true; }
 
     Status seek_bitmap_dictionary(segment_v2::BitmapIndexIterator* iter, SparseRange* range) const override {
         return Status::Cancelled("not-equal predicate not support bitmap index");

--- a/be/src/storage/vectorized/column_null_predicate.cpp
+++ b/be/src/storage/vectorized/column_null_predicate.cpp
@@ -49,7 +49,8 @@ public:
         }
     }
 
-    bool zone_map_filter(const Datum& min, const Datum& max, ZoneMapDetail* detail) const override {
+    bool zone_map_filter(const ZoneMapDetail& detail) const override {
+        const auto& min = detail.min_or_null_value();
         return min.is_null();
     }
 
@@ -116,7 +117,8 @@ public:
         }
     }
 
-    bool zone_map_filter(const Datum& min, const Datum& max, ZoneMapDetail* detail) const override {
+    bool zone_map_filter(const ZoneMapDetail& detail) const override {
+        const auto& max = detail.max_value();
         return !max.is_null();
     }
 

--- a/be/src/storage/vectorized/column_null_predicate.cpp
+++ b/be/src/storage/vectorized/column_null_predicate.cpp
@@ -49,7 +49,9 @@ public:
         }
     }
 
-    bool zone_map_filter(const Datum& min, const Datum& max) const override { return min.is_null(); }
+    bool zone_map_filter(const Datum& min, const Datum& max, ZoneMapDetail* detail) const override {
+        return min.is_null();
+    }
 
     Status seek_bitmap_dictionary(segment_v2::BitmapIndexIterator* iter, SparseRange* range) const override {
         range->clear();
@@ -114,7 +116,9 @@ public:
         }
     }
 
-    bool zone_map_filter(const Datum& min, const Datum& max) const override { return !max.is_null(); }
+    bool zone_map_filter(const Datum& min, const Datum& max, ZoneMapDetail* detail) const override {
+        return !max.is_null();
+    }
 
     Status seek_bitmap_dictionary(segment_v2::BitmapIndexIterator* iter, SparseRange* range) const override {
         return Status::Cancelled("not null predicate not support bitmap index");

--- a/be/src/storage/vectorized/column_or_predicate.cpp
+++ b/be/src/storage/vectorized/column_or_predicate.cpp
@@ -26,9 +26,9 @@ void ColumnOrPredicate::evaluate_or(const Column* column, uint8_t* selection, ui
     }
 }
 
-bool ColumnOrPredicate::zone_map_filter(const Datum& min, const Datum& max, ZoneMapDetail* detail) const {
+bool ColumnOrPredicate::zone_map_filter(const ZoneMapDetail& detail) const {
     for (const ColumnPredicate* child : _child) {
-        RETURN_IF(child->zone_map_filter(min, max), true);
+        RETURN_IF(child->zone_map_filter(detail), true);
     }
     return _child.empty();
 }

--- a/be/src/storage/vectorized/column_or_predicate.cpp
+++ b/be/src/storage/vectorized/column_or_predicate.cpp
@@ -26,7 +26,7 @@ void ColumnOrPredicate::evaluate_or(const Column* column, uint8_t* selection, ui
     }
 }
 
-bool ColumnOrPredicate::zone_map_filter(const Datum& min, const Datum& max) const {
+bool ColumnOrPredicate::zone_map_filter(const Datum& min, const Datum& max, ZoneMapDetail* detail) const {
     for (const ColumnPredicate* child : _child) {
         RETURN_IF(child->zone_map_filter(min, max), true);
     }

--- a/be/src/storage/vectorized/column_or_predicate.h
+++ b/be/src/storage/vectorized/column_or_predicate.h
@@ -32,7 +32,7 @@ public:
 
     bool filter(const BloomFilter& bf) const override { return true; }
 
-    bool zone_map_filter(const Datum& min, const Datum& max, ZoneMapDetail* detail) const override;
+    bool zone_map_filter(const ZoneMapDetail& detail) const override;
 
     bool can_vectorized() const override { return false; }
 

--- a/be/src/storage/vectorized/column_or_predicate.h
+++ b/be/src/storage/vectorized/column_or_predicate.h
@@ -32,7 +32,7 @@ public:
 
     bool filter(const BloomFilter& bf) const override { return true; }
 
-    bool zone_map_filter(const Datum& min, const Datum& max) const override;
+    bool zone_map_filter(const Datum& min, const Datum& max, ZoneMapDetail* detail) const override;
 
     bool can_vectorized() const override { return false; }
 

--- a/be/src/storage/vectorized/column_predicate.h
+++ b/be/src/storage/vectorized/column_predicate.h
@@ -12,7 +12,7 @@
 #include "column/column.h" // Column
 #include "column/datum.h"
 #include "common/object_pool.h"
-#include "in_predicate_utils.h"
+// #include "in_predicate_utils.h"
 #include "storage/olap_common.h" // ColumnId
 #include "storage/vectorized/range.h"
 #include "util/string_parser.hpp"
@@ -100,7 +100,9 @@ public:
     virtual bool filter(const BloomFilter& bf) const { return true; }
 
     // Return false to filter out a data page.
-    virtual bool zone_map_filter(const Datum& min, const Datum& max) const { return true; }
+    virtual bool zone_map_filter(const Datum& min, const Datum& max, ZoneMapDetail* detail = nullptr) const {
+        return true;
+    }
 
     virtual bool support_bloom_filter() const { return false; }
 

--- a/be/src/storage/vectorized/column_predicate.h
+++ b/be/src/storage/vectorized/column_predicate.h
@@ -12,9 +12,9 @@
 #include "column/column.h" // Column
 #include "column/datum.h"
 #include "common/object_pool.h"
-// #include "in_predicate_utils.h"
 #include "storage/olap_common.h" // ColumnId
 #include "storage/vectorized/range.h"
+#include "storage/vectorized/zone_map_detail.h"
 #include "util/string_parser.hpp"
 
 class Roaring;
@@ -100,9 +100,7 @@ public:
     virtual bool filter(const BloomFilter& bf) const { return true; }
 
     // Return false to filter out a data page.
-    virtual bool zone_map_filter(const Datum& min, const Datum& max, ZoneMapDetail* detail = nullptr) const {
-        return true;
-    }
+    virtual bool zone_map_filter(const ZoneMapDetail& detail) const { return true; }
 
     virtual bool support_bloom_filter() const { return false; }
 

--- a/be/src/storage/vectorized/range.h
+++ b/be/src/storage/vectorized/range.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 
+#include "column/datum.h"
 #include "storage/rowset/segment_v2/common.h"
 #include "util/logging.h"
 
@@ -354,5 +355,12 @@ inline bool SparseRange::operator!=(const SparseRange& rhs) const {
 inline std::ostream& operator<<(std::ostream& os, const SparseRange& range) {
     return (os << range.to_string());
 }
+
+struct ZoneMapDetail {
+    bool has_null;
+    bool has_not_null;
+    Datum min_value;
+    Datum max_value;
+};
 
 } // namespace starrocks::vectorized

--- a/be/src/storage/vectorized/range.h
+++ b/be/src/storage/vectorized/range.h
@@ -356,11 +356,4 @@ inline std::ostream& operator<<(std::ostream& os, const SparseRange& range) {
     return (os << range.to_string());
 }
 
-struct ZoneMapDetail {
-    bool has_null;
-    bool has_not_null;
-    Datum min_value;
-    Datum max_value;
-};
-
 } // namespace starrocks::vectorized

--- a/be/src/storage/vectorized/zone_map_detail.h
+++ b/be/src/storage/vectorized/zone_map_detail.h
@@ -1,0 +1,34 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+namespace starrocks {
+namespace vectorized {
+class ZoneMapDetail {
+public:
+    // ctors
+    ZoneMapDetail() = default;
+    ZoneMapDetail(Datum min_or_null_value, Datum max_value)
+            : _has_null(min_or_null_value.is_null()), _min_value(min_or_null_value), _max_value(max_value) {}
+    ZoneMapDetail(Datum min_value, Datum max_value, bool has_null)
+            : _has_null(has_null), _min_value(min_value), _max_value(max_value) {}
+
+    // methods
+    bool has_null() const { return _has_null; }
+    void set_has_null(bool v) { _has_null = v; }
+    bool has_not_null() const { return !_min_value.is_null() || !_max_value.is_null(); }
+    Datum& min_value() { return _min_value; }
+    const Datum& min_value() const { return _min_value; }
+    Datum& max_value() { return _max_value; }
+    const Datum& max_value() const { return _max_value; }
+    const Datum& min_or_null_value() const {
+        if (_has_null) return _null_value;
+        return _min_value;
+    }
+
+private:
+    bool _has_null;
+    Datum _null_value;
+    Datum _min_value;
+    Datum _max_value;
+};
+} // namespace vectorized
+} // namespace starrocks

--- a/be/test/exec/es_scan_reader_test.cpp
+++ b/be/test/exec/es_scan_reader_test.cpp
@@ -33,9 +33,12 @@
 #include "http/http_channel.h"
 #include "http/http_handler.h"
 #include "http/http_request.h"
+DIAGNOSTIC_PUSH
+DIAGNOSTIC_IGNORE("-Wclass-memaccess")
 #include "rapidjson/document.h"
 #include "rapidjson/stringbuffer.h"
 #include "rapidjson/writer.h"
+DIAGNOSTIC_POP
 
 namespace starrocks {
 

--- a/be/test/exprs/vectorized/decimal_binary_function_test.cpp
+++ b/be/test/exprs/vectorized/decimal_binary_function_test.cpp
@@ -185,7 +185,7 @@ void test_decimal_binary_functions(DecimalTestCaseArray const& test_cases, Colum
 
     for (auto i = 0; i < test_cases.size(); i++) {
         auto& tc = test_cases[i];
-        auto& lhs_datum = std::get<0>(tc);
+        // auto& lhs_datum = std::get<0>(tc);
         auto& rhs_datum = std::get<1>(tc);
         auto& expect = std::get<2>(tc);
         auto row_idx = i + off;

--- a/be/test/storage/vectorized/column_predicate_test.cpp
+++ b/be/test/storage/vectorized/column_predicate_test.cpp
@@ -1947,6 +1947,8 @@ TEST(ColumnPredicateTest, test_or) {
     }
 }
 
+#define ZMF(min, max) zone_map_filter(ZoneMapDetail(min, max))
+
 // NOLINTNEXTLINE
 TEST(ColumnPredicateTest, zone_map_filter) {
     std::unique_ptr<ColumnPredicate> eq_100(new_column_eq_predicate(get_type_info(OLAP_FIELD_TYPE_INT), 0, "100"));
@@ -1962,58 +1964,58 @@ TEST(ColumnPredicateTest, zone_map_filter) {
     std::unique_ptr<ColumnPredicate> not_in_90_100(
             new_column_not_in_predicate(get_type_info(OLAP_FIELD_TYPE_INT), 0, {"90", "100"}));
 
-    EXPECT_TRUE(eq_100->zone_map_filter(Datum(90), Datum(100)));
-    EXPECT_TRUE(eq_100->zone_map_filter(Datum(100), Datum(100)));
-    EXPECT_FALSE(eq_100->zone_map_filter(Datum(101), Datum(200)));
-    EXPECT_TRUE(eq_100->zone_map_filter(Datum(), Datum(200)));
-    EXPECT_FALSE(eq_100->zone_map_filter(Datum(), Datum()));
+    EXPECT_TRUE(eq_100->ZMF(Datum(90), Datum(100)));
+    EXPECT_TRUE(eq_100->ZMF(Datum(100), Datum(100)));
+    EXPECT_FALSE(eq_100->ZMF(Datum(101), Datum(200)));
+    EXPECT_TRUE(eq_100->ZMF(Datum(), Datum(200)));
+    EXPECT_FALSE(eq_100->ZMF(Datum(), Datum()));
 
-    EXPECT_TRUE(ne_100->zone_map_filter(Datum(90), Datum(99)));
-    EXPECT_TRUE(ne_100->zone_map_filter(Datum(90), Datum(200)));
-    EXPECT_TRUE(ne_100->zone_map_filter(Datum(), Datum()));
-    EXPECT_TRUE(ne_100->zone_map_filter(Datum(), Datum(99)));
+    EXPECT_TRUE(ne_100->ZMF(Datum(90), Datum(99)));
+    EXPECT_TRUE(ne_100->ZMF(Datum(90), Datum(200)));
+    EXPECT_TRUE(ne_100->ZMF(Datum(), Datum()));
+    EXPECT_TRUE(ne_100->ZMF(Datum(), Datum(99)));
 
-    EXPECT_TRUE(gt_100->zone_map_filter(Datum(90), Datum(101)));
-    EXPECT_TRUE(gt_100->zone_map_filter(Datum(), Datum(101)));
-    EXPECT_FALSE(gt_100->zone_map_filter(Datum(90), Datum(100)));
-    EXPECT_FALSE(gt_100->zone_map_filter(Datum(90), Datum(99)));
-    EXPECT_FALSE(gt_100->zone_map_filter(Datum(), Datum()));
+    EXPECT_TRUE(gt_100->ZMF(Datum(90), Datum(101)));
+    EXPECT_TRUE(gt_100->ZMF(Datum(), Datum(101)));
+    EXPECT_FALSE(gt_100->ZMF(Datum(90), Datum(100)));
+    EXPECT_FALSE(gt_100->ZMF(Datum(90), Datum(99)));
+    EXPECT_FALSE(gt_100->ZMF(Datum(), Datum()));
 
-    EXPECT_TRUE(ge_100->zone_map_filter(Datum(90), Datum(101)));
-    EXPECT_TRUE(ge_100->zone_map_filter(Datum(), Datum(101)));
-    EXPECT_TRUE(ge_100->zone_map_filter(Datum(90), Datum(100)));
-    EXPECT_FALSE(ge_100->zone_map_filter(Datum(90), Datum(99)));
-    EXPECT_FALSE(ge_100->zone_map_filter(Datum(), Datum()));
+    EXPECT_TRUE(ge_100->ZMF(Datum(90), Datum(101)));
+    EXPECT_TRUE(ge_100->ZMF(Datum(), Datum(101)));
+    EXPECT_TRUE(ge_100->ZMF(Datum(90), Datum(100)));
+    EXPECT_FALSE(ge_100->ZMF(Datum(90), Datum(99)));
+    EXPECT_FALSE(ge_100->ZMF(Datum(), Datum()));
 
-    EXPECT_TRUE(lt_100->zone_map_filter(Datum(), Datum(101)));
-    EXPECT_TRUE(lt_100->zone_map_filter(Datum(99), Datum(200)));
-    EXPECT_FALSE(lt_100->zone_map_filter(Datum(100), Datum(200)));
-    EXPECT_FALSE(lt_100->zone_map_filter(Datum(), Datum()));
+    EXPECT_TRUE(lt_100->ZMF(Datum(), Datum(101)));
+    EXPECT_TRUE(lt_100->ZMF(Datum(99), Datum(200)));
+    EXPECT_FALSE(lt_100->ZMF(Datum(100), Datum(200)));
+    EXPECT_FALSE(lt_100->ZMF(Datum(), Datum()));
 
-    EXPECT_TRUE(le_100->zone_map_filter(Datum(), Datum(101)));
-    EXPECT_TRUE(le_100->zone_map_filter(Datum(100), Datum(200)));
-    EXPECT_FALSE(le_100->zone_map_filter(Datum(101), Datum(200)));
-    EXPECT_FALSE(le_100->zone_map_filter(Datum(), Datum()));
+    EXPECT_TRUE(le_100->ZMF(Datum(), Datum(101)));
+    EXPECT_TRUE(le_100->ZMF(Datum(100), Datum(200)));
+    EXPECT_FALSE(le_100->ZMF(Datum(101), Datum(200)));
+    EXPECT_FALSE(le_100->ZMF(Datum(), Datum()));
 
-    EXPECT_TRUE(is_null->zone_map_filter(Datum(), Datum()));
-    EXPECT_TRUE(is_null->zone_map_filter(Datum(), Datum(100)));
-    EXPECT_FALSE(is_null->zone_map_filter(Datum(100), Datum(200)));
+    EXPECT_TRUE(is_null->ZMF(Datum(), Datum()));
+    EXPECT_TRUE(is_null->ZMF(Datum(), Datum(100)));
+    EXPECT_FALSE(is_null->ZMF(Datum(100), Datum(200)));
 
-    EXPECT_TRUE(not_null->zone_map_filter(Datum(), Datum(100)));
-    EXPECT_TRUE(not_null->zone_map_filter(Datum(100), Datum(200)));
-    EXPECT_FALSE(not_null->zone_map_filter(Datum(), Datum()));
+    EXPECT_TRUE(not_null->ZMF(Datum(), Datum(100)));
+    EXPECT_TRUE(not_null->ZMF(Datum(100), Datum(200)));
+    EXPECT_FALSE(not_null->ZMF(Datum(), Datum()));
 
-    EXPECT_TRUE(in_90_100->zone_map_filter(Datum(), Datum(100)));
-    EXPECT_TRUE(in_90_100->zone_map_filter(Datum(100), Datum(110)));
-    EXPECT_TRUE(in_90_100->zone_map_filter(Datum(90), Datum(99)));
-    EXPECT_FALSE(in_90_100->zone_map_filter(Datum(80), Datum(89)));
-    EXPECT_FALSE(in_90_100->zone_map_filter(Datum(101), Datum(110)));
+    EXPECT_TRUE(in_90_100->ZMF(Datum(), Datum(100)));
+    EXPECT_TRUE(in_90_100->ZMF(Datum(100), Datum(110)));
+    EXPECT_TRUE(in_90_100->ZMF(Datum(90), Datum(99)));
+    EXPECT_FALSE(in_90_100->ZMF(Datum(80), Datum(89)));
+    EXPECT_FALSE(in_90_100->ZMF(Datum(101), Datum(110)));
 
-    EXPECT_TRUE(not_in_90_100->zone_map_filter(Datum(), Datum(100)));
-    EXPECT_TRUE(not_in_90_100->zone_map_filter(Datum(100), Datum(110)));
-    EXPECT_TRUE(not_in_90_100->zone_map_filter(Datum(90), Datum(99)));
-    EXPECT_TRUE(not_in_90_100->zone_map_filter(Datum(80), Datum(89)));
-    EXPECT_TRUE(not_in_90_100->zone_map_filter(Datum(101), Datum(110)));
+    EXPECT_TRUE(not_in_90_100->ZMF(Datum(), Datum(100)));
+    EXPECT_TRUE(not_in_90_100->ZMF(Datum(100), Datum(110)));
+    EXPECT_TRUE(not_in_90_100->ZMF(Datum(90), Datum(99)));
+    EXPECT_TRUE(not_in_90_100->ZMF(Datum(80), Datum(89)));
+    EXPECT_TRUE(not_in_90_100->ZMF(Datum(101), Datum(110)));
 }
 
 // NOLINTNEXTLINE
@@ -2031,58 +2033,58 @@ TEST(ColumnPredicateTest, zone_map_filter_char) {
     std::unique_ptr<ColumnPredicate> not_in_xx_yy(
             new_column_not_in_predicate(get_type_info(OLAP_FIELD_TYPE_CHAR), 0, {"xx\0\0", "yy\0\0"}));
 
-    EXPECT_TRUE(eq_xx->zone_map_filter(Datum("tt"), Datum("xx")));
-    EXPECT_TRUE(eq_xx->zone_map_filter(Datum("xx"), Datum("xx")));
-    EXPECT_FALSE(eq_xx->zone_map_filter(Datum("xy"), Datum("yy")));
-    EXPECT_TRUE(eq_xx->zone_map_filter(Datum(), Datum("yy")));
-    EXPECT_FALSE(eq_xx->zone_map_filter(Datum(), Datum()));
+    EXPECT_TRUE(eq_xx->ZMF(Datum("tt"), Datum("xx")));
+    EXPECT_TRUE(eq_xx->ZMF(Datum("xx"), Datum("xx")));
+    EXPECT_FALSE(eq_xx->ZMF(Datum("xy"), Datum("yy")));
+    EXPECT_TRUE(eq_xx->ZMF(Datum(), Datum("yy")));
+    EXPECT_FALSE(eq_xx->ZMF(Datum(), Datum()));
 
-    EXPECT_TRUE(ne_xx->zone_map_filter(Datum("tt"), Datum("xa")));
-    EXPECT_TRUE(ne_xx->zone_map_filter(Datum("tt"), Datum("yy")));
-    EXPECT_TRUE(ne_xx->zone_map_filter(Datum(), Datum()));
-    EXPECT_TRUE(ne_xx->zone_map_filter(Datum(), Datum("xa")));
+    EXPECT_TRUE(ne_xx->ZMF(Datum("tt"), Datum("xa")));
+    EXPECT_TRUE(ne_xx->ZMF(Datum("tt"), Datum("yy")));
+    EXPECT_TRUE(ne_xx->ZMF(Datum(), Datum()));
+    EXPECT_TRUE(ne_xx->ZMF(Datum(), Datum("xa")));
 
-    EXPECT_TRUE(gt_xx->zone_map_filter(Datum("tt"), Datum("xy")));
-    EXPECT_TRUE(gt_xx->zone_map_filter(Datum(), Datum("xy")));
-    EXPECT_FALSE(gt_xx->zone_map_filter(Datum("tt"), Datum("xx")));
-    EXPECT_FALSE(gt_xx->zone_map_filter(Datum("tt"), Datum("xw")));
-    EXPECT_FALSE(gt_xx->zone_map_filter(Datum(), Datum()));
+    EXPECT_TRUE(gt_xx->ZMF(Datum("tt"), Datum("xy")));
+    EXPECT_TRUE(gt_xx->ZMF(Datum(), Datum("xy")));
+    EXPECT_FALSE(gt_xx->ZMF(Datum("tt"), Datum("xx")));
+    EXPECT_FALSE(gt_xx->ZMF(Datum("tt"), Datum("xw")));
+    EXPECT_FALSE(gt_xx->ZMF(Datum(), Datum()));
 
-    EXPECT_TRUE(ge_xx->zone_map_filter(Datum("tt"), Datum("xy")));
-    EXPECT_TRUE(ge_xx->zone_map_filter(Datum(), Datum("xy")));
-    EXPECT_TRUE(ge_xx->zone_map_filter(Datum("tt"), Datum("xx")));
-    EXPECT_FALSE(ge_xx->zone_map_filter(Datum("tt"), Datum("xw")));
-    EXPECT_FALSE(ge_xx->zone_map_filter(Datum(), Datum()));
+    EXPECT_TRUE(ge_xx->ZMF(Datum("tt"), Datum("xy")));
+    EXPECT_TRUE(ge_xx->ZMF(Datum(), Datum("xy")));
+    EXPECT_TRUE(ge_xx->ZMF(Datum("tt"), Datum("xx")));
+    EXPECT_FALSE(ge_xx->ZMF(Datum("tt"), Datum("xw")));
+    EXPECT_FALSE(ge_xx->ZMF(Datum(), Datum()));
 
-    EXPECT_TRUE(lt_xx->zone_map_filter(Datum(), Datum("xy")));
-    EXPECT_TRUE(lt_xx->zone_map_filter(Datum("xw"), Datum("yy")));
-    EXPECT_FALSE(lt_xx->zone_map_filter(Datum("xx"), Datum("yy")));
-    EXPECT_FALSE(lt_xx->zone_map_filter(Datum(), Datum()));
+    EXPECT_TRUE(lt_xx->ZMF(Datum(), Datum("xy")));
+    EXPECT_TRUE(lt_xx->ZMF(Datum("xw"), Datum("yy")));
+    EXPECT_FALSE(lt_xx->ZMF(Datum("xx"), Datum("yy")));
+    EXPECT_FALSE(lt_xx->ZMF(Datum(), Datum()));
 
-    EXPECT_TRUE(le_xx->zone_map_filter(Datum(), Datum("xy")));
-    EXPECT_TRUE(le_xx->zone_map_filter(Datum("xx"), Datum("yy")));
-    EXPECT_FALSE(le_xx->zone_map_filter(Datum("xy"), Datum("yy")));
-    EXPECT_FALSE(le_xx->zone_map_filter(Datum(), Datum()));
+    EXPECT_TRUE(le_xx->ZMF(Datum(), Datum("xy")));
+    EXPECT_TRUE(le_xx->ZMF(Datum("xx"), Datum("yy")));
+    EXPECT_FALSE(le_xx->ZMF(Datum("xy"), Datum("yy")));
+    EXPECT_FALSE(le_xx->ZMF(Datum(), Datum()));
 
-    EXPECT_TRUE(is_null->zone_map_filter(Datum(), Datum()));
-    EXPECT_TRUE(is_null->zone_map_filter(Datum(), Datum("xx")));
-    EXPECT_FALSE(is_null->zone_map_filter(Datum("xx"), Datum("yy")));
+    EXPECT_TRUE(is_null->ZMF(Datum(), Datum()));
+    EXPECT_TRUE(is_null->ZMF(Datum(), Datum("xx")));
+    EXPECT_FALSE(is_null->ZMF(Datum("xx"), Datum("yy")));
 
-    EXPECT_TRUE(not_null->zone_map_filter(Datum(), Datum("xx")));
-    EXPECT_TRUE(not_null->zone_map_filter(Datum("xx"), Datum("yy")));
-    EXPECT_FALSE(not_null->zone_map_filter(Datum(), Datum()));
+    EXPECT_TRUE(not_null->ZMF(Datum(), Datum("xx")));
+    EXPECT_TRUE(not_null->ZMF(Datum("xx"), Datum("yy")));
+    EXPECT_FALSE(not_null->ZMF(Datum(), Datum()));
 
-    EXPECT_TRUE(in_xx_yy->zone_map_filter(Datum(), Datum("xx")));
-    EXPECT_TRUE(in_xx_yy->zone_map_filter(Datum("yy"), Datum("yy\0")));
-    EXPECT_TRUE(in_xx_yy->zone_map_filter(Datum("tt"), Datum("xx")));
-    EXPECT_FALSE(in_xx_yy->zone_map_filter(Datum("ab"), Datum("tt")));
-    EXPECT_FALSE(in_xx_yy->zone_map_filter(Datum("yz"), Datum("zz")));
+    EXPECT_TRUE(in_xx_yy->ZMF(Datum(), Datum("xx")));
+    EXPECT_TRUE(in_xx_yy->ZMF(Datum("yy"), Datum("yy\0")));
+    EXPECT_TRUE(in_xx_yy->ZMF(Datum("tt"), Datum("xx")));
+    EXPECT_FALSE(in_xx_yy->ZMF(Datum("ab"), Datum("tt")));
+    EXPECT_FALSE(in_xx_yy->ZMF(Datum("yz"), Datum("zz")));
 
-    EXPECT_TRUE(not_in_xx_yy->zone_map_filter(Datum(), Datum("xx")));
-    EXPECT_TRUE(not_in_xx_yy->zone_map_filter(Datum("xx"), Datum("yy")));
-    EXPECT_TRUE(not_in_xx_yy->zone_map_filter(Datum("tt"), Datum("x")));
-    EXPECT_TRUE(not_in_xx_yy->zone_map_filter(Datum("ab"), Datum("cd")));
-    EXPECT_TRUE(not_in_xx_yy->zone_map_filter(Datum("xy"), Datum("zz")));
+    EXPECT_TRUE(not_in_xx_yy->ZMF(Datum(), Datum("xx")));
+    EXPECT_TRUE(not_in_xx_yy->ZMF(Datum("xx"), Datum("yy")));
+    EXPECT_TRUE(not_in_xx_yy->ZMF(Datum("tt"), Datum("x")));
+    EXPECT_TRUE(not_in_xx_yy->ZMF(Datum("ab"), Datum("cd")));
+    EXPECT_TRUE(not_in_xx_yy->ZMF(Datum("xy"), Datum("zz")));
 }
 
 // NOLINTNEXTLINE
@@ -2102,58 +2104,58 @@ TEST(ColumnPredicateTest, zone_map_filter_varchar) {
     std::unique_ptr<ColumnPredicate> not_in_xx_yy(
             new_column_not_in_predicate(get_type_info(OLAP_FIELD_TYPE_VARCHAR), 0, {"xx", "yy"}));
 
-    EXPECT_TRUE(eq_xx->zone_map_filter(Datum("tt"), Datum("xx")));
-    EXPECT_TRUE(eq_xx->zone_map_filter(Datum("xx"), Datum("xx")));
-    EXPECT_FALSE(eq_xx->zone_map_filter(Datum("xy"), Datum("yy")));
-    EXPECT_TRUE(eq_xx->zone_map_filter(Datum(), Datum("yy")));
-    EXPECT_FALSE(eq_xx->zone_map_filter(Datum(), Datum()));
+    EXPECT_TRUE(eq_xx->ZMF(Datum("tt"), Datum("xx")));
+    EXPECT_TRUE(eq_xx->ZMF(Datum("xx"), Datum("xx")));
+    EXPECT_FALSE(eq_xx->ZMF(Datum("xy"), Datum("yy")));
+    EXPECT_TRUE(eq_xx->ZMF(Datum(), Datum("yy")));
+    EXPECT_FALSE(eq_xx->ZMF(Datum(), Datum()));
 
-    EXPECT_TRUE(ne_xx->zone_map_filter(Datum("tt"), Datum("xa")));
-    EXPECT_TRUE(ne_xx->zone_map_filter(Datum("tt"), Datum("yy")));
-    EXPECT_TRUE(ne_xx->zone_map_filter(Datum(), Datum()));
-    EXPECT_TRUE(ne_xx->zone_map_filter(Datum(), Datum("xa")));
+    EXPECT_TRUE(ne_xx->ZMF(Datum("tt"), Datum("xa")));
+    EXPECT_TRUE(ne_xx->ZMF(Datum("tt"), Datum("yy")));
+    EXPECT_TRUE(ne_xx->ZMF(Datum(), Datum()));
+    EXPECT_TRUE(ne_xx->ZMF(Datum(), Datum("xa")));
 
-    EXPECT_TRUE(gt_xx->zone_map_filter(Datum("tt"), Datum("xy")));
-    EXPECT_TRUE(gt_xx->zone_map_filter(Datum(), Datum("xy")));
-    EXPECT_FALSE(gt_xx->zone_map_filter(Datum("tt"), Datum("xx")));
-    EXPECT_FALSE(gt_xx->zone_map_filter(Datum("tt"), Datum("xw")));
-    EXPECT_FALSE(gt_xx->zone_map_filter(Datum(), Datum()));
+    EXPECT_TRUE(gt_xx->ZMF(Datum("tt"), Datum("xy")));
+    EXPECT_TRUE(gt_xx->ZMF(Datum(), Datum("xy")));
+    EXPECT_FALSE(gt_xx->ZMF(Datum("tt"), Datum("xx")));
+    EXPECT_FALSE(gt_xx->ZMF(Datum("tt"), Datum("xw")));
+    EXPECT_FALSE(gt_xx->ZMF(Datum(), Datum()));
 
-    EXPECT_TRUE(ge_xx->zone_map_filter(Datum("tt"), Datum("xy")));
-    EXPECT_TRUE(ge_xx->zone_map_filter(Datum(), Datum("xy")));
-    EXPECT_TRUE(ge_xx->zone_map_filter(Datum("tt"), Datum("xx")));
-    EXPECT_FALSE(ge_xx->zone_map_filter(Datum("tt"), Datum("xw")));
-    EXPECT_FALSE(ge_xx->zone_map_filter(Datum(), Datum()));
+    EXPECT_TRUE(ge_xx->ZMF(Datum("tt"), Datum("xy")));
+    EXPECT_TRUE(ge_xx->ZMF(Datum(), Datum("xy")));
+    EXPECT_TRUE(ge_xx->ZMF(Datum("tt"), Datum("xx")));
+    EXPECT_FALSE(ge_xx->ZMF(Datum("tt"), Datum("xw")));
+    EXPECT_FALSE(ge_xx->ZMF(Datum(), Datum()));
 
-    EXPECT_TRUE(lt_xx->zone_map_filter(Datum(), Datum("xy")));
-    EXPECT_TRUE(lt_xx->zone_map_filter(Datum("xw"), Datum("yy")));
-    EXPECT_FALSE(lt_xx->zone_map_filter(Datum("xx"), Datum("yy")));
-    EXPECT_FALSE(lt_xx->zone_map_filter(Datum(), Datum()));
+    EXPECT_TRUE(lt_xx->ZMF(Datum(), Datum("xy")));
+    EXPECT_TRUE(lt_xx->ZMF(Datum("xw"), Datum("yy")));
+    EXPECT_FALSE(lt_xx->ZMF(Datum("xx"), Datum("yy")));
+    EXPECT_FALSE(lt_xx->ZMF(Datum(), Datum()));
 
-    EXPECT_TRUE(le_xx->zone_map_filter(Datum(), Datum("xy")));
-    EXPECT_TRUE(le_xx->zone_map_filter(Datum("xx"), Datum("yy")));
-    EXPECT_FALSE(le_xx->zone_map_filter(Datum("xy"), Datum("yy")));
-    EXPECT_FALSE(le_xx->zone_map_filter(Datum(), Datum()));
+    EXPECT_TRUE(le_xx->ZMF(Datum(), Datum("xy")));
+    EXPECT_TRUE(le_xx->ZMF(Datum("xx"), Datum("yy")));
+    EXPECT_FALSE(le_xx->ZMF(Datum("xy"), Datum("yy")));
+    EXPECT_FALSE(le_xx->ZMF(Datum(), Datum()));
 
-    EXPECT_TRUE(is_null->zone_map_filter(Datum(), Datum()));
-    EXPECT_TRUE(is_null->zone_map_filter(Datum(), Datum("xx")));
-    EXPECT_FALSE(is_null->zone_map_filter(Datum("xx"), Datum("yy")));
+    EXPECT_TRUE(is_null->ZMF(Datum(), Datum()));
+    EXPECT_TRUE(is_null->ZMF(Datum(), Datum("xx")));
+    EXPECT_FALSE(is_null->ZMF(Datum("xx"), Datum("yy")));
 
-    EXPECT_TRUE(not_null->zone_map_filter(Datum(), Datum("xx")));
-    EXPECT_TRUE(not_null->zone_map_filter(Datum("xx"), Datum("yy")));
-    EXPECT_FALSE(not_null->zone_map_filter(Datum(), Datum()));
+    EXPECT_TRUE(not_null->ZMF(Datum(), Datum("xx")));
+    EXPECT_TRUE(not_null->ZMF(Datum("xx"), Datum("yy")));
+    EXPECT_FALSE(not_null->ZMF(Datum(), Datum()));
 
-    EXPECT_TRUE(in_xx_yy->zone_map_filter(Datum(), Datum("xx")));
-    EXPECT_TRUE(in_xx_yy->zone_map_filter(Datum("yy"), Datum("yy\0")));
-    EXPECT_TRUE(in_xx_yy->zone_map_filter(Datum("tt"), Datum("xx")));
-    EXPECT_FALSE(in_xx_yy->zone_map_filter(Datum("ab"), Datum("tt")));
-    EXPECT_FALSE(in_xx_yy->zone_map_filter(Datum("yz"), Datum("zz")));
+    EXPECT_TRUE(in_xx_yy->ZMF(Datum(), Datum("xx")));
+    EXPECT_TRUE(in_xx_yy->ZMF(Datum("yy"), Datum("yy\0")));
+    EXPECT_TRUE(in_xx_yy->ZMF(Datum("tt"), Datum("xx")));
+    EXPECT_FALSE(in_xx_yy->ZMF(Datum("ab"), Datum("tt")));
+    EXPECT_FALSE(in_xx_yy->ZMF(Datum("yz"), Datum("zz")));
 
-    EXPECT_TRUE(not_in_xx_yy->zone_map_filter(Datum(), Datum("xx")));
-    EXPECT_TRUE(not_in_xx_yy->zone_map_filter(Datum("xx"), Datum("yy")));
-    EXPECT_TRUE(not_in_xx_yy->zone_map_filter(Datum("tt"), Datum("x")));
-    EXPECT_TRUE(not_in_xx_yy->zone_map_filter(Datum("ab"), Datum("cd")));
-    EXPECT_TRUE(not_in_xx_yy->zone_map_filter(Datum("xy"), Datum("zz")));
+    EXPECT_TRUE(not_in_xx_yy->ZMF(Datum(), Datum("xx")));
+    EXPECT_TRUE(not_in_xx_yy->ZMF(Datum("xx"), Datum("yy")));
+    EXPECT_TRUE(not_in_xx_yy->ZMF(Datum("tt"), Datum("x")));
+    EXPECT_TRUE(not_in_xx_yy->ZMF(Datum("ab"), Datum("cd")));
+    EXPECT_TRUE(not_in_xx_yy->ZMF(Datum("xy"), Datum("zz")));
 }
 
 } // namespace starrocks::vectorized


### PR DESCRIPTION
ref: #803 

Currently `min` is set to null if `zm.has_null()`. So `min` value is actually not accurate. So I refactor code to add a class `ZoneMapDetail`, which has completed & accurate zone map information.

```
struct ZoneMapDetail {
    bool has_null;
    bool has_not_null;
    Datum min_value;
    Datum max_value;
};

```