### PR TITLE
Parallelization of aggregate streaming operators

### DIFF
--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.h
@@ -45,17 +45,23 @@ private:
 
 class AggregateDistinctStreamingSinkOperatorFactory final : public OperatorFactory {
 public:
-    AggregateDistinctStreamingSinkOperatorFactory(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
+    AggregateDistinctStreamingSinkOperatorFactory(int32_t id, int32_t plan_node_id,
+                                                  AggregatorFactoryPtr aggregator_factory)
             : OperatorFactory(id, "aggregate_distinct_streaming_sink", plan_node_id),
-              _aggregator(std::move(aggregator)) {}
+              _aggregator_factory(std::move(aggregator_factory)) {}
 
     ~AggregateDistinctStreamingSinkOperatorFactory() override = default;
 
     OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override {
-        return std::make_shared<AggregateDistinctStreamingSinkOperator>(_id, _plan_node_id, _aggregator);
+        size_t expected_idx = _aggregator_idx.load(std::memory_order_acquire);
+        while (!_aggregator_idx.compare_exchange_weak(expected_idx, expected_idx + 1))
+            ;
+        return std::make_shared<AggregateDistinctStreamingSinkOperator>(
+                _id, _plan_node_id, _aggregator_factory->get_or_create(expected_idx + 1));
     }
 
 private:
-    AggregatorPtr _aggregator = nullptr;
+    AggregatorFactoryPtr _aggregator_factory = nullptr;
+    std::atomic_size_t _aggregator_idx = 0;
 };
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.h
@@ -53,15 +53,12 @@ public:
     ~AggregateDistinctStreamingSinkOperatorFactory() override = default;
 
     OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override {
-        size_t expected_idx = _aggregator_idx.load(std::memory_order_acquire);
-        while (!_aggregator_idx.compare_exchange_weak(expected_idx, expected_idx + 1))
-            ;
         return std::make_shared<AggregateDistinctStreamingSinkOperator>(
-                _id, _plan_node_id, _aggregator_factory->get_or_create(expected_idx + 1));
+                _id, _plan_node_id, _aggregator_factory->get_or_create(_aggregator_idx++));
     }
 
 private:
     AggregatorFactoryPtr _aggregator_factory = nullptr;
-    std::atomic_size_t _aggregator_idx = 0;
+    size_t _aggregator_idx = 0;
 };
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.h
@@ -35,17 +35,23 @@ private:
 
 class AggregateDistinctStreamingSourceOperatorFactory final : public SourceOperatorFactory {
 public:
-    AggregateDistinctStreamingSourceOperatorFactory(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
+    AggregateDistinctStreamingSourceOperatorFactory(int32_t id, int32_t plan_node_id,
+                                                    AggregatorFactoryPtr aggregator_factory)
             : SourceOperatorFactory(id, "aggregate_distinct_streaming_source", plan_node_id),
-              _aggregator(std::move(aggregator)) {}
+              _aggregator_factory(std::move(aggregator_factory)) {}
 
     ~AggregateDistinctStreamingSourceOperatorFactory() override = default;
 
     OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override {
-        return std::make_shared<AggregateDistinctStreamingSourceOperator>(_id, _plan_node_id, _aggregator);
+        size_t expected_idx = _aggregator_idx.load(std::memory_order_acquire);
+        while (!_aggregator_idx.compare_exchange_weak(expected_idx, expected_idx + 1))
+            ;
+        return std::make_shared<AggregateDistinctStreamingSourceOperator>(
+                _id, _plan_node_id, _aggregator_factory->get_or_create(expected_idx + 1));
     }
 
 private:
-    AggregatorPtr _aggregator = nullptr;
+    AggregatorFactoryPtr _aggregator_factory = nullptr;
+    std::atomic_size_t _aggregator_idx = 0;
 };
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.h
@@ -43,15 +43,12 @@ public:
     ~AggregateDistinctStreamingSourceOperatorFactory() override = default;
 
     OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override {
-        size_t expected_idx = _aggregator_idx.load(std::memory_order_acquire);
-        while (!_aggregator_idx.compare_exchange_weak(expected_idx, expected_idx + 1))
-            ;
         return std::make_shared<AggregateDistinctStreamingSourceOperator>(
-                _id, _plan_node_id, _aggregator_factory->get_or_create(expected_idx + 1));
+                _id, _plan_node_id, _aggregator_factory->get_or_create(_aggregator_idx++));
     }
 
 private:
     AggregatorFactoryPtr _aggregator_factory = nullptr;
