### PR TITLE
Return success when drop not exist materialized view

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/Alter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/Alter.java
@@ -160,7 +160,7 @@ public class Alter {
                 }
             }
             if (table == null) {
-                throw new DdlException("Materialized view " + stmt.getMvName() + " is not find");
+                throw new MetaNotFoundException("Materialized view " + stmt.getMvName() + " is not find");
             }
             // check table type
             if (table.getType() != TableType.OLAP) {
@@ -176,6 +176,12 @@ public class Alter {
             // drop materialized view
             ((MaterializedViewHandler) materializedViewHandler).processDropMaterializedView(stmt, db, olapTable);
 
+        } catch (MetaNotFoundException e) {
+            if (stmt.isSetIfExists()) {
+                LOG.info(e.getMessage());
+            } else {
+                throw e;
+            }
         } finally {
             db.writeUnlock();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/DropMaterializedViewStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/DropMaterializedViewStmt.java
@@ -47,7 +47,7 @@ import java.util.List;
  */
 public class DropMaterializedViewStmt extends DdlStmt {
 
-    private boolean ifExists;
+    private final boolean ifExists;
     private final TableName dbMvName;
     private final TableName dbTblName;
 
@@ -134,7 +134,7 @@ public class DropMaterializedViewStmt extends DdlStmt {
                     }
                 }
             }
-            if (!hasMv) {
+            if (!hasMv && !isSetIfExists()) {
                 throw new AnalysisException("The materialized " + dbMvName.getTbl() + " is not exist");
             }
         }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/DropMaterializedViewStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/DropMaterializedViewStmtTest.java
@@ -21,22 +21,94 @@
 
 package com.starrocks.analysis;
 
+import com.starrocks.catalog.Catalog;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.KeysType;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.SinglePartitionInfo;
+import com.starrocks.catalog.Type;
+import com.starrocks.common.AnalysisException;
 import com.starrocks.common.UserException;
+import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.mysql.privilege.Auth;
+import com.starrocks.mysql.privilege.MockedAuth;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.thrift.TStorageType;
+import mockit.Mock;
+import mockit.MockUp;
 import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.LinkedList;
+import java.util.List;
 
 public class DropMaterializedViewStmtTest {
 
     Analyzer analyzer;
     @Mocked
     Auth auth;
+    private Catalog catalog;
+    @Mocked
+    private ConnectContext connectContext;
 
     @Before
     public void setUp() {
         analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
+        MockedAuth.mockedAuth(auth);
+        catalog = Deencapsulation.newInstance(Catalog.class);
+        analyzer = new Analyzer(catalog, connectContext);
+        Database db = new Database(50000L, "test");
+
+        Column column1 = new Column("col1", Type.BIGINT);
+        Column column2 = new Column("col2", Type.DOUBLE);
+
+        List<Column> baseSchema = new LinkedList<>();
+        baseSchema.add(column1);
+        baseSchema.add(column2);
+
+        SinglePartitionInfo singlePartitionInfo = new SinglePartitionInfo();
+        OlapTable table = new OlapTable(30000, "table",
+                baseSchema, KeysType.AGG_KEYS, singlePartitionInfo, null);
+        table.setBaseIndexId(100);
+        db.createTable(table);
+        table.addPartition(new Partition(100, "p",
+                new MaterializedIndex(200, MaterializedIndex.IndexState.NORMAL), null));
+        table.setIndexMeta(200, "mvname", baseSchema, 0, 0, (short) 0,
+                TStorageType.COLUMN, KeysType.AGG_KEYS);
+
+        new MockUp<Catalog>() {
+            @Mock
+            Catalog getCurrentCatalog() {
+                return catalog;
+            }
+
+            @Mock
+            Auth getAuth() {
+                return auth;
+            }
+
+            @Mock
+            Database getDb(long dbId) {
+                return db;
+            }
+
+            @Mock
+            Database getDb(String dbName) {
+                return db;
+            }
+        };
+
+        new MockUp<Analyzer>() {
+            @Mock
+            String getClusterName() {
+                return "testCluster";
+            }
+        };
     }
 
     @Test
@@ -54,7 +126,8 @@ public class DropMaterializedViewStmtTest {
     @Test
     public void testRepeatedDB() {
         DropMaterializedViewStmt stmt =
-                new DropMaterializedViewStmt(false, new TableName("test", "mvname"), new TableName("test", "table"));
+                new DropMaterializedViewStmt(false, new TableName("test", "mvname"),
+                        new TableName("test", "table"));
         try {
             stmt.analyze(analyzer);
             Assert.fail();
@@ -66,7 +139,8 @@ public class DropMaterializedViewStmtTest {
     @Test
     public void testFromDB() {
         DropMaterializedViewStmt stmt =
-                new DropMaterializedViewStmt(false, new TableName("test", "mvname"), new TableName("", "table"));
+                new DropMaterializedViewStmt(false, new TableName("test", "mvname"),
+                        new TableName("", "table"));
         try {
             stmt.analyze(analyzer);
             Assert.fail();
@@ -77,7 +151,8 @@ public class DropMaterializedViewStmtTest {
 
     @Test
     public void testNormal() {
-        DropMaterializedViewStmt stmt = new DropMaterializedViewStmt(false, new TableName("test", "mvname"), null);
+        DropMaterializedViewStmt stmt = new DropMaterializedViewStmt(false,
+                new TableName("test", "mvname"), null);
         try {
             stmt.analyze(analyzer);
         } catch (UserException e) {
@@ -86,5 +161,19 @@ public class DropMaterializedViewStmtTest {
         } catch (Exception e) {
             e.printStackTrace();
         }
+    }
+
+    @Test(expected = AnalysisException.class)
+    public void testIfExists() throws UserException {
+        DropMaterializedViewStmt stmt = new DropMaterializedViewStmt(false,
+                new TableName("test", "mvname2"), null);
+        stmt.analyze(analyzer);
+    }
+
+    @Test
+    public void testIfNotExists() throws UserException {
+        DropMaterializedViewStmt stmt = new DropMaterializedViewStmt(true,
+                new TableName("test", "mvname2"), null);
+        stmt.analyze(analyzer);
     }
 }


### PR DESCRIPTION
The use send a DDL statement to drop materialized view like the following.
```
DROP MATERIALIZED VIEW if exists t2;
```
If t2 is not exist, the DDL should success instead of throw an exception.
And also, the related unit test is no longer used and to be removed.