### PR TITLE
Reduce the number of directory sync on rowset writing

### DIFF
--- a/be/src/storage/fs/file_block_manager.cpp
+++ b/be/src/storage/fs/file_block_manager.cpp
@@ -217,9 +217,6 @@ Status FileWritableBlock::_close(SyncMode mode) {
             _block_manager->_metrics->total_disk_sync->increment(1);
         }
         sync = _writer->sync();
-        if (sync.ok()) {
-            sync = _block_manager->_sync_metadata(_path);
-        }
         WARN_IF_ERROR(sync, strings::Substitute("Failed to sync when closing block $0", _path));
     }
     Status close = _writer->close();

--- a/be/test/storage/vectorized/cumulative_compaction_test.cpp
+++ b/be/test/storage/vectorized/cumulative_compaction_test.cpp
@@ -263,8 +263,8 @@ TEST_F(CumulativeCompactionTest, test_read_chunk_size) {
 
     // normal total memory footprint
     total_mem_footprint = 1073741824;
-    ASSERT_EQ(2001, Compaction::get_read_chunk_size(mem_limit, config_chunk_size, total_num_rows,
-                                                    total_mem_footprint, source_num));
+    ASSERT_EQ(2001, Compaction::get_read_chunk_size(mem_limit, config_chunk_size, total_num_rows, total_mem_footprint,
+                                                    source_num));
 
     // mem limit is 0
     mem_limit = 0;

--- a/be/test/storage/vectorized/rowset_merger_test.cpp
+++ b/be/test/storage/vectorized/rowset_merger_test.cpp
@@ -63,8 +63,7 @@ public:
         return OLAP_SUCCESS;
     }
 
-    OLAPStatus add_columns(const vectorized::Chunk& chunk, const std::vector<uint32_t>& column_indexes,
-                           bool is_key) {
+    OLAPStatus add_columns(const vectorized::Chunk& chunk, const std::vector<uint32_t>& column_indexes, bool is_key) {
         if (is_key) {
             all_pks->append(*chunk.get_column_by_index(0), 0, chunk.num_rows());
         } else {


### PR DESCRIPTION
Summary: Instead of submiting a directory sync request to filesystem
every time a segment file is created, only send one directory sync
request to filesystem after all segment files have been created.

Benchmark:
On my local machine, the time to load 1.2GB CSV file is improved
from 132s to 123s.