### PR TITLE
[pipeline] fix: make ResultSinkOperators share the same BufferControlBlock

### DIFF
--- a/be/src/exec/pipeline/result_sink_operator.cpp
+++ b/be/src/exec/pipeline/result_sink_operator.cpp
@@ -39,10 +39,10 @@ Status ResultSinkOperator::close(RuntimeState* state) {
     }
 
     // Close the shared sender when the last result sink operator is closing.
-    if (_decrement_num_result_sinks() == 0) {
+    if (_num_result_sinkers.fetch_sub(1, std::memory_order_acq_rel) == 1) {
         if (_sender != nullptr) {
             // Incrementing and reading _num_written_rows needn't memory barrier, because
-            // the visibility of _num_written_rows is guaranteed by _decrement_num_result_sinks.
+            // the visibility of _num_written_rows is guaranteed by _num_result_sinkers.fetch_sub().
             _sender->update_num_written_rows(_num_written_rows.load(std::memory_order_relaxed));
             _sender->close(st);
         }

--- a/be/src/exec/pipeline/result_sink_operator.h
+++ b/be/src/exec/pipeline/result_sink_operator.h
@@ -52,7 +52,7 @@ private:
     TResultSinkType::type _sink_type;
     std::vector<ExprContext*> _output_expr_ctxs;
 
-    /// The following four fields are shared by all the ResultSinkOperators
+    /// The following three fields are shared by all the ResultSinkOperators
     /// created by the same ResultSinkOperatorFactory.
     const std::shared_ptr<BufferControlBlock>& _sender;
     std::atomic<int32_t>& _num_result_sinks;

--- a/be/src/exec/pipeline/result_sink_operator.h
+++ b/be/src/exec/pipeline/result_sink_operator.h
@@ -23,7 +23,7 @@ public:
               _sink_type(sink_type),
               _output_expr_ctxs(output_expr_ctxs),
               _sender(sender),
-              _num_result_sinks(num_result_sinks),
+              _num_result_sinkers(num_result_sinks),
               _num_written_rows(num_written_rows) {}
 
     ~ResultSinkOperator() override = default;
@@ -47,15 +47,13 @@ public:
     Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override;
 
 private:
-    int32_t _decrement_num_result_sinks() { return _num_result_sinks.fetch_add(-1, std::memory_order_acq_rel) - 1; }
-
     TResultSinkType::type _sink_type;
     std::vector<ExprContext*> _output_expr_ctxs;
 
     /// The following three fields are shared by all the ResultSinkOperators
     /// created by the same ResultSinkOperatorFactory.
     const std::shared_ptr<BufferControlBlock>& _sender;
-    std::atomic<int32_t>& _num_result_sinks;
+    std::atomic<int32_t>& _num_result_sinkers;
     std::atomic<int64_t>& _num_written_rows;
 
     std::shared_ptr<ResultWriter> _writer;
@@ -78,13 +76,13 @@ public:
     ~ResultSinkOperatorFactory() override = default;
 
     OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override {
-        // _num_result_sinks is incremented when creating a ResultSinkOperator instance here at the preparing
+        // _num_result_sinkers is incremented when creating a ResultSinkOperator instance here at the preparing
         // phase of FragmentExecutor, and decremented and read when closing ResultSinkOperator. The visibility
-        // of increasing _num_result_sinks to ResultSinkOperator::close is guaranteed by pipeline driver queue,
+        // of increasing _num_result_sinkers to ResultSinkOperator::close is guaranteed by pipeline driver queue,
         // so it doesn't need memory barrier here.
-        _increment_num_result_sinks_no_barrier();
+        _increment_num_result_sinkers_no_barrier();
         return std::make_shared<ResultSinkOperator>(_id, _plan_node_id, _sink_type, _output_expr_ctxs, _sender,
-                                                    _num_result_sinks, _num_written_rows);
+                                                    _num_result_sinkers, _num_written_rows);
     }
 
     Status prepare(RuntimeState* state) override;
@@ -92,7 +90,7 @@ public:
     void close(RuntimeState* state) override;
 
 private:
-    void _increment_num_result_sinks_no_barrier() { _num_result_sinks.fetch_add(1, std::memory_order_relaxed); }
+    void _increment_num_result_sinkers_no_barrier() { _num_result_sinkers.fetch_add(1, std::memory_order_relaxed); }
 
     TResultSinkType::type _sink_type;
     std::vector<TExpr> _t_output_expr;
@@ -102,7 +100,7 @@ private:
     // A fragment_instance_id can only have ONE sender, because result_mgr saves the mapping from fragment_instance_id
     // to sender. Therefore, sender is created in this factory and shared by all the ResultSinkOperator instances.
     std::shared_ptr<BufferControlBlock> _sender;
-    std::atomic<int32_t> _num_result_sinks = 0;
+    std::atomic<int32_t> _num_result_sinkers = 0;
     std::atomic<int64_t> _num_written_rows = 0;
 };
 

--- a/be/src/exec/pipeline/result_sink_operator.h
+++ b/be/src/exec/pipeline/result_sink_operator.h
@@ -38,7 +38,7 @@ public:
 
     bool need_input() const override;
 
-    bool is_finished() const override { return _is_finished && !_fetch_data_result && _sender; }
+    bool is_finished() const override { return _is_finished && !_fetch_data_result; }
 
     void finish(RuntimeState* state) override { _is_finished = true; }
 

--- a/be/src/exec/pipeline/result_sink_operator.h
+++ b/be/src/exec/pipeline/result_sink_operator.h
@@ -47,7 +47,7 @@ public:
     Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override;
 
 private:
-    int32_t _decrement_num_result_sinks() { return _num_result_sinks.fetch_add(-1, std::memory_order_release) - 1; }
+    int32_t _decrement_num_result_sinks() { return _num_result_sinks.fetch_add(-1, std::memory_order_acq_rel) - 1; }
 
     TResultSinkType::type _sink_type;
     std::vector<ExprContext*> _output_expr_ctxs;


### PR DESCRIPTION
A `fragment_instance_id` can only have **ONE** sender, because `result_mgr` saves the mapping from `fragment_instance_id` to sender. 
Therefore, sender is created in the same `ResultSinkOperatorFactory` and shared by all the `ResultSinkOperator` instances.

Fix #1099.