### PR TITLE
Fix CTAS bugs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CTASAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CTASAnalyzer.java
@@ -70,8 +70,10 @@ public class CTASAnalyzer {
                     defaultReplicationNum = replicationNum;
                 }
             }
-            for (String alias : aliases) {
-                tableRefToTable.put(alias, table);
+            if (aliases != null) {
+                for (String alias : aliases) {
+                    tableRefToTable.put(alias, table);
+                }
             }
         }
 
@@ -96,6 +98,8 @@ public class CTASAnalyzer {
             Type type = allFields.get(i).getType();
             if (PrimitiveType.VARCHAR == type.getPrimitiveType()) {
                 type = stringType;
+            } else if (PrimitiveType.DOUBLE == type.getPrimitiveType()) {
+                type = Type.DEFAULT_DECIMAL128;
             }
             ColumnDef columnDef = new ColumnDef(finalColumnNames.get(i), new TypeDef(type), false,
                     null, true, ColumnDef.DefaultValueDef.NOT_SET, "");

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterTest.java
@@ -144,8 +144,7 @@ public class AlterTest {
 
         }
 
-        File file = new File(runningDir);
-        file.delete();
+        UtFrameUtils.cleanStarRocksFeDir(runningDir);
     }
 
     private static void checkTableStateToNormal(OlapTable tb) throws InterruptedException {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CTASAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CTASAnalyzerTest.java
@@ -1,29 +1,18 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
 package com.starrocks.sql.analyzer;
 
-import com.starrocks.analysis.AddPartitionClause;
-import com.starrocks.analysis.AlterTableStmt;
-import com.starrocks.analysis.CreateTableAsSelectStmt;
-import com.starrocks.analysis.CreateTableStmt;
-import com.starrocks.analysis.DropTableStmt;
-import com.starrocks.catalog.Catalog;
-import com.starrocks.catalog.Database;
-import com.starrocks.catalog.OlapTable;
-import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.File;
 import java.util.UUID;
 
-import static com.starrocks.sql.analyzer.AnalyzeTestUtil.analyzeFail;
-import static com.starrocks.sql.analyzer.AnalyzeTestUtil.analyzeSuccessUseInsert;
 
 public class CTASAnalyzerTest {
     // use a unique dir so that it won't be conflict with other unit test which

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CTASAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CTASAnalyzerTest.java
@@ -1,0 +1,71 @@
+package com.starrocks.sql.analyzer;
+
+import com.starrocks.analysis.AddPartitionClause;
+import com.starrocks.analysis.AlterTableStmt;
+import com.starrocks.analysis.CreateTableAsSelectStmt;
+import com.starrocks.analysis.CreateTableStmt;
+import com.starrocks.analysis.DropTableStmt;
+import com.starrocks.catalog.Catalog;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.Config;
+import com.starrocks.common.FeConstants;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.UUID;
+
+import static com.starrocks.sql.analyzer.AnalyzeTestUtil.analyzeFail;
+import static com.starrocks.sql.analyzer.AnalyzeTestUtil.analyzeSuccessUseInsert;
+
+public class CTASAnalyzerTest {
+    // use a unique dir so that it won't be conflict with other unit test which
+    // may also start a Mocked Frontend
+    private static String runningDir = "fe/mocked/AnalyzeInsertTest/" + UUID.randomUUID().toString() + "/";
+    private static ConnectContext connectContext;
+    private static StarRocksAssert starRocksAssert;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        FeConstants.runningUnitTest = true;
+        FeConstants.default_scheduler_interval_millisecond = 100;
+        Config.dynamic_partition_enable = true;
+        Config.dynamic_partition_check_interval_seconds = 1;
+        UtFrameUtils.createMinStarRocksCluster(runningDir);
+
+        // create connect context
+        connectContext = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(connectContext);
+
+        starRocksAssert.withDatabase("ctas").useDatabase("ctas")
+                .withTable("create table test(c1 varchar(10),c2 varchar(10)) DISTRIBUTED BY HASH(c1) " +
+                        "BUCKETS 8 PROPERTIES (\"replication_num\" = \"1\" );")
+                .withTable("create table test3(c1 varchar(10),c2 varchar(10)) DISTRIBUTED BY HASH(c1) " +
+                        "BUCKETS 8 PROPERTIES (\"replication_num\" = \"1\" );");
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        File file = new File(runningDir);
+        file.delete();
+    }
+
+    @Test
+    public void testSimpleCase() throws Exception {
+        ConnectContext ctx = starRocksAssert.getCtx();
+        String CTASSQL1 = "create table test2 as select * from test;";
+
+        UtFrameUtils.parseStmtWithNewAnalyzer(CTASSQL1, ctx);
+
+        String CTASSQL2 = "create table test6 as select c1+c2 as cr from test3;";
+
+        UtFrameUtils.parseStmtWithNewAnalyzer(CTASSQL2, ctx);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CTASAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CTASAnalyzerTest.java
@@ -17,7 +17,7 @@ import java.util.UUID;
 public class CTASAnalyzerTest {
     // use a unique dir so that it won't be conflict with other unit test which
     // may also start a Mocked Frontend
-    private static String runningDir = "fe/mocked/AnalyzeInsertTest/" + UUID.randomUUID().toString() + "/";
+    private static String runningDir = "fe/mocked/CTASAnalyzerTest/" + UUID.randomUUID().toString() + "/";
     private static ConnectContext connectContext;
     private static StarRocksAssert starRocksAssert;
 
@@ -37,13 +37,105 @@ public class CTASAnalyzerTest {
                 .withTable("create table test(c1 varchar(10),c2 varchar(10)) DISTRIBUTED BY HASH(c1) " +
                         "BUCKETS 8 PROPERTIES (\"replication_num\" = \"1\" );")
                 .withTable("create table test3(c1 varchar(10),c2 varchar(10)) DISTRIBUTED BY HASH(c1) " +
-                        "BUCKETS 8 PROPERTIES (\"replication_num\" = \"1\" );");
+                        "BUCKETS 8 PROPERTIES (\"replication_num\" = \"1\" );")
+                .withTable("CREATE TABLE `lineorder` (\n" +
+                        "  `lo_orderdate` date NOT NULL COMMENT \"\",\n" +
+                        "  `lo_orderkey` int(11) NOT NULL COMMENT \"\",\n" +
+                        "  `lo_linenumber` tinyint(4) NOT NULL COMMENT \"\",\n" +
+                        "  `lo_custkey` int(11) NOT NULL COMMENT \"\",\n" +
+                        "  `lo_partkey` int(11) NOT NULL COMMENT \"\",\n" +
+                        "  `lo_suppkey` int(11) NOT NULL COMMENT \"\",\n" +
+                        "  `lo_orderpriority` varchar(16) NULL COMMENT \"\",\n" +
+                        "  `lo_shippriority` tinyint(4) NULL COMMENT \"\",\n" +
+                        "  `lo_quantity` tinyint(4) NOT NULL COMMENT \"\",\n" +
+                        "  `lo_extendedprice` int(11) NOT NULL COMMENT \"\",\n" +
+                        "  `lo_ordtotalprice` int(11) NOT NULL COMMENT \"\",\n" +
+                        "  `lo_discount` tinyint(4) NOT NULL COMMENT \"\",\n" +
+                        "  `lo_revenue` int(11) NOT NULL COMMENT \"\",\n" +
+                        "  `lo_supplycost` int(11) NOT NULL COMMENT \"\",\n" +
+                        "  `lo_tax` tinyint(4) NOT NULL COMMENT \"\",\n" +
+                        "  `lo_commitdate` int(11) NOT NULL COMMENT \"\",\n" +
+                        "  `lo_shipmode` varchar(11) NOT NULL COMMENT \"\"\n" +
+                        ") ENGINE=OLAP \n" +
+                        "DUPLICATE KEY(`lo_orderdate`, `lo_orderkey`)\n" +
+                        "COMMENT \"OLAP\"\n" +
+                        "PARTITION BY RANGE(`lo_orderdate`)\n" +
+                        "(PARTITION p1 VALUES [('1900-01-01'), ('1993-01-01')),\n" +
+                        "PARTITION p2 VALUES [('1993-01-01'), ('1994-01-01')),\n" +
+                        "PARTITION p3 VALUES [('1994-01-01'), ('1995-01-01')),\n" +
+                        "PARTITION p4 VALUES [('1995-01-01'), ('1996-01-01')),\n" +
+                        "PARTITION p5 VALUES [('1996-01-01'), ('1997-01-01')),\n" +
+                        "PARTITION p6 VALUES [('1997-01-01'), ('1998-01-01')),\n" +
+                        "PARTITION p7 VALUES [('1998-01-01'), ('1999-01-01')))\n" +
+                        "DISTRIBUTED BY HASH(`lo_orderkey`) BUCKETS 96 \n" +
+                        "PROPERTIES (\n" +
+                        "\"replication_num\" = \"1\",\n" +
+                        "\"colocate_with\" = \"groupc1\",\n" +
+                        "\"in_memory\" = \"false\",\n" +
+                        "\"storage_format\" = \"DEFAULT\"\n" +
+                        ");")
+                .withTable("CREATE TABLE `customer` (\n" +
+                        "  `c_custkey` int(11) NOT NULL COMMENT \"\",\n" +
+                        "  `c_name` varchar(26) NOT NULL COMMENT \"\",\n" +
+                        "  `c_address` varchar(41) NOT NULL COMMENT \"\",\n" +
+                        "  `c_city` varchar(11) NOT NULL COMMENT \"\",\n" +
+                        "  `c_nation` varchar(16) NOT NULL COMMENT \"\",\n" +
+                        "  `c_region` varchar(13) NOT NULL COMMENT \"\",\n" +
+                        "  `c_phone` varchar(16) NOT NULL COMMENT \"\",\n" +
+                        "  `c_mktsegment` varchar(11) NOT NULL COMMENT \"\"\n" +
+                        ") ENGINE=OLAP \n" +
+                        "DUPLICATE KEY(`c_custkey`)\n" +
+                        "COMMENT \"OLAP\"\n" +
+                        "DISTRIBUTED BY HASH(`c_custkey`) BUCKETS 12 \n" +
+                        "PROPERTIES (\n" +
+                        "\"replication_num\" = \"1\",\n" +
+                        "\"colocate_with\" = \"groupa2\",\n" +
+                        "\"in_memory\" = \"false\",\n" +
+                        "\"storage_format\" = \"DEFAULT\"\n" +
+                        ");")
+                .withTable("CREATE TABLE `supplier` (\n" +
+                        "  `s_suppkey` int(11) NOT NULL COMMENT \"\",\n" +
+                        "  `s_name` varchar(26) NOT NULL COMMENT \"\",\n" +
+                        "  `s_address` varchar(26) NOT NULL COMMENT \"\",\n" +
+                        "  `s_city` varchar(11) NOT NULL COMMENT \"\",\n" +
+                        "  `s_nation` varchar(16) NOT NULL COMMENT \"\",\n" +
+                        "  `s_region` varchar(13) NOT NULL COMMENT \"\",\n" +
+                        "  `s_phone` varchar(16) NOT NULL COMMENT \"\"\n" +
+                        ") ENGINE=OLAP \n" +
+                        "DUPLICATE KEY(`s_suppkey`)\n" +
+                        "COMMENT \"OLAP\"\n" +
+                        "DISTRIBUTED BY HASH(`s_suppkey`) BUCKETS 12 \n" +
+                        "PROPERTIES (\n" +
+                        "\"replication_num\" = \"1\",\n" +
+                        "\"colocate_with\" = \"groupa4\",\n" +
+                        "\"in_memory\" = \"false\",\n" +
+                        "\"storage_format\" = \"DEFAULT\"\n" +
+                        ");")
+                .withTable("CREATE TABLE `part` (\n" +
+                        "  `p_partkey` int(11) NOT NULL COMMENT \"\",\n" +
+                        "  `p_name` varchar(23) NOT NULL COMMENT \"\",\n" +
+                        "  `p_mfgr` varchar(7) NOT NULL COMMENT \"\",\n" +
+                        "  `p_category` varchar(8) NOT NULL COMMENT \"\",\n" +
+                        "  `p_brand` varchar(10) NOT NULL COMMENT \"\",\n" +
+                        "  `p_color` varchar(12) NOT NULL COMMENT \"\",\n" +
+                        "  `p_type` varchar(26) NOT NULL COMMENT \"\",\n" +
+                        "  `p_size` tinyint(4) NOT NULL COMMENT \"\",\n" +
+                        "  `p_container` varchar(11) NOT NULL COMMENT \"\"\n" +
+                        ") ENGINE=OLAP \n" +
+                        "DUPLICATE KEY(`p_partkey`)\n" +
+                        "COMMENT \"OLAP\"\n" +
+                        "DISTRIBUTED BY HASH(`p_partkey`) BUCKETS 12 \n" +
+                        "PROPERTIES (\n" +
+                        "\"replication_num\" = \"1\",\n" +
+                        "\"colocate_with\" = \"groupa5\",\n" +
+                        "\"in_memory\" = \"false\",\n" +
+                        "\"storage_format\" = \"DEFAULT\"\n" +
+                        ");");
     }
 
     @AfterClass
     public static void tearDown() {
-        File file = new File(runningDir);
-        file.delete();
+        UtFrameUtils.cleanStarRocksFeDir(runningDir);
     }
 
     @Test
@@ -56,5 +148,55 @@ public class CTASAnalyzerTest {
         String CTASSQL2 = "create table test6 as select c1+c2 as cr from test3;";
 
         UtFrameUtils.parseStmtWithNewAnalyzer(CTASSQL2, ctx);
+    }
+
+    @Test
+    public void testTPCH() throws Exception {
+        ConnectContext ctx = starRocksAssert.getCtx();
+        String CTASTPCH = "CREATE TABLE lineorder_flat \n" +
+                "    AS SELECT\n" +
+                "    l.LO_ORDERKEY AS LO_ORDERKEY_1,\n" +
+                "    l.LO_LINENUMBER AS LO_LINENUMBER,\n" +
+                "    l.LO_CUSTKEY AS LO_CUSTKEY,\n" +
+                "    l.LO_PARTKEY AS LO_PARTKEY,\n" +
+                "    l.LO_SUPPKEY AS LO_SUPPKEY,\n" +
+                "    l.LO_ORDERDATE AS LO_ORDERDATE,\n" +
+                "    l.LO_ORDERPRIORITY AS LO_ORDERPRIORITY,\n" +
+                "    l.LO_SHIPPRIORITY AS LO_SHIPPRIORITY,\n" +
+                "    l.LO_QUANTITY AS LO_QUANTITY,\n" +
+                "    l.LO_EXTENDEDPRICE AS LO_EXTENDEDPRICE,\n" +
+                "    l.LO_ORDTOTALPRICE AS LO_ORDTOTALPRICE,\n" +
+                "    l.LO_DISCOUNT AS LO_DISCOUNT,\n" +
+                "    l.LO_REVENUE AS LO_REVENUE,\n" +
+                "    l.LO_SUPPLYCOST AS LO_SUPPLYCOST,\n" +
+                "    l.LO_TAX AS LO_TAX,\n" +
+                "    l.LO_COMMITDATE AS LO_COMMITDATE,\n" +
+                "    l.LO_SHIPMODE AS LO_SHIPMODE,\n" +
+                "    c.C_NAME AS C_NAME,\n" +
+                "    c.C_ADDRESS AS C_ADDRESS,\n" +
+                "    c.C_CITY AS C_CITY,\n" +
+                "    c.C_NATION AS C_NATION,\n" +
+                "    c.C_REGION AS C_REGION,\n" +
+                "    c.C_PHONE AS C_PHONE,\n" +
+                "    c.C_MKTSEGMENT AS C_MKTSEGMENT,\n" +
+                "    s.S_NAME AS S_NAME,\n" +
+                "    s.S_ADDRESS AS S_ADDRESS,\n" +
+                "    s.S_CITY AS S_CITY,\n" +
+                "    s.S_NATION AS S_NATION,\n" +
+                "    s.S_REGION AS S_REGION,\n" +
+                "    s.S_PHONE AS S_PHONE,\n" +
+                "    p.P_NAME AS P_NAME,\n" +
+                "    p.P_MFGR AS P_MFGR,\n" +
+                "    p.P_CATEGORY AS P_CATEGORY,\n" +
+                "    p.P_BRAND AS P_BRAND,\n" +
+                "    p.P_COLOR AS P_COLOR,\n" +
+                "    p.P_TYPE AS P_TYPE,\n" +
+                "    p.P_SIZE AS P_SIZE,\n" +
+                "    p.P_CONTAINER AS P_CONTAINER\n" +
+                "FROM lineorder AS l\n" +
+                "INNER JOIN customer AS c ON c.C_CUSTKEY = l.LO_CUSTKEY\n" +
+                "INNER JOIN supplier AS s ON s.S_SUPPKEY = l.LO_SUPPKEY\n" +
+                "INNER JOIN part AS p ON p.P_PARTKEY = l.LO_PARTKEY;";
+        UtFrameUtils.parseStmtWithNewAnalyzer(CTASTPCH, ctx);
     }
 }


### PR DESCRIPTION
#2393 #2394
1. SELECT statement in CTAS may be a SQL without an alias. CTAS should support the SQL as well. 
2. Because double is not precise, the key column in create table is replaced using decimal.