### PR TITLE
Fix thrift proto compatibility bug

### DIFF
--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -921,10 +921,12 @@ service FrontendService {
     MasterService.TMasterResult finishTask(1:MasterService.TFinishTaskRequest request)
     MasterService.TMasterResult report(1:MasterService.TReportRequest request)
     MasterService.TFetchResourceResult fetchResource()
-    
-    TFeResult isMethodSupported(1: TIsMethodSupportedRequest request)
 
-    TMasterOpResult forward(1: TMasterOpRequest params)
+    //NOTE: Do not add numbers to the parameters, otherwise it will cause compatibility problems
+    TFeResult isMethodSupported(TIsMethodSupportedRequest request)
+
+    //NOTE: Do not add numbers to the parameters, otherwise it will cause compatibility problems
+    TMasterOpResult forward(TMasterOpRequest params)
 
     TListTableStatusResult listTableStatus(1:TGetTablesParams params)
 


### PR DESCRIPTION
Before 1.19 version, the functions FrontendService.isMethodSupported and FrontendService.forward had no parameter number. If the new and old versions of fe are running at the same time, there will be compatibility problems. Remove the parameter number of FrontendService.isMethodSupported and FrontendService.forward.