### PR TITLE
Refactor status to improve compile speed

### DIFF
--- a/be/src/common/status.cpp
+++ b/be/src/common/status.cpp
@@ -4,9 +4,9 @@
 
 #include "common/status.h"
 
+#include "gen_cpp/Status_types.h"  // for TStatus
+#include "gen_cpp/status.pb.h"     // for PStatus
 #include "gutil/strings/fastmem.h" // for memcpy_inlined
-#include "gen_cpp/Status_types.h" // for TStatus
-#include "gen_cpp/status.pb.h"    // for PStatus
 
 namespace starrocks {
 

--- a/be/src/common/status.cpp
+++ b/be/src/common/status.cpp
@@ -5,6 +5,8 @@
 #include "common/status.h"
 
 #include "gutil/strings/fastmem.h" // for memcpy_inlined
+#include "gen_cpp/Status_types.h" // for TStatus
+#include "gen_cpp/status.pb.h"    // for PStatus
 
 namespace starrocks {
 

--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -9,11 +9,13 @@
 
 #include "common/compiler_util.h"
 #include "common/logging.h"
-#include "gen_cpp/Status_types.h" // for TStatus
-#include "gen_cpp/status.pb.h"    // for PStatus
+#include "gen_cpp/StatusCode_types.h" // for TStatus
 #include "util/slice.h"           // for Slice
 
 namespace starrocks {
+
+class PStatus;
+class TStatus;
 
 class Status {
 public:

--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -10,7 +10,7 @@
 #include "common/compiler_util.h"
 #include "common/logging.h"
 #include "gen_cpp/StatusCode_types.h" // for TStatus
-#include "util/slice.h"           // for Slice
+#include "util/slice.h"               // for Slice
 
 namespace starrocks {
 

--- a/be/src/exec/pipeline/olap_chunk_source.h
+++ b/be/src/exec/pipeline/olap_chunk_source.h
@@ -32,14 +32,14 @@ public:
                     std::vector<std::string>* unused_output_columns, RuntimeProfile* runtime_profile, int64_t limit)
             : ChunkSource(std::move(morsel)),
               _tuple_id(tuple_id),
+              _limit(limit),
               _conjunct_ctxs(std::move(conjunct_ctxs)),
               _runtime_in_filters(runtime_in_filters),
               _runtime_bloom_filters(*runtime_bloom_filters),
               _key_column_names(std::move(key_column_names)),
               _skip_aggregation(skip_aggregation),
               _unused_output_columns(unused_output_columns),
-              _runtime_profile(runtime_profile),
-              _limit(limit) {
+              _runtime_profile(runtime_profile) {
         _conjunct_ctxs.insert(_conjunct_ctxs.end(), _runtime_in_filters.begin(), _runtime_in_filters.end());
         OlapMorsel* olap_morsel = (OlapMorsel*)_morsel.get();
         _scan_range = olap_morsel->get_scan_range();

--- a/be/src/gen_cpp/CMakeLists.txt
+++ b/be/src/gen_cpp/CMakeLists.txt
@@ -68,6 +68,8 @@ set(SRC_FILES
     ${GEN_CPP_DIR}/RuntimeProfile_types.cpp
     ${GEN_CPP_DIR}/Status_constants.cpp
     ${GEN_CPP_DIR}/Status_types.cpp
+    ${GEN_CPP_DIR}/StatusCode_constants.cpp
+    ${GEN_CPP_DIR}/StatusCode_types.cpp
     ${GEN_CPP_DIR}/Types_constants.cpp
     ${GEN_CPP_DIR}/Types_types.cpp
     ${GEN_CPP_DIR}/parquet_types.cpp

--- a/be/src/util/file_utils.h
+++ b/be/src/util/file_utils.h
@@ -24,6 +24,7 @@
 
 #include <functional>
 #include <string>
+#include <set>
 #include <vector>
 
 #include "common/statusor.h"

--- a/be/src/util/file_utils.h
+++ b/be/src/util/file_utils.h
@@ -23,8 +23,8 @@
 #define STARROCKS_BE_UTIL_FILE_UTILS_H
 
 #include <functional>
-#include <string>
 #include <set>
+#include <string>
 #include <vector>
 
 #include "common/statusor.h"

--- a/gensrc/thrift/Makefile
+++ b/gensrc/thrift/Makefile
@@ -37,6 +37,13 @@ THRIFT_CPP_ARGS = -I ${CURDIR} -I ${BUILD_DIR}/thrift/ --allow-64bit-consts --ge
 
 ${BUILD_DIR}/gen_cpp:
 	mkdir -p $@
+
 # handwrite thrift
 ${BUILD_DIR}/gen_cpp/%_types.cpp: ${CURDIR}/%.thrift | ${BUILD_DIR}/gen_cpp
 	${THRIFT} ${THRIFT_CPP_ARGS} $<
+
+# The default generated header file contains too many unnecessary includes, this will leads a
+# slow compilation speed. We patch a diff to remove these includes.
+${BUILD_DIR}/gen_cpp/StatusCode_types.cpp: ${CURDIR}/StatusCode.thrift | ${BUILD_DIR}/gen_cpp
+	${THRIFT} ${THRIFT_CPP_ARGS} $<
+	patch -p0 -d ${BUILD_DIR}/gen_cpp < StatusCode_types.diff 2>&1 1>/dev/null

--- a/gensrc/thrift/Makefile
+++ b/gensrc/thrift/Makefile
@@ -40,6 +40,3 @@ ${BUILD_DIR}/gen_cpp:
 # handwrite thrift
 ${BUILD_DIR}/gen_cpp/%_types.cpp: ${CURDIR}/%.thrift | ${BUILD_DIR}/gen_cpp
 	${THRIFT} ${THRIFT_CPP_ARGS} $<
-# generated thrift
-${BUILD_DIR}/gen_cpp/%_types.cpp: ${BUILD_DIR}/thrift/%.thrift | ${BUILD_DIR}/gen_cpp
-	${THRIFT} ${THRIFT_CPP_ARGS} $<

--- a/gensrc/thrift/Status.thrift
+++ b/gensrc/thrift/Status.thrift
@@ -22,70 +22,9 @@
 namespace cpp starrocks
 namespace java com.starrocks.thrift
 
-// NOTE: Each item of StatusCode is explicitly assigned a constant value.
-// The TStatusCode struct is used in all FEs and BEs. In order to be able to
-// avoid errors when identifying status_codes in RPC during upgrading StarRocks
-// (update and restart the servers one by one), we must ensure that each element
-// always a fixed value.
-//
-// If each element is not explicitly assigned a constant, then the value of
-// each element will be assigned from 0 in turn, which will need us to be very
-// careful when adding and removing elements, to avoid the same element on
-// different machines to be recognized as a different value. i.e., new elements
-// can only be added to the end, and only elements at the end can be deleted.
-// Unfortunately, this implicit constraint is likely to be ignored by
-// programmers when coding, especially those who are new to StarRocks.
-//
-// NOTE: We use one byte in starrocks::Status, so the max value is 255.
-enum TStatusCode {
-    OK                              = 0,
-    CANCELLED                       = 1,
-    ANALYSIS_ERROR                  = 2,
-    NOT_IMPLEMENTED_ERROR           = 3,
-    RUNTIME_ERROR                   = 4,
-    MEM_LIMIT_EXCEEDED              = 5,
-    INTERNAL_ERROR                  = 6,
-    THRIFT_RPC_ERROR                = 7,
-    TIMEOUT                         = 8,
-    KUDU_NOT_ENABLED                = 9,  // Deprecated
-    KUDU_NOT_SUPPORTED_ON_OS        = 10, // Deprecated
-    MEM_ALLOC_FAILED                = 11,
-    BUFFER_ALLOCATION_FAILED        = 12,
-    MINIMUM_RESERVATION_UNAVAILABLE = 13,
-    PUBLISH_TIMEOUT                 = 14,
-    LABEL_ALREADY_EXISTS            = 15,
-    TOO_MANY_TASKS                  = 16,
-    ES_INTERNAL_ERROR               = 17,
-    ES_INDEX_NOT_FOUND              = 18,
-    ES_SHARD_NOT_FOUND              = 19,
-    ES_INVALID_CONTEXTID            = 20,
-    ES_INVALID_OFFSET               = 21,
-    ES_REQUEST_ERROR                = 22,
-
-    END_OF_FILE         = 30,
-    NOT_FOUND           = 31,
-    CORRUPTION          = 32,
-    INVALID_ARGUMENT    = 33,
-    IO_ERROR            = 34,
-    ALREADY_EXIST       = 35,
-    NETWORK_ERROR       = 36,
-    ILLEGAL_STATE       = 37,
-    NOT_AUTHORIZED      = 38,
-    ABORTED             = 39,
-    REMOTE_ERROR        = 40,
-    SERVICE_UNAVAILABLE = 41,
-    UNINITIALIZED       = 42,
-    CONFIGURATION_ERROR = 43,
-    INCOMPLETE          = 44,
-    OLAP_ERR_VERSION_ALREADY_MERGED = 45,
-    DATA_QUALITY_ERROR  = 46,
-    DUPLICATE_RPC_INVOCATION        = 47,
-
-    UNKNOWN = 50
-}
-
+include "StatusCode.thrift"
 struct TStatus {
-  1: required TStatusCode status_code
+  1: required StatusCode.TStatusCode status_code
   2: optional list<string> error_msgs
 }
 

--- a/gensrc/thrift/StatusCode.thrift
+++ b/gensrc/thrift/StatusCode.thrift
@@ -1,0 +1,86 @@
+// This file is made available under Elastic License 2.0
+// This file is based on code available under the Apache license here:
+//   https://github.com/apache/incubator-doris/blob/master/gensrc/thrift/Status.thrift
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+namespace cpp starrocks
+namespace java com.starrocks.thrift
+
+// NOTE: Each item of StatusCode is explicitly assigned a constant value.
+// The TStatusCode struct is used in all FEs and BEs. In order to be able to
+// avoid errors when identifying status_codes in RPC during upgrading StarRocks
+// (update and restart the servers one by one), we must ensure that each element
+// always a fixed value.
+//
+// If each element is not explicitly assigned a constant, then the value of
+// each element will be assigned from 0 in turn, which will need us to be very
+// careful when adding and removing elements, to avoid the same element on
+// different machines to be recognized as a different value. i.e., new elements
+// can only be added to the end, and only elements at the end can be deleted.
+// Unfortunately, this implicit constraint is likely to be ignored by
+// programmers when coding, especially those who are new to StarRocks.
+//
+// NOTE: We use one byte in starrocks::Status, so the max value is 255.
+enum TStatusCode {
+    OK                              = 0,
+    CANCELLED                       = 1,
+    ANALYSIS_ERROR                  = 2,
+    NOT_IMPLEMENTED_ERROR           = 3,
+    RUNTIME_ERROR                   = 4,
+    MEM_LIMIT_EXCEEDED              = 5,
+    INTERNAL_ERROR                  = 6,
+    THRIFT_RPC_ERROR                = 7,
+    TIMEOUT                         = 8,
+    KUDU_NOT_ENABLED                = 9,  // Deprecated
+    KUDU_NOT_SUPPORTED_ON_OS        = 10, // Deprecated
+    MEM_ALLOC_FAILED                = 11,
+    BUFFER_ALLOCATION_FAILED        = 12,
+    MINIMUM_RESERVATION_UNAVAILABLE = 13,
+    PUBLISH_TIMEOUT                 = 14,
+    LABEL_ALREADY_EXISTS            = 15,
+    TOO_MANY_TASKS                  = 16,
+    ES_INTERNAL_ERROR               = 17,
+    ES_INDEX_NOT_FOUND              = 18,
+    ES_SHARD_NOT_FOUND              = 19,
+    ES_INVALID_CONTEXTID            = 20,
+    ES_INVALID_OFFSET               = 21,
+    ES_REQUEST_ERROR                = 22,
+
+    END_OF_FILE         = 30,
+    NOT_FOUND           = 31,
+    CORRUPTION          = 32,
+    INVALID_ARGUMENT    = 33,
+    IO_ERROR            = 34,
+    ALREADY_EXIST       = 35,
+    NETWORK_ERROR       = 36,
+    ILLEGAL_STATE       = 37,
+    NOT_AUTHORIZED      = 38,
+    ABORTED             = 39,
+    REMOTE_ERROR        = 40,
+    SERVICE_UNAVAILABLE = 41,
+    UNINITIALIZED       = 42,
+    CONFIGURATION_ERROR = 43,
+    INCOMPLETE          = 44,
+    OLAP_ERR_VERSION_ALREADY_MERGED = 45,
+    DATA_QUALITY_ERROR  = 46,
+    DUPLICATE_RPC_INVOCATION        = 47,
+
+    UNKNOWN = 50
+}
+

--- a/gensrc/thrift/StatusCode_types.diff
+++ b/gensrc/thrift/StatusCode_types.diff
@@ -1,0 +1,27 @@
+--- StatusCode_types.cpp	2021-12-02 14:49:35.352849329 +0800
++++ StatusCode_types.cpp.new	2021-12-02 14:42:52.816116556 +0800
+@@ -10,6 +10,7 @@
+ #include <ostream>
+ 
+ #include <thrift/TToString.h>
++#include <thrift/Thrift.h>
+ 
+ namespace starrocks {
+ 
+--- StatusCode_types.h	2021-12-02 14:49:35.352849329 +0800
++++ StatusCode_types.h.new	2021-12-02 14:42:36.364555258 +0800
+@@ -9,13 +9,8 @@
+ 
+ #include <iosfwd>
+ 
+-#include <thrift/Thrift.h>
+-#include <thrift/TApplicationException.h>
+-#include <thrift/TBase.h>
+-#include <thrift/protocol/TProtocol.h>
+-#include <thrift/transport/TTransport.h>
+-
+ #include <functional>
++#include <map>
+ #include <memory>
+ 
+ 


### PR DESCRIPTION
In this CL
1. split Status.thrift into Status.thrift and StatusCode.thrift
2. remove unnecessary include from generated StatusCode_types.h
3. change TStatus and PStatus to forward declare in Status.h
4. reorder initial list to remove compile warning.

From this work, the time compile one file in my laptop reduce from 6.2s to 4.5s.