### PR TITLE
Remove version_hash in BE code paths.

### DIFF
--- a/be/src/http/action/checksum_action.cpp
+++ b/be/src/http/action/checksum_action.cpp
@@ -42,7 +42,6 @@ const std::string TABLET_ID = "tablet_id";
 // do not use name "VERSION",
 // or will be conflict with "VERSION" in thrift/config.h
 const std::string TABLET_VERSION = "version";
-const std::string VERSION_HASH = "version_hash";
 const std::string SCHEMA_HASH = "schema_hash";
 
 ChecksumAction::ChecksumAction(ExecEnv* exec_env) : _exec_env(exec_env) {}
@@ -67,14 +66,6 @@ void ChecksumAction::handle(HttpRequest* req) {
         return;
     }
 
-    // Get version hash
-    const std::string& version_hash_str = req->param(VERSION_HASH);
-    if (version_hash_str.empty()) {
-        std::string error_msg = std::string("parameter " + VERSION_HASH + " not specified in url.");
-        HttpChannel::send_reply(req, HttpStatus::BAD_REQUEST, error_msg);
-        return;
-    }
-
     // Get schema hash
     const std::string& schema_hash_str = req->param(SCHEMA_HASH);
     if (schema_hash_str.empty()) {
@@ -86,12 +77,10 @@ void ChecksumAction::handle(HttpRequest* req) {
     // valid str format
     int64_t tablet_id;
     int64_t version;
-    int64_t version_hash;
     int32_t schema_hash;
     try {
         tablet_id = boost::lexical_cast<int64_t>(tablet_id_str);
         version = boost::lexical_cast<int64_t>(version_str);
-        version_hash = boost::lexical_cast<int64_t>(version_hash_str);
         schema_hash = boost::lexical_cast<int64_t>(schema_hash_str);
     } catch (boost::bad_lexical_cast& e) {
         std::string error_msg = std::string("param format is invalid: ") + std::string(e.what());
@@ -99,10 +88,9 @@ void ChecksumAction::handle(HttpRequest* req) {
         return;
     }
 
-    VLOG_ROW << "get checksum tablet info: " << tablet_id << "-" << version << "-" << version_hash << "-"
-             << schema_hash;
+    VLOG_ROW << "get checksum tablet info: " << tablet_id << "-" << version << "-" << schema_hash;
 
-    int64_t checksum = do_checksum(tablet_id, version, version_hash, schema_hash, req);
+    int64_t checksum = do_checksum(tablet_id, version, schema_hash, req);
     if (checksum == -1L) {
         std::string error_msg = std::string("checksum failed");
         HttpChannel::send_reply(req, HttpStatus::INTERNAL_SERVER_ERROR, error_msg);
@@ -117,12 +105,11 @@ void ChecksumAction::handle(HttpRequest* req) {
     LOG(INFO) << "deal with checksum request finished! tablet id: " << tablet_id;
 }
 
-int64_t ChecksumAction::do_checksum(int64_t tablet_id, int64_t version, int64_t version_hash, int32_t schema_hash,
-                                    HttpRequest* req) {
+int64_t ChecksumAction::do_checksum(int64_t tablet_id, int64_t version, int32_t schema_hash, HttpRequest* req) {
     OLAPStatus res = OLAP_SUCCESS;
     uint32_t checksum;
     EngineChecksumTask engine_task(ExecEnv::GetInstance()->consistency_mem_tracker(), tablet_id, schema_hash, version,
-                                   version_hash, &checksum);
+                                   &checksum);
     res = engine_task.execute();
     if (res != OLAP_SUCCESS) {
         LOG(WARNING) << "checksum failed. status: " << res << ", signature: " << tablet_id;

--- a/be/src/http/action/checksum_action.h
+++ b/be/src/http/action/checksum_action.h
@@ -39,8 +39,7 @@ public:
     void handle(HttpRequest* req) override;
 
 private:
-    std::int64_t do_checksum(std::int64_t tablet_id, std::int64_t version, std::int64_t version_hash,
-                             std::int32_t schema_hash, HttpRequest* req);
+    std::int64_t do_checksum(std::int64_t tablet_id, std::int64_t version, std::int32_t schema_hash, HttpRequest* req);
 
     ExecEnv* _exec_env;
 

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -653,7 +653,6 @@ Status FragmentMgr::exec_external_plan_fragment(const TScanOpenParams& params, c
             TTabletVersionInfo info = iter->second;
             scan_range.tablet_id = tablet_id;
             scan_range.version = std::to_string(info.version);
-            scan_range.version_hash = std::to_string(info.version_hash);
             scan_range.schema_hash = std::to_string(info.schema_hash);
             scan_range.hosts.push_back(address);
         } else {

--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -49,7 +49,6 @@ namespace starrocks {
 static const int64_t MAX_ROWSET_ID = 1L << 56;
 
 typedef int32_t SchemaHash;
-typedef int64_t VersionHash;
 typedef __int128 int128_t;
 typedef unsigned __int128 uint128_t;
 

--- a/be/src/storage/rowset/beta_rowset_reader.h
+++ b/be/src/storage/rowset/beta_rowset_reader.h
@@ -45,8 +45,6 @@ public:
 
     Version version() override { return _rowset->version(); }
 
-    VersionHash version_hash() override { return _rowset->version_hash(); }
-
     RowsetSharedPtr rowset() override { return std::dynamic_pointer_cast<Rowset>(_rowset); }
 
     int64_t filtered_rows() override { return _stats->rows_del_filtered; }

--- a/be/src/storage/rowset/beta_rowset_writer.cpp
+++ b/be/src/storage/rowset/beta_rowset_writer.cpp
@@ -158,7 +158,6 @@ OLAPStatus BetaRowsetWriter::init() {
         _rowset_meta->set_load_id(_context.load_id);
     } else {
         _rowset_meta->set_version(_context.version);
-        _rowset_meta->set_version_hash(_context.version_hash);
     }
     _rowset_meta->set_tablet_uid(_context.tablet_uid);
     return OLAP_SUCCESS;

--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -59,9 +59,8 @@ Status Rowset::load() {
     return Status::OK();
 }
 
-void Rowset::make_visible(Version version, VersionHash version_hash) {
+void Rowset::make_visible(Version version) {
     _rowset_meta->set_version(version);
-    _rowset_meta->set_version_hash(version_hash);
     _rowset_meta->set_rowset_state(VISIBLE);
     // update create time to the visible time,
     // it's used to skip recently published version during compaction
@@ -71,14 +70,13 @@ void Rowset::make_visible(Version version, VersionHash version_hash) {
         _rowset_meta->mutable_delete_predicate()->set_version(version.first);
         return;
     }
-    make_visible_extra(version, version_hash);
+    make_visible_extra(version);
 }
 
 void Rowset::make_commit(int64_t version, uint32_t rowset_seg_id) {
     _rowset_meta->set_rowset_seg_id(rowset_seg_id);
     Version v(version, version);
     _rowset_meta->set_version(v);
-    _rowset_meta->set_version_hash(0);
     _rowset_meta->set_rowset_state(VISIBLE);
     // update create time to the visible time,
     // it's used to skip recently published version during compaction
@@ -88,7 +86,7 @@ void Rowset::make_commit(int64_t version, uint32_t rowset_seg_id) {
         _rowset_meta->mutable_delete_predicate()->set_version(version);
         return;
     }
-    make_visible_extra(v, 0);
+    make_visible_extra(v);
 }
 
 } // namespace starrocks

--- a/be/src/storage/rowset/rowset.h
+++ b/be/src/storage/rowset/rowset.h
@@ -141,7 +141,7 @@ public:
     const RowsetMetaSharedPtr& rowset_meta() const { return _rowset_meta; }
 
     // publish rowset to make it visible to read
-    void make_visible(Version version, VersionHash version_hash);
+    void make_visible(Version version);
 
     // like make_visible but updatable tablet has different mechanism
     // NOTE: only used for updatable tablet's rowset
@@ -150,7 +150,6 @@ public:
     // helper class to access RowsetMeta
     int64_t start_version() const { return rowset_meta()->version().first; }
     int64_t end_version() const { return rowset_meta()->version().second; }
-    VersionHash version_hash() const { return rowset_meta()->version_hash(); }
     size_t index_disk_size() const { return rowset_meta()->index_disk_size(); }
     size_t data_disk_size() const { return rowset_meta()->total_disk_size(); }
     bool empty() const { return rowset_meta()->empty(); }
@@ -268,7 +267,7 @@ protected:
     virtual void do_close() = 0;
 
     // allow subclass to add custom logic when rowset is being published
-    virtual void make_visible_extra(Version version, VersionHash version_hash) {}
+    virtual void make_visible_extra(Version version) {}
 
     const TabletSchema* _schema;
     std::string _rowset_path;

--- a/be/src/storage/rowset/rowset_meta.h
+++ b/be/src/storage/rowset/rowset_meta.h
@@ -130,10 +130,6 @@ public:
 
     void set_end_version(int64_t end_version) { _rowset_meta_pb.set_end_version(end_version); }
 
-    VersionHash version_hash() const { return _rowset_meta_pb.version_hash(); }
-
-    void set_version_hash(VersionHash version_hash) { _rowset_meta_pb.set_version_hash(version_hash); }
-
     int64_t num_rows() const { return _rowset_meta_pb.num_rows(); }
 
     void set_num_rows(int64_t num_rows) { _rowset_meta_pb.set_num_rows(num_rows); }

--- a/be/src/storage/rowset/rowset_reader.h
+++ b/be/src/storage/rowset/rowset_reader.h
@@ -52,8 +52,6 @@ public:
 
     virtual Version version() = 0;
 
-    virtual VersionHash version_hash() = 0;
-
     virtual RowsetSharedPtr rowset() = 0;
 
     virtual int64_t filtered_rows() = 0;

--- a/be/src/storage/rowset/rowset_writer_context.h
+++ b/be/src/storage/rowset/rowset_writer_context.h
@@ -55,7 +55,6 @@ public:
     int64_t partition_id = 0;
     int64_t txn_id = 0;
     Version version{};
-    VersionHash version_hash = 0;
     TabletUid tablet_uid = {0, 0};
     PUniqueId load_id{};
     // temporary segment files create or not, set false as default

--- a/be/src/storage/snapshot_manager.cpp
+++ b/be/src/storage/snapshot_manager.cpp
@@ -243,7 +243,6 @@ Status SnapshotManager::_rename_rowset_id(const RowsetMetaPB& rs_meta_pb, const 
     context.tablet_schema = &tablet_schema;
     context.rowset_state = org_rowset_meta->rowset_state();
     context.version = org_rowset_meta->version();
-    context.version_hash = org_rowset_meta->version_hash();
     // keep segments_overlap same as origin rowset
     context.segments_overlap = rowset_meta->segments_overlap();
 

--- a/be/src/storage/tablet.h
+++ b/be/src/storage/tablet.h
@@ -185,8 +185,6 @@ public:
     bool can_do_compaction();
     const uint32_t calc_cumulative_compaction_score() const;
     const uint32_t calc_base_compaction_score() const;
-    static void compute_version_hash_from_rowsets(const std::vector<RowsetSharedPtr>& rowsets,
-                                                  VersionHash* version_hash);
 
     // operation for clone
     void calc_missed_versions(int64_t spec_version, vector<Version>* missed_versions);
@@ -256,7 +254,7 @@ private:
     Status _contains_version(const Version& version);
     Version _max_continuous_version_from_beginning_unlocked() const;
     RowsetSharedPtr _rowset_with_largest_size();
-    void _delete_inc_rowset_by_version(const Version& version, const VersionHash& version_hash);
+    void _delete_inc_rowset_by_version(const Version& version);
     /// Delete stale rowset by version. This method not only delete the version in expired rowset map,
     /// but also delete the version in rowset meta vector.
     void _delete_stale_rowset_by_version(const Version& version);
@@ -281,7 +279,6 @@ private:
     // should use with migration lock.
     std::atomic<bool> _is_migrating{false};
 
-    // TODO(lingbin): There is a _meta_lock TabletMeta too, there should be a comment to
     // explain how these two locks work together.
     mutable std::shared_mutex _meta_lock;
     // A new load job will produce a new rowset, which will be inserted into both _rs_version_map

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -1109,7 +1109,6 @@ Status TabletManager::_create_inital_rowset_unlocked(const TCreateTabletReq& req
             context.tablet_schema = &tablet->tablet_schema();
             context.rowset_state = VISIBLE;
             context.version = version;
-            context.version_hash = request.version_hash;
             // there is no data in init rowset, so overlapping info is unknown.
             context.segments_overlap = OVERLAP_UNKNOWN;
 

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -1525,7 +1525,6 @@ void TabletUpdates::get_tablet_info_extra(TTabletInfo* info) {
                                  << " rowset=" << err_rowsets;
     }
     info->__set_version(version);
-    info->__set_version_hash(0);
     info->__set_version_count(rowsets.size());
     info->__set_row_count(total_row);
     info->__set_data_size(total_size);
@@ -1874,7 +1873,6 @@ Status TabletUpdates::convert_from(const std::shared_ptr<Tablet>& base_tablet, i
         writer_context.tablet_schema = &_tablet.tablet_schema();
         writer_context.rowset_state = VISIBLE;
         writer_context.version = src_rowset->version();
-        writer_context.version_hash = src_rowset->version_hash();
         writer_context.segments_overlap = src_rowset->rowset_meta()->segments_overlap();
 
         std::unique_ptr<RowsetWriter> rowset_writer;

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -139,7 +139,7 @@ public:
     // Note: EditVersion history count, not like talet.version_count()
     size_t version_history_count() const { return _edit_version_infos.size(); }
 
-    // get info's version, version_hash, version_count, row_count, data_size
+    // get info's version, version_count, row_count, data_size
     void get_tablet_info_extra(TTabletInfo* info);
 
     std::string debug_string() const;

--- a/be/src/storage/task/engine_checksum_task.cpp
+++ b/be/src/storage/task/engine_checksum_task.cpp
@@ -33,12 +33,8 @@
 namespace starrocks {
 
 EngineChecksumTask::EngineChecksumTask(MemTracker* mem_tracker, TTabletId tablet_id, TSchemaHash schema_hash,
-                                       TVersion version, TVersionHash version_hash, uint32_t* checksum)
-        : _tablet_id(tablet_id),
-          _schema_hash(schema_hash),
-          _version(version),
-          _version_hash(version_hash),
-          _checksum(checksum) {
+                                       TVersion version, uint32_t* checksum)
+        : _tablet_id(tablet_id), _schema_hash(schema_hash), _version(version), _checksum(checksum) {
     _mem_tracker = std::make_unique<MemTracker>(-1, "checksum instance", mem_tracker);
 }
 

--- a/be/src/storage/task/engine_checksum_task.h
+++ b/be/src/storage/task/engine_checksum_task.h
@@ -35,7 +35,7 @@ public:
     OLAPStatus execute() override;
 
     EngineChecksumTask(MemTracker* mem_tracker, TTabletId tablet_id, TSchemaHash schema_hash, TVersion version,
-                       TVersionHash version_hash, uint32_t* checksum);
+                       uint32_t* checksum);
 
     ~EngineChecksumTask() override = default;
 
@@ -47,7 +47,6 @@ private:
     TTabletId _tablet_id;
     TSchemaHash _schema_hash;
     TVersion _version;
-    TVersionHash _version_hash;
     uint32_t* _checksum;
 }; // EngineTask
 

--- a/be/src/storage/task/engine_publish_version_task.cpp
+++ b/be/src/storage/task/engine_publish_version_task.cpp
@@ -57,7 +57,6 @@ OLAPStatus EnginePublishVersionTask::finish() {
                                                                           &tablet_related_rs);
 
         Version version(par_ver_info.version, par_ver_info.version);
-        VersionHash version_hash = par_ver_info.version_hash;
 
         // each tablet
         for (auto& tablet_rs : tablet_related_rs) {
@@ -66,8 +65,7 @@ OLAPStatus EnginePublishVersionTask::finish() {
             const RowsetSharedPtr& rowset = tablet_rs.second;
             VLOG(1) << "begin to publish version on tablet. "
                     << "tablet_id=" << tablet_info.tablet_id << ", schema_hash=" << tablet_info.schema_hash
-                    << ", version=" << version.first << ", version_hash=" << version_hash
-                    << ", transaction_id=" << transaction_id;
+                    << ", version=" << version.first << ", transaction_id=" << transaction_id;
             // if rowset is null, it means this be received write task, but failed during write
             // and receive fe's publish version task
             // this be must return as an error tablet
@@ -94,8 +92,8 @@ OLAPStatus EnginePublishVersionTask::finish() {
                 publish_status = StorageEngine::instance()->txn_manager()->publish_txn2(transaction_id, partition_id,
                                                                                         tablet, version.second);
             } else {
-                publish_status = StorageEngine::instance()->txn_manager()->publish_txn(
-                        partition_id, tablet, transaction_id, version, version_hash);
+                publish_status = StorageEngine::instance()->txn_manager()->publish_txn(partition_id, tablet,
+                                                                                       transaction_id, version);
             }
             if (publish_status != OLAP_SUCCESS) {
                 LOG(WARNING) << "failed to publish version. rowset_id=" << rowset->rowset_id()

--- a/be/src/storage/txn_manager.cpp
+++ b/be/src/storage/txn_manager.cpp
@@ -84,9 +84,9 @@ OLAPStatus TxnManager::commit_txn(TPartitionId partition_id, const TabletSharedP
 }
 
 OLAPStatus TxnManager::publish_txn(TPartitionId partition_id, const TabletSharedPtr& tablet,
-                                   TTransactionId transaction_id, const Version& version, VersionHash version_hash) {
+                                   TTransactionId transaction_id, const Version& version) {
     return publish_txn(tablet->data_dir()->get_meta(), partition_id, transaction_id, tablet->tablet_id(),
-                       tablet->schema_hash(), tablet->tablet_uid(), version, version_hash);
+                       tablet->schema_hash(), tablet->tablet_uid(), version);
 }
 
 // delete the txn from manager if it is not committed(not have a valid rowset)
@@ -234,7 +234,7 @@ OLAPStatus TxnManager::commit_txn(KVStore* meta, TPartitionId partition_id, TTra
 // remove a txn from txn manager
 OLAPStatus TxnManager::publish_txn(KVStore* meta, TPartitionId partition_id, TTransactionId transaction_id,
                                    TTabletId tablet_id, SchemaHash schema_hash, const TabletUid& tablet_uid,
-                                   const Version& version, VersionHash version_hash) {
+                                   const Version& version) {
     pair<int64_t, int64_t> key(partition_id, transaction_id);
     TabletInfo tablet_info(tablet_id, schema_hash, tablet_uid);
     RowsetSharedPtr rowset_ptr = nullptr;
@@ -258,7 +258,7 @@ OLAPStatus TxnManager::publish_txn(KVStore* meta, TPartitionId partition_id, TTr
     if (rowset_ptr != nullptr) {
         // TODO(ygl): rowset is already set version here, memory is changed, if save failed
         // it maybe a fatal error
-        rowset_ptr->make_visible(version, version_hash);
+        rowset_ptr->make_visible(version);
         auto& rowset_meta_pb = rowset_ptr->rowset_meta()->get_meta_pb();
         Status st = RowsetMetaManager::save(meta, tablet_uid, rowset_ptr->rowset_id(), rowset_meta_pb);
         if (!st.ok()) {

--- a/be/src/storage/txn_manager.h
+++ b/be/src/storage/txn_manager.h
@@ -79,7 +79,7 @@ public:
                           const PUniqueId& load_id, const RowsetSharedPtr& rowset_ptr, bool is_recovery);
 
     OLAPStatus publish_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, TTransactionId transaction_id,
-                           const Version& version, VersionHash version_hash);
+                           const Version& version);
 
     // publish_txn for updatable tablet
     OLAPStatus publish_txn2(TTransactionId transaction_id, TPartitionId partition_id, const TabletSharedPtr& tablet,
@@ -101,8 +101,7 @@ public:
 
     // remove a txn from txn manager & persist rowset meta
     OLAPStatus publish_txn(KVStore* meta, TPartitionId partition_id, TTransactionId transaction_id, TTabletId tablet_id,
-                           SchemaHash schema_hash, const TabletUid& tablet_uid, const Version& version,
-                           VersionHash version_hash);
+                           SchemaHash schema_hash, const TabletUid& tablet_uid, const Version& version);
 
     // delete the txn from manager if it is not committed(not have a valid rowset)
     OLAPStatus rollback_txn(TPartitionId partition_id, TTransactionId transaction_id, TTabletId tablet_id,

--- a/be/src/storage/vectorized/compaction.cpp
+++ b/be/src/storage/vectorized/compaction.cpp
@@ -58,7 +58,6 @@ Status Compaction::do_compaction_impl() {
     TRACE_COUNTER_INCREMENT("input_segments_num", segments_num);
 
     _output_version = Version(_input_rowsets.front()->start_version(), _input_rowsets.back()->end_version());
-    _tablet->compute_version_hash_from_rowsets(_input_rowsets, &_output_version_hash);
 
     LOG(INFO) << "start " << compaction_name() << ". tablet=" << _tablet->full_name()
               << ", output version is=" << _output_version.first << "-" << _output_version.second;
@@ -135,7 +134,6 @@ Status Compaction::construct_output_rowset_writer() {
     context.tablet_schema = &(_tablet->tablet_schema());
     context.rowset_state = VISIBLE;
     context.version = _output_version;
-    context.version_hash = _output_version_hash;
     context.segments_overlap = NONOVERLAPPING;
     Status st = RowsetFactory::create_rowset_writer(context, &_output_rs_writer);
     if (!st.ok()) {

--- a/be/src/storage/vectorized/compaction.h
+++ b/be/src/storage/vectorized/compaction.h
@@ -82,7 +82,6 @@ protected:
     CompactionState _state;
 
     Version _output_version;
-    VersionHash _output_version_hash;
 
     RuntimeProfile _runtime_profile;
 };

--- a/be/src/storage/vectorized/schema_change.cpp
+++ b/be/src/storage/vectorized/schema_change.cpp
@@ -867,8 +867,7 @@ bool SchemaChangeWithSorting::_internal_sorting(std::vector<ChunkPtr>& chunk_arr
 Status SchemaChangeHandler::process_alter_tablet_v2(const TAlterTabletReqV2& request) {
     LOG(INFO) << "begin to do request alter tablet: base_tablet_id=" << request.base_tablet_id
               << ", base_schema_hash=" << request.base_schema_hash << ", new_tablet_id=" << request.new_tablet_id
-              << ", new_schema_hash=" << request.new_schema_hash << ", alter_version=" << request.alter_version
-              << ", alter_version_hash=" << request.alter_version_hash;
+              << ", new_schema_hash=" << request.new_schema_hash << ", alter_version=" << request.alter_version;
 
     MonotonicStopWatch timer;
     timer.start();
@@ -1171,7 +1170,6 @@ Status SchemaChangeHandler::_convert_historical_rowsets(SchemaChangeParams& sc_p
         writer_context.tablet_schema = &new_tablet->tablet_schema();
         writer_context.rowset_state = VISIBLE;
         writer_context.version = sc_params.rowsets_to_change[i]->version();
-        writer_context.version_hash = sc_params.rowsets_to_change[i]->version_hash();
         writer_context.segments_overlap = sc_params.rowsets_to_change[i]->rowset_meta()->segments_overlap();
 
         if (sc_params.sc_sorting) {

--- a/be/test/storage/vectorized/base_compaction_test.cpp
+++ b/be/test/storage/vectorized/base_compaction_test.cpp
@@ -35,7 +35,6 @@ public:
         rowset_writer_context->tablet_schema = _tablet_schema.get();
         rowset_writer_context->version.first = 0;
         rowset_writer_context->version.second = 1;
-        rowset_writer_context->version_hash = 110;
     }
 
     void create_tablet_schema(KeysType keys_type) {

--- a/be/test/storage/vectorized/cumulative_compaction_test.cpp
+++ b/be/test/storage/vectorized/cumulative_compaction_test.cpp
@@ -33,7 +33,6 @@ public:
         rowset_writer_context->tablet_schema = _tablet_schema.get();
         rowset_writer_context->version.first = 0;
         rowset_writer_context->version.second = 0;
-        rowset_writer_context->version_hash = 110;
     }
 
     void create_tablet_schema(KeysType keys_type) {

--- a/be/test/storage/vectorized/schema_change_test.cpp
+++ b/be/test/storage/vectorized/schema_change_test.cpp
@@ -74,7 +74,6 @@ class SchemaChangeTest : public testing::Test {
         writer_context.tablet_schema = &(tablet->tablet_schema());
         writer_context.rowset_state = VISIBLE;
         writer_context.version = Version(3, 3);
-        writer_context.version_hash = 0;
         std::unique_ptr<RowsetWriter> rowset_writer;
         ASSERT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &rowset_writer).ok());
         EXPECT_EQ(OLAP_SUCCESS, rowset_writer->add_chunk(*base_chunk));
@@ -460,7 +459,6 @@ TEST_F(SchemaChangeTest, convert_from) {
     writer_context.tablet_schema = &(new_tablet->tablet_schema());
     writer_context.rowset_state = VISIBLE;
     writer_context.version = Version(3, 3);
-    writer_context.version_hash = 0;
     std::unique_ptr<RowsetWriter> rowset_writer;
     ASSERT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &rowset_writer).ok());
 
@@ -520,7 +518,6 @@ TEST_F(SchemaChangeTest, schema_change_with_sorting) {
     writer_context.tablet_schema = &(new_tablet->tablet_schema());
     writer_context.rowset_state = VISIBLE;
     writer_context.version = Version(3, 3);
-    writer_context.version_hash = 0;
     std::unique_ptr<RowsetWriter> rowset_writer;
     ASSERT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &rowset_writer).ok());
 

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -71,7 +71,7 @@ message RowsetMetaPB {
     // only for visible rowset.
     optional int64 end_version = 9;
     // only for visible rowset.
-    optional int64 version_hash = 10;
+    optional int64 version_hash = 10 [deprecated = true];
     // total number of rows.
     optional int64 num_rows = 11;
     // calculated by index + data
@@ -274,7 +274,7 @@ message TabletMetaPB {
 message OLAPIndexHeaderMessage {
     required int32 start_version = 1;
     required int32 end_version = 2;
-    required int64 cumulative_version_hash = 3;
+    required int64 cumulative_version_hash = 3 [deprecated = true];
 
     required uint32 segment = 4;
     required uint32 num_rows_per_block = 5;

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -59,8 +59,7 @@ struct TCreateTabletReq {
     1: required Types.TTabletId tablet_id
     2: required TTabletSchema tablet_schema
     3: optional Types.TVersion version
-    // Deprecated
-    4: optional Types.TVersionHash version_hash 
+    4: optional Types.TVersionHash version_hash // Deprecated
     5: optional Types.TStorageMedium storage_medium
     6: optional bool in_restore_mode
     // this new tablet should be colocate with base tablet

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -694,15 +694,15 @@ struct TReplicaMeta {
     2: optional i64 backend_id
     3: optional i32 schema_hash
     4: optional i64 version
-    5: optional i64 version_hash
+    5: optional i64 version_hash // Deprecated
     6: optional i64 data_size
     7: optional i64 row_count
     8: optional string state
     9: optional i64 last_failed_version
-    10: optional i64 last_failed_version_hash
+    10: optional i64 last_failed_version_hash // Deprecated
     11: optional i64 last_failed_time
     12: optional i64 last_success_version
-    13: optional i64 last_success_version_hash
+    13: optional i64 last_success_version_hash // Deprecated
     14: optional i64 version_count
     15: optional i64 path_hash
     16: optional bool bad
@@ -718,7 +718,7 @@ struct TTabletMeta {
     7: optional i32 old_schema_hash
     8: optional i32 new_schema_hash
     9: optional i64 checked_version
-    10: optional i64 checked_version_hash
+    10: optional i64 checked_version_hash // Deprecated
     11: optional bool consistent
     12: optional list<TReplicaMeta> replicas
 }
@@ -809,12 +809,12 @@ struct TPartitionMeta {
     1: optional i64 partition_id
     2: optional string partition_name
     3: optional string state
-    4: optional i64 commit_version_hash
+    4: optional i64 commit_version_hash // Deprecated
     5: optional i64 visible_version
-    6: optional i64 visible_version_hash
+    6: optional i64 visible_version_hash // Deprecated
     7: optional i64 visible_time
     8: optional i64 next_version
-    9: optional i64 next_version_hash
+    9: optional i64 next_version_hash // Deprecated
 }
 
 struct THashDistributionInfo {

--- a/gensrc/thrift/MasterService.thrift
+++ b/gensrc/thrift/MasterService.thrift
@@ -31,7 +31,7 @@ struct TTabletInfo {
     1: required Types.TTabletId tablet_id
     2: required Types.TSchemaHash schema_hash
     3: required Types.TVersion version
-    4: required Types.TVersionHash version_hash
+    4: required Types.TVersionHash version_hash // Deprecated
     5: required Types.TCount row_count
     6: required Types.TSize data_size
     7: optional Types.TStorageMedium storage_medium
@@ -53,7 +53,7 @@ struct TFinishTaskRequest {
     6: optional list<TTabletInfo> finish_tablet_infos
     7: optional i64 tablet_checksum
     8: optional i64 request_version
-    9: optional i64 request_version_hash
+    9: optional i64 request_version_hash // Deprecated
     10: optional string snapshot_path
     11: optional list<Types.TTabletId> error_tablet_ids
     12: optional list<string> snapshot_files

--- a/gensrc/thrift/QueryPlanExtra.thrift
+++ b/gensrc/thrift/QueryPlanExtra.thrift
@@ -30,7 +30,7 @@ include "Descriptors.thrift"
 struct TTabletVersionInfo {
   1: required i64 tablet_id
   2: required i64 version
-  3: required i64 version_hash
+  3: required i64 version_hash // Deprecated
   // i32 for historical reason
   4: required i32 schema_hash
 }


### PR DESCRIPTION
The version_hash is used to differentiate the different loads with the same version.
After the load transaction is changed to two-phase commit, the different loads
will be guaranteed with different versions.
The version_hash is already not used in StarRocks, and can be removed.
This pull request is to remove the version_hash in BE code paths.