### PR TITLE
Add own ClosureGuard for correct memory tracker

### DIFF
--- a/be/src/common/closure_guard.h
+++ b/be/src/common/closure_guard.h
@@ -1,0 +1,61 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#pragma once
+
+#include <google/protobuf/service.h>
+
+#include "runtime/current_thread.h"
+
+namespace starrocks {
+
+// RAII: Call Run() of the closure on destruction.
+// Just like brpc::ClosureGuard, but before calling Run(),
+// the thread-local memory tracker will be reset to NULL.
+class ClosureGuard {
+public:
+    ClosureGuard() : _done(NULL) {}
+
+    // Constructed with a closure which will be Run() inside dtor.
+    explicit ClosureGuard(google::protobuf::Closure* done) : _done(done) {}
+
+    // Run internal closure if it's not NULL.
+    ~ClosureGuard() {
+        if (_done) {
+            SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(nullptr);
+            _done->Run();
+        }
+    }
+
+    // Copying this object makes no sense.
+    ClosureGuard(const ClosureGuard&) = delete;
+    void operator=(const ClosureGuard&) = delete;
+    ClosureGuard(ClosureGuard&&) = delete;
+    void operator=(ClosureGuard&&) = delete;
+
+    // Run internal closure if it's not NULL and set it to `done'.
+    void reset(google::protobuf::Closure* done) {
+        if (_done) {
+            SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(nullptr);
+            _done->Run();
+        }
+        _done = done;
+    }
+
+    // Return and set internal closure to NULL.
+    google::protobuf::Closure* release() {
+        google::protobuf::Closure* const prev_done = _done;
+        _done = NULL;
+        return prev_done;
+    }
+
+    // True if no closure inside.
+    bool empty() const { return _done == NULL; }
+
+    // Exchange closure with another guard.
+    void swap(ClosureGuard& other) { std::swap(_done, other._done); }
+
+private:
+    google::protobuf::Closure* _done;
+};
+
+} // namespace starrocks

--- a/be/test/exprs/vectorized/encryption_functions_test.cpp
+++ b/be/test/exprs/vectorized/encryption_functions_test.cpp
@@ -719,7 +719,9 @@ TEST_F(EncryptionFunctionsTest, sha224Test) {
         ASSERT_EQ(check_result[j], v->get_data()[j].to_string());
     }
 
