### PR TITLE
Wrapping a discontinuous range into a single read function call to reduce function call

### DIFF
--- a/be/src/storage/rowset/segment_v2/array_column_iterator.cpp
+++ b/be/src/storage/rowset/segment_v2/array_column_iterator.cpp
@@ -144,12 +144,12 @@ Status ArrayColumnIterator::next_batch(const vectorized::SparseRange& range, vec
     }
 
     vectorized::SparseRangeIterator iter = range.new_iterator();
-    size_t nread = range.span_size();
+    size_t to_read = range.span_size();
 
     DCHECK_EQ(range.begin(), _array_size_iterator->get_current_ordinal());
     vectorized::SparseRange element_read_range;
     while (iter.has_more()) {
-        vectorized::Range r = iter.next(nread);
+        vectorized::Range r = iter.next(to_read);
 
         RETURN_IF_ERROR(_array_size_iterator->seek_to_ordinal_and_calc_element_ordinal(r.begin()));
         size_t element_ordinal = _array_size_iterator->element_ordinal();

--- a/be/src/storage/rowset/segment_v2/array_column_iterator.cpp
+++ b/be/src/storage/rowset/segment_v2/array_column_iterator.cpp
@@ -122,6 +122,59 @@ Status ArrayColumnIterator::next_batch(size_t* n, vectorized::Column* dst) {
     return Status::OK();
 }
 
+Status ArrayColumnIterator::next_batch(vectorized::SparseRange& range, vectorized::Column* dst) {
+    vectorized::ArrayColumn* array_column = nullptr;
+    vectorized::NullColumn* null_column = nullptr;
+    if (dst->is_nullable()) {
+        auto* nullable_column = down_cast<vectorized::NullableColumn*>(dst);
+
+        array_column = down_cast<vectorized::ArrayColumn*>(nullable_column->data_column().get());
+        null_column = down_cast<vectorized::NullColumn*>(nullable_column->null_column().get());
+    } else {
+        array_column = down_cast<vectorized::ArrayColumn*>(dst);
+    }
+
+    // 1. Read null column
+    if (_null_iterator != nullptr) {
+        RETURN_IF_ERROR(_null_iterator->next_batch(range, null_column));
+        down_cast<vectorized::NullableColumn*>(dst)->update_has_null();
+    }
+    
+    vectorized::SparseRangeIterator iter = range.new_iterator();
+    size_t nread = range.span_size();
+    while (iter.has_more()) {
+        vectorized::Range r = iter.next(nread);
+
+        RETURN_IF_ERROR(_array_size_iterator->seek_to_ordinal_and_calc_element_ordinal(ord));
+        size_t element_ordinal = _array_size_iterator->element_ordinal();
+        //RETURN_IF_ERROR(next_batch(&n, dst));
+        // 2. Read offset column
+        // [1, 2, 3], [4, 5, 6]
+        // In memory, it will be transformed to actual offset(0, 3, 6)
+        // On disk, offset is stored as length array(3, 3)
+        auto* offsets = array_column->offsets_column().get();
+        auto& data = offsets->get_data();
+        size_t end_offset = data.back();
+
+        size_t prev_array_size = offsets->size();
+        vectorized::SparseRange size_read_range(r);
+        RETURN_IF_ERROR(_array_size_iterator->next_batch(size_read_range, offsets));
+        size_t curr_array_size = offsets->size();
+
+        size_t num_to_read = end_offset;
+        for (size_t i = prev_array_size; i < curr_array_size; ++i) {
+            end_offset += data[i];
+            data[i] = end_offset;
+        }
+        num_to_read = end_offset - num_to_read;
+
+        vectorized::SparseRange element_read_range(element_ordinal, element_ordinal + num_to_read);
+        RETURN_IF_ERROR(_element_iterator->next_batch(element_read_range, array_column->elements_column().get()));
+    
+    }
+    return Status::OK();
+}
+
 Status ArrayColumnIterator::fetch_values_by_rowid(const rowid_t* rowids, size_t size, vectorized::Column* values) {
     vectorized::ArrayColumn* array_column = nullptr;
     vectorized::NullColumn* null_column = nullptr;

--- a/be/src/storage/rowset/segment_v2/array_column_iterator.cpp
+++ b/be/src/storage/rowset/segment_v2/array_column_iterator.cpp
@@ -139,7 +139,7 @@ Status ArrayColumnIterator::next_batch(vectorized::SparseRange& range, vectorize
         RETURN_IF_ERROR(_null_iterator->next_batch(range, null_column));
         down_cast<vectorized::NullableColumn*>(dst)->update_has_null();
     }
-    
+
     vectorized::SparseRangeIterator iter = range.new_iterator();
     size_t nread = range.span_size();
 
@@ -176,7 +176,7 @@ Status ArrayColumnIterator::next_batch(vectorized::SparseRange& range, vectorize
 
     DCHECK_EQ(element_read_range.begin(), _element_iterator->get_current_ordinal());
     RETURN_IF_ERROR(_element_iterator->next_batch(element_read_range, array_column->elements_column().get()));
-    
+
     return Status::OK();
 }
 

--- a/be/src/storage/rowset/segment_v2/array_column_iterator.cpp
+++ b/be/src/storage/rowset/segment_v2/array_column_iterator.cpp
@@ -122,7 +122,7 @@ Status ArrayColumnIterator::next_batch(size_t* n, vectorized::Column* dst) {
     return Status::OK();
 }
 
-Status ArrayColumnIterator::next_batch(vectorized::SparseRange& range, vectorized::Column* dst) {
+Status ArrayColumnIterator::next_batch(const vectorized::SparseRange& range, vectorized::Column* dst) {
     vectorized::ArrayColumn* array_column = nullptr;
     vectorized::NullColumn* null_column = nullptr;
     if (dst->is_nullable()) {
@@ -133,6 +133,9 @@ Status ArrayColumnIterator::next_batch(vectorized::SparseRange& range, vectorize
     } else {
         array_column = down_cast<vectorized::ArrayColumn*>(dst);
     }
+
+    CHECK((_null_iterator == nullptr && null_column == nullptr) ||
+          (_null_iterator != nullptr && null_column != nullptr));
 
     // 1. Read null column
     if (_null_iterator != nullptr) {

--- a/be/src/storage/rowset/segment_v2/array_column_iterator.h
+++ b/be/src/storage/rowset/segment_v2/array_column_iterator.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "storage/rowset/segment_v2/column_iterator.h"
+#include "storage/vectorized/range.h"
 
 namespace starrocks {
 
@@ -27,6 +28,8 @@ public:
     Status next_batch(size_t* n, ColumnBlockView* dst, bool* has_null) override;
 
     Status next_batch(size_t* n, vectorized::Column* dst) override;
+
+    Status next_batch(vectorized::SparseRange& range, vectorized::Column* dst) override;
 
     Status seek_to_first() override;
 

--- a/be/src/storage/rowset/segment_v2/array_column_iterator.h
+++ b/be/src/storage/rowset/segment_v2/array_column_iterator.h
@@ -29,7 +29,7 @@ public:
 
     Status next_batch(size_t* n, vectorized::Column* dst) override;
 
-    Status next_batch(vectorized::SparseRange& range, vectorized::Column* dst) override;
+    Status next_batch(const vectorized::SparseRange& range, vectorized::Column* dst) override;
 
     Status seek_to_first() override;
 

--- a/be/src/storage/rowset/segment_v2/binary_dict_page.cpp
+++ b/be/src/storage/rowset/segment_v2/binary_dict_page.cpp
@@ -258,7 +258,7 @@ Status BinaryDictPageDecoder<Type>::next_batch(size_t* n, vectorized::Column* ds
 }
 
 template <FieldType Type>
-Status BinaryDictPageDecoder<Type>::next_batch(vectorized::SparseRange& range, vectorized::Column* dst) {
+Status BinaryDictPageDecoder<Type>::next_batch(const vectorized::SparseRange& range, vectorized::Column* dst) {
     if (_encoding_type == PLAIN_ENCODING) {
         return _data_page_decoder->next_batch(range, dst);
     }
@@ -302,7 +302,7 @@ Status BinaryDictPageDecoder<Type>::next_dict_codes(size_t* n, vectorized::Colum
 }
 
 template <FieldType Type>
-Status BinaryDictPageDecoder<Type>::next_dict_codes(vectorized::SparseRange& range, vectorized::Column* dst) {
+Status BinaryDictPageDecoder<Type>::next_dict_codes(const vectorized::SparseRange& range, vectorized::Column* dst) {
     DCHECK(_encoding_type == DICT_ENCODING);
     DCHECK(_parsed);
     return _data_page_decoder->next_batch(range, dst);

--- a/be/src/storage/rowset/segment_v2/binary_dict_page.cpp
+++ b/be/src/storage/rowset/segment_v2/binary_dict_page.cpp
@@ -31,6 +31,7 @@
 #include "storage/vectorized/chunk_helper.h"
 #include "util/slice.h" // for Slice
 #include "util/unaligned_access.h"
+#include "storage/vectorized/range.h"
 
 namespace starrocks::segment_v2 {
 
@@ -248,34 +249,47 @@ Status BinaryDictPageDecoder<Type>::next_batch(size_t* n, ColumnBlockView* dst) 
 
 template <FieldType Type>
 Status BinaryDictPageDecoder<Type>::next_batch(size_t* n, vectorized::Column* dst) {
+    vectorized::SparseRange read_range;
+    size_t begin = current_index();
+    read_range.add(vectorized::Range(begin, begin + *n));
+    RETURN_IF_ERROR(next_batch(read_range, dst));
+    *n = current_index() - begin;
+    return Status::OK();
+}
+
+template <FieldType Type>
+Status BinaryDictPageDecoder<Type>::next_batch(vectorized::SparseRange& range, vectorized::Column* dst) {
     if (_encoding_type == PLAIN_ENCODING) {
-        return _data_page_decoder->next_batch(n, dst);
+        return _data_page_decoder->next_batch(range, dst);
     }
+
     DCHECK(_parsed);
     DCHECK(_dict_decoder != nullptr) << "dict decoder pointer is nullptr";
     if (_vec_code_buf == nullptr) {
         _vec_code_buf = vectorized::ChunkHelper::column_from_field_type(OLAP_FIELD_TYPE_INT, false);
     }
     _vec_code_buf->resize(0);
-    _vec_code_buf->reserve(*n);
+    _vec_code_buf->reserve(range.span_size());
 
-    RETURN_IF_ERROR(_data_page_decoder->next_batch(n, _vec_code_buf.get()));
+    RETURN_IF_ERROR(_data_page_decoder->next_batch(range, _vec_code_buf.get()));
+    size_t nread = _vec_code_buf->size();
     using cast_type = CppTypeTraits<OLAP_FIELD_TYPE_INT>::CppType;
     const cast_type* codewords = reinterpret_cast<const cast_type*>(_vec_code_buf->raw_data());
     std::vector<Slice> slices;
-    slices.reserve(*n);
+    slices.reserve(nread);
     if constexpr (Type == OLAP_FIELD_TYPE_CHAR) {
-        for (int i = 0; i < *n; ++i) {
+        for (int i = 0; i < nread; ++i) {
             Slice element = _dict_decoder->string_at_index(codewords[i]);
             // Strip trailing '\x00'
             element.size = strnlen(element.data, element.size);
             slices.emplace_back(element);
         }
     } else {
-        for (int i = 0; i < *n; ++i) {
+        for (int i = 0; i < nread; ++i) {
             slices.emplace_back(_dict_decoder->string_at_index(codewords[i]));
         }
     }
+        
     CHECK(dst->append_strings_overflow(slices, _max_value_legth));
     return Status::OK();
 }
@@ -285,6 +299,13 @@ Status BinaryDictPageDecoder<Type>::next_dict_codes(size_t* n, vectorized::Colum
     DCHECK(_encoding_type == DICT_ENCODING);
     DCHECK(_parsed);
     return _data_page_decoder->next_batch(n, dst);
+}
+
+template <FieldType Type>
+Status BinaryDictPageDecoder<Type>::next_dict_codes(vectorized::SparseRange& range, vectorized::Column* dst) {
+    DCHECK(_encoding_type == DICT_ENCODING);
+    DCHECK(_parsed);
+    return _data_page_decoder->next_batch(range, dst);
 }
 
 template class BinaryDictPageDecoder<OLAP_FIELD_TYPE_CHAR>;

--- a/be/src/storage/rowset/segment_v2/binary_dict_page.cpp
+++ b/be/src/storage/rowset/segment_v2/binary_dict_page.cpp
@@ -29,9 +29,9 @@
 #include "gutil/strings/substitute.h" // for Substitute
 #include "storage/rowset/segment_v2/bitshuffle_page.h"
 #include "storage/vectorized/chunk_helper.h"
+#include "storage/vectorized/range.h"
 #include "util/slice.h" // for Slice
 #include "util/unaligned_access.h"
-#include "storage/vectorized/range.h"
 
 namespace starrocks::segment_v2 {
 
@@ -289,7 +289,7 @@ Status BinaryDictPageDecoder<Type>::next_batch(vectorized::SparseRange& range, v
             slices.emplace_back(_dict_decoder->string_at_index(codewords[i]));
         }
     }
-        
+
     CHECK(dst->append_strings_overflow(slices, _max_value_legth));
     return Status::OK();
 }

--- a/be/src/storage/rowset/segment_v2/binary_dict_page.h
+++ b/be/src/storage/rowset/segment_v2/binary_dict_page.h
@@ -36,6 +36,7 @@
 #include "storage/rowset/segment_v2/options.h"
 #include "storage/types.h"
 #include "util/phmap/phmap.h"
+#include "storage/vectorized/range.h"
 
 namespace starrocks {
 namespace segment_v2 {
@@ -124,6 +125,8 @@ public:
 
     Status next_batch(size_t* n, vectorized::Column* dst) override;
 
+    Status next_batch(vectorized::SparseRange& range, vectorized::Column* dst) override;
+
     size_t count() const override { return _data_page_decoder->count(); }
 
     size_t current_index() const override { return _data_page_decoder->current_index(); }
@@ -133,6 +136,8 @@ public:
     void set_dict_decoder(PageDecoder* dict_decoder);
 
     Status next_dict_codes(size_t* n, vectorized::Column* dst) override;
+
+    Status next_dict_codes(vectorized::SparseRange& range, vectorized::Column* dst) override;
 
 private:
     Slice _data;

--- a/be/src/storage/rowset/segment_v2/binary_dict_page.h
+++ b/be/src/storage/rowset/segment_v2/binary_dict_page.h
@@ -35,8 +35,8 @@
 #include "storage/rowset/segment_v2/common.h"
 #include "storage/rowset/segment_v2/options.h"
 #include "storage/types.h"
-#include "util/phmap/phmap.h"
 #include "storage/vectorized/range.h"
+#include "util/phmap/phmap.h"
 
 namespace starrocks {
 namespace segment_v2 {

--- a/be/src/storage/rowset/segment_v2/binary_dict_page.h
+++ b/be/src/storage/rowset/segment_v2/binary_dict_page.h
@@ -125,7 +125,7 @@ public:
 
     Status next_batch(size_t* n, vectorized::Column* dst) override;
 
-    Status next_batch(vectorized::SparseRange& range, vectorized::Column* dst) override;
+    Status next_batch(const vectorized::SparseRange& range, vectorized::Column* dst) override;
 
     size_t count() const override { return _data_page_decoder->count(); }
 
@@ -137,7 +137,7 @@ public:
 
     Status next_dict_codes(size_t* n, vectorized::Column* dst) override;
 
-    Status next_dict_codes(vectorized::SparseRange& range, vectorized::Column* dst) override;
+    Status next_dict_codes(const vectorized::SparseRange& range, vectorized::Column* dst) override;
 
 private:
     Slice _data;

--- a/be/src/storage/rowset/segment_v2/binary_plain_page.cpp
+++ b/be/src/storage/rowset/segment_v2/binary_plain_page.cpp
@@ -4,31 +4,58 @@
 
 namespace starrocks::segment_v2 {
 
+
 template <FieldType Type>
 Status BinaryPlainPageDecoder<Type>::next_batch(size_t* count, vectorized::Column* dst) {
+    vectorized::SparseRange read_range;
+    size_t begin = current_index();
+    read_range.add(vectorized::Range(begin, begin + *count));
+    RETURN_IF_ERROR(next_batch(read_range, dst));
+    *count = current_index() - begin;
+    return Status::OK();
+}
+
+template <FieldType Type>
+Status BinaryPlainPageDecoder<Type>::next_batch(vectorized::SparseRange& range, vectorized::Column* dst) {
     DCHECK(_parsed);
     if (PREDICT_FALSE(_cur_idx >= _num_elems)) {
-        *count = 0;
         return Status::OK();
     }
-    *count = std::min(*count, static_cast<size_t>(_num_elems - _cur_idx));
+
+    size_t nread = std::min(range.span_size(), _num_elems - _cur_idx);
     std::vector<Slice> strs;
-    strs.reserve(*count);
-    size_t end = _cur_idx + *count;
+    strs.reserve(nread);
+    vectorized::SparseRangeIterator iter = range.new_iterator();
     if constexpr (Type == OLAP_FIELD_TYPE_CHAR) {
-        for (/**/; _cur_idx < end; _cur_idx++) {
-            Slice s = string_at_index(_cur_idx);
-            s.size = strnlen(s.data, s.size);
-            strs.emplace_back(s);
+        while(iter.has_more() && nread > 0) {
+            _cur_idx = iter.begin();
+            vectorized::Range r = iter.next(nread);
+            size_t end = _cur_idx + r.span_size();
+            for (; _cur_idx < end; _cur_idx++) {
+                Slice s = string_at_index(_cur_idx);
+                s.size = strnlen(s.data, s.size);
+                strs.emplace_back(s);
+            }
+            nread -= r.span_size();
         }
         if (dst->append_strings(strs)) {
             return Status::OK();
         }
     } else {
-        for (/**/; _cur_idx < end; _cur_idx++) {
-            strs.emplace_back(string_at_index(_cur_idx));
+        while(iter.has_more() && nread > 0) {
+            _cur_idx = iter.begin();
+            vectorized::Range r = iter.next(nread);
+            size_t end = _cur_idx + r.span_size();
+            for (; _cur_idx < end; _cur_idx++) {
+                strs.emplace_back(string_at_index(_cur_idx));
+            }
+            nread -= r.span_size();
         }
-        if (dst->append_continuous_strings(strs)) {
+        if (range.size() == 1) {
+            if (dst->append_continuous_strings(strs)) {
+                return Status::OK();
+            }
+        } else if (dst->append_strings(strs)) {
             return Status::OK();
         }
     }

--- a/be/src/storage/rowset/segment_v2/binary_plain_page.cpp
+++ b/be/src/storage/rowset/segment_v2/binary_plain_page.cpp
@@ -26,7 +26,7 @@ Status BinaryPlainPageDecoder<Type>::next_batch(const vectorized::SparseRange& r
     strs.reserve(nread);
     vectorized::SparseRangeIterator iter = range.new_iterator();
     if constexpr (Type == OLAP_FIELD_TYPE_CHAR) {
-        while (iter.has_more() && nread > 0) {
+        while (nread > 0) {
             _cur_idx = iter.begin();
             vectorized::Range r = iter.next(nread);
             size_t end = _cur_idx + r.span_size();
@@ -41,7 +41,7 @@ Status BinaryPlainPageDecoder<Type>::next_batch(const vectorized::SparseRange& r
             return Status::OK();
         }
     } else {
-        while (iter.has_more() && nread > 0) {
+        while (nread > 0) {
             _cur_idx = iter.begin();
             vectorized::Range r = iter.next(nread);
             size_t end = _cur_idx + r.span_size();

--- a/be/src/storage/rowset/segment_v2/binary_plain_page.cpp
+++ b/be/src/storage/rowset/segment_v2/binary_plain_page.cpp
@@ -4,7 +4,6 @@
 
 namespace starrocks::segment_v2 {
 
-
 template <FieldType Type>
 Status BinaryPlainPageDecoder<Type>::next_batch(size_t* count, vectorized::Column* dst) {
     vectorized::SparseRange read_range;
@@ -27,7 +26,7 @@ Status BinaryPlainPageDecoder<Type>::next_batch(vectorized::SparseRange& range, 
     strs.reserve(nread);
     vectorized::SparseRangeIterator iter = range.new_iterator();
     if constexpr (Type == OLAP_FIELD_TYPE_CHAR) {
-        while(iter.has_more() && nread > 0) {
+        while (iter.has_more() && nread > 0) {
             _cur_idx = iter.begin();
             vectorized::Range r = iter.next(nread);
             size_t end = _cur_idx + r.span_size();
@@ -42,7 +41,7 @@ Status BinaryPlainPageDecoder<Type>::next_batch(vectorized::SparseRange& range, 
             return Status::OK();
         }
     } else {
-        while(iter.has_more() && nread > 0) {
+        while (iter.has_more() && nread > 0) {
             _cur_idx = iter.begin();
             vectorized::Range r = iter.next(nread);
             size_t end = _cur_idx + r.span_size();

--- a/be/src/storage/rowset/segment_v2/binary_plain_page.cpp
+++ b/be/src/storage/rowset/segment_v2/binary_plain_page.cpp
@@ -15,7 +15,7 @@ Status BinaryPlainPageDecoder<Type>::next_batch(size_t* count, vectorized::Colum
 }
 
 template <FieldType Type>
-Status BinaryPlainPageDecoder<Type>::next_batch(vectorized::SparseRange& range, vectorized::Column* dst) {
+Status BinaryPlainPageDecoder<Type>::next_batch(const vectorized::SparseRange& range, vectorized::Column* dst) {
     DCHECK(_parsed);
     if (PREDICT_FALSE(_cur_idx >= _num_elems)) {
         return Status::OK();

--- a/be/src/storage/rowset/segment_v2/binary_plain_page.h
+++ b/be/src/storage/rowset/segment_v2/binary_plain_page.h
@@ -41,9 +41,9 @@
 #include "storage/rowset/segment_v2/page_builder.h"
 #include "storage/rowset/segment_v2/page_decoder.h"
 #include "storage/types.h"
+#include "storage/vectorized/range.h"
 #include "util/coding.h"
 #include "util/faststring.h"
-#include "storage/vectorized/range.h"
 
 namespace starrocks::vectorized {
 class Column;

--- a/be/src/storage/rowset/segment_v2/binary_plain_page.h
+++ b/be/src/storage/rowset/segment_v2/binary_plain_page.h
@@ -229,7 +229,7 @@ public:
 
     Status next_batch(size_t* count, vectorized::Column* dst) override;
 
-    Status next_batch(vectorized::SparseRange& range, vectorized::Column* dst) override;
+    Status next_batch(const vectorized::SparseRange& range, vectorized::Column* dst) override;
 
     size_t count() const override {
         DCHECK(_parsed);

--- a/be/src/storage/rowset/segment_v2/binary_plain_page.h
+++ b/be/src/storage/rowset/segment_v2/binary_plain_page.h
@@ -43,6 +43,7 @@
 #include "storage/types.h"
 #include "util/coding.h"
 #include "util/faststring.h"
+#include "storage/vectorized/range.h"
 
 namespace starrocks::vectorized {
 class Column;
@@ -227,6 +228,8 @@ public:
     }
 
     Status next_batch(size_t* count, vectorized::Column* dst) override;
+
+    Status next_batch(vectorized::SparseRange& range, vectorized::Column* dst) override;
 
     size_t count() const override {
         DCHECK(_parsed);

--- a/be/src/storage/rowset/segment_v2/binary_prefix_page.cpp
+++ b/be/src/storage/rowset/segment_v2/binary_prefix_page.cpp
@@ -321,7 +321,7 @@ Status BinaryPrefixPageDecoder<Type>::next_batch(const vectorized::SparseRange& 
 
     vectorized::SparseRangeIterator iter = range.new_iterator();
     if constexpr (Type == OLAP_FIELD_TYPE_CHAR) {
-        while (iter.has_more() && nread > 0) {
+        while (nread > 0) {
             seek_to_position_in_page(iter.begin());
             bool ok = dst->append_strings({_current_value});
             DCHECK(ok);
@@ -334,7 +334,7 @@ Status BinaryPrefixPageDecoder<Type>::next_batch(const vectorized::SparseRange& 
             nread -= r.span_size();
         }
     } else {
-        while (iter.has_more() && nread > 0) {
+        while (nread > 0) {
             seek_to_position_in_page(iter.begin());
             bool ok = dst->append_strings({_current_value});
             DCHECK(ok);

--- a/be/src/storage/rowset/segment_v2/binary_prefix_page.cpp
+++ b/be/src/storage/rowset/segment_v2/binary_prefix_page.cpp
@@ -303,26 +303,47 @@ Status BinaryPrefixPageDecoder<Type>::_next_value(faststring* value) {
 
 template <FieldType Type>
 Status BinaryPrefixPageDecoder<Type>::next_batch(size_t* n, vectorized::Column* dst) {
+    vectorized::SparseRange read_range;
+    size_t begin = current_index();
+    read_range.add(vectorized::Range(begin, begin + *n));
+    RETURN_IF_ERROR(next_batch(read_range, dst));
+    *n = current_index() - begin + 1;
+    return Status::OK();
+}
+
+template <FieldType Type>
+Status BinaryPrefixPageDecoder<Type>::next_batch(vectorized::SparseRange& range, vectorized::Column* dst) {
     DCHECK(_parsed);
     if (PREDICT_FALSE(_cur_pos >= _num_values)) {
-        *n = 0;
         return Status::OK();
     }
-    *n = std::min(*n, static_cast<size_t>(_num_values - _cur_pos));
-    // FIXME: ???
-    [[maybe_unused]] bool ok = dst->append_strings({_current_value});
-    DCHECK(ok);
+    size_t nread = std::min(static_cast<size_t>(range.span_size()), static_cast<size_t>(_num_values - _cur_pos));
+
+    vectorized::SparseRangeIterator iter = range.new_iterator();
     if constexpr (Type == OLAP_FIELD_TYPE_CHAR) {
-        for (size_t i = 1; i < *n; ++i) {
-            RETURN_IF_ERROR(_next_value(&_current_value));
-            // remove trailing zeros.
-            size_t len = strnlen(reinterpret_cast<const char*>(_current_value.data()), _current_value.size());
-            (void)dst->append_strings({Slice(_current_value.data(), len)});
+        while (iter.has_more() && nread > 0) {
+            seek_to_position_in_page(iter.begin());
+            bool ok = dst->append_strings({_current_value});
+            DCHECK(ok);
+            vectorized::Range r = iter.next(nread);
+            for (size_t i = 1; i < r.span_size(); ++i) {
+                RETURN_IF_ERROR(_next_value(&_current_value));
+                size_t len = strnlen(reinterpret_cast<const char*>(_current_value.data()), _current_value.size());
+                (void)dst->append_strings({Slice(_current_value.data(), len)});
+            }
+            nread -= r.span_size();
         }
     } else {
-        for (size_t i = 1; i < *n; ++i) {
-            RETURN_IF_ERROR(_next_value(&_current_value));
-            (void)dst->append_strings({_current_value});
+        while (iter.has_more() && nread > 0) {
+            seek_to_position_in_page(iter.begin());
+            bool ok = dst->append_strings({_current_value});
+            DCHECK(ok);
+            vectorized::Range r = iter.next(nread);
+            for (size_t i = 1; i < r.span_size(); ++i) {
+                RETURN_IF_ERROR(_next_value(&_current_value));
+                (void)dst->append_strings({_current_value});
+            }
+            nread -= r.span_size();
         }
     }
     return Status::OK();

--- a/be/src/storage/rowset/segment_v2/binary_prefix_page.cpp
+++ b/be/src/storage/rowset/segment_v2/binary_prefix_page.cpp
@@ -312,7 +312,7 @@ Status BinaryPrefixPageDecoder<Type>::next_batch(size_t* n, vectorized::Column* 
 }
 
 template <FieldType Type>
-Status BinaryPrefixPageDecoder<Type>::next_batch(vectorized::SparseRange& range, vectorized::Column* dst) {
+Status BinaryPrefixPageDecoder<Type>::next_batch(const vectorized::SparseRange& range, vectorized::Column* dst) {
     DCHECK(_parsed);
     if (PREDICT_FALSE(_cur_pos >= _num_values)) {
         return Status::OK();

--- a/be/src/storage/rowset/segment_v2/binary_prefix_page.h
+++ b/be/src/storage/rowset/segment_v2/binary_prefix_page.h
@@ -35,6 +35,7 @@
 #include "util/coding.h"
 #include "util/faststring.h"
 #include "util/slice.h"
+#include "storage/vectorized/range.h"
 
 namespace starrocks {
 namespace segment_v2 {
@@ -117,6 +118,8 @@ public:
     Status next_batch(size_t* n, ColumnBlockView* dst) override;
 
     Status next_batch(size_t* n, vectorized::Column* dst) override;
+
+    Status next_batch(vectorized::SparseRange& range, vectorized::Column* dst) override;
 
     size_t count() const override {
         DCHECK(_parsed);

--- a/be/src/storage/rowset/segment_v2/binary_prefix_page.h
+++ b/be/src/storage/rowset/segment_v2/binary_prefix_page.h
@@ -32,10 +32,10 @@
 #include "storage/rowset/segment_v2/options.h"
 #include "storage/rowset/segment_v2/page_builder.h"
 #include "storage/rowset/segment_v2/page_decoder.h"
+#include "storage/vectorized/range.h"
 #include "util/coding.h"
 #include "util/faststring.h"
 #include "util/slice.h"
-#include "storage/vectorized/range.h"
 
 namespace starrocks {
 namespace segment_v2 {

--- a/be/src/storage/rowset/segment_v2/binary_prefix_page.h
+++ b/be/src/storage/rowset/segment_v2/binary_prefix_page.h
@@ -119,7 +119,7 @@ public:
 
     Status next_batch(size_t* n, vectorized::Column* dst) override;
 
-    Status next_batch(vectorized::SparseRange& range, vectorized::Column* dst) override;
+    Status next_batch(const vectorized::SparseRange& range, vectorized::Column* dst) override;
 
     size_t count() const override {
         DCHECK(_parsed);

--- a/be/src/storage/rowset/segment_v2/bitshuffle_page.h
+++ b/be/src/storage/rowset/segment_v2/bitshuffle_page.h
@@ -404,15 +404,15 @@ inline Status BitShufflePageDecoder<Type>::next_batch(const vectorized::SparseRa
         return Status::OK();
     }
 
-    size_t nread = std::min(static_cast<size_t>(range.span_size()), static_cast<size_t>(_num_elements - _cur_index));
+    size_t to_read = std::min(static_cast<size_t>(range.span_size()), static_cast<size_t>(_num_elements - _cur_index));
     vectorized::SparseRangeIterator iter = range.new_iterator();
-    while (iter.has_more() && nread > 0) {
+    while (iter.has_more() && to_read > 0) {
         _cur_index = iter.begin();
-        vectorized::Range r = iter.next(nread);
+        vectorized::Range r = iter.next(to_read);
         int n = dst->append_numbers(get_data(_cur_index * SIZE_OF_TYPE), r.span_size() * SIZE_OF_TYPE);
         DCHECK_EQ(r.span_size(), n);
         _cur_index += r.span_size();
-        nread -= r.span_size();
+        to_read -= r.span_size();
     }
     return Status::OK();
 }

--- a/be/src/storage/rowset/segment_v2/bitshuffle_page.h
+++ b/be/src/storage/rowset/segment_v2/bitshuffle_page.h
@@ -406,7 +406,7 @@ inline Status BitShufflePageDecoder<Type>::next_batch(const vectorized::SparseRa
 
     size_t to_read = std::min(static_cast<size_t>(range.span_size()), static_cast<size_t>(_num_elements - _cur_index));
     vectorized::SparseRangeIterator iter = range.new_iterator();
-    while (iter.has_more() && to_read > 0) {
+    while (to_read > 0) {
         _cur_index = iter.begin();
         vectorized::Range r = iter.next(to_read);
         int n = dst->append_numbers(get_data(_cur_index * SIZE_OF_TYPE), r.span_size() * SIZE_OF_TYPE);

--- a/be/src/storage/rowset/segment_v2/bitshuffle_page.h
+++ b/be/src/storage/rowset/segment_v2/bitshuffle_page.h
@@ -355,6 +355,8 @@ public:
 
     Status next_batch(size_t* count, vectorized::Column* dst) override;
 
+    Status next_batch(vectorized::SparseRange& range, vectorized::Column* dst) override;
+
     size_t count() const override { return _num_elements; }
 
     size_t current_index() const override { return _cur_index; }
@@ -385,18 +387,34 @@ private:
     bool _parsed;
 };
 
+
 template <FieldType Type>
 inline Status BitShufflePageDecoder<Type>::next_batch(size_t* count, vectorized::Column* dst) {
+    vectorized::SparseRange read_range;
+    size_t begin = current_index();
+    read_range.add(vectorized::Range(begin, begin + *count));
+    RETURN_IF_ERROR(next_batch(read_range, dst));
+    *count = current_index() - begin;
+    return Status::OK();
+}
+
+template <FieldType Type>
+inline Status BitShufflePageDecoder<Type>::next_batch(vectorized::SparseRange& range, vectorized::Column* dst) {
     DCHECK(_parsed);
     if (PREDICT_FALSE(_cur_index >= _num_elements)) {
-        *count = 0;
         return Status::OK();
     }
 
-    *count = std::min(*count, static_cast<size_t>(_num_elements - _cur_index));
-    int n = dst->append_numbers(get_data(_cur_index * SIZE_OF_TYPE), *count * SIZE_OF_TYPE);
-    DCHECK_EQ(*count, n);
-    _cur_index += *count;
+    size_t nread = std::min(static_cast<size_t>(range.span_size()), static_cast<size_t>(_num_elements - _cur_index));
+    vectorized::SparseRangeIterator iter = range.new_iterator();
+    while (iter.has_more() && nread > 0) {
+        _cur_index = iter.begin();
+        vectorized::Range r = iter.next(nread);
+        int n = dst->append_numbers(get_data(_cur_index * SIZE_OF_TYPE), r.span_size() * SIZE_OF_TYPE);
+        DCHECK_EQ(r.span_size(), n);
+        _cur_index += r.span_size();
+        nread -= r.span_size();
+    }
     return Status::OK();
 }
 

--- a/be/src/storage/rowset/segment_v2/bitshuffle_page.h
+++ b/be/src/storage/rowset/segment_v2/bitshuffle_page.h
@@ -355,7 +355,7 @@ public:
 
     Status next_batch(size_t* count, vectorized::Column* dst) override;
 
-    Status next_batch(vectorized::SparseRange& range, vectorized::Column* dst) override;
+    Status next_batch(const vectorized::SparseRange& range, vectorized::Column* dst) override;
 
     size_t count() const override { return _num_elements; }
 
@@ -398,7 +398,7 @@ inline Status BitShufflePageDecoder<Type>::next_batch(size_t* count, vectorized:
 }
 
 template <FieldType Type>
-inline Status BitShufflePageDecoder<Type>::next_batch(vectorized::SparseRange& range, vectorized::Column* dst) {
+inline Status BitShufflePageDecoder<Type>::next_batch(const vectorized::SparseRange& range, vectorized::Column* dst) {
     DCHECK(_parsed);
     if (PREDICT_FALSE(_cur_index >= _num_elements)) {
         return Status::OK();

--- a/be/src/storage/rowset/segment_v2/bitshuffle_page.h
+++ b/be/src/storage/rowset/segment_v2/bitshuffle_page.h
@@ -387,7 +387,6 @@ private:
     bool _parsed;
 };
 
-
 template <FieldType Type>
 inline Status BitShufflePageDecoder<Type>::next_batch(size_t* count, vectorized::Column* dst) {
     vectorized::SparseRange read_range;

--- a/be/src/storage/rowset/segment_v2/column_iterator.h
+++ b/be/src/storage/rowset/segment_v2/column_iterator.h
@@ -98,7 +98,7 @@ public:
 
     virtual Status next_batch(size_t* n, vectorized::Column* dst) = 0;
 
-    virtual Status next_batch(vectorized::SparseRange& range, vectorized::Column* dst) {
+    virtual Status next_batch(const vectorized::SparseRange& range, vectorized::Column* dst) {
         return Status::NotSupported("ColumnIterator Not Support batch read");
     }
 
@@ -136,7 +136,7 @@ public:
     // type of |dst| must be `FixedLengthColumn<int32_t>` or `NullableColumn(FixedLengthColumn<int32_t>)`.
     virtual Status next_dict_codes(size_t* n, vectorized::Column* dst) { return Status::NotSupported(""); }
 
-    virtual Status next_dict_codes(vectorized::SparseRange& range, vectorized::Column* dst) {
+    virtual Status next_dict_codes(const vectorized::SparseRange& range, vectorized::Column* dst) {
         return Status::NotSupported("");
     }
 

--- a/be/src/storage/rowset/segment_v2/column_iterator.h
+++ b/be/src/storage/rowset/segment_v2/column_iterator.h
@@ -136,7 +136,9 @@ public:
     // type of |dst| must be `FixedLengthColumn<int32_t>` or `NullableColumn(FixedLengthColumn<int32_t>)`.
     virtual Status next_dict_codes(size_t* n, vectorized::Column* dst) { return Status::NotSupported(""); }
 
-    virtual Status next_dict_codes(vectorized::SparseRange& range, vectorized::Column* dst) { return Status::NotSupported(""); }
+    virtual Status next_dict_codes(vectorized::SparseRange& range, vectorized::Column* dst) {
+        return Status::NotSupported("");
+    }
 
     // given a list of dictionary codes, fill |dst| column with the decoded values.
     // |codes| pointer to the array of dictionary codes.

--- a/be/src/storage/rowset/segment_v2/column_iterator.h
+++ b/be/src/storage/rowset/segment_v2/column_iterator.h
@@ -98,6 +98,10 @@ public:
 
     virtual Status next_batch(size_t* n, vectorized::Column* dst) = 0;
 
+    virtual Status next_batch(vectorized::SparseRange& range, vectorized::Column* dst) {
+        return Status::NotSupported("ColumnIterator Not Support batch read");
+    }
+
     virtual ordinal_t get_current_ordinal() const = 0;
 
     /// for vectorized engine
@@ -131,6 +135,8 @@ public:
     // this method can be invoked only if `all_page_dict_encoded` returns true.
     // type of |dst| must be `FixedLengthColumn<int32_t>` or `NullableColumn(FixedLengthColumn<int32_t>)`.
     virtual Status next_dict_codes(size_t* n, vectorized::Column* dst) { return Status::NotSupported(""); }
+
+    virtual Status next_dict_codes(vectorized::SparseRange& range, vectorized::Column* dst) { return Status::NotSupported(""); }
 
     // given a list of dictionary codes, fill |dst| column with the decoded values.
     // |codes| pointer to the array of dictionary codes.

--- a/be/src/storage/rowset/segment_v2/default_value_column_iterator.cpp
+++ b/be/src/storage/rowset/segment_v2/default_value_column_iterator.cpp
@@ -126,22 +126,22 @@ Status DefaultValueColumnIterator::next_batch(size_t* n, vectorized::Column* dst
 }
 
 Status DefaultValueColumnIterator::next_batch(const vectorized::SparseRange& range, vectorized::Column* dst) {
-    size_t nread = range.span_size();
+    size_t to_read = range.span_size();
     if (_is_default_value_null) {
-        [[maybe_unused]] bool ok = dst->append_nulls(nread);
+        [[maybe_unused]] bool ok = dst->append_nulls(to_read);
         _current_rowid = range.end();
         DCHECK(ok) << "cannot append null to non-nullable column";
     } else {
         if (_type_info->type() == OLAP_FIELD_TYPE_OBJECT || _type_info->type() == OLAP_FIELD_TYPE_HLL ||
             _type_info->type() == OLAP_FIELD_TYPE_PERCENTILE) {
             std::vector<Slice> slices;
-            slices.reserve(nread);
-            for (size_t i = 0; i < nread; i++) {
+            slices.reserve(to_read);
+            for (size_t i = 0; i < to_read; i++) {
                 slices.emplace_back(*reinterpret_cast<const Slice*>(_mem_value));
             }
             dst->append_strings(slices);
         } else {
-            dst->append_value_multiple_times(_mem_value, nread);
+            dst->append_value_multiple_times(_mem_value, to_read);
         }
         _current_rowid = range.end();
     }

--- a/be/src/storage/rowset/segment_v2/default_value_column_iterator.cpp
+++ b/be/src/storage/rowset/segment_v2/default_value_column_iterator.cpp
@@ -125,7 +125,7 @@ Status DefaultValueColumnIterator::next_batch(size_t* n, vectorized::Column* dst
     return Status::OK();
 }
 
-Status DefaultValueColumnIterator::next_batch(vectorized::SparseRange& range, vectorized::Column* dst) {
+Status DefaultValueColumnIterator::next_batch(const vectorized::SparseRange& range, vectorized::Column* dst) {
     size_t nread = range.span_size();
     if (_is_default_value_null) {
         [[maybe_unused]] bool ok = dst->append_nulls(nread);

--- a/be/src/storage/rowset/segment_v2/default_value_column_iterator.h
+++ b/be/src/storage/rowset/segment_v2/default_value_column_iterator.h
@@ -63,6 +63,8 @@ public:
 
     Status next_batch(size_t* n, vectorized::Column* dst) override;
 
+    Status next_batch(vectorized::SparseRange& range, vectorized::Column* dst) override;
+
     ordinal_t get_current_ordinal() const override { return _current_rowid; }
 
     Status get_row_ranges_by_zone_map(const std::vector<const vectorized::ColumnPredicate*>& predicates,

--- a/be/src/storage/rowset/segment_v2/default_value_column_iterator.h
+++ b/be/src/storage/rowset/segment_v2/default_value_column_iterator.h
@@ -63,7 +63,7 @@ public:
 
     Status next_batch(size_t* n, vectorized::Column* dst) override;
 
-    Status next_batch(vectorized::SparseRange& range, vectorized::Column* dst) override;
+    Status next_batch(const vectorized::SparseRange& range, vectorized::Column* dst) override;
 
     ordinal_t get_current_ordinal() const override { return _current_rowid; }
 

--- a/be/src/storage/rowset/segment_v2/dictcode_column_iterator.h
+++ b/be/src/storage/rowset/segment_v2/dictcode_column_iterator.h
@@ -28,7 +28,7 @@ public:
 
     Status next_batch(size_t* n, Column* dst) override { return _col_iter->next_dict_codes(n, dst); }
 
-    Status next_batch(vectorized::SparseRange& range, Column* dst) override {
+    Status next_batch(const vectorized::SparseRange& range, Column* dst) override {
         return _col_iter->next_dict_codes(range, dst);
     }
 
@@ -87,7 +87,7 @@ public:
 
     Status next_batch(size_t* n, Column* dst) override { return _col_iter->next_dict_codes(n, dst); }
 
-    Status next_batch(vectorized::SparseRange& range, Column* dst) override {
+    Status next_batch(const vectorized::SparseRange& range, Column* dst) override {
         return _col_iter->next_dict_codes(range, dst);
     }
 

--- a/be/src/storage/rowset/segment_v2/dictcode_column_iterator.h
+++ b/be/src/storage/rowset/segment_v2/dictcode_column_iterator.h
@@ -7,6 +7,7 @@
 #include "column/column.h"
 #include "runtime/global_dicts.h"
 #include "storage/rowset/segment_v2/column_iterator.h"
+#include "storage/vectorized/range.h"
 
 namespace starrocks::segment_v2 {
 // DictCodeColumnIterator is a wrapper/proxy on another column iterator that will
@@ -26,6 +27,10 @@ public:
     ColumnIterator* column_iterator() const { return _col_iter; }
 
     Status next_batch(size_t* n, Column* dst) override { return _col_iter->next_dict_codes(n, dst); }
+
+    Status next_batch(vectorized::SparseRange& range, Column* dst) override {
+        return _col_iter->next_dict_codes(range, dst);
+    }
 
     Status fetch_values_by_rowid(const rowid_t* rowids, size_t size, vectorized::Column* values) override {
         return _col_iter->fetch_values_by_rowid(rowids, size, values);
@@ -81,6 +86,10 @@ public:
     ColumnIterator* column_iterator() const { return _col_iter; }
 
     Status next_batch(size_t* n, Column* dst) override { return _col_iter->next_dict_codes(n, dst); }
+
+    Status next_batch(vectorized::SparseRange& range, Column* dst) override {
+        return _col_iter->next_dict_codes(range, dst);
+    }
 
     Status fetch_values_by_rowid(const rowid_t* rowids, size_t size, vectorized::Column* values) override {
         if (_local_dict_code_col == nullptr) {

--- a/be/src/storage/rowset/segment_v2/frame_of_reference_page.h
+++ b/be/src/storage/rowset/segment_v2/frame_of_reference_page.h
@@ -195,19 +195,19 @@ public:
                       Type == OLAP_FIELD_TYPE_DECIMAL128,
                       "unexpected field type");
         // clang-format on
-        size_t nread =
+        size_t to_read =
                 std::min(static_cast<size_t>(range.span_size()), static_cast<size_t>(_num_elements - _cur_index));
         vectorized::SparseRangeIterator iter = range.new_iterator();
         while (iter.has_more() && _cur_index < _num_elements) {
             seek_to_position_in_page(iter.begin());
-            vectorized::Range r = iter.next(nread);
+            vectorized::Range r = iter.next(to_read);
             const size_t ori_size = dst->size();
             dst->resize(ori_size + r.span_size());
             auto* p = reinterpret_cast<CppType*>(dst->mutable_raw_data()) + ori_size;
             bool res = _decoder.get_batch(p, r.span_size());
             DCHECK(res);
             _cur_index += r.span_size();
-            nread -= r.span_size();
+            to_read -= r.span_size();
         }
         return Status::OK();
     }

--- a/be/src/storage/rowset/segment_v2/frame_of_reference_page.h
+++ b/be/src/storage/rowset/segment_v2/frame_of_reference_page.h
@@ -165,9 +165,17 @@ public:
     }
 
     Status next_batch(size_t* n, vectorized::Column* dst) override {
+        vectorized::SparseRange read_range;
+        size_t begin = current_index();
+        read_range.add(vectorized::Range(begin, begin + *n));
+        RETURN_IF_ERROR(next_batch(read_range, dst));
+        *n = current_index() - begin;
+        return Status::OK();
+    }
+
+    Status next_batch(vectorized::SparseRange& range, vectorized::Column* dst) override {
         DCHECK(_parsed) << "Must call init() firstly";
-        if (PREDICT_FALSE(*n == 0 || _cur_index >= _num_elements)) {
-            *n = 0;
+        if (PREDICT_FALSE(range.span_size() == 0 || _cur_index >= _num_elements)) {
             return Status::OK();
         }
 
@@ -187,14 +195,19 @@ public:
                       Type == OLAP_FIELD_TYPE_DECIMAL128,
                       "unexpected field type");
         // clang-format on
-
-        *n = std::min(*n, _num_elements - _cur_index);
-        const size_t ori_size = dst->size();
-        dst->resize(ori_size + *n);
-        auto* p = reinterpret_cast<CppType*>(dst->mutable_raw_data()) + ori_size;
-        bool r = _decoder.get_batch(p, *n);
-        DCHECK(r);
-        _cur_index += *n;
+        size_t nread = std::min(static_cast<size_t>(range.span_size()), static_cast<size_t>(_num_elements - _cur_index));
+        vectorized::SparseRangeIterator iter = range.new_iterator();
+        while (iter.has_more() && _cur_index < _num_elements) {
+            seek_to_position_in_page(iter.begin());
+            vectorized::Range r = iter.next(nread);
+            const size_t ori_size = dst->size();
+            dst->resize(ori_size + r.span_size());
+            auto* p = reinterpret_cast<CppType*>(dst->mutable_raw_data()) + ori_size;
+            bool res = _decoder.get_batch(p, r.span_size());
+            DCHECK(res);
+            _cur_index += r.span_size();
+            nread -= r.span_size();
+        }
         return Status::OK();
     }
 

--- a/be/src/storage/rowset/segment_v2/frame_of_reference_page.h
+++ b/be/src/storage/rowset/segment_v2/frame_of_reference_page.h
@@ -195,7 +195,8 @@ public:
                       Type == OLAP_FIELD_TYPE_DECIMAL128,
                       "unexpected field type");
         // clang-format on
-        size_t nread = std::min(static_cast<size_t>(range.span_size()), static_cast<size_t>(_num_elements - _cur_index));
+        size_t nread =
+                std::min(static_cast<size_t>(range.span_size()), static_cast<size_t>(_num_elements - _cur_index));
         vectorized::SparseRangeIterator iter = range.new_iterator();
         while (iter.has_more() && _cur_index < _num_elements) {
             seek_to_position_in_page(iter.begin());

--- a/be/src/storage/rowset/segment_v2/frame_of_reference_page.h
+++ b/be/src/storage/rowset/segment_v2/frame_of_reference_page.h
@@ -198,7 +198,7 @@ public:
         size_t to_read =
                 std::min(static_cast<size_t>(range.span_size()), static_cast<size_t>(_num_elements - _cur_index));
         vectorized::SparseRangeIterator iter = range.new_iterator();
-        while (iter.has_more() && _cur_index < _num_elements) {
+        while (to_read > 0 && _cur_index < _num_elements) {
             seek_to_position_in_page(iter.begin());
             vectorized::Range r = iter.next(to_read);
             const size_t ori_size = dst->size();

--- a/be/src/storage/rowset/segment_v2/frame_of_reference_page.h
+++ b/be/src/storage/rowset/segment_v2/frame_of_reference_page.h
@@ -173,7 +173,7 @@ public:
         return Status::OK();
     }
 
-    Status next_batch(vectorized::SparseRange& range, vectorized::Column* dst) override {
+    Status next_batch(const vectorized::SparseRange& range, vectorized::Column* dst) override {
         DCHECK(_parsed) << "Must call init() firstly";
         if (PREDICT_FALSE(range.span_size() == 0 || _cur_index >= _num_elements)) {
             return Status::OK();

--- a/be/src/storage/rowset/segment_v2/page_decoder.h
+++ b/be/src/storage/rowset/segment_v2/page_decoder.h
@@ -27,6 +27,7 @@
 #include "storage/column_block.h" // for ColumnBlockView
 #include "storage/fs/block_manager.h"
 #include "storage/rowset/segment_v2/page_pointer.h"
+#include "storage/vectorized/range.h"
 
 namespace starrocks::vectorized {
 class Column;
@@ -97,6 +98,10 @@ public:
         return Status::NotSupported("vectorized not supported yet");
     }
 
+    virtual Status next_batch(vectorized::SparseRange& range, vectorized::Column* column) {
+        return Status::NotSupported("PageDecoder Not Support");
+    }
+
     // Return the number of elements in this page.
     virtual size_t count() const = 0;
 
@@ -111,6 +116,10 @@ public:
     virtual EncodingTypePB encoding_type() const = 0;
 
     virtual Status next_dict_codes(size_t* n, vectorized::Column* dst) {
+        return Status::NotSupported("next_dict_codes() not supported");
+    }
+
+    virtual Status next_dict_codes(vectorized::SparseRange& range, vectorized::Column* dst) {
         return Status::NotSupported("next_dict_codes() not supported");
     }
 

--- a/be/src/storage/rowset/segment_v2/page_decoder.h
+++ b/be/src/storage/rowset/segment_v2/page_decoder.h
@@ -98,7 +98,7 @@ public:
         return Status::NotSupported("vectorized not supported yet");
     }
 
-    virtual Status next_batch(vectorized::SparseRange& range, vectorized::Column* column) {
+    virtual Status next_batch(const vectorized::SparseRange& range, vectorized::Column* column) {
         return Status::NotSupported("PageDecoder Not Support");
     }
 
@@ -119,7 +119,7 @@ public:
         return Status::NotSupported("next_dict_codes() not supported");
     }
 
-    virtual Status next_dict_codes(vectorized::SparseRange& range, vectorized::Column* dst) {
+    virtual Status next_dict_codes(const vectorized::SparseRange& range, vectorized::Column* dst) {
         return Status::NotSupported("next_dict_codes() not supported");
     }
 

--- a/be/src/storage/rowset/segment_v2/parsed_page.cpp
+++ b/be/src/storage/rowset/segment_v2/parsed_page.cpp
@@ -221,7 +221,6 @@ public:
         return Status::OK();
     }
 
-
 private:
     friend Status parse_page_v1(std::unique_ptr<ParsedPage>* result, PageHandle handle, const Slice& body,
                                 const DataPageFooterPB& footer, const EncodingInfo* encoding,
@@ -277,7 +276,6 @@ public:
         }
         return Status::OK();
     }
-
 
     Status read(ColumnBlockView* block, size_t* count) override {
         DCHECK_EQ(_offset_in_page, _data_decoder->current_index());

--- a/be/src/storage/rowset/segment_v2/parsed_page.cpp
+++ b/be/src/storage/rowset/segment_v2/parsed_page.cpp
@@ -119,7 +119,7 @@ public:
         return Status::OK();
     }
 
-    Status read(vectorized::Column* column, vectorized::SparseRange& range) override {
+    Status read(vectorized::Column* column, const vectorized::SparseRange& range) override {
         DCHECK_LE(range.span_size(), remaining());
         if (_has_null) {
             vectorized::SparseRangeIterator iter = range.new_iterator();
@@ -202,7 +202,7 @@ public:
         return Status::OK();
     }
 
-    Status read_dict_codes(vectorized::Column* column, vectorized::SparseRange& range) override {
+    Status read_dict_codes(vectorized::Column* column, const vectorized::SparseRange& range) override {
         DCHECK_LE(range.span_size(), remaining());
         if (_has_null) {
             size_t nread = range.span_size();
@@ -255,7 +255,7 @@ public:
         return Status::OK();
     }
 
-    Status read(vectorized::Column* column, vectorized::SparseRange& range) override {
+    Status read(vectorized::Column* column, const vectorized::SparseRange& range) override {
         DCHECK_EQ(_offset_in_page, range.begin());
         DCHECK_EQ(_offset_in_page, _data_decoder->current_index());
         if (_null_flags.size() == 0) {
@@ -271,6 +271,7 @@ public:
                 vectorized::Range r = iter.next(size);
                 nc->null_column()->append_numbers(_null_flags.data() + _offset_in_page, r.span_size());
                 _offset_in_page += r.span_size();
+                size -= r.span_size();
             }
             nc->update_has_null();
         }
@@ -310,7 +311,7 @@ public:
         return Status::OK();
     }
 
-    Status read_dict_codes(vectorized::Column* column, vectorized::SparseRange& range) override {
+    Status read_dict_codes(vectorized::Column* column, const vectorized::SparseRange& range) override {
         DCHECK_EQ(_offset_in_page, range.begin());
         DCHECK_EQ(_offset_in_page, _data_decoder->current_index());
 

--- a/be/src/storage/rowset/segment_v2/parsed_page.cpp
+++ b/be/src/storage/rowset/segment_v2/parsed_page.cpp
@@ -119,6 +119,24 @@ public:
         return Status::OK();
     }
 
+    Status read(vectorized::Column* column, vectorized::SparseRange& range) override {
+        DCHECK_LE(range.span_size(), remaining());
+        if (_has_null) {
+            vectorized::SparseRangeIterator iter = range.new_iterator();
+            size_t nread = range.span_size();
+            while (iter.has_more()) {
+                vectorized::Range r = iter.next(nread);
+                RETURN_IF_ERROR(seek(r.begin()));
+                size_t n = r.span_size();
+                RETURN_IF_ERROR(read(column, &n));
+            }
+        } else {
+            RETURN_IF_ERROR(_data_decoder->next_batch(range, column));
+            _offset_in_page = range.end();
+        }
+        return Status::OK();
+    }
+
     Status read(ColumnBlockView* block, size_t* count) override {
         *count = std::min(*count, remaining());
         size_t nrows_to_read = *count;
@@ -184,6 +202,26 @@ public:
         return Status::OK();
     }
 
+    Status read_dict_codes(vectorized::Column* column, vectorized::SparseRange& range) override {
+        DCHECK_LE(range.span_size(), remaining());
+        if (_has_null) {
+            size_t nread = range.span_size();
+            vectorized::SparseRangeIterator iter = range.new_iterator();
+            while (iter.has_more()) {
+                vectorized::Range r = iter.next(nread);
+                RETURN_IF_ERROR(seek(r.begin()));
+                size_t n = r.span_size();
+                RETURN_IF_ERROR(read_dict_codes(column, &n));
+            }
+        } else {
+            RETURN_IF_ERROR(_data_decoder->next_dict_codes(range, column));
+            _offset_in_page = range.end();
+        }
+
+        return Status::OK();
+    }
+
+
 private:
     friend Status parse_page_v1(std::unique_ptr<ParsedPage>* result, PageHandle handle, const Slice& body,
                                 const DataPageFooterPB& footer, const EncodingInfo* encoding,
@@ -218,6 +256,29 @@ public:
         return Status::OK();
     }
 
+    Status read(vectorized::Column* column, vectorized::SparseRange& range) override {
+        DCHECK_EQ(_offset_in_page, range.begin());
+        DCHECK_EQ(_offset_in_page, _data_decoder->current_index());
+        if (_null_flags.size() == 0) {
+            RETURN_IF_ERROR(_data_decoder->next_batch(range, column));
+            _offset_in_page = range.end();
+        } else {
+            auto nc = down_cast<vectorized::NullableColumn*>(column);
+            RETURN_IF_ERROR(_data_decoder->next_batch(range, nc->data_column().get()));
+            vectorized::SparseRangeIterator iter = range.new_iterator();
+            size_t size = range.span_size();
+            while (iter.has_more()) {
+                _offset_in_page = iter.begin();
+                vectorized::Range r = iter.next(size);
+                nc->null_column()->append_numbers(_null_flags.data() + _offset_in_page, r.span_size());
+                _offset_in_page += r.span_size();
+            }
+            nc->update_has_null();
+        }
+        return Status::OK();
+    }
+
+
     Status read(ColumnBlockView* block, size_t* count) override {
         DCHECK_EQ(_offset_in_page, _data_decoder->current_index());
         RETURN_IF_ERROR(_data_decoder->next_batch(count, block));
@@ -248,6 +309,30 @@ public:
             nc->update_has_null();
         }
         _offset_in_page += *count;
+        return Status::OK();
+    }
+
+    Status read_dict_codes(vectorized::Column* column, vectorized::SparseRange& range) override {
+        DCHECK_EQ(_offset_in_page, range.begin());
+        DCHECK_EQ(_offset_in_page, _data_decoder->current_index());
+
+        if (_null_flags.size() == 0) {
+            RETURN_IF_ERROR(_data_decoder->next_dict_codes(range, column));
+            _offset_in_page = range.end();
+        } else {
+            auto nc = down_cast<vectorized::NullableColumn*>(column);
+            RETURN_IF_ERROR(_data_decoder->next_dict_codes(range, nc->data_column().get()));
+            vectorized::SparseRangeIterator iter = range.new_iterator();
+            size_t size = range.span_size();
+            while (iter.has_more()) {
+                _offset_in_page = iter.begin();
+                vectorized::Range r = iter.next(size);
+                nc->null_column()->append_numbers(_null_flags.data() + _offset_in_page, r.span_size());
+                _offset_in_page += r.span_size();
+            }
+            nc->update_has_null();
+        }
+
         return Status::OK();
     }
 

--- a/be/src/storage/rowset/segment_v2/parsed_page.h
+++ b/be/src/storage/rowset/segment_v2/parsed_page.h
@@ -26,6 +26,7 @@
 #include "storage/rowset/segment_v2/common.h" // ordinal_t
 #include "storage/rowset/segment_v2/page_decoder.h"
 #include "storage/rowset/segment_v2/page_pointer.h"
+#include "storage/vectorized/range.h"
 
 namespace starrocks {
 class ColumnBlockView;
@@ -87,6 +88,10 @@ public:
     // On error, the value of |*count| is undefined.
     virtual Status read(vectorized::Column* column, size_t* count) = 0;
 
+    virtual Status read(vectorized::Column* column, vectorized::SparseRange& range) {
+        return Status::NotSupported("ParsedPage Not Support");
+    }
+
     // Attempts to read up to |*count| records from this page into the |block|.
     // On success, `Status::OK` is returned, and the number of records read will be updated to
     // |count|, the page offset is advanced by this number too. This number is the minimum value
@@ -105,6 +110,8 @@ public:
     // dictionary page, i.e, using these codes to lookup the dictionary page is safe.
     // On error, the value of |*count| is undefined.
     virtual Status read_dict_codes(vectorized::Column* column, size_t* count) = 0;
+
+    virtual Status read_dict_codes(vectorized::Column* column, vectorized::SparseRange& range) = 0;
 
 protected:
     uint32_t _page_index{0};

--- a/be/src/storage/rowset/segment_v2/parsed_page.h
+++ b/be/src/storage/rowset/segment_v2/parsed_page.h
@@ -88,8 +88,8 @@ public:
     // On error, the value of |*count| is undefined.
     virtual Status read(vectorized::Column* column, size_t* count) = 0;
 
-    virtual Status read(vectorized::Column* column, vectorized::SparseRange& range) {
-        return Status::NotSupported("ParsedPage Not Support");
+    virtual Status read(vectorized::Column* column, const vectorized::SparseRange& range) {
+        return Status::NotSupported("Read by range Not Support");
     }
 
     // Attempts to read up to |*count| records from this page into the |block|.
@@ -111,7 +111,7 @@ public:
     // On error, the value of |*count| is undefined.
     virtual Status read_dict_codes(vectorized::Column* column, size_t* count) = 0;
 
-    virtual Status read_dict_codes(vectorized::Column* column, vectorized::SparseRange& range) = 0;
+    virtual Status read_dict_codes(vectorized::Column* column, const vectorized::SparseRange& range) = 0;
 
 protected:
     uint32_t _page_index{0};

--- a/be/src/storage/rowset/segment_v2/plain_page.h
+++ b/be/src/storage/rowset/segment_v2/plain_page.h
@@ -217,15 +217,15 @@ public:
     Status next_batch(const vectorized::SparseRange& range, vectorized::Column* dst) override {
         DCHECK(_parsed);
 
-        size_t nread = range.span_size();
-        if (PREDICT_FALSE(nread == 0 || _cur_idx >= _num_elems)) {
+        size_t to_read = range.span_size();
+        if (PREDICT_FALSE(to_read == 0 || _cur_idx >= _num_elems)) {
             return Status::OK();
         }
 
         vectorized::SparseRangeIterator iter = range.new_iterator();
         while (iter.has_more() && _cur_idx < _num_elems) {
             _cur_idx = iter.begin();
-            vectorized::Range r = iter.next(nread);
+            vectorized::Range r = iter.next(to_read);
             size_t max_fetch = std::min(r.span_size(), _num_elems - _cur_idx);
             int n = dst->append_numbers(&_data[PLAIN_PAGE_HEADER_SIZE + _cur_idx * SIZE_OF_TYPE],
                                         max_fetch * SIZE_OF_TYPE);

--- a/be/src/storage/rowset/segment_v2/plain_page.h
+++ b/be/src/storage/rowset/segment_v2/plain_page.h
@@ -28,6 +28,7 @@
 #include "storage/types.h"
 #include "util/coding.h"
 #include "util/faststring.h"
+#include "storage/vectorized/range.h"
 
 namespace starrocks {
 namespace segment_v2 {
@@ -189,7 +190,7 @@ public:
         return Status::OK();
     }
 
-    Status next_batch(size_t* n, ColumnBlockView* dst) override {
+    Status next_batch(size_t* n, ColumnBlockView* dst) override {    
         DCHECK(_parsed);
 
         if (PREDICT_FALSE(*n == 0 || _cur_idx >= _num_elems)) {
@@ -205,19 +206,32 @@ public:
     }
 
     Status next_batch(size_t* count, vectorized::Column* dst) override {
+        vectorized::SparseRange read_range;
+        size_t begin = current_index();
+        read_range.add(vectorized::Range(begin, begin + *count));
+        RETURN_IF_ERROR(next_batch(read_range, dst));
+        *count = current_index() - begin;
+        return Status::OK();
+    }
+
+    Status next_batch(vectorized::SparseRange& range, vectorized::Column* dst) override {
         DCHECK(_parsed);
 
-        if (PREDICT_FALSE(*count == 0 || _cur_idx >= _num_elems)) {
-            *count = 0;
+        size_t nread = range.span_size();
+        if (PREDICT_FALSE(nread == 0 || _cur_idx >= _num_elems)) {
             return Status::OK();
         }
 
-        size_t max_fetch = std::min(*count, static_cast<size_t>(_num_elems - _cur_idx));
-        int n = dst->append_numbers(&_data[PLAIN_PAGE_HEADER_SIZE + _cur_idx * SIZE_OF_TYPE], max_fetch * SIZE_OF_TYPE);
-        DCHECK_EQ(max_fetch, n);
-        _cur_idx += max_fetch;
-        *count = max_fetch;
-        return Status::OK();
+        vectorized::SparseRangeIterator iter = range.new_iterator();
+        while (iter.has_more() && _cur_idx < _num_elems) {
+            _cur_idx = iter.begin();
+            vectorized::Range r = iter.next(nread);
+            size_t max_fetch = std::min(r.span_size(), _num_elems - _cur_idx);
+            int n = dst->append_numbers(&_data[PLAIN_PAGE_HEADER_SIZE + _cur_idx * SIZE_OF_TYPE], max_fetch * SIZE_OF_TYPE);
+            DCHECK_EQ(max_fetch, n);
+            _cur_idx += max_fetch;
+        }
+        return Status::OK();     
     }
 
     size_t count() const override {

--- a/be/src/storage/rowset/segment_v2/plain_page.h
+++ b/be/src/storage/rowset/segment_v2/plain_page.h
@@ -26,9 +26,9 @@
 #include "storage/rowset/segment_v2/page_builder.h"
 #include "storage/rowset/segment_v2/page_decoder.h"
 #include "storage/types.h"
+#include "storage/vectorized/range.h"
 #include "util/coding.h"
 #include "util/faststring.h"
-#include "storage/vectorized/range.h"
 
 namespace starrocks {
 namespace segment_v2 {
@@ -190,7 +190,7 @@ public:
         return Status::OK();
     }
 
-    Status next_batch(size_t* n, ColumnBlockView* dst) override {    
+    Status next_batch(size_t* n, ColumnBlockView* dst) override {
         DCHECK(_parsed);
 
         if (PREDICT_FALSE(*n == 0 || _cur_idx >= _num_elems)) {
@@ -227,11 +227,12 @@ public:
             _cur_idx = iter.begin();
             vectorized::Range r = iter.next(nread);
             size_t max_fetch = std::min(r.span_size(), _num_elems - _cur_idx);
-            int n = dst->append_numbers(&_data[PLAIN_PAGE_HEADER_SIZE + _cur_idx * SIZE_OF_TYPE], max_fetch * SIZE_OF_TYPE);
+            int n = dst->append_numbers(&_data[PLAIN_PAGE_HEADER_SIZE + _cur_idx * SIZE_OF_TYPE],
+                                        max_fetch * SIZE_OF_TYPE);
             DCHECK_EQ(max_fetch, n);
             _cur_idx += max_fetch;
         }
-        return Status::OK();     
+        return Status::OK();
     }
 
     size_t count() const override {

--- a/be/src/storage/rowset/segment_v2/plain_page.h
+++ b/be/src/storage/rowset/segment_v2/plain_page.h
@@ -214,7 +214,7 @@ public:
         return Status::OK();
     }
 
-    Status next_batch(vectorized::SparseRange& range, vectorized::Column* dst) override {
+    Status next_batch(const vectorized::SparseRange& range, vectorized::Column* dst) override {
         DCHECK(_parsed);
 
         size_t nread = range.span_size();

--- a/be/src/storage/rowset/segment_v2/rle_page.h
+++ b/be/src/storage/rowset/segment_v2/rle_page.h
@@ -28,6 +28,7 @@
 #include "util/coding.h"
 #include "util/rle_encoding.h"
 #include "util/slice.h"
+#include "storage/vectorized/range.h"
 
 namespace starrocks {
 namespace segment_v2 {
@@ -213,23 +214,38 @@ public:
     }
 
     Status next_batch(size_t* n, vectorized::Column* dst) override {
+        vectorized::SparseRange read_range;
+        size_t begin = current_index();
+        read_range.add(vectorized::Range(begin, begin + *n));
+        RETURN_IF_ERROR(next_batch(read_range, dst));
+        *n = current_index() - begin;
+        return Status::OK();
+    }
+
+    Status next_batch(vectorized::SparseRange& range, vectorized::Column* dst) override {
         DCHECK(_parsed);
         if (PREDICT_FALSE(_cur_index >= _num_elements)) {
-            *n = 0;
             return Status::OK();
         }
         CppType value{};
-        *n = std::min(*n, static_cast<size_t>(_num_elements - _cur_index));
-        for (size_t i = 0; i < *n; i++) {
-            if (PREDICT_FALSE(!_rle_decoder.Get(&value))) {
-                return Status::Corruption("RLE decode failed");
+
+        size_t nread = std::min(static_cast<size_t>(range.span_size()), static_cast<size_t>(_num_elements - _cur_index));
+        vectorized::SparseRangeIterator iter = range.new_iterator();
+        while (iter.has_more()) {
+            seek_to_position_in_page(iter.begin());
+            vectorized::Range r = iter.next(nread);
+            for (size_t i = 0; i < r.span_size(); ++i) {
+                if (PREDICT_FALSE(!_rle_decoder.Get(&value))) {
+                    return Status::Corruption("RLE decode failed");
+                }
+                [[maybe_unused]] int p = dst->append_numbers(&value, sizeof(value));
+                DCHECK_EQ(1, p);
             }
-            [[maybe_unused]] int r = dst->append_numbers(&value, sizeof(value));
-            DCHECK_EQ(1, r);
+            _cur_index += r.span_size();
         }
-        _cur_index += *n;
         return Status::OK();
     }
+
 
     size_t count() const override { return _num_elements; }
 

--- a/be/src/storage/rowset/segment_v2/rle_page.h
+++ b/be/src/storage/rowset/segment_v2/rle_page.h
@@ -232,7 +232,7 @@ public:
         size_t nread =
                 std::min(static_cast<size_t>(range.span_size()), static_cast<size_t>(_num_elements - _cur_index));
         vectorized::SparseRangeIterator iter = range.new_iterator();
-        while (iter.has_more()) {
+        while (nread > 0) {
             seek_to_position_in_page(iter.begin());
             vectorized::Range r = iter.next(nread);
             for (size_t i = 0; i < r.span_size(); ++i) {
@@ -243,6 +243,7 @@ public:
                 DCHECK_EQ(1, p);
             }
             _cur_index += r.span_size();
+            nread -= r.span_size();
         }
         return Status::OK();
     }

--- a/be/src/storage/rowset/segment_v2/rle_page.h
+++ b/be/src/storage/rowset/segment_v2/rle_page.h
@@ -25,10 +25,10 @@
 #include "storage/rowset/segment_v2/options.h"
 #include "storage/rowset/segment_v2/page_builder.h"
 #include "storage/rowset/segment_v2/page_decoder.h"
+#include "storage/vectorized/range.h"
 #include "util/coding.h"
 #include "util/rle_encoding.h"
 #include "util/slice.h"
-#include "storage/vectorized/range.h"
 
 namespace starrocks {
 namespace segment_v2 {
@@ -229,7 +229,8 @@ public:
         }
         CppType value{};
 
-        size_t nread = std::min(static_cast<size_t>(range.span_size()), static_cast<size_t>(_num_elements - _cur_index));
+        size_t nread =
+                std::min(static_cast<size_t>(range.span_size()), static_cast<size_t>(_num_elements - _cur_index));
         vectorized::SparseRangeIterator iter = range.new_iterator();
         while (iter.has_more()) {
             seek_to_position_in_page(iter.begin());
@@ -245,7 +246,6 @@ public:
         }
         return Status::OK();
     }
-
 
     size_t count() const override { return _num_elements; }
 

--- a/be/src/storage/rowset/segment_v2/rle_page.h
+++ b/be/src/storage/rowset/segment_v2/rle_page.h
@@ -222,7 +222,7 @@ public:
         return Status::OK();
     }
 
-    Status next_batch(vectorized::SparseRange& range, vectorized::Column* dst) override {
+    Status next_batch(const vectorized::SparseRange& range, vectorized::Column* dst) override {
         DCHECK(_parsed);
         if (PREDICT_FALSE(_cur_index >= _num_elements)) {
             return Status::OK();

--- a/be/src/storage/rowset/segment_v2/rle_page.h
+++ b/be/src/storage/rowset/segment_v2/rle_page.h
@@ -229,12 +229,12 @@ public:
         }
         CppType value{};
 
-        size_t nread =
+        size_t to_read =
                 std::min(static_cast<size_t>(range.span_size()), static_cast<size_t>(_num_elements - _cur_index));
         vectorized::SparseRangeIterator iter = range.new_iterator();
-        while (nread > 0) {
+        while (to_read > 0) {
             seek_to_position_in_page(iter.begin());
-            vectorized::Range r = iter.next(nread);
+            vectorized::Range r = iter.next(to_read);
             for (size_t i = 0; i < r.span_size(); ++i) {
                 if (PREDICT_FALSE(!_rle_decoder.Get(&value))) {
                     return Status::Corruption("RLE decode failed");
@@ -243,7 +243,7 @@ public:
                 DCHECK_EQ(1, p);
             }
             _cur_index += r.span_size();
-            nread -= r.span_size();
+            to_read -= r.span_size();
         }
         return Status::OK();
     }

--- a/be/src/storage/rowset/segment_v2/scalar_column_iterator.cpp
+++ b/be/src/storage/rowset/segment_v2/scalar_column_iterator.cpp
@@ -231,7 +231,7 @@ Status ScalarColumnIterator::next_batch(vectorized::SparseRange& range, vectoriz
     }
     dst->set_delete_state(contain_deleted_row ? DEL_PARTIAL_SATISFIED : DEL_NOT_SATISFIED);
     _opts.stats->bytes_read += (dst->byte_size() - prev_bytes);
-    
+
     return Status::OK();
 }
 
@@ -432,7 +432,7 @@ Status ScalarColumnIterator::_do_next_batch_dict_codes(vectorized::SparseRange& 
         if (iter.begin() >= end_ord) {
             RETURN_IF_ERROR(_page->read_dict_codes(dst, read_range));
             read_range.clear();
-        }        
+        }
     }
 
     if (!read_range.empty()) {

--- a/be/src/storage/rowset/segment_v2/scalar_column_iterator.cpp
+++ b/be/src/storage/rowset/segment_v2/scalar_column_iterator.cpp
@@ -197,6 +197,8 @@ Status ScalarColumnIterator::next_batch(const vectorized::SparseRange& range, ve
     DCHECK_EQ(range.begin(), _current_ordinal);
 
     while (iter.has_more()) {
+        // next row is the first row of next page
+        // do _load_next_page directly to avoid seek_page
         if (_page->remaining() == 0 && iter.begin() == end_ord) {
             _opts.stats->block_seek_num += 1;
             bool eos = false;
@@ -220,6 +222,8 @@ Status ScalarColumnIterator::next_batch(const vectorized::SparseRange& range, ve
             _current_ordinal += r.span_size();
         }
 
+        // next row is not in current page
+        // read current page data first
         if (iter.begin() >= end_ord) {
             RETURN_IF_ERROR(_page->read(dst, read_range));
             read_range.clear();

--- a/be/src/storage/rowset/segment_v2/scalar_column_iterator.cpp
+++ b/be/src/storage/rowset/segment_v2/scalar_column_iterator.cpp
@@ -194,8 +194,8 @@ Status ScalarColumnIterator::next_batch(const vectorized::SparseRange& range, ve
     size_t end_ord = _page->first_ordinal() + _page->num_rows();
     bool contain_deleted_row = (dst->delete_state() != DEL_NOT_SATISFIED);
     vectorized::SparseRange read_range;
-
     DCHECK_EQ(range.begin(), _current_ordinal);
+
     while (iter.has_more()) {
         if (_page->remaining() == 0 && iter.begin() == end_ord) {
             _opts.stats->block_seek_num += 1;

--- a/be/src/storage/rowset/segment_v2/scalar_column_iterator.cpp
+++ b/be/src/storage/rowset/segment_v2/scalar_column_iterator.cpp
@@ -188,7 +188,7 @@ Status ScalarColumnIterator::next_batch(size_t* n, vectorized::Column* dst) {
     return Status::OK();
 }
 
-Status ScalarColumnIterator::next_batch(vectorized::SparseRange& range, vectorized::Column* dst) {
+Status ScalarColumnIterator::next_batch(const vectorized::SparseRange& range, vectorized::Column* dst) {
     size_t prev_bytes = dst->byte_size();
     vectorized::SparseRangeIterator iter = range.new_iterator();
     size_t end_ord = _page->first_ordinal() + _page->num_rows();
@@ -332,7 +332,7 @@ Status ScalarColumnIterator::next_dict_codes(size_t* n, vectorized::Column* dst)
     return (this->*_next_dict_codes_func)(n, dst);
 }
 
-Status ScalarColumnIterator::next_dict_codes(vectorized::SparseRange& range, vectorized::Column* dst) {
+Status ScalarColumnIterator::next_dict_codes(const vectorized::SparseRange& range, vectorized::Column* dst) {
     DCHECK(all_page_dict_encoded());
     return (this->*_next_batch_dict_codes_func)(range, dst);
 }
@@ -398,7 +398,7 @@ Status ScalarColumnIterator::_do_next_dict_codes(size_t* n, vectorized::Column* 
 }
 
 template <FieldType Type>
-Status ScalarColumnIterator::_do_next_batch_dict_codes(vectorized::SparseRange& range, vectorized::Column* dst) {
+Status ScalarColumnIterator::_do_next_batch_dict_codes(const vectorized::SparseRange& range, vectorized::Column* dst) {
     bool contain_deleted_row = false;
     vectorized::SparseRangeIterator iter = range.new_iterator();
     size_t end_ord = _page->first_ordinal() + _page->num_rows();

--- a/be/src/storage/rowset/segment_v2/scalar_column_iterator.cpp
+++ b/be/src/storage/rowset/segment_v2/scalar_column_iterator.cpp
@@ -196,10 +196,13 @@ Status ScalarColumnIterator::next_batch(const vectorized::SparseRange& range, ve
     vectorized::SparseRange read_range;
     DCHECK_EQ(range.begin(), _current_ordinal);
 
+    // read data from discontinuous ranges in multiple pages
+    // data in the same data page will be read together in one function call
+    // to reduce the overhead of multiple function calls
     while (iter.has_more()) {
-        // next row is the first row of next page
-        // do _load_next_page directly to avoid seek_page
         if (_page->remaining() == 0 && iter.begin() == end_ord) {
+            // next row is the first row of next page
+            // do _load_next_page directly to avoid seek_page
             _opts.stats->block_seek_num += 1;
             bool eos = false;
             RETURN_IF_ERROR(_load_next_page(&eos));
@@ -209,6 +212,8 @@ Status ScalarColumnIterator::next_batch(const vectorized::SparseRange& range, ve
             end_ord = _page->first_ordinal() + _page->num_rows();
             contain_deleted_row = contain_deleted_row || _contains_deleted_row(_page->page_index());
         } else if (iter.begin() >= end_ord) {
+            // next row is not in current page
+            // seek data page first
             _opts.stats->block_seek_num += 1;
             RETURN_IF_ERROR(seek_to_ordinal(iter.begin()));
             end_ord = _page->first_ordinal() + _page->num_rows();
@@ -217,19 +222,24 @@ Status ScalarColumnIterator::next_batch(const vectorized::SparseRange& range, ve
 
         _current_ordinal = iter.begin();
         if (end_ord > _current_ordinal) {
+            // the data of current_range is in current page
+            // add current_range into read_range
             vectorized::Range r = iter.next(end_ord - _current_ordinal);
             read_range.add(vectorized::Range(r.begin() - _page->first_ordinal(), r.end() - _page->first_ordinal()));
             _current_ordinal += r.span_size();
         }
 
-        // next row is not in current page
-        // read current page data first
         if (iter.begin() >= end_ord) {
+            // next row is not in current page which means all ranges in
+            // current page have been added in read range
+            // read current page data first
             RETURN_IF_ERROR(_page->read(dst, read_range));
             read_range.clear();
         }
     }
+
     if (!read_range.empty()) {
+        // read data left if read range is not empty
         RETURN_IF_ERROR(_page->read(dst, read_range));
         read_range.clear();
     }

--- a/be/src/storage/rowset/segment_v2/scalar_column_iterator.h
+++ b/be/src/storage/rowset/segment_v2/scalar_column_iterator.h
@@ -142,7 +142,8 @@ private:
 
     int (ScalarColumnIterator::*_dict_lookup_func)(const Slice&) = nullptr;
     Status (ScalarColumnIterator::*_next_dict_codes_func)(size_t* n, vectorized::Column* dst) = nullptr;
-    Status (ScalarColumnIterator::*_next_batch_dict_codes_func)(vectorized::SparseRange& range, vectorized::Column* dst) = nullptr;
+    Status (ScalarColumnIterator::*_next_batch_dict_codes_func)(vectorized::SparseRange& range,
+                                                                vectorized::Column* dst) = nullptr;
     Status (ScalarColumnIterator::*_decode_dict_codes_func)(const int32_t* codes, size_t size,
                                                             vectorized::Column* words) = nullptr;
     Status (ScalarColumnIterator::*_init_dict_decoder_func)() = nullptr;

--- a/be/src/storage/rowset/segment_v2/scalar_column_iterator.h
+++ b/be/src/storage/rowset/segment_v2/scalar_column_iterator.h
@@ -49,7 +49,7 @@ public:
 
     Status next_batch(size_t* n, vectorized::Column* dst) override;
 
-    Status next_batch(vectorized::SparseRange& range, vectorized::Column* dst) override;
+    Status next_batch(const vectorized::SparseRange& range, vectorized::Column* dst) override;
 
     ordinal_t get_current_ordinal() const override { return _current_ordinal; }
 
@@ -68,7 +68,7 @@ public:
 
     Status next_dict_codes(size_t* n, vectorized::Column* dst) override;
 
-    Status next_dict_codes(vectorized::SparseRange& range, vectorized::Column* dst) override;
+    Status next_dict_codes(const vectorized::SparseRange& range, vectorized::Column* dst) override;
 
     Status decode_dict_codes(const int32_t* codes, size_t size, vectorized::Column* words) override;
 
@@ -98,7 +98,7 @@ private:
     Status _do_next_dict_codes(size_t* n, vectorized::Column* dst);
 
     template <FieldType Type>
-    Status _do_next_batch_dict_codes(vectorized::SparseRange& range, vectorized::Column* dst);
+    Status _do_next_batch_dict_codes(const vectorized::SparseRange& range, vectorized::Column* dst);
 
     template <FieldType Type>
     Status _do_decode_dict_codes(const int32_t* codes, size_t size, vectorized::Column* words);
@@ -142,7 +142,7 @@ private:
 
     int (ScalarColumnIterator::*_dict_lookup_func)(const Slice&) = nullptr;
     Status (ScalarColumnIterator::*_next_dict_codes_func)(size_t* n, vectorized::Column* dst) = nullptr;
-    Status (ScalarColumnIterator::*_next_batch_dict_codes_func)(vectorized::SparseRange& range,
+    Status (ScalarColumnIterator::*_next_batch_dict_codes_func)(const vectorized::SparseRange& range,
                                                                 vectorized::Column* dst) = nullptr;
     Status (ScalarColumnIterator::*_decode_dict_codes_func)(const int32_t* codes, size_t size,
                                                             vectorized::Column* words) = nullptr;

--- a/be/src/storage/rowset/segment_v2/scalar_column_iterator.h
+++ b/be/src/storage/rowset/segment_v2/scalar_column_iterator.h
@@ -26,6 +26,7 @@
 #include "storage/rowset/segment_v2/ordinal_page_index.h"
 #include "storage/rowset/segment_v2/page_handle.h"
 #include "storage/rowset/segment_v2/parsed_page.h"
+#include "storage/vectorized/range.h"
 
 namespace starrocks {
 namespace segment_v2 {
@@ -48,6 +49,8 @@ public:
 
     Status next_batch(size_t* n, vectorized::Column* dst) override;
 
+    Status next_batch(vectorized::SparseRange& range, vectorized::Column* dst) override;
+
     ordinal_t get_current_ordinal() const override { return _current_ordinal; }
 
     Status get_row_ranges_by_zone_map(const std::vector<const vectorized::ColumnPredicate*>& predicate,
@@ -64,6 +67,8 @@ public:
     int dict_lookup(const Slice& word) override;
 
     Status next_dict_codes(size_t* n, vectorized::Column* dst) override;
+
+    Status next_dict_codes(vectorized::SparseRange& range, vectorized::Column* dst) override;
 
     Status decode_dict_codes(const int32_t* codes, size_t size, vectorized::Column* words) override;
 
@@ -91,6 +96,9 @@ private:
 
     template <FieldType Type>
     Status _do_next_dict_codes(size_t* n, vectorized::Column* dst);
+
+    template <FieldType Type>
+    Status _do_next_batch_dict_codes(vectorized::SparseRange& range, vectorized::Column* dst);
 
     template <FieldType Type>
     Status _do_decode_dict_codes(const int32_t* codes, size_t size, vectorized::Column* words);
@@ -134,6 +142,7 @@ private:
 
     int (ScalarColumnIterator::*_dict_lookup_func)(const Slice&) = nullptr;
     Status (ScalarColumnIterator::*_next_dict_codes_func)(size_t* n, vectorized::Column* dst) = nullptr;
+    Status (ScalarColumnIterator::*_next_batch_dict_codes_func)(vectorized::SparseRange& range, vectorized::Column* dst) = nullptr;
     Status (ScalarColumnIterator::*_decode_dict_codes_func)(const int32_t* codes, size_t size,
                                                             vectorized::Column* words) = nullptr;
     Status (ScalarColumnIterator::*_init_dict_decoder_func)() = nullptr;

--- a/be/src/storage/rowset/vectorized/rowid_column_iterator.h
+++ b/be/src/storage/rowset/vectorized/rowid_column_iterator.h
@@ -54,7 +54,7 @@ public:
     Status next_batch(vectorized::SparseRange& range, vectorized::Column* dst) override {
         vectorized::SparseRangeIterator iter = range.new_iterator();
         size_t nread = range.span_size();
-        while(iter.has_more()) {
+        while (iter.has_more()) {
             _current_rowid = iter.begin();
             vectorized::Range r = iter.next(nread);
             Buffer<rowid_t>& v = down_cast<FixedLengthColumn<rowid_t>*>(dst)->get_data();

--- a/be/src/storage/rowset/vectorized/rowid_column_iterator.h
+++ b/be/src/storage/rowset/vectorized/rowid_column_iterator.h
@@ -51,6 +51,24 @@ public:
         return Status::OK();
     }
 
+    Status next_batch(vectorized::SparseRange& range, vectorized::Column* dst) override {
+        vectorized::SparseRangeIterator iter = range.new_iterator();
+        size_t nread = range.span_size();
+        while(iter.has_more()) {
+            _current_rowid = iter.begin();
+            vectorized::Range r = iter.next(nread);
+            Buffer<rowid_t>& v = down_cast<FixedLengthColumn<rowid_t>*>(dst)->get_data();
+            const size_t sz = v.size();
+            raw::stl_vector_resize_uninitialized(&v, sz + r.span_size());
+            rowid_t* ptr = &v[sz];
+            for (size_t i = 0; i < r.span_size(); i++) {
+                ptr[i] = _current_rowid + i;
+            }
+            _current_rowid += r.span_size();
+        }
+        return Status::OK();
+    }
+
     Status fetch_values_by_rowid(const rowid_t* rowids, size_t size, vectorized::Column* values) override {
         return Status::NotSupported("Not supported by RowIdColumnIterator: fetch_values_by_rowid");
     }

--- a/be/src/storage/rowset/vectorized/rowid_column_iterator.h
+++ b/be/src/storage/rowset/vectorized/rowid_column_iterator.h
@@ -53,10 +53,10 @@ public:
 
     Status next_batch(const vectorized::SparseRange& range, vectorized::Column* dst) override {
         vectorized::SparseRangeIterator iter = range.new_iterator();
-        size_t nread = range.span_size();
-        while (iter.has_more()) {
+        size_t to_read = range.span_size();
+        while (to_read > 0) {
             _current_rowid = iter.begin();
-            vectorized::Range r = iter.next(nread);
+            vectorized::Range r = iter.next(to_read);
             Buffer<rowid_t>& v = down_cast<FixedLengthColumn<rowid_t>*>(dst)->get_data();
             const size_t sz = v.size();
             raw::stl_vector_resize_uninitialized(&v, sz + r.span_size());
@@ -65,6 +65,7 @@ public:
                 ptr[i] = _current_rowid + i;
             }
             _current_rowid += r.span_size();
+            to_read -= r.span_size();
         }
         return Status::OK();
     }

--- a/be/src/storage/rowset/vectorized/rowid_column_iterator.h
+++ b/be/src/storage/rowset/vectorized/rowid_column_iterator.h
@@ -51,7 +51,7 @@ public:
         return Status::OK();
     }
 
-    Status next_batch(vectorized::SparseRange& range, vectorized::Column* dst) override {
+    Status next_batch(const vectorized::SparseRange& range, vectorized::Column* dst) override {
         vectorized::SparseRangeIterator iter = range.new_iterator();
         size_t nread = range.span_size();
         while (iter.has_more()) {

--- a/be/src/storage/rowset/vectorized/segment_iterator.cpp
+++ b/be/src/storage/rowset/vectorized/segment_iterator.cpp
@@ -121,6 +121,17 @@ private:
             return Status::OK();
         }
 
+        Status read_columns(Chunk* chunk, vectorized::SparseRange& range) {
+            bool may_has_del_row = chunk->delete_state() != DEL_NOT_SATISFIED;
+            for (size_t i = 0; i < _column_iterators.size(); i++) {
+                const ColumnPtr& col = chunk->get_column_by_index(i);
+                RETURN_IF_ERROR(_column_iterators[i]->next_batch(range, col.get()));
+                may_has_del_row |= (col->delete_state() != DEL_NOT_SATISFIED);
+            }
+            chunk->set_delete_state(may_has_del_row ? DEL_PARTIAL_SATISFIED : DEL_NOT_SATISFIED);
+            return Status::OK();
+        }
+
         int64_t memory_usage() const {
             int64_t usage = 0;
             usage += (_read_chunk != nullptr) ? _read_chunk->memory_usage() : 0;
@@ -128,6 +139,8 @@ private:
             usage += (_final_chunk.get() != _dict_chunk.get()) ? _final_chunk->memory_usage() : 0;
             return usage;
         }
+
+        size_t column_size() { return _column_iterators.size(); }
 
         Schema _read_schema;
         Schema _dict_decode_schema;
@@ -204,6 +217,11 @@ private:
     Status _apply_bitmap_index();
 
     Status _read(Chunk* chunk, vector<rowid_t>* rowid, size_t n);
+
+    Status _read_by_column(size_t n, Chunk* result, vector<rowid_t>* rowids);
+
+    Status _read_column(size_t n, rowid_t cur_rowid, uint32_t col_id, SparseRangeIterator range_iter,
+                        Chunk* result, vector<rowid_t>* rowids);
 
 private:
     std::shared_ptr<Segment> _segment;
@@ -557,27 +575,48 @@ Status SegmentIterator::_read_columns(const Schema& schema, Chunk* chunk, size_t
 }
 
 inline Status SegmentIterator::_read(Chunk* chunk, vector<rowid_t>* rowid, size_t n) {
-    Range r = _range_iter.next(n);
-    size_t nread = r.span_size();
-    if (_cur_rowid != r.begin() || _cur_rowid == 0) {
-        _cur_rowid = r.begin();
+    size_t read_num = 0;
+    SparseRange range;
+    std::vector<rowid_t> read_rowid;
+    read_rowid.reserve(n);
+    size_t chunk_rowid_start = _cur_rowid;
+    size_t cur_rowid = _cur_rowid;
+
+    if (_cur_rowid != _range_iter.begin() || _cur_rowid == 0) {
+        _cur_rowid = _range_iter.begin();
         _opts.stats->block_seek_num += 1;
         SCOPED_RAW_TIMER(&_opts.stats->block_seek_ns);
         RETURN_IF_ERROR(_context->seek_columns(_cur_rowid));
     }
+
+    while((read_num < n) && _range_iter.has_more()) {
+        Range r = _range_iter.next(n - read_num);
+        read_num += r.span_size();
+        chunk_rowid_start = r.begin();
+        cur_rowid = r.end();
+        range.add(r);
+    }
+
     {
         _opts.stats->blocks_load += 1;
         SCOPED_RAW_TIMER(&_opts.stats->block_fetch_ns);
-        RETURN_IF_ERROR(_context->read_columns(chunk, nread));
+        RETURN_IF_ERROR(_context->read_columns(chunk, range));
     }
-    _chunk_rowid_start = _cur_rowid;
-    if (rowid != nullptr) {
-        for (uint32_t i = _cur_rowid; i < _cur_rowid + nread; i++) {
-            rowid->push_back(i);
+
+    if (rowid !=  nullptr) {
+        rowid->reserve(range.span_size() + n);
+        vectorized::SparseRangeIterator iter = range.new_iterator();
+        while (iter.has_more()) {
+            vectorized::Range r = iter.next(n);
+            for (uint32_t i = r.begin(); i < r.end(); i++) {
+                rowid->push_back(i);
+            }
         }
     }
-    _cur_rowid += nread;
-    _opts.stats->raw_rows_read += nread;
+
+    _cur_rowid = cur_rowid;
+    _chunk_rowid_start = chunk_rowid_start;
+    _opts.stats->raw_rows_read += read_num;
     chunk->check_or_die();
     return Status::OK();
 }
@@ -626,6 +665,7 @@ Status SegmentIterator::_do_get_next(Chunk* result, vector<rowid_t>* rowid) {
     _context->_final_chunk->reset();
 
     Chunk* chunk = _context->_read_chunk.get();
+
 
     while ((chunk_start < chunk_capacity) & _range_iter.has_more()) {
         RETURN_IF_ERROR(_read(chunk, rowid, chunk_capacity - chunk_start));
@@ -865,6 +905,7 @@ uint16_t SegmentIterator::_filter_by_expr_predicates(Chunk* chunk, vector<rowid_
 
 inline bool SegmentIterator::_can_using_dict_code(const FieldPtr& field) const {
     if (_opts.predicates.find(field->id()) != _opts.predicates.end()) {
+        //return _predicate_need_rewrite[field->id()] && !_opts.predicates.find(field->id())->second.empty();
         return _predicate_need_rewrite[field->id()];
     } else {
         return (_has_bitmap_index || !_opts.predicates.empty()) &&

--- a/be/src/storage/rowset/vectorized/segment_iterator.cpp
+++ b/be/src/storage/rowset/vectorized/segment_iterator.cpp
@@ -220,8 +220,8 @@ private:
 
     Status _read_by_column(size_t n, Chunk* result, vector<rowid_t>* rowids);
 
-    Status _read_column(size_t n, rowid_t cur_rowid, uint32_t col_id, SparseRangeIterator range_iter,
-                        Chunk* result, vector<rowid_t>* rowids);
+    Status _read_column(size_t n, rowid_t cur_rowid, uint32_t col_id, SparseRangeIterator range_iter, Chunk* result,
+                        vector<rowid_t>* rowids);
 
 private:
     std::shared_ptr<Segment> _segment;
@@ -589,7 +589,7 @@ inline Status SegmentIterator::_read(Chunk* chunk, vector<rowid_t>* rowid, size_
         RETURN_IF_ERROR(_context->seek_columns(_cur_rowid));
     }
 
-    while((read_num < n) && _range_iter.has_more()) {
+    while ((read_num < n) && _range_iter.has_more()) {
         Range r = _range_iter.next(n - read_num);
         read_num += r.span_size();
         chunk_rowid_start = r.begin();
@@ -603,7 +603,7 @@ inline Status SegmentIterator::_read(Chunk* chunk, vector<rowid_t>* rowid, size_
         RETURN_IF_ERROR(_context->read_columns(chunk, range));
     }
 
-    if (rowid !=  nullptr) {
+    if (rowid != nullptr) {
         rowid->reserve(range.span_size() + n);
         vectorized::SparseRangeIterator iter = range.new_iterator();
         while (iter.has_more()) {
@@ -665,7 +665,6 @@ Status SegmentIterator::_do_get_next(Chunk* result, vector<rowid_t>* rowid) {
     _context->_final_chunk->reset();
 
     Chunk* chunk = _context->_read_chunk.get();
-
 
     while ((chunk_start < chunk_capacity) & _range_iter.has_more()) {
         RETURN_IF_ERROR(_read(chunk, rowid, chunk_capacity - chunk_start));

--- a/be/src/storage/vectorized/range.h
+++ b/be/src/storage/vectorized/range.h
@@ -90,6 +90,9 @@ public:
     SparseRangeIterator() {}
     explicit SparseRangeIterator(const SparseRange* r);
 
+    SparseRangeIterator(const SparseRangeIterator& iter) :
+        _range(iter._range), _index(iter._index), _next_rowid(iter._next_rowid) {}
+
     rowid_t begin() const { return _next_rowid; }
 
     // Return true iff there are untraversed range, i.e, `next` will return a non-empty range.
@@ -98,6 +101,8 @@ public:
     // Return the next contiguous range contains at most |size| rows.
     // `has_more` must be checked before calling this method.
     Range next(size_t size);
+
+    void next_range(size_t last_rowid, size_t size, SparseRange* srange);
 
     size_t covered_ranges(size_t size) const;
 
@@ -302,6 +307,33 @@ inline Range SparseRangeIterator::next(size_t size) {
         }
     }
     return ret;
+}
+
+inline void SparseRangeIterator::next_range(size_t last_rowid, size_t size, SparseRange* srange) {
+    const std::vector<Range>& ranges = _range->_ranges;
+    while (size > 0 && _index < ranges.size()) {
+        if (_next_rowid >= last_rowid) {
+            LOG(INFO) << "get next range of cur page finish";
+            return;
+        }
+        Range r = ranges[_index];
+        size_t nread = std::min<size_t>(last_rowid - _next_rowid, std::min<size_t>(size, r.end() - _next_rowid));
+        //size_t nread = std::min<size_t>(size, r.end() - _next_rowid);
+        srange->add(Range(_next_rowid, _next_rowid + nread));
+        _next_rowid += nread;
+        if (_next_rowid == r.end()) {
+            ++_index;
+            if (_index < ranges.size()) {
+                _next_rowid = ranges[_index].begin();
+            }
+        }
+        size -= nread;
+        // all data of current page has been read, need to seek page to ensure next page
+        if (r.end() >= last_rowid || _next_rowid >= last_rowid) {
+            break;
+        }
+    }
+    return;
 }
 
 inline size_t SparseRangeIterator::covered_ranges(size_t size) const {

--- a/be/src/storage/vectorized/range.h
+++ b/be/src/storage/vectorized/range.h
@@ -316,7 +316,6 @@ inline void SparseRangeIterator::next_range(size_t size, SparseRange* range) {
         range->add(r);
         size -= r.span_size();
     }
-    return;
 }
 
 inline size_t SparseRangeIterator::covered_ranges(size_t size) const {

--- a/be/src/storage/vectorized/range.h
+++ b/be/src/storage/vectorized/range.h
@@ -90,8 +90,8 @@ public:
     SparseRangeIterator() {}
     explicit SparseRangeIterator(const SparseRange* r);
 
-    SparseRangeIterator(const SparseRangeIterator& iter) :
-        _range(iter._range), _index(iter._index), _next_rowid(iter._next_rowid) {}
+    SparseRangeIterator(const SparseRangeIterator& iter)
+            : _range(iter._range), _index(iter._index), _next_rowid(iter._next_rowid) {}
 
     rowid_t begin() const { return _next_rowid; }
 

--- a/be/src/storage/vectorized/range.h
+++ b/be/src/storage/vectorized/range.h
@@ -102,6 +102,9 @@ public:
     // `has_more` must be checked before calling this method.
     Range next(size_t size);
 
+    // Return the next discontiguous range contains at most |size| rows
+    void next_range(size_t size, SparseRange* range);
+
     size_t covered_ranges(size_t size) const;
 
     size_t convert_to_bitmap(uint8_t* bitmap, size_t max_size) const;
@@ -305,6 +308,15 @@ inline Range SparseRangeIterator::next(size_t size) {
         }
     }
     return ret;
+}
+
+inline void SparseRangeIterator::next_range(size_t size, SparseRange* range) {
+    while (size > 0 && has_more()) {
+        Range r = next(size);
+        range->add(r);
+        size -= r.span_size();
+    }
+    return;
 }
 
 inline size_t SparseRangeIterator::covered_ranges(size_t size) const {

--- a/be/test/storage/rowset/segment_v2/binary_plain_page_test.cpp
+++ b/be/test/storage/rowset/segment_v2/binary_plain_page_test.cpp
@@ -122,6 +122,17 @@ public:
             ASSERT_TRUE(status.ok());
             ASSERT_EQ(1, size);
             ASSERT_EQ("StarRocks", column1->get_data()[0]);
+
+            auto column2 = vectorized::BinaryColumn::create();
+            page_decoder.seek_to_position_in_page(0);
+            vectorized::SparseRange read_range;
+            read_range.add(vectorized::Range(0, 1));
+            read_range.add(vectorized::Range(2, 3));
+            status = page_decoder.next_batch(read_range, column2.get());
+            ASSERT_TRUE(status.ok());
+            ASSERT_EQ(2, column2->size());
+            ASSERT_EQ("Hello", column2->get_data()[0]);
+            ASSERT_EQ("StarRocks", column2->get_data()[1]);
         }
     }
 };

--- a/be/test/storage/rowset/segment_v2/binary_prefix_page_test.cpp
+++ b/be/test/storage/rowset/segment_v2/binary_prefix_page_test.cpp
@@ -221,6 +221,26 @@ public:
             ASSERT_EQ(std::to_string(i), column2->get_slice(i - 1015));
         }
 
+        ret = page_decoder->seek_to_position_in_page(0);
+        ASSERT_TRUE(ret.ok());
+        auto column3 = vectorized::BinaryColumn::create();
+        vectorized::SparseRange read_range;
+        read_range.add(vectorized::Range(0, 10));
+        read_range.add(vectorized::Range(15, 25));
+        read_range.add(vectorized::Range(28, 38));
+        ret = page_decoder->next_batch(read_range, column3.get());
+        ASSERT_TRUE(ret.ok());
+        ASSERT_EQ(30, column3->size());
+        for (int i = 1000; i < 1010; ++i) {
+            ASSERT_EQ(std::to_string(i), column3->get_slice(i - 1000));
+        }
+        for (int i = 1015; i < 1025; ++i) {
+            ASSERT_EQ(std::to_string(i), column3->get_slice(i - 1015 + 10));
+        }
+        for (int i = 1028; i < 1038; ++i) {
+            ASSERT_EQ(std::to_string(i), column3->get_slice(i - 1028 + 20));
+        }
+
         std::string v1_string = std::to_string(1039);
         Slice v1 = Slice(v1_string);
         bool exact_match;

--- a/be/test/storage/rowset/segment_v2/bitshuffle_page_test.cpp
+++ b/be/test/storage/rowset/segment_v2/bitshuffle_page_test.cpp
@@ -200,6 +200,40 @@ public:
                         << datum_to_string(type_info.get(), dst->get(i));
             }
         }
+
+        {
+            // read range data of page
+            segment_v2::PageDecoderOptions decoder_options;
+            PageDecoderType page_decoder(encoded_data, decoder_options);
+            Status status = page_decoder.init();
+            ASSERT_TRUE(status.ok());
+            ASSERT_EQ(0, page_decoder.current_index());
+
+            auto dst = vectorized::ChunkHelper::column_from_field_type(Type, false);
+            vectorized::SparseRange read_range;
+            read_range.add(vectorized::Range(0, count / 3));
+            read_range.add(vectorized::Range(count / 2, (count * 2 / 3)));
+            read_range.add(vectorized::Range((count * 3 / 4), count));
+            size_t read_num = read_range.span_size();
+
+            dst->reserve(read_range.span_size());
+            status = page_decoder.next_batch(read_range, dst.get());
+            ASSERT_TRUE(status.ok());
+            ASSERT_EQ(read_num, dst->size());
+
+            TypeInfoPtr type_info = get_type_info(Type);
+            size_t offset = 0;
+            vectorized::SparseRangeIterator read_iter = read_range.new_iterator();
+            while (read_iter.has_more()) {
+                vectorized::Range r = read_iter.next(read_num);
+                for (int i = 0; i < r.span_size(); ++i) {
+                    ASSERT_EQ(0, type_info->cmp(src->get(r.begin() + i), dst->get(i + offset)))
+                            << " row " << i << ": " << datum_to_string(type_info.get(), src->get(r.begin() + i))
+                            << " vs " << datum_to_string(type_info.get(), dst->get(i + offset));
+                }
+                offset += r.span_size();
+            }
+        }
     }
 
     // The values inserted should be sorted.

--- a/be/test/storage/rowset/segment_v2/column_reader_writer_test.cpp
+++ b/be/test/storage/rowset/segment_v2/column_reader_writer_test.cpp
@@ -218,14 +218,15 @@ protected:
                     size_t offset = 0;
                     vectorized::SparseRangeIterator read_iter = read_range.new_iterator();
                     while (read_iter.has_more()) {
-                        vectorized::Range r = read_iter.next(read_num); 
+                        vectorized::Range r = read_iter.next(read_num);
                         for (int i = 0; i < r.span_size(); ++i) {
                             ASSERT_EQ(0, type_info->cmp(src.get(r.begin() + i), dst->get(i + offset)))
-                                    << " row " << r.begin() + i << ": " << datum_to_string(type_info.get(), src.get(r.begin() + i))
-                                    << " vs " << datum_to_string(type_info.get(), dst->get(i + offset));
+                                    << " row " << r.begin() + i << ": "
+                                    << datum_to_string(type_info.get(), src.get(r.begin() + i)) << " vs "
+                                    << datum_to_string(type_info.get(), dst->get(i + offset));
                         }
                         offset += r.span_size();
-                    }    
+                    }
                 }
             }
         }

--- a/be/test/storage/rowset/segment_v2/column_reader_writer_test.cpp
+++ b/be/test/storage/rowset/segment_v2/column_reader_writer_test.cpp
@@ -46,6 +46,7 @@
 #include "storage/tablet_schema_helper.h"
 #include "storage/types.h"
 #include "storage/vectorized/chunk_helper.h"
+#include "storage/vectorized/range.h"
 
 using std::string;
 
@@ -163,7 +164,6 @@ protected:
                 {
                     st = iter->seek_to_first();
                     ASSERT_TRUE(st.ok()) << st.to_string();
-
                     vectorized::ColumnPtr dst = vectorized::ChunkHelper::column_from_field_type(type, true);
                     // will do direct copy to column
                     size_t rows_read = src.size();
@@ -197,6 +197,35 @@ protected:
                                     << datum_to_string(type_info.get(), dst->get(i));
                         }
                     }
+                }
+
+                {
+                    st = iter->seek_to_first();
+                    ASSERT_TRUE(st.ok());
+
+                    vectorized::ColumnPtr dst = vectorized::ChunkHelper::column_from_field_type(type, true);
+                    vectorized::SparseRange read_range;
+                    size_t write_num = src.size();
+                    read_range.add(vectorized::Range(0, write_num / 3));
+                    read_range.add(vectorized::Range(write_num / 2, (write_num * 2 / 3)));
+                    read_range.add(vectorized::Range((write_num * 3 / 4), write_num));
+                    size_t read_num = read_range.span_size();
+
+                    st = iter->next_batch(read_range, dst.get());
+                    ASSERT_TRUE(st.ok());
+                    ASSERT_EQ(read_num, dst->size());
+
+                    size_t offset = 0;
+                    vectorized::SparseRangeIterator read_iter = read_range.new_iterator();
+                    while (read_iter.has_more()) {
+                        vectorized::Range r = read_iter.next(read_num); 
+                        for (int i = 0; i < r.span_size(); ++i) {
+                            ASSERT_EQ(0, type_info->cmp(src.get(r.begin() + i), dst->get(i + offset)))
+                                    << " row " << r.begin() + i << ": " << datum_to_string(type_info.get(), src.get(r.begin() + i))
+                                    << " vs " << datum_to_string(type_info.get(), dst->get(i + offset));
+                        }
+                        offset += r.span_size();
+                    }    
                 }
             }
         }


### PR DESCRIPTION
Wrapping a discontinuous range into a single read function call to reduce function call

Before this PR, query time using bitmap with low cardinality:
```
+--------------------- +-------------------------+
| cost time with bitmap| cost time without bitmap|
+--------------------- +-------------------------+
|            1.43s     |                  1.14s  |
+--------------------- +-------------------------+

After this PR, query time of the same query:
+--------------------- +-------------------------+
| cost time with bitmap| cost time without bitmap|
+--------------------- +-------------------------+
|            1.04s     |                  1.14s  |
+--------------------- +-------------------------+
```