### PR TITLE
Fix read exception for external hive table without resource name

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
@@ -305,7 +305,7 @@ public class HiveTable extends Table {
     private void validate(Map<String, String> properties) throws DdlException {
         if (properties == null) {
             throw new DdlException("Please set properties of hive table, "
-                    + "they are: database, table and 'hive.metastore.uris'");
+                    + "they are: database, table and resource");
         }
 
         Map<String, String> copiedProps = Maps.newHashMap(properties);
@@ -322,7 +322,7 @@ public class HiveTable extends Table {
         copiedProps.remove(HIVE_TABLE);
 
         // check hive properties
-        // hive.metastore.uris or hive.resource must be set
+        // hive.resource must be set and hive.metastore.uris will be ignored if specified.
         String hiveMetastoreUris = copiedProps.get(HIVE_METASTORE_URIS);
         String resourceName = copiedProps.get(HIVE_RESOURCE);
         if (Strings.isNullOrEmpty(resourceName)) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
@@ -325,13 +325,14 @@ public class HiveTable extends Table {
         // hive.metastore.uris or hive.resource must be set
         String hiveMetastoreUris = copiedProps.get(HIVE_METASTORE_URIS);
         String resourceName = copiedProps.get(HIVE_RESOURCE);
-        if (Strings.isNullOrEmpty(hiveMetastoreUris) && Strings.isNullOrEmpty(resourceName)) {
-            throw new DdlException("property " + HIVE_METASTORE_URIS + " or " + HIVE_RESOURCE + " must be set");
+        if (Strings.isNullOrEmpty(resourceName)) {
+            throw new DdlException("property " + HIVE_RESOURCE + " must be set");
         }
 
         if (!Strings.isNullOrEmpty(hiveMetastoreUris)) {
             copiedProps.remove(HIVE_METASTORE_URIS);
-            hiveProperties.put(HIVE_METASTORE_URIS, hiveMetastoreUris);
+            LOG.warn("property " + HIVE_METASTORE_URIS + " will be ignored " +
+                    "and hive table will be created by using property " + HIVE_RESOURCE + " only.");
         }
 
         if (!Strings.isNullOrEmpty(resourceName)) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
@@ -322,7 +322,7 @@ public class HiveTable extends Table {
         copiedProps.remove(HIVE_TABLE);
 
         // check hive properties
-        // hive.resource must be set and hive.metastore.uris will be ignored if specified.
+        // resource must be set and hive.metastore.uris will be ignored if specified.
         String hiveMetastoreUris = copiedProps.get(HIVE_METASTORE_URIS);
         String resourceName = copiedProps.get(HIVE_RESOURCE);
         if (Strings.isNullOrEmpty(resourceName)) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
@@ -335,78 +335,76 @@ public class HiveTable extends Table {
                     "and hive table will be created by using property " + HIVE_RESOURCE + " only.");
         }
 
-        if (!Strings.isNullOrEmpty(resourceName)) {
-            copiedProps.remove(HIVE_RESOURCE);
-            Resource resource = Catalog.getCurrentCatalog().getResourceMgr().getResource(resourceName);
-            if (resource == null) {
-                throw new DdlException("hive resource [" + resourceName + "] not exists");
-            }
-            if (resource.getType() != ResourceType.HIVE) {
-                throw new DdlException("resource [" + resourceName + "] is not hive resource");
-            }
-            HiveResource hiveResource = (HiveResource) resource;
-            hiveProperties.put(HIVE_METASTORE_URIS, hiveResource.getHiveMetastoreURIs());
-            this.resourceName = resourceName;
-
-            // check column
-            // 1. check column exists in hive table
-            // 2. check column type mapping
-            // 3. check hive partition column exists in table column list
-            org.apache.hadoop.hive.metastore.api.Table hiveTable = Catalog.getCurrentCatalog().getHiveRepository()
-                    .getTable(resourceName, this.hiveDb, this.hiveTable);
-            String hiveTableType = hiveTable.getTableType();
-            if (hiveTableType == null) {
-                throw new DdlException("Unknown hive table type.");
-            }
-            switch (hiveTableType) {
-                case "VIRTUAL_VIEW": // hive view table not supported
-                    throw new DdlException("Hive view table is not supported.");
-                case "EXTERNAL_TABLE": // hive external table supported
-                case "MANAGED_TABLE": // basic hive table supported
-                    break;
-                default:
-                    throw new DdlException("unsupported hive table type [" + hiveTableType + "].");
-            }
-            List<FieldSchema> unPartHiveColumns = hiveTable.getSd().getCols();
-            List<FieldSchema> partHiveColumns = hiveTable.getPartitionKeys();
-            Map<String, FieldSchema> allHiveColumns = unPartHiveColumns.stream()
-                    .collect(Collectors.toMap(FieldSchema::getName, fieldSchema -> fieldSchema));
-            for (FieldSchema hiveColumn : partHiveColumns) {
-                allHiveColumns.put(hiveColumn.getName(), hiveColumn);
-            }
-            for (Column column : this.fullSchema) {
-                FieldSchema hiveColumn = allHiveColumns.get(column.getName());
-                if (hiveColumn == null) {
-                    throw new DdlException("column [" + column.getName() + "] not exists in hive");
-                }
-                Set<PrimitiveType> validColumnTypes = getValidColumnType(hiveColumn.getType());
-                if (!validColumnTypes.contains(column.getPrimitiveType())) {
-                    throw new DdlException("can not convert hive column type [" + hiveColumn.getType() + "] to " +
-                            "starrocks type [" + column.getPrimitiveType() + "]");
-                }
-                if (!column.isAllowNull() && !isTypeRead) {
-                    throw new DdlException(
-                            "hive extern table not support no-nullable column: [" + hiveColumn.getName() + "]");
-                }
-            }
-            for (FieldSchema partHiveColumn : partHiveColumns) {
-                String columnName = partHiveColumn.getName();
-                Column partColumn = this.nameToColumn.get(columnName);
-                if (partColumn == null) {
-                    throw new DdlException("partition column [" + columnName + "] must exist in column list");
-                } else {
-                    this.partColumnNames.add(columnName);
-                }
-            }
-
-            for (FieldSchema s : unPartHiveColumns) {
-                this.dataColumnNames.add(s.getName());
-            }
-
-            // set hdfs path
-            // todo hdfs ip may change, store it in cache?
-            this.hdfsPath = hiveTable.getSd().getLocation();
+        copiedProps.remove(HIVE_RESOURCE);
+        Resource resource = Catalog.getCurrentCatalog().getResourceMgr().getResource(resourceName);
+        if (resource == null) {
+            throw new DdlException("hive resource [" + resourceName + "] not exists");
         }
+        if (resource.getType() != ResourceType.HIVE) {
+            throw new DdlException("resource [" + resourceName + "] is not hive resource");
+        }
+        HiveResource hiveResource = (HiveResource) resource;
+        hiveProperties.put(HIVE_METASTORE_URIS, hiveResource.getHiveMetastoreURIs());
+        this.resourceName = resourceName;
+
+        // check column
+        // 1. check column exists in hive table
+        // 2. check column type mapping
+        // 3. check hive partition column exists in table column list
+        org.apache.hadoop.hive.metastore.api.Table hiveTable = Catalog.getCurrentCatalog().getHiveRepository()
+                .getTable(resourceName, this.hiveDb, this.hiveTable);
+        String hiveTableType = hiveTable.getTableType();
+        if (hiveTableType == null) {
+            throw new DdlException("Unknown hive table type.");
+        }
+        switch (hiveTableType) {
+            case "VIRTUAL_VIEW": // hive view table not supported
+                throw new DdlException("Hive view table is not supported.");
+            case "EXTERNAL_TABLE": // hive external table supported
+            case "MANAGED_TABLE": // basic hive table supported
+                break;
+            default:
+                throw new DdlException("unsupported hive table type [" + hiveTableType + "].");
+        }
+        List<FieldSchema> unPartHiveColumns = hiveTable.getSd().getCols();
+        List<FieldSchema> partHiveColumns = hiveTable.getPartitionKeys();
+        Map<String, FieldSchema> allHiveColumns = unPartHiveColumns.stream()
+                .collect(Collectors.toMap(FieldSchema::getName, fieldSchema -> fieldSchema));
+        for (FieldSchema hiveColumn : partHiveColumns) {
+            allHiveColumns.put(hiveColumn.getName(), hiveColumn);
+        }
+        for (Column column : this.fullSchema) {
+            FieldSchema hiveColumn = allHiveColumns.get(column.getName());
+            if (hiveColumn == null) {
+                throw new DdlException("column [" + column.getName() + "] not exists in hive");
+            }
+            Set<PrimitiveType> validColumnTypes = getValidColumnType(hiveColumn.getType());
+            if (!validColumnTypes.contains(column.getPrimitiveType())) {
+                throw new DdlException("can not convert hive column type [" + hiveColumn.getType() + "] to " +
+                        "starrocks type [" + column.getPrimitiveType() + "]");
+            }
+            if (!column.isAllowNull() && !isTypeRead) {
+                throw new DdlException(
+                        "hive extern table not support no-nullable column: [" + hiveColumn.getName() + "]");
+            }
+        }
+        for (FieldSchema partHiveColumn : partHiveColumns) {
+            String columnName = partHiveColumn.getName();
+            Column partColumn = this.nameToColumn.get(columnName);
+            if (partColumn == null) {
+                throw new DdlException("partition column [" + columnName + "] must exist in column list");
+            } else {
+                this.partColumnNames.add(columnName);
+            }
+        }
+
+        for (FieldSchema s : unPartHiveColumns) {
+            this.dataColumnNames.add(s.getName());
+        }
+
+        // set hdfs path
+        // todo hdfs ip may change, store it in cache?
+        this.hdfsPath = hiveTable.getSd().getLocation();
 
         if (!copiedProps.isEmpty()) {
             throw new DdlException("Unknown table properties: " + copiedProps.toString());

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/HiveTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/HiveTableTest.java
@@ -40,6 +40,7 @@ import java.util.Map;
 public class HiveTableTest {
     private String hiveDb;
     private String hiveTable;
+    String resourceName;
     private List<Column> columns;
     private Map<String, String> properties;
 
@@ -47,6 +48,7 @@ public class HiveTableTest {
     public void setUp() {
         hiveDb = "db0";
         hiveTable = "table0";
+        resourceName = "hive0";
 
         columns = Lists.newArrayList();
         Column column = new Column("col1", Type.BIGINT, true);
@@ -55,22 +57,13 @@ public class HiveTableTest {
         properties = Maps.newHashMap();
         properties.put("database", hiveDb);
         properties.put("table", hiveTable);
-        properties.put("hive.metastore.uris", "thrift://127.0.0.1:9083");
-    }
-
-    @Test
-    public void testNormal() throws DdlException {
-        HiveTable table = new HiveTable(1000, "hive_table", columns, properties);
-        Assert.assertEquals(String.format("%s.%s", hiveDb, hiveTable), table.getHiveDbTable());
-        Assert.assertEquals(1, table.getHiveProperties().size());
+        properties.put("resource", resourceName);
     }
 
     @Test
     public void testWithResourceName(@Mocked Catalog catalog,
                                      @Mocked ResourceMgr resourceMgr,
                                      @Mocked HiveRepository hiveRepository) throws DdlException {
-        String resourceName = "hive0";
-
         Resource hiveResource = new HiveResource(resourceName);
         Map<String, String> resourceProperties = Maps.newHashMap();
         resourceProperties.put("hive.metastore.uris", "thrift://127.0.0.1:9083");


### PR DESCRIPTION
### Steps to reproduce:
1. create external hive table
```
CREATE EXTERNAL TABLE `t1` (
  `id` int,
  `name` string
) ENGINE=HIVE
PROPERTIES (
"database" = "starrocks_test",
"table" = "hdfs_orc_table",
"hive.metastore.uris" = "thrift://192.168.7.158:9083"
);

Query OK, 0 rows affected (0.01 sec)
```

2.  query this table, then it will throw a exception
```
select * from t1;

ERROR 1064 (HY000): get hive client failed, resource[null] not exists
```

### cause analysis：
1. both `metaCache` and `metaClient` are indexed by resource name in `HiveRepository`, but absent in this situation.
2. Inconsistenct and insufficient check about `table properties` while creating external hive table.
3. if hive external table is created with properties both `hive.metastore.uris` and `resource` specified, resource related info will overwrite `hive.metastore.uris` without any conflicts check or prompt.
4. if hive external table is created with properties `hive.metastore.uris` specified only, all of column related check like existence or  partition column filling will be skipped.  Then throw query exception like above example due to missing resource name.

### how to fix
1. Ignore the hive.metastore.uris properties.
2. The resource must be specified.

@imay @wyb 