### PR TITLE
[pipeline] fix: only evaluate other_conjuncts in probe phase

### DIFF
--- a/be/src/exec/vectorized/hash_joiner.cpp
+++ b/be/src/exec/vectorized/hash_joiner.cpp
@@ -151,41 +151,43 @@ bool HashJoiner::need_input() const {
 bool HashJoiner::has_output() const {
     if (_phase == HashJoinPhase::BUILD) {
         return false;
-    } else if (_phase == HashJoinPhase::PROBE) {
+    }
+
+    if (_phase == HashJoinPhase::PROBE) {
         return _probe_input_chunk != nullptr;
-    } else if (_phase == HashJoinPhase::POST_PROBE) {
+    }
+
+    if (_phase == HashJoinPhase::POST_PROBE) {
         // Only RIGHT ANTI-JOIN, RIGHT OUTER-JOIN, FULL OUTER-JOIN has HashJoinPhase::POST_PROBE,
         // in this phase, has_output() returns true until HashJoiner enters into HashJoinPhase::DONE.
         return true;
-    } else {
-        return _buffered_probe_output_chunk != nullptr;
     }
+
+    return false;
 }
 
 void HashJoiner::push_chunk(RuntimeState* state, ChunkPtr&& chunk) {
     DCHECK(chunk && !chunk->is_empty());
     DCHECK(!_probe_input_chunk);
-    _merge_probe_input_chunk(state, std::move(chunk));
-    if (_probe_input_chunk) {
-        _ht_has_remain = true;
-        _prepare_probe_key_columns();
-    }
+
+    _probe_input_chunk = std::move(chunk);
+    _ht_has_remain = true;
+    _prepare_probe_key_columns();
 }
 
 StatusOr<ChunkPtr> HashJoiner::pull_chunk(RuntimeState* state) {
     DCHECK(_phase != HashJoinPhase::BUILD);
+
     auto&& maybe_chunk = _pull_probe_output_chunk(state);
     if (UNLIKELY(!maybe_chunk.ok())) {
         return std::move(maybe_chunk);
     }
+
     ChunkPtr chunk = std::move(maybe_chunk.value());
     if (!chunk || chunk->is_empty()) {
         return std::move(chunk);
     }
-    _filter_probe_output_chunk(chunk);
-    if (!chunk || chunk->is_empty()) {
-        return std::move(chunk);
-    }
+
     auto num_rows = chunk->num_rows();
     _num_rows_returned += num_rows;
     if (_reached_limit()) {
@@ -194,60 +196,47 @@ StatusOr<ChunkPtr> HashJoiner::pull_chunk(RuntimeState* state) {
         _phase = HashJoinPhase::EOS;
         // _ht is useless in this point, so deallocate its memory.
         _ht.close();
-        _buffered_probe_output_chunk = nullptr;
     }
     return std::move(chunk);
 }
 
 StatusOr<ChunkPtr> HashJoiner::_pull_probe_output_chunk(RuntimeState* state) {
     DCHECK(_phase != HashJoinPhase::BUILD);
+
     auto chunk = std::make_shared<Chunk>();
-    if (_phase == HashJoinPhase::PROBE) {
+
+    if (_phase == HashJoinPhase::PROBE || _probe_input_chunk != nullptr) {
         DCHECK(_ht_has_remain && _probe_input_chunk);
+
         RETURN_IF_ERROR(_ht.probe(_key_columns, &_probe_input_chunk, &chunk, &_ht_has_remain));
         if (!_ht_has_remain) {
             _probe_input_chunk = nullptr;
         }
-        _merge_probe_output_chunk(state, std::move(chunk));
-        if (_probe_output_chunk) {
-            return std::move(_probe_output_chunk);
-        }
+
+        _filter_probe_output_chunk(chunk);
+
+        return chunk;
     }
 
     if (_phase == HashJoinPhase::POST_PROBE) {
-        // check if _buffered_probe_chunk have rows, if so, then move it into _probe_chunk.
-        if (_buffered_probe_input_chunk && !_probe_input_chunk) {
-            _probe_input_chunk = std::move(_buffered_probe_input_chunk);
-            _ht_has_remain = true;
-            _prepare_probe_key_columns();
+        if (!_need_post_probe()) {
+            _phase = HashJoinPhase::EOS;
+            _ht.close();
+            return Status::OK();
         }
-        // _probe_chunk has remain rows to be processed, so go on probing ht.
-        if (_probe_input_chunk) {
-            RETURN_IF_ERROR(_ht.probe(_key_columns, &_probe_input_chunk, &chunk, &_ht_has_remain));
-            if (!_ht_has_remain) {
-                _probe_input_chunk = nullptr;
-            }
-            _merge_probe_output_chunk(state, std::move(chunk));
-            if (_probe_output_chunk) {
-                return std::move(_probe_output_chunk);
-            }
+
+        RETURN_IF_ERROR(_ht.probe_remain(&chunk, &_ht_has_remain));
+        if (!_ht_has_remain) {
+            _phase = HashJoinPhase::EOS;
+            _ht.close();
         }
-        // cached _buffered_probe_chunk and _probe_chunk have been exhausted, so now entries of ht should be processed
-        // for RIGHT ANTI-JOIN, RIGHT SEMI-JOIN, FULL OUTER-JOIN.
-        if (!_buffered_probe_input_chunk && !_probe_input_chunk) {
-            RETURN_IF_ERROR(_post_probe(state));
-            if (_probe_output_chunk) {
-                return std::move(_probe_output_chunk);
-            }
-        }
+
+        _filter_post_probe_output_chunk(chunk);
+
+        return chunk;
     }
 
-    // process last less-than-half-sized _buffered_joined_chunk if it exists.
-    if (_phase == HashJoinPhase::EOS && _buffered_probe_output_chunk) {
-        DCHECK(!_probe_output_chunk);
-        return std::move(_buffered_probe_output_chunk);
-    }
-    return std::make_shared<Chunk>();
+    return chunk;
 }
 
 Status HashJoiner::close(RuntimeState* state) {

--- a/be/src/exec/vectorized/hash_joiner.cpp
+++ b/be/src/exec/vectorized/hash_joiner.cpp
@@ -222,7 +222,7 @@ StatusOr<ChunkPtr> HashJoiner::_pull_probe_output_chunk(RuntimeState* state) {
         if (!_need_post_probe()) {
             _phase = HashJoinPhase::EOS;
             _ht.close();
-            return Status::OK();
+            return chunk;
         }
 
         RETURN_IF_ERROR(_ht.probe_remain(&chunk, &_ht_has_remain));

--- a/be/src/exec/vectorized/hash_joiner.h
+++ b/be/src/exec/vectorized/hash_joiner.h
@@ -150,8 +150,8 @@ private:
         }
     }
     void _filter_post_probe_output_chunk(ChunkPtr& chunk) {
-        // Post probe needn't process _other_join_conjunct_ctxs,
-        // because it is ON predicates, which is processed on probe phase.
+        // Post probe needn't process _other_join_conjunct_ctxs, because they
+        // are `ON` predicates, which need to be processed only on probe phase.
         if (chunk && !chunk->is_empty()) {
             ExecNode::eval_conjuncts(_conjunct_ctxs, chunk.get());
         }

--- a/be/src/exec/vectorized/hash_joiner.h
+++ b/be/src/exec/vectorized/hash_joiner.h
@@ -73,54 +73,9 @@ public:
 private:
     static bool _has_null(const ColumnPtr& column);
 
-    StatusOr<ChunkPtr> _pull_probe_output_chunk(RuntimeState* state);
-
     void _init_hash_table_param(HashTableParam* param);
 
     bool _reached_limit() { return _limit != -1 && _num_rows_returned >= _limit; }
-    static void merge_chunk(RuntimeState* state, ChunkPtr& buffered_chunk, ChunkPtr& result_chunk, ChunkPtr&& chunk) {
-        const size_t half_vector_chunk_size = config::vector_chunk_size >> 1;
-        if (!chunk || chunk->is_empty()) {
-            return;
-        }
-        // try to pile chunk with buffered_chunk to form a large enough chunk.
-        if (!buffered_chunk) {
-            buffered_chunk = std::move(chunk);
-        } else if (buffered_chunk->num_rows() + chunk->num_rows() <= config::vector_chunk_size) {
-            Columns& dst_columns = buffered_chunk->columns();
-            Columns& src_columns = chunk->columns();
-            size_t num_rows = chunk->num_rows();
-            // copy the new read chunk to the reserved
-            for (size_t i = 0; i < dst_columns.size(); i++) {
-                dst_columns[i]->append(*src_columns[i], 0, num_rows);
-            }
-        } else if (chunk->num_rows() >= half_vector_chunk_size) {
-            result_chunk = std::move(chunk);
-        } else {
-            result_chunk = std::move(buffered_chunk);
-            buffered_chunk = std::move(chunk);
-        }
-        // _buffered_chunk is piled up to exceed half of vector_chunk_size, it's bigger enough so that it can be moved
-        // into result_chunk.
-        if (buffered_chunk && !result_chunk && buffered_chunk->num_rows() >= half_vector_chunk_size) {
-            result_chunk = std::move(buffered_chunk);
-        }
-    }
-
-    void _merge_probe_input_chunk(RuntimeState* state, ChunkPtr&& chunk) {
-        merge_chunk(state, _buffered_probe_input_chunk, _probe_input_chunk, std::move(chunk));
-    }
-
-    void _merge_probe_output_chunk(RuntimeState* state, ChunkPtr&& chunk) {
-        merge_chunk(state, _buffered_probe_output_chunk, _probe_output_chunk, std::move(chunk));
-    }
-
-    void _filter_probe_output_chunk(ChunkPtr& chunk) {
-        _process_other_conjunct(&chunk);
-        if (chunk && !chunk->is_empty()) {
-            ExecNode::eval_conjuncts(_conjunct_ctxs, chunk.get());
-        }
-    }
 
     void _prepare_key_columns(Columns& key_columns, const ChunkPtr& chunk, const vector<ExprContext*>& expr_ctxs) {
         key_columns.resize(0);
@@ -151,30 +106,6 @@ private:
                _join_type == TJoinOp::FULL_OUTER_JOIN;
     }
 
-    Status _post_probe(RuntimeState* state) {
-        DCHECK(_phase == HashJoinPhase::POST_PROBE);
-        if (!_need_post_probe()) {
-            _phase = HashJoinPhase::EOS;
-            _ht.close();
-            return Status::OK();
-        }
-        DCHECK(!_probe_output_chunk);
-        while (true) {
-            bool has_remain = true;
-            auto chunk = std::make_shared<Chunk>();
-            RETURN_IF_ERROR(_ht.probe_remain(&chunk, &has_remain));
-            _merge_probe_output_chunk(state, std::move(chunk));
-            if (!has_remain) {
-                _phase = HashJoinPhase::EOS;
-                _ht.close();
-                return Status::OK();
-            }
-            if (_probe_output_chunk) {
-                return Status::OK();
-            }
-        }
-    }
-
     void _short_circuit_break() {
         // special cases of short-circuit break.
         if (_ht.get_row_count() == 0 && (_join_type == TJoinOp::INNER_JOIN || _join_type == TJoinOp::LEFT_SEMI_JOIN)) {
@@ -198,6 +129,8 @@ private:
     Status _build(RuntimeState* state);
     Status _probe(RuntimeState* state, ScopedTimer<MonotonicStopWatch>& probe_timer, ChunkPtr* chunk, bool& eos);
 
+    StatusOr<ChunkPtr> _pull_probe_output_chunk(RuntimeState* state);
+
     void _calc_filter_for_other_conjunct(ChunkPtr* chunk, Column::Filter& filter, bool& filter_all, bool& hit_all);
     static void _process_row_for_other_conjunct(ChunkPtr* chunk, size_t start_column, size_t column_count,
                                                 bool filter_all, bool hit_all, const Column::Filter& filter);
@@ -206,6 +139,23 @@ private:
     void _process_other_conjunct_and_remove_duplicate_index(ChunkPtr* chunk);
     void _process_right_anti_join_with_other_conjunct(ChunkPtr* chunk);
     void _process_other_conjunct(ChunkPtr* chunk);
+
+    void _filter_probe_output_chunk(ChunkPtr& chunk) {
+        if (chunk && !chunk->is_empty()) {
+            _process_other_conjunct(&chunk);
+        }
+
+        if (chunk && !chunk->is_empty()) {
+            ExecNode::eval_conjuncts(_conjunct_ctxs, chunk.get());
+        }
+    }
+    void _filter_post_probe_output_chunk(ChunkPtr& chunk) {
+        // Post probe needn't process _other_join_conjunct_ctxs,
+        // because it is ON predicates, which is processed on probe phase.
+        if (chunk && !chunk->is_empty()) {
+            ExecNode::eval_conjuncts(_conjunct_ctxs, chunk.get());
+        }
+    }
 
     static std::string _get_join_type_str(TJoinOp::type join_type);
 
@@ -216,16 +166,16 @@ private:
     std::shared_ptr<RuntimeProfile> _runtime_profile;
     bool _is_closed = false;
 
-    ChunkPtr _buffered_probe_input_chunk;
     ChunkPtr _probe_input_chunk;
 
-    ChunkPtr _buffered_probe_output_chunk;
-    ChunkPtr _probe_output_chunk;
-
     const std::vector<bool>& _is_null_safes;
+    // Equal conjuncts in Join On.
     const std::vector<ExprContext*>& _build_expr_ctxs;
+    // Equal conjuncts in Join On.
     const std::vector<ExprContext*>& _probe_expr_ctxs;
+    // Conjuncts in Join On except equal conjuncts.
     const std::vector<ExprContext*>& _other_join_conjunct_ctxs;
+    // Conjuncts in Join followed by a filter predicate, usually in Where and Having.
     const std::vector<ExprContext*>& _conjunct_ctxs;
     const RowDescriptor& _build_row_descriptor;
     const RowDescriptor& _probe_row_descriptor;


### PR DESCRIPTION
### Introduction
Only Evaluate `other_conjuncts` in the probe phase.

### Detail
As for conjuncts, there are three kinds of conjuncts:
1. Equal conjuncts in Join On, which is stored in `_build_expr_ctxs` and `_probe_expr_ctxs`.
2.  Conjuncts in Join On except equal conjuncts, which is stored in `_other_join_conjunct_ctxs`.
3. Conjuncts in Join followed by a filter predicate, usually in Where and Having, which is stored in `_conjunct_ctxs`.

`RIGHT ANTI JOIN`'s probe has two phase:
1. probe
Use the left table to hit the hash table built by the right table.
2. post_probe
Output rows which are not hit by the left table. 
This phase needn't process _other_join_conjunct_ctxs, because they  are `ON` predicates, which need to be processed only on probe phase.

In the `probe` phase, we cannot output chunk, so chunk is force clear after evaluating `other_conjuncts`.
```C++
void HashJoiner::_process_right_anti_join_with_other_conjunct(ChunkPtr* chunk) {
    _process_other_conjunct_and_remove_duplicate_index(chunk);
    (*chunk)->set_num_rows(0);
}
```

However, in pipeline, `other_conjuncts` is also evaluated wrongly at the `post_probe` phase, which causes RIGHT ANTI JOIN always returns empty.

### Changes
1. Remove `merge` in hash join operator.
TODO: add a merge operator before and after hash join operators.
2. Only evaluate `other_conjuncts` in  the probe phase

Fix #1436 
