### PR TITLE
[ISSUE-1162] HashJoin parallelization in the pipeline engine

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -172,6 +172,7 @@ set(EXEC_FILES
     pipeline/set/union_const_source_operator.cpp
     pipeline/hashjoin/hash_join_build_operator.cpp
     pipeline/hashjoin/hash_join_probe_operator.cpp
+    pipeline/hashjoin/hash_joiner_factory.cpp
     pipeline/set/except_context.cpp
     pipeline/set/except_build_sink_operator.cpp
     pipeline/set/except_probe_sink_operator.cpp

--- a/be/src/exec/pipeline/hashjoin/hash_join_build_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/hash_join_build_operator.cpp
@@ -6,12 +6,20 @@ namespace starrocks {
 namespace pipeline {
 
 HashJoinBuildOperator::HashJoinBuildOperator(int32_t id, const string& name, int32_t plan_node_id,
-                                             HashJoiner* hash_joiner)
+                                             HashJoinerPtr hash_joiner)
         : Operator(id, name, plan_node_id), _hash_joiner(hash_joiner) {}
 Status HashJoinBuildOperator::push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) {
     return _hash_joiner->append_chunk_to_ht(state, chunk);
 }
 
+Status HashJoinBuildOperator::prepare(RuntimeState* state) {
+    RETURN_IF_ERROR(Operator::prepare(state));
+    return _hash_joiner->prepare(state);
+}
+Status HashJoinBuildOperator::close(RuntimeState* state) {
+    _hash_joiner->close(state);
+    return Operator::close(state);
+}
 StatusOr<vectorized::ChunkPtr> HashJoinBuildOperator::pull_chunk(RuntimeState* state) {
     const char* msg = "pull_chunk not supported in HashJoinBuildOperator";
     CHECK(false) << msg;
@@ -25,21 +33,23 @@ void HashJoinBuildOperator::set_finishing(RuntimeState* state) {
     }
 }
 
-HashJoinBuildOperatorFactory::HashJoinBuildOperatorFactory(int32_t id, int32_t plan_node_id, HashJoiner* hash_joiner)
-        : OperatorFactory(id, "hash_join_build", plan_node_id), _hash_joiner(hash_joiner) {}
+HashJoinBuildOperatorFactory::HashJoinBuildOperatorFactory(int32_t id, int32_t plan_node_id,
+                                                           HashJoinerFactoryPtr hash_joiner_factory)
+        : OperatorFactory(id, "hash_join_build", plan_node_id), _hash_joiner_factory(hash_joiner_factory) {}
 
 Status HashJoinBuildOperatorFactory::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(OperatorFactory::prepare(state));
-    return _hash_joiner->prepare(state);
+    return _hash_joiner_factory->prepare(state);
 }
 
 void HashJoinBuildOperatorFactory::close(RuntimeState* state) {
-    _hash_joiner->close(state);
+    _hash_joiner_factory->close(state);
     OperatorFactory::close(state);
 }
 
 OperatorPtr HashJoinBuildOperatorFactory::create(int32_t degree_of_parallelism, int32_t driver_sequence) {
-    return std::make_shared<HashJoinBuildOperator>(_id, _name, _plan_node_id, _hash_joiner);
+    return std::make_shared<HashJoinBuildOperator>(_id, _name, _plan_node_id,
+                                                   _hash_joiner_factory->create(driver_sequence));
 }
 } // namespace pipeline
 } // namespace starrocks

--- a/be/src/exec/pipeline/hashjoin/hash_join_build_operator.h
+++ b/be/src/exec/pipeline/hashjoin/hash_join_build_operator.h
@@ -1,6 +1,7 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
 
 #pragma once
+#include "exec/pipeline/hashjoin/hash_joiner_factory.h"
 #include "exec/pipeline/operator.h"
 #include "exec/pipeline/pipeline_fwd.h"
 #include "exec/vectorized/hash_joiner.h"
