### PR TITLE
remove mem tracker for expr

### DIFF
--- a/be/src/exec/data_sink.cpp
+++ b/be/src/exec/data_sink.cpp
@@ -130,7 +130,6 @@ Status DataSink::init(const TDataSink& thrift_sink) {
 }
 
 Status DataSink::prepare(RuntimeState* state) {
-    _expr_mem_tracker = std::make_unique<MemTracker>(-1, "Data sink", state->instance_mem_tracker());
     return Status::OK();
 }
 

--- a/be/src/exec/data_sink.h
+++ b/be/src/exec/data_sink.h
@@ -64,7 +64,6 @@ public:
     // It must be okay to call this multiple times. Subsequent calls should
     // be ignored.
     virtual Status close(RuntimeState* state, Status exec_status) {
-        _expr_mem_tracker->close();
         _closed = true;
         return Status::OK();
     }
@@ -86,7 +85,6 @@ protected:
     // Set to true after close() has been called. subclasses should check and set this in
     // close().
     bool _closed{false};
-    std::unique_ptr<MemTracker> _expr_mem_tracker;
 
     // Maybe this will be transferred to BufferControlBlock.
     std::shared_ptr<QueryStatistics> _query_statistics;

--- a/be/src/exec/exchange_node.cpp
+++ b/be/src/exec/exchange_node.cpp
@@ -76,8 +76,7 @@ Status ExchangeNode::prepare(RuntimeState* state) {
             state, _input_row_desc, state->fragment_instance_id(), _id, _num_senders,
             config::exchg_node_buffer_size_bytes, _runtime_profile, _is_merging, _sub_plan_query_statistics_recvr);
     if (_is_merging) {
-        RETURN_IF_ERROR(_sort_exec_exprs.prepare(state, _row_descriptor, _row_descriptor, expr_mem_tracker()));
-        // AddExprCtxsToFree(_sort_exec_exprs);
+        RETURN_IF_ERROR(_sort_exec_exprs.prepare(state, _row_descriptor, _row_descriptor));
     }
     return Status::OK();
 }

--- a/be/src/exec/exec_node.h
+++ b/be/src/exec/exec_node.h
@@ -210,10 +210,6 @@ public:
 
     MemTracker* mem_tracker() const { return _mem_tracker.get(); }
 
-    MemTracker* expr_mem_tracker() const { return _expr_mem_tracker.get(); }
-
-    MemPool* expr_mem_pool() { return _expr_mem_pool.get(); }
-
     bool use_vectorized() { return _use_vectorized; }
 
     vectorized::RuntimeFilterProbeCollector& runtime_filter_collector() { return _runtime_filter_collector; }
@@ -298,13 +294,6 @@ protected:
 
     /// Account for peak memory used by this node
     std::shared_ptr<MemTracker> _mem_tracker;
-
-    /// MemTracker used by 'expr_mem_pool_'.
-    std::shared_ptr<MemTracker> _expr_mem_tracker;
-
-    /// MemPool for allocating data structures used by expression evaluators in this node.
-    /// Created in Prepare().
-    std::shared_ptr<MemPool> _expr_mem_pool;
 
     RuntimeProfile::Counter* _rows_returned_counter;
     RuntimeProfile::Counter* _rows_returned_rate;

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.cpp
@@ -8,8 +8,7 @@ Status AggregateBlockingSinkOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(Operator::prepare(state));
     // _aggregator is shared by sink operator and source operator
     // we must only prepare it at sink operator
-    RETURN_IF_ERROR(
-            _aggregator->prepare(state, state->obj_pool(), get_memtracker(), get_memtracker(), get_runtime_profile()));
+    RETURN_IF_ERROR(_aggregator->prepare(state, state->obj_pool(), get_memtracker(), get_runtime_profile()));
     return _aggregator->open(state);
 }
 

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.cpp
@@ -8,8 +8,7 @@ Status AggregateDistinctBlockingSinkOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(Operator::prepare(state));
     // _aggregator is shared by sink operator and source operator
     // we must only prepare it at sink operator
-    RETURN_IF_ERROR(
-            _aggregator->prepare(state, state->obj_pool(), get_memtracker(), get_memtracker(), get_runtime_profile()));
+    RETURN_IF_ERROR(_aggregator->prepare(state, state->obj_pool(), get_memtracker(), get_runtime_profile()));
     return _aggregator->open(state);
 }
 

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.cpp
@@ -9,8 +9,7 @@ Status AggregateDistinctStreamingSinkOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(Operator::prepare(state));
     // _aggregator is shared by sink operator and source operator
     // we must only prepare it at sink operator
-    RETURN_IF_ERROR(
-            _aggregator->prepare(state, state->obj_pool(), get_memtracker(), get_memtracker(), get_runtime_profile()));
+    RETURN_IF_ERROR(_aggregator->prepare(state, state->obj_pool(), get_memtracker(), get_runtime_profile()));
     return _aggregator->open(state);
 }
 

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
@@ -9,8 +9,7 @@ Status AggregateStreamingSinkOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(Operator::prepare(state));
     // _aggregator is shared by sink operator and source operator
     // we must only prepare it at sink operator
-    RETURN_IF_ERROR(
-            _aggregator->prepare(state, state->obj_pool(), get_memtracker(), get_memtracker(), get_runtime_profile()));
+    RETURN_IF_ERROR(_aggregator->prepare(state, state->obj_pool(), get_memtracker(), get_runtime_profile()));
     return _aggregator->open(state);
 }
 

--- a/be/src/exec/pipeline/analysis/analytic_sink_operator.cpp
+++ b/be/src/exec/pipeline/analysis/analytic_sink_operator.cpp
@@ -10,8 +10,7 @@ Status AnalyticSinkOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(Operator::prepare(state));
     // _analytor is shared by sink operator and source operator
     // we must only prepare it at sink operator
-    RETURN_IF_ERROR(
-            _analytor->prepare(state, state->obj_pool(), get_memtracker(), get_memtracker(), get_runtime_profile()));
+    RETURN_IF_ERROR(_analytor->prepare(state, state->obj_pool(), get_memtracker(), get_runtime_profile()));
     RETURN_IF_ERROR(_analytor->open(state));
 
     TAnalyticWindow window = _tnode.analytic_node.window;

--- a/be/src/exec/pipeline/assert_num_rows_operator.cpp
+++ b/be/src/exec/pipeline/assert_num_rows_operator.cpp
@@ -56,7 +56,7 @@ bool AssertNumRowsOperator::is_finished() const {
     return _is_finished && !_cur_chunk;
 }
 
-Status AssertNumRowsOperatorFactory::prepare(RuntimeState* state, MemTracker* mem_tracker) {
+Status AssertNumRowsOperatorFactory::prepare(RuntimeState* state) {
     return Status::OK();
 }
 

--- a/be/src/exec/pipeline/assert_num_rows_operator.h
+++ b/be/src/exec/pipeline/assert_num_rows_operator.h
@@ -70,7 +70,7 @@ public:
                                                        _assertion);
     }
 
-    Status prepare(RuntimeState* state, MemTracker* mem_tracker) override;
+    Status prepare(RuntimeState* state) override;
     void close(RuntimeState* state) override;
 
 private:

--- a/be/src/exec/pipeline/crossjoin/cross_join_left_operator.cpp
+++ b/be/src/exec/pipeline/crossjoin/cross_join_left_operator.cpp
@@ -415,10 +415,10 @@ void CrossJoinLeftOperatorFactory::_init_row_desc() {
     }
 }
 
-Status CrossJoinLeftOperatorFactory::prepare(RuntimeState* state, MemTracker* mem_tracker) {
+Status CrossJoinLeftOperatorFactory::prepare(RuntimeState* state) {
     _init_row_desc();
     RowDescriptor row_desc;
-    RETURN_IF_ERROR(Expr::prepare(_conjunct_ctxs, state, row_desc, mem_tracker));
+    RETURN_IF_ERROR(Expr::prepare(_conjunct_ctxs, state, row_desc));
     RETURN_IF_ERROR(Expr::open(_conjunct_ctxs, state));
     return Status::OK();
 }

--- a/be/src/exec/pipeline/crossjoin/cross_join_left_operator.h
+++ b/be/src/exec/pipeline/crossjoin/cross_join_left_operator.h
@@ -134,7 +134,7 @@ public:
                                                        _probe_column_count, _build_column_count, _cross_join_context);
     }
 
