### PR TITLE
opt topn when limit was small (less than 1024)

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -71,6 +71,7 @@ set(EXEC_FILES
     vectorized/join_hash_map.cpp
     vectorized/topn_node.cpp
     vectorized/chunks_sorter.cpp
+    vectorized/chunk_sorter_heapsorter.cpp
     vectorized/chunks_sorter_topn.cpp
     vectorized/chunks_sorter_full_sort.cpp
     vectorized/cross_join_node.cpp

--- a/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
@@ -65,9 +65,15 @@ OperatorPtr PartitionSortSinkOperatorFactory::create(int32_t degree_of_paralleli
 
     std::shared_ptr<ChunksSorter> chunks_sorter;
     if (_limit >= 0) {
-        chunks_sorter = std::make_unique<vectorized::ChunksSorterTopn>(&(_sort_exec_exprs.lhs_ordering_expr_ctxs()),
-                                                                       &_is_asc_order, &_is_null_first, _offset, _limit,
-                                                                       SIZE_OF_CHUNK_FOR_TOPN);
+        if (_limit <= ChunksSorter::USE_HEAP_SORTER_LIMIT_SZ) {
+            chunks_sorter =
+                    std::make_unique<HeapChunkSorter>(&(_sort_exec_exprs.lhs_ordering_expr_ctxs()), &_is_asc_order,
+                                                      &_is_null_first, _offset, _limit, SIZE_OF_CHUNK_FOR_TOPN);
+        } else {
+            chunks_sorter =
+                    std::make_unique<ChunksSorterTopn>(&(_sort_exec_exprs.lhs_ordering_expr_ctxs()), &_is_asc_order,
+                                                       &_is_null_first, _offset, _limit, SIZE_OF_CHUNK_FOR_TOPN);
+        }
     } else {
         chunks_sorter = std::make_unique<vectorized::ChunksSorterFullSort>(&(_sort_exec_exprs.lhs_ordering_expr_ctxs()),
                                                                            &_is_asc_order, &_is_null_first,

--- a/be/src/exec/pipeline/sort/partition_sort_sink_operator.h
+++ b/be/src/exec/pipeline/sort/partition_sort_sink_operator.h
@@ -6,6 +6,7 @@
 #include "exec/pipeline/operator.h"
 #include "exec/pipeline/sort/sort_context.h"
 #include "exec/sort_exec_exprs.h"
+#include "exec/vectorized/chunk_sorter_heapsorter.h"
 #include "exec/vectorized/chunks_sorter.h"
 #include "exec/vectorized/chunks_sorter_full_sort.h"
 #include "exec/vectorized/chunks_sorter_topn.h"

--- a/be/src/exec/pipeline/sort/sort_context.h
+++ b/be/src/exec/pipeline/sort/sort_context.h
@@ -75,7 +75,9 @@ public:
      * Output the result data in a streaming manner,
      * And dynamically adjust the heap.
      */
-    ChunkPtr pull_chunk(const std::function<uint32_t(DataSegment* min_heap_entry)>& get_and_update_min_entry_func) {
+    // uint32_t UpdateFunc(DataSegment* min_heap_entry)
+    template <class UpdateFunc>
+    ChunkPtr pull_chunk(UpdateFunc&& get_and_update_min_entry_func) {
         // Get appropriate size
         uint32_t needed_rows = std::min((uint64_t)config::vector_chunk_size, _require_rows - _next_output_row);
 

--- a/be/src/exec/vectorized/chunk_sorter_heapsorter.cpp
+++ b/be/src/exec/vectorized/chunk_sorter_heapsorter.cpp
@@ -1,0 +1,239 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#include "exec/vectorized//chunk_sorter_heapsorter.h"
+
+#include <functional>
+#include <memory>
+#include <vector>
+
+#include "column/column_helper.h"
+#include "column/nullable_column.h"
+#include "column/type_traits.h"
+#include "column/vectorized_fwd.h"
+#include "glog/logging.h"
+#include "gutil/casts.h"
+#include "util/defer_op.h"
+
+namespace starrocks::vectorized {
+
+#define APPLY_FOR_ALL_PRIMITIVE_TYPE(M) \
+    M(TYPE_TINYINT)                     \
+    M(TYPE_SMALLINT)                    \
+    M(TYPE_INT)                         \
+    M(TYPE_BIGINT)                      \
+    M(TYPE_LARGEINT)                    \
+    M(TYPE_FLOAT)                       \
+    M(TYPE_DOUBLE)                      \
+    M(TYPE_VARCHAR)                     \
+    M(TYPE_CHAR)                        \
+    M(TYPE_DATE)                        \
+    M(TYPE_DATETIME)                    \
+    M(TYPE_DECIMALV2)                   \
+    M(TYPE_DECIMAL32)                   \
+    M(TYPE_DECIMAL64)                   \
+    M(TYPE_DECIMAL128)                  \
+    M(TYPE_BOOLEAN)
+
+Status HeapChunkSorter::update(RuntimeState* state, const ChunkPtr& chunk) {
+    ScopedTimer<MonotonicStopWatch> timer(_build_timer);
+
+    if (chunk->is_empty()) {
+        return Status::OK();
+    }
+
+    // chunk_holder was shared ownership by itself
+    detail::ChunkHolder* chunk_holder = new detail::ChunkHolder(std::make_shared<DataSegment>(_sort_exprs, chunk));
+    chunk_holder->ref();
+    DeferOp defer([&] { chunk_holder->unref(); });
+    int row_sz = chunk_holder->value()->chunk->num_rows();
+    if (_sort_heap == nullptr) {
+        _sort_heap = std::make_unique<CommonCursorSortHeap>(
+                detail::ChunkCursorComparator(_sort_order_flag.data(), _null_first_flag.data()));
+        _sort_heap->reserve(_number_of_rows_to_sort());
+        // build heap
+        size_t direct_push = std::min<size_t>(_number_of_rows_to_sort(), row_sz);
+        size_t i = 0;
+
+        // push data to heap if heap was not full
+        for (; i < direct_push; ++i) {
+            detail::ChunkRowCursor cursor(i, chunk_holder);
+            _sort_heap->push(std::move(cursor));
+        }
+
+        // compare to heap top and replace top
+        for (; i < row_sz; ++i) {
+            detail::ChunkRowCursor cursor(i, chunk_holder);
+            _sort_heap->replace_top_if_less(std::move(cursor));
+        }
+
+        // Special optimization for single columns
+        if (_sort_exprs->size() == 1) {
+            switch ((*_sort_exprs)[0]->root()->type().type) {
+#define M(NAME)                                                                                            \
+    case PrimitiveType::NAME: {                                                                            \
+        _do_filter_data = std::bind(&HeapChunkSorter::_do_filter_data_for_type<PrimitiveType::NAME>, this, \
+                                    std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);  \
+        break;                                                                                             \
+    }
+                APPLY_FOR_ALL_PRIMITIVE_TYPE(M)
+#undef M
+            default:
+                break;
+            }
+        }
+
+    } else {
+        if (_number_of_rows_to_sort() == _sort_heap->size()) {
+            // if heap was full
+            int rows_afterfilter_sz = _filter_data(chunk_holder, row_sz);
+            COUNTER_UPDATE(_sort_filter_rows, (row_sz - rows_afterfilter_sz));
+            for (int i = 0; i < rows_afterfilter_sz; ++i) {
+                detail::ChunkRowCursor cursor(i, chunk_holder);
+                _sort_heap->replace_top_if_less(std::move(cursor));
+            }
+        } else {
+            // heap was not full we need try push
+            size_t direct_push = std::min<size_t>(_number_of_rows_to_sort() - _sort_heap->size(), row_sz);
+
+            int i = 0;
+            // push data to heap if heap was not full
+            for (; i < direct_push; ++i) {
+                detail::ChunkRowCursor cursor(i, chunk_holder);
+                _sort_heap->push(std::move(cursor));
+            }
+
+            // compare to heap top and replace top
+            for (; i < row_sz; ++i) {
+                detail::ChunkRowCursor cursor(i, chunk_holder);
+                _sort_heap->replace_top_if_less(std::move(cursor));
+            }
+        }
+    }
+    // TODO: merge chunk if necessary
+    return Status::OK();
+}
+
+Status HeapChunkSorter::done(RuntimeState* state) {
+    ScopedTimer<MonotonicStopWatch> timer(_build_timer);
+    if (_sort_heap) {
+        _sorted_values = _sort_heap->sorted_seq();
+    }
+    _sort_heap.reset();
+    return Status::OK();
+}
+
+void HeapChunkSorter::get_next(ChunkPtr* chunk, bool* eos) {
+    ScopedTimer<MonotonicStopWatch> timer(_output_timer);
+
+    if (_next_output_row == _sorted_values.size()) {
+        *eos = true;
+        *chunk = nullptr;
+        return;
+    }
+
+    const size_t count = std::min(size_t(config::vector_chunk_size), _sorted_values.size() - _next_output_row);
+    chunk->reset(_sorted_values[0].data_segment()->chunk->clone_empty(count).release());
+
+    for (int i = _next_output_row; i < count + _next_output_row; ++i) {
+        auto rid = _sorted_values[i].row_id();
+        const auto& ref_chunk = _sorted_values[i].data_segment()->chunk;
+        (*chunk)->append_safe(*ref_chunk, rid, 1);
+    }
+
+    _next_output_row += count;
+}
+
+template <PrimitiveType TYPE>
+void HeapChunkSorter::_do_filter_data_for_type(detail::ChunkHolder* chunk_holder, Column::Filter* filter, int row_sz) {
+    const auto& top_cursor = _sort_heap->top();
+    const int cursor_rid = top_cursor.row_id();
+
+    const auto& top_cursor_column = top_cursor.data_segment()->order_by_columns[0];
+    const auto& input_column = chunk_holder->value()->order_by_columns[0];
+
+    DCHECK_EQ(top_cursor_column->is_nullable(), input_column->is_nullable());
+
+    if (top_cursor_column->is_nullable()) {
+        bool top_is_null = top_cursor_column->is_null(cursor_rid);
+        const auto& need_filter_data =
+                ColumnHelper::cast_to_raw<TYPE>(down_cast<NullableColumn*>(top_cursor_column.get())->data_column())
+                        ->get_data()[cursor_rid];
+
+        const auto& order_by_null_column = down_cast<NullableColumn*>(input_column.get())->null_column();
+        const auto& order_by_data_column = down_cast<NullableColumn*>(input_column.get())->data_column();
+
+        const auto* null_data = order_by_null_column->get_data().data();
+        const auto* order_by_data = ColumnHelper::cast_to_raw<TYPE>(order_by_data_column)->get_data().data();
+        auto* __restrict__ filter_data = filter->data();
+
+        for (int i = 0; i < row_sz; ++i) {
+            // data is null
+            if (null_data[i] && !top_is_null) {
+                filter_data[i] = _null_first_flag[0] * _sort_order_flag[0] < 0;
+            } else if (null_data[i] && top_is_null) {
+                // filter equal rows
+            } else if (!null_data[i] && top_is_null) {
+                filter_data[i] = _null_first_flag[0] * _sort_order_flag[0] > 0;
+            } else {
+                DCHECK(!null_data[i] && !top_is_null);
+                if (_sort_order_flag[0] > 0) {
+                    filter_data[i] = order_by_data[i] < need_filter_data;
+                } else {
+                    filter_data[i] = order_by_data[i] > need_filter_data;
+                }
+            }
+        }
+
+    } else {
+        const auto& need_filter_data = ColumnHelper::cast_to_raw<TYPE>(top_cursor_column)->get_data()[cursor_rid];
+        auto* order_by_column = ColumnHelper::cast_to_raw<TYPE>(input_column);
+
+        const auto* __restrict__ order_by_data = order_by_column->get_data().data();
+        auto* __restrict__ filter_data = filter->data();
+
+        if (_sort_order_flag[0] > 0) {
+            for (int i = 0; i < row_sz; ++i) {
+                filter_data[i] = order_by_data[i] < need_filter_data;
+            }
+        } else {
+            for (int i = 0; i < row_sz; ++i) {
+                filter_data[i] = order_by_data[i] > need_filter_data;
+            }
+        }
+    }
+}
+
+int HeapChunkSorter::_filter_data(detail::ChunkHolder* chunk_holder, int row_sz) {
+    ScopedTimer<MonotonicStopWatch> timer(_sort_filter_costs);
+    // Filter greater or equal top_cursor columns
+    const auto& top_cursor = _sort_heap->top();
+    const int cursor_rid = top_cursor.row_id();
+    const int column_sz = top_cursor.data_segment()->order_by_columns.size();
+
+    Column::Filter filter(row_sz);
+
+    // For single column special optimization
+    if (_do_filter_data) {
+        _do_filter_data(chunk_holder, &filter, row_sz);
+    } else {
+        for (int i = 0; i < row_sz; ++i) {
+            for (int j = 0; j < column_sz; ++j) {
+                int res = chunk_holder->value()->order_by_columns[j]->compare_at(
+                        i, cursor_rid, *top_cursor.data_segment()->order_by_columns[j], _null_first_flag[j]);
+                if (res != 0) {
+                    filter[i] = res * _sort_order_flag[j] < 0;
+                    break;
+                }
+            }
+        }
+    }
+    return chunk_holder->value()->chunk->filter(filter);
+}
+
+void HeapChunkSorter::setup_runtime(RuntimeProfile* profile, const std::string& parent_profile) {
+    ChunksSorter::setup_runtime(profile, parent_profile);
+    _sort_filter_costs = ADD_CHILD_TIMER(profile, "SortFilterCost", parent_profile);
+    _sort_filter_rows = ADD_COUNTER(profile, "SortFilterRows", TUnit::UNIT);
+}
+
+} // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/chunk_sorter_heapsorter.cpp
+++ b/be/src/exec/vectorized/chunk_sorter_heapsorter.cpp
@@ -192,14 +192,16 @@ void HeapChunkSorter::_do_filter_data_for_type(detail::ChunkHolder* chunk_holder
         const auto* order_by_data = ColumnHelper::cast_to_raw<TYPE>(order_by_data_column)->get_data().data();
         auto* __restrict__ filter_data = filter->data();
 
+        // null compare flag
+        int null_compare_flag = _null_first_flag[0] * _sort_order_flag[0];
         for (int i = 0; i < row_sz; ++i) {
             // data is null
             if (null_data[i] && !top_is_null) {
-                filter_data[i] = _null_first_flag[0] * _sort_order_flag[0] < 0;
+                filter_data[i] = null_compare_flag < 0;
             } else if (null_data[i] && top_is_null) {
                 // filter equal rows
             } else if (!null_data[i] && top_is_null) {
-                filter_data[i] = _null_first_flag[0] * _sort_order_flag[0] > 0;
+                filter_data[i] = null_compare_flag > 0;
             } else {
                 DCHECK(!null_data[i] && !top_is_null);
                 if (_sort_order_flag[0] > 0) {

--- a/be/src/exec/vectorized/chunk_sorter_heapsorter.h
+++ b/be/src/exec/vectorized/chunk_sorter_heapsorter.h
@@ -1,0 +1,263 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#pragma once
+
+#include <boost/smart_ptr/intrusive_ptr.hpp>
+#include <boost/smart_ptr/intrusive_ref_counter.hpp>
+#include <functional>
+#include <memory>
+
+#include "column/chunk.h"
+#include "column/vectorized_fwd.h"
+#include "exec/vectorized/chunks_sorter.h"
+#include "glog/logging.h"
+#include "runtime/primitive_type.h"
+
+namespace starrocks::vectorized {
+
+namespace detail {
+using DataSegmentPtr = std::shared_ptr<DataSegment>;
+// this class will be delete by self
+// so we made desctuctor private to avoid alloc memory in stack
+class ChunkHolder {
+public:
+    ChunkHolder(DataSegmentPtr&& ref_value) : _ref_count(0), _ref_val(std::move(ref_value)) {}
+    ChunkHolder(const ChunkHolder&) = delete;
+    void unref() noexcept {
+        DCHECK_GT(_ref_count, 0);
+        _ref_count--;
+        if (_ref_count == 0) {
+            delete this;
+        }
+    }
+    void ref() noexcept { _ref_count++; }
+
+    int ref_count() const { return _ref_count; }
+
+    DataSegmentPtr& value() { return _ref_val; }
+
+private:
+    ~ChunkHolder() noexcept = default;
+    int _ref_count;
+    DataSegmentPtr _ref_val;
+};
+
+struct ChunkRowCursor {
+public:
+    ChunkRowCursor(int row_id, ChunkHolder* holder) : _row_id(row_id), _holder(holder) { _holder->ref(); }
+    ChunkRowCursor(const ChunkRowCursor& other) {
+        _row_id = other._row_id;
+        _holder = other._holder;
+        _holder->ref();
+    }
+
+    ChunkRowCursor& operator=(const ChunkRowCursor& other) {
+        if (_holder) {
+            _holder->unref();
+        }
+        _row_id = other._row_id;
+        _holder = other._holder;
+        _holder->ref();
+        return *this;
+    }
+
+    ChunkRowCursor(ChunkRowCursor&& other) {
+        _row_id = other._row_id;
+        _holder = other._holder;
+        other._holder = nullptr;
+    }
+
+    ChunkRowCursor& operator=(ChunkRowCursor&& other) {
+        std::swap(_row_id, other._row_id);
+        std::swap(_holder, other._holder);
+        return *this;
+    }
+
+    ~ChunkRowCursor() noexcept {
+        if (_holder) {
+            _holder->unref();
+        }
+    }
+    int row_id() const { return _row_id; }
+
+    int ref_count() const { return _holder->ref_count(); }
+
+    const DataSegmentPtr& data_segment() const { return _holder->value(); }
+
+private:
+    size_t _row_id;
+    ChunkHolder* _holder;
+};
+
+template <typename T, typename Sequence, typename Compare>
+class SortingHeap {
+public:
+    SortingHeap(Compare comp) : _comp(std::move(comp)) {}
+
+    bool is_valid() const { return !_queue.empty(); }
+
+    const T& top() { return _queue.front(); }
+
+    size_t size() { return _queue.size(); }
+
+    bool empty() { return _queue.empty(); }
+
+    T& next_child() { return _queue[_next_child_index()]; }
+
+    void reserve(size_t reserve_sz) { _queue.reserve(reserve_sz); }
+
+    void replace_top(T&& new_top) {
+        *_queue.begin() = std::move(new_top);
+        update_top();
+    }
+
+    void remove_top() {
+        std::pop_heap(_queue.begin(), _queue.end(), _comp);
+        _queue.pop_back();
+    }
+
+    void push(T&& rowcur) {
+        _queue.emplace_back(std::move(rowcur));
+        std::push_heap(_queue.begin(), _queue.end(), _comp);
+    }
+
+    Sequence&& sorted_seq() {
+        std::sort_heap(_queue.begin(), _queue.end(), _comp);
+        return std::move(_queue);
+    }
+
+    Sequence& container() { return _queue; }
+
+    // replace top if val less than top()
+    void replace_top_if_less(T&& val) {
+        if (_comp(val, top())) {
+            replace_top(std::move(val));
+        }
+    }
+
+private:
+    Sequence _queue;
+    Compare _comp;
+
+    size_t _next_child_index() {
+        size_t next_idx = 0;
+        if (next_idx == 0) {
+            next_idx = 1;
+            if (_queue.size() > 2 && _comp(_queue[1], _queue[2])) ++next_idx;
+        }
+        return next_idx;
+    }
+
+    void update_top() {
+        size_t size = _queue.size();
+        if (size < 2) return;
+
+        auto begin = _queue.begin();
+
+        size_t child_idx = _next_child_index();
+        auto child_it = begin + child_idx;
+
+        /// Check if we are in order.
+        if (_comp(*child_it, *begin)) return;
+
+        auto curr_it = begin;
+        auto top(std::move(*begin));
+        do {
+            /// We are not in heap-order, swap the parent with it's largest child.
+            *curr_it = std::move(*child_it);
+            curr_it = child_it;
+
+            // recompute the child based off of the updated parent
+            child_idx = 2 * child_idx + 1;
+
+            if (child_idx >= size) break;
+
+            child_it = begin + child_idx;
+
+            if ((child_idx + 1) < size && _comp(*child_it, *(child_it + 1))) {
+                /// Right child exists and is greater than left child.
+                ++child_it;
+                ++child_idx;
+            }
+
+            /// Check if we are in order.
+        } while (!(_comp(*child_it, top)));
+        *curr_it = std::move(top);
+    }
+};
+
+struct ChunkCursorComparator {
+    ChunkCursorComparator(const int* reverse, const int* nan_direction_hint)
+            : reverse(reverse), nan_direction_hint(nan_direction_hint) {}
+
+    bool operator()(const ChunkRowCursor& lhs, const ChunkRowCursor& rhs) const {
+        size_t l_row_id = lhs.row_id();
+        size_t r_row_id = rhs.row_id();
+        int order_by_columns_sz = lhs.data_segment()->order_by_columns.size();
+        for (int i = 0; i < order_by_columns_sz; ++i) {
+            int res = lhs.data_segment()->order_by_columns[i]->compare_at(
+                    l_row_id, r_row_id, *rhs.data_segment()->order_by_columns[i].get(), nan_direction_hint[i]);
+            if (res != 0) return res * reverse[i] < 0;
+        }
+
+        return false;
+    }
+
+private:
+    // 1 or -1
+    const int* reverse;
+    const int* nan_direction_hint;
+};
+} // namespace detail
+
+class HeapChunkSorter final : public ChunksSorter {
+public:
+    using DataSegmentPtr = std::shared_ptr<DataSegment>;
+    HeapChunkSorter(const std::vector<ExprContext*>* sort_exprs, const std::vector<bool>* is_asc,
+                    const std::vector<bool>* is_null_first, size_t offset, size_t limit, size_t size_of_chunk_batch)
+            : ChunksSorter(sort_exprs, is_asc, is_null_first, size_of_chunk_batch), _offset(offset), _limit(limit) {}
+    virtual ~HeapChunkSorter() = default;
+
+    virtual Status update(RuntimeState* state, const ChunkPtr& chunk) override;
+    virtual Status done(RuntimeState* state) override;
+    virtual void get_next(ChunkPtr* chunk, bool* eos) override;
+    virtual int64_t mem_usage() const override {
+        if (_sort_heap == nullptr || _sort_heap->empty()) {
+            return 0;
+        }
+        return _sort_heap->size() * _sort_heap->top().data_segment()->mem_usage();
+    }
+    // TODO: implemnt for pipeline
+    virtual bool pull_chunk(ChunkPtr* chunk) override { return false; }
+    virtual DataSegment* get_result_data_segment() override { return nullptr; }
+    virtual uint64_t get_partition_rows() const override { return 0; }
+    virtual Permutation* get_permutation() const override { return nullptr; }
+
+    void setup_runtime(RuntimeProfile* profile, const std::string& parent_profile) override;
+
+private:
+    inline size_t _number_of_rows_to_sort() const { return _offset + _limit; }
+
+    int _filter_data(detail::ChunkHolder* chunk_holder, int row_sz);
+
+    template <PrimitiveType TYPE>
+    void _do_filter_data_for_type(detail::ChunkHolder* chunk_holder, Column::Filter* filter, int row_sz);
+
+    bool _init_status = false;
+    using CursorContainer = std::vector<detail::ChunkRowCursor>;
+    using CommonCursorSortHeap =
+            detail::SortingHeap<detail::ChunkRowCursor, CursorContainer, detail::ChunkCursorComparator>;
+
+    std::unique_ptr<CommonCursorSortHeap> _sort_heap = nullptr;
+    std::function<void(detail::ChunkHolder*, Column::Filter*, int)> _do_filter_data;
+
+    const size_t _offset;
+    const size_t _limit;
+
+    std::vector<detail::ChunkRowCursor> _sorted_values;
+
+    RuntimeProfile::Counter* _sort_filter_rows = nullptr;
+    RuntimeProfile::Counter* _sort_filter_costs = nullptr;
+};
+
+} // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/chunks_sorter.h
+++ b/be/src/exec/vectorized/chunks_sorter.h
@@ -268,6 +268,7 @@ using DataSegments = std::vector<DataSegment>;
 // Sort Chunks in memory with specified order by rules.
 class ChunksSorter {
 public:
+    static constexpr int USE_HEAP_SORTER_LIMIT_SZ = 1024;
     /**
      * Constructor.
      * @param sort_exprs     The order-by columns or columns with expresion. This sorter will use but not own the object.

--- a/be/src/exec/vectorized/chunks_sorter.h
+++ b/be/src/exec/vectorized/chunks_sorter.h
@@ -284,7 +284,7 @@ public:
                                                               const SortExecExprs& sort_exec_exprs,
                                                               const std::vector<OrderByType>& order_by_types);
 
-    void setup_runtime(RuntimeProfile* profile, const std::string& parent_timer);
+    virtual void setup_runtime(RuntimeProfile* profile, const std::string& parent_timer);
 
     // Append a Chunk for sort.
     virtual Status update(RuntimeState* state, const ChunkPtr& chunk) = 0;

--- a/be/src/exec/vectorized/topn_node.cpp
+++ b/be/src/exec/vectorized/topn_node.cpp
@@ -143,7 +143,9 @@ Status TopNNode::_consume_chunks(RuntimeState* state, ExecNode* child) {
 
     ScopedTimer<MonotonicStopWatch> timer(_sort_timer);
     if (_limit > 0) {
-        if (_limit <= 1024) {
+        // HeapChunkSorter has higher performance when sorting fewer elements,
+        // after testing we think 1024 is a good threshold
+        if (_limit <= ChunksSorter::USE_HEAP_SORTER_LIMIT_SZ) {
             _chunks_sorter =
                     std::make_unique<HeapChunkSorter>(&(_sort_exec_exprs.lhs_ordering_expr_ctxs()), &_is_asc_order,
                                                       &_is_null_first, _offset, _limit, SIZE_OF_CHUNK_FOR_TOPN);

--- a/be/src/exec/vectorized/topn_node.cpp
+++ b/be/src/exec/vectorized/topn_node.cpp
@@ -10,6 +10,7 @@
 #include "exec/pipeline/sort/local_merge_sort_source_operator.h"
 #include "exec/pipeline/sort/partition_sort_sink_operator.h"
 #include "exec/pipeline/sort/sort_context.h"
+#include "exec/vectorized/chunk_sorter_heapsorter.h"
 #include "exec/vectorized/chunks_sorter.h"
 #include "exec/vectorized/chunks_sorter_full_sort.h"
 #include "exec/vectorized/chunks_sorter_topn.h"
@@ -142,9 +143,16 @@ Status TopNNode::_consume_chunks(RuntimeState* state, ExecNode* child) {
 
     ScopedTimer<MonotonicStopWatch> timer(_sort_timer);
     if (_limit > 0) {
-        _chunks_sorter =
-                std::make_unique<ChunksSorterTopn>(&(_sort_exec_exprs.lhs_ordering_expr_ctxs()), &_is_asc_order,
-                                                   &_is_null_first, _offset, _limit, SIZE_OF_CHUNK_FOR_TOPN);
+        if (_limit <= 1024) {
+            _chunks_sorter =
+                    std::make_unique<HeapChunkSorter>(&(_sort_exec_exprs.lhs_ordering_expr_ctxs()), &_is_asc_order,
+                                                      &_is_null_first, _offset, _limit, SIZE_OF_CHUNK_FOR_TOPN);
+        } else {
+            _chunks_sorter =
+                    std::make_unique<ChunksSorterTopn>(&(_sort_exec_exprs.lhs_ordering_expr_ctxs()), &_is_asc_order,
+                                                       &_is_null_first, _offset, _limit, SIZE_OF_CHUNK_FOR_TOPN);
+        }
+
     } else {
         _chunks_sorter =
                 std::make_unique<ChunksSorterFullSort>(&(_sort_exec_exprs.lhs_ordering_expr_ctxs()), &_is_asc_order,

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -34,6 +34,7 @@ set(EXEC_FILES
         ./exec/vectorized/agg_hash_map_test.cpp
         #./exec/vectorized/csv_scanner_test.cpp
         ./exec/vectorized/chunks_sorter_test.cpp
+        ./exec/vectorized/chunks_sorter_heapsorter_test.cpp
         ./exec/vectorized/join_hash_map_test.cpp
         ./exec/vectorized/json_scanner_test.cpp
         ./exec/vectorized/hdfs_scanner_test.cpp

--- a/be/test/exec/vectorized/chunks_sorter_heapsorter_test.cpp
+++ b/be/test/exec/vectorized/chunks_sorter_heapsorter_test.cpp
@@ -1,0 +1,301 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdlib>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include "column/column_helper.h"
+#include "column/column_viewer.h"
+#include "column/datum.h"
+#include "column/vectorized_fwd.h"
+#include "common/object_pool.h"
+#include "exec/vectorized/chunk_sorter_heapsorter.h"
+#include "exprs/expr_context.h"
+#include "exprs/slot_ref.h"
+#include "runtime/primitive_type.h"
+#include "runtime/types.h"
+#include "util/defer_op.h"
+#include "util/value_generator.h"
+
+namespace starrocks::vectorized {
+
+#define APPLY_FOR_ALL_NUMBER_TYPE(M) \
+    M(TYPE_TINYINT)                  \
+    M(TYPE_SMALLINT)                 \
+    M(TYPE_INT)                      \
+    M(TYPE_BIGINT)                   \
+    M(TYPE_LARGEINT)                 \
+    M(TYPE_FLOAT)                    \
+    M(TYPE_DOUBLE)                   \
+    M(TYPE_DECIMAL32)                \
+    M(TYPE_DECIMAL64)                \
+    M(TYPE_DECIMAL128)
+
+struct HeapChunkSorterTest : public testing::Test {
+    ObjectPool _pool;
+};
+
+struct BuildOptions {
+    // use list value
+    std::vector<Datum> use_list_values;
+    // use random value
+    bool use_random_value;
+    // is nullable value
+    bool is_nullable_value;
+};
+
+template <PrimitiveType TYPE>
+struct ColumnRandomAppender {
+    static bool append(ColumnPtr& col, int sz) {
+        auto* spec_col = ColumnHelper::cast_to_raw<TYPE>(col);
+        if constexpr (isArithmeticPT<TYPE>) {
+            auto& container = spec_col->get_data();
+            container.resize(sz);
+            for (int i = 0; i < sz; ++i) {
+                container[i] = RandomGenerator<RunTimeCppType<TYPE>, 10000000>::next_value();
+            }
+            return true;
+        } else {
+            return false;
+        }
+    }
+};
+
+template <template <PrimitiveType, typename... Args> typename Function, typename... Args>
+void dispatch_function(PrimitiveType type, Args&&... args) {
+    bool result = false;
+    switch (type) {
+#define M(NAME)                                                                      \
+    case PrimitiveType::NAME: {                                                      \
+        result = Function<PrimitiveType::NAME>::append(std::forward<Args>(args)...); \
+        break;                                                                       \
+    }
+        APPLY_FOR_ALL_NUMBER_TYPE(M)
+#undef M
+    default:
+        break;
+    }
+    DCHECK(result) << "not support function call for type:" << type;
+}
+
+// depends rand
+struct FakeChunks {
+    FakeChunks(ObjectPool* pool, std::vector<TypeDescriptor*> descs, std::vector<BuildOptions> build_options) {
+        _pool = pool;
+        _type_descs = std::move(descs);
+        _build_options = std::move(build_options);
+
+        for (int i = 0; i < _type_descs.size(); ++i) {
+            _slot_refs.push_back(pool->add(new SlotRef(*_type_descs[i], 0, i)));
+        }
+
+        map.init(_type_descs.size() * 2);
+
+        for (int i = 0; i < _type_descs.size(); ++i) {
+            map[i] = i;
+        }
+    }
+
+    ChunkPtr next_chunk(int chunk_sz) {
+        Columns columns;
+        for (int i = 0; i < _slot_refs.size(); ++i) {
+            columns.push_back(ColumnHelper::create_column(*_type_descs[i], _build_options[i].is_nullable_value));
+        }
+        for (int i = 0; i < _slot_refs.size(); ++i) {
+            const auto& build_option = _build_options[i];
+            if (build_option.use_random_value) {
+                if (!build_option.use_list_values.empty()) {
+                    for (int j = 0; j < chunk_sz; ++j) {
+                        int k = rand() % build_option.use_list_values.size();
+                        columns[i]->append_datum(build_option.use_list_values[k]);
+                    }
+                } else {
+                    dispatch_function<ColumnRandomAppender>(_type_descs[i]->type, columns[i], chunk_sz);
+                }
+            } else {
+                if (build_option.use_list_values.size() >= chunk_sz) {
+                    for (int j = 0; j < chunk_sz; ++j) {
+                        columns[i]->append_datum(build_option.use_list_values[j]);
+                    }
+                } else {
+                    __builtin_unreachable();
+                }
+            }
+        }
+        return std::make_shared<Chunk>(columns, map);
+    }
+    const std::vector<SlotRef*>& slot_refs() { return _slot_refs; }
+
+private:
+    ObjectPool* _pool;
+    std::vector<TypeDescriptor*> _type_descs;
+    std::vector<BuildOptions> _build_options;
+    std::vector<SlotRef*> _slot_refs;
+    butil::FlatMap<SlotId, size_t> map;
+};
+
+TEST_F(HeapChunkSorterTest, single_column_order_by_notnull_test) {
+    std::vector<bool> is_asc = {true};
+    std::vector<bool> null_first = {true};
+
+    {
+        // clang-format off
+        std::vector<TypeDescriptor*> type_descs = {_pool.add(new TypeDescriptor(TYPE_INT)),
+                                                   _pool.add(new TypeDescriptor(TYPE_VARCHAR))};
+        std::vector<BuildOptions> build_options = {
+            {{}, true, false},
+            {{Slice("value1"), Slice("value2"), Slice("value3")}, true, false}
+        };
+        // clang-format on
+
+        srand(0);
+        FakeChunks fake_chunks(&_pool, type_descs, build_options);
+
+        // Test sort by INT less than limit
+        {
+            std::vector<ExprContext*> sort_exprs;
+            sort_exprs.push_back(_pool.add(new ExprContext(fake_chunks.slot_refs()[0])));
+            HeapChunkSorter sorter(&sort_exprs, &is_asc, &null_first, 0, 1024, 1024);
+            sorter.setup_runtime(_pool.add(new RuntimeProfile("")), "");
+            sorter.update(nullptr, fake_chunks.next_chunk(1024));
+            sorter.done(nullptr);
+
+            ChunkPtr chunk;
+            bool eos = false;
+            sorter.get_next(&chunk, &eos);
+            ASSERT_EQ(chunk->num_rows(), 1024);
+            auto column = chunk->get_column_by_slot_id(0);
+            auto* i32_col = ColumnHelper::cast_to_raw<TYPE_INT>(column);
+            const auto& i32_data = i32_col->get_data();
+            ASSERT_TRUE(std::is_sorted(i32_data.begin(), i32_data.end()));
+        }
+        // Test sort by INT greater than limit
+        {
+            std::vector<ExprContext*> sort_exprs;
+            sort_exprs.push_back(_pool.add(new ExprContext(fake_chunks.slot_refs()[0])));
+            HeapChunkSorter sorter(&sort_exprs, &is_asc, &null_first, 0, 1024, 1024);
+            sorter.setup_runtime(_pool.add(new RuntimeProfile("")), "");
+            sorter.update(nullptr, fake_chunks.next_chunk(1023));
+            sorter.update(nullptr, fake_chunks.next_chunk(1023));
+            sorter.done(nullptr);
+
+            ChunkPtr chunk;
+            bool eos = false;
+            sorter.get_next(&chunk, &eos);
+            ASSERT_EQ(chunk->num_rows(), 1024);
+            auto column = chunk->get_column_by_slot_id(0);
+            auto* i32_col = ColumnHelper::cast_to_raw<TYPE_INT>(column);
+            const auto& i32_data = i32_col->get_data();
+            ASSERT_TRUE(std::is_sorted(i32_data.begin(), i32_data.end()));
+            sorter.get_next(&chunk, &eos);
+            ASSERT_TRUE(eos);
+        }
+        // Test sort by VARCHAR
+        {
+            std::vector<ExprContext*> sort_exprs;
+            sort_exprs.push_back(_pool.add(new ExprContext(fake_chunks.slot_refs()[1])));
+            HeapChunkSorter sorter(&sort_exprs, &is_asc, &null_first, 0, 1024, 1024);
+            sorter.setup_runtime(_pool.add(new RuntimeProfile("")), "");
+            sorter.update(nullptr, fake_chunks.next_chunk(1024));
+            sorter.update(nullptr, fake_chunks.next_chunk(1023));
+            sorter.done(nullptr);
+
+            ChunkPtr chunk;
+            bool eos = false;
+            sorter.get_next(&chunk, &eos);
+            auto column = chunk->get_column_by_slot_id(1);
+            auto* slice_col = ColumnHelper::cast_to_raw<TYPE_VARCHAR>(column);
+            const auto& slice_data = slice_col->get_data();
+            ASSERT_TRUE(std::is_sorted(slice_data.begin(), slice_data.end()));
+        }
+    }
+}
+
+TEST_F(HeapChunkSorterTest, single_column_order_by_nullable_test) {
+    {
+        std::vector<bool> is_asc = {true};
+        std::vector<bool> null_first = {true};
+
+        std::vector<TypeDescriptor*> type_descs = {_pool.add(new TypeDescriptor(TYPE_INT))};
+        std::vector<BuildOptions> build_options = {{{5, 2, 5, 3, 1, 4, 7, 8, 3, 9}, false, true}};
+        build_options[0].use_list_values[1].set_null();
+        srand(0);
+        FakeChunks fake_chunks(&_pool, type_descs, build_options);
+
+        {
+            std::vector<ExprContext*> sort_exprs;
+            sort_exprs.push_back(_pool.add(new ExprContext(fake_chunks.slot_refs()[0])));
+            // limit 5
+            int limit_sz = 5;
+            HeapChunkSorter sorter(&sort_exprs, &is_asc, &null_first, 0, limit_sz, 1024);
+            sorter.setup_runtime(_pool.add(new RuntimeProfile("")), "");
+            sorter.update(nullptr, fake_chunks.next_chunk(10));
+            sorter.done(nullptr);
+
+            ChunkPtr chunk;
+            bool eos = false;
+            sorter.get_next(&chunk, &eos);
+            auto column = chunk->get_column_by_slot_id(0);
+            ColumnViewer<TYPE_INT> viewer(column);
+            ASSERT_TRUE(viewer.is_null(0));
+            const auto& container = viewer.column()->get_data();
+            const auto& null_container = viewer.null_column()->get_data();
+            ASSERT_TRUE(std::all_of(null_container.begin() + 1, null_container.end(), [](auto v) { return !v; }));
+            ASSERT_TRUE(std::is_sorted(container.begin() + 1, container.end()));
+        }
+
+        null_first[0] = false;
+        {
+            std::vector<ExprContext*> sort_exprs;
+            sort_exprs.push_back(_pool.add(new ExprContext(fake_chunks.slot_refs()[0])));
+            // limit 5
+            int limit_sz = 10;
+            HeapChunkSorter sorter(&sort_exprs, &is_asc, &null_first, 0, limit_sz, 1024);
+            sorter.setup_runtime(_pool.add(new RuntimeProfile("")), "");
+            sorter.update(nullptr, fake_chunks.next_chunk(10));
+            sorter.done(nullptr);
+
+            ChunkPtr chunk;
+            bool eos = false;
+            sorter.get_next(&chunk, &eos);
+            auto column = chunk->get_column_by_slot_id(0);
+            ColumnViewer<TYPE_INT> viewer(column);
+            ASSERT_TRUE(viewer.is_null(viewer.size() - 1));
+            const auto& container = viewer.column()->get_data();
+            const auto& null_container = viewer.null_column()->get_data();
+            ASSERT_TRUE(std::all_of(null_container.begin(), null_container.end() - 1, [](auto v) { return !v; }));
+            ASSERT_TRUE(std::is_sorted(container.begin(), container.end() - 1));
+        }
+
+        is_asc[0] = false;
+        null_first[0] = true;
+        {
+            std::vector<ExprContext*> sort_exprs;
+            sort_exprs.push_back(_pool.add(new ExprContext(fake_chunks.slot_refs()[0])));
+            // limit 5
+            int limit_sz = 5;
+            HeapChunkSorter sorter(&sort_exprs, &is_asc, &null_first, 0, limit_sz, 1024);
+            sorter.setup_runtime(_pool.add(new RuntimeProfile("")), "");
+            sorter.update(nullptr, fake_chunks.next_chunk(10));
+            sorter.done(nullptr);
+
+            ChunkPtr chunk;
+            bool eos = false;
+            sorter.get_next(&chunk, &eos);
+            auto column = chunk->get_column_by_slot_id(0);
+            ColumnViewer<TYPE_INT> viewer(column);
+            ASSERT_TRUE(viewer.is_null(0));
+            const auto& container = viewer.column()->get_data();
+            const auto& null_container = viewer.null_column()->get_data();
+            ASSERT_TRUE(std::all_of(null_container.begin() + 1, null_container.end(), [](auto v) { return !v; }));
+            ASSERT_TRUE(std::is_sorted(container.begin() + 1, container.end(), std::greater<int32_t>()));
+        }
+    }
+}
+
+} // namespace starrocks::vectorized


### PR DESCRIPTION
use heap sort and sort filter optimize topn sorting

here is my test result:
dataset ssb_100g:


```SQL
SELECT LO_ORDERKEY, LO_REVENUE FROM ssb_100g.lineorder_flat ORDER BY LO_REVENUE LIMIT $limit;
```

| limit | parallel | new  | old  |
| ----- | -------- | ---- | ---- |
| 10    | 8        | 0.16 | 0.37 |
| 10    | 16       | 0.16 | 0.35 |
| 100   | 8        | 0.16 | 0.42 |
| 100   | 16       | 0.16 | 0.40 |
| 1000  | 8        | 0.18 | 0.42 |
| 1000  | 16       | 0.18 | 0.37 |

```SQL
SELECT LO_ORDERKEY, $column FROM ssb_100g.lineorder_flat ORDER BY $column LIMIT 100;
```

| column        | parallel | new  | old  |
| ------------- | -------- | ---- | ---- |
| p_container   | 8        | 0.65 | 0.94 |
| c_phone       | 8        | 0.54 | 0.75 |
| lo_orderkey   | 8        | 0.12 | 0.40 |
| lo_supplycost | 8        | 0.17 | 0.41 |

```sql
select LO_ORDERKEY, $column FROM ssb_100g.lineorder_flat order by LO_ORDERKEY, $column
```

| column        | parallel | new  | old  |
| ------------- | -------- | ---- | ---- |
| p_container   | 8        | 0.41 | 0.52 |
| c_phone       | 8        | 0.39 | 0.53 |
| lo_supplycost | 8        | 0.30 | 0.43 |

