### PR TITLE
Improve FE high concurrent performance part 4: Disable collect query detail info by default

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1312,6 +1312,9 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static boolean enable_routine_load_lag_metrics = false;
 
+    @ConfField(mutable = true)
+    public static boolean enable_collect_query_detail_info = false;
+
     /**
      * Min lag of routine load job to show in metrics
      * Only show the routine load job whose lag is larger than min_routine_load_lag_for_metrics

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/QueryDetailAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/QueryDetailAction.java
@@ -51,7 +51,7 @@ public class QueryDetailAction extends RestBaseAction {
             sendResult(request, response, HttpResponseStatus.BAD_REQUEST);
             return;
         }
-        long eventTime = Long.valueOf(eventTimeStr.trim());
+        long eventTime = Long.parseLong(eventTimeStr.trim());
         List<QueryDetail> queryDetails = QueryDetailQueue.getQueryDetailsAfterTime(eventTime);
         Gson gson = new Gson();
         String jsonString = gson.toJson(queryDetails);

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricCalculator.java
@@ -78,7 +78,7 @@ public class MetricCalculator extends TimerTask {
 
         lastTs = currentTs;
 
-        // max tabet compaction score of all backends
+        // max tablet compaction score of all backends
         long maxCompactionScore = 0;
         List<Metric> compactionScoreMetrics = MetricRepo.getMetricsByName(MetricRepo.TABLET_MAX_COMPACTION_SCORE);
         for (Metric metric : compactionScoreMetrics) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -199,6 +199,9 @@ public class ConnectProcessor {
     }
 
     private void addFinishedQueryDetail() {
+        if (!Config.enable_collect_query_detail_info) {
+            return;
+        }
         QueryDetail queryDetail = ctx.getQueryDetail();
         if (queryDetail == null || !queryDetail.getQueryId().equals(DebugUtil.printId(ctx.getQueryId()))) {
             return;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryDetailQueue.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryDetailQueue.java
@@ -30,7 +30,7 @@ import java.util.List;
 // Queue of QueryDetail.
 // It's used to collect queries for monitor.
 public class QueryDetailQueue {
-    private static LinkedList<QueryDetail> totalQueries = new LinkedList<QueryDetail>();
+    private static final LinkedList<QueryDetail> totalQueries = new LinkedList<QueryDetail>();
 
     //starrocks-manager pull queries every 1 second
     //metrics calculate query latency every 15 second
@@ -59,9 +59,7 @@ public class QueryDetailQueue {
 
     public static synchronized List<QueryDetail> getQueryDetailsAfterTime(long eventTime) {
         List<QueryDetail> results = Lists.newArrayList();
-        Iterator<QueryDetail> it = totalQueries.iterator();
-        while (it.hasNext()) {
-            QueryDetail queryDetail = it.next();
+        for (QueryDetail queryDetail : totalQueries) {
             if (queryDetail.getEventTime() > eventTime) {
                 results.add(queryDetail);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -935,6 +935,9 @@ public class StmtExecutor {
     }
 
     private void addRunningQueryDetail() {
+        if (!Config.enable_collect_query_detail_info) {
+            return;
+        }
         String sql;
         if (parsedStmt.needAuditEncryption()) {
             sql = parsedStmt.toSql();


### PR DESCRIPTION
For https://github.com/StarRocks/starrocks/issues/2407

QueryDetailQueue methods has synchronized, the performance is bad under high query concurrent, and for most of StarRocks users, They needn't this feature, so we should disable this feature by default.