### PR TITLE
[pipeline] Add statistics for record noneffective schedule

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -297,6 +297,9 @@ private:
 
     RuntimeProfile::Counter* _schedule_counter = nullptr;
     RuntimeProfile::Counter* _schedule_effective_counter = nullptr;
+
+    // Use to statistic noneffective times when all operators mostly have been done, just waiting for state transfer.
+    RuntimeProfile::Counter* _schedule_noneffective_pending_counter = nullptr;
     RuntimeProfile::Counter* _schedule_rows_per_chunk = nullptr;
     RuntimeProfile::Counter* _schedule_accumulated_chunk_moved = nullptr;
 


### PR DESCRIPTION
- Add statistics for noneffective schedule when all operators almost have been done.
- Schedulecounter - scheduleeffectivecounter is almost always contributed by schedulenoneffectivependingcounter