### PR TITLE
SinkBuffer optimization by removing waiting logic of rpc task

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -639,7 +639,7 @@ CONF_Int64(pipeline_scan_thread_pool_thread_num, "0");
 // queue size of scan thread pool for pipeline engine.
 CONF_Int64(pipeline_scan_thread_pool_queue_size, "102400");
 // the number of exchange threads pipeline engine.
-CONF_Int64(pipeline_exchange_thread_pool_thread_num, "0");
+CONF_Int64(pipeline_exchange_thread_pool_thread_num, "2");
 // queue size of exchange thread pool for pipeline engine.
 CONF_Int64(pipeline_exchange_thread_pool_queue_size, "102400");
 // the number of execution threads for pipeline engine.

--- a/be/src/util/callback_closure.h
+++ b/be/src/util/callback_closure.h
@@ -31,7 +31,7 @@
 namespace starrocks {
 
 // RefCountClosure with call back
-template <typename T>
+template <typename T, typename C = void>
 class CallBackClosure : public google::protobuf::Closure {
 public:
     CallBackClosure() : _refs(0) {}
@@ -50,6 +50,9 @@ public:
 
     void addFailedHandler(std::function<void()> fn) { _failed_handler = std::move(fn); }
     void addSuccessHandler(std::function<void(const T&)> fn) { _success_handler = fn; }
+    void set_context(const C& ctx) { _ctx = ctx; }
+    C& context() { return _ctx; }
+    const C& context() const { return _ctx; }
 
     void Run() noexcept override {
         try {
@@ -77,5 +80,6 @@ private:
     std::atomic<int> _refs;
     std::function<void()> _failed_handler;
     std::function<void(const T&)> _success_handler;
+    C _ctx;
 };
 } // namespace starrocks


### PR DESCRIPTION
**Before Optomize**

* At any moment, each SinkBuffer has at most one active rpc task, and this rpc task will not exit if buffer is not empty, which means that if closure is busy, the rpc task will wait for the closure to be finished.
* In high concurrency scenarios, these rpc task will monopolize the execution thread, which may cause other SinkBuffers to starve

**After Optimize**

* Introduce a queue of events, include two type of event
    1. new request arriving
    2. channel becomes ready
* Allow each SinkBuffer still has at most one active rpc task, but this rpc task will exit if event queue is empty
* Reduce exchange thread pool size from hard core size to 4, which means less threads can support the same scale of concurrency

**Test Info**

* 1 fe and 3 be
    * 64c/128g
    * fe mixed with one of be
* ssb test set
    * scale factor: 100
* test sqls and command are as follows

```sh
mysqlslap -u root -psr -h 1.1.1.1 -P 9999 -c 64 --number-of-queries 128 -i 10 --create-schema=ssb --query="<sql>";
```

```sql
-- Q1
SELECT SUM(lo_quantity) FROM lineorder_flat;
```

**Test Result**

---

| Q1 | -c 64 --number-of-queries 128 -i 10 | -c 128 --number-of-queries 256 -i 10 |
|:--|:--|:--|
| pipeline_exchange_thread_pool_thread_num=1 | before: 3.005s</br>after: 2.927s</br> rate: 102.7% | before: 6.168s</br>after: 6.010s</br> rate: 102.6% |
| pipeline_exchange_thread_pool_thread_num=2 | before: 2.848s</br>after: 2.796s</br> rate: 101.9% | before: 5.851s</br>after: 5.876s</br> rate: 99.6% |
| pipeline_exchange_thread_pool_thread_num=4 | before: 2.800s</br>after: 2.797s</br> rate: 100.1% | before: 5.904s</br>after: 5.882s</br> rate: 100.4% |
| pipeline_exchange_thread_pool_thread_num=8 | before: 2.914s</br>after: 2.893s</br> rate: 100.7% | before: 5.997s</br>after: 5.978s</br> rate: 100.3% |
| pipeline_exchange_thread_pool_thread_num=16 | before: 2.954s</br>after: 2.891s</br> rate: 102.2% | before: 6.075s</br>after: 5.955s</br> rate: 102.0% |
| pipeline_exchange_thread_pool_thread_num=32 | before: 2.987s</br>after: 2.886s</br> rate: 103.5% | before: 6.242s</br>after: 6.023s</br> rate: 103.6% |
| pipeline_exchange_thread_pool_thread_num=64 | before: 2.982s</br>after: 2.860s</br> rate: 104.3% | before: 6.189s</br>after: 5.914s</br> rate: 104.6% |


**Conclusion**

1. The optimization effect is not that significant, it can improve the performance of about 1-5% in the case of concurrency
2. As the number of thread pools increases, performance remains basically unchanged at the current scale of concurrency. So the recommended thread num can be set to 2 considering the resource utilization efficiency
