### PR TITLE
[pipeline] try to parallelize the scan operator if dop is one

### DIFF
--- a/be/src/exec/pipeline/scan_operator.h
+++ b/be/src/exec/pipeline/scan_operator.h
@@ -42,6 +42,10 @@ public:
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
     void set_io_threads(PriorityThreadPool* io_threads) { _io_threads = io_threads; }
 
+    // If DOP is 1 and the number of morsels is >= 4
+    // make the DOP of the scan operator as 4 and insert a local passthrough after it.
+    static constexpr int PARALLELIZED_MORSELS_THRESHOLD = 4;
+
 private:
     // This method is only invoked when current morsel is reached eof
     // and all cached chunk of this morsel has benn read out

--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -560,8 +560,9 @@ pipeline::OpFactories OlapScanNode::decompose_to_pipeline(pipeline::PipelineBuil
 
     // If dop is one, we use num_fragment_instance > 1 to parallelize the query execution.
     // The scan may be still a bottleneck in this case, so we try to parallelize the scan operator.
-    if (context->degree_of_parallelism() == 1 && morsel_queue->num_morsels() >= 4) {
-        scan_operator->set_degree_of_parallelism(4);
+    if (context->degree_of_parallelism() == 1 &&
+        morsel_queue->num_morsels() >= pipeline::ScanOperator::PARALLELIZED_MORSELS_THRESHOLD) {
+        scan_operator->set_degree_of_parallelism(pipeline::ScanOperator::PARALLELIZED_MORSELS_THRESHOLD);
 
         operators.emplace_back(std::move(scan_operator));
         operators = context->maybe_interpolate_local_passthrough_exchange(operators);

--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -557,12 +557,24 @@ pipeline::OpFactories OlapScanNode::decompose_to_pipeline(pipeline::PipelineBuil
     auto source_id = scan_operator->plan_node_id();
     DCHECK(morsel_queues.count(source_id));
     auto& morsel_queue = morsel_queues[source_id];
-    // ScanOperator's degree_of_parallelism is not more than the number of morsels
-    // If table is empty, then morsel size is zero and we still set degree of parallelism to 1
-    const auto degree_of_parallelism =
-            std::min<size_t>(std::max<size_t>(1, morsel_queue->num_morsels()), context->degree_of_parallelism());
-    scan_operator->set_degree_of_parallelism(degree_of_parallelism);
-    operators.emplace_back(std::move(scan_operator));
+
+    // If dop is one, we use num_fragment_instance > 1 to parallelize the query execution.
+    // The scan may be still a bottleneck in this case, so we try to parallelize the scan operator.
+    if (context->degree_of_parallelism() == 1 && morsel_queue->num_morsels() >= 4) {
+        scan_operator->set_degree_of_parallelism(4);
+
+        operators.emplace_back(std::move(scan_operator));
+        operators = context->maybe_interpolate_local_passthrough_exchange(operators);
+    } else {
+        // ScanOperator's degree_of_parallelism is not more than the number of morsels
+        // If table is empty, then morsel size is zero and we still set degree of parallelism to 1
+        const auto degree_of_parallelism =
+                std::min<size_t>(std::max<size_t>(1, morsel_queue->num_morsels()), context->degree_of_parallelism());
+        scan_operator->set_degree_of_parallelism(degree_of_parallelism);
+
+        operators.emplace_back(std::move(scan_operator));
+    }
+
     if (limit() != -1) {
         operators.emplace_back(std::make_shared<LimitOperatorFactory>(context->next_operator_id(), id(), limit()));
     }


### PR DESCRIPTION
If `DOP` is one, we use `num_fragment_instance > 1` to parallelize the query execution. The scan may be still a bottleneck in this case, so we try to parallelize the scan operator.

After this optimization, the following query costs from 0.77s to 0.55s, where `num_fragment_instance=8` and `dop=1` in 3 BEs.
```sql
select max(length(s_address)) from lineorder_flat where pow(lo_orderkey,1) >= 595000000;
```