### PR TITLE
use phmap flat_hash_map instead of std::unordered_map in global dict

### DIFF
--- a/be/src/exec/vectorized/dict_decode_node.h
+++ b/be/src/exec/vectorized/dict_decode_node.h
@@ -80,11 +80,13 @@ protected:
 private:
     void _init_counter();
 
-    using DefaultDecoder = std::unique_ptr<DictDecoder<TYPE_INT, RGlobalDictMap, TYPE_VARCHAR>>;
+    using DefaultDecoder = DictDecoder<TYPE_INT, RGlobalDictMap, TYPE_VARCHAR>;
+    using DefaultDecoderPtr = std::unique_ptr<DefaultDecoder>;
+
     std::shared_ptr<vectorized::Chunk> _input_chunk;
     std::vector<int32_t> _encode_column_cids;
     std::vector<int32_t> _decode_column_cids;
-    std::vector<DefaultDecoder> _decoders;
+    std::vector<DefaultDecoderPtr> _decoders;
 
     std::vector<ExprContext*> _expr_ctxs;
     std::unordered_map<SlotId, std::pair<ExprContext*, DictOptimizeContext>> _string_functions;

--- a/be/src/exec/vectorized/tablet_scanner.cpp
+++ b/be/src/exec/vectorized/tablet_scanner.cpp
@@ -192,7 +192,7 @@ Status TabletScanner::_init_return_columns() {
 // mapping a slot-column-id to schema-columnid
 Status TabletScanner::_init_global_dicts() {
     const auto& global_dict_map = _runtime_state->get_global_dict_map();
-    auto global_dict = _parent->_obj_pool.add(new std::unordered_map<uint32_t, GlobalDictMap*>());
+    auto global_dict = _parent->_obj_pool.add(new ColumnIdToGlobalDictMap());
     // mapping column id to storage column ids
     for (auto slot : _parent->_tuple_desc->slots()) {
         if (!slot->is_materialized()) {

--- a/be/src/runtime/global_dicts.cpp
+++ b/be/src/runtime/global_dicts.cpp
@@ -66,36 +66,30 @@ void DictOptimizeParser::eval_expr(RuntimeState* state, ExprContext* expr_ctx, D
     ColumnViewer<TYPE_VARCHAR> viewer(result_column);
     int row_sz = viewer.size();
 
-    dict_opt_ctx->code_convert_map_holder.resize(DICT_DECODE_MAX_SIZE + 1);
-    std::fill(dict_opt_ctx->code_convert_map_holder.begin(), dict_opt_ctx->code_convert_map_holder.end(), -1);
-    dict_opt_ctx->code_convert_map = dict_opt_ctx->code_convert_map_holder.data() + 1;
+    dict_opt_ctx->code_convert_map.resize(DICT_DECODE_MAX_SIZE);
+    std::fill(dict_opt_ctx->code_convert_map.begin(), dict_opt_ctx->code_convert_map.end(), -1);
     auto& code_convert_map = dict_opt_ctx->code_convert_map;
 
     GlobalDictMap result_map;
     RGlobalDictMap rresult_map;
-    int id_allocator = 0;
+    int id_allocator = 1;
     for (int i = 0; i < row_sz; ++i) {
         if (viewer.is_null(i)) {
-            code_convert_map[codes[i]] = -1;
+            code_convert_map[codes[i]] = 0;
             dict_opt_ctx->result_nullable = true;
         } else {
             auto value = viewer.value(i);
             Slice slice(value.data, value.size);
-            auto res = result_map.emplace(slice, id_allocator);
-            if (res.second) {
+            auto res = result_map.lazy_emplace(slice, [&](const auto& ctor) {
                 id_allocator++;
-                auto node = result_map.extract(res.first);
                 auto data = state->instance_mem_pool()->allocate(value.size);
                 memcpy(data, value.data, value.size);
-                slice = Slice(data, value.size);
-                node.key() = slice;
-                result_map.insert(res.first, std::move(node));
-            } else {
-                slice = res.first->first;
-            }
+                slice = Slice(data, slice.size);
+                ctor(slice, id_allocator);
+            });
 
-            code_convert_map[codes[i]] = res.first->second;
-            rresult_map.emplace(res.first->second, slice);
+            code_convert_map[codes[i]] = res->second;
+            rresult_map.emplace(res->second, slice);
         }
     }
 
@@ -107,14 +101,14 @@ void DictOptimizeParser::eval_code_convert(const DictOptimizeContext& opt_ctx, c
                                            ColumnPtr* output) {
     int row_size = input->size();
 
-    auto res = Int32Column::create_mutable();
+    auto res = LowCardDictColumn::create_mutable();
     auto& res_data = res->get_data();
     res_data.resize(row_size);
 
     if (input->is_nullable()) {
         const auto* nullable_column = down_cast<const NullableColumn*>(input.get());
         const auto* null_column = down_cast<const NullColumn*>(nullable_column->null_column().get());
-        const auto* data_column = down_cast<const Int32Column*>(nullable_column->data_column().get());
+        const auto* data_column = down_cast<const LowCardDictColumn*>(nullable_column->data_column().get());
         const auto& input_data = data_column->get_data();
 
         for (int i = 0; i < row_size; ++i) {
@@ -127,7 +121,7 @@ void DictOptimizeParser::eval_code_convert(const DictOptimizeContext& opt_ctx, c
             auto& res_null_data = down_cast<NullColumn*>(res_null_column.get())->get_data();
 
             for (int i = 0; i < row_size; ++i) {
-                res_null_data[i] |= (res_data[i] == -1);
+                res_null_data[i] |= (res_data[i] == 0);
             }
 
             *output = NullableColumn::create(std::move(res), std::move(res_null_column));
@@ -135,7 +129,7 @@ void DictOptimizeParser::eval_code_convert(const DictOptimizeContext& opt_ctx, c
             *output = NullableColumn::create(std::move(res), null_column->clone());
         }
     } else {
-        const auto* data_column = down_cast<const Int32Column*>(input.get());
+        const auto* data_column = down_cast<const LowCardDictColumn*>(input.get());
         const auto& input_data = data_column->get_data();
 
         for (int i = 0; i < row_size; ++i) {
@@ -148,11 +142,10 @@ void DictOptimizeParser::eval_code_convert(const DictOptimizeContext& opt_ctx, c
             res_null_data.resize(row_size);
 
             for (int i = 0; i < row_size; ++i) {
-                res_null_data[i] = (res_data[i] == -1);
+                res_null_data[i] = (res_data[i] == 0);
             }
 
             *output = NullableColumn::create(std::move(res), std::unique_ptr<Column>(res_null.release()));
-
         } else {
             *output = std::move(res);
         }

--- a/be/src/runtime/global_dicts.cpp
+++ b/be/src/runtime/global_dicts.cpp
@@ -66,8 +66,8 @@ void DictOptimizeParser::eval_expr(RuntimeState* state, ExprContext* expr_ctx, D
     ColumnViewer<TYPE_VARCHAR> viewer(result_column);
     int row_sz = viewer.size();
 
-    dict_opt_ctx->code_convert_map.resize(DICT_DECODE_MAX_SIZE);
-    std::fill(dict_opt_ctx->code_convert_map.begin(), dict_opt_ctx->code_convert_map.end(), -1);
+    dict_opt_ctx->code_convert_map.resize(DICT_DECODE_MAX_SIZE + 1);
+    std::fill(dict_opt_ctx->code_convert_map.begin(), dict_opt_ctx->code_convert_map.end(), 0);
     auto& code_convert_map = dict_opt_ctx->code_convert_map;
 
     GlobalDictMap result_map;

--- a/be/src/runtime/global_dicts.h
+++ b/be/src/runtime/global_dicts.h
@@ -52,8 +52,8 @@ struct DictOptimizeContext {
     SlotId slot_id;
     // if input was not nullable but output was nullable this flag will set true
     bool result_nullable = false;
-    // size: DICT_DECODE_MAX_SIZE
-    std::vector<DictId> code_convert_map;
+    // size: DICT_DECODE_MAX_SIZE + 1
+    std::vector<int16_t> code_convert_map;
 };
 
 class DictOptimizeParser {

--- a/be/src/storage/rowset/beta_rowset.cpp
+++ b/be/src/storage/rowset/beta_rowset.cpp
@@ -216,7 +216,7 @@ public:
         _iter.reset();
     }
 
-    virtual Status init_encoded_schema(std::unordered_map<uint32_t, vectorized::GlobalDictMap*>& dict_maps) override {
+    virtual Status init_encoded_schema(vectorized::ColumnIdToGlobalDictMap& dict_maps) override {
         RETURN_IF_ERROR(vectorized::ChunkIterator::init_encoded_schema(dict_maps));
         return _iter->init_encoded_schema(dict_maps);
     }

--- a/be/src/storage/rowset/vectorized/rowset_options.h
+++ b/be/src/storage/rowset/vectorized/rowset_options.h
@@ -56,7 +56,7 @@ public:
     starrocks::RuntimeProfile* profile = nullptr;
     bool use_page_cache = false;
 
-    std::unordered_map<ColumnId, GlobalDictMap*>* global_dictmaps = &EMPTY_GLOBAL_DICTMAPS;
+    ColumnIdToGlobalDictMap* global_dictmaps = &EMPTY_GLOBAL_DICTMAPS;
 };
 
 } // namespace starrocks::vectorized

--- a/be/src/storage/rowset/vectorized/segment_options.h
+++ b/be/src/storage/rowset/vectorized/segment_options.h
@@ -57,7 +57,7 @@ public:
     ReaderType reader_type = READER_QUERY;
     int chunk_size = DEFAULT_CHUNK_SIZE;
 
-    const std::unordered_map<ColumnId, GlobalDictMap*>* global_dictmaps = &EMPTY_GLOBAL_DICTMAPS;
+    const ColumnIdToGlobalDictMap* global_dictmaps = &EMPTY_GLOBAL_DICTMAPS;
 };
 
 } // namespace starrocks::vectorized

--- a/be/src/storage/vectorized/aggregate_iterator.cpp
+++ b/be/src/storage/vectorized/aggregate_iterator.cpp
@@ -51,7 +51,7 @@ public:
 
     size_t merged_rows() const override { return _aggregator.merged_rows(); }
 
-    virtual Status init_encoded_schema(std::unordered_map<uint32_t, GlobalDictMap*>& dict_maps) override {
+    virtual Status init_encoded_schema(ColumnIdToGlobalDictMap& dict_maps) override {
         ChunkIterator::init_encoded_schema(dict_maps);
         return _child->init_encoded_schema(dict_maps);
     }

--- a/be/src/storage/vectorized/chunk_iterator.h
+++ b/be/src/storage/vectorized/chunk_iterator.h
@@ -66,7 +66,7 @@ public:
     // If a Field uses the global dictionary strategy, the field will be rewritten as INT
     const Schema& encoded_schema() const { return _encoded_schema; }
 
-    virtual Status init_encoded_schema(std::unordered_map<uint32_t, GlobalDictMap*>& dict_maps) {
+    virtual Status init_encoded_schema(ColumnIdToGlobalDictMap& dict_maps) {
         for (const auto& field : schema().fields()) {
             const auto cid = field->id();
             const auto& name = field->name();
@@ -111,7 +111,7 @@ public:
 
     size_t merged_rows() const override { return _iter->merged_rows(); }
 
-    virtual Status init_encoded_schema(std::unordered_map<uint32_t, GlobalDictMap*>& dict_maps) override {
+    virtual Status init_encoded_schema(ColumnIdToGlobalDictMap& dict_maps) override {
         ChunkIterator::init_encoded_schema(dict_maps);
         _iter->init_encoded_schema(dict_maps);
         return Status::OK();

--- a/be/src/storage/vectorized/merge_iterator.cpp
+++ b/be/src/storage/vectorized/merge_iterator.cpp
@@ -95,7 +95,7 @@ public:
 
     size_t merged_rows() const override { return _merged_rows; }
 
-    virtual Status init_encoded_schema(std::unordered_map<uint32_t, GlobalDictMap*>& dict_maps) override {
+    virtual Status init_encoded_schema(ColumnIdToGlobalDictMap& dict_maps) override {
         ChunkIterator::init_encoded_schema(dict_maps);
         for (int i = 0; i < _children.size(); ++i) {
             RETURN_IF_ERROR(_children[i]->init_encoded_schema(dict_maps));

--- a/be/src/storage/vectorized/projection_iterator.cpp
+++ b/be/src/storage/vectorized/projection_iterator.cpp
@@ -22,7 +22,7 @@ public:
 
     size_t merged_rows() const override { return _child->merged_rows(); }
 
-    virtual Status init_encoded_schema(std::unordered_map<uint32_t, GlobalDictMap*>& dict_maps) override {
+    virtual Status init_encoded_schema(ColumnIdToGlobalDictMap& dict_maps) override {
         ChunkIterator::init_encoded_schema(dict_maps);
         return _child->init_encoded_schema(dict_maps);
     }

--- a/be/src/storage/vectorized/tablet_reader_params.h
+++ b/be/src/storage/vectorized/tablet_reader_params.h
@@ -50,7 +50,7 @@ struct TabletReaderParams {
     std::string to_string() const;
     int chunk_size = 1024;
 
-    std::unordered_map<uint32_t, GlobalDictMap*>* global_dictmaps = &EMPTY_GLOBAL_DICTMAPS;
+    ColumnIdToGlobalDictMap* global_dictmaps = &EMPTY_GLOBAL_DICTMAPS;
 };
 
 } // namespace vectorized

--- a/be/src/storage/vectorized/union_iterator.cpp
+++ b/be/src/storage/vectorized/union_iterator.cpp
@@ -30,7 +30,7 @@ public:
 
     size_t merged_rows() const override { return _merged_rows; }
 
-    virtual Status init_encoded_schema(std::unordered_map<uint32_t, GlobalDictMap*>& dict_maps) override {
+    virtual Status init_encoded_schema(ColumnIdToGlobalDictMap& dict_maps) override {
         ChunkIterator::init_encoded_schema(dict_maps);
         for (auto& child : _children) {
             child->init_encoded_schema(dict_maps);


### PR DESCRIPTION
use phmap flat_hash_map instead of std::unordered_map in global dict
use array instead of flat_hash_map when convert local dict code to global dict code

for #559 