### PR TITLE
BugFix: The journal of creating colocating table replayed in follower throws null pointer exception

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -4078,6 +4078,8 @@ public class Catalog {
                 unlock();
             }
 
+            // NOTE: The table has been added to the database, and the following procedure cannot throw exception.
+
             // we have added these index to memory, only need to persist here
             if (getColocateTableIndex().isColocateTable(tableId)) {
                 GroupId groupId = getColocateTableIndex().getGroup(tableId);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -4097,11 +4097,10 @@ public class Catalog {
                 for (Long tabletId : tabletIdSet) {
                     Catalog.getCurrentInvertedIndex().deleteTablet(tabletId);
                 }
-
-                // only remove from memory, because we have not persist it
-                if (getColocateTableIndex().isColocateTable(tableId) && !addToColocateGroupSuccess) {
-                    getColocateTableIndex().removeTable(tableId);
-                }
+            }
+            // only remove from memory, because we have not persist it
+            if (getColocateTableIndex().isColocateTable(tableId) && !addToColocateGroupSuccess) {
+                getColocateTableIndex().removeTable(tableId);
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
@@ -278,7 +278,7 @@ public class Database extends MetaObject implements Writable {
         checkReplicaQuota();
     }
 
-    // return false if table already exits
+    // return false if table already exists
     public boolean createTableWithLock(Table table, boolean isReplay) {
         writeLock();
         try {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
@@ -278,13 +278,13 @@ public class Database extends MetaObject implements Writable {
         checkReplicaQuota();
     }
 
-    public boolean createTableWithLock(Table table, boolean isReplay, boolean setIfNotExist) {
-        boolean result = true;
+    // return false if table already exits
+    public boolean createTableWithLock(Table table, boolean isReplay) {
         writeLock();
         try {
             String tableName = table.getName();
             if (nameToTable.containsKey(tableName)) {
-                result = setIfNotExist;
+                return false;
             } else {
                 idToTable.put(table.getId(), table);
                 nameToTable.put(table.getName(), table);
@@ -297,7 +297,7 @@ public class Database extends MetaObject implements Writable {
 
                 table.onCreate();
             }
-            return result;
+            return true;
         } finally {
             writeUnlock();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/InfoSchemaDb.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/InfoSchemaDb.java
@@ -43,7 +43,7 @@ public class InfoSchemaDb extends Database {
     }
 
     @Override
-    public boolean createTableWithLock(Table table, boolean isReplay, boolean setIfNotExist) {
+    public boolean createTableWithLock(Table table, boolean isReplay) {
         return false;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/InfoSchemaDbTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/InfoSchemaDbTest.java
@@ -32,7 +32,7 @@ public class InfoSchemaDbTest {
         Database db = new InfoSchemaDb();
 
         Assert.assertFalse(db.createTable(null));
-        Assert.assertFalse(db.createTableWithLock(null, false, false));
+        Assert.assertFalse(db.createTableWithLock(null, false));
         db.dropTable("authors");
         db.dropTableWithLock("authors");
         db.write(null);


### PR DESCRIPTION
When creating a colocate table with `if not exist` hint, the OP_COLOCATE_ADD_TABLE flag will not stored in journal if the table is already exist. The follower replay this journal will throw the null pointer exception.