### PR TITLE
Change the default page format to 2

### DIFF
--- a/be/src/storage/rowset/segment_v2/column_writer.h
+++ b/be/src/storage/rowset/segment_v2/column_writer.h
@@ -57,7 +57,7 @@ struct ColumnWriterOptions {
     // - output: encoding/indexes/dict_page members
     ColumnMetaPB* meta;
     size_t data_page_size = 64 * 1024;
-    uint32_t page_format = 1;
+    uint32_t page_format = 2;
     // store compressed page only when space saving is above the threshold.
     // space saving = 1 - compressed_size / uncompressed_size
     double compression_min_space_saving = 0.1;


### PR DESCRIPTION
Change the default page format to 2, because sub columns's page format of array column is still page format 1.