### PR TITLE
Fix decimal v3 type cast error in ConstantOperator

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
@@ -267,7 +267,9 @@ public class ScalarType extends Type implements Cloneable {
 
     public static ScalarType createDecimalV3Type(PrimitiveType type, int precision, int scale) {
         Preconditions.checkArgument(0 < precision && precision <= PrimitiveType.getMaxPrecisionOfDecimal(type));
-        Preconditions.checkArgument(0 <= scale && scale <= precision);
+        Preconditions.checkArgument(0 <= scale && scale <= precision,
+                "DECIMAL(P[,S]) type P must be greater than or equal to the value of S");
+
         ScalarType scalarType = new ScalarType(type);
         scalarType.precision = precision;
         scalarType.scale = scale;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
@@ -16,6 +16,7 @@ import com.starrocks.sql.optimizer.operator.OperatorType;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
@@ -374,10 +375,17 @@ public final class ConstantOperator extends ScalarOperator implements Comparable
         } else if (desc.isDecimalV2()) {
             return ConstantOperator.createDecimal(BigDecimal.valueOf(Double.parseDouble(childString)), Type.DECIMALV2);
         } else if (desc.isDecimalV3()) {
-            BigDecimal value = new BigDecimal(childString);
+            BigDecimal decimal = new BigDecimal(childString);
             try {
                 ScalarType scalarType = (ScalarType) desc;
-                DecimalLiteral.checkLiteralOverflow(value, scalarType);
+                DecimalLiteral.checkLiteralOverflow(decimal, scalarType);
+
+                int realScale = DecimalLiteral.getRealScale(decimal);
+                int scale = scalarType.getScalarScale();
+                if (scale <= realScale) {
+                    decimal = decimal.setScale(scale, RoundingMode.HALF_UP);
+                }
+
                 if (scalarType.getScalarScale() == 0 && scalarType.getScalarPrecision() == 0) {
                     throw new SemanticException("Forbidden cast to decimal(precision=0, scale=0)");
                 }
@@ -385,7 +393,7 @@ public final class ConstantOperator extends ScalarOperator implements Comparable
                 throw new SemanticException(e.getMessage());
             }
 
-            return ConstantOperator.createDecimal(value, desc);
+            return ConstantOperator.createDecimal(decimal, desc);
         } else if (desc.isChar() || desc.isVarchar()) {
             return ConstantOperator.createChar(childString, desc);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/FoldConstantsRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/FoldConstantsRuleTest.java
@@ -4,6 +4,8 @@ package com.starrocks.sql.optimizer.rewrite.scalar;
 import com.google.common.collect.Lists;
 import com.starrocks.analysis.FunctionName;
 import com.starrocks.catalog.Function;
+import com.starrocks.catalog.PrimitiveType;
+import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Type;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
@@ -18,6 +20,7 @@ import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriteContext;
 import mockit.Expectations;
 import org.junit.Test;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 import static org.junit.Assert.assertEquals;
@@ -128,6 +131,12 @@ public class FoldConstantsRuleTest {
 
         CastOperator cast6 = new CastOperator(Type.BIGINT, ConstantOperator.createDate(LocalDateTime.now()));
         assertEquals(cast6, rule.apply(cast6, null));
+
+        CastOperator cast7 = new CastOperator(ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 1, 1)
+                , ConstantOperator.createDecimal(BigDecimal.valueOf(0.00008),
+                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 6, 6))
+        );
+        assertEquals("0.0", rule.apply(cast7, null).toString());
     }
 
     @Test


### PR DESCRIPTION
#1884

The problem in issue was introduced by #992. The missing precision of decimal is allowed in Cast. So this optimization cannot be done here, but because of the decimal toString processing error, it is not forbidden