### PR TITLE
Fix compound bugs of in-const predicates

### DIFF
--- a/be/src/exprs/vectorized/in_const_predicate.hpp
+++ b/be/src/exprs/vectorized/in_const_predicate.hpp
@@ -243,7 +243,7 @@ public:
 
     ColumnPtr evaluate(ExprContext* context, vectorized::Chunk* ptr) override {
         ColumnPtr lhs = _children[0]->evaluate(context, ptr);
-        if (ColumnHelper::count_nulls(lhs) == lhs->size()) {
+        if (!_eq_null && ColumnHelper::count_nulls(lhs) == lhs->size()) {
             return ColumnHelper::create_const_null_column(lhs->size());
         }
         bool use_array = is_use_array();

--- a/be/src/storage/vectorized/column_predicate_rewriter.cpp
+++ b/be/src/storage/vectorized/column_predicate_rewriter.cpp
@@ -309,23 +309,17 @@ bool ColumnPredicateRewriter::_rewrite_expr_predicate(ObjectPool* pool, const Co
 
     // TODO(yan): use eq/ne predicates when only one item, but it's very very hard to construct ne/eq expr.
     auto used_values = Int32Column::create();
-    uint8_t sel_value = (true_count < false_count) ? 1 : 0;
     for (int i = 0; i < code_size; i++) {
-        if (selection[i] == sel_value) {
+        if (selection[i]) {
             used_values->append(code_values[i]);
         }
     }
     bool eq_null = true;
     bool null_in_set = false;
-    if (field_nullable) {
-        if (selection[code_size] == sel_value) {
-            null_in_set = true;
-        }
+    if (field_nullable && selection[code_size]) {
+        null_in_set = true;
     }
     bool is_not_in = false;
-    if (sel_value == 0) {
-        is_not_in = true;
-    }
 
     // construct in filter.
     RuntimeState* state = pred->runtime_state();


### PR DESCRIPTION
ref: https://github.com/StarRocks/starrocks/issues/2450

---

The first bug is following: we can only create const null column if not `eq_null`.  Otherwise null be will evaluated to 1/0.

```
    ColumnPtr evaluate(ExprContext* context, vectorized::Chunk* ptr) override {
        ColumnPtr lhs = _children[0]->evaluate(context, ptr);
        if (ColumnHelper::count_nulls(lhs) == lhs->size()) {
        if (!_eq_null && ColumnHelper::count_nulls(lhs) == lhs->size()) {
            return ColumnHelper::create_const_null_column(lhs->size());
        }
```

---

The second bug is related to defect of `VectorizedInConstPredicate`. It can not handle `is_not_in` and NULL value simutaneously.  If we evaluate following column
- NULL -> true
-  0 -> true
-  1 -> true
-  2 -> true
- 3 -> false

We may want to construct `VectorizedInConstPredicate` with `_is_not_in = true, eq_null = true`( keep NULL and 3 in hash set) But in this way, NULL value can not be handled in right way. According to the following code, NULL value will be evaluated to 0(but we expect to be 1). 

```
        for (int row = 0; row < size; ++row) {
            if (viewer.is_null(row)) {
                if constexpr (equal_null) {
                    builder.append(1);
                } else {
                    builder.append_null();
                }
                continue;
            }
      ....
        if (_is_not_in) {
            for (int i = 0; i < size; i++) {
                output[i] = 1 - output[i];
            }
        }

```

So to fix the second bug, we don't use `_is_not_in = true`. We still natural way to construct `VectorizedInConstPredicate`
