### PR TITLE
add `any_value` function

### DIFF
--- a/be/src/exprs/agg/aggregate_factory.cpp
+++ b/be/src/exprs/agg/aggregate_factory.cpp
@@ -6,6 +6,7 @@
 #include <unordered_map>
 
 #include "column/type_traits.h"
+#include "exprs/agg/any_value.h"
 #include "exprs/agg/avg.h"
 #include "exprs/agg/bitmap_intersect.h"
 #include "exprs/agg/bitmap_union.h"
@@ -88,6 +89,12 @@ AggregateFunctionPtr AggregateFactory::MakeMaxAggregateFunction() {
 template <PrimitiveType PT>
 AggregateFunctionPtr AggregateFactory::MakeMinAggregateFunction() {
     return std::make_shared<MaxMinAggregateFunction<PT, MinAggregateData<PT>, MinElement<PT, MinAggregateData<PT>>>>();
+}
+
+template <PrimitiveType PT>
+AggregateFunctionPtr AggregateFactory::MakeAnyValueAggregateFunction() {
+    return std::make_shared<
+            AnyValueAggregateFunction<PT, AnyValueAggregateData<PT>, AnyValueElement<PT, AnyValueAggregateData<PT>>>>();
 }
 
 template <typename NestedState>
@@ -364,6 +371,9 @@ public:
             } else if (name == "group_concat") {
                 auto group_count = AggregateFactory::MakeGroupConcatAggregateFunction<ArgPT>();
                 return AggregateFactory::MakeNullableAggregateFunctionVariadic<GroupConcatAggregateState>(group_count);
+            } else if (name == "any_value") {
+                auto any_value = AggregateFactory::MakeAnyValueAggregateFunction<ArgPT>();
+                return AggregateFactory::MakeNullableAggregateFunctionUnary<AnyValueAggregateData<ArgPT>>(any_value);
             }
         } else {
             if (name == "count") {
@@ -396,6 +406,8 @@ public:
                 return AggregateFactory::MakeSumDistinctAggregateFunctionV2<ArgPT>();
             } else if (name == "group_concat") {
                 return AggregateFactory::MakeGroupConcatAggregateFunction<ArgPT>();
+            } else if (name == "any_value") {
+                return AggregateFactory::MakeAnyValueAggregateFunction<ArgPT>();
             }
         }
 
@@ -438,6 +450,9 @@ public:
             } else if (name == "group_concat") {
                 auto group_count = AggregateFactory::MakeGroupConcatAggregateFunction<ArgPT>();
                 return AggregateFactory::MakeNullableAggregateFunctionVariadic<GroupConcatAggregateState>(group_count);
+            } else if (name == "any_value") {
+                auto any_value = AggregateFactory::MakeAnyValueAggregateFunction<ArgPT>();
+                return AggregateFactory::MakeNullableAggregateFunctionUnary<AnyValueAggregateData<ArgPT>>(any_value);
             }
         } else {
             if (name == "avg") {
@@ -452,6 +467,8 @@ public:
                 return AggregateFactory::MakeCountDistinctAggregateFunctionV2<ArgPT>();
             } else if (name == "group_concat") {
                 return AggregateFactory::MakeGroupConcatAggregateFunction<ArgPT>();
+            } else if (name == "any_value") {
+                return AggregateFactory::MakeAnyValueAggregateFunction<ArgPT>();
             }
         }
 
