### PR TITLE
fix the heap use after free bug of stream load

### DIFF
--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -293,7 +293,7 @@ void StreamLoadAction::on_chunk_data(HttpRequest* req) {
         return;
     }
 
-    SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(ctx->mem_tracker);
+    SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(ctx->instance_mem_tracker.get());
 
     struct evhttp_request* ev_req = req->get_evhttp_request();
     auto evbuf = evhttp_request_get_input_buffer(ev_req);

--- a/be/src/runtime/stream_load/stream_load_context.h
+++ b/be/src/runtime/stream_load/stream_load_context.h
@@ -113,6 +113,9 @@ public:
     bool unref() { return _refs.fetch_sub(1) == 1; }
 
 public:
+    // Before the stream load receiving thread exits, Fragment may have been destructed.
+    // At this time, mem_tracker may have been destructed,
+    // so add shared_ptr here to prevent this from happening.
     std::shared_ptr<RuntimeProfile> runtime_profile;
     std::shared_ptr<MemTracker> query_mem_tracker;
     std::shared_ptr<MemTracker> instance_mem_tracker;

--- a/be/src/runtime/stream_load/stream_load_context.h
+++ b/be/src/runtime/stream_load/stream_load_context.h
@@ -113,7 +113,9 @@ public:
     bool unref() { return _refs.fetch_sub(1) == 1; }
 
 public:
-    MemTracker* mem_tracker = nullptr;
+    std::shared_ptr<RuntimeProfile> runtime_profile;
+    std::shared_ptr<MemTracker> query_mem_tracker;
+    std::shared_ptr<MemTracker> instance_mem_tracker;
     // load type, eg: ROUTINE LOAD/MANUAL LOAD
     TLoadType::type load_type;
     // load data source: eg: KAFKA/RAW

--- a/be/src/runtime/stream_load/stream_load_context.h
+++ b/be/src/runtime/stream_load/stream_load_context.h
@@ -113,9 +113,12 @@ public:
     bool unref() { return _refs.fetch_sub(1) == 1; }
 
 public:
-    // Before the stream load receiving thread exits, Fragment may have been destructed.
+    // 1) Before the stream load receiving thread exits, Fragment may have been destructed.
     // At this time, mem_tracker may have been destructed,
     // so add shared_ptr here to prevent this from happening.
+    //
+    // 2) query_mem_tracker is the parent of instance_mem_tracker
+    // runtime_profile will be used by [consumption] of mem_tracker to record peak memory
     std::shared_ptr<RuntimeProfile> runtime_profile;
     std::shared_ptr<MemTracker> query_mem_tracker;
     std::shared_ptr<MemTracker> instance_mem_tracker;

--- a/be/src/runtime/stream_load/stream_load_executor.cpp
+++ b/be/src/runtime/stream_load/stream_load_executor.cpp
@@ -58,7 +58,9 @@ Status StreamLoadExecutor::execute_plan_fragment(StreamLoadContext* ctx) {
     auto st = _exec_env->fragment_mgr()->exec_plan_fragment(
             ctx->put_result.params,
             [ctx](PlanFragmentExecutor* executor) {
-                ctx->mem_tracker = executor->runtime_state()->instance_mem_tracker();
+                ctx->runtime_profile = executor->runtime_state()->runtime_profile_ptr();
+                ctx->query_mem_tracker = executor->runtime_state()->query_mem_tracker_ptr();
+                ctx->instance_mem_tracker = executor->runtime_state()->instance_mem_tracker_ptr();
             },
             [ctx](PlanFragmentExecutor* executor) {
                 ctx->commit_infos = std::move(executor->runtime_state()->tablet_commit_infos());


### PR DESCRIPTION
for #1615 

Before stream load recv thread exits, mem_tracker or runtime_profiole has been deconstructed