### PR TITLE
[ISSUE-1135] Join poller thread

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver_poller.h
+++ b/be/src/exec/pipeline/pipeline_driver_poller.h
@@ -44,7 +44,7 @@ private:
     std::condition_variable _cond;
     DriverList _blocked_drivers;
     DriverQueue* _dispatch_queue;
-    Thread* _polling_thread;
+    scoped_refptr<Thread> _polling_thread;
     std::atomic<bool> _is_polling_thread_initialized;
     std::atomic<bool> _is_shutdown;
 };


### PR DESCRIPTION
## bugfix

Join poller threads in destructor of PipelineDriverPoller to prevent poller thread from accessing deallocated _shutdown.