### PR TITLE
To make CTE BE/pipeline works

### DIFF
--- a/be/src/exec/pipeline/exchange/mcast_local_exchange.cpp
+++ b/be/src/exec/pipeline/exchange/mcast_local_exchange.cpp
@@ -87,8 +87,8 @@ StatusOr<vectorized::ChunkPtr> MultiCastLocalExchanger::pull_chunk(RuntimeState*
         return Status::OK();
     }
     cell = cell->next;
-    VLOG_FILE << "return chunk to " << mcast_consumer_index << ", row = " << cell->chunk->debug_row(0)
-              << ", size = " << cell->chunk->num_rows();
+    VLOG_FILE << "MultiCastLocalExchanger: return chunk to " << mcast_consumer_index
+              << ", row = " << cell->chunk->debug_row(0) << ", size = " << cell->chunk->num_rows();
 
     _progress[mcast_consumer_index] = cell;
     cell->used_count += 1;

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -293,6 +293,7 @@ void FragmentExecutor::_convert_data_sink_to_operator(PipelineBuilderContext* co
             OpFactoryPtr sink_op = std::make_shared<MultiCastLocalExchangeSinkOperatorFactory>(
                     context->next_operator_id(), mcast_local_exchanger);
             _fragment_ctx->pipelines().back()->add_op_factory(sink_op);
+            _fragment_ctx->pipelines().back()->unset_root();
         }
 
         // ==== create source/sink pipelines ====

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -194,10 +194,7 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
         const auto degree_of_parallelism = pipeline->source_operator_factory()->degree_of_parallelism();
         LOG(INFO) << "Pipeline " << pipeline->to_readable_string() << " parallel=" << degree_of_parallelism
                   << " fragment_instance_id=" << print_id(params.fragment_instance_id);
-        // This happens when we create new pipelines at the end of original pipeline
-        // Theoretically we should set original pipeline non-root.
-        // But here for simplicity we just ignore that.
-        const bool is_root = (n == num_pipelines - 1) || (pipeline->is_root());
+        const bool is_root = pipeline->is_root();
         // If pipeline's SourceOperator is with morsels, a MorselQueue is added to the SourceOperator.
         // at present, only ScanOperator need a MorselQueue attached.
         setup_profile_hierarchy(runtime_state, pipeline);

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -187,13 +187,17 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
     const auto& pipelines = _fragment_ctx->pipelines();
     const size_t num_pipelines = pipelines.size();
     size_t driver_id = 0;
+    size_t num_root_drivers = 0;
     for (auto n = 0; n < num_pipelines; ++n) {
         const auto& pipeline = pipelines[n];
         // DOP(degree of parallelism) of Pipeline's SourceOperator determines the Pipeline's DOP.
         const auto degree_of_parallelism = pipeline->source_operator_factory()->degree_of_parallelism();
         LOG(INFO) << "Pipeline " << pipeline->to_readable_string() << " parallel=" << degree_of_parallelism
                   << " fragment_instance_id=" << print_id(params.fragment_instance_id);
-        const bool is_root = (n == num_pipelines - 1);
+        // This happens when we create new pipelines at the end of original pipeline
+        // Theoretically we should set original pipeline non-root.
+        // But here for simplicity we just ignore that.
+        const bool is_root = (n == num_pipelines - 1) || (pipeline->is_root());
         // If pipeline's SourceOperator is with morsels, a MorselQueue is added to the SourceOperator.
         // at present, only ScanOperator need a MorselQueue attached.
         setup_profile_hierarchy(runtime_state, pipeline);
@@ -205,7 +209,7 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
                 DCHECK(degree_of_parallelism <= morsel_queue->num_morsels());
             }
             if (is_root) {
-                _fragment_ctx->set_num_root_drivers(degree_of_parallelism);
+                num_root_drivers += degree_of_parallelism;
             }
             for (size_t i = 0; i < degree_of_parallelism; ++i) {
                 auto&& operators = pipeline->create_operators(degree_of_parallelism, i);
@@ -219,8 +223,9 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
             }
         } else {
             if (is_root) {
-                _fragment_ctx->set_num_root_drivers(degree_of_parallelism);
+                num_root_drivers += degree_of_parallelism;
             }
+
             for (size_t i = 0; i < degree_of_parallelism; ++i) {
                 auto&& operators = pipeline->create_operators(degree_of_parallelism, i);
                 DriverPtr driver = std::make_shared<PipelineDriver>(std::move(operators), _query_ctx, _fragment_ctx,
@@ -232,6 +237,7 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
         // The pipeline created later should be placed in the front
         runtime_state->runtime_profile()->reverse_childs();
     }
+    _fragment_ctx->set_num_root_drivers(num_root_drivers);
     _fragment_ctx->set_drivers(std::move(drivers));
     return Status::OK();
 }
@@ -313,6 +319,7 @@ void FragmentExecutor::_convert_data_sink_to_operator(PipelineBuilderContext* co
             ops.emplace_back(source_op);
             ops.emplace_back(sink_op);
             auto pp = std::make_shared<Pipeline>(context->next_pipe_id(), ops);
+            pp->set_root();
             _fragment_ctx->pipelines().emplace_back(pp);
         }
     }

