### PR TITLE
Fix case expr cause be crash

### DIFF
--- a/be/test/exprs/vectorized/mock_vectorized_expr.h
+++ b/be/test/exprs/vectorized/mock_vectorized_expr.h
@@ -157,7 +157,10 @@ template <PrimitiveType Type>
 class MockNullVectorizedExpr : public MockCostExpr {
 public:
     MockNullVectorizedExpr(const TExprNode& t, size_t size, RunTimeCppType<Type> value)
-            : MockCostExpr(t), flag(0), size(size), value(value) {}
+            : MockNullVectorizedExpr(t, size, value, false) {}
+
+    MockNullVectorizedExpr(const TExprNode& t, size_t size, RunTimeCppType<Type> value, bool only_null)
+            : MockCostExpr(t), only_null(only_null), flag(0), size(size), value(value) {}
 
     DEFINE_NULL_TEST_ROW_FUNCTION(BooleanVal, get_boolean_val);
     DEFINE_NULL_TEST_ROW_FUNCTION(IntVal, get_int_val);


### PR DESCRIPTION
This is due to the fact that the previous logic only determines whether when column is null, not whether then column has a null value

will close #1588 