### PR TITLE
Fix ScalarRangePredicateExtractor rule bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarRangePredicateExtractor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarRangePredicateExtractor.java
@@ -61,8 +61,11 @@ public class ScalarRangePredicateExtractor {
                 .map(ValueDescriptor::toScalarOperator).forEach(result::addAll);
 
         ScalarOperator extractExpr = Utils.compoundAnd(Lists.newArrayList(result));
-        predicate = Utils.compoundAnd(Lists.newArrayList(conjuncts));
+        if (extractExpr == null) {
+            return predicate;
+        }
 
+        predicate = Utils.compoundAnd(Lists.newArrayList(conjuncts));
         if (isOnlyOrCompound(predicate)) {
             Set<ColumnRefOperator> c = new HashSet<>(Utils.extractColumnRef(predicate));
             if (c.size() == extractMap.size() &&

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateScanRule.java
@@ -2,6 +2,7 @@
 
 package com.starrocks.sql.optimizer.rule.transformation;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
@@ -49,6 +50,7 @@ public class PushDownPredicateScanRule extends TransformationRule {
         ScalarRangePredicateExtractor rangeExtractor = new ScalarRangePredicateExtractor();
         predicates = rangeExtractor.rewriteOnlyColumn(Utils.compoundAnd(Utils.extractConjuncts(predicates)
                 .stream().map(rangeExtractor::rewriteOnlyColumn).collect(Collectors.toList())));
+        Preconditions.checkState(predicates != null);
         predicates = scalarOperatorRewriter.rewrite(predicates,
                 ScalarOperatorRewriter.DEFAULT_REWRITE_SCAN_PREDICATE_RULES);
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -418,6 +418,16 @@ public class PlanFragmentTest extends PlanTestBase {
                 "  |----2:EXCHANGE\n" +
                 "  |    \n" +
                 "  0:OlapScanNode"));
+
+        sql = "select * from t0 join test_all_type on NOT 69 IS NOT NULL where true";
+        planFragment = getFragmentPlan(sql);
+        Assert.assertTrue(planFragment.contains("  3:CROSS JOIN\n" +
+                "  |  cross join:\n" +
+                "  |  predicates is NULL.\n" +
+                "  |  \n" +
+                "  |----2:EXCHANGE\n" +
+                "  |    \n" +
+                "  0:EMPTYSET"));
     }
 
     @Test
@@ -4778,5 +4788,12 @@ public class PlanFragmentTest extends PlanTestBase {
                 "  |  join op: INNER JOIN (PARTITIONED)"));
         Assert.assertTrue(plan.contains("9:HASH JOIN\n" +
                 "  |    |  join op: INNER JOIN (PARTITIONED)"));
+    }
+
+    @Test
+    public void testArrayFunctionFilter() throws Exception {
+        String sql = "select * from test_array where array_length(c1) between 2 and 3;";
+        String plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("PREDICATES: array_length(2: c1) >= 2, array_length(2: c1) <= 3"));
     }
 }


### PR DESCRIPTION
https://github.com/StarRocks/starrocks/pull/1796 This pr introduced two bugs:

1. Not handle predicates have functions:
```
select * from test_array where array_length(c1) between 2 and 3;
```
In PushDownPredicateScanRule, we should use `rangeExtractor.rewriteAll`, not `rangeExtractor.rewriteOnlyColumn`

2.Not handle true or null predicate:

```
select * from t0 join test_all_type on NOT 69 IS NOT NULL where true
```
In ScalarRangePredicateExtractor, if extractExpr is null, we should return origin predicate, not null

