### PR TITLE
Cherry-pick bugfix to 1.19

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -4943,7 +4943,7 @@ public class Catalog {
     }
 
     public Collection<Partition> getPartitionsIncludeRecycleBin(OlapTable table) {
-        Collection<Partition> partitions = table.getPartitions();
+        Collection<Partition> partitions = new ArrayList<>(table.getPartitions());
         partitions.addAll(recycleBin.getPartitions(table.getId()));
         return partitions;
     }


### PR DESCRIPTION
Fix bug UnsupportedOperationException when colocate clone and drop partition at the same time (#347)

table.getPartitions() it return HashMap's value
this value can not support addAll Operation will throw an UnsupportedOperationException
it will cause colocate stable status can not update forever.
