### PR TITLE
Support partial update for stream/broker load

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/Load.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/Load.java
@@ -66,10 +66,12 @@ import com.starrocks.thrift.TOpType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class Load {
     private static final Logger LOG = LogManager.getLogger(Load.class);
@@ -485,6 +487,19 @@ public class Load {
         // 3. reanalyze all exprs using new type in vectorized load or using varchar in old load
         analyzeMappingExprs(tbl, analyzer, exprsByName, mvDefineExpr, slotDescByName, useVectorizedLoad);
         LOG.debug("after init column, exprMap: {}", exprsByName);
+    }
+
+    public static List<Column> getPartialUpateColumns(Table tbl, List<ImportColumnDesc> columnExprs) throws UserException {
+        Set<String> specified = columnExprs.stream().map(desc -> desc.getColumnName()).collect(Collectors.toSet());
+        List<Column> ret = new ArrayList<>();
+        for (Column col : tbl.getBaseSchema()) {
+            if (specified.contains(col.getName())) {
+                ret.add(col);
+            } else if (col.isKey()) {
+                throw new DdlException("key column " + col.getName() + " not in partial update columns");
+            }
+        }
+        return ret;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadingTaskPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadingTaskPlanner.java
@@ -114,27 +114,21 @@ public class LoadingTaskPlanner {
         List<Pair<Integer, ColumnDict>> globalDicts = Lists.newArrayList();
         List<Column> destColumns = Lists.newArrayList();
         boolean isPrimaryKey = table.getKeysType() == KeysType.PRIMARY_KEYS;
-        if (isPrimaryKey) {
-            if (partialUpdate) {
-                if (fileGroups.size() > 1) {
-                    throw new DdlException("partial update only support single filegroup.");
-                } else if (fileGroups.size() == 1) {
-                    if (fileGroups.get(0).isNegative()) {
-                        throw new DdlException("Primary key table does not support negative load");
-                    }
-                    destColumns = Load.getPartialUpateColumns(table, fileGroups.get(0).getColumnExprList());
-                } else {
-                    throw new DdlException("filegroup number=" + fileGroups.size() + " is illegal");
+        if (isPrimaryKey && partialUpdate) {
+            if (fileGroups.size() > 1) {
+                throw new DdlException("partial update only support single filegroup.");
+            } else if (fileGroups.size() == 1) {
+                if (fileGroups.get(0).isNegative()) {
+                    throw new DdlException("Primary key table does not support negative load");
                 }
+                destColumns = Load.getPartialUpateColumns(table, fileGroups.get(0).getColumnExprList());
             } else {
-                destColumns = table.getFullSchema();
+                throw new DdlException("filegroup number=" + fileGroups.size() + " is illegal");
             }
+        } else if (!isPrimaryKey && partialUpdate) {
+            throw new DdlException("Only primary key table support partial update");
         } else {
-            if (partialUpdate) {
-                throw new DdlException("Only primary key table support partial update");
-            } else {
-                destColumns = table.getFullSchema();
-            }
+            destColumns = table.getFullSchema();
         }
         for (Column col : destColumns) {
             SlotDescriptor slotDesc = descTable.addSlotDescriptor(tupleDesc);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadPlanner.java
@@ -102,13 +102,28 @@ public class StreamLoadPlanner {
 
     // create the plan. the plan's query id and load id are same, using the parameter 'loadId'
     public TExecPlanFragmentParams plan(TUniqueId loadId) throws UserException {
+        boolean isPrimaryKey = destTable.getKeysType() == KeysType.PRIMARY_KEYS;
         resetAnalyzer();
         // construct tuple descriptor, used for scanNode and dataSink
         TupleDescriptor tupleDesc = descTable.createTupleDescriptor("DstTableTuple");
         boolean negative = streamLoadTask.getNegative();
+        if (isPrimaryKey) {
+            if (negative) {
+                throw new DdlException("Primary key table does not support negative load");
+            }
+        } else {
+            if (streamLoadTask.isPartialUpdate()) {
+                throw new DdlException("Only primary key table support partial update");
+            }
+        }
         List<Pair<Integer, ColumnDict>> globalDicts = Lists.newArrayList();
-        // here we should be full schema to fill the descriptor table
-        for (Column col : destTable.getFullSchema()) {
+        List<Column> destColumns;
+        if (streamLoadTask.isPartialUpdate()) {
+            destColumns = Load.getPartialUpateColumns(destTable, streamLoadTask.getColumnExprDescs());
+        } else {
+            destColumns = destTable.getFullSchema();
+        }
+        for (Column col : destColumns) {
             SlotDescriptor slotDesc = descTable.addSlotDescriptor(tupleDesc);
             slotDesc.setIsMaterialized(true);
             slotDesc.setColumn(col);
@@ -123,7 +138,7 @@ public class StreamLoadPlanner {
                 globalDicts.add(new Pair<>(slotDesc.getId().asInt(), dict));
             }
         }
-        if (destTable.getKeysType() == KeysType.PRIMARY_KEYS) {
+        if (isPrimaryKey) {
             // add op type column
             SlotDescriptor slotDesc = descTable.addSlotDescriptor(tupleDesc);
             slotDesc.setIsMaterialized(true);

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/LoadingTaskPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/LoadingTaskPlannerTest.java
@@ -335,6 +335,102 @@ public class LoadingTaskPlannerTest {
     }
 
     @Test
+    public void testPartialUpdatePlan(@Mocked Catalog catalog, @Mocked SystemInfoService systemInfoService,
+                                   @Injectable Database db, @Injectable OlapTable table) throws Exception {
+        // table schema
+        List<Column> columns = Lists.newArrayList();
+        columns.add(new Column("k1", Type.TINYINT, true, null, true, null, ""));
+        columns.add(new Column("k2", Type.INT, true, null, false, null, ""));
+        columns.add(new Column("k3", ScalarType.createVarchar(50), true, null, true, null, ""));
+        columns.add(new Column("v", Type.BIGINT, false, AggregateType.SUM, false, null, ""));
+
+        Function f1 = new Function(new FunctionName("substr"), new Type[] {Type.VARCHAR, Type.INT, Type.INT},
+                Type.VARCHAR, true);
+        Function f2 = new Function(new FunctionName("casttoint"), new Type[] {Type.VARCHAR},
+                Type.INT, true);
+        new Expectations() {
+            {
+                Catalog.getCurrentSystemInfo();
+                result = systemInfoService;
+                systemInfoService.getIdToBackend();
+                result = idToBackend;
+                table.getKeysType();
+                minTimes = 0;
+                result = KeysType.PRIMARY_KEYS;
+                table.getBaseSchema();
+                result = columns;
+                table.getFullSchema();
+                result = columns;
+                table.getPartitions();
+                minTimes = 0;
+                result = Arrays.asList(partition);
+                partition.getId();
+                minTimes = 0;
+                result = 0;
+                table.getColumn("k1");
+                result = columns.get(0);
+                table.getColumn("k2");
+                result = columns.get(1);
+                table.getColumn("k3");
+                result = columns.get(2);
+                table.getColumn("v");
+                result = columns.get(3);
+                table.getColumn("k33");
+                result = null;
+                catalog.getFunction((Function) any, (Function.CompareMode) any);
+                returns(f1, f1, f2);
+                table.getColumn(Load.LOAD_OP_COLUMN);
+                minTimes = 0;
+                result = null;
+            }
+        };
+
+        // column mappings
+        String sql = "LOAD LABEL label0 (DATA INFILE('path/k2=1/file1') INTO TABLE t2 FORMAT AS 'orc' (k1,k33,v) " +
+                "COLUMNS FROM PATH AS (k2) set (k3 = substr(k33,1,5))) WITH BROKER 'broker0'";
+        SqlParser parser = new SqlParser(new SqlScanner(new StringReader(sql)));
+        LoadStmt loadStmt = (LoadStmt) SqlParserUtils.getFirstStmt(parser);
+        List<Expr> columnMappingList = Deencapsulation.getField(loadStmt.getDataDescriptions().get(0),
+                "columnMappingList");
+
+        // file groups
+        List<BrokerFileGroup> fileGroups = Lists.newArrayList();
+        List<String> files = Lists.newArrayList("path/k2=1/file1");
+        List<String> columnNames = Lists.newArrayList("k1", "k33", "v");
+        DataDescription desc = new DataDescription("t2", null, files, columnNames,
+                null, null, "ORC", Lists.newArrayList("k2"),
+                false, columnMappingList, null);
+        Deencapsulation.invoke(desc, "analyzeColumns");
+        BrokerFileGroup brokerFileGroup = new BrokerFileGroup(desc);
+        Deencapsulation.setField(brokerFileGroup, "columnSeparator", "\t");
+        Deencapsulation.setField(brokerFileGroup, "rowDelimiter", "\n");
+        Deencapsulation.setField(brokerFileGroup, "fileFormat", "ORC");
+        brokerFileGroup.parse(db, desc);
+        fileGroups.add(brokerFileGroup);
+
+        // file status
+        List<List<TBrokerFileStatus>> fileStatusesList = Lists.newArrayList();
+        List<TBrokerFileStatus> fileStatusList = Lists.newArrayList();
+        fileStatusList.add(new TBrokerFileStatus("path/k2=1/file1", false, 268435456, true));
+        fileStatusesList.add(fileStatusList);
+
+        // plan
+        LoadingTaskPlanner planner = new LoadingTaskPlanner(jobId, txnId, db.getId(), table, brokerDesc, fileGroups,
+                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, false);
+        planner.plan(loadId, fileStatusesList, 1);
+
+        // 1. check fragment
+        List<PlanFragment> fragments = planner.getFragments();
+        Assert.assertEquals(1, fragments.size());
+        PlanFragment fragment = fragments.get(0);
+        TPlanFragment tPlanFragment = fragment.toThrift();
+        List<TPlanNode> nodes = tPlanFragment.plan.nodes;
+        Assert.assertEquals(1, nodes.size());
+        TPlanNode tPlanNode = nodes.get(0);
+        Assert.assertEquals(TPlanNodeType.FILE_SCAN_NODE, tPlanNode.node_type);
+    }
+
+    @Test
     public void testLoadWithOpColumnDefault(@Mocked Catalog catalog, @Mocked SystemInfoService systemInfoService,
                                             @Injectable Database db, @Injectable OlapTable table) throws Exception {
         // table schema

--- a/fe/fe-core/src/test/java/com/starrocks/planner/StreamLoadPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/StreamLoadPlannerTest.java
@@ -30,6 +30,7 @@ import com.starrocks.analysis.SqlParser;
 import com.starrocks.analysis.SqlScanner;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Type;
@@ -99,6 +100,49 @@ public class StreamLoadPlannerTest {
         request.setLoadId(new TUniqueId(2, 3));
         request.setFileType(TFileType.FILE_STREAM);
         request.setFormatType(TFileFormatType.FORMAT_CSV_PLAIN);
+        StreamLoadTask streamLoadTask = StreamLoadTask.fromTStreamLoadPutRequest(request, db);
+        StreamLoadPlanner planner = new StreamLoadPlanner(db, destTable, streamLoadTask);
+        planner.plan(streamLoadTask.getId());
+    }
+
+    @Test
+    public void testPartialUpdatePlan() throws UserException {
+        List<Column> columns = Lists.newArrayList();
+        Column c1 = new Column("c1", Type.BIGINT, false);
+        columns.add(c1);
+        Column c2 = new Column("c2", Type.BIGINT, true);
+        columns.add(c2);
+        new Expectations() {
+            {
+                destTable.getKeysType();
+                minTimes = 0;
+                result = KeysType.PRIMARY_KEYS;
+                destTable.getBaseSchema();
+                minTimes = 0;
+                result = columns;
+                destTable.getPartitions();
+                minTimes = 0;
+                result = Arrays.asList(partition);
+                scanNode.init((Analyzer) any);
+                minTimes = 0;
+                scanNode.getChildren();
+                minTimes = 0;
+                result = Lists.newArrayList();
+                scanNode.getId();
+                minTimes = 0;
+                result = new PlanNodeId(5);
+                partition.getId();
+                minTimes = 0;
+                result = 0;
+            }
+        };
+        TStreamLoadPutRequest request = new TStreamLoadPutRequest();
+        request.setTxnId(1);
+        request.setLoadId(new TUniqueId(2, 3));
+        request.setFileType(TFileType.FILE_STREAM);
+        request.setFormatType(TFileFormatType.FORMAT_CSV_PLAIN);
+        request.setPartial_update(true);
+        request.setColumns("c1");
         StreamLoadTask streamLoadTask = StreamLoadTask.fromTStreamLoadPutRequest(request, db);
         StreamLoadPlanner planner = new StreamLoadPlanner(db, destTable, streamLoadTask);
         planner.plan(streamLoadTask.getId());


### PR DESCRIPTION
Passing primary-key flag into StreamLoadPlanner and LoadingTaskPlanner to check the task is a partial update or not. For broker load, maybe there are multiple filegroups and only support one filegroup for the partial update.