-    ASSERT_TRUE(EncryptionFunctions::sha2_close(ctx.get(), FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
+    ASSERT_TRUE(EncryptionFunctions::sha2_close(ctx.get(),
+                                                FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+                        .ok());
 }
 
 TEST_F(EncryptionFunctionsTest, sha256Test) {
@@ -751,7 +753,9 @@ TEST_F(EncryptionFunctionsTest, sha256Test) {
         ASSERT_EQ(check_result[j], v->get_data()[j].to_string());
     }
 
-    ASSERT_TRUE(EncryptionFunctions::sha2_close(ctx.get(), FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
+    ASSERT_TRUE(EncryptionFunctions::sha2_close(ctx.get(),
+                                                FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+                        .ok());
 }
 
 TEST_F(EncryptionFunctionsTest, sha384Test) {
@@ -777,13 +781,16 @@ TEST_F(EncryptionFunctionsTest, sha384Test) {
 
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
 
-    std::string check_result[2] = {"eda8e790960d9ff4fdc6f481ec57bf443c147bf092086006e98a2ab0108afbaaf8e6f51d197f988dd798d2524b12de2c",
-                                   "6195d65242957bdf844e6623acabf2b0879c9cb282a9490ed332f7fdc41aedbda7802af06d07f38d7ed69449d3ff5bf8"};
+    std::string check_result[2] = {
+            "eda8e790960d9ff4fdc6f481ec57bf443c147bf092086006e98a2ab0108afbaaf8e6f51d197f988dd798d2524b12de2c",
+            "6195d65242957bdf844e6623acabf2b0879c9cb282a9490ed332f7fdc41aedbda7802af06d07f38d7ed69449d3ff5bf8"};
     for (int j = 0; j < sizeof(check_result) / sizeof(check_result[0]); ++j) {
         ASSERT_EQ(check_result[j], v->get_data()[j].to_string());
     }
 
-    ASSERT_TRUE(EncryptionFunctions::sha2_close(ctx.get(), FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
+    ASSERT_TRUE(EncryptionFunctions::sha2_close(ctx.get(),
+                                                FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+                        .ok());
 }
 
 TEST_F(EncryptionFunctionsTest, sha512Test) {
@@ -809,13 +816,18 @@ TEST_F(EncryptionFunctionsTest, sha512Test) {
 
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
 
-    std::string check_result[2] = {"9df77afa38c688166eaa7511440dd3a0b1c32918e9ae60b8c74e4b0f530852cd1a0facc610b71ebfcbe345f5fa40983fe68a686144d2c6981b8a3fab1b045cd0",
-                                   "eaf18d26b2976216790d95b2942d15b7db5f926c7d62d35f24c98b8eedbe96f2e6241e5e4fdc6b7d9e7893d94d86cd8a6f3bb6b1804c22097b337ecc24f6015e"};
+    std::string check_result[2] = {
+            "9df77afa38c688166eaa7511440dd3a0b1c32918e9ae60b8c74e4b0f530852cd1a0facc610b71ebfcbe345f5fa40983fe68a686144"
+            "d2c6981b8a3fab1b045cd0",
+            "eaf18d26b2976216790d95b2942d15b7db5f926c7d62d35f24c98b8eedbe96f2e6241e5e4fdc6b7d9e7893d94d86cd8a6f3bb6b180"
+            "4c22097b337ecc24f6015e"};
     for (int j = 0; j < sizeof(check_result) / sizeof(check_result[0]); ++j) {
         ASSERT_EQ(check_result[j], v->get_data()[j].to_string());
     }
 
-    ASSERT_TRUE(EncryptionFunctions::sha2_close(ctx.get(), FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
+    ASSERT_TRUE(EncryptionFunctions::sha2_close(ctx.get(),
+                                                FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+                        .ok());
 }
 
 TEST_F(EncryptionFunctionsTest, invalidSHATest) {
@@ -847,7 +859,9 @@ TEST_F(EncryptionFunctionsTest, invalidSHATest) {
         ASSERT_TRUE(result->is_null(j));
     }
 
-    ASSERT_TRUE(EncryptionFunctions::sha2_close(ctx.get(), FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
+    ASSERT_TRUE(EncryptionFunctions::sha2_close(ctx.get(),
+                                                FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+                        .ok());
 }
 
 } // namespace vectorized

--- a/be/test/exprs/vectorized/json_functions_test.cpp
+++ b/be/test/exprs/vectorized/json_functions_test.cpp
@@ -271,21 +271,21 @@ TEST_F(JsonFunctionsTest, get_json_emptyTest) {
 }
 
 TEST_F(JsonFunctionsTest, json_minify_test) {
-        simdjson::ondemand::parser parser;
-        auto cars_json = R"( { "test":[ { "val1":1, "val2":2 }, { "val1":1, "val2":2 } ] }   )"_padded;
-        simdjson::ondemand::document doc;
-        auto err = parser.iterate(cars_json).get(doc);
-        ASSERT_EQ(err, simdjson::error_code::SUCCESS);
+    simdjson::ondemand::parser parser;
+    auto cars_json = R"( { "test":[ { "val1":1, "val2":2 }, { "val1":1, "val2":2 } ] }   )"_padded;
+    simdjson::ondemand::document doc;
+    auto err = parser.iterate(cars_json).get(doc);
+    ASSERT_EQ(err, simdjson::error_code::SUCCESS);
 
-        simdjson::ondemand::value val;
-        err = doc.get_value().get(val);
-        ASSERT_EQ(err, simdjson::error_code::SUCCESS);
+    simdjson::ondemand::value val;
+    err = doc.get_value().get(val);
+    ASSERT_EQ(err, simdjson::error_code::SUCCESS);
 
-        std::unique_ptr<char[]> buf_ptr;
-        size_t dstlen{};
-        JsonFunctions::minify_json_to_string(val, buf_ptr, dstlen);
-        ASSERT_EQ(std::string(buf_ptr.get(), dstlen), "{\"test\":[{\"val1\":1,\"val2\":2},{\"val1\":1,\"val2\":2}]}");
-        ASSERT_EQ(dstlen, 50);
+    std::unique_ptr<char[]> buf_ptr;
+    size_t dstlen{};
+    JsonFunctions::minify_json_to_string(val, buf_ptr, dstlen);
+    ASSERT_EQ(std::string(buf_ptr.get(), dstlen), "{\"test\":[{\"val1\":1,\"val2\":2},{\"val1\":1,\"val2\":2}]}");
+    ASSERT_EQ(dstlen, 50);
 }
 
 } // namespace vectorized


### PR DESCRIPTION
Before calling the Run() method of a RPC closure, reset
the thread-local memory tracker to NULL to ensure that those
released memory will not be counted into our memory tracker