### PR TITLE
Use hdfsPreadFully to reduce the amount of JNI array allocation for object storage

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -665,7 +665,7 @@ CONF_Int64(max_segment_file_size, "1073741824");
 // Enables using hdfsPreadFully() instead of hdfsRead() when performing HDFS read operations.
 // This is necessary to use HDFS hedged reads (assuming the HDFS client is configured to do so).
 // hdfsPreadFully() are always enabled for object storage.
-CONF_Bool(use_hdfs_pread, "false");
+CONF_Bool(use_hdfs_pread, "true");
 
 } // namespace config
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -662,6 +662,11 @@ CONF_mInt32(buffer_stream_reserve_size, "8192000");
 
 CONF_Int64(max_segment_file_size, "1073741824");
 
+// Enables using hdfsPreadFully() instead of hdfsRead() when performing HDFS read operations.
+// This is necessary to use HDFS hedged reads (assuming the HDFS client is configured to do so).
+// hdfsPreadFully() are always enabled for object storage.
+CONF_Bool(use_hdfs_pread, "false");
+
 } // namespace config
 
 } // namespace starrocks

--- a/be/src/env/env_hdfs.cpp
+++ b/be/src/env/env_hdfs.cpp
@@ -53,8 +53,8 @@ static Status read_at_internal(hdfsFS fs, hdfsFile file, const std::string& file
         }
         if (cur_offset != offset) {
             if (hdfsSeek(fs, file, offset)) {
-                return Status::IOError(strings::Substitute("fail to seek offset, file=$0, offset=$1, error=$2", file_name,
-                                                           offset, get_hdfs_err_msg()));
+                return Status::IOError(strings::Substitute("fail to seek offset, file=$0, offset=$1, error=$2",
+                                                           file_name, offset, get_hdfs_err_msg()));
             }
         }
         size_t bytes_read = 0;

