### PR TITLE
inline some date/time function

### DIFF
--- a/be/src/column/datum.h
+++ b/be/src/column/datum.h
@@ -4,7 +4,7 @@
 
 #include <variant>
 
-#include "runtime/date_value.h"
+#include "runtime/date_value.hpp"
 #include "runtime/decimalv2_value.h"
 #include "runtime/timestamp_value.h"
 #include "storage/decimal12.h"

--- a/be/src/column/fixed_length_column_base.h
+++ b/be/src/column/fixed_length_column_base.h
@@ -5,7 +5,7 @@
 #include <utility>
 
 #include "column/column.h"
-#include "runtime/date_value.h"
+#include "runtime/date_value.hpp"
 #include "runtime/decimalv2_value.h"
 #include "runtime/timestamp_value.h"
 #include "util/raw_container.h"

--- a/be/src/exec/olap_common.h
+++ b/be/src/exec/olap_common.h
@@ -37,7 +37,7 @@
 #include "exec/scan_node.h"
 #include "gen_cpp/PlanNodes_types.h"
 #include "gutil/stl_util.h"
-#include "runtime/date_value.h"
+#include "runtime/date_value.hpp"
 #include "runtime/datetime_value.h"
 #include "runtime/descriptors.h"
 #include "runtime/string_value.hpp"

--- a/be/src/exec/vectorized/mysql_scan_node.cpp
+++ b/be/src/exec/vectorized/mysql_scan_node.cpp
@@ -12,7 +12,7 @@
 #include "exec/text_converter.hpp"
 #include "exprs/slot_ref.h"
 #include "gen_cpp/PlanNodes_types.h"
-#include "runtime/date_value.h"
+#include "runtime/date_value.hpp"
 #include "runtime/decimalv2_value.h"
 #include "runtime/decimalv3.h"
 #include "runtime/row_batch.h"

--- a/be/src/exec/vectorized/olap_scan_prepare.cpp
+++ b/be/src/exec/vectorized/olap_scan_prepare.cpp
@@ -5,6 +5,7 @@
 
 #include "exprs/vectorized/in_const_predicate.hpp"
 #include "gutil/map_util.h"
+#include "runtime/date_value.hpp"
 #include "storage/vectorized/column_predicate.h"
 #include "storage/vectorized/predicate_parser.h"
 

--- a/be/src/formats/csv/converter.h
+++ b/be/src/formats/csv/converter.h
@@ -12,7 +12,7 @@
 
 #include "common/status.h"
 #include "formats/csv/output_stream.h"
-#include "runtime/date_value.h"
+#include "runtime/date_value.hpp"
 #include "runtime/decimalv2_value.h"
 #include "runtime/timestamp_value.h"
 #include "runtime/vectorized/time_types.h"

--- a/be/src/formats/csv/date_converter.cpp
+++ b/be/src/formats/csv/date_converter.cpp
@@ -5,7 +5,7 @@
 #include "column/fixed_length_column.h"
 #include "common/logging.h"
 #include "gutil/casts.h"
