### PR TITLE
Segement use native lz4 library to compress/decompress page

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -461,8 +461,6 @@ set(STARROCKS_DEPENDENCIES
     ${STARROCKS_DEPENDENCIES}
     ${WL_START_GROUP}
     rocksdb
-    librdkafka_cpp
-    librdkafka
     libs2
     snappy
     ${Boost_LIBRARIES}
@@ -471,6 +469,7 @@ set(STARROCKS_DEPENDENCIES
     glog
     re2
     pprof
+    # lz4 must set before librdkafka
     lz4
     libevent
     curl
@@ -497,6 +496,8 @@ set(STARROCKS_DEPENDENCIES
     ryu
     hyperscan
     simdjson
+    librdkafka_cpp
+    librdkafka
     ${WL_END_GROUP}
 )
 

--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -469,7 +469,8 @@ set(STARROCKS_DEPENDENCIES
     glog
     re2
     pprof
-    # lz4 must set before librdkafka
+    # Put lz4 in front of librdkafka to make sure that segment use the native lz4 library to compress/decompress page
+    # Otherwise, he will use the lz4 Library in librdkafka
     lz4
     libevent
     curl


### PR DESCRIPTION
for #2249 

Current segment use lz4 library of librdkafka to compress/decompress page, lz4 library use rd_malloc to malloc memory. It will crash when alloc failed. The native lz4 library will return code, when alloc memory failed