### PR TITLE
[pipeline] limit the number of rows from LimitOperator instances

### DIFF
--- a/be/src/exec/pipeline/limit_operator.cpp
+++ b/be/src/exec/pipeline/limit_operator.cpp
@@ -6,18 +6,26 @@
 #include "runtime/runtime_state.h"
 
 namespace starrocks::pipeline {
+
 StatusOr<vectorized::ChunkPtr> LimitOperator::pull_chunk(RuntimeState* state) {
     return std::move(_cur_chunk);
 }
 
 Status LimitOperator::push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) {
     _cur_chunk = chunk;
-    if (chunk->num_rows() <= _limit) {
-        _limit -= chunk->num_rows();
-    } else {
-        _cur_chunk->set_num_rows(_limit);
-        _limit = 0;
+
+    int64_t old_limit;
+    int64_t num_consume_rows;
+    do {
+        old_limit = _limit.load(std::memory_order_relaxed);
+        num_consume_rows = std::min(old_limit, static_cast<int64_t>(chunk->num_rows()));
+    } while (num_consume_rows && !_limit.compare_exchange_strong(old_limit, old_limit - num_consume_rows));
+
+    if (num_consume_rows != chunk->num_rows()) {
+        _cur_chunk->set_num_rows(num_consume_rows);
     }
+
     return Status::OK();
 }
+
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/limit_operator.h
+++ b/be/src/exec/pipeline/limit_operator.h
@@ -15,17 +15,18 @@ public:
 
     bool has_output() const override { return _cur_chunk != nullptr; }
 
-    bool need_input() const override { return _limit != 0 && _cur_chunk == nullptr; }
+    bool need_input() const override { return !_is_finished && _limit != 0 && _cur_chunk == nullptr; }
 
-    bool is_finished() const override { return _limit == 0 && _cur_chunk == nullptr; }
+    bool is_finished() const override { return (_is_finished || _limit == 0) && _cur_chunk == nullptr; }
 
-    void set_finishing(RuntimeState* state) override { _limit = 0; }
+    void set_finishing(RuntimeState* state) override { _is_finished = true; }
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 
     Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override;
 
 private:
+    bool _is_finished = false;
     std::atomic<int64_t>& _limit;
     vectorized::ChunkPtr _cur_chunk = nullptr;
 };

--- a/be/src/exec/pipeline/limit_operator.h
+++ b/be/src/exec/pipeline/limit_operator.h
@@ -8,7 +8,7 @@ namespace starrocks {
 namespace pipeline {
 class LimitOperator final : public Operator {
 public:
-    LimitOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id, int64_t limit)
+    LimitOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id, std::atomic<int64_t>& limit)
             : Operator(factory, id, "limit", plan_node_id), _limit(limit) {}
 
     ~LimitOperator() override = default;
@@ -26,7 +26,7 @@ public:
     Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override;
 
 private:
-    int64_t _limit = 0;
+    std::atomic<int64_t>& _limit;
     vectorized::ChunkPtr _cur_chunk = nullptr;
 };
 
@@ -42,7 +42,7 @@ public:
     }
 
 private:
-    int64_t _limit = 0;
+    std::atomic<int64_t> _limit;
 };
 
 } // namespace pipeline


### PR DESCRIPTION
`LimitOperator` is parallelized, which means there is multiple instances of `LimitOperator`.
Each instance can output `_limit` rows, which causes the number of rows from all the instances may be bigger than `_limit`.
Luckily, `ExchangeSource` on BE and receiver of `ResultSink` on FE also consider `_limit`, so the result is correct for now.

We can use atomic `_limit` and CAS to ensure the number of rows from LimitOperator instances not bigger than `_limit`.