### PR TITLE
remove mem_tracker from mem pool

### DIFF
--- a/be/src/exec/tablet_info.cpp
+++ b/be/src/exec/tablet_info.cpp
@@ -166,8 +166,7 @@ OlapTablePartitionParam::OlapTablePartitionParam(std::shared_ptr<OlapTableSchema
                                                  const TOlapTablePartitionParam& t_param)
         : _schema(std::move(schema)),
           _t_param(t_param),
-          _mem_tracker(new MemTracker()),
-          _mem_pool(new MemPool(_mem_tracker.get())) {}
+          _mem_pool(new MemPool()) {}
 
 OlapTablePartitionParam::~OlapTablePartitionParam() = default;
 

--- a/be/src/exec/tablet_info.cpp
+++ b/be/src/exec/tablet_info.cpp
@@ -164,9 +164,7 @@ std::string OlapTablePartition::debug_string(TupleDescriptor* tuple_desc) const 
 
 OlapTablePartitionParam::OlapTablePartitionParam(std::shared_ptr<OlapTableSchemaParam> schema,
                                                  const TOlapTablePartitionParam& t_param)
-        : _schema(std::move(schema)),
-          _t_param(t_param),
-          _mem_pool(new MemPool()) {}
+        : _schema(std::move(schema)), _t_param(t_param), _mem_pool(new MemPool()) {}
 
 OlapTablePartitionParam::~OlapTablePartitionParam() = default;
 

--- a/be/src/exec/tablet_info.h
+++ b/be/src/exec/tablet_info.h
@@ -191,7 +191,6 @@ private:
     std::vector<SlotDescriptor*> _distributed_slot_descs;
 
     ObjectPool _obj_pool;
-    std::unique_ptr<MemTracker> _mem_tracker;
     std::unique_ptr<MemPool> _mem_pool;
     std::vector<OlapTablePartition*> _partitions;
     std::unique_ptr<std::map<Tuple*, OlapTablePartition*, OlapTablePartKeyComparator>> _partitions_map;

