### PR TITLE
Fix typos in be/src

### DIFF
--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -239,7 +239,7 @@ void AgentServer::release_snapshot(TAgentResult& t_agent_result, const std::stri
     Status ret_st;
     OLAPStatus err_code = SnapshotManager::instance()->release_snapshot(snapshot_path);
     if (err_code != OLAP_SUCCESS) {
-        LOG(WARNING) << "failt to release_snapshot. snapshot_path: " << snapshot_path << ", err_code: " << err_code;
+        LOG(WARNING) << "fail to release_snapshot. snapshot_path: " << snapshot_path << ", err_code: " << err_code;
         ret_st = Status::RuntimeError(strings::Substitute("fail to release_snapshot. err_code=$0", err_code));
     } else {
         LOG(INFO) << "success to release_snapshot. snapshot_path=" << snapshot_path << ", err_code=" << err_code;

--- a/be/src/agent/utils.cpp
+++ b/be/src/agent/utils.cpp
@@ -206,7 +206,7 @@ std::string AgentUtils::print_agent_status(AgentStatus status) {
     case STARROCKS_INTERNAL_ERROR:
         return "STARROCKS_INTERNAL_ERROR";
     default:
-        return "UNKNOWM";
+        return "UNKNOWN";
     }
 }
 

--- a/be/src/column/datum.cpp
+++ b/be/src/column/datum.cpp
@@ -28,7 +28,7 @@ Status datum_from_string(Datum* dst, FieldType type, const std::string& str, Mem
         bool v;
         auto st = type_info->from_string(&v, str);
         if (st != OLAP_SUCCESS) {
-            return Status::InvalidArgument(Substitute("Failed to conert $0 to Bool type", str));
+            return Status::InvalidArgument(Substitute("Failed to convert $0 to Bool type", str));
         }
         dst->set_int8(v);
         return Status::OK();

--- a/be/src/column/datum_convert.cpp
+++ b/be/src/column/datum_convert.cpp
@@ -25,7 +25,7 @@ Status datum_from_string(TypeInfo* type_info, Datum* dst, const std::string& str
         bool v;
         auto st = type_info->from_string(&v, str);
         if (st != OLAP_SUCCESS) {
-            return Status::InvalidArgument(Substitute("Failed to conert $0 to Bool type", str));
+            return Status::InvalidArgument(Substitute("Failed to convert $0 to Bool type", str));
         }
         dst->set_int8(v);
         return Status::OK();

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -191,12 +191,12 @@ static void init_starrocks_metrics(const std::vector<StorePath>& store_paths) {
     if (init_system_metrics) {
         auto st = DiskInfo::get_disk_devices(paths, &disk_devices);
         if (!st.ok()) {
-            LOG(WARNING) << "get disk devices failed, stauts=" << st.get_error_msg();
+            LOG(WARNING) << "get disk devices failed, status=" << st.get_error_msg();
             return;
         }
         st = get_inet_interfaces(&network_interfaces);
         if (!st.ok()) {
-            LOG(WARNING) << "get inet interfaces failed, stauts=" << st.get_error_msg();
+            LOG(WARNING) << "get inet interfaces failed, status=" << st.get_error_msg();
             return;
         }
     }

--- a/be/src/exec/es/es_predicate.cpp
+++ b/be/src/exec/es/es_predicate.cpp
@@ -519,8 +519,8 @@ Status EsPredicate::_build_in_predicate(const Expr* conjunct, bool* handled) {
             break;
         }
         default:
-            DCHECK(false) << "unsupport type:" << expr->type().type;
-            return Status::InternalError("unsupport type to push down to ES");
+            DCHECK(false) << "unsupported type:" << expr->type().type;
+            return Status::InternalError("unsupported type to push down to ES");
         }
 
         std::string col = slot_desc->col_name();

--- a/be/src/exec/olap_common.h
+++ b/be/src/exec/olap_common.h
@@ -582,7 +582,7 @@ inline Status ColumnValueRange<T>::add_range(SQLFilterOp op, T value) {
     // If we already have IN value range, we can put `value` into it.
     if (is_fixed_value_range()) {
         if (_fixed_op != FILTER_IN) {
-            return Status::InternalError(strings::Substitute("Add Range Fail! Unsupport SQLFilterOp $0", op));
+            return Status::InternalError(strings::Substitute("Add Range Fail! Unsupported SQLFilterOp $0", op));
         }
         std::pair<iterator_type, iterator_type> bound_pair = _fixed_values.equal_range(value);
 
@@ -608,7 +608,7 @@ inline Status ColumnValueRange<T>::add_range(SQLFilterOp op, T value) {
             break;
         }
         default: {
-            return Status::InternalError(strings::Substitute("Add Range Fail! Unsupport SQLFilterOp $0", op));
+            return Status::InternalError(strings::Substitute("Add Range Fail! Unsupported SQLFilterOp $0", op));
         }
         }
 
@@ -663,7 +663,7 @@ inline Status ColumnValueRange<T>::add_range(SQLFilterOp op, T value) {
                 break;
             }
             default: {
-                return Status::InternalError(strings::Substitute("Add Range Fail! Unsupport SQLFilterOp $0", op));
+                return Status::InternalError(strings::Substitute("Add Range Fail! Unsupported SQLFilterOp $0", op));
             }
             }
         }

--- a/be/src/exec/olap_utils.h
+++ b/be/src/exec/olap_utils.h
@@ -81,7 +81,7 @@ inline CompareLargeFunc get_compare_func(PrimitiveType type) {
         return compare_large<StringValue>;
 
     default:
-        CHECK(false) << "Unsupport Compare type";
+        CHECK(false) << "Unsupported Compare type";
     }
 }
 

--- a/be/src/exec/parquet/column_chunk_reader.cpp
+++ b/be/src/exec/parquet/column_chunk_reader.cpp
@@ -124,7 +124,7 @@ Status ColumnChunkReader::_parse_page_data() {
         return Status::InternalError("There are two dictionary page in this column");
     default:
         return Status::NotSupported(
-                strings::Substitute("Not supproted page type: $0", _page_reader->current_header()->type));
+                strings::Substitute("Not supported page type: $0", _page_reader->current_header()->type));
         break;
     }
     _page_parse_state = PAGE_DATA_PARSED;

--- a/be/src/exec/parquet/encoding.h
+++ b/be/src/exec/parquet/encoding.h
@@ -69,7 +69,7 @@ public:
 
     // Currently, this function is only used to read dictionary values.
     virtual Status next_batch(size_t count, uint8_t* dst) {
-        return Status::NotSupported("next_batch is not supportted");
+        return Status::NotSupported("next_batch is not supported");
     }
 };
 

