### PR TITLE
Make hdfs block size configurable for hive external table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1284,6 +1284,13 @@ public class Config extends ConfigBase {
     public static long object_storage_block_size = 64L * 1024L * 1024L;
 
     /**
+     * Used to split hdfs files into blocks for hive external table.
+     * If you want to use the default block size of hdfs, set this parameter to -1
+     */
+    @ConfField(mutable = true)
+    public static long hdfs_block_size = 64L * 1024L * 1024L;
+
+    /**
      * fe will call es api to get es index shard info every es_state_sync_interval_secs
      */
     @ConfField

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaClient.java
@@ -14,6 +14,7 @@ import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.UserException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.FileStatus;
@@ -472,12 +473,15 @@ public class HiveMetaClient {
         long hdfsBlockSize = Config.hdfs_block_size;
         long osBlockSize = Config.object_storage_block_size;
         if (!isObjectStorage(dirPath)) {
-            if (hdfsBlockSize < 0) {
+            if (hdfsBlockSize <= 0) {
                 return getHdfsFileDescsByAPI(dirPath);
             } else {
                 return getHdfsFileDescsByBlockSize(dirPath, hdfsBlockSize);
             }
         } else {
+            if (osBlockSize <= 0) {
+                throw new UserException("invalid config [object_storage_block_size] value: " + osBlockSize);
+            }
             return getHdfsFileDescsByBlockSize(dirPath, osBlockSize);
         }
     }


### PR DESCRIPTION
Add a new configuration hdfs_block_size. It's used to split hdfs files into blocks for hive external table. 
If you want to use the default block size of hdfs, set this parameter to -1.