### PR TITLE
Add routine load lag metrics of Prometheus format (#1210)

### DIFF
--- a/be/src/runtime/routine_load/data_consumer.cpp
+++ b/be/src/runtime/routine_load/data_consumer.cpp
@@ -236,6 +236,7 @@ Status KafkaDataConsumer::group_consume(TimedBlockingQueue<RdKafka::Message*>* q
 Status KafkaDataConsumer::get_partition_offset(std::vector<int32_t>* partition_ids,
                                                std::vector<int64_t>* beginning_offsets,
                                                std::vector<int64_t>* latest_offsets) {
+    _last_visit_time = time(nullptr);
     beginning_offsets->reserve(partition_ids->size());
     latest_offsets->reserve(partition_ids->size());
     for (auto p_id : *partition_ids) {
@@ -256,6 +257,7 @@ Status KafkaDataConsumer::get_partition_offset(std::vector<int32_t>* partition_i
 }
 
 Status KafkaDataConsumer::get_partition_meta(std::vector<int32_t>* partition_ids) {
+    _last_visit_time = time(nullptr);
     // create topic conf
     RdKafka::Conf* tconf = RdKafka::Conf::create(RdKafka::Conf::CONF_TOPIC);
     auto conf_deleter = [tconf]() { delete tconf; };
@@ -329,6 +331,7 @@ Status KafkaDataConsumer::cancel(StreamLoadContext* ctx) {
 Status KafkaDataConsumer::reset() {
     std::unique_lock<std::mutex> l(_lock);
     _cancelled = false;
+    _k_consumer->unassign();
     return Status::OK();
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1305,7 +1305,20 @@ public class Config extends ConfigBase {
     /**
      * connection and socket timeout for broker client
      */
-    @ConfField()
+    @ConfField
     public static int broker_client_timeout_ms = 10000;
-}
 
+    /**
+     * Whether to collect routine load process metrics.
+     * Be careful to turn this on, because this will call kafka api to get the partition's latest offset.
+     */
+    @ConfField(mutable = true)
+    public static boolean enable_routine_load_lag_metrics = false;
+
+    /**
+     * Min lag of routine load job to show in metrics
+     * Only show the routine load job whose lag is larger than min_routine_load_lag_for_metrics
+     */
+    @ConfField(mutable = true)
+    public static long min_routine_load_lag_for_metrics = 10000;
+}

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaProgress.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaProgress.java
@@ -82,6 +82,10 @@ public class KafkaProgress extends RoutineLoadProgress {
         return result;
     }
 
+    public ImmutableMap<Integer, Long> getPartitionIdToOffset() {
+        return ImmutableMap.copyOf(partitionIdToOffset);
+    }
+
     public void addPartitionOffset(Pair<Integer, Long> partitionOffset) {
         partitionIdToOffset.put(partitionOffset.first, partitionOffset.second);
     }
@@ -119,7 +123,7 @@ public class KafkaProgress extends RoutineLoadProgress {
         }
     }
 
-    // modify the partition offset of this progess.
+    // modify the partition offset of this progress.
     // throw exception is the specified partition does not exist in progress.
     public void modifyOffset(List<Pair<Integer, Long>> kafkaPartitionOffsets) throws DdlException {
         for (Pair<Integer, Long> pair : kafkaPartitionOffsets) {

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
@@ -124,7 +124,7 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
         ((KafkaProgress) progress).convertOffset(brokerList, topic, convertedCustomProperties);
     }
 
-    private void convertCustomProperties(boolean rebuild) throws DdlException {
+    public synchronized void convertCustomProperties(boolean rebuild) throws DdlException {
         if (customProperties.isEmpty()) {
             return;
         }
@@ -535,6 +535,12 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
         } finally {
             writeUnlock();
         }
+    }
+
+    @Override
+    public void updateState(JobState jobState, ErrorReason reason, boolean isReplay) throws UserException {
+        super.updateState(jobState, reason, isReplay);
+        customProperties.clear();
     }
 
     private void modifyPropertiesInternal(Map<String, String> jobProperties,

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadManager.java
@@ -68,9 +68,6 @@ import java.util.stream.Collectors;
 public class RoutineLoadManager implements Writable {
     private static final Logger LOG = LogManager.getLogger(RoutineLoadManager.class);
 
-    // Long is beId, integer is the size of tasks in be
-    private Map<Long, Integer> beIdToMaxConcurrentTasks = Maps.newHashMap();
-
     // be => running tasks num
     private Map<Long, Integer> beTasksNum = Maps.newHashMap();
     private ReentrantLock slotLock = new ReentrantLock();
@@ -80,14 +77,6 @@ public class RoutineLoadManager implements Writable {
     private Map<Long, Map<String, List<RoutineLoadJob>>> dbToNameToRoutineLoadJob = Maps.newConcurrentMap();
 
     private ReentrantReadWriteLock lock = new ReentrantReadWriteLock(true);
-
-    private void readLock() {
-        lock.readLock().lock();
-    }
-
-    private void readUnlock() {
-        lock.readLock().unlock();
-    }
 
     private void writeLock() {
         lock.writeLock().lock();

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -257,9 +257,14 @@ message PKafkaOffsetProxyRequest {
     repeated int32 partition_ids = 2;
 }
 
+message PKafkaOffsetBatchProxyRequest {
+    repeated PKafkaOffsetProxyRequest requests = 1;
+}
+
 message PProxyRequest {
     optional PKafkaMetaProxyRequest kafka_meta_request = 1;
     optional PKafkaOffsetProxyRequest kafka_offset_request = 101;
+    optional PKafkaOffsetBatchProxyRequest kafka_offset_batch_request = 102;
 };
 
 message PKafkaMetaProxyResult {
@@ -273,10 +278,15 @@ message PKafkaOffsetProxyResult {
     repeated int64 latest_offsets = 3;
 }
 
+message PKafkaOffsetBatchProxyResult {
+    repeated PKafkaOffsetProxyResult results = 1;
+}
+
 message PProxyResult {
     required PStatus status = 1;
     optional PKafkaMetaProxyResult kafka_meta_result = 2;
     optional PKafkaOffsetProxyResult kafka_offset_result = 101;
+    optional PKafkaOffsetBatchProxyResult kafka_offset_batch_result = 102;
 };
 
 // NOTE(zc): If you want to add new method here,


### PR DESCRIPTION
If you want to use this metric, please set FE config enable_routine_load_lag_metrics to true.
These metrics count the maximum value of all partition lag for each job.
Only show the routine load job whose lag is larger than min_routine_load_lag_for_metrics. The default value of min_routine_load_lag_for_metrics is 10000, and this is a fe config item.

The result is like

starrocks_fe_routine_load_max_lag_of_partition{job_name="routine_load1"} 10200
starrocks_fe_routine_load_max_lag_of_partition{job_name="routine_load2"} 20000
The average response time of the metrics api is 0.2s when 400 tasks are running simultaneously.