### PR TITLE
Optimize Profile for pipeline

### DIFF
--- a/be/src/exec/pipeline/fragment_context.h
+++ b/be/src/exec/pipeline/fragment_context.h
@@ -45,6 +45,8 @@ public:
     }
     void set_fe_addr(const TNetworkAddress& fe_addr) { _fe_addr = fe_addr; }
     const TNetworkAddress& fe_addr() { return _fe_addr; }
+    void set_profile_mode(const TPipelineProfileMode::type& profile_mode) { _profile_mode = profile_mode; }
+    const TPipelineProfileMode::type& profile_mode() { return _profile_mode; }
     FragmentFuture finish_future() { return _finish_promise.get_future(); }
     RuntimeState* runtime_state() const { return _runtime_state.get(); }
     std::shared_ptr<RuntimeState> runtime_state_ptr() { return _runtime_state; }
@@ -119,6 +121,9 @@ private:
     // Id of this instance
     TUniqueId _fragment_instance_id;
     TNetworkAddress _fe_addr;
+
+    // Mode of profile
+    TPipelineProfileMode::type _profile_mode;
 
     // promise used to determine whether fragment finished its execution
     FragmentPromise _finish_promise;

--- a/be/src/exec/pipeline/operator.h
+++ b/be/src/exec/pipeline/operator.h
@@ -145,6 +145,10 @@ protected:
     RuntimeProfile::Counter* _conjuncts_input_counter = nullptr;
     RuntimeProfile::Counter* _conjuncts_output_counter = nullptr;
     RuntimeProfile::Counter* _conjuncts_eval_counter = nullptr;
