### PR TITLE
[pipeline] Remove close in enter_eos_phase

### DIFF
--- a/be/src/exec/vectorized/hash_joiner.h
+++ b/be/src/exec/vectorized/hash_joiner.h
@@ -119,9 +119,7 @@ public:
             _phase.compare_exchange_strong(old_phase, HashJoinPhase::EOS);
         }
     }
-    void enter_eos_phase() {
-        _phase = HashJoinPhase::EOS;
-    }
+    void enter_eos_phase() { _phase = HashJoinPhase::EOS; }
     // build phase
     Status append_chunk_to_ht(RuntimeState* state, const ChunkPtr& chunk);
     Status build_ht(RuntimeState* state);

--- a/be/src/exec/vectorized/hash_joiner.h
+++ b/be/src/exec/vectorized/hash_joiner.h
@@ -121,7 +121,6 @@ public:
     }
     void enter_eos_phase() {
         _phase = HashJoinPhase::EOS;
-        _ht.close();
     }
     // build phase
     Status append_chunk_to_ht(RuntimeState* state, const ChunkPtr& chunk);


### PR DESCRIPTION
- Remove _ht.close() in enter_eos_phase, just keep one call of _ht.close() in HashJoiner::close.