### PR TITLE
Fix DictOptimizeParser::rewrite_descriptor change the slot type

### DIFF
--- a/be/src/exec/pipeline/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan_operator.cpp
@@ -146,7 +146,7 @@ Status ScanOperatorFactory::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(Expr::open(_conjunct_ctxs, state));
 
     auto tuple_desc = state->desc_tbl().get_tuple_descriptor(_olap_scan_node.tuple_id);
-    vectorized::DictOptimizeParser::rewrite_descriptor(state, tuple_desc->slots(), _conjunct_ctxs,
+    vectorized::DictOptimizeParser::rewrite_descriptor(state, tuple_desc->decoded_slots(), _conjunct_ctxs,
                                                        _olap_scan_node.dict_string_id_to_int_ids);
     return Status::OK();
 }

--- a/be/src/exec/pipeline/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan_operator.cpp
@@ -146,8 +146,8 @@ Status ScanOperatorFactory::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(Expr::open(_conjunct_ctxs, state));
 
     auto tuple_desc = state->desc_tbl().get_tuple_descriptor(_olap_scan_node.tuple_id);
-    vectorized::DictOptimizeParser::rewrite_descriptor(state, tuple_desc->decoded_slots(), _conjunct_ctxs,
-                                                       _olap_scan_node.dict_string_id_to_int_ids);
+    vectorized::DictOptimizeParser::rewrite_descriptor(state, _conjunct_ctxs, _olap_scan_node.dict_string_id_to_int_ids,
+                                                       &(tuple_desc->decoded_slots()));
     return Status::OK();
 }
 

