### PR TITLE
[ISSUE-2411] Dop adaptation in pipeline engine

### DIFF
--- a/be/src/agent/heartbeat_server.cpp
+++ b/be/src/agent/heartbeat_server.cpp
@@ -63,12 +63,14 @@ void HeartbeatServer::heartbeat(THeartbeatResult& heartbeat_result, const TMaste
     Status st = _heartbeat(master_info);
     st.to_thrift(&heartbeat_result.status);
 
+    static int32_t num_hardware_cores = std::thread::hardware_concurrency();
     if (st.ok()) {
         heartbeat_result.backend_info.__set_be_port(config::be_port);
         heartbeat_result.backend_info.__set_http_port(config::webserver_port);
         heartbeat_result.backend_info.__set_be_rpc_port(-1);
         heartbeat_result.backend_info.__set_brpc_port(config::brpc_port);
         heartbeat_result.backend_info.__set_version(get_short_version());
+        heartbeat_result.backend_info.__set_num_hardware_cores(num_hardware_cores);
     }
 }
 

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -148,8 +148,8 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
     }
 
     int32_t degree_of_parallelism = 1;
-    if (query_options.__isset.pipeline_dop && query_options.pipeline_dop > 0) {
-        degree_of_parallelism = query_options.pipeline_dop;
+    if (request.__isset.pipeline_dop && request.pipeline_dop > 0) {
+        degree_of_parallelism = request.pipeline_dop;
     } else {
         // default dop is a half of the number of hardware threads.
         degree_of_parallelism = std::max<int32_t>(1, std::thread::hardware_concurrency() / 2);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HashJoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HashJoinNode.java
@@ -70,6 +70,7 @@ public class HashJoinNode extends PlanNode {
     private List<Expr> otherJoinConjuncts;
     private boolean isPushDown;
     private DistributionMode distrMode;
+    private DistributionMode pipelineDistrMode = DistributionMode.PARTITIONED;
     private String colocateReason = ""; // if can not do colocate join, set reason here
     // the flag for local bucket shuffle join
     private boolean isLocalHashBucket = false;
@@ -219,6 +220,22 @@ public class HashJoinNode extends PlanNode {
         this.distrMode = distrMode;
     }
 
+    public DistributionMode getDistributionMode() {
+        return this.distrMode;
+    }
+
+    public void setPipelineDistributionMode(DistributionMode pipelineDistrMode) {
+        this.pipelineDistrMode = pipelineDistrMode;
+    }
+
+    public DistributionMode getPipelineDistributionMode() {
+        return this.pipelineDistrMode;
+    }
+
+    public boolean isBroadcast() {
+        return this.distrMode == DistributionMode.BROADCAST;
+    }
+
     public boolean isLocalHashBucket() {
         return isLocalHashBucket;
     }
@@ -360,7 +377,7 @@ public class HashJoinNode extends PlanNode {
         msg.node_type = TPlanNodeType.HASH_JOIN_NODE;
         msg.hash_join_node = new THashJoinNode();
         msg.hash_join_node.join_op = joinOp.toThrift();
-        msg.hash_join_node.distribution_mode = distrMode.toThrift();
+        msg.hash_join_node.distribution_mode = pipelineDistrMode.toThrift();
         StringBuilder sqlJoinPredicatesBuilder = new StringBuilder();
         for (BinaryPredicate eqJoinPredicate : eqJoinConjuncts) {
             TEqJoinCondition eqJoinCondition = new TEqJoinCondition(eqJoinPredicate.getChild(0).treeToThrift(),

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HashJoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HashJoinNode.java
@@ -70,7 +70,6 @@ public class HashJoinNode extends PlanNode {
     private List<Expr> otherJoinConjuncts;
     private boolean isPushDown;
     private DistributionMode distrMode;
-    private DistributionMode pipelineDistrMode = DistributionMode.PARTITIONED;
     private String colocateReason = ""; // if can not do colocate join, set reason here
     // the flag for local bucket shuffle join
     private boolean isLocalHashBucket = false;
@@ -224,14 +223,6 @@ public class HashJoinNode extends PlanNode {
         return this.distrMode;
     }
 
-    public void setPipelineDistributionMode(DistributionMode pipelineDistrMode) {
-        this.pipelineDistrMode = pipelineDistrMode;
-    }
-
-    public DistributionMode getPipelineDistributionMode() {
-        return this.pipelineDistrMode;
-    }
-
     public boolean isBroadcast() {
         return this.distrMode == DistributionMode.BROADCAST;
     }
@@ -377,7 +368,7 @@ public class HashJoinNode extends PlanNode {
         msg.node_type = TPlanNodeType.HASH_JOIN_NODE;
         msg.hash_join_node = new THashJoinNode();
         msg.hash_join_node.join_op = joinOp.toThrift();
-        msg.hash_join_node.distribution_mode = pipelineDistrMode.toThrift();
+        msg.hash_join_node.distribution_mode = distrMode.toThrift();
         StringBuilder sqlJoinPredicatesBuilder = new StringBuilder();
         for (BinaryPredicate eqJoinPredicate : eqJoinConjuncts) {
             TEqJoinCondition eqJoinCondition = new TEqJoinCondition(eqJoinPredicate.getChild(0).treeToThrift(),

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -141,6 +141,8 @@ public class PlanFragment extends TreeNode<PlanFragment> {
         this.dataPartition = partition;
         this.outputPartition = DataPartition.UNPARTITIONED;
         this.transferQueryStatisticsWithEveryBatch = false;
+        // when dop adaptation is enabled, parallelExecNum and pipelineDop set to degreeOfParallelism and 1 respectively
+        // in default. these values just a hint to help determine numInstances and pipelineDop of a PlanFragment.
         setParallelExecNumIfExists();
         setPipelineDopIfPipelineEngineEnabled();
         setFragmentInPlanTree(planRoot);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -40,7 +40,6 @@ import com.starrocks.thrift.TResultSinkType;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import sun.tools.tree.Context;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -123,6 +123,8 @@ public class PlanFragment extends TreeNode<PlanFragment> {
     // specification of the number of parallel when fragment is executed
     // default value is 1
     protected int parallelExecNum = 1;
+    protected int pipelineDop = 1;
+    protected boolean dopEstimated = false;
 
     protected final Map<Integer, RuntimeFilterDescription> buildRuntimeFilters = Maps.newTreeMap();
     protected final Map<Integer, RuntimeFilterDescription> probeRuntimeFilters = Maps.newTreeMap();
@@ -188,6 +190,21 @@ public class PlanFragment extends TreeNode<PlanFragment> {
      */
     public void setParallelExecNum(int parallelExecNum) {
         this.parallelExecNum = parallelExecNum;
+    }
+
+    public void setPipelineDop(int dop) {
+        this.pipelineDop = dop;
+    }
+
+    public int getPipelineDop() {
+        return pipelineDop;
+    }
+
+    public void setDopEstimated() {
+        dopEstimated = true;
+    }
+    public boolean isDopEstimated() {
+        return dopEstimated;
     }
 
     public void setOutputExprs(List<Expr> outputExprs) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -1903,6 +1903,7 @@ public class Coordinator {
                     if (isEnablePipelineEngine) {
                         params.setIs_pipeline(
                                 fragment.getPlanRoot().canUsePipeLine() && fragment.getSink().canUsePipeLine());
+                        params.setPipeline_dop(fragment.getPipelineDop());
                     }
 
                     if (sessionVariable.isEnableExchangePassThrough()) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -541,7 +541,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     }
 
     // when pipeline engine is enabled
-    // in case of pipeline_dop > 0: return pipeline_dop;
+    // in case of pipeline_dop > 0: return pipeline_dop * parallelExecInstanceNum;
     // in case of pipeline_dop <= 0 and avgNumCores < 2: return 1;
     // in case of pipeline_dop <= 0 and avgNumCores >=2; return avgNumCores/2;
     public int getDegreeOfParallelism() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -115,10 +115,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String PIPELINE_DOP = "pipeline_dop";
 
-    public static final String PIPELINE_BROADCAST_BUILD_BYTES_SUP_LIMIT = "pipeline_broadcast_build_bytes_sup_limit";
-
-    public static final String PIPELINE_BROADCAST_PROBE_BYTES_INF_LIMIT = "pipeline_broadcast_probe_bytes_inf_limit";
-
     public static final String PIPELINE_PROFILE_MODE = "pipeline_profile_mode";
 
     // hash join right table push down
@@ -312,12 +308,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = PIPELINE_DOP)
     private int pipelineDop = 0;
-
-    @VariableMgr.VarAttr(name = PIPELINE_BROADCAST_BUILD_BYTES_SUP_LIMIT)
-    private long pipelineBroadcastBuildBytesSupLimit = 67108864;
-
-    @VariableMgr.VarAttr(name = PIPELINE_BROADCAST_PROBE_BYTES_INF_LIMIT)
-    private long pipelineBroadCastProbeBytesInfLimit = 67108864;
 
     @VariableMgr.VarAttr(name = PIPELINE_PROFILE_MODE)
     private String pipelineProfileMode = "brief";
@@ -546,11 +536,15 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return disableColocateJoin;
     }
 
+    public int getParallelExecInstanceNum() {
+        return parallelExecInstanceNum;
+    }
+
     // when pipeline engine is enabled
     // in case of pipeline_dop > 0: return pipeline_dop;
     // in case of pipeline_dop <= 0 and avgNumCores < 2: return 1;
     // in case of pipeline_dop <= 0 and avgNumCores >=2; return avgNumCores/2;
-    public int getParallelExecInstanceNum() {
+    public int getDegreeOfParallelism() {
         if (enablePipelineEngine) {
             if (pipelineDop > 0) {
                 return pipelineDop;
@@ -710,20 +704,16 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return enablePipelineEngine;
     }
 
+    public boolean isPipelineDopAdaptionEnabled() {
+        return enablePipelineEngine && pipelineDop <= 0;
+    }
+
     public void setEnablePipelineEngine(boolean enablePipelineEngine) {
         this.enablePipelineEngine = enablePipelineEngine;
     }
 
     public int getPipelineDop() {
         return this.pipelineDop;
-    }
-
-    public long getPipelineBroadCastBuildBytesSupLimit() {
-        return this.pipelineBroadcastBuildBytesSupLimit;
-    }
-
-    public long getPipelineBroadCastProbeBytesInfLimit() {
-        return this.pipelineBroadCastProbeBytesInfLimit;
     }
 
     public boolean isEnableReplicationJoin() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -547,7 +547,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public int getDegreeOfParallelism() {
         if (enablePipelineEngine) {
             if (pipelineDop > 0) {
-                return pipelineDop;
+                return pipelineDop * parallelExecInstanceNum;
             }
             int avgNumOfCores = BackendCoreStat.getAvgNumOfHardwareCoresOfBe();
             return avgNumOfCores < 2 ? 1 : avgNumOfCores / 2;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
@@ -290,7 +290,7 @@ public class CostModel {
         }
 
         private int getParallelExecInstanceNum(ExpressionContext context) {
-            return Math.min(ConnectContext.get().getSessionVariable().getParallelExecInstanceNum(),
+            return Math.min(ConnectContext.get().getSessionVariable().getDegreeOfParallelism(),
                     context.getRootProperty().getLeftMostScanTabletsNum());
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
@@ -268,22 +268,13 @@ public class CostModel {
                         return CostEstimate.infinite();
                     }
                     int parallelExecInstanceNum = Math.max(1, getParallelExecInstanceNum(context));
-                    int pipelineDop = 1;
-                    if (sessionVariable.isEnablePipelineEngine()) {
-                        // pipelineDop is 0 means that the query executed in pipeline engine use the half number of cpu
-                        // cores, we use 32 as an estimate value
-                        // todo(ywb) we need to get BE cpu cores from BE heartbeat.
-                        pipelineDop = sessionVariable.getPipelineDop() > 0 ? sessionVariable.getPipelineDop() : 32;
-                    }
                     // beNum is the number of right table should broadcast, now use alive backends
                     int beNum = Math.max(1, Catalog.getCurrentSystemInfo().getBackendIds(true).size());
                     result = CostEstimate
                             .of(statistics.getOutputSize(outputColumns) *
                                             Catalog.getCurrentSystemInfo().getBackendIds(true).size(),
-                                    statistics.getOutputSize(outputColumns) * beNum * parallelExecInstanceNum *
-                                            pipelineDop,
-                                    statistics.getOutputSize(outputColumns) * beNum * parallelExecInstanceNum *
-                                            pipelineDop);
+                                    statistics.getOutputSize(outputColumns) * beNum * parallelExecInstanceNum,
+                                    statistics.getOutputSize(outputColumns) * beNum * parallelExecInstanceNum);
                     break;
                 case SHUFFLE:
                 case GATHER:

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/EnforceAndCostTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/EnforceAndCostTask.java
@@ -224,7 +224,7 @@ public class EnforceAndCostTask extends OptimizerTask implements Cloneable {
         // shuffling large left-hand table data
         int parallelExecInstance = Math.max(1,
                 Math.min(groupExpression.getGroup().getLogicalProperty().getLeftMostScanTabletsNum(),
-                        ConnectContext.get().getSessionVariable().getParallelExecInstanceNum()));
+                        ConnectContext.get().getSessionVariable().getDegreeOfParallelism()));
         int beNum = Math.max(1, Catalog.getCurrentSystemInfo().getBackendIds(true).size());
         Statistics leftChildStats = groupExpression.getInputs().get(curChildIndex - 1).getStatistics();
         Statistics rightChildStats = groupExpression.getInputs().get(curChildIndex).getStatistics();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1263,7 +1263,9 @@ public class PlanFragmentBuilder {
         }
 
         private void estimateDopOfBroadcastJoinInPipeline(PlanFragment fragment) {
-            if (ConnectContext.get() == null || !ConnectContext.get().getSessionVariable().isEnablePipelineEngine()) {
+            if (ConnectContext.get() == null ||
+                    !ConnectContext.get().getSessionVariable().isEnablePipelineEngine() ||
+                    ConnectContext.get().getSessionVariable().getPipelineDop() > 0) {
                 return;
             }
             if (fragment.isDopEstimated()) {
@@ -1272,115 +1274,13 @@ public class PlanFragmentBuilder {
             Preconditions.checkArgument(fragment.getPlanRoot() instanceof HashJoinNode);
             HashJoinNode hashJoinNode = (HashJoinNode) fragment.getPlanRoot();
             HashJoinNode.DistributionMode distributionMode = hashJoinNode.getDistributionMode();
-            if (!distributionMode.equals(HashJoinNode.DistributionMode.BROADCAST) ||
+            if (!distributionMode.equals(HashJoinNode.DistributionMode.BROADCAST) &&
                     !distributionMode.equals(HashJoinNode.DistributionMode.REPLICATED)) {
                 return;
             }
-            final long buildBytesSupLimit = ConnectContext.get().getSessionVariable().getPipelineBroadCastBuildBytesSupLimit();
-            final long probeBytesInfLimit = ConnectContext.get().getSessionVariable().getPipelineBroadCastProbeBytesInfLimit();
-            final int defaultDop = fragment.getParallelExecNum();
-
-            PlanNode leftNode = hashJoinNode.getChild(0);
-            PlanNode rightNode = hashJoinNode.getChild(1);
-            int bestInstanceNum = defaultDop;
-            int bestDop = 1;
-            HashJoinNode.DistributionMode bestDistributionMode = HashJoinNode.DistributionMode.BROADCAST;
-
-            double cost = Double.MAX_VALUE;
-            long leftRowCount = leftNode.getLimit() == -1 ? leftNode.getCardinality()
-                    : Math.min(leftNode.getLimit(), leftNode.getCardinality());
-            double leftCost = leftRowCount * leftNode.getAvgRowSize();
-            long rightRowCount = rightNode.getLimit() == -1 ? rightNode.getCardinality()
-                    : Math.min(rightNode.getLimit(), rightNode.getCardinality());
-            double rightCost = rightRowCount * rightNode.getAvgRowSize();
-
-            // case 1: instance_num=1, dop=1..defaultDop, local shuffle join
-            // CPU_COST = COST(RIGHT)/DOP + COST(LEFT)/DOP + COST(RIGHT)/DOP + COST(LEFT)/DOP
-            // MEM_COST = COST(RIGHT) + COST(LEFT)
-            double memCost = rightCost;
-            if (memCost <= buildBytesSupLimit) {
-                for (int dop = 1; dop <= defaultDop; ++dop) {
-                    if (leftCost > probeBytesInfLimit && leftCost / dop > probeBytesInfLimit) {
-                        continue;
-                    }
-                    double cpuCost = (rightCost / dop + leftCost / dop) * 2;
-                    if (cpuCost < cost) {
-                        cost = cpuCost;
-                        bestInstanceNum = 1;
-                        bestDop = dop;
-                        bestDistributionMode = HashJoinNode.DistributionMode.PARTITIONED;
-                    }
-                }
-            }
-
-            // case 2: instance_num=1..defaultDop, dop=1, local broadcast join
-            // CPU_COST = COST(RIGHT)/N + COST(LEFT)/N
-            // CPU_COST = COST(RIGHT)*N + COST(LEFT)
-            for (int instanceNum = 1; instanceNum <= defaultDop; ++instanceNum) {
-                memCost = rightCost * instanceNum;
-                if (memCost > buildBytesSupLimit) {
-                    continue;
-                }
-                if (leftCost > probeBytesInfLimit && leftCost / instanceNum > probeBytesInfLimit) {
-                    continue;
-                }
-                double cpuCost = rightCost / instanceNum + leftCost / instanceNum;
-                if (cpuCost < cost) {
-                    cost = cpuCost;
-                    bestInstanceNum = instanceNum;
-                    bestDop = 1;
-                    bestDistributionMode = HashJoinNode.DistributionMode.BROADCAST;
-                }
-            }
-
-            // case 3: instance_num=1..defaultDop, dop=defaultDop/instance_num, local shuffle join
-            // CPU_COST: COST(RIGHT)/N/DOP + COST(LEFT)/N/DOP + COST(RIGHT)/N + COST(LEFT)/N
-            // MEM_COST: COST(RIGHT) + COST(LEFT)
-            for (int instanceNum = 1; instanceNum <= defaultDop; ++instanceNum) {
-                for (int dop = defaultDop; dop > 0; --dop) {
-                    memCost = rightCost * instanceNum;
-                    if (memCost > buildBytesSupLimit) {
-                        continue;
-                    }
-                    if (leftCost > probeBytesInfLimit && leftCost / instanceNum > probeBytesInfLimit) {
-                        continue;
-                    }
-                    double cpuCost = rightCost / instanceNum / dop + leftCost / instanceNum / dop
-                            + rightCost / instanceNum + leftCost / instanceNum;
-                    if (cpuCost < cost) {
-                        cost = cpuCost;
-                        bestInstanceNum = instanceNum;
-                        bestDop = dop;
-                        bestDistributionMode = HashJoinNode.DistributionMode.PARTITIONED;
-                    }
-                }
-            }
-
-            // case 4: instance_num=1..defaultDop, dop=defaultDop/instance_num, local broadcast join
-            // CPU_COST: COST(RIGHT)/N + COST(LEFT)/N/DOP
-            // MEM_COST: COST(RIGHT)*N*DOP +COST(LEFT)
-            for (int instanceNum = 1; instanceNum <= defaultDop; ++instanceNum) {
-                for (int dop = defaultDop; dop > 0; --dop) {
-                    memCost = rightCost * instanceNum * dop;
-                    if (memCost > buildBytesSupLimit) {
-                        continue;
-                    }
-                    if (leftCost > probeBytesInfLimit && leftCost / instanceNum > probeBytesInfLimit) {
-                        continue;
-                    }
-                    double cpuCost = rightCost / instanceNum + leftCost / instanceNum / dop;
-                    if (cpuCost < cost) {
-                        cost = cpuCost;
-                        bestInstanceNum = instanceNum;
-                        bestDop = dop;
-                        bestDistributionMode = HashJoinNode.DistributionMode.BROADCAST;
-                    }
-                }
-            }
-            fragment.setParallelExecNum(bestInstanceNum);
-            fragment.setPipelineDop(bestDop);
+            fragment.setPipelineDop(fragment.getParallelExecNum());
+            fragment.setParallelExecNum(1);
             fragment.setDopEstimated();
-            hashJoinNode.setPipelineDistributionMode(bestDistributionMode);
         }
 
         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/system/BackendCoreStat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/BackendCoreStat.java
@@ -2,8 +2,6 @@
 
 package com.starrocks.system;
 
-import java.util.Collections;
-import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -24,16 +22,16 @@ public class BackendCoreStat {
         }
 
         cachedAvgNumOfHardwareCores.compareAndSet(snapshotAvg, 0);
-        List<Integer> numCoresList = Collections.emptyList();
-        numCoresList.addAll(numOfHardwareCoresPerBe.values());
-        if (numCoresList.size() == 0) {
+        Integer[] numCoresArray = new Integer[0];
+        numCoresArray = numOfHardwareCoresPerBe.values().toArray(numCoresArray);
+        if (numCoresArray.length == 0) {
             return -1;
         }
         int sum = 0;
-        for (Integer v : numCoresList) {
+        for (Integer v : numCoresArray) {
             sum += v;
         }
-        int newAvg = sum / numCoresList.size();
+        int newAvg = sum / numCoresArray.length;
         snapshotAvg = 0;
         // Update the cached value if numOfHardwareCoresPerBe is changed(cachedAvgNumOfHardwareCores = -1)
         cachedAvgNumOfHardwareCores.compareAndSet(snapshotAvg, newAvg);

--- a/fe/fe-core/src/main/java/com/starrocks/system/BackendCoreStat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/BackendCoreStat.java
@@ -1,0 +1,42 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+package com.starrocks.system;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class BackendCoreStat {
+    private static ConcurrentHashMap<Long, Integer> numOfHardwareCoresPerBe = new ConcurrentHashMap<>();
+    private static AtomicInteger cachedAvgNumOfHardwareCores = new AtomicInteger(-1);
+
+    public static void setNumOfHardwareCoresOfBe(long be, int numOfCores) {
+        if (numOfHardwareCoresPerBe.putIfAbsent(be, numOfCores) == null) {
+            cachedAvgNumOfHardwareCores.set(-1);
+        }
+    }
+
+    public static int getAvgNumOfHardwareCoresOfBe() {
+        int snapshotAvg = cachedAvgNumOfHardwareCores.get();
+        if (snapshotAvg > 0) {
+            return snapshotAvg;
+        }
+
+        cachedAvgNumOfHardwareCores.compareAndSet(snapshotAvg, 0);
+        List<Integer> numCoresList = Collections.emptyList();
+        numCoresList.addAll(numOfHardwareCoresPerBe.values());
+        if (numCoresList.size() == 0) {
+            return -1;
+        }
+        int sum = 0;
+        for (Integer v : numCoresList) {
+            sum += v;
+        }
+        int newAvg = sum / numCoresList.size();
+        snapshotAvg = 0;
+        // Update the cached value if numOfHardwareCoresPerBe is changed(cachedAvgNumOfHardwareCores = -1)
+        cachedAvgNumOfHardwareCores.compareAndSet(snapshotAvg, newAvg);
+        return newAvg;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
@@ -248,6 +248,11 @@ public class HeartbeatMgr extends MasterDaemon {
                         version = tBackendInfo.getVersion();
                     }
 
+                    // Update number of hardare of cores of corresponding backend.
+                    if (tBackendInfo.isSetNum_hardware_cores()) {
+                        BackendCoreStat.setNumOfHardwareCoresOfBe(backendId, tBackendInfo.getNum_hardware_cores());
+                    }
+
                     // backend.updateOnce(bePort, httpPort, beRpcPort, brpcPort);
                     return new BackendHbResponse(backendId, bePort, httpPort, brpcPort, System.currentTimeMillis(),
                             version);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
@@ -84,10 +84,10 @@ public class CTEPlanTest extends PlanTestBase {
 
         Assert.assertTrue(plan.contains("  STREAM DATA SINK\n" +
                 "    EXCHANGE ID: 01\n" +
-                "    HASH_PARTITIONED: 4: v1\n" +
+                "    UNPARTITIONED\n" +
                 "  STREAM DATA SINK\n" +
-                "    EXCHANGE ID: 04\n" +
-                "    HASH_PARTITIONED: 7: v1\n"));
+                "    EXCHANGE ID: 03\n" +
+                "    UNPARTITIONED\n"));
 
         connectContext.getSessionVariable().setMaxTransformReorderJoins(4);
     }

--- a/gensrc/thrift/HeartbeatService.thrift
+++ b/gensrc/thrift/HeartbeatService.thrift
@@ -37,6 +37,7 @@ struct TBackendInfo {
     3: optional Types.TPort be_rpc_port
     4: optional Types.TPort brpc_port
     5: optional string version
+    6: optional i32 num_hardware_cores
 }
 
 struct THeartbeatResult {

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -294,6 +294,7 @@ struct TExecPlanFragmentParams {
   14: optional TLoadErrorHubInfo load_error_hub_info
 
   50: optional bool is_pipeline
+  51: optional i32 pipeline_dop
 }
 
 struct TExecPlanFragmentResult {


### PR DESCRIPTION
## Enhancement

Setting appropriate values of pipeline_dop and parallel_fragment_exec_instance_num is trial-and-error, so planner in FE set these two parameters according to cost estimation of PlanNode.

The session variable parallel_fragment_exec_instance_num is not adopted when dop adaption enabled(pipeline_dop==0 && enable_pipeline_engine==true).

When dop adapation enabled, for a PlanFragment, in default:
1. parallelExecNum is set to DegreeOfParallelism(half the average number of hardware cores of backends) instead of parallel_fragment_exec_instance_num, 
2. pipelineDop is set to 1.
3. pipelineDop * parallelExecNum <= DegreeOfParallelism

For broadcast/replicated join, fragment instance parallelization is adopted, so set (parallelExecNum, pipelineDop) to (DegreeOfParallelism,1).
For an PlanFragment whose left-deepmost child is ExchangeNode, its child PlanFragment that has the maximum numInstances * pipelineDop is taken into consideration, if the child PlanFragment's DataSink is partitioned, then pipeline paralellization is adopted, otherwise fragment instance parallelization is adopted.

For an PlanFragment whose left-deepmost child is ScanNode, parallelExecNum is predetermined in PlanFragmentBuilder, only the pipelineDop is adjusted to guarantee that  pipelineDop * parallelExecNum <= DegreeOfParallelism.
