### PR TITLE
Support new Jar UDF in FE side

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/CreateFunctionStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/CreateFunctionStmt.java
@@ -68,7 +68,7 @@ public class CreateFunctionStmt extends DdlStmt {
     public static final String FINALIZE_KEY = "finalize_fn";
     public static final String GET_VALUE_KEY = "get_value_fn";
     public static final String REMOVE_KEY = "remove_fn";
-    public static final String OBJECT_FORMAT_KEY = "object_format";
+    public static final String TYPE_KEY = "type";
     public static final String OBJECT_FORMAT_STARROCKS_JAR = "StarrocksJar";
     public static final String EVAL_METHOD_NAME = "evaluate";
 
@@ -157,7 +157,7 @@ public class CreateFunctionStmt extends DdlStmt {
             intermediateType = returnType;
         }
 
-        String object_format = properties.get(OBJECT_FORMAT_KEY);
+        String object_format = properties.get(TYPE_KEY);
         if (OBJECT_FORMAT_STARROCKS_JAR.equals(object_format)) {
             isStarrocksJar = true;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/CreateFunctionStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/CreateFunctionStmt.java
@@ -308,15 +308,15 @@ public class CreateFunctionStmt extends DdlStmt {
     }
 
     private void checkStarrocksJarUdfClass() throws AnalysisException {
-        boolean hasEvalMethod = false;
+        int evalMethodCount = 0;
         for (Method m : udfClass.getMethods()) {
             if (EVAL_METHOD_NAME.equals(m.getName())) {
-                hasEvalMethod = true;
+                evalMethodCount += 1;
             }
             checkStarrocksJarUdfMethod(m);
         }
-        if (!hasEvalMethod) {
-            throw new AnalysisException(String.format("UDF should have '%s'", EVAL_METHOD_NAME));
+        if (evalMethodCount != 1) {
+            throw new AnalysisException(String.format("UDF should have only one '%s' method", EVAL_METHOD_NAME));
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/CreateFunctionStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/CreateFunctionStmt.java
@@ -22,11 +22,15 @@
 package com.starrocks.analysis;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
 import com.starrocks.catalog.AggregateFunction;
 import com.starrocks.catalog.Catalog;
 import com.starrocks.catalog.Function;
+import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarFunction;
+import com.starrocks.catalog.ScalarType;
+import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
@@ -39,7 +43,11 @@ import org.apache.commons.codec.binary.Hex;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLClassLoader;
 import java.net.URLConnection;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -59,7 +67,11 @@ public class CreateFunctionStmt extends DdlStmt {
     public static final String FINALIZE_KEY = "finalize_fn";
     public static final String GET_VALUE_KEY = "get_value_fn";
     public static final String REMOVE_KEY = "remove_fn";
-    public static final String LANGUAGE_KEY = "lang";
+    public static final String OBJECT_TYPE_KEY = "object_type";
+    public static final String OBJECT_TYPE_STARROCKS_JAR = "StarrocksJar";
+    public static final String PREPARE_METHOD_NAME = "prepare";
+    public static final String CLOSE_METHOD_NAME = "close";
+    public static final String EVAL_METHOD_NAME = "evaluate";
 
 
     private final FunctionName functionName;
@@ -68,11 +80,25 @@ public class CreateFunctionStmt extends DdlStmt {
     private final TypeDef returnType;
     private TypeDef intermediateType;
     private final Map<String, String> properties;
+    private boolean isStarrocksJar = false;
 
     // needed item set after analyzed
     private String objectFile;
     private Function function;
     private String checksum;
+    private Class udfClass;
+
+    private static final ImmutableMap<PrimitiveType, Class> PrimitiveTypeToJavaClassType = new ImmutableMap.Builder<PrimitiveType, Class>()
+            .put(PrimitiveType.TINYINT, Byte.class)
+            .put(PrimitiveType.SMALLINT, Short.class)
+            .put(PrimitiveType.INT, Integer.class)
+            .put(PrimitiveType.FLOAT, Float.class)
+            .put(PrimitiveType.DOUBLE, Double.class)
+            .put(PrimitiveType.BIGINT, Long.class)
+            .put(PrimitiveType.CHAR, String.class)
+            .put(PrimitiveType.VARCHAR, String.class)
+            .build();
+
 
     public CreateFunctionStmt(boolean isAggregate, FunctionName functionName, FunctionArgsDef argsDef,
                               TypeDef returnType, TypeDef intermediateType, Map<String, String> properties) {
@@ -105,7 +131,11 @@ public class CreateFunctionStmt extends DdlStmt {
         if (isAggregate) {
             analyzeUda();
         } else {
-            analyzeUdf();
+            if (isStarrocksJar) {
+                analyzeStarrocksJarUdf();
+            } else {
+                analyzeUdf();
+            }
         }
     }
 
@@ -127,6 +157,11 @@ public class CreateFunctionStmt extends DdlStmt {
             intermediateType = returnType;
         }
 
+        String lang = properties.get(OBJECT_TYPE_KEY);
+        if (OBJECT_TYPE_STARROCKS_JAR.equals(lang)) {
+            isStarrocksJar = true;
+        }
+
         objectFile = properties.get(OBJECT_FILE_KEY);
         if (Strings.isNullOrEmpty(objectFile)) {
             throw new AnalysisException("No 'object_file' in properties");
@@ -140,6 +175,27 @@ public class CreateFunctionStmt extends DdlStmt {
         String md5sum = properties.get(MD5_CHECKSUM);
         if (md5sum != null && !md5sum.equalsIgnoreCase(checksum)) {
             throw new AnalysisException("library's checksum is not equal with input, checksum=" + checksum);
+        }
+
+        if (isStarrocksJar) {
+            analyzeUdfClassInStarrocksJar();
+        }
+    }
+
+    private void analyzeUdfClassInStarrocksJar() throws AnalysisException {
+        String symbol = properties.get(SYMBOL_KEY);
+        if (Strings.isNullOrEmpty(symbol)) {
+            throw new AnalysisException("No '" + SYMBOL_KEY + "' in properties");
+        }
+
+        try {
+            URL[] urls = {new URL("jar:" + objectFile + "!/")};
+            URLClassLoader cl = URLClassLoader.newInstance(urls);
+            udfClass = cl.loadClass(symbol);
+        } catch (MalformedURLException e) {
+            throw new AnalysisException("failed to load object_file: " + objectFile);
+        } catch (ClassNotFoundException e) {
+            throw new AnalysisException("class '" + symbol + "' not found in object_file :" + objectFile);
         }
     }
 
@@ -202,6 +258,67 @@ public class CreateFunctionStmt extends DdlStmt {
                 objectFile, symbol, prepareFnSymbol, closeFnSymbol);
         function.setChecksum(checksum);
     }
+
+    private void checkStarrocksJarUdfType(Type type, Class ptype, String pname) throws AnalysisException {
+        if (!(type instanceof ScalarType)) {
+            throw new AnalysisException("UDF does not support non-scalar type: " + type);
+        }
+        ScalarType scalarType = (ScalarType) type;
+        Class cls = PrimitiveTypeToJavaClassType.get(scalarType.getPrimitiveType());
+        if (cls == null) {
+            throw new AnalysisException("UDF does not support type: " + scalarType);
+        }
+        if (!cls.equals(ptype)) {
+            throw new AnalysisException(String.format("UDF %s[%s] type does not match %s", pname,
+                    ptype.getCanonicalName(), cls.getCanonicalName()));
+        }
+    }
+
+    private void checkStarrocksJarUdfMethod(Method method) throws AnalysisException {
+        String name = method.getName();
+        if (PREPARE_METHOD_NAME.equals(name) || EVAL_METHOD_NAME.equals(name)) {
+            Class retType = method.getReturnType();
+            checkStarrocksJarUdfType(returnType.getType(), retType, "Return");
+            if (method.getParameters().length != argsDef.getArgTypes().length) {
+                throw new AnalysisException(String.format("UDF '%s' parameter count does not match", name));
+            }
+            for (int i = 0; i < method.getParameters().length; i++) {
+                Parameter p = method.getParameters()[i];
+                checkStarrocksJarUdfType(argsDef.getArgTypes()[i], p.getType(), p.getName());
+            }
+        } else if (CLOSE_METHOD_NAME.equals(name)) {
+            Class retType = method.getReturnType();
+            if (!retType.equals(void.class)) {
+                throw new AnalysisException(String.format("UDF '%s' return type should be void", CLOSE_METHOD_NAME));
+            }
+            if (method.getParameters().length != 0) {
+                throw new AnalysisException(String.format("UDF '%s' should have zero parameter", CLOSE_METHOD_NAME));
+            }
+        }
+    }
+
+    private void checkStarrocksJarUdfClass() throws AnalysisException {
+        boolean hasEvalMethod = false;
+        for (Method m : udfClass.getMethods()) {
+            if (EVAL_METHOD_NAME.equals(m.getName())) {
+                hasEvalMethod = true;
+            }
+            checkStarrocksJarUdfMethod(m);
+        }
+        if (!hasEvalMethod) {
+            throw new AnalysisException(String.format("UDF should have '%s'", EVAL_METHOD_NAME));
+        }
+    }
+
+    private void analyzeStarrocksJarUdf() throws AnalysisException {
+        checkStarrocksJarUdfClass();
+        function = ScalarFunction.createUdf(
+                functionName, argsDef.getArgTypes(),
+                returnType.getType(), argsDef.isVariadic(), TFunctionBinaryType.SRJAR,
+                objectFile, udfClass.getCanonicalName(), "", "");
+        function.setChecksum(checksum);
+    }
+
 
     @Override
     public String toSql() {

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/CreateFunctionStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/CreateFunctionStmt.java
@@ -34,6 +34,7 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.common.UserException;
 import com.starrocks.mysql.privilege.PrivPredicate;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.thrift.TFunctionBinaryType;
 import org.apache.commons.codec.binary.Hex;
 
 import java.io.IOException;
@@ -58,6 +59,8 @@ public class CreateFunctionStmt extends DdlStmt {
     public static final String FINALIZE_KEY = "finalize_fn";
     public static final String GET_VALUE_KEY = "get_value_fn";
     public static final String REMOVE_KEY = "remove_fn";
+    public static final String LANGUAGE_KEY = "lang";
+
 
     private final FunctionName functionName;
     private final boolean isAggregate;
@@ -195,7 +198,7 @@ public class CreateFunctionStmt extends DdlStmt {
         String closeFnSymbol = properties.get(CLOSE_SYMBOL_KEY);
         function = ScalarFunction.createUdf(
                 functionName, argsDef.getArgTypes(),
-                returnType.getType(), argsDef.isVariadic(),
+                returnType.getType(), argsDef.isVariadic(), TFunctionBinaryType.HIVE,
                 objectFile, symbol, prepareFnSymbol, closeFnSymbol);
         function.setChecksum(checksum);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/AggregateFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/AggregateFunction.java
@@ -296,7 +296,7 @@ public class AggregateFunction extends Function {
     @Override
     public String getProperties() {
         Map<String, String> properties = Maps.newHashMap();
-        properties.put(CreateFunctionStmt.OBJECT_FILE_KEY, getLocation() == null ? "" : getLocation().toString());
+        properties.put(CreateFunctionStmt.FILE_KEY, getLocation() == null ? "" : getLocation().toString());
         properties.put(CreateFunctionStmt.MD5_CHECKSUM, checksum);
         return new Gson().toJson(properties);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarFunction.java
@@ -305,7 +305,7 @@ public class ScalarFunction extends Function {
     @Override
     public String getProperties() {
         Map<String, String> properties = Maps.newHashMap();
-        properties.put(CreateFunctionStmt.OBJECT_FILE_KEY, getLocation() == null ? "" : getLocation().toString());
+        properties.put(CreateFunctionStmt.FILE_KEY, getLocation() == null ? "" : getLocation().toString());
         properties.put(CreateFunctionStmt.MD5_CHECKSUM, checksum);
         properties.put(CreateFunctionStmt.SYMBOL_KEY, symbolName);
         properties.put(CreateFunctionStmt.TYPE_KEY, getBinaryType().name());

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarFunction.java
@@ -212,9 +212,10 @@ public class ScalarFunction extends Function {
     public static ScalarFunction createUdf(
             FunctionName name, Type[] args,
             Type returnType, boolean isVariadic,
+            TFunctionBinaryType binaryType,
             String objectFile, String symbol, String prepareFnSymbol, String closeFnSymbol) {
         ScalarFunction fn = new ScalarFunction(name, args, returnType, isVariadic);
-        fn.setBinaryType(TFunctionBinaryType.HIVE);
+        fn.setBinaryType(binaryType);
         fn.setUserVisible(true);
         fn.symbolName = symbol;
         fn.prepareFnSymbol = prepareFnSymbol;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarFunction.java
@@ -308,6 +308,7 @@ public class ScalarFunction extends Function {
         properties.put(CreateFunctionStmt.OBJECT_FILE_KEY, getLocation() == null ? "" : getLocation().toString());
         properties.put(CreateFunctionStmt.MD5_CHECKSUM, checksum);
         properties.put(CreateFunctionStmt.SYMBOL_KEY, symbolName);
+        properties.put(CreateFunctionStmt.OBJECT_FORMAT_KEY, getBinaryType().name());
         return new Gson().toJson(properties);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarFunction.java
@@ -308,7 +308,7 @@ public class ScalarFunction extends Function {
         properties.put(CreateFunctionStmt.OBJECT_FILE_KEY, getLocation() == null ? "" : getLocation().toString());
         properties.put(CreateFunctionStmt.MD5_CHECKSUM, checksum);
         properties.put(CreateFunctionStmt.SYMBOL_KEY, symbolName);
-        properties.put(CreateFunctionStmt.OBJECT_FORMAT_KEY, getBinaryType().name());
+        properties.put(CreateFunctionStmt.TYPE_KEY, getBinaryType().name());
         return new Gson().toJson(properties);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -823,5 +823,6 @@ public class ExpressionAnalyzer {
             throw new StarRocksPlannerException("CBO Optimizer don't support UDF function: " + fnName,
                     ErrorType.USER_ERROR);
         }
+        return fn;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -59,7 +59,6 @@ import com.starrocks.sql.analyzer.relation.QueryRelation;
 import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.common.TypeManager;
-import com.starrocks.sql.common.UnsupportedException;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.transformer.ExpressionMapping;
 import com.starrocks.sql.optimizer.transformer.SqlToScalarOperatorTranslator;
@@ -317,7 +316,7 @@ public class ExpressionAnalyzer {
                                     + " is invalid.");
                 }
 
-                Function fn = Expr.getBuiltinFunction(op.getName(), new Type[] {commonType, commonType},
+                Function fn = Expr.getBuiltinFunction(op.getName(), new Type[]{commonType, commonType},
                         Function.CompareMode.IS_SUPERTYPE_OF);
 
                 /*
@@ -330,7 +329,7 @@ public class ExpressionAnalyzer {
             } else if (node.getOp().getPos() == ArithmeticExpr.OperatorPosition.UNARY_PREFIX) {
 
                 Function fn = Expr.getBuiltinFunction(
-                        node.getOp().getName(), new Type[] {Type.BIGINT}, Function.CompareMode.IS_SUPERTYPE_OF);
+                        node.getOp().getName(), new Type[]{Type.BIGINT}, Function.CompareMode.IS_SUPERTYPE_OF);
 
                 node.setType(Type.BIGINT);
                 node.setFn(fn);
@@ -464,7 +463,7 @@ public class ExpressionAnalyzer {
             if (node.getFnName().getFunction().equals(FunctionSet.COUNT) && node.getParams().isDistinct()) {
                 //Compatible with the logic of the original search function "count distinct"
                 //TODO: fix how we equal count distinct.
-                fn = Expr.getBuiltinFunction(FunctionSet.COUNT, new Type[] {argumentTypes[0]},
+                fn = Expr.getBuiltinFunction(FunctionSet.COUNT, new Type[]{argumentTypes[0]},
                         Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
             } else if (Arrays.stream(argumentTypes).anyMatch(arg -> arg.matchesType(Type.TIME))) {
                 fn = Expr.getBuiltinFunction(node.getFnName().getFunction(),
@@ -820,9 +819,7 @@ public class ExpressionAnalyzer {
             return null;
         }
 
-        if (Config.enable_udf) {
-            throw UnsupportedException.unsupportedException("CBO Optimizer don't support UDF function: " + fnName);
-        } else {
+        if (!Config.enable_udf) {
             throw new StarRocksPlannerException("CBO Optimizer don't support UDF function: " + fnName,
                     ErrorType.USER_ERROR);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -316,7 +316,7 @@ public class ExpressionAnalyzer {
                                     + " is invalid.");
                 }
 
-                Function fn = Expr.getBuiltinFunction(op.getName(), new Type[]{commonType, commonType},
+                Function fn = Expr.getBuiltinFunction(op.getName(), new Type[] {commonType, commonType},
                         Function.CompareMode.IS_SUPERTYPE_OF);
 
                 /*
@@ -329,7 +329,7 @@ public class ExpressionAnalyzer {
             } else if (node.getOp().getPos() == ArithmeticExpr.OperatorPosition.UNARY_PREFIX) {
 
                 Function fn = Expr.getBuiltinFunction(
-                        node.getOp().getName(), new Type[]{Type.BIGINT}, Function.CompareMode.IS_SUPERTYPE_OF);
+                        node.getOp().getName(), new Type[] {Type.BIGINT}, Function.CompareMode.IS_SUPERTYPE_OF);
 
                 node.setType(Type.BIGINT);
                 node.setFn(fn);
@@ -463,7 +463,7 @@ public class ExpressionAnalyzer {
             if (node.getFnName().getFunction().equals(FunctionSet.COUNT) && node.getParams().isDistinct()) {
                 //Compatible with the logic of the original search function "count distinct"
                 //TODO: fix how we equal count distinct.
-                fn = Expr.getBuiltinFunction(FunctionSet.COUNT, new Type[]{argumentTypes[0]},
+                fn = Expr.getBuiltinFunction(FunctionSet.COUNT, new Type[] {argumentTypes[0]},
                         Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
             } else if (Arrays.stream(argumentTypes).anyMatch(arg -> arg.matchesType(Type.TIME))) {
                 fn = Expr.getBuiltinFunction(node.getFnName().getFunction(),

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -246,6 +246,9 @@ enum TFunctionBinaryType {
 
   // Native-interface, precompiled to IR; loaded from *.ll
   IR,
+
+  // StarRocks customized UDF in jar.
+  SRJAR
 }
 
 // Represents a fully qualified function name.
@@ -433,4 +436,3 @@ enum TCompressionType {
     BZIP2 = 10;
     LZO = 11; // Deprecated
 }
-


### PR DESCRIPTION
ref: #2473 

To differentiate new UDF from old one written in C++, we add properties and new workflow:
1. `type` (if 'StarrocksJar', then `file` in Jar file)
2. search UDF class in jar file by searching name in `symbol`.
3. UDF class should have `evaluate` method, which matches function signature of definition.
4. And there should be only one `evaluate` method which is also non-static.
5. In thrift, we add another function binary type `SRJAR` (abbr of StarrocksJar)

Those keywords are not finalized yet and still needs discussion.

======

It works like

```

CREATE FUNCTION my_add4(INT, INT) RETURNS INT PROPERTIES (
"symbol" = "com.dirlt.SimpleUDF",
"type" = "StarrocksJar",
"file" = "http://localhost:41006/work/myudf.jar"
);

```

and  Java source file is

```
package com.dirlt;

public class SimpleUDF {

    public Integer evaluate(Integer a, Integer b) {
        if (a != null && b != null) {
            return a + b;
        }
        return null;
    }
}

```

And executing `show full function` you can see the detailed information

```
+------------------+-------------+---------------+-------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
| Signature        | Return Type | Function Type | Intermediate Type | Properties                                                                                                                                              |
+------------------+-------------+---------------+-------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
| my_add4(INT,INT) | INT         | Scalar        | NULL              | {"symbol":"com.dirlt.SimpleUDF","file":"http://localhost:41006/work/myudf.jar","type":"SRJAR","md5":"716c6b08413b8ddc39517c0b3becd754"} |
+------------------+-------------+---------------+-------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
```