### PR TITLE
Avoid get invalid value at compute overlap percent

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticRangeValues.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticRangeValues.java
@@ -83,7 +83,7 @@ public class StatisticRangeValues {
         // lengthOfIntersect of char/varchar is infinite
         if (isInfinite(lengthOfIntersect)) {
             if (isFinite(this.distinctValues) && isFinite(other.distinctValues)) {
-                return min(other.distinctValues / this.distinctValues, 1);
+                return min(other.distinctValues / max(1, this.distinctValues), 1);
             }
             return StatisticsEstimateCoefficient.OVERLAP_INFINITE_RANGE_FILTER_COEFFICIENT;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -142,6 +142,17 @@ public class ReplayFromDumpTest {
     }
 
     @Test
+    public void testTPCH17WithUse2AggStage() throws Exception {
+        QueryDumpInfo queryDumpInfo = getDumpInfoFromJson(getDumpInfoFromFile("query_dump/tpch17"));
+        SessionVariable sessionVariable = queryDumpInfo.getSessionVariable();
+        sessionVariable.setNewPlanerAggStage(2);
+        Pair<QueryDumpInfo, String> replayPair =
+                getCostPlanFragment(getDumpInfoFromFile("query_dump/tpch17"), sessionVariable);
+        Assert.assertTrue(replayPair.second.contains("2:AGGREGATE (update serialize)"));
+        Assert.assertTrue(replayPair.second.contains("4:AGGREGATE (merge finalize)"));
+    }
+
+    @Test
     public void testTPCH20() throws Exception {
         compareDumpWithOriginTest("tpchcost/q20");
     }

--- a/fe/fe-core/src/test/resources/sql/query_dump/tpch17.json
+++ b/fe/fe-core/src/test/resources/sql/query_dump/tpch17.json
@@ -1,0 +1,32 @@
+{
+  "statement":" select sum(l_extendedprice) / 7.0 as avg_yearly from lineitem, part where p_partkey \u003d l_partkey and p_brand \u003d \u0027Brand#23\u0027 and p_container \u003d \u0027MED BOX\u0027 and l_quantity \u003c ( select 0.2 * avg(l_quantity) from lineitem where l_partkey \u003d p_partkey );\n",
+  "table_meta":{
+    "test.part":"CREATE TABLE `part` (\n  `P_PARTKEY` int(11) NOT NULL COMMENT \"\",\n  `P_NAME` varchar(55) NOT NULL COMMENT \"\",\n  `P_MFGR` char(25) NOT NULL COMMENT \"\",\n  `P_BRAND` char(10) NOT NULL COMMENT \"\",\n  `P_TYPE` varchar(25) NOT NULL COMMENT \"\",\n  `P_SIZE` int(11) NOT NULL COMMENT \"\",\n  `P_CONTAINER` char(10) NOT NULL COMMENT \"\",\n  `P_RETAILPRICE` double NOT NULL COMMENT \"\",\n  `P_COMMENT` varchar(23) NOT NULL COMMENT \"\",\n  `PAD` char(1) NOT NULL COMMENT \"\"\n) ENGINE\u003dOLAP \nDUPLICATE KEY(`P_PARTKEY`)\nCOMMENT \"OLAP\"\nDISTRIBUTED BY HASH(`P_PARTKEY`) BUCKETS 10 \nPROPERTIES (\n\"replication_num\" \u003d \"1\",\n\"in_memory\" \u003d \"false\",\n\"storage_format\" \u003d \"DEFAULT\"\n);",
+    "test.lineitem":"CREATE TABLE `lineitem` (\n  `L_ORDERKEY` int(11) NOT NULL COMMENT \"\",\n  `L_PARTKEY` int(11) NOT NULL COMMENT \"\",\n  `L_SUPPKEY` int(11) NOT NULL COMMENT \"\",\n  `L_LINENUMBER` int(11) NOT NULL COMMENT \"\",\n  `L_QUANTITY` double NOT NULL COMMENT \"\",\n  `L_EXTENDEDPRICE` double NOT NULL COMMENT \"\",\n  `L_DISCOUNT` double NOT NULL COMMENT \"\",\n  `L_TAX` double NOT NULL COMMENT \"\",\n  `L_RETURNFLAG` char(1) NOT NULL COMMENT \"\",\n  `L_LINESTATUS` char(1) NOT NULL COMMENT \"\",\n  `L_SHIPDATE` date NOT NULL COMMENT \"\",\n  `L_COMMITDATE` date NOT NULL COMMENT \"\",\n  `L_RECEIPTDATE` date NOT NULL COMMENT \"\",\n  `L_SHIPINSTRUCT` char(25) NOT NULL COMMENT \"\",\n  `L_SHIPMODE` char(10) NOT NULL COMMENT \"\",\n  `L_COMMENT` varchar(44) NOT NULL COMMENT \"\",\n  `PAD` char(1) NOT NULL COMMENT \"\"\n) ENGINE\u003dOLAP \nDUPLICATE KEY(`L_ORDERKEY`)\nCOMMENT \"OLAP\"\nDISTRIBUTED BY HASH(`L_ORDERKEY`) BUCKETS 20 \nPROPERTIES (\n\"replication_num\" \u003d \"1\",\n\"in_memory\" \u003d \"false\",\n\"storage_format\" \u003d \"DEFAULT\"\n);"
+  },
+  "table_row_count":{
+    "test.lineitem":{
+      "lineitem":96019450
+    },
+    "test.part":{
+      "part":100000
+    }
+  },
+  "session_variables":"{\"runtime_join_filter_push_down_limit\":1024000,\"codegen_level\":0,\"cbo_cte_reuse\":false,\"character_set_connection\":\"utf8\",\"cbo_use_correlated_join_estimate\":true,\"enable_insert_strict\":false,\"enable_filter_unused_columns_in_scan_stage\":false,\"div_precision_increment\":4,\"tx_isolation\":\"REPEATABLE-READ\",\"wait_timeout\":28800,\"auto_increment_increment\":1,\"foreign_key_checks\":true,\"character_set_client\":\"utf8\",\"autocommit\":true,\"enable_column_expr_predicate\":false,\"character_set_results\":\"utf8\",\"parallel_fragment_exec_instance_num\":1,\"max_scan_key_num\":-1,\"enable_global_runtime_filter\":true,\"forward_to_master\":false,\"net_read_timeout\":60,\"streaming_preaggregation_mode\":\"auto\",\"storage_engine\":\"olap\",\"cbo_enable_dp_join_reorder\":true,\"cbo_enable_low_cardinality_optimize\":true,\"tx_visible_wait_timeout\":10,\"cbo_max_reorder_node_use_exhaustive\":4,\"new_planner_optimize_timeout\":3000000,\"force_schedule_local\":false,\"pipeline_dop\":8,\"enable_query_dump\":false,\"cbo_enable_greedy_join_reorder\":true,\"prefer_join_method\":\"broadcast\",\"load_mem_limit\":0,\"sql_select_limit\":9223372036854775807,\"profiling\":false,\"sql_safe_updates\":0,\"enable_pipeline_engine\":true,\"query_cache_type\":0,\"disable_colocate_join\":false,\"max_pushdown_conditions_per_column\":-1,\"enable_vectorized_engine\":true,\"net_write_timeout\":60,\"collation_database\":\"utf8_general_ci\",\"hash_join_push_down_right_table\":true,\"new_planner_agg_stage\":0,\"pipeline_profile_mode\":\"brief\",\"collation_connection\":\"utf8_general_ci\",\"resource_group\":\"normal\",\"enable_new_planner_push_down_join_to_agg\":false,\"broadcast_row_limit\":15000000,\"exec_mem_limit\":2147483648,\"cbo_max_reorder_node_use_dp\":10,\"disable_join_reorder\":false,\"is_report_success\":true,\"enable_groupby_use_output_alias\":false,\"net_buffer_length\":16384,\"transmission_compression_type\":\"LZ4\",\"enable_vectorized_insert\":true,\"interactive_timeout\":3600,\"enable_spilling\":false,\"batch_size\":1024,\"cbo_enable_replicated_join\":true,\"max_allowed_packet\":1048576,\"query_timeout\":10000,\"enable_cbo\":true,\"collation_server\":\"utf8_general_ci\",\"time_zone\":\"CST\",\"max_execution_time\":3000000,\"character_set_server\":\"utf8\",\"cbo_use_nth_exec_plan\":0,\"rewrite_count_distinct_to_bitmap_hll\":true,\"parallel_exchange_instance_num\":-1,\"sql_mode\":34,\"SQL_AUTO_IS_NULL\":false,\"event_scheduler\":\"OFF\",\"disable_streaming_preaggregations\":false}",
+  "column_statistics":{
+    "test.lineitem":{
+      "L_PARTKEY":"[1.0, 200000.0, 0.0, 4.0, 7.455312E7] ESTIMATE",
+      "L_EXTENDEDPRICE":"[904.0, 104199.5, 0.0, 8.0, 1.213776E8] ESTIMATE",
+      "L_QUANTITY":"[1.0, 50.0, 0.0, 8.0, 24000.0] ESTIMATE"
+    },
+    "test.part":{
+      "P_CONTAINER":"[-Infinity, Infinity, 0.0, 0.0, 0.0] ESTIMATE",
+      "P_PARTKEY":"[1.0, 99995.0, 0.0, 0.0, 0.0] ESTIMATE",
+      "P_BRAND":"[-Infinity, Infinity, 0.0, 0.0, 0.0] ESTIMATE"
+    }
+  },
+  "be_number":1,
+  "exception":[
+
+  ]
+}


### PR DESCRIPTION
#1890 

the `min(other.distinctValues / this.distinctValues, 1);`  may get NaN because of distinct value is 0