+
+private:
+    void _init_rf_counters(bool init_bloom);
+    void _init_conjuct_counters();
 };
 
 class OperatorFactory {

--- a/be/src/exec/pipeline/pipeline.h
+++ b/be/src/exec/pipeline/pipeline.h
@@ -17,7 +17,10 @@ using Pipelines = std::vector<PipelinePtr>;
 class Pipeline {
 public:
     Pipeline() = delete;
-    Pipeline(uint32_t id, const OpFactories& op_factories) : _id(id), _op_factories(op_factories) {}
+    Pipeline(uint32_t id, const OpFactories& op_factories) : _id(id), _op_factories(op_factories) {
+        _runtime_profile = std::make_shared<RuntimeProfile>(strings::Substitute("Pipeline (id=$0)", _id));
+        _runtime_profile->add_info_string("ContainsAllPipelineDrivers", "true");
+    }
 
     uint32_t get_id() const { return _id; }
 
@@ -37,6 +40,8 @@ public:
         DCHECK(!_op_factories.empty());
         return down_cast<SourceOperatorFactory*>(_op_factories[0].get());
     }
+
+    RuntimeProfile* runtime_profile() { return _runtime_profile.get(); }
 
     Status prepare(RuntimeState* state) {
         for (auto& op : _op_factories) {
@@ -67,6 +72,7 @@ public:
 
 private:
     uint32_t _id = 0;
+    std::shared_ptr<RuntimeProfile> _runtime_profile = nullptr;
     OpFactories _op_factories;
 };
 

--- a/be/src/exec/pipeline/pipeline_driver_dispatcher.h
+++ b/be/src/exec/pipeline/pipeline_driver_dispatcher.h
@@ -49,6 +49,7 @@ public:
 private:
     void run();
     void finalize_driver(DriverRawPtr driver, RuntimeState* runtime_state, DriverState state);
+    void update_profile_by_mode(FragmentContext* fragment_ctx, bool done);
 
 private:
     LimitSetter _num_threads_setter;

--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -61,7 +61,6 @@ public:
 
 private:
     ExecEnv* _exec_env = nullptr;
-    TQueryOptions _query_options;
     TUniqueId _query_id;
     std::unique_ptr<FragmentContextManager> _fragment_mgr;
     size_t _total_fragments;

--- a/be/src/exprs/vectorized/runtime_filter_bank.h
+++ b/be/src/exprs/vectorized/runtime_filter_bank.h
@@ -123,12 +123,6 @@ private:
 // into RuntimeBloomFilterEvalContext and make do_evaluate function can be called concurrently.
 struct RuntimeBloomFilterEvalContext {
     RuntimeBloomFilterEvalContext() = default;
-    void prepare(RuntimeProfile* runtime_profile) {
-        join_runtime_filter_timer = ADD_TIMER(runtime_profile, "JoinRuntimeFilterTime");
-        join_runtime_filter_input_counter = ADD_COUNTER(runtime_profile, "JoinRuntimeFilterInputRows", TUnit::UNIT);
-        join_runtime_filter_output_counter = ADD_COUNTER(runtime_profile, "JoinRuntimeFilterOutputRows", TUnit::UNIT);
-        join_runtime_filter_eval_counter = ADD_COUNTER(runtime_profile, "JoinRuntimeFilterEvaluate", TUnit::UNIT);
-    }
 
     std::map<double, RuntimeFilterProbeDescriptor*> selectivity;
     size_t input_chunk_nums = 0;

--- a/be/src/util/runtime_profile.cpp
+++ b/be/src/util/runtime_profile.cpp
@@ -297,6 +297,17 @@ RuntimeProfile* RuntimeProfile::create_child(const std::string& name, bool inden
     return child;
 }
 
+void RuntimeProfile::remove_childs() {
+    std::lock_guard<std::mutex> l(_children_lock);
+    _child_map.clear();
+    _children.clear();
+}
+
+void RuntimeProfile::reverse_childs() {
+    std::lock_guard<std::mutex> l(_children_lock);
+    std::reverse(_children.begin(), _children.end());
+}
+
 void RuntimeProfile::add_child_unlock(RuntimeProfile* child, bool indent, ChildVector::iterator pos) {
     DCHECK(child != nullptr);
     DCHECK(child->_parent == nullptr);

--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -274,6 +274,12 @@ public:
     // [thread-safe]
     RuntimeProfile* create_child(const std::string& name, bool indent = true, bool prepend = false);
 
+    // Remove childs
+    void remove_childs();
+
+    // Reverse childs
+    void reverse_childs();
+
     // Sorts all children according to a custom comparator. Does not
     // invalidate pointers to profiles.
     template <class Compare>

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -29,6 +29,7 @@ import com.starrocks.common.util.CompressionUtils;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.qe.VariableMgr.VarAttr;
 import com.starrocks.thrift.TCompressionType;
+import com.starrocks.thrift.TPipelineProfileMode;
 import com.starrocks.thrift.TQueryOptions;
 import org.json.JSONObject;
 
@@ -112,6 +113,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_PIPELINE_ENGINE = "enable_pipeline_engine";
 
     public static final String PIPELINE_DOP = "pipeline_dop";
+
+    public static final String PIPELINE_PROFILE_MODE = "pipeline_profile_mode";
 
     // hash join right table push down
     public static final String HASH_JOIN_PUSH_DOWN_RIGHT_TABLE = "hash_join_push_down_right_table";
@@ -305,6 +308,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = PIPELINE_DOP)
     private int pipelineDop = 0;
+
+    @VariableMgr.VarAttr(name = PIPELINE_PROFILE_MODE)
+    private String pipelineProfileMode = "brief";
 
     @VariableMgr.VarAttr(name = ENABLE_INSERT_STRICT)
     private boolean enableInsertStrict = true;
@@ -781,6 +787,11 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         tResult.setRuntime_filter_wait_timeout_ms(global_runtime_filter_wait_timeout);
         tResult.setRuntime_filter_send_timeout_ms(global_runtime_filter_rpc_timeout);
         tResult.setPipeline_dop(pipelineDop);
+        if ("brief".equalsIgnoreCase(pipelineProfileMode)) {
+            tResult.setPipeline_profile_mode(TPipelineProfileMode.BRIEF);
+        } else {
+            tResult.setPipeline_profile_mode(TPipelineProfileMode.DETAIL);
+        }
         return tResult;
     }
 

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -80,6 +80,11 @@ struct TLoadErrorHubInfo {
     3: optional TBrokerErrorHubInfo broker_info;
 }
 
+enum TPipelineProfileMode {
+  BRIEF,
+  DETAIL
+}
+
 // Query options with their respective defaults
 struct TQueryOptions {
   1: optional bool abort_on_error = 0
@@ -150,6 +155,8 @@ struct TQueryOptions {
   53: optional i32 runtime_filter_send_timeout_ms = 400;
   // For pipeline query engine
   54: optional i32 pipeline_dop;
+  // For pipeline query engine
+  55: optional TPipelineProfileMode pipeline_profile_mode;
 }
 
 


### PR DESCRIPTION
1. Add session variable `pipeline_profile_mode`, option values are `brief` and `detail`, default value is `brief`
    * `brief`：every pipeline only contains one pipeline driver which has the longest `DriverActiveTime`
    * `detail`：every pipeline contains all the pipeline drivers
2. Add runtime filter related counters when necessary