### PR TITLE
Disable low cardinality global dict optimization for only scan plan

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecodeRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecodeRewriteTest.java
@@ -190,7 +190,8 @@ public class DecodeRewriteTest extends PlanTestBase{
     @Test
     public void testDecodeRewrite9Scan() throws Exception {
         String sql = "select S_ADDRESS from supplier";
-        String plan = getThriftPlan(sql);
+        String plan = getFragmentPlan(sql);
+        Assert.assertFalse(plan.contains("Decode"));
     }
 
     @Test


### PR DESCRIPTION
For https://github.com/StarRocks/starrocks/issues/559

For SQL `select S_ADDRESS from supplier`, we should disable low cardinality global dict optimization.

Currently, If parent operators are Agg, join, shuffle, project, we enable this optimization. In the future, we will support sort and union.