--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -66,7 +66,7 @@ Status OlapScanNode::open(RuntimeState* state) {
     _update_status(status);
 
     _dict_optimize_parser.set_mutable_dict_maps(state->mutable_global_dict_map());
-    DictOptimizeParser::rewrite_descriptor(state, _tuple_desc->slots(), _conjunct_ctxs,
+    DictOptimizeParser::rewrite_descriptor(state, _tuple_desc->decoded_slots(), _conjunct_ctxs,
                                            _olap_scan_node.dict_string_id_to_int_ids);
 
     return Status::OK();

--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -66,8 +66,8 @@ Status OlapScanNode::open(RuntimeState* state) {
     _update_status(status);
 
     _dict_optimize_parser.set_mutable_dict_maps(state->mutable_global_dict_map());
-    DictOptimizeParser::rewrite_descriptor(state, _tuple_desc->decoded_slots(), _conjunct_ctxs,
-                                           _olap_scan_node.dict_string_id_to_int_ids);
+    DictOptimizeParser::rewrite_descriptor(state, _conjunct_ctxs, _olap_scan_node.dict_string_id_to_int_ids,
+                                           &(_tuple_desc->decoded_slots()));
 
     return Status::OK();
 }

--- a/be/src/exec/vectorized/olap_scan_prepare.cpp
+++ b/be/src/exec/vectorized/olap_scan_prepare.cpp
@@ -485,7 +485,7 @@ Status OlapScanConjunctsManager::normalize_conjuncts() {
 
     // TODO(zhuming): if any of the normalized column range is empty, we can know that
     // no row will be selected anymore and can return EOF directly.
-    for (auto& slot : tuple_desc->slots()) {
+    for (auto& slot : tuple_desc->decoded_slots()) {
         const std::string& col_name = slot->col_name();
         PrimitiveType type = slot->type().type;
         switch (type) {
@@ -727,7 +727,7 @@ void OlapScanConjunctsManager::get_column_predicates(PredicateParser* parser, st
         preds->push_back(p);
     }
 
-    const auto& slots = tuple_desc->slots();
+    const auto& slots = tuple_desc->decoded_slots();
     for (auto& iter : slot_index_to_expr_ctxs) {
         int slot_index = iter.first;
         auto& expr_ctxs = iter.second;
@@ -776,7 +776,7 @@ void OlapScanConjunctsManager::get_not_push_down_conjuncts(std::vector<ExprConte
 
 void OlapScanConjunctsManager::build_column_expr_predicates() {
     std::map<SlotId, int> slot_id_to_index;
-    const auto& slots = tuple_desc->slots();
+    const auto& slots = tuple_desc->decoded_slots();
     for (int i = 0; i < slots.size(); i++) {
         const SlotDescriptor* slot_desc = slots[i];
         SlotId slot_id = slot_desc->id();

--- a/be/src/runtime/descriptors.cpp
+++ b/be/src/runtime/descriptors.cpp
@@ -208,8 +208,6 @@ TupleDescriptor::TupleDescriptor(const TTupleDescriptor& tdesc)
           _table_desc(nullptr),
           _byte_size(tdesc.byteSize),
           _num_null_bytes(tdesc.numNullBytes),
-          _num_materialized_slots(0),
-
           _has_varlen_slots(false) {
     if (false == tdesc.__isset.numNullSlots) {
         //be compatible for existing tables with no NULL value
@@ -224,7 +222,6 @@ TupleDescriptor::TupleDescriptor(const PTupleDescriptor& pdesc)
           _table_desc(nullptr),
           _byte_size(pdesc.byte_size()),
           _num_null_bytes(pdesc.num_null_bytes()),
-          _num_materialized_slots(0),
 
           _has_varlen_slots(false) {
     if (!pdesc.has_num_null_slots()) {
@@ -237,17 +234,7 @@ TupleDescriptor::TupleDescriptor(const PTupleDescriptor& pdesc)
 
 void TupleDescriptor::add_slot(SlotDescriptor* slot) {
     _slots.push_back(slot);
-
-    if (slot->is_materialized()) {
-        ++_num_materialized_slots;
-
-        if (slot->type().is_string_type()) {
-            _string_slots.push_back(slot);
-            _has_varlen_slots = true;
-        } else {
-            _no_string_slots.push_back(slot);
-        }
-    }
+    _decoded_slots.push_back(slot);
 }
 
 std::vector<SlotDescriptor*> TupleDescriptor::slots_ordered_by_idx() const {

--- a/be/src/runtime/descriptors.h
+++ b/be/src/runtime/descriptors.h
@@ -274,8 +274,7 @@ public:
     int num_null_bytes() const { return _num_null_bytes; }
     const std::vector<SlotDescriptor*>& slots() const { return _slots; }
     std::vector<SlotDescriptor*>& slots() { return _slots; }
-    const std::vector<SlotDescriptor*>& string_slots() const { return _string_slots; }
-    const std::vector<SlotDescriptor*>& no_string_slots() const { return _no_string_slots; }
+    const std::vector<SlotDescriptor*>& decoded_slots() const { return _decoded_slots; }
     bool has_varlen_slots() const { return _has_varlen_slots; }
     const TableDescriptor* table_desc() const { return _table_desc; }
     void set_table_desc(TableDescriptor* table_desc) { _table_desc = table_desc; }
@@ -299,11 +298,10 @@ private:
     int _byte_size;
     int _num_null_slots;
     int _num_null_bytes;
-    int _num_materialized_slots;
-    std::vector<SlotDescriptor*> _slots;        // contains all slots
-    std::vector<SlotDescriptor*> _string_slots; // contains only materialized string slots
-    // contains only materialized slots except string slots
-    std::vector<SlotDescriptor*> _no_string_slots;
+    std::vector<SlotDescriptor*> _slots; // contains all slots
+    // For a low cardinality string column with global dict,
+    // The type in _slots is int, in _decode_slots is varchar
+    std::vector<SlotDescriptor*> _decoded_slots;
 
     // Provide quick way to check if there are variable length slots.
     // True if _string_slots or _collection_slots have entries.

--- a/be/src/runtime/descriptors.h
+++ b/be/src/runtime/descriptors.h
@@ -78,7 +78,6 @@ std::ostream& operator<<(std::ostream& os, const NullIndicatorOffset& null_indic
 
 class SlotDescriptor {
 public:
-    // virtual ~SlotDescriptor() {};
     SlotId id() const { return _id; }
     const TypeDescriptor& type() const { return _type; }
     TypeDescriptor& type() { return _type; }
@@ -275,6 +274,7 @@ public:
     const std::vector<SlotDescriptor*>& slots() const { return _slots; }
     std::vector<SlotDescriptor*>& slots() { return _slots; }
     const std::vector<SlotDescriptor*>& decoded_slots() const { return _decoded_slots; }
+    std::vector<SlotDescriptor*>& decoded_slots() { return _decoded_slots; }
     bool has_varlen_slots() const { return _has_varlen_slots; }
     const TableDescriptor* table_desc() const { return _table_desc; }
     void set_table_desc(TableDescriptor* table_desc) { _table_desc = table_desc; }

--- a/be/src/runtime/global_dicts.h
+++ b/be/src/runtime/global_dicts.h
@@ -83,9 +83,9 @@ public:
     // For global dictionary optimized columns,
     // the type at the execution level is INT but at the storage level is TYPE_STRING/TYPE_CHAR,
     // so we need to pass the real type to the Table Scanner.
-    static void rewrite_descriptor(RuntimeState* runtime_state, std::vector<SlotDescriptor*> slot_descs,
-                                   std::vector<ExprContext*>& conjunct_ctxs,
-                                   const std::map<int32_t, int32_t>& dict_slots_mapping);
+    static void rewrite_descriptor(RuntimeState* runtime_state, const std::vector<ExprContext*>& conjunct_ctxs,
+                                   const std::map<int32_t, int32_t>& dict_slots_mapping,
+                                   std::vector<SlotDescriptor*>* slot_descs);
 
 private:
     template <bool is_predicate>

--- a/be/src/runtime/row_batch.cpp
+++ b/be/src/runtime/row_batch.cpp
@@ -196,8 +196,6 @@ RowBatch::RowBatch(const RowDescriptor& row_desc, const TRowBatch& input_batch)
         TupleRow* row = get_row(i);
         std::vector<TupleDescriptor*>::const_iterator desc = tuple_descs.begin();
         for (int j = 0; desc != tuple_descs.end(); ++desc, ++j) {
-
-
             Tuple* tuple = row->get_tuple(j);
             if (tuple == nullptr) {
                 continue;

--- a/be/src/runtime/row_batch.cpp
+++ b/be/src/runtime/row_batch.cpp
@@ -121,25 +121,9 @@ RowBatch::RowBatch(const RowDescriptor& row_desc, const PRowBatch& input_batch)
         TupleRow* row = get_row(i);
         std::vector<TupleDescriptor*>::const_iterator desc = tuple_descs.begin();
         for (int j = 0; desc != tuple_descs.end(); ++desc, ++j) {
-            if ((*desc)->string_slots().empty()) {
-                continue;
-            }
             Tuple* tuple = row->get_tuple(j);
             if (tuple == nullptr) {
                 continue;
-            }
-
-            for (auto slot : (*desc)->string_slots()) {
-                DCHECK(slot->type().is_string_type());
-                StringValue* string_val = tuple->get_string_slot(slot->tuple_offset());
-                int offset = reinterpret_cast<intptr_t>(string_val->ptr);
-                string_val->ptr = reinterpret_cast<char*>(tuple_data + offset);
-
-                // Why we do this mask? Field len of StringValue is changed from int to size_t in
-                // StarRocks 0.11. When upgrading, some bits of len sent from 0.10 is random value,
-                // this works fine in version 0.10, however in 0.11 this will lead to an invalid
-                // length. So we make the high bits zero here.
-                string_val->len &= 0x7FFFFFFFL;
             }
         }
     }
@@ -212,28 +196,11 @@ RowBatch::RowBatch(const RowDescriptor& row_desc, const TRowBatch& input_batch)
         TupleRow* row = get_row(i);
         std::vector<TupleDescriptor*>::const_iterator desc = tuple_descs.begin();
         for (int j = 0; desc != tuple_descs.end(); ++desc, ++j) {
-            if ((*desc)->string_slots().empty()) {
-                continue;
-            }
+
 
             Tuple* tuple = row->get_tuple(j);
             if (tuple == nullptr) {
                 continue;
-            }
-
-            std::vector<SlotDescriptor*>::const_iterator slot = (*desc)->string_slots().begin();
-            for (; slot != (*desc)->string_slots().end(); ++slot) {
-                DCHECK((*slot)->type().is_string_type());
-                StringValue* string_val = tuple->get_string_slot((*slot)->tuple_offset());
-
-                int offset = reinterpret_cast<intptr_t>(string_val->ptr);
-                string_val->ptr = reinterpret_cast<char*>(tuple_data + offset);
-
-                // Why we do this mask? Field len of StringValue is changed from int to size_t in
-                // StarRocks 0.11. When upgrading, some bits of len sent from 0.10 is random value,
-                // this works fine in version 0.10, however in 0.11 this will lead to an invalid
-                // length. So we make the high bits zero here.
-                string_val->len &= 0x7FFFFFFFL;
             }
         }
     }
@@ -434,15 +401,6 @@ int RowBatch::total_byte_size() {
                 continue;
             }
             result += (*desc)->byte_size();
-            std::vector<SlotDescriptor*>::const_iterator slot = (*desc)->string_slots().begin();
-            for (; slot != (*desc)->string_slots().end(); ++slot) {
-                DCHECK((*slot)->type().is_string_type());
-                if (tuple->is_null((*slot)->null_indicator_offset())) {
-                    continue;
-                }
-                StringValue* string_val = tuple->get_string_slot((*slot)->tuple_offset());
-                result += string_val->len;
-            }
         }
     }
 


### PR DESCRIPTION
For https://github.com/StarRocks/starrocks/issues/1322

The query plan is right.

```
I1116 19:25:25.106344  4111 global_dicts.cpp:318]  change slot id type to TYPE_VARCHAR 140
I1116 19:25:25.116477  4111 join_hash_map.tpp:410] slot id 140 slot type VARCHAR(-1) slot name c_birth_country
I1116 19:25:25.116509  4111 join_hash_map.tpp:413]  column name nullable-integral-4
I1116 19:25:25.241562  4107 global_dicts.cpp:318]  change slot id type to TYPE_VARCHAR 139
I1116 19:25:25.250615  4107 join_hash_map.tpp:410] slot id 1 slot type INT slot name c_customer_sk
I1116 19:25:25.250638  4107 join_hash_map.tpp:413]  column name integral-4
I1116 19:25:25.250680  4107 join_hash_map.tpp:410] slot id 2 slot type CHAR(16) slot name c_customer_id
I1116 19:25:25.250687  4107 join_hash_map.tpp:413]  column name binary
I1116 19:25:25.251786  4107 join_hash_map.tpp:410] slot id 139 slot type VARCHAR(-1) slot name c_birth_country
```
The core reason is `DictOptimizeParser::rewrite_descriptor` change the slot type from int to varchar.
we shouldn't change it, so we use decoded_slot in olap_scan_node.

Remove the `_string_slots`  and `_no_string_slots` by the way.