--- a/be/src/exec/parquet/file_reader.cpp
+++ b/be/src/exec/parquet/file_reader.cpp
@@ -117,7 +117,7 @@ std::shared_ptr<GroupReader> FileReader::_row_group(int i) {
 Status FileReader::_check_magic(const uint8_t* file_magic) {
     static const char* s_magic = "PAR1";
     if (!memequal(reinterpret_cast<const char*>(file_magic), 4, s_magic, 4)) {
-        return Status::Corruption("Paruqet file magic not match");
+        return Status::Corruption("Parquet file magic not match");
     }
     return Status::OK();
 }

--- a/be/src/exec/parquet/page_reader.cpp
+++ b/be/src/exec/parquet/page_reader.cpp
@@ -52,7 +52,7 @@ Status PageReader::next_header() {
 
 Status PageReader::read_bytes(const uint8_t** buffer, size_t size) {
     if (_offset + size > _next_header_pos) {
-        return Status::InternalError("Size to read exceede page size");
+        return Status::InternalError("Size to read exceed page size");
     }
     uint64_t nbytes = size;
     RETURN_IF_ERROR(_stream.get_bytes(buffer, &nbytes));

--- a/be/src/exec/parquet_builder.cpp
+++ b/be/src/exec/parquet_builder.cpp
@@ -84,12 +84,12 @@ ParquetBuilder::~ParquetBuilder() = default;
 
 Status ParquetBuilder::add_chunk(vectorized::Chunk* chunk) {
     // TODO(c1oudman): implement
-    return Status::NotSupported("Parquest builder not supported yet");
+    return Status::NotSupported("Parquet builder not supported yet");
 }
 
 Status ParquetBuilder::finish() {
     // TODO(cmy): implement
-    return Status::NotSupported("Parquest builder not supported yet");
+    return Status::NotSupported("Parquet builder not supported yet");
 }
 
 } // namespace starrocks

--- a/be/src/exec/pipeline/dict_decode_operator.cpp
+++ b/be/src/exec/pipeline/dict_decode_operator.cpp
@@ -72,7 +72,7 @@ Status DictDecodeOperatorFactory::prepare(RuntimeState* state) {
             _dict_optimize_parser.check_could_apply_dict_optimize(expr_ctx, &dict_ctx);
             if (!dict_ctx.could_apply_dict_optimize) {
                 return Status::InternalError(
-                        fmt::format("Not found dict for function-called cid:{} it may cause by unsupport function",
+                        fmt::format("Not found dict for function-called cid:{} it may cause by unsupported function",
                                     need_encode_cid));
             }
             _dict_optimize_parser.eval_expr(state, expr_ctx, &dict_ctx, need_encode_cid);

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -407,7 +407,7 @@ Status IndexChannel::init(RuntimeState* state, const std::vector<TTabletWithPart
     for (const auto& tablet : tablets) {
         auto* location = _parent->_location->find_tablet(tablet.tablet_id);
         if (location == nullptr) {
-            LOG(WARNING) << "unknow tablet, tablet_id=" << tablet.tablet_id;
+            LOG(WARNING) << "unknown tablet, tablet_id=" << tablet.tablet_id;
             return Status::InternalError("unknown tablet");
         }
         std::vector<NodeChannel*> channels;
@@ -748,7 +748,7 @@ Status OlapTableSink::_send_chunk_by_node(vectorized::Chunk* chunk, IndexChannel
             channel->mark_as_failed(node);
         }
         if (channel->has_intolerable_failure()) {
-            return Status::InternalError("index channel has intoleralbe failure");
+            return Status::InternalError("index channel has intolerable failure");
         }
     }
     return Status::OK();
@@ -780,7 +780,7 @@ Status OlapTableSink::close(RuntimeState* state, Status close_status) {
                     if (!channel_status.ok()) {
                         LOG(WARNING) << "close channel failed. channel_name=" << ch->name()
                                      << ", load_info=" << ch->print_load_info()
-                                     << ", errror_msg=" << channel_status.get_error_msg();
+                                     << ", error_msg=" << channel_status.get_error_msg();
                         index_channel->mark_as_failed(ch);
                     }
                     ch->time_report(&node_add_batch_counter_map, &serialize_batch_ns, &mem_exceeded_block_ns,
@@ -858,7 +858,7 @@ void OlapTableSink::_print_varchar_error_msg(RuntimeState* state, const Slice& s
 
 void OlapTableSink::_print_decimal_error_msg(RuntimeState* state, const DecimalV2Value& decimal, SlotDescriptor* desc) {
     std::stringstream ss;
-    ss << "decimal value is not valid for defination, column=" << desc->col_name() << ", value=" << decimal.to_string()
+    ss << "decimal value is not valid for definition, column=" << desc->col_name() << ", value=" << decimal.to_string()
        << ", precision=" << desc->type().precision << ", scale=" << desc->type().scale;
 #if BE_TEST
     LOG(INFO) << ss.str();

--- a/be/src/exec/vectorized/arrow_to_starrocks_converter.cpp
+++ b/be/src/exec/vectorized/arrow_to_starrocks_converter.cpp
@@ -287,7 +287,7 @@ struct ArrowConverter<AT, PT, is_nullable, is_strict, BinaryATGuard<AT>, BinaryP
 
                     if (ctx != nullptr) {
                         std::string raw_data = "arrow data is fixed size binary type";
-                        std::string reason = strings::Substitute("type length $0 exeeds max length $1", width,
+                        std::string reason = strings::Substitute("type length $0 exceeds max length $1", width,
                                                                  binary_max_length<PT>);
                         ctx->report_error_message(reason, raw_data);
                     }
@@ -322,7 +322,7 @@ struct ArrowConverter<AT, PT, is_nullable, is_strict, BinaryATGuard<AT>, BinaryP
                             const char* s_data = reinterpret_cast<const char*>(concrete_array->GetValue(i, &s_size));
                             std::string raw_data = std::string(s_data, s_size);
                             std::string reason =
-                                    strings::Substitute("string length $0 exeeds max length $1", s_size, max_length);
+                                    strings::Substitute("string length $0 exceeds max length $1", s_size, max_length);
                             ctx->report_error_message(reason, raw_data);
                         }
                     }

--- a/be/src/exec/vectorized/chunks_sorter.h
+++ b/be/src/exec/vectorized/chunks_sorter.h
@@ -270,7 +270,7 @@ class ChunksSorter {
 public:
     /**
      * Constructor.
-     * @param sort_exprs     The order-by columns or columns with expresion. This sorter will use but not own the object.
+     * @param sort_exprs     The order-by columns or columns with expression. This sorter will use but not own the object.
      * @param is_asc         Orders on each column.
      * @param is_null_first  NULL values should at the head or tail.
      * @param size_of_chunk_batch  In the case of a positive limit, this parameter limits the size of the batch in Chunk unit.

--- a/be/src/exec/vectorized/chunks_sorter_full_sort.h
+++ b/be/src/exec/vectorized/chunks_sorter_full_sort.h
@@ -13,7 +13,7 @@ class ChunksSorterFullSort : public ChunksSorter {
 public:
     /**
      * Constructor.
-     * @param sort_exprs     The order-by columns or columns with expresion. This sorter will use but not own the object.
+     * @param sort_exprs     The order-by columns or columns with expression. This sorter will use but not own the object.
      * @param is_asc         Orders on each column.
      * @param is_null_first  NULL values should at the head or tail.
      * @param size_of_chunk_batch  In the case of a positive limit, this parameter limits the size of the batch in Chunk unit.

--- a/be/src/exec/vectorized/chunks_sorter_topn.h
+++ b/be/src/exec/vectorized/chunks_sorter_topn.h
@@ -13,7 +13,7 @@ class ChunksSorterTopn : public ChunksSorter {
 public:
     /**
      * Constructor.
-     * @param sort_exprs     The order-by columns or columns with expresion. This sorter will use but not own the object.
+     * @param sort_exprs     The order-by columns or columns with expression. This sorter will use but not own the object.
      * @param is_asc         Orders on each column.
      * @param is_null_first  NULL values should at the head or tail.
      * @param offset         Number of top rows to skip.

--- a/be/src/exec/vectorized/dict_decode_node.cpp
+++ b/be/src/exec/vectorized/dict_decode_node.cpp
@@ -78,7 +78,7 @@ Status DictDecodeNode::open(RuntimeState* state) {
 
             if (!dict_ctx.could_apply_dict_optimize) {
                 return Status::InternalError(
-                        fmt::format("Not found dict for function-called cid:{} it may cause by unsupport function",
+                        fmt::format("Not found dict for function-called cid:{} it may cause by unsupported function",
                                     need_encode_cid));
             }
 

--- a/be/src/exec/vectorized/es_http_components.cpp
+++ b/be/src/exec/vectorized/es_http_components.cpp
@@ -51,7 +51,7 @@ std::string json_value_to_string(const rapidjson::Value& value) {
             std::stringstream ss;                                             \
             ss << "Expected value of type: " << type_to_string(type)          \
                << "; but found type: " << json_type_to_raw_str(col.GetType()) \
-               << "; Docuemnt slice is : " << json_value_to_string(col);      \
+               << "; Document slice is : " << json_value_to_string(col);      \
             return Status::RuntimeError(ss.str());                            \
         }                                                                     \
     } while (false)
@@ -62,7 +62,7 @@ std::string json_value_to_string(const rapidjson::Value& value) {
             std::stringstream ss;                                               \
             ss << "Expected value of type: " << type_to_string(type)            \
                << "; but found type: " << json_type_to_raw_str(col.GetType())   \
-               << "; Docuemnt source slice is : " << json_value_to_string(col); \
+               << "; Document source slice is : " << json_value_to_string(col); \
             return Status::RuntimeError(ss.str());                              \
         }                                                                       \
     } while (false)
@@ -84,7 +84,7 @@ std::string json_value_to_string(const rapidjson::Value& value) {
             std::stringstream ss;                                               \
             ss << "Expected value of type: " << type_to_string(type)            \
                << "; but found type: " << json_type_to_raw_str(col.GetType())   \
-               << "; Docuemnt source slice is : " << json_value_to_string(col); \
+               << "; Document source slice is : " << json_value_to_string(col); \
             return Status::RuntimeError(ss.str());                              \
         }                                                                       \
     } while (false)
@@ -94,7 +94,7 @@ std::string json_value_to_string(const rapidjson::Value& value) {
         std::stringstream ss;                                             \
         ss << "Expected value of type: " << type_to_string(type)          \
            << "; but found type: " << json_type_to_raw_str(col.GetType()) \
-           << "; Docuemnt slice is : " << json_value_to_string(col);      \
+           << "; Document slice is : " << json_value_to_string(col);      \
         return Status::RuntimeError(ss.str());                            \
     } while (false)
 
@@ -120,7 +120,7 @@ Status ScrollParser::parse(const std::string& scroll_result, bool exactly_once) 
     }
 
     if (!exactly_once && !_document_node.HasMember(FIELD_SCROLL_ID)) {
-        LOG(WARNING) << "Document has not a scroll id field scroll reponse:" << scroll_result;
+        LOG(WARNING) << "Document has not a scroll id field scroll response:" << scroll_result;
         return Status::InternalError("Document has not a scroll id field");
     }
 

--- a/be/src/exec/vectorized/json_scanner.cpp
+++ b/be/src/exec/vectorized/json_scanner.cpp
@@ -332,7 +332,7 @@ Status JsonReader::close() {
  * For example:
  *  [{"colunm1":"value1", "colunm2":10}, {"colunm1":"value2", "colunm2":30}]
  * Result:
- *      colunm1    colunm2
+ *      column1    column2
  *      ------------------
  *      value1     10
  *      value2     30
@@ -347,7 +347,7 @@ Status JsonReader::close() {
  * JsonRoot = "$.RECORDS"
  * JsonPaths = "[$.column1, $.column2]"
  * Result:
- *      colunm1    colunm2
+ *      column1    column2
  *      ------------------
  *      value1     10
  *      value2     30

--- a/be/src/exec/vectorized/orc_scanner_adapter.cpp
+++ b/be/src/exec/vectorized/orc_scanner_adapter.cpp
@@ -1101,7 +1101,7 @@ Status OrcScannerAdapter::init(std::unique_ptr<orc::Reader> reader) {
     try {
         _row_reader = _reader->createRowReader(_row_reader_options);
     } catch (std::exception& e) {
-        auto s = strings::Substitute("OrcScannerAdpater::init failed. reason = $0", e.what());
+        auto s = strings::Substitute("OrcScannerAdapter::init failed. reason = $0", e.what());
         LOG(WARNING) << s;
         return Status::InternalError(s);
     }
@@ -1294,7 +1294,7 @@ Status OrcScannerAdapter::read_next() {
             return Status::EndOfFile("");
         }
     } catch (std::exception& e) {
-        auto s = strings::Substitute("OrcScannerAdpater::read_next failed. reason = $0", e.what());
+        auto s = strings::Substitute("OrcScannerAdapter::read_next failed. reason = $0", e.what());
         LOG(WARNING) << s;
         return Status::InternalError(s);
     }

--- a/be/src/exec/vectorized/schema_scanner/schema_columns_scanner.cpp
+++ b/be/src/exec/vectorized/schema_scanner/schema_columns_scanner.cpp
@@ -69,7 +69,7 @@ Status SchemaColumnsScanner::start(RuntimeState* state) {
     if (nullptr != _param->ip && 0 != _param->port) {
         RETURN_IF_ERROR(SchemaHelper::get_db_names(*(_param->ip), _param->port, db_params, &_db_result));
     } else {
-        return Status::InternalError("IP or port dosn't exists");
+        return Status::InternalError("IP or port doesn't exists");
     }
 
     return Status::OK();
@@ -382,7 +382,7 @@ Status SchemaColumnsScanner::get_new_desc() {
     if (nullptr != _param->ip && 0 != _param->port) {
         RETURN_IF_ERROR(SchemaHelper::describe_table(*(_param->ip), _param->port, desc_params, &_desc_result));
     } else {
-        return Status::InternalError("IP or port dosn't exists");
+        return Status::InternalError("IP or port doesn't exists");
     }
     _column_index = 0;
 
@@ -409,7 +409,7 @@ Status SchemaColumnsScanner::get_new_table() {
     if (nullptr != _param->ip && 0 != _param->port) {
         RETURN_IF_ERROR(SchemaHelper::get_table_names(*(_param->ip), _param->port, table_params, &_table_result));
     } else {
-        return Status::InternalError("IP or port dosn't exists");
+        return Status::InternalError("IP or port doesn't exists");
     }
     _table_index = 0;
     return Status::OK();

--- a/be/src/exec/vectorized/schema_scanner/schema_schema_privileges_scanner.cpp
+++ b/be/src/exec/vectorized/schema_scanner/schema_schema_privileges_scanner.cpp
@@ -34,7 +34,7 @@ Status SchemaSchemaPrivilegesScanner::start(RuntimeState* state) {
     if (nullptr != _param->ip && 0 != _param->port) {
         RETURN_IF_ERROR(SchemaHelper::get_db_privs(*(_param->ip), _param->port, db_privs_params, &_db_privs_result));
     } else {
-        return Status::InternalError("IP or port dosn't exists");
+        return Status::InternalError("IP or port doesn't exists");
     }
     return Status::OK();
 }

--- a/be/src/exec/vectorized/schema_scanner/schema_schemata_scanner.cpp
+++ b/be/src/exec/vectorized/schema_scanner/schema_schemata_scanner.cpp
@@ -45,7 +45,7 @@ Status SchemaSchemataScanner::start(RuntimeState* state) {
     if (nullptr != _param->ip && 0 != _param->port) {
         RETURN_IF_ERROR(SchemaHelper::get_db_names(*(_param->ip), _param->port, db_params, &_db_result));
     } else {
-        return Status::InternalError("IP or port dosn't exists");
+        return Status::InternalError("IP or port doesn't exists");
     }
 
     return Status::OK();

--- a/be/src/exec/vectorized/schema_scanner/schema_table_privileges_scanner.cpp
+++ b/be/src/exec/vectorized/schema_scanner/schema_table_privileges_scanner.cpp
@@ -36,7 +36,7 @@ Status SchemaTablePrivilegesScanner::start(RuntimeState* state) {
         RETURN_IF_ERROR(
                 SchemaHelper::get_table_privs(*(_param->ip), _param->port, table_privs_params, &_table_privs_result));
     } else {
-        return Status::InternalError("IP or port dosn't exists");
+        return Status::InternalError("IP or port doesn't exists");
     }
     return Status::OK();
 }

--- a/be/src/exec/vectorized/schema_scanner/schema_tables_scanner.cpp
+++ b/be/src/exec/vectorized/schema_scanner/schema_tables_scanner.cpp
@@ -64,7 +64,7 @@ Status SchemaTablesScanner::start(RuntimeState* state) {
     if (nullptr != _param->ip && 0 != _param->port) {
         RETURN_IF_ERROR(SchemaHelper::get_db_names(*(_param->ip), _param->port, db_params, &_db_result));
     } else {
-        return Status::InternalError("IP or port dosn't exists");
+        return Status::InternalError("IP or port doesn't exists");
     }
     return Status::OK();
 }
@@ -241,7 +241,7 @@ Status SchemaTablesScanner::get_new_table() {
     if (nullptr != _param->ip && 0 != _param->port) {
         RETURN_IF_ERROR(SchemaHelper::list_table_status(*(_param->ip), _param->port, table_params, &_table_result));
     } else {
-        return Status::InternalError("IP or port dosn't exists");
+        return Status::InternalError("IP or port doesn't exists");
     }
     _table_index = 0;
     return Status::OK();

--- a/be/src/exec/vectorized/schema_scanner/schema_user_privileges_scanner.cpp
+++ b/be/src/exec/vectorized/schema_scanner/schema_user_privileges_scanner.cpp
@@ -34,7 +34,7 @@ Status SchemaUserPrivilegesScanner::start(RuntimeState* state) {
         RETURN_IF_ERROR(
                 SchemaHelper::get_user_privs(*(_param->ip), _param->port, user_privs_params, &_user_privs_result));
     } else {
-        return Status::InternalError("IP or port dosn't exists");
+        return Status::InternalError("IP or port doesn't exists");
     }
     return Status::OK();
 }

--- a/be/src/exec/vectorized/schema_scanner/schema_variables_scanner.cpp
+++ b/be/src/exec/vectorized/schema_scanner/schema_variables_scanner.cpp
@@ -38,7 +38,7 @@ Status SchemaVariablesScanner::start(RuntimeState* state) {
     if (nullptr != _param->ip && 0 != _param->port) {
         RETURN_IF_ERROR(SchemaHelper::show_varialbes(*(_param->ip), _param->port, var_params, &_var_result));
     } else {
-        return Status::InternalError("IP or port dosn't exists");
+        return Status::InternalError("IP or port doesn't exists");
     }
     _begin = _var_result.variables.begin();
     return Status::OK();

--- a/be/src/exprs/agg/variance.h
+++ b/be/src/exprs/agg/variance.h
@@ -173,7 +173,7 @@ public:
         }
     }
 
-    std::string get_name() const override { return "deviatation from average"; }
+    std::string get_name() const override { return "deviation from average"; }
 };
 
 template <PrimitiveType PT, bool is_sample, typename T = RunTimeCppType<PT>,

--- a/be/src/exprs/vectorized/bitmap_functions.h
+++ b/be/src/exprs/vectorized/bitmap_functions.h
@@ -54,7 +54,7 @@ public:
     /**
      * @param: 
      * @paramType columns: [TYPE_OBJECT]
-     * @return TYPE_VARCHA
+     * @return TYPE_VARCHAR
      */
     DEFINE_VECTORIZED_FN(bitmap_to_string);
 

--- a/be/src/exprs/vectorized/like_predicate.h
+++ b/be/src/exprs/vectorized/like_predicate.h
@@ -152,7 +152,7 @@ private:
         /// and whether the pattern has any constant substrings. If the pattern is not a
         /// constant argument, none of the following fields can be set because we cannot know
         /// the format of the pattern in the prepare function and must deal with each pattern
-        /// seperately.
+        /// separately.
         ScalarFunction function;
 
         /// Holds the string the StringValue points to and is set any time.

--- a/be/src/formats/orc/apache-orc/c++/include/orc/Reader.hh
+++ b/be/src/formats/orc/apache-orc/c++/include/orc/Reader.hh
@@ -508,7 +508,7 @@ namespace orc {
     virtual uint64_t getMemoryUseByTypeId(const std::list<uint64_t>& include, int stripeIx=-1) = 0;
 
     /**
-     * Get BloomFiters of all selected columns in the specified stripe
+     * Get BloomFilters of all selected columns in the specified stripe
      * @param stripeIndex index of the stripe to be read for bloom filters.
      * @param included index of selected columns to return (if not specified,
      *        all columns that have bloom filters are considered).

--- a/be/src/formats/orc/apache-orc/c++/src/Reader.cc
+++ b/be/src/formats/orc/apache-orc/c++/src/Reader.cc
@@ -89,7 +89,7 @@ void ColumnSelector::selectChildren(std::vector<bool>& selectedColumns, const Ty
 }
 
 /**
-   * Recurses over a type tree and selects the parents of every selected type.
+   * Recurse over a type tree and selects the parents of every selected type.
    * @return true if any child was selected.
    */
 bool ColumnSelector::selectParents(std::vector<bool>& selectedColumns, const Type& type) {
@@ -103,7 +103,7 @@ bool ColumnSelector::selectParents(std::vector<bool>& selectedColumns, const Typ
 }
 
 /**
-   * Recurses over a type tree and build two maps
+   * Recurse over a type tree and build two maps
    * map<TypeName, TypeId>, map<TypeId, Type>
    */
 void ColumnSelector::buildTypeNameIdMap(const Type* type) {

--- a/be/src/formats/orc/apache-orc/tools/src/CSVFileImport.cc
+++ b/be/src/formats/orc/apache-orc/tools/src/CSVFileImport.cc
@@ -436,7 +436,7 @@ int main(int argc, char* argv[]) {
                         1000000.0;
 
     std::cout << GetDate() << " Finish importing Orc file." << std::endl;
-    std::cout << GetDate() << " Total writer elasped time: " << totalElapsedTime << "s." << std::endl;
+    std::cout << GetDate() << " Total writer elapsed time: " << totalElapsedTime << "s." << std::endl;
     std::cout << GetDate() << " Total writer CPU time: " << static_cast<double>(totalCPUTime) / CLOCKS_PER_SEC << "s."
               << std::endl;
     return 0;

--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -157,9 +157,9 @@ void StreamLoadAction::handle(HttpRequest* req) {
 
 Status StreamLoadAction::_handle(StreamLoadContext* ctx) {
     if (ctx->body_bytes > 0 && ctx->receive_bytes != ctx->body_bytes) {
-        LOG(WARNING) << "recevie body don't equal with body bytes, body_bytes=" << ctx->body_bytes
+        LOG(WARNING) << "receive body don't equal with body bytes, body_bytes=" << ctx->body_bytes
                      << ", receive_bytes=" << ctx->receive_bytes << ", id=" << ctx->id;
-        return Status::InternalError("receive body dont't equal with body bytes");
+        return Status::InternalError("receive body don't equal with body bytes");
     }
     if (!ctx->use_streaming) {
         // if we use non-streaming, we need to close file first,

--- a/be/src/http/http_client.cpp
+++ b/be/src/http/http_client.cpp
@@ -42,7 +42,7 @@ Status HttpClient::init(const std::string& url) {
     if (_curl == nullptr) {
         _curl = curl_easy_init();
         if (_curl == nullptr) {
-            return Status::InternalError("fail to initalize curl");
+            return Status::InternalError("fail to initialize curl");
         }
     } else {
         curl_easy_reset(_curl);

--- a/be/src/runtime/export_task_mgr.cpp
+++ b/be/src/runtime/export_task_mgr.cpp
@@ -211,7 +211,7 @@ void ExportTaskMgr::report_to_master(PlanFragmentExecutor* executor) {
                          << master_address.port << ") because: " << e.what();
             status = client.reopen(config::thrift_rpc_timeout_ms);
             if (!status.ok()) {
-                LOG(WARNING) << "Client repoen failed. with address(" << master_address.hostname << ":"
+                LOG(WARNING) << "Client reopen failed. with address(" << master_address.hostname << ":"
                              << master_address.port << ")";
                 return;
             }

--- a/be/src/runtime/file_result_writer.cpp
+++ b/be/src/runtime/file_result_writer.cpp
@@ -86,7 +86,7 @@ Status FileResultWriter::_create_file_writer() {
         _file_builder = std::make_unique<ParquetBuilder>(std::move(writable_file), _output_expr_ctxs);
         break;
     default:
-        return Status::InternalError(strings::Substitute("unsupport file format: $0", _file_opts->file_format));
+        return Status::InternalError(strings::Substitute("unsupported file format: $0", _file_opts->file_format));
     }
     LOG(INFO) << "create file for exporting query result. file name: " << file_name
               << ". query id: " << print_id(_state->query_id());

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -523,7 +523,7 @@ void FragmentMgr::cancel_worker() {
         }
         for (auto& id : to_delete) {
             cancel(id, PPlanFragmentCancelReason::TIMEOUT);
-            LOG(INFO) << "FragmentMgr cancel worker going to cancel timouet fragment " << print_id(id);
+            LOG(INFO) << "FragmentMgr cancel worker going to cancel timeout fragment " << print_id(id);
         }
 
         // check every 1 seconds

--- a/be/src/runtime/load_channel_mgr.cpp
+++ b/be/src/runtime/load_channel_mgr.cpp
@@ -205,7 +205,7 @@ Status LoadChannelMgr::_start_load_channels_clean() {
     // eg: MemTracker in load channel
     for (auto& channel : timeout_channels) {
         channel->cancel();
-        LOG(INFO) << "Deleted timedout channel. load id=" << channel->load_id() << " timeout=" << channel->timeout();
+        LOG(INFO) << "Deleted timeout channel. load id=" << channel->load_id() << " timeout=" << channel->timeout();
     }
 
     // this log print every 1 min, so that we could observe the mem consumption of load process

--- a/be/src/runtime/mysql_table_writer.cpp
+++ b/be/src/runtime/mysql_table_writer.cpp
@@ -98,7 +98,7 @@ Status MysqlTableWriter::_build_viewers(vectorized::Columns& columns) {
         auto* ctx = _output_expr_ctxs[i];
         const auto& type = ctx->root()->type();
         if (!is_scalar_primitive_type(type.type)) {
-            return Status::InternalError(fmt::format("unsupport type in mysql sink:{}", type.type));
+            return Status::InternalError(fmt::format("unsupported type in mysql sink:{}", type.type));
         }
 
         switch (type.type) {
@@ -117,7 +117,7 @@ Status MysqlTableWriter::_build_viewers(vectorized::Columns& columns) {
         }
 
         default:
-            return Status::InternalError(fmt::format("unsupport type in mysql sink:{}", type.type));
+            return Status::InternalError(fmt::format("unsupported type in mysql sink:{}", type.type));
         }
     }
 

--- a/be/src/runtime/routine_load/data_consumer.cpp
+++ b/be/src/runtime/routine_load/data_consumer.cpp
@@ -245,9 +245,9 @@ Status KafkaDataConsumer::get_partition_offset(std::vector<int32_t>* partition_i
         RdKafka::ErrorCode err =
                 _k_consumer->query_watermark_offsets(_topic, p_id, &beginning_offset, &latest_offset, 5000);
         if (err != RdKafka::ERR_NO_ERROR) {
-            LOG(WARNING) << "failed to query wartermark offset of topic: " << _topic << " partition: " << p_id
+            LOG(WARNING) << "failed to query watermark offset of topic: " << _topic << " partition: " << p_id
                          << ", err: " << RdKafka::err2str(err);
-            return Status::InternalError("failed to query wartermark offset, err: " + RdKafka::err2str(err));
+            return Status::InternalError("failed to query watermark offset, err: " + RdKafka::err2str(err));
         }
         beginning_offsets->push_back(beginning_offset);
         latest_offsets->push_back(latest_offset);

--- a/be/src/runtime/tablets_channel.cpp
+++ b/be/src/runtime/tablets_channel.cpp
@@ -81,11 +81,11 @@ Status TabletsChannel::add_chunk(const PTabletWriterAddChunkRequest& params) {
         auto next_seq = _next_seqs[params.sender_id()];
         // check packet
         if (params.packet_seq() < next_seq) {
-            LOG(INFO) << "packet has already recept before, expect_seq=" << next_seq
-                      << ", recept_seq=" << params.packet_seq();
+            LOG(INFO) << "packet has already received before, expect_seq=" << next_seq
+                      << ", received_seq=" << params.packet_seq();
             return Status::OK();
         } else if (params.packet_seq() > next_seq) {
-            LOG(WARNING) << "lost data packet, expect_seq=" << next_seq << ", recept_seq=" << params.packet_seq();
+            LOG(WARNING) << "lost data packet, expect_seq=" << next_seq << ", received_seq=" << params.packet_seq();
             return Status::InternalError("lost data packet");
         }
     }

--- a/be/src/runtime/vectorized/Volnitsky.h
+++ b/be/src/runtime/vectorized/Volnitsky.h
@@ -103,7 +103,7 @@ public:
         auto callback = [this](const VolnitskyTraits::Ngram ngram, const int offset) {
             return this->putNGramBase(ngram, offset);
         };
-        /// ssize_t is used here because unsigned can't be used with condition like `i >= 0`, unsigned always >= 0
+        /// size_t is used here because unsigned can't be used with condition like `i >= 0`, unsigned always >= 0
         /// And also adding from the end guarantees that we will find first occurrence because we will lookup bigger offsets first.
         for (auto i = static_cast<ssize_t>(needle_size - sizeof(VolnitskyTraits::Ngram)); i >= 0; --i)
             VolnitskyTraits::putNGram(this->needle + i, i + 1, callback);

--- a/be/src/runtime/vectorized/Volnitsky.h
+++ b/be/src/runtime/vectorized/Volnitsky.h
@@ -103,7 +103,7 @@ public:
         auto callback = [this](const VolnitskyTraits::Ngram ngram, const int offset) {
             return this->putNGramBase(ngram, offset);
         };
-        /// size_t is used here because unsigned can't be used with condition like `i >= 0`, unsigned always >= 0
+        /// ssize_t is used here because unsigned can't be used with condition like `i >= 0`, unsigned always >= 0
         /// And also adding from the end guarantees that we will find first occurrence because we will lookup bigger offsets first.
         for (auto i = static_cast<ssize_t>(needle_size - sizeof(VolnitskyTraits::Ngram)); i >= 0; --i)
             VolnitskyTraits::putNGram(this->needle + i, i + 1, callback);

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -118,7 +118,7 @@ void PInternalServiceImpl<T>::transmit_runtime_filter(google::protobuf::RpcContr
                                                       PTransmitRuntimeFilterResult* response,
                                                       google::protobuf::Closure* done) {
     VLOG_FILE << "transmit runtime filter: fragment_instance_id=" << print_id(request->finst_id())
-              << " query_id=" << request->query_id() << ", is_partital=" << request->is_partial()
+              << " query_id=" << request->query_id() << ", is_partial=" << request->is_partial()
               << ", filter_id=" << request->filter_id() << ", is_pipeline=" << request->is_pipeline();
     ClosureGuard closure_guard(done);
     _exec_env->runtime_filter_worker()->receive_runtime_filter(*request);
@@ -261,7 +261,7 @@ void PInternalServiceImpl<T>::cancel_plan_fragment(google::protobuf::RpcControll
     Status st;
     auto reason_string =
             request->has_cancel_reason() ? cancel_reason_to_string(request->cancel_reason()) : "UnknownReason";
-    LOG(INFO) << "cancel framgent, fragment_instance_id=" << print_id(tid) << ", reason: " << reason_string;
+    LOG(INFO) << "cancel fragment, fragment_instance_id=" << print_id(tid) << ", reason: " << reason_string;
 
     if (request->has_is_pipeline() && request->is_pipeline()) {
         TUniqueId query_id;
@@ -291,7 +291,7 @@ void PInternalServiceImpl<T>::cancel_plan_fragment(google::protobuf::RpcControll
         if (request->has_cancel_reason()) {
             st = _exec_env->fragment_mgr()->cancel(tid, request->cancel_reason());
         } else {
-            LOG(INFO) << "cancel framgent, fragment_instance_id=" << print_id(tid);
+            LOG(INFO) << "cancel fragment, fragment_instance_id=" << print_id(tid);
             st = _exec_env->fragment_mgr()->cancel(tid);
         }
         if (!st.ok()) {

--- a/be/src/storage/olap_define.h
+++ b/be/src/storage/olap_define.h
@@ -310,7 +310,7 @@ private:                                 \
     } while (0)
 
 #ifndef BUILD_VERSION
-#define BUILD_VERSION "Unknow"
+#define BUILD_VERSION "Unknown"
 #endif
 
 } // namespace starrocks

--- a/be/src/storage/olap_server.cpp
+++ b/be/src/storage/olap_server.cpp
@@ -137,7 +137,7 @@ Status StorageEngine::start_bg_threads() {
         LOG(INFO) << "path scan/gc threads started. number:" << get_stores().size();
     }
 
-    LOG(INFO) << "all storage engine's backgroud threads are started.";
+    LOG(INFO) << "all storage engine's background threads are started.";
     return Status::OK();
 }
 

--- a/be/src/storage/rowset/beta_rowset.cpp
+++ b/be/src/storage/rowset/beta_rowset.cpp
@@ -89,7 +89,7 @@ Status BetaRowset::do_load() {
 
 OLAPStatus BetaRowset::remove() {
     // TODO should we close and remove all segment reader first?
-    VLOG(1) << "Removing files in rowsset id=" << unique_id() << " version=" << start_version() << "-" << end_version()
+    VLOG(1) << "Removing files in rowset id=" << unique_id() << " version=" << start_version() << "-" << end_version()
             << " tablet_id=" << _rowset_meta->tablet_id();
     bool success = true;
     for (int i = 0; i < num_segments(); ++i) {

--- a/be/src/storage/rowset/binary_dict_page.cpp
+++ b/be/src/storage/rowset/binary_dict_page.cpp
@@ -192,7 +192,7 @@ Status BinaryDictPageDecoder<Type>::init() {
         DCHECK_EQ(_encoding_type, PLAIN_ENCODING);
         _data_page_decoder.reset(new BinaryPlainPageDecoder<Type>(_data, _options));
     } else {
-        LOG(WARNING) << "invalide encoding type:" << _encoding_type;
+        LOG(WARNING) << "invalid encoding type:" << _encoding_type;
         return Status::Corruption(strings::Substitute("invalid encoding type:$0", _encoding_type));
     }
 

--- a/be/src/storage/rowset/binary_plain_page.h
+++ b/be/src/storage/rowset/binary_plain_page.h
@@ -181,7 +181,7 @@ public:
 
         if (_data.size < sizeof(uint32_t)) {
             std::stringstream ss;
-            ss << "file corrupton: not enough bytes for trailer in BinaryPlainPageDecoder ."
+            ss << "file corruption: not enough bytes for trailer in BinaryPlainPageDecoder ."
                   "invalid data size:"
                << _data.size << ", trailer size:" << sizeof(uint32_t);
             return Status::Corruption(ss.str());

--- a/be/src/storage/rowset/bitshuffle_page.h
+++ b/be/src/storage/rowset/bitshuffle_page.h
@@ -239,7 +239,7 @@ public:
         CHECK(!_parsed);
         if (_data.size < BITSHUFFLE_PAGE_HEADER_SIZE) {
             std::stringstream ss;
-            ss << "file corrupton: invalid data size:" << _data.size << ", header size:" << BITSHUFFLE_PAGE_HEADER_SIZE;
+            ss << "file corruption: invalid data size:" << _data.size << ", header size:" << BITSHUFFLE_PAGE_HEADER_SIZE;
             return Status::InternalError(ss.str());
         }
 

--- a/be/src/storage/rowset/bitshuffle_page.h
+++ b/be/src/storage/rowset/bitshuffle_page.h
@@ -239,7 +239,8 @@ public:
         CHECK(!_parsed);
         if (_data.size < BITSHUFFLE_PAGE_HEADER_SIZE) {
             std::stringstream ss;
-            ss << "file corruption: invalid data size:" << _data.size << ", header size:" << BITSHUFFLE_PAGE_HEADER_SIZE;
+            ss << "file corruption: invalid data size:" << _data.size
+               << ", header size:" << BITSHUFFLE_PAGE_HEADER_SIZE;
             return Status::InternalError(ss.str());
         }
 

--- a/be/src/storage/rowset/plain_page.h
+++ b/be/src/storage/rowset/plain_page.h
@@ -117,7 +117,7 @@ public:
 
         if (_data.size < PLAIN_PAGE_HEADER_SIZE) {
             std::stringstream ss;
-            ss << "file corrupton: not enough bytes for header in PlainPageDecoder ."
+            ss << "file corruption: not enough bytes for header in PlainPageDecoder ."
                   "invalid data size:"
                << _data.size << ", header size:" << PLAIN_PAGE_HEADER_SIZE;
             return Status::InternalError(ss.str());
@@ -127,7 +127,7 @@ public:
 
         if (_data.size != PLAIN_PAGE_HEADER_SIZE + _num_elems * SIZE_OF_TYPE) {
             std::stringstream ss;
-            ss << "file corrupton: unexpected data size.";
+            ss << "file corruption: unexpected data size.";
             return Status::InternalError(ss.str());
         }
 

--- a/be/src/storage/rowset/storage_page_decoder.cpp
+++ b/be/src/storage/rowset/storage_page_decoder.cpp
@@ -77,7 +77,7 @@ public:
         } else if (type == PLAIN_ENCODING) {
             return Status::OK();
         } else {
-            LOG(WARNING) << "invalide encoding type:" << type;
+            LOG(WARNING) << "invalid encoding type:" << type;
             return Status::Corruption(strings::Substitute("invalid encoding type:$0", type));
         }
     }

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -544,9 +544,9 @@ void StorageEngine::clear_transaction_task(const TTransactionId transaction_id,
 }
 
 void StorageEngine::_start_clean_fd_cache() {
-    VLOG(10) << "Cleaning file descritpor cache";
+    VLOG(10) << "Cleaning file descriptor cache";
     _file_cache->prune();
-    VLOG(10) << "Cleaned file descritpor cache";
+    VLOG(10) << "Cleaned file descriptor cache";
 }
 
 Status StorageEngine::_perform_cumulative_compaction(DataDir* data_dir) {

--- a/be/src/storage/tablet_meta_manager.cpp
+++ b/be/src/storage/tablet_meta_manager.cpp
@@ -462,10 +462,10 @@ Status TabletMetaManager::build_primary_meta(DataDir* store, rapidjson::Document
         return Status::IOError("clear delvec add to batch failed");
     }
     if (!clear_rowset(store, &batch, tablet_id).ok()) {
-        return Status::IOError("clear rowset add to batch faied");
+        return Status::IOError("clear rowset add to batch failed");
     }
     if (!clear_pending_rowset(store, &batch, tablet_id).ok()) {
-        return Status::IOError("clear rowset add to batch faied");
+        return Status::IOError("clear rowset add to batch failed");
     }
 
     if (doc.HasMember("applied_rs_metas") && doc["applied_rs_metas"].IsArray()) {
@@ -834,7 +834,7 @@ Status TabletMetaManager::get_del_vector(KVStore* meta, TTabletId tablet_id, uin
     };
     st = meta->iterate_range(META_COLUMN_FAMILY_INDEX, lower, upper, traverse_versions);
     if (!st.ok()) {
-        LOG(WARNING) << "fail to iterate rockdb delvecs. tablet_id=" << tablet_id << " segment_id=" << segment_id
+        LOG(WARNING) << "fail to iterate rocksdb delvecs. tablet_id=" << tablet_id << " segment_id=" << segment_id
                      << " error_code=" << st.to_string();
         return st;
     }
@@ -867,7 +867,7 @@ StatusOr<DeleteVectorList> TabletMetaManager::list_del_vector(KVStore* meta, TTa
                                       return true;
                                   });
     if (!st.ok()) {
-        LOG(WARNING) << "fail to iterate rockdb delvecs. tablet_id=" << tablet_id;
+        LOG(WARNING) << "fail to iterate rocksdb delvecs. tablet_id=" << tablet_id;
         return st;
     }
     return std::move(ret);
@@ -1137,10 +1137,10 @@ Status TabletMetaManager::remove(DataDir* store, TTabletId tablet_id) {
             LOG(WARNING) << "clear delvec add to batch failed";
         }
         if (!clear_rowset(store, &batch, tablet_id).ok()) {
-            LOG(WARNING) << "clear rowset add to batch faied";
+            LOG(WARNING) << "clear rowset add to batch failed";
         }
         if (!clear_pending_rowset(store, &batch, tablet_id).ok()) {
-            LOG(WARNING) << "clear rowset add to batch faied";
+            LOG(WARNING) << "clear rowset add to batch failed";
         }
     }
     return meta->write_batch(&batch);

--- a/be/src/storage/vectorized/base_compaction.cpp
+++ b/be/src/storage/vectorized/base_compaction.cpp
@@ -95,7 +95,7 @@ Status BaseCompaction::pick_rowsets_to_compact() {
 
     if (cumulative_base_ratio > base_cumulative_delta_ratio) {
         LOG(INFO) << "satisfy the base compaction policy. tablet=" << _tablet->full_name()
-                  << ", cumualtive_total_size=" << cumulative_total_size << ", base_size=" << base_size
+                  << ", cumulative_total_size=" << cumulative_total_size << ", base_size=" << base_size
                   << ", cumulative_base_ratio=" << cumulative_base_ratio
                   << ", policy_ratio=" << base_cumulative_delta_ratio;
         return Status::OK();
@@ -122,7 +122,7 @@ Status BaseCompaction::pick_rowsets_to_compact() {
 Status BaseCompaction::_check_rowset_overlapping(const std::vector<RowsetSharedPtr>& rowsets) {
     for (auto& rs : rowsets) {
         if (rs->rowset_meta()->is_segments_overlapping()) {
-            return Status::InternalError("base compaction segments overlappinng error.");
+            return Status::InternalError("base compaction segments overlapping error.");
         }
     }
     return Status::OK();

--- a/be/src/storage/vectorized/compaction.cpp
+++ b/be/src/storage/vectorized/compaction.cpp
@@ -504,7 +504,8 @@ Status Compaction::check_correctness(const Statistics& stats) {
     if (_input_row_num != _output_rowset->num_rows() + stats.merged_rows + stats.filtered_rows) {
         LOG(WARNING) << "row_num does not match between cumulative input and output! "
                      << "input_row_num=" << _input_row_num << ", merged_row_num=" << stats.merged_rows
-                     << ", filtered_row_num=" << stats.filtered_rows << ", output_row_num=" << _output_rowset->num_rows();
+                     << ", filtered_row_num=" << stats.filtered_rows
+                     << ", output_row_num=" << _output_rowset->num_rows();
 
         return Status::InternalError("cumulative compaction check lines error.");
     }

--- a/be/src/storage/vectorized/compaction.cpp
+++ b/be/src/storage/vectorized/compaction.cpp
@@ -489,7 +489,7 @@ Status Compaction::check_version_continuity(const std::vector<RowsetSharedPtr>& 
         const RowsetSharedPtr& rowset = rowsets[i];
         if (rowset->start_version() != prev_rowset->end_version() + 1) {
             LOG(WARNING) << "There are missed versions among rowsets. "
-                         << "prev_rowset verison=" << prev_rowset->start_version() << "-" << prev_rowset->end_version()
+                         << "prev_rowset version=" << prev_rowset->start_version() << "-" << prev_rowset->end_version()
                          << ", rowset version=" << rowset->start_version() << "-" << rowset->end_version();
             return Status::InternalError("cumulative compaction miss version error.");
         }
@@ -504,7 +504,7 @@ Status Compaction::check_correctness(const Statistics& stats) {
     if (_input_row_num != _output_rowset->num_rows() + stats.merged_rows + stats.filtered_rows) {
         LOG(WARNING) << "row_num does not match between cumulative input and output! "
                      << "input_row_num=" << _input_row_num << ", merged_row_num=" << stats.merged_rows
-                     << ", filted_row_num=" << stats.filtered_rows << ", output_row_num=" << _output_rowset->num_rows();
+                     << ", filtered_row_num=" << stats.filtered_rows << ", output_row_num=" << _output_rowset->num_rows();
 
         return Status::InternalError("cumulative compaction check lines error.");
     }

--- a/be/src/storage/vectorized/convert_helper.cpp
+++ b/be/src/storage/vectorized/convert_helper.cpp
@@ -88,7 +88,7 @@ public:
     ~DatetimeToDateTypeConverter() = default;
 
     Status convert(void* dst, const void* src, MemPool* memPool) const override {
-        return Status::InternalError("misssing implementation");
+        return Status::InternalError("missing implementation");
     }
 
     Status convert_datum(TypeInfo* src_typeinfo, const Datum& src, TypeInfo* dst_typeinfo, Datum& dst,
@@ -111,7 +111,7 @@ public:
     ~TimestampToDateTypeConverter() = default;
 
     Status convert(void* dst, const void* src, MemPool* memPool) const override {
-        return Status::InternalError("misssing implementation");
+        return Status::InternalError("missing implementation");
     }
 
     Status convert_datum(TypeInfo* src_typeinfo, const Datum& src, TypeInfo* dst_typeinfo, Datum& dst,
@@ -134,7 +134,7 @@ public:
     ~IntToDateTypeConverter() = default;
 
     Status convert(void* dst, const void* src, MemPool* memPool) const override {
-        return Status::InternalError("misssing implementation");
+        return Status::InternalError("missing implementation");
     }
 
     Status convert_datum(TypeInfo* src_typeinfo, const Datum& src, TypeInfo* dst_typeinfo, Datum& dst,
@@ -162,7 +162,7 @@ public:
     ~DateV2ToDateTypeConverter() = default;
 
     Status convert(void* dst, const void* src, MemPool* memPool) const override {
-        return Status::InternalError("misssing implementation");
+        return Status::InternalError("missing implementation");
     }
 
     Status convert_datum(TypeInfo* src_typeinfo, const Datum& src, TypeInfo* dst_typeinfo, Datum& dst,
@@ -228,7 +228,7 @@ public:
     ~DateToDateV2TypeConverter() = default;
 
     Status convert(void* dst, const void* src, MemPool* memPool) const override {
-        return Status::InternalError("misssing implementation");
+        return Status::InternalError("missing implementation");
     }
 
     Status convert_datum(TypeInfo* src_typeinfo, const Datum& src, TypeInfo* dst_typeinfo, Datum& dst,
@@ -248,7 +248,7 @@ public:
     ~DateToDatetimeFieldConveter() = default;
 
     Status convert(void* dst, const void* src, MemPool* memPool) const override {
-        return Status::InternalError("misssing implementation");
+        return Status::InternalError("missing implementation");
     }
 
     Status convert_datum(TypeInfo* src_typeinfo, const Datum& src, TypeInfo* dst_typeinfo, Datum& dst,
@@ -271,7 +271,7 @@ public:
     ~DateV2ToDatetimeFieldConveter() = default;
 
     Status convert(void* dst, const void* src, MemPool* memPool) const override {
-        return Status::InternalError("misssing implementation");
+        return Status::InternalError("missing implementation");
     }
 
     Status convert_datum(TypeInfo* src_typeinfo, const Datum& src, TypeInfo* dst_typeinfo, Datum& dst,
@@ -294,7 +294,7 @@ public:
     ~TimestampToDatetimeTypeConverter() = default;
 
     Status convert(void* dst, const void* src, MemPool* memPool) const override {
-        return Status::InternalError("misssing implementation");
+        return Status::InternalError("missing implementation");
     }
 
     Status convert_datum(TypeInfo* src_typeinfo, const Datum& src, TypeInfo* dst_typeinfo, Datum& dst,
@@ -373,7 +373,7 @@ public:
     ~DatetimeToTimestampTypeConverter() = default;
 
     Status convert(void* dst, const void* src, MemPool* memPool) const override {
-        return Status::InternalError("misssing implementation");
+        return Status::InternalError("missing implementation");
     }
 
     Status convert_datum(TypeInfo* src_typeinfo, const Datum& src, TypeInfo* dst_typeinfo, Datum& dst,
@@ -393,7 +393,7 @@ public:
     ~FloatToDoubleTypeConverter() = default;
 
     Status convert(void* dst, const void* src, MemPool* memPool) const override {
-        return Status::InternalError("misssing implementation");
+        return Status::InternalError("missing implementation");
     }
 
     Status convert_datum(TypeInfo* src_typeinfo, const Datum& src, TypeInfo* dst_typeinfo, Datum& dst,
@@ -416,7 +416,7 @@ public:
     ~DecimalToDecimal12TypeConverter() = default;
 
     Status convert(void* dst, const void* src, MemPool* memPool) const override {
-        return Status::InternalError("misssing implementation");
+        return Status::InternalError("missing implementation");
     }
 
     Status convert_datum(TypeInfo* src_typeinfo, const Datum& src, TypeInfo* dst_typeinfo, Datum& dst,
@@ -437,7 +437,7 @@ public:
     ~Decimal12ToDecimalTypeConverter() = default;
 
     Status convert(void* dst, const void* src, MemPool* memPool) const override {
-        return Status::InternalError("misssing implementation");
+        return Status::InternalError("missing implementation");
     }
 
     Status convert_datum(TypeInfo* src_typeinfo, const Datum& src, TypeInfo* dst_typeinfo, Datum& dst,
@@ -497,7 +497,7 @@ public:
     ~DecimalTypeConverter() = default;
 
     Status convert(void* dst, const void* src, MemPool* memPool) const override {
-        return Status::InternalError("misssing implementation");
+        return Status::InternalError("missing implementation");
     }
 
     Status convert_datum(TypeInfo* src_typeinfo, const Datum& src, TypeInfo* dst_typeinfo, Datum& dst,
@@ -524,7 +524,7 @@ public:
     ~DecimalV3TypeConverter() = default;
 
     Status convert(void* dst, const void* src, MemPool* memPool) const override {
-        return Status::InternalError("misssing implementation");
+        return Status::InternalError("missing implementation");
     }
 
     Status convert_datum(TypeInfo* src_typeinfo, const Datum& src, TypeInfo* dst_typeinfo, Datum& dst,
@@ -560,7 +560,7 @@ public:
 
     Status convert_datum(TypeInfo* src_typeinfo, const Datum& src, TypeInfo* dst_typeinfo, Datum& dst,
                          MemPool* mem_pool) const override {
-        return Status::InternalError("misssing implementation");
+        return Status::InternalError("missing implementation");
     }
 };
 
@@ -573,7 +573,7 @@ public:
     ~StringToOtherTypeConverter() = default;
 
     Status convert(void* dst, const void* src, MemPool* memPool) const override {
-        return Status::InternalError("misssing implementation");
+        return Status::InternalError("missing implementation");
     }
 
     Status convert_datum(TypeInfo* src_typeinfo, const Datum& src, TypeInfo* dst_typeinfo, Datum& dst,
@@ -602,7 +602,7 @@ public:
     ~OtherToStringTypeConverter() = default;
 
     Status convert(void* dst, const void* src, MemPool* memPool) const override {
-        return Status::InternalError("misssing implementation");
+        return Status::InternalError("missing implementation");
     }
 
     Status convert_datum(TypeInfo* src_typeinfo, const Datum& src, TypeInfo* dst_typeinfo, Datum& dst,
@@ -1402,7 +1402,7 @@ const MaterializeTypeConverter* get_materialized_converter(FieldType from_type, 
         return &s_converter;
     }
     default:
-        LOG(WARNING) << "unknown materilized type";
+        LOG(WARNING) << "unknown materialized type";
         break;
     }
     return nullptr;

--- a/be/src/storage/vectorized/meta_reader.cpp
+++ b/be/src/storage/vectorized/meta_reader.cpp
@@ -276,7 +276,7 @@ Status SegmentMetaCollecter::_collect(const std::string& name, ColumnId cid, vec
 // collect dict
 Status SegmentMetaCollecter::_collect_dict(ColumnId cid, vectorized::Column* column, FieldType type) {
     if (!_column_iterators[cid]) {
-        return Status::InvalidArgument("Invalid Collet Params.");
+        return Status::InvalidArgument("Invalid Collect Params.");
     }
 
     std::vector<Slice> words;

--- a/be/src/storage/vectorized/schema_change.cpp
+++ b/be/src/storage/vectorized/schema_change.cpp
@@ -905,7 +905,7 @@ Status SchemaChangeHandler::_do_process_alter_tablet_v2(const TAlterTabletReqV2&
     if (new_tablet->tablet_state() != TABLET_NOTREADY) {
         Status st = _validate_alter_result(new_tablet, request);
         LOG(INFO) << "tablet's state=" << new_tablet->tablet_state()
-                  << " the convert job alreay finished, check its version"
+                  << " the convert job already finished, check its version"
                   << " res=" << st.to_string();
         return Status::InternalError("new tablet's meta is invalid");
     }
@@ -1197,7 +1197,7 @@ Status SchemaChangeHandler::_convert_historical_rowsets(SchemaChangeParams& sc_p
         LOG(INFO) << "new rowset has " << new_rowset->num_segments() << " segments";
         status = sc_params.new_tablet->add_rowset(new_rowset, false);
         if (status.is_already_exist()) {
-            LOG(WARNING) << "version already exist, version revert occured. "
+            LOG(WARNING) << "version already exist, version revert occurred. "
                          << "tablet=" << sc_params.new_tablet->full_name() << ", version='" << sc_params.version.first
                          << "-" << sc_params.version.second;
             StorageEngine::instance()->add_unused_rowset(new_rowset);

--- a/be/src/storage/version_graph.cpp
+++ b/be/src/storage/version_graph.cpp
@@ -356,7 +356,7 @@ void VersionGraph::_add_vertex_to_graph(int64_t vertex_value) {
 OLAPStatus VersionGraph::capture_consistent_versions(const Version& spec_version,
                                                      std::vector<Version>* version_path) const {
     if (spec_version.first > spec_version.second) {
-        LOG(WARNING) << "invalid specfied version. "
+        LOG(WARNING) << "invalid specified version. "
                      << "spec_version=" << spec_version.first << "-" << spec_version.second;
         return OLAP_ERR_INPUT_PARAMETER_ERROR;
     }

--- a/be/src/storage/version_graph.h
+++ b/be/src/storage/version_graph.h
@@ -43,7 +43,7 @@ public:
     void construct_version_graph(const std::vector<RowsetMetaSharedPtr>& rs_metas, int64_t* max_version);
     /// Reconstruct the graph, begin construction the vertex vec and edges list will be cleared.
     void reconstruct_version_graph(const std::vector<RowsetMetaSharedPtr>& rs_metas, int64_t* max_version);
-    /// Add a version to this graph, graph will add the vesion and edge in version.
+    /// Add a version to this graph, graph will add the version and edge in version.
     void add_version_to_graph(const Version& version);
     /// Delete a version from graph. Notice that this del operation only remove this edges and
     /// remain the vertex.
@@ -104,7 +104,7 @@ using TimestampedVersionSharedPtr = std::shared_ptr<TimestampedVersion>;
 /// will compare with the version timestamp and be refreshed.
 class TimestampedVersionPathContainer {
 public:
-    /// TimestampedVersionPathContainer construction function, max_create_time is assgined to 0.
+    /// TimestampedVersionPathContainer construction function, max_create_time is assigned to 0.
     TimestampedVersionPathContainer() {}
 
     /// Return the max create time in a path version.

--- a/be/src/udf/udf.h
+++ b/be/src/udf/udf.h
@@ -199,7 +199,7 @@ public:
     starrocks::FunctionContextImpl* impl() { return _impl; }
 
     /// Methods for maintaining state across UDF/UDA function calls. SetFunctionState() can
-    /// be used to store a pointer that can then be retreived via GetFunctionState(). If
+    /// be used to store a pointer that can then be retrieved via GetFunctionState(). If
     /// GetFunctionState() is called when no pointer is set, it will return
     /// NULL. SetFunctionState() does not take ownership of 'ptr'; it is up to the UDF/UDA
     /// to clean up any function state if necessary.

--- a/be/src/util/bfd_parser.cpp
+++ b/be/src/util/bfd_parser.cpp
@@ -171,7 +171,7 @@ int BfdParser::open_bfd() {
         return -1;
     }
     if (bfd_check_format(_abfd, bfd_archive)) {
-        LOG(WARNING) << "bfd_check_format for archive fialed because errmsg=" << bfd_errmsg(bfd_get_error());
+        LOG(WARNING) << "bfd_check_format for archive failed because errmsg=" << bfd_errmsg(bfd_get_error());
         return -1;
     }
 

--- a/be/src/util/block_compression.cpp
+++ b/be/src/util/block_compression.cpp
@@ -388,7 +388,7 @@ public:
         std::unique_ptr<ZSTD_CStream, decltype(deleter)> stream{ZSTD_createCStream(), deleter};
         auto ret = ZSTD_initCStream(stream.get(), ZSTD_CLEVEL_DEFAULT);
         if (ZSTD_isError(ret)) {
-            return Status::InvalidArgument(strings::Substitute("ZSTD ceate compress stream failed: $0", ret));
+            return Status::InvalidArgument(strings::Substitute("ZSTD create compress stream failed: $0", ret));
         }
 
         ZSTD_outBuffer out_buf;

--- a/be/src/util/broker_load_error_hub.cpp
+++ b/be/src/util/broker_load_error_hub.cpp
@@ -94,7 +94,7 @@ Status BrokerLoadErrorHub::write_to_broker() {
 
 std::string BrokerLoadErrorHub::debug_string() const {
     std::stringstream out;
-    out << "(tatal_error_num=" << _total_error_num << ")";
+    out << "(total_error_num=" << _total_error_num << ")";
     return out.str();
 }
 

--- a/be/src/util/monotime.h
+++ b/be/src/util/monotime.h
@@ -227,10 +227,10 @@ public:
     /// @return Reference to the modified object.
     MonoTime& operator+=(const MonoDelta& delta);
 
-    /// Substract a delta from the point in time represented by the object.
+    /// Subtract a delta from the point in time represented by the object.
     ///
     /// @param [in] delta
-    ///   The delta to substract.
+    ///   The delta to subtract.
     /// @return Reference to the modified object.
     MonoTime& operator-=(const MonoDelta& delta);
     ///@}

--- a/be/src/util/mysql_load_error_hub.cpp
+++ b/be/src/util/mysql_load_error_hub.cpp
@@ -129,7 +129,7 @@ Status MysqlLoadErrorHub::open_mysql_conn(MYSQL** my_conn) {
         LOG(WARNING) << "fail to connect Mysql: "
                      << "Host: " << _info.host << " port: " << _info.port << " user: " << _info.user
                      << " passwd: " << _info.passwd << " db: " << _info.db;
-        return error_status("loal error mysql real connect failed.", *my_conn);
+        return error_status("load error mysql real connect failed.", *my_conn);
     }
 
     return Status::OK();
@@ -144,7 +144,7 @@ Status MysqlLoadErrorHub::error_status(const std::string& prefix, MYSQL* my_conn
 
 std::string MysqlLoadErrorHub::debug_string() const {
     std::stringstream out;
-    out << "(tatal_error_num=" << _total_error_num << ")";
+    out << "(total_error_num=" << _total_error_num << ")";
     return out.str();
 }
 

--- a/be/src/util/null_load_error_hub.cpp
+++ b/be/src/util/null_load_error_hub.cpp
@@ -45,7 +45,7 @@ Status NullLoadErrorHub::close() {
 
 std::string NullLoadErrorHub::debug_string() const {
     std::stringstream out;
-    out << "NullLoadErrorHub(tatal_error_num=" << _total_error_num << ")";
+    out << "NullLoadErrorHub(total_error_num=" << _total_error_num << ")";
     return out.str();
 }
 

--- a/be/src/util/thrift_rpc_helper.cpp
+++ b/be/src/util/thrift_rpc_helper.cpp
@@ -55,7 +55,7 @@ Status ThriftRpcHelper::rpc(const std::string& ip, const int32_t port,
     Status status;
     ClientConnection<T> client(_s_exec_env->get_client_cache<T>(), address, timeout_ms, &status);
     if (!status.ok()) {
-        LOG(WARNING) << "Connect frontent failed, address=" << address << ", status=" << status.get_error_msg();
+        LOG(WARNING) << "Connect frontend failed, address=" << address << ", status=" << status.get_error_msg();
         return status;
     }
     try {
@@ -67,7 +67,7 @@ Status ThriftRpcHelper::rpc(const std::string& ip, const int32_t port,
             SleepFor(MonoDelta::FromMilliseconds(config::thrift_client_retry_interval_ms));
             status = client.reopen(timeout_ms);
             if (!status.ok()) {
-                LOG(WARNING) << "client repoen failed. address=" << address << ", status=" << status.get_error_msg();
+                LOG(WARNING) << "client reopen failed. address=" << address << ", status=" << status.get_error_msg();
                 return status;
             }
             callback(client);


### PR DESCRIPTION
There are 4480 CLion typos in be/src, including 2475 Process code typos, 131 Process literals typos and 1874 Process comments typos.
This PR fix the Process literals.