-#include "runtime/date_value.h"
+#include "runtime/date_value.hpp"
 
 namespace starrocks::vectorized::csv {
 

--- a/be/src/formats/csv/output_stream.h
+++ b/be/src/formats/csv/output_stream.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "runtime/date_value.h"
+#include "runtime/date_value.hpp"
 #include "runtime/decimalv2_value.h"
 #include "runtime/timestamp_value.h"
 

--- a/be/src/runtime/date_value.cpp
+++ b/be/src/runtime/date_value.cpp
@@ -19,7 +19,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "runtime/date_value.h"
+#include "runtime/date_value.hpp"
 
 #include "gutil/strings/substitute.h"
 #include "runtime/timestamp_value.h"
@@ -76,10 +76,6 @@ bool DateValue::from_date_literal_with_check(int64_t date_literal) {
 
     _julian = date::from_date(year, month, day);
     return true;
-}
-
-void DateValue::to_date(int* year, int* month, int* day) const {
-    date::to_date_with_cache(_julian, year, month, day);
 }
 
 bool DateValue::get_weeks_of_year_with_cache(int* weeks) const {
@@ -171,10 +167,6 @@ std::string DateValue::day_name() const {
 
 std::string DateValue::to_string() const {
     return date::to_string(_julian);
-}
-
-DateValue::operator TimestampValue() const {
-    return TimestampValue{date::to_timestamp(_julian)};
 }
 
 } // namespace starrocks::vectorized

--- a/be/src/runtime/date_value.h
+++ b/be/src/runtime/date_value.h
@@ -60,7 +60,7 @@ public:
 
     bool from_string(const char* date_str, size_t len);
 
-    void to_date(int* year, int* month, int* day) const;
+    inline void to_date(int* year, int* month, int* day) const;
 
     bool get_weeks_of_year_with_cache(int* weeks) const;
 
@@ -97,7 +97,7 @@ public:
     template <TimeUnit UNIT>
     inline DateValue add(int count) const;
 
-    operator TimestampValue() const;
+    inline operator TimestampValue() const;
 
 public:
     static const DateValue MAX_DATE_VALUE;

--- a/be/src/runtime/date_value.hpp
+++ b/be/src/runtime/date_value.hpp
@@ -1,0 +1,20 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#pragma once
+
+#include "runtime/date_value.hpp"
+#include "runtime/timestamp_value.h"
+
+namespace starrocks::vectorized {
+inline DateValue::operator TimestampValue() const {
+    return TimestampValue{date::to_timestamp(_julian)};
+}
+
+inline TimestampValue::operator DateValue() const {
+    return DateValue{timestamp::to_julian(_timestamp)};
+}
+
+inline void DateValue::to_date(int* year, int* month, int* day) const {
+    date::to_date_with_cache(_julian, year, month, day);
+}
+} // namespace starrocks::vectorized

--- a/be/src/runtime/timestamp_value.cpp
+++ b/be/src/runtime/timestamp_value.cpp
@@ -21,7 +21,7 @@
 
 #include "runtime/timestamp_value.h"
 
-#include "runtime/date_value.h"
+#include "runtime/date_value.hpp"
 #include "runtime/vectorized/time_types.h"
 #include "util/timezone_utils.h"
 
@@ -854,10 +854,6 @@ std::string TimestampValue::to_string() const {
 
 int TimestampValue::to_string(char* s, size_t n) const {
     return timestamp::to_string(_timestamp, s, n);
-}
-
-TimestampValue::operator DateValue() const {
-    return DateValue{timestamp::to_julian(_timestamp)};
 }
 
 } // namespace starrocks::vectorized

--- a/be/src/runtime/timestamp_value.h
+++ b/be/src/runtime/timestamp_value.h
@@ -25,11 +25,11 @@
 
 #include <string>
 
+#include "runtime/date_value.h"
 #include "runtime/vectorized/time_types.h"
 #include "util/hash_util.hpp"
 
 namespace starrocks::vectorized {
-class DateValue;
 
 enum DateTimeType { TIMESTAMP_TIME = 1, TIMESTAMP_DATE = 2, TIMESTAMP_DATETIME = 3 };
 
@@ -126,7 +126,7 @@ public:
 
     static constexpr int max_string_length() { return 26; }
 
-    operator DateValue() const;
+    inline operator DateValue() const;
 
     static TimestampValue MAX_TIMESTAMP_VALUE;
     static TimestampValue MIN_TIMESTAMP_VALUE;

--- a/be/src/runtime/vectorized/time_types.cpp
+++ b/be/src/runtime/vectorized/time_types.cpp
@@ -14,23 +14,8 @@ const int YY_PART_YEAR = 70;
 const uint64_t LOG_10_INT[] = {1,         10,         100,         1000,         10000UL,       100000UL,
                                1000000UL, 10000000UL, 100000000UL, 1000000000UL, 10000000000UL, 100000000000UL};
 
-struct JulianToDateEntry {
-    // 14 bits
-    uint16_t year;
-
-    // 4 bits
-    uint8_t month;
-
-    // 5 bits
-    uint8_t day;
-
-    // 1-53, Base on 6 bits
-    uint8_t week_th_of_year;
-};
-
 // Date Cache
-static const uint32_t CACHE_JULIAN_DAYS = 200 * 366;
-static JulianToDateEntry g_julian_to_date_cache[CACHE_JULIAN_DAYS];
+JulianToDateEntry g_julian_to_date_cache[CACHE_JULIAN_DAYS];
 
 static const uint32_t CACHE_DATE_LITERAL_START = 19900101;
 static const uint32_t CACHE_DATE_LITERAL_END = 20250101;
@@ -109,40 +94,6 @@ int date::get_days_after_monday(JulianDate julian) {
         // Because It's Sunday.
         return 6;
     }
-}
-
-void date::to_date(JulianDate julian, int* year, int* month, int* day) {
-    int quad;
-    int extra;
-    int y;
-
-    julian += 32044;
-    quad = julian / 146097;
-    extra = (julian - quad * 146097) * 4 + 3;
-    julian += 60 + quad * 3 + extra / 146097;
-    quad = julian / 1461;
-    julian -= quad * 1461;
-    y = julian * 4 / 1461;
-    julian = ((y != 0) ? ((julian + 305) % 365) : ((julian + 306) % 366)) + 123;
-    y += quad * 4;
-    quad = julian * 2141 / 65536;
-
-    *year = y - 4800;
-    *day = julian - 7834 * quad / 256;
-    *month = (quad + 10) % MONTHS_PER_YEAR + 1;
-}
-
-void date::to_date_with_cache(JulianDate julian, int* year, int* month, int* day) {
-    if (julian >= date::UNIX_EPOCH_JULIAN && julian < date::UNIX_EPOCH_JULIAN + CACHE_JULIAN_DAYS) {
-        int p = julian - date::UNIX_EPOCH_JULIAN;
-        *year = g_julian_to_date_cache[p].year;
-        *month = g_julian_to_date_cache[p].month;
-        *day = g_julian_to_date_cache[p].day;
-
-        return;
-    }
-
-    return to_date(julian, year, month, day);
 }
 
 bool date::get_weeks_of_year_with_cache(JulianDate julian, int* weeks) {
@@ -578,17 +529,6 @@ void date::to_string(int year, int month, int day, char* to) {
 
     to[8] = day / 10 + '0';
     to[9] = day % 10 + '0';
-}
-
-void timestamp::to_time(Timestamp timestamp, int* hour, int* minute, int* second, int* microsecond) {
-    Timestamp time = to_time(timestamp);
-
-    *hour = time / USECS_PER_HOUR;
-    time -= (*hour) * USECS_PER_HOUR;
-    *minute = time / USECS_PER_MINUTE;
-    time -= (*minute) * USECS_PER_MINUTE;
-    *second = time / USECS_PER_SEC;
-    *microsecond = time - (*second * USECS_PER_SEC);
 }
 
 bool timestamp::check_time(int hour, int minute, int second, int microsecond) {

--- a/be/src/storage/aggregate_func.h
+++ b/be/src/storage/aggregate_func.h
@@ -22,7 +22,7 @@
 #pragma once
 
 #include "common/object_pool.h"
-#include "runtime/date_value.h"
+#include "runtime/date_value.hpp"
 #include "runtime/datetime_value.h"
 #include "runtime/decimalv2_value.h"
 #include "runtime/mem_pool.h"

--- a/be/src/storage/primary_key_encoder.cpp
+++ b/be/src/storage/primary_key_encoder.cpp
@@ -33,7 +33,7 @@
 #include "column/fixed_length_column.h"
 #include "column/schema.h"
 #include "gutil/endian.h"
-#include "runtime/date_value.h"
+#include "runtime/date_value.hpp"
 #include "storage/tablet_schema.h"
 
 namespace starrocks {

--- a/be/src/storage/reader.cpp
+++ b/be/src/storage/reader.cpp
@@ -25,7 +25,7 @@
 #include <sstream>
 #include <utility>
 
-#include "runtime/date_value.h"
+#include "runtime/date_value.hpp"
 #include "runtime/mem_pool.h"
 #include "runtime/mem_tracker.h"
 #include "runtime/string_value.hpp"

--- a/be/src/storage/rowset/segment_v2/bitshuffle_page.h
+++ b/be/src/storage/rowset/segment_v2/bitshuffle_page.h
@@ -31,7 +31,7 @@
 
 #include "column/fixed_length_column.h"
 #include "gutil/port.h"
-#include "runtime/date_value.h"
+#include "runtime/date_value.hpp"
 #include "storage/olap_common.h"
 #include "storage/rowset/segment_v2/bitshuffle_wrapper.h"
 #include "storage/rowset/segment_v2/common.h"

--- a/be/src/storage/types.h
+++ b/be/src/storage/types.h
@@ -33,7 +33,7 @@
 #include "column/datum.h"
 #include "gen_cpp/segment_v2.pb.h" // for ColumnMetaPB
 #include "gutil/strings/numbers.h"
-#include "runtime/date_value.h"
+#include "runtime/date_value.hpp"
 #include "runtime/datetime_value.h"
 #include "runtime/decimalv2_value.h"
 #include "runtime/mem_pool.h"


### PR DESCRIPTION
optimize year hour function by using inline

ENV

```
1 FE 1 BE 1 parallel
```

DATA SET: SSB 100G

SQL:

```sql
select count(*) from ssb.lineorder_flat group by hour(LO_ORDERDATE);
```

time cost: 7.33-4.46

```
 31.84%  starrocks_be        [.] starrocks::Aggregator::build_hash_map<starrocks::vector
  19.81%  starrocks_be        [.] starrocks::vectorized::timestamp::to_time
  11.41%  starrocks_be        [.] starrocks::vectorized::AggregateFunctionBatchHelper<sta
   5.83%  starrocks_be        [.] starrocks::vectorized::UnpackConstColumnUnaryFunction<s
   4.82%  starrocks_be        [.] bshuf_shuffle_bit_eightelem_AVX_avx2
```

We find that `timestamp::to_time` cost too much CPU. It seems that `timestamp::to_time` was not inline function

SQL:

```sql
select count(*) from ssb.lineorder_flat group by year(LO_ORDERDATE);
```

time cost: 6.97 - 7.12

```
35.02%  starrocks_be        [.] starrocks::Aggregator::build_hash_map<starrocks::vector
  11.25%  starrocks_be        [.] starrocks::vectorized::AggregateFunctionBatchHelper<sta
  10.28%  starrocks_be        [.] starrocks::vectorized::date::to_date_with_cache
   6.76%  starrocks_be        [.] starrocks::vectorized::UnpackConstColumnUnaryFunction<s
```

So we need make `date::to_date_with_cache`, `timestamp::to_time` inline in a loop

`operator TimestampValue/DateVal` also need inline



After:

SQL 1: 5.56 - 5.62

```
  39.11%  starrocks_be        [.] starrocks::Aggregator::build_hash_map<starrocks::vector
  13.16%  starrocks_be        [.] starrocks::vectorized::AggregateFunctionBatchHelper<sta
   6.09%  starrocks_be        [.] starrocks::vectorized::UnpackConstColumnUnaryFunction<s
   5.66%  libc-2.17.so        [.] __memmove_ssse3_back
```



SQL 2: 5.67-5.77

```
  38.44%  starrocks_be        [.] starrocks::Aggregator::build_hash_map<starrocks::vector
  12.91%  starrocks_be        [.] starrocks::vectorized::AggregateFunctionBatchHelper<sta
   6.83%  starrocks_be        [.] starrocks::vectorized::UnpackConstColumnUnaryFunction<s
```

for #980 

