### PR TITLE
Modify the mem config of compaction

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -456,7 +456,9 @@ CONF_mInt64(write_buffer_size, "104857600");
 // user should set these configs properly if necessary.
 CONF_Int64(load_process_max_memory_limit_bytes, "107374182400"); // 100GB
 CONF_Int32(load_process_max_memory_limit_percent, "30");         // 30%
-CONF_Int64(compaction_mem_limit, "2147483648");                  // 2G
+CONF_Int64(compaction_max_memory_limit_bytes, "-1");
+CONF_Int32(compaction_max_memory_limit_percent, "100");
+CONF_Int64(compaction_memory_limit_for_per_worker, "2147483648"); // 2GB
 
 // update interval of tablet stat cache
 CONF_mInt32(tablet_stat_cache_update_interval_second, "300");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -458,7 +458,7 @@ CONF_Int64(load_process_max_memory_limit_bytes, "107374182400"); // 100GB
 CONF_Int32(load_process_max_memory_limit_percent, "30");         // 30%
 CONF_Int64(compaction_max_memory_limit_bytes, "-1");
 CONF_Int32(compaction_max_memory_limit_percent, "100");
-CONF_Int64(compaction_memory_limit_for_per_worker, "2147483648"); // 2GB
+CONF_Int64(compaction_memory_limit_per_worker, "2147483648"); // 2GB
 
 // update interval of tablet stat cache
 CONF_mInt32(tablet_stat_cache_update_interval_second, "300");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -456,7 +456,7 @@ CONF_mInt64(write_buffer_size, "104857600");
 // user should set these configs properly if necessary.
 CONF_Int64(load_process_max_memory_limit_bytes, "107374182400"); // 100GB
 CONF_Int32(load_process_max_memory_limit_percent, "30");         // 30%
-CONF_Int64(compaction_max_memory_limit_bytes, "-1");
+CONF_Int64(compaction_max_memory_limit, "-1");
 CONF_Int32(compaction_max_memory_limit_percent, "100");
 CONF_Int64(compaction_memory_limit_per_worker, "2147483648"); // 2GB
 

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -74,6 +74,26 @@ static int64_t calc_process_max_load_memory(int64_t process_mem_limit) {
     return std::min<int64_t>(max_load_memory_bytes, config::load_process_max_memory_limit_bytes);
 }
 
+static int64_t calc_compaction_max_load_memory(int64_t process_mem_limit) {
+    int64_t limit = config::compaction_max_memory_limit_bytes;
+    int64_t percent = config::compaction_max_memory_limit_percent;
+
+    if (config::compaction_memory_limit_for_per_worker < 0) {
+        config::compaction_memory_limit_for_per_worker = 2147483648; // 2G
+    }
+
+    if (process_mem_limit < 0) {
+        return -1;
+    }
+    if (limit < 0) {
+        limit = process_mem_limit;
+    }
+    if (percent < 0) {
+        percent = 100;
+    }
+    return std::min<int64_t>(limit, process_mem_limit * percent / 100);
+}
+
 Status ExecEnv::init(ExecEnv* env, const std::vector<StorePath>& store_paths) {
     return env->_init(store_paths);
 }
