### PR TITLE
support conjuncts in global dict

### DIFF
--- a/be/src/exec/vectorized/dict_decode_node.cpp
+++ b/be/src/exec/vectorized/dict_decode_node.cpp
@@ -64,11 +64,14 @@ Status DictDecodeNode::prepare(RuntimeState* state) {
             auto& [expr_ctx, dict_ctx] = _string_functions[need_encode_cid];
             DCHECK(expr_ctx->root()->fn().could_apply_dict_optimize);
             _dict_optimize_parser.check_could_apply_dict_optimize(expr_ctx, &dict_ctx);
-            DCHECK(dict_ctx.could_apply_dict_optimize);
+
+            if (!dict_ctx.could_apply_dict_optimize) {
+                Status::InternalError(fmt::format("Not found dict for function-called cid:{}", need_encode_cid));
+            }
+
             _dict_optimize_parser.eval_expr(state, expr_ctx, &dict_ctx, need_encode_cid);
             dict_iter = global_dict.find(need_encode_cid);
             DCHECK(dict_iter != global_dict.end());
-            return Status::InternalError(fmt::format("Not found dict for function-called cid:{}", need_encode_cid));
         }
 
         DefaultDecoderPtr decoder = std::make_unique<DefaultDecoder>();
@@ -138,6 +141,7 @@ Status DictDecodeNode::close(RuntimeState* state) {
     }
     RETURN_IF_ERROR(ExecNode::close(state));
     Expr::close(_expr_ctxs, state);
+    _dict_optimize_parser.close(state);
 
     return Status::OK();
 }

--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -8,6 +8,7 @@
 
 #include "column/column_pool.h"
 #include "column/type_traits.h"
+#include "common/global_types.h"
 #include "common/status.h"
 #include "exec/pipeline/limit_operator.h"
 #include "exec/pipeline/pipeline_builder.h"
@@ -23,6 +24,7 @@
 #include "runtime/current_thread.h"
 #include "runtime/descriptors.h"
 #include "runtime/exec_env.h"
+#include "runtime/primitive_type.h"
 #include "storage/vectorized/chunk_helper.h"
 #include "util/priority_thread_pool.hpp"
 
@@ -54,6 +56,8 @@ Status OlapScanNode::prepare(RuntimeState* state) {
         _runtime_profile->add_info_string("Predicates", _olap_scan_node.sql_predicates);
     }
     _runtime_state = state;
+    _dict_optimize_parser.set_mutable_dict_maps(state->mutable_global_dict_map());
+    RETURN_IF_ERROR(_rewrite_descriptor());
     return Status::OK();
 }
 
@@ -181,6 +185,8 @@ Status OlapScanNode::close(RuntimeState* state) {
         delete chunk;
     }
 
+    _dict_optimize_parser.close(state);
+
     // Reduce the memory usage if the the average string size is greater than 512.
     release_large_columns<BinaryColumn>(config::vector_chunk_size * 512);
 
@@ -200,6 +206,36 @@ void OlapScanNode::_fill_chunk_pool(int count, bool force_column_pool) {
         std::lock_guard<std::mutex> l(_mtx);
         _chunk_pool.push(chk);
     }
