### PR TITLE
[pipeline] fix: exchange sink should send EOS after all channels of a fragment are EOS

### DIFF
--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -178,7 +178,7 @@ Status ExchangeSinkOperator::Channel::send_one_chunk(const vectorized::Chunk* ch
         _chunk_request->set_eos(eos);
         butil::IOBuf attachment;
         _parent->construct_brpc_attachment(_chunk_request, attachment);
-        TransmitChunkInfo info = {this->_channel_id, _brpc_stub, std::move(_chunk_request), attachment};
+        TransmitChunkInfo info = {this->_fragment_instance_id, _brpc_stub, std::move(_chunk_request), attachment};
         _parent->_buffer->add_request(info);
         _current_request_bytes = 0;
         _chunk_request.reset();
@@ -196,7 +196,7 @@ Status ExchangeSinkOperator::Channel::send_chunk_request(PTransmitChunkParamsPtr
     chunk_request->set_be_number(_parent->_be_number);
     chunk_request->set_eos(false);
 
-    TransmitChunkInfo info = {this->_channel_id, _brpc_stub, std::move(chunk_request), attachment};
+    TransmitChunkInfo info = {this->_fragment_instance_id, _brpc_stub, std::move(chunk_request), attachment};
     _parent->_buffer->add_request(info);
 
     return Status::OK();

--- a/be/src/exec/pipeline/exchange/sink_buffer.h
+++ b/be/src/exec/pipeline/exchange/sink_buffer.h
@@ -18,6 +18,9 @@ namespace starrocks::pipeline {
 using PTransmitChunkParamsPtr = std::shared_ptr<PTransmitChunkParams>;
 
 struct TransmitChunkInfo {
+    // For BUCKET_SHFFULE_HASH_PARTITIONED, multiple channels may be related to
+    // a same exchange source fragment instance, so we should use fragment_instance_id
+    // of the destination as the key of destination instead of channel_id.
     TUniqueId fragment_instance_id;
     doris::PBackendService_Stub* brpc_stub;
     PTransmitChunkParamsPtr params;

--- a/be/src/exec/pipeline/exchange/sink_buffer.h
+++ b/be/src/exec/pipeline/exchange/sink_buffer.h
@@ -18,7 +18,7 @@ namespace starrocks::pipeline {
 using PTransmitChunkParamsPtr = std::shared_ptr<PTransmitChunkParams>;
 
 struct TransmitChunkInfo {
-    size_t channel_id;
+    TUniqueId fragment_instance_id;
     doris::PBackendService_Stub* brpc_stub;
     PTransmitChunkParamsPtr params;
     butil::IOBuf attachment;
@@ -26,27 +26,39 @@ struct TransmitChunkInfo {
 
 class SinkBuffer {
 public:
-    SinkBuffer(MemTracker* mem_tracker, size_t channel_number, size_t num_sinkers)
-            : _mem_tracker(mem_tracker), _num_sinkers_per_channel(channel_number, num_sinkers) {
-        for (size_t i = 0; i < channel_number; ++i) {
-            auto* closure = new CallBackClosure<PTransmitChunkResult>();
-            closure->ref();
-            closure->addFailedHandler([this]() noexcept {
-                _in_flight_rpc_num--;
-                _is_cancelled = true;
-                LOG(WARNING) << " transmit chunk rpc failed";
-            });
-            closure->addSuccessHandler([this](const PTransmitChunkResult& result) noexcept {
-                _in_flight_rpc_num--;
-                Status status(result.status());
-                if (!status.ok()) {
+    SinkBuffer(MemTracker* mem_tracker, const std::vector<TPlanFragmentDestination>& destinations, size_t num_sinkers)
+            : _mem_tracker(mem_tracker) {
+        for (const auto& dest : destinations) {
+            const auto& dest_instance_id = dest.fragment_instance_id;
+
+            auto it = _num_sinkers_per_dest_instance.find(dest_instance_id);
+            if (it != _num_sinkers_per_dest_instance.end()) {
+                it->second += num_sinkers;
+            } else {
+                _num_sinkers_per_dest_instance[dest_instance_id] = num_sinkers;
+
+                // This dest_instance_id first occurs, so create closure and buffer for it.
+                auto* closure = new CallBackClosure<PTransmitChunkResult>();
+                closure->ref();
+                closure->addFailedHandler([this]() noexcept {
+                    _in_flight_rpc_num--;
                     _is_cancelled = true;
-                    LOG(WARNING) << " transmit chunk rpc failed, " << status.message();
-                }
-            });
-            _closures.push_back(closure);
-            _buffers.emplace_back();
+                    LOG(WARNING) << " transmit chunk rpc failed";
+                });
+                closure->addSuccessHandler([this](const PTransmitChunkResult& result) noexcept {
+                    _in_flight_rpc_num--;
+                    Status status(result.status());
+                    if (!status.ok()) {
+                        _is_cancelled = true;
+                        LOG(WARNING) << " transmit chunk rpc failed, " << status.message();
+                    }
+                });
+                _closures[dest_instance_id] = closure;
+
+                _buffers[dest_instance_id] = std::queue<TransmitChunkInfo>();
+            }
         }
+
         try {
             _thread = std::thread{&SinkBuffer::process, this};
         } catch (const std::exception& exp) {
@@ -66,14 +78,14 @@ public:
         // at this moment, _in_flight_rpc_num equals 0 and no closure is in flight
         // but it is going to send packet. To handle this properly, we need to wait
         // all the closure finish its io job
-        for (auto* closure : _closures) {
+        for (auto& [_, closure] : _closures) {
             auto cntl = &closure->cntl;
             brpc::Join(cntl->call_id());
             if (closure->unref()) {
                 delete closure;
             }
         }
-        for (auto& buffer : _buffers) {
+        for (auto& [_, buffer] : _buffers) {
             while (!buffer.empty()) {
                 auto& info = buffer.front();
                 info.params->release_finst_id();
@@ -88,7 +100,7 @@ public:
             return;
         }
         std::lock_guard<std::mutex> l(_mutex);
-        _buffers[request.channel_id].push(request);
+        _buffers[request.fragment_instance_id].push(request);
         _buffer_empty_cv.notify_one();
     }
 
@@ -101,7 +113,7 @@ public:
                 {
                     std::unique_lock<std::mutex> l(_mutex);
                     bool is_buffer_empty = true;
-                    for (auto& buffer : _buffers) {
+                    for (auto& [_, buffer] : _buffers) {
                         if (!buffer.empty()) {
                             is_buffer_empty = false;
                             break;
@@ -117,13 +129,13 @@ public:
 
                 for (; spin_iter < spin_threshould; ++spin_iter) {
                     bool find_any = false;
-                    for (auto& buffer : _buffers) {
+                    for (auto& [_, buffer] : _buffers) {
                         if (buffer.empty()) {
                             continue;
                         }
 
                         // std::queue' read is concurrent safe without mutex
-                        if (!_closures[buffer.front().channel_id]->has_in_flight_rpc()) {
+                        if (!_closures[buffer.front().fragment_instance_id]->has_in_flight_rpc()) {
                             TransmitChunkInfo info = buffer.front();
                             find_any = true;
                             _send_rpc(info);
@@ -157,7 +169,7 @@ public:
     bool is_full() const {
         // TODO(hcf) if one channel is congested, it may cause all other channel unwritable
         // std::queue' read is concurrent safe without mutex
-        for (auto& buffer : _buffers) {
+        for (auto& [_, buffer] : _buffers) {
             if (buffer.size() > config::pipeline_io_buffer_size) {
                 return true;
             }
@@ -174,13 +186,13 @@ public:
             return false;
         }
 
-        for (auto* closure : _closures) {
+        for (auto& [_, closure] : _closures) {
             if (closure->has_in_flight_rpc()) {
                 return false;
             }
         }
 
-        for (auto& buffer : _buffers) {
+        for (auto& [_, buffer] : _buffers) {
             if (!buffer.empty()) {
                 return false;
             }
@@ -197,17 +209,18 @@ private:
             // Only the last eos is sent to ExchangeSourceOperator. it must be guaranteed that
             // eos is the last packet to send to finish the input stream of the corresponding of
             // ExchangeSourceOperator and eos is sent exactly-once.
-            if (--_num_sinkers_per_channel[request.channel_id] > 0) {
+            if (--_num_sinkers_per_dest_instance[request.fragment_instance_id] > 0) {
                 if (request.params->chunks_size() == 0) {
-                    _in_flight_rpc_num--;
                     return;
                 } else {
                     request.params->set_eos(false);
                 }
             }
         }
-        request.params->set_sequence(_request_seq);
-        auto* closure = _closures[request.channel_id];
+
+        request.params->set_sequence(_request_seq++);
+
+        auto* closure = _closures[request.fragment_instance_id];
         DCHECK(!closure->has_in_flight_rpc());
         closure->ref();
         closure->cntl.Reset();
@@ -215,18 +228,17 @@ private:
         closure->cntl.request_attachment().append(request.attachment);
         _in_flight_rpc_num++;
         request.brpc_stub->transmit_chunk(&closure->cntl, request.params.get(), &closure->result, closure);
-        _request_seq++;
     }
 
     // To avoid lock
     MemTracker* _mem_tracker = nullptr;
-    vector<size_t> _num_sinkers_per_channel;
+    std::unordered_map<TUniqueId, size_t> _num_sinkers_per_dest_instance;
     int64_t _request_seq = 0;
     std::atomic<int32_t> _in_flight_rpc_num = 0;
     std::atomic_bool _is_cancelled = false;
 
-    std::vector<CallBackClosure<PTransmitChunkResult>*> _closures;
-    std::vector<std::queue<TransmitChunkInfo>> _buffers;
+    std::unordered_map<TUniqueId, CallBackClosure<PTransmitChunkResult>*> _closures;
+    std::unordered_map<TUniqueId, std::queue<TransmitChunkInfo>> _buffers;
     std::condition_variable _buffer_empty_cv;
     std::mutex _mutex;
 

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -235,7 +235,7 @@ void FragmentExecutor::_convert_data_sink_to_operator(const TPlanFragmentExecPar
         starrocks::DataStreamSender* sender = down_cast<starrocks::DataStreamSender*>(datasink);
         auto dop = _fragment_ctx->pipelines().back()->source_operator_factory()->degree_of_parallelism();
         std::shared_ptr<SinkBuffer> sink_buffer = std::make_shared<SinkBuffer>(
-                _fragment_ctx->runtime_state()->instance_mem_tracker(), sender->get_destinations_size(), dop);
+                _fragment_ctx->runtime_state()->instance_mem_tracker(), params.destinations, dop);
 
         OpFactoryPtr exchange_sink = std::make_shared<ExchangeSinkOperatorFactory>(
                 context->next_operator_id(), -1, sink_buffer, sender->get_partition_type(), params.destinations,


### PR DESCRIPTION
In the pipeline engine, we send EOS to channel if all the sinkers of this channel are EOS.
However, as for the `BUCKET_SHFFULE_HASH_PARTITIONED`, multiple channels is related to **one** Exchange Source Fragment Instance, which causes the Exchange Source receives EOS earlier than expected.
Therefore, we should use `fragment_instance_id` of the destination as the key of destination instead of `channel_id`.

Fix #1311 