### PR TITLE
Paralize ExchangeSourceOperator

### DIFF
--- a/be/src/exec/exchange_node.cpp
+++ b/be/src/exec/exchange_node.cpp
@@ -235,8 +235,10 @@ pipeline::OpFactories ExchangeNode::decompose_to_pipeline(pipeline::PipelineBuil
     using namespace pipeline;
     OpFactories operators;
     if (!_is_merging) {
-        operators.emplace_back(std::make_shared<ExchangeSourceOperatorFactory>(context->next_operator_id(), id(),
-                                                                               _num_senders, _input_row_desc));
+        auto exchange_source_op = std::make_shared<ExchangeSourceOperatorFactory>(context->next_operator_id(), id(),
+                                                                                  _num_senders, _input_row_desc);
+        exchange_source_op->set_degree_of_parallelism(context->degree_of_parallelism());
+        operators.emplace_back(exchange_source_op);
         if (limit() != -1) {
             operators.emplace_back(std::make_shared<LimitOperatorFactory>(context->next_operator_id(), id(), limit()));
         }

--- a/be/src/exec/pipeline/exchange/exchange_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_source_operator.cpp
@@ -11,14 +11,8 @@
 namespace starrocks::pipeline {
 Status ExchangeSourceOperator::prepare(RuntimeState* state) {
     Operator::prepare(state);
-    _stream_recvr = state->exec_env()->stream_mgr()->create_recvr(
-            state, _row_desc, state->fragment_instance_id(), _plan_node_id, _num_sender,
-            config::exchg_node_buffer_size_bytes, _runtime_profile, false, nullptr);
-    return Status::OK();
-}
-
-Status ExchangeSourceOperator::close(RuntimeState* state) {
-    Operator::close(state);
+    _stream_recvr = std::move(
+            static_cast<ExchangeSourceOperatorFactory*>(_factory)->create_stream_recvr(state, _runtime_profile));
     return Status::OK();
 }
 
@@ -32,14 +26,31 @@ bool ExchangeSourceOperator::is_finished() const {
 
 void ExchangeSourceOperator::set_finishing(RuntimeState* state) {
     _is_finishing = true;
-    return _stream_recvr->close();
+    static_cast<ExchangeSourceOperatorFactory*>(_factory)->close_stream_recvr();
 }
 
 StatusOr<vectorized::ChunkPtr> ExchangeSourceOperator::pull_chunk(RuntimeState* state) {
     std::unique_ptr<vectorized::Chunk> chunk = std::make_unique<vectorized::Chunk>();
-    RETURN_IF_ERROR(_stream_recvr->get_chunk(&chunk));
+    RETURN_IF_ERROR(_stream_recvr->get_chunk_pipeline(&chunk));
     eval_runtime_bloom_filters(chunk.get());
     return std::move(chunk);
 }
 
+std::shared_ptr<DataStreamRecvr> ExchangeSourceOperatorFactory::create_stream_recvr(
+        RuntimeState* state, const std::shared_ptr<RuntimeProfile>& profile) {
+    if (_stream_recvr != nullptr) {
+        return _stream_recvr;
+    }
+    _stream_recvr = state->exec_env()->stream_mgr()->create_recvr(
+            state, _row_desc, state->fragment_instance_id(), _plan_node_id, _num_sender,
+            config::exchg_node_buffer_size_bytes, profile, false, nullptr);
+    return _stream_recvr;
+}
+
+void ExchangeSourceOperatorFactory::close_stream_recvr() {
+    // The remain two references are hold by DataStreamMgr and ExchangeSourceOperatorFactory
+    if (++_stream_recvr_close_cnt == _stream_recvr.use_count() - 2) {
+        _stream_recvr->close();
+    }
+}
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/exchange/exchange_source_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_source_operator.h
@@ -12,17 +12,12 @@ class RowDescriptor;
 namespace pipeline {
 class ExchangeSourceOperator : public SourceOperator {
 public:
-    ExchangeSourceOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id, int32_t num_sender,
-                           const RowDescriptor& row_desc)
-            : SourceOperator(factory, id, "exchange_source", plan_node_id),
-              _num_sender(num_sender),
-              _row_desc(row_desc) {}
+    ExchangeSourceOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id)
+            : SourceOperator(factory, id, "exchange_source", plan_node_id) {}
 
     ~ExchangeSourceOperator() override = default;
 
     Status prepare(RuntimeState* state) override;
-
-    Status close(RuntimeState* state) override;
 
     bool has_output() const override;
 
@@ -33,10 +28,8 @@ public:
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 
 private:
-    int32_t _num_sender;
-    const RowDescriptor& _row_desc;
-    std::shared_ptr<DataStreamRecvr> _stream_recvr;
-    std::atomic<bool> _is_finishing{false};
+    std::shared_ptr<DataStreamRecvr> _stream_recvr = nullptr;
+    std::atomic<bool> _is_finishing = false;
 };
 
 class ExchangeSourceOperatorFactory final : public SourceOperatorFactory {
@@ -49,12 +42,18 @@ public:
     ~ExchangeSourceOperatorFactory() override = default;
 
     OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override {
-        return std::make_shared<ExchangeSourceOperator>(this, _id, _plan_node_id, _num_sender, _row_desc);
+        return std::make_shared<ExchangeSourceOperator>(this, _id, _plan_node_id);
     }
+
+    std::shared_ptr<DataStreamRecvr> create_stream_recvr(RuntimeState* state,
+                                                         const std::shared_ptr<RuntimeProfile>& profile);
+    void close_stream_recvr();
 
 private:
     int32_t _num_sender;
     const RowDescriptor& _row_desc;
+    std::shared_ptr<DataStreamRecvr> _stream_recvr = nullptr;
+    std::atomic<int64_t> _stream_recvr_close_cnt = 0;
 };
 
 } // namespace pipeline

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -255,7 +255,6 @@ void FragmentExecutor::_convert_data_sink_to_operator(PipelineBuilderContext* co
                                                                       result_sink->get_output_exprs(), _fragment_ctx);
         // Add result sink operator to last pipeline
         _fragment_ctx->pipelines().back()->add_op_factory(op);
-
     } else if (typeid(*datasink) == typeid(starrocks::DataStreamSender)) {
         starrocks::DataStreamSender* sender = down_cast<starrocks::DataStreamSender*>(datasink);
         auto dop = _fragment_ctx->pipelines().back()->source_operator_factory()->degree_of_parallelism();

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -69,7 +69,6 @@ Status PipelineDriver::prepare(RuntimeState* runtime_state) {
 }
 
 StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state) {
-    // VLOG_ROW << "[Driver] enter process: " << this->to_readable_string();
     SCOPED_TIMER(_active_timer);
     _state = DriverState::RUNNING;
     size_t total_chunks_moved = 0;
@@ -128,8 +127,6 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state) {
                     COUNTER_UPDATE(curr_op->_pull_chunk_num_counter, 1);
                     if (maybe_chunk.value() && maybe_chunk.value()->num_rows() > 0) {
                         size_t row_num = maybe_chunk.value()->num_rows();
-                        //VLOG_ROW << "[Driver] Transfer chunk: num_rows=" << row_num << ", "
-                        //         << this->to_readable_string();
                         {
                             SCOPED_TIMER(next_op->_push_timer);
                             status = next_op->push_chunk(runtime_state, maybe_chunk.value());
@@ -261,7 +258,6 @@ void PipelineDriver::finalize(RuntimeState* runtime_state, DriverState state) {
     if (_fragment_ctx->count_down_drivers()) {
         auto status = _fragment_ctx->final_status();
         auto fragment_id = _fragment_ctx->fragment_instance_id();
-        // VLOG_ROW << "[Driver] Last driver finished: final_status=" << status.to_string();
         _query_ctx->count_down_fragments();
     }
 }

--- a/be/src/exec/vectorized/aggregate/aggregate_streaming_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_streaming_node.cpp
@@ -97,10 +97,10 @@ Status AggregateStreamingNode::get_next(RuntimeState* state, ChunkPtr* chunk, bo
                 size_t real_capacity =
                         _aggregator->hash_map_variant().capacity() - _aggregator->hash_map_variant().capacity() / 8;
                 size_t remain_size = real_capacity - _aggregator->hash_map_variant().size();
-                bool ht_needs_expansion = remain_size < input_chunk_size;
+                [[maybe_unused]] bool ht_needs_expansion = remain_size < input_chunk_size;
 
 #ifdef DEBUG
-                // chaos test for streaming or agg, The results have to be consistent
+                // chaos test for streaming or agg, The results have to be consistent
                 // when group by type of double, it maybe cause dissonant result because of precision loss for double
                 // thus, so check case will fail, so it only work under DEBUG mode
                 loop++;

--- a/be/src/runtime/data_stream_recvr.cc
+++ b/be/src/runtime/data_stream_recvr.cc
@@ -69,8 +69,12 @@ public:
     // must acquire data from the returned batch before the next call to get_batch().
     Status get_chunk(vectorized::Chunk** chunk);
 
+    // Same as get_chunk, but this version will not wait if there is non buffer chunks
+    Status get_chunk_pipeline(vectorized::Chunk** chunk);
+
     // check if data has come, work with try_get_chunk.
     bool has_chunk();
+
     // Probe for chunks, because _chunk_queue maybe empty when data hasn't come yet.
     // So compute thread should do other works.
     bool try_get_chunk(vectorized::Chunk** chunk);
@@ -111,6 +115,8 @@ private:
         // the callback is closed- >run() Let the sender continue to send data
         google::protobuf::Closure* closure = nullptr;
     };
+
+    Status _do_get_chunk(vectorized::Chunk** chunk);
 
     // _add_chunks_internal is called by add_chunks and add_chunks_for_pipeline
     Status _add_chunks_internal(const PTransmitChunkParams& request, ::google::protobuf::Closure** done,
@@ -201,6 +207,15 @@ Status DataStreamRecvr::SenderQueue::get_chunk(vectorized::Chunk** chunk) {
         _data_arrival_cv.wait(l);
     }
 
+    return _do_get_chunk(chunk);
+}
+
+Status DataStreamRecvr::SenderQueue::get_chunk_pipeline(vectorized::Chunk** chunk) {
+    std::unique_lock<std::mutex> l(_lock);
+    return _do_get_chunk(chunk);
+}
+
+Status DataStreamRecvr::SenderQueue::_do_get_chunk(vectorized::Chunk** chunk) {
     if (_is_cancelled) {
         return Status::Cancelled("Cancelled SenderQueue::get_chunk");
     }
@@ -619,6 +634,15 @@ Status DataStreamRecvr::get_chunk(std::unique_ptr<vectorized::Chunk>* chunk) {
     DCHECK_EQ(_sender_queues.size(), 1);
     vectorized::Chunk* tmp_chunk = nullptr;
     Status status = _sender_queues[0]->get_chunk(&tmp_chunk);
+    chunk->reset(tmp_chunk);
+    return status;
+}
+
+Status DataStreamRecvr::get_chunk_pipeline(std::unique_ptr<vectorized::Chunk>* chunk) {
+    DCHECK(!_is_merging);
+    DCHECK_EQ(_sender_queues.size(), 1);
+    vectorized::Chunk* tmp_chunk = nullptr;
+    Status status = _sender_queues[0]->get_chunk_pipeline(&tmp_chunk);
     chunk->reset(tmp_chunk);
     return status;
 }

--- a/be/src/runtime/data_stream_recvr.h
+++ b/be/src/runtime/data_stream_recvr.h
@@ -74,6 +74,7 @@ public:
     ~DataStreamRecvr();
 
     Status get_chunk(std::unique_ptr<vectorized::Chunk>* chunk);
+    Status get_chunk_pipeline(std::unique_ptr<vectorized::Chunk>* chunk);
 
     // Deregister from DataStreamMgr instance, which shares ownership of this instance.
     void close();

--- a/be/src/service/backend_service.cpp
+++ b/be/src/service/backend_service.cpp
@@ -104,7 +104,6 @@ void BackendService::transmit_data(TTransmitDataResult& return_val, const TTrans
     VLOG_ROW << "transmit_data(): instance_id=" << params.dest_fragment_instance_id
              << " node_id=" << params.dest_node_id << " #rows=" << params.row_batch.num_rows
              << " eos=" << (params.eos ? "true" : "false");
-    // VLOG_ROW << "transmit_data params: " << apache::thrift::ThriftDebugString(params).c_str();
 
     if (params.__isset.packet_seq) {
         return_val.__set_packet_seq(params.packet_seq);


### PR DESCRIPTION
Paralize `ExchangeSourceOperator`
1. All the `ExchangeSourceOperator` share the `DataStreamRecvr`
2. When new data comming, all the `ExchangeSourceOperator` will receive the notification event, but only one `ExchangeSourceOperator` can actually get the data, so `DataStreamRecvr` should handle this situation properly

