### PR TITLE
Fix limit operator use wrong output columns

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalLimitOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalLimitOperator.java
@@ -8,6 +8,7 @@ import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.OperatorVisitor;
 
+import java.util.ArrayList;
 import java.util.Objects;
 
 public class LogicalLimitOperator extends LogicalOperator {
@@ -26,7 +27,7 @@ public class LogicalLimitOperator extends LogicalOperator {
     }
 
     public LogicalLimitOperator(Builder builder) {
-        super(OperatorType.LOGICAL_LIMIT);
+        super(OperatorType.LOGICAL_LIMIT, builder.getLimit(), builder.getPredicate(), builder.getProjection());
         this.limit = builder.getLimit();
         this.offset = builder.offset;
     }
@@ -41,7 +42,11 @@ public class LogicalLimitOperator extends LogicalOperator {
 
     @Override
     public ColumnRefSet getOutputColumns(ExpressionContext expressionContext) {
-        return expressionContext.getChildLogicalProperty(0).getOutputColumns();
+        if (projection != null) {
+            return new ColumnRefSet(new ArrayList<>(projection.getColumnRefMap().keySet()));
+        } else {
+            return expressionContext.getChildLogicalProperty(0).getOutputColumns();
+        }
     }
 
     public <R, C> R accept(OptExpressionVisitor<R, C> visitor, OptExpression optExpression, C context) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalLimitOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalLimitOperator.java
@@ -7,15 +7,18 @@ import com.starrocks.sql.optimizer.OptExpressionVisitor;
 import com.starrocks.sql.optimizer.base.GatherDistributionSpec;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.OperatorVisitor;
+import com.starrocks.sql.optimizer.operator.Projection;
 
 import java.util.Objects;
 
 public class PhysicalLimitOperator extends PhysicalOperator {
     private final long offset;
 
-    public PhysicalLimitOperator(long offset, long limit) {
+    public PhysicalLimitOperator(long offset, long limit, Projection projection) {
         super(OperatorType.PHYSICAL_LIMIT, GatherDistributionSpec.createGatherDistributionSpec(limit));
         this.offset = offset;
+        this.limit = limit;
+        this.projection = projection;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/LimitImplementationRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/LimitImplementationRule.java
@@ -22,6 +22,7 @@ public class LimitImplementationRule extends ImplementationRule {
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
         LogicalLimitOperator limit = (LogicalLimitOperator) input.getOp();
         return Lists.newArrayList(OptExpression
-                .create(new PhysicalLimitOperator(limit.getOffset(), limit.getLimit()), input.getInputs()));
+                .create(new PhysicalLimitOperator(limit.getOffset(), limit.getLimit(), limit.getProjection()),
+                        input.getInputs()));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -4243,14 +4243,18 @@ public class PlanFragmentTest extends PlanTestBase {
 
     @Test
     public void testLimitLeftJoin() throws Exception {
-        String sql = "select v1 from (select * from t0 limit 1) x0 left outer join t1 on x0.v1 = t1.v4";
+        String sql = "select v1 from (select * from t0 limit 1) x0 left outer join[shuffle] t1 on x0.v1 = t1.v4";
         String plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("  |  join op: RIGHT OUTER JOIN (PARTITIONED)\n" +
+        Assert.assertTrue(plan.contains(" 5:HASH JOIN\n" +
+                "  |  join op: LEFT OUTER JOIN (PARTITIONED)\n" +
                 "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
-                "  |  equal join conjunct: 4: v4 = 1: v1"));
-        Assert.assertTrue(plan.contains("  |----4:EXCHANGE\n" +
-                "  |       limit: 1"));
+                "  |  equal join conjunct: 1: v1 = 4: v4\n" +
+                "  |  \n" +
+                "  |----4:EXCHANGE\n" +
+                "  |    \n" +
+                "  2:EXCHANGE\n" +
+                "     limit: 1"));
 
         sql = "select v1 from (select * from t0 limit 10) x0 left outer join t1 on x0.v1 = t1.v4 limit 1";
         plan = getFragmentPlan(sql);
@@ -4276,55 +4280,55 @@ public class PlanFragmentTest extends PlanTestBase {
                 "     numNodes=0\n" +
                 "     limit: 1"));
 
-        sql = "select v1 from (select * from t0 limit 10) x0 left outer join t1 on x0.v1 = t1.v4 limit 100";
+        sql = "select v1 from (select * from t0 limit 10) x0 left outer join[shuffle] t1 on x0.v1 = t1.v4 limit 100";
         plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("  5:HASH JOIN\n" +
-                "  |  join op: RIGHT OUTER JOIN (PARTITIONED)\n" +
+        Assert.assertTrue(plan.contains("5:HASH JOIN\n" +
+                "  |  join op: LEFT OUTER JOIN (PARTITIONED)\n" +
                 "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
-                "  |  equal join conjunct: 4: v4 = 1: v1\n" +
+                "  |  equal join conjunct: 1: v1 = 4: v4\n" +
                 "  |  limit: 100\n" +
                 "  |  \n" +
                 "  |----4:EXCHANGE\n" +
-                "  |       limit: 10\n" +
                 "  |    \n" +
-                "  1:EXCHANGE"));
-        Assert.assertTrue(plan.contains("PLAN FRAGMENT 1\n" +
+                "  2:EXCHANGE\n" +
+                "     limit: 10"));
+        Assert.assertTrue(plan.contains("PLAN FRAGMENT 2\n" +
                 " OUTPUT EXPRS:\n" +
                 "  PARTITION: UNPARTITIONED\n" +
                 "\n" +
                 "  STREAM DATA SINK\n" +
-                "    EXCHANGE ID: 04\n" +
+                "    EXCHANGE ID: 02\n" +
                 "    HASH_PARTITIONED: 1: v1\n" +
                 "\n" +
-                "  3:EXCHANGE\n" +
-                "     limit: 10\n"));
+                "  1:EXCHANGE\n" +
+                "     limit: 10"));
 
         sql =
                 "select v1 from (select * from t0 limit 10) x0 left outer join (select * from t1 limit 5) x1 on x0.v1 = x1.v4 limit 7";
         plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("join op: LEFT OUTER JOIN (BROADCAST)\n" +
+        Assert.assertTrue(plan.contains("5:HASH JOIN\n" +
+                "  |  join op: RIGHT OUTER JOIN (PARTITIONED)\n" +
                 "  |  hash predicates:\n" +
                 "  |  colocate: false, reason: \n" +
-                "  |  equal join conjunct: 1: v1 = 4: v4\n" +
+                "  |  equal join conjunct: 4: v4 = 1: v1\n" +
                 "  |  limit: 7\n" +
                 "  |  \n" +
-                "  |----3:EXCHANGE\n" +
-                "  |       limit: 5\n" +
+                "  |----4:EXCHANGE\n" +
+                "  |       limit: 7\n" +
                 "  |    \n" +
-                "  0:OlapScanNode"));
-        Assert.assertTrue(plan.contains("PLAN FRAGMENT 1\n" +
+                "  2:EXCHANGE\n" +
+                "     limit: 5"));
+        Assert.assertTrue(plan.contains("PLAN FRAGMENT 2\n" +
                 " OUTPUT EXPRS:\n" +
                 "  PARTITION: UNPARTITIONED\n" +
                 "\n" +
                 "  STREAM DATA SINK\n" +
-                "    EXCHANGE ID: 03\n" +
-                "    UNPARTITIONED\n" +
+                "    EXCHANGE ID: 02\n" +
+                "    HASH_PARTITIONED: 4: v4\n" +
                 "\n" +
-                "  2:EXCHANGE\n" +
-                "     limit: 5\n" +
-                "\n" +
-                "PLAN FRAGMENT 2"));
+                "  1:EXCHANGE\n" +
+                "     limit: 5"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -4727,5 +4727,11 @@ public class PlanFragmentTest extends PlanTestBase {
                 " on a.v1 = b.v7 where b.v8 > t1.v5 limit 10";
         String plan = getFragmentPlan(sql);
         System.out.println(plan);
+        // check join on predicate which has expression with limit operator
+        sql = "select t2.v8 from (select v1, v2, v1 as v3 from t0 where v2<> v3 limit 15) as a join t1 " +
+                "on a.v3 + 1 = t1.v4 join t2 on v4 = v7 join t2 as b" +
+                " on a.v3 + 2 = b.v7 where b.v8 > t1.v5 limit 10";
+        plan = getFragmentPlan(sql);
+        System.out.println(plan);
     }
 }

--- a/fe/fe-core/src/test/resources/sql/subquery/exists-subquery.sql
+++ b/fe/fe-core/src/test/resources/sql/subquery/exists-subquery.sql
@@ -126,29 +126,29 @@ RIGHT SEMI JOIN (join-predicate [6: v5 = 2: v2 AND 2: v2 < 7: v6] post-join-pred
 select v3, min(v1) from t0 group by v3 having exists (select v4 from t1 where v5 = v6);
 [result]
 CROSS JOIN (join-predicate [null] post-join-predicate [null])
-    AGGREGATE ([GLOBAL] aggregate [{4: min=min(4: min)}] group by [[3: v3]] having [null]
-        EXCHANGE SHUFFLE[3]
-            AGGREGATE ([LOCAL] aggregate [{4: min=min(1: v1)}] group by [[3: v3]] having [null]
-                SCAN (columns[1: v1, 3: v3] predicate[null])
+    EXCHANGE GATHER
+        SCAN (columns[6: v5, 7: v6] predicate[6: v5 = 7: v6]) Limit 1
     EXCHANGE BROADCAST
-        EXCHANGE GATHER
-            SCAN (columns[6: v5, 7: v6] predicate[6: v5 = 7: v6]) Limit 1
+        AGGREGATE ([GLOBAL] aggregate [{4: min=min(4: min)}] group by [[3: v3]] having [null]
+            EXCHANGE SHUFFLE[3]
+                AGGREGATE ([LOCAL] aggregate [{4: min=min(1: v1)}] group by [[3: v3]] having [null]
+                    SCAN (columns[1: v1, 3: v3] predicate[null])
 [end]
 
 [sql]
 select v3, min(v1) from t0 group by v3 having exists (select max(v4) from t1 where v5 = 5 group by v6);
 [result]
 CROSS JOIN (join-predicate [null] post-join-predicate [null])
-    AGGREGATE ([GLOBAL] aggregate [{4: min=min(4: min)}] group by [[3: v3]] having [null]
-        EXCHANGE SHUFFLE[3]
-            AGGREGATE ([LOCAL] aggregate [{4: min=min(1: v1)}] group by [[3: v3]] having [null]
-                SCAN (columns[1: v1, 3: v3] predicate[null])
+    EXCHANGE GATHER
+        AGGREGATE ([GLOBAL] aggregate [{}] group by [[7: v6]] having [null]
+            EXCHANGE SHUFFLE[7]
+                AGGREGATE ([LOCAL] aggregate [{}] group by [[7: v6]] having [null]
+                    SCAN (columns[6: v5, 7: v6] predicate[6: v5 = 5])
     EXCHANGE BROADCAST
-        EXCHANGE GATHER
-            AGGREGATE ([GLOBAL] aggregate [{}] group by [[7: v6]] having [null]
-                EXCHANGE SHUFFLE[7]
-                    AGGREGATE ([LOCAL] aggregate [{}] group by [[7: v6]] having [null]
-                        SCAN (columns[6: v5, 7: v6] predicate[6: v5 = 5])
+        AGGREGATE ([GLOBAL] aggregate [{4: min=min(4: min)}] group by [[3: v3]] having [null]
+            EXCHANGE SHUFFLE[3]
+                AGGREGATE ([LOCAL] aggregate [{4: min=min(1: v1)}] group by [[3: v3]] having [null]
+                    SCAN (columns[1: v1, 3: v3] predicate[null])
 [end]
 
 [sql]


### PR DESCRIPTION
#1753 
In this issue, after implement the limit builder, we will meet NPE at getColumnStatistics because of limit operator not use right output columns. 
so,  we need set right projection at logical and physical phase, then set getOutputColumns correctly.