### PR TITLE
Fix expr monotonicity property

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/BinaryPredicate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/BinaryPredicate.java
@@ -69,13 +69,13 @@ public class BinaryPredicate extends Predicate implements Writable {
     private boolean isInferred_ = false;
 
     public enum Operator {
-        EQ("=", "eq", TExprOpcode.EQ, true),
-        NE("!=", "ne", TExprOpcode.NE, true),
+        EQ("=", "eq", TExprOpcode.EQ, false),
+        NE("!=", "ne", TExprOpcode.NE, false),
         LE("<=", "le", TExprOpcode.LE, true),
         GE(">=", "ge", TExprOpcode.GE, true),
         LT("<", "lt", TExprOpcode.LT, true),
         GT(">", "gt", TExprOpcode.GT, true),
-        EQ_FOR_NULL("<=>", "eq_for_null", TExprOpcode.EQ_FOR_NULL, true);
+        EQ_FOR_NULL("<=>", "eq_for_null", TExprOpcode.EQ_FOR_NULL, false);
 
         private final String description;
         private final String name;

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/CastExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/CastExpr.java
@@ -359,6 +359,10 @@ public class CastExpr extends Expr {
 
     @Override
     public boolean isSelfMonotonic() {
-        return true;
+        // It's very tempting to think cast is monotonic, but that's not true.
+        // For example `cast(bigint to tinyint) < 10`
+        // maybe min/max value will overflow tinyint, and we will get NULL value, so `NULL is true` is false.
+        // but some values between min/max value like 5,6,7,8 can be evaluated to true.
+        return false;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithDecimalTypesNewPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithDecimalTypesNewPlannerTest.java
@@ -125,9 +125,9 @@ public class SelectStmtWithDecimalTypesNewPlannerTest {
         String sql = "select col_decimal128p20s3 * 3.14 from db1.decimal_table";
         String expectString = "TExprNode(node_type:ARITHMETIC_EXPR, type:TTypeDesc(types:[TTypeNode(type:SCALAR, " +
                 "scalar_type:TScalarType(type:DECIMAL128, precision:38, scale:5))]), opcode:MULTIPLY, num_children:2," +
-                " output_scale:-1, output_column:-1, has_nullable_child:true, is_nullable:true, is_monotonic:true)," +
+                " output_scale:-1, output_column:-1, has_nullable_child:true, is_nullable:true, is_monotonic:false)," +
                 " TExprNode(node_type:CAST_EXPR, type:TTypeDesc(types:[TTypeNode(type:SCALAR, scalar_type:TScalarType(type:DECIMAL128, precision:38, scale:3))])," +
-                " opcode:INVALID_OPCODE, num_children:1, output_scale:-1, output_column:-1, child_type:DECIMAL128, has_nullable_child:true, is_nullable:true, is_monotonic:true), " +
+                " opcode:INVALID_OPCODE, num_children:1, output_scale:-1, output_column:-1, child_type:DECIMAL128, has_nullable_child:true, is_nullable:true, is_monotonic:false), " +
                 "TExprNode(node_type:SLOT_REF, type:TTypeDesc(types:[TTypeNode(type:SCALAR, scalar_type:TScalarType" +
                 "(type:DECIMAL128, precision:20, scale:3))]), num_children:0, slot_ref:TSlotRef(slot_id:3, tuple_id:0)," +
                 " output_scale:-1, output_column:-1, has_nullable_child:false, is_nullable:true, is_monotonic:true)," +


### PR DESCRIPTION
Fix:  #2507 #2508 #2510 #2511 

Binary Operator `=` and `!=` is not monotonic
- eg.  `C = 10`
- if min/max is [-20, 20], both eveluated to be false
- but 10 in [-20, 20] is true
- so `=` and `!=` is not monotonic

Also cast operator is not monotonic. Maybe cast narrow type to wide type is safe, but quick solution is to disable it.