### PR TITLE
[ISSUE-1098] [pipeline] fixup: decrement global counter num_scan_oeprator when ScanOperator is closed

### DIFF
--- a/be/src/exec/pipeline/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan_operator.cpp
@@ -27,10 +27,12 @@ Status ScanOperator::prepare(RuntimeState* state) {
 Status ScanOperator::close(RuntimeState* state) {
     if (!_is_io_task_active.load(std::memory_order_acquire)) {
         if (_chunk_source) {
-            state->exec_env()->decrement_num_scan_operators(1);
             _chunk_source->close(state);
             _chunk_source = nullptr;
         }
+        // A ScanOperator that has no pending io tasks never submit io tasks again, so it should decrement
+        // global counter num_scan_operators.
+        state->exec_env()->decrement_num_scan_operators(1);
     }
     Operator::close(state);
     return Status::OK();
@@ -68,6 +70,8 @@ bool ScanOperator::pending_finish() {
         return true;
     } else {
         if (_chunk_source) {
+            // A ScanOperator in pending_finish state should decrement global counter num_scan_operators when
+            // its pending io tasks are done.
             _state->exec_env()->decrement_num_scan_operators(1);
             _chunk_source->close(_state);
             _chunk_source = nullptr;


### PR DESCRIPTION
## Bugfix

Global counter num_scan_operators is used to prevent BE from creating excessive ScanOperators in that scenarios exec threads would block when submit pending io tasks to a full tasks queue of io threads. so when ScanOperator is created,  num_scan_operators is incremented, and when ScanOperator is closed, it is decremented. the invariant that increment operations can be performed only when ScanOperator has no pending task.