### PR TITLE
Simplify SinkBuffer by removing thread pool

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -636,10 +636,6 @@ CONF_Int64(pipeline_yield_max_time_spent, "100000000");
 CONF_Int64(pipeline_scan_thread_pool_thread_num, "0");
 // queue size of scan thread pool for pipeline engine.
 CONF_Int64(pipeline_scan_thread_pool_queue_size, "102400");
-// the number of exchange threads pipeline engine.
-CONF_Int64(pipeline_exchange_thread_pool_thread_num, "2");
-// queue size of exchange thread pool for pipeline engine.
-CONF_Int64(pipeline_exchange_thread_pool_queue_size, "102400");
 // the number of execution threads for pipeline engine.
 CONF_Int64(pipeline_exec_thread_pool_thread_num, "0");
 // the buffer size of io task

--- a/be/src/exec/pipeline/exchange/exchange_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_source_operator.cpp
@@ -31,7 +31,7 @@ void ExchangeSourceOperator::set_finishing(RuntimeState* state) {
 
 StatusOr<vectorized::ChunkPtr> ExchangeSourceOperator::pull_chunk(RuntimeState* state) {
     std::unique_ptr<vectorized::Chunk> chunk = std::make_unique<vectorized::Chunk>();
-    RETURN_IF_ERROR(_stream_recvr->get_chunk_pipeline(&chunk));
+    RETURN_IF_ERROR(_stream_recvr->get_chunk_for_pipeline(&chunk));
     eval_runtime_bloom_filters(chunk.get());
     return std::move(chunk);
 }

--- a/be/src/exec/pipeline/exchange/sink_buffer.h
+++ b/be/src/exec/pipeline/exchange/sink_buffer.h
@@ -40,48 +40,46 @@ public:
             : _mem_tracker(state->instance_mem_tracker()),
               _brpc_timeout_ms(std::min(3600, state->query_options().query_timeout) * 1000),
               _num_remaining_sinkers(num_sinkers) {
-        _threads = ExecEnv::GetInstance()->pipeline_exchange_sink_thread_pool();
         for (const auto& dest : destinations) {
             const auto& dest_instance_id = dest.fragment_instance_id;
 
-            auto it = _num_sinkers_per_dest_instance.find(dest_instance_id.lo);
-            if (it != _num_sinkers_per_dest_instance.end()) {
+            auto it = _num_sinkers.find(dest_instance_id.lo);
+            if (it != _num_sinkers.end()) {
                 it->second += num_sinkers;
             } else {
-                _num_sinkers_per_dest_instance[dest_instance_id.lo] = num_sinkers;
+                _num_sinkers[dest_instance_id.lo] = num_sinkers;
 
                 // This dest_instance_id first occurs, so create other variable for this dest instance.
-                auto* closure = new CallBackClosure<PTransmitChunkResult, TUniqueId>();
-                closure->ref();
-                closure->addFailedHandler([this]() noexcept {
+                auto* closure = new CallBackClosure<PTransmitChunkResult, TUniqueId>(dest_instance_id);
+                closure->addFailedHandler([this, closure]() noexcept {
+                    closure->give_back();
                     {
                         std::lock_guard<std::mutex> l(_mutex);
                         _is_finishing = true;
                     }
                     LOG(WARNING) << " transmit chunk rpc failed";
-                    _in_flight_rpc_num.fetch_sub(1, std::memory_order_release);
+                    _num_in_flight_rpc.fetch_sub(1, std::memory_order_release);
                 });
-                closure->addSuccessHandler([this, closure](const PTransmitChunkResult& result) noexcept {
-                    Status status(result.status());
-                    if (!status.ok()) {
-                        {
-                            std::lock_guard<std::mutex> l(_mutex);
-                            _is_finishing = true;
-                        }
-                        LOG(WARNING) << " transmit chunk rpc failed, " << status.message();
-                    } else {
-                        _is_closure_finishing[closure->context().lo]->store(true, std::memory_order_release);
-                        _try_to_trigger_rpc_task(closure->context());
-                    }
-                    _in_flight_rpc_num.fetch_sub(1, std::memory_order_release);
-                });
+                closure->addSuccessHandler(
+                        [this, closure](const TUniqueId& instance_id, const PTransmitChunkResult& result) noexcept {
+                            closure->give_back();
+                            Status status(result.status());
+                            if (!status.ok()) {
+                                {
+                                    std::lock_guard<std::mutex> l(_mutex);
+                                    _is_finishing = true;
+                                }
+                                LOG(WARNING) << " transmit chunk rpc failed, " << status.message();
+                            } else {
+                                std::lock_guard<std::mutex> l(_mutex);
+                                _try_to_send_rpc(instance_id);
+                            }
+                            _num_in_flight_rpc.fetch_sub(1, std::memory_order_release);
+                        });
                 _closures[dest_instance_id.lo] = closure;
-
-                _is_closure_finishing[dest_instance_id.lo] = std::make_unique<std::atomic_bool>(false);
 
                 _request_seqs[dest_instance_id.lo] = 0;
                 _buffers[dest_instance_id.lo] = std::queue<TransmitChunkInfo, std::list<TransmitChunkInfo>>();
-                _instance_mutexes[dest_instance_id.lo] = std::make_unique<std::mutex>();
 
                 PUniqueId finst_id;
                 finst_id.set_hi(dest_instance_id.hi);
@@ -89,9 +87,9 @@ public:
                 _instance_id2finst_id[dest_instance_id.lo] = std::move(finst_id);
             }
 
-            _expected_eos = 0;
-            for (auto& [_, num] : _num_sinkers_per_dest_instance) {
-                _expected_eos += num;
+            _num_remaining_eos = 0;
+            for (auto& [_, num] : _num_sinkers) {
+                _num_remaining_eos += num;
             }
         }
     }
@@ -101,9 +99,7 @@ public:
 
         // Relase resources
         for (auto& [_, closure] : _closures) {
-            if (closure->unref()) {
-                delete closure;
-            }
+            delete closure;
         }
 
         for (auto& [_, buffer] : _buffers) {
@@ -116,22 +112,18 @@ public:
     }
 
     void add_request(const TransmitChunkInfo& request) {
-        DCHECK(_expected_eos > 0);
+        std::lock_guard<std::mutex> l(_mutex);
+        DCHECK(_num_remaining_eos > 0);
         if (_is_finishing) {
             request.params->release_finst_id();
             return;
         }
-        const TUniqueId& instance_id = request.fragment_instance_id;
-        {
-            std::lock_guard<std::mutex> l(*_instance_mutexes[instance_id.lo]);
-            _buffers[instance_id.lo].push(request);
-        }
-
-        _try_to_trigger_rpc_task(instance_id);
+        _buffers[request.fragment_instance_id.lo].push(request);
+        _try_to_send_rpc(request.fragment_instance_id);
     }
 
     bool is_full() const {
-        // TODO(hcf) if one channel is congested, it may cause all other channel unwritable
+        // If one channel is congested, it may cause all other channel unwritable
         // std::queue' read is concurrent safe without mutex
         return std::any_of(_buffers.begin(), _buffers.end(),
                            [](const auto& entry) { return entry.second.size() > config::pipeline_io_buffer_size; });
@@ -145,10 +137,9 @@ public:
         }
 
         // Here is the guarantee that
-        // 1. No new rpc task will be created after finishing stage
-        // 2. No new brpc process will be triggered after finishing stage
-        // Therefore, we just wait for existed rpc task and bprc process to be finished
-        return !_is_rpc_task_active && _in_flight_rpc_num.load(std::memory_order_acquire) == 0;
+        // 1. No new brpc process will be triggered after finishing stage
+        // Therefore, we just wait for bprc process to be finished
+        return _num_in_flight_rpc.load(std::memory_order_acquire) == 0;
     }
 
     void decrease_running_sinkers() {
@@ -159,166 +150,82 @@ public:
     }
 
 private:
-    void _try_to_trigger_rpc_task(const TUniqueId& instance_id) {
-        // Guarantee that no new rpc task will be created after finishing stage
-        {
-            std::lock_guard<std::mutex> l(_mutex);
-            if (_is_finishing) {
-                return;
-            }
-            _events.push(instance_id);
-            if (_is_rpc_task_active) {
-                return;
-            }
-            _is_rpc_task_active = true;
-        }
-        PriorityThreadPool::Task task;
-        task.work_function = [this]() { _process(); };
-        // TODO(by satanson): set a proper priority
-        task.priority = 20;
-        if (!_threads->offer(task)) {
-            LOG(WARNING) << "SinkBuffer failed to offer rpc task due to thread pool shutdown";
-            {
-                std::lock_guard<std::mutex> l(_mutex);
-                _is_finishing = true;
-                _is_rpc_task_active = false;
-            }
-        }
-    }
-
-    void _process() {
-        try {
-            SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_mem_tracker);
-
-            for (;;) {
-                TUniqueId instance_id;
-                {
-                    std::lock_guard<std::mutex> l(_mutex);
-                    if (_is_finishing || _events.empty()) {
-                        _is_rpc_task_active = false;
-                        break;
-                    }
-                    instance_id = _events.front();
-                    _events.pop();
-                }
-
-                auto* closure = _closures[instance_id.lo];
-                auto& buffer = _buffers[instance_id.lo];
-                for (;;) {
-                    {
-                        std::lock_guard<std::mutex> l(*_instance_mutexes[instance_id.lo]);
-                        if (buffer.empty()) {
-                            break;
-                        }
-                    }
-                    if (closure->has_in_flight_rpc()) {
-                        // This closure is bound to finish for a short while
-                        // So block wait for the closure to be finished
-                        if (_is_closure_finishing[instance_id.lo]->load(std::memory_order_acquire)) {
-                            brpc::Join(closure->cntl.call_id());
-                            _is_closure_finishing[instance_id.lo]->store(false, std::memory_order_release);
-                        } else {
-                            break;
-                        }
-                    }
-                    TransmitChunkInfo request = buffer.front();
-                    _send_rpc(request);
-                    request.params->release_finst_id();
-                    {
-                        std::lock_guard<std::mutex> l(*_instance_mutexes[instance_id.lo]);
-                        buffer.pop();
-                    }
-                }
-            }
-        } catch (const std::exception& exp) {
-            LOG(FATAL) << "[ExchangeSinkOperator] sink_buffer::process: " << exp.what();
-        } catch (...) {
-            LOG(FATAL) << "[ExchangeSinkOperator] sink_buffer::process: UNKNOWN";
-        }
-    }
-
-    void _send_rpc(TransmitChunkInfo& request) {
-        // Guarantee that no new brpc process will be triggered after finishing stage
-        std::lock_guard<std::mutex> l(_mutex);
+    void _try_to_send_rpc(const TUniqueId& instance_id) {
         if (_is_finishing) {
             return;
         }
 
-        const TUniqueId& instance_id = request.fragment_instance_id;
-        if (request.params->eos()) {
-            if (--_expected_eos == 0) {
-                _is_finishing = true;
+        for (;;) {
+            auto& buffer = _buffers[instance_id.lo];
+            auto* closure = _closures[instance_id.lo];
+            if (buffer.empty() || !closure->is_idle()) {
+                return;
             }
-            // Only the last eos is sent to ExchangeSourceOperator. it must be guaranteed that
-            // eos is the last packet to send to finish the input stream of the corresponding of
-            // ExchangeSourceOperator and eos is sent exactly-once.
-            if (--_num_sinkers_per_dest_instance[instance_id.lo] > 0) {
-                if (request.params->chunks_size() == 0) {
-                    return;
-                } else {
-                    request.params->set_eos(false);
+
+            TransmitChunkInfo request = buffer.front();
+            buffer.pop();
+
+            if (request.params->eos()) {
+                if (--_num_remaining_eos == 0) {
+                    _is_finishing = true;
+                }
+                // Only the last eos is sent to ExchangeSourceOperator. it must be guaranteed that
+                // eos is the last packet to send to finish the input stream of the corresponding of
+                // ExchangeSourceOperator and eos is sent exactly-once.
+                if (--_num_sinkers[instance_id.lo] > 0) {
+                    if (request.params->chunks_size() == 0) {
+                        request.params->release_finst_id();
+                        continue;
+                    } else {
+                        request.params->set_eos(false);
+                    }
                 }
             }
+
+            request.params->set_allocated_finst_id(&_instance_id2finst_id[instance_id.lo]);
+            request.params->set_sequence(_request_seqs[instance_id.lo]++);
+
+            closure->borrow();
+            closure->cntl.Reset();
+            closure->cntl.set_timeout_ms(_brpc_timeout_ms);
+            closure->cntl.request_attachment().append(request.attachment);
+            _num_in_flight_rpc.fetch_add(1, std::memory_order_release);
+            request.brpc_stub->transmit_chunk(&closure->cntl, request.params.get(), &closure->result, closure);
+
+            request.params->release_finst_id();
+            return;
         }
-
-        request.params->set_allocated_finst_id(&_instance_id2finst_id[instance_id.lo]);
-        request.params->set_sequence(_request_seqs[instance_id.lo]++);
-
-        auto* closure = _closures[instance_id.lo];
-        DCHECK(closure != nullptr);
-        DCHECK(!closure->has_in_flight_rpc());
-        closure->ref();
-        closure->cntl.Reset();
-        closure->cntl.set_timeout_ms(_brpc_timeout_ms);
-        closure->cntl.request_attachment().append(request.attachment);
-        closure->set_context(instance_id);
-        _in_flight_rpc_num.fetch_add(1, std::memory_order_release);
-        _is_closure_finishing[instance_id.lo]->store(false, std::memory_order_acquire);
-        request.brpc_stub->transmit_chunk(&closure->cntl, request.params.get(), &closure->result, closure);
     }
 
-    PriorityThreadPool* _threads = nullptr;
     MemTracker* _mem_tracker = nullptr;
     const int32_t _brpc_timeout_ms;
+
+    std::mutex _mutex;
 
     // Taking into account of efficiency, all the following maps
     // use int64_t as key, which is the field type of TUniqueId::lo
     // because TUniqueId::hi is exactly the same in one query
 
-    phmap::flat_hash_map<int64_t, size_t> _num_sinkers_per_dest_instance;
+    phmap::flat_hash_map<int64_t, size_t> _num_sinkers;
     phmap::flat_hash_map<int64_t, int64_t> _request_seqs;
-    std::atomic<int32_t> _in_flight_rpc_num = 0;
+    std::atomic<int32_t> _num_in_flight_rpc = 0;
+    std::atomic<int32_t> _num_remaining_sinkers;
+    int32_t _num_remaining_eos = 0;
 
     // The request needs the reference to the allocated finst id,
     // so cache finst id for each dest fragment instance.
     phmap::flat_hash_map<int64_t, PUniqueId> _instance_id2finst_id;
-
     phmap::flat_hash_map<int64_t, CallBackClosure<PTransmitChunkResult, TUniqueId>*> _closures;
-    // Closure becomes idle only when handle finished execution
-    // Rpc task may be created in success handler of closure, if this task being executed immediately
-    // and judge whether closure is idle by method closure->has_in_flight_rpc(), and this method may
-    // return true if success handler hasn't finished its execution, which lead to this event(channel ready)
-    // being swallowed
-    phmap::flat_hash_map<int64_t, std::unique_ptr<std::atomic_bool>> _is_closure_finishing;
     phmap::flat_hash_map<int64_t, std::queue<TransmitChunkInfo, std::list<TransmitChunkInfo>>> _buffers;
-    phmap::flat_hash_map<int64_t, std::unique_ptr<std::mutex>> _instance_mutexes;
 
-    std::mutex _mutex;
-    // Events include 'new request' and 'channel ready'
-    std::queue<TUniqueId, std::list<TUniqueId>> _events;
-
-    // _is_rpc_task_active and _is_finishing are used in _try_to_trigger_rpc_task and _send_rpc.
-    // - Write and read them with lock, to protect critical region between _try_to_trigger_rpc_task and _send_rpc.
-    // - Read them without lock in is_finished() and ~SinkBuffer(), whose visibility is guaranteed by atomic.
-    std::atomic<bool> _is_rpc_task_active = false;
     // True means that SinkBuffer needn't input chunk and send chunk anymore,
-    // but there may be still RPC task or in-flight RPC running.
+    // but there may be still in-flight RPC running.
     // It becomes true, when all sinkers have sent EOS, or been set_finished/cancelled, or RPC has returned error.
+    // Modification of this field must under _mutex even it is atomic type because:
+    // 1. atomic: make sure that all threads without _mutex can see the modification immediately
+    // 2. _mutex: guarantee that no rpc will be triggered if SinkBuffer entered finishing stage
     std::atomic<bool> _is_finishing = false;
 
-    int32_t _expected_eos = 0;
-
-    std::atomic<int> _num_remaining_sinkers;
 }; // namespace starrocks::pipeline
 
 } // namespace starrocks::pipeline

--- a/be/src/runtime/data_stream_recvr.cc
+++ b/be/src/runtime/data_stream_recvr.cc
@@ -221,7 +221,6 @@ Status DataStreamRecvr::SenderQueue::_do_get_chunk(vectorized::Chunk** chunk) {
     }
 
     if (_chunk_queue.empty()) {
-        DCHECK_EQ(_num_remaining_senders, 0);
         return Status::OK();
     }
 

--- a/be/src/runtime/data_stream_recvr.cc
+++ b/be/src/runtime/data_stream_recvr.cc
@@ -70,7 +70,7 @@ public:
     Status get_chunk(vectorized::Chunk** chunk);
 
     // Same as get_chunk, but this version will not wait if there is non buffer chunks
-    Status get_chunk_pipeline(vectorized::Chunk** chunk);
+    Status get_chunk_for_pipeline(vectorized::Chunk** chunk);
 
     // check if data has come, work with try_get_chunk.
     bool has_chunk();
@@ -210,7 +210,7 @@ Status DataStreamRecvr::SenderQueue::get_chunk(vectorized::Chunk** chunk) {
     return _do_get_chunk(chunk);
 }
 
-Status DataStreamRecvr::SenderQueue::get_chunk_pipeline(vectorized::Chunk** chunk) {
+Status DataStreamRecvr::SenderQueue::get_chunk_for_pipeline(vectorized::Chunk** chunk) {
     std::unique_lock<std::mutex> l(_lock);
     return _do_get_chunk(chunk);
 }
@@ -637,11 +637,11 @@ Status DataStreamRecvr::get_chunk(std::unique_ptr<vectorized::Chunk>* chunk) {
     return status;
 }
 
-Status DataStreamRecvr::get_chunk_pipeline(std::unique_ptr<vectorized::Chunk>* chunk) {
+Status DataStreamRecvr::get_chunk_for_pipeline(std::unique_ptr<vectorized::Chunk>* chunk) {
     DCHECK(!_is_merging);
     DCHECK_EQ(_sender_queues.size(), 1);
     vectorized::Chunk* tmp_chunk = nullptr;
-    Status status = _sender_queues[0]->get_chunk_pipeline(&tmp_chunk);
+    Status status = _sender_queues[0]->get_chunk_for_pipeline(&tmp_chunk);
     chunk->reset(tmp_chunk);
     return status;
 }

--- a/be/src/runtime/data_stream_recvr.h
+++ b/be/src/runtime/data_stream_recvr.h
@@ -74,7 +74,7 @@ public:
     ~DataStreamRecvr();
 
     Status get_chunk(std::unique_ptr<vectorized::Chunk>* chunk);
-    Status get_chunk_pipeline(std::unique_ptr<vectorized::Chunk>* chunk);
+    Status get_chunk_for_pipeline(std::unique_ptr<vectorized::Chunk>* chunk);
 
     // Deregister from DataStreamMgr instance, which shares ownership of this instance.
     void close();

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -119,10 +119,6 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths) {
                                                                    ? std::thread::hardware_concurrency()
                                                                    : config::pipeline_scan_thread_pool_thread_num,
                                                            config::pipeline_scan_thread_pool_queue_size);
-    _pipeline_exchange_sink_thread_pool = new PriorityThreadPool(
-            config::pipeline_exchange_thread_pool_thread_num <= 0 ? std::thread::hardware_concurrency()
-                                                                  : config::pipeline_exchange_thread_pool_thread_num,
-            config::pipeline_exchange_thread_pool_queue_size);
     _num_scan_operators = 0;
     _etl_thread_pool = new PriorityThreadPool(config::etl_thread_pool_size, config::etl_thread_pool_queue_size);
     _fragment_mgr = new FragmentMgr(this);
@@ -331,10 +327,6 @@ void ExecEnv::_destroy() {
     if (_pipeline_scan_io_thread_pool) {
         delete _pipeline_scan_io_thread_pool;
         _pipeline_scan_io_thread_pool = nullptr;
-    }
-    if (_pipeline_exchange_sink_thread_pool) {
-        delete _pipeline_exchange_sink_thread_pool;
-        _pipeline_exchange_sink_thread_pool = nullptr;
     }
     if (_thread_pool) {
         delete _thread_pool;

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -124,7 +124,6 @@ public:
     ThreadResourceMgr* thread_mgr() { return _thread_mgr; }
     PriorityThreadPool* thread_pool() { return _thread_pool; }
     PriorityThreadPool* pipeline_scan_io_thread_pool() { return _pipeline_scan_io_thread_pool; }
-    PriorityThreadPool* pipeline_exchange_sink_thread_pool() { return _pipeline_exchange_sink_thread_pool; }
     size_t increment_num_scan_operators(size_t n) { return _num_scan_operators.fetch_add(n); }
     size_t decrement_num_scan_operators(size_t n) { return _num_scan_operators.fetch_sub(n); }
     PriorityThreadPool* etl_thread_pool() { return _etl_thread_pool; }
@@ -203,7 +202,6 @@ private:
     ThreadResourceMgr* _thread_mgr = nullptr;
     PriorityThreadPool* _thread_pool = nullptr;
     PriorityThreadPool* _pipeline_scan_io_thread_pool = nullptr;
-    PriorityThreadPool* _pipeline_exchange_sink_thread_pool = nullptr;
     std::atomic<size_t> _num_scan_operators;
     PriorityThreadPool* _etl_thread_pool = nullptr;
     FragmentMgr* _fragment_mgr = nullptr;

--- a/be/src/util/callback_closure.h
+++ b/be/src/util/callback_closure.h
@@ -38,15 +38,19 @@ public:
     ~CallBackClosure() override = default;
 
     bool is_idle() { return _is_idle; }
+
+    // Closure is unsharable, this method should be
+    // invoked before brpc task submited
     void borrow() {
-        bool expected = true;
-        [[maybe_unused]] auto res = _is_idle.compare_exchange_strong(expected, false);
-        DCHECK(res);
+        DCHECK(_is_idle);
+        _is_idle = false;
     }
+
+    // Closure is unsharable, this method should be
+    // invoked after brpc finished
     void give_back() {
-        bool expected = false;
-        [[maybe_unused]] auto res = _is_idle.compare_exchange_strong(expected, true);
-        DCHECK(res);
+        DCHECK(!_is_idle);
+        _is_idle = true;
     }
 
     // Disallow copy and assignment.

--- a/be/src/util/callback_closure.h
+++ b/be/src/util/callback_closure.h
@@ -39,15 +39,13 @@ public:
 
     bool is_idle() { return _is_idle; }
 
-    // Closure is unsharable, this method should be
-    // invoked before brpc task submited
+    // brpc must be serial, so the closure is unsharable
+    // borrow should be invoked before brpc task submited
+    // and give_back should be invoked after brpc finished
     void borrow() {
         DCHECK(_is_idle);
         _is_idle = false;
     }
-
-    // Closure is unsharable, this method should be
-    // invoked after brpc finished
     void give_back() {
         DCHECK(!_is_idle);
         _is_idle = true;


### PR DESCRIPTION
Since the only purpose of `pipeline_exchange_thread_pool` is to start brpc task, it does no improvement to performance and introduces unnecessary complexity including
1. Only one task is executing at any time
2. rpc task interact with brpc task, which need a bunch of auxiliary data structures
3. global mutex
4. etc...

So we can simply remove the `pipeline_exchange_thread_pool` by replacing asynchronous actions with synchronous actions. 

After simplification, There are still only two timing to trigger brpc process

1. add request when closure is idle
2. closure finish previous brpc process and buffer is not empty
