### PR TITLE
[compile] remove unwind dependency in glog

### DIFF
--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -314,7 +314,7 @@ build_rapidjson() {
     cp -r $TP_SOURCE_DIR/$RAPIDJSON_SOURCE/include/rapidjson $TP_INCLUDE_DIR/
 }
 
-# rapidjson
+# simdjson
 build_simdjson() {
     check_if_source_exist $SIMDJSON_SOURCE
     cd $TP_SOURCE_DIR/$SIMDJSON_SOURCE

--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -239,6 +239,7 @@ if [ ! -f $PATCHED_MARK ] && [ $GLOG_SOURCE == "glog-0.3.3" ]; then
 fi
 if [ ! -f $PATCHED_MARK ] && [ $GLOG_SOURCE == "glog-0.4.0" ]; then
     patch -p1 < $TP_PATCH_DIR/glog-0.4.0-for-starrocks2.patch
+    patch -p1 < $TP_PATCH_DIR/glog-0.4.0-remove-unwind-dependency.patch 
     touch $PATCHED_MARK
 fi
 cd -

--- a/thirdparty/patches/glog-0.4.0-remove-unwind-dependency.patch
+++ b/thirdparty/patches/glog-0.4.0-remove-unwind-dependency.patch
@@ -1,0 +1,13 @@
+diff --git a/configure.ac b/configure.ac
+index 02c118c..ab7734f 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -38,7 +38,7 @@ AC_CHECK_HEADERS(sys/syscall.h)
+ # For backtrace with glibc.
+ AC_CHECK_HEADERS(execinfo.h)
+ # For backtrace with libunwind.
+-AC_CHECK_HEADERS(libunwind.h, ac_cv_have_libunwind_h=1, ac_cv_have_libunwind_h=0)
++#AC_CHECK_HEADERS(libunwind.h, ac_cv_have_libunwind_h=1, ac_cv_have_libunwind_h=0)
+ AC_CHECK_HEADERS(ucontext.h)
+ AC_CHECK_HEADERS(sys/utsname.h)
+ AC_CHECK_HEADERS(pwd.h)


### PR DESCRIPTION
glog is automatically looking for libunwind dependencies via configure, 
so if a machine installs libunwind under /usr/lib via yum, it will cause a compilation error