### PR TITLE
Fail fast when fe config with localhost in case of be report state with failure continuously

### DIFF
--- a/be/src/agent/heartbeat_server.cpp
+++ b/be/src/agent/heartbeat_server.cpp
@@ -94,13 +94,13 @@ Status HeartbeatServer::_heartbeat(const TMasterInfo& master_info) {
             LOG(WARNING) << "fail to set cluster id. status=" << st.get_error_msg();
             return Status::InternalError("fail to set cluster id.");
         } else {
-            _master_info->cluster_id = master_info.cluster_id;
             std::string LOCALHOST = "127.0.0.1";
             if ((master_info.network_address.hostname == LOCALHOST) && (master_info.backend_ip != LOCALHOST)) {
                 std::stringstream ss;
                 ss << "FE heartbeat with localhost ip but BE is not deployed on the same machine " << master_info.backend_ip;
                 return Status::InternalError(ss.str());
             } else {
+                _master_info->cluster_id = master_info.cluster_id;
                 LOG(INFO) << "record cluster id. host: " << master_info.network_address.hostname
                           << ". port: " << master_info.network_address.port << ". cluster id: " << master_info.cluster_id;
             }

--- a/be/src/agent/heartbeat_server.cpp
+++ b/be/src/agent/heartbeat_server.cpp
@@ -95,8 +95,15 @@ Status HeartbeatServer::_heartbeat(const TMasterInfo& master_info) {
             return Status::InternalError("fail to set cluster id.");
         } else {
             _master_info->cluster_id = master_info.cluster_id;
-            LOG(INFO) << "record cluster id. host: " << master_info.network_address.hostname
-                      << ". port: " << master_info.network_address.port << ". cluster id: " << master_info.cluster_id;
+            std::string LOCALHOST = "127.0.0.1";
+            if ((master_info.network_address.hostname == LOCALHOST) && (master_info.backend_ip != LOCALHOST)) {
+                std::stringstream ss;
+                ss << "FE heartbeat with localhost ip but BE is not deployed on the same machine " << master_info.backend_ip;
+                return Status::InternalError(ss.str());
+            } else {
+                LOG(INFO) << "record cluster id. host: " << master_info.network_address.hostname
+                          << ". port: " << master_info.network_address.port << ". cluster id: " << master_info.cluster_id;
+            }
         }
     } else {
         if (_master_info->cluster_id != master_info.cluster_id) {

--- a/be/src/agent/heartbeat_server.cpp
+++ b/be/src/agent/heartbeat_server.cpp
@@ -97,12 +97,14 @@ Status HeartbeatServer::_heartbeat(const TMasterInfo& master_info) {
             std::string LOCALHOST = "127.0.0.1";
             if ((master_info.network_address.hostname == LOCALHOST) && (master_info.backend_ip != LOCALHOST)) {
                 std::stringstream ss;
-                ss << "FE heartbeat with localhost ip but BE is not deployed on the same machine " << master_info.backend_ip;
+                ss << "FE heartbeat with localhost ip but BE is not deployed on the same machine "
+                   << master_info.backend_ip;
                 return Status::InternalError(ss.str());
             } else {
                 _master_info->cluster_id = master_info.cluster_id;
                 LOG(INFO) << "record cluster id. host: " << master_info.network_address.hostname
-                          << ". port: " << master_info.network_address.port << ". cluster id: " << master_info.cluster_id;
+                          << ". port: " << master_info.network_address.port
+                          << ". cluster id: " << master_info.cluster_id;
             }
         }
     } else {


### PR DESCRIPTION
FE config with a wrong local ip 127.0.0.1 which may caused by a wrong priority_networks
```
/apps/starrocks/fe/log/fe.log:2021-11-12 17:16:44,386 INFO (main|1) [FrontendOptions.init():96] local address: /127.0.0.1.
/apps/starrocks/fe/log/fe.log:2021-11-12 17:17:03,087 INFO (main|1) [FrontendOptions.init():96] local address: /127.0.0.1.
```
BE will report state with error continuously
```
W1112 17:46:29.757815 23335 task_worker_pool.cpp:1108] Fail to report task to :0, err=-1
W1112 17:46:39.758109 23335 utils.cpp:90] Fail to get master client from cache. host= port=0 code=THRIFT_RPC_ERROR
W1112 17:46:39.758141 23335 task_worker_pool.cpp:1108] Fail to report task to :0, err=-1
W1112 17:46:49.758456 23335 utils.cpp:90] Fail to get master client from cache. host= port=0 code=THRIFT_RPC_ERROR
```