### PR TITLE
Value of _need_convert should not set when parquet type and col_type are both BOOLEAN

### DIFF
--- a/be/src/exec/parquet/column_reader.cpp
+++ b/be/src/exec/parquet/column_reader.cpp
@@ -534,6 +534,12 @@ Status ScalarColumnReader::_init_convert_info() {
         }
         break;
     }
+    case tparquet::Type::BOOLEAN: {
+        if (col_type != PrimitiveType::TYPE_BOOLEAN) {
+            _need_convert = true;
+        }
+        break;
+    }
     default:
         _need_convert = true;
         break;


### PR DESCRIPTION
Fix #1200 