### PR TITLE
Fix estimate not equals predicate cardinality too small without columns statistics.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsEstimateCoefficient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsEstimateCoefficient.java
@@ -19,4 +19,6 @@ public class StatisticsEstimateCoefficient {
     public static final Double PREDICATE_UNKNOWN_FILTER_COEFFICIENT = 0.25;
     // constant value compare constant value filter coefficient
     public static final Double CONSTANT_TO_CONSTANT_PREDICATE_COEFFICIENT = 0.5;
+    // coefficient of overlap percent which overlap range is infinite
+    public static final Double OVERLAP_INFINITE_RANGE_FILTER_COEFFICIENT = 0.5;
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
@@ -594,11 +594,24 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
 
     @Test
     public void testColumnNotEqualsConstant() throws Exception {
+        // check cardinality not 0
         String sql =
                 "select S_SUPPKEY,S_NAME from supplier where s_name <> 'Supplier#000000050' and s_name >= 'Supplier#000000086'";
         String plan = getCostExplain(sql);
-        // check cardinality not 0
         Assert.assertTrue(plan.contains("cardinality: 500000"));
+
+        // test_all_type column statistics are unknown
+        sql = "select t1a,t1b from test_all_type where t1a <> 'xxx'";
+        plan = getCostExplain(sql);
+        Assert.assertTrue(plan.contains("cardinality: 3000000"));
+
+        sql = "select t1b,t1c from test_all_type where t1c <> 10";
+        plan = getCostExplain(sql);
+        Assert.assertTrue(plan.contains("cardinality: 3000000"));
+
+        sql = "select t1b,t1c from test_all_type where id_date <> '2020-01-01'";
+        plan = getCostExplain(sql);
+        Assert.assertTrue(plan.contains("cardinality: 3000000"));
     }
 
     @Test


### PR DESCRIPTION
Estimate not equals predicate cardinality be 0 without columns statistics now.
```
mysql> explain costs select L_ORDERKEY  from lineitem_par where L_SHIPINSTRUCT != 'JD' ;
+-------------------------------------------------------------------------------------------+
| Explain String                                                                            |
+-------------------------------------------------------------------------------------------+
| PLAN FRAGMENT 0(F01)                                                                      |
|   Output Exprs:1: L_ORDERKEY                                                              |
|   Input Partition: UNPARTITIONED                                                          |
|   RESULT SINK                                                                             |
|                                                                                           |
|   2:EXCHANGE                                                                              |
|      cardinality: 0                                                                       |
|                                                                                           |
| PLAN FRAGMENT 1(F00)                                                                      |
|                                                                                           |
|   Input Partition: RANDOM                                                                 |
|   OutPut Partition: UNPARTITIONED                                                         |
|   OutPut Exchange Id: 02                                                                  |
|                                                                                           |
|   1:Project                                                                               |
|   |  output columns:                                                                      |
|   |  1 <-> [1: L_ORDERKEY, INT, false]                                                    |
|   |  cardinality: 0                                                                       |
|   |  column statistics:                                                                   |
|   |  * L_ORDERKEY-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN                          |
|   |                                                                                       |
|   0:OlapScanNode                                                                          |
|      table: lineitem_par, rollup: lineitem_par                                            |
|      preAggregation: on                                                                   |
|      Predicates: [14: L_SHIPINSTRUCT, CHAR, false] != 'JD'                                |
|      partitionsRatio=7/7, tabletsRatio=336/336                                            |
|      tabletList=247662,247664,247666,247668,247670,247672,247674,247676,247678,247680 ... |
|      actualRows=59986052, avgRowSize=2.0                                                  |
|      cardinality: 0                                                                       |
|      column statistics:                                                                   |
|      * L_ORDERKEY-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN                          |
|      * L_SHIPINSTRUCT-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN                      |
+-------------------------------------------------------------------------------------------+
```

Estimate cardinality should not be 0.