### PR TITLE
Fix null data filtered bug in spark load

### DIFF
--- a/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/dpp/SparkDpp.java
+++ b/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/dpp/SparkDpp.java
@@ -864,12 +864,19 @@ public final class SparkDpp implements java.io.Serializable {
         List<StarRocksRangePartitioner.PartitionRangeKey> partitionRangeKeys = new ArrayList<>();
         for (EtlJobConfig.EtlPartition partition : partitionInfo.partitions) {
             StarRocksRangePartitioner.PartitionRangeKey partitionRangeKey = new StarRocksRangePartitioner.PartitionRangeKey();
-            List<Object> startKeyColumns = new ArrayList<>();
-            for (int i = 0; i < partition.startKeys.size(); i++) {
-                Object value = partition.startKeys.get(i);
-                startKeyColumns.add(convertPartitionKey(value, partitionKeySchema.get(i)));
+
+            if (!partition.isMinPartition) {
+                partitionRangeKey.isMinPartition = false;
+                List<Object> startKeyColumns = new ArrayList<>();
+                for (int i = 0; i < partition.startKeys.size(); i++) {
+                    Object value = partition.startKeys.get(i);
+                    startKeyColumns.add(convertPartitionKey(value, partitionKeySchema.get(i)));
+                }
+                partitionRangeKey.startKeys = new DppColumns(startKeyColumns);
+            } else {
+                partitionRangeKey.isMinPartition = true;
             }
-            partitionRangeKey.startKeys = new DppColumns(startKeyColumns);
+
             if (!partition.isMaxPartition) {
                 partitionRangeKey.isMaxPartition = false;
                 List<Object> endKeyColumns = new ArrayList<>();
@@ -881,6 +888,7 @@ public final class SparkDpp implements java.io.Serializable {
             } else {
                 partitionRangeKey.isMaxPartition = true;
             }
+
             partitionRangeKeys.add(partitionRangeKey);
         }
         return partitionRangeKeys;

--- a/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/dpp/StarRocksRangePartitioner.java
+++ b/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/dpp/StarRocksRangePartitioner.java
@@ -65,12 +65,15 @@ public class StarRocksRangePartitioner extends Partitioner {
     }
 
     public static class PartitionRangeKey implements Serializable {
+        public boolean isMinPartition;
         public boolean isMaxPartition;
         public DppColumns startKeys;
         public DppColumns endKeys;
 
         public boolean isRowContained(DppColumns row) {
-            if (isMaxPartition) {
+            if (isMinPartition) {
+                return endKeys.compareTo(row) > 0;
+            } else if (isMaxPartition) {
                 return startKeys.compareTo(row) <= 0;
             } else {
                 return startKeys.compareTo(row) <= 0 && endKeys.compareTo(row) > 0;
@@ -79,7 +82,8 @@ public class StarRocksRangePartitioner extends Partitioner {
 
         public String toString() {
             return "PartitionRangeKey{" +
-                    "isMaxPartition=" + isMaxPartition +
+                    "isMinPartition=" + isMinPartition +
+                    ", isMaxPartition=" + isMaxPartition +
                     ", startKeys=" + startKeys +
                     ", endKeys=" + endKeys +
                     '}';

--- a/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/etl/EtlJobConfig.java
+++ b/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/etl/EtlJobConfig.java
@@ -442,16 +442,19 @@ public class EtlJobConfig implements Serializable {
         public List<Object> startKeys;
         @SerializedName(value = "endKeys")
         public List<Object> endKeys;
+        @SerializedName(value = "isMinPartition")
+        public boolean isMinPartition;
         @SerializedName(value = "isMaxPartition")
         public boolean isMaxPartition;
         @SerializedName(value = "bucketNum")
         public int bucketNum;
 
         public EtlPartition(long partitionId, List<Object> startKeys, List<Object> endKeys,
-                            boolean isMaxPartition, int bucketNum) {
+                            boolean isMinPartition, boolean isMaxPartition, int bucketNum) {
             this.partitionId = partitionId;
             this.startKeys = startKeys;
             this.endKeys = endKeys;
+            this.isMinPartition = isMinPartition;
             this.isMaxPartition = isMaxPartition;
             this.bucketNum = bucketNum;
         }
@@ -462,6 +465,7 @@ public class EtlJobConfig implements Serializable {
                     "partitionId=" + partitionId +
                     ", startKeys=" + startKeys +
                     ", endKeys=" + endKeys +
+                    ", isMinPartition=" + isMinPartition +
                     ", isMaxPartition=" + isMaxPartition +
                     ", bucketNum=" + bucketNum +
                     '}';

--- a/fe/spark-dpp/src/test/java/com/starrocks/load/loadv2/etl/SparkEtlJobTest.java
+++ b/fe/spark-dpp/src/test/java/com/starrocks/load/loadv2/etl/SparkEtlJobTest.java
@@ -67,8 +67,8 @@ public class SparkEtlJobTest {
         List<EtlIndex> indexes = Lists.newArrayList(index1, index2);
         // partition info
         List<EtlPartition> partitions = Lists.newArrayList();
-        partitions.add(new EtlPartition(partition1Id, Lists.newArrayList(0), Lists.newArrayList(100), false, 2));
-        partitions.add(new EtlPartition(partition2Id, Lists.newArrayList(100), Lists.newArrayList(), true, 3));
+        partitions.add(new EtlPartition(partition1Id, Lists.newArrayList(0), Lists.newArrayList(100), false, false, 2));
+        partitions.add(new EtlPartition(partition2Id, Lists.newArrayList(100), Lists.newArrayList(), false, true, 3));
         EtlPartitionInfo partitionInfo =
                 new EtlPartitionInfo("RANGE", Lists.newArrayList("k1"), Lists.newArrayList("k2"), partitions);
         EtlTable table = new EtlTable(indexes, partitionInfo);


### PR DESCRIPTION
Null value is always less than the non-null value (the startkey of the minimum partition), 
so the null data will be filtered when loading.

When the partition columns is compared with the minimum partition, 
the data only needs to be compared with its endkey.

fix #2441 