### PR TITLE
Replace FlatHashMap with phmap

### DIFF
--- a/be/src/column/chunk.h
+++ b/be/src/column/chunk.h
@@ -6,8 +6,10 @@
 
 #include "butil/containers/flat_map.h"
 #include "column/column.h"
+#include "column/column_hash.h"
 #include "column/schema.h"
 #include "common/global_types.h"
+#include "util/phmap/phmap.h"
 
 namespace starrocks {
 class ChunkPB;
@@ -18,12 +20,14 @@ class DatumTuple;
 class Chunk {
 public:
     using ChunkPtr = std::shared_ptr<Chunk>;
+    using SlotHashMap = phmap::flat_hash_map<SlotId, size_t, StdHash<SlotId>>;
+    using CidHashMap = phmap::flat_hash_map<ColumnId, size_t, StdHash<SlotId>>;
+    using TupleHashMap = phmap::flat_hash_map<TupleId, size_t, StdHash<TupleId>>;
 
     Chunk();
     Chunk(Columns columns, SchemaPtr schema);
-    Chunk(Columns columns, const butil::FlatMap<SlotId, size_t>& slot_map);
-    Chunk(Columns columns, const butil::FlatMap<SlotId, size_t>& slot_map,
-          const butil::FlatMap<TupleId, size_t>& tuple_map);
+    Chunk(Columns columns, const SlotHashMap& slot_map);
+    Chunk(Columns columns, const SlotHashMap& slot_map, const TupleHashMap& tuple_map);
 
     Chunk(Chunk&& other) = default;
     Chunk& operator=(Chunk&& other) = default;
@@ -97,8 +101,8 @@ public:
     ColumnPtr& get_column_by_slot_id(SlotId slot_id);
 
     void set_slot_id_to_index(SlotId slot_id, size_t idx) { _slot_id_to_index[slot_id] = idx; }
-    bool is_slot_exist(SlotId id) const { return _slot_id_to_index.seek(id) != nullptr; }
-    bool is_tuple_exist(TupleId id) const { return _tuple_id_to_index.seek(id) != nullptr; }
+    bool is_slot_exist(SlotId id) const { return _slot_id_to_index.contains(id); }
+    bool is_tuple_exist(TupleId id) const { return _tuple_id_to_index.contains(id); }
     void reset_slot_id_to_index() { _slot_id_to_index.clear(); }
 
     void set_columns(const Columns& columns) { _columns = columns; }
@@ -182,8 +186,8 @@ public:
 
     DelCondSatisfied delete_state() const { return _delete_state; }
 
-    const butil::FlatMap<TupleId, size_t>& get_tuple_id_to_index_map() const { return _tuple_id_to_index; }
-    const butil::FlatMap<SlotId, size_t>& get_slot_id_to_index_map() const { return _slot_id_to_index; }
+    const TupleHashMap& get_tuple_id_to_index_map() const { return _tuple_id_to_index; }
+    const SlotHashMap& get_slot_id_to_index_map() const { return _slot_id_to_index; }
 
     // Call `Column::reserve` on each column of |chunk|, with |cap| passed as argument.
     void reserve(size_t cap);
@@ -248,10 +252,10 @@ private:
 
     Columns _columns;
     std::shared_ptr<Schema> _schema;
-    butil::FlatMap<ColumnId, size_t> _cid_to_index;
+    CidHashMap _cid_to_index;
     // For compatibility
-    butil::FlatMap<SlotId, size_t> _slot_id_to_index;
-    butil::FlatMap<TupleId, size_t> _tuple_id_to_index;
+    SlotHashMap _slot_id_to_index;
+    TupleHashMap _tuple_id_to_index;
     DelCondSatisfied _delete_state = DEL_NOT_SATISFIED;
 };
 
@@ -289,7 +293,7 @@ inline const ColumnPtr& Chunk::get_column_by_id(ColumnId cid) const {
 
 inline ColumnPtr& Chunk::get_column_by_id(ColumnId cid) {
     DCHECK(!_cid_to_index.empty());
-    DCHECK(_cid_to_index.seek(cid) != nullptr);
+    DCHECK(_cid_to_index.contains(cid));
     return _columns[_cid_to_index[cid]];
 }
 
@@ -307,8 +311,8 @@ struct RuntimeChunkMeta {
     std::vector<TypeDescriptor> types;
     std::vector<bool> is_nulls;
     std::vector<bool> is_consts;
-    butil::FlatMap<SlotId, size_t> slot_id_to_index;
-    butil::FlatMap<TupleId, size_t> tuple_id_to_index;
+    Chunk::SlotHashMap slot_id_to_index;
+    Chunk::TupleHashMap tuple_id_to_index;
 };
 
 } // namespace vectorized

--- a/be/src/column/chunk.h
+++ b/be/src/column/chunk.h
@@ -21,7 +21,7 @@ class Chunk {
 public:
     using ChunkPtr = std::shared_ptr<Chunk>;
     using SlotHashMap = phmap::flat_hash_map<SlotId, size_t, StdHash<SlotId>>;
-    using CidHashMap = phmap::flat_hash_map<ColumnId, size_t, StdHash<SlotId>>;
+    using ColumnIdHashMap = phmap::flat_hash_map<ColumnId, size_t, StdHash<SlotId>>;
     using TupleHashMap = phmap::flat_hash_map<TupleId, size_t, StdHash<TupleId>>;
 
     Chunk();
@@ -252,7 +252,7 @@ private:
 
     Columns _columns;
     std::shared_ptr<Schema> _schema;
-    CidHashMap _cid_to_index;
+    ColumnIdHashMap _cid_to_index;
     // For compatibility
     SlotHashMap _slot_id_to_index;
     TupleHashMap _tuple_id_to_index;

--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -213,13 +213,17 @@ void OlapScanNode::_scanner_thread(TabletScanner* scanner) {
         tls_thread_status.set_mem_tracker(prev_tracker);
         _running_threads.fetch_sub(1, std::memory_order_release);
     });
-
     tls_thread_status.set_query_id(scanner->runtime_state()->query_id());
 
     Status status = scanner->open(_runtime_state);
     if (!status.ok()) {
         QUERY_LOG_IF(ERROR, !status.is_end_of_file()) << status;
         _update_status(status);
+    } else {
+        status = scanner->runtime_state()->check_mem_limit("olap scanner");
+        if (!status.ok()) {
+            _update_status(status);
+        }
     }
     scanner->set_keep_priority(false);
     // Because we use thread pool to scan data from storage. One scanner can't

--- a/be/src/exec/vectorized/tablet_scanner.cpp
+++ b/be/src/exec/vectorized/tablet_scanner.cpp
@@ -79,6 +79,8 @@ Status TabletScanner::open([[maybe_unused]] RuntimeState* runtime_state) {
                                            _tablet->full_name(), st.to_string());
             st = Status::InternalError(msg);
             LOG(WARNING) << st;
+        } else {
+            RETURN_IF_ERROR(runtime_state->check_mem_limit("olap scanner open"));
         }
         return st;
     }

