### PR TITLE
Fix local aggregate use wrong BackendSelector

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
@@ -1,6 +1,8 @@
 package com.starrocks.sql.plan;
 
 import com.starrocks.common.FeConstants;
+import com.starrocks.common.Pair;
+import com.starrocks.planner.AggregationNode;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -594,12 +596,23 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
         Assert.assertTrue(plan.contains("4:AGGREGATE (merge finalize)"));
     }
 
-
     @Test
     public void testColumnNotEqualsConstant() throws Exception {
-        String sql = "select S_SUPPKEY,S_NAME from supplier where s_name <> 'Supplier#000000050' and s_name >= 'Supplier#000000086'";
+        String sql =
+                "select S_SUPPKEY,S_NAME from supplier where s_name <> 'Supplier#000000050' and s_name >= 'Supplier#000000086'";
         String plan = getCostExplain(sql);
         // check cardinality not 0
         Assert.assertTrue(plan.contains("cardinality: 500000"));
+    }
+
+    @Test
+    public void testLocalAggregationUponJoin() throws Exception {
+        // check that local aggregation is set colocate which upon join with colocate table
+        String sql = "select tbl5.c2,sum(tbl5.c3) from db1.tbl5 join[broadcast] db1.tbl4 on tbl5.c2 = tbl4.c2 group by tbl5.c2;";
+        Pair<String, ExecPlan> pair = UtFrameUtils.getPlanAndFragment(connectContext, sql);
+        ExecPlan execPlan = pair.second;
+        Assert.assertTrue(execPlan.getFragments().get(1).getPlanRoot() instanceof AggregationNode);
+        AggregationNode aggregationNode = (AggregationNode) execPlan.getFragments().get(1).getPlanRoot();
+        Assert.assertTrue(aggregationNode.isColocate());
     }
 }


### PR DESCRIPTION
ref #1308 
Explain :

```
mysql> explain select ast.uid as agent_id, sum(ast.card_count) as card_total from  tbl_agent_day_statistics ast inner join[broadcast] tbl_tjpt_agent_info ap on ap.uid = ast.uid group by ast.uid;
+-------------------------------------------------------------------------------------------+
| Explain String                                                                            |
+-------------------------------------------------------------------------------------------+
| PLAN FRAGMENT 0                                                                           |
|  OUTPUT EXPRS:1: uid | 75: sum(4: card_count)                                             |
|   PARTITION: UNPARTITIONED                                                                |
|                                                                                           |
|   RESULT SINK                                                                             |
|                                                                                           |
|   6:EXCHANGE                                                                              |
|      use vectorized: true                                                                 |
|                                                                                           |
| PLAN FRAGMENT 1                                                                           |
|  OUTPUT EXPRS:                                                                            |
|   PARTITION: RANDOM                                                                       |
|                                                                                           |
|   STREAM DATA SINK                                                                        |
|     EXCHANGE ID: 06                                                                       |
|     UNPARTITIONED                                                                         |
|                                                                                           |
|   5:AGGREGATE (update finalize)                                                           |
|   |  output: sum(4: card_count)                                                           |
|   |  group by: 1: uid                                                                     |
|   |  use vectorized: true                                                                 |
|   |                                                                                       |
|   4:Project                                                                               |
|   |  <slot 1> : 1: uid                                                                    |
|   |  <slot 4> : 4: card_count                                                             |
|   |  use vectorized: true                                                                 |
|   |                                                                                       |
|   3:HASH JOIN                                                                             |
|   |  join op: INNER JOIN (BROADCAST)                                                      |
|   |  hash predicates:                                                                     |
|   |  colocate: false, reason:                                                             |
|   |  equal join conjunct: 1: uid = 40: uid                                                |
|   |  use vectorized: true                                                                 |
|   |                                                                                       |
|   |----2:EXCHANGE                                                                         |
|   |       use vectorized: true                                                            |
|   |                                                                                       |
|   0:OlapScanNode                                                                          |
|      TABLE: tbl_agent_day_statistics                                                      |
|      PREAGGREGATION: ON                                                                   |
|      partitions=4/72                                                                      |
|      rollup: tbl_agent_day_statistics                                                     |
|      tabletRatio=48/48                                                                    |
|      tabletList=697700,697702,697704,697706,697708,697710,697712,697714,697716,697718 ... |
|      cardinality=1                                                                        |
|      avgRowSize=2.0                                                                       |
|      numNodes=0                                                                           |
|      use vectorized: true                                                                 |
|                                                                                           |
| PLAN FRAGMENT 2                                                                           |
|  OUTPUT EXPRS:                                                                            |
|   PARTITION: RANDOM                                                                       |
|                                                                                           |
|   STREAM DATA SINK                                                                        |
|     EXCHANGE ID: 02                                                                       |
|     UNPARTITIONED                                                                         |
|                                                                                           |
|   1:OlapScanNode                                                                          |
|      TABLE: tbl_tjpt_agent_info                                                           |
|      PREAGGREGATION: ON                                                                   |
|      partitions=1/1                                                                       |
|      rollup: tbl_tjpt_agent_info                                                          |
|      tabletRatio=12/12                                                                    |
|      tabletList=699075,699077,699079,699081,699083,699085,699087,699089,699091,699093 ... |
|      cardinality=1                                                                        |
|      avgRowSize=1.0                                                                       |
|      numNodes=0                                                                           |
|      use vectorized: true                                                                 |
+-------------------------------------------------------------------------------------------+
```

Local Aggregate is upon hash join node, which is not consider in PlanFragmentBuilder, aggregationNode should set colocate in order to use ColocateBackendSelector in Coordinator