### PR TITLE
[pipeline] SinkBuffer paralization

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -634,7 +634,7 @@ CONF_Int64(pipeline_io_thread_pool_queue_size, "102400");
 // the number of execution threads for pipeline engine.
 CONF_Int64(pipeline_exec_thread_pool_thread_num, "3");
 // the cache size of io task
-CONF_Int64(pipeline_io_cache_size, "64");
+CONF_Int64(pipeline_io_buffer_size, "64");
 // bitmap serialize version
 CONF_Int16(bitmap_serialize_version, "1");
 // schema change vectorized

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -62,7 +62,7 @@ public:
     // Channel will sent input request directly without batch it.
     // This function is only used when broadcast, because request can be reused
     // by all the channels.
-    Status send_chunk_request(PTransmitChunkParams* params, const butil::IOBuf& attachment);
+    Status send_chunk_request(PTransmitChunkParamsPtr chunk_request, IOBufPtr attachment);
 
     // Used when doing shuffle.
     // This function will copy selective rows in chunks to batch.
@@ -97,6 +97,7 @@ private:
     TNetworkAddress _brpc_dest_addr;
 
     PUniqueId _finst_id;
+    PTransmitChunkParamsPtr _chunk_request;
 
     doris::PBackendService_Stub* _brpc_stub = nullptr;
 
