### PR TITLE
Fix column statistics null fraction estimate error when column not equals to constant

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/BinaryPredicateStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/BinaryPredicateStatisticCalculator.java
@@ -68,15 +68,10 @@ public class BinaryPredicateStatisticCalculator {
         double rowCount = statistics.getOutputRowCount() * (1 - columnStatistic.getNullsFraction()) * predicateFactor;
         // TODO(ywb) use origin column distinct values as new column statistics now, we should re-compute column
         //  distinct values actually.
-        ColumnStatistic newEstimateColumnStatistics = ColumnStatistic.builder().
-                setAverageRowSize(columnStatistic.getAverageRowSize()).
-                setMaxValue(intersectRange.getHigh()).
-                setMinValue(intersectRange.getLow()).
-                setDistinctValuesCount(columnStatistic.getDistinctValuesCount()).
-                setType(columnStatistic.getType()).
-                build();
+        ColumnStatistic newEstimateColumnStatistics =
+                ColumnStatistic.buildFrom(columnStatistic).setNullsFraction(0).build();
         return columnRefOperator.map(operator -> Statistics.buildFrom(statistics).setOutputRowCount(rowCount).
-                        addColumnStatistic(operator, newEstimateColumnStatistics).build()).
+                addColumnStatistic(operator, newEstimateColumnStatistics).build()).
                 orElseGet(() -> Statistics.buildFrom(statistics).setOutputRowCount(rowCount).build());
     }
 
@@ -214,7 +209,7 @@ public class BinaryPredicateStatisticCalculator {
                 setType(columnStatistic.getType()).
                 build();
         return columnRefOperator.map(operator -> Statistics.buildFrom(statistics).setOutputRowCount(rowCount).
-                        addColumnStatistic(operator, newEstimateColumnStatistics).build()).
+                addColumnStatistic(operator, newEstimateColumnStatistics).build()).
                 orElseGet(() -> Statistics.buildFrom(statistics).setOutputRowCount(rowCount).build());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
@@ -593,4 +593,13 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
         Assert.assertTrue(plan.contains("2:AGGREGATE (update serialize)"));
         Assert.assertTrue(plan.contains("4:AGGREGATE (merge finalize)"));
     }
+
+
+    @Test
+    public void testColumnNotEqualsConstant() throws Exception {
+        String sql = "select S_SUPPKEY,S_NAME from supplier where s_name <> 'Supplier#000000050' and s_name >= 'Supplier#000000086'";
+        String plan = getCostExplain(sql);
+        // check cardinality not 0
+        Assert.assertTrue(plan.contains("cardinality: 500000"));
+    }
 }


### PR DESCRIPTION
ref #1288 
newEstimateColumnStatistics not compute the NullsFraction which is NAN default, lead to estimate cardinality error