### PR TITLE
 Fragment with result sink instance num should always be 1

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -512,4 +512,20 @@ public class PlanFragment extends TreeNode<PlanFragment> {
             List<Pair<Integer, ColumnDict>> loadGlobalDicts) {
         this.loadGlobalDicts = loadGlobalDicts;
     }
+
+    public boolean hashLocalBucketShuffleRightOrFullJoin(PlanNode planRoot) {
+        if (planRoot instanceof HashJoinNode) {
+            HashJoinNode joinNode = (HashJoinNode) planRoot;
+            if (joinNode.isLocalHashBucket() &&
+                    (joinNode.getJoinOp().isFullOuterJoin() || joinNode.getJoinOp().isRightJoin())) {
+                return true;
+            }
+        }
+        for (PlanNode childNode : planRoot.getChildren()) {
+            if (hashLocalBucketShuffleRightOrFullJoin(childNode)) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -192,7 +192,10 @@ public class PlanFragmentBuilder {
         execPlan.getOutputExprs().addAll(outputExprs);
 
         // Single tablet direct output
-        if (execPlan.getScanNodes().stream().allMatch(d -> d instanceof OlapScanNode)
+        // Note: If the fragment has right or full join and the join is local bucket shuffle join,
+        // We shouldn't set result sink directly to top fragment, because we will hash multi reslt sink.
+        if (!inputFragment.hashLocalBucketShuffleRightOrFullJoin(inputFragment.getPlanRoot())
+                && execPlan.getScanNodes().stream().allMatch(d -> d instanceof OlapScanNode)
                 && execPlan.getScanNodes().stream().map(d -> ((OlapScanNode) d).getScanTabletIds().size())
                 .reduce(Integer::sum).orElse(2) <= 1) {
             inputFragment.setOutputExprs(outputExprs);


### PR DESCRIPTION
In https://github.com/StarRocks/starrocks/pull/2114 don't  handle 

```
            if (!(leftMostNode instanceof ScanNode)) {
```
branch.

So, if the child fragment is LocalBucketShuffleRightOrFullJoin, but top fragment is agg. we will get the same error.

1. For Coordinator logic simple, we always add a  exchange node if the plan has LocalBucketShuffleRightOrFullJoin
2. Add mutil result sink check in Coordinator.


Will close https://github.com/StarRocks/starrocks/issues/2101 and https://github.com/StarRocks/starrocks/issues/2089