### PR TITLE
Fix cross join lose predicate in JoinAssociativityRule

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalHashJoinOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalHashJoinOperator.java
@@ -57,10 +57,13 @@ public class PhysicalHashJoinOperator extends PhysicalOperator {
         return visitor.visitPhysicalHashJoin(optExpression, context);
     }
 
+    @Override
     public String toString() {
-        return "PhysicalHashJoin" + " {" +
-                "joinType='" + joinType.toString() + '\'' +
-                ", onConjuncts='" + joinPredicate + '\'' +
+        return "PhysicalHashJoinOperator{" +
+                "joinType=" + joinType +
+                ", joinPredicate=" + joinPredicate +
+                ", limit=" + limit +
+                ", predicate=" + predicate +
                 '}';
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarRangePredicateExtractor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarRangePredicateExtractor.java
@@ -44,7 +44,7 @@ public class ScalarRangePredicateExtractor {
         return rewrite(predicate, false);
     }
 
-    public ScalarOperator rewrite(ScalarOperator predicate, boolean onlyExtractColumnRef) {
+    private ScalarOperator rewrite(ScalarOperator predicate, boolean onlyExtractColumnRef) {
         if (predicate.getOpType() != OperatorType.COMPOUND) {
             return predicate;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SemiReorderRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SemiReorderRule.java
@@ -1,6 +1,7 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
 package com.starrocks.sql.optimizer.rule.transformation;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.analysis.JoinOperator;
 import com.starrocks.sql.optimizer.OptExpression;
@@ -55,6 +56,8 @@ public class SemiReorderRule extends TransformationRule {
         LogicalJoinOperator topJoin = (LogicalJoinOperator) input.getOp();
         LogicalJoinOperator leftChildJoin = (LogicalJoinOperator) input.inputAt(0).getOp();
 
+        Preconditions.checkState(topJoin.getPredicate() == null);
+
         LogicalJoinOperator newTopJoin = new LogicalJoinOperator.Builder().withOperator(leftChildJoin)
                 .setProjection(topJoin.getProjection())
                 .build();
@@ -84,6 +87,5 @@ public class SemiReorderRule extends TransformationRule {
                         OptExpression.create(newSemiJoin,
                                 Lists.newArrayList(input.inputAt(0).inputAt(0), input.inputAt(1))),
                         input.inputAt(0).inputAt(1))));
-
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -9,10 +9,15 @@ import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.VariableMgr;
+import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.dump.QueryDumpInfo;
+import com.starrocks.sql.optimizer.rule.RuleSet;
+import com.starrocks.sql.optimizer.rule.transformation.JoinAssociativityRule;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -124,6 +129,18 @@ public class ReplayFromDumpTest {
         return new Pair<>(queryDumpInfo,
                 UtFrameUtils.getNewPlanAndFragmentFromDump(connectContext, queryDumpInfo).second.
                         getExplainString(TExplainLevel.COSTS));
+    }
+
+    private Pair<QueryDumpInfo, String> getPlanFragment(String dumpJsonStr, SessionVariable sessionVariable,
+                                                        TExplainLevel level)
+            throws Exception {
+        QueryDumpInfo queryDumpInfo = getDumpInfoFromJson(dumpJsonStr);
+        if (sessionVariable != null) {
+            queryDumpInfo.setSessionVariable(sessionVariable);
+        }
+        return new Pair<>(queryDumpInfo,
+                UtFrameUtils.getNewPlanAndFragmentFromDump(connectContext, queryDumpInfo).second.
+                        getExplainString(level));
     }
 
     @Test
@@ -241,5 +258,30 @@ public class ReplayFromDumpTest {
                 "  |  \n" +
                 "  |----3:EXCHANGE\n" +
                 "  |       cardinality: 335"));
+    }
+
+    @Test
+    public void testCrossReorder() throws Exception {
+        RuleSet mockRule = new RuleSet() {
+            @Override
+            public void addJoinTransformationRules() {
+                this.getTransformRules().clear();
+                this.getTransformRules().add(JoinAssociativityRule.getInstance());
+            }
+        };
+
+        new MockUp<OptimizerContext>() {
+            @Mock
+            public RuleSet getRuleSet() {
+                return mockRule;
+            }
+        };
+
+        Pair<QueryDumpInfo, String> replayPair =
+                getPlanFragment(getDumpInfoFromFile("query_dump/cross_reorder"), null, TExplainLevel.NORMAL);
+        Assert.assertTrue(replayPair.second.contains("  15:CROSS JOIN\n" +
+                "  |  cross join:\n" +
+                "  |  predicates: (CAST(2: v2 AS DOUBLE) = CAST(8: v2 AS DOUBLE)) OR (3: v3 = 8: v2), " +
+                "CASE WHEN CAST(6: v3 AS BOOLEAN) THEN CAST(11: v2 AS VARCHAR) WHEN CAST(3: v3 AS BOOLEAN) THEN '123' ELSE CAST(12: v3 AS VARCHAR) END > '1'\n"));
     }
 }

