### PR TITLE
[Vertical compaction 1/3] Add row source mask

### DIFF
--- a/be/src/column/vectorized_fwd.h
+++ b/be/src/column/vectorized_fwd.h
@@ -43,10 +43,11 @@ using MutableColumnPtr = std::unique_ptr<Column>;
 using Columns = std::vector<ColumnPtr>;
 using MutableColumns = std::vector<MutableColumnPtr>;
 
+using Int8Column = FixedLengthColumn<int8_t>;
 using UInt8Column = FixedLengthColumn<uint8_t>;
 using BooleanColumn = UInt8Column;
-using Int8Column = FixedLengthColumn<int8_t>;
 using Int16Column = FixedLengthColumn<int16_t>;
+using UInt16Column = FixedLengthColumn<uint16_t>;
 using Int32Column = FixedLengthColumn<int32_t>;
 using UInt32Column = FixedLengthColumn<uint32_t>;
 using Int64Column = FixedLengthColumn<int64_t>;

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -305,6 +305,10 @@ CONF_mInt32(base_compaction_trace_threshold, "120");
 CONF_mInt32(cumulative_compaction_trace_threshold, "60");
 CONF_mInt32(update_compaction_trace_threshold, "20");
 
+// for vertical compaction
+// max mask memory bytes, default is 200M
+CONF_Int64(vertical_compaction_max_mask_memory_bytes, "209715200");
+
 // Port to start debug webserver on
 CONF_Int32(webserver_port, "8040");
 // Number of webserver workers

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -305,9 +305,10 @@ CONF_mInt32(base_compaction_trace_threshold, "120");
 CONF_mInt32(cumulative_compaction_trace_threshold, "60");
 CONF_mInt32(update_compaction_trace_threshold, "20");
 
