### PR TITLE
add columns read to OlapScanNode explain string

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -554,6 +554,20 @@ public class OlapScanNode extends ScanNode {
         }
     }
 
+    private String getReadColumnNames() {
+        Set<String> columnNameSet = desc.getMaterializedSlots().stream()
+                .map(slot -> slot.getColumn().getName()).collect(Collectors.toSet());
+        if (!isPreAggregation && selectedIndexId != -1) {
+            for (Column col : olapTable.getSchemaByIndexId(selectedIndexId)) {
+                if (col.isKey()) {
+                    columnNameSet.add(col.getName());
+                }
+            }
+        }
+
+        return String.join(",", columnNameSet);
+    }
+
     /**
      * We query meta to get request's data location
      * extra result info will pass to backend ScanNode
@@ -618,6 +632,10 @@ public class OlapScanNode extends ScanNode {
                 "numNodes=%s", numNodes));
         output.append("\n");
 
+        output.append(prefix).append(String.format(
+                "columnsRead=%s", getReadColumnNames()));
+        output.append("\n");
+
         return output.toString();
     }
 
@@ -678,6 +696,10 @@ public class OlapScanNode extends ScanNode {
                 "actualRows=%s", actualRows))
                 .append(", ").append(String.format(
                 "avgRowSize=%s", avgRowSize)).append("\n");
+
+        output.append(prefix).append(String.format(
+                "columnsRead=%s", getReadColumnNames()));
+        output.append("\n");
         return output.toString();
     }
 


### PR DESCRIPTION
Add columns read to OlapScanNode explain string, like following:
0:OlapScanNode                                                            |
|      TABLE: table1                                                          |
|      PREAGGREGATION: OFF. Reason: Predicates include the value column       |
|      PREDICATES: 4: pv > 10                                                 |
|      partitions=1/1                                                         |
|      rollup: table1                                                         |
|      tabletRatio=10/10                                                      |
|      tabletList=50012,50014 |
|      cardinality=1                                                          |
|      avgRowSize=1.0                                                         |
|      numNodes=0                                                             |
|      columnsRead=citycode,pv,siteid,username                                |