### PR TITLE
Upgrade log4j2 to 2.17.1 due to CVE-2021-44832

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -42,7 +42,7 @@ under the License.
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <jprotobuf.version>2.4.12</jprotobuf.version>
-        <log4j.version>2.17.0</log4j.version>
+        <log4j.version>2.17.1</log4j.version>
         <jackson.version>2.12.1</jackson.version>
         <spark.version>2.4.6</spark.version>
         <tomcat.version>8.5.70</tomcat.version>

--- a/fs_brokers/apache_hdfs_broker/pom.xml
+++ b/fs_brokers/apache_hdfs_broker/pom.xml
@@ -42,6 +42,7 @@ under the License.
         <protobuf.version>2.5.0</protobuf.version>
         <thrift.version>0.14.1</thrift.version>
         <tomcat.version>8.5.70</tomcat.version>
+        <log4j.version>2.17.1</log4j.version>
     </properties>
 
     <profiles>
@@ -279,14 +280,14 @@ under the License.
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.17.0</version>
+            <version>${log4j.version}</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.17.0</version>
+            <version>${log4j.version}</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java -->


### PR DESCRIPTION
more detail:
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44832