### PR TITLE
free mem in close

### DIFF
--- a/be/src/exec/vectorized/aggregate/aggregate_base_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_base_node.cpp
@@ -32,7 +32,8 @@ Status AggregateBaseNode::close(RuntimeState* state) {
         return Status::OK();
     }
     if (_aggregator != nullptr) {
-        RETURN_IF_ERROR(_aggregator->close(state));
+        _aggregator->close(state);
+        _aggregator.reset();
     }
     return ExecNode::close(state);
 }

--- a/be/src/exec/vectorized/analytic_node.cpp
+++ b/be/src/exec/vectorized/analytic_node.cpp
@@ -108,6 +108,7 @@ Status AnalyticNode::close(RuntimeState* state) {
 
     if (_analytor != nullptr) {
         _analytor->close(state);
+        _analytor.reset();
     }
 
     return ExecNode::close(state);

--- a/be/src/exec/vectorized/cross_join_node.cpp
+++ b/be/src/exec/vectorized/cross_join_node.cpp
@@ -427,6 +427,13 @@ Status CrossJoinNode::close(RuntimeState* state) {
         return Status::OK();
     }
 
+    if (_build_chunk != nullptr) {
+        _build_chunk->reset();
+    }
+    if (_probe_chunk != nullptr) {
+        _probe_chunk->reset();
+    }
+
     child(0)->close(state);
     return ExecNode::close(state);
 }

--- a/be/src/exec/vectorized/except_node.cpp
+++ b/be/src/exec/vectorized/except_node.cpp
@@ -207,6 +207,8 @@ Status ExceptNode::close(RuntimeState* state) {
         _build_pool->free_all();
     }
 
+    _hash_set.reset();
+
     return ExecNode::close(state);
 }
 

--- a/be/src/exec/vectorized/except_node.cpp
+++ b/be/src/exec/vectorized/except_node.cpp
@@ -207,7 +207,9 @@ Status ExceptNode::close(RuntimeState* state) {
         _build_pool->free_all();
     }
 
-    _hash_set.reset();
+    if (_hash_set != nullptr) {
+        _hash_set.reset();
+    }
 
     return ExecNode::close(state);
 }

--- a/be/src/exec/vectorized/intersect_node.cpp
+++ b/be/src/exec/vectorized/intersect_node.cpp
@@ -217,6 +217,7 @@ Status IntersectNode::close(RuntimeState* state) {
     if (_build_pool != nullptr) {
         _build_pool->free_all();
     }
+    _hash_set.reset();
 
     return ExecNode::close(state);
 }

--- a/be/src/exec/vectorized/intersect_node.cpp
+++ b/be/src/exec/vectorized/intersect_node.cpp
@@ -217,7 +217,10 @@ Status IntersectNode::close(RuntimeState* state) {
     if (_build_pool != nullptr) {
         _build_pool->free_all();
     }
-    _hash_set.reset();
+
+    if (_hash_set != nullptr) {
+        _hash_set.reset();
+    }
 
     return ExecNode::close(state);
 }

--- a/be/src/exec/vectorized/join_hash_map.h
+++ b/be/src/exec/vectorized/join_hash_map.h
@@ -503,32 +503,32 @@ public:
 
     Status append_chunk(RuntimeState* state, const ChunkPtr& chunk);
 
-    const ChunkPtr& get_build_chunk() const { return _table_items.build_chunk; }
-    Columns& get_key_columns() { return _table_items.key_columns; }
-    uint32_t get_row_count() const { return _table_items.row_count; }
-    size_t get_probe_column_count() const { return _table_items.probe_column_count; }
-    size_t get_build_column_count() const { return _table_items.build_column_count; }
-    size_t get_bucket_size() const { return _table_items.bucket_size; }
+    const ChunkPtr& get_build_chunk() const { return _table_items->build_chunk; }
+    Columns& get_key_columns() { return _table_items->key_columns; }
+    uint32_t get_row_count() const { return _table_items->row_count; }
+    size_t get_probe_column_count() const { return _table_items->probe_column_count; }
+    size_t get_build_column_count() const { return _table_items->build_column_count; }
+    size_t get_bucket_size() const { return _table_items->bucket_size; }
 
     void remove_duplicate_index(Column::Filter* filter);
 
     int64_t mem_usage() {
         int64_t usage = 0;
-        if (_table_items.build_chunk != nullptr) {
-            usage += _table_items.build_chunk->memory_usage();
+        if (_table_items->build_chunk != nullptr) {
+            usage += _table_items->build_chunk->memory_usage();
         }
-        usage += _table_items.first.capacity() * sizeof(uint32_t);
-        usage += _table_items.next.capacity() * sizeof(uint32_t);
-        if (_table_items.build_pool != nullptr) {
-            usage += _table_items.build_pool->total_reserved_bytes();
+        usage += _table_items->first.capacity() * sizeof(uint32_t);
+        usage += _table_items->next.capacity() * sizeof(uint32_t);
+        if (_table_items->build_pool != nullptr) {
+            usage += _table_items->build_pool->total_reserved_bytes();
         }
-        if (_table_items.probe_pool != nullptr) {
-            usage += _table_items.probe_pool->total_reserved_bytes();
+        if (_table_items->probe_pool != nullptr) {
+            usage += _table_items->probe_pool->total_reserved_bytes();
         }
-        if (_table_items.build_key_column != nullptr) {
-            usage += _table_items.build_key_column->memory_usage();
+        if (_table_items->build_key_column != nullptr) {
+            usage += _table_items->build_key_column->memory_usage();
         }
-        usage += _table_items.build_slice.size() * sizeof(Slice);
+        usage += _table_items->build_slice.size() * sizeof(Slice);
         return usage;
     }
 
@@ -566,8 +566,8 @@ private:
 
     JoinHashMapType _hash_map_type = JoinHashMapType::empty;
 
-    JoinHashTableItems _table_items;
-    HashTableProbeState _probe_state;
+    std::unique_ptr<JoinHashTableItems> _table_items;
+    std::unique_ptr<HashTableProbeState> _probe_state;
 };
 } // namespace starrocks::vectorized
 


### PR DESCRIPTION
When BE fails to execute the fragment, it will call the close() of each Node. After all close() is completed and send_report success, the Fragment destruction will be executed. However, when there are many Scanners, or send_report slowly, OlapScanNode will not complete the close() until the Scanner ends. If the Scanner Closes () It was stuck for some time due to scheduling problems, because many Node's close() did not release the memory, which caused the memory to be released after a period of time after the Fragement was destroyed.