### PR TITLE
support to access parquet boolean column

### DIFF
--- a/be/src/exec/parquet/column_reader.cpp
+++ b/be/src/exec/parquet/column_reader.cpp
@@ -399,6 +399,12 @@ Status ScalarColumnReader::_init_convert_info() {
     // but when we insert value into `col0`, the physical type in parquet file is actually `INT32`
     // so when we read `col0` from parquet file, we have to do a type conversion from int32_t to int8_t.
     switch (parquet_type) {
+    case tparquet::Type::type::BOOLEAN: {
+        if (col_type != PrimitiveType::TYPE_BOOLEAN) {
+            _need_convert = true;
+        }
+        break;
+    }
     case tparquet::Type::type::INT32: {
         if (col_type != PrimitiveType::TYPE_INT) {
             _need_convert = true;

--- a/be/src/exec/parquet/encoding.cpp
+++ b/be/src/exec/parquet/encoding.cpp
@@ -90,6 +90,8 @@ private:
 };
 
 EncodingInfoResolver::EncodingInfoResolver() {
+    // BOOL
+    _add_map<tparquet::Type::BOOLEAN, tparquet::Encoding::PLAIN>();
     // INT32
     _add_map<tparquet::Type::INT32, tparquet::Encoding::PLAIN>();
     _add_map<tparquet::Type::INT32, tparquet::Encoding::RLE_DICTIONARY>();


### PR DESCRIPTION
This PR only supports accessing the boolean column encoded in plan encoding format.  But maybe there are more encodings for boolean column.

issue: #https://github.com/StarRocks/starrocks/issues/1200