-    std::atomic_size_t _aggregator_idx = 0;
+    size_t _aggregator_idx = 0;
 };
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.h
@@ -52,15 +52,12 @@ public:
     ~AggregateStreamingSinkOperatorFactory() override = default;
 
     OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override {
-        size_t expected_idx = _aggregator_idx.load(std::memory_order_acquire);
-        while (!_aggregator_idx.compare_exchange_weak(expected_idx, expected_idx + 1))
-            ;
         return std::make_shared<AggregateStreamingSinkOperator>(_id, _plan_node_id,
-                                                                _aggregator_factory->get_or_create(expected_idx + 1));
+                                                                _aggregator_factory->get_or_create(_aggregator_idx++));
     }
 
 private:
     AggregatorFactoryPtr _aggregator_factory = nullptr;
-    std::atomic_size_t _aggregator_idx = 0;
+    size_t _aggregator_idx = 0;
 };
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.h
@@ -41,15 +41,12 @@ public:
     ~AggregateStreamingSourceOperatorFactory() override = default;
 
     OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override {
-        size_t expected_idx = _aggregator_idx.load(std::memory_order_acquire);
-        while (!_aggregator_idx.compare_exchange_weak(expected_idx, expected_idx + 1))
-            ;
-        return std::make_shared<AggregateStreamingSourceOperator>(_id, _plan_node_id,
-                                                                  _aggregator_factory->get_or_create(expected_idx + 1));
+        return std::make_shared<AggregateStreamingSourceOperator>(
+                _id, _plan_node_id, _aggregator_factory->get_or_create(_aggregator_idx++));
     }
 
 private:
     AggregatorFactoryPtr _aggregator_factory = nullptr;
