### PR TITLE
fix: ScopedCleanup shouldn't be a temporary object

### DIFF
--- a/be/src/exec/vectorized/file_scan_node.cpp
+++ b/be/src/exec/vectorized/file_scan_node.cpp
@@ -19,7 +19,6 @@
 #include "runtime/runtime_state.h"
 #include "util/defer_op.h"
 #include "util/runtime_profile.h"
-#include "util/scoped_cleanup.h"
 
 namespace starrocks::vectorized {
 
@@ -274,7 +273,7 @@ void FileScanNode::scanner_worker(int start_idx, int length) {
 
     // Clone expr context
     std::vector<ExprContext*> scanner_expr_ctxs;
-    auto cleanup = MakeScopedCleanup([this, &scanner_expr_ctxs] { Expr::close(scanner_expr_ctxs, runtime_state()); });
+    DeferOp close_exprs([this, &scanner_expr_ctxs] { Expr::close(scanner_expr_ctxs, runtime_state()); });
     auto status = Expr::clone_if_not_exists(_conjunct_ctxs, runtime_state(), &scanner_expr_ctxs);
 
     if (!status.ok()) {

--- a/be/src/exec/vectorized/file_scan_node.cpp
+++ b/be/src/exec/vectorized/file_scan_node.cpp
@@ -274,7 +274,7 @@ void FileScanNode::scanner_worker(int start_idx, int length) {
 
     // Clone expr context
     std::vector<ExprContext*> scanner_expr_ctxs;
-    MakeScopedCleanup([this, &scanner_expr_ctxs] { Expr::close(scanner_expr_ctxs, runtime_state()); });
+    auto cleanup = MakeScopedCleanup([this, &scanner_expr_ctxs] { Expr::close(scanner_expr_ctxs, runtime_state()); });
     auto status = Expr::clone_if_not_exists(_conjunct_ctxs, runtime_state(), &scanner_expr_ctxs);
 
     if (!status.ok()) {


### PR DESCRIPTION
`ScopedCleanup` shouldn't be a temporary object. Otherwise, it will be destructed immediately after it isn't used anymore.