### PR TITLE
Fix the mem statistics bug of page cache

### DIFF
--- a/be/src/runtime/CMakeLists.txt
+++ b/be/src/runtime/CMakeLists.txt
@@ -92,6 +92,7 @@ set(RUNTIME_FILES
     hdfs/hdfs_fs_cache.cpp
     runtime_filter_worker.cpp
     global_dicts.cpp
+    current_thread.cpp
 )
 
 set(RUNTIME_FILES ${RUNTIME_FILES}

--- a/be/src/runtime/current_thread.cpp
+++ b/be/src/runtime/current_thread.cpp
@@ -1,0 +1,17 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#include "runtime/current_thread.h"
+
+#include "storage/storage_engine.h"
+
+namespace starrocks {
+
+CurrentThread::~CurrentThread() {
+    StorageEngine* storage_engine = ExecEnv::GetInstance()->storage_engine();
+    if (UNLIKELY(storage_engine != nullptr && storage_engine->bg_worker_stopped())) {
+        return;
+    }
+    commit();
+}
+
+} // namespace starrocks

--- a/be/src/runtime/current_thread.h
+++ b/be/src/runtime/current_thread.h
@@ -7,7 +7,6 @@
 #include "gen_cpp/Types_types.h"
 #include "runtime/exec_env.h"
 #include "runtime/mem_tracker.h"
-#include "storage/storage_engine.h"
 #include "util/uid_util.h"
 
 namespace starrocks {
@@ -17,13 +16,9 @@ class TUniqueId;
 class CurrentThread {
 public:
     CurrentThread() = default;
-    ~CurrentThread() { commit(); }
+    ~CurrentThread();
 
     void commit() {
-        StorageEngine* storage_engine = ExecEnv::GetInstance()->storage_engine();
-        if (storage_engine != nullptr && storage_engine->bg_worker_stopped()) {
-            return;
-        }
         MemTracker* cur_tracker = mem_tracker();
         if (_cache_size != 0 && cur_tracker != nullptr) {
             cur_tracker->consume(_cache_size);

--- a/be/src/storage/page_cache.h
+++ b/be/src/storage/page_cache.h
@@ -26,7 +26,9 @@
 #include <utility>
 
 #include "gutil/macros.h" // for DISALLOW_COPY_AND_ASSIGN
+#include "runtime/current_thread.h"
 #include "storage/lru_cache.h"
+#include "util/defer_op.h"
 
 namespace starrocks {
 
@@ -103,7 +105,12 @@ public:
     PageCacheHandle(Cache* cache, Cache::Handle* handle) : _cache(cache), _handle(handle) {}
     ~PageCacheHandle() {
         if (_handle != nullptr) {
+#ifndef BE_TEST
+            MemTracker* prev_tracker =
+                    tls_thread_status.set_mem_tracker(ExecEnv::GetInstance()->page_cache_mem_tracker());
+            DeferOp op([&] { tls_thread_status.set_mem_tracker(prev_tracker); });
             _cache->release(_handle);
+#endif
         }
     }
 

--- a/be/src/storage/page_cache.h
+++ b/be/src/storage/page_cache.h
@@ -109,8 +109,8 @@ public:
             MemTracker* prev_tracker =
                     tls_thread_status.set_mem_tracker(ExecEnv::GetInstance()->page_cache_mem_tracker());
             DeferOp op([&] { tls_thread_status.set_mem_tracker(prev_tracker); });
-            _cache->release(_handle);
 #endif
+            _cache->release(_handle);
         }
     }
 


### PR DESCRIPTION
for #703 

When the Cache memory reaches the upper limit, some items will be eliminated, so the memory release is not necessarily triggered by insert, but may also be in the user's execution thread