-    Status prepare(RuntimeState* state, MemTracker* mem_tracker) override;
+    Status prepare(RuntimeState* state) override;
     void close(RuntimeState* state) override;
 
 private:

--- a/be/src/exec/pipeline/crossjoin/cross_join_right_sink_operator.cpp
+++ b/be/src/exec/pipeline/crossjoin/cross_join_right_sink_operator.cpp
@@ -54,7 +54,7 @@ void CrossJoinRightSinkOperator::finish(RuntimeState* state) {
     }
 }
 
-Status CrossJoinRightSinkOperatorFactory::prepare(RuntimeState* state, MemTracker* mem_tracker) {
+Status CrossJoinRightSinkOperatorFactory::prepare(RuntimeState* state) {
     return Status::OK();
 }
 

--- a/be/src/exec/pipeline/crossjoin/cross_join_right_sink_operator.h
+++ b/be/src/exec/pipeline/crossjoin/cross_join_right_sink_operator.h
@@ -53,7 +53,7 @@ public:
         return ope;
     }
 
-    Status prepare(RuntimeState* state, MemTracker* mem_tracker) override;
+    Status prepare(RuntimeState* state) override;
     void close(RuntimeState* state) override;
 
 private:

--- a/be/src/exec/pipeline/exchange/exchange_merge_sort_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_merge_sort_source_operator.cpp
@@ -126,8 +126,8 @@ Status ExchangeMergeSortSourceOperator::get_next_merging(RuntimeState* state, Ch
     return Status::OK();
 }
 
-Status ExchangeMergeSortSourceOperatorFactory::prepare(RuntimeState* state, MemTracker* mem_tracker) {
-    RETURN_IF_ERROR(_sort_exec_exprs->prepare(state, _row_desc, _row_desc, mem_tracker));
+Status ExchangeMergeSortSourceOperatorFactory::prepare(RuntimeState* state) {
+    RETURN_IF_ERROR(_sort_exec_exprs->prepare(state, _row_desc, _row_desc));
     RETURN_IF_ERROR(_sort_exec_exprs->open(state));
     return Status::OK();
 }

--- a/be/src/exec/pipeline/exchange/exchange_merge_sort_source_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_merge_sort_source_operator.h
@@ -81,7 +81,7 @@ public:
                                                                  _limit);
     }
 
-    Status prepare(RuntimeState* state, MemTracker* mem_tracker) override;
+    Status prepare(RuntimeState* state) override;
     void close(RuntimeState* state) override;
 
 private:

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -481,11 +481,11 @@ OperatorPtr ExchangeSinkOperatorFactory::create(int32_t degree_of_parallelism, i
     }
 }
 
-Status ExchangeSinkOperatorFactory::prepare(RuntimeState* state, MemTracker* mem_tracker) {
+Status ExchangeSinkOperatorFactory::prepare(RuntimeState* state) {
     if (_part_type == TPartitionType::HASH_PARTITIONED ||
         _part_type == TPartitionType::BUCKET_SHFFULE_HASH_PARTITIONED) {
         RowDescriptor row_desc;
-        RETURN_IF_ERROR(Expr::prepare(_partition_expr_ctxs, state, row_desc, mem_tracker));
+        RETURN_IF_ERROR(Expr::prepare(_partition_expr_ctxs, state, row_desc));
         RETURN_IF_ERROR(Expr::open(_partition_expr_ctxs, state));
     }
     return Status::OK();

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.h
@@ -148,7 +148,7 @@ public:
 
     OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override;
 
-    Status prepare(RuntimeState* state, MemTracker* mem_tracker) override;
+    Status prepare(RuntimeState* state) override;
 
     void close(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/fragment_context.h
+++ b/be/src/exec/pipeline/fragment_context.h
@@ -41,8 +41,6 @@ public:
     void set_fe_addr(const TNetworkAddress& fe_addr) { _fe_addr = fe_addr; }
     const TNetworkAddress& fe_addr() { return _fe_addr; }
     FragmentFuture finish_future() { return _finish_promise.get_future(); }
-    MemTracker* mem_tracker() const { return _mem_tracker.get(); }
-    void set_mem_tracker(std::unique_ptr<MemTracker> mem_tracker) { _mem_tracker = std::move(mem_tracker); }
     RuntimeState* runtime_state() const { return _runtime_state.get(); }
     void set_runtime_state(std::shared_ptr<RuntimeState>&& runtime_state) { _runtime_state = std::move(runtime_state); }
     ExecNode* plan() const { return _plan; }
@@ -90,7 +88,7 @@ public:
 
     Status prepare_all_pipelines() {
         for (auto& pipe : _pipelines) {
-            RETURN_IF_ERROR(pipe->prepare(_runtime_state.get(), _mem_tracker.get()));
+            RETURN_IF_ERROR(pipe->prepare(_runtime_state.get()));
         }
         return Status::OK();
     }
@@ -111,9 +109,8 @@ private:
     // promise used to determine whether fragment finished its execution
     FragmentPromise _finish_promise;
 
-    // never adjust the order of _mem_tracker, _runtime_state, _plan, _pipelines and _drivers, since
-    // _plan depends on _runtime_state and _drivers depends on _mem_tracker and _runtime_state.
-    std::unique_ptr<MemTracker> _mem_tracker = nullptr;
+    // never adjust the order of _runtime_state, _plan, _pipelines and _drivers, since
+    // _plan depends on _runtime_state and _drivers depends on _runtime_state.
     std::shared_ptr<RuntimeState> _runtime_state = nullptr;
     ExecNode* _plan = nullptr; // lives in _runtime_state->obj_pool()
     Pipelines _pipelines;

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -79,16 +79,9 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
             std::make_unique<RuntimeState>(query_id, fragment_instance_id, query_options, query_globals, exec_env));
     auto* runtime_state = _fragment_ctx->runtime_state();
 
-    int64_t bytes_limit = query_options.mem_limit;
-    // NOTE: this MemTracker only for olap
-    _fragment_ctx->set_mem_tracker(
-            std::make_unique<MemTracker>(bytes_limit, "fragment mem-limit", exec_env->query_pool_mem_tracker(), true));
-
     runtime_state->set_batch_size(config::vector_chunk_size);
     RETURN_IF_ERROR(runtime_state->init_mem_trackers(query_id));
     runtime_state->set_be_number(backend_num);
-
-    LOG(INFO) << "Using query memory limit: " << PrettyPrinter::print(bytes_limit, TUnit::BYTES);
 
     // Set up desc tbl
     auto* obj_pool = runtime_state->obj_pool();

--- a/be/src/exec/pipeline/operator.h
+++ b/be/src/exec/pipeline/operator.h
@@ -79,7 +79,7 @@ public:
     virtual OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) = 0;
     virtual bool is_source() const { return false; }
     int32_t plan_node_id() const { return _plan_node_id; }
-    virtual Status prepare(RuntimeState* state, MemTracker* mem_tracker) { return Status::OK(); }
+    virtual Status prepare(RuntimeState* state) { return Status::OK(); }
     virtual void close(RuntimeState* state) {}
     std::string get_name() const { return _name + "_" + std::to_string(_id); }
 

--- a/be/src/exec/pipeline/pipeline.h
+++ b/be/src/exec/pipeline/pipeline.h
@@ -37,9 +37,9 @@ public:
         return down_cast<SourceOperatorFactory*>(_op_factories[0].get());
     }
 
