### PR TITLE
Improve FE high concurrent performance part 2: Improve newSessionVariable

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/VariableMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/VariableMgr.java
@@ -38,7 +38,6 @@ import com.starrocks.common.FeMetaVersion;
 import com.starrocks.common.PatternMatcher;
 import com.starrocks.persist.EditLog;
 import com.starrocks.persist.GlobalVarPersistInfo;
-import org.apache.commons.lang.SerializationUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -227,12 +226,12 @@ public class VariableMgr {
     }
 
     public static SessionVariable newSessionVariable() {
-        wlock.lock();
         try {
-            return (SessionVariable) SerializationUtils.clone(defaultSessionVariable);
-        } finally {
-            wlock.unlock();
+            return (SessionVariable) defaultSessionVariable.clone();
+        } catch (CloneNotSupportedException e) {
+            LOG.warn(e);
         }
+        return null;
     }
 
     // Check if this setVar can be set correctly


### PR DESCRIPTION
https://github.com/StarRocks/starrocks/issues/2407

When new ConnectContext, we need new newSessionVariable. but `VariableMgr.newSessionVariable()` hash lock and performance is bad

```
    public ConnectContext() {
        state = new QueryState();
        returnRows = 0;
        serverCapability = MysqlCapability.DEFAULT_CAPABILITY;
        isKilled = false;
        serializer = MysqlSerializer.newInstance();
        sessionVariable = VariableMgr.newSessionVariable();
```

Two improve points:

1. Remove lock, which is safe
2. Use `clone` instead of `SerializationUtils.clone`,  `SerializationUtils.clone` performance is bad.