### PR TITLE
Reduce lock contentions in TabletsWriter

### DIFF
--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -21,101 +21,83 @@
 
 #include "runtime/load_channel.h"
 
+#include <memory>
+
+#include "common/closure_guard.h"
+#include "runtime/load_channel_mgr.h"
 #include "runtime/mem_tracker.h"
 #include "runtime/tablets_channel.h"
 #include "storage/lru_cache.h"
 
 namespace starrocks {
 
-LoadChannel::LoadChannel(const UniqueId& load_id, int64_t timeout_s, std::unique_ptr<MemTracker> mem_tracker)
-        : _load_id(load_id),
+LoadChannel::LoadChannel(LoadChannelMgr* mgr, const UniqueId& load_id, int64_t timeout_s,
+                         std::unique_ptr<MemTracker> mem_tracker)
+        : _load_mgr(mgr),
+          _load_id(load_id),
           _timeout_s(timeout_s),
           _mem_tracker(std::move(mem_tracker)),
           _last_updated_time(time(nullptr)) {}
 
-LoadChannel::~LoadChannel() {
-    LOG(INFO) << "load channel mem peak usage=" << _mem_tracker->peak_consumption()
-              << ", info=" << _mem_tracker->debug_string() << ", load_id=" << _load_id;
-    _tablets_channels.clear();
-}
+LoadChannel::~LoadChannel() {}
 
-Status LoadChannel::open(const PTabletWriterOpenRequest& params) {
-    int64_t index_id = params.index_id();
-    std::shared_ptr<TabletsChannel> channel;
-    {
-        std::lock_guard<std::mutex> l(_lock);
-        auto it = _tablets_channels.find(index_id);
-        if (it != _tablets_channels.end()) {
-            channel = it->second;
-        } else {
-            // create a new tablets channel
-            TabletsChannelKey key(params.id(), index_id);
-            channel.reset(new TabletsChannel(key, _mem_tracker.get()));
-            _tablets_channels.insert({index_id, channel});
-        }
-    }
+void LoadChannel::open(brpc::Controller* cntl, const PTabletWriterOpenRequest* request,
+                       PTabletWriterOpenResult* response, google::protobuf::Closure* done) {
+    ClosureGuard done_guard(done);
 
-    RETURN_IF_ERROR(channel->open(params));
+    _last_updated_time.store(time(nullptr), std::memory_order_relaxed);
+    int64_t index_id = request->index_id();
 
-    _opened = true;
-    _last_updated_time.store(time(nullptr));
-    return Status::OK();
-}
-
-Status LoadChannel::add_chunk(const PTabletWriterAddChunkRequest& request,
-                              google::protobuf::RepeatedPtrField<PTabletInfo>* tablet_vec) {
-    int64_t index_id = request.index_id();
-    // 1. get tablets channel
-    std::shared_ptr<TabletsChannel> channel;
-    {
-        std::lock_guard<std::mutex> l(_lock);
-        auto it = _tablets_channels.find(index_id);
-        if (it == _tablets_channels.end()) {
-            if (_finished_channel_ids.find(index_id) != _finished_channel_ids.end()) {
-                // this channel is already finished, just return OK
-                return Status::OK();
-            }
-            std::stringstream ss;
-            ss << "load channel " << _load_id << " add batch with unknown index id: " << index_id;
-            return Status::InternalError(ss.str());
-        }
-        channel = it->second;
-    }
-
-    // 3. add batch to tablets channel
-    if (request.has_chunk()) {
-        RETURN_IF_ERROR(channel->add_chunk(request));
-    }
-
-    // 4. handle eos
     Status st;
-    if (request.has_eos() && request.eos()) {
-        bool finished = false;
-        RETURN_IF_ERROR(channel->close(request.sender_id(), &finished, request.partition_ids(), tablet_vec));
-        if (finished) {
-            std::lock_guard<std::mutex> l(_lock);
-            _tablets_channels.erase(index_id);
-            _finished_channel_ids.emplace(index_id);
+    {
+        std::lock_guard<std::mutex> l(_lock);
+        if (_tablets_channels.find(index_id) == _tablets_channels.end()) {
+            TabletsChannelKey key(request->id(), index_id);
+            scoped_refptr<TabletsChannel> channel(new TabletsChannel(this, key, _mem_tracker.get()));
+            if (st = channel->open(*request); st.ok()) {
+                _tablets_channels.insert({index_id, std::move(channel)});
+            }
         }
     }
-    _last_updated_time.store(time(nullptr));
-    return st;
+    LOG_IF(WARNING, !st.ok()) << "Fail to open index " << index_id << " of load " << _load_id << ": " << st;
+    response->mutable_status()->set_status_code(st.code());
+    response->mutable_status()->add_error_msgs(st.get_error_msg());
 }
 
-bool LoadChannel::is_finished() {
-    if (!_opened) {
-        return false;
+void LoadChannel::add_chunk(brpc::Controller* cntl, const PTabletWriterAddChunkRequest* request,
+                            PTabletWriterAddBatchResult* response, google::protobuf::Closure* done) {
+    ClosureGuard done_guard(done);
+    _last_updated_time.store(time(nullptr), std::memory_order_relaxed);
+    auto channel = get_tablets_channel(request->index_id());
+    if (channel == nullptr) {
+        response->mutable_status()->set_status_code(TStatusCode::INTERNAL_ERROR);
+        response->mutable_status()->add_error_msgs("cannot find the tablets channel associated with the index id");
+        return;
     }
-    std::lock_guard<std::mutex> l(_lock);
-    return _tablets_channels.empty();
+    channel->add_chunk(cntl, request, response, done_guard.release());
 }
 
-Status LoadChannel::cancel() {
-    std::lock_guard<std::mutex> l(_lock);
+void LoadChannel::cancel() {
+    std::lock_guard l(_lock);
     for (auto& it : _tablets_channels) {
         it.second->cancel();
     }
-    return Status::OK();
+}
+
+void LoadChannel::remove_tablets_channel(int64_t index_id) {
+    std::unique_lock l(_lock);
+    _tablets_channels.erase(index_id);
+    if (_tablets_channels.empty()) {
+        l.unlock();
+        _load_mgr->remove_load_channel(_load_id);
+        // Do NOT touch |this| since here, it could have been deleted.
+    }
+}
+
+scoped_refptr<TabletsChannel> LoadChannel::get_tablets_channel(int64_t index_id) {
+    std::lock_guard l(_lock);
+    auto it = _tablets_channels.find(index_id);
+    return (it != _tablets_channels.end()) ? it->second : nullptr;
 }
 
 } // namespace starrocks

--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -39,8 +39,6 @@ LoadChannel::LoadChannel(LoadChannelMgr* mgr, const UniqueId& load_id, int64_t t
           _mem_tracker(std::move(mem_tracker)),
           _last_updated_time(time(nullptr)) {}
 
-LoadChannel::~LoadChannel() {}
-
 void LoadChannel::open(brpc::Controller* cntl, const PTabletWriterOpenRequest& request,
                        PTabletWriterOpenResult* response, google::protobuf::Closure* done) {
     ClosureGuard done_guard(done);

--- a/be/src/runtime/load_channel.h
+++ b/be/src/runtime/load_channel.h
@@ -59,10 +59,10 @@ public:
 
     // Open a new load channel if it does not exist.
     // NOTE: This method may be called multiple times, and each time with a different |request|.
-    void open(brpc::Controller* cntl, const PTabletWriterOpenRequest* request, PTabletWriterOpenResult* response,
+    void open(brpc::Controller* cntl, const PTabletWriterOpenRequest& request, PTabletWriterOpenResult* response,
               google::protobuf::Closure* done);
 
-    void add_chunk(brpc::Controller* cntl, const PTabletWriterAddChunkRequest* request,
+    void add_chunk(brpc::Controller* cntl, const PTabletWriterAddChunkRequest& request,
                    PTabletWriterAddBatchResult* response, google::protobuf::Closure* done);
 
     void cancel();

--- a/be/src/runtime/load_channel.h
+++ b/be/src/runtime/load_channel.h
@@ -79,7 +79,7 @@ public:
 
 private:
     friend class RefCountedThreadSafe<LoadChannel>;
-    ~LoadChannel();
+    ~LoadChannel() = default;
 
     LoadChannelMgr* _load_mgr;
     UniqueId _load_id;

--- a/be/src/runtime/load_channel_mgr.cpp
+++ b/be/src/runtime/load_channel_mgr.cpp
@@ -23,12 +23,11 @@
 
 #include <memory>
 
+#include "common/closure_guard.h"
 #include "gutil/strings/substitute.h"
-#include "runtime/exec_env.h"
 #include "runtime/load_channel.h"
 #include "runtime/mem_tracker.h"
 #include "service/backend_options.h"
-#include "storage/lru_cache.h"
 #include "util/starrocks_metrics.h"
 #include "util/stopwatch.hpp"
 #include "util/thread.h"
@@ -58,7 +57,6 @@ LoadChannelMgr::LoadChannelMgr() : _is_stopped(false) {
         std::lock_guard<std::mutex> l(_lock);
         return _load_channels.size();
     });
-    _lastest_success_channel = new_lru_cache(1024);
 }
 
 LoadChannelMgr::~LoadChannelMgr() {
@@ -66,7 +64,6 @@ LoadChannelMgr::~LoadChannelMgr() {
     if (_load_channels_clean_thread.joinable()) {
         _load_channels_clean_thread.join();
     }
-    delete _lastest_success_channel;
 }
 
 Status LoadChannelMgr::init(MemTracker* mem_tracker) {
@@ -75,94 +72,52 @@ Status LoadChannelMgr::init(MemTracker* mem_tracker) {
     return Status::OK();
 }
 
-Status LoadChannelMgr::open(const PTabletWriterOpenRequest& params) {
-    UniqueId load_id(params.id());
-    std::shared_ptr<LoadChannel> channel;
+void LoadChannelMgr::open(brpc::Controller* cntl, const PTabletWriterOpenRequest* request,
+                          PTabletWriterOpenResult* response, google::protobuf::Closure* done) {
+    ClosureGuard done_guard(done);
+    UniqueId load_id(request->id());
+    scoped_refptr<LoadChannel> channel;
     {
         std::lock_guard<std::mutex> l(_lock);
         auto it = _load_channels.find(load_id);
         if (it != _load_channels.end()) {
             channel = it->second;
         } else {
-            int64_t mem_limit_in_req = params.has_load_mem_limit() ? params.load_mem_limit() : -1;
+            int64_t mem_limit_in_req = request->has_load_mem_limit() ? request->load_mem_limit() : -1;
             int64_t job_max_memory = calc_job_max_load_memory(mem_limit_in_req, _mem_tracker->limit());
 
-            int64_t timeout_in_req_s = params.has_load_channel_timeout_s() ? params.load_channel_timeout_s() : -1;
+            int64_t timeout_in_req_s = request->has_load_channel_timeout_s() ? request->load_channel_timeout_s() : -1;
             int64_t job_timeout_s = calc_job_timeout_s(timeout_in_req_s);
             auto job_mem_tracker = std::make_unique<MemTracker>(job_max_memory, load_id.to_string(), _mem_tracker);
 
-            channel.reset(new LoadChannel(load_id, job_timeout_s, std::move(job_mem_tracker)));
+            channel.reset(new LoadChannel(this, load_id, job_timeout_s, std::move(job_mem_tracker)));
             _load_channels.insert({load_id, channel});
         }
     }
-
-    RETURN_IF_ERROR(channel->open(params));
-    return Status::OK();
+    channel->open(cntl, request, response, done_guard.release());
 }
 
-static void dummy_deleter(const CacheKey& key, void* value) {}
-
-Status LoadChannelMgr::add_chunk(const PTabletWriterAddChunkRequest& request,
-                                 google::protobuf::RepeatedPtrField<PTabletInfo>* tablet_vec,
-                                 int64_t* wait_lock_time_ns) {
-    UniqueId load_id(request.id());
-    // 1. get load channel
-    std::shared_ptr<LoadChannel> channel;
-    {
-        std::lock_guard<std::mutex> l(_lock);
-        auto it = _load_channels.find(load_id);
-        if (it == _load_channels.end()) {
-            auto* handle = _lastest_success_channel->lookup(load_id.to_string());
-            // success only when eos be true
-            if (handle != nullptr) {
-                _lastest_success_channel->release(handle);
-                if (request.has_eos() && request.eos()) {
-                    return Status::OK();
-                }
-            }
-            return Status::InternalError(
-                    strings::Substitute("fail to add batch in load channel. unknown load_id=$0", load_id.to_string()));
-        }
-        channel = it->second;
+void LoadChannelMgr::add_chunk(brpc::Controller* cntl, const PTabletWriterAddChunkRequest* request,
+                               PTabletWriterAddBatchResult* response, google::protobuf::Closure* done) {
+    VLOG(2) << "Current memory usage=" << _mem_tracker->consumption() << " limit=" << _mem_tracker->limit();
+    ClosureGuard done_guard(done);
+    UniqueId load_id(request->id());
+    auto channel = _find_load_channel(load_id);
+    if (channel != nullptr) {
+        channel->add_chunk(cntl, request, response, done_guard.release());
+    } else {
+        response->mutable_status()->set_status_code(TStatusCode::INTERNAL_ERROR);
+        response->mutable_status()->add_error_msgs("no associated load channel");
     }
-
-    // 3. add batch to load channel
-    // batch may not exist in request(eg: eos request without batch),
-    // this case will be handled in load channel's add batch method.
-    RETURN_IF_ERROR(channel->add_chunk(request, tablet_vec));
-
-    // 4. handle finish
-    if (channel->is_finished()) {
-        LOG(INFO) << "Removing finished load channel load id=" << load_id;
-        {
-            std::lock_guard<std::mutex> l(_lock);
-            _load_channels.erase(load_id);
-            auto* handle = _lastest_success_channel->insert(load_id.to_string(), nullptr, 1, dummy_deleter);
-            _lastest_success_channel->release(handle);
-        }
-        VLOG(1) << "Removed load channel load id=" << load_id;
-    }
-
-    return Status::OK();
 }
 
-Status LoadChannelMgr::cancel(const PTabletWriterCancelRequest& params) {
-    UniqueId load_id(params.id());
-    std::shared_ptr<LoadChannel> cancelled_channel;
-    {
-        std::lock_guard<std::mutex> l(_lock);
-        if (_load_channels.find(load_id) != _load_channels.end()) {
-            cancelled_channel = _load_channels[load_id];
-            _load_channels.erase(load_id);
-        }
+void LoadChannelMgr::cancel(brpc::Controller* cntl, const PTabletWriterCancelRequest* request,
+                            PTabletWriterCancelResult* response, google::protobuf::Closure* done) {
+    ClosureGuard done_guard(done);
+    UniqueId load_id(request->id());
+    if (auto channel = remove_load_channel(load_id); channel != nullptr) {
+        channel->cancel();
     }
-
-    if (cancelled_channel != nullptr) {
-        cancelled_channel->cancel();
-        LOG(INFO) << "Cancelled load channel load id=" << load_id;
-    }
-
-    return Status::OK();
 }
 
 Status LoadChannelMgr::_start_bg_worker() {
@@ -186,14 +141,13 @@ Status LoadChannelMgr::_start_bg_worker() {
 }
 
 Status LoadChannelMgr::_start_load_channels_clean() {
-    std::vector<std::shared_ptr<LoadChannel>> timeout_channels;
+    std::vector<scoped_refptr<LoadChannel>> timeout_channels;
+
     time_t now = time(nullptr);
     {
         std::lock_guard<std::mutex> l(_lock);
-        VLOG(1) << "there are " << _load_channels.size() << " running load channels";
         for (auto it = _load_channels.begin(); it != _load_channels.end(); /**/) {
-            time_t last_updated_time = it->second->last_updated_time();
-            if (difftime(now, last_updated_time) >= it->second->timeout()) {
+            if (difftime(now, it->second->last_updated_time()) >= it->second->timeout()) {
                 timeout_channels.emplace_back(std::move(it->second));
                 it = _load_channels.erase(it);
             } else {
@@ -216,6 +170,22 @@ Status LoadChannelMgr::_start_load_channels_clean() {
               << " current=" << _mem_tracker->consumption() << " peak=" << _mem_tracker->peak_consumption();
 
     return Status::OK();
+}
+
+scoped_refptr<LoadChannel> LoadChannelMgr::_find_load_channel(const UniqueId& load_id) {
+    std::lock_guard l(_lock);
+    auto it = _load_channels.find(load_id);
+    return (it != _load_channels.end()) ? it->second : nullptr;
+}
+
+scoped_refptr<LoadChannel> LoadChannelMgr::remove_load_channel(const UniqueId& load_id) {
+    std::lock_guard l(_lock);
+    if (auto it = _load_channels.find(load_id); it != _load_channels.end()) {
+        auto ret = it->second;
+        _load_channels.erase(it);
+        return ret;
+    }
+    return nullptr;
 }
 
 } // namespace starrocks

--- a/be/src/runtime/load_channel_mgr.h
+++ b/be/src/runtime/load_channel_mgr.h
@@ -54,13 +54,13 @@ public:
 
     Status init(MemTracker* mem_tracker);
 
-    void open(brpc::Controller* cntl, const PTabletWriterOpenRequest* request, PTabletWriterOpenResult* response,
+    void open(brpc::Controller* cntl, const PTabletWriterOpenRequest& request, PTabletWriterOpenResult* response,
               google::protobuf::Closure* done);
 
-    void add_chunk(brpc::Controller* cntl, const PTabletWriterAddChunkRequest* request,
+    void add_chunk(brpc::Controller* cntl, const PTabletWriterAddChunkRequest& request,
                    PTabletWriterAddBatchResult* response, google::protobuf::Closure* done);
 
-    void cancel(brpc::Controller* cntl, const PTabletWriterCancelRequest* request, PTabletWriterCancelResult* response,
+    void cancel(brpc::Controller* cntl, const PTabletWriterCancelRequest& request, PTabletWriterCancelResult* response,
                 google::protobuf::Closure* done);
 
     scoped_refptr<LoadChannel> remove_load_channel(const UniqueId& load_id);

--- a/be/src/runtime/load_channel_mgr.h
+++ b/be/src/runtime/load_channel_mgr.h
@@ -27,17 +27,23 @@
 #include <thread>
 #include <unordered_map>
 
-#include "common/status.h"
+#include "common/statusor.h"
 #include "gen_cpp/InternalService_types.h"
 #include "gen_cpp/Types_types.h"
 #include "gen_cpp/internal_service.pb.h"
+#include "runtime/load_channel.h"
 #include "runtime/tablets_channel.h"
+#include "util/blocking_queue.hpp"
+#include "util/threadpool.h"
 #include "util/uid_util.h"
+
+namespace brpc {
+class Controller;
+}
 
 namespace starrocks {
 
 class Cache;
-class LoadChannel;
 
 // LoadChannelMgr -> LoadChannel -> TabletsChannel -> DeltaWriter
 // All dispatched load data for this backend is routed from this class
@@ -48,23 +54,26 @@ public:
 
     Status init(MemTracker* mem_tracker);
 
-    // open a new load channel if not exist
-    Status open(const PTabletWriterOpenRequest& request);
+    void open(brpc::Controller* cntl, const PTabletWriterOpenRequest* request, PTabletWriterOpenResult* response,
+              google::protobuf::Closure* done);
 
-    Status add_chunk(const PTabletWriterAddChunkRequest& request,
-                     google::protobuf::RepeatedPtrField<PTabletInfo>* tablet_vec, int64_t* wait_lock_time_ns);
+    void add_chunk(brpc::Controller* cntl, const PTabletWriterAddChunkRequest* request,
+                   PTabletWriterAddBatchResult* response, google::protobuf::Closure* done);
 
-    // cancel all tablet stream for 'load_id' load
-    Status cancel(const PTabletWriterCancelRequest& request);
+    void cancel(brpc::Controller* cntl, const PTabletWriterCancelRequest* request, PTabletWriterCancelResult* response,
+                google::protobuf::Closure* done);
+
+    scoped_refptr<LoadChannel> remove_load_channel(const UniqueId& load_id);
 
 private:
     Status _start_bg_worker();
 
+    scoped_refptr<LoadChannel> _find_load_channel(const UniqueId& load_id);
+
     // lock protect the load channel map
     std::mutex _lock;
     // load id -> load channel
-    std::unordered_map<UniqueId, std::shared_ptr<LoadChannel>> _load_channels;
-    Cache* _lastest_success_channel = nullptr;
+    std::unordered_map<UniqueId, scoped_refptr<LoadChannel>> _load_channels;
 
     // check the total load mem consumption of this Backend
     MemTracker* _mem_tracker = nullptr;

--- a/be/src/runtime/tablets_channel.cpp
+++ b/be/src/runtime/tablets_channel.cpp
@@ -128,6 +128,9 @@ void TabletsChannel::add_chunk(brpc::Controller* cntl, const PTabletWriterAddChu
         res.status().to_protobuf(response->mutable_status());
         return;
     } else {
+        // Assuming that most writes will be successful, by setting the status code to OK before submitting
+        // `AsyncDeltaWriterRequest`s, there will be no lock contention most of the time in
+        // `WriteContext::update_status()`
         response->mutable_status()->set_status_code(TStatusCode::OK);
     }
 

--- a/be/src/runtime/tablets_channel.cpp
+++ b/be/src/runtime/tablets_channel.cpp
@@ -21,9 +21,13 @@
 
 #include "runtime/tablets_channel.h"
 
+#include <brpc/controller.h>
+#include <fmt/format.h>
+
+#include "common/closure_guard.h"
 #include "exec/tablet_info.h"
-#include "gutil/stl_util.h"
 #include "gutil/strings/substitute.h"
+#include "runtime/load_channel.h"
 #include "storage/vectorized/delta_writer.h"
 #include "storage/vectorized/memtable.h"
 #include "util/starrocks_metrics.h"
@@ -32,9 +36,12 @@ namespace starrocks {
 
 std::atomic<uint64_t> TabletsChannel::_s_tablet_writer_count;
 
-TabletsChannel::TabletsChannel(const TabletsChannelKey& key, MemTracker* mem_tracker)
-        : _key(key), _state(kInitialized), _mem_tracker(mem_tracker), _closed_senders(64) {
-    _mem_pool = std::make_unique<MemPool>();
+TabletsChannel::TabletsChannel(LoadChannel* load_channel, const TabletsChannelKey& key, MemTracker* mem_tracker)
+        : _load_channel(load_channel),
+          _key(key),
+          _mem_tracker(mem_tracker),
+          _has_chunk_meta(false),
+          _mem_pool(std::make_unique<MemPool>()) {
     static std::once_flag once_flag;
     std::call_once(once_flag, [] {
         REGISTER_GAUGE_STARROCKS_METRIC(tablet_writer_count, [&]() { return _s_tablet_writer_count.load(); });
@@ -49,11 +56,6 @@ TabletsChannel::~TabletsChannel() {
 }
 
 Status TabletsChannel::open(const PTabletWriterOpenRequest& params) {
-    std::lock_guard<std::mutex> l(_global_lock);
-    if (_state == kOpened) {
-        // Normal case, already open by other sender
-        return Status::OK();
-    }
     _txn_id = params.txn_id();
     _index_id = params.index_id();
     _schema = new OlapTableSchemaParam();
@@ -61,103 +63,155 @@ Status TabletsChannel::open(const PTabletWriterOpenRequest& params) {
     _tuple_desc = _schema->tuple_desc();
     _row_desc = new RowDescriptor(_tuple_desc, false);
 
-    _num_remaining_senders = params.num_senders();
-    _next_seqs.resize(_num_remaining_senders, 0);
-    _closed_senders.Reset(_num_remaining_senders);
+    _num_remaining_senders.store(params.num_senders(), std::memory_order_release);
+    _senders = std::vector<Sender>(params.num_senders());
 
     RETURN_IF_ERROR(_open_all_writers(params));
-
-    _state = kOpened;
     return Status::OK();
 }
 
-Status TabletsChannel::add_chunk(const PTabletWriterAddChunkRequest& params) {
-    {
-        std::lock_guard<std::mutex> l(_global_lock);
-        if (_state == kFinished) {
-            return _close_status;
-        }
+void TabletsChannel::add_chunk(brpc::Controller* cntl, const PTabletWriterAddChunkRequest* request,
+                               PTabletWriterAddBatchResult* response, google::protobuf::Closure* done) {
+    ClosureGuard done_guard(done);
 
-        auto next_seq = _next_seqs[params.sender_id()];
-        // check packet
-        if (params.packet_seq() < next_seq) {
-            LOG(INFO) << "packet has already received before, expect_seq=" << next_seq
-                      << ", received_seq=" << params.packet_seq();
-            return Status::OK();
-        } else if (params.packet_seq() > next_seq) {
-            LOG(WARNING) << "lost data packet, expect_seq=" << next_seq << ", received_seq=" << params.packet_seq();
-            return Status::InternalError("lost data packet");
-        }
+    if (UNLIKELY(!request->has_sender_id())) {
+        response->mutable_status()->set_status_code(TStatusCode::INVALID_ARGUMENT);
+        response->mutable_status()->add_error_msgs("no sender_id in PTabletWriterAddChunkRequest");
+        return;
+    }
+    if (UNLIKELY(request->sender_id() < 0)) {
+        response->mutable_status()->set_status_code(TStatusCode::INVALID_ARGUMENT);
+        response->mutable_status()->add_error_msgs("negative sender_id in PTabletWriterAddChunkRequest");
+        return;
+    }
+    if (UNLIKELY(request->sender_id() >= _senders.size())) {
+        response->mutable_status()->set_status_code(TStatusCode::INVALID_ARGUMENT);
+        response->mutable_status()->add_error_msgs(
+                fmt::format("invalid sender_id {} in PTabletWriterAddChunkRequest, limit={}", request->sender_id(),
+                            _senders.size()));
+        return;
+    }
+    if (UNLIKELY(!request->has_packet_seq())) {
+        response->mutable_status()->set_status_code(TStatusCode::INVALID_ARGUMENT);
+        response->mutable_status()->add_error_msgs("no packet_seq in PTabletWriterAddChunkRequest");
+        return;
     }
 
-    auto& pchunk = params.chunk();
-    {
-        std::lock_guard<std::mutex> l(_global_lock);
-        if (_chunk_meta.types.empty()) {
-            RETURN_IF_ERROR(_build_chunk_meta(pchunk));
-        }
+    Sender& sender = _senders[request->sender_id()];
+    std::lock_guard l(sender.lock);
+
+    if (sender.next_seq < 0) {
+        response->mutable_status()->set_status_code(TStatusCode::INTERNAL_ERROR);
+        response->mutable_status()->add_error_msgs("Tablet channel has been cancelled");
+        return;
+    } else if (request->packet_seq() == sender.next_seq) {
+        sender.next_seq++;
+    } else if (request->packet_seq() < sender.next_seq) {
+        LOG(INFO) << "Ignore outdated request from " << cntl->remote_side() << ". seq=" << request->packet_seq()
+                  << " expect=" << sender.next_seq << " load_id=" << _load_channel->load_id();
+        response->mutable_status()->set_status_code(TStatusCode::OK);
+        return;
+    } else {
+        LOG(WARNING) << "Out-of-order request from " << cntl->remote_side() << ". seq=" << request->packet_seq()
+                     << " expect=" << sender.next_seq << " load_id=" << _load_channel->load_id();
+        response->mutable_status()->set_status_code(TStatusCode::INVALID_ARGUMENT);
+        response->mutable_status()->add_error_msgs("out-of-order request");
+        return;
     }
 
-    vectorized::Chunk chunk;
-    RETURN_IF_ERROR(chunk.deserialize((const uint8_t*)pchunk.data().data(), pchunk.data().size(), _chunk_meta,
-                                      pchunk.serialized_size()));
-    DCHECK_EQ(params.tablet_ids_size(), chunk.num_rows());
-
-    size_t channel_size = _tablet_id_to_sorted_indexes.size();
-    std::vector<uint32_t> row_indexes(chunk.num_rows());
-    std::vector<uint32_t> channel_row_idx_start_points(channel_size + 1);
-    {
-        // compute row indexes for each channel
-        channel_row_idx_start_points.assign(channel_size + 1, 0);
-        for (uint32_t i = 0; i < params.tablet_ids_size(); ++i) {
-            uint32_t channel_index = _tablet_id_to_sorted_indexes[params.tablet_ids(i)];
-            channel_row_idx_start_points[channel_index]++;
-        }
-
-        // NOTE: we make the last item equal with number of rows of this chunk
-        for (int i = 1; i <= channel_size; ++i) {
-            channel_row_idx_start_points[i] += channel_row_idx_start_points[i - 1];
-        }
-
-        for (int i = params.tablet_ids_size() - 1; i >= 0; --i) {
-            uint32_t channel_index = _tablet_id_to_sorted_indexes[params.tablet_ids(i)];
-            row_indexes[channel_row_idx_start_points[channel_index] - 1] = i;
-            channel_row_idx_start_points[channel_index]--;
-        }
+    auto res = _create_write_context(request, response, done);
+    if (!res.ok()) {
+        res.status().to_protobuf(response->mutable_status());
+        return;
+    } else {
+        response->mutable_status()->set_status_code(TStatusCode::OK);
     }
+
+    auto context = std::move(res).value();
+    auto channel_size = _tablet_id_to_sorted_indexes.size();
+    auto tablet_ids = request->tablet_ids().data();
+    auto tablet_ids_size = request->tablet_ids_size();
+    auto channel_row_idx_start_points = context->_channel_row_idx_start_points.get();
+    auto row_indexes = context->_row_indexes.get();
+    auto& chunk = context->_chunk;
+    DCHECK_EQ(channel_size, _delta_writers.size());
+
+    auto count_down_latch = BThreadCountDownLatch(1);
+
+    context->set_count_down_latch(&count_down_latch);
 
     for (int i = 0; i < channel_size; ++i) {
         size_t from = channel_row_idx_start_points[i];
         size_t size = channel_row_idx_start_points[i + 1] - from;
         if (size == 0) {
-            // no data for this channel continue;
             continue;
         }
-        auto tablet_id = params.tablet_ids(row_indexes[from]);
+        auto tablet_id = tablet_ids[row_indexes[from]];
         auto it = _delta_writers.find(tablet_id);
-        if (it == std::end(_delta_writers)) {
-            return Status::InternalError(strings::Substitute("unknown tablet to append data, tablet=$0", tablet_id));
-        }
-        {
-            std::lock_guard<std::mutex> l(_tablet_locks[tablet_id & k_shard_size]);
-            auto st = it->second->write(chunk, row_indexes.data(), from, size);
-            if (!st.ok()) {
-                it->second->abort();
-                return st;
+        CHECK(it != _delta_writers.end());
+        auto& delta_writer = it->second;
+
+        AsyncDeltaWriterRequest req;
+        req.chunk = &context->_chunk;
+        req.indexes = row_indexes + from;
+        req.indexes_size = size;
+        req.commit_after_write = false;
+
+        // The reference count of context is increased in the constructor of WriteCallback
+        // and decreased in the destructor of WriteCallback.
+        auto cb = new WriteCallback(context.get());
+
+        delta_writer->write(req, cb);
+    }
+
+    // _channel_row_idx_start_points no longer used, release it to free memory.
+    context->_channel_row_idx_start_points.reset();
+
+    bool close_channel = false;
+
+    // NOTE: Must close sender *AFTER* the write requests submitted, otherwise a delta writer commit request may
+    // be executed ahead of the write requests submitted by other senders.
+    if (request->eos() && _close_sender(&sender, request->partition_ids().data(), request->partition_ids_size()) == 0) {
+        close_channel = true;
+        std::lock_guard l1(_partitions_ids_lock);
+        for (auto& [_, delta_writer] : _delta_writers) {
+            if (UNLIKELY(_partition_ids.count(delta_writer->partition_id()) == 0)) {
+                delta_writer->abort();
+            } else {
+                auto cb = new WriteCallback(context.get());
+                delta_writer->commit(cb);
             }
         }
     }
 
-    {
-        std::lock_guard<std::mutex> l(_global_lock);
-        _next_seqs[params.sender_id()]++;
+    // Must reset the context pointer before waiting on the |count_down_latch|,
+    // because the |count_down_latch| is decreased in the destructor of the context,
+    // and the destructor of the context cannot be called unless we reset the pointer
+    // here.
+    context.reset();
+
+    // This will only block the bthread, will not block the pthread
+    count_down_latch.wait();
+
+    if (close_channel) {
+        _load_channel->remove_tablets_channel(_index_id);
     }
-    return Status::OK();
 }
 
 Status TabletsChannel::_build_chunk_meta(const ChunkPB& pb_chunk) {
-    if (UNLIKELY(pb_chunk.is_nulls().empty() || pb_chunk.slot_id_map().empty())) {
-        return Status::InternalError("pb_chunk meta could not be empty");
+    if (UNLIKELY(pb_chunk.is_nulls().empty())) {
+        return Status::InternalError("ChunkPB::is_nulls() is empty");
+    }
+    if (UNLIKELY(pb_chunk.slot_id_map().empty())) {
+        return Status::InternalError("ChunkPB::slot_id_map() is empty");
+    }
+
+    if (_has_chunk_meta.load(std::memory_order_acquire)) {
+        return Status::OK();
+    }
+    std::lock_guard l(_chunk_meta_lock);
+    if (_has_chunk_meta.load(std::memory_order_acquire)) {
+        return Status::OK();
     }
 
     _chunk_meta.slot_id_to_index.reserve(pb_chunk.slot_id_map().size());
@@ -187,79 +241,24 @@ Status TabletsChannel::_build_chunk_meta(const ChunkPB& pb_chunk) {
     }
 
     if (UNLIKELY(column_index != _chunk_meta.is_nulls.size())) {
-        return Status::InternalError("build chunk meta error");
+        return Status::InternalError("column_index != _chunk_meta.is_nulls.size()");
     }
+    _has_chunk_meta.store(true, std::memory_order_release);
     return Status::OK();
 }
 
-Status TabletsChannel::close(int sender_id, bool* finished,
-                             const google::protobuf::RepeatedField<int64_t>& partition_ids,
-                             google::protobuf::RepeatedPtrField<PTabletInfo>* tablet_vec) {
-    {
-        std::lock_guard<std::mutex> l(_global_lock);
-        if (_state == kFinished) {
-            return _close_status;
-        }
-        if (_closed_senders.Get(sender_id)) {
-            // Double close from one sender, just return OK
-            *finished = (_num_remaining_senders == 0);
-            return _close_status;
-        }
-        for (auto pid : partition_ids) {
-            _partition_ids.emplace(pid);
-        }
-        _closed_senders.Set(sender_id, true);
-        _num_remaining_senders--;
-        *finished = (_num_remaining_senders == 0);
-        if (*finished) {
-            _state = kFinished;
-        }
+// NOTE: Assume sender->lock has been acquired.
+int TabletsChannel::_close_sender(Sender* sender, const int64_t* partitions, size_t partitions_size) {
+    bool ret = false;
+    DCHECK(!sender->closed);
+    sender->closed = true;
+    int n = _num_remaining_senders.fetch_sub(1);
+    DCHECK_GE(n, 1);
+    std::lock_guard l(_partitions_ids_lock);
+    for (int i = 0; i < partitions_size; i++) {
+        _partition_ids.insert(partitions[i]);
     }
-
-    if (*finished) {
-        // All senders are closed
-        // 1. close all delta writers
-        std::unordered_map<int64_t, vectorized::DeltaWriter*> need_wait_writers;
-        for (auto& it : _delta_writers) {
-            if (_partition_ids.count(it.second->partition_id()) > 0) {
-                std::lock_guard<std::mutex> l(_tablet_locks[it.first & k_shard_size]);
-                auto st = it.second->close();
-                if (!st.ok()) {
-                    LOG(WARNING) << "Fail to close tablet writer, tablet_id=" << it.first
-                                 << " transaction_id=" << _txn_id << " err=" << st.to_string();
-                    // just skip this tablet(writer) and continue to close others
-                    continue;
-                }
-                need_wait_writers.emplace(it.first, it.second.get());
-            } else {
-                std::lock_guard<std::mutex> l(_tablet_locks[it.first & k_shard_size]);
-                it.second->abort();
-            }
-        }
-
-        // 2. wait delta writers and build the tablet vector
-        for (auto& [tablet_id, delta_writer] : need_wait_writers) {
-            std::lock_guard<std::mutex> l(_tablet_locks[tablet_id & k_shard_size]);
-            // commit may return error, but no need to handle it here.
-            // tablet_vec will only contains success tablet, and then let FE judge it.
-            if (auto st = delta_writer->commit(); !st.ok()) {
-                continue;
-            }
-            PTabletInfo* tablet_info = tablet_vec->Add();
-            tablet_info->set_tablet_id(delta_writer->tablet()->tablet_id());
-            tablet_info->set_schema_hash(delta_writer->tablet()->schema_hash());
-            const auto& dict_info = delta_writer->committed_rowset_writer()->global_dict_columns_valid_info();
-            for (const auto& item : dict_info) {
-                if (item.second) {
-                    tablet_info->add_valid_dict_cache_columns(item.first);
-                } else {
-                    tablet_info->add_invalid_dict_cache_columns(item.first);
-                }
-            }
-        }
-    }
-
-    return Status::OK();
+    return n - 1;
 }
 
 Status TabletsChannel::_open_all_writers(const PTabletWriterOpenRequest& params) {
@@ -277,7 +276,7 @@ Status TabletsChannel::_open_all_writers(const PTabletWriterOpenRequest& params)
         ss << "unknown index id, key=" << _key;
         return Status::InternalError(ss.str());
     }
-    // init global dict info if need
+    // init global dict info if needed
     for (auto& slot : params.schema().slot_descs()) {
         vectorized::GlobalDictMap global_dict;
         if (slot.global_dict_words_size()) {
@@ -295,7 +294,7 @@ Status TabletsChannel::_open_all_writers(const PTabletWriterOpenRequest& params)
 
     std::vector<int64_t> tablet_ids;
     tablet_ids.reserve(params.tablets_size());
-    for (auto& tablet : params.tablets()) {
+    for (const PTabletWithPartition& tablet : params.tablets()) {
         vectorized::DeltaWriterOptions options;
         options.tablet_id = tablet.tablet_id();
         options.schema_hash = schema_hash;
@@ -307,15 +306,14 @@ Status TabletsChannel::_open_all_writers(const PTabletWriterOpenRequest& params)
         options.slots = index_slots;
         options.global_dicts = &_global_dicts;
 
-        auto res = vectorized::DeltaWriter::open(options, _mem_tracker);
+        auto res = AsyncDeltaWriter::open(options, _mem_tracker);
         if (!res.ok()) {
-            std::stringstream ss;
-            ss << "open delta writer failed, tablet_id=" << tablet.tablet_id() << ", txn_id=" << _txn_id
-               << ", partition_id=" << tablet.partition_id() << ", err=" << res.status();
-            LOG(WARNING) << ss.str();
-            return Status::InternalError(ss.str());
+            LOG(WARNING) << "Fail to open delta writer: " << res.status() << ". tablet_id=" << tablet.tablet_id()
+                         << " txn_id=" << _txn_id << " partition_id=" << tablet.partition_id();
+            return Status::InternalError("fail to open delta writer: " + res.status().get_error_msg());
         }
-        _delta_writers.emplace(tablet.tablet_id(), std::move(res).value());
+        auto writer = std::move(res).value();
+        _delta_writers.emplace(tablet.tablet_id(), std::move(writer));
         tablet_ids.emplace_back(tablet.tablet_id());
     }
     _s_tablet_writer_count += _delta_writers.size();
@@ -328,22 +326,84 @@ Status TabletsChannel::_open_all_writers(const PTabletWriterOpenRequest& params)
     return Status::OK();
 }
 
-Status TabletsChannel::cancel() {
-    {
-        std::lock_guard<std::mutex> l(_global_lock);
-        if (_state == kFinished) {
-            return _close_status;
-        }
+void TabletsChannel::cancel() {
+    for (auto& sender : _senders) {
+        std::lock_guard l(sender.lock);
+        sender.next_seq = -1;
     }
-
     for (auto& it : _delta_writers) {
-        std::lock_guard<std::mutex> l(_tablet_locks[it.first & k_shard_size]);
-        it.second->abort();
+        (void)it.second->abort();
+    }
+}
+
+StatusOr<scoped_refptr<TabletsChannel::WriteContext>> TabletsChannel::_create_write_context(
+        const PTabletWriterAddChunkRequest* request, PTabletWriterAddBatchResult* response,
+        google::protobuf::Closure* done) {
+    if (!request->has_chunk() && !request->eos()) {
+        return Status::InvalidArgument("PTabletWriterAddChunkRequest has no chunk or eos");
     }
 
-    std::lock_guard<std::mutex> l(_global_lock);
-    _state = kFinished;
-    return Status::OK();
+    auto& pchunk = request->chunk();
+    RETURN_IF_ERROR(_build_chunk_meta(pchunk));
+
+    scoped_refptr<WriteContext> context(new WriteContext(response));
+    vectorized::Chunk& chunk = context->_chunk;
+    RETURN_IF_ERROR(chunk.deserialize((const uint8_t*)pchunk.data().data(), pchunk.data().size(), _chunk_meta,
+                                      pchunk.serialized_size()));
+    if (UNLIKELY(request->tablet_ids_size() != chunk.num_rows())) {
+        return Status::InvalidArgument("request->tablet_ids_size() != chunk.num_rows()");
+    }
+
+    const auto channel_size = _tablet_id_to_sorted_indexes.size();
+    context->_row_indexes = std::make_unique<uint32_t[]>(chunk.num_rows());
+    context->_channel_row_idx_start_points = std::make_unique<uint32_t[]>(channel_size + 1);
+
+    auto& row_indexes = context->_row_indexes;
+    auto& channel_row_idx_start_points = context->_channel_row_idx_start_points;
+
+    // compute row indexes for each channel
+    for (uint32_t i = 0; i < request->tablet_ids_size(); ++i) {
+        uint32_t channel_index = _tablet_id_to_sorted_indexes[request->tablet_ids(i)];
+        channel_row_idx_start_points[channel_index]++;
+    }
+
+    // NOTE: we make the last item equal with number of rows of this chunk
+    for (int i = 1; i <= channel_size; ++i) {
+        channel_row_idx_start_points[i] += channel_row_idx_start_points[i - 1];
+    }
+
+    auto tablet_ids = request->tablet_ids().data();
+    auto tablet_ids_size = request->tablet_ids_size();
+    for (int i = tablet_ids_size - 1; i >= 0; --i) {
+        const auto& tablet_id = tablet_ids[i];
+        auto it = _tablet_id_to_sorted_indexes.find(tablet_id);
+        if (UNLIKELY(it == _tablet_id_to_sorted_indexes.end())) {
+            return Status::InternalError("invalid tablet id");
+        }
+        uint32_t channel_index = it->second;
+        row_indexes[channel_row_idx_start_points[channel_index] - 1] = i;
+        channel_row_idx_start_points[channel_index]--;
+    }
+    return std::move(context);
+}
+
+void TabletsChannel::WriteCallback::run(const Status& st, const CommittedRowsetInfo* info) {
+    _context->update_status(st);
+    if (info != nullptr) {
+        PTabletInfo tablet_info;
+        tablet_info.set_tablet_id(info->tablet->tablet_id());
+        tablet_info.set_schema_hash(info->tablet->schema_hash());
+        const auto& rowset_global_dict_columns_valid_info = info->rowset_writer->global_dict_columns_valid_info();
+        for (const auto& item : rowset_global_dict_columns_valid_info) {
+            if (item.second) {
+                tablet_info.add_valid_dict_cache_columns(item.first);
+            } else {
+                tablet_info.add_invalid_dict_cache_columns(item.first);
+            }
+        }
+        _context->add_committed_tablet_info(&tablet_info);
+    }
+    delete this;
 }
 
 std::string TabletsChannelKey::to_string() const {

--- a/be/src/runtime/tablets_channel.cpp
+++ b/be/src/runtime/tablets_channel.cpp
@@ -148,7 +148,7 @@ void TabletsChannel::add_chunk(brpc::Controller* cntl, const PTabletWriterAddChu
         }
         auto tablet_id = tablet_ids[row_indexes[from]];
         auto it = _delta_writers.find(tablet_id);
-        CHECK(it != _delta_writers.end());
+        DCHECK(it != _delta_writers.end());
         auto& delta_writer = it->second;
 
         AsyncDeltaWriterRequest req;

--- a/be/src/runtime/tablets_channel.h
+++ b/be/src/runtime/tablets_channel.h
@@ -18,28 +18,37 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+#pragma once
+
+#include <bthread/condition_variable.h>
+#include <bthread/mutex.h>
 
 #include <cstdint>
+#include <shared_mutex>
 #include <unordered_map>
 #include <utility>
 #include <vector>
 
 #include "column/chunk.h"
+#include "common/statusor.h"
 #include "gen_cpp/InternalService_types.h"
 #include "gen_cpp/Types_types.h"
 #include "gen_cpp/internal_service.pb.h"
+#include "gutil/ref_counted.h"
 #include "runtime/descriptors.h"
 #include "runtime/global_dicts.h"
 #include "runtime/mem_tracker.h"
-#include "util/bitmap.h"
-#include "util/priority_thread_pool.hpp"
-#include "util/uid_util.h"
+#include "storage/vectorized/async_delta_writer.h"
+#include "util/countdown_latch.h"
+
+namespace brpc {
+class Controller;
+}
 
 namespace starrocks {
 
-namespace vectorized {
-class DeltaWriter;
-}
+class OlapTableSchemaParam;
+class LoadChannel;
 
 struct TabletsChannelKey {
     UniqueId id;
@@ -54,79 +63,148 @@ struct TabletsChannelKey {
     std::string to_string() const;
 };
 
-std::ostream& operator<<(std::ostream& os, const TabletsChannelKey& key);
-
-class OlapTableSchemaParam;
+inline std::ostream& operator<<(std::ostream& os, const TabletsChannelKey& key);
 
 // Write channel for a particular (load, index).
-class TabletsChannel {
+class TabletsChannel : public RefCountedThreadSafe<TabletsChannel> {
+    using AsyncDeltaWriter = vectorized::AsyncDeltaWriter;
+    using AsyncDeltaWriterCallback = vectorized::AsyncDeltaWriterCallback;
+    using AsyncDeltaWriterRequest = vectorized::AsyncDeltaWriterRequest;
+    using CommittedRowsetInfo = vectorized::CommittedRowsetInfo;
+
 public:
-    TabletsChannel(const TabletsChannelKey& key, MemTracker* mem_tracker);
+    TabletsChannel(LoadChannel* load_channel, const TabletsChannelKey& key, MemTracker* mem_tracker);
 
-    ~TabletsChannel();
+    TabletsChannel(const TabletsChannel&) = delete;
+    TabletsChannel(TabletsChannel&&) = delete;
+    void operator=(const TabletsChannel&) = delete;
+    void operator=(TabletsChannel&&) = delete;
 
+    const TabletsChannelKey& key() const { return _key; }
+
+    // NOTE: This method is not retryable.
     Status open(const PTabletWriterOpenRequest& params);
 
-    // no-op when this channel has been closed or cancelled
-    Status add_chunk(const PTabletWriterAddChunkRequest& batch);
+    void add_chunk(brpc::Controller* cntl, const PTabletWriterAddChunkRequest* request,
+                   PTabletWriterAddBatchResult* response, google::protobuf::Closure* done);
 
-    // Mark sender with 'sender_id' as closed.
-    // If all senders are closed, close this channel, set '*finished' to true, update 'tablet_vec'
-    // to include all tablets written in this channel.
-    // no-op when this channel has been closed or cancelled
-    Status close(int sender_id, bool* finished, const google::protobuf::RepeatedField<int64_t>& partition_ids,
-                 google::protobuf::RepeatedPtrField<PTabletInfo>* tablet_vec);
+    void cancel();
 
-    // no-op when this channel has been closed or cancelled
-    Status cancel();
+    MemTracker* mem_tracker() { return _mem_tracker; }
 
 private:
-    enum State {
-        kInitialized,
-        kOpened,
-        kFinished // closed or cancelled
+    using BThreadCountDownLatch = GenericCountDownLatch<bthread::Mutex, bthread::ConditionVariable>;
+
+    friend class RefCountedThreadSafe<TabletsChannel>;
+    ~TabletsChannel();
+
+    static std::atomic<uint64_t> _s_tablet_writer_count;
+
+    struct Sender {
+        std::mutex lock;
+        int64_t next_seq = 0; // NOTE: -1 means this sender has closed
+        bool closed = false;
     };
 
-    // open all writer
+    class WriteContext : public RefCountedThreadSafe<WriteContext> {
+    public:
+        explicit WriteContext(PTabletWriterAddBatchResult* response) : _response(response), _latch(nullptr) {}
+
+        WriteContext(const WriteContext&) = delete;
+        void operator=(const WriteContext&) = delete;
+        WriteContext(WriteContext&&) = delete;
+        void operator=(WriteContext&&) = delete;
+
+        void update_status(const Status& status) {
+            if (status.ok() || _response == nullptr) {
+                return;
+            }
+            std::lock_guard l(_response_lock);
+            if (_response->status().status_code() == TStatusCode::OK) {
+                status.to_protobuf(_response->mutable_status());
+            }
+        }
+
+        void add_committed_tablet_info(PTabletInfo* tablet_info) {
+            DCHECK(_response != nullptr);
+            std::lock_guard l(_response_lock);
+            _response->add_tablet_vec()->Swap(tablet_info);
+        }
+
+        void set_count_down_latch(BThreadCountDownLatch* latch) { _latch = latch; }
+
+        void clear_response() { _response = nullptr; }
+
+    private:
+        friend class TabletsChannel;
+        friend class RefCountedThreadSafe<WriteContext>;
+        ~WriteContext() {
+            if (_latch) _latch->count_down();
+        }
+
+        mutable std::mutex _response_lock;
+        PTabletWriterAddBatchResult* _response;
+        BThreadCountDownLatch* _latch;
+
+        vectorized::Chunk _chunk;
+        std::unique_ptr<uint32_t[]> _row_indexes;
+        std::unique_ptr<uint32_t[]> _channel_row_idx_start_points;
+    };
+
+    class WriteCallback : public AsyncDeltaWriterCallback {
+    public:
+        explicit WriteCallback(WriteContext* context) : _context(context) { _context->AddRef(); }
+
+        ~WriteCallback() override { _context->Release(); }
+
+        void run(const Status& st, const CommittedRowsetInfo* info) override;
+
+        WriteCallback(const WriteCallback&) = delete;
+        void operator=(const WriteCallback&) = delete;
+        WriteCallback(WriteCallback&&) = delete;
+        void operator=(WriteCallback&&) = delete;
+
+    private:
+        WriteContext* _context;
+    };
+
     Status _open_all_writers(const PTabletWriterOpenRequest& params);
 
     Status _build_chunk_meta(const ChunkPB& pb_chunk);
 
-    // id of this load channel
+    StatusOr<scoped_refptr<WriteContext>> _create_write_context(const PTabletWriterAddChunkRequest* request,
+                                                                PTabletWriterAddBatchResult* response,
+                                                                google::protobuf::Closure* done);
+
+    int _close_sender(Sender* sender, const int64_t* partitions, size_t partitions_size);
+
+    LoadChannel* _load_channel;
+
     TabletsChannelKey _key;
 
-    State _state;
     MemTracker* _mem_tracker;
-
-    // make execute sequece
-    std::mutex _global_lock;
-    static constexpr int k_shard_size = 127;
-    std::array<std::mutex, k_shard_size + 1> _tablet_locks;
 
     // initialized in open function
     int64_t _txn_id = -1;
     int64_t _index_id = -1;
     OlapTableSchemaParam* _schema = nullptr;
     TupleDescriptor* _tuple_desc = nullptr;
-    // row_desc used to construct
     RowDescriptor* _row_desc = nullptr;
 
     // next sequence we expect
-    int _num_remaining_senders = 0;
-    std::vector<int64_t> _next_seqs;
-    Bitmap _closed_senders;
-    // status to return when operate on an already closed/cancelled channel
-    // currently it's OK.
-    Status _close_status;
+    std::atomic<int> _num_remaining_senders;
+    std::vector<Sender> _senders;
 
+    mutable std::mutex _partitions_ids_lock;
     std::unordered_set<int64_t> _partition_ids;
 
-    static std::atomic<uint64_t> _s_tablet_writer_count;
-
+    mutable std::mutex _chunk_meta_lock;
     vectorized::RuntimeChunkMeta _chunk_meta;
+    std::atomic<bool> _has_chunk_meta;
+
     std::unordered_map<int64_t, uint32_t> _tablet_id_to_sorted_indexes;
     // tablet_id -> TabletChannel
-    std::unordered_map<int64_t, std::unique_ptr<vectorized::DeltaWriter>> _delta_writers;
+    std::unordered_map<int64_t, std::unique_ptr<AsyncDeltaWriter>> _delta_writers;
 
     vectorized::GlobalDictByNameMaps _global_dicts;
     std::unique_ptr<MemPool> _mem_pool;

--- a/be/src/runtime/tablets_channel.h
+++ b/be/src/runtime/tablets_channel.h
@@ -85,7 +85,7 @@ public:
     // NOTE: This method is not retryable.
     Status open(const PTabletWriterOpenRequest& params);
 
-    void add_chunk(brpc::Controller* cntl, const PTabletWriterAddChunkRequest* request,
+    void add_chunk(brpc::Controller* cntl, const PTabletWriterAddChunkRequest& request,
                    PTabletWriterAddBatchResult* response, google::protobuf::Closure* done);
 
     void cancel();
@@ -172,7 +172,7 @@ private:
 
     Status _build_chunk_meta(const ChunkPB& pb_chunk);
 
-    StatusOr<scoped_refptr<WriteContext>> _create_write_context(const PTabletWriterAddChunkRequest* request,
+    StatusOr<scoped_refptr<WriteContext>> _create_write_context(const PTabletWriterAddChunkRequest& request,
                                                                 PTabletWriterAddBatchResult* response,
                                                                 google::protobuf::Closure* done);
 

--- a/be/src/service/brpc_service.cpp
+++ b/be/src/service/brpc_service.cpp
@@ -23,6 +23,7 @@
 
 #include <cstring>
 
+#include "common/config.h"
 #include "common/logging.h"
 #include "service/brpc.h"
 #include "service/internal_service.h"

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -131,7 +131,7 @@ void PInternalServiceImpl<T>::tablet_writer_open(google::protobuf::RpcController
                                                  PTabletWriterOpenResult* response, google::protobuf::Closure* done) {
     VLOG_RPC << "tablet writer open, id=" << print_id(request->id()) << ", index_id=" << request->index_id()
              << ", txn_id=" << request->txn_id();
-    _exec_env->load_channel_mgr()->open(static_cast<brpc::Controller*>(cntl_base), request, response, done);
+    _exec_env->load_channel_mgr()->open(static_cast<brpc::Controller*>(cntl_base), *request, response, done);
 }
 
 template <typename T>
@@ -163,7 +163,7 @@ void PInternalServiceImpl<T>::tablet_writer_add_chunk(google::protobuf::RpcContr
                                                       google::protobuf::Closure* done) {
     VLOG_RPC << "tablet writer add chunk, id=" << print_id(request->id()) << ", index_id=" << request->index_id()
              << ", sender_id=" << request->sender_id();
-    _exec_env->load_channel_mgr()->add_chunk(static_cast<brpc::Controller*>(cntl_base), request, response, done);
+    _exec_env->load_channel_mgr()->add_chunk(static_cast<brpc::Controller*>(cntl_base), *request, response, done);
 }
 
 template <typename T>
@@ -173,7 +173,7 @@ void PInternalServiceImpl<T>::tablet_writer_cancel(google::protobuf::RpcControll
                                                    google::protobuf::Closure* done) {
     VLOG_RPC << "tablet writer cancel, id=" << print_id(request->id()) << ", index_id=" << request->index_id()
              << ", sender_id=" << request->sender_id();
-    _exec_env->load_channel_mgr()->cancel(static_cast<brpc::Controller*>(cntl_base), request, response, done);
+    _exec_env->load_channel_mgr()->cancel(static_cast<brpc::Controller*>(cntl_base), *request, response, done);
 }
 
 template <typename T>

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -42,8 +42,7 @@
 namespace starrocks {
 
 template <typename T>
-PInternalServiceImpl<T>::PInternalServiceImpl(ExecEnv* exec_env)
-        : _exec_env(exec_env), _tablet_worker_pool("tablet", config::number_tablet_writer_threads, 10240) {}
+PInternalServiceImpl<T>::PInternalServiceImpl(ExecEnv* exec_env) : _exec_env(exec_env) {}
 
 template <typename T>
 PInternalServiceImpl<T>::~PInternalServiceImpl() = default;
@@ -54,7 +53,7 @@ void PInternalServiceImpl<T>::transmit_data(google::protobuf::RpcController* cnt
                                             google::protobuf::Closure* done) {
     VLOG_ROW << "transmit data: fragment_instance_id=" << print_id(request->finst_id())
              << " node=" << request->node_id();
-    brpc::Controller* cntl = static_cast<brpc::Controller*>(cntl_base);
+    auto* cntl = static_cast<brpc::Controller*>(cntl_base);
     if (cntl->request_attachment().size() > 0) {
         PRowBatch* batch = (const_cast<PTransmitDataParams*>(request))->mutable_row_batch();
         butil::IOBuf& io_buf = cntl->request_attachment();
@@ -118,7 +117,7 @@ void PInternalServiceImpl<T>::transmit_runtime_filter(google::protobuf::RpcContr
                                                       PTransmitRuntimeFilterResult* response,
                                                       google::protobuf::Closure* done) {
     VLOG_FILE << "transmit runtime filter: fragment_instance_id=" << print_id(request->finst_id())
-              << " query_id=" << request->query_id() << ", is_partial=" << request->is_partial()
+              << " query_id=" << print_id(request->query_id()) << ", is_partital=" << request->is_partial()
               << ", filter_id=" << request->filter_id() << ", is_pipeline=" << request->is_pipeline();
     ClosureGuard closure_guard(done);
     _exec_env->runtime_filter_worker()->receive_runtime_filter(*request);
@@ -127,18 +126,12 @@ void PInternalServiceImpl<T>::transmit_runtime_filter(google::protobuf::RpcContr
 }
 
 template <typename T>
-void PInternalServiceImpl<T>::tablet_writer_open(google::protobuf::RpcController* controller,
+void PInternalServiceImpl<T>::tablet_writer_open(google::protobuf::RpcController* cntl_base,
                                                  const PTabletWriterOpenRequest* request,
                                                  PTabletWriterOpenResult* response, google::protobuf::Closure* done) {
-    VLOG_RPC << "tablet writer open, id=" << request->id() << ", index_id=" << request->index_id()
+    VLOG_RPC << "tablet writer open, id=" << print_id(request->id()) << ", index_id=" << request->index_id()
              << ", txn_id=" << request->txn_id();
-    ClosureGuard closure_guard(done);
-    auto st = _exec_env->load_channel_mgr()->open(*request);
-    if (!st.ok()) {
-        LOG(WARNING) << "load channel open failed, message=" << st.get_error_msg() << ", id=" << request->id()
-                     << ", index_id=" << request->index_id() << ", txn_id=" << request->txn_id();
-    }
-    st.to_protobuf(response->mutable_status());
+    _exec_env->load_channel_mgr()->open(static_cast<brpc::Controller*>(cntl_base), request, response, done);
 }
 
 template <typename T>
@@ -164,48 +157,23 @@ void PInternalServiceImpl<T>::tablet_writer_add_batch(google::protobuf::RpcContr
 }
 
 template <typename T>
-void PInternalServiceImpl<T>::tablet_writer_add_chunk(google::protobuf::RpcController* controller,
+void PInternalServiceImpl<T>::tablet_writer_add_chunk(google::protobuf::RpcController* cntl_base,
                                                       const PTabletWriterAddChunkRequest* request,
                                                       PTabletWriterAddBatchResult* response,
                                                       google::protobuf::Closure* done) {
-    VLOG_RPC << "tablet writer add chunk, id=" << request->id() << ", index_id=" << request->index_id()
+    VLOG_RPC << "tablet writer add chunk, id=" << print_id(request->id()) << ", index_id=" << request->index_id()
              << ", sender_id=" << request->sender_id();
-    // add chunk maybe cost a lot of time, and this callback thread will be held.
-    // this will influence query execution, because the pthreads under bthread may be
-    // exhausted, so we put this to a local thread pool to process
-    _tablet_worker_pool.offer([request, response, done, this]() {
-        ClosureGuard closure_guard(done);
-        int64_t execution_time_ns = 0;
-        int64_t wait_lock_time_ns = 0;
-        {
-            SCOPED_RAW_TIMER(&execution_time_ns);
-            auto st = _exec_env->load_channel_mgr()->add_chunk(*request, response->mutable_tablet_vec(),
-                                                               &wait_lock_time_ns);
-            if (!st.ok()) {
-                LOG(WARNING) << "tablet writer add chunk failed, message=" << st.get_error_msg()
-                             << ", id=" << print_id(request->id()) << ", index_id=" << request->index_id()
-                             << ", sender_id=" << request->sender_id();
-            }
-            st.to_protobuf(response->mutable_status());
-        }
-        response->set_execution_time_us(execution_time_ns / 1000);
-        response->set_wait_lock_time_us(wait_lock_time_ns / 1000);
-    });
+    _exec_env->load_channel_mgr()->add_chunk(static_cast<brpc::Controller*>(cntl_base), request, response, done);
 }
 
 template <typename T>
-void PInternalServiceImpl<T>::tablet_writer_cancel(google::protobuf::RpcController* controller,
+void PInternalServiceImpl<T>::tablet_writer_cancel(google::protobuf::RpcController* cntl_base,
                                                    const PTabletWriterCancelRequest* request,
                                                    PTabletWriterCancelResult* response,
                                                    google::protobuf::Closure* done) {
-    VLOG_RPC << "tablet writer cancel, id=" << request->id() << ", index_id=" << request->index_id()
+    VLOG_RPC << "tablet writer cancel, id=" << print_id(request->id()) << ", index_id=" << request->index_id()
              << ", sender_id=" << request->sender_id();
-    ClosureGuard closure_guard(done);
-    auto st = _exec_env->load_channel_mgr()->cancel(*request);
-    if (!st.ok()) {
-        LOG(WARNING) << "tablet writer cancel failed, id=" << request->id() << ", index_id=" << request->index_id()
-                     << ", sender_id=" << request->sender_id();
-    }
+    _exec_env->load_channel_mgr()->cancel(static_cast<brpc::Controller*>(cntl_base), request, response, done);
 }
 
 template <typename T>

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -117,7 +117,7 @@ void PInternalServiceImpl<T>::transmit_runtime_filter(google::protobuf::RpcContr
                                                       PTransmitRuntimeFilterResult* response,
                                                       google::protobuf::Closure* done) {
     VLOG_FILE << "transmit runtime filter: fragment_instance_id=" << print_id(request->finst_id())
-              << " query_id=" << print_id(request->query_id()) << ", is_partital=" << request->is_partial()
+              << " query_id=" << print_id(request->query_id()) << ", is_partial=" << request->is_partial()
               << ", filter_id=" << request->filter_id() << ", is_pipeline=" << request->is_pipeline();
     ClosureGuard closure_guard(done);
     _exec_env->runtime_filter_worker()->receive_runtime_filter(*request);

--- a/be/src/service/internal_service.h
+++ b/be/src/service/internal_service.h
@@ -24,7 +24,6 @@
 #include "common/status.h"
 #include "gen_cpp/doris_internal_service.pb.h"
 #include "gen_cpp/internal_service.pb.h"
-#include "util/priority_thread_pool.hpp"
 
 namespace brpc {
 class Controller;
@@ -86,7 +85,6 @@ private:
 
 private:
     ExecEnv* _exec_env;
-    PriorityThreadPool _tablet_worker_pool;
 };
 
 } // namespace starrocks

--- a/be/src/storage/vectorized/memtable.h
+++ b/be/src/storage/vectorized/memtable.h
@@ -34,7 +34,9 @@ public:
 
     // return true suggests caller should flush this memory table
     bool insert(const Chunk& chunk, const uint32_t* indexes, uint32_t from, uint32_t size);
+
     OLAPStatus flush();
+
     Status finalize();
 
     bool is_full() const;


### PR DESCRIPTION
Summary: reduce lock contentions in TabletsChannel

- Replace the mutex `_global_lock` in TabletsChannel with multiple ones, each
  one corresponding to a single sender to remove some lock contentions between
  different senders
- Using atomic flag to indicate whether the chunk meta has been created. 
   The atomic flag can make accessing chunk meta a lock-free operation, except for the first access.
- Replace DeltaWriter with AsyncDeltaWriter and remove the `_tablet_locks`, so
   there will be no lock contention between the senders writing to the same DeltaWriter

Benchmark:
On my distributed StarRocks cluster with 3 BE nodes deployed on different machines, I
compared the time and CPU usage to load 17 CSV files, with a total size of 1.2 GB, using
broker load with config max_broker_concurrency=32, and the results are listed below:

|             | Table Buckets  | Load Time | CPU    |
|------- |----------------|------------|------|
| Before | 512                    | 84s            |  333% |
| Before | 1024                 | 114s            | 310% |
| Before | 2048                | 155s            | 310% |
| After    | 512                   | 57s              | 650% |
| After    | 1024                 | 57s              | 970% |
| After    | 2048                 | 61s             | 1100% |

