### PR TITLE
[pipeline] check whether driver can short circuit break in poller

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -218,22 +218,22 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state) {
 }
 
 void PipelineDriver::check_short_circuit() {
-    size_t new_first_unfinished = _first_unfinished;
+    int last_finished = -1;
     for (int i = _first_unfinished; i < _operators.size() - 1; i++) {
         if (_operators[i]->is_finished()) {
-            new_first_unfinished = i + 1;
+            last_finished = i;
         }
     }
 
-    if (new_first_unfinished == _first_unfinished) {
+    if (last_finished == -1) {
         return;
     }
 
-    _mark_operator_finishing(_operators[new_first_unfinished], _runtime_state);
-    for (auto i = _first_unfinished; i < new_first_unfinished; ++i) {
+    _mark_operator_finishing(_operators[last_finished + 1], _runtime_state);
+    for (auto i = _first_unfinished; i <= last_finished; ++i) {
         _mark_operator_finished(_operators[i], _runtime_state);
     }
-    _first_unfinished = new_first_unfinished;
+    _first_unfinished = last_finished + 1;
 
     if (sink_operator()->is_finished()) {
         finish_operators(_runtime_state);

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -217,7 +217,7 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state) {
     }
 }
 
-void PipelineDriver::maybe_short_circuit() {
+void PipelineDriver::check_short_circuit() {
     size_t new_first_unfinished = _first_unfinished;
     for (int i = _first_unfinished; i < _operators.size() - 1; i++) {
         if (_operators[i]->is_finished()) {

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -221,7 +221,7 @@ void PipelineDriver::maybe_short_circuit() {
     size_t new_first_unfinished = _first_unfinished;
     for (int i = _first_unfinished; i < _operators.size() - 1; i++) {
         if (_operators[i]->is_finished()) {
-            new_first_unfinished = i;
+            new_first_unfinished = i + 1;
         }
     }
 
@@ -229,10 +229,16 @@ void PipelineDriver::maybe_short_circuit() {
         return;
     }
 
+    _mark_operator_finishing(_operators[new_first_unfinished], _runtime_state);
     for (auto i = _first_unfinished; i < new_first_unfinished; ++i) {
         _mark_operator_finished(_operators[i], _runtime_state);
     }
     _first_unfinished = new_first_unfinished;
+
+    if (sink_operator()->is_finished()) {
+        finish_operators(_runtime_state);
+        _state = is_still_pending_finish() ? DriverState::PENDING_FINISH : DriverState::FINISH;
+    }
 }
 
 void PipelineDriver::mark_precondition_not_ready() {

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -241,7 +241,7 @@ public:
                 return false;
             }
 
-            maybe_short_circuit();
+            check_short_circuit();
             if (_state == DriverState::PENDING_FINISH) {
                 return false;
             }
@@ -257,7 +257,7 @@ public:
     }
 
     // Check whether an operator can be short-circuited, when is_precondition_block() becomes false from true.
-    void maybe_short_circuit();
+    void check_short_circuit();
 
     bool is_root() const { return _is_root; }
 

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -242,6 +242,9 @@ public:
             }
 
             maybe_short_circuit();
+            if (_state == DriverState::PENDING_FINISH) {
+                return false;
+            }
         }
 
         // OUTPUT_FULL
@@ -253,7 +256,7 @@ public:
         return source_operator()->is_finished() || source_operator()->has_output();
     }
 
-    // Check whether an operator can be short-circuited, when is_precondition_block() from true to false.
+    // Check whether an operator can be short-circuited, when is_precondition_block() becomes false from true.
     void maybe_short_circuit();
 
     bool is_root() const { return _is_root; }

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -236,8 +236,12 @@ public:
         }
 
         // PRECONDITION_BLOCK
-        if (is_precondition_block()) {
-            return false;
+        if (_state == DriverState::PRECONDITION_BLOCK) {
+            if (is_precondition_block()) {
+                return false;
+            }
+
+            maybe_short_circuit();
         }
 
         // OUTPUT_FULL
@@ -248,6 +252,9 @@ public:
         // INPUT_EMPTY
         return source_operator()->is_finished() || source_operator()->has_output();
     }
+
+    // Check whether an operator can be short-circuited, when is_precondition_block() from true to false.
+    void maybe_short_circuit();
 
     bool is_root() const { return _is_root; }
 
@@ -261,6 +268,8 @@ private:
     void _mark_operator_cancelled(OperatorPtr& op, RuntimeState* runtime_state);
     void _mark_operator_closed(OperatorPtr& op, RuntimeState* runtime_state);
     void _close_operators(RuntimeState* runtime_state);
+
+    RuntimeState* _runtime_state = nullptr;
 
     Operators _operators;
 

--- a/be/src/exec/vectorized/hash_joiner.h
+++ b/be/src/exec/vectorized/hash_joiner.h
@@ -162,7 +162,10 @@ private:
 
     void _short_circuit_break() {
         // special cases of short-circuit break.
-        if (_ht.get_row_count() == 0 && (_join_type == TJoinOp::INNER_JOIN || _join_type == TJoinOp::LEFT_SEMI_JOIN)) {
+        if (_ht.get_row_count() == 0 &&
+            (_join_type == TJoinOp::INNER_JOIN || _join_type == TJoinOp::LEFT_SEMI_JOIN ||
+             _join_type == TJoinOp::RIGHT_SEMI_JOIN || _join_type == TJoinOp::RIGHT_ANTI_JOIN ||
+             _join_type == TJoinOp::RIGHT_OUTER_JOIN)) {
             _phase = HashJoinPhase::EOS;
             set_finished();
         }


### PR DESCRIPTION
### Introduction
When `HashJoinBuildOperator` has finished and the hash table is empty, `HashJoinProbeOperator` should be short circuited. 
However, we only check a driver `is_finished()` in the Dispatcher thread. `HashJoinProbeOperator` must wait util input is not empty and then it can be pushed back to Dispatcher queue.

We can check whether driver can short circuit break in poller.

After this optimization, the consuming time of TPC-H Q21 is from 1.32s to 0.32s.

### Changes
- Check `maybe_short_circuit()` when `is_precondition_block()` becomes false in poller.
- Make `RIGHT_SEMI_JOIN`, `RIGHT_ANTI_JOIN`, and `RIGHT_OUTER_JOIN` can be short circuited.
