### PR TITLE
Fix ldap authentication failed bug (#1309)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/mysql/security/LdapSecurity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/security/LdapSecurity.java
@@ -34,6 +34,7 @@ public class LdapSecurity {
             ctx = new InitialDirContext(env);
             return true;
         } catch (Exception e) {
+            LOG.warn("check ldap password failed, dn = {}, password = {}", dn, password, e);
         } finally {
             if (ctx != null) {
                 try {


### PR DESCRIPTION
Ldap authentication should use mysql_clear_password auth plugin. Add mysql_clear_password to supported plugins.