-    Status prepare(RuntimeState* state, MemTracker* mem_tracker) {
+    Status prepare(RuntimeState* state) {
         for (auto& op : _op_factories) {
-            RETURN_IF_ERROR(op->prepare(state, mem_tracker));
+            RETURN_IF_ERROR(op->prepare(state));
         }
         return Status::OK();
     }

--- a/be/src/exec/pipeline/project_operator.cpp
+++ b/be/src/exec/pipeline/project_operator.cpp
@@ -65,10 +65,10 @@ Status ProjectOperator::push_chunk(RuntimeState* state, const vectorized::ChunkP
     return Status::OK();
 }
 
-Status ProjectOperatorFactory::prepare(RuntimeState* state, MemTracker* mem_tracker) {
+Status ProjectOperatorFactory::prepare(RuntimeState* state) {
     RowDescriptor row_desc;
-    RETURN_IF_ERROR(Expr::prepare(_expr_ctxs, state, row_desc, mem_tracker));
-    RETURN_IF_ERROR(Expr::prepare(_common_sub_expr_ctxs, state, row_desc, mem_tracker));
+    RETURN_IF_ERROR(Expr::prepare(_expr_ctxs, state, row_desc));
+    RETURN_IF_ERROR(Expr::prepare(_common_sub_expr_ctxs, state, row_desc));
 
     RETURN_IF_ERROR(Expr::open(_expr_ctxs, state));
     RETURN_IF_ERROR(Expr::open(_common_sub_expr_ctxs, state));

--- a/be/src/exec/pipeline/project_operator.h
+++ b/be/src/exec/pipeline/project_operator.h
@@ -70,7 +70,7 @@ public:
                                                  _common_sub_column_ids, _common_sub_expr_ctxs);
     }
 
-    Status prepare(RuntimeState* state, MemTracker* mem_tracker);
+    Status prepare(RuntimeState* state);
     void close(RuntimeState* state);
 
 private:

--- a/be/src/exec/pipeline/result_sink_operator.cpp
+++ b/be/src/exec/pipeline/result_sink_operator.cpp
@@ -90,10 +90,10 @@ Status ResultSinkOperator::push_chunk(RuntimeState* state, const vectorized::Chu
         return status.status();
     }
 }
-Status ResultSinkOperatorFactory::prepare(RuntimeState* state, MemTracker* mem_tracker) {
+Status ResultSinkOperatorFactory::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(Expr::create_expr_trees(state->obj_pool(), _t_output_expr, &_output_expr_ctxs));
     RowDescriptor row_desc;
-    RETURN_IF_ERROR(Expr::prepare(_output_expr_ctxs, state, row_desc, mem_tracker));
+    RETURN_IF_ERROR(Expr::prepare(_output_expr_ctxs, state, row_desc));
     return Status::OK();
 }
 

--- a/be/src/exec/pipeline/result_sink_operator.h
+++ b/be/src/exec/pipeline/result_sink_operator.h
@@ -64,7 +64,7 @@ public:
         return std::make_shared<ResultSinkOperator>(_id, _plan_node_id, _sink_type, _output_expr_ctxs);
     }
 
-    Status prepare(RuntimeState* state, MemTracker* mem_tracker) override;
+    Status prepare(RuntimeState* state) override;
 
     void close(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan_operator.cpp
@@ -182,9 +182,9 @@ StatusOr<vectorized::ChunkPtr> ScanOperator::pull_chunk(RuntimeState* state) {
     }
 }
 
