### PR TITLE
[pipeline] make each dispatcher thread own its private queue

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -154,6 +154,7 @@ set(EXEC_FILES
     pipeline/pipeline_driver_queue.cpp
     pipeline/pipeline_driver_poller.cpp
     pipeline/pipeline_driver.cpp
+    pipeline/pipeline_driver_queue_manager.cpp
     pipeline/exec_state_reporter.cpp
     pipeline/fragment_context.cpp
     pipeline/query_context.cpp

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -319,6 +319,10 @@ public:
 
     std::string to_readable_string() const;
 
+    void set_dispatcher_id(int dispatcher_id) { _dispatcher_id = dispatcher_id; }
+
+    int dispatcher_id() { return _dispatcher_id; }
+
 private:
     // check whether fragment is cancelled. It is used before pull_chunk and push_chunk.
     bool _check_fragment_is_canceled(RuntimeState* runtime_state);
@@ -360,6 +364,8 @@ private:
     const int64_t _yield_max_time_spent;
 
     phmap::flat_hash_map<int32_t, OperatorStage> _operator_stages;
+
+    int _dispatcher_id = -1;
 
     // metrics
     RuntimeProfile::Counter* _total_timer = nullptr;

--- a/be/src/exec/pipeline/pipeline_driver_dispatcher.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_dispatcher.cpp
@@ -115,7 +115,7 @@ void GlobalDriverDispatcher::run() {
             switch (driver_state) {
             case READY:
             case RUNNING: {
-                this->_driver_queue_manager->put_back(dispatcher_id, driver);
+                this->_driver_queue_manager->put_back(driver);
                 break;
             }
             case FINISH:
@@ -151,7 +151,7 @@ void GlobalDriverDispatcher::dispatch(DriverRawPtr driver) {
             driver->set_driver_state(DriverState::INPUT_EMPTY);
             this->_blocked_driver_poller->add_blocked_driver(driver);
         } else {
-            this->_driver_queue_manager->put_back(-1, driver);
+            this->_driver_queue_manager->put_back(driver);
         }
     }
 }

--- a/be/src/exec/pipeline/pipeline_driver_dispatcher.h
+++ b/be/src/exec/pipeline/pipeline_driver_dispatcher.h
@@ -9,6 +9,7 @@
 #include "exec/pipeline/pipeline_driver.h"
 #include "exec/pipeline/pipeline_driver_poller.h"
 #include "exec/pipeline/pipeline_driver_queue.h"
+#include "exec/pipeline/pipeline_driver_queue_manager.h"
 #include "exec/pipeline/pipeline_fwd.h"
 #include "exec/pipeline/query_context.h"
 #include "runtime/runtime_state.h"
@@ -18,6 +19,7 @@
 
 namespace starrocks {
 namespace pipeline {
+
 class DriverDispatcher;
 using DriverDispatcherPtr = std::shared_ptr<DriverDispatcher>;
 
@@ -53,7 +55,7 @@ private:
 
 private:
     LimitSetter _num_threads_setter;
-    std::unique_ptr<DriverQueue> _driver_queue;
+    std::unique_ptr<DriverQueueManager> _driver_queue_manager;
     std::unique_ptr<ThreadPool> _thread_pool;
     PipelineDriverPollerPtr _blocked_driver_poller;
     std::unique_ptr<ExecStateReporter> _exec_state_reporter;

--- a/be/src/exec/pipeline/pipeline_driver_poller.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_poller.cpp
@@ -111,7 +111,7 @@ void PipelineDriverPoller::run_internal() {
         } else {
             spin_count = 0;
 
-            _dispatch_queue_manager->put_back(-1, ready_drivers);
+            _dispatch_queue_manager->put_back(ready_drivers);
             ready_drivers.clear();
         }
 

--- a/be/src/exec/pipeline/pipeline_driver_poller.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_poller.cpp
@@ -111,7 +111,7 @@ void PipelineDriverPoller::run_internal() {
         } else {
             spin_count = 0;
 
-            _dispatch_queue->put_back(ready_drivers);
+            _dispatch_queue_manager->put_back(-1, ready_drivers);
             ready_drivers.clear();
         }
 

--- a/be/src/exec/pipeline/pipeline_driver_poller.h
+++ b/be/src/exec/pipeline/pipeline_driver_poller.h
@@ -9,16 +9,19 @@
 #include <mutex>
 
 #include "pipeline_driver.h"
-#include "pipeline_driver_queue.h"
+#include "pipeline_driver_queue_manager.h"
 #include "util/thread.h"
+
 namespace starrocks {
 namespace pipeline {
+
 class PipelineDriverPoller;
 using PipelineDriverPollerPtr = std::unique_ptr<PipelineDriverPoller>;
+
 class PipelineDriverPoller {
 public:
-    explicit PipelineDriverPoller(DriverQueue* dispatch_queue)
-            : _dispatch_queue(dispatch_queue),
+    explicit PipelineDriverPoller(DriverQueueManager* dispatch_queue_manager)
+            : _dispatch_queue_manager(dispatch_queue_manager),
               _polling_thread(nullptr),
               _is_polling_thread_initialized(false),
               _is_shutdown(false) {}
@@ -43,10 +46,11 @@ private:
     std::mutex _mutex;
     std::condition_variable _cond;
     DriverList _blocked_drivers;
-    DriverQueue* _dispatch_queue;
+    DriverQueueManager* _dispatch_queue_manager;
     scoped_refptr<Thread> _polling_thread;
     std::atomic<bool> _is_polling_thread_initialized;
     std::atomic<bool> _is_shutdown;
 };
+
 } // namespace pipeline
 } // namespace starrocks

--- a/be/src/exec/pipeline/pipeline_driver_queue.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_queue.cpp
@@ -27,6 +27,14 @@ void QuerySharedDriverQueue::put_back(const std::vector<DriverRawPtr>& drivers) 
     }
 }
 
+DriverRawPtr QuerySharedDriverQueue::take_own(size_t* queue_index) {
+    if (_size == 0) {
+        return nullptr;
+    }
+
+    return take(queue_index);
+}
+
 DriverRawPtr QuerySharedDriverQueue::take(size_t* queue_index) {
     // -1 means no candidates; else has candidate.
     int queue_idx = -1;

--- a/be/src/exec/pipeline/pipeline_driver_queue.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_queue.cpp
@@ -27,81 +27,43 @@ void QuerySharedDriverQueue::put_back(const std::vector<DriverRawPtr>& drivers) 
     }
 }
 
