### PR TITLE
Upgrade log4j2 to 2.16.0

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -343,21 +343,21 @@ under the License.
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-api</artifactId>
-                <version>2.13.3</version>
+                <version>2.16.0</version>
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core -->
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-core</artifactId>
-                <version>2.13.3</version>
+                <version>2.16.0</version>
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-slf4j-impl -->
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-slf4j-impl</artifactId>
-                <version>2.12.1</version>
+                <version>2.16.0</version>
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/io.dropwizard.metrics/metrics-core -->

--- a/fs_brokers/apache_hdfs_broker/pom.xml
+++ b/fs_brokers/apache_hdfs_broker/pom.xml
@@ -279,14 +279,14 @@ under the License.
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.13.3</version>
+            <version>2.16.0</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.13.3</version>
+            <version>2.16.0</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java -->


### PR DESCRIPTION
Fix #2021 
log4j2 2.16.0 released
https://lists.apache.org/thread/d6v4r6nosxysyq9rvnr779336yf0woz4
This is a better version to solve CVE-2021-44228