### PR TITLE
[pipeline] fix exit logic of exchange and result sink when the query is canceled

### DIFF
--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -208,6 +208,8 @@ Status ExchangeSinkOperator::Channel::_close_internal(RuntimeState* state, Fragm
     return Status::OK();
 }
 
+// TODO(lzh): Remove fragment_ctx from parameters.
+//  Cancel flag should probably be owned by RuntimeState instead of FragmentContext.
 void ExchangeSinkOperator::Channel::close(RuntimeState* state, FragmentContext* fragment_ctx) {
     state->log_error(_close_internal(state, fragment_ctx).get_error_msg());
 }

--- a/be/src/exec/pipeline/exchange/sink_buffer.h
+++ b/be/src/exec/pipeline/exchange/sink_buffer.h
@@ -37,7 +37,8 @@ class SinkBuffer {
 public:
     SinkBuffer(RuntimeState* state, const std::vector<TPlanFragmentDestination>& destinations, size_t num_sinkers)
             : _mem_tracker(state->instance_mem_tracker()),
-              _brpc_timeout_ms(std::min(3600, state->query_options().query_timeout) * 1000) {
+              _brpc_timeout_ms(std::min(3600, state->query_options().query_timeout) * 1000),
+              _num_remaining_sinkers(num_sinkers) {
         _threads = ExecEnv::GetInstance()->pipeline_exchange_sink_thread_pool();
         for (const auto& dest : destinations) {
             const auto& dest_instance_id = dest.fragment_instance_id;
@@ -52,15 +53,14 @@ public:
                 auto* closure = new CallBackClosure<PTransmitChunkResult, TUniqueId>();
                 closure->ref();
                 closure->addFailedHandler([this]() noexcept {
-                    _in_flight_rpc_num.fetch_sub(1, std::memory_order_release);
                     {
                         std::lock_guard<std::mutex> l(_mutex);
                         _is_finishing = true;
                     }
                     LOG(WARNING) << " transmit chunk rpc failed";
+                    _in_flight_rpc_num.fetch_sub(1, std::memory_order_release);
                 });
                 closure->addSuccessHandler([this, closure](const PTransmitChunkResult& result) noexcept {
-                    _in_flight_rpc_num.fetch_sub(1, std::memory_order_release);
                     Status status(result.status());
                     if (!status.ok()) {
                         {
@@ -72,8 +72,10 @@ public:
                         _is_closure_finishing[closure->context().lo]->store(true, std::memory_order_release);
                         _try_to_trigger_rpc_task(closure->context());
                     }
+                    _in_flight_rpc_num.fetch_sub(1, std::memory_order_release);
                 });
                 _closures[dest_instance_id.lo] = closure;
+
                 _is_closure_finishing[dest_instance_id.lo] = std::make_unique<std::atomic_bool>(false);
 
                 _request_seqs[dest_instance_id.lo] = 0;
@@ -94,32 +96,7 @@ public:
     }
 
     ~SinkBuffer() {
-        _is_destructing.store(true, std::memory_order_release);
-
-        // Handle abnormal exit of SinkBuffer
-        // TODO(hcf) It may be solved by adding state 'PENDING_FINISH' for ExchangeSinkOperator
-        bool abnormal_exit = false;
-        if (!is_finished()) {
-            std::lock_guard<std::mutex> l(_mutex);
-            abnormal_exit = true;
-            _is_finishing = true;
-        }
-        if (abnormal_exit) {
-            for (auto& [_, closure] : _closures) {
-                brpc::Join(closure->cntl.call_id());
-            }
-        }
-
-        // Wait for the rpc task to exit to avoid
-        // DeferOp accessing illegal memory
-        std::promise<void>* exit_promise = nullptr;
-        {
-            std::lock_guard<std::mutex> l(_mutex);
-            exit_promise = _rpc_task_exit_promise.get();
-        }
-        if (exit_promise != nullptr) {
-            exit_promise->get_future().get();
-        }
+        DCHECK(is_finished());
 
         // Relase resources
         for (auto& [_, closure] : _closures) {
@@ -127,6 +104,7 @@ public:
                 delete closure;
             }
         }
+
         for (auto& [_, buffer] : _buffers) {
             while (!buffer.empty()) {
                 auto& request = buffer.front();
@@ -138,7 +116,7 @@ public:
 
     void add_request(const TransmitChunkInfo& request) {
         DCHECK(_expected_eos > 0);
-        if (_is_destructing.load(std::memory_order_acquire)) {
+        if (_is_finishing) {
             request.params->release_finst_id();
             return;
         }
@@ -157,16 +135,26 @@ public:
                            [](const auto& entry) { return entry.second.size() > config::pipeline_io_buffer_size; });
     }
 
-    bool is_finished() {
-        if (!_is_finishing) {
-            return false;
-        }
+    // SinkBuffer needn't input request anymore.
+    bool is_finishing() const { return _is_finishing; }
 
-        // Here is the guarantee that
-        // 1. No new rpc task will be created after finishing stage
-        // 2. No new brpc process will be triggered after finishing stage
-        // So we just wait for existed rpc task and bprc process to be finished
-        return !_is_rpc_task_active && _in_flight_rpc_num.load(std::memory_order_acquire) == 0;
+    bool is_finished() const {
+        return _is_finishing                                               // SinkBuffer needn't input request anymore,
+               && !_is_rpc_task_active                                     // and rpc task is running,
+               && _in_flight_rpc_num.load(std::memory_order_acquire) == 0; // and there isn't in flight RPC.
+    }
+
+    void decrease_running_sinkers() {
+        if (--_num_remaining_sinkers == 0) {
+            // decrease_running_sinkers() is called by ExchangeSinkOperator::set_finished(),
+            // and is_finishing() is called by ExchangeSinkOperator::is_finishing().
+            // - In the normal cases, decrease_running_sinkers() is called after is_finishing()
+            // returns true, so it is meaningless to set _is_finishing here.
+            // - In the abnormal cases, such as query is cancelled, decrease_running_sinkers()
+            // may be called when is_finishing() still returns false, so _is_finishing can
+            // become true earlier here.
+            _is_finishing = true;
+        }
     }
 
 private:
@@ -182,8 +170,6 @@ private:
             return;
         }
 
-        _rpc_task_exit_promise = std::make_shared<std::promise<void>>();
-
         PriorityThreadPool::Task task;
         task.work_function = [this]() { _process(); };
         // TODO(by satanson): set a proper priority
@@ -194,12 +180,10 @@ private:
             LOG(WARNING) << "SinkBuffer failed to offer rpc task due to thread pool shutdown";
             _is_finishing = true;
             _is_rpc_task_active = false;
-            _rpc_task_exit_promise = nullptr;
         }
     }
 
     void _process() {
-        auto exit_promise = _rpc_task_exit_promise;
         try {
             SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_mem_tracker);
 
@@ -250,7 +234,6 @@ private:
         } catch (...) {
             LOG(FATAL) << "[ExchangeSinkOperator] sink_buffer::process: UNKNOWN";
         }
-        exit_promise->set_value();
     }
 
     void _send_rpc(TransmitChunkInfo& request) {
@@ -320,15 +303,13 @@ private:
     std::mutex _mutex;
     // Events include 'new request' and 'channel ready'
     std::queue<TUniqueId, std::list<TUniqueId>> _events;
-    bool _is_finishing = false;
+    // Means that SinkBuffer needn't input chunk anymore.
+    // it becomes true, when all sinkers have sent EOS, or been set_finished/cancelled, or RPC has returned error.
+    std::atomic<bool> _is_finishing = false;
     bool _is_rpc_task_active = false;
     int32_t _expected_eos = 0;
 
-    std::atomic_bool _is_destructing = false;
-
-    // This field is used to help properly handle special situation
-    // that SinkBuffer may destruct when method is_finished() return false
-    std::shared_ptr<std::promise<void>> _rpc_task_exit_promise = nullptr;
+    std::atomic<int> _num_remaining_sinkers;
 };
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -227,8 +227,9 @@ void FragmentExecutor::_convert_data_sink_to_operator(const TPlanFragmentExecPar
     if (typeid(*datasink) == typeid(starrocks::ResultSink)) {
         starrocks::ResultSink* result_sink = down_cast<starrocks::ResultSink*>(datasink);
         // Result sink doesn't have plan node id;
-        OpFactoryPtr op = std::make_shared<ResultSinkOperatorFactory>(
-                context->next_operator_id(), -1, result_sink->get_sink_type(), result_sink->get_output_exprs());
+        OpFactoryPtr op = std::make_shared<ResultSinkOperatorFactory>(context->next_operator_id(), -1,
+                                                                      result_sink->get_sink_type(),
+                                                                      result_sink->get_output_exprs(), _fragment_ctx);
         // Add result sink operator to last pipeline
         _fragment_ctx->pipelines().back()->add_op_factory(op);
     } else if (typeid(*datasink) == typeid(starrocks::DataStreamSender)) {
@@ -239,7 +240,7 @@ void FragmentExecutor::_convert_data_sink_to_operator(const TPlanFragmentExecPar
 
         OpFactoryPtr exchange_sink = std::make_shared<ExchangeSinkOperatorFactory>(
                 context->next_operator_id(), -1, sink_buffer, sender->get_partition_type(), params.destinations,
-                params.sender_id, sender->get_dest_node_id(), sender->get_partition_exprs());
+                params.sender_id, sender->get_dest_node_id(), sender->get_partition_exprs(), _fragment_ctx);
         _fragment_ctx->pipelines().back()->add_op_factory(exchange_sink);
     }
 }

--- a/be/src/exec/pipeline/operator.h
+++ b/be/src/exec/pipeline/operator.h
@@ -68,6 +68,14 @@ public:
     // output chunks will be produced
     virtual bool is_finished() const = 0;
 
+    // pending_finish returns whether this operator still has pending i/o task which executed in i/o threads
+    // and has reference to the object owned by the operator or FragmentContext.
+    // It can ONLY be called after calling set_finished().
+    // When a driver's sink operator is finished, the driver should wait for pending i/o task completion.
+    // Otherwise, pending tasks shall reference to destructed objects in the operator or FragmentContext,
+    // since FragmentContext is unregistered prematurely after all the drivers are finalized.
+    virtual bool pending_finish() const { return false; }
+
     // Pull chunk from this operator
     // Use shared_ptr, because in some cases (local broadcast exchange),
     // the chunk need to be shared
@@ -75,8 +83,6 @@ public:
 
     // Push chunk to this operator
     virtual Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) = 0;
-
-    virtual bool pending_finish() const { return false; }
 
     int32_t get_id() const { return _id; }
 

--- a/be/src/exec/pipeline/operator.h
+++ b/be/src/exec/pipeline/operator.h
@@ -76,6 +76,8 @@ public:
     // Push chunk to this operator
     virtual Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) = 0;
 
+    virtual bool pending_finish() const { return false; }
+
     int32_t get_id() const { return _id; }
 
     int32_t get_plan_node_id() const { return _plan_node_id; }

--- a/be/src/exec/pipeline/operator.h
+++ b/be/src/exec/pipeline/operator.h
@@ -74,6 +74,7 @@ public:
     // When a driver's sink operator is finished, the driver should wait for pending i/o task completion.
     // Otherwise, pending tasks shall reference to destructed objects in the operator or FragmentContext,
     // since FragmentContext is unregistered prematurely after all the drivers are finalized.
+    // Only source and sink operator may return true, and other operators always return false.
     virtual bool pending_finish() const { return false; }
 
     // Pull chunk from this operator

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -164,6 +164,7 @@ public:
                _state == DriverState::INTERNAL_ERROR;
     }
     bool pending_finish() { return _state == DriverState::PENDING_FINISH; }
