### PR TITLE
Fix inconsistency of resource type check

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/CreateResourceStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/CreateResourceStmt.java
@@ -24,6 +24,7 @@ package com.starrocks.analysis;
 import com.starrocks.catalog.Catalog;
 import com.starrocks.catalog.Resource.ResourceType;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.FeNameFormat;
@@ -32,6 +33,7 @@ import com.starrocks.common.util.PrintableMap;
 import com.starrocks.mysql.privilege.PrivPredicate;
 import com.starrocks.qe.ConnectContext;
 
+import java.util.Arrays;
 import java.util.Map;
 
 // CREATE [EXTERNAL] RESOURCE resource_name
@@ -85,7 +87,9 @@ public class CreateResourceStmt extends DdlStmt {
         }
         resourceType = ResourceType.fromString(type);
         if (resourceType == ResourceType.UNKNOWN) {
-            throw new AnalysisException("Unsupported resource type: " + type);
+            throw new AnalysisException("Unrecognized resource type: " + type + ". " + "Only " +
+                    Arrays.toString(Arrays.stream(ResourceType.values())
+                            .filter(t -> t != ResourceType.UNKNOWN).toArray()) + "are supported.");
         }
         if (!isExternal) {
             throw new AnalysisException(resourceType + " resource type must be external.");

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/CreateResourceStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/CreateResourceStmt.java
@@ -87,11 +87,8 @@ public class CreateResourceStmt extends DdlStmt {
         if (resourceType == ResourceType.UNKNOWN) {
             throw new AnalysisException("Unsupported resource type: " + type);
         }
-        if (resourceType == ResourceType.SPARK && !isExternal) {
-            throw new AnalysisException("Spark is external resource");
-        }
-        if (resourceType == ResourceType.HIVE && !isExternal) {
-            throw new AnalysisException("Hive is external resource");
+        if (!isExternal) {
+            throw new AnalysisException(resourceType + " resource type must be external.");
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/CreateResourceStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/CreateResourceStmt.java
@@ -89,7 +89,7 @@ public class CreateResourceStmt extends DdlStmt {
         if (resourceType == ResourceType.UNKNOWN) {
             throw new AnalysisException("Unrecognized resource type: " + type + ". " + "Only " +
                     Arrays.toString(Arrays.stream(ResourceType.values())
-                            .filter(t -> t != ResourceType.UNKNOWN).toArray()) + "are supported.");
+                            .filter(t -> t != ResourceType.UNKNOWN).toArray()) + " are supported.");
         }
         if (!isExternal) {
             throw new AnalysisException(resourceType + " resource type must be external.");

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Resource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Resource.java
@@ -76,8 +76,9 @@ public abstract class Resource implements Writable {
                 resource = new OdbcCatalogResource(stmt.getResourceName());
                 break;
             default:
-                throw new DdlException("Unrecognized resource type: " + type + ". " +
-                        "Only " + Arrays.toString(Arrays.stream(ResourceType.values()).filter(t -> t != ResourceType.UNKNOWN).toArray()) + "are supported.");
+                throw new DdlException("Unrecognized resource type: " + type + ". " + "Only " +
+                        Arrays.toString(Arrays.stream(ResourceType.values())
+                                .filter(t -> t != ResourceType.UNKNOWN).toArray()) + "are supported.");
         }
 
         resource.setProperties(stmt.getProperties());

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Resource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Resource.java
@@ -23,6 +23,7 @@ package com.starrocks.catalog;
 
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.analysis.CreateResourceStmt;
+import com.starrocks.common.AnalysisException;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
@@ -76,9 +77,7 @@ public abstract class Resource implements Writable {
                 resource = new OdbcCatalogResource(stmt.getResourceName());
                 break;
             default:
-                throw new DdlException("Unrecognized resource type: " + type + ". " + "Only " +
-                        Arrays.toString(Arrays.stream(ResourceType.values())
-                                .filter(t -> t != ResourceType.UNKNOWN).toArray()) + "are supported.");
+                throw new DdlException("Unsupported resource type: " + type);
         }
 
         resource.setProperties(stmt.getProperties());

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Resource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Resource.java
@@ -32,6 +32,7 @@ import com.starrocks.persist.gson.GsonUtils;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Map;
 
 public abstract class Resource implements Writable {
@@ -75,7 +76,8 @@ public abstract class Resource implements Writable {
                 resource = new OdbcCatalogResource(stmt.getResourceName());
                 break;
             default:
-                throw new DdlException("Only support spark and hive resource.");
+                throw new DdlException("Unrecognized resource type: " + type + ". " +
+                        "Only " + Arrays.toString(Arrays.stream(ResourceType.values()).filter(t -> t != ResourceType.UNKNOWN).toArray()) + "are supported.");
         }
 
         resource.setProperties(stmt.getProperties());

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Resource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Resource.java
@@ -23,7 +23,6 @@ package com.starrocks.catalog;
 
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.analysis.CreateResourceStmt;
-import com.starrocks.common.AnalysisException;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
@@ -33,7 +32,6 @@ import com.starrocks.persist.gson.GsonUtils;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Map;
 
 public abstract class Resource implements Writable {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceMgr.java
@@ -67,13 +67,8 @@ public class ResourceMgr implements Writable {
     }
 
     public void createResource(CreateResourceStmt stmt) throws DdlException {
-        if (stmt.getResourceType() != ResourceType.SPARK
-                && stmt.getResourceType() != ResourceType.HIVE) {
-            throw new DdlException("Only support Spark or Hive resource.");
-        }
-
-        String resourceName = stmt.getResourceName();
         Resource resource = Resource.fromStmt(stmt);
+        String resourceName = stmt.getResourceName();
         if (nameToResource.putIfAbsent(resourceName, resource) != null) {
             throw new DdlException("Resource(" + resourceName + ") already exist");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceMgr.java
@@ -26,7 +26,6 @@ import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.analysis.CreateResourceStmt;
 import com.starrocks.analysis.DropResourceStmt;
-import com.starrocks.catalog.Resource.ResourceType;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;


### PR DESCRIPTION
Fix inconsistency of resource type check:
1. resource type related code in `createResource` is duplicated and inconsistent with that in `Resource.fromStmt`
2. it is unnecessary because it should be checked in analyze stage with fail fast. 