### PR TITLE
Fix handle empty project operator error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalProjectOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalProjectOperator.java
@@ -41,10 +41,6 @@ public final class LogicalProjectOperator extends LogicalOperator {
 
     @Override
     public ColumnRefSet getOutputColumns(ExpressionContext expressionContext) {
-        if (columnRefMap.isEmpty()) {
-            return expressionContext.getChildOutputColumns(0);
-        }
-
         ColumnRefSet columns = new ColumnRefSet();
         for (Map.Entry<ColumnRefOperator, ScalarOperator> kv : columnRefMap.entrySet()) {
             columns.union(kv.getKey());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MergeProjectWithChildRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MergeProjectWithChildRule.java
@@ -27,6 +27,10 @@ public class MergeProjectWithChildRule extends TransformationRule {
     @Override
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
         LogicalProjectOperator logicalProjectOperator = (LogicalProjectOperator) input.getOp();
+
+        if (logicalProjectOperator.getColumnRefMap().isEmpty()) {
+            return Lists.newArrayList(input.getInputs().get(0));
+        }
         LogicalOperator child = (LogicalOperator) input.inputAt(0).getOp();
 
         ColumnRefSet projectColumns = logicalProjectOperator.getOutputColumns(

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneProjectRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneProjectRule.java
@@ -7,6 +7,7 @@ import com.starrocks.sql.optimizer.ExpressionContext;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.Utils;
+import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
@@ -38,7 +39,10 @@ public class PruneProjectRule extends TransformationRule {
             }
         }
 
-        return true;
+        // For count(*), the child output columns maybe empty, we needn't apply this rule
+        LogicalOperator logicalOperator = (LogicalOperator) input.inputAt(0).getOp();
+        ColumnRefSet outputColumn = logicalOperator.getOutputColumns(new ExpressionContext(input.inputAt(0)));
+        return outputColumn.cardinality() > 0;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -183,7 +183,7 @@ public class PlanFragmentBuilder {
         }
 
         List<Expr> outputExprs = outputColumns.stream().map(variable -> ScalarOperatorToExpr
-                        .buildExecExpression(variable, new ScalarOperatorToExpr.FormatterContext(execPlan.getColRefToExpr())))
+                .buildExecExpression(variable, new ScalarOperatorToExpr.FormatterContext(execPlan.getColRefToExpr())))
                 .collect(Collectors.toList());
         execPlan.getOutputExprs().addAll(outputExprs);
 
@@ -1071,7 +1071,7 @@ public class PlanFragmentBuilder {
                 }
                 List<Expr> distributeExpressions =
                         partitionColumns.stream().map(e -> ScalarOperatorToExpr.buildExecExpression(e,
-                                        new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
+                                new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
                                 .collect(Collectors.toList());
                 dataPartition = DataPartition.hashPartitioned(distributeExpressions);
             } else {
@@ -1308,7 +1308,7 @@ public class PlanFragmentBuilder {
 
                 List<Expr> eqJoinConjuncts =
                         eqOnPredicates.stream().map(e -> ScalarOperatorToExpr.buildExecExpression(e,
-                                        new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
+                                new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
                                 .collect(Collectors.toList());
 
                 for (Expr expr : eqJoinConjuncts) {
@@ -1320,13 +1320,13 @@ public class PlanFragmentBuilder {
                 List<ScalarOperator> otherJoin = Utils.extractConjuncts(node.getJoinPredicate());
                 otherJoin.removeAll(eqOnPredicates);
                 List<Expr> otherJoinConjuncts = otherJoin.stream().map(e -> ScalarOperatorToExpr.buildExecExpression(e,
-                                new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
+                        new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
                         .collect(Collectors.toList());
 
                 // 3. Get conjuncts
                 List<ScalarOperator> predicates = Utils.extractConjuncts(node.getPredicate());
                 List<Expr> conjuncts = predicates.stream().map(e -> ScalarOperatorToExpr.buildExecExpression(e,
-                                new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
+                        new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
                         .collect(Collectors.toList());
 
                 if (joinOperator.isLeftOuterJoin()) {
@@ -1387,14 +1387,14 @@ public class PlanFragmentBuilder {
                             .map(columnRefFactory::getColumnRef).collect(Collectors.toList());
                     List<Expr> leftJoinExprs =
                             leftPredicates.stream().map(e -> ScalarOperatorToExpr.buildExecExpression(e,
-                                            new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
+                                    new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
                                     .collect(Collectors.toList());
 
                     List<ScalarOperator> rightPredicates = rightOnPredicateColumns.stream()
                             .map(columnRefFactory::getColumnRef).collect(Collectors.toList());
                     List<Expr> rightJoinExprs =
                             rightPredicates.stream().map(e -> ScalarOperatorToExpr.buildExecExpression(e,
-                                            new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
+                                    new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
                                     .collect(Collectors.toList());
 
                     DataPartition lhsJoinPartition = new DataPartition(TPartitionType.HASH_PARTITIONED,
@@ -1628,7 +1628,7 @@ public class PlanFragmentBuilder {
 
             List<Expr> partitionExprs =
                     node.getPartitionExpressions().stream().map(e -> ScalarOperatorToExpr.buildExecExpression(e,
-                                    new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
+                            new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
                             .collect(Collectors.toList());
 
             List<OrderByElement> orderByElements = node.getOrderByElements().stream().map(e -> new OrderByElement(

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/UtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/UtilsTest.java
@@ -82,7 +82,6 @@ public class UtilsTest {
         starRocksAssert = new StarRocksAssert(connectContext);
         String DB_NAME = "test";
         starRocksAssert.withDatabase(DB_NAME).useDatabase(DB_NAME);
-        starRocksAssert.enableNewPlanner();
 
         connectContext.getSessionVariable().setMaxTransformReorderJoins(8);
         connectContext.getSessionVariable().setOptimizerExecuteTimeout(10000000000L);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -240,7 +240,6 @@ public class PlanFragmentTest extends PlanTestBase {
 
         sql = "select v1+20, if(false, v1, NULL) from t0 where v1 is null";
         planFragment = getFragmentPlan(sql);
-        System.out.println(planFragment);
         Assert.assertTrue(planFragment.contains("  1:Project\n" +
                 "  |  <slot 4> : 1: v1 + 20\n" +
                 "  |  <slot 5> : NULL"));
@@ -773,7 +772,6 @@ public class PlanFragmentTest extends PlanTestBase {
         String explainString;
         queryStr = "select k2, count(k3) from nocolocate3 group by k2";
         explainString = getFragmentPlan(queryStr);
-        System.out.println(explainString);
         Assert.assertTrue(explainString.contains("  3:AGGREGATE (merge finalize)\n"
                 + "  |  output: count(4: count)\n"
                 + "  |  group by: 2: k2\n"
@@ -1338,7 +1336,6 @@ public class PlanFragmentTest extends PlanTestBase {
         String sql = "select * from (select v1, v2 from t0 limit 10) a join [shuffle] " +
                 "(select v1, v2 from t0 limit 1) b on a.v1 = b.v1";
         String plan = getFragmentPlan(sql);
-        System.out.println(plan);
         Assert.assertTrue(plan.contains("join op: INNER JOIN (PARTITIONED)"));
         Assert.assertTrue(plan.contains("  |----5:EXCHANGE\n" +
                 "  |       limit: 1"));
@@ -3933,12 +3930,11 @@ public class PlanFragmentTest extends PlanTestBase {
     @Test
     public void testReplicationJoinWithPartitionTable() throws Exception {
         connectContext.getSessionVariable().setEnableReplicationJoin(true);
-        boolean oldValue = FeConstants.runningUnitTest;
         FeConstants.runningUnitTest = true;
         String sql = "select * from join1 join pushdown_test on join1.id = pushdown_test.k1;";
         String plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("INNER JOIN (BROADCAST)"));
-        FeConstants.runningUnitTest = oldValue;
+        FeConstants.runningUnitTest = false;
         connectContext.getSessionVariable().setEnableReplicationJoin(false);
     }
 
@@ -4515,5 +4511,18 @@ public class PlanFragmentTest extends PlanTestBase {
                 "     cardinality=1\n" +
                 "     avgRowSize=3.0\n" +
                 "     numNodes=0\n"));
+    }
+
+    @Test
+    public void testEmptyProjectCountStar() throws Exception {
+        String sql = "select count(*) from test_all_type a, test_all_type b where a.t1a is not null";
+        String plan = getCostExplain(sql);
+        Assert.assertTrue(plan.contains("  3:CROSS JOIN\n" +
+                "  |  cross join:\n" +
+                "  |  predicates is NULL.\n" +
+                "  |  cardinality: 1\n" +
+                "  |  column statistics: \n" +
+                "  |  * t1a-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN\n" +
+                "  |  * t1b-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN"));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestBase.java
@@ -62,7 +62,6 @@ public class PlanTestBase {
         starRocksAssert = new StarRocksAssert(connectContext);
         String DB_NAME = "test";
         starRocksAssert.withDatabase(DB_NAME).useDatabase(DB_NAME);
-        starRocksAssert.enableNewPlanner();
 
         connectContext.getCatalog().setStatisticStorage(new MockTpchStatisticStorage(1));
         connectContext.getSessionVariable().setMaxTransformReorderJoins(8);

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
@@ -71,10 +71,6 @@ public class StarRocksAssert {
         return this;
     }
 
-    public StarRocksAssert enableNewPlanner() {
-        return this;
-    }
-
     public StarRocksAssert withDatabase(String dbName) throws Exception {
         CreateDbStmt createDbStmt =
                 (CreateDbStmt) UtFrameUtils.parseAndAnalyzeStmt("create database " + dbName + ";", ctx);


### PR DESCRIPTION
For https://github.com/StarRocks/starrocks/issues/1583

```
java.lang.IllegalStateException: null
        at com.google.common.base.Preconditions.checkState(Preconditions.java:494) ~[spark-dpp-1.0.0.jar:?]
        at com.starrocks.sql.optimizer.statistics.Statistics.getColumnStatistic(Statistics.java:57) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.statistics.ExpressionStatisticCalculator$ExpressionStatisticVisitor.visitVariableReference(Expressi
onStatisticCalculator.java:54) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.statistics.ExpressionStatisticCalculator$ExpressionStatisticVisitor.visitVariableReference(Expressi
onStatisticCalculator.java:37) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator.accept(ColumnRefOperator.java:99) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.statistics.ExpressionStatisticCalculator.calculate(ExpressionStatisticCalculator.java:34) ~[starroc
ks-fe.jar:?]
        at com.starrocks.sql.optimizer.statistics.ExpressionStatisticCalculator.calculate(ExpressionStatisticCalculator.java:30) ~[starroc
ks-fe.jar:?]
        at com.starrocks.sql.optimizer.statistics.StatisticsCalculator.visitOperator(StatisticsCalculator.java:176) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.statistics.StatisticsCalculator.computeJoinNode(StatisticsCalculator.java:752) ~[starrocks-fe.jar:?
]
        at com.starrocks.sql.optimizer.statistics.StatisticsCalculator.visitLogicalJoin(StatisticsCalculator.java:646) ~[starrocks-fe.jar:
?]
        at com.starrocks.sql.optimizer.statistics.StatisticsCalculator.visitLogicalJoin(StatisticsCalculator.java:118) ~[starrocks-fe.jar:
?]
```

1. when get getOutputColumns from `LogicalProjectOperator` and columnRefMap.isEmpty, shouldn't get output columns from child
2. Add check in PruneProjectRule
3. In MergeProjectWithChildRule, if columnRefMap.isEmpty, should remove the project operator.
