### PR TITLE
Fix scalar operator rewrite error when high concurrency

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateScanRule.java
@@ -33,8 +33,6 @@ public class PushDownPredicateScanRule extends TransformationRule {
     public static final PushDownPredicateScanRule ES_SCAN =
             new PushDownPredicateScanRule(OperatorType.LOGICAL_ES_SCAN);
 
-    private final ScalarOperatorRewriter scalarOperatorRewriter = new ScalarOperatorRewriter();
-
     public PushDownPredicateScanRule(OperatorType type) {
         super(RuleType.TF_PUSH_DOWN_PREDICATE_SCAN, Pattern.create(OperatorType.LOGICAL_FILTER, type));
     }
@@ -46,6 +44,7 @@ public class PushDownPredicateScanRule extends TransformationRule {
         OptExpression scan = input.getInputs().get(0);
         LogicalScanOperator logicalScanOperator = (LogicalScanOperator) scan.getOp();
 
+        ScalarOperatorRewriter scalarOperatorRewriter = new ScalarOperatorRewriter();
         ScalarOperator predicates = Utils.compoundAnd(lfo.getPredicate(), logicalScanOperator.getPredicate());
         ScalarRangePredicateExtractor rangeExtractor = new ScalarRangePredicateExtractor();
         predicates = rangeExtractor.rewriteOnlyColumn(Utils.compoundAnd(Utils.extractConjuncts(predicates)


### PR DESCRIPTION
For #1689
1. The PushDownPredicateScanRule is a single instance
2. The `ScalarOperatorRewriter` rewrite operator depend on  `ScalarOperatorRewriterContext.changeNums`, but it's unsafe mutli-thread