### PR TITLE
[ISSUE-1135] Shutdown pipeline driver poller

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver_poller.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_poller.cpp
@@ -19,10 +19,8 @@ void PipelineDriverPoller::start() {
 
 void PipelineDriverPoller::shutdown() {
     if (this->_is_shutdown.load() == false) {
-        {
-            this->_is_shutdown.store(true, std::memory_order_release);
-            _cond.notify_one();
-        }
+        this->_is_shutdown.store(true, std::memory_order_release);
+        _cond.notify_one();
     }
 }
 

--- a/be/src/exec/pipeline/pipeline_driver_poller.h
+++ b/be/src/exec/pipeline/pipeline_driver_poller.h
@@ -24,7 +24,7 @@ public:
               _is_shutdown(false) {}
 
     using DriverList = std::list<DriverRawPtr>;
-    ~PipelineDriverPoller() = default;
+    ~PipelineDriverPoller() { shutdown(); };
     // start poller thread
     void start();
     // shutdown poller thread


### PR DESCRIPTION
## Bugfix

Invoke shutdown function in ~PipelineDriverPoller,  and in shutdown, notify poller thead waiting on condvar to quit timely.