### PR TITLE
[pipeline] register fragment context after preparing

### DIFF
--- a/be/src/exec/pipeline/fragment_context.cpp
+++ b/be/src/exec/pipeline/fragment_context.cpp
@@ -16,6 +16,16 @@ FragmentContext* FragmentContextManager::get_or_register(const TUniqueId& fragme
     }
 }
 
+void FragmentContextManager::register_ctx(const TUniqueId& fragment_id, FragmentContextPtr fragment_ctx) {
+    std::lock_guard<std::mutex> lock(_lock);
+
+    if (_fragment_contexts.find(fragment_id) != _fragment_contexts.end()) {
+        return;
+    }
+
+    _fragment_contexts.emplace(fragment_id, std::move(fragment_ctx));
+}
+
 FragmentContextPtr FragmentContextManager::get(const TUniqueId& fragment_id) {
     std::lock_guard<std::mutex> lock(_lock);
     auto it = _fragment_contexts.find(fragment_id);

--- a/be/src/exec/pipeline/fragment_context.h
+++ b/be/src/exec/pipeline/fragment_context.h
@@ -161,7 +161,10 @@ public:
 
     FragmentContext* get_or_register(const TUniqueId& fragment_id);
     FragmentContextPtr get(const TUniqueId& fragment_id);
+
+    void register_ctx(const TUniqueId& fragment_id, FragmentContextPtr fragment_ctx);
     void unregister(const TUniqueId& fragment_id);
+
     void cancel(const Status& status);
 
 private:

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -94,7 +94,9 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
     // initialize query's deadline
     _query_ctx->extend_lifetime();
 
-    _fragment_ctx = _query_ctx->fragment_mgr()->get_or_register(fragment_instance_id);
+    auto fragment_ctx = std::make_unique<FragmentContext>();
+    _fragment_ctx = fragment_ctx.get();
+
     _fragment_ctx->set_query_id(query_id);
     _fragment_ctx->set_fragment_instance_id(fragment_instance_id);
     _fragment_ctx->set_fe_addr(coord);
@@ -233,6 +235,9 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
         runtime_state->runtime_profile()->reverse_childs();
     }
     _fragment_ctx->set_drivers(std::move(drivers));
+
+    _query_ctx->fragment_mgr()->register_ctx(fragment_instance_id, std::move(fragment_ctx));
+
     return Status::OK();
 }
 


### PR DESCRIPTION
### Introduction
`FragmentContext` is registered to `QueryContext` by `QueryContext::get_or_register()`, and then init this `FragmentContext`.
However, Global Runtime Filter may be created quickly by other Fragment. The RF receiver maybe sees the destination fragment exists (already registered to `QueryContext`), but the member variables of fragment is still preparing.

### Changes
- Add `QueryContext::register_ctx()`.
- Call `QueryContext::register_ctx()` at the end of `FragmentExecutor::prepare()`