### PR TITLE
SinkBuffer replace thread with threadPool

### DIFF
--- a/be/src/exec/pipeline/exchange/sink_buffer.h
+++ b/be/src/exec/pipeline/exchange/sink_buffer.h
@@ -2,8 +2,12 @@
 
 #pragma once
 
+#include <algorithm>
+#include <future>
+#include <list>
 #include <mutex>
 #include <queue>
+#include <unordered_map>
 
 #include "column/chunk.h"
 #include "gen_cpp/BackendService.h"
@@ -12,6 +16,7 @@
 #include "util/brpc_stub_cache.h"
 #include "util/callback_closure.h"
 #include "util/defer_op.h"
+#include "util/priority_thread_pool.hpp"
 
 namespace starrocks::pipeline {
 
@@ -31,6 +36,7 @@ class SinkBuffer {
 public:
     SinkBuffer(MemTracker* mem_tracker, const std::vector<TPlanFragmentDestination>& destinations, size_t num_sinkers)
             : _mem_tracker(mem_tracker) {
+        _threads = ExecEnv::GetInstance()->pipeline_exchange_sink_thread_pool();
         for (const auto& dest : destinations) {
             const auto& dest_instance_id = dest.fragment_instance_id;
 
@@ -44,46 +50,65 @@ public:
                 auto* closure = new CallBackClosure<PTransmitChunkResult>();
                 closure->ref();
                 closure->addFailedHandler([this]() noexcept {
-                    _in_flight_rpc_num--;
-                    _is_cancelled = true;
+                    _in_flight_rpc_num.fetch_sub(1, std::memory_order_release);
+                    {
+                        std::lock_guard<std::mutex> l(_mutex);
+                        _is_finishing = true;
+                    }
                     LOG(WARNING) << " transmit chunk rpc failed";
                 });
                 closure->addSuccessHandler([this](const PTransmitChunkResult& result) noexcept {
-                    _in_flight_rpc_num--;
+                    _in_flight_rpc_num.fetch_sub(1, std::memory_order_release);
                     Status status(result.status());
                     if (!status.ok()) {
-                        _is_cancelled = true;
+                        {
+                            std::lock_guard<std::mutex> l(_mutex);
+                            _is_finishing = true;
+                        }
                         LOG(WARNING) << " transmit chunk rpc failed, " << status.message();
                     }
                 });
                 _closures[dest_instance_id] = closure;
-
-                _buffers[dest_instance_id] = std::queue<TransmitChunkInfo>();
+                _buffers[dest_instance_id] = std::queue<TransmitChunkInfo, std::list<TransmitChunkInfo>>();
+                _request_seqs[dest_instance_id] = 0;
             }
-        }
 
-        try {
-            _thread = std::thread{&SinkBuffer::process, this};
-        } catch (const std::exception& exp) {
-            LOG(FATAL) << "[ExchangeSinkOperator] create thread: " << exp.what();
-        } catch (...) {
-            LOG(FATAL) << "[ExchangeSinkOperator] create thread: unknown";
+            _expected_eos = 0;
+            for (auto& [_, num] : _num_sinkers_per_dest_instance) {
+                _expected_eos += num;
+            }
         }
     }
 
     ~SinkBuffer() {
-        _is_finished = true;
-        _buffer_empty_cv.notify_one();
-        _thread.join();
+        // Handle abnormal exit of SinkBuffer
+        // TODO(hcf) It may be solved by adding state 'PENDING_FINISH' for ExchangeSinkOperator
+        bool abnormal_exit = false;
+        if (!is_finished()) {
+            std::lock_guard<std::mutex> l(_mutex);
+            abnormal_exit = true;
+            _is_finishing = true;
+        }
+        if (abnormal_exit) {
+            for (auto& [_, closure] : _closures) {
+                auto cntl = &closure->cntl;
+                brpc::Join(cntl->call_id());
+            }
+        }
 
-        // TODO(hcf) is_finish() unable to judge such situation that when process()
-        // pickup request from buffer and before transmitting through brpc.
-        // at this moment, _in_flight_rpc_num equals 0 and no closure is in flight
-        // but it is going to send packet. To handle this properly, we need to wait
-        // all the closure finish its io job
+        // Wait for the rpc task to exit to avoid
+        // DeferOp accessing illegal memory
+        std::promise<void>* exit_promise = nullptr;
+        {
+            std::lock_guard<std::mutex> l(_mutex);
+            exit_promise = _rpc_task_exit_promise.get();
+        }
+        if (exit_promise != nullptr) {
+            exit_promise->get_future().get();
+        }
+
+        // Relase resources
         for (auto& [_, closure] : _closures) {
-            auto cntl = &closure->cntl;
-            brpc::Join(cntl->call_id());
             if (closure->unref()) {
                 delete closure;
             }
@@ -98,116 +123,146 @@ public:
     }
 
     void add_request(const TransmitChunkInfo& request) {
-        if (_is_finished) {
-            request.params->release_finst_id();
-            return;
+        DCHECK(_expected_eos > 0);
+        {
+            // Guarantee that no request will be added to buffer after finishing stage
+            std::lock_guard<std::mutex> l(_mutex);
+            if (_is_finishing) {
+                request.params->release_finst_id();
+                return;
+            } else {
+                _buffers[request.fragment_instance_id].push(request);
+            }
         }
-        std::lock_guard<std::mutex> l(_mutex);
-        _buffers[request.fragment_instance_id].push(request);
-        _buffer_empty_cv.notify_one();
+
+        _try_to_trigger_rpc_task();
     }
 
-    void process() {
+    bool is_full() const {
+        // TODO(hcf) if one channel is congested, it may cause all other channel unwritable
+        // std::queue' read is concurrent safe without mutex
+        return std::any_of(_buffers.begin(), _buffers.end(),
+                           [](const auto& entry) { return entry.second.size() > config::pipeline_io_buffer_size; });
+    }
+
+    bool is_finished() {
+        if (!_is_finishing) {
+            return false;
+        }
+
+        // Here is the guarantee that
+        // 1. No new rpc task will be created after finishing stage
+        // 2. No new brpc process will be triggered after finishing stage
+        // So we just wait for existed rpc task and bprc process to be finished
+        return !_is_rpc_task_active && _in_flight_rpc_num.load(std::memory_order_acquire) == 0;
+    }
+
+private:
+    void _try_to_trigger_rpc_task() {
+        // Guarantee that no new rpc task will be created after finishing stage
+        std::lock_guard<std::mutex> l(_mutex);
+        if (_is_finishing) {
+            return;
+        }
+
+        // Tell rpc task scan buffer one more time
+        if (_is_rpc_task_active) {
+            _need_one_more_check = true;
+            return;
+        }
+
+        // Waiting for rpc task to exit, it won't take too long
+        if (_rpc_task_exit_promise != nullptr) {
+            _rpc_task_exit_promise->get_future().get();
+        }
+        _rpc_task_exit_promise = std::make_unique<std::promise<void>>();
+
+        PriorityThreadPool::Task task;
+        task.work_function = [this]() { _process(); };
+        // TODO(by satanson): set a proper priority
+        task.priority = 20;
+
+        _is_rpc_task_active = true;
+        if (!_threads->offer(task)) {
+            LOG(WARNING) << "SinkBuffer failed to offer rpc task due to thread pool shutdown";
+            _is_finishing = true;
+            _is_rpc_task_active = false;
+            _rpc_task_exit_promise = nullptr;
+        }
+    }
+
+    void _process() {
         try {
             MemTracker* prev_tracker = tls_thread_status.set_mem_tracker(_mem_tracker);
             DeferOp op([&] { tls_thread_status.set_mem_tracker(prev_tracker); });
 
-            while (!_is_finished) {
-                {
-                    std::unique_lock<std::mutex> l(_mutex);
-                    bool is_buffer_empty = true;
-                    for (auto& [_, buffer] : _buffers) {
-                        if (!buffer.empty()) {
-                            is_buffer_empty = false;
-                            break;
+            for (;;) {
+                bool buffer_empty = true;
+                bool send_any = false;
+                for (auto& [fragment_instance_id, buffer] : _buffers) {
+                    auto* closure = _closures[fragment_instance_id];
+                    DCHECK(closure != nullptr);
+                    if (buffer.empty()) {
+                        continue;
+                    }
+                    buffer_empty = false;
+                    if (closure->has_in_flight_rpc()) {
+                        continue;
+                    }
+                    send_any = true;
+
+                    TransmitChunkInfo info = buffer.front();
+                    _send_rpc(info);
+                    info.params->release_finst_id();
+                    if (info.params->eos()) {
+                        std::lock_guard<std::mutex> l(_mutex);
+                        if (--_expected_eos == 0) {
+                            _is_finishing = true;
                         }
                     }
-                    if (is_buffer_empty) {
-                        _buffer_empty_cv.wait(l);
+                    {
+                        std::lock_guard<std::mutex> l(_mutex);
+                        buffer.pop();
                     }
                 }
 
-                const size_t spin_threshould = 100;
-                size_t spin_iter = 0;
-
-                for (; spin_iter < spin_threshould; ++spin_iter) {
-                    bool find_any = false;
-                    for (auto& [_, buffer] : _buffers) {
-                        if (buffer.empty()) {
-                            continue;
-                        }
-
-                        // std::queue' read is concurrent safe without mutex
-                        if (!_closures[buffer.front().fragment_instance_id]->has_in_flight_rpc()) {
-                            TransmitChunkInfo info = buffer.front();
-                            find_any = true;
-                            _send_rpc(info);
-                            {
-                                std::lock_guard<std::mutex> l(_mutex);
-                                buffer.pop();
-                            }
-                            info.params->release_finst_id();
-                        }
+                if (buffer_empty) {
+                    // When traversing the buffer, a new request may be inserted
+                    // so the value of buffer_empty may not be that accurate, we
+                    // need to communicate with add_request through _need_one_more_check
+                    // in order to avoid exiting rpc task with non-empty buffer
+                    std::lock_guard<std::mutex> l(_mutex);
+                    if (_need_one_more_check) {
+                        _need_one_more_check = false;
+                        continue;
                     }
-
-                    if (find_any) {
-                        spin_iter = 0;
-                    }
-                }
-
-                // Find none ready closure after multiply spin, just wait for a while
+                    _need_one_more_check = false;
+                    _is_rpc_task_active = false;
+                    break;
+                } else if (!send_any) {
 #ifdef __x86_64__
-                _mm_pause();
+                    _mm_pause();
 #else
-                sched_yield();
+                    // TODO: Maybe there's a better intrinsic like _mm_pause on non-x86_64 architecture.
+                    sched_yield();
 #endif
+                }
             }
         } catch (const std::exception& exp) {
             LOG(FATAL) << "[ExchangeSinkOperator] sink_buffer::process: " << exp.what();
         } catch (...) {
             LOG(FATAL) << "[ExchangeSinkOperator] sink_buffer::process: UNKNOWN";
         }
+        _rpc_task_exit_promise->set_value();
     }
 
-    bool is_full() const {
-        // TODO(hcf) if one channel is congested, it may cause all other channel unwritable
-        // std::queue' read is concurrent safe without mutex
-        for (auto& [_, buffer] : _buffers) {
-            if (buffer.size() > config::pipeline_io_buffer_size) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    bool is_finished() const {
-        if (_is_cancelled) {
-            return true;
-        }
-
-        if (_in_flight_rpc_num > 0) {
-            return false;
-        }
-
-        for (auto& [_, closure] : _closures) {
-            if (closure->has_in_flight_rpc()) {
-                return false;
-            }
-        }
-
-        for (auto& [_, buffer] : _buffers) {
-            if (!buffer.empty()) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    bool is_cancelled() const { return _is_cancelled; }
-
-private:
     void _send_rpc(TransmitChunkInfo& request) {
+        // Guarantee that no new brpc process will be triggered after finishing stage
+        std::lock_guard<std::mutex> l(_mutex);
+        if (_is_finishing) {
+            return;
+        }
+
         if (request.params->eos()) {
             // Only the last eos is sent to ExchangeSourceOperator. it must be guaranteed that
             // eos is the last packet to send to finish the input stream of the corresponding of
@@ -220,33 +275,37 @@ private:
                 }
             }
         }
-
-        request.params->set_sequence(_request_seq++);
-
+        request.params->set_sequence(_request_seqs[request.fragment_instance_id]++);
         auto* closure = _closures[request.fragment_instance_id];
+        DCHECK(closure != nullptr);
         DCHECK(!closure->has_in_flight_rpc());
         closure->ref();
         closure->cntl.Reset();
         closure->cntl.set_timeout_ms(500);
         closure->cntl.request_attachment().append(request.attachment);
-        _in_flight_rpc_num++;
+        _in_flight_rpc_num.fetch_add(1, std::memory_order_release);
         request.brpc_stub->transmit_chunk(&closure->cntl, request.params.get(), &closure->result, closure);
     }
 
-    // To avoid lock
+    PriorityThreadPool* _threads = nullptr;
     MemTracker* _mem_tracker = nullptr;
+
     std::unordered_map<TUniqueId, size_t> _num_sinkers_per_dest_instance;
-    int64_t _request_seq = 0;
+    std::unordered_map<TUniqueId, int64_t> _request_seqs;
     std::atomic<int32_t> _in_flight_rpc_num = 0;
-    std::atomic_bool _is_cancelled = false;
 
     std::unordered_map<TUniqueId, CallBackClosure<PTransmitChunkResult>*> _closures;
-    std::unordered_map<TUniqueId, std::queue<TransmitChunkInfo>> _buffers;
-    std::condition_variable _buffer_empty_cv;
-    std::mutex _mutex;
+    std::unordered_map<TUniqueId, std::queue<TransmitChunkInfo, std::list<TransmitChunkInfo>>> _buffers;
 
-    std::thread _thread;
-    std::atomic_bool _is_finished = false;
+    std::mutex _mutex;
+    bool _is_finishing = false;
+    bool _need_one_more_check = false;
+    bool _is_rpc_task_active = false;
+    int32_t _expected_eos = 0;
+
+    // This field is used to help properly handle special situation
+    // that SinkBuffer may destruct when method is_finished() return false
+    std::unique_ptr<std::promise<void>> _rpc_task_exit_promise = nullptr;
 };
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -191,7 +191,7 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
                                                                     driver_id++, is_root);
                 driver->set_morsel_queue(morsel_queue.get());
                 auto* scan_operator = down_cast<ScanOperator*>(driver->source_operator());
-                scan_operator->set_io_threads(exec_env->pipeline_io_thread_pool());
+                scan_operator->set_io_threads(exec_env->pipeline_scan_io_thread_pool());
                 setup_profile_hierarchy(runtime_state, driver);
                 drivers.emplace_back(std::move(driver));
             }

--- a/be/src/exec/pipeline/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan_operator.cpp
@@ -113,8 +113,9 @@ void ScanOperator::_trigger_next_scan(RuntimeState* state) {
     };
     // TODO(by satanson): set a proper priority
     task.priority = 20;
-    // try to submit io task, always return true except that _io_threads is shutdown.
-    _io_threads->try_offer(task);
+    if (!_io_threads->offer(task)) {
+        LOG(WARNING) << "ScanOperator failed to offer io task due to thread pool shutdown";
+    }
 }
 
 void ScanOperator::_pickup_morsel(RuntimeState* state) {

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -94,8 +94,10 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths) {
     LOG(INFO) << strings::Substitute("[PIPELINE] IO thread pool: thread_num=$0, queue_size=$1",
                                      config::pipeline_io_thread_pool_thread_num,
                                      config::pipeline_io_thread_pool_queue_size);
-    _pipeline_io_thread_pool = new PriorityThreadPool(config::pipeline_io_thread_pool_thread_num,
-                                                      config::pipeline_io_thread_pool_queue_size);
+    _pipeline_scan_io_thread_pool = new PriorityThreadPool(config::pipeline_io_thread_pool_thread_num,
+                                                           config::pipeline_io_thread_pool_queue_size);
+    _pipeline_exchange_sink_thread_pool = new PriorityThreadPool(config::pipeline_io_thread_pool_thread_num,
+                                                                 config::pipeline_io_thread_pool_queue_size);
     _num_scan_operators = 0;
     _etl_thread_pool = new PriorityThreadPool(config::etl_thread_pool_size, config::etl_thread_pool_queue_size);
     _fragment_mgr = new FragmentMgr(this);
@@ -295,9 +297,13 @@ void ExecEnv::_destroy() {
         delete _etl_thread_pool;
         _etl_thread_pool = nullptr;
     }
-    if (_pipeline_io_thread_pool) {
-        delete _pipeline_io_thread_pool;
-        _pipeline_io_thread_pool = nullptr;
+    if (_pipeline_scan_io_thread_pool) {
+        delete _pipeline_scan_io_thread_pool;
+        _pipeline_scan_io_thread_pool = nullptr;
+    }
+    if (_pipeline_exchange_sink_thread_pool) {
+        delete _pipeline_exchange_sink_thread_pool;
+        _pipeline_exchange_sink_thread_pool = nullptr;
     }
     if (_thread_pool) {
         delete _thread_pool;

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -122,7 +122,8 @@ public:
 
     ThreadResourceMgr* thread_mgr() { return _thread_mgr; }
     PriorityThreadPool* thread_pool() { return _thread_pool; }
-    PriorityThreadPool* pipeline_io_thread_pool() { return _pipeline_io_thread_pool; }
+    PriorityThreadPool* pipeline_scan_io_thread_pool() { return _pipeline_scan_io_thread_pool; }
+    PriorityThreadPool* pipeline_exchange_sink_thread_pool() { return _pipeline_exchange_sink_thread_pool; }
     size_t increment_num_scan_operators(size_t n) { return _num_scan_operators.fetch_add(n); }
     size_t decrement_num_scan_operators(size_t n) { return _num_scan_operators.fetch_sub(n); }
     PriorityThreadPool* etl_thread_pool() { return _etl_thread_pool; }
@@ -200,7 +201,8 @@ private:
 
     ThreadResourceMgr* _thread_mgr = nullptr;
     PriorityThreadPool* _thread_pool = nullptr;
-    PriorityThreadPool* _pipeline_io_thread_pool = nullptr;
+    PriorityThreadPool* _pipeline_scan_io_thread_pool = nullptr;
+    PriorityThreadPool* _pipeline_exchange_sink_thread_pool = nullptr;
     std::atomic<size_t> _num_scan_operators;
     PriorityThreadPool* _etl_thread_pool = nullptr;
     FragmentMgr* _fragment_mgr = nullptr;


### PR DESCRIPTION
Target of this pr

1. Replace thread with thread pool of SinkBuffer, we need to split the whole time slices into multiple independent time slices
2. Safely release PTransmitChunkParams's finst_id in any cases
3. Simply the logic of method `SinkBuffer::is_finished`
4. Remove the blocking logic in the destructor of SinkBuffer

In order to simply the logic of method `SinkBuffer::is_finished`, `_is_finishing` is introduced here, it means all the requests have been flushed to brpc or something wrong occurred. And once it becomes this stage,  the following three constraints are established
1. No new io task will be created
1. No new brpc process will be triggered
2. No new request will be added to buffer

As for abnormal exit of SinkBuffer(query canceled) , we should also handle this situation

[related-issue](https://github.com/StarRocks/starrocks/issues/1340)