### PR TITLE
Support AGG min/max in low cardinality optimize

### DIFF
--- a/be/src/runtime/global_dicts.cpp
+++ b/be/src/runtime/global_dicts.cpp
@@ -180,12 +180,13 @@ void DictOptimizeParser::eval_expr(RuntimeState* state, ExprContext* expr_ctx, D
 
     GlobalDictMap result_map;
     RGlobalDictMap rresult_map;
+    std::vector<Slice> values;
+    values.reserve(row_sz);
+
+    // distinct result values
     int id_allocator = 1;
     for (int i = 0; i < row_sz; ++i) {
-        if (viewer.is_null(i)) {
-            code_convert_map[codes[i]] = 0;
-            dict_opt_ctx->result_nullable = true;
-        } else {
+        if (!viewer.is_null(i)) {
             auto value = viewer.value(i);
             Slice slice(value.data, value.size);
             auto res = result_map.lazy_emplace(slice, [&](const auto& ctor) {
@@ -195,9 +196,27 @@ void DictOptimizeParser::eval_expr(RuntimeState* state, ExprContext* expr_ctx, D
                 slice = Slice(data, slice.size);
                 ctor(slice, id_allocator);
             });
+            values.emplace_back(res->first);
+        }
+    }
 
-            code_convert_map[codes[i]] = res->second;
-            rresult_map.emplace(res->second, slice);
+    // sort and build result map
+    Slice::Comparator comparator;
+    std::sort(values.begin(), values.end(), comparator);
+    int sorted_id = 1;
+    for (int i = 0; i < values.size(); ++i) {
+        auto slice = values[i];
+        result_map[slice] = sorted_id;
+        rresult_map[sorted_id++] = slice;
+    }
+
+    // build code convert map
+    for (int i = 0; i < values.size(); ++i) {
+        if (viewer.is_null(i)) {
+            code_convert_map[codes[i]] = 0;
+            dict_opt_ctx->result_nullable = true;
+        } else {
+            code_convert_map[codes[i]] = result_map.find(viewer.value(i))->second;
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/AddDecodeNodeForDictStringRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/AddDecodeNodeForDictStringRule.java
@@ -7,8 +7,10 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.starrocks.analysis.Expr;
 import com.starrocks.catalog.Catalog;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
@@ -434,25 +436,50 @@ public class AddDecodeNodeForDictStringRule implements PhysicalOperatorTreeRewri
             return exchangeOperator;
         }
 
+        private static Set<String> couldApplyLowCardAggregateFunction = Sets.newHashSet(
+                FunctionSet.COUNT, FunctionSet.MULTI_DISTINCT_COUNT, FunctionSet.MAX, FunctionSet.MIN
+        );
+
         private PhysicalHashAggregateOperator rewriteAggOperator(PhysicalHashAggregateOperator aggOperator,
                                                                  DecodeContext context) {
             Map<Integer, Integer> newStringToDicts = Maps.newHashMap();
 
             Map<ColumnRefOperator, CallOperator> newAggMap = Maps.newHashMap(aggOperator.getAggregations());
             for (Map.Entry<ColumnRefOperator, CallOperator> kv : aggOperator.getAggregations().entrySet()) {
-
                 boolean canApplyDictDecodeOpt = (kv.getValue().getUsedColumns().cardinality() > 0) &&
-                        (kv.getValue().getFnName().equals(FunctionSet.COUNT) ||
-                                kv.getValue().getFnName().equals(FunctionSet.MULTI_DISTINCT_COUNT));
+                        (couldApplyLowCardAggregateFunction.contains(kv.getValue().getFnName()));
                 if (canApplyDictDecodeOpt) {
+                    CallOperator oldCall = kv.getValue();
                     int columnId = kv.getValue().getUsedColumns().getFirstId();
                     if (context.stringColumnIdToDictColumnIds.containsKey(columnId)) {
                         Integer dictColumnId = context.stringColumnIdToDictColumnIds.get(columnId);
                         ColumnRefOperator dictColumn = context.columnRefFactory.getColumnRef(dictColumnId);
-                        CallOperator newCall = new CallOperator(kv.getValue().getFnName(), kv.getValue().getType(),
-                                Collections.singletonList(dictColumn), kv.getValue().getFunction(),
-                                kv.getValue().isDistinct());
-                        newAggMap.put(kv.getKey(), newCall);
+
+                        List<ScalarOperator> newArguments = Collections.singletonList(dictColumn);
+                        Type[] newTypes = newArguments.stream().map(ScalarOperator::getType).toArray(Type[]::new);
+                        Function newFunction = Expr.getBuiltinFunction(kv.getValue().getFnName(), newTypes,
+                                Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+                        Type newReturnType = oldCall.getType();
+
+                        ColumnRefOperator outputColumn = kv.getKey();
+
+                        // Add decode node to aggregate function that returns a string
+                        if (oldCall.getType().isVarchar()) {
+                            newReturnType = ID_TYPE;
+                            ColumnRefOperator outputStringColumn = kv.getKey();
+                            // now we only support max/min for dict columns
+                            // so we use input dict column
+                            newStringToDicts.put(outputStringColumn.getId(), dictColumnId);
+                            
+                            newAggMap.remove(outputStringColumn);
+                            outputColumn = dictColumn;
+                        }
+
+                        CallOperator newCall = new CallOperator(oldCall.getFnName(), newReturnType,
+                                newArguments, newFunction,
+                                oldCall.isDistinct());
+
+                        newAggMap.put(outputColumn, newCall);
                     }
                 }
             }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecodeRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecodeRewriteTest.java
@@ -318,6 +318,29 @@ public class DecodeRewriteTest extends PlanTestBase {
     }
 
     @Test
+    public void testDecodeNodeRewrite12() throws Exception {
+        String sql;
+        String plan;
+
+        sql = "select max(S_ADDRESS) from supplier";
+        plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("Decode"));
+
+        sql = "select min(S_ADDRESS) from supplier";
+        plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("Decode"));
+
+        sql = "select max(upper(S_ADDRESS)) from supplier";
+        plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("Decode"));
+        Assert.assertTrue(plan.contains(" <function id 12>"));
+
+        sql = "select max(\"CONST\") from supplier";
+        plan = getFragmentPlan(sql);
+        Assert.assertFalse(plan.contains("Decode"));
+    }
+
+    @Test
     public void testScanFilter() throws Exception {
         String sql = "select count(*) from supplier where S_ADDRESS = 'kks' group by S_ADDRESS ";
         String plan = getFragmentPlan(sql);


### PR DESCRIPTION
1. make dict code order after function apply
eg:
    before [abd, aBc] -> upper -> [ABD, ABC] -> [1, 2]
    after  [abd, aBc] -> ...                    [2, 1]
2. support rewrite max/min aggoperator in plan