### PR TITLE
Fix str_to_date return date throw error type

### DIFF
--- a/be/src/exprs/vectorized/time_functions.cpp
+++ b/be/src/exprs/vectorized/time_functions.cpp
@@ -1125,6 +1125,15 @@ Status TimeFunctions::str_to_date_close(starrocks_udf::FunctionContext* context,
     return Status::OK();
 }
 
+DEFINE_UNARY_FN_WITH_IMPL(TimestampToDate, value) {
+    return DateValue{timestamp::to_julian(value._timestamp)};
+}
+
+ColumnPtr TimeFunctions::str2date(FunctionContext* context, const Columns& columns) {
+    ColumnPtr datetime = str_to_date(context, columns);
+    return VectorizedStrictUnaryFunction<TimestampToDate>::evaluate<TYPE_DATETIME, TYPE_DATE>(datetime);
+}
+
 Status TimeFunctions::format_prepare(starrocks_udf::FunctionContext* context,
                                      starrocks_udf::FunctionContext::FunctionStateScope scope) {
     if (scope != FunctionContext::FRAGMENT_LOCAL) {

--- a/be/src/exprs/vectorized/time_functions.h
+++ b/be/src/exprs/vectorized/time_functions.h
@@ -364,11 +364,19 @@ public:
     static ColumnPtr str_to_date_uncommon(FunctionContext* context, const starrocks::vectorized::Columns& columns);
     /**
      *
+     * cast string to datetime
      * @param context
      * @param columns [BinaryColumn of TYPE_VARCHAR, BinaryColumn of TYPE_VARCHAR]  The first column holds the datetime string, the second column holds the format.
      * @return  TimestampColumn
      */
     DEFINE_VECTORIZED_FN(str_to_date);
+
+    /** 
+     * 
+     * cast string to date, the function will call by FE getStrToDateFunction, and is invisible to user
+     * 
+     */
+    DEFINE_VECTORIZED_FN(str2date);
 
     static bool is_date_format(const Slice& slice, char** start);
     static bool is_datetime_format(const Slice& slice, char** start);

--- a/be/test/exprs/vectorized/time_functions_test.cpp
+++ b/be/test/exprs/vectorized/time_functions_test.cpp
@@ -2023,5 +2023,158 @@ TEST_F(TimeFunctionsTest, dateTruncTest) {
     }
 }
 
+TEST_F(TimeFunctionsTest, str2date) {
+    FunctionContext* ctx = FunctionContext::create_test_context();
+    auto ptr = std::unique_ptr<FunctionContext>(ctx);
+
+    const char* str1 = "01,5,2013";
+    const char* str2 = "2020-06-24 17:10:25";
+    const char* fmt1 = "%d,%m,%Y";
+    const char* fmt2 = "%Y-%m-%d %H:%i:%s";
+    DateValue ts1 = DateValue::create(2013, 5, 1);
+    DateValue ts2 = DateValue::create(2020, 6, 24);
+
+    const auto& varchar_type_desc = TypeDescriptor::create_varchar_type(TypeDescriptor::MAX_VARCHAR_LENGTH);
+    // nullable
+    {
+        auto str_col = ColumnHelper::create_column(varchar_type_desc, true);
+        auto fmt_col = ColumnHelper::create_column(varchar_type_desc, true);
+        str_col->append_datum(Slice(str1)); // str1 <=> fmt1
+        fmt_col->append_datum(Slice(fmt1));
+        str_col->append_datum(Slice(str2)); // str2 <=> fmt2
+        fmt_col->append_datum(Slice(fmt2));
+        (void)str_col->append_nulls(1); // null <=> fmt1
+        fmt_col->append_datum(Slice(fmt1));
+        str_col->append_datum(Slice(str1)); // str1 <=> null
+        (void)fmt_col->append_nulls(1);
+        (void)str_col->append_nulls(1); // null <=> null
+        (void)fmt_col->append_nulls(1);
+
+        Columns columns;
+        columns.emplace_back(str_col);
+        columns.emplace_back(fmt_col);
+        ColumnPtr result = TimeFunctions::str2date(ctx, columns);
+        ASSERT_TRUE(result->is_nullable());
+
+        NullableColumn::Ptr nullable_col = ColumnHelper::as_column<NullableColumn>(result);
+        ASSERT_EQ(5, nullable_col->size());
+        ASSERT_EQ(ts1, nullable_col->get(0).get_date());
+        ASSERT_EQ(ts2, nullable_col->get(1).get_date());
+        for (int i = 2; i < 5; ++i) {
+            ASSERT_TRUE(nullable_col->is_null(i));
+        }
+    }
+    // const
+    {
+        auto str_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(str1, 1);
+        auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(fmt1, 1);
+        Columns columns;
+        columns.emplace_back(str_col);
+        columns.emplace_back(fmt_col);
+        ColumnPtr result = TimeFunctions::str2date(ctx, columns);
+        ASSERT_TRUE(result->is_constant());
+
+        ConstColumn::Ptr const_col = ColumnHelper::as_column<ConstColumn>(result);
+        ASSERT_FALSE(const_col->is_date());
+        ASSERT_EQ(1, const_col->size());
+        ASSERT_EQ(ts1, const_col->get(0).get_date());
+    }
+    // const <=> non-const
+    {
+        auto str_col = ColumnHelper::create_column(varchar_type_desc, true);
+        auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(fmt1, 1);
+        str_col->append_datum(Slice(str1));
+        (void)str_col->append_nulls(1);
+        str_col->append_datum(Slice("25,06,2020"));
+
+        Columns columns;
+        columns.emplace_back(str_col);
+        columns.emplace_back(fmt_col);
+
+        ColumnPtr result = TimeFunctions::str2date(ctx, columns);
+        ASSERT_TRUE(result->is_nullable());
+
+        NullableColumn::Ptr nullable_col = ColumnHelper::as_column<NullableColumn>(result);
+        ASSERT_EQ(3, nullable_col->size());
+        ASSERT_EQ(ts1, nullable_col->get(0).get_date());
+        ASSERT_TRUE(nullable_col->is_null(1));
+        ASSERT_EQ(DateValue::create(2020, 6, 25), nullable_col->get(2).get_date());
+    }
+}
+
+TEST_F(TimeFunctionsTest, str2date_of_dateformat) {
+    FunctionContext* ctx = FunctionContext::create_test_context();
+    auto ptr = std::unique_ptr<FunctionContext>(ctx);
+
+    const char* str1 = "2013-05-01";
+    const char* fmt1 = "%Y-%m-%d";
+    DateValue ts1 = DateValue::create(2013, 5, 1);
+    const auto& varchar_type_desc = TypeDescriptor::create_varchar_type(TypeDescriptor::MAX_VARCHAR_LENGTH);
+    // const <=> non-const
+    {
+        auto str_col = ColumnHelper::create_column(varchar_type_desc, true);
+        auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(fmt1, 1);
+        str_col->append_datum(Slice(str1));
+        (void)str_col->append_nulls(1);
+        str_col->append_datum(Slice("2020-06-25"));
+        str_col->append_datum(Slice("     2020-03-12"));
+        str_col->append_datum(Slice("   2020-03-12    11:35:23  "));
+        str_col->append_datum(Slice("   2020-0  "));
+
+        Columns columns;
+        columns.emplace_back(str_col);
+        columns.emplace_back(fmt_col);
+
+        ColumnPtr result = TimeFunctions::str2date(ctx, columns);
+        ASSERT_TRUE(result->is_nullable());
+
+        NullableColumn::Ptr nullable_col = ColumnHelper::as_column<NullableColumn>(result);
+
+        ASSERT_EQ(ts1, nullable_col->get(0).get_date());
+        ASSERT_TRUE(nullable_col->is_null(1));
+        ASSERT_EQ(DateValue::create(2020, 6, 25), nullable_col->get(2).get_date());
+        ASSERT_EQ(DateValue::create(2020, 3, 12), nullable_col->get(3).get_date());
+        ASSERT_EQ(DateValue::create(2020, 3, 12), nullable_col->get(4).get_date());
+        ASSERT_TRUE(nullable_col->is_null(5));
+    }
+}
+
+TEST_F(TimeFunctionsTest, str2date_of_datetimeformat) {
+    FunctionContext* ctx = FunctionContext::create_test_context();
+    auto ptr = std::unique_ptr<FunctionContext>(ctx);
+
+    const char* str1 = "2013-05-01 11:12:13";
+    const char* fmt1 = "%Y-%m-%d %H:%i:%s";
+    DateValue ts1 = DateValue::create(2013, 5, 1);
+    [[maybe_unused]] DateValue ts2 = DateValue::create(2020, 6, 24);
+    const auto& varchar_type_desc = TypeDescriptor::create_varchar_type(TypeDescriptor::MAX_VARCHAR_LENGTH);
+    // const <=> non-const
+    {
+        auto str_col = ColumnHelper::create_column(varchar_type_desc, true);
+        auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(fmt1, 1);
+        str_col->append_datum(Slice(str1));
+        (void)str_col->append_nulls(1);
+        str_col->append_datum(Slice("2020-06-25 12:05:39"));
+        str_col->append_datum(Slice("     2020-03-12 08:19:39"));
+        str_col->append_datum(Slice("   2020-03-12    11:35:23  "));
+        str_col->append_datum(Slice("   2020-03-12    11:  "));
+
+        Columns columns;
+        columns.emplace_back(str_col);
+        columns.emplace_back(fmt_col);
+
+        ColumnPtr result = TimeFunctions::str2date(ctx, columns);
+        ASSERT_TRUE(result->is_nullable());
+
+        NullableColumn::Ptr nullable_col = ColumnHelper::as_column<NullableColumn>(result);
+
+        ASSERT_EQ(ts1, nullable_col->get(0).get_date());
+        ASSERT_TRUE(nullable_col->is_null(1));
+        ASSERT_EQ(DateValue::create(2020, 6, 25), nullable_col->get(2).get_date());
+        ASSERT_EQ(DateValue::create(2020, 3, 12), nullable_col->get(3).get_date());
+        ASSERT_EQ(DateValue::create(2020, 3, 12), nullable_col->get(4).get_date());
+        ASSERT_EQ(DateValue::create(2020, 3, 12), nullable_col->get(5).get_date());
+    }
+}
 } // namespace vectorized
 } // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -60,7 +60,11 @@ import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.common.TypeManager;
 import com.starrocks.sql.common.UnsupportedException;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.transformer.ExpressionMapping;
