### PR TITLE
make buffer stream reserve bytes configurable

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -652,6 +652,10 @@ CONF_Int16(bitmap_serialize_version, "1");
 CONF_Bool(enable_schema_change_vectorized, "true");
 // max hdfs file handle
 CONF_mInt32(max_hdfs_file_handle, "1000");
+// buffer stream reserve size
+// each column will reserve buffer_stream_reserve_size bytes for read
+// default: 8M
+CONF_mInt32(buffer_stream_reserve_size, "8192000");
 
 } // namespace config
 

--- a/be/src/util/buffered_stream.cpp
+++ b/be/src/util/buffered_stream.cpp
@@ -2,6 +2,7 @@
 
 #include "util/buffered_stream.h"
 
+#include "common/config.h"
 #include "env/env.h"
 #include "util/bit_util.h"
 
@@ -9,7 +10,7 @@ namespace starrocks {
 
 BufferedInputStream::BufferedInputStream(RandomAccessFile* file, uint64_t offset, uint64_t length)
         : _file(file), _offset(offset), _end_offset(offset + length) {
-    _reserve(8 * 1024 * 1024);
+    _reserve(config::buffer_stream_reserve_size);
 }
 
 Status BufferedInputStream::get_bytes(const uint8_t** buffer, size_t* nbytes, bool peek) {


### PR DESCRIPTION
From the results of some of my tests, it is very difficult to find a suitable buffer size. So for now let this value be configurable.

here was my test result:
1FE 1BE SSB-1T

| query                                     | 8M        | 8K        | 800K |
| ----------------------------------------- | --------- | --------- |-----|
| select count(lo_shipmode) from lineorder; | 8.43-8.88 | 7.51-8.88 ||
| select count(s_suppkey),count(s_name),count(s_city),count(s_region),count(s_phone) from supplier; | 0.34|1.2 |0.72|



