### PR TITLE
Refactor FlushToken to take unique_ptr as argument and remove const_cast

### DIFF
--- a/be/src/storage/memtable_flush_executor.cpp
+++ b/be/src/storage/memtable_flush_executor.cpp
@@ -21,15 +21,33 @@
 
 #include "storage/memtable_flush_executor.h"
 
-#include <functional>
 #include <memory>
 
 #include "runtime/current_thread.h"
 #include "storage/vectorized/memtable.h"
-#include "util/defer_op.h"
-#include "util/scoped_cleanup.h"
 
 namespace starrocks {
+
+class MemtableFlushTask final : public Runnable {
+public:
+    MemtableFlushTask(FlushToken* flush_token, std::unique_ptr<vectorized::MemTable> memtable)
+            : _flush_token(flush_token), _memtable(std::move(memtable)) {}
+
+    ~MemtableFlushTask() = default;
+
+    void run() override {
+        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_memtable->mem_tracker());
+
+        _flush_token->_stats.cur_flush_count++;
+        _flush_token->_flush_memtable(_memtable.get());
+        _flush_token->_stats.cur_flush_count--;
+        _memtable.reset();
+    }
+
+private:
+    FlushToken* _flush_token;
+    std::unique_ptr<vectorized::MemTable> _memtable;
+};
 
 std::ostream& operator<<(std::ostream& os, const FlushStatistic& stat) {
     os << "(flush time(ms)=" << stat.flush_time_ns / 1000 / 1000 << ", flush count=" << stat.flush_count << ")"
@@ -37,20 +55,16 @@ std::ostream& operator<<(std::ostream& os, const FlushStatistic& stat) {
     return os;
 }
 
-Status FlushToken::submit(const std::shared_ptr<vectorized::MemTable>& memtable) {
+Status FlushToken::submit(std::unique_ptr<vectorized::MemTable> memtable) {
     if (_flush_status.load() != OLAP_SUCCESS) {
         std::stringstream ss;
         ss << "tablet_id = " << memtable->tablet_id() << " flush_status error ";
         return Status::InternalError(ss.str());
     }
-    _flush_token->submit_func([this, memtable] {
-        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(memtable->mem_tracker());
-        _stats.cur_flush_count++;
-        _flush_memtable(memtable);
-        const_cast<std::shared_ptr<vectorized::MemTable>&>(memtable).reset();
-        _stats.cur_flush_count--;
-    });
-    return Status::OK();
+    // Does not acount the size of MemtableFlushTask into any memory tracker
+    COPED_THREAD_LOCAL_MEM_TRACKER_SETTER(nullptr);
+    auto task = std::make_shared<MemtableFlushTask>(this, std::move(memtable));
+    return _flush_token->submit(std::move(task));
 }
 
 void FlushToken::cancel() {
@@ -62,9 +76,7 @@ OLAPStatus FlushToken::wait() {
     return _flush_status.load();
 }
 
-void FlushToken::_flush_memtable(std::shared_ptr<vectorized::MemTable> memtable) {
-    SCOPED_CLEANUP({ memtable.reset(); });
-
+void FlushToken::_flush_memtable(vectorized::MemTable* memtable) {
     // If previous flush has failed, return directly
     if (_flush_status.load() != OLAP_SUCCESS) {
         return;
@@ -83,20 +95,17 @@ void FlushToken::_flush_memtable(std::shared_ptr<vectorized::MemTable> memtable)
 }
 
 Status MemTableFlushExecutor::init(const std::vector<DataDir*>& data_dirs) {
-    int32_t data_dir_num = data_dirs.size();
-    size_t min_threads = std::max(1, config::flush_thread_num_per_store);
-    size_t max_threads = data_dir_num * min_threads;
+    int data_dir_num = static_cast<int>(data_dirs.size());
+    int min_threads = std::max<int>(1, config::flush_thread_num_per_store);
+    int max_threads = data_dir_num * min_threads;
     return ThreadPoolBuilder("MemTableFlushThreadPool")
             .set_min_threads(min_threads)
             .set_max_threads(max_threads)
             .build(&_flush_pool);
 }
 
-// NOTE: we use SERIAL mode here to ensure all mem-tables from one tablet are flushed in order.
-OLAPStatus MemTableFlushExecutor::create_flush_token(std::unique_ptr<FlushToken>* flush_token,
-                                                     ThreadPool::ExecutionMode execution_mode) {
-    *flush_token = std::make_unique<FlushToken>(_flush_pool->new_token(execution_mode));
-    return OLAP_SUCCESS;
+std::unique_ptr<FlushToken> MemTableFlushExecutor::create_flush_token(ThreadPool::ExecutionMode execution_mode) {
+    return std::make_unique<FlushToken>(_flush_pool->new_token(execution_mode));
 }
 
 } // namespace starrocks

--- a/be/src/storage/memtable_flush_executor.cpp
+++ b/be/src/storage/memtable_flush_executor.cpp
@@ -62,7 +62,7 @@ Status FlushToken::submit(std::unique_ptr<vectorized::MemTable> memtable) {
         return Status::InternalError(ss.str());
     }
     // Does not acount the size of MemtableFlushTask into any memory tracker
-    COPED_THREAD_LOCAL_MEM_TRACKER_SETTER(nullptr);
+    SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(nullptr);
     auto task = std::make_shared<MemtableFlushTask>(this, std::move(memtable));
     return _flush_token->submit(std::move(task));
 }

--- a/be/src/storage/memtable_flush_executor.h
+++ b/be/src/storage/memtable_flush_executor.h
@@ -60,7 +60,7 @@ public:
     explicit FlushToken(std::unique_ptr<ThreadPoolToken> flush_pool_token)
             : _flush_token(std::move(flush_pool_token)), _flush_status(OLAP_SUCCESS) {}
 
-    Status submit(const std::shared_ptr<vectorized::MemTable>& mem_table);
+    Status submit(std::unique_ptr<vectorized::MemTable> mem_table);
 
     // error has happpens, so we cancel this token
     // And remove all tasks in the queue.
@@ -73,7 +73,9 @@ public:
     const FlushStatistic& get_stats() const { return _stats; }
 
 private:
-    void _flush_memtable(std::shared_ptr<vectorized::MemTable> mem_table);
+    friend class MemtableFlushTask;
+
+    void _flush_memtable(vectorized::MemTable* mem_table);
 
     std::unique_ptr<ThreadPoolToken> _flush_token;
 
@@ -102,8 +104,9 @@ public:
     // because it needs path hash of each data dir.
     Status init(const std::vector<DataDir*>& data_dirs);
 
-    OLAPStatus create_flush_token(std::unique_ptr<FlushToken>* flush_token,
-                                  ThreadPool::ExecutionMode execution_mode = ThreadPool::ExecutionMode::SERIAL);
+    // NOTE: we use SERIAL mode here to ensure all mem-tables from one tablet are flushed in order.
+    std::unique_ptr<FlushToken> create_flush_token(
+            ThreadPool::ExecutionMode execution_mode = ThreadPool::ExecutionMode::SERIAL);
 
 private:
     std::unique_ptr<ThreadPool> _flush_pool;

--- a/be/src/storage/vectorized/delta_writer.h
+++ b/be/src/storage/vectorized/delta_writer.h
@@ -82,7 +82,7 @@ private:
     TabletSharedPtr _tablet;
     RowsetSharedPtr _cur_rowset;
     std::unique_ptr<RowsetWriter> _rowset_writer;
-    std::shared_ptr<MemTable> _mem_table;
+    std::unique_ptr<MemTable> _mem_table;
     const TabletSchema* _tablet_schema;
     bool _delta_written_success;
 

--- a/be/test/exec/tablet_sink_test.cpp
+++ b/be/test/exec/tablet_sink_test.cpp
@@ -277,8 +277,7 @@ public:
 
     void tablet_writer_add_batch(google::protobuf::RpcController* controller,
                                  const PTabletWriterAddBatchRequest* request, PTabletWriterAddBatchResult* response,
-                                 google::protobuf::Closure* done) override {
-    }
+                                 google::protobuf::Closure* done) override {}
     void tablet_writer_cancel(google::protobuf::RpcController* controller, const PTabletWriterCancelRequest* request,
                               PTabletWriterCancelResult* response, google::protobuf::Closure* done) override {
         done->Run();


### PR DESCRIPTION
Summary: remove the `const_cast` and pass memory table by unique_ptr instead of shared_ptr