### PR TITLE
Modify Hive external table scan scheduling strategy

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -646,8 +646,8 @@ CONF_Int64(pipeline_io_buffer_size, "64");
 CONF_Int16(bitmap_serialize_version, "1");
 // schema change vectorized
 CONF_Bool(enable_schema_change_vectorized, "true");
-// max hdfs file instance
-CONF_mInt32(max_hdfs_file_instance, "1000");
+// max hdfs file handle
+CONF_mInt32(max_hdfs_file_handle, "1000");
 
 } // namespace config
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -646,6 +646,8 @@ CONF_Int64(pipeline_io_buffer_size, "64");
 CONF_Int16(bitmap_serialize_version, "1");
 // schema change vectorized
 CONF_Bool(enable_schema_change_vectorized, "true");
+// max hdfs file instance
+CONF_mInt32(max_hdfs_file_instance, "1000");
 
 } // namespace config
 

--- a/be/src/env/env_hdfs.h
+++ b/be/src/env/env_hdfs.h
@@ -12,9 +12,11 @@ namespace starrocks {
 // Now this is not thread-safe.
 class HdfsRandomAccessFile : public RandomAccessFile {
 public:
-    HdfsRandomAccessFile(hdfsFS fs, hdfsFile file, std::string filename);
-    ~HdfsRandomAccessFile() override = default;
+    HdfsRandomAccessFile(hdfsFS fs, std::string filename);
+    virtual ~HdfsRandomAccessFile() noexcept;
 
+    Status open();
+    void close() noexcept;
     Status read(uint64_t offset, Slice* res) const override;
     Status read_at(uint64_t offset, const Slice& res) const override;
     Status readv_at(uint64_t offset, const Slice* res, size_t res_cnt) const override;
@@ -25,6 +27,7 @@ public:
     hdfsFile hdfs_file() const { return _file; }
 
 private:
+    bool _opened;
     hdfsFS _fs;
     hdfsFile _file;
     std::string _filename;

--- a/be/src/exec/vectorized/hdfs_scan_node.cpp
+++ b/be/src/exec/vectorized/hdfs_scan_node.cpp
@@ -2,12 +2,16 @@
 
 #include "exec/vectorized/hdfs_scan_node.h"
 
+#include <atomic>
 #include <memory>
 
 #include "env/env_hdfs.h"
+#include "exec/vectorized/hdfs_scanner.h"
 #include "exprs/expr.h"
 #include "exprs/expr_context.h"
 #include "exprs/vectorized/runtime_filter.h"
+#include "fmt/core.h"
+#include "glog/logging.h"
 #include "runtime/current_thread.h"
 #include "runtime/exec_env.h"
 #include "runtime/hdfs/hdfs_fs_cache.h"
@@ -18,6 +22,7 @@
 #include "util/priority_thread_pool.hpp"
 
 namespace starrocks::vectorized {
+
 HdfsScanNode::HdfsScanNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs)
         : ScanNode(pool, tnode, descs) {}
 
@@ -189,6 +194,7 @@ Status HdfsScanNode::_create_and_init_scanner(RuntimeState* state, const HdfsFil
     scanner_params.min_max_tuple_desc = _min_max_tuple_desc;
     scanner_params.hive_column_names = &_hive_column_names;
     scanner_params.parent = this;
+    scanner_params.open_limit = hdfs_file_desc.scan_limit;
 
     HdfsScanner* scanner = nullptr;
     if (hdfs_file_desc.hdfs_file_format == THdfsFileFormat::PARQUET) {
@@ -196,7 +202,7 @@ Status HdfsScanNode::_create_and_init_scanner(RuntimeState* state, const HdfsFil
     } else if (hdfs_file_desc.hdfs_file_format == THdfsFileFormat::ORC) {
         scanner = _pool->add(new HdfsOrcScanner());
     } else {
-        string msg = "unsupported hdfs file format: " + hdfs_file_desc.hdfs_file_format;
+        std::string msg = fmt::format("unsupported hdfs file format: {}", hdfs_file_desc.hdfs_file_format);
         LOG(WARNING) << msg;
         return Status::NotSupported(msg);
     }
@@ -266,7 +272,57 @@ void HdfsScanNode::_scanner_thread(HdfsScanner* scanner) {
     DeferOp op([&] {
         tls_thread_status.set_mem_tracker(prev_tracker);
         _running_threads.fetch_sub(1, std::memory_order_release);
+
+        if (_closed_scanners.load(std::memory_order_acquire) == _num_scanners) {
+            _result_chunks.shutdown();
+        }
     });
+
+    // if global status was not ok
+    // we need fast failure
+    if (!_get_status().ok()) {
+        scanner->release_pending_token(&_pending_token);
+        scanner->close(_runtime_state);
+        _closed_scanners.fetch_add(1, std::memory_order_release);
+        _close_pending_scanners();
+        return;
+    }
+
+    int concurrency_limit = config::max_hdfs_file_instance;
+
+    // There is a situation where once a resource overrun has occurred,
+    // the scanners that were previously overrun are basically in a pending state,
+    // so even if there are enough resources to follow, they cannot be fully utilized,
+    // and we need to schedule the scanners that are in a pending state as well.
+    if (scanner->has_pending_token()) {
+        int concurrency = std::min<int>(kMaxConcurrency, _num_scanners);
+        int need_put = concurrency - _running_threads;
+        int left_resource = concurrency_limit - scanner->scan_limit();
+        if (left_resource > 0) {
+            need_put = std::min(left_resource, need_put);
+            std::lock_guard<std::mutex> l(_mtx);
+            while (need_put-- > 0 && !_pending_scanners.empty()) {
+                if (!_submit_scanner(_pending_scanners.pop(), false)) {
+                    break;
+                }
+            }
+        }
+    }
+
+    if (!scanner->has_pending_token()) {
+        scanner->acquire_pending_token(&_pending_token);
+    }
+
+    // if opened file greater than this. scanner will push back to pending list.
+    // We can't have all scanners in the pending state, we need to
+    // make sure there is at least one thread on each SCAN NODE that can be running
+    if (!scanner->is_open() && scanner->scan_limit() > concurrency_limit) {
+        if (!scanner->has_pending_token()) {
+            std::lock_guard<std::mutex> l(_mtx);
+            _pending_scanners.push(scanner);
+            return;
+        }
+    }
 
     Status status = scanner->open(_runtime_state);
     scanner->set_keep_priority(false);
@@ -281,6 +337,7 @@ void HdfsScanNode::_scanner_thread(HdfsScanner* scanner) {
             std::lock_guard<std::mutex> l(_mtx);
             if (_chunk_pool.empty()) {
                 scanner->set_keep_priority(true);
+                scanner->release_pending_token(&_pending_token);
                 _pending_scanners.push(scanner);
                 scanner = nullptr;
                 break;
@@ -310,20 +367,23 @@ void HdfsScanNode::_scanner_thread(HdfsScanner* scanner) {
         if (status.ok() && resubmit) {
             if (!_submit_scanner(scanner, false)) {
                 std::lock_guard<std::mutex> l(_mtx);
+                scanner->release_pending_token(&_pending_token);
                 _pending_scanners.push(scanner);
             }
         } else if (status.ok()) {
             DCHECK(scanner == nullptr);
         } else if (status.is_end_of_file()) {
+            scanner->release_pending_token(&_pending_token);
             scanner->close(_runtime_state);
             _closed_scanners.fetch_add(1, std::memory_order_release);
             std::lock_guard<std::mutex> l(_mtx);
-            scanner = _pending_scanners.empty() ? nullptr : _pending_scanners.pop();
-            if (scanner != nullptr && !_submit_scanner(scanner, false)) {
-                _pending_scanners.push(scanner);
+            auto nscanner = _pending_scanners.empty() ? nullptr : _pending_scanners.pop();
+            if (nscanner != nullptr && !_submit_scanner(nscanner, false)) {
+                _pending_scanners.push(nscanner);
             }
         } else {
             _update_status(status);
+            scanner->release_pending_token(&_pending_token);
             scanner->close(_runtime_state);
             _closed_scanners.fetch_add(1, std::memory_order_release);
             _close_pending_scanners();
@@ -331,14 +391,11 @@ void HdfsScanNode::_scanner_thread(HdfsScanner* scanner) {
     } else {
         // sometimes state == ok but global_status was not ok
         if (scanner != nullptr) {
+            scanner->release_pending_token(&_pending_token);
             scanner->close(_runtime_state);
             _closed_scanners.fetch_add(1, std::memory_order_release);
             _close_pending_scanners();
         }
-    }
-
-    if (_closed_scanners.load(std::memory_order_acquire) == _num_scanners) {
-        _result_chunks.shutdown();
     }
 }
 
@@ -440,9 +497,7 @@ Status HdfsScanNode::close(RuntimeState* state) {
 
     _close_pending_scanners();
     for (auto* hdfsFile : _hdfs_files) {
-        if (hdfsFile->hdfs_fs != nullptr && hdfsFile->hdfs_file != nullptr) {
-            hdfsCloseFile(hdfsFile->hdfs_fs, hdfsFile->hdfs_file);
-        }
+        hdfsFile->fs.reset();
     }
 
     Expr::close(_min_max_conjunct_ctxs, state);
@@ -546,31 +601,27 @@ Status HdfsScanNode::_find_and_insert_hdfs_file(const THdfsScanRange& scan_range
 
         auto* hdfs_file_desc = _pool->add(new HdfsFileDesc());
         hdfs_file_desc->hdfs_fs = nullptr;
-        hdfs_file_desc->hdfs_file = nullptr;
         hdfs_file_desc->fs = std::move(file);
         hdfs_file_desc->partition_id = scan_range.partition_id;
         hdfs_file_desc->path = scan_range.relative_path;
         hdfs_file_desc->file_length = scan_range.file_length;
         hdfs_file_desc->splits.emplace_back(&scan_range);
         hdfs_file_desc->hdfs_file_format = scan_range.file_format;
+        hdfs_file_desc->scan_limit = nullptr;
         _hdfs_files.emplace_back(hdfs_file_desc);
     } else {
         hdfsFS hdfs;
-        RETURN_IF_ERROR(HdfsFsCache::instance()->get_connection(namenode, &hdfs));
-        auto* file = hdfsOpenFile(hdfs, native_file_path.c_str(), O_RDONLY, 0, 0, 0);
-        if (file == nullptr) {
-            return Status::InternalError(strings::Substitute("open file failed, file=$0", native_file_path));
-        }
-
+        std::atomic<int32_t>* scan_limit = nullptr;
+        RETURN_IF_ERROR(HdfsFsCache::instance()->get_connection(namenode, &hdfs, &scan_limit));
         auto* hdfs_file_desc = _pool->add(new HdfsFileDesc());
         hdfs_file_desc->hdfs_fs = hdfs;
-        hdfs_file_desc->hdfs_file = file;
-        hdfs_file_desc->fs = std::make_shared<HdfsRandomAccessFile>(hdfs, file, native_file_path);
+        hdfs_file_desc->fs = std::make_shared<HdfsRandomAccessFile>(hdfs, native_file_path);
         hdfs_file_desc->partition_id = scan_range.partition_id;
         hdfs_file_desc->path = scan_range.relative_path;
         hdfs_file_desc->file_length = scan_range.file_length;
         hdfs_file_desc->splits.emplace_back(&scan_range);
         hdfs_file_desc->hdfs_file_format = scan_range.file_format;
+        hdfs_file_desc->scan_limit = scan_limit;
         _hdfs_files.emplace_back(hdfs_file_desc);
     }
 

--- a/be/src/exec/vectorized/hdfs_scan_node.h
+++ b/be/src/exec/vectorized/hdfs_scan_node.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <atomic>
+#include <memory>
 
 #include "env/env.h"
 #include "exec/scan_node.h"
@@ -15,14 +16,15 @@ namespace starrocks::vectorized {
 
 struct HdfsFileDesc {
     hdfsFS hdfs_fs;
-    hdfsFile hdfs_file;
     THdfsFileFormat::type hdfs_file_format;
-    std::shared_ptr<RandomAccessFile> fs = nullptr;
+    std::shared_ptr<RandomAccessFile> fs;
 
     int partition_id = 0;
     std::string path;
     int64_t file_length = 0;
     std::vector<const THdfsScanRange*> splits;
+
+    std::atomic<int32_t>* scan_limit = nullptr;
 };
 
 class HdfsScanNode final : public starrocks::ScanNode {
@@ -145,6 +147,8 @@ private:
     Status _status;
     RuntimeState* _runtime_state = nullptr;
     bool _is_hdfs_fs = true;
+
+    std::atomic_bool _pending_token = true;
 
     std::atomic<int32_t> _scanner_submit_count = 0;
     std::atomic<int32_t> _running_threads = 0;

--- a/be/src/exec/vectorized/hdfs_scan_node.h
+++ b/be/src/exec/vectorized/hdfs_scan_node.h
@@ -24,7 +24,7 @@ struct HdfsFileDesc {
     int64_t file_length = 0;
     std::vector<const THdfsScanRange*> splits;
 
-    std::atomic<int32_t>* scan_limit = nullptr;
+    std::atomic<int32_t>* open_limit = nullptr;
 };
 
 class HdfsScanNode final : public starrocks::ScanNode {

--- a/be/src/exec/vectorized/hdfs_scanner.h
+++ b/be/src/exec/vectorized/hdfs_scanner.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <utility>
 
 #include "column/chunk.h"
@@ -77,6 +78,8 @@ struct HdfsScannerParams {
     std::vector<std::string>* hive_column_names;
 
     HdfsScanNode* parent = nullptr;
+
+    std::atomic<int32_t>* open_limit;
 };
 
 struct HdfsFileReaderParam {
@@ -133,13 +136,20 @@ struct HdfsFileReaderParam {
     bool can_use_dict_filter_on_slot(SlotDescriptor* slot) const;
 };
 
+// if *lvalue == expect, swap(*lvalue,*rvalue)
+inline bool atomic_cas(std::atomic_bool* lvalue, std::atomic_bool* rvalue, bool expect) {
+    bool res = lvalue->compare_exchange_strong(expect, *rvalue);
+    if (res) *rvalue = expect;
+    return res;
+}
+
 class HdfsScanner {
 public:
     HdfsScanner() = default;
     virtual ~HdfsScanner() = default;
 
     Status open(RuntimeState* runtime_state);
-    Status close(RuntimeState* runtime_state);
+    void close(RuntimeState* runtime_state) noexcept;
     Status get_next(RuntimeState* runtime_state, ChunkPtr* chunk);
     Status init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params);
 
@@ -150,8 +160,28 @@ public:
 
     RuntimeState* runtime_state() { return _runtime_state; }
 
+    int scan_limit() { return *_scanner_params.open_limit; }
+
+    bool is_open() { return _is_open; }
+
+    bool acquire_pending_token(std::atomic_bool* token) {
+        // acquire resource
+        return atomic_cas(token, &_pending_token, true);
+    }
+
+    bool release_pending_token(std::atomic_bool* token) {
+        if (_pending_token) {
+            _pending_token = false;
+            *token = true;
+            return true;
+        }
+        return false;
+    }
+
+    bool has_pending_token() { return _pending_token; }
+
     virtual Status do_open(RuntimeState* runtime_state) = 0;
-    virtual Status do_close(RuntimeState* runtime_state) = 0;
+    virtual void do_close(RuntimeState* runtime_state) noexcept = 0;
     virtual Status do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) = 0;
     virtual Status do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) = 0;
 
@@ -162,6 +192,8 @@ private:
     void _build_file_read_param();
 
 protected:
+    std::atomic_bool _pending_token = false;
+
     HdfsFileReaderParam _file_read_param;
     HdfsScannerParams _scanner_params;
     RuntimeState* _runtime_state = nullptr;
@@ -183,7 +215,7 @@ public:
 
     void update_counter();
     Status do_open(RuntimeState* runtime_state) override;
-    Status do_close(RuntimeState* runtime_state) override;
+    void do_close(RuntimeState* runtime_state) noexcept override;
     Status do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) override;
     Status do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) override;
 

--- a/be/src/exec/vectorized/hdfs_scanner.h
+++ b/be/src/exec/vectorized/hdfs_scanner.h
@@ -160,7 +160,7 @@ public:
 
     RuntimeState* runtime_state() { return _runtime_state; }
 
-    int scan_limit() { return *_scanner_params.open_limit; }
+    int open_limit() { return *_scanner_params.open_limit; }
 
     bool is_open() { return _is_open; }
 

--- a/be/src/exec/vectorized/hdfs_scanner_orc.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_orc.cpp
@@ -327,10 +327,9 @@ void HdfsOrcScanner::update_counter() {
 #endif
 }
 
-Status HdfsParquetScanner::do_close(RuntimeState* runtime_state) {
+void HdfsParquetScanner::do_close(RuntimeState* runtime_state) noexcept {
     update_counter();
     _reader.reset();
-    return Status::OK();
 }
 
 Status HdfsOrcScanner::do_open(RuntimeState* runtime_state) {
@@ -387,10 +386,9 @@ Status HdfsOrcScanner::do_open(RuntimeState* runtime_state) {
     return Status::OK();
 }
 
-Status HdfsOrcScanner::do_close(RuntimeState* runtime_state) {
+void HdfsOrcScanner::do_close(RuntimeState* runtime_state) noexcept {
     _orc_adapter.reset(nullptr);
     update_counter();
-    return Status::OK();
 }
 
 Status HdfsOrcScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) {

--- a/be/src/exec/vectorized/hdfs_scanner_orc.h
+++ b/be/src/exec/vectorized/hdfs_scanner_orc.h
@@ -18,7 +18,7 @@ public:
 
     void update_counter();
     Status do_open(RuntimeState* runtime_state) override;
-    Status do_close(RuntimeState* runtime_state) override;
+    void do_close(RuntimeState* runtime_state) noexcept override;
     Status do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) override;
     Status do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) override;
 

--- a/be/src/runtime/hdfs/hdfs_fs_cache.cpp
+++ b/be/src/runtime/hdfs/hdfs_fs_cache.cpp
@@ -2,6 +2,9 @@
 
 #include "runtime/hdfs/hdfs_fs_cache.h"
 
+#include <memory>
+#include <utility>
+
 #include "gutil/strings/substitute.h"
 #include "util/hdfs_util.h"
 
@@ -35,14 +38,16 @@ static Status parse_namenode(const std::string& path, std::string* namenode) {
     return Status::OK();
 }
 
-Status HdfsFsCache::get_connection(const std::string& path, hdfsFS* fs, HdfsFsMap* local_cache) {
+Status HdfsFsCache::get_connection(const std::string& path, hdfsFS* fs, ResourceSemaphorePtr* res,
+                                   HdfsFsMap* local_cache) {
     std::string namenode;
     RETURN_IF_ERROR(parse_namenode(path, &namenode));
 
     if (local_cache != nullptr) {
         auto it = local_cache->find(namenode);
         if (it != local_cache->end()) {
-            *fs = it->second;
+            *fs = it->second.first;
+            *res = it->second.second.get();
             return Status::OK();
         }
     }
@@ -52,21 +57,24 @@ Status HdfsFsCache::get_connection(const std::string& path, hdfsFS* fs, HdfsFsMa
 
         auto it = _cache.find(namenode);
         if (it != _cache.end()) {
-            *fs = it->second;
+            *fs = it->second.first;
+            *res = it->second.second.get();
         } else {
             auto hdfs_builder = hdfsNewBuilder();
             hdfsBuilderSetNameNode(hdfs_builder, namenode.c_str());
+            auto semaphore = std::make_unique<ResourceSemaphore>(0);
             *fs = hdfsBuilderConnect(hdfs_builder);
+            *res = semaphore.get();
             if (*fs == nullptr) {
                 return Status::InternalError(strings::Substitute("fail to connect hdfs namenode, name=$0, err=$1",
                                                                  namenode, get_hdfs_err_msg()));
             }
-            _cache[namenode] = *fs;
+            _cache[namenode] = std::make_pair(*fs, std::move(semaphore));
         }
     }
 
     if (local_cache != nullptr) {
-        local_cache->emplace(namenode, *fs);
+        local_cache->emplace(namenode, std::make_pair(*fs, std::make_unique<ResourceSemaphore>(0)));
     }
 
     return Status::OK();

--- a/be/src/runtime/hdfs/hdfs_fs_cache.h
+++ b/be/src/runtime/hdfs/hdfs_fs_cache.h
@@ -19,9 +19,9 @@ namespace starrocks {
 // Cache for HDFS file system
 class HdfsFsCache {
 public:
-    using ResourceSemaphore = std::atomic<int32_t>;
-    using ResourceSemaphorePtr = ResourceSemaphore*;
-    using HdfsFsMap = std::unordered_map<std::string, std::pair<hdfsFS, std::unique_ptr<ResourceSemaphore>>>;
+    using FileOpenLimit = std::atomic<int32_t>;
+    using FileOpenLimitPtr = FileOpenLimit*;
+    using HdfsFsMap = std::unordered_map<std::string, std::pair<hdfsFS, std::unique_ptr<FileOpenLimit>>>;
 
     static HdfsFsCache* instance() {
         static HdfsFsCache s_instance;
@@ -29,7 +29,7 @@ public:
     }
 
     // This function is thread-safe
-    Status get_connection(const std::string& path, hdfsFS* fs, ResourceSemaphorePtr* semaphore = nullptr,
+    Status get_connection(const std::string& path, hdfsFS* fs, FileOpenLimitPtr* semaphore = nullptr,
                           HdfsFsMap* map = nullptr);
 
 private:

--- a/be/src/runtime/hdfs/hdfs_fs_cache.h
+++ b/be/src/runtime/hdfs/hdfs_fs_cache.h
@@ -4,9 +4,12 @@
 
 #include <hdfs/hdfs.h>
 
+#include <atomic>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <unordered_map>
+#include <utility>
 
 #include "common/status.h"
 #include "gutil/macros.h"
@@ -16,7 +19,9 @@ namespace starrocks {
 // Cache for HDFS file system
 class HdfsFsCache {
 public:
-    using HdfsFsMap = std::unordered_map<std::string, hdfsFS>;
+    using ResourceSemaphore = std::atomic<int32_t>;
+    using ResourceSemaphorePtr = ResourceSemaphore*;
+    using HdfsFsMap = std::unordered_map<std::string, std::pair<hdfsFS, std::unique_ptr<ResourceSemaphore>>>;
 
     static HdfsFsCache* instance() {
         static HdfsFsCache s_instance;
@@ -24,7 +29,8 @@ public:
     }
 
     // This function is thread-safe
-    Status get_connection(const std::string& path, hdfsFS* fs, HdfsFsMap* map = nullptr);
+    Status get_connection(const std::string& path, hdfsFS* fs, ResourceSemaphorePtr* semaphore = nullptr,
+                          HdfsFsMap* map = nullptr);
 
 private:
     std::mutex _lock;

--- a/be/test/exec/vectorized/hdfs_scanner_test.cpp
+++ b/be/test/exec/vectorized/hdfs_scanner_test.cpp
@@ -216,8 +216,7 @@ TEST_F(HdfsScannerTest, TestParquetGetNext) {
     status = scanner->get_next(_runtime_state, &chunk);
     ASSERT_TRUE(status.is_end_of_file());
 
-    status = scanner->close(_runtime_state);
-    ASSERT_TRUE(status.ok());
+    scanner->close(_runtime_state);
 }
 
 static TTypeDesc create_primitive_type_desc(TPrimitiveType::type type) {
@@ -358,8 +357,7 @@ TEST_F(HdfsScannerTest, TestOrcGetNext) {
     EXPECT_TRUE(status.ok());
     READ_ORC_ROWS(scanner, 100);
     EXPECT_EQ(scanner->raw_rows_read(), 100);
-    status = scanner->close(_runtime_state);
-    EXPECT_TRUE(status.ok());
+    scanner->close(_runtime_state);
 }
 
 static SlotDesc orc_min_max_descs[] = {{"id", TypeDescriptor::from_primtive_type(PrimitiveType::TYPE_BIGINT)},
@@ -443,8 +441,7 @@ TEST_F(HdfsScannerTest, TestOrcGetNextWithMinMaxFilterNoRows) {
     EXPECT_TRUE(status.ok());
     READ_ORC_ROWS(scanner, 0);
     EXPECT_EQ(scanner->raw_rows_read(), 0);
-    status = scanner->close(_runtime_state);
-    EXPECT_TRUE(status.ok());
+    scanner->close(_runtime_state);
 }
 
 TEST_F(HdfsScannerTest, TestOrcGetNextWithMinMaxFilterRows1) {
@@ -479,8 +476,7 @@ TEST_F(HdfsScannerTest, TestOrcGetNextWithMinMaxFilterRows1) {
     EXPECT_TRUE(status.ok());
     READ_ORC_ROWS(scanner, 100);
     EXPECT_EQ(scanner->raw_rows_read(), 100);
-    status = scanner->close(_runtime_state);
-    EXPECT_TRUE(status.ok());
+    scanner->close(_runtime_state);
 }
 
 TEST_F(HdfsScannerTest, TestOrcGetNextWithMinMaxFilterRows2) {
@@ -515,8 +511,7 @@ TEST_F(HdfsScannerTest, TestOrcGetNextWithMinMaxFilterRows2) {
     EXPECT_TRUE(status.ok());
     READ_ORC_ROWS(scanner, 100);
     EXPECT_EQ(scanner->raw_rows_read(), 100);
-    status = scanner->close(_runtime_state);
-    EXPECT_TRUE(status.ok());
+    scanner->close(_runtime_state);
 }
 
 static SlotDesc string_key_value_orc_desc[] = {
@@ -602,8 +597,7 @@ TEST_F(HdfsScannerTest, TestOrcGetNextWithDictFilter) {
     // since we use dict filter eval cache, we can do filter on orc cvb
     // so actually read rows is 1000.
     EXPECT_EQ(scanner->raw_rows_read(), 1000);
-    status = scanner->close(_runtime_state);
-    EXPECT_TRUE(status.ok());
+    scanner->close(_runtime_state);
 }
 
 static SlotDesc datetime_orc_descs[] = {{"c0", TypeDescriptor::from_primtive_type(PrimitiveType::TYPE_DATETIME)}, {""}};
@@ -707,8 +701,7 @@ TEST_F(HdfsScannerTest, TestOrcGetNextWithDatetimeMinMaxFilter) {
     EXPECT_TRUE(status.ok());
     READ_ORC_ROWS(scanner, 4640);
     EXPECT_EQ(scanner->raw_rows_read(), 4640);
-    status = scanner->close(_runtime_state);
-    EXPECT_TRUE(status.ok());
+    scanner->close(_runtime_state);
 }
 
 static SlotDesc padding_char_varchar_desc[] = {{"c0", TypeDescriptor::from_primtive_type(PrimitiveType::TYPE_CHAR)},
@@ -819,8 +812,7 @@ TEST_F(HdfsScannerTest, TestOrcGetNextWithPaddingCharDictFilter) {
     // since we use dict filter eval cache, we can do filter on orc cvb
     // so actually read rows is 1000.
     EXPECT_EQ(scanner->raw_rows_read(), 1000);
-    status = scanner->close(_runtime_state);
-    EXPECT_TRUE(status.ok());
+    scanner->close(_runtime_state);
 }
 
 } // namespace starrocks::vectorized


### PR DESCRIPTION
In the previous scan scheduling, if there were multiple partitions, each partition would be scanned equally,
and although this would allow each scanner to be scheduled very equally, it would also result in too many HDFS files being open at the same time. 
In some scenarios several thousand HDFS handles may be held at the same time. It will increase the load on HDFS.

Now we will limit max_hdfs_file_instance in hive external table, if opened file greater than this. scanner will push back to pending list

if opened file greater than this. scanner will push back to pending list. We can't have all scanners in the pending state, we need to make sure there is at least one thread on each SCAN NODE that can be running
