### PR TITLE
Fix decode rewrite with order by bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/AddDecodeNodeForDictStringRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/AddDecodeNodeForDictStringRule.java
@@ -166,6 +166,8 @@ public class AddDecodeNodeForDictStringRule implements PhysicalOperatorTreeRewri
                 OptExpression newChildExpr = childExpr.getOp().accept(this, childExpr, context);
                 if (context.hasEncoded) {
                     insertDecodeExpr(optExpression, Collections.singletonList(newChildExpr), i, context);
+                } else {
+                    optExpression.setChild(i, newChildExpr);
                 }
             }
             return visitProjectionAfter(optExpression, context);
@@ -653,7 +655,6 @@ public class AddDecodeNodeForDictStringRule implements PhysicalOperatorTreeRewri
         result.setLogicalProperty(childExpr.get(0).getLogicalProperty());
         return result;
     }
-
 
     private static class CouldApplyDictOptimizeVisitor extends ScalarOperatorVisitor<Boolean, Void> {
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecodeRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecodeRewriteTest.java
@@ -405,4 +405,13 @@ public class DecodeRewriteTest extends PlanTestBase{
         Assert.assertTrue(plan.contains(" 5:AGGREGATE (update serialize)\n" +
                 "  |  output: count(if(3 IS NULL, NULL, 7))"));
     }
+
+    @Test
+    public void testGroupByWithOrderBy() throws Exception {
+        connectContext.getSessionVariable().setNewPlanerAggStage(2);
+        String sql = "select max(S_NAME) as b from supplier group by S_ADDRESS order by b";
+        String plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("group by: 10: S_ADDRESS"));
+        connectContext.getSessionVariable().setNewPlanerAggStage(0);
+    }
 }


### PR DESCRIPTION
For https://github.com/StarRocks/starrocks/issues/559

The new rewritten child expression should always set.