### PR TITLE
Enhancement: reduce the memory usage of segment

### DIFF
--- a/be/src/storage/vectorized/meta_reader.cpp
+++ b/be/src/storage/vectorized/meta_reader.cpp
@@ -309,39 +309,32 @@ Status SegmentMetaCollecter::_collect_min(ColumnId cid, vectorized::Column* colu
 
 template <bool is_max>
 Status SegmentMetaCollecter::__collect_max_or_min(ColumnId cid, vectorized::Column* column, FieldType type) {
-    auto footer_pb = _segment->footer();
-    for (size_t i = 0; i < footer_pb.columns_size(); i++) {
-        if (footer_pb.columns(i).column_id() == cid) {
-            for (size_t j = 0; j < footer_pb.columns(i).indexes_size(); j++) {
-                if (footer_pb.columns(i).indexes(j).type() != ZONE_MAP_INDEX) {
-                    continue;
-                }
-                const ColumnIndexMetaPB& c_meta_pb = footer_pb.columns(i).indexes(j);
-                const ZoneMapIndexPB& zone_map_index_pb = c_meta_pb.zone_map_index();
-                const ZoneMapPB& segment_zone_map_pb = zone_map_index_pb.segment_zone_map();
-
-                TypeInfoPtr type_info = get_type_info(delegate_type(type));
-                if constexpr (!is_max) {
-                    vectorized::Datum min;
-                    if (!segment_zone_map_pb.has_null()) {
-                        RETURN_IF_ERROR(vectorized::datum_from_string(type_info.get(), &min, segment_zone_map_pb.min(),
-                                                                      nullptr));
-                        column->append_datum(min);
-                    }
-                } else if constexpr (is_max) {
-                    vectorized::Datum max;
-                    if (segment_zone_map_pb.has_not_null()) {
-                        RETURN_IF_ERROR(vectorized::datum_from_string(type_info.get(), &max, segment_zone_map_pb.max(),
-                                                                      nullptr));
-                        column->append_datum(max);
-                    }
-                }
-                return Status::OK();
-            }
-            break;
+    if (cid >= _segment->num_columns()) {
+        return Status::NotFound("");
+    }
+    const ColumnReader* col_reader = _segment->column(cid);
+    if (col_reader == nullptr || col_reader->segment_zone_map() == nullptr) {
+        return Status::NotFound("");
+    }
+    if (col_reader->column_type() != type) {
+        return Status::InternalError("column type mismatch");
+    }
+    const ZoneMapPB* segment_zone_map_pb = col_reader->segment_zone_map();
+    TypeInfoPtr type_info = get_type_info(col_reader->column_type());
+    if constexpr (!is_max) {
+        vectorized::Datum min;
+        if (!segment_zone_map_pb->has_null()) {
+            RETURN_IF_ERROR(vectorized::datum_from_string(type_info.get(), &min, segment_zone_map_pb->min(), nullptr));
+            column->append_datum(min);
+        }
+    } else if constexpr (is_max) {
+        vectorized::Datum max;
+        if (segment_zone_map_pb->has_not_null()) {
+            RETURN_IF_ERROR(vectorized::datum_from_string(type_info.get(), &max, segment_zone_map_pb->max(), nullptr));
+            column->append_datum(max);
         }
     }
-    return Status::NotFound("");
+    return Status::OK();
 }
 
 } // namespace starrocks::vectorized

--- a/be/src/storage/vectorized/meta_reader.cpp
+++ b/be/src/storage/vectorized/meta_reader.cpp
@@ -320,7 +320,7 @@ Status SegmentMetaCollecter::__collect_max_or_min(ColumnId cid, vectorized::Colu
         return Status::InternalError("column type mismatch");
     }
     const ZoneMapPB* segment_zone_map_pb = col_reader->segment_zone_map();
-    TypeInfoPtr type_info = get_type_info(col_reader->column_type());
+    TypeInfoPtr type_info = get_type_info(delegate_type(type));
     if constexpr (!is_max) {
         vectorized::Datum min;
         if (!segment_zone_map_pb->has_null()) {

--- a/be/test/storage/rowset/segment_v2/column_reader_writer_test.cpp
+++ b/be/test/storage/rowset/segment_v2/column_reader_writer_test.cpp
@@ -132,7 +132,7 @@ protected:
             reader_opts.storage_format_version = version;
             reader_opts.block_mgr = block_mgr.get();
             std::unique_ptr<ColumnReader> reader;
-            auto st = ColumnReader::create(&_tracker, reader_opts, meta, num_rows, fname, &reader);
+            auto st = ColumnReader::create(&_tracker, reader_opts, &meta, fname, &reader);
             ASSERT_TRUE(st.ok());
 
             ColumnIterator* iter = nullptr;
@@ -292,8 +292,6 @@ protected:
         src_elements->append(6);
         src_offsets->append(6);
 
-        int num_rows = src_column->size();
-
         TypeInfoPtr type_info = get_type_info(array_column);
         ColumnMetaPB meta;
 
@@ -349,7 +347,7 @@ protected:
             reader_opts.block_mgr = block_mgr.get();
             reader_opts.storage_format_version = 2;
             std::unique_ptr<ColumnReader> reader;
-            auto st = ColumnReader::create(&_tracker, reader_opts, meta, num_rows, fname, &reader);
+            auto st = ColumnReader::create(&_tracker, reader_opts, &meta, fname, &reader);
             ASSERT_TRUE(st.ok());
 
             ColumnIterator* iter = nullptr;


### PR DESCRIPTION
Related issue #788

- Does not keep `SegmentFooterPB` in memory anymore
- Save index meta and index reader as a union in `ColumnReader`
- Reorder class memory fields to reduce class size
- Avoid creating unused fields

In my test environment (with 1 BE, 10,000 replicas, 300 columns per replica), memory consumption dropped from 15GB to 7.2GB