### PR TITLE
Fix early deallocation `pass_through_chunk_buffer` using ref count

### DIFF
--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -41,7 +41,7 @@ public:
     // when data is added via add_row() and not sent directly via send_batch().
     Channel(ExchangeSinkOperator* parent, const TNetworkAddress& brpc_dest, const TUniqueId& fragment_instance_id,
             PlanNodeId dest_node_id, size_t channel_id, bool enable_exchange_pass_through,
-            const PassThroughChunkBufferPtr& pass_through_chunk_buffer)
+            PassThroughChunkBuffer* pass_through_chunk_buffer)
             : _parent(parent),
               _fragment_instance_id(fragment_instance_id),
               _dest_node_id(dest_node_id),
@@ -270,7 +270,8 @@ ExchangeSinkOperator::ExchangeSinkOperator(OperatorFactory* factory, int32_t id,
           _fragment_ctx(fragment_ctx) {
     std::map<int64_t, int64_t> fragment_id_to_channel_index;
     RuntimeState* state = fragment_ctx->runtime_state();
-    auto pass_through_chunk_buffer = state->exec_env()->stream_mgr()->get_pass_through_chunk_buffer(state->query_id());
+    PassThroughChunkBuffer* pass_through_chunk_buffer =
+            state->exec_env()->stream_mgr()->get_pass_through_chunk_buffer(state->query_id());
 
     // fragment_instance_id.lo == -1 indicates that the destination is pseudo for bucket shuffle join.
     std::optional<std::shared_ptr<Channel>> pseudo_channel;

--- a/be/src/exec/pipeline/fragment_context.cpp
+++ b/be/src/exec/pipeline/fragment_context.cpp
@@ -1,6 +1,9 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
 
 #include "exec/pipeline/fragment_context.h"
+
+#include "runtime/data_stream_mgr.h"
+#include "runtime/exec_env.h"
 namespace starrocks::pipeline {
 
 FragmentContext* FragmentContextManager::get_or_register(const TUniqueId& fragment_id) {
@@ -50,6 +53,12 @@ void FragmentContextManager::cancel(const Status& status) {
     for (auto& _fragment_context : _fragment_contexts) {
         _fragment_context.second->cancel(status);
     }
+}
+void FragmentContext::prepare_pass_through_chunk_buffer() {
+    _runtime_state->exec_env()->stream_mgr()->prepare_pass_through_chunk_buffer(_query_id);
+}
+void FragmentContext::destroy_pass_through_chunk_buffer() {
+    _runtime_state->exec_env()->stream_mgr()->destroy_pass_through_chunk_buffer(_query_id);
 }
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/fragment_context.h
+++ b/be/src/exec/pipeline/fragment_context.h
@@ -116,6 +116,9 @@ public:
 
     RuntimeFilterPort* runtime_filter_port() { return _runtime_state->runtime_filter_port(); }
 
+    void prepare_pass_through_chunk_buffer();
+    void destroy_pass_through_chunk_buffer();
+
 private:
     // Id of this query
     TUniqueId _query_id;

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -118,7 +118,7 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
         exec_env->runtime_filter_worker()->open_query(query_id, request.query_options, params.runtime_filter_params,
                                                       true);
     }
-    _query_ctx->prepare_pass_through_chunk_buffer();
+    _fragment_ctx->prepare_pass_through_chunk_buffer();
 
     // Set up desc tbl
     auto* obj_pool = runtime_state->obj_pool();

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -118,7 +118,7 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
         exec_env->runtime_filter_worker()->open_query(query_id, request.query_options, params.runtime_filter_params,
                                                       true);
     }
-    exec_env->stream_mgr()->prepare_pass_through_chunk_buffer(query_id);
+    _query_ctx->prepare_pass_through_chunk_buffer();
 
     // Set up desc tbl
     auto* obj_pool = runtime_state->obj_pool();

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -311,6 +311,7 @@ void PipelineDriver::finalize(RuntimeState* runtime_state, DriverState state) {
     // last finished driver notify FE the fragment's completion again and
     // unregister the FragmentContext.
     if (_fragment_ctx->count_down_drivers()) {
+        _fragment_ctx->destroy_pass_through_chunk_buffer();
         auto status = _fragment_ctx->final_status();
         auto fragment_id = _fragment_ctx->fragment_instance_id();
         _query_ctx->count_down_fragments();

--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -29,6 +29,12 @@ void QueryContext::cancel(const Status& status) {
     _fragment_mgr->cancel(status);
 }
 
+void QueryContext::prepare_pass_through_chunk_buffer() {
+    if (_exec_env != nullptr) {
+        _exec_env->stream_mgr()->prepare_pass_through_chunk_buffer(_query_id);
+    }
+}
+
 QueryContextManager::QueryContextManager() = default;
 QueryContextManager::~QueryContextManager() = default;
 QueryContext* QueryContextManager::get_or_register(const TUniqueId& query_id) {

--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -18,7 +18,6 @@ QueryContext::~QueryContext() {
         if (_is_runtime_filter_coordinator) {
             _exec_env->runtime_filter_worker()->close_query(_query_id);
         }
-        _exec_env->stream_mgr()->destroy_pass_through_chunk_buffer(_query_id);
     }
 }
 FragmentContextManager* QueryContext::fragment_mgr() {
@@ -27,12 +26,6 @@ FragmentContextManager* QueryContext::fragment_mgr() {
 
 void QueryContext::cancel(const Status& status) {
     _fragment_mgr->cancel(status);
-}
-
-void QueryContext::prepare_pass_through_chunk_buffer() {
-    if (_exec_env != nullptr) {
-        _exec_env->stream_mgr()->prepare_pass_through_chunk_buffer(_query_id);
-    }
 }
 
 QueryContextManager::QueryContextManager() = default;

--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -59,6 +59,8 @@ public:
 
     void set_is_runtime_filter_coordinator(bool flag) { _is_runtime_filter_coordinator = flag; }
 
+    void prepare_pass_through_chunk_buffer();
+
 private:
     ExecEnv* _exec_env = nullptr;
     TUniqueId _query_id;

--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -59,8 +59,6 @@ public:
 
     void set_is_runtime_filter_coordinator(bool flag) { _is_runtime_filter_coordinator = flag; }
 
-    void prepare_pass_through_chunk_buffer();
-
 private:
     ExecEnv* _exec_env = nullptr;
     TUniqueId _query_id;

--- a/be/src/runtime/data_stream_mgr.cpp
+++ b/be/src/runtime/data_stream_mgr.cpp
@@ -226,11 +226,11 @@ void DataStreamMgr::cancel(const TUniqueId& fragment_instance_id) {
 }
 
 void DataStreamMgr::prepare_pass_through_chunk_buffer(const TUniqueId& query_id) {
-    _pass_through_chunk_buffer_manager.open(query_id);
+    _pass_through_chunk_buffer_manager.open_fragment_instance(query_id);
 }
 
 void DataStreamMgr::destroy_pass_through_chunk_buffer(const TUniqueId& query_id) {
-    _pass_through_chunk_buffer_manager.close(query_id);
+    _pass_through_chunk_buffer_manager.close_fragment_instance(query_id);
 }
 
 PassThroughChunkBuffer* DataStreamMgr::get_pass_through_chunk_buffer(const TUniqueId& query_id) {

--- a/be/src/runtime/data_stream_mgr.cpp
+++ b/be/src/runtime/data_stream_mgr.cpp
@@ -59,8 +59,8 @@ std::shared_ptr<DataStreamRecvr> DataStreamMgr::create_recvr(
         bool keep_order) {
     DCHECK(profile != nullptr);
     VLOG_FILE << "creating receiver for fragment=" << fragment_instance_id << ", node=" << dest_node_id;
-    auto pass_through_chunk_buffer = get_pass_through_chunk_buffer(state->query_id());
-    DCHECK(pass_through_chunk_buffer.get() != nullptr);
+    PassThroughChunkBuffer* pass_through_chunk_buffer = get_pass_through_chunk_buffer(state->query_id());
+    DCHECK(pass_through_chunk_buffer != nullptr);
     std::shared_ptr<DataStreamRecvr> recvr(new DataStreamRecvr(
             this, state, row_desc, fragment_instance_id, dest_node_id, num_senders, is_merging, buffer_size, profile,
             std::move(sub_plan_query_statistics_recvr), is_pipeline, keep_order, pass_through_chunk_buffer));
@@ -226,34 +226,15 @@ void DataStreamMgr::cancel(const TUniqueId& fragment_instance_id) {
 }
 
 void DataStreamMgr::prepare_pass_through_chunk_buffer(const TUniqueId& query_id) {
-    {
-        std::unique_lock _l(_pass_through_chunk_lock);
-        if (_pass_through_chunk_buffer_manager.find(query_id) == _pass_through_chunk_buffer_manager.end()) {
-            PassThroughChunkBufferPtr buffer = std::make_shared<PassThroughChunkBuffer>(query_id);
-            _pass_through_chunk_buffer_manager.emplace(std::make_pair(query_id, buffer));
-        }
-    }
+    _pass_through_chunk_buffer_manager.open(query_id);
 }
 
 void DataStreamMgr::destroy_pass_through_chunk_buffer(const TUniqueId& query_id) {
-    {
-        std::unique_lock _l(_pass_through_chunk_lock);
-        auto it = _pass_through_chunk_buffer_manager.find(query_id);
-        if (it != _pass_through_chunk_buffer_manager.end()) {
-            _pass_through_chunk_buffer_manager.erase(it);
-        }
-    }
+    _pass_through_chunk_buffer_manager.close(query_id);
 }
 
-PassThroughChunkBufferPtr DataStreamMgr::get_pass_through_chunk_buffer(const TUniqueId& query_id) {
-    {
-        std::unique_lock _l(_pass_through_chunk_lock);
-        auto it = _pass_through_chunk_buffer_manager.find(query_id);
-        if (it == _pass_through_chunk_buffer_manager.end()) {
-            return nullptr;
-        }
-        return it->second;
-    }
+PassThroughChunkBuffer* DataStreamMgr::get_pass_through_chunk_buffer(const TUniqueId& query_id) {
+    return _pass_through_chunk_buffer_manager.get(query_id);
 }
 
 } // namespace starrocks

--- a/be/src/runtime/data_stream_mgr.h
+++ b/be/src/runtime/data_stream_mgr.h
@@ -92,7 +92,7 @@ public:
 
     void prepare_pass_through_chunk_buffer(const TUniqueId& query_id);
     void destroy_pass_through_chunk_buffer(const TUniqueId& query_id);
-    PassThroughChunkBufferPtr get_pass_through_chunk_buffer(const TUniqueId& query_id);
+    PassThroughChunkBuffer* get_pass_through_chunk_buffer(const TUniqueId& query_id);
 
 private:
     friend class DataStreamRecvr;
@@ -140,9 +140,7 @@ private:
 
     inline uint32_t get_hash_value(const TUniqueId& fragment_instance_id, PlanNodeId node_id);
 
-    // query_id <-> PassThroughChunkBufferPtr
-    std::mutex _pass_through_chunk_lock;
-    std::unordered_map<TUniqueId, PassThroughChunkBufferPtr> _pass_through_chunk_buffer_manager{};
+    PassThroughChunkBufferManager _pass_through_chunk_buffer_manager;
 };
 
 } // namespace starrocks

--- a/be/src/runtime/data_stream_recvr.cc
+++ b/be/src/runtime/data_stream_recvr.cc
@@ -703,8 +703,7 @@ DataStreamRecvr::DataStreamRecvr(DataStreamMgr* stream_mgr, RuntimeState* runtim
                                  const TUniqueId& fragment_instance_id, PlanNodeId dest_node_id, int num_senders,
                                  bool is_merging, int total_buffer_limit, std::shared_ptr<RuntimeProfile> profile,
                                  std::shared_ptr<QueryStatisticsRecvr> sub_plan_query_statistics_recvr,
-                                 bool is_pipeline, bool keep_order,
-                                 const PassThroughChunkBufferPtr& pass_through_chunk_buffer)
+                                 bool is_pipeline, bool keep_order, PassThroughChunkBuffer* pass_through_chunk_buffer)
         : _mgr(stream_mgr),
           _fragment_instance_id(fragment_instance_id),
           _dest_node_id(dest_node_id),

--- a/be/src/runtime/data_stream_recvr.h
+++ b/be/src/runtime/data_stream_recvr.h
@@ -116,7 +116,7 @@ private:
                     const TUniqueId& fragment_instance_id, PlanNodeId dest_node_id, int num_senders, bool is_merging,
                     int total_buffer_limit, std::shared_ptr<RuntimeProfile> profile,
                     std::shared_ptr<QueryStatisticsRecvr> sub_plan_query_statistics_recvr, bool is_pipeline,
-                    bool keep_order, const PassThroughChunkBufferPtr& pass_through_chunk_buffer);
+                    bool keep_order, PassThroughChunkBuffer* pass_through_chunk_buffer);
 
     // If receive queue is full, done is enqueue pending, and return with *done is nullptr
     Status add_chunks(const PTransmitChunkParams& request, ::google::protobuf::Closure** done);

--- a/be/src/runtime/local_pass_through_buffer.cpp
+++ b/be/src/runtime/local_pass_through_buffer.cpp
@@ -13,7 +13,7 @@ public:
     void append_chunk(const vectorized::Chunk* chunk, size_t chunk_size) {
         auto clone = chunk->clone_unique();
         {
-            std::unique_lock l(_mutex);
+            std::unique_lock lock(_mutex);
             _buffer.emplace_back(std::move(clone));
             _bytes.push_back(chunk_size);
         }
@@ -21,7 +21,7 @@ public:
 
     void pull_chunks(ChunkUniquePtrVector* chunks, std::vector<size_t>* bytes) {
         {
-            std::unique_lock l(_mutex);
+            std::unique_lock lock(_mutex);
             chunks->swap(_buffer);
             bytes->swap(_bytes);
         }
@@ -37,7 +37,7 @@ private:
 class PassThroughChannel {
 public:
     PassThroughSenderChannel* get_or_create_sender_channel(int sender_id) {
-        std::unique_lock l(_mutex);
+        std::unique_lock lock(_mutex);
         auto it = _sender_id_to_channel.find(sender_id);
         if (it == _sender_id_to_channel.end()) {
             auto* channel = new PassThroughSenderChannel();
@@ -71,7 +71,7 @@ PassThroughChunkBuffer::~PassThroughChunkBuffer() {
 }
 
 PassThroughChannel* PassThroughChunkBuffer::get_or_create_channel(const Key& key) {
-    std::unique_lock l(_mutex);
+    std::unique_lock lock(_mutex);
     auto it = _key_to_channel.find(key);
     if (it == _key_to_channel.end()) {
         auto* channel = new PassThroughChannel();
@@ -95,10 +95,10 @@ void PassThroughContext::pull_chunks(int sender_id, ChunkUniquePtrVector* chunks
     sender_channel->pull_chunks(chunks, bytes);
 }
 
-void PassThroughChunkBufferManager::open(const TUniqueId& query_id) {
-    VLOG_FILE << "PassThroughChunkBufferManager::open, query_id = " << query_id;
+void PassThroughChunkBufferManager::open_fragment_instance(const TUniqueId& query_id) {
+    VLOG_FILE << "PassThroughChunkBufferManager::open_fragment_instance, query_id = " << query_id;
     {
-        std::unique_lock _l(_mutex);
+        std::unique_lock lock(_mutex);
         auto it = _query_id_to_buffer.find(query_id);
         if (it == _query_id_to_buffer.end()) {
             PassThroughChunkBuffer* buffer = new PassThroughChunkBuffer(query_id);
@@ -109,10 +109,10 @@ void PassThroughChunkBufferManager::open(const TUniqueId& query_id) {
     }
 }
 
-void PassThroughChunkBufferManager::close(const TUniqueId& query_id) {
-    VLOG_FILE << "PassThroughChunkBufferManager::close, query_id = " << query_id;
+void PassThroughChunkBufferManager::close_fragment_instance(const TUniqueId& query_id) {
+    VLOG_FILE << "PassThroughChunkBufferManager::close_fragment_instance, query_id = " << query_id;
     {
-        std::unique_lock _l(_mutex);
+        std::unique_lock lock(_mutex);
         auto it = _query_id_to_buffer.find(query_id);
         if (it != _query_id_to_buffer.end()) {
             int rc = it->second->unref();
@@ -126,7 +126,7 @@ void PassThroughChunkBufferManager::close(const TUniqueId& query_id) {
 
 PassThroughChunkBuffer* PassThroughChunkBufferManager::get(const TUniqueId& query_id) {
     {
-        std::unique_lock _l(_mutex);
+        std::unique_lock lock(_mutex);
         auto it = _query_id_to_buffer.find(query_id);
         if (it == _query_id_to_buffer.end()) {
             return nullptr;

--- a/be/src/runtime/local_pass_through_buffer.h
+++ b/be/src/runtime/local_pass_through_buffer.h
@@ -30,18 +30,25 @@ public:
     PassThroughChunkBuffer(const TUniqueId& query_id);
     ~PassThroughChunkBuffer();
     PassThroughChannel* get_or_create_channel(const Key& key);
+    int ref() {
+        _ref_count += 1;
+        return _ref_count;
+    }
+    int unref() {
+        _ref_count -= 1;
+        return _ref_count;
+    }
 
 private:
     std::mutex _mutex;
     const TUniqueId _query_id;
     std::unordered_map<Key, PassThroughChannel*, KeyHash> _key_to_channel;
+    int _ref_count;
 };
-using PassThroughChunkBufferPtr = std::shared_ptr<PassThroughChunkBuffer>;
 
 class PassThroughContext {
 public:
-    PassThroughContext(const PassThroughChunkBufferPtr& chunk_buffer, TUniqueId fragment_instance_id,
-                       PlanNodeId node_id)
+    PassThroughContext(PassThroughChunkBuffer* chunk_buffer, TUniqueId fragment_instance_id, PlanNodeId node_id)
             : _chunk_buffer(chunk_buffer), _fragment_instance_id(fragment_instance_id), _node_id(node_id) {}
     void init();
     void append_chunk(int sender_id, const vectorized::Chunk* chunk, size_t chunk_size);
@@ -49,10 +56,21 @@ public:
 
 private:
     // hold this chunk buffer to avoid early deallocation.
-    PassThroughChunkBufferPtr _chunk_buffer;
+    PassThroughChunkBuffer* _chunk_buffer;
     TUniqueId _fragment_instance_id;
     PlanNodeId _node_id;
     PassThroughChannel* _channel = nullptr;
+};
+
+class PassThroughChunkBufferManager {
+public:
+    void open(const TUniqueId& query_id);
+    void close(const TUniqueId& query_id);
+    PassThroughChunkBuffer* get(const TUniqueId& query_id);
+
+private:
+    std::mutex _mutex;
+    std::unordered_map<TUniqueId, PassThroughChunkBuffer*> _query_id_to_buffer;
 };
 
 } // namespace starrocks

--- a/be/src/runtime/local_pass_through_buffer.h
+++ b/be/src/runtime/local_pass_through_buffer.h
@@ -30,10 +30,7 @@ public:
     PassThroughChunkBuffer(const TUniqueId& query_id);
     ~PassThroughChunkBuffer();
     PassThroughChannel* get_or_create_channel(const Key& key);
-    int ref() {
-        _ref_count += 1;
-        return _ref_count;
-    }
+    int ref() { return ++_ref_count; }
     int unref() {
         _ref_count -= 1;
         return _ref_count;
@@ -64,8 +61,12 @@ private:
 
 class PassThroughChunkBufferManager {
 public:
-    void open(const TUniqueId& query_id);
-    void close(const TUniqueId& query_id);
+    // Called when fragment instance is about to open/close
+    // We don't care open/close by which fragment instance,
+    // just to want to make sure that fragment instances in a query can
+    // share the same `PassThroughChunkBuffer*` struct
+    void open_fragment_instance(const TUniqueId& query_id);
+    void close_fragment_instance(const TUniqueId& query_id);
     PassThroughChunkBuffer* get(const TUniqueId& query_id);
 
 private:

--- a/be/src/storage/async_delta_writer_executor.h
+++ b/be/src/storage/async_delta_writer_executor.h
@@ -1,6 +1,10 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
 
+#include "common/compiler_util.h"
+DIAGNOSTIC_PUSH
+DIAGNOSTIC_IGNORE("-Wclass-memaccess")
 #include <bthread/execution_queue.h>
+DIAGNOSTIC_POP
 
 #include "common/config.h"
 #include "util/threadpool.h"


### PR DESCRIPTION
ref: #2406 

It's not determinstic that all `open_query` requests are issued before `close_query` requests. So it's very likely that `PassThroughChunkBuffer` will be deallocated if some `close_query` request is issued. 

This PR fixes this problem by using ref count:
1. add ref count when `open_query` called, and dec ref count when `close_query` called.
2. we can be assured that `PassThroughChunkBuffer` can obtained if any query request is not closed.

