### PR TITLE
fix fail to prepare tablet reader bug for branch 2.0 (#2026)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -630,7 +630,7 @@ public class DatabaseTransactionMgr {
     // check whether transaction can be finished or not
     // for each tablet of load txn, if most replicas version publish successed
     // the trasaction can be treated as successful and can be finished
-    public boolean canTxnFinished(TransactionState txn, Set<Long> errReplicas) {
+    public boolean canTxnFinished(TransactionState txn, Set<Long> errReplicas, Set<Long> unfinishedBackends) {
         Database db = catalog.getDb(txn.getDbId());
         if (db == null) {
             return true;
@@ -670,6 +670,9 @@ public class DatabaseTransactionMgr {
                                 if (!errReplicas.contains(replica.getId()) && replica.getLastFailedVersion() < 0) {
                                     if (replica.getVersion() >= partitionCommitInfo.getVersion()) {
                                         ++healthReplicaNum;
+                                    } else if (unfinishedBackends != null
+                                            && unfinishedBackends.contains(replica.getBackendId())) {
+                                        errReplicas.add(replica.getId());
                                     }
                                 }
                             }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -429,9 +429,10 @@ public class GlobalTransactionMgr implements Writable {
         dbTransactionMgr.finishTransaction(transactionId, errorReplicaIds);
     }
 
-    public boolean canTxnFinished(TransactionState txn, Set<Long> errReplicas) throws UserException {
+    public boolean canTxnFinished(TransactionState txn, Set<Long> errReplicas,
+                                  Set<Long> unfinishedBackends) throws UserException {
         DatabaseTransactionMgr dbTransactionMgr = getDatabaseTransactionMgr(txn.getDbId());
-        return dbTransactionMgr.canTxnFinished(txn, errReplicas);
+        return dbTransactionMgr.canTxnFinished(txn, errReplicas, unfinishedBackends);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -94,6 +94,7 @@ public class PublishVersionDaemon extends MasterDaemon {
         for (TransactionState transactionState : readyTransactionStates) {
             Map<Long, PublishVersionTask> transTasks = transactionState.getPublishVersionTasks();
             Set<Long> publishErrorReplicaIds = Sets.newHashSet();
+            Set<Long> unfinishedBackends = Sets.newHashSet();
             boolean allTaskFinished = true;
             for (PublishVersionTask publishVersionTask : transTasks.values()) {
                 if (publishVersionTask.isFinished()) {
@@ -105,11 +106,13 @@ public class PublishVersionDaemon extends MasterDaemon {
                     }
                 } else {
                     allTaskFinished = false;
+                    unfinishedBackends.add(publishVersionTask.getBackendId());
                 }
             }
             boolean shouldFinishTxn = true;
             if (!allTaskFinished) {
-                shouldFinishTxn = globalTransactionMgr.canTxnFinished(transactionState, publishErrorReplicaIds);
+                shouldFinishTxn = globalTransactionMgr.canTxnFinished(transactionState,
+                        publishErrorReplicaIds, unfinishedBackends);
             }
 
             if (shouldFinishTxn) {

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/GlobalTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/GlobalTransactionMgrTest.java
@@ -527,7 +527,7 @@ public class GlobalTransactionMgrTest {
         FakeCatalog.setCatalog(masterCatalog);
         Set<Long> errorReplicaIds = Sets.newHashSet();
         errorReplicaIds.add(CatalogTestUtil.testReplicaId2);
-        assertEquals(masterTransMgr.canTxnFinished(transactionState, errorReplicaIds), false);
+        assertEquals(masterTransMgr.canTxnFinished(transactionState, errorReplicaIds, Sets.newHashSet()), false);
         masterTransMgr.finishTransaction(CatalogTestUtil.testDbId1, transactionId, errorReplicaIds);
         assertEquals(TransactionStatus.COMMITTED, transactionState.getTransactionStatus());
         Replica replcia1 = tablet.getReplicaById(CatalogTestUtil.testReplicaId1);
@@ -541,7 +541,7 @@ public class GlobalTransactionMgrTest {
         assertEquals(CatalogTestUtil.testStartVersion + 1, replcia3.getLastFailedVersion());
 
         errorReplicaIds = Sets.newHashSet();
-        assertEquals(masterTransMgr.canTxnFinished(transactionState, errorReplicaIds), false);
+        assertEquals(masterTransMgr.canTxnFinished(transactionState, errorReplicaIds, Sets.newHashSet()), false);
         masterTransMgr.finishTransaction(CatalogTestUtil.testDbId1, transactionId, errorReplicaIds);
         assertEquals(TransactionStatus.VISIBLE, transactionState.getTransactionStatus());
         assertEquals(CatalogTestUtil.testStartVersion + 1, replcia1.getVersion());
@@ -606,7 +606,7 @@ public class GlobalTransactionMgrTest {
 
         // master finish the transaction2
         errorReplicaIds = Sets.newHashSet();
-        assertEquals(masterTransMgr.canTxnFinished(transactionState, errorReplicaIds), false);
+        assertEquals(masterTransMgr.canTxnFinished(transactionState, errorReplicaIds, Sets.newHashSet()), false);
         masterTransMgr.finishTransaction(CatalogTestUtil.testDbId1, transactionId2, errorReplicaIds);
         assertEquals(TransactionStatus.VISIBLE, transactionState.getTransactionStatus());
         assertEquals(CatalogTestUtil.testStartVersion + 2, replcia1.getVersion());


### PR DESCRIPTION
fix fail to prepare tablet reader bug (#2026)

Now publish version will succeed when quorum succeeds. But the finished transaction will update the version of all replicas to a visible version, which will lead to query the unsuccessful replica and result in query failure. Fix the bug by skipping updating the unsuccessful replica's version when the transaction is finished.