### PR TITLE
Fix ConcurrentModification for group by clause expression

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -404,7 +404,7 @@ public class QueryAnalyzer {
         cteScope.setParent(scope);
         for (View withQuery : stmt.getWithClause().getViews()) {
 
-            QueryRelation query = transformQueryStmt(withQuery.getQueryStmt(), cteScope);
+            QueryRelation query = transformQueryStmt(withQuery.getQueryStmtWithParse(), cteScope);
 
             /*
              *  Because the analysis of CTE is sensitive to order
@@ -856,7 +856,7 @@ public class QueryAnalyzer {
 
         if (table instanceof View) {
             View view = (View) table;
-            QueryRelation query = transformQueryStmt(view.getQueryStmt(), scope);
+            QueryRelation query = transformQueryStmt(view.getQueryStmtWithParse(), scope);
 
             ImmutableList.Builder<Field> outputFields = ImmutableList.builder();
             for (Field field : query.getRelationFields().getAllFields()) {
@@ -968,7 +968,8 @@ public class QueryAnalyzer {
         if (node.getGroupByClause() != null) {
             GroupByClause groupByClause = node.getGroupByClause();
             if (groupByClause.getGroupingType() == GroupByClause.GroupingType.GROUP_BY) {
-                for (Expr groupingExpr : groupByClause.getGroupingExprs()) {
+                List<Expr> groupingExprs = groupByClause.getGroupingExprs();
+                for (Expr groupingExpr : groupingExprs) {
                     if (groupingExpr instanceof IntLiteral) {
                         long ordinal = ((IntLiteral) groupingExpr).getLongValue();
                         if (ordinal < 1 || ordinal > outputExpressions.size()) {
@@ -1017,7 +1018,7 @@ public class QueryAnalyzer {
 
                     List<List<Expr>> groupingSets =
                             Sets.powerSet(IntStream.range(0, rewriteOriGrouping.size())
-                                            .boxed().collect(Collectors.toSet())).stream()
+                                    .boxed().collect(Collectors.toSet())).stream()
                                     .map(l -> l.stream().map(rewriteOriGrouping::get).collect(Collectors.toList()))
                                     .collect(Collectors.toList());
 


### PR DESCRIPTION
For version 1.19, some user catch a exception:
```
java.util.ConcurrentModificationException: null
 at java.util.ArrayList$Itr.checkForComodification(ArrayList.java:909) ~[?:1.8.0_181]
 at java.util.ArrayList$Itr.next(ArrayList.java:859) ~[?:1.8.0_181]
 at java.util.AbstractCollection.addAll(AbstractCollection.java:343) ~[?:1.8.0_181]
 at java.util.LinkedHashSet.<init>(LinkedHashSet.java:169) ~[?:1.8.0_181]
 at com.starrocks.analysis.GroupByClause.genGroupingExprs(GroupByClause.java:145) ~[starrocks-fe.jar:?]
 at com.starrocks.analysis.GroupByClause.getGroupingExprs(GroupByClause.java:129) ~[starrocks-fe.jar:?]
 at com.starrocks.sql.analyzer.QueryAnalyzer.analyzeGroupBy(QueryAnalyzer.java:911) ~[starrocks-fe.jar:?]
 at com.starrocks.sql.analyzer.QueryAnalyzer.transformSelectStmt(QueryAnalyzer.java:167) ~[starrocks-fe.jar:?]
 at com.starrocks.sql.analyzer.QueryAnalyzer.transformQueryStmt(QueryAnalyzer.java:147) ~[starrocks-fe.jar:?]
 at com.starrocks.sql.analyzer.QueryAnalyzer.resolveTableRef(QueryAnalyzer.java:748) ~[starrocks-fe.jar:?]
 at com.starrocks.sql.analyzer.QueryAnalyzer.analyzeFrom(QueryAnalyzer.java:613) ~[starrocks-fe.jar:?]
 at com.starrocks.sql.analyzer.QueryAnalyzer.transformSelectStmt(QueryAnalyzer.java:158) ~[starrocks-fe.jar:?]
 at com.starrocks.sql.analyzer.QueryAnalyzer.transformQueryStmt(QueryAnalyzer.java:147) ~[starrocks-fe.jar:?]
 at com.starrocks.sql.analyzer.QueryAnalyzer.lambda$transformSetOperationStmt$399(QueryAnalyzer.java:265) ~[starrocks-fe.jar:?]
 at com.starrocks.sql.analyzer.QueryAnalyzer.resolveTableRef(QueryAnalyzer.java:804) ~[starrocks-fe.jar:?]
 at com.starrocks.sql.analyzer.QueryAnalyzer.analyzeFrom(QueryAnalyzer.java:613) ~[starrocks-fe.jar:?]
 at com.starrocks.sql.analyzer.QueryAnalyzer.transformSelectStmt(QueryAnalyzer.java:158) ~[starrocks-fe.jar:?]
 at com.starrocks.sql.analyzer.QueryAnalyzer.transformQueryStmt(QueryAnalyzer.java:147) ~[starrocks-fe.jar:?]
......
```

The bug:
`View` is globally shared metadata, but the method `getQueryStmt` will cache a queryStmt.... It's cause analyzer will use same object after