### PR TITLE
Fix the problem that Memory is not released in time when scanning Par…

### DIFF
--- a/be/src/exec/vectorized/hdfs_scanner_orc.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_orc.cpp
@@ -329,6 +329,7 @@ void HdfsOrcScanner::update_counter() {
 
 Status HdfsParquetScanner::do_close(RuntimeState* runtime_state) {
     update_counter();
+    _reader.reset();
     return Status::OK();
 }
 


### PR DESCRIPTION
…quet

reader will acquire too much memory, but scanner is only destroyed at the end of the query.

heap profile:
```
     0.0   0.0% 100.0%    348.0  17.2% starrocks::parquet::ColumnChunkReader::_parse_page_data
     0.0   0.0% 100.0%   1740.0  85.8% starrocks::parquet::ColumnChunkReader::init
     0.0   0.0% 100.0%   1740.2  85.8% starrocks::parquet::ColumnReader::create
     0.0   0.0% 100.0%      0.0   0.0% starrocks::parquet::EncodingInfo::create_decoder (inline)
     0.0   0.0% 100.0%      0.7   0.0% starrocks::parquet::FileReader::_parse_footer
     0.0   0.0% 100.0%      0.0   0.0% starrocks::parquet::FileReader::_pre_process_schema
     0.0   0.0% 100.0%      0.5   0.0% starrocks::parquet::FileReader::_row_group (inline)
     0.0   0.0% 100.0%      0.5   0.0% starrocks::parquet::GroupReader::GroupReader
     0.0   0.0% 100.0%   1740.3  85.8% starrocks::parquet::GroupReader::_init_column_readers
     0.0   0.0% 100.0%      0.8   0.0% starrocks::parquet::GroupReader::_init_read_chunk
```
will close #1400 