### PR TITLE
Optimize: remove some unneeded checks when moving tablet to trash

### DIFF
--- a/be/src/storage/base_tablet.cpp
+++ b/be/src/storage/base_tablet.cpp
@@ -54,4 +54,8 @@ void BaseTablet::_gen_tablet_path() {
     }
 }
 
+std::string BaseTablet::tablet_id_path() const {
+    return _tablet_path.substr(0, _tablet_path.rfind('/'));
+}
+
 } /* namespace starrocks */

--- a/be/src/storage/base_tablet.h
+++ b/be/src/storage/base_tablet.h
@@ -43,7 +43,21 @@ public:
 
     inline DataDir* data_dir() const;
 
-    // TODO: may be schema_hash_path() is a more accurate name?
+    // A tablet's data are stored in disk files under a directory with structure like:
+    //   ${storage_root_path}/${shard_number}/${tablet_id}/${schema_hash}
+    //
+    // The reason why create a directory ${schema_hash} under the directory ${tablet_id} is that in some very
+    // earlier versions of Doris(https://github.com/apache/incubator-doris), it's possible to have multiple
+    // tablets with the same tablet id but different schema hash, therefore the schema hash is constructed as
+    // part of the data path of a tablet to distinguish each other.
+    // The design that multiple tablets can share the same tablet id has been dropped by Doris, but the directory
+    // structure has been kept.
+    // Since StarRocks is built on earlier work on Doris, this directory structure has been kept in StarRocks too.
+    //
+    // `tablet_path()` returns the full path of the directory ${schema_hash}.
+    // `tablet_id_path()` returns the full path of the directory ${tablet_id}.
+    //
+    // TODO: rename `tablet_path()` to `schema_hash_path()`.
     const std::string& tablet_path() const;
 
     std::string tablet_id_path() const;

--- a/be/src/storage/base_tablet.h
+++ b/be/src/storage/base_tablet.h
@@ -42,7 +42,11 @@ public:
     virtual ~BaseTablet() = default;
 
     inline DataDir* data_dir() const;
+
+    // TODO: may be schema_hash_path() is a more accurate name?
     const std::string& tablet_path() const;
+
+    std::string tablet_id_path() const;
 
     TabletState tablet_state() const { return _state; }
     OLAPStatus set_tablet_state(TabletState state);

--- a/be/src/storage/data_dir.cpp
+++ b/be/src/storage/data_dir.cpp
@@ -574,15 +574,16 @@ void DataDir::perform_path_gc_by_tablet() {
             // could find the tablet, then skip check it
             continue;
         }
-        std::filesystem::path tablet_path(path);
-        std::filesystem::path data_dir_path = tablet_path.parent_path().parent_path().parent_path().parent_path();
+        std::filesystem::path schema_hash_path(path);
+        std::filesystem::path tablet_id_path = schema_hash_path.parent_path();
+        std::filesystem::path data_dir_path = tablet_id_path.parent_path().parent_path().parent_path();
         std::string data_dir_string = data_dir_path.string();
         DataDir* data_dir = StorageEngine::instance()->get_store(data_dir_string);
         if (data_dir == nullptr) {
             LOG(WARNING) << "could not find data dir for tablet path " << path;
             continue;
         }
-        _tablet_manager->try_delete_unused_tablet_path(data_dir, tablet_id, schema_hash, path);
+        _tablet_manager->try_delete_unused_tablet_path(data_dir, tablet_id, schema_hash, tablet_id_path.string());
     }
     _all_tablet_schemahash_paths.clear();
     LOG(INFO) << "finished one time path gc by tablet.";

