### PR TITLE
load index lazily to reduce the first I/O time of queries

### DIFF
--- a/be/src/storage/rowset/segment_v2/column_reader.cpp
+++ b/be/src/storage/rowset/segment_v2/column_reader.cpp
@@ -517,24 +517,21 @@ Status ColumnReader::new_iterator(ColumnIterator** iterator) {
 
 Status ColumnReader::_load_zone_map_index_once() {
     Status status = _zonemap_index_once.call([this] {
-        RETURN_IF_ERROR(_load_zone_map_index(!config::disable_storage_page_cache, _opts.kept_in_memory));
-        return Status::OK();
+        return _load_zone_map_index(!config::disable_storage_page_cache, _opts.kept_in_memory);
     });
     return status;
 }
 
 Status ColumnReader::_load_bitmap_index_once() {
     Status status = _bitmap_index_once.call([this] {
-        RETURN_IF_ERROR(_load_bitmap_index(!config::disable_storage_page_cache, _opts.kept_in_memory));
-        return Status::OK();
+        return _load_bitmap_index(!config::disable_storage_page_cache, _opts.kept_in_memory);
     });
     return status;
 }
 
 Status ColumnReader::_load_bloom_filter_index_once() {
     Status status = _bloomfilter_index_once.call([this] {
-        RETURN_IF_ERROR(_load_bloom_filter_index(!config::disable_storage_page_cache, _opts.kept_in_memory));
-        return Status::OK();
+        return _load_bloom_filter_index(!config::disable_storage_page_cache, _opts.kept_in_memory);
     });
     return status;
 }
@@ -543,9 +540,7 @@ Status ColumnReader::load_ordinal_index_once() {
     // Only load ordinal index.
     // Other indexes like zone map/bitmap/bloomfilter should be load when necessary
     Status status = _ordinal_index_once.call([this] {
-        bool use_page_cache = !config::disable_storage_page_cache;
-        RETURN_IF_ERROR(_load_ordinal_index(use_page_cache, _opts.kept_in_memory));
-        return Status::OK();
+        return _load_ordinal_index(!config::disable_storage_page_cache, _opts.kept_in_memory);
     });
     return status;
 }

--- a/be/src/storage/rowset/segment_v2/column_reader.cpp
+++ b/be/src/storage/rowset/segment_v2/column_reader.cpp
@@ -197,6 +197,7 @@ Status ColumnReader::read_page(const ColumnIteratorOptions& iter_opts, const Pag
 Status ColumnReader::get_row_ranges_by_zone_map(CondColumn* cond_column, CondColumn* delete_condition,
                                                 std::unordered_set<uint32_t>* delete_partial_filtered_pages,
                                                 RowRanges* row_ranges) {
+    RETURN_IF_ERROR(_load_zone_map_index_once());
     std::vector<uint32_t> page_indexes;
     RETURN_IF_ERROR(_get_filtered_pages(cond_column, delete_condition, delete_partial_filtered_pages, &page_indexes));
     RETURN_IF_ERROR(_calculate_row_ranges(page_indexes, row_ranges));

--- a/be/src/storage/rowset/segment_v2/column_reader.cpp
+++ b/be/src/storage/rowset/segment_v2/column_reader.cpp
@@ -516,32 +516,28 @@ Status ColumnReader::new_iterator(ColumnIterator** iterator) {
 }
 
 Status ColumnReader::_load_zone_map_index_once() {
-    Status status = _zonemap_index_once.call([this] {
-        return _load_zone_map_index(!config::disable_storage_page_cache, _opts.kept_in_memory);
-    });
+    Status status = _zonemap_index_once.call(
+            [this] { return _load_zone_map_index(!config::disable_storage_page_cache, _opts.kept_in_memory); });
     return status;
 }
 
 Status ColumnReader::_load_bitmap_index_once() {
-    Status status = _bitmap_index_once.call([this] {
-        return _load_bitmap_index(!config::disable_storage_page_cache, _opts.kept_in_memory);
-    });
+    Status status = _bitmap_index_once.call(
+            [this] { return _load_bitmap_index(!config::disable_storage_page_cache, _opts.kept_in_memory); });
     return status;
 }
 
 Status ColumnReader::_load_bloom_filter_index_once() {
-    Status status = _bloomfilter_index_once.call([this] {
-        return _load_bloom_filter_index(!config::disable_storage_page_cache, _opts.kept_in_memory);
-    });
+    Status status = _bloomfilter_index_once.call(
+            [this] { return _load_bloom_filter_index(!config::disable_storage_page_cache, _opts.kept_in_memory); });
     return status;
 }
 
 Status ColumnReader::load_ordinal_index_once() {
     // Only load ordinal index.
     // Other indexes like zone map/bitmap/bloomfilter should be load when necessary
-    Status status = _ordinal_index_once.call([this] {
-        return _load_ordinal_index(!config::disable_storage_page_cache, _opts.kept_in_memory);
-    });
+    Status status = _ordinal_index_once.call(
+            [this] { return _load_ordinal_index(!config::disable_storage_page_cache, _opts.kept_in_memory); });
     return status;
 }
 

--- a/be/src/storage/rowset/segment_v2/column_reader.cpp
+++ b/be/src/storage/rowset/segment_v2/column_reader.cpp
@@ -538,8 +538,7 @@ Status ColumnReader::_load_bloom_filter_index_once() {
     return status;
 }
 
-
-Status ColumnReader::ensure_index_loaded() {
+Status ColumnReader::load_ordinal_index_once() {
     // Only load ordinal index.
     // Other indexes like zone map/bitmap/bloomfilter should be load when necessary
     Status status = _ordinal_index_once.call([this] {

--- a/be/src/storage/rowset/segment_v2/column_reader.cpp
+++ b/be/src/storage/rowset/segment_v2/column_reader.cpp
@@ -174,6 +174,7 @@ Status ColumnReader::_init(ColumnMetaPB* meta) {
 }
 
 Status ColumnReader::new_bitmap_index_iterator(BitmapIndexIterator** iterator) {
+    RETURN_IF_ERROR(_load_bitmap_index_once());
     RETURN_IF_ERROR(_bitmap_index.reader->new_iterator(iterator));
     return Status::OK();
 }
@@ -308,6 +309,7 @@ Status ColumnReader::_calculate_row_ranges(const std::vector<uint32_t>& page_ind
 }
 
 Status ColumnReader::get_row_ranges_by_bloom_filter(CondColumn* cond_column, RowRanges* row_ranges) {
+    RETURN_IF_ERROR(_load_bloom_filter_index_once());
     RowRanges bf_row_ranges;
     std::unique_ptr<BloomFilterIndexIterator> bf_iter;
     RETURN_IF_ERROR(_bloom_filter_index.reader->new_iterator(&bf_iter));
@@ -340,6 +342,7 @@ Status ColumnReader::get_row_ranges_by_bloom_filter(CondColumn* cond_column, Row
 // prerequisite: at least one predicate in |predicates| support bloom filter.
 Status ColumnReader::bloom_filter(const std::vector<const vectorized::ColumnPredicate*>& predicates,
                                   vectorized::SparseRange* row_ranges) {
+    RETURN_IF_ERROR(_load_bloom_filter_index_once());
     vectorized::SparseRange bf_row_ranges;
     std::unique_ptr<BloomFilterIndexIterator> bf_iter;
     RETURN_IF_ERROR(_bloom_filter_index.reader->new_iterator(&bf_iter));
@@ -441,6 +444,7 @@ Status ColumnReader::zone_map_filter(const std::vector<const vectorized::ColumnP
                                      const vectorized::ColumnPredicate* del_predicate,
                                      std::unordered_set<uint32_t>* del_partial_filtered_pages,
                                      vectorized::SparseRange* row_ranges) {
+    RETURN_IF_ERROR(_load_zone_map_index_once());
     std::vector<uint32_t> page_indexes;
     RETURN_IF_ERROR(_zone_map_filter(predicates, del_predicate, del_partial_filtered_pages, &page_indexes));
     RETURN_IF_ERROR(_calculate_row_ranges(page_indexes, row_ranges));
@@ -510,24 +514,39 @@ Status ColumnReader::new_iterator(ColumnIterator** iterator) {
     }
 }
 
-Status ColumnReader::ensure_index_loaded(ReaderType reader_type) {
-    Status status = _load_ordinal_index_once.call([this] {
+Status ColumnReader::_load_zone_map_index_once() {
+    Status status = _zonemap_index_once.call([this] {
+        RETURN_IF_ERROR(_load_zone_map_index(!config::disable_storage_page_cache, _opts.kept_in_memory));
+        return Status::OK();
+    });
+    return status;
+}
+
+Status ColumnReader::_load_bitmap_index_once() {
+    Status status = _bitmap_index_once.call([this] {
+        RETURN_IF_ERROR(_load_bitmap_index(!config::disable_storage_page_cache, _opts.kept_in_memory));
+        return Status::OK();
+    });
+    return status;
+}
+
+Status ColumnReader::_load_bloom_filter_index_once() {
+    Status status = _bloomfilter_index_once.call([this] {
+        RETURN_IF_ERROR(_load_bloom_filter_index(!config::disable_storage_page_cache, _opts.kept_in_memory));
+        return Status::OK();
+    });
+    return status;
+}
+
+
+Status ColumnReader::ensure_index_loaded() {
+    // Only load ordinal index.
+    // Other indexes like zone map/bitmap/bloomfilter should be load when necessary
+    Status status = _ordinal_index_once.call([this] {
         bool use_page_cache = !config::disable_storage_page_cache;
         RETURN_IF_ERROR(_load_ordinal_index(use_page_cache, _opts.kept_in_memory));
         return Status::OK();
     });
-    RETURN_IF_ERROR(status);
-
-    if (is_query(reader_type)) {
-        status = _load_indices_once.call([this] {
-            // ZoneMap, Bitmap, BloomFilter is only necessary for query.
-            bool use_page_cache = !config::disable_storage_page_cache;
-            RETURN_IF_ERROR(_load_zone_map_index(use_page_cache, _opts.kept_in_memory));
-            RETURN_IF_ERROR(_load_bitmap_index(use_page_cache, _opts.kept_in_memory));
-            RETURN_IF_ERROR(_load_bloom_filter_index(use_page_cache, _opts.kept_in_memory));
-            return Status::OK();
-        });
-    }
     return status;
 }
 

--- a/be/src/storage/rowset/segment_v2/column_reader.h
+++ b/be/src/storage/rowset/segment_v2/column_reader.h
@@ -177,9 +177,7 @@ public:
 
     uint32_t version() const { return _opts.storage_format_version; }
 
-    // Read and load necessary column indexes into memory if it hasn't been loaded.
-    // May be called multiple times, subsequent calls will no op.
-    Status ensure_index_loaded();
+    Status load_ordinal_index_once();
 
 private:
     struct private_type {

--- a/be/src/storage/rowset/segment_v2/column_reader.h
+++ b/be/src/storage/rowset/segment_v2/column_reader.h
@@ -179,7 +179,7 @@ public:
 
     // Read and load necessary column indexes into memory if it hasn't been loaded.
     // May be called multiple times, subsequent calls will no op.
-    Status ensure_index_loaded(ReaderType reader_type);
+    Status ensure_index_loaded();
 
 private:
     struct private_type {
@@ -212,6 +212,10 @@ private:
     void operator=(ColumnReader&&) = delete;
 
     Status _init(ColumnMetaPB* meta);
+
+    Status _load_zone_map_index_once();
+    Status _load_bitmap_index_once();
+    Status _load_bloom_filter_index_once();
 
     Status _load_zone_map_index(bool use_page_cache, bool kept_in_memory);
     Status _load_ordinal_index(bool use_page_cache, bool kept_in_memory);
@@ -266,8 +270,10 @@ private:
     // The ordinal index must be loaded before read operation.
     // zonemap, bitmap, bloomfilter is only necessary for query.
     // the other operations can not load these indices.
-    StarRocksCallOnce<Status> _load_ordinal_index_once;
-    StarRocksCallOnce<Status> _load_indices_once;
+    StarRocksCallOnce<Status> _ordinal_index_once;
+    StarRocksCallOnce<Status> _zonemap_index_once;
+    StarRocksCallOnce<Status> _bitmap_index_once;
+    StarRocksCallOnce<Status> _bloomfilter_index_once;
 
     std::bitset<16> _flags;
 };

--- a/be/src/storage/rowset/segment_v2/scalar_column_iterator.cpp
+++ b/be/src/storage/rowset/segment_v2/scalar_column_iterator.cpp
@@ -36,7 +36,7 @@ ScalarColumnIterator::~ScalarColumnIterator() = default;
 
 Status ScalarColumnIterator::init(const ColumnIteratorOptions& opts) {
     _opts = opts;
-    RETURN_IF_ERROR(_reader->ensure_index_loaded(_opts.reader_type));
+    RETURN_IF_ERROR(_reader->ensure_index_loaded());
     _opts.stats->total_columns_data_page_count += _reader->num_data_pages();
 
     if (_reader->encoding_info()->encoding() != DICT_ENCODING) {

--- a/be/src/storage/rowset/segment_v2/scalar_column_iterator.cpp
+++ b/be/src/storage/rowset/segment_v2/scalar_column_iterator.cpp
@@ -36,7 +36,7 @@ ScalarColumnIterator::~ScalarColumnIterator() = default;
 
 Status ScalarColumnIterator::init(const ColumnIteratorOptions& opts) {
     _opts = opts;
-    RETURN_IF_ERROR(_reader->ensure_index_loaded());
+    RETURN_IF_ERROR(_reader->load_ordinal_index_once());
     _opts.stats->total_columns_data_page_count += _reader->num_data_pages();
 
     if (_reader->encoding_info()->encoding() != DICT_ENCODING) {

--- a/be/src/storage/rowset/vectorized/segment_iterator.cpp
+++ b/be/src/storage/rowset/vectorized/segment_iterator.cpp
@@ -349,6 +349,7 @@ Status SegmentIterator::_init_column_iterators(const Schema& schema) {
             iter_opts.use_page_cache = _opts.use_page_cache;
             iter_opts.rblock = _rblock.get();
             iter_opts.check_dict_encoding = check_dict_enc;
+            iter_opts.reader_type = _opts.reader_type;
             RETURN_IF_ERROR(_column_iterators[cid]->init(iter_opts));
 
             // we have a global dict map but column was not encode by dict


### PR DESCRIPTION
When reading column data, all the indexes of column will be loaded, no matter whether they are used or not. But reading index will incur random I/O, which will hurt first-time reading performance.
So we can just load the necessary indexes to improve the first-time reading performance.
I use the Query 2.1 of SSB 100G data set to test performance, it indicate that the latency can be reduced about 200ms of 4300ms when loading zone-map index of three columns.