### PR TITLE
Optimize rowset compaction score calculation

### DIFF
--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -60,6 +60,7 @@ Status Rowset::load() {
 void Rowset::make_visible(Version version) {
     _rowset_meta->set_version(version);
     _rowset_meta->set_rowset_state(VISIBLE);
+    _rowset_meta->update_compaction_score();
     // update create time to the visible time,
     // it's used to skip recently published version during compaction
     _rowset_meta->set_creation_time(UnixSeconds());


### PR DESCRIPTION
For tables which are not primary key model, the compaction score of rowset is determined when the rowset is visible and will not change. Just return the compaction_score by get_compaction_score to avoid calculation online.