### PR TITLE
Fix the bug of destroy slots after alloc mem failed

### DIFF
--- a/be/src/util/phmap/phmap.h
+++ b/be/src/util/phmap/phmap.h
@@ -1811,8 +1811,10 @@ private:
         auto layout = MakeLayout(capacity_);
         // Unpoison before returning the memory to the allocator.
         SanitizerUnpoisonMemoryRegion(slots_, sizeof(slot_type) * capacity_);
-        Deallocate<Layout::Alignment()>(&alloc_ref(), ctrl_, layout.AllocSize());
-        ctrl_ = EmptyGroup();
+        if (ctrl_ != EmptyGroup()) {
+            Deallocate<Layout::Alignment()>(&alloc_ref(), ctrl_, layout.AllocSize());
+            ctrl_ = EmptyGroup();
+        }
         slots_ = nullptr;
         size_ = 0;
         capacity_ = 0;


### PR DESCRIPTION

When phmap is initialized, it will point ctrl_ to a static memory area. When resize, the capacity is set first, and then the memory is applied. If the memory application fails, the capacity is not 0 during the destructuring, and will free memory In fact, the memory application is not successful. Cause crash