### PR TITLE
Fix table function node statistics error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -930,12 +930,18 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
 
     @Override
     public Void visitLogicalTableFunction(LogicalTableFunctionOperator node, ExpressionContext context) {
-        return computeTableFunctionNode(context, node.getOutputColumns(null));
+        ColumnRefSet columnRefSet = new ColumnRefSet();
+        columnRefSet.union(node.getFnResultColumnRefSet());
+        columnRefSet.union(node.getOuterColumnRefSet());
+        return computeTableFunctionNode(context, columnRefSet);
     }
 
     @Override
     public Void visitPhysicalTableFunction(PhysicalTableFunctionOperator node, ExpressionContext context) {
-        return computeTableFunctionNode(context, node.getOutputColumns());
+        ColumnRefSet columnRefSet = new ColumnRefSet();
+        columnRefSet.union(node.getFnResultColumnRefSet());
+        columnRefSet.union(node.getOuterColumnRefSet());
+        return computeTableFunctionNode(context, columnRefSet);
     }
 
     private Void computeTableFunctionNode(ExpressionContext context, ColumnRefSet outputColumns) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/ExecPlan.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/ExecPlan.java
@@ -10,6 +10,7 @@ import com.starrocks.planner.ScanNode;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.Explain;
 import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.thrift.TExplainLevel;
 
