### PR TITLE
fix the bug of hook calloc

### DIFF
--- a/be/src/service/mem_hook.cpp
+++ b/be/src/service/mem_hook.cpp
@@ -219,6 +219,12 @@ void* my_realloc(void* p, size_t size) __THROW {
 
 // calloc
 void* my_calloc(size_t n, size_t size) __THROW {
+    // If size is zero, the behavior is implementation defined (null pointer may be returned
+    // or some non-null pointer may be returned that may not be used to access storage)
+    if (UNLIKELY(size == 0)) {
+        return nullptr;
+    }
+
     void* ptr = tc_calloc(n, size);
     MEMORY_CONSUME_PTR(ptr);
     return ptr;

--- a/be/test/column/bytes_test.cpp
+++ b/be/test/column/bytes_test.cpp
@@ -200,7 +200,7 @@ TEST(BytesTest, test_hook_calloc) {
         if (size == 0) {
             ASSERT_TRUE(ptr == nullptr);
         } else {
-            cfree(ptr);
+            free(ptr);
         }
         after = g_mem_usage;
         ASSERT_EQ(before, after);

--- a/be/test/column/bytes_test.cpp
+++ b/be/test/column/bytes_test.cpp
@@ -196,8 +196,12 @@ TEST(BytesTest, test_hook_calloc) {
         size = rand() % (1024 * 1024);
         count = rand() % 10;
         before = g_mem_usage;
-        ptr = calloc(size, count);
-        cfree(ptr);
+        ptr = calloc(count, size);
+        if (size == 0) {
+            ASSERT_TRUE(ptr == nullptr);
+        } else {
+            cfree(ptr);
+        }
         after = g_mem_usage;
         ASSERT_EQ(before, after);
     }
@@ -205,7 +209,7 @@ TEST(BytesTest, test_hook_calloc) {
     // alloc 0
     before = g_mem_usage;
     ptr = calloc(0, 0);
-    cfree(ptr);
+    ASSERT_TRUE(ptr == nullptr);
     after = g_mem_usage;
     ASSERT_EQ(before, after);
 }


### PR DESCRIPTION
https://en.cppreference.com/w/c/memory/calloc

// If size is zero, the behavior is implementation defined (null pointer may be returned
// or some non-null pointer may be returned that may not be used to access storage)

cfree is obsoleted and replaced by free