### PR TITLE
Remove default escape for brackets (#1139)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/AddSqlBlackListStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/AddSqlBlackListStmt.java
@@ -43,7 +43,7 @@ public class AddSqlBlackListStmt extends StatementBase {
 
         super.analyze(analyzer);
 
-        sql = sql.trim().toLowerCase().replaceAll("\\(", "\\\\(").replaceAll("\\)", "\\\\)").replaceAll(" +", " ");
+        sql = sql.trim().toLowerCase().replaceAll(" +", " ");
         if (sql != null && sql.length() > 0) {
             try {
                 sqlPattern = Pattern.compile(sql);

--- a/fe/fe-core/src/test/java/com/starrocks/planner/QueryPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/QueryPlannerTest.java
@@ -26,6 +26,8 @@ import com.starrocks.analysis.DropDbStmt;
 import com.starrocks.analysis.ShowCreateDbStmt;
 import com.starrocks.analysis.StatementBase;
 import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.meta.SqlBlackList;
+import com.starrocks.meta.BlackListSql;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.QueryState.MysqlStateType;
 import com.starrocks.qe.StmtExecutor;
@@ -39,6 +41,8 @@ import org.junit.Test;
 import java.io.File;
 import java.util.List;
 import java.util.UUID;
+import java.util.ArrayList;
+import java.util.Map;
 
 public class QueryPlannerTest {
     // use a unique dir so that it won't be conflict with other unit test which
@@ -142,19 +146,53 @@ public class QueryPlannerTest {
         stmtExecutor0.execute();
 
         String addBlackListSql = "add sqlblacklist \"select k1 from .+\"";
-        List<StatementBase> stmts = UtFrameUtils.parseAndAnalyzeStmts(addBlackListSql, connectContext);
-
-        String sql = "select k1 from test.baseall";
-        StmtExecutor stmtExecutor1 = new StmtExecutor(connectContext, sql);
+        StmtExecutor stmtExecutor1 = new StmtExecutor(connectContext, addBlackListSql);
         stmtExecutor1.execute();
 
-        String showBlackListSql = "show sqlblacklist";
-        StmtExecutor stmtExecutor2 = new StmtExecutor(connectContext, showBlackListSql);
-        stmtExecutor2.execute();
+        Assert.assertEquals(SqlBlackList.getInstance().sqlBlackListMap.entrySet().size(), 1);
+        long id = -1;
+        for (Map.Entry<String, BlackListSql> entry : SqlBlackList.getInstance().sqlBlackListMap.entrySet()) {
+        id = entry.getValue().id;
+            Assert.assertEquals("select k1 from .+", entry.getKey());
+        }
 
-        String deleteBlackListSql = "delete sqlblacklist 0";
+        String sql = "select k1 from test.baseall";
+        StmtExecutor stmtExecutor2 = new StmtExecutor(connectContext, sql);
+        stmtExecutor2.execute();
+        Assert.assertEquals("Access denied; This sql is in blacklist, please contact your admin", connectContext.getState().getErrorMessage());
+
+        String deleteBlackListSql = "delete sqlblacklist " + String.valueOf(id);
         StmtExecutor stmtExecutor3 = new StmtExecutor(connectContext, deleteBlackListSql);
         stmtExecutor3.execute();
+        Assert.assertEquals(0, SqlBlackList.getInstance().sqlBlackListMap.entrySet().size());
+    }
+
+    @Test
+    public void testSqlBlackListUseWhere() throws Exception {
+        String setEnableSqlBlacklist = "admin set frontend config (\"enable_sql_blacklist\" = \"true\")";
+        StmtExecutor stmtExecutor0 = new StmtExecutor(connectContext, setEnableSqlBlacklist);
+        stmtExecutor0.execute();
+
+        String addBlackListSql = "add sqlblacklist \"((?!where).)*\"";
+        StmtExecutor stmtExecutor1 = new StmtExecutor(connectContext, addBlackListSql);
+        stmtExecutor1.execute();
+
+        Assert.assertEquals(SqlBlackList.getInstance().sqlBlackListMap.entrySet().size(), 1);
+        long id = -1;
+        for (Map.Entry<String, BlackListSql> entry : SqlBlackList.getInstance().sqlBlackListMap.entrySet()) {
+            id = entry.getValue().id;
+            Assert.assertEquals("((?!where).)*", entry.getKey());
+        }
+
+        String sql = "select k1 from test.baseall where k1 > 0";
+        StmtExecutor stmtExecutor2 = new StmtExecutor(connectContext, sql);
+        stmtExecutor2.execute();
+        Assert.assertEquals("Access denied; This sql is in blacklist, please contact your admin", connectContext.getState().getErrorMessage());
+
+        String deleteBlackListSql = "delete sqlblacklist " + String.valueOf(id);
+        StmtExecutor stmtExecutor3 = new StmtExecutor(connectContext, deleteBlackListSql);
+        stmtExecutor3.execute();
+        Assert.assertEquals(0, SqlBlackList.getInstance().sqlBlackListMap.entrySet().size());
     }
 
     @Test


### PR DESCRIPTION
cherry-pick b4cf2c9f60
- Remove default escape for brackets, so we can use brackets in regular expression.