### PR TITLE
Support modify column/add bloom filter/add bitmap index for table with primary key

### DIFF
--- a/be/src/agent/heartbeat_server.h
+++ b/be/src/agent/heartbeat_server.h
@@ -42,7 +42,6 @@ class HeartbeatServer : public HeartbeatServiceIf {
 public:
     explicit HeartbeatServer(TMasterInfo* master_info);
     ~HeartbeatServer() override = default;
-    ;
 
     virtual void init_cluster_id();
 

--- a/be/src/agent/utils.h
+++ b/be/src/agent/utils.h
@@ -34,7 +34,6 @@ class MasterServerClient {
 public:
     MasterServerClient(const TMasterInfo& master_info, FrontendServiceClientCache* client_cache);
     virtual ~MasterServerClient() = default;
-    ;
 
     // Reprot finished task to the master server
     //
@@ -66,9 +65,7 @@ private:
 class AgentUtils {
 public:
     AgentUtils() = default;
-    ;
     virtual ~AgentUtils() = default;
-    ;
 
     // Use rsync synchronize folder from remote agent to local folder
     //

--- a/be/src/exprs/vectorized/cast_expr.h
+++ b/be/src/exprs/vectorized/cast_expr.h
@@ -30,7 +30,6 @@ public:
             : Expr(node), _cast_element_expr(cast_element_expr) {}
 
     ~VectorizedCastArrayExpr() override = default;
-    ;
 
     ColumnPtr evaluate(ExprContext* context, vectorized::Chunk* ptr) override {
         ColumnPtr column = _children[0]->evaluate(context, ptr);

--- a/be/src/http/action/health_action.h
+++ b/be/src/http/action/health_action.h
@@ -34,7 +34,6 @@ public:
     HealthAction(ExecEnv* exec_env);
 
     ~HealthAction() override = default;
-    ;
 
     void handle(HttpRequest* req) override;
 

--- a/be/src/plugin/plugin_loader.h
+++ b/be/src/plugin/plugin_loader.h
@@ -38,7 +38,6 @@ public:
     PluginLoader(std::string name, int type) : _name(std::move(name)), _type(type), _close(false) {}
 
     virtual ~PluginLoader() = default;
-    ;
 
     virtual Status install() = 0;
 

--- a/be/src/runtime/thread_resource_mgr.h
+++ b/be/src/runtime/thread_resource_mgr.h
@@ -87,7 +87,6 @@ public:
     class ResourcePool {
     public:
         virtual ~ResourcePool() = default;
-        ;
         // Acquire a thread for the pool.  This will always succeed; the
         // pool will go over the quota.
         // Pools should use this API to reserve threads they need in order

--- a/be/src/storage/base_tablet.h
+++ b/be/src/storage/base_tablet.h
@@ -150,7 +150,7 @@ inline void BaseTablet::set_creation_time(int64_t creation_time) {
 }
 
 inline bool BaseTablet::equal(int64_t id, int32_t hash) {
-    return (tablet_id() == id) && (schema_hash() == hash);
+    return tablet_id() == id && schema_hash() == hash;
 }
 
 inline const TabletSchema& BaseTablet::tablet_schema() const {

--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -768,7 +768,7 @@ void PrimaryIndex::unload() {
     if (!_loaded) {
         return;
     }
-    LOG(INFO) << "unload primary index tablet:" << _tablet_id << " size:" << size() << "capacity:" << capacity()
+    LOG(INFO) << "unload primary index tablet:" << _tablet_id << " size:" << size() << " capacity:" << capacity()
               << " memory: " << memory_usage();
     if (_pkey_to_rssid_rowid) {
         _pkey_to_rssid_rowid.reset();
@@ -818,7 +818,7 @@ Status PrimaryIndex::_do_load(Tablet* tablet) {
     size_t total_dels = 0;
     auto st = tablet->updates()->get_rowsets_total_stats(rowset_ids, &total_rows2, &total_dels);
     if (!st.ok() || total_rows2 != total_rows) {
-        LOG(WARNING) << "load primary index get_rowsets_total_stats error " << st;
+        LOG(WARNING) << "load primary index get_rowsets_total_stats error: " << st;
     }
     DCHECK(total_rows2 == total_rows);
     if (total_data_size > 4000000000 || total_rows > 10000000 || total_segments > 400) {

--- a/be/src/storage/rowset/beta_rowset_writer.cpp
+++ b/be/src/storage/rowset/beta_rowset_writer.cpp
@@ -291,8 +291,7 @@ Status BetaRowsetWriter::_final_merge() {
                 auto old_path =
                         BetaRowset::segment_temp_file_path(_context.rowset_path_prefix, _context.rowset_id, seg_id);
                 auto new_path = BetaRowset::segment_file_path(_context.rowset_path_prefix, _context.rowset_id, seg_id);
-                auto st = _context.env->rename_file(old_path, new_path);
-                RETURN_IF_ERROR_WITH_WARN(st, "Fail to rename file");
+                RETURN_IF_ERROR_WITH_WARN(_context.env->rename_file(old_path, new_path), "Fail to rename file");
             }
             _context.write_tmp = false;
             return Status::OK();

--- a/be/src/storage/rowset/rowset_meta_manager.cpp
+++ b/be/src/storage/rowset/rowset_meta_manager.cpp
@@ -21,34 +21,26 @@
 
 #include "storage/rowset/rowset_meta_manager.h"
 
-#include <boost/algorithm/string/trim.hpp>
-#include <fstream>
-#include <sstream>
 #include <string>
 #include <vector>
 
 #include "common/logging.h"
 #include "common/status.h"
 #include "gutil/strings/split.h"
-#include "json2pb/json_to_pb.h"
-#include "json2pb/pb_to_json.h"
-#include "storage/olap_define.h"
-#include "storage/storage_engine.h"
 
 namespace starrocks {
 
 const std::string ROWSET_PREFIX = "rst_";
 
 bool RowsetMetaManager::check_rowset_meta(KVStore* meta, const TabletUid& tablet_uid, const RowsetId& rowset_id) {
-    std::string key = ROWSET_PREFIX + tablet_uid.to_string() + "_" + rowset_id.to_string();
+    std::string key = get_rowset_meta_key(tablet_uid, rowset_id);
     std::string value;
-    Status s = meta->get(META_COLUMN_FAMILY_INDEX, key, &value);
-    return s.ok();
+    return meta->get(META_COLUMN_FAMILY_INDEX, key, &value).ok();
 }
 
 Status RowsetMetaManager::save(KVStore* meta, const TabletUid& tablet_uid, const RowsetId& rowset_id,
                                const RowsetMetaPB& rowset_meta_pb) {
-    std::string key = ROWSET_PREFIX + tablet_uid.to_string() + "_" + rowset_id.to_string();
+    std::string key = get_rowset_meta_key(tablet_uid, rowset_id);
     std::string value;
     bool ret = rowset_meta_pb.SerializeToString(&value);
     if (!ret) {
@@ -60,7 +52,7 @@ Status RowsetMetaManager::save(KVStore* meta, const TabletUid& tablet_uid, const
 }
 
 Status RowsetMetaManager::remove(KVStore* meta, const TabletUid& tablet_uid, const RowsetId& rowset_id) {
-    std::string key = ROWSET_PREFIX + tablet_uid.to_string() + "_" + rowset_id.to_string();
+    std::string key = get_rowset_meta_key(tablet_uid, rowset_id);
     return meta->remove(META_COLUMN_FAMILY_INDEX, key);
 }
 

--- a/be/src/storage/schema_change.cpp
+++ b/be/src/storage/schema_change.cpp
@@ -1602,7 +1602,7 @@ OLAPStatus SchemaChangeHandler::_do_process_alter_tablet_v2(const TAlterTabletRe
     }
 
     if (base_tablet->keys_type() == KeysType::PRIMARY_KEYS) {
-        Status st = new_tablet->updates()->perform_linked_schema_change(request.alter_version, base_tablet.get());
+        Status st = new_tablet->updates()->schema_change_linked(request.alter_version, base_tablet.get());
         if (!st.ok()) {
             LOG(WARNING) << "schema change new tablet load snapshot error " << st.to_string();
             return OLAP_ERR_OTHER_ERROR;

--- a/be/src/storage/schema_change.cpp
+++ b/be/src/storage/schema_change.cpp
@@ -1602,7 +1602,7 @@ OLAPStatus SchemaChangeHandler::_do_process_alter_tablet_v2(const TAlterTabletRe
     }
 
     if (base_tablet->keys_type() == KeysType::PRIMARY_KEYS) {
-        Status st = new_tablet->updates()->schema_change_linked(request.alter_version, base_tablet.get());
+        Status st = new_tablet->updates()->link_from(base_tablet.get(), request.alter_version);
         if (!st.ok()) {
             LOG(WARNING) << "schema change new tablet load snapshot error " << st.to_string();
             return OLAP_ERR_OTHER_ERROR;

--- a/be/src/storage/schema_change.cpp
+++ b/be/src/storage/schema_change.cpp
@@ -1602,7 +1602,7 @@ OLAPStatus SchemaChangeHandler::_do_process_alter_tablet_v2(const TAlterTabletRe
     }
 
     if (base_tablet->keys_type() == KeysType::PRIMARY_KEYS) {
-        Status st = new_tablet->updates()->load_from_base_tablet(request.alter_version, base_tablet.get());
+        Status st = new_tablet->updates()->perform_linked_schema_change(request.alter_version, base_tablet.get());
         if (!st.ok()) {
             LOG(WARNING) << "schema change new tablet load snapshot error " << st.to_string();
             return OLAP_ERR_OTHER_ERROR;

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -847,8 +847,8 @@ void StorageEngine::add_unused_rowset(const RowsetSharedPtr& rowset) {
         return;
     }
 
-    VLOG(3) << "add unused rowset, rowset id:" << rowset->rowset_id() << ", version:" << rowset->version().first << "-"
-            << rowset->version().second << ", unique id:" << rowset->unique_id();
+    VLOG(3) << "add unused rowset, rowset id:" << rowset->rowset_id() << ", version:" << rowset->version()
+            << ", unique id:" << rowset->unique_id();
 
     auto rowset_id = rowset->rowset_id().to_string();
 

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -66,23 +66,6 @@
 #include "util/time.h"
 #include "util/trace.h"
 
-using apache::thrift::ThriftDebugString;
-
-using std::back_inserter;
-using std::copy;
-using std::inserter;
-using std::list;
-using std::map;
-using std::nothrow;
-using std::pair;
-using std::priority_queue;
-using std::set;
-using std::set_difference;
-using std::string;
-using std::stringstream;
-using std::vector;
-using strings::Substitute;
-
 namespace starrocks {
 
 StorageEngine* StorageEngine::_s_instance = nullptr;
@@ -230,7 +213,7 @@ Status StorageEngine::_init_store_map() {
 }
 
 void StorageEngine::_update_storage_medium_type_count() {
-    set<TStorageMedium::type> available_storage_medium_types;
+    std::set<TStorageMedium::type> available_storage_medium_types;
 
     std::lock_guard<std::mutex> l(_store_lock);
     for (auto& it : _store_map) {
@@ -404,8 +387,7 @@ std::vector<DataDir*> StorageEngine::get_stores_for_create_tablet(TStorageMedium
         }
     }
     //  TODO(lingbin): should it be a global util func?
-    std::random_device rd;
-    srand(rd());
+    std::srand(std::random_device()());
     std::shuffle(stores.begin(), stores.end(), std::mt19937(std::random_device()()));
     return stores;
 }
@@ -715,14 +697,14 @@ OLAPStatus StorageEngine::_start_trash_sweep(double* usage) {
         *usage = *usage > curr_usage ? *usage : curr_usage;
 
         OLAPStatus curr_res = OLAP_SUCCESS;
-        string snapshot_path = info.path + SNAPSHOT_PREFIX;
+        std::string snapshot_path = info.path + SNAPSHOT_PREFIX;
         curr_res = _do_sweep(snapshot_path, local_now, snapshot_expire);
         if (curr_res != OLAP_SUCCESS) {
             LOG(WARNING) << "failed to sweep snapshot. path=" << snapshot_path << ", err_code=" << curr_res;
             res = curr_res;
         }
 
-        string trash_path = info.path + TRASH_PREFIX;
+        std::string trash_path = info.path + TRASH_PREFIX;
         curr_res = _do_sweep(trash_path, local_now, curr_usage > guard_space ? 0 : trash_expire);
         if (curr_res != OLAP_SUCCESS) {
             LOG(WARNING) << "failed to sweep trash. [path=%s" << trash_path << ", err_code=" << curr_res;
@@ -797,7 +779,7 @@ void StorageEngine::_clean_unused_txns() {
     }
 }
 
-OLAPStatus StorageEngine::_do_sweep(const string& scan_root, const time_t& local_now, const int32_t expire) {
+OLAPStatus StorageEngine::_do_sweep(const std::string& scan_root, const time_t& local_now, const int32_t expire) {
     OLAPStatus res = OLAP_SUCCESS;
     if (!FileUtils::check_exist(scan_root)) {
         // dir not existed. no need to sweep trash.
@@ -806,9 +788,9 @@ OLAPStatus StorageEngine::_do_sweep(const string& scan_root, const time_t& local
 
     try {
         for (const auto& item : std::filesystem::directory_iterator(scan_root)) {
-            string path_name = item.path().string();
-            string dir_name = item.path().filename().string();
-            string str_time = dir_name.substr(0, dir_name.find('.'));
+            std::string path_name = item.path().string();
+            std::string dir_name = item.path().filename().string();
+            std::string str_time = dir_name.substr(0, dir_name.find('.'));
             tm local_tm_create;
             memset(&local_tm_create, 0, sizeof(tm));
 
@@ -822,7 +804,7 @@ OLAPStatus StorageEngine::_do_sweep(const string& scan_root, const time_t& local
             // try get timeout in dir name, the old snapshot dir does not contain timeout
             // eg: 20190818221123.3.86400, the 86400 is timeout, in second
             size_t pos = dir_name.find('.', str_time.size() + 1);
-            if (pos != string::npos) {
+            if (pos != std::string::npos) {
                 actual_expire = std::stoi(dir_name.substr(pos + 1));
             }
             VLOG(10) << "get actual expire time " << actual_expire << " of dir: " << dir_name;
@@ -871,8 +853,7 @@ void StorageEngine::add_unused_rowset(const RowsetSharedPtr& rowset) {
     auto rowset_id = rowset->rowset_id().to_string();
 
     std::lock_guard lock(_gc_mutex);
-    auto it = _unused_rowsets.find(rowset_id);
-    if (it == _unused_rowsets.end()) {
+    if (_unused_rowsets.find(rowset_id) == _unused_rowsets.end()) {
         rowset->set_need_delete_file();
         rowset->close();
         _unused_rowsets[rowset_id] = rowset;
@@ -931,7 +912,7 @@ OLAPStatus StorageEngine::obtain_shard_path(TStorageMedium::type storage_medium,
     return res;
 }
 
-OLAPStatus StorageEngine::load_header(const string& shard_path, const TCloneReq& request, bool restore,
+OLAPStatus StorageEngine::load_header(const std::string& shard_path, const TCloneReq& request, bool restore,
                                       bool is_primary_key) {
     DataDir* store = nullptr;
     {

--- a/be/src/storage/tablet_meta_manager.cpp
+++ b/be/src/storage/tablet_meta_manager.cpp
@@ -674,19 +674,19 @@ Status TabletMetaManager::rowset_commit(DataDir* store, TTabletId tablet_id, int
     auto handle = store->get_meta()->handle(META_COLUMN_FAMILY_INDEX);
     string logkey = encode_meta_log_key(tablet_id, logid);
     TabletMetaLogPB log;
-    auto op = log.add_ops();
-    op->set_type(TabletMetaOpType::OP_ROWSET_COMMIT);
-    op->set_allocated_commit(edit);
-    auto logv = log.SerializeAsString();
-    op->release_commit();
-    rocksdb::Status st = batch.Put(handle, logkey, logv);
+    auto ops = log.add_ops();
+    ops->set_type(TabletMetaOpType::OP_ROWSET_COMMIT);
+    ops->set_allocated_commit(edit);
+    auto logvalue = log.SerializeAsString();
+    ops->release_commit();
+    rocksdb::Status st = batch.Put(handle, logkey, logvalue);
     if (!st.ok()) {
         LOG(WARNING) << "rowset_commit failed, rocksdb.batch.put failed";
         return to_status(st);
     }
     string rowsetkey = encode_meta_rowset_key(tablet_id, rowset.rowset_seg_id());
-    auto rowsetv = rowset.SerializeAsString();
-    st = batch.Put(handle, rowsetkey, rowsetv);
+    auto rowsetvalue = rowset.SerializeAsString();
+    st = batch.Put(handle, rowsetkey, rowsetvalue);
     if (!st.ok()) {
         LOG(WARNING) << "rowset_commit failed, rocksdb.batch.put failed";
         return to_status(st);
@@ -744,15 +744,15 @@ Status TabletMetaManager::apply_rowset_commit(DataDir* store, TTabletId tablet_i
                                               vector<std::pair<uint32_t, DelVectorPtr>>& delvecs) {
     WriteBatch batch;
     auto handle = store->get_meta()->handle(META_COLUMN_FAMILY_INDEX);
+    string logkey = encode_meta_log_key(tablet_id, logid);
     TabletMetaLogPB log;
-    auto op = log.add_ops();
-    op->set_type(TabletMetaOpType::OP_APPLY);
-    auto version_pb = op->mutable_apply();
+    auto ops = log.add_ops();
+    ops->set_type(TabletMetaOpType::OP_APPLY);
+    auto version_pb = ops->mutable_apply();
     version_pb->set_major(version.major());
     version_pb->set_minor(version.minor());
-    string logkey = encode_meta_log_key(tablet_id, logid);
-    auto logv = log.SerializeAsString();
-    rocksdb::Status st = batch.Put(handle, logkey, logv);
+    auto logval = log.SerializeAsString();
+    rocksdb::Status st = batch.Put(handle, logkey, logval);
     if (!st.ok()) {
         LOG(WARNING) << "rowset_commit failed, rocksdb.batch.put failed";
         return to_status(st);
@@ -778,23 +778,22 @@ Status TabletMetaManager::traverse_meta_logs(DataDir* store, TTabletId tablet_id
     std::string lower_bound = encode_meta_log_key(tablet_id, 0);
     std::string upper_bound = encode_meta_log_key(tablet_id, UINT64_MAX);
 
-    auto fn = [&](const std::string_view& key, const std::string_view& value) {
-        TTabletId tid;
-        uint64_t logid;
-        if (!decode_meta_log_key(key, &tid, &logid)) {
-            ret = Status::Corruption("corrupted key of meta log");
-            return false;
-        }
-        DCHECK_EQ(tablet_id, tid);
-        TabletMetaLogPB log;
-        if (!log.ParseFromArray(value.data(), value.size())) {
-            ret = Status::Corruption("corrupted value of meta log");
-            return false;
-        }
-        return func(logid, log);
-    };
-
-    auto st = store->get_meta()->iterate_range(META_COLUMN_FAMILY_INDEX, lower_bound, upper_bound, fn);
+    auto st = store->get_meta()->iterate_range(META_COLUMN_FAMILY_INDEX, lower_bound, upper_bound,
+                                               [&](const std::string_view& key, const std::string_view& value) {
+                                                   TTabletId tid;
+                                                   uint64_t logid;
+                                                   if (!decode_meta_log_key(key, &tid, &logid)) {
+                                                       ret = Status::Corruption("corrupted key of meta log");
+                                                       return false;
+                                                   }
+                                                   DCHECK_EQ(tablet_id, tid);
+                                                   TabletMetaLogPB log;
+                                                   if (!log.ParseFromArray(value.data(), value.size())) {
+                                                       ret = Status::Corruption("corrupted value of meta log");
+                                                       return false;
+                                                   }
+                                                   return func(logid, log);
+                                               });
     if (!st.ok()) {
         LOG(WARNING) << "Fail to iterate log, ret=" << st.to_string();
         ret = st;
@@ -885,9 +884,9 @@ Status TabletMetaManager::delete_del_vector_range(KVStore* meta, TTabletId table
     std::string end_key = encode_del_vector_key(tablet_id, segment_id, start_version - 1);
     auto cf_handle = meta->handle(META_COLUMN_FAMILY_INDEX);
     WriteBatch batch;
-    rocksdb::Status st1 = batch.DeleteRange(cf_handle, begin_key, end_key);
-    if (!st1.ok()) {
-        return to_status(st1);
+    rocksdb::Status st = batch.DeleteRange(cf_handle, begin_key, end_key);
+    if (!st.ok()) {
+        return to_status(st);
     }
     return meta->write_batch(&batch);
 }
@@ -1160,8 +1159,8 @@ Status TabletMetaManager::pending_rowset_commit(DataDir* store, TTabletId tablet
         }
     }
     auto pkey = encode_meta_pending_rowset_key(tablet_id, version);
-    auto pv = rowset.SerializeAsString();
-    auto st = batch.Put(handle, pkey, pv);
+    auto pvalue = rowset.SerializeAsString();
+    auto st = batch.Put(handle, pkey, pvalue);
     if (!st.ok()) {
         LOG(WARNING) << "pending_rowset_commit, rocksdb.batch.put failed";
         return to_status(st);

--- a/be/src/storage/tablet_schema.cpp
+++ b/be/src/storage/tablet_schema.cpp
@@ -484,16 +484,14 @@ size_t TabletSchema::row_size() const {
 }
 
 size_t TabletSchema::field_index(const std::string& field_name) const {
-    bool field_exist = false;
     int ordinal = -1;
     for (auto& column : _cols) {
         ordinal++;
         if (column.name() == field_name) {
-            field_exist = true;
-            break;
+            return ordinal;
         }
     }
-    return field_exist ? ordinal : -1;
+    return -1;
 }
 
 const std::vector<TabletColumn>& TabletSchema::columns() const {

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -1882,7 +1882,7 @@ Status TabletUpdates::load_from_base_tablet(const TAlterTabletReqV2& request,
         writer_context.partition_id = _tablet.partition_id();
         writer_context.tablet_schema_hash = _tablet.schema_hash();
         writer_context.rowset_type = _tablet.tablet_meta()->preferred_rowset_type();
-        writer_context.rowset_path_prefix = _tablet.tablet_path();
+        writer_context.rowset_path_prefix = _tablet.schema_hash_path();
         writer_context.tablet_schema = &_tablet.tablet_schema();
         writer_context.rowset_state = VISIBLE;
         writer_context.version = rowset->version();

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -32,6 +32,7 @@
 #include "storage/vectorized/chunk_helper.h"
 #include "storage/vectorized/chunk_iterator.h"
 #include "storage/vectorized/rowset_merger.h"
+#include "storage/vectorized/schema_change.h"
 #include "util/defer_op.h"
 #include "util/pretty_printer.h"
 #include "util/scoped_cleanup.h"
@@ -60,8 +61,7 @@ vector<uint32_t> modify(const vector<uint32_t>& orig, Itr1 add_begin, Itr1 add_e
     ret.reserve(orig.size() + (add_end - add_begin) + (del_end - del_begin));
     for (auto v : orig) {
         // TODO: optimize when #dels is large
-        bool ok = std::find(del_begin, del_end, v) == del_end;
-        if (ok) {
+        if (std::find(del_begin, del_end, v) == del_end) {
             ret.push_back(v);
         }
     }
@@ -88,38 +88,39 @@ Status TabletUpdates::init() {
     return _load_from_pb(*updates);
 }
 
-Status TabletUpdates::_load_from_pb(const TabletUpdatesPB& updates) {
+Status TabletUpdates::_load_from_pb(const TabletUpdatesPB& tablet_updates_pb) {
     std::unique_lock l1(_lock);
     std::unique_lock l2(_rowsets_lock);
-    const auto& versions = updates.versions();
-    if (versions.size() == 0) {
+    const auto& edit_version_meta_pbs = tablet_updates_pb.versions();
+    if (edit_version_meta_pbs.empty()) {
         _set_error();
-        string msg = "updates.versions should have at least 1 version";
+        string msg = "tablet_updates_pb.edit_version_meta_pbs should have at least 1 version";
         LOG(ERROR) << msg;
         return Status::InternalError(msg);
     }
-    _versions.clear();
-    for (auto& v : versions) {
-        _redo_edit_version_log(v);
+    _edit_version_infos.clear();
+    for (auto& edit_version_meta_pb : edit_version_meta_pbs) {
+        _redo_edit_version_log(edit_version_meta_pb);
     }
-    EditVersion apply_version(updates.apply_version().major(), updates.apply_version().minor());
+    EditVersion apply_version(tablet_updates_pb.apply_version().major(), tablet_updates_pb.apply_version().minor());
     _sync_apply_version_idx(apply_version);
 
-    _next_rowset_id = updates.next_rowset_id();
-    _next_log_id = updates.next_log_id();
-    auto apply_log_func = [&](uint64_t logid, const TabletMetaLogPB& log) -> bool {
-        CHECK(!log.ops().empty());
-        for (auto& op : log.ops()) {
-            switch (op.type()) {
+    _next_rowset_id = tablet_updates_pb.next_rowset_id();
+    _next_log_id = tablet_updates_pb.next_log_id();
+    auto apply_log_func = [&](uint64_t logid, const TabletMetaLogPB& tablet_meta_log_pb) -> bool {
+        CHECK(!tablet_meta_log_pb.ops().empty());
+        for (auto& tablet_meta_op_pb : tablet_meta_log_pb.ops()) {
+            switch (tablet_meta_op_pb.type()) {
             case OP_ROWSET_COMMIT:
             case OP_COMPACTION_COMMIT:
-                _redo_edit_version_log(op.commit());
+                _redo_edit_version_log(tablet_meta_op_pb.commit());
                 break;
             case OP_APPLY:
-                _sync_apply_version_idx(EditVersion(op.apply().major(), op.apply().minor()));
+                _sync_apply_version_idx(
+                        EditVersion(tablet_meta_op_pb.apply().major(), tablet_meta_op_pb.apply().minor()));
                 break;
             default:
-                LOG(FATAL) << "unsupported TabletMetaLogPB type: " << TabletMetaOpType_Name(op.type());
+                LOG(FATAL) << "unsupported TabletMetaLogPB type: " << TabletMetaOpType_Name(tablet_meta_op_pb.type());
             }
         }
         _next_log_id = logid + 1;
@@ -129,24 +130,26 @@ Status TabletUpdates::_load_from_pb(const TabletUpdatesPB& updates) {
     if (!st.ok()) {
         return st;
     }
-    DCHECK_LE(updates.next_log_id(), _next_log_id) << " tabletid:" << _tablet.tablet_id();
+    DCHECK_LE(tablet_updates_pb.next_log_id(), _next_log_id) << " tabletid:" << _tablet.tablet_id();
 
     // Load pending rowsets
-    auto pending_rowset_iter_func = [&](int64_t version, const std::string_view& rowset_meta_data) -> bool {
-        RowsetMetaSharedPtr rowset_meta(new RowsetMeta());
-        CHECK(rowset_meta->init(rowset_meta_data)) << "Corrupted rowset meta";
-        RowsetSharedPtr rowset;
-        st = RowsetFactory::create_rowset(&_tablet.tablet_schema(), _tablet.schema_hash_path(), rowset_meta, &rowset);
-        if (st.ok()) {
-            _pending_commits.emplace(version, rowset);
-        } else {
-            LOG(WARNING) << "Fail to create rowset from pending rowset meta. rowset=" << rowset_meta->rowset_id()
-                         << " type=" << rowset_meta->rowset_type() << " state=" << rowset_meta->rowset_state();
-        }
-        return true;
-    };
-    RETURN_IF_ERROR(TabletMetaManager::pending_rowset_iterate(_tablet.data_dir(), _tablet.tablet_id(),
-                                                              pending_rowset_iter_func));
+    RETURN_IF_ERROR(TabletMetaManager::pending_rowset_iterate(
+            _tablet.data_dir(), _tablet.tablet_id(),
+            [&](int64_t version, const std::string_view& rowset_meta_data) -> bool {
+                RowsetMetaSharedPtr rowset_meta(new RowsetMeta());
+                CHECK(rowset_meta->init(rowset_meta_data)) << "Corrupted rowset meta";
+                RowsetSharedPtr rowset;
+                st = RowsetFactory::create_rowset(&_tablet.tablet_schema(), _tablet.schema_hash_path(), rowset_meta,
+                                                  &rowset);
+                if (st.ok()) {
+                    _pending_commits.emplace(version, rowset);
+                } else {
+                    LOG(WARNING) << "Fail to create rowset from pending rowset meta. rowset="
+                                 << rowset_meta->rowset_id() << " type=" << rowset_meta->rowset_type()
+                                 << " state=" << rowset_meta->rowset_state();
+                }
+                return true;
+            }));
 
     std::set<uint32_t> all_rowsets;
     std::set<uint32_t> active_rowsets;
@@ -156,23 +159,24 @@ Status TabletUpdates::_load_from_pb(const TabletUpdatesPB& updates) {
     // Load all rowsets of this tablet into memory.
     // NOTE: This may change in a near future, e.g, manage rowsets in a separate module and load
     // them on demand.
-    auto rowset_iterate_func = [&](const RowsetMetaSharedPtr& rowset_meta) -> bool {
-        RowsetSharedPtr rowset;
-        st = RowsetFactory::create_rowset(&_tablet.tablet_schema(), _tablet.schema_hash_path(), rowset_meta, &rowset);
-        if (st.ok()) {
-            _rowsets[rowset_meta->get_rowset_seg_id()] = std::move(rowset);
-        } else {
-            LOG(WARNING) << "Fail to create rowset from rowset meta. rowset=" << rowset_meta->rowset_id()
-                         << " type=" << rowset_meta->rowset_type() << " state=" << rowset_meta->rowset_state();
-        }
-        all_rowsets.insert(rowset_meta->get_rowset_seg_id());
-        return true;
-    };
-    RETURN_IF_ERROR(TabletMetaManager::rowset_iterate(_tablet.data_dir(), _tablet.tablet_id(), rowset_iterate_func));
+    RETURN_IF_ERROR(TabletMetaManager::rowset_iterate(
+            _tablet.data_dir(), _tablet.tablet_id(), [&](const RowsetMetaSharedPtr& rowset_meta) -> bool {
+                RowsetSharedPtr rowset;
+                st = RowsetFactory::create_rowset(&_tablet.tablet_schema(), _tablet.schema_hash_path(), rowset_meta,
+                                                  &rowset);
+                if (st.ok()) {
+                    _rowsets[rowset_meta->get_rowset_seg_id()] = std::move(rowset);
+                } else {
+                    LOG(WARNING) << "Fail to create rowset from rowset meta. rowset=" << rowset_meta->rowset_id()
+                                 << " type=" << rowset_meta->rowset_type() << " state=" << rowset_meta->rowset_state();
+                }
+                all_rowsets.insert(rowset_meta->get_rowset_seg_id());
+                return true;
+            }));
 
     // Find unused rowsets.
-    for (size_t i = 0; i < _versions.size(); i++) {
-        auto& rs = _versions[i]->rowsets;
+    for (size_t i = 0; i < _edit_version_infos.size(); i++) {
+        auto& rs = _edit_version_infos[i]->rowsets;
         for (auto rid : rs) {
             bool inserted = active_rowsets.insert(rid).second;
             if (i > _apply_version_idx && inserted) {
@@ -215,8 +219,8 @@ Status TabletUpdates::_load_from_pb(const TabletUpdatesPB& updates) {
         if (unapplied_rowsets.find(rsid) == unapplied_rowsets.end()) {
             // rowset applied, must have delvec
             for (int i = 0; i < rowset->num_segments(); i++) {
-                int64_t dummy;
                 DelVector delvec;
+                int64_t dummy;
                 auto st = TabletMetaManager::get_del_vector(_tablet.data_dir()->get_meta(), _tablet.tablet_id(),
                                                             rsid + i, INT64_MAX, &delvec, &dummy);
                 if (!st.ok()) {
@@ -233,7 +237,7 @@ Status TabletUpdates::_load_from_pb(const TabletUpdatesPB& updates) {
         _rowset_stats.emplace(rsid, std::move(stats));
     }
     l2.unlock(); // _rowsets_lock
-    _update_total_stats(_versions[_apply_version_idx]->rowsets);
+    _update_total_stats(_edit_version_infos[_apply_version_idx]->rowsets);
     VLOG(1) << "load tablet " << _debug_string(false, true);
     _try_commit_pendings_unlocked();
     _check_for_apply();
@@ -247,7 +251,7 @@ size_t TabletUpdates::data_size() const {
     {
         std::lock_guard rl(_lock);
         std::lock_guard lg(_rowset_stats_lock);
-        auto& last = _versions.back();
+        auto& last = _edit_version_infos.back();
         for (uint32_t rowsetid : last->rowsets) {
             auto itr = _rowset_stats.find(rowsetid);
             if (itr != _rowset_stats.end()) {
@@ -270,7 +274,7 @@ size_t TabletUpdates::num_rows() const {
     {
         std::lock_guard rl(_lock);
         std::lock_guard lg(_rowset_stats_lock);
-        auto& last = _versions.back();
+        auto& last = _edit_version_infos.back();
         for (uint32_t rowsetid : last->rowsets) {
             auto itr = _rowset_stats.find(rowsetid);
             if (itr != _rowset_stats.end()) {
@@ -289,14 +293,14 @@ size_t TabletUpdates::num_rows() const {
 
 size_t TabletUpdates::num_rowsets() const {
     std::lock_guard rl(_lock);
-    return _versions.empty() ? 0 : _versions.back()->rowsets.size();
+    return _edit_version_infos.empty() ? 0 : _edit_version_infos.back()->rowsets.size();
 }
 
 size_t TabletUpdates::version_count() const {
     std::lock_guard rl(_lock);
     size_t ret = _pending_commits.size();
-    if (!_versions.empty()) {
-        ret += _versions.back()->rowsets.size();
+    if (!_edit_version_infos.empty()) {
+        ret += _edit_version_infos.back()->rowsets.size();
     }
     return ret;
 }
@@ -308,7 +312,7 @@ size_t TabletUpdates::num_pending() const {
 
 int64_t TabletUpdates::max_version() const {
     std::lock_guard rl(_lock);
-    return _versions.empty() ? 0 : _versions.back()->version.major();
+    return _edit_version_infos.empty() ? 0 : _edit_version_infos.back()->version.major();
 }
 
 Status TabletUpdates::get_rowsets_total_stats(const std::vector<uint32_t>& rowsets, size_t* total_rows,
@@ -333,12 +337,12 @@ Status TabletUpdates::get_rowsets_total_stats(const std::vector<uint32_t>& rowse
     return Status::OK();
 }
 
-void TabletUpdates::_sync_apply_version_idx(const EditVersion& v) {
-    // usually applied version is at the end of _versions vector
+void TabletUpdates::_sync_apply_version_idx(const EditVersion& edit_version) {
+    // usually applied version is at the end of _edit_version_infos vector
     // so search from the back
     // assuming _lock held
-    for (ssize_t i = _versions.size() - 1; i >= 0; i--) {
-        if (_versions[i]->version == v) {
+    for (ssize_t i = _edit_version_infos.size() - 1; i >= 0; i--) {
+        if (_edit_version_infos[i]->version == edit_version) {
             _apply_version_idx = i;
             _apply_version_changed.notify_all();
             return;
@@ -348,41 +352,45 @@ void TabletUpdates::_sync_apply_version_idx(const EditVersion& v) {
     _set_error();
 }
 
-void TabletUpdates::_redo_edit_version_log(const EditVersionMetaPB& v) {
-    std::unique_ptr<EditVersionInfo> tmp = std::make_unique<EditVersionInfo>();
-    tmp->version = EditVersion(v.version().major(), v.version().minor());
-    tmp->creation_time = v.creation_time();
-    if (v.rowsets_add_size() > 0 || v.rowsets_del_size() > 0) {
+void TabletUpdates::_redo_edit_version_log(const EditVersionMetaPB& edit_version_meta_pb) {
+    std::unique_ptr<EditVersionInfo> edit_version_info = std::make_unique<EditVersionInfo>();
+    edit_version_info->version =
+            EditVersion(edit_version_meta_pb.version().major(), edit_version_meta_pb.version().minor());
+    edit_version_info->creation_time = edit_version_meta_pb.creation_time();
+    if (edit_version_meta_pb.rowsets_add_size() > 0 || edit_version_meta_pb.rowsets_del_size() > 0) {
         // incremental
-        CHECK(!_versions.empty()) << "incremental edit without full last version";
-        auto& last_rowsets = _versions.back()->rowsets;
-        auto new_rowsets = modify(last_rowsets, v.rowsets_add().begin(), v.rowsets_add().end(), v.rowsets_del().begin(),
-                                  v.rowsets_del().end());
-        tmp->rowsets.swap(new_rowsets);
+        CHECK(!_edit_version_infos.empty()) << "incremental edit without full last version";
+        auto& last_rowsets = _edit_version_infos.back()->rowsets;
+        auto new_rowsets = modify(last_rowsets, edit_version_meta_pb.rowsets_add().begin(),
+                                  edit_version_meta_pb.rowsets_add().end(), edit_version_meta_pb.rowsets_del().begin(),
+                                  edit_version_meta_pb.rowsets_del().end());
+        edit_version_info->rowsets.swap(new_rowsets);
     } else {
         // full
-        tmp->rowsets.assign(v.rowsets().begin(), v.rowsets().end());
+        edit_version_info->rowsets.assign(edit_version_meta_pb.rowsets().begin(), edit_version_meta_pb.rowsets().end());
     }
-    tmp->deltas.assign(v.deltas().begin(), v.deltas().end());
-    if (v.has_compaction()) {
-        tmp->compaction = std::make_unique<CompactionInfo>();
-        auto& cpb = v.compaction();
-        tmp->compaction->start_version = EditVersion(cpb.start_version().major(), cpb.start_version().minor());
-        tmp->compaction->inputs.assign(cpb.inputs().begin(), cpb.inputs().end());
-        tmp->compaction->output = cpb.outputs()[0];
+    edit_version_info->deltas.assign(edit_version_meta_pb.deltas().begin(), edit_version_meta_pb.deltas().end());
+    if (edit_version_meta_pb.has_compaction()) {
+        edit_version_info->compaction = std::make_unique<CompactionInfo>();
+        auto& compaction_info_pb = edit_version_meta_pb.compaction();
+        edit_version_info->compaction->start_version =
+                EditVersion(compaction_info_pb.start_version().major(), compaction_info_pb.start_version().minor());
+        edit_version_info->compaction->inputs.assign(compaction_info_pb.inputs().begin(),
+                                                     compaction_info_pb.inputs().end());
+        edit_version_info->compaction->output = compaction_info_pb.outputs()[0];
     }
-    _versions.emplace_back(std::move(tmp));
-    _next_rowset_id += v.rowsetid_add();
+    _edit_version_infos.emplace_back(std::move(edit_version_info));
+    _next_rowset_id += edit_version_meta_pb.rowsetid_add();
 }
 
 Status TabletUpdates::_get_apply_version_and_rowsets(int64_t* version, std::vector<RowsetSharedPtr>* rowsets,
                                                      std::vector<uint32_t>* rowset_ids) {
     std::lock_guard rl(_lock);
-    EditVersionInfo* v = nullptr;
-    v = _versions[_apply_version_idx].get();
-    rowsets->reserve(v->rowsets.size());
+    EditVersionInfo* edit_version_info = nullptr;
+    edit_version_info = _edit_version_infos[_apply_version_idx].get();
+    rowsets->reserve(edit_version_info->rowsets.size());
     std::lock_guard<std::mutex> lg(_rowsets_lock);
-    for (uint32_t rsid : v->rowsets) {
+    for (uint32_t rsid : edit_version_info->rowsets) {
         auto itr = _rowsets.find(rsid);
         DCHECK(itr != _rowsets.end());
         if (itr != _rowsets.end()) {
@@ -393,8 +401,8 @@ Status TabletUpdates::_get_apply_version_and_rowsets(int64_t* version, std::vect
                                _debug_string(false, true)));
         }
     }
-    rowset_ids->assign(v->rowsets.begin(), v->rowsets.end());
-    *version = v->version.major();
+    rowset_ids->assign(edit_version_info->rowsets.begin(), edit_version_info->rowsets.end());
+    *version = edit_version_info->version.major();
     return Status::OK();
 }
 
@@ -420,11 +428,11 @@ Status TabletUpdates::rowset_commit(int64_t version, const RowsetSharedPtr& rows
     Status st;
     {
         std::lock_guard wl(_lock);
-        if (version <= _versions.back()->version.major()) {
+        if (version <= _edit_version_infos.back()->version.major()) {
             LOG(WARNING) << "ignored already committed version " << version << " of tablet " << _tablet.tablet_id();
             _ignore_rowset_commit(version, rowset);
             return Status::OK();
-        } else if (version > _versions.back()->version.major() + 1) {
+        } else if (version > _edit_version_infos.back()->version.major() + 1) {
             if (_pending_commits.size() > 100) {
                 // there must be something wrong, return error rather than accepting more commits
                 string msg = Substitute(
@@ -434,17 +442,15 @@ Status TabletUpdates::rowset_commit(int64_t version, const RowsetSharedPtr& rows
                 LOG(WARNING) << msg;
                 return Status::InternalError(msg);
             }
-            auto ret = _pending_commits.emplace(version, rowset);
-            if (!ret.second) {
+            if (!_pending_commits.emplace(version, rowset).second) {
                 LOG(WARNING) << "ignore add rowset to pending commits, same version already "
                                 "exists version:"
                              << version << " " << _debug_string(false, false);
                 _ignore_rowset_commit(version, rowset);
             } else {
-                auto& rowset_meta = rowset->rowset_meta()->get_meta_pb();
-                string rkey = RowsetMetaManager::get_rowset_meta_key(_tablet.tablet_uid(), rowset->rowset_id());
-                st = TabletMetaManager::pending_rowset_commit(_tablet.data_dir(), _tablet.tablet_id(), version,
-                                                              rowset_meta, rkey);
+                st = TabletMetaManager::pending_rowset_commit(
+                        _tablet.data_dir(), _tablet.tablet_id(), version, rowset->rowset_meta()->get_meta_pb(),
+                        RowsetMetaManager::get_rowset_meta_key(_tablet.tablet_uid(), rowset->rowset_id()));
                 if (!st.ok()) {
                     LOG(WARNING) << "add rowset to pending commits failed tablet:" << _tablet.tablet_id()
                                  << " version:" << version << " " << st << " " << _debug_string(false, true);
@@ -475,19 +481,18 @@ Status TabletUpdates::rowset_commit(int64_t version, const RowsetSharedPtr& rows
 
 Status TabletUpdates::_rowset_commit_unlocked(int64_t version, const RowsetSharedPtr& rowset) {
     EditVersionMetaPB edit;
-    auto v = edit.mutable_version();
-    v->set_major(version);
-    v->set_minor(0);
+    auto edit_version_pb = edit.mutable_version();
+    edit_version_pb->set_major(version);
+    edit_version_pb->set_minor(0);
     int64_t creation_time = time(nullptr);
     edit.set_creation_time(creation_time);
     std::vector<uint32_t> nrs;
     uint32_t rowsetid = _next_rowset_id;
-    if (_versions.empty()) {
-        auto mrs = edit.mutable_rowsets();
-        mrs->Add(rowsetid);
+    if (_edit_version_infos.empty()) {
+        edit.mutable_rowsets()->Add(rowsetid);
         nrs.emplace_back(rowsetid);
     } else {
-        auto& ors = _versions.back()->rowsets;
+        auto& ors = _edit_version_infos.back()->rowsets;
         nrs.reserve(ors.size() + 1);
         nrs.assign(ors.begin(), ors.end());
         nrs.push_back(rowsetid);
@@ -504,10 +509,9 @@ Status TabletUpdates::_rowset_commit_unlocked(int64_t version, const RowsetShare
     edit.set_rowsetid_add(rowsetid_add);
     // TODO: is rollback modification of rowset meta required if commit failed?
     rowset->make_commit(version, rowsetid);
-    auto& rowset_meta = rowset->rowset_meta()->get_meta_pb();
-    string rkey = RowsetMetaManager::get_rowset_meta_key(_tablet.tablet_uid(), rowset->rowset_id());
-    auto st = TabletMetaManager::rowset_commit(_tablet.data_dir(), _tablet.tablet_id(), _next_log_id, &edit,
-                                               rowset_meta, rkey);
+    auto st = TabletMetaManager::rowset_commit(
+            _tablet.data_dir(), _tablet.tablet_id(), _next_log_id, &edit, rowset->rowset_meta()->get_meta_pb(),
+            RowsetMetaManager::get_rowset_meta_key(_tablet.tablet_uid(), rowset->rowset_id()));
     if (!st.ok()) {
         LOG(WARNING) << "rowset commit failed: " << st << " " << _debug_string(false, false);
         return st;
@@ -515,12 +519,12 @@ Status TabletUpdates::_rowset_commit_unlocked(int64_t version, const RowsetShare
     // apply in-memory state after commit success
     _next_log_id++;
     _next_rowset_id += rowsetid_add;
-    std::unique_ptr<EditVersionInfo> newversion = std::make_unique<EditVersionInfo>();
-    newversion->version = EditVersion(version, 0);
-    newversion->creation_time = creation_time;
-    newversion->rowsets.swap(nrs);
-    newversion->deltas.push_back(rowsetid);
-    _versions.emplace_back(std::move(newversion));
+    std::unique_ptr<EditVersionInfo> edit_version_info = std::make_unique<EditVersionInfo>();
+    edit_version_info->version = EditVersion(version, 0);
+    edit_version_info->creation_time = creation_time;
+    edit_version_info->rowsets.swap(nrs);
+    edit_version_info->deltas.push_back(rowsetid);
+    _edit_version_infos.emplace_back(std::move(edit_version_info));
     {
         std::lock_guard<std::mutex> lg(_rowsets_lock);
         _rowsets[rowsetid] = rowset;
@@ -543,17 +547,15 @@ Status TabletUpdates::_rowset_commit_unlocked(int64_t version, const RowsetShare
 
 void TabletUpdates::_try_commit_pendings_unlocked() {
     if (_pending_commits.size() > 0) {
-        int64_t current_version = _versions.back()->version.major();
+        int64_t current_version = _edit_version_infos.back()->version.major();
         for (auto itr = _pending_commits.begin(); itr != _pending_commits.end();) {
             int64_t version = itr->first;
             if (version <= current_version) {
-                // ignore
                 LOG(WARNING) << "ignore pending rowset tablet: " << _tablet.tablet_id() << " version:" << version
                              << " #pending:" << _pending_commits.size();
                 _ignore_rowset_commit(version, itr->second);
                 itr = _pending_commits.erase(itr);
             } else if (version == current_version + 1) {
-                // commit
                 auto& rowset = itr->second;
                 auto st = _rowset_commit_unlocked(version, rowset);
                 if (!st.ok()) {
@@ -570,7 +572,7 @@ void TabletUpdates::_try_commit_pendings_unlocked() {
                           << " size:" << PrettyPrinter::print(rowset->data_disk_size(), TUnit::BYTES)
                           << " #pending:" << _pending_commits.size();
                 itr = _pending_commits.erase(itr);
-                current_version = _versions.back()->version.major();
+                current_version = _edit_version_infos.back()->version.major();
             } else {
                 break;
             }
@@ -607,16 +609,15 @@ void TabletUpdates::_check_for_apply() {
         return;
     }
     _apply_running_lock.lock();
-    if (_apply_running || _apply_version_idx + 1 == _versions.size()) {
+    if (_apply_running || _apply_version_idx + 1 == _edit_version_infos.size()) {
         _apply_running_lock.unlock();
         return;
     }
     _apply_running = true;
     _apply_running_lock.unlock();
-    auto pool = StorageEngine::instance()->update_manager()->apply_thread_pool();
     std::shared_ptr<Runnable> task(
             std::make_shared<ApplyCommitTask>(std::static_pointer_cast<Tablet>(_tablet.shared_from_this())));
-    auto st = pool->submit(std::move(task));
+    auto st = StorageEngine::instance()->update_manager()->apply_thread_pool()->submit(std::move(task));
     if (!st.ok()) {
         _set_error();
         LOG(ERROR) << "submit apply task failed: " << st << _debug_string(false, false);
@@ -630,28 +631,26 @@ void TabletUpdates::do_apply() {
         const EditVersionInfo* version_info_apply = nullptr;
         {
             std::lock_guard rl(_lock);
-            if (_apply_version_idx + 1 >= _versions.size()) {
+            if (_apply_version_idx + 1 >= _edit_version_infos.size()) {
                 if (first) {
                     LOG(WARNING) << "illegal state: do_apply should not be called when there is "
-                                    "nothing to apply"
+                                    "nothing to apply: "
                                  << _debug_string(false);
                 }
                 break;
             }
             // we make sure version_info_apply will never be deleted before apply finished
-            version_info_apply = _versions[_apply_version_idx + 1].get();
+            version_info_apply = _edit_version_infos[_apply_version_idx + 1].get();
         }
         if (version_info_apply->deltas.size() > 0) {
             int64_t duration_ns = 0;
             {
                 StarRocksMetrics::instance()->update_rowset_commit_apply_total.increment(1);
                 SCOPED_RAW_TIMER(&duration_ns);
-                // rowset commit
                 _apply_rowset_commit(*version_info_apply);
             }
             StarRocksMetrics::instance()->update_rowset_commit_apply_duration_us.increment(duration_ns / 1000);
         } else if (version_info_apply->compaction) {
-            // compaction
             // _compaction_running may be false after BE restart, reset it to true
             _compaction_running = true;
             _apply_compaction_commit(*version_info_apply);
@@ -683,10 +682,9 @@ void TabletUpdates::_apply_rowset_commit(const EditVersionInfo& version_info) {
     // NOTE: after commit, apply must success or fatal crash
     int64_t t_start = MonotonicMillis();
     auto tablet_id = _tablet.tablet_id();
-    KVStore* meta = _tablet.data_dir()->get_meta();
     uint32_t rowset_id = version_info.deltas[0];
     auto& version = version_info.version;
-    VLOG(1) << "apply_rowset_commit start tablet:" << tablet_id << " version:" << version_info.version.to_string()
+    VLOG(1) << "apply_rowset_commit start tablet:" << tablet_id << " version:" << version.to_string()
             << " rowset:" << rowset_id;
     RowsetSharedPtr rowset = _get_rowset(rowset_id);
     auto manager = StorageEngine::instance()->update_manager();
@@ -723,9 +721,6 @@ void TabletUpdates::_apply_rowset_commit(const EditVersionInfo& version_info) {
     for (uint32_t i = 0; i < rowset->num_segments(); i++) {
         new_deletes[rowset_id + i] = {};
     }
-    size_t old_total_del = 0;
-    size_t total_del = 0;
-    size_t new_del = 0;
     auto& upserts = state.upserts();
     for (uint32_t i = 0; i < upserts.size(); i++) {
         if (upserts[i] != nullptr) {
@@ -745,16 +740,20 @@ void TabletUpdates::_apply_rowset_commit(const EditVersionInfo& version_info) {
     int64_t t_index = MonotonicMillis();
 
     size_t ndelvec = new_deletes.size();
-    string delvec_change_info;
-    vector<std::pair<uint32_t, DelVectorPtr>> new_del_vecs(new_deletes.size());
+    vector<std::pair<uint32_t, DelVectorPtr>> new_del_vecs(ndelvec);
     size_t idx = 0;
-    for (auto& e : new_deletes) {
-        uint32_t rssid = e.first;
+    size_t old_total_del = 0;
+    size_t total_del = 0;
+    size_t new_del = 0;
+    string delvec_change_info;
+    KVStore* meta = _tablet.data_dir()->get_meta();
+    for (auto& new_delete : new_deletes) {
+        uint32_t rssid = new_delete.first;
         if (rssid >= rowset_id && rssid < rowset_id + rowset->num_segments()) {
             // it's newly added rowset's segment, do not have latest delvec yet
             new_del_vecs[idx].first = rssid;
             new_del_vecs[idx].second = std::make_shared<DelVector>();
-            auto& del_ids = e.second;
+            auto& del_ids = new_delete.second;
             new_del_vecs[idx].second->init(version.major(), del_ids.data(), del_ids.size());
             if (VLOG_IS_ON(1)) {
                 StringAppendF(&delvec_change_info, " %u:+%zu", rssid, del_ids.size());
@@ -774,9 +773,9 @@ void TabletUpdates::_apply_rowset_commit(const EditVersionInfo& version_info) {
                 return;
             }
             new_del_vecs[idx].first = rssid;
-            old_del_vec->add_dels_as_new_version(e.second, version.major(), &(new_del_vecs[idx].second));
+            old_del_vec->add_dels_as_new_version(new_delete.second, version.major(), &(new_del_vecs[idx].second));
             size_t cur_old = old_del_vec->cardinality();
-            size_t cur_add = e.second.size();
+            size_t cur_add = new_delete.second.size();
             size_t cur_new = new_del_vecs[idx].second->cardinality();
             if (cur_old + cur_add != cur_new) {
                 // should not happen, data inconsistent
@@ -811,7 +810,7 @@ void TabletUpdates::_apply_rowset_commit(const EditVersionInfo& version_info) {
             DCHECK(false) << msg;
             LOG(ERROR) << msg;
         } else {
-            iter->second->num_dels += e.second.size();
+            iter->second->num_dels += new_delete.second.size();
             _calc_compaction_score(iter->second.get());
             DCHECK_LE(iter->second->num_dels, iter->second->num_rows);
         }
@@ -869,7 +868,7 @@ RowsetSharedPtr TabletUpdates::_get_rowset(uint32_t rowset_id) {
 
 Status TabletUpdates::_wait_for_version(const EditVersion& version, int64_t timeout_ms) {
     std::unique_lock<std::mutex> ul(_lock);
-    if (!(_versions[_apply_version_idx]->version < version)) {
+    if (!(_edit_version_infos[_apply_version_idx]->version < version)) {
         return Status::OK();
     }
     int64_t wait_start = MonotonicMillis();
@@ -879,14 +878,14 @@ Status TabletUpdates::_wait_for_version(const EditVersion& version, int64_t time
             break;
         }
         int64_t now = MonotonicMillis();
-        if (!(_versions[_apply_version_idx]->version < version)) {
+        if (!(_edit_version_infos[_apply_version_idx]->version < version)) {
             if (now - wait_start > 3000) {
                 LOG(WARNING) << Substitute("wait_for_version slow($0ms) version:$1 $2", now - wait_start,
                                            version.to_string(), _debug_string(false, true));
             }
             break;
         }
-        if (_versions.back()->version < version &&
+        if (_edit_version_infos.back()->version < version &&
             (_pending_commits.empty() || _pending_commits.rbegin()->first < version.major())) {
             string msg = Substitute("wait_for_version failed version:$0 $1", version.to_string(),
                                     _debug_string(false, true));
@@ -907,10 +906,10 @@ StatusOr<std::unique_ptr<CompactionInfo>> TabletUpdates::_get_compaction() {
     std::unique_ptr<CompactionInfo> info = std::make_unique<CompactionInfo>();
     std::lock_guard rl(_lock);
     // 1. start compaction at current apply version
-    info->start_version = _versions[_apply_version_idx]->version;
+    info->start_version = _edit_version_infos[_apply_version_idx]->version;
     // 2. TODO: select compaction input rowsets
     // currently just select all rowset for demo purpose
-    info->inputs = _versions[_apply_version_idx]->rowsets;
+    info->inputs = _edit_version_infos[_apply_version_idx]->rowsets;
     return info;
 }
 
@@ -975,15 +974,15 @@ Status TabletUpdates::_commit_compaction(std::unique_ptr<CompactionInfo>* pinfo,
     RETURN_IF_ERROR(_compaction_state->load(rowset.get()));
     std::lock_guard wl(_lock);
     EditVersionMetaPB edit;
-    auto lastv = _versions.back().get();
-    auto v = edit.mutable_version();
-    v->set_major(lastv->version.major());
-    v->set_minor(lastv->version.minor() + 1);
+    auto lastv = _edit_version_infos.back().get();
+    auto edit_version_pb = edit.mutable_version();
+    edit_version_pb->set_major(lastv->version.major());
+    edit_version_pb->set_minor(lastv->version.minor() + 1);
     int64_t creation_time = time(nullptr);
     edit.set_creation_time(creation_time);
     uint32_t rowsetid = _next_rowset_id;
     auto& inputs = (*pinfo)->inputs;
-    auto& ors = _versions.back()->rowsets;
+    auto& ors = _edit_version_infos.back()->rowsets;
     for (auto rowset_id : inputs) {
         if (std::find(ors.begin(), ors.end(), rowset_id) == ors.end()) {
             // This may happen after a full clone.
@@ -1017,7 +1016,7 @@ Status TabletUpdates::_commit_compaction(std::unique_ptr<CompactionInfo>* pinfo,
     edit.set_rowsetid_add(rowsetid_add);
 
     // TODO: is rollback modification of rowset meta required if commit failed?
-    rowset->make_commit(v->major(), rowsetid);
+    rowset->make_commit(edit_version_pb->major(), rowsetid);
     auto& rowset_meta = rowset->rowset_meta()->get_meta_pb();
 
     // TODO(cbl): impl and use TabletMetaManager::compaction commit
@@ -1032,13 +1031,13 @@ Status TabletUpdates::_commit_compaction(std::unique_ptr<CompactionInfo>* pinfo,
     (*pinfo)->output = rowsetid;
     _next_log_id++;
     _next_rowset_id += rowsetid_add;
-    std::unique_ptr<EditVersionInfo> newversion = std::make_unique<EditVersionInfo>();
-    newversion->version = EditVersion(v->major(), v->minor());
-    newversion->creation_time = creation_time;
-    newversion->rowsets.swap(nrs);
-    newversion->compaction.swap(*pinfo);
-    _versions.emplace_back(std::move(newversion));
-    auto newversion_ptr = _versions.back().get();
+    std::unique_ptr<EditVersionInfo> edit_version_info = std::make_unique<EditVersionInfo>();
+    edit_version_info->version = EditVersion(edit_version_pb->major(), edit_version_pb->minor());
+    edit_version_info->creation_time = creation_time;
+    edit_version_info->rowsets.swap(nrs);
+    edit_version_info->compaction.swap(*pinfo);
+    _edit_version_infos.emplace_back(std::move(edit_version_info));
+    auto edit_version_info_ptr = _edit_version_infos.back().get();
     {
         std::lock_guard<std::mutex> lg(_rowsets_lock);
         _rowsets[rowsetid] = rowset;
@@ -1055,14 +1054,14 @@ Status TabletUpdates::_commit_compaction(std::unique_ptr<CompactionInfo>* pinfo,
         _rowset_stats.emplace(rowsetid, std::move(rowset_stats));
     }
     LOG(INFO) << "commit compaction tablet:" << _tablet.tablet_id()
-              << " version:" << newversion_ptr->version.to_string() << " rowset:" << rowsetid
+              << " version:" << edit_version_info_ptr->version.to_string() << " rowset:" << rowsetid
               << " #seg:" << rowset->num_segments() << " #row:" << rowset->num_rows()
               << " size:" << PrettyPrinter::print(rowset->data_disk_size(), TUnit::BYTES)
               << " #pending:" << _pending_commits.size()
               << " state_memory:" << PrettyPrinter::print(_compaction_state->memory_usage(), TUnit::BYTES);
     VLOG(1) << "update compaction commit " << _debug_string(false, true);
     _check_for_apply();
-    *commit_version = newversion_ptr->version;
+    *commit_version = edit_version_info_ptr->version;
     return Status::OK();
 }
 
@@ -1194,11 +1193,13 @@ void TabletUpdates::_erase_expired_versions(int64_t expire_time,
                                             std::vector<std::unique_ptr<EditVersionInfo>>* expire_list) {
     DCHECK(expire_list->empty());
     std::lock_guard l(_lock);
-    for (int i = 0; i < _apply_version_idx && _versions[i]->creation_time <= expire_time; i++) {
-        expire_list->emplace_back(std::move(_versions[i]));
+    for (int i = 0; i < _apply_version_idx; i++) {
+        if (_edit_version_infos[i]->creation_time <= expire_time) {
+            expire_list->emplace_back(std::move(_edit_version_infos[i]));
+        }
     }
     auto n = expire_list->size();
-    _versions.erase(_versions.begin(), _versions.begin() + n);
+    _edit_version_infos.erase(_edit_version_infos.begin(), _edit_version_infos.begin() + n);
     _apply_version_idx -= n;
 }
 
@@ -1212,8 +1213,8 @@ bool TabletUpdates::check_rowset_id(const RowsetId& rowset_id) const {
     }
     {
         std::lock_guard rl(_lock);
-        for (auto& e : _pending_commits) {
-            if (e.second->rowset_id() == rowset_id) {
+        for (auto& pending_commit : _pending_commits) {
+            if (pending_commit.second->rowset_id() == rowset_id) {
                 return true;
             }
         }
@@ -1224,8 +1225,8 @@ bool TabletUpdates::check_rowset_id(const RowsetId& rowset_id) const {
 std::set<uint32_t> TabletUpdates::_active_rowsets() {
     std::set<uint32_t> ret;
     std::lock_guard rl(_lock);
-    for (const auto& v : _versions) {
-        ret.insert(v->rowsets.begin(), v->rowsets.end());
+    for (const auto& edit_version_info : _edit_version_infos) {
+        ret.insert(edit_version_info->rowsets.begin(), edit_version_info->rowsets.end());
     }
     return ret;
 }
@@ -1236,18 +1237,19 @@ void TabletUpdates::remove_expired_versions(int64_t expire_time) {
         return;
     }
     /// Remove expired versions from memory.
-    std::vector<std::unique_ptr<EditVersionInfo>> expired_versions;
-    _erase_expired_versions(expire_time, &expired_versions);
+    std::vector<std::unique_ptr<EditVersionInfo>> expired_edit_version_infos;
+    _erase_expired_versions(expire_time, &expired_edit_version_infos);
 
-    if (!expired_versions.empty()) {
+    if (!expired_edit_version_infos.empty()) {
         std::unique_lock wrlock(_tablet.get_header_lock());
         _tablet.save_meta();
 
         std::set<uint32_t> unused_rid;
         std::set<uint32_t> active_rid = _active_rowsets();
-        for (const auto& v : expired_versions) {
-            VLOG(1) << "Removing expired version " << v->version.to_string() << " of tablet " << _tablet.tablet_id();
-            for (uint32_t expired_rid : v->rowsets) {
+        for (const auto& expired_edit_version_info : expired_edit_version_infos) {
+            VLOG(1) << "Removing expired version " << expired_edit_version_info->version.to_string() << " of tablet "
+                    << _tablet.tablet_id();
+            for (uint32_t expired_rid : expired_edit_version_info->rowsets) {
                 if (active_rid.count(expired_rid) == 0) {
                     unused_rid.insert(expired_rid);
                 }
@@ -1266,7 +1268,7 @@ void TabletUpdates::remove_expired_versions(int64_t expire_time) {
         }
 
         /// Remove useless delete vectors.
-        auto max_expired_version = expired_versions.back()->version.major();
+        auto max_expired_version = expired_edit_version_infos.back()->version.major();
         auto meta_store = _tablet.data_dir()->get_meta();
         auto tablet_id = _tablet.tablet_id();
 
@@ -1298,17 +1300,17 @@ int64_t TabletUpdates::get_compaction_score() {
     vector<uint32_t> rowsets;
     {
         std::lock_guard rl(_lock);
-        if (_apply_version_idx + 2 < _versions.size() || _pending_commits.size() >= 2) {
+        if (_apply_version_idx + 2 < _edit_version_infos.size() || _pending_commits.size() >= 2) {
             // has too many pending tasks, skip compaction
             return -1;
         }
-        for (size_t i = _apply_version_idx + 1; i < _versions.size(); i++) {
-            if (_versions[i]->compaction) {
+        for (size_t i = _apply_version_idx + 1; i < _edit_version_infos.size(); i++) {
+            if (_edit_version_infos[i]->compaction) {
                 // has pending compaction not finished, do not do compaction
                 return -1;
             }
         }
-        rowsets = _versions[_apply_version_idx]->rowsets;
+        rowsets = _edit_version_infos[_apply_version_idx]->rowsets;
     }
     int64_t total_score = -_compaction_cost_seek;
     bool has_error = false;
@@ -1373,8 +1375,8 @@ Status TabletUpdates::compaction(MemTracker* mem_tracker) {
     {
         std::lock_guard rl(_lock);
         // 1. start compaction at current apply version
-        info->start_version = _versions[_apply_version_idx]->version;
-        rowsets = _versions[_apply_version_idx]->rowsets;
+        info->start_version = _edit_version_infos[_apply_version_idx]->version;
+        rowsets = _edit_version_infos[_apply_version_idx]->rowsets;
     }
     size_t total_valid_rowsets = 0;
     size_t total_rows = 0;
@@ -1499,7 +1501,7 @@ void TabletUpdates::get_tablet_info_extra(TTabletInfo* info) {
     vector<uint32_t> rowsets;
     {
         std::lock_guard rl(_lock);
-        auto& last = _versions.back();
+        auto& last = _edit_version_infos.back();
         version = last->version.major();
         rowsets = last->rowsets;
     }
@@ -1548,14 +1550,14 @@ std::string TabletUpdates::_debug_string(bool lock, bool abbr) const {
     vector<uint32_t> rowsets;
     string pending_info;
     if (lock) _lock.lock();
-    num_version = _versions.size();
+    num_version = _edit_version_infos.size();
     apply_idx = _apply_version_idx;
-    first_version = _versions[0]->version;
-    apply_version = _versions[_apply_version_idx]->version;
-    last_version = _versions.back()->version;
-    rowsets = _versions.back()->rowsets;
-    for (auto const& e : _pending_commits) {
-        StringAppendF(&pending_info, "%ld,", e.first);
+    first_version = _edit_version_infos[0]->version;
+    apply_version = _edit_version_infos[_apply_version_idx]->version;
+    last_version = _edit_version_infos.back()->version;
+    rowsets = _edit_version_infos.back()->rowsets;
+    for (auto const& pending_commit : _pending_commits) {
+        StringAppendF(&pending_info, "%ld,", pending_commit.first);
     }
     if (lock) _lock.unlock();
 
@@ -1622,12 +1624,12 @@ RowsetSharedPtr TabletUpdates::get_delta_rowset(int64_t version) const {
         return nullptr;
     }
     std::lock_guard lg(_lock);
-    if (version < _versions[0]->version.major() || _versions.back()->version.major() < version) {
+    if (version < _edit_version_infos[0]->version.major() || _edit_version_infos.back()->version.major() < version) {
         return nullptr;
     }
-    int idx_hint = version - _versions[0]->version.major();
-    for (auto i = idx_hint; i < _versions.size(); i++) {
-        const auto& vi = _versions[i];
+    int idx_hint = version - _edit_version_infos[0]->version.major();
+    for (auto i = idx_hint; i < _edit_version_infos.size(); i++) {
+        const auto& vi = _edit_version_infos[i];
         if (vi->version.major() < version) {
             continue;
         }
@@ -1646,7 +1648,7 @@ RowsetSharedPtr TabletUpdates::get_delta_rowset(int64_t version) const {
 }
 
 Status TabletUpdates::get_applied_rowsets(int64_t version, std::vector<RowsetSharedPtr>* rowsets,
-                                          EditVersion* full_version) {
+                                          EditVersion* full_edit_version) {
     if (_error) {
         return Status::InternalError(
                 Substitute("tablet updates in error state, cannot get_applied_rowsets failed, "
@@ -1657,11 +1659,11 @@ Status TabletUpdates::get_applied_rowsets(int64_t version, std::vector<RowsetSha
     RETURN_IF_ERROR(_wait_for_version(EditVersion(version, 0), 60000));
     std::lock_guard rl(_lock);
     for (ssize_t i = _apply_version_idx; i >= 0; i--) {
-        const auto& v = _versions[i];
-        if (v->version.major() == version) {
-            rowsets->reserve(v->rowsets.size());
+        const auto& edit_version_info = _edit_version_infos[i];
+        if (edit_version_info->version.major() == version) {
+            rowsets->reserve(edit_version_info->rowsets.size());
             std::lock_guard<std::mutex> lg(_rowsets_lock);
-            for (uint32_t rsid : v->rowsets) {
+            for (uint32_t rsid : edit_version_info->rowsets) {
                 auto itr = _rowsets.find(rsid);
                 DCHECK(itr != _rowsets.end());
                 if (itr != _rowsets.end()) {
@@ -1671,8 +1673,8 @@ Status TabletUpdates::get_applied_rowsets(int64_t version, std::vector<RowsetSha
                                                        rsid, _debug_string(false, true)));
                 }
             }
-            if (full_version != nullptr) {
-                *full_version = v->version;
+            if (full_edit_version != nullptr) {
+                *full_edit_version = edit_version_info->version;
             }
             return Status::OK();
         }
@@ -1809,6 +1811,194 @@ Status TabletUpdates::load_from_base_tablet(int64_t request_version, Tablet* bas
     return Status::OK();
 }
 
+Status TabletUpdates::load_from_base_tablet(const TAlterTabletReqV2& request,
+                                            vectorized::SchemaChangeParams& sc_params) {
+    DCHECK(_tablet.tablet_state() == TABLET_NOTREADY)
+            << "load_from_base_tablet is only allowed in schema change process";
+    int64_t request_version = request.alter_version;
+    LOG(INFO) << "load_from_base_tablet start tablet:" << _tablet.tablet_id() << " request_version:" << request_version
+              << " #pending:" << _pending_commits.size();
+    const std::shared_ptr<Tablet>& base_tablet = sc_params.base_tablet;
+    int64_t max_version = base_tablet->updates()->max_version();
+    if (max_version < request_version) {
+        LOG(WARNING) << "load_from_base_tablet base_tablet's max_version:" << max_version
+                     << " < alter_version:" << request_version << " tablet:" << _tablet.tablet_id()
+                     << " base_tablet:" << base_tablet->tablet_id();
+        return Status::InternalError("load_from_base_tablet max_version < request_version");
+    }
+    std::vector<RowsetSharedPtr> rowsets;
+    EditVersion version;
+    Status status = base_tablet->updates()->get_applied_rowsets(request_version, &rowsets, &version);
+    if (!status.ok()) {
+        LOG(WARNING) << "load_from_base_tablet get base tablet rowsets error tablet:" << base_tablet->tablet_id()
+                     << " request_version:" << request_version << " reason:" << status;
+        return status;
+    }
+
+    // disable compaction temporarily when tablet just loaded
+    _last_compaction_time_ms = UnixMillis();
+
+    auto kv_store = _tablet.data_dir()->get_meta();
+    auto update_manager = StorageEngine::instance()->update_manager();
+    auto tablet_id = _tablet.tablet_id();
+
+    // delete old meta
+    auto data_dir = _tablet.data_dir();
+    rocksdb::WriteBatch wb;
+    RETURN_IF_ERROR(TabletMetaManager::clear_log(data_dir, &wb, tablet_id));
+    RETURN_IF_ERROR(TabletMetaManager::clear_rowset(data_dir, &wb, tablet_id));
+    RETURN_IF_ERROR(TabletMetaManager::clear_pending_rowset(data_dir, &wb, tablet_id));
+    RETURN_IF_ERROR(TabletMetaManager::clear_del_vector(data_dir, &wb, tablet_id));
+
+    std::unique_lock wrlock(_tablet.get_header_lock());
+    status = kv_store->write_batch(&wb);
+    if (!status.ok()) {
+        LOG(WARNING) << "Fail to delete old meta and write new meta" << tablet_id << ": " << status;
+        return Status::InternalError("Fail to delete old meta and write new meta");
+    }
+
+    auto chunk_changer = sc_params.chunk_changer.get();
+
+    vectorized::Schema base_schema = vectorized::ChunkHelper::convert_schema_to_format_v2(base_tablet->tablet_schema());
+    vectorized::TabletReaderParams read_params;
+    read_params.reader_type = ReaderType::READER_ALTER_TABLE;
+    read_params.skip_aggregation = false;
+    read_params.chunk_size = config::vector_chunk_size;
+
+    for (const auto& rowset : rowsets) {
+        LOG(INFO) << "begin to convert a history rowset. version=" << rowset->version().first << "-"
+                  << rowset->version().second;
+
+        vectorized::TabletReader* tablet_reader =
+                new vectorized::TabletReader(base_tablet, Version(0, version.major()), base_schema);
+        tablet_reader->set_delete_predicates_version(Version(0, max_version));
+        RETURN_IF_ERROR(tablet_reader->prepare());
+        RETURN_IF_ERROR(tablet_reader->open(read_params));
+
+        RowsetWriterContext writer_context(kDataFormatUnknown, config::storage_format_version);
+        writer_context.rowset_id = StorageEngine::instance()->next_rowset_id();
+        writer_context.tablet_uid = _tablet.tablet_uid();
+        writer_context.tablet_id = _tablet.tablet_id();
+        writer_context.partition_id = _tablet.partition_id();
+        writer_context.tablet_schema_hash = _tablet.schema_hash();
+        writer_context.rowset_type = _tablet.tablet_meta()->preferred_rowset_type();
+        writer_context.rowset_path_prefix = _tablet.tablet_path();
+        writer_context.tablet_schema = &_tablet.tablet_schema();
+        writer_context.rowset_state = VISIBLE;
+        writer_context.version = rowset->version();
+        writer_context.version_hash = rowset->version_hash();
+        writer_context.segments_overlap = rowset->rowset_meta()->segments_overlap();
+
+        std::unique_ptr<RowsetWriter> rowset_writer;
+        status = RowsetFactory::create_rowset_writer(writer_context, &rowset_writer);
+        if (!status.ok()) {
+            LOG(INFO) << "build rowset writer failed";
+            return Status::InternalError("build rowset writer failed");
+        }
+
+        status = _convert_from_base_rowset(base_tablet, tablet_reader, chunk_changer, rowset_writer);
+        if (!status.ok()) {
+            LOG(WARNING) << "failed to convert from base rowset, exit alter process";
+            return status;
+        }
+
+        _tablet.obtain_push_lock();
+        std::shared_ptr<Rowset> new_rowset = rowset_writer->build();
+        if (new_rowset == nullptr) {
+            LOG(WARNING) << "failed to build rowset, exit alter process";
+            _tablet.release_push_lock();
+            return Status::InternalError("failed to build rowset, exit alter process");
+        }
+
+        LOG(INFO) << "new rowset has " << new_rowset->num_segments() << " segments";
+        status = rowset_commit(new_rowset->end_version(), new_rowset);
+        if (!status.ok()) {
+            LOG(WARNING) << "failed to register new version. "
+                         << " tablet=" << _tablet.full_name() << ", version=" << rowset->version().first << "-"
+                         << rowset->version().second;
+            StorageEngine::instance()->add_unused_rowset(new_rowset);
+            _tablet.release_push_lock();
+            break;
+        } else {
+            VLOG(3) << "commit new version. tablet=" << _tablet.full_name() << ", version=" << rowset->version().first
+                    << "-" << rowset->version().second;
+        }
+        _tablet.release_push_lock();
+
+        VLOG(10) << "succeed to convert a history version."
+                 << " version=" << rowset->version().first << "-" << rowset->version().second;
+    }
+
+    auto index_entry = update_manager->index_cache().get_or_create(tablet_id);
+    index_entry->update_expire_time(MonotonicMillis() + update_manager->get_cache_expire_ms());
+    index_entry->value().unload();
+    update_manager->index_cache().release(index_entry);
+    _tablet.set_tablet_state(TabletState::TABLET_RUNNING);
+    LOG(INFO) << "load_from_base_tablet finish tablet:" << _tablet.tablet_id() << " version:" << this->max_version()
+              << " #pending:" << _pending_commits.size();
+    return Status::OK();
+}
+
+Status TabletUpdates::_convert_from_base_rowset(const std::shared_ptr<Tablet>& base_tablet,
+                                                vectorized::TabletReader* tablet_reader,
+                                                vectorized::ChunkChanger* chunk_changer,
+                                                const std::unique_ptr<RowsetWriter>& rowset_writer) {
+    vectorized::Schema base_schema = vectorized::ChunkHelper::convert_schema_to_format_v2(base_tablet->tablet_schema());
+    vectorized::ChunkPtr base_chunk = vectorized::ChunkHelper::new_chunk(base_schema, config::vector_chunk_size);
+
+    vectorized::Schema new_schema = vectorized::ChunkHelper::convert_schema_to_format_v2(_tablet.tablet_schema());
+    vectorized::ChunkPtr new_chunk = vectorized::ChunkHelper::new_chunk(new_schema, config::vector_chunk_size);
+
+    std::unique_ptr<MemPool> mem_pool(new MemPool());
+
+    do {
+        Status status = tablet_reader->do_get_next(base_chunk.get());
+
+        if (!status.ok()) {
+            if (status.is_end_of_file()) {
+                break;
+            } else {
+                std::stringstream ss;
+                ss << "tablet reader failed to get next chunk, status is:" << status.to_string();
+                LOG(WARNING) << ss.str();
+                return Status::InternalError(ss.str());
+            }
+        }
+
+        if (!chunk_changer->change_chunk(base_chunk, new_chunk, base_tablet->tablet_meta(), _tablet.tablet_meta(),
+                                         mem_pool.get())) {
+            LOG(WARNING) << "failed to change data in chunk";
+            return Status::InternalError("failed to change data in chunk");
+        }
+        if (rowset_writer->add_chunk(*new_chunk) != OLAP_SUCCESS) {
+            LOG(WARNING) << "failed to add chunk";
+            return Status::InternalError("failed to add chunk");
+        }
+        base_chunk->reset();
+        new_chunk->reset();
+        mem_pool->clear();
+    } while (base_chunk->num_rows() == 0);
+
+    if (base_chunk->num_rows() != 0) {
+        if (!chunk_changer->change_chunk(base_chunk, new_chunk, base_tablet->tablet_meta(), _tablet.tablet_meta(),
+                                         mem_pool.get())) {
+            LOG(WARNING) << "failed to change data in chunk";
+            return Status::InternalError("failed to change data in chunk");
+        }
+        if (rowset_writer->add_chunk(*new_chunk) != OLAP_SUCCESS) {
+            LOG(WARNING) << "failed to add chunk";
+            return Status::InternalError("failed to add chunk");
+        }
+    }
+
+    if (rowset_writer->flush() != OLAP_SUCCESS) {
+        LOG(WARNING) << "failed to flush rowset writer";
+        return Status::InternalError("failed to flush rowset writer");
+    }
+
+    return Status::OK();
+}
+
 void TabletUpdates::_remove_unused_rowsets() {
     std::vector<RowsetSharedPtr> skipped_rowsets;
     RowsetSharedPtr rowset;
@@ -1842,7 +2032,7 @@ void TabletUpdates::_remove_unused_rowsets() {
 
 void TabletUpdates::_to_updates_pb_unlocked(TabletUpdatesPB* updates_pb) const {
     updates_pb->Clear();
-    for (const auto& version : _versions) {
+    for (const auto& version : _edit_version_infos) {
         EditVersionMetaPB* version_pb = updates_pb->add_versions();
         // version
         version_pb->mutable_version()->set_major(version->version.major());
@@ -1868,8 +2058,8 @@ void TabletUpdates::_to_updates_pb_unlocked(TabletUpdatesPB* updates_pb) const {
     }
     updates_pb->set_next_rowset_id(_next_rowset_id);
     updates_pb->set_next_log_id(_next_log_id);
-    if (_apply_version_idx < _versions.size()) {
-        const EditVersion& apply_version = _versions[_apply_version_idx]->version;
+    if (_apply_version_idx < _edit_version_infos.size()) {
+        const EditVersion& apply_version = _edit_version_infos[_apply_version_idx]->version;
         updates_pb->mutable_apply_version()->set_major(apply_version.major());
         updates_pb->mutable_apply_version()->set_minor(apply_version.minor());
     }
@@ -1943,7 +2133,7 @@ Status TabletUpdates::load_snapshot(const SnapshotMeta& snapshot_meta) {
         if (snapshot_meta.tablet_meta().schema_hash() != _tablet.schema_hash()) {
             return Status::InvalidArgument("mismatched schema hash");
         }
-        if (snapshot_meta.snapshot_version() <= _versions.back()->version.major()) {
+        if (snapshot_meta.snapshot_version() <= _edit_version_infos.back()->version.major()) {
             return Status::Cancelled("snapshot version too small");
         }
         for (const auto& rowset_meta_pb : snapshot_meta.rowset_metas()) {
@@ -1976,7 +2166,7 @@ Status TabletUpdates::load_snapshot(const SnapshotMeta& snapshot_meta) {
         std::unique_lock l3(_rowset_stats_lock);
 
         // Check version again after lock acquired.
-        if (snapshot_meta.snapshot_version() <= _versions.back()->version.major()) {
+        if (snapshot_meta.snapshot_version() <= _edit_version_infos.back()->version.major()) {
             return Status::Cancelled("snapshot version too small");
         }
 
@@ -2000,21 +2190,21 @@ Status TabletUpdates::load_snapshot(const SnapshotMeta& snapshot_meta) {
             VLOG(2) << "mark rowset " << tablet_id << "@" << rssid << "@" << rowset->rowset_id() << " as unused";
             (void)_unused_rowsets.blocking_put(std::move(rowset));
         }
-        STLClearObject(&_versions);
+        STLClearObject(&_edit_version_infos);
         STLClearObject(&_rowsets);
         STLClearObject(&_rowset_stats);
 
         _apply_version_idx = 0;
         _rowsets = std::move(new_rowsets);
 
-        auto& new_version = _versions.emplace_back(std::make_unique<EditVersionInfo>());
+        auto& new_version = _edit_version_infos.emplace_back(std::make_unique<EditVersionInfo>());
         new_version->version = EditVersion(snapshot_meta.snapshot_version(), 0);
         new_version->creation_time = time(nullptr);
         new_version->rowsets.reserve(_rowsets.size());
         for (const auto& [rid, rowset] : _rowsets) {
             new_version->rowsets.emplace_back(rid);
         }
-        DCHECK_EQ(1, _versions.size());
+        DCHECK_EQ(1, _edit_version_infos.size());
 
         WriteBatch wb;
         CHECK_FAIL(TabletMetaManager::clear_log(data_store, &wb, tablet_id));
@@ -2111,7 +2301,7 @@ Status TabletUpdates::clear_meta() {
     StorageEngine::instance()->update_manager()->index_cache().remove_by_key(_tablet.tablet_id());
     STLClearObject(&_rowsets);
     STLClearObject(&_rowset_stats);
-    STLClearObject(&_versions);
+    STLClearObject(&_edit_version_infos);
     return Status::OK();
 }
 
@@ -2119,7 +2309,7 @@ void TabletUpdates::_update_total_stats(const std::vector<uint32_t>& rowsets) {
     size_t nrow = 0;
     size_t ndel = 0;
     {
-        std::lock_guard l3(_rowset_stats_lock);
+        std::lock_guard l(_rowset_stats_lock);
         for (auto rid : rowsets) {
             auto itr = _rowset_stats.find(rid);
             if (itr != _rowset_stats.end()) {

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -1929,10 +1929,6 @@ Status TabletUpdates::load_from_base_tablet(const TAlterTabletReqV2& request,
                  << " version=" << rowset->version().first << "-" << rowset->version().second;
     }
 
-    auto index_entry = update_manager->index_cache().get_or_create(tablet_id);
-    index_entry->update_expire_time(MonotonicMillis() + update_manager->get_cache_expire_ms());
-    index_entry->value().unload();
-    update_manager->index_cache().release(index_entry);
     _tablet.set_tablet_state(TabletState::TABLET_RUNNING);
     LOG(INFO) << "load_from_base_tablet finish tablet:" << _tablet.tablet_id() << " version:" << this->max_version()
               << " #pending:" << _pending_commits.size();

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -156,9 +156,9 @@ public:
     void to_updates_pb(TabletUpdatesPB* updates_pb) const;
 
     // Used for schema change, migrate another tablet's version&rowsets to this tablet
-    Status load_from_base_tablet(int64_t version, Tablet* base_tablet);
+    Status perform_linked_schema_change(int64_t version, Tablet* base_tablet);
 
-    Status load_from_base_tablet(const TAlterTabletReqV2& request, vectorized::SchemaChangeParams& sc_params);
+    Status perform_directly_schema_change(const TAlterTabletReqV2& request, vectorized::SchemaChangeParams& sc_params);
 
     Status load_snapshot(const SnapshotMeta& snapshot_meta);
 

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -155,10 +155,10 @@ public:
     void to_updates_pb(TabletUpdatesPB* updates_pb) const;
 
     // Used for schema change, migrate another tablet's version&rowsets to this tablet
-    Status schema_change_linked(int64_t request_version, Tablet* base_tablet);
+    Status link_from(Tablet* base_tablet, int64_t request_version);
 
-    Status schema_change_directly(int64_t request_version, const std::shared_ptr<Tablet>& base_tablet,
-                                  vectorized::ChunkChanger* chunk_changer);
+    Status convert_from(const std::shared_ptr<Tablet>& base_tablet, int64_t request_version,
+                        vectorized::ChunkChanger* chunk_changer);
 
     Status load_snapshot(const SnapshotMeta& snapshot_meta);
 

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -33,7 +33,6 @@ class RowsetReadOptions;
 class Schema;
 class TabletReader;
 class ChunkChanger;
-struct SchemaChangeParams;
 } // namespace vectorized
 
 struct EditVersion {
@@ -156,9 +155,10 @@ public:
     void to_updates_pb(TabletUpdatesPB* updates_pb) const;
 
     // Used for schema change, migrate another tablet's version&rowsets to this tablet
-    Status perform_linked_schema_change(int64_t version, Tablet* base_tablet);
+    Status perform_linked_schema_change(int64_t request_version, Tablet* base_tablet);
 
-    Status perform_directly_schema_change(const TAlterTabletReqV2& request, vectorized::SchemaChangeParams& sc_params);
+    Status perform_directly_schema_change(int64_t request_version, const std::shared_ptr<Tablet>& base_tablet,
+                                          vectorized::ChunkChanger* chunk_changer);
 
     Status load_snapshot(const SnapshotMeta& snapshot_meta);
 

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -155,10 +155,10 @@ public:
     void to_updates_pb(TabletUpdatesPB* updates_pb) const;
 
     // Used for schema change, migrate another tablet's version&rowsets to this tablet
-    Status perform_linked_schema_change(int64_t request_version, Tablet* base_tablet);
+    Status schema_change_linked(int64_t request_version, Tablet* base_tablet);
 
-    Status perform_directly_schema_change(int64_t request_version, const std::shared_ptr<Tablet>& base_tablet,
-                                          vectorized::ChunkChanger* chunk_changer);
+    Status schema_change_directly(int64_t request_version, const std::shared_ptr<Tablet>& base_tablet,
+                                  vectorized::ChunkChanger* chunk_changer);
 
     Status load_snapshot(const SnapshotMeta& snapshot_meta);
 
@@ -270,7 +270,8 @@ private:
     void _update_total_stats(const std::vector<uint32_t>& rowsets);
 
     Status _convert_from_base_rowset(const std::shared_ptr<Tablet>& base_tablet,
-                                     vectorized::TabletReader* tablet_reader, vectorized::ChunkChanger* chunk_changer,
+                                     const std::vector<vectorized::ChunkIteratorPtr>& seg_iterators,
+                                     vectorized::ChunkChanger* chunk_changer,
                                      const std::unique_ptr<RowsetWriter>& rowset_writer);
 
 private:

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -11,6 +11,7 @@
 #include "common/statusor.h"
 #include "gen_cpp/olap_file.pb.h"
 #include "storage/olap_common.h"
+#include "storage/rowset/rowset_writer.h"
 #include "util/blocking_queue.hpp"
 
 namespace starrocks {
@@ -30,6 +31,9 @@ class ChunkIterator;
 class CompactionState;
 class RowsetReadOptions;
 class Schema;
+class TabletReader;
+class ChunkChanger;
+struct SchemaChangeParams;
 } // namespace vectorized
 
 struct EditVersion {
@@ -134,7 +138,7 @@ public:
     bool check_rowset_id(const RowsetId& rowset_id) const;
 
     // Note: EditVersion history count, not like talet.version_count()
-    size_t version_history_count() const { return _versions.size(); }
+    size_t version_history_count() const { return _edit_version_infos.size(); }
 
     // get info's version, version_hash, version_count, row_count, data_size
     void get_tablet_info_extra(TTabletInfo* info);
@@ -153,6 +157,8 @@ public:
 
     // Used for schema change, migrate another tablet's version&rowsets to this tablet
     Status load_from_base_tablet(int64_t version, Tablet* base_tablet);
+
+    Status load_from_base_tablet(const TAlterTabletReqV2& request, vectorized::SchemaChangeParams& sc_params);
 
     Status load_snapshot(const SnapshotMeta& snapshot_meta);
 
@@ -263,12 +269,16 @@ private:
 
     void _update_total_stats(const std::vector<uint32_t>& rowsets);
 
+    Status _convert_from_base_rowset(const std::shared_ptr<Tablet>& base_tablet,
+                                     vectorized::TabletReader* tablet_reader, vectorized::ChunkChanger* chunk_changer,
+                                     const std::unique_ptr<RowsetWriter>& rowset_writer);
+
 private:
     Tablet& _tablet;
 
-    // |_lock| protects |_versions|, |_next_rowset_id|, |_next_log_id|, |_apply_version_idx|, |_pending_commits|.
+    // |_lock| protects |_edit_version_infos|, |_next_rowset_id|, |_next_log_id|, |_apply_version_idx|, |_pending_commits|.
     mutable std::mutex _lock;
-    std::vector<std::unique_ptr<EditVersionInfo>> _versions;
+    std::vector<std::unique_ptr<EditVersionInfo>> _edit_version_infos;
     uint32_t _next_rowset_id = 0;
     uint64_t _next_log_id = 0;
     size_t _apply_version_idx = 0;

--- a/be/src/storage/vectorized/convert_helper.cpp
+++ b/be/src/storage/vectorized/convert_helper.cpp
@@ -1028,8 +1028,6 @@ const TypeConverter* get_type_converter(FieldType from_type, FieldType to_type) 
 template <typename SrcType>
 class BitMapTypeConverter : public MaterializeTypeConverter {
 public:
-    ;
-
     BitMapTypeConverter() = default;
     ~BitMapTypeConverter() = default;
 
@@ -1043,8 +1041,7 @@ public:
                 dst_col->append_datum(dst_datum);
                 continue;
             }
-            uint64_t origin_value;
-            origin_value = src_datum.get<SrcType>();
+            uint64_t origin_value = src_datum.get<SrcType>();
             if (origin_value < 0) {
                 LOG(WARNING) << "The input which less than zero "
                              << " is not valid, to_bitmap only support bigint value from 0 to "
@@ -1104,8 +1101,7 @@ public:
                 dst_col->append_datum(dst_datum);
                 continue;
             }
-            double origin_value;
-            origin_value = src_datum.get<SrcType>();
+            double origin_value = src_datum.get<SrcType>();
             PercentileValue percentile;
             percentile.add(origin_value);
             dst_datum.set_percentile(&percentile);

--- a/be/src/storage/vectorized/delta_writer.cpp
+++ b/be/src/storage/vectorized/delta_writer.cpp
@@ -291,8 +291,7 @@ Status DeltaWriter::close_wait(google::protobuf::RepeatedPtrField<PTabletInfo>* 
     }
     _delta_written_success = true;
 
-    const FlushStatistic& stat = _flush_token->get_stats();
-    LOG(INFO) << "Closed delta writer. tablet_id=" << _tablet->tablet_id() << " stats=" << stat;
+    LOG(INFO) << "Closed delta writer. tablet_id=" << _tablet->tablet_id() << " stats=" << _flush_token->get_stats();
     return Status::OK();
 }
 

--- a/be/src/storage/vectorized/range.h
+++ b/be/src/storage/vectorized/range.h
@@ -37,9 +37,9 @@ public:
     // return a new range that represent the intersection of |this| and |r|.
     Range intersection(const Range& r) const;
 
-    bool has_intersection(const Range& rhs) const { return !(_end <= rhs.begin() || rhs._end <= _begin); }
+    bool has_intersection(const Range& rhs) const { return !(_end <= rhs.begin() || rhs.end() <= _begin); }
 
-    bool contains(rowid_t row) const { return row - _begin < _end - _begin; }
+    bool contains(rowid_t row) const { return row < _end; }
 
     std::string to_string() const;
 
@@ -291,11 +291,11 @@ inline bool SparseRangeIterator::has_more() const {
 
 inline Range SparseRangeIterator::next(size_t size) {
     const std::vector<Range>& ranges = _range->_ranges;
-    const Range& r = ranges[_index];
-    size = std::min<size_t>(size, r.end() - _next_rowid);
+    const Range& range = ranges[_index];
+    size = std::min<size_t>(size, range.end() - _next_rowid);
     Range ret(_next_rowid, _next_rowid + size);
     _next_rowid += size;
-    if (_next_rowid == r.end()) {
+    if (_next_rowid == range.end()) {
         ++_index;
         if (_index < ranges.size()) {
             _next_rowid = ranges[_index].begin();

--- a/be/src/storage/vectorized/schema_change.cpp
+++ b/be/src/storage/vectorized/schema_change.cpp
@@ -295,10 +295,9 @@ bool ChunkChanger::change_chunk(ChunkPtr& base_chunk, ChunkPtr& new_chunk, const
     for (size_t i = 0; i < new_chunk->num_columns(); ++i) {
         int ref_column = _schema_mapping[i].ref_column;
         if (ref_column >= 0) {
-            FieldType ref_type = TypeUtils::to_storage_format_v2(
-                    base_tablet->tablet_meta()->tablet_schema().column(ref_column).type());
-            FieldType new_type =
-                    TypeUtils::to_storage_format_v2(new_tablet->tablet_meta()->tablet_schema().column(i).type());
+            FieldType ref_type =
+                    TypeUtils::to_storage_format_v2(base_tablet_meta->tablet_schema().column(ref_column).type());
+            FieldType new_type = TypeUtils::to_storage_format_v2(new_tablet_meta->tablet_schema().column(i).type());
             if (!_schema_mapping[i].materialized_function.empty()) {
                 const auto& materialized_function = _schema_mapping[i].materialized_function;
                 const MaterializeTypeConverter* converter =

--- a/be/src/storage/vectorized/schema_change.cpp
+++ b/be/src/storage/vectorized/schema_change.cpp
@@ -73,7 +73,7 @@ public:
     static bool _chunk_comparator(const ChunkRow& lhs, const ChunkRow& rhs) { return compare_chunk_row(lhs, rhs) < 0; }
 
 private:
-    ChunkAllocator* _chunk_allocator;
+    ChunkAllocator* _chunk_allocator = nullptr;
     ChunkPtr _swap_chunk;
     size_t _max_allocated_rows;
 };
@@ -732,10 +732,7 @@ bool SchemaChangeDirectly::process(vectorized::TabletReader* reader, RowsetWrite
 }
 
 SchemaChangeWithSorting::SchemaChangeWithSorting(ChunkChanger* chunk_changer, size_t memory_limitation)
-        : SchemaChange(),
-          _chunk_changer(chunk_changer),
-          _memory_limitation(memory_limitation),
-          _chunk_allocator(nullptr) {}
+        : SchemaChange(), _chunk_changer(chunk_changer), _memory_limitation(memory_limitation) {}
 
 SchemaChangeWithSorting::~SchemaChangeWithSorting() {
     SAFE_DELETE(_chunk_allocator);

--- a/be/src/storage/vectorized/schema_change.cpp
+++ b/be/src/storage/vectorized/schema_change.cpp
@@ -946,7 +946,8 @@ Status SchemaChangeHandler::_do_process_alter_tablet_v2(const TAlterTabletReqV2&
     if (base_tablet->keys_type() == KeysType::PRIMARY_KEYS) {
         Status status;
         if (sc_params.sc_directly) {
-            status = new_tablet->updates()->perform_directly_schema_change(request, sc_params);
+            status = new_tablet->updates()->perform_directly_schema_change(request.alter_version, base_tablet,
+                                                                           sc_params.chunk_changer.get());
         } else if (sc_params.sc_sorting) {
             LOG(WARNING) << "schema change of primary key model do not support sorting.";
             status = Status::NotSupported("schema change of primary key model do not support sorting.");

--- a/be/src/storage/vectorized/schema_change.cpp
+++ b/be/src/storage/vectorized/schema_change.cpp
@@ -942,13 +942,13 @@ Status SchemaChangeHandler::_do_process_alter_tablet_v2(const TAlterTabletReqV2&
     if (base_tablet->keys_type() == KeysType::PRIMARY_KEYS) {
         Status status;
         if (sc_params.sc_directly) {
-            status = new_tablet->updates()->schema_change_directly(request.alter_version, base_tablet,
-                                                                   sc_params.chunk_changer.get());
+            status = new_tablet->updates()->convert_from(base_tablet, request.alter_version,
+                                                         sc_params.chunk_changer.get());
         } else if (sc_params.sc_sorting) {
             LOG(WARNING) << "schema change of primary key model do not support sorting.";
             status = Status::NotSupported("schema change of primary key model do not support sorting.");
         } else {
-            status = new_tablet->updates()->schema_change_linked(request.alter_version, base_tablet.get());
+            status = new_tablet->updates()->link_from(base_tablet.get(), request.alter_version);
         }
         if (!status.ok()) {
             LOG(WARNING) << "schema change new tablet load snapshot error: " << status.to_string();

--- a/be/src/storage/vectorized/schema_change.cpp
+++ b/be/src/storage/vectorized/schema_change.cpp
@@ -932,6 +932,39 @@ Status SchemaChangeHandler::_do_process_alter_tablet_v2(const TAlterTabletReqV2&
     sc_params.new_tablet = new_tablet;
     sc_params.chunk_changer = std::make_unique<ChunkChanger>(sc_params.new_tablet->tablet_schema());
 
+    // primary key do not support materialized view, initialize materialized_params_map here,
+    // just for later column_mapping of _parse_request.
+    if (request.__isset.materialized_view_params) {
+        for (auto item : request.materialized_view_params) {
+            AlterMaterializedViewParam mv_param;
+            mv_param.column_name = item.column_name;
+            /*
+             * origin_column_name is always be set now,
+             * but origin_column_name may be not set in some materialized view function. eg:count(1)
+            */
+            if (item.__isset.origin_column_name) {
+                mv_param.origin_column_name = item.origin_column_name;
+            }
+
+            /*
+            * TODO(lhy)
+            * Building the materialized view function for schema_change here based on defineExpr.
+            * This is a trick because the current storage layer does not support expression evaluation.
+            * We can refactor this part of the code until the uniform expression evaluates the logic.
+            * count distinct materialized view will set mv_expr with to_bitmap or hll_hash.
+            * count materialized view will set mv_expr with count.
+            */
+            if (item.__isset.mv_expr) {
+                if (item.mv_expr.nodes[0].node_type == TExprNodeType::FUNCTION_CALL) {
+                    mv_param.mv_expr = item.mv_expr.nodes[0].fn.name.function_name;
+                } else if (item.mv_expr.nodes[0].node_type == TExprNodeType::CASE_EXPR) {
+                    mv_param.mv_expr = "count_field";
+                }
+            }
+            sc_params.materialized_params_map.insert(std::make_pair(item.column_name, mv_param));
+        }
+    }
+
     Status status = _parse_request(sc_params.base_tablet, sc_params.new_tablet, sc_params.chunk_changer.get(),
                                    &sc_params.sc_sorting, &sc_params.sc_directly, sc_params.materialized_params_map);
     if (!status.ok()) {
@@ -1043,36 +1076,7 @@ Status SchemaChangeHandler::_do_process_alter_tablet_v2_normal(const TAlterTable
     sc_params.rowset_readers = std::move(readers);
     sc_params.version = Version(0, end_version);
     sc_params.rowsets_to_change = rowsets_to_change;
-    if (request.__isset.materialized_view_params) {
-        for (auto item : request.materialized_view_params) {
-            AlterMaterializedViewParam mv_param;
-            mv_param.column_name = item.column_name;
-            /*
-             * origin_column_name is always be set now,
-             * but origin_column_name may be not set in some materialized view function. eg:count(1)
-            */
-            if (item.__isset.origin_column_name) {
-                mv_param.origin_column_name = item.origin_column_name;
-            }
 
-            /*
-            * TODO(lhy)
-            * Building the materialized view function for schema_change here based on defineExpr.
-            * This is a trick because the current storage layer does not support expression evaluation.
-            * We can refactor this part of the code until the uniform expression evaluates the logic.
-            * count distinct materialized view will set mv_expr with to_bitmap or hll_hash.
-            * count materialized view will set mv_expr with count.
-            */
-            if (item.__isset.mv_expr) {
-                if (item.mv_expr.nodes[0].node_type == TExprNodeType::FUNCTION_CALL) {
-                    mv_param.mv_expr = item.mv_expr.nodes[0].fn.name.function_name;
-                } else if (item.mv_expr.nodes[0].node_type == TExprNodeType::CASE_EXPR) {
-                    mv_param.mv_expr = "count_field";
-                }
-            }
-            sc_params.materialized_params_map.insert(std::make_pair(item.column_name, mv_param));
-        }
-    }
     status = _convert_historical_rowsets(sc_params);
     if (!status.ok()) {
         return status;

--- a/be/src/storage/vectorized/schema_change.cpp
+++ b/be/src/storage/vectorized/schema_change.cpp
@@ -46,14 +46,6 @@
 #include "storage/wrapper_field.h"
 #include "util/unaligned_access.h"
 
-using std::deque;
-using std::list;
-using std::nothrow;
-using std::pair;
-using std::string;
-using std::stringstream;
-using std::vector;
-
 namespace starrocks {
 namespace vectorized {
 
@@ -62,7 +54,7 @@ using ChunkRow = std::pair<size_t, Chunk*>;
 int compare_chunk_row(const ChunkRow& lhs, const ChunkRow& rhs) {
     for (uint16_t i = 0; i < lhs.second->schema()->num_key_fields(); ++i) {
         int res = lhs.second->get_column_by_index(i)->compare_at(lhs.first, rhs.first,
-                                                                 *(rhs.second->get_column_by_index(i)), -1);
+                                                                 *rhs.second->get_column_by_index(i), -1);
         if (res != 0) {
             return res;
         }
@@ -118,8 +110,7 @@ ChunkChanger::ChunkChanger(const TabletSchema& tablet_schema) {
 }
 
 ChunkChanger::~ChunkChanger() {
-    SchemaMapping::iterator it = _schema_mapping.begin();
-    for (; it != _schema_mapping.end(); ++it) {
+    for (SchemaMapping::iterator it = _schema_mapping.begin(); it != _schema_mapping.end(); ++it) {
         SAFE_DELETE(it->default_value);
     }
     _schema_mapping.clear();
@@ -129,8 +120,7 @@ ColumnMapping* ChunkChanger::get_mutable_column_mapping(size_t column_index) {
     if (column_index >= _schema_mapping.size()) {
         return nullptr;
     }
-
-    return &(_schema_mapping[column_index]);
+    return &_schema_mapping[column_index];
 }
 
 #define TYPE_REINTERPRET_CAST(FromType, ToType)      \
@@ -193,7 +183,7 @@ class ConvertTypeResolver {
     DECLARE_SINGLETON(ConvertTypeResolver);
 
 public:
-    bool get_convert_type_info(const FieldType from_type, const FieldType to_type) const {
+    bool convert_type_exist(const FieldType from_type, const FieldType to_type) const {
         return _convert_type_set.find(std::make_pair(from_type, to_type)) != _convert_type_set.end();
     }
 
@@ -278,8 +268,23 @@ ConvertTypeResolver::ConvertTypeResolver() {
 
 ConvertTypeResolver::~ConvertTypeResolver() {}
 
-bool ChunkChanger::change_chunk(ChunkPtr& base_chunk, ChunkPtr& new_chunk, TabletSharedPtr& base_tablet,
-                                TabletSharedPtr& new_tablet, MemPool* mem_pool) {
+const MaterializeTypeConverter* ChunkChanger::_get_materialize_type_converter(std::string materialized_function,
+                                                                              FieldType type) {
+    if (materialized_function == "to_bitmap") {
+        return vectorized::get_materialized_converter(type, OLAP_MATERIALIZE_TYPE_BITMAP);
+    } else if (materialized_function == "hll_hash") {
+        return vectorized::get_materialized_converter(type, OLAP_MATERIALIZE_TYPE_HLL);
+    } else if (materialized_function == "count_field") {
+        return vectorized::get_materialized_converter(type, OLAP_MATERIALIZE_TYPE_COUNT);
+    } else if (materialized_function == "percentile_hash") {
+        return vectorized::get_materialized_converter(type, OLAP_MATERIALIZE_TYPE_PERCENTILE);
+    } else {
+        return nullptr;
+    }
+}
+
+bool ChunkChanger::change_chunk(ChunkPtr& base_chunk, ChunkPtr& new_chunk, const TabletMetaSharedPtr& base_tablet_meta,
+                                const TabletMetaSharedPtr& new_tablet_meta, MemPool* mem_pool) {
     if (new_chunk->num_columns() != _schema_mapping.size()) {
         LOG(WARNING) << "new chunk does not match with schema mapping rules. "
                      << "chunk_schema_size=" << new_chunk->num_columns()
@@ -289,50 +294,36 @@ bool ChunkChanger::change_chunk(ChunkPtr& base_chunk, ChunkPtr& new_chunk, Table
 
     for (size_t i = 0; i < new_chunk->num_columns(); ++i) {
         int ref_column = _schema_mapping[i].ref_column;
-
-        if (_schema_mapping[i].ref_column >= 0) {
+        if (ref_column >= 0) {
             FieldType ref_type = TypeUtils::to_storage_format_v2(
                     base_tablet->tablet_meta()->tablet_schema().column(ref_column).type());
             FieldType new_type =
                     TypeUtils::to_storage_format_v2(new_tablet->tablet_meta()->tablet_schema().column(i).type());
             if (!_schema_mapping[i].materialized_function.empty()) {
-                const MaterializeTypeConverter* converter = nullptr;
-                if (_schema_mapping[i].materialized_function == "to_bitmap") {
-                    converter = vectorized::get_materialized_converter(ref_type, OLAP_MATERIALIZE_TYPE_BITMAP);
-                } else if (_schema_mapping[i].materialized_function == "hll_hash") {
-                    converter = vectorized::get_materialized_converter(ref_type, OLAP_MATERIALIZE_TYPE_HLL);
-                } else if (_schema_mapping[i].materialized_function == "count_field") {
-                    converter = vectorized::get_materialized_converter(ref_type, OLAP_MATERIALIZE_TYPE_COUNT);
-                } else if (_schema_mapping[i].materialized_function == "percentile_hash") {
-                    converter = vectorized::get_materialized_converter(ref_type, OLAP_MATERIALIZE_TYPE_PERCENTILE);
-                } else {
-                    LOG(WARNING) << "error materialized view function : " << _schema_mapping[i].materialized_function;
-                    return false;
-                }
-                VLOG(3) << "_schema_mapping[" << i
-                        << "].materialized_function : " << _schema_mapping[i].materialized_function;
-
+                const auto& materialized_function = _schema_mapping[i].materialized_function;
+                const MaterializeTypeConverter* converter =
+                        _get_materialize_type_converter(materialized_function, ref_type);
+                VLOG(3) << "_schema_mapping[" << i << "].materialized_function: " << materialized_function;
                 if (converter == nullptr) {
-                    LOG(WARNING) << "error materialized view function : " << _schema_mapping[i].materialized_function;
+                    LOG(WARNING) << "error materialized view function : " << materialized_function;
                     return false;
                 }
                 ColumnPtr& base_col = base_chunk->get_column_by_index(ref_column);
                 ColumnPtr& new_col = new_chunk->get_column_by_index(i);
-                Field f = ChunkHelper::convert_field_to_format_v2(
-                        ref_column, base_tablet->tablet_meta()->tablet_schema().column(ref_column));
-                Status st =
-                        converter->convert_materialized(base_col, new_col, f.type().get(),
-                                                        base_tablet->tablet_meta()->tablet_schema().column(ref_column));
+                Field ref_field = ChunkHelper::convert_field_to_format_v2(
+                        ref_column, base_tablet_meta->tablet_schema().column(ref_column));
+                Status st = converter->convert_materialized(base_col, new_col, ref_field.type().get(),
+                                                            base_tablet_meta->tablet_schema().column(ref_column));
                 if (!st.ok()) {
                     return false;
                 }
                 continue;
             }
 
-            int reftype_precision = base_tablet->tablet_meta()->tablet_schema().column(ref_column).precision();
-            int reftype_scale = base_tablet->tablet_meta()->tablet_schema().column(ref_column).scale();
-            int newtype_precision = new_tablet->tablet_meta()->tablet_schema().column(i).precision();
-            int newtype_scale = new_tablet->tablet_meta()->tablet_schema().column(i).scale();
+            int reftype_precision = base_tablet_meta->tablet_schema().column(ref_column).precision();
+            int reftype_scale = base_tablet_meta->tablet_schema().column(ref_column).scale();
+            int newtype_precision = new_tablet_meta->tablet_schema().column(i).precision();
+            int newtype_scale = new_tablet_meta->tablet_schema().column(i).scale();
 
             ColumnPtr& base_col = base_chunk->get_column_by_index(ref_column);
             ColumnPtr& new_col = new_chunk->get_column_by_index(i);
@@ -348,10 +339,9 @@ bool ChunkChanger::change_chunk(ChunkPtr& base_chunk, ChunkPtr& new_chunk, Table
                             new_col->append_datum(new_datum);
                             continue;
                         }
-
                         Slice base_slice = base_datum.get_slice();
                         Slice slice;
-                        slice.size = new_tablet->tablet_meta()->tablet_schema().column(i).length();
+                        slice.size = new_tablet_meta->tablet_schema().column(i).length();
                         slice.data = reinterpret_cast<char*>(mem_pool->allocate(slice.size));
                         if (slice.data == nullptr) {
                             LOG(WARNING) << "failed to allocate memory in mem_pool";
@@ -368,7 +358,7 @@ bool ChunkChanger::change_chunk(ChunkPtr& base_chunk, ChunkPtr& new_chunk, Table
                 } else {
                     new_col = base_col;
                 }
-            } else if (ConvertTypeResolver::instance()->get_convert_type_info(ref_type, new_type)) {
+            } else if (ConvertTypeResolver::instance()->convert_type_exist(ref_type, new_type)) {
                 auto converter = vectorized::get_type_converter(ref_type, new_type);
                 if (converter == nullptr) {
                     LOG(WARNING) << "failed to get type converter, from_type=" << ref_type << ", to_type" << new_type;
@@ -376,13 +366,13 @@ bool ChunkChanger::change_chunk(ChunkPtr& base_chunk, ChunkPtr& new_chunk, Table
                 }
                 for (size_t row_index = 0; row_index < base_chunk->num_rows(); ++row_index) {
                     Datum base_datum = base_col->get(row_index);
-                    Field f = ChunkHelper::convert_field_to_format_v2(
-                            ref_column, base_tablet->tablet_meta()->tablet_schema().column(ref_column));
-                    Field f2 = ChunkHelper::convert_field_to_format_v2(
-                            i, new_tablet->tablet_meta()->tablet_schema().column(i));
+                    Field ref_field = ChunkHelper::convert_field_to_format_v2(
+                            ref_column, base_tablet_meta->tablet_schema().column(ref_column));
+                    Field new_field =
+                            ChunkHelper::convert_field_to_format_v2(i, new_tablet_meta->tablet_schema().column(i));
                     Datum new_datum;
-                    Status st =
-                            converter->convert_datum(f.type().get(), base_datum, f2.type().get(), new_datum, mem_pool);
+                    Status st = converter->convert_datum(ref_field.type().get(), base_datum, new_field.type().get(),
+                                                         new_datum, mem_pool);
                     if (!st.ok()) {
                         LOG(WARNING) << "failed to convert " << field_type_to_string(ref_type) << " to "
                                      << field_type_to_string(new_type);
@@ -414,11 +404,9 @@ bool ChunkChanger::change_chunk(ChunkPtr& base_chunk, ChunkPtr& new_chunk, Table
                                  << " from_type=" << ref_type << ", to_type=" << new_type;
                     return false;
                 }
-
-                //new_col->append(*base_col);
                 if (new_type < ref_type) {
                     LOG(INFO) << "type degraded while altering column. "
-                              << "column=" << new_tablet->tablet_meta()->tablet_schema().column(i).name()
+                              << "column=" << new_tablet_meta->tablet_schema().column(i).name()
                               << ", origin_type=" << field_type_to_string(ref_type)
                               << ", alter_type=" << field_type_to_string(new_type);
                 }
@@ -431,9 +419,9 @@ bool ChunkChanger::change_chunk(ChunkPtr& base_chunk, ChunkPtr& new_chunk, Table
                     dst_datum.set_null();
                 } else {
                     std::string tmp = _schema_mapping[i].default_value->to_string();
-                    Field f = ChunkHelper::convert_field_to_format_v2(
-                            i, new_tablet->tablet_meta()->tablet_schema().column(i));
-                    Status st = datum_from_string(f.type().get(), &dst_datum, tmp, nullptr);
+                    Field new_field =
+                            ChunkHelper::convert_field_to_format_v2(i, new_tablet_meta->tablet_schema().column(i));
+                    Status st = datum_from_string(new_field.type().get(), &dst_datum, tmp, nullptr);
                     if (!st.ok()) {
                         LOG(WARNING) << "create datum from string failed";
                         return false;
@@ -538,7 +526,6 @@ void ChunkAllocator::release(ChunkPtr& chunk, size_t num_rows) {
         LOG(INFO) << "null chunk released.";
         return;
     }
-
     _memory_allocated -= std::max(chunk->num_rows(), num_rows) * _row_len;
     return;
 }
@@ -601,7 +588,7 @@ bool ChunkMerger::merge(std::vector<ChunkPtr>& chunk_arr, RowsetWriter* rowset_w
             nread = 0;
         }
 
-        tmp_chunk->append(*(_heap.top().chunk), _heap.top().row_index, 1);
+        tmp_chunk->append(*_heap.top().chunk, _heap.top().row_index, 1);
         nread += 1;
         if (!_pop_heap()) {
             process_err();
@@ -668,7 +655,7 @@ bool LinkedSchemaChange::process(vectorized::TabletReader* reader, RowsetWriter*
 #endif
 
     OLAPStatus status =
-            new_rowset_writer->add_rowset_for_linked_schema_change(rowset, _chunk_changer.get_schema_mapping());
+            new_rowset_writer->add_rowset_for_linked_schema_change(rowset, _chunk_changer->get_schema_mapping());
     if (status != OLAP_SUCCESS) {
         LOG(WARNING) << "fail to convert rowset."
                      << ", new_tablet=" << new_tablet->full_name() << ", base_tablet=" << base_tablet->full_name()
@@ -676,14 +663,11 @@ bool LinkedSchemaChange::process(vectorized::TabletReader* reader, RowsetWriter*
                      << new_rowset_writer->version().second;
         return false;
     }
-
     return true;
 }
 
 bool SchemaChangeDirectly::process(vectorized::TabletReader* reader, RowsetWriter* new_rowset_writer,
                                    TabletSharedPtr new_tablet, TabletSharedPtr base_tablet, RowsetSharedPtr rowset) {
-    bool result = true;
-
     vectorized::Schema base_schema = ChunkHelper::convert_schema_to_format_v2(base_tablet->tablet_schema());
     ChunkPtr base_chunk = ChunkHelper::new_chunk(base_schema, config::vector_chunk_size);
 
@@ -706,51 +690,48 @@ bool SchemaChangeDirectly::process(vectorized::TabletReader* reader, RowsetWrite
         Status status = reader->do_get_next(base_chunk.get());
 
         if (!status.ok()) {
-            if (!status.is_end_of_file()) {
-                LOG(WARNING) << "failed to get next chunk, status is:" << status.to_string();
-                return false;
-            } else {
+            if (status.is_end_of_file()) {
                 break;
+            } else {
+                LOG(WARNING) << "tablet reader failed to get next chunk, status: " << status.to_string();
+                return false;
             }
         }
-        if (!_chunk_changer.change_chunk(base_chunk, new_chunk, base_tablet, new_tablet, mem_pool.get())) {
+        if (!_chunk_changer->change_chunk(base_chunk, new_chunk, base_tablet->tablet_meta(), new_tablet->tablet_meta(),
+                                          mem_pool.get())) {
             LOG(WARNING) << "failed to change data in chunk";
             return false;
         }
-
-        OLAPStatus olap_st = new_rowset_writer->add_chunk(*new_chunk);
-        if (olap_st != OLAP_SUCCESS) {
+        if (new_rowset_writer->add_chunk(*new_chunk) != OLAP_SUCCESS) {
             LOG(WARNING) << "failed to write chunk";
             return false;
         }
-
-        new_chunk->reset();
         base_chunk->reset();
+        new_chunk->reset();
         mem_pool->clear();
     } while (base_chunk->num_rows() == 0);
 
     if (base_chunk->num_rows() != 0) {
-        if (!_chunk_changer.change_chunk(base_chunk, new_chunk, base_tablet, new_tablet, mem_pool.get())) {
+        if (!_chunk_changer->change_chunk(base_chunk, new_chunk, base_tablet->tablet_meta(), new_tablet->tablet_meta(),
+                                          mem_pool.get())) {
             LOG(WARNING) << "failed to change data in chunk";
             return false;
         }
-
-        OLAPStatus olap_st = new_rowset_writer->add_chunk(*new_chunk);
-        if (olap_st != OLAP_SUCCESS) {
+        if (new_rowset_writer->add_chunk(*new_chunk) != OLAP_SUCCESS) {
             LOG(WARNING) << "failed to write chunk";
             return false;
         }
     }
 
-    if (OLAP_SUCCESS != new_rowset_writer->flush()) {
+    if (new_rowset_writer->flush() != OLAP_SUCCESS) {
         LOG(WARNING) << "failed to flush rowset writer";
-        result = false;
+        return false;
     }
 
-    return result;
+    return true;
 }
 
-SchemaChangeWithSorting::SchemaChangeWithSorting(ChunkChanger& chunk_changer, size_t memory_limitation)
+SchemaChangeWithSorting::SchemaChangeWithSorting(ChunkChanger* chunk_changer, size_t memory_limitation)
         : SchemaChange(),
           _chunk_changer(chunk_changer),
           _memory_limitation(memory_limitation),
@@ -762,10 +743,8 @@ SchemaChangeWithSorting::~SchemaChangeWithSorting() {
 
 bool SchemaChangeWithSorting::process(vectorized::TabletReader* reader, RowsetWriter* new_rowset_writer,
                                       TabletSharedPtr new_tablet, TabletSharedPtr base_tablet, RowsetSharedPtr rowset) {
-    bool result = true;
-
     if (_chunk_allocator == nullptr) {
-        _chunk_allocator = new (nothrow) ChunkAllocator(new_tablet->tablet_schema(), _memory_limitation);
+        _chunk_allocator = new (std::nothrow) ChunkAllocator(new_tablet->tablet_schema(), _memory_limitation);
         if (_chunk_allocator == nullptr) {
             LOG(FATAL) << "failed to malloc chunk allocator. size=" << sizeof(ChunkAllocator);
             return false;
@@ -818,7 +797,7 @@ bool SchemaChangeWithSorting::process(vectorized::TabletReader* reader, RowsetWr
                 return false;
             }
 
-            for (vector<ChunkPtr>::iterator it = chunk_arr.begin(); it != chunk_arr.end(); ++it) {
+            for (std::vector<ChunkPtr>::iterator it = chunk_arr.begin(); it != chunk_arr.end(); ++it) {
                 _chunk_allocator->release(*it, (*it)->num_rows());
             }
 
@@ -830,7 +809,8 @@ bool SchemaChangeWithSorting::process(vectorized::TabletReader* reader, RowsetWr
             return false;
         }
 
-        if (!_chunk_changer.change_chunk(base_chunk, new_chunk, base_tablet, new_tablet, mem_pool.get())) {
+        if (!_chunk_changer->change_chunk(base_chunk, new_chunk, base_tablet->tablet_meta(), new_tablet->tablet_meta(),
+                                          mem_pool.get())) {
             _chunk_allocator->release(new_chunk, base_chunk->num_rows());
             LOG(WARNING) << "failed to change data in chunk";
             return false;
@@ -862,16 +842,16 @@ bool SchemaChangeWithSorting::process(vectorized::TabletReader* reader, RowsetWr
 
     if (OLAP_SUCCESS != new_rowset_writer->flush()) {
         LOG(WARNING) << "failed to flush rowset writer";
-        result = false;
+        return false;
     }
 
-    return result;
+    return true;
 }
 
 bool SchemaChangeWithSorting::_internal_sorting(std::vector<ChunkPtr>& chunk_arr, RowsetWriter* new_rowset_writer,
                                                 TabletSharedPtr tablet) {
     if (chunk_arr.size() == 1) {
-        new_rowset_writer->add_chunk(*(chunk_arr[0]));
+        new_rowset_writer->add_chunk(*chunk_arr[0]);
         if (new_rowset_writer->flush() != OLAP_SUCCESS) {
             LOG(WARNING) << "failed to finalizing writer.";
             return false;
@@ -940,8 +920,7 @@ Status SchemaChangeHandler::_do_process_alter_tablet_v2(const TAlterTabletReqV2&
         return Status::InternalError("new tablet's meta is invalid");
     }
 
-    LOG(INFO) << "finish to validate alter tablet request. begin to convert data from base tablet "
-                 "to new tablet"
+    LOG(INFO) << "finish to validate alter tablet request. begin to convert data from base tablet to new tablet"
               << " base_tablet=" << base_tablet->full_name() << " new_tablet=" << new_tablet->full_name();
 
     std::shared_lock base_migration_rlock(base_tablet->get_migration_lock(), std::try_to_lock);
@@ -953,119 +932,9 @@ Status SchemaChangeHandler::_do_process_alter_tablet_v2(const TAlterTabletReqV2&
         return Status::InternalError("new tablet get migration r_lock failed");
     }
 
-    if (base_tablet->keys_type() == KeysType::PRIMARY_KEYS) {
-        Status st = new_tablet->updates()->load_from_base_tablet(request.alter_version, base_tablet.get());
-        if (!st.ok()) {
-            LOG(WARNING) << "schema change new tablet load snapshot error " << st.to_string();
-            return st;
-        }
-        return Status::OK();
-    } else {
-        return _do_process_alter_tablet_v2_normal(request, base_tablet, new_tablet);
-    }
-}
-
-Status SchemaChangeHandler::_do_process_alter_tablet_v2_normal(const TAlterTabletReqV2& request,
-                                                               const TabletSharedPtr& base_tablet,
-                                                               const TabletSharedPtr& new_tablet) {
-    OLAPStatus res = OLAP_SUCCESS;
-    // begin to find deltas to convert from base tablet to new tablet so that
-    // obtain base tablet and new tablet's push lock and header write lock to prevent loading data
-
-    std::vector<ColumnId> return_columns;
-    RowsetSharedPtr max_rowset;
-    std::vector<RowsetSharedPtr> rowsets_to_change;
-    int32_t end_version = -1;
-    Status status;
-    {
-        std::lock_guard l1(base_tablet->get_push_lock());
-        std::lock_guard l2(new_tablet->get_push_lock());
-        std::lock_guard l3(base_tablet->get_header_lock());
-        std::lock_guard l4(new_tablet->get_header_lock());
-
-        // check if the tablet has alter task
-        // if it has alter task, it means it is under old alter process
-
-        std::vector<Version> versions_to_be_changed;
-        status = _get_versions_to_be_changed(base_tablet, &versions_to_be_changed);
-        if (!status.ok()) {
-            LOG(WARNING) << "fail to get version to be changed. res=" << res;
-            return status;
-        }
-        LOG(INFO) << "versions to be changed size:" << versions_to_be_changed.size();
-        for (auto& version : versions_to_be_changed) {
-            RowsetSharedPtr rowset = base_tablet->get_rowset_by_version(version);
-            rowsets_to_change.push_back(rowset);
-        }
-        LOG(INFO) << "rowsets_to_change size is:" << rowsets_to_change.size();
-
-        size_t num_cols = base_tablet->tablet_schema().num_columns();
-        return_columns.resize(num_cols);
-        for (int i = 0; i < num_cols; ++i) {
-            return_columns[i] = i;
-        }
-
-        Version max_version = base_tablet->max_version();
-        max_rowset = base_tablet->rowset_with_max_version();
-        if (max_rowset == nullptr || max_version.second < request.alter_version) {
-            LOG(WARNING) << "base tablet's max version=" << (max_rowset == nullptr ? 0 : max_rowset->end_version())
-                         << " is less than request version=" << request.alter_version;
-
-            return Status::InternalError("base tablet's max version is less than request version");
-        }
-
-        LOG(INFO) << "begin to remove all data from new tablet to prevent rewrite."
-                  << " new_tablet=" << new_tablet->full_name();
-        std::vector<RowsetSharedPtr> rowsets_to_delete;
-        std::vector<Version> new_tablet_versions;
-        new_tablet->list_versions(&new_tablet_versions);
-        for (auto& version : new_tablet_versions) {
-            if (version.second <= max_rowset->end_version()) {
-                RowsetSharedPtr rowset = new_tablet->get_rowset_by_version(version);
-                rowsets_to_delete.push_back(rowset);
-            }
-        }
-        LOG(INFO) << "rowsets_to_delete size is:" << rowsets_to_delete.size()
-                  << " version is:" << max_rowset->end_version();
-        new_tablet->modify_rowsets(std::vector<RowsetSharedPtr>(), rowsets_to_delete);
-        new_tablet->set_cumulative_layer_point(-1);
-        new_tablet->save_meta();
-        for (auto& rowset : rowsets_to_delete) {
-            // do not call rowset.remove directly, using gc thread to delete it
-            StorageEngine::instance()->add_unused_rowset(rowset);
-        }
-
-        // init one delete handler
-        for (auto& version : versions_to_be_changed) {
-            if (version.second > end_version) {
-                end_version = version.second;
-            }
-        }
-    }
-
-    Schema base_schema = ChunkHelper::convert_schema_to_format_v2(base_tablet->tablet_schema(), return_columns);
-    Version delete_predicates_version(0, max_rowset->version().second);
-    TabletReaderParams read_params;
-    read_params.reader_type = ReaderType::READER_ALTER_TABLE;
-    read_params.skip_aggregation = false;
-    read_params.chunk_size = config::vector_chunk_size;
-
-    std::vector<std::unique_ptr<vectorized::TabletReader>> readers;
-    for (auto rowset : rowsets_to_change) {
-        auto tablet_rowset_reader =
-                std::make_unique<vectorized::TabletReader>(base_tablet, rowset->version(), base_schema);
-        tablet_rowset_reader->set_delete_predicates_version(delete_predicates_version);
-        RETURN_IF_ERROR(tablet_rowset_reader->prepare());
-        RETURN_IF_ERROR(tablet_rowset_reader->open(read_params));
-        readers.emplace_back(std::move(tablet_rowset_reader));
-    }
-
     SchemaChangeParams sc_params;
     sc_params.base_tablet = base_tablet;
     sc_params.new_tablet = new_tablet;
-    sc_params.rowset_readers = std::move(readers);
-    sc_params.version = Version(0, end_version);
-    sc_params.rowsets_to_change = rowsets_to_change;
     if (request.__isset.materialized_view_params) {
         for (auto item : request.materialized_view_params) {
             AlterMaterializedViewParam mv_param;
@@ -1096,11 +965,125 @@ Status SchemaChangeHandler::_do_process_alter_tablet_v2_normal(const TAlterTable
             sc_params.materialized_params_map.insert(std::make_pair(item.column_name, mv_param));
         }
     }
+
+    sc_params.chunk_changer = std::make_unique<ChunkChanger>(sc_params.new_tablet->tablet_schema());
+
+    Status status = _parse_request(sc_params);
+    if (!status.ok()) {
+        LOG(WARNING) << "failed to parse the request. res=" << status.get_error_msg();
+        return status;
+    }
+
+    if (base_tablet->keys_type() == KeysType::PRIMARY_KEYS) {
+        Status status;
+        if (sc_params.sc_directly) {
+            status = new_tablet->updates()->load_from_base_tablet(request, sc_params);
+        } else if (sc_params.sc_sorting) {
+            LOG(WARNING) << "schema change of primary key model do not support sorting.";
+            status = Status::NotSupported("schema change of primary key model do not support sorting.");
+        } else {
+            status = new_tablet->updates()->load_from_base_tablet(request.alter_version, base_tablet.get());
+        }
+        if (!status.ok()) {
+            LOG(WARNING) << "schema change new tablet load snapshot error: " << status.to_string();
+            return status;
+        }
+        return Status::OK();
+    } else {
+        return _do_process_alter_tablet_v2_normal(request, sc_params, base_tablet, new_tablet);
+    }
+}
+
+Status SchemaChangeHandler::_do_process_alter_tablet_v2_normal(const TAlterTabletReqV2& request,
+                                                               SchemaChangeParams& sc_params,
+                                                               const TabletSharedPtr& base_tablet,
+                                                               const TabletSharedPtr& new_tablet) {
+    // begin to find deltas to convert from base tablet to new tablet so that
+    // obtain base tablet and new tablet's push lock and header write lock to prevent loading data
+    RowsetSharedPtr max_rowset;
+    std::vector<RowsetSharedPtr> rowsets_to_change;
+    int32_t end_version = -1;
+    Status status;
+    {
+        std::lock_guard l1(base_tablet->get_push_lock());
+        std::lock_guard l2(new_tablet->get_push_lock());
+        std::lock_guard l3(base_tablet->get_header_lock());
+        std::lock_guard l4(new_tablet->get_header_lock());
+
+        std::vector<Version> versions_to_be_changed;
+        status = _get_versions_to_be_changed(base_tablet, &versions_to_be_changed);
+        if (!status.ok()) {
+            LOG(WARNING) << "fail to get version to be changed. status: " << status;
+            return status;
+        }
+        LOG(INFO) << "versions to be changed size:" << versions_to_be_changed.size();
+        for (auto& version : versions_to_be_changed) {
+            rowsets_to_change.push_back(base_tablet->get_rowset_by_version(version));
+        }
+        LOG(INFO) << "rowsets_to_change size is:" << rowsets_to_change.size();
+
+        Version max_version = base_tablet->max_version();
+        max_rowset = base_tablet->rowset_with_max_version();
+        if (max_rowset == nullptr || max_version.second < request.alter_version) {
+            LOG(WARNING) << "base tablet's max version=" << (max_rowset == nullptr ? 0 : max_rowset->end_version())
+                         << " is less than request version=" << request.alter_version;
+            return Status::InternalError("base tablet's max version is less than request version");
+        }
+
+        LOG(INFO) << "begin to remove all data from new tablet to prevent rewrite."
+                  << " new_tablet=" << new_tablet->full_name();
+        std::vector<RowsetSharedPtr> rowsets_to_delete;
+        std::vector<Version> new_tablet_versions;
+        new_tablet->list_versions(&new_tablet_versions);
+        for (auto& version : new_tablet_versions) {
+            if (version.second <= max_rowset->end_version()) {
+                rowsets_to_delete.push_back(new_tablet->get_rowset_by_version(version));
+            }
+        }
+        LOG(INFO) << "rowsets_to_delete size is:" << rowsets_to_delete.size()
+                  << " version is:" << max_rowset->end_version();
+        new_tablet->modify_rowsets(std::vector<RowsetSharedPtr>(), rowsets_to_delete);
+        new_tablet->set_cumulative_layer_point(-1);
+        new_tablet->save_meta();
+        for (auto& rowset : rowsets_to_delete) {
+            // do not call rowset.remove directly, using gc thread to delete it
+            StorageEngine::instance()->add_unused_rowset(rowset);
+        }
+
+        // init one delete handler
+        for (auto& version : versions_to_be_changed) {
+            if (version.second > end_version) {
+                end_version = version.second;
+            }
+        }
+    }
+
+    Schema base_schema = ChunkHelper::convert_schema_to_format_v2(base_tablet->tablet_schema());
+    Version delete_predicates_version(0, max_rowset->version().second);
+    TabletReaderParams read_params;
+    read_params.reader_type = ReaderType::READER_ALTER_TABLE;
+    read_params.skip_aggregation = false;
+    read_params.chunk_size = config::vector_chunk_size;
+
+    std::vector<std::unique_ptr<vectorized::TabletReader>> readers;
+    for (auto rowset : rowsets_to_change) {
+        vectorized::TabletReader* tablet_reader = new TabletReader(base_tablet, rowset->version(), base_schema);
+        tablet_reader->set_delete_predicates_version(delete_predicates_version);
+        RETURN_IF_ERROR(tablet_reader->prepare());
+        RETURN_IF_ERROR(tablet_reader->open(read_params));
+        readers.emplace_back(std::move(tablet_reader));
+    }
+
+    sc_params.rowset_readers = std::move(readers);
+    sc_params.version = Version(0, end_version);
+    sc_params.rowsets_to_change = rowsets_to_change;
+
     status = _convert_historical_rowsets(sc_params);
     if (!status.ok()) {
         return status;
     }
 
+    OLAPStatus res = OLAP_SUCCESS;
     {
         // set state to ready
         std::unique_lock new_wlock(new_tablet->get_header_lock());
@@ -1114,12 +1097,9 @@ Status SchemaChangeHandler::_do_process_alter_tablet_v2_normal(const TAlterTable
         new_tablet->save_meta();
     }
 
-    if (res == OLAP_SUCCESS) {
-        // _validate_alter_result should be outside the above while loop.
-        // to avoid requiring the header lock twice.
-        status = _validate_alter_result(new_tablet, request);
-    }
-
+    // _validate_alter_result should be outside the above while loop.
+    // to avoid requiring the header lock twice.
+    status = _validate_alter_result(new_tablet, request);
     if (!status.ok()) {
         LOG(WARNING) << "failed to alter tablet. base_tablet=" << base_tablet->full_name()
                      << ", drop new_tablet=" << new_tablet->full_name();
@@ -1137,16 +1117,12 @@ Status SchemaChangeHandler::_get_versions_to_be_changed(TabletSharedPtr base_tab
         LOG(WARNING) << "Tablet has no version. base_tablet=" << base_tablet->full_name();
         return Status::InternalError("tablet alter version does not exists");
     }
-
     std::vector<Version> span_versions;
     if (!base_tablet->capture_consistent_versions(Version(0, rowset->version().second), &span_versions).ok()) {
         return Status::InternalError("capture consistent versions failed");
     }
-
-    for (uint32_t i = 0; i < span_versions.size(); i++) {
-        versions_to_be_changed->push_back(span_versions[i]);
-    }
-
+    versions_to_be_changed->insert(std::end(*versions_to_be_changed), std::begin(span_versions),
+                                   std::end(span_versions));
     return Status::OK();
 }
 
@@ -1154,34 +1130,18 @@ Status SchemaChangeHandler::_convert_historical_rowsets(SchemaChangeParams& sc_p
     LOG(INFO) << "begin to convert historical rowsets for new_tablet from base_tablet."
               << " base_tablet=" << sc_params.base_tablet->full_name()
               << ", new_tablet=" << sc_params.new_tablet->full_name();
-
-    // The filter information is added to the change, the column information of the filter is set
-    // in _parse_request and some data is filtered at each change of the row block.
-    ChunkChanger chunk_changer(sc_params.new_tablet->tablet_schema());
-
-    bool sc_sorting = false;
-    bool sc_directly = false;
-    std::unique_ptr<SchemaChange> sc_procedure;
-
-    // a. parse Alter request
-    Status status = _parse_request(sc_params.base_tablet, sc_params.new_tablet, &chunk_changer, &sc_sorting,
-                                   &sc_directly, sc_params.materialized_params_map);
-
     DeferOp save_meta([&sc_params] {
         std::unique_lock new_wlock(sc_params.new_tablet->get_header_lock());
         sc_params.new_tablet->save_meta();
     });
-    if (!status.ok()) {
-        LOG(WARNING) << "failed to parse the request. res=" << status.get_error_msg();
-        return status;
-    }
 
-    if (sc_sorting) {
+    std::unique_ptr<SchemaChange> sc_procedure;
+    auto chunk_changer = sc_params.chunk_changer.get();
+    if (sc_params.sc_sorting) {
         LOG(INFO) << "doing schema change with sorting for base_tablet " << sc_params.base_tablet->full_name();
-        size_t memory_limitation =
-                static_cast<size_t>(config::memory_limitation_per_thread_for_schema_change) * 1024 * 1024 * 1024;
-        sc_procedure = std::make_unique<SchemaChangeWithSorting>(chunk_changer, memory_limitation);
-    } else if (sc_directly) {
+        sc_procedure = std::make_unique<SchemaChangeWithSorting>(
+                chunk_changer, config::memory_limitation_per_thread_for_schema_change * 1024 * 1024 * 1024);
+    } else if (sc_params.sc_directly) {
         sc_procedure = std::make_unique<SchemaChangeDirectly>(chunk_changer);
     } else {
         LOG(INFO) << "doing linked schema change for base_tablet " << sc_params.base_tablet->full_name();
@@ -1191,16 +1151,15 @@ Status SchemaChangeHandler::_convert_historical_rowsets(SchemaChangeParams& sc_p
     if (sc_procedure.get() == nullptr) {
         LOG(WARNING) << "failed to malloc SchemaChange. "
                      << "malloc_size=" << sizeof(SchemaChangeWithSorting);
-        status = Status::InternalError("failed to malloc SchemaChange");
-        return status;
+        return Status::InternalError("failed to malloc SchemaChange");
     }
+
+    Status status;
 
     for (int i = 0; i < sc_params.rowset_readers.size(); ++i) {
         LOG(INFO) << "begin to convert a history rowset. version=" << sc_params.rowsets_to_change[i]->version().first
                   << "-" << sc_params.rowsets_to_change[i]->version().second;
-        // set status for monitor
-        // If only one new_table is running, ref table will be set to running
-        // NOTE if the first sub_table is fail, it will continue as normal
+
         TabletSharedPtr new_tablet = sc_params.new_tablet;
         TabletSharedPtr base_tablet = sc_params.base_tablet;
         RowsetWriterContext writer_context(kDataFormatV2, config::storage_format_version);
@@ -1211,30 +1170,28 @@ Status SchemaChangeHandler::_convert_historical_rowsets(SchemaChangeParams& sc_p
         writer_context.tablet_schema_hash = new_tablet->schema_hash();
         writer_context.rowset_type = sc_params.new_tablet->tablet_meta()->preferred_rowset_type();
         writer_context.rowset_path_prefix = new_tablet->schema_hash_path();
-        writer_context.tablet_schema = &(new_tablet->tablet_schema());
+        writer_context.tablet_schema = &new_tablet->tablet_schema();
         writer_context.rowset_state = VISIBLE;
         writer_context.version = sc_params.rowsets_to_change[i]->version();
         writer_context.version_hash = sc_params.rowsets_to_change[i]->version_hash();
         writer_context.segments_overlap = sc_params.rowsets_to_change[i]->rowset_meta()->segments_overlap();
 
-        if (sc_sorting) {
+        if (sc_params.sc_sorting) {
             writer_context.write_tmp = true;
         }
 
         std::unique_ptr<RowsetWriter> rowset_writer;
         status = RowsetFactory::create_rowset_writer(writer_context, &rowset_writer);
         if (!status.ok()) {
-            status = Status::InternalError("build rowset writer failed");
             LOG(INFO) << "build rowset writer failed";
-            return status;
+            return Status::InternalError("build rowset writer failed");
         }
 
         if (!sc_procedure->process(sc_params.rowset_readers[i].get(), rowset_writer.get(), new_tablet, base_tablet,
                                    sc_params.rowsets_to_change[i])) {
             LOG(WARNING) << "failed to process the version."
                          << " version=" << sc_params.version.first << "-" << sc_params.version.second;
-            status = Status::InternalError("process failed");
-            return status;
+            return Status::InternalError("process failed");
         }
         // Add the new version of the data to the header,
         // To prevent deadlocks, be sure to lock the old table first and then the new one
@@ -1279,21 +1236,22 @@ Status SchemaChangeHandler::_convert_historical_rowsets(SchemaChangeParams& sc_p
     return status;
 }
 
-// @static
-Status SchemaChangeHandler::_parse_request(
-        TabletSharedPtr base_tablet, TabletSharedPtr new_tablet, ChunkChanger* chunk_changer, bool* sc_sorting,
-        bool* sc_directly,
-        const std::unordered_map<std::string, AlterMaterializedViewParam>& materialized_function_map) {
-    for (int i = 0, new_schema_size = new_tablet->tablet_schema().num_columns(); i < new_schema_size; ++i) {
+Status SchemaChangeHandler::_parse_request(SchemaChangeParams& sc_params) {
+    const auto& base_tablet = sc_params.base_tablet;
+    const auto& new_tablet = sc_params.new_tablet;
+    auto chunk_changer = sc_params.chunk_changer.get();
+    bool* sc_sorting = &sc_params.sc_sorting;
+    bool* sc_directly = &sc_params.sc_directly;
+    const auto& materialized_function_map = sc_params.materialized_params_map;
+    for (int i = 0; i < new_tablet->tablet_schema().num_columns(); ++i) {
         const TabletColumn& new_column = new_tablet->tablet_schema().column(i);
-        string column_name = std::string(new_column.name());
+        std::string column_name(new_column.name());
         ColumnMapping* column_mapping = chunk_changer->get_mutable_column_mapping(i);
 
         if (materialized_function_map.find(column_name) != materialized_function_map.end()) {
             AlterMaterializedViewParam mvParam = materialized_function_map.find(column_name)->second;
             column_mapping->materialized_function = mvParam.mv_expr;
-            std::string origin_column_name = mvParam.origin_column_name;
-            int32_t column_index = base_tablet->field_index(origin_column_name);
+            int32_t column_index = base_tablet->field_index(mvParam.origin_column_name);
             if (column_index >= 0) {
                 column_mapping->ref_column = column_index;
                 continue;
@@ -1342,7 +1300,7 @@ Status SchemaChangeHandler::_parse_request(
     // If the reference sequence of the Key column is out of order, it needs to be reordered
     int num_default_value = 0;
 
-    for (int i = 0, new_schema_size = new_tablet->num_key_columns(); i < new_schema_size; ++i) {
+    for (int i = 0; i < new_tablet->num_key_columns(); ++i) {
         ColumnMapping* column_mapping = chunk_changer->get_mutable_column_mapping(i);
 
         if (column_mapping->ref_column < 0) {
@@ -1414,8 +1372,8 @@ Status SchemaChangeHandler::_parse_request(
         }
     }
 
-    if (base_tablet->delete_predicates().size() != 0) {
-        //there exists delete condition in header, can't do linked schema change
+    if (!base_tablet->delete_predicates().empty()) {
+        // there exists delete condition in header, can't do linked schema change
         *sc_directly = true;
     }
 

--- a/be/src/storage/vectorized/schema_change.h
+++ b/be/src/storage/vectorized/schema_change.h
@@ -139,25 +139,6 @@ private:
     DISALLOW_COPY_AND_ASSIGN(SchemaChangeWithSorting);
 };
 
-struct AlterMaterializedViewParam {
-    std::string column_name;
-    std::string origin_column_name;
-    std::string mv_expr;
-};
-
-struct SchemaChangeParams {
-    AlterTabletType alter_tablet_type;
-    TabletSharedPtr base_tablet;
-    TabletSharedPtr new_tablet;
-    std::vector<std::unique_ptr<vectorized::TabletReader>> rowset_readers;
-    Version version;
-    std::unordered_map<std::string, AlterMaterializedViewParam> materialized_params_map;
-    std::vector<RowsetSharedPtr> rowsets_to_change;
-    bool sc_sorting = false;
-    bool sc_directly = false;
-    std::unique_ptr<ChunkChanger> chunk_changer = nullptr;
-};
-
 class SchemaChangeHandler {
 public:
     SchemaChangeHandler() {}
@@ -165,6 +146,25 @@ public:
 
     // schema change v2, it will not set alter task in base tablet
     Status process_alter_tablet_v2(const TAlterTabletReqV2& request);
+
+    struct AlterMaterializedViewParam {
+        std::string column_name;
+        std::string origin_column_name;
+        std::string mv_expr;
+    };
+
+    struct SchemaChangeParams {
+        AlterTabletType alter_tablet_type;
+        TabletSharedPtr base_tablet;
+        TabletSharedPtr new_tablet;
+        std::vector<std::unique_ptr<vectorized::TabletReader>> rowset_readers;
+        Version version;
+        std::unordered_map<std::string, AlterMaterializedViewParam> materialized_params_map;
+        std::vector<RowsetSharedPtr> rowsets_to_change;
+        bool sc_sorting = false;
+        bool sc_directly = false;
+        std::unique_ptr<ChunkChanger> chunk_changer = nullptr;
+    };
 
 private:
     Status _get_versions_to_be_changed(TabletSharedPtr base_tablet, std::vector<Version>* versions_to_be_changed);

--- a/be/src/storage/vectorized/schema_change.h
+++ b/be/src/storage/vectorized/schema_change.h
@@ -108,8 +108,7 @@ private:
 // @brief schema change without sorting.
 class SchemaChangeDirectly : public SchemaChange {
 public:
-    explicit SchemaChangeDirectly(ChunkChanger* chunk_changer)
-            : SchemaChange(), _chunk_changer(chunk_changer), _chunk_allocator(nullptr) {}
+    explicit SchemaChangeDirectly(ChunkChanger* chunk_changer) : SchemaChange(), _chunk_changer(chunk_changer) {}
     virtual ~SchemaChangeDirectly() { SAFE_DELETE(_chunk_allocator); }
 
     bool process(vectorized::TabletReader* reader, RowsetWriter* new_rowset_writer, TabletSharedPtr new_tablet,
@@ -117,7 +116,7 @@ public:
 
 private:
     ChunkChanger* _chunk_changer = nullptr;
-    ChunkAllocator* _chunk_allocator;
+    ChunkAllocator* _chunk_allocator = nullptr;
     DISALLOW_COPY_AND_ASSIGN(SchemaChangeDirectly);
 };
 
@@ -135,7 +134,7 @@ private:
 
     ChunkChanger* _chunk_changer = nullptr;
     size_t _memory_limitation;
-    ChunkAllocator* _chunk_allocator;
+    ChunkAllocator* _chunk_allocator = nullptr;
     DISALLOW_COPY_AND_ASSIGN(SchemaChangeWithSorting);
 };
 

--- a/be/src/storage/vectorized/schema_change.h
+++ b/be/src/storage/vectorized/schema_change.h
@@ -178,7 +178,10 @@ private:
 
     static Status _convert_historical_rowsets(SchemaChangeParams& sc_params);
 
-    static Status _parse_request(SchemaChangeParams& sc_params);
+    static Status _parse_request(
+            const std::shared_ptr<Tablet>& base_tablet, const std::shared_ptr<Tablet>& new_tablet,
+            ChunkChanger* chunk_changer, bool* sc_sorting, bool* sc_directly,
+            const std::unordered_map<std::string, AlterMaterializedViewParam>& materialized_function_map);
 
     // default_value for new column is needed
     static Status _init_column_mapping(ColumnMapping* column_mapping, const TabletColumn& column_schema,

--- a/be/src/storage/vectorized/tablet_reader.cpp
+++ b/be/src/storage/vectorized/tablet_reader.cpp
@@ -99,7 +99,7 @@ Status TabletReader::_init_collector(const TabletReaderParams& params) {
     rs_opts.runtime_state = params.runtime_state;
     rs_opts.profile = params.profile;
     rs_opts.use_page_cache = params.use_page_cache;
-    rs_opts.tablet_schema = &(_tablet->tablet_schema());
+    rs_opts.tablet_schema = &_tablet->tablet_schema();
     rs_opts.global_dictmaps = params.global_dictmaps;
     if (keys_type == KeysType::PRIMARY_KEYS) {
         rs_opts.is_primary_keys = true;
@@ -262,8 +262,8 @@ Status TabletReader::_init_delete_predicates(const TabletReaderParams& params, D
                 LOG(WARNING) << "invalid delete condition: " << pred_pb.sub_predicates(i) << "]";
                 return Status::InternalError("invalid delete condition string");
             }
-            size_t idx = _tablet->tablet_schema().field_index(cond.column_name);
-            if (idx >= _tablet->num_key_columns() && _tablet->keys_type() != DUP_KEYS) {
+            if (_tablet->tablet_schema().field_index(cond.column_name) >= _tablet->num_key_columns() &&
+                _tablet->keys_type() != DUP_KEYS) {
                 LOG(WARNING) << "ignore delete condition of non-key column: " << pred_pb.sub_predicates(i);
                 continue;
             }

--- a/be/src/storage/vectorized/tablet_reader.h
+++ b/be/src/storage/vectorized/tablet_reader.h
@@ -1,4 +1,5 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+#pragma once
 
 #include <memory>
 #include <vector>

--- a/be/src/storage/wrapper_field.cpp
+++ b/be/src/storage/wrapper_field.cpp
@@ -51,8 +51,7 @@ WrapperField* WrapperField::create(const TabletColumn& column, uint32_t len) {
         variable_len = column.length();
     }
 
-    WrapperField* wrapper = new WrapperField(rep, variable_len, is_string_type);
-    return wrapper;
+    return new WrapperField(rep, variable_len, is_string_type);
 }
 
 WrapperField* WrapperField::create_by_type(const FieldType& type, int32_t var_length) {

--- a/be/test/storage/tablet_mgr_test.cpp
+++ b/be/test/storage/tablet_mgr_test.cpp
@@ -118,7 +118,7 @@ TEST_F(TabletMgrTest, CreateTablet) {
     TabletSharedPtr tablet = _tablet_mgr->get_tablet(111, 3333);
     ASSERT_TRUE(tablet != nullptr);
     // check dir exist
-    bool dir_exist = FileUtils::check_exist(tablet->tablet_path());
+    bool dir_exist = FileUtils::check_exist(tablet->schema_hash_path());
     ASSERT_TRUE(dir_exist);
     // check meta has this tablet
     TabletMetaSharedPtr new_tablet_meta(new TabletMeta());
@@ -178,7 +178,7 @@ TEST_F(TabletMgrTest, DropTablet) {
     ASSERT_TRUE(tablet != nullptr);
 
     // check dir exist
-    std::string tablet_path = tablet->tablet_path();
+    std::string tablet_path = tablet->schema_hash_path();
     bool dir_exist = FileUtils::check_exist(tablet_path);
     ASSERT_TRUE(dir_exist);
 

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -809,7 +809,7 @@ TEST_F(TabletUpdatesTest, compaction) {
     EXPECT_EQ(best_tablet->updates()->get_compaction_score(), -1);
 }
 
-TEST_F(TabletUpdatesTest, schema_change_linked) {
+TEST_F(TabletUpdatesTest, link_from) {
     srand(GetCurrentTimeMicros());
     _tablet = create_tablet(rand(), rand());
     _tablet2 = create_tablet2(rand(), rand());
@@ -826,12 +826,12 @@ TEST_F(TabletUpdatesTest, schema_change_linked) {
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
     _tablet2->set_tablet_state(TABLET_NOTREADY);
-    ASSERT_TRUE(_tablet2->updates()->schema_change_linked(4, _tablet.get()).ok());
+    ASSERT_TRUE(_tablet2->updates()->link_from(_tablet.get(), 4).ok());
 
     ASSERT_EQ(N, read_tablet(_tablet2, 4));
 }
 
-TEST_F(TabletUpdatesTest, schema_change_directly) {
+TEST_F(TabletUpdatesTest, convert_from) {
     srand(GetCurrentTimeMicros());
     _tablet = create_tablet(rand(), rand());
     const auto& tablet_to_schema_change = create_tablet_to_schema_change(rand(), rand());
@@ -864,7 +864,7 @@ TEST_F(TabletUpdatesTest, schema_change_directly) {
             }
         }
     }
-    ASSERT_TRUE(tablet_to_schema_change->updates()->schema_change_directly(4, _tablet, chunk_changer.get()).ok());
+    ASSERT_TRUE(tablet_to_schema_change->updates()->convert_from(_tablet, 4, chunk_changer.get()).ok());
 
     ASSERT_EQ(N, read_tablet_and_compare_schema_changed(tablet_to_schema_change, 4, keys));
 }

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -24,6 +24,7 @@
 #include "storage/update_manager.h"
 #include "storage/vectorized/chunk_helper.h"
 #include "storage/vectorized/empty_iterator.h"
+#include "storage/vectorized/schema_change.h"
 #include "storage/vectorized/union_iterator.h"
 #include "util/defer_op.h"
 #include "util/path_util.h"
@@ -125,6 +126,45 @@ public:
         k3.column_name = "v2";
         k3.__set_is_key(false);
         k3.column_type.type = TPrimitiveType::INT;
+        request.tablet_schema.columns.push_back(k3);
+
+        TColumn k4;
+        k4.column_name = "v3";
+        k4.__set_is_key(false);
+        k4.column_type.type = TPrimitiveType::INT;
+        k4.__set_default_value("1");
+        request.tablet_schema.columns.push_back(k4);
+        auto st = StorageEngine::instance()->create_tablet(request);
+        CHECK(st.ok()) << st.to_string();
+        return StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, false);
+    }
+
+    TabletSharedPtr create_tablet_to_schema_change(int64_t tablet_id, int32_t schema_hash) {
+        TCreateTabletReq request;
+        request.tablet_id = tablet_id;
+        request.__set_version(1);
+        request.__set_version_hash(0);
+        request.tablet_schema.schema_hash = schema_hash;
+        request.tablet_schema.short_key_column_count = 6;
+        request.tablet_schema.keys_type = TKeysType::PRIMARY_KEYS;
+        request.tablet_schema.storage_type = TStorageType::COLUMN;
+
+        TColumn k1;
+        k1.column_name = "pk";
+        k1.__set_is_key(true);
+        k1.column_type.type = TPrimitiveType::INT;
+        request.tablet_schema.columns.push_back(k1);
+
+        TColumn k2;
+        k2.column_name = "v1";
+        k2.__set_is_key(false);
+        k2.column_type.type = TPrimitiveType::SMALLINT;
+        request.tablet_schema.columns.push_back(k2);
+
+        TColumn k3;
+        k3.column_name = "v2";
+        k3.__set_is_key(false);
+        k3.column_type.type = TPrimitiveType::VARCHAR;
         request.tablet_schema.columns.push_back(k3);
 
         TColumn k4;
@@ -317,6 +357,35 @@ static ssize_t read_and_compare(const vectorized::ChunkIteratorPtr& iter, const 
     return count;
 }
 
+static ssize_t read_and_compare_schema_changed(const vectorized::ChunkIteratorPtr& iter, const vector<int64_t>& keys) {
+    auto chunk = vectorized::ChunkHelper::new_chunk(iter->schema(), 100);
+    auto full_chunk = vectorized::ChunkHelper::new_chunk(iter->schema(), keys.size());
+    auto& cols = full_chunk->columns();
+    std::unique_ptr<MemPool> mem_pool(new MemPool());
+    for (size_t i = 0; i < keys.size(); i++) {
+        cols[0]->append_datum(vectorized::Datum((int32_t)keys[i]));
+        cols[1]->append_datum(vectorized::Datum((int16_t)(keys[i] % 100 + 1)));
+        cols[2]->append_datum(vectorized::Datum(Slice{std::to_string((int64_t)(keys[i] % 1000 + 2))}));
+        cols[3]->append_datum(vectorized::Datum(1));
+    }
+    size_t count = 0;
+    while (true) {
+        auto st = iter->get_next(chunk.get());
+        if (st.is_end_of_file()) {
+            break;
+        } else if (st.ok()) {
+            for (auto i = 0; i < chunk->num_rows(); i++) {
+                EXPECT_EQ(full_chunk->get(count + i).compare(iter->schema(), chunk->get(i)), 0);
+            }
+            count += chunk->num_rows();
+            chunk->reset();
+        } else {
+            return -1;
+        }
+    }
+    return count;
+}
+
 static ssize_t read_until_eof(const vectorized::ChunkIteratorPtr& iter) {
     auto chunk = vectorized::ChunkHelper::new_chunk(iter->schema(), 100);
     size_t count = 0;
@@ -349,6 +418,15 @@ static ssize_t read_tablet_and_compare(const TabletSharedPtr& tablet, int64_t ve
         return -1;
     }
     return read_and_compare(iter, keys);
+}
+
+static ssize_t read_tablet_and_compare_schema_changed(const TabletSharedPtr& tablet, int64_t version,
+                                                      const vector<int64_t>& keys) {
+    auto iter = create_tablet_iterator(tablet, version);
+    if (iter == nullptr) {
+        return -1;
+    }
+    return read_and_compare_schema_changed(iter, keys);
 }
 
 TEST_F(TabletUpdatesTest, writeread) {
@@ -756,6 +834,48 @@ TEST_F(TabletUpdatesTest, perform_linked_schema_change) {
     ASSERT_TRUE(_tablet2->updates()->perform_linked_schema_change(4, _tablet.get()).ok());
 
     ASSERT_EQ(N, read_tablet(_tablet2, 4));
+}
+
+TEST_F(TabletUpdatesTest, perform_directly_schema_change) {
+    srand(GetCurrentTimeMicros());
+    _tablet = create_tablet(rand(), rand());
+    const auto& tablet_to_schema_change = create_tablet_to_schema_change(rand(), rand());
+    std::vector<int64_t> keys;
+    int N = 100;
+    for (int i = 0; i < N; i++) {
+        keys.push_back(i);
+    }
+    ASSERT_TRUE(_tablet->rowset_commit(2, create_rowset(_tablet, keys)).ok());
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    ASSERT_TRUE(_tablet->rowset_commit(3, create_rowset(_tablet, keys)).ok());
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    ASSERT_TRUE(_tablet->rowset_commit(4, create_rowset(_tablet, keys)).ok());
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    tablet_to_schema_change->set_tablet_state(TABLET_NOTREADY);
+    auto chunk_changer = std::make_unique<vectorized::ChunkChanger>(tablet_to_schema_change->tablet_schema());
+    for (int i = 0; i < tablet_to_schema_change->tablet_schema().num_columns(); ++i) {
+        const auto& new_column = tablet_to_schema_change->tablet_schema().column(i);
+        int32_t column_index = _tablet->field_index(std::string{new_column.name()});
+        auto column_mapping = chunk_changer->get_mutable_column_mapping(i);
+        if (column_index >= 0) {
+            column_mapping->ref_column = column_index;
+        } else {
+            column_mapping->default_value = WrapperField::create(new_column);
+
+            ASSERT_FALSE(column_mapping->default_value == nullptr) << "init column mapping failed: malloc error";
+
+            if (new_column.is_nullable() && new_column.default_value().length() == 0) {
+                column_mapping->default_value->set_null();
+            } else {
+                column_mapping->default_value->from_string(new_column.default_value());
+            }
+        }
+    }
+    ASSERT_TRUE(
+            tablet_to_schema_change->updates()->perform_directly_schema_change(4, _tablet, chunk_changer.get()).ok());
+
+    ASSERT_EQ(N, read_tablet_and_compare_schema_changed(tablet_to_schema_change, 4, keys));
 }
 
 // NOLINTNEXTLINE

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -809,7 +809,7 @@ TEST_F(TabletUpdatesTest, compaction) {
     EXPECT_EQ(best_tablet->updates()->get_compaction_score(), -1);
 }
 
-TEST_F(TabletUpdatesTest, perform_linked_schema_change) {
+TEST_F(TabletUpdatesTest, schema_change_linked) {
     srand(GetCurrentTimeMicros());
     _tablet = create_tablet(rand(), rand());
     _tablet2 = create_tablet2(rand(), rand());
@@ -826,12 +826,12 @@ TEST_F(TabletUpdatesTest, perform_linked_schema_change) {
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
     _tablet2->set_tablet_state(TABLET_NOTREADY);
-    ASSERT_TRUE(_tablet2->updates()->perform_linked_schema_change(4, _tablet.get()).ok());
+    ASSERT_TRUE(_tablet2->updates()->schema_change_linked(4, _tablet.get()).ok());
 
     ASSERT_EQ(N, read_tablet(_tablet2, 4));
 }
 
-TEST_F(TabletUpdatesTest, perform_directly_schema_change) {
+TEST_F(TabletUpdatesTest, schema_change_directly) {
     srand(GetCurrentTimeMicros());
     _tablet = create_tablet(rand(), rand());
     const auto& tablet_to_schema_change = create_tablet_to_schema_change(rand(), rand());
@@ -864,8 +864,7 @@ TEST_F(TabletUpdatesTest, perform_directly_schema_change) {
             }
         }
     }
-    ASSERT_TRUE(
-            tablet_to_schema_change->updates()->perform_directly_schema_change(4, _tablet, chunk_changer.get()).ok());
+    ASSERT_TRUE(tablet_to_schema_change->updates()->schema_change_directly(4, _tablet, chunk_changer.get()).ok());
 
     ASSERT_EQ(N, read_tablet_and_compare_schema_changed(tablet_to_schema_change, 4, keys));
 }

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -736,7 +736,7 @@ TEST_F(TabletUpdatesTest, compaction) {
     EXPECT_EQ(best_tablet->updates()->get_compaction_score(), -1);
 }
 
-TEST_F(TabletUpdatesTest, load_from_base_tablet) {
+TEST_F(TabletUpdatesTest, perform_linked_schema_change) {
     srand(GetCurrentTimeMicros());
     _tablet = create_tablet(rand(), rand());
     _tablet2 = create_tablet2(rand(), rand());
@@ -753,7 +753,7 @@ TEST_F(TabletUpdatesTest, load_from_base_tablet) {
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
     _tablet2->set_tablet_state(TABLET_NOTREADY);
-    ASSERT_TRUE(_tablet2->updates()->load_from_base_tablet(4, _tablet.get()).ok());
+    ASSERT_TRUE(_tablet2->updates()->perform_linked_schema_change(4, _tablet.get()).ok());
 
     ASSERT_EQ(N, read_tablet(_tablet2, 4));
 }

--- a/be/test/storage/vectorized/schema_change_test.cpp
+++ b/be/test/storage/vectorized/schema_change_test.cpp
@@ -417,7 +417,7 @@ TEST_F(SchemaChangeTest, convert_int_to_count) {
     EXPECT_EQ(dst_datum.get_int64(), 1);
 }
 
-TEST_F(SchemaChangeTest, schema_change_directly) {
+TEST_F(SchemaChangeTest, convert_from) {
     CreateSrcTablet(1001);
     StorageEngine* engine = StorageEngine::instance();
     TCreateTabletReq create_tablet_req;

--- a/be/test/storage/vectorized/schema_change_test.cpp
+++ b/be/test/storage/vectorized/schema_change_test.cpp
@@ -436,8 +436,7 @@ TEST_F(SchemaChangeTest, schema_change_directly) {
         ColumnMapping* column_mapping = chunk_changer.get_mutable_column_mapping(i);
         column_mapping->ref_column = i;
     }
-
-    _sc_procedure = new (std::nothrow) SchemaChangeDirectly(chunk_changer);
+    _sc_procedure = new (std::nothrow) SchemaChangeDirectly(&chunk_changer);
     Version version(3, 3);
     RowsetSharedPtr rowset = base_tablet->get_rowset_by_version(version);
     ASSERT_TRUE(rowset != nullptr);
@@ -497,7 +496,7 @@ TEST_F(SchemaChangeTest, schema_change_with_sorting) {
     column_mapping->ref_column = 3;
 
     _sc_procedure = new (std::nothrow) SchemaChangeWithSorting(
-            chunk_changer, config::memory_limitation_per_thread_for_schema_change * 1024 * 1024 * 1024);
+            &chunk_changer, config::memory_limitation_per_thread_for_schema_change * 1024 * 1024 * 1024);
     Version version(3, 3);
     RowsetSharedPtr rowset = base_tablet->get_rowset_by_version(version);
     ASSERT_TRUE(rowset != nullptr);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -1518,9 +1518,6 @@ public class SchemaChangeHandler extends AlterHandler {
                 processDropColumn((DropColumnClause) alterClause, olapTable, indexSchemaMap, newIndexes);
             } else if (alterClause instanceof ModifyColumnClause) {
                 // modify column
-                if (olapTable.getKeysType() == KeysType.PRIMARY_KEYS) {
-                    throw new DdlException("Primary key table do not support modify column");
-                }
                 processModifyColumn((ModifyColumnClause) alterClause, olapTable, indexSchemaMap);
             } else if (alterClause instanceof ReorderColumnsClause) {
                 // reorder column
@@ -1534,9 +1531,6 @@ public class SchemaChangeHandler extends AlterHandler {
             } else if (alterClause instanceof CreateIndexClause) {
                 processAddIndex((CreateIndexClause) alterClause, olapTable, newIndexes);
             } else if (alterClause instanceof DropIndexClause) {
-                if (olapTable.getKeysType() == KeysType.PRIMARY_KEYS) {
-                    throw new DdlException("Primary key table do not support drop index");
-                }
                 processDropIndex((DropIndexClause) alterClause, olapTable, newIndexes);
             } else {
                 Preconditions.checkState(false);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -1532,9 +1532,6 @@ public class SchemaChangeHandler extends AlterHandler {
                 // modify table properties
                 // do nothing, properties are already in propertyMap
             } else if (alterClause instanceof CreateIndexClause) {
-                if (olapTable.getKeysType() == KeysType.PRIMARY_KEYS) {
-                    throw new DdlException("Primary key table do not support create index");
-                }
                 processAddIndex((CreateIndexClause) alterClause, olapTable, newIndexes);
             } else if (alterClause instanceof DropIndexClause) {
                 if (olapTable.getKeysType() == KeysType.PRIMARY_KEYS) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -1518,6 +1518,9 @@ public class SchemaChangeHandler extends AlterHandler {
                 processDropColumn((DropColumnClause) alterClause, olapTable, indexSchemaMap, newIndexes);
             } else if (alterClause instanceof ModifyColumnClause) {
                 // modify column
+                if (olapTable.getKeysType() == KeysType.PRIMARY_KEYS) {
+                    throw new DdlException("Primary key table do not support modify column");
+                }
                 processModifyColumn((ModifyColumnClause) alterClause, olapTable, indexSchemaMap);
             } else if (alterClause instanceof ReorderColumnsClause) {
                 // reorder column

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -407,8 +407,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                     for (Tablet shadowTablet : shadowIdx.getTablets()) {
                         long shadowTabletId = shadowTablet.getId();
                         long originTabletId = partitionIndexTabletMap.get(partitionId, shadowIdxId).get(shadowTabletId);
-                        List<Replica> shadowReplicas = shadowTablet.getReplicas();
-                        for (Replica shadowReplica : shadowReplicas) {
+                        for (Replica shadowReplica : shadowTablet.getReplicas()) {
                             AlterReplicaTask rollupTask = new AlterReplicaTask(
                                     shadowReplica.getBackendId(), dbId, tableId, partitionId,
                                     shadowIdxId, originIdxId,
@@ -553,7 +552,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                 }
                 Preconditions.checkNotNull(droppedIdx, originIdxId + " vs. " + shadowIdxId);
 
-                // set replica state
+                // set the replica state from ReplicaState.ALTER to ReplicaState.NORMAL since the schema change is done.
                 for (Tablet tablet : shadowIdx.getTablets()) {
                     for (Replica replica : tablet.getReplicas()) {
                         replica.setState(ReplicaState.NORMAL);
@@ -562,7 +561,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
 
                 partition.visualiseShadowIndex(shadowIdxId, originIdxId == partition.getBaseIndex().getId());
 
-                // delete origin replicas
+                // the origin tablet created by old schema can be deleted from FE meta data
                 for (Tablet originTablet : droppedIdx.getTablets()) {
                     Catalog.getCurrentInvertedIndex().deleteTablet(originTablet.getId());
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/AggregateInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/AggregateInfo.java
@@ -82,8 +82,6 @@ public final class AggregateInfo extends AggregateInfoBase {
         }
     }
 
-    ;
-
     // created by createMergeAggInfo()
     private AggregateInfo mergeAggInfo_;
 

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/Analyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/Analyzer.java
@@ -315,7 +315,6 @@ public class Analyzer {
         }
     }
 
-    ;
     private final GlobalState globalState;
 
     // An analyzer stores analysis state for a single select block. A select block can be

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/StmtRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/StmtRewriter.java
@@ -335,7 +335,6 @@ public class StmtRewriter {
         if (!(expr instanceof CompoundPredicate)) {
             return false;
         }
-        ;
         if (Expr.IS_OR_PREDICATE.apply(expr)) {
             return expr.contains(Subquery.class);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HashDistributionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HashDistributionInfo.java
@@ -142,7 +142,6 @@ public class HashDistributionInfo extends DistributionInfo {
         builder.append("]; ");
 
         builder.append("bucket num: ").append(bucketNum).append("; ");
-        ;
 
         return builder.toString();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionInfo.java
@@ -200,7 +200,6 @@ public class PartitionInfo implements Writable {
 
         for (Map.Entry<Long, DataProperty> entry : idToDataProperty.entrySet()) {
             buff.append(entry.getKey()).append("is HDD: ");
-            ;
             if (entry.getValue().equals(new DataProperty(TStorageMedium.HDD))) {
                 buff.append(true);
             } else {

--- a/fe/fe-core/src/main/java/com/starrocks/metric/Metric.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/Metric.java
@@ -47,8 +47,6 @@ public abstract class Metric<T> {
         NOUNIT
     }
 
-    ;
-
     protected String name;
     protected MetricType type;
     protected MetricUnit unit;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryDetail.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryDetail.java
@@ -31,8 +31,6 @@ public class QueryDetail implements Serializable {
         CANCELLED
     }
 
-    ;
-
     // When query received, FE will construct a QueryDetail
     // object. This object will set queryId, startTime, sql
     // fields. As well state is be set as RUNNING. 

--- a/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/dpp/SparkDpp.java
+++ b/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/dpp/SparkDpp.java
@@ -483,7 +483,6 @@ public final class SparkDpp implements java.io.Serializable {
                                 abnormalRowAcc.add(1);
                                 return result.iterator();
                             }
-                            ;
                             keyColumns.add(columnObject);
                         }
 
@@ -495,7 +494,6 @@ public final class SparkDpp implements java.io.Serializable {
                                 abnormalRowAcc.add(1);
                                 return result.iterator();
                             }
-                            ;
                             valueColumns.add(columnObject);
                             loadEstimateSizeAcc.add(SizeEstimator.estimate(columnObject));
                         }

--- a/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/dpp/SparkRDDAggregator.java
+++ b/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/dpp/SparkRDDAggregator.java
@@ -53,8 +53,6 @@ public abstract class SparkRDDAggregator<T> implements Serializable {
         return value;
     }
 
-    ;
-
     public static SparkRDDAggregator buildAggregator(EtlJobConfig.EtlColumn column) throws SparkDppException {
         String aggType = StringUtils.lowerCase(column.aggregationType);
         String columnType = StringUtils.lowerCase(column.columnType);


### PR DESCRIPTION
Table with primary key only support add/delete column when doing schema change.
The pull request is to support more schema change including modify column type/add bloom filter/add bitmap index/drop bitmap index.
I make a performance test on SSB 100G using Query 1.4. Add a bloomfilter index on `s_address` which the cardinality is 20000. After the bloomfilter, the data expansion ratio is 0.408%. And the latency like the following.
```
without bloomfilter:  14.63 sec(the first time),  0.19 sec(the second time).
with bloomfilter:      3.10 sec(the first time),  0.03 sec(the second time).
Data is read from disk upon first time, read from OS page cache upon second time.
```