### PR TITLE
fix to assign wrong nullable property to dict column

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -386,15 +386,17 @@ public class PlanFragmentBuilder {
                 ArrayList<SlotDescriptor> slots = childTuple.getSlots();
                 for (SlotDescriptor slot : slots) {
                     int slotId = slot.getId().asInt();
+                    boolean isNullable = slot.getIsNullable();
                     if (node.getDictToStrings().containsKey(slotId)) {
                         Integer stringSlotId = node.getDictToStrings().get(slotId);
                         SlotDescriptor slotDescriptor =
                                 context.getDescTbl().addSlotDescriptor(tupleDescriptor, new SlotId(stringSlotId));
-                        slotDescriptor.setIsNullable(true);
+                        slotDescriptor.setIsNullable(isNullable);
                         slotDescriptor.setIsMaterialized(true);
                         slotDescriptor.setType(Type.VARCHAR);
 
-                        context.getColRefToExpr().put(new ColumnRefOperator(stringSlotId, Type.VARCHAR, "xxx", true),
+                        context.getColRefToExpr().put(new ColumnRefOperator(stringSlotId, Type.VARCHAR,
+                                        "<dict-code>", slotDescriptor.getIsNullable()),
                                 new SlotRef(stringSlotId.toString(), slotDescriptor));
                     } else {
                         // Note: must change the parent tuple id

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecodeRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecodeRewriteTest.java
@@ -472,4 +472,22 @@ public class DecodeRewriteTest extends PlanTestBase {
                 "  |  <slot 9> : hex(10)\n" +
                 "  |  <slot 10> : 10: S_ADDRESS"));
     }
+
+    @Test
+    public void testAssignWrongNullableProperty() throws Exception {
+        String sql = "SELECT S_ADDRESS, Dense_rank() OVER ( ORDER BY S_SUPPKEY) FROM supplier UNION SELECT S_ADDRESS, Dense_rank() OVER ( ORDER BY S_SUPPKEY) FROM supplier;";
+        String plan = getCostExplain(sql);
+        Assert.assertTrue(plan.contains("  0:UNION\n" +
+                "  |  child exprs:\n" +
+                "  |      [3, VARCHAR, false] | [9, BIGINT, true]\n" +
+                "  |      [14, VARCHAR, false] | [20, BIGINT, true]"));
+        Assert.assertTrue(plan.contains("  13:Project\n" +
+                "  |  output columns:\n" +
+                "  |  14 <-> [14: S_ADDRESS, VARCHAR, false]\n" +
+                "  |  20 <-> [20: dense_rank(), BIGINT, true]"));
+        Assert.assertTrue(plan.contains("  9:Decode\n" +
+                "  |  <dict id 22> : <string id 14>\n" +
+                "  |  cardinality: 1"));
+
+    }
 }


### PR DESCRIPTION
ref: #1690 

When generating plan fragment on dict decode node, the nullable property of dict column is always set to true, which is wrong. 

We have to use the same value of nullable property of dict code column. The nullable property should be consistent always.