### PR TITLE
Set version_hash to 0 when BackupJobInfo is persisted

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupJobInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupJobInfo.java
@@ -453,6 +453,8 @@ public class BackupJobInfo implements Writable {
                 if (verbose) {
                     part.put("id", partInfo.id);
                     part.put("version", partInfo.version);
+                    // write a version_hash for compatibility
+                    part.put("version_hash", 0);
                     JSONObject indexes = new JSONObject();
                     part.put("indexes", indexes);
                     for (BackupIndexInfo idxInfo : partInfo.indexes.values()) {


### PR DESCRIPTION
close #1947 
To be compatible with older versions, we should set the version_hash json key when BackupJobInfo is persisted.