### PR TITLE
Improve FE high concurrent performance part 1: reduce lock in BaseGenericObjectPool

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -174,7 +174,7 @@ under the License.
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-pool2</artifactId>
-                <version>2.2</version>
+                <version>2.3</version>
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/commons-net/commons-net -->


### PR DESCRIPTION

For https://github.com/StarRocks/starrocks/issues/2407

<img width="1056" alt="lock" src="https://user-images.githubusercontent.com/9894906/147249124-2da708c2-2bf6-479c-b292-23807d82b2e8.png">

in commons-pool 2.2, the updateStatsReturn method is 

```
    final void updateStatsReturn(long activeTime) {
        this.returnedCount.incrementAndGet();
        synchronized(this.activeTimes) {
            this.activeTimes.add(activeTime);
            this.activeTimes.poll();
        }
    }
```
in commons-pool 2.3, the updateStatsReturn method is 

```
    final void updateStatsReturn(long activeTime) {
        returnedCount.incrementAndGet();
        activeTimes.add(activeTime);
    }
```
So we should upgrade commons-pool to 2.3