### PR TITLE
[pipeline] check fragment cancelled for pending finish driver

### DIFF
--- a/be/src/exec/pipeline/exchange/sink_buffer.cpp
+++ b/be/src/exec/pipeline/exchange/sink_buffer.cpp
@@ -199,7 +199,7 @@ void SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id) {
 
         auto* closure =
                 new DisposableClosure<PTransmitChunkResult, ClosureContext>({instance_id, request.params->sequence()});
-        closure->addFailedHandler([this, closure](const ClosureContext& ctx) noexcept {
+        closure->addFailedHandler([this](const ClosureContext& ctx) noexcept {
             _is_finishing = true;
             {
                 std::lock_guard<std::mutex> l(*_mutexes[ctx.instance_id.lo]);
@@ -207,10 +207,10 @@ void SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id) {
                 --_num_in_flight_rpcs[ctx.instance_id.lo];
             }
             --_total_in_flight_rpc;
-            LOG(WARNING) << " transmit chunk rpc failed";
+            LOG(WARNING) << "transmit chunk rpc failed";
         });
         closure->addSuccessHandler(
-                [this, closure](const ClosureContext& ctx, const PTransmitChunkResult& result) noexcept {
+                [this](const ClosureContext& ctx, const PTransmitChunkResult& result) noexcept {
                     Status status(result.status());
                     {
                         std::lock_guard<std::mutex> l(*_mutexes[ctx.instance_id.lo]);
@@ -219,7 +219,7 @@ void SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id) {
                     }
                     if (!status.ok()) {
                         _is_finishing = true;
-                        LOG(WARNING) << " transmit chunk rpc failed, " << status.message();
+                        LOG(WARNING) << "transmit chunk rpc failed, " << status.message();
                     } else {
                         std::lock_guard<std::mutex> l(*_mutexes[ctx.instance_id.lo]);
                         _process_send_window(ctx.instance_id, ctx.sequence);

--- a/be/src/exec/pipeline/pipeline_driver_poller.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_poller.cpp
@@ -55,6 +55,16 @@ void PipelineDriverPoller::run_internal() {
 
             if (driver->pending_finish()) {
                 if (driver->is_still_pending_finish()) {
+                    if (driver->fragment_ctx()->is_canceled()) {
+                        driver->cancel_operators(driver->fragment_ctx()->runtime_state());
+                        if (!driver->is_still_pending_finish()) {
+                            driver->set_driver_state(DriverState::CANCELED);
+                            remove_blocked_driver(local_blocked_drivers, driver_it);
+                            ready_drivers.emplace_back(driver);
+
+                            continue;
+                        }
+                    }
                     ++driver_it;
                 } else {
                     // driver->pending_finish() return true means that when a driver's sink operator is finished,

--- a/be/src/exec/pipeline/pipeline_driver_poller.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_poller.cpp
@@ -56,7 +56,8 @@ void PipelineDriverPoller::run_internal() {
             if (driver->pending_finish()) {
                 if (driver->is_still_pending_finish()) {
                     // The driver maybe becomes pending finish before the fragment is cancelled,
-                    // so we need call set_cancelled of operators of this driver here.
+                    // which causes there isn't chance to call set_cancelled() of the driver,
+                    // so we need call set_cancelled() of operators of this driver here.
                     if (driver->fragment_ctx()->is_canceled()) {
                         driver->cancel_operators(driver->fragment_ctx()->runtime_state());
                         if (!driver->is_still_pending_finish()) {

--- a/be/src/exec/pipeline/pipeline_driver_poller.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_poller.cpp
@@ -53,38 +53,7 @@ void PipelineDriverPoller::run_internal() {
         while (driver_it != local_blocked_drivers.end()) {
             auto* driver = *driver_it;
 
-            if (driver->pending_finish()) {
-                if (driver->is_still_pending_finish()) {
-                    // The driver maybe becomes pending finish before the fragment is cancelled,
-                    // which causes there isn't chance to call set_cancelled() of the driver,
-                    // so we need call set_cancelled() of operators of this driver here.
-                    if (driver->fragment_ctx()->is_canceled()) {
-                        driver->cancel_operators(driver->fragment_ctx()->runtime_state());
-                        if (!driver->is_still_pending_finish()) {
-                            driver->set_driver_state(DriverState::CANCELED);
-                            remove_blocked_driver(local_blocked_drivers, driver_it);
-                            ready_drivers.emplace_back(driver);
-
-                            continue;
-                        }
-                    }
-                    ++driver_it;
-                } else {
-                    // driver->pending_finish() return true means that when a driver's sink operator is finished,
-                    // but its source operator still has pending io task that executed in io threads and has
-                    // reference to object outside(such as desc_tbl) owned by FragmentContext. So a driver in
-                    // PENDING_FINISH state should wait for pending io task's completion, then turn into FINISH state,
-                    // otherwise, pending tasks shall reference to destructed objects in FragmentContext since
-                    // FragmentContext is unregistered prematurely.
-                    driver->set_driver_state(driver->fragment_ctx()->is_canceled() ? DriverState::CANCELED
-                                                                                   : DriverState::FINISH);
-                    remove_blocked_driver(local_blocked_drivers, driver_it);
-                    ready_drivers.emplace_back(driver);
-                }
-            } else if (driver->is_finished()) {
-                remove_blocked_driver(local_blocked_drivers, driver_it);
-                ready_drivers.emplace_back(driver);
-            } else if (driver->query_ctx()->is_expired()) {
+            if (driver->query_ctx()->is_expired()) {
                 // there are not any drivers belonging to a query context can make progress for an expiration period
                 // indicates that some fragments are missing because of failed exec_plan_fragment invocation. in
                 // this situation, query is failed finally, so drivers are marked PENDING_FINISH/FINISH.
@@ -114,6 +83,24 @@ void PipelineDriverPoller::run_internal() {
                     remove_blocked_driver(local_blocked_drivers, driver_it);
                     ready_drivers.emplace_back(driver);
                 }
+            } else if (driver->pending_finish()) {
+                if (driver->is_still_pending_finish()) {
+                    ++driver_it;
+                } else {
+                    // driver->pending_finish() return true means that when a driver's sink operator is finished,
+                    // but its source operator still has pending io task that executed in io threads and has
+                    // reference to object outside(such as desc_tbl) owned by FragmentContext. So a driver in
+                    // PENDING_FINISH state should wait for pending io task's completion, then turn into FINISH state,
+                    // otherwise, pending tasks shall reference to destructed objects in FragmentContext since
+                    // FragmentContext is unregistered prematurely.
+                    driver->set_driver_state(driver->fragment_ctx()->is_canceled() ? DriverState::CANCELED
+                                                                                   : DriverState::FINISH);
+                    remove_blocked_driver(local_blocked_drivers, driver_it);
+                    ready_drivers.emplace_back(driver);
+                }
+            } else if (driver->is_finished()) {
+                remove_blocked_driver(local_blocked_drivers, driver_it);
+                ready_drivers.emplace_back(driver);
             } else if (driver->is_not_blocked()) {
                 driver->set_driver_state(DriverState::READY);
                 remove_blocked_driver(local_blocked_drivers, driver_it);

--- a/be/src/exec/pipeline/pipeline_driver_poller.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_poller.cpp
@@ -55,6 +55,8 @@ void PipelineDriverPoller::run_internal() {
 
             if (driver->pending_finish()) {
                 if (driver->is_still_pending_finish()) {
+                    // The driver maybe becomes pending finish before the fragment is cancelled,
+                    // so we need call set_cancelled of operators of this driver here.
                     if (driver->fragment_ctx()->is_canceled()) {
                         driver->cancel_operators(driver->fragment_ctx()->runtime_state());
                         if (!driver->is_still_pending_finish()) {


### PR DESCRIPTION
### Introduction
The driver maybe becomes pending finish before the fragment is cancelled, which causes there isn't chance to call `set_cancelled()` of the driver, so we need call `set_cancelled()` in the Poller when the driver is still pending finish.

`SinkBuffer` waits all the `ExchangeSinkOperator`s send EOS to all the destinations except `finst_id==-1`, which indicates that the destination is pseudo for bucket shuffle join. Therefore, `SinkBuffer::_num_remaining_eos` should exclude these destinations.

Fix #2327.

### Changes
- Check `fragment->is_cancelled()` and call `driver->set_cancelled()` when the driver is still pending finish in Poller.
- `SinkBuffer::_num_remaining_eos` exclude the destinations, whose `finst_id` is -1.
