### PR TITLE
Fix correlated subquery use cte with alias bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/ExpressionMapping.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/ExpressionMapping.java
@@ -46,11 +46,12 @@ public class ExpressionMapping {
         this.scope = scope;
         List<ColumnRefOperator> fieldsList = new ArrayList<>(fieldMappings);
         if (outer != null) {
+            this.scope.setParent(outer.getScope());
             fieldsList.addAll(outer.getFieldMappings());
+            this.outerScopeRelationId = outer.getScope().getRelationId();
         }
         this.fieldMappings = new ColumnRefOperator[fieldsList.size()];
         fieldsList.toArray(this.fieldMappings);
-        this.outerScopeRelationId = outer.getScope().getRelationId();
     }
 
     public ExpressionMapping(Scope scope) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
@@ -401,7 +401,7 @@ public class RelationTransformer extends RelationVisitor<LogicalPlan, Expression
 
             return new LogicalPlan(
                     new OptExprBuilder(new LogicalCTEConsumeOperator(node.getCteId(), cteOutputColumnRefMap),
-                            Collections.emptyList(), new ExpressionMapping(expressionMapping.getScope(), cteOutputs)),
+                            Collections.emptyList(), new ExpressionMapping(node.getScope(), cteOutputs)),
                     null, null);
         } else {
             LogicalPlan logicalPlan = visit(node.getCteQuery());


### PR DESCRIPTION
#2525

In CTE reuse, the analysis should use the Scope in CTERelation, not the Scope in LogicalCTEProducer that has been parsed

In this position, expressionMapping is the parsing of the query in CTE, and the corresponding expressionMapping.getScope() is the scope of the query in CTE. And node.getScope() is the Scope resolved by CTERelation as Relation.
For example: with cte as (select v1,v2,v3 from t0) select t.v1 from cte t, then expressionMapping.getScope() is [cte.v1, cte.v2, cte.v3], and node.getScope( ) Is [t.v1, t.v2, t.v3], then if t.v1 is to be resolve, node.getScope is obviously required