-    std::atomic_size_t _aggregator_idx = 0;
+    size_t _aggregator_idx = 0;
 };
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.h
@@ -34,17 +34,22 @@ private:
 
 class AggregateStreamingSourceOperatorFactory final : public SourceOperatorFactory {
 public:
-    AggregateStreamingSourceOperatorFactory(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
+    AggregateStreamingSourceOperatorFactory(int32_t id, int32_t plan_node_id, AggregatorFactoryPtr aggregator_factory)
             : SourceOperatorFactory(id, "aggregate_streaming_source", plan_node_id),
-              _aggregator(std::move(aggregator)) {}
+              _aggregator_factory(std::move(aggregator_factory)) {}
 
     ~AggregateStreamingSourceOperatorFactory() override = default;
 
     OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override {
-        return std::make_shared<AggregateStreamingSourceOperator>(_id, _plan_node_id, _aggregator);
+        size_t expected_idx = _aggregator_idx.load(std::memory_order_acquire);
+        while (!_aggregator_idx.compare_exchange_weak(expected_idx, expected_idx + 1))
+            ;
+        return std::make_shared<AggregateStreamingSourceOperator>(_id, _plan_node_id,
+                                                                  _aggregator_factory->get_or_create(expected_idx + 1));
     }
 
 private:
-    AggregatorPtr _aggregator = nullptr;
+    AggregatorFactoryPtr _aggregator_factory = nullptr;
+    std::atomic_size_t _aggregator_idx = 0;
 };
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/operator.h
+++ b/be/src/exec/pipeline/operator.h
@@ -4,6 +4,7 @@
 
 #include "column/vectorized_fwd.h"
 #include "common/statusor.h"
+#include "gutil/casts.h"
 
 namespace starrocks {
 class Expr;

--- a/be/src/exec/vectorized/aggregate/aggregate_base_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_base_node.cpp
@@ -14,7 +14,7 @@ AggregateBaseNode::~AggregateBaseNode() = default;
 
 Status AggregateBaseNode::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(ExecNode::prepare(state));
-    _aggregator = std::make_shared<Aggregator>(_tnode, child(0)->row_desc());
+    _aggregator = std::make_shared<Aggregator>(_tnode);
     return _aggregator->prepare(state, _pool, mem_tracker(), expr_mem_tracker(), runtime_profile());
 }
 

--- a/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
@@ -160,7 +160,7 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > AggregateBlockingNode::
     operators_with_sink = context->maybe_interpolate_local_exchange(operators_with_sink);
 
     // shared by sink operator and source operator
-    AggregatorPtr aggregator = std::make_shared<Aggregator>(_tnode, child(0)->row_desc());
+    AggregatorPtr aggregator = std::make_shared<Aggregator>(_tnode);
 
     operators_with_sink.emplace_back(
             std::make_shared<AggregateBlockingSinkOperatorFactory>(context->next_operator_id(), id(), aggregator));

--- a/be/src/exec/vectorized/aggregate/aggregate_streaming_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_streaming_node.cpp
@@ -222,11 +222,13 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > AggregateStreamingNode:
         pipeline::PipelineBuilderContext* context) {
     using namespace pipeline;
     OpFactories operators_with_sink = _children[0]->decompose_to_pipeline(context);
+    // We cannot get degree of parallelism from PipelineBuilderContext, of which is only a suggest value
+    // and we may set other parallelism for source operator in many special cases
     size_t degree_of_parallelism =
             down_cast<SourceOperatorFactory*>(operators_with_sink[0].get())->degree_of_parallelism();
 
     // shared by sink operator factory and source operator factory
-    AggregatorFactoryPtr aggregator_factory = std::make_shared<AggregatorFactory>(_tnode, child(0)->row_desc());
+    AggregatorFactoryPtr aggregator_factory = std::make_shared<AggregatorFactory>(_tnode);
 
     auto sink_operator = std::make_shared<AggregateStreamingSinkOperatorFactory>(context->next_operator_id(), id(),
                                                                                  aggregator_factory);

--- a/be/src/exec/vectorized/aggregate/aggregate_streaming_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_streaming_node.cpp
@@ -222,22 +222,24 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > AggregateStreamingNode:
         pipeline::PipelineBuilderContext* context) {
     using namespace pipeline;
     OpFactories operators_with_sink = _children[0]->decompose_to_pipeline(context);
-    operators_with_sink = context->maybe_interpolate_local_exchange(operators_with_sink);
+    size_t degree_of_parallelism =
+            down_cast<SourceOperatorFactory*>(operators_with_sink[0].get())->degree_of_parallelism();
 
-    // shared by sink operator and source operator
-    AggregatorPtr aggregator = std::make_shared<Aggregator>(_tnode, child(0)->row_desc());
+    // shared by sink operator factory and source operator factory
+    AggregatorFactoryPtr aggregator_factory = std::make_shared<AggregatorFactory>(_tnode, child(0)->row_desc());
 
-    operators_with_sink.emplace_back(
-            std::make_shared<AggregateStreamingSinkOperatorFactory>(context->next_operator_id(), id(), aggregator));
+    auto sink_operator = std::make_shared<AggregateStreamingSinkOperatorFactory>(context->next_operator_id(), id(),
+                                                                                 aggregator_factory);
+    operators_with_sink.emplace_back(sink_operator);
     context->add_pipeline(operators_with_sink);
 
     OpFactories operators_with_source;
-    auto source_operator =
-            std::make_shared<AggregateStreamingSourceOperatorFactory>(context->next_operator_id(), id(), aggregator);
+    auto source_operator = std::make_shared<AggregateStreamingSourceOperatorFactory>(context->next_operator_id(), id(),
+                                                                                     aggregator_factory);
 
-    // TODO(hcf) Currently, the shared data structure aggregator does not support concurrency.
-    // So the degree of parallism must set to 1, we'll fix it later
-    source_operator->set_degree_of_parallelism(1);
+    // Aggregator must be used by a pair of sink and source operators,
+    // so operators_with_source's degree of parallelism must be equal with operators_with_sink's
+    source_operator->set_degree_of_parallelism(degree_of_parallelism);
     operators_with_source.push_back(std::move(source_operator));
     return operators_with_source;
 }

--- a/be/src/exec/vectorized/aggregate/distinct_blocking_node.cpp
+++ b/be/src/exec/vectorized/aggregate/distinct_blocking_node.cpp
@@ -127,7 +127,7 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > DistinctBlockingNode::d
     operators_with_sink = context->maybe_interpolate_local_exchange(operators_with_sink);
 
     // shared by sink operator and source operator
