### PR TITLE
Fix can not choose replicate join in plan fragment builder

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanNode.java
@@ -817,12 +817,10 @@ abstract public class PlanNode extends TreeNode<PlanNode> {
     }
 
     public boolean canDoReplicatedJoin() {
-        if (children.size() == 1) {
-            return getChild(0).canDoReplicatedJoin();
-        } else if (children.size() == 2) {
-            return getChild(1).canDoReplicatedJoin();
-        } else {
-            return false;
+        boolean canDoReplicatedJoin = false;
+        for (PlanNode childNode : children) {
+            canDoReplicatedJoin |= childNode.canDoReplicatedJoin();
         }
+        return canDoReplicatedJoin;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -3954,6 +3954,47 @@ public class PlanFragmentTest extends PlanTestBase {
     }
 
     @Test
+    public void testReplicationJoinWithEmptyNode() throws Exception {
+        // check replicate join without exception
+        connectContext.getSessionVariable().setEnableReplicationJoin(true);
+        FeConstants.runningUnitTest = true;
+        String sql = "with cross_join as (\n" +
+                "  select * from \n" +
+                "  (SELECT \n" +
+                "      t0.v1, \n" +
+                "      t0.v2, \n" +
+                "      t0.v3\n" +
+                "    FROM \n" +
+                "      t0 \n" +
+                "    WHERE \n" +
+                "      false)\n" +
+                "  subt0 LEFT SEMI \n" +
+                "  JOIN \n" +
+                "    (SELECT \n" +
+                "      t2.v7, \n" +
+                "      t2.v8, \n" +
+                "      t2.v9\n" +
+                "    FROM \n" +
+                "      t2 \n" +
+                "    WHERE \n" +
+                "      false)\n" +
+                "  subt2 ON subt0.v3 = subt2.v8, \n" +
+                "  t1 \n" +
+                ")\n" +
+                "SELECT \n" +
+                "  DISTINCT cross_join.v1 \n" +
+                "FROM \n" +
+                "  t0 LEFT JOIN\n" +
+                "  cross_join\n" +
+                "  ON cross_join.v4 = t0.v2;";
+        String plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("9:HASH JOIN\n" +
+                "  |  join op: LEFT OUTER JOIN (REPLICATED)"));
+        FeConstants.runningUnitTest = false;
+        connectContext.getSessionVariable().setEnableReplicationJoin(false);
+    }
+
+    @Test
     public void testOuterJoinBucketShuffle() throws Exception {
         String sql = "SELECT DISTINCT t0.v1 FROM t0 RIGHT JOIN[BUCKET] t1 ON t0.v1 = t1.v4";
         String plan = getFragmentPlan(sql);


### PR DESCRIPTION
#1691 
we choose replicate join in physical plan, but in plan fragment build, the check of canDoReplicatedJoin is falut.
eg.
```
                             join(replicate)
                            /             \
                      scan                    join
                                            /      \
                                          scan     exchange
```
for join noe, only check right child is not right,  the left child should also consider