### PR TITLE
Fix Error in column Range

### DIFF
--- a/be/src/exec/olap_common.h
+++ b/be/src/exec/olap_common.h
@@ -671,6 +671,8 @@ inline Status ColumnValueRange<T>::add_range(SQLFilterOp op, T value) {
         if (FILTER_LARGER_OR_EQUAL == _low_op && FILTER_LESS_OR_EQUAL == _high_op && _high_value == _low_value) {
             _fixed_values.insert(_high_value);
             _fixed_op = FILTER_IN;
+        } else {
+            _empty_range = _low_value > _high_value;
         }
     }
     _is_init_state = false;

--- a/be/src/exec/olap_common.h
+++ b/be/src/exec/olap_common.h
@@ -398,6 +398,7 @@ inline Status ColumnValueRange<T>::add_fixed_values(SQLFilterOp op, const std::s
         } else if (is_fixed_value_range()) {
             DCHECK_EQ(FILTER_IN, _fixed_op);
             _fixed_values = STLSetIntersection(_fixed_values, values);
+            _empty_range = _fixed_values.empty();
             _fixed_op = op;
         } else if (!values.empty()) {
             _fixed_values = values;

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -25,6 +25,7 @@ set(EXEC_FILES
         ./env/output_stream_wrapper_test.cpp
         ./exec/buffered_reader_test.cpp
         ./exec/es_query_builder_test.cpp
+        ./exec/column_value_range_test.cpp
         ./exec/plain_text_line_reader_bzip_test.cpp
         ./exec/plain_text_line_reader_gzip_test.cpp
         ./exec/plain_text_line_reader_lz4frame_test.cpp

--- a/be/test/exec/column_value_range_test.cpp
+++ b/be/test/exec/column_value_range_test.cpp
@@ -82,6 +82,14 @@ TEST(NormalizeRangeTest, RangeTest) {
         bool ok = range.add_fixed_values(SQLFilterOp::FILTER_NOT_IN, {3}).ok();
         ASSERT_FALSE(ok);
     }
+    {
+        // where range > 1000 and range < 2000
+        ColumnValueRange<CppType> range("test", Type, std::numeric_limits<CppType>::lowest(),
+                                        std::numeric_limits<CppType>::max());
+        range.add_range(SQLFilterOp::FILTER_LESS, 1000);
+        range.add_range(SQLFilterOp::FILTER_LARGER, 2000);
+        ASSERT_TRUE(range.is_empty_value_range());
+    }
 }
 
 TEST(NormalizeRangeTest, BoolRangeTest) {

--- a/be/test/exec/column_value_range_test.cpp
+++ b/be/test/exec/column_value_range_test.cpp
@@ -1,0 +1,67 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#include "column/type_traits.h"
+#include "exec/olap_common.h"
+#include "gtest/gtest.h"
+
+namespace starrocks::vectorized {
+TEST(NormalizeRangeTest, RangeTest) {
+    const constexpr PrimitiveType Type = TYPE_INT;
+    using CppType = RunTimeCppType<Type>;
+    {
+        // where range in (1,2,3,4) and range not in (1, 2)
+        ColumnValueRange<CppType> range("test", Type, std::numeric_limits<CppType>::lowest(),
+                                        std::numeric_limits<CppType>::max());
+        range.add_fixed_values(SQLFilterOp::FILTER_IN, {1, 2, 3, 4});
+        range.add_fixed_values(SQLFilterOp::FILTER_NOT_IN, {1, 2});
+        std::set<CppType> values = {3, 4};
+        ASSERT_EQ(range._fixed_values, values);
+    }
+    {
+        // where range in (1, 2) and range > 1
+        ColumnValueRange<CppType> range("test", Type, std::numeric_limits<CppType>::lowest(),
+                                        std::numeric_limits<CppType>::max());
+        range.add_fixed_values(SQLFilterOp::FILTER_IN, {1, 2});
+        range.add_range(SQLFilterOp::FILTER_LARGER, 1);
+
+        ASSERT_TRUE(range.is_fixed_value_range());
+        ASSERT_EQ(range._fixed_values.size(), 1);
+    }
+    {
+        // where range in (1, 2) and range > 2
+        ColumnValueRange<CppType> range("test", Type, std::numeric_limits<CppType>::lowest(),
+                                        std::numeric_limits<CppType>::max());
+        range.add_fixed_values(SQLFilterOp::FILTER_IN, {1, 2});
+        range.add_range(SQLFilterOp::FILTER_LARGER, 2);
+        ASSERT_TRUE(range.is_empty_value_range());
+    }
+}
+
+TEST(NormalizeRangeTest, BoolRangeTest) {
+    {
+        // range not in (false) and range < false
+        // not support for this range
+        ColumnValueRange<int> range("test", TYPE_BOOLEAN, 0, 1);
+        range.add_range(SQLFilterOp::FILTER_LESS, true);
+        bool res = range.add_fixed_values(SQLFilterOp::FILTER_NOT_IN, {false}).ok();
+        ASSERT_FALSE(res);
+    }
+    {
+        // range not in (false) and range < empty
+        // not support for this range
+        ColumnValueRange<int> range("test", TYPE_BOOLEAN, 0, 1);
+        range.add_fixed_values(SQLFilterOp::FILTER_NOT_IN, {false});
+        bool res = range.add_range(SQLFilterOp::FILTER_LESS, true).ok();
+        ASSERT_FALSE(res);
+    }
+    {
+        // range != false and range < true
+        // not support for this range
+        ColumnValueRange<int> range("test", TYPE_BOOLEAN, 0, 1);
+        range.add_fixed_values(SQLFilterOp::FILTER_NOT_IN, {false});
+        range.add_range(SQLFilterOp::FILTER_LESS, true);
+        ASSERT_FALSE(range.is_empty_value_range());
+    }
+}
+
+} // namespace starrocks::vectorized


### PR DESCRIPTION
for https://github.com/StarRocks/starrocks/issues/2089


1. _empty_range should be reset when _fixed_values was empty 
2. Fix bug in Range(>limit) intersect Range(Fixed value)