### PR TITLE
Fix routine load loss data bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -949,8 +949,13 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
 
     @Override
     public void replayOnAborted(TransactionState txnState) {
-        // attachment may be null if this task is aborted by FE
-        if (txnState.getTxnCommitAttachment() != null) {
+        // Attachment may be null if this task is aborted by FE.
+        // For the aborted txn, we should check the cause of the error,
+        // the detailed information is in the checkCommitInfo function.
+        if (txnState.getTxnCommitAttachment() != null &&
+                checkCommitInfo((RLTaskTxnCommitAttachment) txnState.getTxnCommitAttachment(),
+                        txnState,
+                        TransactionState.TxnStatusChangeReason.fromString(txnState.getReason()))) {
             replayUpdateProgress((RLTaskTxnCommitAttachment) txnState.getTxnCommitAttachment());
         }
         this.abortedTaskNum++;


### PR DESCRIPTION
The aborted transaction still carries the offset information. The master does not advance the offset if the error reason is not `all partitions has no data to load`. However, the followers does not judge the logic, it still advance the offset.  Unfortunately, the vote procedure is been triggered. The follower change to master and the data is loss. So the pull request is add the logic to check the error reason when advancing the offset.