### PR TITLE
BugFix: The log of creating colocating table replayed in follower throws null pointer exception (#913)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -3984,6 +3984,8 @@ public class Catalog {
         // if failed in any step, use this set to do clear things
         Set<Long> tabletIdSet = new HashSet<Long>();
 
+        boolean createTblSuccess = false;
+        boolean addToColocateGroupSuccess = false;
         // create partition
         try {
             // do not create partition for external table
@@ -4034,12 +4036,20 @@ public class Catalog {
                 if (getDb(db.getFullName()) == null) {
                     throw new DdlException("database has been dropped when creating table");
                 }
-                if (!db.createTableWithLock(olapTable, false, stmt.isSetIfNotExists())) {
-                    ErrorReport.reportDdlException(ErrorCode.ERR_CANT_CREATE_TABLE, tableName, "table already exists");
+                createTblSuccess = db.createTableWithLock(olapTable, false);
+                if (!createTblSuccess) {
+                    if (!stmt.isSetIfNotExists()) {
+                        ErrorReport.reportDdlException(ErrorCode.ERR_CANT_CREATE_TABLE, tableName, "table already exists");
+                    } else {
+                        LOG.info("create table[{}] which already exists", tableName);
+                        return;
+                    }
                 }
             } finally {
                 unlock();
             }
+
+            // NOTE: The table has been added to the database, and the following procedure cannot throw exception.
 
             // we have added these index to memory, only need to persist here
             if (getColocateTableIndex().isColocateTable(tableId)) {
@@ -4048,23 +4058,23 @@ public class Catalog {
                 ColocatePersistInfo info =
                         ColocatePersistInfo.createForAddTable(groupId, tableId, backendsPerBucketSeq);
                 editLog.logColocateAddTable(info);
+                addToColocateGroupSuccess = true;
             }
             LOG.info("successfully create table[{};{}]", tableName, tableId);
             // register or remove table from DynamicPartition after table created
             DynamicPartitionUtil.registerOrRemoveDynamicPartitionTable(db.getId(), olapTable);
             dynamicPartitionScheduler.createOrUpdateRuntimeInfo(
                     tableName, DynamicPartitionScheduler.LAST_UPDATE_TIME, TimeUtils.getCurrentFormatTime());
-        } catch (DdlException e) {
-            for (Long tabletId : tabletIdSet) {
-                Catalog.getCurrentInvertedIndex().deleteTablet(tabletId);
+        } finally {
+            if (!createTblSuccess) {
+                for (Long tabletId : tabletIdSet) {
+                    Catalog.getCurrentInvertedIndex().deleteTablet(tabletId);
+                }
             }
-
             // only remove from memory, because we have not persist it
-            if (getColocateTableIndex().isColocateTable(tableId)) {
+            if (getColocateTableIndex().isColocateTable(tableId) && !addToColocateGroupSuccess) {
                 getColocateTableIndex().removeTable(tableId);
             }
-
-            throw e;
         }
     }
 
@@ -4085,18 +4095,22 @@ public class Catalog {
             if (getDb(db.getFullName()) == null) {
                 throw new DdlException("database has been dropped when creating table");
             }
-            if (!db.createTableWithLock(mysqlTable, false, stmt.isSetIfNotExists())) {
-                ErrorReport.reportDdlException(ErrorCode.ERR_CANT_CREATE_TABLE, tableName, "table already exists");
+            if (!db.createTableWithLock(mysqlTable, false)) {
+                if (!stmt.isSetIfNotExists()) {
+                    ErrorReport.reportDdlException(ErrorCode.ERR_CANT_CREATE_TABLE, tableName, "table already exists");
+                } else {
+                    LOG.info("create table[{}] which already exists", tableName);
+                    return;
+                }
             }
         } finally {
             unlock();
         }
 
         LOG.info("successfully create table[{}-{}]", tableName, tableId);
-        return;
     }
 
-    private Table createEsTable(Database db, CreateTableStmt stmt) throws DdlException {
+    private void createEsTable(Database db, CreateTableStmt stmt) throws DdlException {
         String tableName = stmt.getTableName();
 
         // create columns
@@ -4128,15 +4142,19 @@ public class Catalog {
             if (getDb(db.getFullName()) == null) {
                 throw new DdlException("database has been dropped when creating table");
             }
-            if (!db.createTableWithLock(esTable, false, stmt.isSetIfNotExists())) {
-                ErrorReport.reportDdlException(ErrorCode.ERR_CANT_CREATE_TABLE, tableName, "table already exists");
+            if (!db.createTableWithLock(esTable, false)) {
+                if (!stmt.isSetIfNotExists()) {
+                    ErrorReport.reportDdlException(ErrorCode.ERR_CANT_CREATE_TABLE, tableName, "table already exists");
+                } else {
+                    LOG.info("create table[{}] which already exists", tableName);
+                    return;
+                }
             }
         } finally {
             unlock();
         }
 
         LOG.info("successfully create table{} with id {}", tableName, tableId);
-        return esTable;
     }
 
     private void createBrokerTable(Database db, CreateTableStmt stmt) throws DdlException {
@@ -4157,16 +4175,19 @@ public class Catalog {
             if (getDb(db.getFullName()) == null) {
                 throw new DdlException("database has been dropped when creating table");
             }
-            if (!db.createTableWithLock(brokerTable, false, stmt.isSetIfNotExists())) {
-                ErrorReport.reportDdlException(ErrorCode.ERR_CANT_CREATE_TABLE, tableName, "table already exists");
+            if (!db.createTableWithLock(brokerTable, false)) {
+                if (!stmt.isSetIfNotExists()) {
+                    ErrorReport.reportDdlException(ErrorCode.ERR_CANT_CREATE_TABLE, tableName, "table already exists");
+                } else {
+                    LOG.info("create table[{}] which already exists", tableName);
+                    return;
+                }
             }
         } finally {
             unlock();
         }
 
         LOG.info("successfully create table[{}-{}]", tableName, tableId);
-
-        return;
     }
 
     private void createHiveTable(Database db, CreateTableStmt stmt) throws DdlException {
@@ -4190,8 +4211,13 @@ public class Catalog {
             if (getDb(db.getFullName()) == null) {
                 throw new DdlException("database has been dropped when creating table");
             }
-            if (!db.createTableWithLock(hiveTable, false, stmt.isSetIfNotExists())) {
-                ErrorReport.reportDdlException(ErrorCode.ERR_CANT_CREATE_TABLE, tableName, "table already exists");
+            if (!db.createTableWithLock(hiveTable, false)) {
+                if (!stmt.isSetIfNotExists()) {
+                    ErrorReport.reportDdlException(ErrorCode.ERR_CANT_CREATE_TABLE, tableName, "table already exists");
+                } else {
+                    LOG.info("create table[{}] which already exists", tableName);
+                    return;
+                }
             }
         } finally {
             unlock();
@@ -4485,7 +4511,7 @@ public class Catalog {
 
     public void replayCreateTable(String dbName, Table table) {
         Database db = this.fullNameToDb.get(dbName);
-        db.createTableWithLock(table, true, false);
+        db.createTableWithLock(table, true);
 
         if (!isCheckpointThread()) {
             // add to inverted index
@@ -5944,8 +5970,13 @@ public class Catalog {
             if (getDb(db.getFullName()) == null) {
                 throw new DdlException("database has been dropped when creating view");
             }
-            if (!db.createTableWithLock(newView, false, stmt.isSetIfNotExists())) {
-                ErrorReport.reportDdlException(ErrorCode.ERR_CANT_CREATE_TABLE, tableName, "table already exists");
+            if (!db.createTableWithLock(newView, false)) {
+                if (!stmt.isSetIfNotExists()) {
+                    ErrorReport.reportDdlException(ErrorCode.ERR_CANT_CREATE_TABLE, tableName, "table already exists");
+                } else {
+                    LOG.info("create table[{}] which already exists", tableName);
+                    return;
+                }
             }
         } finally {
             unlock();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
@@ -278,13 +278,13 @@ public class Database extends MetaObject implements Writable {
         checkReplicaQuota();
     }
 
-    public boolean createTableWithLock(Table table, boolean isReplay, boolean setIfNotExist) {
-        boolean result = true;
+    // return false if table already exists
+    public boolean createTableWithLock(Table table, boolean isReplay) {
         writeLock();
         try {
             String tableName = table.getName();
             if (nameToTable.containsKey(tableName)) {
-                result = setIfNotExist;
+                return false;
             } else {
                 idToTable.put(table.getId(), table);
                 nameToTable.put(table.getName(), table);
@@ -297,7 +297,7 @@ public class Database extends MetaObject implements Writable {
 
                 table.onCreate();
             }
-            return result;
+            return true;
         } finally {
             writeUnlock();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/InfoSchemaDb.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/InfoSchemaDb.java
@@ -43,7 +43,7 @@ public class InfoSchemaDb extends Database {
     }
 
     @Override
-    public boolean createTableWithLock(Table table, boolean isReplay, boolean setIfNotExist) {
+    public boolean createTableWithLock(Table table, boolean isReplay) {
         return false;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/InfoSchemaDbTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/InfoSchemaDbTest.java
@@ -32,7 +32,7 @@ public class InfoSchemaDbTest {
         Database db = new InfoSchemaDb();
 
         Assert.assertFalse(db.createTable(null));
-        Assert.assertFalse(db.createTableWithLock(null, false, false));
+        Assert.assertFalse(db.createTableWithLock(null, false));
         db.dropTable("authors");
         db.dropTableWithLock("authors");
         db.write(null);


### PR DESCRIPTION
When creating a colocate table, if the if not exist statement is used, it may cause an invalid tableId to be used when writing the OP_COLOCATE_ADD_TABLE log. If the table already exists, do not write the OP_COLOCATE_ADD_TABLE log