### PR TITLE
Fix EsNode use wrong colocate backend selector

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -1157,6 +1157,10 @@ public class Coordinator {
         if (colocateFragmentIds.contains(node.getFragmentId().asInt())) {
             return true;
         }
+        // can not cross fragment
+        if (node instanceof ExchangeNode) {
+            return false;
+        }
 
         if (node.isColocate()) {
             colocateFragmentIds.add(node.getFragmentId().asInt());
@@ -1181,17 +1185,22 @@ public class Coordinator {
             return true;
         }
 
+        // can not cross fragment
+        if (node instanceof ExchangeNode) {
+            return false;
+        }
+
         if (node.isReplicated()) {
             replicateFragmentIds.add(node.getFragmentId().asInt());
             return true;
         }
 
-        boolean childHasColocate = false;
+        boolean childHasReplicated = false;
         for (PlanNode childNode : node.getChildren()) {
-            childHasColocate |= isReplicatedFragment(childNode);
+            childHasReplicated |= isReplicatedFragment(childNode);
         }
 
-        return childHasColocate;
+        return childHasReplicated;
     }
 
     // check whether the node fragment is bucket shuffle join fragment
@@ -1203,6 +1212,10 @@ public class Coordinator {
 
         if (bucketShuffleFragmentIds.contains(fragmentId)) {
             return true;
+        }
+        // can not cross fragment
+        if (node instanceof ExchangeNode) {
+            return false;
         }
 
         // One fragment could only have one HashJoinNode


### PR DESCRIPTION
#1748 
the check of **isColocateFragment**  cross child fragment, child fragement which is colocate will lead parent fragment to colocate