### PR TITLE
Segement use native lz4 library to compress/decompress page (#2243)

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -456,8 +456,6 @@ set(STARROCKS_DEPENDENCIES
     ${STARROCKS_DEPENDENCIES}
     ${WL_START_GROUP}
     rocksdb
-    librdkafka_cpp
-    librdkafka
     libs2
     snappy
     ${Boost_LIBRARIES}
@@ -466,6 +464,8 @@ set(STARROCKS_DEPENDENCIES
     glog
     re2
     pprof
+    # Put lz4 in front of librdkafka to make sure that segment use the native lz4 library to compress/decompress page
+    # Otherwise, he will use the lz4 Library in librdkafka
     lz4
     libevent
     curl
@@ -491,6 +491,8 @@ set(STARROCKS_DEPENDENCIES
     fmt
     ryu
     hyperscan
+    librdkafka_cpp
+    librdkafka
     ${WL_END_GROUP}
 )
 


### PR DESCRIPTION
for #2249

Current segment use lz4 library of librdkafka to compress/decompress page, lz4 library use rd_malloc to malloc memory. It will crash when alloc failed. The native lz4 library will return code, when alloc memory failed