--- a/fe/fe-core/src/test/resources/sql/query_dump/cross_reorder.json
+++ b/fe/fe-core/src/test/resources/sql/query_dump/cross_reorder.json
@@ -1,0 +1,45 @@
+{
+  "statement": "SELECT * FROM (     SELECT CASE              WHEN t0.v3 THEN t2.v2             WHEN s0.v3 THEN \u0027123\u0027             ELSE t2.v3         END AS x0, t1.v1     FROM s0          JOIN t0 ON s0.v2 \u003d t0.v2         JOIN t1 ON s0.v2 \u003d t1.v2 OR s0.v3 \u003d t1.v2\n       JOIN t2 ON t1.v2 \u003d t2.v2     WHERE t2.v1 \u003d 2 ) temp WHERE x0 \u003e 1;\n",
+  "table_meta": {
+    "td.t2": "CREATE TABLE `t2` (\n  `v1` bigint(20) NULL COMMENT \"\",\n  `v2` bigint(20) NULL COMMENT \"\",\n  `v3` bigint(20) NULL COMMENT \"\"\n) ENGINE\u003dOLAP \nDUPLICATE KEY(`v1`, `v2`, `v3`)\nCOMMENT \"OLAP\"\nDISTRIBUTED BY HASH(`v1`) BUCKETS 3 \nPROPERTIES (\n\"replication_num\" \u003d \"1\",\n\"in_memory\" \u003d \"false\",\n\"storage_format\" \u003d \"DEFAULT\"\n);",
+    "td.t0": "CREATE TABLE `t0` (\n  `v1` bigint(20) NULL COMMENT \"\",\n  `v2` bigint(20) NULL COMMENT \"\",\n  `v3` bigint(20) NULL COMMENT \"\"\n) ENGINE\u003dOLAP \nDUPLICATE KEY(`v1`, `v2`, `v3`)\nCOMMENT \"OLAP\"\nDISTRIBUTED BY HASH(`v1`) BUCKETS 3 \nPROPERTIES (\n\"replication_num\" \u003d \"1\",\n\"in_memory\" \u003d \"false\",\n\"storage_format\" \u003d \"DEFAULT\"\n);",
+    "td.t1": "CREATE TABLE `t1` (\n  `v1` bigint(20) NULL COMMENT \"\",\n  `v2` bigint(20) NULL COMMENT \"\",\n  `v3` bigint(20) NULL COMMENT \"\"\n) ENGINE\u003dOLAP \nDUPLICATE KEY(`v1`, `v2`, `v3`)\nCOMMENT \"OLAP\"\nDISTRIBUTED BY HASH(`v1`) BUCKETS 3 \nPROPERTIES (\n\"replication_num\" \u003d \"1\",\n\"in_memory\" \u003d \"false\",\n\"storage_format\" \u003d \"DEFAULT\"\n);",
+    "td.s0": "CREATE TABLE `s0` (\n  `v1` varchar(2000) NULL COMMENT \"\",\n  `v2` varchar(2000) NULL COMMENT \"\",\n  `v3` bigint(20) NULL COMMENT \"\"\n) ENGINE\u003dOLAP \nDUPLICATE KEY(`v1`, `v2`, `v3`)\nCOMMENT \"OLAP\"\nDISTRIBUTED BY HASH(`v1`) BUCKETS 3 \nPROPERTIES (\n\"replication_num\" \u003d \"1\",\n\"in_memory\" \u003d \"false\",\n\"storage_format\" \u003d \"DEFAULT\"\n);"
+  },
+  "table_row_count": {
+    "td.t0": {
+      "t0": 3
+    },
+    "td.s0": {
+      "s0": 3
+    },
+    "td.t1": {
+      "t1": 3
+    },
+    "td.t2": {
+      "t2": 3
+    }
+  },
+  "session_variables": "{\"runtime_join_filter_push_down_limit\":1024000,\"codegen_level\":0,\"cbo_cte_reuse\":false,\"character_set_connection\":\"utf8\",\"cbo_use_correlated_join_estimate\":true,\"enable_insert_strict\":false,\"enable_filter_unused_columns_in_scan_stage\":false,\"div_precision_increment\":4,\"tx_isolation\":\"REPEATABLE-READ\",\"wait_timeout\":28800,\"auto_increment_increment\":1,\"foreign_key_checks\":true,\"character_set_client\":\"utf8\",\"autocommit\":true,\"enable_column_expr_predicate\":false,\"character_set_results\":\"utf8\",\"parallel_fragment_exec_instance_num\":1,\"max_scan_key_num\":-1,\"enable_global_runtime_filter\":true,\"forward_to_master\":false,\"net_read_timeout\":60,\"streaming_preaggregation_mode\":\"auto\",\"storage_engine\":\"olap\",\"cbo_enable_dp_join_reorder\":true,\"cbo_enable_low_cardinality_optimize\":true,\"tx_visible_wait_timeout\":10,\"cbo_max_reorder_node_use_exhaustive\":4,\"new_planner_optimize_timeout\":30000000,\"force_schedule_local\":false,\"pipeline_dop\":0,\"enable_query_dump\":false,\"cbo_enable_greedy_join_reorder\":true,\"prefer_join_method\":\"broadcast\",\"load_mem_limit\":0,\"sql_select_limit\":9223372036854775807,\"profiling\":false,\"sql_safe_updates\":0,\"enable_pipeline_engine\":false,\"query_cache_type\":0,\"disable_colocate_join\":false,\"max_pushdown_conditions_per_column\":-1,\"enable_vectorized_engine\":true,\"net_write_timeout\":60,\"collation_database\":\"utf8_general_ci\",\"hash_join_push_down_right_table\":true,\"new_planner_agg_stage\":0,\"pipeline_profile_mode\":\"brief\",\"collation_connection\":\"utf8_general_ci\",\"resource_group\":\"normal\",\"enable_new_planner_push_down_join_to_agg\":false,\"broadcast_row_limit\":15000000,\"exec_mem_limit\":2147483648,\"cbo_max_reorder_node_use_dp\":10,\"disable_join_reorder\":false,\"is_report_success\":true,\"enable_groupby_use_output_alias\":false,\"net_buffer_length\":16384,\"transmission_compression_type\":\"LZ4\",\"enable_vectorized_insert\":true,\"interactive_timeout\":3600,\"enable_spilling\":false,\"batch_size\":1024,\"cbo_enable_replicated_join\":false,\"max_allowed_packet\":1048576,\"query_timeout\":300,\"enable_cbo\":true,\"collation_server\":\"utf8_general_ci\",\"time_zone\":\"Asia/Shanghai\",\"max_execution_time\":3000000,\"character_set_server\":\"utf8\",\"cbo_use_nth_exec_plan\":0,\"rewrite_count_distinct_to_bitmap_hll\":true,\"parallel_exchange_instance_num\":-1,\"sql_mode\":34,\"SQL_AUTO_IS_NULL\":false,\"event_scheduler\":\"OFF\",\"disable_streaming_preaggregations\":false}",
+  "column_statistics": {
+    "td.t0": {
+      "v2": "[1.0, 3.0, 0.0, 8.0, 3.0] ESTIMATE",
+      "v3": "[1.0, 3.0, 0.0, 8.0, 3.0] ESTIMATE"
+    },
+    "td.s0": {
+      "v2": "[-Infinity, Infinity, 0.0, 1.0, 3.0] ESTIMATE",
+      "v3": "[1.0, 3.0, 0.0, 8.0, 3.0] ESTIMATE"
+    },
+    "td.t1": {
+      "v1": "[1.0, 3.0, 0.0, 8.0, 3.0] ESTIMATE",
+      "v2": "[1.0, 3.0, 0.0, 8.0, 3.0] ESTIMATE"
+    },
+    "td.t2": {
+      "v1": "[1.0, 3.0, 0.0, 8.0, 3.0] ESTIMATE",
+      "v2": "[1.0, 3.0, 0.0, 8.0, 3.0] ESTIMATE",
+      "v3": "[1.0, 3.0, 0.0, 8.0, 3.0] ESTIMATE"
+    }
+  },
+  "be_number": 1,
+  "exception": []
+}


