### PR TITLE
SerializedKeyAggHashSet default not use TwoLevelHashSet

### DIFF
--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.cpp
@@ -76,7 +76,7 @@ Status AggregateBlockingSinkOperator::push_chunk(RuntimeState* state, const vect
 
         _mem_tracker->set(_aggregator->hash_map_variant().memory_usage() +
                           _aggregator->mem_pool()->total_reserved_bytes());
-        _aggregator->try_convert_to_two_level_map();
+        TRY_CATCH_BAD_ALLOC(_aggregator->try_convert_to_two_level_map());
     }
     if (_aggregator->is_none_group_by_exprs()) {
         _aggregator->compute_single_agg_state(chunk_size);

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.cpp
@@ -62,6 +62,10 @@ Status AggregateDistinctBlockingSinkOperator::push_chunk(RuntimeState* state, co
         APPLY_FOR_VARIANT_ALL(HASH_SET_METHOD)
 #undef HASH_SET_METHOD
 
+        _mem_tracker->set(_aggregator->hash_set_variant().memory_usage() +
+                          _aggregator->mem_pool()->total_reserved_bytes());
+        TRY_CATCH_BAD_ALLOC(_aggregator->try_convert_to_two_level_set());
+
         _aggregator->update_num_input_rows(chunk->num_rows());
         if (limit_with_no_agg) {
             auto size = _aggregator->hash_set_variant().size();

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.cpp
@@ -78,6 +78,10 @@ Status AggregateDistinctStreamingSinkOperator::_push_chunk_by_force_preaggregati
     }
 
     COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_set_variant().size());
+
+    _mem_tracker->set(_aggregator->hash_set_variant().memory_usage() + _aggregator->mem_pool()->total_reserved_bytes());
+    TRY_CATCH_BAD_ALLOC(_aggregator->try_convert_to_two_level_set());
+
     return Status::OK();
 }
 
@@ -112,6 +116,10 @@ Status AggregateDistinctStreamingSinkOperator::_push_chunk_by_auto(const size_t 
         }
 
         COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_set_variant().size());
