### PR TITLE
Fix bug create group by view failed.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/SlotRef.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/SlotRef.java
@@ -182,7 +182,6 @@ public class SlotRef extends Expr {
         } else if (label != null) {
             return label + sb.toString();
         } else if (desc.getSourceExprs() != null) {
-            sb.append("<slot ").append(desc.getId().asInt()).append(">");
             for (Expr expr : desc.getSourceExprs()) {
                 sb.append(" ");
                 sb.append(expr.toSql());


### PR DESCRIPTION
Fix #918 

create view use inlineview.
if inlineview sql contains <slots x> for selectstmt , it will failed in init view.

remove <solt x> will only impact test case.