### PR TITLE
Remove checks for schema hash from TabletManager

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -313,8 +313,7 @@ void* TaskWorkerPool::_create_tablet_worker_thread_callback(void* arg_this) {
         } else {
             ++_s_report_version;
             // get path hash of the created tablet
-            TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(
-                    create_tablet_req.tablet_id, create_tablet_req.tablet_schema.schema_hash);
+            auto tablet = StorageEngine::instance()->tablet_manager()->get_tablet(create_tablet_req.tablet_id);
             DCHECK(tablet != nullptr);
             TTabletInfo tablet_info;
             tablet_info.tablet_id = tablet->tablet_id();
@@ -368,11 +367,10 @@ void* TaskWorkerPool::_drop_tablet_worker_thread_callback(void* arg_this) {
         TStatusCode::type status_code = TStatusCode::OK;
         std::vector<std::string> error_msgs;
         TStatus task_status;
-        TabletSharedPtr dropped_tablet = StorageEngine::instance()->tablet_manager()->get_tablet(
-                drop_tablet_req.tablet_id, drop_tablet_req.schema_hash);
+        TabletSharedPtr dropped_tablet =
+                StorageEngine::instance()->tablet_manager()->get_tablet(drop_tablet_req.tablet_id);
         if (dropped_tablet != nullptr) {
-            Status drop_status = StorageEngine::instance()->tablet_manager()->drop_tablet(drop_tablet_req.tablet_id,
-                                                                                          drop_tablet_req.schema_hash);
+            Status drop_status = StorageEngine::instance()->tablet_manager()->drop_tablet(drop_tablet_req.tablet_id);
             if (!drop_status.ok()) {
                 LOG(WARNING) << "drop table failed! signature: " << agent_task_req.signature;
                 error_msgs.emplace_back("drop table failed!");
@@ -788,8 +786,8 @@ void* TaskWorkerPool::_update_tablet_meta_worker_thread_callback(void* arg_this)
         TStatus task_status;
 
         for (const auto& tablet_meta_info : update_tablet_meta_req.tabletMetaInfos) {
-            TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(
-                    tablet_meta_info.tablet_id, tablet_meta_info.schema_hash);
+            TabletSharedPtr tablet =
+                    StorageEngine::instance()->tablet_manager()->get_tablet(tablet_meta_info.tablet_id);
             if (tablet == nullptr) {
                 LOG(WARNING) << "could not find tablet when update partition id"
                              << " tablet_id=" << tablet_meta_info.tablet_id
@@ -961,7 +959,7 @@ void* TaskWorkerPool::_storage_medium_migrate_worker_thread_callback(void* arg_t
             TSchemaHash schema_hash = storage_medium_migrate_req.schema_hash;
             TStorageMedium::type storage_medium = storage_medium_migrate_req.storage_medium;
 
-            TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, schema_hash);
+            TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id);
             if (tablet == nullptr) {
                 LOG(WARNING) << "can't find tablet. tablet_id=" << tablet_id << ", schema_hash=" << schema_hash;
                 status_code = TStatusCode::RUNTIME_ERROR;
@@ -1544,7 +1542,7 @@ void* TaskWorkerPool::_move_dir_thread_callback(void* arg_this) {
 
 AgentStatus TaskWorkerPool::_move_dir(const TTabletId tablet_id, const TSchemaHash schema_hash, const std::string& src,
                                       int64_t job_id, bool overwrite, std::vector<std::string>* error_msgs) {
-    TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, schema_hash);
+    TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id);
     if (tablet == nullptr) {
         LOG(INFO) << "Fail to get tablet_id=" << tablet_id << " schema hash=" << schema_hash;
         error_msgs->push_back("failed to get tablet");

--- a/be/src/exec/pipeline/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/olap_chunk_source.cpp
@@ -118,7 +118,7 @@ Status OlapChunkSource::_get_tablet(const TInternalScanRange* scan_range) {
     _version = strtoul(scan_range->version.c_str(), nullptr, 10);
 
     std::string err;
-    _tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, schema_hash, true, &err);
+    _tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, true, &err);
     if (!_tablet) {
         std::stringstream ss;
         ss << "failed to get tablet. tablet_id=" << tablet_id << ", with schema_hash=" << schema_hash

--- a/be/src/exec/vectorized/olap_meta_scanner.cpp
+++ b/be/src/exec/vectorized/olap_meta_scanner.cpp
@@ -67,7 +67,7 @@ Status OlapMetaScanner::_get_tablet(const TInternalScanRange* scan_range) {
     _version = strtoul(scan_range->version.c_str(), nullptr, 10);
 
     std::string err;
-    _tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, schema_hash, true, &err);
+    _tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, true, &err);
     if (!_tablet) {
         std::stringstream ss;
         ss << "failed to get tablet. tablet_id=" << tablet_id << ", with schema_hash=" << schema_hash

--- a/be/src/exec/vectorized/olap_meta_scanner.cpp
+++ b/be/src/exec/vectorized/olap_meta_scanner.cpp
@@ -8,7 +8,8 @@
 namespace starrocks {
 namespace vectorized {
 
-OlapMetaScanner::OlapMetaScanner(OlapMetaScanNode* parent) : _parent(parent), _is_open(false) {}
+OlapMetaScanner::OlapMetaScanner(OlapMetaScanNode* parent)
+        : _parent(parent), _runtime_state(nullptr), _is_open(false) {}
 
 Status OlapMetaScanner::init(RuntimeState* runtime_state, const OlapMetaScannerParams& params) {
     _runtime_state = runtime_state;

--- a/be/src/exec/vectorized/tablet_scanner.cpp
+++ b/be/src/exec/vectorized/tablet_scanner.cpp
@@ -96,7 +96,7 @@ Status TabletScanner::_get_tablet(const TInternalScanRange* scan_range) {
     _version = strtoul(scan_range->version.c_str(), nullptr, 10);
 
     std::string err;
-    _tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, schema_hash, true, &err);
+    _tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, true, &err);
     if (!_tablet) {
         std::stringstream ss;
         ss << "failed to get tablet. tablet_id=" << tablet_id << ", with schema_hash=" << schema_hash

--- a/be/src/http/action/compaction_action.cpp
+++ b/be/src/http/action/compaction_action.cpp
@@ -49,17 +49,15 @@ Status CompactionAction::_handle_show_compaction(HttpRequest* req, std::string* 
         return Status::NotSupported("The overall compaction status is not supported yet");
     }
 
-    uint64_t tablet_id = 0;
-    uint32_t schema_hash = 0;
+    uint64_t tablet_id;
     try {
         tablet_id = std::stoull(req_tablet_id);
-        schema_hash = std::stoul(req_schema_hash);
     } catch (const std::exception& e) {
         LOG(WARNING) << "invalid argument.tablet_id:" << req_tablet_id << ", schema_hash:" << req_schema_hash;
         return Status::InternalError(strings::Substitute("convert failed, $0", e.what()));
     }
 
-    TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, schema_hash);
+    TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id);
     if (tablet == nullptr) {
         return Status::NotFound("Tablet not found");
     }

--- a/be/src/http/action/meta_action.cpp
+++ b/be/src/http/action/meta_action.cpp
@@ -54,7 +54,7 @@ Status MetaAction::_handle_header(HttpRequest* req, std::string* json_meta) {
         return Status::InternalError(strings::Substitute("convert failed, $0", e.what()));
     }
 
-    TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, schema_hash);
+    TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id);
     if (tablet == nullptr) {
         LOG(WARNING) << "no tablet for tablet_id:" << tablet_id << " schema hash:" << schema_hash;
         return Status::InternalError("no tablet exist");

--- a/be/src/http/action/restore_tablet_action.cpp
+++ b/be/src/http/action/restore_tablet_action.cpp
@@ -84,7 +84,7 @@ Status RestoreTabletAction::_handle(HttpRequest* req) {
     int32_t schema_hash = std::atoi(schema_hash_str.c_str());
     LOG(INFO) << "get restore tablet action request: " << tablet_id << "-" << schema_hash;
 
-    TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, schema_hash);
+    TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id);
     if (tablet != nullptr) {
         LOG(WARNING) << "find tablet. tablet_id=" << tablet_id << " schema_hash=" << schema_hash;
         return Status::InternalError("tablet already exists, can not restore.");

--- a/be/src/runtime/snapshot_loader.cpp
+++ b/be/src/runtime/snapshot_loader.cpp
@@ -251,7 +251,7 @@ Status SnapshotLoader::download(const std::map<std::string, std::string>& src_to
             return Status::InternalError(ss.str());
         }
 
-        TabletSharedPtr tablet = _env->storage_engine()->tablet_manager()->get_tablet(local_tablet_id, schema_hash);
+        TabletSharedPtr tablet = _env->storage_engine()->tablet_manager()->get_tablet(local_tablet_id);
         if (tablet == nullptr) {
             std::stringstream ss;
             ss << "failed to get local tablet: " << local_tablet_id;

--- a/be/src/runtime/snapshot_loader.cpp
+++ b/be/src/runtime/snapshot_loader.cpp
@@ -232,7 +232,7 @@ Status SnapshotLoader::download(const std::map<std::string, std::string>& src_to
         RETURN_IF_ERROR(_get_tablet_id_and_schema_hash_from_file_path(local_path, &local_tablet_id, &schema_hash));
         downloaded_tablet_ids->push_back(local_tablet_id);
 
-        int64_t remote_tablet_id;
+        int64_t remote_tablet_id = 0;
         RETURN_IF_ERROR(_get_tablet_id_from_remote_path(remote_path, &remote_tablet_id));
         VLOG(2) << "get local tablet id: " << local_tablet_id << ", schema hash: " << schema_hash
                 << ", remote tablet id: " << remote_tablet_id;

--- a/be/src/storage/push_handler.cpp
+++ b/be/src/storage/push_handler.cpp
@@ -124,8 +124,7 @@ OLAPStatus PushHandler::_do_streaming_ingestion(const TabletSharedPtr& tablet, c
                       << "tablet=" << tablet->full_name() << ", related_tablet_id=" << related_tablet_id
                       << ", related_schema_hash=" << related_schema_hash
                       << ", transaction_id=" << request.transaction_id;
-            TabletSharedPtr related_tablet =
-                    StorageEngine::instance()->tablet_manager()->get_tablet(related_tablet_id, related_schema_hash);
+            TabletSharedPtr related_tablet = StorageEngine::instance()->tablet_manager()->get_tablet(related_tablet_id);
 
             // if related tablet not exists, only push current tablet
             if (related_tablet == nullptr) {

--- a/be/src/storage/schema_change.cpp
+++ b/be/src/storage/schema_change.cpp
@@ -1536,8 +1536,7 @@ Status SchemaChangeHandler::process_alter_tablet_v2(const TAlterTabletReqV2& req
 // Should delete the old code after upgrade finished.
 OLAPStatus SchemaChangeHandler::_do_process_alter_tablet_v2(const TAlterTabletReqV2& request) {
     OLAPStatus res = OLAP_SUCCESS;
-    TabletSharedPtr base_tablet =
-            StorageEngine::instance()->tablet_manager()->get_tablet(request.base_tablet_id, request.base_schema_hash);
+    TabletSharedPtr base_tablet = StorageEngine::instance()->tablet_manager()->get_tablet(request.base_tablet_id);
     if (base_tablet == nullptr) {
         LOG(WARNING) << "fail to find base tablet. base_tablet=" << request.base_tablet_id
                      << ", base_schema_hash=" << request.base_schema_hash;
@@ -1545,8 +1544,7 @@ OLAPStatus SchemaChangeHandler::_do_process_alter_tablet_v2(const TAlterTabletRe
     }
 
     // new tablet has to exist
-    TabletSharedPtr new_tablet =
-            StorageEngine::instance()->tablet_manager()->get_tablet(request.new_tablet_id, request.new_schema_hash);
+    TabletSharedPtr new_tablet = StorageEngine::instance()->tablet_manager()->get_tablet(request.new_tablet_id);
     if (new_tablet == nullptr) {
         LOG(WARNING) << "fail to find new tablet."
                      << " new_tablet=" << request.new_tablet_id << ", new_schema_hash=" << request.new_schema_hash;

--- a/be/src/storage/snapshot_manager.cpp
+++ b/be/src/storage/snapshot_manager.cpp
@@ -83,7 +83,7 @@ Status SnapshotManager::make_snapshot(const TSnapshotRequest& request, string* s
         LOG(WARNING) << "Invalid snapshot format. version=" << request.preferred_snapshot_format;
         return Status::InvalidArgument("invalid snapshot_format");
     }
-    auto tablet = StorageEngine::instance()->tablet_manager()->get_tablet(request.tablet_id, request.schema_hash);
+    auto tablet = StorageEngine::instance()->tablet_manager()->get_tablet(request.tablet_id);
     if (tablet == nullptr) {
         LOG(WARNING) << "Fail to get tablet. tablet=" << request.tablet_id << " schema_hash=" << request.schema_hash;
         return Status::RuntimeError("tablet not found");

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -492,8 +492,8 @@ void StorageEngine::clear_transaction_task(const TTransactionId transaction_id,
         // each tablet
         for (auto& tablet_info : tablet_infos) {
             // should use tablet uid to ensure clean txn correctly
-            TabletSharedPtr tablet = _tablet_manager->get_tablet(
-                    tablet_info.first.tablet_id, tablet_info.first.schema_hash, tablet_info.first.tablet_uid);
+            TabletSharedPtr tablet =
+                    _tablet_manager->get_tablet(tablet_info.first.tablet_id, tablet_info.first.tablet_uid);
             // The tablet may be dropped or altered, leave a INFO log and go on process other tablet
             if (tablet == nullptr) {
                 LOG(INFO) << "tablet is no longer exist, tablet_id=" << tablet_info.first.tablet_id
@@ -701,8 +701,7 @@ void StorageEngine::_clean_unused_rowset_metas() {
             return true;
         }
 
-        TabletSharedPtr tablet =
-                _tablet_manager->get_tablet(rowset_meta->tablet_id(), rowset_meta->tablet_schema_hash(), tablet_uid);
+        TabletSharedPtr tablet = _tablet_manager->get_tablet(rowset_meta->tablet_id(), tablet_uid);
         if (tablet == nullptr) {
             return true;
         }
@@ -726,8 +725,7 @@ void StorageEngine::_clean_unused_txns() {
     std::set<TabletInfo> tablet_infos;
     _txn_manager->get_all_related_tablets(&tablet_infos);
     for (auto& tablet_info : tablet_infos) {
-        TabletSharedPtr tablet = _tablet_manager->get_tablet(tablet_info.tablet_id, tablet_info.schema_hash,
-                                                             tablet_info.tablet_uid, true);
+        TabletSharedPtr tablet = _tablet_manager->get_tablet(tablet_info.tablet_id, tablet_info.tablet_uid, true);
         if (tablet == nullptr) {
             // TODO(ygl) :  should check if tablet still in meta, it's a improvement
             // case 1: tablet still in meta, just remove from memory
@@ -921,7 +919,7 @@ OLAPStatus StorageEngine::execute_task(EngineTask* task) {
         sort(tablet_infos.begin(), tablet_infos.end());
         std::vector<TabletSharedPtr> related_tablets;
         for (TabletInfo& tablet_info : tablet_infos) {
-            TabletSharedPtr tablet = _tablet_manager->get_tablet(tablet_info.tablet_id, tablet_info.schema_hash);
+            TabletSharedPtr tablet = _tablet_manager->get_tablet(tablet_info.tablet_id);
             if (tablet != nullptr) {
                 related_tablets.push_back(tablet);
                 tablet->obtain_header_wrlock();
@@ -955,7 +953,7 @@ OLAPStatus StorageEngine::execute_task(EngineTask* task) {
         sort(tablet_infos.begin(), tablet_infos.end());
         std::vector<TabletSharedPtr> related_tablets;
         for (TabletInfo& tablet_info : tablet_infos) {
-            TabletSharedPtr tablet = _tablet_manager->get_tablet(tablet_info.tablet_id, tablet_info.schema_hash);
+            TabletSharedPtr tablet = _tablet_manager->get_tablet(tablet_info.tablet_id);
             if (tablet != nullptr) {
                 related_tablets.push_back(tablet);
                 tablet->obtain_header_wrlock();

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -708,8 +708,7 @@ bool Tablet::check_migrate(const TabletSharedPtr& tablet) {
         LOG(WARNING) << "tablet is migrating. tablet_id=" << tablet->tablet_id();
         return true;
     } else {
-        if (tablet !=
-            StorageEngine::instance()->tablet_manager()->get_tablet(tablet->tablet_id(), tablet->schema_hash())) {
+        if (tablet != StorageEngine::instance()->tablet_manager()->get_tablet(tablet->tablet_id())) {
             LOG(WARNING) << "tablet has been migrated. tablet_id=" << tablet->tablet_id();
             return true;
         }

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -21,6 +21,7 @@
 
 #include "storage/tablet_manager.h"
 
+#include <fmt/format.h>
 #include <re2/re2.h>
 #include <thrift/protocol/TDebugProtocol.h>
 
@@ -57,125 +58,74 @@ using strings::Substitute;
 
 namespace starrocks {
 
-static bool _cmp_tablet_by_create_time(const TabletSharedPtr& a, const TabletSharedPtr& b) {
-    return a->creation_time() < b->creation_time();
-}
-
 TabletManager::TabletManager(MemTracker* mem_tracker, int32_t tablet_map_lock_shard_size)
         : _mem_tracker(mem_tracker),
-          _tablets_shards_size(tablet_map_lock_shard_size),
+          _tablets_shards(tablet_map_lock_shard_size),
           _tablets_shards_mask(tablet_map_lock_shard_size - 1),
           _last_update_stat_ms(0) {
-    CHECK_GT(_tablets_shards_size, 0);
-    CHECK_EQ(_tablets_shards_size & _tablets_shards_mask, 0);
-    _tablets_shards.resize(_tablets_shards_size);
-    for (auto& tablets_shard : _tablets_shards) {
-        tablets_shard.lock = std::make_unique<std::shared_mutex>();
-    }
+    CHECK_GT(_tablets_shards.size(), 0) << "tablets shard count greater than 0";
+    CHECK_EQ(_tablets_shards.size() & _tablets_shards_mask, 0) << "tablets shard count must be power of two";
 }
 
-Status TabletManager::_add_tablet_unlocked(TTabletId tablet_id, SchemaHash schema_hash, const TabletSharedPtr& tablet,
-                                           bool update_meta, bool force) {
-    Status res = Status::OK();
-    TabletSharedPtr existed_tablet = nullptr;
-    tablet_map_t& tablet_map = _get_tablet_map(tablet_id);
-    for (const TabletSharedPtr& item : tablet_map[tablet_id].table_arr) {
-        if (item->equal(tablet_id, schema_hash)) {
-            existed_tablet = item;
-            break;
-        }
-    }
-
-    if (existed_tablet == nullptr) {
-        return _add_tablet_to_map_unlocked(tablet_id, schema_hash, tablet, update_meta, false /*keep_state*/,
-                                           false /*drop_old*/);
-    }
-
-    if (!force) {
-        if (existed_tablet->tablet_path() == tablet->tablet_path()) {
-            LOG(WARNING) << "add the same tablet twice! tablet_id=" << tablet_id
-                         << " tablet_path=" << tablet->tablet_path();
-            return Status::InternalError("tablet already exists");
-        }
-        if (existed_tablet->data_dir() == tablet->data_dir()) {
-            LOG(WARNING) << "add tablet with same data dir twice! tablet_id=" << tablet_id;
-            return Status::InternalError("tablet already exists");
-        }
-    }
-
-    existed_tablet->obtain_header_rdlock();
-    const RowsetSharedPtr old_rowset = existed_tablet->rowset_with_max_version();
-    const RowsetSharedPtr new_rowset = tablet->rowset_with_max_version();
-
-    // If new tablet is empty, it is a newly created schema change tablet.
-    // the old tablet is dropped before add tablet. it should not exist old tablet
-    if (new_rowset == nullptr) {
-        existed_tablet->release_header_lock();
-        // it seems useless to call unlock and return here.
-        // it could prevent error when log level is changed in the future.
-        LOG(FATAL) << "new tablet is empty and old tablet exists. it should not happen."
-                   << " tablet_id=" << tablet_id;
-        return Status::InternalError("tablet already exists");
-    }
-    int64_t old_time = old_rowset == nullptr ? -1 : old_rowset->creation_time();
-    int64_t new_time = new_rowset->creation_time();
-    int32_t old_version = old_rowset == nullptr ? -1 : old_rowset->end_version();
-    int32_t new_version = new_rowset->end_version();
-    existed_tablet->release_header_lock();
-
-    // In restore process, we replace all origin files in tablet dir with
-    // the downloaded snapshot files. Then we try to reload tablet header.
-    // force == true means we forcibly replace the Tablet in tablet_map
-    // with the new one.
-    bool keep_state = force;
-    if (force || (new_version > old_version || (new_version == old_version && new_time > old_time))) {
-        // check if new tablet's meta is in store and add new tablet's meta to meta store
-        res = _add_tablet_to_map_unlocked(tablet_id, schema_hash, tablet, update_meta, keep_state, true /*drop_old*/);
+Status TabletManager::_add_tablet_unlocked(const TabletSharedPtr& new_tablet, bool update_meta, bool force) {
+    TabletSharedPtr old_tablet = _get_tablet_unlocked(new_tablet->tablet_id());
+    if (old_tablet == nullptr) {
+        RETURN_IF_ERROR(_update_tablet_map_and_partition_info(new_tablet));
+    } else if (force) {
+        RETURN_IF_ERROR(_drop_tablet_unlocked(old_tablet->tablet_id(), true));
+        RETURN_IF_ERROR(_update_tablet_map_and_partition_info(new_tablet));
     } else {
-        res = Status::InternalError("tablet already exists");
-    }
-    LOG(WARNING) << "add duplicated tablet. force=" << force << " res=" << res.to_string() << " tablet_id=" << tablet_id
-                 << " schema_hash=" << schema_hash << " old_version=" << old_version << " new_version=" << new_version
-                 << " old_time=" << old_time << " new_time=" << new_time
-                 << " old_tablet_path=" << existed_tablet->tablet_path()
-                 << " new_tablet_path=" << tablet->tablet_path();
-
-    return res;
-}
-
-Status TabletManager::_add_tablet_to_map_unlocked(TTabletId tablet_id, SchemaHash schema_hash,
-                                                  const TabletSharedPtr& tablet, bool update_meta, bool keep_state,
-                                                  bool drop_old) {
-    // check if new tablet's meta is in store and add new tablet's meta to meta store
-    if (update_meta) {
-        // call tablet save meta in order to valid the meta
-        tablet->save_meta();
-    }
-    if (drop_old) {
-        // If the new tablet is fresher than the existing one, then replace
-        // the existing tablet with the new one.
-        Status st = _drop_tablet_unlocked(tablet_id, schema_hash, keep_state);
-        if (!st.ok()) {
-            LOG(WARNING) << "Fail to drop old tablet when add new tablet. tablet_id=" << tablet_id;
-            return st;
+        if (old_tablet->tablet_path() == new_tablet->tablet_path()) {
+            LOG(WARNING) << "add the same tablet twice! tablet_id=" << new_tablet->tablet_id()
+                         << " tablet_path=" << new_tablet->tablet_path();
+            return Status::InternalError("tablet already exists");
+        }
+        if (old_tablet->data_dir() == new_tablet->data_dir()) {
+            LOG(WARNING) << "add tablet with same data dir twice! tablet_id=" << new_tablet->tablet_id();
+            return Status::InternalError("tablet already exists");
+        }
+        old_tablet->obtain_header_rdlock();
+        auto old_rowset = old_tablet->rowset_with_max_version();
+        auto new_rowset = new_tablet->rowset_with_max_version();
+        auto old_time = (old_rowset == nullptr) ? -1 : old_rowset->creation_time();
+        auto new_time = (new_rowset == nullptr) ? -1 : new_rowset->creation_time();
+        auto old_version = (old_rowset == nullptr) ? -1 : old_rowset->end_version();
+        auto new_version = (new_rowset == nullptr) ? -1 : new_rowset->end_version();
+        old_tablet->release_header_lock();
+        bool allow_add = (new_version > old_version) || (new_version == old_version && new_time > old_time);
+        if (allow_add) {
+            RETURN_IF_ERROR(_drop_tablet_unlocked(old_tablet->tablet_id(), false));
+            RETURN_IF_ERROR(_update_tablet_map_and_partition_info(new_tablet));
+            LOG(INFO) << "Added duplicated tablet. tablet_id=" << new_tablet->tablet_id()
+                      << " old_schema_hash=" << old_tablet->schema_hash()
+                      << " new_schema_hash=" << new_tablet->schema_hash();
+        } else {
+            return Status::InternalError("tablet already exists");
         }
     }
+    if (update_meta) {
+        new_tablet->save_meta();
+    }
+    return Status::OK();
+}
+
+Status TabletManager::_update_tablet_map_and_partition_info(const TabletSharedPtr& tablet) {
     // Register tablet into DataDir, so that we can manage tablet from
     // the perspective of root path.
     // Example: unregister all tables when a bad disk found.
     tablet->register_tablet_into_dir();
-    tablet_map_t& tablet_map = _get_tablet_map(tablet_id);
-    tablet_map[tablet_id].table_arr.push_back(tablet);
-    tablet_map[tablet_id].table_arr.sort(_cmp_tablet_by_create_time);
+    tablet_map_t& tablet_map = _get_tablet_map(tablet->tablet_id());
+    auto [it, inserted] = tablet_map.emplace(tablet->tablet_id(), tablet);
+    if (!inserted) {
+        return Status::InternalError(fmt::format("tablet {} already exist in map", tablet->tablet_id()));
+    }
     _add_tablet_to_partition(*tablet);
-
     return Status::OK();
 }
 
 bool TabletManager::_check_tablet_id_exist_unlocked(TTabletId tablet_id) {
     tablet_map_t& tablet_map = _get_tablet_map(tablet_id);
-    auto it = tablet_map.find(tablet_id);
-    return it != tablet_map.end() && !it->second.table_arr.empty();
+    return tablet_map.count(tablet_id) > 0;
 }
 
 Status TabletManager::create_tablet(const TCreateTabletReq& request, std::vector<DataDir*> stores) {
@@ -194,14 +144,14 @@ Status TabletManager::create_tablet(const TCreateTabletReq& request, std::vector
     // tablet_id exist but with different schema_hash, return an error(report task will
     // eventually trigger its deletion).
     if (request.tablet_schema.keys_type == TKeysType::PRIMARY_KEYS) {
-        TabletSharedPtr tablet = _get_tablet_unlocked(tablet_id, schema_hash, true, nullptr);
+        TabletSharedPtr tablet = _get_tablet_unlocked(tablet_id, true, nullptr);
         if (tablet != nullptr && tablet->tablet_state() != TABLET_SHUTDOWN) {
             return Status::OK();
         } else if (tablet != nullptr) {
             return Status::InternalError("primary key tablet still resident in shutdown queue");
         }
     } else if (_check_tablet_id_exist_unlocked(tablet_id)) {
-        TabletSharedPtr tablet = _get_tablet_unlocked(tablet_id, schema_hash);
+        TabletSharedPtr tablet = _get_tablet_unlocked(tablet_id);
         if (tablet != nullptr) {
             LOG(INFO) << "Created tablet " << tablet_id << ": already exist";
             return Status::OK();
@@ -217,7 +167,7 @@ Status TabletManager::create_tablet(const TCreateTabletReq& request, std::vector
     // If the CreateTabletReq has base_tablet_id then it is a alter-tablet request
     if (request.__isset.base_tablet_id && request.base_tablet_id > 0) {
         is_schema_change = true;
-        base_tablet = _get_tablet_unlocked(request.base_tablet_id, request.base_schema_hash);
+        base_tablet = _get_tablet_unlocked(request.base_tablet_id);
         if (base_tablet == nullptr) {
             LOG(WARNING) << "Fail to create tablet(change schema), base tablet does not exist. "
                          << "new_tablet_id=" << tablet_id << " new_schema_hash=" << schema_hash
@@ -249,9 +199,9 @@ Status TabletManager::create_tablet(const TCreateTabletReq& request, std::vector
     return Status::OK();
 }
 
-TabletSharedPtr TabletManager::_internal_create_tablet_unlocked(const AlterTabletType alter_type,
-                                                                const TCreateTabletReq& request,
-                                                                const bool is_schema_change, const Tablet* base_tablet,
+TabletSharedPtr TabletManager::_internal_create_tablet_unlocked(AlterTabletType alter_type,
+                                                                const TCreateTabletReq& request, bool is_schema_change,
+                                                                const Tablet* base_tablet,
                                                                 const std::vector<DataDir*>& data_dirs) {
     // If in schema-change state, base_tablet must also be provided.
     // i.e., is_schema_change and base_tablet are either assigned or not assigned
@@ -264,9 +214,8 @@ TabletSharedPtr TabletManager::_internal_create_tablet_unlocked(const AlterTable
     if (tablet == nullptr) {
         return nullptr;
     }
-
-    int64_t new_tablet_id = request.tablet_id;
-    int32_t new_schema_hash = request.tablet_schema.schema_hash;
+    CHECK_EQ(request.tablet_id, tablet->tablet_id());
+    CHECK_EQ(request.tablet_schema.schema_hash, tablet->schema_hash());
 
     // should remove the tablet's pending_id no matter create-tablet success or not
     DataDir* data_dir = tablet->data_dir();
@@ -333,7 +282,7 @@ TabletSharedPtr TabletManager::_internal_create_tablet_unlocked(const AlterTable
             }
         }
         // Add tablet to StorageEngine will make it visiable to user
-        status = _add_tablet_unlocked(new_tablet_id, new_schema_hash, tablet, true, false);
+        status = _add_tablet_unlocked(tablet, true, false);
         if (!status.ok()) {
             LOG(WARNING) << "Fail to add tablet to StorageEngine: " << status.to_string();
             break;
@@ -346,11 +295,11 @@ TabletSharedPtr TabletManager::_internal_create_tablet_unlocked(const AlterTable
     }
     // something is wrong, we need clear environment
     if (is_tablet_added) {
-        status = _drop_tablet_unlocked(new_tablet_id, new_schema_hash, false);
+        status = _drop_tablet_unlocked(tablet->tablet_id(), false);
         LOG_IF(WARNING, !status.ok()) << "Fail to drop tablet when create tablet failed: " << status.to_string();
     } else {
         tablet->delete_all_files();
-        (void)TabletMetaManager::remove(data_dir, new_tablet_id, new_schema_hash);
+        (void)TabletMetaManager::remove(data_dir, tablet->tablet_id(), tablet->schema_hash());
     }
     return nullptr;
 }
@@ -364,8 +313,7 @@ static std::string _gen_tablet_dir(const std::string& dir, int16_t shard_id, int
 }
 
 TabletSharedPtr TabletManager::_create_tablet_meta_and_dir_unlocked(const TCreateTabletReq& request,
-                                                                    const bool is_schema_change,
-                                                                    const Tablet* base_tablet,
+                                                                    bool is_schema_change, const Tablet* base_tablet,
                                                                     const std::vector<DataDir*>& data_dirs) {
     for (const auto& data_dir : data_dirs) {
         TabletMetaSharedPtr tablet_meta;
@@ -392,12 +340,12 @@ TabletSharedPtr TabletManager::_create_tablet_meta_and_dir_unlocked(const TCreat
     return nullptr;
 }
 
-Status TabletManager::drop_tablet(TTabletId tablet_id, SchemaHash schema_hash, bool keep_state) {
+Status TabletManager::drop_tablet(TTabletId tablet_id, bool keep_state) {
     MemTracker* prev_tracker = tls_thread_status.set_mem_tracker(_mem_tracker);
     DeferOp op([&] { tls_thread_status.set_mem_tracker(prev_tracker); });
 
     std::unique_lock wlock(_get_tablets_shard_lock(tablet_id));
-    return _drop_tablet_unlocked(tablet_id, schema_hash, keep_state);
+    return _drop_tablet_unlocked(tablet_id, keep_state);
 }
 
 // Drop specified tablet, the main logical is as follows:
@@ -408,11 +356,11 @@ Status TabletManager::drop_tablet(TTabletId tablet_id, SchemaHash schema_hash, b
 //          base-tablet cannot be dropped;
 //      b. other cases:
 //          drop specified tablet directly and clear schema change info.
-Status TabletManager::_drop_tablet_unlocked(TTabletId tablet_id, SchemaHash schema_hash, bool keep_state) {
+Status TabletManager::_drop_tablet_unlocked(TTabletId tablet_id, bool keep_state) {
     StarRocksMetrics::instance()->drop_tablet_requests_total.increment(1);
 
     // Fetch tablet which need to be dropped
-    TabletSharedPtr tablet_to_drop = _get_tablet_unlocked(tablet_id, schema_hash);
+    TabletSharedPtr tablet_to_drop = _get_tablet_unlocked(tablet_id);
     if (tablet_to_drop == nullptr) {
         LOG(WARNING) << "Fail to drop tablet " << tablet_id << ": not exist";
         return Status::NotFound(strings::Substitute("tablet $0 not fount", tablet_id));
@@ -423,19 +371,18 @@ Status TabletManager::_drop_tablet_unlocked(TTabletId tablet_id, SchemaHash sche
     // in schema-change state.
     AlterTabletTaskSharedPtr alter_task = tablet_to_drop->alter_task();
     if (alter_task == nullptr) {
-        return _drop_tablet_directly_unlocked(tablet_id, schema_hash, keep_state);
+        return _drop_tablet_directly_unlocked(tablet_id, keep_state);
     }
 
     AlterTabletState alter_state = alter_task->alter_state();
     TTabletId related_tablet_id = alter_task->related_tablet_id();
-    TSchemaHash related_schema_hash = alter_task->related_schema_hash();
 
-    TabletSharedPtr related_tablet = _get_tablet_unlocked(related_tablet_id, related_schema_hash);
+    TabletSharedPtr related_tablet = _get_tablet_unlocked(related_tablet_id);
     if (related_tablet == nullptr) {
         // TODO(lingbin): in what case, can this happen?
         LOG(WARNING) << "Dropping tablet directly when related tablet not found. "
                      << " tablet_id=" << related_tablet_id;
-        return _drop_tablet_directly_unlocked(tablet_id, schema_hash, keep_state);
+        return _drop_tablet_directly_unlocked(tablet_id, keep_state);
     }
 
     // Check whether the tablet we want to delete is in schema-change state
@@ -470,13 +417,12 @@ Status TabletManager::_drop_tablet_unlocked(TTabletId tablet_id, SchemaHash sche
     // For example: A related to B, BUT B related to C.
     // If drop A, should not clear B's alter task
     AlterTabletTaskSharedPtr related_alter_task = related_tablet->alter_task();
-    if (related_alter_task != nullptr && related_alter_task->related_tablet_id() == tablet_id &&
-        related_alter_task->related_schema_hash() == schema_hash) {
+    if (related_alter_task != nullptr && related_alter_task->related_tablet_id() == tablet_id) {
         related_tablet->delete_alter_task();
         related_tablet->save_meta();
     }
     related_tablet->release_header_lock();
-    Status res = _drop_tablet_directly_unlocked(tablet_id, schema_hash, keep_state);
+    Status res = _drop_tablet_directly_unlocked(tablet_id, keep_state);
     if (!res.ok()) {
         LOG(WARNING) << "Fail to drop tablet which in schema change. tablet=" << tablet_to_drop->full_name();
         return res;
@@ -493,52 +439,40 @@ Status TabletManager::drop_tablets_on_error_root_path(const std::vector<TabletIn
     if (tablet_info_vec.empty()) {
         return Status::OK();
     }
-    for (int32 i = 0; i < _tablets_shards_size; i++) {
-        std::unique_lock wlock(*_tablets_shards[i].lock);
+    auto num_shards = _tablets_shards.size();
+    for (int i = 0; i < num_shards; i++) {
+        std::unique_lock wlock(_tablets_shards[i].lock);
         for (const TabletInfo& tablet_info : tablet_info_vec) {
             TTabletId tablet_id = tablet_info.tablet_id;
             if ((tablet_id & _tablets_shards_mask) != i) {
                 continue;
             }
-            TSchemaHash schema_hash = tablet_info.schema_hash;
-            TabletSharedPtr dropped_tablet = _get_tablet_unlocked(tablet_id, schema_hash);
+            TabletSharedPtr dropped_tablet = _get_tablet_unlocked(tablet_id);
             if (dropped_tablet == nullptr) {
                 LOG(WARNING) << "dropping tablet not exist. tablet_id=" << tablet_id;
                 continue;
             } else {
                 tablet_map_t& tablet_map = _get_tablet_map(tablet_id);
-                for (list<TabletSharedPtr>::iterator it = tablet_map[tablet_id].table_arr.begin();
-                     it != tablet_map[tablet_id].table_arr.end();) {
-                    if ((*it)->equal(tablet_id, schema_hash)) {
-                        // We should first remove tablet from partition_map to avoid iterator
-                        // becoming invalid.
-                        _remove_tablet_from_partition(*(*it));
-                        it = tablet_map[tablet_id].table_arr.erase(it);
-                    } else {
-                        ++it;
-                    }
-                }
+                _remove_tablet_from_partition(*dropped_tablet);
+                tablet_map.erase(tablet_id);
             }
         }
     }
     return Status::OK();
 }
 
-TabletSharedPtr TabletManager::get_tablet(TTabletId tablet_id, SchemaHash schema_hash, bool include_deleted,
-                                          std::string* err) {
+TabletSharedPtr TabletManager::get_tablet(TTabletId tablet_id, bool include_deleted, std::string* err) {
     std::shared_lock rlock(_get_tablets_shard_lock(tablet_id));
-    return _get_tablet_unlocked(tablet_id, schema_hash, include_deleted, err);
+    return _get_tablet_unlocked(tablet_id, include_deleted, err);
 }
 
-TabletSharedPtr TabletManager::_get_tablet_unlocked(TTabletId tablet_id, SchemaHash schema_hash, bool include_deleted,
-                                                    std::string* err) {
-    TabletSharedPtr tablet;
-    tablet = _get_tablet_unlocked(tablet_id, schema_hash);
+TabletSharedPtr TabletManager::_get_tablet_unlocked(TTabletId tablet_id, bool include_deleted, std::string* err) {
+    TabletSharedPtr tablet = _get_tablet_unlocked(tablet_id);
     if (tablet == nullptr && include_deleted) {
         std::shared_lock rlock(_shutdown_tablets_lock);
         for (auto& deleted_tablet : _shutdown_tablets) {
             CHECK(deleted_tablet != nullptr) << "deleted tablet is nullptr";
-            if (deleted_tablet->tablet_id() == tablet_id && deleted_tablet->schema_hash() == schema_hash) {
+            if (deleted_tablet->tablet_id() == tablet_id) {
                 tablet = deleted_tablet;
                 break;
             }
@@ -563,10 +497,10 @@ TabletSharedPtr TabletManager::_get_tablet_unlocked(TTabletId tablet_id, SchemaH
     return tablet;
 }
 
-TabletSharedPtr TabletManager::get_tablet(TTabletId tablet_id, SchemaHash schema_hash, const TabletUid& tablet_uid,
-                                          bool include_deleted, std::string* err) {
+TabletSharedPtr TabletManager::get_tablet(TTabletId tablet_id, const TabletUid& tablet_uid, bool include_deleted,
+                                          std::string* err) {
     std::shared_lock rlock(_get_tablets_shard_lock(tablet_id));
-    TabletSharedPtr tablet = _get_tablet_unlocked(tablet_id, schema_hash, include_deleted, err);
+    TabletSharedPtr tablet = _get_tablet_unlocked(tablet_id, include_deleted, err);
     if (tablet != nullptr && tablet->tablet_uid() == tablet_uid) {
         return tablet;
     }
@@ -627,68 +561,65 @@ TabletSharedPtr TabletManager::find_best_tablet_to_compaction(CompactionType com
     uint32_t highest_score = 1;
     TabletSharedPtr best_tablet;
     for (const auto& tablets_shard : _tablets_shards) {
-        std::shared_lock rlock(*tablets_shard.lock);
-        for (const auto& tablet_map : tablets_shard.tablet_map) {
-            for (const TabletSharedPtr& tablet_ptr : tablet_map.second.table_arr) {
-                if (tablet_ptr->keys_type() == PRIMARY_KEYS) {
+        std::shared_lock rlock(tablets_shard.lock);
+        for (auto [tablet_id, tablet_ptr] : tablets_shard.tablet_map) {
+            if (tablet_ptr->keys_type() == PRIMARY_KEYS) {
+                continue;
+            }
+            AlterTabletTaskSharedPtr cur_alter_task = tablet_ptr->alter_task();
+            if (cur_alter_task != nullptr && cur_alter_task->alter_state() != ALTER_FINISHED &&
+                cur_alter_task->alter_state() != ALTER_FAILED) {
+                TabletSharedPtr related_tablet = _get_tablet_unlocked(cur_alter_task->related_tablet_id());
+                if (related_tablet != nullptr && tablet_ptr->creation_time() > related_tablet->creation_time()) {
+                    // Current tablet is newly created during schema-change or rollup, skip it
                     continue;
                 }
-                AlterTabletTaskSharedPtr cur_alter_task = tablet_ptr->alter_task();
-                if (cur_alter_task != nullptr && cur_alter_task->alter_state() != ALTER_FINISHED &&
-                    cur_alter_task->alter_state() != ALTER_FAILED) {
-                    TabletSharedPtr related_tablet = _get_tablet_unlocked(cur_alter_task->related_tablet_id(),
-                                                                          cur_alter_task->related_schema_hash());
-                    if (related_tablet != nullptr && tablet_ptr->creation_time() > related_tablet->creation_time()) {
-                        // Current tablet is newly created during schema-change or rollup, skip it
-                        continue;
-                    }
-                }
-                // A not-ready tablet maybe a newly created tablet under schema-change, skip it
-                if (tablet_ptr->tablet_state() == TABLET_NOTREADY) {
-                    continue;
-                }
+            }
+            // A not-ready tablet maybe a newly created tablet under schema-change, skip it
+            if (tablet_ptr->tablet_state() == TABLET_NOTREADY) {
+                continue;
+            }
 
-                if (tablet_ptr->data_dir()->path_hash() != data_dir->path_hash() || !tablet_ptr->is_used() ||
-                    !tablet_ptr->init_succeeded() || !tablet_ptr->can_do_compaction()) {
+            if (tablet_ptr->data_dir()->path_hash() != data_dir->path_hash() || !tablet_ptr->is_used() ||
+                !tablet_ptr->init_succeeded() || !tablet_ptr->can_do_compaction()) {
+                continue;
+            }
+
+            int64_t last_failure_ms = tablet_ptr->last_cumu_compaction_failure_time();
+            if (compaction_type == CompactionType::BASE_COMPACTION) {
+                last_failure_ms = tablet_ptr->last_base_compaction_failure_time();
+            }
+            if (now_ms - last_failure_ms <= config::min_compaction_failure_interval_sec * 1000) {
+                VLOG(1) << "Too often to check compaction, skip it."
+                        << "compaction_type=" << compaction_type_str << ", last_failure_time_ms=" << last_failure_ms
+                        << ", tablet_id=" << tablet_ptr->tablet_id();
+                continue;
+            }
+
+            if (compaction_type == CompactionType::BASE_COMPACTION) {
+                if (!tablet_ptr->get_base_lock().try_lock()) {
                     continue;
                 }
+                tablet_ptr->get_base_lock().unlock();
+            } else {
+                if (!tablet_ptr->get_cumulative_lock().try_lock()) {
+                    continue;
+                }
+                tablet_ptr->get_cumulative_lock().unlock();
+            }
 
-                int64_t last_failure_ms = tablet_ptr->last_cumu_compaction_failure_time();
+            uint32_t table_score = 0;
+            {
+                std::shared_lock rdlock(tablet_ptr->get_header_lock());
                 if (compaction_type == CompactionType::BASE_COMPACTION) {
-                    last_failure_ms = tablet_ptr->last_base_compaction_failure_time();
+                    table_score = tablet_ptr->calc_base_compaction_score();
+                } else if (compaction_type == CompactionType::CUMULATIVE_COMPACTION) {
+                    table_score = tablet_ptr->calc_cumulative_compaction_score();
                 }
-                if (now_ms - last_failure_ms <= config::min_compaction_failure_interval_sec * 1000) {
-                    VLOG(1) << "Too often to check compaction, skip it."
-                            << "compaction_type=" << compaction_type_str << ", last_failure_time_ms=" << last_failure_ms
-                            << ", tablet_id=" << tablet_ptr->tablet_id();
-                    continue;
-                }
-
-                if (compaction_type == CompactionType::BASE_COMPACTION) {
-                    if (!tablet_ptr->get_base_lock().try_lock()) {
-                        continue;
-                    }
-                    tablet_ptr->get_base_lock().unlock();
-                } else {
-                    if (!tablet_ptr->get_cumulative_lock().try_lock()) {
-                        continue;
-                    }
-                    tablet_ptr->get_cumulative_lock().unlock();
-                }
-
-                uint32_t table_score = 0;
-                {
-                    std::shared_lock rdlock(tablet_ptr->get_header_lock());
-                    if (compaction_type == CompactionType::BASE_COMPACTION) {
-                        table_score = tablet_ptr->calc_base_compaction_score();
-                    } else if (compaction_type == CompactionType::CUMULATIVE_COMPACTION) {
-                        table_score = tablet_ptr->calc_cumulative_compaction_score();
-                    }
-                }
-                if (table_score > highest_score) {
-                    highest_score = table_score;
-                    best_tablet = tablet_ptr;
-                }
+            }
+            if (table_score > highest_score) {
+                highest_score = table_score;
+                best_tablet = tablet_ptr;
             }
         }
     }
@@ -712,42 +643,39 @@ TabletSharedPtr TabletManager::find_best_tablet_to_do_update_compaction(DataDir*
     int64_t highest_score = 0;
     TabletSharedPtr best_tablet;
     for (const auto& tablets_shard : _tablets_shards) {
-        std::shared_lock rlock(*tablets_shard.lock);
-        for (const auto& tablet_map : tablets_shard.tablet_map) {
-            for (const TabletSharedPtr& tablet_ptr : tablet_map.second.table_arr) {
-                if (tablet_ptr->keys_type() != PRIMARY_KEYS) {
+        std::shared_lock rlock(tablets_shard.lock);
+        for (const auto& [tablet_id, tablet_ptr] : tablets_shard.tablet_map) {
+            if (tablet_ptr->keys_type() != PRIMARY_KEYS) {
+                continue;
+            }
+            AlterTabletTaskSharedPtr cur_alter_task = tablet_ptr->alter_task();
+            if (cur_alter_task != nullptr && cur_alter_task->alter_state() != ALTER_FINISHED &&
+                cur_alter_task->alter_state() != ALTER_FAILED) {
+                TabletSharedPtr related_tablet = _get_tablet_unlocked(cur_alter_task->related_tablet_id());
+                if (related_tablet != nullptr && tablet_ptr->creation_time() > related_tablet->creation_time()) {
+                    // Current tablet is newly created during schema-change or rollup, skip it
                     continue;
                 }
-                AlterTabletTaskSharedPtr cur_alter_task = tablet_ptr->alter_task();
-                if (cur_alter_task != nullptr && cur_alter_task->alter_state() != ALTER_FINISHED &&
-                    cur_alter_task->alter_state() != ALTER_FAILED) {
-                    TabletSharedPtr related_tablet = _get_tablet_unlocked(cur_alter_task->related_tablet_id(),
-                                                                          cur_alter_task->related_schema_hash());
-                    if (related_tablet != nullptr && tablet_ptr->creation_time() > related_tablet->creation_time()) {
-                        // Current tablet is newly created during schema-change or rollup, skip it
-                        continue;
-                    }
-                }
-                // A not-ready tablet maybe a newly created tablet under schema-change, skip it
-                if (tablet_ptr->tablet_state() == TABLET_NOTREADY) {
-                    continue;
-                }
+            }
+            // A not-ready tablet maybe a newly created tablet under schema-change, skip it
+            if (tablet_ptr->tablet_state() == TABLET_NOTREADY) {
+                continue;
+            }
 
-                if (tablet_ptr->data_dir()->path_hash() != data_dir->path_hash() || !tablet_ptr->is_used() ||
-                    !tablet_ptr->init_succeeded()) {
-                    continue;
-                }
+            if (tablet_ptr->data_dir()->path_hash() != data_dir->path_hash() || !tablet_ptr->is_used() ||
+                !tablet_ptr->init_succeeded()) {
+                continue;
+            }
 
-                int64_t table_score = tablet_ptr->updates()->get_compaction_score();
-                // tablet_score maybe negative, which means it's not worthy to do compaction
-                if (table_score <= 0) {
-                    continue;
-                }
+            int64_t table_score = tablet_ptr->updates()->get_compaction_score();
+            // tablet_score maybe negative, which means it's not worthy to do compaction
+            if (table_score <= 0) {
+                continue;
+            }
 
-                if (table_score > highest_score) {
-                    highest_score = table_score;
-                    best_tablet = tablet_ptr;
-                }
+            if (table_score > highest_score) {
+                highest_score = table_score;
+                best_tablet = tablet_ptr;
             }
         }
     }
@@ -837,7 +765,7 @@ Status TabletManager::load_tablet_from_meta(DataDir* data_dir, TTabletId tablet_
         // tablet state is invalid, drop tablet
         return Status::InternalError("tablet in running state but without delta");
     }
-    auto st = _add_tablet_unlocked(tablet_id, schema_hash, tablet, update_meta, force);
+    auto st = _add_tablet_unlocked(tablet, update_meta, force);
     LOG_IF(WARNING, !st.ok()) << "Fail to add tablet " << tablet->full_name();
     return st;
 }
@@ -882,20 +810,6 @@ Status TabletManager::load_tablet_from_dir(DataDir* store, TTabletId tablet_id, 
     return st;
 }
 
-void TabletManager::release_schema_change_lock(TTabletId tablet_id) {
-    VLOG(3) << "release_schema_change_lock begin. tablet_id=" << tablet_id;
-    std::shared_lock rlock(_get_tablets_shard_lock(tablet_id));
-
-    tablet_map_t& tablet_map = _get_tablet_map(tablet_id);
-    auto it = tablet_map.find(tablet_id);
-    if (it == tablet_map.end()) {
-        LOG(WARNING) << "tablet does not exists. tablet=" << tablet_id;
-    } else {
-        it->second.schema_change_lock.unlock();
-    }
-    VLOG(3) << "release_schema_change_lock end. tablet_id=" << tablet_id;
-}
-
 Status TabletManager::report_tablet_info(TTabletInfo* tablet_info) {
     StarRocksMetrics::instance()->report_tablet_requests_total.increment(1);
 
@@ -924,27 +838,20 @@ Status TabletManager::report_all_tablets_info(std::map<TTabletId, TTablet>* tabl
     StarRocksMetrics::instance()->report_all_tablets_requests_total.increment(1);
 
     for (const auto& tablets_shard : _tablets_shards) {
-        std::shared_lock rlock(*tablets_shard.lock);
-        for (const auto& item : tablets_shard.tablet_map) {
-            if (item.second.table_arr.empty()) {
-                continue;
-            }
-
-            uint64_t tablet_id = item.first;
+        std::shared_lock rlock(tablets_shard.lock);
+        for (const auto& [tablet_id, tablet_ptr] : tablets_shard.tablet_map) {
             TTablet t_tablet;
-            for (const TabletSharedPtr& tablet_ptr : item.second.table_arr) {
-                TTabletInfo tablet_info;
-                tablet_ptr->build_tablet_report_info(&tablet_info);
+            TTabletInfo tablet_info;
+            tablet_ptr->build_tablet_report_info(&tablet_info);
 
-                // find expired transaction corresponding to this tablet
-                TabletInfo tinfo(tablet_id, tablet_ptr->schema_hash(), tablet_ptr->tablet_uid());
-                auto find = expire_txn_map.find(tinfo);
-                if (find != expire_txn_map.end()) {
-                    tablet_info.__set_transaction_ids(find->second);
-                    expire_txn_map.erase(find);
-                }
-                t_tablet.tablet_infos.push_back(tablet_info);
+            // find expired transaction corresponding to this tablet
+            TabletInfo tinfo(tablet_id, tablet_ptr->schema_hash(), tablet_ptr->tablet_uid());
+            auto find = expire_txn_map.find(tinfo);
+            if (find != expire_txn_map.end()) {
+                tablet_info.__set_transaction_ids(find->second);
+                expire_txn_map.erase(find);
             }
+            t_tablet.tablet_infos.push_back(tablet_info);
 
             if (!t_tablet.tablet_infos.empty()) {
                 tablets_info->emplace(tablet_id, t_tablet);
@@ -960,21 +867,14 @@ Status TabletManager::start_trash_sweep() {
     DeferOp op([&] { tls_thread_status.set_mem_tracker(prev_tracker); });
 
     {
-        std::vector<int64_t> tablets_to_clean;
         // we use this vector to save all tablet ptr for saving lock time.
         std::vector<TabletSharedPtr> all_tablets;
         for (auto& tablets_shard : _tablets_shards) {
             tablet_map_t& tablet_map = tablets_shard.tablet_map;
             {
-                std::shared_lock rlock(*tablets_shard.lock);
-                for (auto& item : tablet_map) {
-                    // try to clean empty item
-                    if (item.second.table_arr.empty()) {
-                        tablets_to_clean.push_back(item.first);
-                    }
-                    for (const TabletSharedPtr& tablet : item.second.table_arr) {
-                        all_tablets.push_back(tablet);
-                    }
+                std::shared_lock rlock(tablets_shard.lock);
+                for (auto& [tablet_id, tablet] : tablet_map) {
+                    all_tablets.push_back(tablet);
                 }
             }
 
@@ -983,24 +883,6 @@ Status TabletManager::start_trash_sweep() {
                 tablet->delete_expired_stale_rowset();
             }
             all_tablets.clear();
-
-            if (!tablets_to_clean.empty()) {
-                std::unique_lock wlock(*tablets_shard.lock);
-                // clean empty tablet id item
-                for (const auto& tablet_id_to_clean : tablets_to_clean) {
-                    auto& item = tablet_map[tablet_id_to_clean];
-                    if (item.table_arr.empty()) {
-                        // try to get schema change lock if could get schema change lock, then nobody
-                        // own the lock could remove the item
-                        // it will core if schema change thread may hold the lock and this thread will deconstruct lock
-                        if (item.schema_change_lock.try_lock()) {
-                            item.schema_change_lock.unlock();
-                            tablet_map.erase(tablet_id_to_clean);
-                        }
-                    }
-                }
-                tablets_to_clean.clear(); // We should clear the vector before next loop
-            }
         }
     }
 
@@ -1103,7 +985,7 @@ void TabletManager::register_clone_tablet(int64_t tablet_id) {
     DeferOp op([&] { tls_thread_status.set_mem_tracker(prev_tracker); });
 
     tablets_shard& shard = _get_tablets_shard(tablet_id);
-    std::unique_lock wlock(*shard.lock);
+    std::unique_lock wlock(shard.lock);
     shard.tablets_under_clone.insert(tablet_id);
 }
 
@@ -1112,7 +994,7 @@ void TabletManager::unregister_clone_tablet(int64_t tablet_id) {
     DeferOp op([&] { tls_thread_status.set_mem_tracker(prev_tracker); });
 
     tablets_shard& shard = _get_tablets_shard(tablet_id);
-    std::unique_lock wlock(*shard.lock);
+    std::unique_lock wlock(shard.lock);
     shard.tablets_under_clone.erase(tablet_id);
 }
 
@@ -1124,7 +1006,7 @@ void TabletManager::try_delete_unused_tablet_path(DataDir* data_dir, TTabletId t
     // acquire the read lock, so that there is no creating tablet or load tablet from meta tasks
     // create tablet and load tablet task should check whether the dir exists
     tablets_shard& shard = _get_tablets_shard(tablet_id);
-    std::shared_lock rlock(*shard.lock);
+    std::shared_lock rlock(shard.lock);
 
     // check if meta already exists
     TabletMetaSharedPtr tablet_meta(new TabletMeta());
@@ -1151,37 +1033,35 @@ void TabletManager::try_delete_unused_tablet_path(DataDir* data_dir, TTabletId t
 }
 
 bool TabletManager::try_schema_change_lock(TTabletId tablet_id) {
-    bool res = false;
-    VLOG(3) << "Locking tablet_id=" << tablet_id;
     std::shared_lock rlock(_get_tablets_shard_lock(tablet_id));
     tablet_map_t& tablet_map = _get_tablet_map(tablet_id);
     auto it = tablet_map.find(tablet_id);
     if (it == tablet_map.end()) {
         LOG(WARNING) << "Fail to lock nonexistent tablet_id=" << tablet_id;
+        return false;
     } else {
-        res = (it->second.schema_change_lock.try_lock());
+        return _schema_change_lock_tbl.try_lock(it->first);
     }
-    VLOG(3) << "Locked tablet_id=" << tablet_id;
-    return res;
+}
+
+void TabletManager::release_schema_change_lock(TTabletId tablet_id) {
+    (void)_schema_change_lock_tbl.unlock(tablet_id);
 }
 
 void TabletManager::update_root_path_info(std::map<std::string, DataDirInfo>* path_map, size_t* tablet_count) {
     DCHECK(tablet_count != nullptr);
     *tablet_count = 0;
     for (const auto& tablets_shard : _tablets_shards) {
-        std::shared_lock rlock(*tablets_shard.lock);
-        for (const auto& entry : tablets_shard.tablet_map) {
-            const TableInstances& instance = entry.second;
-            for (const auto& tablet : instance.table_arr) {
-                ++(*tablet_count);
-                int64_t data_size = tablet->tablet_footprint();
-                auto iter = path_map->find(tablet->data_dir()->path());
-                if (iter == path_map->end()) {
-                    continue;
-                }
-                if (iter->second.is_used) {
-                    iter->second.data_used_capacity += data_size;
-                }
+        std::shared_lock rlock(tablets_shard.lock);
+        for (const auto& [tablet_id, tablet] : tablets_shard.tablet_map) {
+            ++(*tablet_count);
+            int64_t data_size = tablet->tablet_footprint();
+            auto iter = path_map->find(tablet->data_dir()->path());
+            if (iter == path_map->end()) {
+                continue;
+            }
+            if (iter->second.is_used) {
+                iter->second.data_used_capacity += data_size;
             }
         }
     }
@@ -1199,22 +1079,18 @@ void TabletManager::do_tablet_meta_checkpoint(DataDir* data_dir) {
     DeferOp op([&] { tls_thread_status.set_mem_tracker(prev_tracker); });
 
     std::vector<TabletSharedPtr> related_tablets;
-    {
-        for (const auto& tablets_shard : _tablets_shards) {
-            std::shared_lock rlock(*tablets_shard.lock);
-            for (const auto& tablet_map : tablets_shard.tablet_map) {
-                for (const TabletSharedPtr& tablet_ptr : tablet_map.second.table_arr) {
-                    if (tablet_ptr->tablet_state() != TABLET_RUNNING) {
-                        continue;
-                    }
-
-                    if (tablet_ptr->data_dir()->path_hash() != data_dir->path_hash() || !tablet_ptr->is_used() ||
-                        !tablet_ptr->init_succeeded()) {
-                        continue;
-                    }
-                    related_tablets.push_back(tablet_ptr);
-                }
+    for (const auto& tablets_shard : _tablets_shards) {
+        std::shared_lock rlock(tablets_shard.lock);
+        for (const auto& [tablet_id, tablet_ptr] : tablets_shard.tablet_map) {
+            if (tablet_ptr->tablet_state() != TABLET_RUNNING) {
+                continue;
             }
+
+            if (tablet_ptr->data_dir()->path_hash() != data_dir->path_hash() || !tablet_ptr->is_used() ||
+                !tablet_ptr->init_succeeded()) {
+                continue;
+            }
+            related_tablets.push_back(tablet_ptr);
         }
     }
     for (const TabletSharedPtr& tablet : related_tablets) {
@@ -1225,28 +1101,14 @@ void TabletManager::do_tablet_meta_checkpoint(DataDir* data_dir) {
 void TabletManager::_build_tablet_stat() {
     _tablet_stat_cache.clear();
     for (const auto& tablets_shard : _tablets_shards) {
-        std::shared_lock rlock(*tablets_shard.lock);
-        for (const auto& item : tablets_shard.tablet_map) {
-            if (item.second.table_arr.empty()) {
-                continue;
-            }
-
+        std::shared_lock rlock(tablets_shard.lock);
+        for (const auto& [tablet_id, tablet] : tablets_shard.tablet_map) {
             TTabletStat stat;
-            stat.tablet_id = item.first;
-            for (const TabletSharedPtr& tablet : item.second.table_arr) {
-                // TODO(lingbin): if it is nullptr, why is it not deleted?
-                if (tablet == nullptr) {
-                    continue;
-                }
-                // TODO(cbl): get row num and data size together is faster
-                stat.__set_data_size(tablet->tablet_footprint());
-                stat.__set_row_num(tablet->num_rows());
-                VLOG(3) << "building tablet stat. tablet_id=" << item.first
-                        << ", data_size=" << tablet->tablet_footprint() << ", row_num=" << tablet->num_rows();
-                break;
-            }
-
-            _tablet_stat_cache.emplace(item.first, stat);
+            stat.tablet_id = tablet_id;
+            // TODO(cbl): get row num and data size together is faster
+            stat.__set_data_size(tablet->tablet_footprint());
+            stat.__set_row_num(tablet->num_rows());
+            _tablet_stat_cache.emplace(tablet_id, stat);
         }
     }
 }
@@ -1311,7 +1173,7 @@ Status TabletManager::_create_inital_rowset_unlocked(const TCreateTabletReq& req
 }
 
 Status TabletManager::_create_tablet_meta_unlocked(const TCreateTabletReq& request, DataDir* store,
-                                                   const bool is_schema_change, const Tablet* base_tablet,
+                                                   bool is_schema_change, const Tablet* base_tablet,
                                                    TabletMetaSharedPtr* tablet_meta) {
     uint32_t next_unique_id = 0;
     std::unordered_map<uint32_t, uint32_t> col_idx_to_unique_id;
@@ -1360,58 +1222,40 @@ Status TabletManager::_create_tablet_meta_unlocked(const TCreateTabletReq& reque
                               rowset_type, tablet_meta);
 }
 
-Status TabletManager::_drop_tablet_directly_unlocked(TTabletId tablet_id, SchemaHash schema_hash, bool keep_state) {
-    TabletSharedPtr dropped_tablet = _get_tablet_unlocked(tablet_id, schema_hash);
-    if (dropped_tablet == nullptr) {
+Status TabletManager::_drop_tablet_directly_unlocked(TTabletId tablet_id, bool keep_state) {
+    tablet_map_t& tablet_map = _get_tablet_map(tablet_id);
+    auto it = tablet_map.find(tablet_id);
+    if (it == tablet_map.end()) {
         LOG(WARNING) << "Fail to drop nonexistent tablet " << tablet_id;
         return Status::NotFound("");
     }
-    tablet_map_t& tablet_map = _get_tablet_map(tablet_id);
-    list<TabletSharedPtr>& candidate_tablets = tablet_map[tablet_id].table_arr;
-    auto it = candidate_tablets.begin();
-    while (it != candidate_tablets.end()) {
-        if (!(*it)->equal(tablet_id, schema_hash)) {
-            ++it;
-            continue;
-        }
-
-        TabletSharedPtr tablet = *it;
-        _remove_tablet_from_partition(*(*it));
-        it = candidate_tablets.erase(it);
-        if (!keep_state) {
-            // drop tablet will update tablet meta, should lock
-            std::unique_lock wrlock(tablet->get_header_lock());
-            LOG(INFO) << "Shutting down tablet " << tablet_id;
-            // NOTE: has to update tablet here, but must not update tablet meta directly.
-            // because other thread may hold the tablet object, they may save meta too.
-            // If update meta directly here, other thread may override the meta
-            // and the tablet will be loaded at restart time.
-            // To avoid this exception, we first set the state of the tablet to `SHUTDOWN`.
-            tablet->set_tablet_state(TABLET_SHUTDOWN);
-            tablet->save_meta();
-            {
-                std::unique_lock wlock(_shutdown_tablets_lock);
-                _shutdown_tablets.push_back(tablet);
-            }
+    TabletSharedPtr dropped_tablet = it->second;
+    tablet_map.erase(it);
+    _remove_tablet_from_partition(*dropped_tablet);
+    if (!keep_state) {
+        LOG(INFO) << "Shutting down tablet " << tablet_id;
+        // drop tablet will update tablet meta, should lock
+        std::unique_lock wrlock(dropped_tablet->get_header_lock());
+        // NOTE: has to update tablet here, but must not update tablet meta directly.
+        // because other thread may hold the tablet object, they may save meta too.
+        // If update meta directly here, other thread may override the meta
+        // and the tablet will be loaded at restart time.
+        // To avoid this exception, we first set the state of the tablet to `SHUTDOWN`.
+        dropped_tablet->set_tablet_state(TABLET_SHUTDOWN);
+        dropped_tablet->save_meta();
+        {
+            std::unique_lock wlock(_shutdown_tablets_lock);
+            _shutdown_tablets.push_back(dropped_tablet);
         }
     }
-
     dropped_tablet->deregister_tablet_from_dir();
     return Status::OK();
 }
 
-TabletSharedPtr TabletManager::_get_tablet_unlocked(TTabletId tablet_id, SchemaHash schema_hash) {
+TabletSharedPtr TabletManager::_get_tablet_unlocked(TTabletId tablet_id) {
     tablet_map_t& tablet_map = _get_tablet_map(tablet_id);
     auto it = tablet_map.find(tablet_id);
-    if (it != tablet_map.end()) {
-        for (TabletSharedPtr tablet : it->second.table_arr) {
-            CHECK(tablet != nullptr) << "tablet is nullptr. tablet_id=" << tablet_id;
-            if (tablet->equal(tablet_id, schema_hash)) {
-                return tablet;
-            }
-        }
-    }
-    return nullptr;
+    return it != tablet_map.end() ? it->second : nullptr;
 }
 
 void TabletManager::_add_tablet_to_partition(const Tablet& tablet) {
@@ -1428,7 +1272,7 @@ void TabletManager::_remove_tablet_from_partition(const Tablet& tablet) {
 }
 
 std::shared_mutex& TabletManager::_get_tablets_shard_lock(TTabletId tabletId) {
-    return *_get_tablets_shard(tabletId).lock;
+    return _get_tablets_shard(tabletId).lock;
 }
 
 TabletManager::tablet_map_t& TabletManager::_get_tablet_map(TTabletId tabletId) {
@@ -1524,7 +1368,7 @@ Status TabletManager::create_tablet_from_meta_snapshot(DataDir* store, TTabletId
     }
 
     std::unique_lock l(_get_tablets_shard_lock(tablet_id));
-    if (_get_tablet_unlocked(tablet_id, schema_hash, true, nullptr) != nullptr) {
+    if (_get_tablet_unlocked(tablet_id, true, nullptr) != nullptr) {
         return Status::InternalError("tablet already exist");
     }
 
@@ -1541,7 +1385,7 @@ Status TabletManager::create_tablet_from_meta_snapshot(DataDir* store, TTabletId
         LOG_IF(WARNING, !st.ok()) << "Fail to clear meta store: " << st;
         return Status::InternalError("tablet init failed");
     }
-    auto st = _add_tablet_unlocked(tablet_id, schema_hash, tablet, true, false);
+    auto st = _add_tablet_unlocked(tablet, true, false);
     LOG_IF(WARNING, !st.ok()) << "Fail to add cloned tablet " << tablet_id << ": " << st;
     return st;
 }

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -92,8 +92,8 @@ Status TabletManager::_add_tablet_unlocked(const TabletSharedPtr& new_tablet, bo
         auto old_version = (old_rowset == nullptr) ? -1 : old_rowset->end_version();
         auto new_version = (new_rowset == nullptr) ? -1 : new_rowset->end_version();
         old_tablet->release_header_lock();
-        bool allow_add = (new_version > old_version) || (new_version == old_version && new_time > old_time);
-        if (allow_add) {
+        bool replace_old = (new_version > old_version) || (new_version == old_version && new_time > old_time);
+        if (replace_old) {
             RETURN_IF_ERROR(_drop_tablet_unlocked(old_tablet->tablet_id(), false));
             RETURN_IF_ERROR(_update_tablet_map_and_partition_info(new_tablet));
             LOG(INFO) << "Added duplicated tablet. tablet_id=" << new_tablet->tablet_id()

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -97,8 +97,8 @@ Status TabletManager::_add_tablet_unlocked(const TabletSharedPtr& new_tablet, bo
             RETURN_IF_ERROR(_drop_tablet_unlocked(old_tablet->tablet_id(), false));
             RETURN_IF_ERROR(_update_tablet_map_and_partition_info(new_tablet));
             LOG(INFO) << "Added duplicated tablet. tablet_id=" << new_tablet->tablet_id()
-                      << " old_schema_hash=" << old_tablet->schema_hash()
-                      << " new_schema_hash=" << new_tablet->schema_hash();
+                      << " old_tablet_path=" << old_tablet->tablet_path()
+                      << " new_tablet_path=" << new_tablet->tablet_path();
         } else {
             return Status::InternalError("tablet already exists");
         }

--- a/be/src/storage/tablet_manager.h
+++ b/be/src/storage/tablet_manager.h
@@ -131,12 +131,13 @@ public:
     void unregister_clone_tablet(int64_t tablet_id);
 
 private:
-    using tablet_map_t = std::unordered_map<int64_t, TabletSharedPtr>;
+    using TabletMap = std::unordered_map<int64_t, TabletSharedPtr>;
+    using TabletSet = std::unordered_set<int64_t>;
 
-    struct tablets_shard {
+    struct TabletsShard {
         mutable std::shared_mutex lock;
-        tablet_map_t tablet_map;
-        std::set<int64_t> tablets_under_clone;
+        TabletMap tablet_map;
+        TabletSet tablets_under_clone;
     };
 
     class LockTable {
@@ -190,13 +191,13 @@ private:
 
     std::shared_mutex& _get_tablets_shard_lock(TTabletId tabletId);
 
-    tablet_map_t& _get_tablet_map(TTabletId tablet_id);
+    TabletMap& _get_tablet_map(TTabletId tablet_id);
 
-    tablets_shard& _get_tablets_shard(TTabletId tabletId);
+    TabletsShard& _get_tablets_shard(TTabletId tabletId);
 
     MemTracker* _mem_tracker = nullptr;
 
-    std::vector<tablets_shard> _tablets_shards;
+    std::vector<TabletsShard> _tablets_shards;
     const int32_t _tablets_shards_mask;
     LockTable _schema_change_lock_tbl;
 

--- a/be/src/storage/tablet_manager.h
+++ b/be/src/storage/tablet_manager.h
@@ -39,6 +39,7 @@
 #include "storage/olap_define.h"
 #include "storage/options.h"
 #include "storage/tablet.h"
+#include "util/spinlock.h"
 
 namespace starrocks {
 
@@ -62,7 +63,7 @@ public:
     // task to be fail, even if there is enough space on other disks
     Status create_tablet(const TCreateTabletReq& request, std::vector<DataDir*> stores);
 
-    Status drop_tablet(TTabletId tablet_id, SchemaHash schema_hash, bool keep_state = false);
+    Status drop_tablet(TTabletId tablet_id, bool keep_state = false);
 
     Status drop_tablets_on_error_root_path(const std::vector<TabletInfo>& tablet_info_vec);
 
@@ -70,11 +71,10 @@ public:
 
     TabletSharedPtr find_best_tablet_to_do_update_compaction(DataDir* data_dir);
 
-    TabletSharedPtr get_tablet(TTabletId tablet_id, SchemaHash schema_hash, bool include_deleted = false,
-                               std::string* err = nullptr);
+    TabletSharedPtr get_tablet(TTabletId tablet_id, bool include_deleted = false, std::string* err = nullptr);
 
-    TabletSharedPtr get_tablet(TTabletId tablet_id, SchemaHash schema_hash, const TabletUid& tablet_uid,
-                               bool include_deleted = false, std::string* err = nullptr);
+    TabletSharedPtr get_tablet(TTabletId tablet_id, const TabletUid& tablet_uid, bool include_deleted = false,
+                               std::string* err = nullptr);
 
     // Extract tablet_id and schema_hash from given path.
     //
@@ -131,34 +131,56 @@ public:
     void unregister_clone_tablet(int64_t tablet_id);
 
 private:
+    using tablet_map_t = std::unordered_map<int64_t, TabletSharedPtr>;
+
+    struct tablets_shard {
+        mutable std::shared_mutex lock;
+        tablet_map_t tablet_map;
+        std::set<int64_t> tablets_under_clone;
+    };
+
+    class LockTable {
+    public:
+        bool is_locked(int64_t tablet_id);
+        bool try_lock(int64_t tablet_id);
+        bool unlock(int64_t tablet_id);
+
+    private:
+        constexpr static int kNumShard = 128;
+
+        int _shard(int64_t tablet_id) { return tablet_id % kNumShard; }
+
+        SpinLock _latches[kNumShard];
+        std::unordered_set<int64_t> _locks[kNumShard];
+    };
+
+    TabletManager(const TabletManager&) = delete;
+    const TabletManager& operator=(const TabletManager&) = delete;
+
     // Add a tablet pointer to StorageEngine
     // If force, drop the existing tablet add this new one
-    Status _add_tablet_unlocked(TTabletId tablet_id, SchemaHash schema_hash, const TabletSharedPtr& tablet,
-                                bool update_meta, bool force);
+    Status _add_tablet_unlocked(const TabletSharedPtr& tablet, bool update_meta, bool force);
 
-    Status _add_tablet_to_map_unlocked(TTabletId tablet_id, SchemaHash schema_hash, const TabletSharedPtr& tablet,
-                                       bool update_meta, bool keep_state, bool drop_old);
+    Status _update_tablet_map_and_partition_info(const TabletSharedPtr& tablet);
 
     bool _check_tablet_id_exist_unlocked(TTabletId tablet_id);
     Status _create_inital_rowset_unlocked(const TCreateTabletReq& request, Tablet* tablet);
 
-    Status _drop_tablet_directly_unlocked(TTabletId tablet_id, TSchemaHash schema_hash, bool keep_state = false);
+    Status _drop_tablet_directly_unlocked(TTabletId tablet_id, bool keep_state = false);
 
-    Status _drop_tablet_unlocked(TTabletId tablet_id, SchemaHash schema_hash, bool keep_state);
+    Status _drop_tablet_unlocked(TTabletId tablet_id, bool keep_state);
 
-    TabletSharedPtr _get_tablet_unlocked(TTabletId tablet_id, SchemaHash schema_hash);
-    TabletSharedPtr _get_tablet_unlocked(TTabletId tablet_id, SchemaHash schema_hash, bool include_deleted,
-                                         std::string* err);
+    TabletSharedPtr _get_tablet_unlocked(TTabletId tablet_id);
+    TabletSharedPtr _get_tablet_unlocked(TTabletId tablet_id, bool include_deleted, std::string* err);
 
-    TabletSharedPtr _internal_create_tablet_unlocked(const AlterTabletType alter_type, const TCreateTabletReq& request,
-                                                     const bool is_schema_change, const Tablet* base_tablet,
+    TabletSharedPtr _internal_create_tablet_unlocked(AlterTabletType alter_type, const TCreateTabletReq& request,
+                                                     bool is_schema_change, const Tablet* base_tablet,
                                                      const std::vector<DataDir*>& data_dirs);
-    TabletSharedPtr _create_tablet_meta_and_dir_unlocked(const TCreateTabletReq& request, const bool is_schema_change,
+    TabletSharedPtr _create_tablet_meta_and_dir_unlocked(const TCreateTabletReq& request, bool is_schema_change,
                                                          const Tablet* base_tablet,
                                                          const std::vector<DataDir*>& data_dirs);
-    Status _create_tablet_meta_unlocked(const TCreateTabletReq& request, DataDir* store,
-                                        const bool is_schema_change_tablet, const Tablet* base_tablet,
-                                        TabletMetaSharedPtr* tablet_meta);
+    Status _create_tablet_meta_unlocked(const TCreateTabletReq& request, DataDir* store, bool is_schema_change_tablet,
+                                        const Tablet* base_tablet, TabletMetaSharedPtr* tablet_meta);
 
     void _build_tablet_stat();
 
@@ -168,33 +190,15 @@ private:
 
     std::shared_mutex& _get_tablets_shard_lock(TTabletId tabletId);
 
-    TabletManager(const TabletManager&) = delete;
-    const TabletManager& operator=(const TabletManager&) = delete;
+    tablet_map_t& _get_tablet_map(TTabletId tablet_id);
 
-    // TODO(lingbin): should be TabletInstances?
-    // should be removed after schema_hash be removed
-    struct TableInstances {
-        std::mutex schema_change_lock;
-        // The first element(i.e. tablet_arr[0]) is the base tablet. When we add new tablet
-        // to tablet_arr, we will sort all the elements in create-time ascending order,
-        // which will ensure the first one is base-tablet
-        std::list<TabletSharedPtr> table_arr;
-    };
-    // tablet_id -> TabletInstances
-    using tablet_map_t = std::unordered_map<int64_t, TableInstances>;
-
-    struct tablets_shard {
-        // protect tablet_map, tablets_under_clone
-        std::unique_ptr<std::shared_mutex> lock;
-        tablet_map_t tablet_map;
-        std::set<int64_t> tablets_under_clone;
-    };
+    tablets_shard& _get_tablets_shard(TTabletId tabletId);
 
     MemTracker* _mem_tracker = nullptr;
 
-    const int32_t _tablets_shards_size;
-    const int32_t _tablets_shards_mask;
     std::vector<tablets_shard> _tablets_shards;
+    const int32_t _tablets_shards_mask;
+    LockTable _schema_change_lock_tbl;
 
     // Protect _partition_tablet_map, should not be obtained before _tablet_map_lock to avoid dead lock
     std::shared_mutex _partition_tablet_map_lock;
@@ -210,11 +214,25 @@ private:
     std::map<int64_t, TTabletStat> _tablet_stat_cache;
     // last update time of tablet stat cache
     int64_t _last_update_stat_ms;
-
-    tablet_map_t& _get_tablet_map(TTabletId tablet_id);
-
-    tablets_shard& _get_tablets_shard(TTabletId tabletId);
 };
+
+inline bool TabletManager::LockTable::is_locked(int64_t tablet_id) {
+    auto s = _shard(tablet_id);
+    std::lock_guard l(_latches[s]);
+    return _locks[s].count(tablet_id) > 0;
+}
+
+inline bool TabletManager::LockTable::try_lock(int64_t tablet_id) {
+    auto s = _shard(tablet_id);
+    std::lock_guard l(_latches[s]);
+    return _locks[s].insert(tablet_id).second;
+}
+
+inline bool TabletManager::LockTable::unlock(int64_t tablet_id) {
+    auto s = _shard(tablet_id);
+    std::lock_guard l(_latches[s]);
+    return _locks[s].erase(tablet_id) > 0;
+}
 
 } // namespace starrocks
 

--- a/be/src/storage/tablet_manager.h
+++ b/be/src/storage/tablet_manager.h
@@ -28,6 +28,7 @@
 #include <set>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "agent/status.h"

--- a/be/src/storage/task/engine_batch_load_task.cpp
+++ b/be/src/storage/task/engine_batch_load_task.cpp
@@ -100,7 +100,7 @@ AgentStatus EngineBatchLoadTask::_init() {
 
     // Check replica exist
     TabletSharedPtr tablet;
-    tablet = StorageEngine::instance()->tablet_manager()->get_tablet(_push_req.tablet_id, _push_req.schema_hash);
+    tablet = StorageEngine::instance()->tablet_manager()->get_tablet(_push_req.tablet_id);
     if (tablet == nullptr) {
         LOG(WARNING) << "get tables failed. "
                      << "tablet_id: " << _push_req.tablet_id << ", schema_hash: " << _push_req.schema_hash;
@@ -151,8 +151,7 @@ OLAPStatus EngineBatchLoadTask::_push(const TPushReq& request, std::vector<TTabl
         return OLAP_ERR_CE_CMD_PARAMS_ERROR;
     }
 
-    TabletSharedPtr tablet =
-            StorageEngine::instance()->tablet_manager()->get_tablet(request.tablet_id, request.schema_hash);
+    TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(request.tablet_id);
     if (tablet == nullptr) {
         LOG(WARNING) << "false to find tablet. tablet=" << request.tablet_id << ", schema_hash=" << request.schema_hash;
         StarRocksMetrics::instance()->push_requests_fail_total.increment(1);
@@ -214,8 +213,7 @@ OLAPStatus EngineBatchLoadTask::_delete_data(const TPushReq& request, std::vecto
     }
 
     // 1. Get all tablets with same tablet_id
-    TabletSharedPtr tablet =
-            StorageEngine::instance()->tablet_manager()->get_tablet(request.tablet_id, request.schema_hash);
+    TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(request.tablet_id);
     if (tablet == nullptr) {
         LOG(WARNING) << "can't find tablet. tablet=" << request.tablet_id << ", schema_hash=" << request.schema_hash;
         return OLAP_ERR_TABLE_NOT_FOUND;

--- a/be/src/storage/task/engine_checksum_task.cpp
+++ b/be/src/storage/task/engine_checksum_task.cpp
@@ -51,7 +51,7 @@ OLAPStatus EngineChecksumTask::_compute_checksum() {
         return OLAP_ERR_CE_CMD_PARAMS_ERROR;
     }
 
-    TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(_tablet_id, _schema_hash);
+    TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(_tablet_id);
     if (nullptr == tablet.get()) {
         LOG(WARNING) << "can't find tablet. tablet_id=" << _tablet_id << " schema_hash=" << _schema_hash;
         return OLAP_ERR_TABLE_NOT_FOUND;

--- a/be/src/storage/task/engine_clone_task.cpp
+++ b/be/src/storage/task/engine_clone_task.cpp
@@ -216,8 +216,7 @@ void EngineCloneTask::_set_tablet_info(Status status, bool is_new_tablet) {
                              << ", schema_hash:" << _clone_req.schema_hash << ", signature:" << _signature
                              << ", version:" << tablet_info.version
                              << ", expected_version: " << _clone_req.committed_version;
-                Status drop_status = StorageEngine::instance()->tablet_manager()->drop_tablet(_clone_req.tablet_id,
-                                                                                              _clone_req.schema_hash);
+                Status drop_status = StorageEngine::instance()->tablet_manager()->drop_tablet(_clone_req.tablet_id);
                 if (!drop_status.ok() && !drop_status.is_not_found()) {
                     // just log
                     LOG(WARNING) << "Fail to drop stale cloned table. tablet id=" << _clone_req.tablet_id;

--- a/be/src/storage/task/engine_publish_version_task.cpp
+++ b/be/src/storage/task/engine_publish_version_task.cpp
@@ -78,8 +78,8 @@ OLAPStatus EnginePublishVersionTask::finish() {
                 res = OLAP_ERR_PUSH_ROWSET_NOT_FOUND;
                 continue;
             }
-            TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(
-                    tablet_info.tablet_id, tablet_info.schema_hash, tablet_info.tablet_uid);
+            TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_info.tablet_id,
+                                                                                             tablet_info.tablet_uid);
             if (tablet == nullptr) {
                 LOG(WARNING) << "can't get tablet when publish version. tablet_id=" << tablet_info.tablet_id
                              << " schema_hash=" << tablet_info.schema_hash;
@@ -132,8 +132,7 @@ OLAPStatus EnginePublishVersionTask::finish() {
             if (!_publish_version_req.strict_mode) {
                 break;
             }
-            TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_info.tablet_id,
-                                                                                             tablet_info.schema_hash);
+            TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_info.tablet_id);
             if (tablet == nullptr) {
                 _error_tablet_ids->push_back(tablet_info.tablet_id);
             } else {

--- a/be/src/storage/task/engine_storage_migration_task.cpp
+++ b/be/src/storage/task/engine_storage_migration_task.cpp
@@ -34,7 +34,7 @@ EngineStorageMigrationTask::EngineStorageMigrationTask(TTabletId tablet_id, TSch
 OLAPStatus EngineStorageMigrationTask::execute() {
     StarRocksMetrics::instance()->storage_migrate_requests_total.increment(1);
 
-    TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(_tablet_id, _schema_hash);
+    TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(_tablet_id);
     if (tablet == nullptr) {
         LOG(WARNING) << "failed to find tablet. tablet_id=" << _tablet_id << ", schema_hash=" << _schema_hash;
         return OLAP_ERR_TABLE_NOT_FOUND;
@@ -257,7 +257,7 @@ OLAPStatus EngineStorageMigrationTask::_storage_migrate(TabletSharedPtr tablet) 
 
         // if old tablet finished schema change, then the schema change status of the new tablet is DONE
         // else the schema change status of the new tablet is FAILED
-        TabletSharedPtr new_tablet = StorageEngine::instance()->tablet_manager()->get_tablet(_tablet_id, _schema_hash);
+        TabletSharedPtr new_tablet = StorageEngine::instance()->tablet_manager()->get_tablet(_tablet_id);
         if (new_tablet == nullptr) {
             // tablet already loaded success.
             // just log, and not set need_remove_new_path.

--- a/be/src/storage/vectorized/push_handler.cpp
+++ b/be/src/storage/vectorized/push_handler.cpp
@@ -312,7 +312,7 @@ Status PushHandler::_do_streaming_ingestion(TabletSharedPtr tablet, const TPushR
                           << ", related_schema_hash=" << related_schema_hash
                           << ", transaction_id=" << request.transaction_id;
                 TabletSharedPtr related_tablet =
-                        StorageEngine::instance()->tablet_manager()->get_tablet(related_tablet_id, related_schema_hash);
+                        StorageEngine::instance()->tablet_manager()->get_tablet(related_tablet_id);
 
                 // if related tablet not exists, only push current tablet
                 if (related_tablet == nullptr) {

--- a/be/src/storage/vectorized/schema_change.cpp
+++ b/be/src/storage/vectorized/schema_change.cpp
@@ -877,8 +877,7 @@ Status SchemaChangeHandler::process_alter_tablet_v2(const TAlterTabletReqV2& req
 }
 
 Status SchemaChangeHandler::_do_process_alter_tablet_v2(const TAlterTabletReqV2& request) {
-    TabletSharedPtr base_tablet =
-            StorageEngine::instance()->tablet_manager()->get_tablet(request.base_tablet_id, request.base_schema_hash);
+    TabletSharedPtr base_tablet = StorageEngine::instance()->tablet_manager()->get_tablet(request.base_tablet_id);
     if (base_tablet == nullptr) {
         LOG(WARNING) << "fail to find base tablet. base_tablet=" << request.base_tablet_id
                      << ", base_schema_hash=" << request.base_schema_hash;
@@ -886,8 +885,7 @@ Status SchemaChangeHandler::_do_process_alter_tablet_v2(const TAlterTabletReqV2&
     }
 
     // new tablet has to exist
-    TabletSharedPtr new_tablet =
-            StorageEngine::instance()->tablet_manager()->get_tablet(request.new_tablet_id, request.new_schema_hash);
+    TabletSharedPtr new_tablet = StorageEngine::instance()->tablet_manager()->get_tablet(request.new_tablet_id);
     if (new_tablet == nullptr) {
         LOG(WARNING) << "fail to find new tablet."
                      << " new_tablet=" << request.new_tablet_id << ", new_schema_hash=" << request.new_schema_hash;

--- a/be/test/storage/delete_handler_test.cpp
+++ b/be/test/storage/delete_handler_test.cpp
@@ -250,16 +250,14 @@ protected:
         set_default_create_tablet_request(&_create_tablet);
         auto res = k_engine->create_tablet(_create_tablet);
         ASSERT_TRUE(res.ok()) << res.to_string();
-        tablet = k_engine->tablet_manager()->get_tablet(_create_tablet.tablet_id,
-                                                        _create_tablet.tablet_schema.schema_hash);
+        tablet = k_engine->tablet_manager()->get_tablet(_create_tablet.tablet_id);
         ASSERT_TRUE(tablet.get() != nullptr);
         _tablet_path = tablet->tablet_path();
 
         set_create_duplicate_tablet_request(&_create_dup_tablet);
         res = k_engine->create_tablet(_create_dup_tablet);
         ASSERT_TRUE(res.ok()) << res.to_string();
-        dup_tablet = k_engine->tablet_manager()->get_tablet(_create_dup_tablet.tablet_id,
-                                                            _create_dup_tablet.tablet_schema.schema_hash);
+        dup_tablet = k_engine->tablet_manager()->get_tablet(_create_dup_tablet.tablet_id);
         ASSERT_TRUE(dup_tablet.get() != nullptr);
         _dup_tablet_path = tablet->tablet_path();
     }
@@ -267,8 +265,7 @@ protected:
     void TearDown() {
         tablet.reset();
         dup_tablet.reset();
-        (void)StorageEngine::instance()->tablet_manager()->drop_tablet(_create_tablet.tablet_id,
-                                                                       _create_tablet.tablet_schema.schema_hash);
+        (void)StorageEngine::instance()->tablet_manager()->drop_tablet(_create_tablet.tablet_id);
         ASSERT_TRUE(FileUtils::remove_all(config::storage_root_path).ok());
     }
 
@@ -408,16 +405,14 @@ protected:
         set_default_create_tablet_request(&_create_tablet);
         auto res = k_engine->create_tablet(_create_tablet);
         ASSERT_TRUE(res.ok()) << res.to_string();
-        tablet = k_engine->tablet_manager()->get_tablet(_create_tablet.tablet_id,
-                                                        _create_tablet.tablet_schema.schema_hash);
+        tablet = k_engine->tablet_manager()->get_tablet(_create_tablet.tablet_id);
         ASSERT_TRUE(tablet.get() != nullptr);
         _tablet_path = tablet->tablet_path();
     }
 
     void TearDown() {
         tablet.reset();
-        (void)StorageEngine::instance()->tablet_manager()->drop_tablet(_create_tablet.tablet_id,
-                                                                       _create_tablet.tablet_schema.schema_hash);
+        (void)StorageEngine::instance()->tablet_manager()->drop_tablet(_create_tablet.tablet_id);
         ASSERT_TRUE(FileUtils::remove_all(config::storage_root_path).ok());
     }
 
@@ -737,8 +732,7 @@ protected:
         set_default_create_tablet_request(&_create_tablet);
         auto res = k_engine->create_tablet(_create_tablet);
         ASSERT_TRUE(res.ok()) << res.to_string();
-        tablet = k_engine->tablet_manager()->get_tablet(_create_tablet.tablet_id,
-                                                        _create_tablet.tablet_schema.schema_hash);
+        tablet = k_engine->tablet_manager()->get_tablet(_create_tablet.tablet_id);
         ASSERT_TRUE(tablet != nullptr);
         _tablet_path = tablet->tablet_path();
 
@@ -749,8 +743,7 @@ protected:
     void TearDown() {
         tablet.reset();
         _delete_handler.finalize();
-        (void)StorageEngine::instance()->tablet_manager()->drop_tablet(_create_tablet.tablet_id,
-                                                                       _create_tablet.tablet_schema.schema_hash);
+        (void)StorageEngine::instance()->tablet_manager()->drop_tablet(_create_tablet.tablet_id);
         ASSERT_TRUE(FileUtils::remove_all(config::storage_root_path).ok());
     }
 

--- a/be/test/storage/delta_writer_test.cpp
+++ b/be/test/storage/delta_writer_test.cpp
@@ -303,7 +303,7 @@ TEST_F(TestDeltaWriter, open) {
     TDropTabletReq drop_request;
     auto tablet_id = 10003;
     auto schema_hash = 270068375;
-    st = k_engine->tablet_manager()->drop_tablet(tablet_id, schema_hash);
+    st = k_engine->tablet_manager()->drop_tablet(tablet_id);
     ASSERT_TRUE(st.ok()) << st.to_string();
 }
 
@@ -393,7 +393,7 @@ TEST_F(TestDeltaWriter, write) {
     ASSERT_EQ(OLAP_SUCCESS, res);
 
     // publish version success
-    TabletSharedPtr tablet = k_engine->tablet_manager()->get_tablet(write_req.tablet_id, write_req.schema_hash);
+    TabletSharedPtr tablet = k_engine->tablet_manager()->get_tablet(write_req.tablet_id);
     std::cout << "before publish, tablet row nums:" << tablet->num_rows() << std::endl;
     KVStore* meta = tablet->data_dir()->get_meta();
     Version version;
@@ -418,7 +418,7 @@ TEST_F(TestDeltaWriter, write) {
     }
     ASSERT_EQ(1, tablet->num_rows());
 
-    st = k_engine->tablet_manager()->drop_tablet(write_req.tablet_id, write_req.schema_hash);
+    st = k_engine->tablet_manager()->drop_tablet(write_req.tablet_id);
     ASSERT_TRUE(st.ok()) << st.to_string();
     delete delta_writer;
 }

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -142,13 +142,11 @@ public:
 
     void TearDown() override {
         if (_tablet2) {
-            StorageEngine::instance()->tablet_manager()->drop_tablet(_tablet2->tablet_id(), _tablet2->schema_hash(),
-                                                                     false);
+            StorageEngine::instance()->tablet_manager()->drop_tablet(_tablet2->tablet_id(), false);
             _tablet2.reset();
         }
         if (_tablet) {
-            StorageEngine::instance()->tablet_manager()->drop_tablet(_tablet->tablet_id(), _tablet->schema_hash(),
-                                                                     false);
+            StorageEngine::instance()->tablet_manager()->drop_tablet(_tablet->tablet_id(), false);
             _tablet.reset();
         }
     }
@@ -768,8 +766,8 @@ TEST_F(TabletUpdatesTest, load_snapshot_incremental) {
 
     DeferOp defer([&]() {
         auto tablet_mgr = StorageEngine::instance()->tablet_manager();
-        (void)tablet_mgr->drop_tablet(tablet0->tablet_id(), tablet0->schema_hash());
-        (void)tablet_mgr->drop_tablet(tablet1->tablet_id(), tablet1->schema_hash());
+        (void)tablet_mgr->drop_tablet(tablet0->tablet_id());
+        (void)tablet_mgr->drop_tablet(tablet1->tablet_id());
         (void)FileUtils::remove_all(tablet0->tablet_path());
         (void)FileUtils::remove_all(tablet1->tablet_path());
     });

--- a/be/test/storage/update_manager_test.cpp
+++ b/be/test/storage/update_manager_test.cpp
@@ -94,7 +94,7 @@ public:
         request.tablet_schema.columns.push_back(k3);
         auto st = StorageEngine::instance()->create_tablet(request);
         ASSERT_TRUE(st.ok()) << st.to_string();
-        _tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, schema_hash);
+        _tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id);
         ASSERT_TRUE(_tablet);
     }
 
@@ -104,8 +104,7 @@ public:
         _meta.reset();
         FileUtils::remove_all(_root_path);
         if (_tablet) {
-            StorageEngine::instance()->tablet_manager()->drop_tablet(_tablet->tablet_id(), _tablet->schema_hash(),
-                                                                     false);
+            StorageEngine::instance()->tablet_manager()->drop_tablet(_tablet->tablet_id(), false);
             _tablet.reset();
         }
     }

--- a/be/test/storage/vectorized/rowset_merger_test.cpp
+++ b/be/test/storage/vectorized/rowset_merger_test.cpp
@@ -129,14 +129,13 @@ public:
         request.tablet_schema.columns.push_back(k3);
         auto st = StorageEngine::instance()->create_tablet(request);
         ASSERT_TRUE(st.ok()) << st.to_string();
-        _tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, schema_hash);
+        _tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id);
         ASSERT_TRUE(_tablet);
     }
 
     void TearDown() override {
         if (_tablet) {
-            StorageEngine::instance()->tablet_manager()->drop_tablet(_tablet->tablet_id(), _tablet->schema_hash(),
-                                                                     false);
+            StorageEngine::instance()->tablet_manager()->drop_tablet(_tablet->tablet_id(), false);
             _tablet.reset();
         }
     }

--- a/be/test/storage/vectorized/schema_change_test.cpp
+++ b/be/test/storage/vectorized/schema_change_test.cpp
@@ -54,8 +54,7 @@ class SchemaChangeTest : public testing::Test {
         AddColumn(&create_tablet_req, "v2", TPrimitiveType::INT, false);
         Status res = engine->create_tablet(create_tablet_req);
         ASSERT_TRUE(res.ok());
-        TabletSharedPtr tablet = engine->tablet_manager()->get_tablet(create_tablet_req.tablet_id,
-                                                                      create_tablet_req.tablet_schema.schema_hash);
+        TabletSharedPtr tablet = engine->tablet_manager()->get_tablet(create_tablet_req.tablet_id);
         vectorized::Schema base_schema = ChunkHelper::convert_schema_to_format_v2(tablet->tablet_schema());
         ChunkPtr base_chunk = ChunkHelper::new_chunk(base_schema, config::vector_chunk_size);
         for (size_t i = 0; i < 4; ++i) {
@@ -434,9 +433,8 @@ TEST_F(SchemaChangeTest, schema_change_directly) {
     AddColumn(&create_tablet_req, "v2", TPrimitiveType::VARCHAR, false);
     Status res = engine->create_tablet(create_tablet_req);
     ASSERT_TRUE(res.ok()) << res.to_string();
-    TabletSharedPtr new_tablet = engine->tablet_manager()->get_tablet(create_tablet_req.tablet_id,
-                                                                      create_tablet_req.tablet_schema.schema_hash);
-    TabletSharedPtr base_tablet = engine->tablet_manager()->get_tablet(1001, 270068375);
+    TabletSharedPtr new_tablet = engine->tablet_manager()->get_tablet(create_tablet_req.tablet_id);
+    TabletSharedPtr base_tablet = engine->tablet_manager()->get_tablet(1001);
 
     ChunkChanger chunk_changer(new_tablet->tablet_schema());
     for (size_t i = 0; i < 4; ++i) {
@@ -474,8 +472,8 @@ TEST_F(SchemaChangeTest, schema_change_directly) {
 
     ASSERT_TRUE(_sc_procedure->process(tablet_rowset_reader, rowset_writer.get(), new_tablet, base_tablet, rowset));
     delete tablet_rowset_reader;
-    (void)StorageEngine::instance()->tablet_manager()->drop_tablet(1001, 270068375);
-    (void)StorageEngine::instance()->tablet_manager()->drop_tablet(1002, 270068375);
+    (void)StorageEngine::instance()->tablet_manager()->drop_tablet(1001);
+    (void)StorageEngine::instance()->tablet_manager()->drop_tablet(1002);
 }
 
 TEST_F(SchemaChangeTest, schema_change_with_sorting) {
@@ -489,9 +487,8 @@ TEST_F(SchemaChangeTest, schema_change_with_sorting) {
     AddColumn(&create_tablet_req, "v2", TPrimitiveType::VARCHAR, false);
     Status res = engine->create_tablet(create_tablet_req);
     ASSERT_TRUE(res.ok()) << res.to_string();
-    TabletSharedPtr new_tablet = engine->tablet_manager()->get_tablet(create_tablet_req.tablet_id,
-                                                                      create_tablet_req.tablet_schema.schema_hash);
-    TabletSharedPtr base_tablet = engine->tablet_manager()->get_tablet(1001, 270068375);
+    TabletSharedPtr new_tablet = engine->tablet_manager()->get_tablet(create_tablet_req.tablet_id);
+    TabletSharedPtr base_tablet = engine->tablet_manager()->get_tablet(1001);
 
     ChunkChanger chunk_changer(new_tablet->tablet_schema());
     ColumnMapping* column_mapping = chunk_changer.get_mutable_column_mapping(0);
@@ -534,8 +531,8 @@ TEST_F(SchemaChangeTest, schema_change_with_sorting) {
 
     ASSERT_TRUE(_sc_procedure->process(tablet_rowset_reader, rowset_writer.get(), new_tablet, base_tablet, rowset));
     delete tablet_rowset_reader;
-    (void)StorageEngine::instance()->tablet_manager()->drop_tablet(1001, 270068375);
-    (void)StorageEngine::instance()->tablet_manager()->drop_tablet(1002, 270068375);
+    (void)StorageEngine::instance()->tablet_manager()->drop_tablet(1001);
+    (void)StorageEngine::instance()->tablet_manager()->drop_tablet(1002);
 }
 
 } // namespace starrocks::vectorized


### PR DESCRIPTION
Close issue #915

It's impossible to have two tablets with the same tablet id but a different schema hash in StarRocks, so there is no need to check the schema hash.

Removing checks for schema hash can simplify the logic and reduce some memory usage.