--- a/be/src/env/env_hdfs.cpp
+++ b/be/src/env/env_hdfs.cpp
@@ -10,8 +10,8 @@
 
 namespace starrocks {
 
-HdfsRandomAccessFile::HdfsRandomAccessFile(hdfsFS fs, std::string filename)
-        : _opened(false), _fs(fs), _file(nullptr), _filename(std::move(filename)) {}
+HdfsRandomAccessFile::HdfsRandomAccessFile(hdfsFS fs, std::string filename, bool usePread)
+        : _opened(false), _fs(fs), _file(nullptr), _filename(std::move(filename)), _usePread(usePread) {}
 
 HdfsRandomAccessFile::~HdfsRandomAccessFile() noexcept {
     close();
@@ -38,7 +38,8 @@ void HdfsRandomAccessFile::close() noexcept {
     }
 }
 
-static Status read_at_internal(hdfsFS fs, hdfsFile file, const std::string& file_name, int64_t offset, Slice* res) {
+static Status read_at_internal(hdfsFS fs, hdfsFile file, const std::string& file_name, int64_t offset, Slice* res,
+                               bool usePread) {
     auto cur_offset = hdfsTell(fs, file);
     if (cur_offset == -1) {
         return Status::IOError(
@@ -46,36 +47,43 @@ static Status read_at_internal(hdfsFS fs, hdfsFile file, const std::string& file
     }
     if (cur_offset != offset) {
         if (hdfsSeek(fs, file, offset)) {
-            return Status::IOError(strings::Substitute("fail to seek offset, file=$0, offset=$1, error=$1", file_name,
+            return Status::IOError(strings::Substitute("fail to seek offset, file=$0, offset=$1, error=$2", file_name,
                                                        offset, get_hdfs_err_msg()));
         }
     }
-    size_t bytes_read = 0;
-    while (bytes_read < res->size) {
-        size_t to_read = res->size - bytes_read;
-        auto hdfs_res = hdfsRead(fs, file, res->data + bytes_read, to_read);
-        if (hdfs_res < 0) {
-            return Status::IOError(
-                    strings::Substitute("fail to read file, file=$0, error=$1", file_name, get_hdfs_err_msg()));
-        } else if (hdfs_res == 0) {
-            break;
+    if (usePread) {
+        if (hdfsPreadFully(fs, file, offset, res->data, res->size) == -1) {
+            return Status::IOError(strings::Substitute("fail to hdfsPreadFully file, file=$0, error=$1", file_name,
+                                                       get_hdfs_err_msg()));
         }
-        bytes_read += hdfs_res;
+    } else {
+        size_t bytes_read = 0;
+        while (bytes_read < res->size) {
+            size_t to_read = res->size - bytes_read;
+            auto hdfs_res = hdfsRead(fs, file, res->data + bytes_read, to_read);
+            if (hdfs_res < 0) {
+                return Status::IOError(
+                        strings::Substitute("fail to hdfsRead file, file=$0, error=$1", file_name, get_hdfs_err_msg()));
+            } else if (hdfs_res == 0) {
+                break;
+            }
+            bytes_read += hdfs_res;
+        }
+        res->size = bytes_read;
     }
-    res->size = bytes_read;
     return Status::OK();
 }
 
 Status HdfsRandomAccessFile::read(uint64_t offset, Slice* res) const {
     DCHECK(_opened);
-    RETURN_IF_ERROR(read_at_internal(_fs, _file, _filename, offset, res));
+    RETURN_IF_ERROR(read_at_internal(_fs, _file, _filename, offset, res, _usePread));
     return Status::OK();
 }
 
 Status HdfsRandomAccessFile::read_at(uint64_t offset, const Slice& res) const {
     DCHECK(_opened);
     Slice slice = res;
-    RETURN_IF_ERROR(read_at_internal(_fs, _file, _filename, offset, &slice));
+    RETURN_IF_ERROR(read_at_internal(_fs, _file, _filename, offset, &slice, _usePread));
     if (slice.size != res.size) {
         return Status::InternalError(
                 strings::Substitute("fail to read enough data, file=$0, offset=$1, size=$2, expect=$3", _filename,

--- a/be/src/env/env_hdfs.h
+++ b/be/src/env/env_hdfs.h
@@ -12,7 +12,7 @@ namespace starrocks {
 // Now this is not thread-safe.
 class HdfsRandomAccessFile : public RandomAccessFile {
 public:
-    HdfsRandomAccessFile(hdfsFS fs, std::string filename);
+    HdfsRandomAccessFile(hdfsFS fs, std::string filename, bool usePread);
     virtual ~HdfsRandomAccessFile() noexcept;
 
     Status open();
@@ -31,6 +31,7 @@ private:
     hdfsFS _fs;
     hdfsFile _file;
     std::string _filename;
+    bool _usePread;
 };
 
 } // namespace starrocks

--- a/be/src/exec/vectorized/hdfs_scan_node.cpp
+++ b/be/src/exec/vectorized/hdfs_scan_node.cpp
@@ -19,6 +19,7 @@
 #include "runtime/runtime_state.h"
 #include "storage/vectorized/chunk_helper.h"
 #include "util/defer_op.h"
+#include "util/hdfs_util.h"
 #include "util/priority_thread_pool.hpp"
 
 namespace starrocks::vectorized {
@@ -587,7 +588,9 @@ Status HdfsScanNode::_find_and_insert_hdfs_file(const THdfsScanRange& scan_range
     file_path /= scan_range.relative_path;
     const std::string& native_file_path = file_path.native();
     std::string namenode;
-    RETURN_IF_ERROR(_get_name_node_from_path(native_file_path, &namenode));
+    RETURN_IF_ERROR(get_name_node_from_path(native_file_path, &namenode));
+    _is_hdfs_fs = is_hdfs_path(namenode.c_str());
+    bool usePread = starrocks::config::use_hdfs_pread || is_object_storage_path(namenode.c_str());
 
     if (namenode.compare("default") == 0) {
         // local file, current only for test
@@ -611,7 +614,7 @@ Status HdfsScanNode::_find_and_insert_hdfs_file(const THdfsScanRange& scan_range
         RETURN_IF_ERROR(HdfsFsCache::instance()->get_connection(namenode, &hdfs, &open_limit));
         auto* hdfs_file_desc = _pool->add(new HdfsFileDesc());
         hdfs_file_desc->hdfs_fs = hdfs;
-        hdfs_file_desc->fs = std::make_shared<HdfsRandomAccessFile>(hdfs, native_file_path);
+        hdfs_file_desc->fs = std::make_shared<HdfsRandomAccessFile>(hdfs, native_file_path, usePread);
         hdfs_file_desc->partition_id = scan_range.partition_id;
         hdfs_file_desc->path = scan_range.relative_path;
         hdfs_file_desc->file_length = scan_range.file_length;
@@ -621,41 +624,6 @@ Status HdfsScanNode::_find_and_insert_hdfs_file(const THdfsScanRange& scan_range
         _hdfs_files.emplace_back(hdfs_file_desc);
     }
 
-    std::unordered_set<std::string> object_storage_scheme_set = {"s3a://", "oss://"};
-    for (string scheme : object_storage_scheme_set) {
-        if (namenode.rfind(scheme, 0) == 0) {
-            _is_hdfs_fs = false;
-            break;
-        }
-    }
-
-    return Status::OK();
-}
-
-Status HdfsScanNode::_get_name_node_from_path(const std::string& path, std::string* namenode) {
-    const string local_fs("file:/");
-    size_t n = path.find("://");
-
-    if (n == string::npos) {
-        if (path.compare(0, local_fs.length(), local_fs) == 0) {
-            // Hadoop Path routines strip out consecutive /'s, so recognize 'file:/blah'.
-            *namenode = "file:///";
-        } else {
-            // Path is not qualified, so use the default FS.
-            *namenode = "default";
-        }
-    } else if (n == 0) {
-        return Status::InternalError("Path missing schema");
-    } else {
-        // Path is qualified, i.e. "scheme://authority/path/to/file".  Extract
-        // "scheme://authority/".
-        n = path.find('/', n + 3);
-        if (n == string::npos) {
-            return Status::InternalError("Path missing '/' after authority");
-        }
-        // Include the trailing '/' for local filesystem case, i.e. "file:///".
-        *namenode = path.substr(0, n + 1);
-    }
     return Status::OK();
 }
 

--- a/be/src/exec/vectorized/hdfs_scan_node.h
+++ b/be/src/exec/vectorized/hdfs_scan_node.h
@@ -91,8 +91,6 @@ private:
 
     void _init_counter(RuntimeState* state);
 
-    static Status _get_name_node_from_path(const std::string& path, std::string* namenode);
-
     int _tuple_id = 0;
     const TupleDescriptor* _tuple_desc = nullptr;
 

--- a/be/src/util/hdfs_util.cpp
+++ b/be/src/util/hdfs_util.cpp
@@ -2,11 +2,19 @@
 
 #include "util/hdfs_util.h"
 
+#include <common/status.h>
 #include <hdfs/hdfs.h>
+
+#include <string>
+using std::string;
 
 #include "util/error_util.h"
 
 namespace starrocks {
+
+const char* FILESYS_PREFIX_HDFS = "hdfs://";
+const char* FILESYS_PREFIX_S3 = "s3a://";
+const char* FILESYS_PREFIX_OSS = "oss://";
 
 std::string get_hdfs_err_msg() {
     std::string error_msg = get_str_err_msg();
@@ -17,6 +25,54 @@ std::string get_hdfs_err_msg() {
         ss << ", root_cause=" << root_cause;
     }
     return ss.str();
+}
+
+Status get_name_node_from_path(const std::string& path, std::string* namenode) {
+    const string local_fs("file:/");
+    size_t n = path.find("://");
+
+    if (n == string::npos) {
+        if (path.compare(0, local_fs.length(), local_fs) == 0) {
+            // Hadoop Path routines strip out consecutive /'s, so recognize 'file:/blah'.
+            *namenode = "file:///";
+        } else {
+            // Path is not qualified, so use the default FS.
+            *namenode = "default";
+        }
+    } else if (n == 0) {
+        return Status::InternalError("Path missing schema");
+    } else {
+        // Path is qualified, i.e. "scheme://authority/path/to/file".  Extract
+        // "scheme://authority/".
+        n = path.find('/', n + 3);
+        if (n == string::npos) {
+            return Status::InternalError("Path missing '/' after authority");
+        }
+        // Include the trailing '/' for local filesystem case, i.e. "file:///".
+        *namenode = path.substr(0, n + 1);
+    }
+    return Status::OK();
+}
+
+bool is_specific_path(const char* path, const char* specific_prefix) {
+    size_t prefix_len = strlen(specific_prefix);
+    return strncmp(path, specific_prefix, prefix_len) == 0;
+}
+
+bool is_hdfs_path(const char* path) {
+    return is_specific_path(path, FILESYS_PREFIX_HDFS);
+}
+
+bool is_s3a_path(const char* path) {
+    return is_specific_path(path, FILESYS_PREFIX_S3);
+}
+
+bool is_oss_path(const char* path) {
+    return is_specific_path(path, FILESYS_PREFIX_OSS);
+}
+
+bool is_object_storage_path(const char* path) {
+    return (is_oss_path(path) || is_s3a_path(path));
 }
 
 } // namespace starrocks

--- a/be/src/util/hdfs_util.h
+++ b/be/src/util/hdfs_util.h
@@ -4,8 +4,18 @@
 
 #include <string>
 
+#include "common/status.h"
+
 namespace starrocks {
 
 std::string get_hdfs_err_msg();
 
-}
+Status get_name_node_from_path(const std::string& path, std::string* namenode);
+
+// Returns true if the path refers to a location on an HDFS filesystem.
+bool is_hdfs_path(const char* path);
+
+// Returns true if the path refers to a location on object storage filesystem.
+bool is_object_storage_path(const char* path);
+
+} // namespace starrocks


### PR DESCRIPTION
libhdfs in version 3.3.0 contains 3 interfaces to read data: hdfsRead(), hdfsPread(),  ​hdfsPreadFully().
   1. hdfsRead() is the default read interface to read HDFS. 
   2. hdfsPread() is used to HDFS hedged reads. About HDFS hedged reads: https://issues.apache.org/jira/browse/HDFS-5776
   3. hdfsPreadFully() will "Read the specified number of bytes" instead of hdfsPread() will "Read up to the specified number of bytes".

If the underlying FileSystem does not support ByteBuffer reads (HDFS-2834) (e.g., S3A/OSS does not support this feature), then hdfsPread() will allocate a Java array equal in size to the specified length of the buffer; the call to hdfsPread() may only fill up the buffer partially. Under this circumstance, it will repeat the call to hdfsPread() since the buffer was not filled, which will cause another large array allocation; this can result in a lot of wasted time doing unnecessary array allocations. The idea comes from https://issues.apache.org/jira/browse/IMPALA-8525.

hdfsPreadFully() will be default option to read HDFS. The configure `user_hdfs_pread` can be used to enable hdfsRead() instead of  hdfsPreadFully().