### PR TITLE
Revert "[SR-4416] update thrift to 0.14 (#184)"

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/GenericPool.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/GenericPool.java
@@ -29,7 +29,6 @@ import org.apache.commons.pool2.impl.GenericKeyedObjectPool;
 import org.apache.commons.pool2.impl.GenericKeyedObjectPoolConfig;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.thrift.TConfiguration;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.transport.TSocket;
@@ -128,7 +127,7 @@ public class GenericPool<VALUE extends org.apache.thrift.TServiceClient> {
                 LOG.debug("before create socket hostname={} key.port={} timeoutMs={}",
                         key.hostname, key.port, timeoutMs);
             }
-            TTransport transport = new TSocket(TConfiguration.custom().build(), key.hostname, key.port, timeoutMs);
+            TTransport transport = new TSocket(key.hostname, key.port, timeoutMs);
             transport.open();
             TProtocol protocol = new TBinaryProtocol(transport);
             VALUE client = (VALUE) newInstance(className, protocol);

--- a/fe/fe-core/src/main/java/com/starrocks/common/ThriftServerContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ThriftServerContext.java
@@ -22,11 +22,13 @@
 package com.starrocks.common;
 
 import com.starrocks.thrift.TNetworkAddress;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.thrift.server.ServerContext;
 
 public class ThriftServerContext implements ServerContext {
-
-    private final TNetworkAddress client;
+    private static final Logger LOG = LogManager.getLogger(ThriftServerEventProcessor.class);
+    private TNetworkAddress client;
 
     public ThriftServerContext(TNetworkAddress clientAddress) {
         this.client = clientAddress;
@@ -34,23 +36,5 @@ public class ThriftServerContext implements ServerContext {
 
     public TNetworkAddress getClient() {
         return client;
-    }
-
-    @Override
-    public <T> T unwrap(Class<T> iface) {
-        try {
-            if (isWrapperFor(iface)) {
-                return iface.cast(client);
-            } else {
-                throw new RuntimeException("The context is not a wrapper for " + iface.getName());
-            }
-        } catch (Exception e) {
-            throw new RuntimeException("The context is not a wrapper and does not implement the interface");
-        }
-    }
-
-    @Override
-    public boolean isWrapperFor(Class<?> iface) {
-        return iface.isInstance(client);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/ThriftServerEventProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ThriftServerEventProcessor.java
@@ -28,9 +28,9 @@ import org.apache.logging.log4j.Logger;
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.server.ServerContext;
 import org.apache.thrift.server.TServerEventHandler;
+import org.apache.thrift.transport.TFramedTransport;
 import org.apache.thrift.transport.TSocket;
 import org.apache.thrift.transport.TTransport;
-import org.apache.thrift.transport.layered.TFramedTransport;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaStoreThriftClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaStoreThriftClient.java
@@ -137,12 +137,11 @@ import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.thrift.TConfiguration;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.protocol.TCompactProtocol;
 import org.apache.thrift.protocol.TProtocol;
-import org.apache.thrift.transport.layered.TFramedTransport;
+import org.apache.thrift.transport.TFramedTransport;
 import org.apache.thrift.transport.TSocket;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
@@ -440,7 +439,7 @@ public class HiveMetaStoreThriftClient implements IMetaStoreClient, AutoCloseabl
                             throw new MetaException(e.toString());
                         }
                     } else {
-                        transport = new TSocket(TConfiguration.custom().build(), store.getHost(), store.getPort(), clientSocketTimeout);
+                        transport = new TSocket(store.getHost(), store.getPort(), clientSocketTimeout);
                     }
 
                     if (useSasl) {
@@ -524,7 +523,7 @@ public class HiveMetaStoreThriftClient implements IMetaStoreClient, AutoCloseabl
                                     + "Continuing without it.", e);
                         }
                     }
