### PR TITLE
use full_chunk queue in local shuffle and multiple sources in local passthrough

### DIFF
--- a/be/src/exec/pipeline/exchange/local_exchange.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange.cpp
@@ -70,6 +70,10 @@ Status PartitionExchanger::accept(const vectorized::ChunkPtr& chunk, const int32
 
     auto& partitioner = _partitioners[sink_driver_sequence];
 
+    // Create a new partition_row_indexes here instead of reusing it in the partitioner.
+    // The chunk and partition_row_indexes are cached in the queue of source operator,
+    // and used later in pull_chunk() of source operator. If we reuse partition_row_indexes in partitioner,
+    // it will be overwritten by the next time calling partitioner.partition_chunk().
     std::shared_ptr<std::vector<uint32_t>> partition_row_indexes = std::make_shared<std::vector<uint32_t>>(num_rows);
     partitioner.partition_chunk(chunk, *partition_row_indexes);
 

--- a/be/src/exec/pipeline/exchange/local_exchange.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange.cpp
@@ -95,7 +95,14 @@ Status BroadcastExchanger::accept(const vectorized::ChunkPtr& chunk) {
 
 Status PassthroughExchanger::accept(const vectorized::ChunkPtr& chunk) {
     _memory_manager->update_row_count(chunk->num_rows());
-    _source->get_sources()[0]->add_chunk(chunk);
+
+    size_t sources_num = _source->get_sources().size();
+    if (sources_num == 1) {
+        _source->get_sources()[0]->add_chunk(chunk);
+    } else {
+        _source->get_sources()[(_next_accept_source++) % sources_num]->add_chunk(chunk);
+    }
+
     return Status::OK();
 }
 

--- a/be/src/exec/pipeline/exchange/local_exchange.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange.cpp
@@ -7,72 +7,77 @@
 
 namespace starrocks::pipeline {
 
-PartitionExchanger::PartitionExchanger(const std::shared_ptr<LocalExchangeMemoryManager>& memory_manager,
-                                       LocalExchangeSourceOperatorFactory* source, bool is_shuffle,
-                                       const std::vector<ExprContext*>& partition_expr_ctxs)
-        : LocalExchanger(memory_manager),
-          _source(source),
-          _is_shuffle(is_shuffle),
-          _partition_expr_ctxs(partition_expr_ctxs) {
-    _partitions_columns.resize(partition_expr_ctxs.size());
-    _row_indexes.resize(config::vector_chunk_size);
+Status PartitionExchanger::Partitioner::partition_chunk(const vectorized::ChunkPtr& chunk,
+                                                        std::vector<uint32_t>& partition_row_indexes) {
+    size_t num_rows = chunk->num_rows();
+    size_t num_partitions = _source->get_sources().size();
+
+    for (size_t i = 0; i < _partitions_columns.size(); ++i) {
+        _partitions_columns[i] = _partition_expr_ctxs[i]->evaluate(chunk.get());
+        DCHECK(_partitions_columns[i] != nullptr);
+    }
+
+    if (_is_shuffle) {
+        _hash_values.assign(num_rows, HashUtil::FNV_SEED);
+        for (const vectorized::ColumnPtr& column : _partitions_columns) {
+            column->fnv_hash(&_hash_values[0], 0, num_rows);
+        }
+    } else {
+        // The data distribution was calculated using CRC32_HASH,
+        // and bucket shuffle need to use the same hash function when sending data.
+        _hash_values.assign(num_rows, 0);
+        for (const vectorized::ColumnPtr& column : _partitions_columns) {
+            column->crc32_hash(&_hash_values[0], 0, num_rows);
+        }
+    }
+
+    // Compute row indexes for each channel.
+    _partition_row_indexes_start_points.assign(num_partitions + 1, 0);
+    for (size_t i = 0; i < num_rows; ++i) {
+        size_t channel_index = _hash_values[i] % num_partitions;
+        _partition_row_indexes_start_points[channel_index]++;
+        _hash_values[i] = channel_index;
+    }
+    // We make the last item equal with number of rows of this chunk.
+    for (int i = 1; i <= num_partitions; ++i) {
+        _partition_row_indexes_start_points[i] += _partition_row_indexes_start_points[i - 1];
+    }
+
+    for (int i = static_cast<int>(num_rows) - 1; i >= 0; --i) {
+        partition_row_indexes[--_partition_row_indexes_start_points[_hash_values[i]]] = i;
+    }
+
+    return Status::OK();
 }
 
-Status PartitionExchanger::accept(const vectorized::ChunkPtr& chunk) {
-    uint16_t num_rows = chunk->num_rows();
+PartitionExchanger::PartitionExchanger(const std::shared_ptr<LocalExchangeMemoryManager>& memory_manager,
+                                       LocalExchangeSourceOperatorFactory* source, bool is_shuffle,
+                                       const std::vector<ExprContext*>& partition_expr_ctxs, const size_t num_sinks)
+        : LocalExchanger(memory_manager), _source(source) {
+    _partitioners.reserve(num_sinks);
+    for (size_t i = 0; i < num_sinks; i++) {
+        _partitioners.emplace_back(source, is_shuffle, partition_expr_ctxs);
+    }
+}
+
+Status PartitionExchanger::accept(const vectorized::ChunkPtr& chunk, const int32_t sink_driver_sequence) {
+    size_t num_rows = chunk->num_rows();
     if (num_rows == 0) {
         return Status::OK();
     }
 
-    _memory_manager->update_row_count(chunk->num_rows());
+    _memory_manager->update_row_count(static_cast<int32_t>(num_rows));
 
-    // hash-partition batch's rows across channels
-    int num_channels = _source->get_sources().size();
-    {
-        // SCOPED_TIMER(_shuffle_hash_timer);
-        for (size_t i = 0; i < _partitions_columns.size(); ++i) {
-            _partitions_columns[i] = _partition_expr_ctxs[i]->evaluate(chunk.get());
-            DCHECK(_partitions_columns[i] != nullptr);
-        }
+    auto& partitioner = _partitioners[sink_driver_sequence];
 
-        if (_is_shuffle) {
-            _hash_values.assign(num_rows, HashUtil::FNV_SEED);
-            for (const vectorized::ColumnPtr& column : _partitions_columns) {
-                column->fnv_hash(&_hash_values[0], 0, num_rows);
-            }
-        } else {
-            // The data distribution was calculated using CRC32_HASH,
-            // and bucket shuffle need to use the same hash function when sending data
-            _hash_values.assign(num_rows, 0);
-            for (const vectorized::ColumnPtr& column : _partitions_columns) {
-                column->crc32_hash(&_hash_values[0], 0, num_rows);
-            }
-        }
+    std::shared_ptr<std::vector<uint32_t>> partition_row_indexes = std::make_shared<std::vector<uint32_t>>(num_rows);
+    partitioner.partition_chunk(chunk, *partition_row_indexes);
 
-        // compute row indexes for each channel
-        _channel_row_idx_start_points.assign(num_channels + 1, 0);
-        for (uint16_t i = 0; i < num_rows; ++i) {
-            uint16_t channel_index = _hash_values[i] % num_channels;
-            _channel_row_idx_start_points[channel_index]++;
-            _hash_values[i] = channel_index;
-        }
-        // NOTE:
-        // we make the last item equal with number of rows of this chunk
-        for (int i = 1; i <= num_channels; ++i) {
-            _channel_row_idx_start_points[i] += _channel_row_idx_start_points[i - 1];
-        }
-
-        for (int i = num_rows - 1; i >= 0; --i) {
-            _row_indexes[_channel_row_idx_start_points[_hash_values[i]] - 1] = i;
-            _channel_row_idx_start_points[_hash_values[i]]--;
-        }
-    }
-
-    for (int i = 0; i < num_channels; ++i) {
-        size_t from = _channel_row_idx_start_points[i];
-        size_t size = _channel_row_idx_start_points[i + 1] - from;
+    for (size_t i = 0; i < _source->get_sources().size(); ++i) {
+        size_t from = partitioner.partition_begin_offset(i);
+        size_t size = partitioner.partition_end_offset(i) - from;
         if (size == 0) {
-            // no data for this channel continue;
+            // No data for this partition.
             continue;
         }
         // TODO(kks): support bucket shuffle later
@@ -80,12 +85,12 @@ Status PartitionExchanger::accept(const vectorized::ChunkPtr& chunk) {
         //     // dest bucket is no used, continue
         //     continue;
         // }
-        RETURN_IF_ERROR(_source->get_sources()[i]->add_chunk(chunk.get(), _row_indexes.data(), from, size));
+        RETURN_IF_ERROR(_source->get_sources()[i]->add_chunk(chunk, partition_row_indexes, from, size));
     }
     return Status::OK();
 }
 
-Status BroadcastExchanger::accept(const vectorized::ChunkPtr& chunk) {
+Status BroadcastExchanger::accept(const vectorized::ChunkPtr& chunk, const int32_t sink_driver_sequence) {
     _memory_manager->update_row_count(chunk->num_rows());
     for (auto* buffer : _source->get_sources()) {
         buffer->add_chunk(chunk);
@@ -93,7 +98,7 @@ Status BroadcastExchanger::accept(const vectorized::ChunkPtr& chunk) {
     return Status::OK();
 }
 
-Status PassthroughExchanger::accept(const vectorized::ChunkPtr& chunk) {
+Status PassthroughExchanger::accept(const vectorized::ChunkPtr& chunk, const int32_t sink_driver_sequence) {
     _memory_manager->update_row_count(chunk->num_rows());
 
     size_t sources_num = _source->get_sources().size();

--- a/be/src/exec/pipeline/exchange/local_exchange.h
+++ b/be/src/exec/pipeline/exchange/local_exchange.h
@@ -101,12 +101,15 @@ public:
 
     void finish(RuntimeState* state) override {
         if (decrement_sink_number() == 1) {
-            _source->get_sources()[0]->finish(state);
+            for (auto* source : _source->get_sources()) {
+                source->finish(state);
+            }
         }
     }
 
 private:
     LocalExchangeSourceOperatorFactory* _source;
+    size_t _next_accept_source = 0;
 };
 } // namespace pipeline
 } // namespace starrocks

--- a/be/src/exec/pipeline/exchange/local_exchange.h
+++ b/be/src/exec/pipeline/exchange/local_exchange.h
@@ -7,19 +7,21 @@
 #include "column/vectorized_fwd.h"
 #include "exec/pipeline/exchange/local_exchange_memory_manager.h"
 #include "exec/pipeline/exchange/local_exchange_source_operator.h"
+#include "exprs/expr_context.h"
 
 namespace starrocks {
 class ExprContext;
 class RuntimeState;
+
 namespace pipeline {
 // Inspire from com.facebook.presto.operator.exchange.LocalExchanger
 // Exchange the local data from local sink operator to local source operator
 class LocalExchanger {
 public:
-    LocalExchanger(std::shared_ptr<LocalExchangeMemoryManager> memory_manager)
+    explicit LocalExchanger(std::shared_ptr<LocalExchangeMemoryManager> memory_manager)
             : _memory_manager(std::move(memory_manager)) {}
 
-    virtual Status accept(const vectorized::ChunkPtr& chunk) = 0;
+    virtual Status accept(const vectorized::ChunkPtr& chunk, int32_t sink_driver_sequence) = 0;
 
     virtual void finish(RuntimeState* state) = 0;
 
@@ -36,12 +38,49 @@ protected:
 
 // Exchange the local data for shuffle
 class PartitionExchanger final : public LocalExchanger {
+    class Partitioner {
+    public:
+        Partitioner(LocalExchangeSourceOperatorFactory* source, const bool is_shuffle,
+                    const std::vector<ExprContext*>& partition_expr_ctxs)
+                : _source(source), _is_shuffle(is_shuffle), _partition_expr_ctxs(partition_expr_ctxs) {
+            _partitions_columns.resize(partition_expr_ctxs.size());
+            _hash_values.reserve(config::vector_chunk_size);
+        }
+
+        // Divide chunk into shuffle partitions.
+        // partition_row_indexes records the row indexes for the current shuffle index.
+        // Sender will arrange the row indexes according to partitions.
+        // For example, if there are 3 channels, it will put partition 0's row first,
+        // then partition 1's row indexes, then put partition 2's row indexes in the last.
+        Status partition_chunk(const vectorized::ChunkPtr& chunk, std::vector<uint32_t>& partition_row_indexes);
+
+        size_t partition_begin_offset(size_t partition_id) { return _partition_row_indexes_start_points[partition_id]; }
+
+        size_t partition_end_offset(size_t partition_id) {
+            return _partition_row_indexes_start_points[partition_id + 1];
+        }
+
+    private:
+        LocalExchangeSourceOperatorFactory* _source;
+        const bool _is_shuffle;
+        // Compute per-row partition values.
+        const std::vector<ExprContext*>& _partition_expr_ctxs;
+
+        vectorized::Columns _partitions_columns;
+        std::vector<uint32_t> _hash_values;
+        // This array record the channel start point in _row_indexes
+        // And the last item is the number of rows of the current shuffle chunk.
+        // It will easy to get number of rows belong to one channel by doing
+        // _partition_row_indexes_start_points[i + 1] - _partition_row_indexes_start_points[i]
+        std::vector<size_t> _partition_row_indexes_start_points;
+    };
+
 public:
     PartitionExchanger(const std::shared_ptr<LocalExchangeMemoryManager>& memory_manager,
                        LocalExchangeSourceOperatorFactory* source, bool is_shuffle,
-                       const std::vector<ExprContext*>& _partition_expr_ctxs);
+                       const std::vector<ExprContext*>& _partition_expr_ctxs, size_t num_sinks);
 
-    Status accept(const vectorized::ChunkPtr& chunk) override;
+    Status accept(const vectorized::ChunkPtr& chunk, int32_t sink_driver_sequence) override;
 
     void finish(RuntimeState* state) override {
         if (decrement_sink_number() == 1) {
@@ -53,21 +92,9 @@ public:
 
 private:
     LocalExchangeSourceOperatorFactory* _source;
-    bool _is_shuffle = true;
-    std::vector<ExprContext*> _partition_expr_ctxs; // compute per-row partition values
-
-    vectorized::Columns _partitions_columns;
-    std::vector<uint32_t> _hash_values;
-    // This array record the channel start point in _row_indexes
-    // And the last item is the number of rows of the current shuffle chunk.
-    // It will easy to get number of rows belong to one channel by doing
-    // _channel_row_idx_start_points[i + 1] - _channel_row_idx_start_points[i]
-    std::vector<uint16_t> _channel_row_idx_start_points;
-    // Record the row indexes for the current shuffle index. Sender will arrange the row indexes
-    // according to channels. For example, if there are 3 channels, this _row_indexes will put
-    // channel 0's row first, then channel 1's row indexes, then put channel 2's row indexes in
-    // the last.
-    std::vector<uint32_t> _row_indexes;
+    // For local shuffle exchanger.
+    // The sink_driver_sequence-th local sink operator exclusively uses the sink_driver_sequence-th partitioner
+    std::vector<Partitioner> _partitioners;
 };
 
 // Exchange the local data for broadcast
@@ -77,7 +104,7 @@ public:
                        LocalExchangeSourceOperatorFactory* source)
             : LocalExchanger(memory_manager), _source(source) {}
 
-    Status accept(const vectorized::ChunkPtr& chunk) override;
+    Status accept(const vectorized::ChunkPtr& chunk, int32_t sink_driver_sequence) override;
 
     void finish(RuntimeState* state) override {
         if (decrement_sink_number() == 1) {
@@ -97,7 +124,8 @@ public:
     PassthroughExchanger(const std::shared_ptr<LocalExchangeMemoryManager>& memory_manager,
                          LocalExchangeSourceOperatorFactory* source)
             : LocalExchanger(memory_manager), _source(source) {}
-    Status accept(const vectorized::ChunkPtr& chunk) override;
+
+    Status accept(const vectorized::ChunkPtr& chunk, int32_t sink_driver_sequence) override;
 
     void finish(RuntimeState* state) override {
         if (decrement_sink_number() == 1) {
@@ -109,7 +137,8 @@ public:
 
 private:
     LocalExchangeSourceOperatorFactory* _source;
-    size_t _next_accept_source = 0;
+    std::atomic<size_t> _next_accept_source = 0;
 };
+
 } // namespace pipeline
 } // namespace starrocks

--- a/be/src/exec/pipeline/exchange/local_exchange.h
+++ b/be/src/exec/pipeline/exchange/local_exchange.h
@@ -92,8 +92,9 @@ public:
 
 private:
     LocalExchangeSourceOperatorFactory* _source;
-    // For local shuffle exchanger.
-    // The sink_driver_sequence-th local sink operator exclusively uses the sink_driver_sequence-th partitioner
+    // Used for local shuffle exchanger.
+    // The sink_driver_sequence-th local sink operator exclusively uses the sink_driver_sequence-th partitioner.
+    // TODO(lzh): limit the size of _partitioners, because it will cost too much memory when dop is high.
     std::vector<Partitioner> _partitioners;
 };
 

--- a/be/src/exec/pipeline/exchange/local_exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange_sink_operator.cpp
@@ -28,7 +28,7 @@ void LocalExchangeSinkOperator::finish(RuntimeState* state) {
 }
 
 Status LocalExchangeSinkOperator::push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) {
-    _exchanger->accept(chunk);
+    _exchanger->accept(chunk, _driver_sequence);
     return Status::OK();
 }
 

--- a/be/src/exec/pipeline/exchange/local_exchange_sink_operator.h
+++ b/be/src/exec/pipeline/exchange/local_exchange_sink_operator.h
@@ -10,8 +10,9 @@
 namespace starrocks::pipeline {
 class LocalExchangeSinkOperator final : public Operator {
 public:
-    LocalExchangeSinkOperator(int32_t id, const std::shared_ptr<LocalExchanger>& exchanger)
-            : Operator(id, "local_exchange_sink", -1), _exchanger(exchanger) {}
+    LocalExchangeSinkOperator(int32_t id, const std::shared_ptr<LocalExchanger>& exchanger,
+                              const int32_t driver_sequence)
+            : Operator(id, "local_exchange_sink", -1), _exchanger(exchanger), _driver_sequence(driver_sequence) {}
 
     ~LocalExchangeSinkOperator() override = default;
 
@@ -32,6 +33,7 @@ public:
 private:
     bool _is_finished = false;
     const std::shared_ptr<LocalExchanger>& _exchanger;
+    const int32_t _driver_sequence;
 };
 
 class LocalExchangeSinkOperatorFactory final : public OperatorFactory {
@@ -42,7 +44,7 @@ public:
     ~LocalExchangeSinkOperatorFactory() override = default;
 
     OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override {
-        return std::make_shared<LocalExchangeSinkOperator>(_id, _exchanger);
+        return std::make_shared<LocalExchangeSinkOperator>(_id, _exchanger, driver_sequence);
     }
 
 private:

--- a/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
@@ -7,31 +7,25 @@
 
 namespace starrocks::pipeline {
 
+// Used for PassthroughExchanger.
+// The input chunk is most likely full chunk, so we don't merge it to avoid copying chunk data.
 Status LocalExchangeSourceOperator::add_chunk(vectorized::ChunkPtr chunk) {
     std::lock_guard<std::mutex> l(_chunk_lock);
 
-    _full_chunks.emplace(std::move(chunk));
+    _full_chunk_queue.emplace(std::move(chunk));
 
     return Status::OK();
 }
 
-Status LocalExchangeSourceOperator::add_chunk(vectorized::Chunk* chunk, const uint32_t* indexes, uint32_t from,
+// Used for partitionExchanger.
+// Only enqueue the partition chunk information here, and merge chunk in pull_chunk.
+Status LocalExchangeSourceOperator::add_chunk(vectorized::ChunkPtr chunk,
+                                              std::shared_ptr<std::vector<uint32_t>> indexes, uint32_t from,
                                               uint32_t size) {
     std::lock_guard<std::mutex> l(_chunk_lock);
 
-    if (_partial_chunk == nullptr) {
-        _partial_chunk = chunk->clone_empty_with_slot();
-    }
-
-    if (_partial_chunk->num_rows() + size > config::vector_chunk_size) {
-        _full_chunks.emplace(std::move(_partial_chunk));
-        _partial_chunk = chunk->clone_empty_with_slot();
-    }
-
-    _partial_chunk->append_selective(*chunk, indexes, from, size);
-    if (_partial_chunk->num_rows() >= config::vector_chunk_size) {
-        _full_chunks.emplace(std::move(_partial_chunk));
-    }
+    _partition_chunk_queue.emplace(std::move(chunk), std::move(indexes), from, size);
+    _partition_rows_num += size;
 
     return Status::OK();
 }
@@ -39,29 +33,64 @@ Status LocalExchangeSourceOperator::add_chunk(vectorized::Chunk* chunk, const ui
 bool LocalExchangeSourceOperator::is_finished() const {
     std::lock_guard<std::mutex> l(_chunk_lock);
 
-    return _is_finished && _full_chunks.empty() && _partial_chunk == nullptr;
+    return _is_finished && _full_chunk_queue.empty() && !_partition_rows_num;
 }
 
 bool LocalExchangeSourceOperator::has_output() const {
     std::lock_guard<std::mutex> l(_chunk_lock);
 
-    return (!_full_chunks.empty()) || (_is_finished && _partial_chunk != nullptr);
+    return !_full_chunk_queue.empty() || _partition_rows_num > config::vector_chunk_size ||
+           (_is_finished && _partition_rows_num > 0);
 }
 
 StatusOr<vectorized::ChunkPtr> LocalExchangeSourceOperator::pull_chunk(RuntimeState* state) {
+    vectorized::ChunkPtr chunk = _pull_passthrough_chunk(state);
+    if (chunk == nullptr) {
+        chunk = _pull_shuffle_chunk(state);
+    }
+    _memory_manager->update_row_count(-(static_cast<int32_t>(chunk->num_rows())));
+    return std::move(chunk);
+}
+
+vectorized::ChunkPtr LocalExchangeSourceOperator::_pull_passthrough_chunk(RuntimeState* state) {
     std::lock_guard<std::mutex> l(_chunk_lock);
 
-    vectorized::ChunkPtr dst_chunk;
-    if (!_full_chunks.empty()) {
-        dst_chunk = std::move(_full_chunks.front());
-        _full_chunks.pop();
-    } else {
-        DCHECK(_is_finished && _partial_chunk != nullptr);
-        dst_chunk = std::move(_partial_chunk);
+    if (!_full_chunk_queue.empty()) {
+        vectorized::ChunkPtr chunk = std::move(_full_chunk_queue.front());
+        _full_chunk_queue.pop();
+        return chunk;
     }
 
-    _memory_manager->update_row_count(-(static_cast<int32_t>(dst_chunk->num_rows())));
-    return std::move(dst_chunk);
+    return nullptr;
+}
+
+vectorized::ChunkPtr LocalExchangeSourceOperator::_pull_shuffle_chunk(RuntimeState* state) {
+    std::vector<PartitionChunk> selected_partition_chunks;
+    size_t rows_num = 0;
+    // Lock during pop partition chunks from queue.
+    {
+        std::lock_guard<std::mutex> l(_chunk_lock);
+
+        DCHECK(!_partition_chunk_queue.empty());
+
+        while (!_partition_chunk_queue.empty() &&
+               rows_num + _partition_chunk_queue.front().size <= config::vector_chunk_size) {
+            rows_num += _partition_chunk_queue.front().size;
+            selected_partition_chunks.emplace_back(std::move(_partition_chunk_queue.front()));
+            _partition_chunk_queue.pop();
+        }
+        _partition_rows_num -= rows_num;
+    }
+
+    // Unlock during merging partition chunks into a full chunk.
+    vectorized::ChunkPtr chunk = selected_partition_chunks[0].chunk->clone_empty_with_slot();
+    chunk->reserve(rows_num);
+    for (const auto& partition_chunk : selected_partition_chunks) {
+        chunk->append_selective(*partition_chunk.chunk, partition_chunk.indexes->data(), partition_chunk.from,
+                                partition_chunk.size);
+    }
+
+    return chunk;
 }
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
@@ -9,16 +9,9 @@ namespace starrocks::pipeline {
 
 Status LocalExchangeSourceOperator::add_chunk(vectorized::ChunkPtr chunk) {
     std::lock_guard<std::mutex> l(_chunk_lock);
-    if (_full_chunk == nullptr) {
-        _full_chunk = std::move(chunk);
-    } else {
-        vectorized::Columns& dest_columns = _full_chunk->columns();
-        vectorized::Columns& src_columns = chunk->columns();
-        size_t num_rows = chunk->num_rows();
-        for (size_t i = 0; i < dest_columns.size(); i++) {
-            dest_columns[i]->append(*src_columns[i], 0, num_rows);
-        }
-    }
+
+    _full_chunks.emplace(std::move(chunk));
+
     return Status::OK();
 }
 
@@ -31,28 +24,44 @@ Status LocalExchangeSourceOperator::add_chunk(vectorized::Chunk* chunk, const ui
     }
 
     if (_partial_chunk->num_rows() + size > config::vector_chunk_size) {
-        _full_chunk = std::move(_partial_chunk);
+        _full_chunks.emplace(std::move(_partial_chunk));
         _partial_chunk = chunk->clone_empty_with_slot();
     }
 
     _partial_chunk->append_selective(*chunk, indexes, from, size);
+    if (_partial_chunk->num_rows() >= config::vector_chunk_size) {
+        _full_chunks.emplace(std::move(_partial_chunk));
+    }
+
     return Status::OK();
 }
 
 bool LocalExchangeSourceOperator::is_finished() const {
     std::lock_guard<std::mutex> l(_chunk_lock);
-    return _is_finished && _full_chunk == nullptr && _partial_chunk == nullptr;
+
+    return _is_finished && _full_chunks.empty() && _partial_chunk == nullptr;
 }
 
 bool LocalExchangeSourceOperator::has_output() const {
     std::lock_guard<std::mutex> l(_chunk_lock);
-    return _full_chunk != nullptr;
+
+    return (!_full_chunks.empty()) || (_is_finished && _partial_chunk != nullptr);
 }
 
 StatusOr<vectorized::ChunkPtr> LocalExchangeSourceOperator::pull_chunk(RuntimeState* state) {
     std::lock_guard<std::mutex> l(_chunk_lock);
-    _memory_manager->update_row_count(-_full_chunk->num_rows());
-    return std::move(_full_chunk);
+
+    vectorized::ChunkPtr dst_chunk;
+    if (!_full_chunks.empty()) {
+        dst_chunk = std::move(_full_chunks.front());
+        _full_chunks.pop();
+    } else {
+        DCHECK(_is_finished && _partial_chunk != nullptr);
+        dst_chunk = std::move(_partial_chunk);
+    }
+
+    _memory_manager->update_row_count(-(static_cast<int32_t>(dst_chunk->num_rows())));
+    return std::move(dst_chunk);
 }
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
@@ -8,7 +8,7 @@
 namespace starrocks::pipeline {
 
 // Used for PassthroughExchanger.
-// The input chunk is most likely full chunk, so we don't merge it to avoid copying chunk data.
+// The input chunk is most likely full, so we don't merge it to avoid copying chunk data.
 Status LocalExchangeSourceOperator::add_chunk(vectorized::ChunkPtr chunk) {
     std::lock_guard<std::mutex> l(_chunk_lock);
 
@@ -17,8 +17,8 @@ Status LocalExchangeSourceOperator::add_chunk(vectorized::ChunkPtr chunk) {
     return Status::OK();
 }
 
-// Used for partitionExchanger.
-// Only enqueue the partition chunk information here, and merge chunk in pull_chunk.
+// Used for PartitionExchanger.
+// Only enqueue the partition chunk information here, and merge chunk in pull_chunk().
 Status LocalExchangeSourceOperator::add_chunk(vectorized::ChunkPtr chunk,
                                               std::shared_ptr<std::vector<uint32_t>> indexes, uint32_t from,
                                               uint32_t size) {

--- a/be/src/exec/pipeline/exchange/local_exchange_source_operator.h
+++ b/be/src/exec/pipeline/exchange/local_exchange_source_operator.h
@@ -11,13 +11,30 @@
 
 namespace starrocks::pipeline {
 class LocalExchangeSourceOperator final : public SourceOperator {
+    class PartitionChunk {
+    public:
+        PartitionChunk(vectorized::ChunkPtr chunk, std::shared_ptr<std::vector<uint32_t>> indexes, const uint32_t from,
+                       const uint32_t size)
+                : chunk(std::move(chunk)), indexes(std::move(indexes)), from(from), size(size) {}
+
+        PartitionChunk(const PartitionChunk&) = delete;
+
+        PartitionChunk(PartitionChunk&&) = default;
+
+        vectorized::ChunkPtr chunk;
+        std::shared_ptr<std::vector<uint32_t>> indexes;
+        const uint32_t from;
+        const uint32_t size;
+    };
+
 public:
     LocalExchangeSourceOperator(int32_t id, const std::shared_ptr<LocalExchangeMemoryManager>& memory_manager)
             : SourceOperator(id, "local_exchange_source", -1), _memory_manager(memory_manager) {}
 
     Status add_chunk(vectorized::ChunkPtr chunk);
 
-    Status add_chunk(vectorized::Chunk* chunk, const uint32_t* indexes, uint32_t from, uint32_t size);
+    Status add_chunk(vectorized::ChunkPtr chunk, std::shared_ptr<std::vector<uint32_t>> indexes, uint32_t from,
+                     uint32_t size);
 
     bool has_output() const override;
 
@@ -32,9 +49,17 @@ public:
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 
 private:
+    vectorized::ChunkPtr _pull_passthrough_chunk(RuntimeState* state);
+
+    vectorized::ChunkPtr _pull_shuffle_chunk(RuntimeState* state);
+
     std::atomic<bool> _is_finished{false};
-    std::queue<vectorized::ChunkPtr> _full_chunks;
-    vectorized::ChunkUniquePtr _partial_chunk = nullptr;
+
+    std::queue<vectorized::ChunkPtr> _full_chunk_queue;
+
+    std::queue<PartitionChunk> _partition_chunk_queue;
+    size_t _partition_rows_num = 0;
+
     // TODO(KKS): make it lock free
     mutable std::mutex _chunk_lock;
     const std::shared_ptr<LocalExchangeMemoryManager>& _memory_manager;

--- a/be/src/exec/pipeline/exchange/local_exchange_source_operator.h
+++ b/be/src/exec/pipeline/exchange/local_exchange_source_operator.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <mutex>
+#include <queue>
 #include <utility>
 
 #include "exec/pipeline/exchange/local_exchange_memory_manager.h"
@@ -25,9 +26,6 @@ public:
     void finish(RuntimeState* state) override {
         std::lock_guard<std::mutex> l(_chunk_lock);
 
-        if (_partial_chunk != nullptr) {
-            _full_chunk = std::move(_partial_chunk);
-        }
         _is_finished = true;
     }
 
@@ -35,7 +33,7 @@ public:
 
 private:
     std::atomic<bool> _is_finished{false};
-    vectorized::ChunkPtr _full_chunk = nullptr;
+    std::queue<vectorized::ChunkPtr> _full_chunks;
     vectorized::ChunkUniquePtr _partial_chunk = nullptr;
     // TODO(KKS): make it lock free
     mutable std::mutex _chunk_lock;

--- a/be/src/exec/pipeline/set/except_context.cpp
+++ b/be/src/exec/pipeline/set/except_context.cpp
@@ -10,7 +10,7 @@ Status ExceptContext::prepare(RuntimeState* state, const std::vector<ExprContext
     _dst_tuple_desc = state->desc_tbl().get_tuple_descriptor(_dst_tuple_id);
     _dst_nullables.reserve(build_exprs.size());
     for (auto build_expr : build_exprs) {
-        _dst_nullables.emplace_back(build_expr->is_nullable());
+        _dst_nullables.emplace_back(build_expr->root()->is_nullable());
     }
 
     return Status::OK();


### PR DESCRIPTION
If `_row_count >= _max_row_count`, all the sink operators sharing one `LocalExchangeMemoryManager` will be full.

- To make sure at least one partition source operator is ready to output chunk before all the sink operators are full, `max_row_count` must be at least `shuffle_partitions_num * config::vector_chunk_size`.
- The  local shuffle partitions may be slope, so a local shuffle source operator maybe receive multiple `full_chunk`. Therefore, use `queue _full_chunks` instead of one `_full_chunk`.
- Make local passthrough sink operator can output chunks to multiple exchange source operator. In this way, DOP of the source operator in `gather_pipelines_to_one` can be greater than one.