### PR TITLE
Fix the mem statistics bug of result sink

### DIFF
--- a/be/src/runtime/result_sink.cpp
+++ b/be/src/runtime/result_sink.cpp
@@ -103,7 +103,11 @@ Status ResultSink::open(RuntimeState* state) {
 }
 
 Status ResultSink::send_chunk(RuntimeState* state, vectorized::Chunk* chunk) {
-    // Query memory, no longer count the memory of the final sent result set
+    // The ResultWriter memory that sends the results is no longer recorded to the query memory.
+    // There are two reason:
+    // 1. the query result has come out, and then the memory limit is triggered, cancel, it is not necessary
+    // 2. if this memory is counted, The memory of the receiving thread needs to be recorded,
+    // and the life cycle of MemTracker needs to be considered
     SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(nullptr);
     return _writer->append_chunk(chunk);
 }

--- a/be/src/runtime/result_sink.cpp
+++ b/be/src/runtime/result_sink.cpp
@@ -26,6 +26,7 @@
 #include "common/config.h"
 #include "exprs/expr.h"
 #include "runtime/buffer_control_block.h"
+#include "runtime/current_thread.h"
 #include "runtime/exec_env.h"
 #include "runtime/file_result_writer.h"
 #include "runtime/mem_tracker.h"
@@ -102,6 +103,7 @@ Status ResultSink::open(RuntimeState* state) {
 }
 
 Status ResultSink::send_chunk(RuntimeState* state, vectorized::Chunk* chunk) {
+    SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(nullptr);
     return _writer->append_chunk(chunk);
 }
 

--- a/be/src/runtime/result_sink.cpp
+++ b/be/src/runtime/result_sink.cpp
@@ -103,6 +103,7 @@ Status ResultSink::open(RuntimeState* state) {
 }
 
 Status ResultSink::send_chunk(RuntimeState* state, vectorized::Chunk* chunk) {
+    // Query memory, no longer count the memory of the final sent result set
     SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(nullptr);
     return _writer->append_chunk(chunk);
 }


### PR DESCRIPTION
for #1560 

Remove the memory of ResultWriter from the query memory