### PR TITLE
Replace boost::thread with std::thread

### DIFF
--- a/be/src/runtime/result_buffer_mgr.cpp
+++ b/be/src/runtime/result_buffer_mgr.cpp
@@ -32,12 +32,6 @@
 
 namespace starrocks {
 
-//std::size_t hash_value(const TUniqueId& fragment_id) {
-//    uint32_t value = RawValue::get_hash_value(&fragment_id.lo, TypeDescriptor(TYPE_BIGINT), 0);
-//    value = RawValue::get_hash_value(&fragment_id.hi, TypeDescriptor(TYPE_BIGINT), value);
-//    return value;
-//}
-
 ResultBufferMgr::ResultBufferMgr() {
     // Each BufferControlBlock has a limited queue size of 1024, it's not needed to count the
     // actual size of all BufferControlBlock.
@@ -53,8 +47,7 @@ ResultBufferMgr::~ResultBufferMgr() {
 }
 
 Status ResultBufferMgr::init() {
-    _cancel_thread =
-            std::make_unique<boost::thread>(std::bind<void>(std::mem_fn(&ResultBufferMgr::cancel_thread), this));
+    _cancel_thread = std::make_unique<std::thread>(std::bind<void>(std::mem_fn(&ResultBufferMgr::cancel_thread), this));
     return Status::OK();
 }
 

--- a/be/src/runtime/result_buffer_mgr.h
+++ b/be/src/runtime/result_buffer_mgr.h
@@ -19,16 +19,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef STARROCKS_BE_RUNTIME_RESULT_BUFFER_MGR_H
-#define STARROCKS_BE_RUNTIME_RESULT_BUFFER_MGR_H
+#pragma once
 
-#include <boost/thread/thread.hpp>
-#include <boost/unordered_map.hpp>
 #include <map>
+#include <thread>
+#include <unordered_map>
 #include <vector>
 
 #include "common/status.h"
 #include "gen_cpp/Types_types.h"
+#include "util/hash_util.hpp"
 #include "util/uid_util.h"
 
 namespace starrocks {
@@ -61,7 +61,7 @@ public:
     Status cancel_at_time(time_t cancel_time, const TUniqueId& query_id);
 
 private:
-    typedef boost::unordered_map<TUniqueId, std::shared_ptr<BufferControlBlock>> BufferMap;
+    typedef std::unordered_map<TUniqueId, std::shared_ptr<BufferControlBlock>> BufferMap;
     typedef std::map<time_t, std::vector<TUniqueId>> TimeoutMap;
 
     std::shared_ptr<BufferControlBlock> find_control_block(const TUniqueId& query_id);
@@ -83,11 +83,6 @@ private:
     // cancel time maybe equal, so use one list
     TimeoutMap _timeout_map;
 
-    std::unique_ptr<boost::thread> _cancel_thread;
+    std::unique_ptr<std::thread> _cancel_thread;
 };
-
-// TUniqueId hash function used for boost::unordered_map
-std::size_t hash_value(const TUniqueId& fragment_id);
 } // namespace starrocks
-
-#endif

--- a/be/src/util/runtime_profile.cpp
+++ b/be/src/util/runtime_profile.cpp
@@ -21,7 +21,8 @@
 
 #include "util/runtime_profile.h"
 
-#include <boost/thread/thread.hpp>
+#include <boost/date_time/posix_time/posix_time_types.hpp>
+#include <boost/thread/thread_time.hpp>
 #include <iomanip>
 #include <iostream>
 #include <memory>
@@ -661,7 +662,7 @@ void RuntimeProfile::add_bucketing_counters(const std::string& name, const std::
 
     if (_s_periodic_counter_update_state.update_thread == nullptr) {
         _s_periodic_counter_update_state.update_thread =
-                std::make_unique<boost::thread>(&RuntimeProfile::periodic_counter_update_loop);
+                std::make_unique<std::thread>(&RuntimeProfile::periodic_counter_update_loop);
     }
 
     BucketCountersInfo info{.src_counter = src_counter, .num_sampled = 0};
@@ -689,7 +690,7 @@ void RuntimeProfile::register_periodic_counter(Counter* src_counter, SampleFn sa
 
     if (_s_periodic_counter_update_state.update_thread == nullptr) {
         _s_periodic_counter_update_state.update_thread =
-                std::make_unique<boost::thread>(&RuntimeProfile::periodic_counter_update_loop);
+                std::make_unique<std::thread>(&RuntimeProfile::periodic_counter_update_loop);
     }
 
     switch (type) {

--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -19,16 +19,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef STARROCKS_BE_SRC_COMMON_UTIL_RUNTIME_PROFILE_H
-#define STARROCKS_BE_SRC_COMMON_UTIL_RUNTIME_PROFILE_H
+#pragma once
 
 #include <sys/resource.h>
 #include <sys/time.h> // NOLINT
 
 #include <atomic>
-#include <boost/thread/thread.hpp>
 #include <functional>
 #include <iostream>
+#include <thread>
 #include <utility>
 
 #include "common/compiler_util.h"
@@ -549,7 +548,7 @@ private:
         volatile bool _done{false};
 
         // Thread performing asynchronous updates.
-        std::unique_ptr<boost::thread> update_thread;
+        std::unique_ptr<std::thread> update_thread;
 
         // A map of the dst (rate) counter to the src counter and elapsed time.
         typedef std::map<Counter*, RateCounterInfo> RateCounterMap;
@@ -688,5 +687,3 @@ private:
 };
 
 } // namespace starrocks
-
-#endif

--- a/be/src/util/thrift_server.cpp
+++ b/be/src/util/thrift_server.cpp
@@ -32,10 +32,10 @@
 #include <thrift/transport/TServerSocket.h>
 #include <thrift/transport/TSocket.h>
 
-#include <boost/thread.hpp>
 #include <condition_variable>
 #include <memory>
 #include <sstream>
+#include <thread>
 #include <utility>
 
 namespace starrocks {
@@ -101,7 +101,7 @@ Status ThriftServer::ThriftServerEventProcessor::start_and_wait_for_server() {
     _thrift_server->_started = false;
 
     _thrift_server->_server_thread =
-            std::make_unique<boost::thread>(&ThriftServer::ThriftServerEventProcessor::supervise, this);
+            std::make_unique<std::thread>(&ThriftServer::ThriftServerEventProcessor::supervise, this);
 
     // Loop protects against spurious wakeup. Locks provide necessary fences to ensure
     // visibility.

--- a/be/src/util/thrift_server.h
+++ b/be/src/util/thrift_server.h
@@ -19,14 +19,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef STARROCKS_BE_SRC_COMMON_UTIL_THRIFT_SERVER_H
-#define STARROCKS_BE_SRC_COMMON_UTIL_THRIFT_SERVER_H
+#pragma once
 
 #include <thrift/TProcessor.h>
 #include <thrift/server/TServer.h>
 
-#include <boost/thread.hpp>
-#include <boost/unordered_map.hpp>
+#include <thread>
+#include <unordered_map>
 
 #include "common/status.h"
 #include "util/metrics.h"
@@ -121,7 +120,7 @@ private:
     const std::string _name;
 
     // Thread that runs the TNonblockingServer::serve loop
-    std::unique_ptr<boost::thread> _server_thread;
+    std::unique_ptr<std::thread> _server_thread;
 
     // Thrift housekeeping
     std::unique_ptr<apache::thrift::server::TServer> _server;
@@ -135,7 +134,7 @@ private:
 
     // Map of active session keys to shared_ptr containing that key; when a key is
     // removed it is automatically freed.
-    typedef boost::unordered_map<SessionKey*, std::shared_ptr<SessionKey> > SessionKeySet;
+    typedef std::unordered_map<SessionKey*, std::shared_ptr<SessionKey> > SessionKeySet;
     SessionKeySet _session_keys;
 
     // True if metrics are enabled
@@ -154,5 +153,3 @@ private:
 };
 
 } // namespace starrocks
-
-#endif


### PR DESCRIPTION
This will reduce about 900 including headers when compiling some files.