### PR TITLE
BugFix: re-order the column as the json key

### DIFF
--- a/be/src/exec/vectorized/json_scanner.cpp
+++ b/be/src/exec/vectorized/json_scanner.cpp
@@ -440,7 +440,7 @@ void JsonReader::_reorder_column(std::vector<SlotDescriptor*>* slot_descs,
 
     std::set<std::string> key_set;
 
-    // index of sorted elements in the ordered_slot_descs.
+    // Index of sorted elements in the ordered_slot_descs.
     size_t idx = 0;
 
     std::ostringstream oss;
@@ -465,9 +465,11 @@ void JsonReader::_reorder_column(std::vector<SlotDescriptor*>* slot_descs,
 
         key_set.insert(key);
 
+        // Find the SlotDescriptor with the json document key.
         auto itr = std::find_if(ordered_slot_descs.begin(), ordered_slot_descs.end(),
                                 [&key](const SlotDescriptor* desc) { return desc->col_name() == key; });
 
+        // Swap the SlotDescriptor to the expected index.
         if (itr != ordered_slot_descs.end()) {
             std::swap(ordered_slot_descs[idx], *itr);
             idx++;

--- a/be/src/exec/vectorized/json_scanner.cpp
+++ b/be/src/exec/vectorized/json_scanner.cpp
@@ -469,9 +469,7 @@ void JsonReader::_reorder_column(std::vector<SlotDescriptor*>* slot_descs,
                                 [&key](const SlotDescriptor* desc) { return desc->col_name() == key; });
 
         if (itr != ordered_slot_descs.end()) {
-            auto tmp = *itr;
-            *itr = ordered_slot_descs.at(idx);
-            ordered_slot_descs.at(idx) = tmp;
+            std::swap(ordered_slot_descs[idx], *itr);
             idx++;
         }
     }


### PR DESCRIPTION
It's faster to iterate the simdjson document as the key order of json.
ref: https://github.com/simdjson/simdjson/blob/master/doc/basics.md

This PR is to fix the mistake of the reordering.
ref: #1651 

# Benchmark Result:
test case: ndjson format, 95 MB per file, 100 files in total,
| Version | Throughput | 
| --- | --- | 
| fixed | 118MB/s | 
| main | 86MB/s |