@@ -32,14 +33,17 @@ public class ExecPlan {
 
     private final OptExpression physicalPlan;
     private final List<ColumnRefOperator> outputColumns;
+    private final ColumnRefFactory columnRefFactory;
 
     public ExecPlan(PlannerContext planCtx, ConnectContext connectContext, List<String> colNames,
-                    OptExpression physicalPlan, List<ColumnRefOperator> outputColumns) {
+                    OptExpression physicalPlan, List<ColumnRefOperator> outputColumns,
+                    ColumnRefFactory columnRefFactory) {
         this.planCtx = planCtx;
         this.connectContext = connectContext;
         this.colNames = colNames;
         this.physicalPlan = physicalPlan;
         this.outputColumns = outputColumns;
+        this.columnRefFactory = columnRefFactory;
     }
 
     public ConnectContext getConnectContext() {
@@ -93,7 +97,7 @@ public class ExecPlan {
     public String getExplainString(TExplainLevel level) {
         StringBuilder str = new StringBuilder();
         if (level == null) {
-            str.append(Explain.toString(physicalPlan, outputColumns));
+            str.append(Explain.toString(physicalPlan, outputColumns, columnRefFactory));
         } else {
             if (planCount != 0) {
                 str.append("There are ").append(planCount).append(" plans in optimizer search space\n");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -132,7 +132,8 @@ public class PlanFragmentBuilder {
     public ExecPlan createPhysicalPlan(OptExpression plan, PlannerContext plannerContext, ConnectContext connectContext,
                                        List<ColumnRefOperator> outputColumns, ColumnRefFactory columnRefFactory,
                                        List<String> colNames) {
-        ExecPlan execPlan = new ExecPlan(plannerContext, connectContext, colNames, plan, outputColumns);
+        ExecPlan execPlan =
+                new ExecPlan(plannerContext, connectContext, colNames, plan, outputColumns, columnRefFactory);
         createOutputFragment(new PhysicalPlanTranslator(columnRefFactory).visit(plan, execPlan), execPlan,
                 outputColumns);
         execPlan.setPlanCount(plan.getPlanCount());
@@ -144,7 +145,8 @@ public class PlanFragmentBuilder {
                                                             List<ColumnRefOperator> outputColumns,
                                                             ColumnRefFactory columnRefFactory,
                                                             List<String> colNames) {
-        ExecPlan execPlan = new ExecPlan(plannerContext, connectContext, colNames, plan, outputColumns);
+        ExecPlan execPlan =
+                new ExecPlan(plannerContext, connectContext, colNames, plan, outputColumns, columnRefFactory);
         PlanFragment root = new PhysicalPlanTranslator(columnRefFactory).visit(plan, execPlan);
 
         List<Expr> outputExprs = outputColumns.stream().map(variable -> ScalarOperatorToExpr
@@ -162,7 +164,8 @@ public class PlanFragmentBuilder {
                                                 ConnectContext connectContext,
                                                 List<ColumnRefOperator> outputColumns,
                                                 ColumnRefFactory columnRefFactory, boolean isStatistic) {
-        ExecPlan execPlan = new ExecPlan(plannerContext, connectContext, new ArrayList<>(), plan, outputColumns);
+        ExecPlan execPlan =
+                new ExecPlan(plannerContext, connectContext, new ArrayList<>(), plan, outputColumns, columnRefFactory);
         createOutputFragment(new PhysicalPlanTranslator(columnRefFactory).visit(plan, execPlan), execPlan,
                 outputColumns);
 
@@ -187,7 +190,7 @@ public class PlanFragmentBuilder {
         }
 
         List<Expr> outputExprs = outputColumns.stream().map(variable -> ScalarOperatorToExpr
-                .buildExecExpression(variable, new ScalarOperatorToExpr.FormatterContext(execPlan.getColRefToExpr())))
+                        .buildExecExpression(variable, new ScalarOperatorToExpr.FormatterContext(execPlan.getColRefToExpr())))
                 .collect(Collectors.toList());
         execPlan.getOutputExprs().addAll(outputExprs);
 
@@ -1118,7 +1121,7 @@ public class PlanFragmentBuilder {
                 }
                 List<Expr> distributeExpressions =
                         partitionColumns.stream().map(e -> ScalarOperatorToExpr.buildExecExpression(e,
-                                new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
+                                        new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
                                 .collect(Collectors.toList());
                 dataPartition = DataPartition.hashPartitioned(distributeExpressions);
             } else {
@@ -1357,7 +1360,7 @@ public class PlanFragmentBuilder {
 
                 List<Expr> eqJoinConjuncts =
                         eqOnPredicates.stream().map(e -> ScalarOperatorToExpr.buildExecExpression(e,
-                                new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
+                                        new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
                                 .collect(Collectors.toList());
 
                 for (Expr expr : eqJoinConjuncts) {
@@ -1369,13 +1372,13 @@ public class PlanFragmentBuilder {
                 List<ScalarOperator> otherJoin = Utils.extractConjuncts(node.getJoinPredicate());
                 otherJoin.removeAll(eqOnPredicates);
                 List<Expr> otherJoinConjuncts = otherJoin.stream().map(e -> ScalarOperatorToExpr.buildExecExpression(e,
-                        new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
+                                new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
                         .collect(Collectors.toList());
 
                 // 3. Get conjuncts
                 List<ScalarOperator> predicates = Utils.extractConjuncts(node.getPredicate());
                 List<Expr> conjuncts = predicates.stream().map(e -> ScalarOperatorToExpr.buildExecExpression(e,
-                        new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
+                                new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
                         .collect(Collectors.toList());
 
                 if (joinOperator.isLeftOuterJoin()) {
@@ -1436,14 +1439,14 @@ public class PlanFragmentBuilder {
                             .map(columnRefFactory::getColumnRef).collect(Collectors.toList());
                     List<Expr> leftJoinExprs =
                             leftPredicates.stream().map(e -> ScalarOperatorToExpr.buildExecExpression(e,
-                                    new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
+                                            new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
                                     .collect(Collectors.toList());
 
                     List<ScalarOperator> rightPredicates = rightOnPredicateColumns.stream()
                             .map(columnRefFactory::getColumnRef).collect(Collectors.toList());
                     List<Expr> rightJoinExprs =
                             rightPredicates.stream().map(e -> ScalarOperatorToExpr.buildExecExpression(e,
-                                    new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
+                                            new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
                                     .collect(Collectors.toList());
 
                     DataPartition lhsJoinPartition = new DataPartition(TPartitionType.HASH_PARTITIONED,
@@ -1711,7 +1714,7 @@ public class PlanFragmentBuilder {
 
             List<Expr> partitionExprs =
                     node.getPartitionExpressions().stream().map(e -> ScalarOperatorToExpr.buildExecExpression(e,
-                            new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
+                                    new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
                             .collect(Collectors.toList());
 
             List<OrderByElement> orderByElements = node.getOrderByElements().stream().map(e -> new OrderByElement(

--- a/fe/fe-core/src/test/resources/sql/optimized-plan/lateral.sql
+++ b/fe/fe-core/src/test/resources/sql/optimized-plan/lateral.sql
@@ -54,3 +54,25 @@ select v1 from tarray, unnest(v3) limit 5
 TABLE FUNCTION (unnest) LIMIT 5
     SCAN (columns[1: v1, 3: v3] predicate[null])
 [end]
+
+[sql]
+select v1,v2,unnest + 1 from t0,unnest([1,2,3]);
+[result]
+TABLE FUNCTION (unnest)
+    SCAN (columns[1: v1, 2: v2] predicate[null])
+[end]
+
+[sql]
+select *,u from (select v1,v2,unnest + 1 as u from t0,unnest([1,2,3])) t;
+[result]
+TABLE FUNCTION (unnest)
+    SCAN (columns[1: v1, 2: v2] predicate[null])
+[end]
+
+[sql]
+select v1,v2,unnest + 1 from t0,unnest([1,2,3]) where unnest = 1;
+[result]
+PREDICATE 4: unnest = 1
+    TABLE FUNCTION (unnest)
+        SCAN (columns[1: v1, 2: v2] predicate[null])
+[end]


### PR DESCRIPTION
When the LogicalProject and LogicalTableFunction nodes are merged, the return value of outputColumns will be changed. The StatisticsCalculator needs to return the columns needed in the projection to meet the statistical information calculation of the expression
 #2000