### PR TITLE
fix fail to prepare tablet reader bug

### DIFF
--- a/be/src/storage/task/engine_publish_version_task.cpp
+++ b/be/src/storage/task/engine_publish_version_task.cpp
@@ -120,8 +120,8 @@ OLAPStatus EnginePublishVersionTask::finish() {
             }
             partition_related_tablet_infos.erase(tablet_info);
             VLOG(1) << "publish version successfully on tablet. tablet=" << tablet->full_name()
-                      << ", transaction_id=" << transaction_id << ", version=" << version.first
-                      << ", res=" << publish_status;
+                    << ", transaction_id=" << transaction_id << ", version=" << version.first
+                    << ", res=" << publish_status;
         }
 
         // check if the related tablet remained all have the version

--- a/be/src/storage/task/engine_publish_version_task.cpp
+++ b/be/src/storage/task/engine_publish_version_task.cpp
@@ -119,9 +119,9 @@ OLAPStatus EnginePublishVersionTask::finish() {
                 }
             }
             partition_related_tablet_infos.erase(tablet_info);
-            VLOG(1) << "publish version successfully on tablet. tablet=" << tablet->full_name()
-                    << ", transaction_id=" << transaction_id << ", version=" << version.first
-                    << ", res=" << publish_status;
+            LOG(INFO) << "publish version successfully on tablet. tablet=" << tablet->full_name()
+                      << ", transaction_id=" << transaction_id << ", version=" << version.first
+                      << ", res=" << publish_status;
         }
 
         // check if the related tablet remained all have the version
@@ -146,8 +146,8 @@ OLAPStatus EnginePublishVersionTask::finish() {
         }
     }
 
-    VLOG(1) << "finish to publish version on transaction."
-            << "transaction_id=" << transaction_id << ", error_tablet_size=" << _error_tablet_ids->size();
+    LOG(INFO) << "finish to publish version on transaction."
+              << "transaction_id=" << transaction_id << ", error_tablet_size=" << _error_tablet_ids->size();
     return res;
 }
 

--- a/be/src/storage/task/engine_publish_version_task.cpp
+++ b/be/src/storage/task/engine_publish_version_task.cpp
@@ -119,7 +119,7 @@ OLAPStatus EnginePublishVersionTask::finish() {
                 }
             }
             partition_related_tablet_infos.erase(tablet_info);
-            LOG(INFO) << "publish version successfully on tablet. tablet=" << tablet->full_name()
+            VLOG(1) << "publish version successfully on tablet. tablet=" << tablet->full_name()
                       << ", transaction_id=" << transaction_id << ", version=" << version.first
                       << ", res=" << publish_status;
         }

--- a/be/src/storage/task/engine_publish_version_task.cpp
+++ b/be/src/storage/task/engine_publish_version_task.cpp
@@ -146,8 +146,8 @@ OLAPStatus EnginePublishVersionTask::finish() {
         }
     }
 
-    LOG(INFO) << "finish to publish version on transaction."
-              << "transaction_id=" << transaction_id << ", error_tablet_size=" << _error_tablet_ids->size();
+    VLOG(1) << "finish to publish version on transaction."
+            << "transaction_id=" << transaction_id << ", error_tablet_size=" << _error_tablet_ids->size();
     return res;
 }
 

