### PR TITLE
[pipeline] Remove Chunks' Reuse for repeat operator

### DIFF
--- a/be/src/exec/pipeline/aggregate/repeat/repeat_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/repeat/repeat_operator.cpp
@@ -3,6 +3,7 @@
 #include "exec/pipeline/aggregate/repeat/repeat_operator.h"
 
 #include "column/chunk.h"
+#include "exec/exec_node.h"
 #include "runtime/descriptors.h"
 
 namespace starrocks::pipeline {
@@ -32,6 +33,7 @@ StatusOr<vectorized::ChunkPtr> RepeatOperator::pull_chunk(RuntimeState* state) {
     ChunkPtr curr_chunk = _curr_chunk->clone_empty(_curr_chunk->num_rows());
     curr_chunk->append_safe(*_curr_chunk, 0, _curr_chunk->num_rows());
     extend_and_update_columns(&curr_chunk);
+    ExecNode::eval_conjuncts(_conjunct_ctxs, curr_chunk.get());
     return curr_chunk;
 }
 

--- a/be/src/exec/pipeline/aggregate/repeat/repeat_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/repeat/repeat_operator.cpp
@@ -29,67 +29,28 @@ bool RepeatOperator::has_output() const {
 }
 
 StatusOr<vectorized::ChunkPtr> RepeatOperator::pull_chunk(RuntimeState* state) {
-    if (_repeat_times_last > 0) {
-        Columns columns = _curr_columns;
-        // get a suitable chunk.
-        _curr_chunk->set_columns(columns);
+    ChunkPtr curr_chunk = _curr_chunk->clone_empty(_curr_chunk->num_rows());
+    curr_chunk->append_safe(*_curr_chunk, 0, _curr_chunk->num_rows());
+    extend_and_update_columns(&curr_chunk);
+    return curr_chunk;
+}
 
-        // unneed to extend, because columns has been extended at first access.
-        // update virtual columns for grouping_id and grouping()/grouping_id() columns.
-        for (int i = 0; i < _grouping_list.size(); ++i) {
-            // _grouping_columns needs to be referenced more than once, so it cannot be moved.
-            auto grouping_column =
-                    (_curr_chunk->num_rows() == config::vector_chunk_size)
-                            ? _grouping_columns[i][_repeat_times_last]
-                            : generate_repeat_column(_grouping_list[i][_repeat_times_last], _curr_chunk->num_rows());
+void RepeatOperator::extend_and_update_columns(ChunkPtr* curr_chunk) {
+    // extend virtual columns for gourping_id and grouping()/grouping_id() columns.
+    for (int i = 0; i < _grouping_list.size(); ++i) {
+        auto grouping_column = generate_repeat_column(_grouping_list[i][_repeat_times_last], (*curr_chunk)->num_rows());
 
-            _curr_chunk->update_column(grouping_column, _tuple_desc->slots()[i]->id());
-        }
-
-        // update columns for unneed columns.
-        const std::vector<SlotId>& null_slot_ids = _null_slot_ids[_repeat_times_last];
-        for (auto slot_id : null_slot_ids) {
-            // _column_null needs to be referenced more than once, so it cannot be moved.
-            auto null_column = (_curr_chunk->num_rows() == config::vector_chunk_size)
-                                       ? _column_null
-                                       : ColumnHelper::create_const_null_column(_curr_chunk->num_rows());
-
-            _curr_chunk->update_column(null_column, slot_id);
-        }
-
-        // tranform to the next.
-        ++_repeat_times_last;
-        return _curr_chunk;
-    } else {
-        // extend virtual columns for grouping_id and grouping()/grouping_id() columns.
-        for (int i = 0; i < _grouping_list.size(); ++i) {
-            // _grouping_columns needs to be referenced more than once, so it cannot be moved.
-            auto grouping_column =
-                    (_curr_chunk->num_rows() == config::vector_chunk_size)
-                            ? _grouping_columns[i][_repeat_times_last]
-                            : generate_repeat_column(_grouping_list[i][_repeat_times_last], _curr_chunk->num_rows());
-
-            _curr_chunk->append_column(grouping_column, _tuple_desc->slots()[i]->id());
-        }
-
-        // save original exgtended columns.
-        _curr_columns = _curr_chunk->columns();
-
-        // update columns for unneed columns.
-        const std::vector<SlotId>& null_slot_ids = _null_slot_ids[_repeat_times_last];
-        for (auto slot_id : null_slot_ids) {
-            // _column_null needs to be referenced more than once, so it cannot be moved.
-            auto null_column = (_curr_chunk->num_rows() == config::vector_chunk_size)
-                                       ? _column_null
-                                       : ColumnHelper::ColumnHelper::create_const_null_column(_curr_chunk->num_rows());
-
-            _curr_chunk->update_column(null_column, slot_id);
-        }
-
-        // tranform to the next.
-        ++_repeat_times_last;
-        return _curr_chunk;
+        (*curr_chunk)->append_column(grouping_column, _tuple_desc->slots()[i]->id());
     }
+
+    // update columns for unneed columns.
+    const std::vector<SlotId>& null_slot_ids = _null_slot_ids[_repeat_times_last];
+    for (auto slot_id : null_slot_ids) {
+        auto null_column = ColumnHelper::create_const_null_column((*curr_chunk)->num_rows());
+
+        (*curr_chunk)->update_column(null_column, slot_id);
+    }
+    ++_repeat_times_last;
 }
 
 Status RepeatOperator::push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) {

--- a/be/src/exec/pipeline/aggregate/repeat/repeat_operator.h
+++ b/be/src/exec/pipeline/aggregate/repeat/repeat_operator.h
@@ -55,6 +55,8 @@ private:
         return ConstColumn::create(column, num_rows);
     }
 
+    void extend_and_update_columns(vectorized::ChunkPtr* curr_chunk);
+
     /*
      * _curr_chunk
      * _curr_columns
@@ -62,8 +64,6 @@ private:
      */
     // accessing chunk.
     ChunkPtr _curr_chunk;
-    // original columns for accessing chunk.
-    Columns _curr_columns;
 
     /*
      * _slot_id_set_list

--- a/be/src/exec/pipeline/aggregate/repeat/repeat_operator.h
+++ b/be/src/exec/pipeline/aggregate/repeat/repeat_operator.h
@@ -6,6 +6,7 @@
 #include "column/vectorized_fwd.h"
 #include "common/global_types.h"
 #include "exec/pipeline/operator.h"
+#include "exprs/expr_context.h"
 
 namespace starrocks {
 class TupleDescriptor;
@@ -19,7 +20,7 @@ public:
                    uint64_t repeat_times_last, const ColumnPtr& column_null,
                    const std::vector<std::vector<ColumnPtr>>& grouping_columns,
                    const std::vector<std::vector<int64_t>>& grouping_list, const TupleId& output_tuple_id,
-                   const TupleDescriptor* tuple_desc)
+                   const TupleDescriptor* tuple_desc, const std::vector<ExprContext*>& conjunct_ctxs)
             : Operator(id, "repeat", plan_node_id),
               _slot_id_set_list(slot_id_set_list),
               _all_slot_ids(all_slot_ids),
@@ -31,7 +32,8 @@ public:
               _grouping_columns(grouping_columns),
               _grouping_list(grouping_list),
               _output_tuple_id(output_tuple_id),
-              _tuple_desc(tuple_desc) {}
+              _tuple_desc(tuple_desc),
+              _conjunct_ctxs(conjunct_ctxs) {}
     ~RepeatOperator() override = default;
 
     bool has_output() const override;
@@ -105,6 +107,8 @@ private:
     const TupleId& _output_tuple_id;
     const TupleDescriptor* _tuple_desc;
 
+    // used for expr's compute.
+    const std::vector<ExprContext*>& _conjunct_ctxs;
     // Whether prev operator has no output
     bool _is_finished = false;
 };
@@ -117,7 +121,7 @@ public:
                           uint64_t repeat_times_last, ColumnPtr&& column_null,
                           std::vector<std::vector<ColumnPtr>>&& grouping_columns,
                           std::vector<std::vector<int64_t>>&& grouping_list, TupleId&& output_tuple_id,
-                          const TupleDescriptor* tuple_desc)
+                          const TupleDescriptor* tuple_desc, std::vector<ExprContext*>&& conjunct_ctxs)
             : OperatorFactory(id, "repeat", plan_node_id),
               _slot_id_set_list(std::move(slot_id_set_list)),
               _all_slot_ids(std::move(all_slot_ids)),
@@ -129,7 +133,8 @@ public:
               _grouping_columns(std::move(grouping_columns)),
               _grouping_list(std::move(grouping_list)),
               _output_tuple_id(std::move(output_tuple_id)),
-              _tuple_desc(tuple_desc) {}
+              _tuple_desc(tuple_desc),
+              _conjunct_ctxs(std::move(conjunct_ctxs)) {}
 
     ~RepeatOperatorFactory() override = default;
 
@@ -137,7 +142,7 @@ public:
         return std::make_shared<RepeatOperator>(_id, _plan_node_id, _slot_id_set_list, _all_slot_ids, _null_slot_ids,
                                                 _repeat_id_list, _repeat_times_required, _repeat_times_last,
                                                 _column_null, _grouping_columns, _grouping_list, _output_tuple_id,
-                                                _tuple_desc);
+                                                _tuple_desc, _conjunct_ctxs);
     }
 
 private:
@@ -153,6 +158,7 @@ private:
     std::vector<std::vector<int64_t>> _grouping_list;
     TupleId _output_tuple_id;
     const TupleDescriptor* _tuple_desc;
+    std::vector<ExprContext*> _conjunct_ctxs;
 };
 } // namespace pipeline
 } // namespace starrocks

--- a/be/src/exec/vectorized/repeat_node.cpp
+++ b/be/src/exec/vectorized/repeat_node.cpp
@@ -203,7 +203,7 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > RepeatNode::decompose_t
             context->next_operator_id(), id(), std::move(_slot_id_set_list), std::move(_all_slot_ids),
             std::move(_null_slot_ids), std::move(_repeat_id_list), _repeat_times_required, _repeat_times_last,
             std::move(_column_null), std::move(_grouping_columns), std::move(_grouping_list),
-            std::move(_output_tuple_id), _tuple_desc));
+            std::move(_output_tuple_id), _tuple_desc, std::move(_conjunct_ctxs)));
 
     return operators;
 }


### PR DESCRIPTION
In some cases, because the later predicate logic may modify the input data, the reuse of column data should be cancelled.

as in https://github.com/StarRocks/starrocks/pull/934