### PR TITLE
Ignore report version check before process tablet report (#2342)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/master/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/master/ReportHandler.java
@@ -229,13 +229,7 @@ public class ReportHandler extends Daemon {
                 ReportHandler.diskReport(beId, disks);
             }
             if (tablets != null) {
-                long backendReportVersion = Catalog.getCurrentSystemInfo().getBackendReportVersion(beId);
-                if (reportVersion < backendReportVersion) {
-                    LOG.warn("out of date report version {} from backend[{}]. current report version[{}]",
-                            reportVersion, beId, backendReportVersion);
-                } else {
-                    ReportHandler.tabletReport(beId, tablets, reportVersion);
-                }
+                ReportHandler.tabletReport(beId, tablets, reportVersion);
             }
         }
     }
@@ -568,7 +562,6 @@ public class ReportHandler extends Daemon {
                         continue;
                     }
 
-                    // check report version again
                     long currentBackendReportVersion =
                             Catalog.getCurrentSystemInfo().getBackendReportVersion(backendId);
                     if (backendReportVersion < currentBackendReportVersion) {


### PR DESCRIPTION
In processing tablet reports, sync and deleteFromMeta already have the logic to check the reportVersion, so there is no need to check before processing tablet reports. Otherwise, it will block the processing of other logic if the reportVersion is updated frequently.