### PR TITLE
[pipeline] avoid local passthrough if union node only has one child

### DIFF
--- a/be/src/exec/pipeline/pipeline_builder.cpp
+++ b/be/src/exec/pipeline/pipeline_builder.cpp
@@ -103,7 +103,12 @@ OpFactories PipelineBuilderContext::maybe_interpolate_local_shuffle_exchange(
     return operators_source_with_local_shuffle;
 }
 
-OpFactories PipelineBuilderContext::gather_pipelines_to_one(std::vector<OpFactories>& pred_operators_list) {
+OpFactories PipelineBuilderContext::maybe_gather_pipelines_to_one(std::vector<OpFactories>& pred_operators_list) {
+    // If there is only one pred pipeline, we needn't local passthrough anymore.
+    if (pred_operators_list.size() == 1) {
+        return pred_operators_list[0];
+    }
+
     // Approximately, each pred driver can output config::vector_chunk_size rows at the same time.
     size_t max_row_count = 0;
     for (const auto& pred_ops : pred_operators_list) {

--- a/be/src/exec/pipeline/pipeline_builder.h
+++ b/be/src/exec/pipeline/pipeline_builder.h
@@ -41,7 +41,7 @@ public:
     // Append a LocalExchangeSinkOperator to the tail of each pipeline.
     // Create a new pipeline with a LocalExchangeSourceOperator.
     // These local exchange sink operators and the source operator share a passthrough exchanger.
-    OpFactories gather_pipelines_to_one(std::vector<OpFactories>& pred_operators_list);
+    OpFactories maybe_gather_pipelines_to_one(std::vector<OpFactories>& pred_operators_list);
 
     uint32_t next_pipe_id() { return _next_pipeline_id++; }
 

--- a/be/src/exec/vectorized/union_node.cpp
+++ b/be/src/exec/vectorized/union_node.cpp
@@ -387,7 +387,7 @@ pipeline::OpFactories UnionNode::decompose_to_pipeline(pipeline::PipelineBuilder
         this->init_runtime_filter_for_operator(operators_list[i].back().get(), context, rc_rf_probe_collector);
     }
 
-    return context->gather_pipelines_to_one(operators_list);
+    return context->maybe_gather_pipelines_to_one(operators_list);
 }
 
 } // namespace starrocks::vectorized


### PR DESCRIPTION
In pipeline, local passthrough exchange is used to gather multiple pipelines, each of which derived from each child of UnionNode, to one pipeline.
If UnionNode only has on child, we needn't local passthrough exchange anymore.