### PR TITLE
Desc table_name interface adapt to hive external table (#1197)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/DescribeStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/DescribeStmt.java
@@ -166,6 +166,11 @@ public class DescribeStmt extends ShowStmt {
                 ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_TABLE_ERROR, dbTableName.getTbl());
             }
 
+            if (table.getType() == TableType.HIVE) {
+                // Reuse the logic of `desc <table_name>` because hive external table doesn't support view.
+                isAllTables = false;
+            }
+
             if (!isAllTables) {
                 // show base table schema only
                 String procString = "/dbs/" + db.getId() + "/" + table.getId() + "/" + TableProcDir.INDEX_SCHEMA


### PR DESCRIPTION
before:
```
mysql> desc external_hive_tbl all;
ERROR 1064 (HY000): Unknown storage engine 'HIVE'
```

after:
```
mysql> desc external_hive_tbl;
+-------+------------+------+------+---------+-------+
| Field | Type       | Null | Key  | Default | Extra |
+-------+------------+------+------+---------+-------+
| id    | BIGINT     | Yes  | true | NULL    |       |
| name  | VARCHAR(1) | Yes  | true | NULL    |       |
| city  | VARCHAR(1) | Yes  | true | NULL    |       |
+-------+------------+------+------+---------+-------+
3 rows in set (0.01 sec)
```

cc @gengjun-git