--- a/be/src/exec/vectorized/aggregate/agg_hash_map.h
+++ b/be/src/exec/vectorized/aggregate/agg_hash_map.h
@@ -463,8 +463,7 @@ struct AggHashMapWithSerializedKey {
     HashMap hash_map;
 
     AggHashMapWithSerializedKey()
-            : tracker(std::make_unique<MemTracker>()),
-              mem_pool(std::make_unique<MemPool>(tracker.get())),
+            : mem_pool(std::make_unique<MemPool>()),
               buffer(mem_pool->allocate(max_one_row_size * config::vector_chunk_size)) {}
 
     template <typename Func>
@@ -563,7 +562,6 @@ struct AggHashMapWithSerializedKey {
     Buffer<uint32_t> slice_sizes;
     uint32_t max_one_row_size = 8;
 
-    std::unique_ptr<MemTracker> tracker;
     std::unique_ptr<MemPool> mem_pool;
     uint8_t* buffer;
     ResultVector results;
@@ -588,7 +586,7 @@ struct AggHashMapWithSerializedKeyFixedSize {
     std::vector<CacheEntry> caches;
 
     AggHashMapWithSerializedKeyFixedSize()
-            : tracker(std::make_unique<MemTracker>()), mem_pool(std::make_unique<MemPool>(tracker.get())) {
+            : mem_pool(std::make_unique<MemPool>()) {
         caches.reserve(config::vector_chunk_size);
         uint8_t* buffer = reinterpret_cast<uint8_t*>(caches.data());
         memset(buffer, 0x0, max_fixed_size * config::vector_chunk_size);
@@ -704,7 +702,6 @@ struct AggHashMapWithSerializedKeyFixedSize {
     static constexpr bool has_single_null_key = false;
 
     Buffer<uint32_t> slice_sizes;
-    std::unique_ptr<MemTracker> tracker;
     std::unique_ptr<MemPool> mem_pool;
     ResultVector results;
     std::vector<Slice> tmp_slices;

--- a/be/src/exec/vectorized/aggregate/agg_hash_map.h
+++ b/be/src/exec/vectorized/aggregate/agg_hash_map.h
@@ -585,8 +585,7 @@ struct AggHashMapWithSerializedKeyFixedSize {
 
     std::vector<CacheEntry> caches;
 
-    AggHashMapWithSerializedKeyFixedSize()
-            : mem_pool(std::make_unique<MemPool>()) {
+    AggHashMapWithSerializedKeyFixedSize() : mem_pool(std::make_unique<MemPool>()) {
         caches.reserve(config::vector_chunk_size);
         uint8_t* buffer = reinterpret_cast<uint8_t*>(caches.data());
         memset(buffer, 0x0, max_fixed_size * config::vector_chunk_size);

--- a/be/src/exec/vectorized/aggregate/agg_hash_set.h
+++ b/be/src/exec/vectorized/aggregate/agg_hash_set.h
@@ -317,8 +317,7 @@ struct AggHashSetOfSerializedKey {
     HashSet hash_set;
 
     AggHashSetOfSerializedKey()
-            : _tracker(std::make_unique<MemTracker>()),
-              _mem_pool(std::make_unique<MemPool>(_tracker.get())),
+            : _mem_pool(std::make_unique<MemPool>()),
               _buffer(_mem_pool->allocate(max_one_row_size * config::vector_chunk_size)) {}
 
     void build_set(size_t chunk_size, const Columns& key_columns, MemPool* pool) {
@@ -409,7 +408,6 @@ struct AggHashSetOfSerializedKey {
     Buffer<uint32_t> slice_sizes;
     size_t max_one_row_size = 8;
 
-    std::unique_ptr<MemTracker> _tracker;
     std::unique_ptr<MemPool> _mem_pool;
     uint8_t* _buffer;
     ResultVector results;
@@ -428,8 +426,7 @@ struct AggHashSetOfSerializedKeyFixedSize {
     static constexpr size_t max_fixed_size = sizeof(FixedSizeSliceKey);
 
     AggHashSetOfSerializedKeyFixedSize()
-            : _tracker(std::make_unique<MemTracker>()),
-              _mem_pool(std::make_unique<MemPool>(_tracker.get())),
+            : _mem_pool(std::make_unique<MemPool>()),
               buffer(_mem_pool->allocate(max_fixed_size * config::vector_chunk_size)) {
         memset(buffer, 0x0, max_fixed_size * config::vector_chunk_size);
     }
@@ -522,7 +519,6 @@ struct AggHashSetOfSerializedKeyFixedSize {
     static constexpr bool has_single_null_key = false;
 
     Buffer<uint32_t> slice_sizes;
-    std::unique_ptr<MemTracker> _tracker;
     std::unique_ptr<MemPool> _mem_pool;
     uint8_t* buffer;
     ResultVector results;

--- a/be/src/exec/vectorized/aggregator.cpp
+++ b/be/src/exec/vectorized/aggregator.cpp
@@ -181,7 +181,7 @@ Status Aggregator::prepare(RuntimeState* state, ObjectPool* pool, MemTracker* me
         RETURN_IF_ERROR(Expr::prepare(ctx, state, child_row_desc));
     }
 
-    _mem_pool = std::make_unique<MemPool>(_mem_tracker);
+    _mem_pool = std::make_unique<MemPool>();
 
     // Initial for FunctionContext of every aggregate functions
     for (int i = 0; i < _agg_fn_ctxs.size(); ++i) {

--- a/be/src/exec/vectorized/analytor.cpp
+++ b/be/src/exec/vectorized/analytor.cpp
@@ -217,7 +217,7 @@ Status Analytor::prepare(RuntimeState* state, ObjectPool* pool, MemTracker* mem_
     }
 
     SCOPED_TIMER(_runtime_profile->total_time_counter());
-    _mem_pool.reset(new MemPool(_mem_tracker));
+    _mem_pool.reset(new MemPool());
 
     _compute_timer = ADD_TIMER(_runtime_profile, "ComputeTime");
     DCHECK_EQ(_result_tuple_desc->slots().size(), _agg_functions.size());

--- a/be/src/exec/vectorized/es_http_scanner.cpp
+++ b/be/src/exec/vectorized/es_http_scanner.cpp
@@ -24,8 +24,6 @@ EsHttpScanner::EsHttpScanner(RuntimeState* state, RuntimeProfile* profile, Tuple
           _next_range(0),
           _line_eof(true),
           _batch_eof(false),
-          _mem_tracker(new MemTracker(-1, "EsHttp FileScanner", state->instance_mem_tracker())),
-          _mem_pool(_state->instance_mem_tracker()),
           _tuple_desc(nullptr),
           _es_reader(nullptr),
           _es_scroll_parser(nullptr),

--- a/be/src/exec/vectorized/es_http_scanner.h
+++ b/be/src/exec/vectorized/es_http_scanner.h
@@ -51,7 +51,6 @@ private:
     int _next_range;
     bool _line_eof;
     bool _batch_eof;
-    std::unique_ptr<MemTracker> _mem_tracker;
     MemPool _mem_pool;
 
     const TupleDescriptor* _tuple_desc;

--- a/be/src/exec/vectorized/except_node.cpp
+++ b/be/src/exec/vectorized/except_node.cpp
@@ -33,7 +33,7 @@ Status ExceptNode::prepare(RuntimeState* state) {
     _tuple_desc = state->desc_tbl().get_tuple_descriptor(_tuple_id);
 
     DCHECK(_tuple_desc != nullptr);
-    _build_pool = std::make_unique<MemPool>(mem_tracker());
+    _build_pool = std::make_unique<MemPool>();
 
     _build_set_timer = ADD_TIMER(runtime_profile(), "BuildSetTime");
     _erase_duplicate_row_timer = ADD_TIMER(runtime_profile(), "EraseDuplicateRowTime");

--- a/be/src/exec/vectorized/except_node.h
+++ b/be/src/exec/vectorized/except_node.h
@@ -55,8 +55,7 @@ class ExceptNode : public ExecNode {
 
         HashSetFromExprs()
                 : hash_set(std::make_unique<HashSet>()),
-                  _tracker(std::make_unique<MemTracker>()),
-                  _mem_pool(std::make_unique<MemPool>(_tracker.get())),
+                  _mem_pool(std::make_unique<MemPool>()),
                   _buffer(_mem_pool->allocate(_max_one_row_size * config::vector_chunk_size)) {}
 
         Iterator begin() { return hash_set->begin(); }
@@ -162,7 +161,6 @@ class ExceptNode : public ExecNode {
 
         Buffer<uint32_t> _slice_sizes;
         size_t _max_one_row_size = 8;
-        std::unique_ptr<MemTracker> _tracker;
         std::unique_ptr<MemPool> _mem_pool;
         uint8_t* _buffer;
         ResultVector _results;

--- a/be/src/exec/vectorized/hdfs_scan_node.cpp
+++ b/be/src/exec/vectorized/hdfs_scan_node.cpp
@@ -65,7 +65,7 @@ Status HdfsScanNode::init(const TPlanNode& tnode, RuntimeState* state) {
         _hive_column_names = tnode.hdfs_scan_node.hive_column_names;
     }
 
-    _mem_pool = std::make_unique<MemPool>(state->instance_mem_tracker());
+    _mem_pool = std::make_unique<MemPool>();
 
     return Status::OK();
 }

--- a/be/src/exec/vectorized/intersect_node.cpp
+++ b/be/src/exec/vectorized/intersect_node.cpp
@@ -34,7 +34,7 @@ Status IntersectNode::prepare(RuntimeState* state) {
     _tuple_desc = state->desc_tbl().get_tuple_descriptor(_tuple_id);
 
     DCHECK(_tuple_desc != nullptr);
-    _build_pool = std::make_unique<MemPool>(mem_tracker());
+    _build_pool = std::make_unique<MemPool>();
 
     _build_set_timer = ADD_TIMER(runtime_profile(), "BuildSetTime");
     _refine_intersect_row_timer = ADD_TIMER(runtime_profile(), "RefineIntersectRowTime");

--- a/be/src/exec/vectorized/intersect_node.h
+++ b/be/src/exec/vectorized/intersect_node.h
@@ -54,8 +54,7 @@ class IntersectNode : public ExecNode {
 
         HashSetFromExprs()
                 : hash_set(std::make_unique<HashSet>()),
-                  _tracker(std::make_unique<MemTracker>()),
-                  _mem_pool(std::make_unique<MemPool>(_tracker.get())),
+                  _mem_pool(std::make_unique<MemPool>()),
                   _buffer(_mem_pool->allocate(_max_one_row_size * config::vector_chunk_size)) {}
 
         Iterator begin() { return hash_set->begin(); }
@@ -175,7 +174,6 @@ class IntersectNode : public ExecNode {
 
         Buffer<uint32_t> _slice_sizes;
         size_t _max_one_row_size = 8;
-        std::unique_ptr<MemTracker> _tracker;
         std::unique_ptr<MemPool> _mem_pool;
         uint8_t* _buffer;
         ResultVector _results;

--- a/be/src/exec/vectorized/join_hash_map.cpp
+++ b/be/src/exec/vectorized/join_hash_map.cpp
@@ -225,8 +225,8 @@ void JoinHashTable::create(const HashTableParam& param) {
     _table_items.bucket_size = 0;
     _table_items.build_chunk = std::make_shared<Chunk>();
     _table_items.mem_tracker = param.mem_tracker;
-    _table_items.build_pool = std::make_unique<MemPool>(_table_items.mem_tracker);
-    _table_items.probe_pool = std::make_unique<MemPool>(_table_items.mem_tracker);
+    _table_items.build_pool = std::make_unique<MemPool>();
+    _table_items.probe_pool = std::make_unique<MemPool>();
     _table_items.with_other_conjunct = param.with_other_conjunct;
     _table_items.join_type = param.join_type;
     _table_items.row_desc = param.row_desc;

--- a/be/src/exec/vectorized/mysql_scan_node.cpp
+++ b/be/src/exec/vectorized/mysql_scan_node.cpp
@@ -61,7 +61,7 @@ Status MysqlScanNode::prepare(RuntimeState* state) {
     _mysql_scanner.reset(new (std::nothrow) MysqlScanner(_my_param));
     DCHECK(_mysql_scanner != nullptr);
 
-    _tuple_pool.reset(new (std::nothrow) MemPool(mem_tracker()));
+    _tuple_pool.reset(new (std::nothrow) MemPool());
     DCHECK(_tuple_pool != nullptr);
 
     _is_init = true;

--- a/be/src/exprs/expr_context.cpp
+++ b/be/src/exprs/expr_context.cpp
@@ -60,7 +60,7 @@ Status ExprContext::prepare(RuntimeState* state, const RowDescriptor& row_desc) 
     }
     DCHECK(_pool.get() == nullptr);
     _prepared = true;
-    _pool = std::make_unique<MemPool>(state->instance_mem_tracker());
+    _pool = std::make_unique<MemPool>();
     return _root->prepare(state, row_desc, this);
 }
 
@@ -117,7 +117,7 @@ Status ExprContext::clone(RuntimeState* state, ExprContext** new_ctx) {
     DCHECK(*new_ctx == nullptr);
 
     *new_ctx = state->obj_pool()->add(new ExprContext(_root));
-    (*new_ctx)->_pool = std::make_unique<MemPool>(_pool->mem_tracker());
+    (*new_ctx)->_pool = std::make_unique<MemPool>();
     for (auto& _fn_context : _fn_contexts) {
         (*new_ctx)->_fn_contexts.push_back(_fn_context->impl()->clone((*new_ctx)->_pool.get()));
     }
@@ -136,7 +136,7 @@ Status ExprContext::clone(RuntimeState* state, ExprContext** new_ctx, Expr* root
     DCHECK(*new_ctx == nullptr);
 
     *new_ctx = state->obj_pool()->add(new ExprContext(root));
-    (*new_ctx)->_pool = std::make_unique<MemPool>(_pool->mem_tracker());
+    (*new_ctx)->_pool = std::make_unique<MemPool>();
     for (auto& _fn_context : _fn_contexts) {
         (*new_ctx)->_fn_contexts.push_back(_fn_context->impl()->clone((*new_ctx)->_pool.get()));
     }

--- a/be/src/runtime/mem_pool.cpp
+++ b/be/src/runtime/mem_pool.cpp
@@ -50,7 +50,6 @@ MemPool::~MemPool() {
         total_bytes_released += chunk.chunk.size;
         ChunkAllocator::instance()->free(chunk.chunk);
     }
-    mem_tracker_->release(total_bytes_released);
     StarRocksMetrics::instance()->memory_pool_bytes_total.increment(-total_bytes_released);
 }
 
@@ -76,7 +75,6 @@ void MemPool::free_all() {
     total_allocated_bytes_ = 0;
     total_reserved_bytes_ = 0;
 
-    mem_tracker_->release(total_bytes_released);
     StarRocksMetrics::instance()->memory_pool_bytes_total.increment(-total_bytes_released);
 }
 
@@ -105,7 +103,7 @@ bool MemPool::find_chunk(size_t min_size, bool check_limits) {
     }
 
     // Didn't find a big enough free chunk - need to allocate new chunk.
-    size_t chunk_size = 0;
+    size_t chunk_size;
     DCHECK_LE(next_chunk_size_, MAX_CHUNK_SIZE);
 
     if (config::disable_mem_pools) {
@@ -118,16 +116,10 @@ bool MemPool::find_chunk(size_t min_size, bool check_limits) {
     }
 
     chunk_size = BitUtil::RoundUpToPowerOfTwo(chunk_size);
-    if (check_limits) {
-        if (!mem_tracker_->try_consume(chunk_size)) return false;
-    } else {
-        mem_tracker_->consume(chunk_size);
-    }
 
     // Allocate a new chunk. Return early if allocate fails.
     Chunk chunk;
     if (!ChunkAllocator::instance()->allocate(chunk_size, &chunk)) {
-        mem_tracker_->release(chunk_size);
         return false;
     }
     ASAN_POISON_MEMORY_REGION(chunk.data, chunk_size);
@@ -172,12 +164,6 @@ void MemPool::acquire_data(MemPool* src, bool keep_current) {
     src->total_reserved_bytes_ -= total_transfered_bytes;
     total_reserved_bytes_ += total_transfered_bytes;
 
-    // Skip unnecessary atomic ops if the mem_trackers are the same.
-    if (src->mem_tracker_ != mem_tracker_) {
-        src->mem_tracker_->release(total_transfered_bytes);
-        mem_tracker_->consume(total_transfered_bytes);
-    }
-
     // insert new chunks after current_chunk_idx_
     auto insert_chunk = chunks_.begin() + current_chunk_idx_ + 1;
     chunks_.insert(insert_chunk, src->chunks_.begin(), end_chunk);
@@ -203,18 +189,12 @@ void MemPool::acquire_data(MemPool* src, bool keep_current) {
 }
 
 void MemPool::exchange_data(MemPool* other) {
-    int64_t delta_size = other->total_reserved_bytes_ - total_reserved_bytes_;
-
     std::swap(current_chunk_idx_, other->current_chunk_idx_);
     std::swap(next_chunk_size_, other->next_chunk_size_);
     std::swap(total_allocated_bytes_, other->total_allocated_bytes_);
     std::swap(total_reserved_bytes_, other->total_reserved_bytes_);
     std::swap(peak_allocated_bytes_, other->peak_allocated_bytes_);
     std::swap(chunks_, other->chunks_);
-
-    // update MemTracker
-    mem_tracker_->consume(delta_size);
-    other->mem_tracker_->release(delta_size);
 }
 
 std::string MemPool::debug_string() {

--- a/be/src/runtime/mem_pool.h
+++ b/be/src/runtime/mem_pool.h
@@ -91,16 +91,12 @@ class MemTracker;
 ///    delete p;
 class MemPool {
 public:
-    /// 'tracker' tracks the amount of memory allocated by this pool. Must not be NULL.
-    MemPool(MemTracker* mem_tracker)
+    MemPool()
             : current_chunk_idx_(-1),
               next_chunk_size_(INITIAL_CHUNK_SIZE),
               total_allocated_bytes_(0),
               total_reserved_bytes_(0),
-              peak_allocated_bytes_(0),
-              mem_tracker_(mem_tracker) {
-        DCHECK(mem_tracker != nullptr);
-    }
+              peak_allocated_bytes_(0) {}
 
     /// Frees all chunks of memory and subtracts the total allocated bytes
     /// from the registered limits.
@@ -164,8 +160,6 @@ public:
     int64_t total_allocated_bytes() const { return total_allocated_bytes_; }
     int64_t total_reserved_bytes() const { return total_reserved_bytes_; }
     int64_t peak_allocated_bytes() const { return peak_allocated_bytes_; }
-
-    MemTracker* mem_tracker() { return mem_tracker_; }
 
     static const int DEFAULT_ALIGNMENT = 16;
 
@@ -269,10 +263,6 @@ private:
     int64_t peak_allocated_bytes_;
 
     std::vector<ChunkInfo> chunks_;
-
-    /// The current and peak memory footprint of this pool. This is different from
-    /// total allocated_bytes_ since it includes bytes in chunks that are not used.
-    MemTracker* mem_tracker_;
 };
 
 // Stamp out templated implementations here so they're included in IR module

--- a/be/src/runtime/row_batch.cpp
+++ b/be/src/runtime/row_batch.cpp
@@ -45,7 +45,7 @@ RowBatch::RowBatch(const RowDescriptor& row_desc, int capacity, MemTracker* mem_
           _num_tuples_per_row(row_desc.tuple_descriptors().size()),
           _row_desc(row_desc),
           _need_to_return(false),
-          _tuple_data_pool(new MemPool(_mem_tracker)) {
+          _tuple_data_pool(new MemPool()) {
     DCHECK(_mem_tracker != nullptr);
     DCHECK_GT(capacity, 0);
     _tuple_ptrs_size = _capacity * _num_tuples_per_row * sizeof(Tuple*);
@@ -74,7 +74,7 @@ RowBatch::RowBatch(const RowDescriptor& row_desc, const PRowBatch& input_batch, 
           _num_tuples_per_row(input_batch.row_tuples_size()),
           _row_desc(row_desc),
           _need_to_return(false),
-          _tuple_data_pool(new MemPool(_mem_tracker)) {
+          _tuple_data_pool(new MemPool()) {
     DCHECK(_mem_tracker != nullptr);
     _tuple_ptrs_size = _num_rows * _num_tuples_per_row * sizeof(Tuple*);
     DCHECK_GT(_tuple_ptrs_size, 0);
@@ -166,7 +166,7 @@ RowBatch::RowBatch(const RowDescriptor& row_desc, const TRowBatch& input_batch, 
           _num_tuples_per_row(input_batch.row_tuples.size()),
           _row_desc(row_desc),
           _need_to_return(false),
-          _tuple_data_pool(new MemPool(_mem_tracker)) {
+          _tuple_data_pool(new MemPool()) {
     DCHECK(_mem_tracker != nullptr);
     _tuple_ptrs_size = _num_rows * input_batch.row_tuples.size() * sizeof(Tuple*);
     DCHECK_GT(_tuple_ptrs_size, 0);

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -197,13 +197,13 @@ Status RuntimeState::init_mem_trackers(const TUniqueId& query_id) {
     _instance_mem_tracker =
             std::make_unique<MemTracker>(&_profile, -1, runtime_profile()->name(), _query_mem_tracker.get());
 
-    _instance_mem_pool = std::make_unique<MemPool>(_instance_mem_tracker.get());
+    _instance_mem_pool = std::make_unique<MemPool>();
     return Status::OK();
 }
 
 Status RuntimeState::init_instance_mem_tracker() {
     _instance_mem_tracker = std::make_unique<MemTracker>(-1);
-    _instance_mem_pool = std::make_unique<MemPool>(_instance_mem_tracker.get());
+    _instance_mem_pool = std::make_unique<MemPool>();
     return Status::OK();
 }
 

--- a/be/src/runtime/tablets_channel.cpp
+++ b/be/src/runtime/tablets_channel.cpp
@@ -39,7 +39,7 @@ std::atomic<uint64_t> TabletsChannel::_s_tablet_writer_count;
 TabletsChannel::TabletsChannel(const TabletsChannelKey& key, MemTracker* mem_tracker)
         : _key(key), _state(kInitialized), _closed_senders(64) {
     _mem_tracker = std::make_unique<MemTracker>(-1, "tablets channel", mem_tracker, true);
-    _mem_pool = std::make_unique<MemPool>(_mem_tracker.get());
+    _mem_pool = std::make_unique<MemPool>();
     static std::once_flag once_flag;
     std::call_once(once_flag, [] {
         REGISTER_GAUGE_STARROCKS_METRIC(tablet_writer_count, [&]() { return _s_tablet_writer_count.load(); });

--- a/be/src/runtime/vectorized_row_batch.cpp
+++ b/be/src/runtime/vectorized_row_batch.cpp
@@ -29,8 +29,7 @@ VectorizedRowBatch::VectorizedRowBatch(const TabletSchema* schema, const std::ve
     _selected_in_use = false;
     _size = 0;
 
-    _tracker = std::make_unique<MemTracker>(-1);
-    _mem_pool = std::make_unique<MemPool>(_tracker.get());
+    _mem_pool = std::make_unique<MemPool>();
 
     _selected = reinterpret_cast<uint16_t*>(new char[sizeof(uint16_t) * _capacity]);
 

--- a/be/src/runtime/vectorized_row_batch.h
+++ b/be/src/runtime/vectorized_row_batch.h
@@ -119,7 +119,6 @@ private:
     bool _selected_in_use = false;
     uint8_t _block_status = 0;
 
-    std::unique_ptr<MemTracker> _tracker;
     std::unique_ptr<MemPool> _mem_pool;
     uint16_t _limit;
 };

--- a/be/src/storage/aggregate_func.h
+++ b/be/src/storage/aggregate_func.h
@@ -26,7 +26,6 @@
 #include "runtime/datetime_value.h"
 #include "runtime/decimalv2_value.h"
 #include "runtime/mem_pool.h"
-#include "runtime/mem_tracker.h"
 #include "runtime/string_value.h"
 #include "runtime/timestamp_value.h"
 #include "storage/hll.h"
@@ -509,8 +508,6 @@ struct AggregateFuncTraits<OLAP_FIELD_AGGREGATION_HLL_UNION, OLAP_FIELD_TYPE_HLL
         }
         dst_slice->data = reinterpret_cast<char*>(hll);
 
-        mem_pool->mem_tracker()->consume(sizeof(HyperLogLog));
-
         agg_pool->add(hll);
     }
 
@@ -561,8 +558,6 @@ struct AggregateFuncTraits<OLAP_FIELD_AGGREGATION_BITMAP_UNION, OLAP_FIELD_TYPE_
         }
 
         dst_slice->data = (char*)bitmap;
-
-        mem_pool->mem_tracker()->consume(sizeof(BitmapValue));
 
         agg_pool->add(bitmap);
     }
@@ -620,8 +615,6 @@ struct AggregateFuncTraits<OLAP_FIELD_AGGREGATION_PERCENTILE_UNION, OLAP_FIELD_T
         }
 
         dst_slice->data = reinterpret_cast<char*>(percentile);
-
-        mem_pool->mem_tracker()->consume(sizeof(PercentileValue));
 
         agg_pool->add(percentile);
     }

--- a/be/src/storage/memtable.cpp
+++ b/be/src/storage/memtable.cpp
@@ -46,8 +46,8 @@ MemTable::MemTable(int64_t tablet_id, Schema* schema, const TabletSchema* tablet
           _rowset_writer(rowset_writer) {
     _schema_size = _schema->schema_size();
     _mem_tracker = std::make_unique<MemTracker>(-1, "memtable", mem_tracker, true);
-    _buffer_mem_pool = std::make_unique<MemPool>(_mem_tracker.get());
-    _table_mem_pool = std::make_unique<MemPool>(_mem_tracker.get());
+    _buffer_mem_pool = std::make_unique<MemPool>();
+    _table_mem_pool = std::make_unique<MemPool>();
     _skip_list = new Table(_row_comparator, _table_mem_pool.get(), _keys_type == KeysType::DUP_KEYS);
 }
 

--- a/be/src/storage/merger.cpp
+++ b/be/src/storage/merger.cpp
@@ -70,7 +70,7 @@ OLAPStatus Merger::merge_rowsets(MemTracker* mem_tracker, const TabletSharedPtr&
     // TODO: add mem_tracker for ObjectPool?
     DeferOp release_object_pool_memory([&tracker] { return tracker->release(tracker->consumption()); });
 
-    std::unique_ptr<MemPool> mem_pool(new MemPool(tracker.get()));
+    std::unique_ptr<MemPool> mem_pool(new MemPool());
 
     RowCursor row_cursor;
     RETURN_NOT_OK_LOG(row_cursor.init(tablet->tablet_schema()),

--- a/be/src/storage/push_handler.cpp
+++ b/be/src/storage/push_handler.cpp
@@ -485,7 +485,7 @@ OLAPStatus PushBrokerReader::init(const Schema* schema, const TBrokerScanRange& 
         LOG(WARNING) << "Failed to init mem trackers, msg: " << status.get_error_msg();
         return OLAP_ERR_PUSH_INIT_ERROR;
     }
-    _mem_pool = std::make_unique<MemPool>(_runtime_state->instance_mem_tracker());
+    _mem_pool = std::make_unique<MemPool>();
 
     switch (t_scan_range.ranges[0].format_type) {
     default:

--- a/be/src/storage/reader.cpp
+++ b/be/src/storage/reader.cpp
@@ -301,8 +301,7 @@ void CollectIterator::clear() {
 }
 
 Reader::Reader() {
-    _tracker = std::make_unique<MemTracker>(-1);
-    _predicate_mem_pool = std::make_unique<MemPool>(_tracker.get());
+    _predicate_mem_pool = std::make_unique<MemPool>();
 }
 
 Reader::~Reader() {

--- a/be/src/storage/reader.h
+++ b/be/src/storage/reader.h
@@ -197,7 +197,6 @@ private:
     TabletSharedPtr tablet() { return _tablet; }
 
 private:
-    std::unique_ptr<MemTracker> _tracker;
     std::unique_ptr<MemPool> _predicate_mem_pool;
     std::set<uint32_t> _load_bf_columns;
     std::vector<uint32_t> _return_columns;

--- a/be/src/storage/row_block.cpp
+++ b/be/src/storage/row_block.cpp
@@ -43,8 +43,7 @@ using std::vector;
 namespace starrocks {
 
 RowBlock::RowBlock(const TabletSchema* schema) : _capacity(0), _schema(schema) {
-    _tracker = std::make_unique<MemTracker>(-1);
-    _mem_pool = std::make_unique<MemPool>(_tracker.get());
+    _mem_pool = std::make_unique<MemPool>();
 }
 
 RowBlock::~RowBlock() {

--- a/be/src/storage/row_block.h
+++ b/be/src/storage/row_block.h
@@ -126,7 +126,6 @@ private:
     size_t _limit = 0;
     uint8_t _block_status = DEL_PARTIAL_SATISFIED;
 
-    std::unique_ptr<MemTracker> _tracker;
     std::unique_ptr<MemPool> _mem_pool;
 
     RowBlock(const RowBlock&) = delete;

--- a/be/src/storage/row_block2.cpp
+++ b/be/src/storage/row_block2.cpp
@@ -34,8 +34,7 @@ RowBlockV2::RowBlockV2(const Schema& schema, uint16_t capacity)
         : _schema(schema),
           _capacity(capacity),
           _column_vector_batches(_schema.num_columns()),
-          _tracker(new MemTracker(-1, "RowBlockV2")),
-          _pool(new MemPool(_tracker.get())),
+          _pool(new MemPool()),
           _selection_vector(nullptr) {
     for (auto cid : _schema.column_ids()) {
         Status status = ColumnVectorBatch::create(

--- a/be/src/storage/row_block2.h
+++ b/be/src/storage/row_block2.h
@@ -120,8 +120,6 @@ private:
     std::vector<std::unique_ptr<ColumnVectorBatch>> _column_vector_batches;
 
     size_t _num_rows;
-    // manages the memory for slice's data
-    std::unique_ptr<MemTracker> _tracker;
     std::unique_ptr<MemPool> _pool;
 
     // index of selected rows for rows passed the predicate

--- a/be/src/storage/rowset/segment_v2/binary_dict_page.cpp
+++ b/be/src/storage/rowset/segment_v2/binary_dict_page.cpp
@@ -41,8 +41,7 @@ BinaryDictPageBuilder::BinaryDictPageBuilder(const PageBuilderOptions& options)
           _finished(false),
           _data_page_builder(nullptr),
           _dict_builder(nullptr),
-          _encoding_type(DICT_ENCODING),
-          _pool(&_tracker) {
+          _encoding_type(DICT_ENCODING) {
     // initially use DICT_ENCODING
     _data_page_builder = std::make_unique<BitshufflePageBuilder<OLAP_FIELD_TYPE_INT>>(options);
     _data_page_builder->reserve_head(BINARY_DICT_PAGE_HEADER_SIZE);

--- a/be/src/storage/rowset/segment_v2/binary_dict_page.h
+++ b/be/src/storage/rowset/segment_v2/binary_dict_page.h
@@ -110,7 +110,6 @@ private:
     // query for dict item -> dict id
     phmap::flat_hash_map<std::string, uint32_t, HashOfSlice, Eq> _dictionary;
     // TODO(zc): rethink about this mem pool
-    MemTracker _tracker;
     MemPool _pool;
     faststring _first_value;
 };

--- a/be/src/storage/rowset/segment_v2/bitmap_index_reader.h
+++ b/be/src/storage/rowset/segment_v2/bitmap_index_reader.h
@@ -93,7 +93,7 @@ public:
               _has_null(has_null),
               _num_bitmap(num_bitmap),
               _current_rowid(0),
-              _pool(new MemPool(&_tracker)) {}
+              _pool(new MemPool()) {}
 
     bool has_null_bitmap() const { return _has_null; }
 
@@ -140,7 +140,6 @@ private:
     bool _has_null;
     rowid_t _num_bitmap;
     rowid_t _current_rowid;
-    MemTracker _tracker;
     std::unique_ptr<MemPool> _pool;
 };
 

--- a/be/src/storage/rowset/segment_v2/bitmap_index_writer.cpp
+++ b/be/src/storage/rowset/segment_v2/bitmap_index_writer.cpp
@@ -69,8 +69,7 @@ public:
     using CppType = typename CppTypeTraits<field_type>::CppType;
     using MemoryIndexType = typename BitmapIndexTraits<CppType>::MemoryIndexType;
 
-    explicit BitmapIndexWriterImpl(TypeInfoPtr type_info)
-            : _typeinfo(std::move(type_info)), _reverted_index_size(0), _pool(&_tracker) {}
+    explicit BitmapIndexWriterImpl(TypeInfoPtr type_info) : _typeinfo(std::move(type_info)), _reverted_index_size(0) {}
 
     ~BitmapIndexWriterImpl() override = default;
 

--- a/be/src/storage/rowset/segment_v2/bloom_filter_index_reader.h
+++ b/be/src/storage/rowset/segment_v2/bloom_filter_index_reader.h
@@ -86,11 +86,10 @@ public:
 
 private:
     BloomFilterIndexIterator(BloomFilterIndexReader* reader, std::unique_ptr<IndexedColumnIterator> bf_iter)
-            : _reader(reader), _bloom_filter_iter(std::move(bf_iter)), _pool(new MemPool(&_tracker)) {}
+            : _reader(reader), _bloom_filter_iter(std::move(bf_iter)), _pool(new MemPool()) {}
 
     BloomFilterIndexReader* _reader;
     std::unique_ptr<IndexedColumnIterator> _bloom_filter_iter;
-    MemTracker _tracker;
     std::unique_ptr<MemPool> _pool;
 };
 

--- a/be/src/storage/rowset/segment_v2/bloom_filter_index_writer.cpp
+++ b/be/src/storage/rowset/segment_v2/bloom_filter_index_writer.cpp
@@ -98,10 +98,7 @@ public:
     using ValueDict = typename BloomFilterTraits<CppType>::ValueDict;
 
     explicit BloomFilterIndexWriterImpl(const BloomFilterOptions& bf_options, TypeInfoPtr typeinfo)
-            : _bf_options(bf_options),
-              _typeinfo(std::move(typeinfo)),
-              _has_null(false),
-              _bf_buffer_size(0) {}
+            : _bf_options(bf_options), _typeinfo(std::move(typeinfo)), _has_null(false), _bf_buffer_size(0) {}
 
     ~BloomFilterIndexWriterImpl() override = default;
 

--- a/be/src/storage/rowset/segment_v2/bloom_filter_index_writer.cpp
+++ b/be/src/storage/rowset/segment_v2/bloom_filter_index_writer.cpp
@@ -100,8 +100,6 @@ public:
     explicit BloomFilterIndexWriterImpl(const BloomFilterOptions& bf_options, TypeInfoPtr typeinfo)
             : _bf_options(bf_options),
               _typeinfo(std::move(typeinfo)),
-
-              _pool(&_tracker),
               _has_null(false),
               _bf_buffer_size(0) {}
 
@@ -167,7 +165,6 @@ public:
 private:
     BloomFilterOptions _bf_options;
     TypeInfoPtr _typeinfo;
-    MemTracker _tracker;
     MemPool _pool;
     bool _has_null;
     uint64_t _bf_buffer_size;

--- a/be/src/storage/rowset/segment_v2/column_reader.h
+++ b/be/src/storage/rowset/segment_v2/column_reader.h
@@ -606,7 +606,7 @@ public:
               _schema_length(schema_length),
               _is_default_value_null(false),
               _type_size(0),
-              _pool(new MemPool(&_tracker)),
+              _pool(new MemPool()),
               _num_rows(num_rows) {}
 
     Status init(const ColumnIteratorOptions& opts) override;

--- a/be/src/storage/rowset/segment_v2/indexed_column_writer.cpp
+++ b/be/src/storage/rowset/segment_v2/indexed_column_writer.cpp
@@ -46,8 +46,6 @@ IndexedColumnWriter::IndexedColumnWriter(const IndexedColumnWriterOptions& optio
         : _options(options),
           _typeinfo(std::move(typeinfo)),
           _wblock(wblock),
-          _mem_tracker(-1),
-          _mem_pool(&_mem_tracker),
           _num_values(0),
           _num_data_pages(0),
           _validx_key_coder(nullptr),

--- a/be/src/storage/rowset/segment_v2/indexed_column_writer.h
+++ b/be/src/storage/rowset/segment_v2/indexed_column_writer.h
@@ -96,7 +96,6 @@ private:
     TypeInfoPtr _typeinfo;
     fs::WritableBlock* _wblock;
     // only used for `_first_value`
-    MemTracker _mem_tracker;
     MemPool _mem_pool;
 
     ordinal_t _num_values;

--- a/be/src/storage/rowset/segment_v2/zone_map_index.cpp
+++ b/be/src/storage/rowset/segment_v2/zone_map_index.cpp
@@ -90,7 +90,6 @@ private:
     ZoneMap _segment_zone_map;
     // TODO(zc): we should replace this memory pool later, we only allocate min/max
     // for field. But MemPool allocate 4KB least, it will a waste for most cases.
-    MemTracker _tracker;
     MemPool _pool;
 
     // serialized ZoneMapPB for each data page
@@ -99,7 +98,7 @@ private:
 };
 
 template <FieldType type>
-ZoneMapIndexWriterImpl<type>::ZoneMapIndexWriterImpl(Field* field) : _field(field), _pool(&_tracker) {
+ZoneMapIndexWriterImpl<type>::ZoneMapIndexWriterImpl(Field* field) : _field(field) {
     _page_zone_map.min_value = _field->allocate_value(&_pool);
     _page_zone_map.max_value = _field->allocate_value(&_pool);
     _reset_zone_map(&_page_zone_map);
@@ -244,8 +243,7 @@ Status ZoneMapIndexReader::load(fs::BlockManager* block_mgr, const std::string& 
     std::unique_ptr<IndexedColumnIterator> iter;
     RETURN_IF_ERROR(reader.new_iterator(&iter));
 
-    MemTracker tracker;
-    MemPool pool(&tracker);
+    MemPool pool;
     _page_zone_maps.resize(reader.num_values());
 
     // read and cache all page zone maps

--- a/be/src/storage/schema_change.cpp
+++ b/be/src/storage/schema_change.cpp
@@ -932,7 +932,7 @@ bool RowBlockMerger::merge(const std::vector<RowBlock*>& row_block_arr, RowsetWr
     // TODO: add mem_tracker for ObjectPool?
     DeferOp release_object_pool_memory(
             [this] { return this->_mem_tracker->release(this->_mem_tracker->consumption()); });
-    std::unique_ptr<MemPool> mem_pool(new MemPool(_mem_tracker.get()));
+    std::unique_ptr<MemPool> mem_pool(new MemPool());
     std::unique_ptr<ObjectPool> agg_object_pool(new ObjectPool());
 
     RowCursor row_cursor;

--- a/be/src/storage/vectorized/convert_helper.cpp
+++ b/be/src/storage/vectorized/convert_helper.cpp
@@ -2163,7 +2163,6 @@ Status BlockConverter::convert(::starrocks::RowBlockV2* dst, ::starrocks::RowBlo
                                 src->_selection_vector, src->_selected_size);
     }
     std::swap(dst->_num_rows, src->_num_rows);
-    std::swap(dst->_tracker, src->_tracker);
     std::swap(dst->_pool, src->_pool);
     std::swap(dst->_selection_vector, src->_selection_vector);
     std::swap(dst->_selected_size, src->_selected_size);

--- a/be/src/storage/vectorized/schema_change.cpp
+++ b/be/src/storage/vectorized/schema_change.cpp
@@ -678,8 +678,7 @@ bool SchemaChangeDirectly::process(vectorized::TabletReader* reader, RowsetWrite
     vectorized::Schema new_schema = ChunkHelper::convert_schema_to_format_v2(new_tablet->tablet_schema());
     ChunkPtr new_chunk = ChunkHelper::new_chunk(new_schema, config::vector_chunk_size);
 
-    std::unique_ptr<MemTracker> mem_tracker(new MemTracker(-1));
-    std::unique_ptr<MemPool> mem_pool(new MemPool(mem_tracker.get()));
+    std::unique_ptr<MemPool> mem_pool(new MemPool());
     do {
         Status status = reader->do_get_next(base_chunk.get());
 
@@ -756,8 +755,7 @@ bool SchemaChangeWithSorting::process(vectorized::TabletReader* reader, RowsetWr
     vectorized::Schema new_schema = ChunkHelper::convert_schema(new_tablet->tablet_schema());
 
     ChunkSorter chunk_sorter(_chunk_allocator);
-    std::unique_ptr<MemTracker> mem_tracker(new MemTracker(-1));
-    std::unique_ptr<MemPool> mem_pool(new MemPool(mem_tracker.get()));
+    std::unique_ptr<MemPool> mem_pool(new MemPool());
 
     DeferOp release_chunkarr([this, &chunk_arr] {
         for (auto& it : chunk_arr) {

--- a/be/src/storage/vectorized/tablet_reader.cpp
+++ b/be/src/storage/vectorized/tablet_reader.cpp
@@ -22,7 +22,7 @@
 namespace starrocks::vectorized {
 
 TabletReader::TabletReader(TabletSharedPtr tablet, const Version& version, Schema schema)
-        : ChunkIterator(std::move(schema)), _tablet(tablet), _version(version), _mempool(&_memtracker) {
+        : ChunkIterator(std::move(schema)), _tablet(tablet), _version(version) {
     _delete_predicates_version = version;
 }
 

--- a/be/src/storage/vectorized/tablet_reader.h
+++ b/be/src/storage/vectorized/tablet_reader.h
@@ -57,7 +57,6 @@ private:
     // _delete_predicates_version will be set as max_version of tablet in schema change vectorized
     Version _delete_predicates_version;
 
-    MemTracker _memtracker;
     MemPool _mempool;
 
     PredicateMap _pushdown_predicates;

--- a/be/src/testutil/function_utils.cpp
+++ b/be/src/testutil/function_utils.cpp
@@ -24,7 +24,6 @@
 #include <vector>
 
 #include "runtime/mem_pool.h"
-#include "runtime/mem_tracker.h"
 #include "udf/udf.h"
 #include "udf/udf_internal.h"
 
@@ -33,16 +32,14 @@ namespace starrocks {
 FunctionUtils::FunctionUtils() {
     starrocks_udf::FunctionContext::TypeDesc return_type;
     std::vector<starrocks_udf::FunctionContext::TypeDesc> arg_types;
-    _mem_tracker = new MemTracker();
-    _memory_pool = new MemPool(_mem_tracker);
+    _memory_pool = new MemPool();
     _fn_ctx = FunctionContextImpl::create_context(_state, _memory_pool, return_type, arg_types, 0, false);
 }
 FunctionUtils::FunctionUtils(RuntimeState* state) {
     _state = state;
     starrocks_udf::FunctionContext::TypeDesc return_type;
     std::vector<starrocks_udf::FunctionContext::TypeDesc> arg_types;
-    _mem_tracker = new MemTracker();
-    _memory_pool = new MemPool(_mem_tracker);
+    _memory_pool = new MemPool();
     _fn_ctx = FunctionContextImpl::create_context(_state, _memory_pool, return_type, arg_types, 0, false);
 }
 
@@ -50,7 +47,6 @@ FunctionUtils::~FunctionUtils() {
     _fn_ctx->impl()->close();
     delete _fn_ctx;
     delete _memory_pool;
-    delete _mem_tracker;
 }
 
 } // namespace starrocks

--- a/be/src/testutil/function_utils.h
+++ b/be/src/testutil/function_utils.h
@@ -26,7 +26,6 @@ class FunctionContext;
 namespace starrocks {
 
 class MemPool;
-class MemTracker;
 class RuntimeState;
 
 class FunctionUtils {
@@ -39,7 +38,6 @@ public:
 
 private:
     RuntimeState* _state = nullptr;
-    MemTracker* _mem_tracker = nullptr;
     MemPool* _memory_pool = nullptr;
     starrocks_udf::FunctionContext* _fn_ctx = nullptr;
 };

--- a/be/test/exec/orc_scanner_test.cpp
+++ b/be/test/exec/orc_scanner_test.cpp
@@ -363,8 +363,7 @@ TEST_F(OrcScannerTest, normal) {
 
     ORCScanner scanner(&_runtime_state, _profile, params, ranges, _addresses, &_counter);
     ASSERT_TRUE(scanner.open().ok());
-    MemTracker tracker;
-    MemPool tuple_pool(&tracker);
+    MemPool tuple_pool;
 
     Tuple* tuple = (Tuple*)tuple_pool.allocate(_desc_tbl->get_tuple_descriptor(1)->byte_size());
     bool eof = false;
@@ -470,8 +469,7 @@ TEST_F(OrcScannerTest, normal2) {
 
     ORCScanner scanner(&_runtime_state, _profile, params, ranges, _addresses, &_counter);
     ASSERT_TRUE(scanner.open().ok());
-    MemTracker tracker;
-    MemPool tuple_pool(&tracker);
+    MemPool tuple_pool;
 
     Tuple* tuple = (Tuple*)tuple_pool.allocate(_desc_tbl->get_tuple_descriptor(1)->byte_size());
     bool eof = false;
@@ -770,8 +768,7 @@ TEST_F(OrcScannerTest, normal3) {
 
     ORCScanner scanner(&_runtime_state, _profile, params, ranges, _addresses, &_counter);
     ASSERT_TRUE(scanner.open().ok());
-    MemTracker tracker;
-    MemPool tuple_pool(&tracker);
+    MemPool tuple_pool;
 
     Tuple* tuple = (Tuple*)tuple_pool.allocate(_desc_tbl->get_tuple_descriptor(1)->byte_size());
     bool eof = false;

--- a/be/test/exec/vectorized/join_hash_map_test.cpp
+++ b/be/test/exec/vectorized/join_hash_map_test.cpp
@@ -14,7 +14,7 @@ protected:
         config::vector_chunk_size = 4096;
         _object_pool = std::make_shared<ObjectPool>();
         _mem_tracker = std::make_shared<MemTracker>();
-        _mem_pool = std::make_shared<MemPool>(_mem_tracker.get());
+        _mem_pool = std::make_shared<MemPool>();
         _runtime_profile = create_runtime_profile();
         _runtime_state = create_runtime_state();
     }
@@ -494,8 +494,8 @@ void JoinHashMapTest::prepare_table_items(JoinHashTableItems* table_items, uint3
     table_items->first.resize(table_items->bucket_size);
     table_items->row_count = row_count;
     table_items->next.resize(row_count + 1);
-    table_items->build_pool = std::make_unique<MemPool>(_mem_tracker.get());
-    table_items->probe_pool = std::make_unique<MemPool>(_mem_tracker.get());
+    table_items->build_pool = std::make_unique<MemPool>();
+    table_items->probe_pool = std::make_unique<MemPool>();
     table_items->mem_tracker = _mem_tracker.get();
     table_items->search_ht_timer = ADD_TIMER(_runtime_profile, "SearchHashTableTimer");
     table_items->output_build_column_timer = ADD_TIMER(_runtime_profile, "OutputBuildColumnTimer");
@@ -1113,8 +1113,8 @@ TEST_F(JoinHashMapTest, SerializedJoinBuildProbeFunc) {
     table_items.join_keys.emplace_back(JoinKeyDesc{TYPE_INT, false});
     table_items.join_keys.emplace_back(JoinKeyDesc{TYPE_INT, false});
     table_items.mem_tracker = runtime_state->instance_mem_tracker();
-    table_items.build_pool = std::make_unique<MemPool>(runtime_state->instance_mem_tracker());
-    table_items.probe_pool = std::make_unique<MemPool>(runtime_state->instance_mem_tracker());
+    table_items.build_pool = std::make_unique<MemPool>();
+    table_items.probe_pool = std::make_unique<MemPool>();
     probe_state.probe_row_count = 10;
     probe_state.buckets.resize(config::vector_chunk_size);
     probe_state.next.resize(config::vector_chunk_size, 0);
@@ -1176,8 +1176,8 @@ TEST_F(JoinHashMapTest, SerializedJoinBuildProbeFuncNullable) {
     table_items.join_keys.emplace_back(JoinKeyDesc{TYPE_INT, false});
     table_items.next.resize(11);
     table_items.mem_tracker = runtime_state->instance_mem_tracker();
-    table_items.build_pool = std::make_unique<MemPool>(runtime_state->instance_mem_tracker());
-    table_items.probe_pool = std::make_unique<MemPool>(runtime_state->instance_mem_tracker());
+    table_items.build_pool = std::make_unique<MemPool>();
+    table_items.probe_pool = std::make_unique<MemPool>();
     probe_state.probe_row_count = 10;
     probe_state.buckets.resize(config::vector_chunk_size);
     probe_state.next.resize(config::vector_chunk_size, 0);
@@ -1689,7 +1689,7 @@ TEST_F(JoinHashMapTest, FixedSizeJoinHashTable) {
     auto runtime_state = create_runtime_state();
     auto mem_tracker = create_mem_tracker(runtime_profile);
     std::shared_ptr<ObjectPool> object_pool = std::make_shared<ObjectPool>();
-    std::shared_ptr<MemPool> mem_pool = std::make_shared<MemPool>(mem_tracker.get());
+    std::shared_ptr<MemPool> mem_pool = std::make_shared<MemPool>();
     config::vector_chunk_size = 4096;
 
     TDescriptorTableBuilder row_desc_builder;

--- a/be/test/runtime/free_list_test.cpp
+++ b/be/test/runtime/free_list_test.cpp
@@ -26,13 +26,11 @@
 #include <string>
 
 #include "runtime/mem_pool.h"
-#include "runtime/mem_tracker.h"
 
 namespace starrocks {
 
 TEST(FreeListTest, Basic) {
-    MemTracker tracker;
-    MemPool pool(&tracker);
+    MemPool pool;
     FreeList list;
 
     int allocated_size;

--- a/be/test/runtime/mem_pool_test.cpp
+++ b/be/test/runtime/mem_pool_test.cpp
@@ -25,16 +25,14 @@
 
 #include <string>
 
-#include "runtime/mem_tracker.h"
 #include "util/logging.h"
 
 namespace starrocks {
 
 TEST(MemPoolTest, Basic) {
-    MemTracker tracker(-1);
-    MemPool p(&tracker);
-    MemPool p2(&tracker);
-    MemPool p3(&tracker);
+    MemPool p;
+    MemPool p2;
+    MemPool p3;
 
     // allocate a total of 24K in 32-byte pieces (for which we only request 25 bytes)
     for (int i = 0; i < 768; ++i) {
@@ -93,7 +91,7 @@ TEST(MemPoolTest, Basic) {
     EXPECT_EQ(256 * 1024, p2.total_reserved_bytes());
 
     {
-        MemPool p4(&tracker);
+        MemPool p4;
         p4.exchange_data(&p2);
         EXPECT_EQ(33 * 1024, p4.total_allocated_bytes());
         EXPECT_EQ(256 * 1024, p4.total_reserved_bytes());
@@ -105,8 +103,7 @@ TEST(MemPoolTest, Basic) {
 // remaining chunks are consistent if there were more than one used chunk and some
 // free chunks.
 TEST(MemPoolTest, Keep) {
-    MemTracker tracker(-1);
-    MemPool p(&tracker);
+    MemPool p;
     p.allocate(4 * 1024);
     p.allocate(8 * 1024);
     p.allocate(16 * 1024);
@@ -119,7 +116,7 @@ TEST(MemPoolTest, Keep) {
     p.allocate(4 * 1024);
     EXPECT_EQ(p.total_allocated_bytes(), (1 + 4) * 1024);
     EXPECT_EQ(p.total_reserved_bytes(), (4 + 8 + 16) * 1024);
-    MemPool p2(&tracker);
+    MemPool p2;
     p2.acquire_data(&p, true);
 
     {
@@ -138,8 +135,7 @@ TEST(MemPoolTest, MaxAllocation) {
     int64_t int_max_rounded = BitUtil::round_up(LARGE_ALLOC_SIZE, 8);
 
     // Allocate a single LARGE_ALLOC_SIZE chunk
-    MemTracker tracker(-1);
-    MemPool p1(&tracker);
+    MemPool p1;
     uint8_t* ptr = p1.allocate(LARGE_ALLOC_SIZE);
     EXPECT_TRUE(ptr != NULL);
     EXPECT_EQ(int_max_rounded, p1.total_reserved_bytes());
@@ -147,7 +143,7 @@ TEST(MemPoolTest, MaxAllocation) {
     p1.free_all();
 
     // Allocate a small chunk (DEFAULT_INITIAL_CHUNK_SIZE) followed by an LARGE_ALLOC_SIZE chunk
-    MemPool p2(&tracker);
+    MemPool p2;
     p2.allocate(8);
     EXPECT_EQ(p2.total_reserved_bytes(), 4096);
     EXPECT_EQ(p2.total_allocated_bytes(), 8);
@@ -159,7 +155,7 @@ TEST(MemPoolTest, MaxAllocation) {
 
     // Allocate three LARGE_ALLOC_SIZE chunks followed by a small chunk followed by another LARGE_ALLOC_SIZE
     // chunk
-    MemPool p3(&tracker);
+    MemPool p3;
     p3.allocate(LARGE_ALLOC_SIZE);
     // Allocates new int_max_rounded * 2 chunk
     // NOTE: exceed MAX_CHUNK_SIZE limit, will not *2

--- a/be/test/runtime/string_buffer_test.cpp
+++ b/be/test/runtime/string_buffer_test.cpp
@@ -26,7 +26,6 @@
 #include <string>
 
 #include "runtime/mem_pool.h"
-#include "runtime/mem_tracker.h"
 
 namespace starrocks {
 
@@ -40,8 +39,7 @@ void validate_string(const std::string& std_str, const StringBuffer& str) {
 }
 
 TEST(StringBufferTest, Basic) {
-    MemTracker tracker;
-    MemPool pool(&tracker);
+    MemPool pool;
     StringBuffer str(&pool);
     std::string std_str;
 

--- a/be/test/storage/aggregate_func_test.cpp
+++ b/be/test/storage/aggregate_func_test.cpp
@@ -25,7 +25,6 @@
 
 #include "common/object_pool.h"
 #include "runtime/mem_pool.h"
-#include "runtime/mem_tracker.h"
 #include "storage/decimal12.h"
 #include "storage/uint24.h"
 
@@ -43,8 +42,7 @@ void test_min() {
     static const size_t kValSize = sizeof(CppType) + 1; // '1' represent the leading bool flag.
     char buf[64];
 
-    std::unique_ptr<MemTracker> tracker(new MemTracker(-1));
-    std::unique_ptr<MemPool> mem_pool(new MemPool(tracker.get()));
+    std::unique_ptr<MemPool> mem_pool(new MemPool());
     ObjectPool agg_object_pool;
     const AggregateInfo* agg = get_aggregate_info(OLAP_FIELD_AGGREGATION_MIN, field_type);
 
@@ -119,8 +117,7 @@ void test_max() {
 
     char buf[64];
 
-    std::unique_ptr<MemTracker> tracker(new MemTracker(-1));
-    std::unique_ptr<MemPool> mem_pool(new MemPool(tracker.get()));
+    std::unique_ptr<MemPool> mem_pool(new MemPool());
     ObjectPool agg_object_pool;
     const AggregateInfo* agg = get_aggregate_info(OLAP_FIELD_AGGREGATION_MAX, field_type);
 
@@ -195,8 +192,7 @@ void test_sum() {
     char buf[64];
     RowCursorCell dst(buf);
 
-    std::unique_ptr<MemTracker> tracker(new MemTracker(-1));
-    std::unique_ptr<MemPool> mem_pool(new MemPool(tracker.get()));
+    std::unique_ptr<MemPool> mem_pool(new MemPool());
     ObjectPool agg_object_pool;
     const AggregateInfo* agg = get_aggregate_info(OLAP_FIELD_AGGREGATION_SUM, field_type);
 
@@ -270,8 +266,7 @@ void test_replace() {
     char buf[64];
     RowCursorCell dst(buf);
 
-    std::unique_ptr<MemTracker> tracker(new MemTracker(-1));
-    std::unique_ptr<MemPool> mem_pool(new MemPool(tracker.get()));
+    std::unique_ptr<MemPool> mem_pool(new MemPool());
     ObjectPool agg_object_pool;
     const AggregateInfo* agg = get_aggregate_info(OLAP_FIELD_AGGREGATION_REPLACE, field_type);
 
@@ -329,8 +324,7 @@ void test_replace_string() {
     dst_slice->data = nullptr;
     dst_slice->size = 0;
 
-    std::unique_ptr<MemTracker> tracker(new MemTracker(-1));
-    std::unique_ptr<MemPool> mem_pool(new MemPool(tracker.get()));
+    std::unique_ptr<MemPool> mem_pool(new MemPool());
     ObjectPool agg_object_pool;
     const AggregateInfo* agg = get_aggregate_info(OLAP_FIELD_AGGREGATION_REPLACE, field_type);
 

--- a/be/test/storage/comparison_predicate_test.cpp
+++ b/be/test/storage/comparison_predicate_test.cpp
@@ -90,9 +90,7 @@ static std::string to_datetime_string(uint64_t& datetime_value) {
 #define TEST_PREDICATE_DEFINITION(CLASS_NAME)                                                                     \
     class CLASS_NAME : public testing::Test {                                                                     \
     public:                                                                                                       \
-        CLASS_NAME() : _vectorized_batch(NULL) {                                                                  \
-            _mem_pool.reset(new MemPool());                                                     \
-        }                                                                                                         \
+        CLASS_NAME() : _vectorized_batch(NULL) { _mem_pool.reset(new MemPool()); }                                \
         ~CLASS_NAME() {                                                                                           \
             if (_vectorized_batch != NULL) {                                                                      \
                 delete _vectorized_batch;                                                                         \

--- a/be/test/storage/comparison_predicate_test.cpp
+++ b/be/test/storage/comparison_predicate_test.cpp
@@ -91,8 +91,7 @@ static std::string to_datetime_string(uint64_t& datetime_value) {
     class CLASS_NAME : public testing::Test {                                                                     \
     public:                                                                                                       \
         CLASS_NAME() : _vectorized_batch(NULL) {                                                                  \
-            _mem_tracker.reset(new MemTracker(-1));                                                               \
-            _mem_pool.reset(new MemPool(_mem_tracker.get()));                                                     \
+            _mem_pool.reset(new MemPool());                                                     \
         }                                                                                                         \
         ~CLASS_NAME() {                                                                                           \
             if (_vectorized_batch != NULL) {                                                                      \
@@ -120,7 +119,6 @@ static std::string to_datetime_string(uint64_t& datetime_value) {
             _vectorized_batch = new VectorizedRowBatch(tablet_schema, ids, size);                                 \
             _vectorized_batch->set_size(size);                                                                    \
         }                                                                                                         \
-        std::unique_ptr<MemTracker> _mem_tracker;                                                                 \
         std::unique_ptr<MemPool> _mem_pool;                                                                       \
         VectorizedRowBatch* _vectorized_batch;                                                                    \
     };

--- a/be/test/storage/delta_writer_test.cpp
+++ b/be/test/storage/delta_writer_test.cpp
@@ -331,8 +331,7 @@ TEST_F(TestDeltaWriter, write) {
     DeltaWriter::open(&write_req, k_tablet_meta_mem_tracker, &delta_writer);
     ASSERT_NE(delta_writer, nullptr);
 
-    MemTracker tracker;
-    MemPool pool(&tracker);
+    MemPool pool;
     // Tuple 1
     {
         Tuple* tuple = reinterpret_cast<Tuple*>(pool.allocate(tuple_desc->byte_size()));

--- a/be/test/storage/in_list_predicate_test.cpp
+++ b/be/test/storage/in_list_predicate_test.cpp
@@ -89,9 +89,7 @@ static std::string to_datetime_string(uint64_t& datetime_value) {
 
 class TestInListPredicate : public testing::Test {
 public:
-    TestInListPredicate() : _vectorized_batch(NULL) {
-        _mem_pool.reset(new MemPool());
-    }
+    TestInListPredicate() : _vectorized_batch(NULL) { _mem_pool.reset(new MemPool()); }
 
     ~TestInListPredicate() {
         if (_vectorized_batch != NULL) {

--- a/be/test/storage/in_list_predicate_test.cpp
+++ b/be/test/storage/in_list_predicate_test.cpp
@@ -90,8 +90,7 @@ static std::string to_datetime_string(uint64_t& datetime_value) {
 class TestInListPredicate : public testing::Test {
 public:
     TestInListPredicate() : _vectorized_batch(NULL) {
-        _mem_tracker.reset(new MemTracker(-1));
-        _mem_pool.reset(new MemPool(_mem_tracker.get()));
+        _mem_pool.reset(new MemPool());
     }
 
     ~TestInListPredicate() {
@@ -123,7 +122,6 @@ public:
         _vectorized_batch = new VectorizedRowBatch(tablet_schema, ids, size);
         _vectorized_batch->set_size(size);
     }
-    std::unique_ptr<MemTracker> _mem_tracker;
     std::unique_ptr<MemPool> _mem_pool;
     VectorizedRowBatch* _vectorized_batch;
 };

--- a/be/test/storage/key_coder_test.cpp
+++ b/be/test/storage/key_coder_test.cpp
@@ -27,18 +27,16 @@
 #include <limits>
 
 #include "runtime/mem_pool.h"
-#include "runtime/mem_tracker.h"
 #include "util/debug_util.h"
 
 namespace starrocks {
 
 class KeyCoderTest : public testing::Test {
 public:
-    KeyCoderTest() : _pool(&_tracker) {}
+    KeyCoderTest() {}
     virtual ~KeyCoderTest() {}
 
 private:
-    MemTracker _tracker;
     MemPool _pool;
 };
 

--- a/be/test/storage/null_predicate_test.cpp
+++ b/be/test/storage/null_predicate_test.cpp
@@ -59,8 +59,7 @@ static uint64_t to_datetime_timestamp(const std::string& value_string) {
 class TestNullPredicate : public testing::Test {
 public:
     TestNullPredicate() : _vectorized_batch(NULL) {
-        _mem_tracker.reset(new MemTracker(-1));
-        _mem_pool.reset(new MemPool(_mem_tracker.get()));
+        _mem_pool.reset(new MemPool());
     }
 
     ~TestNullPredicate() {
@@ -91,7 +90,6 @@ public:
         _vectorized_batch = new VectorizedRowBatch(tablet_schema, ids, size);
         _vectorized_batch->set_size(size);
     }
-    std::unique_ptr<MemTracker> _mem_tracker;
     std::unique_ptr<MemPool> _mem_pool;
     VectorizedRowBatch* _vectorized_batch;
 };

--- a/be/test/storage/null_predicate_test.cpp
+++ b/be/test/storage/null_predicate_test.cpp
@@ -58,9 +58,7 @@ static uint64_t to_datetime_timestamp(const std::string& value_string) {
 
 class TestNullPredicate : public testing::Test {
 public:
-    TestNullPredicate() : _vectorized_batch(NULL) {
-        _mem_pool.reset(new MemPool());
-    }
+    TestNullPredicate() : _vectorized_batch(NULL) { _mem_pool.reset(new MemPool()); }
 
     ~TestNullPredicate() {
         if (_vectorized_batch != NULL) {

--- a/be/test/storage/row_block_v2_test.cpp
+++ b/be/test/storage/row_block_v2_test.cpp
@@ -94,8 +94,7 @@ TEST_F(TestRowBlockV2, test_convert) {
     block_info.null_supported = true;
     auto res = output_block.init(block_info);
     ASSERT_EQ(OLAP_SUCCESS, res);
-    MemTracker tracker;
-    MemPool pool(&tracker);
+    MemPool pool;
     for (int i = 0; i < input_block.capacity(); ++i) {
         RowBlockRow row = input_block.row(i);
 

--- a/be/test/storage/row_cursor_test.cpp
+++ b/be/test/storage/row_cursor_test.cpp
@@ -254,9 +254,7 @@ void set_tablet_schema_for_cmp_and_aggregate(TabletSchema* tablet_schema) {
 
 class TestRowCursor : public testing::Test {
 public:
-    TestRowCursor() {
-        _mem_pool.reset(new MemPool());
-    }
+    TestRowCursor() { _mem_pool.reset(new MemPool()); }
 
     virtual void SetUp() {}
 

--- a/be/test/storage/row_cursor_test.cpp
+++ b/be/test/storage/row_cursor_test.cpp
@@ -25,7 +25,6 @@
 
 #include "common/object_pool.h"
 #include "runtime/mem_pool.h"
-#include "runtime/mem_tracker.h"
 #include "storage/row.h"
 #include "storage/tablet_schema.h"
 #include "util/logging.h"
@@ -256,15 +255,13 @@ void set_tablet_schema_for_cmp_and_aggregate(TabletSchema* tablet_schema) {
 class TestRowCursor : public testing::Test {
 public:
     TestRowCursor() {
-        _mem_tracker.reset(new MemTracker(-1));
-        _mem_pool.reset(new MemPool(_mem_tracker.get()));
+        _mem_pool.reset(new MemPool());
     }
 
     virtual void SetUp() {}
 
     virtual void TearDown() {}
 
-    std::unique_ptr<MemTracker> _mem_tracker;
     std::unique_ptr<MemPool> _mem_pool;
 };
 
@@ -476,8 +473,7 @@ TEST_F(TestRowCursor, AggregateWithoutNull) {
     left.set_field_content(4, reinterpret_cast<char*>(&l_decimal), _mem_pool.get());
     left.set_field_content(5, reinterpret_cast<char*>(&l_varchar), _mem_pool.get());
 
-    std::unique_ptr<MemTracker> tracker(new MemTracker(-1));
-    std::unique_ptr<MemPool> mem_pool(new MemPool(tracker.get()));
+    std::unique_ptr<MemPool> mem_pool(new MemPool());
     ObjectPool agg_object_pool;
     init_row_with_others(&row, left, mem_pool.get(), &agg_object_pool);
 
@@ -537,8 +533,7 @@ TEST_F(TestRowCursor, AggregateWithNull) {
     left.set_null(4);
     left.set_field_content(5, reinterpret_cast<char*>(&l_varchar), _mem_pool.get());
 
-    std::unique_ptr<MemTracker> tracker(new MemTracker(-1));
-    std::unique_ptr<MemPool> mem_pool(new MemPool(tracker.get()));
+    std::unique_ptr<MemPool> mem_pool(new MemPool());
     ObjectPool agg_object_pool;
     init_row_with_others(&row, left, mem_pool.get(), &agg_object_pool);
 

--- a/be/test/storage/rowset/beta_rowset_test.cpp
+++ b/be/test/storage/rowset/beta_rowset_test.cpp
@@ -234,8 +234,7 @@ TEST_F(BetaRowsetTest, BasicFunctionTest) {
         // k2 := k1 * 10
         // k3 := 4096 * i + rid
         for (int i = 0; i < num_segments; ++i) {
-            MemTracker mem_tracker(-1);
-            MemPool mem_pool(&mem_tracker);
+            MemPool mem_pool;
             for (int rid = 0; rid < rows_per_segment; ++rid) {
                 uint32_t k1 = rid * 10 + i;
                 uint32_t k2 = k1 * 10;
@@ -429,8 +428,7 @@ TEST_F(BetaRowsetTest, DiscontinuousRowidTest) {
         input_row.init(tablet_schema);
 
         for (int i = 0; i < num_segments; ++i) {
-            MemTracker mem_tracker(-1);
-            MemPool mem_pool(&mem_tracker);
+            MemPool mem_pool;
             for (int rid = 0; rid < rows_per_segment; ++rid) {
                 uint32_t k1 = rid;
                 uint32_t k2 = rid;
@@ -538,8 +536,7 @@ TEST_F(BetaRowsetTest, DiscontinuousRowid1Test) {
         input_row.init(tablet_schema);
 
         for (int i = 0; i < num_segments; ++i) {
-            MemTracker mem_tracker(-1);
-            MemPool mem_pool(&mem_tracker);
+            MemPool mem_pool;
             for (int rid = 0; rid < rows_per_segment; ++rid) {
                 uint32_t k1 = rid;
                 uint32_t k2 = rid;

--- a/be/test/storage/rowset/segment_v2/binary_dict_page_test.cpp
+++ b/be/test/storage/rowset/segment_v2/binary_dict_page_test.cpp
@@ -84,8 +84,7 @@ public:
         ASSERT_EQ(slices.size(), page_decoder.count());
 
         //check values
-        auto tracker = std::make_shared<MemTracker>();
-        MemPool pool(tracker.get());
+        MemPool pool;
         TypeInfoPtr type_info = get_type_info(OLAP_FIELD_TYPE_VARCHAR);
         size_t size = slices.size();
         std::unique_ptr<ColumnVectorBatch> cvb;
@@ -176,8 +175,7 @@ public:
             ASSERT_TRUE(status.ok());
 
             //check values
-            auto tracker = std::make_shared<MemTracker>();
-            MemPool pool(tracker.get());
+            MemPool pool;
             TypeInfoPtr type_info = get_type_info(OLAP_FIELD_TYPE_VARCHAR);
             std::unique_ptr<ColumnVectorBatch> cvb;
             ColumnVectorBatch::create(1, false, type_info, nullptr, &cvb);

--- a/be/test/storage/rowset/segment_v2/binary_plain_page_test.cpp
+++ b/be/test/storage/rowset/segment_v2/binary_plain_page_test.cpp
@@ -74,8 +74,7 @@ public:
         //test1
 
         if (!vectorize) {
-            MemTracker tracker;
-            MemPool pool(&tracker);
+            MemPool pool;
             size_t size = 3;
             std::unique_ptr<ColumnVectorBatch> cvb;
             ColumnVectorBatch::create(size, true, get_type_info(OLAP_FIELD_TYPE_VARCHAR), nullptr, &cvb);

--- a/be/test/storage/rowset/segment_v2/binary_prefix_page_test.cpp
+++ b/be/test/storage/rowset/segment_v2/binary_prefix_page_test.cpp
@@ -79,8 +79,7 @@ public:
         ASSERT_EQ(slices.size(), page_decoder->count());
 
         //check values
-        auto tracker = std::make_shared<MemTracker>();
-        MemPool pool(tracker.get());
+        MemPool pool;
         TypeInfoPtr type_info = get_type_info(OLAP_FIELD_TYPE_VARCHAR);
         size_t size = slices.size();
         std::unique_ptr<ColumnVectorBatch> cvb;

--- a/be/test/storage/rowset/segment_v2/bitmap_index_test.cpp
+++ b/be/test/storage/rowset/segment_v2/bitmap_index_test.cpp
@@ -41,7 +41,7 @@ class BitmapIndexTest : public testing::Test {
 public:
     const std::string kTestDir = "/bitmap_index_test";
 
-    BitmapIndexTest() : _pool(&_tracker) {}
+    BitmapIndexTest() {}
 
 protected:
     void SetUp() override {

--- a/be/test/storage/rowset/segment_v2/bitshuffle_page_test.cpp
+++ b/be/test/storage/rowset/segment_v2/bitshuffle_page_test.cpp
@@ -42,8 +42,7 @@ public:
 
     template <FieldType type, class PageDecoderType>
     void copy_one(PageDecoderType* decoder, typename TypeTraits<type>::CppType* ret) {
-        auto tracker = std::make_shared<MemTracker>();
-        MemPool pool(tracker.get());
+        MemPool pool;
         std::unique_ptr<ColumnVectorBatch> cvb;
         ColumnVectorBatch::create(1, true, get_type_info(type), nullptr, &cvb);
         ColumnBlock block(cvb.get(), &pool);
@@ -82,8 +81,7 @@ public:
         ASSERT_TRUE(status.ok());
         ASSERT_EQ(0, page_decoder.current_index());
 
-        MemTracker tracker;
-        MemPool pool(&tracker);
+        MemPool pool;
 
         std::unique_ptr<ColumnVectorBatch> cvb;
         ColumnVectorBatch::create(size, false, get_type_info(Type), nullptr, &cvb);

--- a/be/test/storage/rowset/segment_v2/column_reader_writer_test.cpp
+++ b/be/test/storage/rowset/segment_v2/column_reader_writer_test.cpp
@@ -55,7 +55,7 @@ static const std::string TEST_DIR = "/column_reader_writer_test";
 
 class ColumnReaderWriterTest : public testing::Test {
 public:
-    ColumnReaderWriterTest() : _pool(&_tracker) {}
+    ColumnReaderWriterTest() {}
 
     ~ColumnReaderWriterTest() override = default;
 
@@ -204,8 +204,7 @@ protected:
                 st = iter.seek_to_first();
                 ASSERT_TRUE(st.ok()) << st.to_string();
 
-                auto tracker = std::make_shared<MemTracker>();
-                MemPool pool(tracker.get());
+                MemPool pool;
                 std::unique_ptr<ColumnVectorBatch> cvb;
                 ColumnVectorBatch::create(0, true, type_info, nullptr, &cvb);
                 cvb->resize(1024);
@@ -232,8 +231,7 @@ protected:
             }
 
             {
-                auto tracker = std::make_shared<MemTracker>();
-                MemPool pool(tracker.get());
+                MemPool pool;
                 std::unique_ptr<ColumnVectorBatch> cvb;
                 ColumnVectorBatch::create(0, true, type_info, nullptr, &cvb);
                 cvb->resize(1024);

--- a/be/test/storage/rowset/segment_v2/frame_of_reference_page_test.cpp
+++ b/be/test/storage/rowset/segment_v2/frame_of_reference_page_test.cpp
@@ -42,8 +42,7 @@ class FrameOfReferencePageTest : public testing::Test {
 public:
     template <FieldType type, class PageDecoderType>
     void copy_one(PageDecoderType* decoder, typename TypeTraits<type>::CppType* ret) {
-        auto tracker = std::make_shared<MemTracker>();
-        MemPool pool(tracker.get());
+        MemPool pool;
         std::unique_ptr<ColumnVectorBatch> cvb;
         ColumnVectorBatch::create(1, true, get_type_info(type), nullptr, &cvb);
         ColumnBlock block(cvb.get(), &pool);
@@ -75,8 +74,7 @@ public:
         ASSERT_EQ(0, for_page_decoder.current_index());
         ASSERT_EQ(size, for_page_decoder.count());
 
-        auto tracker = std::make_shared<MemTracker>();
-        MemPool pool(tracker.get());
+        MemPool pool;
         std::unique_ptr<ColumnVectorBatch> cvb;
         ColumnVectorBatch::create(size, true, get_type_info(Type), nullptr, &cvb);
         ColumnBlock block(cvb.get(), &pool);

--- a/be/test/storage/rowset/segment_v2/plain_page_test.cpp
+++ b/be/test/storage/rowset/segment_v2/plain_page_test.cpp
@@ -50,8 +50,7 @@ public:
 
     template <FieldType type, class PageDecoderType>
     void copy_one(PageDecoderType* decoder, typename TypeTraits<type>::CppType* ret) {
-        auto tracker = std::make_shared<MemTracker>();
-        MemPool pool(tracker.get());
+        MemPool pool;
         std::unique_ptr<ColumnVectorBatch> cvb;
         ColumnVectorBatch::create(1, true, get_type_info(type), nullptr, &cvb);
         ColumnBlock block(cvb.get(), &pool);
@@ -89,8 +88,7 @@ public:
 
         ASSERT_EQ(0, page_decoder.current_index());
 
-        MemTracker tracker;
-        MemPool pool(&tracker);
+        MemPool pool;
 
         std::unique_ptr<ColumnVectorBatch> cvb;
         ColumnVectorBatch::create(size, true, get_type_info(Type), nullptr, &cvb);

--- a/be/test/storage/rowset/segment_v2/rle_page_test.cpp
+++ b/be/test/storage/rowset/segment_v2/rle_page_test.cpp
@@ -45,8 +45,7 @@ public:
 
     template <FieldType type, class PageDecoderType>
     void copy_one(PageDecoderType* decoder, typename TypeTraits<type>::CppType* ret) {
-        auto tracker = std::make_shared<MemTracker>();
-        MemPool pool(tracker.get());
+        MemPool pool;
         std::unique_ptr<ColumnVectorBatch> cvb;
         ColumnVectorBatch::create(1, true, get_type_info(type), nullptr, &cvb);
         ColumnBlock block(cvb.get(), &pool);
@@ -90,8 +89,7 @@ public:
         ASSERT_EQ(0, rle_page_decoder.current_index());
         ASSERT_EQ(size, rle_page_decoder.count());
 
-        auto tracker = std::make_shared<MemTracker>();
-        MemPool pool(tracker.get());
+        MemPool pool;
         std::unique_ptr<ColumnVectorBatch> cvb;
         ColumnVectorBatch::create(size, true, get_type_info(Type), nullptr, &cvb);
         ColumnBlock block(cvb.get(), &pool);

--- a/be/test/storage/rowset/segment_v2/segment_test.cpp
+++ b/be/test/storage/rowset/segment_v2/segment_test.cpp
@@ -766,8 +766,7 @@ TEST_F(SegmentReaderWriterTest, TestDefaultValueColumn) {
 
 TEST_F(SegmentReaderWriterTest, TestStringDict) {
     size_t num_rows_per_block = 10;
-    MemTracker tracker;
-    MemPool pool(&tracker);
+    MemPool pool;
 
     std::shared_ptr<TabletSchema> tablet_schema(new TabletSchema());
     tablet_schema->_num_key_columns = 3;

--- a/be/test/storage/skiplist_test.cpp
+++ b/be/test/storage/skiplist_test.cpp
@@ -263,9 +263,7 @@ private:
     SkipList<Key, TestComparator> _list;
 
 public:
-    ConcurrentTest()
-            : _mem_pool(new MemPool()),
-              _list(TestComparator(), _mem_pool.get(), false) {}
+    ConcurrentTest() : _mem_pool(new MemPool()), _list(TestComparator(), _mem_pool.get(), false) {}
 
     // REQUIRES: External synchronization
     void write_step(Random* rnd) {

--- a/be/test/storage/skiplist_test.cpp
+++ b/be/test/storage/skiplist_test.cpp
@@ -55,8 +55,7 @@ struct TestComparator {
 class SkipTest : public testing::Test {};
 
 TEST_F(SkipTest, Empty) {
-    std::unique_ptr<MemTracker> tracker(new MemTracker(-1));
-    std::unique_ptr<MemPool> mem_pool(new MemPool(tracker.get()));
+    std::unique_ptr<MemPool> mem_pool(new MemPool());
 
     TestComparator cmp;
     SkipList<Key, TestComparator> list(cmp, mem_pool.get(), false);
@@ -73,8 +72,7 @@ TEST_F(SkipTest, Empty) {
 }
 
 TEST_F(SkipTest, InsertAndLookup) {
-    std::unique_ptr<MemTracker> tracker(new MemTracker(-1));
-    std::unique_ptr<MemPool> mem_pool(new MemPool(tracker.get()));
+    std::unique_ptr<MemPool> mem_pool(new MemPool());
 
     const int N = 2000;
     const int R = 5000;
@@ -153,8 +151,7 @@ TEST_F(SkipTest, InsertAndLookup) {
 
 // Only non-DUP model will use Find() and InsertWithHint().
 TEST_F(SkipTest, InsertWithHintNoneDupModel) {
-    std::unique_ptr<MemTracker> tracker(new MemTracker(-1));
-    std::unique_ptr<MemPool> mem_pool(new MemPool(tracker.get()));
+    std::unique_ptr<MemPool> mem_pool(new MemPool());
 
     const int N = 2000;
     const int R = 5000;
@@ -259,7 +256,6 @@ private:
     // Current state of the test
     State _current;
 
-    std::unique_ptr<MemTracker> _mem_tracker;
     std::unique_ptr<MemPool> _mem_pool;
 
     // SkipList is not protected by _mu.  We just use a single writer
@@ -268,8 +264,7 @@ private:
 
 public:
     ConcurrentTest()
-            : _mem_tracker(new MemTracker(-1)),
-              _mem_pool(new MemPool(_mem_tracker.get())),
+            : _mem_pool(new MemPool()),
               _list(TestComparator(), _mem_pool.get(), false) {}
 
     // REQUIRES: External synchronization

--- a/be/test/storage/storage_types_test.cpp
+++ b/be/test/storage/storage_types_test.cpp
@@ -43,8 +43,7 @@ void common_test(typename TypeTraits<field_type>::CppType src_val) {
     ASSERT_EQ(sizeof(src_val), type->size());
     {
         typename TypeTraits<field_type>::CppType dst_val;
-        MemTracker tracker;
-        MemPool pool(&tracker);
+        MemPool pool;
         type->deep_copy((char*)&dst_val, (char*)&src_val, &pool);
         ASSERT_TRUE(type->equal((char*)&src_val, (char*)&dst_val));
         ASSERT_EQ(0, type->cmp((char*)&src_val, (char*)&dst_val));
@@ -83,8 +82,7 @@ void test_char(Slice src_val) {
     {
         char buf[64];
         Slice dst_val(buf, sizeof(buf));
-        MemTracker tracker;
-        MemPool pool(&tracker);
+        MemPool pool;
         type->deep_copy((char*)&dst_val, (char*)&src_val, &pool);
         ASSERT_TRUE(type->equal((char*)&src_val, (char*)&dst_val));
         ASSERT_EQ(0, type->cmp((char*)&src_val, (char*)&dst_val));

--- a/be/test/storage/vectorized/base_compaction_test.cpp
+++ b/be/test/storage/vectorized/base_compaction_test.cpp
@@ -147,7 +147,7 @@ public:
         ASSERT_TRUE(FileUtils::create_dir(_schema_hash_path).ok());
 
         _tablet_meta_mem_tracker.reset(new MemTracker(-1));
-        _mem_pool.reset(new MemPool(_tablet_meta_mem_tracker.get()));
+        _mem_pool.reset(new MemPool());
 
         _compaction_mem_tracker.reset(new MemTracker(-1));
     }

--- a/be/test/storage/vectorized/cumulative_compaction_test.cpp
+++ b/be/test/storage/vectorized/cumulative_compaction_test.cpp
@@ -147,7 +147,7 @@ public:
         ASSERT_TRUE(FileUtils::create_dir(_schema_hash_path).ok());
 
         _tablet_meta_mem_tracker.reset(new MemTracker(-1));
-        _mem_pool.reset(new MemPool(_tablet_meta_mem_tracker.get()));
+        _mem_pool.reset(new MemPool());
 
         _compaction_mem_tracker.reset(new MemTracker(-1));
     }

--- a/be/test/storage/vectorized/schema_change_test.cpp
+++ b/be/test/storage/vectorized/schema_change_test.cpp
@@ -119,8 +119,7 @@ class SchemaChangeTest : public testing::Test {
         src_datum.set<T>(val);
         Datum dst_datum;
         auto converter = vectorized::get_type_converter(type, OLAP_FIELD_TYPE_VARCHAR);
-        std::unique_ptr<MemTracker> mem_tracker(new MemTracker(-1));
-        std::unique_ptr<MemPool> mem_pool(new MemPool(mem_tracker.get()));
+        std::unique_ptr<MemPool> mem_pool(new MemPool());
         Status st = converter->convert_datum(f.type().get(), src_datum, f2.type().get(), dst_datum, mem_pool.get());
         ASSERT_TRUE(st.ok());
 
@@ -146,8 +145,7 @@ class SchemaChangeTest : public testing::Test {
         src_datum.set_slice(slice);
         Datum dst_datum;
         auto converter = vectorized::get_type_converter(OLAP_FIELD_TYPE_VARCHAR, type);
-        std::unique_ptr<MemTracker> mem_tracker(new MemTracker(-1));
-        std::unique_ptr<MemPool> mem_pool(new MemPool(mem_tracker.get()));
+        std::unique_ptr<MemPool> mem_pool(new MemPool());
         Status st = converter->convert_datum(f.type().get(), src_datum, f2.type().get(), dst_datum, mem_pool.get());
         ASSERT_TRUE(st.ok());
 
@@ -228,8 +226,7 @@ TEST_F(SchemaChangeTest, convert_float_to_double) {
     src_datum.set_float(1.2345);
     Datum dst_datum;
     auto converter = vectorized::get_type_converter(OLAP_FIELD_TYPE_FLOAT, OLAP_FIELD_TYPE_DOUBLE);
-    std::unique_ptr<MemTracker> mem_tracker(new MemTracker(-1));
-    std::unique_ptr<MemPool> mem_pool(new MemPool(mem_tracker.get()));
+    std::unique_ptr<MemPool> mem_pool(new MemPool());
     Status st = converter->convert_datum(f.type().get(), src_datum, f2.type().get(), dst_datum, mem_pool.get());
     ASSERT_TRUE(st.ok());
 
@@ -246,8 +243,7 @@ TEST_F(SchemaChangeTest, convert_datetime_to_date) {
     Field f = ChunkHelper::convert_field_to_format_v2(0, src_tablet_schema.column(0));
     Field f2 = ChunkHelper::convert_field_to_format_v2(0, dst_tablet_schema.column(0));
 
-    std::unique_ptr<MemTracker> mem_tracker(new MemTracker(-1));
-    std::unique_ptr<MemPool> mem_pool(new MemPool(mem_tracker.get()));
+    std::unique_ptr<MemPool> mem_pool(new MemPool());
     Datum src_datum;
     std::string origin_val = "2021-09-28 16:07:00";
 
@@ -275,8 +271,7 @@ TEST_F(SchemaChangeTest, convert_date_to_datetime) {
 
     Field f = ChunkHelper::convert_field_to_format_v2(0, src_tablet_schema.column(0));
     Field f2 = ChunkHelper::convert_field_to_format_v2(0, dst_tablet_schema.column(0));
-    std::unique_ptr<MemTracker> mem_tracker(new MemTracker(-1));
-    std::unique_ptr<MemPool> mem_pool(new MemPool(mem_tracker.get()));
+    std::unique_ptr<MemPool> mem_pool(new MemPool());
     Datum src_datum;
     std::string origin_val = "2021-09-28";
     tm time_tm;
@@ -304,8 +299,7 @@ TEST_F(SchemaChangeTest, convert_int_to_date_v2) {
     Field f = ChunkHelper::convert_field_to_format_v2(0, src_tablet_schema.column(0));
     Field f2 = ChunkHelper::convert_field_to_format_v2(0, dst_tablet_schema.column(0));
 
-    std::unique_ptr<MemTracker> mem_tracker(new MemTracker(-1));
-    std::unique_ptr<MemPool> mem_pool(new MemPool(mem_tracker.get()));
+    std::unique_ptr<MemPool> mem_pool(new MemPool());
     Datum src_datum;
     std::string origin_val = "2021-09-28";
     tm time_tm;
@@ -330,8 +324,7 @@ TEST_F(SchemaChangeTest, convert_int_to_date) {
     Field f = ChunkHelper::convert_field_to_format_v2(0, src_tablet_schema.column(0));
     Field f2 = ChunkHelper::convert_field_to_format_v2(0, dst_tablet_schema.column(0));
 
-    std::unique_ptr<MemTracker> mem_tracker(new MemTracker(-1));
-    std::unique_ptr<MemPool> mem_pool(new MemPool(mem_tracker.get()));
+    std::unique_ptr<MemPool> mem_pool(new MemPool());
     Datum src_datum;
     std::string origin_val = "2021-09-28";
     tm time_tm;


### PR DESCRIPTION
for #703 

MemPool is associated with the MemTrackerTree of the process through MemTracker. Under the Hook-based memory statistics model, memory statistics are performed at the ThreadLocl Hook. And MemPool itself can also view UsedMemory and PeakMemory, so MemTracker is removed from MemPool.