### PR TITLE
Fix multi cross join reorder NPE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/ReorderJoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/ReorderJoinRule.java
@@ -267,13 +267,17 @@ public class ReorderJoinRule extends Rule {
 
         @Override
         public OptExpression visitLogicalJoin(OptExpression optExpression, Void context) {
-            ColumnRefSet outputColumns = new ColumnRefSet(optExpression.getOp().getProjection().getOutputColumns());
             ColumnRefSet childInputColumns = new ColumnRefSet();
             optExpression.getInputs().forEach(opt -> childInputColumns.union(
                     ((LogicalOperator) opt.getOp()).getOutputColumns(new ExpressionContext(opt))));
 
             OptExpression left = rewrite(optExpression.inputAt(0));
             OptExpression right = rewrite(optExpression.inputAt(1));
+
+            ColumnRefSet outputColumns = new ColumnRefSet();
+            if (optExpression.getOp().getProjection() != null) {
+                outputColumns = new ColumnRefSet(optExpression.getOp().getProjection().getOutputColumns());
+            }
 
             if (childInputColumns.equals(outputColumns)) {
                 LogicalJoinOperator joinOperator = new LogicalJoinOperator.Builder().withOperator(

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/MultiJoinReorderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/MultiJoinReorderTest.java
@@ -489,4 +489,13 @@ public class MultiJoinReorderTest extends PlanTestBase {
                 "  4:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BUCKET_SHUFFLE)"));
     }
+
+    @Test
+    public void testMultiCrossJoinReorder() throws Exception {
+        // check multi cross join reorder without exception
+        String sql = "select count(*) from t0,t1,t2,t3,t0 as t4, t1 as t5 where true";
+        String plan = getFragmentPlan(sql);
+        System.out.println(plan);
+        Assert.assertTrue(plan.contains("17:CROSS JOIN"));
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -16,6 +16,7 @@ import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.common.StarRocksPlannerException;
@@ -5101,5 +5102,15 @@ public class PlanFragmentTest extends PlanTestBase {
         String plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("equal join conjunct: 2: v2 = 5: v5"));
         Assert.assertTrue(plan.contains("1:EMPTYSET"));
+    }
+
+    @Test
+    public void testMultiCrossJoinReorder() throws Exception {
+        // check multi cross join reorder without exception
+        ConnectContext.get().getSessionVariable().setMaxTransformReorderJoins(4);
+        String sql = "select count(*) from t0,t1,t2,t3,t0 as t4, t1 as t5 where true";
+        String plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("19:CROSS JOIN"));
+        ConnectContext.get().getSessionVariable().setMaxTransformReorderJoins(8);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -5103,14 +5103,4 @@ public class PlanFragmentTest extends PlanTestBase {
         Assert.assertTrue(plan.contains("equal join conjunct: 2: v2 = 5: v5"));
         Assert.assertTrue(plan.contains("1:EMPTYSET"));
     }
-
-    @Test
-    public void testMultiCrossJoinReorder() throws Exception {
-        // check multi cross join reorder without exception
-        ConnectContext.get().getSessionVariable().setMaxTransformReorderJoins(4);
-        String sql = "select count(*) from t0,t1,t2,t3,t0 as t4, t1 as t5 where true";
-        String plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("19:CROSS JOIN"));
-        ConnectContext.get().getSessionVariable().setMaxTransformReorderJoins(8);
-    }
 }


### PR DESCRIPTION
#2285 
RemoveDuplicateProject not deal the situation when getProjection is null