### PR TITLE
Fix outer join push down error predicate which can not eliminate null

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateJoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateJoinRule.java
@@ -240,15 +240,27 @@ public class PushDownPredicateJoinRule extends TransformationRule {
         ScalarOperator derivedPredicate = JoinPredicateUtils.equivalenceDerive(predicate, false);
         List<ScalarOperator> derivedPredicates = Utils.extractConjuncts(derivedPredicate);
 
-        if (join.getJoinType().isLeftOuterJoin() || join.getJoinType().isLeftSemiJoin()) {
+        if (join.getJoinType().isLeftSemiJoin()) {
             for (ScalarOperator p : derivedPredicates) {
                 if (rightOutputColumns.containsAll(p.getUsedColumns())) {
                     rightPushDown.add(p);
                 }
             }
-        } else if (join.getJoinType().isRightOuterJoin() || join.getJoinType().isRightSemiJoin()) {
+        } else if (join.getJoinType().isLeftOuterJoin()) {
+            for (ScalarOperator p : derivedPredicates) {
+                if (rightOutputColumns.containsAll(p.getUsedColumns()) && canEliminateNull(rightOutputColumns, p.clone())) {
+                    rightPushDown.add(p);
+                }
+            }
+        } else if (join.getJoinType().isRightSemiJoin()) {
             for (ScalarOperator p : derivedPredicates) {
                 if (leftOutputColumns.containsAll(p.getUsedColumns())) {
+                    leftPushDown.add(p);
+                }
+            }
+        } else if (join.getJoinType().isRightOuterJoin()) {
+            for (ScalarOperator p : derivedPredicates) {
+                if (leftOutputColumns.containsAll(p.getUsedColumns()) && canEliminateNull(leftOutputColumns, p.clone())) {
                     leftPushDown.add(p);
                 }
             }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -5051,4 +5051,47 @@ public class PlanFragmentTest extends PlanTestBase {
                 "  |  <slot 3> : 3: t1c\n" +
                 "  |  <slot 40> : CAST(37 AS INT)"));
     }
+
+    @Test
+    public void testPushDownEquivalenceDerivePredicate() throws Exception {
+        // check is null predicate on t1.v5 which equivalences derive from t1.v4 can not push down to scan node
+        String sql = "SELECT \n" +
+                "  subt0.v2, \n" +
+                "  t1.v6\n" +
+                "FROM \n" +
+                "  (\n" +
+                "    SELECT \n" +
+                "      t0.v1, \n" +
+                "      t0.v2, \n" +
+                "      t0.v3\n" +
+                "    FROM \n" +
+                "      t0\n" +
+                "  ) subt0 \n" +
+                "  LEFT JOIN t1 ON subt0.v3 = t1.v4 \n" +
+                "  AND subt0.v3 = t1.v4 \n" +
+                "  AND subt0.v3 = t1.v5 \n" +
+                "  AND subt0.v3 >= t1.v5 \n" +
+                "WHERE \n" +
+                "  (\n" +
+                "    (\n" +
+                "      (t1.v4) < (\n" +
+                "        (\n" +
+                "          (-650850438)-(\n" +
+                "            (\n" +
+                "              (2000266938)%(-1243652117)\n" +
+                "            )\n" +
+                "          )\n" +
+                "        )\n" +
+                "      )\n" +
+                "    ) IS NULL\n" +
+                "  ) \n" +
+                "GROUP BY \n" +
+                " subt0.v2, \n" +
+                "  t1.v6;";
+        String plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains(" 0:OlapScanNode\n" +
+                "     TABLE: t1\n" +
+                "     PREAGGREGATION: ON\n" +
+                "     partitions=0/1"));
+    }
 }


### PR DESCRIPTION
#2251 
Reason : 
Left outer join push **is null predicate** to right table,  which is generate from equivalence derive. 

we should check the predicate can eliminate null before push down