### PR TITLE
Clear expired load labels and delete infos when doing checkpoint

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -2232,7 +2232,7 @@ public class Catalog {
         labelCleaner = new MasterDaemon("LoadLabelCleaner", Config.label_clean_interval_second * 1000L) {
             @Override
             protected void runAfterCatalogReady() {
-                clearExpiredLabel();
+                clearExpiredJobs();
             }
         };
     }
@@ -7484,7 +7484,7 @@ public class Catalog {
         this.imageJournalId = imageJournalId;
     }
 
-    public void clearExpiredLabel() {
+    public void clearExpiredJobs() {
         loadManager.removeOldLoadJob();
         exportMgr.removeOldExportJobs();
         deleteHandler.removeOldDeleteInfo();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -7489,5 +7489,6 @@ public class Catalog {
         exportMgr.removeOldExportJobs();
         deleteHandler.removeOldDeleteInfo();
         globalTransactionMgr.removeExpiredTxns();
+        routineLoadManager.cleanOldRoutineLoadJobs();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -327,7 +327,7 @@ public class Catalog {
     private UpdateDbUsedDataQuotaDaemon updateDbUsedDataQuotaDaemon;
 
     private MasterDaemon labelCleaner; // To clean old LabelInfo, ExportJobInfos
-    private MasterDaemon txnCleaner; // To clean aborted or timeout txns
+    private MasterDaemon txnTimeoutChecker; // To abort timeout txns
     private Daemon replayer;
     private Daemon timePrinter;
     private Daemon listener;
@@ -853,8 +853,8 @@ public class Catalog {
         // 4. create load and export job label cleaner thread
         createLabelCleaner();
 
-        // 5. create txn cleaner thread
-        createTxnCleaner();
+        // 5. create txn timeout checker thread
+        createTxnTimeoutChecker();
 
         // 6. start state listener thread
         createStateListener();
@@ -1308,8 +1308,8 @@ public class Catalog {
         ColocateTableBalancer.getInstance().start();
         // Publish Version Daemon
         publishVersionDaemon.start();
-        // Start txn cleaner
-        txnCleaner.start();
+        // Start txn timeout checker
+        txnTimeoutChecker.start();
         // Alter
         getAlterInstance().start();
         // Consistency checker
@@ -2237,8 +2237,8 @@ public class Catalog {
         };
     }
 
-    public void createTxnCleaner() {
-        txnCleaner = new MasterDaemon("txnTimeoutChecker", Config.transaction_clean_interval_second) {
+    public void createTxnTimeoutChecker() {
+        txnTimeoutChecker = new MasterDaemon("txnTimeoutChecker", Config.transaction_clean_interval_second) {
             @Override
             protected void runAfterCatalogReady() {
                 globalTransactionMgr.abortTimeoutTxns();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -2232,18 +2232,16 @@ public class Catalog {
         labelCleaner = new MasterDaemon("LoadLabelCleaner", Config.label_clean_interval_second * 1000L) {
             @Override
             protected void runAfterCatalogReady() {
-                loadManager.removeOldLoadJob();
-                exportMgr.removeOldExportJobs();
-                deleteHandler.removeOldDeleteInfo();
+                clearExpiredLabel();
             }
         };
     }
 
     public void createTxnCleaner() {
-        txnCleaner = new MasterDaemon("txnCleaner", Config.transaction_clean_interval_second) {
+        txnCleaner = new MasterDaemon("txnTimeoutChecker", Config.transaction_clean_interval_second) {
             @Override
             protected void runAfterCatalogReady() {
-                globalTransactionMgr.removeExpiredAndTimeoutTxns();
+                globalTransactionMgr.abortTimeoutTxns();
             }
         };
     }
@@ -7486,5 +7484,10 @@ public class Catalog {
         this.imageJournalId = imageJournalId;
     }
 
+    public void clearExpiredLabel() {
+        loadManager.removeOldLoadJob();
+        exportMgr.removeOldExportJobs();
+        deleteHandler.removeOldDeleteInfo();
+        globalTransactionMgr.removeExpiredTxns();
+    }
 }
-

--- a/fe/fe-core/src/main/java/com/starrocks/load/DeleteHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/DeleteHandler.java
@@ -795,7 +795,20 @@ public class DeleteHandler implements Writable {
     }
 
     public static DeleteHandler read(DataInput in) throws IOException {
-        String json = Text.readString(in);
+        String json;
+        try {
+            json = Text.readString(in);
+
+            // In older versions of fe, the information in the deleteHandler is not cleaned up,
+            // and if there are many delete statements, it will cause an int overflow
+            // and report an IllegalArgumentException.
+            //
+            // dbToDeleteInfos is only used to record history delete info,
+            // discarding it doesn't make much of a difference
+        } catch (IllegalArgumentException e) {
+            LOG.warn("read delete handler json string failed, ignore", e);
+            return new DeleteHandler();
+        }
         return GsonUtils.GSON.fromJson(json, DeleteHandler.class);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadManager.java
@@ -66,7 +66,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 
 /**
- * The broker and mini load jobs(v2) are included in this class.
+ * The broker and spark load jobs(v2) are included in this class.
  * <p>
  * The lock sequence:
  * Database.lock

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadManager.java
@@ -66,7 +66,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 
 /**
- * The broker and spark load jobs(v2) are included in this class.
+ * The broker and spark load jobs are included in this class.
  * <p>
  * The lock sequence:
  * Database.lock

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadManager.java
@@ -477,9 +477,6 @@ public class RoutineLoadManager implements Writable {
                     unprotectedRemoveJobFromDb(routineLoadJob);
                     iterator.remove();
 
-                    RoutineLoadOperation operation = new RoutineLoadOperation(routineLoadJob.getId(),
-                            routineLoadJob.getState());
-                    Catalog.getCurrentCatalog().getEditLog().logRemoveRoutineLoadJob(operation);
                     LOG.info(new LogBuilder(LogKey.ROUTINE_LOAD_JOB, routineLoadJob.getId())
                             .add("end_timestamp", routineLoadJob.getEndTimestamp())
                             .add("current_timestamp", currentTimestamp)

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadScheduler.java
@@ -124,8 +124,6 @@ public class RoutineLoadScheduler extends MasterDaemon {
 
         // check timeout tasks
         routineLoadManager.processTimeoutTasks();
-
-        routineLoadManager.cleanOldRoutineLoadJobs();
     }
 
     private List<RoutineLoadJob> getNeedScheduleRoutineJobs() throws LoadException {

--- a/fe/fe-core/src/main/java/com/starrocks/master/Checkpoint.java
+++ b/fe/fe-core/src/main/java/com/starrocks/master/Checkpoint.java
@@ -100,7 +100,7 @@ public class Checkpoint extends MasterDaemon {
                 return;
             }
 
-            catalog.clearExpiredLabel();
+            catalog.clearExpiredJobs();
 
             catalog.saveImage();
             replayedJournalId = catalog.getReplayedJournalId();

--- a/fe/fe-core/src/main/java/com/starrocks/master/Checkpoint.java
+++ b/fe/fe-core/src/main/java/com/starrocks/master/Checkpoint.java
@@ -100,6 +100,8 @@ public class Checkpoint extends MasterDaemon {
                 return;
             }
 
+            catalog.clearExpiredLabel();
+
             catalog.saveImage();
             replayedJournalId = catalog.getReplayedJournalId();
             if (MetricRepo.isInit) {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -1420,21 +1420,6 @@ public class DatabaseTransactionMgr {
         return timeoutTxns;
     }
 
-    public void removeExpiredAndTimeoutTxns(long currentMillis) {
-        removeExpiredTxns(currentMillis);
-        List<Long> timeoutTxns = getTimeoutTxns(currentMillis);
-        // abort timeout txns
-        for (Long txnId : timeoutTxns) {
-            try {
-                abortTransaction(txnId, "timeout by txn manager", null);
-                LOG.info("transaction [" + txnId + "] is timeout, abort it by transaction manager");
-            } catch (UserException e) {
-                // abort may be failed. it is acceptable. just print a log
-                LOG.warn("abort timeout txn {} failed. msg: {}", txnId, e.getMessage());
-            }
-        }
-    }
-
     public void abortTimeoutTxns(long currentMillis) {
         List<Long> timeoutTxns = getTimeoutTxns(currentMillis);
         // abort timeout txns

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -462,10 +462,17 @@ public class GlobalTransactionMgr implements Writable {
      * expired: txn is in VISIBLE or ABORTED, and is expired.
      * timeout: txn is in PREPARE, but timeout
      */
-    public void removeExpiredAndTimeoutTxns() {
+    public void abortTimeoutTxns() {
         long currentMillis = System.currentTimeMillis();
         for (DatabaseTransactionMgr dbTransactionMgr : dbIdToDatabaseTransactionMgrs.values()) {
-            dbTransactionMgr.removeExpiredAndTimeoutTxns(currentMillis);
+            dbTransactionMgr.abortTimeoutTxns(currentMillis);
+        }
+    }
+
+    public void removeExpiredTxns() {
+        long currentMillis = System.currentTimeMillis();
+        for (DatabaseTransactionMgr dbTransactionMgr : dbIdToDatabaseTransactionMgrs.values()) {
+            dbTransactionMgr.removeExpiredTxns(currentMillis);
         }
     }
 


### PR DESCRIPTION
1. PR #2337 prevents expired delete infos from entering the image. Once delete information enters the image, FE will never clean it up. We should clear delete infos when doing checkpoint. Spark load jobs, broker load jobs, export jobs also have the same problem.
2. Previously, clearing routine load jobs used a different method. FE will delete the routine load jobs and write a related delete log to BDBJE. The followers synchronize the delete logs and replay these logs. Thousands of routine load jobs will generate many delete logs and cause high overhead. 

Now, the master will clean all load jobs、delete infos and the followers synchronize the checkpoint image.