### PR TITLE
Upgrade thrift version to 0.14.1 For broker

### DIFF
--- a/fs_brokers/apache_hdfs_broker/pom.xml
+++ b/fs_brokers/apache_hdfs_broker/pom.xml
@@ -40,7 +40,7 @@ under the License.
         <guava.version>30.1.1-jre</guava.version>
         <zookeeper.version>3.4.14</zookeeper.version>
         <protobuf.version>2.5.0</protobuf.version>
-        <thrift.version>0.13.0</thrift.version>
+        <thrift.version>0.14.1</thrift.version>
         <tomcat.version>8.5.70</tomcat.version>
     </properties>
 


### PR DESCRIPTION
close #1909
Fix broker memory leak caused by thrift vulnerability. In Apache Thrift 0.9.3 to 0.13.0, malicious RPC clients could send short messages which would result in a large memory allocation, potentially leading to denial of service. Details is https://www.suse.com/zh-cn/security/cve/CVE-2020-13949.html