### PR TITLE
check data read range is empty when array column is nullable

### DIFF
--- a/be/src/storage/rowset/segment_v2/array_column_iterator.cpp
+++ b/be/src/storage/rowset/segment_v2/array_column_iterator.cpp
@@ -146,14 +146,14 @@ Status ArrayColumnIterator::next_batch(const vectorized::SparseRange& range, vec
     vectorized::SparseRangeIterator iter = range.new_iterator();
     size_t to_read = range.span_size();
 
-    DCHECK_EQ(range.begin(), _array_size_iterator->get_current_ordinal());
+    // array column can be nested, range may be empty
+    DCHECK(range.empty() || (range.begin() == _array_size_iterator->get_current_ordinal()));
     vectorized::SparseRange element_read_range;
     while (iter.has_more()) {
         vectorized::Range r = iter.next(to_read);
 
         RETURN_IF_ERROR(_array_size_iterator->seek_to_ordinal_and_calc_element_ordinal(r.begin()));
         size_t element_ordinal = _array_size_iterator->element_ordinal();
-        //RETURN_IF_ERROR(next_batch(&n, dst));
         // 2. Read offset column
         // [1, 2, 3], [4, 5, 6]
         // In memory, it will be transformed to actual offset(0, 3, 6)
@@ -177,7 +177,8 @@ Status ArrayColumnIterator::next_batch(const vectorized::SparseRange& range, vec
         element_read_range.add(vectorized::Range(element_ordinal, element_ordinal + num_to_read));
     }
 
-    DCHECK_EQ(element_read_range.begin(), _element_iterator->get_current_ordinal());
+    // if array column is nullable, element_read_range may be empty
+    DCHECK(element_read_range.empty() || (element_read_range.begin() == _element_iterator->get_current_ordinal()));
     RETURN_IF_ERROR(_element_iterator->next_batch(element_read_range, array_column->elements_column().get()));
 
     return Status::OK();

--- a/be/src/storage/rowset/segment_v2/scalar_column_iterator.cpp
+++ b/be/src/storage/rowset/segment_v2/scalar_column_iterator.cpp
@@ -194,7 +194,8 @@ Status ScalarColumnIterator::next_batch(const vectorized::SparseRange& range, ve
     size_t end_ord = _page->first_ordinal() + _page->num_rows();
     bool contain_deleted_row = (dst->delete_state() != DEL_NOT_SATISFIED);
     vectorized::SparseRange read_range;
-    DCHECK_EQ(range.begin(), _current_ordinal);
+    // range is empty should only occur when array column is nullable
+    DCHECK(range.empty() || (range.begin() == _current_ordinal));
 
     // read data from discontinuous ranges in multiple pages
     // data in the same data page will be read together in one function call


### PR DESCRIPTION
when array column is nullable, data read range could be empty
check range is empty before get `range.begin()` to avoid nullptr exception in ASAN type