### PR TITLE
Fix can not extract plan with new_planner_agg_stage=1

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
@@ -109,9 +109,9 @@ public class CostModel {
                     inputStatistics.getComputeSize());
         }
 
-        // Note: This method logic must consistent with SplitAggregateRule::canGenerateTwoStageAggregate
+
         boolean canGenerateOneStageAggNode(ExpressionContext context) {
-            // 1 Must do two stage aggregate if child operator is LogicalRepeatOperator
+            // 1. Must do two stage aggregate if child operator is LogicalRepeatOperator
             //   If the repeat node is used as the input node of the Exchange node.
             //   Will cause the node to be unable to confirm whether it is const during serialization
             //   (BE does this for efficiency reasons).
@@ -121,7 +121,7 @@ public class CostModel {
                 return false;
             }
 
-            // 2 Must do two stage aggregate is aggregate function has array type
+            // 2. Must do two stage aggregate is aggregate function has array type
             if (context.getOp() instanceof PhysicalHashAggregateOperator) {
                 PhysicalHashAggregateOperator operator = (PhysicalHashAggregateOperator) context.getOp();
                 if (operator.getAggregations().values().stream().anyMatch(callOperator
@@ -130,14 +130,7 @@ public class CostModel {
                 }
             }
 
-            // 3 Must do one stage aggregate If the child contains limit,
-            // the aggregation must be a single node to ensure correctness.
-            // eg. select count(*) from (select * table limit 2) t
-            if (context.getChildOperator(0).hasLimit()) {
-                return true;
-            }
-
-            // 4. agg distinct function with multi columns can not generate one stage aggregate
+            // 3. agg distinct function with multi columns can not generate one stage aggregate
             if (context.getOp() instanceof PhysicalHashAggregateOperator) {
                 PhysicalHashAggregateOperator operator = (PhysicalHashAggregateOperator) context.getOp();
                 if (operator.getAggregations().values().stream().anyMatch(callOperator -> callOperator.isDistinct() &&
@@ -145,7 +138,28 @@ public class CostModel {
                     return false;
                 }
             }
+            return true;
+        }
 
+        boolean mustGenerateOneStageAggNode(ExpressionContext context) {
+            // Must do one stage aggregate If the child contains limit,
+            // the aggregation must be a single node to ensure correctness.
+            // eg. select count(*) from (select * table limit 2) t
+            if (context.getChildOperator(0).hasLimit()) {
+                return true;
+            }
+            return false;
+        }
+
+        // Note: This method logic must consistent with SplitAggregateRule::needGenerateMultiStageAggregate
+        boolean needGenerateOneStageAggNode(ExpressionContext context) {
+            if (!canGenerateOneStageAggNode(context)) {
+                return false;
+            }
+            if (mustGenerateOneStageAggNode(context)) {
+                return true;
+            }
+            // respect user hint
             int aggStage = ConnectContext.get().getSessionVariable().getNewPlannerAggStage();
             return aggStage == 1 || aggStage == 0;
         }
@@ -212,7 +226,7 @@ public class CostModel {
 
         @Override
         public CostEstimate visitPhysicalHashAggregate(PhysicalHashAggregateOperator node, ExpressionContext context) {
-            if (!canGenerateOneStageAggNode(context) && !node.isSplit() && node.getType().isGlobal()) {
+            if (!needGenerateOneStageAggNode(context) && !node.isSplit() && node.getType().isGlobal()) {
                 return CostEstimate.infinite();
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
@@ -20,7 +20,6 @@ import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.operator.AggType;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
-import com.starrocks.sql.optimizer.operator.logical.LogicalOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalRepeatOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
@@ -56,8 +55,17 @@ public class SplitAggregateRule extends TransformationRule {
         return agg.getType().isGlobal() && !agg.isSplit();
     }
 
-    // Note: This method logic must consistent with CostEstimator::canGenerateOneStageAggNode
-    private boolean needGenerateTwoStageAggregate(OptExpression input, long distinctCount) {
+    private boolean canGenerateMultiStageAggregate(OptExpression input) {
+        // Must do one stage aggregate If the child contains limit,
+        // the aggregation must be a single node to ensure correctness.
+        // eg. select count(*) from (select * table limit 2) t
+        if (input.inputAt(0).getOp().hasLimit()) {
+            return false;
+        }
+        return true;
+    }
+
+    private boolean mustGenerateMultiStageAggregate(OptExpression input, List<CallOperator> distinctAggCallOperator) {
         LogicalAggregationOperator aggregationOperator = (LogicalAggregationOperator) input.getOp();
         // 1 Must do two stage aggregate if child operator is LogicalRepeatOperator
         //   If the repeat node is used as the input node of the Exchange node.
@@ -68,32 +76,36 @@ public class SplitAggregateRule extends TransformationRule {
         if (input.inputAt(0).getOp() instanceof LogicalRepeatOperator) {
             return true;
         }
-
         // 2 Must do two stage aggregate is aggregate function has array type
         if (aggregationOperator.getAggregations().values().stream().anyMatch(callOperator
                 -> callOperator.getChildren().stream().anyMatch(c -> c.getType().isArrayType()))) {
             return true;
         }
+        // 3. Must generate three, four phase aggregate for distinct aggregate with multi columns
+        boolean hasMultiColumns =
+                distinctAggCallOperator.stream().anyMatch(callOperator -> callOperator.getChildren().size() > 1);
+        if (distinctAggCallOperator.size() > 0 && hasMultiColumns) {
+            return true;
+        }
+        return false;
+    }
 
-        // 3 Must do one stage aggregate If the child contains limit,
-        // the aggregation must be a single node to ensure correctness.
-        // eg. select count(*) from (select * table limit 2) t
-        if (((LogicalOperator) input.inputAt(0).getOp()).getLimit() != -1) {
+    // Note: This method logic must consistent with CostEstimator::needGenerateOneStageAggNode
+    private boolean needGenerateMultiStageAggregate(OptExpression input, List<CallOperator> distinctAggCallOperator) {
+        // 1. check if can generate multi stage aggregate.
+        if (!canGenerateMultiStageAggregate(input)) {
             return false;
         }
-
-        // 4 Respect user hint
+        // 2. check if must generate multi stage aggregate.
+        if (mustGenerateMultiStageAggregate(input, distinctAggCallOperator)) {
+            return true;
+        }
+        // 3. Respect user hint
         int aggStage = ConnectContext.get().getSessionVariable().getNewPlannerAggStage();
         if (aggStage == 1) {
             return false;
         }
-
-        // 5 generate two, three, four phase aggregate for distinct aggregate
-        if (distinctCount > 0) {
-            return true;
-        }
-
-        // 6 If scan tablet sum leas than 1, do one phase aggregate is enough
+        // 4. If scan tablet sum leas than 1, do one phase aggregate is enough
         if (aggStage == 0 && input.getLogicalProperty().isExecuteInOneTablet()) {
             return false;
         }
@@ -137,7 +149,7 @@ public class SplitAggregateRule extends TransformationRule {
                 .collect(Collectors.toList());
         long distinctCount = distinctAggCallOperator.size();
 
-        if (!needGenerateTwoStageAggregate(input, distinctCount)) {
+        if (!needGenerateMultiStageAggregate(input, distinctAggCallOperator)) {
             return Lists.newArrayList();
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecodeRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecodeRewriteTest.java
@@ -141,10 +141,12 @@ public class DecodeRewriteTest extends PlanTestBase {
         Assert.assertTrue(plan.contains("count(10: S_ADDRESS)"));
 
         sql = "select count(distinct S_ADDRESS) from supplier";
+        connectContext.getSessionVariable().setNewPlanerAggStage(4);
         plan = getFragmentPlan(sql);
         Assert.assertFalse(plan.contains("Decode"));
         Assert.assertTrue(plan.contains("count(10: S_ADDRESS)"));
         Assert.assertTrue(plan.contains("HASH_PARTITIONED: 10: S_ADDRESS"));
+        connectContext.getSessionVariable().setNewPlanerAggStage(0);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -4595,4 +4595,38 @@ public class PlanFragmentTest extends PlanTestBase {
                 "  |  * t1a-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN\n" +
                 "  |  * t1b-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN"));
     }
+
+    @Test
+    public void testCountDistinctMultiColumns() throws Exception {
+        connectContext.getSessionVariable().setNewPlanerAggStage(1);
+        String sql = "select count(distinct L_SHIPMODE,L_ORDERKEY) from lineitem";
+        String plan = getFragmentPlan(sql);
+        // check use 4 stage agg plan
+        Assert.assertTrue(plan.contains("5:AGGREGATE (merge finalize)\n" +
+                "  |  output: count(18: count)"));
+        Assert.assertTrue(plan.contains("3:AGGREGATE (update serialize)\n" +
+                "  |  output: count(if(15: L_SHIPMODE IS NULL, NULL, 1: L_ORDERKEY))\n" +
+                "  |  group by: \n" +
+                "  |  \n" +
+                "  2:AGGREGATE (merge serialize)\n" +
+                "  |  group by: 1: L_ORDERKEY, 15: L_SHIPMODE\n" +
+                "  |  \n" +
+                "  1:AGGREGATE (update serialize)\n" +
+                "  |  STREAMING\n" +
+                "  |  group by: 1: L_ORDERKEY, 15: L_SHIPMODE"));
+
+        sql = "select count(distinct L_SHIPMODE,L_ORDERKEY) from lineitem group by L_PARTKEY";
+        plan = getFragmentPlan(sql);
+        // check use 3 stage agg plan
+        Assert.assertTrue(plan.contains(" 4:AGGREGATE (update finalize)\n" +
+                "  |  output: count(if(15: L_SHIPMODE IS NULL, NULL, 1: L_ORDERKEY))\n" +
+                "  |  group by: 2: L_PARTKEY\n" +
+                "  |  \n" +
+                "  3:AGGREGATE (merge serialize)\n" +
+                "  |  group by: 1: L_ORDERKEY, 2: L_PARTKEY, 15: L_SHIPMODE"));
+        Assert.assertTrue(plan.contains("1:AGGREGATE (update serialize)\n" +
+                "  |  STREAMING\n" +
+                "  |  group by: 1: L_ORDERKEY, 2: L_PARTKEY, 15: L_SHIPMODE"));
+        connectContext.getSessionVariable().setNewPlanerAggStage(0);
+    }
 }


### PR DESCRIPTION
ref #1473 
can not extract best plan because of the one stage plan is  pruned by the costMoel because the distinct agg in one Stage with multi columns is not  valid  plan. And in splite agg rule it not splite to multi agg stage because the session varibale new_planner_agg_stage is set to 1 

So, we need use a right order when check the needGenerateMultiStageAgg