### PR TITLE
Add ColumnVisitor for accessing Column without modifying Column

### DIFF
--- a/be/src/column/CMakeLists.txt
+++ b/be/src/column/CMakeLists.txt
@@ -18,4 +18,5 @@ add_library(Column STATIC
         binary_column.cpp
         object_column.cpp
         decimalv3_column.cpp
+        column_visitor.cpp
         )

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <type_traits>
 
+#include "column/column_visitor.h"
 #include "column/datum.h"
 #include "column/vectorized_fwd.h"
 #include "gutil/casts.h"
@@ -338,6 +339,8 @@ public:
 
     virtual bool reach_capacity_limit() const = 0;
 
+    virtual Status accept(ColumnVisitor* visitor) const = 0;
+
 protected:
     DelCondSatisfied _delete_state = DEL_NOT_SATISFIED;
 };
@@ -389,6 +392,8 @@ public:
     typename AncestorBaseType::Ptr clone_shared() const override {
         return typename AncestorBase::Ptr(new Derived(*derived()));
     }
+
+    Status accept(ColumnVisitor* visitor) const override { return visitor->visit(*static_cast<const Derived*>(this)); }
 };
 
 } // namespace vectorized

--- a/be/src/column/column_visitor.cpp
+++ b/be/src/column/column_visitor.cpp
@@ -1,0 +1,56 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#include "column/column_visitor.h"
+
+namespace starrocks {
+
+#define VISIT_IMPL(ClassName) \
+    Status ColumnVisitor::visit(const ClassName& column) { return Status::NotSupported(#ClassName); }
+
+VISIT_IMPL(vectorized::NullableColumn)
+VISIT_IMPL(vectorized::ConstColumn)
+VISIT_IMPL(vectorized::ArrayColumn)
+VISIT_IMPL(vectorized::BinaryColumn)
+VISIT_IMPL(vectorized::Int8Column)
+VISIT_IMPL(vectorized::UInt8Column)
+VISIT_IMPL(vectorized::Int16Column)
+VISIT_IMPL(vectorized::UInt16Column)
+VISIT_IMPL(vectorized::Int32Column)
+VISIT_IMPL(vectorized::UInt32Column)
+VISIT_IMPL(vectorized::Int64Column)
+VISIT_IMPL(vectorized::UInt64Column)
+VISIT_IMPL(vectorized::Int128Column)
+VISIT_IMPL(vectorized::FloatColumn)
+VISIT_IMPL(vectorized::DoubleColumn)
+VISIT_IMPL(vectorized::DateColumn)
+VISIT_IMPL(vectorized::TimestampColumn)
+VISIT_IMPL(vectorized::DecimalColumn)
+VISIT_IMPL(vectorized::Decimal32Column)
+VISIT_IMPL(vectorized::Decimal64Column)
+VISIT_IMPL(vectorized::Decimal128Column)
+VISIT_IMPL(vectorized::HyperLogLogColumn)
+VISIT_IMPL(vectorized::BitmapColumn)
+VISIT_IMPL(vectorized::PercentileColumn)
+VISIT_IMPL(vectorized::FixedLengthColumn<int96_t>)
+VISIT_IMPL(vectorized::FixedLengthColumn<uint24_t>)
+VISIT_IMPL(vectorized::FixedLengthColumn<decimal12_t>)
+
+VISIT_IMPL(vectorized::FixedLengthColumnBase<int8_t>)
+VISIT_IMPL(vectorized::FixedLengthColumnBase<uint8_t>)
+VISIT_IMPL(vectorized::FixedLengthColumnBase<int16_t>)
+VISIT_IMPL(vectorized::FixedLengthColumnBase<uint16_t>)
+VISIT_IMPL(vectorized::FixedLengthColumnBase<int32_t>)
+VISIT_IMPL(vectorized::FixedLengthColumnBase<uint32_t>)
+VISIT_IMPL(vectorized::FixedLengthColumnBase<int64_t>)
+VISIT_IMPL(vectorized::FixedLengthColumnBase<uint64_t>)
+VISIT_IMPL(vectorized::FixedLengthColumnBase<vectorized::int128_t>)
+VISIT_IMPL(vectorized::FixedLengthColumnBase<float>)
+VISIT_IMPL(vectorized::FixedLengthColumnBase<double>)
+VISIT_IMPL(vectorized::FixedLengthColumnBase<vectorized::DateValue>)
+VISIT_IMPL(vectorized::FixedLengthColumnBase<DecimalV2Value>)
+VISIT_IMPL(vectorized::FixedLengthColumnBase<vectorized::TimestampValue>)
+VISIT_IMPL(vectorized::FixedLengthColumnBase<uint24_t>)
+VISIT_IMPL(vectorized::FixedLengthColumnBase<int96_t>)
+VISIT_IMPL(vectorized::FixedLengthColumnBase<decimal12_t>)
+
+} // namespace starrocks

--- a/be/src/column/column_visitor.h
+++ b/be/src/column/column_visitor.h
@@ -1,0 +1,68 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#pragma once
+
+#include "column/vectorized_fwd.h"
+#include "common/status.h"
+#include "runtime/decimalv2_value.h"
+#include "storage/decimal12.h"
+#include "storage/uint24.h"
+#include "util/int96.h"
+
+namespace starrocks {
+
+class ColumnVisitor {
+public:
+    virtual ~ColumnVisitor() = default;
+
+    // The default implementation of `visit` will return `Status::NotSupported`
+    virtual Status visit(const vectorized::NullableColumn& column);
+    virtual Status visit(const vectorized::ConstColumn& column);
+    virtual Status visit(const vectorized::ArrayColumn& column);
+    virtual Status visit(const vectorized::BinaryColumn& column);
+    virtual Status visit(const vectorized::Int8Column& column);
+    virtual Status visit(const vectorized::UInt8Column& column);
+    virtual Status visit(const vectorized::Int16Column& column);
+    virtual Status visit(const vectorized::UInt16Column& column);
+    virtual Status visit(const vectorized::Int32Column& column);
+    virtual Status visit(const vectorized::UInt32Column& column);
+    virtual Status visit(const vectorized::Int64Column& column);
+    virtual Status visit(const vectorized::UInt64Column& column);
+    virtual Status visit(const vectorized::Int128Column& column);
+    virtual Status visit(const vectorized::DoubleColumn& column);
+    virtual Status visit(const vectorized::FloatColumn& column);
+    virtual Status visit(const vectorized::DateColumn& column);
+    virtual Status visit(const vectorized::TimestampColumn& column);
+    virtual Status visit(const vectorized::DecimalColumn& column);
+    virtual Status visit(const vectorized::Decimal32Column& column);
+    virtual Status visit(const vectorized::Decimal64Column& column);
+    virtual Status visit(const vectorized::Decimal128Column& column);
+    virtual Status visit(const vectorized::HyperLogLogColumn& column);
+    virtual Status visit(const vectorized::BitmapColumn& column);
+    virtual Status visit(const vectorized::PercentileColumn& column);
+    virtual Status visit(const vectorized::FixedLengthColumn<int96_t>& column);
+    virtual Status visit(const vectorized::FixedLengthColumn<uint24_t>& column);
+    virtual Status visit(const vectorized::FixedLengthColumn<decimal12_t>& column);
+
+    // NOTE: Inherited classes normally does not need to implement the following methods, they are
+    // defined here mainly for successful compiling.
+    virtual Status visit(const vectorized::FixedLengthColumnBase<int8_t>& column);
+    virtual Status visit(const vectorized::FixedLengthColumnBase<uint8_t>& column);
+    virtual Status visit(const vectorized::FixedLengthColumnBase<int16_t>& column);
+    virtual Status visit(const vectorized::FixedLengthColumnBase<uint16_t>& column);
+    virtual Status visit(const vectorized::FixedLengthColumnBase<int32_t>& column);
+    virtual Status visit(const vectorized::FixedLengthColumnBase<uint32_t>& column);
+    virtual Status visit(const vectorized::FixedLengthColumnBase<int64_t>& column);
+    virtual Status visit(const vectorized::FixedLengthColumnBase<uint64_t>& column);
+    virtual Status visit(const vectorized::FixedLengthColumnBase<vectorized::int128_t>& column);
+    virtual Status visit(const vectorized::FixedLengthColumnBase<float>& column);
+    virtual Status visit(const vectorized::FixedLengthColumnBase<double>& column);
+    virtual Status visit(const vectorized::FixedLengthColumnBase<vectorized::DateValue>& column);
+    virtual Status visit(const vectorized::FixedLengthColumnBase<DecimalV2Value>& column);
+    virtual Status visit(const vectorized::FixedLengthColumnBase<vectorized::TimestampValue>& column);
+    virtual Status visit(const vectorized::FixedLengthColumnBase<int96_t>& column);
+    virtual Status visit(const vectorized::FixedLengthColumnBase<uint24_t>& column);
+    virtual Status visit(const vectorized::FixedLengthColumnBase<decimal12_t>& column);
+};
+
+} // namespace starrocks

--- a/be/src/column/column_visitor.h
+++ b/be/src/column/column_visitor.h
@@ -44,7 +44,7 @@ public:
     virtual Status visit(const vectorized::FixedLengthColumn<uint24_t>& column);
     virtual Status visit(const vectorized::FixedLengthColumn<decimal12_t>& column);
 
-    // NOTE: Inherited classes normally does not need to implement the following methods, they are
+    // NOTE: Inherited classes normally don't need to implement the following methods, they are
     // defined here mainly for successful compiling.
     virtual Status visit(const vectorized::FixedLengthColumnBase<int8_t>& column);
     virtual Status visit(const vectorized::FixedLengthColumnBase<uint8_t>& column);

--- a/be/src/column/vectorized_fwd.h
+++ b/be/src/column/vectorized_fwd.h
@@ -31,9 +31,14 @@ using Buffer = std::vector<T>;
 
 class ArrayColumn;
 class BinaryColumn;
+class NullableColumn;
+class ConstColumn;
 
 template <typename T>
 class FixedLengthColumn;
+
+template <typename T>
+class FixedLengthColumnBase;
 
 template <typename T>
 class DecimalV3Column;

--- a/be/test/storage/vectorized/cumulative_compaction_test.cpp
+++ b/be/test/storage/vectorized/cumulative_compaction_test.cpp
@@ -263,8 +263,8 @@ TEST_F(CumulativeCompactionTest, test_read_chunk_size) {
 
     // normal total memory footprint
     total_mem_footprint = 1073741824;
-    ASSERT_EQ(2001, Compaction::get_read_chunk_size(mem_limit, config_chunk_size, total_num_rows,
-                                                    total_mem_footprint, source_num));
+    ASSERT_EQ(2001, Compaction::get_read_chunk_size(mem_limit, config_chunk_size, total_num_rows, total_mem_footprint,
+                                                    source_num));
 
     // mem limit is 0
     mem_limit = 0;

--- a/be/test/storage/vectorized/rowset_merger_test.cpp
+++ b/be/test/storage/vectorized/rowset_merger_test.cpp
@@ -63,8 +63,7 @@ public:
         return OLAP_SUCCESS;
     }
 
-    OLAPStatus add_columns(const vectorized::Chunk& chunk, const std::vector<uint32_t>& column_indexes,
-                           bool is_key) {
+    OLAPStatus add_columns(const vectorized::Chunk& chunk, const std::vector<uint32_t>& column_indexes, bool is_key) {
         if (is_key) {
             all_pks->append(*chunk.get_column_by_index(0), 0, chunk.num_rows());
         } else {


### PR DESCRIPTION
Summary: ColumnVisitor allows adding new virtual functions
to the family of Columns, without modifying the Column classes.
Instead, a ColumnVisitor class is created that implements all of
the appropriate specializations of the virtual function.