### PR TITLE
Fix table function push down predicate check

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateTableFunctionRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateTableFunctionRule.java
@@ -32,7 +32,7 @@ public class PushDownPredicateTableFunctionRule extends TransformationRule {
         List<ScalarOperator> pushDownPredicates = Lists.newArrayList();
         for (Iterator<ScalarOperator> iter = filters.iterator(); iter.hasNext(); ) {
             ScalarOperator filter = iter.next();
-            if (!tvfOperator.getFnResultColumnRefSet().contains(filter.getUsedColumns())) {
+            if (!tvfOperator.getFnResultColumnRefSet().isIntersect(filter.getUsedColumns())) {
                 iter.remove();
                 pushDownPredicates.add(filter);
             }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -4899,4 +4899,14 @@ public class PlanFragmentTest extends PlanTestBase {
                 "  |  <slot 11> : CAST(5: v5 AS DECIMAL128(37,18))"));
         Config.enable_decimal_v3 = false;
     }
+
+    @Test
+    public void testUnnestFunctionPredicate() throws Exception {
+        String sql = "select x2, xx, unnest from " +
+                "(Select 2 as x2, group_concat(t1a, ',') as xx from test_all_type) as j0, " +
+                "unnest(split(xx, ',')) where unnest + x2 = 2;";
+        String plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("4:SELECT\n" +
+                "  |  predicates: CAST(13: unnest AS DOUBLE) + CAST(12: expr AS DOUBLE) = 2.0\n"));
+    }
 }


### PR DESCRIPTION
Predicate push down on table function operator, check used columns error
```
mysql> select x2, xx, unnest from (Select 2 as x2, group_concat(v1, ',') as xx from s0) as j0, unnest(split(xx, ','));
+------+-------+--------+
| x2   | xx    | unnest |
+------+-------+--------+
|    2 | 1,2,3 | 1      |
|    2 | 1,2,3 | 2      |
|    2 | 1,2,3 | 3      |
+------+-------+--------+
3 rows in set (0.01 sec)

mysql> select x2, xx, unnest from (Select 2 as x2, group_concat(v1, ',') as xx from s0) as j0, unnest(split(xx, ',')) where unnest + x2 = 2;
ERROR 1064 (HY000): Unknown error
```