### PR TITLE
Check resource is null or not when show resources command is executing

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceMgr.java
@@ -144,9 +144,11 @@ public class ResourceMgr implements Writable {
 
             for (Map.Entry<String, Resource> entry : nameToResource.entrySet()) {
                 Resource resource = entry.getValue();
-                // check resource privs
-                if (!Catalog.getCurrentCatalog().getAuth().checkResourcePriv(ConnectContext.get(), resource.getName(),
-                        PrivPredicate.SHOW)) {
+                // Since nameToResource.entrySet is not thread safe, resource may be dropped
+                // during show resources.So that We should do a null pointer check here.
+                // If resource is not null then we should check resource privs.
+                if (resource == null || !Catalog.getCurrentCatalog().getAuth().checkResourcePriv(
+                        ConnectContext.get(), resource.getName(), PrivPredicate.SHOW)) {
                     continue;
                 }
                 resource.getProcNodeData(result);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceMgr.java
@@ -145,7 +145,7 @@ public class ResourceMgr implements Writable {
             for (Map.Entry<String, Resource> entry : nameToResource.entrySet()) {
                 Resource resource = entry.getValue();
                 // Since `nameToResource.entrySet` may change after it is called, resource
-                // may be dropped during `show resources`.So that We should do a null pointer
+                // may be dropped during `show resources`.So that we should do a null pointer
                 // check here. If resource is not null then we should check resource privs.
                 if (resource == null || !Catalog.getCurrentCatalog().getAuth().checkResourcePriv(
                         ConnectContext.get(), resource.getName(), PrivPredicate.SHOW)) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceMgr.java
@@ -144,9 +144,9 @@ public class ResourceMgr implements Writable {
 
             for (Map.Entry<String, Resource> entry : nameToResource.entrySet()) {
                 Resource resource = entry.getValue();
-                // Since nameToResource.entrySet is not thread safe, resource may be dropped
-                // during show resources.So that We should do a null pointer check here.
-                // If resource is not null then we should check resource privs.
+                // Since `nameToResource.entrySet` may chang after it is called, resource
+                // may be dropped during `show resources`.So that We should do a null pointer
+                // check here. If resource is not null then we should check resource privs.
                 if (resource == null || !Catalog.getCurrentCatalog().getAuth().checkResourcePriv(
                         ConnectContext.get(), resource.getName(), PrivPredicate.SHOW)) {
                     continue;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceMgr.java
@@ -144,7 +144,7 @@ public class ResourceMgr implements Writable {
 
             for (Map.Entry<String, Resource> entry : nameToResource.entrySet()) {
                 Resource resource = entry.getValue();
-                // Since `nameToResource.entrySet` may chang after it is called, resource
+                // Since `nameToResource.entrySet` may change after it is called, resource
                 // may be dropped during `show resources`.So that We should do a null pointer
                 // check here. If resource is not null then we should check resource privs.
                 if (resource == null || !Catalog.getCurrentCatalog().getAuth().checkResourcePriv(


### PR DESCRIPTION
Ignore the resource which was dropped during 'show resources' to fix npe exception.
```
2021-11-24 15:35:16,936 WARN (starrocks-mysql-nio-pool-152|8584) [StmtExecutor.execute():454] execute Exception, sql show resources
java.lang.NullPointerException: null
        at com.starrocks.catalog.ResourceMgr$ResourceProcNode.fetchResult(ResourceMgr.java:154) ~[starrocks-fe.jar:?]
        at com.starrocks.catalog.ResourceMgr.getResourcesInfo(ResourceMgr.java:127) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ShowExecutor.handleShowResources(ShowExecutor.java:1234) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ShowExecutor.execute(ShowExecutor.java:225) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.StmtExecutor.handleShow(StmtExecutor.java:1169) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:425) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:248) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.dispatch(ConnectProcessor.java:397) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.processOnce(ConnectProcessor.java:633) ~[starrocks-fe.jar:
```