### PR TITLE
[Vertical compaction] improve the calculation method of aggregated rows in chunk aggregator

### DIFF
--- a/be/src/storage/vectorized/chunk_aggregator.cpp
+++ b/be/src/storage/vectorized/chunk_aggregator.cpp
@@ -238,8 +238,8 @@ void ChunkAggregator::update_source(ChunkPtr& chunk, std::vector<RowSourceMask>*
             }
         }
 
-        if (_aggregated_rows > 0 && _key_fields > 0) {
-            _is_eq[0] = _row_equal(_aggregate_chunk.get(), _aggregated_rows - 1, chunk.get(), 0);
+        if (_aggregate_rows > 0 && _key_fields > 0) {
+            _is_eq[0] = _row_equal(_aggregate_chunk.get(), _aggregate_rows - 1, chunk.get(), 0);
         } else {
             _is_eq[0] = 0;
         }
@@ -276,7 +276,7 @@ void ChunkAggregator::aggregate() {
     _aggregate_loops.clear();
 
     // first key is not equal with last row in previous chunk
-    bool previous_neq = !_is_eq[_source_row] && (_aggregated_rows > 0);
+    bool previous_neq = !_is_eq[_source_row] && (_aggregate_rows > 0);
 
     // same with last row
     if (_is_eq[_source_row] == 1) {
@@ -288,10 +288,10 @@ void ChunkAggregator::aggregate() {
     uint32_t row = _source_row;
     for (; row < _source_size; ++row) {
         if (_is_eq[row] == 0) {
-            if (_aggregated_rows >= _max_aggregate_rows) {
+            if (_aggregate_rows >= _max_aggregate_rows) {
                 break;
             }
-            ++_aggregated_rows;
+            ++_aggregate_rows;
             _selective_index.emplace_back(row);
             _aggregate_loops.emplace_back(1);
         } else {
@@ -315,12 +315,12 @@ void ChunkAggregator::aggregate() {
 }
 
 bool ChunkAggregator::is_finish() {
-    return (_aggregate_chunk == nullptr || _aggregated_rows >= _max_aggregate_rows);
+    return (_aggregate_chunk == nullptr || _aggregate_rows >= _max_aggregate_rows);
 }
 
 void ChunkAggregator::aggregate_reset() {
     _aggregate_chunk = ChunkHelper::new_chunk(*_schema, _reserve_rows);
-    _aggregated_rows = 0;
+    _aggregate_rows = 0;
 
     for (int i = 0; i < _num_fields; ++i) {
         auto p = _aggregate_chunk->get_column_by_index(i).get();

--- a/be/src/storage/vectorized/chunk_aggregator.cpp
+++ b/be/src/storage/vectorized/chunk_aggregator.cpp
@@ -237,8 +237,8 @@ void ChunkAggregator::update_source(ChunkPtr& chunk, std::vector<RowSourceMask>*
             }
         }
 
-        if (_aggregate_chunk->num_rows() > 0 && _key_fields > 0) {
-            _is_eq[0] = _row_equal(_aggregate_chunk.get(), _aggregate_chunk->num_rows() - 1, chunk.get(), 0);
+        if (_aggregated_rows > 0 && _key_fields > 0) {
+            _is_eq[0] = _row_equal(_aggregate_chunk.get(), _aggregated_rows - 1, chunk.get(), 0);
         } else {
             _is_eq[0] = 0;
         }
@@ -271,14 +271,11 @@ void ChunkAggregator::aggregate() {
 
     DCHECK(_source_row < _source_size) << "It's impossible";
 
-    // maybe haven't new rows
-    uint32_t row = _aggregate_chunk->num_rows();
-
     _selective_index.clear();
     _aggregate_loops.clear();
 
     // first key is not equal with last row in previous chunk
-    bool previous_neq = !_is_eq[_source_row] && (_aggregate_chunk->num_rows() != 0);
+    bool previous_neq = !_is_eq[_source_row] && (_aggregated_rows > 0);
 
     // same with last row
     if (_is_eq[_source_row] == 1) {
@@ -290,10 +287,10 @@ void ChunkAggregator::aggregate() {
     uint32_t aggregate_rows = _source_row;
     for (; aggregate_rows < _source_size; ++aggregate_rows) {
         if (_is_eq[aggregate_rows] == 0) {
-            if (row >= _aggregate_rows) {
+            if (_aggregated_rows >= _aggregate_rows) {
                 break;
             }
-            ++row;
+            ++_aggregated_rows;
             _selective_index.emplace_back(aggregate_rows);
             _aggregate_loops.emplace_back(1);
         } else {
@@ -317,11 +314,12 @@ void ChunkAggregator::aggregate() {
 }
 
 bool ChunkAggregator::is_finish() {
-    return (_aggregate_chunk == nullptr || _aggregate_chunk->num_rows() >= _aggregate_rows);
+    return (_aggregate_chunk == nullptr || _aggregated_rows >= _aggregate_rows);
 }
 
 void ChunkAggregator::aggregate_reset() {
     _aggregate_chunk = ChunkHelper::new_chunk(*_schema, _reserve_rows);
+    _aggregated_rows = 0;
 
     for (int i = 0; i < _num_fields; ++i) {
         auto p = _aggregate_chunk->get_column_by_index(i).get();
@@ -351,7 +349,7 @@ size_t ChunkAggregator::memory_usage() {
     size_t container_memory_usage = _aggregate_chunk->container_memory_usage();
 
     size_t num_rows = _aggregate_chunk->num_rows();
-    // last column value is in aggregator before finalize,
+    // the last row of non-key column is in aggregator (not in aggregate chunk) before finalize,
     // the size of key columns is 1 greater that value columns,
     // so we use num_rows - 1 as chunk num rows.
     if (num_rows <= 1) {
@@ -377,7 +375,7 @@ size_t ChunkAggregator::bytes_usage() {
     }
 
     size_t num_rows = _aggregate_chunk->num_rows();
-    // last column value is in aggregator before finalize,
+    // the last row of non-key column is in aggregator (not in aggregate chunk) before finalize,
     // the size of key columns is 1 greater that value columns,
     // so we use num_rows - 1 as chunk num rows.
     if (num_rows <= 1) {

--- a/be/src/storage/vectorized/chunk_aggregator.h
+++ b/be/src/storage/vectorized/chunk_aggregator.h
@@ -18,15 +18,16 @@ using CompareFN = void (*)(const Column* col, uint8_t* flags);
 
 class ChunkAggregator {
 private:
-    ChunkAggregator(const Schema* schema, uint32_t reserve_rows, uint32_t aggregate_rows, double factor,
+    ChunkAggregator(const Schema* schema, uint32_t reserve_rows, uint32_t max_aggregate_rows, double factor,
                     bool is_vertical_merge, bool is_key);
 
 public:
-    ChunkAggregator(const Schema* schema, uint32_t reserve_rows, uint32_t aggregate_rows, double factor);
+    ChunkAggregator(const Schema* schema, uint32_t reserve_rows, uint32_t max_aggregate_rows, double factor);
 
-    ChunkAggregator(const Schema* schema, uint32_t aggregate_rows, double factor);
+    ChunkAggregator(const Schema* schema, uint32_t max_aggregate_rows, double factor);
 
-    ChunkAggregator(const Schema* schema, uint32_t aggregate_rows, double factor, bool is_vertical_merge, bool is_key);
+    ChunkAggregator(const Schema* schema, uint32_t max_aggregate_rows, double factor, bool is_vertical_merge,
+                    bool is_key);
 
     void update_source(ChunkPtr& chunk) { update_source(chunk, nullptr); }
     // |source_masks| is used if |_is_vertical_merge| is true.
@@ -70,8 +71,7 @@ private:
 
     uint32_t _reserve_rows;
 
-    // total limit of aggregate rows
-    uint32_t _aggregate_rows;
+    uint32_t _max_aggregate_rows;
 
     std::vector<CompareFN> _comparator;
 

--- a/be/src/storage/vectorized/chunk_aggregator.h
+++ b/be/src/storage/vectorized/chunk_aggregator.h
@@ -90,8 +90,8 @@ private:
     ChunkPtr _aggregate_chunk;
     // the last row of non-key column is in aggregator (not in aggregate chunk) before finalize.
     // in vertical compaction, there maybe only non-key column in aggregate chunk,
-    // so we cannot use _aggregate_chunk->num_rows() as aggregated rows.
-    uint32_t _aggregated_rows = 0;
+    // so we cannot use _aggregate_chunk->num_rows() as aggregate rows.
+    uint32_t _aggregate_rows = 0;
 
     // aggregate factor
     double _factor;

--- a/be/src/storage/vectorized/chunk_aggregator.h
+++ b/be/src/storage/vectorized/chunk_aggregator.h
@@ -70,6 +70,7 @@ private:
 
     uint32_t _reserve_rows;
 
+    // total limit of aggregate rows
     uint32_t _aggregate_rows;
 
     std::vector<CompareFN> _comparator;
@@ -87,6 +88,10 @@ private:
     std::vector<uint32_t> _aggregate_loops;
 
     ChunkPtr _aggregate_chunk;
+    // the last row of non-key column is in aggregator (not in aggregate chunk) before finalize.
+    // in vertical compaction, there maybe only non-key column in aggregate chunk,
+    // so we cannot use _aggregate_chunk->num_rows() as aggregated rows.
+    uint32_t _aggregated_rows = 0;
 
     // aggregate factor
     double _factor;

--- a/be/test/storage/vectorized/chunk_aggregator_test.cpp
+++ b/be/test/storage/vectorized/chunk_aggregator_test.cpp
@@ -11,7 +11,7 @@
 
 namespace starrocks::vectorized {
 
-TEST(ColumnAggregator, testNoneAggregator) {
+TEST(ChunkAggregatorTest, testNoneAggregator) {
     FieldPtr key = std::make_shared<Field>(1, "key", FieldType::OLAP_FIELD_TYPE_INT, false);
     key->set_aggregate_method(FieldAggregationMethod::OLAP_FIELD_AGGREGATION_NONE);
     key->set_is_key(true);
@@ -61,6 +61,54 @@ TEST(ColumnAggregator, testNoneAggregator) {
     auto r_col = down_cast<Int32Column*>(ck->get_column_by_index(1).get());
 
     ASSERT_EQ(1024, r_col->get_data()[0]);
+
+    ASSERT_EQ(false, aggregator.is_finish());
+}
+
+TEST(ChunkAggregatorTest, testNonKeyColumnsByMask) {
+    FieldPtr value = std::make_shared<Field>(1, "value", FieldType::OLAP_FIELD_TYPE_INT, false);
+    value->set_aggregate_method(FieldAggregationMethod::OLAP_FIELD_AGGREGATION_SUM);
+    value->set_is_key(false);
+
+    Fields fields;
+    fields.emplace_back(value);
+
+    SchemaPtr schema = std::make_shared<Schema>(fields);
+
+    ChunkAggregator aggregator(schema.get(), 1024, 0, true, false);
+
+    ASSERT_EQ(true, aggregator.source_exhausted());
+
+    auto v_col = Int32Column::create();
+    std::vector<RowSourceMask> source_masks;
+    for (int i = 0; i < 1024; ++i) {
+        v_col->append(1);
+        if (i % 2 == 0) {
+            source_masks.emplace_back(RowSourceMask{0, false});
+        } else {
+            source_masks.emplace_back(RowSourceMask{0, true});
+        }
+    }
+    Columns cols{v_col};
+    ChunkPtr chunk = std::make_shared<Chunk>(cols, schema);
+
+    aggregator.update_source(chunk, &source_masks);
+    ASSERT_EQ(true, aggregator.is_do_aggregate());
+    ASSERT_EQ(false, aggregator.source_exhausted());
+
+    aggregator.aggregate();
+
+    ASSERT_EQ(true, aggregator.source_exhausted());
+    ASSERT_EQ(true, aggregator.has_aggregate_data());
+    ASSERT_EQ(false, aggregator.is_finish());
+    ASSERT_EQ(512, aggregator._aggregated_rows);
+
+    auto ck = aggregator.aggregate_result();
+    ASSERT_EQ(512, ck->num_rows());
+    auto r_col = down_cast<Int32Column*>(ck->get_column_by_index(0).get());
+    for (size_t i = 0; i < ck->num_rows(); ++i) {
+        ASSERT_EQ(2, r_col->get_data()[i]);
+    }
 
     ASSERT_EQ(false, aggregator.is_finish());
 }

--- a/be/test/storage/vectorized/chunk_aggregator_test.cpp
+++ b/be/test/storage/vectorized/chunk_aggregator_test.cpp
@@ -101,7 +101,7 @@ TEST(ChunkAggregatorTest, testNonKeyColumnsByMask) {
     ASSERT_EQ(true, aggregator.source_exhausted());
     ASSERT_EQ(true, aggregator.has_aggregate_data());
     ASSERT_EQ(false, aggregator.is_finish());
-    ASSERT_EQ(512, aggregator._aggregated_rows);
+    ASSERT_EQ(512, aggregator._aggregate_rows);
 
     auto ck = aggregator.aggregate_result();
     ASSERT_EQ(512, ck->num_rows());


### PR DESCRIPTION
The last row of the non-key column is in the column aggregator instead of in the aggregate chunk before finalizing.
In vertical compaction, there may be some only non-key columns in the aggregate chunk,
the _aggregate_chunk->num_rows() can not be used as the aggregate_rows.
So the aggregate_rows should be calculated in the aggregate function.