### PR TITLE
Fix std::mktime uninitialized bug

### DIFF
--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -30,6 +30,7 @@
 #include <boost/algorithm/string/split.hpp>
 #include <csignal>
 #include <cstdio>
+#include <cstring>
 #include <filesystem>
 #include <memory>
 #include <new>
@@ -699,6 +700,8 @@ OLAPStatus StorageEngine::_start_trash_sweep(double* usage) {
 
     time_t now = time(nullptr);
     tm local_tm_now;
+    memset(&local_tm_now, 0, sizeof(tm));
+
     if (localtime_r(&now, &local_tm_now) == nullptr) {
         LOG(WARNING) << "fail to localtime_r time. time=" << now;
         return OLAP_ERR_OS_ERROR;
@@ -809,6 +812,8 @@ OLAPStatus StorageEngine::_do_sweep(const string& scan_root, const time_t& local
             string dir_name = item.path().filename().string();
             string str_time = dir_name.substr(0, dir_name.find('.'));
             tm local_tm_create;
+            memset(&local_tm_create, 0, sizeof(tm));
+
             if (strptime(str_time.c_str(), "%Y%m%d%H%M%S", &local_tm_create) == nullptr) {
                 LOG(WARNING) << "fail to strptime time. [time=" << str_time << "]";
                 res = OLAP_ERR_OS_ERROR;


### PR DESCRIPTION
ref: https://stackoverflow.com/questions/25374877/mktime-function-of-libc-returns-different-values-for-the-same-input

which may cause make snapshot error

a simple case eg:
```c++
#include <time.h>

#include <chrono>
#include <iostream>
#include <string>

int main() {
    time_t now = time(nullptr); 
    tm local_tm_now;
    if (localtime_r(&now, &local_tm_now) == nullptr) {
        return 1;
    }
    const time_t local_now = std::mktime(&local_tm_now); 
    tm local_tm_create;

    std::string str_time = "20211118192604";
    if (strptime(str_time.c_str(), "%Y%m%d%H%M%S", &local_tm_create) == nullptr) {
        return 2;
    }
    if (difftime(local_now, std::mktime(&local_tm_create)) >= 1800) {
        return 3; // GCC10 GLIBC2.29 will return here
    }

    return 0; // GCC4 GLIBC2.21 will return here
}
```