### PR TITLE
Disable low cardinality optimization for predicate in project

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/Projection.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/Projection.java
@@ -4,6 +4,7 @@ package com.starrocks.sql.optimizer.operator;
 import com.google.common.base.Preconditions;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.PredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.AddDecodeNodeForDictStringRule;
 
@@ -69,7 +70,11 @@ public class Projection {
         return false;
     }
 
-    private static boolean couldApplyDictOptimize(ScalarOperator operator) {
+    public static boolean couldApplyDictOptimize(ScalarOperator operator) {
+        // Predicate in projection is rare case, don't optimize it
+        if (operator instanceof PredicateOperator) {
+            return false;
+        }
         return operator.accept(new AddDecodeNodeForDictStringRule.CouldApplyDictOptimizeVisitor(), null);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/AddDecodeNodeForDictStringRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/AddDecodeNodeForDictStringRule.java
@@ -363,7 +363,7 @@ public class AddDecodeNodeForDictStringRule implements PhysicalOperatorTreeRewri
                 return;
             }
 
-            if (!couldApplyDictOptimize(operator)) {
+            if (!Projection.couldApplyDictOptimize(operator)) {
                 return;
             }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecodeRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecodeRewriteTest.java
@@ -420,19 +420,19 @@ public class DecodeRewriteTest extends PlanTestBase{
         String sql = "select count(t.a) from(select S_ADDRESS in ('kks', 'kks2') as a from supplier) as t";
         String plan = getVerboseExplain(sql);
 
-        Assert.assertTrue(plan.contains(" 11: S_ADDRESS IN ('kks', 'kks2')"));
+        Assert.assertTrue(plan.contains(" 3: S_ADDRESS IN ('kks', 'kks2')"));
 
         sql = "select count(t.a) from(select S_ADDRESS = 'kks' as a from supplier) as t";
         plan = getVerboseExplain(sql);
-        Assert.assertTrue(plan.contains(" [11: S_ADDRESS, INT, false] = 'kks'"));
+        Assert.assertTrue(plan.contains("[3: S_ADDRESS, VARCHAR, false] = 'kks'"));
 
         sql = "select count(t.a) from(select S_ADDRESS is null as a from supplier) as t";
         plan = getVerboseExplain(sql);
-        Assert.assertTrue(plan.contains("11: S_ADDRESS IS NULL"));
+        Assert.assertTrue(plan.contains("3: S_ADDRESS IS NULL"));
 
         sql = "select count(t.a) from(select S_ADDRESS is not null as a from supplier) as t";
         plan = getVerboseExplain(sql);
-        Assert.assertTrue(plan.contains("11: S_ADDRESS IS NOT NULL"));
+        Assert.assertTrue(plan.contains("3: S_ADDRESS IS NOT NULL"));
 
         sql = "select count(t.a) from(select S_ADDRESS <=> 'kks' as a from supplier) as t";
         plan = getVerboseExplain(sql);


### PR DESCRIPTION
For https://github.com/StarRocks/starrocks/issues/1305

I support low cardinality optimization for predicate in project in https://github.com/StarRocks/starrocks/pull/1283

But currently our BE handle predicate in project has some issues, also consider the predicate in projection is rare case, so we disable optimize this case