### PR TITLE
Fragment with result sink instance num should always be 1

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -1165,6 +1165,10 @@ public class Coordinator {
             }
 
             int parallelExecInstanceNum = fragment.getParallelExecNum();
+            // The instance num for result sink fragment must be 1
+            if (fragment.getSink() instanceof ResultSink) {
+                parallelExecInstanceNum = 1;
+            }
             boolean hasColocate = (isColocateFragment(fragment.getPlanRoot()) &&
                     fragmentIdToSeqToAddressMap.containsKey(fragment.getFragmentId())
                     && fragmentIdToSeqToAddressMap.get(fragment.getFragmentId()).size() > 0);


### PR DESCRIPTION
For https://github.com/StarRocks/starrocks/issues/2097

If fragment with result sink has multi instances, one instance result sink sent eos, FE will return result directly, which is wrong.