### PR TITLE
make the column type of the hive table always nullable

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
@@ -380,6 +380,10 @@ public class HiveTable extends Table {
                     throw new DdlException("can not convert hive column type [" + hiveColumn.getType() + "] to " +
                             "starrocks type [" + column.getPrimitiveType() + "]");
                 }
+                if (!column.isAllowNull() && !isTypeRead) {
+                    throw new DdlException(
+                            "hive extern table not support no-nullable column: [" + hiveColumn.getName() + "]");
+                }
             }
             for (FieldSchema partHiveColumn : partHiveColumns) {
                 String columnName = partHiveColumn.getName();

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/HiveTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/HiveTableTest.java
@@ -49,7 +49,7 @@ public class HiveTableTest {
         hiveTable = "table0";
 
         columns = Lists.newArrayList();
-        Column column = new Column("col1", Type.BIGINT);
+        Column column = new Column("col1", Type.BIGINT, true);
         columns.add(column);
 
         properties = Maps.newHashMap();
@@ -107,14 +107,14 @@ public class HiveTableTest {
             }
         };
 
-        columns.add(new Column("col2", Type.INT));
+        columns.add(new Column("col2", Type.INT, true));
         properties.put("resource", resourceName);
         HiveTable table = new HiveTable(1000, "hive_table", columns, properties);
         Assert.assertEquals(hiveTable, table.getHiveTable());
         Assert.assertEquals(hiveDb, table.getHiveDb());
         Assert.assertEquals(String.format("%s.%s", hiveDb, hiveTable), table.getHiveDbTable());
         Assert.assertEquals(hdfsPath, table.getHdfsPath());
-        Assert.assertEquals(Lists.newArrayList(new Column("col1", Type.BIGINT)), table.getPartitionColumns());
+        Assert.assertEquals(Lists.newArrayList(new Column("col1", Type.BIGINT, true)), table.getPartitionColumns());
     }
 
     @Test(expected = DdlException.class)


### PR DESCRIPTION
we still have a lot of work to do in the not null column type of Hive tables,
so for now we'll disable the not null type creation


for #1302