### PR TITLE
reduce reserve bytes for buffer input stream

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -646,6 +646,10 @@ CONF_Int64(pipeline_io_buffer_size, "64");
 CONF_Int16(bitmap_serialize_version, "1");
 // schema change vectorized
 CONF_Bool(enable_schema_change_vectorized, "true");
+// buffer stream reserve size
+// each column will reserve buffer_stream_reserve_size bytes for read
+// default: 8k
+CONF_mInt32(buffer_stream_reserve_size, "8192");
 
 } // namespace config
 

--- a/be/src/util/buffered_stream.cpp
+++ b/be/src/util/buffered_stream.cpp
@@ -2,6 +2,7 @@
 
 #include "util/buffered_stream.h"
 
+#include "common/config.h"
 #include "env/env.h"
 #include "util/bit_util.h"
 
@@ -9,7 +10,7 @@ namespace starrocks {
 
 BufferedInputStream::BufferedInputStream(RandomAccessFile* file, uint64_t offset, uint64_t length)
         : _file(file), _offset(offset), _end_offset(offset + length) {
-    _reserve(8 * 1024 * 1024);
+    _reserve(config::buffer_stream_reserve_size);
 }
 
 Status BufferedInputStream::get_bytes(const uint8_t** buffer, size_t* nbytes, bool peek) {


### PR DESCRIPTION
8M for each column will consume too much memory in flat table 