### PR TITLE
Fix select group by view error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/SelectStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/SelectStmt.java
@@ -370,6 +370,9 @@ public class SelectStmt extends QueryStmt {
 
         fromClause_.setNeedToSql(needToSql);
         fromClause_.analyze(analyzer);
+        if (groupByClause != null) {
+            groupByClause.setNeedToSql(needToSql);
+        }
 
         // Generate !empty() predicates to filter out empty collections.
         // Skip this step when analyzing a WITH-clause because CollectionTableRefs

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -655,6 +655,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return enableGroupbyUseOutputAlias;
     }
 
+    public void setEnableGroupbyUseOutputAlias(boolean enableGroupbyUseOutputAlias) {
+        this.enableGroupbyUseOutputAlias = enableGroupbyUseOutputAlias;
+    }
+
     public boolean getEnableQueryDump() {
         return enableQueryDump;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ViewPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ViewPlanTest.java
@@ -1183,8 +1183,10 @@ public class ViewPlanTest extends PlanTestBase {
 
     @Test
     public void testSql257() throws Exception {
+        connectContext.getSessionVariable().setEnableGroupbyUseOutputAlias(true);
         String sql = "select v1 as v2 from t0 group by v1, v2;";
         testView(sql);
+        connectContext.getSessionVariable().setEnableGroupbyUseOutputAlias(false);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ViewPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ViewPlanTest.java
@@ -1563,4 +1563,24 @@ public class ViewPlanTest extends PlanTestBase {
         Assert.assertEquals(sqlPlan, viewPlan);
         starRocksAssert.dropView("test_view15");
     }
+
+    @Test
+    public void testGroupByView() throws  Exception {
+        String sql = "select case  when c1=1 then 1 end from " +
+                        "(select '1' c1  union  all select '2') a group by case  when c1=1 then 1 end;";
+        testView(sql);
+
+        sql = "select case  when c1=1 then 1 end from " +
+                "(select '1' c1  union  all select '2') a group by rollup(case  when c1=1 then 1 end, a.c1);";
+        testView(sql);
+
+        sql = "select case  when c1=1 then 1 end from " +
+                "(select '1' c1  union  all select '2') a group by cube(case when c1=1 then 1 end, a.c1);";
+        testView(sql);
+
+        sql = "select case when c1=1 then 1 end from " +
+                "(select '1' c1  union  all select '2') a " +
+                "group by grouping sets((case when c1=1 then 1 end, c1), (case  when c1=1 then 1 end));";
+        testView(sql);
+    }
 }


### PR DESCRIPTION
The reason about:
toSql of select clause use select result expr which is after analyze, but toSql of group clause use orig expr.

```
select x1 + 1 from table group by x1 + 1;
```
then the view sql will be:

```
select x1 + 1.0 from table group by x1 + 1;
```

the query sql will failed when analyze aggregate node