### PR TITLE
reduce simdjson memory consuming

### DIFF
--- a/be/src/env/env_stream_pipe.cpp
+++ b/be/src/env/env_stream_pipe.cpp
@@ -19,8 +19,8 @@ Status StreamPipeSequentialFile::read(Slice* result) {
     return _file->read(reinterpret_cast<uint8_t*>(result->data), &(result->size), &eof);
 }
 
-Status StreamPipeSequentialFile::read_one_message(std::unique_ptr<uint8_t[]>* buf, size_t* length) {
-    return _file->read_one_message(buf, length);
+Status StreamPipeSequentialFile::read_one_message(std::unique_ptr<uint8_t[]>* buf, size_t* length, size_t padding) {
+    return _file->read_one_message(buf, length, padding);
 }
 
 Status StreamPipeSequentialFile::skip(uint64_t n) {

--- a/be/src/env/env_stream_pipe.h
+++ b/be/src/env/env_stream_pipe.h
@@ -16,7 +16,7 @@ public:
     ~StreamPipeSequentialFile() override;
 
     Status read(Slice* result) override;
-    Status read_one_message(std::unique_ptr<uint8_t[]>* buf, size_t* length);
+    Status read_one_message(std::unique_ptr<uint8_t[]>* buf, size_t* length, size_t padding = 0);
 
     Status skip(uint64_t n) override;
     const std::string& filename() const override { return _filename; }

--- a/be/src/exec/broker_reader.cpp
+++ b/be/src/exec/broker_reader.cpp
@@ -125,7 +125,7 @@ Status BrokerReader::open() {
 }
 
 //not support
-Status BrokerReader::read_one_message(std::unique_ptr<uint8_t[]>* buf, size_t* length) {
+Status BrokerReader::read_one_message(std::unique_ptr<uint8_t[]>* buf, size_t* length, size_t padding) {
     return Status::NotSupported("Not support");
 }
 

--- a/be/src/exec/broker_reader.h
+++ b/be/src/exec/broker_reader.h
@@ -52,7 +52,7 @@ public:
 
     Status read(uint8_t* buf, size_t* buf_len, bool* eof) override;
     Status readat(int64_t position, int64_t nbytes, int64_t* bytes_read, void* out) override;
-    Status read_one_message(std::unique_ptr<uint8_t[]>* buf, size_t* length) override;
+    Status read_one_message(std::unique_ptr<uint8_t[]>* buf, size_t* length, size_t padding = 0) override;
     int64_t size() override;
     Status seek(int64_t position) override;
     Status tell(int64_t* position) override;

--- a/be/src/exec/buffered_reader.cpp
+++ b/be/src/exec/buffered_reader.cpp
@@ -50,7 +50,7 @@ Status BufferedReader::open() {
 }
 
 //not support
-Status BufferedReader::read_one_message(std::unique_ptr<uint8_t[]>* buf, size_t* length) {
+Status BufferedReader::read_one_message(std::unique_ptr<uint8_t[]>* buf, size_t* length, size_t padding) {
     return Status::NotSupported("Not support");
 }
 

--- a/be/src/exec/buffered_reader.h
+++ b/be/src/exec/buffered_reader.h
@@ -44,7 +44,7 @@ public:
     // Read
     Status read(uint8_t* buf, size_t* buf_len, bool* eof) override;
     Status readat(int64_t position, int64_t nbytes, int64_t* bytes_read, void* out) override;
-    Status read_one_message(std::unique_ptr<uint8_t[]>* buf, size_t* length) override;
+    Status read_one_message(std::unique_ptr<uint8_t[]>* buf, size_t* length, size_t padding = 0) override;
     int64_t size() override;
     Status seek(int64_t position) override;
     Status tell(int64_t* position) override;

--- a/be/src/exec/file_reader.h
+++ b/be/src/exec/file_reader.h
@@ -46,7 +46,7 @@ public:
      * if read eof then return Status::OK and length is set 0 and buf is set NULL,
      *  other return readed bytes.
      */
-    virtual Status read_one_message(std::unique_ptr<uint8_t[]>* buf, size_t* length) = 0;
+    virtual Status read_one_message(std::unique_ptr<uint8_t[]>* buf, size_t* length, size_t padding = 0) = 0;
     virtual int64_t size() = 0;
     virtual Status seek(int64_t position) = 0;
     virtual Status tell(int64_t* position) = 0;

--- a/be/src/exec/local_file_reader.cpp
+++ b/be/src/exec/local_file_reader.cpp
@@ -59,7 +59,7 @@ bool LocalFileReader::closed() {
 }
 
 // Read all bytes
-Status LocalFileReader::read_one_message(std::unique_ptr<uint8_t[]>* buf, size_t* length) {
+Status LocalFileReader::read_one_message(std::unique_ptr<uint8_t[]>* buf, size_t* length, size_t padding) {
     bool eof;
     int64_t file_size = size() - _current_offset;
     if (file_size <= 0) {
@@ -68,7 +68,7 @@ Status LocalFileReader::read_one_message(std::unique_ptr<uint8_t[]>* buf, size_t
         return Status::OK();
     }
     *length = file_size;
-    buf->reset(new uint8_t[file_size]);
+    buf->reset(new uint8_t[file_size + padding]);
     read(buf->get(), length, &eof);
     return Status::OK();
 }

--- a/be/src/exec/local_file_reader.h
+++ b/be/src/exec/local_file_reader.h
@@ -41,7 +41,7 @@ public:
     // is set to zero.
     Status read(uint8_t* buf, size_t* buf_len, bool* eof) override;
     Status readat(int64_t position, int64_t nbytes, int64_t* bytes_read, void* out) override;
-    Status read_one_message(std::unique_ptr<uint8_t[]>* buf, size_t* length) override;
+    Status read_one_message(std::unique_ptr<uint8_t[]>* buf, size_t* length, size_t padding = 0) override;
     int64_t size() override;
     Status seek(int64_t position) override;
     Status tell(int64_t* position) override;

--- a/be/src/exec/vectorized/json_scanner.cpp
+++ b/be/src/exec/vectorized/json_scanner.cpp
@@ -604,6 +604,7 @@ Status JsonDocumentStreamParser::get(simdjson::ondemand::object* row) {
     } catch (simdjson::simdjson_error& e) {
         std::string err_msg;
         if (e.error() == simdjson::CAPACITY) {
+            // It's necessary to tell the user when they try to load json array whose payload size is beyond the simdjson::ondemand::parser's buffer.
             err_msg =
                     "The input payload size is beyond parser limit. Please set strip_outer_array true if you want to "
                     "load json array";

--- a/be/src/exec/vectorized/json_scanner.cpp
+++ b/be/src/exec/vectorized/json_scanner.cpp
@@ -223,7 +223,7 @@ Status JsonScanner::_parse_json_paths(const std::string& jsonpath, std::vector<s
             const char* cstr = path.get_c_str();
 
             JsonFunctions::parse_json_paths(std::string(cstr), &parsed_paths);
-            path_vecs->push_back(parsed_paths);
+            path_vecs->emplace_back(std::move(parsed_paths));
         }
         return Status::OK();
     } catch (simdjson::simdjson_error& e) {

--- a/be/src/exec/vectorized/json_scanner.h
+++ b/be/src/exec/vectorized/json_scanner.h
@@ -134,7 +134,8 @@ private:
     uint8_t* _data;
     simdjson::ondemand::parser _parser;
 
-    // _first_shot denotes wheather the first element of the document stream would be returned.
+    // _first_shot denotes whether the first element of the document stream would be returned,
+    // telling us whether to forward the stream iterator.
     bool _first_shot = false;
     simdjson::ondemand::document_stream _doc_stream;
     simdjson::ondemand::document_stream::iterator _doc_stream_itr;
@@ -149,7 +150,8 @@ private:
     uint8_t* _data;
     simdjson::ondemand::parser _parser;
 
-    // _first_shot denotes wheather the first element of the array would be returned.
+    // _first_shot denotes whether the first element of the array would be returned.
+    // telling us whether to forward the array iterator.
     bool _first_shot = false;
     simdjson::ondemand::document _doc;
     simdjson::ondemand::array _array;

--- a/be/src/exec/vectorized/json_scanner.h
+++ b/be/src/exec/vectorized/json_scanner.h
@@ -121,8 +121,11 @@ class JsonParser {
 public:
     JsonParser() = default;
     virtual ~JsonParser() = default;
+    // parse initiates the parser. The inner iterator would point to the first object to be returned.
     virtual Status parse(uint8_t* data, size_t len, size_t allocated) = 0;
+    // get returns the object pointed by the inner iterator.
     virtual Status get(simdjson::ondemand::object* row) = 0;
+    // next forwards the inner iterator.
     virtual Status next() = 0;
 };
 

--- a/be/src/exec/vectorized/json_scanner.h
+++ b/be/src/exec/vectorized/json_scanner.h
@@ -127,7 +127,7 @@ public:
 
 class JsonDocumentStreamParser : public JsonParser {
 public:
-    Status parse(uint8_t* data, size_t len,size_t allocated) override;
+    Status parse(uint8_t* data, size_t len, size_t allocated) override;
     Status get_next(simdjson::ondemand::object* row) override;
 
 private:

--- a/be/src/exec/vectorized/json_scanner.h
+++ b/be/src/exec/vectorized/json_scanner.h
@@ -76,6 +76,10 @@ public:
     Status close();
 
 private:
+    Status _read_chunk_from_document_stream(Chunk* chunk, int32_t rows_to_read,
+                                            const std::vector<SlotDescriptor*>& slot_descs);
+    Status _read_chunk_from_array(Chunk* chunk, int32_t rows_to_read, const std::vector<SlotDescriptor*>& slot_descs);
+
     Status _read_and_parse_json();
 
     Status _construct_row(simdjson::ondemand::object* row, Chunk* chunk,
@@ -124,16 +128,16 @@ public:
     // parse initiates the parser. The inner iterator would point to the first object to be returned.
     virtual Status parse(uint8_t* data, size_t len, size_t allocated) = 0;
     // get returns the object pointed by the inner iterator.
-    virtual Status get(simdjson::ondemand::object* row) = 0;
+    virtual Status get_current(simdjson::ondemand::object* row) = 0;
     // next forwards the inner iterator.
-    virtual Status next() = 0;
+    virtual Status advance() = 0;
 };
 
 class JsonDocumentStreamParser : public JsonParser {
 public:
     Status parse(uint8_t* data, size_t len, size_t allocated) override;
-    Status get(simdjson::ondemand::object* row) override;
-    Status next() override;
+    Status get_current(simdjson::ondemand::object* row) override;
+    Status advance() override;
 
 private:
     uint8_t* _data;
@@ -146,8 +150,8 @@ private:
 class JsonArrayParser : public JsonParser {
 public:
     Status parse(uint8_t* data, size_t len, size_t allocated) override;
-    Status get(simdjson::ondemand::object* row) override;
-    Status next() override;
+    Status get_current(simdjson::ondemand::object* row) override;
+    Status advance() override;
 
 private:
     uint8_t* _data;

--- a/be/src/exec/vectorized/json_scanner.h
+++ b/be/src/exec/vectorized/json_scanner.h
@@ -122,21 +122,20 @@ public:
     JsonParser() = default;
     virtual ~JsonParser() = default;
     virtual Status parse(uint8_t* data, size_t len, size_t allocated) = 0;
-    virtual Status get_next(simdjson::ondemand::object* row) = 0;
+    virtual Status get(simdjson::ondemand::object* row) = 0;
+    virtual Status next() = 0;
 };
 
 class JsonDocumentStreamParser : public JsonParser {
 public:
     Status parse(uint8_t* data, size_t len, size_t allocated) override;
-    Status get_next(simdjson::ondemand::object* row) override;
+    Status get(simdjson::ondemand::object* row) override;
+    Status next() override;
 
 private:
     uint8_t* _data;
     simdjson::ondemand::parser _parser;
 
-    // _first_shot denotes whether the first element of the document stream would be returned,
-    // telling us whether to forward the stream iterator.
-    bool _first_shot = false;
     simdjson::ondemand::document_stream _doc_stream;
     simdjson::ondemand::document_stream::iterator _doc_stream_itr;
 };
@@ -144,15 +143,13 @@ private:
 class JsonArrayParser : public JsonParser {
 public:
     Status parse(uint8_t* data, size_t len, size_t allocated) override;
-    Status get_next(simdjson::ondemand::object* row) override;
+    Status get(simdjson::ondemand::object* row) override;
+    Status next() override;
 
 private:
     uint8_t* _data;
     simdjson::ondemand::parser _parser;
 
-    // _first_shot denotes whether the first element of the array would be returned.
-    // telling us whether to forward the array iterator.
-    bool _first_shot = false;
     simdjson::ondemand::document _doc;
     simdjson::ondemand::array _array;
     simdjson::ondemand::array_iterator _array_itr;

--- a/be/src/exec/vectorized/json_scanner.h
+++ b/be/src/exec/vectorized/json_scanner.h
@@ -17,6 +17,7 @@ namespace starrocks::vectorized {
 
 struct JsonPath;
 class JsonReader;
+class JsonParser;
 class JsonScanner : public FileScanner {
 public:
     JsonScanner(RuntimeState* state, RuntimeProfile* profile, const TBrokerScanRange& scan_range,
@@ -77,16 +78,6 @@ public:
 private:
     Status _read_and_parse_json();
 
-    // _next_row forwards iterator, returns false when EOF is got.
-    Status _next_row();
-
-    // get_row returns row pointed by iterator.
-    Status _get_row(simdjson::ondemand::object* row, bool* empty);
-
-    Status _get_row_from_array(simdjson::ondemand::object* row);
-
-    Status _get_row_from_document_stream(simdjson::ondemand::object* row, bool* empty);
-
     Status _construct_row(simdjson::ondemand::object* row, Chunk* chunk,
                           const std::vector<SlotDescriptor*>& slot_descs);
 
@@ -115,16 +106,8 @@ private:
 
     std::unique_ptr<uint8_t[]> _json_binary_ptr;
 
-    simdjson::ondemand::parser _parser;
-
-    bool _stream_is_empty = true;
-    simdjson::ondemand::document_stream _doc_stream;
-    simdjson::ondemand::document_stream::iterator _doc_stream_itr;
-
-    bool _array_is_empty = true;
-    simdjson::ondemand::array_iterator _array_begin;
-    simdjson::ondemand::array_iterator _array_end;
-
+    std::unique_ptr<JsonParser> _parser;
+    bool _empty_parser = true;
     // only used in unit test.
     // TODO: The semantics of Streaming Load And Routine Load is non-consistent.
     //       Import a json library supporting streaming parse.
@@ -132,6 +115,45 @@ private:
     size_t _buf_size = 1048576; // 1MB, the buf size for parsing json in unit test
     raw::RawVector<char> _buf;
 #endif
+};
+
+class JsonParser {
+public:
+    JsonParser() = default;
+    virtual ~JsonParser() = default;
+    virtual Status parse(uint8_t* data, size_t len, size_t allocated) = 0;
+    virtual Status get_next(simdjson::ondemand::object* row) = 0;
+};
+
+class JsonDocumentStreamParser : public JsonParser {
+public:
+    Status parse(uint8_t* data, size_t len,size_t allocated) override;
+    Status get_next(simdjson::ondemand::object* row) override;
+
+private:
+    uint8_t* _data;
+    simdjson::ondemand::parser _parser;
+
+    // _first_shot denotes wheather the first element of the document stream would be returned.
+    bool _first_shot = false;
+    simdjson::ondemand::document_stream _doc_stream;
+    simdjson::ondemand::document_stream::iterator _doc_stream_itr;
+};
+
+class JsonArrayParser : public JsonParser {
+public:
+    Status parse(uint8_t* data, size_t len, size_t allocated) override;
+    Status get_next(simdjson::ondemand::object* row) override;
+
+private:
+    uint8_t* _data;
+    simdjson::ondemand::parser _parser;
+
+    // _first_shot denotes wheather the first element of the array would be returned.
+    bool _first_shot = false;
+    simdjson::ondemand::document _doc;
+    simdjson::ondemand::array _array;
+    simdjson::ondemand::array_iterator _array_itr;
 };
 
 } // namespace starrocks::vectorized

--- a/be/src/runtime/stream_load/stream_load_pipe.h
+++ b/be/src/runtime/stream_load/stream_load_pipe.h
@@ -85,7 +85,7 @@ public:
     // If _total_length == -1, this should be a Kafka routine load task,
     // just get the next buffer directly from the buffer queue, because one buffer contains a complete piece of data.
     // Otherwise, this should be a stream load task that needs to read the specified amount of data.
-    Status read_one_message(std::unique_ptr<uint8_t[]>* data, size_t* length) override {
+    Status read_one_message(std::unique_ptr<uint8_t[]>* data, size_t* length, size_t padding) override {
         if (_total_length < -1) {
             std::stringstream ss;
             ss << "invalid, _total_length is: " << _total_length;
@@ -101,7 +101,7 @@ public:
         }
 
         // _total_length > 0, read the entire data
-        data->reset(new uint8_t[_total_length]);
+        data->reset(new uint8_t[_total_length + padding]);
         *length = _total_length;
         bool eof = false;
         Status st = read(data->get(), length, &eof);


### PR DESCRIPTION
This PR is to reduce the memory consumption in json stream load, includes following modifications:
1. using `simdjson::ondemand::parser::iterate` to parse json array
2. using `simdjson::ondemand::parser::iterate_many` to parse ndjson
3. eliminating the pre-allocated buffer for `iterate_many`

With this optimization, in my test case of routine load with 400 concurrencies, the  `Virtual Memory Size` would be reduced from 150GB to 8GB