### PR TITLE
Decode rewrite support filter

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -171,6 +171,13 @@ public class OlapScanNode extends ScanNode {
         return selectedPartitionIds;
     }
 
+    // The dict id int column ids to dict string column ids
+    private Map<Integer, Integer> dictStringIdToIntIds = Maps.newHashMap();
+
+    public void setDictStringIdToIntIds(Map<Integer, Integer> dictStringIdToIntIds) {
+        this.dictStringIdToIntIds = dictStringIdToIntIds;
+    }
+
     /**
      * This method is mainly used to update scan range info in OlapScanNode by the new materialized selector.
      * Situation1:
@@ -672,6 +679,7 @@ public class OlapScanNode extends ScanNode {
         if (ConnectContext.get() != null) {
             msg.olap_scan_node.setEnable_column_expr_predicate(ConnectContext.get().getSessionVariable().getEnableColumnExprPredicate());
         }
+        msg.olap_scan_node.setDict_string_id_to_int_ids(dictStringIdToIntIds);
     }
 
     // export some tablets

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalHashJoinOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalHashJoinOperator.java
@@ -101,19 +101,15 @@ public class PhysicalHashJoinOperator extends PhysicalOperator {
             dictSet.union(id);
         }
 
-        if (predicate != null) {
-            if (predicate.getUsedColumns().isIntersect(dictSet)) {
-                return true;
-            }
+        if (predicate != null && predicate.getUsedColumns().isIntersect(dictSet)) {
+            return false;
         }
 
-        if (joinPredicate != null) {
-            if (joinPredicate.getUsedColumns().isIntersect(dictSet)) {
-                return true;
-            }
+        if (joinPredicate != null && joinPredicate.getUsedColumns().isIntersect(dictSet)) {
+            return false;
         }
 
-        return false;
+        return true;
     }
 
     public void fillDisableDictOptimizeColumns(ColumnRefSet columnRefSet) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalOlapScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalOlapScanOperator.java
@@ -3,6 +3,7 @@
 package com.starrocks.sql.optimizer.operator.physical;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Pair;
@@ -33,6 +34,10 @@ public class PhysicalOlapScanOperator extends PhysicalScanOperator {
     private String turnOffReason;
 
     private List<Pair<Integer, ColumnDict>> globalDicts = Lists.newArrayList();
+    // For the simple predicate k1 = "olap", could apply global dict optimization,
+    // need to store the string column k1 and generate the string slot in plan fragment builder
+    private List<ColumnRefOperator> globalDictStringColumns = Lists.newArrayList();
+    private Map<Integer, Integer> dictStringIdToIntIds = Maps.newHashMap();
 
     public PhysicalOlapScanOperator(Table table,
                                     List<ColumnRefOperator> outputColumns,
@@ -89,6 +94,23 @@ public class PhysicalOlapScanOperator extends PhysicalScanOperator {
         this.globalDicts = globalDicts;
     }
 
+    public List<ColumnRefOperator> getGlobalDictStringColumns() {
+        return globalDictStringColumns;
+    }
+
+    public void setGlobalDictStringColumns(
+            List<ColumnRefOperator> globalDictStringColumns) {
+        this.globalDictStringColumns = globalDictStringColumns;
+    }
+
+    public Map<Integer, Integer> getDictStringIdToIntIds() {
+        return dictStringIdToIntIds;
+    }
+
+    public void setDictStringIdToIntIds(Map<Integer, Integer> dictStringIdToIntIds) {
+        this.dictStringIdToIntIds = dictStringIdToIntIds;
+    }
+
     @Override
     public String toString() {
         return "PhysicalOlapScan" + " {" +
@@ -119,7 +141,6 @@ public class PhysicalOlapScanOperator extends PhysicalScanOperator {
         }
     }
 
-    // FixMe(KKS): Fix filter
     @Override
     public boolean couldApplyStringDict(Set<Integer> childDictColumns) {
         return true;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/BinaryPredicateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/BinaryPredicateOperator.java
@@ -9,8 +9,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import static com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator.BinaryType.EQ_FOR_NULL;
-
 public class BinaryPredicateOperator extends PredicateOperator {
     private static final Map<BinaryType, BinaryType> BINARY_COMMUTATIVE_MAP =
             ImmutableMap.<BinaryType, BinaryType>builder()
@@ -142,15 +140,5 @@ public class BinaryPredicateOperator extends PredicateOperator {
     @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(), type);
-    }
-
-    @Override
-    public boolean isStrictPredicate() {
-        if (type == EQ_FOR_NULL) {
-            return false;
-        }
-        // To exclude 1 = 1;
-        // TODO(kks): Currently, we only allow column ref and cast, we should allow some functions
-        return getChild(0).isColumnRefOrCast() || getChild(1).isColumnRefOrCast();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CaseWhenOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CaseWhenOperator.java
@@ -14,7 +14,7 @@ public class CaseWhenOperator extends CallOperator {
     private boolean hasElse;
 
     private int whenStart;
-    private int whenEnd;
+    private final int whenEnd;
 
     public CaseWhenOperator(CaseWhenOperator other, List<ScalarOperator> children) {
         super("CaseWhen", other.type, children);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CompoundPredicateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CompoundPredicateOperator.java
@@ -79,13 +79,4 @@ public class CompoundPredicateOperator extends PredicateOperator {
     public int hashCode() {
         return Objects.hash(super.hashCode(), type);
     }
-
-    @Override
-    public boolean isStrictPredicate() {
-        if (type == CompoundType.NOT) {
-            return false; // Always return false for NOT
-        }
-
-        return getChild(0).isStrictPredicate() && getChild(1).isStrictPredicate();
-    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/InPredicateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/InPredicateOperator.java
@@ -91,9 +91,4 @@ public class InPredicateOperator extends PredicateOperator {
     public int hashCode() {
         return Objects.hash(super.hashCode(), isNotIn);
     }
-
-    @Override
-    public boolean isStrictPredicate() {
-        return getChild(0).isColumnRefOrCast();
-    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/IsNullPredicateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/IsNullPredicateOperator.java
@@ -60,13 +60,4 @@ public class IsNullPredicateOperator extends PredicateOperator {
     public int hashCode() {
         return Objects.hash(super.hashCode(), isNotNull);
     }
-
-    @Override
-    public boolean isStrictPredicate() {
-        if (getChild(0).isColumnRefOrCast()) {
-            return isNotNull;
-        } else {
-            return false;
-        }
-    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/LikePredicateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/LikePredicateOperator.java
@@ -76,9 +76,4 @@ public class LikePredicateOperator extends PredicateOperator {
     public int hashCode() {
         return Objects.hash(super.hashCode(), likeType);
     }
-
-    @Override
-    public boolean isStrictPredicate() {
-        return getChild(0).isColumnRefOrCast();
-    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperator.java
@@ -108,37 +108,14 @@ public abstract class ScalarOperator implements Cloneable {
         return new ColumnRefSet();
     }
 
-    /**
-     * debug string is used to print scalar operator tree
-     */
     public String debugString() {
         return toString();
-    }
-
-    /**
-     * For a predicate, if input is Null, output is Null or false, we call it is strict.
-     */
-    public boolean isStrictPredicate() {
-        return false;
-    }
-
-    // If 'this' is a ColumnRef or a Cast that wraps a ColumnRef, returns true.
-    public boolean isColumnRefOrCast() {
-        if (this instanceof ColumnRefOperator) {
-            return true;
-        }
-        return this instanceof CastOperator && getChild(0) instanceof ColumnRefOperator;
     }
 
     public boolean isColumnRef() {
         return this instanceof ColumnRefOperator;
     }
 