-// for vertical compaction
-// max mask memory bytes, default is 200M
-CONF_Int64(vertical_compaction_max_mask_memory_bytes, "209715200");
+// Max row source mask memory bytes, default is 200M.
+// Should be smaller than compaction_mem_limit.
+// When the row source mask buffer exceeds this, it will be persisted to a temporary file on the disk.
+CONF_Int64(max_row_source_mask_memory_bytes, "209715200");
 
 // Port to start debug webserver on
 CONF_Int32(webserver_port, "8040");

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -144,6 +144,7 @@ add_library(Olap STATIC
     vectorized/predicate_parser.cpp
     vectorized/projection_iterator.cpp
     vectorized/push_handler.cpp
+    vectorized/row_source_mask.cpp
     vectorized/schema_change.cpp
     vectorized/tablet_reader.cpp
     vectorized/tablet_reader_params.cpp

--- a/be/src/storage/data_dir.cpp
+++ b/be/src/storage/data_dir.cpp
@@ -94,6 +94,7 @@ Status DataDir::init(bool read_only) {
     RETURN_IF_ERROR_WITH_WARN(update_capacity(), "update_capacity failed");
     RETURN_IF_ERROR_WITH_WARN(_init_cluster_id(), "_init_cluster_id failed");
     RETURN_IF_ERROR_WITH_WARN(_init_data_dir(), "_init_data_dir failed");
+    RETURN_IF_ERROR_WITH_WARN(_init_tmp_dir(), "_init_tmp_dir failed");
     RETURN_IF_ERROR_WITH_WARN(_init_file_system(), "_init_file_system failed");
     RETURN_IF_ERROR_WITH_WARN(_init_meta(read_only), "_init_meta failed");
 
@@ -183,7 +184,15 @@ Status DataDir::_init_data_dir() {
         RETURN_IF_ERROR_WITH_WARN(Status::IOError(strings::Substitute("failed to create data root path $0", data_path)),
                                   "check_exist failed");
     }
+    return Status::OK();
+}
 
+Status DataDir::_init_tmp_dir() {
+    std::string tmp_path = _path + TMP_PREFIX;
+    if (!FileUtils::check_exist(tmp_path) && !FileUtils::create_dir(tmp_path).ok()) {
+        RETURN_IF_ERROR_WITH_WARN(Status::IOError(strings::Substitute("failed to create tmp path $0", tmp_path)),
+                                  "check_exist failed");
+    }
     return Status::OK();
 }
 

--- a/be/src/storage/data_dir.h
+++ b/be/src/storage/data_dir.h
@@ -120,6 +120,7 @@ private:
     std::string _cluster_id_path() const { return _path + CLUSTER_ID_PREFIX; }
     Status _init_cluster_id();
     Status _init_data_dir();
+    Status _init_tmp_dir();
     Status _init_file_system();
     Status _init_meta(bool read_only = false);
 

--- a/be/src/storage/olap_define.h
+++ b/be/src/storage/olap_define.h
@@ -58,6 +58,7 @@ static const std::string TRASH_PREFIX = "/trash";           // NOLINT
 static const std::string UNUSED_PREFIX = "/unused";         // NOLINT
 static const std::string ERROR_LOG_PREFIX = "/error_log";   // NOLINT
 static const std::string CLONE_PREFIX = "/clone";           // NOLINT
+static const std::string TMP_PREFIX = "/tmp";               // NOLINT
 
 static const int32_t OLAP_DATA_VERSION_APPLIED = STARROCKS_V1;
 

--- a/be/src/storage/vectorized/row_source_mask.cpp
+++ b/be/src/storage/vectorized/row_source_mask.cpp
@@ -1,0 +1,146 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#include "storage/vectorized/row_source_mask.h"
+
+#include "common/config.h"
+#include "common/logging.h"
+#include "common/status.h"
+
+namespace starrocks::vectorized {
+
+RowSourceMaskBuffer::RowSourceMaskBuffer(int64_t tablet_id, const std::string& storage_root_path)
+        : _mask_column(std::move(UInt16Column::create_mutable())),
+        _tablet_id(tablet_id),
+        _storage_root_path(storage_root_path) {}
+
+RowSourceMaskBuffer::~RowSourceMaskBuffer() {
+    _reset_mask_column();
+    if (_tmp_file_fd > 0) {
+        ::close(_tmp_file_fd);
+    }
+}
+
+Status RowSourceMaskBuffer::write(const std::vector<RowSourceMask>& source_masks) {
+    if (_mask_column->byte_size() >= config::vertical_compaction_max_mask_memory_bytes) {
+        if (_tmp_file_fd == -1) {
+            RETURN_IF_ERROR(_create_tmp_file());
+        }
+        RETURN_IF_ERROR(_serialize_masks());
+        _reset_mask_column();
+    }
+
+    for (const auto& mask : source_masks) {
+        _mask_column->append(mask.data);
+    }
+    return Status::OK();
+}
+
+StatusOr<bool> RowSourceMaskBuffer::has_remaining() {
+    if (_current_index < _mask_column->size()) {
+        return true;
+    }
+
+    if (_tmp_file_fd > 0) {
+        DCHECK_EQ(_current_index, _mask_column->size());
+        _reset_mask_column();
+        _current_index = 0;
+        Status st = _deserialize_masks();
+        if (st.ok()) {
+            return true;
+        } else if (!st.is_end_of_file()) {
+            return st;
+        }
+    }
+    return false;
+}
+
+bool RowSourceMaskBuffer::has_same_source(uint16_t source, size_t count) const {
+    if (_mask_column->size() - _current_index < count) {
+        return false;
+    }
+
+    for (int i = 0; i < count; ++i) {
+        RowSourceMask mask(_mask_column->get(_current_index + i).get_uint16());
+        if (mask.get_source_num() != source) {
+            return false;
+        }
+    }
+    return true;
+}
+
+Status RowSourceMaskBuffer::flip() {
+    _current_index = 0;
+    if (_tmp_file_fd > 0) {
+        off_t offset = lseek(_tmp_file_fd, 0, SEEK_SET);
+        if (offset != 0) {
+            LOG(WARNING) << "fail to seek to offset 0. offset=" << offset;
+            return Status::InternalError("fail to seek to offset 0");
+        }
+        _reset_mask_column();
+    }
+    return Status::OK();
+}
+
+Status RowSourceMaskBuffer::flush() {
+    if (_tmp_file_fd > 0 && !_mask_column->empty()) {
+        RETURN_IF_ERROR(_serialize_masks());
+        _reset_mask_column();
+    }
+    return Status::OK();
+}
+
+Status RowSourceMaskBuffer::_create_tmp_file() {
+    std::stringstream tmp_file_path_s;
+    // storage/tmp/compaction_mask_12345.abcdef
+    tmp_file_path_s << _storage_root_path << TMP_PREFIX << "/" << "compaction_mask_" << _tablet_id << ".XXXXXX";
+    std::string tmp_file_path = tmp_file_path_s.str();
+    _tmp_file_fd = mkstemp(tmp_file_path.data());
+    if (_tmp_file_fd < 0) {
+        LOG(WARNING) << "fail to create mask tmp file. path=" << tmp_file_path;
+        return Status::InternalError("fail to create mask tmp file");
+    }
+    unlink(tmp_file_path.data());
+    return Status::OK();
+}
+
+Status RowSourceMaskBuffer::_serialize_masks() {
+    size_t content_size = _mask_column->serialize_size();
+    ssize_t w_size = ::write(_tmp_file_fd, &content_size, sizeof(uint64_t));
+    if (w_size != sizeof(uint64_t)) {
+        LOG(WARNING) << "fail to write masks size to mask file. write size=" << w_size;
+        return Status::InternalError("fail to write masks size to mask file");
+    }
+
+    string content;
+    content.resize(content_size);
+    _mask_column->serialize_column((uint8_t*)(content.data()));
+    w_size = ::write(_tmp_file_fd, content.data(), content_size);
+    if (w_size != content_size) {
+        LOG(WARNING) << "fail to write masks to mask file. write size=" << w_size;
+        return Status::InternalError("fail to write masks to mask file");
+    }
+    return Status::OK();
+}
+
+Status RowSourceMaskBuffer::_deserialize_masks() {
+    uint64_t content_size = 0;
+    ssize_t r_size = ::read(_tmp_file_fd, &content_size, sizeof(uint64_t));
+    if (r_size == 0) {
+        return Status::EndOfFile("end of file");
+    } else if (r_size != sizeof(uint64_t)) {
+        LOG(WARNING) << "fail to read masks size from mask file. read size=" << r_size;
+        return Status::InternalError("fail to read masks size from mask file");
+    }
+
+    string content;
+    content.resize(content_size);
+    r_size = ::read(_tmp_file_fd, content.data(), content_size);
+    if (r_size != content_size) {
+        LOG(WARNING) << "fail to read masks from mask file. read size=" << r_size;
+        return Status::InternalError("fail to read masks from mask file");
+    }
+    _mask_column->deserialize_column((uint8_t*)(content.data()));
+    return Status::OK();
+}
+
+} // namespace starrocks::vectorized

--- a/be/src/storage/vectorized/row_source_mask.cpp
+++ b/be/src/storage/vectorized/row_source_mask.cpp
@@ -10,8 +10,8 @@ namespace starrocks::vectorized {
 
 RowSourceMaskBuffer::RowSourceMaskBuffer(int64_t tablet_id, const std::string& storage_root_path)
         : _mask_column(std::move(UInt16Column::create_mutable())),
-        _tablet_id(tablet_id),
-        _storage_root_path(storage_root_path) {}
+          _tablet_id(tablet_id),
+          _storage_root_path(storage_root_path) {}
 
 RowSourceMaskBuffer::~RowSourceMaskBuffer() {
     _reset_mask_column();
@@ -92,7 +92,8 @@ Status RowSourceMaskBuffer::flush() {
 Status RowSourceMaskBuffer::_create_tmp_file() {
     std::stringstream tmp_file_path_s;
     // storage/tmp/compaction_mask_12345.abcdef
-    tmp_file_path_s << _storage_root_path << TMP_PREFIX << "/" << "compaction_mask_" << _tablet_id << ".XXXXXX";
+    tmp_file_path_s << _storage_root_path << TMP_PREFIX << "/"
+                    << "compaction_mask_" << _tablet_id << ".XXXXXX";
     std::string tmp_file_path = tmp_file_path_s.str();
     _tmp_file_fd = mkstemp(tmp_file_path.data());
     if (_tmp_file_fd < 0) {

--- a/be/src/storage/vectorized/row_source_mask.h
+++ b/be/src/storage/vectorized/row_source_mask.h
@@ -1,0 +1,98 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#pragma once
+
+#include "column/fixed_length_column.h"
+#include "common/statusor.h"
+
+namespace starrocks::vectorized {
+
+// RowSourceMask stores a uint16_t data that represents the source (segment iterator in compaction) of each row
+// and the aggregation state of the row.
+//
+// RowSourceMask is used to merge non-key columns without comparing keys in vertical compaction,
+// and to improve compaction efficiency and reduce memory usage.
+//
+// The lower 15 bits represent the source number, so the count of sources must be be less than or equal to 0x7FFF.
+// The higher 1 bit represents the aggregation flag, and is used in agg and uniq data model.
+// Agg flag is 1 means that the key of the row is the same as the previous row.
+struct RowSourceMask {
+    RowSourceMask(uint16_t data) : data(data) {}
+
+    RowSourceMask(uint16_t source_num, bool agg_flag) {
+        set_source_num(source_num);
+        set_agg_flag(agg_flag);
+    }
+
+    uint16_t get_source_num() const { return data & MASK_NUMBER; }
+
+    bool get_agg_flag() const { return (data & MASK_FLAG) != 0; }
+
+    void set_source_num(uint16_t source_num) {
+        data = (data & MASK_FLAG) | (source_num & MASK_NUMBER);
+    }
+
+    void set_agg_flag(bool agg_flag) {
+        data = agg_flag ? data | MASK_FLAG : data & ~MASK_FLAG;
+    }
+
+    uint16_t data = 0;
+
+    static constexpr size_t MAX_SOURCES = 0x7FFF;
+    static constexpr uint16_t MASK_NUMBER = 0x7FFF;
+    static constexpr uint16_t MASK_FLAG = 0x8000;
+};
+
+// RowSourceMaskBuffer is responsible for storing a series of row source masks.
+// When the buffer exceeds vertical_compaction_max_memory_mask_size, it will be persisted to a temporary file on the disk.
+//
+// Usage Example:
+//     // create
+//     RowSourceMaskBuffer buffer;
+//
+//     // write masks
+//     buffer.write(masks1);
+//     buffer.write(masks2);
+//     ...
+//     buffer.flush();
+//
+//     // read masks
+//     buffer.flip();
+//     while (buffer.has_remaining().value()) {
+//         RowSourceMask mask = buffer.current();
+//         buffer.advance();
+//     }
+//
+class RowSourceMaskBuffer {
+public:
+    explicit RowSourceMaskBuffer(int64_t tablet_id, const std::string &storage_root_path);
+    ~RowSourceMaskBuffer();
+
+    Status write(const std::vector<RowSourceMask> &source_masks);
+    StatusOr<bool> has_remaining();
+    bool has_same_source(uint16_t source, size_t count) const;
+
+    RowSourceMask current() const { return RowSourceMask(_mask_column->get(_current_index).get_uint16()); }
+    void advance() { ++_current_index; }
+
+    Status flip();
+    Status flush();
+
+private:
+    void _reset_mask_column() { _mask_column->reset_column(); }
+    Status _create_tmp_file();
+    Status _serialize_masks();
+    Status _deserialize_masks();
+
+    UInt16Column::MutablePtr _mask_column;
+
+    // for read
+    uint64_t _current_index = 0;
+
+    // temporary file for persistence
+    int _tmp_file_fd = -1;
+    int64_t _tablet_id;
+    std::string _storage_root_path;
+};
+
+} // namespace starrocks::vectorized

--- a/be/src/storage/vectorized/row_source_mask.h
+++ b/be/src/storage/vectorized/row_source_mask.h
@@ -28,13 +28,9 @@ struct RowSourceMask {
 
     bool get_agg_flag() const { return (data & MASK_FLAG) != 0; }
 
-    void set_source_num(uint16_t source_num) {
-        data = (data & MASK_FLAG) | (source_num & MASK_NUMBER);
-    }
+    void set_source_num(uint16_t source_num) { data = (data & MASK_FLAG) | (source_num & MASK_NUMBER); }
 
-    void set_agg_flag(bool agg_flag) {
-        data = agg_flag ? data | MASK_FLAG : data & ~MASK_FLAG;
-    }
+    void set_agg_flag(bool agg_flag) { data = agg_flag ? data | MASK_FLAG : data & ~MASK_FLAG; }
 
     uint16_t data = 0;
 
@@ -65,10 +61,10 @@ struct RowSourceMask {
 //
 class RowSourceMaskBuffer {
 public:
-    explicit RowSourceMaskBuffer(int64_t tablet_id, const std::string &storage_root_path);
+    explicit RowSourceMaskBuffer(int64_t tablet_id, const std::string& storage_root_path);
     ~RowSourceMaskBuffer();
 
-    Status write(const std::vector<RowSourceMask> &source_masks);
+    Status write(const std::vector<RowSourceMask>& source_masks);
     StatusOr<bool> has_remaining();
     bool has_same_source(uint16_t source, size_t count) const;
 

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -170,6 +170,7 @@ set(EXEC_FILES
         ./storage/vectorized/projection_iterator_test.cpp
         ./storage/vectorized/push_handler_test.cpp
         ./storage/vectorized/range_test.cpp
+        ./storage/vectorized/row_source_mask_test.cpp
         ./storage/vectorized/union_iterator_test.cpp
         ./storage/vectorized/unique_iterator_test.cpp
         ./storage/vectorized/cumulative_compaction_test.cpp

--- a/be/test/storage/vectorized/row_source_mask_test.cpp
+++ b/be/test/storage/vectorized/row_source_mask_test.cpp
@@ -11,7 +11,7 @@ namespace starrocks::vectorized {
 class RowSourceMaskTest : public testing::Test {
 protected:
     void SetUp() override {
-        _max_mask_memory_bytes = config::vertical_compaction_max_mask_memory_bytes;
+        _max_row_source_mask_memory_bytes = config::max_row_source_mask_memory_bytes;
 
         // create tmp dir
         std::stringstream tmp_dir_s;
@@ -21,7 +21,7 @@ protected:
     }
 
     void TearDown() override {
-        config::vertical_compaction_max_mask_memory_bytes = _max_mask_memory_bytes;
+        config::max_row_source_mask_memory_bytes = _max_row_source_mask_memory_bytes;
 
         // remove tmp dir
         if (!_tmp_dir.empty()) {
@@ -29,7 +29,7 @@ protected:
         }
     }
 
-    int64_t _max_mask_memory_bytes;
+    int64_t _max_row_source_mask_memory_bytes;
     std::string _tmp_dir;
 };
 
@@ -56,7 +56,7 @@ TEST_F(RowSourceMaskTest, mask) {
 TEST_F(RowSourceMaskTest, memory_masks) {
     RowSourceMaskBuffer buffer(0, config::storage_root_path);
     std::vector<RowSourceMask> source_masks;
-    config::vertical_compaction_max_mask_memory_bytes = 1024;
+    config::max_row_source_mask_memory_bytes = 1024;
 
     source_masks.emplace_back(RowSourceMask(0, false));
     source_masks.emplace_back(RowSourceMask(1, true));
@@ -137,7 +137,7 @@ TEST_F(RowSourceMaskTest, memory_masks) {
 TEST_F(RowSourceMaskTest, memory_masks_with_persistence) {
     RowSourceMaskBuffer buffer(1, config::storage_root_path);
     std::vector<RowSourceMask> source_masks;
-    config::vertical_compaction_max_mask_memory_bytes = 1;
+    config::max_row_source_mask_memory_bytes = 1;
 
     source_masks.emplace_back(RowSourceMask(0, false));
     source_masks.emplace_back(RowSourceMask(1, true));

--- a/be/test/storage/vectorized/row_source_mask_test.cpp
+++ b/be/test/storage/vectorized/row_source_mask_test.cpp
@@ -1,0 +1,218 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#include "storage/vectorized/row_source_mask.h"
+
+#include "common/config.h"
+#include "gtest/gtest.h"
+#include "util/file_utils.h"
+
+namespace starrocks::vectorized {
+
+class RowSourceMaskTest : public testing::Test {
+protected:
+    void SetUp() override {
+        _max_mask_memory_bytes = config::vertical_compaction_max_mask_memory_bytes;
+
+        // create tmp dir
+        std::stringstream tmp_dir_s;
+        tmp_dir_s << config::storage_root_path << TMP_PREFIX;
+        _tmp_dir = tmp_dir_s.str();
+        FileUtils::create_dir(_tmp_dir);
+    }
+
+    void TearDown() override {
+        config::vertical_compaction_max_mask_memory_bytes = _max_mask_memory_bytes;
+
+        // remove tmp dir
+        if (!_tmp_dir.empty()) {
+            FileUtils::remove(_tmp_dir);
+        }
+    }
+
+    int64_t _max_mask_memory_bytes;
+    std::string _tmp_dir;
+};
+
+// NOLINTNEXTLINE
+TEST_F(RowSourceMaskTest, mask) {
+    RowSourceMask mask(0);
+    ASSERT_EQ(0, mask.get_source_num());
+    ASSERT_EQ(false, mask.get_agg_flag());
+
+    mask.data = 0x8000;
+    ASSERT_EQ(0, mask.get_source_num());
+    ASSERT_EQ(true, mask.get_agg_flag());
+
+    mask.set_source_num(0x7FFF);
+    mask.set_agg_flag(false);
+    ASSERT_EQ(0x7FFF, mask.data);
+
+    mask.set_source_num(0x7FFF);
+    mask.set_agg_flag(true);
+    ASSERT_EQ(0xFFFF, mask.data);
+}
+
+// NOLINTNEXTLINE
+TEST_F(RowSourceMaskTest, memory_masks) {
+    RowSourceMaskBuffer buffer(0, config::storage_root_path);
+    std::vector<RowSourceMask> source_masks;
+    config::vertical_compaction_max_mask_memory_bytes = 1024;
+
+    source_masks.emplace_back(RowSourceMask(0, false));
+    source_masks.emplace_back(RowSourceMask(1, true));
+    source_masks.emplace_back(RowSourceMask(1, false));
+    buffer.write(source_masks);
+    source_masks.clear();
+    source_masks.emplace_back(RowSourceMask(1, true));
+    source_masks.emplace_back(RowSourceMask(3, true));
+    source_masks.emplace_back(RowSourceMask(2, true));
+    buffer.write(source_masks);
+    buffer.flush();
+
+    // --- read ---
+    buffer.flip();
+    auto st = buffer.has_remaining();
+    ASSERT_TRUE(st.ok());
+    ASSERT_TRUE(st.value());
+    RowSourceMask mask = buffer.current();
+    ASSERT_EQ(0, mask.get_source_num());
+    ASSERT_FALSE(mask.get_agg_flag());
+    buffer.advance();
+
+    ASSERT_TRUE(buffer.has_remaining().value());
+    mask = buffer.current();
+    ASSERT_EQ(1, mask.get_source_num());
+    ASSERT_TRUE(mask.get_agg_flag());
+    buffer.advance();
+
+    ASSERT_TRUE(buffer.has_remaining().value());
+    mask = buffer.current();
+    ASSERT_EQ(1, mask.get_source_num());
+    ASSERT_FALSE(mask.get_agg_flag());
+    buffer.advance();
+
+    ASSERT_TRUE(buffer.has_remaining().value());
+    mask = buffer.current();
+    ASSERT_EQ(1, mask.get_source_num());
+    ASSERT_TRUE(mask.get_agg_flag());
+    buffer.advance();
+
+    ASSERT_TRUE(buffer.has_remaining().value());
+    mask = buffer.current();
+    ASSERT_EQ(3, mask.get_source_num());
+    ASSERT_TRUE(mask.get_agg_flag());
+    buffer.advance();
+
+    ASSERT_TRUE(buffer.has_remaining().value());
+    mask = buffer.current();
+    ASSERT_EQ(2, mask.get_source_num());
+    ASSERT_TRUE(mask.get_agg_flag());
+    buffer.advance();
+
+    // end
+    st = buffer.has_remaining();
+    ASSERT_TRUE(st.ok());
+    ASSERT_FALSE(st.value());
+
+    // --- read again and check has same source ---
+    buffer.flip();
+    ASSERT_TRUE(buffer.has_remaining().value());
+    mask = buffer.current();
+    ASSERT_EQ(0, mask.get_source_num());
+    ASSERT_FALSE(mask.get_agg_flag());
+    buffer.advance();
+
+    ASSERT_TRUE(buffer.has_remaining().value());
+    mask = buffer.current();
+    ASSERT_EQ(1, mask.get_source_num());
+    ASSERT_TRUE(mask.get_agg_flag());
+
+    // check has same source
+    ASSERT_TRUE(buffer.has_same_source(mask.get_source_num(), 2));
+    ASSERT_TRUE(buffer.has_same_source(mask.get_source_num(), 3));
+    ASSERT_FALSE(buffer.has_same_source(mask.get_source_num(), 4));
+}
+
+// NOLINTNEXTLINE
+TEST_F(RowSourceMaskTest, memory_masks_with_persistence) {
+    RowSourceMaskBuffer buffer(1, config::storage_root_path);
+    std::vector<RowSourceMask> source_masks;
+    config::vertical_compaction_max_mask_memory_bytes = 1;
+
+    source_masks.emplace_back(RowSourceMask(0, false));
+    source_masks.emplace_back(RowSourceMask(1, true));
+    source_masks.emplace_back(RowSourceMask(1, false));
+    buffer.write(source_masks);
+    source_masks.clear();
+    source_masks.emplace_back(RowSourceMask(1, true));
+    source_masks.emplace_back(RowSourceMask(3, true));
+    source_masks.emplace_back(RowSourceMask(2, true));
+    buffer.write(source_masks);
+    buffer.flush();
+
+    // --- read ---
+    buffer.flip();
+    auto st = buffer.has_remaining();
+    ASSERT_TRUE(st.ok());
+    ASSERT_TRUE(st.value());
+    RowSourceMask mask = buffer.current();
+    ASSERT_EQ(0, mask.get_source_num());
+    ASSERT_FALSE(mask.get_agg_flag());
+    buffer.advance();
+
+    ASSERT_TRUE(buffer.has_remaining().value());
+    mask = buffer.current();
+    ASSERT_EQ(1, mask.get_source_num());
+    ASSERT_TRUE(mask.get_agg_flag());
+    buffer.advance();
+
+    ASSERT_TRUE(buffer.has_remaining().value());
+    mask = buffer.current();
+    ASSERT_EQ(1, mask.get_source_num());
+    ASSERT_FALSE(mask.get_agg_flag());
+    buffer.advance();
+
+    ASSERT_TRUE(buffer.has_remaining().value());
+    mask = buffer.current();
+    ASSERT_EQ(1, mask.get_source_num());
+    ASSERT_TRUE(mask.get_agg_flag());
+    buffer.advance();
+
+    ASSERT_TRUE(buffer.has_remaining().value());
+    mask = buffer.current();
+    ASSERT_EQ(3, mask.get_source_num());
+    ASSERT_TRUE(mask.get_agg_flag());
+    buffer.advance();
+
+    ASSERT_TRUE(buffer.has_remaining().value());
+    mask = buffer.current();
+    ASSERT_EQ(2, mask.get_source_num());
+    ASSERT_TRUE(mask.get_agg_flag());
+    buffer.advance();
+
+    // end
+    st = buffer.has_remaining();
+    ASSERT_TRUE(st.ok());
+    ASSERT_FALSE(st.value());
+
+    // --- read again and check has same source ---
+    buffer.flip();
+    ASSERT_TRUE(buffer.has_remaining().value());
+    mask = buffer.current();
+    ASSERT_EQ(0, mask.get_source_num());
+    ASSERT_FALSE(mask.get_agg_flag());
+    buffer.advance();
+
+    ASSERT_TRUE(buffer.has_remaining().value());
+    mask = buffer.current();
+    ASSERT_EQ(1, mask.get_source_num());
+    ASSERT_TRUE(mask.get_agg_flag());
+
+    // check has same source
+    ASSERT_TRUE(buffer.has_same_source(mask.get_source_num(), 2));
+    // new masks are not deserialized, so there is only 2 same sources
+    ASSERT_FALSE(buffer.has_same_source(mask.get_source_num(), 3));
+    ASSERT_FALSE(buffer.has_same_source(mask.get_source_num(), 4));
+}
+
+} // namespace starrocks::vectorized


### PR DESCRIPTION
#1112 

RowSourceMask stores a uint16_t data that represents the source (segment iterator in compaction) of each row and the aggregation state of the row.

RowSourceMask is used to merge non-key columns without comparing keys in vertical compaction,
and to improve compaction efficiency and reduce memory usage.

The lower 15 bits represent the source number, so the count of sources must be be less than or equal to 32767.
The higher 1 bit represents the aggregation flag, and is used in agg and uniq data model.
Agg flag is 1 means that the key of the row is the same as the previous row.