### PR TITLE
Add extra field `serialized_size` to check deserialize sanity

### DIFF
--- a/be/src/column/chunk.cpp
+++ b/be/src/column/chunk.cpp
@@ -138,7 +138,8 @@ size_t Chunk::serialize_size() const {
     return size;
 }
 
-void Chunk::serialize(uint8_t* dst) const {
+size_t Chunk::serialize(uint8_t* dst) const {
+    uint8_t* head = dst;
     uint32_t version = 1;
     encode_fixed32_le(dst, version);
     dst += sizeof(uint32_t);
@@ -149,6 +150,7 @@ void Chunk::serialize(uint8_t* dst) const {
     for (const auto& column : _columns) {
         dst = column->serialize_column(dst);
     }
+    return dst - head;
 }
 
 size_t Chunk::serialize_with_meta(starrocks::ChunkPB* chunk) const {
@@ -182,15 +184,17 @@ size_t Chunk::serialize_with_meta(starrocks::ChunkPB* chunk) const {
 
     size_t size = serialize_size();
     chunk->mutable_data()->resize(size);
-    serialize((uint8_t*)chunk->mutable_data()->data());
+    size_t written_size = serialize((uint8_t*)chunk->mutable_data()->data());
+    chunk->set_serialized_size(written_size);
     return size;
 }
 
-Status Chunk::deserialize(const uint8_t* src, size_t len, const RuntimeChunkMeta& meta) {
+Status Chunk::deserialize(const uint8_t* src, size_t len, const RuntimeChunkMeta& meta, size_t serialized_size) {
     _slot_id_to_index = meta.slot_id_to_index;
     _tuple_id_to_index = meta.tuple_id_to_index;
     _columns.resize(_slot_id_to_index.size() + _tuple_id_to_index.size());
 
+    const uint8_t* head = src;
     uint32_t version = decode_fixed32_le(src);
     DCHECK_EQ(version, 1);
     src += sizeof(uint32_t);
@@ -206,10 +210,18 @@ Status Chunk::deserialize(const uint8_t* src, size_t len, const RuntimeChunkMeta
         src = column->deserialize_column(src);
     }
 
-    size_t except = serialize_size();
-    if (UNLIKELY(len != except)) {
-        return Status::InternalError(
-                strings::Substitute("deserialize chunk data failed. len: $0, except: $1", len, except));
+    // The logic is a bit confusing here.
+    // `len` and `expected` are both "estimated" serialized size. it could be larger than real serialized size.
+    // `serialized_size` and `read_size` are both "real" serialized size. it's exactly how much bytes are written into buffer.
+    // For some object column types like bitmap/hll/percentile, "estimated" and "real" are not always the same.
+    // And fr bitmap, sometimes `len` and `expected` are different. So to fix that problem, we fallback to compare "real" serialized size.
+    size_t read_size = src - head;
+    size_t expected = serialize_size();
+
+    if (UNLIKELY(len != expected && read_size != serialized_size)) {
+        return Status::InternalError(strings::Substitute(
+                "deserialize chunk data failed. len: $0, expected: $1, serialized_size: $2, deserialized_size: $3", len,
+                expected, serialized_size, read_size));
     }
     DCHECK_EQ(rows, num_rows());
     return Status::OK();

--- a/be/src/column/chunk.cpp
+++ b/be/src/column/chunk.cpp
@@ -214,9 +214,8 @@ Status Chunk::deserialize(const uint8_t* src, size_t len, const RuntimeChunkMeta
     // `len` and `expected` are both "estimated" serialized size. it could be larger than real serialized size.
     // `serialized_size` and `read_size` are both "real" serialized size. it's exactly how much bytes are written into buffer.
     // For some object column types like bitmap/hll/percentile, "estimated" and "real" are not always the same.
-    // And fr bitmap, sometimes `len` and `expected` are different. So to fix that problem, we fallback to compare "real" serialized size.
+    // And for bitmap, sometimes `len` and `expected` are different. So to fix that problem, we fallback to compare "real" serialized size.
 
-    // kks gives a proposal, and I think it's a truly great idea.
     // We compare "real" serialized size first. It may fails because of backward compatibility. For old version of BE,
     // there is no "serialized_size" this field(which means the value is zero), and we fallback to compare "estimated" serialized size.
     // And for new version of BE, the "real" serialized size always matches, and we can save the cost of calling `serialzied_size`.

--- a/be/src/column/chunk.h
+++ b/be/src/column/chunk.h
@@ -119,10 +119,10 @@ public:
     //     ...
     //     column n data
     // Note: You should ensure the dst buffer size is enough
-    void serialize(uint8_t* dst) const;
+    size_t serialize(uint8_t* dst) const;
 
     // Deserialize chunk by |src| (chunk data) and |meta| (chunk meta)
-    Status deserialize(const uint8_t* src, size_t len, const RuntimeChunkMeta& meta);
+    Status deserialize(const uint8_t* src, size_t len, const RuntimeChunkMeta& meta, size_t serialized_size);
 
     // Create an empty chunk with the same meta and reserve it of size chunk _num_rows
     // not clone tuple column

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -472,7 +472,8 @@ Status ExchangeSinkOperator::serialize_chunk(const vectorized::Chunk* src, Chunk
             uncompressed_size = src->serialize_size();
             // TODO(kks): resize without initializing the new bytes
             dst->mutable_data()->resize(uncompressed_size);
-            src->serialize((uint8_t*)dst->mutable_data()->data());
+            size_t written_size = src->serialize((uint8_t*)dst->mutable_data()->data());
+            dst->set_serialized_size(written_size);
         }
     }
 

--- a/be/src/runtime/data_stream_recvr.cc
+++ b/be/src/runtime/data_stream_recvr.cc
@@ -502,9 +502,11 @@ Status DataStreamRecvr::SenderQueue::add_chunks_and_keep_order(const PTransmitCh
 
 Status DataStreamRecvr::SenderQueue::_deserialize_chunk(const ChunkPB& pchunk, vectorized::Chunk* chunk,
                                                         faststring* uncompressed_buffer) {
+    size_t serialized_size = pchunk.serialized_size();
     if (pchunk.compress_type() == CompressionTypePB::NO_COMPRESSION) {
         SCOPED_TIMER(_recvr->_deserialize_row_batch_timer);
-        RETURN_IF_ERROR(chunk->deserialize((const uint8_t*)pchunk.data().data(), pchunk.data().size(), _chunk_meta));
+        RETURN_IF_ERROR(chunk->deserialize((const uint8_t*)pchunk.data().data(), pchunk.data().size(), _chunk_meta,
+                                           serialized_size));
     } else {
         size_t uncompressed_size = 0;
         {
@@ -518,7 +520,8 @@ Status DataStreamRecvr::SenderQueue::_deserialize_chunk(const ChunkPB& pchunk, v
         }
         {
             SCOPED_TIMER(_recvr->_deserialize_row_batch_timer);
-            RETURN_IF_ERROR(chunk->deserialize(uncompressed_buffer->data(), uncompressed_size, _chunk_meta));
+            RETURN_IF_ERROR(
+                    chunk->deserialize(uncompressed_buffer->data(), uncompressed_size, _chunk_meta, serialized_size));
         }
     }
     return Status::OK();

--- a/be/src/runtime/tablets_channel.cpp
+++ b/be/src/runtime/tablets_channel.cpp
@@ -102,7 +102,8 @@ Status TabletsChannel::add_chunk(const PTabletWriterAddChunkRequest& params) {
     }
 
     vectorized::Chunk chunk;
-    RETURN_IF_ERROR(chunk.deserialize((const uint8_t*)pchunk.data().data(), pchunk.data().size(), _chunk_meta));
+    RETURN_IF_ERROR(chunk.deserialize((const uint8_t*)pchunk.data().data(), pchunk.data().size(), _chunk_meta,
+                                      pchunk.serialized_size()));
     DCHECK_EQ(params.tablet_ids_size(), chunk.num_rows());
 
     size_t channel_size = _tablet_id_to_sorted_indexes.size();

--- a/be/test/column/chunk_test.cpp
+++ b/be/test/column/chunk_test.cpp
@@ -149,7 +149,7 @@ TEST_F(ChunkTest, test_serde) {
 
     std::string buffer;
     buffer.resize(chunk->serialize_size());
-    chunk->serialize((uint8_t*)buffer.data());
+    size_t written_size = chunk->serialize((uint8_t*)buffer.data());
 
     RuntimeChunkMeta meta;
     meta.slot_id_to_index.init(2);
@@ -162,7 +162,7 @@ TEST_F(ChunkTest, test_serde) {
     meta.types[1] = TypeDescriptor(PrimitiveType::TYPE_INT);
 
     std::unique_ptr<Chunk> new_chunk = chunk->clone_empty_with_schema();
-    new_chunk->deserialize((uint8_t*)buffer.data(), buffer.size(), meta);
+    new_chunk->deserialize((uint8_t*)buffer.data(), buffer.size(), meta, written_size);
 
     ASSERT_EQ(new_chunk->num_rows(), chunk->num_rows());
     for (size_t i = 0; i < chunk->columns().size(); ++i) {

--- a/gensrc/proto/data.proto
+++ b/gensrc/proto/data.proto
@@ -59,4 +59,7 @@ message ChunkPB {
     repeated bool is_consts = 6; // column is const
     repeated int32 tuple_id_map = 7; // tuple id to column id map
     optional int64 data_size = 8; // used to record size using brpc attachment
+    // for some object column types like bitmap/hll/percentile
+    // we may estimate larger serialized_size but actually don't use that much space.
+    optional int64 serialized_size  = 9; // how many bytes are really written into data.
 };


### PR DESCRIPTION
ref: #2166 

reverted pr: #2163  #2193 

This PR proposes another solution to check deserialized sanity:
1. when doing serialization work, we add `seraizlied_size` into `ChunkPB`. This field means how many bytes are actually written into buffer
2. when doing deserialization work,  we comapre two pairs. If any of them matches, we think it's okay:
   - `len` vs `chunk->serialized_size()`. they are both estimated serialized size. 
   - `serialized_size` vs `read_size`. they are both exact serialized size.

And this solution is backward-compatible.