### PR TITLE
Use hashtable for resource manager to achieve strong consistency

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceMgr.java
@@ -22,7 +22,6 @@
 package com.starrocks.catalog;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.analysis.CreateResourceStmt;
 import com.starrocks.analysis.DropResourceStmt;
@@ -42,6 +41,7 @@ import org.apache.logging.log4j.Logger;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
 
@@ -59,7 +59,7 @@ public class ResourceMgr implements Writable {
 
     // { resourceName -> Resource}
     @SerializedName(value = "nameToResource")
-    private final Map<String, Resource> nameToResource = Maps.newConcurrentMap();
+    private final Hashtable<String, Resource> nameToResource = new Hashtable<>();
     private final ResourceProcNode procNode = new ResourceProcNode();
 
     public ResourceMgr() {


### PR DESCRIPTION
ResourceMgr use ConcurrentHashMap to store nameToResource information in memory.
Since ConcurrentHashMap is weak consistency, we will see inconsistent data when use `show resources` command and `create/drop resource`.
```

mysql> show resources;
+-------------------+--------------+---------------------+-----------------------------+
| Name              | ResourceType | Key                 | Value                       |
+-------------------+--------------+---------------------+-----------------------------+
| hive2             | hive         | hive.metastore.uris | thrift://172.26.92.141:9083 |
| hive_resource_248 | hive         | hive.metastore.uris | thrift://10.10.44.98:9083   |
+-------------------+--------------+---------------------+-----------------------------+
2 rows in set (0.00 sec)

mysql> drop resource hive_resource_248;
ERROR 1064 (HY000): Resource(hive_resource_248) does not exist

mysql>CREATE EXTERNAL RESOURCE hive_resource_concurrency_crt_999 PROPERTIES ("type" = "hive","hive.metastore.uris" = "thrift://172.26.92.141:9083");
ERROR 1064 (HY000): Resource(hive_resource_concurrency_crt_999) already exist
```
We should use HashTable to provide strong consistency. Since update resource is not a frequency operation, high performance has lower priority than data consistency.