### PR TITLE
Fix the agg bug of process mem allocate failed

### DIFF
--- a/be/src/exec/pipeline/set/except_context.cpp
+++ b/be/src/exec/pipeline/set/except_context.cpp
@@ -2,6 +2,8 @@
 
 #include "exec/pipeline/set/except_context.h"
 
+#include "runtime/current_thread.h"
+
 namespace starrocks::pipeline {
 
 Status ExceptContext::prepare(RuntimeState* state, const std::vector<ExprContext*>& build_exprs) {
@@ -28,7 +30,8 @@ Status ExceptContext::close(RuntimeState* state) {
 
 Status ExceptContext::append_chunk_to_ht(RuntimeState* state, const ChunkPtr& chunk,
                                          const std::vector<ExprContext*>& dst_exprs) {
-    return _hash_set->build_set(state, chunk, dst_exprs, _build_pool.get());
+    TRY_CATCH_BAD_ALLOC(_hash_set->build_set(state, chunk, dst_exprs, _build_pool.get()));
+    return Status::OK();
 }
 
 Status ExceptContext::erase_chunk_from_ht(RuntimeState* state, const ChunkPtr& chunk,

--- a/be/src/exec/pipeline/set/intersect_context.cpp
+++ b/be/src/exec/pipeline/set/intersect_context.cpp
@@ -2,6 +2,8 @@
 
 #include "exec/pipeline/set/intersect_context.h"
 
+#include "runtime/current_thread.h"
+
 namespace starrocks::pipeline {
 
 Status IntersectContext::prepare(RuntimeState* state, const std::vector<ExprContext*>& build_exprs) {
@@ -27,7 +29,8 @@ Status IntersectContext::close(RuntimeState* state) {
 
 Status IntersectContext::append_chunk_to_ht(RuntimeState* state, const ChunkPtr& chunk,
                                             const std::vector<ExprContext*>& dst_exprs) {
-    return _hash_set->build_set(state, chunk, dst_exprs, _build_pool.get());
+    TRY_CATCH_BAD_ALLOC(_hash_set->build_set(state, chunk, dst_exprs, _build_pool.get()));
+    return Status::OK();
 }
 
 Status IntersectContext::refine_chunk_from_ht(RuntimeState* state, const ChunkPtr& chunk,

--- a/be/src/exec/vectorized/aggregate/agg_hash_map.h
+++ b/be/src/exec/vectorized/aggregate/agg_hash_map.h
@@ -9,6 +9,7 @@
 #include "column/column_helper.h"
 #include "column/hash_set.h"
 #include "column/type_traits.h"
+#include "exec/vectorized/aggregate/agg_hash_set.h"
 #include "gutil/casts.h"
 #include "gutil/strings/fastmem.h"
 #include "runtime/mem_pool.h"
@@ -107,8 +108,11 @@ struct AggHashMapWithOneNumberKey {
             AGG_HASH_MAP_PREFETCH_HASH_VALUE();
 
             FieldType key = column->get_data()[i];
-            auto iter = hash_map.lazy_emplace_with_hash(key, hash_values[i],
-                                                        [&](const auto& ctor) { ctor(key, allocate_func()); });
+            auto iter = hash_map.lazy_emplace_with_hash(key, hash_values[i], [&](const auto& ctor) {
+                AggDataPtr pv = allocate_func();
+                ERASE_AND_THROW_BAD_ALLOC_IF_NULL_WITH_HASH(hash_map, pv, key, hash_values[i]);
+                ctor(key, pv);
+            });
             (*agg_states)[i] = iter->second;
         }
     }
@@ -160,6 +164,7 @@ struct AggHashMapWithOneNullableNumberKey {
         if (key_columns[0]->only_null()) {
             if (null_key_data == nullptr) {
                 null_key_data = allocate_func();
+                THROW_BAD_ALLOC_IF_NULL(null_key_data);
             }
             for (size_t i = 0; i < chunk_size; i++) {
                 (*agg_states)[i] = null_key_data;
@@ -174,8 +179,11 @@ struct AggHashMapWithOneNullableNumberKey {
                     AGG_HASH_MAP_PREFETCH_HASH_VALUE();
 
                     auto key = data_column->get_data()[i];
-                    auto iter = hash_map.lazy_emplace_with_hash(key, hash_values[i],
-                                                                [&](const auto& ctor) { ctor(key, allocate_func()); });
+                    auto iter = hash_map.lazy_emplace_with_hash(key, hash_values[i], [&](const auto& ctor) {
+                        AggDataPtr pv = allocate_func();
+                        ERASE_AND_THROW_BAD_ALLOC_IF_NULL_WITH_HASH(hash_map, pv, key, hash_values[i]);
+                        ctor(key, pv);
+                    });
                     (*agg_states)[i] = iter->second;
                 }
                 return;
@@ -185,6 +193,7 @@ struct AggHashMapWithOneNullableNumberKey {
                 if (key_columns[0]->is_null(i)) {
                     if (null_key_data == nullptr) {
                         null_key_data = allocate_func();
+                        THROW_BAD_ALLOC_IF_NULL(null_key_data);
                     }
                     (*agg_states)[i] = null_key_data;
                 } else {
@@ -205,6 +214,7 @@ struct AggHashMapWithOneNullableNumberKey {
         if (key_columns[0]->only_null()) {
             if (null_key_data == nullptr) {
                 null_key_data = allocate_func();
+                THROW_BAD_ALLOC_IF_NULL(null_key_data);
             }
             for (size_t i = 0; i < chunk_size; i++) {
                 (*agg_states)[i] = null_key_data;
@@ -228,6 +238,7 @@ struct AggHashMapWithOneNullableNumberKey {
                 if (key_columns[0]->is_null(i)) {
                     if (null_key_data == nullptr) {
                         null_key_data = allocate_func();
+                        THROW_BAD_ALLOC_IF_NULL(null_key_data);
                     }
                     (*agg_states)[i] = null_key_data;
                 } else {
@@ -241,7 +252,11 @@ struct AggHashMapWithOneNullableNumberKey {
     void _handle_data_key_column(ColumnType* data_column, size_t row, Func&& allocate_func,
                                  Buffer<AggDataPtr>* agg_states) {
         auto key = data_column->get_data()[row];
-        auto iter = hash_map.lazy_emplace(key, [&](const auto& ctor) { ctor(key, allocate_func()); });
+        auto iter = hash_map.lazy_emplace(key, [&](const auto& ctor) {
+            AggDataPtr pv = allocate_func();
+            ERASE_AND_THROW_BAD_ALLOC_IF_NULL(hash_map, pv, key);
+            ctor(key, pv);
+        });
         (*agg_states)[row] = iter->second;
     }
 
@@ -288,10 +303,11 @@ struct AggHashMapWithOneStringKey {
             auto iter = hash_map.lazy_emplace_with_hash(key, hash_values[i], [&](const auto& ctor) {
                 // we must persist the slice before insert
                 uint8_t* pos = pool->allocate(key.size);
-                THROW_BAD_ALLOC_IF_NULL(pos);
+                ERASE_AND_THROW_BAD_ALLOC_IF_NULL_WITH_HASH(hash_map, pos, key, hash_values[i]);
                 strings::memcpy_inlined(pos, key.data, key.size);
                 Slice pk{pos, key.size};
                 AggDataPtr pv = allocate_func();
+                ERASE_AND_THROW_BAD_ALLOC_IF_NULL_WITH_HASH(hash_map, pv, key, hash_values[i]);
                 ctor(pk, pv);
             });
             (*agg_states)[i] = iter->second;
@@ -340,6 +356,7 @@ struct AggHashMapWithOneNullableStringKey {
         if (key_columns[0]->only_null()) {
             if (null_key_data == nullptr) {
                 null_key_data = allocate_func();
+                THROW_BAD_ALLOC_IF_NULL(null_key_data);
             }
             for (size_t i = 0; i < chunk_size; i++) {
                 (*agg_states)[i] = null_key_data;
@@ -357,10 +374,11 @@ struct AggHashMapWithOneNullableStringKey {
                     auto key = data_column->get_slice(i);
                     auto iter = hash_map.lazy_emplace_with_hash(key, hash_values[i], [&](const auto& ctor) {
                         uint8_t* pos = pool->allocate(key.size);
-                        THROW_BAD_ALLOC_IF_NULL(pos);
+                        ERASE_AND_THROW_BAD_ALLOC_IF_NULL_WITH_HASH(hash_map, pos, key, hash_values[i]);
                         strings::memcpy_inlined(pos, key.data, key.size);
                         Slice pk{pos, key.size};
                         AggDataPtr pv = allocate_func();
+                        ERASE_AND_THROW_BAD_ALLOC_IF_NULL_WITH_HASH(hash_map, pv, key, hash_values[i]);
                         ctor(pk, pv);
                     });
                     (*agg_states)[i] = iter->second;
@@ -372,6 +390,7 @@ struct AggHashMapWithOneNullableStringKey {
                 if (key_columns[0]->is_null(i)) {
                     if (null_key_data == nullptr) {
                         null_key_data = allocate_func();
+                        THROW_BAD_ALLOC_IF_NULL(null_key_data);
                     }
                     (*agg_states)[i] = null_key_data;
                 } else {
@@ -391,6 +410,7 @@ struct AggHashMapWithOneNullableStringKey {
         if (key_columns[0]->only_null()) {
             if (null_key_data == nullptr) {
                 null_key_data = allocate_func();
+                THROW_BAD_ALLOC_IF_NULL(null_key_data);
             }
             for (size_t i = 0; i < chunk_size; i++) {
                 (*agg_states)[i] = null_key_data;
@@ -412,6 +432,7 @@ struct AggHashMapWithOneNullableStringKey {
                 if (nullable_column->is_null(i)) {
                     if (null_key_data == nullptr) {
                         null_key_data = allocate_func();
+                        THROW_BAD_ALLOC_IF_NULL(null_key_data);
                     }
                     (*agg_states)[i] = null_key_data;
                 } else {
@@ -427,10 +448,11 @@ struct AggHashMapWithOneNullableStringKey {
         auto key = data_column->get_slice(row);
         auto iter = hash_map.lazy_emplace(key, [&](const auto& ctor) {
             uint8_t* pos = pool->allocate(key.size);
-            THROW_BAD_ALLOC_IF_NULL(pos);
+            ERASE_AND_THROW_BAD_ALLOC_IF_NULL(hash_map, pos, key);
             strings::memcpy_inlined(pos, key.data, key.size);
             Slice pk{pos, key.size};
             AggDataPtr pv = allocate_func();
+            ERASE_AND_THROW_BAD_ALLOC_IF_NULL(hash_map, pv, key);
             ctor(pk, pv);
         });
         (*agg_states)[row] = iter->second;
@@ -496,10 +518,11 @@ struct AggHashMapWithSerializedKey {
             auto iter = hash_map.lazy_emplace(key, [&](const auto& ctor) {
                 // we must persist the slice before insert
                 uint8_t* pos = pool->allocate(key.size);
-                THROW_BAD_ALLOC_IF_NULL(pos);
+                ERASE_AND_THROW_BAD_ALLOC_IF_NULL(hash_map, pos, key);
                 strings::memcpy_inlined(pos, key.data, key.size);
                 Slice pk{pos, key.size};
                 AggDataPtr pv = allocate_func();
+                ERASE_AND_THROW_BAD_ALLOC_IF_NULL(hash_map, pv, key);
                 ctor(pk, pv);
             });
             (*agg_states)[i] = iter->second;
@@ -633,6 +656,7 @@ struct AggHashMapWithSerializedKeyFixedSize {
             FixedSizeSliceKey& key = caches[i].key;
             auto iter = hash_map.lazy_emplace_with_hash(key, caches[i].hashval, [&](const auto& ctor) {
                 AggDataPtr pv = allocate_func();
+                ERASE_AND_THROW_BAD_ALLOC_IF_NULL_WITH_HASH(hash_map, pv, key, caches[i].hashval);
                 ctor(key, pv);
             });
             (*agg_states)[i] = iter->second;

--- a/be/src/exec/vectorized/aggregate/agg_hash_set.h
+++ b/be/src/exec/vectorized/aggregate/agg_hash_set.h
@@ -52,6 +52,18 @@ using SliceAggTwoLevelHashSet =
         phmap::parallel_flat_hash_set<TSliceWithHash<seed>, THashOnSliceWithHash<seed>, TEqualOnSliceWithHash<seed>,
                                       phmap::priv::Allocator<Slice>, 4>;
 
+#define ERASE_AND_THROW_BAD_ALLOC_IF_NULL(hash_set, pv, key) \
+    if (UNLIKELY(pv == nullptr)) {                           \
+        hash_set.erase(key);                                 \
+        throw std::bad_alloc();                              \
+    }
+
+#define ERASE_AND_THROW_BAD_ALLOC_IF_NULL_WITH_HASH(hash_set, pv, key, hash) \
+    if (UNLIKELY(pv == nullptr)) {                                           \
+        hash_set.erase_with_hash(key, hash);                                 \
+        throw std::bad_alloc();                                              \
+    }
+
 // ==============================================================
 // handle one number hash key
 template <PrimitiveType primitive_type, typename HashSet>
@@ -191,7 +203,7 @@ struct AggHashSetOfOneStringKey {
             hash_set.lazy_emplace(key, [&](const auto& ctor) {
                 // we must persist the slice before insert
                 uint8_t* pos = pool->allocate(key.size);
-                THROW_BAD_ALLOC_IF_NULL(pos);
+                ERASE_AND_THROW_BAD_ALLOC_IF_NULL(hash_set, pos, key);
                 memcpy(pos, key.data, key.size);
                 ctor(pos, key.size, key.hash);
             });
@@ -287,7 +299,7 @@ struct AggHashSetOfOneNullableStringKey {
 
         hash_set.lazy_emplace(key, [&](const auto& ctor) {
             uint8_t* pos = pool->allocate(key.size);
-            THROW_BAD_ALLOC_IF_NULL(pos);
+            ERASE_AND_THROW_BAD_ALLOC_IF_NULL(hash_set, pos, key);
             memcpy(pos, key.data, key.size);
             ctor(pos, key.size, key.hash);
         });
@@ -350,7 +362,7 @@ struct AggHashSetOfSerializedKey {
             hash_set.lazy_emplace(key, [&](const auto& ctor) {
                 // we must persist the slice before insert
                 uint8_t* pos = pool->allocate(key.size);
-                THROW_BAD_ALLOC_IF_NULL(pos);
+                ERASE_AND_THROW_BAD_ALLOC_IF_NULL(hash_set, pos, key);
                 memcpy(pos, key.data, key.size);
                 ctor(pos, key.size, key.hash);
             });

--- a/be/src/exec/vectorized/aggregator.cpp
+++ b/be/src/exec/vectorized/aggregator.cpp
@@ -199,6 +199,7 @@ Status Aggregator::prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile
 
     if (_group_by_expr_ctxs.empty()) {
         _single_agg_state = _mem_pool->allocate_aligned(_agg_states_total_size, _max_agg_state_align_size);
+        THROW_BAD_ALLOC_IF_NULL(_single_agg_state);
         for (int i = 0; i < _agg_functions.size(); i++) {
             _agg_functions[i]->create(_single_agg_state + _agg_states_offsets[i]);
         }
@@ -243,7 +244,7 @@ Status Aggregator::close(RuntimeState* state) {
             }
 #define HASH_MAP_METHOD(NAME)                                                  \
     else if (_hash_map_variant.type == vectorized::HashMapVariant::Type::NAME) \
-            _release_agg_memory<decltype(_hash_map_variant.NAME)::element_type>(*_hash_map_variant.NAME);
+            _release_agg_memory<decltype(_hash_map_variant.NAME)::element_type>(_hash_map_variant.NAME.get());
             APPLY_FOR_VARIANT_ALL(HASH_MAP_METHOD)
 #undef HASH_MAP_METHOD
         }

--- a/be/src/exec/vectorized/aggregator.h
+++ b/be/src/exec/vectorized/aggregator.h
@@ -261,7 +261,7 @@ public:
                 [this]() {
                     vectorized::AggDataPtr agg_state =
                             _mem_pool->allocate_aligned(_agg_states_total_size, _max_agg_state_align_size);
-                    THROW_BAD_ALLOC_IF_NULL(agg_state);
+                    RETURN_IF_UNLIKELY_NULL(agg_state, (uint8_t*)(nullptr));
                     for (int i = 0; i < _agg_functions.size(); i++) {
                         _agg_functions[i]->create(agg_state + _agg_states_offsets[i]);
                     }
@@ -277,7 +277,7 @@ public:
                 [this]() {
                     vectorized::AggDataPtr agg_state =
                             _mem_pool->allocate_aligned(_agg_states_total_size, _max_agg_state_align_size);
-                    THROW_BAD_ALLOC_IF_NULL(agg_state);
+                    RETURN_IF_UNLIKELY_NULL(agg_state, (uint8_t*)(nullptr));
                     for (int i = 0; i < _agg_functions.size(); i++) {
                         _agg_functions[i]->create(agg_state + _agg_states_offsets[i]);
                     }
@@ -472,14 +472,16 @@ private:
     void _init_agg_hash_variant(HashVariantType& hash_variant);
 
     template <typename HashMapWithKey>
-    void _release_agg_memory(HashMapWithKey& hash_map_with_key) {
-        auto it = hash_map_with_key.hash_map.begin();
-        auto end = hash_map_with_key.hash_map.end();
-        while (it != end) {
-            for (int i = 0; i < _agg_functions.size(); i++) {
-                _agg_functions[i]->destroy(it->second + _agg_states_offsets[i]);
+    void _release_agg_memory(HashMapWithKey* hash_map_with_key) {
+        if (hash_map_with_key != nullptr) {
+            auto it = hash_map_with_key->hash_map.begin();
+            auto end = hash_map_with_key->hash_map.end();
+            while (it != end) {
+                for (int i = 0; i < _agg_functions.size(); i++) {
+                    _agg_functions[i]->destroy(it->second + _agg_states_offsets[i]);
+                }
+                ++it;
             }
-            ++it;
         }
     }
 };

--- a/be/src/exec/vectorized/except_hash_set.h
+++ b/be/src/exec/vectorized/except_hash_set.h
@@ -62,7 +62,7 @@ public:
 
     size_t size() { return _hash_set->size(); }
 
-    Status build_set(RuntimeState* state, const ChunkPtr& chunk, const std::vector<ExprContext*>& exprs, MemPool* pool);
+    void build_set(RuntimeState* state, const ChunkPtr& chunk, const std::vector<ExprContext*>& exprs, MemPool* pool);
 
     Status erase_duplicate_row(RuntimeState* state, const ChunkPtr& chunk, const std::vector<ExprContext*>& exprs);
 

--- a/be/src/exec/vectorized/intersect_hash_set.h
+++ b/be/src/exec/vectorized/intersect_hash_set.h
@@ -58,8 +58,8 @@ public:
 
     bool empty() { return _hash_set->empty(); }
 
-    Status build_set(RuntimeState* state, const ChunkPtr& chunkPtr, const std::vector<ExprContext*>& exprs,
-                     MemPool* pool);
+    void build_set(RuntimeState* state, const ChunkPtr& chunkPtr, const std::vector<ExprContext*>& exprs,
+                   MemPool* pool);
 
     Status refine_intersect_row(RuntimeState* state, const ChunkPtr& chunkPtr, const std::vector<ExprContext*>& exprs,
                                 int hit_times);

--- a/be/src/exec/vectorized/intersect_node.cpp
+++ b/be/src/exec/vectorized/intersect_node.cpp
@@ -11,6 +11,7 @@
 #include "exec/pipeline/set/intersect_output_source_operator.h"
 #include "exec/pipeline/set/intersect_probe_sink_operator.h"
 #include "exprs/expr.h"
+#include "runtime/current_thread.h"
 #include "runtime/runtime_state.h"
 
 namespace starrocks::vectorized {
@@ -94,7 +95,7 @@ Status IntersectNode::open(RuntimeState* state) {
     RETURN_IF_ERROR(child(0)->get_next(state, &chunk, &eos));
     if (!eos) {
         ScopedTimer<MonotonicStopWatch> build_timer(_build_set_timer);
-        RETURN_IF_ERROR(_hash_set->build_set(state, chunk, _child_expr_lists[0], _build_pool.get()));
+        TRY_CATCH_BAD_ALLOC(_hash_set->build_set(state, chunk, _child_expr_lists[0], _build_pool.get()));
         while (true) {
             RETURN_IF_ERROR(state->check_mem_limit("IntersectNode"));
             RETURN_IF_CANCELLED(state);
@@ -108,7 +109,7 @@ Status IntersectNode::open(RuntimeState* state) {
             if (chunk->num_rows() == 0) {
                 continue;
             }
-            RETURN_IF_ERROR(_hash_set->build_set(state, chunk, _child_expr_lists[0], _build_pool.get()));
+            TRY_CATCH_BAD_ALLOC(_hash_set->build_set(state, chunk, _child_expr_lists[0], _build_pool.get()));
         }
     }
 

--- a/be/src/util/phmap/phmap.h
+++ b/be/src/util/phmap/phmap.h
@@ -2933,19 +2933,6 @@ public:
         return 1;
     }
 
-    template <class K = key_type>
-    size_type erase_with_hash(const key_arg<K>& key, size_t hashval) {
-        Inner& inner = sets_[subidx(hashval)];
-        auto& set = inner.set_;
-        typename Lockable::UpgradeLock m(inner);
-        auto it = set.find(key, hashval);
-        if (it == set.end()) return 0;
-
-        typename Lockable::UpgradeToUnique unique(m);
-        set._erase(it);
-        return 1;
-    }
-
     // --------------------------------------------------------------------
     iterator erase(const_iterator cit) { return erase(cit.iter_); }
 

--- a/be/src/util/phmap/phmap.h
+++ b/be/src/util/phmap/phmap.h
@@ -2933,6 +2933,19 @@ public:
         return 1;
     }
 
+    template <class K = key_type>
+    size_type erase_with_hash(const key_arg<K>& key, size_t hashval) {
+        Inner& inner = sets_[subidx(hashval)];
+        auto& set = inner.set_;
+        typename Lockable::UpgradeLock m(inner);
+        auto it = set.find(key, hashval);
+        if (it == set.end()) return 0;
+
+        typename Lockable::UpgradeToUnique unique(m);
+        set._erase(it);
+        return 1;
+    }
+
     // --------------------------------------------------------------------
     iterator erase(const_iterator cit) { return erase(cit.iter_); }
 


### PR DESCRIPTION
When calling HashMap::lazy_emplace(), the location is allocated first, and then the value object is created. If the creation of the value object fails (such as memory allocation failure), the corresponding location is not released. When AggNode exits, we will query the HashTable, Deconstruct all objects. If this problem occurs, there will be pairs of objects that are forced to destruct without being successfully constructed. The repair method is to delete the corresponding element from the hash table when the value fails to be constructed
