### PR TITLE
The fe process should not exit when the non-master node writes editLog

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBJEJournal.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBJEJournal.java
@@ -29,6 +29,7 @@ import com.sleepycat.je.OperationStatus;
 import com.sleepycat.je.rep.InsufficientLogException;
 import com.sleepycat.je.rep.NetworkRestore;
 import com.sleepycat.je.rep.NetworkRestoreConfig;
+import com.sleepycat.je.rep.ReplicaWriteException;
 import com.starrocks.catalog.Catalog;
 import com.starrocks.common.Pair;
 import com.starrocks.common.io.DataOutputBuffer;
@@ -159,6 +160,9 @@ public class BDBJEJournal implements Journal {
                             id, currentJournalDB.getDb().getDatabaseName(), System.currentTimeMillis());
                     break;
                 }
+            } catch (ReplicaWriteException e) {
+                LOG.error("non-master nodes should not write editLog", e);
+                throw e;
             } catch (DatabaseException e) {
                 LOG.error("catch an exception when writing to database. sleep and retry. journal id {}", id, e);
                 try {

--- a/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBJEJournal.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBJEJournal.java
@@ -161,7 +161,7 @@ public class BDBJEJournal implements Journal {
                     break;
                 }
             } catch (ReplicaWriteException e) {
-                LOG.error("non-master nodes should not write editLog", e);
+                LOG.error("non-master nodes should not write editLog. journal id {}", id, e);
                 throw e;
             } catch (DatabaseException e) {
                 LOG.error("catch an exception when writing to database. sleep and retry. journal id {}", id, e);

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -21,6 +21,7 @@
 
 package com.starrocks.persist;
 
+import com.sleepycat.je.rep.ReplicaWriteException;
 import com.starrocks.alter.AlterJobV2;
 import com.starrocks.alter.BatchAlterJobPersistInfo;
 import com.starrocks.alter.DecommissionBackendJob;
@@ -852,6 +853,8 @@ public class EditLog {
 
         try {
             journal.write(op, writable);
+        } catch (ReplicaWriteException e) {
+            throw e;
         } catch (Exception e) {
             LOG.error("Fatal Error : write stream Exception", e);
             System.exit(-1);


### PR DESCRIPTION
ref: https://github.com/StarRocks/starrocks/issues/1466
When adding new functions to fe, if you do not have a good understanding of metadata related operations, it is easy to write some edit logs on non-master nodes, which will cause the fe process to exit.