--- a/be/test/exec/tablet_sink_test.cpp
+++ b/be/test/exec/tablet_sink_test.cpp
@@ -277,8 +277,7 @@ public:
 
     void tablet_writer_add_batch(google::protobuf::RpcController* controller,
                                  const PTabletWriterAddBatchRequest* request, PTabletWriterAddBatchResult* response,
-                                 google::protobuf::Closure* done) override {
-    }
+                                 google::protobuf::Closure* done) override {}
     void tablet_writer_cancel(google::protobuf::RpcController* controller, const PTabletWriterCancelRequest* request,
                               PTabletWriterCancelResult* response, google::protobuf::Closure* done) override {
         done->Run();

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -629,7 +629,7 @@ public class DatabaseTransactionMgr {
     // check whether transaction can be finished or not
     // for each tablet of load txn, if most replicas version publish successed
     // the trasaction can be treated as successful and can be finished
-    public boolean canTxnFinished(TransactionState txn, Set<Long> errReplicas) {
+    public boolean canTxnFinished(TransactionState txn, Set<Long> errReplicas, Set<Long> unfinishedBackends) {
         Database db = catalog.getDb(txn.getDbId());
         if (db == null) {
             return true;
@@ -669,6 +669,9 @@ public class DatabaseTransactionMgr {
                                 if (!errReplicas.contains(replica.getId()) && replica.getLastFailedVersion() < 0) {
                                     if (replica.getVersion() >= partitionCommitInfo.getVersion()) {
                                         ++healthReplicaNum;
+                                    } else if (unfinishedBackends != null
+                                            && unfinishedBackends.contains(replica.getBackendId())) {
+                                        errReplicas.add(replica.getId());
                                     }
                                 }
                             }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -429,9 +429,10 @@ public class GlobalTransactionMgr implements Writable {
         dbTransactionMgr.finishTransaction(transactionId, errorReplicaIds);
     }
 
-    public boolean canTxnFinished(TransactionState txn, Set<Long> errReplicas) throws UserException {
+    public boolean canTxnFinished(TransactionState txn, Set<Long> errReplicas,
+                                  Set<Long> unfinishedBackends) throws UserException {
         DatabaseTransactionMgr dbTransactionMgr = getDatabaseTransactionMgr(txn.getDbId());
-        return dbTransactionMgr.canTxnFinished(txn, errReplicas);
+        return dbTransactionMgr.canTxnFinished(txn, errReplicas, unfinishedBackends);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -114,12 +114,6 @@ public class PublishVersionDaemon extends MasterDaemon {
             if (!allTaskFinished) {
                 shouldFinishTxn = globalTransactionMgr.canTxnFinished(transactionState,
                         publishErrorReplicaIds, unfinishedBackends);
-                if (shouldFinishTxn) {
-                    LOG.info("transaction:{} succeed for quorum finish. unfinished backends:{}, error replica:{}",
-                            transactionState.getTransactionId(),
-                            unfinishedBackends.stream().limit(10).collect(Collectors.toList()),
-                            publishErrorReplicaIds.stream().limit(10).collect(Collectors.toList()));
-                }
             }
 
             if (shouldFinishTxn) {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -37,7 +37,6 @@ import org.apache.logging.log4j.Logger;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 public class PublishVersionDaemon extends MasterDaemon {
 

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/GlobalTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/GlobalTransactionMgrTest.java
@@ -527,7 +527,7 @@ public class GlobalTransactionMgrTest {
         FakeCatalog.setCatalog(masterCatalog);
         Set<Long> errorReplicaIds = Sets.newHashSet();
         errorReplicaIds.add(CatalogTestUtil.testReplicaId2);
-        assertEquals(masterTransMgr.canTxnFinished(transactionState, errorReplicaIds), false);
+        assertEquals(masterTransMgr.canTxnFinished(transactionState, errorReplicaIds, Sets.newHashSet()), false);
         masterTransMgr.finishTransaction(CatalogTestUtil.testDbId1, transactionId, errorReplicaIds);
         assertEquals(TransactionStatus.COMMITTED, transactionState.getTransactionStatus());
         Replica replcia1 = tablet.getReplicaById(CatalogTestUtil.testReplicaId1);
@@ -541,7 +541,7 @@ public class GlobalTransactionMgrTest {
         assertEquals(CatalogTestUtil.testStartVersion + 1, replcia3.getLastFailedVersion());
 
         errorReplicaIds = Sets.newHashSet();
-        assertEquals(masterTransMgr.canTxnFinished(transactionState, errorReplicaIds), false);
+        assertEquals(masterTransMgr.canTxnFinished(transactionState, errorReplicaIds, Sets.newHashSet()), false);
         masterTransMgr.finishTransaction(CatalogTestUtil.testDbId1, transactionId, errorReplicaIds);
         assertEquals(TransactionStatus.VISIBLE, transactionState.getTransactionStatus());
         assertEquals(CatalogTestUtil.testStartVersion + 1, replcia1.getVersion());
@@ -606,7 +606,7 @@ public class GlobalTransactionMgrTest {
 
         // master finish the transaction2
         errorReplicaIds = Sets.newHashSet();
-        assertEquals(masterTransMgr.canTxnFinished(transactionState, errorReplicaIds), false);
+        assertEquals(masterTransMgr.canTxnFinished(transactionState, errorReplicaIds, Sets.newHashSet()), false);
         masterTransMgr.finishTransaction(CatalogTestUtil.testDbId1, transactionId2, errorReplicaIds);
         assertEquals(TransactionStatus.VISIBLE, transactionState.getTransactionStatus());
         assertEquals(CatalogTestUtil.testStartVersion + 2, replcia1.getVersion());


### PR DESCRIPTION
Now publish version will succeed when quorum succeeds. But the finished transaction will update the version of all replicas to a visible version, which will lead to query the unsuccessful replica and result in query failure. Fix the bug by skipping updating the unsuccessful replica's version when the transaction is finished.