### PR TITLE
Fix some problems of pipeline engine

### DIFF
--- a/be/src/exec/pipeline/exchange/sink_buffer.h
+++ b/be/src/exec/pipeline/exchange/sink_buffer.h
@@ -214,12 +214,6 @@ private:
                     TransmitChunkInfo info = buffer.front();
                     _send_rpc(info);
                     info.params->release_finst_id();
-                    if (info.params->eos()) {
-                        std::lock_guard<std::mutex> l(_mutex);
-                        if (--_expected_eos == 0) {
-                            _is_finishing = true;
-                        }
-                    }
                     {
                         std::lock_guard<std::mutex> l(_mutex);
                         buffer.pop();
@@ -264,6 +258,9 @@ private:
         }
 
         if (request.params->eos()) {
+            if (--_expected_eos == 0) {
+                _is_finishing = true;
+            }
             // Only the last eos is sent to ExchangeSourceOperator. it must be guaranteed that
             // eos is the last packet to send to finish the input stream of the corresponding of
             // ExchangeSourceOperator and eos is sent exactly-once.

--- a/be/src/exec/pipeline/sort/local_merge_sort_source_operator.cpp
+++ b/be/src/exec/pipeline/sort/local_merge_sort_source_operator.cpp
@@ -23,9 +23,7 @@ StatusOr<vectorized::ChunkPtr> LocalMergeSortSourceOperator::pull_chunk(RuntimeS
 }
 
 void LocalMergeSortSourceOperator::set_finishing(RuntimeState* state) {
-    if (!_is_finished) {
-        _is_finished = true;
-    }
+    _is_finished = true;
 }
 
 void LocalMergeSortSourceOperator::set_finished(RuntimeState* state) {

--- a/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
@@ -42,14 +42,12 @@ Status PartitionSortSinkOperator::push_chunk(RuntimeState* state, const vectoriz
 }
 
 void PartitionSortSinkOperator::set_finishing(RuntimeState* state) {
-    if (!_is_finished) {
-        _chunks_sorter->finish(state);
+    _chunks_sorter->finish(state);
 
-        // Current partition sort is ended, and
-        // the last call will drive LocalMergeSortSourceOperator to work.
-        _sort_context->finish_partition(_chunks_sorter->get_partition_rows());
-        _is_finished = true;
-    }
+    // Current partition sort is ended, and
+    // the last call will drive LocalMergeSortSourceOperator to work.
+    _sort_context->finish_partition(_chunks_sorter->get_partition_rows());
+    _is_finished = true;
 }
 
 Status PartitionSortSinkOperatorFactory::prepare(RuntimeState* state) {


### PR DESCRIPTION
1. Fix the problem of decreasing `_expected_eos` at a wrong time. The property of request `eos` may be changed after calling method `_send_rpc`
2. Remove redundant idempotent logic because `set_finishing` will be invoked exactly once