### PR TITLE
Remove query id string from thread local data (#2058)

### DIFF
--- a/be/src/common/logging.h
+++ b/be/src/common/logging.h
@@ -79,7 +79,7 @@ class TUniqueId;
 }
 
 // Print log with query id.
-#define QUERY_LOG(level) LOG(level) << "[" << CurrentThread::query_id_string() << "] "
-#define QUERY_LOG_IF(level, cond) LOG_IF(level, cond) << "[" << tls_thread_status.query_id_string() << "] "
+#define QUERY_LOG(level) LOG(level) << "[" << tls_thread_status.query_id() << "] "
+#define QUERY_LOG_IF(level, cond) LOG_IF(level, cond) << "[" << tls_thread_status.query_id() << "] "
 
 #endif

--- a/be/src/runtime/current_thread.h
+++ b/be/src/runtime/current_thread.h
@@ -30,13 +30,9 @@ public:
         }
     }
 
-    void set_query_id(const starrocks::TUniqueId& query_id) {
-        _query_id = query_id;
-        _str_query_id = starrocks::print_id(query_id);
-    }
+    void set_query_id(const starrocks::TUniqueId& query_id) { _query_id = query_id; }
 
     const starrocks::TUniqueId& query_id() { return _query_id; }
-    const std::string& query_id_string() { return _str_query_id; }
 
     // Return prev memory tracker.
     starrocks::MemTracker* set_mem_tracker(starrocks::MemTracker* mem_tracker) {
@@ -94,12 +90,11 @@ public:
     }
 
 private:
+    const static int64_t BATCH_SIZE = 2 * 1024 * 1024;
+
     int64_t _cache_size = 0;
     MemTracker* _mem_tracker = nullptr;
     TUniqueId _query_id;
-    std::string _str_query_id;
-
-    const static int64_t BATCH_SIZE = 2 * 1024 * 1024;
 };
 
 inline thread_local CurrentThread tls_thread_status;


### PR DESCRIPTION
The query id string in TLS has no usage now