### PR TITLE
[WIP] Maybe right way to handle null_in_set in IN-CONST predicate

### DIFF
--- a/be/src/exprs/vectorized/in_const_predicate.hpp
+++ b/be/src/exprs/vectorized/in_const_predicate.hpp
@@ -214,7 +214,11 @@ public:
         for (int row = 0; row < size; ++row) {
             if (viewer.is_null(row)) {
                 if constexpr (equal_null) {
-                    builder.append(1);
+                    if constexpr (null_in_set) {
+                        builder.append(1);
+                    } else {
+                        builder.append(0);
+                    }
                 } else {
                     builder.append_null();
                 }


### PR DESCRIPTION
if `eq_null` is true, and we are probing NULL value
- if `null_in_set` is true, then should return 1
- else should return 0