### PR TITLE
Fix CouldApplyDictOptimize error for const operator

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/AddDecodeNodeForDictStringRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/AddDecodeNodeForDictStringRule.java
@@ -716,7 +716,7 @@ public class AddDecodeNodeForDictStringRule implements PhysicalOperatorTreeRewri
 
         @Override
         public Boolean visitConstant(ConstantOperator literal, Void context) {
-            return true;
+            return false;
         }
 
         @Override

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecodeRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecodeRewriteTest.java
@@ -51,8 +51,6 @@ public class DecodeRewriteTest extends PlanTestBase{
                 "\"storage_format\" = \"DEFAULT\"\n" +
                 ");");
 
-
-        connectContext.getSessionVariable().setEnableLowCardinalityOptimize(true);
         FeConstants.USE_MOCK_DICT_MANAGER = true;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -53,7 +53,6 @@ public class PlanFragmentTest extends PlanTestBase {
                 .withTable("create table test.nocolocate3\n" +
                         "(k1 int, k2 int, k3 int) distributed by hash(k1, k2) buckets 10\n" +
                         "properties(\"replication_num\" = \"1\");");
-        connectContext.getSessionVariable().setEnableLowCardinalityOptimize(true);
     }
 
     @Test


### PR DESCRIPTION
```

java.util.NoSuchElementException: No value present

	at com.starrocks.sql.optimizer.base.ColumnRefSet.getFirstId(ColumnRefSet.java:40)
	at com.starrocks.sql.optimizer.rewrite.AddDecodeNodeForDictStringRule$DecodeVisitor.rewriteOneScalarOperatorForProjection(AddDecodeNodeForDictStringRule.java:370)
	at com.starrocks.sql.optimizer.rewrite.AddDecodeNodeForDictStringRule$DecodeVisitor.rewriteProjectOperator(AddDecodeNodeForDictStringRule.java:335)
	at com.starrocks.sql.optimizer.rewrite.AddDecodeNodeForDictStringRule$DecodeVisitor.visitProjectionAfter(AddDecodeNodeForDictStringRule.java:148)
	at com.starrocks.sql.optimizer.rewrite.AddDecodeNodeForDictStringRule$DecodeVisitor.visitPhysicalHashAggregate(AddDecodeNodeForDictStringRule.java:529)
	at com.starrocks.sql.optimizer.rewrite.AddDecodeNodeForDictStringRule$DecodeVisitor.visitPhysicalHashAggregate(AddDecodeNodeForDictStringRule.java:126)
	at com.starrocks.sql.optimizer.operator.physical.PhysicalHashAggregateOperator.accept(PhysicalHashAggregateOperator.java:127)
	at com.starrocks.sql.optimizer.rewrite.AddDecodeNodeForDictStringRule.rewrite(AddDecodeNodeForDictStringRule.java:621)
	at com.starrocks.sql.optimizer.Optimizer.optimize(Optimizer.java:161)
```