### PR TITLE
Support array type in primary and unique key.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/ColumnDef.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/ColumnDef.java
@@ -174,7 +174,7 @@ public class ColumnDef {
                         String.format("Cannot specify aggregate function '%s' for key column '%s'", aggregateType,
                                 name));
             }
-            if (!(aggregateType.checkCompatibility(type.getPrimitiveType()) || (aggregateType.isReplaceFamily() && type.isArrayType()))) {
+            if (!aggregateType.checkCompatibility(type)) {
                 throw new AnalysisException(
                         String.format("Invalid aggregate function '%s' for '%s'", aggregateType, name));
             }

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/ColumnDef.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/ColumnDef.java
@@ -174,7 +174,8 @@ public class ColumnDef {
                         String.format("Cannot specify aggregate function '%s' for key column '%s'", aggregateType,
                                 name));
             }
-            if (!aggregateType.checkCompatibility(type.getPrimitiveType())) {
+            
+            if (!(aggregateType.checkCompatibility(type.getPrimitiveType()) || type.isArrayType())) {
                 throw new AnalysisException(
                         String.format("Invalid aggregate function '%s' for '%s'", aggregateType, name));
             }

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/ColumnDef.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/ColumnDef.java
@@ -174,8 +174,7 @@ public class ColumnDef {
                         String.format("Cannot specify aggregate function '%s' for key column '%s'", aggregateType,
                                 name));
             }
-            
-            if (!(aggregateType.checkCompatibility(type.getPrimitiveType()) || type.isArrayType())) {
+            if (!(aggregateType.checkCompatibility(type.getPrimitiveType()) || (aggregateType.isReplaceFamily() && type.isArrayType()))) {
                 throw new AnalysisException(
                         String.format("Invalid aggregate function '%s' for '%s'", aggregateType, name));
             }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/AggregateType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/AggregateType.java
@@ -126,7 +126,7 @@ public enum AggregateType {
         this.sqlName = sqlName;
     }
 
-    public static boolean checkCompatibility(AggregateType aggType, PrimitiveType priType) {
+    public static boolean checkPrimitiveTypeCompatibility(AggregateType aggType, PrimitiveType priType) {
         return compatibilityMap.get(aggType).contains(priType);
     }
 
@@ -139,8 +139,8 @@ public enum AggregateType {
         return toSql();
     }
 
-    public boolean checkCompatibility(PrimitiveType priType) {
-        return checkCompatibility(this, priType);
+    public boolean checkCompatibility(Type type) {
+        return checkPrimitiveTypeCompatibility(this, type.getPrimitiveType()) || (this.isReplaceFamily() && type.isArrayType());
     }
 
     public boolean isReplaceFamily() {


### PR DESCRIPTION
before this PR:
```
mysql> create table t1(id bigint not null, ids array<int>) primary key(id) distributed by hash(id);
ERROR 1064 (HY000): Invalid aggregate function 'REPLACE' for 'ids'
mysql> create table t2(id bigint not null, ids array<int>) unique key(id) distributed by hash(id);
ERROR 1064 (HY000): Invalid aggregate function 'REPLACE' for 'ids'
mysql>
```

after this PR:
```
mysql> create table t1(id bigint not null, ids array<int>) primary key(id) distributed by hash(id);
Query OK, 0 rows affected (0.11 sec)

mysql> desc t1;
+-------+------------+------+-------+---------+-------+
| Field | Type       | Null | Key   | Default | Extra |
+-------+------------+------+-------+---------+-------+
| id    | BIGINT     | No   | true  | NULL    |       |
| ids   | ARRAY<INT> | Yes  | false | NULL    |       |
+-------+------------+------+-------+---------+-------+
2 rows in set (0.00 sec)

mysql> create table t2(id bigint not null, ids array<int>) unique key(id) distributed by hash(id);
Query OK, 0 rows affected (0.13 sec)

mysql> desc t2;
+-------+------------+------+-------+---------+-------+
| Field | Type       | Null | Key   | Default | Extra |
+-------+------------+------+-------+---------+-------+
| id    | BIGINT     | No   | true  | NULL    |       |
| ids   | ARRAY<INT> | Yes  | false | NULL    |       |
+-------+------------+------+-------+---------+-------+
2 rows in set (0.01 sec)

mysql>
```
ATT, resolve #1715 