### PR TITLE
Clear expired load labels and delete infos when doing checkpoint (#2377)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadManager.java
@@ -65,7 +65,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 
 /**
- * The broker and mini load jobs(v2) are included in this class.
+ * The broker and spark load jobs are included in this class.
  * <p>
  * The lock sequence:
  * Database.lock

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadManager.java
@@ -486,9 +486,6 @@ public class RoutineLoadManager implements Writable {
                     unprotectedRemoveJobFromDb(routineLoadJob);
                     iterator.remove();
 
-                    RoutineLoadOperation operation = new RoutineLoadOperation(routineLoadJob.getId(),
-                            routineLoadJob.getState());
-                    Catalog.getCurrentCatalog().getEditLog().logRemoveRoutineLoadJob(operation);
                     LOG.info(new LogBuilder(LogKey.ROUTINE_LOAD_JOB, routineLoadJob.getId())
                             .add("end_timestamp", routineLoadJob.getEndTimestamp())
                             .add("current_timestamp", currentTimestamp)

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadScheduler.java
@@ -124,8 +124,6 @@ public class RoutineLoadScheduler extends MasterDaemon {
 
         // check timeout tasks
         routineLoadManager.processTimeoutTasks();
-
-        routineLoadManager.cleanOldRoutineLoadJobs();
     }
 
     private List<RoutineLoadJob> getNeedScheduleRoutineJobs() throws LoadException {

--- a/fe/fe-core/src/main/java/com/starrocks/master/Checkpoint.java
+++ b/fe/fe-core/src/main/java/com/starrocks/master/Checkpoint.java
@@ -108,6 +108,8 @@ public class Checkpoint extends MasterDaemon {
                 return;
             }
 
+            catalog.clearExpiredJobs();
+
             catalog.saveImage();
             replayedJournalId = catalog.getReplayedJournalId();
             if (MetricRepo.isInit) {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -1096,7 +1096,6 @@ public class DatabaseTransactionMgr {
                 if (transactionState.isExpired(currentMillis)) {
                     finalStatusTransactionStateDeque.pop();
                     clearTransactionState(transactionState);
-                    editLog.logDeleteTransactionState(transactionState);
                     LOG.info("transaction [" + transactionState.getTransactionId() +
                             "] is expired, remove it from transaction manager");
                 } else {
@@ -1399,8 +1398,7 @@ public class DatabaseTransactionMgr {
         return timeoutTxns;
     }
 
-    public void removeExpiredAndTimeoutTxns(long currentMillis) {
-        removeExpiredTxns(currentMillis);
+    public void abortTimeoutTxns(long currentMillis) {
         List<Long> timeoutTxns = getTimeoutTxns(currentMillis);
         // abort timeout txns
         for (Long txnId : timeoutTxns) {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -461,10 +461,17 @@ public class GlobalTransactionMgr implements Writable {
      * expired: txn is in VISIBLE or ABORTED, and is expired.
      * timeout: txn is in PREPARE, but timeout
      */
-    public void removeExpiredAndTimeoutTxns() {
+    public void abortTimeoutTxns() {
         long currentMillis = System.currentTimeMillis();
         for (DatabaseTransactionMgr dbTransactionMgr : dbIdToDatabaseTransactionMgrs.values()) {
-            dbTransactionMgr.removeExpiredAndTimeoutTxns(currentMillis);
+            dbTransactionMgr.abortTimeoutTxns(currentMillis);
+        }
+    }
+
+    public void removeExpiredTxns() {
+        long currentMillis = System.currentTimeMillis();
+        for (DatabaseTransactionMgr dbTransactionMgr : dbIdToDatabaseTransactionMgrs.values()) {
+            dbTransactionMgr.removeExpiredTxns(currentMillis);
         }
     }
 


### PR DESCRIPTION
1. PR #2337 prevents expired delete infos from entering the image. Once delete information enters the image, FE will never clean it up. We should clear delete infos when doing checkpoint. Spark load jobs, broker load jobs, export jobs also have the same problem.
2. Previously, clearing routine load jobs used a different method. FE will delete the routine load jobs and write a related delete log to BDBJE. The followers synchronize the delete logs and replay these logs. Thousands of routine load jobs will generate many delete logs and cause high overhead. 

Now, the master will clean all load jobs、delete infos and the followers synchronize the checkpoint image.