### PR TITLE
use session variable except broker load

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -459,9 +459,9 @@ public class Coordinator {
 
             // Disable pipeline engine for `INSERT INTO`.
             // TODO: remove this when load supports pipeline engine.
-            SessionVariable sessionVariable = ConnectContext.get().getSessionVariable();
-            boolean isEnablePipelineEngine =
-                    sessionVariable.isEnablePipelineEngine() && (fragments.get(0).getSink() instanceof ResultSink);
+            boolean isEnablePipelineEngine = ConnectContext.get() != null &&
+                    ConnectContext.get().getSessionVariable().isEnablePipelineEngine() &&
+                    (fragments.get(0).getSink() instanceof ResultSink);
 
             for (PlanFragment fragment : fragments) {
                 FragmentExecParams params = fragmentExecParamsMap.get(fragment.getFragmentId());


### PR DESCRIPTION
As for PR #2431, `ConnectContext.get()` will be `null`, when query is about load.