### PR TITLE
[cherry-pick] Fix lazy materialize error in nullable dict column (#1904)

### DIFF
--- a/be/src/storage/rowset/segment_v2/dictcode_column_iterator.cpp
+++ b/be/src/storage/rowset/segment_v2/dictcode_column_iterator.cpp
@@ -2,6 +2,7 @@
 
 #include "storage/rowset/segment_v2/dictcode_column_iterator.h"
 
+#include "column/column_helper.h"
 #include "storage/rowset/segment_v2/scalar_column_iterator.h"
 
 namespace starrocks::segment_v2 {
@@ -68,6 +69,14 @@ auto GlobalDictCodeColumnIterator::_get_local_dict_col_container(Column* column)
         dict_column = down_cast<LowCardDictColumn*>(column);
     }
     return dict_column->get_data();
+}
+
+void GlobalDictCodeColumnIterator::_acquire_null_data(Column* global_dict_column, Column* local_dict_column) {
+    if (_opts.is_nullable) {
+        auto dst_column = down_cast<vectorized::NullableColumn*>(global_dict_column);
+        auto src_column = down_cast<vectorized::NullableColumn*>(local_dict_column);
+        dst_column->null_column_data() = std::move(src_column->null_column_data());
+    }
 }
 
 } // namespace starrocks::segment_v2

--- a/be/src/storage/rowset/segment_v2/dictcode_column_iterator.h
+++ b/be/src/storage/rowset/segment_v2/dictcode_column_iterator.h
@@ -90,6 +90,7 @@ public:
         RETURN_IF_ERROR(_col_iter->fetch_dict_codes_by_rowid(rowids, size, _local_dict_code_col.get()));
         const auto& container = _get_local_dict_col_container(_local_dict_code_col.get());
         RETURN_IF_ERROR(decode_dict_codes(container.data(), container.size(), values));
+        _acquire_null_data(values, _local_dict_code_col.get());
         return Status::OK();
     }
 
@@ -140,10 +141,6 @@ public:
         if (output_nullable) {
             auto& null_data = down_cast<vectorized::NullableColumn*>(words)->null_column_data();
             null_data.resize(size);
-            for (int i = 0; i < size; ++i) {
-                null_data[i] = (res_data[i] == 0);
-            }
-            down_cast<vectorized::NullableColumn*>(words)->update_has_null();
         }
 
         return Status::OK();
@@ -158,6 +155,7 @@ public:
 private:
     Status _build_to_global_dict();
     void _init_local_dict_col();
+    void _acquire_null_data(Column* global_dict_column, Column* local_dict_column);
     const LowCardDictColumn::Container& _get_local_dict_col_container(Column* column);
 
     ColumnId _cid;


### PR DESCRIPTION
if global dict column has empty string ("")
local dict slice (data=0x00, size=0) will found a global dict string
(data= "", size = 0)