### PR TITLE
Fixed crash at ExechangeSource::close

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -646,7 +646,7 @@ CONF_Int64(pipeline_exec_thread_pool_thread_num, "0");
 // the buffer size of io task
 CONF_Int64(pipeline_io_buffer_size, "64");
 // the buffer size of SinkBuffer
-CONF_Int64(pipeline_sink_buffer_size, "1024");
+CONF_Int64(pipeline_sink_buffer_size, "64");
 // bitmap serialize version
 CONF_Int16(bitmap_serialize_version, "1");
 // max hdfs file handle

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -645,6 +645,8 @@ CONF_Int64(pipeline_scan_thread_pool_queue_size, "102400");
 CONF_Int64(pipeline_exec_thread_pool_thread_num, "0");
 // the buffer size of io task
 CONF_Int64(pipeline_io_buffer_size, "64");
+// the buffer size of SinkBuffer
+CONF_Int64(pipeline_sink_buffer_size, "1024");
 // bitmap serialize version
 CONF_Int16(bitmap_serialize_version, "1");
 // max hdfs file handle

--- a/be/src/exec/pipeline/exchange/exchange_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_source_operator.cpp
@@ -48,8 +48,7 @@ std::shared_ptr<DataStreamRecvr> ExchangeSourceOperatorFactory::create_stream_re
 }
 
 void ExchangeSourceOperatorFactory::close_stream_recvr() {
-    // The remain two references are hold by DataStreamMgr and ExchangeSourceOperatorFactory
-    if (++_stream_recvr_close_cnt == _stream_recvr.use_count() - 2) {
+    if (--_stream_recvr_cnt == 0) {
         _stream_recvr->close();
     }
 }

--- a/be/src/exec/pipeline/exchange/exchange_source_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_source_operator.h
@@ -42,6 +42,7 @@ public:
     ~ExchangeSourceOperatorFactory() override = default;
 
     OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override {
+        ++_stream_recvr_cnt;
         return std::make_shared<ExchangeSourceOperator>(this, _id, _plan_node_id);
     }
 
@@ -53,7 +54,7 @@ private:
     int32_t _num_sender;
     const RowDescriptor& _row_desc;
     std::shared_ptr<DataStreamRecvr> _stream_recvr = nullptr;
-    std::atomic<int64_t> _stream_recvr_close_cnt = 0;
+    std::atomic<int64_t> _stream_recvr_cnt = 0;
 };
 
 } // namespace pipeline

--- a/be/src/exec/pipeline/exchange/sink_buffer.h
+++ b/be/src/exec/pipeline/exchange/sink_buffer.h
@@ -121,10 +121,15 @@ public:
     }
 
     bool is_full() const {
-        // If one channel is congested, it may cause all other channel unwritable
         // std::queue' read is concurrent safe without mutex
-        return std::any_of(_buffers.begin(), _buffers.end(),
-                           [](const auto& entry) { return entry.second.size() > config::pipeline_io_buffer_size; });
+        // Judgement may not that accurate because we do not known in advance which
+        // instance the data to be sent corresponds to
+        size_t max_buffer_size = config::pipeline_sink_buffer_size * _buffers.size();
+        size_t buffer_size = 0;
+        for (auto& [_, buffer] : _buffers) {
+            buffer_size += buffer.size();
+        }
+        return buffer_size > max_buffer_size;
     }
 
     bool is_finished() const {


### PR DESCRIPTION
We cannot rely on the ref count of shard_ptr, because operator may close early