### PR TITLE
[pipeline] fix: HashJoinBuildOperator::prepare should call Operator::prepare

### DIFF
--- a/be/src/exec/pipeline/hashjoin/hash_join_build_operator.h
+++ b/be/src/exec/pipeline/hashjoin/hash_join_build_operator.h
@@ -14,8 +14,6 @@ class HashJoinBuildOperator final : public Operator {
 public:
     HashJoinBuildOperator(int32_t id, const string& name, int32_t plan_node_id, HashJoiner* hash_joiner);
     ~HashJoinBuildOperator() = default;
-    Status prepare(RuntimeState* state) override { return Status::OK(); };
-    Status close(RuntimeState* state) override { return Status::OK(); };
 
     bool has_output() const override {
         CHECK(false) << "has_output not supported in HashJoinBuildOperator";


### PR DESCRIPTION
Nowadays, `Operator::prepare()` initialize some member variables, like `_push_chunk_num_counter`, so we `prepare()` of Operator's child class should call `Operator::prepare()` first.

fix #1116 