### PR TITLE
Remove unused source type FORCE_SHUFFLE_JOIN

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ChildPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ChildPropertyDeriver.java
@@ -143,7 +143,7 @@ public class ChildPropertyDeriver extends OperatorVisitor<Void, ExpressionContex
         HashDistributionSpec rightDistribution = DistributionSpec.createHashDistributionSpec(
                 new HashDistributionDesc(rightOnPredicateColumns, HashDistributionDesc.SourceType.SHUFFLE_JOIN));
 
-        doHashShuffle(equalOnPredicate, leftDistribution, rightDistribution);
+        doHashShuffle(leftDistribution, rightDistribution);
 
         // Respect use join hint
         if ("SHUFFLE".equalsIgnoreCase(hint)) {
@@ -172,24 +172,7 @@ public class ChildPropertyDeriver extends OperatorVisitor<Void, ExpressionContex
         return visitJoinRequirements(node, context, canDoColocatedJoin);
     }
 
-    private void doHashShuffle(List<BinaryPredicateOperator> equalOnPredicate, HashDistributionSpec leftDistribution,
-                               HashDistributionSpec rightDistribution) {
-
-        // Need to force shuffle if the on clause contains expression
-        // @Todo: It's a temporary solution
-        if (equalOnPredicate.stream().anyMatch(p -> !isColumnToColumnBinaryPredicate(p))) {
-            PhysicalPropertySet leftProperty = createPropertySetByDistribution(new HashDistributionSpec(
-                    new HashDistributionDesc(leftDistribution.getShuffleColumns(),
-                            HashDistributionDesc.SourceType.FORCE_SHUFFLE_JOIN)));
-
-            PhysicalPropertySet rightProperty = createPropertySetByDistribution(new HashDistributionSpec(
-                    new HashDistributionDesc(rightDistribution.getShuffleColumns(),
-                            HashDistributionDesc.SourceType.FORCE_SHUFFLE_JOIN)));
-
-            outputInputProps.add(OutputInputProperty.emptyOutputOf(leftProperty, rightProperty));
-            return;
-        }
-
+    private void doHashShuffle(HashDistributionSpec leftDistribution, HashDistributionSpec rightDistribution) {
         // shuffle
         PhysicalPropertySet leftInputProperty = createPropertySetByDistribution(leftDistribution);
         PhysicalPropertySet rightInputProperty = createPropertySetByDistribution(rightDistribution);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/HashDistributionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/HashDistributionDesc.java
@@ -18,9 +18,7 @@ public class HashDistributionDesc {
         //  the result will be error
         SHUFFLE_AGG, // hash property from shuffle agg
         SHUFFLE_JOIN, // hash property from shuffle join
-        BUCKET_JOIN, // hash property from bucket join
-        // @Todo: It's a temporary solution
-        FORCE_SHUFFLE_JOIN, // hash property from shuffle join if contains expression in on clause
+        BUCKET_JOIN // hash property from bucket join
     }
 
     private final List<Integer> columns;


### PR DESCRIPTION
#2701 
FORCE_SHUFFLE_JOIN is a temporary solution,  it used for the on clause contains expression, because we push expression to child in RBO phase, this is useless.