-                } catch (MetaException | TTransportException e) {
+                } catch (MetaException e) {
                     LOG.error("Unable to connect to metastore with URI " + store
                             + " in attempt " + attempt, e);
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/TableQueryPlanAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/TableQueryPlanAction.java
@@ -61,7 +61,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
 import org.apache.thrift.TSerializer;
-import org.apache.thrift.transport.TTransportException;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -159,9 +158,6 @@ public class TableQueryPlanAction extends RestBaseAction {
             // status code  should conforms to HTTP semantic
             resultMap.put("status", e.getCode().code());
             resultMap.put("exception", e.getMessage());
-        } catch (TTransportException e) {
-            resultMap.put("status", "-1");
-            resultMap.put("exception", e.getMessage());
         }
         ObjectMapper mapper = new ObjectMapper();
         try {
@@ -188,7 +184,7 @@ public class TableQueryPlanAction extends RestBaseAction {
      * @throws StarRocksHttpException
      */
     private void handleQuery(ConnectContext context, String requestDb, String requestTable, String sql,
-                             Map<String, Object> result) throws StarRocksHttpException, TTransportException {
+                             Map<String, Object> result) throws StarRocksHttpException {
         // use SE to resolve sql
         StmtExecutor stmtExecutor = new StmtExecutor(context, new OriginStatement(sql, 0), false);
         try {

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -336,7 +336,7 @@ under the License.
             <dependency>
                 <groupId>org.apache.thrift</groupId>
                 <artifactId>libthrift</artifactId>
-                <version>0.14.0</version>
+                <version>0.13.0</version>
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-api -->

--- a/fs_brokers/apache_hdfs_broker/pom.xml
+++ b/fs_brokers/apache_hdfs_broker/pom.xml
@@ -235,7 +235,7 @@ under the License.
         <dependency>
             <groupId>org.apache.thrift</groupId>
             <artifactId>libthrift</artifactId>
-            <version>0.14.0</version>
+            <version>0.13.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.tomcat.embed</groupId>


### PR DESCRIPTION
This reverts commit 9637c8115852e19ec68a5428243026032dcf2530.
All connection types should be tested, including kerberos, sasl, ssl.
Some type connection has compatible problem:
```java
Caused by: java.lang.AbstractMethodError: org.apache.thrift.transport.TTransport.checkReadBytesAvailable(J)V
at org.apache.thrift.protocol.TBinaryProtocol.checkStringReadLength(TBinaryProtocol.java:443) ~[libthrift-0.14.0.jar:0.14.0]
at org.apache.thrift.protocol.TBinaryProtocol.readStringBody(TBinaryProtocol.java:414) ~[libthrift-0.14.0.jar:0.14.0]
at org.apache.thrift.protocol.TBinaryProtocol.readString(TBinaryProtocol.java:410) ~[libthrift-0.14.0.jar:0.14.0]
at org.apache.thrift.protocol.TBinaryProtocol.readMessageBegin(TBinaryProtocol.java:250) ~[libthrift-0.14.0.jar:0.14.0]
at org.apache.thrift.TServiceClient.receiveBase(TServiceClient.java:77) ~[libthrift-0.14.0.jar:0.14.0]
at org.apache.hadoop.hive.metastore.api.ThriftHiveMetastore$Client.recv_get_table(ThriftHiveMetastore.java:1993) ~[hive-apache-3.0.0-5.jar:3.0.0-4-4-g7dde337]
at org.apache.hadoop.hive.metastore.api.ThriftHiveMetastore$Client.get_table(ThriftHiveMetastore.java:1979) ~[hive-apache-3.0.0-5.jar:3.0.0-4-4-g7dde337]
at com.starrocks.external.hive.HiveMetaStoreThriftClient.getTable(HiveMetaStoreThriftClient.java:588) ~[starrocks-fe.jar:?]
at com.starrocks.external.hive.HiveMetaStoreThriftClient.getTable(HiveMetaStoreThriftClient.java:583) ~[starrocks-fe.jar:?]
at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_111]
at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_111]
at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_111]
at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_111]
at org.apache.hadoop.hive.metastore.RetryingMetaStoreClient.invoke(RetryingMetaStoreClient.java:208) ~[hive-apache-3.0.0-5.jar:3.0.0-4-4-g7dde337]
at com.sun.proxy.$Proxy38.getTable(Unknown Source) ~[?:?]
at com.starrocks.external.hive.HiveMetaClient.getPartitionKeys(HiveMetaClient.java:140) ~[starrocks-fe.jar:?]
at com.starrocks.external.hive.HiveMetaCache.loadPartitionKeys(HiveMetaCache.java:106) ~[starrocks-fe.jar:?]
at com.starrocks.external.hive.HiveMetaCache.access$000(HiveMetaCache.java:25) ~[starrocks-fe.jar:?]
at com.starrocks.external.hive.HiveMetaCache$1.load(HiveMetaCache.java:58) ~[starrocks-fe.jar:?]
at com.starrocks.external.hive.HiveMetaCache$1.load(HiveMetaCache.java:55) ~[starrocks-fe.jar:?]
at com.google.common.cache.CacheLoader$1.load(CacheLoader.java:192) ~[spark-dpp-1.0.0.jar:?]
at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3529) ~[spark-dpp-1.0.0.jar:?]
at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2278) ~[spark-dpp-1.0.0.jar:?]
at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2155) ~[spark-dpp-1.0.0.jar:?]
at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2045) ~[spark-dpp-1.0.0.jar:?]
... 21 more
```