### PR TITLE
Add setBadForce property to distinguish between manual setting to bad and automatic system setting to bad

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/AdminShowReplicaStatusStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/AdminShowReplicaStatusStmt.java
@@ -44,7 +44,7 @@ public class AdminShowReplicaStatusStmt extends ShowStmt {
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
             .add("TabletId").add("ReplicaId").add("BackendId").add("Version").add("LastFailedVersion")
             .add("LastSuccessVersion").add("CommittedVersion").add("SchemaHash").add("VersionNum")
-            .add("IsBad").add("State").add("Status")
+            .add("IsBad").add("IsSetBadForce").add("State").add("Status")
             .build();
 
     private TableRef tblRef;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -7407,6 +7407,7 @@ public class Catalog {
             }
             if (status == ReplicaStatus.BAD || status == ReplicaStatus.OK) {
                 if (replica.setBad(status == ReplicaStatus.BAD)) {
+                    replica.isForceSetBad(replica.isBad());
                     if (!isReplay) {
                         SetReplicaStatusOperationLog log =
                                 new SetReplicaStatusOperationLog(backendId, tabletId, status);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -7406,8 +7406,7 @@ public class Catalog {
                 return;
             }
             if (status == ReplicaStatus.BAD || status == ReplicaStatus.OK) {
-                if (replica.setBad(status == ReplicaStatus.BAD)) {
-                    replica.isForceSetBad(replica.isBad());
+                if (replica.setBadForce(status == ReplicaStatus.BAD)) {
                     if (!isReplay) {
                         SetReplicaStatusOperationLog log =
                                 new SetReplicaStatusOperationLog(backendId, tabletId, status);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MetadataViewer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MetadataViewer.java
@@ -120,6 +120,7 @@ public class MetadataViewer {
                             row.add(String.valueOf(replica.getSchemaHash()));
                             row.add(String.valueOf(replica.getVersionCount()));
                             row.add(String.valueOf(replica.isBad()));
+                            row.add(String.valueOf(replica.isSetBadForce()));
                             row.add(replica.getState().name());
                             row.add(status.name());
                             result.add(row);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Replica.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Replica.java
@@ -96,8 +96,10 @@ public class Replica implements Writable {
 
     private long pathHash = -1;
 
-    // bad means this Replica is unrecoverable and we will delete it
+    // If bad and isForceSetBad are both true, it means this Replica is unrecoverable and we will delete it
+    // if bad is true and isForceSetBad is false, it means this replica can be recover by be.
     private boolean bad = false;
+    private boolean isForceSetBad = false;
 
     /*
      * If set to true, with means this replica need to be repaired. explicitly.
@@ -220,6 +222,14 @@ public class Replica implements Writable {
         }
         this.bad = bad;
         return true;
+    }
+
+    public void isForceSetBad(boolean isForceSetBad) {
+        this.isForceSetBad = isForceSetBad;
+    }
+
+    public boolean isForceSetBad() {
+        return this.isForceSetBad;
     }
 
     public boolean needFurtherRepair() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Replica.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Replica.java
@@ -96,10 +96,10 @@ public class Replica implements Writable {
 
     private long pathHash = -1;
 
-    // If bad and isForceSetBad are both true, it means this Replica is unrecoverable and we will delete it
+    // If bad and setBadForce are both true, it means this Replica is unrecoverable and we will delete it
     // if bad is true and isForceSetBad is false, it means this replica can be recover by be.
     private boolean bad = false;
-    private boolean isForceSetBad = false;
+    private boolean setBadForce = false;
 
     /*
      * If set to true, with means this replica need to be repaired. explicitly.
@@ -224,12 +224,17 @@ public class Replica implements Writable {
         return true;
     }
 
-    public void isForceSetBad(boolean isForceSetBad) {
-        this.isForceSetBad = isForceSetBad;
+    public boolean setBadForce(boolean bad) {
+        if (this.bad == bad) {
+            return false;
+        }
+        this.bad = bad;
+        this.setBadForce = bad;
+        return true;
     }
 
-    public boolean isForceSetBad() {
-        return this.isForceSetBad;
+    public boolean isSetBadForce() {
+        return this.setBadForce;
     }
 
     public boolean needFurtherRepair() {

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/ReplicasProcNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/ReplicasProcNode.java
@@ -41,7 +41,7 @@ public class ReplicasProcNode implements ProcNodeInterface {
             .add("LstSuccessVersion").add("LstSuccessVersionHash")
             .add("LstFailedVersion").add("LstFailedVersionHash")
             .add("LstFailedTime").add("SchemaHash").add("DataSize").add("RowCount").add("State")
-            .add("IsBad").add("VersionCount").add("PathHash").add("MetaUrl").add("CompactionStatus")
+            .add("IsBad").add("IsSetBadForce").add("VersionCount").add("PathHash").add("MetaUrl").add("CompactionStatus")
             .build();
 
     private long tabletId;
@@ -93,6 +93,7 @@ public class ReplicasProcNode implements ProcNodeInterface {
                     String.valueOf(replica.getRowCount()),
                     String.valueOf(replica.getState()),
                     String.valueOf(replica.isBad()),
+                    String.valueOf(replica.isSetBadForce()),
                     String.valueOf(replica.getVersionCount()),
                     String.valueOf(replica.getPathHash()),
                     metaUrl,

--- a/fe/fe-core/src/main/java/com/starrocks/master/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/master/ReportHandler.java
@@ -454,8 +454,11 @@ public class ReportHandler extends Daemon {
                             continue;
                         }
 
-                        if (metaVersion < backendVersion
-                                || (metaVersion == backendVersion && replica.isBad())) {
+                        // 1. replica is not force set bad
+                        // 2. metaVersion < backendVersion or (metaVersion == backendVersion && replica.isBad())
+                        if (!replica.isForceSetBad() &&
+                                ((metaVersion < backendVersion) ||
+                                        (metaVersion == backendVersion && replica.isBad()))) {
 
                             // This is just a optimization for the old compatibility
                             // The init version in FE is (1-0), in BE is (2-0)
@@ -477,6 +480,7 @@ public class ReportHandler extends Daemon {
                             if (replica.getLastFailedVersion() < 0 && !isInitVersion) {
                                 // last failed version < 0 means this replica becomes health after sync,
                                 // so we write an edit log to sync this operation
+                                replica.setBad(false);
                                 ReplicaPersistInfo info = ReplicaPersistInfo.createForClone(dbId, tableId,
                                         partitionId, indexId, tabletId, backendId, replica.getId(),
                                         replica.getVersion(), schemaHash,

--- a/fe/fe-core/src/main/java/com/starrocks/master/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/master/ReportHandler.java
@@ -454,9 +454,9 @@ public class ReportHandler extends Daemon {
                             continue;
                         }
 
-                        // 1. replica is not force set bad
+                        // 1. replica is not set bad force
                         // 2. metaVersion < backendVersion or (metaVersion == backendVersion && replica.isBad())
-                        if (!replica.isForceSetBad() &&
+                        if (!replica.isSetBadForce() &&
                                 ((metaVersion < backendVersion) ||
                                         (metaVersion == backendVersion && replica.isBad()))) {
 


### PR DESCRIPTION
The status of replica, after being manually set to bad, will be reset to ok after tabletReport. But the reality is that the tablet on be is corrupted but not detected. The current handling is a bit tricky: replica status is not reset to ok in master, but the updateStatus log is recorded. So that the bad replica can still be recovered by copy. We should add another property to distinguish between manual setting to bad and automatic system setting to bad. Manually setting to bad can not be reset to ok after tabletReport.