### PR TITLE
[pipeline] fix: lock when updating SinkBuffer::_is_finishing

### DIFF
--- a/be/src/exec/pipeline/exchange/sink_buffer.h
+++ b/be/src/exec/pipeline/exchange/sink_buffer.h
@@ -145,8 +145,8 @@ public:
 
     void decrease_running_sinkers() {
         if (--_num_remaining_sinkers == 0) {
-            // To protect critical region for trigger_rpc_task, rpc task, and send_rpc,
-            // we should use lock here, even if _is_finishing is atomic bool.
+            // _is_finishing is used to return early for _try_to_trigger_rpc_task, RPC task _process, and _send_rpc.
+            // To protect critical region between them, we should use lock here, even if _is_finishing is atomic bool.
             std::lock_guard<std::mutex> l(_mutex);
             _is_finishing = true;
         }

--- a/be/src/exec/pipeline/exchange/sink_buffer.h
+++ b/be/src/exec/pipeline/exchange/sink_buffer.h
@@ -145,8 +145,9 @@ public:
 
     void decrease_running_sinkers() {
         if (--_num_remaining_sinkers == 0) {
-            // _is_finishing is used to return early for _try_to_trigger_rpc_task, RPC task _process, and _send_rpc.
-            // To protect critical region between them, we should use lock here, even if _is_finishing is atomic bool.
+            // _is_finishing is used in _try_to_trigger_rpc_task, RPC task _process, and _send_rpc.
+            // To protect critical region between them, we should use lock here,
+            // even if _is_finishing is atomic bool.
             std::lock_guard<std::mutex> l(_mutex);
             _is_finishing = true;
         }

--- a/be/src/exec/pipeline/exchange/sink_buffer.h
+++ b/be/src/exec/pipeline/exchange/sink_buffer.h
@@ -303,14 +303,15 @@ private:
     // Events include 'new request' and 'channel ready'
     std::queue<TUniqueId, std::list<TUniqueId>> _events;
 
+    // _is_rpc_task_active and _is_finishing are used in _try_to_trigger_rpc_task, and _send_rpc.
+    // - Write them with lock, to protect critical region between _try_to_trigger_rpc_task, and _send_rpc.
+    // - Read them without lock, whose visibility is guaranteed by atomic.
+    std::atomic<bool> _is_rpc_task_active = false;
     // True means that SinkBuffer needn't input chunk and send chunk anymore,
     // but there may be still RPC task or in-flight RPC running.
     // It becomes true, when all sinkers have sent EOS, or been set_finished/cancelled, or RPC has returned error.
     std::atomic<bool> _is_finishing = false;
-    // _is_finishing and _is_rpc_task_active are used in _try_to_trigger_rpc_task, RPC task _process, and _send_rpc.
-    // - Write them with lock, to protect critical region between _try_to_trigger_rpc_task, _process, and _send_rpc.
-    // - Read them without lock, whose visibility is guaranteed by atomic.
-    std::atomic<bool> _is_rpc_task_active = false;
+
     int32_t _expected_eos = 0;
 
     std::atomic<int> _num_remaining_sinkers;

--- a/be/src/exec/pipeline/exchange/sink_buffer.h
+++ b/be/src/exec/pipeline/exchange/sink_buffer.h
@@ -303,8 +303,8 @@ private:
     // Events include 'new request' and 'channel ready'
     std::queue<TUniqueId, std::list<TUniqueId>> _events;
 
-    // _is_rpc_task_active and _is_finishing are used in _try_to_trigger_rpc_task, and _send_rpc.
-    // - Write and read them with lock, to protect critical region between _try_to_trigger_rpc_task, and _send_rpc.
+    // _is_rpc_task_active and _is_finishing are used in _try_to_trigger_rpc_task and _send_rpc.
+    // - Write and read them with lock, to protect critical region between _try_to_trigger_rpc_task and _send_rpc.
     // - Read them without lock in is_finished() and ~SinkBuffer(), whose visibility is guaranteed by atomic.
     std::atomic<bool> _is_rpc_task_active = false;
     // True means that SinkBuffer needn't input chunk and send chunk anymore,

--- a/be/src/exec/pipeline/exchange/sink_buffer.h
+++ b/be/src/exec/pipeline/exchange/sink_buffer.h
@@ -304,8 +304,8 @@ private:
     std::queue<TUniqueId, std::list<TUniqueId>> _events;
 
     // _is_rpc_task_active and _is_finishing are used in _try_to_trigger_rpc_task, and _send_rpc.
-    // - Write them with lock, to protect critical region between _try_to_trigger_rpc_task, and _send_rpc.
-    // - Read them without lock, whose visibility is guaranteed by atomic.
+    // - Write and read them with lock, to protect critical region between _try_to_trigger_rpc_task, and _send_rpc.
+    // - Read them without lock in is_finished() and ~SinkBuffer(), whose visibility is guaranteed by atomic.
     std::atomic<bool> _is_rpc_task_active = false;
     // True means that SinkBuffer needn't input chunk and send chunk anymore,
     // but there may be still RPC task or in-flight RPC running.


### PR DESCRIPTION
### Introduction
In `SinkBuffer`, `_is_finishing` is used to return early for `_try_to_trigger_rpc_task`, RPC task `_process`, and `_send_rpc`.
To protect critical region between them, we should use lock when updating it, even if `_is_finishing` is atomic bool.

### Changes
- Lock when updating `SinkBuffer::_is_finishing` in `decrease_running_sinkers()`.
- Make `_is_finishing` and `_is_rpc_task_active` atomic to avoid using lock in `is_finished()`.