### PR TITLE
[pipeline] feat: decompose intersect node to pipeline

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -176,6 +176,10 @@ set(EXEC_FILES
     pipeline/set/except_build_sink_operator.cpp
     pipeline/set/except_probe_sink_operator.cpp
     pipeline/set/except_output_source_operator.cpp
+    pipeline/set/intersect_context.cpp
+    pipeline/set/intersect_build_sink_operator.cpp
+    pipeline/set/intersect_probe_sink_operator.cpp
+    pipeline/set/intersect_output_source_operator.cpp
 )
 
 set(EXEC_FILES

--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -87,6 +87,7 @@ set(EXEC_FILES
     vectorized/parquet_reader.cpp
     vectorized/file_scan_node.cpp
     vectorized/assert_num_rows_node.cpp
+    vectorized/intersect_hash_set.cpp
     vectorized/intersect_node.cpp
     vectorized/hdfs_scanner.cpp
     vectorized/hdfs_scanner_orc.cpp

--- a/be/src/exec/pipeline/set/except_build_sink_operator.cpp
+++ b/be/src/exec/pipeline/set/except_build_sink_operator.cpp
@@ -14,6 +14,7 @@ Status ExceptBuildSinkOperator::push_chunk(RuntimeState* state, const vectorized
 
 Status ExceptBuildSinkOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(Operator::prepare(state));
+
     return _except_ctx->prepare(state, _dst_exprs);
 }
 
@@ -28,9 +29,9 @@ Status ExceptBuildSinkOperatorFactory::prepare(RuntimeState* state) {
 }
 
 void ExceptBuildSinkOperatorFactory::close(RuntimeState* state) {
-    OperatorFactory::close(state);
-
     Expr::close(_dst_exprs, state);
+
+    OperatorFactory::close(state);
 }
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/set/except_build_sink_operator.h
+++ b/be/src/exec/pipeline/set/except_build_sink_operator.h
@@ -10,10 +10,9 @@ namespace starrocks::pipeline {
 // ExceptNode is decomposed to ExceptBuildSinkOperator, ExceptProbeSinkOperator, and ExceptOutputSourceOperator.
 // - ExceptBuildSinkOperator (BUILD) builds the hast set from the output rows of ExceptNode's first child.
 // - ExceptProbeSinkOperator (PROBE) labels keys as deleted in the hash set from the output rows of reset children.
-//   PROBE depends on BUILD, which means it should wait for BUILD to finish building the hast set.
-//   Multiple PROBEs from multiple children can be parallelized to label keys as deleted.
+//   The first PROBE depends on BUILD, and the rest i-th PROBE depends on the (i-1)-th PROBE.
 // - ExceptOutputSourceOperator (OUTPUT) traverses the hast set and outputs undeleted rows.
-//   OUTPUT depends on all the PROBEs, which means it should wait for PROBEs to finish labeling keys as delete.
+//   OUTPUT depends on the last PROBE, which means it should wait for all the PROBEs to finish labeling keys as delete.
 //
 // The input chunks of BUILD and PROBE are shuffled by the local shuffle operator.
 // The number of shuffled partitions is the degree of parallelism (DOP), which means

--- a/be/src/exec/pipeline/set/except_build_sink_operator.h
+++ b/be/src/exec/pipeline/set/except_build_sink_operator.h
@@ -8,16 +8,21 @@
 namespace starrocks::pipeline {
 
 // ExceptNode is decomposed to ExceptBuildSinkOperator, ExceptProbeSinkOperator, and ExceptOutputSourceOperator.
-// - ExceptBuildSinkOperator (BUILD) builds the hast set from the output rows of ExceptNode's first child.
-// - ExceptProbeSinkOperator (PROBE) labels keys as deleted in the hash set from the output rows of reset children.
-//   The first PROBE depends on BUILD, and the rest i-th PROBE depends on the (i-1)-th PROBE.
-// - ExceptOutputSourceOperator (OUTPUT) traverses the hast set and outputs undeleted rows.
-//   OUTPUT depends on the last PROBE, which means it should wait for all the PROBEs to finish labeling keys as delete.
+// - ExceptBuildSinkOperator builds a hast set from the ExceptNode's first child.
+// - Each ExceptProbeSinkOperator probes the hash set built by ExceptBuildSinkOperator and labels the key as deleted.
+// - ExceptOutputSourceOperator traverses the hast set and picks up undeleted entries after probe phase is finished.
 //
-// The input chunks of BUILD and PROBE are shuffled by the local shuffle operator.
-// The number of shuffled partitions is the degree of parallelism (DOP), which means
-// the number of partition hash sets and the number of BUILD drivers, PROBE drivers of one child, OUTPUT drivers
-// are both DOP. And each pair of BUILD/PROBE/OUTPUT drivers shares a same except partition context.
+// ExceptBuildSinkOperator, ExceptProbeSinkOperator, and ExceptOutputSourceOperator
+// belong to different pipelines. There is dependency between them:
+// - The first ExceptProbeSinkOperator depends on ExceptBuildSinkOperator.
+// - The rest ExceptProbeSinkOperator depends on the prev ExceptProbeSinkOperator.
+// - ExceptOutputSourceOperator depends on the last ExceptProbeSinkOperator.
+// The execution sequence is as follows: ExceptBuildSinkOperator -> ExceptProbeSinkOperator 0
+// -> ExceptProbeSinkOperator 1 -> ... -> ExceptProbeSinkOperator N -> ExceptBuildSinkOperator.
+//
+// The rows are shuffled to degree of parallelism (DOP) partitions by local shuffle exchange.
+// For each partition, there are a ExceptBuildSinkOperator driver, a ExceptProbeSinkOperator driver
+// for each child, and a ExceptOutputSourceOperator.
 class ExceptBuildSinkOperator final : public Operator {
 public:
     ExceptBuildSinkOperator(int32_t id, int32_t plan_node_id, std::shared_ptr<ExceptContext> except_ctx,

--- a/be/src/exec/pipeline/set/except_context.cpp
+++ b/be/src/exec/pipeline/set/except_context.cpp
@@ -36,27 +36,27 @@ Status ExceptContext::erase_chunk_from_ht(RuntimeState* state, const ChunkPtr& c
 
 StatusOr<vectorized::ChunkPtr> ExceptContext::pull_chunk(RuntimeState* state) {
     // 1. Get at most *config::vector_chunk_size* remained keys from ht.
-    size_t remained_keys_num = 0;
+    size_t num_remained_keys = 0;
     _remained_keys.resize(config::vector_chunk_size);
-    while (_next_processed_iter != _hash_set->end() && remained_keys_num < config::vector_chunk_size) {
+    while (_next_processed_iter != _hash_set->end() && num_remained_keys < config::vector_chunk_size) {
         if (!_next_processed_iter->deleted) {
-            _remained_keys[remained_keys_num++] = _next_processed_iter->slice;
+            _remained_keys[num_remained_keys++] = _next_processed_iter->slice;
         }
         ++_next_processed_iter;
     }
 
     ChunkPtr dst_chunk = std::make_shared<vectorized::Chunk>();
-    if (remained_keys_num > 0) {
+    if (num_remained_keys > 0) {
         // 2. Create dest columns.
         vectorized::Columns dst_columns(_dst_nullables.size());
         for (size_t i = 0; i < _dst_nullables.size(); ++i) {
             const auto& slot = _dst_tuple_desc->slots()[i];
             dst_columns[i] = vectorized::ColumnHelper::create_column(slot->type(), _dst_nullables[i]);
-            dst_columns[i]->reserve(remained_keys_num);
+            dst_columns[i]->reserve(num_remained_keys);
         }
 
         // 3. Serialize remained keys to the dest columns.
-        _hash_set->deserialize_to_columns(_remained_keys, dst_columns, remained_keys_num);
+        _hash_set->deserialize_to_columns(_remained_keys, dst_columns, num_remained_keys);
 
         // 4. Add dest columns to the dest chunk.
         for (size_t i = 0; i < dst_columns.size(); i++) {

--- a/be/src/exec/pipeline/set/except_context.h
+++ b/be/src/exec/pipeline/set/except_context.h
@@ -80,7 +80,7 @@ private:
     // The BUILD, PROBES, and OUTPUT operators execute sequentially.
     // BUILD -> 1-th PROBE -> 2-th PROBE -> ... -> n-th PROBE -> OUTPUT.
     // _finished_dependency_index will increase by one when a BUILD or PROBE is finished.
-    // i-th PROBE must wait for _finished_dependency_index becoming i-1,
+    // The i-th PROBE must wait for _finished_dependency_index becoming i-1,
     // and OUTPUT must wait for _finished_dependency_index becoming n.
     std::atomic<int32_t> _finished_dependency_index{-1};
 };

--- a/be/src/exec/pipeline/set/except_output_source_operator.h
+++ b/be/src/exec/pipeline/set/except_output_source_operator.h
@@ -22,15 +22,18 @@ namespace starrocks::pipeline {
 // are both DOP. And each pair of BUILD/PROBE/OUTPUT drivers shares a same except partition context.
 class ExceptOutputSourceOperator final : public SourceOperator {
 public:
-    ExceptOutputSourceOperator(int32_t id, int32_t plan_node_id, std::shared_ptr<ExceptContext> except_ctx)
-            : SourceOperator(id, "except_output_source", plan_node_id), _except_ctx(std::move(except_ctx)) {}
+    ExceptOutputSourceOperator(int32_t id, int32_t plan_node_id, std::shared_ptr<ExceptContext> except_ctx,
+                               const int32_t dependency_index)
+            : SourceOperator(id, "except_output_source", plan_node_id),
+              _except_ctx(std::move(except_ctx)),
+              _dependency_index(dependency_index) {}
 
     bool has_output() const override {
-        return _except_ctx->is_erase_ht_finished() && !_except_ctx->is_output_finished();
+        return _except_ctx->is_dependency_finished(_dependency_index) && !_except_ctx->is_output_finished();
     }
 
     bool is_finished() const override {
-        return _except_ctx->is_erase_ht_finished() && _except_ctx->is_output_finished();
+        return _except_ctx->is_dependency_finished(_dependency_index) && _except_ctx->is_output_finished();
     }
 
     // Finish is noop.
@@ -42,24 +45,28 @@ public:
 
 private:
     std::shared_ptr<ExceptContext> _except_ctx;
+    const int32_t _dependency_index;
 };
 
 class ExceptOutputSourceOperatorFactory final : public SourceOperatorFactory {
 public:
     ExceptOutputSourceOperatorFactory(int32_t id, int32_t plan_node_id,
-                                      ExceptPartitionContextFactoryPtr except_partition_ctx_factory)
+                                      ExceptPartitionContextFactoryPtr except_partition_ctx_factory,
+                                      const int32_t dependency_index)
             : SourceOperatorFactory(id, "except_output_source", plan_node_id),
-              _except_partition_ctx_factory(std::move(except_partition_ctx_factory)) {}
+              _except_partition_ctx_factory(std::move(except_partition_ctx_factory)),
+              _dependency_index(dependency_index) {}
 
     OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override {
         return std::make_shared<ExceptOutputSourceOperator>(
-                _id, _plan_node_id, _except_partition_ctx_factory->get_or_create(driver_sequence));
+                _id, _plan_node_id, _except_partition_ctx_factory->get_or_create(driver_sequence), _dependency_index);
     }
 
     void close(RuntimeState* state) override;
 
 private:
     ExceptPartitionContextFactoryPtr _except_partition_ctx_factory;
+    const int32_t _dependency_index;
 };
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/set/except_output_source_operator.h
+++ b/be/src/exec/pipeline/set/except_output_source_operator.h
@@ -11,10 +11,9 @@ namespace starrocks::pipeline {
 // ExceptNode is decomposed to ExceptBuildSinkOperator, ExceptProbeSinkOperator, and ExceptOutputSourceOperator.
 // - ExceptBuildSinkOperator (BUILD) builds the hast set from the output rows of ExceptNode's first child.
 // - ExceptProbeSinkOperator (PROBE) labels keys as deleted in the hash set from the output rows of reset children.
-//   PROBE depends on BUILD, which means it should wait for BUILD to finish building the hast set.
-//   Multiple PROBEs from multiple children can be parallelized to label keys as deleted.
+//   The first PROBE depends on BUILD, and the rest i-th PROBE depends on the (i-1)-th PROBE.
 // - ExceptOutputSourceOperator (OUTPUT) traverses the hast set and outputs undeleted rows.
-//   OUTPUT depends on all the PROBEs, which means it should wait for PROBEs to finish labeling keys as delete.
+//   OUTPUT depends on the last PROBE, which means it should wait for all the PROBEs to finish labeling keys as delete.
 //
 // The input chunks of BUILD and PROBE are shuffled by the local shuffle operator.
 // The number of shuffled partitions is the degree of parallelism (DOP), which means

--- a/be/src/exec/pipeline/set/except_probe_sink_operator.h
+++ b/be/src/exec/pipeline/set/except_probe_sink_operator.h
@@ -7,17 +7,8 @@
 
 namespace starrocks::pipeline {
 
-// ExceptNode is decomposed to ExceptBuildSinkOperator, ExceptProbeSinkOperator, and ExceptOutputSourceOperator.
-// - ExceptBuildSinkOperator (BUILD) builds the hast set from the output rows of ExceptNode's first child.
-// - ExceptProbeSinkOperator (PROBE) labels keys as deleted in the hash set from the output rows of reset children.
-//   The first PROBE depends on BUILD, and the rest i-th PROBE depends on the (i-1)-th PROBE.
-// - ExceptOutputSourceOperator (OUTPUT) traverses the hast set and outputs undeleted rows.
-//   OUTPUT depends on the last PROBE, which means it should wait for all the PROBEs to finish labeling keys as delete.
-//
-// The input chunks of BUILD and PROBE are shuffled by the local shuffle operator.
-// The number of shuffled partitions is the degree of parallelism (DOP), which means
-// the number of partition hash sets and the number of BUILD drivers, PROBE drivers of one child, OUTPUT drivers
-// are both DOP. And each pair of BUILD/PROBE/OUTPUT drivers shares a same except partition context.
+// Each ExceptProbeSinkOperator probes the hash set built by ExceptBuildSinkOperator and labels the key as deleted.
+// For more detail information, see the comments of class ExceptBuildSinkOperator.
 class ExceptProbeSinkOperator final : public Operator {
 public:
     ExceptProbeSinkOperator(int32_t id, int32_t plan_node_id, std::shared_ptr<ExceptContext> except_ctx,

--- a/be/src/exec/pipeline/set/except_probe_sink_operator.h
+++ b/be/src/exec/pipeline/set/except_probe_sink_operator.h
@@ -23,7 +23,7 @@ class ExceptProbeSinkOperator final : public Operator {
 public:
     ExceptProbeSinkOperator(int32_t id, int32_t plan_node_id, std::shared_ptr<ExceptContext> except_ctx,
                             const std::vector<ExprContext*>& dst_exprs, const int32_t dependency_index)
-            : Operator(id, "except_erase_sink", plan_node_id),
+            : Operator(id, "except_probe_sink", plan_node_id),
               _except_ctx(std::move(except_ctx)),
               _dst_exprs(dst_exprs),
               _dependency_index(dependency_index) {}
@@ -50,7 +50,7 @@ public:
     Status push_chunk(RuntimeState* state, const ChunkPtr& chunk) override;
 
 private:
-    std::shared_ptr<ExceptContext> _except_ctx;
+    ExceptContextPtr _except_ctx;
 
     const std::vector<ExprContext*>& _dst_exprs;
 
@@ -63,7 +63,7 @@ public:
     ExceptProbeSinkOperatorFactory(int32_t id, int32_t plan_node_id,
                                    ExceptPartitionContextFactoryPtr except_partition_ctx_factory,
                                    const std::vector<ExprContext*>& dst_exprs, const int32_t dependency_index)
-            : OperatorFactory(id, "except_erase_sink", plan_node_id),
+            : OperatorFactory(id, "except_probe_sink", plan_node_id),
               _except_partition_ctx_factory(std::move(except_partition_ctx_factory)),
               _dst_exprs(dst_exprs),
               _dependency_index(dependency_index) {}

--- a/be/src/exec/pipeline/set/except_probe_sink_operator.h
+++ b/be/src/exec/pipeline/set/except_probe_sink_operator.h
@@ -10,10 +10,9 @@ namespace starrocks::pipeline {
 // ExceptNode is decomposed to ExceptBuildSinkOperator, ExceptProbeSinkOperator, and ExceptOutputSourceOperator.
 // - ExceptBuildSinkOperator (BUILD) builds the hast set from the output rows of ExceptNode's first child.
 // - ExceptProbeSinkOperator (PROBE) labels keys as deleted in the hash set from the output rows of reset children.
-//   PROBE depends on BUILD, which means it should wait for BUILD to finish building the hast set.
-//   Multiple PROBEs from multiple children can be parallelized to label keys as deleted.
+//   The first PROBE depends on BUILD, and the rest i-th PROBE depends on the (i-1)-th PROBE.
 // - ExceptOutputSourceOperator (OUTPUT) traverses the hast set and outputs undeleted rows.
-//   OUTPUT depends on all the PROBEs, which means it should wait for PROBEs to finish labeling keys as delete.
+//   OUTPUT depends on the last PROBE, which means it should wait for all the PROBEs to finish labeling keys as delete.
 //
 // The input chunks of BUILD and PROBE are shuffled by the local shuffle operator.
 // The number of shuffled partitions is the degree of parallelism (DOP), which means

--- a/be/src/exec/pipeline/set/intersect_build_sink_operator.cpp
+++ b/be/src/exec/pipeline/set/intersect_build_sink_operator.cpp
@@ -1,0 +1,37 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#include "exec/pipeline/set/intersect_build_sink_operator.h"
+
+namespace starrocks::pipeline {
+
+StatusOr<vectorized::ChunkPtr> IntersectBuildSinkOperator::pull_chunk(RuntimeState* state) {
+    return Status::InternalError("Shouldn't pull chunk from sink operator");
+}
+
+Status IntersectBuildSinkOperator::push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) {
+    return _intersect_ctx->append_chunk_to_ht(state, chunk, _dst_exprs);
+}
+
+Status IntersectBuildSinkOperator::prepare(RuntimeState* state) {
+    RETURN_IF_ERROR(Operator::prepare(state));
+
+    return _intersect_ctx->prepare(state, _dst_exprs);
+}
+
+Status IntersectBuildSinkOperatorFactory::prepare(RuntimeState* state) {
+    RETURN_IF_ERROR(OperatorFactory::prepare(state));
+
+    RowDescriptor row_desc;
+    Expr::prepare(_dst_exprs, state, row_desc);
+    Expr::open(_dst_exprs, state);
+
+    return Status::OK();
+}
+
+void IntersectBuildSinkOperatorFactory::close(RuntimeState* state) {
+    Expr::close(_dst_exprs, state);
+
+    OperatorFactory::close(state);
+}
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/set/intersect_build_sink_operator.h
+++ b/be/src/exec/pipeline/set/intersect_build_sink_operator.h
@@ -7,6 +7,18 @@
 
 namespace starrocks::pipeline {
 
+// IntersectNode is decomposed to IntersectBuildSinkOperator, IntersectProbeSinkOperator, and IntersectOutputSourceOperator.
+// - IntersectBuildSinkOperator (BUILD) builds the hast set from the output rows of IntersectNode's first child.
+// - IntersectProbeSinkOperator (PROBE) labels the hit times of a key as i in the hash set,if the original hit
+//   times is i-1. The first PROBE depends on BUILD, and the rest i-th PROBE depends on the (i-1)-th PROBE.
+// - IntersectOutputSourceOperator (OUTPUT) traverses the hast set and outputs rows,
+//   whose hit times are equal to the number of PROBEs. OUTPUT depends on the last PROBE,
+//   which means it should wait for all the PROBEs to finish labeling keys as delete.
+//
+// The input chunks of BUILD and PROBE are shuffled by the local shuffle operator.
+// The number of shuffled partitions is the degree of parallelism (DOP), which means
+// the number of partition hash sets and the number of BUILD drivers, PROBE drivers of one child, OUTPUT drivers
+// are both DOP. And each pair of BUILD/PROBE/OUTPUT drivers shares a same intersect partition context.
 class IntersectBuildSinkOperator final : public Operator {
 public:
     IntersectBuildSinkOperator(int32_t id, int32_t plan_node_id, std::shared_ptr<IntersectContext> intersect_ctx,

--- a/be/src/exec/pipeline/set/intersect_build_sink_operator.h
+++ b/be/src/exec/pipeline/set/intersect_build_sink_operator.h
@@ -1,0 +1,68 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#pragma once
+
+#include "exec/pipeline/operator.h"
+#include "exec/pipeline/set/intersect_context.h"
+
+namespace starrocks::pipeline {
+
+class IntersectBuildSinkOperator final : public Operator {
+public:
+    IntersectBuildSinkOperator(int32_t id, int32_t plan_node_id, std::shared_ptr<IntersectContext> intersect_ctx,
+                               const std::vector<ExprContext*>& dst_exprs)
+            : Operator(id, "intersect_build_sink", plan_node_id),
+              _intersect_ctx(std::move(intersect_ctx)),
+              _dst_exprs(dst_exprs) {}
+
+    bool need_input() const override { return !is_finished(); }
+
+    bool has_output() const override { return false; }
+
+    bool is_finished() const override { return _is_finished; }
+
+    void finish(RuntimeState* state) override {
+        if (!_is_finished) {
+            _is_finished = true;
+            _intersect_ctx->finish_build_ht();
+        }
+    }
+
+    Status prepare(RuntimeState* state) override;
+
+    StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
+
+    Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override;
+
+private:
+    std::shared_ptr<IntersectContext> _intersect_ctx;
+
+    const std::vector<ExprContext*>& _dst_exprs;
+
+    bool _is_finished = false;
+};
+
+class IntersectBuildSinkOperatorFactory final : public OperatorFactory {
+public:
+    IntersectBuildSinkOperatorFactory(int32_t id, int32_t plan_node_id,
+                                      IntersectPartitionContextFactoryPtr intersect_partition_ctx_factory,
+                                      const std::vector<ExprContext*>& dst_exprs)
+            : OperatorFactory(id, "intersect_build_sink", plan_node_id),
+              _intersect_partition_ctx_factory(std::move(intersect_partition_ctx_factory)),
+              _dst_exprs(dst_exprs) {}
+
+    OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override {
+        return std::make_shared<IntersectBuildSinkOperator>(
+                _id, _plan_node_id, _intersect_partition_ctx_factory->get_or_create(driver_sequence), _dst_exprs);
+    }
+
+    Status prepare(RuntimeState* state) override;
+
+    void close(RuntimeState* state) override;
+
+private:
+    IntersectPartitionContextFactoryPtr _intersect_partition_ctx_factory;
+    const std::vector<ExprContext*>& _dst_exprs;
+};
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/set/intersect_context.cpp
+++ b/be/src/exec/pipeline/set/intersect_context.cpp
@@ -1,0 +1,74 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#include "exec/pipeline/set/intersect_context.h"
+
+namespace starrocks {
+
+namespace pipeline {
+
+Status IntersectContext::prepare(RuntimeState* state, const std::vector<ExprContext*>& build_exprs) {
+    _build_pool = std::make_unique<MemPool>();
+
+    _dst_tuple_desc = state->desc_tbl().get_tuple_descriptor(_dst_tuple_id);
+    _dst_nullables.reserve(build_exprs.size());
+    for (auto build_expr : build_exprs) {
+        _dst_nullables.emplace_back(build_expr->root()->is_nullable());
+    }
+
+    return Status::OK();
+}
+
+Status IntersectContext::close(RuntimeState* state) {
+    if (_build_pool != nullptr) {
+        _build_pool->free_all();
+    }
+
+    return Status::OK();
+}
+
+Status IntersectContext::append_chunk_to_ht(RuntimeState* state, const ChunkPtr& chunk,
+                                            const std::vector<ExprContext*>& dst_exprs) {
+    return _hash_set->build_set(state, chunk, dst_exprs, _build_pool.get());
+}
+
+Status IntersectContext::refine_chunk_from_ht(RuntimeState* state, const ChunkPtr& chunk,
+                                              const std::vector<ExprContext*>& dst_exprs, const int hit_times) {
+    return _hash_set->refine_intersect_row(state, chunk, dst_exprs, hit_times);
+}
+
+StatusOr<vectorized::ChunkPtr> IntersectContext::pull_chunk(RuntimeState* state) {
+    // 1. Get at most *config::vector_chunk_size* remained keys from ht.
+    size_t remained_keys_num = 0;
+    _remained_keys.resize(config::vector_chunk_size);
+    while (_next_processed_iter != _hash_set->end() && remained_keys_num < config::vector_chunk_size) {
+        if (_next_processed_iter->hit_times == _intersect_times) {
+            _remained_keys[remained_keys_num++] = _next_processed_iter->slice;
+        }
+        ++_next_processed_iter;
+    }
+
+    ChunkPtr dst_chunk = std::make_shared<vectorized::Chunk>();
+    if (remained_keys_num > 0) {
+        // 2. Create dest columns.
+        vectorized::Columns dst_columns(_dst_nullables.size());
+        for (size_t i = 0; i < _dst_nullables.size(); ++i) {
+            const auto& slot = _dst_tuple_desc->slots()[i];
+            dst_columns[i] = vectorized::ColumnHelper::create_column(slot->type(), _dst_nullables[i]);
+            dst_columns[i]->reserve(remained_keys_num);
+        }
+
+        // 3. Serialize remained keys to the dest columns.
+        _hash_set->deserialize_to_columns(_remained_keys, dst_columns, remained_keys_num);
+
+        // 4. Add dest columns to the dest chunk.
+        for (size_t i = 0; i < dst_columns.size(); i++) {
+            dst_chunk->append_column(std::move(dst_columns[i]), _dst_tuple_desc->slots()[i]->id());
+        }
+    }
+
+    return std::move(dst_chunk);
+}
+
+} // namespace pipeline
+
+} // namespace starrocks

--- a/be/src/exec/pipeline/set/intersect_context.cpp
+++ b/be/src/exec/pipeline/set/intersect_context.cpp
@@ -2,9 +2,7 @@
 
 #include "exec/pipeline/set/intersect_context.h"
 
-namespace starrocks {
-
-namespace pipeline {
+namespace starrocks::pipeline {
 
 Status IntersectContext::prepare(RuntimeState* state, const std::vector<ExprContext*>& build_exprs) {
     _build_pool = std::make_unique<MemPool>();
@@ -69,6 +67,4 @@ StatusOr<vectorized::ChunkPtr> IntersectContext::pull_chunk(RuntimeState* state)
     return std::move(dst_chunk);
 }
 
-} // namespace pipeline
-
-} // namespace starrocks
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/set/intersect_output_source_operator.cpp
+++ b/be/src/exec/pipeline/set/intersect_output_source_operator.cpp
@@ -1,0 +1,20 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#include "exec/pipeline/set/intersect_output_source_operator.h"
+
+namespace starrocks::pipeline {
+
+StatusOr<vectorized::ChunkPtr> IntersectOutputSourceOperator::pull_chunk(RuntimeState* state) {
+    return _intersect_ctx->pull_chunk(state);
+}
+
+Status IntersectOutputSourceOperator::close(RuntimeState* state) {
+    RETURN_IF_ERROR(_intersect_ctx->close(state));
+    return Operator::close(state);
+}
+
+void IntersectOutputSourceOperatorFactory::close(RuntimeState* state) {
+    SourceOperatorFactory::close(state);
+}
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/set/intersect_output_source_operator.h
+++ b/be/src/exec/pipeline/set/intersect_output_source_operator.h
@@ -8,6 +8,18 @@
 
 namespace starrocks::pipeline {
 
+// IntersectNode is decomposed to IntersectBuildSinkOperator, IntersectProbeSinkOperator, and IntersectOutputSourceOperator.
+// - IntersectBuildSinkOperator (BUILD) builds the hast set from the output rows of IntersectNode's first child.
+// - IntersectProbeSinkOperator (PROBE) labels the hit times of a key as i in the hash set,if the original hit
+//   times is i-1. The first PROBE depends on BUILD, and the rest i-th PROBE depends on the (i-1)-th PROBE.
+// - IntersectOutputSourceOperator (OUTPUT) traverses the hast set and outputs rows,
+//   whose hit times are equal to the number of PROBEs. OUTPUT depends on the last PROBE,
+//   which means it should wait for all the PROBEs to finish labeling keys as delete.
+//
+// The input chunks of BUILD and PROBE are shuffled by the local shuffle operator.
+// The number of shuffled partitions is the degree of parallelism (DOP), which means
+// the number of partition hash sets and the number of BUILD drivers, PROBE drivers of one child, OUTPUT drivers
+// are both DOP. And each pair of BUILD/PROBE/OUTPUT drivers shares a same intersect partition context.
 class IntersectOutputSourceOperator final : public SourceOperator {
 public:
     IntersectOutputSourceOperator(int32_t id, int32_t plan_node_id, std::shared_ptr<IntersectContext> intersect_ctx,

--- a/be/src/exec/pipeline/set/intersect_output_source_operator.h
+++ b/be/src/exec/pipeline/set/intersect_output_source_operator.h
@@ -1,0 +1,61 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#pragma once
+
+#include "exec/pipeline/operator.h"
+#include "exec/pipeline/set/intersect_context.h"
+#include "exec/pipeline/source_operator.h"
+
+namespace starrocks::pipeline {
+
+class IntersectOutputSourceOperator final : public SourceOperator {
+public:
+    IntersectOutputSourceOperator(int32_t id, int32_t plan_node_id, std::shared_ptr<IntersectContext> intersect_ctx,
+                                  const int32_t dependency_index)
+            : SourceOperator(id, "intersect_output_source", plan_node_id),
+              _intersect_ctx(std::move(intersect_ctx)),
+              _dependency_index(dependency_index) {}
+
+    bool has_output() const override {
+        return _intersect_ctx->is_dependency_finished(_dependency_index) && !_intersect_ctx->is_output_finished();
+    }
+
+    bool is_finished() const override {
+        return _intersect_ctx->is_dependency_finished(_dependency_index) && _intersect_ctx->is_output_finished();
+    }
+
+    // Finish is noop.
+    void finish(RuntimeState* state) override {}
+
+    StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
+
+    Status close(RuntimeState* state) override;
+
+private:
+    std::shared_ptr<IntersectContext> _intersect_ctx;
+    const int32_t _dependency_index;
+};
+
+class IntersectOutputSourceOperatorFactory final : public SourceOperatorFactory {
+public:
+    IntersectOutputSourceOperatorFactory(int32_t id, int32_t plan_node_id,
+                                         IntersectPartitionContextFactoryPtr intersect_partition_ctx_factory,
+                                         const int32_t dependency_index)
+            : SourceOperatorFactory(id, "intersect_output_source", plan_node_id),
+              _intersect_partition_ctx_factory(std::move(intersect_partition_ctx_factory)),
+              _dependency_index(dependency_index) {}
+
+    OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override {
+        return std::make_shared<IntersectOutputSourceOperator>(
+                _id, _plan_node_id, _intersect_partition_ctx_factory->get_or_create(driver_sequence),
+                _dependency_index);
+    }
+
+    void close(RuntimeState* state) override;
+
+private:
+    IntersectPartitionContextFactoryPtr _intersect_partition_ctx_factory;
+    const int32_t _dependency_index;
+};
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/set/intersect_output_source_operator.h
+++ b/be/src/exec/pipeline/set/intersect_output_source_operator.h
@@ -8,18 +8,9 @@
 
 namespace starrocks::pipeline {
 
-// IntersectNode is decomposed to IntersectBuildSinkOperator, IntersectProbeSinkOperator, and IntersectOutputSourceOperator.
-// - IntersectBuildSinkOperator (BUILD) builds the hast set from the output rows of IntersectNode's first child.
-// - IntersectProbeSinkOperator (PROBE) labels the hit times of a key as i in the hash set,if the original hit
-//   times is i-1. The first PROBE depends on BUILD, and the rest i-th PROBE depends on the (i-1)-th PROBE.
-// - IntersectOutputSourceOperator (OUTPUT) traverses the hast set and outputs rows,
-//   whose hit times are equal to the number of PROBEs. OUTPUT depends on the last PROBE,
-//   which means it should wait for all the PROBEs to finish labeling keys as delete.
-//
-// The input chunks of BUILD and PROBE are shuffled by the local shuffle operator.
-// The number of shuffled partitions is the degree of parallelism (DOP), which means
-// the number of partition hash sets and the number of BUILD drivers, PROBE drivers of one child, OUTPUT drivers
-// are both DOP. And each pair of BUILD/PROBE/OUTPUT drivers shares a same intersect partition context.
+// IntersectOutputSourceOperator traverses the hast set and picks up entries hit by all
+// IntersectProbeSinkOperators after probe phase is finished.
+// For more detail information, see the comments of class IntersectBuildSinkOperator.
 class IntersectOutputSourceOperator final : public SourceOperator {
 public:
     IntersectOutputSourceOperator(int32_t id, int32_t plan_node_id, std::shared_ptr<IntersectContext> intersect_ctx,

--- a/be/src/exec/pipeline/set/intersect_probe_sink_operator.cpp
+++ b/be/src/exec/pipeline/set/intersect_probe_sink_operator.cpp
@@ -1,0 +1,31 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#include "exec/pipeline/set/intersect_probe_sink_operator.h"
+
+namespace starrocks::pipeline {
+
+StatusOr<vectorized::ChunkPtr> IntersectProbeSinkOperator::pull_chunk(RuntimeState* state) {
+    return Status::InternalError("Shouldn't pull chunk from sink operator");
+}
+
+Status IntersectProbeSinkOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk) {
+    return _intersect_ctx->refine_chunk_from_ht(state, chunk, _dst_exprs, _dependency_index + 1);
+}
+
+Status IntersectProbeSinkOperatorFactory::prepare(RuntimeState* state) {
+    RETURN_IF_ERROR(OperatorFactory::prepare(state));
+
+    RowDescriptor row_desc;
+    Expr::prepare(_dst_exprs, state, row_desc);
+    Expr::open(_dst_exprs, state);
+
+    return Status::OK();
+}
+
+void IntersectProbeSinkOperatorFactory::close(RuntimeState* state) {
+    Expr::close(_dst_exprs, state);
+
+    OperatorFactory::close(state);
+}
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/set/intersect_probe_sink_operator.h
+++ b/be/src/exec/pipeline/set/intersect_probe_sink_operator.h
@@ -1,0 +1,78 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#pragma once
+
+#include "exec/pipeline/operator.h"
+#include "exec/pipeline/set/intersect_context.h"
+
+namespace starrocks::pipeline {
+
+class IntersectProbeSinkOperator final : public Operator {
+public:
+    IntersectProbeSinkOperator(int32_t id, int32_t plan_node_id, std::shared_ptr<IntersectContext> intersect_ctx,
+                               const std::vector<ExprContext*>& dst_exprs, const int32_t dependency_index)
+            : Operator(id, "intersect_probe_sink", plan_node_id),
+              _intersect_ctx(std::move(intersect_ctx)),
+              _dst_exprs(dst_exprs),
+              _dependency_index(dependency_index) {}
+
+    bool need_input() const override {
+        return _intersect_ctx->is_dependency_finished(_dependency_index) &&
+               !(_is_finished || _intersect_ctx->is_ht_empty());
+    }
+
+    bool has_output() const override { return false; }
+
+    bool is_finished() const override {
+        return _intersect_ctx->is_dependency_finished(_dependency_index) &&
+               (_is_finished || _intersect_ctx->is_ht_empty());
+    }
+
+    void finish(RuntimeState* state) override {
+        if (!_is_finished) {
+            _is_finished = true;
+            _intersect_ctx->finish_probe_ht();
+        }
+    }
+
+    StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
+
+    Status push_chunk(RuntimeState* state, const ChunkPtr& chunk) override;
+
+private:
+    IntersectContextPtr _intersect_ctx;
+
+    const std::vector<ExprContext*>& _dst_exprs;
+
+    bool _is_finished = false;
+    const int32_t _dependency_index;
+};
+
+class IntersectProbeSinkOperatorFactory final : public OperatorFactory {
+public:
+    IntersectProbeSinkOperatorFactory(int32_t id, int32_t plan_node_id,
+                                      IntersectPartitionContextFactoryPtr intersect_partition_ctx_factory,
+                                      const std::vector<ExprContext*>& dst_exprs, const int32_t dependency_index)
+            : OperatorFactory(id, "intersect_probe_sink", plan_node_id),
+              _intersect_partition_ctx_factory(std::move(intersect_partition_ctx_factory)),
+              _dst_exprs(dst_exprs),
+              _dependency_index(dependency_index) {}
+
+    OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override {
+        IntersectContextPtr intersect_ctx = _intersect_partition_ctx_factory->get_or_create(driver_sequence);
+        return std::make_shared<IntersectProbeSinkOperator>(_id, _plan_node_id, std::move(intersect_ctx), _dst_exprs,
+                                                            _dependency_index);
+    }
+
+    Status prepare(RuntimeState* state) override;
+
+    void close(RuntimeState* state) override;
+
+private:
+    IntersectPartitionContextFactoryPtr _intersect_partition_ctx_factory;
+
+    const std::vector<ExprContext*>& _dst_exprs;
+    const int32_t _dependency_index;
+};
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/set/intersect_probe_sink_operator.h
+++ b/be/src/exec/pipeline/set/intersect_probe_sink_operator.h
@@ -7,6 +7,18 @@
 
 namespace starrocks::pipeline {
 
+// IntersectNode is decomposed to IntersectBuildSinkOperator, IntersectProbeSinkOperator, and IntersectOutputSourceOperator.
+// - IntersectBuildSinkOperator (BUILD) builds the hast set from the output rows of IntersectNode's first child.
+// - IntersectProbeSinkOperator (PROBE) labels the hit times of a key as i in the hash set,if the original hit
+//   times is i-1. The first PROBE depends on BUILD, and the rest i-th PROBE depends on the (i-1)-th PROBE.
+// - IntersectOutputSourceOperator (OUTPUT) traverses the hast set and outputs rows,
+//   whose hit times are equal to the number of PROBEs. OUTPUT depends on the last PROBE,
+//   which means it should wait for all the PROBEs to finish labeling keys as delete.
+//
+// The input chunks of BUILD and PROBE are shuffled by the local shuffle operator.
+// The number of shuffled partitions is the degree of parallelism (DOP), which means
+// the number of partition hash sets and the number of BUILD drivers, PROBE drivers of one child, OUTPUT drivers
+// are both DOP. And each pair of BUILD/PROBE/OUTPUT drivers shares a same intersect partition context.
 class IntersectProbeSinkOperator final : public Operator {
 public:
     IntersectProbeSinkOperator(int32_t id, int32_t plan_node_id, std::shared_ptr<IntersectContext> intersect_ctx,

--- a/be/src/exec/pipeline/set/intersect_probe_sink_operator.h
+++ b/be/src/exec/pipeline/set/intersect_probe_sink_operator.h
@@ -7,18 +7,9 @@
 
 namespace starrocks::pipeline {
 
-// IntersectNode is decomposed to IntersectBuildSinkOperator, IntersectProbeSinkOperator, and IntersectOutputSourceOperator.
-// - IntersectBuildSinkOperator (BUILD) builds the hast set from the output rows of IntersectNode's first child.
-// - IntersectProbeSinkOperator (PROBE) labels the hit times of a key as i in the hash set,if the original hit
-//   times is i-1. The first PROBE depends on BUILD, and the rest i-th PROBE depends on the (i-1)-th PROBE.
-// - IntersectOutputSourceOperator (OUTPUT) traverses the hast set and outputs rows,
-//   whose hit times are equal to the number of PROBEs. OUTPUT depends on the last PROBE,
-//   which means it should wait for all the PROBEs to finish labeling keys as delete.
-//
-// The input chunks of BUILD and PROBE are shuffled by the local shuffle operator.
-// The number of shuffled partitions is the degree of parallelism (DOP), which means
-// the number of partition hash sets and the number of BUILD drivers, PROBE drivers of one child, OUTPUT drivers
-// are both DOP. And each pair of BUILD/PROBE/OUTPUT drivers shares a same intersect partition context.
+// Each IntersectProbeSinkOperator probes the hash set built by IntersectBuildSinkOperator.
+// The hash set records the ordinal of IntersectProbeSinkOperator per key if the key is hit.
+// For more detail information, see the comments of class IntersectBuildSinkOperator.
 class IntersectProbeSinkOperator final : public Operator {
 public:
     IntersectProbeSinkOperator(int32_t id, int32_t plan_node_id, std::shared_ptr<IntersectContext> intersect_ctx,

--- a/be/src/exec/pipeline/set/union_const_source_operator.h
+++ b/be/src/exec/pipeline/set/union_const_source_operator.h
@@ -60,12 +60,12 @@ public:
 
     OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override {
         // Divide _const_expr_lists into *degree_of_parallelism* parts,
-        // each of which contains *rows_num_per_driver* continuous rows except the last part.
+        // each of which contains *num_rows_per_driver* continuous rows except the last part.
         size_t rows_total = _const_expr_lists.size();
-        size_t rows_num_per_driver = (rows_total + degree_of_parallelism - 1) / degree_of_parallelism;
-        size_t rows_offset = rows_num_per_driver * driver_sequence;
+        size_t num_rows_per_driver = (rows_total + degree_of_parallelism - 1) / degree_of_parallelism;
+        size_t rows_offset = num_rows_per_driver * driver_sequence;
         DCHECK(rows_total > rows_offset);
-        size_t rows_count = std::min(rows_num_per_driver, rows_total - rows_offset);
+        size_t rows_count = std::min(num_rows_per_driver, rows_total - rows_offset);
 
         return std::make_shared<UnionConstSourceOperator>(_id, _plan_node_id, _dst_slots,
                                                           _const_expr_lists.data() + rows_offset, rows_count);

--- a/be/src/exec/vectorized/except_node.cpp
+++ b/be/src/exec/vectorized/except_node.cpp
@@ -229,14 +229,14 @@ pipeline::OpFactories ExceptNode::decompose_to_pipeline(pipeline::PipelineBuilde
         operators_with_except_erase_sink = context->maybe_interpolate_local_shuffle_exchange(
                 operators_with_except_erase_sink, _child_expr_lists[i]);
         operators_with_except_erase_sink.emplace_back(std::make_shared<pipeline::ExceptProbeSinkOperatorFactory>(
-                context->next_operator_id(), id(), except_partition_ctx_factory, _child_expr_lists[i]));
+                context->next_operator_id(), id(), except_partition_ctx_factory, _child_expr_lists[i], i - 1));
         context->add_pipeline(operators_with_except_erase_sink);
     }
 
     // ExceptOutputSourceOperator is used to assemble the undeleted keys to output chunks.
     pipeline::OpFactories operators_with_except_output_source;
     auto except_output_source = std::make_shared<pipeline::ExceptOutputSourceOperatorFactory>(
-            context->next_operator_id(), id(), except_partition_ctx_factory);
+            context->next_operator_id(), id(), except_partition_ctx_factory, _children.size() - 1);
     except_output_source->set_degree_of_parallelism(context->degree_of_parallelism());
     operators_with_except_output_source.emplace_back(std::move(except_output_source));
 

--- a/be/src/exec/vectorized/except_node.cpp
+++ b/be/src/exec/vectorized/except_node.cpp
@@ -225,12 +225,12 @@ pipeline::OpFactories ExceptNode::decompose_to_pipeline(pipeline::PipelineBuilde
 
     // Use the rest children to erase keys from the hast table by ExceptProbeSinkOperator.
     for (size_t i = 1; i < _children.size(); i++) {
-        pipeline::OpFactories operators_with_except_erase_sink = child(i)->decompose_to_pipeline(context);
-        operators_with_except_erase_sink = context->maybe_interpolate_local_shuffle_exchange(
-                operators_with_except_erase_sink, _child_expr_lists[i]);
-        operators_with_except_erase_sink.emplace_back(std::make_shared<pipeline::ExceptProbeSinkOperatorFactory>(
+        pipeline::OpFactories operators_with_except_probe_sink = child(i)->decompose_to_pipeline(context);
+        operators_with_except_probe_sink = context->maybe_interpolate_local_shuffle_exchange(
+                operators_with_except_probe_sink, _child_expr_lists[i]);
+        operators_with_except_probe_sink.emplace_back(std::make_shared<pipeline::ExceptProbeSinkOperatorFactory>(
                 context->next_operator_id(), id(), except_partition_ctx_factory, _child_expr_lists[i], i - 1));
-        context->add_pipeline(operators_with_except_erase_sink);
+        context->add_pipeline(operators_with_except_probe_sink);
     }
 
     // ExceptOutputSourceOperator is used to assemble the undeleted keys to output chunks.

--- a/be/src/exec/vectorized/intersect_hash_set.cpp
+++ b/be/src/exec/vectorized/intersect_hash_set.cpp
@@ -39,7 +39,7 @@ Status IntersectHashSet<HashSet>::build_set(RuntimeState* state, const ChunkPtr&
 
 template <typename HashSet>
 Status IntersectHashSet<HashSet>::refine_intersect_row(RuntimeState* state, const ChunkPtr& chunkPtr,
-                                                       const std::vector<ExprContext*>& exprs, int hit_times) {
+                                                       const std::vector<ExprContext*>& exprs, const int hit_times) {
     size_t chunk_size = chunkPtr->num_rows();
     _slice_sizes.assign(config::vector_chunk_size, 0);
     size_t cur_max_one_row_size = _get_max_serialize_size(chunkPtr, exprs);
@@ -66,8 +66,7 @@ Status IntersectHashSet<HashSet>::refine_intersect_row(RuntimeState* state, cons
 }
 
 template <typename HashSet>
-void IntersectHashSet<HashSet>::deserialize_to_columns(KeyVector& keys, const Columns& key_columns,
-                                                       int32_t batch_size) {
+void IntersectHashSet<HashSet>::deserialize_to_columns(KeyVector& keys, const Columns& key_columns, size_t batch_size) {
     for (const auto& key_column : key_columns) {
         if (!key_column->is_nullable()) {
             for (auto& key : keys) {

--- a/be/src/exec/vectorized/intersect_hash_set.cpp
+++ b/be/src/exec/vectorized/intersect_hash_set.cpp
@@ -1,0 +1,127 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#include "exec/vectorized/intersect_hash_set.h"
+
+#include "exec/exec_node.h"
+
+namespace starrocks::vectorized {
+
+template <typename HashSet>
+Status IntersectHashSet<HashSet>::build_set(RuntimeState* state, const ChunkPtr& chunkPtr,
+                                            const std::vector<ExprContext*>& exprs, MemPool* pool) {
+    size_t chunk_size = chunkPtr->num_rows();
+
+    _slice_sizes.assign(config::vector_chunk_size, 0);
+    size_t cur_max_one_row_size = _get_max_serialize_size(chunkPtr, exprs);
+    if (UNLIKELY(cur_max_one_row_size > _max_one_row_size)) {
+        _max_one_row_size = cur_max_one_row_size;
+        _mem_pool->clear();
+        _buffer = _mem_pool->allocate(_max_one_row_size * config::vector_chunk_size);
+        if (UNLIKELY(_buffer == nullptr)) {
+            return Status::InternalError("Mem usage has exceed the limit of BE");
+        }
+    }
+
+    _serialize_columns(chunkPtr, exprs, chunk_size);
+
+    for (size_t i = 0; i < chunk_size; ++i) {
+        IntersectSliceFlag key(_buffer + i * _max_one_row_size, _slice_sizes[i]);
+        _hash_set->lazy_emplace(key, [&](const auto& ctor) {
+            // we must persist the slice before insert
+            uint8_t* pos = pool->allocate(key.slice.size);
+            memcpy(pos, key.slice.data, key.slice.size);
+            ctor(pos, key.slice.size);
+        });
+    }
+    RETURN_IF_LIMIT_EXCEEDED(state, "Intersect, while build hash table.");
+    return Status::OK();
+}
+
+template <typename HashSet>
+Status IntersectHashSet<HashSet>::refine_intersect_row(RuntimeState* state, const ChunkPtr& chunkPtr,
+                                                       const std::vector<ExprContext*>& exprs, int hit_times) {
+    size_t chunk_size = chunkPtr->num_rows();
+    _slice_sizes.assign(config::vector_chunk_size, 0);
+    size_t cur_max_one_row_size = _get_max_serialize_size(chunkPtr, exprs);
+    if (UNLIKELY(cur_max_one_row_size > _max_one_row_size)) {
+        _max_one_row_size = cur_max_one_row_size;
+        _mem_pool->clear();
+        _buffer = _mem_pool->allocate(_max_one_row_size * config::vector_chunk_size);
+        if (UNLIKELY(_buffer == nullptr)) {
+            return Status::InternalError("Mem usage has exceed the limit of BE");
+        }
+        RETURN_IF_LIMIT_EXCEEDED(state, "Intersect, while probe hash table.");
+    }
+
+    _serialize_columns(chunkPtr, exprs, chunk_size);
+
+    for (size_t i = 0; i < chunk_size; ++i) {
+        IntersectSliceFlag key(_buffer + i * _max_one_row_size, _slice_sizes[i]);
+        auto iter = _hash_set->find(key);
+        if (iter != _hash_set->end() && iter->hit_times == hit_times - 1) {
+            iter->hit_times = hit_times;
+        }
+    }
+    return Status::OK();
+}
+
+template <typename HashSet>
+void IntersectHashSet<HashSet>::deserialize_to_columns(KeyVector& keys, const Columns& key_columns,
+                                                       int32_t batch_size) {
+    for (const auto& key_column : key_columns) {
+        if (!key_column->is_nullable()) {
+            for (auto& key : keys) {
+                key.data += sizeof(bool);
+            }
+        } else if (key_column->is_constant()) {
+            continue;
+        }
+
+        key_column->deserialize_and_append_batch(keys, batch_size);
+    }
+}
+
+template <typename HashSet>
+size_t IntersectHashSet<HashSet>::_get_max_serialize_size(const ChunkPtr& chunkPtr,
+                                                          const std::vector<ExprContext*>& exprs) {
+    size_t max_size = 0;
+    for (auto* expr : exprs) {
+        ColumnPtr key_column = expr->evaluate(chunkPtr.get());
+        max_size += key_column->max_one_element_serialize_size();
+        if (!key_column->is_nullable()) {
+            max_size += sizeof(bool);
+        }
+    }
+    return max_size;
+}
+
+template <typename HashSet>
+void IntersectHashSet<HashSet>::_serialize_columns(const ChunkPtr& chunkPtr, const std::vector<ExprContext*>& exprs,
+                                                   size_t chunk_size) {
+    const bool null = false;
+    for (auto expr : exprs) {
+        ColumnPtr key_column = expr->evaluate(chunkPtr.get());
+        if (key_column->is_nullable()) {
+            key_column->serialize_batch(_buffer, _slice_sizes, chunk_size, _max_one_row_size);
+        } else {
+            if (!key_column->is_constant()) {
+                for (size_t i = 0; i < chunk_size; ++i) {
+                    memcpy(_buffer + i * _max_one_row_size + _slice_sizes[i], &null, sizeof(bool));
+                    _slice_sizes[i] += sizeof(bool);
+                    _slice_sizes[i] += key_column->serialize(i, _buffer + i * _max_one_row_size + _slice_sizes[i]);
+                }
+            } else {
+                for (size_t i = 0; i < chunk_size; ++i) {
+                    memcpy(_buffer + i * _max_one_row_size + _slice_sizes[i], &null, sizeof(bool));
+                    _slice_sizes[i] += sizeof(bool);
+                    _slice_sizes[i] += key_column->serialize(0, _buffer + i * _max_one_row_size + _slice_sizes[i]);
+                }
+            }
+        }
+    }
+}
+
+template class IntersectHashSet<
+        phmap::flat_hash_set<IntersectSliceFlag, IntersectSliceFlagHash, IntersectSliceFlagEqual>>;
+
+} // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/intersect_hash_set.h
+++ b/be/src/exec/vectorized/intersect_hash_set.h
@@ -1,0 +1,87 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#pragma once
+
+#include "column/chunk.h"
+#include "column/column_hash.h"
+#include "exprs/expr_context.h"
+#include "runtime/mem_pool.h"
+#include "util/phmap/phmap.h"
+#include "util/slice.h"
+
+namespace starrocks {
+
+namespace vectorized {
+
+class IntersectSliceFlag;
+struct IntersectSliceFlagEqual;
+struct IntersectSliceFlagHash;
+template <typename HashSet>
+class IntersectHashSet;
+
+using IntersectHashSerializeSet =
+        IntersectHashSet<phmap::flat_hash_set<IntersectSliceFlag, IntersectSliceFlagHash, IntersectSliceFlagEqual>>;
+
+class IntersectSliceFlag {
+public:
+    IntersectSliceFlag(const uint8_t* d, size_t n) : slice(d, n), hit_times(0) {}
+
+    Slice slice;
+    mutable uint16_t hit_times;
+};
+
+struct IntersectSliceFlagEqual {
+    bool operator()(const IntersectSliceFlag& x, const IntersectSliceFlag& y) const {
+        return memequal(x.slice.data, x.slice.size, y.slice.data, y.slice.size);
+    }
+};
+
+struct IntersectSliceFlagHash {
+    static const uint32_t CRC_SEED = 0x811C9DC5;
+    std::size_t operator()(const IntersectSliceFlag& sliceMayUnneed) const {
+        const Slice& slice = sliceMayUnneed.slice;
+        return crc_hash_64(slice.data, slice.size, CRC_SEED);
+    }
+};
+
+template <typename HashSet>
+class IntersectHashSet {
+public:
+    using Iterator = typename HashSet::iterator;
+    using KeyVector = typename std::vector<Slice>;
+
+    IntersectHashSet()
+            : _hash_set(std::make_unique<HashSet>()),
+              _mem_pool(std::make_unique<MemPool>()),
+              _buffer(_mem_pool->allocate(_max_one_row_size * config::vector_chunk_size)) {}
+
+    Iterator begin() { return _hash_set->begin(); }
+
+    Iterator end() { return _hash_set->end(); }
+
+    bool empty() { return _hash_set->empty(); }
+
+    Status build_set(RuntimeState* state, const ChunkPtr& chunkPtr, const std::vector<ExprContext*>& exprs,
+                     MemPool* pool);
+
+    Status refine_intersect_row(RuntimeState* state, const ChunkPtr& chunkPtr, const std::vector<ExprContext*>& exprs,
+                                int hit_times);
+
+    void deserialize_to_columns(KeyVector& keys, const Columns& key_columns, int32_t batch_size);
+
+private:
+    void _serialize_columns(const ChunkPtr& chunkPtr, const std::vector<ExprContext*>& exprs, size_t chunk_size);
+
+    size_t _get_max_serialize_size(const ChunkPtr& chunkPtr, const std::vector<ExprContext*>& exprs);
+
+    std::unique_ptr<HashSet> _hash_set;
+
+    Buffer<uint32_t> _slice_sizes;
+    size_t _max_one_row_size = 8;
+    std::unique_ptr<MemPool> _mem_pool;
+    uint8_t* _buffer;
+};
+
+} // namespace vectorized
+
+} // namespace starrocks

--- a/be/src/exec/vectorized/intersect_hash_set.h
+++ b/be/src/exec/vectorized/intersect_hash_set.h
@@ -67,7 +67,7 @@ public:
     Status refine_intersect_row(RuntimeState* state, const ChunkPtr& chunkPtr, const std::vector<ExprContext*>& exprs,
                                 int hit_times);
 
-    void deserialize_to_columns(KeyVector& keys, const Columns& key_columns, int32_t batch_size);
+    void deserialize_to_columns(KeyVector& keys, const Columns& key_columns, size_t batch_size);
 
 private:
     void _serialize_columns(const ChunkPtr& chunkPtr, const std::vector<ExprContext*>& exprs, size_t chunk_size);

--- a/be/src/exec/vectorized/intersect_hash_set.h
+++ b/be/src/exec/vectorized/intersect_hash_set.h
@@ -9,9 +9,7 @@
 #include "util/phmap/phmap.h"
 #include "util/slice.h"
 
-namespace starrocks {
-
-namespace vectorized {
+namespace starrocks::vectorized {
 
 class IntersectSliceFlag;
 struct IntersectSliceFlagEqual;
@@ -82,6 +80,4 @@ private:
     uint8_t* _buffer;
 };
 
-} // namespace vectorized
-
-} // namespace starrocks
+} // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/intersect_node.cpp
+++ b/be/src/exec/vectorized/intersect_node.cpp
@@ -237,12 +237,12 @@ pipeline::OpFactories IntersectNode::decompose_to_pipeline(pipeline::PipelineBui
 
     // Use the rest children to erase keys from the hast table by IntersectProbeSinkOperator.
     for (size_t i = 1; i < _children.size(); i++) {
-        pipeline::OpFactories operators_with_intersect_erase_sink = child(i)->decompose_to_pipeline(context);
-        operators_with_intersect_erase_sink = context->maybe_interpolate_local_shuffle_exchange(
-                operators_with_intersect_erase_sink, _child_expr_lists[i]);
-        operators_with_intersect_erase_sink.emplace_back(std::make_shared<pipeline::IntersectProbeSinkOperatorFactory>(
+        pipeline::OpFactories operators_with_intersect_probe_sink = child(i)->decompose_to_pipeline(context);
+        operators_with_intersect_probe_sink = context->maybe_interpolate_local_shuffle_exchange(
+                operators_with_intersect_probe_sink, _child_expr_lists[i]);
+        operators_with_intersect_probe_sink.emplace_back(std::make_shared<pipeline::IntersectProbeSinkOperatorFactory>(
                 context->next_operator_id(), id(), intersect_partition_ctx_factory, _child_expr_lists[i], i - 1));
-        context->add_pipeline(operators_with_intersect_erase_sink);
+        context->add_pipeline(operators_with_intersect_probe_sink);
     }
 
     // IntersectOutputSourceOperator is used to assemble the undeleted keys to output chunks.

--- a/be/src/exec/vectorized/intersect_node.h
+++ b/be/src/exec/vectorized/intersect_node.h
@@ -9,6 +9,7 @@
 #include "column/column_helper.h"
 #include "column/type_traits.h"
 #include "exec/olap_common.h"
+#include "exec/vectorized/intersect_hash_set.h"
 #include "exprs/expr_context.h"
 #include "runtime/mem_pool.h"
 #include "runtime/mem_tracker.h"
@@ -24,161 +25,6 @@ class TupleDescriptor;
 
 namespace starrocks::vectorized {
 class IntersectNode : public ExecNode {
-    class SliceFlag {
-    public:
-        SliceFlag(const uint8_t* d, size_t n) : slice(d, n), hit_times(0) {}
-
-        Slice slice;
-        mutable uint16_t hit_times;
-    };
-
-    struct SliceFlagEqual {
-        bool operator()(const SliceFlag& x, const SliceFlag& y) const {
-            return memequal(x.slice.data, x.slice.size, y.slice.data, y.slice.size);
-        }
-    };
-
-    struct SliceFlagHash {
-        static const uint32_t CRC_SEED = 0x811C9DC5;
-        std::size_t operator()(const SliceFlag& sliceMayUnneed) const {
-            const Slice& slice = sliceMayUnneed.slice;
-            return crc_hash_64(slice.data, slice.size, CRC_SEED);
-        }
-    };
-
-    template <typename HashSet>
-    struct HashSetFromExprs {
-        using Iterator = typename HashSet::iterator;
-        using ResultVector = typename std::vector<Slice>;
-        std::unique_ptr<HashSet> hash_set;
-
-        HashSetFromExprs()
-                : hash_set(std::make_unique<HashSet>()),
-                  _mem_pool(std::make_unique<MemPool>()),
-                  _buffer(_mem_pool->allocate(_max_one_row_size * config::vector_chunk_size)) {}
-
-        Iterator begin() { return hash_set->begin(); }
-
-        Iterator end() { return hash_set->end(); }
-
-        void serialize_columns(const ChunkPtr& chunkPtr, const std::vector<ExprContext*>& exprs, size_t chunk_size,
-                               const std::function<void(const ColumnPtr&, int)>& get_type) {
-            const bool null = false;
-            for (size_t i = 0; i < exprs.size(); i++) {
-                ColumnPtr key_column = exprs[i]->evaluate(chunkPtr.get());
-                get_type(key_column, i);
-                if (key_column->is_nullable()) {
-                    key_column->serialize_batch(_buffer, _slice_sizes, chunk_size, _max_one_row_size);
-                } else {
-                    if (!key_column->is_constant()) {
-                        for (size_t j = 0; j < chunk_size; ++j) {
-                            memcpy(_buffer + j * _max_one_row_size + _slice_sizes[j], &null, sizeof(bool));
-                            _slice_sizes[j] += sizeof(bool);
-                            _slice_sizes[j] +=
-                                    key_column->serialize(j, _buffer + j * _max_one_row_size + _slice_sizes[j]);
-                        }
-                    } else {
-                        for (size_t j = 0; j < chunk_size; ++j) {
-                            memcpy(_buffer + j * _max_one_row_size + _slice_sizes[j], &null, sizeof(bool));
-                            _slice_sizes[j] += sizeof(bool);
-                            _slice_sizes[j] +=
-                                    key_column->serialize(0, _buffer + j * _max_one_row_size + _slice_sizes[j]);
-                        }
-                    }
-                }
-            }
-        }
-
-        Status build_set(RuntimeState* state, const ChunkPtr& chunkPtr, const std::vector<ExprContext*>& exprs,
-                         MemPool* pool, const std::function<void(const ColumnPtr&, int)>& get_type) {
-            size_t chunk_size = chunkPtr->num_rows();
-
-            _slice_sizes.assign(config::vector_chunk_size, 0);
-            size_t cur_max_one_row_size = get_max_serialize_size(chunkPtr, exprs);
-            if (UNLIKELY(cur_max_one_row_size > _max_one_row_size)) {
-                _max_one_row_size = cur_max_one_row_size;
-                _mem_pool->clear();
-                _buffer = _mem_pool->allocate(_max_one_row_size * config::vector_chunk_size);
-                if (UNLIKELY(_buffer == nullptr)) {
-                    return Status::InternalError("Mem usage has exceed the limit of BE");
-                }
-            }
-
-            serialize_columns(chunkPtr, exprs, chunk_size, get_type);
-
-            for (size_t i = 0; i < chunk_size; ++i) {
-                SliceFlag key(_buffer + i * _max_one_row_size, _slice_sizes[i]);
-                hash_set->lazy_emplace(key, [&](const auto& ctor) {
-                    // we must persist the slice before insert
-                    uint8_t* pos = pool->allocate(key.slice.size);
-                    memcpy(pos, key.slice.data, key.slice.size);
-                    ctor(pos, key.slice.size);
-                });
-            }
-            RETURN_IF_LIMIT_EXCEEDED(state, "Intersect, while build hash table.");
-            return Status::OK();
-        }
-
-        Status refine_intersect_row(RuntimeState* state, const ChunkPtr& chunkPtr,
-                                    const std::vector<ExprContext*>& exprs, int hit_times) {
-            size_t chunk_size = chunkPtr->num_rows();
-            _slice_sizes.assign(config::vector_chunk_size, 0);
-            size_t cur_max_one_row_size = get_max_serialize_size(chunkPtr, exprs);
-            if (UNLIKELY(cur_max_one_row_size > _max_one_row_size)) {
-                _max_one_row_size = cur_max_one_row_size;
-                _mem_pool->clear();
-                _buffer = _mem_pool->allocate(_max_one_row_size * config::vector_chunk_size);
-                if (UNLIKELY(_buffer == nullptr)) {
-                    return Status::InternalError("Mem usage has exceed the limit of BE");
-                }
-                RETURN_IF_LIMIT_EXCEEDED(state, "Intersect, while probe hash table.");
-            }
-
-            serialize_columns(chunkPtr, exprs, chunk_size, [](const ColumnPtr& column, int i) -> void {});
-
-            for (size_t i = 0; i < chunk_size; ++i) {
-                SliceFlag key(_buffer + i * _max_one_row_size, _slice_sizes[i]);
-                auto iter = hash_set->find(key);
-                if (iter != hash_set->end() && iter->hit_times == hit_times - 1) {
-                    iter->hit_times = hit_times;
-                }
-            }
-            return Status::OK();
-        }
-
-        size_t get_max_serialize_size(const ChunkPtr& chunkPtr, const std::vector<ExprContext*>& exprs) {
-            size_t max_size = 0;
-            for (auto* expr : exprs) {
-                ColumnPtr key_column = expr->evaluate(chunkPtr.get());
-                max_size += key_column->max_one_element_serialize_size();
-                if (!key_column->is_nullable()) {
-                    max_size += sizeof(bool);
-                }
-            }
-            return max_size;
-        }
-
-        void insert_keys_to_columns(ResultVector& keys, const Columns& key_columns, int32_t batch_size) {
-            for (const auto& key_column : key_columns) {
-                if (!key_column->is_nullable()) {
-                    for (auto& key : keys) {
-                        key.data += sizeof(bool);
-                    }
-                } else if (key_column->is_constant()) {
-                    continue;
-                }
-
-                key_column->deserialize_and_append_batch(keys, batch_size);
-            }
-        }
-
-        Buffer<uint32_t> _slice_sizes;
-        size_t _max_one_row_size = 8;
-        std::unique_ptr<MemPool> _mem_pool;
-        uint8_t* _buffer;
-        ResultVector _results;
-    };
-
 public:
     IntersectNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs);
 
@@ -190,9 +36,9 @@ public:
     Status close(RuntimeState* state) override;
 
 private:
-    /// Tuple id resolved in Prepare() to set tuple_desc_;
+    // Tuple id resolved in Prepare() to set tuple_desc_;
     const int _tuple_id;
-    /// Descriptor for tuples this union node constructs.
+    // Descriptor for tuples this union node constructs.
     const TupleDescriptor* _tuple_desc;
     // Exprs materialized by this node. The i-th result expr list refers to the i-th child.
     std::vector<std::vector<ExprContext*>> _child_expr_lists;
@@ -205,9 +51,9 @@ private:
     std::vector<IntersectColumnTypes> _types;
     size_t _intersect_times = 0;
 
-    using HashSerializeSet = HashSetFromExprs<phmap::flat_hash_set<SliceFlag, SliceFlagHash, SliceFlagEqual>>;
-    std::unique_ptr<HashSerializeSet> _hash_set;
-    HashSerializeSet::Iterator _hash_set_iterator;
+    std::unique_ptr<IntersectHashSerializeSet> _hash_set;
+    IntersectHashSerializeSet::Iterator _hash_set_iterator;
+    IntersectHashSerializeSet::KeyVector _remained_keys;
 
     // pool for allocate key.
     std::unique_ptr<MemPool> _build_pool;

--- a/be/src/exec/vectorized/intersect_node.h
+++ b/be/src/exec/vectorized/intersect_node.h
@@ -35,6 +35,8 @@ public:
     Status get_next(RuntimeState* state, ChunkPtr* row_batch, bool* eos) override;
     Status close(RuntimeState* state) override;
 
+    pipeline::OpFactories decompose_to_pipeline(pipeline::PipelineBuilderContext* context) override;
+
 private:
     // Tuple id resolved in Prepare() to set tuple_desc_;
     const int _tuple_id;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IntersectNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IntersectNode.java
@@ -42,4 +42,9 @@ public class IntersectNode extends SetOperationNode {
     protected void toThrift(TPlanNode msg) {
         toThrift(msg, TPlanNodeType.INTERSECT_NODE);
     }
+
+    @Override
+    public boolean canUsePipeLine() {
+        return getChildren().stream().allMatch(PlanNode::canUsePipeLine);
+    }
 }


### PR DESCRIPTION
Close #1131.
`IntersectNode` is decomposed to `IntersectBuildSinkOperator`, `IntersectProbeSinkOperator`, and `IntersectOutputSourceOperator`.
- `IntersectBuildSinkOperator` builds a hast set from the `IntersectNode`'s first child.
- Each `IntersectProbeSinkOperator` probes the hash set built by `IntersectBuildSinkOperator`. The hash set records the ordinal of IntersectProbeSinkOperator per key if the key is hit.
- `IntersectOutputSourceOperator` traverses the hast set and picks up entries hit by all `IntersectProbeSinkOperators` after probe phase is finished.

`IntersectBuildSinkOperator`, `IntersectProbeSinkOperator`, and `IntersectOutputSourceOperator` belong to different pipelines. There is dependency between them:
- The first `IntersectProbeSinkOperator` depends on `IntersectBuildSinkOperator`.
- The rest `IntersectProbeSinkOperator` depends on the prev `IntersectProbeSinkOperator`.
- `IntersectOutputSourceOperator` depends on the last `IntersectProbeSinkOperator`.
 
The execution sequence is as follows:  `IntersectBuildSinkOperator` -> `IntersectProbeSinkOperator 0` -> `IntersectProbeSinkOperator 1` -> ... -> `IntersectProbeSinkOperator N` -> `IntersectOutputSourceOperator`.

The rows are shuffled to degree of parallelism (DOP) partitions by local shuffle exchange. For each partition, there are a IntersectBuildSinkOperator driver, a IntersectProbeSinkOperator driver for each child, and a IntersectOutputSourceOperator.

Fix #1132.
In addition, multiple ExceptProbeSinkOperators should probe the hash set sequentially instead of concurrently, because `ExceptHashSet<HashSet>::erase_duplicate_row()` use some object share member variables, such as `_slice_sizes`, `_max_one_row_size`, and `_buffer`.