### PR TITLE
Fix NPE when collect meta error in BE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/AddDecodeNodeForDictStringRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/AddDecodeNodeForDictStringRule.java
@@ -661,7 +661,7 @@ public class AddDecodeNodeForDictStringRule implements PhysicalOperatorTreeRewri
             }
         }
         PhysicalDecodeOperator decodeOperator = new PhysicalDecodeOperator(ImmutableMap.copyOf(dictToStrings),
-                context.stringFunctions);
+                Maps.newHashMap(context.stringFunctions));
         OptExpression result = OptExpression.create(decodeOperator, childExpr);
         result.setStatistics(childExpr.get(0).getStatistics());
         result.setLogicalProperty(childExpr.get(0).getLogicalProperty());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CacheDictManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CacheDictManager.java
@@ -10,7 +10,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import com.starrocks.catalog.Catalog;
 import com.starrocks.catalog.Database;
-import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.base.ColumnIdentifier;
@@ -122,7 +121,10 @@ public class CacheDictManager implements IDictManager {
             .maximumSize(Config.statistic_cache_columns)
             .buildAsync(dictLoader);
 
-    private ColumnDict deserializeColumnDict(TStatisticData statisticData) throws AnalysisException {
+    private ColumnDict deserializeColumnDict(TStatisticData statisticData) {
+        if (statisticData.dict == null) {
+            throw new RuntimeException("Collect dict error in BE");
+        }
         TGlobalDict tGlobalDict = statisticData.dict;
         ImmutableMap.Builder<String, Integer> dicts = ImmutableMap.builder();
         if (tGlobalDict.isSetIds()) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecodeRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecodeRewriteTest.java
@@ -406,6 +406,14 @@ public class DecodeRewriteTest extends PlanTestBase {
         String sql = "select max(S_NAME) as b from supplier group by S_ADDRESS order by b";
         String plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("group by: 10: S_ADDRESS"));
+
+        sql = "select substr(S_ADDRESS, 0, 1) from supplier group by substr(S_ADDRESS, 0, 1) " +
+                "order by substr(S_ADDRESS, 0, 1)";
+        plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("  5:Decode\n" +
+                "  |  <dict id 11> : <string id 9>\n" +
+                "  |  string functions:\n" +
+                "  |  <function id 11> : substr(10: S_ADDRESS, 0, 1)"));
         connectContext.getSessionVariable().setNewPlanerAggStage(0);
     }
 


### PR DESCRIPTION
For https://github.com/StarRocks/starrocks/issues/1573

1. The arg `context.stringFunctions` for PhysicalDecodeOperator should copy, we will clear context.stringFunctions later
2. If meta collect error in BE, we should throw exception