+    bool is_still_pending_finish() { return source_operator()->pending_finish() || sink_operator()->pending_finish(); }
     // return false if all the dependencies are ready, otherwise return true.
     bool dependencies_block() {
         if (_all_dependencies_ready) {

--- a/be/src/exec/pipeline/pipeline_driver_dispatcher.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_dispatcher.cpp
@@ -40,7 +40,7 @@ void GlobalDriverDispatcher::finalize_driver(DriverRawPtr driver, RuntimeState* 
     driver->finalize(runtime_state, state);
     if (driver->query_ctx()->is_finished()) {
         auto query_id = driver->query_ctx()->query_id();
-        DCHECK(!driver->source_operator()->pending_finish());
+        DCHECK(!driver->is_still_pending_finish());
         QueryContextManager::instance()->remove(query_id);
     }
 }
@@ -72,7 +72,7 @@ void GlobalDriverDispatcher::run() {
                 VLOG_ROW << "[Driver] Canceled: driver=" << driver
                          << ", error=" << fragment_ctx->final_status().to_string();
                 driver->finish_operators(runtime_state);
-                if (driver->source_operator()->pending_finish()) {
+                if (driver->is_still_pending_finish()) {
                     driver->set_driver_state(DriverState::PENDING_FINISH);
                     _blocked_driver_poller->add_blocked_driver(driver);
                 } else {
@@ -95,7 +95,7 @@ void GlobalDriverDispatcher::run() {
                 VLOG_ROW << "[Driver] Process error: error=" << status.status().to_string();
                 query_ctx->cancel(status.status());
                 driver->finish_operators(runtime_state);
-                if (driver->source_operator()->pending_finish()) {
+                if (driver->is_still_pending_finish()) {
                     driver->set_driver_state(DriverState::PENDING_FINISH);
                     _blocked_driver_poller->add_blocked_driver(driver);
                 } else {

--- a/be/src/exec/pipeline/pipeline_driver_poller.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_poller.cpp
@@ -52,7 +52,7 @@ void PipelineDriverPoller::run_internal() {
         while (driver_it != local_blocked_drivers.end()) {
             auto* driver = *driver_it;
 
-            if (driver->pending_finish() && !driver->source_operator()->pending_finish()) {
+            if (driver->pending_finish() && !driver->is_still_pending_finish()) {
                 // driver->pending_finish() return true means that when a driver's sink operator is finished,
                 // but its source operator still has pending io task that executed in io threads and has
                 // reference to object outside(such as desc_tbl) owned by FragmentContext. So a driver in
@@ -73,7 +73,7 @@ void PipelineDriverPoller::run_internal() {
                 // If the fragment is expired when the source operator is already pending i/o task,
                 // The state of driver shouldn't be changed.
                 driver->finish_operators(driver->fragment_ctx()->runtime_state());
-                if (driver->source_operator()->pending_finish()) {
+                if (driver->is_still_pending_finish()) {
                     driver->set_driver_state(DriverState::PENDING_FINISH);
                     ++driver_it;
                 } else {
@@ -85,7 +85,7 @@ void PipelineDriverPoller::run_internal() {
                 // If the fragment is cancelled when the source operator is already pending i/o task,
                 // The state of driver shouldn't be changed.
                 driver->finish_operators(driver->fragment_ctx()->runtime_state());
-                if (driver->source_operator()->pending_finish()) {
+                if (driver->is_still_pending_finish()) {
                     driver->set_driver_state(DriverState::PENDING_FINISH);
                     ++driver_it;
                 } else {

--- a/be/src/exec/pipeline/result_sink_operator.h
+++ b/be/src/exec/pipeline/result_sink_operator.h
@@ -4,9 +4,11 @@
 
 #include <utility>
 
+#include "exec/pipeline/fragment_context.h"
 #include "exec/pipeline/operator.h"
 #include "gen_cpp/InternalService_types.h"
 #include "runtime/mysql_result_writer.h"
+
 namespace starrocks {
 class BufferControlBlock;
 class ExprContext;
@@ -18,13 +20,14 @@ public:
     ResultSinkOperator(int32_t id, int32_t plan_node_id, TResultSinkType::type sink_type,
                        const std::vector<ExprContext*>& output_expr_ctxs,
                        const std::shared_ptr<BufferControlBlock>& sender, std::atomic<int32_t>& num_result_sinks,
-                       std::atomic<int64_t>& num_written_rows)
+                       std::atomic<int64_t>& num_written_rows, FragmentContext* const fragment_ctx)
             : Operator(id, "result_sink", plan_node_id),
               _sink_type(sink_type),
               _output_expr_ctxs(output_expr_ctxs),
               _sender(sender),
               _num_result_sinkers(num_result_sinks),
-              _num_written_rows(num_written_rows) {}
+              _num_written_rows(num_written_rows),
+              _fragment_ctx(fragment_ctx) {}
 
     ~ResultSinkOperator() override = default;
 
@@ -63,15 +66,18 @@ private:
 
     mutable Status _last_error;
     bool _is_finished = false;
+
+    FragmentContext* const _fragment_ctx;
 };
 
 class ResultSinkOperatorFactory final : public OperatorFactory {
 public:
     ResultSinkOperatorFactory(int32_t id, int32_t plan_node_id, TResultSinkType::type sink_type,
-                              std::vector<TExpr> t_output_expr)
+                              std::vector<TExpr> t_output_expr, FragmentContext* const fragment_ctx)
             : OperatorFactory(id, "result_sink", plan_node_id),
               _sink_type(sink_type),
-              _t_output_expr(std::move(t_output_expr)) {}
+              _t_output_expr(std::move(t_output_expr)),
+              _fragment_ctx(fragment_ctx) {}
 
     ~ResultSinkOperatorFactory() override = default;
 
@@ -82,7 +88,7 @@ public:
         // so it doesn't need memory barrier here.
         _increment_num_result_sinkers_no_barrier();
         return std::make_shared<ResultSinkOperator>(_id, _plan_node_id, _sink_type, _output_expr_ctxs, _sender,
-                                                    _num_result_sinkers, _num_written_rows);
+                                                    _num_result_sinkers, _num_written_rows, _fragment_ctx);
     }
 
     Status prepare(RuntimeState* state) override;
@@ -102,6 +108,8 @@ private:
     std::shared_ptr<BufferControlBlock> _sender;
     std::atomic<int32_t> _num_result_sinkers = 0;
     std::atomic<int64_t> _num_written_rows = 0;
+
+    FragmentContext* const _fragment_ctx;
 };
 
 } // namespace pipeline

--- a/be/src/exec/pipeline/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan_operator.cpp
@@ -68,7 +68,7 @@ bool ScanOperator::has_output() const {
     return true;
 }
 
-bool ScanOperator::pending_finish() {
+bool ScanOperator::pending_finish() const {
     DCHECK(_is_finished);
     // If there is no next morsel, and io task is active
     // we just wait for the io thread to end

--- a/be/src/exec/pipeline/scan_operator.h
+++ b/be/src/exec/pipeline/scan_operator.h
@@ -34,7 +34,7 @@ public:
 
     bool has_output() const override;
 
-    bool pending_finish() override;
+    bool pending_finish() const override;
 
     bool is_finished() const override;
 

--- a/be/src/exec/pipeline/source_operator.h
+++ b/be/src/exec/pipeline/source_operator.h
@@ -18,13 +18,6 @@ public:
     ~SourceOperator() override = default;
 
     bool need_input() const override { return false; }
-    // pending_finish returns whether this source operator still has pending i/o task which executed in i/o threads
-    // and has reference to the object outside (such as desc_tbl) owned by FragmentContext.
-    // It can ONLY be called after calling finish().
-    // When a driver's sink operator is finished, the driver should wait for pending i/o task completion.
-    // Otherwise, pending tasks shall reference to destructed objects in FragmentContext,
-    // since FragmentContext is unregistered prematurely after all the drivers are finalized.
-    //    virtual bool pending_finish() { return false; }
 
     Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override {
         return Status::InternalError("Shouldn't push chunk to source operator");

--- a/be/src/exec/pipeline/source_operator.h
+++ b/be/src/exec/pipeline/source_operator.h
@@ -24,7 +24,7 @@ public:
     // When a driver's sink operator is finished, the driver should wait for pending i/o task completion.
     // Otherwise, pending tasks shall reference to destructed objects in FragmentContext,
     // since FragmentContext is unregistered prematurely after all the drivers are finalized.
-    virtual bool pending_finish() { return false; }
+    //    virtual bool pending_finish() { return false; }
 
     Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override {
         return Status::InternalError("Shouldn't push chunk to source operator");

--- a/be/src/runtime/data_stream_recvr.cc
+++ b/be/src/runtime/data_stream_recvr.cc
@@ -344,17 +344,19 @@ Status DataStreamRecvr::SenderQueue::_add_chunks_internal(const PTransmitChunkPa
         std::unique_lock<std::mutex> l(_lock);
         wait_timer.stop();
 
-        for (auto& pair : chunks) {
-            _chunk_queue.emplace_back(std::move(pair));
+        if (!_is_cancelled) {
+            for (auto& pair : chunks) {
+                _chunk_queue.emplace_back(std::move(pair));
+            }
+            // if done is nullptr, this function can't delay this response
+            if (done != nullptr && _recvr->exceeds_limit(total_chunk_bytes)) {
+                MonotonicStopWatch monotonicStopWatch;
+                DCHECK(*done != nullptr);
+                _pending_closures.emplace_back(*done, monotonicStopWatch);
+                *done = nullptr;
+            }
+            _recvr->_num_buffered_bytes += total_chunk_bytes;
         }
-        // if done is nullptr, this function can't delay this response
-        if (done != nullptr && _recvr->exceeds_limit(total_chunk_bytes)) {
-            MonotonicStopWatch monotonicStopWatch;
-            DCHECK(*done != nullptr);
-            _pending_closures.emplace_back(*done, monotonicStopWatch);
-            *done = nullptr;
-        }
-        _recvr->_num_buffered_bytes += total_chunk_bytes;
     }
     cb();
     return Status::OK();

--- a/be/test/exec/pipeline/pipeline_control_flow_test.cpp
+++ b/be/test/exec/pipeline/pipeline_control_flow_test.cpp
@@ -69,7 +69,7 @@ std::atomic<size_t> lifecycle_error_num;
 class TestOperator : public Operator {
 public:
     TestOperator(int32_t id, const std::string& name, int32_t plan_node_id) : Operator(id, name, plan_node_id) {}
-    ~TestOperator() {
+    ~TestOperator() override {
         if (!_is_prepared) {
             ++lifecycle_error_num;
         }
@@ -133,7 +133,7 @@ public:
             _chunks.push_back(PipelineTestBase::_create_and_fill_chunk(chunk_size));
         }
     }
-    ~TestSourceOperator() {
+    ~TestSourceOperator() override {
         if (!_is_prepared) {
             ++lifecycle_error_num;
         }
@@ -184,7 +184,7 @@ public:
 
     bool has_output() const override { return _index < _chunks.size(); }
     bool is_finished() const override { return !has_output(); }
-    bool pending_finish() { return --_pending_finish_cnt >= 0; }
+    bool pending_finish() const override { return --_pending_finish_cnt >= 0; }
 
     Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override;
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
@@ -193,7 +193,7 @@ private:
     CounterPtr _counter;
     std::vector<vectorized::ChunkPtr> _chunks;
     size_t _index = 0;
-    std::atomic<int32_t> _pending_finish_cnt;
+    mutable std::atomic<int32_t> _pending_finish_cnt;
 
     bool _is_prepared = false;
     bool _is_finishing = false;


### PR DESCRIPTION
### Introduction
When the query is cancelled, exchange sink and result shouldn't send EOS. Otherwise, EOS from result sink may arrived at  FE earlier than cancel report, which causes FE returns success empty result to MySQL client instead of error result.

What's more, destructor of SinkBuffer shouldn't block and wait RPC to response, because SinkBuffer is destructed in the PipelineDispatcher thread, and ExchangeSource responses to SinkBuffer also in  the PipelineDispatcher thread, which causes dead lock.

Fix #1534 .

### Changes
- `ExchangeSinkOperator::close()` and `ResultSinkOperator::close()` don't send EOS when query is cancelled.
- In `DataStreamRecvr::SenderQueue::_add_chunks_internal()`, check `_is_cancelled` again before adding `closures` into `_pending_closures` , because the lock is released between checking `_is_cancelled` and adding `closures` into `_pending_closures`, where `_is_cancelled` may be changed by `PInternalServiceImpl::cancel_plan_fragment()`. The code is as follows.
- Add `pending_finish()` to base class `Operator`, and add override implementation to `ExchangeSinkOperator`. Don't wait RPC to response in `~SinkBuffer()`.
```C++
Status DataStreamRecvr::SenderQueue::_add_chunks_internal(const PTransmitChunkParams& request,
                                                          ::google::protobuf::Closure** done,
                                                          const std::function<void()>& cb) {
{
    std::unique_lock<std::mutex> l(_lock);
    if (_is_cancelled) {
        return Status::OK();
    }

    // Check RPC sequence, and deserialize _chunk_meta.
    // ....
}

/// `_is_cancelled` may be changed by `PInternalServiceImpl::cancel_plan_fragment()` here.
// Deserialize chunk from request.
// ...

{
    std::unique_lock<std::mutex> l(_lock);
    for (auto& pair : chunks) {
        _chunk_queue.emplace_back(std::move(pair));
    }
    // if done is nullptr, this function can't delay this response
    if (done != nullptr && _recvr->exceeds_limit(total_chunk_bytes)) {
        MonotonicStopWatch monotonicStopWatch;
        DCHECK(*done != nullptr);
        _pending_closures.emplace_back(*done, monotonicStopWatch);
        *done = nullptr;
    }
    _recvr->_num_buffered_bytes += total_chunk_bytes;
}

```