### PR TITLE
Restore the "desc all" grammar that was deleted by mistake which was introduced in #1121

### DIFF
--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -2680,6 +2680,10 @@ describe_stmt ::=
     {:
         RESULT = new DescribeStmt(table, false);
     :}
+    | describe_command table_name:table KW_ALL
+    {:
+        RESULT = new DescribeStmt(table, true);
+    :}
     | describe_command opt_explain_level:explain_level query_stmt:query
      {:
          query.setIsExplain(true, explain_level);


### PR DESCRIPTION
#1121