@@ -156,16 +157,17 @@ Status ExchangeSinkOperator::Channel::send_one_chunk(const vectorized::Chunk* ch
 
 Status ExchangeSinkOperator::Channel::send_one_chunk(const vectorized::Chunk* chunk, bool eos, bool* is_real_sent) {
     *is_real_sent = false;
-
-    PTransmitChunkParams request;
-    request.set_allocated_finst_id(&_finst_id);
-    request.set_node_id(_dest_node_id);
-    request.set_sender_id(_parent->_sender_id);
-    request.set_be_number(_parent->_be_number);
+    if (_chunk_request == nullptr) {
+        _chunk_request = std::make_shared<PTransmitChunkParams>();
+        _chunk_request->set_allocated_finst_id(&_finst_id);
+        _chunk_request->set_node_id(_dest_node_id);
+        _chunk_request->set_sender_id(_parent->_sender_id);
+        _chunk_request->set_be_number(_parent->_be_number);
+    }
 
     // If chunk is not null, append it to request
     if (chunk != nullptr) {
-        auto pchunk = request.add_chunks();
+        auto pchunk = _chunk_request->add_chunks();
         RETURN_IF_ERROR(_parent->serialize_chunk(chunk, pchunk, &_is_first_chunk));
         _current_request_bytes += pchunk->data().size();
     }
@@ -173,34 +175,28 @@ Status ExchangeSinkOperator::Channel::send_one_chunk(const vectorized::Chunk* ch
     // Try to accumulate enough bytes before sending a RPC. When eos is true we should send
     // last packet
     if (_current_request_bytes > _parent->_request_bytes_threshold || eos) {
-        request.set_eos(eos);
-        butil::IOBuf attachment;
-        _parent->construct_brpc_attachment(&request, &attachment);
-        TransmitChunkInfo info = {this->_channel_id, std::move(request), _brpc_stub, attachment};
+        _chunk_request->set_eos(eos);
+        IOBufPtr attachment = std::make_shared<butil::IOBuf>();
+        _parent->construct_brpc_attachment(_chunk_request, attachment);
+        TransmitChunkInfo info = {this->_channel_id, _brpc_stub, std::move(_chunk_request), std::move(attachment)};
         _parent->_buffer->add_request(info);
         _current_request_bytes = 0;
-        // The original design is bad, we must release_finst_id here!
-        info.params.release_finst_id();
-
+        _chunk_request.reset();
         *is_real_sent = true;
     }
 
     return Status::OK();
 }
 
-Status ExchangeSinkOperator::Channel::send_chunk_request(PTransmitChunkParams* params, const butil::IOBuf& attachment) {
-    params->mutable_finst_id()->CopyFrom(_finst_id);
-    params->set_node_id(_dest_node_id);
-    params->set_sender_id(_parent->_sender_id);
-    params->set_be_number(_parent->_be_number);
+Status ExchangeSinkOperator::Channel::send_chunk_request(PTransmitChunkParamsPtr chunk_request, IOBufPtr attachment) {
+    chunk_request->set_allocated_finst_id(&_finst_id);
+    chunk_request->set_node_id(_dest_node_id);
+    chunk_request->set_sender_id(_parent->_sender_id);
+    chunk_request->set_be_number(_parent->_be_number);
+    chunk_request->set_eos(false);
 
-    params->set_eos(false);
-    // TODO (by satanson): eliminate redundant copy in broadcast scenarios
-    TransmitChunkInfo info = {this->_channel_id, *params, _brpc_stub, attachment};
+    TransmitChunkInfo info = {this->_channel_id, _brpc_stub, std::move(chunk_request), std::move(attachment)};
     _parent->_buffer->add_request(info);
-
-    // The original design is bad, we must release_finst_id here!
-    info.params.release_finst_id();
 
     return Status::OK();
 }
@@ -305,9 +301,6 @@ Status ExchangeSinkOperator::prepare(RuntimeState* state) {
         RETURN_IF_ERROR(_channel->init(state));
     }
 
-    // set eos for all channels.
-    // It will be set to true when closing.
-    _chunk_request.set_eos(false);
     _row_indexes.resize(config::vector_chunk_size);
 
     return Status::OK();
@@ -332,21 +325,26 @@ Status ExchangeSinkOperator::push_chunk(RuntimeState* state, const vectorized::C
         return Status::OK();
     }
     if (_part_type == TPartitionType::UNPARTITIONED || _channels.size() == 1) {
+        if (_chunk_request == nullptr) {
+            _chunk_request = std::make_shared<PTransmitChunkParams>();
+        }
+
         // We use sender request to avoid serialize chunk many times.
         // 1. create a new chunk PB to serialize
-        ChunkPB* pchunk = _chunk_request.add_chunks();
+        ChunkPB* pchunk = _chunk_request->add_chunks();
         // 2. serialize input chunk to pchunk
         RETURN_IF_ERROR(serialize_chunk(chunk.get(), pchunk, &_is_first_chunk, _channels.size()));
         _current_request_bytes += pchunk->data().size();
         // 3. if request bytes exceede the threshold, send current request
         if (_current_request_bytes > _request_bytes_threshold) {
-            butil::IOBuf attachment;
-            construct_brpc_attachment(&_chunk_request, &attachment);
+            IOBufPtr attachment = std::make_shared<butil::IOBuf>();
+            construct_brpc_attachment(_chunk_request, attachment);
             for (const auto& channel : _channels) {
-                RETURN_IF_ERROR(channel->send_chunk_request(&_chunk_request, attachment));
+                PTransmitChunkParamsPtr copy = std::make_shared<PTransmitChunkParams>(*_chunk_request);
+                RETURN_IF_ERROR(channel->send_chunk_request(copy, attachment));
             }
             _current_request_bytes = 0;
-            _chunk_request.clear_chunks();
+            _chunk_request.reset();
         }
     } else if (_part_type == TPartitionType::RANDOM) {
         // Round-robin batches among channels. Wait for the current channel to finish its
@@ -424,8 +422,19 @@ void ExchangeSinkOperator::finish(RuntimeState* state) {
     if (_is_finished) {
         return;
     }
-
     _is_finished = true;
+
+    if (_chunk_request != nullptr) {
+        IOBufPtr attachment = std::make_shared<butil::IOBuf>();
+        construct_brpc_attachment(_chunk_request, attachment);
+        for (const auto& channel : _channels) {
+            PTransmitChunkParamsPtr copy = std::make_shared<PTransmitChunkParams>(*_chunk_request);
+            channel->send_chunk_request(copy, attachment);
+        }
+        _current_request_bytes = 0;
+        _chunk_request.reset();
+    }
+
     for (auto& _channel : _channels) {
         _channel->close(state);
     }
@@ -495,9 +504,9 @@ Status ExchangeSinkOperator::serialize_chunk(const vectorized::Chunk* src, Chunk
     return Status::OK();
 }
 
-void ExchangeSinkOperator::construct_brpc_attachment(PTransmitChunkParams* params, butil::IOBuf* attachment) {
-    for (int i = 0; i < params->chunks().size(); ++i) {
-        auto chunk = params->mutable_chunks(i);
+void ExchangeSinkOperator::construct_brpc_attachment(PTransmitChunkParamsPtr chunk_request, IOBufPtr attachment) {
+    for (int i = 0; i < chunk_request->chunks().size(); ++i) {
+        auto chunk = chunk_request->mutable_chunks(i);
         chunk->set_data_size(chunk->data().size());
         attachment->append(chunk->data());
         chunk->clear_data();

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.h
@@ -9,6 +9,7 @@
 #include "common/object_pool.h"
 #include "common/status.h"
 #include "exec/data_sink.h"
+#include "exec/pipeline/exchange/sink_buffer.h"
 #include "exec/pipeline/operator.h"
 #include "gen_cpp/data.pb.h"
 #include "gen_cpp/internal_service.pb.h"
@@ -54,7 +55,7 @@ public:
     // For other chunk, only serialize the chunk data to ChunkPB.
     Status serialize_chunk(const vectorized::Chunk* chunk, ChunkPB* dst, bool* is_first_chunk, int num_receivers = 1);
 
-    void construct_brpc_attachment(PTransmitChunkParams* _chunk_request, butil::IOBuf* attachment);
+    void construct_brpc_attachment(PTransmitChunkParamsPtr _chunk_request, IOBufPtr attachment);
 
     RuntimeProfile* profile() { return _profile; }
 
@@ -81,9 +82,9 @@ private:
     int _curr_random_channel_idx = 0;
 
     // Only used when broadcast
-    PTransmitChunkParams _chunk_request;
+    PTransmitChunkParamsPtr _chunk_request;
     size_t _current_request_bytes = 0;
-    size_t _request_bytes_threshold = 0;
+    size_t _request_bytes_threshold = config::max_transmit_batched_bytes;
 
     bool _is_first_chunk = true;
 

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.h
@@ -55,7 +55,7 @@ public:
     // For other chunk, only serialize the chunk data to ChunkPB.
     Status serialize_chunk(const vectorized::Chunk* chunk, ChunkPB* dst, bool* is_first_chunk, int num_receivers = 1);
 
-    void construct_brpc_attachment(PTransmitChunkParamsPtr _chunk_request, IOBufPtr attachment);
+    void construct_brpc_attachment(PTransmitChunkParamsPtr _chunk_request, butil::IOBuf& attachment);
 
     RuntimeProfile* profile() { return _profile; }
 

--- a/be/src/exec/pipeline/scan_operator.h
+++ b/be/src/exec/pipeline/scan_operator.h
@@ -53,7 +53,7 @@ private:
     // TODO(hcf) ugly, remove this later
     RuntimeState* _state = nullptr;
 
-    const size_t _batch_size = config::pipeline_io_cache_size;
+    const size_t _batch_size = config::pipeline_io_buffer_size;
     mutable bool _is_finished = false;
     std::atomic_bool _is_io_task_active = false;
     const TOlapScanNode& _olap_scan_node;


### PR DESCRIPTION
In [previous pr](https://github.com/StarRocks/starrocks/pull/1104), we solve the problem of disorder by simply serializing sender side. But if one channel is congested, it may cause other channel unwritable.

So, in this pr, we implement serial transmission in the channel dimension, which means different channels may still be out of order