### PR TITLE
Add support for org.apache.hadoop.mapred.TextInputFormat especially for CSV

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -91,6 +91,7 @@ set(EXEC_FILES
     vectorized/intersect_node.cpp
     vectorized/hdfs_scanner.cpp
     vectorized/hdfs_scanner_orc.cpp
+    vectorized/hdfs_scanner_text.cpp
     vectorized/json_scanner.cpp
     vectorized/project_node.cpp
     vectorized/dict_decode_node.cpp
@@ -202,8 +203,7 @@ set(EXEC_FILES
 
 IF (WITH_HDFS)
     set(EXEC_FILES ${EXEC_FILES}
-        vectorized/hdfs_scan_node.cpp
-    )
+        vectorized/hdfs_scan_node.cpp)
 endif()
 
 add_library(Exec STATIC

--- a/be/src/exec/vectorized/csv_scanner.cpp
+++ b/be/src/exec/vectorized/csv_scanner.cpp
@@ -11,30 +11,7 @@
 
 namespace starrocks::vectorized {
 
-/// CSVScanner::CSVReader
-Status CSVScanner::CSVReader::next_record(Record* record) {
-    if (_limit > 0 && _parsed_bytes > _limit) {
-        return Status::EndOfFile("Reached limit");
-    }
-    char* d;
-    size_t pos = 0;
-    while ((d = _buff.find(_record_delimiter, pos)) == nullptr) {
-        pos = _buff.available();
-        _buff.compact();
-        if (_buff.free_space() == 0) {
-            RETURN_IF_ERROR(_expand_buffer());
-        }
-        RETURN_IF_ERROR(_fill_buffer());
-    }
-    size_t l = d - _buff.position();
-    *record = Record(_buff.position(), l);
-    _buff.skip(l + 1);
-    //               ^^ skip record delimiter.
-    _parsed_bytes += l + 1;
-    return Status::OK();
-}
-
-Status CSVScanner::CSVReader::_fill_buffer() {
+Status CSVScanner::ScannerCSVReader::_fill_buffer() {
     SCOPED_RAW_TIMER(&_counter->file_read_ns);
 
     DCHECK(_buff.free_space() > 0);
@@ -59,50 +36,6 @@ Status CSVScanner::CSVReader::_fill_buffer() {
         _buff.append(_record_delimiter);
     }
     return Status::OK();
-}
-
-Status CSVScanner::CSVReader::_expand_buffer() {
-    if (UNLIKELY(_storage.size() >= kMaxBufferSize)) {
-        return Status::InternalError("CSV line length exceed limit " + std::to_string(kMaxBufferSize));
-    }
-    size_t new_capacity = std::min(_storage.size() * 2, kMaxBufferSize);
-    DCHECK_EQ(_storage.data(), _buff.position()) << "should compact buffer before expand";
-    _storage.resize(new_capacity);
-    Buffer new_buff(_storage.data(), _storage.size());
-    new_buff.add_limit(_buff.available());
-    DCHECK_EQ(_storage.data(), new_buff.position());
-    DCHECK_EQ(_buff.available(), new_buff.available());
-    _buff = new_buff;
-    return Status::OK();
-}
-
-void CSVScanner::CSVReader::split_record(const Record& record, Fields* fields) const {
-    const char* value = record.data;
-    const char* ptr = record.data;
-    const size_t size = record.size;
-
-    if (_field_delimiter.size() == 1) {
-        for (size_t i = 0; i < size; ++i, ++ptr) {
-            if (*ptr == _field_delimiter[0]) {
-                fields->emplace_back(value, ptr - value);
-                value = ptr + 1;
-            }
-        }
-    } else {
-        const auto fd_size = _field_delimiter.size();
-        const auto* const base = ptr;
-
-        do {
-            ptr = static_cast<char*>(memmem(value, size - (value - base), _field_delimiter.data(), fd_size));
-            if (ptr != nullptr) {
-                fields->emplace_back(value, ptr - value);
-                value = ptr + fd_size;
-            }
-        } while (ptr != nullptr);
-
-        ptr = record.data + size;
-    }
-    fields->emplace_back(value, ptr - value);
 }
 
 CSVScanner::CSVScanner(RuntimeState* state, RuntimeProfile* profile, const TBrokerScanRange& scan_range,
@@ -191,7 +124,7 @@ StatusOr<ChunkPtr> CSVScanner::get_next() {
                 return st;
             }
 
-            _curr_reader = std::make_unique<CSVReader>(file, _record_delimiter, _field_delimiter);
+            _curr_reader = std::make_unique<ScannerCSVReader>(file, _record_delimiter, _field_delimiter);
             _curr_reader->set_counter(_counter);
             if (_scan_range.ranges[_curr_file_index].size > 0 &&
                 _scan_range.ranges[_curr_file_index].format_type == TFileFormatType::FORMAT_CSV_PLAIN) {

--- a/be/src/exec/vectorized/csv_scanner.h
+++ b/be/src/exec/vectorized/csv_scanner.h
@@ -8,6 +8,7 @@
 
 #include "exec/vectorized/file_scanner.h"
 #include "formats/csv/converter.h"
+#include "formats/csv/csv_reader.h"
 #include "util/logging.h"
 #include "util/raw_container.h"
 
@@ -18,14 +19,6 @@ class SequentialFile;
 namespace starrocks::vectorized {
 
 class CSVScanner final : public FileScanner {
-#ifndef BE_TEST
-    constexpr static size_t kMinBufferSize = 8 * 1024 * 1024L;
-    constexpr static size_t kMaxBufferSize = 512 * 1024 * 1024L;
-#else
-    constexpr static size_t kMinBufferSize = 128 * 1024L;
-    constexpr static size_t kMaxBufferSize = 512 * 1024L;
-#endif
-
 public:
     CSVScanner(RuntimeState* state, RuntimeProfile* profile, const TBrokerScanRange& scan_range,
                ScannerCounter* counter);
@@ -37,86 +30,19 @@ public:
     void close() override{};
 
 private:
-    class Buffer {
+    class ScannerCSVReader : public CSVReader {
     public:
-        // Does NOT take the ownership of |buff|.
-        Buffer(char* buff, size_t cap) : _begin(buff), _position(buff), _limit(buff), _end(buff + cap) {}
-
-        void append(char c) { *_limit++ = c; }
-
-        // Returns the number of bytes between the current position and the limit.
-        size_t available() const { return _limit - _position; }
-
-        // Returns the number of elements between the the limit and the end.
-        size_t free_space() const { return _end - _limit; }
-
-        // Returns this buffer's capacity.
-        size_t capacity() const { return _end - _begin; }
-
-        // Returns this buffer's read position.
-        char* position() { return _position; }
-
-        // Returns this buffer's write position.
-        char* limit() { return _limit; }
-
-        void add_limit(size_t n) { _limit += n; }
-
-        // Finds the first character equal to the given character |c|. Search begins at |pos|.
-        // Return: address of the first character of the found character or NULL if no such
-        // character is found.
-        char* find(char c, size_t pos = 0) { return (char*)memchr(position() + pos, c, available() - pos); }
-
-        void skip(size_t n) { _position += n; }
-
-        // Compacts this buffer.
-        // The bytes between the buffer's current position and its limit, if any,
-        // are copied to the beginning of the buffer.
-        void compact() {
-            size_t n = available();
-            memmove(_begin, _position, available());
-            _limit = _begin + n;
-            _position = _begin;
+        ScannerCSVReader(std::shared_ptr<SequentialFile> file, char record_delimiter, string field_delimiter)
+                :CSVReader(record_delimiter, field_delimiter) {
+            _file = file;
         }
-
-    private:
-        char* _begin;
-        char* _position; // next read position
-        char* _limit;    // next write position
-        char* _end;
-    };
-
-    class CSVReader {
-    public:
-        using Record = Slice;
-        using Field = Slice;
-        using Fields = std::vector<Field>;
-
-        CSVReader(std::shared_ptr<SequentialFile> file, char record_delimiter, string field_delimiter)
-                : _file(std::move(file)),
-                  _record_delimiter(record_delimiter),
-                  _field_delimiter(std::move(field_delimiter)),
-                  _storage(kMinBufferSize),
-                  _buff(_storage.data(), _storage.size()) {}
-
-        Status next_record(Record* record);
-
-        void set_limit(size_t limit) { _limit = limit; }
-
-        void split_record(const Record& record, Fields* fields) const;
 
         void set_counter(ScannerCounter* counter) { _counter = counter; }
 
-    private:
-        Status _expand_buffer();
-        Status _fill_buffer();
+        Status _fill_buffer() override;
 
+    private:
         std::shared_ptr<SequentialFile> _file;
-        char _record_delimiter;
-        string _field_delimiter;
-        raw::RawVector<char> _storage;
-        Buffer _buff;
-        size_t _parsed_bytes = 0;
-        size_t _limit = 0;
         ScannerCounter* _counter = nullptr;
     };
 
@@ -127,7 +53,7 @@ private:
     void _report_error(const std::string& line, const std::string& err_msg);
 
     using ConverterPtr = std::unique_ptr<csv::Converter>;
-    using CSVReaderPtr = std::unique_ptr<CSVReader>;
+    using CSVReaderPtr = std::unique_ptr<ScannerCSVReader>;
 
     const TBrokerScanRange& _scan_range;
     std::vector<Column*> _column_raw_ptrs;

--- a/be/src/exec/vectorized/csv_scanner.h
+++ b/be/src/exec/vectorized/csv_scanner.h
@@ -33,7 +33,7 @@ private:
     class ScannerCSVReader : public CSVReader {
     public:
         ScannerCSVReader(std::shared_ptr<SequentialFile> file, char record_delimiter, string field_delimiter)
-                :CSVReader(record_delimiter, field_delimiter) {
+                : CSVReader(record_delimiter, field_delimiter) {
             _file = file;
         }
 

--- a/be/src/exec/vectorized/hdfs_scan_node.cpp
+++ b/be/src/exec/vectorized/hdfs_scan_node.cpp
@@ -9,6 +9,7 @@
 #include "exec/vectorized/hdfs_scanner.h"
 #include "exprs/expr.h"
 #include "exprs/expr_context.h"
+#include "exec/vectorized/hdfs_scanner_text.h"
 #include "exprs/vectorized/runtime_filter.h"
 #include "fmt/core.h"
 #include "glog/logging.h"
@@ -202,6 +203,8 @@ Status HdfsScanNode::_create_and_init_scanner(RuntimeState* state, const HdfsFil
         scanner = _pool->add(new HdfsParquetScanner());
     } else if (hdfs_file_desc.hdfs_file_format == THdfsFileFormat::ORC) {
         scanner = _pool->add(new HdfsOrcScanner());
+    } else if (hdfs_file_desc.hdfs_file_format == THdfsFileFormat::TEXT) {
+        scanner = _pool->add(new HdfsTextScanner());
     } else {
         std::string msg = fmt::format("unsupported hdfs file format: {}", hdfs_file_desc.hdfs_file_format);
         LOG(WARNING) << msg;

--- a/be/src/exec/vectorized/hdfs_scan_node.cpp
+++ b/be/src/exec/vectorized/hdfs_scan_node.cpp
@@ -7,9 +7,9 @@
 
 #include "env/env_hdfs.h"
 #include "exec/vectorized/hdfs_scanner.h"
+#include "exec/vectorized/hdfs_scanner_text.h"
 #include "exprs/expr.h"
 #include "exprs/expr_context.h"
-#include "exec/vectorized/hdfs_scanner_text.h"
 #include "exprs/vectorized/runtime_filter.h"
 #include "fmt/core.h"
 #include "glog/logging.h"

--- a/be/src/exec/vectorized/hdfs_scanner_text.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_text.cpp
@@ -1,0 +1,119 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#include "exec/vectorized/hdfs_scanner_text.h"
+
+#include "exec/vectorized/hdfs_scan_node.h"
+#include "gen_cpp/Descriptors_types.h"
+#include "gutil/strings/substitute.h"
+#include "util/utf8_check.h"
+
+namespace starrocks::vectorized {
+
+Status HdfsTextScanner::HdfsScannerCSVReader::_fill_buffer() {
+    DCHECK(_buff.free_space() > 0);
+    Slice s(_buff.limit(), _buff.free_space());
+    Status st = _file->read(_offset, &s);
+    _offset += s.size;
+    // According to the specification of `Env::read`, when reached the end of
+    // a file, the returned status will be OK instead of EOF, but here we check
+    // EOF also for safety.
+    if (st.is_end_of_file()) {
+        s.size = 0;
+    } else if (!st.ok()) {
+        return st;
+    }
+    _buff.add_limit(s.size);
+    auto n = _buff.available();
+    if (s.size == 0 && n == 0) {
+        // Has reached the end of file and the buffer is empty.
+        return Status::EndOfFile(_file->file_name());
+    } else if (s.size == 0 && _buff.position()[n - 1] != _record_delimiter) {
+        // Has reached the end of file but still no record delimiter found, which
+        // is valid, according the RFC, add the record delimiter ourself.
+        _buff.append(_record_delimiter);
+    }
+    return Status::OK();
+}
+
+Status HdfsTextScanner::do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) {
+    TTextFileDesc text_file_desc = _scanner_params.scan_ranges[0]->text_file_desc;
+    _field_delimiter = text_file_desc.field_delim;
+    // we should cast string to char now since csv reader only support record delimiter by char
+    _record_delimiter = text_file_desc.line_delim.front();
+    return Status::OK();
+}
+
+Status HdfsTextScanner::do_open(RuntimeState* runtime_state) {
+    _reader = std::make_unique<HdfsScannerCSVReader>(_scanner_params.fs, _record_delimiter, _field_delimiter,
+                                          _scanner_params.scan_ranges[0]->offset);
+    for (int i = 0; i < _scanner_params.materialize_slots.size(); i++) {
+        auto slot = _scanner_params.materialize_slots[i];
+        ConverterPtr conv = csv::get_converter(slot->type(), true);
+        if (conv == nullptr) {
+            auto msg = strings::Substitute("Unsupported CSV type $0", slot->type().debug_string());
+            return Status::InternalError(msg);
+        }
+        _converters.emplace_back(std::move(conv));
+    }
+    return Status::OK();
+}
+
+void HdfsTextScanner::do_close(RuntimeState* runtime_state) noexcept {
+    update_counter();
+    _reader.reset();
+}
+
+Status HdfsTextScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) {
+    return _parse_csv(chunk);
+}
+
+Status HdfsTextScanner::_parse_csv(ChunkPtr* chunk) {
+    const int capacity = config::vector_chunk_size;
+    DCHECK_EQ(0, chunk->get()->num_rows());
+    Status status;
+    CSVReader::Record record;
+    CSVReader::Fields fields;
+
+    int num_columns = chunk->get()->num_columns();
+    _column_raw_ptrs.resize(num_columns);
+    for (int i = 0; i < num_columns; i++) {
+        _column_raw_ptrs[i] = chunk->get()->get_column_by_index(i).get();
+    }
+
+    csv::Converter::Options options;
+
+    for (size_t num_rows = chunk->get()->num_rows(); num_rows < capacity; /**/) {
+        status = _reader->next_record(&record);
+        if (status.is_end_of_file()) {
+            break;
+        } else if (!status.ok()) {
+            return status;
+        } else if (record.empty()) {
+            // always skip blank lines.
+            continue;
+        }
+
+        fields.clear();
+        _reader->split_record(record, &fields);
+
+        if (!validate_utf8(record.data, record.size)) {
+            continue;
+        }
+
+        bool has_error = false;
+        for (int j = 0, k = 0; j < _scanner_params.materialize_slots.size(); j++) {
+            const Slice& field = fields[_scanner_params.materialize_slots[j]->id() - 1];
+            options.type_desc = &(_scanner_params.materialize_slots[j]->type());
+            if (!_converters[k]->read_string(_column_raw_ptrs[k], field, options)) {
+                chunk->get()->set_num_rows(num_rows);
+                has_error = true;
+                break;
+            }
+            k++;
+        }
+        num_rows += !has_error;
+    }
+    return chunk->get()->num_rows() > 0 ? Status::OK() : Status::EndOfFile("");
+}
+
+} // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/hdfs_scanner_text.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_text.cpp
@@ -45,7 +45,7 @@ Status HdfsTextScanner::do_init(RuntimeState* runtime_state, const HdfsScannerPa
 
 Status HdfsTextScanner::do_open(RuntimeState* runtime_state) {
     _reader = std::make_unique<HdfsScannerCSVReader>(_scanner_params.fs, _record_delimiter, _field_delimiter,
-                                          _scanner_params.scan_ranges[0]->offset);
+                                                     _scanner_params.scan_ranges[0]->offset);
     for (int i = 0; i < _scanner_params.materialize_slots.size(); i++) {
         auto slot = _scanner_params.materialize_slots[i];
         ConverterPtr conv = csv::get_converter(slot->type(), true);

--- a/be/src/exec/vectorized/hdfs_scanner_text.h
+++ b/be/src/exec/vectorized/hdfs_scanner_text.h
@@ -1,0 +1,46 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#pragma once
+
+#include "exec/vectorized/hdfs_scanner.h"
+#include "formats/csv/converter.h"
+#include "formats/csv/csv_reader.h"
+
+namespace starrocks::vectorized {
+
+class HdfsTextScanner final : public HdfsScanner {
+public:
+    HdfsTextScanner() = default;
+    ~HdfsTextScanner() override = default;
+
+    Status do_open(RuntimeState* runtime_state) override;
+    void do_close(RuntimeState* runtime_state) noexcept override;
+    Status do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) override;
+    Status do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) override;
+    Status _parse_csv(ChunkPtr* chunk);
+
+private:
+    class HdfsScannerCSVReader : public CSVReader {
+    public:
+        HdfsScannerCSVReader(std::shared_ptr<RandomAccessFile> file, char record_delimiter, string field_delimiter, size_t offset)
+                :CSVReader(record_delimiter, field_delimiter) {
+            _file = file;
+            _offset = offset;
+        }
+
+        Status _fill_buffer() override;
+
+    private:
+        std::shared_ptr<RandomAccessFile> _file;
+        size_t _offset = 0;
+    };
+
+    using ConverterPtr = std::unique_ptr<csv::Converter>;
+
+    char _record_delimiter;
+    string _field_delimiter;
+    std::vector<Column*> _column_raw_ptrs;
+    std::vector<ConverterPtr> _converters;
+    std::shared_ptr<CSVReader> _reader = nullptr;
+};
+} // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/hdfs_scanner_text.h
+++ b/be/src/exec/vectorized/hdfs_scanner_text.h
@@ -22,8 +22,9 @@ public:
 private:
     class HdfsScannerCSVReader : public CSVReader {
     public:
-        HdfsScannerCSVReader(std::shared_ptr<RandomAccessFile> file, char record_delimiter, string field_delimiter, size_t offset)
-                :CSVReader(record_delimiter, field_delimiter) {
+        HdfsScannerCSVReader(std::shared_ptr<RandomAccessFile> file, char record_delimiter, string field_delimiter,
+                             size_t offset)
+                : CSVReader(record_delimiter, field_delimiter) {
             _file = file;
             _offset = offset;
         }

--- a/be/src/formats/CMakeLists.txt
+++ b/be/src/formats/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(Formats STATIC
         csv/binary_converter.cpp
         csv/boolean_converter.cpp
         csv/converter.cpp
+        csv/csv_reader.cpp
         csv/date_converter.cpp
         csv/datetime_converter.cpp
         csv/decimalv2_converter.cpp

--- a/be/src/formats/csv/csv_reader.cpp
+++ b/be/src/formats/csv/csv_reader.cpp
@@ -1,0 +1,73 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#include "formats/csv/csv_reader.h"
+
+namespace starrocks::vectorized {
+
+Status CSVReader::next_record(Record* record) {
+    if (_limit > 0 && _parsed_bytes > _limit) {
+        return Status::EndOfFile("Reached limit");
+    }
+    char* d;
+    size_t pos = 0;
+    while ((d = _buff.find(_record_delimiter, pos)) == nullptr) {
+        pos = _buff.available();
+        _buff.compact();
+        if (_buff.free_space() == 0) {
+            RETURN_IF_ERROR(_expand_buffer());
+        }
+        RETURN_IF_ERROR(_fill_buffer());
+    }
+    size_t l = d - _buff.position();
+    *record = Record(_buff.position(), l);
+    _buff.skip(l + 1);
+    //               ^^ skip record delimiter.
+    _parsed_bytes += l + 1;
+    return Status::OK();
+}
+
+Status CSVReader::_expand_buffer() {
+    if (UNLIKELY(_storage.size() >= kMaxBufferSize)) {
+        return Status::InternalError("CSV line length exceed limit " + std::to_string(kMaxBufferSize));
+    }
+    size_t new_capacity = std::min(_storage.size() * 2, kMaxBufferSize);
+    DCHECK_EQ(_storage.data(), _buff.position()) << "should compact buffer before expand";
+    _storage.resize(new_capacity);
+    CSVBuffer new_buff(_storage.data(), _storage.size());
+    new_buff.add_limit(_buff.available());
+    DCHECK_EQ(_storage.data(), new_buff.position());
+    DCHECK_EQ(_buff.available(), new_buff.available());
+    _buff = new_buff;
+    return Status::OK();
+}
+
+void CSVReader::split_record(const Record& record, Fields* fields) const {
+    const char* value = record.data;
+    const char* ptr = record.data;
+    const size_t size = record.size;
+
+    if (_field_delimiter.size() == 1) {
+        for (size_t i = 0; i < size; ++i, ++ptr) {
+            if (*ptr == _field_delimiter[0]) {
+                fields->emplace_back(value, ptr - value);
+                value = ptr + 1;
+            }
+        }
+    } else {
+        const auto fd_size = _field_delimiter.size();
+        const auto* const base = ptr;
+
+        do {
+            ptr = static_cast<char*>(memmem(value, size - (value - base), _field_delimiter.data(), fd_size));
+            if (ptr != nullptr) {
+                fields->emplace_back(value, ptr - value);
+                value = ptr + fd_size;
+            }
+        } while (ptr != nullptr);
+
+        ptr = record.data + size;
+    }
+    fields->emplace_back(value, ptr - value);
+}
+
+} // namespace starrocks::vectorized

--- a/be/src/formats/csv/csv_reader.h
+++ b/be/src/formats/csv/csv_reader.h
@@ -88,9 +88,7 @@ protected:
     raw::RawVector<char> _storage;
     CSVBuffer _buff;
 
-    virtual Status _fill_buffer() {
-        return Status::InternalError("unsupported csv reader!");
-    }
+    virtual Status _fill_buffer() { return Status::InternalError("unsupported csv reader!"); }
 
 private:
     Status _expand_buffer();

--- a/be/src/formats/csv/csv_reader.h
+++ b/be/src/formats/csv/csv_reader.h
@@ -1,0 +1,103 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#pragma once
+
+#include "formats/csv/converter.h"
+
+namespace starrocks::vectorized {
+class CSVBuffer {
+public:
+    // Does NOT take the ownership of |buff|.
+    CSVBuffer(char* buff, size_t cap) : _begin(buff), _position(buff), _limit(buff), _end(buff + cap) {}
+
+    void append(char c) { *_limit++ = c; }
+
+    // Returns the number of bytes between the current position and the limit.
+    size_t available() const { return _limit - _position; }
+
+    // Returns the number of elements between the the limit and the end.
+    size_t free_space() const { return _end - _limit; }
+
+    // Returns this buffer's capacity.
+    size_t capacity() const { return _end - _begin; }
+
+    // Returns this buffer's read position.
+    char* position() { return _position; }
+
+    // Returns this buffer's write position.
+    char* limit() { return _limit; }
+
+    void add_limit(size_t n) { _limit += n; }
+
+    // Finds the first character equal to the given character |c|. Search begins at |pos|.
+    // Return: address of the first character of the found character or NULL if no such
+    // character is found.
+    char* find(char c, size_t pos = 0) { return (char*)memchr(position() + pos, c, available() - pos); }
+
+    void skip(size_t n) { _position += n; }
+
+    // Compacts this buffer.
+    // The bytes between the buffer's current position and its limit, if any,
+    // are copied to the beginning of the buffer.
+    void compact() {
+        size_t n = available();
+        memmove(_begin, _position, available());
+        _limit = _begin + n;
+        _position = _begin;
+    }
+
+private:
+    char* _begin;
+    char* _position; // next read position
+    char* _limit;    // next write position
+    char* _end;
+};
+
+class CSVReader {
+#ifndef BE_TEST
+    constexpr static size_t kMinBufferSize = 8 * 1024 * 1024L;
+    constexpr static size_t kMaxBufferSize = 512 * 1024 * 1024L;
+#else
+    constexpr static size_t kMinBufferSize = 128 * 1024L;
+    constexpr static size_t kMaxBufferSize = 512 * 1024L;
+#endif
+
+public:
+    using Record = Slice;
+    using Field = Slice;
+    using Fields = std::vector<Field>;
+
+    CSVReader(char record_delimiter, string field_delimiter)
+            : _record_delimiter(record_delimiter),
+              _field_delimiter(std::move(field_delimiter)),
+              _storage(kMinBufferSize),
+              _buff(_storage.data(), _storage.size()) {}
+
+    virtual ~CSVReader() {}
+
+    Status next_record(Record* record);
+
+    void set_limit(size_t limit) { _limit = limit; }
+
+    void split_record(const Record& record, Fields* fields) const;
+
+protected:
+    // TODO: support string
+    char _record_delimiter;
+    string _field_delimiter;
+    raw::RawVector<char> _storage;
+    CSVBuffer _buff;
+
+    virtual Status _fill_buffer() {
+        return Status::InternalError("unsupported csv reader!");
+    }
+
+private:
+    Status _expand_buffer();
+
+    size_t _parsed_bytes = 0;
+    size_t _limit = 0;
+    size_t _offset = 0;
+};
+
+} // namespace starrocks::vectorized

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HdfsFileDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HdfsFileDesc.java
@@ -3,6 +3,7 @@
 package com.starrocks.external.hive;
 
 import com.google.common.collect.ImmutableList;
+import com.starrocks.external.hive.text.TextFileFormatDesc;
 
 public class HdfsFileDesc {
     private String fileName;
@@ -10,6 +11,7 @@ public class HdfsFileDesc {
     private long length;
     private ImmutableList<HdfsFileBlockDesc> blockDescs;
     private boolean splittable;
+    private TextFileFormatDesc textFileFormatDesc;
 
     public HdfsFileDesc(String fileName, String compression, long length,
                         ImmutableList<HdfsFileBlockDesc> blockDescs) {
@@ -21,9 +23,11 @@ public class HdfsFileDesc {
     }
 
     public HdfsFileDesc(String fileName, String compression, long length,
-                        ImmutableList<HdfsFileBlockDesc> blockDescs, boolean splittable) {
+                        ImmutableList<HdfsFileBlockDesc> blockDescs, boolean splittable,
+                        TextFileFormatDesc textFileFormatDesc) {
         this(fileName, compression, length, blockDescs);
         this.splittable = splittable;
+        this.textFileFormatDesc = textFileFormatDesc;
     }
 
     public String getFileName() {
@@ -44,5 +48,9 @@ public class HdfsFileDesc {
 
     public boolean isSplittable() {
         return splittable;
+    }
+
+    public TextFileFormatDesc getTextFileFormatDesc() {
+        return textFileFormatDesc;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HdfsFileFormat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HdfsFileFormat.java
@@ -8,17 +8,20 @@ import com.starrocks.thrift.THdfsFileFormat;
 public enum HdfsFileFormat {
     UNKNOWN("unknown"),
     PARQUET("org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat"),
-    ORC("org.apache.hadoop.hive.ql.io.orc.OrcInputFormat");
+    ORC("org.apache.hadoop.hive.ql.io.orc.OrcInputFormat"),
+    TEXT("org.apache.hadoop.mapred.TextInputFormat");
 
     private static final ImmutableMap<String, HdfsFileFormat> validInputFormats =
             new ImmutableMap.Builder<String, HdfsFileFormat>()
                     .put("org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat", PARQUET)
                     .put("org.apache.hadoop.hive.ql.io.orc.OrcInputFormat", ORC)
+                    .put("org.apache.hadoop.mapred.TextInputFormat", TEXT)
                     .build();
     private static final ImmutableMap<String, Boolean> fileFormatSplittableInfos =
             new ImmutableMap.Builder<String, Boolean>()
                     .put("org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat", true)
                     .put("org.apache.hadoop.hive.ql.io.orc.OrcInputFormat", true)
+                    .put("org.apache.hadoop.mapred.TextInputFormat", true)
                     .build();
 
     private final String inputFormat;
@@ -41,6 +44,8 @@ public enum HdfsFileFormat {
                 return THdfsFileFormat.PARQUET;
             case ORC:
                 return THdfsFileFormat.ORC;
+            case TEXT:
+                return THdfsFileFormat.TEXT;
             default:
                 break;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaClient.java
@@ -15,6 +15,7 @@ import com.starrocks.catalog.Type;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.external.ObejctStorageUtils;
+import com.starrocks.external.hive.text.TextFileFormatDesc;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.FileStatus;
@@ -188,7 +189,8 @@ public class HiveMetaClient {
 
             String path = ObejctStorageUtils.formatObjectStoragePath(sd.getLocation());
             List<HdfsFileDesc> fileDescs = getHdfsFileDescs(path,
-                    ObejctStorageUtils.isObjectStorage(path) || HdfsFileFormat.isSplittable(sd.getInputFormat()));
+                    ObejctStorageUtils.isObjectStorage(path) || HdfsFileFormat.isSplittable(sd.getInputFormat()),
+                    sd);
             return new HivePartition(format, ImmutableList.copyOf(fileDescs), path);
         } catch (NoSuchObjectException e) {
             throw new DdlException("get hive partition meta data failed: "
@@ -452,10 +454,16 @@ public class HiveMetaClient {
         }
     }
 
-    private List<HdfsFileDesc> getHdfsFileDescs(String dirPath, boolean isSplittable) throws Exception {
+    private List<HdfsFileDesc> getHdfsFileDescs(String dirPath, boolean isSplittable,
+                                                StorageDescriptor sd) throws Exception {
         URI uri = new URI(dirPath);
         FileSystem fileSystem = getFileSystem(uri);
         List<HdfsFileDesc> fileDescs = Lists.newArrayList();
+        // get properties like 'field.delim' and 'line.delim' from StorageDescriptor
+        TextFileFormatDesc textFileFormatDesc = new TextFileFormatDesc(
+                sd.getSerdeInfo().getParameters().getOrDefault("field.delim", ","),
+                sd.getSerdeInfo().getParameters().getOrDefault("line.delim", "\n"));
+
         // fileSystem.listLocatedStatus is an api to list all statuses and
         // block locations of the files in the given path in one operation.
         // The performance is better than getting status and block location one by one.
@@ -470,7 +478,7 @@ public class HiveMetaClient {
                 BlockLocation[] blockLocations = locatedFileStatus.getBlockLocations();
                 List<HdfsFileBlockDesc> fileBlockDescs = getHdfsFileBlockDescs(blockLocations);
                 fileDescs.add(new HdfsFileDesc(fileName, "", locatedFileStatus.getLen(),
-                        ImmutableList.copyOf(fileBlockDescs), isSplittable));
+                        ImmutableList.copyOf(fileBlockDescs), isSplittable, textFileFormatDesc));
             }
         } catch (FileNotFoundException ignored) {
             // hive empty partition may not create directory

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/text/TextFileFormatDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/text/TextFileFormatDesc.java
@@ -1,0 +1,22 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+package com.starrocks.external.hive.text;
+
+import com.starrocks.thrift.TTextFileDesc;
+
+public class TextFileFormatDesc {
+    private String fieldDelim;
+    private String lineDelim;
+
+    public TextFileFormatDesc(String fDelim, String lDelim) {
+        this.fieldDelim = fDelim;
+        this.lineDelim = lDelim;
+    }
+
+    public TTextFileDesc toThrift() {
+        TTextFileDesc desc = new TTextFileDesc();
+        desc.field_delim = fieldDelim;
+        desc.line_delim = lineDelim;
+        return desc;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
@@ -30,6 +30,7 @@ import com.starrocks.external.hive.HdfsFileBlockDesc;
 import com.starrocks.external.hive.HdfsFileDesc;
 import com.starrocks.external.hive.HdfsFileFormat;
 import com.starrocks.external.hive.HivePartition;
+import com.starrocks.external.hive.text.TextFileFormatDesc;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.system.Backend;
 import com.starrocks.thrift.TExplainLevel;
@@ -401,7 +402,8 @@ public class HdfsScanNode extends ScanNode {
         do {
             if (remainingBytes <= splitSize) {
                 createScanRangeLocationsForSplit(partitionId, fileDesc,
-                        blockDesc, fileFormat, offset + length - remainingBytes, remainingBytes);
+                        blockDesc, fileFormat, offset + length - remainingBytes,
+                        remainingBytes);
                 remainingBytes = 0;
             } else if (remainingBytes <= 2 * splitSize) {
                 long mid = (remainingBytes + 1) / 2;
@@ -413,7 +415,8 @@ public class HdfsScanNode extends ScanNode {
                 remainingBytes = 0;
             } else {
                 createScanRangeLocationsForSplit(partitionId, fileDesc,
-                        blockDesc, fileFormat, offset + length - remainingBytes, splitSize);
+                        blockDesc, fileFormat, offset + length - remainingBytes,
+                        splitSize);
                 remainingBytes -= splitSize;
             }
         } while (remainingBytes > 0);
@@ -433,6 +436,7 @@ public class HdfsScanNode extends ScanNode {
         hdfsScanRange.setPartition_id(partitionId);
         hdfsScanRange.setFile_length(fileDesc.getLength());
         hdfsScanRange.setFile_format(fileFormat.toThrift());
+        hdfsScanRange.setText_file_desc(fileDesc.getTextFileFormatDesc().toThrift());
         TScanRange scanRange = new TScanRange();
         scanRange.setHdfs_scan_range(hdfsScanRange);
         scanRangeLocations.setScan_range(scanRange);

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -56,6 +56,16 @@ enum THdfsFileFormat {
   ORC,
 }
 
+
+// Text file desc
+struct TTextFileDesc {
+    // property 'field.delim'
+    1: optional string  field_delim
+
+    // property 'line.delim'
+    2: optional string line_delim
+}
+
 enum TSchemaTableType {
     SCH_AUTHORS= 0,
     SCH_CHARSETS,

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -214,6 +214,9 @@ struct THdfsScanRange {
 
     // file format of hdfs file
     6: optional Descriptors.THdfsFileFormat file_format
+
+    // text file desc
+    7: optional Descriptors.TTextFileDesc text_file_desc
 }
 
 // Specification of an individual data range which is held in its entirety


### PR DESCRIPTION
Close #1873 
Add support for TextInputFormat, 
```
CREATE EXTERNAL RESOURCE "hive0" PROPERTIES (   "type" = "hive",   "hive.metastore.uris" = "thrift://xxxx:9083" );

CREATE EXTERNAL TABLE `csv_test` (
  `countryid` int NULL,
  `countryname` string NULL,
  `capital` string NULL,
  `population` string NULL
) ENGINE=HIVE
PROPERTIES (
  "resource" = "hive0",
  "database" = "default",
  "table" = "countries_list"
);

MySQL [hive_test]> select population from csv_test limit 2;
+------------+
| population |
+------------+
| 328 |
| 80         |
+------------+
MySQL [hive_test]> select * from csv_test;
+-----------+-------------+---------+------------+
| countryid | countryname | capital | population |
+-----------+-------------+---------+------------+
|         0 | China       | BeiJing | 80         |
|         1 | USA         | Wash    | 328        |
|         0 | China       | BeiJing | 80         |
|         1 | USA         | Wash    | 328        |
+-----------+-------------+---------+------------+
MySQL [hive_test]> select distinct(countryid) from csv_test;
+-----------+
| countryid |
+-----------+
|         0 |
|         1 |
+-----------+
3 rows in set (1.25 sec)
```
Since we can not get schema from file, we just parse column from row record in order. For example, if we create table
```
CREATE EXTERNAL TABLE `csv_test` (
  `countryid` int NULL,
  `population` string NULL
) ENGINE=HIVE
PROPERTIES (
  "resource" = "hive0",
  "database" = "default",
  "table" = "countries_list"
);
```
It will always return `countryname` for `population`. Some other system like hive and impala has the same semantics.