+}
+
+// For global dictionary optimized columns,
+// the type at the execution level is INT but at the storage level is TYPE_STRING/TYPE_CHAR,
+// so we need to pass the real type to the Table Scanner.
+Status OlapScanNode::_rewrite_descriptor() {
+    const auto& global_dict = _runtime_state->get_global_dict_map();
+    if (global_dict.empty()) return Status::OK();
+
+    for (auto& slot : _tuple_desc->slots()) {
+        if (global_dict.count(slot->id())) {
+            slot->type().type = TYPE_VARCHAR;
+        }
+    }
+
+    const auto& dict_slots_mapping = _olap_scan_node.dict_string_id_to_int_ids;
+    // rewrite slot-id for conjunct
+    std::vector<SlotId> slots;
+    for (auto& conjunct : _conjunct_ctxs) {
+        slots.clear();
+        Expr* expr_root = conjunct->root();
+        if (expr_root->get_slot_ids(&slots) == 1) {
+            if (auto iter = dict_slots_mapping.find(slots[0]); iter != dict_slots_mapping.end()) {
+                ColumnRef* column_ref = expr_root->get_column_ref();
+                column_ref->set_slot_id(iter->second);
+            }
+        }
+    }
+
+    return Status::OK();
 }
 
 void OlapScanNode::_scanner_thread(TabletScanner* scanner) {
@@ -450,6 +486,8 @@ Status OlapScanNode::_start_scan_thread(RuntimeState* state) {
     RETURN_IF_ERROR(_conjuncts_manager.get_key_ranges(&key_ranges));
     std::vector<ExprContext*> conjunct_ctxs;
     _conjuncts_manager.get_not_push_down_conjuncts(&conjunct_ctxs);
+
+    _dict_optimize_parser.rewrite_conjuncts(&conjunct_ctxs, state);
 
     int scanners_per_tablet = std::max(1, 64 / (int)_scan_ranges.size());
     for (auto& scan_range : _scan_ranges) {

--- a/be/src/exec/vectorized/olap_scan_node.h
+++ b/be/src/exec/vectorized/olap_scan_node.h
@@ -102,6 +102,7 @@ private:
     Status _get_status();
 
     void _fill_chunk_pool(int count, bool force_column_pool);
+    Status _rewrite_descriptor();
     bool _submit_scanner(TabletScanner* scanner, bool blockable);
     void _close_pending_scanners();
     int _compute_priority(int32_t num_submitted_tasks);
@@ -109,8 +110,9 @@ private:
     TOlapScanNode _olap_scan_node;
     std::vector<std::unique_ptr<TInternalScanRange>> _scan_ranges;
     RuntimeState* _runtime_state = nullptr;
-    const TupleDescriptor* _tuple_desc = nullptr;
+    TupleDescriptor* _tuple_desc = nullptr;
     OlapScanConjunctsManager _conjuncts_manager;
+    DictOptimizeParser _dict_optimize_parser;
     const Schema* _chunk_schema = nullptr;
     ObjectPool _obj_pool;
 

--- a/be/src/exec/vectorized/project_node.cpp
+++ b/be/src/exec/vectorized/project_node.cpp
@@ -83,19 +83,12 @@ Status ProjectNode::prepare(RuntimeState* state) {
     GlobalDictMaps* mdict_maps = state->mutable_global_dict_map();
     _dict_optimize_parser.set_mutable_dict_maps(mdict_maps);
 
-    auto init_dict_optimize = [&](std::vector<ExprContext*>& expr_ctxs, std::vector<DictOptimizeContext>& dict_ctxs,
-                                  std::vector<SlotId>& target_slots) {
-        dict_ctxs.resize(expr_ctxs.size());
-        for (int i = 0; i < expr_ctxs.size(); ++i) {
-            _dict_optimize_parser.check_could_apply_dict_optimize(expr_ctxs[i], &dict_ctxs[i]);
-            if (dict_ctxs[i].could_apply_dict_optimize) {
-                _dict_optimize_parser.eval_expr(state, expr_ctxs[i], &dict_ctxs[i], target_slots[i]);
-            }
-        }
+    auto init_dict_optimize = [&](std::vector<ExprContext*>& expr_ctxs, std::vector<SlotId>& target_slots) {
+        _dict_optimize_parser.rewrite_exprs(&expr_ctxs, state, target_slots);
     };
 
-    init_dict_optimize(_common_sub_expr_ctxs, _common_sub_dict_optimize_ctxs, _common_sub_slot_ids);
-    init_dict_optimize(_expr_ctxs, _dict_optimize_ctxs, _slot_ids);
+    init_dict_optimize(_common_sub_expr_ctxs, _common_sub_slot_ids);
+    init_dict_optimize(_expr_ctxs, _slot_ids);
 
     return Status::OK();
 }
@@ -133,15 +126,7 @@ Status ProjectNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) {
     {
         SCOPED_TIMER(_common_sub_expr_compute_timer);
         for (size_t i = 0; i < _common_sub_slot_ids.size(); ++i) {
-            if (_common_sub_dict_optimize_ctxs[i].could_apply_dict_optimize) {
-                auto cid = _common_sub_dict_optimize_ctxs[i].slot_id;
-                auto& src_col = (*chunk)->get_column_by_slot_id(cid);
-                ColumnPtr result_column;
-                _dict_optimize_parser.eval_code_convert(_common_sub_dict_optimize_ctxs[i], src_col, &result_column);
-                (*chunk)->append_column(std::move(result_column), _common_sub_slot_ids[i]);
-            } else {
-                (*chunk)->append_column(_common_sub_expr_ctxs[i]->evaluate((*chunk).get()), _common_sub_slot_ids[i]);
-            }
+            (*chunk)->append_column(_common_sub_expr_ctxs[i]->evaluate((*chunk).get()), _common_sub_slot_ids[i]);
         }
     }
 
@@ -150,13 +135,7 @@ Status ProjectNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) {
     {
         SCOPED_TIMER(_expr_compute_timer);
         for (size_t i = 0; i < _slot_ids.size(); ++i) {
-            if (_dict_optimize_ctxs[i].could_apply_dict_optimize) {
-                auto cid = _dict_optimize_ctxs[i].slot_id;
-                auto& src_col = (*chunk)->get_column_by_slot_id(cid);
-                _dict_optimize_parser.eval_code_convert(_dict_optimize_ctxs[i], src_col, &result_columns[i]);
-            } else {
-                result_columns[i] = _expr_ctxs[i]->evaluate((*chunk).get());
-            }
+            result_columns[i] = _expr_ctxs[i]->evaluate((*chunk).get());
 
             if (result_columns[i]->only_null()) {
                 result_columns[i] = ColumnHelper::create_column(_expr_ctxs[i]->root()->type(), true);
@@ -218,6 +197,7 @@ Status ProjectNode::close(RuntimeState* state) {
 
     Expr::close(_expr_ctxs, state);
     Expr::close(_common_sub_expr_ctxs, state);
+    _dict_optimize_parser.close(state);
     RETURN_IF_ERROR(ExecNode::close(state));
     return Status::OK();
 }

--- a/be/src/exec/vectorized/project_node.h
+++ b/be/src/exec/vectorized/project_node.h
@@ -34,12 +34,10 @@ public:
 private:
     std::vector<SlotId> _slot_ids;
     std::vector<ExprContext*> _expr_ctxs;
-    std::vector<DictOptimizeContext> _dict_optimize_ctxs;
     std::vector<bool> _type_is_nullable;
 
     std::vector<SlotId> _common_sub_slot_ids;
     std::vector<ExprContext*> _common_sub_expr_ctxs;
-    std::vector<DictOptimizeContext> _common_sub_dict_optimize_ctxs;
 
     RuntimeProfile::Counter* _expr_compute_timer = nullptr;
     RuntimeProfile::Counter* _common_sub_expr_compute_timer = nullptr;

--- a/be/src/exprs/agg/avg.h
+++ b/be/src/exprs/agg/avg.h
@@ -117,7 +117,7 @@ public:
         // For type of int/tinyint/bitint..., the result of avg is float/double
         // But the floating point operations are much slower than integer operations
         // So, we use integers to perform operations
-        SumResultType local_sum_for_arithmetic{};
+        [[maybe_unused]] SumResultType local_sum_for_arithmetic{};
 
         for (size_t i = frame_start; i < frame_end; ++i) {
             if constexpr (pt_is_datetime<PT>) {

--- a/be/src/exprs/expr.cpp
+++ b/be/src/exprs/expr.cpp
@@ -658,6 +658,19 @@ ColumnPtr Expr::evaluate(ExprContext* context, vectorized::Chunk* ptr) {
     return nullptr;
 }
 
+vectorized::ColumnRef* Expr::get_column_ref() {
+    if (this->is_slotref()) {
+        return down_cast<vectorized::ColumnRef*>(this);
+    }
+    for (auto child : this->children()) {
+        vectorized::ColumnRef* ref = nullptr;
+        if ((ref = child->get_column_ref()) != nullptr) {
+            return ref;
+        }
+    }
+    return nullptr;
+}
+
 } // namespace starrocks
 
 #pragma clang diagnostic pop

--- a/be/src/exprs/expr.h
+++ b/be/src/exprs/expr.h
@@ -68,7 +68,8 @@ class UserFunctionCacheEntry;
 
 namespace vectorized {
 class Chunk;
-}
+class ColumnRef;
+} // namespace vectorized
 
 using vectorized::ColumnPtr;
 
@@ -230,6 +231,9 @@ public:
     virtual ColumnPtr evaluate_const(ExprContext* context);
 
     virtual ColumnPtr evaluate(ExprContext* context, vectorized::Chunk* ptr);
+
+    // get the first column ref in expr
+    vectorized::ColumnRef* get_column_ref();
 
 protected:
     friend class MathFunctions;

--- a/be/src/runtime/descriptors.h
+++ b/be/src/runtime/descriptors.h
@@ -81,6 +81,7 @@ public:
     // virtual ~SlotDescriptor() {};
     SlotId id() const { return _id; }
     const TypeDescriptor& type() const { return _type; }
+    TypeDescriptor& type() { return _type; }
     TupleId parent() const { return _parent; }
     // Returns the column index of this slot, including partition keys.
     // (e.g., col_pos - num_partition_keys = the table column this slot corresponds to)
@@ -111,7 +112,7 @@ private:
     friend class OlapTableSchemaParam;
 
     const SlotId _id;
-    const TypeDescriptor _type;
+    TypeDescriptor _type;
     const TupleId _parent;
     const int _col_pos;
     const int _tuple_offset;
@@ -272,6 +273,7 @@ public:
     int num_null_slots() const { return _num_null_slots; }
     int num_null_bytes() const { return _num_null_bytes; }
     const std::vector<SlotDescriptor*>& slots() const { return _slots; }
+    std::vector<SlotDescriptor*>& slots() { return _slots; }
     const std::vector<SlotDescriptor*>& string_slots() const { return _string_slots; }
     const std::vector<SlotDescriptor*>& no_string_slots() const { return _no_string_slots; }
     bool has_varlen_slots() const { return _has_varlen_slots; }

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -155,4 +155,5 @@ add_library(Olap STATIC
     vectorized/cumulative_compaction.cpp
     vectorized/compaction.cpp
     vectorized/rowset_merger.cpp
+    vectorized/column_predicate_rewriter.cpp
 )

--- a/be/src/storage/vectorized/column_predicate.h
+++ b/be/src/storage/vectorized/column_predicate.h
@@ -42,14 +42,14 @@ enum class PredicateType {
     kGT = 3,
     kGE = 4,
     kLT = 5,
-    kLE = 5,
-    kInList = 6,
-    kNotInList = 7,
-    kIsNull = 8,
-    kNotNull = 9,
-    kAnd = 10,
-    kOr = 11,
-    kExpr = 12,
+    kLE = 6,
+    kInList = 7,
+    kNotInList = 8,
+    kIsNull = 9,
+    kNotNull = 10,
+    kAnd = 11,
+    kOr = 12,
+    kExpr = 13,
 };
 
 template <typename T>

--- a/be/src/storage/vectorized/column_predicate_rewriter.cpp
+++ b/be/src/storage/vectorized/column_predicate_rewriter.cpp
@@ -1,0 +1,212 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#include "storage/vectorized/column_predicate_rewriter.h"
+
+#include <algorithm>
+#include <utility>
+
+#include "column/binary_column.h"
+#include "column/datum.h"
+#include "column/vectorized_fwd.h"
+#include "common/object_pool.h"
+#include "exprs/expr_context.h"
+#include "storage/rowset/segment_v2/column_reader.h"
+
+namespace starrocks::vectorized {
+constexpr static const FieldType kDictCodeType = OLAP_FIELD_TYPE_INT;
+
+void ColumnPredicateRewriter::rewrite_predicate(ObjectPool* pool) {
+    // because schema has reordered
+    // so we only need to check the first `predicate_column_size` fields
+    for (size_t i = 0; i < _predicate_column_size; i++) {
+        const FieldPtr& field = _schema.field(i);
+        ColumnId cid = field->id();
+        if (_predicate_need_rewrite[cid]) {
+            _rewrite_predicate(pool, field);
+        }
+    }
+}
+
+bool ColumnPredicateRewriter::_rewrite_predicate(ObjectPool* pool, const FieldPtr& field) {
+    auto cid = field->id();
+    DCHECK(_column_iterators[cid]->all_page_dict_encoded());
+    auto iter = _predicates.find(cid);
+    if (iter == _predicates.end()) {
+        return false;
+    }
+    PredicateList& preds = iter->second;
+    // the predicate has been erased, because of bitmap index filter.
+    RETURN_IF(preds.empty(), false);
+
+    // TODO: use pair<slice,int>
+    std::vector<std::pair<std::string, int>> sorted_dicts;
+
+    std::vector<const ColumnPredicate*> remove_list;
+
+    for (int i = 0; i < preds.size(); ++i) {
+        const ColumnPredicate* pred = preds[i];
+        if (PredicateType::kEQ == pred->type()) {
+            Datum value = pred->value();
+            int code = _column_iterators[cid]->dict_lookup(value.get_slice());
+            if (code < 0) {
+                // predicate always false, clear scan range, this will make `get_next` return EOF directly.
+                _scan_range = _scan_range.intersection(SparseRange());
+                continue;
+            }
+            auto ptr = new_column_eq_predicate(get_type_info(kDictCodeType), cid, std::to_string(code));
+            preds[i] = pool->add(ptr);
+            continue;
+        }
+        if (PredicateType::kNE == pred->type()) {
+            Datum value = pred->value();
+            int code = _column_iterators[cid]->dict_lookup(value.get_slice());
+            if (code < 0) {
+                if (!field->is_nullable()) {
+                    // predicate always true, clear this predicate.
+                    remove_list.push_back(preds[i]);
+                    continue;
+                } else {
+                    // convert this predicate to `not null` predicate.
+                    auto ptr = new_column_null_predicate(get_type_info(kDictCodeType), cid, false);
+                    preds[i] = pool->add(ptr);
+                    continue;
+                }
+            }
+            auto ptr = new_column_ne_predicate(get_type_info(kDictCodeType), cid, std::to_string(code));
+            preds[i] = pool->add(ptr);
+            continue;
+        }
+        if (PredicateType::kInList == pred->type()) {
+            std::vector<Datum> values = pred->values();
+            std::vector<int> codewords;
+            for (const auto& value : values) {
+                if (int code = _column_iterators[cid]->dict_lookup(value.get_slice()); code >= 0) {
+                    codewords.emplace_back(code);
+                }
+            }
+            if (codewords.empty()) {
+                // predicate always false, clear scan range.
+                _scan_range = _scan_range.intersection(SparseRange());
+                continue;
+            }
+            std::vector<std::string> str_codewords;
+            str_codewords.reserve(codewords.size());
+            for (int code : codewords) {
+                str_codewords.emplace_back(std::to_string(code));
+            }
+            auto ptr = new_column_in_predicate(get_type_info(kDictCodeType), cid, str_codewords);
+            preds[i] = pool->add(ptr);
+        }
+        if (PredicateType::kNotInList == pred->type()) {
+            std::vector<Datum> values = pred->values();
+            std::vector<int> codewords;
+            for (const auto& value : values) {
+                if (int code = _column_iterators[cid]->dict_lookup(value.get_slice()); code >= 0) {
+                    codewords.emplace_back(code);
+                }
+            }
+            if (codewords.empty()) {
+                if (!field->is_nullable()) {
+                    // predicate always true, clear this predicate.
+                    remove_list.push_back(preds[i]);
+                    continue;
+                } else {
+                    // convert this predicate to `not null` predicate.
+                    auto ptr = new_column_null_predicate(get_type_info(kDictCodeType), cid, false);
+                    preds[i] = pool->add(ptr);
+                    continue;
+                }
+            }
+            std::vector<std::string> str_codewords;
+            str_codewords.reserve(codewords.size());
+            for (int code : codewords) {
+                str_codewords.emplace_back(std::to_string(code));
+            }
+            auto ptr = new_column_not_in_predicate(get_type_info(kDictCodeType), cid, str_codewords);
+            preds[i] = pool->add(ptr);
+        }
+        if (PredicateType::kGE == pred->type() || PredicateType::kGT == pred->type()) {
+            get_segment_dict(&sorted_dicts, _column_iterators[cid]);
+            auto value = pred->value().get_slice().to_string();
+            auto iter = std::lower_bound(
+                    sorted_dicts.begin(), sorted_dicts.end(), value,
+                    [](const auto& entity, const auto& value) { return entity.first.compare(value) < 0; });
+            std::vector<std::string> str_codewords;
+            // X > 3.5 find 4, range(4, inf)
+            // X > 3 find 3, range(3, inf)
+            // X >= 3.5 find 4, range(4, inf)
+            // X >= 3 find 3, range(3, inf)
+            if (PredicateType::kGT == pred->type() && iter != sorted_dicts.end() && iter->first == value) {
+                iter++;
+            }
+            while (iter < sorted_dicts.end()) {
+                str_codewords.push_back(std::to_string(iter->second));
+                iter++;
+            }
+            if (!str_codewords.empty()) {
+                auto ptr = new_column_in_predicate(get_type_info(kDictCodeType), cid, str_codewords);
+                preds[i] = pool->add(ptr);
+            } else {
+                _scan_range = _scan_range.intersection(SparseRange());
+                continue;
+            }
+        }
+        if (PredicateType::kLE == pred->type() || PredicateType::kLT == pred->type()) {
+            get_segment_dict(&sorted_dicts, _column_iterators[cid]);
+            std::vector<std::string> str_codewords;
+            auto value = pred->value().get_slice().to_string();
+            auto iter = std::lower_bound(
+                    sorted_dicts.begin(), sorted_dicts.end(), value,
+                    [](const auto& entity, const auto& value) { return entity.first.compare(value) < 0; });
+            auto begin_iter = sorted_dicts.begin();
+            // X < 3.5 find 4, range(-inf, 3)
+            // X < 3 find 3, range(-inf, 2)
+            // X <= 3.5 find 4, range(-inf, 3)
+            // X <= 3 find 3, range(-inf, 3)
+            if (!(PredicateType::kLE == pred->type() && iter != sorted_dicts.end() && iter->first == value)) {
+                iter--;
+            }
+            while (begin_iter <= iter && begin_iter != sorted_dicts.end()) {
+                str_codewords.push_back(std::to_string(begin_iter->second));
+                begin_iter++;
+            }
+            if (!str_codewords.empty()) {
+                auto ptr = new_column_in_predicate(get_type_info(kDictCodeType), cid, str_codewords);
+                preds[i] = pool->add(ptr);
+            } else {
+                _scan_range = _scan_range.intersection(SparseRange());
+                continue;
+            }
+        }
+    }
+
+    for (const auto pred_will_remove : remove_list) {
+        auto willrm = std::find(preds.begin(), preds.end(), pred_will_remove);
+        preds.erase(willrm);
+    }
+
+    return true;
+}
+
+// This function is only used to rewrite the LE/LT/GE/GT condition.
+// For the greater than or less than condition,
+// you need to get the values of all ordered dictionaries and rewrite them as `InList` expressions
+void ColumnPredicateRewriter::get_segment_dict(std::vector<std::pair<std::string, int>>* dicts,
+                                               segment_v2::ColumnIterator* iter) {
+    auto column_iterator = down_cast<segment_v2::FileColumnIterator*>(iter);
+    auto dict_size = column_iterator->dict_size();
+    int dict_codes[dict_size];
+    std::iota(dict_codes, dict_codes + dict_size, 0);
+
+    auto column = BinaryColumn::create();
+    column_iterator->decode_dict_codes(dict_codes, dict_size, column.get());
+
+    for (int i = 0; i < dict_size; ++i) {
+        dicts->emplace_back(column->get_slice(i).to_string(), dict_codes[i]);
+    }
+
+    std::sort(dicts->begin(), dicts->end(),
+              [](const auto& e1, const auto& e2) { return e1.first.compare(e2.first) < 0; });
+}
+
+} // namespace starrocks::vectorized

--- a/be/src/storage/vectorized/column_predicate_rewriter.h
+++ b/be/src/storage/vectorized/column_predicate_rewriter.h
@@ -1,0 +1,46 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#pragma once
+
+#include <cstdint>
+
+#include "column/schema.h"
+#include "common/object_pool.h"
+#include "storage/olap_common.h"
+#include "storage/rowset/segment_v2/column_reader.h"
+#include "storage/vectorized/column_predicate.h"
+
+namespace starrocks::vectorized {
+// For dictionary columns, predicates can be rewriten
+// Int columns.
+// ColumnPredicateRewriter was a helper class, won't acquire any resource
+
+// column predicate rewrite in SegmentIter->init-> rewrite stage
+class ColumnPredicateRewriter {
+public:
+    using ColumnIterators = std::vector<segment_v2::ColumnIterator*>;
+    using PushDownPredicates = std::unordered_map<ColumnId, PredicateList>;
+
+    ColumnPredicateRewriter(ColumnIterators& column_iterators, PushDownPredicates& pushdown_predicates, Schema& schema,
+                            std::vector<uint8_t>& need_rewrite, int predicate_column_size, SparseRange& scan_range)
+            : _column_iterators(column_iterators),
+              _predicates(pushdown_predicates),
+              _schema(schema),
+              _predicate_need_rewrite(need_rewrite),
+              _predicate_column_size(predicate_column_size),
+              _scan_range(scan_range) {}
+
+    void rewrite_predicate(ObjectPool* pool);
+
+private:
+    bool _rewrite_predicate(ObjectPool* pool, const FieldPtr& field);
+    void get_segment_dict(std::vector<std::pair<std::string, int>>* dicts, segment_v2::ColumnIterator* iter);
+
+    ColumnIterators& _column_iterators;
+    PushDownPredicates& _predicates;
+    Schema& _schema;
+    std::vector<uint8_t>& _predicate_need_rewrite;
+    int _predicate_column_size;
+    SparseRange& _scan_range;
+};
+} // namespace starrocks::vectorized

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -330,6 +330,7 @@ struct TOlapScanNode {
   20: optional string rollup_name
   21: optional string sql_predicates
   22: optional bool enable_column_expr_predicate
+  23: optional map<i32, i32> dict_string_id_to_int_ids
 }
 struct TEqJoinCondition {
   // left-hand side of "<a> = <b>"


### PR DESCRIPTION
1. could rewrite simple predicate in low card column
2. could eval any predicate in olap_scan_node

For the global dictionary column, the slot type and slot id planned by FE above are
inconsistent with the actual slot and need to be rewritten by BE. In addition,
not all simple expressions can be pushed down to the storage layer,
The ability to execute expressions that cannot be successfully
pushed down is required to OLAP_SCAN_NODE.

The following SQLs can be pushed down and rewritten:
```
select count(*), d_yearmonth from dates where d_yearmonth >= 'Jan1992' and d_yearmonth <= "Jan1997x" group by d_yearmonth order by d_yearmonth;

select count(*),d_yearmonth from dates where d_yearmonth >= 'Jan1992' and d_yearmonth not in ("Jan1997", null) group by d_yearmonth having d_yearmonth != '0xff' order by d_yearmonth;

select count(*),d_yearmonth from dates where d_yearmonth >= 'ZZZZZZZZ' and d_yearmonth not in ("Jan1997", null) group by d_yearmonth having d_yearmonth != '0xff' order by d_yearmonth;
```

for #559

