### PR TITLE
[pipeline] push down in filters for project node

### DIFF
--- a/be/src/common/global_types.h
+++ b/be/src/common/global_types.h
@@ -30,4 +30,26 @@ typedef int SlotId;
 typedef int TableId;
 typedef int PlanNodeId;
 
+// Mapping from input slot to output slot of an ExecNode.
+struct TupleSlotMapping {
+    TupleId from_tuple_id;
+    SlotId from_slot_id;
+    TupleId to_tuple_id;
+    SlotId to_slot_id;
+
+    TupleSlotMapping() = default;
+    ~TupleSlotMapping() = default;
+
+    TupleSlotMapping(const TupleSlotMapping&) = default;
+    TupleSlotMapping(TupleSlotMapping&&) = default;
+    TupleSlotMapping& operator=(TupleSlotMapping&&) = default;
+    TupleSlotMapping& operator=(const TupleSlotMapping&) = default;
+
+    TupleSlotMapping(TupleId from_tuple_id, SlotId from_slot_id, TupleId to_tuple_id, SlotId to_slot_id)
+            : from_tuple_id(from_tuple_id),
+              from_slot_id(from_slot_id),
+              to_tuple_id(to_tuple_id),
+              to_slot_id(to_slot_id) {}
+};
+
 }; // namespace starrocks

--- a/be/src/common/global_types.h
+++ b/be/src/common/global_types.h
@@ -31,6 +31,7 @@ typedef int TableId;
 typedef int PlanNodeId;
 
 // Mapping from input slot to output slot of an ExecNode.
+// It is used for pipeline to rewrite runtime in filters.
 struct TupleSlotMapping {
     TupleId from_tuple_id;
     SlotId from_slot_id;

--- a/be/src/exec/exec_node.h
+++ b/be/src/exec/exec_node.h
@@ -178,6 +178,11 @@ public:
         }
     }
 
+    // Make the node store the slot mappings from input slot to output slot of ancestor nodes (include itself).
+    // It is used for pipeline to rewrite runtime in filters.
+    virtual void push_down_tuple_slot_mappings(RuntimeState* state,
+                                               const std::vector<TupleSlotMapping>& parent_mappings);
+
     // recursive helper method for generating a string for Debug_string().
     // implementations should call debug_string(int, std::stringstream) on their children.
     // Input parameters:
@@ -260,6 +265,10 @@ protected:
     RuntimeProfile::Counter* _memory_used_counter;
 
     bool _use_vectorized;
+
+    // Mappings from input slot to output slot of ancestor nodes (include itself).
+    // It is used for pipeline to rewrite runtime in filters.
+    std::vector<TupleSlotMapping> _tuple_slot_mappings;
 
     ExecNode* child(int i) { return _children[i]; }
 

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -129,6 +129,8 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
     ExecNode* plan = nullptr;
     RETURN_IF_ERROR(ExecNode::create_tree(runtime_state, obj_pool, fragment.plan, *desc_tbl, &plan));
     plan->push_down_join_runtime_filter_recursively(runtime_state);
+    std::vector<TupleSlotMapping> empty_mappings;
+    plan->push_down_tuple_slot_mappings(runtime_state, empty_mappings);
     runtime_state->set_fragment_root_id(plan->id());
     _fragment_ctx->set_plan(plan);
 

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -324,8 +324,9 @@ void PipelineDriver::_update_overhead_timer() {
     profile->get_children(&children);
     for (auto* child_profile : children) {
         auto* total_timer = child_profile->get_counter("OperatorTotalTime");
-        if (total_timer != nullptr) continue;
-        overhead_time -= total_timer->value();
+        if (total_timer != nullptr) {
+            overhead_time -= total_timer->value();
+        }
     }
 
     COUNTER_UPDATE(_overhead_timer, overhead_time);

--- a/be/src/exec/vectorized/project_node.h
+++ b/be/src/exec/vectorized/project_node.h
@@ -24,6 +24,8 @@ public:
     void push_down_predicate(RuntimeState* state, std::list<ExprContext*>* expr_ctxs) override;
     void push_down_join_runtime_filter(RuntimeState* state,
                                        vectorized::RuntimeFilterProbeCollector* collector) override;
+    void push_down_tuple_slot_mappings(RuntimeState* state,
+                                       const std::vector<TupleSlotMapping>& parent_mappings) override;
 
     std::vector<std::shared_ptr<pipeline::OperatorFactory>> decompose_to_pipeline(
             pipeline::PipelineBuilderContext* context) override;


### PR DESCRIPTION
### Introduction
In-filters are constructed by a node and may be pushed down to its descendant node. Different tuple id and slot id between descendant and ancestor nodes may be referenced to the same column, such as `ProjectNode`, so we need use ancestor's tuple slot mappings to rewrite in filters, which maps input slot to output slot for ProjectNode.

### Changes
- Declare
    - Add struct `TupleSlotMapping`.
    - Add member `ExecNode::_tuple_slot_mappings` and `Operator::_tuple_slot_mappings`.
- Push down in ExecNode Tree
    - Add method `ExecNode::push_down_tuple_slot_mappings()` overloaded by `ProjectNode`.
    - Call `plan->push_down_tuple_slot_mappings()` in `pipeline::FragmentExecutor::prepare()`.
- Pass to Pipeline
    - Pass `ExecNode::_tuple_slot_mappings` to `Operator::_tuple_slot_mappings` in ` ExecNode::init_runtime_filter_for_operator()`.
- Use
    - Use `_tuple_slot_mappings` to rewrite in filters in `OperatorFactory::_prepare_runtime_in_filters()`.