### PR TITLE
to issue #2469: fix CTE analyze error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -68,6 +68,7 @@ import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.common.TypeManager;
 import com.starrocks.sql.optimizer.base.SetQualifier;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -484,7 +485,10 @@ public class QueryAnalyzer {
 
                     @Override
                     public List<String> visitCTE(CTERelation node, Void context) {
-                        return node.getCteQuery().getColumnOutputNames();
+                        if (StringUtils.equals(item.getTblName().getTbl(), node.getName())) {
+                            return node.getCteQuery().getColumnOutputNames();
+                        }
+                        return Collections.emptyList();
                     }
                 }.visit(analyzeState.getRelation()));
 
@@ -535,8 +539,9 @@ public class QueryAnalyzer {
             }
         }
 
-        Preconditions.checkArgument(outputExpressionBuilder.build().size() == columnOutputNames.size());
-        analyzeState.setOutputExpression(outputExpressionBuilder.build());
+        List<Expr> outputExpr = outputExpressionBuilder.build();
+        Preconditions.checkArgument(outputExpr.size() == columnOutputNames.size());
+        analyzeState.setOutputExpression(outputExpr);
         analyzeState.setColumnOutputNames(columnOutputNames);
         return outputExpressionBuilder.build();
     }
@@ -751,7 +756,7 @@ public class QueryAnalyzer {
                 //                "having v1 in (select v3 from w where v2 = 2)
                 // cte used in outer query and subquery can't use same relation-id and field
                 CTERelation newCteRelation =
-                        new CTERelation(cteRelation.getCteId(), cteRelation.getName(), cteRelation.getCteQuery());
+                        new CTERelation(cteRelation.getCteId(), tableName.getTbl(), cteRelation.getCteQuery());
                 newCteRelation.setScope(
                         new Scope(RelationId.of(newCteRelation), new RelationFields(outputFields.build())));
                 return newCteRelation;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -486,7 +486,7 @@ public class QueryAnalyzer {
                     @Override
                     public List<String> visitCTE(CTERelation node, Void context) {
                         if (item.getTblName() == null ||
-                            StringUtils.equals(item.getTblName().getTbl(), node.getName())) {
+                                StringUtils.equals(item.getTblName().getTbl(), node.getName())) {
                             return node.getCteQuery().getColumnOutputNames();
                         }
                         return Collections.emptyList();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -485,7 +485,8 @@ public class QueryAnalyzer {
 
                     @Override
                     public List<String> visitCTE(CTERelation node, Void context) {
-                        if (StringUtils.equals(item.getTblName().getTbl(), node.getName())) {
+                        if (item.getTblName() == null ||
+                            StringUtils.equals(item.getTblName().getTbl(), node.getName())) {
                             return node.getCteQuery().getColumnOutputNames();
                         }
                         return Collections.emptyList();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCTETest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCTETest.java
@@ -16,7 +16,7 @@ import static com.starrocks.sql.analyzer.AnalyzeTestUtil.analyzeSuccess;
 public class AnalyzeCTETest {
     // use a unique dir so that it won't be conflict with other unit test which
     // may also start a Mocked Frontend
-    private static String runningDir = "fe/mocked/AnalyzeJoin/" + UUID.randomUUID().toString() + "/";
+    private static String runningDir = "fe/mocked/AnalyzeCTE/" + UUID.randomUUID().toString() + "/";
 
     @BeforeClass
     public static void beforeClass() throws Exception {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCTETest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCTETest.java
@@ -1,0 +1,67 @@
+package com.starrocks.sql.analyzer;
+
+import com.starrocks.sql.analyzer.relation.QueryRelation;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.UUID;
+
+import static com.starrocks.sql.analyzer.AnalyzeTestUtil.analyzeFail;
+import static com.starrocks.sql.analyzer.AnalyzeTestUtil.analyzeSuccess;
+
+public class AnalyzeCTETest {
+    // use a unique dir so that it won't be conflict with other unit test which
+    // may also start a Mocked Frontend
+    private static String runningDir = "fe/mocked/AnalyzeJoin/" + UUID.randomUUID().toString() + "/";
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster(runningDir);
+        AnalyzeTestUtil.init();
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        File file = new File(runningDir);
+        file.delete();
+    }
+
+    @Test
+    public void testSingle() {
+        analyzeSuccess("with c1 as (select * from t0) select c1.* from c1");
+        analyzeSuccess("with c1 as (select * from t0) select a.* from c1 a");
+        analyzeSuccess("with c1 as (select * from t0) select a.* from c1 a");
+
+        // original table name is not allowed to access when alias-name exists
+        analyzeFail("with c1 as (select * from t0) select c1.* from c1 a");
+    }
+
+    @Test
+    public void testMulti() {
+        // without alias
+        QueryRelation query = analyzeSuccess("with "
+                + "tbl1 as (select v1, v2 from t0), "
+                + "tbl2 as (select v4, v5 from t1)"
+                + "select tbl1.*, tbl2.* from tbl1 join tbl2 on tbl1.v1 = tbl2.v4");
+        Assert.assertEquals("v1,v2,v4,v5", String.join(",", query.getColumnOutputNames()));
+
+        // with alias
+        query = analyzeSuccess("with "
+                + "tbl1 as (select v1, v2 from t0),"
+                + "tbl2 as (select v4, v5 from t1)"
+                + "select a.*, b.* from tbl1 a join tbl2 b on a.v1 = b.v4");
+        Assert.assertEquals("v1,v2,v4,v5", String.join(",", query.getColumnOutputNames()));
+
+        // partial alias
+        query = analyzeSuccess("with "
+                + "tbl1 as (select v1, v2 from t0),"
+                + "tbl2 as (select v4, v5 from t1)"
+                + "select a.*, tbl2.* from tbl1 a join tbl2 on a.v1 = tbl2.v4");
+        Assert.assertEquals("v1,v2,v4,v5", String.join(",", query.getColumnOutputNames()));
+    }
+}
+

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCTETest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCTETest.java
@@ -1,3 +1,4 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
 package com.starrocks.sql.analyzer;
 
 import com.starrocks.sql.analyzer.relation.QueryRelation;


### PR DESCRIPTION
## Problem 
According to issue #2469 , when multiple CTEs are referenced by a single query block, the 'Unknown error' will be thrown.

The root cause is `com.starrocks.sql.analyzer.QueryAnalyzer#analyzeSelect`  iterates the Query Relation to get all `columnOutputNames`, but when the query has multiple CTEs, all CTEs in the relation will be visited multiple times, cause duplicated `columnOutputNames`. 

Eg. The `columnOutputNames` will be `k1, k2, k3, k4, col1, col2, col3, k1, k2, k3, k4, col1, col2, col3` for above query in the issue.

## Fix 
1. Build CTERelation with aliased name for query `from cte xxx` 
2. Search column names of specified CTE for select clause `select cte.*` 
