### PR TITLE
[pipeline] Transform stage to OperatorStage::PROCESSING before process pipeline driver

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver_dispatcher.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_dispatcher.cpp
@@ -139,13 +139,13 @@ void GlobalDriverDispatcher::run() {
 }
 
 void GlobalDriverDispatcher::dispatch(DriverRawPtr driver) {
+    driver->dispatch_operators();
     if (driver->dependencies_block()) {
         driver->set_driver_state(DriverState::DEPENDENCIES_BLOCK);
         this->_blocked_driver_poller->add_blocked_driver(driver);
     } else {
         this->_driver_queue->put_back(driver);
     }
-    driver->dispatch_operators();
 }
 
 void GlobalDriverDispatcher::report_exec_state(FragmentContext* fragment_ctx, const Status& status, bool done) {


### PR DESCRIPTION
`enum OperatorStage {
    INIT = 0,
    PREPARED = 4,
    PROCESSING = 8,
    FINISHING = 12,
    FINISHED = 16,
    CLOSED = 20,
};`

- As we put driver to _driver_queue, process pipeline driver before dispatch_operators maybe transform later stage(FINISHING...) back to PROCESSING, so can't guarantee that called exactly one time.