### PR TITLE
Fix two bugs in column expr predicates

### DIFF
--- a/be/src/storage/rowset/vectorized/segment_iterator.cpp
+++ b/be/src/storage/rowset/vectorized/segment_iterator.cpp
@@ -1210,24 +1210,8 @@ Status SegmentIterator::_check_low_cardinality_optimization() {
         DCHECK(iter != _opts.predicates.end());
         const PredicateList& preds = iter->second;
         if (preds.size() > 0) {
-            bool can_using_global_dict = _can_using_global_dict(field);
-            _predicate_need_rewrite[cid] = std::all_of(preds.begin(), preds.end(), [=](auto* pred) {
-                auto pred_type = pred->type();
-                bool eq_predicate = pred_type == PredicateType::kEQ || pred_type == PredicateType::kInList ||
-                                    pred_type == PredicateType::kNE || pred_type == PredicateType::kNotInList;
-                bool range_predicate =
-                        can_using_global_dict && (pred_type == PredicateType::kGE || pred_type == PredicateType::kLE ||
-                                                  pred_type == PredicateType::kGT || pred_type == PredicateType::kLT);
-                return eq_predicate || range_predicate;
-            });
-            if (can_using_global_dict && !_predicate_need_rewrite[cid]) {
-                std::string msg = fmt::format("expect predicates could use low cardinality in cid:{}", cid);
-                DCHECK(false) << msg;
-                return Status::InternalError(msg);
-            }
-            // TODO(yan): We have some troubles of rewriting predicates of dict column because of char padding.
             // for string column of low cardinality, we can always rewrite predicates.
-            // _predicate_need_rewrite[cid] = true;
+            _predicate_need_rewrite[cid] = true;
         }
     }
     return Status::OK();

--- a/be/src/storage/vectorized/column_predicate.h
+++ b/be/src/storage/vectorized/column_predicate.h
@@ -130,8 +130,11 @@ public:
 
     virtual PredicateType type() const = 0;
 
+    // Constant value in the predicate. And this constant value might be adjusted according to schema.
+    // For example, if column type is char(20), then this constant value might be zero-padded to 20 chars.
     virtual Datum value() const { return Datum(); }
 
+    // Constant value in the predicate in vector form. In contrast to `value()`, these value are un-modified.
     virtual std::vector<Datum> values() const { return std::vector<Datum>{}; }
 
     virtual Status convert_to(const ColumnPredicate** output, const TypeInfoPtr& target_type_info,

--- a/be/src/storage/vectorized/column_predicate_rewriter.cpp
+++ b/be/src/storage/vectorized/column_predicate_rewriter.cpp
@@ -134,7 +134,8 @@ bool ColumnPredicateRewriter::_rewrite_predicate(ObjectPool* pool, const FieldPt
         }
         if (PredicateType::kGE == pred->type() || PredicateType::kGT == pred->type()) {
             _get_segment_dict(&sorted_dicts, _column_iterators[cid]);
-            auto value = pred->value().get_slice().to_string();
+            // use non-padding string value.
+            auto value = pred->values()[0].get_slice().to_string();
             auto iter = std::lower_bound(
                     sorted_dicts.begin(), sorted_dicts.end(), value,
                     [](const auto& entity, const auto& value) { return entity.first.compare(value) < 0; });
@@ -160,11 +161,12 @@ bool ColumnPredicateRewriter::_rewrite_predicate(ObjectPool* pool, const FieldPt
         }
         if (PredicateType::kLE == pred->type() || PredicateType::kLT == pred->type()) {
             _get_segment_dict(&sorted_dicts, _column_iterators[cid]);
-            std::vector<std::string> str_codewords;
-            auto value = pred->value().get_slice().to_string();
+            // use non-padding string value.
+            auto value = pred->values()[0].get_slice().to_string();
             auto iter = std::lower_bound(
                     sorted_dicts.begin(), sorted_dicts.end(), value,
                     [](const auto& entity, const auto& value) { return entity.first.compare(value) < 0; });
+            std::vector<std::string> str_codewords;
             auto begin_iter = sorted_dicts.begin();
             // X < 3.5 find 4, range(-inf, 3)
             // X < 3 find 3, range(-inf, 2)


### PR DESCRIPTION
This PR fixes two bugs. And these two bugs are found when we are running our daily tests.

1. Don't early return if the size of chunk filtered by the expr predicates is 0. Maybe there are more data in the segment files.
2. Dict values from dict columns are non-padded. So when we rewrite predicates on dict column, we should use non-padded string, instead of zero-padded string.