### PR TITLE
Bugfix: the number of rowsets needs to be greater than 1 in vertical merge

### DIFF
--- a/be/test/storage/vectorized/rowset_merger_test.cpp
+++ b/be/test/storage/vectorized/rowset_merger_test.cpp
@@ -253,7 +253,7 @@ TEST_F(RowsetMergerTest, vertical_merge) {
     srand(GetCurrentTimeMicros());
     create_tablet(rand(), rand());
     const int max_segments = 8;
-    const int num_segment = 1 + rand() % max_segments;
+    const int num_segment = 2 + rand() % max_segments;
     const int N = 500000 + rand() % 1000000;
     MergeConfig cfg;
     cfg.chunk_size = 1000 + rand() % 2000;
@@ -342,7 +342,7 @@ TEST_F(RowsetMergerTest, vertical_merge_seq) {
     srand(GetCurrentTimeMicros());
     create_tablet(rand(), rand());
     const int max_segments = 8;
-    const int num_segment = 1 + rand() % max_segments;
+    const int num_segment = 2 + rand() % max_segments;
     const int N = 500000 + rand() % 1000000;
     MergeConfig cfg;
     cfg.chunk_size = 100 + rand() % 2000;


### PR DESCRIPTION
This is the requirements of MaskMergeIterator.