### PR TITLE
[Colocate] refactor colocate group status modification api

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpServer.java
@@ -150,6 +150,7 @@ public class HttpServer {
         ColocateMetaService.BucketSeqAction.registerAction(controller);
         ColocateMetaService.ColocateMetaAction.registerAction(controller);
         ColocateMetaService.MarkGroupStableAction.registerAction(controller);
+        ColocateMetaService.MarkGroupUnstableAction.registerAction(controller);
         ProfileAction.registerAction(controller);
         QueryDetailAction.registerAction(controller);
         ConnectionAction.registerAction(controller);


### PR DESCRIPTION
fix #1705 

The old api uses post and delete to mark unstable or stable, and is confusing.
The behavior is opposite to the documentation.

I think it would be better to change to the following:
`POST /api/colocate/group_stable?db_id=10005&group_id=10008` mark group stable
`POST /api/colocate/group_unstable?db_id=10005&group_id=10008` mark group unstable