### PR TITLE
Fix the bug of thread local memory statistics leak

### DIFF
--- a/be/src/exec/parquet/column_chunk_reader.cpp
+++ b/be/src/exec/parquet/column_chunk_reader.cpp
@@ -142,7 +142,7 @@ void ColumnChunkReader::_reserve_uncompress_buf(size_t size) {
 
 Status ColumnChunkReader::_read_and_decompress_page_data(uint32_t compressed_size, uint32_t uncompressed_size,
                                                          bool is_compressed) {
-    RETURN_IF_ERROR(tls_thread_status.mem_tracker()->check_mem_limit("read and decompress page"));
+    RETURN_IF_ERROR(CurrentThread::mem_tracker()->check_mem_limit("read and decompress page"));
     if (is_compressed && _compress_codec != nullptr) {
         Slice com_slice("", compressed_size);
         RETURN_IF_ERROR(_page_reader->read_bytes((const uint8_t**)&com_slice.data, com_slice.size));

--- a/be/src/runtime/current_thread.cpp
+++ b/be/src/runtime/current_thread.cpp
@@ -9,9 +9,11 @@ namespace starrocks {
 CurrentThread::~CurrentThread() {
     StorageEngine* storage_engine = ExecEnv::GetInstance()->storage_engine();
     if (UNLIKELY(storage_engine != nullptr && storage_engine->bg_worker_stopped())) {
+        tls_is_thread_status_init = false;
         return;
     }
     commit();
+    tls_is_thread_status_init = false;
 }
 
 } // namespace starrocks

--- a/be/src/runtime/current_thread.h
+++ b/be/src/runtime/current_thread.h
@@ -18,9 +18,13 @@ namespace starrocks {
 
 class TUniqueId;
 
+inline thread_local MemTracker* tls_mem_tracker = nullptr;
+inline thread_local MemTracker* tls_exceed_mem_tracker = nullptr;
+inline thread_local bool tls_is_thread_status_init = false;
+
 class CurrentThread {
 public:
-    CurrentThread() = default;
+    CurrentThread() { tls_is_thread_status_init = true; }
     ~CurrentThread();
 
     void commit() {
@@ -38,21 +42,19 @@ public:
     // Return prev memory tracker.
     starrocks::MemTracker* set_mem_tracker(starrocks::MemTracker* mem_tracker) {
         commit();
-        auto* prev = _mem_tracker;
-        _mem_tracker = mem_tracker;
+        auto* prev = tls_mem_tracker;
+        tls_mem_tracker = mem_tracker;
         return prev;
     }
 
-    starrocks::MemTracker* mem_tracker() {
-        if (UNLIKELY(_mem_tracker == nullptr)) {
-            _mem_tracker = ExecEnv::GetInstance()->process_mem_tracker();
+    static starrocks::MemTracker* mem_tracker() {
+        if (UNLIKELY(tls_mem_tracker == nullptr)) {
+            tls_mem_tracker = ExecEnv::GetInstance()->process_mem_tracker();
         }
-        return _mem_tracker;
+        return tls_mem_tracker;
     }
 
-    void set_exceed_mem_tracker(starrocks::MemTracker* mem_tracker) { _exceed_mem_tracker = mem_tracker; }
-
-    starrocks::MemTracker* exceed_mem_tracker() { return _exceed_mem_tracker; }
+    static void set_exceed_mem_tracker(starrocks::MemTracker* mem_tracker) { tls_exceed_mem_tracker = mem_tracker; }
 
     bool set_is_catched(bool is_catched) {
         bool old = _is_catched;
@@ -60,7 +62,7 @@ public:
         return old;
     }
 
-    bool is_catched() { return _is_catched; }
+    bool is_catched() const { return _is_catched; }
 
     void mem_consume(int64_t size) {
         MemTracker* cur_tracker = mem_tracker();
@@ -81,18 +83,31 @@ public:
                 return true;
             } else {
                 _cache_size -= size;
-                _exceed_mem_tracker = limit_tracker;
+                tls_exceed_mem_tracker = limit_tracker;
                 return false;
             }
         }
         return true;
     }
 
-    void mem_consume_without_cache(int64_t size) {
+    static void mem_consume_without_cache(int64_t size) {
         MemTracker* cur_tracker = mem_tracker();
         if (cur_tracker != nullptr && size != 0) {
             cur_tracker->consume(size);
         }
+    }
+
+    static bool try_mem_consume_without_cache(int64_t size) {
+        MemTracker* cur_tracker = mem_tracker();
+        if (cur_tracker != nullptr && size != 0) {
+            MemTracker* limit_tracker = cur_tracker->try_consume(size);
+            if (LIKELY(limit_tracker == nullptr)) {
+                return true;
+            } else {
+                return false;
+            }
+        }
+        return true;
     }
 
     void mem_release(int64_t size) {
@@ -104,7 +119,7 @@ public:
         }
     }
 
-    void mem_release_without_cache(int64_t size) {
+    static void mem_release_without_cache(int64_t size) {
         MemTracker* cur_tracker = mem_tracker();
         if (cur_tracker != nullptr && size != 0) {
             cur_tracker->release(size);
@@ -115,8 +130,6 @@ private:
     const static int64_t BATCH_SIZE = 2 * 1024 * 1024;
 
     int64_t _cache_size = 0;
-    MemTracker* _mem_tracker = nullptr;
-    MemTracker* _exceed_mem_tracker = nullptr;
     TUniqueId _query_id;
     bool _is_catched = false;
 };
@@ -140,17 +153,17 @@ private:
     MemTracker* _old_mem_tracker;
 };
 
-#define TRY_CATCH_BAD_ALLOC(stmt)                                                \
-    do {                                                                         \
-        try {                                                                    \
-            bool prev = tls_thread_status.set_is_catched(true);                  \
-            DeferOp op([&] { tls_thread_status.set_is_catched(prev); });         \
-            { stmt; }                                                            \
-        } catch (std::bad_alloc const&) {                                        \
-            MemTracker* exceed_tracker = tls_thread_status.exceed_mem_tracker(); \
-            tls_thread_status.set_exceed_mem_tracker(nullptr);                   \
-            return Status::MemoryLimitExceeded(exceed_tracker->err_msg(""));     \
-        }                                                                        \
+#define TRY_CATCH_BAD_ALLOC(stmt)                                            \
+    do {                                                                     \
+        try {                                                                \
+            bool prev = tls_thread_status.set_is_catched(true);              \
+            DeferOp op([&] { tls_thread_status.set_is_catched(prev); });     \
+            { stmt; }                                                        \
+        } catch (std::bad_alloc const&) {                                    \
+            MemTracker* exceed_tracker = tls_exceed_mem_tracker;             \
+            tls_exceed_mem_tracker = nullptr;                                \
+            return Status::MemoryLimitExceeded(exceed_tracker->err_msg("")); \
+        }                                                                    \
     } while (0)
 
 } // namespace starrocks

--- a/be/src/storage/rowset/segment_v2/page_io.cpp
+++ b/be/src/storage/rowset/segment_v2/page_io.cpp
@@ -113,7 +113,7 @@ Status PageIO::write_page(fs::WritableBlock* wblock, const std::vector<Slice>& b
 
 Status PageIO::read_and_decompress_page(const PageReadOptions& opts, PageHandle* handle, Slice* body,
                                         PageFooterPB* footer) {
-    RETURN_IF_ERROR(tls_thread_status.mem_tracker()->check_mem_limit("read and decompress page"));
+    RETURN_IF_ERROR(CurrentThread::mem_tracker()->check_mem_limit("read and decompress page"));
 
     opts.sanity_check();
     opts.stats->total_pages_num++;


### PR DESCRIPTION
Some third-party libraries will release thread local memory when the thread exits. If tls_thread_status has been destructed at this time, the statistics of this memory will be leaked. Generally, when the TPC-DS is tested under high pressure, it will be found that every time the pressure test ends. , The memory statistics is greater than the actual memory use.

If tls thread_status has been destructed, directly submit the memory statistics, no need to use tls_thread_status cached to 2M and then submit

for #2297 