### PR TITLE
Add metrics for slow query and meta log count (#502)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -434,6 +434,8 @@ public class Catalog {
 
     private StatisticStorage statisticStorage;
 
+    private long imageJournalId;
+
     public List<Frontend> getFrontends(FrontendNodeType nodeType) {
         if (nodeType == null) {
             // get all
@@ -1512,6 +1514,7 @@ public class Catalog {
         Preconditions.checkState(remoteChecksum == checksum, remoteChecksum + " vs. " + checksum);
 
         long loadImageEndTime = System.currentTimeMillis();
+        this.imageJournalId = storage.getImageJournalId();
         LOG.info("finished to load image in " + (loadImageEndTime - loadImageStartTime) + " ms");
     }
 
@@ -7374,5 +7377,12 @@ public class Catalog {
         }
     }
 
+    public long getImageJournalId() {
+        return imageJournalId;
+    }
+
+    public void setImageJournalId(long imageJournalId) {
+        this.imageJournalId = imageJournalId;
+    }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/http/meta/MetaService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/meta/MetaService.java
@@ -215,6 +215,8 @@ public class MetaService {
                 return;
             }
 
+            Catalog.getCurrentCatalog().setImageJournalId(version);
+
             // Delete old image files
             MetaCleaner cleaner = new MetaCleaner(Config.meta_dir + "/image");
             try {

--- a/fe/fe-core/src/main/java/com/starrocks/master/Checkpoint.java
+++ b/fe/fe-core/src/main/java/com/starrocks/master/Checkpoint.java
@@ -113,6 +113,7 @@ public class Checkpoint extends MasterDaemon {
             if (MetricRepo.isInit) {
                 MetricRepo.COUNTER_IMAGE_WRITE.increase(1L);
             }
+            Catalog.getServingCatalog().setImageJournalId(checkPointVersion);
             LOG.info("checkpoint finished save image.{}", replayedJournalId);
         } catch (Exception e) {
             e.printStackTrace();

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricCalculator.java
@@ -59,10 +59,10 @@ public class MetricCalculator extends TimerTask {
         long interval = (currentTs - lastTs) / 1000 + 1;
 
         // qps
-        long currenQueryCounter = MetricRepo.COUNTER_QUERY_ALL.getValue();
-        double qps = (double) (currenQueryCounter - lastQueryCounter) / interval;
+        long currentQueryCounter = MetricRepo.COUNTER_QUERY_ALL.getValue();
+        double qps = (double) (currentQueryCounter - lastQueryCounter) / interval;
         MetricRepo.GAUGE_QUERY_PER_SECOND.setValue(qps < 0 ? 0.0 : qps);
-        lastQueryCounter = currenQueryCounter;
+        lastQueryCounter = currentQueryCounter;
 
         // rps
         long currentRequestCounter = MetricRepo.COUNTER_REQUEST_ALL.getValue();

--- a/fe/fe-core/src/main/java/com/starrocks/persist/Storage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/Storage.java
@@ -112,7 +112,7 @@ public class Storage {
             for (File child : children) {
                 String name = child.getName();
                 try {
-                    if (name.startsWith(IMAGE) && name.contains(".")) {
+                    if (!name.equals(IMAGE_NEW) && name.startsWith(IMAGE) && name.contains(".")) {
                         imageJournalId = Math.max(Long.parseLong(name.substring(name.lastIndexOf('.') + 1)), imageJournalId);
                     }
                 } catch (Exception e) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -33,6 +33,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
 import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
@@ -152,6 +153,9 @@ public class ConnectProcessor {
                 // ok query
                 MetricRepo.COUNTER_QUERY_SUCCESS.increase(1L);
                 MetricRepo.HISTO_QUERY_LATENCY.update(elapseMs);
+                if (elapseMs > Config.qe_slow_log_ms) {
+                    MetricRepo.COUNTER_SLOW_QUERY.increase(1L);
+                }
             }
             ctx.getAuditEventBuilder().setIsQuery(true);
         } else {


### PR DESCRIPTION
add metrics:
1. slow_query: total slow query count whose execute time is bigger than Config.qe_slow_log_ms.
2. meta_log_count: total meta log count in bdb je, these log will be replayed when fe restarts.