### PR TITLE
Fix display rollup information incorrect

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
@@ -708,7 +708,6 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
         info.add(baseIndexName);
         info.add(rollupIndexName);
         info.add(rollupIndexId);
-        info.add(Integer.toString(rollupSchemaHash));
         info.add(watershedTxnId);
         info.add(jobState.name());
         info.add(errMsg);

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/ShowAlterStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/ShowAlterStmt.java
@@ -254,9 +254,9 @@ public class ShowAlterStmt extends ShowStmt {
         ShowResultSetMetaData.Builder builder = ShowResultSetMetaData.builder();
 
         ImmutableList<String> titleNames = null;
-        if (type == AlterType.ROLLUP) {
+        if (type == AlterType.ROLLUP || type == AlterType.MATERIALIZED_VIEW) {
             titleNames = RollupProcDir.TITLE_NAMES;
-        } else if (type == AlterType.COLUMN || type == AlterType.MATERIALIZED_VIEW) {
+        } else if (type == AlterType.COLUMN ) {
             titleNames = SchemaChangeProcDir.TITLE_NAMES;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/ShowAlterStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/ShowAlterStmt.java
@@ -256,7 +256,7 @@ public class ShowAlterStmt extends ShowStmt {
         ImmutableList<String> titleNames = null;
         if (type == AlterType.ROLLUP || type == AlterType.MATERIALIZED_VIEW) {
             titleNames = RollupProcDir.TITLE_NAMES;
-        } else if (type == AlterType.COLUMN ) {
+        } else if (type == AlterType.COLUMN) {
             titleNames = SchemaChangeProcDir.TITLE_NAMES;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/FrontendsProcNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/FrontendsProcNode.java
@@ -125,7 +125,12 @@ public class FrontendsProcNode implements ProcNodeInterface {
             } else {
                 info.add("NULL");
             }
-            info.add(fe.getFeVersion());
+
+            if (fe.getFeVersion() == null) {
+                info.add("NULL");
+            } else {
+                info.add(fe.getFeVersion());
+            }
 
             infos.add(info);
         }


### PR DESCRIPTION
The information is not right when using `show alter table rollup`. The value is not corresponds to the tab bar.
The pull request adjust the position to make it be right.

