### PR TITLE
fix the bug of oom in high concurrency

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -70,7 +70,7 @@ CONF_Int64(tc_max_total_thread_cache_bytes, "1073741824");
 // defaults to bytes if no unit is given"
 // must larger than 0. and if larger than physical memory size,
 // it will be set to physical memory size.
-CONF_String(mem_limit, "80%");
+CONF_String(mem_limit, "90%");
 
 // the port heartbeat service used
 CONF_Int32(heartbeat_service_port, "9050");

--- a/be/src/exec/vectorized/chunks_sorter_full_sort.cpp
+++ b/be/src/exec/vectorized/chunks_sorter_full_sort.cpp
@@ -248,7 +248,7 @@ Status ChunksSorterFullSort::update(RuntimeState* state, const ChunkPtr& chunk) 
     try {
         _big_chunk->append(*chunk);
     } catch (std::bad_alloc const&) {
-        return Status::InternalError("Mem usage has exceed the limit of BE");
+        return Status::MemoryLimitExceeded("Mem usage has exceed the limit of BE");
     }
     DCHECK(!_big_chunk->has_const_column());
     return Status::OK();

--- a/be/src/exec/vectorized/chunks_sorter_full_sort.cpp
+++ b/be/src/exec/vectorized/chunks_sorter_full_sort.cpp
@@ -245,8 +245,11 @@ Status ChunksSorterFullSort::update(RuntimeState* state, const ChunkPtr& chunk) 
         return Status::InternalError("Full sort in single query instance only support at most 4294967295 rows");
     }
 
-    _big_chunk->append(*chunk);
-
+    try {
+        _big_chunk->append(*chunk);
+    } catch (std::bad_alloc const&) {
+        return Status::InternalError("Mem usage has exceed the limit of BE");
+    }
     DCHECK(!_big_chunk->has_const_column());
     return Status::OK();
 }

--- a/be/src/exec/vectorized/chunks_sorter_topn.cpp
+++ b/be/src/exec/vectorized/chunks_sorter_topn.cpp
@@ -181,7 +181,7 @@ Status ChunksSorterTopn::_build_sorting_data(RuntimeState* state, Permutation& p
         try {
             permutation_second.resize(row_count);
         } catch (std::bad_alloc const&) {
-            return Status::InternalError("Mem usage has exceed the limit of BE");
+            return Status::MemoryLimitExceeded("Mem usage has exceed the limit of BE");
         }
 
         uint32_t perm_index = 0;

--- a/be/src/exec/vectorized/chunks_sorter_topn.cpp
+++ b/be/src/exec/vectorized/chunks_sorter_topn.cpp
@@ -178,7 +178,11 @@ Status ChunksSorterTopn::_build_sorting_data(RuntimeState* state, Permutation& p
     // this time, because we will filter chunks before initialize permutations, so we just check memory usage.
     if (!_init_merged_segment) {
         // this time, Just initialized permutations.second.
-        permutation_second.resize(row_count);
+        try {
+            permutation_second.resize(row_count);
+        } catch (std::bad_alloc const&) {
+            return Status::InternalError("Mem usage has exceed the limit of BE");
+        }
 
         uint32_t perm_index = 0;
         for (uint32_t i = 0; i < segments.size(); ++i) {

--- a/be/src/exec/vectorized/cross_join_node.cpp
+++ b/be/src/exec/vectorized/cross_join_node.cpp
@@ -484,7 +484,7 @@ Status CrossJoinNode::_build(RuntimeState* state) {
                                                                        row_number);
                     }
                 } catch (std::bad_alloc const&) {
-                    return Status::InternalError("Mem usage has exceed the limit of BE");
+                    return Status::MemoryLimitExceeded("Mem usage has exceed the limit of BE");
                 }
             }
         }

--- a/be/src/exec/vectorized/cross_join_node.cpp
+++ b/be/src/exec/vectorized/cross_join_node.cpp
@@ -478,9 +478,13 @@ Status CrossJoinNode::_build(RuntimeState* state) {
                 // the complexity and time of cross-join chunks from left table with small chunks
                 // from right table.
                 size_t col_number = chunk->num_columns();
-                for (size_t col = 0; col < col_number; ++col) {
-                    _build_chunk->get_column_by_index(col)->append(*(chunk->get_column_by_index(col).get()), 0,
-                                                                   row_number);
+                try {
+                    for (size_t col = 0; col < col_number; ++col) {
+                        _build_chunk->get_column_by_index(col)->append(*(chunk->get_column_by_index(col).get()), 0,
+                                                                       row_number);
+                    }
+                } catch (std::bad_alloc const&) {
+                    return Status::InternalError("Mem usage has exceed the limit of BE");
                 }
             }
         }

