### PR TITLE
Fix the bug of RequiredStoredColumnReader

### DIFF
--- a/be/src/exec/parquet/stored_column_reader.cpp
+++ b/be/src/exec/parquet/stored_column_reader.cpp
@@ -143,6 +143,7 @@ public:
         _reader = std::make_unique<ColumnChunkReader>(_field->max_def_level(), _field->max_rep_level(),
                                                       _field->type_length, chunk_metadata, file, opts);
         RETURN_IF_ERROR(_reader->init());
+        _num_values_left_in_cur_page = _reader->num_values();
         return Status::OK();
     }
 


### PR DESCRIPTION
for #1359

The first page is not read

The reason is that the first Page page was not read and skipped over. The parquet files generated by Hive are all Nullable, and this Reader will not be used, but the NotNull Column can be generated through spark, which has not been shown by the customer before. There may be two reasons for the problem: (1) The data is wrong and has not been found (2) The user did not use tools such as Sparek to generate NotNull Parquet file columns.