### PR TITLE
Fix table function node statistics error and Predicate PushDown

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/Explain.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/Explain.java
@@ -393,7 +393,7 @@ public class Explain {
                                                       OperatorPrinter.ExplainContext context) {
             PhysicalTableFunctionOperator tableFunction = (PhysicalTableFunctionOperator) optExpression.getOp();
             StringBuilder sb = new StringBuilder("- TABLE FUNCTION [" + tableFunction.getFn().functionName() + "]");
-            sb.append(buildOutputColumns(tableFunction, ""));
+            sb.append(buildOutputColumns(tableFunction, "[" + tableFunction.getOutputColumns() + "]"));
             sb.append("\n");
 
             buildCostEstimate(sb, optExpression, context.step);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateTableFunctionRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateTableFunctionRule.java
@@ -32,7 +32,7 @@ public class PushDownPredicateTableFunctionRule extends TransformationRule {
         List<ScalarOperator> pushDownPredicates = Lists.newArrayList();
         for (Iterator<ScalarOperator> iter = filters.iterator(); iter.hasNext(); ) {
             ScalarOperator filter = iter.next();
-            if (!tvfOperator.getFnResultColumnRefSet().contains(filter.getUsedColumns())) {
+            if (tvfOperator.getOuterColumnRefSet().contains(filter.getUsedColumns())) {
                 iter.remove();
                 pushDownPredicates.add(filter);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -930,12 +930,18 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
 
     @Override
     public Void visitLogicalTableFunction(LogicalTableFunctionOperator node, ExpressionContext context) {
-        return computeTableFunctionNode(context, node.getOutputColumns(null));
+        ColumnRefSet columnRefSet = new ColumnRefSet();
+        columnRefSet.union(node.getFnResultColumnRefSet());
+        columnRefSet.union(node.getOuterColumnRefSet());
+        return computeTableFunctionNode(context, columnRefSet);
     }
 
     @Override
     public Void visitPhysicalTableFunction(PhysicalTableFunctionOperator node, ExpressionContext context) {
-        return computeTableFunctionNode(context, node.getOutputColumns());
+        ColumnRefSet columnRefSet = new ColumnRefSet();
+        columnRefSet.union(node.getFnResultColumnRefSet());
+        columnRefSet.union(node.getOuterColumnRefSet());
+        return computeTableFunctionNode(context, columnRefSet);
     }
 
     private Void computeTableFunctionNode(ExpressionContext context, ColumnRefSet outputColumns) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -187,7 +187,7 @@ public class PlanFragmentBuilder {
         }
 
         List<Expr> outputExprs = outputColumns.stream().map(variable -> ScalarOperatorToExpr
-                .buildExecExpression(variable, new ScalarOperatorToExpr.FormatterContext(execPlan.getColRefToExpr())))
+                        .buildExecExpression(variable, new ScalarOperatorToExpr.FormatterContext(execPlan.getColRefToExpr())))
                 .collect(Collectors.toList());
         execPlan.getOutputExprs().addAll(outputExprs);
 
@@ -1118,7 +1118,7 @@ public class PlanFragmentBuilder {
                 }
                 List<Expr> distributeExpressions =
                         partitionColumns.stream().map(e -> ScalarOperatorToExpr.buildExecExpression(e,
-                                new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
+                                        new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
                                 .collect(Collectors.toList());
                 dataPartition = DataPartition.hashPartitioned(distributeExpressions);
             } else {
@@ -1357,7 +1357,7 @@ public class PlanFragmentBuilder {
 
                 List<Expr> eqJoinConjuncts =
                         eqOnPredicates.stream().map(e -> ScalarOperatorToExpr.buildExecExpression(e,
-                                new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
+                                        new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
                                 .collect(Collectors.toList());
 
                 for (Expr expr : eqJoinConjuncts) {
@@ -1369,13 +1369,13 @@ public class PlanFragmentBuilder {
                 List<ScalarOperator> otherJoin = Utils.extractConjuncts(node.getJoinPredicate());
                 otherJoin.removeAll(eqOnPredicates);
                 List<Expr> otherJoinConjuncts = otherJoin.stream().map(e -> ScalarOperatorToExpr.buildExecExpression(e,
-                        new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
+                                new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
                         .collect(Collectors.toList());
 
                 // 3. Get conjuncts
                 List<ScalarOperator> predicates = Utils.extractConjuncts(node.getPredicate());
                 List<Expr> conjuncts = predicates.stream().map(e -> ScalarOperatorToExpr.buildExecExpression(e,
-                        new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
+                                new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
                         .collect(Collectors.toList());
 
                 if (joinOperator.isLeftOuterJoin()) {
@@ -1436,14 +1436,14 @@ public class PlanFragmentBuilder {
                             .map(columnRefFactory::getColumnRef).collect(Collectors.toList());
                     List<Expr> leftJoinExprs =
                             leftPredicates.stream().map(e -> ScalarOperatorToExpr.buildExecExpression(e,
-                                    new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
+                                            new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
                                     .collect(Collectors.toList());
 
                     List<ScalarOperator> rightPredicates = rightOnPredicateColumns.stream()
                             .map(columnRefFactory::getColumnRef).collect(Collectors.toList());
                     List<Expr> rightJoinExprs =
                             rightPredicates.stream().map(e -> ScalarOperatorToExpr.buildExecExpression(e,
-                                    new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
+                                            new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
                                     .collect(Collectors.toList());
 
                     DataPartition lhsJoinPartition = new DataPartition(TPartitionType.HASH_PARTITIONED,
@@ -1711,7 +1711,7 @@ public class PlanFragmentBuilder {
 
             List<Expr> partitionExprs =
                     node.getPartitionExpressions().stream().map(e -> ScalarOperatorToExpr.buildExecExpression(e,
-                            new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
+                                    new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
                             .collect(Collectors.toList());
 
             List<OrderByElement> orderByElements = node.getOrderByElements().stream().map(e -> new OrderByElement(

--- a/fe/fe-core/src/test/resources/sql/optimized-plan/lateral.sql
+++ b/fe/fe-core/src/test/resources/sql/optimized-plan/lateral.sql
@@ -54,3 +54,25 @@ select v1 from tarray, unnest(v3) limit 5
 TABLE FUNCTION (unnest) LIMIT 5
     SCAN (columns[1: v1, 3: v3] predicate[null])
 [end]
+
+[sql]
+select v1,v2,unnest + 1 from t0,unnest([1,2,3]);
+[result]
+TABLE FUNCTION (unnest)
+    SCAN (columns[1: v1, 2: v2] predicate[null])
+[end]
+
+[sql]
+select *,u from (select v1,v2,unnest + 1 as u from t0,unnest([1,2,3])) t;
+[result]
+TABLE FUNCTION (unnest)
+    SCAN (columns[1: v1, 2: v2] predicate[null])
+[end]
+
+[sql]
+select v1,v2,unnest + 1 from t0,unnest([1,2,3]) where unnest = 1;
+[result]
+PREDICATE 4: unnest = 1
+    TABLE FUNCTION (unnest)
+        SCAN (columns[1: v1, 2: v2] predicate[null])
+[end]

--- a/fe/fe-core/src/test/resources/sql/optimized-plan/predicate-pushdown.sql
+++ b/fe/fe-core/src/test/resources/sql/optimized-plan/predicate-pushdown.sql
@@ -258,3 +258,11 @@ INNER JOIN (join-predicate [1: v1 = 4: v4 AND 2: v2 = 8: case] post-join-predica
             AGGREGATE ([LOCAL] aggregate [{7: count=count(5: v5)}] group by [[4: v4]] having [null]
                 SCAN (columns[4: v4, 5: v5] predicate[null])
 [end]
+
+[sql]
+select * from (select v1 + unnest as u from (select * from t0,unnest([1,2,3])) t ) x where u = 1
+[result]
+PREDICATE add(1: v1, cast(4: unnest as bigint(20))) = 1
+    TABLE FUNCTION (unnest)
+        SCAN (columns[1: v1] predicate[null])
+[end]


### PR DESCRIPTION
When the LogicalProject and LogicalTableFunction nodes are merged, the return value of outputColumns will be changed. The StatisticsCalculator needs to return the columns needed in the projection to meet the statistical information calculation of the expression
#2000