--- a/be/src/storage/snapshot_manager.cpp
+++ b/be/src/storage/snapshot_manager.cpp
@@ -275,7 +275,7 @@ Status SnapshotManager::_rename_rowset_id(const RowsetMetaPB& rs_meta_pb, const 
 std::string SnapshotManager::_calc_snapshot_id_path(const TabletSharedPtr& tablet, int64_t timeout_s) {
     // get current timestamp string
     string time_str;
-    if (gen_timestamp_string(&time_str) != OLAP_SUCCESS) {
+    if (!gen_timestamp_string(&time_str).ok()) {
         LOG(WARNING) << "Fail to gen_timestamp_string";
         return "";
     }

--- a/be/src/storage/tablet_manager.h
+++ b/be/src/storage/tablet_manager.h
@@ -121,7 +121,7 @@ public:
     bool try_schema_change_lock(TTabletId tablet_id);
 
     void try_delete_unused_tablet_path(DataDir* data_dir, TTabletId tablet_id, SchemaHash schema_hash,
-                                       const string& schema_hash_path);
+                                       const string& tablet_id_path);
 
     void update_root_path_info(std::map<std::string, DataDirInfo>* path_map, size_t* tablet_counter);
 

--- a/be/src/storage/utils.cpp
+++ b/be/src/storage/utils.cpp
@@ -21,13 +21,17 @@
 
 #include "storage/utils.h"
 
+#include <bvar/bvar.h>
 #include <dirent.h>
+#include <fmt/format.h>
 #include <lz4/lz4.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include <atomic>
 #include <boost/regex.hpp>
 #include <cerrno>
+#include <chrono>
 #include <cstdarg>
 #include <cstdint>
 #include <cstdio>
@@ -54,87 +58,59 @@ using std::vector;
 
 namespace starrocks {
 
+static bvar::LatencyRecorder g_move_trash("starrocks", "move_to_trash");
+
 uint32_t olap_adler32(uint32_t adler, const char* buf, size_t len) {
     return adler32(adler, reinterpret_cast<const Bytef*>(buf), len);
 }
 
-OLAPStatus gen_timestamp_string(string* out_string) {
+Status gen_timestamp_string(string* out_string) {
     time_t now = time(nullptr);
     tm local_tm;
 
     if (localtime_r(&now, &local_tm) == nullptr) {
-        LOG(WARNING) << "fail to localtime_r time. time=" << now;
-        return OLAP_ERR_OS_ERROR;
+        return Status::InternalError("localtime_r", static_cast<int16_t>(errno), std::strerror(errno));
     }
     char time_suffix[16] = {0}; // Example: 20150706111404
     if (strftime(time_suffix, sizeof(time_suffix), "%Y%m%d%H%M%S", &local_tm) == 0) {
-        LOG(WARNING) << "fail to strftime time. time=" << now;
-        return OLAP_ERR_OS_ERROR;
+        return Status::InternalError("localtime_r", static_cast<int16_t>(errno), std::strerror(errno));
     }
 
     *out_string = time_suffix;
-    return OLAP_SUCCESS;
+    return Status::OK();
 }
 
-OLAPStatus move_to_trash(const std::filesystem::path& schema_hash_root, const std::filesystem::path& file_path) {
-    OLAPStatus res = OLAP_SUCCESS;
-    string old_file_path = file_path.string();
-    string old_file_name = file_path.filename().string();
-    string storage_root = schema_hash_root
-                                  .parent_path() // tablet_path
-                                  .parent_path() // shard_path
-                                  .parent_path() // DATA_PREFIX
-                                  .parent_path() // storage_root
-                                  .string();
+Status move_to_trash(const std::filesystem::path& file_path) {
+    static std::atomic<uint64_t> delete_counter{0}; // a global counter to avoid file name duplication.
+
+    auto t0 = std::chrono::steady_clock::now();
+
+    std::string old_file_path = file_path.string();
+    std::string old_file_name = file_path.filename().string();
+    std::string storage_root = file_path
+                                       .parent_path() // shard_path
+                                       .parent_path() // DATA_PREFIX
+                                       .parent_path() // storage_root
+                                       .string();
 
     // 1. get timestamp string
-    string time_str;
-    if ((res = gen_timestamp_string(&time_str)) != OLAP_SUCCESS) {
-        LOG(WARNING) << "failed to generate time_string when move file to trash. err code=" << res;
-        return res;
-    }
+    std::string time_str;
+    RETURN_IF_ERROR(gen_timestamp_string(&time_str));
 
-    // 2. generate new file path
-    static uint64_t delete_counter = 0; // a global counter to avoid file name duplication.
-    static std::mutex lock;             // lock for delete_counter
-    std::stringstream new_file_dir_stream;
-    lock.lock();
-    // when file_path points to a schema_path, we need to save tablet info in trash_path,
-    // so we add file_path.parent_path().filename() in new_file_path.
-    // other conditions are not considered, for they are nothing serious.
-    new_file_dir_stream << storage_root << TRASH_PREFIX << "/" << time_str << "." << delete_counter++ << "/"
-                        << file_path.parent_path().filename().string();
-    lock.unlock();
-    string new_file_dir = new_file_dir_stream.str();
-    string new_file_path = new_file_dir + "/" + old_file_name;
-    // create target dir, or the rename() function will fail.
-    if (!FileUtils::check_exist(new_file_dir) && !FileUtils::create_dir(new_file_dir).ok()) {
-        LOG(WARNING) << "delete file failed. due to mkdir failed. file=" << old_file_path
-                     << " new_dir=" << new_file_dir;
-        return OLAP_ERR_OS_ERROR;
+    std::string new_file_dir = fmt::format("{}{}/{}.{}/", storage_root, TRASH_PREFIX, time_str,
+                                           delete_counter.fetch_add(1, std::memory_order_relaxed));
+    std::string new_file_path = fmt::format("{}/{}", new_file_dir, old_file_name);
+    // 2. create target dir, or the rename() function will fail.
+    if (auto st = Env::Default()->create_dir(new_file_dir); !st.ok()) {
+        // May be because the parent directory does not exist, try create directories recursively.
+        RETURN_IF_ERROR(FileUtils::create_dir(new_file_dir));
     }
 
     // 3. remove file to trash
-    VLOG(3) << "move file to trash. " << old_file_path << " -> " << new_file_path;
-    if (rename(old_file_path.c_str(), new_file_path.c_str()) < 0) {
-        LOG(WARNING) << "move file to trash failed. file=" << old_file_path << " target=" << new_file_path;
-        return OLAP_ERR_OS_ERROR;
-    }
-
-    // 4. check parent dir of source file, delete it when empty
-    string source_parent_dir = schema_hash_root.parent_path().string(); // tablet_id level
-    std::set<std::string> sub_dirs, sub_files;
-
-    RETURN_CODE_IF_ERROR_WITH_WARN(FileUtils::list_dirs_files(source_parent_dir, &sub_dirs, &sub_files, Env::Default()),
-                                   OLAP_SUCCESS, "access dir failed. [dir=" + source_parent_dir + "].");
-
-    if (sub_dirs.empty() && sub_files.empty()) {
-        LOG(INFO) << "remove empty dir " << source_parent_dir;
-        // no need to exam return status
-        Env::Default()->delete_dir(source_parent_dir);
-    }
-
-    return OLAP_SUCCESS;
+    auto st = Env::Default()->rename_file(old_file_path, new_file_path);
+    auto t1 = std::chrono::steady_clock::now();
+    g_move_trash << std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count();
+    return st;
 }
 
 OLAPStatus copy_file(const string& src, const string& dest) {

--- a/be/src/storage/utils.h
+++ b/be/src/storage/utils.h
@@ -40,6 +40,7 @@
 #include <vector>
 
 #include "common/logging.h"
+#include "common/status.h"
 #if defined(__i386) || defined(__x86_64__)
 #include "storage/bhp_lib.h"
 #endif
@@ -71,10 +72,10 @@ private:
 #define ADLER32_INIT adler32(0L, Z_NULL, 0)
 uint32_t olap_adler32(uint32_t adler, const char* buf, size_t len);
 
-OLAPStatus gen_timestamp_string(std::string* out_string);
+Status gen_timestamp_string(std::string* out_string);
 
 // move file to storage_root/trash, file can be a directory
-OLAPStatus move_to_trash(const std::filesystem::path& schema_hash_root, const std::filesystem::path& file_path);
+Status move_to_trash(const std::filesystem::path& tablet_id_path);
 
 OLAPStatus copy_file(const std::string& src, const std::string& dest);
 

--- a/be/src/util/file_utils.cpp
+++ b/be/src/util/file_utils.cpp
@@ -51,33 +51,10 @@ Status FileUtils::create_dir(const std::string& path, Env* env) {
 
     std::string partial_path;
     for (const auto& it : p) {
-        partial_path = partial_path + it.string() + "/";
-        bool is_dir = false;
-
-        Status s = env->is_directory(partial_path, &is_dir);
-
-        if (s.ok()) {
-            if (is_dir) {
-                // It's a normal directory.
-                continue;
-            }
-
-            // Maybe a file or a symlink. Let's try to follow the symlink.
-            std::string real_partial_path;
-            RETURN_IF_ERROR(env->canonicalize(partial_path, &real_partial_path));
-
-            RETURN_IF_ERROR(env->is_directory(real_partial_path, &is_dir));
-            if (is_dir) {
-                // It's a symlink to a directory.
-                continue;
-            } else {
-                return Status::IOError(partial_path + " exists but is not a directory");
-            }
-        }
-
+        partial_path.append(it.string());
+        partial_path.append("/");
         RETURN_IF_ERROR(env->create_dir_if_missing(partial_path));
     }
-
     return Status::OK();
 }
 

--- a/be/test/storage/tablet_meta_manager_test.cpp
+++ b/be/test/storage/tablet_meta_manager_test.cpp
@@ -17,6 +17,7 @@ protected:
     void SetUp() override {
         fs::path tmp = fs::temp_directory_path();
         fs::path dir = tmp / "tablet_meta_manager_test";
+        fs::remove_all(dir);
         CHECK(fs::create_directory(dir));
         _data_dir = std::make_unique<DataDir>(dir.string());
         Status st = _data_dir->init();


### PR DESCRIPTION
1. There is no need for `FileUtils::create_dir()` to check if the parent directory exists.
2. There is no need to check if a directory is empty before removing it.
3. There is no need to call `FileUtils::create_dir` in most cases to create the tablet trash directory.
4. There is no need to check whether a directory exists before moving it to the trash.