-    /**
-     * is ConstantOperator?
-     *
-     * @return True/False
-     */
     public boolean isConstantRef() {
         return this instanceof ConstantOperator;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CacheDictManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CacheDictManager.java
@@ -190,6 +190,10 @@ public class CacheDictManager implements IDictManager {
     @Override
     public void updateGlobalDict(long tableId, String columnName, long versionTime) {
         ColumnIdentifier columnIdentifier = new ColumnIdentifier(tableId, columnName);
+        if (!dictStatistics.synchronous().asMap().containsKey(columnIdentifier)) {
+            return;
+        }
+
         Optional<ColumnDict> columnDictOptional = dictStatistics.synchronous().get(columnIdentifier);
         Preconditions.checkState(columnDictOptional != null && columnDictOptional.isPresent());
         ColumnDict columnDict = columnDictOptional.get();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -451,6 +451,15 @@ public class PlanFragmentBuilder {
                 context.getColRefToExpr().put(entry.getKey(), new SlotRef(entry.getKey().toString(), slotDescriptor));
             }
 
+            for (ColumnRefOperator entry : node.getGlobalDictStringColumns()) {
+                SlotDescriptor slotDescriptor =
+                        context.getDescTbl().addSlotDescriptor(tupleDescriptor, new SlotId(entry.getId()));
+                slotDescriptor.setIsNullable(entry.isNullable());
+                slotDescriptor.setType(entry.getType());
+                slotDescriptor.setIsMaterialized(false);
+                context.getColRefToExpr().put(entry, new SlotRef(entry.toString(), slotDescriptor));
+            }
+
             // set predicate
             List<ScalarOperator> predicates = Utils.extractConjuncts(node.getPredicate());
             ScalarOperatorToExpr.FormatterContext formatterContext =
@@ -464,6 +473,7 @@ public class PlanFragmentBuilder {
 
             // set isPreAggregation
             scanNode.setIsPreAggregation(node.isPreAggregation(), node.getTurnOffReason());
+            scanNode.setDictStringIdToIntIds(node.getDictStringIdToIntIds());
 
             context.getScanNodes().add(scanNode);
             PlanFragment fragment =

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -450,7 +450,9 @@ public class DatabaseTransactionMgr {
                 tableToValidDictCacheColumns.put(tableId, new HashSet<>());
             }
             // Valid column set should intersect and remove all invalid columns
-            if (i == 0) {
+            // Only need to add valid column set once
+            if (tableToValidDictCacheColumns.get(tableId).isEmpty() &&
+                    !tabletCommitInfos.get(i).getValidDictCacheColumns().isEmpty()) {
                 tableToValidDictCacheColumns.get(tableId).addAll(tabletCommitInfos.get(i).getValidDictCacheColumns());
             }
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithDecimalTypesNewPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithDecimalTypesNewPlannerTest.java
@@ -138,19 +138,7 @@ public class SelectStmtWithDecimalTypesNewPlannerTest {
     @Test
     public void testMod() throws Exception {
         String sql = "select mod(0.022330165, NULL) as result from db1.decimal_table";
-	String expectString = "TPlanFragment(plan:TPlan(nodes:[TPlanNode(node_id:1, node_type:PROJECT_NODE, " +
-		"num_children:1, limit:-1, row_tuples:[1], nullable_tuples:[false], compact_data:false, use_vectorized:true, " + 
-		"project_node:TProjectNode(slot_map:{4=TExpr(nodes:[TExprNode(node_type:NULL_LITERAL, type:TTypeDesc(types:[TTypeNode(type:SCALAR, " + 
-		"scalar_type:TScalarType(type:DECIMAL32, precision:9, scale:9))]), num_children:0, output_scale:-1, use_vectorized:true, " + 
-		"has_nullable_child:false, is_nullable:true, is_monotonic:true)])})), TPlanNode(node_id:0, node_type:OLAP_SCAN_NODE, " + 
-		"num_children:0, limit:-1, row_tuples:[0], nullable_tuples:[false], compact_data:false, olap_scan_node:TOlapScanNode(tuple_id:0, " + 
-		"key_column_name:[key0], key_column_type:[INT], is_preaggregation:true, rollup_name:decimal_table, " + 
-		"enable_column_expr_predicate:false), use_vectorized:true)]), output_exprs:[TExpr(nodes:[TExprNode(node_type:SLOT_REF, " + 
-		"type:TTypeDesc(types:[TTypeNode(type:SCALAR, scalar_type:TScalarType(type:DECIMAL32, precision:9, scale:9))]), " + 
-		"num_children:0, slot_ref:TSlotRef(slot_id:4, tuple_id:1), output_scale:-1, output_column:-1, use_vectorized:true, " + 
-		"has_nullable_child:false, is_nullable:true, is_monotonic:true)])], " + 
-                "output_sink:TDataSink(type:RESULT_SINK, " +
-		"result_sink:TResultSink(type:MYSQL_PROTOCAL)), partition:TDataPartition(type:RANDOM, partition_exprs:[]))";
+	String expectString = "TScalarType(type:DECIMAL32, precision:9, scale:9))";
 	String thrift = UtFrameUtils.getPlanThriftStringForNewPlanner(ctx, sql);
 	Assert.assertTrue(thrift.contains(expectString));
     }

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -330,6 +330,7 @@ struct TOlapScanNode {
   20: optional string rollup_name
   21: optional string sql_predicates
   22: optional bool enable_column_expr_predicate
+  23: optional map<i32, i32> dict_string_id_to_int_ids
 }
 struct TEqJoinCondition {
   // left-hand side of "<a> = <b>"


### PR DESCRIPTION
For https://github.com/StarRocks/starrocks/issues/559

1. Remove unused `isStrictPredicate` method
2. Decode rewrite support filter for Olap scan node
3. For agg having, needn't handle it
4. For join predicate, disable global dict optimization 
