### PR TITLE
[ISSUE-1262] Add pretty print to PipelineDriver

### DIFF
--- a/be/src/exec/pipeline/hashjoin/hash_join_build_operator.h
+++ b/be/src/exec/pipeline/hashjoin/hash_join_build_operator.h
@@ -30,6 +30,10 @@ public:
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
     void finish(RuntimeState* state) override;
 
+    std::string get_name() const override {
+        return strings::Substitute("$0(HashJoiner=$1)", Operator::get_name(), _hash_joiner);
+    }
+
 private:
     HashJoiner* _hash_joiner;
     bool _is_finished = false;

--- a/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.h
+++ b/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.h
@@ -25,6 +25,9 @@ public:
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state);
     void finish(RuntimeState* state) override;
     bool is_ready() const override;
+    std::string get_name() const override {
+        return strings::Substitute("$0(HashJoiner=$1)", Operator::get_name(), _hash_joiner);
+    }
 
 private:
     HashJoiner* _hash_joiner;

--- a/be/src/exec/pipeline/operator.h
+++ b/be/src/exec/pipeline/operator.h
@@ -5,6 +5,7 @@
 #include "column/vectorized_fwd.h"
 #include "common/statusor.h"
 #include "gutil/casts.h"
+#include "gutil/strings/substitute.h"
 #include "runtime/mem_tracker.h"
 #include "util/runtime_profile.h"
 
@@ -59,10 +60,8 @@ public:
 
     RuntimeProfile* get_runtime_profile() const { return _runtime_profile.get(); }
 
-    std::string get_name() const {
-        std::stringstream ss;
-        ss << _name + "_" << this;
-        return ss.str();
+    virtual std::string get_name() const {
+        return strings::Substitute("$0_$1($2)", _name, this, is_finished() ? "X" : "O");
     }
 
 protected:

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -88,7 +88,6 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state) {
                 }
                 auto status = maybe_chunk.status();
                 if (!status.ok() && !status.is_end_of_file()) {
-                    LOG(WARNING) << " status " << status.to_string();
                     return status;
                 }
 
@@ -175,7 +174,6 @@ void PipelineDriver::finish_operators(RuntimeState* state) {
 }
 
 void PipelineDriver::finalize(RuntimeState* runtime_state, DriverState state) {
-    VLOG_ROW << "[Driver] finalize, driver=" << this;
     if (state == DriverState::FINISH || state == DriverState::CANCELED || state == DriverState::INTERNAL_ERROR) {
         auto num_operators = _operators.size();
         for (auto i = _first_unfinished; i < num_operators; ++i) {
@@ -207,14 +205,13 @@ void PipelineDriver::finalize(RuntimeState* runtime_state, DriverState state) {
     if (_fragment_ctx->count_down_drivers()) {
         auto status = _fragment_ctx->final_status();
         auto fragment_id = _fragment_ctx->fragment_instance_id();
-        VLOG_ROW << "[Driver] Last driver finished: final_status=" << status.to_string();
         _query_ctx->count_down_fragments();
     }
 }
 
 std::string PipelineDriver::to_readable_string() const {
     std::stringstream ss;
-    ss << "operator-chain: [";
+    ss << "driver=" << this << ", status=" << ds_to_string(this->driver_state()) << ", operator-chain: [";
     for (size_t i = 0; i < _operators.size(); ++i) {
         if (i == 0) {
             ss << _operators[i]->get_name();

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -132,7 +132,7 @@ public:
     StatusOr<DriverState> process(RuntimeState* runtime_state);
     void finalize(RuntimeState* runtime_state, DriverState state);
     DriverAcct& driver_acct() { return _driver_acct; }
-    DriverState driver_state() { return _state; }
+    DriverState driver_state() const { return _state; }
     void set_driver_state(DriverState state) { _state = state; }
     Operators& operators() { return _operators; }
     SourceOperator* source_operator() { return down_cast<SourceOperator*>(_operators.front().get()); }


### PR DESCRIPTION
## Enhancement
Add prety print to PipelineDriver for debug, i.e.

driver=0xca924c0, status=RUNNING, operator-chain: [local_exchange_source_0xc55b530(X) -> hash_join_build_0xce49c40(O)(HashJoiner=0xcaa9210)]
driver=0xca92790, status=OUTPUT_FULL, operator-chain: [local_exchange_source_0xc55b870(X) -> hash_join_probe_0xce49da0(X)(HashJoiner=0xcaa9210) -> project_0xc55ceb0(X) -> exchange_sink_0xe129210(X)]
Notice:

O means the operator is unfinished, X means is finished