### PR TITLE
[pipeline] fix: check whether hash table is empty for aggregate streaming

### DIFF
--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.cpp
@@ -19,6 +19,11 @@ bool AggregateDistinctStreamingSinkOperator::is_finished() const {
 
 void AggregateDistinctStreamingSinkOperator::set_finishing(RuntimeState* state) {
     _is_finished = true;
+
+    if (_aggregator->hash_set_variant().size() == 0) {
+        _aggregator->set_ht_eos();
+    }
+
     _aggregator->sink_complete();
 }
 

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
@@ -19,6 +19,11 @@ bool AggregateStreamingSinkOperator::is_finished() const {
 
 void AggregateStreamingSinkOperator::set_finishing(RuntimeState* state) {
     _is_finished = true;
+
+    if (_aggregator->hash_map_variant().size() == 0) {
+        _aggregator->set_ht_eos();
+    }
+
     _aggregator->sink_complete();
 }
 


### PR DESCRIPTION
`aggregator->convert_hash_set_to_chunk(hash_set, ...)` assumes that `hash_set` is not empty and uses it without checking empty.

 `AggregateDistinctStreaming` and `AggregateStreaming` don't check this, while `AggregateDistinctBlocking` and `AggregateBlocking` check this in sink's `set_finishing()`  like follows:
```C++
void AggregateDistinctBlockingSinkOperator::set_finishing(RuntimeState* state) {
    _is_finished = true;

    COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_set_variant().size());

    // If hash set is empty, we don't need to return value
    if (_aggregator->hash_set_variant().size() == 0) {
        _aggregator->set_ht_eos();
    }
}
```


Fix #1317