### PR TITLE
Fix JoinAssociativityRule projection rewrite error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/JoinAssociativityRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/JoinAssociativityRule.java
@@ -161,6 +161,9 @@ public class JoinAssociativityRule extends TransformationRule {
         HashMap<ColumnRefOperator, ScalarOperator> rightExpression = new HashMap<>();
         HashMap<ColumnRefOperator, ScalarOperator> leftExpression = new HashMap<>();
         if (leftChildJoinProjection != null) {
+            // leftChildJoinProjection not only contains the projection from leftChild1 and leftChild2.
+            // but also contains the projection generated from left join, such like columnRef -> constant(20 -> "16")
+            // this projection is can put it leftExpression or rightExpression. we put it on the right here.
             for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : leftChildJoinProjection.getColumnRefMap()
                     .entrySet()) {
                 if (!entry.getValue().isColumnRef() &&
@@ -169,6 +172,10 @@ public class JoinAssociativityRule extends TransformationRule {
                 } else if (!entry.getValue().isColumnRef() &&
                         leftChild1.getOutputColumns().containsAll(entry.getValue().getUsedColumns())) {
                     leftExpression.put(entry.getKey(), entry.getValue());
+                } else if (!entry.getValue().isColumnRef()) {
+                    // because we put columnRef -> constant(20 -> "16") the rightExpression, the other projection like
+                    // columnRef ->columnRef (21 -> 20) also need to put to rightExpression.
+                    rightExpression.put(entry.getKey(), entry.getValue());
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -171,12 +171,7 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
 
             Preconditions.checkState(projection.getCommonSubOperatorMap().isEmpty());
             for (ColumnRefOperator columnRefOperator : projection.getColumnRefMap().keySet()) {
-                // derive stats from child
-                // use clone here because it will be rewrite later
-                ScalarOperator mapOperator = projection.getColumnRefMap().get(columnRefOperator).clone();
-
-                ReplaceColumnRefRewriter rewriter = new ReplaceColumnRefRewriter(projection.getColumnRefMap(), true);
-                mapOperator = mapOperator.accept(rewriter, null);
+                ScalarOperator mapOperator = projection.getColumnRefMap().get(columnRefOperator);
                 pruneBuilder.addColumnStatistic(columnRefOperator,
                         ExpressionStatisticCalculator.calculate(mapOperator, pruneBuilder.build()));
             }
@@ -561,8 +556,6 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
         allBuilder.addColumnStatistics(inputStatistics.getColumnStatistics());
 
         for (ColumnRefOperator requiredColumnRefOperator : columnRefMap.keySet()) {
-            // derive stats from child
-            // use clone here because it will be rewrite later
             ScalarOperator mapOperator = columnRefMap.get(requiredColumnRefOperator);
             ColumnStatistic outputStatistic = ExpressionStatisticCalculator.calculate(mapOperator, allBuilder.build());
             builder.addColumnStatistic(requiredColumnRefOperator, outputStatistic);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -93,7 +93,6 @@ import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.PredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
-import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
 import com.starrocks.sql.optimizer.rule.transformation.JoinPredicateUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -5015,4 +5015,41 @@ public class PlanFragmentTest extends PlanTestBase {
         Assert.assertTrue(plan.contains("6:Project\n" +
                 "  |  <slot 2> : 2: v2"));
     }
+
+    @Test
+    public void testSelectConstantFormJoin() throws Exception {
+        String sql = "SELECT \n" +
+                "  * \n" +
+                "from \n" +
+                "  (\n" +
+                "    select \n" +
+                "      ref_0.t1c as c5, \n" +
+                "      37 as c6 \n" +
+                "    from \n" +
+                "      test_all_type as ref_0 \n" +
+                "      inner join test_all_type as ref_1 on (\n" +
+                "        ref_0.t1f = ref_1.t1f\n" +
+                "      ) \n" +
+                "    where \n" +
+                "      ref_0.t1c <> ref_0.t1c\n" +
+                "  ) as subq_0 \n" +
+                "  inner join part as ref_2 on (subq_0.c5 = ref_2.P_PARTKEY) \n" +
+                "  inner join supplier as ref_3 on (subq_0.c5 = ref_3.S_SUPPKEY) \n" +
+                "where \n" +
+                "  (\n" +
+                "    (ref_3.S_NAME > ref_2.P_TYPE) \n" +
+                "    and (true)\n" +
+                "  ) \n" +
+                "  and (\n" +
+                "    (subq_0.c6 = ref_3.S_NATIONKEY) \n" +
+                "    and (true)\n" +
+                "  ) \n" +
+                "limit \n" +
+                "  45;";
+        String plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains(" 6:Project\n" +
+                "  |  <slot 3> : 3: t1c\n" +
+                "  |  <slot 21> : 37\n" +
+                "  |  <slot 40> : CAST(21: expr AS INT)"));
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -5047,9 +5047,8 @@ public class PlanFragmentTest extends PlanTestBase {
                 "limit \n" +
                 "  45;";
         String plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains(" 6:Project\n" +
+        Assert.assertTrue(plan.contains("6:Project\n" +
                 "  |  <slot 3> : 3: t1c\n" +
-                "  |  <slot 21> : 37\n" +
-                "  |  <slot 40> : CAST(21: expr AS INT)"));
+                "  |  <slot 40> : CAST(37 AS INT)"));
     }
 }


### PR DESCRIPTION
#2219 
In JoinAssociativityRule 
```
           join1
         /        \
      join2        C
    /      \
    A      B
```
 join2's projection which push to A should use the projection of A to rewrite 