--- a/be/src/exec/vectorized/hash_join_node.cpp
+++ b/be/src/exec/vectorized/hash_join_node.cpp
@@ -180,7 +180,11 @@ Status HashJoinNode::open(RuntimeState* state) {
             RETURN_IF_ERROR(state->check_mem_limit("HashJoinNode"));
             // copy chunk of right table
             SCOPED_TIMER(_copy_right_table_chunk_timer);
-            RETURN_IF_ERROR(_ht.append_chunk(state, chunk));
+            try {
+                RETURN_IF_ERROR(_ht.append_chunk(state, chunk));
+            } catch (std::bad_alloc const&) {
+                return Status::InternalError("Mem usage has exceed the limit of BE");
+            }
         }
     }
 

--- a/be/src/exec/vectorized/hash_join_node.cpp
+++ b/be/src/exec/vectorized/hash_join_node.cpp
@@ -183,7 +183,7 @@ Status HashJoinNode::open(RuntimeState* state) {
             try {
                 RETURN_IF_ERROR(_ht.append_chunk(state, chunk));
             } catch (std::bad_alloc const&) {
-                return Status::InternalError("Mem usage has exceed the limit of BE");
+                return Status::MemoryLimitExceeded("Mem usage has exceed the limit of BE");
             }
         }
     }

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -191,6 +191,7 @@ Status ExecEnv::init_mem_tracker() {
     std::stringstream ss;
     // --mem_limit="" means no memory limit
     bytes_limit = ParseUtil::parse_mem_spec(config::mem_limit, &is_percent);
+    // use 90% of mem_limit as the soft mem limit of BE
     bytes_limit = bytes_limit * 0.9;
     if (bytes_limit <= 0) {
         ss << "Failed to parse mem limit from '" + config::mem_limit + "'.";

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -191,6 +191,7 @@ Status ExecEnv::init_mem_tracker() {
     std::stringstream ss;
     // --mem_limit="" means no memory limit
     bytes_limit = ParseUtil::parse_mem_spec(config::mem_limit, &is_percent);
+    bytes_limit = bytes_limit * 0.9;
     if (bytes_limit <= 0) {
         ss << "Failed to parse mem limit from '" + config::mem_limit + "'.";
         return Status::InternalError(ss.str());

--- a/be/src/storage/vectorized/delta_writer.cpp
+++ b/be/src/storage/vectorized/delta_writer.cpp
@@ -175,7 +175,7 @@ Status DeltaWriter::write(Chunk* chunk, const uint32_t* indexes, uint32_t from, 
     try {
         flush = _mem_table->insert(*chunk, indexes, from, size);
     } catch (std::bad_alloc const&) {
-        return Status::InternalError("Mem usage has exceed the limit of BE");
+        return Status::MemoryLimitExceeded("Mem usage has exceed the limit of BE");
     }
 
     if (flush || _mem_table->is_full()) {

--- a/be/src/storage/vectorized/delta_writer.cpp
+++ b/be/src/storage/vectorized/delta_writer.cpp
@@ -171,7 +171,12 @@ Status DeltaWriter::write(Chunk* chunk, const uint32_t* indexes, uint32_t from, 
         RETURN_IF_ERROR(_init());
     }
 
-    bool flush = _mem_table->insert(*chunk, indexes, from, size);
+    bool flush = false;
+    try {
+        flush = _mem_table->insert(*chunk, indexes, from, size);
+    } catch (std::bad_alloc const&) {
+        return Status::InternalError("Mem usage has exceed the limit of BE");
+    }
 
     if (flush || _mem_table->is_full()) {
         RETURN_IF_ERROR(_flush_memtable_async());

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -39,3 +39,67 @@ export_env_from_conf() {
         fi
     done < $1
 }
+
+# Read the config [mem_limit] from configuration file of BE and set the upper limit of TCMalloc memory allocation
+# if mem_limit is not set, use 90% of machine memory
+export_mem_limit_from_conf() {
+    mem_limit_is_set=false;
+    while read line; do
+        envline=`echo $line | sed 's/[[:blank:]]*=[[:blank:]]*/=/g' | sed 's/^[[:blank:]]*//g' | egrep "^mem_limit=*"`
+        if [[ $envline == *"="* ]]; then
+            value=`echo $envline | sed 's/mem_limit=//g'`
+            mem_limit_is_set=true
+        fi
+    done < $1
+
+    # read /proc/meminfo to fetch total memory of machine
+    mem_total=$(cat /proc/meminfo |grep 'MemTotal' |awk -F : '{print $2}' |sed 's/^[ \t]*//g' | awk '{printf $1}')
+    if [ "$mem_total" == "" ]; then
+        echo "can't get mem info from /proc/meminfo"
+        return 1
+    fi
+
+    if [ "$mem_limit_is_set" == "false" ]; then
+        # if not set, the mem limit if 90% of total memory
+        mem=`expr $mem_total \* 90 / 100 / 1024`
+    else
+        final=${value: -1}
+        case $final in
+            t|T)
+                value=`echo ${value%?}`
+                mem=`expr $value \* 1024 \* 1024`
+                ;;
+            g|G)
+                value=`echo ${value%?}`
+                mem=`expr $value \* 1024`
+                ;;
+            m|M)
+                value=`echo ${value%?}`
+                mem=`expr $value`
+                ;;
+            k|K)
+                value=`echo ${value%?}`
+                mem=`expr $value / 1024`
+                ;;
+            b|B)
+                value=`echo ${value%?}`
+                mem=`expr $value / 1024 / 1024`
+                ;;
+            %)
+                value=`echo ${value%?}`
+                mem=`expr $mem_total \* $value / 100 / 1024`
+                ;;
+            *)
+                mem=`expr $value / 1024 / 1024`
+                ;;
+            esac
+    fi
+
+    if [ $mem -lt 1024 ]; then
+        echo "invalid mem limit: mem_limit<1024M"
+        return 1
+    fi
+
+    export TCMALLOC_HEAP_LIMIT_MB=${mem}
+    return 0
+}

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -95,8 +95,8 @@ export_mem_limit_from_conf() {
             esac
     fi
 
-    if [ $mem -lt 1024 ]; then
-        echo "invalid mem limit: mem_limit<1024M"
+    if [ $mem -le 0 ]; then
+        echo "invalid mem limit: mem_limit<=0M"
         return 1
     elif [ $mem -gt `expr $mem_total / 1024` ]; then
         echo "mem_limit is larger then machine memory"

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -98,6 +98,9 @@ export_mem_limit_from_conf() {
     if [ $mem -lt 1024 ]; then
         echo "invalid mem limit: mem_limit<1024M"
         return 1
+    elif [ $mem -gt `expr $mem_total / 1024` ]; then
+        echo "mem_limit is larger then machine memory"
+        return 1
     fi
 
     export TCMALLOC_HEAP_LIMIT_MB=${mem}

--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -51,6 +51,11 @@ export LOG_DIR=${STARROCKS_HOME}/log
 export PID_DIR=`cd "$curdir"; pwd`
 
 export_env_from_conf $STARROCKS_HOME/conf/be.conf
+export_mem_limit_from_conf $STARROCKS_HOME/conf/be.conf
+
+if [ $? -ne 0 ]; then
+    exit 1
+fi
 
 if [ -e $STARROCKS_HOME/conf/hadoop_env.sh ]; then
     source $STARROCKS_HOME/conf/hadoop_env.sh


### PR DESCRIPTION
for #1623 

![image](https://user-images.githubusercontent.com/11428742/144532239-d5fd7c37-264a-4634-95aa-60bf16330cfd.png)

By default, in order to release memory performance, we turn off aggressive_memory_decommit (when releasing memory, adjacent free memory is automatically merged)

TcMalloc's memory is returned to the OS in small batches under our own control timing (10 seconds)

The cause of the problem is under high concurrency. The free list and large span set have a lot of free memory. When we have a large block of memory allocation, there is no suitable Span. At this time, because there is no limit, TcMalloc will apply for a large block again from the OS. Memory, and at this time, the memory occupancy rate is already very high, all OS oom kills the starrrocks thread

One current solution:
-With the memory limit configured by BE (machine memory*90%), the TcMalloc memory upper limit is set through environment variables. After the upper limit is reached, TcMalloc finds that the memory exceeds the limit, it will pass the GC and merge the small Span to complete the memory allocation
-90% of BE configuration, as the soft limit of BE memory
-Our memory mechanism is to allocate first, then Check. If there is a large block of memory allocation, it will happen. After timely GC, there is still no suitable memory allocation. If memory allocation fails, bad_alloc will be triggered, so in several possible large memory allocations Point, add try catch exception
-Sort, CrossJoin, HashJoin, MemTable
-There may also be a large block of memory allocation in the aggregation. It is not easy to add catch at present, and directly assert in phmap