### PR TITLE
Fix query rows error bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MergeLimitWithSortRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MergeLimitWithSortRule.java
@@ -30,8 +30,9 @@ public class MergeLimitWithSortRule extends TransformationRule {
         LogicalLimitOperator limit = (LogicalLimitOperator) input.getOp();
         LogicalTopNOperator sort = (LogicalTopNOperator) input.getInputs().get(0).getOp();
 
-        OptExpression result = new OptExpression(
-                new LogicalTopNOperator(sort.getOrderByElements(), limit.getLimit(), limit.getOffset()));
+        long l = limit.hasLimit() ? limit.getLimit() : -1;
+        long of = limit.hasOffset() ? limit.getOffset() : 0;
+        OptExpression result = new OptExpression(new LogicalTopNOperator(sort.getOrderByElements(), l, of));
         result.getInputs().addAll(input.getInputs().get(0).getInputs());
         return Lists.newArrayList(result);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1145,6 +1145,7 @@ public class PlanFragmentBuilder {
         public PlanFragment visitPhysicalTopN(OptExpression optExpr, ExecPlan context) {
             PlanFragment inputFragment = visit(optExpr.inputAt(0), context);
             PhysicalTopNOperator topN = (PhysicalTopNOperator) optExpr.getOp();
+            Preconditions.checkState(topN.getOffset() >= 0);
             if (!topN.isSplit()) {
                 return buildPartialTopNFragment(optExpr, context, topN.getOrderSpec(), topN.getLimit(),
                         topN.getOffset(),

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -5162,4 +5162,17 @@ public class PlanFragmentTest extends PlanTestBase {
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 4: v1 = 1: v1"));
     }
+
+    @Test
+    public void testTopNOffsetError() throws Exception {
+        long limit = connectContext.getSessionVariable().getSqlSelectLimit();
+        connectContext.getSessionVariable().setSqlSelectLimit(200);
+        String sql = "select * from (select * from t0 order by v1 limit 5) as a left join t1 on a.v1 = t1.v4";
+        String plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("  1:TOP-N\n" +
+                "  |  order by: <slot 1> 1: v1 ASC\n" +
+                "  |  offset: 0\n" +
+                "  |  limit: 5"));
+        connectContext.getSessionVariable().setSqlSelectLimit(limit);
+    }
 }


### PR DESCRIPTION
Backgroud:

```
DROP TABLE IF EXISTS test;
CREATE TABLE test (
  id int(11),
  name varchar(128)
) ENGINE=OLAP 
DUPLICATE KEY(id)
DISTRIBUTED BY HASH(id) BUCKETS 10 
PROPERTIES (
  "replication_num" = "1",
  "in_memory" = "true",
  "storage_format" = "DEFAULT"
);

insert into test
select 1,'a1' union all
select 2,'a2' union all
select 3,'a3' union all
select 4,'a4' union all
select 5,'a5' union all
select 6,'a6' union all
select 7,'a7' union all
select 8,'a8' union all
select 9,'a9';
```

Some users has report bugs when using DBeaver for SQL:
```
mysql>  select v1.* from ( select id from test order by id limit 5 ) v1 left join test v2 on v1.id = v2.id;
```

In DBeaver:
```
mysql>  select v1.* from ( select id from test order by id limit 5 ) v1 left join test v2 on v1.id = v2.id;
+------+
| id   |
+------+
|    2 |
|    1 |
|    3 |
|    4 |
+------+
4 rows in set (0.03 sec)
```

But in Mysql client:
```
mysql>   select v1.* from ( select id from test order by id limit 5 ) v1 left join test v2 on v1.id = v2.id;
+------+
| id   |
+------+
|    2 |
|    5 |
|    1 |
|    3 |
|    4 |
+------+
5 rows in set (0.05 sec)
```

The result will lose one rows, the reason about:
* DBeaver will send `set SQL_SELECT_LIMIT =  xx` first before send query, but Mysql client not, so the SQL which starrocks received will be more limit clause compared to MySQL Client.
* CBO order by clause merge multi limit clause has same bug