+
+        _mem_tracker->set(_aggregator->hash_set_variant().memory_usage() +
+                          _aggregator->mem_pool()->total_reserved_bytes());
+        TRY_CATCH_BAD_ALLOC(_aggregator->try_convert_to_two_level_set());
     } else {
         {
             SCOPED_TIMER(_aggregator->agg_compute_timer());

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
@@ -78,7 +78,7 @@ Status AggregateStreamingSinkOperator::_push_chunk_by_force_preaggregation(const
     }
 
     _mem_tracker->set(_aggregator->hash_map_variant().memory_usage() + _aggregator->mem_pool()->total_reserved_bytes());
-    _aggregator->try_convert_to_two_level_map();
+    TRY_CATCH_BAD_ALLOC(_aggregator->try_convert_to_two_level_map());
 
     COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_map_variant().size());
     return Status::OK();
@@ -116,7 +116,7 @@ Status AggregateStreamingSinkOperator::_push_chunk_by_auto(const size_t chunk_si
 
         _mem_tracker->set(_aggregator->hash_map_variant().memory_usage() +
                           _aggregator->mem_pool()->total_reserved_bytes());
-        _aggregator->try_convert_to_two_level_map();
+        TRY_CATCH_BAD_ALLOC(_aggregator->try_convert_to_two_level_map());
 
         COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_map_variant().size());
     } else {

--- a/be/src/exec/vectorized/aggregate/agg_hash_variant.h
+++ b/be/src/exec/vectorized/aggregate/agg_hash_variant.h
@@ -471,7 +471,7 @@ using OneStringAggHashSet = AggHashSetOfOneStringKey<SliceAggHashSet<seed>>;
 template <PhmapSeed seed>
 using NullOneStringAggHashSet = AggHashSetOfOneNullableStringKey<SliceAggHashSet<seed>>;
 template <PhmapSeed seed>
-using SerializedKeyAggHashSet = AggHashSetOfSerializedKey<SliceAggTwoLevelHashSet<seed>>;
+using SerializedKeyAggHashSet = AggHashSetOfSerializedKey<SliceAggHashSet<seed>>;
 template <PhmapSeed seed>
 using SerializedTwoLevelKeyAggHashSet = AggHashSetOfSerializedKey<SliceAggTwoLevelHashSet<seed>>;
 template <PhmapSeed seed>

--- a/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
@@ -69,7 +69,7 @@ Status AggregateBlockingNode::open(RuntimeState* state) {
 
                 _mem_tracker->set(_aggregator->hash_map_variant().memory_usage() +
                                   _aggregator->mem_pool()->total_reserved_bytes());
-                _aggregator->try_convert_to_two_level_map();
+                TRY_CATCH_BAD_ALLOC(_aggregator->try_convert_to_two_level_map());
             }
             if (_aggregator->is_none_group_by_exprs()) {
                 _aggregator->compute_single_agg_state(chunk_size);

--- a/be/src/exec/vectorized/aggregate/aggregate_streaming_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_streaming_node.cpp
@@ -89,7 +89,7 @@ Status AggregateStreamingNode::get_next(RuntimeState* state, ChunkPtr* chunk, bo
 
                 _mem_tracker->set(_aggregator->hash_map_variant().memory_usage() +
                                   _aggregator->mem_pool()->total_reserved_bytes());
-                _aggregator->try_convert_to_two_level_map();
+                TRY_CATCH_BAD_ALLOC(_aggregator->try_convert_to_two_level_map());
 
                 COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_map_variant().size());
 
@@ -137,7 +137,7 @@ Status AggregateStreamingNode::get_next(RuntimeState* state, ChunkPtr* chunk, bo
 
                     _mem_tracker->set(_aggregator->hash_map_variant().memory_usage() +
                                       _aggregator->mem_pool()->total_reserved_bytes());
-                    _aggregator->try_convert_to_two_level_map();
+                    TRY_CATCH_BAD_ALLOC(_aggregator->try_convert_to_two_level_map());
                     COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_map_variant().size());
 
                     continue;

--- a/be/src/exec/vectorized/aggregate/distinct_blocking_node.cpp
+++ b/be/src/exec/vectorized/aggregate/distinct_blocking_node.cpp
@@ -59,6 +59,9 @@ Status DistinctBlockingNode::open(RuntimeState* state) {
             APPLY_FOR_VARIANT_ALL(HASH_SET_METHOD)
 #undef HASH_SET_METHOD
 
+            _mem_tracker->set(_aggregator->hash_set_variant().memory_usage() + _aggregator->mem_pool()->total_reserved_bytes());
+            TRY_CATCH_BAD_ALLOC(_aggregator->try_convert_to_two_level_set());
+
             _aggregator->update_num_input_rows(chunk->num_rows());
             if (limit_with_no_agg) {
                 auto size = _aggregator->hash_set_variant().size();

--- a/be/src/exec/vectorized/aggregate/distinct_blocking_node.cpp
+++ b/be/src/exec/vectorized/aggregate/distinct_blocking_node.cpp
@@ -59,7 +59,8 @@ Status DistinctBlockingNode::open(RuntimeState* state) {
             APPLY_FOR_VARIANT_ALL(HASH_SET_METHOD)
 #undef HASH_SET_METHOD
 
-            _mem_tracker->set(_aggregator->hash_set_variant().memory_usage() + _aggregator->mem_pool()->total_reserved_bytes());
+            _mem_tracker->set(_aggregator->hash_set_variant().memory_usage() +
+                              _aggregator->mem_pool()->total_reserved_bytes());
             TRY_CATCH_BAD_ALLOC(_aggregator->try_convert_to_two_level_set());
 
             _aggregator->update_num_input_rows(chunk->num_rows());

--- a/be/src/exec/vectorized/aggregate/distinct_streaming_node.cpp
+++ b/be/src/exec/vectorized/aggregate/distinct_streaming_node.cpp
@@ -87,6 +87,7 @@ Status DistinctStreamingNode::get_next(RuntimeState* state, ChunkPtr* chunk, boo
 
                 _mem_tracker->set(_aggregator->hash_set_variant().memory_usage() +
                                   _aggregator->mem_pool()->total_reserved_bytes());
+                TRY_CATCH_BAD_ALLOC(_aggregator->try_convert_to_two_level_set());
 
                 continue;
             } else {
@@ -126,6 +127,7 @@ Status DistinctStreamingNode::get_next(RuntimeState* state, ChunkPtr* chunk, boo
 
                     _mem_tracker->set(_aggregator->hash_set_variant().memory_usage() +
                                       _aggregator->mem_pool()->total_reserved_bytes());
+                    TRY_CATCH_BAD_ALLOC(_aggregator->try_convert_to_two_level_set());
 
                     continue;
                 } else {

--- a/be/src/exec/vectorized/aggregator.cpp
+++ b/be/src/exec/vectorized/aggregator.cpp
@@ -471,7 +471,7 @@ void Aggregator::output_chunk_by_streaming_with_selection(vectorized::ChunkPtr* 
     output_chunk_by_streaming(chunk);
 }
 
-#define CONVERT_TO_TWO_LEVEL(DST, SRC)                                                             \
+#define CONVERT_TO_TWO_LEVEL_MAP(DST, SRC)                                                         \
     if (_hash_map_variant.type == vectorized::HashMapVariant::Type::SRC) {                         \
         _hash_map_variant.DST = std::make_unique<decltype(_hash_map_variant.DST)::element_type>(); \
         _hash_map_variant.DST->hash_map.reserve(_hash_map_variant.SRC->hash_map.capacity());       \
@@ -482,10 +482,28 @@ void Aggregator::output_chunk_by_streaming_with_selection(vectorized::ChunkPtr* 
         return;                                                                                    \
     }
 
+#define CONVERT_TO_TWO_LEVEL_SET(DST, SRC)                                                         \
+    if (_hash_set_variant.type == vectorized::HashSetVariant::Type::SRC) {                         \
+        _hash_set_variant.DST = std::make_unique<decltype(_hash_set_variant.DST)::element_type>(); \
+        _hash_set_variant.DST->hash_set.reserve(_hash_set_variant.SRC->hash_set.capacity());       \
+        _hash_set_variant.DST->hash_set.insert(_hash_set_variant.SRC->hash_set.begin(),            \
+                                               _hash_set_variant.SRC->hash_set.end());             \
+        _hash_set_variant.type = vectorized::HashSetVariant::Type::DST;                            \
+        _hash_set_variant.SRC.reset();                                                             \
+        return;                                                                                    \
+    }
+
 void Aggregator::try_convert_to_two_level_map() {
     if (_mem_tracker->consumption() > two_level_memory_threshold) {
-        CONVERT_TO_TWO_LEVEL(phase1_slice_two_level, phase1_slice);
-        CONVERT_TO_TWO_LEVEL(phase2_slice_two_level, phase2_slice);
+        CONVERT_TO_TWO_LEVEL_MAP(phase1_slice_two_level, phase1_slice);
+        CONVERT_TO_TWO_LEVEL_MAP(phase2_slice_two_level, phase2_slice);
+    }
+}
+
+void Aggregator::try_convert_to_two_level_set() {
+    if (_mem_tracker->consumption() > two_level_memory_threshold) {
+        CONVERT_TO_TWO_LEVEL_SET(phase1_slice_two_level, phase1_slice);
+        CONVERT_TO_TWO_LEVEL_SET(phase2_slice_two_level, phase2_slice);
     }
 }
 

--- a/be/src/exec/vectorized/aggregator.h
+++ b/be/src/exec/vectorized/aggregator.h
@@ -137,6 +137,7 @@ public:
     // we convert the single hash map to two level hash map.
     // two level hash map is better in large data set.
     void try_convert_to_two_level_map();
+    void try_convert_to_two_level_set();
 
 #ifdef NDEBUG
     static constexpr size_t two_level_memory_threshold = 33554432; // 32M, L3 Cache


### PR DESCRIPTION
add convert to two level logic for hash set

SQL | Mem | cardinality | Normal | TwoLevel | ConvertToTwoLevel
-- | -- | -- | -- | -- | --
select count(distinct lo_shipmode, lo_partkey, lo_quantity) from lineorder_l; | 9.2G | 2.9亿 | timeout(180s+) | 93.4s | 93.4s
select count(distinct lo_shipmode, lo_partkey%500000, lo_quantity) from lineorder_l; | 9.8G | 1.6亿 | timeout(180s+) | 90.3s | 90.1s
select count(distinct lo_shipmode, lo_partkey%250000, lo_quantity) from lineorder_l; | 5.5G | 8700万 | timeout(180s+) | 72.7s | 71.8s
select count(distinct lo_shipmode, lo_partkey%100000, lo_quantity) from lineorder_l; | 2.6G | 3500万 | 145s | 51.4s | 51.3s
select count(distinct lo_shipmode, lo_partkey%50000, lo_quantity) from lineorder_l; | 1.3G | 1750万 | 39.7s | 47.3s | 45.5s
select count(distinct lo_shipmode, lo_partkey%25000, lo_quantity) from lineorder_l; | 667M | 875万 | 36.4s | 38.8s | 39.4s
select count(distinct lo_shipmode, lo_partkey%10000, lo_quantity) from lineorder_l; | 200M | 350万 | 28.9s | 31.2s | 31.9s
select count(distinct lo_shipmode, lo_partkey%5000, lo_quantity) from lineorder_l; | 103M | 175万 | 26.1s | 27.0s | 28.1s
select count(distinct lo_shipmode, lo_partkey%2500, lo_quantity) from lineorder_l; | 52M | 87万 | 23.5s | 24.3s | 26.9s
select count(distinct lo_shipmode, lo_partkey%1000, lo_quantity) from lineorder_l; | 23M | 34万 | 17.9s | 19.1s | 18.1s
select count(distinct lo_shipmode, lo_partkey%500, lo_quantity) from lineorder_l; | 11M | 17万 | 13.1s | 15.5s | 13.2s
select count(distinct lo_shipmode, lo_partkey%200, lo_quantity) from lineorder_l; | 5.6M | 7万 | 10.4s | 11.2s | 10.9s
select count(distinct lo_shipmode, lo_partkey%100, lo_quantity) from lineorder_l; | 3M | 3.5万 | 9.4s | 10.1s | 9.3s
select count(distinct lo_shipmode, lo_partkey%50, lo_quantity) from lineorder_l; | 1.7M | 1.75万 | 8.9s | 9.5s | 8.7s
select count(distinct lo_shipmode, lo_partkey%10, lo_quantity) from lineorder_l; | 236K | 3500 | 7.1s | 7.5s | 7.1s
