### PR TITLE
Fix cte output columns not use view define

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/relation/CTERelation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/relation/CTERelation.java
@@ -2,14 +2,18 @@
 
 package com.starrocks.sql.analyzer.relation;
 
+import java.util.List;
+
 public class CTERelation extends Relation {
     private final String cteId;
     private final String name;
+    private final List<String> columnOutputNames;
     private final QueryRelation cteQuery;
 
-    public CTERelation(String cteId, String name, QueryRelation cteQuery) {
+    public CTERelation(String cteId, String name, List<String> columnOutputNames, QueryRelation cteQuery) {
         this.cteId = cteId;
         this.name = name;
+        this.columnOutputNames = columnOutputNames;
         this.cteQuery = cteQuery;
     }
 
@@ -23,6 +27,10 @@ public class CTERelation extends Relation {
 
     public String getName() {
         return name;
+    }
+
+    public List<String> getColumnOutputNames() {
+        return columnOutputNames;
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCTETest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCTETest.java
@@ -39,6 +39,18 @@ public class AnalyzeCTETest {
 
         // original table name is not allowed to access when alias-name exists
         analyzeFail("with c1 as (select * from t0) select c1.* from c1 a");
+
+        QueryRelation query = analyzeSuccess(
+                "with c1(a,b,c) as (select * from t0) select c1.* from c1");
+        Assert.assertEquals("a,b,c", String.join(",", query.getColumnOutputNames()));
+
+        query = analyzeSuccess(
+                "with c1(a,b,c) as (select * from t0) select t.* from c1 t");
+        Assert.assertEquals("a,b,c", String.join(",", query.getColumnOutputNames()));
+
+        query = analyzeSuccess(
+                "with c1(a,b,c) as (select * from t0), c2 as (select * from t1) select c2.*,t.* from c1 t,c2");
+        Assert.assertEquals("v4,v5,v6,a,b,c", String.join(",", query.getColumnOutputNames()));
     }
 
     @Test


### PR DESCRIPTION
#2469 

The output columns of cte should first use the column names in the definition. If the column names are not included in the definition, then use the column names in the query statement. This bug is because the column names in the view define are not recorded in CTERelation. Will cause the header column name error in the terminal