### PR TITLE
[pipeline] use ContextBase to short-circuit and close complex operators

### DIFF
--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.cpp
@@ -12,6 +12,11 @@ Status AggregateBlockingSinkOperator::prepare(RuntimeState* state) {
     return _aggregator->open(state);
 }
 
+Status AggregateBlockingSinkOperator::close(RuntimeState* state) {
+    RETURN_IF_ERROR(_aggregator->close_one_operator(state));
+    return Operator::close(state);
+}
+
 void AggregateBlockingSinkOperator::set_finishing(RuntimeState* state) {
     _is_finished = true;
 

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.cpp
@@ -13,7 +13,7 @@ Status AggregateBlockingSinkOperator::prepare(RuntimeState* state) {
 }
 
 Status AggregateBlockingSinkOperator::close(RuntimeState* state) {
-    RETURN_IF_ERROR(_aggregator->close_one_operator(state));
+    RETURN_IF_ERROR(_aggregator->unref(state));
     return Operator::close(state);
 }
 

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.cpp
@@ -6,8 +6,6 @@ namespace starrocks::pipeline {
 
 Status AggregateBlockingSinkOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(Operator::prepare(state));
-    // _aggregator is shared by sink operator and source operator
-    // we must only prepare it at sink operator
     RETURN_IF_ERROR(_aggregator->prepare(state, state->obj_pool(), get_runtime_profile(), _mem_tracker.get()));
     return _aggregator->open(state);
 }

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.cpp
@@ -12,10 +12,6 @@ Status AggregateBlockingSinkOperator::prepare(RuntimeState* state) {
     return _aggregator->open(state);
 }
 
-bool AggregateBlockingSinkOperator::is_finished() const {
-    return _is_finished;
-}
-
 void AggregateBlockingSinkOperator::set_finishing(RuntimeState* state) {
     _is_finished = true;
 

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.h
@@ -13,7 +13,7 @@ public:
     AggregateBlockingSinkOperator(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
             : Operator(id, "aggregate_blocking_sink", plan_node_id), _aggregator(std::move(aggregator)) {
         _aggregator->set_aggr_phase(AggrPhase2);
-        _aggregator->ref_no_barrier();
+        _aggregator->ref();
     }
     ~AggregateBlockingSinkOperator() override = default;
 

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.h
@@ -29,8 +29,11 @@ public:
     Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override;
 
 private:
-    // It is used to perform aggregation algorithms
-    // shared by AggregateBlockingSourceOperator
+    // It is used to perform aggregation algorithms shared by
+    // AggregateBlockingSourceOperator. It is
+    // - prepared at SinkOperator::prepare(),
+    // - reffed at constructor() of both sink and source operator,
+    // - unreffed at close() of both sink and source operator.
     AggregatorPtr _aggregator = nullptr;
     // Whether prev operator has no output
     bool _is_finished = false;

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.h
@@ -17,8 +17,8 @@ public:
     ~AggregateBlockingSinkOperator() override = default;
 
     bool has_output() const override { return false; }
-    bool need_input() const override { return true; }
-    bool is_finished() const override;
+    bool need_input() const override { return !is_finished(); }
+    bool is_finished() const override { return _is_finished; }
     void set_finishing(RuntimeState* state) override;
 
     Status prepare(RuntimeState* state) override;

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.h
@@ -13,15 +13,17 @@ public:
     AggregateBlockingSinkOperator(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
             : Operator(id, "aggregate_blocking_sink", plan_node_id), _aggregator(std::move(aggregator)) {
         _aggregator->set_aggr_phase(AggrPhase2);
+        _aggregator->create_one_operator();
     }
     ~AggregateBlockingSinkOperator() override = default;
 
     bool has_output() const override { return false; }
     bool need_input() const override { return !is_finished(); }
-    bool is_finished() const override { return _is_finished; }
+    bool is_finished() const override { return _is_finished || _aggregator->is_finished(); }
     void set_finishing(RuntimeState* state) override;
 
     Status prepare(RuntimeState* state) override;
+    Status close(RuntimeState* state) override;
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
     Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override;

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.h
@@ -13,7 +13,7 @@ public:
     AggregateBlockingSinkOperator(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
             : Operator(id, "aggregate_blocking_sink", plan_node_id), _aggregator(std::move(aggregator)) {
         _aggregator->set_aggr_phase(AggrPhase2);
-        _aggregator->create_one_operator();
+        _aggregator->ref_no_barrier();
     }
     ~AggregateBlockingSinkOperator() override = default;
 

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.cpp
@@ -21,7 +21,7 @@ void AggregateBlockingSourceOperator::set_finished(RuntimeState* state) {
 Status AggregateBlockingSourceOperator::close(RuntimeState* state) {
     // _aggregator is shared by sink operator and source operator
     // we must only close it at source operator
-    RETURN_IF_ERROR(_aggregator->close_one_operator(state));
+    RETURN_IF_ERROR(_aggregator->unref(state));
     return SourceOperator::close(state);
 }
 

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.cpp
@@ -19,8 +19,6 @@ void AggregateBlockingSourceOperator::set_finished(RuntimeState* state) {
 }
 
 Status AggregateBlockingSourceOperator::close(RuntimeState* state) {
-    // _aggregator is shared by sink operator and source operator
-    // we must only close it at source operator
     RETURN_IF_ERROR(_aggregator->unref(state));
     return SourceOperator::close(state);
 }

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.cpp
@@ -14,14 +14,14 @@ bool AggregateBlockingSourceOperator::is_finished() const {
     return _aggregator->is_sink_complete() && _aggregator->is_ht_eos();
 }
 
-void AggregateBlockingSourceOperator::set_finishing(RuntimeState* state) {
-    _is_finished = true;
+void AggregateBlockingSourceOperator::set_finished(RuntimeState* state) {
+    _aggregator->set_finished();
 }
 
 Status AggregateBlockingSourceOperator::close(RuntimeState* state) {
     // _aggregator is shared by sink operator and source operator
     // we must only close it at source operator
-    RETURN_IF_ERROR(_aggregator->close(state));
+    RETURN_IF_ERROR(_aggregator->close_one_operator(state));
     return SourceOperator::close(state);
 }
 
@@ -59,4 +59,5 @@ StatusOr<vectorized::ChunkPtr> AggregateBlockingSourceOperator::pull_chunk(Runti
 
     return std::move(chunk);
 }
+
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.h
@@ -12,7 +12,7 @@ class AggregateBlockingSourceOperator : public SourceOperator {
 public:
     AggregateBlockingSourceOperator(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
             : SourceOperator(id, "aggregate_blocking_source", plan_node_id), _aggregator(std::move(aggregator)) {
-        _aggregator->ref_no_barrier();
+        _aggregator->ref();
     }
 
     ~AggregateBlockingSourceOperator() override = default;

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.h
@@ -19,8 +19,7 @@ public:
 
     bool has_output() const override;
     bool is_finished() const override;
-    // set_finishing does nothing.
-    void set_finishing(RuntimeState* state) override {}
+
     void set_finished(RuntimeState* state) override;
 
     Status close(RuntimeState* state) override;

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.h
@@ -27,8 +27,11 @@ public:
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 
 private:
-    // It is used to perform aggregation algorithms
-    // shared by AggregateBlockingSinkOperator
+    // It is used to perform aggregation algorithms shared by
+    // AggregateBlockingSinkOperator. It is
+    // - prepared at SinkOperator::prepare(),
+    // - reffed at constructor() of both sink and source operator,
+    // - unreffed at close() of both sink and source operator.
     AggregatorPtr _aggregator = nullptr;
 };
 

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.h
@@ -11,12 +11,17 @@ namespace starrocks::pipeline {
 class AggregateBlockingSourceOperator : public SourceOperator {
 public:
     AggregateBlockingSourceOperator(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
-            : SourceOperator(id, "aggregate_blocking_source", plan_node_id), _aggregator(std::move(aggregator)) {}
+            : SourceOperator(id, "aggregate_blocking_source", plan_node_id), _aggregator(std::move(aggregator)) {
+        _aggregator->create_one_operator();
+    }
+
     ~AggregateBlockingSourceOperator() override = default;
 
     bool has_output() const override;
     bool is_finished() const override;
-    void set_finishing(RuntimeState* state) override;
+    // set_finishing does nothing.
+    void set_finishing(RuntimeState* state) override {}
+    void set_finished(RuntimeState* state) override;
 
     Status close(RuntimeState* state) override;
 
@@ -26,8 +31,6 @@ private:
     // It is used to perform aggregation algorithms
     // shared by AggregateBlockingSinkOperator
     AggregatorPtr _aggregator = nullptr;
-    // Whether prev operator has no output
-    bool _is_finished = false;
 };
 
 class AggregateBlockingSourceOperatorFactory final : public SourceOperatorFactory {

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.h
@@ -12,7 +12,7 @@ class AggregateBlockingSourceOperator : public SourceOperator {
 public:
     AggregateBlockingSourceOperator(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
             : SourceOperator(id, "aggregate_blocking_source", plan_node_id), _aggregator(std::move(aggregator)) {
-        _aggregator->create_one_operator();
+        _aggregator->ref_no_barrier();
     }
 
     ~AggregateBlockingSourceOperator() override = default;

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.cpp
@@ -6,8 +6,6 @@ namespace starrocks::pipeline {
 
 Status AggregateDistinctBlockingSinkOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(Operator::prepare(state));
-    // _aggregator is shared by sink operator and source operator
-    // we must only prepare it at sink operator
     RETURN_IF_ERROR(_aggregator->prepare(state, state->obj_pool(), get_runtime_profile(), _mem_tracker.get()));
     return _aggregator->open(state);
 }

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.cpp
@@ -12,10 +12,6 @@ Status AggregateDistinctBlockingSinkOperator::prepare(RuntimeState* state) {
     return _aggregator->open(state);
 }
 
-bool AggregateDistinctBlockingSinkOperator::is_finished() const {
-    return _is_finished;
-}
-
 void AggregateDistinctBlockingSinkOperator::set_finishing(RuntimeState* state) {
     _is_finished = true;
 

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.cpp
@@ -12,6 +12,11 @@ Status AggregateDistinctBlockingSinkOperator::prepare(RuntimeState* state) {
     return _aggregator->open(state);
 }
 
+Status AggregateDistinctBlockingSinkOperator::close(RuntimeState* state) {
+    RETURN_IF_ERROR(_aggregator->close_one_operator(state));
+    return Operator::close(state);
+}
+
 void AggregateDistinctBlockingSinkOperator::set_finishing(RuntimeState* state) {
     _is_finished = true;
 

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.cpp
@@ -13,7 +13,7 @@ Status AggregateDistinctBlockingSinkOperator::prepare(RuntimeState* state) {
 }
 
 Status AggregateDistinctBlockingSinkOperator::close(RuntimeState* state) {
-    RETURN_IF_ERROR(_aggregator->close_one_operator(state));
+    RETURN_IF_ERROR(_aggregator->unref(state));
     return Operator::close(state);
 }
 

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.h
@@ -17,8 +17,8 @@ public:
     ~AggregateDistinctBlockingSinkOperator() override = default;
 
     bool has_output() const override { return false; }
-    bool need_input() const override { return true; }
-    bool is_finished() const override;
+    bool need_input() const override { return !is_finished(); }
+    bool is_finished() const override { return _is_finished; }
     void set_finishing(RuntimeState* state) override;
 
     Status prepare(RuntimeState* state) override;

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.h
@@ -13,15 +13,17 @@ public:
     AggregateDistinctBlockingSinkOperator(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
             : Operator(id, "aggregate_distinct_blocking_sink", plan_node_id), _aggregator(std::move(aggregator)) {
         _aggregator->set_aggr_phase(AggrPhase2);
+        _aggregator->create_one_operator();
     }
     ~AggregateDistinctBlockingSinkOperator() override = default;
 
     bool has_output() const override { return false; }
     bool need_input() const override { return !is_finished(); }
-    bool is_finished() const override { return _is_finished; }
+    bool is_finished() const override { return _is_finished || _aggregator->is_finished(); }
     void set_finishing(RuntimeState* state) override;
 
     Status prepare(RuntimeState* state) override;
+    Status close(RuntimeState* state) override;
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
     Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override;

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.h
@@ -13,7 +13,7 @@ public:
     AggregateDistinctBlockingSinkOperator(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
             : Operator(id, "aggregate_distinct_blocking_sink", plan_node_id), _aggregator(std::move(aggregator)) {
         _aggregator->set_aggr_phase(AggrPhase2);
-        _aggregator->ref_no_barrier();
+        _aggregator->ref();
     }
     ~AggregateDistinctBlockingSinkOperator() override = default;
 

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.h
@@ -29,8 +29,11 @@ public:
     Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override;
 
 private:
-    // It is used to perform aggregation algorithms
-    // shared by AggregateBlockingSourceOperator
+    // It is used to perform aggregation algorithms shared by
+    // AggregateDistinctBlockingSourceOperator. It is
+    // - prepared at SinkOperator::prepare(),
+    // - reffed at constructor() of both sink and source operator,
+    // - unreffed at close() of both sink and source operator.
     AggregatorPtr _aggregator = nullptr;
     // Whether prev operator has no output
     bool _is_finished = false;

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.h
@@ -13,7 +13,7 @@ public:
     AggregateDistinctBlockingSinkOperator(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
             : Operator(id, "aggregate_distinct_blocking_sink", plan_node_id), _aggregator(std::move(aggregator)) {
         _aggregator->set_aggr_phase(AggrPhase2);
-        _aggregator->create_one_operator();
+        _aggregator->ref_no_barrier();
     }
     ~AggregateDistinctBlockingSinkOperator() override = default;
 

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.cpp
@@ -14,14 +14,14 @@ bool AggregateDistinctBlockingSourceOperator::is_finished() const {
     return _aggregator->is_sink_complete() && _aggregator->is_ht_eos();
 }
 
-void AggregateDistinctBlockingSourceOperator::set_finishing(RuntimeState* state) {
-    _is_finished = true;
+void AggregateDistinctBlockingSourceOperator::set_finished(RuntimeState* state) {
+    _aggregator->set_finished();
 }
 
 Status AggregateDistinctBlockingSourceOperator::close(RuntimeState* state) {
     // _aggregator is shared by sink operator and source operator
     // we must only close it at source operator
-    RETURN_IF_ERROR(_aggregator->close(state));
+    RETURN_IF_ERROR(_aggregator->close_one_operator(state));
     return SourceOperator::close(state);
 }
 

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.cpp
@@ -21,7 +21,7 @@ void AggregateDistinctBlockingSourceOperator::set_finished(RuntimeState* state) 
 Status AggregateDistinctBlockingSourceOperator::close(RuntimeState* state) {
     // _aggregator is shared by sink operator and source operator
     // we must only close it at source operator
-    RETURN_IF_ERROR(_aggregator->close_one_operator(state));
+    RETURN_IF_ERROR(_aggregator->unref(state));
     return SourceOperator::close(state);
 }
 

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.cpp
@@ -19,8 +19,6 @@ void AggregateDistinctBlockingSourceOperator::set_finished(RuntimeState* state) 
 }
 
 Status AggregateDistinctBlockingSourceOperator::close(RuntimeState* state) {
-    // _aggregator is shared by sink operator and source operator
-    // we must only close it at source operator
     RETURN_IF_ERROR(_aggregator->unref(state));
     return SourceOperator::close(state);
 }

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.h
@@ -13,7 +13,7 @@ public:
     AggregateDistinctBlockingSourceOperator(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
             : SourceOperator(id, "aggregate_distinct_blocking_source", plan_node_id),
               _aggregator(std::move(aggregator)) {
-        _aggregator->ref_no_barrier();
+        _aggregator->ref();
     }
 
     ~AggregateDistinctBlockingSourceOperator() override = default;

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.h
@@ -28,8 +28,11 @@ public:
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 
 private:
-    // It is used to perform aggregation algorithms
-    // shared by AggregateBlockingSinkOperator
+    // It is used to perform aggregation algorithms shared by
+    // AggregateDistinctBlockingSinkOperator. It is
+    // - prepared at SinkOperator::prepare(),
+    // - reffed at constructor() of both sink and source operator,
+    // - unreffed at close() of both sink and source operator.
     AggregatorPtr _aggregator = nullptr;
 };
 

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.h
@@ -12,12 +12,17 @@ class AggregateDistinctBlockingSourceOperator : public SourceOperator {
 public:
     AggregateDistinctBlockingSourceOperator(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
             : SourceOperator(id, "aggregate_distinct_blocking_source", plan_node_id),
-              _aggregator(std::move(aggregator)) {}
+              _aggregator(std::move(aggregator)) {
+        _aggregator->create_one_operator();
+    }
+
     ~AggregateDistinctBlockingSourceOperator() override = default;
 
     bool has_output() const override;
     bool is_finished() const override;
-    void set_finishing(RuntimeState* state) override;
+    // set_finishing does nothing.
+    void set_finishing(RuntimeState* state) override {}
+    void set_finished(RuntimeState* state) override;
 
     Status close(RuntimeState* state) override;
 
@@ -27,8 +32,6 @@ private:
     // It is used to perform aggregation algorithms
     // shared by AggregateBlockingSinkOperator
     AggregatorPtr _aggregator = nullptr;
-    // Whether prev operator has no output
-    bool _is_finished = false;
 };
 
 class AggregateDistinctBlockingSourceOperatorFactory final : public SourceOperatorFactory {

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.h
@@ -13,7 +13,7 @@ public:
     AggregateDistinctBlockingSourceOperator(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
             : SourceOperator(id, "aggregate_distinct_blocking_source", plan_node_id),
               _aggregator(std::move(aggregator)) {
-        _aggregator->create_one_operator();
+        _aggregator->ref_no_barrier();
     }
 
     ~AggregateDistinctBlockingSourceOperator() override = default;

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.h
@@ -20,8 +20,7 @@ public:
 
     bool has_output() const override;
     bool is_finished() const override;
-    // set_finishing does nothing.
-    void set_finishing(RuntimeState* state) override {}
+
     void set_finished(RuntimeState* state) override;
 
     Status close(RuntimeState* state) override;

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.cpp
@@ -13,6 +13,11 @@ Status AggregateDistinctStreamingSinkOperator::prepare(RuntimeState* state) {
     return _aggregator->open(state);
 }
 
+Status AggregateDistinctStreamingSinkOperator::close(RuntimeState* state) {
+    RETURN_IF_ERROR(_aggregator->close_one_operator(state));
+    return Operator::close(state);
+}
+
 void AggregateDistinctStreamingSinkOperator::set_finishing(RuntimeState* state) {
     _is_finished = true;
 

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.cpp
@@ -13,10 +13,6 @@ Status AggregateDistinctStreamingSinkOperator::prepare(RuntimeState* state) {
     return _aggregator->open(state);
 }
 
-bool AggregateDistinctStreamingSinkOperator::is_finished() const {
-    return _is_finished;
-}
-
 void AggregateDistinctStreamingSinkOperator::set_finishing(RuntimeState* state) {
     _is_finished = true;
 

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.cpp
@@ -14,7 +14,7 @@ Status AggregateDistinctStreamingSinkOperator::prepare(RuntimeState* state) {
 }
 
 Status AggregateDistinctStreamingSinkOperator::close(RuntimeState* state) {
-    RETURN_IF_ERROR(_aggregator->close_one_operator(state));
+    RETURN_IF_ERROR(_aggregator->unref(state));
     return Operator::close(state);
 }
 

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.cpp
@@ -7,8 +7,6 @@ namespace starrocks::pipeline {
 
 Status AggregateDistinctStreamingSinkOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(Operator::prepare(state));
-    // _aggregator is shared by sink operator and source operator
-    // we must only prepare it at sink operator
     RETURN_IF_ERROR(_aggregator->prepare(state, state->obj_pool(), get_runtime_profile(), _mem_tracker.get()));
     return _aggregator->open(state);
 }

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.h
@@ -13,7 +13,7 @@ public:
     AggregateDistinctStreamingSinkOperator(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
             : Operator(id, "aggregate_distinct_streaming_sink", plan_node_id), _aggregator(std::move(aggregator)) {
         _aggregator->set_aggr_phase(AggrPhase1);
-        _aggregator->create_one_operator();
+        _aggregator->ref_no_barrier();
     }
     ~AggregateDistinctStreamingSinkOperator() override = default;
 

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.h
@@ -13,15 +13,17 @@ public:
     AggregateDistinctStreamingSinkOperator(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
             : Operator(id, "aggregate_distinct_streaming_sink", plan_node_id), _aggregator(std::move(aggregator)) {
         _aggregator->set_aggr_phase(AggrPhase1);
+        _aggregator->create_one_operator();
     }
     ~AggregateDistinctStreamingSinkOperator() override = default;
 
     bool has_output() const override { return false; }
     bool need_input() const override { return !is_finished(); }
-    bool is_finished() const override { return _is_finished; }
+    bool is_finished() const override { return _is_finished || _aggregator->is_finished(); }
     void set_finishing(RuntimeState* state) override;
 
     Status prepare(RuntimeState* state) override;
+    Status close(RuntimeState* state) override;
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
     Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override;

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.h
@@ -13,7 +13,7 @@ public:
     AggregateDistinctStreamingSinkOperator(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
             : Operator(id, "aggregate_distinct_streaming_sink", plan_node_id), _aggregator(std::move(aggregator)) {
         _aggregator->set_aggr_phase(AggrPhase1);
-        _aggregator->ref_no_barrier();
+        _aggregator->ref();
     }
     ~AggregateDistinctStreamingSinkOperator() override = default;
 

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.h
@@ -17,8 +17,8 @@ public:
     ~AggregateDistinctStreamingSinkOperator() override = default;
 
     bool has_output() const override { return false; }
-    bool need_input() const override { return true; }
-    bool is_finished() const override;
+    bool need_input() const override { return !is_finished(); }
+    bool is_finished() const override { return _is_finished; }
     void set_finishing(RuntimeState* state) override;
 
     Status prepare(RuntimeState* state) override;

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.h
@@ -38,8 +38,11 @@ private:
     // Invoked by push_chunk  if current mode is TStreamingPreaggregationMode::AUTO
     Status _push_chunk_by_auto(const size_t chunk_size);
 
-    // It is used to perform aggregation algorithms
-    // shared by AggregateStreamingSourceOperator
+    // It is used to perform aggregation algorithms shared by
+    // AggregateDistinctStreamingSourceOperator. It is
+    // - prepared at SinkOperator::prepare(),
+    // - reffed at constructor() of both sink and source operator,
+    // - unreffed at close() of both sink and source operator.
     AggregatorPtr _aggregator = nullptr;
     // Whether prev operator has no output
     bool _is_finished = false;

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.cpp
@@ -36,7 +36,7 @@ void AggregateDistinctStreamingSourceOperator::set_finished(RuntimeState* state)
 Status AggregateDistinctStreamingSourceOperator::close(RuntimeState* state) {
     // _aggregator is shared by sink operator and source operator
     // we must only close it at source operator
-    RETURN_IF_ERROR(_aggregator->close_one_operator(state));
+    RETURN_IF_ERROR(_aggregator->unref(state));
     return SourceOperator::close(state);
 }
 

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.cpp
@@ -29,14 +29,14 @@ bool AggregateDistinctStreamingSourceOperator::is_finished() const {
     return _aggregator->is_sink_complete() && _aggregator->is_chunk_buffer_empty() && _aggregator->is_ht_eos();
 }
 
-void AggregateDistinctStreamingSourceOperator::set_finishing(RuntimeState* state) {
-    _is_finished = true;
+void AggregateDistinctStreamingSourceOperator::set_finished(RuntimeState* state) {
+    _aggregator->set_finished();
 }
 
 Status AggregateDistinctStreamingSourceOperator::close(RuntimeState* state) {
     // _aggregator is shared by sink operator and source operator
     // we must only close it at source operator
-    RETURN_IF_ERROR(_aggregator->close(state));
+    RETURN_IF_ERROR(_aggregator->close_one_operator(state));
     return SourceOperator::close(state);
 }
 

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.cpp
@@ -34,8 +34,6 @@ void AggregateDistinctStreamingSourceOperator::set_finished(RuntimeState* state)
 }
 
 Status AggregateDistinctStreamingSourceOperator::close(RuntimeState* state) {
-    // _aggregator is shared by sink operator and source operator
-    // we must only close it at source operator
     RETURN_IF_ERROR(_aggregator->unref(state));
     return SourceOperator::close(state);
 }

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.h
@@ -13,7 +13,7 @@ public:
     AggregateDistinctStreamingSourceOperator(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
             : SourceOperator(id, "aggregate_distinct_streaming_source", plan_node_id),
               _aggregator(std::move(aggregator)) {
-        _aggregator->create_one_operator();
+        _aggregator->ref_no_barrier();
     }
 
     ~AggregateDistinctStreamingSourceOperator() override = default;

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.h
@@ -12,12 +12,17 @@ class AggregateDistinctStreamingSourceOperator : public SourceOperator {
 public:
     AggregateDistinctStreamingSourceOperator(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
             : SourceOperator(id, "aggregate_distinct_streaming_source", plan_node_id),
-              _aggregator(std::move(aggregator)) {}
+              _aggregator(std::move(aggregator)) {
+        _aggregator->create_one_operator();
+    }
+
     ~AggregateDistinctStreamingSourceOperator() override = default;
 
     bool has_output() const override;
     bool is_finished() const override;
-    void set_finishing(RuntimeState* state) override;
+    // set_finishing does nothing.
+    void set_finishing(RuntimeState* state) override {}
+    void set_finished(RuntimeState* state) override;
 
     Status close(RuntimeState* state) override;
 
@@ -29,8 +34,6 @@ private:
     // It is used to perform aggregation algorithms
     // shared by AggregateStreamingSinkOperator
     AggregatorPtr _aggregator = nullptr;
-    // Whether prev operator has no output
-    bool _is_finished = false;
 };
 
 class AggregateDistinctStreamingSourceOperatorFactory final : public SourceOperatorFactory {

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.h
@@ -13,7 +13,7 @@ public:
     AggregateDistinctStreamingSourceOperator(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
             : SourceOperator(id, "aggregate_distinct_streaming_source", plan_node_id),
               _aggregator(std::move(aggregator)) {
-        _aggregator->ref_no_barrier();
+        _aggregator->ref();
     }
 
     ~AggregateDistinctStreamingSourceOperator() override = default;

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.h
@@ -30,8 +30,11 @@ public:
 private:
     void _output_chunk_from_hash_set(vectorized::ChunkPtr* chunk);
 
-    // It is used to perform aggregation algorithms
-    // shared by AggregateStreamingSinkOperator
+    // It is used to perform aggregation algorithms shared by
+    // AggregateDistinctStreamingSinkOperator. It is
+    // - prepared at SinkOperator::prepare(),
+    // - reffed at constructor() of both sink and source operator,
+    // - unreffed at close() of both sink and source operator.
     AggregatorPtr _aggregator = nullptr;
 };
 

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.h
@@ -20,8 +20,7 @@ public:
 
     bool has_output() const override;
     bool is_finished() const override;
-    // set_finishing does nothing.
-    void set_finishing(RuntimeState* state) override {}
+
     void set_finished(RuntimeState* state) override;
 
     Status close(RuntimeState* state) override;

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
@@ -13,10 +13,6 @@ Status AggregateStreamingSinkOperator::prepare(RuntimeState* state) {
     return _aggregator->open(state);
 }
 
-bool AggregateStreamingSinkOperator::is_finished() const {
-    return _is_finished;
-}
-
 void AggregateStreamingSinkOperator::set_finishing(RuntimeState* state) {
     _is_finished = true;
 

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
@@ -7,8 +7,6 @@ namespace starrocks::pipeline {
 
 Status AggregateStreamingSinkOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(Operator::prepare(state));
-    // _aggregator is shared by sink operator and source operator
-    // we must only prepare it at sink operator
     RETURN_IF_ERROR(_aggregator->prepare(state, state->obj_pool(), get_runtime_profile(), _mem_tracker.get()));
     return _aggregator->open(state);
 }

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
@@ -13,6 +13,11 @@ Status AggregateStreamingSinkOperator::prepare(RuntimeState* state) {
     return _aggregator->open(state);
 }
 
+Status AggregateStreamingSinkOperator::close(RuntimeState* state) {
+    RETURN_IF_ERROR(_aggregator->close_one_operator(state));
+    return Operator::close(state);
+}
+
 void AggregateStreamingSinkOperator::set_finishing(RuntimeState* state) {
     _is_finished = true;
 

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
@@ -14,7 +14,7 @@ Status AggregateStreamingSinkOperator::prepare(RuntimeState* state) {
 }
 
 Status AggregateStreamingSinkOperator::close(RuntimeState* state) {
-    RETURN_IF_ERROR(_aggregator->close_one_operator(state));
+    RETURN_IF_ERROR(_aggregator->unref(state));
     return Operator::close(state);
 }
 

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.h
@@ -13,7 +13,7 @@ public:
     AggregateStreamingSinkOperator(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
             : Operator(id, "aggregate_streaming_sink", plan_node_id), _aggregator(std::move(aggregator)) {
         _aggregator->set_aggr_phase(AggrPhase1);
-        _aggregator->ref_no_barrier();
+        _aggregator->ref();
     }
     ~AggregateStreamingSinkOperator() override = default;
 

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.h
@@ -13,7 +13,7 @@ public:
     AggregateStreamingSinkOperator(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
             : Operator(id, "aggregate_streaming_sink", plan_node_id), _aggregator(std::move(aggregator)) {
         _aggregator->set_aggr_phase(AggrPhase1);
-        _aggregator->create_one_operator();
+        _aggregator->ref_no_barrier();
     }
     ~AggregateStreamingSinkOperator() override = default;
 

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.h
@@ -17,8 +17,8 @@ public:
     ~AggregateStreamingSinkOperator() override = default;
 
     bool has_output() const override { return false; }
-    bool need_input() const override { return true; }
-    bool is_finished() const override;
+    bool need_input() const override { return !is_finished(); }
+    bool is_finished() const override { return _is_finished; }
     void set_finishing(RuntimeState* state) override;
 
     Status prepare(RuntimeState* state) override;

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.h
@@ -13,15 +13,17 @@ public:
     AggregateStreamingSinkOperator(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
             : Operator(id, "aggregate_streaming_sink", plan_node_id), _aggregator(std::move(aggregator)) {
         _aggregator->set_aggr_phase(AggrPhase1);
+        _aggregator->create_one_operator();
     }
     ~AggregateStreamingSinkOperator() override = default;
 
     bool has_output() const override { return false; }
     bool need_input() const override { return !is_finished(); }
-    bool is_finished() const override { return _is_finished; }
+    bool is_finished() const override { return _is_finished || _aggregator->is_finished(); }
     void set_finishing(RuntimeState* state) override;
 
     Status prepare(RuntimeState* state) override;
+    Status close(RuntimeState* state) override;
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
     Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override;

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.h
@@ -38,8 +38,11 @@ private:
     // Invoked by push_chunk  if current mode is TStreamingPreaggregationMode::AUTO
     Status _push_chunk_by_auto(const size_t chunk_size);
 
-    // It is used to perform aggregation algorithms
-    // shared by AggregateStreamingSourceOperator
+    // It is used to perform aggregation algorithms shared by
+    // AggregateStreamingSourceOperator. It is
+    // - prepared at SinkOperator::prepare(),
+    // - reffed at constructor() of both sink and source operator,
+    // - unreffed at close() of both sink and source operator.
     AggregatorPtr _aggregator = nullptr;
     // Whether prev operator has no output
     bool _is_finished = false;

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.cpp
@@ -52,8 +52,6 @@ void AggregateStreamingSourceOperator::set_finished(RuntimeState* state) {
 }
 
 Status AggregateStreamingSourceOperator::close(RuntimeState* state) {
-    // _aggregator is shared by sink operator and source operator
-    // we must only close it at source operator
     RETURN_IF_ERROR(_aggregator->unref(state));
     return SourceOperator::close(state);
 }

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.cpp
@@ -47,10 +47,14 @@ void AggregateStreamingSourceOperator::set_finishing(RuntimeState* state) {
     _is_finished = true;
 }
 
+void AggregateStreamingSourceOperator::set_finished(RuntimeState* state) {
+    _aggregator->set_finished();
+}
+
 Status AggregateStreamingSourceOperator::close(RuntimeState* state) {
     // _aggregator is shared by sink operator and source operator
     // we must only close it at source operator
-    RETURN_IF_ERROR(_aggregator->close(state));
+    RETURN_IF_ERROR(_aggregator->close_one_operator(state));
     return SourceOperator::close(state);
 }
 

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.cpp
@@ -54,7 +54,7 @@ void AggregateStreamingSourceOperator::set_finished(RuntimeState* state) {
 Status AggregateStreamingSourceOperator::close(RuntimeState* state) {
     // _aggregator is shared by sink operator and source operator
     // we must only close it at source operator
-    RETURN_IF_ERROR(_aggregator->close_one_operator(state));
+    RETURN_IF_ERROR(_aggregator->unref(state));
     return SourceOperator::close(state);
 }
 

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.h
@@ -11,12 +11,16 @@ namespace starrocks::pipeline {
 class AggregateStreamingSourceOperator : public SourceOperator {
 public:
     AggregateStreamingSourceOperator(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
-            : SourceOperator(id, "aggregate_streaming_source", plan_node_id), _aggregator(std::move(aggregator)) {}
+            : SourceOperator(id, "aggregate_streaming_source", plan_node_id), _aggregator(std::move(aggregator)) {
+        _aggregator->create_one_operator();
+    }
+
     ~AggregateStreamingSourceOperator() override = default;
 
     bool has_output() const override;
     bool is_finished() const override;
     void set_finishing(RuntimeState* state) override;
+    void set_finished(RuntimeState* state) override;
 
     Status close(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.h
@@ -29,8 +29,11 @@ public:
 private:
     void _output_chunk_from_hash_map(vectorized::ChunkPtr* chunk);
 
-    // It is used to perform aggregation algorithms
-    // shared by AggregateStreamingSinkOperator
+    // It is used to perform aggregation algorithms shared by
+    // AggregateStreamingSinkOperator. It is
+    // - prepared at SinkOperator::prepare(),
+    // - reffed at constructor() of both sink and source operator,
+    // - unreffed at close() of both sink and source operator.
     AggregatorPtr _aggregator = nullptr;
     // Whether prev operator has no output
     mutable bool _is_finished = false;

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.h
@@ -12,7 +12,7 @@ class AggregateStreamingSourceOperator : public SourceOperator {
 public:
     AggregateStreamingSourceOperator(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
             : SourceOperator(id, "aggregate_streaming_source", plan_node_id), _aggregator(std::move(aggregator)) {
-        _aggregator->create_one_operator();
+        _aggregator->ref_no_barrier();
     }
 
     ~AggregateStreamingSourceOperator() override = default;

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.h
@@ -12,7 +12,7 @@ class AggregateStreamingSourceOperator : public SourceOperator {
 public:
     AggregateStreamingSourceOperator(int32_t id, int32_t plan_node_id, AggregatorPtr aggregator)
             : SourceOperator(id, "aggregate_streaming_source", plan_node_id), _aggregator(std::move(aggregator)) {
-        _aggregator->ref_no_barrier();
+        _aggregator->ref();
     }
 
     ~AggregateStreamingSourceOperator() override = default;

--- a/be/src/exec/pipeline/analysis/analytic_sink_operator.cpp
+++ b/be/src/exec/pipeline/analysis/analytic_sink_operator.cpp
@@ -38,8 +38,13 @@ Status AnalyticSinkOperator::prepare(RuntimeState* state) {
     return Status::OK();
 }
 
+Status AnalyticSinkOperator::close(RuntimeState* state) {
+    RETURN_IF_ERROR(_analytor->close_one_operator(state));
+    return Operator::close(state);
+}
+
 bool AnalyticSinkOperator::is_finished() const {
-    return _is_finished;
+    return _is_finished || _analytor->is_finished();
 }
 
 void AnalyticSinkOperator::set_finishing(RuntimeState* state) {

--- a/be/src/exec/pipeline/analysis/analytic_sink_operator.cpp
+++ b/be/src/exec/pipeline/analysis/analytic_sink_operator.cpp
@@ -43,10 +43,6 @@ Status AnalyticSinkOperator::close(RuntimeState* state) {
     return Operator::close(state);
 }
 
-bool AnalyticSinkOperator::is_finished() const {
-    return _is_finished || _analytor->is_finished();
-}
-
 void AnalyticSinkOperator::set_finishing(RuntimeState* state) {
     _is_finished = true;
     _analytor->input_eos() = true;

--- a/be/src/exec/pipeline/analysis/analytic_sink_operator.cpp
+++ b/be/src/exec/pipeline/analysis/analytic_sink_operator.cpp
@@ -39,7 +39,7 @@ Status AnalyticSinkOperator::prepare(RuntimeState* state) {
 }
 
 Status AnalyticSinkOperator::close(RuntimeState* state) {
-    RETURN_IF_ERROR(_analytor->close_one_operator(state));
+    RETURN_IF_ERROR(_analytor->unref(state));
     return Operator::close(state);
 }
 

--- a/be/src/exec/pipeline/analysis/analytic_sink_operator.h
+++ b/be/src/exec/pipeline/analysis/analytic_sink_operator.h
@@ -9,7 +9,9 @@ namespace starrocks::pipeline {
 class AnalyticSinkOperator : public Operator {
 public:
     AnalyticSinkOperator(int32_t id, int32_t plan_node_id, const TPlanNode& tnode, AnalytorPtr analytor)
-            : Operator(id, "analytic_sink", plan_node_id), _tnode(tnode), _analytor(analytor) {}
+            : Operator(id, "analytic_sink", plan_node_id), _tnode(tnode), _analytor(std::move(analytor)) {
+        _analytor->create_one_operator();
+    }
     ~AnalyticSinkOperator() = default;
 
     bool has_output() const override { return false; }
@@ -18,6 +20,7 @@ public:
     void set_finishing(RuntimeState* state) override;
 
     Status prepare(RuntimeState* state) override;
+    Status close(RuntimeState* state) override;
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
     Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override;

--- a/be/src/exec/pipeline/analysis/analytic_sink_operator.h
+++ b/be/src/exec/pipeline/analysis/analytic_sink_operator.h
@@ -10,7 +10,7 @@ class AnalyticSinkOperator : public Operator {
 public:
     AnalyticSinkOperator(int32_t id, int32_t plan_node_id, const TPlanNode& tnode, AnalytorPtr analytor)
             : Operator(id, "analytic_sink", plan_node_id), _tnode(tnode), _analytor(std::move(analytor)) {
-        _analytor->create_one_operator();
+        _analytor->ref_no_barrier();
     }
     ~AnalyticSinkOperator() = default;
 

--- a/be/src/exec/pipeline/analysis/analytic_sink_operator.h
+++ b/be/src/exec/pipeline/analysis/analytic_sink_operator.h
@@ -10,7 +10,7 @@ class AnalyticSinkOperator : public Operator {
 public:
     AnalyticSinkOperator(int32_t id, int32_t plan_node_id, const TPlanNode& tnode, AnalytorPtr analytor)
             : Operator(id, "analytic_sink", plan_node_id), _tnode(tnode), _analytor(std::move(analytor)) {
-        _analytor->ref_no_barrier();
+        _analytor->ref();
     }
     ~AnalyticSinkOperator() = default;
 

--- a/be/src/exec/pipeline/analysis/analytic_sink_operator.h
+++ b/be/src/exec/pipeline/analysis/analytic_sink_operator.h
@@ -15,8 +15,8 @@ public:
     ~AnalyticSinkOperator() = default;
 
     bool has_output() const override { return false; }
-    bool need_input() const override { return true; }
-    bool is_finished() const override;
+    bool need_input() const override { return !is_finished(); }
+    bool is_finished() const override { return _is_finished || _analytor->is_finished(); }
     void set_finishing(RuntimeState* state) override;
 
     Status prepare(RuntimeState* state) override;

--- a/be/src/exec/pipeline/analysis/analytic_source_operator.cpp
+++ b/be/src/exec/pipeline/analysis/analytic_source_operator.cpp
@@ -12,14 +12,12 @@ bool AnalyticSourceOperator::is_finished() const {
     return _analytor->is_sink_complete() && _analytor->is_chunk_buffer_empty();
 }
 
-void AnalyticSourceOperator::set_finishing(RuntimeState* state) {
-    _is_finished = true;
+void AnalyticSourceOperator::set_finished(RuntimeState* state) {
+    _analytor->set_finished();
 }
 
 Status AnalyticSourceOperator::close(RuntimeState* state) {
-    // _analytor is shared by sink operator and source operator
-    // we must only close it at source operator
-    RETURN_IF_ERROR(_analytor->close(state));
+    RETURN_IF_ERROR(_analytor->close_one_operator(state));
     return SourceOperator::close(state);
 }
 

--- a/be/src/exec/pipeline/analysis/analytic_source_operator.cpp
+++ b/be/src/exec/pipeline/analysis/analytic_source_operator.cpp
@@ -17,7 +17,7 @@ void AnalyticSourceOperator::set_finished(RuntimeState* state) {
 }
 
 Status AnalyticSourceOperator::close(RuntimeState* state) {
-    RETURN_IF_ERROR(_analytor->close_one_operator(state));
+    RETURN_IF_ERROR(_analytor->unref(state));
     return SourceOperator::close(state);
 }
 

--- a/be/src/exec/pipeline/analysis/analytic_source_operator.h
+++ b/be/src/exec/pipeline/analysis/analytic_source_operator.h
@@ -11,12 +11,16 @@ namespace starrocks::pipeline {
 class AnalyticSourceOperator : public SourceOperator {
 public:
     AnalyticSourceOperator(int32_t id, int32_t plan_node_id, AnalytorPtr analytor)
-            : SourceOperator(id, "analytic_source", plan_node_id), _analytor(std::move(analytor)) {}
+            : SourceOperator(id, "analytic_source", plan_node_id), _analytor(std::move(analytor)) {
+        _analytor->create_one_operator();
+    }
     ~AnalyticSourceOperator() override = default;
 
     bool has_output() const override;
     bool is_finished() const override;
-    void set_finishing(RuntimeState* state) override;
+    // set_finishing does nothing.
+    void set_finishing(RuntimeState* state) override {}
+    void set_finished(RuntimeState* state) override;
 
     Status close(RuntimeState* state) override;
 
@@ -26,8 +30,6 @@ private:
     // It is used to perform analytic algorithms
     // shared by AnalyticSinkOperator
     AnalytorPtr _analytor = nullptr;
-    // Whether prev operator has no output
-    bool _is_finished = false;
 };
 
 class AnalyticSourceOperatorFactory final : public SourceOperatorFactory {

--- a/be/src/exec/pipeline/analysis/analytic_source_operator.h
+++ b/be/src/exec/pipeline/analysis/analytic_source_operator.h
@@ -18,8 +18,7 @@ public:
 
     bool has_output() const override;
     bool is_finished() const override;
-    // set_finishing does nothing.
-    void set_finishing(RuntimeState* state) override {}
+
     void set_finished(RuntimeState* state) override;
 
     Status close(RuntimeState* state) override;

--- a/be/src/exec/pipeline/analysis/analytic_source_operator.h
+++ b/be/src/exec/pipeline/analysis/analytic_source_operator.h
@@ -12,7 +12,7 @@ class AnalyticSourceOperator : public SourceOperator {
 public:
     AnalyticSourceOperator(int32_t id, int32_t plan_node_id, AnalytorPtr analytor)
             : SourceOperator(id, "analytic_source", plan_node_id), _analytor(std::move(analytor)) {
-        _analytor->ref_no_barrier();
+        _analytor->ref();
     }
     ~AnalyticSourceOperator() override = default;
 

--- a/be/src/exec/pipeline/analysis/analytic_source_operator.h
+++ b/be/src/exec/pipeline/analysis/analytic_source_operator.h
@@ -12,7 +12,7 @@ class AnalyticSourceOperator : public SourceOperator {
 public:
     AnalyticSourceOperator(int32_t id, int32_t plan_node_id, AnalytorPtr analytor)
             : SourceOperator(id, "analytic_source", plan_node_id), _analytor(std::move(analytor)) {
-        _analytor->create_one_operator();
+        _analytor->ref_no_barrier();
     }
     ~AnalyticSourceOperator() override = default;
 

--- a/be/src/exec/pipeline/context_base.h
+++ b/be/src/exec/pipeline/context_base.h
@@ -27,6 +27,9 @@ public:
     ContextBase& operator=(ContextBase&&) = delete;
     ContextBase& operator=(const ContextBase&) = delete;
 
+    // For pipeline, it is called by unref() when the last operator is unreffed.
+    // For non-pipeline, it is called by close() of the exec node directly
+    // without calling ref and unref.
     virtual Status close(RuntimeState* state) = 0;
 
     // ref_no_barrier and unref are used to close context
@@ -48,7 +51,8 @@ public:
     // When the output operator is finished, the context can be finished regardless of other running operators.
     void set_finished() { _is_finished.store(true, std::memory_order_release); }
 
-    // Predicate whether the context is finished, which is used to notify non-output operators finished early.
+    // Predicate whether the context is finished, which is used to notify
+    // non-output operators to be finished early.
     bool is_finished() const { return _is_finished.load(std::memory_order_acquire); }
 
 private:

--- a/be/src/exec/pipeline/context_base.h
+++ b/be/src/exec/pipeline/context_base.h
@@ -35,9 +35,7 @@ public:
     // - close_one_operator is called by operator::close() at the close stage.
     // It is the guaranteed by the dispatcher queue that the increment operations
     // by create_one_operator() are visible to close_one_operator(), so we needn't barrier here.
-    void create_one_operator() {
-        _num_running_operators.fetch_add(1, std::memory_order_relaxed);
-    }
+    void create_one_operator() { _num_running_operators.fetch_add(1, std::memory_order_relaxed); }
 
     // Called by operator::close. Close the context when the last running operator is closed.
     Status close_one_operator(RuntimeState* state) {

--- a/be/src/exec/pipeline/context_base.h
+++ b/be/src/exec/pipeline/context_base.h
@@ -29,16 +29,16 @@ public:
 
     virtual Status close(RuntimeState* state) = 0;
 
-    // create_one_operator and close_one_operator are used to close context
+    // ref_no_barrier and unref are used to close context
     // when the last running related operator is closed.
-    // - create_one_operator is called by operator::constructor() at the preparation stage.
-    // - close_one_operator is called by operator::close() at the close stage.
+    // - ref_no_barrier is called by operator::constructor() at the preparation stage.
+    // - unref is called by operator::close() at the close stage.
     // It is the guaranteed by the dispatcher queue that the increment operations
-    // by create_one_operator() are visible to close_one_operator(), so we needn't barrier here.
-    void create_one_operator() { _num_running_operators.fetch_add(1, std::memory_order_relaxed); }
+    // by ref_no_barrier() are visible to unref(), so we needn't barrier here.
+    void ref_no_barrier() { _num_running_operators.fetch_add(1, std::memory_order_relaxed); }
 
     // Called by operator::close. Close the context when the last running operator is closed.
-    Status close_one_operator(RuntimeState* state) {
+    Status unref(RuntimeState* state) {
         if (_num_running_operators.fetch_sub(1, std::memory_order_acq_rel) == 1) {
             return close(state);
         }

--- a/be/src/exec/pipeline/context_base.h
+++ b/be/src/exec/pipeline/context_base.h
@@ -1,0 +1,61 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#pragma once
+
+#include "common/status.h"
+#include "runtime/runtime_state.h"
+
+namespace starrocks::pipeline {
+
+// The complex ExecNode is usually decomposed to multiple operators,
+// which share some variables in a context, and have dependency relationships between them.
+// (For example, HashJoinNode is composed to HashJoinBuildOperator and HashJoinProbeOperator,
+// which share a HashJoiner context. And HashJoinProbeOperator depends on HashJoinBuildOperator.)
+// Assume OpA depends on OpB.
+// However, OpA can be finished earlier than OpB, if it's successor operator is finished early.
+// Therefore, there are two problems which needs to be considered:
+// 1. OpB should perceive that OpA has been finished early.
+// 2. Context object can be released only if both OpA and OpB are closed,
+//    because the close order of OpA and OpB are uncertain.
+class ContextBase {
+public:
+    ContextBase() = default;
+    ~ContextBase() = default;
+
+    ContextBase(const ContextBase&) = delete;
+    ContextBase(ContextBase&&) = delete;
+    ContextBase& operator=(ContextBase&&) = delete;
+    ContextBase& operator=(const ContextBase&) = delete;
+
+    virtual Status close(RuntimeState* state) = 0;
+
+    // create_one_operator and close_one_operator are used to close context
+    // when the last running related operator is closed.
+    // - create_one_operator is called by operator::constructor() at the preparation stage.
+    // - close_one_operator is called by operator::close() at the close stage.
+    // It is the guaranteed by the dispatcher queue that the increment operations
+    // by create_one_operator() are visible to close_one_operator(), so we needn't barrier here.
+    void create_one_operator() {
+        _num_running_operators.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    // Called by operator::close. Close the context when the last running operator is closed.
+    Status close_one_operator(RuntimeState* state) {
+        if (_num_running_operators.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+            return close(state);
+        }
+        return Status::OK();
+    }
+
+    // When the output operator is finished, the context can be finished regardless of other running operators.
+    void set_finished() { _is_finished.store(true, std::memory_order_release); }
+
+    // Predicate whether the context is finished, which is used to notify non-output operators finished early.
+    bool is_finished() const { return _is_finished.load(std::memory_order_acquire); }
+
+private:
+    std::atomic<int32_t> _num_running_operators = 0;
+    std::atomic<bool> _is_finished = false;
+};
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/context_with_dependency.h
+++ b/be/src/exec/pipeline/context_with_dependency.h
@@ -29,7 +29,7 @@ public:
 
     // For pipeline, it is called by unref() when the last operator is unreffed.
     // For non-pipeline, it is called by close() of the exec node directly
-    // without calling ref and unref, such as AggregateBaseNode.
+    // without calling ref and unref. For example, AggregateBaseNode uses Aggregator.
     virtual Status close(RuntimeState* state) = 0;
 
     // ref and unref are used to close context

--- a/be/src/exec/pipeline/context_with_dependency.h
+++ b/be/src/exec/pipeline/context_with_dependency.h
@@ -29,16 +29,16 @@ public:
 
     // For pipeline, it is called by unref() when the last operator is unreffed.
     // For non-pipeline, it is called by close() of the exec node directly
-    // without calling ref and unref.
+    // without calling ref and unref, such as AggregateBaseNode.
     virtual Status close(RuntimeState* state) = 0;
 
-    // ref_no_barrier and unref are used to close context
+    // ref and unref are used to close context
     // when the last running related operator is closed.
-    // - ref_no_barrier is called by operator::constructor() at the preparation stage.
+    // - ref is called by operator::constructor() at the preparation stage.
     // - unref is called by operator::close() at the close stage.
     // It is the guaranteed by the dispatcher queue that the increment operations
-    // by ref_no_barrier() are visible to unref(), so we needn't barrier here.
-    void ref_no_barrier() { _num_running_operators.fetch_add(1, std::memory_order_relaxed); }
+    // by ref() are visible to unref(), so we needn't barrier here.
+    void ref() { _num_running_operators.fetch_add(1, std::memory_order_relaxed); }
 
     // Called by operator::close. Close the context when the last running operator is closed.
     Status unref(RuntimeState* state) {

--- a/be/src/exec/pipeline/context_with_dependency.h
+++ b/be/src/exec/pipeline/context_with_dependency.h
@@ -17,15 +17,15 @@ namespace starrocks::pipeline {
 // 1. OpB should perceive that OpA has been finished early.
 // 2. Context object can be released only if both OpA and OpB are closed,
 //    because the close order of OpA and OpB are uncertain.
-class ContextBase {
+class ContextWithDependency {
 public:
-    ContextBase() = default;
-    ~ContextBase() = default;
+    ContextWithDependency() = default;
+    ~ContextWithDependency() = default;
 
-    ContextBase(const ContextBase&) = delete;
-    ContextBase(ContextBase&&) = delete;
-    ContextBase& operator=(ContextBase&&) = delete;
-    ContextBase& operator=(const ContextBase&) = delete;
+    ContextWithDependency(const ContextWithDependency&) = delete;
+    ContextWithDependency(ContextWithDependency&&) = delete;
+    ContextWithDependency& operator=(ContextWithDependency&&) = delete;
+    ContextWithDependency& operator=(const ContextWithDependency&) = delete;
 
     // For pipeline, it is called by unref() when the last operator is unreffed.
     // For non-pipeline, it is called by close() of the exec node directly

--- a/be/src/exec/pipeline/crossjoin/cross_join_context.h
+++ b/be/src/exec/pipeline/crossjoin/cross_join_context.h
@@ -7,11 +7,11 @@
 
 #include "column/chunk.h"
 #include "column/vectorized_fwd.h"
-#include "exec/pipeline/context_base.h"
+#include "exec/pipeline/context_with_dependency.h"
 
 namespace starrocks::pipeline {
 
-class CrossJoinContext final : public ContextBase {
+class CrossJoinContext final : public ContextWithDependency {
 public:
     explicit CrossJoinContext(const int32_t num_right_sinkers)
             : _num_right_sinkers(num_right_sinkers), _build_chunks(num_right_sinkers) {}

--- a/be/src/exec/pipeline/crossjoin/cross_join_context.h
+++ b/be/src/exec/pipeline/crossjoin/cross_join_context.h
@@ -11,7 +11,7 @@
 
 namespace starrocks::pipeline {
 
-class CrossJoinContext : public ContextBase {
+class CrossJoinContext final : public ContextBase {
 public:
     explicit CrossJoinContext(const int32_t num_right_sinkers)
             : _num_right_sinkers(num_right_sinkers), _build_chunks(num_right_sinkers) {}

--- a/be/src/exec/pipeline/crossjoin/cross_join_context.h
+++ b/be/src/exec/pipeline/crossjoin/cross_join_context.h
@@ -7,13 +7,16 @@
 
 #include "column/chunk.h"
 #include "column/vectorized_fwd.h"
+#include "exec/pipeline/context_base.h"
 
 namespace starrocks::pipeline {
 
-class CrossJoinContext {
+class CrossJoinContext : public ContextBase {
 public:
     explicit CrossJoinContext(const int32_t num_right_sinkers)
             : _num_right_sinkers(num_right_sinkers), _build_chunks(num_right_sinkers) {}
+
+    Status close(RuntimeState* state) override { return Status::OK(); }
 
     bool is_build_chunk_empty() const {
         return std::all_of(_build_chunks.begin(), _build_chunks.end(),

--- a/be/src/exec/pipeline/crossjoin/cross_join_left_operator.h
+++ b/be/src/exec/pipeline/crossjoin/cross_join_left_operator.h
@@ -28,13 +28,13 @@ public:
               _build_column_count(build_column_count),
               _conjunct_ctxs(conjunct_ctxs),
               _cross_join_context(cross_join_context) {
-        _cross_join_context->create_one_operator();
+        _cross_join_context->ref_no_barrier();
     }
 
     ~CrossJoinLeftOperator() override = default;
 
     Status close(RuntimeState* state) override {
-        RETURN_IF_ERROR(_cross_join_context->close_one_operator(state));
+        RETURN_IF_ERROR(_cross_join_context->unref(state));
         return Operator::close(state);
     }
 

--- a/be/src/exec/pipeline/crossjoin/cross_join_left_operator.h
+++ b/be/src/exec/pipeline/crossjoin/cross_join_left_operator.h
@@ -72,9 +72,7 @@ public:
 
     void set_finishing(RuntimeState* state) override { _is_finished = true; }
 
-    void set_finished(RuntimeState* state) override {
-        _cross_join_context->set_finished();
-    }
+    void set_finished(RuntimeState* state) override { _cross_join_context->set_finished(); }
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/crossjoin/cross_join_left_operator.h
+++ b/be/src/exec/pipeline/crossjoin/cross_join_left_operator.h
@@ -27,9 +27,16 @@ public:
               _probe_column_count(probe_column_count),
               _build_column_count(build_column_count),
               _conjunct_ctxs(conjunct_ctxs),
-              _cross_join_context(cross_join_context) {}
+              _cross_join_context(cross_join_context) {
+        _cross_join_context->create_one_operator();
+    }
 
     ~CrossJoinLeftOperator() override = default;
+
+    Status close(RuntimeState* state) override {
+        RETURN_IF_ERROR(_cross_join_context->close_one_operator(state));
+        return Operator::close(state);
+    }
 
     bool is_ready() const override { return _cross_join_context->is_right_finished(); }
 
@@ -64,6 +71,10 @@ public:
     }
 
     void set_finishing(RuntimeState* state) override { _is_finished = true; }
+
+    void set_finished(RuntimeState* state) override {
+        _cross_join_context->set_finished();
+    }
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/crossjoin/cross_join_left_operator.h
+++ b/be/src/exec/pipeline/crossjoin/cross_join_left_operator.h
@@ -28,7 +28,7 @@ public:
               _build_column_count(build_column_count),
               _conjunct_ctxs(conjunct_ctxs),
               _cross_join_context(cross_join_context) {
-        _cross_join_context->ref_no_barrier();
+        _cross_join_context->ref();
     }
 
     ~CrossJoinLeftOperator() override = default;

--- a/be/src/exec/pipeline/crossjoin/cross_join_right_sink_operator.h
+++ b/be/src/exec/pipeline/crossjoin/cross_join_right_sink_operator.h
@@ -17,7 +17,7 @@ public:
             : Operator(id, "cross_join_right_sink", plan_node_id),
               _driver_sequence(driver_sequence),
               _cross_join_context(cross_join_context) {
-        _cross_join_context->ref_no_barrier();
+        _cross_join_context->ref();
     }
 
     ~CrossJoinRightSinkOperator() override = default;

--- a/be/src/exec/pipeline/crossjoin/cross_join_right_sink_operator.h
+++ b/be/src/exec/pipeline/crossjoin/cross_join_right_sink_operator.h
@@ -17,13 +17,13 @@ public:
             : Operator(id, "cross_join_right_sink", plan_node_id),
               _driver_sequence(driver_sequence),
               _cross_join_context(cross_join_context) {
-        _cross_join_context->create_one_operator();
+        _cross_join_context->ref_no_barrier();
     }
 
     ~CrossJoinRightSinkOperator() override = default;
 
     Status close(RuntimeState* state) override {
-        RETURN_IF_ERROR(_cross_join_context->close_one_operator(state));
+        RETURN_IF_ERROR(_cross_join_context->unref(state));
         return Operator::close(state);
     }
 

--- a/be/src/exec/pipeline/hashjoin/hash_join_build_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/hash_join_build_operator.cpp
@@ -8,7 +8,7 @@ namespace pipeline {
 HashJoinBuildOperator::HashJoinBuildOperator(int32_t id, const string& name, int32_t plan_node_id,
                                              HashJoinerPtr hash_joiner)
         : Operator(id, name, plan_node_id), _hash_joiner(hash_joiner) {
-    _hash_joiner->ref_no_barrier();
+    _hash_joiner->ref();
 }
 
 Status HashJoinBuildOperator::push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) {

--- a/be/src/exec/pipeline/hashjoin/hash_join_build_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/hash_join_build_operator.cpp
@@ -8,7 +8,7 @@ namespace pipeline {
 HashJoinBuildOperator::HashJoinBuildOperator(int32_t id, const string& name, int32_t plan_node_id,
                                              HashJoinerPtr hash_joiner)
         : Operator(id, name, plan_node_id), _hash_joiner(hash_joiner) {
-    _hash_joiner->create_one_operator();
+    _hash_joiner->ref_no_barrier();
 }
 
 Status HashJoinBuildOperator::push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) {
@@ -20,7 +20,7 @@ Status HashJoinBuildOperator::prepare(RuntimeState* state) {
     return _hash_joiner->prepare(state);
 }
 Status HashJoinBuildOperator::close(RuntimeState* state) {
-    RETURN_IF_ERROR(_hash_joiner->close_one_operator(state));
+    RETURN_IF_ERROR(_hash_joiner->unref(state));
     return Operator::close(state);
 }
 

--- a/be/src/exec/pipeline/hashjoin/hash_join_build_operator.h
+++ b/be/src/exec/pipeline/hashjoin/hash_join_build_operator.h
@@ -15,6 +15,7 @@ class HashJoinBuildOperator final : public Operator {
 public:
     HashJoinBuildOperator(int32_t id, const string& name, int32_t plan_node_id, HashJoinerPtr hash_joiner);
     ~HashJoinBuildOperator() = default;
+
     Status prepare(RuntimeState* state) override;
     Status close(RuntimeState* state) override;
 
@@ -22,14 +23,13 @@ public:
         CHECK(false) << "has_output not supported in HashJoinBuildOperator";
         return false;
     }
-
     bool need_input() const override { return !is_finished(); }
 
-    bool is_finished() const override { return _is_finished; }
+    void set_finishing(RuntimeState* state) override;
+    bool is_finished() const override { return _is_finished || _hash_joiner->is_finished(); }
 
     Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override;
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
-    void set_finishing(RuntimeState* state) override;
 
 private:
     HashJoinerPtr _hash_joiner;

--- a/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.cpp
@@ -7,7 +7,7 @@ namespace pipeline {
 HashJoinProbeOperator::HashJoinProbeOperator(int32_t id, const string& name, int32_t plan_node_id,
                                              HashJoinerPtr hash_joiner)
         : OperatorWithDependency(id, name, plan_node_id), _hash_joiner(hash_joiner) {
-    _hash_joiner->create_one_operator();
+    _hash_joiner->ref_no_barrier();
 }
 
 bool HashJoinProbeOperator::has_output() const {

--- a/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.cpp
@@ -6,7 +6,9 @@ namespace starrocks {
 namespace pipeline {
 HashJoinProbeOperator::HashJoinProbeOperator(int32_t id, const string& name, int32_t plan_node_id,
                                              HashJoinerPtr hash_joiner)
-        : OperatorWithDependency(id, name, plan_node_id), _hash_joiner(hash_joiner) {}
+        : OperatorWithDependency(id, name, plan_node_id), _hash_joiner(hash_joiner) {
+    _hash_joiner->create_one_operator();
+}
 
 bool HashJoinProbeOperator::has_output() const {
     return _hash_joiner->has_output();
@@ -30,10 +32,12 @@ StatusOr<vectorized::ChunkPtr> HashJoinProbeOperator::pull_chunk(RuntimeState* s
 }
 
 void HashJoinProbeOperator::set_finishing(RuntimeState* state) {
-    if (!_is_finished) {
-        _hash_joiner->enter_post_probe_phase();
-        _is_finished = true;
-    }
+    _is_finished = true;
+    _hash_joiner->enter_post_probe_phase();
+}
+
+void HashJoinProbeOperator::set_finished(RuntimeState* state) {
+    _hash_joiner->set_finished();
 }
 
 bool HashJoinProbeOperator::is_ready() const {

--- a/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.cpp
@@ -7,7 +7,7 @@ namespace pipeline {
 HashJoinProbeOperator::HashJoinProbeOperator(int32_t id, const string& name, int32_t plan_node_id,
                                              HashJoinerPtr hash_joiner)
         : OperatorWithDependency(id, name, plan_node_id), _hash_joiner(hash_joiner) {
-    _hash_joiner->ref_no_barrier();
+    _hash_joiner->ref();
 }
 
 bool HashJoinProbeOperator::has_output() const {

--- a/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.h
+++ b/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.h
@@ -17,15 +17,22 @@ public:
 
     Status prepare(RuntimeState* state) override { return OperatorWithDependency::prepare(state); }
 
-    Status close(RuntimeState* state) override { return OperatorWithDependency::close(state); }
+    Status close(RuntimeState* state) override {
+        RETURN_IF_ERROR(_hash_joiner->close_one_operator(state));
+        return OperatorWithDependency::close(state);
+    }
 
     bool has_output() const override;
     bool need_input() const override;
+
     bool is_finished() const override;
+    void set_finishing(RuntimeState* state) override;
+    void set_finished(RuntimeState* state) override;
+
+    bool is_ready() const override;
+
     Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk);
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state);
-    void set_finishing(RuntimeState* state) override;
-    bool is_ready() const override;
 
 private:
     HashJoinerPtr _hash_joiner;

--- a/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.h
+++ b/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.h
@@ -18,7 +18,7 @@ public:
     Status prepare(RuntimeState* state) override { return OperatorWithDependency::prepare(state); }
 
     Status close(RuntimeState* state) override {
-        RETURN_IF_ERROR(_hash_joiner->close_one_operator(state));
+        RETURN_IF_ERROR(_hash_joiner->unref(state));
         return OperatorWithDependency::close(state);
     }
 

--- a/be/src/exec/pipeline/operator.h
+++ b/be/src/exec/pipeline/operator.h
@@ -39,7 +39,7 @@ public:
     // data inside is processed.
     // It's one of the stages of the operator life cycle（prepare -> finishing -> finished -> closed)
     // This method will be exactly invoked once in the whole life cycle
-    virtual void set_finishing(RuntimeState* state) = 0;
+    virtual void set_finishing(RuntimeState* state) {}
 
     // set_finished is used to shutdown both input and output stream of a operator and after its invocation
     // buffered data inside the operator is cleared.

--- a/be/src/exec/pipeline/set/except_build_sink_operator.cpp
+++ b/be/src/exec/pipeline/set/except_build_sink_operator.cpp
@@ -18,6 +18,11 @@ Status ExceptBuildSinkOperator::prepare(RuntimeState* state) {
     return _except_ctx->prepare(state, _dst_exprs);
 }
 
+Status ExceptBuildSinkOperator::close(RuntimeState* state) {
+    RETURN_IF_ERROR(_except_ctx->close_one_operator(state));
+    return Operator::close(state);
+}
+
 Status ExceptBuildSinkOperatorFactory::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(OperatorFactory::prepare(state));
 

--- a/be/src/exec/pipeline/set/except_build_sink_operator.cpp
+++ b/be/src/exec/pipeline/set/except_build_sink_operator.cpp
@@ -19,7 +19,7 @@ Status ExceptBuildSinkOperator::prepare(RuntimeState* state) {
 }
 
 Status ExceptBuildSinkOperator::close(RuntimeState* state) {
-    RETURN_IF_ERROR(_except_ctx->close_one_operator(state));
+    RETURN_IF_ERROR(_except_ctx->unref(state));
     return Operator::close(state);
 }
 

--- a/be/src/exec/pipeline/set/except_build_sink_operator.h
+++ b/be/src/exec/pipeline/set/except_build_sink_operator.h
@@ -30,7 +30,7 @@ public:
             : Operator(id, "except_build_sink", plan_node_id),
               _except_ctx(std::move(except_ctx)),
               _dst_exprs(dst_exprs) {
-        _except_ctx->ref_no_barrier();
+        _except_ctx->ref();
     }
 
     bool need_input() const override { return !is_finished(); }

--- a/be/src/exec/pipeline/set/except_build_sink_operator.h
+++ b/be/src/exec/pipeline/set/except_build_sink_operator.h
@@ -30,7 +30,7 @@ public:
             : Operator(id, "except_build_sink", plan_node_id),
               _except_ctx(std::move(except_ctx)),
               _dst_exprs(dst_exprs) {
-        _except_ctx->create_one_operator();
+        _except_ctx->ref_no_barrier();
     }
 
     bool need_input() const override { return !is_finished(); }

--- a/be/src/exec/pipeline/set/except_build_sink_operator.h
+++ b/be/src/exec/pipeline/set/except_build_sink_operator.h
@@ -29,13 +29,15 @@ public:
                             const std::vector<ExprContext*>& dst_exprs)
             : Operator(id, "except_build_sink", plan_node_id),
               _except_ctx(std::move(except_ctx)),
-              _dst_exprs(dst_exprs) {}
+              _dst_exprs(dst_exprs) {
+        _except_ctx->create_one_operator();
+    }
 
     bool need_input() const override { return !is_finished(); }
 
     bool has_output() const override { return false; }
 
-    bool is_finished() const override { return _is_finished; }
+    bool is_finished() const override { return _is_finished || _except_ctx->is_finished(); }
 
     void set_finishing(RuntimeState* state) override {
         _is_finished = true;
@@ -43,6 +45,7 @@ public:
     }
 
     Status prepare(RuntimeState* state) override;
+    Status close(RuntimeState* state) override;
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/set/except_context.h
+++ b/be/src/exec/pipeline/set/except_context.h
@@ -14,6 +14,7 @@
 #include "util/hash_util.hpp"
 #include "util/phmap/phmap.h"
 #include "util/slice.h"
+#include "exec/pipeline/context_base.h"
 
 namespace starrocks::pipeline {
 
@@ -24,7 +25,7 @@ class ExceptPartitionContextFactory;
 using ExceptPartitionContextFactoryPtr = std::shared_ptr<ExceptPartitionContextFactory>;
 
 // Used as the shared context for ExceptBuildSinkOperator, ExceptProbeSinkOperator, and ExceptOutputSourceOperator.
-class ExceptContext {
+class ExceptContext : public ContextBase {
 public:
     explicit ExceptContext(const int dst_tuple_id) : _dst_tuple_id(dst_tuple_id) {}
 

--- a/be/src/exec/pipeline/set/except_context.h
+++ b/be/src/exec/pipeline/set/except_context.h
@@ -25,7 +25,7 @@ class ExceptPartitionContextFactory;
 using ExceptPartitionContextFactoryPtr = std::shared_ptr<ExceptPartitionContextFactory>;
 
 // Used as the shared context for ExceptBuildSinkOperator, ExceptProbeSinkOperator, and ExceptOutputSourceOperator.
-class ExceptContext : public ContextBase {
+class ExceptContext final : public ContextBase {
 public:
     explicit ExceptContext(const int dst_tuple_id) : _dst_tuple_id(dst_tuple_id) {}
 

--- a/be/src/exec/pipeline/set/except_context.h
+++ b/be/src/exec/pipeline/set/except_context.h
@@ -7,7 +7,7 @@
 #include "column/type_traits.h"
 #include "common/statusor.h"
 #include "exec/olap_common.h"
-#include "exec/pipeline/context_base.h"
+#include "exec/pipeline/context_with_dependency.h"
 #include "exec/vectorized/except_hash_set.h"
 #include "exprs/expr_context.h"
 #include "gutil/casts.h"
@@ -25,7 +25,7 @@ class ExceptPartitionContextFactory;
 using ExceptPartitionContextFactoryPtr = std::shared_ptr<ExceptPartitionContextFactory>;
 
 // Used as the shared context for ExceptBuildSinkOperator, ExceptProbeSinkOperator, and ExceptOutputSourceOperator.
-class ExceptContext final : public ContextBase {
+class ExceptContext final : public ContextWithDependency {
 public:
     explicit ExceptContext(const int dst_tuple_id) : _dst_tuple_id(dst_tuple_id) {}
 

--- a/be/src/exec/pipeline/set/except_context.h
+++ b/be/src/exec/pipeline/set/except_context.h
@@ -7,6 +7,7 @@
 #include "column/type_traits.h"
 #include "common/statusor.h"
 #include "exec/olap_common.h"
+#include "exec/pipeline/context_base.h"
 #include "exec/vectorized/except_hash_set.h"
 #include "exprs/expr_context.h"
 #include "gutil/casts.h"
@@ -14,7 +15,6 @@
 #include "util/hash_util.hpp"
 #include "util/phmap/phmap.h"
 #include "util/slice.h"
-#include "exec/pipeline/context_base.h"
 
 namespace starrocks::pipeline {
 

--- a/be/src/exec/pipeline/set/except_output_source_operator.cpp
+++ b/be/src/exec/pipeline/set/except_output_source_operator.cpp
@@ -9,7 +9,7 @@ StatusOr<vectorized::ChunkPtr> ExceptOutputSourceOperator::pull_chunk(RuntimeSta
 }
 
 Status ExceptOutputSourceOperator::close(RuntimeState* state) {
-    RETURN_IF_ERROR(_except_ctx->close_one_operator(state));
+    RETURN_IF_ERROR(_except_ctx->unref(state));
     return Operator::close(state);
 }
 

--- a/be/src/exec/pipeline/set/except_output_source_operator.cpp
+++ b/be/src/exec/pipeline/set/except_output_source_operator.cpp
@@ -9,7 +9,7 @@ StatusOr<vectorized::ChunkPtr> ExceptOutputSourceOperator::pull_chunk(RuntimeSta
 }
 
 Status ExceptOutputSourceOperator::close(RuntimeState* state) {
-    RETURN_IF_ERROR(_except_ctx->close(state));
+    RETURN_IF_ERROR(_except_ctx->close_one_operator(state));
     return Operator::close(state);
 }
 

--- a/be/src/exec/pipeline/set/except_output_source_operator.h
+++ b/be/src/exec/pipeline/set/except_output_source_operator.h
@@ -28,7 +28,6 @@ public:
         return _except_ctx->is_dependency_finished(_dependency_index) && _except_ctx->is_output_finished();
     }
 
-
     void set_finished(RuntimeState* state) override { _except_ctx->set_finished(); }
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;

--- a/be/src/exec/pipeline/set/except_output_source_operator.h
+++ b/be/src/exec/pipeline/set/except_output_source_operator.h
@@ -17,7 +17,7 @@ public:
             : SourceOperator(id, "except_output_source", plan_node_id),
               _except_ctx(std::move(except_ctx)),
               _dependency_index(dependency_index) {
-        _except_ctx->ref_no_barrier();
+        _except_ctx->ref();
     }
 
     bool has_output() const override {

--- a/be/src/exec/pipeline/set/except_output_source_operator.h
+++ b/be/src/exec/pipeline/set/except_output_source_operator.h
@@ -16,7 +16,9 @@ public:
                                const int32_t dependency_index)
             : SourceOperator(id, "except_output_source", plan_node_id),
               _except_ctx(std::move(except_ctx)),
-              _dependency_index(dependency_index) {}
+              _dependency_index(dependency_index) {
+        _except_ctx->create_one_operator();
+    }
 
     bool has_output() const override {
         return _except_ctx->is_dependency_finished(_dependency_index) && !_except_ctx->is_output_finished();
@@ -26,8 +28,11 @@ public:
         return _except_ctx->is_dependency_finished(_dependency_index) && _except_ctx->is_output_finished();
     }
 
-    // Finish is noop.
+    // set_finishing does nothing.
     void set_finishing(RuntimeState* state) override {}
+    void set_finished(RuntimeState* state) override {
+        _except_ctx->set_finished();
+    }
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/set/except_output_source_operator.h
+++ b/be/src/exec/pipeline/set/except_output_source_operator.h
@@ -17,7 +17,7 @@ public:
             : SourceOperator(id, "except_output_source", plan_node_id),
               _except_ctx(std::move(except_ctx)),
               _dependency_index(dependency_index) {
-        _except_ctx->create_one_operator();
+        _except_ctx->ref_no_barrier();
     }
 
     bool has_output() const override {

--- a/be/src/exec/pipeline/set/except_output_source_operator.h
+++ b/be/src/exec/pipeline/set/except_output_source_operator.h
@@ -28,8 +28,7 @@ public:
         return _except_ctx->is_dependency_finished(_dependency_index) && _except_ctx->is_output_finished();
     }
 
-    // set_finishing does nothing.
-    void set_finishing(RuntimeState* state) override {}
+
     void set_finished(RuntimeState* state) override { _except_ctx->set_finished(); }
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;

--- a/be/src/exec/pipeline/set/except_output_source_operator.h
+++ b/be/src/exec/pipeline/set/except_output_source_operator.h
@@ -30,9 +30,7 @@ public:
 
     // set_finishing does nothing.
     void set_finishing(RuntimeState* state) override {}
-    void set_finished(RuntimeState* state) override {
-        _except_ctx->set_finished();
-    }
+    void set_finished(RuntimeState* state) override { _except_ctx->set_finished(); }
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/set/except_probe_sink_operator.cpp
+++ b/be/src/exec/pipeline/set/except_probe_sink_operator.cpp
@@ -4,6 +4,11 @@
 
 namespace starrocks::pipeline {
 
+Status ExceptProbeSinkOperator::close(RuntimeState* state) {
+    RETURN_IF_ERROR(_except_ctx->close_one_operator(state));
+    return Operator::close(state);
+}
+
 StatusOr<vectorized::ChunkPtr> ExceptProbeSinkOperator::pull_chunk(RuntimeState* state) {
     return Status::InternalError("Shouldn't pull chunk from sink operator");
 }

--- a/be/src/exec/pipeline/set/except_probe_sink_operator.cpp
+++ b/be/src/exec/pipeline/set/except_probe_sink_operator.cpp
@@ -5,7 +5,7 @@
 namespace starrocks::pipeline {
 
 Status ExceptProbeSinkOperator::close(RuntimeState* state) {
-    RETURN_IF_ERROR(_except_ctx->close_one_operator(state));
+    RETURN_IF_ERROR(_except_ctx->unref(state));
     return Operator::close(state);
 }
 

--- a/be/src/exec/pipeline/set/except_probe_sink_operator.h
+++ b/be/src/exec/pipeline/set/except_probe_sink_operator.h
@@ -17,7 +17,7 @@ public:
               _except_ctx(std::move(except_ctx)),
               _dst_exprs(dst_exprs),
               _dependency_index(dependency_index) {
-        _except_ctx->ref_no_barrier();
+        _except_ctx->ref();
     }
 
     Status close(RuntimeState* state) override;

--- a/be/src/exec/pipeline/set/except_probe_sink_operator.h
+++ b/be/src/exec/pipeline/set/except_probe_sink_operator.h
@@ -16,7 +16,11 @@ public:
             : Operator(id, "except_probe_sink", plan_node_id),
               _except_ctx(std::move(except_ctx)),
               _dst_exprs(dst_exprs),
-              _dependency_index(dependency_index) {}
+              _dependency_index(dependency_index) {
+        _except_ctx->create_one_operator();
+    }
+
+    Status close(RuntimeState* state) override;
 
     bool need_input() const override {
         return _except_ctx->is_dependency_finished(_dependency_index) && !(_is_finished || _except_ctx->is_ht_empty());
@@ -25,6 +29,9 @@ public:
     bool has_output() const override { return false; }
 
     bool is_finished() const override {
+        if (_except_ctx->is_finished()) {
+            return true;
+        }
         return _except_ctx->is_dependency_finished(_dependency_index) && (_is_finished || _except_ctx->is_ht_empty());
     }
 

--- a/be/src/exec/pipeline/set/except_probe_sink_operator.h
+++ b/be/src/exec/pipeline/set/except_probe_sink_operator.h
@@ -17,7 +17,7 @@ public:
               _except_ctx(std::move(except_ctx)),
               _dst_exprs(dst_exprs),
               _dependency_index(dependency_index) {
-        _except_ctx->create_one_operator();
+        _except_ctx->ref_no_barrier();
     }
 
     Status close(RuntimeState* state) override;

--- a/be/src/exec/pipeline/set/intersect_build_sink_operator.cpp
+++ b/be/src/exec/pipeline/set/intersect_build_sink_operator.cpp
@@ -18,6 +18,11 @@ Status IntersectBuildSinkOperator::prepare(RuntimeState* state) {
     return _intersect_ctx->prepare(state, _dst_exprs);
 }
 
+Status IntersectBuildSinkOperator::close(RuntimeState* state) {
+    RETURN_IF_ERROR(_intersect_ctx->close_one_operator(state));
+    return Operator::close(state);
+}
+
 Status IntersectBuildSinkOperatorFactory::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(OperatorFactory::prepare(state));
 

--- a/be/src/exec/pipeline/set/intersect_build_sink_operator.cpp
+++ b/be/src/exec/pipeline/set/intersect_build_sink_operator.cpp
@@ -19,7 +19,7 @@ Status IntersectBuildSinkOperator::prepare(RuntimeState* state) {
 }
 
 Status IntersectBuildSinkOperator::close(RuntimeState* state) {
-    RETURN_IF_ERROR(_intersect_ctx->close_one_operator(state));
+    RETURN_IF_ERROR(_intersect_ctx->unref(state));
     return Operator::close(state);
 }
 

--- a/be/src/exec/pipeline/set/intersect_build_sink_operator.h
+++ b/be/src/exec/pipeline/set/intersect_build_sink_operator.h
@@ -1,4 +1,4 @@
-// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+ // This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
 
 #pragma once
 
@@ -31,13 +31,15 @@ public:
                                const std::vector<ExprContext*>& dst_exprs)
             : Operator(id, "intersect_build_sink", plan_node_id),
               _intersect_ctx(std::move(intersect_ctx)),
-              _dst_exprs(dst_exprs) {}
+              _dst_exprs(dst_exprs) {
+        _intersect_ctx->create_one_operator();
+    }
 
     bool need_input() const override { return !is_finished(); }
 
     bool has_output() const override { return false; }
 
-    bool is_finished() const override { return _is_finished; }
+    bool is_finished() const override { return _is_finished || _intersect_ctx->is_finished(); }
 
     void set_finishing(RuntimeState* state) override {
         _is_finished = true;
@@ -45,6 +47,7 @@ public:
     }
 
     Status prepare(RuntimeState* state) override;
+    Status close(RuntimeState* state) override;
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/set/intersect_build_sink_operator.h
+++ b/be/src/exec/pipeline/set/intersect_build_sink_operator.h
@@ -32,7 +32,7 @@ public:
             : Operator(id, "intersect_build_sink", plan_node_id),
               _intersect_ctx(std::move(intersect_ctx)),
               _dst_exprs(dst_exprs) {
-        _intersect_ctx->create_one_operator();
+        _intersect_ctx->ref_no_barrier();
     }
 
     bool need_input() const override { return !is_finished(); }

--- a/be/src/exec/pipeline/set/intersect_build_sink_operator.h
+++ b/be/src/exec/pipeline/set/intersect_build_sink_operator.h
@@ -1,4 +1,4 @@
- // This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
 
 #pragma once
 

--- a/be/src/exec/pipeline/set/intersect_build_sink_operator.h
+++ b/be/src/exec/pipeline/set/intersect_build_sink_operator.h
@@ -32,7 +32,7 @@ public:
             : Operator(id, "intersect_build_sink", plan_node_id),
               _intersect_ctx(std::move(intersect_ctx)),
               _dst_exprs(dst_exprs) {
-        _intersect_ctx->ref_no_barrier();
+        _intersect_ctx->ref();
     }
 
     bool need_input() const override { return !is_finished(); }

--- a/be/src/exec/pipeline/set/intersect_context.h
+++ b/be/src/exec/pipeline/set/intersect_context.h
@@ -49,7 +49,6 @@ public:
     // Called in the preparation phase of IntersectBuildSinkOperator.
     Status prepare(RuntimeState* state, const std::vector<ExprContext*>& build_exprs);
 
-    // Called in the close phase of both IntersectBuildSinkOperator and IntersectOutputSourceOperator.
     Status close(RuntimeState* state) override;
 
     Status append_chunk_to_ht(RuntimeState* state, const ChunkPtr& chunk, const std::vector<ExprContext*>& dst_exprs);

--- a/be/src/exec/pipeline/set/intersect_context.h
+++ b/be/src/exec/pipeline/set/intersect_context.h
@@ -8,6 +8,7 @@
 #include "column/type_traits.h"
 #include "common/statusor.h"
 #include "exec/olap_common.h"
+#include "exec/pipeline/context_base.h"
 #include "exec/vectorized/intersect_hash_set.h"
 #include "exprs/expr_context.h"
 #include "gutil/casts.h"
@@ -15,7 +16,6 @@
 #include "util/hash_util.hpp"
 #include "util/phmap/phmap.h"
 #include "util/slice.h"
-#include "exec/pipeline/context_base.h"
 
 namespace starrocks::pipeline {
 
@@ -26,7 +26,7 @@ class IntersectPartitionContextFactory;
 using IntersectPartitionContextFactoryPtr = std::shared_ptr<IntersectPartitionContextFactory>;
 
 // Used as the shared context for IntersectBuildSinkOperator, IntersectProbeSinkOperator, and IntersectOutputSourceOperator.
-class IntersectContext : public pipeline::ContextBase  {
+class IntersectContext : public ContextBase {
 public:
     IntersectContext(const int dst_tuple_id, const size_t intersect_times)
             : _dst_tuple_id(dst_tuple_id), _intersect_times(intersect_times) {}
@@ -49,7 +49,7 @@ public:
     // Called in the preparation phase of IntersectBuildSinkOperator.
     Status prepare(RuntimeState* state, const std::vector<ExprContext*>& build_exprs);
 
-    // Called in the close phase of bothe IntersectBuildSinkOperator and IntersectOutputSourceOperator.
+    // Called in the close phase of both IntersectBuildSinkOperator and IntersectOutputSourceOperator.
     Status close(RuntimeState* state) override;
 
     Status append_chunk_to_ht(RuntimeState* state, const ChunkPtr& chunk, const std::vector<ExprContext*>& dst_exprs);

--- a/be/src/exec/pipeline/set/intersect_context.h
+++ b/be/src/exec/pipeline/set/intersect_context.h
@@ -26,7 +26,7 @@ class IntersectPartitionContextFactory;
 using IntersectPartitionContextFactoryPtr = std::shared_ptr<IntersectPartitionContextFactory>;
 
 // Used as the shared context for IntersectBuildSinkOperator, IntersectProbeSinkOperator, and IntersectOutputSourceOperator.
-class IntersectContext : public ContextBase {
+class IntersectContext final : public ContextBase {
 public:
     IntersectContext(const int dst_tuple_id, const size_t intersect_times)
             : _dst_tuple_id(dst_tuple_id), _intersect_times(intersect_times) {}

--- a/be/src/exec/pipeline/set/intersect_context.h
+++ b/be/src/exec/pipeline/set/intersect_context.h
@@ -15,6 +15,7 @@
 #include "util/hash_util.hpp"
 #include "util/phmap/phmap.h"
 #include "util/slice.h"
+#include "exec/pipeline/context_base.h"
 
 namespace starrocks::pipeline {
 
@@ -25,7 +26,7 @@ class IntersectPartitionContextFactory;
 using IntersectPartitionContextFactoryPtr = std::shared_ptr<IntersectPartitionContextFactory>;
 
 // Used as the shared context for IntersectBuildSinkOperator, IntersectProbeSinkOperator, and IntersectOutputSourceOperator.
-class IntersectContext {
+class IntersectContext : public pipeline::ContextBase  {
 public:
     IntersectContext(const int dst_tuple_id, const size_t intersect_times)
             : _dst_tuple_id(dst_tuple_id), _intersect_times(intersect_times) {}
@@ -48,8 +49,8 @@ public:
     // Called in the preparation phase of IntersectBuildSinkOperator.
     Status prepare(RuntimeState* state, const std::vector<ExprContext*>& build_exprs);
 
-    // Called in the close phase of IntersectOutputSourceOperator.
-    Status close(RuntimeState* state);
+    // Called in the close phase of bothe IntersectBuildSinkOperator and IntersectOutputSourceOperator.
+    Status close(RuntimeState* state) override;
 
     Status append_chunk_to_ht(RuntimeState* state, const ChunkPtr& chunk, const std::vector<ExprContext*>& dst_exprs);
 

--- a/be/src/exec/pipeline/set/intersect_context.h
+++ b/be/src/exec/pipeline/set/intersect_context.h
@@ -8,7 +8,7 @@
 #include "column/type_traits.h"
 #include "common/statusor.h"
 #include "exec/olap_common.h"
-#include "exec/pipeline/context_base.h"
+#include "exec/pipeline/context_with_dependency.h"
 #include "exec/vectorized/intersect_hash_set.h"
 #include "exprs/expr_context.h"
 #include "gutil/casts.h"
@@ -26,7 +26,7 @@ class IntersectPartitionContextFactory;
 using IntersectPartitionContextFactoryPtr = std::shared_ptr<IntersectPartitionContextFactory>;
 
 // Used as the shared context for IntersectBuildSinkOperator, IntersectProbeSinkOperator, and IntersectOutputSourceOperator.
-class IntersectContext final : public ContextBase {
+class IntersectContext final : public ContextWithDependency {
 public:
     IntersectContext(const int dst_tuple_id, const size_t intersect_times)
             : _dst_tuple_id(dst_tuple_id), _intersect_times(intersect_times) {}

--- a/be/src/exec/pipeline/set/intersect_output_source_operator.cpp
+++ b/be/src/exec/pipeline/set/intersect_output_source_operator.cpp
@@ -9,7 +9,7 @@ StatusOr<vectorized::ChunkPtr> IntersectOutputSourceOperator::pull_chunk(Runtime
 }
 
 Status IntersectOutputSourceOperator::close(RuntimeState* state) {
-    RETURN_IF_ERROR(_intersect_ctx->close(state));
+    RETURN_IF_ERROR(_intersect_ctx->close_one_operator(state));
     return Operator::close(state);
 }
 

--- a/be/src/exec/pipeline/set/intersect_output_source_operator.cpp
+++ b/be/src/exec/pipeline/set/intersect_output_source_operator.cpp
@@ -9,7 +9,7 @@ StatusOr<vectorized::ChunkPtr> IntersectOutputSourceOperator::pull_chunk(Runtime
 }
 
 Status IntersectOutputSourceOperator::close(RuntimeState* state) {
-    RETURN_IF_ERROR(_intersect_ctx->close_one_operator(state));
+    RETURN_IF_ERROR(_intersect_ctx->unref(state));
     return Operator::close(state);
 }
 

--- a/be/src/exec/pipeline/set/intersect_output_source_operator.h
+++ b/be/src/exec/pipeline/set/intersect_output_source_operator.h
@@ -31,9 +31,7 @@ public:
 
     // set_finishing does nothing.
     void set_finishing(RuntimeState* state) override {}
-    void set_finished(RuntimeState* state) override {
-        _intersect_ctx->set_finished();
-    }
+    void set_finished(RuntimeState* state) override { _intersect_ctx->set_finished(); }
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/set/intersect_output_source_operator.h
+++ b/be/src/exec/pipeline/set/intersect_output_source_operator.h
@@ -29,7 +29,6 @@ public:
         return _intersect_ctx->is_dependency_finished(_dependency_index) && _intersect_ctx->is_output_finished();
     }
 
-
     void set_finished(RuntimeState* state) override { _intersect_ctx->set_finished(); }
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;

--- a/be/src/exec/pipeline/set/intersect_output_source_operator.h
+++ b/be/src/exec/pipeline/set/intersect_output_source_operator.h
@@ -18,7 +18,7 @@ public:
             : SourceOperator(id, "intersect_output_source", plan_node_id),
               _intersect_ctx(std::move(intersect_ctx)),
               _dependency_index(dependency_index) {
-        _intersect_ctx->ref_no_barrier();
+        _intersect_ctx->ref();
     }
 
     bool has_output() const override {

--- a/be/src/exec/pipeline/set/intersect_output_source_operator.h
+++ b/be/src/exec/pipeline/set/intersect_output_source_operator.h
@@ -18,7 +18,7 @@ public:
             : SourceOperator(id, "intersect_output_source", plan_node_id),
               _intersect_ctx(std::move(intersect_ctx)),
               _dependency_index(dependency_index) {
-        _intersect_ctx->create_one_operator();
+        _intersect_ctx->ref_no_barrier();
     }
 
     bool has_output() const override {

--- a/be/src/exec/pipeline/set/intersect_output_source_operator.h
+++ b/be/src/exec/pipeline/set/intersect_output_source_operator.h
@@ -17,7 +17,9 @@ public:
                                   const int32_t dependency_index)
             : SourceOperator(id, "intersect_output_source", plan_node_id),
               _intersect_ctx(std::move(intersect_ctx)),
-              _dependency_index(dependency_index) {}
+              _dependency_index(dependency_index) {
+        _intersect_ctx->create_one_operator();
+    }
 
     bool has_output() const override {
         return _intersect_ctx->is_dependency_finished(_dependency_index) && !_intersect_ctx->is_output_finished();
@@ -27,8 +29,11 @@ public:
         return _intersect_ctx->is_dependency_finished(_dependency_index) && _intersect_ctx->is_output_finished();
     }
 
-    // Finish is noop.
+    // set_finishing does nothing.
     void set_finishing(RuntimeState* state) override {}
+    void set_finished(RuntimeState* state) override {
+        _intersect_ctx->set_finished();
+    }
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/set/intersect_output_source_operator.h
+++ b/be/src/exec/pipeline/set/intersect_output_source_operator.h
@@ -29,8 +29,7 @@ public:
         return _intersect_ctx->is_dependency_finished(_dependency_index) && _intersect_ctx->is_output_finished();
     }
 
-    // set_finishing does nothing.
-    void set_finishing(RuntimeState* state) override {}
+
     void set_finished(RuntimeState* state) override { _intersect_ctx->set_finished(); }
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;

--- a/be/src/exec/pipeline/set/intersect_probe_sink_operator.cpp
+++ b/be/src/exec/pipeline/set/intersect_probe_sink_operator.cpp
@@ -5,7 +5,7 @@
 namespace starrocks::pipeline {
 
 Status IntersectProbeSinkOperator::close(RuntimeState* state) {
-    RETURN_IF_ERROR(_intersect_ctx->close_one_operator(state));
+    RETURN_IF_ERROR(_intersect_ctx->unref(state));
     return Operator::close(state);
 }
 

--- a/be/src/exec/pipeline/set/intersect_probe_sink_operator.cpp
+++ b/be/src/exec/pipeline/set/intersect_probe_sink_operator.cpp
@@ -4,6 +4,11 @@
 
 namespace starrocks::pipeline {
 
+Status IntersectProbeSinkOperator::close(RuntimeState* state) {
+    RETURN_IF_ERROR(_intersect_ctx->close_one_operator(state));
+    return Operator::close(state);
+}
+
 StatusOr<vectorized::ChunkPtr> IntersectProbeSinkOperator::pull_chunk(RuntimeState* state) {
     return Status::InternalError("Shouldn't pull chunk from sink operator");
 }

--- a/be/src/exec/pipeline/set/intersect_probe_sink_operator.h
+++ b/be/src/exec/pipeline/set/intersect_probe_sink_operator.h
@@ -18,7 +18,7 @@ public:
               _intersect_ctx(std::move(intersect_ctx)),
               _dst_exprs(dst_exprs),
               _dependency_index(dependency_index) {
-        _intersect_ctx->ref_no_barrier();
+        _intersect_ctx->ref();
     }
 
     bool need_input() const override {

--- a/be/src/exec/pipeline/set/intersect_probe_sink_operator.h
+++ b/be/src/exec/pipeline/set/intersect_probe_sink_operator.h
@@ -18,7 +18,7 @@ public:
               _intersect_ctx(std::move(intersect_ctx)),
               _dst_exprs(dst_exprs),
               _dependency_index(dependency_index) {
-        _intersect_ctx->create_one_operator();
+        _intersect_ctx->ref_no_barrier();
     }
 
     bool need_input() const override {

--- a/be/src/exec/pipeline/set/intersect_probe_sink_operator.h
+++ b/be/src/exec/pipeline/set/intersect_probe_sink_operator.h
@@ -17,7 +17,9 @@ public:
             : Operator(id, "intersect_probe_sink", plan_node_id),
               _intersect_ctx(std::move(intersect_ctx)),
               _dst_exprs(dst_exprs),
-              _dependency_index(dependency_index) {}
+              _dependency_index(dependency_index) {
+        _intersect_ctx->create_one_operator();
+    }
 
     bool need_input() const override {
         return _intersect_ctx->is_dependency_finished(_dependency_index) &&
@@ -27,6 +29,10 @@ public:
     bool has_output() const override { return false; }
 
     bool is_finished() const override {
+        if (_intersect_ctx->is_finished()) {
+            return true;
+        }
+
         return _intersect_ctx->is_dependency_finished(_dependency_index) &&
                (_is_finished || _intersect_ctx->is_ht_empty());
     }
@@ -35,6 +41,8 @@ public:
         _is_finished = true;
         _intersect_ctx->finish_probe_ht();
     }
+
+    Status close(RuntimeState* state) override;
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/sort/local_merge_sort_source_operator.cpp
+++ b/be/src/exec/pipeline/sort/local_merge_sort_source_operator.cpp
@@ -14,7 +14,7 @@
 namespace starrocks::pipeline {
 
 Status LocalMergeSortSourceOperator::close(RuntimeState* state) {
-    RETURN_IF_ERROR(_sort_context->close_one_operator(state));
+    RETURN_IF_ERROR(_sort_context->unref(state));
     return Operator::close(state);
 }
 

--- a/be/src/exec/pipeline/sort/local_merge_sort_source_operator.cpp
+++ b/be/src/exec/pipeline/sort/local_merge_sort_source_operator.cpp
@@ -12,6 +12,12 @@
 #include "runtime/runtime_state.h"
 
 namespace starrocks::pipeline {
+
+Status LocalMergeSortSourceOperator::close(RuntimeState* state) {
+    RETURN_IF_ERROR(_sort_context->close_one_operator(state));
+    return Operator::close(state);
+}
+
 StatusOr<vectorized::ChunkPtr> LocalMergeSortSourceOperator::pull_chunk(RuntimeState* state) {
     return _sort_context->pull_chunk();
 }
@@ -20,6 +26,10 @@ void LocalMergeSortSourceOperator::set_finishing(RuntimeState* state) {
     if (!_is_finished) {
         _is_finished = true;
     }
+}
+
+void LocalMergeSortSourceOperator::set_finished(RuntimeState* state) {
+    _sort_context->set_finished();
 }
 
 bool LocalMergeSortSourceOperator::has_output() const {

--- a/be/src/exec/pipeline/sort/local_merge_sort_source_operator.h
+++ b/be/src/exec/pipeline/sort/local_merge_sort_source_operator.h
@@ -5,6 +5,7 @@
 #include "column/vectorized_fwd.h"
 #include "exec/pipeline/source_operator.h"
 #include "exec/sort_exec_exprs.h"
+#include "exec/pipeline/sort/sort_context.h"
 
 namespace starrocks {
 namespace pipeline {
@@ -18,9 +19,13 @@ class SortContext;
 class LocalMergeSortSourceOperator final : public SourceOperator {
 public:
     LocalMergeSortSourceOperator(int32_t id, int32_t plan_node_id, SortContext* sort_context)
-            : SourceOperator(id, "local_merge_sort_source", plan_node_id), _sort_context(sort_context) {}
+            : SourceOperator(id, "local_merge_sort_source", plan_node_id), _sort_context(sort_context) {
+        _sort_context->create_one_operator();
+    }
 
     ~LocalMergeSortSourceOperator() override = default;
+
+    Status close(RuntimeState* state) override;
 
     bool has_output() const override;
 
@@ -31,6 +36,7 @@ public:
     void add_morsel(Morsel* morsel) {}
 
     void set_finishing(RuntimeState* state) override;
+    void set_finished(RuntimeState* state) override;
 
 private:
     bool _is_finished = false;

--- a/be/src/exec/pipeline/sort/local_merge_sort_source_operator.h
+++ b/be/src/exec/pipeline/sort/local_merge_sort_source_operator.h
@@ -20,7 +20,7 @@ class LocalMergeSortSourceOperator final : public SourceOperator {
 public:
     LocalMergeSortSourceOperator(int32_t id, int32_t plan_node_id, SortContext* sort_context)
             : SourceOperator(id, "local_merge_sort_source", plan_node_id), _sort_context(sort_context) {
-        _sort_context->ref_no_barrier();
+        _sort_context->ref();
     }
 
     ~LocalMergeSortSourceOperator() override = default;

--- a/be/src/exec/pipeline/sort/local_merge_sort_source_operator.h
+++ b/be/src/exec/pipeline/sort/local_merge_sort_source_operator.h
@@ -3,9 +3,9 @@
 #pragma once
 
 #include "column/vectorized_fwd.h"
+#include "exec/pipeline/sort/sort_context.h"
 #include "exec/pipeline/source_operator.h"
 #include "exec/sort_exec_exprs.h"
-#include "exec/pipeline/sort/sort_context.h"
 
 namespace starrocks {
 namespace pipeline {

--- a/be/src/exec/pipeline/sort/local_merge_sort_source_operator.h
+++ b/be/src/exec/pipeline/sort/local_merge_sort_source_operator.h
@@ -20,7 +20,7 @@ class LocalMergeSortSourceOperator final : public SourceOperator {
 public:
     LocalMergeSortSourceOperator(int32_t id, int32_t plan_node_id, SortContext* sort_context)
             : SourceOperator(id, "local_merge_sort_source", plan_node_id), _sort_context(sort_context) {
-        _sort_context->create_one_operator();
+        _sort_context->ref_no_barrier();
     }
 
     ~LocalMergeSortSourceOperator() override = default;

--- a/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
@@ -26,7 +26,7 @@ Status PartitionSortSinkOperator::prepare(RuntimeState* state) {
 }
 
 Status PartitionSortSinkOperator::close(RuntimeState* state) {
-    RETURN_IF_ERROR(_sort_context->close_one_operator(state));
+    RETURN_IF_ERROR(_sort_context->unref(state));
     return Operator::close(state);
 }
 

--- a/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
@@ -26,15 +26,12 @@ Status PartitionSortSinkOperator::prepare(RuntimeState* state) {
 }
 
 Status PartitionSortSinkOperator::close(RuntimeState* state) {
+    RETURN_IF_ERROR(_sort_context->close_one_operator(state));
     return Operator::close(state);
 }
 
 StatusOr<vectorized::ChunkPtr> PartitionSortSinkOperator::pull_chunk(RuntimeState* state) {
     CHECK(false) << "Shouldn't pull chunk from result sink operator";
-}
-
-bool PartitionSortSinkOperator::need_input() const {
-    return true;
 }
 
 Status PartitionSortSinkOperator::push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) {

--- a/be/src/exec/pipeline/sort/partition_sort_sink_operator.h
+++ b/be/src/exec/pipeline/sort/partition_sort_sink_operator.h
@@ -41,7 +41,9 @@ public:
               _materialized_tuple_desc(materialized_tuple_desc),
               _parent_node_row_desc(parent_node_row_desc),
               _parent_node_child_row_desc(parent_node_child_row_desc),
-              _sort_context(sort_context) {}
+              _sort_context(sort_context) {
+        _sort_context->create_one_operator();
+    }
 
     ~PartitionSortSinkOperator() override = default;
 
@@ -51,9 +53,9 @@ public:
 
     bool has_output() const override { return false; }
 
-    bool need_input() const override;
+    bool need_input() const override { return !is_finished(); }
 
-    bool is_finished() const override { return _is_finished; }
+    bool is_finished() const override { return _is_finished || _sort_context->is_finished(); }
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/sort/partition_sort_sink_operator.h
+++ b/be/src/exec/pipeline/sort/partition_sort_sink_operator.h
@@ -42,7 +42,7 @@ public:
               _parent_node_row_desc(parent_node_row_desc),
               _parent_node_child_row_desc(parent_node_child_row_desc),
               _sort_context(sort_context) {
-        _sort_context->ref_no_barrier();
+        _sort_context->ref();
     }
 
     ~PartitionSortSinkOperator() override = default;

--- a/be/src/exec/pipeline/sort/partition_sort_sink_operator.h
+++ b/be/src/exec/pipeline/sort/partition_sort_sink_operator.h
@@ -42,7 +42,7 @@ public:
               _parent_node_row_desc(parent_node_row_desc),
               _parent_node_child_row_desc(parent_node_child_row_desc),
               _sort_context(sort_context) {
-        _sort_context->create_one_operator();
+        _sort_context->ref_no_barrier();
     }
 
     ~PartitionSortSinkOperator() override = default;

--- a/be/src/exec/pipeline/sort/sort_context.h
+++ b/be/src/exec/pipeline/sort/sort_context.h
@@ -21,7 +21,7 @@ class ChunksSorter;
 namespace pipeline {
 using namespace vectorized;
 
-class SortContext : public ContextBase {
+class SortContext final : public ContextBase {
 public:
     explicit SortContext(int64_t limit, const int32_t num_right_sinkers, const std::vector<bool>& is_asc_order,
                          const std::vector<bool>& is_null_first)

--- a/be/src/exec/pipeline/sort/sort_context.h
+++ b/be/src/exec/pipeline/sort/sort_context.h
@@ -11,6 +11,7 @@
 #include "exec/vectorized/chunks_sorter.h"
 #include "exec/vectorized/chunks_sorter_full_sort.h"
 #include "exec/vectorized/chunks_sorter_topn.h"
+#include "exec/pipeline/context_base.h"
 
 namespace starrocks {
 namespace vectorized {
@@ -20,7 +21,7 @@ class ChunksSorter;
 namespace pipeline {
 using namespace vectorized;
 
-class SortContext {
+class SortContext : public ContextBase {
 public:
     explicit SortContext(int64_t limit, const int32_t num_right_sinkers, const std::vector<bool>& is_asc_order,
                          const std::vector<bool>& is_null_first)
@@ -28,6 +29,8 @@ public:
         _chunks_sorter_partions.reserve(num_right_sinkers);
         _data_segment_heaps.reserve(num_right_sinkers);
     }
+
+    Status close(RuntimeState* state) override { return Status::OK(); }
 
     void finish_partition(uint64_t partition_rows) {
         _total_rows.fetch_add(partition_rows, std::memory_order_relaxed);

--- a/be/src/exec/pipeline/sort/sort_context.h
+++ b/be/src/exec/pipeline/sort/sort_context.h
@@ -8,10 +8,10 @@
 
 #include "column/chunk.h"
 #include "column/vectorized_fwd.h"
+#include "exec/pipeline/context_base.h"
 #include "exec/vectorized/chunks_sorter.h"
 #include "exec/vectorized/chunks_sorter_full_sort.h"
 #include "exec/vectorized/chunks_sorter_topn.h"
-#include "exec/pipeline/context_base.h"
 
 namespace starrocks {
 namespace vectorized {

--- a/be/src/exec/pipeline/sort/sort_context.h
+++ b/be/src/exec/pipeline/sort/sort_context.h
@@ -8,7 +8,7 @@
 
 #include "column/chunk.h"
 #include "column/vectorized_fwd.h"
-#include "exec/pipeline/context_base.h"
+#include "exec/pipeline/context_with_dependency.h"
 #include "exec/vectorized/chunks_sorter.h"
 #include "exec/vectorized/chunks_sorter_full_sort.h"
 #include "exec/vectorized/chunks_sorter_topn.h"
@@ -21,7 +21,7 @@ class ChunksSorter;
 namespace pipeline {
 using namespace vectorized;
 
-class SortContext final : public ContextBase {
+class SortContext final : public ContextWithDependency {
 public:
     explicit SortContext(int64_t limit, const int32_t num_right_sinkers, const std::vector<bool>& is_asc_order,
                          const std::vector<bool>& is_null_first)

--- a/be/src/exec/vectorized/aggregate/aggregate_base_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_base_node.cpp
@@ -23,7 +23,7 @@ Status AggregateBaseNode::close(RuntimeState* state) {
         return Status::OK();
     }
     if (_aggregator != nullptr) {
-        _aggregator->close(state);
+        RETURN_IF_ERROR(_aggregator->close(state));
     }
     return ExecNode::close(state);
 }

--- a/be/src/exec/vectorized/aggregator.h
+++ b/be/src/exec/vectorized/aggregator.h
@@ -55,7 +55,7 @@ using AggregatorPtr = std::shared_ptr<Aggregator>;
 
 // Component used to process aggregation including bloking aggregate and streaming aggregate
 // it contains common data struct and algorithm of aggregation
-class Aggregator : public pipeline::ContextWithDependency {
+class Aggregator final : public pipeline::ContextWithDependency {
 public:
     Aggregator(const TPlanNode& tnode);
 

--- a/be/src/exec/vectorized/aggregator.h
+++ b/be/src/exec/vectorized/aggregator.h
@@ -10,7 +10,7 @@
 #include "column/column_helper.h"
 #include "column/type_traits.h"
 #include "column/vectorized_fwd.h"
-#include "exec/pipeline/context_base.h"
+#include "exec/pipeline/context_with_dependency.h"
 #include "exec/vectorized/aggregate/agg_hash_variant.h"
 #include "exprs/agg/aggregate_factory.h"
 #include "exprs/expr.h"
@@ -55,7 +55,7 @@ using AggregatorPtr = std::shared_ptr<Aggregator>;
 
 // Component used to process aggregation including bloking aggregate and streaming aggregate
 // it contains common data struct and algorithm of aggregation
-class Aggregator : public pipeline::ContextBase {
+class Aggregator : public pipeline::ContextWithDependency {
 public:
     Aggregator(const TPlanNode& tnode);
 

--- a/be/src/exec/vectorized/aggregator.h
+++ b/be/src/exec/vectorized/aggregator.h
@@ -10,6 +10,7 @@
 #include "column/column_helper.h"
 #include "column/type_traits.h"
 #include "column/vectorized_fwd.h"
+#include "exec/pipeline/context_base.h"
 #include "exec/vectorized/aggregate/agg_hash_variant.h"
 #include "exprs/agg/aggregate_factory.h"
 #include "exprs/expr.h"
@@ -54,7 +55,7 @@ using AggregatorPtr = std::shared_ptr<Aggregator>;
 
 // Component used to process aggregation including bloking aggregate and streaming aggregate
 // it contains common data struct and algorithm of aggregation
-class Aggregator {
+class Aggregator : public pipeline::ContextBase {
 public:
     Aggregator(const TPlanNode& tnode);
 
@@ -63,7 +64,7 @@ public:
     Status open(RuntimeState* state);
     Status prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile* runtime_profile, MemTracker* mem_tracker);
 
-    Status close(RuntimeState* state);
+    Status close(RuntimeState* state) override;
 
     std::unique_ptr<MemPool>& mem_pool() { return _mem_pool; };
     bool is_none_group_by_exprs() { return _group_by_expr_ctxs.empty(); }

--- a/be/src/exec/vectorized/analytor.h
+++ b/be/src/exec/vectorized/analytor.h
@@ -32,7 +32,7 @@ using AnalytorPtr = std::shared_ptr<Analytor>;
 // it contains common data struct and algorithm of analysis
 // TODO(hcf) this component is shared by multiply sink/source operators in pipeline engine
 // TODO(hcf) all the data should be protected by lightweight lock
-class Analytor : public pipeline::ContextWithDependency {
+class Analytor final : public pipeline::ContextWithDependency {
     friend class ManagedFunctionStates;
 
 public:

--- a/be/src/exec/vectorized/analytor.h
+++ b/be/src/exec/vectorized/analytor.h
@@ -2,12 +2,12 @@
 
 #pragma once
 
+#include "exec/pipeline/context_base.h"
 #include "exprs/agg/aggregate_factory.h"
 #include "exprs/expr.h"
 #include "runtime/descriptors.h"
 #include "runtime/types.h"
 #include "util/runtime_profile.h"
-#include "exec/pipeline/context_base.h"
 
 namespace starrocks {
 

--- a/be/src/exec/vectorized/analytor.h
+++ b/be/src/exec/vectorized/analytor.h
@@ -7,6 +7,7 @@
 #include "runtime/descriptors.h"
 #include "runtime/types.h"
 #include "util/runtime_profile.h"
+#include "exec/pipeline/context_base.h"
 
 namespace starrocks {
 
@@ -31,7 +32,7 @@ using AnalytorPtr = std::shared_ptr<Analytor>;
 // it contains common data struct and algorithm of analysis
 // TODO(hcf) this component is shared by multiply sink/source operators in pipeline engine
 // TODO(hcf) all the data should be protected by lightweight lock
-class Analytor {
+class Analytor : public pipeline::ContextBase {
     friend class ManagedFunctionStates;
 
 public:
@@ -40,7 +41,7 @@ public:
 
     Status prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile* runtime_profile);
     Status open(RuntimeState* state);
-    Status close(RuntimeState* state);
+    Status close(RuntimeState* state) override;
 
     enum FrameType {
         Unbounded,               // BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING

--- a/be/src/exec/vectorized/analytor.h
+++ b/be/src/exec/vectorized/analytor.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "exec/pipeline/context_base.h"
+#include "exec/pipeline/context_with_dependency.h"
 #include "exprs/agg/aggregate_factory.h"
 #include "exprs/expr.h"
 #include "runtime/descriptors.h"
@@ -32,7 +32,7 @@ using AnalytorPtr = std::shared_ptr<Analytor>;
 // it contains common data struct and algorithm of analysis
 // TODO(hcf) this component is shared by multiply sink/source operators in pipeline engine
 // TODO(hcf) all the data should be protected by lightweight lock
-class Analytor : public pipeline::ContextBase {
+class Analytor : public pipeline::ContextWithDependency {
     friend class ManagedFunctionStates;
 
 public:

--- a/be/src/exec/vectorized/hash_joiner.cpp
+++ b/be/src/exec/vectorized/hash_joiner.cpp
@@ -250,11 +250,9 @@ StatusOr<ChunkPtr> HashJoiner::_pull_probe_output_chunk(RuntimeState* state) {
     return std::make_shared<Chunk>();
 }
 
-void HashJoiner::close(RuntimeState* state) {
-    if (!_is_closed) {
-        _ht.close();
-        _is_closed = true;
-    }
+Status HashJoiner::close(RuntimeState* state) {
+    _ht.close();
+    return Status::OK();
 }
 
 bool HashJoiner::_has_null(const ColumnPtr& column) {

--- a/be/src/exec/vectorized/hash_joiner.h
+++ b/be/src/exec/vectorized/hash_joiner.h
@@ -39,7 +39,7 @@ enum HashJoinPhase {
     EOS = 4,
 };
 
-class HashJoiner : public pipeline::ContextWithDependency {
+class HashJoiner final : public pipeline::ContextWithDependency {
 public:
     HashJoiner(const THashJoinNode& hash_join_node, TPlanNodeId node_id, TPlanNodeType::type node_type, int64_t limit,
                const std::vector<bool>& is_null_safes, const std::vector<ExprContext*>& build_expr_ctxs,

--- a/be/src/exec/vectorized/hash_joiner.h
+++ b/be/src/exec/vectorized/hash_joiner.h
@@ -6,6 +6,7 @@
 #include "column/fixed_length_column.h"
 #include "common/statusor.h"
 #include "exec/exec_node.h"
+#include "exec/pipeline/context_base.h"
 #include "exec/vectorized/hash_join_node.h"
 #include "exec/vectorized/join_hash_map.h"
 #include "util/phmap/phmap.h"
@@ -37,7 +38,7 @@ enum HashJoinPhase {
     POST_PROBE = 2,
     EOS = 4,
 };
-class HashJoiner {
+class HashJoiner : public pipeline::ContextBase {
 public:
     HashJoiner(const THashJoinNode& hash_join_node, TPlanNodeId node_id, TPlanNodeType::type node_type, int64_t limit,
                const std::vector<bool>& is_null_safes, const std::vector<ExprContext*>& build_expr_ctxs,
@@ -48,7 +49,7 @@ public:
 
     ~HashJoiner() = default;
     Status prepare(RuntimeState* state);
-    void close(RuntimeState* state);
+    Status close(RuntimeState* state) override;
     bool need_input() const;
     bool has_output() const;
     bool is_build_done() const { return _phase != HashJoinPhase::BUILD; }

--- a/be/src/exec/vectorized/hash_joiner.h
+++ b/be/src/exec/vectorized/hash_joiner.h
@@ -38,6 +38,7 @@ enum HashJoinPhase {
     POST_PROBE = 2,
     EOS = 4,
 };
+
 class HashJoiner : public pipeline::ContextBase {
 public:
     HashJoiner(const THashJoinNode& hash_join_node, TPlanNodeId node_id, TPlanNodeType::type node_type, int64_t limit,

--- a/be/src/exec/vectorized/hash_joiner.h
+++ b/be/src/exec/vectorized/hash_joiner.h
@@ -6,7 +6,7 @@
 #include "column/fixed_length_column.h"
 #include "common/statusor.h"
 #include "exec/exec_node.h"
-#include "exec/pipeline/context_base.h"
+#include "exec/pipeline/context_with_dependency.h"
 #include "exec/vectorized/hash_join_node.h"
 #include "exec/vectorized/join_hash_map.h"
 #include "util/phmap/phmap.h"
@@ -39,7 +39,7 @@ enum HashJoinPhase {
     EOS = 4,
 };
 
-class HashJoiner : public pipeline::ContextBase {
+class HashJoiner : public pipeline::ContextWithDependency {
 public:
     HashJoiner(const THashJoinNode& hash_join_node, TPlanNodeId node_id, TPlanNodeType::type node_type, int64_t limit,
                const std::vector<bool>& is_null_safes, const std::vector<ExprContext*>& build_expr_ctxs,


### PR DESCRIPTION
### Introduction
> The complex ExecNode is usually decomposed to multiple operators, which share some variables in a context, and have dependency relationships between them.
For example, HashJoinNode is composed to HashJoinBuildOperator and HashJoinProbeOperator,
which share a HashJoiner context. And HashJoinProbeOperator depends on HashJoinBuildOperator.
> 
> Assume `OpA` depends on `OpB`.
However, `OpA` can be finished earlier than OpB, if its successor operator is finished early.
Therefore, there are two problems which needs to be considered:
> 1. `OpB` should perceive that `OpA` has been finished early.
> 2. Context object can be released only if both `OpA` and `OpB` are closed,  because the close order of `OpA` and `OpB` are uncertain.

### Changes
1. Add a class `pipeline::ContextBase`.
    -  `ref_no_barrier()` and `unref()` use  an atomic variable to guarantee that the context will be closed when the last running operator is closed.
    - `set_finished()` and `is_finished()` is used to mark output operator is finished, and non-output operator can be finished immediately.
2.  Call  `ContextBase::ref_no_barrier()` in the constructor of `XxxSinkOperator` and `XxxSourceOperator`.
3. Call `ContextBase::unref()` in `close()` of `XxxSinkOperator` and `XxxSourceOperator`.
4. Call `ContextBase::set_finished()` in `set_finished()` of `XxxSourceOperator`.
5. Call  `ContextBase::is_finished()` in `is_finished()` of `XxxSinkOperator`.

Fix #1382