@@ -12,10 +13,10 @@ namespace pipeline {
 using HashJoiner = starrocks::vectorized::HashJoiner;
 class HashJoinBuildOperator final : public Operator {
 public:
-    HashJoinBuildOperator(int32_t id, const string& name, int32_t plan_node_id, HashJoiner* hash_joiner);
+    HashJoinBuildOperator(int32_t id, const string& name, int32_t plan_node_id, HashJoinerPtr hash_joiner);
     ~HashJoinBuildOperator() = default;
-    Status prepare(RuntimeState* state) override { return Operator::prepare(state); };
-    Status close(RuntimeState* state) override { return Operator::close(state); };
+    Status prepare(RuntimeState* state) override;
+    Status close(RuntimeState* state) override;
 
     bool has_output() const override {
         CHECK(false) << "has_output not supported in HashJoinBuildOperator";
@@ -31,19 +32,19 @@ public:
     void set_finishing(RuntimeState* state) override;
 
 private:
-    HashJoiner* _hash_joiner;
+    HashJoinerPtr _hash_joiner;
     bool _is_finished = false;
 };
 class HashJoinBuildOperatorFactory final : public OperatorFactory {
 public:
-    HashJoinBuildOperatorFactory(int32_t id, int32_t plan_node_id, HashJoiner* hash_joiner);
+    HashJoinBuildOperatorFactory(int32_t id, int32_t plan_node_id, HashJoinerFactoryPtr hash_joiner_factory);
     ~HashJoinBuildOperatorFactory() = default;
     Status prepare(RuntimeState* state) override;
     void close(RuntimeState* state) override;
     OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override;
 
 private:
-    HashJoiner* _hash_joiner;
+    HashJoinerFactoryPtr _hash_joiner_factory;
 };
 } // namespace pipeline
 } // namespace starrocks

--- a/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.cpp
@@ -5,7 +5,7 @@
 namespace starrocks {
 namespace pipeline {
 HashJoinProbeOperator::HashJoinProbeOperator(int32_t id, const string& name, int32_t plan_node_id,
-                                             HashJoiner* hash_joiner)
+                                             HashJoinerPtr hash_joiner)
         : OperatorWithDependency(id, name, plan_node_id), _hash_joiner(hash_joiner) {}
 
 bool HashJoinProbeOperator::has_output() const {
@@ -41,8 +41,8 @@ bool HashJoinProbeOperator::is_ready() const {
 }
 
 HashJoinProbeOperatorFactory::HashJoinProbeOperatorFactory(int32_t id, int32_t plan_node_id,
-                                                           std::unique_ptr<HashJoiner>&& hash_joiner)
-        : OperatorFactory(id, "hash_join_probe", plan_node_id), _hash_joiner(std::move(hash_joiner)) {}
+                                                           HashJoinerFactoryPtr hash_joiner_factory)
+        : OperatorFactory(id, "hash_join_probe", plan_node_id), _hash_joiner_factory(hash_joiner_factory) {}
 
 Status HashJoinProbeOperatorFactory::prepare(RuntimeState* state) {
     return OperatorFactory::prepare(state);
@@ -52,7 +52,8 @@ void HashJoinProbeOperatorFactory::close(RuntimeState* state) {
 }
 
 OperatorPtr HashJoinProbeOperatorFactory::create(int32_t degree_of_parallelism, int32_t driver_sequence) {
-    return std::make_shared<HashJoinProbeOperator>(_id, _name, _plan_node_id, _hash_joiner.get());
+    return std::make_shared<HashJoinProbeOperator>(_id, _name, _plan_node_id,
+                                                   _hash_joiner_factory->create(driver_sequence));
 }
 
 } // namespace pipeline

--- a/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.h
+++ b/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "exec/pipeline/hashjoin/hash_joiner_factory.h"
 #include "exec/pipeline/operator.h"
 #include "exec/pipeline/operator_with_dependency.h"
 #include "exec/pipeline/pipeline_fwd.h"
@@ -11,7 +12,7 @@ namespace pipeline {
 using HashJoiner = starrocks::vectorized::HashJoiner;
 class HashJoinProbeOperator final : public OperatorWithDependency {
 public:
-    HashJoinProbeOperator(int32_t id, const string& name, int32_t plan_node_id, HashJoiner* hash_joiner);
+    HashJoinProbeOperator(int32_t id, const string& name, int32_t plan_node_id, HashJoinerPtr hash_joiner);
     ~HashJoinProbeOperator() = default;
 
     Status prepare(RuntimeState* state) override { return OperatorWithDependency::prepare(state); }
@@ -27,13 +28,13 @@ public:
     bool is_ready() const override;
 
 private:
-    HashJoiner* _hash_joiner;
+    HashJoinerPtr _hash_joiner;
     bool _is_finished = false;
 };
 
 class HashJoinProbeOperatorFactory final : public OperatorFactory {
 public:
-    HashJoinProbeOperatorFactory(int32_t id, int32_t plan_node_id, std::unique_ptr<HashJoiner>&& hash_joiner);
+    HashJoinProbeOperatorFactory(int32_t id, int32_t plan_node_id, HashJoinerFactoryPtr hash_joiner);
 
     ~HashJoinProbeOperatorFactory() = default;
 
@@ -43,7 +44,7 @@ public:
     OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override;
 
 private:
-    std::unique_ptr<HashJoiner> _hash_joiner;
+    HashJoinerFactoryPtr _hash_joiner_factory;
 };
 } // namespace pipeline
 } // namespace starrocks

