### PR TITLE
Pipeline sinkbuffer pool

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -634,12 +634,16 @@ CONF_Int64(pipeline_yield_max_chunks_moved, "100");
 // yield PipelineDriver when maximum time in nano-seconds has spent
 // in current execution round.
 CONF_Int64(pipeline_yield_max_time_spent, "100000000");
-// the number of io threads pipeline engine.
-CONF_Int64(pipeline_io_thread_pool_thread_num, "3");
-// queue size of io thread pool for pipeline engine.
-CONF_Int64(pipeline_io_thread_pool_queue_size, "102400");
+// the number of scan threads pipeline engine.
+CONF_Int64(pipeline_scan_thread_pool_thread_num, "0");
+// queue size of scan thread pool for pipeline engine.
+CONF_Int64(pipeline_scan_thread_pool_queue_size, "102400");
+// the number of exchange threads pipeline engine.
+CONF_Int64(pipeline_exchange_thread_pool_thread_num, "0");
+// queue size of exchange thread pool for pipeline engine.
+CONF_Int64(pipeline_exchange_thread_pool_queue_size, "102400");
 // the number of execution threads for pipeline engine.
-CONF_Int64(pipeline_exec_thread_pool_thread_num, "3");
+CONF_Int64(pipeline_exec_thread_pool_thread_num, "0");
 // the buffer size of io task
 CONF_Int64(pipeline_io_buffer_size, "64");
 // bitmap serialize version

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -111,13 +111,14 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths) {
     _thread_mgr = new ThreadResourceMgr();
     _thread_pool = new PriorityThreadPool(config::doris_scanner_thread_pool_thread_num,
                                           config::doris_scanner_thread_pool_queue_size);
-    LOG(INFO) << strings::Substitute("[PIPELINE] IO thread pool: thread_num=$0, queue_size=$1",
-                                     config::pipeline_io_thread_pool_thread_num,
-                                     config::pipeline_io_thread_pool_queue_size);
-    _pipeline_scan_io_thread_pool = new PriorityThreadPool(config::pipeline_io_thread_pool_thread_num,
-                                                           config::pipeline_io_thread_pool_queue_size);
-    _pipeline_exchange_sink_thread_pool = new PriorityThreadPool(config::pipeline_io_thread_pool_thread_num,
-                                                                 config::pipeline_io_thread_pool_queue_size);
+    _pipeline_scan_io_thread_pool = new PriorityThreadPool(config::pipeline_scan_thread_pool_thread_num <= 0
+                                                                   ? std::thread::hardware_concurrency()
+                                                                   : config::pipeline_scan_thread_pool_thread_num,
+                                                           config::pipeline_scan_thread_pool_queue_size);
+    _pipeline_exchange_sink_thread_pool = new PriorityThreadPool(
+            config::pipeline_exchange_thread_pool_thread_num <= 0 ? std::thread::hardware_concurrency()
+                                                                  : config::pipeline_exchange_thread_pool_thread_num,
+            config::pipeline_exchange_thread_pool_queue_size);
     _num_scan_operators = 0;
     _etl_thread_pool = new PriorityThreadPool(config::etl_thread_pool_size, config::etl_thread_pool_queue_size);
     _fragment_mgr = new FragmentMgr(this);


### PR DESCRIPTION
Rename following configs
1. pipeline_io_thread_pool_thread_num -> pipeline_scan_thread_pool_thread_num （ <=0 means using core num as max thread num)
2. pipeline_io_thread_pool_queue_size -> pipeline_scan_thread_pool_queue_size

Add following configs
1. pipeline_exchange_thread_pool_thread_num（ <=0 means using core num as max thread num)
2. pipeline_exchange_thread_pool_queue_size