### PR TITLE
[pipeline] skip merge bloom filter if key column is nullptr

### DIFF
--- a/be/src/exec/pipeline/runtime_filter_types.h
+++ b/be/src/exec/pipeline/runtime_filter_types.h
@@ -272,7 +272,7 @@ public:
             desc->set_is_pipeline(true);
             // skip if it does not have consumer.
             if (!desc->has_consumer()) continue;
-            // skip if ht.size() > limit and it's only for local.
+            // skip if ht.size() > limit, and it's only for local.
             if (!desc->has_remote_targets() && row_count > _limit) continue;
             PrimitiveType build_type = desc->build_expr_type();
             vectorized::JoinRuntimeFilter* filter =
@@ -289,7 +289,7 @@ public:
             while (param_it != params.end()) {
                 auto& desc = *(desc_it++);
                 auto& param = *(param_it++);
-                if (desc->runtime_filter() == nullptr) {
+                if (desc->runtime_filter() == nullptr || param.column == nullptr) {
                     continue;
                 }
                 auto status = vectorized::RuntimeFilterHelper::fill_runtime_bloom_filter(


### PR DESCRIPTION
`RuntimeBloomFilterBuildParams` is used to build runtime bloom-filters, including key columns from Hash Table.
`RuntimeBloomFilterBuildParams` for local RF will be empty with `nullptr` key column if it doesn't have consumer or exceeds limit of rows.

Therefore, skip merge bloom filter if key column is `nullptr`.

```C++
    Status HashJoiner::_create_runtime_bloom_filters(RuntimeState* state, int64_t limit) {
        for (auto* rf_desc : _build_runtime_filters) {
            rf_desc->set_is_pipeline(true);
            // skip if it does not have consumer.
            if (!rf_desc->has_consumer()) {
                _runtime_bloom_filter_build_params.emplace_back(false, nullptr, -1);
                continue;
            }
            if (!rf_desc->has_remote_targets() && _ht.get_row_count() > limit) {
                _runtime_bloom_filter_build_params.emplace_back(false, nullptr, -1);
                continue;
            }

            int expr_order = rf_desc->build_expr_order();
            ColumnPtr column = _ht.get_key_columns()[expr_order];
            bool eq_null = _is_null_safes[expr_order];
            _runtime_bloom_filter_build_params.emplace_back(eq_null, column, _ht.get_row_count());
        }
        return Status::OK();
    }
```