-DriverRawPtr QuerySharedDriverQueue::put_back_and_take(const std::vector<DriverRawPtr>& drivers, size_t* queue_index) {
-    std::lock_guard<std::mutex> lock(_global_mutex);
-
-    if (_size == 0 && drivers.size() == 1) {
-        *queue_index = drivers[0]->driver_acct().get_level() % QUEUE_SIZE;
-        return drivers[0];
-    }
-
-    _size += drivers.size();
-    for (int i = 0; i < drivers.size(); i++) {
-        _queues[drivers[i]->driver_acct().get_level() % QUEUE_SIZE].queue.emplace_back(drivers[i]);
-    }
-
-    return _do_take(queue_index);
-}
-
 DriverRawPtr QuerySharedDriverQueue::take(size_t* queue_index) {
-    std::unique_lock<std::mutex> lock(_global_mutex);
-    return _do_take(queue_index);
-}
-
-std::vector<DriverRawPtr> QuerySharedDriverQueue::steal() {
-    std::lock_guard<std::mutex> lock(_global_mutex);
-
-    std::vector<DriverRawPtr> steal_drivers;
-    if (_size == 0) {
-        return steal_drivers;
-    }
-
-    for (int i = 0; i < QUEUE_SIZE; ++i) {
-        int num_steals_drivers = (_queues[i].queue.size() + 1) / 2;
-        while (num_steals_drivers--) {
-            steal_drivers.emplace_back(_queues[i].queue.back());
-            _queues[i].queue.pop_back();
-        }
-    }
-
-    _size -= steal_drivers.size();
-
-    return steal_drivers;
-}
-
-DriverRawPtr QuerySharedDriverQueue::_do_take(size_t* queue_index) {
     // -1 means no candidates; else has candidate.
     int queue_idx = -1;
     double target_accu_time = 0;
     DriverRawPtr driver_ptr;
 
-    for (int i = 0; i < QUEUE_SIZE; ++i) {
-        // we just search for queue has element
-        if (!_queues[i].queue.empty()) {
-            double local_target_time = _queues[i].accu_time_after_divisor();
-            // if this is first queue that has element, we select it;
-            // else we choose queue that the execution time is less sufficient,
-            // and record time.
-            if (queue_idx < 0 || local_target_time < target_accu_time) {
-                target_accu_time = local_target_time;
-                queue_idx = i;
+    {
+        std::unique_lock<std::mutex> lock(_global_mutex);
+
+        for (int i = 0; i < QUEUE_SIZE; ++i) {
+            // we just search for queue has element
+            if (!_queues[i].queue.empty()) {
+                double local_target_time = _queues[i].accu_time_after_divisor();
+                // if this is first queue that has element, we select it;
+                // else we choose queue that the execution time is less sufficient,
+                // and record time.
+                if (queue_idx < 0 || local_target_time < target_accu_time) {
+                    target_accu_time = local_target_time;
+                    queue_idx = i;
+                }
             }
         }
+
+        if (queue_idx < 0) {
+            return nullptr;
+        }
+
+        // record queue's index to accumulate time for it.
+        *queue_index = queue_idx;
+        driver_ptr = _queues[queue_idx].queue.front();
+        _queues[queue_idx].queue.pop_front();
+
+        --_size;
+
+        // next pipeline driver to execute.
+        return driver_ptr;
     }
-
-    if (queue_idx < 0) {
-        return nullptr;
-    }
-
-    // record queue's index to accumulate time for it.
-    *queue_index = queue_idx;
-    driver_ptr = _queues[queue_idx].queue.front();
-    _queues[queue_idx].queue.pop_front();
-
-    --_size;
-
-    // next pipeline driver to execute.
-    return driver_ptr;
 }
 
 SubQuerySharedDriverQueue* QuerySharedDriverQueue::get_sub_queue(size_t index) {

--- a/be/src/exec/pipeline/pipeline_driver_queue.h
+++ b/be/src/exec/pipeline/pipeline_driver_queue.h
@@ -35,6 +35,7 @@ public:
     virtual void put_back(const std::vector<DriverRawPtr>& drivers) = 0;
 
     virtual DriverRawPtr take(size_t* queue_index) = 0;
+    virtual DriverRawPtr take_own(size_t* queue_index) = 0;
 
     virtual SubQuerySharedDriverQueue* get_sub_queue(size_t) = 0;
 };
@@ -64,6 +65,7 @@ public:
 
     // return nullptr if queue is empty.
     DriverRawPtr take(size_t* queue_index) override;
+    DriverRawPtr take_own(size_t* queue_index) override;
 
     SubQuerySharedDriverQueue* get_sub_queue(size_t) override;
 
@@ -74,7 +76,7 @@ private:
     std::mutex _global_mutex;
 
     SubQuerySharedDriverQueue _queues[QUEUE_SIZE];
-    int _size = 0;
+    std::atomic<int> _size = 0;
 };
 
 } // namespace pipeline

--- a/be/src/exec/pipeline/pipeline_driver_queue.h
+++ b/be/src/exec/pipeline/pipeline_driver_queue.h
@@ -33,10 +33,8 @@ public:
 
     virtual void put_back(const DriverRawPtr driver) = 0;
     virtual void put_back(const std::vector<DriverRawPtr>& drivers) = 0;
-    virtual DriverRawPtr put_back_and_take(const std::vector<DriverRawPtr>& drivers, size_t* queue_index) = 0;
 
     virtual DriverRawPtr take(size_t* queue_index) = 0;
-    virtual std::vector<DriverRawPtr> steal() = 0;
 
     virtual SubQuerySharedDriverQueue* get_sub_queue(size_t) = 0;
 };
