### PR TITLE
Optimize the return type of some date functions to optimize group by key

### DIFF
--- a/be/src/exec/vectorized/aggregate/agg_hash_map.h
+++ b/be/src/exec/vectorized/aggregate/agg_hash_map.h
@@ -41,6 +41,8 @@ using SliceAggHashMap = phmap::flat_hash_map<Slice, AggDataPtr, SliceHashWithSee
 // ==================
 // one level fixed size slice hash map
 template <PhmapSeed seed>
+using FixedSize4SliceAggHashMap = phmap::flat_hash_map<SliceKey4, AggDataPtr, FixedSizeSliceKeyHash<SliceKey4, seed>>;
+template <PhmapSeed seed>
 using FixedSize8SliceAggHashMap = phmap::flat_hash_map<SliceKey8, AggDataPtr, FixedSizeSliceKeyHash<SliceKey8, seed>>;
 template <PhmapSeed seed>
 using FixedSize16SliceAggHashMap =

--- a/be/src/exec/vectorized/aggregate/agg_hash_set.h
+++ b/be/src/exec/vectorized/aggregate/agg_hash_set.h
@@ -36,6 +36,8 @@ using SliceAggHashSet =
 // ==================
 // one level fixed size slice hash set
 template <PhmapSeed seed>
+using FixedSize4SliceAggHashSet = phmap::flat_hash_set<SliceKey4, FixedSizeSliceKeyHash<SliceKey4, seed>>;
+template <PhmapSeed seed>
 using FixedSize8SliceAggHashSet = phmap::flat_hash_set<SliceKey8, FixedSizeSliceKeyHash<SliceKey8, seed>>;
 template <PhmapSeed seed>
 using FixedSize16SliceAggHashSet = phmap::flat_hash_set<SliceKey16, FixedSizeSliceKeyHash<SliceKey16, seed>>;