-    AggregatorPtr aggregator = std::make_shared<Aggregator>(_tnode, child(0)->row_desc());
+    AggregatorPtr aggregator = std::make_shared<Aggregator>(_tnode);
 
     operators_with_sink.emplace_back(std::make_shared<AggregateDistinctBlockingSinkOperatorFactory>(
             context->next_operator_id(), id(), aggregator));

--- a/be/src/exec/vectorized/aggregate/distinct_streaming_node.cpp
+++ b/be/src/exec/vectorized/aggregate/distinct_streaming_node.cpp
@@ -208,22 +208,24 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > DistinctStreamingNode::
         pipeline::PipelineBuilderContext* context) {
     using namespace pipeline;
     OpFactories operators_with_sink = _children[0]->decompose_to_pipeline(context);
-    operators_with_sink = context->maybe_interpolate_local_exchange(operators_with_sink);
+    size_t degree_of_parallelism =
+            down_cast<SourceOperatorFactory*>(operators_with_sink[0].get())->degree_of_parallelism();
 
-    // shared by sink operator and source operator
-    AggregatorPtr aggregator = std::make_shared<Aggregator>(_tnode, child(0)->row_desc());
+    // shared by sink operator factory and source operator factory
+    AggregatorFactoryPtr aggregator_factory = std::make_shared<AggregatorFactory>(_tnode, child(0)->row_desc());
 
-    operators_with_sink.emplace_back(std::make_shared<AggregateDistinctStreamingSinkOperatorFactory>(
-            context->next_operator_id(), id(), aggregator));
+    auto sink_operator = std::make_shared<AggregateDistinctStreamingSinkOperatorFactory>(context->next_operator_id(),
+                                                                                         id(), aggregator_factory);
+    operators_with_sink.emplace_back(sink_operator);
     context->add_pipeline(operators_with_sink);
 
     OpFactories operators_with_source;
     auto source_operator = std::make_shared<AggregateDistinctStreamingSourceOperatorFactory>(
-            context->next_operator_id(), id(), aggregator);
+            context->next_operator_id(), id(), aggregator_factory);
 
-    // TODO(hcf) Currently, the shared data structure aggregator does not support concurrency.
-    // So the degree of parallism must set to 1, we'll fix it later
-    source_operator->set_degree_of_parallelism(1);
+    // Aggregator must be used by a pair of sink and source operators,
+    // so operators_with_source's degree of parallelism must be equal with operators_with_sink's
+    source_operator->set_degree_of_parallelism(degree_of_parallelism);
     operators_with_source.push_back(std::move(source_operator));
     return operators_with_source;
 }

