### PR TITLE
[pipeline] add profile to exchange sink operator

### DIFF
--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -533,6 +533,8 @@ OperatorPtr ExchangeSinkOperatorFactory::create(int32_t degree_of_parallelism, i
 }
 
 Status ExchangeSinkOperatorFactory::prepare(RuntimeState* state) {
+    RETURN_IF_ERROR(OperatorFactory::prepare(state));
+
     if (_part_type == TPartitionType::HASH_PARTITIONED ||
         _part_type == TPartitionType::BUCKET_SHFFULE_HASH_PARTITIONED) {
         RowDescriptor row_desc;

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -247,6 +247,9 @@ ExchangeSinkOperator::ExchangeSinkOperator(int32_t id, int32_t plan_node_id, con
 
 Status ExchangeSinkOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(Operator::prepare(state));
+
+    SCOPED_TIMER(_runtime_profile->total_time_counter());
+
     _be_number = state->be_number();
 
     // Set compression type according to query options
@@ -268,11 +271,9 @@ Status ExchangeSinkOperator::prepare(RuntimeState* state) {
             instances += channel->get_fragment_instance_id_str();
         }
     }
-    std::stringstream title;
-    title << "DataStreamSender (dst_id=" << _dest_node_id << ", dst_fragments=[" << instances << "])";
-    _profile = state->obj_pool()->add(new RuntimeProfile(title.str()));
-
-    SCOPED_TIMER(_profile->total_time_counter());
+    _runtime_profile->add_info_string("DestID", std::to_string(_dest_node_id));
+    _runtime_profile->add_info_string("DestFragments", instances);
+    _runtime_profile->add_info_string("PartType", _TPartitionType_VALUES_TO_NAMES.at(_part_type));
 
     if (_part_type == TPartitionType::UNPARTITIONED || _part_type == TPartitionType::RANDOM) {
         // Randomize the order we open/transmit to channels to avoid thundering herd problems.
@@ -285,16 +286,16 @@ Status ExchangeSinkOperator::prepare(RuntimeState* state) {
         DCHECK(false) << "shouldn't go to here";
     }
 
-    _bytes_sent_counter = ADD_COUNTER(profile(), "BytesSent", TUnit::BYTES);
-    _uncompressed_bytes_counter = ADD_COUNTER(profile(), "UncompressedBytes", TUnit::BYTES);
-    _ignore_rows = ADD_COUNTER(profile(), "IgnoreRows", TUnit::UNIT);
-    _serialize_batch_timer = ADD_TIMER(profile(), "SerializeBatchTime");
-    _compress_timer = ADD_TIMER(profile(), "CompressTime");
-    _send_request_timer = ADD_TIMER(profile(), "SendRequestTime");
-    _wait_response_timer = ADD_TIMER(profile(), "WaitResponseTime");
-    _overall_throughput = profile()->add_derived_counter(
+    _bytes_sent_counter = ADD_COUNTER(_runtime_profile, "BytesSent", TUnit::BYTES);
+    _uncompressed_bytes_counter = ADD_COUNTER(_runtime_profile, "UncompressedBytes", TUnit::BYTES);
+    _ignore_rows = ADD_COUNTER(_runtime_profile, "IgnoreRows", TUnit::UNIT);
+    _serialize_batch_timer = ADD_TIMER(_runtime_profile, "SerializeBatchTime");
+    _compress_timer = ADD_TIMER(_runtime_profile, "CompressTime");
+    _send_request_timer = ADD_TIMER(_runtime_profile, "SendRequestTime");
+    _wait_response_timer = ADD_TIMER(_runtime_profile, "WaitResponseTime");
+    _overall_throughput = _runtime_profile->add_derived_counter(
             "OverallThroughput", TUnit::BYTES_PER_SECOND,
-            [capture0 = _bytes_sent_counter, capture1 = profile()->total_time_counter()] {
+            [capture0 = _bytes_sent_counter, capture1 = _runtime_profile->total_time_counter()] {
                 return RuntimeProfile::units_per_second(capture0, capture1);
             },
             "");
@@ -320,7 +321,7 @@ StatusOr<vectorized::ChunkPtr> ExchangeSinkOperator::pull_chunk(RuntimeState* st
 }
 
 Status ExchangeSinkOperator::push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) {
-    SCOPED_TIMER(_profile->total_time_counter());
+    SCOPED_TIMER(_runtime_profile->total_time_counter());
     uint16_t num_rows = chunk->num_rows();
     if (num_rows == 0) {
         return Status::OK();
@@ -439,7 +440,8 @@ void ExchangeSinkOperator::set_finishing(RuntimeState* state) {
 }
 
 Status ExchangeSinkOperator::close(RuntimeState* state) {
-    ScopedTimer<MonotonicStopWatch> close_timer(_profile != nullptr ? _profile->total_time_counter() : nullptr);
+    ScopedTimer<MonotonicStopWatch> close_timer(_runtime_profile != nullptr ? _runtime_profile->total_time_counter()
+                                                                            : nullptr);
     Operator::close(state);
     return _close_status;
 }

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.h
@@ -57,8 +57,6 @@ public:
 
     void construct_brpc_attachment(PTransmitChunkParamsPtr _chunk_request, butil::IOBuf& attachment);
 
-    RuntimeProfile* profile() { return _profile; }
-
 private:
     class Channel;
 
@@ -102,7 +100,6 @@ private:
     // Only sender will change this value, so no need to use lock to protect it.
     Status _close_status;
 
-    RuntimeProfile* _profile; // Allocated from _pool
     RuntimeProfile::Counter* _serialize_batch_timer;
     RuntimeProfile::Counter* _compress_timer{};
     RuntimeProfile::Counter* _bytes_sent_counter;


### PR DESCRIPTION
1. `ExchangeSinkOperator` creates `runtime_profile` themselves, which is not added into `runtime_state`.
2. Add `DestID`, `DestFragments`, and `PartType` to profile for exchange sink operator.