### PR TITLE
Improve select * from table limit 10 query in BE

### DIFF
--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -263,6 +263,11 @@ void OlapScanNode::_scanner_thread(TabletScanner* scanner) {
             delete chunk;
             break;
         }
+        // Improve for select * from table limit x;
+        if (limit() != -1 && scanner->num_rows_read() >= limit()) {
+            status = Status::EndOfFile("limit reach");
+            break;
+        }
         if (scanner->raw_rows_read() >= raw_rows_threshold) {
             resubmit = true;
             break;

--- a/be/src/exec/vectorized/tablet_scanner.h
+++ b/be/src/exec/vectorized/tablet_scanner.h
@@ -50,6 +50,7 @@ public:
 
     RuntimeState* runtime_state() { return _runtime_state; }
     int64_t raw_rows_read() const { return _raw_rows_read; }
+    int64_t num_rows_read() const { return _num_rows_read; }
 
     // REQUIRES: `init(RuntimeState*, const TabletScannerParams&)` has been called.
     const Schema& chunk_schema() const { return _prj_iter->output_schema(); }
@@ -63,7 +64,7 @@ private:
     Status _init_return_columns();
     Status _init_global_dicts();
     Status _init_unused_output_columns(const std::vector<std::string>& unused_output_columns);
-    void _update_realtime_counter();
+    void _update_realtime_counter(Chunk* chunk);
     void update_counter();
 
     RuntimeState* _runtime_state = nullptr;


### PR DESCRIPTION
```
    SCAN:(Active: 6.410ms, non-child: 31.38%)
       - CachedPagesNum: 61
       - CompressedBytesRead: 0
       - CreateSegmentIter: 996.449us
       - IOTime: 0.000ns
       - PushdownPredicates: 0
       - RawRowsRead: 8.19K
       - SegmentInit: 124.544us
         - BitmapIndexFilter: 0.000ns
         - BitmapIndexFilterRows: 0
         - BloomFilterFilterRows: 0
         - SegmentZoneMapFilterRows: 0
         - ShortKeyFilterRows: 0
         - ZoneMapIndexFilterRows: 0
       - SegmentRead: 6.282ms
         - BlockFetch: 5.583ms
         - BlockFetchCount: 2
```

From the profile, we could get two improve points:
1. RawRowsRead shouldn't be 8.19K, only need to be 10
2. BlockFetchCount shouldn't be 2, only need to be 1