### PR TITLE
Fix runtime filter and hash join bug in pipeline

### DIFF
--- a/be/src/exec/pipeline/context_with_dependency.h
+++ b/be/src/exec/pipeline/context_with_dependency.h
@@ -55,7 +55,7 @@ public:
     // non-output operators to be finished early.
     bool is_finished() const { return _is_finished.load(std::memory_order_acquire); }
 
-private:
+protected:
     std::atomic<int32_t> _num_running_operators = 0;
     std::atomic<bool> _is_finished = false;
 };

--- a/be/src/exec/pipeline/runtime_filter_types.h
+++ b/be/src/exec/pipeline/runtime_filter_types.h
@@ -227,7 +227,7 @@ public:
             if (k < i) {
                 _partial_in_filters[k] = std::move(_partial_in_filters[i]);
             }
-            num_rows += _ht_row_counts[i];
+            num_rows = std::max(num_rows, _ht_row_counts[i]);
         }
 
         can_merge_in_filters = can_merge_in_filters && (num_rows <= 1024) && k >= 0;

--- a/be/src/exec/vectorized/hash_joiner.h
+++ b/be/src/exec/vectorized/hash_joiner.h
@@ -160,6 +160,7 @@ private:
         // special cases of short-circuit break.
         if (_ht.get_row_count() == 0 && (_join_type == TJoinOp::INNER_JOIN || _join_type == TJoinOp::LEFT_SEMI_JOIN)) {
             _phase = HashJoinPhase::EOS;
+            set_finished();
         }
 
         if (_ht.get_row_count() > 0) {
@@ -172,6 +173,7 @@ private:
                 // TODO: This reserved field will be removed in the implementation mechanism in the future.
                 // at that time, you can directly use Column::has_null() to judge
                 _phase = HashJoinPhase::EOS;
+                set_finished();
             }
         }
     }


### PR DESCRIPTION
1. Like https://github.com/StarRocks/starrocks/pull/1765， when merge in filter,  the num_rows shouldn't add all, should keep max one num_rows
2. When _short_circuit_break， we should call `set_finished `