### PR TITLE
fix: remove mem tracker for hash join operator in pipeline

### DIFF
--- a/be/src/exec/pipeline/hashjoin/hash_join_build_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/hash_join_build_operator.cpp
@@ -28,8 +28,8 @@ void HashJoinBuildOperator::finish(RuntimeState* state) {
 HashJoinBuildOperatorFactory::HashJoinBuildOperatorFactory(int32_t id, int32_t plan_node_id, HashJoiner* hash_joiner)
         : OperatorFactory(id, "hash_join_build", plan_node_id), _hash_joiner(hash_joiner) {}
 
-Status HashJoinBuildOperatorFactory::prepare(RuntimeState* state, MemTracker* mem_tracker) {
-    RETURN_IF_ERROR(OperatorFactory::prepare(state, mem_tracker));
+Status HashJoinBuildOperatorFactory::prepare(RuntimeState* state) {
+    RETURN_IF_ERROR(OperatorFactory::prepare(state));
     return _hash_joiner->prepare(state);
 }
 

--- a/be/src/exec/pipeline/hashjoin/hash_join_build_operator.h
+++ b/be/src/exec/pipeline/hashjoin/hash_join_build_operator.h
@@ -39,7 +39,7 @@ class HashJoinBuildOperatorFactory final : public OperatorFactory {
 public:
     HashJoinBuildOperatorFactory(int32_t id, int32_t plan_node_id, HashJoiner* hash_joiner);
     ~HashJoinBuildOperatorFactory() = default;
-    Status prepare(RuntimeState* state, MemTracker* mem_tracker) override;
+    Status prepare(RuntimeState* state) override;
     void close(RuntimeState* state) override;
     OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override;
 

--- a/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.cpp
@@ -44,8 +44,8 @@ HashJoinProbeOperatorFactory::HashJoinProbeOperatorFactory(int32_t id, int32_t p
                                                            std::unique_ptr<HashJoiner>&& hash_joiner)
         : OperatorFactory(id, "hash_join_probe", plan_node_id), _hash_joiner(std::move(hash_joiner)) {}
 
-Status HashJoinProbeOperatorFactory::prepare(RuntimeState* state, MemTracker* mem_tracker) {
-    return OperatorFactory::prepare(state, mem_tracker);
+Status HashJoinProbeOperatorFactory::prepare(RuntimeState* state) {
+    return OperatorFactory::prepare(state);
 }
 void HashJoinProbeOperatorFactory::close(RuntimeState* state) {
     OperatorFactory::close(state);

--- a/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.h
+++ b/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.h
@@ -37,7 +37,7 @@ public:
 
     ~HashJoinProbeOperatorFactory() = default;
 
-    Status prepare(RuntimeState* state, MemTracker* mem_tracker) override;
+    Status prepare(RuntimeState* state) override;
     void close(RuntimeState* state) override;
 
     OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override;

--- a/be/src/exec/vectorized/hash_joiner.cpp
+++ b/be/src/exec/vectorized/hash_joiner.cpp
@@ -87,10 +87,10 @@ Status HashJoiner::prepare(RuntimeState* state) {
     _avg_output_chunk_size = ADD_COUNTER(_runtime_profile, "AvgOutputChunkSize", TUnit::UNIT);
     _runtime_profile->add_info_string("JoinType", _get_join_type_str(_join_type));
 
-    RETURN_IF_ERROR(Expr::prepare(_build_expr_ctxs, state, _build_row_descriptor, _expr_mem_tracker.get()));
-    RETURN_IF_ERROR(Expr::prepare(_probe_expr_ctxs, state, _probe_row_descriptor, _expr_mem_tracker.get()));
-    RETURN_IF_ERROR(Expr::prepare(_other_join_conjunct_ctxs, state, _row_descriptor, _expr_mem_tracker.get()));
-    RETURN_IF_ERROR(Expr::prepare(_conjunct_ctxs, state, _row_descriptor, _expr_mem_tracker.get()));
+    RETURN_IF_ERROR(Expr::prepare(_build_expr_ctxs, state, _build_row_descriptor));
+    RETURN_IF_ERROR(Expr::prepare(_probe_expr_ctxs, state, _probe_row_descriptor));
+    RETURN_IF_ERROR(Expr::prepare(_other_join_conjunct_ctxs, state, _row_descriptor));
+    RETURN_IF_ERROR(Expr::prepare(_conjunct_ctxs, state, _row_descriptor));
     RETURN_IF_ERROR(Expr::open(_build_expr_ctxs, state));
     RETURN_IF_ERROR(Expr::open(_probe_expr_ctxs, state));
     RETURN_IF_ERROR(Expr::open(_other_join_conjunct_ctxs, state));


### PR DESCRIPTION
`MemTracker` has been removed from `Expr::prepare()` and `Operator::preapre()`, so fix it for hash join operator in pipeline .