### PR TITLE
Move including UUIDGenerator from header to source

### DIFF
--- a/be/src/exprs/vectorized/string_functions.cpp
+++ b/be/src/exprs/vectorized/string_functions.cpp
@@ -1118,7 +1118,7 @@ template <bool src_is_utf8, bool fill_is_utf8, PadType pad_type>
 static inline ColumnPtr pad_utf8_const(Columns const& columns, BinaryColumn* src, const uint8_t* fill,
                                        const size_t fill_size, const size_t len,
                                        std::vector<size_t> const& fill_utf8_index) {
-    BOOST_STATIC_ASSERT(src_is_utf8 || fill_is_utf8);
+    static_assert(src_is_utf8 || fill_is_utf8);
 
     const auto num_rows = src->size();
     NullableBinaryColumnBuilder builder;

--- a/be/src/storage/data_dir.cpp
+++ b/be/src/storage/data_dir.cpp
@@ -23,6 +23,7 @@
 
 #include <mntent.h>
 #include <sys/file.h>
+#include <sys/stat.h>
 #include <sys/statfs.h>
 #include <utime.h>
 

--- a/be/src/storage/task/engine_clone_task.cpp
+++ b/be/src/storage/task/engine_clone_task.cpp
@@ -21,6 +21,8 @@
 
 #include "storage/task/engine_clone_task.h"
 
+#include <sys/stat.h>
+
 #include <filesystem>
 #include <set>
 

--- a/be/src/util/uid_util.cpp
+++ b/be/src/util/uid_util.cpp
@@ -24,6 +24,7 @@
 #include <algorithm>
 
 #include "gutil/endian.h"
+#include "util/uuid_generator.h"
 
 namespace starrocks {
 
@@ -48,6 +49,28 @@ std::string print_id(const PUniqueId& id) {
     memcpy(uuid.data + 0, &hi, 8);
     memcpy(uuid.data + 8, &lo, 8);
     return boost::uuids::to_string(uuid);
+}
+
+UniqueId UniqueId::gen_uid() {
+    UniqueId uid(0, 0);
+    auto uuid = UUIDGenerator::instance()->next_uuid();
+    memcpy(&uid.hi, uuid.data, sizeof(int64_t));
+    memcpy(&uid.lo, uuid.data + sizeof(int64_t), sizeof(int64_t));
+    return uid;
+}
+
+/// generates a 16 byte
+std::string generate_uuid_string() {
+    return boost::uuids::to_string(boost::uuids::basic_random_generator<boost::mt19937>()());
+}
+
+/// generates a 16 byte UUID
+TUniqueId generate_uuid() {
+    auto uuid = boost::uuids::basic_random_generator<boost::mt19937>()();
+    TUniqueId uid;
+    memcpy(&uid.hi, uuid.data, sizeof(int64_t));
+    memcpy(&uid.lo, uuid.data + sizeof(int64_t), sizeof(int64_t));
+    return uid;
 }
 
 } // namespace starrocks

--- a/be/src/util/uid_util.h
+++ b/be/src/util/uid_util.h
@@ -29,7 +29,6 @@
 #include "gen_cpp/types.pb.h"    // for PUniqueId
 // #include "util/debug_util.h"
 #include "util/hash_util.hpp"
-#include "util/uuid_generator.h"
 
 namespace starrocks {
 
@@ -72,13 +71,7 @@ struct UniqueId {
     }
 
     // currently, the implementation is uuid, but it may change in the future
-    static UniqueId gen_uid() {
-        UniqueId uid(0, 0);
-        auto uuid = UUIDGenerator::instance()->next_uuid();
-        memcpy(&uid.hi, uuid.data, sizeof(int64_t));
-        memcpy(&uid.lo, uuid.data + sizeof(int64_t), sizeof(int64_t));
-        return uid;
-    }
+    static UniqueId gen_uid();
 
     ~UniqueId() noexcept = default;
 
@@ -131,18 +124,10 @@ inline std::size_t hash_value(const starrocks::TUniqueId& id) {
 }
 
 /// generates a 16 byte UUID
-inline std::string generate_uuid_string() {
-    return boost::uuids::to_string(boost::uuids::basic_random_generator<boost::mt19937>()());
-}
+std::string generate_uuid_string();
 
 /// generates a 16 byte UUID
-inline TUniqueId generate_uuid() {
-    auto uuid = boost::uuids::basic_random_generator<boost::mt19937>()();
-    TUniqueId uid;
-    memcpy(&uid.hi, uuid.data, sizeof(int64_t));
-    memcpy(&uid.lo, uuid.data + sizeof(int64_t), sizeof(int64_t));
-    return uid;
-}
+TUniqueId generate_uuid();
 
 std::ostream& operator<<(std::ostream& os, const UniqueId& uid);
 


### PR DESCRIPTION
'uuid_generator.h' will include about 500 header files, and it is
included in 'uid_util.h' files. It caused every souce file have these
500 include headers.

In this CL, I move the uuid_generator.h including form uid_util.h to
uid_util.cpp, which can reduce about 500 includings in each source
files.