### PR TITLE
Not to push global runtime filter accross CTE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
@@ -352,6 +352,7 @@ public class AggregationNode extends PlanNode {
 
     @Override
     public boolean pushDownRuntimeFilters(RuntimeFilterDescription description, Expr probeExpr) {
+        if (!canPushDownRuntimeFilter()) return false;
         if (probeExpr.isBoundByTupleIds(getTupleIds())) {
             if (probeExpr instanceof SlotRef) {
                 for (Expr gexpr : aggInfo.getGroupingExprs()) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ExchangeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ExchangeNode.java
@@ -178,6 +178,8 @@ public class ExchangeNode extends PlanNode {
 
     @Override
     public boolean pushDownRuntimeFilters(RuntimeFilterDescription description, Expr probeExpr) {
+        if (!canPushDownRuntimeFilter()) return false;
+
         boolean accept = false;
         if (description.canPushAcrossExchangeNode()) {
             description.enterExchangeNode();

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanNode.java
@@ -782,7 +782,14 @@ abstract public class PlanNode extends TreeNode<PlanNode> {
         return false;
     }
 
+
     public boolean canPushDownRuntimeFilter() {
+        // RuntimeFilter can only be pushed into multicast fragment iff.
+        // this runtime filter is applied to all consumers. It's quite hard to do
+        // thorough analysis, so we disable it for safety.
+        if (fragment_ instanceof MultiCastPlanFragment) {
+            return false;
+        }
         return true;
     }
 
@@ -790,9 +797,7 @@ abstract public class PlanNode extends TreeNode<PlanNode> {
     }
 
     public boolean pushDownRuntimeFilters(RuntimeFilterDescription description, Expr probeExpr) {
-        if (!canPushDownRuntimeFilter()) {
-            return false;
-        }
+        if (!canPushDownRuntimeFilter()) return false;
 
         // theoretically runtime filter can be applied on multiple child nodes.
         boolean accept = false;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ProjectNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ProjectNode.java
@@ -121,6 +121,7 @@ public class ProjectNode extends PlanNode {
 
     @Override
     public boolean pushDownRuntimeFilters(RuntimeFilterDescription description, Expr probeExpr) {
+        if (!canPushDownRuntimeFilter()) return false;
         if (probeExpr.isBoundByTupleIds(getTupleIds())) {
             if (probeExpr instanceof SlotRef) {
                 for (Map.Entry<SlotId, Expr> kv : slotMap.entrySet()) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/SetOperationNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/SetOperationNode.java
@@ -436,6 +436,7 @@ public abstract class SetOperationNode extends PlanNode {
 
     @Override
     public boolean pushDownRuntimeFilters(RuntimeFilterDescription description, Expr probeExpr) {
+        if (!canPushDownRuntimeFilter()) return false;
         if (!probeExpr.isBoundByTupleIds(getTupleIds())) return false;
 
         if (probeExpr instanceof SlotRef) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/OperatorStrings.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/OperatorStrings.java
@@ -15,6 +15,9 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalLimitOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalTopNOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalAssertOneRowOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalCTEAnchorOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalCTEConsumeOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalCTEProduceOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalDistributionOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalFilterOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalHashAggregateOperator;
@@ -395,6 +398,33 @@ public class OperatorStrings {
         @Override
         public OperatorStr visitPhysicalLimit(OptExpression optExpression, Integer step) {
             return visit(optExpression.getInputs().get(0), step);
+        }
+
+        @Override
+        public OperatorStr visitPhysicalCTEAnchor(OptExpression optExpression, Integer step) {
+            OperatorStr producer = visit(optExpression.getInputs().get(0), step + 1);
+            OperatorStr consumer = visit(optExpression.getInputs().get(1), step + 1);
+            PhysicalCTEAnchorOperator op = (PhysicalCTEAnchorOperator) optExpression.getOp();
+            String sb = "CTEAnchor(cteid=" + op.getCteId() + ") ";
+            ArrayList<OperatorStr> children = new ArrayList<>();
+            children.add(producer);
+            children.add(consumer);
+            return new OperatorStr(sb, step, children);
+        }
+
+        @Override
+        public OperatorStr visitPhysicalCTEProduce(OptExpression optExpression, Integer step) {
+            OperatorStr children = visit(optExpression.getInputs().get(0), step + 1);
+            PhysicalCTEProduceOperator op = (PhysicalCTEProduceOperator) optExpression.getOp();
+            String sb = "CTEProducer(cteid=" + op.getCteId() + ") ";
+            return new OperatorStr(sb, step, Collections.singletonList(children));
+        }
+
+        @Override
+        public OperatorStr visitPhysicalCTEConsume(OptExpression optExpression, Integer step) {
+            PhysicalCTEConsumeOperator op = (PhysicalCTEConsumeOperator) optExpression.getOp();
+            String sb = "CTEConsumer(cteid=" + op.getCteId() + ") ";
+            return new OperatorStr(sb, step, Collections.emptyList());
         }
     }
 }


### PR DESCRIPTION
ref: #2400 #1675 

For following CTE, we can not apply global runtime filter generated in ` cte.ss_store_sk = store.s_store_sk where store.s_market_id = 4` down to CTE, otherwise the answer will be incorrect.

```
with cte as (
    -- select count(*) from store_sales where ss_sold_date_sk < 2451818
    -- 1403859
    select ss_item_sk, ss_ticket_number, ss_store_sk from store_sales where ss_sold_date_sk < 2451818
)

select count(*) from
(
select * from cte
union all
(
    select cte.ss_item_sk,cte.ss_ticket_number,cte.ss_store_sk
    -- s_market_id = 4, s_store_sk = 4
    -- select count(*) from store_sales where ss_sold_date_sk < 2451818 and ss_store_sk = 4
    -- 227760. Global runtime filter works.
     from cte join store on cte.ss_store_sk = store.s_store_sk where store.s_market_id = 4
)) as t;
```


