### PR TITLE
Support create table with varchar when hive table has a column with char

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
@@ -441,7 +441,7 @@ public class HiveTable extends Table {
             case "BINARY":
                 return Sets.newHashSet(PrimitiveType.VARCHAR);
             case "CHAR":
-                return Sets.newHashSet(PrimitiveType.CHAR);
+                return Sets.newHashSet(PrimitiveType.CHAR, PrimitiveType.VARCHAR);
             case "BOOLEAN":
                 return Sets.newHashSet(PrimitiveType.BOOLEAN);
             default:


### PR DESCRIPTION
table in hive with column 
```
col_char char(100) comment "column char"
```
we should support create external table with varchar(100) since we assume they are compatible in starrocks. And convert char to varchar will not loss precision.
```
create external table ext_test (
    ->  col_char varchar(100) comment "column char" )
    ->  ENGINE=hive
    ->  properties (
    ->   "resource" = "hive0",
    ->    "table" = "hive_test",
    ->     "database" = "starrocks_hive");

ERROR 1064 (HY000): can not convert hive column type [char(100)] to starrocks type [VARCHAR]
```
