### PR TITLE
Fix hive external table is supported.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
@@ -351,6 +351,9 @@ public class HiveTable extends Table {
             org.apache.hadoop.hive.metastore.api.Table hiveTable = Catalog.getCurrentCatalog().getHiveRepository()
                     .getTable(resourceName, this.hiveDb, this.hiveTable);
             String hiveTableType = hiveTable.getTableType();
+            if (hiveTableType == null) {
+                throw new DdlException("Unknown hive table type.");
+            }
             switch (hiveTableType) {
                 case "VIRTUAL_VIEW": // hive view table not supported
                     throw new DdlException("Hive view table is not supported.");

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
@@ -355,9 +355,10 @@ public class HiveTable extends Table {
                 if ("VIRTUAL_VIEW".equals(hiveTableType)) {
                     throw new DdlException("Hive view table is not supported.");
                 } else if ("EXTERNAL_TABLE".equals(hiveTableType)) {
-                    throw new DdlException("Hive external table is not supported.");
+                    // hive external table is supported
+                } else {
+                    throw new DdlException("unsupported hive table type [" + hiveTableType + "].");
                 }
-                throw new DdlException("unsupported hive table type [" + hiveTableType + "].");
             }
             List<FieldSchema> unPartHiveColumns = hiveTable.getSd().getCols();
             List<FieldSchema> partHiveColumns = hiveTable.getPartitionKeys();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
@@ -351,14 +351,14 @@ public class HiveTable extends Table {
             org.apache.hadoop.hive.metastore.api.Table hiveTable = Catalog.getCurrentCatalog().getHiveRepository()
                     .getTable(resourceName, this.hiveDb, this.hiveTable);
             String hiveTableType = hiveTable.getTableType();
-            if (!"MANAGED_TABLE".equals(hiveTableType)) {
-                if ("VIRTUAL_VIEW".equals(hiveTableType)) {
+            switch (hiveTableType) {
+                case "VIRTUAL_VIEW": // hive view tale not supported
                     throw new DdlException("Hive view table is not supported.");
-                } else if ("EXTERNAL_TABLE".equals(hiveTableType)) {
-                    // hive external table is supported
-                } else {
+                case "EXTERNAL_TABLE": // hive external table supported
+                case "MANAGED_TABLE": // basic hive table supported
+                    break;
+                default:
                     throw new DdlException("unsupported hive table type [" + hiveTableType + "].");
-                }
             }
             List<FieldSchema> unPartHiveColumns = hiveTable.getSd().getCols();
             List<FieldSchema> partHiveColumns = hiveTable.getPartitionKeys();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
@@ -352,7 +352,7 @@ public class HiveTable extends Table {
                     .getTable(resourceName, this.hiveDb, this.hiveTable);
             String hiveTableType = hiveTable.getTableType();
             switch (hiveTableType) {
-                case "VIRTUAL_VIEW": // hive view tale not supported
+                case "VIRTUAL_VIEW": // hive view table not supported
                     throw new DdlException("Hive view table is not supported.");
                 case "EXTERNAL_TABLE": // hive external table supported
                 case "MANAGED_TABLE": // basic hive table supported


### PR DESCRIPTION
In #1111 and #1110 
It was test mistake to disable hive external table.
Hive external table is supported if input format supports it. 
Now restore the behavior of Hive external table