### PR TITLE
Fix NPE in Dict Optimize when Project node has unsupported dict operator

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/Projection.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/Projection.java
@@ -119,6 +119,17 @@ public class Projection {
         }
     }
 
+    public boolean hasUnsupportedDictOperator(Set<Integer> stringColumnIds) {
+        ColumnRefSet stringColumnRefSet = new ColumnRefSet();
+        for (Integer stringColumnId : stringColumnIds) {
+            stringColumnRefSet.union(stringColumnId);
+        }
+
+        ColumnRefSet columnRefSet = new ColumnRefSet();
+        this.fillDisableDictOptimizeColumns(columnRefSet);
+        return columnRefSet.isIntersect(stringColumnRefSet);
+    }
+
     private void fillDisableDictOptimizeColumns(ScalarOperator operator, ColumnRefSet columnRefSet) {
         if (!couldApplyDictOptimize(operator)) {
             columnRefSet.union(operator.getUsedColumns());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/AddDecodeNodeForDictStringRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/AddDecodeNodeForDictStringRule.java
@@ -155,12 +155,24 @@ public class AddDecodeNodeForDictStringRule implements PhysicalOperatorTreeRewri
         public OptExpression visitProjectionAfter(OptExpression optExpression, DecodeContext context) {
             if (context.hasEncoded && optExpression.getOp().getProjection() != null) {
                 Projection projection = optExpression.getOp().getProjection();
-                if (projection.couldApplyStringDict(context.stringColumnIdToDictColumnIds.keySet())) {
+                Set<Integer> stringColumnIds = context.stringColumnIdToDictColumnIds.keySet();
+
+                // if projection has not support operator in dict column,
+                // Decode node will be inserted
+                if (projection.hasUnsupportedDictOperator(stringColumnIds)) {
+                    // child has dict columns
+                    OptExpression decodeExp = generateDecodeOExpr(context, Collections.singletonList(optExpression));
+                    decodeExp.getOp().setProjection(optExpression.getOp().getProjection());
+                    optExpression.getOp().setProjection(null);
+                    context.clear();
+                    return decodeExp;
+                } else if (projection.couldApplyStringDict(stringColumnIds)) {
                     Projection newProjection = rewriteProjectOperator(projection, context);
                     optExpression.getOp().setProjection(newProjection);
                     return optExpression;
+                } else {
+                    context.clear();
                 }
-                context.clear();
             }
             return optExpression;
         }
@@ -470,7 +482,7 @@ public class AddDecodeNodeForDictStringRule implements PhysicalOperatorTreeRewri
                             // now we only support max/min for dict columns
                             // so we use input dict column
                             newStringToDicts.put(outputStringColumn.getId(), dictColumnId);
-                            
+
                             newAggMap.remove(outputStringColumn);
                             outputColumn = dictColumn;
                         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecodeRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecodeRewriteTest.java
@@ -341,6 +341,62 @@ public class DecodeRewriteTest extends PlanTestBase {
     }
 
     @Test
+    public void testDecodeNodeRewrite13() throws Exception {
+        String sql;
+        String plan;
+        // case join:
+        // select unsupported_function(dict_col) from table1 join table2
+        // Add Decode Node before unsupported Projection 1
+        sql = "select coalesce(l.S_ADDRESS,l.S_NATIONKEY) from supplier l join supplier r on l.s_suppkey = r.s_suppkey";
+        plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("  4:Project\n" +
+                "  |  <slot 17> : coalesce(3, CAST(4: S_NATIONKEY AS VARCHAR))"));
+        Assert.assertTrue(plan.contains("  3:Decode\n" +
+                "  |  <dict id 18> : <string id 3>"));
+
+        // select unsupported_function(dict_col), dict_col from table1 join table2
+        // Add Decode Node before unsupported Projection 2
+        sql = "select coalesce(l.S_ADDRESS,l.S_NATIONKEY),l.S_ADDRESS,r.S_ADDRESS " +
+                "from supplier l join supplier r on l.s_suppkey = r.s_suppkey";
+        plan = getFragmentPlan(sql);
+
+        Assert.assertTrue(plan.contains("  4:Project\n" +
+                "  |  <slot 3> : 3\n" +
+                "  |  <slot 11> : 11\n" +
+                "  |  <slot 17> : coalesce(3, CAST(4: S_NATIONKEY AS VARCHAR))"));
+        Assert.assertTrue(plan.contains("  3:Decode\n" +
+                "  |  <dict id 18> : <string id 3>\n" +
+                "  |  <dict id 19> : <string id 11>"));
+
+
+        // select unsupported_function(dict_col), supported_func(dict_col), dict_col
+        // from table1 join table2;
+        // projection has both supported operator and no-supported operator
+        sql = "select coalesce(l.S_ADDRESS,l.S_NATIONKEY), upper(l.S_ADDRESS), l.S_ADDRESS " +
+                "from supplier l join supplier r on l.s_suppkey = r.s_suppkey";
+        plan = getFragmentPlan(sql);
+
+        Assert.assertFalse(plan.contains("Decode"));
+
+        // select unsupported_function(dict_col), supported_func(table2.dict_col2), table2.dict_col2
+        // from table1 join table2;
+        // left table don't support dict optimize, but right table support it
+        sql = "select coalesce(l.S_ADDRESS,l.S_NATIONKEY), upper(r.P_MFGR),r.P_MFGR " +
+                "from supplier l join part_v2 r on l.s_suppkey = r.P_PARTKEY";
+        plan = getFragmentPlan(sql);
+
+        Assert.assertTrue(plan.contains("  5:Decode\n" +
+                "  |  <dict id 21> : <string id 11>\n" +
+                "  |  <dict id 22> : <string id 20>\n" +
+                "  |  string functions:\n" +
+                "  |  <function id 22> : upper(21: P_MFGR)"));
+        Assert.assertTrue(plan.contains("  4:Project\n" +
+                "  |  <slot 19> : coalesce(3: S_ADDRESS, CAST(4: S_NATIONKEY AS VARCHAR))\n" +
+                "  |  <slot 21> : 21: P_MFGR\n" +
+                "  |  <slot 22> : upper(21: P_MFGR)"));
+    }
+
+    @Test
     public void testScanFilter() throws Exception {
         String sql = "select count(*) from supplier where S_ADDRESS = 'kks' group by S_ADDRESS ";
         String plan = getFragmentPlan(sql);
@@ -486,7 +542,8 @@ public class DecodeRewriteTest extends PlanTestBase {
 
     @Test
     public void testAssignWrongNullableProperty() throws Exception {
-        String sql = "SELECT S_ADDRESS, Dense_rank() OVER ( ORDER BY S_SUPPKEY) FROM supplier UNION SELECT S_ADDRESS, Dense_rank() OVER ( ORDER BY S_SUPPKEY) FROM supplier;";
+        String sql =
+                "SELECT S_ADDRESS, Dense_rank() OVER ( ORDER BY S_SUPPKEY) FROM supplier UNION SELECT S_ADDRESS, Dense_rank() OVER ( ORDER BY S_SUPPKEY) FROM supplier;";
         String plan = getCostExplain(sql);
         Assert.assertTrue(plan.contains("  0:UNION\n" +
                 "  |  child exprs:\n" +


### PR DESCRIPTION
if projection has not support operator in dict column, Decode node will be inserted

will close #1993 and #1992 