### PR TITLE
Print the thread which holding the catalog lock when try_lock timeout

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -749,12 +749,10 @@ public class Catalog {
         while (true) {
             try {
                 if (!lock.tryLock(Config.catalog_try_lock_timeout_ms, TimeUnit.MILLISECONDS)) {
-                    if (LOG.isDebugEnabled()) {
-                        // to see which thread held this lock for long time.
-                        Thread owner = lock.getOwner();
-                        if (owner != null) {
-                            LOG.debug("catalog lock is held by: {}", Util.dumpThread(owner, 10));
-                        }
+                    // to see which thread held this lock for long time.
+                    Thread owner = lock.getOwner();
+                    if (owner != null) {
+                        LOG.warn("catalog lock is held by: {}", Util.dumpThread(owner, 10));
                     }
 
                     if (mustLock) {
@@ -2614,7 +2612,7 @@ public class Catalog {
         LOG.info("createDb dbName = " + fullDbName + ", id = " + id);
     }
 
-    // For replay edit log, need't lock metadata
+    // For replay edit log, needn't lock metadata
     public void unprotectCreateDb(Database db) {
         idToDb.put(db.getId(), db);
         fullNameToDb.put(db.getFullName(), db);


### PR DESCRIPTION
Print the log about the thread which holds the catalog lock. 
FE can open this kind of log with low frequency to locate the root cause of the problem quickly and easily.