### PR TITLE
Fix the bug that the state of replica is always in decommission (#1997)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -212,6 +212,9 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
     private boolean srcPathResourceHold = false;
     private boolean destPathResourceHold = false;
 
+    private Replica decommissionedReplica;
+    private ReplicaState decommissionedReplicaPreviousState;
+
     public TabletSchedCtx(Type type, String cluster, long dbId, long tblId, long partId,
                           long idxId, long tabletId, long createTime) {
         this.type = type;
@@ -711,6 +714,19 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
             this.destPathHash = -1;
             this.cloneTask = null;
         }
+    }
+
+    public void resetDecommissionedReplicaState() {
+        if (decommissionedReplica != null
+                && decommissionedReplica.getState() == ReplicaState.DECOMMISSION
+                && decommissionedReplicaPreviousState != null) {
+            decommissionedReplica.setState(decommissionedReplicaPreviousState);
+        }
+    }
+
+    public void setDecommissionedReplica(Replica replica) {
+        this.decommissionedReplica = replica;
+        this.decommissionedReplicaPreviousState = replica.getState();
     }
 
     public void deleteReplica(Replica replica) {

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -984,6 +984,8 @@ public class TabletScheduler extends MasterDaemon {
             long nextTxnId =
                     Catalog.getCurrentGlobalTransactionMgr().getTransactionIDGenerator().getNextTransactionId();
             replica.setWatermarkTxnId(nextTxnId);
+            tabletCtx.resetDecommissionedReplicaState();
+            tabletCtx.setDecommissionedReplica(replica);
             replica.setState(ReplicaState.DECOMMISSION);
             // set priority to normal because it may wait for a long time. Remain it as VERY_HIGH may block other task.
             tabletCtx.setOrigPriority(Priority.NORMAL);
@@ -1197,6 +1199,7 @@ public class TabletScheduler extends MasterDaemon {
 
     private void releaseTabletCtx(TabletSchedCtx tabletCtx, TabletSchedCtx.State state) {
         tabletCtx.setState(state);
+        tabletCtx.resetDecommissionedReplicaState();
         tabletCtx.releaseResource(this);
         tabletCtx.setFinishedTime(System.currentTimeMillis());
     }


### PR DESCRIPTION
To remove the redundant replica, proceed as follows.
1. Select the replica to be dropped according to the following priority
   1). replica on the backend, which was dropped.
   2). replica state is bad
   3). replica is unavailable
   4). replica' state is under clone or decommission.
   5). replica with failed version.
   6). replica with a lower version.
   7). replica on the same host.
   8). replica as the balance source.
   9). replica stored on high load backend.
2. Set the replica state to decommission, find the current largest txn number and return the TabletSchedCtx to the scheduling queue.
3. All the txn smaller than the found txn number is finished. FE can drop this replica.

But the second and third steps may be separated by a long time. Another replica sees the problem, like the version incomplete or backend unavailable during this period. The scheduler may go through other repair processes or select another replica to decommission if this happens. The replica state will stay as decommissioned and not be scheduled.

To fix this problem, reset the decommissioned replica state when
1. Scheduler chooses another replica to decommission.
2. TabletSchedCtx is finished.