### PR TITLE
Using below op aggfn instead of above op aggfn in MergeTwoAggRule

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Function.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Function.java
@@ -259,6 +259,10 @@ public class Function implements Writable {
         return checksum;
     }
 
+    public void setArgTypes(Type[] argTypes) {
+        this.argTypes = argTypes;
+    }
+
     // TODO(cmy): Currently we judge whether it is UDF by wheter the 'location' is set.
     // Maybe we should use a separate variable to identify,
     // but additional variables need to modify the persistence information.

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Function.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Function.java
@@ -259,10 +259,6 @@ public class Function implements Writable {
         return checksum;
     }
 
-    public void setArgTypes(Type[] argTypes) {
-        this.argTypes = argTypes;
-    }
-
     // TODO(cmy): Currently we judge whether it is UDF by wheter the 'location' is set.
     // Maybe we should use a separate variable to identify,
     // but additional variables need to modify the persistence information.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MergeTwoAggRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MergeTwoAggRule.java
@@ -112,7 +112,9 @@ public class MergeTwoAggRule extends TransformationRule {
 
             CallOperator newFn;
             if (aggCallMapBelow.containsKey(ref)) {
-                newFn = new CallOperator(fn.getFnName(), fn.getType(), aggCallMapBelow.get(ref).getChildren(),
+                CallOperator belowOp = aggCallMapBelow.get(ref);
+                fn.getFunction().setArgTypes(belowOp.getFunction().getArgs());
+                newFn = new CallOperator(fn.getFnName(), fn.getType(), belowOp.getChildren(),
                         fn.getFunction(), fn.isDistinct());
             } else {
                 newFn = new CallOperator(fn.getFnName(), fn.getType(), Lists.newArrayList(ref), fn.getFunction(),

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MergeTwoAggRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MergeTwoAggRule.java
@@ -113,9 +113,8 @@ public class MergeTwoAggRule extends TransformationRule {
             CallOperator newFn;
             if (aggCallMapBelow.containsKey(ref)) {
                 CallOperator belowOp = aggCallMapBelow.get(ref);
-                fn.getFunction().setArgTypes(belowOp.getFunction().getArgs());
                 newFn = new CallOperator(fn.getFnName(), fn.getType(), belowOp.getChildren(),
-                        fn.getFunction(), fn.isDistinct());
+                        belowOp.getFunction(), fn.isDistinct());
             } else {
                 newFn = new CallOperator(fn.getFnName(), fn.getType(), Lists.newArrayList(ref), fn.getFunction(),
                         fn.isDistinct());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -705,4 +705,12 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
 
         setTableStatistics(t0, 10000);
     }
+
+    @Test
+    public void testMergeTwoAggArgTypes() throws Exception {
+        String sql = "select sum(t.int_sum) from (select sum(t1c) as int_sum from test_all_type)t";
+        String planFragment = getVerboseExplain(sql);
+        Assert.assertTrue(planFragment.contains("  1:AGGREGATE (update serialize)\n" +
+                "  |  aggregate: sum[([3: t1c, INT, true]); args: INT; result: BIGINT;"));
+    }
 }


### PR DESCRIPTION
ref #1230 