### PR TITLE
Make CountDownLatch customizable

### DIFF
--- a/be/src/util/countdown_latch.h
+++ b/be/src/util/countdown_latch.h
@@ -34,10 +34,11 @@ namespace starrocks {
 // This is a C++ implementation of the Java CountDownLatch
 // class.
 // See http://docs.oracle.com/javase/6/docs/api/java/util/concurrent/CountDownLatch.html
-class CountDownLatch {
+template <typename Lock, typename Cond>
+class GenericCountDownLatch {
 public:
     // Initialize the latch with the given initial count.
-    explicit CountDownLatch(int count) : count_(count) {}
+    explicit GenericCountDownLatch(int count) : count_(count) {}
 
     // REQUIRES: amount >= 0.
     // Decrement the count of this latch by 'amount'.
@@ -76,12 +77,15 @@ public:
         }
     }
 
+    template <typename Duration>
+    bool wait_for(const Duration& dur) const {
+        std::unique_lock lock(lock_);
+        return cond_.wait_for(lock, dur, [&]() { return count_ <= 0; });
+    }
+
     // Waits for the count on the latch to reach zero, or until 'delta' time elapses.
     // Returns true if the count became zero, false otherwise.
-    bool wait_for(const MonoDelta& delta) const {
-        std::unique_lock lock(lock_);
-        return cond_.wait_for(lock, std::chrono::nanoseconds(delta.ToNanoseconds()), [&]() { return count_ <= 0; });
-    }
+    bool wait_for(const MonoDelta& delta) const { return wait_for(std::chrono::nanoseconds(delta.ToNanoseconds())); }
 
     // Reset the latch with the given count. This is equivalent to reconstructing
     // the latch. If 'count' is 0, and there are currently waiters, those waiters
@@ -101,25 +105,28 @@ public:
     }
 
 private:
-    mutable std::mutex lock_;
-    mutable std::condition_variable cond_;
+    mutable Lock lock_;
+    mutable Cond cond_;
 
     int64_t count_;
-    CountDownLatch(const CountDownLatch&) = delete;
-    const CountDownLatch& operator=(const CountDownLatch&) = delete;
+    GenericCountDownLatch(const GenericCountDownLatch&) = delete;
+    const GenericCountDownLatch& operator=(const GenericCountDownLatch&) = delete;
 };
 
+using CountDownLatch = GenericCountDownLatch<std::mutex, std::condition_variable>;
+
 // Utility class which calls latch->CountDown() in its destructor.
+template <typename T>
 class CountDownOnScopeExit {
 public:
-    explicit CountDownOnScopeExit(CountDownLatch* latch) : latch_(latch) {}
+    explicit CountDownOnScopeExit(T* latch) : latch_(latch) {}
     ~CountDownOnScopeExit() { latch_->count_down(); }
 
 private:
     CountDownOnScopeExit(const CountDownOnScopeExit&) = delete;
     const CountDownOnScopeExit& operator=(const CountDownOnScopeExit&) = delete;
 
-    CountDownLatch* latch_;
+    T* latch_;
 };
 
 } // namespace starrocks


### PR DESCRIPTION
Summary: make CountDownLatch customizable for different mutex and condition variables.

By making CountDownLatch customizable, we can pass `bthread::Mutex` and `bthread::ConditionVariable` as the template
arguments, make the CountDownLatch usable in bthread.
