### PR TITLE
[pipeline] fix: call mark_precondition_ready before check_short_circuit

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -168,7 +168,51 @@ public:
     void finalize(RuntimeState* runtime_state, DriverState state);
     DriverAcct& driver_acct() { return _driver_acct; }
     DriverState driver_state() const { return _state; }
-    void set_driver_state(DriverState state) { _state = state; }
+
+    void set_driver_state(DriverState state) {
+        if (state == _state) {
+            return;
+        }
+
+        switch (_state) {
+        case DriverState::INPUT_EMPTY: {
+            auto elapsed_time = _input_empty_timer_sw->elapsed_time();
+            if (_first_input_empty_timer->value() == 0) {
+                _first_input_empty_timer->update(elapsed_time);
+            } else {
+                _followup_input_empty_timer->update(elapsed_time);
+            }
+            _input_empty_timer->update(elapsed_time);
+            break;
+        }
+        case DriverState::OUTPUT_FULL:
+            _output_full_timer->update(_output_full_timer_sw->elapsed_time());
+            break;
+        case DriverState::PRECONDITION_BLOCK: {
+            _precondition_block_timer->update(_precondition_block_timer_sw->elapsed_time());
+            break;
+        }
+        default:
+            break;
+        }
+
+        switch (state) {
+        case DriverState::INPUT_EMPTY:
+            _input_empty_timer_sw->reset();
+            break;
+        case DriverState::OUTPUT_FULL:
+            _output_full_timer_sw->reset();
+            break;
+        case DriverState::PRECONDITION_BLOCK:
+            _precondition_block_timer_sw->reset();
+            break;
+        default:
+            break;
+        }
+
+        _state = state;
+    }
+
     Operators& operators() { return _operators; }
     SourceOperator* source_operator() { return down_cast<SourceOperator*>(_operators.front().get()); }
     RuntimeProfile* runtime_profile() { return _runtime_profile.get(); }
@@ -241,19 +285,31 @@ public:
                 return false;
             }
 
+            // TODO(trueeyu): This writing is to ensure that MemTracker will not be destructed before the thread ends.
+            //  This writing method is a bit tricky, and when there is a better way, replace it
+            mark_precondition_ready(_runtime_state);
+
             check_short_circuit();
             if (_state == DriverState::PENDING_FINISH) {
                 return false;
             }
+            // Driver state must be set to a state different from PRECONDITION_BLOCK bellow,
+            // to avoid call mark_precondition_ready() and check_short_circuit() multiple times.
         }
 
         // OUTPUT_FULL
         if (!sink_operator()->need_input()) {
+            set_driver_state(DriverState::OUTPUT_FULL);
             return false;
         }
 
         // INPUT_EMPTY
-        return source_operator()->is_finished() || source_operator()->has_output();
+        if (!source_operator()->is_finished() && !source_operator()->has_output()) {
+            set_driver_state(DriverState::INPUT_EMPTY);
+            return false;
+        }
+
+        return true;
     }
 
     // Check whether an operator can be short-circuited, when is_precondition_block() becomes false from true.
@@ -297,6 +353,7 @@ private:
     DriverAcct _driver_acct;
     // The first one is source operator
     MorselQueue* _morsel_queue = nullptr;
+    // _state must be set by set_driver_state() to record state timer.
     DriverState _state;
     std::shared_ptr<RuntimeProfile> _runtime_profile = nullptr;
     const size_t _yield_max_chunks_moved;

--- a/be/src/exec/pipeline/pipeline_driver_poller.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_poller.cpp
@@ -97,31 +97,6 @@ void PipelineDriverPoller::run_internal() {
                     ready_drivers.emplace_back(driver);
                 }
             } else if (driver->is_not_blocked()) {
-                switch (driver->driver_state()) {
-                case DriverState::INPUT_EMPTY: {
-                    auto elapsed_time = driver->_input_empty_timer_sw->elapsed_time();
-                    if (driver->_first_input_empty_timer->value() == 0) {
-                        driver->_first_input_empty_timer->update(elapsed_time);
-                    } else {
-                        driver->_followup_input_empty_timer->update(elapsed_time);
-                    }
-                    driver->_input_empty_timer->update(elapsed_time);
-                    break;
-                }
-                case DriverState::OUTPUT_FULL:
-                    driver->_output_full_timer->update(driver->_output_full_timer_sw->elapsed_time());
-                    break;
-                case DriverState::PRECONDITION_BLOCK: {
-                    // TODO(trueeyu): This writing is to ensure that MemTracker will not be destructed before the thread ends.
-                    //  This writing method is a bit tricky, and when there is a better way, replace it
-                    auto runtime_state_ptr = driver->fragment_ctx()->runtime_state_ptr();
-                    driver->mark_precondition_ready(runtime_state_ptr.get());
-                    driver->_precondition_block_timer->update(driver->_precondition_block_timer_sw->elapsed_time());
-                    break;
-                }
-                default:
-                    break;
-                }
                 driver->set_driver_state(DriverState::READY);
                 remove_blocked_driver(local_blocked_drivers, driver_it);
                 ready_drivers.emplace_back(driver);
@@ -158,19 +133,6 @@ void PipelineDriverPoller::add_blocked_driver(const DriverRawPtr driver) {
     std::unique_lock<std::mutex> lock(this->_mutex);
     this->_blocked_drivers.push_back(driver);
     driver->_pending_timer_sw->reset();
-    switch (driver->driver_state()) {
-    case DriverState::INPUT_EMPTY:
-        driver->_input_empty_timer_sw->reset();
-        break;
-    case DriverState::OUTPUT_FULL:
-        driver->_output_full_timer_sw->reset();
-        break;
-    case DriverState::PRECONDITION_BLOCK:
-        driver->_precondition_block_timer_sw->reset();
-        break;
-    default:
-        break;
-    }
     this->_cond.notify_one();
 }
 


### PR DESCRIPTION
- `mark_precondition_ready` should be called before `check_short_circuit`, because `check_short_circuit` maybe sets operators finished.
- Record state timer in `Driver::set_driver_state()`. 