### PR TITLE
Fix Vectorized engine not support unknown child type cast

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/ArithmeticExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/ArithmeticExpr.java
@@ -355,10 +355,8 @@ public class ArithmeticExpr extends Expr {
     @Override
     protected void toThrift(TExprNode msg) {
         msg.node_type = TExprNodeType.ARITHMETIC_EXPR;
-        if (useVectorized || !type.getPrimitiveType().isDecimalOfAnyVersion()) {
-            msg.setOpcode(op.getOpcode());
-            msg.setOutput_column(outputColumn);
-        }
+        msg.setOpcode(op.getOpcode());
+        msg.setOutput_column(outputColumn);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/CastExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/CastExpr.java
@@ -186,13 +186,10 @@ public class CastExpr extends Expr {
         msg.node_type = TExprNodeType.CAST_EXPR;
         msg.setOpcode(opcode);
         msg.setOutput_column(outputColumn);
-        // vectorized engine all use cast-expression
-        if (this.useVectorized || (type.isNativeType() && getChild(0).getType().isNativeType())) {
-            if (getChild(0).getType().isComplexType()) {
-                msg.setChild_type_desc(getChild(0).getType().toThrift());
-            } else {
-                msg.setChild_type(getChild(0).getType().getPrimitiveType().toThrift());
-            }
+        if (getChild(0).getType().isComplexType()) {
+            msg.setChild_type_desc(getChild(0).getType().toThrift());
+        } else {
+            msg.setChild_type(getChild(0).getType().getPrimitiveType().toThrift());
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
@@ -504,7 +504,6 @@ public class HiveTable extends Table {
             tPartition.setFile_format(hivePartitions.get(i).getFormat().toThrift());
 
             List<LiteralExpr> keys = key.getKeys();
-            keys.forEach(v -> v.setUseVectorized(true));
             tPartition.setPartition_key_exprs(keys.stream().map(Expr::treeToThrift).collect(Collectors.toList()));
 
             THdfsPartitionLocation tPartitionLocation = new THdfsPartitionLocation();

--- a/fe/fe-core/src/main/java/com/starrocks/load/ExportJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/ExportJob.java
@@ -349,9 +349,6 @@ public class ExportJob implements Writable {
                 break;
         }
         fragment.setOutputExprs(createOutputExprs());
-        if (fragment.isOutPutExprsVectorized()) {
-            fragment.setOutPutExprsUseVectorized();
-        }
 
         scanNode.setFragmentId(fragment.getFragmentId());
         fragment.setSink(new ExportSink(exportTempPath, fileNamePrefix + taskIdx + "_", columnSeparator,

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadJob.java
@@ -968,7 +968,6 @@ public class SparkLoadJob extends BulkLoadJob {
                 destSidToSrcSidWithoutTrans.put(destSlotDesc.getId().asInt(), srcSlotDesc.getId().asInt());
                 Expr expr = new SlotRef(srcSlotDesc);
                 expr = castToSlot(destSlotDesc, expr);
-                expr.setUseVectorized(useVectorized);
                 params.putToExpr_of_dest_slot(destSlotDesc.getId().asInt(), expr.treeToThrift());
             }
             params.setDest_sid_to_src_sid_without_trans(destSidToSrcSidWithoutTrans);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
@@ -358,7 +358,6 @@ public class AggregationNode extends PlanNode {
                     // push down only when both of them are slot ref and slot id match.
                     if ((gexpr instanceof SlotRef) &&
                             (((SlotRef) gexpr).getSlotId().asInt() == ((SlotRef) probeExpr).getSlotId().asInt())) {
-                        gexpr.setUseVectorized(gexpr.isVectorized());
                         if (children.get(0).pushDownRuntimeFilters(description, gexpr)) {
                             return true;
                         }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DataPartition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DataPartition.java
@@ -126,19 +126,4 @@ public class DataPartition {
         str.append("\n");
         return str.toString();
     }
-
-    public void setUseVectorized(boolean flag) {
-        for (Expr expr : partitionExprs) {
-            expr.setUseVectorized(flag);
-        }
-    }
-
-    public boolean isVectorized() {
-        for (Expr expr : partitionExprs) {
-            if (!expr.isVectorized()) {
-                return false;
-            }
-        }
-        return true;
-    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/FileScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FileScanNode.java
@@ -339,16 +339,6 @@ public class FileScanNode extends LoadScanNode {
                 expr.analyze(analyzer);
             }
             expr = castToSlot(destSlotDesc, expr);
-
-            // check expr is vectorized or not.
-            if (useVectorizedLoad) {
-                if (!expr.isVectorized()) {
-                    useVectorizedLoad = false;
-                } else {
-                    expr.setUseVectorized(true);
-                }
-            }
-
             context.params.putToExpr_of_dest_slot(destSlotDesc.getId().asInt(), expr.treeToThrift());
         }
         context.params.setDest_sid_to_src_sid_without_trans(destSidToSrcSidWithoutTrans);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HashJoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HashJoinNode.java
@@ -170,7 +170,6 @@ public class HashJoinNode extends PlanNode {
             BinaryPredicate joinConjunct = eqJoinConjuncts.get(i);
             Preconditions.checkArgument(BinaryPredicate.IS_EQ_NULL_PREDICATE.apply(joinConjunct) ||
                     BinaryPredicate.IS_EQ_PREDICATE.apply(joinConjunct));
-            joinConjunct.setUseVectorized(joinConjunct.isVectorized());
             RuntimeFilterDescription rf = new RuntimeFilterDescription();
             rf.setFilterId(runtimeFilterIdIdGenerator.getNextId().asInt());
             rf.setBuildPlanNodeId(this.id.asInt());

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -431,25 +431,6 @@ public class PlanFragment extends TreeNode<PlanFragment> {
         return transferQueryStatisticsWithEveryBatch;
     }
 
-    public boolean isOutPutExprsVectorized() {
-        if (outputExprs != null) {
-            for (Expr expr : outputExprs) {
-                if (!expr.isVectorized()) {
-                    return false;
-                }
-            }
-        }
-        return true;
-    }
-
-    public void setOutPutExprsUseVectorized() {
-        if (outputExprs != null) {
-            for (Expr expr : outputExprs) {
-                expr.setUseVectorized(true);
-            }
-        }
-    }
-
     public void collectBuildRuntimeFilters(PlanNode root) {
         if (root instanceof ExchangeNode) {
             return;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ProjectNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ProjectNode.java
@@ -130,7 +130,6 @@ public class ProjectNode extends PlanNode {
                     // then replace probeExpr with kv.getValue()
                     // and push down kv.getValue()
                     if (probeExpr.isBound(kv.getKey())) {
-                        kv.getValue().setUseVectorized(kv.getValue().isVectorized());
                         if (children.get(0).pushDownRuntimeFilters(description, kv.getValue())) {
                             return true;
                         }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/SetOperationNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/SetOperationNode.java
@@ -452,7 +452,6 @@ public abstract class SetOperationNode extends PlanNode {
                 // try to push all children if any expr of a child can match `probeExpr`
                 for (Expr mexpr : materializedResultExprLists_.get(i)) {
                     if ((mexpr instanceof SlotRef) && mappedProbeSlotIds.contains(((SlotRef) mexpr).getSlotId().asInt())) {
-                        mexpr.setUseVectorized(mexpr.isVectorized());
                         if (children.get(i).pushDownRuntimeFilters(description, mexpr)) {
                             pushDown = true;
                         }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadScanNode.java
@@ -245,15 +245,6 @@ public class StreamLoadScanNode extends LoadScanNode {
             }
             expr = castToSlot(dstSlotDesc, expr);
 
-            // check expr is vectorized or not.
-            if (useVectorizedLoad) {
-                if (!expr.isVectorized()) {
-                    useVectorizedLoad = false;
-                } else {
-                    expr.setUseVectorized(true);
-                }
-            }
-
             brokerScanRange.params.putToExpr_of_dest_slot(dstSlotDesc.getId().asInt(), expr.treeToThrift());
         }
         brokerScanRange.params.setDest_sid_to_src_sid_without_trans(destSidToSrcSidWithoutTrans);

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithDecimalTypesNewPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithDecimalTypesNewPlannerTest.java
@@ -124,13 +124,13 @@ public class SelectStmtWithDecimalTypesNewPlannerTest {
         String sql = "select col_decimal128p20s3 * 3.14 from db1.decimal_table";
         String expectString = "TExprNode(node_type:ARITHMETIC_EXPR, type:TTypeDesc(types:[TTypeNode(type:SCALAR, " +
                 "scalar_type:TScalarType(type:DECIMAL128, precision:38, scale:5))]), opcode:MULTIPLY, num_children:2," +
-                " output_scale:-1, output_column:-1, use_vectorized:true, has_nullable_child:true, is_nullable:true, is_monotonic:true)," +
+                " output_scale:-1, output_column:-1, has_nullable_child:true, is_nullable:true, is_monotonic:true)," +
                 " TExprNode(node_type:SLOT_REF, type:TTypeDesc(types:[TTypeNode(type:SCALAR, scalar_type:TScalarType" +
                 "(type:DECIMAL128, precision:20, scale:3))]), num_children:0, slot_ref:TSlotRef(slot_id:3, tuple_id:0)," +
-                " output_scale:-1, output_column:-1, use_vectorized:true, has_nullable_child:false, is_nullable:true, is_monotonic:true)," +
+                " output_scale:-1, output_column:-1, has_nullable_child:false, is_nullable:true, is_monotonic:true)," +
                 " TExprNode(node_type:DECIMAL_LITERAL, type:TTypeDesc(types:[TTypeNode(type:SCALAR, scalar_type:" +
                 "TScalarType(type:DECIMAL128, precision:38, scale:2))]), num_children:0, decimal_literal:" +
-                "TDecimalLiteral(value:3.14), output_scale:-1, use_vectorized:true, has_nullable_child:false," +
+                "TDecimalLiteral(value:3.14), output_scale:-1, has_nullable_child:false," +
                 " is_nullable:false, is_monotonic:true)";
         String thrift = UtFrameUtils.getPlanThriftString(ctx, sql);
         Assert.assertTrue(thrift.contains(expectString));

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/LoadingTaskPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/LoadingTaskPlannerTest.java
@@ -306,7 +306,6 @@ public class LoadingTaskPlannerTest {
         TExprNode node = k1Expr.nodes.get(0);
         Assert.assertEquals(TExprNodeType.SLOT_REF, node.node_type);
         Assert.assertEquals(TPrimitiveType.TINYINT, node.type.types.get(0).scalar_type.type);
-        Assert.assertTrue(node.use_vectorized);
 
         // 2.2 check k2 from path
         TExpr k2Expr = exprOfDestSlot.get(1);
@@ -314,11 +313,9 @@ public class LoadingTaskPlannerTest {
         TExprNode castNode = k2Expr.nodes.get(0);
         Assert.assertEquals(TExprNodeType.CAST_EXPR, castNode.node_type);
         Assert.assertEquals(TPrimitiveType.INT, castNode.fn.ret_type.types.get(0).scalar_type.type);
-        Assert.assertTrue(castNode.use_vectorized);
         node = k2Expr.nodes.get(1);
         Assert.assertEquals(TExprNodeType.SLOT_REF, node.node_type);
         Assert.assertEquals(TPrimitiveType.VARCHAR, node.type.types.get(0).scalar_type.type);
-        Assert.assertTrue(node.use_vectorized);
 
         // 2.3 check k3 mapping
         TExpr k3Expr = exprOfDestSlot.get(2);
@@ -335,7 +332,6 @@ public class LoadingTaskPlannerTest {
         node = k3Expr.nodes.get(3);
         Assert.assertEquals(TExprNodeType.INT_LITERAL, node.node_type);
         Assert.assertEquals(5, node.int_literal.value);
-        Assert.assertTrue(node.use_vectorized);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/planner/HdfsScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/HdfsScanNodeTest.java
@@ -271,7 +271,6 @@ public class HdfsScanNodeTest {
         Assert.assertEquals(3, min.nodes.size());
         Assert.assertEquals(TExprNodeType.BINARY_PRED, min.nodes.get(0).node_type);
         Assert.assertEquals(TExprOpcode.GE, min.nodes.get(0).opcode);
-        Assert.assertTrue(min.nodes.get(0).use_vectorized);
         Assert.assertEquals(TExprNodeType.SLOT_REF, min.nodes.get(1).node_type);
         Assert.assertEquals(TExprNodeType.INT_LITERAL, min.nodes.get(2).node_type);
         Assert.assertEquals(2, min.nodes.get(2).int_literal.value);
@@ -280,7 +279,6 @@ public class HdfsScanNodeTest {
         Assert.assertEquals(3, max.nodes.size());
         Assert.assertEquals(TExprNodeType.BINARY_PRED, max.nodes.get(0).node_type);
         Assert.assertEquals(TExprOpcode.LE, max.nodes.get(0).opcode);
-        Assert.assertTrue(min.nodes.get(0).use_vectorized);
         Assert.assertEquals(TExprNodeType.SLOT_REF, max.nodes.get(1).node_type);
         Assert.assertEquals(TExprNodeType.INT_LITERAL, max.nodes.get(2).node_type);
         Assert.assertEquals(2, max.nodes.get(2).int_literal.value);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -1105,7 +1105,7 @@ public class PlanFragmentTest extends PlanTestBase {
                         + "(type:SCALAR, scalar_type:TScalarType(type:SMALLINT))]), num_children:0, "
                         + "int_literal:TIntLiteral"
                         + "(value:2), "
-                        + "output_scale:-1, use_vectorized:true, has_nullable_child:false, is_nullable:false, "
+                        + "output_scale:-1, has_nullable_child:false, is_nullable:false, "
                         + "is_monotonic:true)])]]"));
     }
 
@@ -1351,7 +1351,6 @@ public class PlanFragmentTest extends PlanTestBase {
         String sql = "select * from (select v1, v2 from t0) a join [shuffle] " +
                 "(select v4 from t1 limit 1) b on a.v1 = b.v4";
         String plan = getFragmentPlan(sql);
-        System.out.println(plan);
         Assert.assertTrue(plan.contains("join op: INNER JOIN (PARTITIONED)"));
     }
 
@@ -1360,7 +1359,6 @@ public class PlanFragmentTest extends PlanTestBase {
         String sql = "select * from (select v1, v2 from t0 limit 10) a join [shuffle] " +
                 "(select v4 from t1 ) b on a.v1 = b.v4";
         String plan = getFragmentPlan(sql);
-        System.out.println(plan);
         Assert.assertTrue(plan.contains("join op: INNER JOIN (PARTITIONED)"));
     }
 
@@ -1442,7 +1440,7 @@ public class PlanFragmentTest extends PlanTestBase {
         Assert.assertTrue(plan.contains(
                 "sort_tuple_slot_exprs:[TExpr(nodes:[TExprNode(node_type:SLOT_REF, type:TTypeDesc(types:[TTypeNode"
                         + "(type:SCALAR, scalar_type:TScalarType(type:BIGINT))]), num_children:0, slot_ref:TSlotRef"
-                        + "(slot_id:1, tuple_id:2), output_scale:-1, output_column:-1, use_vectorized:true, "
+                        + "(slot_id:1, tuple_id:2), output_scale:-1, output_column:-1, "
                         + "has_nullable_child:false, is_nullable:true, is_monotonic:true)])]"));
     }
 
@@ -1518,7 +1516,6 @@ public class PlanFragmentTest extends PlanTestBase {
     public void testJoinLimitLeft() throws Exception {
         String sql = "select * from t0 left outer join t1 on t0.v1 = t1.v4 limit 10";
         String plan = getFragmentPlan(sql);
-        System.out.println(plan);
         Assert.assertTrue(plan.contains("  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
                 "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
@@ -1561,7 +1558,6 @@ public class PlanFragmentTest extends PlanTestBase {
 
         sql = "select * from t0, t1 limit 10";
         plan = getFragmentPlan(sql);
-        System.out.println(plan);
         Assert.assertTrue(plan.contains("3:CROSS JOIN\n" +
                 "  |  cross join:\n" +
                 "  |  predicates is NULL.\n" +
@@ -1919,7 +1915,6 @@ public class PlanFragmentTest extends PlanTestBase {
     public void testCountDistinctWithSameMultiColumns() throws Exception {
         String sql = "select count(distinct t1b,t1c), count(distinct t1b,t1c) from test_all_type";
         String plan = getFragmentPlan(sql);
-        System.out.println(plan);
         Assert.assertTrue(plan.contains("6:AGGREGATE (merge finalize)"));
 
         sql = "select count(distinct t1b,t1c), count(distinct t1b,t1c) from test_all_type group by t1d";
@@ -2161,7 +2156,6 @@ public class PlanFragmentTest extends PlanTestBase {
         starRocksAssert.query(sql).explainContains("output: sum(1: id), bitmap_union_count(2: id2)");
 
         sql = "select count(distinct id2) from test.hll_table";
-        System.out.println(starRocksAssert.query(sql).explainQuery());
         starRocksAssert.query(sql).explainContains("hll_union_agg(2: id2)", "3: count");
 
         sql = "select sum(id) / count(distinct id2) from test.hll_table";
@@ -3666,7 +3660,6 @@ public class PlanFragmentTest extends PlanTestBase {
     public void testMultiCountDistinctType() throws Exception {
         String sql = "select count(distinct t1a,t1b) from test_all_type";
         String plan = getVerboseExplain(sql);
-        System.out.println(plan);
         Assert.assertTrue(plan.contains("3:AGGREGATE (update serialize)\n" +
                 "  |  aggregate: count[(if[(1: t1a IS NULL, NULL, [2: t1b, SMALLINT, true]); args: BOOLEAN,SMALLINT,SMALLINT; result: SMALLINT; args nullable: true; result nullable: true]); args: SMALLINT; result: BIGINT; args nullable: true; result nullable: false]"));
         Assert.assertTrue(plan.contains("5:AGGREGATE (merge finalize)\n" +
@@ -4287,7 +4280,6 @@ public class PlanFragmentTest extends PlanTestBase {
 
         String sql = "select value, SUM(id) from join1 group by value";
         String plan = getFragmentPlan(sql);
-        System.out.println(plan);
         Assert.assertTrue(plan.contains("  1:AGGREGATE (update finalize)\n" +
                 "  |  output: sum(2: id)\n" +
                 "  |  group by: 3: value\n" +


### PR DESCRIPTION
For https://github.com/StarRocks/starrocks/issues/1555

Seems https://github.com/StarRocks/starrocks/pull/1449 introduced this bug

In cast expr, the useVectorized is false, so BE report Vectorized engine not support unknown child type cast
```
        // vectorized engine all use cast-expression
        if (this.useVectorized || (type.isNativeType() && getChild(0).getType().isNativeType())) {
            if (getChild(0).getType().isComplexType()) {
                msg.setChild_type_desc(getChild(0).getType().toThrift());
            } else {
                msg.setChild_type(getChild(0).getType().getPrimitiveType().toThrift());
            }
```