### PR TITLE
Optimize: delete meta instantly when dropping a tablet

### DIFF
--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -914,7 +914,7 @@ Status TabletManager::start_trash_sweep() {
             LOG(INFO) << ((info.flag == kMoveFilesToTrash) ? "Moved " : " Removed ") << tablet->tablet_id_path();
         } else {
             remove_meta = false;
-            LOG(WARNING) << "Fail to move " << tablet->tablet_id_path() << " to trash:" << st;
+            LOG(WARNING) << "Fail to remove or move " << tablet->tablet_id_path() << " :" << st;
         }
 
         if (remove_meta) {

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -86,7 +86,7 @@ Status TabletManager::_add_tablet_unlocked(const TabletSharedPtr& new_tablet, bo
     if (old_tablet == nullptr) {
         RETURN_IF_ERROR(_update_tablet_map_and_partition_info(new_tablet));
     } else if (force) {
-        RETURN_IF_ERROR(_drop_tablet_unlocked(old_tablet->tablet_id(), true));
+        RETURN_IF_ERROR(_drop_tablet_unlocked(old_tablet->tablet_id(), kKeepMetaAndFiles));
         RETURN_IF_ERROR(_update_tablet_map_and_partition_info(new_tablet));
     } else {
         if (old_tablet->schema_hash_path() == new_tablet->schema_hash_path()) {
@@ -108,7 +108,7 @@ Status TabletManager::_add_tablet_unlocked(const TabletSharedPtr& new_tablet, bo
         old_tablet->release_header_lock();
         bool replace_old = (new_version > old_version) || (new_version == old_version && new_time > old_time);
         if (replace_old) {
-            RETURN_IF_ERROR(_drop_tablet_unlocked(old_tablet->tablet_id(), false));
+            RETURN_IF_ERROR(_drop_tablet_unlocked(old_tablet->tablet_id(), kMoveFilesToTrash));
             RETURN_IF_ERROR(_update_tablet_map_and_partition_info(new_tablet));
             LOG(INFO) << "Added duplicated tablet. tablet_id=" << new_tablet->tablet_id()
                       << " old_tablet_path=" << old_tablet->schema_hash_path()
@@ -284,7 +284,7 @@ TabletSharedPtr TabletManager::_internal_create_tablet_unlocked(AlterTabletType 
     }
     // something is wrong, we need clear environment
     if (is_tablet_added) {
-        status = _drop_tablet_unlocked(tablet->tablet_id(), false);
+        status = _drop_tablet_unlocked(tablet->tablet_id(), kMoveFilesToTrash);
         LOG_IF(WARNING, !status.ok()) << "Fail to drop tablet when create tablet failed: " << status.to_string();
     } else {
         tablet->delete_all_files();
@@ -329,9 +329,9 @@ TabletSharedPtr TabletManager::_create_tablet_meta_and_dir_unlocked(const TCreat
     return nullptr;
 }
 
-Status TabletManager::drop_tablet(TTabletId tablet_id, bool keep_state) {
+Status TabletManager::drop_tablet(TTabletId tablet_id, TabletDropFlag flag) {
     std::unique_lock wlock(_get_tablets_shard_lock(tablet_id));
-    return _drop_tablet_unlocked(tablet_id, keep_state);
+    return _drop_tablet_unlocked(tablet_id, flag);
 }
 
 // Drop specified tablet, the main logical is as follows:
@@ -342,7 +342,7 @@ Status TabletManager::drop_tablet(TTabletId tablet_id, bool keep_state) {
 //          base-tablet cannot be dropped;
 //      b. other cases:
 //          drop specified tablet directly and clear schema change info.
-Status TabletManager::_drop_tablet_unlocked(TTabletId tablet_id, bool keep_state) {
+Status TabletManager::_drop_tablet_unlocked(TTabletId tablet_id, TabletDropFlag flag) {
     StarRocksMetrics::instance()->drop_tablet_requests_total.increment(1);
 
     // Fetch tablet which need to be dropped
@@ -357,7 +357,7 @@ Status TabletManager::_drop_tablet_unlocked(TTabletId tablet_id, bool keep_state
     // in schema-change state.
     AlterTabletTaskSharedPtr alter_task = tablet_to_drop->alter_task();
     if (alter_task == nullptr) {
-        return _drop_tablet_directly_unlocked(tablet_id, keep_state);
+        return _drop_tablet_directly_unlocked(tablet_id, flag);
     }
 
     AlterTabletState alter_state = alter_task->alter_state();
@@ -368,7 +368,7 @@ Status TabletManager::_drop_tablet_unlocked(TTabletId tablet_id, bool keep_state
         // TODO(lingbin): in what case, can this happen?
         LOG(WARNING) << "Dropping tablet directly when related tablet not found. "
                      << " tablet_id=" << related_tablet_id;
-        return _drop_tablet_directly_unlocked(tablet_id, keep_state);
+        return _drop_tablet_directly_unlocked(tablet_id, flag);
     }
 
     // Check whether the tablet we want to delete is in schema-change state
@@ -408,12 +408,11 @@ Status TabletManager::_drop_tablet_unlocked(TTabletId tablet_id, bool keep_state
         related_tablet->save_meta();
     }
     related_tablet->release_header_lock();
-    Status res = _drop_tablet_directly_unlocked(tablet_id, keep_state);
+    auto res = _drop_tablet_directly_unlocked(tablet_id, flag);
     if (!res.ok()) {
         LOG(WARNING) << "Fail to drop tablet which in schema change. tablet=" << tablet_to_drop->full_name();
         return res;
     }
-
     LOG(INFO) << "Dropped tablet " << tablet_id;
     return res;
 }
@@ -454,7 +453,7 @@ TabletSharedPtr TabletManager::_get_tablet_unlocked(TTabletId tablet_id, bool in
     if (tablet == nullptr && include_deleted) {
         std::shared_lock rlock(_shutdown_tablets_lock);
         if (auto it = _shutdown_tablets.find(tablet_id); it != _shutdown_tablets.end()) {
-            tablet = it->second;
+            tablet = it->second.tablet;
         }
     }
 
@@ -730,7 +729,8 @@ Status TabletManager::load_tablet_from_meta(DataDir* data_dir, TTabletId tablet_
     if (tablet->tablet_state() == TABLET_SHUTDOWN) {
         LOG(INFO) << "Loaded shutdown tablet " << tablet_id;
         std::unique_lock shutdown_tablets_wlock(_shutdown_tablets_lock);
-        _shutdown_tablets.emplace(tablet->tablet_id(), std::move(tablet));
+        DroppedTabletInfo info{.tablet = std::move(tablet), .flag = kMoveFilesToTrash};
+        _shutdown_tablets.emplace(tablet->tablet_id(), std::move(info));
         return Status::NotFound("tablet state is shutdown");
     }
     // NOTE: We do not check tablet's initial version here, because if BE restarts when
@@ -856,19 +856,20 @@ Status TabletManager::start_trash_sweep() {
         }
     }
 
-    std::vector<TabletSharedPtr> tablets_to_check;
+    std::vector<DroppedTabletInfo> tablets_to_check;
     {
         std::shared_lock l(_shutdown_tablets_lock);
         tablets_to_check.reserve(_shutdown_tablets.size());
-        for (auto& [tablet_id, tablet_ptr] : _shutdown_tablets) {
-            tablets_to_check.emplace_back(tablet_ptr);
+        for (auto& [tablet_id, info] : _shutdown_tablets) {
+            tablets_to_check.emplace_back(info);
         }
     }
 
     std::vector<TTabletId> finished_tablets;
     finished_tablets.reserve(tablets_to_check.size());
 
-    for (const auto& tablet : tablets_to_check) {
+    for (const auto& info : tablets_to_check) {
+        auto& tablet = info.tablet;
         // The current thread has two references: _shutdown_tablets[i] and tablets_to_checks[i], check
         // if there is another thread has reference to the tablet, and if so, does not remove the tablet for now.
         if (tablet.use_count() > 2) {
@@ -878,6 +879,11 @@ Status TabletManager::start_trash_sweep() {
         TabletMeta tablet_meta;
         Status st = TabletMetaManager::get_tablet_meta(tablet->data_dir(), tablet->tablet_id(), tablet->schema_hash(),
                                                        &tablet_meta);
+        if (!st.ok() && !st.is_not_found()) {
+            LOG(WARNING) << "Fail to get tablet meta: " << st;
+            break;
+        }
+
         if (st.ok()) {
             if (tablet_meta.tablet_uid() != tablet->tablet_uid()) {
                 finished_tablets.push_back(tablet->tablet_id());
@@ -890,55 +896,31 @@ Status TabletManager::start_trash_sweep() {
                            << ". tablet_uid=" << tablet->tablet_uid();
                 continue;
             }
-            // move data to trash
-            auto tablet_id_path = tablet->tablet_id_path();
-            st = Env::Default()->path_exists(tablet_id_path);
-            if (st.ok() && config::trash_file_expire_time_sec > 0) {
-                // take snapshot of tablet meta for recovery
-                if (tablet->keys_type() == KeysType::PRIMARY_KEYS) {
-                    if (st = SnapshotManager::instance()->make_snapshot_on_tablet_meta(tablet); !st.ok()) {
-                        LOG(WARNING) << "Fail to make_snapshot_on_tablet_meta, tablet_id=" << tablet->tablet_id()
-                                     << " schema_hash=" << tablet->schema_hash() << ", status=" << st.to_string();
-                        continue;
-                    }
-                } else {
-                    auto meta_file_path = fmt::format("{}/{}.hdr", tablet->schema_hash_path(), tablet->tablet_id());
-                    tablet->tablet_meta()->save(meta_file_path);
-                }
-                if (st = move_to_trash(tablet_id_path); st.ok()) {
-                    LOG(INFO) << "Moved " << tablet_id_path << " to trash";
-                } else {
-                    LOG(WARNING) << "Fail to move " << tablet_id_path << " to trash";
-                    continue;
-                }
-            } else if (st.ok()) {
-                // Ignore the result.
-                (void)FileUtils::remove_all(tablet_id_path);
-            } else if (st.is_not_found()) {
-                st = Status::OK();
-            } else {
-                LOG(WARNING) << "Fail to check " << tablet_id_path << ": " << st;
+            // remove tablet meta
+            if (st = _remove_tablet_meta(tablet); !st.ok()) {
+                LOG(WARNING) << "Fail to remove tablet meta of tablet " << tablet->tablet_id() << ": " << st;
                 continue;
             }
-            DCHECK(st.ok()) << st;
-            if (tablet->keys_type() == KeysType::PRIMARY_KEYS) {
-                st = tablet->updates()->clear_meta();
-            } else {
-                st = TabletMetaManager::remove(tablet->data_dir(), tablet->tablet_id(), tablet->schema_hash());
-            }
-
-            if (st.ok()) {
-                finished_tablets.push_back(tablet->tablet_id());
-            } else {
-                LOG(WARNING) << "Fail to clear tablet meta: " << st;
-            }
-        } else if (st.is_not_found()) {
-            finished_tablets.push_back(tablet->tablet_id());
-        } else {
-            LOG(WARNING) << "Fail to get tablet meta: " << st;
-            break;
         }
-    } // for loop tablets_to_check
+
+        if (info.flag == kMoveFilesToTrash) {
+            st = _move_tablet_directories_to_trash(tablet);
+            if (st.ok() || st.is_not_found()) {
+                finished_tablets.push_back(tablet->tablet_id());
+                LOG(INFO) << "Moved " << tablet->tablet_id_path() << " to trash";
+            } else {
+                LOG(WARNING) << "Fail to move " << tablet->tablet_id_path() << " to trash:" << st;
+            }
+        } else {
+            st = _remove_tablet_directories(tablet);
+            if (st.ok() || st.is_not_found()) {
+                finished_tablets.push_back(tablet->tablet_id());
+                LOG(INFO) << "Removed " << tablet->tablet_id_path();
+            } else {
+                LOG(WARNING) << "Fail to remove " << tablet->tablet_id_path() << ":" << st;
+            }
+        }
+    }
 
     if (!finished_tablets.empty()) {
         std::unique_lock l(_shutdown_tablets_lock);
@@ -1172,7 +1154,7 @@ Status TabletManager::_create_tablet_meta_unlocked(const TCreateTabletReq& reque
                               col_idx_to_unique_id, RowsetTypePB::BETA_ROWSET, tablet_meta);
 }
 
-Status TabletManager::_drop_tablet_directly_unlocked(TTabletId tablet_id, bool keep_state) {
+Status TabletManager::_drop_tablet_directly_unlocked(TTabletId tablet_id, TabletDropFlag flag) {
     TabletMap& tablet_map = _get_tablet_map(tablet_id);
     auto it = tablet_map.find(tablet_id);
     if (it == tablet_map.end()) {
@@ -1182,21 +1164,54 @@ Status TabletManager::_drop_tablet_directly_unlocked(TTabletId tablet_id, bool k
     TabletSharedPtr dropped_tablet = it->second;
     tablet_map.erase(it);
     _remove_tablet_from_partition(*dropped_tablet);
-    if (!keep_state) {
-        LOG(INFO) << "Shutting down tablet " << tablet_id;
-        // drop tablet will update tablet meta, should lock
-        std::unique_lock wrlock(dropped_tablet->get_header_lock());
-        // NOTE: has to update tablet here, but must not update tablet meta directly.
-        // because other thread may hold the tablet object, they may save meta too.
-        // If update meta directly here, other thread may override the meta
-        // and the tablet will be loaded at restart time.
-        // To avoid this exception, we first set the state of the tablet to `SHUTDOWN`.
-        dropped_tablet->set_tablet_state(TABLET_SHUTDOWN);
-        dropped_tablet->save_meta();
+
+    DroppedTabletInfo drop_info{.tablet = dropped_tablet, .flag = flag};
+
+    if (flag == kDeleteFiles) {
         {
-            std::unique_lock wlock(_shutdown_tablets_lock);
-            _shutdown_tablets.emplace(dropped_tablet->tablet_id(), dropped_tablet);
+            // NOTE: Other threads may save the tablet meta back to storage again after we
+            // have deleted it here, and the tablet will reappear after restarted.
+            // To prevent this, set the tablet state to `SHUTDOWN` first before removing tablet
+            // meta from storage, and assuming that no thread will change the tablet state back
+            // to 'RUNNING' from 'SHUTDOWN'.
+            std::unique_lock l(dropped_tablet->get_header_lock());
+            dropped_tablet->set_tablet_state(TABLET_SHUTDOWN);
         }
+
+        // Remove tablet meta from storage, crash the program if failed.
+        if (auto st = _remove_tablet_meta(dropped_tablet); !st.ok()) {
+            LOG(FATAL) << "Fail to remove tablet meta: " << st;
+        }
+        LOG(INFO) << "Removed tablet " << tablet_id;
+
+        // Remove the tablet directory in background to avoid holding the lock of tablet map shard for long.
+        std::unique_lock l(_shutdown_tablets_lock);
+        _shutdown_tablets.emplace(dropped_tablet->tablet_id(), std::move(drop_info));
+    } else if (flag == kMoveFilesToTrash) {
+        // See comments above
+        {
+            std::unique_lock l(dropped_tablet->get_header_lock());
+            dropped_tablet->set_tablet_state(TABLET_SHUTDOWN);
+        }
+
+        // If we call `_remove_tablet_meta` on primary key tablet, all its in-memory meta information
+        // will lose, which will make the background snapshot creation failed.
+        if (dropped_tablet->keys_type() == PRIMARY_KEYS) {
+            dropped_tablet->save_meta();
+            LOG(INFO) << "Shutdown primary key tablet " << tablet_id;
+        } else {
+            auto st = _remove_tablet_meta(dropped_tablet);
+            LOG_IF(FATAL, !st.ok()) << "Fail to remove tablet meta: " << st;
+            LOG(INFO) << "Removed tablet " << tablet_id;
+        }
+
+        // MOVE the tablet segment files to trash in background to avoid holding the lock of tablet map shard for long.
+        std::unique_lock l(_shutdown_tablets_lock);
+        _shutdown_tablets.emplace(dropped_tablet->tablet_id(), std::move(drop_info));
+    } else if (flag == kKeepMetaAndFiles) {
+        // nothing to do
+    } else {
+        return Status::InternalError(fmt::format("unknown TabletDropFlag {}", (int)flag));
     }
     dropped_tablet->deregister_tablet_from_dir();
     return Status::OK();
@@ -1335,6 +1350,33 @@ Status TabletManager::create_tablet_from_meta_snapshot(DataDir* store, TTabletId
     auto st = _add_tablet_unlocked(tablet, true, false);
     LOG_IF(WARNING, !st.ok()) << "Fail to add cloned tablet " << tablet_id << ": " << st;
     return st;
+}
+
+Status TabletManager::_remove_tablet_meta(const TabletSharedPtr& tablet) {
+    if (tablet->keys_type() == KeysType::PRIMARY_KEYS) {
+        return tablet->updates()->clear_meta();
+    } else {
+        return TabletMetaManager::remove(tablet->data_dir(), tablet->tablet_id(), tablet->schema_hash());
+    }
+}
+
+Status TabletManager::_remove_tablet_directories(const TabletSharedPtr& tablet) {
+    return FileUtils::remove_all(tablet->tablet_id_path());
+}
+
+Status TabletManager::_move_tablet_directories_to_trash(const TabletSharedPtr& tablet) {
+    if (config::trash_file_expire_time_sec == 0) {
+        return _remove_tablet_directories(tablet);
+    }
+    // take snapshot of tablet meta for recovery
+    if (tablet->keys_type() == KeysType::PRIMARY_KEYS) {
+        RETURN_IF_ERROR(SnapshotManager::instance()->make_snapshot_on_tablet_meta(tablet));
+    } else {
+        auto meta_file_path = fmt::format("{}/{}.hdr", tablet->schema_hash_path(), tablet->tablet_id());
+        tablet->tablet_meta()->save(meta_file_path);
+    }
+    // move tablet directories to ${storage_root_path}/trash
+    return move_to_trash(tablet->tablet_id_path());
 }
 
 } // end namespace starrocks

--- a/be/src/storage/tablet_manager.h
+++ b/be/src/storage/tablet_manager.h
@@ -37,6 +37,7 @@
 #include "gen_cpp/BackendService_types.h"
 #include "gen_cpp/MasterService_types.h"
 #include "storage/kv_store.h"
+#include "storage/olap_common.h"
 #include "storage/olap_define.h"
 #include "storage/options.h"
 #include "storage/tablet.h"
@@ -46,6 +47,12 @@ namespace starrocks {
 
 class Tablet;
 class DataDir;
+
+enum TabletDropFlag {
+    kMoveFilesToTrash = 0,
+    kDeleteFiles = 1,
+    kKeepMetaAndFiles = 2,
+};
 
 // TabletManager provides get, add, delete tablet method for storage engine
 // NOTE: If you want to add a method that needs to hold meta-lock before you can call it,
@@ -64,7 +71,7 @@ public:
     // task to be fail, even if there is enough space on other disks
     Status create_tablet(const TCreateTabletReq& request, std::vector<DataDir*> stores);
 
-    Status drop_tablet(TTabletId tablet_id, bool keep_state = false);
+    Status drop_tablet(TTabletId tablet_id, TabletDropFlag flag = kMoveFilesToTrash);
 
     Status drop_tablets_on_error_root_path(const std::vector<TabletInfo>& tablet_info_vec);
 
@@ -149,6 +156,11 @@ private:
         TabletSet tablets_under_clone;
     };
 
+    struct DroppedTabletInfo {
+        TabletSharedPtr tablet;
+        TabletDropFlag flag;
+    };
+
     class LockTable {
     public:
         bool is_locked(int64_t tablet_id);
@@ -175,9 +187,9 @@ private:
 
     Status _create_inital_rowset_unlocked(const TCreateTabletReq& request, Tablet* tablet);
 
-    Status _drop_tablet_directly_unlocked(TTabletId tablet_id, bool keep_state = false);
+    Status _drop_tablet_directly_unlocked(TTabletId tablet_id, TabletDropFlag flag);
 
-    Status _drop_tablet_unlocked(TTabletId tablet_id, bool keep_state);
+    Status _drop_tablet_unlocked(TTabletId tablet_id, TabletDropFlag flag);
 
     TabletSharedPtr _get_tablet_unlocked(TTabletId tablet_id);
     TabletSharedPtr _get_tablet_unlocked(TTabletId tablet_id, bool include_deleted, std::string* err);
@@ -203,6 +215,10 @@ private:
 
     TabletsShard& _get_tablets_shard(TTabletId tabletId);
 
+    Status _remove_tablet_meta(const TabletSharedPtr& tablet);
+    Status _remove_tablet_directories(const TabletSharedPtr& tablet);
+    Status _move_tablet_directories_to_trash(const TabletSharedPtr& tablet);
+
     MemTracker* _mem_tracker = nullptr;
 
     std::vector<TabletsShard> _tablets_shards;
@@ -215,7 +231,7 @@ private:
     mutable std::shared_mutex _shutdown_tablets_lock;
     // partition_id => tablet_info
     std::map<int64_t, std::set<TabletInfo>> _partition_tablet_map;
-    std::map<int64_t, TabletSharedPtr> _shutdown_tablets;
+    std::map<int64_t, DroppedTabletInfo> _shutdown_tablets;
 
     std::mutex _tablet_stat_mutex;
     // cache to save tablets' statistics, such as data-size and row-count

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -186,11 +186,11 @@ public:
 
     void TearDown() override {
         if (_tablet2) {
-            StorageEngine::instance()->tablet_manager()->drop_tablet(_tablet2->tablet_id(), false);
+            StorageEngine::instance()->tablet_manager()->drop_tablet(_tablet2->tablet_id());
             _tablet2.reset();
         }
         if (_tablet) {
-            StorageEngine::instance()->tablet_manager()->drop_tablet(_tablet->tablet_id(), false);
+            StorageEngine::instance()->tablet_manager()->drop_tablet(_tablet->tablet_id());
             _tablet.reset();
         }
     }
@@ -946,8 +946,8 @@ TEST_F(TabletUpdatesTest, load_snapshot_incremental_ignore_already_committed_ver
 
     DeferOp defer([&]() {
         auto tablet_mgr = StorageEngine::instance()->tablet_manager();
-        (void)tablet_mgr->drop_tablet(tablet0->tablet_id(), tablet0->schema_hash());
-        (void)tablet_mgr->drop_tablet(tablet1->tablet_id(), tablet1->schema_hash());
+        (void)tablet_mgr->drop_tablet(tablet0->tablet_id());
+        (void)tablet_mgr->drop_tablet(tablet1->tablet_id());
         (void)FileUtils::remove_all(tablet0->schema_hash_path());
         (void)FileUtils::remove_all(tablet1->schema_hash_path());
     });
@@ -1010,8 +1010,8 @@ TEST_F(TabletUpdatesTest, load_snapshot_incremental_mismatched_tablet_id) {
 
     DeferOp defer([&]() {
         auto tablet_mgr = StorageEngine::instance()->tablet_manager();
-        (void)tablet_mgr->drop_tablet(tablet0->tablet_id(), tablet0->schema_hash());
-        (void)tablet_mgr->drop_tablet(tablet1->tablet_id(), tablet1->schema_hash());
+        (void)tablet_mgr->drop_tablet(tablet0->tablet_id());
+        (void)tablet_mgr->drop_tablet(tablet1->tablet_id());
         (void)FileUtils::remove_all(tablet0->schema_hash_path());
         (void)FileUtils::remove_all(tablet1->schema_hash_path());
     });
@@ -1061,8 +1061,8 @@ TEST_F(TabletUpdatesTest, load_snapshot_incremental_data_file_not_exist) {
 
     DeferOp defer([&]() {
         auto tablet_mgr = StorageEngine::instance()->tablet_manager();
-        (void)tablet_mgr->drop_tablet(tablet0->tablet_id(), tablet0->schema_hash());
-        (void)tablet_mgr->drop_tablet(tablet1->tablet_id(), tablet1->schema_hash());
+        (void)tablet_mgr->drop_tablet(tablet0->tablet_id());
+        (void)tablet_mgr->drop_tablet(tablet1->tablet_id());
         (void)FileUtils::remove_all(tablet0->schema_hash_path());
         (void)FileUtils::remove_all(tablet1->schema_hash_path());
     });
@@ -1114,8 +1114,8 @@ TEST_F(TabletUpdatesTest, load_snapshot_incremental_incorrect_version) {
 
     DeferOp defer([&]() {
         auto tablet_mgr = StorageEngine::instance()->tablet_manager();
-        (void)tablet_mgr->drop_tablet(tablet0->tablet_id(), tablet0->schema_hash());
-        (void)tablet_mgr->drop_tablet(tablet1->tablet_id(), tablet1->schema_hash());
+        (void)tablet_mgr->drop_tablet(tablet0->tablet_id());
+        (void)tablet_mgr->drop_tablet(tablet1->tablet_id());
         (void)FileUtils::remove_all(tablet0->schema_hash_path());
         (void)FileUtils::remove_all(tablet1->schema_hash_path());
     });
@@ -1170,8 +1170,8 @@ TEST_F(TabletUpdatesTest, load_snapshot_full) {
 
     DeferOp defer([&]() {
         auto tablet_mgr = StorageEngine::instance()->tablet_manager();
-        (void)tablet_mgr->drop_tablet(tablet0->tablet_id(), tablet0->schema_hash());
-        (void)tablet_mgr->drop_tablet(tablet1->tablet_id(), tablet1->schema_hash());
+        (void)tablet_mgr->drop_tablet(tablet0->tablet_id());
+        (void)tablet_mgr->drop_tablet(tablet1->tablet_id());
         (void)FileUtils::remove_all(tablet0->schema_hash_path());
         (void)FileUtils::remove_all(tablet1->schema_hash_path());
     });
@@ -1207,8 +1207,8 @@ TEST_F(TabletUpdatesTest, load_snapshot_full_file_not_exist) {
 
     DeferOp defer([&]() {
         auto tablet_mgr = StorageEngine::instance()->tablet_manager();
-        (void)tablet_mgr->drop_tablet(tablet0->tablet_id(), tablet0->schema_hash());
-        (void)tablet_mgr->drop_tablet(tablet1->tablet_id(), tablet1->schema_hash());
+        (void)tablet_mgr->drop_tablet(tablet0->tablet_id());
+        (void)tablet_mgr->drop_tablet(tablet1->tablet_id());
         (void)FileUtils::remove_all(tablet0->schema_hash_path());
         (void)FileUtils::remove_all(tablet1->schema_hash_path());
     });
@@ -1267,8 +1267,8 @@ TEST_F(TabletUpdatesTest, load_snapshot_full_mismatched_tablet_id) {
 
     DeferOp defer([&]() {
         auto tablet_mgr = StorageEngine::instance()->tablet_manager();
-        (void)tablet_mgr->drop_tablet(tablet0->tablet_id(), tablet0->schema_hash());
-        (void)tablet_mgr->drop_tablet(tablet1->tablet_id(), tablet1->schema_hash());
+        (void)tablet_mgr->drop_tablet(tablet0->tablet_id());
+        (void)tablet_mgr->drop_tablet(tablet1->tablet_id());
         (void)FileUtils::remove_all(tablet0->schema_hash_path());
         (void)FileUtils::remove_all(tablet1->schema_hash_path());
     });
@@ -1319,8 +1319,8 @@ TEST_F(TabletUpdatesTest, test_issue_4193) {
 
     DeferOp defer([&]() {
         auto tablet_mgr = StorageEngine::instance()->tablet_manager();
-        (void)tablet_mgr->drop_tablet(tablet0->tablet_id(), tablet0->schema_hash());
-        (void)tablet_mgr->drop_tablet(tablet1->tablet_id(), tablet1->schema_hash());
+        (void)tablet_mgr->drop_tablet(tablet0->tablet_id());
+        (void)tablet_mgr->drop_tablet(tablet1->tablet_id());
         (void)FileUtils::remove_all(tablet0->schema_hash_path());
         (void)FileUtils::remove_all(tablet1->schema_hash_path());
     });
@@ -1360,8 +1360,8 @@ TEST_F(TabletUpdatesTest, test_issue_4181) {
 
     DeferOp defer([&]() {
         auto tablet_mgr = StorageEngine::instance()->tablet_manager();
-        (void)tablet_mgr->drop_tablet(tablet0->tablet_id(), tablet0->schema_hash());
-        (void)tablet_mgr->drop_tablet(tablet1->tablet_id(), tablet1->schema_hash());
+        (void)tablet_mgr->drop_tablet(tablet0->tablet_id());
+        (void)tablet_mgr->drop_tablet(tablet1->tablet_id());
         (void)FileUtils::remove_all(tablet0->schema_hash_path());
         (void)FileUtils::remove_all(tablet1->schema_hash_path());
     });
@@ -1402,7 +1402,7 @@ TEST_F(TabletUpdatesTest, snapshot_with_empty_rowset) {
 
     DeferOp defer([&]() {
         auto tablet_mgr = StorageEngine::instance()->tablet_manager();
-        (void)tablet_mgr->drop_tablet(tablet0->tablet_id(), tablet0->schema_hash());
+        (void)tablet_mgr->drop_tablet(tablet0->tablet_id());
         (void)FileUtils::remove_all(tablet0->schema_hash_path());
     });
 
@@ -1420,7 +1420,7 @@ TEST_F(TabletUpdatesTest, snapshot_with_empty_rowset) {
 
     DeferOp defer2([&]() {
         auto tablet_mgr = StorageEngine::instance()->tablet_manager();
-        (void)tablet_mgr->drop_tablet(tablet1->tablet_id(), tablet1->schema_hash());
+        (void)tablet_mgr->drop_tablet(tablet1->tablet_id());
         (void)FileUtils::remove_all(tablet1->schema_hash_path());
     });
 

--- a/be/test/storage/update_manager_test.cpp
+++ b/be/test/storage/update_manager_test.cpp
@@ -104,7 +104,7 @@ public:
         _meta.reset();
         FileUtils::remove_all(_root_path);
         if (_tablet) {
-            StorageEngine::instance()->tablet_manager()->drop_tablet(_tablet->tablet_id(), false);
+            StorageEngine::instance()->tablet_manager()->drop_tablet(_tablet->tablet_id());
             _tablet.reset();
         }
     }

--- a/be/test/storage/vectorized/rowset_merger_test.cpp
+++ b/be/test/storage/vectorized/rowset_merger_test.cpp
@@ -131,7 +131,7 @@ public:
 
     void TearDown() override {
         if (_tablet) {
-            StorageEngine::instance()->tablet_manager()->drop_tablet(_tablet->tablet_id(), false);
+            StorageEngine::instance()->tablet_manager()->drop_tablet(_tablet->tablet_id());
             _tablet.reset();
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -7455,7 +7455,7 @@ public class Catalog {
                         List<Replica> replicas = tablet.getReplicas();
                         for (Replica replica : replicas) {
                             long backendId = replica.getBackendId();
-                            DropReplicaTask dropTask = new DropReplicaTask(backendId, tabletId, schemaHash);
+                            DropReplicaTask dropTask = new DropReplicaTask(backendId, tabletId, schemaHash, true);
                             batchTask.addTask(dropTask);
                         } // end for replicas
                     } // end for tablets

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -1029,7 +1029,7 @@ public class TabletScheduler extends MasterDaemon {
     }
 
     private void sendDeleteReplicaTask(long backendId, long tabletId, int schemaHash) {
-        DropReplicaTask task = new DropReplicaTask(backendId, tabletId, schemaHash);
+        DropReplicaTask task = new DropReplicaTask(backendId, tabletId, schemaHash, false);
         AgentBatchTask batchTask = new AgentBatchTask();
         batchTask.addTask(task);
         AgentTaskExecutor.submit(batchTask);

--- a/fe/fe-core/src/main/java/com/starrocks/master/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/master/ReportHandler.java
@@ -693,7 +693,7 @@ public class ReportHandler extends Daemon {
 
                 if (needDelete) {
                     // drop replica
-                    DropReplicaTask task = new DropReplicaTask(backendId, tabletId, backendTabletInfo.getSchema_hash());
+                    DropReplicaTask task = new DropReplicaTask(backendId, tabletId, backendTabletInfo.getSchema_hash(), false);
                     batchTask.addTask(task);
                     LOG.warn("delete tablet[" + tabletId + " - " + backendTabletInfo.getSchema_hash()
                             + "] from backend[" + backendId + "] because not found in meta");
@@ -705,7 +705,7 @@ public class ReportHandler extends Daemon {
                 // this tablet is found in meta but with invalid schema hash.
                 // delete it.
                 int schemaHash = foundTabletsWithInvalidSchema.get(tabletId).getSchema_hash();
-                DropReplicaTask task = new DropReplicaTask(backendId, tabletId, schemaHash);
+                DropReplicaTask task = new DropReplicaTask(backendId, tabletId, schemaHash, false);
                 batchTask.addTask(task);
                 LOG.warn("delete tablet[" + tabletId + " - " + schemaHash + "] from backend[" + backendId
                         + "] because invalid schema hash");

--- a/fe/fe-core/src/main/java/com/starrocks/task/DropReplicaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/DropReplicaTask.java
@@ -26,10 +26,12 @@ import com.starrocks.thrift.TTaskType;
 
 public class DropReplicaTask extends AgentTask {
     private int schemaHash; // set -1L as unknown
+    private boolean force;
 
-    public DropReplicaTask(long backendId, long tabletId, int schemaHash) {
+    public DropReplicaTask(long backendId, long tabletId, int schemaHash, boolean force) {
         super(null, backendId, TTaskType.DROP, -1L, -1L, -1L, -1L, tabletId);
         this.schemaHash = schemaHash;
+        this.force = force;
     }
 
     public TDropTabletReq toThrift() {
@@ -37,6 +39,7 @@ public class DropReplicaTask extends AgentTask {
         if (this.schemaHash != -1) {
             request.setSchema_hash(schemaHash);
         }
+        request.setForce(force);
         return request;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/task/AgentTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/task/AgentTaskTest.java
@@ -119,7 +119,7 @@ public class AgentTaskTest {
                 false, TTabletType.TABLET_TYPE_DISK);
 
         // drop
-        dropTask = new DropReplicaTask(backendId1, tabletId1, schemaHash1);
+        dropTask = new DropReplicaTask(backendId1, tabletId1, schemaHash1, false);
 
         // push
         pushTask =
@@ -266,7 +266,7 @@ public class AgentTaskTest {
         Assert.assertEquals(1, AgentTaskQueue.getTaskNum(backendId1, TTaskType.DROP, true));
 
         dropTask.failed();
-        DropReplicaTask dropTask2 = new DropReplicaTask(backendId2, tabletId1, schemaHash1);
+        DropReplicaTask dropTask2 = new DropReplicaTask(backendId2, tabletId1, schemaHash1, false);
         AgentTaskQueue.addTask(dropTask2);
         dropTask2.failed();
         Assert.assertEquals(1, AgentTaskQueue.getTaskNum(backendId1, TTaskType.DROP, true));

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -79,6 +79,7 @@ struct TCreateTabletReq {
 struct TDropTabletReq {
     1: required Types.TTabletId tablet_id
     2: optional Types.TSchemaHash schema_hash
+    3: optional bool force
 }
 
 struct TAlterTabletReq {


### PR DESCRIPTION
BE still will load many dropped tablets upon start. It will lead to a long startup time.
Because FE have already stored dropped tablets in recycle bin for quite a long time. There is no necessity to move the tablet to recycle bin in BE storage. Instead, we can drop the tablet instantly. This  pull request include three optimizations as the following.
1. Do not load already-dropped tablets on startup, thus reducing the startup time if there are lots of dropped tablets.
2. Reduce the number of writes to RocksDB when deleting tablet meta. The original implementation needs two write operations, while this optimization only needs one write operation.
3. Reduce the size of records written to RocksDB and reduce the number of write stalls when dropping lots of tablets in a short time period.
