### PR TITLE
[pipeline] fix: don't partition hash table for NOT IN

### DIFF
--- a/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
@@ -55,7 +55,7 @@ void LocalExchangeSourceOperator::set_finished(RuntimeState* state) {
     // Compute out the number of rows of the _full_chunk_queue.
     size_t full_rows_num = 0;
     while (!_full_chunk_queue.empty()) {
-        auto&& chunk = std::move(_full_chunk_queue.front());
+        auto chunk = std::move(_full_chunk_queue.front());
         _full_chunk_queue.pop();
         full_rows_num += chunk->num_rows();
     }

--- a/be/src/exec/vectorized/hash_join_node.cpp
+++ b/be/src/exec/vectorized/hash_join_node.cpp
@@ -350,10 +350,16 @@ Status HashJoinNode::close(RuntimeState* state) {
 }
 
 pipeline::OpFactories HashJoinNode::decompose_to_pipeline(pipeline::PipelineBuilderContext* context) {
+    // "col NOT IN (NULL, val1, val2)" always returns false, so hash join should
+    // return empty result in this case. Hash join cannot be divided into multiple
+    // partitions in this case. Otherwise, NULL value in right table will only occur
+    // in some partition hash table, and other partition hash table can output chunk.
+    size_t num_partitions = _join_type == TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN ? 1 : context->degree_of_parallelism();
+
     auto hash_joiner_factory = std::make_shared<starrocks::pipeline::HashJoinerFactory>(
             _hash_join_node, _id, _type, limit(), std::move(_is_null_safes), _build_expr_ctxs, _probe_expr_ctxs,
             std::move(_other_join_conjunct_ctxs), std::move(_conjunct_ctxs), child(1)->row_desc(), child(0)->row_desc(),
-            _row_descriptor, context->degree_of_parallelism());
+            _row_descriptor, num_partitions);
 
     auto build_op = std::make_shared<pipeline::HashJoinBuildOperatorFactory>(context->next_operator_id(), id(),
                                                                              hash_joiner_factory);
@@ -362,15 +368,24 @@ pipeline::OpFactories HashJoinNode::decompose_to_pipeline(pipeline::PipelineBuil
                                                                              hash_joiner_factory);
     auto rhs_operators = child(1)->decompose_to_pipeline(context);
     auto lhs_operators = child(0)->decompose_to_pipeline(context);
-    // both HashJoin{Build, Probe}Operator are parallelized, so add LocalExchangeOperator
-    // to shuffle multi-stream into #degree_of_parallelism# streams each of that pipes into HashJoin{Build, Probe}Operator.
-    auto operators_with_build_op = context->maybe_interpolate_local_shuffle_exchange(rhs_operators, _build_expr_ctxs);
-    auto operators_with_probe_op = context->maybe_interpolate_local_shuffle_exchange(lhs_operators, _probe_expr_ctxs);
+
+    if (_join_type == TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN) {
+        rhs_operators = context->maybe_interpolate_local_passthrough_exchange(rhs_operators);
+        lhs_operators = context->maybe_interpolate_local_passthrough_exchange(lhs_operators);
+    } else {
+        // both HashJoin{Build, Probe}Operator are parallelized, so add LocalExchangeOperator
+        // to shuffle multi-stream into #degree_of_parallelism# streams each of that pipes into HashJoin{Build, Probe}Operator.
+        rhs_operators = context->maybe_interpolate_local_shuffle_exchange(rhs_operators, _build_expr_ctxs);
+        lhs_operators = context->maybe_interpolate_local_shuffle_exchange(lhs_operators, _probe_expr_ctxs);
+    }
+
     // add build-side pipeline to context and return probe-side pipeline.
-    operators_with_build_op.emplace_back(std::move(build_op));
-    context->add_pipeline(operators_with_build_op);
-    operators_with_probe_op.emplace_back(std::move(probe_op));
-    return operators_with_probe_op;
+    rhs_operators.emplace_back(std::move(build_op));
+    context->add_pipeline(rhs_operators);
+
+    lhs_operators.emplace_back(std::move(probe_op));
+
+    return lhs_operators;
 }
 
 bool HashJoinNode::_has_null(const ColumnPtr& column) {


### PR DESCRIPTION
### Introduction

`<col> NOT IN (NULL, <val1>, <val2>)` always returns false, so hash join should return empty result in this case. 
Hash join cannot be divided into multiple partitions in this case. Otherwise, `NULL` value in right table will only occur in some partition hash table, and other partition hash table can output chunk.

Fix #1660.

### Changes
- Insert local passthrough exchange instead of local shuffle exchange when join type is `NULL_AWARE_LEFT_ANTI_JOIN`.
