### PR TITLE
Fix the bug of recvr mem statistics

### DIFF
--- a/be/src/runtime/data_stream_mgr.cpp
+++ b/be/src/runtime/data_stream_mgr.cpp
@@ -60,7 +60,7 @@ std::shared_ptr<DataStreamRecvr> DataStreamMgr::create_recvr(
     DCHECK(profile != nullptr);
     VLOG_FILE << "creating receiver for fragment=" << fragment_instance_id << ", node=" << dest_node_id;
     std::shared_ptr<DataStreamRecvr> recvr(new DataStreamRecvr(
-            this, state->instance_mem_tracker(), row_desc, fragment_instance_id, dest_node_id, num_senders, is_merging,
+            this, state, row_desc, fragment_instance_id, dest_node_id, num_senders, is_merging,
             buffer_size, profile, std::move(sub_plan_query_statistics_recvr), is_pipeline));
     uint32_t hash_value = get_hash_value(fragment_instance_id, dest_node_id);
     std::lock_guard<std::mutex> l(_lock);

--- a/be/src/runtime/data_stream_mgr.cpp
+++ b/be/src/runtime/data_stream_mgr.cpp
@@ -59,9 +59,9 @@ std::shared_ptr<DataStreamRecvr> DataStreamMgr::create_recvr(
         bool is_merging, std::shared_ptr<QueryStatisticsRecvr> sub_plan_query_statistics_recvr, bool is_pipeline) {
     DCHECK(profile != nullptr);
     VLOG_FILE << "creating receiver for fragment=" << fragment_instance_id << ", node=" << dest_node_id;
-    std::shared_ptr<DataStreamRecvr> recvr(new DataStreamRecvr(
-            this, state, row_desc, fragment_instance_id, dest_node_id, num_senders, is_merging,
-            buffer_size, profile, std::move(sub_plan_query_statistics_recvr), is_pipeline));
+    std::shared_ptr<DataStreamRecvr> recvr(
+            new DataStreamRecvr(this, state, row_desc, fragment_instance_id, dest_node_id, num_senders, is_merging,
+                                buffer_size, profile, std::move(sub_plan_query_statistics_recvr), is_pipeline));
     uint32_t hash_value = get_hash_value(fragment_instance_id, dest_node_id);
     std::lock_guard<std::mutex> l(_lock);
     _fragment_stream_set.emplace(fragment_instance_id, dest_node_id);

--- a/be/src/runtime/data_stream_recvr.cc
+++ b/be/src/runtime/data_stream_recvr.cc
@@ -598,7 +598,7 @@ Status DataStreamRecvr::create_merger_for_pipeline(const SortExecExprs* exprs, c
     return Status::OK();
 }
 
-DataStreamRecvr::DataStreamRecvr(DataStreamMgr* stream_mgr, MemTracker* mem_tracker, const RowDescriptor& row_desc,
+DataStreamRecvr::DataStreamRecvr(DataStreamMgr* stream_mgr, RuntimeState* runtime_state, const RowDescriptor& row_desc,
                                  const TUniqueId& fragment_instance_id, PlanNodeId dest_node_id, int num_senders,
                                  bool is_merging, int total_buffer_limit, std::shared_ptr<RuntimeProfile> profile,
                                  std::shared_ptr<QueryStatisticsRecvr> sub_plan_query_statistics_recvr,
@@ -610,8 +610,10 @@ DataStreamRecvr::DataStreamRecvr(DataStreamMgr* stream_mgr, MemTracker* mem_trac
           _row_desc(row_desc),
           _is_merging(is_merging),
           _num_buffered_bytes(0),
-          _mem_tracker(mem_tracker),
           _profile(std::move(profile)),
+          _instance_profile(runtime_state->runtime_profile_ptr()),
+          _query_mem_tracker(runtime_state->query_mem_tracker_ptr()),
+          _instance_mem_tracker(runtime_state->instance_mem_tracker_ptr()),
           _sub_plan_query_statistics_recvr(std::move(sub_plan_query_statistics_recvr)),
           _is_pipeline(is_pipeline) {
     // Create one queue per sender if is_merging is true.
@@ -662,7 +664,7 @@ void DataStreamRecvr::add_batch(const PRowBatch& batch, int sender_id, int be_nu
 }
 
 Status DataStreamRecvr::add_chunks(const PTransmitChunkParams& request, ::google::protobuf::Closure** done) {
-    MemTracker* prev_tracker = tls_thread_status.set_mem_tracker(_mem_tracker);
+    MemTracker* prev_tracker = tls_thread_status.set_mem_tracker(_instance_mem_tracker.get());
     DeferOp op([&] { tls_thread_status.set_mem_tracker(prev_tracker); });
 
     SCOPED_TIMER(_sender_total_timer);

--- a/be/src/runtime/data_stream_recvr.h
+++ b/be/src/runtime/data_stream_recvr.h
@@ -113,7 +113,7 @@ private:
     friend class DataStreamMgr;
     class SenderQueue;
 
-    DataStreamRecvr(DataStreamMgr* stream_mgr, MemTracker* mem_tracker, const RowDescriptor& row_desc,
+    DataStreamRecvr(DataStreamMgr* stream_mgr, RuntimeState* runtime_state, const RowDescriptor& row_desc,
                     const TUniqueId& fragment_instance_id, PlanNodeId dest_node_id, int num_senders, bool is_merging,
                     int total_buffer_limit, std::shared_ptr<RuntimeProfile> profile,
                     std::shared_ptr<QueryStatisticsRecvr> sub_plan_query_statistics_recvr, bool is_pipeline);
@@ -158,9 +158,6 @@ private:
     // total number of bytes held across all sender queues.
     std::atomic<int> _num_buffered_bytes{0};
 
-    // Memtracker for batches in the sender queue(s).
-    MemTracker* _mem_tracker = nullptr;
-
     // One or more queues of row batches received from senders. If _is_merging is true,
     // there is one SenderQueue for each sender. Otherwise, row batches from all senders
     // are placed in the same SenderQueue. The SenderQueue instances are owned by the
@@ -175,6 +172,11 @@ private:
 
     // Runtime profile storing the counters below.
     std::shared_ptr<RuntimeProfile> _profile;
+
+    // instance profile and mem_tracker
+    std::shared_ptr<RuntimeProfile> _instance_profile;
+    std::shared_ptr<MemTracker> _query_mem_tracker;
+    std::shared_ptr<MemTracker> _instance_mem_tracker;
 
     // Number of bytes received
     RuntimeProfile::Counter* _bytes_received_counter;


### PR DESCRIPTION
add_chunks has obtained recvr, and then the instance is closed, and the recvr is removed from the recvr mgr. At this time, the corresponding MemTracker has also been deconstructed, but the add_chunks has not ended yet, and this MemTracker is still being used