### PR TITLE
check before alloc when try catch std::bad_alloc

### DIFF
--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -333,4 +333,11 @@ inline std::ostream& operator<<(std::ostream& os, const Status& st) {
         }                                 \
     } while (0)
 
+#define RETURN_IF_UNLIKELY(cond, ret) \
+    do {                              \
+        if (UNLIKELY(cond)) {         \
+            return ret;               \
+        }                             \
+    } while (0)
+
 #define WARN_UNUSED_RESULT __attribute__((warn_unused_result))

--- a/be/src/exec/parquet/column_chunk_reader.cpp
+++ b/be/src/exec/parquet/column_chunk_reader.cpp
@@ -12,6 +12,7 @@
 #include "exec/parquet/types.h"
 #include "exec/parquet/utils.h"
 #include "gutil/strings/substitute.h"
+#include "runtime/current_thread.h"
 #include "util/runtime_profile.h"
 
 namespace starrocks::parquet {
@@ -141,6 +142,7 @@ void ColumnChunkReader::_reserve_uncompress_buf(size_t size) {
 
 Status ColumnChunkReader::_read_and_decompress_page_data(uint32_t compressed_size, uint32_t uncompressed_size,
                                                          bool is_compressed) {
+    RETURN_IF_ERROR(tls_thread_status.mem_tracker()->check_mem_limit("read and decompress page"));
     if (is_compressed && _compress_codec != nullptr) {
         Slice com_slice("", compressed_size);
         RETURN_IF_ERROR(_page_reader->read_bytes((const uint8_t**)&com_slice.data, com_slice.size));

--- a/be/src/exec/vectorized/analytic_node.cpp
+++ b/be/src/exec/vectorized/analytic_node.cpp
@@ -17,6 +17,7 @@
 #include "exprs/expr.h"
 #include "exprs/expr_context.h"
 #include "gutil/strings/substitute.h"
+#include "runtime/current_thread.h"
 #include "runtime/runtime_state.h"
 #include "udf/udf.h"
 #include "util/runtime_profile.h"
@@ -311,34 +312,30 @@ Status AnalyticNode::_fetch_next_chunk(RuntimeState* state) {
     size_t chunk_size = child_chunk->num_rows();
     _analytor->update_input_rows(chunk_size);
 
-    try {
-        for (size_t i = 0; i < _analytor->agg_fn_ctxs().size(); i++) {
-            for (size_t j = 0; j < _analytor->agg_expr_ctxs()[i].size(); j++) {
-                ColumnPtr column = _analytor->agg_expr_ctxs()[i][j]->evaluate(child_chunk.get());
-                // Currently, only lead and lag window function have multi args.
-                // For performance, we do this special handle.
-                // In future, if need, we could remove this if else easily.
-                if (j == 0) {
-                    _analytor->append_column(chunk_size, _analytor->agg_intput_columns()[i][j].get(), column);
-                } else {
-                    _analytor->agg_intput_columns()[i][j]->append(*column, 0, column->size());
+    TRY_CATCH_BAD_ALLOC(
+            for (size_t i = 0; i < _analytor->agg_fn_ctxs().size(); i++) {
+                for (size_t j = 0; j < _analytor->agg_expr_ctxs()[i].size(); j++) {
+                    ColumnPtr column = _analytor->agg_expr_ctxs()[i][j]->evaluate(child_chunk.get());
+                    // Currently, only lead and lag window function have multi args.
+                    // For performance, we do this special handle.
+                    // In future, if need, we could remove this if else easily.
+                    if (j == 0) {
+                        _analytor->append_column(chunk_size, _analytor->agg_intput_columns()[i][j].get(), column);
+                    } else {
+                        _analytor->agg_intput_columns()[i][j]->append(*column, 0, column->size());
+                    }
                 }
             }
-        }
 
-        for (size_t i = 0; i < _analytor->partition_ctxs().size(); i++) {
-            ColumnPtr column = _analytor->partition_ctxs()[i]->evaluate(child_chunk.get());
-            _analytor->append_column(chunk_size, _analytor->partition_columns()[i].get(), column);
-        }
+            for (size_t i = 0; i < _analytor->partition_ctxs().size(); i++) {
+                ColumnPtr column = _analytor->partition_ctxs()[i]->evaluate(child_chunk.get());
+                _analytor->append_column(chunk_size, _analytor->partition_columns()[i].get(), column);
+            }
 
-        for (size_t i = 0; i < _analytor->order_ctxs().size(); i++) {
-            ColumnPtr column = _analytor->order_ctxs()[i]->evaluate(child_chunk.get());
-            _analytor->append_column(chunk_size, _analytor->order_columns()[i].get(), column);
-        }
-        RETURN_IF_ERROR(state->check_mem_limit("AnalyticNode"));
-    } catch (std::bad_alloc const&) {
-        return Status::MemoryLimitExceeded("Mem usage has exceed the limit of BE");
-    }
+            for (size_t i = 0; i < _analytor->order_ctxs().size(); i++) {
+                ColumnPtr column = _analytor->order_ctxs()[i]->evaluate(child_chunk.get());
+                _analytor->append_column(chunk_size, _analytor->order_columns()[i].get(), column);
+            });
 
     _analytor->input_chunks().emplace_back(std::move(child_chunk));
     return Status::OK();

--- a/be/src/exec/vectorized/analytic_node.cpp
+++ b/be/src/exec/vectorized/analytic_node.cpp
@@ -312,30 +312,30 @@ Status AnalyticNode::_fetch_next_chunk(RuntimeState* state) {
     size_t chunk_size = child_chunk->num_rows();
     _analytor->update_input_rows(chunk_size);
 
-    TRY_CATCH_BAD_ALLOC(
-            for (size_t i = 0; i < _analytor->agg_fn_ctxs().size(); i++) {
-                for (size_t j = 0; j < _analytor->agg_expr_ctxs()[i].size(); j++) {
-                    ColumnPtr column = _analytor->agg_expr_ctxs()[i][j]->evaluate(child_chunk.get());
-                    // Currently, only lead and lag window function have multi args.
-                    // For performance, we do this special handle.
-                    // In future, if need, we could remove this if else easily.
-                    if (j == 0) {
-                        _analytor->append_column(chunk_size, _analytor->agg_intput_columns()[i][j].get(), column);
-                    } else {
-                        _analytor->agg_intput_columns()[i][j]->append(*column, 0, column->size());
-                    }
-                }
+    for (size_t i = 0; i < _analytor->agg_fn_ctxs().size(); i++) {
+        for (size_t j = 0; j < _analytor->agg_expr_ctxs()[i].size(); j++) {
+            ColumnPtr column = _analytor->agg_expr_ctxs()[i][j]->evaluate(child_chunk.get());
+            // Currently, only lead and lag window function have multi args.
+            // For performance, we do this special handle.
+            // In future, if need, we could remove this if else easily.
+            if (j == 0) {
+                TRY_CATCH_BAD_ALLOC(
+                        _analytor->append_column(chunk_size, _analytor->agg_intput_columns()[i][j].get(), column));
+            } else {
+                TRY_CATCH_BAD_ALLOC(_analytor->agg_intput_columns()[i][j]->append(*column, 0, column->size()));
             }
+        }
+    }
 
-            for (size_t i = 0; i < _analytor->partition_ctxs().size(); i++) {
-                ColumnPtr column = _analytor->partition_ctxs()[i]->evaluate(child_chunk.get());
-                _analytor->append_column(chunk_size, _analytor->partition_columns()[i].get(), column);
-            }
+    for (size_t i = 0; i < _analytor->partition_ctxs().size(); i++) {
+        ColumnPtr column = _analytor->partition_ctxs()[i]->evaluate(child_chunk.get());
+        TRY_CATCH_BAD_ALLOC(_analytor->append_column(chunk_size, _analytor->partition_columns()[i].get(), column));
+    }
 
-            for (size_t i = 0; i < _analytor->order_ctxs().size(); i++) {
-                ColumnPtr column = _analytor->order_ctxs()[i]->evaluate(child_chunk.get());
-                _analytor->append_column(chunk_size, _analytor->order_columns()[i].get(), column);
-            });
+    for (size_t i = 0; i < _analytor->order_ctxs().size(); i++) {
+        ColumnPtr column = _analytor->order_ctxs()[i]->evaluate(child_chunk.get());
+        TRY_CATCH_BAD_ALLOC(_analytor->append_column(chunk_size, _analytor->order_columns()[i].get(), column));
+    }
 
     _analytor->input_chunks().emplace_back(std::move(child_chunk));
     return Status::OK();

--- a/be/src/exec/vectorized/chunks_sorter_topn.cpp
+++ b/be/src/exec/vectorized/chunks_sorter_topn.cpp
@@ -178,11 +178,7 @@ Status ChunksSorterTopn::_build_sorting_data(RuntimeState* state, Permutation& p
     // this time, because we will filter chunks before initialize permutations, so we just check memory usage.
     if (!_init_merged_segment) {
         // this time, Just initialized permutations.second.
-        try {
-            permutation_second.resize(row_count);
-        } catch (std::bad_alloc const&) {
-            return Status::MemoryLimitExceeded("Mem usage has exceed the limit of BE");
-        }
+        permutation_second.resize(row_count);
 
         uint32_t perm_index = 0;
         for (uint32_t i = 0; i < segments.size(); ++i) {

--- a/be/src/exec/vectorized/cross_join_node.cpp
+++ b/be/src/exec/vectorized/cross_join_node.cpp
@@ -10,6 +10,7 @@
 #include "exec/pipeline/operator.h"
 #include "exec/pipeline/pipeline_builder.h"
 #include "exprs/expr_context.h"
+#include "runtime/current_thread.h"
 #include "runtime/runtime_state.h"
 
 namespace starrocks::vectorized {
@@ -477,15 +478,7 @@ Status CrossJoinNode::_build(RuntimeState* state) {
                 // merge chunks from child(1) (the right table) into a big chunk, which can reduce
                 // the complexity and time of cross-join chunks from left table with small chunks
                 // from right table.
-                size_t col_number = chunk->num_columns();
-                try {
-                    for (size_t col = 0; col < col_number; ++col) {
-                        _build_chunk->get_column_by_index(col)->append(*(chunk->get_column_by_index(col).get()), 0,
-                                                                       row_number);
-                    }
-                } catch (std::bad_alloc const&) {
-                    return Status::MemoryLimitExceeded("Mem usage has exceed the limit of BE");
-                }
+                TRY_CATCH_BAD_ALLOC(_build_chunk->append(*chunk));
             }
         }
     }

--- a/be/src/exec/vectorized/hash_join_node.cpp
+++ b/be/src/exec/vectorized/hash_join_node.cpp
@@ -20,6 +20,7 @@
 #include "exprs/vectorized/in_const_predicate.hpp"
 #include "exprs/vectorized/runtime_filter_bank.h"
 #include "gutil/strings/substitute.h"
+#include "runtime/current_thread.h"
 #include "runtime/runtime_filter_worker.h"
 #include "simd/simd.h"
 #include "util/runtime_profile.h"
@@ -181,23 +182,13 @@ Status HashJoinNode::open(RuntimeState* state) {
         {
             // copy chunk of right table
             SCOPED_TIMER(_copy_right_table_chunk_timer);
-            try {
-                RETURN_IF_ERROR(_ht.append_chunk(state, chunk));
-                RETURN_IF_ERROR(state->check_mem_limit("HashJoinNode"));
-            } catch (std::bad_alloc const&) {
-                return Status::MemoryLimitExceeded("Mem usage has exceed the limit of BE");
-            }
+            TRY_CATCH_BAD_ALLOC(RETURN_IF_ERROR(_ht.append_chunk(state, chunk)));
         }
     }
 
     {
-        try {
-            // build hash table: compute key columns, and then build the hash table.
-            RETURN_IF_ERROR(_build(state));
-            RETURN_IF_ERROR(state->check_mem_limit("HashJoinNode"));
-        } catch (std::bad_alloc const&) {
-            return Status::MemoryLimitExceeded("Mem usage has exceed the limit of BE");
-        }
+        // build hash table: compute key columns, and then build the hash table.
+        TRY_CATCH_BAD_ALLOC(RETURN_IF_ERROR(_build(state)));
         COUNTER_SET(_build_rows_counter, static_cast<int64_t>(_ht.get_row_count()));
         COUNTER_SET(_build_buckets_counter, static_cast<int64_t>(_ht.get_bucket_size()));
     }

--- a/be/src/exec/vectorized/topn_node.cpp
+++ b/be/src/exec/vectorized/topn_node.cpp
@@ -14,6 +14,7 @@
 #include "exec/vectorized/chunks_sorter_full_sort.h"
 #include "exec/vectorized/chunks_sorter_topn.h"
 #include "gutil/casts.h"
+#include "runtime/current_thread.h"
 
 namespace starrocks::vectorized {
 
@@ -160,20 +161,11 @@ Status TopNNode::_consume_chunks(RuntimeState* state, ExecNode* child) {
         if (chunk != nullptr && chunk->num_rows() > 0) {
             ChunkPtr materialize_chunk = ChunksSorter::materialize_chunk_before_sort(
                     chunk.get(), _materialized_tuple_desc, _sort_exec_exprs, _order_by_types);
-            try {
-                RETURN_IF_ERROR(_chunks_sorter->update(state, materialize_chunk));
-                RETURN_IF_ERROR(state->check_mem_limit("Sort"));
-            } catch (std::bad_alloc const&) {
-                return Status::MemoryLimitExceeded("Mem usage has exceed the limit of BE");
-            }
+            TRY_CATCH_BAD_ALLOC(RETURN_IF_ERROR(_chunks_sorter->update(state, materialize_chunk)));
         }
     } while (!eos);
-    try {
-        RETURN_IF_ERROR(_chunks_sorter->done(state));
-        RETURN_IF_ERROR(state->check_mem_limit("Sort"));
-    } catch (std::bad_alloc const&) {
-        return Status::MemoryLimitExceeded("Mem usage has exceed the limit of BE");
-    }
+
+    TRY_CATCH_BAD_ALLOC(RETURN_IF_ERROR(_chunks_sorter->done(state)));
     return Status::OK();
 }
 

--- a/be/src/runtime/mem_tracker.cpp
+++ b/be/src/runtime/mem_tracker.cpp
@@ -209,10 +209,14 @@ Status MemTracker::check_mem_limit(const std::string& msg) const {
         return Status::OK();
     }
 
+    return Status::MemoryLimitExceeded(tracker->err_msg(msg));
+}
+
+std::string MemTracker::err_msg(const std::string& msg) const {
     std::stringstream str;
     str << "Memory exceed limit. " << msg << " ";
-    str << "Used: " << tracker->consumption() << ", Limit: " << tracker->limit() << ". ";
-    switch (tracker->type()) {
+    str << "Used: " << consumption() << ", Limit: " << limit() << ". ";
+    switch (type()) {
     case MemTracker::NO_SET:
         break;
     case MemTracker::QUERY:
@@ -234,7 +238,7 @@ Status MemTracker::check_mem_limit(const std::string& msg) const {
     default:
         break;
     }
-    return Status::MemoryLimitExceeded(str.str());
+    return str.str();
 }
 
 } // end namespace starrocks

--- a/be/src/runtime/mem_tracker.h
+++ b/be/src/runtime/mem_tracker.h
@@ -155,8 +155,8 @@ public:
     /// are updated.
     /// Returns true if the try succeeded.
     WARN_UNUSED_RESULT
-    bool try_consume(int64_t bytes) {
-        if (UNLIKELY(bytes <= 0)) return true;
+    MemTracker* try_consume(int64_t bytes) {
+        if (UNLIKELY(bytes <= 0)) return nullptr;
         int64_t i;
         // Walk the tracker tree top-down.
         for (i = _all_trackers.size() - 1; i >= 0; --i) {
@@ -172,13 +172,13 @@ public:
                     for (int64_t j = _all_trackers.size() - 1; j > i; --j) {
                         _all_trackers[j]->_consumption->add(-bytes);
                     }
-                    return false;
+                    return tracker;
                 }
             }
         }
         // Everyone succeeded, return.
         DCHECK_EQ(i, -1);
-        return true;
+        return nullptr;
     }
 
     /// Decreases consumption of this tracker and its ancestors by 'bytes'.
@@ -270,6 +270,8 @@ public:
     Status MemLimitExceeded(RuntimeState* state, const std::string& details, int64_t failed_allocation = 0);
 
     Status check_mem_limit(const std::string& msg) const;
+
+    std::string err_msg(const std::string& msg) const;
 
     static const std::string COUNTER_NAME;
 

--- a/be/src/service/mem_hook.cpp
+++ b/be/src/service/mem_hook.cpp
@@ -189,7 +189,7 @@ std::atomic<int64_t> g_mem_usage(0);
 #define MEMORY_RELEASE_SIZE(size) g_mem_usage.fetch_sub(size)
 #define MEMORY_CONSUME_PTR(ptr) g_mem_usage.fetch_add(tc_malloc_size(ptr))
 #define MEMORY_RELEASE_PTR(ptr) g_mem_usage.fetch_sub(tc_malloc_size(ptr))
-#define TRY_MEM_CONSUME(size) g_mem_usage.fetch_add(size)
+#define TRY_MEM_CONSUME(size, err_ret) g_mem_usage.fetch_add(size)
 #define SET_EXCEED_MEM_TRACKER() (void)0
 #define IS_BAD_ALLOC_CATCHED() false
 #endif

--- a/be/src/service/mem_hook.cpp
+++ b/be/src/service/mem_hook.cpp
@@ -173,35 +173,37 @@ void operator delete[](void* p, size_t size, std::align_val_t al) noexcept {
 */
 
 #ifndef BE_TEST
-const int64_t TRY_CONSUME_SIZE = 1 * 1024 * 1024 * 1024;
 #define TC_MALLOC_SIZE(ptr) tc_malloc_size(ptr)
-#define MEMORY_CONSUME_PTR(ptr) starrocks::tls_thread_status.mem_consume(tc_malloc_size(ptr))
-#define MEMORY_RELEASE_PTR(ptr) starrocks::tls_thread_status.mem_release(tc_malloc_size(ptr))
 #define MEMORY_CONSUME_SIZE(size) starrocks::tls_thread_status.mem_consume(size)
 #define MEMORY_RELEASE_SIZE(size) starrocks::tls_thread_status.mem_release(size)
-#define LARGE_MEM_CONSUME_RETURN_ENOMEM(size) RETURN_IF(!starrocks::tls_thread_status.try_mem_consume(size), ENOMEM);
-#define LARGE_MEM_CONSUME(size) RETURN_IF(!starrocks::tls_thread_status.try_mem_consume(size), nullptr);
+#define MEMORY_CONSUME_PTR(ptr) MEMORY_CONSUME_SIZE(tc_malloc_size(ptr))
+#define MEMORY_RELEASE_PTR(ptr) MEMORY_RELEASE_SIZE(tc_malloc_size(ptr))
+#define TRY_MEM_CONSUME(size, err_ret) RETURN_IF_UNLIKELY(!starrocks::tls_thread_status.try_mem_consume(size), err_ret)
+#define SET_EXCEED_MEM_TRACKER() \
+    starrocks::tls_thread_status.set_exceed_mem_tracker(starrocks::ExecEnv::GetInstance()->process_mem_tracker())
+#define IS_BAD_ALLOC_CATCHED() starrocks::tls_thread_status.is_catched()
 #else
-const int64_t TRY_CONSUME_SIZE = 32 * 1024 * 1024;
 std::atomic<int64_t> g_mem_usage(0);
 #define TC_MALLOC_SIZE(ptr) tc_malloc_size(ptr)
-#define MEMORY_CONSUME_PTR(ptr) g_mem_usage.fetch_add(tc_malloc_size(ptr))
-#define MEMORY_RELEASE_PTR(ptr) g_mem_usage.fetch_sub(tc_malloc_size(ptr))
 #define MEMORY_CONSUME_SIZE(size) g_mem_usage.fetch_add(size)
 #define MEMORY_RELEASE_SIZE(size) g_mem_usage.fetch_sub(size)
-#define LARGE_MEM_CONSUME_RETURN_ENOMEM(size) g_mem_usage.fetch_add(size)
-#define LARGE_MEM_CONSUME(size) g_mem_usage.fetch_add(size)
+#define MEMORY_CONSUME_PTR(ptr) g_mem_usage.fetch_add(tc_malloc_size(ptr))
+#define MEMORY_RELEASE_PTR(ptr) g_mem_usage.fetch_sub(tc_malloc_size(ptr))
+#define TRY_MEM_CONSUME(size) g_mem_usage.fetch_add(size)
+#define SET_EXCEED_MEM_TRACKER() (void)0
+#define IS_BAD_ALLOC_CATCHED() false
 #endif
 
 extern "C" {
 // malloc
 void* my_malloc(size_t size) __THROW {
-    if (UNLIKELY(size >= TRY_CONSUME_SIZE)) {
+    if (IS_BAD_ALLOC_CATCHED()) {
         // NOTE: do NOT call `tc_malloc_size` here, it may call the new operator, which in turn will
         // call the `my_malloc`, and result in a deadloop.
-        LARGE_MEM_CONSUME(tc_nallocx(size, 0));
+        TRY_MEM_CONSUME(tc_nallocx(size, 0), nullptr);
         void* ptr = tc_malloc(size);
         if (UNLIKELY(ptr == nullptr)) {
+            SET_EXCEED_MEM_TRACKER();
             MEMORY_RELEASE_SIZE(tc_nallocx(size, 0));
         }
         return ptr;
@@ -231,10 +233,12 @@ void* my_realloc(void* p, size_t size) __THROW {
         return nullptr;
     }
     int64_t old_size = TC_MALLOC_SIZE(p);
-    if (UNLIKELY(size >= TRY_CONSUME_SIZE)) {
-        LARGE_MEM_CONSUME(tc_nallocx(size, 0) - old_size);
+
+    if (IS_BAD_ALLOC_CATCHED()) {
+        TRY_MEM_CONSUME(tc_nallocx(size, 0) - old_size, nullptr);
         void* ptr = tc_realloc(p, size);
         if (UNLIKELY(ptr == nullptr)) {
+            SET_EXCEED_MEM_TRACKER();
             MEMORY_RELEASE_SIZE(tc_nallocx(size, 0) - old_size);
         }
         return ptr;
@@ -257,10 +261,12 @@ void* my_calloc(size_t n, size_t size) __THROW {
     if (UNLIKELY(size == 0)) {
         return nullptr;
     }
-    if (UNLIKELY(n * size >= TRY_CONSUME_SIZE)) {
-        LARGE_MEM_CONSUME(n * size);
+
+    if (IS_BAD_ALLOC_CATCHED()) {
+        TRY_MEM_CONSUME(n * size, nullptr);
         void* ptr = tc_calloc(n, size);
         if (UNLIKELY(ptr == nullptr)) {
+            SET_EXCEED_MEM_TRACKER();
             MEMORY_RELEASE_SIZE(n * size);
         } else {
             MEMORY_CONSUME_SIZE(TC_MALLOC_SIZE(ptr) - n * size);
@@ -280,10 +286,11 @@ void my_cfree(void* ptr) __THROW {
 
 // memalign
 void* my_memalign(size_t align, size_t size) __THROW {
-    if (UNLIKELY(size >= TRY_CONSUME_SIZE)) {
-        LARGE_MEM_CONSUME(size);
+    if (IS_BAD_ALLOC_CATCHED()) {
+        TRY_MEM_CONSUME(size, nullptr);
         void* ptr = tc_memalign(align, size);
         if (UNLIKELY(ptr == nullptr)) {
+            SET_EXCEED_MEM_TRACKER();
             MEMORY_RELEASE_SIZE(size);
         } else {
             MEMORY_CONSUME_SIZE(TC_MALLOC_SIZE(ptr) - size);
@@ -298,10 +305,11 @@ void* my_memalign(size_t align, size_t size) __THROW {
 
 // aligned_alloc
 void* my_aligned_alloc(size_t align, size_t size) __THROW {
-    if (UNLIKELY(size >= TRY_CONSUME_SIZE)) {
-        LARGE_MEM_CONSUME(size);
+    if (IS_BAD_ALLOC_CATCHED()) {
+        TRY_MEM_CONSUME(size, nullptr);
         void* ptr = tc_memalign(align, size);
         if (UNLIKELY(ptr == nullptr)) {
+            SET_EXCEED_MEM_TRACKER();
             MEMORY_RELEASE_SIZE(size);
         } else {
             MEMORY_CONSUME_SIZE(TC_MALLOC_SIZE(ptr) - size);
@@ -316,10 +324,11 @@ void* my_aligned_alloc(size_t align, size_t size) __THROW {
 
 // valloc
 void* my_valloc(size_t size) __THROW {
-    if (UNLIKELY(size >= TRY_CONSUME_SIZE)) {
-        LARGE_MEM_CONSUME(size);
+    if (IS_BAD_ALLOC_CATCHED()) {
+        TRY_MEM_CONSUME(size, nullptr);
         void* ptr = tc_valloc(size);
         if (UNLIKELY(ptr == nullptr)) {
+            SET_EXCEED_MEM_TRACKER();
             MEMORY_RELEASE_SIZE(size);
         } else {
             MEMORY_CONSUME_SIZE(TC_MALLOC_SIZE(ptr) - size);
@@ -334,10 +343,11 @@ void* my_valloc(size_t size) __THROW {
 
 // pvalloc
 void* my_pvalloc(size_t size) __THROW {
-    if (UNLIKELY(size >= TRY_CONSUME_SIZE)) {
-        LARGE_MEM_CONSUME(size);
+    if (IS_BAD_ALLOC_CATCHED()) {
+        TRY_MEM_CONSUME(size, nullptr);
         void* ptr = tc_valloc(size);
         if (UNLIKELY(ptr == nullptr)) {
+            SET_EXCEED_MEM_TRACKER();
             MEMORY_RELEASE_SIZE(size);
         } else {
             MEMORY_CONSUME_SIZE(TC_MALLOC_SIZE(ptr) - size);
@@ -352,10 +362,11 @@ void* my_pvalloc(size_t size) __THROW {
 
 // posix_memalign
 int my_posix_memalign(void** r, size_t align, size_t size) __THROW {
-    if (UNLIKELY(size >= TRY_CONSUME_SIZE)) {
-        LARGE_MEM_CONSUME_RETURN_ENOMEM(size);
+    if (IS_BAD_ALLOC_CATCHED()) {
+        TRY_MEM_CONSUME(size, ENOMEM);
         int ret = tc_posix_memalign(r, align, size);
         if (UNLIKELY(ret != 0)) {
+            SET_EXCEED_MEM_TRACKER();
             MEMORY_RELEASE_SIZE(size);
         } else {
             MEMORY_CONSUME_SIZE(TC_MALLOC_SIZE(*r) - size);

--- a/be/src/storage/rowset/segment_v2/page_io.cpp
+++ b/be/src/storage/rowset/segment_v2/page_io.cpp
@@ -113,6 +113,8 @@ Status PageIO::write_page(fs::WritableBlock* wblock, const std::vector<Slice>& b
 
 Status PageIO::read_and_decompress_page(const PageReadOptions& opts, PageHandle* handle, Slice* body,
                                         PageFooterPB* footer) {
+    RETURN_IF_ERROR(tls_thread_status.mem_tracker()->check_mem_limit("read and decompress page"));
+
     opts.sanity_check();
     opts.stats->total_pages_num++;
 


### PR DESCRIPTION
If the code segment has already try catch std::bad_alloc exception, the memory is checked first and then applied. Otherwise, alloc first, then check.

for #1986 
