### PR TITLE
[pipeline] fix: set filter back to result chunk for SEMI JOIN

### DIFF
--- a/be/src/exec/vectorized/hash_joiner.cpp
+++ b/be/src/exec/vectorized/hash_joiner.cpp
@@ -354,7 +354,7 @@ void HashJoiner::_process_outer_join_with_other_conjunct(ChunkPtr* chunk, size_t
     (*chunk)->filter(filter);
 }
 
-void HashJoiner::_process_other_conjunct_and_remove_duplicate_index(ChunkPtr* chunk) {
+void HashJoiner::_process_semi_join_with_other_conjunct(ChunkPtr* chunk) {
     bool filter_all = false;
     bool hit_all = false;
     Column::Filter filter;
@@ -362,10 +362,17 @@ void HashJoiner::_process_other_conjunct_and_remove_duplicate_index(ChunkPtr* ch
     _calc_filter_for_other_conjunct(chunk, filter, filter_all, hit_all);
 
     _ht.remove_duplicate_index(&filter);
+    (*chunk)->filter(filter);
 }
 
 void HashJoiner::_process_right_anti_join_with_other_conjunct(ChunkPtr* chunk) {
-    _process_other_conjunct_and_remove_duplicate_index(chunk);
+    bool filter_all = false;
+    bool hit_all = false;
+    Column::Filter filter;
+
+    _calc_filter_for_other_conjunct(chunk, filter, filter_all, hit_all);
+
+    _ht.remove_duplicate_index(&filter);
     (*chunk)->set_num_rows(0);
 }
 
@@ -380,7 +387,7 @@ void HashJoiner::_process_other_conjunct(ChunkPtr* chunk) {
     case TJoinOp::LEFT_ANTI_JOIN:
     case TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN:
     case TJoinOp::RIGHT_SEMI_JOIN:
-        _process_other_conjunct_and_remove_duplicate_index(chunk);
+        _process_semi_join_with_other_conjunct(chunk);
         break;
     case TJoinOp::RIGHT_ANTI_JOIN:
         _process_right_anti_join_with_other_conjunct(chunk);

--- a/be/src/exec/vectorized/hash_joiner.h
+++ b/be/src/exec/vectorized/hash_joiner.h
@@ -141,18 +141,18 @@ private:
     void _process_other_conjunct(ChunkPtr* chunk);
 
     void _filter_probe_output_chunk(ChunkPtr& chunk) {
-        if (chunk && !chunk->is_empty()) {
+        if (chunk && !chunk->is_empty() && !_other_join_conjunct_ctxs.empty()) {
             _process_other_conjunct(&chunk);
         }
 
-        if (chunk && !chunk->is_empty()) {
+        if (chunk && !chunk->is_empty() && !_conjunct_ctxs.empty()) {
             ExecNode::eval_conjuncts(_conjunct_ctxs, chunk.get());
         }
     }
     void _filter_post_probe_output_chunk(ChunkPtr& chunk) {
         // Post probe needn't process _other_join_conjunct_ctxs, because they
         // are `ON` predicates, which need to be processed only on probe phase.
-        if (chunk && !chunk->is_empty()) {
+        if (chunk && !chunk->is_empty() && !_conjunct_ctxs.empty()) {
             ExecNode::eval_conjuncts(_conjunct_ctxs, chunk.get());
         }
     }

--- a/be/src/exec/vectorized/hash_joiner.h
+++ b/be/src/exec/vectorized/hash_joiner.h
@@ -141,6 +141,10 @@ private:
     void _process_other_conjunct(ChunkPtr* chunk);
 
     void _filter_probe_output_chunk(ChunkPtr& chunk) {
+        // Probe in JoinHashMap is divided into probe with other_conjuncts and without other_conjuncts.
+        // Probe without other_conjuncts directly labels the hash table as hit, while _process_other_conjunct()
+        // only remains the rows which are not hit the hash table before. Therefore, _process_other_conjunct can
+        // not be called when other_conjuncts is empty.
         if (chunk && !chunk->is_empty() && !_other_join_conjunct_ctxs.empty()) {
             _process_other_conjunct(&chunk);
         }

--- a/be/src/exec/vectorized/hash_joiner.h
+++ b/be/src/exec/vectorized/hash_joiner.h
@@ -136,7 +136,7 @@ private:
                                                 bool filter_all, bool hit_all, const Column::Filter& filter);
 
     void _process_outer_join_with_other_conjunct(ChunkPtr* chunk, size_t start_column, size_t column_count);
-    void _process_other_conjunct_and_remove_duplicate_index(ChunkPtr* chunk);
+    void _process_semi_join_with_other_conjunct(ChunkPtr* chunk);
     void _process_right_anti_join_with_other_conjunct(ChunkPtr* chunk);
     void _process_other_conjunct(ChunkPtr* chunk);
 


### PR DESCRIPTION
### Introduction

`_process_semi_join_with_other_conjunct()`, which is used by `RIGHT_SEMI_JOIN`, `RIGHT_OUTER_JOIN`, and etc., doesn't set filter result, which is evaluated by `other_conjuncts`, **back to the result chunk**.

What's more, `_process_semi_join_with_other_conjunct()` can only be used when `other_conjuncts` is empty.
The reason is that `JoinHashMap::probe` for RIGHT SEMI JOIN is divided into two cases:
 - probe with `other_conjuncts`
    In this case, *probe* phase returns rows. *Evaluate other conjuncts* phase labels keys in Hash Table as hitted after evaluating each row by `other_conjuncts`, and only outputs result rows whose key is **not hitted before**.
 - probe without `other_conjuncts`.
    In this case, we needn't evaluate `other_conjuncts`, so *probe* phase returns result rows and **directly labels** Hash Table. However, if we still call `_process_semi_join_with_other_conjunct()`, it will try to find the key **not hitted before**, which is impossible in this case.

```C++
void JoinHashTable::_remove_duplicate_index_for_right_semi_join(Column::Filter* filter) {
    size_t row_count = filter->size();
    for (size_t i = 0; i < row_count; i++) {
        if ((*filter)[i] == 1) {
            // Only remain rows whose key **not hitted before**.
            if (_probe_state.build_match_index[_probe_state.build_index[i]] == 0) {
                _probe_state.build_match_index[_probe_state.build_index[i]] = 1;
            } else {
                (*filter)[i] = 0;
            }
        }
    }
}

template <PrimitiveType PT, class BuildFunc, class ProbeFunc>
template <bool first_probe>
void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_right_semi_join(
        const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data) {
    // ...
                    // Directly labels Hash Table at probe.
                    _probe_state->build_match_index[build_index] = 1;
    // ...
}
```


Fix #1488 

### Changes
- `_process_right_anti_join_with_other_conjunct()` doesn't use `_process_other_conjunct_and_remove_duplicate_index()` any more, and copies codes from `_process_other_conjunct_and_remove_duplicate_index()` to itself.
- Rename `_process_other_conjunct_and_remove_duplicate_index()` to `_process_semi_join_with_other_conjunct()`.
-  Set filter back to the result chunk in `_process_semi_join_with_other_conjunct()`.
- Only calling `_process_semi_join_with_other_conjunct()` when `other_conjuncts` is empty.
   
