### PR TITLE
Remove default nullptr value of ExecNode::init

### DIFF
--- a/be/src/exec/exec_node.h
+++ b/be/src/exec/exec_node.h
@@ -82,7 +82,7 @@ public:
     /// Initializes this object from the thrift tnode desc. The subclass should
     /// do any initialization that can fail in Init() rather than the ctor.
     /// If overridden in subclass, must first call superclass's Init().
-    virtual Status init(const TPlanNode& tnode, RuntimeState* state = nullptr);
+    virtual Status init(const TPlanNode& tnode, RuntimeState* state);
 
     // Sets up internal structures, etc., without doing any actual work.
     // Must be called prior to open(). Will only be called once in this

--- a/be/src/exec/vectorized/file_scan_node.cpp
+++ b/be/src/exec/vectorized/file_scan_node.cpp
@@ -38,7 +38,7 @@ FileScanNode::~FileScanNode() {
 }
 
 Status FileScanNode::init(const TPlanNode& tnode, RuntimeState* state) {
-    RETURN_IF_ERROR(ScanNode::init(tnode));
+    RETURN_IF_ERROR(ScanNode::init(tnode, state));
     return Status::OK();
 }
 

--- a/be/src/exec/vectorized/schema_scan_node.cpp
+++ b/be/src/exec/vectorized/schema_scan_node.cpp
@@ -29,7 +29,7 @@ SchemaScanNode::~SchemaScanNode() {
 }
 
 Status SchemaScanNode::init(const TPlanNode& tnode, RuntimeState* state) {
-    RETURN_IF_ERROR(ExecNode::init(tnode));
+    RETURN_IF_ERROR(ExecNode::init(tnode, state));
     if (tnode.schema_scan_node.__isset.db) {
         _scanner_param.db = _pool->add(new std::string(tnode.schema_scan_node.db));
     }


### PR DESCRIPTION
Currently, `_runtime_state` is set by `ExecNode::init()`, so we must pass `state` to `ExecNode::init()`.

Fix #2244.