### PR TITLE
Advance the time point of triggering the next scan task

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -633,7 +633,7 @@ CONF_Int64(pipeline_io_thread_pool_thread_num, "3");
 CONF_Int64(pipeline_io_thread_pool_queue_size, "102400");
 // the number of execution threads for pipeline engine.
 CONF_Int64(pipeline_exec_thread_pool_thread_num, "3");
-// the cache size of io task
+// the buffer size of io task
 CONF_Int64(pipeline_io_buffer_size, "64");
 // bitmap serialize version
 CONF_Int16(bitmap_serialize_version, "1");

--- a/be/src/exec/pipeline/chunk_source.h
+++ b/be/src/exec/pipeline/chunk_source.h
@@ -30,9 +30,11 @@ public:
     // Whether cache is empty or not
     virtual bool has_output() const = 0;
 
-    virtual StatusOr<vectorized::ChunkPtr> get_next_chunk_from_cache() = 0;
+    virtual size_t get_buffer_size() const = 0;
 
-    virtual Status cache_next_batch_chunks_blocking(size_t batch_size, bool& can_finish) = 0;
+    virtual StatusOr<vectorized::ChunkPtr> get_next_chunk_from_buffer() = 0;
+
+    virtual Status buffer_next_batch_chunks_blocking(size_t batch_size, bool& can_finish) = 0;
 
 protected:
     // The morsel will own by pipeline driver

--- a/be/src/exec/pipeline/olap_chunk_source.h
+++ b/be/src/exec/pipeline/olap_chunk_source.h
@@ -49,9 +49,11 @@ public:
 
     bool has_output() const override;
 
-    StatusOr<vectorized::ChunkPtr> get_next_chunk_from_cache() override;
+    virtual size_t get_buffer_size() const override;
 
-    Status cache_next_batch_chunks_blocking(size_t batch_size, bool& can_finish) override;
+    StatusOr<vectorized::ChunkPtr> get_next_chunk_from_buffer() override;
+
+    Status buffer_next_batch_chunks_blocking(size_t batch_size, bool& can_finish) override;
 
 private:
     Status _get_tablet(const TInternalScanRange* scan_range);
@@ -76,7 +78,7 @@ private:
     TInternalScanRange* _scan_range;
 
     Status _status = Status::OK();
-    UnboundedBlockingQueue<vectorized::ChunkPtr> _chunk_cache;
+    UnboundedBlockingQueue<vectorized::ChunkPtr> _chunk_buffer;
     // The conjuncts couldn't push down to storage engine
     std::vector<ExprContext*> _not_push_down_conjuncts;
     vectorized::ConjunctivePredicates _not_push_down_predicates;


### PR DESCRIPTION
Currently, scan operator trigger scan task when buffer is empty, in some cases, which may cause greater delay.

And the solution is relatively simple, we try to trigger next scan task as long as buffer's size reaches its threshold(half of batch size)