### PR TITLE
Fix the dead lock bug of data stream recvr (#1631)

### DIFF
--- a/be/src/runtime/data_stream_recvr.h
+++ b/be/src/runtime/data_stream_recvr.h
@@ -128,8 +128,6 @@ private:
     // total buffer limit.
     bool exceeds_limit(int batch_size) { return _num_buffered_bytes + batch_size > _total_buffer_limit; }
 
-    bool exceeds_limit() { return _num_buffered_bytes > _total_buffer_limit; }
-
     // DataStreamMgr instance used to create this recvr. (Not owned)
     DataStreamMgr* _mgr;
 


### PR DESCRIPTION
The sender will have have multiple chunks. When reaching the memory limit, sometimes the ChunkQueue will be empty, but PendingClosure is not empty. The get_chunk() will keep waiting forever. The pull request guarantee that the last chunk of one request is consumed, the response will be send to sender.