@@ -516,6 +533,7 @@ AggregateFuncResolver::AggregateFuncResolver() {
 
     ADD_ALL_TYPE("max");
     ADD_ALL_TYPE("min");
+    ADD_ALL_TYPE("any_value");
 
     add_aggregate_mapping<TYPE_BOOLEAN, TYPE_BIGINT>("multi_distinct_count");
     add_aggregate_mapping<TYPE_TINYINT, TYPE_BIGINT>("multi_distinct_count");

--- a/be/src/exprs/agg/aggregate_factory.h
+++ b/be/src/exprs/agg/aggregate_factory.h
@@ -44,6 +44,9 @@ public:
     template <PrimitiveType PT>
     static AggregateFunctionPtr MakeMinAggregateFunction();
 
+    template <PrimitiveType PT>
+    static AggregateFunctionPtr MakeAnyValueAggregateFunction();
+
     template <typename NestedState>
     static AggregateFunctionPtr MakeNullableAggregateFunctionUnary(AggregateFunctionPtr nested_function);
 

--- a/be/src/exprs/agg/any_value.h
+++ b/be/src/exprs/agg/any_value.h
@@ -1,0 +1,234 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#pragma once
+
+#include <limits>
+#include <type_traits>
+
+#include "column/fixed_length_column.h"
+#include "column/type_traits.h"
+#include "exprs/agg/aggregate.h"
+#include "gutil/casts.h"
+#include "util/raw_container.h"
+
+namespace starrocks::vectorized {
+
+template <PrimitiveType PT, typename = guard::Guard>
+struct AnyValueAggregateData {};
+
+template <PrimitiveType PT>
+struct AnyValueAggregateData<PT, IntegralPTGuard<PT>> {
+    using T = RunTimeCppType<PT>;
+    T result = std::numeric_limits<T>::max();
+    bool has_value = false;
+
+    void reset() {
+        result = std::numeric_limits<T>::max();
+        has_value = false;
+    }
+};
+
+template <PrimitiveType PT>
+struct AnyValueAggregateData<PT, FloatPTGuard<PT>> {
+    using T = RunTimeCppType<PT>;
+    T result = std::numeric_limits<T>::max();
+    bool has_value = false;
+
+    void reset() {
+        result = std::numeric_limits<T>::max();
+        has_value = false;
+    }
+};
+
+template <>
+struct AnyValueAggregateData<TYPE_DECIMALV2, guard::Guard> {
+    bool has_value = false;
+    DecimalV2Value result = DecimalV2Value::get_max_decimal();
+
+    void reset() {
+        result = DecimalV2Value::get_max_decimal();
+        has_value = false;
+    }
+};
+
+template <PrimitiveType PT>
+struct AnyValueAggregateData<PT, DecimalPTGuard<PT>> {
+    bool has_value = false;
+    using T = RunTimeCppType<PT>;
+    T result = get_max_decimal<T>();
+    void reset() {
+        result = get_max_decimal<T>();
+        has_value = false;
+    }
+};
+
+template <>
+struct AnyValueAggregateData<TYPE_DATETIME, guard::Guard> {
+    bool has_value = false;
+    TimestampValue result = TimestampValue::MAX_TIMESTAMP_VALUE;
+
+    void reset() {
+        result = TimestampValue::MAX_TIMESTAMP_VALUE;
+        has_value = false;
+    }
+};
+
+template <>
+struct AnyValueAggregateData<TYPE_DATE, guard::Guard> {
+    bool has_value = false;
+    DateValue result = DateValue::MAX_DATE_VALUE;
+
+    void reset() {
+        result = DateValue::MAX_DATE_VALUE;
+        has_value = false;
+    }
+};
+
+template <PrimitiveType PT>
+struct AnyValueAggregateData<PT, BinaryPTGuard<PT>> {
+    int32_t size = -1;
+    Buffer<uint8_t> buffer;
+
+    bool has_value() const { return size > -1; }
+
+    Slice slice() const { return {buffer.data(), buffer.size()}; }
+
+    void reset() {
+        buffer.clear();
+        size = -1;
+    }
+};
+
+template <PrimitiveType PT, typename State, typename = guard::Guard>
+struct AnyValueElement {
+    using T = RunTimeCppType<PT>;
+    void operator()(State& state, const T& right) const {
+        if (UNLIKELY(!state.has_value)) {
+            state.result = right;
+            state.has_value = true;
+        }
+    }
+};
+
+template <PrimitiveType PT>
+struct AnyValueElement<PT, AnyValueAggregateData<PT>, BinaryPTGuard<PT>> {
+    void operator()(AnyValueAggregateData<PT>& state, const Slice& right) const {
+        if (UNLIKELY(!state.has_value())) {
+            state.buffer.resize(right.size);
+            memcpy(state.buffer.data(), right.data, right.size);
+            state.size = right.size;
+        }
+    }
+};
+
+template <PrimitiveType PT, typename State, class OP, typename T = RunTimeCppType<PT>, typename = guard::Guard>
+class AnyValueAggregateFunction final
+        : public AggregateFunctionBatchHelper<State, AnyValueAggregateFunction<PT, State, OP, T>> {
+public:
+    using InputColumnType = RunTimeColumnType<PT>;
+
+    void reset(FunctionContext* ctx, const Columns& args, AggDataPtr state) const override {
+        this->data(state).reset();
+    }
+
+    void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
+                size_t row_num) const override {
+        DCHECK(!columns[0]->is_nullable() && !columns[0]->is_binary());
+        const auto& column = down_cast<const InputColumnType&>(*columns[0]);
+        const T& value = column.get_data()[row_num];
+        OP()(this->data(state), value);
+    }
+
+    void update_batch_single_state(FunctionContext* ctx, size_t batch_size, const Column** columns,
+                                   AggDataPtr __restrict state) const override {
+        update(ctx, columns, state, 0);
+    }
+
+    void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
+        DCHECK(!column->is_nullable() && !column->is_binary());
+        const auto* input_column = down_cast<const InputColumnType*>(column);
+        T value = input_column->get_data()[row_num];
+        OP()(this->data(state), value);
+    }
+
+    void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
+        DCHECK(!to->is_nullable() && !to->is_binary());
+        down_cast<InputColumnType*>(to)->append(this->data(state).result);
+    }
+
+    void convert_to_serialize_format(const Columns& src, size_t chunk_size, ColumnPtr* dst) const override {
+        *dst = src[0];
+    }
+
+    void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
+        DCHECK(!to->is_nullable() && !to->is_binary());
+        down_cast<InputColumnType*>(to)->append(this->data(state).result);
+    }
+
+    void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,
+                    size_t end) const override {
+        DCHECK_GT(end, start);
+        InputColumnType* column = down_cast<InputColumnType*>(dst);
+        for (size_t i = start; i < end; ++i) {
+            column->get_data()[i] = this->data(state).result;
+        }
+    }
+
+    std::string get_name() const override { return "any_value"; }
+};
+
+template <PrimitiveType PT, typename State, class OP>
+class AnyValueAggregateFunction<PT, State, OP, RunTimeCppType<PT>, BinaryPTGuard<PT>> final
+        : public AggregateFunctionBatchHelper<State, AnyValueAggregateFunction<PT, State, OP, RunTimeCppType<PT>>> {
+public:
+    void reset(FunctionContext* ctx, const Columns& args, AggDataPtr __restrict state) const override {
+        this->data(state).reset();
+    }
+
+    void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
+                size_t row_num) const override {
+        DCHECK((*columns[0]).is_binary());
+        Slice value = columns[0]->get(row_num).get_slice();
+        OP()(this->data(state), value);
+    }
+
+    void update_batch_single_state(FunctionContext* ctx, size_t batch_size, const Column** columns,
+                                   AggDataPtr __restrict state) const override {
+        update(ctx, columns, state, 0);
+    }
+
+    void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
+        DCHECK(column->is_binary());
+        Slice value = column->get(row_num).get_slice();
+        OP()(this->data(state), value);
+    }
+
+    void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
+        DCHECK(to->is_binary());
+        BinaryColumn* column = down_cast<BinaryColumn*>(to);
+        column->append(this->data(state).slice());
+    }
+
+    void convert_to_serialize_format(const Columns& src, size_t chunk_size, ColumnPtr* dst) const override {
+        *dst = src[0];
+    }
+
+    void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
+        DCHECK(to->is_binary());
+        BinaryColumn* column = down_cast<BinaryColumn*>(to);
+        column->append(this->data(state).slice());
+    }
+
+    void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,
+                    size_t end) const override {
+        DCHECK_GT(end, start);
+        BinaryColumn* column = down_cast<BinaryColumn*>(dst);
+        for (size_t i = start; i < end; ++i) {
+            column->append(this->data(state).slice());
+        }
+    }
+
+    std::string get_name() const override { return "any_value"; }
+};
+
+} // namespace starrocks::vectorized

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/BuiltinAggregateFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/BuiltinAggregateFunction.java
@@ -100,6 +100,7 @@ public class BuiltinAggregateFunction extends Function {
     // We should move this to something in the catalog instead of having it
     // here like this.
     public enum Operator {
+        ANY_VALUE("ANY_VALUE", TAggregationOp.ANY_VALUE, null),
         COUNT("COUNT", TAggregationOp.COUNT, Type.BIGINT),
         MIN("MIN", TAggregationOp.MIN, null),
         MAX("MAX", TAggregationOp.MAX, null),

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/FunctionCallExpr.java
@@ -592,7 +592,8 @@ public class FunctionCallExpr extends Expr {
             new ImmutableSortedSet.Builder<>(String.CASE_INSENSITIVE_ORDER)
                     .add(FunctionSet.MAX).add(FunctionSet.MIN)
                     .add(FunctionSet.LEAD).add(FunctionSet.LAG)
-                    .add(FunctionSet.FIRST_VALUE).add(FunctionSet.LAST_VALUE).build();
+                    .add(FunctionSet.FIRST_VALUE).add(FunctionSet.LAST_VALUE)
+                    .add(FunctionSet.ANY_VALUE).build();
 
     private static final Set<String> DECIMAL_AGG_FUNCTION_WIDER_TYPE =
             new ImmutableSortedSet.Builder<>(String.CASE_INSENSITIVE_ORDER)

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -73,6 +73,7 @@ public class FunctionSet {
     public static final String MULTI_DISTINCT_COUNT = "multi_distinct_count";
     public static final String MULTI_DISTINCT_SUM = "multi_distinct_sum";
     public static final String DICT_MERGE = "dict_merge";
+    public static final String ANY_VALUE = "any_value";
 
     // Window functions:
     public static final String LEAD = "lead";
@@ -436,6 +437,10 @@ public class FunctionSet {
             addBuiltin(AggregateFunction.createBuiltin("ndv",
                     Lists.newArrayList(t), Type.BIGINT, Type.VARCHAR,
                     true, false, true));
+
+            // ANY_VALUE
+            addBuiltin(AggregateFunction.createBuiltin("any_value",
+                    Lists.newArrayList(t), t, t, true, false, false));
 
             //APPROX_COUNT_DISTINCT
             //alias of ndv, compute approx count distinct use HyperLogLog

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -409,6 +409,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = ENABLE_COLUMN_EXPR_PREDICATE)
     private boolean enableColumnExprPredicate = false;
 
+    @VariableMgr.VarAttr(name = "ONLY_FULL_GROUP_BY", flag = VariableMgr.INVISIBLE)
+    @Deprecated
+    private boolean onlyFullGroupBy = true;
+
     // The following variables are deprecated and invisible //
     // ----------------------------------------------------------------------------//
 
@@ -550,6 +554,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean getEnableInsertStrict() {
         return enableInsertStrict;
+    }
+
+    public boolean getOnlyFullGroupBy() {
+        return onlyFullGroupBy;
+    }
+
+    public void disableOnlyFullGroupBy() {
+        this.onlyFullGroupBy = false;
     }
 
     public void setEnableInsertStrict(boolean enableInsertStrict) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DecimalV3FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DecimalV3FunctionAnalyzer.java
@@ -27,7 +27,8 @@ public class DecimalV3FunctionAnalyzer {
             new ImmutableSortedSet.Builder<>(String.CASE_INSENSITIVE_ORDER)
                     .add(FunctionSet.MAX).add(FunctionSet.MIN)
                     .add(FunctionSet.LEAD).add(FunctionSet.LAG)
-                    .add(FunctionSet.FIRST_VALUE).add(FunctionSet.LAST_VALUE).build();
+                    .add(FunctionSet.FIRST_VALUE).add(FunctionSet.LAST_VALUE)
+                    .add(FunctionSet.ANY_VALUE).build();
 
     public static final Set<String> DECIMAL_AGG_FUNCTION_WIDER_TYPE =
             new ImmutableSortedSet.Builder<>(String.CASE_INSENSITIVE_ORDER)

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -11,6 +11,7 @@ import com.starrocks.analysis.StringLiteral;
 import com.starrocks.catalog.AggregateFunction;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.Type;
+import com.starrocks.qe.ConnectContext;
 
 public class FunctionAnalyzer {
 
@@ -24,6 +25,11 @@ public class FunctionAnalyzer {
         }
 
         FunctionName fnName = functionCallExpr.getFnName();
+        if (fnName.getFunction().equalsIgnoreCase("any_value")
+                && ConnectContext.get().getSessionVariable().getOnlyFullGroupBy()) {
+            throw new SemanticException("Function `any_value` is not supported when ONLY_FULL_GROUP_BY is enable.");
+        }
+
         if (fnName.getFunction().equalsIgnoreCase("date_trunc")) {
             if (!(functionCallExpr.getChild(0) instanceof StringLiteral)) {
                 throw new SemanticException("date_trunc requires first parameter must be a string constant");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MergeTwoAggRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MergeTwoAggRule.java
@@ -37,7 +37,7 @@ import java.util.Map;
 public class MergeTwoAggRule extends TransformationRule {
     private static final List<String> ALLOW_MERGE_AGGREGATE_FUNCTIONS = Lists.newArrayList(FunctionSet.SUM,
             FunctionSet.MAX, FunctionSet.MIN, FunctionSet.BITMAP_UNION, FunctionSet.HLL_UNION,
-            FunctionSet.PERCENTILE_UNION);
+            FunctionSet.PERCENTILE_UNION, FunctionSet.ANY_VALUE);
 
     public MergeTwoAggRule() {
         super(RuleType.TF_MERGE_TWO_AGG_RULE, Pattern.create(OperatorType.LOGICAL_AGGR).addChildren(
@@ -83,7 +83,8 @@ public class MergeTwoAggRule extends TransformationRule {
             if (!aggCallMapBelow.containsKey(ref)) {
                 // max/min on grouping column is equals with direct aggregate on column
                 if (!FunctionSet.MAX.equalsIgnoreCase(call.getFnName()) &&
-                        !FunctionSet.MIN.equalsIgnoreCase(call.getFnName())) {
+                        !FunctionSet.MIN.equalsIgnoreCase(call.getFnName()) &&
+                        !FunctionSet.ANY_VALUE.equalsIgnoreCase(call.getFnName())) {
                     return false;
                 }
             } else {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -169,6 +169,9 @@ public class ExpressionStatisticCalculator {
                 case FunctionSet.MIN:
                     value = columnStatistic.getMinValue();
                     return new ColumnStatistic(value, value, 0, callOperator.getType().getSlotSize(), 1);
+                case FunctionSet.ANY_VALUE:
+                    value = (columnStatistic.getMaxValue() - columnStatistic.getMinValue()) / 2;
+                    return new ColumnStatistic(value, value, 0, callOperator.getType().getSlotSize(), 1);
                 case FunctionSet.YEAR:
                     int minValue = 1700;
                     int maxValue = 2100;

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
@@ -23,6 +23,7 @@ package com.starrocks.analysis;
 
 import com.starrocks.common.AnalysisException;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.AfterClass;
@@ -382,5 +383,22 @@ public class SelectStmtTest {
         String selectStmtStr2 =
                 "SELECT db1.tbl1.k1 FROM db1.tbl1 GROUP BY db1.tbl1 HAVING ((MAX(TIMEDIFF(NULL, NULL))) IS NULL)";
         UtFrameUtils.parseAndAnalyzeStmt(selectStmtStr2, ctx);
+    }
+
+    @Test
+    public void testAnyValueFunctions() throws Exception {
+        ConnectContext ctx = UtFrameUtils.createDefaultCtx();
+        String selectStmtStr =
+                "SELECT db1.tbl1.k1, any_value(db1.tbl1.k2) FROM db1.tbl1 GROUP BY db1.tbl1.k1";
+        try {
+            UtFrameUtils.parseAndAnalyzeStmt(selectStmtStr, ctx);
+        } catch (SemanticException e) {
+            Assert.assertTrue(e.getMessage().contains(
+                    "Function `any_value` is not supported when ONLY_FULL_GROUP_BY is enable."));
+        }
+        ctx.getSessionVariable().disableOnlyFullGroupBy();
+        selectStmtStr =
+                "SELECT db1.tbl1.k1, any_value(db1.tbl1.k2) FROM db1.tbl1 GROUP BY db1.tbl1.k1";
+        UtFrameUtils.parseAndAnalyzeStmt(selectStmtStr, ctx);
     }
 }

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -426,6 +426,7 @@ enum TAggregationOp {
   LAG,
   HLL_C,
   BITMAP_UNION,
+  ANY_VALUE
 }
 
 //struct TAggregateFunctionCall {


### PR DESCRIPTION
Issue: [Add a new ANY_VALUE function](https://github.com/StarRocks/starrocks/issues/1938)

`ANY_VALUE` will fail at analyze phase when FULL_GROUP_BY is set to true (default).

Besides, `ANY_VALUE` will choose the first value as the result for performance consideration.