### PR TITLE
Fix get not valid number at expression estimate

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/FoldConstantsRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/FoldConstantsRule.java
@@ -23,7 +23,7 @@ public class FoldConstantsRule extends BottomUpScalarOperatorRewriteRule {
 
     @Override
     public ScalarOperator visitCall(CallOperator call, ScalarOperatorRewriteContext context) {
-        if (call.isAggregate() || notAllConstant(call.getChildren())) {
+        if (call.isAggregate() || notAllConstantRef(call.getChildren())) {
             return call;
         }
         return ScalarOperatorEvaluator.INSTANCE.evaluation(call);
@@ -193,10 +193,6 @@ public class FoldConstantsRule extends BottomUpScalarOperatorRewriteRule {
 
     private boolean notAllConstantRef(List<ScalarOperator> operators) {
         return !operators.stream().allMatch(ScalarOperator::isConstantRef);
-    }
-
-    private boolean notAllConstant(List<ScalarOperator> operators) {
-        return !operators.stream().allMatch(ScalarOperator::isConstant);
     }
 
     private boolean hasNull(List<ScalarOperator> operators) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/FoldConstantsRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/FoldConstantsRule.java
@@ -23,7 +23,7 @@ public class FoldConstantsRule extends BottomUpScalarOperatorRewriteRule {
 
     @Override
     public ScalarOperator visitCall(CallOperator call, ScalarOperatorRewriteContext context) {
-        if (call.isAggregate() || notAllConstantRef(call.getChildren())) {
+        if (call.isAggregate() || notAllConstant(call.getChildren())) {
             return call;
         }
         return ScalarOperatorEvaluator.INSTANCE.evaluation(call);
@@ -36,7 +36,7 @@ public class FoldConstantsRule extends BottomUpScalarOperatorRewriteRule {
             return ConstantOperator.createNull(Type.BOOLEAN);
         }
 
-        if (notAllConstantRef(predicate.getChildren())) {
+        if (notAllConstant(predicate.getChildren())) {
             return predicate;
         }
 
@@ -78,7 +78,7 @@ public class FoldConstantsRule extends BottomUpScalarOperatorRewriteRule {
             return ConstantOperator.createBoolean(!predicate.isNotNull());
         }
 
-        if (notAllConstantRef(predicate.getChildren())) {
+        if (notAllConstant(predicate.getChildren())) {
             return predicate;
         }
 
@@ -107,7 +107,7 @@ public class FoldConstantsRule extends BottomUpScalarOperatorRewriteRule {
             return ConstantOperator.createNull(operator.getType());
         }
 
-        if (notAllConstantRef(operator.getChildren())) {
+        if (notAllConstant(operator.getChildren())) {
             return operator;
         }
 
@@ -148,7 +148,7 @@ public class FoldConstantsRule extends BottomUpScalarOperatorRewriteRule {
             return ConstantOperator.createNull(Type.BOOLEAN);
         }
 
-        if (notAllConstantRef(predicate.getChildren())) {
+        if (notAllConstant(predicate.getChildren())) {
             return predicate;
         }
 
@@ -191,7 +191,7 @@ public class FoldConstantsRule extends BottomUpScalarOperatorRewriteRule {
         return predicate;
     }
 
-    private boolean notAllConstantRef(List<ScalarOperator> operators) {
+    private boolean notAllConstant(List<ScalarOperator> operators) {
         return !operators.stream().allMatch(ScalarOperator::isConstantRef);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/FoldConstantsRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/FoldConstantsRule.java
@@ -36,7 +36,7 @@ public class FoldConstantsRule extends BottomUpScalarOperatorRewriteRule {
             return ConstantOperator.createNull(Type.BOOLEAN);
         }
 
-        if (notAllConstant(predicate.getChildren())) {
+        if (notAllConstantRef(predicate.getChildren())) {
             return predicate;
         }
 
@@ -78,7 +78,7 @@ public class FoldConstantsRule extends BottomUpScalarOperatorRewriteRule {
             return ConstantOperator.createBoolean(!predicate.isNotNull());
         }
 
-        if (notAllConstant(predicate.getChildren())) {
+        if (notAllConstantRef(predicate.getChildren())) {
             return predicate;
         }
 
@@ -107,7 +107,7 @@ public class FoldConstantsRule extends BottomUpScalarOperatorRewriteRule {
             return ConstantOperator.createNull(operator.getType());
         }
 
-        if (notAllConstant(operator.getChildren())) {
+        if (notAllConstantRef(operator.getChildren())) {
             return operator;
         }
 
@@ -148,7 +148,7 @@ public class FoldConstantsRule extends BottomUpScalarOperatorRewriteRule {
             return ConstantOperator.createNull(Type.BOOLEAN);
         }
 
-        if (notAllConstant(predicate.getChildren())) {
+        if (notAllConstantRef(predicate.getChildren())) {
             return predicate;
         }
 
@@ -191,8 +191,12 @@ public class FoldConstantsRule extends BottomUpScalarOperatorRewriteRule {
         return predicate;
     }
 
-    private boolean notAllConstant(List<ScalarOperator> operators) {
+    private boolean notAllConstantRef(List<ScalarOperator> operators) {
         return !operators.stream().allMatch(ScalarOperator::isConstantRef);
+    }
+
+    private boolean notAllConstant(List<ScalarOperator> operators) {
+        return !operators.stream().allMatch(ScalarOperator::isConstant);
     }
 
     private boolean hasNull(List<ScalarOperator> operators) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnStatistic.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnStatistic.java
@@ -82,6 +82,10 @@ public class ColumnStatistic {
         return this.minValue == NEGATIVE_INFINITY || this.maxValue == POSITIVE_INFINITY;
     }
 
+    public boolean hasNaNValue() {
+        return Double.isNaN(minValue) || Double.isNaN(maxValue);
+    }
+
     // TODO(ywb): remove this after user can dump statistics with type
     public boolean isUnknownValue() {
         return this.minValue == NEGATIVE_INFINITY && this.maxValue == POSITIVE_INFINITY && this.nullsFraction == 0 &&

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/PredicateStatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/PredicateStatisticsCalculator.java
@@ -161,9 +161,20 @@ public class PredicateStatisticsCalculator {
             // For CastOperator, we need use child as column statistics
             leftChild = getChildForCastOperator(leftChild);
             rightChild = getChildForCastOperator(rightChild);
-
+            // compute left and right column statistics
             ColumnStatistic leftColumnStatistic = getExpressionStatistic(leftChild);
             ColumnStatistic rightColumnStatistic = getExpressionStatistic(rightChild);
+            // do not use NaN to estimate predicate
+            if (leftColumnStatistic.hasNaNValue()) {
+                leftColumnStatistic =
+                        ColumnStatistic.buildFrom(leftColumnStatistic).setMaxValue(Double.POSITIVE_INFINITY)
+                                .setMinValue(Double.NEGATIVE_INFINITY).build();
+            }
+            if (rightColumnStatistic.hasNaNValue()) {
+                rightColumnStatistic =
+                        rightColumnStatistic.buildFrom(rightColumnStatistic).setMaxValue(Double.POSITIVE_INFINITY)
+                                .setMinValue(Double.NEGATIVE_INFINITY).build();
+            }
 
             if (leftChild.isVariable()) {
                 Optional<ColumnRefOperator> leftChildOpt;
@@ -172,7 +183,7 @@ public class PredicateStatisticsCalculator {
 
                 if (rightChild.isConstant()) {
                     OptionalDouble constant =
-                            (rightColumnStatistic.isInfiniteRange() || rightColumnStatistic.hasNaNValue()) ?
+                            (rightColumnStatistic.isInfiniteRange()) ?
                                     OptionalDouble.empty() : OptionalDouble.of(rightColumnStatistic.getMaxValue());
                     Statistics binaryStats =
                             BinaryPredicateStatisticCalculator.estimateColumnToConstantComparison(leftChildOpt,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/PredicateStatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/PredicateStatisticsCalculator.java
@@ -171,8 +171,9 @@ public class PredicateStatisticsCalculator {
                 leftChildOpt = leftChild.isColumnRef() ? Optional.of((ColumnRefOperator) leftChild) : Optional.empty();
 
                 if (rightChild.isConstant()) {
-                    OptionalDouble constant = (rightColumnStatistic.isInfiniteRange()) ? OptionalDouble.empty() :
-                            OptionalDouble.of(rightColumnStatistic.getMaxValue());
+                    OptionalDouble constant =
+                            (rightColumnStatistic.isInfiniteRange() || rightColumnStatistic.hasNaNValue()) ?
+                                    OptionalDouble.empty() : OptionalDouble.of(rightColumnStatistic.getMaxValue());
                     Statistics binaryStats =
                             BinaryPredicateStatisticCalculator.estimateColumnToConstantComparison(leftChildOpt,
                                     leftColumnStatistic, predicate, constant, statistics);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -863,4 +863,24 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
         Assert.assertTrue(planFragment.contains("     tabletList=10213\n" +
                 "     cardinality=1"));
     }
+
+    @Test
+    public void testNullArithmeticExpression() throws Exception {
+        String sql = "SELECT supplier.S_NATIONKEY FROM supplier WHERE (supplier.S_NATIONKEY) " +
+                "BETWEEN (((NULL)/(CAST(\"\" AS INT ) ))) AND (supplier.S_NATIONKEY)";
+        String plan = getFragmentPlan(sql);
+
+        sql = "SELECT supplier.S_NATIONKEY FROM supplier WHERE (supplier.S_NATIONKEY) " +
+                "BETWEEN (((NULL) + (CAST(\"\" AS INT ) ))) AND (supplier.S_NATIONKEY)";
+        plan = getFragmentPlan(sql);
+
+        sql = "SELECT supplier.S_NATIONKEY FROM supplier WHERE (supplier.S_NATIONKEY) " +
+                "BETWEEN (((NULL) - (CAST(\"\" AS INT ) ))) AND (supplier.S_NATIONKEY)";
+        plan = getFragmentPlan(sql);
+
+        sql = "SELECT supplier.S_NATIONKEY FROM supplier WHERE (supplier.S_NATIONKEY) " +
+                "BETWEEN (((NULL) * (CAST(\"\" AS INT ) ))) AND (supplier.S_NATIONKEY)";
+        plan = getFragmentPlan(sql);
+        System.out.println(plan);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -866,6 +866,7 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
 
     @Test
     public void testNullArithmeticExpression() throws Exception {
+        // check constant operator with null
         String sql = "SELECT supplier.S_NATIONKEY FROM supplier WHERE (supplier.S_NATIONKEY) " +
                 "BETWEEN (((NULL)/(CAST(\"\" AS INT ) ))) AND (supplier.S_NATIONKEY)";
         String plan = getFragmentPlan(sql);
@@ -881,6 +882,17 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
         sql = "SELECT supplier.S_NATIONKEY FROM supplier WHERE (supplier.S_NATIONKEY) " +
                 "BETWEEN (((NULL) * (CAST(\"\" AS INT ) ))) AND (supplier.S_NATIONKEY)";
         plan = getFragmentPlan(sql);
-        System.out.println(plan);
+        // check variable operator with null
+        sql = "SELECT supplier.S_NATIONKEY FROM supplier WHERE (null / supplier.S_NATIONKEY) " +
+                "BETWEEN (((NULL) * (CAST(\"\" AS INT ) ))) AND (supplier.S_NATIONKEY)";
+        plan = getFragmentPlan(sql);
+
+        sql = "SELECT supplier.S_NATIONKEY FROM supplier WHERE (supplier.S_NATIONKEY / null) " +
+                "BETWEEN (((NULL) * (CAST(\"\" AS INT ) ))) AND (supplier.S_NATIONKEY)";
+        plan = getFragmentPlan(sql);
+
+        sql = "SELECT supplier.S_NATIONKEY FROM supplier WHERE (null / S_NAME) " +
+                "BETWEEN (((NULL) * (CAST(\"\" AS INT ) ))) AND (supplier.S_NATIONKEY)";
+        plan = getFragmentPlan(sql);
     }
 }


### PR DESCRIPTION
#1835 
At compute expression statistics, we may get NaN min/max value because of the null value，we need to adjust it before compute predicate factor.
A FoldConstantRule problem was discovered during the revision process, which was modified along with it  