### PR TITLE
Update drop backend behavior (#1578)

### DIFF
--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -964,7 +964,7 @@ alter_table_clause ::=
     {:
         RESULT = new AddPartitionClause(desc, distribution, properties, isTempPartition);
     :}
-    | KW_DROP opt_tmp:isTempPartition KW_PARTITION opt_force:force opt_if_exists:ifExists ident:partitionName
+    | KW_DROP opt_tmp:isTempPartition KW_PARTITION opt_if_exists:ifExists ident:partitionName opt_force:force
     {:
         RESULT = new DropPartitionClause(ifExists, partitionName, isTempPartition, force ? force : isTempPartition);
     :}
@@ -1029,13 +1029,13 @@ alter_system_clause ::=
     {:
         RESULT = new AddBackendClause(hostPorts, clusterName);
     :}
-    | KW_DROP KW_BACKEND string_list:hostPorts
+    | KW_DROP KW_BACKEND string_list:hostPorts opt_force:force
     {:
-        RESULT = new DropBackendClause(hostPorts, false);
+        RESULT = new DropBackendClause(hostPorts, force);
     :}
     | KW_DROPP KW_BACKEND string_list:hostPorts
     {:
-        RESULT = new DropBackendClause(hostPorts, true);
+        RESULT = new DropBackendClause(hostPorts, true, true);
     :}
     | KW_DECOMMISSION KW_BACKEND string_list:hostPorts
     {:
@@ -1706,11 +1706,11 @@ revoke_stmt ::=
 // Drop statement
 drop_stmt ::=
     /* Database */
-    KW_DROP KW_DATABASE opt_force:force opt_if_exists:ifExists ident:db
+    KW_DROP KW_DATABASE opt_if_exists:ifExists ident:db opt_force:force
     {:
         RESULT = new DropDbStmt(ifExists, db, force);
     :}
-    | KW_DROP KW_SCHEMA opt_force:force opt_if_exists:ifExists ident:db
+    | KW_DROP KW_SCHEMA opt_if_exists:ifExists ident:db opt_force:force
     {:
         RESULT = new DropDbStmt(ifExists, db, !force);
     :}
@@ -1725,7 +1725,7 @@ drop_stmt ::=
         RESULT = new DropFunctionStmt(functionName, args);
     :}
     /* Table */
-    | KW_DROP KW_TABLE opt_force:force opt_if_exists:ifExists table_name:name
+    | KW_DROP KW_TABLE opt_if_exists:ifExists table_name:name opt_force:force
     {:
         RESULT = new DropTableStmt(ifExists, name, force);
     :}

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SystemHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SystemHandler.java
@@ -151,13 +151,7 @@ public class SystemHandler extends AlterHandler {
         } else if (alterClause instanceof DropBackendClause) {
             // drop backend
             DropBackendClause dropBackendClause = (DropBackendClause) alterClause;
-            if (!dropBackendClause.isForce()) {
-                throw new DdlException("It is highly NOT RECOMMENDED to use DROP BACKEND stmt."
-                        + "It is not safe to directly drop a backend. "
-                        + "All data on this backend will be discarded permanently. "
-                        + "If you insist, use DROPP BACKEND stmt (double P).");
-            }
-            Catalog.getCurrentSystemInfo().dropBackends(dropBackendClause.getHostPortPairs());
+            Catalog.getCurrentSystemInfo().dropBackends(dropBackendClause);
         } else if (alterClause instanceof DecommissionBackendClause) {
             // decommission
             DecommissionBackendClause decommissionBackendClause = (DecommissionBackendClause) alterClause;

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/DropBackendClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/DropBackendClause.java
@@ -26,18 +26,31 @@ import java.util.List;
 public class DropBackendClause extends BackendClause {
     private boolean force;
 
+    // [DROPP backend] syntax is the old style, we will remove the [DROPP] in a future version.
+    @Deprecated
+    private boolean oldStyle;
+
     public DropBackendClause(List<String> hostPorts) {
         super(hostPorts);
         this.force = true;
     }
 
     public DropBackendClause(List<String> hostPorts, boolean force) {
+        this(hostPorts, force, false);
+    }
+
+    public DropBackendClause(List<String> hostPorts, boolean force, boolean oldStyle) {
         super(hostPorts);
         this.force = force;
+        this.oldStyle = oldStyle;
     }
 
     public boolean isForce() {
         return force;
+    }
+
+    public boolean isOldStyle() {
+        return oldStyle;
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/DropPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/DropPartitionTest.java
@@ -109,7 +109,7 @@ public class DropPartitionTest {
         OlapTable table = (OlapTable) db.getTable("tbl1");
         Partition partition = table.getPartition("p20210202");
         long tabletId = partition.getBaseIndex().getTablets().get(0).getId();
-        String dropPartitionSql = " alter table test.tbl1 drop partition force p20210202;";
+        String dropPartitionSql = " alter table test.tbl1 drop partition p20210202 force;";
         dropPartition(dropPartitionSql);
         List<Replica> replicaList =
                 Catalog.getCurrentCatalog().getTabletInvertedIndex().getReplicasByTabletId(tabletId);

--- a/fe/fe-core/src/test/java/com/starrocks/cluster/SystemInfoServiceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/cluster/SystemInfoServiceTest.java
@@ -243,14 +243,14 @@ public class SystemInfoServiceTest {
         DropBackendClause dropStmt = new DropBackendClause(Lists.newArrayList("192.168.0.1:1234"));
         dropStmt.analyze(analyzer);
         try {
-            Catalog.getCurrentSystemInfo().dropBackends(dropStmt.getHostPortPairs());
+            Catalog.getCurrentSystemInfo().dropBackends(dropStmt);
         } catch (DdlException e) {
             e.printStackTrace();
             Assert.fail();
         }
 
         try {
-            Catalog.getCurrentSystemInfo().dropBackends(dropStmt.getHostPortPairs());
+            Catalog.getCurrentSystemInfo().dropBackends(dropStmt);
         } catch (DdlException e) {
             Assert.assertTrue(e.getMessage().contains("does not exist"));
         }


### PR DESCRIPTION
`DROP BACKEND` will drop all tablets on the backend. If some tables have only one replica, the data will be lost.
The pull request is to add a prompt when necessary. As well, `DROP BACKNE <backend> FORCE` can be used to forcibly drop the backend.