### PR TITLE
Support create bloomfilter index when create and alter table for primary key.

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -1818,7 +1818,7 @@ Status TabletUpdates::convert_from(const std::shared_ptr<Tablet>& base_tablet, i
     DCHECK(_tablet.tablet_state() == TABLET_NOTREADY)
             << "tablet state is not TABLET_NOTREADY, convert_from is not allowed"
             << " tablet_id:" << _tablet.tablet_id() << " tablet_state:" << _tablet.tablet_state();
-    LOG(INFO) << "start convert_from. "
+    LOG(INFO) << "start convert_from."
               << " new tablet_id:" << _tablet.tablet_id() << " request_version:" << request_version
               << " #pending:" << _pending_commits.size();
     int64_t max_version = base_tablet->updates()->max_version();

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -891,7 +891,8 @@ public class SchemaChangeHandler extends AlterHandler {
         double bfFpp = 0;
         try {
             bfColumns = PropertyAnalyzer
-                    .analyzeBloomFilterColumns(propertyMap, indexSchemaMap.get(olapTable.getBaseIndexId()));
+                    .analyzeBloomFilterColumns(propertyMap, indexSchemaMap.get(olapTable.getBaseIndexId()),
+                    olapTable.getKeysType() == KeysType.PRIMARY_KEYS);
             bfFpp = PropertyAnalyzer.analyzeBloomFilterFpp(propertyMap);
         } catch (AnalysisException e) {
             throw new DdlException(e.getMessage());

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -3866,7 +3866,8 @@ public class Catalog {
         Set<String> bfColumns = null;
         double bfFpp = 0;
         try {
-            bfColumns = PropertyAnalyzer.analyzeBloomFilterColumns(properties, baseSchema);
+            bfColumns = PropertyAnalyzer.analyzeBloomFilterColumns(properties, baseSchema,
+                olapTable.getKeysType() == KeysType.PRIMARY_KEYS);
             if (bfColumns != null && bfColumns.isEmpty()) {
                 bfColumns = null;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -294,8 +294,8 @@ public class PropertyAnalyzer {
         return schemaVersion;
     }
 
-    public static Set<String> analyzeBloomFilterColumns(Map<String, String> properties, List<Column> columns)
-            throws AnalysisException {
+    public static Set<String> analyzeBloomFilterColumns(Map<String, String> properties, List<Column> columns,
+            boolean isPrimaryKey) throws AnalysisException {
         Set<String> bfColumns = null;
         if (properties != null && properties.containsKey(PROPERTIES_BF_COLUMNS)) {
             bfColumns = Sets.newHashSet();
@@ -326,11 +326,11 @@ public class PropertyAnalyzer {
                             bfColumn, type));
                 }
 
-                // Only support create bloom filter on duplicate table or key columns of UNIQUE/AGGREGATE table.
-                if (!(column.isKey() || column.getAggregationType() == AggregateType.NONE)) {
-                    // Although the implementation supports bf for replace non-key column,
+                // Only support create bloom filter on DUPLICATE/PRIMARY table or key columns of UNIQUE/AGGREGATE table.
+                if (!(column.isKey() || isPrimaryKey || column.getAggregationType() == AggregateType.NONE)) {
+                    // Although the implementation supports bloom filter for replace non-key column,
                     // for simplicity and unity, we don't expose that to user.
-                    throw new AnalysisException("Bloom filter index only used in columns of DUP_KEYS table or "
+                    throw new AnalysisException("Bloom filter index only used in columns of DUP_KEYS/PRIMARY table or "
                             + "key columns of UNIQUE_KEYS/AGG_KEYS table. invalid column: " + bfColumn);
                 }
 

--- a/fe/fe-core/src/test/java/com/starrocks/common/PropertyAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/PropertyAnalyzerTest.java
@@ -55,7 +55,7 @@ public class PropertyAnalyzerTest {
         Map<String, String> properties = Maps.newHashMap();
         properties.put(PropertyAnalyzer.PROPERTIES_BF_COLUMNS, "k1");
 
-        Set<String> bfColumns = PropertyAnalyzer.analyzeBloomFilterColumns(properties, columns);
+        Set<String> bfColumns = PropertyAnalyzer.analyzeBloomFilterColumns(properties, columns, false);
         Assert.assertEquals(Sets.newHashSet("k1"), bfColumns);
     }
 
@@ -75,7 +75,7 @@ public class PropertyAnalyzerTest {
         // no bf columns
         properties.put(PropertyAnalyzer.PROPERTIES_BF_COLUMNS, "");
         try {
-            Assert.assertEquals(Sets.newHashSet(), PropertyAnalyzer.analyzeBloomFilterColumns(properties, columns));
+            Assert.assertEquals(Sets.newHashSet(), PropertyAnalyzer.analyzeBloomFilterColumns(properties, columns, false));
         } catch (AnalysisException e) {
             Assert.fail();
         }
@@ -83,7 +83,7 @@ public class PropertyAnalyzerTest {
         // k4 not exist
         properties.put(PropertyAnalyzer.PROPERTIES_BF_COLUMNS, "k4");
         try {
-            PropertyAnalyzer.analyzeBloomFilterColumns(properties, columns);
+            PropertyAnalyzer.analyzeBloomFilterColumns(properties, columns, false);
         } catch (AnalysisException e) {
             Assert.assertTrue(e.getMessage().contains("Invalid bloom filter column 'k4'"));
         }
@@ -91,7 +91,7 @@ public class PropertyAnalyzerTest {
         // tinyint not supported
         properties.put(PropertyAnalyzer.PROPERTIES_BF_COLUMNS, "k2");
         try {
-            PropertyAnalyzer.analyzeBloomFilterColumns(properties, columns);
+            PropertyAnalyzer.analyzeBloomFilterColumns(properties, columns, false);
         } catch (AnalysisException e) {
             Assert.assertTrue(e.getMessage().contains("Invalid bloom filter column 'k2'"));
         }
@@ -99,7 +99,7 @@ public class PropertyAnalyzerTest {
         // bool not supported
         properties.put(PropertyAnalyzer.PROPERTIES_BF_COLUMNS, "k3");
         try {
-            PropertyAnalyzer.analyzeBloomFilterColumns(properties, columns);
+            PropertyAnalyzer.analyzeBloomFilterColumns(properties, columns, false);
         } catch (AnalysisException e) {
             Assert.assertTrue(e.getMessage().contains("Invalid bloom filter column 'k3'"));
         }
@@ -107,7 +107,7 @@ public class PropertyAnalyzerTest {
         // not replace value
         properties.put(PropertyAnalyzer.PROPERTIES_BF_COLUMNS, "v2");
         try {
-            PropertyAnalyzer.analyzeBloomFilterColumns(properties, columns);
+            PropertyAnalyzer.analyzeBloomFilterColumns(properties, columns, false);
         } catch (AnalysisException e) {
             Assert.assertTrue(e.getMessage().contains("Bloom filter index only used in"));
         }
@@ -115,7 +115,7 @@ public class PropertyAnalyzerTest {
         // reduplicated column
         properties.put(PropertyAnalyzer.PROPERTIES_BF_COLUMNS, "k1,K1");
         try {
-            PropertyAnalyzer.analyzeBloomFilterColumns(properties, columns);
+            PropertyAnalyzer.analyzeBloomFilterColumns(properties, columns, false);
         } catch (AnalysisException e) {
             Assert.assertTrue(e.getMessage().contains("Duplicate bloom filter column 'K1'"));
         }


### PR DESCRIPTION
ATT. resolve #1577 

before this PR:

```
mysql> create table t(id bigint not null, name string not null) primary key(id) distributed by hash(id) buckets 4 properties("bloom_filter_columns"="name");
ERROR 1064 (HY000): Bloom filter index only used in columns of DUP_KEYS table or key columns of UNIQUE_KEYS/AGG_KEYS table. invalid column: name
```

after this PR:

```
mysql> create table t(id bigint not null, name string not null) primary key(id) distributed by hash(id) properties("bloom_filter_columns"="name");
Query OK, 0 rows affected (0.42 sec)

mysql> desc t;
+-------+----------------+------+-------+---------+--------------+
| Field | Type           | Null | Key   | Default | Extra        |
+-------+----------------+------+-------+---------+--------------+
| id    | BIGINT         | No   | true  | NULL    |              |
| name  | VARCHAR(65533) | No   | false | NULL    | BLOOM_FILTER |
+-------+----------------+------+-------+---------+--------------+
2 rows in set (0.01 sec)
```