### PR TITLE
[pipeline] use _plan_node_id instead of _id in profile title

### DIFF
--- a/be/src/exec/pipeline/operator.cpp
+++ b/be/src/exec/pipeline/operator.cpp
@@ -13,7 +13,7 @@ Operator::Operator(int32_t id, const std::string& name, int32_t plan_node_id)
         : _id(id), _name(name), _plan_node_id(plan_node_id) {
     std::string upper_name(_name);
     std::transform(upper_name.begin(), upper_name.end(), upper_name.begin(), ::toupper);
-    _runtime_profile = std::make_shared<RuntimeProfile>(strings::Substitute("$0 (id=$1)", upper_name, _id));
+    _runtime_profile = std::make_shared<RuntimeProfile>(strings::Substitute("$0 (id=$1)", upper_name, _plan_node_id));
     _runtime_profile->set_metadata(_id);
     _mem_tracker = std::make_unique<MemTracker>(_runtime_profile.get(), -1, _runtime_profile->name(), nullptr);
 }


### PR DESCRIPTION
`_id` is an internal concept for a fragment instance, while `_plan_node_id` can predicates the relation between Exchange Source and Exchange Sink.
Therefore, we should use `_plan_node_id` instead of `_id` in profile title. 