### PR TITLE
Fix the disk usage statistics result after the disk of aliyun ecs is expanded

### DIFF
--- a/be/src/storage/data_dir.cpp
+++ b/be/src/storage/data_dir.cpp
@@ -714,10 +714,7 @@ Status DataDir::update_capacity() {
     try {
         std::filesystem::space_info path_info = std::filesystem::space(_path);
         _available_bytes = path_info.available;
-        if (_disk_capacity_bytes == 0) {
-            // disk capacity only need to be set once
-            _disk_capacity_bytes = path_info.capacity;
-        }
+        _disk_capacity_bytes = path_info.capacity;
     } catch (std::filesystem::filesystem_error& e) {
         RETURN_IF_ERROR_WITH_WARN(Status::IOError(strings::Substitute("get path $0 available capacity failed, error=$1",
                                                                       _path, e.what())),


### PR DESCRIPTION
ref: [(#1424)](https://github.com/StarRocks/starrocks/issues/1424)
After using the online dynamic expansion function of Alibaba Cloud Disk, the backend disk total capacity information needs to be updated