### PR TITLE
Fix the bug of meta mem statisitcs

### DIFF
--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <malloc.h>
+
 #include <string>
 #include <vector>
 
@@ -21,6 +23,14 @@ public:
     ~Status() noexcept {
         if (!is_moved_from(_state)) {
             delete[] _state;
+        }
+    }
+
+    int64_t err_msg_mem_size() const {
+        if (!is_moved_from(_state)) {
+            return malloc_usable_size((void*)_state);
+        } else {
+            return 0;
         }
     }
 
@@ -268,7 +278,7 @@ inline std::ostream& operator<<(std::ostream& os, const Status& st) {
     do {                                     \
         status = (stmt);                     \
         if (UNLIKELY(!status.ok())) {        \
-            return;                          \
+            return status;                   \
         }                                    \
     } while (false)
 

--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -36,8 +36,12 @@ Rowset::Rowset(const TabletSchema* schema, std::string rowset_path, RowsetMetaSh
           _refs_by_reader(0) {}
 
 Status Rowset::load() {
-    SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(ExecEnv::GetInstance()->tablet_meta_mem_tracker());
+    Status st = Status::OK();
+    SCOPED_THREAD_LOCAL_MEM_TRACKER_OF_FUNC(ExecEnv::GetInstance()->tablet_meta_mem_tracker(), _load(), st);
+    return st;
+}
 
+Status Rowset::_load() {
     // if the state is ROWSET_UNLOADING it means close() is called
     // and the rowset is already loaded, and the resource is not closed yet.
     if (_rowset_state_machine.rowset_state() == ROWSET_LOADED) {

--- a/be/src/storage/rowset/rowset.h
+++ b/be/src/storage/rowset/rowset.h
@@ -257,6 +257,8 @@ protected:
     // this is non-public because all clients should use RowsetFactory to obtain pointer to initialized Rowset
     Rowset(const TabletSchema* schema, std::string rowset_path, RowsetMetaSharedPtr rowset_meta);
 
+    Status _load();
+
     // this is non-public because all clients should use RowsetFactory to obtain pointer to initialized Rowset
     virtual OLAPStatus init() = 0;
 

--- a/be/src/storage/tablet.h
+++ b/be/src/storage/tablet.h
@@ -248,6 +248,8 @@ protected:
     void on_shutdown() override;
 
 private:
+    Status _add_rowset(const RowsetSharedPtr& rowset, bool need_persist = true);
+    Status _add_inc_rowset(const RowsetSharedPtr& rowset);
     Status _init_once_action();
     void _print_missed_versions(const std::vector<Version>& missed_versions) const;
     bool _contains_rowset(const RowsetId rowset_id);
@@ -260,6 +262,8 @@ private:
     void _delete_stale_rowset_by_version(const Version& version);
     Status _capture_consistent_rowsets_unlocked(const vector<Version>& version_path,
                                                 vector<RowsetSharedPtr>* rowsets) const;
+    Status _revise_tablet_meta(const std::vector<RowsetMetaSharedPtr>& rowsets_to_clone,
+                               const std::vector<Version>& versions_to_delete);
 
 private:
     friend class TabletUpdates;

--- a/be/src/storage/tablet_manager.h
+++ b/be/src/storage/tablet_manager.h
@@ -62,11 +62,11 @@ public:
     // TODO(lingbin): Other schema-change type do not need to be on the same disk. Because
     // there may be insufficient space on the current disk, which will lead the schema-change
     // task to be fail, even if there is enough space on other disks
-    Status create_tablet(const TCreateTabletReq& request, std::vector<DataDir*> stores);
+    Status create_tablet(const TCreateTabletReq& request, const std::vector<DataDir*>& stores);
 
     Status drop_tablet(TTabletId tablet_id, bool keep_state = false);
 
-    Status drop_tablets_on_error_root_path(const std::vector<TabletInfo>& tablet_info_vec);
+    void drop_tablets_on_error_root_path(const std::vector<TabletInfo>& tablet_info_vec);
 
     TabletSharedPtr find_best_tablet_to_compaction(CompactionType compaction_type, DataDir* data_dir);
 
@@ -164,6 +164,19 @@ private:
 
     TabletManager(const TabletManager&) = delete;
     const TabletManager& operator=(const TabletManager&) = delete;
+
+    Status _create_tablet(const TCreateTabletReq& request, const std::vector<DataDir*>& stores);
+    Status _drop_tablet(TTabletId tablet_id, bool keep_state = false);
+
+    Status _start_trash_sweep();
+    Status _create_tablet_from_meta_snapshot(DataDir* data_dir, TTabletId tablet_id, SchemaHash schema_hash,
+                                             const std::string& schema_hash_path, bool restore = false);
+
+    Status _load_tablet_from_meta(DataDir* data_dir, TTabletId tablet_id, TSchemaHash schema_hash,
+                                  const std::string& header, bool update_meta, bool force = false, bool restore = false,
+                                  bool check_path = true);
+    Status _load_tablet_from_dir(DataDir* data_dir, TTabletId tablet_id, SchemaHash schema_hash,
+                                 const std::string& schema_hash_path, bool force = false, bool restore = false);
 
     // Add a tablet pointer to StorageEngine
     // If force, drop the existing tablet add this new one


### PR DESCRIPTION
for #1752 

Status msg will apply for memory. The current msg memory allocation is recorded to TabletMeta, but the release of memory is recorded by ProcessMemTracker. When a large number of metadata update fails, it will cause the metadata memory statistics to be inaccurate.