@@ -63,11 +61,9 @@ public:
 
     void put_back(const DriverRawPtr driver) override;
     void put_back(const std::vector<DriverRawPtr>& drivers) override;
-    DriverRawPtr put_back_and_take(const std::vector<DriverRawPtr>& drivers, size_t* queue_index) override;
 
-    // return nullptr if queue is closed;
+    // return nullptr if queue is empty.
     DriverRawPtr take(size_t* queue_index) override;
-    std::vector<DriverRawPtr> steal() override;
 
     SubQuerySharedDriverQueue* get_sub_queue(size_t) override;
 

--- a/be/src/exec/pipeline/pipeline_driver_queue_manager.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_queue_manager.cpp
@@ -94,7 +94,7 @@ void DriverQueueManager::put_back(const DriverRawPtr driver) {
 }
 
 void DriverQueueManager::put_back(const std::vector<DriverRawPtr>& drivers) {
-    int dispatcher_id;
+    int dispatcher_id = 0;
     std::vector<std::vector<DriverRawPtr>> ready_drivers_per_dispatcher(_num_dispatchers);
     for (auto driver : drivers) {
         dispatcher_id = driver->dispatcher_id();

--- a/be/src/exec/pipeline/pipeline_driver_queue_manager.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_queue_manager.cpp
@@ -1,0 +1,117 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#include "exec/pipeline/pipeline_driver_queue_manager.h"
+
+namespace starrocks::pipeline {
+
+int gcd(int x, int y) {
+    return y > 0 ? gcd(y, x % y) : x;
+}
+
+void DriverQueueManager::initialize(int num_dispatchers) {
+    _num_dispatchers = num_dispatchers;
+
+    _queue_per_dispatcher.reserve(_num_dispatchers);
+    _remote_queue_per_dispatcher.reserve(_num_dispatchers);
+    for (int i = 0; i < _num_dispatchers; i++) {
+        _queue_per_dispatcher.emplace_back(std::make_unique<QuerySharedDriverQueue>());
+        _remote_queue_per_dispatcher.emplace_back(std::make_unique<QuerySharedDriverQueue>());
+    }
+
+    // Every step size is coprime with _num_dispatchers.
+    _rand_step_sizes.reserve(_num_dispatchers);
+    for (int i = 1; _rand_step_sizes.size() <= _num_dispatchers; i++) {
+        if (gcd(i, _num_dispatchers) == 1) {
+            _rand_step_sizes.emplace_back(i);
+        }
+    }
+}
+
+void DriverQueueManager::close() {
+    _pl.close();
+}
+
+StatusOr<DriverRawPtr> DriverQueueManager::take(int dispatcher_id, size_t* queue_index, bool* is_from_remote) {
+    *is_from_remote = false;
+
+    // 1. take from own local queue.
+    DriverRawPtr driver = _queue_per_dispatcher[dispatcher_id]->take(queue_index);
+    if (driver != nullptr) {
+        return driver;
+    }
+
+    for (;;) {
+        auto local_state = _pl.get_state();
+        if (local_state.closed()) {
+            return Status::Cancelled("Shutdown");
+        }
+
+        // 2. take from own remote queue.
+        auto driver = _remote_queue_per_dispatcher[dispatcher_id]->take(queue_index);
+        if (driver != nullptr) {
+            *is_from_remote = true;
+            return driver;
+        }
+
+        int pos = _random_dispatcher_id();
+        const int offset = _rand_step_sizes[pos];
+        for (int i = 0; i < _num_dispatchers; i++) {
+            const int steal_id = pos % _num_dispatchers;
+            pos += offset;
+
+            // 3. steal from other local queue.
+            std::vector<DriverRawPtr> steal_drivers = _queue_per_dispatcher[steal_id]->steal();
+            if (!steal_drivers.empty()) {
+                return _queue_per_dispatcher[dispatcher_id]->put_back_and_take(steal_drivers, queue_index);
+            }
+
+            // 4. steal from other remote queue.
+            steal_drivers = _remote_queue_per_dispatcher[steal_id]->steal();
+            if (!steal_drivers.empty()) {
+                return _queue_per_dispatcher[dispatcher_id]->put_back_and_take(steal_drivers, queue_index);
+            }
+        }
+
+        _pl.wait(local_state);
+    }
+}
+
+void DriverQueueManager::put_back(int dispatcher_id, const DriverRawPtr driver) {
+    if (dispatcher_id >= 0) {
+        _queue_per_dispatcher[dispatcher_id]->put_back(driver);
+    } else {
+        dispatcher_id = _random_dispatcher_id();
+        _remote_queue_per_dispatcher[dispatcher_id]->put_back(driver);
+        _pl.notify_one();
+    }
+}
+
+void DriverQueueManager::put_back(int dispatcher_id, const std::vector<DriverRawPtr>& drivers) {
+    if (dispatcher_id >= 0) {
+        _queue_per_dispatcher[dispatcher_id]->put_back(drivers);
+    } else {
+        std::vector<std::vector<DriverRawPtr>> ready_drivers_per_dispatcher(_num_dispatchers);
+        for (auto driver : drivers) {
+            ready_drivers_per_dispatcher[_random_dispatcher_id()].emplace_back(driver);
+        }
+
+        for (int i = 0; i < _num_dispatchers; i++) {
+            if (!ready_drivers_per_dispatcher[i].empty()) {
+                _remote_queue_per_dispatcher[i]->put_back(ready_drivers_per_dispatcher[i]);
+            }
+        }
+
+        _pl.notify(drivers.size());
+    }
+}
+
+SubQuerySharedDriverQueue* DriverQueueManager::get_sub_queue(int dispatcher_id, size_t queue_index,
+                                                             bool is_from_remote) {
+    if (is_from_remote) {
+        return _remote_queue_per_dispatcher[dispatcher_id]->get_sub_queue(queue_index);
+    }
+
+    return _queue_per_dispatcher[dispatcher_id]->get_sub_queue(queue_index);
+}
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/pipeline_driver_queue_manager.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_queue_manager.cpp
@@ -2,6 +2,8 @@
 
 #include "exec/pipeline/pipeline_driver_queue_manager.h"
 
+#include <random>
+
 namespace starrocks::pipeline {
 
 int gcd(int x, int y) {
@@ -37,7 +39,7 @@ StatusOr<DriverRawPtr> DriverQueueManager::take(int dispatcher_id, size_t* queue
     *is_from_remote = false;
 
     // 1. take from own local queue.
-    DriverRawPtr driver = _queue_per_dispatcher[dispatcher_id]->take(queue_index);
+    DriverRawPtr driver = _queue_per_dispatcher[dispatcher_id]->take_own(queue_index);
     if (driver != nullptr) {
         driver->set_dispatcher_id(dispatcher_id);
         return driver;
@@ -128,6 +130,13 @@ SubQuerySharedDriverQueue* DriverQueueManager::get_sub_queue(int dispatcher_id, 
     }
 
     return _queue_per_dispatcher[dispatcher_id]->get_sub_queue(queue_index);
+}
+
+int DriverQueueManager::_random_dispatcher_id() {
+    std::random_device rand_dev;
+    std::mt19937 generator(rand_dev());
+    std::uniform_int_distribution<int> distribution(0, _num_dispatchers - 1);
+    return distribution(generator);
 }
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/pipeline_driver_queue_manager.h
+++ b/be/src/exec/pipeline/pipeline_driver_queue_manager.h
@@ -70,9 +70,7 @@ public:
     int gen_dispatcher_id() { return _next_dispatcher_id.fetch_add(1, std::memory_order_relaxed); }
 
 private:
-    int _random_dispatcher_id() {
-        return _next_rand_dispatcher_id.fetch_add(1, std::memory_order_relaxed) % _num_dispatchers;
-    }
+    int _random_dispatcher_id();
 
     static constexpr int NUM_PL = 4;
 
@@ -89,8 +87,6 @@ private:
     // Generate dispatcher id when the dispatcher thread starts.
     std::atomic<int> _next_dispatcher_id = 0;
 
-    // Start from different starting pos for every steal.
-    std::atomic<int> _next_rand_dispatcher_id = 0;
     // Each start pos is corresponding to a different step size coprime with _num_dispatchers.
     // In this way, make the steal order of the different start pos different.
     std::vector<int> _rand_step_sizes;

--- a/be/src/exec/pipeline/pipeline_driver_queue_manager.h
+++ b/be/src/exec/pipeline/pipeline_driver_queue_manager.h
@@ -1,0 +1,94 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#pragma once
+
+#include "exec/pipeline/pipeline_driver_queue.h"
+#include "util/sys_futex.h"
+
+namespace starrocks::pipeline {
+
+class ParkingLot {
+public:
+    class State {
+    public:
+        explicit State(int32_t val) : _val(val) {}
+
+        int32_t val() const { return _val; }
+
+        bool closed() const { return _val & 1; }
+
+    private:
+        int32_t _val;
+    };
+
+    State get_state() { return State(_state.load(std::memory_order_acquire)); }
+
+    void close() {
+        _state.fetch_or(1, std::memory_order_release);
+        notify_all();
+    }
+
+    void wait(State expected) { futex_wait_private(reinterpret_cast<int32_t*>(&_state), expected.val(), nullptr); }
+
+    void notify_one() { notify(1); }
+
+    void notify_all() { notify(std::numeric_limits<int32_t>::max()); }
+
+    void notify(int nwake) {
+        _state.fetch_add(1 << 1, std::memory_order_release);
+        futex_wake_private(reinterpret_cast<int32_t*>(&_state), nwake);
+    }
+
+private:
+    // The lowest bit is denoted whether it is closed.
+    std::atomic<int32_t> _state = 0;
+};
+
+class DriverQueueManager {
+public:
+    DriverQueueManager() = default;
+    ~DriverQueueManager() = default;
+
+    void initialize(int num_dispatchers);
+
+    void close();
+
+    // TODO: make it able to change the number of dispatchers.
+    void change_num_dispatchers(int new_num_dispatchers) {}
+
+    StatusOr<DriverRawPtr> take(int dispatcher_id, size_t* queue_index, bool* is_from_remote);
+    // Put the driver back to _queue_per_dispatcher if dispatcher_id is not -1.
+    // Otherwise, put the driver to a random _remote_queue_per_dispatcher.
+    void put_back(int dispatcher_id, const DriverRawPtr driver);
+    void put_back(int dispatcher_id, const std::vector<DriverRawPtr>& drivers);
+
+    SubQuerySharedDriverQueue* get_sub_queue(int dispatcher_id, size_t queue_index, bool is_from_remote);
+
+    // Generate dispatcher id when the dispatcher thread starts.
+    int gen_dispatcher_id() { return _next_dispatcher_id.fetch_add(1, std::memory_order_relaxed); }
+
+private:
+    int _random_dispatcher_id() {
+        return _next_rand_dispatcher_id.fetch_add(1, std::memory_order_relaxed) % _num_dispatchers;
+    }
+
+    // Used to block and notify dispatcher threads.
+    ParkingLot _pl;
+
+    int _num_dispatchers = 0;
+    // Dispatcher thread puts the driver back to its own local queue.
+    std::vector<std::unique_ptr<QuerySharedDriverQueue>> _queue_per_dispatcher;
+    // Non-dispatcher thread puts the driver to a remote queue.
+    std::vector<std::unique_ptr<QuerySharedDriverQueue>> _remote_queue_per_dispatcher;
+
+    // Generate dispatcher id when the dispatcher thread starts.
+    std::atomic<int> _next_dispatcher_id = 0;
+
+    // Start from different starting pos for every steal.
+    std::atomic<int> _next_rand_dispatcher_id = 0;
+    // Each start pos is corresponding to a different step size coprime with _num_dispatchers.
+    // In this way, make the steal order of the different start pos different.
+    std::vector<int> _rand_step_sizes;
+};
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/pipeline_driver_queue_manager.h
+++ b/be/src/exec/pipeline/pipeline_driver_queue_manager.h
@@ -59,8 +59,8 @@ public:
     StatusOr<DriverRawPtr> take(int dispatcher_id, size_t* queue_index, bool* is_from_remote);
     // Put the driver back to _queue_per_dispatcher if dispatcher_id is not -1.
     // Otherwise, put the driver to a random _remote_queue_per_dispatcher.
-    void put_back(int dispatcher_id, const DriverRawPtr driver);
-    void put_back(int dispatcher_id, const std::vector<DriverRawPtr>& drivers);
+    void put_back(const DriverRawPtr driver);
+    void put_back(const std::vector<DriverRawPtr>& drivers);
 
     void notify(int dispatcher_id, int num_drivers);
 

--- a/be/src/util/sys_futex.h
+++ b/be/src/util/sys_futex.h
@@ -1,0 +1,18 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#pragma once
+
+#include <linux/futex.h>
+#include <syscall.h>
+
+namespace starrocks {
+
+inline int futex_wait_private(void* addr1, int expected, const timespec* timeout) {
+    return syscall(SYS_futex, addr1, FUTEX_WAIT_PRIVATE, expected, timeout, nullptr, 0);
+}
+
+inline int futex_wake_private(void* addr1, int nwake) {
+    return syscall(SYS_futex, addr1, FUTEX_WAKE_PRIVATE, nwake, nullptr, nullptr, 0);
+}
+
+} // namespace starrocks


### PR DESCRIPTION
Each dispatcher has two private driver queues, a local one and a remote one.

For put operations:
- Dispatcher thread puts the driver back to its local queue. Don't notify the blocked dispatcher.
- Non-dispatcher thread puts the driver in the remote queue of a random dispatcher. Notify one blocked dispatcher.

For taking operations:
1. Dispatcher first tries to take the driver from its local queue.
2. If failed, try to take the driver from its remote queue.
3. If failed, tries to steal the driver from the local and remote queue of other dispatchers in a random traverse order.
4. If failed, block by `futex`. After waking up, jump to step 2.
