### PR TITLE
[pipeline] avoid local shuffle for scan followed by aggregate

### DIFF
--- a/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
@@ -172,7 +172,7 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > AggregateBlockingNode::
             // The san operator followed by an aggregate operator indicates the aggregating key is the same as
             // the bucket key of this table, so we needn't local shuffle for this case.
             auto* source_op = operators_with_sink[0].get();
-            if (operators_with_sink.size() > 1 || typeid(*source_op) != typeid(pipeline::ScanOperatorFactory)) {
+            if (typeid(*source_op) != typeid(pipeline::ScanOperatorFactory)) {
                 std::vector<ExprContext*> group_by_expr_ctxs;
                 Expr::create_expr_trees(_pool, _tnode.agg_node.grouping_exprs, &group_by_expr_ctxs);
                 operators_with_sink =

--- a/be/src/exec/vectorized/aggregate/distinct_blocking_node.cpp
+++ b/be/src/exec/vectorized/aggregate/distinct_blocking_node.cpp
@@ -152,7 +152,7 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > DistinctBlockingNode::d
     // The san operator followed by an aggregate operator indicates the aggregating key is the same as
     // the bucket key of this table, so we needn't local shuffle for this case.
     auto* source_op = operators_with_sink[0].get();
-    if (operators_with_sink.size() > 1 || typeid(*source_op) != typeid(pipeline::ScanOperatorFactory)) {
+    if (typeid(*source_op) != typeid(pipeline::ScanOperatorFactory)) {
         operators_with_sink =
                 context->maybe_interpolate_local_shuffle_exchange(operators_with_sink, partition_expr_ctxs);
     }

--- a/be/src/exec/vectorized/aggregate/distinct_blocking_node.cpp
+++ b/be/src/exec/vectorized/aggregate/distinct_blocking_node.cpp
@@ -6,6 +6,7 @@
 #include "exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.h"
 #include "exec/pipeline/operator.h"
 #include "exec/pipeline/pipeline_builder.h"
+#include "exec/pipeline/scan_operator.h"
 #include "exec/vectorized/aggregator.h"
 #include "runtime/current_thread.h"
 
@@ -148,7 +149,14 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > DistinctBlockingNode::d
     // Initialize OperatorFactory's fields involving runtime filters.
     this->init_runtime_filter_for_operator(source_operator.get(), context, rc_rf_probe_collector);
 
-    operators_with_sink = context->maybe_interpolate_local_shuffle_exchange(operators_with_sink, partition_expr_ctxs);
+    // The san operator followed by an aggregate operator indicates the aggregating key is the same as
+    // the bucket key of this table, so we needn't local shuffle for this case.
+    auto* source_op = operators_with_sink[0].get();
+    if (operators_with_sink.size() > 1 || typeid(*source_op) != typeid(pipeline::ScanOperatorFactory)) {
+        operators_with_sink =
+                context->maybe_interpolate_local_shuffle_exchange(operators_with_sink, partition_expr_ctxs);
+    }
+
     operators_with_sink.push_back(std::move(sink_operator));
     context->add_pipeline(operators_with_sink);
     // Aggregator must be used by a pair of sink and source operators,


### PR DESCRIPTION
### Introduction
The san operator followed by an aggregate operator indicates the aggregating key is the same as the bucket key of this table, so we needn't local shuffle for this case.

After this optimization, in 3 BEs and DOP=8, `sum_sql` costs from 0.65s to 0.30s, and `distinct_sql` costs from 0.61s to 0.27s.
```sql
-- ssb_100g

-- sum_sql
SELECT SUM(lo_ordtotalprice), lo_orderkey FROM lineorder group by lo_orderkey limit 1;

-- distinct_sql
SELECT COUNT (DISTINCT lo_partkey), lo_orderkey FROM lineorder group by lo_orderkey limit 100;
```