### PR TITLE
Revert "use read size not serailized size to check sanity (#2163)"

### DIFF
--- a/be/src/column/chunk.cpp
+++ b/be/src/column/chunk.cpp
@@ -191,7 +191,6 @@ Status Chunk::deserialize(const uint8_t* src, size_t len, const RuntimeChunkMeta
     _tuple_id_to_index = meta.tuple_id_to_index;
     _columns.resize(_slot_id_to_index.size() + _tuple_id_to_index.size());
 
-    const uint8_t* data_start = src;
     uint32_t version = decode_fixed32_le(src);
     DCHECK_EQ(version, 1);
     src += sizeof(uint32_t);
@@ -206,12 +205,11 @@ Status Chunk::deserialize(const uint8_t* src, size_t len, const RuntimeChunkMeta
     for (const auto& column : _columns) {
         src = column->deserialize_column(src);
     }
-    const uint8_t* data_end = src;
-    size_t read_size = (data_end - data_start);
 
-    if (UNLIKELY(len != read_size)) {
+    size_t except = serialize_size();
+    if (UNLIKELY(len != except)) {
         return Status::InternalError(
-                strings::Substitute("deserialize chunk data failed. len: $0, read: $1", len, read_size));
+                strings::Substitute("deserialize chunk data failed. len: $0, except: $1", len, except));
     }
     DCHECK_EQ(rows, num_rows());
     return Status::OK();


### PR DESCRIPTION
This reverts commit eb530ee3740162b65128fdd2269b54f0cca023d9.

Note: I'm gonna revert this PR because we find some object type like percentile and HLL does not fit this logic. Percentile and HLL will allocate more serialized size but don't use that much space.

I'm gonna further to explore some backward-compatible solution to fix this problem.