### PR TITLE
Optimize queries which use bitmap indexes

### DIFF
--- a/be/src/storage/rowset/segment_v2/array_column_iterator.cpp
+++ b/be/src/storage/rowset/segment_v2/array_column_iterator.cpp
@@ -122,6 +122,18 @@ Status ArrayColumnIterator::next_batch(size_t* n, vectorized::Column* dst) {
     return Status::OK();
 }
 
+Status ArrayColumnIterator::next_batch(vectorized::SparseRange& range, vectorized::Column* dst) {
+    vectorized::SparseRangeIterator iter = range.new_iterator();
+    size_t nread = range.span_size();
+    while (iter.has_more()) {
+        vectorized::Range r = iter.next(nread);
+        size_t n = r.span_size();
+        RETURN_IF_ERROR(seek_to_ordinal(r.begin()));
+        RETURN_IF_ERROR(next_batch(&n, dst));
+    }
+    return Status::OK();
+}
+
 Status ArrayColumnIterator::fetch_values_by_rowid(const rowid_t* rowids, size_t size, vectorized::Column* values) {
     vectorized::ArrayColumn* array_column = nullptr;
     vectorized::NullColumn* null_column = nullptr;

--- a/be/src/storage/rowset/segment_v2/array_column_iterator.h
+++ b/be/src/storage/rowset/segment_v2/array_column_iterator.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "storage/rowset/segment_v2/column_iterator.h"
+#include "storage/vectorized/range.h"
 
 namespace starrocks {
 
@@ -27,6 +28,8 @@ public:
     Status next_batch(size_t* n, ColumnBlockView* dst, bool* has_null) override;
 
     Status next_batch(size_t* n, vectorized::Column* dst) override;
+
+    Status next_batch(vectorized::SparseRange& range, vectorized::Column* dst) override;
 
     Status seek_to_first() override;
 

--- a/be/src/storage/rowset/segment_v2/binary_dict_page.cpp
+++ b/be/src/storage/rowset/segment_v2/binary_dict_page.cpp
@@ -29,9 +29,9 @@
 #include "gutil/strings/substitute.h" // for Substitute
 #include "storage/rowset/segment_v2/bitshuffle_page.h"
 #include "storage/vectorized/chunk_helper.h"
+#include "storage/vectorized/range.h"
 #include "util/slice.h" // for Slice
 #include "util/unaligned_access.h"
-#include "storage/vectorized/range.h"
 
 namespace starrocks::segment_v2 {
 
@@ -314,7 +314,7 @@ Status BinaryDictPageDecoder<Type>::next_batch(vectorized::SparseRange& range, v
             slices.emplace_back(_dict_decoder->string_at_index(codewords[i]));
         }
     }
-        
+
     CHECK(dst->append_strings_overflow(slices, _max_value_legth));
     return Status::OK();
 }

--- a/be/src/storage/rowset/segment_v2/binary_dict_page.h
+++ b/be/src/storage/rowset/segment_v2/binary_dict_page.h
@@ -36,6 +36,7 @@
 #include "storage/rowset/segment_v2/options.h"
 #include "storage/types.h"
 #include "util/phmap/phmap.h"
+#include "storage/vectorized/range.h"
 
 namespace starrocks {
 namespace segment_v2 {
@@ -126,6 +127,8 @@ public:
 
     Status next_batch(size_t* n, vectorized::Column* dst) override;
 
+    Status next_batch(vectorized::SparseRange& range, vectorized::Column* dst) override;
+
     size_t count() const override { return _data_page_decoder->count(); }
 
     size_t current_index() const override { return _data_page_decoder->current_index(); }
@@ -135,6 +138,8 @@ public:
     void set_dict_decoder(PageDecoder* dict_decoder);
 
     Status next_dict_codes(size_t* n, vectorized::Column* dst) override;
+
+    Status next_dict_codes(vectorized::SparseRange& range, vectorized::Column* dst) override;
 
 private:
     Slice _data;

--- a/be/src/storage/rowset/segment_v2/binary_dict_page.h
+++ b/be/src/storage/rowset/segment_v2/binary_dict_page.h
@@ -35,8 +35,8 @@
 #include "storage/rowset/segment_v2/common.h"
 #include "storage/rowset/segment_v2/options.h"
 #include "storage/types.h"
-#include "util/phmap/phmap.h"
 #include "storage/vectorized/range.h"
+#include "util/phmap/phmap.h"
 
 namespace starrocks {
 namespace segment_v2 {

--- a/be/src/storage/rowset/segment_v2/binary_plain_page.cpp
+++ b/be/src/storage/rowset/segment_v2/binary_plain_page.cpp
@@ -35,6 +35,55 @@ Status BinaryPlainPageDecoder<Type>::next_batch(size_t* count, vectorized::Colum
     return Status::InvalidArgument("Column::append_strings() not supported");
 }
 
+template <FieldType Type>
+Status BinaryPlainPageDecoder<Type>::next_batch(vectorized::SparseRange& range, vectorized::Column* dst) {
+    DCHECK(_parsed);
+    if (PREDICT_FALSE(_cur_idx >= _num_elems)) {
+        return Status::OK();
+    }
+    /*
+    if (_cur_idx != range.begin()) {
+        LOG(INFO) << "binary plain page cur_idx is not equal begin of range";
+        return Status::InternalError("binary plain page decoder cur_idx error");
+    }
+    */
+    size_t nread = std::min(range.span_size(), _num_elems - _cur_idx);
+    std::vector<Slice> strs;
+    strs.reserve(nread);
+    vectorized::SparseRangeIterator iter = range.new_iterator();
+    if constexpr (Type == OLAP_FIELD_TYPE_CHAR) {
+        while(iter.has_more() && _cur_idx < _num_elems) {
+            //LOG(INFO) << "type char";
+            _cur_idx = iter.begin();
+            vectorized::Range r = iter.next(nread);
+            size_t end = _cur_idx + r.span_size();
+            for (; _cur_idx < end; _cur_idx++) {
+                Slice s = string_at_index(_cur_idx);
+                s.size = strnlen(s.data, s.size);
+                strs.emplace_back(s);
+            }
+        }
+        if (dst->append_strings(strs)) {
+            return Status::OK();
+        }
+    } else {
+        while(iter.has_more() && _cur_idx < _num_elems) {
+            _cur_idx = iter.begin();
+            vectorized::Range r = iter.next(nread);
+            //LOG(INFO) << "type other" << ", _cur_idx is " << _cur_idx << ", range size is " << r.span_size();
+            size_t end = _cur_idx + r.span_size();
+            //LOG(INFO) << "_cur_idx is " << _cur_idx << ", end_idx is " << end;
+            for (; _cur_idx < end; _cur_idx++) {
+                strs.emplace_back(string_at_index(_cur_idx));
+            }
+        }
+        if (dst->append_continuous_strings(strs)) {
+            return Status::OK();
+        }
+    }
+    return Status::InvalidArgument("Column::append_strings() not supported");
+}
+
 template class BinaryPlainPageDecoder<OLAP_FIELD_TYPE_CHAR>;
 template class BinaryPlainPageDecoder<OLAP_FIELD_TYPE_VARCHAR>;
 template class BinaryPlainPageDecoder<OLAP_FIELD_TYPE_HLL>;

--- a/be/src/storage/rowset/segment_v2/binary_plain_page.cpp
+++ b/be/src/storage/rowset/segment_v2/binary_plain_page.cpp
@@ -41,18 +41,12 @@ Status BinaryPlainPageDecoder<Type>::next_batch(vectorized::SparseRange& range, 
     if (PREDICT_FALSE(_cur_idx >= _num_elems)) {
         return Status::OK();
     }
-    /*
-    if (_cur_idx != range.begin()) {
-        LOG(INFO) << "binary plain page cur_idx is not equal begin of range";
-        return Status::InternalError("binary plain page decoder cur_idx error");
-    }
-    */
     size_t nread = std::min(range.span_size(), _num_elems - _cur_idx);
     std::vector<Slice> strs;
     strs.reserve(nread);
     vectorized::SparseRangeIterator iter = range.new_iterator();
     if constexpr (Type == OLAP_FIELD_TYPE_CHAR) {
-        while(iter.has_more() && _cur_idx < _num_elems) {
+        while (iter.has_more() && _cur_idx < _num_elems) {
             //LOG(INFO) << "type char";
             _cur_idx = iter.begin();
             vectorized::Range r = iter.next(nread);
@@ -67,12 +61,10 @@ Status BinaryPlainPageDecoder<Type>::next_batch(vectorized::SparseRange& range, 
             return Status::OK();
         }
     } else {
-        while(iter.has_more() && _cur_idx < _num_elems) {
+        while (iter.has_more() && _cur_idx < _num_elems) {
             _cur_idx = iter.begin();
             vectorized::Range r = iter.next(nread);
-            //LOG(INFO) << "type other" << ", _cur_idx is " << _cur_idx << ", range size is " << r.span_size();
             size_t end = _cur_idx + r.span_size();
-            //LOG(INFO) << "_cur_idx is " << _cur_idx << ", end_idx is " << end;
             for (; _cur_idx < end; _cur_idx++) {
                 strs.emplace_back(string_at_index(_cur_idx));
             }

--- a/be/src/storage/rowset/segment_v2/binary_plain_page.h
+++ b/be/src/storage/rowset/segment_v2/binary_plain_page.h
@@ -43,6 +43,7 @@
 #include "storage/types.h"
 #include "util/coding.h"
 #include "util/faststring.h"
+#include "storage/vectorized/range.h"
 
 namespace starrocks::vectorized {
 class Column;
@@ -229,6 +230,8 @@ public:
     }
 
     Status next_batch(size_t* count, vectorized::Column* dst) override;
+
+    Status next_batch(vectorized::SparseRange& range, vectorized::Column* dst) override;
 
     size_t count() const override {
         DCHECK(_parsed);

--- a/be/src/storage/rowset/segment_v2/binary_plain_page.h
+++ b/be/src/storage/rowset/segment_v2/binary_plain_page.h
@@ -41,9 +41,9 @@
 #include "storage/rowset/segment_v2/page_builder.h"
 #include "storage/rowset/segment_v2/page_decoder.h"
 #include "storage/types.h"
+#include "storage/vectorized/range.h"
 #include "util/coding.h"
 #include "util/faststring.h"
-#include "storage/vectorized/range.h"
 
 namespace starrocks::vectorized {
 class Column;

--- a/be/src/storage/rowset/segment_v2/binary_prefix_page.cpp
+++ b/be/src/storage/rowset/segment_v2/binary_prefix_page.cpp
@@ -330,13 +330,11 @@ Status BinaryPrefixPageDecoder<Type>::next_batch(size_t* n, vectorized::Column* 
 
 template <FieldType Type>
 Status BinaryPrefixPageDecoder<Type>::next_batch(vectorized::SparseRange& range, vectorized::Column* dst) {
-    LOG(INFO) << "binary prefix page decoder";
     DCHECK(_parsed);
     if (PREDICT_FALSE(_cur_pos >= _num_values)) {
         return Status::OK();
     }
     size_t nread = std::min(static_cast<size_t>(range.span_size()), static_cast<size_t>(_num_values - _cur_pos));
-    // FIXME: ???
     [[maybe_unused]] bool ok = dst->append_strings({_current_value});
     DCHECK(ok);
     vectorized::SparseRangeIterator iter = range.new_iterator();
@@ -352,11 +350,9 @@ Status BinaryPrefixPageDecoder<Type>::next_batch(vectorized::SparseRange& range,
             nread -= r.span_size();
         }
     } else {
-        LOG(INFO) << "binary prefix type varchar";
         while (iter.has_more() && nread > 0) {
             seek_to_position_in_page(iter.begin());
             vectorized::Range r = iter.next(nread);
-            LOG(INFO) << "nread is " << nread << ", range size is " << r.span_size();
             for (size_t i = 1; i < r.span_size(); ++i) {
                 RETURN_IF_ERROR(_next_value(&_current_value));
                 (void)dst->append_strings({_current_value});
@@ -364,7 +360,6 @@ Status BinaryPrefixPageDecoder<Type>::next_batch(vectorized::SparseRange& range,
             nread -= r.span_size();
         }
     }
-    LOG(INFO) << "binary prefix page decoder next batch finish";
     return Status::OK();
 }
 

--- a/be/src/storage/rowset/segment_v2/binary_prefix_page.h
+++ b/be/src/storage/rowset/segment_v2/binary_prefix_page.h
@@ -35,6 +35,7 @@
 #include "util/coding.h"
 #include "util/faststring.h"
 #include "util/slice.h"
+#include "storage/vectorized/range.h"
 
 namespace starrocks {
 namespace segment_v2 {
@@ -117,6 +118,8 @@ public:
     Status next_batch(size_t* n, ColumnBlockView* dst) override;
 
     Status next_batch(size_t* n, vectorized::Column* dst) override;
+
+    Status next_batch(vectorized::SparseRange& range, vectorized::Column* dst) override;
 
     size_t count() const override {
         DCHECK(_parsed);

--- a/be/src/storage/rowset/segment_v2/binary_prefix_page.h
+++ b/be/src/storage/rowset/segment_v2/binary_prefix_page.h
@@ -32,10 +32,10 @@
 #include "storage/rowset/segment_v2/options.h"
 #include "storage/rowset/segment_v2/page_builder.h"
 #include "storage/rowset/segment_v2/page_decoder.h"
+#include "storage/vectorized/range.h"
 #include "util/coding.h"
 #include "util/faststring.h"
 #include "util/slice.h"
-#include "storage/vectorized/range.h"
 
 namespace starrocks {
 namespace segment_v2 {

--- a/be/src/storage/rowset/segment_v2/bitshuffle_page.h
+++ b/be/src/storage/rowset/segment_v2/bitshuffle_page.h
@@ -292,8 +292,9 @@ public:
         if (_options.is_decoded) {
             if (_data.size != _num_element_after_padding * _size_of_element + BITSHUFFLE_PAGE_HEADER_SIZE) {
                 std::stringstream ss;
-                ss << "Size information unmatched, _data.size:" << _data.size
-                   << ", _num_elements:" << _num_elements << ", expected size is " << _num_element_after_padding * _size_of_element + BITSHUFFLE_PAGE_HEADER_SIZE;
+                ss << "Size information unmatched, _data.size:" << _data.size << ", _num_elements:" << _num_elements
+                   << ", expected size is "
+                   << _num_element_after_padding * _size_of_element + BITSHUFFLE_PAGE_HEADER_SIZE;
                 return Status::InternalError(ss.str());
             }
         }
@@ -470,8 +471,8 @@ inline Status BitShufflePageDecoder<Type>::next_batch(vectorized::SparseRange& r
         return Status::OK();
     }
 
-    if (range.size() == 1 && _options.enable_direct_copy && !_is_decoded && range.span_size() >= _num_elements && _cur_index <= 0 &&
-        dst->capacity() - dst->size() >= _num_element_after_padding) {
+    if (range.size() == 1 && _options.enable_direct_copy && !_is_decoded && range.span_size() >= _num_elements &&
+        _cur_index <= 0 && dst->capacity() - dst->size() >= _num_element_after_padding) {
         // if the page is not decoded and to read the whole page data
         // decode the page directly to dst to save mem copy from _decoded to dst
         // Now this can be used to optimize compaction

--- a/be/src/storage/rowset/segment_v2/bitshuffle_page.h
+++ b/be/src/storage/rowset/segment_v2/bitshuffle_page.h
@@ -387,7 +387,7 @@ private:
             _decoded.resize(_num_element_after_padding * _size_of_element);
             RETURN_IF_ERROR(_decode_to(_decoded.data()));
             // release original memory
-            if (_options.page_handle && !_options.is_decoded) {
+            if (_options.page_handle) {
                 _options.page_handle->release_memory();
             }
         }

--- a/be/src/storage/rowset/segment_v2/column_iterator.h
+++ b/be/src/storage/rowset/segment_v2/column_iterator.h
@@ -99,6 +99,10 @@ public:
 
     virtual Status next_batch(size_t* n, vectorized::Column* dst) = 0;
 
+    virtual Status next_batch(vectorized::SparseRange& range, vectorized::Column* dst) {
+        return Status::NotSupported("ColumnIterator Not Support batch read");
+    }
+
     virtual ordinal_t get_current_ordinal() const = 0;
 
     virtual Status get_row_ranges_by_zone_map(CondColumn* cond_column, CondColumn* delete_condition,
@@ -141,6 +145,8 @@ public:
     // this method can be invoked only if `all_page_dict_encoded` returns true.
     // type of |dst| must be `FixedLengthColumn<int32_t>` or `NullableColumn(FixedLengthColumn<int32_t>)`.
     virtual Status next_dict_codes(size_t* n, vectorized::Column* dst) { return Status::NotSupported(""); }
+
+    virtual Status next_dict_codes(vectorized::SparseRange& range, vectorized::Column* dst) { return Status::NotSupported(""); }
 
     // given a list of dictionary codes, fill |dst| column with the decoded values.
     // |codes| pointer to the array of dictionary codes.

--- a/be/src/storage/rowset/segment_v2/column_iterator.h
+++ b/be/src/storage/rowset/segment_v2/column_iterator.h
@@ -146,7 +146,9 @@ public:
     // type of |dst| must be `FixedLengthColumn<int32_t>` or `NullableColumn(FixedLengthColumn<int32_t>)`.
     virtual Status next_dict_codes(size_t* n, vectorized::Column* dst) { return Status::NotSupported(""); }
 
-    virtual Status next_dict_codes(vectorized::SparseRange& range, vectorized::Column* dst) { return Status::NotSupported(""); }
+    virtual Status next_dict_codes(vectorized::SparseRange& range, vectorized::Column* dst) {
+        return Status::NotSupported("");
+    }
 
     // given a list of dictionary codes, fill |dst| column with the decoded values.
     // |codes| pointer to the array of dictionary codes.

--- a/be/src/storage/rowset/segment_v2/column_reader.cpp
+++ b/be/src/storage/rowset/segment_v2/column_reader.cpp
@@ -179,7 +179,7 @@ Status ColumnReader::new_bitmap_index_iterator(BitmapIndexIterator** iterator) {
 }
 
 Status ColumnReader::read_page(const ColumnIteratorOptions& iter_opts, const PagePointer& pp, PageHandle* handle,
-                               Slice* page_body, PageFooterPB* footer) {
+                               Slice* page_body, PageFooterPB* footer, bool is_data_page) {
     iter_opts.sanity_check();
     PageReadOptions opts;
     opts.rblock = iter_opts.rblock;
@@ -189,6 +189,9 @@ Status ColumnReader::read_page(const ColumnIteratorOptions& iter_opts, const Pag
     opts.verify_checksum = _opts.verify_checksum;
     opts.use_page_cache = iter_opts.use_page_cache;
     opts.kept_in_memory = _opts.kept_in_memory;
+    if (is_data_page) {
+        opts.encoding_type = _encoding_info->encoding();
+    }
 
     return PageIO::read_and_decompress_page(opts, handle, page_body, footer);
 }

--- a/be/src/storage/rowset/segment_v2/column_reader.h
+++ b/be/src/storage/rowset/segment_v2/column_reader.h
@@ -118,7 +118,7 @@ public:
 
     // read a page from file into a page handle
     Status read_page(const ColumnIteratorOptions& iter_opts, const PagePointer& pp, PageHandle* handle,
-                     Slice* page_body, PageFooterPB* footer);
+                     Slice* page_body, PageFooterPB* footer, bool is_data_page = false);
 
     bool is_nullable() const { return _flags[kIsNullablePos]; }
 

--- a/be/src/storage/rowset/segment_v2/column_reader.h
+++ b/be/src/storage/rowset/segment_v2/column_reader.h
@@ -118,7 +118,7 @@ public:
 
     // read a page from file into a page handle
     Status read_page(const ColumnIteratorOptions& iter_opts, const PagePointer& pp, PageHandle* handle,
-                     Slice* page_body, PageFooterPB* footer, bool is_data_page = false);
+                     Slice* page_body, PageFooterPB* footer, bool is_data_page);
 
     bool is_nullable() const { return _flags[kIsNullablePos]; }
 

--- a/be/src/storage/rowset/segment_v2/default_value_column_iterator.h
+++ b/be/src/storage/rowset/segment_v2/default_value_column_iterator.h
@@ -63,6 +63,8 @@ public:
 
     Status next_batch(size_t* n, vectorized::Column* dst) override;
 
+    Status next_batch(vectorized::SparseRange& range, vectorized::Column* dst) override;
+
     ordinal_t get_current_ordinal() const override { return _current_rowid; }
 
     Status get_row_ranges_by_zone_map(const std::vector<const vectorized::ColumnPredicate*>& predicates,

--- a/be/src/storage/rowset/segment_v2/dictcode_column_iterator.h
+++ b/be/src/storage/rowset/segment_v2/dictcode_column_iterator.h
@@ -27,6 +27,10 @@ public:
 
     Status next_batch(size_t* n, Column* dst) override { return _col_iter->next_dict_codes(n, dst); }
 
+    Status next_batch(vectorized::SparseRange& range, Column* dst) override {
+        return _col_iter->next_dict_codes(range, dst);
+    }
+    
     Status fetch_values_by_rowid(const rowid_t* rowids, size_t size, vectorized::Column* values) override {
         return _col_iter->fetch_values_by_rowid(rowids, size, values);
     }
@@ -81,6 +85,10 @@ public:
     ColumnIterator* column_iterator() const { return _col_iter; }
 
     Status next_batch(size_t* n, Column* dst) override { return _col_iter->next_dict_codes(n, dst); }
+
+    Status next_batch(vectorized::SparseRange& range, Column* dst) override {
+        return _col_iter->next_dict_codes(range, dst);
+    }
 
     Status fetch_values_by_rowid(const rowid_t* rowids, size_t size, vectorized::Column* values) override {
         if (_local_dict_code_col == nullptr) {

--- a/be/src/storage/rowset/segment_v2/dictcode_column_iterator.h
+++ b/be/src/storage/rowset/segment_v2/dictcode_column_iterator.h
@@ -30,7 +30,7 @@ public:
     Status next_batch(vectorized::SparseRange& range, Column* dst) override {
         return _col_iter->next_dict_codes(range, dst);
     }
-    
+
     Status fetch_values_by_rowid(const rowid_t* rowids, size_t size, vectorized::Column* values) override {
         return _col_iter->fetch_values_by_rowid(rowids, size, values);
     }

--- a/be/src/storage/rowset/segment_v2/frame_of_reference_page.h
+++ b/be/src/storage/rowset/segment_v2/frame_of_reference_page.h
@@ -220,7 +220,8 @@ public:
                       Type == OLAP_FIELD_TYPE_DECIMAL128,
                       "unexpected field type");
         // clang-format on
-        size_t nread = std::min(static_cast<size_t>(range.span_size()), static_cast<size_t>(_num_elements - _cur_index));
+        size_t nread =
+                std::min(static_cast<size_t>(range.span_size()), static_cast<size_t>(_num_elements - _cur_index));
         vectorized::SparseRangeIterator iter = range.new_iterator();
         while (iter.has_more() && _cur_index < _num_elements) {
             seek_to_position_in_page(iter.begin());

--- a/be/src/storage/rowset/segment_v2/indexed_column_reader.cpp
+++ b/be/src/storage/rowset/segment_v2/indexed_column_reader.cpp
@@ -73,7 +73,7 @@ Status IndexedColumnReader::load_index_page(fs::ReadableBlock* rblock, const Pag
                                             IndexPageReader* reader) {
     Slice body;
     PageFooterPB footer;
-    RETURN_IF_ERROR(read_page(rblock, PagePointer(pp), handle, &body, &footer));
+    RETURN_IF_ERROR(read_page(rblock, PagePointer(pp), handle, &body, &footer, false));
     RETURN_IF_ERROR(reader->parse(body, footer.index_page_footer()));
     return Status::OK();
 }
@@ -118,11 +118,13 @@ Status IndexedColumnIterator::_read_data_page(const PagePointer& pp) {
     Slice body;
     PageFooterPB footer;
     size_t type = _reader->encoding_info()->encoding();
-    bool is_decoded = _reader->use_page_cache() && (type == EncodingTypePB::DICT_ENCODING ||  type == EncodingTypePB::BIT_SHUFFLE);
+    bool is_decoded =
+            _reader->use_page_cache() && (type == EncodingTypePB::DICT_ENCODING || type == EncodingTypePB::BIT_SHUFFLE);
     RETURN_IF_ERROR(_reader->read_page(_rblock.get(), pp, &handle, &body, &footer, true));
     // parse data page
     // note that page_index is not used in IndexedColumnIterator, so we pass 0
-    return parse_page(&_data_page, std::move(handle), body, footer.data_page_footer(), _reader->encoding_info(), pp, 0, is_decoded);
+    return parse_page(&_data_page, std::move(handle), body, footer.data_page_footer(), _reader->encoding_info(), pp, 0,
+                      is_decoded);
 }
 
 Status IndexedColumnIterator::seek_to_ordinal(ordinal_t idx) {

--- a/be/src/storage/rowset/segment_v2/indexed_column_reader.h
+++ b/be/src/storage/rowset/segment_v2/indexed_column_reader.h
@@ -128,13 +128,15 @@ public:
         return size;
     }
 
+    bool use_page_cache() const { return _use_page_cache; }
+
 private:
     Status load_index_page(fs::ReadableBlock* rblock, const PagePointerPB& pp, PageHandle* handle,
                            IndexPageReader* reader);
 
     // read a page specified by `pp' from `file' into `handle'
     Status read_page(fs::ReadableBlock* rblock, const PagePointer& pp, PageHandle* handle, Slice* body,
-                     PageFooterPB* footer) const;
+                     PageFooterPB* footer, bool is_data_page = false) const;
 
     fs::BlockManager* _block_mgr;
     std::string _file_name;

--- a/be/src/storage/rowset/segment_v2/indexed_column_reader.h
+++ b/be/src/storage/rowset/segment_v2/indexed_column_reader.h
@@ -136,7 +136,7 @@ private:
 
     // read a page specified by `pp' from `file' into `handle'
     Status read_page(fs::ReadableBlock* rblock, const PagePointer& pp, PageHandle* handle, Slice* body,
-                     PageFooterPB* footer, bool is_data_page = false) const;
+                     PageFooterPB* footer, bool is_data_page) const;
 
     fs::BlockManager* _block_mgr;
     std::string _file_name;

--- a/be/src/storage/rowset/segment_v2/options.h
+++ b/be/src/storage/rowset/segment_v2/options.h
@@ -40,6 +40,7 @@ class PageDecoderOptions {
 public:
     PageHandle* page_handle = nullptr;
     bool enable_direct_copy = false;
+    bool is_decoded = false;
 };
 
 } // namespace segment_v2

--- a/be/src/storage/rowset/segment_v2/page_decoder.h
+++ b/be/src/storage/rowset/segment_v2/page_decoder.h
@@ -25,6 +25,7 @@
 #include "gen_cpp/segment_v2.pb.h"
 #include "runtime/timestamp_value.h"
 #include "storage/column_block.h" // for ColumnBlockView
+#include "storage/vectorized/range.h"
 
 namespace starrocks::vectorized {
 class Column;
@@ -95,6 +96,10 @@ public:
         return Status::NotSupported("vectorized not supported yet");
     }
 
+    virtual Status next_batch(vectorized::SparseRange& range, vectorized::Column* column) {
+        return Status::NotSupported("PageDecoder Not Support");
+    }
+
     // Return the number of elements in this page.
     virtual size_t count() const = 0;
 
@@ -109,6 +114,10 @@ public:
     virtual EncodingTypePB encoding_type() const = 0;
 
     virtual Status next_dict_codes(size_t* n, vectorized::Column* dst) {
+        return Status::NotSupported("next_dict_codes() not supported");
+    }
+
+    virtual Status next_dict_codes(vectorized::SparseRange& range, vectorized::Column* dst) {
         return Status::NotSupported("next_dict_codes() not supported");
     }
 

--- a/be/src/storage/rowset/segment_v2/page_io.cpp
+++ b/be/src/storage/rowset/segment_v2/page_io.cpp
@@ -201,9 +201,7 @@ Status PageIO::read_and_decompress_page(const PageReadOptions& opts, PageHandle*
         size_t bitshuffle_header_size = 16;
         size_t type = EncodingTypePB::BIT_SHUFFLE;
         if (opts.encoding_type == EncodingTypePB::DICT_ENCODING) {
-            //LOG(INFO) << "page_silice size before decompress is " << page_slice.size;
             type = decode_fixed32_le((const uint8_t*)&page_slice.data[0]);
-            //LOG(INFO) << "encode type is " << encoding_type << ", decoded type is " << type;
             if (type != EncodingTypePB::DICT_ENCODING && type != EncodingTypePB::PLAIN_ENCODING) {
                 return Status::InternalError(strings::Substitute("error encoding type, expected is:$0, actual is:$1", DICT_ENCODING, type));
             }
@@ -216,7 +214,6 @@ Status PageIO::read_and_decompress_page(const PageReadOptions& opts, PageHandle*
             size_t compressed_size = decode_fixed32_le((const uint8_t*)&page_slice[4 + dict_header_size]);
             size_t num_element_after_padding = decode_fixed32_le((const uint8_t*)&page_slice[8 + dict_header_size]);
             size_t size_of_element = decode_fixed32_le((const uint8_t*)&page_slice[12 + dict_header_size]);
-            //LOG(INFO) << "num_elements is " << num_elements << ", compressed_size is " << compressed_size << ", num_element_after_padding is " << num_element_after_padding << ", size_of_element is " << size_of_element;
         
             size_t header_size = dict_header_size + bitshuffle_header_size;
             size_t data_size = num_element_after_padding * size_of_element;

--- a/be/src/storage/rowset/segment_v2/page_io.cpp
+++ b/be/src/storage/rowset/segment_v2/page_io.cpp
@@ -36,6 +36,7 @@
 #include "util/faststring.h"
 #include "util/runtime_profile.h"
 #include "util/scoped_cleanup.h"
+#include "storage/rowset/segment_v2/bitshuffle_wrapper.h"
 
 namespace starrocks::segment_v2 {
 
@@ -193,6 +194,56 @@ Status PageIO::read_and_decompress_page(const PageReadOptions& opts, PageHandle*
         opts.stats->uncompressed_bytes_read += page_slice.size;
     } else {
         opts.stats->uncompressed_bytes_read += body_size;
+    }
+
+    if (opts.use_page_cache && (opts.encoding_type == EncodingTypePB::DICT_ENCODING || opts.encoding_type == EncodingTypePB::BIT_SHUFFLE)) {
+        size_t dict_header_size = 4;
+        size_t bitshuffle_header_size = 16;
+        size_t type = EncodingTypePB::BIT_SHUFFLE;
+        if (opts.encoding_type == EncodingTypePB::DICT_ENCODING) {
+            //LOG(INFO) << "page_silice size before decompress is " << page_slice.size;
+            type = decode_fixed32_le((const uint8_t*)&page_slice.data[0]);
+            //LOG(INFO) << "encode type is " << encoding_type << ", decoded type is " << type;
+            if (type != EncodingTypePB::DICT_ENCODING && type != EncodingTypePB::PLAIN_ENCODING) {
+                return Status::InternalError(strings::Substitute("error encoding type, expected is:$0, actual is:$1", DICT_ENCODING, type));
+            }
+        } else  {
+            dict_header_size = 0;
+        }
+
+        if (type == opts.encoding_type) {
+            size_t num_elements = decode_fixed32_le((const uint8_t*)&page_slice[0 + dict_header_size]);
+            size_t compressed_size = decode_fixed32_le((const uint8_t*)&page_slice[4 + dict_header_size]);
+            size_t num_element_after_padding = decode_fixed32_le((const uint8_t*)&page_slice[8 + dict_header_size]);
+            size_t size_of_element = decode_fixed32_le((const uint8_t*)&page_slice[12 + dict_header_size]);
+            //LOG(INFO) << "num_elements is " << num_elements << ", compressed_size is " << compressed_size << ", num_element_after_padding is " << num_element_after_padding << ", size_of_element is " << size_of_element;
+        
+            size_t header_size = dict_header_size + bitshuffle_header_size;
+            size_t data_size = num_element_after_padding * size_of_element;
+            size_t null_size = footer->data_page_footer().nullmap_size();
+
+            std::unique_ptr<char[]> decompressed_page(
+                    new char[header_size + data_size + null_size + footer_size + 4 + vectorized::Column::APPEND_OVERFLOW_MAX_SIZE]);
+            // append dict_Header and bitshuffle_header
+            memcpy(decompressed_page.get(), page_slice.data, header_size);
+            Slice compressed_body(page_slice.data + header_size, page_slice.size - 4 - footer_size - header_size - null_size);
+            Slice decompressed_body(&(decompressed_page.get()[header_size]), data_size);
+            {
+                SCOPED_RAW_TIMER(&opts.stats->decompress_ns);
+                int64_t bytes = bitshuffle::decompress_lz4(compressed_body.data, decompressed_body.data,
+                                               num_element_after_padding, size_of_element, 0);
+                if (bytes != compressed_body.size) {
+                    return Status::Corruption(
+                        strings::Substitute("decompress failed: expected number of bytes consumed=&0 vs real consumed=$1",
+                                            compressed_body.size, bytes));
+                }
+            }
+            // append null_flag and footer and footer size
+            memcpy(decompressed_body.data + decompressed_body.size, page_slice.data + body_size - null_size, null_size + footer_size + 4);
+            // free memory of compressed page
+            page = std::move(decompressed_page);
+            page_slice = Slice(page.get(), header_size + data_size + null_size + footer_size + 4);
+        }
     }
 
     *body = Slice(page_slice.data, page_slice.size - 4 - footer_size);

--- a/be/src/storage/rowset/segment_v2/page_io.cpp
+++ b/be/src/storage/rowset/segment_v2/page_io.cpp
@@ -30,13 +30,13 @@
 #include "gutil/strings/substitute.h"
 #include "storage/fs/block_manager.h"
 #include "storage/page_cache.h"
+#include "storage/rowset/segment_v2/bitshuffle_wrapper.h"
 #include "util/block_compression.h"
 #include "util/coding.h"
 #include "util/crc32c.h"
 #include "util/faststring.h"
 #include "util/runtime_profile.h"
 #include "util/scoped_cleanup.h"
-#include "storage/rowset/segment_v2/bitshuffle_wrapper.h"
 
 namespace starrocks::segment_v2 {
 
@@ -196,16 +196,18 @@ Status PageIO::read_and_decompress_page(const PageReadOptions& opts, PageHandle*
         opts.stats->uncompressed_bytes_read += body_size;
     }
 
-    if (opts.use_page_cache && (opts.encoding_type == EncodingTypePB::DICT_ENCODING || opts.encoding_type == EncodingTypePB::BIT_SHUFFLE)) {
+    if (opts.use_page_cache &&
+        (opts.encoding_type == EncodingTypePB::DICT_ENCODING || opts.encoding_type == EncodingTypePB::BIT_SHUFFLE)) {
         size_t dict_header_size = 4;
         size_t bitshuffle_header_size = 16;
         size_t type = EncodingTypePB::BIT_SHUFFLE;
         if (opts.encoding_type == EncodingTypePB::DICT_ENCODING) {
             type = decode_fixed32_le((const uint8_t*)&page_slice.data[0]);
             if (type != EncodingTypePB::DICT_ENCODING && type != EncodingTypePB::PLAIN_ENCODING) {
-                return Status::InternalError(strings::Substitute("error encoding type, expected is:$0, actual is:$1", DICT_ENCODING, type));
+                return Status::InternalError(
+                        strings::Substitute("error encoding type, expected is:$0, actual is:$1", DICT_ENCODING, type));
             }
-        } else  {
+        } else {
             dict_header_size = 0;
         }
 
@@ -214,29 +216,31 @@ Status PageIO::read_and_decompress_page(const PageReadOptions& opts, PageHandle*
             size_t compressed_size = decode_fixed32_le((const uint8_t*)&page_slice[4 + dict_header_size]);
             size_t num_element_after_padding = decode_fixed32_le((const uint8_t*)&page_slice[8 + dict_header_size]);
             size_t size_of_element = decode_fixed32_le((const uint8_t*)&page_slice[12 + dict_header_size]);
-        
+
             size_t header_size = dict_header_size + bitshuffle_header_size;
             size_t data_size = num_element_after_padding * size_of_element;
             size_t null_size = footer->data_page_footer().nullmap_size();
 
-            std::unique_ptr<char[]> decompressed_page(
-                    new char[header_size + data_size + null_size + footer_size + 4 + vectorized::Column::APPEND_OVERFLOW_MAX_SIZE]);
+            std::unique_ptr<char[]> decompressed_page(new char[header_size + data_size + null_size + footer_size + 4 +
+                                                               vectorized::Column::APPEND_OVERFLOW_MAX_SIZE]);
             // append dict_Header and bitshuffle_header
             memcpy(decompressed_page.get(), page_slice.data, header_size);
-            Slice compressed_body(page_slice.data + header_size, page_slice.size - 4 - footer_size - header_size - null_size);
+            Slice compressed_body(page_slice.data + header_size,
+                                  page_slice.size - 4 - footer_size - header_size - null_size);
             Slice decompressed_body(&(decompressed_page.get()[header_size]), data_size);
             {
                 SCOPED_RAW_TIMER(&opts.stats->decompress_ns);
                 int64_t bytes = bitshuffle::decompress_lz4(compressed_body.data, decompressed_body.data,
-                                               num_element_after_padding, size_of_element, 0);
+                                                           num_element_after_padding, size_of_element, 0);
                 if (bytes != compressed_body.size) {
-                    return Status::Corruption(
-                        strings::Substitute("decompress failed: expected number of bytes consumed=&0 vs real consumed=$1",
-                                            compressed_body.size, bytes));
+                    return Status::Corruption(strings::Substitute(
+                            "decompress failed: expected number of bytes consumed=&0 vs real consumed=$1",
+                            compressed_body.size, bytes));
                 }
             }
             // append null_flag and footer and footer size
-            memcpy(decompressed_body.data + decompressed_body.size, page_slice.data + page_slice.size - 4 - footer_size - null_size, null_size + footer_size + 4);
+            memcpy(decompressed_body.data + decompressed_body.size,
+                   page_slice.data + page_slice.size - 4 - footer_size - null_size, null_size + footer_size + 4);
             // free memory of compressed page
             page = std::move(decompressed_page);
             page_slice = Slice(page.get(), header_size + data_size + null_size + footer_size + 4);

--- a/be/src/storage/rowset/segment_v2/page_io.cpp
+++ b/be/src/storage/rowset/segment_v2/page_io.cpp
@@ -236,7 +236,7 @@ Status PageIO::read_and_decompress_page(const PageReadOptions& opts, PageHandle*
                 }
             }
             // append null_flag and footer and footer size
-            memcpy(decompressed_body.data + decompressed_body.size, page_slice.data + body_size - null_size, null_size + footer_size + 4);
+            memcpy(decompressed_body.data + decompressed_body.size, page_slice.data + page_slice.size - 4 - footer_size - null_size, null_size + footer_size + 4);
             // free memory of compressed page
             page = std::move(decompressed_page);
             page_slice = Slice(page.get(), header_size + data_size + null_size + footer_size + 4);

--- a/be/src/storage/rowset/segment_v2/page_io.h
+++ b/be/src/storage/rowset/segment_v2/page_io.h
@@ -59,6 +59,9 @@ struct PageReadOptions {
     // currently used for in memory olap table
     bool kept_in_memory = false;
 
+    // page encoding type
+    EncodingTypePB encoding_type = EncodingTypePB::UNKNOWN_ENCODING;
+
     void sanity_check() const {
         CHECK_NOTNULL(rblock);
         CHECK_NOTNULL(stats);

--- a/be/src/storage/rowset/segment_v2/parsed_page.cpp
+++ b/be/src/storage/rowset/segment_v2/parsed_page.cpp
@@ -187,7 +187,7 @@ public:
 private:
     friend Status parse_page_v1(std::unique_ptr<ParsedPage>* result, PageHandle handle, const Slice& body,
                                 const DataPageFooterPB& footer, const EncodingInfo* encoding,
-                                const PagePointer& page_pointer, uint32_t page_index);
+                                const PagePointer& page_pointer, uint32_t page_index, bool is_decoded);
 
     bool _has_null = false;
     Slice _null_bitmap;
@@ -254,7 +254,7 @@ public:
 private:
     friend Status parse_page_v2(std::unique_ptr<ParsedPage>* result, PageHandle handle, const Slice& body,
                                 const DataPageFooterPB& footer, const EncodingInfo* encoding,
-                                const PagePointer& page_pointer, uint32_t page_index);
+                                const PagePointer& page_pointer, uint32_t page_index, bool is_decoded);
 
     faststring _null_flags;
     PageHandle _page_handle;
@@ -262,7 +262,7 @@ private:
 
 Status parse_page_v1(std::unique_ptr<ParsedPage>* result, PageHandle handle, const Slice& body,
                      const DataPageFooterPB& footer, const EncodingInfo* encoding, const PagePointer& page_pointer,
-                     uint32_t page_index) {
+                     uint32_t page_index, bool is_decoded) {
     auto page = std::make_unique<ParsedPageV1>();
     page->_page_handle = std::move(handle);
 
@@ -276,6 +276,7 @@ Status parse_page_v1(std::unique_ptr<ParsedPage>* result, PageHandle handle, con
     Slice data_slice(body.data, body.size - null_size);
     PageDecoder* decoder = nullptr;
     PageDecoderOptions opts;
+    opts.is_decoded = is_decoded;
     RETURN_IF_ERROR(encoding->create_page_decoder(data_slice, opts, &decoder));
     page->_data_decoder.reset(decoder);
     RETURN_IF_ERROR(page->_data_decoder->init());
@@ -292,7 +293,7 @@ Status parse_page_v1(std::unique_ptr<ParsedPage>* result, PageHandle handle, con
 
 Status parse_page_v2(std::unique_ptr<ParsedPage>* result, PageHandle handle, const Slice& body,
                      const DataPageFooterPB& footer, const EncodingInfo* encoding, const PagePointer& page_pointer,
-                     uint32_t page_index) {
+                     uint32_t page_index, bool is_decoded) {
     auto page = std::make_unique<ParsedPageV2>();
     page->_page_handle = std::move(handle);
 
@@ -334,6 +335,7 @@ Status parse_page_v2(std::unique_ptr<ParsedPage>* result, PageHandle handle, con
     PageDecoderOptions opts;
     opts.page_handle = &(page->_page_handle);
     opts.enable_direct_copy = true;
+    opts.is_decoded = is_decoded;
     RETURN_IF_ERROR(encoding->create_page_decoder(data_slice, opts, &decoder));
     page->_data_decoder.reset(decoder);
     RETURN_IF_ERROR(page->_data_decoder->init());
@@ -349,13 +351,13 @@ Status parse_page_v2(std::unique_ptr<ParsedPage>* result, PageHandle handle, con
 
 Status parse_page(std::unique_ptr<ParsedPage>* result, PageHandle handle, const Slice& body,
                   const DataPageFooterPB& footer, const EncodingInfo* encoding, const PagePointer& page_pointer,
-                  uint32_t page_index) {
+                  uint32_t page_index, bool is_decoded) {
     uint32_t version = footer.has_format_version() ? footer.format_version() : 1;
     if (version == 1) {
-        return parse_page_v1(result, std::move(handle), body, footer, encoding, page_pointer, page_index);
+        return parse_page_v1(result, std::move(handle), body, footer, encoding, page_pointer, page_index, is_decoded);
     }
     if (version == 2) {
-        return parse_page_v2(result, std::move(handle), body, footer, encoding, page_pointer, page_index);
+        return parse_page_v2(result, std::move(handle), body, footer, encoding, page_pointer, page_index, is_decoded);
     }
     return Status::InternalError(strings::Substitute("Unknown page format version $0", version));
 }

--- a/be/src/storage/rowset/segment_v2/parsed_page.cpp
+++ b/be/src/storage/rowset/segment_v2/parsed_page.cpp
@@ -208,7 +208,6 @@ public:
         return Status::OK();
     }
 
-
 private:
     friend Status parse_page_v1(std::unique_ptr<ParsedPage>* result, PageHandle handle, const Slice& body,
                                 const DataPageFooterPB& footer, const EncodingInfo* encoding,
@@ -264,7 +263,6 @@ public:
         return Status::OK();
     }
 
-
     Status read(ColumnBlockView* block, size_t* count) override {
         DCHECK_EQ(_offset_in_page, _data_decoder->current_index());
         RETURN_IF_ERROR(_data_decoder->next_batch(count, block));
@@ -300,7 +298,8 @@ public:
 
     Status read_dict_codes(vectorized::Column* column, vectorized::SparseRange& range) override {
         if (_offset_in_page != range.begin()) {
-            LOG(INFO) << "update offset in page failed" << ", offset_in_page is " << _offset_in_page << ", range begin is " << range.begin();
+            LOG(INFO) << "update offset in page failed"
+                      << ", offset_in_page is " << _offset_in_page << ", range begin is " << range.begin();
             return Status::InternalError("update offset in page failed");
         }
         DCHECK_EQ(_offset_in_page, _data_decoder->current_index());

--- a/be/src/storage/rowset/segment_v2/parsed_page.h
+++ b/be/src/storage/rowset/segment_v2/parsed_page.h
@@ -26,6 +26,7 @@
 #include "storage/rowset/segment_v2/common.h" // ordinal_t
 #include "storage/rowset/segment_v2/page_decoder.h"
 #include "storage/rowset/segment_v2/page_pointer.h"
+#include "storage/vectorized/range.h"
 
 namespace starrocks {
 class ColumnBlockView;
@@ -87,6 +88,10 @@ public:
     // On error, the value of |*count| is undefined.
     virtual Status read(vectorized::Column* column, size_t* count) = 0;
 
+    virtual Status read(vectorized::Column* column, vectorized::SparseRange& range) {
+        return Status::NotSupported("ParsedPage Not Support");
+    }
+
     // Attempts to read up to |*count| records from this page into the |block|.
     // On success, `Status::OK` is returned, and the number of records read will be updated to
     // |count|, the page offset is advanced by this number too. This number is the minimum value
@@ -105,6 +110,8 @@ public:
     // dictionary page, i.e, using these codes to lookup the dictionary page is safe.
     // On error, the value of |*count| is undefined.
     virtual Status read_dict_codes(vectorized::Column* column, size_t* count) = 0;
+
+    virtual Status read_dict_codes(vectorized::Column* column, vectorized::SparseRange& range) = 0;
 
 protected:
     uint32_t _page_index{0};

--- a/be/src/storage/rowset/segment_v2/parsed_page.h
+++ b/be/src/storage/rowset/segment_v2/parsed_page.h
@@ -122,7 +122,7 @@ protected:
 
 Status parse_page(std::unique_ptr<ParsedPage>* result, PageHandle handle, const Slice& body,
                   const DataPageFooterPB& footer, const EncodingInfo* encoding, const PagePointer& page_pointer,
-                  uint32_t page_index);
+                  uint32_t page_index, bool is_decoded);
 
 } // namespace segment_v2
 } // namespace starrocks

--- a/be/src/storage/rowset/segment_v2/plain_page.h
+++ b/be/src/storage/rowset/segment_v2/plain_page.h
@@ -26,9 +26,9 @@
 #include "storage/rowset/segment_v2/page_builder.h"
 #include "storage/rowset/segment_v2/page_decoder.h"
 #include "storage/types.h"
+#include "storage/vectorized/range.h"
 #include "util/coding.h"
 #include "util/faststring.h"
-#include "storage/vectorized/range.h"
 
 namespace starrocks {
 namespace segment_v2 {
@@ -234,11 +234,12 @@ public:
             _cur_idx = iter.begin();
             vectorized::Range r = iter.next(nread);
             size_t max_fetch = std::min(r.span_size(), _num_elems - _cur_idx);
-            int n = dst->append_numbers(&_data[PLAIN_PAGE_HEADER_SIZE + _cur_idx * SIZE_OF_TYPE], max_fetch * SIZE_OF_TYPE);
+            int n = dst->append_numbers(&_data[PLAIN_PAGE_HEADER_SIZE + _cur_idx * SIZE_OF_TYPE],
+                                        max_fetch * SIZE_OF_TYPE);
             DCHECK_EQ(max_fetch, n);
             _cur_idx += max_fetch;
         }
-        return Status::OK();     
+        return Status::OK();
     }
 
     size_t count() const override {

--- a/be/src/storage/rowset/segment_v2/rle_page.h
+++ b/be/src/storage/rowset/segment_v2/rle_page.h
@@ -25,10 +25,10 @@
 #include "storage/rowset/segment_v2/options.h"
 #include "storage/rowset/segment_v2/page_builder.h"
 #include "storage/rowset/segment_v2/page_decoder.h"
+#include "storage/vectorized/range.h"
 #include "util/coding.h"
 #include "util/rle_encoding.h"
 #include "util/slice.h"
-#include "storage/vectorized/range.h"
 
 namespace starrocks {
 namespace segment_v2 {
@@ -240,7 +240,8 @@ public:
         }
         CppType value{};
 
-        size_t nread = std::min(static_cast<size_t>(range.span_size()), static_cast<size_t>(_num_elements - _cur_index));
+        size_t nread =
+                std::min(static_cast<size_t>(range.span_size()), static_cast<size_t>(_num_elements - _cur_index));
         vectorized::SparseRangeIterator iter = range.new_iterator();
         while (iter.has_more()) {
             seek_to_position_in_page(iter.begin());
@@ -256,7 +257,6 @@ public:
         }
         return Status::OK();
     }
-
 
     size_t count() const override { return _num_elements; }
 

--- a/be/src/storage/rowset/segment_v2/scalar_column_iterator.cpp
+++ b/be/src/storage/rowset/segment_v2/scalar_column_iterator.cpp
@@ -70,11 +70,13 @@ Status ScalarColumnIterator::init(const ColumnIteratorOptions& opts) {
         _decode_dict_codes_func = &ScalarColumnIterator::_do_decode_dict_codes<OLAP_FIELD_TYPE_CHAR>;
         _dict_lookup_func = &ScalarColumnIterator::_do_dict_lookup<OLAP_FIELD_TYPE_CHAR>;
         _next_dict_codes_func = &ScalarColumnIterator::_do_next_dict_codes<OLAP_FIELD_TYPE_CHAR>;
+        _next_batch_dict_codes_func = &ScalarColumnIterator::_do_next_batch_dict_codes<OLAP_FIELD_TYPE_CHAR>;
         _fetch_all_dict_words_func = &ScalarColumnIterator::_fetch_all_dict_words<OLAP_FIELD_TYPE_CHAR>;
     } else if (_all_dict_encoded && _reader->column_type() == OLAP_FIELD_TYPE_VARCHAR) {
         _decode_dict_codes_func = &ScalarColumnIterator::_do_decode_dict_codes<OLAP_FIELD_TYPE_VARCHAR>;
         _dict_lookup_func = &ScalarColumnIterator::_do_dict_lookup<OLAP_FIELD_TYPE_VARCHAR>;
         _next_dict_codes_func = &ScalarColumnIterator::_do_next_dict_codes<OLAP_FIELD_TYPE_VARCHAR>;
+        _next_batch_dict_codes_func = &ScalarColumnIterator::_do_next_batch_dict_codes<OLAP_FIELD_TYPE_VARCHAR>;
         _fetch_all_dict_words_func = &ScalarColumnIterator::_fetch_all_dict_words<OLAP_FIELD_TYPE_VARCHAR>;
     }
     return Status::OK();
@@ -183,6 +185,65 @@ Status ScalarColumnIterator::next_batch(size_t* n, vectorized::Column* dst) {
     dst->set_delete_state(contain_deleted_row ? DEL_PARTIAL_SATISFIED : DEL_NOT_SATISFIED);
     *n -= remaining;
     _opts.stats->bytes_read += static_cast<int64_t>(dst->byte_size() - prev_bytes);
+    return Status::OK();
+}
+
+Status ScalarColumnIterator::next_batch(vectorized::SparseRange& range, vectorized::Column* dst) {
+    size_t prev_bytes = dst->byte_size();
+    vectorized::SparseRangeIterator iter = range.new_iterator();
+    size_t end_ord = _page->first_ordinal() + _page->num_rows();
+    bool contain_deleted_row = (dst->delete_state() != DEL_NOT_SATISFIED);
+    vectorized::SparseRange read_range;
+
+    if (range.begin() != _current_ordinal) {
+        LOG(INFO) << "seek failed" << ", range begin is " << range.begin() << ", _current ordinal is " << _current_ordinal;
+        return Status::InternalError("seek failed");
+    }
+
+    while (iter.has_more()) {
+        if (_page->remaining() == 0 && iter.begin() == end_ord) {
+            _opts.stats->block_seek_num += 1;
+            bool eos = false;
+            RETURN_IF_ERROR(_load_next_page(&eos));
+            if (eos) {
+                break;
+            }
+            end_ord = _page->first_ordinal() + _page->num_rows();
+            contain_deleted_row = contain_deleted_row || _contains_deleted_row(_page->page_index());
+        } else if (iter.begin() >= end_ord) {
+            _opts.stats->block_seek_num += 1;
+            RETURN_IF_ERROR(seek_to_ordinal(iter.begin()));
+            end_ord = _page->first_ordinal() + _page->num_rows();
+            contain_deleted_row = contain_deleted_row || _contains_deleted_row(_page->page_index());
+        }
+
+        _current_ordinal = iter.begin();
+        if (end_ord > _current_ordinal) {
+            vectorized::Range r = iter.next(end_ord - _current_ordinal);
+            read_range.add(vectorized::Range(r.begin() - _page->first_ordinal(), r.end() - _page->first_ordinal()));
+            _current_ordinal += r.span_size();
+        }
+
+        if (iter.begin() >= end_ord) {
+            Status st = _page->read(dst, read_range);
+            if (!st.ok()) {
+                LOG(INFO) << "page read next batch failed";
+                return st;
+            }
+            read_range.clear();
+        }
+    }
+    if (!read_range.empty()) {
+        Status st = _page->read(dst, read_range);
+        if (!st.ok()) {
+            LOG(INFO) << "page read next batch failed";
+            return st;
+        }
+        read_range.clear();
+    }
+    dst->set_delete_state(contain_deleted_row ? DEL_PARTIAL_SATISFIED : DEL_NOT_SATISFIED);
+    _opts.stats->bytes_read += (dst->byte_size() - prev_bytes);
+    
     return Status::OK();
 }
 
@@ -303,6 +364,11 @@ Status ScalarColumnIterator::next_dict_codes(size_t* n, vectorized::Column* dst)
     return (this->*_next_dict_codes_func)(n, dst);
 }
 
+Status ScalarColumnIterator::next_dict_codes(vectorized::SparseRange& range, vectorized::Column* dst) {
+    DCHECK(all_page_dict_encoded());
+    return (this->*_next_batch_dict_codes_func)(range, dst);
+}
+
 Status ScalarColumnIterator::decode_dict_codes(const int32_t* codes, size_t size, vectorized::Column* words) {
     DCHECK(all_page_dict_encoded());
     return (this->*_decode_dict_codes_func)(codes, size, words);
@@ -360,6 +426,68 @@ Status ScalarColumnIterator::_do_next_dict_codes(size_t* n, vectorized::Column* 
     }
     dst->set_delete_state(contain_delted_row ? DEL_PARTIAL_SATISFIED : DEL_NOT_SATISFIED);
     *n -= remaining;
+    return Status::OK();
+}
+
+template <FieldType Type>
+Status ScalarColumnIterator::_do_next_batch_dict_codes(vectorized::SparseRange& range, vectorized::Column* dst) {
+    bool contain_deleted_row = false;
+    vectorized::SparseRangeIterator iter = range.new_iterator();
+    size_t end_ord = _page->first_ordinal() + _page->num_rows();
+    vectorized::SparseRange read_range;
+
+    if (range.begin() != _current_ordinal) {
+        LOG(INFO) << "seek failed" << ", range begin is " << range.begin() << ", _current ordinal is " << _current_ordinal;
+        return Status::InternalError("seek failed");
+    }
+
+    while (iter.has_more()) {
+        if (_page->remaining() == 0 && iter.begin() == end_ord) {
+            _opts.stats->block_seek_num += 1;
+            bool eos = false;
+            RETURN_IF_ERROR(_load_next_page(&eos));
+            if (eos) {
+                break;
+            }
+            end_ord = _page->first_ordinal() + _page->num_rows();
+            contain_deleted_row = contain_deleted_row || _contains_deleted_row(_page->page_index());
+        } else if (iter.begin() >= end_ord) {
+            _opts.stats->block_seek_num += 1;
+            RETURN_IF_ERROR(seek_to_ordinal(iter.begin()));
+            end_ord = _page->first_ordinal() + _page->num_rows();
+            contain_deleted_row = contain_deleted_row || _contains_deleted_row(_page->page_index());
+        }
+
+        _current_ordinal = iter.begin();
+        if (end_ord > _current_ordinal) {
+            vectorized::Range r = iter.next(end_ord - _current_ordinal);
+            read_range.add(vectorized::Range(r.begin() - _page->first_ordinal(), r.end() - _page->first_ordinal()));
+            _current_ordinal += r.span_size();
+        }
+
+        if (iter.begin() >= end_ord) {
+            //LOG(INFO) << "read range offset begin is " << read_range.begin() << ", page offset is " << _page->offset();
+            Status st = _page->read_dict_codes(dst, read_range);
+            if (!st.ok()) {
+                LOG(INFO) << "page read next batch failed";
+                return st;
+            }
+            //LOG(INFO) << "last read rowid is " << read_range.end() << ", end ord of cur page is " << end_ord << ", next row_id is " << iter.begin();
+            read_range.clear();
+        }        
+    }
+
+    if (!read_range.empty()) {
+        //RETURN_IF_ERROR(_page->read(dst, range));
+        Status st = _page->read_dict_codes(dst, read_range);
+        if (!st.ok()) {
+            LOG(INFO) << "page read next batch failed";
+            return st;
+        }
+        read_range.clear();
+    }
+    dst->set_delete_state(contain_deleted_row ? DEL_PARTIAL_SATISFIED : DEL_NOT_SATISFIED);
+
     return Status::OK();
 }
 

--- a/be/src/storage/rowset/segment_v2/scalar_column_iterator.h
+++ b/be/src/storage/rowset/segment_v2/scalar_column_iterator.h
@@ -26,6 +26,7 @@
 #include "storage/rowset/segment_v2/ordinal_page_index.h"
 #include "storage/rowset/segment_v2/page_handle.h"
 #include "storage/rowset/segment_v2/parsed_page.h"
+#include "storage/vectorized/range.h"
 
 namespace starrocks {
 namespace segment_v2 {
@@ -47,6 +48,8 @@ public:
     Status next_batch(size_t* n, ColumnBlockView* dst, bool* has_null) override;
 
     Status next_batch(size_t* n, vectorized::Column* dst) override;
+
+    Status next_batch(vectorized::SparseRange& range, vectorized::Column* dst) override;
 
     ordinal_t get_current_ordinal() const override { return _current_ordinal; }
 
@@ -72,6 +75,8 @@ public:
     int dict_lookup(const Slice& word) override;
 
     Status next_dict_codes(size_t* n, vectorized::Column* dst) override;
+
+    Status next_dict_codes(vectorized::SparseRange& range, vectorized::Column* dst) override;
 
     Status decode_dict_codes(const int32_t* codes, size_t size, vectorized::Column* words) override;
 
@@ -99,6 +104,9 @@ private:
 
     template <FieldType Type>
     Status _do_next_dict_codes(size_t* n, vectorized::Column* dst);
+
+    template <FieldType Type>
+    Status _do_next_batch_dict_codes(vectorized::SparseRange& range, vectorized::Column* dst);
 
     template <FieldType Type>
     Status _do_decode_dict_codes(const int32_t* codes, size_t size, vectorized::Column* words);
@@ -142,6 +150,7 @@ private:
 
     int (ScalarColumnIterator::*_dict_lookup_func)(const Slice&) = nullptr;
     Status (ScalarColumnIterator::*_next_dict_codes_func)(size_t* n, vectorized::Column* dst) = nullptr;
+    Status (ScalarColumnIterator::*_next_batch_dict_codes_func)(vectorized::SparseRange& range, vectorized::Column* dst) = nullptr;
     Status (ScalarColumnIterator::*_decode_dict_codes_func)(const int32_t* codes, size_t size,
                                                             vectorized::Column* words) = nullptr;
     Status (ScalarColumnIterator::*_init_dict_decoder_func)() = nullptr;

--- a/be/src/storage/rowset/segment_v2/scalar_column_iterator.h
+++ b/be/src/storage/rowset/segment_v2/scalar_column_iterator.h
@@ -150,7 +150,8 @@ private:
 
     int (ScalarColumnIterator::*_dict_lookup_func)(const Slice&) = nullptr;
     Status (ScalarColumnIterator::*_next_dict_codes_func)(size_t* n, vectorized::Column* dst) = nullptr;
-    Status (ScalarColumnIterator::*_next_batch_dict_codes_func)(vectorized::SparseRange& range, vectorized::Column* dst) = nullptr;
+    Status (ScalarColumnIterator::*_next_batch_dict_codes_func)(vectorized::SparseRange& range,
+                                                                vectorized::Column* dst) = nullptr;
     Status (ScalarColumnIterator::*_decode_dict_codes_func)(const int32_t* codes, size_t size,
                                                             vectorized::Column* words) = nullptr;
     Status (ScalarColumnIterator::*_init_dict_decoder_func)() = nullptr;

--- a/be/src/storage/rowset/vectorized/rowid_column_iterator.h
+++ b/be/src/storage/rowset/vectorized/rowid_column_iterator.h
@@ -52,6 +52,24 @@ public:
         return Status::OK();
     }
 
+    Status next_batch(vectorized::SparseRange& range, vectorized::Column* dst) override {
+        vectorized::SparseRangeIterator iter = range.new_iterator();
+        size_t nread = range.span_size();
+        while(iter.has_more()) {
+            _current_rowid = iter.begin();
+            vectorized::Range r = iter.next(nread);
+            Buffer<rowid_t>& v = down_cast<FixedLengthColumn<rowid_t>*>(dst)->get_data();
+            const size_t sz = v.size();
+            raw::stl_vector_resize_uninitialized(&v, sz + r.span_size());
+            rowid_t* ptr = &v[sz];
+            for (size_t i = 0; i < r.span_size(); i++) {
+                ptr[i] = _current_rowid + i;
+            }
+            _current_rowid += r.span_size();
+        }
+        return Status::OK();
+    }
+
     Status fetch_values_by_rowid(const rowid_t* rowids, size_t size, vectorized::Column* values) override {
         return Status::NotSupported("Not supported by RowIdColumnIterator: fetch_values_by_rowid");
     }

--- a/be/src/storage/rowset/vectorized/rowid_column_iterator.h
+++ b/be/src/storage/rowset/vectorized/rowid_column_iterator.h
@@ -55,7 +55,7 @@ public:
     Status next_batch(vectorized::SparseRange& range, vectorized::Column* dst) override {
         vectorized::SparseRangeIterator iter = range.new_iterator();
         size_t nread = range.span_size();
-        while(iter.has_more()) {
+        while (iter.has_more()) {
             _current_rowid = iter.begin();
             vectorized::Range r = iter.next(nread);
             Buffer<rowid_t>& v = down_cast<FixedLengthColumn<rowid_t>*>(dst)->get_data();

--- a/be/src/storage/rowset/vectorized/segment_iterator.cpp
+++ b/be/src/storage/rowset/vectorized/segment_iterator.cpp
@@ -599,7 +599,7 @@ inline Status SegmentIterator::_read(Chunk* chunk, vector<rowid_t>* rowid, size_
     }
 
     if (rowid !=  nullptr) {
-        rowid->reserve(range.span_size() + n);
+        rowid->reserve(rowid->size() + range.span_size());
         vectorized::SparseRangeIterator iter = range.new_iterator();
         while (iter.has_more()) {
             vectorized::Range r = iter.next(n);
@@ -611,7 +611,7 @@ inline Status SegmentIterator::_read(Chunk* chunk, vector<rowid_t>* rowid, size_
 
     _cur_rowid = cur_rowid;
     _chunk_rowid_start = chunk_rowid_start;
-    _opts.stats->raw_rows_read += n;
+    _opts.stats->raw_rows_read += range.span_size();
     chunk->check_or_die();
     return Status::OK();
 }

--- a/be/src/storage/rowset/vectorized/segment_iterator.cpp
+++ b/be/src/storage/rowset/vectorized/segment_iterator.cpp
@@ -213,8 +213,8 @@ private:
 
     Status _read_by_column(size_t n, Chunk* result, vector<rowid_t>* rowids);
 
-    Status _read_column(size_t n, rowid_t cur_rowid, uint32_t col_id, SparseRangeIterator range_iter,
-                        Chunk* result, vector<rowid_t>* rowids);
+    Status _read_column(size_t n, rowid_t cur_rowid, uint32_t col_id, SparseRangeIterator range_iter, Chunk* result,
+                        vector<rowid_t>* rowids);
 
 private:
     std::shared_ptr<Segment> _segment;
@@ -584,7 +584,7 @@ inline Status SegmentIterator::_read(Chunk* chunk, vector<rowid_t>* rowid, size_
         RETURN_IF_ERROR(_context->seek_columns(_cur_rowid));
     }
 
-    while((read_num < n) && _range_iter.has_more()) {
+    while ((read_num < n) && _range_iter.has_more()) {
         Range r = _range_iter.next(n - read_num);
         read_num += r.span_size();
         chunk_rowid_start = r.begin();
@@ -598,7 +598,7 @@ inline Status SegmentIterator::_read(Chunk* chunk, vector<rowid_t>* rowid, size_
         RETURN_IF_ERROR(_context->read_columns(chunk, range));
     }
 
-    if (rowid !=  nullptr) {
+    if (rowid != nullptr) {
         rowid->reserve(rowid->size() + range.span_size());
         vectorized::SparseRangeIterator iter = range.new_iterator();
         while (iter.has_more()) {
@@ -661,7 +661,6 @@ Status SegmentIterator::_do_get_next(Chunk* result, vector<rowid_t>* rowid) {
     _context->_final_chunk->reset();
 
     Chunk* chunk = _context->_read_chunk.get();
-
 
     while ((chunk_start < chunk_capacity) & _range_iter.has_more()) {
         RETURN_IF_ERROR(_read(chunk, rowid, chunk_capacity - chunk_start));

--- a/be/src/storage/vectorized/range.h
+++ b/be/src/storage/vectorized/range.h
@@ -90,6 +90,9 @@ public:
     SparseRangeIterator() {}
     explicit SparseRangeIterator(const SparseRange* r);
 
+    SparseRangeIterator(const SparseRangeIterator& iter) :
+        _range(iter._range), _index(iter._index), _next_rowid(iter._next_rowid) {}
+
     rowid_t begin() const { return _next_rowid; }
 
     // Return true iff there are untraversed range, i.e, `next` will return a non-empty range.

--- a/be/src/storage/vectorized/range.h
+++ b/be/src/storage/vectorized/range.h
@@ -90,8 +90,8 @@ public:
     SparseRangeIterator() {}
     explicit SparseRangeIterator(const SparseRange* r);
 
-    SparseRangeIterator(const SparseRangeIterator& iter) :
-        _range(iter._range), _index(iter._index), _next_rowid(iter._next_rowid) {}
+    SparseRangeIterator(const SparseRangeIterator& iter)
+            : _range(iter._range), _index(iter._index), _next_rowid(iter._next_rowid) {}
 
     rowid_t begin() const { return _next_rowid; }
 


### PR DESCRIPTION
There are two changes as follows.
1. decompress the bitshuffle-encoded pages in advance to fit the page cache
2. replace read with range_read to reduce function calls