### PR TITLE
Optimize cast reduce rule

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -23,6 +23,7 @@ import com.starrocks.sql.optimizer.operator.physical.PhysicalHashJoinOperator;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
 
@@ -35,6 +36,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class Utils {
@@ -385,5 +387,33 @@ public class Utils {
             return true;
         }
         return false;
+    }
+
+    /**
+     * Try cast op to descType, return empty if failed
+     */
+    public static Optional<ScalarOperator> tryCastConstant(ScalarOperator op, Type descType) {
+        // Forbidden cast float, because behavior isn't same with before
+        if (!op.isConstantRef() || op.getType().matchesType(descType) || Type.FLOAT.equals(op.getType())
+                || descType.equals(Type.FLOAT)) {
+            return Optional.empty();
+        }
+
+        try {
+            if (((ConstantOperator) op).isNull()) {
+                return Optional.of(ConstantOperator.createNull(descType));
+            }
+
+            ConstantOperator result = ((ConstantOperator) op).castTo(descType);
+            if (result.toString().equalsIgnoreCase(op.toString())) {
+                return Optional.of(result);
+            } else if (descType.isDate() && (op.getType().isIntegerType() || op.getType().isStringType())) {
+                if (op.toString().equalsIgnoreCase(result.toString().replaceAll("-", ""))) {
+                    return Optional.of(result);
+                }
+            }
+        } catch (Exception ignored) {
+        }
+        return Optional.empty();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ImplicitCastRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ImplicitCastRule.java
@@ -9,13 +9,13 @@ import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.Type;
 import com.starrocks.sql.common.TypeManager;
+import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.scalar.BetweenPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CaseWhenOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
-import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.LikePredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
@@ -109,13 +109,13 @@ public class ImplicitCastRule extends TopDownScalarOperatorRewriteRule {
 
         // we will try cast const operator to variable operator
         if (rightChild.isVariable() && leftChild.isConstantRef()) {
-            Optional<ScalarOperator> op = tryCastConstant(leftChild, type2);
+            Optional<ScalarOperator> op = Utils.tryCastConstant(leftChild, type2);
             if (op.isPresent()) {
                 predicate.getChildren().set(0, op.get());
                 return predicate;
             }
         } else if (leftChild.isVariable() && rightChild.isConstantRef()) {
-            Optional<ScalarOperator> op = tryCastConstant(rightChild, type1);
+            Optional<ScalarOperator> op = Utils.tryCastConstant(rightChild, type1);
             if (op.isPresent()) {
                 predicate.getChildren().set(1, op.get());
                 return predicate;
@@ -217,7 +217,7 @@ public class ImplicitCastRule extends TopDownScalarOperatorRewriteRule {
             List<ScalarOperator> newChild = Lists.newArrayList();
             newChild.add(predicate.getChild(0));
             for (int i = 1; i < types.size(); i++) {
-                Optional<ScalarOperator> op = tryCastConstant(predicate.getChild(i), firstType);
+                Optional<ScalarOperator> op = Utils.tryCastConstant(predicate.getChild(i), firstType);
                 op.ifPresent(newChild::add);
             }
 
@@ -241,33 +241,5 @@ public class ImplicitCastRule extends TopDownScalarOperatorRewriteRule {
 
     private void addCastChild(Type returnType, ScalarOperator node, int index) {
         node.getChildren().set(index, new CastOperator(returnType, node.getChild(index), true));
-    }
-
-    /**
-     * Try cast op to descType, return empty if failed
-     */
-    private Optional<ScalarOperator> tryCastConstant(ScalarOperator op, Type descType) {
-        // Forbidden cast float, because behavior isn't same with before
-        if (!op.isConstantRef() || op.getType().matchesType(descType) || Type.FLOAT.equals(op.getType())
-                || descType.equals(Type.FLOAT)) {
-            return Optional.empty();
-        }
-
-        try {
-            if (((ConstantOperator) op).isNull()) {
-                return Optional.of(ConstantOperator.createNull(descType));
-            }
-
-            ConstantOperator result = ((ConstantOperator) op).castTo(descType);
-            if (result.toString().equalsIgnoreCase(op.toString())) {
-                return Optional.of(result);
-            } else if (descType.isDate() && (op.getType().isIntegerType() || op.getType().isStringType())) {
-                if (op.toString().equalsIgnoreCase(result.toString().replaceAll("-", ""))) {
-                    return Optional.of(result);
-                }
-            }
-        } catch (Exception ignored) {
-        }
-        return Optional.empty();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRule.java
@@ -4,9 +4,13 @@ package com.starrocks.sql.optimizer.rewrite.scalar;
 
 import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.Type;
+import com.starrocks.sql.optimizer.Utils;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriteContext;
+
+import java.util.Optional;
 
 //
 // Reduce duplicate cast functions
@@ -52,6 +56,28 @@ public class ReduceCastRule extends TopDownScalarOperatorRewriteRule {
         return operator;
     }
 
+    @Override
+    public ScalarOperator visitBinaryPredicate(BinaryPredicateOperator operator,
+                                               ScalarOperatorRewriteContext context) {
+        ScalarOperator child1 = operator.getChild(0);
+        ScalarOperator child2 = operator.getChild(1);
+
+        if (!(child1 instanceof CastOperator && child2.isConstantRef())) {
+            return operator;
+        }
+
+        ScalarOperator castChild = child1.getChild(0);
+
+        if (!(castChild.getType().isNumericType() && child2.getType().isNumericType())) {
+            return operator;
+        }
+
+        Optional<ScalarOperator> resultChild2 = Utils.tryCastConstant(child2, castChild.getType());
+        return resultChild2
+                .map(scalarOperator -> new BinaryPredicateOperator(operator.getBinaryType(), castChild, scalarOperator))
+                .orElse(operator);
+    }
+
     public boolean checkCastTypeReduceAble(Type parent, Type child, Type grandChild) {
         int parentSlotSize = parent.getSlotSize();
         int childSlotSize = child.getSlotSize();
@@ -68,9 +94,6 @@ public class ReduceCastRule extends TopDownScalarOperatorRewriteRule {
                 PrimitiveType.getAssignmentCompatibleType(grandChild.getPrimitiveType(), child.getPrimitiveType());
         PrimitiveType parentCompatibleType =
                 PrimitiveType.getAssignmentCompatibleType(child.getPrimitiveType(), parent.getPrimitiveType());
-        if (childCompatibleType == PrimitiveType.INVALID_TYPE || parentCompatibleType == PrimitiveType.INVALID_TYPE) {
-            return false;
-        }
-        return true;
+        return childCompatibleType != PrimitiveType.INVALID_TYPE && parentCompatibleType != PrimitiveType.INVALID_TYPE;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -146,6 +146,16 @@ public class PlanFragmentTest extends PlanTestBase {
     }
 
     @Test
+    public void testReduceCast() throws Exception {
+        String sql = "select t1a, t1b from test_all_type where t1c > 2000 + 1";
+        String plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("  0:OlapScanNode\n" +
+                "     TABLE: test_all_type\n" +
+                "     PREAGGREGATION: ON\n" +
+                "     PREDICATES: 3: t1c > 2001"));
+    }
+
+    @Test
     public void testExpression1() throws Exception {
         String sql = "select sum(v1 + v2) from t0";
         String planFragment = getFragmentPlan(sql);


### PR DESCRIPTION
For sql：
```
select * from xx where id_int = 2000 * 1;
```
Optimizer need find type of `2000 * 1` first, and result type of most math expression always be `BIGINT` because avoid number overflow, so the sql will transform to
```
select * from xxx where cast(id_int as bigint) = 2000 -- There be a bigint constant
```

but in fact, we don't need extra cast expression, we want sql:
```
select * from xxx where id_int = 2000 -- There be a int constant
```

for #833