### PR TITLE
Fix .Net Mysql.Data connect starrocks

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -1000,7 +1000,7 @@ public class ShowExecutor {
     }
 
     // Show alter statement.
-    private void handleShowCollation() throws AnalysisException {
+    private void handleShowCollation() {
         ShowCollationStmt showStmt = (ShowCollationStmt) stmt;
         List<List<String>> rows = Lists.newArrayList();
         List<String> row = Lists.newArrayList();
@@ -1008,6 +1008,15 @@ public class ShowExecutor {
         row.add("utf8_general_ci");
         row.add("utf8");
         row.add("33");
+        row.add("Yes");
+        row.add("Yes");
+        row.add("1");
+        rows.add(row);
+        // | binary | binary | 63 | Yes | Yes | 1 |
+        row = Lists.newArrayList();
+        row.add("binary");
+        row.add("binary");
+        row.add("63");
         row.add("Yes");
         row.add("Yes");
         row.add("1");


### PR DESCRIPTION
Fix #1013 
This because .Net Mysql.Data will execute 
```
show collation;
```
it only return id 33 
but in our code Type.java getMysqlResultSetFieldCharsetIndex
it could return 33 or 63
for 63 the driver can not find character for id 63 to set.