### PR TITLE
[WIP]Read column sequentially as much as possible to optimize IO

### DIFF
--- a/be/src/storage/vectorized/range.h
+++ b/be/src/storage/vectorized/range.h
@@ -90,6 +90,16 @@ public:
     SparseRangeIterator() {}
     explicit SparseRangeIterator(const SparseRange* r);
 
+    SparseRangeIterator(const SparseRangeIterator& iter) :
+        _range(iter._range), _index(iter._index), _next_rowid(iter._next_rowid) { }
+
+    SparseRangeIterator& operator=(const SparseRangeIterator& rhs) {
+        _range = rhs._range;
+        _index = rhs._index;
+        _next_rowid = rhs._next_rowid;
+        return *this;
+    }
+
     rowid_t begin() const { return _next_rowid; }
 
     // Return true iff there are untraversed range, i.e, `next` will return a non-empty range.


### PR DESCRIPTION
Now in segment_iterator, we read column by small range if bitmap index is effective. It behaves like reading some rows from one column, then switch to next column and then read some rows, which is not IO friendly. I optimize reading scheme by reading column data as much as possible to fill the chunk.