### PR TITLE
fix daily ASAN check

### DIFF
--- a/be/src/exec/vectorized/json_scanner.cpp
+++ b/be/src/exec/vectorized/json_scanner.cpp
@@ -449,7 +449,6 @@ Status JsonReader::_read_chunk_from_array(Chunk* chunk, int32_t rows_to_read,
                 (void)!row.raw_json().get(sv);
                 _state->append_error_msg_to_file(std::string(sv.data(), sv.size()), st.to_string());
             }
-            continue;
         }
 
         st = parser->advance();


### PR DESCRIPTION
This PR is to fix the error in the daily ASAN check.
```
starrocks_be: /home/disk1/doris-deps/thirdparty/installed/include/simdjson/generic/ondemand/value_iterator-inl.h:864: void simdjson::fallback::ondemand::value_iterator::assert_at_child() const: Assertion `_json_iter->_depth == _depth + 1' failed.
*** Aborted at 1640717594 (unix time) try "date -d @1640717594" if you are using GNU date ***
PC: @     0x7fc275b19387 __GI_raise
*** SIGABRT (@0x3f700007e49) received by PID 32329 (TID 0x7fc10f043700) from PID 32329; stack trace: ***
    @          0x8c77b82 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7fc2767e4630 (unknown)
    @     0x7fc275b19387 __GI_raise
    @     0x7fc275b1aa78 __GI_abort
    @     0x7fc275b121a6 __assert_fail_base
    @     0x7fc275b12252 __GI___assert_fail
    @          0x66578b4 simdjson::fallback::ondemand::value_iterator::assert_at_child()
    @          0x664bc75 starrocks::vectorized::JsonArrayParser::get_current()
    @          0x6621ef1 starrocks::vectorized::JsonReader::_read_chunk_from_array()
    @          0x661cc93 starrocks::vectorized::JsonReader::read_chunk()
    @          0x6617895 starrocks::vectorized::JsonScanner::get_next()
    @          0x65f1380 starrocks::vectorized::FileScanNode::scanner_scan()
    @          0x65f233a starrocks::vectorized::FileScanNode::scanner_worker()
    @          0x65fbc1f std::__invoke_impl<>()
    @          0x65fb9ac std::__invoke<>()
    @          0x65fb8a3 _ZNSt6thread8_InvokerISt5tupleIJMN9starrocks10vectorized12FileScanNodeEFviiEPS4_imEEE9_M_invokeIJLm0ELm1ELm2ELm3EEEEvSt12_Index_tupleIJXspT_EEE
    @          0x65fb824 std::thread::_Invoker<>::operator()()
    @          0x65fb808 std::thread::_State_impl<>::_M_run()
    @          0xa811500 execute_native_thread_routine
    @     0x7fc2767dcea5 start_thread
    @     0x7fc275be18dd __clone
    @                0x0 (unknown)
```