### PR TITLE
Fix mysql predicate case when bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/CaseExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/CaseExpr.java
@@ -125,7 +125,7 @@ public class CaseExpr extends Expr {
         StringBuilder output = new StringBuilder("CASE");
         int childIdx = 0;
         if (hasCaseExpr) {
-            output.append(children.get(childIdx++).toSql());
+            output.append(" ").append(children.get(childIdx++).toSql());
         }
         while (childIdx + 2 <= children.size()) {
             output.append(" WHEN " + children.get(childIdx++).toSql());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSingleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSingleTest.java
@@ -328,7 +328,7 @@ public class AnalyzeSingleTest {
                         "abs(`v1`)," +
                         "`v1` * `v1` / `v1` % `v1` + `v1` - `v1` DIV `v1`,`v2` & ~ `v1` | `v3` ^ 1," +
                         "`v1` + 20," +
-                        "CASE`v2` WHEN `v3` THEN 1 ELSE 0 END",
+                        "CASE `v2` WHEN `v3` THEN 1 ELSE 0 END",
                 String.join(",", query.getColumnOutputNames()));
 
         query = analyzeSuccess(

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -3275,19 +3275,19 @@ public class PlanFragmentTest extends PlanTestBase {
         String sql23 =
                 "select case 'a' when 'b' then 'a' when substr(k7,2,1) then 2 when false then 3 else 0 end as col23 from test.baseall";
         Assert.assertTrue(StringUtils.containsIgnoreCase(getFragmentPlan(sql23),
-                "CASE'a' WHEN 'b' THEN 'a' WHEN substr(9: k7, 2, 1) THEN '2' WHEN '0' THEN '3' ELSE '0' END"));
+                "CASE 'a' WHEN 'b' THEN 'a' WHEN substr(9: k7, 2, 1) THEN '2' WHEN '0' THEN '3' ELSE '0' END"));
 
         // 2.3.1  first when expr is not constant
         String sql231 =
                 "select case 'a' when substr(k7,2,1) then 2 when 1 then 'a' when false then 3 else 0 end as col231 from test.baseall";
         Assert.assertTrue(StringUtils.containsIgnoreCase(getFragmentPlan(sql231),
-                "CASE'a' WHEN substr(9: k7, 2, 1) THEN '2' WHEN '1' THEN 'a' WHEN '0' THEN '3' ELSE '0' END"));
+                "CASE 'a' WHEN substr(9: k7, 2, 1) THEN '2' WHEN '1' THEN 'a' WHEN '0' THEN '3' ELSE '0' END"));
 
         // 2.3.2 case expr is not constant
         String sql232 =
                 "select case k1 when substr(k7,2,1) then 2 when 1 then 'a' when false then 3 else 0 end as col232 from test.baseall";
         Assert.assertTrue(StringUtils.containsIgnoreCase(getFragmentPlan(sql232),
-                "CASECAST(1: k1 AS VARCHAR) WHEN substr(9: k7, 2, 1) THEN '2' WHEN '1' THEN 'a' WHEN '0' THEN '3' ELSE '0' END"));
+                "CASE CAST(1: k1 AS VARCHAR) WHEN substr(9: k7, 2, 1) THEN '2' WHEN '1' THEN 'a' WHEN '0' THEN '3' ELSE '0' END"));
 
         // 3.1 test float,float in case expr
         String sql31 = "select case cast(100 as float) when 1 then 'a' when 2 then 'b' else 'other' end as col31;";


### PR DESCRIPTION
For #1599

```
mysql> select * from external_mysql_table_with_null where case id_int  when '' then id_float else 0  end  > 1 limit 1;
ERROR 1064 (HY000): mysql query failed. Err: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'WHEN '' THEN id_float ELSE 0.0 END > 1.0)' at line 1
```

Reason:`WHERE (CASEid_int WHEN`

```
mysql> explain select * from external_mysql_table_with_null where case id_int  when '' then id_float else 0  end  > 1 limit 1;
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Explain String                                                                                                                                                                                                                            |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| WORK ON CBO OPTIMIZER                                                                                                                                                                                                                     |
| PLAN FRAGMENT 0                                                                                                                                                                                                                           |
|  OUTPUT EXPRS:id_tinyint | id_smallint | id_int | id_float | id_double | id_decimal | id_date | id_datetime | id_char | id_varchar                                                                                                        |
|   PARTITION: UNPARTITIONED                                                                                                                                                                                                                |
|                                                                                                                                                                                                                                           |
|   RESULT SINK                                                                                                                                                                                                                             |
|                                                                                                                                                                                                                                           |
|   0:SCAN MYSQL                                                                                                                                                                                                                            |
|      TABLE: `mysql_external_null`                                                                                                                                                                                                         |
|      Query: SELECT `id_tinyint`, `id_smallint`, `id_int`, `id_float`, `id_double`, `id_decimal`, `id_date`, `id_datetime`, `id_char`, `id_varchar` FROM `mysql_external_null` WHERE (CASEid_int WHEN '' THEN id_float ELSE 0.0 END > 1.0) |
|      limit: 1                                                                                                                                                                                                                             |
|      use vectorized: true                                                                                                                                                                                                                 |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
12 rows in set (0.00 sec)
```