### PR TITLE
Fix cast date stats when stats has infinity

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -106,14 +106,15 @@ public class ExpressionStatisticCalculator {
 
             ConstantOperator max = ConstantOperator.createBigint((long) childStatistic.getMaxValue());
             ConstantOperator min = ConstantOperator.createBigint((long) childStatistic.getMinValue());
-            if (cast.getChild(0).getType().isDateType()) {
-                max = ConstantOperator.createDatetime(Utils.getDatetimeFromLong((long) childStatistic.getMaxValue()));
-                min = ConstantOperator.createDatetime(Utils.getDatetimeFromLong((long) childStatistic.getMinValue()));
-            }
 
             try {
-                max = max.castTo(cast.getType());
-                min = min.castTo(cast.getType());
+                if (cast.getChild(0).getType().isDateType()) {
+                    max = ConstantOperator.createDatetime(Utils.getDatetimeFromLong((long) childStatistic.getMaxValue()));
+                    min = ConstantOperator.createDatetime(Utils.getDatetimeFromLong((long) childStatistic.getMinValue()));
+                } else {
+                    max = max.castTo(cast.getType());
+                    min = min.castTo(cast.getType());
+                }
             } catch (Exception e) {
                 LOG.warn("expression statistic compute cast failed: " + max.toString() + ", " + min.toString() +
                         ", to type: " + cast.getType());
@@ -234,14 +235,14 @@ public class ExpressionStatisticCalculator {
                             callOperator.getType().getSlotSize(), distinctValues);
                 case FunctionSet.DIVIDE:
                     double divideMinValue = Math.min(Math.min(
-                            Math.min(left.getMinValue() / divisorNotZero(right.getMinValue()),
-                                    left.getMinValue() / divisorNotZero(right.getMaxValue())),
-                            left.getMaxValue() / divisorNotZero(right.getMinValue())),
+                                    Math.min(left.getMinValue() / divisorNotZero(right.getMinValue()),
+                                            left.getMinValue() / divisorNotZero(right.getMaxValue())),
+                                    left.getMaxValue() / divisorNotZero(right.getMinValue())),
                             left.getMaxValue() / divisorNotZero(right.getMaxValue()));
                     double divideMaxValue = Math.max(Math.max(
-                            Math.max(left.getMinValue() / divisorNotZero(right.getMinValue()),
-                                    left.getMinValue() / divisorNotZero(right.getMaxValue())),
-                            left.getMaxValue() / divisorNotZero(right.getMinValue())),
+                                    Math.max(left.getMinValue() / divisorNotZero(right.getMinValue()),
+                                            left.getMinValue() / divisorNotZero(right.getMaxValue())),
+                                    left.getMaxValue() / divisorNotZero(right.getMinValue())),
                             left.getMaxValue() / divisorNotZero(right.getMaxValue()));
                     return new ColumnStatistic(divideMinValue, divideMaxValue, nullsFraction,
                             callOperator.getType().getSlotSize(),

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
@@ -862,13 +862,44 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
 
     @Test
     public void testCastDatePredicate() throws Exception {
-        String sql = "select L_SHIPDATE from lineitem where year(L_SHIPDATE) = 1998";
-
         OlapTable lineitem = (OlapTable) connectContext.getCatalog().getDb("default_cluster:test").getTable("lineitem");
 
         MockTpchStatisticStorage mock = new MockTpchStatisticStorage(100);
         connectContext.getCatalog().setStatisticStorage(mock);
 
+        // ===========================
+        // To handle cast(int) in normal range
+        String sql = "select L_PARTKEY from lineitem where year(L_PARTKEY) = 1998";
+        new Expectations(mock) {
+            {
+                mock.getColumnStatistic(lineitem, "L_PARTKEY");
+                result = new ColumnStatistic(19921212, 19980202, 0, 8, 20000);
+            }
+        };
+
+        String plan = getCostExplain(sql);
+        System.out.println(plan);
+        Assert.assertTrue(plan.contains("     column statistics: \n" +
+                "     * L_PARTKEY-->[1.9921212E7, 1.9980202E7, 0.0, 8.0, 20000.0] ESTIMATE"));
+
+        // ===========================
+        // To handle cast(int) in infinity range
+        sql = "select L_PARTKEY from lineitem where year(L_PARTKEY) = 1998";
+        new Expectations(mock) {
+            {
+                mock.getColumnStatistic(lineitem, "L_PARTKEY");
+                result = new ColumnStatistic(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, 0, 8, 20000);
+            }
+        };
+
+        plan = getCostExplain(sql);
+        System.out.println(plan);
+        Assert.assertTrue(plan.contains("     column statistics: \n" +
+                "     * L_PARTKEY-->[-Infinity, Infinity, 0.0, 8.0, 20000.0] ESTIMATE"));
+
+        // ===========================
+        // To handle cast(date) in normal range
+        sql = "select L_SHIPDATE from lineitem where year(L_SHIPDATE) = 1998";
         new Expectations(mock) {
             {
                 mock.getColumnStatistic(lineitem, "L_SHIPDATE");
@@ -876,12 +907,13 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
             }
         };
 
-        String plan = getCostExplain(sql);
-
+        plan = getCostExplain(sql);
         System.out.println(plan);
         Assert.assertTrue(plan.contains("     column statistics: \n" +
                 "     * L_SHIPDATE-->[1.9921212E7, 1.9980202E7, 0.0, 8.0, 1.0] ESTIMATE"));
 
+        // ===========================
+        // To handle cast(date) in infinity range
         new Expectations(mock) {
             {
                 mock.getColumnStatistic(lineitem, "L_SHIPDATE");


### PR DESCRIPTION
ref: #1957 #2014 

If we don't have any stats of a date column, the value of min/max is double.infinity. 

And when we try to cast double.infinity to date, it throws exception. We have to catch that exception, and fall back to original stats.