### PR DESCRIPTION
Such as SQL:
```
SELECT *
FROM (
	SELECT CASE 
			WHEN t0.v3 THEN t2.v2
			WHEN s0.v3 THEN '123'
			ELSE t2.v3
		END AS x0, t1.v1
	FROM s0
		JOIN t0 ON s0.v2 = t0.v2
		JOIN t1 ON s0.v2 = t1.v2 OR s0.v3 = t1.v2
		JOIN t2 ON t1.v2 = t2.v2
	WHERE t2.v1 = 2
) temp
WHERE x0 > 1;
```

The Join plan:
```
|   15:Project                                                                                                                                                 |
|   |  <slot 7> : 7: v1                                                                                                                                        |
|   |  <slot 13> : CASE WHEN CAST(6: v3 AS BOOLEAN) THEN CAST(11: v2 AS VARCHAR) WHEN CAST(3: v3 AS BOOLEAN) THEN '123' ELSE CAST(12: v3 AS VARCHAR) END       |
|   |                                                                                                                                                          |
|   14:CROSS JOIN                                                                                                                                              |
|   |  cross join:                                                                                                                                             |
|   |  predicates: CASE WHEN CAST(6: v3 AS BOOLEAN) THEN CAST(11: v2 AS VARCHAR) WHEN CAST(3: v3 AS BOOLEAN) THEN '123' ELSE CAST(12: v3 AS VARCHAR) END > '1' |
|   |                                                                                                                                                          |
|   |----13:EXCHANGE                                                                                                                                           |
|   |                                                                                                                                                          |
|   6:Project                                                                                                                                                  |
|   |  <slot 2> : 2: v2                                                                                                                                        |
|   |  <slot 3> : 3: v3                                                                                                                                        |
|   |  <slot 6> : 6: v3                                                                                                                                        |
|   |                                                                                                                                                          |
|   5:HASH JOIN                                                                                                                                                |
|   |  join op: INNER JOIN (BROADCAST)                                                                                                                         |
|   |  hash predicates:                                                                                                                                        |
|   |  colocate: false, reason:                                                                                                                                |
|   |  equal join conjunct: 15: cast = 14: cast
```

The plan was lose predicate `s0.v2 = t1.v2 OR s0.v3 = t1.v2` on CROSS_JOIN

The right plan:
```
|   14:CROSS JOIN                                                                                                                                              |
|   |  cross join:                                                                                                                                             |
|   |  predicates: (CAST(2: v2 AS DOUBLE) = CAST(8: v2 AS DOUBLE)) OR (3: v3 = 8: v2), CASE WHEN CAST(6: v3 AS BOOLEAN) THEN CAST(11: v2 AS VARCHAR) WHEN CAST(3: v3 AS BOOLEAN) THEN '123' ELSE CAST(12: v3 AS VARCHAR) END > '1' |
```
