### PR TITLE
Fix the bug of process mem_pool alloc failed

### DIFF
--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -340,4 +340,11 @@ inline std::ostream& operator<<(std::ostream& os, const Status& st) {
         }                             \
     } while (0)
 
+#define THROW_BAD_ALLOC_IF_NULL(ptr)    \
+    do {                                \
+        if (UNLIKELY(ptr == nullptr)) { \
+            throw std::bad_alloc();     \
+        }                               \
+    } while (0)
+
 #define WARN_UNUSED_RESULT __attribute__((warn_unused_result))

--- a/be/src/exec/vectorized/aggregate/agg_hash_map.h
+++ b/be/src/exec/vectorized/aggregate/agg_hash_map.h
@@ -288,7 +288,7 @@ struct AggHashMapWithOneStringKey {
             auto iter = hash_map.lazy_emplace_with_hash(key, hash_values[i], [&](const auto& ctor) {
                 // we must persist the slice before insert
                 uint8_t* pos = pool->allocate(key.size);
-                assert(pos != nullptr);
+                THROW_BAD_ALLOC_IF_NULL(pos);
                 strings::memcpy_inlined(pos, key.data, key.size);
                 Slice pk{pos, key.size};
                 AggDataPtr pv = allocate_func();
@@ -357,7 +357,7 @@ struct AggHashMapWithOneNullableStringKey {
                     auto key = data_column->get_slice(i);
                     auto iter = hash_map.lazy_emplace_with_hash(key, hash_values[i], [&](const auto& ctor) {
                         uint8_t* pos = pool->allocate(key.size);
-                        assert(pos != nullptr);
+                        THROW_BAD_ALLOC_IF_NULL(pos);
                         strings::memcpy_inlined(pos, key.data, key.size);
                         Slice pk{pos, key.size};
                         AggDataPtr pv = allocate_func();
@@ -427,7 +427,7 @@ struct AggHashMapWithOneNullableStringKey {
         auto key = data_column->get_slice(row);
         auto iter = hash_map.lazy_emplace(key, [&](const auto& ctor) {
             uint8_t* pos = pool->allocate(key.size);
-            assert(pos != nullptr);
+            THROW_BAD_ALLOC_IF_NULL(pos);
             strings::memcpy_inlined(pos, key.data, key.size);
             Slice pk{pos, key.size};
             AggDataPtr pv = allocate_func();
@@ -469,7 +469,7 @@ struct AggHashMapWithSerializedKey {
     AggHashMapWithSerializedKey()
             : mem_pool(std::make_unique<MemPool>()),
               buffer(mem_pool->allocate(max_one_row_size * config::vector_chunk_size)) {
-        assert(buffer != nullptr);
+        THROW_BAD_ALLOC_IF_NULL(buffer);
     }
 
     template <typename Func>
@@ -484,7 +484,7 @@ struct AggHashMapWithSerializedKey {
             // reserved extra SLICE_MEMEQUAL_OVERFLOW_PADDING bytes to prevent SIMD instructions
             // from accessing out-of-bound memory.
             buffer = mem_pool->allocate(max_one_row_size * config::vector_chunk_size + SLICE_MEMEQUAL_OVERFLOW_PADDING);
-            assert(buffer != nullptr);
+            THROW_BAD_ALLOC_IF_NULL(buffer);
         }
 
         for (const auto& key_column : key_columns) {
@@ -496,7 +496,7 @@ struct AggHashMapWithSerializedKey {
             auto iter = hash_map.lazy_emplace(key, [&](const auto& ctor) {
                 // we must persist the slice before insert
                 uint8_t* pos = pool->allocate(key.size);
-                assert(pos != nullptr);
+                THROW_BAD_ALLOC_IF_NULL(pos);
                 strings::memcpy_inlined(pos, key.data, key.size);
                 Slice pk{pos, key.size};
                 AggDataPtr pv = allocate_func();
@@ -519,7 +519,7 @@ struct AggHashMapWithSerializedKey {
             max_one_row_size = cur_max_one_row_size;
             mem_pool->clear();
             buffer = mem_pool->allocate(max_one_row_size * config::vector_chunk_size);
-            assert(buffer != nullptr);
+            THROW_BAD_ALLOC_IF_NULL(buffer);
         }
 
         for (const auto& key_column : key_columns) {

--- a/be/src/exec/vectorized/aggregate/agg_hash_set.h
+++ b/be/src/exec/vectorized/aggregate/agg_hash_set.h
@@ -191,7 +191,7 @@ struct AggHashSetOfOneStringKey {
             hash_set.lazy_emplace(key, [&](const auto& ctor) {
                 // we must persist the slice before insert
                 uint8_t* pos = pool->allocate(key.size);
-                assert(pos != nullptr);
+                THROW_BAD_ALLOC_IF_NULL(pos);
                 memcpy(pos, key.data, key.size);
                 ctor(pos, key.size, key.hash);
             });
@@ -287,7 +287,7 @@ struct AggHashSetOfOneNullableStringKey {
 
         hash_set.lazy_emplace(key, [&](const auto& ctor) {
             uint8_t* pos = pool->allocate(key.size);
-            assert(pos != nullptr);
+            THROW_BAD_ALLOC_IF_NULL(pos);
             memcpy(pos, key.data, key.size);
             ctor(pos, key.size, key.hash);
         });
@@ -322,7 +322,7 @@ struct AggHashSetOfSerializedKey {
     AggHashSetOfSerializedKey()
             : _mem_pool(std::make_unique<MemPool>()),
               _buffer(_mem_pool->allocate(max_one_row_size * config::vector_chunk_size)) {
-        assert(_buffer != nullptr);
+        THROW_BAD_ALLOC_IF_NULL(_buffer);
     }
 
     void build_set(size_t chunk_size, const Columns& key_columns, MemPool* pool) {
@@ -336,7 +336,7 @@ struct AggHashSetOfSerializedKey {
             // from accessing out-of-bound memory.
             _buffer =
                     _mem_pool->allocate(max_one_row_size * config::vector_chunk_size + SLICE_MEMEQUAL_OVERFLOW_PADDING);
-            assert(_buffer != nullptr);
+            THROW_BAD_ALLOC_IF_NULL(_buffer);
         }
 
         for (const auto& key_column : key_columns) {
@@ -350,7 +350,7 @@ struct AggHashSetOfSerializedKey {
             hash_set.lazy_emplace(key, [&](const auto& ctor) {
                 // we must persist the slice before insert
                 uint8_t* pos = pool->allocate(key.size);
-                assert(pos != nullptr);
+                THROW_BAD_ALLOC_IF_NULL(pos);
                 memcpy(pos, key.data, key.size);
                 ctor(pos, key.size, key.hash);
             });
@@ -368,7 +368,7 @@ struct AggHashSetOfSerializedKey {
             max_one_row_size = cur_max_one_row_size;
             _mem_pool->clear();
             _buffer = _mem_pool->allocate(max_one_row_size * config::vector_chunk_size);
-            assert(_buffer != nullptr);
+            THROW_BAD_ALLOC_IF_NULL(_buffer);
         }
 
         for (const auto& key_column : key_columns) {
@@ -436,7 +436,7 @@ struct AggHashSetOfSerializedKeyFixedSize {
     AggHashSetOfSerializedKeyFixedSize()
             : _mem_pool(std::make_unique<MemPool>()),
               buffer(_mem_pool->allocate(max_fixed_size * config::vector_chunk_size)) {
-        assert(buffer != nullptr);
+        THROW_BAD_ALLOC_IF_NULL(buffer);
         memset(buffer, 0x0, max_fixed_size * config::vector_chunk_size);
     }
 

--- a/be/src/exec/vectorized/aggregator.cpp
+++ b/be/src/exec/vectorized/aggregator.cpp
@@ -3,6 +3,7 @@
 #include "aggregator.h"
 
 #include "exprs/anyval_util.h"
+#include "runtime/current_thread.h"
 
 namespace starrocks {
 
@@ -209,9 +210,9 @@ Status Aggregator::prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile
     // For SQL: select distinct id from table or select id from from table group by id;
     // we don't need to allocate memory for agg states.
     if (_is_only_group_by_columns) {
-        _init_agg_hash_variant(_hash_set_variant);
+        TRY_CATCH_BAD_ALLOC(_init_agg_hash_variant(_hash_set_variant));
     } else {
-        _init_agg_hash_variant(_hash_map_variant);
+        TRY_CATCH_BAD_ALLOC(_init_agg_hash_variant(_hash_map_variant));
     }
 
     return Status::OK();

--- a/be/src/exec/vectorized/aggregator.h
+++ b/be/src/exec/vectorized/aggregator.h
@@ -261,6 +261,7 @@ public:
                 [this]() {
                     vectorized::AggDataPtr agg_state =
                             _mem_pool->allocate_aligned(_agg_states_total_size, _max_agg_state_align_size);
+                    THROW_BAD_ALLOC_IF_NULL(agg_state);
                     for (int i = 0; i < _agg_functions.size(); i++) {
                         _agg_functions[i]->create(agg_state + _agg_states_offsets[i]);
                     }
@@ -276,6 +277,7 @@ public:
                 [this]() {
                     vectorized::AggDataPtr agg_state =
                             _mem_pool->allocate_aligned(_agg_states_total_size, _max_agg_state_align_size);
+                    THROW_BAD_ALLOC_IF_NULL(agg_state);
                     for (int i = 0; i < _agg_functions.size(); i++) {
                         _agg_functions[i]->create(agg_state + _agg_states_offsets[i]);
                     }


### PR DESCRIPTION
Should throw std::bad_alloc if alloc failed, the bad::alloc exception has already catched in build_hash_set/build_hash_map