### PR TITLE
Add a num_segment threshold when loading multiple big files(#2067)

### DIFF
--- a/be/src/storage/rowset/beta_rowset_writer.h
+++ b/be/src/storage/rowset/beta_rowset_writer.h
@@ -72,6 +72,8 @@ public:
 
     int64_t num_rows() override { return _num_rows_written; }
 
+    int num_segment() override { return _num_segment; }
+
     int64_t total_data_size() override { return _total_data_size; }
 
     RowsetId rowset_id() override { return _context.rowset_id; }

--- a/be/src/storage/rowset/rowset_writer.h
+++ b/be/src/storage/rowset/rowset_writer.h
@@ -114,6 +114,8 @@ public:
 
     virtual int64_t num_rows() = 0;
 
+    virtual int num_segment() = 0;
+
     virtual int64_t total_data_size() = 0;
 
     virtual RowsetId rowset_id() = 0;

--- a/be/src/storage/rowset/vectorized/rowset_writer_adapter.h
+++ b/be/src/storage/rowset/vectorized/rowset_writer_adapter.h
@@ -53,6 +53,8 @@ public:
 
     int64_t num_rows() override { return _writer->num_rows(); }
 
+    int num_segment() override { return _writer->num_segment(); }
+
     int64_t total_data_size() override { return _writer->total_data_size(); }
 
     RowsetId rowset_id() override { return _writer->rowset_id(); }

--- a/be/src/storage/vectorized/memtable.cpp
+++ b/be/src/storage/vectorized/memtable.cpp
@@ -199,6 +199,12 @@ OLAPStatus MemTable::flush() {
             RETURN_NOT_OK(_rowset_writer->flush_chunk_with_deletes(*_result_chunk, *_deletes));
         }
     }
+    if (_rowset_writer->num_segment() > config::tablet_max_versions) {
+        LOG(WARNING) << "Too many segment files in one load. tablet=" << _tablet_id
+                     << ", segment_count=" << _rowset_writer->num_segment()
+                     << ", limit=" << config::tablet_max_versions;
+        return OLAP_ERR_OTHER_ERROR;
+    }
     StarRocksMetrics::instance()->memtable_flush_total.increment(1);
     StarRocksMetrics::instance()->memtable_flush_duration_us.increment(duration_ns / 1000);
     VLOG(1) << "memtable flush: " << duration_ns / 1000 << "us";

--- a/be/test/storage/vectorized/rowset_merger_test.cpp
+++ b/be/test/storage/vectorized/rowset_merger_test.cpp
@@ -53,6 +53,8 @@ public:
 
     int64_t num_rows() override { return all_pks->size(); }
 
+    int num_segment() override { return 0; }
+
     int64_t total_data_size() override { return 0; }
 
     RowsetId rowset_id() override { return RowsetId(); }


### PR DESCRIPTION
A threshold is necessary
before the vertical compaction is used to alleviate the compaction memory usage.
It will reuse config::tablet_max_versions because it's a temporary solution.