### PR TITLE
[pipeline] add Driver::set_cancelled and ExchangeSinkOperator overrides it

### DIFF
--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -310,7 +310,7 @@ Status ExchangeSinkOperator::prepare(RuntimeState* state) {
 }
 
 bool ExchangeSinkOperator::is_finished() const {
-    return _is_finished && _buffer->is_finishing();
+    return _is_finished;
 }
 
 bool ExchangeSinkOperator::need_input() const {
@@ -321,8 +321,8 @@ bool ExchangeSinkOperator::pending_finish() const {
     return !_buffer->is_finished();
 }
 
-void ExchangeSinkOperator::set_finished(RuntimeState* state) {
-    _buffer->decrease_running_sinkers();
+void ExchangeSinkOperator::set_cancelled(RuntimeState* state) {
+    _buffer->cancel_one_sinker();
 }
 
 StatusOr<vectorized::ChunkPtr> ExchangeSinkOperator::pull_chunk(RuntimeState* state) {

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.h
@@ -52,7 +52,7 @@ public:
 
     void set_finishing(RuntimeState* state) override;
 
-    void set_finished(RuntimeState* state) override;
+    void set_cancelled(RuntimeState* state) override;
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/operator.h
+++ b/be/src/exec/pipeline/operator.h
@@ -33,7 +33,7 @@ public:
     virtual ~Operator() = default;
 
     // prepare is used to do the initialization work
-    // It's one of the stages of the operator life cycle（prepare -> finishing -> finished -> closed)
+    // It's one of the stages of the operator life cycle（prepare -> finishing -> finished -> [cancelled] -> closed)
     // This method will be exactly invoked once in the whole life cycle
     virtual Status prepare(RuntimeState* state);
 
@@ -44,7 +44,7 @@ public:
     // finish function is used to finish the following operator of the current operator that encounters its EOS
     // and has no data to push into its following operator, but the operator is not finished until its buffered
     // data inside is processed.
-    // It's one of the stages of the operator life cycle（prepare -> finishing -> finished -> closed)
+    // It's one of the stages of the operator life cycle（prepare -> finishing -> finished -> [cancelled] -> closed)
     // This method will be exactly invoked once in the whole life cycle
     virtual void set_finishing(RuntimeState* state) {}
 
@@ -56,15 +56,21 @@ public:
     // an implementation-specific context should override set_finished function, such as LocalExchangeSourceOperator.
     // For an ordinary operator, set_finished function is trivial and just has the same implementation with
     // set_finishing function.
-    // It's one of the stages of the operator life cycle（prepare -> finishing -> finished -> closed)
+    // It's one of the stages of the operator life cycle（prepare -> finishing -> finished -> [cancelled] -> closed)
     // This method will be exactly invoked once in the whole life cycle
     virtual void set_finished(RuntimeState* state) {}
+
+    // It's one of the stages of the operator life cycle（prepare -> finishing -> finished -> [cancelled] -> closed)
+    // - When the fragment exits abnormally, the stage operator will become to CANCELLED between FINISHED and CLOSE.
+    // - When the fragment exits normally, there isn't CANCELLED stage for the drivers.
+    // Sometimes, the operator need to realize it is cancelled to stop earlier than normal, such as ExchangeSink.
+    virtual void set_cancelled(RuntimeState* state) {}
 
     // when local runtime filters are ready, the operator should bound its corresponding runtime in-filters.
     virtual void set_precondition_ready(RuntimeState* state);
 
     // close is used to do the cleanup work
-    // It's one of the stages of the operator life cycle（prepare -> finishing -> finished -> closed)
+    // It's one of the stages of the operator life cycle（prepare -> finishing -> finished -> [cancelled] -> closed)
     // This method will be exactly invoked once in the whole life cycle
     virtual Status close(RuntimeState* state);
 

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -127,7 +127,8 @@ enum OperatorStage {
     PROCESSING = 3,
     FINISHING = 4,
     FINISHED = 5,
-    CLOSED = 6,
+    CANCELLED = 6,
+    CLOSED = 7,
 };
 
 class PipelineDriver {
@@ -182,6 +183,7 @@ public:
     // Notify all the unfinished operators to be finished.
     // It is usually used when the sink operator is finished, or the fragment is cancelled or expired.
     void finish_operators(RuntimeState* runtime_state);
+    void cancel_operators(RuntimeState* runtime_state);
 
     Operator* sink_operator() { return _operators.back().get(); }
     bool is_finished() {
@@ -256,6 +258,7 @@ private:
     bool _check_fragment_is_canceled(RuntimeState* runtime_state);
     void _mark_operator_finishing(OperatorPtr& op, RuntimeState* runtime_state);
     void _mark_operator_finished(OperatorPtr& op, RuntimeState* runtime_state);
+    void _mark_operator_cancelled(OperatorPtr& op, RuntimeState* runtime_state);
     void _mark_operator_closed(OperatorPtr& op, RuntimeState* runtime_state);
     void _close_operators(RuntimeState* runtime_state);
 

--- a/be/src/exec/pipeline/pipeline_driver_dispatcher.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_dispatcher.cpp
@@ -71,7 +71,7 @@ void GlobalDriverDispatcher::run() {
             if (fragment_ctx->is_canceled()) {
                 VLOG_ROW << "[Driver] Canceled: driver=" << driver
                          << ", error=" << fragment_ctx->final_status().to_string();
-                driver->finish_operators(runtime_state);
+                driver->cancel_operators(runtime_state);
                 if (driver->is_still_pending_finish()) {
                     driver->set_driver_state(DriverState::PENDING_FINISH);
                     _blocked_driver_poller->add_blocked_driver(driver);
@@ -94,7 +94,7 @@ void GlobalDriverDispatcher::run() {
             if (!status.ok()) {
                 VLOG_ROW << "[Driver] Process error: error=" << status.status().to_string();
                 query_ctx->cancel(status.status());
-                driver->finish_operators(runtime_state);
+                driver->cancel_operators(runtime_state);
                 if (driver->is_still_pending_finish()) {
                     driver->set_driver_state(DriverState::PENDING_FINISH);
                     _blocked_driver_poller->add_blocked_driver(driver);

--- a/be/src/exec/pipeline/pipeline_driver_poller.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_poller.cpp
@@ -73,7 +73,7 @@ void PipelineDriverPoller::run_internal() {
                 //
                 // If the fragment is expired when the source operator is already pending i/o task,
                 // The state of driver shouldn't be changed.
-                driver->finish_operators(driver->fragment_ctx()->runtime_state());
+                driver->cancel_operators(driver->fragment_ctx()->runtime_state());
                 if (driver->is_still_pending_finish()) {
                     driver->set_driver_state(DriverState::PENDING_FINISH);
                     ++driver_it;
@@ -85,7 +85,7 @@ void PipelineDriverPoller::run_internal() {
             } else if (!driver->pending_finish() && driver->fragment_ctx()->is_canceled()) {
                 // If the fragment is cancelled when the source operator is already pending i/o task,
                 // The state of driver shouldn't be changed.
-                driver->finish_operators(driver->fragment_ctx()->runtime_state());
+                driver->cancel_operators(driver->fragment_ctx()->runtime_state());
                 if (driver->is_still_pending_finish()) {
                     driver->set_driver_state(DriverState::PENDING_FINISH);
                     ++driver_it;


### PR DESCRIPTION
### Introduction
`ExchangeSinkOperator::is_finished()` should return true directly and turn into `PENDING_FINISH` stage, when its previous operator is finished, because it will never add new chunk to `SinkBuffer` anymore.

`SinkBuffer` is finished when all EOS has been sent to the destination fragment in the normal case. However, for the abnormal case, `SinkBuffer` needn't send the rest chunk requests and EOS requests anymore, if the whole fragment is cancelled. 
Therefore,  we should introduce a new stage `CANCELLED` and method `set_cancelled()` for operator to make `ExchangeSinkOperator` can be aware that it is cancelled.

### Changes
- Add  new stage `CANCELLED` and method `set_finished()` to `Operator`.
- `ExchangeSinkOperator::is_finished()` returns true, when `set_finishing()` has been called.
- Move the logic of `ExchangeSinkOperator::set_finished()` to `ExchangeSinkOperator::set_cancelled()`.

After this optimization, the consuming time of TPC-DS Q14 DOP=32 is from 7.5s to 6.5s.
- before: total_counter=160871, effective_counter=54875, noneffective_counter=77499, effective_rate=0.34, noneffective_rate=0.48
- after: total_counter=74193, effective_counter=52687, noneffective_counter=0, effective_rate=0.71, noneffective_rate=0.0

noneffective is the case `_first_unfinished == (num_operators - 1) `.