### PR TITLE
check hash_map_with_key nullable before release agg memory

### DIFF
--- a/be/src/exec/vectorized/aggregator.cpp
+++ b/be/src/exec/vectorized/aggregator.cpp
@@ -199,6 +199,7 @@ Status Aggregator::prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile
 
     if (_group_by_expr_ctxs.empty()) {
         _single_agg_state = _mem_pool->allocate_aligned(_agg_states_total_size, _max_agg_state_align_size);
+        THROW_BAD_ALLOC_IF_NULL(_single_agg_state);
         for (int i = 0; i < _agg_functions.size(); i++) {
             _agg_functions[i]->create(_single_agg_state + _agg_states_offsets[i]);
         }
@@ -243,7 +244,7 @@ Status Aggregator::close(RuntimeState* state) {
             }
 #define HASH_MAP_METHOD(NAME)                                                  \
     else if (_hash_map_variant.type == vectorized::HashMapVariant::Type::NAME) \
-            _release_agg_memory<decltype(_hash_map_variant.NAME)::element_type>(*_hash_map_variant.NAME);
+            _release_agg_memory<decltype(_hash_map_variant.NAME)::element_type>(_hash_map_variant.NAME.get());
             APPLY_FOR_VARIANT_ALL(HASH_MAP_METHOD)
 #undef HASH_MAP_METHOD
         }

--- a/be/src/exec/vectorized/aggregator.h
+++ b/be/src/exec/vectorized/aggregator.h
@@ -472,14 +472,16 @@ private:
     void _init_agg_hash_variant(HashVariantType& hash_variant);
 
     template <typename HashMapWithKey>
-    void _release_agg_memory(HashMapWithKey& hash_map_with_key) {
-        auto it = hash_map_with_key.hash_map.begin();
-        auto end = hash_map_with_key.hash_map.end();
-        while (it != end) {
-            for (int i = 0; i < _agg_functions.size(); i++) {
-                _agg_functions[i]->destroy(it->second + _agg_states_offsets[i]);
+    void _release_agg_memory(HashMapWithKey* hash_map_with_key) {
+        if (hash_map_with_key != nullptr) {
+            auto it = hash_map_with_key.hash_map.begin();
+            auto end = hash_map_with_key.hash_map.end();
+            while (it != end) {
+                for (int i = 0; i < _agg_functions.size(); i++) {
+                    _agg_functions[i]->destroy(it->second + _agg_states_offsets[i]);
+                }
+                ++it;
             }
-            ++it;
         }
     }
 };

--- a/be/src/exec/vectorized/aggregator.h
+++ b/be/src/exec/vectorized/aggregator.h
@@ -474,8 +474,8 @@ private:
     template <typename HashMapWithKey>
     void _release_agg_memory(HashMapWithKey* hash_map_with_key) {
         if (hash_map_with_key != nullptr) {
-            auto it = hash_map_with_key.hash_map.begin();
-            auto end = hash_map_with_key.hash_map.end();
+            auto it = hash_map_with_key->hash_map.begin();
+            auto end = hash_map_with_key->hash_map.end();
             while (it != end) {
                 for (int i = 0; i < _agg_functions.size(); i++) {
                     _agg_functions[i]->destroy(it->second + _agg_states_offsets[i]);


### PR DESCRIPTION
Should throw std::bad_alloc if alloc failed, the bad::alloc exception has already catched in build_hash_set/build_hash_map

should check hash_map_with_key is null or not before release agg memory