--- a/be/src/exec/vectorized/aggregate/distinct_streaming_node.cpp
+++ b/be/src/exec/vectorized/aggregate/distinct_streaming_node.cpp
@@ -208,11 +208,13 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > DistinctStreamingNode::
         pipeline::PipelineBuilderContext* context) {
     using namespace pipeline;
     OpFactories operators_with_sink = _children[0]->decompose_to_pipeline(context);
+    // We cannot get degree of parallelism from PipelineBuilderContext, of which is only a suggest value
+    // and we may set other parallelism for source operator in many special cases
     size_t degree_of_parallelism =
             down_cast<SourceOperatorFactory*>(operators_with_sink[0].get())->degree_of_parallelism();
 
     // shared by sink operator factory and source operator factory
-    AggregatorFactoryPtr aggregator_factory = std::make_shared<AggregatorFactory>(_tnode, child(0)->row_desc());
+    AggregatorFactoryPtr aggregator_factory = std::make_shared<AggregatorFactory>(_tnode);
 
     auto sink_operator = std::make_shared<AggregateDistinctStreamingSinkOperatorFactory>(context->next_operator_id(),
                                                                                          id(), aggregator_factory);

--- a/be/src/exec/vectorized/aggregator.cpp
+++ b/be/src/exec/vectorized/aggregator.cpp
@@ -6,8 +6,7 @@
 
 namespace starrocks {
 
-Aggregator::Aggregator(const TPlanNode& tnode, const RowDescriptor& child_row_desc)
-        : _tnode(tnode), _child_row_desc(child_row_desc) {}
+Aggregator::Aggregator(const TPlanNode& tnode) : _tnode(tnode) {}
 
 Status Aggregator::open(RuntimeState* state) {
     RETURN_IF_ERROR(Expr::open(_group_by_expr_ctxs, state));
@@ -174,10 +173,12 @@ Status Aggregator::prepare(RuntimeState* state, ObjectPool* pool, MemTracker* me
     _output_tuple_desc = state->desc_tbl().get_tuple_descriptor(_output_tuple_id);
     DCHECK_EQ(_intermediate_tuple_desc->slots().size(), _output_tuple_desc->slots().size());
 
-    RETURN_IF_ERROR(Expr::prepare(_group_by_expr_ctxs, state, _child_row_desc, expr_mem_tracker));
+    // create an empty RowDescriptor, and it will be removed sooner or later
+    RowDescriptor child_row_desc;
+    RETURN_IF_ERROR(Expr::prepare(_group_by_expr_ctxs, state, child_row_desc, expr_mem_tracker));
 
     for (const auto& ctx : _agg_expr_ctxs) {
-        RETURN_IF_ERROR(Expr::prepare(ctx, state, _child_row_desc, expr_mem_tracker));
+        RETURN_IF_ERROR(Expr::prepare(ctx, state, child_row_desc, expr_mem_tracker));
     }
 
     _mem_pool = std::make_unique<MemPool>(_mem_tracker);

--- a/be/src/exec/vectorized/aggregator.h
+++ b/be/src/exec/vectorized/aggregator.h
@@ -491,7 +491,6 @@ public:
             : _tnode(tnode), _child_row_desc(child_row_desc) {}
 
     AggregatorPtr get_or_create(size_t id) {
-        std::lock_guard<std::mutex> l(_lock);
         auto it = _aggregators.find(id);
         if (it != _aggregators.end()) {
             return it->second;
@@ -505,7 +504,6 @@ private:
     const TPlanNode& _tnode;
     const RowDescriptor& _child_row_desc;
 
-    std::mutex _lock;
     std::unordered_map<size_t, AggregatorPtr> _aggregators;
 };
 

--- a/be/src/exec/vectorized/aggregator.h
+++ b/be/src/exec/vectorized/aggregator.h
@@ -58,7 +58,7 @@ using AggregatorPtr = std::shared_ptr<Aggregator>;
 // TODO(hcf) all the data should be protected by lightweight lock
 class Aggregator {
 public:
-    Aggregator(const TPlanNode& tnode, const RowDescriptor& child_row_desc);
+    Aggregator(const TPlanNode& tnode);
 
     ~Aggregator() = default;
 
@@ -150,7 +150,6 @@ public:
 
 private:
     const TPlanNode& _tnode;
-    const RowDescriptor& _child_row_desc;
 
     ObjectPool* _pool;
     std::unique_ptr<MemPool> _mem_pool;
@@ -487,22 +486,20 @@ using AggregatorFactoryPtr = std::shared_ptr<AggregatorFactory>;
 
 class AggregatorFactory {
 public:
-    AggregatorFactory(const TPlanNode& tnode, const RowDescriptor& child_row_desc)
-            : _tnode(tnode), _child_row_desc(child_row_desc) {}
+    AggregatorFactory(const TPlanNode& tnode) : _tnode(tnode) {}
 
     AggregatorPtr get_or_create(size_t id) {
         auto it = _aggregators.find(id);
         if (it != _aggregators.end()) {
             return it->second;
         }
-        auto aggregator = std::make_shared<Aggregator>(_tnode, _child_row_desc);
+        auto aggregator = std::make_shared<Aggregator>(_tnode);
         _aggregators[id] = aggregator;
         return aggregator;
     }
 
 private:
     const TPlanNode& _tnode;
-    const RowDescriptor& _child_row_desc;
 
     std::unordered_map<size_t, AggregatorPtr> _aggregators;
 };


### PR DESCRIPTION
The first level of aggregation can be parallelized simply by each pair of sink and source operator exclusively holding a aggregator. In this way, there will be duplicate keys across those aggregators, and it's ok because the second level of aggregation will do the final aggregation