### PR TITLE
BugFix: Fix Be crash while doing schema change

### DIFF
--- a/be/src/storage/vectorized/schema_change.cpp
+++ b/be/src/storage/vectorized/schema_change.cpp
@@ -336,7 +336,7 @@ bool ChunkChanger::change_chunk(ChunkPtr& base_chunk, ChunkPtr& new_chunk, Table
 
             if (new_type == ref_type && (!is_decimalv3_field_type(new_type) ||
                                          (reftype_precision == newtype_precision && reftype_scale == newtype_scale))) {
-                if (new_type == OLAP_FIELD_TYPE_CHAR) {
+                if (new_type == OLAP_FIELD_TYPE_CHAR || (new_col->is_nullable() ^ base_col->is_nullable())) {
                     for (size_t row_index = 0; row_index < base_chunk->num_rows(); ++row_index) {
                         Datum base_datum = base_col->get(row_index);
                         Datum new_datum;

--- a/be/src/storage/vectorized/schema_change.cpp
+++ b/be/src/storage/vectorized/schema_change.cpp
@@ -336,7 +336,7 @@ bool ChunkChanger::change_chunk(ChunkPtr& base_chunk, ChunkPtr& new_chunk, Table
 
             if (new_type == ref_type && (!is_decimalv3_field_type(new_type) ||
                                          (reftype_precision == newtype_precision && reftype_scale == newtype_scale))) {
-                if (new_type == OLAP_FIELD_TYPE_CHAR || (new_col->is_nullable() != base_col->is_nullable())) {
+                if (new_type == OLAP_FIELD_TYPE_CHAR) {
                     for (size_t row_index = 0; row_index < base_chunk->num_rows(); ++row_index) {
                         Datum base_datum = base_col->get(row_index);
                         Datum new_datum;
@@ -350,12 +350,18 @@ bool ChunkChanger::change_chunk(ChunkPtr& base_chunk, ChunkPtr& new_chunk, Table
                         Slice slice;
                         slice.size = new_tablet->tablet_meta()->tablet_schema().column(i).length();
                         slice.data = reinterpret_cast<char*>(mem_pool->allocate(slice.size));
+                        if (slice.data == nullptr) {
+                            LOG(WARNING) << "failed to allocate memory in mem_pool";
+                            return false;
+                        }
                         memset(slice.data, 0, slice.size);
                         size_t copy_size = slice.size < base_slice.size ? slice.size : base_slice.size;
                         memcpy(slice.data, base_slice.data, copy_size);
                         new_datum.set(slice);
                         new_col->append_datum(new_datum);
                     }
+                } else if (new_col->is_nullable() != base_col->is_nullable()) {
+                    new_col->append(*base_col.get());
                 } else {
                     new_col = base_col;
                 }

--- a/be/src/storage/vectorized/schema_change.cpp
+++ b/be/src/storage/vectorized/schema_change.cpp
@@ -336,7 +336,7 @@ bool ChunkChanger::change_chunk(ChunkPtr& base_chunk, ChunkPtr& new_chunk, Table
 
             if (new_type == ref_type && (!is_decimalv3_field_type(new_type) ||
                                          (reftype_precision == newtype_precision && reftype_scale == newtype_scale))) {
-                if (new_type == OLAP_FIELD_TYPE_CHAR || (new_col->is_nullable() ^ base_col->is_nullable())) {
+                if (new_type == OLAP_FIELD_TYPE_CHAR || (new_col->is_nullable() != base_col->is_nullable())) {
                     for (size_t row_index = 0; row_index < base_chunk->num_rows(); ++row_index) {
                         Datum base_datum = base_col->get(row_index);
                         Datum new_datum;


### PR DESCRIPTION
Add a check for consistency between the nullable of the new column and the old column when doing schema_change
If nullable is inconsistent, new column can not be assigned as old column directly
close https://github.com/StarRocks/starrocks/issues/1296