### PR TITLE
Fix BE crash in lowcardinality optimization when late materialize

### DIFF
--- a/be/src/storage/rowset/vectorized/segment_iterator.cpp
+++ b/be/src/storage/rowset/vectorized/segment_iterator.cpp
@@ -178,6 +178,8 @@ private:
     template <bool late_materialization>
     Status _build_context(ScanContext* ctx);
 
+    Status _init_decoders();
+
     void _rewrite_predicates();
 
     Status _decode_dict_codes(ScanContext* ctx);
@@ -916,7 +918,6 @@ Status SegmentIterator::_build_context(ScanContext* ctx) {
             if (use_global_dict_code) {
                 iter = new segment_v2::GlobalDictCodeColumnIterator(cid, _column_iterators[cid],
                                                                     _opts.global_dictmaps->at(cid));
-                _column_decoders[cid].set_iterator(iter);
             } else {
                 iter = new segment_v2::DictCodeColumnIterator(cid, _column_iterators[cid]);
             }
@@ -986,6 +987,8 @@ Status SegmentIterator::_init_context() {
     DCHECK_EQ(_predicate_columns, _opts.predicates.size());
     _late_materialization_ratio = config::late_materialization_ratio;
 
+    RETURN_IF_ERROR(_init_decoders());
+
     if (_predicate_columns == 0 || _predicate_columns >= _schema.num_fields()) {
         // non or all field has predicate, disable late materialization.
         RETURN_IF_ERROR(_build_context<false>(&_context_list[0]));
@@ -1013,6 +1016,22 @@ Status SegmentIterator::_init_context() {
         }
     }
     _switch_context(&_context_list[0]);
+    return Status::OK();
+}
+
+Status SegmentIterator::_init_decoders() {
+    // init decoder for all columns
+    // in some case _build_context<false> won't be called
+    for (int i = 0; i < _schema.num_fields(); ++i) {
+        const FieldPtr& f = _schema.field(i);
+        const ColumnId cid = f->id();
+        if (_can_using_global_dict(f)) {
+            auto iter = new segment_v2::GlobalDictCodeColumnIterator(cid, _column_iterators[cid],
+                                                                     _opts.global_dictmaps->at(cid));
+            _obj_pool.add(iter);
+            _column_decoders[cid].set_iterator(iter);
+        }
+    }
     return Status::OK();
 }
 

--- a/be/src/storage/rowset/vectorized/segment_iterator.cpp
+++ b/be/src/storage/rowset/vectorized/segment_iterator.cpp
@@ -178,7 +178,7 @@ private:
     template <bool late_materialization>
     Status _build_context(ScanContext* ctx);
 
-    Status _init_decoders();
+    Status _init_global_dict_decoder();
 
     void _rewrite_predicates();
 
@@ -987,7 +987,7 @@ Status SegmentIterator::_init_context() {
     DCHECK_EQ(_predicate_columns, _opts.predicates.size());
     _late_materialization_ratio = config::late_materialization_ratio;
 
-    RETURN_IF_ERROR(_init_decoders());
+    RETURN_IF_ERROR(_init_global_dict_decoder());
 
     if (_predicate_columns == 0 || _predicate_columns >= _schema.num_fields()) {
         // non or all field has predicate, disable late materialization.
@@ -1019,7 +1019,7 @@ Status SegmentIterator::_init_context() {
     return Status::OK();
 }
 
-Status SegmentIterator::_init_decoders() {
+Status SegmentIterator::_init_global_dict_decoder() {
     // init decoder for all columns
     // in some case _build_context<false> won't be called
     for (int i = 0; i < _schema.num_fields(); ++i) {


### PR DESCRIPTION
if query has a a complex type, segment iterator will always use
late materialization `_build_context<false>` won't be called.


will close #2024 