### PR TITLE
Enhancement: should skip path check for tablets in trash

### DIFF
--- a/be/src/storage/data_dir.cpp
+++ b/be/src/storage/data_dir.cpp
@@ -569,7 +569,7 @@ void DataDir::perform_path_gc_by_tablet() {
             LOG(WARNING) << "invalid tablet id " << tablet_id << " or schema hash " << schema_hash << ", path=" << path;
             continue;
         }
-        TabletSharedPtr tablet = _tablet_manager->get_tablet(tablet_id, false);
+        TabletSharedPtr tablet = _tablet_manager->get_tablet(tablet_id, true);
         if (tablet != nullptr) {
             // could find the tablet, then skip check it
             continue;


### PR DESCRIPTION
`perform_path_gc_by_tablet` will do the following steps to decide whether a tablet directory can be removed:
1. Call `TabletManager::get_tablet` if see if the tablet is resident in memory and if so, skip deleting the directory
2. Read the RocksDB to see if the tablet meta exist in RocksDB and if so, skip deleting the directory
3. All above checks passed, begin to delete the directory.

For an already-dropped tablet but with its meta still existing in RocksDB, if we pass false as the second argument of `TabletManager::get_tablet`, the first two steps are required to do, but if we pass true as the second argument, only
 the first step is needed.