### PR TITLE
Read version_2 data using version_1 type

### DIFF
--- a/be/src/column/datum.h
+++ b/be/src/column/datum.h
@@ -59,12 +59,16 @@ public:
     const HyperLogLog* get_hyperloglog() const { return get<HyperLogLog*>(); }
     const BitmapValue* get_bitmap() const { return get<BitmapValue*>(); }
     const PercentileValue* get_percentile() const { return get<PercentileValue*>(); }
-
-    int32_t get_datev1() const {
+    /*
+    // when storage_format_version is 1
+    // schema will be set as DateV1, but storage type may be DateV2
+    const DateValue get_datev1() const {
         if (std::get_if<uint24_t>(&_value)) {
-            return get_uint24();
+            DateValue tmp;
+            tmp.from_mysql_date(get_uint24());
+            return tmp;
         } else {
-            return get_int32();
+            return get_date();
         }
     }
 
@@ -76,6 +80,19 @@ public:
         }
     }
 
+    // when storage_format_version is 1
+    // schema will be set as Datetime, but storage type may be Timestamp
+    const TimestampValue get_datetime() const {
+        if (std::get_if<int64_t>(&_value)) {
+            LOG(INFO) << "date time to timestamp";
+            TimestampValue timestamp{0};
+            timestamp.from_timestamp_literal(get_int64()));
+            return timestamp;
+        } else {
+            return get_timestamp();
+        }
+    }
+*/
     void set_int8(int8_t v) { set<decltype(v)>(v); }
     void set_uint8(uint8_t v) { set<decltype(v)>(v); }
     void set_int16(int16_t v) { set<decltype(v)>(v); }

--- a/be/src/column/datum.h
+++ b/be/src/column/datum.h
@@ -59,40 +59,7 @@ public:
     const HyperLogLog* get_hyperloglog() const { return get<HyperLogLog*>(); }
     const BitmapValue* get_bitmap() const { return get<BitmapValue*>(); }
     const PercentileValue* get_percentile() const { return get<PercentileValue*>(); }
-    /*
-    // when storage_format_version is 1
-    // schema will be set as DateV1, but storage type may be DateV2
-    const DateValue get_datev1() const {
-        if (std::get_if<uint24_t>(&_value)) {
-            DateValue tmp;
-            tmp.from_mysql_date(get_uint24());
-            return tmp;
-        } else {
-            return get_date();
-        }
-    }
 
-    const DecimalV2Value from_decimal_v1() const {
-        if (auto pval = std::get_if<decimal12_t>(&_value)) {
-            return DecimalV2Value((*pval).integer, (*pval).fraction);
-        } else {
-            return std::get<DecimalV2Value>(_value);
-        }
-    }
-
-    // when storage_format_version is 1
-    // schema will be set as Datetime, but storage type may be Timestamp
-    const TimestampValue get_datetime() const {
-        if (std::get_if<int64_t>(&_value)) {
-            LOG(INFO) << "date time to timestamp";
-            TimestampValue timestamp{0};
-            timestamp.from_timestamp_literal(get_int64()));
-            return timestamp;
-        } else {
-            return get_timestamp();
-        }
-    }
-*/
     void set_int8(int8_t v) { set<decltype(v)>(v); }
     void set_uint8(uint8_t v) { set<decltype(v)>(v); }
     void set_int16(int16_t v) { set<decltype(v)>(v); }

--- a/be/src/storage/vectorized/convert_helper.cpp
+++ b/be/src/storage/vectorized/convert_helper.cpp
@@ -99,12 +99,9 @@ public:
             dst.set_null();
             return Status::OK();
         }
-
-        auto src_value = src.get_int64();
-        int64_t part1 = (src_value / 1000000L);
-        uint24_t year = static_cast<uint24_t>((part1 / 10000L) % 10000);
-        uint24_t mon = static_cast<uint24_t>((part1 / 100) % 100);
-        uint24_t day = static_cast<uint24_t>(part1 % 100);
+        auto timestamp = src.get_timestamp();
+        int year, mon, day, hour, minute, second, usec;
+        timestamp.to_timestamp(&year, &mon, &day, &hour, &minute, &second, &usec);
         dst.set_uint24((year << 9) + (mon << 5) + day);
         return Status::OK();
     }
