### PR TITLE
[ISSUE-958] Rename session variable query_threads to pipeline_dop

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -105,8 +105,11 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
     }
 
     int32_t degree_of_parallelism = 1;
-    if (query_options.__isset.query_threads) {
-        degree_of_parallelism = std::max<int32_t>(query_options.query_threads, degree_of_parallelism);
+    if (query_options.__isset.pipeline_dop && query_options.pipeline_dop > 0) {
+        degree_of_parallelism = query_options.pipeline_dop;
+    } else {
+        // default dop is a half of the number of hardware threads.
+        degree_of_parallelism = std::max<int32_t>(1, std::thread::hardware_concurrency() / 2);
     }
 
     // pipeline scan mode

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -111,7 +111,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // them do the real work on core.
     public static final String ENABLE_PIPELINE_ENGINE = "enable_pipeline_engine";
 
-    public static final String PIPELINE_QUERY_THREADS = "query_threads";
+    public static final String PIPELINE_DOP = "pipeline_dop";
 
     public static final String PIPELINE_SCAN_MODE = "pipeline_scan_mode";
 
@@ -296,8 +296,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = PARALLEL_FRAGMENT_EXEC_INSTANCE_NUM)
     private int parallelExecInstanceNum = 1;
 
-    @VariableMgr.VarAttr(name = PIPELINE_QUERY_THREADS)
-    private int pipelineQueryThreads = 1;
+    @VariableMgr.VarAttr(name = PIPELINE_DOP)
+    private int pipelineDop = 0;
 
     // 1 means that ScanOperators use async io, otherwise, use sync io instead.
     @VariableMgr.VarAttr(name = PIPELINE_SCAN_MODE)
@@ -745,7 +745,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         final int global_runtime_filter_rpc_timeout = 400;
         tResult.setRuntime_filter_wait_timeout_ms(global_runtime_filter_wait_timeout);
         tResult.setRuntime_filter_send_timeout_ms(global_runtime_filter_rpc_timeout);
-        tResult.setQuery_threads(pipelineQueryThreads);
+        tResult.setPipeline_dop(pipelineDop);
         tResult.setPipeline_scan_mode(pipelineScanMode);
         tResult.setPipeline_query_expire_seconds(pipelineQueryExpireSeconds);
         return tResult;

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -149,7 +149,7 @@ struct TQueryOptions {
   // Timeout in ms to send runtime filter across nodes.
   53: optional i32 runtime_filter_send_timeout_ms = 400;
   // For pipeline query engine
-  54: optional i32 query_threads;
+  54: optional i32 pipeline_dop;
   // For pipeline query engine
   55: optional i32 pipeline_scan_mode;
   // For query context expired period


### PR DESCRIPTION
## Enhancement
Rename session variable query_threads to pipeline_dop that is the maximum of drivers a pipeline can be instantiated.