### PR TITLE
BugFix: GC rowset file by mistake upon startup. (#2500)

### DIFF
--- a/be/src/storage/rowset/unique_rowset_id_generator.cpp
+++ b/be/src/storage/rowset/unique_rowset_id_generator.cpp
@@ -60,6 +60,12 @@ bool UniqueRowsetIdGenerator::id_in_use(const RowsetId& rowset_id) const {
 }
 
 void UniqueRowsetIdGenerator::release_id(const RowsetId& rowset_id) {
+    if (rowset_id.version < _version) {
+        return;
+    }
+    if ((rowset_id.mi != _backend_uid.hi) || (rowset_id.lo != _backend_uid.lo)) {
+        return;
+    }
     std::lock_guard<SpinLock> l(_lock);
     _valid_rowset_id_hi.erase(rowset_id.hi);
 }


### PR DESCRIPTION
The RowsetId a string of length 48. To reduce memory consumption,
only the high 16-bit string, like "0200000000000006", stored in the unordered_set.
Upon restart, the start point will be reset as zero. The number may
be overlap with the rowsets compacted. After compaction, the high-16 string
will be removed from the unordered_set. The Rowset GC daemon will remove the
files generated by the import in progress.

release_id() should check backend_uid first to avoid the startup problem.