### PR TITLE
Release page memory earlier to save memory

### DIFF
--- a/be/src/storage/rowset/segment_v2/column_writer.cpp
+++ b/be/src/storage/rowset/segment_v2/column_writer.cpp
@@ -355,16 +355,6 @@ ScalarColumnWriter::ScalarColumnWriter(const ColumnWriterOptions& opts, std::uni
     DCHECK(wblock != nullptr);
 }
 
-ScalarColumnWriter::~ScalarColumnWriter() {
-    // delete all pages
-    Page* page = _pages.head;
-    while (page != nullptr) {
-        Page* next_page = page->next;
-        delete page;
-        page = next_page;
-    }
-}
-
 Status ScalarColumnWriter::init() {
     RETURN_IF_ERROR(get_block_compression_codec(_opts.meta->compression(), &_compress_codec));
 
@@ -459,7 +449,9 @@ Status ScalarColumnWriter::write_data() {
     Page* page = _pages.head;
     while (page != nullptr) {
         RETURN_IF_ERROR(_write_data_page(page));
+        Page* last_page = page;
         page = page->next;
+        delete last_page;
     }
     return Status::OK();
 }

--- a/be/src/storage/rowset/segment_v2/column_writer.cpp
+++ b/be/src/storage/rowset/segment_v2/column_writer.cpp
@@ -355,6 +355,16 @@ ScalarColumnWriter::ScalarColumnWriter(const ColumnWriterOptions& opts, std::uni
     DCHECK(wblock != nullptr);
 }
 
+ScalarColumnWriter::~ScalarColumnWriter() {
+    // delete all pages
+    Page* page = _pages.head;
+    while (page != nullptr) {
+        Page* next_page = page->next;
+        delete page;
+        page = next_page;
+    }
+}
+
 Status ScalarColumnWriter::init() {
     RETURN_IF_ERROR(get_block_compression_codec(_opts.meta->compression(), &_compress_codec));
 
@@ -452,6 +462,7 @@ Status ScalarColumnWriter::write_data() {
         Page* last_page = page;
         page = page->next;
         delete last_page;
+        _pages.head = page;
     }
     return Status::OK();
 }

--- a/be/src/storage/rowset/segment_v2/column_writer.h
+++ b/be/src/storage/rowset/segment_v2/column_writer.h
@@ -148,6 +148,8 @@ class ScalarColumnWriter final : public ColumnWriter {
 public:
     ScalarColumnWriter(const ColumnWriterOptions& opts, std::unique_ptr<Field> field, fs::WritableBlock* output_file);
 
+    ~ScalarColumnWriter() override;
+
     Status init() override;
 
     Status append(const vectorized::Column& column) override;

--- a/be/src/storage/rowset/segment_v2/column_writer.h
+++ b/be/src/storage/rowset/segment_v2/column_writer.h
@@ -148,8 +148,6 @@ class ScalarColumnWriter final : public ColumnWriter {
 public:
     ScalarColumnWriter(const ColumnWriterOptions& opts, std::unique_ptr<Field> field, fs::WritableBlock* output_file);
 
-    ~ScalarColumnWriter() override;
-
     Status init() override;
 
     Status append(const vectorized::Column& column) override;


### PR DESCRIPTION
ColumnWriter release the memory after flushing all pages. These pages occupied memory. 
The pull request changes the memory release strategy and releases page memory earlier.