@@ -222,9 +219,7 @@ public:
             dst.set_null();
             return Status::OK();
         }
-        TimestampValue timestamp{0};
-        timestamp.from_timestamp_literal(src.get_int64());
-        dst.set_date(timestamp);
+        dst.set_date(src.get_timestamp());
         return Status::OK();
     }
 };
@@ -244,9 +239,7 @@ public:
             dst.set_null();
             return Status::OK();
         }
-        DateValue tmp;
-        tmp.from_mysql_date(src.get_datev1());
-        dst.set_date(tmp);
+        dst.set_date(src.get_date());
         return Status::OK();
     }
 };
@@ -266,11 +259,10 @@ public:
             dst.set_null();
             return Status::OK();
         }
-        auto src_value = src.get_datev1();
-        int day = static_cast<int>(src_value & 31);
-        int mon = static_cast<int>(src_value >> 5 & 15);
-        int year = static_cast<int>(src_value >> 9);
-        dst.set_int64(static_cast<int64>(year * 10000L + mon * 100L + day) * 1000000);
+        DateValue date_v2 = src.get_date();
+        int year, month, day;
+        date_v2.to_date(&year, &month, &day);
+        dst.set_int64(static_cast<int64>(year * 10000L + month * 100L + day) * 1000000);
         return Status::OK();
     }
 };
@@ -338,11 +330,10 @@ public:
             dst.set_null();
             return Status::OK();
         }
-        auto src_value = src.get_datev1();
-        int day = implicit_cast<int>(src_value & 31u);
-        int mon = implicit_cast<int>((src_value >> 5u) & 15u);
-        int year = implicit_cast<int>(src_value >> 9u);
-        dst.set_timestamp(TimestampValue::create(year, mon, day, 0, 0, 0));
+        DateValue date_v2 = src.get_date();
+        int year, month, day;
+        date_v2.to_date(&year, &month, &day);
+        dst.set_timestamp(TimestampValue::create(year, month, day, 0, 0, 0));
         return Status::OK();
     }
 };
@@ -393,9 +384,7 @@ public:
             dst.set_null();
             return Status::OK();
         }
-        TimestampValue timestamp{0};
-        timestamp.from_timestamp_literal(src.get_int64());
-        dst.set_timestamp(timestamp);
+        dst.set_timestamp(src.get_timestamp());
         return Status::OK();
     }
 };
@@ -459,7 +448,7 @@ public:
             dst.set_null();
             return Status::OK();
         }
-        DecimalV2Value dst_value = src.from_decimal_v1();
+        DecimalV2Value dst_value = src.get_decimal();
         dst.set_decimal(dst_value);
         return Status::OK();
     }
@@ -988,6 +977,9 @@ const TypeConverter* get_to_varchar_converter(FieldType from_type, FieldType to_
     }
 }
 
