### PR TITLE
Wait until memtable flushed to disk if memory limit exceeded

### DIFF
--- a/be/src/runtime/load_channel_mgr.h
+++ b/be/src/runtime/load_channel_mgr.h
@@ -58,17 +58,6 @@ public:
     Status cancel(const PTabletWriterCancelRequest& request);
 
 private:
-    // check if the total load mem consumption exceeds limit.
-    // If yes, it will pick several load channels to try to reduce memory consumption to limit.
-    void _handle_mem_exceed_limit(const std::shared_ptr<LoadChannel>& data_channel);
-
-    // find a load channel to reduce memory consumption
-    // 1. select the load channel that consume this batch data if limit exceeded.
-    // 2. select the largest limit exceeded load channel.
-    // 3. select the largest consumption load channel.
-    bool _find_candidate_load_channel(const std::shared_ptr<LoadChannel>& data_channel,
-                                      std::shared_ptr<LoadChannel>* candidate_channel);
-
     Status _start_bg_worker();
 
     // lock protect the load channel map

--- a/be/src/runtime/tablets_channel.cpp
+++ b/be/src/runtime/tablets_channel.cpp
@@ -34,8 +34,7 @@ namespace starrocks {
 std::atomic<uint64_t> TabletsChannel::_s_tablet_writer_count;
 
 TabletsChannel::TabletsChannel(const TabletsChannelKey& key, MemTracker* mem_tracker)
-        : _key(key), _state(kInitialized), _closed_senders(64) {
-    _mem_tracker = std::make_unique<MemTracker>(-1, "tablets channel", mem_tracker, true);
+        : _key(key), _state(kInitialized), _mem_tracker(mem_tracker), _closed_senders(64) {
     _mem_pool = std::make_unique<MemPool>();
     static std::once_flag once_flag;
     std::call_once(once_flag, [] {
@@ -45,7 +44,6 @@ TabletsChannel::TabletsChannel(const TabletsChannelKey& key, MemTracker* mem_tra
 
 TabletsChannel::~TabletsChannel() {
     _s_tablet_writer_count -= _delta_writers.size();
-    STLDeleteValues(&_delta_writers);
     delete _row_desc;
     delete _schema;
     _mem_pool.reset();
@@ -142,9 +140,9 @@ Status TabletsChannel::add_chunk(const PTabletWriterAddChunkRequest& params) {
         }
         {
             std::lock_guard<std::mutex> l(_tablet_locks[tablet_id & k_shard_size]);
-            auto st = it->second->write(&chunk, row_indexes.data(), from, size);
+            auto st = it->second->write(chunk, row_indexes.data(), from, size);
             if (!st.ok()) {
-                (void)it->second->cancel();
+                it->second->abort();
                 return st;
             }
         }
@@ -232,79 +230,36 @@ Status TabletsChannel::close(int sender_id, bool* finished,
                     // just skip this tablet(writer) and continue to close others
                     continue;
                 }
-                need_wait_writers.emplace(it.first, it.second);
+                need_wait_writers.emplace(it.first, it.second.get());
             } else {
                 std::lock_guard<std::mutex> l(_tablet_locks[it.first & k_shard_size]);
-                auto st = it.second->cancel();
-                if (!st.ok()) {
-                    LOG(WARNING) << "Fail to cancel tablet writer, tablet_id=" << it.first
-                                 << " transaction_id=" << _txn_id;
-                    // just skip this tablet(writer) and continue to close others
-                    continue;
-                }
+                it.second->abort();
             }
         }
 
         // 2. wait delta writers and build the tablet vector
-        for (auto& it : need_wait_writers) {
-            std::lock_guard<std::mutex> l(_tablet_locks[it.first & k_shard_size]);
-            // close may return failed, but no need to handle it here.
+        for (auto& [tablet_id, delta_writer] : need_wait_writers) {
+            std::lock_guard<std::mutex> l(_tablet_locks[tablet_id & k_shard_size]);
+            // commit may return error, but no need to handle it here.
             // tablet_vec will only contains success tablet, and then let FE judge it.
-            it.second->close_wait(tablet_vec);
+            if (auto st = delta_writer->commit(); !st.ok()) {
+                continue;
+            }
+            PTabletInfo* tablet_info = tablet_vec->Add();
+            tablet_info->set_tablet_id(delta_writer->tablet()->tablet_id());
+            tablet_info->set_schema_hash(delta_writer->tablet()->schema_hash());
+            const auto& dict_info = delta_writer->committed_rowset_writer()->global_dict_columns_valid_info();
+            for (const auto& item : dict_info) {
+                if (item.second) {
+                    tablet_info->add_valid_dict_cache_columns(item.first);
+                } else {
+                    tablet_info->add_invalid_dict_cache_columns(item.first);
+                }
+            }
         }
     }
 
     return Status::OK();
-}
-
-Status TabletsChannel::reduce_mem_usage_async(const std::set<int64_t>& flush_tablet_ids, int64_t* tablet_id,
-                                              int64_t* tablet_mem_consumption) {
-    vectorized::DeltaWriter* vectorized_writer = nullptr;
-    int64_t max_consume = 0L;
-
-    {
-        std::lock_guard<std::mutex> l(_global_lock);
-        if (_state == kFinished) {
-            // TabletsChannel is closed without LoadChannel's lock,
-            // therefore it's possible for reduce_mem_usage_async() to be called right after close().
-            return _close_status;
-        }
-
-        // find tablet writer with largest mem consumption
-        for (auto& it : _delta_writers) {
-            if (it.second->mem_consumption() > max_consume &&
-                flush_tablet_ids.find(it.first) == flush_tablet_ids.end()) {
-                max_consume = it.second->mem_consumption();
-                vectorized_writer = it.second;
-                *tablet_id = it.first;
-            }
-        }
-    }
-    if (vectorized_writer == nullptr || max_consume == 0) {
-        // barely not happend, just return OK
-        return Status::OK();
-    }
-    VLOG(3) << "pick the delta writer to flush, with mem consumption: " << max_consume << ", channel key: " << _key;
-    *tablet_mem_consumption = max_consume;
-    std::lock_guard<std::mutex> l(_tablet_locks[*tablet_id & k_shard_size]);
-    return vectorized_writer->flush_memtable_async();
-}
-
-Status TabletsChannel::wait_mem_usage_reduced(int64_t tablet_id) {
-    vectorized::DeltaWriter* vectorized_writer = nullptr;
-    {
-        std::lock_guard<std::mutex> l(_global_lock);
-        auto it = _delta_writers.find(tablet_id);
-        if (it == _delta_writers.end()) {
-            std::stringstream ss;
-            ss << "tablet writer is not found. tablet id: " << tablet_id;
-            return Status::InternalError(ss.str());
-        }
-        vectorized_writer = it->second;
-    }
-
-    std::lock_guard<std::mutex> l(_tablet_locks[tablet_id & k_shard_size]);
-    return vectorized_writer->wait_memtable_flushed();
 }
 
 Status TabletsChannel::_open_all_writers(const PTabletWriterOpenRequest& params) {
@@ -352,16 +307,15 @@ Status TabletsChannel::_open_all_writers(const PTabletWriterOpenRequest& params)
         options.slots = index_slots;
         options.global_dicts = &_global_dicts;
 
-        vectorized::DeltaWriter* writer = nullptr;
-        auto st = vectorized::DeltaWriter::open(options, _mem_tracker.get(), &writer);
-        if (!st.ok()) {
+        auto res = vectorized::DeltaWriter::open(options, _mem_tracker);
+        if (!res.ok()) {
             std::stringstream ss;
             ss << "open delta writer failed, tablet_id=" << tablet.tablet_id() << ", txn_id=" << _txn_id
-               << ", partition_id=" << tablet.partition_id() << ", err=" << st.to_string();
+               << ", partition_id=" << tablet.partition_id() << ", err=" << res.status();
             LOG(WARNING) << ss.str();
             return Status::InternalError(ss.str());
         }
-        _delta_writers.emplace(tablet.tablet_id(), writer);
+        _delta_writers.emplace(tablet.tablet_id(), std::move(res).value());
         tablet_ids.emplace_back(tablet.tablet_id());
     }
     _s_tablet_writer_count += _delta_writers.size();
@@ -384,7 +338,7 @@ Status TabletsChannel::cancel() {
 
     for (auto& it : _delta_writers) {
         std::lock_guard<std::mutex> l(_tablet_locks[it.first & k_shard_size]);
-        it.second->cancel();
+        it.second->abort();
     }
 
     std::lock_guard<std::mutex> l(_global_lock);

--- a/be/src/storage/vectorized/delta_writer.cpp
+++ b/be/src/storage/vectorized/delta_writer.cpp
@@ -297,7 +297,7 @@ Status DeltaWriter::commit() {
     if (!_state.compare_exchange_strong(curr_state, kCommitted, std::memory_order_acq_rel)) {
         return Status::InternalError("delta writer has been aborted");
     }
-    LOG(INFO) << "Closed delta writer. tablet_id=" << _tablet->tablet_id();
+    LOG(INFO) << "Closed delta writer. tablet_id=" << _tablet->tablet_id() << " stats=" << _flush_token->get_stats();
     return Status::OK();
 }
 

--- a/be/src/storage/vectorized/delta_writer.cpp
+++ b/be/src/storage/vectorized/delta_writer.cpp
@@ -226,8 +226,9 @@ Status DeltaWriter::close() {
     case kUninitialized:
     case kCommitted:
     case kAborted:
-    case kClosed:
         return Status::InternalError(fmt::format("cannot close delta writer in {} state", _state_name(state)));
+    case kClosed:
+        return Status::OK();
     case kWriting:
         st = _flush_memtable_async();
         _set_state(st.ok() ? kClosed : kAborted);

--- a/be/src/storage/vectorized/delta_writer.cpp
+++ b/be/src/storage/vectorized/delta_writer.cpp
@@ -297,6 +297,7 @@ Status DeltaWriter::commit() {
     if (!_state.compare_exchange_strong(curr_state, kCommitted, std::memory_order_acq_rel)) {
         return Status::InternalError("delta writer has been aborted");
     }
+    LOG(INFO) << "Closed delta writer. tablet_id=" << _tablet->tablet_id();
     return Status::OK();
 }
 

--- a/be/src/storage/vectorized/delta_writer.h
+++ b/be/src/storage/vectorized/delta_writer.h
@@ -55,7 +55,7 @@ public:
     [[nodiscard]] Status close();
 
     // Wait until all data have been flushed to disk, then create a new Rowset.
-    // REQUIRE: The DeltaWriter has been successfully `close()`d.
+    // Prerequite: the DeltaWriter has been successfully `close()`d.
     // [NOT thread-safe]
     [[nodiscard]] Status commit();
 
@@ -73,7 +73,7 @@ public:
 
     MemTracker* mem_tracker() { return _mem_tracker; };
 
-    // REQUIRE: has successfully `commit()`ed
+    // Return the rowset created by `commit()`, or nullptr if `commit()` not been called or failed.
     const Rowset* committed_rowset() const { return _cur_rowset.get(); }
 
     // REQUIRE: has successfully `commit()`ed

--- a/be/src/storage/vectorized/delta_writer.h
+++ b/be/src/storage/vectorized/delta_writer.h
@@ -100,6 +100,7 @@ private:
     Status _init();
     Status _flush_memtable_async();
     Status _flush_memtable();
+    const char* _state_name(State state) const;
 
     void _garbage_collection();
 

--- a/be/src/storage/vectorized/delta_writer.h
+++ b/be/src/storage/vectorized/delta_writer.h
@@ -2,8 +2,11 @@
 
 #pragma once
 
+#include <bthread/execution_queue.h>
+
 #include "column/vectorized_fwd.h"
 #include "gen_cpp/internal_service.pb.h"
+#include "gutil/macros.h"
 #include "storage/rowset/rowset_writer.h"
 #include "storage/tablet.h"
 
@@ -36,60 +39,89 @@ struct DeltaWriterOptions {
 };
 
 // Writer for a particular (load, index, tablet).
-// This class is NOT thread-safe, external synchronization is required.
 class DeltaWriter {
 public:
-    static Status open(const DeltaWriterOptions& opt, MemTracker* mem_tracker, DeltaWriter** writer);
-
+    // Create a new DeltaWriter and call `TxnManager::prepare_txn` to register a new trasaction associated with
+    // this DeltaWriter.
+    static StatusOr<std::unique_ptr<DeltaWriter>> open(const DeltaWriterOptions& opt, MemTracker* mem_tracker);
     ~DeltaWriter();
 
-    Status write(Chunk* chunk, const uint32_t* indexes, uint32_t from, uint32_t size);
+    DISALLOW_COPY_AND_ASSIGN(DeltaWriter);
 
-    // flush the last memtable to flush queue, must call it before close_wait()
-    Status close();
-    // wait for all memtables to be flushed.
-    // mem_consumption() should be 0 after this function returns.
-    Status close_wait(google::protobuf::RepeatedPtrField<PTabletInfo>* tablet_vec);
+    // [NOT thread-safe]
+    [[nodiscard]] Status write(const Chunk& chunk, const uint32_t* indexes, uint32_t from, uint32_t size);
 
-    // abandon current memtable and wait for all pending-flushing memtables to be destructed.
-    // mem_consumption() should be 0 after this function returns.
-    Status cancel();
+    // Flush all in-memory data to disk, without waiting.
+    // Subsequent `write()`s to this DeltaWriter will fail after this method returned.
+    // [NOT thread-safe]
+    [[nodiscard]] Status close();
 
-    // submit current memtable to flush queue.
-    // this is currently for reducing mem consumption of this delta writer.
-    Status flush_memtable_async();
-    // wait all memtables in flush queue to be flushed.
-    Status wait_memtable_flushed();
+    // Wait until all data have been flushed to disk, then create a new Rowset.
+    // REQUIRE: The DeltaWriter has been successfully `close()`d.
+    // [NOT thread-safe]
+    [[nodiscard]] Status commit();
+
+    // Rollback all writes and delete the Rowset created by 'commit()', if any.
+    // [thread-safe]
+    void abort();
+
+    int64_t txn_id() const { return _opt.txn_id; }
+
+    const PUniqueId& load_id() const { return _opt.load_id; }
 
     int64_t partition_id() const;
 
-    int64_t mem_consumption() const;
+    const Tablet* tablet() const { return _tablet.get(); }
+
+    MemTracker* mem_tracker() { return _mem_tracker; };
+
+    // REQUIRE: has successfully `commit()`ed
+    const Rowset* committed_rowset() const { return _cur_rowset.get(); }
+
+    // REQUIRE: has successfully `commit()`ed
+    const RowsetWriter* committed_rowset_writer() const { return _rowset_writer.get(); }
+
+    // REQUIRE: has successfully `commit()`ed
+    const vectorized::DictColumnsValidMap& global_dict_columns_valid_info() const {
+        CHECK_EQ(kCommitted, _state);
+        CHECK(_rowset_writer != nullptr);
+        return _rowset_writer->global_dict_columns_valid_info();
+    }
 
 private:
+    enum State {
+        kUninitialized,
+        kWriting,
+        kClosed,
+        kAborted,
+        kCommitted, // committed state can transfer to kAborted state
+    };
+
     DeltaWriter(const DeltaWriterOptions& opt, MemTracker* parent, StorageEngine* storage_engine);
 
     Status _init();
-
-    // push a full memtable to flush executor
     Status _flush_memtable_async();
+    Status _flush_memtable();
 
     void _garbage_collection();
 
     void _reset_mem_table();
 
-    bool _is_init = false;
+    State _get_state() { return _state.load(std::memory_order_acquire); }
+    void _set_state(State state) { _state.store(state, std::memory_order_release); }
+
+    std::atomic<State> _state;
     DeltaWriterOptions _opt;
+    MemTracker* _mem_tracker;
+    StorageEngine* _storage_engine;
+
     TabletSharedPtr _tablet;
     RowsetSharedPtr _cur_rowset;
     std::unique_ptr<RowsetWriter> _rowset_writer;
     std::unique_ptr<MemTable> _mem_table;
     const TabletSchema* _tablet_schema;
-    bool _delta_written_success;
 
-    StorageEngine* _storage_engine;
     std::unique_ptr<FlushToken> _flush_token;
-    std::unique_ptr<MemTracker> _mem_tracker;
-    bool _is_cancelled = false;
 };
 
 } // namespace vectorized

--- a/be/src/storage/vectorized/delta_writer.h
+++ b/be/src/storage/vectorized/delta_writer.h
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#include <bthread/execution_queue.h>
-
 #include "column/vectorized_fwd.h"
 #include "gen_cpp/internal_service.pb.h"
 #include "gutil/macros.h"

--- a/be/test/storage/vectorized/rowset_merger_test.cpp
+++ b/be/test/storage/vectorized/rowset_merger_test.cpp
@@ -63,8 +63,7 @@ public:
         return OLAP_SUCCESS;
     }
 
-    OLAPStatus add_columns(const vectorized::Chunk& chunk, const std::vector<uint32_t>& column_indexes,
-                           bool is_key) {
+    OLAPStatus add_columns(const vectorized::Chunk& chunk, const std::vector<uint32_t>& column_indexes, bool is_key) {
         if (is_key) {
             all_pks->append(*chunk.get_column_by_index(0), 0, chunk.num_rows());
         } else {


### PR DESCRIPTION
Summary: when the loading memory usage exceeds the limit, block the RPC thread
until the memtable flushed to disk or, in other words, stop the sender from sending
more chunks until the memtable has been flushed to disk.

It should be noted that when the memory usage exceeded the limit, a bunch of small
files may be created on disk, this is not a new issue introduced by this patch, but this
patch may increase the possibility. A new patch is needed to solve the problem of a
bunch of small files.