-Status ScanOperatorFactory::prepare(RuntimeState* state, MemTracker* mem_tracker) {
+Status ScanOperatorFactory::prepare(RuntimeState* state) {
     RowDescriptor row_desc;
-    RETURN_IF_ERROR(Expr::prepare(_conjunct_ctxs, state, row_desc, mem_tracker));
+    RETURN_IF_ERROR(Expr::prepare(_conjunct_ctxs, state, row_desc));
     RETURN_IF_ERROR(Expr::open(_conjunct_ctxs, state));
     return Status::OK();
 }

--- a/be/src/exec/pipeline/scan_operator.h
+++ b/be/src/exec/pipeline/scan_operator.h
@@ -76,7 +76,7 @@ public:
     // ScanOperator needs to attach MorselQueue.
     bool with_morsels() const override { return true; }
 
-    Status prepare(RuntimeState* state, MemTracker* mem_tracker) override;
+    Status prepare(RuntimeState* state) override;
     void close(RuntimeState* state) override;
 
 private:

--- a/be/src/exec/pipeline/select_operator.cpp
+++ b/be/src/exec/pipeline/select_operator.cpp
@@ -80,9 +80,9 @@ Status SelectOperator::push_chunk(RuntimeState* state, const vectorized::ChunkPt
     return Status::OK();
 }
 
-Status SelectOperatorFactory::prepare(RuntimeState* state, MemTracker* mem_tracker) {
+Status SelectOperatorFactory::prepare(RuntimeState* state) {
     RowDescriptor row_desc;
-    RETURN_IF_ERROR(Expr::prepare(_conjunct_ctxs, state, row_desc, mem_tracker));
+    RETURN_IF_ERROR(Expr::prepare(_conjunct_ctxs, state, row_desc));
     RETURN_IF_ERROR(Expr::open(_conjunct_ctxs, state));
     return Status::OK();
 }

--- a/be/src/exec/pipeline/select_operator.h
+++ b/be/src/exec/pipeline/select_operator.h
@@ -50,7 +50,7 @@ public:
         return std::make_shared<SelectOperator>(_id, _plan_node_id, _conjunct_ctxs);
     }
 
-    Status prepare(RuntimeState* state, MemTracker* mem_tracker) override;
+    Status prepare(RuntimeState* state) override;
     void close(RuntimeState* state) override;
 
 private:

--- a/be/src/exec/pipeline/set/union_const_source_operator.cpp
+++ b/be/src/exec/pipeline/set/union_const_source_operator.cpp
@@ -44,12 +44,12 @@ StatusOr<vectorized::ChunkPtr> UnionConstSourceOperator::pull_chunk(starrocks::R
     return std::move(chunk);
 }
 
-Status UnionConstSourceOperatorFactory::prepare(RuntimeState* state, MemTracker* mem_tracker) {
-    RETURN_IF_ERROR(OperatorFactory::prepare(state, mem_tracker));
+Status UnionConstSourceOperatorFactory::prepare(RuntimeState* state) {
+    RETURN_IF_ERROR(OperatorFactory::prepare(state));
 
     RowDescriptor row_desc;
     for (const vector<ExprContext*>& exprs : _const_expr_lists) {
-        RETURN_IF_ERROR(Expr::prepare(exprs, state, row_desc, mem_tracker));
+        RETURN_IF_ERROR(Expr::prepare(exprs, state, row_desc));
     }
 
     for (const vector<ExprContext*>& exprs : _const_expr_lists) {

--- a/be/src/exec/pipeline/set/union_const_source_operator.h
+++ b/be/src/exec/pipeline/set/union_const_source_operator.h
@@ -72,7 +72,7 @@ public:
                                                           _const_expr_lists.data() + rows_offset, rows_count);
     }
 
-    Status prepare(RuntimeState* state, MemTracker* mem_tracker) override;
+    Status prepare(RuntimeState* state) override;
     void close(RuntimeState* state) override;
 
 private:

--- a/be/src/exec/pipeline/sort/sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/sort_sink_operator.cpp
@@ -100,8 +100,8 @@ void SortSinkOperator::finish(RuntimeState* state) {
     _is_finished = true;
 }
 
-Status SortSinkOperatorFactory::prepare(RuntimeState* state, MemTracker* mem_tracker) {
-    RETURN_IF_ERROR(_sort_exec_exprs.prepare(state, _parent_node_row_desc, _parent_node_child_row_desc, mem_tracker));
+Status SortSinkOperatorFactory::prepare(RuntimeState* state) {
+    RETURN_IF_ERROR(_sort_exec_exprs.prepare(state, _parent_node_row_desc, _parent_node_child_row_desc));
     RETURN_IF_ERROR(_sort_exec_exprs.open(state));
     return Status::OK();
 }

--- a/be/src/exec/pipeline/sort/sort_sink_operator.h
+++ b/be/src/exec/pipeline/sort/sort_sink_operator.h
@@ -98,7 +98,7 @@ public:
         return ope;
     }
 
-    Status prepare(RuntimeState* state, MemTracker* mem_tracker) override;
+    Status prepare(RuntimeState* state) override;
     void close(RuntimeState* state) override;
 
 private:

--- a/be/src/exec/sort_exec_exprs.cpp
+++ b/be/src/exec/sort_exec_exprs.cpp
@@ -52,11 +52,11 @@ Status SortExecExprs::init(const std::vector<ExprContext*>& lhs_ordering_expr_ct
 }
 
 Status SortExecExprs::prepare(RuntimeState* state, const RowDescriptor& child_row_desc,
-                              const RowDescriptor& output_row_desc, MemTracker* expr_mem_tracker) {
+                              const RowDescriptor& output_row_desc) {
     if (_materialize_tuple) {
-        RETURN_IF_ERROR(Expr::prepare(_sort_tuple_slot_expr_ctxs, state, child_row_desc, expr_mem_tracker));
+        RETURN_IF_ERROR(Expr::prepare(_sort_tuple_slot_expr_ctxs, state, child_row_desc));
     }
-    RETURN_IF_ERROR(Expr::prepare(_lhs_ordering_expr_ctxs, state, output_row_desc, expr_mem_tracker));
+    RETURN_IF_ERROR(Expr::prepare(_lhs_ordering_expr_ctxs, state, output_row_desc));
     return Status::OK();
 }
 

--- a/be/src/exec/sort_exec_exprs.h
+++ b/be/src/exec/sort_exec_exprs.h
@@ -52,8 +52,7 @@ public:
                 ObjectPool* pool);
 
     // prepare all expressions used for sorting and tuple materialization.
-    Status prepare(RuntimeState* state, const RowDescriptor& child_row_desc, const RowDescriptor& output_row_desc,
-                   MemTracker* mem_tracker);
+    Status prepare(RuntimeState* state, const RowDescriptor& child_row_desc, const RowDescriptor& output_row_desc);
 
     // open all expressions used for sorting and tuple materialization.
     Status open(RuntimeState* state);

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -526,7 +526,7 @@ Status OlapTableSink::prepare(RuntimeState* state) {
     SCOPED_TIMER(_profile->total_time_counter());
 
     // Prepare the exprs to run.
-    RETURN_IF_ERROR(Expr::prepare(_output_expr_ctxs, state, _input_row_desc, _expr_mem_tracker.get()));
+    RETURN_IF_ERROR(Expr::prepare(_output_expr_ctxs, state, _input_row_desc));
 
     // get table's tuple descriptor
     _output_tuple_desc = state->desc_tbl().get_tuple_descriptor(_tuple_desc_id);

--- a/be/src/exec/vectorized/aggregate/aggregate_base_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_base_node.cpp
@@ -15,7 +15,7 @@ AggregateBaseNode::~AggregateBaseNode() = default;
 Status AggregateBaseNode::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(ExecNode::prepare(state));
     _aggregator = std::make_shared<Aggregator>(_tnode);
-    return _aggregator->prepare(state, _pool, mem_tracker(), expr_mem_tracker(), runtime_profile());
+    return _aggregator->prepare(state, _pool, mem_tracker(), runtime_profile());
 }
 
 Status AggregateBaseNode::close(RuntimeState* state) {

--- a/be/src/exec/vectorized/aggregator.cpp
+++ b/be/src/exec/vectorized/aggregator.cpp
@@ -17,7 +17,8 @@ Status Aggregator::open(RuntimeState* state) {
     return Status::OK();
 }
 
-Status Aggregator::prepare(RuntimeState* state, ObjectPool* pool, MemTracker* mem_tracker, RuntimeProfile* runtime_profile) {
+Status Aggregator::prepare(RuntimeState* state, ObjectPool* pool, MemTracker* mem_tracker,
+                           RuntimeProfile* runtime_profile) {
     _pool = pool;
     _mem_tracker = mem_tracker;
     _runtime_profile = runtime_profile;

--- a/be/src/exec/vectorized/aggregator.cpp
+++ b/be/src/exec/vectorized/aggregator.cpp
@@ -17,8 +17,7 @@ Status Aggregator::open(RuntimeState* state) {
     return Status::OK();
 }
 
-Status Aggregator::prepare(RuntimeState* state, ObjectPool* pool, MemTracker* mem_tracker, MemTracker* expr_mem_tracker,
-                           RuntimeProfile* runtime_profile) {
+Status Aggregator::prepare(RuntimeState* state, ObjectPool* pool, MemTracker* mem_tracker, RuntimeProfile* runtime_profile) {
     _pool = pool;
     _mem_tracker = mem_tracker;
     _runtime_profile = runtime_profile;
@@ -175,10 +174,10 @@ Status Aggregator::prepare(RuntimeState* state, ObjectPool* pool, MemTracker* me
 
     // create an empty RowDescriptor, and it will be removed sooner or later
     RowDescriptor child_row_desc;
-    RETURN_IF_ERROR(Expr::prepare(_group_by_expr_ctxs, state, child_row_desc, expr_mem_tracker));
+    RETURN_IF_ERROR(Expr::prepare(_group_by_expr_ctxs, state, child_row_desc));
 
     for (const auto& ctx : _agg_expr_ctxs) {
-        RETURN_IF_ERROR(Expr::prepare(ctx, state, child_row_desc, expr_mem_tracker));
+        RETURN_IF_ERROR(Expr::prepare(ctx, state, child_row_desc));
     }
 
     _mem_pool = std::make_unique<MemPool>(_mem_tracker);

--- a/be/src/exec/vectorized/aggregator.h
+++ b/be/src/exec/vectorized/aggregator.h
@@ -63,8 +63,7 @@ public:
     ~Aggregator() = default;
 
     Status open(RuntimeState* state);
-    Status prepare(RuntimeState* state, ObjectPool* pool, MemTracker* mem_tracker, MemTracker* expr_mem_tracker,
-                   RuntimeProfile* runtime_profile);
+    Status prepare(RuntimeState* state, ObjectPool* pool, MemTracker* mem_tracker, RuntimeProfile* runtime_profile);
 
     Status close(RuntimeState* state);
 

--- a/be/src/exec/vectorized/analytic_node.cpp
+++ b/be/src/exec/vectorized/analytic_node.cpp
@@ -64,7 +64,7 @@ Status AnalyticNode::prepare(RuntimeState* state) {
     DCHECK(child(0)->row_desc().is_prefix_of(row_desc()));
 
     _analytor = std::make_shared<Analytor>(_tnode, child(0)->row_desc(), _result_tuple_desc);
-    RETURN_IF_ERROR(_analytor->prepare(state, _pool, mem_tracker(), expr_mem_tracker(), runtime_profile()));
+    RETURN_IF_ERROR(_analytor->prepare(state, _pool, mem_tracker(), runtime_profile()));
 
     return Status::OK();
 }

--- a/be/src/exec/vectorized/analytor.cpp
+++ b/be/src/exec/vectorized/analytor.cpp
@@ -80,7 +80,8 @@ Analytor::Analytor(const TPlanNode& tnode, const RowDescriptor& child_row_desc,
              << " _rows_end_offset " << _rows_end_offset;
 }
 
-Status Analytor::prepare(RuntimeState* state, ObjectPool* pool, MemTracker* mem_tracker, RuntimeProfile* runtime_profile) {
+Status Analytor::prepare(RuntimeState* state, ObjectPool* pool, MemTracker* mem_tracker,
+                         RuntimeProfile* runtime_profile) {
     _pool = pool;
     _mem_tracker = mem_tracker;
     _runtime_profile = runtime_profile;

--- a/be/src/exec/vectorized/analytor.cpp
+++ b/be/src/exec/vectorized/analytor.cpp
@@ -80,8 +80,7 @@ Analytor::Analytor(const TPlanNode& tnode, const RowDescriptor& child_row_desc,
              << " _rows_end_offset " << _rows_end_offset;
 }
 
-Status Analytor::prepare(RuntimeState* state, ObjectPool* pool, MemTracker* mem_tracker, MemTracker* expr_mem_tracker,
-                         RuntimeProfile* runtime_profile) {
+Status Analytor::prepare(RuntimeState* state, ObjectPool* pool, MemTracker* mem_tracker, RuntimeProfile* runtime_profile) {
     _pool = pool;
     _mem_tracker = mem_tracker;
     _runtime_profile = runtime_profile;
@@ -224,7 +223,7 @@ Status Analytor::prepare(RuntimeState* state, ObjectPool* pool, MemTracker* mem_
 
     SCOPED_TIMER(_compute_timer);
     for (const auto& ctx : _agg_expr_ctxs) {
-        Expr::prepare(ctx, state, _child_row_desc, expr_mem_tracker);
+        Expr::prepare(ctx, state, _child_row_desc);
     }
 
     if (!_partition_ctxs.empty() || !_order_ctxs.empty()) {
@@ -233,10 +232,10 @@ Status Analytor::prepare(RuntimeState* state, ObjectPool* pool, MemTracker* mem_
         tuple_ids.push_back(_buffered_tuple_id);
         RowDescriptor cmp_row_desc(state->desc_tbl(), tuple_ids, vector<bool>(2, false));
         if (!_partition_ctxs.empty()) {
-            RETURN_IF_ERROR(Expr::prepare(_partition_ctxs, state, cmp_row_desc, expr_mem_tracker));
+            RETURN_IF_ERROR(Expr::prepare(_partition_ctxs, state, cmp_row_desc));
         }
         if (!_order_ctxs.empty()) {
-            RETURN_IF_ERROR(Expr::prepare(_order_ctxs, state, cmp_row_desc, expr_mem_tracker));
+            RETURN_IF_ERROR(Expr::prepare(_order_ctxs, state, cmp_row_desc));
         }
     }
 

--- a/be/src/exec/vectorized/analytor.h
+++ b/be/src/exec/vectorized/analytor.h
@@ -38,8 +38,7 @@ public:
     ~Analytor() = default;
     Analytor(const TPlanNode& tnode, const RowDescriptor& child_row_desc, const TupleDescriptor* result_tuple_desc);
 
-    Status prepare(RuntimeState* state, ObjectPool* pool, MemTracker* mem_tracker, MemTracker* expr_mem_tracker,
-                   RuntimeProfile* runtime_profile);
+    Status prepare(RuntimeState* state, ObjectPool* pool, MemTracker* mem_tracker, RuntimeProfile* runtime_profile);
     Status open(RuntimeState* state);
     Status close(RuntimeState* state);
 

--- a/be/src/exec/vectorized/dict_decode_node.cpp
+++ b/be/src/exec/vectorized/dict_decode_node.cpp
@@ -45,7 +45,7 @@ void DictDecodeNode::_init_counter() {
 Status DictDecodeNode::prepare(RuntimeState* state) {
     SCOPED_TIMER(_runtime_profile->total_time_counter());
     RETURN_IF_ERROR(ExecNode::prepare(state));
-    RETURN_IF_ERROR(Expr::prepare(_expr_ctxs, state, row_desc(), expr_mem_tracker()));
+    RETURN_IF_ERROR(Expr::prepare(_expr_ctxs, state, row_desc()));
 
     const auto& global_dict = state->get_global_dict_map();
     _dict_optimize_parser.set_mutable_dict_maps(state->mutable_global_dict_map());

--- a/be/src/exec/vectorized/except_node.cpp
+++ b/be/src/exec/vectorized/except_node.cpp
@@ -40,7 +40,7 @@ Status ExceptNode::prepare(RuntimeState* state) {
     _get_result_timer = ADD_TIMER(runtime_profile(), "GetResultTime");
 
     for (size_t i = 0; i < _child_expr_lists.size(); ++i) {
-        RETURN_IF_ERROR(Expr::prepare(_child_expr_lists[i], state, child(i)->row_desc(), expr_mem_tracker()));
+        RETURN_IF_ERROR(Expr::prepare(_child_expr_lists[i], state, child(i)->row_desc()));
         DCHECK_EQ(_child_expr_lists[i].size(), _tuple_desc->slots().size());
     }
 

--- a/be/src/exec/vectorized/file_scanner.cpp
+++ b/be/src/exec/vectorized/file_scanner.cpp
@@ -28,8 +28,7 @@ FileScanner::FileScanner(starrocks::RuntimeState* state, starrocks::RuntimeProfi
           _counter(counter),
           _row_desc(nullptr),
           _strict_mode(false),
-          _error_counter(0) {
-}
+          _error_counter(0) {}
 
 FileScanner::~FileScanner() {
     Expr::close(_dest_expr_ctx, _state);

--- a/be/src/exec/vectorized/file_scanner.cpp
+++ b/be/src/exec/vectorized/file_scanner.cpp
@@ -27,12 +27,6 @@ FileScanner::FileScanner(starrocks::RuntimeState* state, starrocks::RuntimeProfi
           _params(params),
           _counter(counter),
           _row_desc(nullptr),
-#if BE_TEST
-          _mem_tracker(new MemTracker()),
-#else
-          _mem_tracker(new MemTracker(-1, "Broker FileScanner", state->instance_mem_tracker())),
-//          _mem_pool(_state->instance_mem_tracker()),
-#endif
           _strict_mode(false),
           _error_counter(0) {
 }
@@ -90,7 +84,7 @@ Status FileScanner::init_expr_ctx() {
 
         ExprContext* ctx = nullptr;
         RETURN_IF_ERROR(Expr::create_expr_tree(_state->obj_pool(), it->second, &ctx));
-        RETURN_IF_ERROR(ctx->prepare(_state, *_row_desc.get(), _mem_tracker.get()));
+        RETURN_IF_ERROR(ctx->prepare(_state, *_row_desc.get()));
         RETURN_IF_ERROR(ctx->open(_state));
 
         _dest_expr_ctx.emplace_back(ctx);

--- a/be/src/exec/vectorized/file_scanner.h
+++ b/be/src/exec/vectorized/file_scanner.h
@@ -63,7 +63,6 @@ protected:
     ScannerCounter* _counter;
 
     std::unique_ptr<RowDescriptor> _row_desc;
-    std::unique_ptr<MemTracker> _mem_tracker;
 
     bool _strict_mode;
     int64_t _error_counter;

--- a/be/src/exec/vectorized/hash_join_node.cpp
+++ b/be/src/exec/vectorized/hash_join_node.cpp
@@ -97,9 +97,9 @@ Status HashJoinNode::prepare(RuntimeState* state) {
     _avg_output_chunk_size = ADD_COUNTER(_runtime_profile, "AvgOutputChunkSize", TUnit::UNIT);
     _runtime_profile->add_info_string("JoinType", _get_join_type_str(_join_type));
 
-    RETURN_IF_ERROR(Expr::prepare(_build_expr_ctxs, state, child(1)->row_desc(), expr_mem_tracker()));
-    RETURN_IF_ERROR(Expr::prepare(_probe_expr_ctxs, state, child(0)->row_desc(), expr_mem_tracker()));
-    RETURN_IF_ERROR(Expr::prepare(_other_join_conjunct_ctxs, state, _row_descriptor, expr_mem_tracker()));
+    RETURN_IF_ERROR(Expr::prepare(_build_expr_ctxs, state, child(1)->row_desc()));
+    RETURN_IF_ERROR(Expr::prepare(_probe_expr_ctxs, state, child(0)->row_desc()));
+    RETURN_IF_ERROR(Expr::prepare(_other_join_conjunct_ctxs, state, _row_descriptor));
 
     HashTableParam param;
     _init_hash_table_param(&param);

--- a/be/src/exec/vectorized/hdfs_scan_node.cpp
+++ b/be/src/exec/vectorized/hdfs_scan_node.cpp
@@ -80,8 +80,8 @@ Status HdfsScanNode::prepare(RuntimeState* state) {
     }
 
     RETURN_IF_ERROR(ScanNode::prepare(state));
-    RETURN_IF_ERROR(Expr::prepare(_min_max_conjunct_ctxs, state, *_min_max_row_desc, expr_mem_tracker()));
-    RETURN_IF_ERROR(Expr::prepare(_partition_conjunct_ctxs, state, row_desc(), expr_mem_tracker()));
+    RETURN_IF_ERROR(Expr::prepare(_min_max_conjunct_ctxs, state, *_min_max_row_desc));
+    RETURN_IF_ERROR(Expr::prepare(_partition_conjunct_ctxs, state, row_desc()));
     _init_counter(state);
 
     _runtime_state = state;

--- a/be/src/exec/vectorized/intersect_node.cpp
+++ b/be/src/exec/vectorized/intersect_node.cpp
@@ -41,7 +41,7 @@ Status IntersectNode::prepare(RuntimeState* state) {
     _get_result_timer = ADD_TIMER(runtime_profile(), "GetResultTime");
 
     for (size_t i = 0; i < _child_expr_lists.size(); ++i) {
-        RETURN_IF_ERROR(Expr::prepare(_child_expr_lists[i], state, child(i)->row_desc(), expr_mem_tracker()));
+        RETURN_IF_ERROR(Expr::prepare(_child_expr_lists[i], state, child(i)->row_desc()));
         DCHECK_EQ(_child_expr_lists[i].size(), _tuple_desc->slots().size());
     }
 

--- a/be/src/exec/vectorized/project_node.cpp
+++ b/be/src/exec/vectorized/project_node.cpp
@@ -74,8 +74,8 @@ Status ProjectNode::prepare(RuntimeState* state) {
     SCOPED_TIMER(_runtime_profile->total_time_counter());
     RETURN_IF_ERROR(ExecNode::prepare(state));
 
-    RETURN_IF_ERROR(Expr::prepare(_expr_ctxs, state, row_desc(), expr_mem_tracker()));
-    RETURN_IF_ERROR(Expr::prepare(_common_sub_expr_ctxs, state, row_desc(), expr_mem_tracker()));
+    RETURN_IF_ERROR(Expr::prepare(_expr_ctxs, state, row_desc()));
+    RETURN_IF_ERROR(Expr::prepare(_common_sub_expr_ctxs, state, row_desc()));
 
     _expr_compute_timer = ADD_TIMER(runtime_profile(), "ExprComputeTime");
     _common_sub_expr_compute_timer = ADD_TIMER(runtime_profile(), "CommonSubExprComputeTime");
@@ -271,7 +271,7 @@ void ProjectNode::push_down_join_runtime_filter(RuntimeState* state,
             if (_slot_ids[i] == slot_id) {
                 // replace with new probe expr
                 ExprContext* new_probe_expr_ctx = _expr_ctxs[i];
-                rf_desc->replace_probe_expr_ctx(state, row_desc(), expr_mem_tracker(), new_probe_expr_ctx);
+                rf_desc->replace_probe_expr_ctx(state, row_desc(), new_probe_expr_ctx);
                 match = true;
                 break;
             }

--- a/be/src/exec/vectorized/topn_node.cpp
+++ b/be/src/exec/vectorized/topn_node.cpp
@@ -61,7 +61,7 @@ Status TopNNode::prepare(RuntimeState* state) {
     SCOPED_TIMER(_runtime_profile->total_time_counter());
 
     RETURN_IF_ERROR(ExecNode::prepare(state));
-    RETURN_IF_ERROR(_sort_exec_exprs.prepare(state, child(0)->row_desc(), _row_descriptor, expr_mem_tracker()));
+    RETURN_IF_ERROR(_sort_exec_exprs.prepare(state, child(0)->row_desc(), _row_descriptor));
 
     _abort_on_default_limit_exceeded = _abort_on_default_limit_exceeded && state->abort_on_default_limit_exceeded();
 

--- a/be/src/exec/vectorized/union_node.cpp
+++ b/be/src/exec/vectorized/union_node.cpp
@@ -66,11 +66,11 @@ Status UnionNode::prepare(RuntimeState* state) {
     _tuple_desc = state->desc_tbl().get_tuple_descriptor(_tuple_id);
 
     for (const vector<ExprContext*>& exprs : _const_expr_lists) {
-        RETURN_IF_ERROR(Expr::prepare(exprs, state, row_desc(), expr_mem_tracker()));
+        RETURN_IF_ERROR(Expr::prepare(exprs, state, row_desc()));
     }
 
     for (size_t i = 0; i < _child_expr_lists.size(); i++) {
-        RETURN_IF_ERROR(Expr::prepare(_child_expr_lists[i], state, child(i)->row_desc(), expr_mem_tracker()));
+        RETURN_IF_ERROR(Expr::prepare(_child_expr_lists[i], state, child(i)->row_desc()));
     }
 
     return Status::OK();

--- a/be/src/exprs/expr.cpp
+++ b/be/src/exprs/expr.cpp
@@ -463,10 +463,9 @@ inline static int get_byte_size_of_primitive_type(PrimitiveType type) {
     return 0;
 }
 
-Status Expr::prepare(const std::vector<ExprContext*>& ctxs, RuntimeState* state, const RowDescriptor& row_desc,
-                     MemTracker* tracker) {
+Status Expr::prepare(const std::vector<ExprContext*>& ctxs, RuntimeState* state, const RowDescriptor& row_desc) {
     for (auto ctx : ctxs) {
-        RETURN_IF_ERROR(ctx->prepare(state, row_desc, tracker));
+        RETURN_IF_ERROR(ctx->prepare(state, row_desc));
     }
     return Status::OK();
 }

--- a/be/src/exprs/expr.h
+++ b/be/src/exprs/expr.h
@@ -192,8 +192,7 @@ public:
 
     /// Convenience function for preparing multiple expr trees.
     /// Allocations from 'ctxs' will be counted against 'tracker'.
-    static Status prepare(const std::vector<ExprContext*>& ctxs, RuntimeState* state, const RowDescriptor& row_desc,
-                          MemTracker* tracker);
+    static Status prepare(const std::vector<ExprContext*>& ctxs, RuntimeState* state, const RowDescriptor& row_desc);
 
     /// Convenience function for opening multiple expr trees.
     static Status open(const std::vector<ExprContext*>& ctxs, RuntimeState* state);

--- a/be/src/exprs/expr_context.cpp
+++ b/be/src/exprs/expr_context.cpp
@@ -54,16 +54,12 @@ ExprContext::~ExprContext() {
     }
 }
 
-// TODO(zc): memory tracker
-Status ExprContext::prepare(RuntimeState* state, const RowDescriptor& row_desc, MemTracker* tracker) {
+Status ExprContext::prepare(RuntimeState* state, const RowDescriptor& row_desc) {
     if (_prepared) {
         return Status::OK();
     }
-    DCHECK(tracker != nullptr) << std::endl << get_stack_trace();
     DCHECK(_pool.get() == nullptr);
     _prepared = true;
-    // TODO: use param tracker to replace instance_mem_tracker
-    // _pool.reset(new MemPool(new MemTracker(-1)));
     _pool = std::make_unique<MemPool>(state->instance_mem_tracker());
     return _root->prepare(state, row_desc, this);
 }

--- a/be/src/exprs/expr_context.h
+++ b/be/src/exprs/expr_context.h
@@ -68,7 +68,7 @@ public:
 
     /// Prepare expr tree for evaluation.
     /// Allocations from this context will be counted against 'tracker'.
-    Status prepare(RuntimeState* state, const RowDescriptor& row_desc, MemTracker* tracker);
+    Status prepare(RuntimeState* state, const RowDescriptor& row_desc);
 
     /// Must be called after calling Prepare(). Does not need to be called on clones.
     /// Idempotent (this allows exprs to be opened multiple times in subplans without

--- a/be/src/exprs/vectorized/runtime_filter_bank.cpp
+++ b/be/src/exprs/vectorized/runtime_filter_bank.cpp
@@ -275,10 +275,9 @@ Status RuntimeFilterProbeDescriptor::init(ObjectPool* pool, const TRuntimeFilter
     return Status::OK();
 }
 
-Status RuntimeFilterProbeDescriptor::prepare(RuntimeState* state, const RowDescriptor& row_desc, MemTracker* tracker,
-                                             RuntimeProfile* p) {
+Status RuntimeFilterProbeDescriptor::prepare(RuntimeState* state, const RowDescriptor& row_desc, RuntimeProfile* p) {
     if (_probe_expr_ctx != nullptr) {
-        RETURN_IF_ERROR(_probe_expr_ctx->prepare(state, row_desc, tracker));
+        RETURN_IF_ERROR(_probe_expr_ctx->prepare(state, row_desc));
     }
     _open_timestamp = UnixMillis();
     _latency_timer = ADD_COUNTER(p, strings::Substitute("JoinRuntimeFilter/$0/latency", _filter_id), TUnit::TIME_NS);
@@ -301,12 +300,12 @@ void RuntimeFilterProbeDescriptor::close(RuntimeState* state) {
 }
 
 void RuntimeFilterProbeDescriptor::replace_probe_expr_ctx(RuntimeState* state, const RowDescriptor& row_desc,
-                                                          MemTracker* tracker, ExprContext* new_probe_expr_ctx) {
+                                                          ExprContext* new_probe_expr_ctx) {
     // close old probe expr
     _probe_expr_ctx->close(state);
     // create new probe expr and open it.
     _probe_expr_ctx = state->obj_pool()->add(new ExprContext(new_probe_expr_ctx->root()));
-    _probe_expr_ctx->prepare(state, row_desc, tracker);
+    _probe_expr_ctx->prepare(state, row_desc);
     _probe_expr_ctx->open(state);
 }
 
@@ -339,12 +338,12 @@ RuntimeFilterProbeCollector::RuntimeFilterProbeCollector(RuntimeFilterProbeColle
           _input_chunk_nums(that._input_chunk_nums),
           _wait_timeout_ms(that._wait_timeout_ms) {}
 
-Status RuntimeFilterProbeCollector::prepare(RuntimeState* state, const RowDescriptor& row_desc, MemTracker* tracker,
+Status RuntimeFilterProbeCollector::prepare(RuntimeState* state, const RowDescriptor& row_desc,
                                             RuntimeProfile* profile) {
     _runtime_profile = profile;
     for (auto& it : _descriptors) {
         RuntimeFilterProbeDescriptor* rf_desc = it.second;
-        RETURN_IF_ERROR(rf_desc->prepare(state, row_desc, tracker, profile));
+        RETURN_IF_ERROR(rf_desc->prepare(state, row_desc, profile));
     }
     return Status::OK();
 }

--- a/be/src/exprs/vectorized/runtime_filter_bank.h
+++ b/be/src/exprs/vectorized/runtime_filter_bank.h
@@ -84,7 +84,7 @@ class RuntimeFilterProbeDescriptor {
 public:
     RuntimeFilterProbeDescriptor() = default;
     Status init(ObjectPool* pool, const TRuntimeFilterDescription& desc, TPlanNodeId node_id);
-    Status prepare(RuntimeState* state, const RowDescriptor& row_desc, MemTracker* tracker, RuntimeProfile* p);
+    Status prepare(RuntimeState* state, const RowDescriptor& row_desc, RuntimeProfile* p);
     Status open(RuntimeState* state);
     void close(RuntimeState* state);
     int32_t filter_id() const { return _filter_id; }
@@ -101,8 +101,7 @@ public:
         return true;
     }
     PrimitiveType probe_expr_type() const { return _probe_expr_ctx->root()->type().type; }
-    void replace_probe_expr_ctx(RuntimeState* state, const RowDescriptor& row_desc, MemTracker* tracker,
-                                ExprContext* new_probe_expr_ctx);
+    void replace_probe_expr_ctx(RuntimeState* state, const RowDescriptor& row_desc, ExprContext* new_probe_expr_ctx);
     std::string debug_string() const;
     JoinRuntimeFilter::RunningContext* runtime_filter_ctx() { return &_runtime_filter_ctx; }
 
@@ -125,7 +124,7 @@ public:
     RuntimeFilterProbeCollector();
     RuntimeFilterProbeCollector(RuntimeFilterProbeCollector&& that) noexcept;
     size_t size() const { return _descriptors.size(); }
-    Status prepare(RuntimeState* state, const RowDescriptor& row_desc, MemTracker* tracker, RuntimeProfile* p);
+    Status prepare(RuntimeState* state, const RowDescriptor& row_desc, RuntimeProfile* p);
     Status open(RuntimeState* state);
     void close(RuntimeState* state);
     void evaluate(vectorized::Chunk* chunk);

--- a/be/src/runtime/data_stream_sender.cpp
+++ b/be/src/runtime/data_stream_sender.cpp
@@ -488,11 +488,11 @@ Status DataStreamSender::prepare(RuntimeState* state) {
         std::shuffle(_channels.begin(), _channels.end(), std::mt19937(std::random_device()()));
     } else if (_part_type == TPartitionType::HASH_PARTITIONED ||
                _part_type == TPartitionType::BUCKET_SHFFULE_HASH_PARTITIONED) {
-        RETURN_IF_ERROR(Expr::prepare(_partition_expr_ctxs, state, _row_desc, _expr_mem_tracker.get()));
+        RETURN_IF_ERROR(Expr::prepare(_partition_expr_ctxs, state, _row_desc));
     } else {
-        RETURN_IF_ERROR(Expr::prepare(_partition_expr_ctxs, state, _row_desc, _expr_mem_tracker.get()));
+        RETURN_IF_ERROR(Expr::prepare(_partition_expr_ctxs, state, _row_desc));
         for (auto iter : _partition_infos) {
-            RETURN_IF_ERROR(iter->prepare(state, _row_desc, _expr_mem_tracker.get()));
+            RETURN_IF_ERROR(iter->prepare(state, _row_desc));
         }
     }
 

--- a/be/src/runtime/dpp_sink_internal.cpp
+++ b/be/src/runtime/dpp_sink_internal.cpp
@@ -152,9 +152,9 @@ Status PartitionInfo::from_thrift(ObjectPool* pool, const TRangePartition& t_par
     return Status::OK();
 }
 
-Status PartitionInfo::prepare(RuntimeState* state, const RowDescriptor& row_desc, MemTracker* mem_tracker) {
+Status PartitionInfo::prepare(RuntimeState* state, const RowDescriptor& row_desc) {
     if (_distributed_expr_ctxs.size() > 0) {
-        RETURN_IF_ERROR(Expr::prepare(_distributed_expr_ctxs, state, row_desc, mem_tracker));
+        RETURN_IF_ERROR(Expr::prepare(_distributed_expr_ctxs, state, row_desc));
     }
     return Status::OK();
 }

--- a/be/src/runtime/dpp_sink_internal.h
+++ b/be/src/runtime/dpp_sink_internal.h
@@ -193,7 +193,7 @@ public:
 
     static Status from_thrift(ObjectPool* pool, const TRangePartition& t_partition, PartitionInfo* partition);
 
-    Status prepare(RuntimeState* state, const RowDescriptor& row_desc, MemTracker*);
+    Status prepare(RuntimeState* state, const RowDescriptor& row_desc);
 
     Status open(RuntimeState* state);
 

--- a/be/src/runtime/export_sink.cpp
+++ b/be/src/runtime/export_sink.cpp
@@ -32,14 +32,12 @@
 #include "formats/csv/output_stream_file.h"
 #include "gutil/strings/substitute.h"
 #include "runtime/exec_env.h"
-#include "runtime/mem_tracker.h"
 #include "runtime/row_batch.h"
 #include "runtime/runtime_state.h"
 #include "runtime/tuple_row.h"
 #include "util/runtime_profile.h"
 #include "util/time.h"
 #include "util/types.h"
-#include "util/uid_util.h"
 
 namespace starrocks {
 
@@ -73,10 +71,8 @@ Status ExportSink::prepare(RuntimeState* state) {
     _profile = state->obj_pool()->add(new RuntimeProfile(title.str()));
     SCOPED_TIMER(_profile->total_time_counter());
 
-    _mem_tracker = std::make_unique<MemTracker>(-1, "ExportSink", state->instance_mem_tracker());
-
     // Prepare the exprs to run.
-    RETURN_IF_ERROR(Expr::prepare(_output_expr_ctxs, state, _row_desc, _mem_tracker.get()));
+    RETURN_IF_ERROR(Expr::prepare(_output_expr_ctxs, state, _row_desc));
 
     // TODO(lingbin): add some Counter
     _bytes_written_counter = ADD_COUNTER(profile(), "BytesExported", TUnit::BYTES);

--- a/be/src/runtime/export_sink.h
+++ b/be/src/runtime/export_sink.h
@@ -80,8 +80,6 @@ private:
 
     RuntimeProfile* _profile;
 
-    std::unique_ptr<MemTracker> _mem_tracker;
-
     RuntimeProfile::Counter* _bytes_written_counter;
     RuntimeProfile::Counter* _rows_written_counter;
     RuntimeProfile::Counter* _write_timer;

--- a/be/src/runtime/memory_scratch_sink.cpp
+++ b/be/src/runtime/memory_scratch_sink.cpp
@@ -63,7 +63,7 @@ Status MemoryScratchSink::prepare_exprs(RuntimeState* state) {
     // From the thrift expressions create the real exprs.
     RETURN_IF_ERROR(Expr::create_expr_trees(state->obj_pool(), _t_output_expr, &_output_expr_ctxs));
     // Prepare the exprs to run.
-    RETURN_IF_ERROR(Expr::prepare(_output_expr_ctxs, state, _row_desc, _expr_mem_tracker.get()));
+    RETURN_IF_ERROR(Expr::prepare(_output_expr_ctxs, state, _row_desc));
     // generate the arrow schema
     RETURN_IF_ERROR(convert_to_arrow_schema(_row_desc, &_arrow_schema));
     convert_to_slot_types_and_ids();

--- a/be/src/runtime/mysql_table_sink.cpp
+++ b/be/src/runtime/mysql_table_sink.cpp
@@ -24,8 +24,6 @@
 #include <sstream>
 
 #include "exprs/expr.h"
-#include "runtime/mem_tracker.h"
-#include "runtime/mysql_table_sink.h"
 #include "runtime/runtime_state.h"
 #include "util/debug_util.h"
 #include "util/runtime_profile.h"
@@ -56,7 +54,7 @@ Status MysqlTableSink::init(const TDataSink& t_sink) {
 Status MysqlTableSink::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(DataSink::prepare(state));
     // Prepare the exprs to run.
-    RETURN_IF_ERROR(Expr::prepare(_output_expr_ctxs, state, _row_desc, _mem_tracker.get()));
+    RETURN_IF_ERROR(Expr::prepare(_output_expr_ctxs, state, _row_desc));
     std::stringstream title;
     title << "MysqlTableSink (frag_id=" << state->fragment_instance_id() << ")";
     // create profile

--- a/be/src/runtime/mysql_table_sink.h
+++ b/be/src/runtime/mysql_table_sink.h
@@ -36,7 +36,6 @@ class TMysqlTableSink;
 class RuntimeState;
 class RuntimeProfile;
 class ExprContext;
-class MemTracker;
 
 // This class is a sinker, which put input data to mysql table
 class MysqlTableSink : public DataSink {
@@ -69,7 +68,6 @@ private:
     MysqlTableWriter* _writer = nullptr;
 
     RuntimeProfile* _profile = nullptr;
-    std::unique_ptr<MemTracker> _mem_tracker;
 };
 
 } // namespace starrocks

--- a/be/src/runtime/result_sink.cpp
+++ b/be/src/runtime/result_sink.cpp
@@ -57,7 +57,7 @@ Status ResultSink::prepare_exprs(RuntimeState* state) {
     // From the thrift expressions create the real exprs.
     RETURN_IF_ERROR(Expr::create_expr_trees(state->obj_pool(), _t_output_expr, &_output_expr_ctxs));
     // Prepare the exprs to run.
-    RETURN_IF_ERROR(Expr::prepare(_output_expr_ctxs, state, _row_desc, _expr_mem_tracker.get()));
+    RETURN_IF_ERROR(Expr::prepare(_output_expr_ctxs, state, _row_desc));
     return Status::OK();
 }
 

--- a/be/src/storage/vectorized/column_expr_predicate.cpp
+++ b/be/src/storage/vectorized/column_expr_predicate.cpp
@@ -128,7 +128,7 @@ public:
         ExprContext* cast_expr_ctx = obj_pool->add(new ExprContext(cast_expr));
 
         RowDescriptor row_desc; // I think we don't need to use it at all.
-        RETURN_IF_ERROR(cast_expr_ctx->prepare(_state, row_desc, _state->instance_mem_tracker()));
+        RETURN_IF_ERROR(cast_expr_ctx->prepare(_state, row_desc));
         RETURN_IF_ERROR(cast_expr_ctx->open(_state));
 
         ColumnExprPredicate* pred =

--- a/be/test/exec/pipeline/pipeline_test_base.cpp
+++ b/be/test/exec/pipeline/pipeline_test_base.cpp
@@ -70,10 +70,6 @@ void PipelineTestBase::_prepare() {
     _fragment_future = _fragment_ctx->finish_future();
     _runtime_state = _fragment_ctx->runtime_state();
 
-    int64_t bytes_limit = _request.query_options.mem_limit;
-    _fragment_ctx->set_mem_tracker(std::make_unique<MemTracker>(bytes_limit, "pipeline test mem-limit",
-                                                                _exec_env->query_pool_mem_tracker(), true));
-
     _runtime_state->set_batch_size(config::vector_chunk_size);
     ASSERT_TRUE(_runtime_state->init_mem_trackers(query_id).ok());
     _runtime_state->set_be_number(_request.backend_num);

--- a/be/test/exec/vectorized/hdfs_scanner_test.cpp
+++ b/be/test/exec/vectorized/hdfs_scanner_test.cpp
@@ -429,7 +429,7 @@ TEST_F(HdfsScannerTest, TestOrcGetNextWithMinMaxFilterNoRows) {
     extend_orc_min_max_conjuncts(&_pool, param, thres);
     RowDescriptor row_desc(param->min_max_tuple_desc, true);
     for (ExprContext* ctx : param->min_max_conjunct_ctxs) {
-        ctx->prepare(_runtime_state, row_desc, _runtime_state->instance_mem_tracker());
+        ctx->prepare(_runtime_state, row_desc);
         ctx->open(_runtime_state);
     }
 
@@ -465,7 +465,7 @@ TEST_F(HdfsScannerTest, TestOrcGetNextWithMinMaxFilterRows1) {
     extend_orc_min_max_conjuncts(&_pool, param, thres);
     RowDescriptor row_desc(param->min_max_tuple_desc, true);
     for (ExprContext* ctx : param->min_max_conjunct_ctxs) {
-        ctx->prepare(_runtime_state, row_desc, _runtime_state->instance_mem_tracker());
+        ctx->prepare(_runtime_state, row_desc);
         ctx->open(_runtime_state);
     }
 
@@ -501,7 +501,7 @@ TEST_F(HdfsScannerTest, TestOrcGetNextWithMinMaxFilterRows2) {
     extend_orc_min_max_conjuncts(&_pool, param, thres);
     RowDescriptor row_desc(param->min_max_tuple_desc, true);
     for (ExprContext* ctx : param->min_max_conjunct_ctxs) {
-        ctx->prepare(_runtime_state, row_desc, _runtime_state->instance_mem_tracker());
+        ctx->prepare(_runtime_state, row_desc);
         ctx->open(_runtime_state);
     }
 
@@ -580,7 +580,7 @@ TEST_F(HdfsScannerTest, TestOrcGetNextWithDictFilter) {
     for (auto& it : param->conjunct_ctxs_by_slot) {
         for (auto& it2 : it.second) {
             ExprContext* ctx = it2;
-            ctx->prepare(_runtime_state, row_desc, _runtime_state->instance_mem_tracker());
+            ctx->prepare(_runtime_state, row_desc);
             ctx->open(_runtime_state);
         }
     }
@@ -692,7 +692,7 @@ TEST_F(HdfsScannerTest, TestOrcGetNextWithDatetimeMinMaxFilter) {
     extend_datetime_orc_min_max_conjuncts(&_pool, param);
     RowDescriptor row_desc(param->min_max_tuple_desc, true);
     for (ExprContext* ctx : param->min_max_conjunct_ctxs) {
-        ctx->prepare(_runtime_state, row_desc, _runtime_state->instance_mem_tracker());
+        ctx->prepare(_runtime_state, row_desc);
         ctx->open(_runtime_state);
     }
 


### PR DESCRIPTION
for #703 

expr_mem_tracker is actually not used in the Expr::prepare() implementation, and will not be used in the new memory framework in the future