+// Datetime, Date and decimal should not be used
+// Use Timestamp, Date V2 and decimal v2 to replace
+// Should be deleted after storage_format_vesion = 1 is forbid
 const TypeConverter* get_type_converter(FieldType from_type, FieldType to_type) {
     if (from_type == OLAP_FIELD_TYPE_VARCHAR) {
         return get_from_varchar_converter(from_type, to_type);
@@ -1641,6 +1633,7 @@ public:
     ~TimestampToDatetimeFieldConverter() override = default;
 
     void convert(void* dst, const void* src) const override {
+        LOG(INFO) << "convert from datetime to timestamp";
         unaligned_store<int64_t>(dst, unaligned_load<TimestampValue>(src).to_timestamp_literal());
     }
 

--- a/be/src/storage/vectorized/schema_change.cpp
+++ b/be/src/storage/vectorized/schema_change.cpp
@@ -361,7 +361,6 @@ bool ChunkChanger::change_chunk(ChunkPtr& base_chunk, ChunkPtr& new_chunk, Table
                     new_col = base_col;
                 }
             } else if (ConvertTypeResolver::instance()->get_convert_type_info(ref_type, new_type)) {
-                LOG(INFO) << "src type is " << ref_type << ", new type is " << new_type;
                 auto converter = vectorized::get_type_converter(ref_type, new_type);
                 if (converter == nullptr) {
                     LOG(WARNING) << "failed to get type converter, from_type=" << ref_type << ", to_type" << new_type;
@@ -1236,8 +1235,6 @@ Status SchemaChangeHandler::_convert_historical_rowsets(SchemaChangeParams& sc_p
 
         VLOG(10) << "succeed to convert a history version."
                  << " version=" << sc_params.version.first << "-" << sc_params.version.second;
-        // XXX: The SchemaChange state should not be cancelled at this point,
-        // because the new Delta has to be converted to the old and new Schema versions
     }
 
     if (status.ok()) {

--- a/be/test/storage/vectorized/schema_change_test.cpp
+++ b/be/test/storage/vectorized/schema_change_test.cpp
@@ -253,8 +253,8 @@ TEST_F(SchemaChangeTest, convert_datetime_to_date) {
 
     tm time_tm;
     strptime(origin_val.c_str(), "%Y-%m-%d %H:%M:%S", &time_tm);
-    int64_t value = ((time_tm.tm_year + 1900) * 10000L + (time_tm.tm_mon + 1) * 100L + time_tm.tm_mday) * 1000000L +
-                    time_tm.tm_hour * 10000L + time_tm.tm_min * 100L + time_tm.tm_sec;
+    TimestampValue timestamp = TimestampValue::create(2021, 9, 28, 0, 0, 0);
+    int64_t value = timestamp.timestamp();
     src_datum.set_int64(value);
     Datum dst_datum;
     auto converter = vectorized::get_type_converter(OLAP_FIELD_TYPE_DATETIME, OLAP_FIELD_TYPE_DATE);
@@ -262,7 +262,7 @@ TEST_F(SchemaChangeTest, convert_datetime_to_date) {
     Status st = converter->convert_datum(f.type().get(), src_datum, f2.type().get(), dst_datum, mem_pool.get());
     ASSERT_TRUE(st.ok());
 
-    int dst_value = (time_tm.tm_year + 1900) * 16 * 32 + (time_tm.tm_mon + 1) * 32 + time_tm.tm_mday;
+    int dst_value = (2021 << 9) + (9 << 5) + 28;
     EXPECT_EQ(dst_value, dst_datum.get_uint24());
 }
 
@@ -281,16 +281,17 @@ TEST_F(SchemaChangeTest, convert_date_to_datetime) {
     std::string origin_val = "2021-09-28";
     tm time_tm;
     strptime(origin_val.c_str(), "%Y-%m-%d", &time_tm);
-    int value = (time_tm.tm_year + 1900) * 16 * 32 + (time_tm.tm_mon + 1) * 32 + time_tm.tm_mday;
-    src_datum.set_uint24(value);
 
+    DateValue date_v2;
+    date_v2.from_date(2021, 9, 28);
+    src_datum.set_date(date_v2);
     Datum dst_datum;
     auto converter = vectorized::get_type_converter(OLAP_FIELD_TYPE_DATE, OLAP_FIELD_TYPE_DATETIME);
 
     Status st = converter->convert_datum(f.type().get(), src_datum, f2.type().get(), dst_datum, mem_pool.get());
     ASSERT_TRUE(st.ok());
 
-    int64_t dst_value = ((time_tm.tm_year + 1900) * 10000L + (time_tm.tm_mon + 1) * 100L + time_tm.tm_mday) * 1000000L;
+    int64_t dst_value = (2021 * 10000L + 9 * 100L + 28) * 1000000L;
     EXPECT_EQ(dst_value, dst_datum.get_int64());
 }
 


### PR DESCRIPTION
When storage_format_version is set as 1,  datetime, date v1 and decimal type will be used in schema.
But the storage type may be timestamp, datev2 and decimalv2.
To be compatible, we should ensure the old schema can be used to read new version data.