### PR TITLE
Set names correctly for all threads

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -56,6 +56,7 @@
 #include "util/monotime.h"
 #include "util/starrocks_metrics.h"
 #include "util/stopwatch.hpp"
+#include "util/thread.h"
 
 namespace starrocks {
 
@@ -210,6 +211,7 @@ void TaskWorkerPool::_remove_task_info(const TTaskType::type task_type, int64_t 
 void TaskWorkerPool::_spawn_callback_worker_thread(CALLBACK_FUNCTION callback_func) {
     std::thread worker_thread(callback_func, this);
     _worker_threads.emplace_back(std::move(worker_thread));
+    Thread::set_thread_name(_worker_threads.back(), "task_worker");
 }
 
 void TaskWorkerPool::_finish_task(const TFinishTaskRequest& finish_task_request) {

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -45,6 +45,7 @@
 #include "util/network_util.h"
 #include "util/starrocks_metrics.h"
 #include "util/system_metrics.h"
+#include "util/thread.h"
 #include "util/thrift_util.h"
 #include "util/time.h"
 
@@ -265,12 +266,14 @@ void Daemon::init(int argc, char** argv, const std::vector<StorePath>& paths) {
     vectorized::date::init_date_cache();
 
     std::thread tcmalloc_gc_thread(gc_tcmalloc_memory, this);
+    Thread::set_thread_name(tcmalloc_gc_thread, "tcmalloc_daemon");
     _daemon_threads.emplace_back(std::move(tcmalloc_gc_thread));
 
     init_starrocks_metrics(paths);
 
     if (config::enable_metric_calculator) {
         std::thread calculate_metrics_thread(calculate_metrics, this);
+        Thread::set_thread_name(calculate_metrics_thread, "metrics_daemon");
         _daemon_threads.emplace_back(std::move(calculate_metrics_thread));
     }
 

--- a/be/src/exec/pipeline/exec_state_reporter.cpp
+++ b/be/src/exec/pipeline/exec_state_reporter.cpp
@@ -143,7 +143,7 @@ Status ExecStateReporter::report_exec_status(const TReportExecStatusParams& para
 }
 
 ExecStateReporter::ExecStateReporter() {
-    auto status = ThreadPoolBuilder("exec_state_reporter_thread")
+    auto status = ThreadPoolBuilder("ex_state_report") // exec state reporter
                           .set_min_threads(1)
                           .set_max_threads(2)
                           .set_max_queue_size(1000)

--- a/be/src/exec/pipeline/pipeline_driver_poller.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_poller.cpp
@@ -8,7 +8,7 @@ namespace starrocks::pipeline {
 void PipelineDriverPoller::start() {
     DCHECK(this->_polling_thread.get() == nullptr);
     auto status = Thread::create(
-            "pipeline", "PipelineDriverPoller", [this]() { run_internal(); }, &this->_polling_thread);
+            "pipeline", "pipeline_poller", [this]() { run_internal(); }, &this->_polling_thread);
     if (!status.ok()) {
         LOG(FATAL) << "Fail to create PipelineDriverPoller: error=" << status.to_string();
     }

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -40,6 +40,7 @@
 #include "util/brpc_stub_cache.h"
 #include "util/defer_op.h"
 #include "util/monotime.h"
+#include "util/thread.h"
 #include "util/uid_util.h"
 
 static const uint8_t VALID_SEL_FAILED = 0x0;
@@ -612,6 +613,7 @@ Status OlapTableSink::open(RuntimeState* state) {
     }
 
     _sender_thread = std::thread(&OlapTableSink::_send_chunk_process, this);
+    Thread::set_thread_name(_sender_thread, "olap_table_send");
     return Status::OK();
 }
 

--- a/be/src/exec/vectorized/es_http_scan_node.cpp
+++ b/be/src/exec/vectorized/es_http_scan_node.cpp
@@ -15,6 +15,7 @@
 #include "runtime/current_thread.h"
 #include "util/defer_op.h"
 #include "util/spinlock.h"
+#include "util/thread.h"
 
 namespace starrocks::vectorized {
 EsHttpScanNode::EsHttpScanNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs)
@@ -239,6 +240,7 @@ Status EsHttpScanNode::_start_scan_thread(RuntimeState* state) {
     for (int i = 0; i < _scan_ranges.size(); i++) {
         _scanner_threads.emplace_back(&EsHttpScanNode::_scanner_scan, this, std::move(scanners[i]),
                                       std::ref(_scanners_status[i]));
+        Thread::set_thread_name(_scanner_threads.back(), "es_http_scan");
     }
     return Status::OK();
 }

--- a/be/src/exec/vectorized/file_scan_node.cpp
+++ b/be/src/exec/vectorized/file_scan_node.cpp
@@ -19,6 +19,7 @@
 #include "runtime/runtime_state.h"
 #include "util/defer_op.h"
 #include "util/runtime_profile.h"
+#include "util/thread.h"
 
 namespace starrocks::vectorized {
 
@@ -86,6 +87,7 @@ Status FileScanNode::start_scanners() {
 
         _num_running_scanners = 1;
         _scanner_threads.emplace_back(&FileScanNode::scanner_worker, this, 0, _scan_ranges.size());
+        Thread::set_thread_name(_scanner_threads.back(), "file_scanner");
     }
     return Status::OK();
 }

--- a/be/src/http/ev_http_server.cpp
+++ b/be/src/http/ev_http_server.cpp
@@ -39,6 +39,7 @@
 #include "http/http_request.h"
 #include "service/brpc.h"
 #include "util/debug_util.h"
+#include "util/thread.h"
 
 namespace starrocks {
 
@@ -121,6 +122,7 @@ Status EvHttpServer::start() {
             event_base_dispatch(base.get());
         };
         _workers.emplace_back(worker);
+        Thread::set_thread_name(_workers.back(), "ev_http_server");
         _workers[i].detach();
     }
     return Status::OK();

--- a/be/src/runtime/broker_mgr.cpp
+++ b/be/src/runtime/broker_mgr.cpp
@@ -30,12 +30,14 @@
 #include "runtime/exec_env.h"
 #include "service/backend_options.h"
 #include "util/starrocks_metrics.h"
+#include "util/thread.h"
 #include "util/thrift_util.h"
 
 namespace starrocks {
 
 BrokerMgr::BrokerMgr(ExecEnv* exec_env)
         : _exec_env(exec_env), _thread_stop(false), _ping_thread(&BrokerMgr::ping_worker, this) {
+    Thread::set_thread_name(_ping_thread, "broker_hrtbeat"); // broker heart beat
     REGISTER_GAUGE_STARROCKS_METRIC(broker_count, [this]() {
         std::lock_guard<std::mutex> l(_mutex);
         return _broker_set.size();

--- a/be/src/runtime/external_scan_context_mgr.cpp
+++ b/be/src/runtime/external_scan_context_mgr.cpp
@@ -29,6 +29,7 @@
 #include "runtime/fragment_mgr.h"
 #include "runtime/result_queue_mgr.h"
 #include "util/starrocks_metrics.h"
+#include "util/thread.h"
 #include "util/uid_util.h"
 
 namespace starrocks {
@@ -37,6 +38,7 @@ ExternalScanContextMgr::ExternalScanContextMgr(ExecEnv* exec_env) : _exec_env(ex
     // start the reaper thread for gc the expired context
     _keep_alive_reaper = std::make_unique<std::thread>(
             std::bind<void>(std::mem_fn(&ExternalScanContextMgr::gc_expired_context), this));
+    Thread::set_thread_name(_keep_alive_reaper.get()->native_handle(), "kepalive_reaper");
     _keep_alive_reaper->detach();
     REGISTER_GAUGE_STARROCKS_METRIC(active_scan_context_count, [this]() {
         std::lock_guard<std::mutex> l(_lock);

--- a/be/src/runtime/load_channel_mgr.cpp
+++ b/be/src/runtime/load_channel_mgr.cpp
@@ -31,6 +31,7 @@
 #include "storage/lru_cache.h"
 #include "util/starrocks_metrics.h"
 #include "util/stopwatch.hpp"
+#include "util/thread.h"
 
 namespace starrocks {
 
@@ -180,6 +181,7 @@ Status LoadChannelMgr::_start_bg_worker() {
             sleep(interval);
         }
     });
+    Thread::set_thread_name(_load_channels_clean_thread, "load_chan_clean");
     return Status::OK();
 }
 

--- a/be/src/runtime/load_path_mgr.cpp
+++ b/be/src/runtime/load_path_mgr.cpp
@@ -34,6 +34,7 @@
 #include "storage/olap_define.h"
 #include "storage/storage_engine.h"
 #include "util/file_utils.h"
+#include "util/thread.h"
 
 namespace starrocks {
 
@@ -56,6 +57,7 @@ Status LoadPathMgr::init() {
 
     _idx = 0;
     pthread_create(&_cleaner_id, nullptr, LoadPathMgr::cleaner, this);
+    Thread::set_thread_name(_cleaner_id, "load_path_mgr");
     return Status::OK();
 }
 

--- a/be/src/runtime/result_buffer_mgr.cpp
+++ b/be/src/runtime/result_buffer_mgr.cpp
@@ -29,6 +29,7 @@
 #include "runtime/raw_value.h"
 #include "util/debug_util.h"
 #include "util/starrocks_metrics.h"
+#include "util/thread.h"
 
 namespace starrocks {
 
@@ -48,6 +49,7 @@ ResultBufferMgr::~ResultBufferMgr() {
 
 Status ResultBufferMgr::init() {
     _cancel_thread = std::make_unique<std::thread>(std::bind<void>(std::mem_fn(&ResultBufferMgr::cancel_thread), this));
+    Thread::set_thread_name(_cancel_thread->native_handle(), "res_buf_mgr");
     return Status::OK();
 }
 

--- a/be/src/runtime/routine_load/data_consumer_group.h
+++ b/be/src/runtime/routine_load/data_consumer_group.h
@@ -34,7 +34,7 @@ class DataConsumerGroup {
 public:
     typedef std::function<void(const Status&)> ConsumeFinishCallback;
 
-    DataConsumerGroup() : _grp_id(UniqueId::gen_uid()), _thread_pool(3, 10) {}
+    DataConsumerGroup() : _grp_id(UniqueId::gen_uid()), _thread_pool("data_consume", 3, 10) {}
 
     virtual ~DataConsumerGroup() { _consumers.clear(); }
 

--- a/be/src/runtime/routine_load/data_consumer_pool.cpp
+++ b/be/src/runtime/routine_load/data_consumer_pool.cpp
@@ -23,6 +23,7 @@
 
 #include "common/config.h"
 #include "runtime/routine_load/data_consumer_group.h"
+#include "util/thread.h"
 
 namespace starrocks {
 
@@ -124,6 +125,7 @@ Status DataConsumerPool::start_bg_worker() {
             sleep(interval);
         }
     });
+    Thread::set_thread_name(_clean_idle_consumer_thread, "clean_idle_cm");
     _clean_idle_consumer_thread.detach();
     return Status::OK();
 }

--- a/be/src/runtime/routine_load/routine_load_task_executor.h
+++ b/be/src/runtime/routine_load/routine_load_task_executor.h
@@ -48,7 +48,8 @@ public:
 
     RoutineLoadTaskExecutor(ExecEnv* exec_env)
             : _exec_env(exec_env),
-              _thread_pool(config::routine_load_thread_pool_size, config::routine_load_thread_pool_size),
+              _thread_pool("routine_load", config::routine_load_thread_pool_size,
+                           config::routine_load_thread_pool_size),
               _data_consumer_pool(10) {
         REGISTER_GAUGE_STARROCKS_METRIC(routine_load_task_count, [this]() {
             std::lock_guard<std::mutex> l(_lock);

--- a/be/src/runtime/runtime_filter_worker.cpp
+++ b/be/src/runtime/runtime_filter_worker.cpp
@@ -14,6 +14,7 @@
 #include "util/brpc_stub_cache.h"
 #include "util/defer_op.h"
 #include "util/ref_count_closure.h"
+#include "util/thread.h"
 #include "util/time.h"
 
 namespace starrocks {
@@ -369,7 +370,9 @@ public:
 
 static_assert(std::is_move_assignable<RuntimeFilterWorkerEvent>::value);
 
-RuntimeFilterWorker::RuntimeFilterWorker(ExecEnv* env) : _exec_env(env), _thread([this] { execute(); }) {}
+RuntimeFilterWorker::RuntimeFilterWorker(ExecEnv* env) : _exec_env(env), _thread([this] { execute(); }) {
+    Thread::set_thread_name(_thread, "runtime_filter");
+}
 
 RuntimeFilterWorker::~RuntimeFilterWorker() {
     _queue.shutdown();

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -43,7 +43,7 @@ namespace starrocks {
 
 template <typename T>
 PInternalServiceImpl<T>::PInternalServiceImpl(ExecEnv* exec_env)
-        : _exec_env(exec_env), _tablet_worker_pool(config::number_tablet_writer_threads, 10240) {}
+        : _exec_env(exec_env), _tablet_worker_pool("tablet", config::number_tablet_writer_threads, 10240) {}
 
 template <typename T>
 PInternalServiceImpl<T>::~PInternalServiceImpl() = default;

--- a/be/src/storage/async_delta_writer_executor.h
+++ b/be/src/storage/async_delta_writer_executor.h
@@ -15,13 +15,12 @@ public:
         if (_thread_pool != nullptr) {
             return Status::InternalError("already initialized");
         }
-        auto st = ThreadPoolBuilder("AsyncDeltaWriterExecutor")
-                          .set_min_threads(config::number_tablet_writer_threads / 2)
-                          .set_max_threads(std::max<int>(1, config::number_tablet_writer_threads))
-                          .set_max_queue_size(40960)
-                          .set_idle_timeout(MonoDelta::FromMilliseconds(5 * 60 * 1000))
-                          .build(&_thread_pool);
-        return st;
+        return ThreadPoolBuilder("delta_writer")
+                .set_min_threads(config::number_tablet_writer_threads / 2)
+                .set_max_threads(std::max<int>(1, config::number_tablet_writer_threads))
+                .set_max_queue_size(40960)
+                .set_idle_timeout(MonoDelta::FromMilliseconds(5 * 60 * 1000))
+                .build(&_thread_pool);
     }
 
     int submit(void* (*fn)(void*), void* args) override {

--- a/be/src/storage/memtable_flush_executor.cpp
+++ b/be/src/storage/memtable_flush_executor.cpp
@@ -98,7 +98,7 @@ Status MemTableFlushExecutor::init(const std::vector<DataDir*>& data_dirs) {
     int data_dir_num = static_cast<int>(data_dirs.size());
     int min_threads = std::max<int>(1, config::flush_thread_num_per_store);
     int max_threads = data_dir_num * min_threads;
-    return ThreadPoolBuilder("MemTableFlushThreadPool")
+    return ThreadPoolBuilder("mem_tab_flush") // mem table flush
             .set_min_threads(min_threads)
             .set_max_threads(max_threads)
             .build(&_flush_pool);

--- a/be/src/storage/olap_server.cpp
+++ b/be/src/storage/olap_server.cpp
@@ -33,6 +33,7 @@
 #include "storage/storage_engine.h"
 #include "storage/update_manager.h"
 #include "storage/vectorized/compaction.h"
+#include "util/thread.h"
 #include "util/time.h"
 
 using std::string;
@@ -55,17 +56,21 @@ volatile uint32_t g_schema_change_active_threads = 0;
 
 Status StorageEngine::start_bg_threads() {
     _update_cache_expire_thread = std::thread([this] { _update_cache_expire_thread_callback(nullptr); });
+    Thread::set_thread_name(_update_cache_expire_thread, "cache_expire");
     LOG(INFO) << "update cache expire thread started";
 
     _unused_rowset_monitor_thread = std::thread([this] { _unused_rowset_monitor_thread_callback(nullptr); });
+    Thread::set_thread_name(_unused_rowset_monitor_thread, "rowset_monitor");
     LOG(INFO) << "unused rowset monitor thread started";
 
     // start thread for monitoring the snapshot and trash folder
     _garbage_sweeper_thread = std::thread([this] { _garbage_sweeper_thread_callback(nullptr); });
+    Thread::set_thread_name(_garbage_sweeper_thread, "garbage_sweeper");
     LOG(INFO) << "garbage sweeper thread started";
 
     // start thread for monitoring the tablet with io error
     _disk_stat_monitor_thread = std::thread([this] { _disk_stat_monitor_thread_callback(nullptr); });
+    Thread::set_thread_name(_disk_stat_monitor_thread, "disk_monitor");
     LOG(INFO) << "disk stat monitor thread started";
 
     // convert store map to vector
@@ -95,6 +100,7 @@ Status StorageEngine::start_bg_threads() {
         _base_compaction_threads.emplace_back([this, data_dir_num, data_dirs, i] {
             _base_compaction_thread_callback(nullptr, data_dirs[i % data_dir_num]);
         });
+        Thread::set_thread_name(_base_compaction_threads.back(), "base_compact");
     }
     LOG(INFO) << "base compaction threads started. number: " << base_compaction_num_threads;
 
@@ -103,6 +109,7 @@ Status StorageEngine::start_bg_threads() {
         _cumulative_compaction_threads.emplace_back([this, data_dir_num, data_dirs, i] {
             _cumulative_compaction_thread_callback(nullptr, data_dirs[i % data_dir_num]);
         });
+        Thread::set_thread_name(_cumulative_compaction_threads.back(), "cumulat_compact");
     }
     LOG(INFO) << "cumulative compaction threads started. number: " << cumulative_compaction_num_threads;
 
@@ -114,25 +121,29 @@ Status StorageEngine::start_bg_threads() {
         _update_compaction_threads.emplace_back([this, data_dir_num, data_dirs, i] {
             _update_compaction_thread_callback(nullptr, data_dirs[i % data_dir_num]);
         });
+        Thread::set_thread_name(_update_compaction_threads.back(), "update_compact");
     }
     LOG(INFO) << "update compaction threads started. number: " << update_compaction_num_threads;
 
     // tablet checkpoint thread
     for (auto data_dir : data_dirs) {
         _tablet_checkpoint_threads.emplace_back([this, data_dir] { _tablet_checkpoint_callback((void*)data_dir); });
+        Thread::set_thread_name(_tablet_checkpoint_threads.back(), "tablet_check_pt");
     }
     LOG(INFO) << "tablet checkpoint thread started";
 
     // fd cache clean thread
     _fd_cache_clean_thread = std::thread([this] { _fd_cache_clean_callback(nullptr); });
+    Thread::set_thread_name(_fd_cache_clean_thread, "fd_cache_clean");
     LOG(INFO) << "fd cache clean thread started";
 
     // path scan and gc thread
     if (config::path_gc_check) {
         for (auto data_dir : get_stores()) {
             _path_scan_threads.emplace_back([this, data_dir] { _path_scan_thread_callback((void*)data_dir); });
-
             _path_gc_threads.emplace_back([this, data_dir] { _path_gc_thread_callback((void*)data_dir); });
+            Thread::set_thread_name(_path_scan_threads.back(), "path_scan");
+            Thread::set_thread_name(_path_gc_threads.back(), "path_gc");
         }
         LOG(INFO) << "path scan/gc threads started. number:" << get_stores().size();
     }

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -62,6 +62,7 @@
 #include "util/pretty_printer.h"
 #include "util/scoped_cleanup.h"
 #include "util/starrocks_metrics.h"
+#include "util/thread.h"
 #include "util/time.h"
 #include "util/trace.h"
 
@@ -127,6 +128,7 @@ void StorageEngine::load_data_dirs(const std::vector<DataDir*>& data_dirs) {
                 // TODO(lingbin): why not exit progress, to force OP to change the conf
             }
         });
+        Thread::set_thread_name(threads.back(), "load_data_dir");
     }
     for (auto& thread : threads) {
         thread.join();
@@ -198,6 +200,7 @@ Status StorageEngine::_init_store_map() {
                 LOG(WARNING) << "Store load failed, status=" << st.to_string() << ", path=" << store->path();
             }
         });
+        Thread::set_thread_name(threads.back(), "init_store_path");
     }
     for (auto& thread : threads) {
         thread.join();

--- a/be/src/util/runtime_profile.cpp
+++ b/be/src/util/runtime_profile.cpp
@@ -35,6 +35,7 @@
 #include "util/debug_util.h"
 #include "util/monotime.h"
 #include "util/pretty_printer.h"
+#include "util/thread.h"
 
 namespace starrocks {
 
@@ -663,6 +664,7 @@ void RuntimeProfile::add_bucketing_counters(const std::string& name, const std::
     if (_s_periodic_counter_update_state.update_thread == nullptr) {
         _s_periodic_counter_update_state.update_thread =
                 std::make_unique<std::thread>(&RuntimeProfile::periodic_counter_update_loop);
+        Thread::set_thread_name(_s_periodic_counter_update_state.update_thread.get()->native_handle(), "rf_cnt_update");
     }
 
     BucketCountersInfo info{.src_counter = src_counter, .num_sampled = 0};
@@ -691,6 +693,7 @@ void RuntimeProfile::register_periodic_counter(Counter* src_counter, SampleFn sa
     if (_s_periodic_counter_update_state.update_thread == nullptr) {
         _s_periodic_counter_update_state.update_thread =
                 std::make_unique<std::thread>(&RuntimeProfile::periodic_counter_update_loop);
+        Thread::set_thread_name(_s_periodic_counter_update_state.update_thread.get()->native_handle(), "rf_cnt_update");
     }
 
     switch (type) {

--- a/be/src/util/thread.h
+++ b/be/src/util/thread.h
@@ -26,6 +26,7 @@
 #include <syscall.h>
 
 #include <atomic>
+#include <thread>
 
 #include "common/status.h"
 #include "gutil/ref_counted.h"
@@ -133,6 +134,11 @@ public:
     // performance sensistive code, however it is only guaranteed to return a
     // unique and stable thread ID, not necessarily the system thread ID.
     static int64_t current_thread_id();
+
+    // Set name for thread
+    // name's size should be less than 16, otherwise it will be truncated
+    static void set_thread_name(pthread_t t, const std::string name);
+    static void set_thread_name(std::thread& t, const std::string name);
 
 private:
     friend class ThreadJoiner;

--- a/be/src/util/threadpool.cpp
+++ b/be/src/util/threadpool.cpp
@@ -561,8 +561,7 @@ void ThreadPool::dispatch_thread() {
 }
 
 Status ThreadPool::create_thread() {
-    return Thread::create("thread pool", strings::Substitute("$0 [worker]", _name), &ThreadPool::dispatch_thread, this,
-                          nullptr);
+    return Thread::create("thread pool", _name, &ThreadPool::dispatch_thread, this, nullptr);
 }
 
 void ThreadPool::check_not_pool_thread_unlocked() {

--- a/be/src/util/thrift_server.cpp
+++ b/be/src/util/thrift_server.cpp
@@ -38,6 +38,8 @@
 #include <thread>
 #include <utility>
 
+#include "util/thread.h"
+
 namespace starrocks {
 
 // Helper class that starts a server in a separate thread, and handles
@@ -102,6 +104,7 @@ Status ThriftServer::ThriftServerEventProcessor::start_and_wait_for_server() {
 
     _thrift_server->_server_thread =
             std::make_unique<std::thread>(&ThriftServer::ThriftServerEventProcessor::supervise, this);
+    Thread::set_thread_name(_thrift_server->_server_thread.get()->native_handle(), "thrift_server");
 
     // Loop protects against spurious wakeup. Locks provide necessary fences to ensure
     // visibility.


### PR DESCRIPTION
Set name for all threads except brpc, because bprc does not provide a way to set the thread name