+import com.starrocks.sql.optimizer.transformer.SqlToScalarOperatorTranslator;
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
 
 import java.math.BigInteger;
 import java.util.Arrays;
@@ -73,6 +77,8 @@ import static com.starrocks.sql.analyzer.AnalyticAnalyzer.verifyAnalyticExpressi
 import static com.starrocks.sql.common.UnsupportedException.unsupportedException;
 
 public class ExpressionAnalyzer {
+    private static final Pattern HAS_TIME_PART = Pattern.compile("^.*[HhIiklrSsT]+.*$");
+
     private final Catalog catalog;
     private final ConnectContext session;
 
@@ -469,64 +475,9 @@ public class ExpressionAnalyzer {
                             node.getFnName().getFunction());
                 }
             } else if (Arrays.stream(argumentTypes).anyMatch(Type::isDecimalV3)) {
-                Type commonType = DecimalV3FunctionAnalyzer.normalizeDecimalArgTypes(argumentTypes, node.getFnName());
-                fn = Expr.getBuiltinFunction(node.getFnName().getFunction(),
-                        argumentTypes, Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
-
-                if (fn == null) {
-                    fn = getUdfFunction(node.getFnName(), argumentTypes);
-                }
-
-                if (fn == null) {
-                    throw new SemanticException("No matching function with signature: %s(%s).",
-                            node.getFnName().getFunction(),
-                            node.getParams().isStar() ? "*" : Joiner.on(", ")
-                                    .join(Arrays.stream(argumentTypes).map(Type::toSql).collect(Collectors.toList())));
-                }
-
-                if (DecimalV3FunctionAnalyzer.DECIMAL_AGG_FUNCTION.contains(node.getFnName().getFunction())) {
-                    Type argType = node.getChild(0).getType();
-                    // stddev/variance always use decimal128(38,9) to computing result.
-                    if (DecimalV3FunctionAnalyzer.DECIMAL_AGG_VARIANCE_STDDEV_TYPE
-                            .contains(node.getFnName().getFunction()) && argType.isDecimalV3()) {
-                        argType = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 9);
-                        node.setChild(0, TypeManager.addCastExpr(node.getChild(0), argType));
-                    }
-                    fn = DecimalV3FunctionAnalyzer
-                            .rectifyAggregationFunction((AggregateFunction) fn, argType, commonType);
-                } else if (
-                        DecimalV3FunctionAnalyzer.DECIMAL_UNARY_FUNCTION_SET.contains(node.getFnName().getFunction()) ||
-                                DecimalV3FunctionAnalyzer.DECIMAL_IDENTICAL_TYPE_FUNCTION_SET
-                                        .contains(node.getFnName().getFunction()) ||
-                                node.getFnName().getFunction().equalsIgnoreCase("if")) {
-                    // DecimalV3 types in resolved fn's argument should be converted into commonType so that right CastExprs
-                    // are interpolated into FunctionCallExpr's children whose type does match the corresponding argType of fn.
-                    List<Type> argTypes;
-                    if (node.getFnName().getFunction().equalsIgnoreCase("money_format")) {
-                        argTypes = Arrays.asList(argumentTypes);
-                    } else {
-                        argTypes = Arrays.stream(fn.getArgs()).map(t -> t.isDecimalV3() ? commonType : t)
-                                .collect(Collectors.toList());
-                    }
-
-                    Type returnType = fn.getReturnType();
-                    // Decimal v3 function return type maybe need change
-                    if (returnType.isDecimalV3() && commonType.isValid()) {
-                        returnType = commonType;
-                    }
-                    ScalarFunction newFn = new ScalarFunction(fn.getFunctionName(), argTypes, returnType,
-                            fn.getLocation(), ((ScalarFunction) fn).getSymbolName(),
-                            ((ScalarFunction) fn).getPrepareFnSymbol(),
-                            ((ScalarFunction) fn).getCloseFnSymbol());
-                    newFn.setFunctionId(fn.getFunctionId());
-                    newFn.setChecksum(fn.getChecksum());
-                    newFn.setBinaryType(fn.getBinaryType());
-                    newFn.setHasVarArgs(fn.hasVarArgs());
-                    newFn.setId(fn.getId());
-                    newFn.setUserVisible(fn.isUserVisible());
-
-                    fn = newFn;
-                }
+                fn = getDecimalV3Function(node, argumentTypes);
+            } else if ("str_to_date".equalsIgnoreCase(node.getFnName().getFunction())) {
+                fn = getStrToDateFunction(node, argumentTypes);
             } else {
                 fn = Expr.getBuiltinFunction(node.getFnName().getFunction(),
                         argumentTypes, Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
@@ -551,6 +502,106 @@ public class ExpressionAnalyzer {
             node.setType(fn.getReturnType());
             FunctionAnalyzer.analyze(node);
             return null;
+        }
+
+        private Function getStrToDateFunction(FunctionCallExpr node, Type[] argumentTypes) {
+            /*
+             * @TODO: Determine the return type of this function
+             * If is format is constant and don't contains time part, return date type, to compatible with mysql.
+             * In fact we don't want to support str_to_date return date like mysql, reason:
+             * 1. The return type of FE/BE str_to_date function signature is datetime, return date
+             *    let type different, it's will throw unpredictable error
+             * 2. Support return date and datetime at same time in one function is complicated.
+             * 3. The meaning of the function is confusing. In mysql, will return date if format is a constant
+             *    string and it's not contains "%H/%M/%S" pattern, but it's a trick logic, if format is a variable
+             *    expression, like: str_to_date(col1, col2), and the col2 is '%Y%m%d', the result always be
+             *    datetime.
+             */
+            Function fn = Expr.getBuiltinFunction(node.getFnName().getFunction(),
+                    argumentTypes, Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+
+            if (fn == null) {
+                return null;
+            }
+
+            if (!node.getChild(1).isConstant()) {
+                return fn;
+            }
+
+            ExpressionMapping expressionMapping =
+                    new ExpressionMapping(new Scope(RelationId.anonymous(), new RelationFields()),
+                            com.google.common.collect.Lists.newArrayList());
+
+            ScalarOperator format = SqlToScalarOperatorTranslator.translate(node.getChild(1), expressionMapping);
+            if (format.isConstantRef() && !HAS_TIME_PART.matcher(format.toString()).matches()) {
+                return Expr
+                        .getBuiltinFunction("str2date", argumentTypes, Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+            }
+
+            return fn;
+        }
+
+        Function getDecimalV3Function(FunctionCallExpr node, Type[] argumentTypes) {
+            Function fn;
+            Type commonType = DecimalV3FunctionAnalyzer.normalizeDecimalArgTypes(argumentTypes, node.getFnName());
+            fn = Expr.getBuiltinFunction(node.getFnName().getFunction(),
+                    argumentTypes, Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+
+            if (fn == null) {
+                fn = getUdfFunction(node.getFnName(), argumentTypes);
+            }
+
+            if (fn == null) {
+                throw new SemanticException("No matching function with signature: %s(%s).",
+                        node.getFnName().getFunction(),
+                        node.getParams().isStar() ? "*" : Joiner.on(", ")
+                                .join(Arrays.stream(argumentTypes).map(Type::toSql).collect(Collectors.toList())));
+            }
+
+            if (DecimalV3FunctionAnalyzer.DECIMAL_AGG_FUNCTION.contains(node.getFnName().getFunction())) {
+                Type argType = node.getChild(0).getType();
+                // stddev/variance always use decimal128(38,9) to computing result.
+                if (DecimalV3FunctionAnalyzer.DECIMAL_AGG_VARIANCE_STDDEV_TYPE
+                        .contains(node.getFnName().getFunction()) && argType.isDecimalV3()) {
+                    argType = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 9);
+                    node.setChild(0, TypeManager.addCastExpr(node.getChild(0), argType));
+                }
+                fn = DecimalV3FunctionAnalyzer
+                        .rectifyAggregationFunction((AggregateFunction) fn, argType, commonType);
+            } else if (
+                    DecimalV3FunctionAnalyzer.DECIMAL_UNARY_FUNCTION_SET.contains(node.getFnName().getFunction()) ||
+                            DecimalV3FunctionAnalyzer.DECIMAL_IDENTICAL_TYPE_FUNCTION_SET
+                                    .contains(node.getFnName().getFunction()) ||
+                            node.getFnName().getFunction().equalsIgnoreCase("if")) {
+                // DecimalV3 types in resolved fn's argument should be converted into commonType so that right CastExprs
+                // are interpolated into FunctionCallExpr's children whose type does match the corresponding argType of fn.
+                List<Type> argTypes;
+                if (node.getFnName().getFunction().equalsIgnoreCase("money_format")) {
+                    argTypes = Arrays.asList(argumentTypes);
+                } else {
+                    argTypes = Arrays.stream(fn.getArgs()).map(t -> t.isDecimalV3() ? commonType : t)
+                            .collect(Collectors.toList());
+                }
+
+                Type returnType = fn.getReturnType();
+                // Decimal v3 function return type maybe need change
+                if (returnType.isDecimalV3() && commonType.isValid()) {
+                    returnType = commonType;
+                }
+                ScalarFunction newFn = new ScalarFunction(fn.getFunctionName(), argTypes, returnType,
+                        fn.getLocation(), ((ScalarFunction) fn).getSymbolName(),
+                        ((ScalarFunction) fn).getPrepareFnSymbol(),
+                        ((ScalarFunction) fn).getCloseFnSymbol());
+                newFn.setFunctionId(fn.getFunctionId());
+                newFn.setChecksum(fn.getChecksum());
+                newFn.setBinaryType(fn.getBinaryType());
+                newFn.setHasVarArgs(fn.hasVarArgs());
+                newFn.setId(fn.getId());
+                newFn.setUserVisible(fn.isUserVisible());
+
+                fn = newFn;
+            }
+            return fn;
         }
 
         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -64,7 +64,6 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.transformer.ExpressionMapping;
 import com.starrocks.sql.optimizer.transformer.SqlToScalarOperatorTranslator;
 import org.apache.commons.lang3.StringUtils;
-import org.jetbrains.annotations.NotNull;
 
 import java.math.BigInteger;
 import java.util.Arrays;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
@@ -133,8 +133,15 @@ public class ScalarOperatorFunctions {
             return ConstantOperator.createDatetime(ldt, Type.DATETIME);
         } else {
             LocalDate ld = LocalDate.from(builder.toFormatter().parse(date.getVarchar()));
-            return ConstantOperator.createDatetime(ld.atTime(0, 0, 0), Type.DATE);
+            return ConstantOperator.createDatetime(ld.atTime(0, 0, 0), Type.DATETIME);
         }
+    }
+
+    @FEFunction(name = "str2date", argTypes = {"VARCHAR", "VARCHAR"}, returnType = "DATE")
+    public static ConstantOperator str2Date(ConstantOperator date, ConstantOperator fmtLiteral) {
+        DateTimeFormatterBuilder builder = unixDatetimeFormatBuilder(fmtLiteral.getVarchar());
+        LocalDate ld = LocalDate.from(builder.toFormatter().parse(date.getVarchar()));
+        return ConstantOperator.createDatetime(ld.atTime(0, 0, 0), Type.DATE);
     }
 
     @FEFunction(name = "years_sub", argTypes = {"DATETIME", "INT"}, returnType = "DATETIME")

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
@@ -290,7 +290,7 @@ public class ScalarOperatorFunctionsTest {
         Assert.assertEquals("2019-05-09T09:10:45", ScalarOperatorFunctions
                 .dateParse(ConstantOperator.createVarchar("20190509-9:10:45"),
                         ConstantOperator.createVarchar("%Y%m%d-%k:%i:%S")).getDatetime().toString());
-        Assert.assertEquals("2020-02-21",
+        Assert.assertEquals("2020-02-21 00:00:00",
                 ScalarOperatorFunctions.dateParse(ConstantOperator.createVarchar("2020-02-21"),
                         ConstantOperator.createVarchar("%Y-%m-%d")).toString());
 
@@ -306,9 +306,23 @@ public class ScalarOperatorFunctionsTest {
                 () -> ScalarOperatorFunctions.dateParse(ConstantOperator.createVarchar("2020-2-21"),
                         ConstantOperator.createVarchar("%w")).getVarchar());
 
+        Assert.assertThrows(DateTimeParseException.class,
+                () -> ScalarOperatorFunctions.dateParse(ConstantOperator.createVarchar("2020-02-21"),
+                        ConstantOperator.createVarchar("%w")).getVarchar());
+
         Assert.assertThrows("Unable to obtain LocalDateTime", DateTimeException.class, () -> ScalarOperatorFunctions
                 .dateParse(ConstantOperator.createVarchar("2013-05-17 12:35:10"),
                         ConstantOperator.createVarchar("%Y-%m-%d %h:%i:%s")).getDatetime().toString());
+    }
+
+    @Test
+    public void str2Date() {
+        Assert.assertEquals("2013-05-10T00:00", ScalarOperatorFunctions
+                .str2Date(ConstantOperator.createVarchar("2013,05,10"), ConstantOperator.createVarchar("%Y,%m,%d"))
+                .getDate().toString());
+        Assert.assertEquals("2013-05-17T00:00", ScalarOperatorFunctions
+                .str2Date(ConstantOperator.createVarchar("2013-05-17 12:35:10"),
+                        ConstantOperator.createVarchar("%Y-%m-%d %H:%i:%s")).getDate().toString());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -2180,7 +2180,12 @@ public class PlanFragmentTest extends PlanTestBase {
         starRocksAssert.query(castSql).explainContains("8: k11 < '2020-03-26 00:00:00'");
 
         String castSql2 = "select str_to_date('11/09/2011', '%m/%d/%Y');";
-        starRocksAssert.query(castSql2).explainContains("constant exprs:", "'2011-11-09 00:00:00'");
+        starRocksAssert.query(castSql2).explainContains("constant exprs:", "'2011-11-09'");
+
+        String castSql3 = "select str_to_date('11/09/2011', k6) from test.baseall";
+        System.out.println(starRocksAssert.query(castSql3).explainQuery());
+        starRocksAssert.query(castSql3).explainContains("  1:Project\n" +
+                "  |  <slot 12> : str_to_date('11/09/2011', 6: k6)");
     }
 
     @Test

--- a/gensrc/script/vectorized/vectorized_functions.py
+++ b/gensrc/script/vectorized/vectorized_functions.py
@@ -317,6 +317,8 @@ vectorized_functions = [
      'TimeFunctions::format_prepare', 'TimeFunctions::format_close'],
     [50242, 'date_format', 'VARCHAR', ['DATE', 'VARCHAR'], 'TimeFunctions::date_format',
      'TimeFunctions::format_prepare', 'TimeFunctions::format_close'],
+    # cast string to date, the function will call by FE getStrToDateFunction, and is invisible to user
+    [50243, 'str2date', 'DATE', ['VARCHAR', 'VARCHAR'], 'TimeFunctions::str2date', 'TimeFunctions::str_to_date_prepare', 'TimeFunctions::str_to_date_close'],
     [50250, 'time_to_sec', 'BIGINT', ['TIME'], 'TimeFunctions::time_to_sec'],
 
     [50300, 'unix_timestamp', 'INT', [], 'TimeFunctions::to_unix_for_now'],


### PR DESCRIPTION
For #1218

The bug reason is retrun type of function `str_to_date` is changeable.
For compatible with mysql, the function need return date some times, and return datetime some times, it's let optimizer confusing.