--- a/be/src/exec/pipeline/hashjoin/hash_joiner_factory.cpp
+++ b/be/src/exec/pipeline/hashjoin/hash_joiner_factory.cpp
@@ -1,0 +1,27 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#include "exec/pipeline/hashjoin/hash_joiner_factory.h"
+
+namespace starrocks {
+namespace pipeline {
+Status HashJoinerFactory::prepare(RuntimeState* state) {
+    RETURN_IF_ERROR(Expr::prepare(_build_expr_ctxs, state, _build_row_descriptor));
+    RETURN_IF_ERROR(Expr::prepare(_probe_expr_ctxs, state, _probe_row_descriptor));
+    RETURN_IF_ERROR(Expr::prepare(_other_join_conjunct_ctxs, state, _row_descriptor));
+    RETURN_IF_ERROR(Expr::prepare(_conjunct_ctxs, state, _row_descriptor));
+    RETURN_IF_ERROR(Expr::open(_build_expr_ctxs, state));
+    RETURN_IF_ERROR(Expr::open(_probe_expr_ctxs, state));
+    RETURN_IF_ERROR(Expr::open(_other_join_conjunct_ctxs, state));
+    RETURN_IF_ERROR(Expr::open(_conjunct_ctxs, state));
+    return Status::OK();
+}
+
+void HashJoinerFactory::close(RuntimeState* state) {
+    Expr::close(_conjunct_ctxs, state);
+    Expr::close(_other_join_conjunct_ctxs, state);
+    Expr::close(_probe_expr_ctxs, state);
+    Expr::close(_build_expr_ctxs, state);
+}
+
+} // namespace pipeline
+} // namespace starrocks

--- a/be/src/exec/pipeline/hashjoin/hash_joiner_factory.h
+++ b/be/src/exec/pipeline/hashjoin/hash_joiner_factory.h
@@ -1,0 +1,65 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#pragma once
+#include <memory>
+#include <vector>
+
+#include "exec/vectorized/hash_joiner.h"
+namespace starrocks {
+namespace pipeline {
+using HashJoiner = starrocks::vectorized::HashJoiner;
+using HashJoinerPtr = std::shared_ptr<HashJoiner>;
+using HashJoiners = std::vector<HashJoinerPtr>;
+class HashJoinerFactory;
+using HashJoinerFactoryPtr = std::shared_ptr<HashJoinerFactory>;
+class HashJoinerFactory {
+public:
+    HashJoinerFactory(const THashJoinNode& hash_join_node, TPlanNodeId node_id, TPlanNodeType::type node_type,
+                      int64_t limit, std::vector<bool>&& is_null_safes, std::vector<ExprContext*> build_expr_ctxs,
+                      std::vector<ExprContext*> probe_expr_ctxs, std::vector<ExprContext*>&& other_join_conjunct_ctxs,
+                      std::vector<ExprContext*>&& conjunct_ctxs, const RowDescriptor& build_row_descriptor,
+                      const RowDescriptor& probe_row_descriptor, const RowDescriptor& row_descriptor, int dop)
+            : _hash_join_node(hash_join_node),
+              _node_id(node_id),
+              _node_type(node_type),
+              _limit(limit),
+              _is_null_safes(std::move(is_null_safes)),
+              _build_expr_ctxs(std::move(build_expr_ctxs)),
+              _probe_expr_ctxs(std::move(probe_expr_ctxs)),
+              _other_join_conjunct_ctxs(std::move(other_join_conjunct_ctxs)),
+              _conjunct_ctxs(std::move(conjunct_ctxs)),
+              _build_row_descriptor(build_row_descriptor),
+              _probe_row_descriptor(probe_row_descriptor),
+              _row_descriptor(row_descriptor),
+              _hash_joiners(dop) {}
+
+    Status prepare(RuntimeState* state);
+    void close(RuntimeState* state);
+
+    HashJoinerPtr create(int i) {
+        if (!_hash_joiners[i]) {
+            _hash_joiners[i] = std::make_shared<HashJoiner>(
+                    _hash_join_node, _node_id, _node_type, _limit, _is_null_safes, _build_expr_ctxs, _probe_expr_ctxs,
+                    _other_join_conjunct_ctxs, _conjunct_ctxs, _build_row_descriptor, _probe_row_descriptor,
+                    _row_descriptor);
+        }
+        return _hash_joiners[i];
+    }
+
+private:
+    const THashJoinNode& _hash_join_node;
+    TPlanNodeId _node_id;
+    TPlanNodeType::type _node_type;
+    int64_t _limit;
+    std::vector<bool> _is_null_safes;
+    std::vector<ExprContext*> _build_expr_ctxs;
+    std::vector<ExprContext*> _probe_expr_ctxs;
+    std::vector<ExprContext*> _other_join_conjunct_ctxs;
+    std::vector<ExprContext*> _conjunct_ctxs;
+    const RowDescriptor _build_row_descriptor;
+    const RowDescriptor _probe_row_descriptor;
+    const RowDescriptor _row_descriptor;
+    HashJoiners _hash_joiners;
+};
+} // namespace pipeline
+} // namespace starrocks

