### PR TITLE
OSS file shoud split by object storage file size

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/external/ObejctStorageUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/ObejctStorageUtils.java
@@ -1,0 +1,26 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+package com.starrocks.external;
+
+public class ObejctStorageUtils {
+    private static final String SCHEME_S3A = "s3a://";
+    private static final String SCHEME_S3 = "s3://";
+    private static final String SCHEME_S3N = "s3n://";
+    private static final String SCHEME_S3_PREFIX = "s3";
+    private static final String SCHEME_OSS_PREFIX = "oss";
+
+    public static boolean isObjectStorage(String path) {
+        return path.startsWith(SCHEME_S3_PREFIX) || path.startsWith(SCHEME_OSS_PREFIX);
+    }
+
+    public static String formatObjectStoragePath(String path) {
+        if (path.startsWith(SCHEME_S3)) {
+            return SCHEME_S3A + path.substring(5);
+        }
+        if (path.startsWith(SCHEME_S3N)) {
+            return SCHEME_S3A + path.substring(6);
+        }
+
+        return path;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaClient.java
@@ -62,6 +62,7 @@ public class HiveMetaClient {
     private static final String SCHEME_S3 = "s3://";
     private static final String SCHEME_S3N = "s3n://";
     private static final String SCHEME_S3_PREFIX = "s3";
+    private static final String SCHEME_OSS_PREFIX = "oss";
 
     private final LinkedList<AutoCloseClient> clientPool = new LinkedList<>();
     private final Object clientPoolLock = new Object();
@@ -494,7 +495,7 @@ public class HiveMetaClient {
     }
 
     private boolean isObjectStorage(String path) {
-        return path.startsWith(SCHEME_S3_PREFIX);
+        return path.startsWith(SCHEME_S3_PREFIX) || path.startsWith(SCHEME_OSS_PREFIX);
     }
 
     private boolean isValidDataFile(FileStatus fileStatus) {


### PR DESCRIPTION
Since OSS file also use default blocklocation which use full file size, so we should split it like s3 files for performance consideration