### PR TITLE
[Minor Fix] Fix BE crash in eq_for_null debug/asan mode, fix some war…

### DIFF
--- a/be/src/exec/olap_utils.h
+++ b/be/src/exec/olap_utils.h
@@ -25,6 +25,7 @@
 #include <cmath>
 
 #include "common/logging.h"
+#include "gen_cpp/Exprs_types.h"
 #include "gen_cpp/Opcodes_types.h"
 #include "runtime/datetime_value.h"
 #include "runtime/primitive_type.h"
@@ -206,6 +207,9 @@ inline SQLFilterOp to_olap_filter_type(TExprOpcode::type type, bool opposite) {
 
     case TExprOpcode::NE:
         return opposite ? FILTER_IN : FILTER_NOT_IN;
+
+    case TExprOpcode::EQ_FOR_NULL:
+        return FILTER_IN;
 
     default:
         VLOG(1) << "TExprOpcode: " << type;

--- a/be/src/exprs/agg/avg.h
+++ b/be/src/exprs/agg/avg.h
@@ -85,7 +85,7 @@ public:
         // For type of int/tinyint/bitint..., the result of avg is float/double
         // But the floating point operations are much slower than integer operations
         // So, we use integers to perform operations
-        SumResultType local_sum_for_arithmetic{};
+        [[maybe_unused]] SumResultType local_sum_for_arithmetic{};
 
         for (size_t i = 0; i < batch_size; ++i) {
             if constexpr (pt_is_datetime<PT>) {


### PR DESCRIPTION
…ning

will close #907 

case 1:
```sql
select * from t1 where k1 <=> 1;
```
It's equals to EQ

case 2:
```sql
select * from t1 where k1 <=> null;
```
type  of k1 will not equals to LITERAL_NULL,  so storage engine will not use this conjunct 