### PR TITLE
Solve the problem of creating chunk with unstable slot order

### DIFF
--- a/be/src/exec/pipeline/dict_decode_operator.cpp
+++ b/be/src/exec/pipeline/dict_decode_operator.cpp
@@ -33,6 +33,10 @@ Status DictDecodeOperator::push_chunk(RuntimeState* state, const vectorized::Chu
     }
 
     _cur_chunk = std::make_shared<vectorized::Chunk>();
+
+    // The order when traversing Chunk::_slot_id_to_index may be unstable of different instance of DictDecodeOperator
+    // Subsequent operator may call Chunk::append_selective which requires Chunk::_slot_id_to_index to be exactly same
+    // So here we keep the output chunks with the same order as original chunks
     std::vector<std::pair<vectorized::ColumnPtr, int>> columns_with_original_order(chunk->columns().size());
     const auto& slot_id_to_index_map = chunk->get_slot_id_to_index_map();
     for (const auto& [slot_id, index] : slot_id_to_index_map) {


### PR DESCRIPTION
## Related Issue

[#2471](https://github.com/StarRocks/starrocks/issues/2471)

## Root cause

1. `DictDecodeOperator::pull_chunk` create chunk with different order, more specifically, with different `Chunk::_slot_id_to_index`
2. `LocalExchangeSourceOperator` will call `Chunk::append_selective` which requires `Chunk::_slot_id_to_index` to be exactly the same

## How to fix

The solution is kind of straightforward, and here are two two possible methods

1. `DictDecodeOperator::pull_chunk` keep the original order, **which is taken by this pr**
2. `Chunk::append_selective` allow `Chunk::_slot_id_to_index` to be different as long as the set of the slot_id is exactly same