@@ -193,7 +213,9 @@ Status ExecEnv::init_mem_tracker() {
     int64_t load_mem_limit = calc_process_max_load_memory(_mem_tracker->limit());
     _load_mem_tracker = new MemTracker(MemTracker::LOAD, load_mem_limit, "load", _mem_tracker);
     _tablet_meta_mem_tracker = new MemTracker(-1, "tablet_meta", _mem_tracker);
-    _compaction_mem_tracker = new MemTracker(-1, "compaction", _mem_tracker);
+
+    int64_t compaction_mem_limit = calc_compaction_max_load_memory(_mem_tracker->limit());
+    _compaction_mem_tracker = new MemTracker(compaction_mem_limit, "compaction", _mem_tracker);
     _schema_change_mem_tracker = new MemTracker(-1, "schema_change", _mem_tracker);
     _column_pool_mem_tracker = new MemTracker(-1, "column_pool", _mem_tracker);
     _page_cache_mem_tracker = new MemTracker(-1, "page_cache", _mem_tracker);

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -75,7 +75,7 @@ static int64_t calc_process_max_load_memory(int64_t process_mem_limit) {
 }
 
 static int64_t calc_compaction_max_load_memory(int64_t process_mem_limit) {
-    int64_t limit = config::compaction_max_memory_limit_bytes;
+    int64_t limit = config::compaction_max_memory_limit;
     int64_t percent = config::compaction_max_memory_limit_percent;
 
     if (config::compaction_memory_limit_per_worker < 0) {

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -78,8 +78,8 @@ static int64_t calc_compaction_max_load_memory(int64_t process_mem_limit) {
     int64_t limit = config::compaction_max_memory_limit_bytes;
     int64_t percent = config::compaction_max_memory_limit_percent;
 
-    if (config::compaction_memory_limit_for_per_worker < 0) {
-        config::compaction_memory_limit_for_per_worker = 2147483648; // 2G
+    if (config::compaction_memory_limit_per_worker < 0) {
+        config::compaction_memory_limit_per_worker = 2147483648; // 2G
     }
 
     if (process_mem_limit < 0) {

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -589,8 +589,7 @@ Status StorageEngine::_perform_cumulative_compaction(DataDir* data_dir) {
 
     StarRocksMetrics::instance()->cumulative_compaction_request_total.increment(1);
 
-    std::unique_ptr<MemTracker> mem_tracker =
-            std::make_unique<MemTracker>(config::compaction_mem_limit, "", _options.compaction_mem_tracker);
+    std::unique_ptr<MemTracker> mem_tracker = std::make_unique<MemTracker>(-1, "", _options.compaction_mem_tracker);
     vectorized::CumulativeCompaction cumulative_compaction(mem_tracker.get(), best_tablet);
 
     Status res = cumulative_compaction.compact();
@@ -630,8 +629,7 @@ Status StorageEngine::_perform_base_compaction(DataDir* data_dir) {
 
     StarRocksMetrics::instance()->base_compaction_request_total.increment(1);
 
-    std::unique_ptr<MemTracker> mem_tracker =
-            std::make_unique<MemTracker>(config::compaction_mem_limit, "", _options.compaction_mem_tracker);
+    std::unique_ptr<MemTracker> mem_tracker = std::make_unique<MemTracker>(-1, "", _options.compaction_mem_tracker);
     vectorized::BaseCompaction base_compaction(mem_tracker.get(), best_tablet);
 
     Status res = base_compaction.compact();

--- a/be/src/storage/vectorized/compaction.cpp
+++ b/be/src/storage/vectorized/compaction.cpp
@@ -68,7 +68,7 @@ Status Compaction::do_compaction_impl() {
 
     // 2. write combined rows to output rowset
     Statistics stats;
-    auto res = merge_rowsets(config::compaction_memory_limit_for_per_worker, &stats);
+    auto res = merge_rowsets(config::compaction_memory_limit_per_worker, &stats);
 
     if (!res.ok()) {
         LOG(WARNING) << "fail to do " << compaction_name() << ". res=" << res.to_string()

--- a/be/src/storage/vectorized/compaction.cpp
+++ b/be/src/storage/vectorized/compaction.cpp
@@ -68,7 +68,7 @@ Status Compaction::do_compaction_impl() {
 
     // 2. write combined rows to output rowset
     Statistics stats;
-    auto res = merge_rowsets(_mem_tracker->limit(), &stats);
+    auto res = merge_rowsets(config::compaction_memory_limit_for_per_worker, &stats);
 
     if (!res.ok()) {
         LOG(WARNING) << "fail to do " << compaction_name() << ". res=" << res.to_string()


### PR DESCRIPTION
for #1411 

Compaction memory does not have a total limit. Current,  config::compaction_mem_limit is only the memory limit of a single Compaction task, but it is used as a total limit, which will cause the Compaction execution to fail.

Currently does not support dynamically adjusting the number of threads based on memory usage, so percernt is temporarily set to -1