--- a/be/src/exec/pipeline/pipeline.h
+++ b/be/src/exec/pipeline/pipeline.h
@@ -70,10 +70,14 @@ public:
         return ss.str();
     }
 
+    bool is_root() const { return _is_root; }
+    void set_root() { _is_root = true; }
+
 private:
     uint32_t _id = 0;
     std::shared_ptr<RuntimeProfile> _runtime_profile = nullptr;
     OpFactories _op_factories;
+    bool _is_root = false;
 };
 
 } // namespace pipeline

--- a/be/src/exec/pipeline/pipeline.h
+++ b/be/src/exec/pipeline/pipeline.h
@@ -72,6 +72,7 @@ public:
 
     bool is_root() const { return _is_root; }
     void set_root() { _is_root = true; }
+    void unset_root() { _is_root = false; }
 
 private:
     uint32_t _id = 0;

--- a/be/src/exec/pipeline/pipeline_builder.cpp
+++ b/be/src/exec/pipeline/pipeline_builder.cpp
@@ -95,6 +95,7 @@ OpFactories PipelineBuilderContext::gather_pipelines_to_one(std::vector<OpFactor
 Pipelines PipelineBuilder::build(const FragmentContext& fragment, ExecNode* exec_node) {
     pipeline::OpFactories operators = exec_node->decompose_to_pipeline(&_context);
     _context.add_pipeline(operators);
+    _context.get_pipelines().back()->set_root();
     return _context.get_pipelines();
 }
 

--- a/be/src/runtime/mcast_data_stream_sink.cpp
+++ b/be/src/runtime/mcast_data_stream_sink.cpp
@@ -5,7 +5,7 @@ namespace starrocks {
 
 static Status kOnlyPipelinedEngine = Status::NotSupported("Don't support non-pipelined query engine");
 
-MultiCastDataStreamSink::MultiCastDataStreamSink(ObjectPool* pool) : _pool(pool), _profile(nullptr), _sinks() {}
+MultiCastDataStreamSink::MultiCastDataStreamSink(ObjectPool* pool) : _pool(pool), _sinks() {}
 
 void MultiCastDataStreamSink::add_data_stream_sink(std::unique_ptr<DataStreamSender> data_stream_sink) {
     _sinks.emplace_back(std::move(data_stream_sink));
@@ -15,20 +15,11 @@ Status MultiCastDataStreamSink::init(const TDataSink& thrift_sink) {
     for (auto& s : _sinks) {
         RETURN_IF_ERROR(s->init(thrift_sink));
     }
-    _create_profile();
     return Status::OK();
 }
 
 Status MultiCastDataStreamSink::prepare(RuntimeState* state) {
     return kOnlyPipelinedEngine;
-}
-
-void MultiCastDataStreamSink::_create_profile() {
-    std::string title("MultiCastDataStreamSink");
-    _profile = _pool->add(new RuntimeProfile(title));
-    for (auto& s : _sinks) {
-        _profile->add_child(s->profile(), true, nullptr);
-    }
 }
 
 Status MultiCastDataStreamSink::open(RuntimeState* state) {

--- a/be/src/runtime/mcast_data_stream_sink.h
+++ b/be/src/runtime/mcast_data_stream_sink.h
@@ -14,14 +14,12 @@ public:
     Status prepare(RuntimeState* state) override;
     Status open(RuntimeState* state) override;
     Status close(RuntimeState* state, Status exec_status) override;
-    RuntimeProfile* profile() override { return _profile; }
+    RuntimeProfile* profile() override { return nullptr; }
     std::vector<std::unique_ptr<DataStreamSender> >& get_sinks() { return _sinks; }
     Status send_chunk(RuntimeState* state, vectorized::Chunk* chunk) override;
 
 private:
-    void _create_profile();
     ObjectPool* _pool;
-    RuntimeProfile* _profile;
     std::vector<std::unique_ptr<DataStreamSender> > _sinks;
 };
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/MultiCastPlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/MultiCastPlanFragment.java
@@ -30,6 +30,7 @@ public class MultiCastPlanFragment extends PlanFragment {
 
     public MultiCastPlanFragment(PlanFragment planFragment) {
         super(planFragment.fragmentId, planFragment.planRoot, DataPartition.RANDOM);
+        this.children.addAll(planFragment.getChildren());
     }
 
     public List<PlanFragment> getDestFragmentList() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/OperatorBuilderFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/OperatorBuilderFactory.java
@@ -5,6 +5,7 @@ import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalAssertOneRowOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalCTEConsumeOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalEsScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalExceptOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalFilterOperator;
@@ -63,6 +64,8 @@ public class OperatorBuilderFactory {
             return new LogicalRepeatOperator.Builder();
         } else if (operator instanceof LogicalLimitOperator) {
             return new LogicalLimitOperator.Builder();
+        } else if (operator instanceof LogicalCTEConsumeOperator) {
+            return new LogicalCTEConsumeOperator.Builder();
         } else {
             throw new StarRocksPlannerException("not implement builder", ErrorType.INTERNAL_ERROR);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalCTEConsumeOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalCTEConsumeOperator.java
@@ -87,4 +87,31 @@ public class LogicalCTEConsumeOperator extends LogicalOperator {
     public int hashCode() {
         return Objects.hash(super.hashCode(), cteId, cteOutputColumnRefMap);
     }
+
+
+    public static class Builder
+            extends LogicalOperator.Builder<LogicalCTEConsumeOperator, LogicalCTEConsumeOperator.Builder> {
+        private String cteId;
+
+        private Map<ColumnRefOperator, ColumnRefOperator> cteOutputColumnRefMap;
+
+        @Override
+        public LogicalCTEConsumeOperator build() {
+            return new LogicalCTEConsumeOperator(this);
+        }
+
+        @Override
+        public LogicalCTEConsumeOperator.Builder withOperator(LogicalCTEConsumeOperator operator) {
+            super.withOperator(operator);
+            this.cteId = operator.cteId;
+            this.cteOutputColumnRefMap = operator.cteOutputColumnRefMap;
+            return this;
+        }
+    }
+
+    private LogicalCTEConsumeOperator(LogicalCTEConsumeOperator.Builder builder) {
+        super(OperatorType.LOGICAL_CTE_CONSUME, builder.getLimit(), builder.getPredicate(), builder.getProjection());
+        this.cteId = builder.cteId;
+        this.cteOutputColumnRefMap = builder.cteOutputColumnRefMap;
+    }
 }


### PR DESCRIPTION
ref: #1490 #1667 

There are several issues when running CTE
1. FE reports "not implement builder"
2. FE failed to get fragment
3. BE failed to create profile (It turns out we don't need to create profile in `MultiDataStreamSink`, because in pipeline mode, profile is created by operator)
4. For each fragment, only one root pipeline is allowed. But that assumption is not true any more if we support CTE. We can mark any pipeline as root, instead of deducing root or not by framework itself.

I have run following SQL in 10k time without fail (parallel = 8, dop = 3)

```
with t as ( select ws_item_sk, ws_order_number from web_sales LIMIT 100000 ) 

select count(*) from t t1 inner join t t2 inner  join  t t3 

on t1.ws_item_sk = t2.ws_item_sk and t1.ws_item_sk = t3.ws_item_sk

```

-------

A simple performance comparison using following SQL(on TPCDS 100G) and command

```
with ss as (
 select
          i_manufact_id,sum(ss_ext_sales_price) total_sales
 from
 	store_sales,
 	date_dim,
         customer_address,
         item
 where
         i_manufact_id in (select
  i_manufact_id
from
 item
where i_category in ('Electronics'))
 and     ss_item_sk              = i_item_sk
 and     ss_sold_date_sk         = d_date_sk
 and     d_year                  = 1998
 and     d_moy                   = 5
 and     ss_addr_sk              = ca_address_sk
 and     ca_gmt_offset           = -5
 group by i_manufact_id)

 select * from ss
        union all
        select * from ss;
```

```
python run-bench.py --times 10 --concurrency 8  --sqlfile queryset/test_multi_cast.sql --db tpcds_100g  --mysql --endpoint localhost --port 41003 --user root --vars cbo_cte_reuse=false,enable_pipeline_engine=true --dop 3
```

cbo_cte_reuse = false, takes 480ms on average
cbo_cte_reuse = true, takes 380ms on average.
