### PR TITLE
Fix group has redundant group expression

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/GroupExpression.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/GroupExpression.java
@@ -41,6 +41,7 @@ public class GroupExpression {
     private final Map<PhysicalPropertySet, Pair<Double, List<PhysicalPropertySet>>> lowestCostTable;
     private final Set<OutputInputProperty> validOutputInputProperties;
     private Map<OutputInputProperty, Integer> propertiesPlanCountMap;
+    private boolean isUnused = false;
 
     public GroupExpression(Operator op, List<Group> inputs) {
         this.op = op;
@@ -79,7 +80,7 @@ public class GroupExpression {
     }
 
     public boolean isUnused() {
-        return hasEmptyRootGroup() || hasEmptyChildGroup();
+        return hasEmptyRootGroup() || hasEmptyChildGroup() || isUnused;
     }
 
     private boolean hasEmptyChildGroup() {
@@ -96,6 +97,10 @@ public class GroupExpression {
 
     public void setRuleExplored(Rule rule) {
         ruleMasks.set(rule.type().ordinal());
+    }
+
+    public void setUnused(boolean isUnused) {
+        this.isUnused = isUnused;
     }
 
     public boolean hasRuleExplored(Rule rule) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Memo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Memo.java
@@ -191,6 +191,13 @@ public class Memo {
         for (GroupExpression groupExpression : needReinsertedExpressions) {
             if (!groupExpressions.containsKey(groupExpression)) {
                 groupExpressions.put(groupExpression, groupExpression);
+            } else {
+                // group expression is already in the Memo's groupExpressions, this indicates that
+                // this is a redundant group Expression, it's should be remove.
+                // And the redundant group expression may be already in the TaskScheduler stack, so it should be
+                // set unused.
+                groupExpression.getGroup().removeGroupExpression(groupExpression);
+                groupExpression.setUnused(true);
             }
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/EnumeratePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/EnumeratePlanTest.java
@@ -320,7 +320,7 @@ public class EnumeratePlanTest extends DistributedEnvPlanTestBase {
                 "    numwait desc,\n" +
                 "    s_name limit 100;";
         int planCount = getPlanCount(sql);
-        Assert.assertEquals(502, planCount);
+        Assert.assertEquals(522, planCount);
     }
 
     @Test


### PR DESCRIPTION
#2087 
This bug Is due to the group merge process. For groupExpression in the needReinsertedExpressions, if it is in Memo's groupExpressions, it means it's redundant, should be removed from group