### PR TITLE
Fix project expression reuse bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorsReuseRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorsReuseRule.java
@@ -60,12 +60,12 @@ public class ScalarOperatorsReuseRule implements PhysicalOperatorTreeRewriteRule
                 return projection;
             }
 
-            boolean hasRewritted = false;
+            boolean hasRewrite = false;
             for (ScalarOperator operator : columnRefMap.values()) {
                 ScalarOperator rewriteOperator =
                         ScalarOperatorsReuse.rewriteOperatorWithCommonOperator(operator, commonSubOperators);
                 if (!rewriteOperator.equals(operator)) {
-                    hasRewritted = true;
+                    hasRewrite = true;
                     break;
                 }
             }
@@ -75,12 +75,19 @@ public class ScalarOperatorsReuseRule implements PhysicalOperatorTreeRewriteRule
              * 2. Put the common sub operators to projection, we need to compute
              * common sub operators firstly in BE
              */
-            if (hasRewritted) {
+            if (hasRewrite) {
                 Map<ColumnRefOperator, ScalarOperator> newMap =
                         Maps.newTreeMap(Comparator.comparingInt(ColumnRefOperator::getId));
                 for (Map.Entry<ColumnRefOperator, ScalarOperator> kv : columnRefMap.entrySet()) {
-                    newMap.put(kv.getKey(), ScalarOperatorsReuse.
-                            rewriteOperatorWithCommonOperator(kv.getValue(), commonSubOperators));
+                    ScalarOperator rewriteOperator =
+                            ScalarOperatorsReuse.rewriteOperatorWithCommonOperator(kv.getValue(), commonSubOperators);
+
+                    if (rewriteOperator.isColumnRef() && newMap.containsValue(rewriteOperator)) {
+                        // must avoid multi columnRef: columnRef
+                        newMap.put(kv.getKey(), kv.getValue());
+                    } else {
+                        newMap.put(kv.getKey(), rewriteOperator);
+                    }
                 }
 
                 Map<ColumnRefOperator, ScalarOperator> newCommonMap =

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorsReuseRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorsReuseRule.java
@@ -60,12 +60,12 @@ public class ScalarOperatorsReuseRule implements PhysicalOperatorTreeRewriteRule
                 return projection;
             }
 
-            boolean hasRewrite = false;
+            boolean hasRewritten = false;
             for (ScalarOperator operator : columnRefMap.values()) {
                 ScalarOperator rewriteOperator =
                         ScalarOperatorsReuse.rewriteOperatorWithCommonOperator(operator, commonSubOperators);
                 if (!rewriteOperator.equals(operator)) {
-                    hasRewrite = true;
+                    hasRewritten = true;
                     break;
                 }
             }
@@ -75,7 +75,7 @@ public class ScalarOperatorsReuseRule implements PhysicalOperatorTreeRewriteRule
              * 2. Put the common sub operators to projection, we need to compute
              * common sub operators firstly in BE
              */
-            if (hasRewrite) {
+            if (hasRewritten) {
                 Map<ColumnRefOperator, ScalarOperator> newMap =
                         Maps.newTreeMap(Comparator.comparingInt(ColumnRefOperator::getId));
                 for (Map.Entry<ColumnRefOperator, ScalarOperator> kv : columnRefMap.entrySet()) {
@@ -84,6 +84,7 @@ public class ScalarOperatorsReuseRule implements PhysicalOperatorTreeRewriteRule
 
                     if (rewriteOperator.isColumnRef() && newMap.containsValue(rewriteOperator)) {
                         // must avoid multi columnRef: columnRef
+                        // @TODO: remove it if BE support COW column
                         newMap.put(kv.getKey(), kv.getValue());
                     } else {
                         newMap.put(kv.getKey(), rewriteOperator);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
@@ -77,6 +77,10 @@ public final class SqlToScalarOperatorTranslator {
         ScalarOperator scalarOperator = SqlToScalarOperatorTranslator.translate(expression, expressionMapping);
         if (expressionMapping.hasExpression(expression) || scalarOperator.isColumnRef()) {
             columnRef = (ColumnRefOperator) scalarOperator;
+        } else if (scalarOperator.isVariable() && projections.containsValue(scalarOperator)) {
+            columnRef = projections.entrySet().stream().filter(e -> scalarOperator.equals(e.getValue())).findAny().map(
+                    Map.Entry::getKey).orElse(null);
+            Preconditions.checkNotNull(columnRef);
         } else {
             columnRef = columnRefFactory.create(expression, expression.getType(), expression.isNullable());
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -5162,4 +5162,12 @@ public class PlanFragmentTest extends PlanTestBase {
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 4: v1 = 1: v1"));
     }
+
+    @Test
+    public void testProjectReuse() throws Exception {
+        String sql = "select nullif(v1, v1) + (0) as a , nullif(v1, v1) + (1 - 1) as b from t0;";
+        String plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("<slot 4> : nullif(1: v1, 1: v1) + 0"));
+        Assert.assertTrue(plan.contains(" OUTPUT EXPRS:4: expr | 4: expr"));
+    }
 }


### PR DESCRIPTION
For #2448

```
mysql> explain select * from (select nullif(v1, v1) + (0) as a , nullif(v1, v1) + (1 - 1) as b from t0) xx;
+-----------------------------------------+
| Explain String                          |
+-----------------------------------------+
| PLAN FRAGMENT 0                         |
|  OUTPUT EXPRS:4: expr | 5: expr         |
|   PARTITION: UNPARTITIONED              |
|                                         |
|   1:Project                             |
|   |  <slot 4> : 7: add                  |
|   |  <slot 5> : 7: add                  |
|   |  common expressions:                |
|   |  <slot 6> : nullif(1: v1, 1: v1)    |
|   |  <slot 7> : 6: nullif + 0           |
|   |  use vectorized: true               |
|   |                                     |
|   0:OlapScanNode                        |
+-----------------------------------------+
```

Fix ways:
* Reuse column in analyzer
* Forbidden same column-ref multi mapping 