### PR TITLE
[FIX] By default exchange pass through is disabled

### DIFF
--- a/be/src/storage/vectorized/async_delta_writer.h
+++ b/be/src/storage/vectorized/async_delta_writer.h
@@ -2,7 +2,12 @@
 
 #pragma once
 
+#include "common/compiler_util.h"
+DIAGNOSTIC_PUSH
+DIAGNOSTIC_IGNORE("-Wclass-memaccess")
 #include <bthread/execution_queue.h>
+DIAGNOSTIC_POP
+
 #include <google/protobuf/service.h>
 
 #include "storage/vectorized/delta_writer.h"

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -70,7 +70,7 @@ message PTransmitChunkParams {
 
     // Some statistics for the runing query
     optional PQueryStatistics query_statistics = 8;
-    optional bool use_pass_through = 9 [default = true] ;
+    optional bool use_pass_through = 9 [default = false] ;
 };
 
 message PTransmitDataResult {


### PR DESCRIPTION
If we don't set `use_pass_through`, by default it should be false.