### PR TITLE
add cancel check in ES Scanner

### DIFF
--- a/be/src/exec/vectorized/es_http_scanner.cpp
+++ b/be/src/exec/vectorized/es_http_scanner.cpp
@@ -59,6 +59,7 @@ Status EsHttpScanner::get_next(RuntimeState* runtime_state, ChunkPtr* chunk, boo
     }
 
     while (!_batch_eof) {
+        RETURN_IF_CANCELLED(runtime_state);
         if (_line_eof || _es_scroll_parser == nullptr) {
             RETURN_IF_ERROR(_es_reader->get_next(&_batch_eof, _es_scroll_parser));
             _es_scroll_parser->set_params(_tuple_desc, &_docvalue_context);


### PR DESCRIPTION
ES http scan node will wait for the completion of the scanner scan
before closing, when a query reaches the limit limit does not release
resources in a timely manner, which may cause additional invalid
resource overhead.

such as `select * from ESTable limit 10;`