### PR TITLE
[ISSUE-2030] Bugfix: Pushdown rf to ExchangeSource in pipeline execution engine

### DIFF
--- a/be/src/exec/vectorized/aggregate/aggregate_base_node.h
+++ b/be/src/exec/vectorized/aggregate/aggregate_base_node.h
@@ -13,7 +13,7 @@ class AggregateBaseNode : public ExecNode {
 public:
     AggregateBaseNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs);
     ~AggregateBaseNode() override;
-
+    Status init(const TPlanNode& tnode, RuntimeState* state = nullptr) override;
     Status prepare(RuntimeState* state) override;
     Status close(RuntimeState* state) override;
     void push_down_join_runtime_filter(RuntimeState* state,
@@ -21,6 +21,9 @@ public:
 
 protected:
     const TPlanNode& _tnode;
+    // _group_by_expr_ctxs used by the pipeline execution engine to push down rf to children nodes before
+    // pipeline decomposition.
+    std::vector<ExprContext*> _group_by_expr_ctxs;
     AggregatorPtr _aggregator = nullptr;
     bool _child_eos = false;
 };

--- a/be/src/exec/vectorized/aggregate/distinct_blocking_node.cpp
+++ b/be/src/exec/vectorized/aggregate/distinct_blocking_node.cpp
@@ -133,9 +133,8 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > DistinctBlockingNode::d
 
     // shared by sink operator and source operator
     AggregatorFactoryPtr aggregator_factory = std::make_shared<AggregatorFactory>(_tnode);
-    std::vector<ExprContext*> partition_expr_ctxs;
-    Expr::create_expr_trees(_pool, _tnode.agg_node.grouping_exprs, &partition_expr_ctxs);
 
+    auto partition_expr_ctxs = std::move(_group_by_expr_ctxs);
     auto sink_operator = std::make_shared<AggregateDistinctBlockingSinkOperatorFactory>(
             context->next_operator_id(), id(), aggregator_factory, partition_expr_ctxs);
     // Initialize OperatorFactory's fields involving runtime filters.


### PR DESCRIPTION
# Bugfix
Rf is pushed down before pipeline decomposition in this point the Aggregator is not constructed, so in AggregateBaseNode::push_down_join_runtime_filter function, abtaining _group_by_expr_ctxs from aggregator is crashed, to solve this problem, a _group_by_expr_ctxs field is added to AggregateBaseNode class and this field is initialized at AggregateBaseNode::init function before pipeline decompositition.