### PR TITLE
[ISSUE-1261] set_finished LocalExchangeSourceOperator because of short-circuit break of HashJoinProbeOperator

### DIFF
--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.cpp
@@ -16,7 +16,7 @@ bool AggregateBlockingSinkOperator::is_finished() const {
     return _is_finished;
 }
 
-void AggregateBlockingSinkOperator::finish(RuntimeState* state) {
+void AggregateBlockingSinkOperator::set_finishing(RuntimeState* state) {
     if (_is_finished) {
         return;
     }

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.h
@@ -19,7 +19,7 @@ public:
     bool has_output() const override { return false; }
     bool need_input() const override { return true; }
     bool is_finished() const override;
-    void finish(RuntimeState* state) override;
+    void set_finishing(RuntimeState* state) override;
 
     Status prepare(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.cpp
@@ -14,7 +14,7 @@ bool AggregateBlockingSourceOperator::is_finished() const {
     return _aggregator->is_sink_complete() && _aggregator->is_ht_eos();
 }
 
-void AggregateBlockingSourceOperator::finish(RuntimeState* state) {
+void AggregateBlockingSourceOperator::set_finishing(RuntimeState* state) {
     _is_finished = true;
 }
 

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.h
@@ -16,7 +16,7 @@ public:
 
     bool has_output() const override;
     bool is_finished() const override;
-    void finish(RuntimeState* state) override;
+    void set_finishing(RuntimeState* state) override;
 
     Status close(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.cpp
@@ -16,7 +16,7 @@ bool AggregateDistinctBlockingSinkOperator::is_finished() const {
     return _is_finished;
 }
 
-void AggregateDistinctBlockingSinkOperator::finish(RuntimeState* state) {
+void AggregateDistinctBlockingSinkOperator::set_finishing(RuntimeState* state) {
     if (_is_finished) {
         return;
     }

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.h
@@ -19,7 +19,7 @@ public:
     bool has_output() const override { return false; }
     bool need_input() const override { return true; }
     bool is_finished() const override;
-    void finish(RuntimeState* state) override;
+    void set_finishing(RuntimeState* state) override;
 
     Status prepare(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.cpp
@@ -14,7 +14,7 @@ bool AggregateDistinctBlockingSourceOperator::is_finished() const {
     return _aggregator->is_sink_complete() && _aggregator->is_ht_eos();
 }
 
-void AggregateDistinctBlockingSourceOperator::finish(RuntimeState* state) {
+void AggregateDistinctBlockingSourceOperator::set_finishing(RuntimeState* state) {
     _is_finished = true;
 }
 

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.h
@@ -17,7 +17,7 @@ public:
 
     bool has_output() const override;
     bool is_finished() const override;
-    void finish(RuntimeState* state) override;
+    void set_finishing(RuntimeState* state) override;
 
     Status close(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.cpp
@@ -17,7 +17,7 @@ bool AggregateDistinctStreamingSinkOperator::is_finished() const {
     return _is_finished;
 }
 
-void AggregateDistinctStreamingSinkOperator::finish(RuntimeState* state) {
+void AggregateDistinctStreamingSinkOperator::set_finishing(RuntimeState* state) {
     _is_finished = true;
     _aggregator->sink_complete();
 }

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.h
@@ -19,7 +19,7 @@ public:
     bool has_output() const override { return false; }
     bool need_input() const override { return true; }
     bool is_finished() const override;
-    void finish(RuntimeState* state) override;
+    void set_finishing(RuntimeState* state) override;
 
     Status prepare(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.cpp
@@ -29,7 +29,7 @@ bool AggregateDistinctStreamingSourceOperator::is_finished() const {
     return _aggregator->is_sink_complete() && _aggregator->is_chunk_buffer_empty() && _aggregator->is_ht_eos();
 }
 
-void AggregateDistinctStreamingSourceOperator::finish(RuntimeState* state) {
+void AggregateDistinctStreamingSourceOperator::set_finishing(RuntimeState* state) {
     _is_finished = true;
 }
 

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.h
@@ -17,7 +17,7 @@ public:
 
     bool has_output() const override;
     bool is_finished() const override;
-    void finish(RuntimeState* state) override;
+    void set_finishing(RuntimeState* state) override;
 
     Status close(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
@@ -17,7 +17,7 @@ bool AggregateStreamingSinkOperator::is_finished() const {
     return _is_finished;
 }
 
-void AggregateStreamingSinkOperator::finish(RuntimeState* state) {
+void AggregateStreamingSinkOperator::set_finishing(RuntimeState* state) {
     _is_finished = true;
     _aggregator->sink_complete();
 }

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.h
@@ -19,7 +19,7 @@ public:
     bool has_output() const override { return false; }
     bool need_input() const override { return true; }
     bool is_finished() const override;
-    void finish(RuntimeState* state) override;
+    void set_finishing(RuntimeState* state) override;
 
     Status prepare(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.cpp
@@ -43,7 +43,7 @@ bool AggregateStreamingSourceOperator::is_finished() const {
     return _is_finished;
 }
 
-void AggregateStreamingSourceOperator::finish(RuntimeState* state) {
+void AggregateStreamingSourceOperator::set_finishing(RuntimeState* state) {
     _is_finished = true;
 }
 

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.h
@@ -16,7 +16,7 @@ public:
 
     bool has_output() const override;
     bool is_finished() const override;
-    void finish(RuntimeState* state) override;
+    void set_finishing(RuntimeState* state) override;
 
     Status close(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/aggregate/repeat/repeat_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/repeat/repeat_operator.cpp
@@ -17,7 +17,7 @@ bool RepeatOperator::is_finished() const {
     return _is_finished && _repeat_times_last >= _repeat_times_required;
 }
 
-void RepeatOperator::finish(RuntimeState* state) {
+void RepeatOperator::set_finishing(RuntimeState* state) {
     if (_is_finished) {
         return;
     }

--- a/be/src/exec/pipeline/aggregate/repeat/repeat_operator.h
+++ b/be/src/exec/pipeline/aggregate/repeat/repeat_operator.h
@@ -41,7 +41,7 @@ public:
         return _repeat_times_last >= _repeat_times_required;
     }
     bool is_finished() const override;
-    void finish(RuntimeState* state) override;
+    void set_finishing(RuntimeState* state) override;
 
     Status prepare(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/analysis/analytic_sink_operator.cpp
+++ b/be/src/exec/pipeline/analysis/analytic_sink_operator.cpp
@@ -42,7 +42,7 @@ bool AnalyticSinkOperator::is_finished() const {
     return _is_finished;
 }
 
-void AnalyticSinkOperator::finish(RuntimeState* state) {
+void AnalyticSinkOperator::set_finishing(RuntimeState* state) {
     if (_is_finished) {
         return;
     }

--- a/be/src/exec/pipeline/analysis/analytic_sink_operator.h
+++ b/be/src/exec/pipeline/analysis/analytic_sink_operator.h
@@ -15,7 +15,7 @@ public:
     bool has_output() const override { return false; }
     bool need_input() const override { return true; }
     bool is_finished() const override;
-    void finish(RuntimeState* state) override;
+    void set_finishing(RuntimeState* state) override;
 
     Status prepare(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/analysis/analytic_source_operator.cpp
+++ b/be/src/exec/pipeline/analysis/analytic_source_operator.cpp
@@ -12,7 +12,7 @@ bool AnalyticSourceOperator::is_finished() const {
     return _analytor->is_sink_complete() && _analytor->is_chunk_buffer_empty();
 }
 
-void AnalyticSourceOperator::finish(RuntimeState* state) {
+void AnalyticSourceOperator::set_finishing(RuntimeState* state) {
     _is_finished = true;
 }
 

--- a/be/src/exec/pipeline/analysis/analytic_source_operator.h
+++ b/be/src/exec/pipeline/analysis/analytic_source_operator.h
@@ -16,7 +16,7 @@ public:
 
     bool has_output() const override;
     bool is_finished() const override;
-    void finish(RuntimeState* state) override;
+    void set_finishing(RuntimeState* state) override;
 
     Status close(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/assert_num_rows_operator.cpp
+++ b/be/src/exec/pipeline/assert_num_rows_operator.cpp
@@ -48,7 +48,7 @@ Status AssertNumRowsOperator::push_chunk(RuntimeState* state, const vectorized::
     return Status::OK();
 }
 
-void AssertNumRowsOperator::finish(RuntimeState* state) {
+void AssertNumRowsOperator::set_finishing(RuntimeState* state) {
     _is_finished = true;
 }
 

--- a/be/src/exec/pipeline/assert_num_rows_operator.h
+++ b/be/src/exec/pipeline/assert_num_rows_operator.h
@@ -39,7 +39,7 @@ public:
     bool need_input() const override;
     Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override;
 
-    void finish(RuntimeState* state) override;
+    void set_finishing(RuntimeState* state) override;
     bool is_finished() const override;
 
 private:

--- a/be/src/exec/pipeline/crossjoin/cross_join_left_operator.h
+++ b/be/src/exec/pipeline/crossjoin/cross_join_left_operator.h
@@ -63,7 +63,7 @@ public:
         return _is_finished && _is_curr_probe_chunk_finished();
     }
 
-    void finish(RuntimeState* state) override { _is_finished = true; }
+    void set_finishing(RuntimeState* state) override { _is_finished = true; }
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/crossjoin/cross_join_right_sink_operator.h
+++ b/be/src/exec/pipeline/crossjoin/cross_join_right_sink_operator.h
@@ -26,7 +26,7 @@ public:
 
     bool is_finished() const override { return _is_finished; }
 
-    void finish(RuntimeState* state) override {
+    void set_finishing(RuntimeState* state) override {
         if (!_is_finished) {
             _is_finished = true;
             // Used to notify cross_join_left_operator.

--- a/be/src/exec/pipeline/dict_decode_operator.h
+++ b/be/src/exec/pipeline/dict_decode_operator.h
@@ -41,7 +41,7 @@ public:
 
     bool is_finished() const override { return _is_finished && _cur_chunk == nullptr; }
 
-    void finish(RuntimeState* state) override { _is_finished = true; }
+    void set_finishing(RuntimeState* state) override { _is_finished = true; }
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/exchange/exchange_merge_sort_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_merge_sort_source_operator.cpp
@@ -36,7 +36,7 @@ bool ExchangeMergeSortSourceOperator::is_finished() const {
     }
 }
 
-void ExchangeMergeSortSourceOperator::finish(RuntimeState* state) {
+void ExchangeMergeSortSourceOperator::set_finishing(RuntimeState* state) {
     if (_is_finished) {
         return;
     }

--- a/be/src/exec/pipeline/exchange/exchange_merge_sort_source_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_merge_sort_source_operator.h
@@ -35,7 +35,7 @@ public:
 
     bool is_finished() const override;
 
-    void finish(RuntimeState* state) override;
+    void set_finishing(RuntimeState* state) override;
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -419,7 +419,7 @@ Status ExchangeSinkOperator::push_chunk(RuntimeState* state, const vectorized::C
     return Status::OK();
 }
 
-void ExchangeSinkOperator::finish(RuntimeState* state) {
+void ExchangeSinkOperator::set_finishing(RuntimeState* state) {
     if (_is_finished) {
         return;
     }

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.h
@@ -45,7 +45,7 @@ public:
 
     bool is_finished() const override;
 
-    void finish(RuntimeState* state) override;
+    void set_finishing(RuntimeState* state) override;
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/exchange/exchange_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_source_operator.cpp
@@ -30,7 +30,7 @@ bool ExchangeSourceOperator::is_finished() const {
     return _stream_recvr->is_finished();
 }
 
-void ExchangeSourceOperator::finish(RuntimeState* state) {
+void ExchangeSourceOperator::set_finishing(RuntimeState* state) {
     if (_is_finishing) {
         return;
     }

--- a/be/src/exec/pipeline/exchange/exchange_source_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_source_operator.h
@@ -25,7 +25,7 @@ public:
 
     bool is_finished() const override;
 
-    void finish(RuntimeState* state) override;
+    void set_finishing(RuntimeState* state) override;
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/exchange/local_exchange.h
+++ b/be/src/exec/pipeline/exchange/local_exchange.h
@@ -97,7 +97,7 @@ public:
     void finish(RuntimeState* state) override {
         if (decrement_sink_number() == 1) {
             for (auto* source : _source->get_sources()) {
-                source->finish(state);
+                source->set_finishing(state);
             }
         }
     }
@@ -121,7 +121,7 @@ public:
     void finish(RuntimeState* state) override {
         if (decrement_sink_number() == 1) {
             for (auto* source : _source->get_sources()) {
-                source->finish(state);
+                source->set_finishing(state);
             }
         }
     }
@@ -139,7 +139,7 @@ public:
     void finish(RuntimeState* state) override {
         if (decrement_sink_number() == 1) {
             for (auto* source : _source->get_sources()) {
-                source->finish(state);
+                source->set_finishing(state);
             }
         }
     }

--- a/be/src/exec/pipeline/exchange/local_exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange_sink_operator.cpp
@@ -20,7 +20,7 @@ StatusOr<vectorized::ChunkPtr> LocalExchangeSinkOperator::pull_chunk(RuntimeStat
     return Status::InternalError("Shouldn't call pull_chunk from local exchange sink.");
 }
 
-void LocalExchangeSinkOperator::finish(RuntimeState* state) {
+void LocalExchangeSinkOperator::set_finishing(RuntimeState* state) {
     if (!_is_finished) {
         _is_finished = true;
         _exchanger->finish(state);

--- a/be/src/exec/pipeline/exchange/local_exchange_sink_operator.h
+++ b/be/src/exec/pipeline/exchange/local_exchange_sink_operator.h
@@ -28,7 +28,7 @@ public:
     // In either case,  LocalExchangeSinkOperator is finished.
     bool is_finished() const override { return _is_finished || _exchanger->is_all_sources_finished(); }
 
-    void finish(RuntimeState* state) override;
+    void set_finishing(RuntimeState* state) override;
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/exchange/local_exchange_sink_operator.h
+++ b/be/src/exec/pipeline/exchange/local_exchange_sink_operator.h
@@ -22,7 +22,11 @@ public:
 
     bool need_input() const override;
 
-    bool is_finished() const override { return _is_finished; }
+    // _is_finished is true indicates that LocalExchangeSinkOperator is finished by its preceding operator.
+    // _is_all_source_finished() returning true indicates that all its corresponding LocalExchangeSourceOperators
+    // has finished.
+    // In either case,  LocalExchangeSinkOperator is finished.
+    bool is_finished() const override { return _is_finished || _exchanger->is_all_sources_finished(); }
 
     void finish(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
@@ -49,7 +49,7 @@ bool LocalExchangeSourceOperator::has_output() const {
            (_is_finished && _partition_rows_num > 0);
 }
 
-void LocalExchangeSourceOperator::finish_backward(RuntimeState* state) {
+void LocalExchangeSourceOperator::set_finished(RuntimeState* state) {
     std::lock_guard<std::mutex> l(_chunk_lock);
     if (_is_finished) {
         return;

--- a/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
@@ -11,7 +11,10 @@ namespace starrocks::pipeline {
 // The input chunk is most likely full, so we don't merge it to avoid copying chunk data.
 Status LocalExchangeSourceOperator::add_chunk(vectorized::ChunkPtr chunk) {
     std::lock_guard<std::mutex> l(_chunk_lock);
-
+    if (_is_finished) {
+        return Status::OK();
+    }
+    _memory_manager->update_row_count(chunk->num_rows());
     _full_chunk_queue.emplace(std::move(chunk));
 
     return Status::OK();
@@ -23,7 +26,10 @@ Status LocalExchangeSourceOperator::add_chunk(vectorized::ChunkPtr chunk,
                                               std::shared_ptr<std::vector<uint32_t>> indexes, uint32_t from,
                                               uint32_t size) {
     std::lock_guard<std::mutex> l(_chunk_lock);
-
+    if (_is_finished) {
+        return Status::OK();
+    }
+    _memory_manager->update_row_count(size);
     _partition_chunk_queue.emplace(std::move(chunk), std::move(indexes), from, size);
     _partition_rows_num += size;
 
@@ -41,6 +47,28 @@ bool LocalExchangeSourceOperator::has_output() const {
 
     return !_full_chunk_queue.empty() || _partition_rows_num >= config::vector_chunk_size ||
            (_is_finished && _partition_rows_num > 0);
+}
+
+void LocalExchangeSourceOperator::finish_backward(RuntimeState* state) {
+    std::lock_guard<std::mutex> l(_chunk_lock);
+    if (_is_finished) {
+        return;
+    }
+    _is_finished = true;
+    // Compute out the number of rows of the _full_chunk_queue.
+    size_t full_rows_num = 0;
+    while (!_full_chunk_queue.empty()) {
+        auto&& chunk = std::move(_full_chunk_queue.front());
+        _full_chunk_queue.pop();
+        full_rows_num += chunk->num_rows();
+    }
+    // clear _full_chunk_queue
+    { [[maybe_unused]] typeof(_full_chunk_queue) tmp = std::move(_full_chunk_queue); }
+    // clear _partition_chunk_queue
+    { [[maybe_unused]] typeof(_partition_chunk_queue) tmp = std::move(_partition_chunk_queue); }
+    // Subtract the number of rows of buffered chunks from row_count of _memory_manager and make it unblocked.
+    _memory_manager->update_row_count(-(full_rows_num + _partition_rows_num));
+    _partition_rows_num = 0;
 }
 
 StatusOr<vectorized::ChunkPtr> LocalExchangeSourceOperator::pull_chunk(RuntimeState* state) {

--- a/be/src/exec/pipeline/exchange/local_exchange_source_operator.h
+++ b/be/src/exec/pipeline/exchange/local_exchange_source_operator.h
@@ -40,9 +40,9 @@ public:
 
     bool is_finished() const override;
 
+    void finish_backward(RuntimeState* state) override;
     void finish(RuntimeState* state) override {
         std::lock_guard<std::mutex> l(_chunk_lock);
-
         _is_finished = true;
     }
 

--- a/be/src/exec/pipeline/exchange/local_exchange_source_operator.h
+++ b/be/src/exec/pipeline/exchange/local_exchange_source_operator.h
@@ -40,8 +40,8 @@ public:
 
     bool is_finished() const override;
 
-    void finish_backward(RuntimeState* state) override;
-    void finish(RuntimeState* state) override {
+    void set_finished(RuntimeState* state) override;
+    void set_finishing(RuntimeState* state) override {
         std::lock_guard<std::mutex> l(_chunk_lock);
         _is_finished = true;
     }

--- a/be/src/exec/pipeline/hashjoin/hash_join_build_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/hash_join_build_operator.cpp
@@ -18,7 +18,7 @@ StatusOr<vectorized::ChunkPtr> HashJoinBuildOperator::pull_chunk(RuntimeState* s
     return Status::NotSupported(msg);
 }
 
-void HashJoinBuildOperator::finish(RuntimeState* state) {
+void HashJoinBuildOperator::set_finishing(RuntimeState* state) {
     if (!_is_finished) {
         _hash_joiner->build_ht(state);
         _is_finished = true;

--- a/be/src/exec/pipeline/hashjoin/hash_join_build_operator.h
+++ b/be/src/exec/pipeline/hashjoin/hash_join_build_operator.h
@@ -28,7 +28,7 @@ public:
 
     Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override;
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
-    void finish(RuntimeState* state) override;
+    void set_finishing(RuntimeState* state) override;
 
 private:
     HashJoiner* _hash_joiner;

--- a/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.cpp
@@ -29,7 +29,7 @@ StatusOr<vectorized::ChunkPtr> HashJoinProbeOperator::pull_chunk(RuntimeState* s
     return _hash_joiner->pull_chunk(state);
 }
 
-void HashJoinProbeOperator::finish(RuntimeState* state) {
+void HashJoinProbeOperator::set_finishing(RuntimeState* state) {
     if (!_is_finished) {
         _hash_joiner->enter_post_probe_phase();
         _is_finished = true;

--- a/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.h
+++ b/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.h
@@ -23,7 +23,7 @@ public:
     bool is_finished() const override;
     Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk);
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state);
-    void finish(RuntimeState* state) override;
+    void set_finishing(RuntimeState* state) override;
     bool is_ready() const override;
 
 private:

--- a/be/src/exec/pipeline/limit_operator.h
+++ b/be/src/exec/pipeline/limit_operator.h
@@ -19,7 +19,7 @@ public:
 
     bool is_finished() const override { return _limit == 0 && _cur_chunk == nullptr; }
 
-    void finish(RuntimeState* state) override { _limit = 0; }
+    void set_finishing(RuntimeState* state) override { _limit = 0; }
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/operator.h
+++ b/be/src/exec/pipeline/operator.h
@@ -44,12 +44,19 @@ public:
     // The method should be idempotent, because it may be triggered
     // multiple times in the entire life cycle
     // finish function is used to finish the following operator of the current operator that encounters its EOS
-    // and has no data to push into its following operator.
-    virtual void finish(RuntimeState* state) = 0;
+    // and has no data to push into its following operator, but the operator is not finished until its buffered
+    // data inside is processed.
+    virtual void set_finishing(RuntimeState* state) = 0;
 
-    // finish_backward is used to finish the preceding operator of the current operator that finishes in advance
-    // and never need input data to consume.
-    virtual void finish_backward(RuntimeState* state) { finish(state); }
+    // set_finished is used to shutdown both input and output stream of a operator and after its invocation
+    // buffered data inside the operator is cleared.
+    // This function is used to shutdown preceding operators of the current operator if it is finished in advance,
+    // when the query or fragment instance is canceled, set_finished is also called to shutdown unfinished operators.
+    // A complex source operator that interacts with the corresponding sink operator in its preceding drivers via
+    // an implementation-specific context should override set_finished function, such as LocalExchangeSourceOperator.
+    // For an ordinary operator, set_finished function is trivial and just has the same implementation with
+    // set_finishing function.
+    virtual void set_finished(RuntimeState* state) { set_finishing(state); }
 
     // Pull chunk from this operator
     // Use shared_ptr, because in some cases (local broadcast exchange),

--- a/be/src/exec/pipeline/operator.h
+++ b/be/src/exec/pipeline/operator.h
@@ -43,7 +43,13 @@ public:
     // The operator should finish processing.
     // The method should be idempotent, because it may be triggered
     // multiple times in the entire life cycle
+    // finish function is used to finish the following operator of the current operator that encounters its EOS
+    // and has no data to push into its following operator.
     virtual void finish(RuntimeState* state) = 0;
+
+    // finish_backward is used to finish the preceding operator of the current operator that finishes in advance
+    // and never need input data to consume.
+    virtual void finish_backward(RuntimeState* state) { finish(state); }
 
     // Pull chunk from this operator
     // Use shared_ptr, because in some cases (local broadcast exchange),

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -63,9 +63,9 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state) {
                 if (curr_op->is_finished()) {
                     if (i == 0) {
                         // For source operators
-                        curr_op->finish(runtime_state);
+                        curr_op->set_finishing(runtime_state);
                     }
-                    next_op->finish(runtime_state);
+                    next_op->set_finishing(runtime_state);
                     _new_first_unfinished = i + 1;
                     continue;
                 }
@@ -116,9 +116,9 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state) {
                 if (curr_op->is_finished()) {
                     if (i == 0) {
                         // For source operators
-                        curr_op->finish(runtime_state);
+                        curr_op->set_finishing(runtime_state);
                     }
-                    next_op->finish(runtime_state);
+                    next_op->set_finishing(runtime_state);
                     _new_first_unfinished = i + 1;
                     continue;
                 }
@@ -132,7 +132,7 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state) {
         }
         // close finished operators and update _first_unfinished index
         for (auto i = _first_unfinished; i < _new_first_unfinished; ++i) {
-            _operators[i]->finish_backward(runtime_state);
+            _operators[i]->set_finished(runtime_state);
             RETURN_IF_ERROR(_operators[i]->close(runtime_state));
         }
         _first_unfinished = _new_first_unfinished;
@@ -170,7 +170,7 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state) {
 
 void PipelineDriver::finish_operators(RuntimeState* state) {
     for (auto i = _first_unfinished; i < _operators.size(); ++i) {
-        _operators[i]->finish_backward(state);
+        _operators[i]->set_finished(state);
     }
 }
 
@@ -179,7 +179,7 @@ void PipelineDriver::finalize(RuntimeState* runtime_state, DriverState state) {
     if (state == DriverState::FINISH || state == DriverState::CANCELED || state == DriverState::INTERNAL_ERROR) {
         auto num_operators = _operators.size();
         for (auto i = _first_unfinished; i < num_operators; ++i) {
-            _operators[i]->finish_backward(runtime_state);
+            _operators[i]->set_finished(runtime_state);
             _operators[i]->close(runtime_state);
         }
     } else {

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -132,7 +132,7 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state) {
         }
         // close finished operators and update _first_unfinished index
         for (auto i = _first_unfinished; i < _new_first_unfinished; ++i) {
-            _operators[i]->finish(runtime_state);
+            _operators[i]->finish_backward(runtime_state);
             RETURN_IF_ERROR(_operators[i]->close(runtime_state));
         }
         _first_unfinished = _new_first_unfinished;
@@ -170,7 +170,7 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state) {
 
 void PipelineDriver::finish_operators(RuntimeState* state) {
     for (auto i = _first_unfinished; i < _operators.size(); ++i) {
-        _operators[i]->finish(state);
+        _operators[i]->finish_backward(state);
     }
 }
 
@@ -179,7 +179,7 @@ void PipelineDriver::finalize(RuntimeState* runtime_state, DriverState state) {
     if (state == DriverState::FINISH || state == DriverState::CANCELED || state == DriverState::INTERNAL_ERROR) {
         auto num_operators = _operators.size();
         for (auto i = _first_unfinished; i < num_operators; ++i) {
-            _operators[i]->finish(runtime_state);
+            _operators[i]->finish_backward(runtime_state);
             _operators[i]->close(runtime_state);
         }
     } else {

--- a/be/src/exec/pipeline/project_operator.h
+++ b/be/src/exec/pipeline/project_operator.h
@@ -33,7 +33,7 @@ public:
 
     bool is_finished() const override { return _is_finished && _cur_chunk == nullptr; }
 
-    void finish(RuntimeState* state) override { _is_finished = true; }
+    void set_finishing(RuntimeState* state) override { _is_finished = true; }
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/result_sink_operator.h
+++ b/be/src/exec/pipeline/result_sink_operator.h
@@ -40,7 +40,7 @@ public:
 
     bool is_finished() const override { return _is_finished && !_fetch_data_result; }
 
-    void finish(RuntimeState* state) override { _is_finished = true; }
+    void set_finishing(RuntimeState* state) override { _is_finished = true; }
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan_operator.cpp
@@ -83,7 +83,7 @@ bool ScanOperator::is_finished() const {
     return _is_finished;
 }
 
-void ScanOperator::finish(RuntimeState* state) {
+void ScanOperator::set_finishing(RuntimeState* state) {
     _is_finished = true;
 }
 

--- a/be/src/exec/pipeline/scan_operator.h
+++ b/be/src/exec/pipeline/scan_operator.h
@@ -38,7 +38,7 @@ public:
 
     bool is_finished() const override;
 
-    void finish(RuntimeState* state) override;
+    void set_finishing(RuntimeState* state) override;
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
     void set_io_threads(PriorityThreadPool* io_threads) { _io_threads = io_threads; }

--- a/be/src/exec/pipeline/select_operator.h
+++ b/be/src/exec/pipeline/select_operator.h
@@ -22,7 +22,7 @@ public:
     bool need_input() const override;
     bool is_finished() const override { return _is_finished && !_curr_chunk && !_pre_output_chunk; }
 
-    void finish(RuntimeState* state) override { _is_finished = true; }
+    void set_finishing(RuntimeState* state) override { _is_finished = true; }
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/set/except_build_sink_operator.h
+++ b/be/src/exec/pipeline/set/except_build_sink_operator.h
@@ -37,7 +37,7 @@ public:
 
     bool is_finished() const override { return _is_finished; }
 
-    void finish(RuntimeState* state) override {
+    void set_finishing(RuntimeState* state) override {
         if (!_is_finished) {
             _is_finished = true;
             _except_ctx->finish_build_ht();

--- a/be/src/exec/pipeline/set/except_output_source_operator.h
+++ b/be/src/exec/pipeline/set/except_output_source_operator.h
@@ -27,7 +27,7 @@ public:
     }
 
     // Finish is noop.
-    void finish(RuntimeState* state) override {}
+    void set_finishing(RuntimeState* state) override {}
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/set/except_probe_sink_operator.h
+++ b/be/src/exec/pipeline/set/except_probe_sink_operator.h
@@ -28,7 +28,7 @@ public:
         return _except_ctx->is_dependency_finished(_dependency_index) && (_is_finished || _except_ctx->is_ht_empty());
     }
 
-    void finish(RuntimeState* state) override {
+    void set_finishing(RuntimeState* state) override {
         if (!_is_finished) {
             _is_finished = true;
             _except_ctx->finish_probe_ht();

--- a/be/src/exec/pipeline/set/intersect_build_sink_operator.h
+++ b/be/src/exec/pipeline/set/intersect_build_sink_operator.h
@@ -39,7 +39,7 @@ public:
 
     bool is_finished() const override { return _is_finished; }
 
-    void finish(RuntimeState* state) override {
+    void set_finishing(RuntimeState* state) override {
         if (!_is_finished) {
             _is_finished = true;
             _intersect_ctx->finish_build_ht();

--- a/be/src/exec/pipeline/set/intersect_output_source_operator.h
+++ b/be/src/exec/pipeline/set/intersect_output_source_operator.h
@@ -28,7 +28,7 @@ public:
     }
 
     // Finish is noop.
-    void finish(RuntimeState* state) override {}
+    void set_finishing(RuntimeState* state) override {}
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/set/intersect_probe_sink_operator.h
+++ b/be/src/exec/pipeline/set/intersect_probe_sink_operator.h
@@ -31,7 +31,7 @@ public:
                (_is_finished || _intersect_ctx->is_ht_empty());
     }
 
-    void finish(RuntimeState* state) override {
+    void set_finishing(RuntimeState* state) override {
         if (!_is_finished) {
             _is_finished = true;
             _intersect_ctx->finish_probe_ht();

--- a/be/src/exec/pipeline/set/union_const_source_operator.h
+++ b/be/src/exec/pipeline/set/union_const_source_operator.h
@@ -36,7 +36,7 @@ public:
     bool is_finished() const override { return !has_output(); };
 
     // finish is noop.
-    void finish(RuntimeState* state) override{};
+    void set_finishing(RuntimeState* state) override{};
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/set/union_passthrough_operator.h
+++ b/be/src/exec/pipeline/set/union_passthrough_operator.h
@@ -43,7 +43,7 @@ public:
 
     bool is_finished() const override { return _is_finished && _dst_chunk == nullptr; }
 
-    void finish(RuntimeState* state) override { _is_finished = true; }
+    void set_finishing(RuntimeState* state) override { _is_finished = true; }
 
     Status push_chunk(RuntimeState* state, const ChunkPtr& src_chunk) override;
 

--- a/be/src/exec/pipeline/sort/sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/sort_sink_operator.cpp
@@ -95,7 +95,7 @@ vectorized::ChunkPtr SortSinkOperator::_materialize_chunk_before_sort(vectorized
     return materialize_chunk;
 }
 
-void SortSinkOperator::finish(RuntimeState* state) {
+void SortSinkOperator::set_finishing(RuntimeState* state) {
     _chunks_sorter->finish(state);
     _is_finished = true;
 }

--- a/be/src/exec/pipeline/sort/sort_sink_operator.h
+++ b/be/src/exec/pipeline/sort/sort_sink_operator.h
@@ -52,7 +52,7 @@ public:
 
     Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override;
 
-    void finish(RuntimeState* state) override;
+    void set_finishing(RuntimeState* state) override;
 
 private:
     // This method is the same as topn node.

--- a/be/src/exec/pipeline/sort/sort_source_operator.cpp
+++ b/be/src/exec/pipeline/sort/sort_source_operator.cpp
@@ -29,7 +29,7 @@ StatusOr<vectorized::ChunkPtr> SortSourceOperator::pull_chunk(RuntimeState* stat
     }
 }
 
-void SortSourceOperator::finish(RuntimeState* state) {
+void SortSourceOperator::set_finishing(RuntimeState* state) {
     _is_finished = true;
 }
 

--- a/be/src/exec/pipeline/sort/sort_source_operator.h
+++ b/be/src/exec/pipeline/sort/sort_source_operator.h
@@ -34,7 +34,7 @@ public:
 
     void add_morsel(Morsel* morsel) {}
 
-    void finish(RuntimeState* state) override;
+    void set_finishing(RuntimeState* state) override;
 
 private:
     std::shared_ptr<vectorized::ChunksSorter> _chunks_sorter;

--- a/be/src/exec/pipeline/table_function_operator.cpp
+++ b/be/src/exec/pipeline/table_function_operator.cpp
@@ -16,7 +16,7 @@ bool TableFunctionOperator::is_finished() const {
     return _is_finished && !has_output();
 }
 
-void TableFunctionOperator::finish(RuntimeState* state) {
+void TableFunctionOperator::set_finishing(RuntimeState* state) {
     _is_finished = true;
 }
 

--- a/be/src/exec/pipeline/table_function_operator.h
+++ b/be/src/exec/pipeline/table_function_operator.h
@@ -27,7 +27,7 @@ public:
 
     bool is_finished() const override;
 
-    void finish(RuntimeState* state) override;
+    void set_finishing(RuntimeState* state) override;
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 

--- a/be/test/exec/pipeline/pipeline_control_flow_test.cpp
+++ b/be/test/exec/pipeline/pipeline_control_flow_test.cpp
@@ -75,7 +75,7 @@ public:
 
     bool has_output() const override { return _index < _chunks.size(); }
     bool is_finished() const override { return !has_output(); }
-    void finish(RuntimeState* state) override {}
+    void set_finishing(RuntimeState* state) override {}
 
     Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override;
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
@@ -126,7 +126,7 @@ public:
     bool need_input() const override { return true; }
     bool has_output() const override { return _chunk != nullptr; }
     bool is_finished() const override { return _is_finished && !has_output(); }
-    void finish(RuntimeState* state) override { _is_finished = true; }
+    void set_finishing(RuntimeState* state) override { _is_finished = true; }
 
     Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override;
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
@@ -174,7 +174,7 @@ public:
     bool need_input() const override { return true; }
     bool has_output() const override { return _chunk != nullptr; }
     bool is_finished() const override { return _is_finished; }
-    void finish(RuntimeState* state) override { _is_finished = true; }
+    void set_finishing(RuntimeState* state) override { _is_finished = true; }
 
     Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override;
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;


### PR DESCRIPTION
## Bugfix
In a pipeline, some operators can finish in advance, e.g.
1. LimitOperator: it finishes after consume sufficient rows.
2. HashJoinProbeOperator: it finishes if HashJoinBuildOperator build a empty HT and the join type is INNER JOIN, RIGHT JOIN or RIGHT SEMI-JOIN.

when a pipeline is in the form of  ExchangeSourceOperator->Operator(finish in advance) and the pipeline's dop > 1, LocalExchange would get stuck in a corner case if:
1. There exists a driver, the latter operator(i.e. HashJoinProbeOperator) is finished, then finish function of the former ExchangeSourceOperator ignores the buffered chunks the number of rows of that is taken into consideration when LocalExchanger determines whether it has available room to accept new chunks from LocalExchangeSinkOperators.
2. LocalExchanger have no available room to accept new chunks from LocalExchangeSinkOperators, so drivers that ends with the LocalExchangeSinkOperator are blocked in OUTPUT_FULL state, and drivers that starts with LocalExchangeSourceOperator are blocked in INTPUT_EMPTY state, in such scenarios, a query is always executed timeout.

The solution to this issue is that set_finished function which is invoked in the timepoint distinct from the set_finishing(original name is Operator::finish) function is added to Operator.  set_finished function is used to shutdown both input/output stream and clear the buffered data inside, while set_finishing function is just used to shutdown input stream of the operator that becomes finished until it has processed all buffered data inside.

Most of operators have trivial set_finished function that just call set_finishing function. however, ExchangeSourceOperator's set_finished function will clear the buffered chunks and subtract the number of rows of the buffered chunks from LocalExchanger and make it unblocked.