### PR TITLE
Maintain send window only if ExchangeMergeSortSourceOperator

### DIFF
--- a/be/src/exec/pipeline/exchange/sink_buffer.h
+++ b/be/src/exec/pipeline/exchange/sink_buffer.h
@@ -40,7 +40,8 @@ struct ClosureContext {
 // TODO(hcf) how to export brpc error
 class SinkBuffer {
 public:
-    SinkBuffer(RuntimeState* state, const std::vector<TPlanFragmentDestination>& destinations, size_t num_sinkers);
+    SinkBuffer(RuntimeState* state, const std::vector<TPlanFragmentDestination>& destinations, bool is_dest_merge,
+               size_t num_sinkers);
     ~SinkBuffer();
 
     void add_request(const TransmitChunkInfo& request);
@@ -59,8 +60,9 @@ private:
     void _process_send_window(const TUniqueId& instance_id, const int64_t sequence);
     void _try_to_send_rpc(const TUniqueId& instance_id);
 
-    MemTracker* _mem_tracker = nullptr;
+    const MemTracker* _mem_tracker;
     const int32_t _brpc_timeout_ms;
+    const bool _is_dest_merge;
 
     // Taking into account of efficiency, all the following maps
     // use int64_t as key, which is the field type of TUniqueId::lo

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DataStreamSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DataStreamSink.java
@@ -34,6 +34,8 @@ public class DataStreamSink extends DataSink {
 
     private DataPartition outputPartition;
 
+    private boolean isMerge;
+
     public DataStreamSink(PlanNodeId exchNodeId) {
         this.exchNodeId = exchNodeId;
     }
@@ -50,6 +52,10 @@ public class DataStreamSink extends DataSink {
 
     public void setPartition(DataPartition partition) {
         outputPartition = partition;
+    }
+
+    public void setMerge(boolean isMerge) {
+        this.isMerge = isMerge;
     }
 
     @Override
@@ -79,6 +85,7 @@ public class DataStreamSink extends DataSink {
         TDataSink result = new TDataSink(TDataSinkType.DATA_STREAM_SINK);
         TDataStreamSink tStreamSink =
                 new TDataStreamSink(exchNodeId.asInt(), outputPartition.toThrift());
+        tStreamSink.setIs_merge(isMerge);
         result.setStream_sink(tStreamSink);
         return result;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ExchangeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ExchangeNode.java
@@ -106,6 +106,10 @@ public class ExchangeNode extends PlanNode {
         return distributionType;
     }
 
+    public boolean isMerge() {
+        return mergeInfo != null;
+    }
+
     @Override
     public final void computeTupleIds() {
         clearTupleIds();

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -206,6 +206,7 @@ public class PlanFragment extends TreeNode<PlanFragment> {
             // we're streaming to an exchange node
             DataStreamSink streamSink = new DataStreamSink(destNode.getId());
             streamSink.setPartition(outputPartition);
+            streamSink.setMerge(destNode.isMerge());
             streamSink.setFragment(this);
             sink = streamSink;
         } else {
@@ -228,6 +229,7 @@ public class PlanFragment extends TreeNode<PlanFragment> {
             // we're streaming to an exchange node
             DataStreamSink streamSink = new DataStreamSink(destNode.getId());
             streamSink.setPartition(outputPartition);
+            streamSink.setMerge(destNode.isMerge());
             streamSink.setFragment(this);
             sink = streamSink;
         } else {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecodeRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecodeRewriteTest.java
@@ -516,7 +516,7 @@ public class DecodeRewriteTest extends PlanTestBase {
                 "dict_string_id_to_int_ids:{20=28}"));
         Assert.assertTrue(plan.contains("RESULT_SINK, result_sink:TResultSink(type:MYSQL_PROTOCAL)), " +
                 "partition:TDataPartition(type:RANDOM, partition_exprs:[]), query_global_dicts:[TGlobalDict(columnId:28"));
-        Assert.assertTrue(plan.contains("TDataPartition(type:UNPARTITIONED, partition_exprs:[]))), " +
+        Assert.assertTrue(plan.contains("TDataPartition(type:UNPARTITIONED, partition_exprs:[]), is_merge:false)), " +
                 "partition:TDataPartition(type:RANDOM, partition_exprs:[]), query_global_dicts:[TGlobalDict(columnId:28"));
     }
 

--- a/gensrc/thrift/DataSinks.thrift
+++ b/gensrc/thrift/DataSinks.thrift
@@ -82,6 +82,13 @@ struct TDataStreamSink {
   2: required Partitions.TDataPartition output_partition
 
   3: optional bool ignore_not_found
+
+  // Only useful in pipeline mode
+  // If receiver side is ExchangeMergeSortSourceOperator, then all the
+  // packets should be kept in order (according sequence), so the sender
+  // side need to maintain a send window in order to avoiding the receiver
+  // buffer too many out-of-order packets
+  4: optional bool is_merge
 }
 
 struct TMultiCastDataStreamSink {


### PR DESCRIPTION
Continue of previous pr [pr-2051](https://github.com/StarRocks/starrocks/pull/2051) 、[pr-2170](https://github.com/StarRocks/starrocks/pull/2170)

Since normal ExchangeSourceOperator needn't keep order at receiver side, therefore, the sender does not need to maintain the sending window