### PR TITLE
Refactor: refine the impl of ColumnReader

### DIFF
--- a/be/src/storage/rowset/segment_v2/column_reader.cpp
+++ b/be/src/storage/rowset/segment_v2/column_reader.cpp
@@ -21,7 +21,7 @@
 
 #include "storage/rowset/segment_v2/column_reader.h"
 
-#include <column/datum_convert.h>
+#include <fmt/format.h>
 
 #include <memory>
 #include <utility>
@@ -30,11 +30,11 @@
 #include "column/column.h"
 #include "column/column_helper.h"
 #include "column/datum.h"
+#include "column/datum_convert.h"
 #include "column/nullable_column.h"
 #include "common/logging.h"
 #include "gutil/casts.h"
-#include "gutil/strings/substitute.h" // for Substitute
-#include "storage/column_block.h"     // for ColumnBlockView
+#include "storage/column_block.h" // for ColumnBlockView
 #include "storage/olap_cond.h"
 #include "storage/rowset/segment_v2/binary_dict_page.h" // for BinaryDictPageDecoder
 #include "storage/rowset/segment_v2/bitmap_index_reader.h"
@@ -51,51 +51,22 @@
 
 namespace starrocks::segment_v2 {
 
-using strings::Substitute;
-
-Status ColumnReader::create(MemTracker* mem_tracker, const ColumnReaderOptions& opts, ColumnMetaPB* meta,
-                            const std::string& file_name, std::unique_ptr<ColumnReader>* reader) {
-    auto type = static_cast<FieldType>(meta->type());
-    if (is_scalar_field_type(delegate_type(type))) {
-        auto r = std::make_unique<ColumnReader>(private_type(0), mem_tracker, opts, file_name);
-        RETURN_IF_ERROR(r->init(meta));
-        *reader = std::move(r);
-        return Status::OK();
-    } else if (type == FieldType::OLAP_FIELD_TYPE_ARRAY) {
-        auto array_reader = std::make_unique<ColumnReader>(private_type(0), mem_tracker, opts, file_name);
-        array_reader->_sub_readers = std::make_unique<SubReaderList>();
-
-        size_t col = 0;
-        std::unique_ptr<ColumnReader> element_reader;
-        RETURN_IF_ERROR(ColumnReader::create(mem_tracker, opts, meta->mutable_children_columns(col), file_name,
-                                             &element_reader));
-        col++;
-        array_reader->_sub_readers->emplace_back(std::move(element_reader));
-
-        if (meta->is_nullable()) {
-            std::unique_ptr<ColumnReader> null_reader;
-            RETURN_IF_ERROR(ColumnReader::create(mem_tracker, opts, meta->mutable_children_columns(col), file_name,
-                                                 &null_reader));
-            col++;
-            array_reader->_sub_readers->emplace_back(std::move(null_reader));
-        }
-
-        std::unique_ptr<ColumnReader> array_size_reader;
-        RETURN_IF_ERROR(ColumnReader::create(mem_tracker, opts, meta->mutable_children_columns(col), file_name,
-                                             &array_size_reader));
-        array_reader->_sub_readers->emplace_back(std::move(array_size_reader));
-
-        RETURN_IF_ERROR(array_reader->init(meta));
-        *reader = std::move(array_reader);
-        return Status::OK();
-    } else {
-        return Status::NotSupported("unsupported type for ColumnReader: " + std::to_string(type));
-    }
+StatusOr<std::unique_ptr<ColumnReader>> ColumnReader::create(MemTracker* mem_tracker, const ColumnReaderOptions& opts,
+                                                             ColumnMetaPB* meta, const std::string& file_name) {
+    auto r = std::make_unique<ColumnReader>(private_type(0), mem_tracker, opts, file_name);
+    RETURN_IF_ERROR(r->_init(meta));
+    return std::move(r);
 }
 
 ColumnReader::ColumnReader(const private_type&, MemTracker* mem_tracker, const ColumnReaderOptions& opts,
                            const std::string& file_name)
-        : _mem_tracker(mem_tracker), _opts(opts), _file_name(file_name) {
+        : _mem_tracker(mem_tracker),
+          _opts(opts),
+          _file_name(file_name),
+          _zone_map_index(),
+          _ordinal_index(),
+          _bitmap_index(),
+          _bloom_filter_index() {
     _mem_tracker->consume(sizeof(ColumnReader));
 }
 
@@ -113,7 +84,7 @@ ColumnReader::~ColumnReader() {
     delete (_flags[kHasBloomFilterIndexReaderPos] ? _bloom_filter_index.reader : nullptr);
 }
 
-Status ColumnReader::init(ColumnMetaPB* meta) {
+Status ColumnReader::_init(ColumnMetaPB* meta) {
     _column_length = meta->length();
     _column_type = static_cast<FieldType>(meta->type());
     _dict_page_pointer = PagePointer(meta->dict_page());
@@ -122,42 +93,91 @@ Status ColumnReader::init(ColumnMetaPB* meta) {
     _flags.set(kAllDictEncodedPos, meta->all_dict_encoded());
     _flags.set(kIsNullablePos, meta->is_nullable());
 
-    if (_column_type == OLAP_FIELD_TYPE_ARRAY) {
-        return Status::OK();
-    }
+    if (is_scalar_field_type(delegate_type(_column_type))) {
+        RETURN_IF_ERROR(EncodingInfo::get(delegate_type(_column_type), meta->encoding(), &_encoding_info));
+        RETURN_IF_ERROR(get_block_compression_codec(meta->compression(), &_compress_codec));
 
-    RETURN_IF_ERROR(EncodingInfo::get(delegate_type(_column_type), meta->encoding(), &_encoding_info));
-    RETURN_IF_ERROR(get_block_compression_codec(meta->compression(), &_compress_codec));
-
-    for (int i = 0; i < meta->indexes_size(); i++) {
-        auto* index_meta = meta->mutable_indexes(i);
-        switch (index_meta->type()) {
-        case ORDINAL_INDEX:
-            _ordinal_index.meta = index_meta->release_ordinal_index();
-            _flags.set(kHasOrdinalIndexMetaPos, true);
-            break;
-        case ZONE_MAP_INDEX:
-            _zone_map_index.meta = index_meta->release_zone_map_index();
-            _segment_zone_map.reset(_zone_map_index.meta->release_segment_zone_map());
-            _flags.set(kHasZoneMapIndexMetaPos, true);
-            break;
-        case BITMAP_INDEX:
-            _bitmap_index.meta = index_meta->release_bitmap_index();
-            _flags.set(kHasBitmapIndexMetaPos, true);
-            break;
-        case BLOOM_FILTER_INDEX:
-            _bloom_filter_index.meta = index_meta->release_bloom_filter_index();
-            _flags.set(kHasBloomFilterIndexMetaPos, true);
-            break;
-        case UNKNOWN_INDEX_TYPE:
-            return Status::Corruption(strings::Substitute("Bad file $0: unknown index type", _file_name));
+        for (int i = 0; i < meta->indexes_size(); i++) {
+            auto* index_meta = meta->mutable_indexes(i);
+            switch (index_meta->type()) {
+            case ORDINAL_INDEX:
+                _ordinal_index.meta = index_meta->release_ordinal_index();
+                _flags.set(kHasOrdinalIndexMetaPos, true);
+                break;
+            case ZONE_MAP_INDEX:
+                _zone_map_index.meta = index_meta->release_zone_map_index();
+                _segment_zone_map.reset(_zone_map_index.meta->release_segment_zone_map());
+                _flags.set(kHasZoneMapIndexMetaPos, true);
+                break;
+            case BITMAP_INDEX:
+                _bitmap_index.meta = index_meta->release_bitmap_index();
+                _flags.set(kHasBitmapIndexMetaPos, true);
+                break;
+            case BLOOM_FILTER_INDEX:
+                _bloom_filter_index.meta = index_meta->release_bloom_filter_index();
+                _flags.set(kHasBloomFilterIndexMetaPos, true);
+                break;
+            case UNKNOWN_INDEX_TYPE:
+                return Status::Corruption(fmt::format("Bad file {}: unknown index type", _file_name));
+            }
         }
+        if (!_flags[kHasOrdinalIndexMetaPos]) {
+            return Status::Corruption(
+                    fmt::format("Bad file {}: missing ordinal index for column {}", _file_name, meta->column_id()));
+        }
+        return Status::OK();
+    } else if (_column_type == FieldType::OLAP_FIELD_TYPE_ARRAY) {
+        _sub_readers = std::make_unique<SubReaderList>();
+        if (meta->is_nullable()) {
+            if (meta->children_columns_size() != 3) {
+                return Status::InvalidArgument("nullable array should have 3 children columns");
+            }
+            _sub_readers->reserve(3);
+
+            // elements
+            auto res = ColumnReader::create(_mem_tracker, _opts, meta->mutable_children_columns(0), _file_name);
+            if (!res.ok()) {
+                return res.status();
+            }
+            _sub_readers->emplace_back(std::move(res).value());
+
+            // null flags
+            res = ColumnReader::create(_mem_tracker, _opts, meta->mutable_children_columns(1), _file_name);
+            if (!res.ok()) {
+                return res.status();
+            }
+            _sub_readers->emplace_back(std::move(res).value());
+
+            // offsets
+            res = ColumnReader::create(_mem_tracker, _opts, meta->mutable_children_columns(2), _file_name);
+            if (!res.ok()) {
+                return res.status();
+            }
+            _sub_readers->emplace_back(std::move(res).value());
+        } else {
+            if (meta->children_columns_size() != 2) {
+                return Status::InvalidArgument("non-nullable array should have 2 children columns");
+            }
+            _sub_readers->reserve(2);
+
+            // elements
+            auto res = ColumnReader::create(_mem_tracker, _opts, meta->mutable_children_columns(0), _file_name);
+            if (!res.ok()) {
+                return res.status();
+            }
+            _sub_readers->emplace_back(std::move(res).value());
+
+            // offsets
+            res = ColumnReader::create(_mem_tracker, _opts, meta->mutable_children_columns(1), _file_name);
+            if (!res.ok()) {
+                return res.status();
+            }
+            _sub_readers->emplace_back(std::move(res).value());
+        }
+        return Status::OK();
+    } else {
+        return Status::NotSupported(fmt::format("unsupported field type {}", (int)_column_type));
     }
-    if (!_flags[kHasOrdinalIndexMetaPos]) {
-        return Status::Corruption(
-                strings::Substitute("Bad file $0: missing ordinal index for column $1", _file_name, meta->column_id()));
-    }
-    return Status::OK();
 }
 
 Status ColumnReader::new_bitmap_index_iterator(BitmapIndexIterator** iterator) {
@@ -276,7 +296,8 @@ Status ColumnReader::_calculate_row_ranges(const std::vector<uint32_t>& page_ind
     for (auto i : page_indexes) {
         ordinal_t page_first_id = _ordinal_index.reader->get_first_ordinal(i);
         ordinal_t page_last_id = _ordinal_index.reader->get_last_ordinal(i);
-        RowRanges page_row_ranges(RowRanges::create_single(page_first_id, page_last_id + 1));
+        RowRanges page_row_ranges(
+                RowRanges::create_single(static_cast<int64_t>(page_first_id), static_cast<int64_t>(page_last_id + 1)));
         RowRanges::ranges_union(*row_ranges, page_row_ranges, row_ranges);
     }
     return Status::OK();
@@ -306,7 +327,7 @@ Status ColumnReader::get_row_ranges_by_bloom_filter(CondColumn* cond_column, Row
         auto iter = _ordinal_index.reader->seek_at_or_before(from);
         while (idx < to) {
             page_ids.insert(iter.page_index());
-            idx = iter.last_ordinal() + 1;
+            idx = static_cast<int>(iter.last_ordinal() + 1);
             iter.next();
         }
     }
@@ -314,8 +335,8 @@ Status ColumnReader::get_row_ranges_by_bloom_filter(CondColumn* cond_column, Row
         std::unique_ptr<BloomFilter> bf;
         RETURN_IF_ERROR(bf_iter->read_bloom_filter(pid, &bf));
         if (cond_column->eval(bf.get())) {
-            bf_row_ranges.add(RowRange(_ordinal_index.reader->get_first_ordinal(pid),
-                                       _ordinal_index.reader->get_last_ordinal(pid) + 1));
+            bf_row_ranges.add(RowRange(static_cast<int64_t>(_ordinal_index.reader->get_first_ordinal(pid)),
+                                       static_cast<int64_t>(_ordinal_index.reader->get_last_ordinal(pid) + 1)));
         }
     }
     RowRanges::ranges_intersection(*row_ranges, bf_row_ranges, row_ranges);
@@ -337,7 +358,7 @@ Status ColumnReader::bloom_filter(const std::vector<const vectorized::ColumnPred
         auto iter = _ordinal_index.reader->seek_at_or_before(r.begin());
         while (idx < r.end()) {
             page_ids.insert(iter.page_index());
-            idx = iter.last_ordinal() + 1;
+            idx = static_cast<int>(iter.last_ordinal() + 1);
             iter.next();
         }
     }
@@ -365,7 +386,7 @@ Status ColumnReader::_load_ordinal_index(bool use_page_cache, bool kept_in_memor
         delete index_meta;
         _flags.set(kHasOrdinalIndexMetaPos, false);
         _flags.set(kHasOrdinalIndexReaderPos, true);
-        _mem_tracker->consume(_ordinal_index.reader->mem_usage());
+        _mem_tracker->consume(static_cast<int64_t>(_ordinal_index.reader->mem_usage()));
     }
     return st;
 }
@@ -379,7 +400,7 @@ Status ColumnReader::_load_zone_map_index(bool use_page_cache, bool kept_in_memo
         delete index_meta;
         _flags.set(kHasZoneMapIndexMetaPos, false);
         _flags.set(kHasZoneMapIndexReaderPos, true);
-        _mem_tracker->consume(_zone_map_index.reader->mem_usage());
+        _mem_tracker->consume(static_cast<int64_t>(_zone_map_index.reader->mem_usage()));
     }
     return st;
 }
@@ -393,7 +414,7 @@ Status ColumnReader::_load_bitmap_index(bool use_page_cache, bool kept_in_memory
         delete index_meta;
         _flags.set(kHasBitmapIndexMetaPos, false);
         _flags.set(kHasBitmapIndexReaderPos, true);
-        _mem_tracker->consume(_bitmap_index.reader->mem_usage());
+        _mem_tracker->consume(static_cast<int64_t>(_bitmap_index.reader->mem_usage()));
     }
     return st;
 }
@@ -407,7 +428,7 @@ Status ColumnReader::_load_bloom_filter_index(bool use_page_cache, bool kept_in_
         delete index_meta;
         _flags.set(kHasBloomFilterIndexMetaPos, false);
         _flags.set(kHasBloomFilterIndexReaderPos, true);
-        _mem_tracker->consume(_bloom_filter_index.reader->mem_usage());
+        _mem_tracker->consume(static_cast<int64_t>(_bloom_filter_index.reader->mem_usage()));
     }
     return st;
 }
@@ -423,7 +444,7 @@ Status ColumnReader::seek_to_first(OrdinalPageIndexIterator* iter) {
 Status ColumnReader::seek_at_or_before(ordinal_t ordinal, OrdinalPageIndexIterator* iter) {
     *iter = _ordinal_index.reader->seek_at_or_before(ordinal);
     if (!iter->valid()) {
-        return Status::NotFound(strings::Substitute("Failed to seek to ordinal $0, ", ordinal));
+        return Status::NotFound(fmt::format("Failed to seek to ordinal {}", ordinal));
     }
     return Status::OK();
 }
@@ -759,7 +780,7 @@ Status FileColumnIterator::seek_to_ordinal_and_calc_element_ordinal(ordinal_t or
         RETURN_IF_ERROR(_read_data_page(_page_iter));
     }
     _array_size.resize(0);
-    _element_ordinal = _page->corresponding_element_ordinal();
+    _element_ordinal = static_cast<int64_t>(_page->corresponding_element_ordinal());
     _current_ordinal = _page->first_ordinal();
     _seek_to_pos_in_page(_page.get(), 0);
     size_t size_to_read = ord - _current_ordinal;
@@ -804,7 +825,7 @@ Status FileColumnIterator::next_batch(size_t* n, ColumnBlockView* dst, bool* has
     *n -= remaining;
     // TODO(hkp): for string type, the bytes_read should be passed to page decoder
     // bytes_read = data size + null bitmap size
-    _opts.stats->bytes_read += *n * dst->type_info()->size() + BitmapSize(*n);
+    _opts.stats->bytes_read += static_cast<int64_t>(*n * dst->type_info()->size() + BitmapSize(*n));
     return Status::OK();
 }
 
@@ -830,7 +851,7 @@ Status FileColumnIterator::next_batch(size_t* n, vectorized::Column* dst) {
     }
     dst->set_delete_state(contain_deleted_row ? DEL_PARTIAL_SATISFIED : DEL_NOT_SATISFIED);
     *n -= remaining;
-    _opts.stats->bytes_read += (dst->byte_size() - prev_bytes);
+    _opts.stats->bytes_read += static_cast<int64_t>(dst->byte_size() - prev_bytes);
     return Status::OK();
 }
 
@@ -1000,7 +1021,7 @@ Status FileColumnIterator::_do_next_dict_codes(size_t* n, vectorized::Column* ds
         RETURN_IF_ERROR(_page->read_dict_codes(dst, &nread));
         _current_ordinal += nread;
         remaining -= nread;
-        _opts.stats->bytes_read += nread * sizeof(int32_t);
+        _opts.stats->bytes_read += static_cast<int64_t>(nread * sizeof(int32_t));
     }
     dst->set_delete_state(contain_delted_row ? DEL_PARTIAL_SATISFIED : DEL_NOT_SATISFIED);
     *n -= remaining;
@@ -1027,7 +1048,7 @@ Status FileColumnIterator::_do_decode_dict_codes(const int32_t* codes, size_t si
     }
     [[maybe_unused]] bool ok = words->append_strings(slices);
     DCHECK(ok);
-    _opts.stats->bytes_read += words->byte_size() + BitmapSize(slices.size());
+    _opts.stats->bytes_read += static_cast<int64_t>(words->byte_size() + BitmapSize(slices.size()));
     return Status::OK();
 }
 
@@ -1061,7 +1082,7 @@ Status FileColumnIterator::_fetch_by_rowid(const rowid_t* rowids, size_t size, v
         DCHECK_EQ(_current_ordinal, _page->first_ordinal() + _page->offset());
     } while (rowids != end);
     values->set_delete_state(contain_deleted_row ? DEL_PARTIAL_SATISFIED : DEL_NOT_SATISFIED);
-    _opts.stats->bytes_read += values->byte_size() - prev_bytes;
+    _opts.stats->bytes_read += static_cast<int64_t>(values->byte_size() - prev_bytes);
     DCHECK_EQ(_current_ordinal, _page->first_ordinal() + _page->offset());
     return Status::OK();
 }
@@ -1079,10 +1100,10 @@ Status FileColumnIterator::fetch_dict_codes_by_rowid(const rowid_t* rowids, size
 int FileColumnIterator::dict_size() {
     if (_reader->column_type() == OLAP_FIELD_TYPE_CHAR) {
         auto dict = down_cast<BinaryPlainPageDecoder<OLAP_FIELD_TYPE_CHAR>*>(_dict_decoder.get());
-        return dict->dict_size();
+        return static_cast<int>(dict->dict_size());
     } else if (_reader->column_type() == OLAP_FIELD_TYPE_VARCHAR) {
         auto dict = down_cast<BinaryPlainPageDecoder<OLAP_FIELD_TYPE_VARCHAR>*>(_dict_decoder.get());
-        return dict->dict_size();
+        return static_cast<int>(dict->dict_size());
     }
     __builtin_unreachable();
     return 0;
@@ -1099,13 +1120,13 @@ Status DefaultValueColumnIterator::init(const ColumnIteratorOptions& opts) {
             _is_default_value_null = true;
         } else {
             _type_size = _type_info->size();
-            _mem_value = reinterpret_cast<void*>(_pool->allocate(_type_size));
+            _mem_value = reinterpret_cast<void*>(_pool->allocate(static_cast<int64_t>(_type_size)));
             if (UNLIKELY(_mem_value == nullptr)) {
                 return Status::InternalError("Mem usage has exceed the limit of BE");
             }
             OLAPStatus s = OLAP_SUCCESS;
             if (_type_info->type() == OLAP_FIELD_TYPE_CHAR) {
-                int32_t length = _schema_length;
+                auto length = static_cast<int32_t>(_schema_length);
                 char* string_buffer = reinterpret_cast<char*>(_pool->allocate(length));
                 if (UNLIKELY(string_buffer == nullptr)) {
                     return Status::InternalError("Mem usage has exceed the limit of BE");
@@ -1117,7 +1138,7 @@ Status DefaultValueColumnIterator::init(const ColumnIteratorOptions& opts) {
             } else if (_type_info->type() == OLAP_FIELD_TYPE_VARCHAR || _type_info->type() == OLAP_FIELD_TYPE_HLL ||
                        _type_info->type() == OLAP_FIELD_TYPE_OBJECT ||
                        _type_info->type() == OLAP_FIELD_TYPE_PERCENTILE) {
-                int32_t length = _default_value.length();
+                auto length = static_cast<int32_t>(_default_value.length());
                 char* string_buffer = reinterpret_cast<char*>(_pool->allocate(length));
                 if (UNLIKELY(string_buffer == nullptr)) {
                     return Status::InternalError("Mem usage has exceed the limit of BE");
@@ -1132,8 +1153,7 @@ Status DefaultValueColumnIterator::init(const ColumnIteratorOptions& opts) {
                 s = _type_info->from_string(_mem_value, _default_value);
             }
             if (s != OLAP_SUCCESS) {
-                return Status::InternalError(
-                        strings::Substitute("get value of type from default value failed. status:$0", s));
+                return Status::InternalError(fmt::format("get value of type from default value failed. status:{}", s));
             }
         }
     } else if (_is_nullable) {
@@ -1177,7 +1197,7 @@ Status DefaultValueColumnIterator::next_batch(size_t* n, vectorized::Column* dst
             for (size_t i = 0; i < *n; i++) {
                 slices.emplace_back(*reinterpret_cast<const Slice*>(_mem_value));
             }
-            dst->append_strings(slices);
+            (void)dst->append_strings(slices);
         } else {
             dst->append_value_multiple_times(_mem_value, *n);
         }

--- a/be/src/storage/rowset/segment_v2/column_reader.h
+++ b/be/src/storage/rowset/segment_v2/column_reader.h
@@ -30,7 +30,7 @@
 #include "column/datum.h"
 #include "column/fixed_length_column.h"
 #include "column/vectorized_fwd.h"
-#include "common/status.h"         // for Status
+#include "common/statusor.h"       // for Status
 #include "gen_cpp/segment_v2.pb.h" // for ColumnMetaPB
 #include "runtime/mem_pool.h"
 #include "runtime/mem_tracker.h"
@@ -123,8 +123,8 @@ public:
     // Note that |meta| is mutable, this method may change its internal state.
     //
     // To developers: keep this method lightweight, should not incur any I/O.
-    static Status create(MemTracker* mem_tracker, const ColumnReaderOptions& opts, ColumnMetaPB* meta,
-                         const std::string& file_name, std::unique_ptr<ColumnReader>* reader);
+    static StatusOr<std::unique_ptr<ColumnReader>> create(MemTracker* mem_tracker, const ColumnReaderOptions& opts,
+                                                          ColumnMetaPB* meta, const std::string& file_name);
 
     ColumnReader(const private_type&, MemTracker* mem_tracker, const ColumnReaderOptions& opts,
                  const std::string& file_name);
@@ -233,7 +233,7 @@ private:
     ColumnReader(ColumnReader&&) = delete;
     void operator=(ColumnReader&&) = delete;
 
-    Status init(ColumnMetaPB* meta);
+    Status _init(ColumnMetaPB* meta);
 
     Status _load_zone_map_index(bool use_page_cache, bool kept_in_memory);
     Status _load_ordinal_index(bool use_page_cache, bool kept_in_memory);
@@ -269,7 +269,7 @@ private:
     FieldType _column_type = OLAP_FIELD_TYPE_UNKNOWN;
     PagePointer _dict_page_pointer;
     ColumnReaderOptions _opts;
-    uint64_t _num_rows;
+    uint64_t _num_rows = 0;
     const std::string& _file_name;
 
     // initialized in init(), used for create PageDecoder
@@ -543,8 +543,8 @@ private:
 
 class ArrayFileColumnIterator final : public ColumnIterator {
 public:
-    explicit ArrayFileColumnIterator(ColumnIterator* null_iterator, ColumnIterator* array_size_iterator,
-                                     ColumnIterator* item_iterator);
+    ArrayFileColumnIterator(ColumnIterator* null_iterator, ColumnIterator* array_size_iterator,
+                            ColumnIterator* element_iterator);
 
     ~ArrayFileColumnIterator() override = default;
 

--- a/be/src/storage/rowset/segment_v2/segment.cpp
+++ b/be/src/storage/rowset/segment_v2/segment.cpp
@@ -285,10 +285,11 @@ Status Segment::_create_column_readers(SegmentFooterPB* footer) {
         opts.block_mgr = _block_mgr;
         opts.storage_format_version = footer->version();
         opts.kept_in_memory = _tablet_schema->is_in_memory();
-        std::unique_ptr<ColumnReader> reader;
-        RETURN_IF_ERROR(
-                ColumnReader::create(_mem_tracker, opts, footer->mutable_columns(iter->second), _fname, &reader));
-        _column_readers[ordinal] = std::move(reader);
+        auto res = ColumnReader::create(_mem_tracker, opts, footer->mutable_columns(iter->second), _fname);
+        if (!res.ok()) {
+            return res.status();
+        }
+        _column_readers[ordinal] = std::move(res).value();
     }
     return Status::OK();
 }

--- a/be/test/storage/rowset/segment_v2/column_reader_writer_test.cpp
+++ b/be/test/storage/rowset/segment_v2/column_reader_writer_test.cpp
@@ -131,12 +131,12 @@ protected:
             ColumnReaderOptions reader_opts;
             reader_opts.storage_format_version = version;
             reader_opts.block_mgr = block_mgr.get();
-            std::unique_ptr<ColumnReader> reader;
-            auto st = ColumnReader::create(&_tracker, reader_opts, &meta, fname, &reader);
-            ASSERT_TRUE(st.ok());
+            auto res = ColumnReader::create(&_tracker, reader_opts, &meta, fname);
+            ASSERT_TRUE(res.ok());
+            auto reader = std::move(res).value();
 
             ColumnIterator* iter = nullptr;
-            st = reader->new_iterator(&iter);
+            auto st = reader->new_iterator(&iter);
             ASSERT_TRUE(st.ok());
             std::unique_ptr<ColumnIterator> guard(iter);
             std::unique_ptr<fs::ReadableBlock> rblock;
@@ -346,9 +346,9 @@ protected:
             ColumnReaderOptions reader_opts;
             reader_opts.block_mgr = block_mgr.get();
             reader_opts.storage_format_version = 2;
-            std::unique_ptr<ColumnReader> reader;
-            auto st = ColumnReader::create(&_tracker, reader_opts, &meta, fname, &reader);
-            ASSERT_TRUE(st.ok());
+            auto res = ColumnReader::create(&_tracker, reader_opts, &meta, fname);
+            ASSERT_TRUE(res.ok());
+            auto reader = std::move(res).value();
 
             ColumnIterator* iter = nullptr;
             ASSERT_TRUE(reader->new_iterator(&iter).ok());
@@ -364,7 +364,7 @@ protected:
 
             // sequence read
             {
-                st = iter->seek_to_first();
+                auto st = iter->seek_to_first();
                 ASSERT_TRUE(st.ok()) << st.to_string();
 
                 auto dst_offsets = vectorized::UInt32Column::create();


### PR DESCRIPTION
Close issue #925

1. Using `StatusOr<std::unique_ptr<ColumnReader>>` as the return type of `ColumnReader::create`
2. Remove clang-tidy warnings
3. Initialize array column in `ColumnReader::init` instead of `ColumnReader::create`