### PR TITLE
Strengthen semantics of operator's life cycle hook

### DIFF
--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.cpp
@@ -17,9 +17,6 @@ bool AggregateBlockingSinkOperator::is_finished() const {
 }
 
 void AggregateBlockingSinkOperator::set_finishing(RuntimeState* state) {
-    if (_is_finished) {
-        return;
-    }
     _is_finished = true;
 
     if (!_aggregator->is_none_group_by_exprs()) {

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.cpp
@@ -17,9 +17,6 @@ bool AggregateDistinctBlockingSinkOperator::is_finished() const {
 }
 
 void AggregateDistinctBlockingSinkOperator::set_finishing(RuntimeState* state) {
-    if (_is_finished) {
-        return;
-    }
     _is_finished = true;
 
     COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_set_variant().size());

--- a/be/src/exec/pipeline/aggregate/repeat/repeat_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/repeat/repeat_operator.cpp
@@ -18,9 +18,6 @@ bool RepeatOperator::is_finished() const {
 }
 
 void RepeatOperator::set_finishing(RuntimeState* state) {
-    if (_is_finished) {
-        return;
-    }
     _is_finished = true;
 }
 

--- a/be/src/exec/pipeline/analysis/analytic_sink_operator.cpp
+++ b/be/src/exec/pipeline/analysis/analytic_sink_operator.cpp
@@ -43,10 +43,6 @@ bool AnalyticSinkOperator::is_finished() const {
 }
 
 void AnalyticSinkOperator::set_finishing(RuntimeState* state) {
-    if (_is_finished) {
-        return;
-    }
-
     _is_finished = true;
     _analytor->input_eos() = true;
     _process_by_partition_if_necessary();

--- a/be/src/exec/pipeline/crossjoin/cross_join_right_sink_operator.h
+++ b/be/src/exec/pipeline/crossjoin/cross_join_right_sink_operator.h
@@ -27,11 +27,9 @@ public:
     bool is_finished() const override { return _is_finished; }
 
     void set_finishing(RuntimeState* state) override {
-        if (!_is_finished) {
-            _is_finished = true;
-            // Used to notify cross_join_left_operator.
-            _cross_join_context->finish_one_right_sinker();
-        }
+        _is_finished = true;
+        // Used to notify cross_join_left_operator.
+        _cross_join_context->finish_one_right_sinker();
     }
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;

--- a/be/src/exec/pipeline/exchange/exchange_merge_sort_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_merge_sort_source_operator.cpp
@@ -37,9 +37,6 @@ bool ExchangeMergeSortSourceOperator::is_finished() const {
 }
 
 void ExchangeMergeSortSourceOperator::set_finishing(RuntimeState* state) {
-    if (_is_finished) {
-        return;
-    }
     _is_finished = true;
     return _stream_recvr->close();
 }

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -420,9 +420,6 @@ Status ExchangeSinkOperator::push_chunk(RuntimeState* state, const vectorized::C
 }
 
 void ExchangeSinkOperator::set_finishing(RuntimeState* state) {
-    if (_is_finished) {
-        return;
-    }
     _is_finished = true;
 
     if (_chunk_request != nullptr) {

--- a/be/src/exec/pipeline/exchange/exchange_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_source_operator.cpp
@@ -31,9 +31,6 @@ bool ExchangeSourceOperator::is_finished() const {
 }
 
 void ExchangeSourceOperator::set_finishing(RuntimeState* state) {
-    if (_is_finishing) {
-        return;
-    }
     _is_finishing = true;
     return _stream_recvr->close();
 }

--- a/be/src/exec/pipeline/exchange/local_exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange_sink_operator.cpp
@@ -21,10 +21,8 @@ StatusOr<vectorized::ChunkPtr> LocalExchangeSinkOperator::pull_chunk(RuntimeStat
 }
 
 void LocalExchangeSinkOperator::set_finishing(RuntimeState* state) {
-    if (!_is_finished) {
-        _is_finished = true;
-        _exchanger->finish(state);
-    }
+    _is_finished = true;
+    _exchanger->finish(state);
 }
 
 Status LocalExchangeSinkOperator::push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) {

--- a/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
@@ -51,9 +51,6 @@ bool LocalExchangeSourceOperator::has_output() const {
 
 void LocalExchangeSourceOperator::set_finished(RuntimeState* state) {
     std::lock_guard<std::mutex> l(_chunk_lock);
-    if (_is_finished) {
-        return;
-    }
     _is_finished = true;
     // Compute out the number of rows of the _full_chunk_queue.
     size_t full_rows_num = 0;

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -24,6 +24,7 @@ Status PipelineDriver::prepare(RuntimeState* runtime_state) {
     source_operator()->add_morsel_queue(_morsel_queue);
     for (auto& op : _operators) {
         RETURN_IF_ERROR(op->prepare(runtime_state));
+        _operator_stages[op->get_id()] = OperatorStage::PREPARED;
     }
     // Driver has no dependencies always sets _all_dependencies_ready to true;
     _all_dependencies_ready = _dependencies.empty();
@@ -63,9 +64,9 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state) {
                 if (curr_op->is_finished()) {
                     if (i == 0) {
                         // For source operators
-                        curr_op->set_finishing(runtime_state);
+                        _finishing_operator(curr_op, runtime_state);
                     }
-                    next_op->set_finishing(runtime_state);
+                    _finishing_operator(next_op, runtime_state);
                     _new_first_unfinished = i + 1;
                     continue;
                 }
@@ -116,9 +117,9 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state) {
                 if (curr_op->is_finished()) {
                     if (i == 0) {
                         // For source operators
-                        curr_op->set_finishing(runtime_state);
+                        _finishing_operator(curr_op, runtime_state);
                     }
-                    next_op->set_finishing(runtime_state);
+                    _finishing_operator(next_op, runtime_state);
                     _new_first_unfinished = i + 1;
                     continue;
                 }
@@ -132,8 +133,7 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state) {
         }
         // close finished operators and update _first_unfinished index
         for (auto i = _first_unfinished; i < _new_first_unfinished; ++i) {
-            _operators[i]->set_finished(runtime_state);
-            RETURN_IF_ERROR(_operators[i]->close(runtime_state));
+            _finish_operator(_operators[i], runtime_state);
         }
         _first_unfinished = _new_first_unfinished;
 
@@ -168,23 +168,29 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state) {
     }
 }
 
-void PipelineDriver::finish_operators(RuntimeState* state) {
-    for (auto i = _first_unfinished; i < _operators.size(); ++i) {
-        _operators[i]->set_finished(state);
+void PipelineDriver::dispatch_operators() {
+    for (auto& op : _operators) {
+        _operator_stages[op->get_id()] = OperatorStage::PROCESSING;
+    }
+}
+
+void PipelineDriver::finish_operators(RuntimeState* runtime_state) {
+    for (auto& op : _operators) {
+        _finish_operator(op, runtime_state);
+    }
+}
+void PipelineDriver::_close_operators(RuntimeState* runtime_state) {
+    for (auto& op : _operators) {
+        _close_operator(op, runtime_state);
     }
 }
 
 void PipelineDriver::finalize(RuntimeState* runtime_state, DriverState state) {
     VLOG_ROW << "[Driver] finalize, driver=" << this;
-    if (state == DriverState::FINISH || state == DriverState::CANCELED || state == DriverState::INTERNAL_ERROR) {
-        auto num_operators = _operators.size();
-        for (auto i = _first_unfinished; i < num_operators; ++i) {
-            _operators[i]->set_finished(runtime_state);
-            _operators[i]->close(runtime_state);
-        }
-    } else {
-        DCHECK(false);
-    }
+    DCHECK(state == DriverState::FINISH || state == DriverState::CANCELED || state == DriverState::INTERNAL_ERROR);
+
+    _close_operators(runtime_state);
+
     _state = state;
 
     // Calculate total time before report profile
@@ -239,6 +245,35 @@ bool PipelineDriver::_check_fragment_is_canceled(RuntimeState* runtime_state) {
         return true;
     }
     return false;
+}
+
+void PipelineDriver::_finishing_operator(OperatorPtr& op, RuntimeState* state) {
+    auto& op_state = _operator_stages[op->get_id()];
+    if (op_state >= OperatorStage::FINISHING) {
+        return;
+    }
+    op->set_finishing(state);
+    op_state = OperatorStage::FINISHING;
+}
+
+void PipelineDriver::_finish_operator(OperatorPtr& op, RuntimeState* state) {
+    _finishing_operator(op, state);
+    auto& op_state = _operator_stages[op->get_id()];
+    if (op_state >= OperatorStage::FINISHED) {
+        return;
+    }
+    op->set_finished(state);
+    op_state = OperatorStage::FINISHED;
+}
+
+void PipelineDriver::_close_operator(OperatorPtr& op, RuntimeState* state) {
+    _finish_operator(op, state);
+    auto& op_state = _operator_stages[op->get_id()];
+    if (op_state >= OperatorStage::CLOSED) {
+        return;
+    }
+    op->close(state);
+    op_state = OperatorStage::CLOSED;
 }
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -191,9 +191,9 @@ public:
 private:
     // check whether fragment is cancelled. It is used before pull_chunk and push_chunk.
     bool _check_fragment_is_canceled(RuntimeState* runtime_state);
-    void _finishing_operator(OperatorPtr& op, RuntimeState* runtime_state);
-    void _finish_operator(OperatorPtr& op, RuntimeState* runtime_state);
-    void _close_operator(OperatorPtr& op, RuntimeState* runtime_state);
+    void _mark_operator_finishing(OperatorPtr& op, RuntimeState* runtime_state);
+    void _mark_operator_finished(OperatorPtr& op, RuntimeState* runtime_state);
+    void _mark_operator_closed(OperatorPtr& op, RuntimeState* runtime_state);
     void _close_operators(RuntimeState* runtime_state);
 
     Operators _operators;

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -14,6 +14,7 @@
 #include "exec/pipeline/pipeline_fwd.h"
 #include "exec/pipeline/query_context.h"
 #include "exec/pipeline/source_operator.h"
+#include "util/phmap/phmap.h"
 
 namespace starrocks {
 namespace pipeline {
@@ -214,7 +215,7 @@ private:
     const size_t _yield_max_chunks_moved;
     const int64_t _yield_max_time_spent;
 
-    std::unordered_map<int32_t, OperatorStage> _operator_stages;
+    phmap::flat_hash_map<int32_t, OperatorStage> _operator_stages;
 
     // metrics
     RuntimeProfile::Counter* _total_timer = nullptr;

--- a/be/src/exec/pipeline/pipeline_driver_dispatcher.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_dispatcher.cpp
@@ -145,6 +145,7 @@ void GlobalDriverDispatcher::dispatch(DriverRawPtr driver) {
     } else {
         this->_driver_queue->put_back(driver);
     }
+    driver->dispatch_operators();
 }
 
 void GlobalDriverDispatcher::report_exec_state(FragmentContext* fragment_ctx, const Status& status, bool done) {

--- a/be/src/exec/pipeline/project_operator.cpp
+++ b/be/src/exec/pipeline/project_operator.cpp
@@ -11,14 +11,11 @@
 
 namespace starrocks::pipeline {
 Status ProjectOperator::prepare(RuntimeState* state) {
-    Operator::prepare(state);
-
-    return Status::OK();
+    return Operator::prepare(state);
 }
 
 Status ProjectOperator::close(RuntimeState* state) {
-    Operator::close(state);
-    return Status::OK();
+    return Operator::close(state);
 }
 
 StatusOr<vectorized::ChunkPtr> ProjectOperator::pull_chunk(RuntimeState* state) {

--- a/be/src/exec/pipeline/select_operator.cpp
+++ b/be/src/exec/pipeline/select_operator.cpp
@@ -9,13 +9,11 @@
 
 namespace starrocks::pipeline {
 Status SelectOperator::prepare(RuntimeState* state) {
-    Operator::prepare(state);
-    return Status::OK();
+    return Operator::prepare(state);
 }
 
 Status SelectOperator::close(RuntimeState* state) {
-    Operator::close(state);
-    return Status::OK();
+    return Operator::close(state);
 }
 
 StatusOr<vectorized::ChunkPtr> SelectOperator::pull_chunk(RuntimeState* state) {

--- a/be/src/exec/pipeline/set/except_build_sink_operator.h
+++ b/be/src/exec/pipeline/set/except_build_sink_operator.h
@@ -38,10 +38,8 @@ public:
     bool is_finished() const override { return _is_finished; }
 
     void set_finishing(RuntimeState* state) override {
-        if (!_is_finished) {
-            _is_finished = true;
-            _except_ctx->finish_build_ht();
-        }
+        _is_finished = true;
+        _except_ctx->finish_build_ht();
     }
 
     Status prepare(RuntimeState* state) override;

--- a/be/src/exec/pipeline/set/except_probe_sink_operator.h
+++ b/be/src/exec/pipeline/set/except_probe_sink_operator.h
@@ -29,10 +29,8 @@ public:
     }
 
     void set_finishing(RuntimeState* state) override {
-        if (!_is_finished) {
-            _is_finished = true;
-            _except_ctx->finish_probe_ht();
-        }
+        _is_finished = true;
+        _except_ctx->finish_probe_ht();
     }
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;

--- a/be/src/exec/pipeline/set/intersect_build_sink_operator.h
+++ b/be/src/exec/pipeline/set/intersect_build_sink_operator.h
@@ -40,10 +40,8 @@ public:
     bool is_finished() const override { return _is_finished; }
 
     void set_finishing(RuntimeState* state) override {
-        if (!_is_finished) {
-            _is_finished = true;
-            _intersect_ctx->finish_build_ht();
-        }
+        _is_finished = true;
+        _intersect_ctx->finish_build_ht();
     }
 
     Status prepare(RuntimeState* state) override;

--- a/be/src/exec/pipeline/set/intersect_probe_sink_operator.h
+++ b/be/src/exec/pipeline/set/intersect_probe_sink_operator.h
@@ -32,10 +32,8 @@ public:
     }
 
     void set_finishing(RuntimeState* state) override {
-        if (!_is_finished) {
-            _is_finished = true;
-            _intersect_ctx->finish_probe_ht();
-        }
+        _is_finished = true;
+        _intersect_ctx->finish_probe_ht();
     }
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;

--- a/be/src/exec/pipeline/sort/sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/sort_sink_operator.cpp
@@ -18,8 +18,7 @@ using namespace starrocks::vectorized;
 
 namespace starrocks::pipeline {
 Status SortSinkOperator::prepare(RuntimeState* state) {
-    Operator::prepare(state);
-    return Status::OK();
+    return Operator::prepare(state);
 }
 
 Status SortSinkOperator::close(RuntimeState* state) {

--- a/be/test/exec/pipeline/pipeline_control_flow_test.cpp
+++ b/be/test/exec/pipeline/pipeline_control_flow_test.cpp
@@ -1,6 +1,7 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
 
 #include <mutex>
+#include <random>
 
 #include "pipeline_test_base.h"
 #include "util/thrift_util.h"
@@ -63,19 +64,127 @@ private:
 
 using CounterPtr = std::shared_ptr<Counter>;
 
+std::atomic<size_t> lifecycle_error_num;
+
+class TestOperator : public Operator {
+public:
+    TestOperator(int32_t id, const std::string& name, int32_t plan_node_id) : Operator(id, name, plan_node_id) {}
+    ~TestOperator() {
+        if (!_is_prepared) {
+            ++lifecycle_error_num;
+        }
+        if (!_is_finishing) {
+            ++lifecycle_error_num;
+        }
+        if (!_is_finished) {
+            ++lifecycle_error_num;
+        }
+        if (!_is_closed) {
+            ++lifecycle_error_num;
+        }
+    }
+
+    Status prepare(RuntimeState* state) override {
+        RETURN_IF_ERROR(Operator::prepare(state));
+        if (_is_prepared) {
+            ++lifecycle_error_num;
+        }
+        _is_prepared = true;
+        return Status::OK();
+    }
+
+    void set_finishing(RuntimeState* state) override {
+        if (_is_finishing) {
+            ++lifecycle_error_num;
+        }
+        _is_finishing = true;
+    }
+
+    void set_finished(RuntimeState* state) override {
+        if (_is_finished) {
+            ++lifecycle_error_num;
+        }
+        _is_finished = true;
+    }
+
+    Status close(RuntimeState* state) override {
+        if (_is_closed) {
+            ++lifecycle_error_num;
+        }
+        _is_closed = true;
+        return Operator::close(state);
+    }
+
+private:
+    bool _is_prepared = false;
+    bool _is_finishing = false;
+    bool _is_finished = false;
+    bool _is_closed = false;
+};
+
 class TestSourceOperator : public SourceOperator {
 public:
-    TestSourceOperator(int32_t id, int32_t plan_node_id, size_t chunk_num, size_t chunk_size, CounterPtr counter)
-            : SourceOperator(id, "test_source", plan_node_id), _counter(counter) {
+    TestSourceOperator(int32_t id, int32_t plan_node_id, size_t chunk_num, size_t chunk_size, CounterPtr counter,
+                       int32_t pending_finish_cnt)
+            : SourceOperator(id, "test_source", plan_node_id),
+              _counter(counter),
+              _pending_finish_cnt(pending_finish_cnt) {
         for (size_t i = 0; i < chunk_num; ++i) {
             _chunks.push_back(PipelineTestBase::_create_and_fill_chunk(chunk_size));
         }
     }
-    ~TestSourceOperator() override = default;
+    ~TestSourceOperator() {
+        if (!_is_prepared) {
+            ++lifecycle_error_num;
+        }
+        if (!_is_finishing) {
+            ++lifecycle_error_num;
+        }
+        if (!_is_finished) {
+            ++lifecycle_error_num;
+        }
+        if (!_is_closed) {
+            ++lifecycle_error_num;
+        }
+    }
+
+    Status prepare(RuntimeState* state) override {
+        RETURN_IF_ERROR(SourceOperator::prepare(state));
+        if (_is_prepared) {
+            ++lifecycle_error_num;
+        }
+        _is_prepared = true;
+        return Status::OK();
+    }
+
+    void set_finishing(RuntimeState* state) override {
+        if (_is_finishing) {
+            ++lifecycle_error_num;
+        }
+        _is_finishing = true;
+    }
+
+    void set_finished(RuntimeState* state) override {
+        if (_is_finished) {
+            ++lifecycle_error_num;
+        }
+        _is_finished = true;
+    }
+
+    Status close(RuntimeState* state) override {
+        if (_pending_finish_cnt >= 0) {
+            ++lifecycle_error_num;
+        }
+        if (_is_closed) {
+            ++lifecycle_error_num;
+        }
+        _is_closed = true;
+        return SourceOperator::close(state);
+    }
 
     bool has_output() const override { return _index < _chunks.size(); }
     bool is_finished() const override { return !has_output(); }
-    void set_finishing(RuntimeState* state) override {}
+    bool pending_finish() { return --_pending_finish_cnt >= 0; }
 
     Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override;
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
@@ -84,6 +193,12 @@ private:
     CounterPtr _counter;
     std::vector<vectorized::ChunkPtr> _chunks;
     size_t _index = 0;
+    std::atomic<int32_t> _pending_finish_cnt;
+
+    bool _is_prepared = false;
+    bool _is_finishing = false;
+    bool _is_finished = false;
+    bool _is_closed = false;
 };
 
 Status TestSourceOperator::push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) {
@@ -99,34 +214,41 @@ StatusOr<vectorized::ChunkPtr> TestSourceOperator::pull_chunk(RuntimeState* stat
 
 class TestSourceOperatorFactory final : public SourceOperatorFactory {
 public:
-    TestSourceOperatorFactory(int32_t id, int32_t plan_node_id, size_t chunk_num, size_t chunk_size, CounterPtr counter)
+    TestSourceOperatorFactory(int32_t id, int32_t plan_node_id, size_t chunk_num, size_t chunk_size, CounterPtr counter,
+                              int32_t pending_finish_cnt)
             : SourceOperatorFactory(id, "test_source", plan_node_id),
               _chunk_num(chunk_num),
               _chunk_size(chunk_size),
-              _counter(counter) {}
+              _counter(counter),
+              _pending_finish_cnt(pending_finish_cnt) {}
 
     ~TestSourceOperatorFactory() override = default;
 
     OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override {
-        return std::make_shared<TestSourceOperator>(_id, _plan_node_id, _chunk_num, _chunk_size, _counter);
+        return std::make_shared<TestSourceOperator>(_id, _plan_node_id, _chunk_num, _chunk_size, _counter,
+                                                    _pending_finish_cnt);
     }
 
 private:
     size_t _chunk_num;
     size_t _chunk_size;
     CounterPtr _counter;
+    int32_t _pending_finish_cnt;
 };
 
-class TestNormalOperator : public Operator {
+class TestNormalOperator : public TestOperator {
 public:
     TestNormalOperator(int32_t id, int32_t plan_node_id, CounterPtr counter)
-            : Operator(id, "test_normal", plan_node_id), _counter(counter) {}
+            : TestOperator(id, "test_normal", plan_node_id), _counter(counter) {}
     ~TestNormalOperator() override = default;
 
     bool need_input() const override { return true; }
     bool has_output() const override { return _chunk != nullptr; }
     bool is_finished() const override { return _is_finished && !has_output(); }
-    void set_finishing(RuntimeState* state) override { _is_finished = true; }
+    void set_finishing(RuntimeState* state) override {
+        TestOperator::set_finishing(state);
+        _is_finished = true;
+    }
 
     Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override;
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
@@ -165,16 +287,19 @@ private:
     CounterPtr _counter;
 };
 
-class TestSinkOperator : public Operator {
+class TestSinkOperator : public TestOperator {
 public:
     TestSinkOperator(int32_t id, int32_t plan_node_id, CounterPtr counter)
-            : Operator(id, "test_sink", plan_node_id), _counter(counter) {}
+            : TestOperator(id, "test_sink", plan_node_id), _counter(counter) {}
     ~TestSinkOperator() override = default;
 
     bool need_input() const override { return true; }
     bool has_output() const override { return _chunk != nullptr; }
     bool is_finished() const override { return _is_finished; }
-    void set_finishing(RuntimeState* state) override { _is_finished = true; }
+    void set_finishing(RuntimeState* state) override {
+        TestOperator::set_finishing(state);
+        _is_finished = true;
+    }
 
     Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override;
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
@@ -212,16 +337,18 @@ private:
 class TestPipelineControlFlow : public PipelineTestBase {};
 
 TEST_F(TestPipelineControlFlow, test_two_operatories) {
+    std::default_random_engine e;
+    std::uniform_int_distribution<int32_t> u32(0, 100);
     size_t chunk_num = 1;
     size_t chunk_size = 1;
     CounterPtr sourceCounter = std::make_shared<Counter>();
     CounterPtr sinkCounter = std::make_shared<Counter>();
 
-    _pipeline_builder = [=]() {
+    _pipeline_builder = [&]() {
         OpFactories op_factories;
 
-        op_factories.push_back(std::make_shared<TestSourceOperatorFactory>(next_operator_id(), next_plan_node_id(),
-                                                                           chunk_num, chunk_size, sourceCounter));
+        op_factories.push_back(std::make_shared<TestSourceOperatorFactory>(
+                next_operator_id(), next_plan_node_id(), chunk_num, chunk_size, sourceCounter, u32(e)));
         op_factories.push_back(
                 std::make_shared<TestSinkOperatorFactory>(next_operator_id(), next_plan_node_id(), sinkCounter));
 
@@ -233,20 +360,23 @@ TEST_F(TestPipelineControlFlow, test_two_operatories) {
     ASSERT_TRUE(_fragment_future.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
     ASSERT_COUNTER_CHUNK_NUM(sourceCounter, 0, chunk_num);
     ASSERT_COUNTER_CHUNK_NUM(sinkCounter, chunk_num, 0);
+    ASSERT_EQ(lifecycle_error_num, 0);
 }
 
 TEST_F(TestPipelineControlFlow, test_three_operatories) {
+    std::default_random_engine e;
+    std::uniform_int_distribution<int32_t> u32(0, 100);
     size_t chunk_num = 1;
     size_t chunk_size = 1;
     CounterPtr sourceCounter = std::make_shared<Counter>();
     CounterPtr normalCounter = std::make_shared<Counter>();
     CounterPtr sinkCounter = std::make_shared<Counter>();
 
-    _pipeline_builder = [=]() {
+    _pipeline_builder = [&]() {
         OpFactories op_factories;
 
-        op_factories.push_back(std::make_shared<TestSourceOperatorFactory>(next_operator_id(), next_plan_node_id(),
-                                                                           chunk_num, chunk_size, sourceCounter));
+        op_factories.push_back(std::make_shared<TestSourceOperatorFactory>(
+                next_operator_id(), next_plan_node_id(), chunk_num, chunk_size, sourceCounter, u32(e)));
         op_factories.push_back(
                 std::make_shared<TestNormalOperatorFactory>(next_operator_id(), next_plan_node_id(), normalCounter));
         op_factories.push_back(
@@ -261,9 +391,12 @@ TEST_F(TestPipelineControlFlow, test_three_operatories) {
     ASSERT_COUNTER_CHUNK_NUM(sourceCounter, 0, chunk_num);
     ASSERT_COUNTER_CHUNK_NUM(normalCounter, chunk_num, chunk_num);
     ASSERT_COUNTER_CHUNK_NUM(sinkCounter, chunk_num, 0);
+    ASSERT_EQ(lifecycle_error_num, 0);
 }
 
 TEST_F(TestPipelineControlFlow, test_multi_operators) {
+    std::default_random_engine e;
+    std::uniform_int_distribution<int32_t> u32(0, 100);
     size_t max_mid_operator_num = 128;
     size_t chunk_num = 1;
     size_t chunk_size = 1;
@@ -276,11 +409,11 @@ TEST_F(TestPipelineControlFlow, test_multi_operators) {
             normalCounters.push_back(std::make_shared<Counter>());
         }
 
-        _pipeline_builder = [=]() {
+        _pipeline_builder = [&]() {
             OpFactories op_factories;
 
-            op_factories.push_back(std::make_shared<TestSourceOperatorFactory>(next_operator_id(), next_plan_node_id(),
-                                                                               chunk_num, chunk_size, sourceCounter));
+            op_factories.push_back(std::make_shared<TestSourceOperatorFactory>(
+                    next_operator_id(), next_plan_node_id(), chunk_num, chunk_size, sourceCounter, u32(e)));
             for (size_t j = 0; j < i; ++j) {
                 op_factories.push_back(std::make_shared<TestNormalOperatorFactory>(
                         next_operator_id(), next_plan_node_id(), normalCounters[j]));
@@ -299,21 +432,24 @@ TEST_F(TestPipelineControlFlow, test_multi_operators) {
             ASSERT_COUNTER_CHUNK_NUM(normalCounters[j], chunk_num, chunk_num);
         }
         ASSERT_COUNTER_CHUNK_NUM(sinkCounter, chunk_num, 0);
+        ASSERT_EQ(lifecycle_error_num, 0);
     }
 }
 
 TEST_F(TestPipelineControlFlow, test_full_chunk_size) {
+    std::default_random_engine e;
+    std::uniform_int_distribution<int32_t> u32(0, 100);
     size_t chunk_num = 1;
     size_t chunk_size = config::vector_chunk_size;
     CounterPtr sourceCounter = std::make_shared<Counter>();
     CounterPtr normalCounter = std::make_shared<Counter>();
     CounterPtr sinkCounter = std::make_shared<Counter>();
 
-    _pipeline_builder = [=]() {
+    _pipeline_builder = [&]() {
         OpFactories op_factories;
 
-        op_factories.push_back(std::make_shared<TestSourceOperatorFactory>(next_operator_id(), next_plan_node_id(),
-                                                                           chunk_num, chunk_size, sourceCounter));
+        op_factories.push_back(std::make_shared<TestSourceOperatorFactory>(
+                next_operator_id(), next_plan_node_id(), chunk_num, chunk_size, sourceCounter, u32(e)));
         op_factories.push_back(
                 std::make_shared<TestNormalOperatorFactory>(next_operator_id(), next_plan_node_id(), normalCounter));
         op_factories.push_back(
@@ -328,20 +464,23 @@ TEST_F(TestPipelineControlFlow, test_full_chunk_size) {
     ASSERT_COUNTER_CHUNK_NUM(sourceCounter, 0, chunk_num);
     ASSERT_COUNTER_CHUNK_NUM(normalCounter, chunk_num, chunk_num);
     ASSERT_COUNTER_CHUNK_NUM(sinkCounter, chunk_num, 0);
+    ASSERT_EQ(lifecycle_error_num, 0);
 }
 
 TEST_F(TestPipelineControlFlow, test_multi_chunks) {
+    std::default_random_engine e;
+    std::uniform_int_distribution<int32_t> u32(0, 100);
     size_t chunk_num = 1000;
     size_t chunk_size = 1;
     CounterPtr sourceCounter = std::make_shared<Counter>();
     CounterPtr normalCounter = std::make_shared<Counter>();
     CounterPtr sinkCounter = std::make_shared<Counter>();
 
-    _pipeline_builder = [=]() {
+    _pipeline_builder = [&]() {
         OpFactories op_factories;
 
-        op_factories.push_back(std::make_shared<TestSourceOperatorFactory>(next_operator_id(), next_plan_node_id(),
-                                                                           chunk_num, chunk_size, sourceCounter));
+        op_factories.push_back(std::make_shared<TestSourceOperatorFactory>(
+                next_operator_id(), next_plan_node_id(), chunk_num, chunk_size, sourceCounter, u32(e)));
         op_factories.push_back(
                 std::make_shared<TestNormalOperatorFactory>(next_operator_id(), next_plan_node_id(), normalCounter));
         op_factories.push_back(
@@ -356,9 +495,12 @@ TEST_F(TestPipelineControlFlow, test_multi_chunks) {
     ASSERT_COUNTER_CHUNK_NUM(sourceCounter, 0, chunk_num);
     ASSERT_COUNTER_CHUNK_NUM(normalCounter, chunk_num, chunk_num);
     ASSERT_COUNTER_CHUNK_NUM(sinkCounter, chunk_num, 0);
+    ASSERT_EQ(lifecycle_error_num, 0);
 }
 
 TEST_F(TestPipelineControlFlow, test_local_exchange_operator_with_non_full_chunk) {
+    std::default_random_engine e;
+    std::uniform_int_distribution<int32_t> u32(0, 100);
     size_t max_degree_of_parallelism = 16;
     size_t chunk_num = 128;
     size_t chunk_size = 1;
@@ -368,11 +510,11 @@ TEST_F(TestPipelineControlFlow, test_local_exchange_operator_with_non_full_chunk
         CounterPtr normalCounter = std::make_shared<Counter>();
         CounterPtr sinkCounter = std::make_shared<Counter>();
 
-        _pipeline_builder = [=]() {
+        _pipeline_builder = [&]() {
             OpFactories op_factories;
 
             auto source_op_factory = std::make_shared<TestSourceOperatorFactory>(
-                    next_operator_id(), next_plan_node_id(), chunk_num, chunk_size, sourceCounter);
+                    next_operator_id(), next_plan_node_id(), chunk_num, chunk_size, sourceCounter, u32(e));
             source_op_factory->set_degree_of_parallelism(i);
             op_factories.push_back(source_op_factory);
 
@@ -401,10 +543,13 @@ TEST_F(TestPipelineControlFlow, test_local_exchange_operator_with_non_full_chunk
             ASSERT_COUNTER_CHUNK_ROW_NUM(normalCounter, chunk_num * chunk_size * i, chunk_num * chunk_size * i);
             ASSERT_COUNTER_CHUNK_ROW_NUM(sinkCounter, chunk_num * chunk_size * i, 0);
         }
+        ASSERT_EQ(lifecycle_error_num, 0);
     }
 }
 
 TEST_F(TestPipelineControlFlow, test_local_exchange_operator_with_full_chunk) {
+    std::default_random_engine e;
+    std::uniform_int_distribution<int32_t> u32(0, 100);
     size_t max_degree_of_parallelism = 16;
     size_t chunk_num = 128;
     size_t original_chunk_size = config::vector_chunk_size;
@@ -416,11 +561,11 @@ TEST_F(TestPipelineControlFlow, test_local_exchange_operator_with_full_chunk) {
         CounterPtr normalCounter = std::make_shared<Counter>();
         CounterPtr sinkCounter = std::make_shared<Counter>();
 
-        _pipeline_builder = [=]() {
+        _pipeline_builder = [&]() {
             OpFactories op_factories;
 
             auto source_op_factory = std::make_shared<TestSourceOperatorFactory>(
-                    next_operator_id(), next_plan_node_id(), chunk_num, chunk_size, sourceCounter);
+                    next_operator_id(), next_plan_node_id(), chunk_num, chunk_size, sourceCounter, u32(e));
             source_op_factory->set_degree_of_parallelism(i);
             op_factories.push_back(source_op_factory);
             op_factories = maybe_interpolate_local_passthrough_exchange(op_factories);
@@ -438,6 +583,7 @@ TEST_F(TestPipelineControlFlow, test_local_exchange_operator_with_full_chunk) {
         ASSERT_COUNTER_CHUNK_NUM(sourceCounter, 0, chunk_num * i);
         ASSERT_COUNTER_CHUNK_NUM(normalCounter, chunk_num * i, chunk_num * i);
         ASSERT_COUNTER_CHUNK_NUM(sinkCounter, chunk_num * i, 0);
+        ASSERT_EQ(lifecycle_error_num, 0);
     }
 
     config::vector_chunk_size = original_chunk_size;


### PR DESCRIPTION
1. Ensure that all the stages of operator, including `prepare`、`set_finishing`、`set_finished`、`close`, will be exactly called once in the whole life cycle. And there is one exception that if prepare failed, then the other stages will never called.
2. And based on this, `set_finishing`、`set_finished`、`close` needn't to be idempotent any more
3. Add some life cycle assert to unit test  for the semantics of the `exactly once`

[related-issue](https://github.com/StarRocks/starrocks/issues/1292)