### PR TITLE
[pipeline] fix: Union operator should consider both constant and non-constant columns

### DIFF
--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -116,7 +116,8 @@ public:
         return dst_column;
     }
 
-    static ColumnPtr unpack_nullable_column(const TypeDescriptor& dst_type_desc, bool dst_nullable,
+    // Update column according to whether the dest column and source column are nullable or not.
+    static ColumnPtr update_column_nullable(const TypeDescriptor& dst_type_desc, bool dst_nullable,
                                             const ColumnPtr& src_column, int num_rows) {
         if (src_column->is_nullable()) {
             if (dst_nullable) {
@@ -147,13 +148,13 @@ public:
             return copy_and_unfold_const_column(dst_type_desc, dst_nullable, src_column, num_rows);
         }
 
-        return unpack_nullable_column(dst_type_desc, dst_nullable, src_column, num_rows);
+        return update_column_nullable(dst_type_desc, dst_nullable, src_column, num_rows);
     }
 
     // Copy the source column according to the specific dest type and nullable.
     static ColumnPtr clone_column(const TypeDescriptor& dst_type_desc, bool dst_nullable, const ColumnPtr& src_column,
                                   int num_rows) {
-        auto dst_column = unpack_nullable_column(dst_type_desc, dst_nullable, src_column, num_rows);
+        auto dst_column = update_column_nullable(dst_type_desc, dst_nullable, src_column, num_rows);
         return dst_column->clone_shared();
     }
 

--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -94,6 +94,69 @@ public:
         return column;
     }
 
+    static ColumnPtr copy_and_unfold_const_column(const TypeDescriptor& dst_type_desc, bool dst_nullable,
+                                                  const ColumnPtr& src_column, int num_rows) {
+        ColumnPtr dst_column = create_column(dst_type_desc, dst_nullable);
+        dst_column->reserve(num_rows);
+
+        if (src_column->only_null()) {
+            // 1. If src is constant and nullable, create an only null dest column.
+            DCHECK(dst_nullable);
+            [[maybe_unused]] bool ok = dst_column->append_nulls(num_rows);
+            DCHECK(ok);
+        } else {
+            // 2. If src is constant and non-nullable, copy and unfold the constant column.
+            auto* const_column = as_raw_column<vectorized::ConstColumn>(src_column);
+            // Note: we must create a new column every time here,
+            // because VectorizedLiteral always return a same shared_ptr and we will modify it later.
+            dst_column->append(*const_column->data_column(), 0, 1);
+            dst_column->assign(num_rows, 0);
+        }
+
+        return dst_column;
+    }
+
+    static ColumnPtr unpack_nullable_column(const TypeDescriptor& dst_type_desc, bool dst_nullable,
+                                            const ColumnPtr& src_column, int num_rows) {
+        if (src_column->is_nullable()) {
+            if (dst_nullable) {
+                // 1. Src column and dest column are both nullable.
+                return src_column;
+            } else {
+                // 2. src column is nullable, and dest column is non-nullable.
+                auto* nullable_column = as_raw_column<NullableColumn>(src_column);
+                DCHECK(!nullable_column->has_null());
+                return nullable_column->data_column();
+            }
+        } else {
+            // 3. Src column and dest column are both non-nullable.
+            if (!dst_nullable) {
+                return src_column;
+            } else {
+                // 4. src column is non-nullable, and dest column is nullable.
+                ColumnPtr nullable_column = NullableColumn::create(src_column, NullColumn::create(num_rows, 0));
+                return nullable_column;
+            }
+        }
+    }
+
+    // Move the source column according to the specific dest type and nullable.
+    static ColumnPtr move_column(const TypeDescriptor& dst_type_desc, bool dst_nullable, const ColumnPtr& src_column,
+                                 int num_rows) {
+        if (src_column->is_constant()) {
+            return copy_and_unfold_const_column(dst_type_desc, dst_nullable, src_column, num_rows);
+        }
+
+        return unpack_nullable_column(dst_type_desc, dst_nullable, src_column, num_rows);
+    }
+
+    // Copy the source column according to the specific dest type and nullable.
+    static ColumnPtr clone_column(const TypeDescriptor& dst_type_desc, bool dst_nullable, const ColumnPtr& src_column,
+                                  int num_rows) {
+        auto dst_column = unpack_nullable_column(dst_type_desc, dst_nullable, src_column, num_rows);
+        return dst_column->clone_shared();
+    }
+
     static ColumnPtr create_column(const TypeDescriptor& type_desc, bool nullable);
 
     // If is_const is true, you must pass the size arg

--- a/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
@@ -39,7 +39,7 @@ bool LocalExchangeSourceOperator::is_finished() const {
 bool LocalExchangeSourceOperator::has_output() const {
     std::lock_guard<std::mutex> l(_chunk_lock);
 
-    return !_full_chunk_queue.empty() || _partition_rows_num > config::vector_chunk_size ||
+    return !_full_chunk_queue.empty() || _partition_rows_num >= config::vector_chunk_size ||
            (_is_finished && _partition_rows_num > 0);
 }
 

--- a/be/src/exec/pipeline/set/union_const_source_operator.cpp
+++ b/be/src/exec/pipeline/set/union_const_source_operator.cpp
@@ -25,9 +25,11 @@ StatusOr<vectorized::ChunkPtr> UnionConstSourceOperator::pull_chunk(starrocks::R
         for (size_t row_i = 0; row_i < rows_count; row_i++) {
             // Each const_expr_list is projected to ONE dest row.
             DCHECK_EQ(_const_expr_lists[_next_processed_row_index + row_i].size(), columns_count);
-            ColumnPtr src_column = _const_expr_lists[_next_processed_row_index + row_i][col_i]->evaluate(nullptr);
 
-            _move_column(dst_column, src_column);
+            ColumnPtr src_column = _const_expr_lists[_next_processed_row_index + row_i][col_i]->evaluate(nullptr);
+            auto cur_row_dst_column =
+                    vectorized::ColumnHelper::move_column(dst_slot->type(), dst_slot->is_nullable(), src_column, 1);
+            dst_column->append(*cur_row_dst_column, 0, 1);
         }
 
         chunk->append_column(std::move(dst_column), dst_slot->id());
@@ -37,20 +39,6 @@ StatusOr<vectorized::ChunkPtr> UnionConstSourceOperator::pull_chunk(starrocks::R
 
     DCHECK_CHUNK(chunk);
     return std::move(chunk);
-}
-
-void UnionConstSourceOperator::_move_column(ColumnPtr& dst_column, ColumnPtr& src_column) {
-    if (src_column->is_constant()) {
-        if (src_column->is_nullable()) {
-            DCHECK(dst_column->is_nullable());
-            dst_column->append_nulls(1);
-        } else {
-            auto* src_const_column = vectorized::ColumnHelper::as_raw_column<vectorized::ConstColumn>(src_column);
-            dst_column->append(*src_const_column->data_column(), 0, 1);
-        }
-    } else {
-        dst_column->append(*src_column, 0, 1);
-    }
 }
 
 Status UnionConstSourceOperatorFactory::prepare(RuntimeState* state) {

--- a/be/src/exec/pipeline/set/union_const_source_operator.h
+++ b/be/src/exec/pipeline/set/union_const_source_operator.h
@@ -4,8 +4,8 @@
 #include "exec/exec_node.h"
 #include "exec/pipeline/source_operator.h"
 
-namespace starrocks {
-namespace pipeline {
+namespace starrocks::pipeline {
+
 // UNION ALL operator has three kinds of sub-node as follows:
 // 1. Passthrough.
 //    The src column from sub-node is projected to the dest column without expressions.
@@ -41,6 +41,8 @@ public:
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 
 private:
+    void _move_column(ColumnPtr& dst_column, ColumnPtr& src_column);
+
     const std::vector<SlotDescriptor*>& _dst_slots;
 
     // The evaluation of each const expr_list is projected to ONE dest row.
@@ -81,5 +83,4 @@ private:
     const std::vector<std::vector<ExprContext*>>& _const_expr_lists;
 };
 
-} // namespace pipeline
-} // namespace starrocks
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/set/union_const_source_operator.h
+++ b/be/src/exec/pipeline/set/union_const_source_operator.h
@@ -41,8 +41,6 @@ public:
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 
 private:
-    void _move_column(ColumnPtr& dst_column, ColumnPtr& src_column);
-
     const std::vector<SlotDescriptor*>& _dst_slots;
 
     // The evaluation of each const expr_list is projected to ONE dest row.

--- a/be/src/exec/pipeline/set/union_passthrough_operator.h
+++ b/be/src/exec/pipeline/set/union_passthrough_operator.h
@@ -50,13 +50,6 @@ public:
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 
 private:
-    // Clones the src column to the dst chunk, which used when the src column is mapped to multiple dest columns.
-    void _clone_column(ChunkPtr& dst_chunk, const ColumnPtr& src_column, const SlotDescriptor* dst_slot,
-                       size_t row_count);
-    // Moves the src column to the dst chunk, which used when the src column is mapped to the only one dest column.
-    void _move_column(ChunkPtr& dst_chunk, const ColumnPtr& src_column, const SlotDescriptor* dst_slot,
-                      size_t row_count);
-
     // Maps the dst slot id of the dest chunk to that of the src chunk.
     // There may be multiple dest slot ids mapping to the same src slot id,
     // so we should decide whether you can move the src column according to this situation.


### PR DESCRIPTION
Currently, `UnionPassthroughSinkOperator` only considers non-constant columns, and `UnionConstSourceOperator` only considers constant columns.


`UnionPassthroughSinkOperator` and `UnionConstSourceOperator` should consider both constant and non-constant columns.

Abstract `move_column()` and `clone_column()` to `ColumnHelper`.