--- a/be/src/exec/vectorized/hash_joiner.h
+++ b/be/src/exec/vectorized/hash_joiner.h
@@ -40,9 +40,10 @@ enum HashJoinPhase {
 class HashJoiner {
 public:
     HashJoiner(const THashJoinNode& hash_join_node, TPlanNodeId node_id, TPlanNodeType::type node_type, int64_t limit,
-               std::vector<bool>&& is_null_safes, std::vector<ExprContext*>&& build_expr_ctxs,
-               std::vector<ExprContext*>&& probe_expr_ctxs, std::vector<ExprContext*>&& other_join_conjunct_ctxs,
-               std::vector<ExprContext*>&& conjunct_ctxs, const RowDescriptor& build_row_descriptor,
+               const std::vector<bool>& is_null_safes, const std::vector<ExprContext*>& build_expr_ctxs,
+               const std::vector<ExprContext*>& probe_expr_ctxs,
+               const std::vector<ExprContext*>& other_join_conjunct_ctxs,
+               const std::vector<ExprContext*>& conjunct_ctxs, const RowDescriptor& build_row_descriptor,
                const RowDescriptor& probe_row_descriptor, const RowDescriptor& row_descriptor);
 
     ~HashJoiner() = default;
@@ -219,14 +220,14 @@ private:
     ChunkPtr _buffered_probe_output_chunk;
     ChunkPtr _probe_output_chunk;
 
-    std::vector<bool> _is_null_safes;
-    std::vector<ExprContext*> _build_expr_ctxs;
-    std::vector<ExprContext*> _probe_expr_ctxs;
-    std::vector<ExprContext*> _other_join_conjunct_ctxs;
-    std::vector<ExprContext*> _conjunct_ctxs;
-    RowDescriptor _build_row_descriptor;
-    RowDescriptor _probe_row_descriptor;
-    RowDescriptor _row_descriptor;
+    const std::vector<bool>& _is_null_safes;
+    const std::vector<ExprContext*>& _build_expr_ctxs;
+    const std::vector<ExprContext*>& _probe_expr_ctxs;
+    const std::vector<ExprContext*>& _other_join_conjunct_ctxs;
+    const std::vector<ExprContext*>& _conjunct_ctxs;
+    const RowDescriptor& _build_row_descriptor;
+    const RowDescriptor& _probe_row_descriptor;
+    const RowDescriptor& _row_descriptor;
 
     std::list<ExprContext*> _runtime_in_filters;
     std::list<RuntimeFilterBuildDescriptor*> _build_runtime_filters;


### PR DESCRIPTION
## Changes

Both probe side and build side of a HashJoin are partitioned by a LocalShuffle operator, then multiple HashJoin instances are executed parallelly on different sub-partitions.