### PR TITLE
Fix right outer join bucket shuffle join bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -2047,24 +2047,16 @@ public class Coordinator {
             // So if this bucket shuffle is right join or full join, we need to add empty bucket scan range which is pruned by predicate.
             if (rightOrFullBucketShuffleFragmentIds.contains(fragmentId.asInt())) {
                 int bucketNum = getFragmentBucketNum(fragmentId);
-                HashMap<TNetworkAddress, Long> assignedBucketPerHost = Maps.newHashMap();
-                Set<TNetworkAddress> aliveBackendAdress =
-                        Catalog.getCurrentSystemInfo().getIdToBackend().values().stream().filter(Backend::isAlive)
-                                .map(be -> new TNetworkAddress(be.getHost(), be.getBePort()))
-                                .collect(Collectors.toSet());
 
                 for (int bucketSeq = 0; bucketSeq < bucketNum; ++bucketSeq) {
                     if (!bucketSeqToAddress.containsKey(bucketSeq)) {
-                        Long minAssignedBuckets = Long.MAX_VALUE;
-                        TNetworkAddress minLocation = null;
-                        for (TNetworkAddress location : aliveBackendAdress) {
-                            Long assignedBucket = findOrInsert(assignedBucketPerHost, location, 0L);
-                            if (assignedBucket < minAssignedBuckets) {
-                                minAssignedBuckets = assignedBucket;
-                                minLocation = location;
-                            }
+                        Reference<Long> backendIdRef = new Reference<>();
+                        TNetworkAddress execHostport = SimpleScheduler.getHost(idToBackend, backendIdRef);
+                        if (execHostport == null) {
+                            throw new UserException("there is no scanNode Backend");
                         }
-                        bucketSeqToAddress.put(bucketSeq, minLocation);
+                        addressToBackendID.put(execHostport, backendIdRef.getRef());
+                        bucketSeqToAddress.put(bucketSeq, execHostport);
                     }
                     if (!bucketSeqToScanRange.containsKey(bucketSeq)) {
                         bucketSeqToScanRange.put(bucketSeq, Maps.newHashMap());


### PR DESCRIPTION
In PR: https://github.com/StarRocks/starrocks/pull/1209

Don't update `addressToBackendID`, So there will be a NPE
```
2021-11-13 18:20:00,031 WARN (starrocks-mysql-nio-pool-26|305) [StmtExecutor.execute():465] execute Exception, sql select count(*) from te
st_basic_nullable as a left outer join test_basic as b on a.id_int = b.id_int where a.id_int = 1;
java.lang.NullPointerException: null
        at com.starrocks.qe.Coordinator$BackendExecState.<init>(Coordinator.java:1617) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.Coordinator.exec(Coordinator.java:513) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.StmtExecutor.handleQueryStmt(StmtExecutor.java:778) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:379) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:248) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.dispatch(ConnectProcessor.java:397) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.processOnce(ConnectProcessor.java:633) ~[starrocks-fe.jar:?]
        at com.starrocks.mysql.nio.ReadListener.lambda$handleEvent$0(ReadListener.java:54) ~[starrocks-fe.jar:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_252]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_252]
```

This PR also simplify the  execHostport select logic.