### PR TITLE
Fix miss compute nullable properties when build decode node

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -416,6 +416,8 @@ public class PlanFragmentBuilder {
                 Preconditions.checkState(context.getColRefToExpr().containsKey(entry.getKey()));
             }
 
+            tupleDescriptor.computeMemLayout();
+
             DecodeNode decodeNode = new DecodeNode(context.getPlanCtx().getNextNodeId(),
                     tupleDescriptor,
                     inputFragment.getPlanRoot(),


### PR DESCRIPTION
when we call `new SlotDescriptor`, nullIndicatorBit will be init with
value 0, but when we call `toThrift()`,slot will always nullable because
nullIndicatorBit was not -1,set nullable will be ignored.So we need call
computeMemLayout after set nullable properties


will close #2078