### PR TITLE
[Vertical compaction] calculate reader chunk size according to memory limit

### DIFF
--- a/be/src/storage/rowset/segment_v2/column_reader.cpp
+++ b/be/src/storage/rowset/segment_v2/column_reader.cpp
@@ -110,7 +110,7 @@ Status ColumnReader::_init(ColumnMetaPB* meta) {
     _column_type = static_cast<FieldType>(meta->type());
     _dict_page_pointer = PagePointer(meta->dict_page());
     _num_rows = meta->num_rows();
-    _total_raw_size = meta->total_raw_size();
+    _total_mem_footprint = meta->total_mem_footprint();
     _flags.set(kHasAllDictEncodedPos, meta->has_all_dict_encoded());
     _flags.set(kAllDictEncodedPos, meta->all_dict_encoded());
     _flags.set(kIsNullablePos, meta->is_nullable());

--- a/be/src/storage/rowset/segment_v2/column_reader.cpp
+++ b/be/src/storage/rowset/segment_v2/column_reader.cpp
@@ -110,6 +110,7 @@ Status ColumnReader::_init(ColumnMetaPB* meta) {
     _column_type = static_cast<FieldType>(meta->type());
     _dict_page_pointer = PagePointer(meta->dict_page());
     _num_rows = meta->num_rows();
+    _total_raw_size = meta->total_raw_size();
     _flags.set(kHasAllDictEncodedPos, meta->has_all_dict_encoded());
     _flags.set(kAllDictEncodedPos, meta->all_dict_encoded());
     _flags.set(kIsNullablePos, meta->is_nullable());

--- a/be/src/storage/rowset/segment_v2/column_reader.h
+++ b/be/src/storage/rowset/segment_v2/column_reader.h
@@ -137,6 +137,7 @@ public:
     bool all_dict_encoded() const { return _flags[kAllDictEncodedPos]; }
 
     size_t num_rows() const { return _num_rows; }
+    uint64_t total_raw_size() const { return _total_raw_size; }
 
     int32_t num_data_pages() { return _ordinal_index.reader ? _ordinal_index.reader->num_data_pages() : 0; }
 
@@ -225,6 +226,7 @@ private:
     PagePointer _dict_page_pointer;
     ColumnReaderOptions _opts;
     uint64_t _num_rows = 0;
+    uint64_t _total_raw_size = 0;
     const std::string& _file_name;
 
     // initialized in init(), used for create PageDecoder

--- a/be/src/storage/rowset/segment_v2/column_reader.h
+++ b/be/src/storage/rowset/segment_v2/column_reader.h
@@ -137,7 +137,7 @@ public:
     bool all_dict_encoded() const { return _flags[kAllDictEncodedPos]; }
 
     size_t num_rows() const { return _num_rows; }
-    uint64_t total_raw_size() const { return _total_raw_size; }
+    uint64_t total_mem_footprint() const { return _total_mem_footprint; }
 
     int32_t num_data_pages() { return _ordinal_index.reader ? _ordinal_index.reader->num_data_pages() : 0; }
 
@@ -226,7 +226,7 @@ private:
     PagePointer _dict_page_pointer;
     ColumnReaderOptions _opts;
     uint64_t _num_rows = 0;
-    uint64_t _total_raw_size = 0;
+    uint64_t _total_mem_footprint = 0;
     const std::string& _file_name;
 
     // initialized in init(), used for create PageDecoder

--- a/be/src/storage/rowset/segment_v2/column_writer.cpp
+++ b/be/src/storage/rowset/segment_v2/column_writer.cpp
@@ -240,6 +240,8 @@ public:
 
     bool is_global_dict_valid() override { return _scalar_column_writer->is_global_dict_valid(); }
 
+    uint64_t total_raw_size() const override { return _scalar_column_writer->total_raw_size(); }
+
 private:
     std::unique_ptr<ScalarColumnWriter> _scalar_column_writer;
     bool _is_speculated = false;
@@ -413,6 +415,7 @@ uint64_t ScalarColumnWriter::estimate_buffer_size() {
 Status ScalarColumnWriter::finish() {
     RETURN_IF_ERROR(finish_current_page());
     _opts.meta->set_num_rows(_next_rowid);
+    _opts.meta->set_total_raw_size(_total_raw_size);
     return Status::OK();
 }
 
@@ -600,6 +603,8 @@ Status ScalarColumnWriter::finish_current_page() {
 }
 
 Status ScalarColumnWriter::append(const vectorized::Column& column) {
+    _total_raw_size += column.byte_size();
+
     const uint8_t* ptr = column.raw_data();
     const uint8_t* null =
             is_nullable() ? down_cast<const vectorized::NullableColumn*>(&column)->null_column()->raw_data() : nullptr;
@@ -607,6 +612,8 @@ Status ScalarColumnWriter::append(const vectorized::Column& column) {
 }
 
 Status ScalarColumnWriter::append_array_offsets(const vectorized::Column& column) {
+    _total_raw_size += column.byte_size();
+
     // Write offset column, it's only used in ArrayColumn
     // [1, 2, 3], [4, 5, 6]
     // In memory, it will be transformed by actual offset(0, 3, 6)
@@ -753,6 +760,7 @@ ArrayColumnWriter::ArrayColumnWriter(const ColumnWriterOptions& opts, std::uniqu
                                      std::unique_ptr<ScalarColumnWriter> offset_writer,
                                      std::unique_ptr<ColumnWriter> element_writer)
         : ColumnWriter(std::move(field), opts.meta->is_nullable()),
+          _opts(opts),
           _null_writer(std::move(null_writer)),
           _array_size_writer(std::move(offset_writer)),
           _element_writer(std::move(element_writer)) {}
@@ -835,7 +843,20 @@ Status ArrayColumnWriter::finish() {
     }
     RETURN_IF_ERROR(_array_size_writer->finish());
     RETURN_IF_ERROR(_element_writer->finish());
+
+    _opts.meta->set_num_rows(get_next_rowid());
+    _opts.meta->set_total_raw_size(total_raw_size());
     return Status::OK();
+}
+
+uint64_t ArrayColumnWriter::total_raw_size() const {
+    uint64_t total_raw_size = 0;
+    if (is_nullable()) {
+        total_raw_size += _null_writer->total_raw_size();
+    }
+    total_raw_size += _array_size_writer->total_raw_size();
+    total_raw_size += _element_writer->total_raw_size();
+    return total_raw_size;
 }
 
 Status ArrayColumnWriter::write_data() {

--- a/be/src/storage/rowset/segment_v2/column_writer.h
+++ b/be/src/storage/rowset/segment_v2/column_writer.h
@@ -127,7 +127,7 @@ public:
 
     Field* get_field() const { return _field.get(); }
 
-    virtual uint64_t total_raw_size() const = 0;
+    virtual uint64_t total_mem_footprint() const = 0;
 
 private:
     std::unique_ptr<Field> _field;
@@ -175,7 +175,7 @@ public:
 
     bool is_global_dict_valid() override { return _is_global_dict_valid; }
 
-    uint64_t total_raw_size() const override { return _total_raw_size; }
+    uint64_t total_mem_footprint() const override { return _total_mem_footprint; }
 
 private:
     // All Pages will be organized into a linked list
@@ -247,7 +247,7 @@ private:
 
     bool _is_global_dict_valid = true;
 
-    uint64_t _total_raw_size = 0;
+    uint64_t _total_mem_footprint = 0;
 };
 
 class ArrayColumnWriter final : public ColumnWriter {
@@ -280,7 +280,7 @@ public:
 
     ordinal_t get_next_rowid() const override { return _array_size_writer->get_next_rowid(); }
 
-    uint64_t total_raw_size() const override;
+    uint64_t total_mem_footprint() const override;
 
 private:
     Status _append(const vectorized::Column& column);

--- a/be/src/storage/rowset/segment_v2/column_writer.h
+++ b/be/src/storage/rowset/segment_v2/column_writer.h
@@ -127,6 +127,8 @@ public:
 
     Field* get_field() const { return _field.get(); }
 
+    virtual uint64_t total_raw_size() const = 0;
+
 private:
     std::unique_ptr<Field> _field;
     bool _is_nullable;
@@ -172,6 +174,8 @@ public:
     ordinal_t get_next_rowid() const override { return _next_rowid; }
 
     bool is_global_dict_valid() override { return _is_global_dict_valid; }
+
+    uint64_t total_raw_size() const override { return _total_raw_size; }
 
 private:
     // All Pages will be organized into a linked list
@@ -242,6 +246,8 @@ private:
     int64_t _previous_ordinal = 0;
 
     bool _is_global_dict_valid = true;
+
+    uint64_t _total_raw_size = 0;
 };
 
 class ArrayColumnWriter final : public ColumnWriter {
@@ -274,8 +280,12 @@ public:
 
     ordinal_t get_next_rowid() const override { return _array_size_writer->get_next_rowid(); }
 
+    uint64_t total_raw_size() const override;
+
 private:
     Status _append(const vectorized::Column& column);
+
+    ColumnWriterOptions _opts;
 
     std::unique_ptr<ScalarColumnWriter> _null_writer;
     std::unique_ptr<ScalarColumnWriter> _array_size_writer;

--- a/be/src/storage/vectorized/compaction.cpp
+++ b/be/src/storage/vectorized/compaction.cpp
@@ -7,7 +7,9 @@
 #include "gutil/strings/substitute.h"
 #include "runtime/current_thread.h"
 #include "runtime/exec_env.h"
+#include "storage/rowset/beta_rowset.h"
 #include "storage/rowset/rowset_factory.h"
+#include "storage/rowset/segment_v2/column_reader.h"
 #include "storage/vectorized/chunk_helper.h"
 #include "storage/vectorized/tablet_reader.h"
 #include "util/defer_op.h"
@@ -72,6 +74,21 @@ uint32_t Compaction::get_segment_max_rows(int64_t max_segment_file_size, int64_t
         max_segment_rows = 1;
     }
     return max_segment_rows;
+}
+
+int32_t Compaction::get_read_chunk_size(int64_t mem_limit, int32_t config_chunk_size, int64_t total_num_rows,
+                                        int64_t total_row_size, size_t source_num) {
+    uint64_t chunk_size = config_chunk_size;
+    if (mem_limit > 0) {
+        int64_t avg_row_size = (total_row_size + 1) / (total_num_rows + 1);
+        // The result of the division operation be zero, so added one
+        chunk_size = 1 + mem_limit / (source_num * avg_row_size + 1);
+    }
+
+    if (chunk_size > config_chunk_size) {
+        chunk_size = config_chunk_size;
+    }
+    return chunk_size;
 }
 
 void Compaction::split_column_into_groups(size_t num_columns, size_t num_key_columns, int64_t max_columns_per_group,
@@ -152,9 +169,9 @@ Status Compaction::do_compaction_impl() {
     Statistics stats;
     Status res;
     if (algorithm == kVertical) {
-        res = _merge_rowsets_vertically(&stats);
+        res = _merge_rowsets_vertically(segment_iterator_num, &stats);
     } else {
-        res = _merge_rowsets_horizontally(config::compaction_memory_limit_per_worker, &stats);
+        res = _merge_rowsets_horizontally(segment_iterator_num, &stats);
     }
     if (!res.ok()) {
         LOG(WARNING) << "fail to do " << compaction_name() << ". res=" << res.to_string()
@@ -249,7 +266,7 @@ Status Compaction::construct_output_rowset_writer(uint32_t max_rows_per_segment,
     return Status::OK();
 }
 
-Status Compaction::_merge_rowsets_horizontally(int64_t mem_limit, Statistics* stats_output) {
+Status Compaction::_merge_rowsets_horizontally(size_t segment_iterator_num, Statistics* stats_output) {
     TRACE_COUNTER_SCOPE_LATENCY_US("merge_rowsets_latency_us");
     Schema schema = ChunkHelper::convert_schema_to_format_v2(_tablet->tablet_schema());
     TabletReader reader(_tablet, _output_rs_writer->version(), schema);
@@ -257,21 +274,15 @@ Status Compaction::_merge_rowsets_horizontally(int64_t mem_limit, Statistics* st
     reader_params.reader_type = compaction_type();
     reader_params.profile = _runtime_profile.create_child("merge_rowsets");
 
-    int64_t num_rows = 0;
+    int64_t total_num_rows = 0;
     int64_t total_row_size = 0;
-    uint64_t chunk_size = DEFAULT_CHUNK_SIZE;
-    if (mem_limit > 0) {
-        for (auto& rowset : _input_rowsets) {
-            num_rows += rowset->num_rows();
-            total_row_size += rowset->total_row_size();
-        }
-        int64_t avg_row_size = (total_row_size + 1) / (num_rows + 1);
-        // The result of thie division operation be zero, so added one
-        chunk_size = 1 + mem_limit / (_input_rowsets.size() * avg_row_size + 1);
+    for (auto& rowset : _input_rowsets) {
+        total_num_rows += rowset->num_rows();
+        total_row_size += rowset->total_row_size();
     }
-    if (chunk_size > config::vector_chunk_size) {
-        chunk_size = config::vector_chunk_size;
-    }
+    int32_t chunk_size = get_read_chunk_size(config::compaction_memory_limit_per_worker, config::vector_chunk_size,
+                                             total_num_rows, total_row_size, segment_iterator_num);
+    VLOG(1) << "tablet=" << _tablet->tablet_id() << ", reader chunk size=" << chunk_size;
     reader_params.chunk_size = chunk_size;
     RETURN_IF_ERROR(reader.prepare());
     RETURN_IF_ERROR(reader.open(reader_params));
@@ -334,7 +345,7 @@ Status Compaction::_merge_rowsets_horizontally(int64_t mem_limit, Statistics* st
     return Status::OK();
 }
 
-Status Compaction::_merge_rowsets_vertically(Statistics* stats_output) {
+Status Compaction::_merge_rowsets_vertically(size_t segment_iterator_num, Statistics* stats_output) {
     TRACE_COUNTER_SCOPE_LATENCY_US("merge_rowsets_latency_us");
     auto mask_buffer = std::make_unique<RowSourceMaskBuffer>(_tablet->tablet_id(), _tablet->data_dir()->path());
     auto source_masks = std::make_unique<std::vector<RowSourceMask>>();
@@ -350,7 +361,30 @@ Status Compaction::_merge_rowsets_vertically(Statistics* stats_output) {
         TabletReaderParams reader_params;
         reader_params.reader_type = compaction_type();
         reader_params.profile = _runtime_profile.create_child("merge_rowsets");
-        reader_params.chunk_size = config::vector_chunk_size;
+
+        int64_t total_num_rows = 0;
+        int64_t total_row_size = 0;
+        for (auto& rowset : _input_rowsets) {
+            if (rowset->rowset_meta()->rowset_type() != BETA_ROWSET) {
+                continue;
+            }
+
+            total_num_rows += rowset->num_rows();
+            auto* beta_rowset = down_cast<BetaRowset*>(rowset.get());
+            for (auto& segment : beta_rowset->segments()) {
+                for (uint32_t column_index : _column_groups[i]) {
+                    const auto* column_reader = segment->column(column_index);
+                    if (column_reader == nullptr) {
+                        continue;
+                    }
+                    total_row_size += column_reader->total_raw_size();
+                }
+            }
+        }
+        int32_t chunk_size = get_read_chunk_size(config::compaction_memory_limit_per_worker, config::vector_chunk_size,
+                                                 total_num_rows, total_row_size, segment_iterator_num);
+        VLOG(1) << "tablet=" << _tablet->tablet_id() << ", column group=" << i << ", reader chunk size=" << chunk_size;
+        reader_params.chunk_size = chunk_size;
         RETURN_IF_ERROR(reader.prepare());
         RETURN_IF_ERROR(reader.open(reader_params));
 

--- a/be/src/storage/vectorized/compaction.h
+++ b/be/src/storage/vectorized/compaction.h
@@ -61,7 +61,7 @@ public:
 
     static uint32_t get_segment_max_rows(int64_t max_segment_file_size, int64_t input_row_num, int64_t input_size);
     static int32_t get_read_chunk_size(int64_t mem_limit, int32_t config_chunk_size, int64_t num_rows,
-                                       int64_t total_row_size, size_t source_num);
+                                       int64_t total_mem_footprint, size_t source_num);
 
     static void split_column_into_groups(size_t num_columns, size_t num_key_columns, int64_t max_columns_per_group,
                                          std::vector<std::vector<uint32_t>>* column_groups);

--- a/be/src/storage/vectorized/compaction.h
+++ b/be/src/storage/vectorized/compaction.h
@@ -60,6 +60,8 @@ public:
                                                            size_t source_num);
 
     static uint32_t get_segment_max_rows(int64_t max_segment_file_size, int64_t input_row_num, int64_t input_size);
+    static int32_t get_read_chunk_size(int64_t mem_limit, int32_t config_chunk_size, int64_t num_rows,
+                                       int64_t total_row_size, size_t source_num);
 
     static void split_column_into_groups(size_t num_columns, size_t num_key_columns, int64_t max_columns_per_group,
                                          std::vector<std::vector<uint32_t>>* column_groups);
@@ -108,8 +110,8 @@ private:
     // merge rows from vectorized reader and write into `_output_rs_writer`.
     // return Status::OK() and set statistics into `*stats_output`.
     // return others on error
-    Status _merge_rowsets_horizontally(int64_t mem_limit, Statistics* stats_output);
-    Status _merge_rowsets_vertically(Statistics* stats_output);
+    Status _merge_rowsets_horizontally(size_t segment_iterator_num, Statistics* stats_output);
+    Status _merge_rowsets_vertically(size_t segment_iterator_num, Statistics* stats_output);
 };
 
 } // namespace starrocks::vectorized

--- a/be/test/storage/rowset/segment_v2/column_reader_writer_test.cpp
+++ b/be/test/storage/rowset/segment_v2/column_reader_writer_test.cpp
@@ -379,6 +379,10 @@ protected:
                 ASSERT_EQ("[1, 2, 3]", dst_column->debug_item(0));
                 ASSERT_EQ("[4, 5, 6]", dst_column->debug_item(1));
             }
+
+            // check num
+            ASSERT_EQ(2, reader->num_rows());
+            ASSERT_EQ(36, reader->total_raw_size());
         }
     }
 
@@ -606,6 +610,75 @@ TEST_F(ColumnReaderWriterTest, test_default_value) {
 TEST_F(ColumnReaderWriterTest, test_array_int) {
     test_int_array<2>();
     test_int_array<2>("1");
+}
+
+TEST_F(ColumnReaderWriterTest, test_scalar_column_total_raw_size) {
+    auto col = vectorized::ChunkHelper::column_from_field_type(OLAP_FIELD_TYPE_INT, true);
+    size_t count = 1024;
+    col->reserve(count);
+    for (int32_t i = 0; i < count; ++i) {
+        (void)col->append_numbers(&i, sizeof(int32_t));
+    }
+    for (size_t i = 0; i < count; i += 2) {
+        ((int32_t*)col->raw_data())[i] = 0;
+        (void)col->set_null(i);
+    }
+
+    ColumnMetaPB meta;
+    auto env = std::make_unique<EnvMemory>();
+    auto block_mgr = std::make_unique<fs::FileBlockManager>(env.get(), fs::BlockManagerOptions());
+    ASSERT_TRUE(env->create_dir(TEST_DIR).ok());
+    const std::string fname = strings::Substitute("$0/test_scalar_column_total_raw_size.data", TEST_DIR);
+
+    // write data
+    {
+        std::unique_ptr<fs::WritableBlock> wblock;
+        fs::CreateBlockOptions opts({fname});
+        Status st = block_mgr->create_block(opts, &wblock);
+        ASSERT_TRUE(st.ok()) << st.to_string();
+
+        ColumnWriterOptions writer_opts;
+        writer_opts.page_format = 2;
+        writer_opts.meta = &meta;
+        writer_opts.meta->set_column_id(0);
+        writer_opts.meta->set_unique_id(0);
+        writer_opts.meta->set_type(OLAP_FIELD_TYPE_INT);
+        writer_opts.adaptive_page_format = true;
+        writer_opts.meta->set_length(0);
+        writer_opts.meta->set_encoding(BIT_SHUFFLE);
+        writer_opts.meta->set_compression(starrocks::LZ4_FRAME);
+        writer_opts.meta->set_is_nullable(true);
+        writer_opts.need_zone_map = true;
+
+        TabletColumn column(OLAP_FIELD_AGGREGATION_NONE, OLAP_FIELD_TYPE_INT);
+        std::unique_ptr<ColumnWriter> writer;
+        ColumnWriter::create(writer_opts, &column, wblock.get(), &writer);
+        st = writer->init();
+        ASSERT_TRUE(st.ok()) << st.to_string();
+
+        ASSERT_TRUE(writer->append(*col).ok());
+
+        ASSERT_TRUE(writer->finish().ok());
+        ASSERT_TRUE(writer->write_data().ok());
+        ASSERT_TRUE(writer->write_ordinal_index().ok());
+        ASSERT_TRUE(writer->write_zone_map().ok());
+
+        // close the file
+        ASSERT_TRUE(wblock->close().ok());
+    }
+
+    // read and check
+    {
+        // read and check
+        ColumnReaderOptions reader_opts;
+        reader_opts.storage_format_version = 2;
+        reader_opts.block_mgr = block_mgr.get();
+        auto res = ColumnReader::create(_tablet_meta_mem_tracker.get(), reader_opts, &meta, fname);
+        ASSERT_TRUE(res.ok());
+        auto reader = std::move(res).value();
+        ASSERT_EQ(1024, reader->num_rows());
+        ASSERT_EQ(1024 * 4 + 1024, reader->total_raw_size());
+    }
 }
 
 } // namespace starrocks::segment_v2

--- a/be/test/storage/rowset/segment_v2/column_reader_writer_test.cpp
+++ b/be/test/storage/rowset/segment_v2/column_reader_writer_test.cpp
@@ -382,7 +382,7 @@ protected:
 
             // check num
             ASSERT_EQ(2, reader->num_rows());
-            ASSERT_EQ(36, reader->total_raw_size());
+            ASSERT_EQ(36, reader->total_mem_footprint());
         }
     }
 
@@ -612,7 +612,7 @@ TEST_F(ColumnReaderWriterTest, test_array_int) {
     test_int_array<2>("1");
 }
 
-TEST_F(ColumnReaderWriterTest, test_scalar_column_total_raw_size) {
+TEST_F(ColumnReaderWriterTest, test_scalar_column_total_mem_footprint) {
     auto col = vectorized::ChunkHelper::column_from_field_type(OLAP_FIELD_TYPE_INT, true);
     size_t count = 1024;
     col->reserve(count);
@@ -628,7 +628,7 @@ TEST_F(ColumnReaderWriterTest, test_scalar_column_total_raw_size) {
     auto env = std::make_unique<EnvMemory>();
     auto block_mgr = std::make_unique<fs::FileBlockManager>(env.get(), fs::BlockManagerOptions());
     ASSERT_TRUE(env->create_dir(TEST_DIR).ok());
-    const std::string fname = strings::Substitute("$0/test_scalar_column_total_raw_size.data", TEST_DIR);
+    const std::string fname = strings::Substitute("$0/test_scalar_column_total_mem_footprint.data", TEST_DIR);
 
     // write data
     {
@@ -677,7 +677,7 @@ TEST_F(ColumnReaderWriterTest, test_scalar_column_total_raw_size) {
         ASSERT_TRUE(res.ok());
         auto reader = std::move(res).value();
         ASSERT_EQ(1024, reader->num_rows());
-        ASSERT_EQ(1024 * 4 + 1024, reader->total_raw_size());
+        ASSERT_EQ(1024 * 4 + 1024, reader->total_mem_footprint());
     }
 }
 

--- a/be/test/storage/vectorized/cumulative_compaction_test.cpp
+++ b/be/test/storage/vectorized/cumulative_compaction_test.cpp
@@ -251,4 +251,25 @@ TEST_F(CumulativeCompactionTest, test_vertical_compact_succeed) {
     do_compaction();
 }
 
+TEST_F(CumulativeCompactionTest, test_read_chunk_size) {
+    // total row size is 0 in old segment
+    int64_t mem_limit = 2147483648;
+    int32_t config_chunk_size = 4096;
+    int64_t total_num_rows = 10000;
+    int64_t total_row_size = 0;
+    size_t source_num = 10;
+    ASSERT_EQ(config_chunk_size, Compaction::get_read_chunk_size(mem_limit, config_chunk_size, total_num_rows,
+                                                                 total_row_size, source_num));
+
+    // normal total row size
+    total_row_size = 1073741824;
+    ASSERT_EQ(2001, Compaction::get_read_chunk_size(mem_limit, config_chunk_size, total_num_rows,
+                                                    total_row_size, source_num));
+
+    // mem limit is 0
+    mem_limit = 0;
+    ASSERT_EQ(config_chunk_size, Compaction::get_read_chunk_size(mem_limit, config_chunk_size, total_num_rows,
+                                                                 total_row_size, source_num));
+}
+
 } // namespace starrocks::vectorized

--- a/be/test/storage/vectorized/cumulative_compaction_test.cpp
+++ b/be/test/storage/vectorized/cumulative_compaction_test.cpp
@@ -256,20 +256,20 @@ TEST_F(CumulativeCompactionTest, test_read_chunk_size) {
     int64_t mem_limit = 2147483648;
     int32_t config_chunk_size = 4096;
     int64_t total_num_rows = 10000;
-    int64_t total_row_size = 0;
+    int64_t total_mem_footprint = 0;
     size_t source_num = 10;
     ASSERT_EQ(config_chunk_size, Compaction::get_read_chunk_size(mem_limit, config_chunk_size, total_num_rows,
-                                                                 total_row_size, source_num));
+                                                                 total_mem_footprint, source_num));
 
-    // normal total row size
-    total_row_size = 1073741824;
+    // normal total memory footprint
+    total_mem_footprint = 1073741824;
     ASSERT_EQ(2001, Compaction::get_read_chunk_size(mem_limit, config_chunk_size, total_num_rows,
-                                                    total_row_size, source_num));
+                                                    total_mem_footprint, source_num));
 
     // mem limit is 0
     mem_limit = 0;
     ASSERT_EQ(config_chunk_size, Compaction::get_read_chunk_size(mem_limit, config_chunk_size, total_num_rows,
-                                                                 total_row_size, source_num));
+                                                                 total_mem_footprint, source_num));
 }
 
 } // namespace starrocks::vectorized

--- a/gensrc/proto/segment_v2.proto
+++ b/gensrc/proto/segment_v2.proto
@@ -169,6 +169,8 @@ message ColumnMetaPB {
     optional uint64 num_rows = 11;
     // whether all data pages are encoded by dict encoding.
     optional bool all_dict_encoded = 30;
+    // used to calculate reader chunk size in vertical compaction
+    optional uint64 total_raw_size = 31;
 }
 
 message SegmentFooterPB {

--- a/gensrc/proto/segment_v2.proto
+++ b/gensrc/proto/segment_v2.proto
@@ -170,7 +170,7 @@ message ColumnMetaPB {
     // whether all data pages are encoded by dict encoding.
     optional bool all_dict_encoded = 30;
     // used to calculate reader chunk size in vertical compaction
-    optional uint64 total_raw_size = 31;
+    optional uint64 total_mem_footprint = 31;
 }
 
 message SegmentFooterPB {


### PR DESCRIPTION
#1112

The default reader chunk size is 4096. When the string column is large,
the chunk read from each segment will be very large and take up a lot of memory.

So reader chunk size needs to be calculated according to memory limit and column size.

Fix calculation bug when the rowset is overlapping in horizontal compaction