### PR TITLE
Bugfix: check size in debug string when column is empty

### DIFF
--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -265,10 +265,14 @@ public:
     std::string debug_string() const override {
         std::stringstream ss;
         ss << "[";
-        for (int i = 0; i < size() - 1; ++i) {
+        size_t size = this->size();
+        for (int i = 0; i < size - 1; ++i) {
             ss << debug_item(i) << ", ";
         }
-        ss << debug_item(size() - 1) << "]";
+        if (size > 0) {
+            ss << debug_item(size - 1);
+        }
+        ss << "]";
         return ss.str();
     }
 

--- a/be/src/column/fixed_length_column_base.cpp
+++ b/be/src/column/fixed_length_column_base.cpp
@@ -256,10 +256,14 @@ template <typename T>
 std::string FixedLengthColumnBase<T>::debug_string() const {
     std::stringstream ss;
     ss << "[";
-    for (int i = 0; i < _data.size() - 1; ++i) {
+    size_t size = this->size();
+    for (int i = 0; i < size - 1; ++i) {
         ss << debug_item(i) << ", ";
     }
-    ss << debug_item(_data.size() - 1) << "]";
+    if (size > 0) {
+        ss << debug_item(size - 1);
+    }
+    ss << "]";
     return ss.str();
 }
 

--- a/be/src/column/object_column.h
+++ b/be/src/column/object_column.h
@@ -184,10 +184,14 @@ public:
     std::string debug_string() const override {
         std::stringstream ss;
         ss << "[";
-        for (int i = 0; i < size() - 1; ++i) {
+        size_t size = this->size();
+        for (int i = 0; i < size - 1; ++i) {
             ss << debug_item(i) << ", ";
         }
-        ss << debug_item(size() - 1) << "]";
+        if (size > 0) {
+            ss << debug_item(size - 1);
+        }
+        ss << "]";
         return ss.str();
     }
 


### PR DESCRIPTION
debug_item(-1) is wrong when column is empty