### PR TITLE
Split hdfs block to increase the degree of parallelism when the default hdfs block size is too large

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1278,10 +1278,11 @@ public class Config extends ConfigBase {
     public static long hive_meta_store_timeout_s = 10L;
 
     /**
-     * Used to split object storage files into smaller blocks for hive external table
+     * Used to split files stored in dfs such as object storage
+     * or hdfs into smaller files for hive external table
      */
     @ConfField(mutable = true)
-    public static long object_storage_block_size = 64L * 1024L * 1024L;
+    public static long hive_max_split_size = 64L * 1024L * 1024L;
 
     /**
      * fe will call es api to get es index shard info every es_state_sync_interval_secs

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HdfsFileBlockDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HdfsFileBlockDesc.java
@@ -8,6 +8,7 @@ public class HdfsFileBlockDesc {
     private long[] replicaHostIds;
     private long[] diskIds;
     private HiveMetaClient metaClient;
+    private boolean splittable;
 
     public HdfsFileBlockDesc(long offset, long length, long[] replicaHostIds,
                              long[] diskIds, HiveMetaClient metaClient) {
@@ -16,6 +17,13 @@ public class HdfsFileBlockDesc {
         this.replicaHostIds = replicaHostIds;
         this.diskIds = diskIds;
         this.metaClient = metaClient;
+        this.splittable = false;
+    }
+
+    public HdfsFileBlockDesc(long offset, long length, long[] replicaHostIds,
+                             long[] diskIds, HiveMetaClient metaClient, boolean splittable) {
+        this(offset, length, replicaHostIds, diskIds, metaClient);
+        this.splittable = splittable;
     }
 
     public String getDataNodeIp(long hostId) {
@@ -36,5 +44,9 @@ public class HdfsFileBlockDesc {
 
     public long[] getDiskIds() {
         return diskIds;
+    }
+
+    public boolean isSplittable() {
+        return splittable;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HdfsFileBlockDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HdfsFileBlockDesc.java
@@ -8,7 +8,6 @@ public class HdfsFileBlockDesc {
     private long[] replicaHostIds;
     private long[] diskIds;
     private HiveMetaClient metaClient;
-    private boolean splittable;
 
     public HdfsFileBlockDesc(long offset, long length, long[] replicaHostIds,
                              long[] diskIds, HiveMetaClient metaClient) {
@@ -17,13 +16,6 @@ public class HdfsFileBlockDesc {
         this.replicaHostIds = replicaHostIds;
         this.diskIds = diskIds;
         this.metaClient = metaClient;
-        this.splittable = false;
-    }
-
-    public HdfsFileBlockDesc(long offset, long length, long[] replicaHostIds,
-                             long[] diskIds, HiveMetaClient metaClient, boolean splittable) {
-        this(offset, length, replicaHostIds, diskIds, metaClient);
-        this.splittable = splittable;
     }
 
     public String getDataNodeIp(long hostId) {
@@ -44,9 +36,5 @@ public class HdfsFileBlockDesc {
 
     public long[] getDiskIds() {
         return diskIds;
-    }
-
-    public boolean isSplittable() {
-        return splittable;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HdfsFileDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HdfsFileDesc.java
@@ -9,6 +9,7 @@ public class HdfsFileDesc {
     private String compression;
     private long length;
     private ImmutableList<HdfsFileBlockDesc> blockDescs;
+    private boolean splittable;
 
     public HdfsFileDesc(String fileName, String compression, long length,
                         ImmutableList<HdfsFileBlockDesc> blockDescs) {
@@ -16,6 +17,13 @@ public class HdfsFileDesc {
         this.compression = compression;
         this.length = length;
         this.blockDescs = blockDescs;
+        this.splittable = false;
+    }
+
+    public HdfsFileDesc(String fileName, String compression, long length,
+                        ImmutableList<HdfsFileBlockDesc> blockDescs, boolean splittable) {
+        this(fileName, compression, length, blockDescs);
+        this.splittable = splittable;
     }
 
     public String getFileName() {
@@ -32,5 +40,9 @@ public class HdfsFileDesc {
 
     public ImmutableList<HdfsFileBlockDesc> getBlockDescs() {
         return blockDescs;
+    }
+
+    public boolean isSplittable() {
+        return splittable;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HdfsFileFormat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HdfsFileFormat.java
@@ -15,6 +15,11 @@ public enum HdfsFileFormat {
                     .put("org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat", PARQUET)
                     .put("org.apache.hadoop.hive.ql.io.orc.OrcInputFormat", ORC)
                     .build();
+    private static final ImmutableMap<String, Boolean> fileFormatSplittableInfos =
+            new ImmutableMap.Builder<String, Boolean>()
+                    .put("org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat", true)
+                    .put("org.apache.hadoop.hive.ql.io.orc.OrcInputFormat", true)
+                    .build();
 
     private final String inputFormat;
 
@@ -24,6 +29,10 @@ public enum HdfsFileFormat {
 
     public static HdfsFileFormat fromHdfsInputFormatClass(String className) {
         return validInputFormats.get(className);
+    }
+
+    public static boolean isSplittable(String className) {
+        return fileFormatSplittableInfos.containsKey(className) && fileFormatSplittableInfos.get(className);
     }
 
     public THdfsFileFormat toThrift() {

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaClient.java
@@ -468,9 +468,9 @@ public class HiveMetaClient {
                 }
                 String fileName = Utils.getSuffixName(dirPath, locatedFileStatus.getPath().toString());
                 BlockLocation[] blockLocations = locatedFileStatus.getBlockLocations();
-                List<HdfsFileBlockDesc> fileBlockDescs = getHdfsFileBlockDescs(blockLocations, isSplittable);
+                List<HdfsFileBlockDesc> fileBlockDescs = getHdfsFileBlockDescs(blockLocations);
                 fileDescs.add(new HdfsFileDesc(fileName, "", locatedFileStatus.getLen(),
-                        ImmutableList.copyOf(fileBlockDescs)));
+                        ImmutableList.copyOf(fileBlockDescs), isSplittable));
             }
         } catch (FileNotFoundException ignored) {
             // hive empty partition may not create directory
@@ -488,15 +488,13 @@ public class HiveMetaClient {
                 lcFileName.endsWith(".copying") || lcFileName.endsWith(".tmp"));
     }
 
-    private List<HdfsFileBlockDesc> getHdfsFileBlockDescs(BlockLocation[] blockLocations,
-                                                          boolean splittable) throws IOException {
+    private List<HdfsFileBlockDesc> getHdfsFileBlockDescs(BlockLocation[] blockLocations) throws IOException {
         List<HdfsFileBlockDesc> fileBlockDescs = Lists.newArrayList();
         for (BlockLocation blockLocation : blockLocations) {
             fileBlockDescs.add(buildHdfsFileBlockDesc(
                     blockLocation.getOffset(),
                     blockLocation.getLength(),
-                    getReplicaHostIds(blockLocation.getNames()),
-                    splittable)
+                    getReplicaHostIds(blockLocation.getNames()))
             );
         }
         return fileBlockDescs;
@@ -511,8 +509,7 @@ public class HiveMetaClient {
         return replicaHostIds;
     }
 
-    private HdfsFileBlockDesc buildHdfsFileBlockDesc(long offset, long length,
-                                                     long[] replicaHostIds, boolean splittable) {
+    private HdfsFileBlockDesc buildHdfsFileBlockDesc(long offset, long length, long[] replicaHostIds) {
         return new HdfsFileBlockDesc(offset,
                 length,
                 replicaHostIds,
@@ -520,8 +517,7 @@ public class HiveMetaClient {
                 // because this function is a rpc call, we give a fake value now.
                 // Set it to real value, when planner needs this param.
                 new long[] {UNKNOWN_STORAGE_ID},
-                this,
-                splittable);
+                this);
     }
 
     private FileSystem getFileSystem(URI uri) throws IOException {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
@@ -23,6 +23,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.UserException;
 import com.starrocks.external.hive.HdfsFileBlockDesc;
@@ -376,12 +377,59 @@ public class HdfsScanNode extends ScanNode {
 
     private void addScanRangeLocations(long partitionId, HdfsFileDesc fileDesc, HdfsFileBlockDesc blockDesc,
                                        HdfsFileFormat fileFormat) {
+        // NOTE: Config.hive_max_split_size should be extracted to a local variable,
+        // because it may be changed before calling 'splitScanRangeLocations'
+        // and after needSplit has been calculated.
+        long splitSize = Config.hive_max_split_size;
+        boolean needSplit = blockDesc.isSplittable() && blockDesc.getLength() > splitSize;
+        if (needSplit) {
+            splitScanRangeLocations(partitionId, fileDesc, blockDesc, fileFormat, splitSize);
+        } else {
+            createScanRangeLocationsForSplit(partitionId, fileDesc, blockDesc,
+                    fileFormat, blockDesc.getOffset(), blockDesc.getLength());
+        }
+    }
+
+    private void splitScanRangeLocations(long partitionId,
+                                               HdfsFileDesc fileDesc,
+                                               HdfsFileBlockDesc blockDesc,
+                                               HdfsFileFormat fileFormat,
+                                               long splitSize) {
+        long remainingBytes = blockDesc.getLength();
+        long length = blockDesc.getLength();
+        long offset = blockDesc.getOffset();
+        do {
+            if (remainingBytes <= splitSize) {
+                createScanRangeLocationsForSplit(partitionId, fileDesc,
+                        blockDesc, fileFormat, offset + length - remainingBytes, remainingBytes);
+                remainingBytes = 0;
+            } else if (remainingBytes <= 2 * splitSize) {
+                long mid = (remainingBytes + 1) / 2;
+                createScanRangeLocationsForSplit(partitionId, fileDesc,
+                        blockDesc, fileFormat, offset + length - remainingBytes, mid);
+                createScanRangeLocationsForSplit(partitionId, fileDesc,
+                        blockDesc, fileFormat, offset + length - remainingBytes + mid,
+                        remainingBytes - mid);
+                remainingBytes = 0;
+            } else {
+                createScanRangeLocationsForSplit(partitionId, fileDesc,
+                        blockDesc, fileFormat, offset + length - remainingBytes, splitSize);
+                remainingBytes -= splitSize;
+            }
+        } while (remainingBytes > 0);
+    }
+
+    private void createScanRangeLocationsForSplit(long partitionId,
+                                                  HdfsFileDesc fileDesc,
+                                                  HdfsFileBlockDesc blockDesc,
+                                                  HdfsFileFormat fileFormat,
+                                                  long offset, long length) {
         TScanRangeLocations scanRangeLocations = new TScanRangeLocations();
 
         THdfsScanRange hdfsScanRange = new THdfsScanRange();
         hdfsScanRange.setRelative_path(fileDesc.getFileName());
-        hdfsScanRange.setOffset(blockDesc.getOffset());
-        hdfsScanRange.setLength(blockDesc.getLength());
+        hdfsScanRange.setOffset(offset);
+        hdfsScanRange.setLength(length);
         hdfsScanRange.setPartition_id(partitionId);
         hdfsScanRange.setFile_length(fileDesc.getLength());
         hdfsScanRange.setFile_format(fileFormat.toThrift());

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
@@ -381,7 +381,7 @@ public class HdfsScanNode extends ScanNode {
         // because it may be changed before calling 'splitScanRangeLocations'
         // and after needSplit has been calculated.
         long splitSize = Config.hive_max_split_size;
-        boolean needSplit = blockDesc.isSplittable() && blockDesc.getLength() > splitSize;
+        boolean needSplit = fileDesc.isSplittable() && blockDesc.getLength() > splitSize;
         if (needSplit) {
             splitScanRangeLocations(partitionId, fileDesc, blockDesc, fileFormat, splitSize);
         } else {
@@ -391,10 +391,10 @@ public class HdfsScanNode extends ScanNode {
     }
 
     private void splitScanRangeLocations(long partitionId,
-                                               HdfsFileDesc fileDesc,
-                                               HdfsFileBlockDesc blockDesc,
-                                               HdfsFileFormat fileFormat,
-                                               long splitSize) {
+                                         HdfsFileDesc fileDesc,
+                                         HdfsFileBlockDesc blockDesc,
+                                         HdfsFileFormat fileFormat,
+                                         long splitSize) {
         long remainingBytes = blockDesc.getLength();
         long length = blockDesc.getLength();
         long offset = blockDesc.getOffset();


### PR DESCRIPTION
For hdfs block which has large block size. We should split into smaller blocks to increase the degree of parallelism.
We can see in the hadoop code, we may get 'blocklocation' with large block size such as 256MB.
```
  public static BlockLocation[] locatedBlocks2Locations(
      List<LocatedBlock> blocks) {
    if (blocks == null) {
      return new BlockLocation[0];
    }
    int nrBlocks = blocks.size();
    BlockLocation[] blkLocations = new BlockLocation[nrBlocks];
    if (nrBlocks == 0) {
      return blkLocations;
    }
    int idx = 0;
    for (LocatedBlock blk : blocks) {
      assert idx < nrBlocks : "Incorrect index";
      DatanodeInfo[] locations = blk.getLocations();
      String[] hosts = new String[locations.length];
      String[] xferAddrs = new String[locations.length];
      String[] racks = new String[locations.length];
      for (int hCnt = 0; hCnt < locations.length; hCnt++) {
        hosts[hCnt] = locations[hCnt].getHostName();
        xferAddrs[hCnt] = locations[hCnt].getXferAddr();
        NodeBase node = new NodeBase(xferAddrs[hCnt],
                                     locations[hCnt].getNetworkLocation());
        racks[hCnt] = node.toString();
      }
      DatanodeInfo[] cachedLocations = blk.getCachedLocations();
      String[] cachedHosts = new String[cachedLocations.length];
      for (int i=0; i<cachedLocations.length; i++) {
        cachedHosts[i] = cachedLocations[i].getHostName();
      }
      blkLocations[idx] = new BlockLocation(xferAddrs, hosts, cachedHosts,
                                            racks,
                                            blk.getStorageIDs(),
                                            blk.getStorageTypes(),
                                            blk.getStartOffset(),
                                            blk.getBlockSize(),
                                            blk.isCorrupt());
      idx++;
    }
    return blkLocations;
  }
```