### PR TITLE
Fix the int overflow bug of DeleteHandler

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/DeleteHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/DeleteHandler.java
@@ -744,6 +744,10 @@ public class DeleteHandler implements Writable {
         if (deleteInfo == null) {
             return;
         }
+        if ((System.currentTimeMillis() - deleteInfo.getCreateTimeMs()) / 1000 > Config.label_keep_max_second) {
+            LOG.info("delete info outdated, create time: {}, ignore", deleteInfo.getCreateTimeMs());
+            return;
+        }
         long dbId = deleteInfo.getDbId();
         LOG.info("replay delete, dbId {}", dbId);
         updateTableDeleteInfo(catalog, dbId, deleteInfo.getTableId());
@@ -760,6 +764,10 @@ public class DeleteHandler implements Writable {
     public void replayMultiDelete(MultiDeleteInfo deleteInfo, Catalog catalog) {
         // add to deleteInfos
         if (deleteInfo == null) {
+            return;
+        }
+        if ((System.currentTimeMillis() - deleteInfo.getCreateTimeMs()) / 1000 > Config.label_keep_max_second) {
+            LOG.info("delete info outdated, create time: {}, ignore", deleteInfo.getCreateTimeMs());
             return;
         }
         long dbId = deleteInfo.getDbId();
@@ -795,7 +803,20 @@ public class DeleteHandler implements Writable {
     }
 
     public static DeleteHandler read(DataInput in) throws IOException {
-        String json = Text.readString(in);
+        String json;
+        try {
+            json = Text.readString(in);
+
+            // In older versions of fe, the information in the deleteHandler is not cleaned up,
+            // and if there are many delete statements, it will cause an int overflow
+            // and report an IllegalArgumentException.
+            //
+            // dbToDeleteInfos is only used to record history delete info,
+            // discarding it doesn't make much of a difference
+        } catch (IllegalArgumentException e) {
+            LOG.warn("read delete handler json string failed, ignore", e);
+            return new DeleteHandler();
+        }
         return GsonUtils.GSON.fromJson(json, DeleteHandler.class);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/DeleteHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/DeleteHandler.java
@@ -744,13 +744,13 @@ public class DeleteHandler implements Writable {
         if (deleteInfo == null) {
             return;
         }
+        long dbId = deleteInfo.getDbId();
+        updateTableDeleteInfo(catalog, dbId, deleteInfo.getTableId());
         if ((System.currentTimeMillis() - deleteInfo.getCreateTimeMs()) / 1000 > Config.label_keep_max_second) {
             LOG.info("delete info outdated, create time: {}, ignore", deleteInfo.getCreateTimeMs());
             return;
         }
-        long dbId = deleteInfo.getDbId();
         LOG.info("replay delete, dbId {}", dbId);
-        updateTableDeleteInfo(catalog, dbId, deleteInfo.getTableId());
         dbToDeleteInfos.putIfAbsent(dbId, Lists.newArrayList());
         List<MultiDeleteInfo> deleteInfoList = dbToDeleteInfos.get(dbId);
         lock.writeLock().lock();
@@ -766,13 +766,13 @@ public class DeleteHandler implements Writable {
         if (deleteInfo == null) {
             return;
         }
+        long dbId = deleteInfo.getDbId();
+        updateTableDeleteInfo(catalog, dbId, deleteInfo.getTableId());
         if ((System.currentTimeMillis() - deleteInfo.getCreateTimeMs()) / 1000 > Config.label_keep_max_second) {
             LOG.info("delete info outdated, create time: {}, ignore", deleteInfo.getCreateTimeMs());
             return;
         }
-        long dbId = deleteInfo.getDbId();
         LOG.info("replay delete, dbId {}", dbId);
-        updateTableDeleteInfo(catalog, dbId, deleteInfo.getTableId());
         dbToDeleteInfos.putIfAbsent(dbId, Lists.newArrayList());
         List<MultiDeleteInfo> deleteInfoList = dbToDeleteInfos.get(dbId);
         lock.writeLock().lock();


### PR DESCRIPTION
When doing checkpoint, it is to create a separate catalog object, first load the image, then replay the bdb log. So this PR https://github.com/StarRocks/starrocks/pull/667 Clearing only the deleteInfo  from existing memory does not reduce the number of deleteInfo in the image. Do not add the outdated delete info when replaying bdb log, this will reduce the number of deleteInfo in the image when doing checkpoint.