--- a/be/src/runtime/data_stream_recvr.cc
+++ b/be/src/runtime/data_stream_recvr.cc
@@ -259,14 +259,14 @@ Status DataStreamRecvr::SenderQueue::_build_chunk_meta(const ChunkPB& pb_chunk) 
         return Status::InternalError("pb_chunk meta could not be empty");
     }
 
-    _chunk_meta.slot_id_to_index.init(pb_chunk.slot_id_map().size());
+    _chunk_meta.slot_id_to_index.reserve(pb_chunk.slot_id_map().size());
     for (int i = 0; i < pb_chunk.slot_id_map().size(); i += 2) {
-        _chunk_meta.slot_id_to_index.insert(pb_chunk.slot_id_map()[i], pb_chunk.slot_id_map()[i + 1]);
+        _chunk_meta.slot_id_to_index[pb_chunk.slot_id_map()[i]] = pb_chunk.slot_id_map()[i + 1];
     }
 
-    _chunk_meta.tuple_id_to_index.init(pb_chunk.tuple_id_map().size());
+    _chunk_meta.tuple_id_to_index.reserve(pb_chunk.tuple_id_map().size());
     for (int i = 0; i < pb_chunk.tuple_id_map().size(); i += 2) {
-        _chunk_meta.tuple_id_to_index.insert(pb_chunk.tuple_id_map()[i], pb_chunk.tuple_id_map()[i + 1]);
+        _chunk_meta.tuple_id_to_index[pb_chunk.tuple_id_map()[i]] = pb_chunk.tuple_id_map()[i + 1];
     }
 
     _chunk_meta.is_nulls.resize(pb_chunk.is_nulls().size());

--- a/be/src/runtime/tablets_channel.cpp
+++ b/be/src/runtime/tablets_channel.cpp
@@ -160,9 +160,9 @@ Status TabletsChannel::_build_chunk_meta(const ChunkPB& pb_chunk) {
         return Status::InternalError("pb_chunk meta could not be empty");
     }
 
-    _chunk_meta.slot_id_to_index.init(pb_chunk.slot_id_map().size());
+    _chunk_meta.slot_id_to_index.reserve(pb_chunk.slot_id_map().size());
     for (int i = 0; i < pb_chunk.slot_id_map().size(); i += 2) {
-        _chunk_meta.slot_id_to_index.insert(pb_chunk.slot_id_map()[i], pb_chunk.slot_id_map()[i + 1]);
+        _chunk_meta.slot_id_to_index[pb_chunk.slot_id_map()[i]] = pb_chunk.slot_id_map()[i + 1];
     }
 
     _chunk_meta.is_nulls.resize(pb_chunk.is_nulls().size());

