### PR TITLE
Decode node should set limit if necessary

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/AddDecodeNodeForDictStringRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/AddDecodeNodeForDictStringRule.java
@@ -6,6 +6,7 @@ import com.clearspring.analytics.util.Lists;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.starrocks.catalog.Catalog;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.FunctionSet;
@@ -51,6 +52,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator.BinaryType.EQ_FOR_NULL;
 
@@ -81,6 +83,7 @@ public class AddDecodeNodeForDictStringRule implements PhysicalOperatorTreeRewri
         boolean hasEncoded = false;
         final ColumnRefFactory columnRefFactory;
         final Map<Long, List<Integer>> tableIdToStringColumnIds;
+        final Set<Integer> allStringColumnIds;
         // For the low cardinality string columns that have applied global dict optimization
         Map<Integer, Integer> stringColumnIdToDictColumnIds;
         // The string functions have applied global dict optimization
@@ -98,6 +101,10 @@ public class AddDecodeNodeForDictStringRule implements PhysicalOperatorTreeRewri
             stringFunctions = Maps.newHashMap();
             globalDicts = Lists.newArrayList();
             disableDictOptimizeColumns = new ColumnRefSet();
+            allStringColumnIds = Sets.newHashSet();
+            for (List<Integer> ids : tableIdToStringColumnIds.values()) {
+                allStringColumnIds.addAll(ids);
+            }
         }
 
         public void clear() {
@@ -135,9 +142,11 @@ public class AddDecodeNodeForDictStringRule implements PhysicalOperatorTreeRewri
 
         private void visitProjectionBefore(OptExpression optExpression, DecodeContext context) {
             if (optExpression.getOp().getProjection() != null) {
-                context.needEncode = true;
                 Projection projection = optExpression.getOp().getProjection();
-                projection.fillDisableDictOptimizeColumns(context.disableDictOptimizeColumns);
+                context.needEncode = context.needEncode || projection.needApplyStringDict(context.allStringColumnIds);
+                if (context.needEncode) {
+                    projection.fillDisableDictOptimizeColumns(context.disableDictOptimizeColumns);
+                }
             }
         }
 
@@ -664,6 +673,7 @@ public class AddDecodeNodeForDictStringRule implements PhysicalOperatorTreeRewri
         }
         PhysicalDecodeOperator decodeOperator = new PhysicalDecodeOperator(ImmutableMap.copyOf(dictToStrings),
                 Maps.newHashMap(context.stringFunctions));
+        decodeOperator.setLimit(childExpr.get(0).getOp().getLimit());
         OptExpression result = OptExpression.create(decodeOperator, childExpr);
         result.setStatistics(childExpr.get(0).getStatistics());
         result.setLogicalProperty(childExpr.get(0).getLogicalProperty());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -420,6 +420,7 @@ public class PlanFragmentBuilder {
                     inputFragment.getPlanRoot(),
                     node.getDictToStrings(), projectMap);
             decodeNode.computeStatistics(optExpression.getStatistics());
+            decodeNode.setLimit(node.getLimit());
 
             inputFragment.setPlanRoot(decodeNode);
             return inputFragment;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecodeRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecodeRewriteTest.java
@@ -462,18 +462,6 @@ public class DecodeRewriteTest extends PlanTestBase {
     }
 
     @Test
-    public void testCallFunctionOnConstant() throws Exception {
-        String sql = "select hex(10), s_address from supplier";
-        String plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("  2:Decode\n" +
-                "  |  <dict id 10> : <string id 3>\n" +
-                "  |  \n" +
-                "  1:Project\n" +
-                "  |  <slot 9> : hex(10)\n" +
-                "  |  <slot 10> : 10: S_ADDRESS"));
-    }
-
-    @Test
     public void testAssignWrongNullableProperty() throws Exception {
         String sql = "SELECT S_ADDRESS, Dense_rank() OVER ( ORDER BY S_SUPPKEY) FROM supplier UNION SELECT S_ADDRESS, Dense_rank() OVER ( ORDER BY S_SUPPKEY) FROM supplier;";
         String plan = getCostExplain(sql);
@@ -502,5 +490,25 @@ public class DecodeRewriteTest extends PlanTestBase {
         Assert.assertTrue(plan.contains("  3:Decode\n" +
                 "  |  <dict id 10> : <string id 3>\n" +
                 "  |  cardinality: 1"));
+    }
+
+    @Test
+    public void testDecodeWithLimit() throws Exception {
+        String sql = "select count(*), S_ADDRESS from supplier group by S_ADDRESS limit 10";
+        String plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("  2:Decode\n" +
+                "  |  <dict id 10> : <string id 3>\n" +
+                "  |  limit: 10"));
+    }
+
+    @Test
+    public void testNoDecode() throws Exception {
+        String sql = "select *, to_bitmap(S_SUPPKEY) from supplier limit 1";
+        String plan = getFragmentPlan(sql);
+        Assert.assertFalse(plan.contains("Decode"));
+
+        sql = "select hex(10), s_address from supplier";
+        plan = getFragmentPlan(sql);
+        Assert.assertFalse(plan.contains("Decode"));
     }
 }


### PR DESCRIPTION
For https://github.com/StarRocks/starrocks/issues/1923

1. Set limit to decode node if child node has limit
2. Disable global dict optimization for SQL `select *, to_bitmap(S_SUPPKEY) from table`, add a `needApplyStringDict` to projection.