--- a/be/src/exec/vectorized/aggregate/agg_hash_variant.h
+++ b/be/src/exec/vectorized/aggregate/agg_hash_variant.h
@@ -42,8 +42,10 @@ namespace starrocks::vectorized {
     M(phase2_slice)                   \
     M(phase2_slice_two_level)         \
     M(phase2_int32_two_level)         \
+    M(phase1_slice_fx4)               \
     M(phase1_slice_fx8)               \
     M(phase1_slice_fx16)              \
+    M(phase2_slice_fx4)               \
     M(phase2_slice_fx8)               \
     M(phase2_slice_fx16)
 
@@ -128,8 +130,10 @@ namespace starrocks::vectorized {
     M(phase2_null_string)        \
     M(phase2_slice_two_level)    \
     M(phase2_int32_two_level)    \
+    M(phase1_slice_fx4)          \
     M(phase1_slice_fx8)          \
     M(phase1_slice_fx16)         \
+    M(phase2_slice_fx4)          \
     M(phase2_slice_fx8)          \
     M(phase2_slice_fx16)
 
@@ -200,6 +204,8 @@ using Int32TwoLevelAggHashMapWithOneNumberKey = AggHashMapWithOneNumberKey<TYPE_
 
 // fixed slice key type.
 template <PhmapSeed seed>
+using SerializedKeyFixedSize4AggHashMap = AggHashMapWithSerializedKeyFixedSize<FixedSize4SliceAggHashMap<seed>>;
+template <PhmapSeed seed>
 using SerializedKeyFixedSize8AggHashMap = AggHashMapWithSerializedKeyFixedSize<FixedSize8SliceAggHashMap<seed>>;
 template <PhmapSeed seed>
 using SerializedKeyFixedSize16AggHashMap = AggHashMapWithSerializedKeyFixedSize<FixedSize16SliceAggHashMap<seed>>;
@@ -246,6 +252,7 @@ struct HashMapVariant {
         phase1_slice_two_level,
         phase1_int32_two_level,
 
+        phase1_slice_fx4,
         phase1_slice_fx8,
         phase1_slice_fx16,
 
@@ -277,6 +284,7 @@ struct HashMapVariant {
         phase2_slice_two_level,
         phase2_int32_two_level,
 
+        phase2_slice_fx4,
         phase2_slice_fx8,
         phase2_slice_fx16,
     };
@@ -314,6 +322,7 @@ struct HashMapVariant {
     std::unique_ptr<SerializedKeyTwoLevelAggHashMap<PhmapSeed1>> phase1_slice_two_level;
     std::unique_ptr<Int32TwoLevelAggHashMapWithOneNumberKey<PhmapSeed1>> phase1_int32_two_level;
 
+    std::unique_ptr<SerializedKeyFixedSize4AggHashMap<PhmapSeed1>> phase1_slice_fx4;
     std::unique_ptr<SerializedKeyFixedSize8AggHashMap<PhmapSeed1>> phase1_slice_fx8;
     std::unique_ptr<SerializedKeyFixedSize16AggHashMap<PhmapSeed1>> phase1_slice_fx16;
 
@@ -349,6 +358,7 @@ struct HashMapVariant {
     std::unique_ptr<SerializedKeyTwoLevelAggHashMap<PhmapSeed2>> phase2_slice_two_level;
     std::unique_ptr<Int32TwoLevelAggHashMapWithOneNumberKey<PhmapSeed2>> phase2_int32_two_level;
 
+    std::unique_ptr<SerializedKeyFixedSize4AggHashMap<PhmapSeed2>> phase2_slice_fx4;
     std::unique_ptr<SerializedKeyFixedSize8AggHashMap<PhmapSeed2>> phase2_slice_fx8;
     std::unique_ptr<SerializedKeyFixedSize16AggHashMap<PhmapSeed2>> phase2_slice_fx16;
 
@@ -469,6 +479,9 @@ using Int32TwoLevelAggHashSetOfOneNumberKey = AggHashSetOfOneNumberKey<TYPE_INT,
 
 // For fixed slice type.
 template <PhmapSeed seed>
+using SerializedKeyAggHashSetFixedSize4 = AggHashSetOfSerializedKeyFixedSize<FixedSize4SliceAggHashSet<seed>>;
+
+template <PhmapSeed seed>
 using SerializedKeyAggHashSetFixedSize8 = AggHashSetOfSerializedKeyFixedSize<FixedSize8SliceAggHashSet<seed>>;
 
 template <PhmapSeed seed>
@@ -539,8 +552,10 @@ struct HashSetVariant {
         phase2_slice_two_level,
         phase2_int32_two_level,
 
+        phase1_slice_fx4,
         phase1_slice_fx8,
         phase1_slice_fx16,
+        phase2_slice_fx4,
         phase2_slice_fx8,
         phase2_slice_fx16,
     };
@@ -614,8 +629,10 @@ struct HashSetVariant {
     std::unique_ptr<SerializedTwoLevelKeyAggHashSet<PhmapSeed2>> phase2_slice_two_level;
     std::unique_ptr<Int32TwoLevelAggHashSetOfOneNumberKey<PhmapSeed2>> phase2_int32_two_level;
 
+    std::unique_ptr<SerializedKeyAggHashSetFixedSize4<PhmapSeed1>> phase1_slice_fx4;
     std::unique_ptr<SerializedKeyAggHashSetFixedSize8<PhmapSeed1>> phase1_slice_fx8;
     std::unique_ptr<SerializedKeyAggHashSetFixedSize16<PhmapSeed1>> phase1_slice_fx16;
+    std::unique_ptr<SerializedKeyAggHashSetFixedSize4<PhmapSeed2>> phase2_slice_fx4;
     std::unique_ptr<SerializedKeyAggHashSetFixedSize8<PhmapSeed2>> phase2_slice_fx8;
     std::unique_ptr<SerializedKeyAggHashSetFixedSize16<PhmapSeed2>> phase2_slice_fx16;
 

--- a/be/src/exprs/vectorized/time_functions.cpp
+++ b/be/src/exprs/vectorized/time_functions.cpp
@@ -305,6 +305,16 @@ DEFINE_UNARY_FN_WITH_IMPL(yearImpl, v) {
 
 DEFINE_TIME_UNARY_FN(year, TYPE_DATETIME, TYPE_INT);
 
+// year
+// return type: INT16
+DEFINE_UNARY_FN_WITH_IMPL(yearV2Impl, v) {
+    int y, m, d;
+    ((DateValue)v).to_date(&y, &m, &d);
+    return y;
+}
+
+DEFINE_TIME_UNARY_FN(yearV2, TYPE_DATETIME, TYPE_SMALLINT);
+
 // quarter
 DEFINE_UNARY_FN_WITH_IMPL(quarterImpl, v) {
     int y, m, d;
@@ -321,6 +331,15 @@ DEFINE_UNARY_FN_WITH_IMPL(monthImpl, v) {
 }
 DEFINE_TIME_UNARY_FN(month, TYPE_DATETIME, TYPE_INT);
 
+// month
+// return type: INT8
+DEFINE_UNARY_FN_WITH_IMPL(monthV2Impl, v) {
+    int y, m, d;
+    ((DateValue)v).to_date(&y, &m, &d);
+    return m;
+}
+DEFINE_TIME_UNARY_FN(monthV2, TYPE_DATETIME, TYPE_TINYINT);
+
 // day
 DEFINE_UNARY_FN_WITH_IMPL(dayImpl, v) {
     int y, m, d;
@@ -328,6 +347,15 @@ DEFINE_UNARY_FN_WITH_IMPL(dayImpl, v) {
     return d;
 }
 DEFINE_TIME_UNARY_FN(day, TYPE_DATETIME, TYPE_INT);
+
+// day
+// return type: INT8
+DEFINE_UNARY_FN_WITH_IMPL(dayV2Impl, v) {
+    int y, m, d;
+    ((DateValue)v).to_date(&y, &m, &d);
+    return d;
+}
+DEFINE_TIME_UNARY_FN(dayV2, TYPE_DATETIME, TYPE_TINYINT);
 
 // hour of the day
 DEFINE_UNARY_FN_WITH_IMPL(hourImpl, v) {
@@ -337,6 +365,14 @@ DEFINE_UNARY_FN_WITH_IMPL(hourImpl, v) {
 }
 DEFINE_TIME_UNARY_FN(hour, TYPE_DATETIME, TYPE_INT);
 
+// hour of the day
+DEFINE_UNARY_FN_WITH_IMPL(hourV2Impl, v) {
+    int hour1, mintue1, second1, usec1;
+    v.to_time(&hour1, &mintue1, &second1, &usec1);
+    return hour1;
+}
+DEFINE_TIME_UNARY_FN(hourV2, TYPE_DATETIME, TYPE_TINYINT);
+
 // minute of the hour
 DEFINE_UNARY_FN_WITH_IMPL(minuteImpl, v) {
     int hour1, mintue1, second1, usec1;
@@ -345,6 +381,14 @@ DEFINE_UNARY_FN_WITH_IMPL(minuteImpl, v) {
 }
 DEFINE_TIME_UNARY_FN(minute, TYPE_DATETIME, TYPE_INT);
 
+// minute of the hour
+DEFINE_UNARY_FN_WITH_IMPL(minuteV2Impl, v) {
+    int hour1, mintue1, second1, usec1;
+    v.to_time(&hour1, &mintue1, &second1, &usec1);
+    return mintue1;
+}
+DEFINE_TIME_UNARY_FN(minuteV2, TYPE_DATETIME, TYPE_TINYINT);
+
 // second of the minute
 DEFINE_UNARY_FN_WITH_IMPL(secondImpl, v) {
     int hour1, mintue1, second1, usec1;
@@ -352,6 +396,14 @@ DEFINE_UNARY_FN_WITH_IMPL(secondImpl, v) {
     return second1;
 }
 DEFINE_TIME_UNARY_FN(second, TYPE_DATETIME, TYPE_INT);
+
+// second of the minute
+DEFINE_UNARY_FN_WITH_IMPL(secondV2Impl, v) {
+    int hour1, mintue1, second1, usec1;
+    v.to_time(&hour1, &mintue1, &second1, &usec1);
+    return second1;
+}
+DEFINE_TIME_UNARY_FN(secondV2, TYPE_DATETIME, TYPE_TINYINT);
 
 // day_of_week
 DEFINE_UNARY_FN_WITH_IMPL(day_of_weekImpl, v) {

--- a/be/src/exprs/vectorized/time_functions.h
+++ b/be/src/exprs/vectorized/time_functions.h
@@ -11,6 +11,7 @@
 
 namespace starrocks {
 namespace vectorized {
+// TODO:
 class TimeFunctions {
 public:
     /**
@@ -45,6 +46,12 @@ public:
 
     /**
      * @paramType columns: [TimestampColumn]
+     * @return Int16Column
+     */
+    DEFINE_VECTORIZED_FN(yearV2);
+
+    /**
+     * @paramType columns: [TimestampColumn]
      * @return IntColumn
      */
     DEFINE_VECTORIZED_FN(quarter);
@@ -56,6 +63,14 @@ public:
      * @return IntColumn    Code of a month in a year: [1, 12].
      */
     DEFINE_VECTORIZED_FN(month);
+
+    /**
+     * Get month of the timestamp.
+     * @param context
+     * @param columns [TimestampColumn] Columns that hold timestamps.
+     * @return Int8Column Code of a month in a year: [1, 12].
+     */
+    DEFINE_VECTORIZED_FN(monthV2);
 
     /**
      * Get day of week of the timestamp.
@@ -79,6 +94,14 @@ public:
      * @return  IntColumn Day of the week:
      */
     DEFINE_VECTORIZED_FN(day);
+
+    /**
+     * Get day of the timestamp.
+     * @param context
+     * @param columns [TimestampColumn] Columns that hold timestamps.
+     * @return  Int8Column Day of the week:
+     */
+    DEFINE_VECTORIZED_FN(dayV2);
 
     /**
      * Get day of the year.
@@ -105,6 +128,14 @@ public:
     DEFINE_VECTORIZED_FN(hour);
 
     /**
+     * Get hour of the day
+     * @param context
+     * @param columns [TimestampColumn] Columns that hold timestamps.
+     * @return  Int8Column hour of the day:
+     */
+    DEFINE_VECTORIZED_FN(hourV2);
+
+    /**
      * Get minute of the hour
      * @param context
      * @param columns [TimestampColumn] Columns that hold timestamps.
@@ -113,12 +144,28 @@ public:
     DEFINE_VECTORIZED_FN(minute);
 
     /**
+     * Get minute of the hour
+     * @param context
+     * @param columns [TimestampColumn] Columns that hold timestamps.
+     * @return  Int8Column minute of the hour:
+     */
+    DEFINE_VECTORIZED_FN(minuteV2);
+
+    /**
      * Get second of the minute
      * @param context
      * @param columns [TimestampColumn] Columns that hold timestamps.
      * @return  IntColumn second of the minute:
      */
     DEFINE_VECTORIZED_FN(second);
+
+    /**
+     * Get second of the minute
+     * @param context
+     * @param columns [TimestampColumn] Columns that hold timestamps.
+     * @return  IntColumn second of the minute:
+     */
+    DEFINE_VECTORIZED_FN(secondV2);
 
     /*
      * Called by datetime_trunc

--- a/be/src/runtime/date_value.hpp
+++ b/be/src/runtime/date_value.hpp
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "runtime/date_value.hpp"
+#include "runtime/date_value.h"
 #include "runtime/timestamp_value.h"
 
 namespace starrocks::vectorized {

--- a/gensrc/script/vectorized/vectorized_functions.py
+++ b/gensrc/script/vectorized/vectorized_functions.py
@@ -254,20 +254,20 @@ vectorized_functions = [
      'StringFunctions::parse_url_prepare', 'StringFunctions::parse_url_close'],
 
     # 50xxx: timestamp functions
-    [50010, 'year', 'INT', ['DATETIME'], 'TimeFunctions::year'],
-    [50020, 'month', 'INT', ['DATETIME'], 'TimeFunctions::month'],
+    [50010, 'year', 'SMALLINT', ['DATETIME'], 'TimeFunctions::yearV2'],
+    [50020, 'month', 'TINYINT', ['DATETIME'], 'TimeFunctions::monthV2'],
     [50030, 'quarter', 'INT', ['DATETIME'], 'TimeFunctions::quarter'],
     [50040, 'dayofweek', 'INT', ['DATETIME'], 'TimeFunctions::day_of_week'],
     [50050, 'to_date', 'DATE', ['DATETIME'], 'TimeFunctions::to_date'],
     [50051, 'date', 'DATE', ['DATETIME'], 'TimeFunctions::to_date'],
     [50060, 'dayofmonth', 'INT', ['DATETIME'], 'TimeFunctions::day'],
-    [50061, 'day', 'INT', ['DATETIME'], 'TimeFunctions::day'],
+    [50061, 'day', 'TINYINT', ['DATETIME'], 'TimeFunctions::dayV2'],
     [50062, 'dayofyear', 'INT', ['DATETIME'], 'TimeFunctions::day_of_year'],
     [50063, 'weekofyear', 'INT', ['DATETIME'], 'TimeFunctions::week_of_year'],
 
-    [50070, 'hour', 'INT', ['DATETIME'], 'TimeFunctions::hour'],
-    [50080, 'minute', 'INT', ['DATETIME'], 'TimeFunctions::minute'],
-    [50090, 'second', 'INT', ['DATETIME'], 'TimeFunctions::second'],
+    [50070, 'hour', 'TINYINT', ['DATETIME'], 'TimeFunctions::hourV2'],
+    [50080, 'minute', 'TINYINT', ['DATETIME'], 'TimeFunctions::minuteV2'],
+    [50090, 'second', 'TINYINT', ['DATETIME'], 'TimeFunctions::secondV2'],
 
     [50110, 'years_add', 'DATETIME', ['DATETIME', 'INT'], 'TimeFunctions::years_add'],
     [50111, 'years_sub', 'DATETIME', ['DATETIME', 'INT'], 'TimeFunctions::years_sub'],


### PR DESCRIPTION
1. Optimize function for year/month/day/hour/minute/second
2. To be compatible with grayscale upgrades, we are not removing the old implementation for now

For some time function, we don't need to optimize the separate year because the to_date function is currently inlined, so some of the seemingly redundant calculations have already been optimized away.

I compared the assembly code of the separate implementation and the current implementation and they are identical.

year: https://godbolt.org/z/d94joTqE5
day: https://godbolt.org/z/h9K7MP97b

We can't verify the effect of this optimization yet, because currently, our FE plan is that the return value of year(not-nullable(input)) is nullable, and we need to make FE support this optimization