### PR TITLE
BugFix: Remove the std::move when construct DroppedTabletInfo

### DIFF
--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -729,7 +729,7 @@ Status TabletManager::load_tablet_from_meta(DataDir* data_dir, TTabletId tablet_
     if (tablet->tablet_state() == TABLET_SHUTDOWN) {
         LOG(INFO) << "Loaded shutdown tablet " << tablet_id;
         std::unique_lock shutdown_tablets_wlock(_shutdown_tablets_lock);
-        DroppedTabletInfo info{.tablet = std::move(tablet), .flag = kMoveFilesToTrash};
+        DroppedTabletInfo info{.tablet = tablet, .flag = kMoveFilesToTrash};
         _shutdown_tablets.emplace(tablet->tablet_id(), std::move(info));
         return Status::NotFound("tablet state is shutdown");
     }


### PR DESCRIPTION
The tablet is nullptr after std::move to DroppedTabletInfo. It will be crashed in the subsequent access.
So the std::move() function should be removed in this pull request.