### PR TITLE
bug fix: aggregateStreamingnode->get_next not init chunk, make invali…

### DIFF
--- a/be/src/exec/vectorized/aggregate/aggregate_streaming_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_streaming_node.cpp
@@ -37,6 +37,10 @@ Status AggregateStreamingNode::get_next(RuntimeState* state, ChunkPtr* chunk, bo
         return Status::OK();
     }
 
+    if (*chunk != nullptr) {
+        (*chunk)->reset();
+    }
+
     // TODO: merge small chunks to large chunk for optimization
     while (!_child_eos) {
         ChunkPtr input_chunk;


### PR DESCRIPTION
when streamingPreaggregationMode = auto

the sql like below return different results
`select count(*), sum(id_decimal_rt) from (select sum(id_decimal) id_decimal_rt, id_char id_char_rt from test_basic_decimal_8 group by id_char) a;`