--- a/be/test/column/chunk_test.cpp
+++ b/be/test/column/chunk_test.cpp
@@ -152,9 +152,9 @@ TEST_F(ChunkTest, test_serde) {
     size_t written_size = chunk->serialize((uint8_t*)buffer.data());
 
     RuntimeChunkMeta meta;
-    meta.slot_id_to_index.init(2);
-    meta.slot_id_to_index.insert(0, 0);
-    meta.slot_id_to_index.insert(1, 1);
+    meta.slot_id_to_index.reserve(2);
+    meta.slot_id_to_index[0] = 0;
+    meta.slot_id_to_index[1] = 1;
     meta.is_nulls.resize(2, false);
     meta.is_consts.resize(2, false);
     meta.types.resize(2);
@@ -222,7 +222,7 @@ TEST_F(ChunkTest, test_reset) {
     chk->reset();
     ASSERT_EQ(1, chk->num_columns());
     ASSERT_EQ(1, chk->get_slot_id_to_index_map().size());
-    ASSERT_EQ(0, *(chk->get_slot_id_to_index_map().seek(1)));
+    ASSERT_EQ(0, chk->get_slot_id_to_index_map().find(1)->second);
     ASSERT_EQ(0, chk->num_rows());
     ASSERT_EQ(DEL_NOT_SATISFIED, chk->delete_state());
 }

--- a/be/test/exec/vectorized/chunks_sorter_test.cpp
+++ b/be/test/exec/vectorized/chunks_sorter_test.cpp
@@ -104,8 +104,8 @@ public:
         Columns columns2 = {col_cust_key_2, col_nation_2, col_region_2, col_mkt_sgmt_2};
         Columns columns3 = {col_cust_key_3, col_nation_3, col_region_3, col_mkt_sgmt_3};
 
-        butil::FlatMap<SlotId, size_t> map;
-        map.init(columns1.size() * 2);
+        Chunk::SlotHashMap map;
+        map.reserve(columns1.size() * 2);
         for (int i = 0; i < columns1.size(); ++i) {
             map[i] = i;
         }

--- a/be/test/runtime/vectorized/sorted_chunks_merger_test.cpp
+++ b/be/test/runtime/vectorized/sorted_chunks_merger_test.cpp
@@ -79,8 +79,8 @@ public:
         Columns columns_2 = {col_cust_key_2, col_nation_2, col_region_2};
         Columns columns_3 = {col_cust_key_3, col_nation_3, col_region_3};
 
-        butil::FlatMap<SlotId, size_t> map;
-        map.init(columns_1.size() * 2);
+        Chunk::SlotHashMap map;
+        map.reserve(columns_1.size() * 2);
         for (int i = 0; i < columns_1.size(); ++i) {
             map[i] = i;
         }


### PR DESCRIPTION
butil::flat_hash_map will crash when alloc memory failed, 
The performance of phmap is similar to that of butil::flat_hash_map,
so replace butil::flat_hash_map with phmap

other: add memory check at scanner start and  tablet reader open

benchmark
```
BM_flat_map_write/10/10000000 2498093767 ns   2497836466 ns            1
BM_ph_map_write/10/10000000   2291367791 ns   2291133849 ns            1
BM_std_map_write/10/10000000  4659501572 ns   4659049334 ns            1
BM_flat_map_read/10/10000000   109282751 ns    109269147 ns            5
BM_ph_map_read/10/10000000     107042127 ns    107030743 ns            7
BM_std_map_read/10/10000000    189086153 ns    189068631 ns            4
BM_flat_map_write/20/5000000  2550580682 ns   2550326159 ns            1
BM_ph_map_write/20/5000000    2272034233 ns   2271808873 ns            1
BM_std_map_write/20/5000000   4628640040 ns   4628181049 ns            1
BM_flat_map_read/20/5000000     54620627 ns     54615556 ns           13
BM_ph_map_read/20/5000000       53531170 ns     53526210 ns           13
BM_std_map_read/20/5000000      94520854 ns     94512069 ns            7
BM_flat_map_write/50/2000000  2438117047 ns   2437852993 ns            1
BM_ph_map_write/50/2000000    2263344970 ns   2263118343 ns            1
BM_std_map_write/50/2000000   4698198146 ns   4697736135 ns            1
BM_flat_map_read/50/2000000     21963232 ns     21961071 ns           32
BM_ph_map_read/50/2000000       21877043 ns     21874701 ns           32
BM_std_map_read/50/2000000      37850863 ns     37847164 ns           18
BM_flat_map_write/100/1000000 2400771995 ns   2400534471 ns            1
BM_ph_map_write/100/1000000   2274662196 ns   2274437041 ns            1
BM_std_map_write/100/1000000  4670092308 ns   4669458416 ns            1
BM_flat_map_read/100/1000000    10999981 ns     10998777 ns           64
BM_ph_map_read/100/1000000      10876766 ns     10875760 ns           64
BM_std_map_read/100/1000000     18929481 ns     18927416 ns           37
BM_flat_map_read/500/1000000    11033794 ns     11032721 ns           64
BM_ph_map_read/500/1000000      10903268 ns     10902257 ns           64
BM_std_map_read/500/1000000     18983870 ns     18982109 ns           37
```