### PR TITLE
Bugfix: select the appropriate child get_next interface according to …

### DIFF
--- a/be/src/storage/vectorized/aggregate_iterator.cpp
+++ b/be/src/storage/vectorized/aggregate_iterator.cpp
@@ -82,7 +82,12 @@ Status AggregateIterator::do_get_next(Chunk* chunk, std::vector<RowSourceMask>* 
         if (_aggregator.source_exhausted()) {
             _curr_chunk->reset();
 
-            Status st = _child->get_next(_curr_chunk.get(), source_masks);
+            Status st;
+            if (source_masks) {
+                st = _child->get_next(_curr_chunk.get(), source_masks);
+            } else {
+                st = _child->get_next(_curr_chunk.get());
+            }
 
             if (st.is_end_of_file()) {
                 _fetch_finish = true;


### PR DESCRIPTION
…whether the source masks is null in AggregateIterator

When source_masks is null, use the get_next(chunk) interface of child.