### PR TITLE
Use session's chunk_size instead of config::vector_chunk_size

### DIFF
--- a/be/src/column/array_column.cpp
+++ b/be/src/column/array_column.cpp
@@ -181,9 +181,9 @@ void ArrayColumn::serialize_batch(uint8_t* dst, Buffer<uint32_t>& slice_sizes, s
     }
 }
 
-void ArrayColumn::deserialize_and_append_batch(std::vector<Slice>& srcs, size_t batch_size) {
-    reserve(batch_size);
-    for (size_t i = 0; i < batch_size; ++i) {
+void ArrayColumn::deserialize_and_append_batch(std::vector<Slice>& srcs, size_t chunk_size) {
+    reserve(chunk_size);
+    for (size_t i = 0; i < chunk_size; ++i) {
         srcs[i].data = (char*)deserialize_and_append((uint8_t*)srcs[i].data);
     }
 }

--- a/be/src/column/array_column.h
+++ b/be/src/column/array_column.h
@@ -93,7 +93,7 @@ public:
 
     const uint8_t* deserialize_and_append(const uint8_t* pos) override;
 
-    void deserialize_and_append_batch(std::vector<Slice>& srcs, size_t batch_size) override;
+    void deserialize_and_append_batch(std::vector<Slice>& srcs, size_t chunk_size) override;
 
     uint32_t serialize_size(size_t idx) const override;
 

--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -365,10 +365,10 @@ const uint8_t* BinaryColumn::deserialize_and_append(const uint8_t* pos) {
     return pos + string_size;
 }
 
-void BinaryColumn::deserialize_and_append_batch(std::vector<Slice>& srcs, size_t batch_size) {
+void BinaryColumn::deserialize_and_append_batch(std::vector<Slice>& srcs, size_t chunk_size) {
     uint32_t string_size = *((uint32_t*)srcs[0].data);
-    _bytes.reserve(batch_size * string_size * 2);
-    for (size_t i = 0; i < batch_size; ++i) {
+    _bytes.reserve(chunk_size * string_size * 2);
+    for (size_t i = 0; i < chunk_size; ++i) {
         srcs[i].data = (char*)deserialize_and_append((uint8_t*)srcs[i].data);
     }
 }

--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -178,7 +178,7 @@ public:
 
     const uint8_t* deserialize_and_append(const uint8_t* pos) override;
 
-    void deserialize_and_append_batch(std::vector<Slice>& srcs, size_t batch_size) override;
+    void deserialize_and_append_batch(std::vector<Slice>& srcs, size_t chunk_size) override;
 
     uint32_t serialize_size(size_t idx) const override { return sizeof(uint32_t) + _offsets[idx + 1] - _offsets[idx]; }
 

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -240,7 +240,7 @@ public:
     // deserialize one data and append to this column
     virtual const uint8_t* deserialize_and_append(const uint8_t* pos) = 0;
 
-    virtual void deserialize_and_append_batch(std::vector<Slice>& srcs, size_t batch_size) = 0;
+    virtual void deserialize_and_append_batch(std::vector<Slice>& srcs, size_t chunk_size) = 0;
 
     // One element serialize_size
     virtual uint32_t serialize_size(size_t idx) const = 0;

--- a/be/src/column/column_builder.h
+++ b/be/src/column/column_builder.h
@@ -17,19 +17,19 @@ public:
     using NullColumnPtr = NullColumn::Ptr;
     using DatumType = RunTimeCppType<Type>;
 
-    ColumnBuilder() {
+    ColumnBuilder(int32_t chunk_size) {
         static_assert(!pt_is_decimal<Type>, "Not support Decimal32/64/128 types");
         _has_null = false;
         _column = RunTimeColumnType<Type>::create();
         _null_column = NullColumn::create();
-        reserve(config::vector_chunk_size);
+        reserve(chunk_size);
     }
 
-    ColumnBuilder(int precision, int scale) {
+    ColumnBuilder(int32_t chunk_size, int precision, int scale) {
         _has_null = false;
         _column = RunTimeColumnType<Type>::create();
         _null_column = NullColumn::create();
-        reserve(config::vector_chunk_size);
+        reserve(chunk_size);
 
         if constexpr (pt_is_decimal<Type>) {
             static constexpr auto max_precision = decimal_precision_limit<DatumType>;

--- a/be/src/column/column_helper.cpp
+++ b/be/src/column/column_helper.cpp
@@ -20,7 +20,7 @@ NullColumnPtr ColumnHelper::one_size_null_column = NullColumn::create(1, 1);
 NullColumnPtr ColumnHelper::s_all_not_null_column = nullptr;
 
 void ColumnHelper::init_static_variable() {
-    ColumnHelper::s_all_not_null_column = NullColumn::create(config::vector_chunk_size, 0);
+    ColumnHelper::s_all_not_null_column = NullColumn::create(config::chunk_size_all_not_null_column, 0);
 }
 
 Column::Filter& ColumnHelper::merge_nullable_filter(Column* column) {

--- a/be/src/column/column_helper.cpp
+++ b/be/src/column/column_helper.cpp
@@ -17,12 +17,6 @@ NullColumnPtr ColumnHelper::one_size_not_null_column = NullColumn::create(1, 0);
 
 NullColumnPtr ColumnHelper::one_size_null_column = NullColumn::create(1, 1);
 
-NullColumnPtr ColumnHelper::s_all_not_null_column = nullptr;
-
-void ColumnHelper::init_static_variable() {
-    ColumnHelper::s_all_not_null_column = NullColumn::create(config::chunk_size_all_not_null_column, 0);
-}
-
 Column::Filter& ColumnHelper::merge_nullable_filter(Column* column) {
     if (column->is_nullable()) {
         auto* nullable_column = down_cast<NullableColumn*>(column);

--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -23,8 +23,6 @@ namespace starrocks::vectorized {
 
 class ColumnHelper {
 public:
-    static void init_static_variable();
-
     // The input column is nullable or non-nullable uint8 column
     // The result column is not nullable uint8 column
     // For nullable uint8 column, we merge it's null column and data column
@@ -304,8 +302,6 @@ public:
     static NullColumnPtr one_size_not_null_column;
 
     static NullColumnPtr one_size_null_column;
-
-    static NullColumnPtr s_all_not_null_column;
 };
 
 } // namespace starrocks::vectorized

--- a/be/src/column/column_pool.h
+++ b/be/src/column/column_pool.h
@@ -135,8 +135,8 @@ class CACHELINE_ALIGNED ColumnPool {
             return obj;
         }
 
-        inline void return_object(T* ptr) {
-            if (UNLIKELY(column_reserved_size(ptr) > config::vector_chunk_size)) {
+        inline void return_object(T* ptr, size_t chunk_size) {
+            if (UNLIKELY(column_reserved_size(ptr) > chunk_size)) {
                 delete ptr;
                 return;
             }
@@ -204,11 +204,11 @@ public:
         return ptr;
     }
 
-    inline void return_column(T* ptr) {
+    inline void return_column(T* ptr, size_t chunk_size) {
         LocalPool* lp = _get_or_new_local_pool();
         if (LIKELY(lp != nullptr)) {
             reset_column(ptr);
-            lp->return_object(ptr);
+            lp->return_object(ptr, chunk_size);
         } else {
             delete ptr;
         }
@@ -391,9 +391,9 @@ inline T* get_column() {
 }
 
 template <typename T>
-inline void return_column(T* ptr) {
+inline void return_column(T* ptr, size_t chunk_size) {
     static_assert(InList<ColumnPool<T>, ColumnPoolList>::value, "Cannot use column pool");
-    ColumnPool<T>::singleton()->return_column(ptr);
+    ColumnPool<T>::singleton()->return_column(ptr, chunk_size);
 }
 
 template <typename T>

--- a/be/src/column/const_column.h
+++ b/be/src/column/const_column.h
@@ -135,14 +135,14 @@ public:
         return pos + _data->serialize_size(0);
     }
 
-    void deserialize_and_append_batch(std::vector<Slice>& srcs, size_t batch_size) override {
-        _size += batch_size;
+    void deserialize_and_append_batch(std::vector<Slice>& srcs, size_t chunk_size) override {
+        _size += chunk_size;
         if (_data->empty()) {
             _data->deserialize_and_append((uint8_t*)srcs[0].data);
         }
         uint32_t serialize_size = _data->serialize_size(0);
         // Note: we must update the pos
-        for (size_t i = 0; i < batch_size; i++) {
+        for (size_t i = 0; i < chunk_size; i++) {
             srcs[0].data = srcs[0].data + serialize_size;
         }
     }

--- a/be/src/column/fixed_length_column_base.cpp
+++ b/be/src/column/fixed_length_column_base.cpp
@@ -158,9 +158,9 @@ const uint8_t* FixedLengthColumnBase<T>::deserialize_and_append(const uint8_t* p
 }
 
 template <typename T>
-void FixedLengthColumnBase<T>::deserialize_and_append_batch(std::vector<Slice>& srcs, size_t batch_size) {
-    raw::make_room(&_data, batch_size);
-    for (size_t i = 0; i < batch_size; ++i) {
+void FixedLengthColumnBase<T>::deserialize_and_append_batch(std::vector<Slice>& srcs, size_t chunk_size) {
+    raw::make_room(&_data, chunk_size);
+    for (size_t i = 0; i < chunk_size; ++i) {
         memcpy(&_data[i], srcs[i].data, sizeof(T));
         srcs[i].data = srcs[i].data + sizeof(T);
     }

--- a/be/src/column/fixed_length_column_base.h
+++ b/be/src/column/fixed_length_column_base.h
@@ -143,7 +143,7 @@ public:
 
     const uint8_t* deserialize_and_append(const uint8_t* pos) override;
 
-    void deserialize_and_append_batch(std::vector<Slice>& srcs, size_t batch_size) override;
+    void deserialize_and_append_batch(std::vector<Slice>& srcs, size_t chunk_size) override;
 
     uint32_t serialize_size(size_t idx) const override { return sizeof(ValueType); }
 

--- a/be/src/column/nullable_column.cpp
+++ b/be/src/column/nullable_column.cpp
@@ -232,8 +232,8 @@ const uint8_t* NullableColumn::deserialize_and_append(const uint8_t* pos) {
     return pos;
 }
 
-void NullableColumn::deserialize_and_append_batch(std::vector<Slice>& srcs, size_t batch_size) {
-    for (size_t i = 0; i < batch_size; ++i) {
+void NullableColumn::deserialize_and_append_batch(std::vector<Slice>& srcs, size_t chunk_size) {
+    for (size_t i = 0; i < chunk_size; ++i) {
         srcs[i].data = (char*)deserialize_and_append((uint8_t*)srcs[i].data);
     }
 }

--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -155,7 +155,7 @@ public:
 
     const uint8_t* deserialize_and_append(const uint8_t* pos) override;
 
-    void deserialize_and_append_batch(std::vector<Slice>& srcs, size_t batch_size) override;
+    void deserialize_and_append_batch(std::vector<Slice>& srcs, size_t chunk_size) override;
 
     uint32_t serialize_size(size_t idx) const override {
         if (_null_column->get_data()[idx]) {

--- a/be/src/column/object_column.cpp
+++ b/be/src/column/object_column.cpp
@@ -149,7 +149,7 @@ const uint8_t* ObjectColumn<T>::deserialize_and_append(const uint8_t* pos) {
 }
 
 template <typename T>
-void ObjectColumn<T>::deserialize_and_append_batch(std::vector<Slice>& srcs, size_t batch_size) {
+void ObjectColumn<T>::deserialize_and_append_batch(std::vector<Slice>& srcs, size_t chunk_size) {
     DCHECK(false) << "Don't support object column deserialize and append";
 }
 

--- a/be/src/column/object_column.h
+++ b/be/src/column/object_column.h
@@ -108,7 +108,7 @@ public:
 
     const uint8_t* deserialize_and_append(const uint8_t* pos) override;
 
-    void deserialize_and_append_batch(std::vector<Slice>& srcs, size_t batch_size) override;
+    void deserialize_and_append_batch(std::vector<Slice>& srcs, size_t chunk_size) override;
 
     uint32_t serialize_size(size_t idx) const override;
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -572,6 +572,10 @@ CONF_Bool(ignore_rowset_stale_unconsistent_delete, "false");
 // The chunk size for vector query engine
 CONF_Int32(vector_chunk_size, "4096");
 
+// The chunk size for all_not_null_column,
+// It's only used in ColumnHelper::s_all_not_null_column
+CONF_Int32(chunk_size_all_not_null_column, "16384");
+
 // valid range: [0-1000].
 // `0` will disable late materialization.
 // `1000` will enable late materialization always.

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -572,10 +572,6 @@ CONF_Bool(ignore_rowset_stale_unconsistent_delete, "false");
 // The chunk size for vector query engine
 CONF_Int32(vector_chunk_size, "4096");
 
-// The chunk size for all_not_null_column,
-// It's only used in ColumnHelper::s_all_not_null_column
-CONF_Int32(chunk_size_all_not_null_column, "16384");
-
 // valid range: [0-1000].
 // `0` will disable late materialization.
 // `1000` will enable late materialization always.

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -262,7 +262,6 @@ void Daemon::init(int argc, char** argv, const std::vector<StorePath>& paths) {
 
     UserFunctionCache::instance()->init(config::user_function_dir);
 
-    vectorized::ColumnHelper::init_static_variable();
     vectorized::date::init_date_cache();
 
     std::thread tcmalloc_gc_thread(gc_tcmalloc_memory, this);

--- a/be/src/exec/exchange_node.cpp
+++ b/be/src/exec/exchange_node.cpp
@@ -83,7 +83,7 @@ Status ExchangeNode::open(RuntimeState* state) {
     if (_use_vectorized) {
         if (_is_merging) {
             RETURN_IF_ERROR(_sort_exec_exprs.open(state));
-            RETURN_IF_ERROR(_stream_recvr->create_merger(&_sort_exec_exprs, &_is_asc_order, &_nulls_first));
+            RETURN_IF_ERROR(_stream_recvr->create_merger(state, &_sort_exec_exprs, &_is_asc_order, &_nulls_first));
         }
         return Status::OK();
     }
@@ -196,7 +196,7 @@ Status ExchangeNode::get_next_merging(RuntimeState* state, ChunkPtr* chunk, bool
             _num_rows_skipped = _offset;
             _num_rows_returned += size;
             COUNTER_SET(_rows_returned_counter, _num_rows_returned);
-            // the first Chunk will have a size less than config::vector_chunk_size.
+            // the first Chunk will have a size less than chunk_size.
             return Status::OK();
         }
 

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.cpp
@@ -60,7 +60,7 @@ Status AggregateBlockingSinkOperator::push_chunk(RuntimeState* state, const vect
              _aggregator->conjunct_ctxs().empty() &&       // no 'having' clause
              _aggregator->get_aggr_phase() == AggrPhase2); // phase 2, keep it to make things safe
     const auto chunk_size = chunk->num_rows();
-    DCHECK_LE(chunk_size, state->batch_size());
+    DCHECK_LE(chunk_size, state->chunk_size());
 
     SCOPED_TIMER(_aggregator->agg_compute_timer());
     if (!_aggregator->is_none_group_by_exprs()) {

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.cpp
@@ -27,7 +27,7 @@ StatusOr<vectorized::ChunkPtr> AggregateBlockingSourceOperator::pull_chunk(Runti
     SCOPED_TIMER(_runtime_profile->total_time_counter());
     RETURN_IF_CANCELLED(state);
 
-    int32_t chunk_size = state->batch_size();
+    int32_t chunk_size = state->chunk_size();
     vectorized::ChunkPtr chunk = std::make_shared<vectorized::Chunk>();
 
     if (_aggregator->is_none_group_by_exprs()) {

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.cpp
@@ -45,7 +45,7 @@ StatusOr<vectorized::ChunkPtr> AggregateDistinctBlockingSinkOperator::pull_chunk
 }
 
 Status AggregateDistinctBlockingSinkOperator::push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) {
-    DCHECK_LE(chunk->num_rows(), state->batch_size());
+    DCHECK_LE(chunk->num_rows(), state->chunk_size());
     _aggregator->evaluate_exprs(chunk.get());
 
     {

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.cpp
@@ -27,7 +27,7 @@ StatusOr<vectorized::ChunkPtr> AggregateDistinctBlockingSourceOperator::pull_chu
     SCOPED_TIMER(_runtime_profile->total_time_counter());
     RETURN_IF_CANCELLED(state);
 
-    int32_t chunk_size = state->batch_size();
+    int32_t chunk_size = state->chunk_size();
     vectorized::ChunkPtr chunk = std::make_shared<vectorized::Chunk>();
 
     if (false) {

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.cpp
@@ -71,7 +71,7 @@ void AggregateDistinctStreamingSourceOperator::_output_chunk_from_hash_set(vecto
 #define HASH_MAP_METHOD(NAME)                                                                                     \
     else if (_aggregator->hash_set_variant().type == vectorized::HashSetVariant::Type::NAME)                      \
             _aggregator->convert_hash_set_to_chunk<decltype(_aggregator->hash_set_variant().NAME)::element_type>( \
-                    *_aggregator->hash_set_variant().NAME, state->batch_size(), chunk);
+                    *_aggregator->hash_set_variant().NAME, state->chunk_size(), chunk);
     APPLY_FOR_VARIANT_ALL(HASH_MAP_METHOD)
 #undef HASH_MAP_METHOD
     else {

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.cpp
@@ -92,7 +92,7 @@ void AggregateStreamingSourceOperator::_output_chunk_from_hash_map(vectorized::C
 #define HASH_MAP_METHOD(NAME)                                                                                     \
     else if (_aggregator->hash_map_variant().type == vectorized::HashMapVariant::Type::NAME)                      \
             _aggregator->convert_hash_map_to_chunk<decltype(_aggregator->hash_map_variant().NAME)::element_type>( \
-                    *_aggregator->hash_map_variant().NAME, state->batch_size(), chunk);
+                    *_aggregator->hash_map_variant().NAME, state->chunk_size(), chunk);
     APPLY_FOR_VARIANT_ALL(HASH_MAP_METHOD)
 #undef HASH_MAP_METHOD
     else {

--- a/be/src/exec/pipeline/aggregate/repeat/repeat_operator.h
+++ b/be/src/exec/pipeline/aggregate/repeat/repeat_operator.h
@@ -94,10 +94,10 @@ private:
     const uint64_t _repeat_times_required;
     // repeat timer for chunk. 0 <=  _repeat_times_last < _repeat_times_required.
     uint64_t _repeat_times_last;
-    // only null columns for reusing, It has config::vector_chunk_size rows.
+    // only null columns for reusing, It has chunk_size rows.
     const ColumnPtr& _column_null;
     // column for grouping_id and virtual columns for grouping()/grouping_id() for reusing.
-    // It has config::vector_chunk_size rows.
+    // It has chunk_size rows.
     const std::vector<std::vector<ColumnPtr>>& _grouping_columns;
     // _grouping_list for grouping_id'value and grouping()/grouping_id()'s value.
     // It's a two dimensional array.

--- a/be/src/exec/pipeline/chunk_source.h
+++ b/be/src/exec/pipeline/chunk_source.h
@@ -34,7 +34,7 @@ public:
 
     virtual StatusOr<vectorized::ChunkPtr> get_next_chunk_from_buffer() = 0;
 
-    virtual Status buffer_next_batch_chunks_blocking(size_t batch_size, bool& can_finish) = 0;
+    virtual Status buffer_next_batch_chunks_blocking(size_t chunk_size, bool& can_finish) = 0;
 
 protected:
     // The morsel will own by pipeline driver

--- a/be/src/exec/pipeline/crossjoin/cross_join_left_operator.cpp
+++ b/be/src/exec/pipeline/crossjoin/cross_join_left_operator.cpp
@@ -41,7 +41,7 @@ void CrossJoinLeftOperator::_init_chunk(vectorized::ChunkPtr* chunk, RuntimeStat
     }
 
     *chunk = std::move(new_chunk);
-    (*chunk)->reserve(state->batch_size());
+    (*chunk)->reserve(state->chunk_size());
 }
 
 void CrossJoinLeftOperator::_copy_joined_rows_with_index_base_probe(vectorized::ChunkPtr& chunk, size_t row_count,
@@ -241,7 +241,7 @@ void CrossJoinLeftOperator::_select_build_chunk(const int32_t unprocessed_build_
         DCHECK(_curr_build_chunk != nullptr && _curr_build_chunk->num_rows() > 0);
 
         _curr_total_build_rows = _curr_build_chunk->num_rows();
-        _curr_build_rows_threshold = (_curr_total_build_rows / state->batch_size()) * state->batch_size();
+        _curr_build_rows_threshold = (_curr_total_build_rows / state->chunk_size()) * state->chunk_size();
         _curr_build_rows_remainder = _curr_total_build_rows - _curr_build_rows_threshold;
 
         _within_threshold_build_rows_index = 0;
@@ -262,7 +262,7 @@ StatusOr<vectorized::ChunkPtr> CrossJoinLeftOperator::pull_chunk(RuntimeState* s
 
     for (;;) {
         // need row_count to fill in chunk.
-        size_t row_count = state->batch_size() - chunk->num_rows();
+        size_t row_count = state->chunk_size() - chunk->num_rows();
 
         // means we have scan all chunks of right tables.
         // we should scan all remain rows of right table.
@@ -357,7 +357,7 @@ StatusOr<vectorized::ChunkPtr> CrossJoinLeftOperator::pull_chunk(RuntimeState* s
 
         // When the chunk is full or the current probe chunk is finished
         // crossing join with build chunks, we can output this chunk.
-        if (chunk->num_rows() >= state->batch_size() || _is_curr_probe_chunk_finished()) {
+        if (chunk->num_rows() >= state->chunk_size() || _is_curr_probe_chunk_finished()) {
             eval_conjuncts_and_in_filters(_conjunct_ctxs, chunk.get());
             break;
         }

--- a/be/src/exec/pipeline/exchange/exchange_merge_sort_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_merge_sort_source_operator.cpp
@@ -16,7 +16,7 @@ Status ExchangeMergeSortSourceOperator::prepare(RuntimeState* state) {
     _stream_recvr = state->exec_env()->stream_mgr()->create_recvr(
             state, _row_desc, state->fragment_instance_id(), _plan_node_id, _num_sender,
             config::exchg_node_buffer_size_bytes, _runtime_profile, true, nullptr, true, true);
-    _stream_recvr->create_merger_for_pipeline(_sort_exec_exprs, &_is_asc_order, &_nulls_first);
+    _stream_recvr->create_merger_for_pipeline(state, _sort_exec_exprs, &_is_asc_order, &_nulls_first);
     return Status::OK();
 }
 
@@ -99,7 +99,7 @@ Status ExchangeMergeSortSourceOperator::get_next_merging(RuntimeState* state, Ch
             _num_rows_input = _offset;
             _num_rows_returned += rewind_size;
 
-            // the first Chunk will have a size less than config::vector_chunk_size.
+            // the first Chunk will have a size less than state->chunk_size().
             return Status::OK();
         }
 

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -168,7 +168,7 @@ Status ExchangeSinkOperator::Channel::add_rows_selective(vectorized::Chunk* chun
         _chunk = chunk->clone_empty_with_tuple();
     }
 
-    if (_chunk->num_rows() + size > state->batch_size()) {
+    if (_chunk->num_rows() + size > state->chunk_size()) {
         RETURN_IF_ERROR(send_one_chunk(_chunk.get(), false));
         // we only clear column data, because we need to reuse column schema
         _chunk->set_num_rows(0);
@@ -351,7 +351,7 @@ Status ExchangeSinkOperator::prepare(RuntimeState* state) {
         RETURN_IF_ERROR(_channel->init(state));
     }
 
-    _row_indexes.resize(state->batch_size());
+    _row_indexes.resize(state->chunk_size());
 
     return Status::OK();
 }

--- a/be/src/exec/pipeline/exchange/local_exchange.h
+++ b/be/src/exec/pipeline/exchange/local_exchange.h
@@ -65,7 +65,7 @@ class PartitionExchanger final : public LocalExchanger {
                     const std::vector<ExprContext*>& partition_expr_ctxs)
                 : _source(source), _is_shuffle(is_shuffle), _partition_expr_ctxs(partition_expr_ctxs) {
             _partitions_columns.resize(partition_expr_ctxs.size());
-            _hash_values.reserve(config::vector_chunk_size);
+            _hash_values.reserve(source->runtime_state()->chunk_size());
         }
 
         // Divide chunk into shuffle partitions.

--- a/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
@@ -45,7 +45,7 @@ bool LocalExchangeSourceOperator::is_finished() const {
 bool LocalExchangeSourceOperator::has_output() const {
     std::lock_guard<std::mutex> l(_chunk_lock);
 
-    return !_full_chunk_queue.empty() || _partition_rows_num >= config::vector_chunk_size ||
+    return !_full_chunk_queue.empty() || _partition_rows_num >= _factory->runtime_state()->chunk_size() ||
            (_is_finished && _partition_rows_num > 0);
 }
 
@@ -99,7 +99,7 @@ vectorized::ChunkPtr LocalExchangeSourceOperator::_pull_shuffle_chunk(RuntimeSta
         DCHECK(!_partition_chunk_queue.empty());
 
         while (!_partition_chunk_queue.empty() &&
-               rows_num + _partition_chunk_queue.front().size <= state->batch_size()) {
+               rows_num + _partition_chunk_queue.front().size <= state->chunk_size()) {
             rows_num += _partition_chunk_queue.front().size;
             selected_partition_chunks.emplace_back(std::move(_partition_chunk_queue.front()));
             _partition_chunk_queue.pop();

--- a/be/src/exec/pipeline/exchange/multi_cast_local_exchange.cpp
+++ b/be/src/exec/pipeline/exchange/multi_cast_local_exchange.cpp
@@ -42,7 +42,7 @@ bool MultiCastLocalExchanger::can_push_chunk() const {
     // if for the fastest consumer, the exchanger still has enough chunk to be consumed.
     // the exchanger does not need any input.
     if ((_current_accumulated_row_size - _fast_accumulated_row_size) >
-        config::vector_chunk_size * kBufferedRowSizeScaleFactor) {
+        _runtime_state->chunk_size() * kBufferedRowSizeScaleFactor) {
         return false;
     }
     return true;

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -108,7 +108,7 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
     _fragment_ctx->set_runtime_state(
             std::make_unique<RuntimeState>(query_id, fragment_instance_id, query_options, query_globals, exec_env));
     auto* runtime_state = _fragment_ctx->runtime_state();
-    runtime_state->set_batch_size(config::vector_chunk_size);
+    runtime_state->set_chunk_size(query_options.chunk_size);
     runtime_state->init_mem_trackers(query_id);
     runtime_state->set_be_number(backend_num);
 
@@ -123,7 +123,7 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
     // Set up desc tbl
     auto* obj_pool = runtime_state->obj_pool();
     DescriptorTbl* desc_tbl = nullptr;
-    RETURN_IF_ERROR(DescriptorTbl::create(obj_pool, t_desc_tbl, &desc_tbl));
+    RETURN_IF_ERROR(DescriptorTbl::create(obj_pool, t_desc_tbl, &desc_tbl, runtime_state->chunk_size()));
     runtime_state->set_desc_tbl(desc_tbl);
     // Set up plan
     ExecNode* plan = nullptr;

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -108,7 +108,7 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
     _fragment_ctx->set_runtime_state(
             std::make_unique<RuntimeState>(query_id, fragment_instance_id, query_options, query_globals, exec_env));
     auto* runtime_state = _fragment_ctx->runtime_state();
-    runtime_state->set_chunk_size(query_options.chunk_size);
+    runtime_state->set_chunk_size(query_options.batch_size);
     runtime_state->init_mem_trackers(query_id);
     runtime_state->set_be_number(backend_num);
 

--- a/be/src/exec/pipeline/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/olap_chunk_source.cpp
@@ -143,10 +143,10 @@ Status OlapChunkSource::_init_reader_params(const std::vector<OlapScanRange*>& k
     _params.runtime_state = _runtime_state;
     _params.use_page_cache = !config::disable_storage_page_cache;
     // Improve for select * from table limit x, x is small
-    if (_limit != -1 && _limit < config::vector_chunk_size) {
+    if (_limit != -1 && _limit < _runtime_state->chunk_size()) {
         _params.chunk_size = _limit;
     } else {
-        _params.chunk_size = config::vector_chunk_size;
+        _params.chunk_size = _runtime_state->chunk_size();
     }
 
     PredicateParser parser(_tablet->tablet_schema());
@@ -294,15 +294,15 @@ StatusOr<vectorized::ChunkPtr> OlapChunkSource::get_next_chunk_from_buffer() {
     return chunk;
 }
 
-Status OlapChunkSource::buffer_next_batch_chunks_blocking(size_t batch_size, bool& can_finish) {
+Status OlapChunkSource::buffer_next_batch_chunks_blocking(size_t chunk_size, bool& can_finish) {
     if (!_status.ok()) {
         return _status;
     }
     using namespace vectorized;
 
-    for (size_t i = 0; i < batch_size && !can_finish; ++i) {
+    for (size_t i = 0; i < chunk_size && !can_finish; ++i) {
         ChunkUniquePtr chunk(
-                ChunkHelper::new_chunk_pooled(_prj_iter->encoded_schema(), config::vector_chunk_size, true));
+                ChunkHelper::new_chunk_pooled(_prj_iter->encoded_schema(), _runtime_state->chunk_size(), true));
         _status = _read_chunk_from_storage(_runtime_state, chunk.get());
         if (!_status.ok()) {
             // end of file is normal case, need process chunk

--- a/be/src/exec/pipeline/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/olap_chunk_source.cpp
@@ -294,13 +294,13 @@ StatusOr<vectorized::ChunkPtr> OlapChunkSource::get_next_chunk_from_buffer() {
     return chunk;
 }
 
-Status OlapChunkSource::buffer_next_batch_chunks_blocking(size_t chunk_size, bool& can_finish) {
+Status OlapChunkSource::buffer_next_batch_chunks_blocking(size_t batch_size, bool& can_finish) {
     if (!_status.ok()) {
         return _status;
     }
     using namespace vectorized;
 
-    for (size_t i = 0; i < chunk_size && !can_finish; ++i) {
+    for (size_t i = 0; i < batch_size && !can_finish; ++i) {
         ChunkUniquePtr chunk(
                 ChunkHelper::new_chunk_pooled(_prj_iter->encoded_schema(), _runtime_state->chunk_size(), true));
         _status = _read_chunk_from_storage(_runtime_state, chunk.get());

--- a/be/src/exec/pipeline/olap_chunk_source.h
+++ b/be/src/exec/pipeline/olap_chunk_source.h
@@ -60,7 +60,7 @@ public:
 
     StatusOr<vectorized::ChunkPtr> get_next_chunk_from_buffer() override;
 
-    Status buffer_next_batch_chunks_blocking(size_t batch_size, bool& can_finish) override;
+    Status buffer_next_batch_chunks_blocking(size_t chunk_size, bool& can_finish) override;
 
 private:
     Status _get_tablet(const TInternalScanRange* scan_range);

--- a/be/src/exec/pipeline/operator.cpp
+++ b/be/src/exec/pipeline/operator.cpp
@@ -151,6 +151,7 @@ OperatorFactory::OperatorFactory(int32_t id, const std::string& name, int32_t pl
 }
 
 Status OperatorFactory::prepare(RuntimeState* state) {
+    _state = state;
     if (_runtime_filter_collector) {
         RETURN_IF_ERROR(_runtime_filter_collector->prepare(state, _row_desc, _runtime_profile.get()));
     }

--- a/be/src/exec/pipeline/operator.h
+++ b/be/src/exec/pipeline/operator.h
@@ -223,6 +223,10 @@ public:
     }
     const std::vector<SlotId>& get_filter_null_value_columns() const { return _filter_null_value_columns; }
 
+    void set_runtime_state(RuntimeState* state) { this->_state = state; }
+
+    RuntimeState* runtime_state() { return _state; }
+
 protected:
     void _prepare_runtime_in_filters(RuntimeState* state) {
         auto holders = _runtime_filter_hub->gather_holders(_rf_waiting_set);
@@ -257,6 +261,8 @@ protected:
     // Mappings from input slot to output slot of ancestor exec nodes (include itself).
     // It is used to rewrite runtime in filters.
     std::vector<TupleSlotMapping> _tuple_slot_mappings;
+
+    RuntimeState* _state = nullptr;
 };
 
 using OpFactoryPtr = std::shared_ptr<OperatorFactory>;

--- a/be/src/exec/pipeline/pipeline_builder.cpp
+++ b/be/src/exec/pipeline/pipeline_builder.cpp
@@ -6,17 +6,18 @@
 
 namespace starrocks::pipeline {
 
-OpFactories PipelineBuilderContext::maybe_interpolate_local_broadcast_exchange(OpFactories& pred_operators,
+OpFactories PipelineBuilderContext::maybe_interpolate_local_broadcast_exchange(RuntimeState* state,
+                                                                               OpFactories& pred_operators,
                                                                                int num_receivers) {
     if (num_receivers == 1) {
-        return maybe_interpolate_local_passthrough_exchange(pred_operators);
+        return maybe_interpolate_local_passthrough_exchange(state, pred_operators);
     }
 
     auto pseudo_plan_node_id = next_pseudo_plan_node_id();
-    auto mem_mgr =
-            std::make_shared<LocalExchangeMemoryManager>(config::vector_chunk_size * num_receivers * num_receivers);
+    auto mem_mgr = std::make_shared<LocalExchangeMemoryManager>(state->chunk_size() * num_receivers * num_receivers);
     auto local_exchange_source =
             std::make_shared<LocalExchangeSourceOperatorFactory>(next_operator_id(), pseudo_plan_node_id, mem_mgr);
+    local_exchange_source->set_runtime_state(state);
     auto local_exchange = std::make_shared<BroadcastExchanger>(mem_mgr, local_exchange_source.get());
     auto local_exchange_sink =
             std::make_shared<LocalExchangeSinkOperatorFactory>(next_operator_id(), pseudo_plan_node_id, local_exchange);
@@ -33,11 +34,13 @@ OpFactories PipelineBuilderContext::maybe_interpolate_local_broadcast_exchange(O
     return operators_source_with_local_exchange;
 }
 
-OpFactories PipelineBuilderContext::maybe_interpolate_local_passthrough_exchange(OpFactories& pred_operators) {
-    return maybe_interpolate_local_passthrough_exchange(pred_operators, 1);
+OpFactories PipelineBuilderContext::maybe_interpolate_local_passthrough_exchange(RuntimeState* state,
+                                                                                 OpFactories& pred_operators) {
+    return maybe_interpolate_local_passthrough_exchange(state, pred_operators, 1);
 }
 
-OpFactories PipelineBuilderContext::maybe_interpolate_local_passthrough_exchange(OpFactories& pred_operators,
+OpFactories PipelineBuilderContext::maybe_interpolate_local_passthrough_exchange(RuntimeState* state,
+                                                                                 OpFactories& pred_operators,
                                                                                  int num_receivers) {
     // predecessor pipeline has multiple drivers that will produce multiple output streams, but sort operator is
     // not parallelized now and can not accept multiple streams as input, so add a LocalExchange to gather multiple
@@ -50,9 +53,10 @@ OpFactories PipelineBuilderContext::maybe_interpolate_local_passthrough_exchange
 
     auto pseudo_plan_node_id = next_pseudo_plan_node_id();
     int buffer_size = std::max(num_receivers, static_cast<int>(source_operator->degree_of_parallelism()));
-    auto mem_mgr = std::make_shared<LocalExchangeMemoryManager>(config::vector_chunk_size * buffer_size);
+    auto mem_mgr = std::make_shared<LocalExchangeMemoryManager>(state->chunk_size() * buffer_size);
     auto local_exchange_source =
             std::make_shared<LocalExchangeSourceOperatorFactory>(next_operator_id(), pseudo_plan_node_id, mem_mgr);
+    local_exchange_source->set_runtime_state(state);
     auto local_exchange = std::make_shared<PassthroughExchanger>(mem_mgr, local_exchange_source.get());
     auto local_exchange_sink =
             std::make_shared<LocalExchangeSinkOperatorFactory>(next_operator_id(), pseudo_plan_node_id, local_exchange);
@@ -70,7 +74,7 @@ OpFactories PipelineBuilderContext::maybe_interpolate_local_passthrough_exchange
 }
 
 OpFactories PipelineBuilderContext::maybe_interpolate_local_shuffle_exchange(
-        OpFactories& pred_operators, const std::vector<ExprContext*>& partition_expr_ctxs) {
+        RuntimeState* state, OpFactories& pred_operators, const std::vector<ExprContext*>& partition_expr_ctxs) {
     DCHECK(!pred_operators.empty() && pred_operators[0]->is_source());
 
     // If DOP is one, we needn't partition input chunks.
@@ -83,9 +87,10 @@ OpFactories PipelineBuilderContext::maybe_interpolate_local_shuffle_exchange(
 
     // To make sure at least one partition source operator is ready to output chunk before sink operators are full.
     auto pseudo_plan_node_id = next_pseudo_plan_node_id();
-    auto mem_mgr = std::make_shared<LocalExchangeMemoryManager>(shuffle_partitions_num * config::vector_chunk_size);
+    auto mem_mgr = std::make_shared<LocalExchangeMemoryManager>(shuffle_partitions_num * state->chunk_size());
     auto local_shuffle_source =
             std::make_shared<LocalExchangeSourceOperatorFactory>(next_operator_id(), pseudo_plan_node_id, mem_mgr);
+    local_shuffle_source->set_runtime_state(state);
     auto local_shuffle = std::make_shared<PartitionExchanger>(
             mem_mgr, local_shuffle_source.get(), true, partition_expr_ctxs, pred_source_op->degree_of_parallelism());
 
@@ -103,23 +108,25 @@ OpFactories PipelineBuilderContext::maybe_interpolate_local_shuffle_exchange(
     return operators_source_with_local_shuffle;
 }
 
-OpFactories PipelineBuilderContext::maybe_gather_pipelines_to_one(std::vector<OpFactories>& pred_operators_list) {
+OpFactories PipelineBuilderContext::maybe_gather_pipelines_to_one(RuntimeState* state,
+                                                                  std::vector<OpFactories>& pred_operators_list) {
     // If there is only one pred pipeline, we needn't local passthrough anymore.
     if (pred_operators_list.size() == 1) {
         return pred_operators_list[0];
     }
 
-    // Approximately, each pred driver can output config::vector_chunk_size rows at the same time.
+    // Approximately, each pred driver can output state->chunk_size() rows at the same time.
     size_t max_row_count = 0;
     for (const auto& pred_ops : pred_operators_list) {
         auto* source_operator = down_cast<SourceOperatorFactory*>(pred_ops[0].get());
-        max_row_count += source_operator->degree_of_parallelism() * config::vector_chunk_size;
+        max_row_count += source_operator->degree_of_parallelism() * state->chunk_size();
     }
 
     auto pseudo_plan_node_id = next_pseudo_plan_node_id();
     auto mem_mgr = std::make_shared<LocalExchangeMemoryManager>(max_row_count);
     auto local_exchange_source =
             std::make_shared<LocalExchangeSourceOperatorFactory>(next_operator_id(), pseudo_plan_node_id, mem_mgr);
+    local_exchange_source->set_runtime_state(state);
     auto exchanger = std::make_shared<PassthroughExchanger>(mem_mgr, local_exchange_source.get());
 
     // Append a local exchange sink to the tail of each pipeline, which comes to end.

--- a/be/src/exec/pipeline/pipeline_builder.h
+++ b/be/src/exec/pipeline/pipeline_builder.h
@@ -21,11 +21,13 @@ public:
         _pipelines.emplace_back(std::make_unique<Pipeline>(next_pipe_id(), operators));
     }
 
-    OpFactories maybe_interpolate_local_broadcast_exchange(OpFactories& pred_operators, int num_receivers);
+    OpFactories maybe_interpolate_local_broadcast_exchange(RuntimeState* state, OpFactories& pred_operators,
+                                                           int num_receivers);
 
     // Input the output chunks from the drivers of pred operators into ONE driver of the post operators.
-    OpFactories maybe_interpolate_local_passthrough_exchange(OpFactories& pred_operators);
-    OpFactories maybe_interpolate_local_passthrough_exchange(OpFactories& pred_operators, int num_receivers);
+    OpFactories maybe_interpolate_local_passthrough_exchange(RuntimeState* state, OpFactories& pred_operators);
+    OpFactories maybe_interpolate_local_passthrough_exchange(RuntimeState* state, OpFactories& pred_operators,
+                                                             int num_receivers);
 
     // Input the output chunks from multiple drivers of pred operators into DOP drivers of the post operators,
     // by partitioning each row output chunk to DOP partitions according to the key,
@@ -33,7 +35,7 @@ public:
     // It is used to parallelize complex operators. For example, the build Hash Table (HT) operator can partition
     // the input chunks to build multiple partition HTs, and the probe HT operator can also partition the input chunks
     // and probe on multiple partition HTs in parallel.
-    OpFactories maybe_interpolate_local_shuffle_exchange(OpFactories& pred_operators,
+    OpFactories maybe_interpolate_local_shuffle_exchange(RuntimeState* state, OpFactories& pred_operators,
                                                          const std::vector<ExprContext*>& partition_expr_ctxs);
 
     // Uses local exchange to gather the output chunks of multiple predecessor pipelines
@@ -41,7 +43,7 @@ public:
     // Append a LocalExchangeSinkOperator to the tail of each pipeline.
     // Create a new pipeline with a LocalExchangeSourceOperator.
     // These local exchange sink operators and the source operator share a passthrough exchanger.
-    OpFactories maybe_gather_pipelines_to_one(std::vector<OpFactories>& pred_operators_list);
+    OpFactories maybe_gather_pipelines_to_one(RuntimeState* state, std::vector<OpFactories>& pred_operators_list);
 
     uint32_t next_pipe_id() { return _next_pipeline_id++; }
 

--- a/be/src/exec/pipeline/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan_operator.cpp
@@ -106,7 +106,7 @@ StatusOr<vectorized::ChunkPtr> ScanOperator::pull_chunk(RuntimeState* state) {
     }
 
     auto&& chunk = _chunk_source->get_next_chunk_from_buffer();
-    // If buffer size is smaller than half of buffer_size,
+    // If number of cached chunk is smaller than half of buffer_size,
     // we can start the next scan task ahead of time to obtain better continuity
     if (_chunk_source->get_buffer_size() < (_buffer_size >> 1) && !_is_io_task_active.load(std::memory_order_acquire) &&
         _chunk_source->has_next_chunk()) {

--- a/be/src/exec/pipeline/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan_operator.cpp
@@ -106,9 +106,9 @@ StatusOr<vectorized::ChunkPtr> ScanOperator::pull_chunk(RuntimeState* state) {
     }
 
     auto&& chunk = _chunk_source->get_next_chunk_from_buffer();
-    // If buffer size is smaller than half of batch_size,
+    // If buffer size is smaller than half of buffer_size,
     // we can start the next scan task ahead of time to obtain better continuity
-    if (_chunk_source->get_buffer_size() < (_batch_size >> 1) && !_is_io_task_active.load(std::memory_order_acquire) &&
+    if (_chunk_source->get_buffer_size() < (_buffer_size >> 1) && !_is_io_task_active.load(std::memory_order_acquire) &&
         _chunk_source->has_next_chunk()) {
         RETURN_IF_ERROR(_trigger_next_scan(state));
     }
@@ -126,7 +126,7 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state) {
     task.work_function = [this, state]() {
         {
             SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(state->instance_mem_tracker());
-            _chunk_source->buffer_next_batch_chunks_blocking(_batch_size, _is_finished);
+            _chunk_source->buffer_next_batch_chunks_blocking(_buffer_size, _is_finished);
         }
         _is_io_task_active.store(false, std::memory_order_release);
     };

--- a/be/src/exec/pipeline/scan_operator.h
+++ b/be/src/exec/pipeline/scan_operator.h
@@ -52,7 +52,7 @@ private:
     // TODO(hcf) ugly, remove this later
     RuntimeState* _state = nullptr;
 
-    const size_t _batch_size = config::pipeline_io_buffer_size;
+    const size_t _buffer_size = config::pipeline_io_buffer_size;
     mutable bool _is_finished = false;
     std::atomic_bool _is_io_task_active = false;
     int32_t _io_task_retry_cnt = 0;

--- a/be/src/exec/pipeline/set/except_context.cpp
+++ b/be/src/exec/pipeline/set/except_context.cpp
@@ -9,7 +9,7 @@ namespace starrocks::pipeline {
 Status ExceptContext::prepare(RuntimeState* state, const std::vector<ExprContext*>& build_exprs) {
     _build_pool = std::make_unique<MemPool>();
 
-    RETURN_IF_ERROR(_hash_set->init());
+    RETURN_IF_ERROR(_hash_set->init(state));
 
     _dst_tuple_desc = state->desc_tbl().get_tuple_descriptor(_dst_tuple_id);
     _dst_nullables.reserve(build_exprs.size());
@@ -40,10 +40,10 @@ Status ExceptContext::erase_chunk_from_ht(RuntimeState* state, const ChunkPtr& c
 }
 
 StatusOr<vectorized::ChunkPtr> ExceptContext::pull_chunk(RuntimeState* state) {
-    // 1. Get at most *config::vector_chunk_size* remained keys from ht.
+    // 1. Get at most *state->chunk_size()* remained keys from ht.
     size_t num_remained_keys = 0;
-    _remained_keys.resize(config::vector_chunk_size);
-    while (_next_processed_iter != _hash_set->end() && num_remained_keys < config::vector_chunk_size) {
+    _remained_keys.resize(state->chunk_size());
+    while (_next_processed_iter != _hash_set->end() && num_remained_keys < state->chunk_size()) {
         if (!_next_processed_iter->deleted) {
             _remained_keys[num_remained_keys++] = _next_processed_iter->slice;
         }

--- a/be/src/exec/pipeline/set/intersect_context.cpp
+++ b/be/src/exec/pipeline/set/intersect_context.cpp
@@ -7,7 +7,7 @@
 namespace starrocks::pipeline {
 
 Status IntersectContext::prepare(RuntimeState* state, const std::vector<ExprContext*>& build_exprs) {
-    RETURN_IF_ERROR(_hash_set->init());
+    RETURN_IF_ERROR(_hash_set->init(state));
     _build_pool = std::make_unique<MemPool>();
 
     _dst_tuple_desc = state->desc_tbl().get_tuple_descriptor(_dst_tuple_id);
@@ -39,10 +39,10 @@ Status IntersectContext::refine_chunk_from_ht(RuntimeState* state, const ChunkPt
 }
 
 StatusOr<vectorized::ChunkPtr> IntersectContext::pull_chunk(RuntimeState* state) {
-    // 1. Get at most *config::vector_chunk_size* remained keys from ht.
+    // 1. Get at most *state->chunk_size()* remained keys from ht.
     size_t num_remained_keys = 0;
-    _remained_keys.resize(config::vector_chunk_size);
-    while (_next_processed_iter != _hash_set->end() && num_remained_keys < config::vector_chunk_size) {
+    _remained_keys.resize(state->chunk_size());
+    while (_next_processed_iter != _hash_set->end() && num_remained_keys < state->chunk_size()) {
         if (_next_processed_iter->hit_times == _intersect_times) {
             _remained_keys[num_remained_keys++] = _next_processed_iter->slice;
         }

--- a/be/src/exec/pipeline/set/union_const_source_operator.cpp
+++ b/be/src/exec/pipeline/set/union_const_source_operator.cpp
@@ -11,7 +11,7 @@ StatusOr<vectorized::ChunkPtr> UnionConstSourceOperator::pull_chunk(starrocks::R
 
     auto chunk = std::make_shared<vectorized::Chunk>();
 
-    size_t rows_count = std::min(static_cast<size_t>(state->batch_size()), _rows_total - _next_processed_row_index);
+    size_t rows_count = std::min(static_cast<size_t>(state->chunk_size()), _rows_total - _next_processed_row_index);
     size_t columns_count = _dst_slots.size();
 
     for (size_t col_i = 0; col_i < columns_count; col_i++) {

--- a/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
@@ -66,18 +66,18 @@ OperatorPtr PartitionSortSinkOperatorFactory::create(int32_t degree_of_paralleli
     std::shared_ptr<ChunksSorter> chunks_sorter;
     if (_limit >= 0) {
         if (_limit <= ChunksSorter::USE_HEAP_SORTER_LIMIT_SZ) {
-            chunks_sorter =
-                    std::make_unique<HeapChunkSorter>(&(_sort_exec_exprs.lhs_ordering_expr_ctxs()), &_is_asc_order,
-                                                      &_is_null_first, _offset, _limit, SIZE_OF_CHUNK_FOR_TOPN);
+            chunks_sorter = std::make_unique<HeapChunkSorter>(
+                    runtime_state(), &(_sort_exec_exprs.lhs_ordering_expr_ctxs()), &_is_asc_order, &_is_null_first,
+                    _offset, _limit, SIZE_OF_CHUNK_FOR_TOPN);
         } else {
-            chunks_sorter =
-                    std::make_unique<ChunksSorterTopn>(&(_sort_exec_exprs.lhs_ordering_expr_ctxs()), &_is_asc_order,
-                                                       &_is_null_first, _offset, _limit, SIZE_OF_CHUNK_FOR_TOPN);
+            chunks_sorter = std::make_unique<ChunksSorterTopn>(
+                    runtime_state(), &(_sort_exec_exprs.lhs_ordering_expr_ctxs()), &_is_asc_order, &_is_null_first,
+                    _offset, _limit, SIZE_OF_CHUNK_FOR_TOPN);
         }
     } else {
-        chunks_sorter = std::make_unique<vectorized::ChunksSorterFullSort>(&(_sort_exec_exprs.lhs_ordering_expr_ctxs()),
-                                                                           &_is_asc_order, &_is_null_first,
-                                                                           SIZE_OF_CHUNK_FOR_FULL_SORT);
+        chunks_sorter = std::make_unique<vectorized::ChunksSorterFullSort>(
+                runtime_state(), &(_sort_exec_exprs.lhs_ordering_expr_ctxs()), &_is_asc_order, &_is_null_first,
+                SIZE_OF_CHUNK_FOR_FULL_SORT);
     }
     auto sort_context = _sort_context_factory->create(driver_sequence);
 

--- a/be/src/exec/pipeline/sort/sort_context.cpp
+++ b/be/src/exec/pipeline/sort/sort_context.cpp
@@ -4,9 +4,10 @@
 
 namespace starrocks {
 namespace pipeline {
-SortContextFactory::SortContextFactory(bool is_merging, int64_t limit, int32_t num_right_sinkers,
+SortContextFactory::SortContextFactory(RuntimeState* state, bool is_merging, int64_t limit, int32_t num_right_sinkers,
                                        const std::vector<bool>& is_asc_order, const std::vector<bool>& is_null_first)
-        : _is_merging(is_merging),
+        : _state(state),
+          _is_merging(is_merging),
           _sort_contexts(is_merging ? 1 : num_right_sinkers),
           _limit(limit),
           _num_right_sinkers(num_right_sinkers),
@@ -19,7 +20,8 @@ SortContextPtr SortContextFactory::create(int32_t idx) {
 
     DCHECK_LE(actual_idx, _sort_contexts.size());
     if (!_sort_contexts[actual_idx]) {
-        _sort_contexts[actual_idx] = std::make_shared<SortContext>(_limit, num_sinkers, _is_asc_order, _is_null_first);
+        _sort_contexts[actual_idx] =
+                std::make_shared<SortContext>(_state, _limit, num_sinkers, _is_asc_order, _is_null_first);
     }
     return _sort_contexts[actual_idx];
 }

--- a/be/src/exec/pipeline/sort/sort_context.h
+++ b/be/src/exec/pipeline/sort/sort_context.h
@@ -25,9 +25,12 @@ using SortContextPtr = std::shared_ptr<SortContext>;
 using SortContexts = std::vector<SortContextPtr>;
 class SortContext final : public ContextWithDependency {
 public:
-    explicit SortContext(int64_t limit, const int32_t num_right_sinkers, const std::vector<bool>& is_asc_order,
-                         const std::vector<bool>& is_null_first)
-            : _limit(limit), _num_partition_sinkers(num_right_sinkers), _comparer(limit, is_asc_order, is_null_first) {
+    explicit SortContext(RuntimeState* state, int64_t limit, const int32_t num_right_sinkers,
+                         const std::vector<bool>& is_asc_order, const std::vector<bool>& is_null_first)
+            : _state(state),
+              _limit(limit),
+              _num_partition_sinkers(num_right_sinkers),
+              _comparer(limit, is_asc_order, is_null_first) {
         _chunks_sorter_partions.reserve(num_right_sinkers);
         _data_segment_heaps.reserve(num_right_sinkers);
     }
@@ -79,7 +82,7 @@ public:
     template <class UpdateFunc>
     ChunkPtr pull_chunk(UpdateFunc&& get_and_update_min_entry_func) {
         // Get appropriate size
-        uint32_t needed_rows = std::min((uint64_t)config::vector_chunk_size, _require_rows - _next_output_row);
+        uint32_t needed_rows = std::min((uint64_t)_state->chunk_size(), _require_rows - _next_output_row);
 
         uint32_t rows_number = 0;
         if (rows_number >= needed_rows) {
@@ -137,6 +140,7 @@ public:
     }
 
 private:
+    RuntimeState* _state;
     const int64_t _limit;
     // size of all chunks from all partitions.
     std::atomic<int64_t> _total_rows = 0;
@@ -240,12 +244,13 @@ class SortContextFactory;
 using SortContextFactoryPtr = std::shared_ptr<SortContextFactory>;
 class SortContextFactory {
 public:
-    SortContextFactory(bool is_merging, int64_t limit, int32_t num_right_sinkers,
+    SortContextFactory(RuntimeState* state, bool is_merging, int64_t limit, int32_t num_right_sinkers,
                        const std::vector<bool>& _is_asc_order, const std::vector<bool>& is_null_first);
 
     SortContextPtr create(int32_t idx);
 
 private:
+    RuntimeState* _state;
     // _is_merging is true means to merge multiple output streams of PartitionSortSinkOperators into a common
     // LocalMergeSortSourceOperator that will produce a total order output stream.
     // _is_merging is false means to pipe each output stream of PartitionSortSinkOperators to an independent

--- a/be/src/exec/pipeline/table_function_operator.cpp
+++ b/be/src/exec/pipeline/table_function_operator.cpp
@@ -76,7 +76,7 @@ StatusOr<vectorized::ChunkPtr> TableFunctionOperator::pull_chunk(RuntimeState* s
     DCHECK(_input_chunk != nullptr);
 
     SCOPED_TIMER(_runtime_profile->total_time_counter());
-    size_t chunk_size = state->batch_size();
+    size_t chunk_size = state->chunk_size();
     size_t remain_chunk_size = chunk_size;
     std::vector<vectorized::ColumnPtr> output_columns;
 

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -241,7 +241,7 @@ Status NodeChannel::add_chunk(vectorized::Chunk* chunk, const int64_t* tablet_id
         _cur_chunk = chunk->clone_empty_with_slot();
     }
 
-    if (_cur_chunk->num_rows() >= config::vector_chunk_size) {
+    if (_cur_chunk->num_rows() >= _runtime_state->chunk_size()) {
         {
             SCOPED_RAW_TIMER(&_queue_push_lock_ns);
             std::lock_guard<std::mutex> l(_pending_batches_lock);

--- a/be/src/exec/vectorized/aggregate/agg_hash_variant.h
+++ b/be/src/exec/vectorized/aggregate/agg_hash_variant.h
@@ -362,12 +362,12 @@ struct HashMapVariant {
     std::unique_ptr<SerializedKeyFixedSize8AggHashMap<PhmapSeed2>> phase2_slice_fx8;
     std::unique_ptr<SerializedKeyFixedSize16AggHashMap<PhmapSeed2>> phase2_slice_fx16;
 
-    void init(Type type_) {
+    void init(RuntimeState* state, Type type_) {
         type = type_;
         switch (type_) {
-#define M(NAME)                                                  \
-    case Type::NAME:                                             \
-        NAME = std::make_unique<decltype(NAME)::element_type>(); \
+#define M(NAME)                                                                     \
+    case Type::NAME:                                                                \
+        NAME = std::make_unique<decltype(NAME)::element_type>(state->chunk_size()); \
         break;
             APPLY_FOR_VARIANT_ALL(M)
 #undef M
@@ -636,12 +636,12 @@ struct HashSetVariant {
     std::unique_ptr<SerializedKeyAggHashSetFixedSize8<PhmapSeed2>> phase2_slice_fx8;
     std::unique_ptr<SerializedKeyAggHashSetFixedSize16<PhmapSeed2>> phase2_slice_fx16;
 
-    void init(Type type_) {
+    void init(RuntimeState* state, Type type_) {
         type = type_;
         switch (type_) {
-#define M(NAME)                                                  \
-    case Type::NAME:                                             \
-        NAME = std::make_unique<decltype(NAME)::element_type>(); \
+#define M(NAME)                                                                     \
+    case Type::NAME:                                                                \
+        NAME = std::make_unique<decltype(NAME)::element_type>(state->chunk_size()); \
         break;
             APPLY_FOR_VARIANT_ALL(M)
 #undef M

--- a/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
@@ -48,7 +48,7 @@ Status AggregateBlockingNode::open(RuntimeState* state) {
             continue;
         }
 
-        DCHECK_LE(chunk->num_rows(), config::vector_chunk_size);
+        DCHECK_LE(chunk->num_rows(), runtime_state()->chunk_size());
 
         _aggregator->evaluate_exprs(chunk.get());
 
@@ -131,7 +131,7 @@ Status AggregateBlockingNode::get_next(RuntimeState* state, ChunkPtr* chunk, boo
         *eos = true;
         return Status::OK();
     }
-    int32_t chunk_size = config::vector_chunk_size;
+    int32_t chunk_size = runtime_state()->chunk_size();
 
     if (_aggregator->is_none_group_by_exprs()) {
         SCOPED_TIMER(_aggregator->get_results_timer());
@@ -170,10 +170,11 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > AggregateBlockingNode::
         if (agg_node.__isset.grouping_exprs && !_tnode.agg_node.grouping_exprs.empty()) {
             std::vector<ExprContext*> group_by_expr_ctxs;
             Expr::create_expr_trees(_pool, _tnode.agg_node.grouping_exprs, &group_by_expr_ctxs);
-            operators_with_sink =
-                    context->maybe_interpolate_local_shuffle_exchange(operators_with_sink, group_by_expr_ctxs);
+            operators_with_sink = context->maybe_interpolate_local_shuffle_exchange(
+                    runtime_state(), operators_with_sink, group_by_expr_ctxs);
         } else {
-            operators_with_sink = context->maybe_interpolate_local_passthrough_exchange(operators_with_sink);
+            operators_with_sink =
+                    context->maybe_interpolate_local_passthrough_exchange(runtime_state(), operators_with_sink);
         }
     }
     // We cannot get degree of parallelism from PipelineBuilderContext, of which is only a suggest value

--- a/be/src/exec/vectorized/aggregate/aggregate_streaming_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_streaming_node.cpp
@@ -238,7 +238,7 @@ void AggregateStreamingNode::_output_chunk_from_hash_map(ChunkPtr* chunk) {
 #define HASH_MAP_METHOD(NAME)                                                                                     \
     else if (_aggregator->hash_map_variant().type == HashMapVariant::Type::NAME)                                  \
             _aggregator->convert_hash_map_to_chunk<decltype(_aggregator->hash_map_variant().NAME)::element_type>( \
-                    *_aggregator->hash_map_variant().NAME, config::vector_chunk_size, chunk);
+                    *_aggregator->hash_map_variant().NAME, runtime_state()->chunk_size(), chunk);
     APPLY_FOR_VARIANT_ALL(HASH_MAP_METHOD)
 #undef HASH_MAP_METHOD
     else {

--- a/be/src/exec/vectorized/aggregate/distinct_blocking_node.cpp
+++ b/be/src/exec/vectorized/aggregate/distinct_blocking_node.cpp
@@ -42,7 +42,7 @@ Status DistinctBlockingNode::open(RuntimeState* state) {
         if (chunk->is_empty()) {
             continue;
         }
-        DCHECK_LE(chunk->num_rows(), config::vector_chunk_size);
+        DCHECK_LE(chunk->num_rows(), runtime_state()->chunk_size());
 
         _aggregator->evaluate_exprs(chunk.get());
 
@@ -105,7 +105,7 @@ Status DistinctBlockingNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool
         *eos = true;
         return Status::OK();
     }
-    int32_t chunk_size = config::vector_chunk_size;
+    int32_t chunk_size = runtime_state()->chunk_size();
 
     if (false) {
     }
@@ -152,7 +152,8 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > DistinctBlockingNode::d
     // Initialize OperatorFactory's fields involving runtime filters.
     this->init_runtime_filter_for_operator(source_operator.get(), context, rc_rf_probe_collector);
 
-    operators_with_sink = context->maybe_interpolate_local_shuffle_exchange(operators_with_sink, partition_expr_ctxs);
+    operators_with_sink = context->maybe_interpolate_local_shuffle_exchange(runtime_state(), operators_with_sink,
+                                                                            partition_expr_ctxs);
     operators_with_sink.push_back(std::move(sink_operator));
     context->add_pipeline(operators_with_sink);
     // Aggregator must be used by a pair of sink and source operators,

--- a/be/src/exec/vectorized/aggregate/distinct_streaming_node.cpp
+++ b/be/src/exec/vectorized/aggregate/distinct_streaming_node.cpp
@@ -212,7 +212,7 @@ void DistinctStreamingNode::_output_chunk_from_hash_set(ChunkPtr* chunk) {
 #define HASH_MAP_METHOD(NAME)                                                                                     \
     else if (_aggregator->hash_set_variant().type == HashSetVariant::Type::NAME)                                  \
             _aggregator->convert_hash_set_to_chunk<decltype(_aggregator->hash_set_variant().NAME)::element_type>( \
-                    *_aggregator->hash_set_variant().NAME, config::vector_chunk_size, chunk);
+                    *_aggregator->hash_set_variant().NAME, runtime_state()->chunk_size(), chunk);
     APPLY_FOR_VARIANT_ALL(HASH_MAP_METHOD)
 #undef HASH_MAP_METHOD
     else {

--- a/be/src/exec/vectorized/aggregator.cpp
+++ b/be/src/exec/vectorized/aggregator.cpp
@@ -61,7 +61,7 @@ Status Aggregator::prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile
     }
     VLOG_ROW << "has_nullable_key " << _has_nullable_key;
 
-    _tmp_agg_states.resize(config::vector_chunk_size);
+    _tmp_agg_states.resize(_state->chunk_size());
 
     size_t agg_size = _tnode.agg_node.aggregate_functions.size();
     _agg_fn_ctxs.resize(agg_size);
@@ -471,26 +471,26 @@ void Aggregator::output_chunk_by_streaming_with_selection(vectorized::ChunkPtr* 
     output_chunk_by_streaming(chunk);
 }
 
-#define CONVERT_TO_TWO_LEVEL_MAP(DST, SRC)                                                         \
-    if (_hash_map_variant.type == vectorized::HashMapVariant::Type::SRC) {                         \
-        _hash_map_variant.DST = std::make_unique<decltype(_hash_map_variant.DST)::element_type>(); \
-        _hash_map_variant.DST->hash_map.reserve(_hash_map_variant.SRC->hash_map.capacity());       \
-        _hash_map_variant.DST->hash_map.insert(_hash_map_variant.SRC->hash_map.begin(),            \
-                                               _hash_map_variant.SRC->hash_map.end());             \
-        _hash_map_variant.type = vectorized::HashMapVariant::Type::DST;                            \
-        _hash_map_variant.SRC.reset();                                                             \
-        return;                                                                                    \
+#define CONVERT_TO_TWO_LEVEL_MAP(DST, SRC)                                                                             \
+    if (_hash_map_variant.type == vectorized::HashMapVariant::Type::SRC) {                                             \
+        _hash_map_variant.DST = std::make_unique<decltype(_hash_map_variant.DST)::element_type>(_state->chunk_size()); \
+        _hash_map_variant.DST->hash_map.reserve(_hash_map_variant.SRC->hash_map.capacity());                           \
+        _hash_map_variant.DST->hash_map.insert(_hash_map_variant.SRC->hash_map.begin(),                                \
+                                               _hash_map_variant.SRC->hash_map.end());                                 \
+        _hash_map_variant.type = vectorized::HashMapVariant::Type::DST;                                                \
+        _hash_map_variant.SRC.reset();                                                                                 \
+        return;                                                                                                        \
     }
 
-#define CONVERT_TO_TWO_LEVEL_SET(DST, SRC)                                                         \
-    if (_hash_set_variant.type == vectorized::HashSetVariant::Type::SRC) {                         \
-        _hash_set_variant.DST = std::make_unique<decltype(_hash_set_variant.DST)::element_type>(); \
-        _hash_set_variant.DST->hash_set.reserve(_hash_set_variant.SRC->hash_set.capacity());       \
-        _hash_set_variant.DST->hash_set.insert(_hash_set_variant.SRC->hash_set.begin(),            \
-                                               _hash_set_variant.SRC->hash_set.end());             \
-        _hash_set_variant.type = vectorized::HashSetVariant::Type::DST;                            \
-        _hash_set_variant.SRC.reset();                                                             \
-        return;                                                                                    \
+#define CONVERT_TO_TWO_LEVEL_SET(DST, SRC)                                                                             \
+    if (_hash_set_variant.type == vectorized::HashSetVariant::Type::SRC) {                                             \
+        _hash_set_variant.DST = std::make_unique<decltype(_hash_set_variant.DST)::element_type>(_state->chunk_size()); \
+        _hash_set_variant.DST->hash_set.reserve(_hash_set_variant.SRC->hash_set.capacity());                           \
+        _hash_set_variant.DST->hash_set.insert(_hash_set_variant.SRC->hash_set.begin(),                                \
+                                               _hash_set_variant.SRC->hash_set.end());                                 \
+        _hash_set_variant.type = vectorized::HashSetVariant::Type::DST;                                                \
+        _hash_set_variant.SRC.reset();                                                                                 \
+        return;                                                                                                        \
     }
 
 void Aggregator::try_convert_to_two_level_map() {
@@ -519,13 +519,13 @@ vectorized::Columns Aggregator::_create_agg_result_columns() {
             // we need to create a not-nullable column.
             agg_result_columns[i] = vectorized::ColumnHelper::create_column(
                     _agg_fn_types[i].result_type, _agg_fn_types[i].has_nullable_child & _agg_fn_types[i].is_nullable);
-            agg_result_columns[i]->reserve(config::vector_chunk_size);
+            agg_result_columns[i]->reserve(_state->chunk_size());
         }
     } else {
         for (size_t i = 0; i < _agg_fn_types.size(); ++i) {
             agg_result_columns[i] = vectorized::ColumnHelper::create_column(_agg_fn_types[i].serde_type,
                                                                             _agg_fn_types[i].has_nullable_child);
-            agg_result_columns[i]->reserve(config::vector_chunk_size);
+            agg_result_columns[i]->reserve(_state->chunk_size());
         }
     }
     return agg_result_columns;
@@ -536,7 +536,7 @@ vectorized::Columns Aggregator::_create_group_by_columns() {
     for (size_t i = 0; i < _group_by_types.size(); ++i) {
         group_by_columns[i] =
                 vectorized::ColumnHelper::create_column(_group_by_types[i].result_type, _group_by_types[i].is_nullable);
-        group_by_columns[i]->reserve(config::vector_chunk_size);
+        group_by_columns[i]->reserve(_state->chunk_size());
     }
     return group_by_columns;
 }
@@ -779,7 +779,7 @@ void Aggregator::_init_agg_hash_variant(HashVariantType& hash_variant) {
     }
     VLOG_ROW << "hash type is "
              << static_cast<typename std::underlying_type<typename HashVariantType::Type>::type>(type);
-    hash_variant.init(type);
+    hash_variant.init(_state, type);
 
 #define SET_FIXED_SLICE_HASH_MAP_FIELD(TYPE)                  \
     if (type == HashVariantType::Type::TYPE) {                \

--- a/be/src/exec/vectorized/aggregator.h
+++ b/be/src/exec/vectorized/aggregator.h
@@ -344,8 +344,8 @@ public:
         // If there is null key, output it last
         if constexpr (HashMapWithKey::has_single_null_key) {
             if (_is_ht_eos && hash_map_with_key.null_key_data != nullptr) {
-                // The output chunk size couldn't larger than config::vector_chunk_size
-                if (read_index < config::vector_chunk_size) {
+                // The output chunk size couldn't larger than _state->chunk_size()
+                if (read_index < _state->chunk_size()) {
                     // For multi group by key, we don't need to special handle null key
                     DCHECK(group_by_columns.size() == 1);
                     DCHECK(group_by_columns[0]->is_nullable());
@@ -419,8 +419,8 @@ public:
         // IF there is null key, output it last
         if constexpr (HashSetWithKey::has_single_null_key) {
             if (_is_ht_eos && hash_set.has_null_key) {
-                // The output chunk size couldn't larger than config::vector_chunk_size
-                if (read_index < config::vector_chunk_size) {
+                // The output chunk size couldn't larger than _state->chunk_size()
+                if (read_index < _state->chunk_size()) {
                     // For multi group by key, we don't need to special handle null key
                     DCHECK(group_by_columns.size() == 1);
                     DCHECK(group_by_columns[0]->is_nullable());

--- a/be/src/exec/vectorized/analytic_node.cpp
+++ b/be/src/exec/vectorized/analytic_node.cpp
@@ -89,7 +89,7 @@ Status AnalyticNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) {
         return Status::OK();
     }
 
-    _analytor->remove_unused_buffer_values();
+    _analytor->remove_unused_buffer_values(state);
 
     RETURN_IF_ERROR((this->*_get_next)(state, chunk, eos));
     if (*eos) {
@@ -350,7 +350,8 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > AnalyticNode::decompose
 
     // analytic's dop must be 1 if with no partition clause
     if (_tnode.analytic_node.partition_exprs.empty()) {
-        operators_with_sink = context->maybe_interpolate_local_passthrough_exchange(operators_with_sink);
+        operators_with_sink =
+                context->maybe_interpolate_local_passthrough_exchange(runtime_state(), operators_with_sink);
     }
     auto degree_of_parallelism =
             down_cast<SourceOperatorFactory*>(operators_with_sink[0].get())->degree_of_parallelism();

--- a/be/src/exec/vectorized/analytor.cpp
+++ b/be/src/exec/vectorized/analytor.cpp
@@ -171,7 +171,7 @@ Status Analytor::prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile* 
                         _agg_expr_ctxs[i][j]->root()->type(), _agg_expr_ctxs[i][j]->root()->is_nullable(),
                         _agg_expr_ctxs[i][j]->root()->is_constant(), 0);
             }
-            _agg_intput_columns[i][j]->reserve(config::vector_chunk_size * BUFFER_CHUNK_NUMBER);
+            _agg_intput_columns[i][j]->reserve(state->chunk_size() * BUFFER_CHUNK_NUMBER);
         }
 
         DCHECK(_agg_functions[i] != nullptr);
@@ -203,7 +203,7 @@ Status Analytor::prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile* 
         _partition_columns[i] = vectorized::ColumnHelper::create_column(
                 _partition_ctxs[i]->root()->type(), _partition_ctxs[i]->root()->is_nullable() | has_outer_join_child,
                 _partition_ctxs[i]->root()->is_constant(), 0);
-        _partition_columns[i]->reserve(config::vector_chunk_size * BUFFER_CHUNK_NUMBER);
+        _partition_columns[i]->reserve(state->chunk_size() * BUFFER_CHUNK_NUMBER);
     }
 
     RETURN_IF_ERROR(Expr::create_expr_trees(_pool, analytic_node.order_by_exprs, &_order_ctxs));
@@ -212,7 +212,7 @@ Status Analytor::prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile* 
         _order_columns[i] = vectorized::ColumnHelper::create_column(
                 _order_ctxs[i]->root()->type(), _order_ctxs[i]->root()->is_nullable() | has_outer_join_child,
                 _order_ctxs[i]->root()->is_constant(), 0);
-        _order_columns[i]->reserve(config::vector_chunk_size * BUFFER_CHUNK_NUMBER);
+        _order_columns[i]->reserve(state->chunk_size() * BUFFER_CHUNK_NUMBER);
     }
 
     SCOPED_TIMER(_runtime_profile->total_time_counter());
@@ -476,10 +476,10 @@ void Analytor::reset_state_for_new_partition(int64_t found_partition_end) {
     DCHECK_GE(_current_row_position, 0);
 }
 
-void Analytor::remove_unused_buffer_values() {
+void Analytor::remove_unused_buffer_values(RuntimeState* state) {
     if (_input_chunks.size() <= _output_chunk_index ||
         _input_chunk_first_row_positions[_output_chunk_index] - _removed_from_buffer_rows <
-                config::vector_chunk_size * BUFFER_CHUNK_NUMBER) {
+                state->chunk_size() * BUFFER_CHUNK_NUMBER) {
         return;
     }
 

--- a/be/src/exec/vectorized/analytor.h
+++ b/be/src/exec/vectorized/analytor.h
@@ -112,7 +112,7 @@ public:
     void find_peer_group_end();
     void reset_state_for_new_partition(int64_t found_partition_end);
 
-    void remove_unused_buffer_values();
+    void remove_unused_buffer_values(RuntimeState* state);
 
 #ifdef NDEBUG
     static constexpr int32_t BUFFER_CHUNK_NUMBER = 1000;

--- a/be/src/exec/vectorized/assert_num_rows_node.cpp
+++ b/be/src/exec/vectorized/assert_num_rows_node.cpp
@@ -135,8 +135,8 @@ pipeline::OpFactories AssertNumRowsNode::decompose_to_pipeline(pipeline::Pipelin
     using namespace pipeline;
 
     OpFactories operator_before_assert_num_rows_source = _children[0]->decompose_to_pipeline(context);
-    operator_before_assert_num_rows_source =
-            context->maybe_interpolate_local_passthrough_exchange(operator_before_assert_num_rows_source);
+    operator_before_assert_num_rows_source = context->maybe_interpolate_local_passthrough_exchange(
+            runtime_state(), operator_before_assert_num_rows_source);
 
     auto source_factory = std::make_shared<AssertNumRowsOperatorFactory>(
             context->next_operator_id(), id(), _desired_num_rows, _subquery_string, std::move(_assertion));

--- a/be/src/exec/vectorized/chunk_sorter_heapsorter.cpp
+++ b/be/src/exec/vectorized/chunk_sorter_heapsorter.cpp
@@ -147,7 +147,7 @@ void HeapChunkSorter::get_next(ChunkPtr* chunk, bool* eos) {
         return;
     }
     *eos = false;
-    size_t count = std::min(size_t(config::vector_chunk_size), _merged_segment.chunk->num_rows() - _next_output_row);
+    size_t count = std::min(size_t(_state->chunk_size()), _merged_segment.chunk->num_rows() - _next_output_row);
     chunk->reset(_merged_segment.chunk->clone_empty(count).release());
     (*chunk)->append_safe(*_merged_segment.chunk, _next_output_row, count);
     _next_output_row += count;
@@ -158,7 +158,7 @@ bool HeapChunkSorter::pull_chunk(ChunkPtr* chunk) {
         *chunk = nullptr;
         return true;
     }
-    size_t count = std::min(size_t(config::vector_chunk_size), _merged_segment.chunk->num_rows() - _next_output_row);
+    size_t count = std::min(size_t(_state->chunk_size()), _merged_segment.chunk->num_rows() - _next_output_row);
     chunk->reset(_merged_segment.chunk->clone_empty(count).release());
     (*chunk)->append_safe(*_merged_segment.chunk, _next_output_row, count);
     _next_output_row += count;

--- a/be/src/exec/vectorized/chunk_sorter_heapsorter.h
+++ b/be/src/exec/vectorized/chunk_sorter_heapsorter.h
@@ -212,9 +212,11 @@ private:
 class HeapChunkSorter final : public ChunksSorter {
 public:
     using DataSegmentPtr = std::shared_ptr<DataSegment>;
-    HeapChunkSorter(const std::vector<ExprContext*>* sort_exprs, const std::vector<bool>* is_asc,
+    HeapChunkSorter(RuntimeState* state, const std::vector<ExprContext*>* sort_exprs, const std::vector<bool>* is_asc,
                     const std::vector<bool>* is_null_first, size_t offset, size_t limit, size_t size_of_chunk_batch)
-            : ChunksSorter(sort_exprs, is_asc, is_null_first, size_of_chunk_batch), _offset(offset), _limit(limit) {}
+            : ChunksSorter(state, sort_exprs, is_asc, is_null_first, size_of_chunk_batch),
+              _offset(offset),
+              _limit(limit) {}
     ~HeapChunkSorter() = default;
 
     Status update(RuntimeState* state, const ChunkPtr& chunk) override;

--- a/be/src/exec/vectorized/chunks_sorter.cpp
+++ b/be/src/exec/vectorized/chunks_sorter.cpp
@@ -14,9 +14,10 @@
 
 namespace starrocks::vectorized {
 
-ChunksSorter::ChunksSorter(const std::vector<ExprContext*>* sort_exprs, const std::vector<bool>* is_asc,
-                           const std::vector<bool>* is_null_first, size_t size_of_chunk_batch)
-        : _sort_exprs(sort_exprs), _size_of_chunk_batch(size_of_chunk_batch) {
+ChunksSorter::ChunksSorter(RuntimeState* state, const std::vector<ExprContext*>* sort_exprs,
+                           const std::vector<bool>* is_asc, const std::vector<bool>* is_null_first,
+                           size_t size_of_chunk_batch)
+        : _state(state), _sort_exprs(sort_exprs), _size_of_chunk_batch(size_of_chunk_batch) {
     DCHECK(_sort_exprs != nullptr);
     DCHECK(is_asc != nullptr);
     DCHECK(is_null_first != nullptr);

--- a/be/src/exec/vectorized/chunks_sorter.h
+++ b/be/src/exec/vectorized/chunks_sorter.h
@@ -276,7 +276,7 @@ public:
      * @param is_null_first  NULL values should at the head or tail.
      * @param size_of_chunk_batch  In the case of a positive limit, this parameter limits the size of the batch in Chunk unit.
      */
-    ChunksSorter(const std::vector<ExprContext*>* sort_exprs, const std::vector<bool>* is_asc,
+    ChunksSorter(RuntimeState* state, const std::vector<ExprContext*>* sort_exprs, const std::vector<bool>* is_asc,
                  const std::vector<bool>* is_null_first, size_t size_of_chunk_batch = 1000);
     virtual ~ChunksSorter();
 
@@ -314,6 +314,8 @@ public:
 
 protected:
     inline size_t _get_number_of_order_by_columns() const { return _sort_exprs->size(); }
+
+    RuntimeState* _state;
 
     // sort rules
     const std::vector<ExprContext*>* _sort_exprs;

--- a/be/src/exec/vectorized/chunks_sorter_full_sort.cpp
+++ b/be/src/exec/vectorized/chunks_sorter_full_sort.cpp
@@ -236,10 +236,11 @@ private:
     }
 };
 
-ChunksSorterFullSort::ChunksSorterFullSort(const std::vector<ExprContext*>* sort_exprs, const std::vector<bool>* is_asc,
-                                           const std::vector<bool>* is_null_first, size_t size_of_chunk_batch)
-        : ChunksSorter(sort_exprs, is_asc, is_null_first, size_of_chunk_batch) {
-    _selective_values.resize(config::vector_chunk_size);
+ChunksSorterFullSort::ChunksSorterFullSort(RuntimeState* state, const std::vector<ExprContext*>* sort_exprs,
+                                           const std::vector<bool>* is_asc, const std::vector<bool>* is_null_first,
+                                           size_t size_of_chunk_batch)
+        : ChunksSorter(state, sort_exprs, is_asc, is_null_first, size_of_chunk_batch) {
+    _selective_values.resize(_state->chunk_size());
 }
 
 ChunksSorterFullSort::~ChunksSorterFullSort() = default;
@@ -277,7 +278,7 @@ void ChunksSorterFullSort::get_next(ChunkPtr* chunk, bool* eos) {
         return;
     }
     *eos = false;
-    size_t count = std::min(size_t(config::vector_chunk_size), _sorted_permutation.size() - _next_output_row);
+    size_t count = std::min(size_t(_state->chunk_size()), _sorted_permutation.size() - _next_output_row);
     chunk->reset(_sorted_segment->chunk->clone_empty(count).release());
     _append_rows_to_chunk(chunk->get(), _sorted_segment->chunk.get(), _sorted_permutation, _next_output_row, count);
     _next_output_row += count;
@@ -311,7 +312,7 @@ bool ChunksSorterFullSort::pull_chunk(ChunkPtr* chunk) {
         *chunk = nullptr;
         return true;
     }
-    size_t count = std::min(size_t(config::vector_chunk_size), _sorted_permutation.size() - _next_output_row);
+    size_t count = std::min(size_t(_state->chunk_size()), _sorted_permutation.size() - _next_output_row);
     chunk->reset(_sorted_segment->chunk->clone_empty(count).release());
     _append_rows_to_chunk(chunk->get(), _sorted_segment->chunk.get(), _sorted_permutation, _next_output_row, count);
     _next_output_row += count;

--- a/be/src/exec/vectorized/chunks_sorter_full_sort.h
+++ b/be/src/exec/vectorized/chunks_sorter_full_sort.h
@@ -18,8 +18,9 @@ public:
      * @param is_null_first  NULL values should at the head or tail.
      * @param size_of_chunk_batch  In the case of a positive limit, this parameter limits the size of the batch in Chunk unit.
      */
-    ChunksSorterFullSort(const std::vector<ExprContext*>* sort_exprs, const std::vector<bool>* is_asc,
-                         const std::vector<bool>* is_null_first, size_t size_of_chunk_batch);
+    ChunksSorterFullSort(RuntimeState* state, const std::vector<ExprContext*>* sort_exprs,
+                         const std::vector<bool>* is_asc, const std::vector<bool>* is_null_first,
+                         size_t size_of_chunk_batch);
     ~ChunksSorterFullSort() override;
 
     // Append a Chunk for sort.

--- a/be/src/exec/vectorized/chunks_sorter_topn.cpp
+++ b/be/src/exec/vectorized/chunks_sorter_topn.cpp
@@ -11,10 +11,10 @@
 
 namespace starrocks::vectorized {
 
-ChunksSorterTopn::ChunksSorterTopn(const std::vector<ExprContext*>* sort_exprs, const std::vector<bool>* is_asc,
-                                   const std::vector<bool>* is_null_first, size_t offset, size_t limit,
-                                   size_t size_of_chunk_batch)
-        : ChunksSorter(sort_exprs, is_asc, is_null_first, size_of_chunk_batch),
+ChunksSorterTopn::ChunksSorterTopn(RuntimeState* state, const std::vector<ExprContext*>* sort_exprs,
+                                   const std::vector<bool>* is_asc, const std::vector<bool>* is_null_first,
+                                   size_t offset, size_t limit, size_t size_of_chunk_batch)
+        : ChunksSorter(state, sort_exprs, is_asc, is_null_first, size_of_chunk_batch),
           _offset(offset),
           _limit(limit),
           _init_merged_segment(false) {
@@ -31,7 +31,7 @@ Status ChunksSorterTopn::update(RuntimeState* state, const ChunkPtr& chunk) {
     if (chunk_number <= 0) {
         raw_chunks.push_back(chunk);
         chunk_number++;
-    } else if (raw_chunks[chunk_number - 1]->num_rows() + chunk->num_rows() > config::vector_chunk_size) {
+    } else if (raw_chunks[chunk_number - 1]->num_rows() + chunk->num_rows() > _state->chunk_size()) {
         raw_chunks.push_back(chunk);
         chunk_number++;
     } else {
@@ -84,7 +84,7 @@ void ChunksSorterTopn::get_next(ChunkPtr* chunk, bool* eos) {
         return;
     }
     *eos = false;
-    size_t count = std::min(size_t(config::vector_chunk_size), _merged_segment.chunk->num_rows() - _next_output_row);
+    size_t count = std::min(size_t(_state->chunk_size()), _merged_segment.chunk->num_rows() - _next_output_row);
     chunk->reset(_merged_segment.chunk->clone_empty(count).release());
     (*chunk)->append_safe(*_merged_segment.chunk, _next_output_row, count);
     _next_output_row += count;
@@ -113,7 +113,7 @@ bool ChunksSorterTopn::pull_chunk(ChunkPtr* chunk) {
         *chunk = nullptr;
         return true;
     }
-    size_t count = std::min(size_t(config::vector_chunk_size), _merged_segment.chunk->num_rows() - _next_output_row);
+    size_t count = std::min(size_t(_state->chunk_size()), _merged_segment.chunk->num_rows() - _next_output_row);
     chunk->reset(_merged_segment.chunk->clone_empty(count).release());
     (*chunk)->append_safe(*_merged_segment.chunk, _next_output_row, count);
     _next_output_row += count;
@@ -125,7 +125,7 @@ bool ChunksSorterTopn::pull_chunk(ChunkPtr* chunk) {
 }
 
 Status ChunksSorterTopn::_sort_chunks(RuntimeState* state) {
-    const size_t batch_size = _raw_chunks.size_of_rows;
+    const size_t chunk_size = _raw_chunks.size_of_rows;
 
     // chunks for this batch.
     DataSegments segments;
@@ -144,7 +144,7 @@ Status ChunksSorterTopn::_sort_chunks(RuntimeState* state) {
 
     // step 2: filter batch-chunks as permutations.first and permutations.second when _init_merged_segment == true.
     // sort part chunks in permutations.first and permutations.second, if _init_merged_segment == false means permutations.first is empty.
-    RETURN_IF_ERROR(_filter_and_sort_data_by_row_cmp(state, permutations, segments, batch_size));
+    RETURN_IF_ERROR(_filter_and_sort_data_by_row_cmp(state, permutations, segments, chunk_size));
 
     // step 3:
     // (1) take permutations.first as BEFORE.
@@ -248,7 +248,7 @@ void ChunksSorterTopn::_set_permutation_complete(std::pair<Permutation, Permutat
 }
 
 // In general, we take the first and last row from _merged_segment:
-// step 1: use last row to filter batch_size rows in segments as two parts(rows < lastRow and rows >= lastRow),
+// step 1: use last row to filter chunk_size rows in segments as two parts(rows < lastRow and rows >= lastRow),
 // step 2: use first row to filter all rows < lastRow, result in two parts, the BEFORE is (rows < firstRow), the IN is (rows >= firstRow and rwos < lastRows),
 // step 3: set this result in filter_array, BEOFRE(filter_array's value is 2), IN(filter_array's value is 1), others is give up.
 // all this is done in get_filter_array.
@@ -261,7 +261,7 @@ void ChunksSorterTopn::_set_permutation_complete(std::pair<Permutation, Permutat
 // at last we sort parts datas in permutations.first and permutations.second.
 Status ChunksSorterTopn::_filter_and_sort_data_by_row_cmp(RuntimeState* state,
                                                           std::pair<Permutation, Permutation>& permutations,
-                                                          DataSegments& segments, const size_t batch_size) {
+                                                          DataSegments& segments, const size_t chunk_size) {
     ScopedTimer<MonotonicStopWatch> timer(_sort_timer);
 
     DCHECK(_get_number_of_order_by_columns() > 0) << "order by columns can't be empty";

--- a/be/src/exec/vectorized/chunks_sorter_topn.h
+++ b/be/src/exec/vectorized/chunks_sorter_topn.h
@@ -20,7 +20,7 @@ public:
      * @param limit          Number of top rows after those skipped to extract. Zero means no limit.
      * @param size_of_chunk_batch  In the case of a positive limit, this parameter limits the size of the batch in Chunk unit.
      */
-    ChunksSorterTopn(const std::vector<ExprContext*>* sort_exprs, const std::vector<bool>* is_asc,
+    ChunksSorterTopn(RuntimeState* state, const std::vector<ExprContext*>* sort_exprs, const std::vector<bool>* is_asc,
                      const std::vector<bool>* is_null_first, size_t offset = 0, size_t limit = 0,
                      size_t size_of_chunk_batch = 1000);
     ~ChunksSorterTopn() override;
@@ -68,7 +68,7 @@ private:
                                           std::vector<std::vector<uint8_t>>& filter_array);
 
     Status _filter_and_sort_data_by_row_cmp(RuntimeState* state, std::pair<Permutation, Permutation>& permutation,
-                                            DataSegments& segments, size_t batch_size);
+                                            DataSegments& segments, size_t chunk_size);
 
     Status _merge_sort_data_as_merged_segment(RuntimeState* state, std::pair<Permutation, Permutation>& new_permutation,
                                               DataSegments& segments);

--- a/be/src/exec/vectorized/cross_join_node.cpp
+++ b/be/src/exec/vectorized/cross_join_node.cpp
@@ -305,7 +305,7 @@ Status CrossJoinNode::get_next_internal(RuntimeState* state, ChunkPtr* chunk, bo
         }
 
         // need row_count to fill in chunk.
-        size_t row_count = config::vector_chunk_size - (*chunk)->num_rows();
+        size_t row_count = runtime_state()->chunk_size() - (*chunk)->num_rows();
 
         // means we have scan all chunks of right tables.
         // we should scan all remain rows of right table.
@@ -387,7 +387,7 @@ Status CrossJoinNode::get_next_internal(RuntimeState* state, ChunkPtr* chunk, bo
             continue;
         }
 
-        if ((*chunk)->num_rows() < config::vector_chunk_size) {
+        if ((*chunk)->num_rows() < runtime_state()->chunk_size()) {
             continue;
         }
 
@@ -493,7 +493,7 @@ Status CrossJoinNode::_build(RuntimeState* state) {
     // Should not call num_rows on nullptr.
     if (_build_chunk != nullptr) {
         _number_of_build_rows = _build_chunk->num_rows();
-        _build_chunks_size = (_number_of_build_rows / config::vector_chunk_size) * config::vector_chunk_size;
+        _build_chunks_size = (_number_of_build_rows / runtime_state()->chunk_size()) * runtime_state()->chunk_size();
     }
 
     RETURN_IF_ERROR(child(1)->close(state));
@@ -531,7 +531,7 @@ void CrossJoinNode::_init_chunk(ChunkPtr* chunk) {
     }
 
     *chunk = std::move(new_chunk);
-    (*chunk)->reserve(config::vector_chunk_size);
+    (*chunk)->reserve(runtime_state()->chunk_size());
 }
 
 pipeline::OpFactories CrossJoinNode::decompose_to_pipeline(pipeline::PipelineBuilderContext* context) {

--- a/be/src/exec/vectorized/csv_scanner.cpp
+++ b/be/src/exec/vectorized/csv_scanner.cpp
@@ -177,7 +177,7 @@ StatusOr<ChunkPtr> CSVScanner::get_next() {
     SCOPED_RAW_TIMER(&_counter->total_ns);
 
     ChunkPtr chunk;
-    const int chunk_capacity = config::vector_chunk_size;
+    const int chunk_capacity = _state->chunk_size();
     auto src_chunk = _create_chunk(_src_slot_descriptors);
     src_chunk->reserve(chunk_capacity);
 
@@ -225,7 +225,7 @@ StatusOr<ChunkPtr> CSVScanner::get_next() {
 }
 
 Status CSVScanner::_parse_csv(Chunk* chunk) {
-    const int capacity = config::vector_chunk_size;
+    const int capacity = _state->chunk_size();
     DCHECK_EQ(0, chunk->num_rows());
     Status status;
     CSVReader::Record record;

--- a/be/src/exec/vectorized/es_http_components.cpp
+++ b/be/src/exec/vectorized/es_http_components.cpp
@@ -8,6 +8,7 @@
 #include "column/nullable_column.h"
 #include "common/config.h"
 #include "runtime/primitive_type.h"
+#include "runtime/runtime_state.h"
 #include "runtime/timestamp_value.h"
 
 namespace starrocks::vectorized {
@@ -147,7 +148,7 @@ Status ScrollParser::parse(const std::string& scroll_result, bool exactly_once) 
     return Status::OK();
 }
 
-Status ScrollParser::fill_chunk(ChunkPtr* chunk, bool* line_eos) {
+Status ScrollParser::fill_chunk(RuntimeState* state, ChunkPtr* chunk, bool* line_eos) {
     if (current_eos()) {
         *line_eos = true;
         return Status::OK();
@@ -164,7 +165,7 @@ Status ScrollParser::fill_chunk(ChunkPtr* chunk, bool* line_eos) {
     }
 
     size_t left_sz = _size - _cur_line;
-    size_t fill_sz = std::min(left_sz, (size_t)config::vector_chunk_size);
+    size_t fill_sz = std::min(left_sz, (size_t)state->chunk_size());
 
     auto slots = _tuple_desc->slots();
 

--- a/be/src/exec/vectorized/es_http_components.h
+++ b/be/src/exec/vectorized/es_http_components.h
@@ -24,7 +24,7 @@ public:
     ~ScrollParser() = default;
 
     Status parse(const std::string& scroll_result, bool exactly_once = false);
-    Status fill_chunk(ChunkPtr* chunk, bool* line_eos);
+    Status fill_chunk(RuntimeState* state, ChunkPtr* chunk, bool* line_eos);
 
     const std::string& get_scroll_id() { return _scroll_id; }
     int get_size() { return _size; }

--- a/be/src/exec/vectorized/es_http_scan_node.cpp
+++ b/be/src/exec/vectorized/es_http_scan_node.cpp
@@ -273,10 +273,10 @@ Status EsHttpScanNode::_create_scanner(int scanner_idx, std::unique_ptr<EsHttpSc
         properties[ESScanReader::KEY_TYPE] = es_scan_range.type;
     }
     properties[ESScanReader::KEY_SHARD] = std::to_string(es_scan_range.shard_id);
-    properties[ESScanReader::KEY_BATCH_SIZE] = std::to_string(runtime_state()->batch_size());
+    properties[ESScanReader::KEY_BATCH_SIZE] = std::to_string(runtime_state()->chunk_size());
     properties[ESScanReader::KEY_HOST_PORT] = get_host_port(es_scan_range.es_hosts);
     // push down limit to Elasticsearch
-    if (limit() != -1 && limit() <= runtime_state()->batch_size()) {
+    if (limit() != -1 && limit() <= runtime_state()->chunk_size()) {
         properties[ESScanReader::KEY_TERMINATE_AFTER] = std::to_string(limit());
     }
 

--- a/be/src/exec/vectorized/es_http_scanner.cpp
+++ b/be/src/exec/vectorized/es_http_scanner.cpp
@@ -71,7 +71,7 @@ Status EsHttpScanner::get_next(RuntimeState* runtime_state, ChunkPtr* chunk, boo
 
         COUNTER_UPDATE(_rows_read_counter, 1);
         SCOPED_TIMER(_materialize_timer);
-        RETURN_IF_ERROR(_es_scroll_parser->fill_chunk(chunk, &_line_eof));
+        RETURN_IF_ERROR(_es_scroll_parser->fill_chunk(runtime_state, chunk, &_line_eof));
 
         if (chunk->get() != nullptr) {
             ExecNode::eval_conjuncts(_conjunct_ctxs, chunk->get());

--- a/be/src/exec/vectorized/except_hash_set.cpp
+++ b/be/src/exec/vectorized/except_hash_set.cpp
@@ -12,13 +12,13 @@ template <typename HashSet>
 void ExceptHashSet<HashSet>::build_set(RuntimeState* state, const ChunkPtr& chunk,
                                        const std::vector<ExprContext*>& exprs, MemPool* pool) {
     size_t chunk_size = chunk->num_rows();
-    _slice_sizes.assign(config::vector_chunk_size, 0);
+    _slice_sizes.assign(state->chunk_size(), 0);
 
     size_t cur_max_one_row_size = _get_max_serialize_size(chunk, exprs);
     if (UNLIKELY(cur_max_one_row_size > _max_one_row_size)) {
         _max_one_row_size = cur_max_one_row_size;
         _mem_pool->clear();
-        _buffer = _mem_pool->allocate(_max_one_row_size * config::vector_chunk_size);
+        _buffer = _mem_pool->allocate(_max_one_row_size * state->chunk_size());
         THROW_BAD_ALLOC_IF_NULL(_buffer);
     }
 
@@ -36,16 +36,25 @@ void ExceptHashSet<HashSet>::build_set(RuntimeState* state, const ChunkPtr& chun
 }
 
 template <typename HashSet>
+Status ExceptHashSet<HashSet>::init(RuntimeState* state) {
+    _hash_set = std::make_unique<HashSet>();
+    _mem_pool = std::make_unique<MemPool>();
+    _buffer = _mem_pool->allocate(_max_one_row_size * state->chunk_size());
+    RETURN_IF_UNLIKELY_NULL(_buffer, Status::MemoryAllocFailed("alloc mem of except hash set failed"));
+    return Status::OK();
+}
+
+template <typename HashSet>
 Status ExceptHashSet<HashSet>::erase_duplicate_row(RuntimeState* state, const ChunkPtr& chunk,
                                                    const std::vector<ExprContext*>& exprs) {
     size_t chunk_size = chunk->num_rows();
-    _slice_sizes.assign(config::vector_chunk_size, 0);
+    _slice_sizes.assign(state->chunk_size(), 0);
 
     size_t cur_max_one_row_size = _get_max_serialize_size(chunk, exprs);
     if (UNLIKELY(cur_max_one_row_size > _max_one_row_size)) {
         _max_one_row_size = cur_max_one_row_size;
         _mem_pool->clear();
-        _buffer = _mem_pool->allocate(_max_one_row_size * config::vector_chunk_size);
+        _buffer = _mem_pool->allocate(_max_one_row_size * state->chunk_size());
         if (UNLIKELY(_buffer == nullptr)) {
             return Status::InternalError("Mem usage has exceed the limit of BE");
         }
@@ -66,7 +75,7 @@ Status ExceptHashSet<HashSet>::erase_duplicate_row(RuntimeState* state, const Ch
 }
 
 template <typename HashSet>
-void ExceptHashSet<HashSet>::deserialize_to_columns(KeyVector& keys, const Columns& key_columns, size_t batch_size) {
+void ExceptHashSet<HashSet>::deserialize_to_columns(KeyVector& keys, const Columns& key_columns, size_t chunk_size) {
     for (auto& key_column : key_columns) {
         DCHECK(!key_column->is_constant());
         // Because the serialized key is always nullable,
@@ -77,7 +86,7 @@ void ExceptHashSet<HashSet>::deserialize_to_columns(KeyVector& keys, const Colum
             }
         }
 
-        key_column->deserialize_and_append_batch(keys, batch_size);
+        key_column->deserialize_and_append_batch(keys, chunk_size);
     }
 }
 

--- a/be/src/exec/vectorized/except_hash_set.h
+++ b/be/src/exec/vectorized/except_hash_set.h
@@ -46,13 +46,7 @@ public:
 
     ExceptHashSet() = default;
 
-    Status init() {
-        _hash_set = std::make_unique<HashSet>();
-        _mem_pool = std::make_unique<MemPool>();
-        _buffer = _mem_pool->allocate(_max_one_row_size * config::vector_chunk_size);
-        RETURN_IF_UNLIKELY_NULL(_buffer, Status::MemoryAllocFailed("alloc mem of except hash set failed"));
-        return Status::OK();
-    }
+    Status init(RuntimeState* state);
 
     Iterator begin() { return _hash_set->begin(); }
 
@@ -66,7 +60,7 @@ public:
 
     Status erase_duplicate_row(RuntimeState* state, const ChunkPtr& chunk, const std::vector<ExprContext*>& exprs);
 
-    void deserialize_to_columns(KeyVector& keys, const Columns& key_columns, size_t batch_size);
+    void deserialize_to_columns(KeyVector& keys, const Columns& key_columns, size_t chunk_size);
 
     int64_t mem_usage() { return _hash_set->dump_bound() + _mem_pool->total_reserved_bytes(); }
 

--- a/be/src/exec/vectorized/except_node.cpp
+++ b/be/src/exec/vectorized/except_node.cpp
@@ -82,7 +82,7 @@ Status ExceptNode::open(RuntimeState* state) {
 
     // initial build hash table used for remove duplicted
     _hash_set = std::make_unique<ExceptHashSerializeSet>();
-    RETURN_IF_ERROR(_hash_set->init());
+    RETURN_IF_ERROR(_hash_set->init(state));
 
     ChunkPtr chunk = nullptr;
     RETURN_IF_ERROR(child(0)->open(state));
@@ -149,8 +149,8 @@ Status ExceptNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) {
     }
 
     int32_t read_index = 0;
-    _remained_keys.resize(config::vector_chunk_size);
-    while (_hash_set_iterator != _hash_set->end() && read_index < config::vector_chunk_size) {
+    _remained_keys.resize(runtime_state()->chunk_size());
+    while (_hash_set_iterator != _hash_set->end() && read_index < runtime_state()->chunk_size()) {
         if (!_hash_set_iterator->deleted) {
             _remained_keys[read_index] = _hash_set_iterator->slice;
             ++read_index;
@@ -164,7 +164,7 @@ Status ExceptNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) {
         for (size_t i = 0; i < _types.size(); ++i) {
             result_columns[i] = // default NullableColumn
                     ColumnHelper::create_column(_types[i].result_type, _types[i].is_nullable);
-            result_columns[i]->reserve(config::vector_chunk_size);
+            result_columns[i]->reserve(runtime_state()->chunk_size());
         }
 
         {
@@ -187,7 +187,7 @@ Status ExceptNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) {
         *eos = true;
     }
 
-    DCHECK_LE(result_chunk->num_rows(), config::vector_chunk_size);
+    DCHECK_LE(result_chunk->num_rows(), runtime_state()->chunk_size());
     *chunk = std::move(result_chunk);
 
     DCHECK_CHUNK(*chunk);
@@ -223,8 +223,8 @@ pipeline::OpFactories ExceptNode::decompose_to_pipeline(pipeline::PipelineBuilde
 
     // Use the first child to build the hast table by ExceptBuildSinkOperator.
     pipeline::OpFactories operators_with_except_build_sink = child(0)->decompose_to_pipeline(context);
-    operators_with_except_build_sink =
-            context->maybe_interpolate_local_shuffle_exchange(operators_with_except_build_sink, _child_expr_lists[0]);
+    operators_with_except_build_sink = context->maybe_interpolate_local_shuffle_exchange(
+            runtime_state(), operators_with_except_build_sink, _child_expr_lists[0]);
     operators_with_except_build_sink.emplace_back(std::make_shared<pipeline::ExceptBuildSinkOperatorFactory>(
             context->next_operator_id(), id(), except_partition_ctx_factory, _child_expr_lists[0]));
     // Initialize OperatorFactory's fields involving runtime filters.
@@ -236,7 +236,7 @@ pipeline::OpFactories ExceptNode::decompose_to_pipeline(pipeline::PipelineBuilde
     for (size_t i = 1; i < _children.size(); i++) {
         pipeline::OpFactories operators_with_except_probe_sink = child(i)->decompose_to_pipeline(context);
         operators_with_except_probe_sink = context->maybe_interpolate_local_shuffle_exchange(
-                operators_with_except_probe_sink, _child_expr_lists[i]);
+                runtime_state(), operators_with_except_probe_sink, _child_expr_lists[i]);
         operators_with_except_probe_sink.emplace_back(std::make_shared<pipeline::ExceptProbeSinkOperatorFactory>(
                 context->next_operator_id(), id(), except_partition_ctx_factory, _child_expr_lists[i], i - 1));
         // Initialize OperatorFactory's fields involving runtime filters.

--- a/be/src/exec/vectorized/hash_join_node.cpp
+++ b/be/src/exec/vectorized/hash_join_node.cpp
@@ -313,7 +313,7 @@ Status HashJoinNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) {
         }
     }
 
-    DCHECK_LE((*chunk)->num_rows(), config::vector_chunk_size);
+    DCHECK_LE((*chunk)->num_rows(), runtime_state()->chunk_size());
     _num_rows_returned += (*chunk)->num_rows();
     _output_chunk_count++;
     if (reached_limit()) {
@@ -353,8 +353,10 @@ pipeline::OpFactories HashJoinNode::decompose_to_pipeline(pipeline::PipelineBuil
     if (_distribution_mode == TJoinDistributionMode::BROADCAST) {
         num_partitions = context->degree_of_parallelism();
 
-        rhs_operators = context->maybe_interpolate_local_broadcast_exchange(rhs_operators, num_partitions);
-        lhs_operators = context->maybe_interpolate_local_passthrough_exchange(lhs_operators, num_partitions);
+        rhs_operators =
+                context->maybe_interpolate_local_broadcast_exchange(runtime_state(), rhs_operators, num_partitions);
+        lhs_operators =
+                context->maybe_interpolate_local_passthrough_exchange(runtime_state(), lhs_operators, num_partitions);
     } else {
         // "col NOT IN (NULL, val1, val2)" always returns false, so hash join should
         // return empty result in this case. Hash join cannot be divided into multiple
@@ -363,15 +365,17 @@ pipeline::OpFactories HashJoinNode::decompose_to_pipeline(pipeline::PipelineBuil
         if (_join_type == TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN) {
             num_partitions = 1;
 
-            rhs_operators = context->maybe_interpolate_local_passthrough_exchange(rhs_operators);
-            lhs_operators = context->maybe_interpolate_local_passthrough_exchange(lhs_operators);
+            rhs_operators = context->maybe_interpolate_local_passthrough_exchange(runtime_state(), rhs_operators);
+            lhs_operators = context->maybe_interpolate_local_passthrough_exchange(runtime_state(), lhs_operators);
         } else {
             num_partitions = context->degree_of_parallelism();
 
             // both HashJoin{Build, Probe}Operator are parallelized, so add LocalExchangeOperator
             // to shuffle multi-stream into #degree_of_parallelism# streams each of that pipes into HashJoin{Build, Probe}Operator.
-            rhs_operators = context->maybe_interpolate_local_shuffle_exchange(rhs_operators, _build_expr_ctxs);
-            lhs_operators = context->maybe_interpolate_local_shuffle_exchange(lhs_operators, _probe_expr_ctxs);
+            rhs_operators =
+                    context->maybe_interpolate_local_shuffle_exchange(runtime_state(), rhs_operators, _build_expr_ctxs);
+            lhs_operators =
+                    context->maybe_interpolate_local_shuffle_exchange(runtime_state(), lhs_operators, _probe_expr_ctxs);
         }
     }
 
@@ -509,8 +513,8 @@ Status HashJoinNode::_probe(RuntimeState* state, ScopedTimer<MonotonicStopWatch>
                         } else {
                             if (_cur_left_input_chunk->num_rows() <= 0) {
                                 continue;
-                            } else if (_cur_left_input_chunk->num_rows() >= config::vector_chunk_size / 2) {
-                                // the probe chunk size of read from right child >= config::vector_chunk_size, direct return
+                            } else if (_cur_left_input_chunk->num_rows() >= runtime_state()->chunk_size() / 2) {
+                                // the probe chunk size of read from right child >= runtime_state()->chunk_size(), direct return
                                 _probing_chunk = std::move(_cur_left_input_chunk);
                             } else if (_pre_left_input_chunk == nullptr) {
                                 // the probe chunk size is small, reserve for merge next probe chunk
@@ -518,8 +522,8 @@ Status HashJoinNode::_probe(RuntimeState* state, ScopedTimer<MonotonicStopWatch>
                                 continue;
                             } else {
                                 if (_cur_left_input_chunk->num_rows() + _pre_left_input_chunk->num_rows() >
-                                    config::vector_chunk_size) {
-                                    // the two chunk size > config::vector_chunk_size, return the first reserved chunk
+                                    runtime_state()->chunk_size()) {
+                                    // the two chunk size > runtime_state()->chunk_size(), return the first reserved chunk
                                     _probing_chunk = std::move(_pre_left_input_chunk);
                                     _pre_left_input_chunk = std::move(_cur_left_input_chunk);
                                 } else {
@@ -568,7 +572,7 @@ Status HashJoinNode::_probe(RuntimeState* state, ScopedTimer<MonotonicStopWatch>
             }
         }
 
-        RETURN_IF_ERROR(_ht.probe(_key_columns, &_probing_chunk, chunk, &_ht_has_remain));
+        RETURN_IF_ERROR(_ht.probe(state, _key_columns, &_probing_chunk, chunk, &_ht_has_remain));
         if (!_ht_has_remain) {
             _probing_chunk = nullptr;
         }
@@ -606,7 +610,7 @@ Status HashJoinNode::_probe_remain(ChunkPtr* chunk, bool& eos) {
     ScopedTimer<MonotonicStopWatch> probe_timer(_probe_timer);
 
     while (!_build_eos) {
-        RETURN_IF_ERROR(_ht.probe_remain(chunk, &_right_table_has_remain));
+        RETURN_IF_ERROR(_ht.probe_remain(runtime_state(), chunk, &_right_table_has_remain));
 
         eval_join_runtime_filters(chunk);
 

--- a/be/src/exec/vectorized/hash_joiner.cpp
+++ b/be/src/exec/vectorized/hash_joiner.cpp
@@ -188,7 +188,7 @@ StatusOr<ChunkPtr> HashJoiner::_pull_probe_output_chunk(RuntimeState* state) {
     if (_phase == HashJoinPhase::PROBE || _probe_input_chunk != nullptr) {
         DCHECK(_ht_has_remain && _probe_input_chunk);
 
-        RETURN_IF_ERROR(_ht.probe(_key_columns, &_probe_input_chunk, &chunk, &_ht_has_remain));
+        RETURN_IF_ERROR(_ht.probe(state, _key_columns, &_probe_input_chunk, &chunk, &_ht_has_remain));
         if (!_ht_has_remain) {
             _probe_input_chunk = nullptr;
         }
@@ -204,7 +204,7 @@ StatusOr<ChunkPtr> HashJoiner::_pull_probe_output_chunk(RuntimeState* state) {
             return chunk;
         }
 
-        RETURN_IF_ERROR(_ht.probe_remain(&chunk, &_ht_has_remain));
+        RETURN_IF_ERROR(_ht.probe_remain(state, &chunk, &_ht_has_remain));
         if (!_ht_has_remain) {
             enter_eos_phase();
         }

--- a/be/src/exec/vectorized/hdfs_scan_node.cpp
+++ b/be/src/exec/vectorized/hdfs_scan_node.cpp
@@ -161,8 +161,8 @@ Status HdfsScanNode::_start_scan_thread(RuntimeState* state) {
     // init chunk pool
     _pending_scanners.reverse();
     _num_scanners = _pending_scanners.size();
-    _chunks_per_scanner = config::doris_scanner_row_num / config::vector_chunk_size;
-    _chunks_per_scanner += static_cast<int>(config::doris_scanner_row_num % config::vector_chunk_size != 0);
+    _chunks_per_scanner = config::doris_scanner_row_num / runtime_state()->chunk_size();
+    _chunks_per_scanner += static_cast<int>(config::doris_scanner_row_num % runtime_state()->chunk_size() != 0);
     int concurrency = std::min<int>(kMaxConcurrency, _num_scanners);
     int chunks = _chunks_per_scanner * concurrency;
     _chunk_pool.reserve(chunks);
@@ -418,7 +418,7 @@ void HdfsScanNode::_fill_chunk_pool(int count) {
     std::lock_guard<std::mutex> l(_mtx);
 
     for (int i = 0; i < count; i++) {
-        auto chunk = ChunkHelper::new_chunk(*_tuple_desc, config::vector_chunk_size);
+        auto chunk = ChunkHelper::new_chunk(*_tuple_desc, runtime_state()->chunk_size());
         _chunk_pool.push(std::move(chunk));
     }
 }

--- a/be/src/exec/vectorized/hdfs_scanner_orc.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_orc.cpp
@@ -230,7 +230,7 @@ bool OrcRowReaderFilter::filterOnPickStringDictionary(
         }
         // create chunk
         orc::StringDictionary* dict = it->second;
-        if (dict->dictionaryOffset.size() > config::vector_chunk_size) {
+        if (dict->dictionaryOffset.size() > _adapter->runtime_state()->chunk_size()) {
             continue;
         }
         vectorized::ChunkPtr dict_value_chunk = std::make_shared<vectorized::Chunk>();
@@ -361,12 +361,12 @@ Status HdfsOrcScanner::do_open(RuntimeState* runtime_state) {
         }
     }
 
-    _orc_adapter = std::make_unique<OrcScannerAdapter>(_src_slot_descriptors);
+    _orc_adapter = std::make_unique<OrcScannerAdapter>(runtime_state, _src_slot_descriptors);
     _orc_row_reader_filter =
             std::make_shared<OrcRowReaderFilter>(_scanner_params, _file_read_param, _orc_adapter.get());
     _orc_adapter->disable_broker_load_mode();
     _orc_adapter->set_row_reader_filter(_orc_row_reader_filter);
-    _orc_adapter->set_read_chunk_size(config::vector_chunk_size);
+    _orc_adapter->set_read_chunk_size(runtime_state->chunk_size());
     _orc_adapter->set_runtime_state(runtime_state);
     _orc_adapter->set_current_file_name(_scanner_params.scan_ranges[0]->relative_path);
     RETURN_IF_ERROR(_orc_adapter->set_timezone(_file_read_param.timezone));

--- a/be/src/exec/vectorized/intersect_hash_set.cpp
+++ b/be/src/exec/vectorized/intersect_hash_set.cpp
@@ -7,18 +7,26 @@
 #include "util/phmap/phmap_dump.h"
 
 namespace starrocks::vectorized {
+template <typename HashSet>
+Status IntersectHashSet<HashSet>::init(RuntimeState* state) {
+    _hash_set = std::make_unique<HashSet>();
+    _mem_pool = std::make_unique<MemPool>();
+    _buffer = _mem_pool->allocate(_max_one_row_size * state->chunk_size());
+    RETURN_IF_UNLIKELY_NULL(_buffer, Status::MemoryAllocFailed("alloc mem for intersect hash set failed"));
+    return Status::OK();
+}
 
 template <typename HashSet>
 void IntersectHashSet<HashSet>::build_set(RuntimeState* state, const ChunkPtr& chunkPtr,
                                           const std::vector<ExprContext*>& exprs, MemPool* pool) {
     size_t chunk_size = chunkPtr->num_rows();
 
-    _slice_sizes.assign(config::vector_chunk_size, 0);
+    _slice_sizes.assign(state->chunk_size(), 0);
     size_t cur_max_one_row_size = _get_max_serialize_size(chunkPtr, exprs);
     if (UNLIKELY(cur_max_one_row_size > _max_one_row_size)) {
         _max_one_row_size = cur_max_one_row_size;
         _mem_pool->clear();
-        _buffer = _mem_pool->allocate(_max_one_row_size * config::vector_chunk_size);
+        _buffer = _mem_pool->allocate(_max_one_row_size * state->chunk_size());
         THROW_BAD_ALLOC_IF_NULL(_buffer);
     }
 
@@ -40,12 +48,12 @@ template <typename HashSet>
 Status IntersectHashSet<HashSet>::refine_intersect_row(RuntimeState* state, const ChunkPtr& chunkPtr,
                                                        const std::vector<ExprContext*>& exprs, const int hit_times) {
     size_t chunk_size = chunkPtr->num_rows();
-    _slice_sizes.assign(config::vector_chunk_size, 0);
+    _slice_sizes.assign(state->chunk_size(), 0);
     size_t cur_max_one_row_size = _get_max_serialize_size(chunkPtr, exprs);
     if (UNLIKELY(cur_max_one_row_size > _max_one_row_size)) {
         _max_one_row_size = cur_max_one_row_size;
         _mem_pool->clear();
-        _buffer = _mem_pool->allocate(_max_one_row_size * config::vector_chunk_size);
+        _buffer = _mem_pool->allocate(_max_one_row_size * state->chunk_size());
         if (UNLIKELY(_buffer == nullptr)) {
             return Status::InternalError("Mem usage has exceed the limit of BE");
         }
@@ -65,7 +73,7 @@ Status IntersectHashSet<HashSet>::refine_intersect_row(RuntimeState* state, cons
 }
 
 template <typename HashSet>
-void IntersectHashSet<HashSet>::deserialize_to_columns(KeyVector& keys, const Columns& key_columns, size_t batch_size) {
+void IntersectHashSet<HashSet>::deserialize_to_columns(KeyVector& keys, const Columns& key_columns, size_t chunk_size) {
     for (const auto& key_column : key_columns) {
         // Because the serialized key is always nullable,
         // drop the null byte of the key if the dest column is non-nullable.
@@ -77,7 +85,7 @@ void IntersectHashSet<HashSet>::deserialize_to_columns(KeyVector& keys, const Co
             continue;
         }
 
-        key_column->deserialize_and_append_batch(keys, batch_size);
+        key_column->deserialize_and_append_batch(keys, chunk_size);
     }
 }
 

--- a/be/src/exec/vectorized/intersect_hash_set.h
+++ b/be/src/exec/vectorized/intersect_hash_set.h
@@ -44,13 +44,7 @@ public:
 
     IntersectHashSet() = default;
 
-    Status init() {
-        _hash_set = std::make_unique<HashSet>();
-        _mem_pool = std::make_unique<MemPool>();
-        _buffer = _mem_pool->allocate(_max_one_row_size * config::vector_chunk_size);
-        RETURN_IF_UNLIKELY_NULL(_buffer, Status::MemoryAllocFailed("alloc mem for intersect hash set failed"));
-        return Status::OK();
-    }
+    Status init(RuntimeState* state);
 
     Iterator begin() { return _hash_set->begin(); }
 
@@ -64,7 +58,7 @@ public:
     Status refine_intersect_row(RuntimeState* state, const ChunkPtr& chunkPtr, const std::vector<ExprContext*>& exprs,
                                 int hit_times);
 
-    void deserialize_to_columns(KeyVector& keys, const Columns& key_columns, size_t batch_size);
+    void deserialize_to_columns(KeyVector& keys, const Columns& key_columns, size_t chunk_size);
 
     int64_t mem_usage() const;
 

--- a/be/src/exec/vectorized/intersect_node.cpp
+++ b/be/src/exec/vectorized/intersect_node.cpp
@@ -85,7 +85,7 @@ Status IntersectNode::open(RuntimeState* state) {
 
     // initial build hash table used for record hitting.
     _hash_set = std::make_unique<IntersectHashSerializeSet>();
-    RETURN_IF_ERROR(_hash_set->init());
+    RETURN_IF_ERROR(_hash_set->init(state));
 
     ChunkPtr chunk = nullptr;
     RETURN_IF_ERROR(child(0)->open(state));
@@ -161,8 +161,8 @@ Status IntersectNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) 
     }
 
     int32_t read_index = 0;
-    _remained_keys.resize(config::vector_chunk_size);
-    while (_hash_set_iterator != _hash_set->end() && read_index < config::vector_chunk_size) {
+    _remained_keys.resize(runtime_state()->chunk_size());
+    while (_hash_set_iterator != _hash_set->end() && read_index < runtime_state()->chunk_size()) {
         if (_hash_set_iterator->hit_times == _intersect_times) {
             _remained_keys[read_index] = _hash_set_iterator->slice;
             ++read_index;
@@ -176,7 +176,7 @@ Status IntersectNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) 
         for (size_t i = 0; i < _types.size(); ++i) {
             result_columns[i] = // default NullableColumn
                     ColumnHelper::create_column(_types[i].result_type, _types[i].is_nullable);
-            result_columns[i]->reserve(config::vector_chunk_size);
+            result_columns[i]->reserve(runtime_state()->chunk_size());
         }
 
         {
@@ -199,7 +199,7 @@ Status IntersectNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) 
         *eos = true;
     }
 
-    DCHECK_LE(result_chunk->num_rows(), config::vector_chunk_size);
+    DCHECK_LE(result_chunk->num_rows(), runtime_state()->chunk_size());
     *chunk = std::move(result_chunk);
 
     DCHECK_CHUNK(*chunk);
@@ -237,7 +237,7 @@ pipeline::OpFactories IntersectNode::decompose_to_pipeline(pipeline::PipelineBui
     // Use the first child to build the hast table by IntersectBuildSinkOperator.
     pipeline::OpFactories operators_with_intersect_build_sink = child(0)->decompose_to_pipeline(context);
     operators_with_intersect_build_sink = context->maybe_interpolate_local_shuffle_exchange(
-            operators_with_intersect_build_sink, _child_expr_lists[0]);
+            runtime_state(), operators_with_intersect_build_sink, _child_expr_lists[0]);
     operators_with_intersect_build_sink.emplace_back(std::make_shared<pipeline::IntersectBuildSinkOperatorFactory>(
             context->next_operator_id(), id(), intersect_partition_ctx_factory, _child_expr_lists[0]));
     // Initialize OperatorFactory's fields involving runtime filters.
@@ -249,7 +249,7 @@ pipeline::OpFactories IntersectNode::decompose_to_pipeline(pipeline::PipelineBui
     for (size_t i = 1; i < _children.size(); i++) {
         pipeline::OpFactories operators_with_intersect_probe_sink = child(i)->decompose_to_pipeline(context);
         operators_with_intersect_probe_sink = context->maybe_interpolate_local_shuffle_exchange(
-                operators_with_intersect_probe_sink, _child_expr_lists[i]);
+                runtime_state(), operators_with_intersect_probe_sink, _child_expr_lists[i]);
         operators_with_intersect_probe_sink.emplace_back(std::make_shared<pipeline::IntersectProbeSinkOperatorFactory>(
                 context->next_operator_id(), id(), intersect_partition_ctx_factory, _child_expr_lists[i], i - 1));
         // Initialize OperatorFactory's fields involving runtime filters.

--- a/be/src/exec/vectorized/join_hash_map.cpp
+++ b/be/src/exec/vectorized/join_hash_map.cpp
@@ -15,12 +15,12 @@ namespace starrocks::vectorized {
 Status SerializedJoinBuildFunc::prepare(RuntimeState* state, JoinHashTableItems* table_items,
                                         HashTableProbeState* probe_state) {
     table_items->build_slice.resize(table_items->row_count + 1);
-    probe_state->buckets.resize(config::vector_chunk_size);
-    probe_state->is_nulls.resize(config::vector_chunk_size);
+    probe_state->buckets.resize(state->chunk_size());
+    probe_state->is_nulls.resize(state->chunk_size());
     return Status::OK();
 }
 
-Status SerializedJoinBuildFunc::construct_hash_table(JoinHashTableItems* table_items,
+Status SerializedJoinBuildFunc::construct_hash_table(RuntimeState* state, JoinHashTableItems* table_items,
                                                      HashTableProbeState* probe_state) {
     uint32_t row_count = table_items->row_count;
 
@@ -51,22 +51,22 @@ Status SerializedJoinBuildFunc::construct_hash_table(JoinHashTableItems* table_i
     RETURN_IF_UNLIKELY_NULL(ptr, Status::MemoryAllocFailed("alloc mem for hash join build failed"));
 
     // serialize and build hash table
-    uint32_t quo = row_count / config::vector_chunk_size;
-    uint32_t rem = row_count % config::vector_chunk_size;
+    uint32_t quo = row_count / state->chunk_size();
+    uint32_t rem = row_count % state->chunk_size();
 
     if (!null_columns.empty()) {
         for (size_t i = 0; i < quo; i++) {
-            _build_nullable_columns(table_items, probe_state, data_columns, null_columns,
-                                    1 + config::vector_chunk_size * i, config::vector_chunk_size, &ptr);
+            _build_nullable_columns(table_items, probe_state, data_columns, null_columns, 1 + state->chunk_size() * i,
+                                    state->chunk_size(), &ptr);
         }
-        _build_nullable_columns(table_items, probe_state, data_columns, null_columns,
-                                1 + config::vector_chunk_size * quo, rem, &ptr);
+        _build_nullable_columns(table_items, probe_state, data_columns, null_columns, 1 + state->chunk_size() * quo,
+                                rem, &ptr);
     } else {
         for (size_t i = 0; i < quo; i++) {
-            _build_columns(table_items, probe_state, data_columns, 1 + config::vector_chunk_size * i,
-                           config::vector_chunk_size, &ptr);
+            _build_columns(table_items, probe_state, data_columns, 1 + state->chunk_size() * i, state->chunk_size(),
+                           &ptr);
         }
-        _build_columns(table_items, probe_state, data_columns, 1 + config::vector_chunk_size * quo, rem, &ptr);
+        _build_columns(table_items, probe_state, data_columns, 1 + state->chunk_size() * quo, rem, &ptr);
     }
 
     return Status::OK();
@@ -280,7 +280,7 @@ Status JoinHashTable::build(RuntimeState* state) {
         _probe_state->build_match_index[0] = 1;
     }
 
-    JoinHashMapHelper::prepare_map_index(_probe_state.get());
+    JoinHashMapHelper::prepare_map_index(_probe_state.get(), state->chunk_size());
 
     switch (_hash_map_type) {
     case JoinHashMapType::empty:
@@ -299,13 +299,14 @@ Status JoinHashTable::build(RuntimeState* state) {
     return Status::OK();
 }
 
-Status JoinHashTable::probe(const Columns& key_columns, ChunkPtr* probe_chunk, ChunkPtr* chunk, bool* eos) {
+Status JoinHashTable::probe(RuntimeState* state, const Columns& key_columns, ChunkPtr* probe_chunk, ChunkPtr* chunk,
+                            bool* eos) {
     switch (_hash_map_type) {
     case JoinHashMapType::empty:
         break;
-#define M(NAME)                                                                \
-    case JoinHashMapType::NAME:                                                \
-        RETURN_IF_ERROR(_##NAME->probe(key_columns, probe_chunk, chunk, eos)); \
+#define M(NAME)                                                                       \
+    case JoinHashMapType::NAME:                                                       \
+        RETURN_IF_ERROR(_##NAME->probe(state, key_columns, probe_chunk, chunk, eos)); \
         break;
         APPLY_FOR_JOIN_VARIANTS(M)
 #undef M
@@ -315,13 +316,13 @@ Status JoinHashTable::probe(const Columns& key_columns, ChunkPtr* probe_chunk, C
     return Status::OK();
 }
 
-Status JoinHashTable::probe_remain(ChunkPtr* chunk, bool* eos) {
+Status JoinHashTable::probe_remain(RuntimeState* state, ChunkPtr* chunk, bool* eos) {
     switch (_hash_map_type) {
     case JoinHashMapType::empty:
         break;
-#define M(NAME)                                             \
-    case JoinHashMapType::NAME:                             \
-        RETURN_IF_ERROR(_##NAME->probe_remain(chunk, eos)); \
+#define M(NAME)                                                    \
+    case JoinHashMapType::NAME:                                    \
+        RETURN_IF_ERROR(_##NAME->probe_remain(state, chunk, eos)); \
         break;
         APPLY_FOR_JOIN_VARIANTS(M)
 #undef M

--- a/be/src/exec/vectorized/join_hash_map.h
+++ b/be/src/exec/vectorized/join_hash_map.h
@@ -234,13 +234,13 @@ public:
         }
     }
 
-    static void prepare_map_index(HashTableProbeState* probe_state) {
-        probe_state->build_index.resize(config::vector_chunk_size + 8);
-        probe_state->probe_index.resize(config::vector_chunk_size + 8);
-        probe_state->next.resize(config::vector_chunk_size);
-        probe_state->probe_match_index.resize(config::vector_chunk_size);
-        probe_state->probe_match_filter.resize(config::vector_chunk_size);
-        probe_state->buckets.resize(config::vector_chunk_size);
+    static void prepare_map_index(HashTableProbeState* probe_state, int32_t chunk_size) {
+        probe_state->build_index.resize(chunk_size + 8);
+        probe_state->probe_index.resize(chunk_size + 8);
+        probe_state->next.resize(chunk_size);
+        probe_state->probe_match_index.resize(chunk_size);
+        probe_state->probe_match_filter.resize(chunk_size);
+        probe_state->buckets.resize(chunk_size);
     }
 
     static Slice get_hash_key(const Columns& key_columns, size_t row_idx, uint8_t* buffer) {
@@ -282,7 +282,8 @@ public:
     }
 
     static const Buffer<CppType>& get_key_data(const JoinHashTableItems& table_items);
-    static Status construct_hash_table(JoinHashTableItems* table_items, HashTableProbeState* probe_state);
+    static Status construct_hash_table(RuntimeState* state, JoinHashTableItems* table_items,
+                                       HashTableProbeState* probe_state);
 };
 
 template <PrimitiveType PT>
@@ -296,7 +297,8 @@ public:
     static const Buffer<CppType>& get_key_data(const JoinHashTableItems& table_items) {
         return ColumnHelper::as_raw_column<const ColumnType>(table_items.build_key_column)->get_data();
     }
-    static Status construct_hash_table(JoinHashTableItems* table_items, HashTableProbeState* probe_state);
+    static Status construct_hash_table(RuntimeState* state, JoinHashTableItems* table_items,
+                                       HashTableProbeState* probe_state);
 
 private:
     static void _build_columns(JoinHashTableItems* table_items, HashTableProbeState* probe_state,
@@ -311,7 +313,8 @@ class SerializedJoinBuildFunc {
 public:
     static Status prepare(RuntimeState* state, JoinHashTableItems* table_items, HashTableProbeState* probe_state);
     static const Buffer<Slice>& get_key_data(const JoinHashTableItems& table_items) { return table_items.build_slice; }
-    static Status construct_hash_table(JoinHashTableItems* table_items, HashTableProbeState* probe_state);
+    static Status construct_hash_table(RuntimeState* state, JoinHashTableItems* table_items,
+                                       HashTableProbeState* probe_state);
 
 private:
     static void _build_columns(JoinHashTableItems* table_items, HashTableProbeState* probe_state,
@@ -328,7 +331,7 @@ public:
     using CppType = typename RunTimeTypeTraits<PT>::CppType;
     using ColumnType = typename RunTimeTypeTraits<PT>::ColumnType;
 
-    static void prepare(JoinHashTableItems* table_items, HashTableProbeState* probe_state) {}
+    static void prepare(RuntimeState* state, JoinHashTableItems* table_items, HashTableProbeState* probe_state) {}
 
     static Status lookup_init(const JoinHashTableItems& table_items, HashTableProbeState* probe_state);
 
@@ -341,9 +344,9 @@ public:
     using CppType = typename RunTimeTypeTraits<PT>::CppType;
     using ColumnType = typename RunTimeTypeTraits<PT>::ColumnType;
 
-    static Status prepare(JoinHashTableItems* table_items, HashTableProbeState* probe_state) {
+    static Status prepare(RuntimeState* state, JoinHashTableItems* table_items, HashTableProbeState* probe_state) {
         probe_state->probe_key_column = ColumnType::create(probe_state->probe_row_count);
-        probe_state->is_nulls.resize(config::vector_chunk_size);
+        probe_state->is_nulls.resize(state->chunk_size());
         return Status::OK();
     }
 
@@ -365,10 +368,10 @@ class SerializedJoinProbeFunc {
 public:
     static const Buffer<Slice>& get_key_data(const HashTableProbeState& probe_state) { return probe_state.probe_slice; }
 
-    static void prepare(JoinHashTableItems* table_items, HashTableProbeState* probe_state) {
+    static void prepare(RuntimeState* state, JoinHashTableItems* table_items, HashTableProbeState* probe_state) {
         table_items->probe_pool->clear();
         probe_state->probe_slice.resize(probe_state->probe_row_count);
-        probe_state->is_nulls.resize(config::vector_chunk_size);
+        probe_state->is_nulls.resize(state->chunk_size());
     }
 
     static Status lookup_init(const JoinHashTableItems& table_items, HashTableProbeState* probe_state);
@@ -389,8 +392,9 @@ public:
             : _table_items(table_items), _probe_state(probe_state) {}
 
     Status build(RuntimeState* state);
-    Status probe(const Columns& key_columns, ChunkPtr* probe_chunk, ChunkPtr* chunk, bool* has_remain);
-    Status probe_remain(ChunkPtr* chunk, bool* has_remain);
+    Status probe(RuntimeState* state, const Columns& key_columns, ChunkPtr* probe_chunk, ChunkPtr* chunk,
+                 bool* has_remain);
+    Status probe_remain(RuntimeState* state, ChunkPtr* chunk, bool* has_remain);
 
 private:
     Status _probe_output(ChunkPtr* probe_chunk, ChunkPtr* chunk);
@@ -409,77 +413,84 @@ private:
 
     void _copy_build_nullable_column(const ColumnPtr& src_column, ChunkPtr* chunk, const SlotDescriptor* slot);
 
-    Status _search_ht(ChunkPtr* probe_chunk);
-    void _search_ht_remain();
+    Status _search_ht(RuntimeState* state, ChunkPtr* probe_chunk);
+    void _search_ht_remain(RuntimeState* state);
 
     template <bool first_probe>
-    void _search_ht_impl(const Buffer<CppType>& build_data, const Buffer<CppType>& data);
+    void _search_ht_impl(RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& data);
 
     // for one key inner join
     template <bool first_probe>
-    void _probe_from_ht(const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data);
+    void _probe_from_ht(RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data);
 
     // for one key left outer join
     template <bool first_probe>
-    void _probe_from_ht_for_left_outer_join(const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data);
+    void _probe_from_ht_for_left_outer_join(RuntimeState* state, const Buffer<CppType>& build_data,
+                                            const Buffer<CppType>& probe_data);
 
     // for one key left semi join
     template <bool first_probe>
-    void _probe_from_ht_for_left_semi_join(const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data);
+    void _probe_from_ht_for_left_semi_join(RuntimeState* state, const Buffer<CppType>& build_data,
+                                           const Buffer<CppType>& probe_data);
 
     // for one key left anti join
     template <bool first_probe>
-    void _probe_from_ht_for_left_anti_join(const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data);
+    void _probe_from_ht_for_left_anti_join(RuntimeState* state, const Buffer<CppType>& build_data,
+                                           const Buffer<CppType>& probe_data);
 
     // for one key right outer join
     template <bool first_probe>
-    void _probe_from_ht_for_right_outer_join(const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data);
+    void _probe_from_ht_for_right_outer_join(RuntimeState* state, const Buffer<CppType>& build_data,
+                                             const Buffer<CppType>& probe_data);
 
     // for one key right semi join
     template <bool first_probe>
-    void _probe_from_ht_for_right_semi_join(const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data);
+    void _probe_from_ht_for_right_semi_join(RuntimeState* state, const Buffer<CppType>& build_data,
+                                            const Buffer<CppType>& probe_data);
 
     // for one key right anti join
     template <bool first_probe>
-    void _probe_from_ht_for_right_anti_join(const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data);
+    void _probe_from_ht_for_right_anti_join(RuntimeState* state, const Buffer<CppType>& build_data,
+                                            const Buffer<CppType>& probe_data);
 
     // for one key full outer join
     template <bool first_probe>
-    void _probe_from_ht_for_full_outer_join(const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data);
+    void _probe_from_ht_for_full_outer_join(RuntimeState* state, const Buffer<CppType>& build_data,
+                                            const Buffer<CppType>& probe_data);
 
     // for left outer join with other join conjunct
     template <bool first_probe>
-    void _probe_from_ht_for_left_outer_join_with_other_conjunct(const Buffer<CppType>& build_data,
+    void _probe_from_ht_for_left_outer_join_with_other_conjunct(RuntimeState* state, const Buffer<CppType>& build_data,
                                                                 const Buffer<CppType>& probe_data);
 
     // for left semi join with other join conjunct
     template <bool first_probe>
-    void _probe_from_ht_for_left_semi_join_with_other_conjunct(const Buffer<CppType>& build_data,
+    void _probe_from_ht_for_left_semi_join_with_other_conjunct(RuntimeState* state, const Buffer<CppType>& build_data,
                                                                const Buffer<CppType>& probe_data);
 
     // for left anti join with other join conjunct
     template <bool first_probe>
-    void _probe_from_ht_for_left_anti_join_with_other_conjunct(const Buffer<CppType>& build_data,
+    void _probe_from_ht_for_left_anti_join_with_other_conjunct(RuntimeState* state, const Buffer<CppType>& build_data,
                                                                const Buffer<CppType>& probe_data);
 
     // for one key right outer join with other conjunct
     template <bool first_probe>
-    void _probe_from_ht_for_right_outer_join_with_other_conjunct(const Buffer<CppType>& build_data,
+    void _probe_from_ht_for_right_outer_join_with_other_conjunct(RuntimeState* state, const Buffer<CppType>& build_data,
                                                                  const Buffer<CppType>& probe_data);
 
     // for one key right semi join with other join conjunct
     template <bool first_probe>
-    void _probe_from_ht_for_right_semi_join_with_other_conjunct(const Buffer<CppType>& build_data,
+    void _probe_from_ht_for_right_semi_join_with_other_conjunct(RuntimeState* state, const Buffer<CppType>& build_data,
                                                                 const Buffer<CppType>& probe_data);
 
     // for one key right anti join with other join conjunct
     template <bool first_probe>
-    void _probe_from_ht_for_right_anti_join_with_other_conjunct(const Buffer<CppType>& build_data,
+    void _probe_from_ht_for_right_anti_join_with_other_conjunct(RuntimeState* state, const Buffer<CppType>& build_data,
                                                                 const Buffer<CppType>& probe_data);
 
     // for one key full outer join with other join conjunct
     template <bool first_probe>
-    void _probe_from_ht_for_full_outer_join_with_other_conjunct(const Buffer<CppType>& build_data,
+    void _probe_from_ht_for_full_outer_join_with_other_conjunct(RuntimeState* state, const Buffer<CppType>& build_data,
                                                                 const Buffer<CppType>& probe_data);
 
     JoinHashTableItems* _table_items = nullptr;
@@ -498,8 +509,8 @@ public:
     void close();
 
     Status build(RuntimeState* state);
-    Status probe(const Columns& key_columns, ChunkPtr* probe_chunk, ChunkPtr* chunk, bool* eos);
-    Status probe_remain(ChunkPtr* chunk, bool* eos);
+    Status probe(RuntimeState* state, const Columns& key_columns, ChunkPtr* probe_chunk, ChunkPtr* chunk, bool* eos);
+    Status probe_remain(RuntimeState* state, ChunkPtr* chunk, bool* eos);
 
     Status append_chunk(RuntimeState* state, const ChunkPtr& chunk);
 

--- a/be/src/exec/vectorized/json_scanner.cpp
+++ b/be/src/exec/vectorized/json_scanner.cpp
@@ -35,7 +35,7 @@ JsonScanner::JsonScanner(RuntimeState* state, RuntimeProfile* profile, const TBr
         : FileScanner(state, profile, scan_range.params, counter),
           _scan_range(scan_range),
           _next_range(0),
-          _max_chunk_size(config::vector_chunk_size),
+          _max_chunk_size(state->chunk_size()),
           _cur_file_reader(nullptr),
           _cur_file_eof(true) {}
 

--- a/be/src/exec/vectorized/mysql_scan_node.cpp
+++ b/be/src/exec/vectorized/mysql_scan_node.cpp
@@ -322,7 +322,7 @@ Status MysqlScanNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) 
             return Status::OK();
         }
 
-        if (row_num >= config::vector_chunk_size) {
+        if (row_num >= runtime_state()->chunk_size()) {
             return Status::OK();
         }
 

--- a/be/src/exec/vectorized/olap_meta_scanner.cpp
+++ b/be/src/exec/vectorized/olap_meta_scanner.cpp
@@ -32,7 +32,7 @@ Status OlapMetaScanner::_init_meta_reader_params() {
     _reader_params.tablet = _tablet;
     _reader_params.version = Version(0, _version);
     _reader_params.runtime_state = _runtime_state;
-    _reader_params.chunk_size = config::vector_chunk_size;
+    _reader_params.chunk_size = _runtime_state->chunk_size();
     _reader_params.id_to_names = &_parent->_meta_scan_node.id_to_names;
     _reader_params.desc_tbl = &_parent->_desc_tbl;
 

--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -184,7 +184,7 @@ Status OlapScanNode::close(RuntimeState* state) {
     _dict_optimize_parser.close(state);
 
     // Reduce the memory usage if the the average string size is greater than 512.
-    release_large_columns<BinaryColumn>(config::vector_chunk_size * 512);
+    release_large_columns<BinaryColumn>(runtime_state()->chunk_size() * 512);
 
     return ScanNode::close(state);
 }
@@ -197,7 +197,7 @@ OlapScanNode::~OlapScanNode() {
 }
 
 void OlapScanNode::_fill_chunk_pool(int count, bool force_column_pool) {
-    const size_t capacity = config::vector_chunk_size;
+    const size_t capacity = runtime_state()->chunk_size();
     for (int i = 0; i < count; i++) {
         ChunkPtr chunk(ChunkHelper::new_chunk_pooled(*_chunk_schema, capacity, force_column_pool));
         {
@@ -503,8 +503,8 @@ Status OlapScanNode::_start_scan_thread(RuntimeState* state) {
     }
     _pending_scanners.reverse();
     _num_scanners = _pending_scanners.size();
-    _chunks_per_scanner = config::doris_scanner_row_num / config::vector_chunk_size;
-    _chunks_per_scanner += (config::doris_scanner_row_num % config::vector_chunk_size != 0);
+    _chunks_per_scanner = config::doris_scanner_row_num / runtime_state()->chunk_size();
+    _chunks_per_scanner += (config::doris_scanner_row_num % runtime_state()->chunk_size() != 0);
     int concurrency = std::min<int>(kMaxConcurrency, _num_scanners);
     int chunks = _chunks_per_scanner * concurrency;
     _chunk_pool.reserve(chunks);

--- a/be/src/exec/vectorized/orc_scanner.cpp
+++ b/be/src/exec/vectorized/orc_scanner.cpp
@@ -73,7 +73,7 @@ ORCScanner::ORCScanner(starrocks::RuntimeState* state, starrocks::RuntimeProfile
                        const TBrokerScanRange& scan_range, starrocks::vectorized::ScannerCounter* counter)
         : FileScanner(state, profile, scan_range.params, counter),
           _scan_range(scan_range),
-          _max_chunk_size(config::vector_chunk_size ? config::vector_chunk_size : 4096),
+          _max_chunk_size(_state->chunk_size() ? _state->chunk_size() : 4096),
           _next_range(0),
           _error_counter(0),
           _status_eof(false) {}
@@ -105,7 +105,7 @@ Status ORCScanner::open() {
     for (int i = 0; i < num_columns_from_orc; ++i) {
         _orc_slot_descriptors[i] = _src_slot_descriptors[i];
     }
-    _orc_adapter = std::make_unique<OrcScannerAdapter>(_orc_slot_descriptors);
+    _orc_adapter = std::make_unique<OrcScannerAdapter>(_state, _orc_slot_descriptors);
     _orc_adapter->set_broker_load_mode(_strict_mode);
     _orc_adapter->set_timezone(_state->timezone());
     _orc_adapter->drop_nanoseconds_in_datetime();

--- a/be/src/exec/vectorized/orc_scanner_adapter.cpp
+++ b/be/src/exec/vectorized/orc_scanner_adapter.cpp
@@ -973,9 +973,9 @@ const FillColumnFunction& find_fill_func(PrimitiveType type, bool nullable) {
     return nullable ? FunctionsMap::instance()->get_nullable_func(type) : FunctionsMap::instance()->get_func(type);
 }
 
-OrcScannerAdapter::OrcScannerAdapter(const std::vector<SlotDescriptor*>& src_slot_descriptors)
+OrcScannerAdapter::OrcScannerAdapter(RuntimeState* state, const std::vector<SlotDescriptor*>& src_slot_descriptors)
         : _src_slot_descriptors(src_slot_descriptors),
-          _read_chunk_size(config::vector_chunk_size),
+          _read_chunk_size(state->chunk_size()),
           _tzinfo(cctz::utc_time_zone()),
           _tzoffset_in_seconds(0),
           _drop_nanoseconds_in_datetime(false),

--- a/be/src/exec/vectorized/orc_scanner_adapter.h
+++ b/be/src/exec/vectorized/orc_scanner_adapter.h
@@ -34,7 +34,7 @@ using FillColumnFunction = void (*)(orc::ColumnVectorBatch* cvb, ColumnPtr& col,
 class OrcScannerAdapter {
 public:
     // src slot descriptors should exactly matches columns in row readers.
-    explicit OrcScannerAdapter(const std::vector<SlotDescriptor*>& src_slot_descriptors);
+    explicit OrcScannerAdapter(RuntimeState* state, const std::vector<SlotDescriptor*>& src_slot_descriptors);
     ~OrcScannerAdapter();
     Status init(std::unique_ptr<orc::InputStream> input_stream);
     Status init(std::unique_ptr<orc::Reader> reader);
@@ -87,6 +87,7 @@ public:
                                       const std::vector<std::string>* hive_column_names, const orc::Type& root_type);
 
     void set_runtime_state(RuntimeState* state) { _state = state; }
+    RuntimeState* runtime_state() { return _state; }
     void set_current_slot(SlotDescriptor* slot) { _current_slot = slot; }
     const SlotDescriptor* get_current_slot() const { return _current_slot; }
     void set_current_file_name(const std::string& name) { _current_file_name = name; }

--- a/be/src/exec/vectorized/parquet_scanner.cpp
+++ b/be/src/exec/vectorized/parquet_scanner.cpp
@@ -24,7 +24,7 @@ ParquetScanner::ParquetScanner(RuntimeState* state, RuntimeProfile* profile, con
           _next_file(0),
           _curr_file_reader(nullptr),
           _scanner_eof(false),
-          _max_chunk_size(config::vector_chunk_size ? config::vector_chunk_size : 4096),
+          _max_chunk_size(state->chunk_size() ? state->chunk_size() : 4096),
           _batch_start_idx(0),
           _chunk_start_idx(0) {
     _chunk_filter.reserve(_max_chunk_size);

--- a/be/src/exec/vectorized/repeat_node.h
+++ b/be/src/exec/vectorized/repeat_node.h
@@ -55,11 +55,11 @@ private:
     // accessing chunk.
     ChunkPtr _curr_chunk;
 
-    // only null columns for reusing, It has config::vector_chunk_size rows.
+    // only null columns for reusing, It has chunk_size rows.
     ColumnPtr _column_null;
 
     // column for grouping_id and virtual columns for grouping()/grouping_id() for reusing.
-    // It has config::vector_chunk_size rows.
+    // It has chunk_size rows.
     std::vector<std::vector<ColumnPtr>> _grouping_columns;
 
     // _grouping_list for gourping_id'value and grouping()/grouping_id()'s value.

--- a/be/src/exec/vectorized/schema_scan_node.cpp
+++ b/be/src/exec/vectorized/schema_scan_node.cpp
@@ -201,7 +201,7 @@ Status SchemaScanNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos)
             break;
         }
 
-        if (row_num >= config::vector_chunk_size) {
+        if (row_num >= runtime_state()->chunk_size()) {
             break;
         }
 

--- a/be/src/exec/vectorized/table_function_node.cpp
+++ b/be/src/exec/vectorized/table_function_node.cpp
@@ -90,7 +90,7 @@ Status TableFunctionNode::open(RuntimeState* state) {
 Status TableFunctionNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) {
     RETURN_IF_CANCELLED(state);
     SCOPED_TIMER(_runtime_profile->total_time_counter());
-    int chunk_size = config::vector_chunk_size;
+    int chunk_size = runtime_state()->chunk_size();
     int reserve_chunk_size = chunk_size;
     std::vector<ColumnPtr> output_columns;
 

--- a/be/src/exec/vectorized/tablet_scanner.cpp
+++ b/be/src/exec/vectorized/tablet_scanner.cpp
@@ -96,7 +96,7 @@ Status TabletScanner::close(RuntimeState* state) {
     _predicate_free_pool.clear();
     Expr::close(_conjunct_ctxs, state);
     // Reduce the memory usage if the the average string size is greater than 512.
-    release_large_columns<BinaryColumn>(config::vector_chunk_size * 512);
+    release_large_columns<BinaryColumn>(state->chunk_size() * 512);
     _is_closed = true;
     return Status::OK();
 }
@@ -129,10 +129,10 @@ Status TabletScanner::_init_reader_params(const std::vector<OlapScanRange*>* key
     _params.need_agg_finalize = _need_agg_finalize;
     _params.use_page_cache = !config::disable_storage_page_cache;
     // Improve for select * from table limit x, x is small
-    if (_parent->_limit != -1 && _parent->_limit < config::vector_chunk_size) {
+    if (_parent->_limit != -1 && _parent->_limit < runtime_state()->chunk_size()) {
         _params.chunk_size = _parent->_limit;
     } else {
-        _params.chunk_size = config::vector_chunk_size;
+        _params.chunk_size = runtime_state()->chunk_size();
     }
 
     PredicateParser parser(_tablet->tablet_schema());

--- a/be/src/exec/vectorized/topn_node.cpp
+++ b/be/src/exec/vectorized/topn_node.cpp
@@ -146,19 +146,19 @@ Status TopNNode::_consume_chunks(RuntimeState* state, ExecNode* child) {
         // HeapChunkSorter has higher performance when sorting fewer elements,
         // after testing we think 1024 is a good threshold
         if (_limit <= ChunksSorter::USE_HEAP_SORTER_LIMIT_SZ) {
-            _chunks_sorter =
-                    std::make_unique<HeapChunkSorter>(&(_sort_exec_exprs.lhs_ordering_expr_ctxs()), &_is_asc_order,
-                                                      &_is_null_first, _offset, _limit, SIZE_OF_CHUNK_FOR_TOPN);
+            _chunks_sorter = std::make_unique<HeapChunkSorter>(state, &(_sort_exec_exprs.lhs_ordering_expr_ctxs()),
+                                                               &_is_asc_order, &_is_null_first, _offset, _limit,
+                                                               SIZE_OF_CHUNK_FOR_TOPN);
         } else {
-            _chunks_sorter =
-                    std::make_unique<ChunksSorterTopn>(&(_sort_exec_exprs.lhs_ordering_expr_ctxs()), &_is_asc_order,
-                                                       &_is_null_first, _offset, _limit, SIZE_OF_CHUNK_FOR_TOPN);
+            _chunks_sorter = std::make_unique<ChunksSorterTopn>(state, &(_sort_exec_exprs.lhs_ordering_expr_ctxs()),
+                                                                &_is_asc_order, &_is_null_first, _offset, _limit,
+                                                                SIZE_OF_CHUNK_FOR_TOPN);
         }
 
     } else {
         _chunks_sorter =
-                std::make_unique<ChunksSorterFullSort>(&(_sort_exec_exprs.lhs_ordering_expr_ctxs()), &_is_asc_order,
-                                                       &_is_null_first, SIZE_OF_CHUNK_FOR_FULL_SORT);
+                std::make_unique<ChunksSorterFullSort>(state, &(_sort_exec_exprs.lhs_ordering_expr_ctxs()),
+                                                       &_is_asc_order, &_is_null_first, SIZE_OF_CHUNK_FOR_FULL_SORT);
     }
 
     bool eos = false;
@@ -191,14 +191,14 @@ pipeline::OpFactories TopNNode::decompose_to_pipeline(pipeline::PipelineBuilderC
 
     if (!is_merging) {
         // prepend local shuffle to PartitionSortSinkOperator
-        operators_sink_with_sort =
-                context->maybe_interpolate_local_shuffle_exchange(operators_sink_with_sort, _analytic_partition_exprs);
+        operators_sink_with_sort = context->maybe_interpolate_local_shuffle_exchange(
+                runtime_state(), operators_sink_with_sort, _analytic_partition_exprs);
     }
 
     auto degree_of_parallelism =
             down_cast<SourceOperatorFactory*>(operators_sink_with_sort[0].get())->degree_of_parallelism();
-    auto sort_context_factory = std::make_shared<SortContextFactory>(is_merging, _limit, degree_of_parallelism,
-                                                                     _is_asc_order, _is_null_first);
+    auto sort_context_factory = std::make_shared<SortContextFactory>(
+            runtime_state(), is_merging, _limit, degree_of_parallelism, _is_asc_order, _is_null_first);
 
     // Create a shared RefCountedRuntimeFilterCollector
     auto&& rc_rf_probe_collector = std::make_shared<RcRfProbeCollector>(2, std::move(this->runtime_filter_collector()));

--- a/be/src/exec/vectorized/union_node.cpp
+++ b/be/src/exec/vectorized/union_node.cpp
@@ -376,10 +376,10 @@ pipeline::OpFactories UnionNode::decompose_to_pipeline(pipeline::PipelineBuilder
 
         // Each _const_expr_list is project to one row.
         // Divide _const_expr_lists into several drivers, each of which is going to evaluate
-        // at least *config::vector_chunk_size* _const_expr_list.
-        size_t parallelism =
-                std::min(context->degree_of_parallelism(),
-                         (_const_expr_lists.size() + config::vector_chunk_size - 1) / config::vector_chunk_size);
+        // at least *runtime_state()->chunk_size()* _const_expr_list.
+        size_t parallelism = std::min(
+                context->degree_of_parallelism(),
+                (_const_expr_lists.size() + runtime_state()->chunk_size() - 1) / runtime_state()->chunk_size());
         union_const_source_op->set_degree_of_parallelism(parallelism);
 
         operators_list[i].emplace_back(std::move(union_const_source_op));
@@ -387,7 +387,7 @@ pipeline::OpFactories UnionNode::decompose_to_pipeline(pipeline::PipelineBuilder
         this->init_runtime_filter_for_operator(operators_list[i].back().get(), context, rc_rf_probe_collector);
     }
 
-    return context->maybe_gather_pipelines_to_one(operators_list);
+    return context->maybe_gather_pipelines_to_one(runtime_state(), operators_list);
 }
 
 } // namespace starrocks::vectorized

--- a/be/src/exprs/agg/any_value.h
+++ b/be/src/exprs/agg/any_value.h
@@ -139,7 +139,7 @@ public:
         OP()(this->data(state), value);
     }
 
-    void update_batch_single_state(FunctionContext* ctx, size_t batch_size, const Column** columns,
+    void update_batch_single_state(FunctionContext* ctx, size_t chunk_size, const Column** columns,
                                    AggDataPtr __restrict state) const override {
         update(ctx, columns, state, 0);
     }
@@ -192,7 +192,7 @@ public:
         OP()(this->data(state), value);
     }
 
-    void update_batch_single_state(FunctionContext* ctx, size_t batch_size, const Column** columns,
+    void update_batch_single_state(FunctionContext* ctx, size_t chunk_size, const Column** columns,
                                    AggDataPtr __restrict state) const override {
         update(ctx, columns, state, 0);
     }

--- a/be/src/exprs/agg/avg.h
+++ b/be/src/exprs/agg/avg.h
@@ -78,7 +78,7 @@ public:
         this->data(state).count++;
     }
 
-    void update_batch_single_state(FunctionContext* ctx, size_t batch_size, const Column** columns,
+    void update_batch_single_state(FunctionContext* ctx, size_t chunk_size, const Column** columns,
                                    AggDataPtr __restrict state) const override {
         DCHECK(!columns[0]->is_nullable());
         [[maybe_unused]] const InputColumnType* column = down_cast<const InputColumnType*>(columns[0]);
@@ -87,7 +87,7 @@ public:
         // So, we use integers to perform operations
         [[maybe_unused]] SumResultType local_sum_for_arithmetic{};
 
-        for (size_t i = 0; i < batch_size; ++i) {
+        for (size_t i = 0; i < chunk_size; ++i) {
             if constexpr (pt_is_datetime<PT>) {
                 this->data(state).sum += column->get_data()[i].to_unix_second();
             } else if constexpr (pt_is_date<PT>) {
@@ -106,7 +106,7 @@ public:
         if constexpr (pt_is_arithmetic<PT>) {
             this->data(state).sum += local_sum_for_arithmetic;
         }
-        this->data(state).count += batch_size;
+        this->data(state).count += chunk_size;
     }
 
     void update_batch_single_state(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,

--- a/be/src/exprs/agg/count.h
+++ b/be/src/exprs/agg/count.h
@@ -25,9 +25,9 @@ public:
         ++this->data(state).count;
     }
 
-    void update_batch_single_state(FunctionContext* ctx, size_t batch_size, const Column** columns,
+    void update_batch_single_state(FunctionContext* ctx, size_t chunk_size, const Column** columns,
                                    AggDataPtr __restrict state) const override {
-        this->data(state).count += batch_size;
+        this->data(state).count += chunk_size;
     }
 
     void update_batch_single_state(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
@@ -56,11 +56,11 @@ public:
         down_cast<Int64Column*>(to)->append(this->data(state).count);
     }
 
-    void batch_serialize(size_t batch_size, const Buffer<AggDataPtr>& agg_states, size_t state_offset,
+    void batch_serialize(size_t chunk_size, const Buffer<AggDataPtr>& agg_states, size_t state_offset,
                          Column* to) const override {
         Int64Column* column = down_cast<Int64Column*>(to);
         Buffer<int64_t>& result_data = column->get_data();
-        for (size_t i = 0; i < batch_size; i++) {
+        for (size_t i = 0; i < chunk_size; i++) {
             result_data.emplace_back(data(agg_states[i] + state_offset).count);
         }
     }
@@ -70,9 +70,9 @@ public:
         down_cast<Int64Column*>(to)->append(this->data(state).count);
     }
 
-    void batch_finalize(size_t batch_size, const Buffer<AggDataPtr>& agg_states, size_t state_offsets,
+    void batch_finalize(size_t chunk_size, const Buffer<AggDataPtr>& agg_states, size_t state_offsets,
                         Column* to) const {
-        batch_serialize(batch_size, agg_states, state_offsets, to);
+        batch_serialize(chunk_size, agg_states, state_offsets, to);
     }
 
     void convert_to_serialize_format(const Columns& src, size_t chunk_size, ColumnPtr* dst) const override {
@@ -96,20 +96,20 @@ public:
         this->data(state).count += !columns[0]->is_null(row_num);
     }
 
-    void update_batch_single_state(FunctionContext* ctx, size_t batch_size, const Column** columns,
+    void update_batch_single_state(FunctionContext* ctx, size_t chunk_size, const Column** columns,
                                    AggDataPtr __restrict state) const override {
         if (columns[0]->is_nullable()) {
             const auto* nullable_column = down_cast<const NullableColumn*>(columns[0]);
             if (nullable_column->has_null()) {
                 const uint8_t* null_data = nullable_column->immutable_null_column_data().data();
-                for (size_t i = 0; i < batch_size; ++i) {
+                for (size_t i = 0; i < chunk_size; ++i) {
                     this->data(state).count += !null_data[i];
                 }
             } else {
                 this->data(state).count += nullable_column->size();
             }
         } else {
-            this->data(state).count += batch_size;
+            this->data(state).count += chunk_size;
         }
     }
 
@@ -151,11 +151,11 @@ public:
         down_cast<Int64Column*>(to)->append(this->data(state).count);
     }
 
-    void batch_serialize(size_t batch_size, const Buffer<AggDataPtr>& agg_states, size_t state_offset,
+    void batch_serialize(size_t chunk_size, const Buffer<AggDataPtr>& agg_states, size_t state_offset,
                          Column* to) const override {
         Int64Column* column = down_cast<Int64Column*>(to);
         Buffer<int64_t>& result_data = column->get_data();
-        for (size_t i = 0; i < batch_size; i++) {
+        for (size_t i = 0; i < chunk_size; i++) {
             result_data.emplace_back(data(agg_states[i] + state_offset).count);
         }
     }
@@ -165,9 +165,9 @@ public:
         down_cast<Int64Column*>(to)->append(this->data(state).count);
     }
 
-    void batch_finalize(size_t batch_size, const Buffer<AggDataPtr>& agg_states, size_t state_offsets,
+    void batch_finalize(size_t chunk_size, const Buffer<AggDataPtr>& agg_states, size_t state_offsets,
                         Column* to) const {
-        batch_serialize(batch_size, agg_states, state_offsets, to);
+        batch_serialize(chunk_size, agg_states, state_offsets, to);
     }
 
     void convert_to_serialize_format(const Columns& src, size_t chunk_size, ColumnPtr* dst) const override {

--- a/be/src/exprs/agg/distinct.h
+++ b/be/src/exprs/agg/distinct.h
@@ -280,7 +280,7 @@ public:
     // The following two functions are specialized because of performance issue.
     // We have found out that by precomputing and prefetching hash values, we can boost peformance of hash table by a lot.
     // And this is a quite useful pattern for phmap::flat_hash_table.
-    void update_batch_single_state(FunctionContext* ctx, size_t batch_size, const Column** columns,
+    void update_batch_single_state(FunctionContext* ctx, size_t chunk_size, const Column** columns,
                                    AggDataPtr __restrict state) const override {
         const ColumnType* column = down_cast<const ColumnType*>(columns[0]);
         size_t mem_usage = 0;
@@ -290,9 +290,9 @@ public:
             size_t hash_value;
         };
 
-        std::vector<CacheEntry> cache(batch_size);
+        std::vector<CacheEntry> cache(chunk_size);
         const auto& container_data = column->get_data();
-        for (size_t i = 0; i < batch_size; ++i) {
+        for (size_t i = 0; i < chunk_size; ++i) {
             size_t hash_value = agg_state.set.hash_function()(container_data[i]);
             cache[i] = CacheEntry{hash_value};
         }
@@ -300,8 +300,8 @@ public:
         size_t prefetch_index = 16;
 
         MemPool* mem_pool = ctx->impl()->mem_pool();
-        for (size_t i = 0; i < batch_size; ++i) {
-            if (prefetch_index < batch_size) {
+        for (size_t i = 0; i < chunk_size; ++i) {
+            if (prefetch_index < chunk_size) {
                 agg_state.set.prefetch_hash(cache[prefetch_index].hash_value);
                 prefetch_index++;
             }
@@ -310,7 +310,7 @@ public:
         ctx->impl()->add_mem_usage(mem_usage);
     }
 
-    void update_batch(FunctionContext* ctx, size_t batch_size, size_t state_offset, const Column** columns,
+    void update_batch(FunctionContext* ctx, size_t chunk_size, size_t state_offset, const Column** columns,
                       AggDataPtr* states) const override {
         const ColumnType* column = down_cast<const ColumnType*>(columns[0]);
         size_t mem_usage = 0;
@@ -323,9 +323,9 @@ public:
             size_t hash_value;
         };
 
-        std::vector<CacheEntry> cache(batch_size);
+        std::vector<CacheEntry> cache(chunk_size);
         const auto& container_data = column->get_data();
-        for (size_t i = 0; i < batch_size; ++i) {
+        for (size_t i = 0; i < chunk_size; ++i) {
             AggDataPtr state = states[i] + state_offset;
             auto& agg_state = this->data(state);
             size_t hash_value = agg_state.set.hash_function()(container_data[i]);
@@ -335,8 +335,8 @@ public:
         size_t prefetch_index = 16;
 
         MemPool* mem_pool = ctx->impl()->mem_pool();
-        for (size_t i = 0; i < batch_size; ++i) {
-            if (prefetch_index < batch_size) {
+        for (size_t i = 0; i < chunk_size; ++i) {
+            if (prefetch_index < chunk_size) {
                 cache[prefetch_index].agg_state->set.prefetch_hash(cache[prefetch_index].hash_value);
                 prefetch_index++;
             }
@@ -453,7 +453,7 @@ public:
         DCHECK(false) << "this method shouldn't be called";
     }
 
-    void update_batch_single_state(FunctionContext* ctx, size_t batch_size, const Column** columns,
+    void update_batch_single_state(FunctionContext* ctx, size_t chunk_size, const Column** columns,
                                    AggDataPtr __restrict state) const override {
         size_t mem_usage = 0;
         auto& agg_state = this->data(state);

--- a/be/src/exprs/agg/group_concat.h
+++ b/be/src/exprs/agg/group_concat.h
@@ -98,7 +98,7 @@ public:
         }
     }
 
-    void update_batch_single_state(FunctionContext* ctx, size_t batch_size, const Column** columns,
+    void update_batch_single_state(FunctionContext* ctx, size_t chunk_size, const Column** columns,
                                    AggDataPtr __restrict state) const override {
         if (ctx->get_num_args() > 1) {
             const InputColumnType* column_val = down_cast<const InputColumnType*>(columns[0]);
@@ -110,14 +110,14 @@ public:
             } else {
                 Slice sep = ColumnHelper::get_const_value<TYPE_VARCHAR>(const_column_sep);
                 this->data(state).intermediate_string.reserve(column_val->get_bytes().size() +
-                                                              sep.get_size() * batch_size);
+                                                              sep.get_size() * chunk_size);
             }
         } else {
             const InputColumnType* column_val = down_cast<const InputColumnType*>(columns[0]);
-            this->data(state).intermediate_string.reserve(column_val->get_bytes().size() + 2 * batch_size);
+            this->data(state).intermediate_string.reserve(column_val->get_bytes().size() + 2 * chunk_size);
         }
 
-        for (size_t i = 0; i < batch_size; ++i) {
+        for (size_t i = 0; i < chunk_size; ++i) {
             update(ctx, columns, state, i);
         }
     }

--- a/be/src/exprs/agg/nullable_aggregate.h
+++ b/be/src/exprs/agg/nullable_aggregate.h
@@ -99,16 +99,16 @@ public:
         }
     }
 
-    void batch_serialize(size_t batch_size, const Buffer<AggDataPtr>& agg_states, size_t state_offset,
+    void batch_serialize(size_t chunk_size, const Buffer<AggDataPtr>& agg_states, size_t state_offset,
                          Column* to) const override {
-        for (size_t i = 0; i < batch_size; i++) {
+        for (size_t i = 0; i < chunk_size; i++) {
             serialize_to_column(nullptr, agg_states[i] + state_offset, to);
         }
     }
 
-    void batch_finalize(FunctionContext* ctx, size_t batch_size, const Buffer<AggDataPtr>& agg_states,
+    void batch_finalize(FunctionContext* ctx, size_t chunk_size, const Buffer<AggDataPtr>& agg_states,
                         size_t state_offset, Column* to) const override {
-        for (size_t i = 0; i < batch_size; i++) {
+        for (size_t i = 0; i < chunk_size; i++) {
             finalize_to_column(ctx, agg_states[i] + state_offset, to);
         }
     }
@@ -173,16 +173,16 @@ public:
         }
     }
 
-    void merge_batch(FunctionContext* ctx, size_t batch_size, size_t state_offset, const Column* column,
+    void merge_batch(FunctionContext* ctx, size_t chunk_size, size_t state_offset, const Column* column,
                      AggDataPtr* states) const override {
-        for (size_t i = 0; i < batch_size; ++i) {
+        for (size_t i = 0; i < chunk_size; ++i) {
             merge(ctx, column, states[i] + state_offset, i);
         }
     }
 
-    void merge_batch_selectively(FunctionContext* ctx, size_t batch_size, size_t state_offset, const Column* column,
+    void merge_batch_selectively(FunctionContext* ctx, size_t chunk_size, size_t state_offset, const Column* column,
                                  AggDataPtr* states, const std::vector<uint8_t>& filter) const override {
-        for (size_t i = 0; i < batch_size; i++) {
+        for (size_t i = 0; i < chunk_size; i++) {
             // TODO: optimize with simd ?
             if (filter[i] == 0) {
                 merge(ctx, column, states[i] + state_offset, i);
@@ -190,9 +190,9 @@ public:
         }
     }
 
-    void merge_batch_single_state(FunctionContext* ctx, size_t batch_size, const Column* column,
+    void merge_batch_single_state(FunctionContext* ctx, size_t chunk_size, const Column* column,
                                   AggDataPtr __restrict state) const override {
-        for (size_t i = 0; i < batch_size; ++i) {
+        for (size_t i = 0; i < chunk_size; ++i) {
             merge(ctx, column, state, i);
         }
     }
@@ -211,7 +211,7 @@ public:
                 size_t row_num) const override {}
 
     // TODO(kks): abstract the AVX2 filter process later
-    void update_batch(FunctionContext* ctx, size_t batch_size, size_t state_offset, const Column** columns,
+    void update_batch(FunctionContext* ctx, size_t chunk_size, size_t state_offset, const Column** columns,
                       AggDataPtr* states) const override {
         // Scalar function compute will return non-nullable column
         // for nullable column when the real whole chunk data all not-null.
@@ -224,7 +224,7 @@ public:
             // !important: filter must be an uint8_t container
             constexpr int batch_nums = 256 / (8 * sizeof(uint8_t));
             __m256i all0 = _mm256_setzero_si256();
-            while (offset + batch_nums < batch_size) {
+            while (offset + batch_nums < chunk_size) {
                 // TODO(kks): when our memory allocate could align 32-byte, we could use _mm256_load_si256
                 __m256i f = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(f_data + offset));
                 int mask = _mm256_movemask_epi8(_mm256_cmpgt_epi8(f, all0));
@@ -249,7 +249,7 @@ public:
                 offset += batch_nums;
             }
 #endif
-            for (size_t i = offset; i < batch_size; ++i) {
+            for (size_t i = offset; i < chunk_size; ++i) {
                 if (f_data[i] == 0) {
                     this->data(states[i] + state_offset).is_null = false;
                     this->nested_function->update(ctx, &data_column,
@@ -257,7 +257,7 @@ public:
                 }
             }
         } else {
-            for (size_t i = 0; i < batch_size; ++i) {
+            for (size_t i = 0; i < chunk_size; ++i) {
                 this->data(states[i] + state_offset).is_null = false;
                 this->nested_function->update(ctx, columns, this->data(states[i] + state_offset).mutable_nest_state(),
                                               i);
@@ -265,7 +265,7 @@ public:
         }
     }
 
-    void update_batch_selectively(FunctionContext* ctx, size_t batch_size, size_t state_offset, const Column** columns,
+    void update_batch_selectively(FunctionContext* ctx, size_t chunk_size, size_t state_offset, const Column** columns,
                                   AggDataPtr* states, const std::vector<uint8_t>& selection) const override {
         // Scalar function compute will return non-nullable column
         // for nullable column when the real whole chunk data all not-null.
@@ -279,7 +279,7 @@ public:
             // !important: filter must be an uint8_t container
             constexpr int batch_nums = 256 / (8 * sizeof(uint8_t));
             __m256i all0 = _mm256_setzero_si256();
-            while (offset + batch_nums < batch_size) {
+            while (offset + batch_nums < chunk_size) {
                 // TODO(kks): when our memory allocate could align 32-byte, we could use _mm256_load_si256
                 __m256i f = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(f_data + offset));
                 int mask = _mm256_movemask_epi8(_mm256_cmpgt_epi8(f, all0));
@@ -308,7 +308,7 @@ public:
             }
 #endif
 
-            for (size_t i = offset; i < batch_size; ++i) {
+            for (size_t i = offset; i < chunk_size; ++i) {
                 if (!f_data[i] & !selection[i]) {
                     this->data(states[i] + state_offset).is_null = false;
                     this->nested_function->update(ctx, &data_column,
@@ -316,7 +316,7 @@ public:
                 }
             }
         } else {
-            for (size_t i = 0; i < batch_size; ++i) {
+            for (size_t i = 0; i < chunk_size; ++i) {
                 if (!selection[i]) {
                     this->data(states[i] + state_offset).is_null = false;
                     this->nested_function->update(ctx, columns,
@@ -326,7 +326,7 @@ public:
         }
     }
 
-    void update_batch_single_state(FunctionContext* ctx, size_t batch_size, const Column** columns,
+    void update_batch_single_state(FunctionContext* ctx, size_t chunk_size, const Column** columns,
                                    AggDataPtr __restrict state) const override {
         // Scalar function compute will return non-nullable column
         // for nullable column when the real whole chunk data all not-null.
@@ -337,7 +337,7 @@ public:
             // The fast pass
             if (!column->has_null()) {
                 this->data(state).is_null = false;
-                this->nested_function->update_batch_single_state(ctx, batch_size, &data_column,
+                this->nested_function->update_batch_single_state(ctx, chunk_size, &data_column,
                                                                  this->data(state).mutable_nest_state());
                 return;
             }
@@ -348,7 +348,7 @@ public:
             // !important: filter must be an uint8_t container
             constexpr int batch_nums = 256 / (8 * sizeof(uint8_t));
             __m256i all0 = _mm256_setzero_si256();
-            while (offset + batch_nums < batch_size) {
+            while (offset + batch_nums < chunk_size) {
                 __m256i f = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(f_data + offset));
                 int mask = _mm256_movemask_epi8(_mm256_cmpgt_epi8(f, all0));
                 // all not null
@@ -371,7 +371,7 @@ public:
             }
 #endif
 
-            for (size_t i = offset; i < batch_size; ++i) {
+            for (size_t i = offset; i < chunk_size; ++i) {
                 if (f_data[i] == 0) {
                     this->nested_function->update(ctx, &data_column, this->data(state).mutable_nest_state(), i);
                     this->data(state).is_null = false;
@@ -379,7 +379,7 @@ public:
             }
         } else {
             this->data(state).is_null = false;
-            this->nested_function->update_batch_single_state(ctx, batch_size, columns,
+            this->nested_function->update_batch_single_state(ctx, chunk_size, columns,
                                                              this->data(state).mutable_nest_state());
         }
     }
@@ -455,14 +455,14 @@ public:
         this->nested_function->update(ctx, data_columns.data(), this->data(state).mutable_nest_state(), row_num);
     }
 
-    void update_batch(FunctionContext* ctx, size_t batch_size, size_t state_offset, const Column** columns,
+    void update_batch(FunctionContext* ctx, size_t chunk_size, size_t state_offset, const Column** columns,
                       AggDataPtr* states) const override {
-        for (size_t i = 0; i < batch_size; ++i) {
+        for (size_t i = 0; i < chunk_size; ++i) {
             update(ctx, columns, states[i] + state_offset, i);
         }
     }
 
-    void update_batch_selectively(FunctionContext* ctx, size_t batch_size, size_t state_offset, const Column** columns,
+    void update_batch_selectively(FunctionContext* ctx, size_t chunk_size, size_t state_offset, const Column** columns,
                                   AggDataPtr* states, const std::vector<uint8_t>& selection) const override {
         auto column_size = ctx->get_num_args();
         // This container stores the columns we really pass to the nested function.
@@ -470,7 +470,7 @@ public:
         data_columns.resize(column_size);
 
         std::vector<uint8_t> null_data_result;
-        null_data_result.resize(batch_size);
+        null_data_result.resize(chunk_size);
 
         // has_nullable_column: false, means every column is data column.
         bool has_nullable_column = false;
@@ -485,7 +485,7 @@ public:
                 if (columns[i]->has_null()) {
                     has_null = true;
                     auto null_data = column->null_column()->raw_data();
-                    for (size_t j = 0; j < batch_size; ++j) {
+                    for (size_t j = 0; j < chunk_size; ++j) {
                         null_data_result[j] |= null_data[j];
                     }
                 }
@@ -496,7 +496,7 @@ public:
 
         if (has_nullable_column) {
             if (has_null) {
-                for (size_t i = 0; i < batch_size; ++i) {
+                for (size_t i = 0; i < chunk_size; ++i) {
                     if (!null_data_result[i] & !selection[i]) {
                         this->data(states[i] + state_offset).is_null = false;
                         this->nested_function->update(ctx, data_columns.data(),
@@ -504,7 +504,7 @@ public:
                     }
                 }
             } else {
-                for (size_t i = 0; i < batch_size; ++i) {
+                for (size_t i = 0; i < chunk_size; ++i) {
                     if (!selection[i]) {
                         this->data(states[i] + state_offset).is_null = false;
                         this->nested_function->update(ctx, data_columns.data(),
@@ -514,7 +514,7 @@ public:
             }
         } else {
             // Because every column is data column, so we still use columns.
-            for (size_t i = 0; i < batch_size; ++i) {
+            for (size_t i = 0; i < chunk_size; ++i) {
                 if (!selection[i]) {
                     this->data(states[i] + state_offset).is_null = false;
                     this->nested_function->update(ctx, columns,
@@ -524,9 +524,9 @@ public:
         }
     }
 
-    void update_batch_single_state(FunctionContext* ctx, size_t batch_size, const Column** columns,
+    void update_batch_single_state(FunctionContext* ctx, size_t chunk_size, const Column** columns,
                                    AggDataPtr __restrict state) const override {
-        for (size_t i = 0; i < batch_size; ++i) {
+        for (size_t i = 0; i < chunk_size; ++i) {
             update(ctx, columns, state, i);
         }
     }

--- a/be/src/exprs/agg/sum.h
+++ b/be/src/exprs/agg/sum.h
@@ -50,11 +50,11 @@ public:
         this->data(state).sum += column.get_data()[row_num];
     }
 
-    void update_batch_single_state(FunctionContext* ctx, size_t batch_size, const Column** columns,
+    void update_batch_single_state(FunctionContext* ctx, size_t chunk_size, const Column** columns,
                                    AggDataPtr __restrict state) const override {
         const auto* column = down_cast<const InputColumnType*>(columns[0]);
         const auto* data = column->get_data().data();
-        for (size_t i = 0; i < batch_size; ++i) {
+        for (size_t i = 0; i < chunk_size; ++i) {
             this->data(state).sum += data[i];
         }
     }
@@ -91,11 +91,11 @@ public:
         down_cast<ResultColumnType*>(to)->append(this->data(state).sum);
     }
 
-    void batch_serialize(size_t batch_size, const Buffer<AggDataPtr>& agg_states, size_t state_offset,
+    void batch_serialize(size_t chunk_size, const Buffer<AggDataPtr>& agg_states, size_t state_offset,
                          Column* to) const override {
         ResultColumnType* column = down_cast<ResultColumnType*>(to);
         Buffer<ResultType>& result_data = column->get_data();
-        for (size_t i = 0; i < batch_size; i++) {
+        for (size_t i = 0; i < chunk_size; i++) {
             result_data.emplace_back(this->data(agg_states[i] + state_offset).sum);
         }
     }
@@ -106,9 +106,9 @@ public:
         down_cast<ResultColumnType*>(to)->append(this->data(state).sum);
     }
 
-    void batch_finalize(size_t batch_size, const Buffer<AggDataPtr>& agg_states, size_t state_offset,
+    void batch_finalize(size_t chunk_size, const Buffer<AggDataPtr>& agg_states, size_t state_offset,
                         Column* to) const {
-        batch_serialize(batch_size, agg_states, state_offset, to);
+        batch_serialize(chunk_size, agg_states, state_offset, to);
     }
 
     void convert_to_serialize_format(const Columns& src, size_t chunk_size, ColumnPtr* dst) const override {

--- a/be/src/exprs/agg/window.h
+++ b/be/src/exprs/agg/window.h
@@ -13,17 +13,17 @@ class WindowFunction : public AggregateFunctionStateHelper<State> {
         DCHECK(false) << "Shouldn't call this method for window function!";
     }
 
-    void merge_batch(FunctionContext* ctx, size_t batch_size, size_t state_offset, const Column* column,
+    void merge_batch(FunctionContext* ctx, size_t chunk_size, size_t state_offset, const Column* column,
                      AggDataPtr* states) const override {
         DCHECK(false) << "Shouldn't call this method for window function!";
     }
 
-    void merge_batch_selectively(FunctionContext* ctx, size_t batch_size, size_t state_offset, const Column* column,
+    void merge_batch_selectively(FunctionContext* ctx, size_t chunk_size, size_t state_offset, const Column* column,
                                  AggDataPtr* states, const std::vector<uint8_t>& filter) const override {
         DCHECK(false) << "Shouldn't call this method for window function!";
     }
 
-    void merge_batch_single_state(FunctionContext* ctx, size_t batch_size, const Column* column,
+    void merge_batch_single_state(FunctionContext* ctx, size_t chunk_size, const Column* column,
                                   AggDataPtr __restrict state) const override {
         DCHECK(false) << "Shouldn't call this method for window function!";
     }
@@ -33,17 +33,17 @@ class WindowFunction : public AggregateFunctionStateHelper<State> {
         DCHECK(false) << "Shouldn't call this method for window function!";
     }
 
-    void update_batch(FunctionContext* ctx, size_t batch_size, size_t state_offset, const Column** columns,
+    void update_batch(FunctionContext* ctx, size_t chunk_size, size_t state_offset, const Column** columns,
                       AggDataPtr* states) const override {
         DCHECK(false) << "Shouldn't call this method for window function!";
     }
 
-    void update_batch_selectively(FunctionContext* ctx, size_t batch_size, size_t state_offset, const Column** column,
+    void update_batch_selectively(FunctionContext* ctx, size_t chunk_size, size_t state_offset, const Column** column,
                                   AggDataPtr* states, const std::vector<uint8_t>& filter) const override {
         DCHECK(false) << "Shouldn't call this method for window function!";
     }
 
-    void update_batch_single_state(FunctionContext* ctx, size_t batch_size, const Column** columns,
+    void update_batch_single_state(FunctionContext* ctx, size_t chunk_size, const Column** columns,
                                    AggDataPtr __restrict state) const override {
         DCHECK(false) << "Shouldn't call this method for window function!";
     }
@@ -56,12 +56,12 @@ class WindowFunction : public AggregateFunctionStateHelper<State> {
         DCHECK(false) << "Shouldn't call this method for window function!";
     }
 
-    void batch_serialize(size_t batch_size, const Buffer<AggDataPtr>& agg_states, size_t state_offset,
+    void batch_serialize(size_t chunk_size, const Buffer<AggDataPtr>& agg_states, size_t state_offset,
                          Column* to) const override {
         DCHECK(false) << "Shouldn't call this method for window function!";
     }
 
-    void batch_finalize(FunctionContext* ctx, size_t batch_size, const Buffer<AggDataPtr>& agg_states,
+    void batch_finalize(FunctionContext* ctx, size_t chunk_size, const Buffer<AggDataPtr>& agg_states,
                         size_t state_offset, Column* to) const override {
         DCHECK(false) << "Shouldn't call this method for window function!";
     }

--- a/be/src/exprs/vectorized/binary_function.h
+++ b/be/src/exprs/vectorized/binary_function.h
@@ -471,14 +471,14 @@ public:
             ln = p->null_column();
         } else if (v1->is_constant()) {
             ld = ColumnHelper::as_raw_column<ConstColumn>(v1)->data_column();
-            ln = ColumnHelper::s_all_not_null_column;
+            ln = NullColumn::create(v1->size(), 0);
         } else if (v1->is_nullable()) {
             auto p = ColumnHelper::as_raw_column<NullableColumn>(v1);
             ld = p->data_column();
             ln = p->null_column();
         } else {
             ld = v1;
-            ln = ColumnHelper::s_all_not_null_column;
+            ln = NullColumn::create(v1->size(), 0);
         }
 
         if (v2->only_null()) {
@@ -489,14 +489,14 @@ public:
             rn = p->null_column();
         } else if (v2->is_constant()) {
             rd = ColumnHelper::as_raw_column<ConstColumn>(v2)->data_column();
-            rn = ColumnHelper::s_all_not_null_column;
+            rn = NullColumn::create(v2->size(), 0);
         } else if (v2->is_nullable()) {
             auto p = ColumnHelper::as_raw_column<NullableColumn>(v2);
             rd = p->data_column();
             rn = p->null_column();
         } else {
             rd = v2;
-            rn = ColumnHelper::s_all_not_null_column;
+            rn = NullColumn::create(v2->size(), 0);
         }
 
         // return must be nullable column

--- a/be/src/exprs/vectorized/binary_predicate.cpp
+++ b/be/src/exprs/vectorized/binary_predicate.cpp
@@ -60,9 +60,8 @@ public:
         ColumnViewer<Type> v2(r);
         Columns list = {l, r};
 
-        ColumnBuilder<TYPE_BOOLEAN> builder;
-
         size_t size = list[0]->size();
+        ColumnBuilder<TYPE_BOOLEAN> builder(size);
         for (int row = 0; row < size; ++row) {
             auto null1 = v1.is_null(row);
             auto null2 = v2.is_null(row);

--- a/be/src/exprs/vectorized/bitmap_functions.cpp
+++ b/be/src/exprs/vectorized/bitmap_functions.cpp
@@ -16,9 +16,9 @@ namespace starrocks::vectorized {
 
 ColumnPtr BitmapFunctions::to_bitmap(FunctionContext* context, const starrocks::vectorized::Columns& columns) {
     ColumnViewer<TYPE_VARCHAR> viewer(columns[0]);
-    ColumnBuilder<TYPE_OBJECT> builder;
 
     size_t size = columns[0]->size();
+    ColumnBuilder<TYPE_OBJECT> builder(size);
     for (int row = 0; row < size; ++row) {
         if (viewer.is_null(row)) {
             builder.append_null();
@@ -52,9 +52,9 @@ ColumnPtr BitmapFunctions::to_bitmap(FunctionContext* context, const starrocks::
 
 ColumnPtr BitmapFunctions::bitmap_hash(FunctionContext* context, const starrocks::vectorized::Columns& columns) {
     ColumnViewer<TYPE_VARCHAR> viewer(columns[0]);
-    ColumnBuilder<TYPE_OBJECT> builder;
 
     size_t size = columns[0]->size();
+    ColumnBuilder<TYPE_OBJECT> builder(size);
     for (int row = 0; row < size; ++row) {
         BitmapValue bitmap;
 
@@ -73,9 +73,9 @@ ColumnPtr BitmapFunctions::bitmap_hash(FunctionContext* context, const starrocks
 
 ColumnPtr BitmapFunctions::bitmap_count(FunctionContext* context, const starrocks::vectorized::Columns& columns) {
     ColumnViewer<TYPE_OBJECT> viewer(columns[0]);
-    ColumnBuilder<TYPE_BIGINT> builder;
 
     size_t size = columns[0]->size();
+    ColumnBuilder<TYPE_BIGINT> builder(size);
     for (int row = 0; row < size; ++row) {
         int64_t value = viewer.is_null(row) ? 0 : viewer.value(row)->cardinality();
         builder.append(value);
@@ -95,9 +95,8 @@ ColumnPtr BitmapFunctions::bitmap_or(FunctionContext* context, const starrocks::
     ColumnViewer<TYPE_OBJECT> lhs(columns[0]);
     ColumnViewer<TYPE_OBJECT> rhs(columns[1]);
 
-    ColumnBuilder<TYPE_OBJECT> builder;
-
     size_t size = columns[0]->size();
+    ColumnBuilder<TYPE_OBJECT> builder(size);
     for (int row = 0; row < size; ++row) {
         if (lhs.is_null(row) || rhs.is_null(row)) {
             builder.append_null();
@@ -120,9 +119,8 @@ ColumnPtr BitmapFunctions::bitmap_and(FunctionContext* context, const starrocks:
     ColumnViewer<TYPE_OBJECT> lhs(columns[0]);
     ColumnViewer<TYPE_OBJECT> rhs(columns[1]);
 
-    ColumnBuilder<TYPE_OBJECT> builder;
-
     size_t size = columns[0]->size();
+    ColumnBuilder<TYPE_OBJECT> builder(size);
     for (int row = 0; row < size; ++row) {
         if (lhs.is_null(row) || rhs.is_null(row)) {
             builder.append_null();
@@ -152,11 +150,10 @@ ColumnPtr BitmapFunctions::bitmap_from_string(FunctionContext* context, const Co
     RETURN_IF_COLUMNS_ONLY_NULL(columns);
 
     ColumnViewer<TYPE_VARCHAR> viewer(columns[0]);
-    ColumnBuilder<TYPE_OBJECT> builder;
-
     std::vector<uint64_t> bits;
 
     size_t size = columns[0]->size();
+    ColumnBuilder<TYPE_OBJECT> builder(size);
     for (int row = 0; row < size; ++row) {
         if (viewer.is_null(row)) {
             builder.append_null();
@@ -207,9 +204,8 @@ ColumnPtr BitmapFunctions::bitmap_andnot(FunctionContext* context, const starroc
     ColumnViewer<TYPE_OBJECT> lhs(columns[0]);
     ColumnViewer<TYPE_OBJECT> rhs(columns[1]);
 
-    ColumnBuilder<TYPE_OBJECT> builder;
-
     size_t size = columns[0]->size();
+    ColumnBuilder<TYPE_OBJECT> builder(size);
     for (int row = 0; row < size; ++row) {
         if (lhs.is_null(row) || rhs.is_null(row)) {
             builder.append_null();
@@ -232,9 +228,8 @@ ColumnPtr BitmapFunctions::bitmap_xor(FunctionContext* context, const starrocks:
     ColumnViewer<TYPE_OBJECT> lhs(columns[0]);
     ColumnViewer<TYPE_OBJECT> rhs(columns[1]);
 
-    ColumnBuilder<TYPE_OBJECT> builder;
-
     size_t size = columns[0]->size();
+    ColumnBuilder<TYPE_OBJECT> builder(size);
     for (int row = 0; row < size; ++row) {
         if (lhs.is_null(row) || rhs.is_null(row)) {
             builder.append_null();
@@ -257,9 +252,8 @@ ColumnPtr BitmapFunctions::bitmap_remove(FunctionContext* context, const starroc
     ColumnViewer<TYPE_OBJECT> lhs(columns[0]);
     ColumnViewer<TYPE_BIGINT> rhs(columns[1]);
 
-    ColumnBuilder<TYPE_OBJECT> builder;
-
     size_t size = columns[0]->size();
+    ColumnBuilder<TYPE_OBJECT> builder(size);
     for (int row = 0; row < size; ++row) {
         if (lhs.is_null(row) || rhs.is_null(row)) {
             builder.append_null();

--- a/be/src/exprs/vectorized/case_expr.cpp
+++ b/be/src/exprs/vectorized/case_expr.cpp
@@ -136,9 +136,8 @@ private:
         ColumnViewer<WhenType> case_viewer(case_column);
         then_viewers.emplace_back(else_column);
 
-        ColumnBuilder<ResultType> builder(this->type().precision, this->type().scale);
         size_t size = when_columns[0]->size();
-        builder.reserve(size);
+        ColumnBuilder<ResultType> builder(size, this->type().precision, this->type().scale);
 
         bool columns_has_null = false;
         for (ColumnPtr& column : when_columns) {
@@ -247,9 +246,8 @@ private:
         then_columns.emplace_back(else_column);
         then_viewers.emplace_back(else_column);
 
-        ColumnBuilder<ResultType> builder(this->type().precision, this->type().scale);
         size_t size = when_columns[0]->size();
-        builder.reserve(size);
+        ColumnBuilder<ResultType> builder(size, this->type().precision, this->type().scale);
 
         bool when_columns_has_null = false;
         for (ColumnPtr& column : when_columns) {

--- a/be/src/exprs/vectorized/cast_expr.cpp
+++ b/be/src/exprs/vectorized/cast_expr.cpp
@@ -95,8 +95,8 @@ UNARY_FN_CAST(TYPE_TIME, TYPE_BOOLEAN, ImplicitToBoolean);
 
 template <>
 ColumnPtr cast_fn<TYPE_VARCHAR, TYPE_BOOLEAN>(ColumnPtr& column) {
-    ColumnBuilder<TYPE_BOOLEAN> builder;
     ColumnViewer<TYPE_VARCHAR> viewer(column);
+    ColumnBuilder<TYPE_BOOLEAN> builder(viewer.size());
 
     StringParser::ParseResult result;
 
@@ -136,8 +136,8 @@ ColumnPtr cast_fn<TYPE_VARCHAR, TYPE_BOOLEAN>(ColumnPtr& column) {
 
 template <>
 ColumnPtr cast_fn<TYPE_VARCHAR, TYPE_HLL>(ColumnPtr& column) {
-    ColumnBuilder<TYPE_HLL> builder;
     ColumnViewer<TYPE_VARCHAR> viewer(column);
+    ColumnBuilder<TYPE_HLL> builder(viewer.size());
     for (int row = 0; row < viewer.size(); ++row) {
         if (viewer.is_null(row)) {
             builder.append_null();
@@ -180,9 +180,8 @@ DEFINE_UNARY_FN_WITH_IMPL(TimestampToNumber, value) {
 
 template <PrimitiveType FromType, PrimitiveType ToType>
 ColumnPtr cast_int_from_string_fn(ColumnPtr& column) {
-    ColumnBuilder<ToType> builder;
     ColumnViewer<TYPE_VARCHAR> viewer(column);
-
+    ColumnBuilder<ToType> builder(viewer.size());
     StringParser::ParseResult result;
 
     for (int row = 0; row < viewer.size(); ++row) {
@@ -204,8 +203,8 @@ ColumnPtr cast_int_from_string_fn(ColumnPtr& column) {
 
 template <PrimitiveType FromType, PrimitiveType ToType>
 ColumnPtr cast_float_from_string_fn(ColumnPtr& column) {
-    ColumnBuilder<ToType> builder;
     ColumnViewer<TYPE_VARCHAR> viewer(column);
+    ColumnBuilder<ToType> builder(viewer.size());
 
     StringParser::ParseResult result;
 
@@ -375,8 +374,8 @@ UNARY_FN_CAST(TYPE_DATETIME, TYPE_DECIMALV2, TimestampToDecimal);
 
 template <>
 ColumnPtr cast_fn<TYPE_VARCHAR, TYPE_DECIMALV2>(ColumnPtr& column) {
-    ColumnBuilder<TYPE_DECIMALV2> builder;
     ColumnViewer<TYPE_VARCHAR> viewer(column);
+    ColumnBuilder<TYPE_DECIMALV2> builder(viewer.size());
 
     if (!column->has_null()) {
         for (int row = 0; row < viewer.size(); ++row) {
@@ -407,8 +406,8 @@ ColumnPtr cast_fn<TYPE_VARCHAR, TYPE_DECIMALV2>(ColumnPtr& column) {
 // date
 template <PrimitiveType FromType, PrimitiveType ToType>
 ColumnPtr cast_to_date_fn(ColumnPtr& column) {
-    ColumnBuilder<TYPE_DATE> builder;
     ColumnViewer<FromType> viewer(column);
+    ColumnBuilder<TYPE_DATE> builder(viewer.size());
 
     for (int row = 0; row < viewer.size(); ++row) {
         if (viewer.is_null(row)) {
@@ -446,8 +445,8 @@ UNARY_FN_CAST(TYPE_DATETIME, TYPE_DATE, TimestampToDate);
 
 template <>
 ColumnPtr cast_fn<TYPE_VARCHAR, TYPE_DATE>(ColumnPtr& column) {
-    ColumnBuilder<TYPE_DATE> builder;
     ColumnViewer<TYPE_VARCHAR> viewer(column);
+    ColumnBuilder<TYPE_DATE> builder(viewer.size());
 
     if (!column->has_null()) {
         for (int row = 0; row < viewer.size(); ++row) {
@@ -477,8 +476,8 @@ ColumnPtr cast_fn<TYPE_VARCHAR, TYPE_DATE>(ColumnPtr& column) {
 // datetime(timestamp)
 template <PrimitiveType FromType, PrimitiveType ToType>
 ColumnPtr cast_to_timestamp_fn(ColumnPtr& column) {
-    ColumnBuilder<TYPE_DATETIME> builder;
     ColumnViewer<FromType> viewer(column);
+    ColumnBuilder<TYPE_DATETIME> builder(viewer.size());
 
     for (int row = 0; row < viewer.size(); ++row) {
         if (viewer.is_null(row)) {
@@ -516,8 +515,8 @@ UNARY_FN_CAST(TYPE_DATE, TYPE_DATETIME, DateToTimestmap);
 
 template <>
 ColumnPtr cast_fn<TYPE_VARCHAR, TYPE_DATETIME>(ColumnPtr& column) {
-    ColumnBuilder<TYPE_DATETIME> builder;
     ColumnViewer<TYPE_VARCHAR> viewer(column);
+    ColumnBuilder<TYPE_DATETIME> builder(viewer.size());
 
     if (!column->has_null()) {
         for (int row = 0; row < viewer.size(); ++row) {
@@ -578,9 +577,8 @@ UNARY_FN_CAST(TYPE_DATETIME, TYPE_TIME, DatetimeToTime);
 
 template <>
 ColumnPtr cast_fn<TYPE_VARCHAR, TYPE_TIME>(ColumnPtr& column) {
-    ColumnBuilder<TYPE_TIME> builder;
-
     auto size = column->size();
+    ColumnBuilder<TYPE_TIME> builder(size);
     ColumnViewer<TYPE_VARCHAR> viewer_time(column);
     for (size_t row = 0; row < size; ++row) {
         if (viewer_time.is_null(row)) {
@@ -866,8 +864,8 @@ private:
         }
 
         // type.length > 0
-        ColumnBuilder<TYPE_VARCHAR> builder;
         ColumnViewer<FloatType> viewer(column);
+        ColumnBuilder<TYPE_VARCHAR> builder(viewer.size());
 
         char value[MAX_DOUBLE_STR_LENGTH];
         size_t len = 0;
@@ -899,8 +897,8 @@ private:
             return column;
         }
 
-        ColumnBuilder<TYPE_VARCHAR> builder;
         ColumnViewer<TYPE_VARCHAR> viewer(column);
+        ColumnBuilder<TYPE_VARCHAR> builder(viewer.size());
 
         for (int row = 0; row < viewer.size(); ++row) {
             if (viewer.is_null(row)) {
@@ -917,8 +915,8 @@ private:
     }
 
     ColumnPtr _evaluate_time(ExprContext* context, const ColumnPtr& column) {
-        ColumnBuilder<TYPE_VARCHAR> builder;
         ColumnViewer<TYPE_TIME> viewer(column);
+        ColumnBuilder<TYPE_VARCHAR> builder(viewer.size());
 
         for (int row = 0; row < viewer.size(); ++row) {
             if (viewer.is_null(row)) {

--- a/be/src/exprs/vectorized/condition_expr.cpp
+++ b/be/src/exprs/vectorized/condition_expr.cpp
@@ -76,12 +76,13 @@ public:
         }
 
         Columns list = {lhs, rhs};
-        ColumnBuilder<Type> result(this->type().precision, this->type().scale);
 
         ColumnViewer<Type> lhs_viewer(lhs);
         ColumnViewer<Type> rhs_viewer(rhs);
 
         size_t size = list[0]->size();
+        ColumnBuilder<Type> result(size, this->type().precision, this->type().scale);
+
         for (int row = 0; row < size; ++row) {
             if (lhs_viewer.is_null(row)) {
                 result.append(rhs_viewer.value(row), rhs_viewer.is_null(row));
@@ -112,12 +113,12 @@ public:
         }
 
         Columns list = {lhs, rhs};
-        ColumnBuilder<Type> result(this->type().precision, this->type().scale);
 
         ColumnViewer<Type> lhs_viewer(lhs);
         ColumnViewer<Type> rhs_viewer(rhs);
 
         size_t size = list[0]->size();
+        ColumnBuilder<Type> result(size, this->type().precision, this->type().scale);
         for (int row = 0; row < size; ++row) {
             if (lhs_viewer.is_null(row)) {
                 result.append_null();
@@ -160,7 +161,6 @@ public:
         }
 
         Columns list = {bhs, lhs, rhs};
-        ColumnBuilder<Type> result(this->type().precision, this->type().scale);
 
         auto bhs_nulls = ColumnHelper::count_nulls(bhs);
         auto lhs_nulls = ColumnHelper::count_nulls(lhs);
@@ -170,6 +170,7 @@ public:
         ColumnViewer<Type> lhs_viewer(lhs);
         ColumnViewer<Type> rhs_viewer(rhs);
         size_t size = list[0]->size();
+        ColumnBuilder<Type> result(size, this->type().precision, this->type().scale);
 
         // optimization for 3 columns all not null.
         if (bhs_nulls == 0 && lhs_nulls == 0 && rhs_nulls == 0) {
@@ -253,9 +254,9 @@ public:
         }
 
         // choose not null
-        ColumnBuilder<Type> builder(this->type().precision, this->type().scale);
         int size = columns[0]->size();
         int col_size = viewers.size();
+        ColumnBuilder<Type> builder(size, this->type().precision, this->type().scale);
 
         for (int row = 0; row < size; ++row) {
             int col;

--- a/be/src/exprs/vectorized/encryption_functions.cpp
+++ b/be/src/exprs/vectorized/encryption_functions.cpp
@@ -21,7 +21,7 @@ ColumnPtr EncryptionFunctions::aes_encrypt(FunctionContext* ctx, const Columns& 
     auto key_viewer = ColumnViewer<TYPE_VARCHAR>(columns[1]);
 
     const int size = columns[0]->size();
-    ColumnBuilder<TYPE_VARCHAR> result;
+    ColumnBuilder<TYPE_VARCHAR> result(size);
     for (int row = 0; row < size; ++row) {
         if (src_viewer.is_null(row)) {
             result.append_null();
@@ -56,7 +56,7 @@ ColumnPtr EncryptionFunctions::aes_decrypt(FunctionContext* ctx, const Columns& 
     auto key_viewer = ColumnViewer<TYPE_VARCHAR>(columns[1]);
 
     const int size = columns[0]->size();
-    ColumnBuilder<TYPE_VARCHAR> result;
+    ColumnBuilder<TYPE_VARCHAR> result(size);
     for (int row = 0; row < size; ++row) {
         if (src_viewer.is_null(row) || key_viewer.is_null(row)) {
             result.append_null();
@@ -90,7 +90,7 @@ ColumnPtr EncryptionFunctions::aes_decrypt(FunctionContext* ctx, const Columns& 
 ColumnPtr EncryptionFunctions::from_base64(FunctionContext* ctx, const Columns& columns) {
     auto src_viewer = ColumnViewer<TYPE_VARCHAR>(columns[0]);
     const int size = columns[0]->size();
-    ColumnBuilder<TYPE_VARCHAR> result;
+    ColumnBuilder<TYPE_VARCHAR> result(size);
     for (int row = 0; row < size; ++row) {
         if (src_viewer.is_null(row)) {
             result.append_null();
@@ -123,7 +123,7 @@ ColumnPtr EncryptionFunctions::to_base64(FunctionContext* ctx, const Columns& co
     auto src_viewer = ColumnViewer<TYPE_VARCHAR>(columns[0]);
 
     const int size = columns[0]->size();
-    ColumnBuilder<TYPE_VARCHAR> result;
+    ColumnBuilder<TYPE_VARCHAR> result(size);
     for (int row = 0; row < size; ++row) {
         if (src_viewer.is_null(row)) {
             result.append_null();
@@ -158,8 +158,8 @@ ColumnPtr EncryptionFunctions::md5sum(FunctionContext* ctx, const Columns& colum
         list.emplace_back(ColumnViewer<TYPE_VARCHAR>(col));
     }
 
-    ColumnBuilder<TYPE_VARCHAR> result;
     auto size = columns[0]->size();
+    ColumnBuilder<TYPE_VARCHAR> result(size);
     for (int row = 0; row < size; row++) {
         Md5Digest digest;
         for (auto& view : list) {
@@ -180,8 +180,8 @@ ColumnPtr EncryptionFunctions::md5sum(FunctionContext* ctx, const Columns& colum
 ColumnPtr EncryptionFunctions::md5(FunctionContext* ctx, const Columns& columns) {
     auto src_viewer = ColumnViewer<TYPE_VARCHAR>(columns[0]);
 
-    ColumnBuilder<TYPE_VARCHAR> result;
     auto size = columns[0]->size();
+    ColumnBuilder<TYPE_VARCHAR> result(size);
     for (int row = 0; row < size; row++) {
         if (src_viewer.is_null(row)) {
             result.append_null();
@@ -237,10 +237,9 @@ ColumnPtr EncryptionFunctions::invalid_sha(FunctionContext* ctx, const Columns& 
 
 ColumnPtr EncryptionFunctions::sha224(FunctionContext* ctx, const Columns& columns) {
     auto src_viewer = ColumnViewer<TYPE_VARCHAR>(columns[0]);
-    ColumnBuilder<TYPE_VARCHAR> result;
 
     auto size = columns[0]->size();
-    result.reserve(size);
+    ColumnBuilder<TYPE_VARCHAR> result(size);
     for (int row = 0; row < size; row++) {
         if (src_viewer.is_null(row)) {
             result.append_null();
@@ -260,10 +259,9 @@ ColumnPtr EncryptionFunctions::sha224(FunctionContext* ctx, const Columns& colum
 
 ColumnPtr EncryptionFunctions::sha256(FunctionContext* ctx, const Columns& columns) {
     auto src_viewer = ColumnViewer<TYPE_VARCHAR>(columns[0]);
-    ColumnBuilder<TYPE_VARCHAR> result;
 
     auto size = columns[0]->size();
-    result.reserve(size);
+    ColumnBuilder<TYPE_VARCHAR> result(size);
     for (int row = 0; row < size; row++) {
         if (src_viewer.is_null(row)) {
             result.append_null();
@@ -283,10 +281,9 @@ ColumnPtr EncryptionFunctions::sha256(FunctionContext* ctx, const Columns& colum
 
 ColumnPtr EncryptionFunctions::sha384(FunctionContext* ctx, const Columns& columns) {
     auto src_viewer = ColumnViewer<TYPE_VARCHAR>(columns[0]);
-    ColumnBuilder<TYPE_VARCHAR> result;
 
     auto size = columns[0]->size();
-    result.reserve(size);
+    ColumnBuilder<TYPE_VARCHAR> result(size);
     for (int row = 0; row < size; row++) {
         if (src_viewer.is_null(row)) {
             result.append_null();
@@ -306,10 +303,9 @@ ColumnPtr EncryptionFunctions::sha384(FunctionContext* ctx, const Columns& colum
 
 ColumnPtr EncryptionFunctions::sha512(FunctionContext* ctx, const Columns& columns) {
     auto src_viewer = ColumnViewer<TYPE_VARCHAR>(columns[0]);
-    ColumnBuilder<TYPE_VARCHAR> result;
 
     auto size = columns[0]->size();
-    result.reserve(size);
+    ColumnBuilder<TYPE_VARCHAR> result(size);
     for (int row = 0; row < size; row++) {
         if (src_viewer.is_null(row)) {
             result.append_null();
@@ -332,10 +328,8 @@ ColumnPtr EncryptionFunctions::sha2(FunctionContext* ctx, const Columns& columns
         auto src_viewer = ColumnViewer<TYPE_VARCHAR>(columns[0]);
         auto length_viewer = ColumnViewer<TYPE_INT>(columns[1]);
 
-        ColumnBuilder<TYPE_VARCHAR> result;
-
         auto size = columns[0]->size();
-        result.reserve(size);
+        ColumnBuilder<TYPE_VARCHAR> result(size);
 
         for (int row = 0; row < size; row++) {
             if (src_viewer.is_null(row)) {

--- a/be/src/exprs/vectorized/es_functions.cpp
+++ b/be/src/exprs/vectorized/es_functions.cpp
@@ -9,8 +9,8 @@
 namespace starrocks::vectorized {
 
 ColumnPtr ESFunctions::match(FunctionContext* context, const Columns& columns) {
-    ColumnBuilder<TYPE_BOOLEAN> result;
     auto size = columns[0]->size();
+    ColumnBuilder<TYPE_BOOLEAN> result(size);
     for (int row = 0; row < size; ++row) {
         result.append(true);
     }

--- a/be/src/exprs/vectorized/geo_functions.cpp
+++ b/be/src/exprs/vectorized/geo_functions.cpp
@@ -20,9 +20,9 @@ struct StConstructState {
 
 ColumnPtr GeoFunctions::st_from_wkt_common(FunctionContext* ctx, const Columns& columns, GeoShapeType shape_type) {
     ColumnViewer<TYPE_VARCHAR> wkt_viewer(columns[0]);
-    ColumnBuilder<TYPE_VARCHAR> result;
 
     auto size = columns[0]->size();
+    ColumnBuilder<TYPE_VARCHAR> result(size);
 
     StConstructState* state = (StConstructState*)ctx->get_function_state(FunctionContext::FRAGMENT_LOCAL);
     if (state == nullptr) {
@@ -114,9 +114,9 @@ ColumnPtr GeoFunctions::st_circle(FunctionContext* context, const Columns& colum
     ColumnViewer<TYPE_DOUBLE> lng_viewer(columns[0]);
     ColumnViewer<TYPE_DOUBLE> lat_viewer(columns[1]);
     ColumnViewer<TYPE_DOUBLE> radius_viewer(columns[2]);
-    ColumnBuilder<TYPE_VARCHAR> result;
 
     auto size = columns[0]->size();
+    ColumnBuilder<TYPE_VARCHAR> result(size);
     StConstructState* state = (StConstructState*)context->get_function_state(FunctionContext::FRAGMENT_LOCAL);
     if (state == nullptr) {
         for (int row = 0; row < size; ++row) {
@@ -155,9 +155,9 @@ ColumnPtr GeoFunctions::st_circle(FunctionContext* context, const Columns& colum
 ColumnPtr GeoFunctions::st_point(FunctionContext* context, const Columns& columns) {
     auto x_column = ColumnViewer<TYPE_DOUBLE>(columns[0]);
     auto y_column = ColumnViewer<TYPE_DOUBLE>(columns[1]);
-    ColumnBuilder<TYPE_VARCHAR> result;
 
     auto size = columns[0]->size();
+    ColumnBuilder<TYPE_VARCHAR> result(size);
     for (int row = 0; row < size; ++row) {
         if (x_column.is_null(row) || y_column.is_null(row)) {
             result.append_null();
@@ -183,9 +183,9 @@ ColumnPtr GeoFunctions::st_point(FunctionContext* context, const Columns& column
 
 ColumnPtr GeoFunctions::st_x(FunctionContext* context, const Columns& columns) {
     ColumnViewer<TYPE_VARCHAR> encode(columns[0]);
-    ColumnBuilder<TYPE_DOUBLE> result;
 
     auto size = columns[0]->size();
+    ColumnBuilder<TYPE_DOUBLE> result(size);
     for (int row = 0; row < size; ++row) {
         if (encode.is_null(row)) {
             result.append_null();
@@ -208,9 +208,9 @@ ColumnPtr GeoFunctions::st_x(FunctionContext* context, const Columns& columns) {
 
 ColumnPtr GeoFunctions::st_y(FunctionContext* context, const Columns& columns) {
     ColumnViewer<TYPE_VARCHAR> encode(columns[0]);
-    ColumnBuilder<TYPE_DOUBLE> result;
 
     auto size = columns[0]->size();
+    ColumnBuilder<TYPE_DOUBLE> result(size);
     for (int row = 0; row < size; ++row) {
         if (encode.is_null(row)) {
             result.append_null();
@@ -236,9 +236,9 @@ ColumnPtr GeoFunctions::st_distance_sphere(FunctionContext* context, const Colum
     ColumnViewer<TYPE_DOUBLE> x_lat(columns[1]);
     ColumnViewer<TYPE_DOUBLE> y_lng(columns[2]);
     ColumnViewer<TYPE_DOUBLE> y_lat(columns[3]);
-    ColumnBuilder<TYPE_DOUBLE> result;
 
     auto size = columns[0]->size();
+    ColumnBuilder<TYPE_DOUBLE> result(size);
     for (int row = 0; row < size; ++row) {
         if (x_lng.is_null(row) || x_lat.is_null(row) || y_lng.is_null(row) || y_lat.is_null(row)) {
             result.append_null();
@@ -264,9 +264,9 @@ ColumnPtr GeoFunctions::st_distance_sphere(FunctionContext* context, const Colum
 
 ColumnPtr GeoFunctions::st_as_wkt(FunctionContext* context, const Columns& columns) {
     ColumnViewer<TYPE_VARCHAR> shape_viewer(columns[0]);
-    ColumnBuilder<TYPE_VARCHAR> result;
 
     auto size = columns[0]->size();
+    ColumnBuilder<TYPE_VARCHAR> result(size);
     for (int row = 0; row < size; ++row) {
         if (shape_viewer.is_null(row)) {
             result.append_null();
@@ -338,7 +338,6 @@ Status GeoFunctions::st_contains_prepare(FunctionContext* ctx, FunctionContext::
 ColumnPtr GeoFunctions::st_contains(FunctionContext* context, const Columns& columns) {
     ColumnViewer<TYPE_VARCHAR> lhs_viewer(columns[0]);
     ColumnViewer<TYPE_VARCHAR> rhs_viewer(columns[1]);
-    ColumnBuilder<TYPE_BOOLEAN> result;
 
     const StContainsState* state =
             reinterpret_cast<StContainsState*>(context->get_function_state(FunctionContext::FRAGMENT_LOCAL));
@@ -347,6 +346,7 @@ ColumnPtr GeoFunctions::st_contains(FunctionContext* context, const Columns& col
     }
 
     auto size = columns[0]->size();
+    ColumnBuilder<TYPE_BOOLEAN> result(size);
     for (int row = 0; row < size; ++row) {
         if (lhs_viewer.is_null(row) || rhs_viewer.is_null(row)) {
             result.append_null();

--- a/be/src/exprs/vectorized/hash_functions.h
+++ b/be/src/exprs/vectorized/hash_functions.h
@@ -26,9 +26,8 @@ inline ColumnPtr HashFunctions::murmur_hash3_32(FunctionContext* context,
         viewers.emplace_back(column);
     }
 
-    ColumnBuilder<TYPE_INT> builder;
-
     size_t size = columns[0]->size();
+    ColumnBuilder<TYPE_INT> builder(size);
     for (int row = 0; row < size; ++row) {
         uint32_t seed = HashUtil::MURMUR3_32_SEED;
         bool has_null = false;

--- a/be/src/exprs/vectorized/in_const_predicate.hpp
+++ b/be/src/exprs/vectorized/in_const_predicate.hpp
@@ -205,11 +205,10 @@ public:
     // equal_null: true means that 'null' in column and 'null' in set is equal.
     template <bool null_in_set, bool equal_null, bool use_array>
     ColumnPtr eval_on_chunk(const ColumnPtr& lhs) {
-        ColumnBuilder<TYPE_BOOLEAN> builder;
         ColumnViewer<Type> viewer(lhs);
-
-        uint8_t* output = ColumnHelper::cast_to_raw<TYPE_BOOLEAN>(builder.data_column())->get_data().data();
         size_t size = viewer.size();
+        ColumnBuilder<TYPE_BOOLEAN> builder(size);
+        uint8_t* output = ColumnHelper::cast_to_raw<TYPE_BOOLEAN>(builder.data_column())->get_data().data();
 
         for (int row = 0; row < size; ++row) {
             if (viewer.is_null(row)) {

--- a/be/src/exprs/vectorized/in_iterator_predicate.hpp
+++ b/be/src/exprs/vectorized/in_iterator_predicate.hpp
@@ -82,9 +82,9 @@ public:
         }
 
         ColumnViewer<Type> find_viewer(find);
-        ColumnBuilder<TYPE_BOOLEAN> builder;
 
         size_t size = columns[0]->size();
+        ColumnBuilder<TYPE_BOOLEAN> builder(size);
         for (int row = 0; row < size; ++row) {
             if (find_viewer.is_null(row)) {
                 builder.append_null();

--- a/be/src/exprs/vectorized/json_functions.cpp
+++ b/be/src/exprs/vectorized/json_functions.cpp
@@ -173,8 +173,8 @@ ColumnPtr JsonFunctions::_iterate_rows(FunctionContext* context, const Columns& 
 
     simdjson::ondemand::parser parser;
 
-    ColumnBuilder<primitive_type> result;
     auto size = columns[0]->size();
+    ColumnBuilder<primitive_type> result(size);
     for (int row = 0; row < size; ++row) {
         if (json_viewer.is_null(row) || path_viewer.is_null(row)) {
             result.append_null();

--- a/be/src/exprs/vectorized/like_predicate.cpp
+++ b/be/src/exprs/vectorized/like_predicate.cpp
@@ -341,7 +341,7 @@ ColumnPtr LikePredicate::regex_match_full(FunctionContext* context, const starro
     auto value_column = VECTORIZED_FN_ARGS(0);
 
     ColumnViewer<TYPE_VARCHAR> value_viewer(value_column);
-    ColumnBuilder<TYPE_BOOLEAN> result;
+    ColumnBuilder<TYPE_BOOLEAN> result(value_viewer.size());
 
     // pattern is constant value, use context's regex
     if (context->is_constant_column(1)) {
@@ -408,7 +408,7 @@ ColumnPtr LikePredicate::regex_match_partial(FunctionContext* context, const sta
     auto value_column = VECTORIZED_FN_ARGS(0);
 
     ColumnViewer<TYPE_VARCHAR> value_viewer(value_column);
-    ColumnBuilder<TYPE_BOOLEAN> result;
+    ColumnBuilder<TYPE_BOOLEAN> result(value_viewer.size());
 
     // pattern is constant value, use context's regex
     if (context->is_constant_column(1)) {

--- a/be/src/exprs/vectorized/locate.cpp
+++ b/be/src/exprs/vectorized/locate.cpp
@@ -149,9 +149,9 @@ ColumnPtr haystack_vector_and_needle_vector(const ColumnPtr& haystack_ptr, const
     ColumnViewer<TYPE_VARCHAR> haystack_viewer(haystack_ptr);
     ColumnViewer<TYPE_VARCHAR> needle_viewer(needle_ptr);
     ColumnViewer<TYPE_INT> start_pos_viewer(start_pos_ptr);
-    ColumnBuilder<TYPE_INT> builder;
 
     size_t size = haystack_ptr->size();
+    ColumnBuilder<TYPE_INT> builder(size);
 
     for (size_t i = 0; i < size; ++i) {
         if (haystack_viewer.is_null(i) || needle_viewer.is_null(i) || start_pos_viewer.is_null(i)) {

--- a/be/src/exprs/vectorized/math_functions.cpp
+++ b/be/src/exprs/vectorized/math_functions.cpp
@@ -383,8 +383,8 @@ ColumnPtr MathFunctions::conv_int(FunctionContext* context, const starrocks::vec
     auto src_base = ColumnViewer<TYPE_TINYINT>(columns[1]);
     auto dest_base = ColumnViewer<TYPE_TINYINT>(columns[2]);
 
-    ColumnBuilder<TYPE_VARCHAR> result;
     auto size = columns[0]->size();
+    ColumnBuilder<TYPE_VARCHAR> result(size);
     for (int row = 0; row < size; ++row) {
         if (bigint.is_null(row) || src_base.is_null(row) || dest_base.is_null(row)) {
             result.append_null();
@@ -423,8 +423,8 @@ ColumnPtr MathFunctions::conv_string(FunctionContext* context, const starrocks::
     auto src_base = ColumnViewer<TYPE_TINYINT>(columns[1]);
     auto dest_base = ColumnViewer<TYPE_TINYINT>(columns[2]);
 
-    ColumnBuilder<TYPE_VARCHAR> result;
     auto size = columns[0]->size();
+    ColumnBuilder<TYPE_VARCHAR> result(size);
     for (int row = 0; row < size; ++row) {
         if (string_viewer.is_null(row) || src_base.is_null(row) || dest_base.is_null(row)) {
             result.append_null();
@@ -503,7 +503,7 @@ ColumnPtr MathFunctions::rand(FunctionContext* context, const Columns& columns) 
     auto* seed = reinterpret_cast<uint32_t*>(context->get_function_state(FunctionContext::THREAD_LOCAL));
     DCHECK(seed != nullptr);
 
-    ColumnBuilder<TYPE_DOUBLE> result;
+    ColumnBuilder<TYPE_DOUBLE> result(num_rows);
     generate_randoms(&result, num_rows, seed);
 
     return result.build(false);

--- a/be/src/exprs/vectorized/math_functions.h
+++ b/be/src/exprs/vectorized/math_functions.h
@@ -378,7 +378,6 @@ public:
         RETURN_IF_COLUMNS_ONLY_NULL(columns);
 
         const auto& type = context->get_return_type();
-        ColumnBuilder<Type> result(type.precision, type.scale);
 
         std::vector<ColumnViewer<Type>> list;
         list.reserve(columns.size());
@@ -387,6 +386,7 @@ public:
         }
 
         auto size = columns[0]->size();
+        ColumnBuilder<Type> result(size, type.precision, type.scale);
         for (int row = 0; row < size; row++) {
             auto value = list[0].value(row);
             bool is_null = false;
@@ -419,7 +419,6 @@ public:
         RETURN_IF_COLUMNS_ONLY_NULL(columns);
 
         const auto& type = context->get_return_type();
-        ColumnBuilder<Type> result(type.precision, type.scale);
 
         std::vector<ColumnViewer<Type>> list;
         list.reserve(columns.size());
@@ -428,6 +427,7 @@ public:
         }
 
         auto size = columns[0]->size();
+        ColumnBuilder<Type> result(size, type.precision, type.scale);
         for (int row = 0; row < size; row++) {
             auto value = list[0].value(row);
             bool is_null = false;

--- a/be/src/exprs/vectorized/percentile_functions.cpp
+++ b/be/src/exprs/vectorized/percentile_functions.cpp
@@ -39,8 +39,8 @@ ColumnPtr PercentileFunctions::percentile_empty(FunctionContext* context, const 
 ColumnPtr PercentileFunctions::percentile_approx_raw(FunctionContext* context, const Columns& columns) {
     ColumnViewer<TYPE_PERCENTILE> viewer1(columns[0]);
     ColumnViewer<TYPE_DOUBLE> viewer2(columns[1]);
-    ColumnBuilder<TYPE_DOUBLE> builder;
     size_t size = columns[0]->size();
+    ColumnBuilder<TYPE_DOUBLE> builder(size);
     for (int row = 0; row < size; ++row) {
         double result = viewer1.value(row)->quantile(viewer2.value(row));
         builder.append(result);

--- a/be/src/exprs/vectorized/split_part.cpp
+++ b/be/src/exprs/vectorized/split_part.cpp
@@ -31,8 +31,8 @@ ColumnPtr StringFunctions::split_part(FunctionContext* context, const starrocks:
     ColumnViewer delimiter_viewer = ColumnViewer<TYPE_VARCHAR>(columns[1]);
     ColumnViewer part_number_viewer = ColumnViewer<TYPE_INT>(columns[2]);
 
-    ColumnBuilder<TYPE_VARCHAR> res;
     size_t size = columns[0]->size();
+    ColumnBuilder<TYPE_VARCHAR> res(size);
     for (int i = 0; i < size; ++i) {
         if (haystack_viewer.is_null(i) || delimiter_viewer.is_null(i) || part_number_viewer.is_null(i)) {
             res.append_null();

--- a/be/src/exprs/vectorized/string_functions.cpp
+++ b/be/src/exprs/vectorized/string_functions.cpp
@@ -1507,7 +1507,7 @@ ColumnPtr StringFunctions::append_trailing_char_if_absent(FunctionContext* conte
         ColumnViewer<TYPE_VARCHAR> src_viewer(columns[0]);
         ColumnViewer<TYPE_VARCHAR> tailing_viewer(columns[1]);
 
-        ColumnBuilder<TYPE_VARCHAR> dst_builder;
+        ColumnBuilder<TYPE_VARCHAR> dst_builder(row_num);
 
         for (int row = 0; row < row_num; ++row) {
             if (src_viewer.is_null(row) || tailing_viewer.is_null(row) || tailing_viewer.value(row).size != 1) {
@@ -2452,8 +2452,8 @@ ColumnPtr StringFunctions::null_or_empty(FunctionContext* context, const starroc
     DCHECK_EQ(columns.size(), 1);
     auto str_viewer = ColumnViewer<TYPE_VARCHAR>(columns[0]);
 
-    ColumnBuilder<TYPE_BOOLEAN> result;
     auto size = columns[0]->size();
+    ColumnBuilder<TYPE_BOOLEAN> result(size);
     for (int row = 0; row < size; row++) {
         if (str_viewer.is_null(row)) {
             result.append(true);
@@ -2558,8 +2558,8 @@ ColumnPtr StringFunctions::regexp_extract_general(FunctionContext* context, re2:
     auto ptn_viewer = ColumnViewer<TYPE_VARCHAR>(columns[1]);
     auto field_viewer = ColumnViewer<TYPE_BIGINT>(columns[2]);
 
-    ColumnBuilder<TYPE_VARCHAR> result;
     auto size = columns[0]->size();
+    ColumnBuilder<TYPE_VARCHAR> result(size);
     for (int row = 0; row < size; ++row) {
         if (content_viewer.is_null(row) || ptn_viewer.is_null(row) || field_viewer.is_null(row)) {
             result.append_null();
@@ -2606,8 +2606,8 @@ ColumnPtr StringFunctions::regexp_extract_const(re2::RE2* const_re, const Column
     auto content_viewer = ColumnViewer<TYPE_VARCHAR>(columns[0]);
     auto field_viewer = ColumnViewer<TYPE_BIGINT>(columns[2]);
 
-    ColumnBuilder<TYPE_VARCHAR> result;
     auto size = columns[0]->size();
+    ColumnBuilder<TYPE_VARCHAR> result(size);
     for (int row = 0; row < size; ++row) {
         if (content_viewer.is_null(row) || field_viewer.is_null(row)) {
             result.append_null();
@@ -2660,8 +2660,8 @@ ColumnPtr StringFunctions::regexp_replace_general(FunctionContext* context, re2:
     auto ptn_viewer = ColumnViewer<TYPE_VARCHAR>(columns[1]);
     auto rpl_viewer = ColumnViewer<TYPE_VARCHAR>(columns[2]);
 
-    ColumnBuilder<TYPE_VARCHAR> result;
     auto size = columns[0]->size();
+    ColumnBuilder<TYPE_VARCHAR> result(size);
     for (int row = 0; row < size; ++row) {
         if (str_viewer.is_null(row) || ptn_viewer.is_null(row) || rpl_viewer.is_null(row)) {
             result.append_null();
@@ -2691,8 +2691,8 @@ ColumnPtr StringFunctions::regexp_replace_const(re2::RE2* const_re, const Column
     auto str_viewer = ColumnViewer<TYPE_VARCHAR>(columns[0]);
     auto rpl_viewer = ColumnViewer<TYPE_VARCHAR>(columns[2]);
 
-    ColumnBuilder<TYPE_VARCHAR> result;
     auto size = columns[0]->size();
+    ColumnBuilder<TYPE_VARCHAR> result(size);
     for (int row = 0; row < size; ++row) {
         if (str_viewer.is_null(row) || rpl_viewer.is_null(row)) {
             result.append_null();
@@ -2726,8 +2726,8 @@ ColumnPtr StringFunctions::money_format_double(FunctionContext* context,
                                                const starrocks::vectorized::Columns& columns) {
     auto money_viewer = ColumnViewer<TYPE_DOUBLE>(columns[0]);
 
-    ColumnBuilder<TYPE_VARCHAR> result;
     auto size = columns[0]->size();
+    ColumnBuilder<TYPE_VARCHAR> result(size);
     for (int row = 0; row < size; ++row) {
         if (money_viewer.is_null(row)) {
             result.append_null();
@@ -2746,8 +2746,8 @@ ColumnPtr StringFunctions::money_format_bigint(FunctionContext* context,
                                                const starrocks::vectorized::Columns& columns) {
     auto money_viewer = ColumnViewer<TYPE_BIGINT>(columns[0]);
 
-    ColumnBuilder<TYPE_VARCHAR> result;
     auto size = columns[0]->size();
+    ColumnBuilder<TYPE_VARCHAR> result(size);
     for (int row = 0; row < size; ++row) {
         if (money_viewer.is_null(row)) {
             result.append_null();
@@ -2766,8 +2766,8 @@ ColumnPtr StringFunctions::money_format_largeint(FunctionContext* context,
                                                  const starrocks::vectorized::Columns& columns) {
     auto money_viewer = ColumnViewer<TYPE_LARGEINT>(columns[0]);
 
-    ColumnBuilder<TYPE_VARCHAR> result;
     auto size = columns[0]->size();
+    ColumnBuilder<TYPE_VARCHAR> result(size);
     for (int row = 0; row < size; ++row) {
         if (money_viewer.is_null(row)) {
             result.append_null();
@@ -2788,8 +2788,8 @@ ColumnPtr StringFunctions::money_format_decimalv2val(FunctionContext* context,
                                                      const starrocks::vectorized::Columns& columns) {
     auto money_viewer = ColumnViewer<TYPE_DECIMALV2>(columns[0]);
 
-    ColumnBuilder<TYPE_VARCHAR> result;
     auto size = columns[0]->size();
+    ColumnBuilder<TYPE_VARCHAR> result(size);
     for (int row = 0; row < size; ++row) {
         if (money_viewer.is_null(row)) {
             result.append_null();
@@ -2857,8 +2857,8 @@ ColumnPtr StringFunctions::parse_url_general(FunctionContext* context, const sta
     auto str_viewer = ColumnViewer<TYPE_VARCHAR>(columns[0]);
     auto part_viewer = ColumnViewer<TYPE_VARCHAR>(columns[1]);
 
-    ColumnBuilder<TYPE_VARCHAR> result;
     auto size = columns[0]->size();
+    ColumnBuilder<TYPE_VARCHAR> result(size);
     for (int row = 0; row < size; ++row) {
         if (str_viewer.is_null(row) || part_viewer.is_null(row)) {
             result.append_null();
@@ -2894,8 +2894,8 @@ ColumnPtr StringFunctions::parse_url_const(UrlParser::UrlPart* url_part, Functio
                                            const starrocks::vectorized::Columns& columns) {
     auto str_viewer = ColumnViewer<TYPE_VARCHAR>(columns[0]);
 
-    ColumnBuilder<TYPE_VARCHAR> result;
     auto size = columns[0]->size();
+    ColumnBuilder<TYPE_VARCHAR> result(size);
     for (int row = 0; row < size; ++row) {
         if (str_viewer.is_null(row)) {
             result.append_null();

--- a/be/src/exprs/vectorized/string_functions.h
+++ b/be/src/exprs/vectorized/string_functions.h
@@ -475,8 +475,8 @@ ColumnPtr StringFunctions::money_format_decimal(FunctionContext* context,
     const auto& type = context->get_arg_type(0);
     int scale = type->scale;
 
-    ColumnBuilder<TYPE_VARCHAR> result;
     auto num_rows = columns[0]->size();
+    ColumnBuilder<TYPE_VARCHAR> result(num_rows);
     if (scale > 2) {
         // scale down
         money_format_decimal_impl<Type, false, true>(context, money_viewer, num_rows, scale - 2, &result);

--- a/be/src/exprs/vectorized/time_functions.cpp
+++ b/be/src/exprs/vectorized/time_functions.cpp
@@ -155,8 +155,8 @@ ColumnPtr TimeFunctions::convert_tz_general(FunctionContext* context, const Colu
     auto from_str = ColumnViewer<TYPE_VARCHAR>(columns[1]);
     auto to_str = ColumnViewer<TYPE_VARCHAR>(columns[2]);
 
-    ColumnBuilder<TYPE_DATETIME> result;
     auto size = columns[0]->size();
+    ColumnBuilder<TYPE_DATETIME> result(size);
     for (int row = 0; row < size; ++row) {
         if (time_viewer.is_null(row) || from_str.is_null(row) || to_str.is_null(row)) {
             result.append_null();
@@ -197,8 +197,8 @@ ColumnPtr TimeFunctions::convert_tz_const(FunctionContext* context, const Column
                                           const cctz::time_zone& to) {
     auto time_viewer = ColumnViewer<TYPE_DATETIME>(columns[0]);
 
-    ColumnBuilder<TYPE_DATETIME> result;
     auto size = columns[0]->size();
+    ColumnBuilder<TYPE_DATETIME> result(size);
     for (int row = 0; row < size; ++row) {
         if (time_viewer.is_null(row)) {
             result.append_null();
@@ -614,8 +614,8 @@ ColumnPtr TimeFunctions::to_unix_from_datetime(FunctionContext* context, const C
 
     auto date_viewer = ColumnViewer<TYPE_DATETIME>(columns[0]);
 
-    ColumnBuilder<TYPE_INT> result;
     auto size = columns[0]->size();
+    ColumnBuilder<TYPE_INT> result(size);
     for (int row = 0; row < size; ++row) {
         if (date_viewer.is_null(row)) {
             result.append_null();
@@ -649,8 +649,8 @@ ColumnPtr TimeFunctions::to_unix_from_date(FunctionContext* context, const Colum
 
     auto date_viewer = ColumnViewer<TYPE_DATE>(columns[0]);
 
-    ColumnBuilder<TYPE_INT> result;
     auto size = columns[0]->size();
+    ColumnBuilder<TYPE_INT> result(size);
     for (int row = 0; row < size; ++row) {
         if (date_viewer.is_null(row)) {
             result.append_null();
@@ -683,8 +683,8 @@ ColumnPtr TimeFunctions::to_unix_from_datetime_with_format(FunctionContext* cont
     auto date_viewer = ColumnViewer<TYPE_VARCHAR>(columns[0]);
     auto formatViewer = ColumnViewer<TYPE_VARCHAR>(columns[1]);
 
-    ColumnBuilder<TYPE_INT> result;
     auto size = columns[0]->size();
+    ColumnBuilder<TYPE_INT> result(size);
     for (int row = 0; row < size; ++row) {
         if (date_viewer.is_null(row) || formatViewer.is_null(row)) {
             result.append_null();
@@ -736,8 +736,8 @@ ColumnPtr TimeFunctions::from_unix_to_datetime(FunctionContext* context, const C
 
     ColumnViewer<TYPE_INT> data_column(columns[0]);
 
-    ColumnBuilder<TYPE_VARCHAR> result;
     auto size = columns[0]->size();
+    ColumnBuilder<TYPE_VARCHAR> result(size);
     for (int row = 0; row < size; ++row) {
         if (data_column.is_null(row)) {
             result.append_null();
@@ -833,11 +833,11 @@ ColumnPtr TimeFunctions::from_unix_with_format_general(FunctionContext* context,
 
     RETURN_IF_COLUMNS_ONLY_NULL(columns);
 
-    ColumnBuilder<TYPE_VARCHAR> result;
     ColumnViewer<TYPE_INT> data_column(columns[0]);
     ColumnViewer<TYPE_VARCHAR> format_column(columns[1]);
 
     auto size = columns[0]->size();
+    ColumnBuilder<TYPE_VARCHAR> result(size);
     for (int row = 0; row < size; ++row) {
         if (data_column.is_null(row) || format_column.is_null(row)) {
             result.append_null();
@@ -881,10 +881,10 @@ ColumnPtr TimeFunctions::from_unix_with_format_const(std::string& format_content
 
     RETURN_IF_COLUMNS_ONLY_NULL(columns);
 
-    ColumnBuilder<TYPE_VARCHAR> result;
     ColumnViewer<TYPE_INT> data_column(columns[0]);
 
     auto size = columns[0]->size();
+    ColumnBuilder<TYPE_VARCHAR> result(size);
     for (int row = 0; row < size; ++row) {
         if (data_column.is_null(row)) {
             result.append_null();
@@ -1036,10 +1036,9 @@ Status TimeFunctions::str_to_date_prepare(starrocks_udf::FunctionContext* contex
 ColumnPtr TimeFunctions::str_to_date_from_date_format(FunctionContext* context,
                                                       const starrocks::vectorized::Columns& columns,
                                                       const char* str_format) {
-    ColumnBuilder<TYPE_DATETIME> result;
     size_t size = columns[0]->size();
+    ColumnBuilder<TYPE_DATETIME> result(size);
 
-    result.reserve(size);
     TimestampValue ts;
     auto str_viewer = ColumnViewer<TYPE_VARCHAR>(columns[0]);
     auto fmt_viewer = ColumnViewer<TYPE_VARCHAR>(columns[1]);
@@ -1079,9 +1078,8 @@ ColumnPtr TimeFunctions::str_to_date_from_date_format(FunctionContext* context,
 ColumnPtr TimeFunctions::str_to_date_from_datetime_format(FunctionContext* context,
                                                           const starrocks::vectorized::Columns& columns,
                                                           const char* str_format) {
-    ColumnBuilder<TYPE_DATETIME> result;
     size_t size = columns[0]->size();
-    result.reserve(size);
+    ColumnBuilder<TYPE_DATETIME> result(size);
 
     TimestampValue ts;
     auto str_viewer = ColumnViewer<TYPE_VARCHAR>(columns[0]);
@@ -1132,8 +1130,7 @@ ColumnPtr TimeFunctions::str_to_date_uncommon(FunctionContext* context, const Co
     RETURN_IF_COLUMNS_ONLY_NULL(columns);
 
     size_t size = columns[0]->size(); // minimum number of rows.
-    ColumnBuilder<TYPE_DATETIME> result;
-    result.reserve(size);
+    ColumnBuilder<TYPE_DATETIME> result(size);
 
     auto str_viewer = ColumnViewer<TYPE_VARCHAR>(columns[0]);
     auto fmt_viewer = ColumnViewer<TYPE_VARCHAR>(columns[1]);
@@ -1251,11 +1248,10 @@ Status TimeFunctions::format_close(starrocks_udf::FunctionContext* context,
 
 template <typename OP, PrimitiveType Type>
 ColumnPtr date_format_func(const Columns& cols, size_t patten_size) {
-    ColumnBuilder<TYPE_VARCHAR> builder;
     ColumnViewer<Type> viewer(cols[0]);
 
     size_t num_rows = viewer.size();
-
+    ColumnBuilder<TYPE_VARCHAR> builder(num_rows);
     builder.data_column()->reserve(num_rows, num_rows * patten_size);
 
     for (int i = 0; i < num_rows; ++i) {
@@ -1383,10 +1379,10 @@ bool standard_format_one_row(const TimestampValue& timestamp_value, char* buf, c
 
 template <PrimitiveType Type>
 ColumnPtr standard_format(const std::string& fmt, int len, const starrocks::vectorized::Columns& columns) {
-    ColumnBuilder<TYPE_VARCHAR> result;
     auto ts_viewer = ColumnViewer<Type>(columns[0]);
 
     size_t size = columns[0]->size();
+    ColumnBuilder<TYPE_VARCHAR> result(size);
 
     char buf[len];
     for (size_t i = 0; i < size; ++i) {
@@ -1458,7 +1454,6 @@ ColumnPtr TimeFunctions::datetime_format(FunctionContext* context, const Columns
         return do_format<TYPE_DATETIME>(fc, columns);
     } else {
         bool all_const = ColumnHelper::is_all_const(columns);
-        ColumnBuilder<TYPE_VARCHAR> builder;
         ColumnViewer<TYPE_DATETIME> viewer_date(columns[0]);
         ColumnViewer<TYPE_VARCHAR> viewer_format(columns[1]);
 
@@ -1466,8 +1461,7 @@ ColumnPtr TimeFunctions::datetime_format(FunctionContext* context, const Columns
         // which could reduce unnecessary calculations
         size_t num_rows = all_const ? viewer_date.size() : columns[0]->size();
 
-        builder.reserve(columns[0]->size());
-
+        ColumnBuilder<TYPE_VARCHAR> builder(columns[0]->size());
         for (int i = 0; i < num_rows; ++i) {
             if (viewer_date.is_null(i)) {
                 builder.append_null();
@@ -1491,11 +1485,10 @@ ColumnPtr TimeFunctions::date_format(FunctionContext* context, const Columns& co
         return do_format<TYPE_DATE>(fc, columns);
     } else {
         int num_rows = columns[0]->size();
-        ColumnBuilder<TYPE_VARCHAR> builder;
         ColumnViewer<TYPE_DATE> viewer_date(columns[0]);
         ColumnViewer<TYPE_VARCHAR> viewer_format(columns[1]);
 
-        builder.reserve(columns[0]->size());
+        ColumnBuilder<TYPE_VARCHAR> builder(columns[0]->size());
 
         for (int i = 0; i < num_rows; ++i) {
             if (viewer_date.is_null(i)) {

--- a/be/src/exprs/vectorized/utility_functions.cpp
+++ b/be/src/exprs/vectorized/utility_functions.cpp
@@ -22,10 +22,10 @@ ColumnPtr UtilityFunctions::current_version(FunctionContext* context, const Colu
 }
 
 ColumnPtr UtilityFunctions::sleep(FunctionContext* context, const Columns& columns) {
-    ColumnBuilder<TYPE_BOOLEAN> result;
     ColumnViewer<TYPE_INT> data_column(columns[0]);
 
     auto size = columns[0]->size();
+    ColumnBuilder<TYPE_BOOLEAN> result(size);
     for (int row = 0; row < size; ++row) {
         if (data_column.is_null(row)) {
             result.append_null();
@@ -53,8 +53,7 @@ ColumnPtr UtilityFunctions::last_query_id(FunctionContext* context, const Column
 ColumnPtr UtilityFunctions::uuid(FunctionContext*, const Columns& columns) {
     int32_t num_rows = ColumnHelper::get_const_value<TYPE_INT>(columns.back());
 
-    ColumnBuilder<TYPE_VARCHAR> result;
-    result.reserve(num_rows);
+    ColumnBuilder<TYPE_VARCHAR> result(num_rows);
     for (int i = 0; i < num_rows; ++i) {
         result.append(generate_uuid_string());
     }

--- a/be/src/runtime/data_stream_recvr.cc
+++ b/be/src/runtime/data_stream_recvr.cc
@@ -651,10 +651,10 @@ void DataStreamRecvr::SenderQueue::close() {
     }
 }
 
-Status DataStreamRecvr::create_merger(const SortExecExprs* exprs, const std::vector<bool>* is_asc,
+Status DataStreamRecvr::create_merger(RuntimeState* state, const SortExecExprs* exprs, const std::vector<bool>* is_asc,
                                       const std::vector<bool>* is_null_first) {
     DCHECK(_is_merging);
-    _chunks_merger = std::make_unique<vectorized::SortedChunksMerger>(_keep_order);
+    _chunks_merger = std::make_unique<vectorized::SortedChunksMerger>(state, _keep_order);
     vectorized::ChunkSuppliers chunk_suppliers;
     for (SenderQueue* q : _sender_queues) {
         // we use chunk_supplier in non-pipeline.
@@ -680,10 +680,11 @@ Status DataStreamRecvr::create_merger(const SortExecExprs* exprs, const std::vec
     return Status::OK();
 }
 
-Status DataStreamRecvr::create_merger_for_pipeline(const SortExecExprs* exprs, const std::vector<bool>* is_asc,
+Status DataStreamRecvr::create_merger_for_pipeline(RuntimeState* state, const SortExecExprs* exprs,
+                                                   const std::vector<bool>* is_asc,
                                                    const std::vector<bool>* is_null_first) {
     DCHECK(_is_merging);
-    _chunks_merger = std::make_unique<vectorized::SortedChunksMerger>(_keep_order);
+    _chunks_merger = std::make_unique<vectorized::SortedChunksMerger>(state, _keep_order);
     vectorized::ChunkSuppliers chunk_suppliers;
     for (SenderQueue* q : _sender_queues) {
         // we willn't use chunk_supplier in pipeline.

--- a/be/src/runtime/data_stream_recvr.h
+++ b/be/src/runtime/data_stream_recvr.h
@@ -83,9 +83,9 @@ public:
     // Create a SortedRunMerger instance to merge rows from multiple sender according to the
     // specified row comparator. Fetches the first batches from the individual sender
     // queues. The exprs used in less_than must have already been prepared and opened.
-    Status create_merger(const SortExecExprs* exprs, const std::vector<bool>* is_asc,
+    Status create_merger(RuntimeState* state, const SortExecExprs* exprs, const std::vector<bool>* is_asc,
                          const std::vector<bool>* is_null_first);
-    Status create_merger_for_pipeline(const SortExecExprs* exprs, const std::vector<bool>* is_asc,
+    Status create_merger_for_pipeline(RuntimeState* state, const SortExecExprs* exprs, const std::vector<bool>* is_asc,
                                       const std::vector<bool>* is_null_first);
 
     // Fill output_batch with the next batch of rows obtained by merging the per-sender
@@ -127,9 +127,9 @@ private:
     // Empties the sender queues and notifies all waiting consumers of cancellation.
     void cancel_stream();
 
-    // Return true if the addition of a new batch of size 'batch_size' would exceed the
+    // Return true if the addition of a new batch of size 'chunk_size' would exceed the
     // total buffer limit.
-    bool exceeds_limit(int batch_size) { return _num_buffered_bytes + batch_size > _total_buffer_limit; }
+    bool exceeds_limit(int chunk_size) { return _num_buffered_bytes + chunk_size > _total_buffer_limit; }
 
     // DataStreamMgr instance used to create this recvr. (Not owned)
     DataStreamMgr* _mgr;

--- a/be/src/runtime/descriptors.cpp
+++ b/be/src/runtime/descriptors.cpp
@@ -144,7 +144,7 @@ HdfsPartitionDescriptor::HdfsPartitionDescriptor(const THdfsTable& thrift_table,
           _location(thrift_partition.location.suffix),
           _thrift_partition_key_exprs(thrift_partition.partition_key_exprs) {}
 
-Status HdfsPartitionDescriptor::create_part_key_exprs(ObjectPool* pool) {
+Status HdfsPartitionDescriptor::create_part_key_exprs(ObjectPool* pool, int32_t chunk_size) {
     RETURN_IF_ERROR(Expr::create_expr_trees(pool, _thrift_partition_key_exprs, &_partition_key_value_evals));
     return Status::OK();
 }
@@ -455,7 +455,8 @@ std::string RowDescriptor::debug_string() const {
     return ss.str();
 }
 
-Status DescriptorTbl::create(ObjectPool* pool, const TDescriptorTable& thrift_tbl, DescriptorTbl** tbl) {
+Status DescriptorTbl::create(ObjectPool* pool, const TDescriptorTable& thrift_tbl, DescriptorTbl** tbl,
+                             int32_t chunk_size) {
     *tbl = pool->add(new DescriptorTbl());
 
     // deserialize table descriptors first, they are being referenced by tuple descriptors
@@ -482,7 +483,7 @@ Status DescriptorTbl::create(ObjectPool* pool, const TDescriptorTable& thrift_tb
             break;
         case TTableType::HDFS_TABLE: {
             auto* hdfs_desc = pool->add(new HdfsTableDescriptor(tdesc, pool));
-            RETURN_IF_ERROR(hdfs_desc->create_key_exprs(pool));
+            RETURN_IF_ERROR(hdfs_desc->create_key_exprs(pool, chunk_size));
             desc = hdfs_desc;
             break;
         }

--- a/be/src/runtime/descriptors.h
+++ b/be/src/runtime/descriptors.h
@@ -174,7 +174,7 @@ public:
     // partition slots would be [x, y]
     // partition key values wold be [1, 2]
     std::vector<ExprContext*>& partition_key_value_evals() { return _partition_key_value_evals; }
-    Status create_part_key_exprs(ObjectPool* pool);
+    Status create_part_key_exprs(ObjectPool* pool, int32_t chunk_size);
 
 private:
     int64_t _id = 0;
@@ -196,9 +196,9 @@ public:
 
     const std::string& hdfs_base_dir() const { return _hdfs_base_dir; }
 
-    Status create_key_exprs(ObjectPool* pool) {
+    Status create_key_exprs(ObjectPool* pool, int32_t chunk_size) {
         for (auto& part : _partition_id_to_desc_map) {
-            RETURN_IF_ERROR(part.second->create_part_key_exprs(pool));
+            RETURN_IF_ERROR(part.second->create_part_key_exprs(pool, chunk_size));
         }
         return Status::OK();
     }
@@ -318,7 +318,7 @@ class DescriptorTbl {
 public:
     // Creates a descriptor tbl within 'pool' from thrift_tbl and returns it via 'tbl'.
     // Returns OK on success, otherwise error (in which case 'tbl' will be unset).
-    static Status create(ObjectPool* pool, const TDescriptorTable& thrift_tbl, DescriptorTbl** tbl);
+    static Status create(ObjectPool* pool, const TDescriptorTable& thrift_tbl, DescriptorTbl** tbl, int32_t chunk_size);
 
     TableDescriptor* get_table_descriptor(TableId id) const;
     TupleDescriptor* get_tuple_descriptor(TupleId id) const;

--- a/be/src/runtime/dpp_sink_internal.cpp
+++ b/be/src/runtime/dpp_sink_internal.cpp
@@ -137,7 +137,8 @@ Status PartRange::from_thrift(ObjectPool* pool, const TPartitionRange& t_part_ra
     return Status::OK();
 }
 
-Status PartitionInfo::from_thrift(ObjectPool* pool, const TRangePartition& t_partition, PartitionInfo* partition) {
+Status PartitionInfo::from_thrift(ObjectPool* pool, const TRangePartition& t_partition, PartitionInfo* partition,
+                                  int32_t chunk_size) {
     partition->_id = t_partition.partition_id;
     RETURN_IF_ERROR(PartRange::from_thrift(pool, t_partition.range, &partition->_range));
     if (t_partition.__isset.distributed_exprs) {

--- a/be/src/runtime/dpp_sink_internal.h
+++ b/be/src/runtime/dpp_sink_internal.h
@@ -190,7 +190,8 @@ class PartitionInfo {
 public:
     PartitionInfo() {}
 
-    static Status from_thrift(ObjectPool* pool, const TRangePartition& t_partition, PartitionInfo* partition);
+    static Status from_thrift(ObjectPool* pool, const TRangePartition& t_partition, PartitionInfo* partition,
+                              int32_t chunk_size);
 
     Status prepare(RuntimeState* state, const RowDescriptor& row_desc);
 

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -602,7 +602,7 @@ Status FragmentMgr::exec_external_plan_fragment(const TScanOpenParams& params, c
     // set up desc tbl
     DescriptorTbl* desc_tbl = nullptr;
     ObjectPool obj_pool;
-    st = DescriptorTbl::create(&obj_pool, t_query_plan_info.desc_tbl, &desc_tbl);
+    st = DescriptorTbl::create(&obj_pool, t_query_plan_info.desc_tbl, &desc_tbl, params.batch_size);
     if (!st.ok()) {
         LOG(WARNING) << "open context error: extract DescriptorTbl failure";
         std::stringstream msg;
@@ -675,7 +675,7 @@ Status FragmentMgr::exec_external_plan_fragment(const TScanOpenParams& params, c
     exec_fragment_params.__set_params(fragment_exec_params);
     // batch_size for one RowBatch
     TQueryOptions query_options;
-    query_options.batch_size = params.batch_size;
+    query_options.chunk_size = params.batch_size;
     query_options.query_timeout = params.query_timeout;
     query_options.mem_limit = params.mem_limit;
     query_options.query_type = TQueryType::EXTERNAL;

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -675,7 +675,7 @@ Status FragmentMgr::exec_external_plan_fragment(const TScanOpenParams& params, c
     exec_fragment_params.__set_params(fragment_exec_params);
     // batch_size for one RowBatch
     TQueryOptions query_options;
-    query_options.chunk_size = params.batch_size;
+    query_options.batch_size = params.batch_size;
     query_options.query_timeout = params.query_timeout;
     query_options.mem_limit = params.mem_limit;
     query_options.query_type = TQueryType::EXTERNAL;

--- a/be/src/runtime/mysql_table_sink.cpp
+++ b/be/src/runtime/mysql_table_sink.cpp
@@ -48,7 +48,7 @@ Status MysqlTableSink::init(const TDataSink& t_sink) {
     _conn_info.passwd = t_mysql_sink.passwd;
     _conn_info.db = t_mysql_sink.db;
     _mysql_tbl = t_mysql_sink.table;
-    _batch_size = MYSQL_SINK_BATCH_SIZE;
+    _chunk_size = MYSQL_SINK_BATCH_SIZE;
 
     // From the thrift expressions create the real exprs.
     RETURN_IF_ERROR(Expr::create_expr_trees(_pool, _t_output_expr, &_output_expr_ctxs));
@@ -70,7 +70,7 @@ Status MysqlTableSink::open(RuntimeState* state) {
     // Prepare the exprs to run.
     RETURN_IF_ERROR(Expr::open(_output_expr_ctxs, state));
     // create writer
-    _writer = std::make_unique<MysqlTableWriter>(_output_expr_ctxs, _batch_size);
+    _writer = std::make_unique<MysqlTableWriter>(_output_expr_ctxs, _chunk_size);
     RETURN_IF_ERROR(_writer->open(_conn_info, _mysql_tbl));
     return Status::OK();
 }

--- a/be/src/runtime/mysql_table_sink.h
+++ b/be/src/runtime/mysql_table_sink.h
@@ -62,7 +62,7 @@ private:
     ObjectPool* _pool;
     const RowDescriptor& _row_desc;
     const std::vector<TExpr>& _t_output_expr;
-    int _batch_size;
+    int _chunk_size;
 
     std::vector<ExprContext*> _output_expr_ctxs;
 

--- a/be/src/runtime/mysql_table_writer.h
+++ b/be/src/runtime/mysql_table_writer.h
@@ -78,7 +78,7 @@ public:
 #undef M
                     vectorized::ColumnViewer<TYPE_NULL>>;
 
-    MysqlTableWriter(const std::vector<ExprContext*>& output_exprs, int batch_size);
+    MysqlTableWriter(const std::vector<ExprContext*>& output_exprs, int chunk_size);
     ~MysqlTableWriter();
 
     // connnect to mysql server
@@ -104,7 +104,7 @@ private:
 
     std::string _mysql_tbl;
     __StarRocksMysql* _mysql_conn;
-    int _batch_size;
+    int _chunk_size;
 };
 
 } // namespace starrocks

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -147,9 +147,6 @@ Status PlanFragmentExecutor::prepare(const TExecPlanFragmentParams& request) {
         static_cast<ExchangeNode*>(exch_node)->set_num_senders(num_senders);
     }
 
-    std::vector<ExecNode*> adaptor_nodes;
-    _plan->collect_nodes(TPlanNodeType::ADAPTER_NODE, &adaptor_nodes);
-
     RETURN_IF_ERROR(_plan->prepare(_runtime_state));
     // set scan ranges
     std::vector<ExecNode*> scan_nodes;

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -70,7 +70,7 @@ Status PlanFragmentExecutor::prepare(const TExecPlanFragmentParams& request) {
               << " fragment_instance_id=" << print_id(params.fragment_instance_id)
               << " backend_num=" << request.backend_num;
 
-    _runtime_state->set_batch_size(config::vector_chunk_size);
+    DCHECK(_runtime_state->chunk_size() > 0);
 
     _runtime_state->set_be_number(request.backend_num);
     if (request.__isset.import_label) {
@@ -118,7 +118,7 @@ Status PlanFragmentExecutor::prepare(const TExecPlanFragmentParams& request) {
     // set up desc tbl
     DescriptorTbl* desc_tbl = nullptr;
     DCHECK(request.__isset.desc_tbl);
-    RETURN_IF_ERROR(DescriptorTbl::create(obj_pool(), request.desc_tbl, &desc_tbl));
+    RETURN_IF_ERROR(DescriptorTbl::create(obj_pool(), request.desc_tbl, &desc_tbl, _runtime_state->chunk_size()));
     _runtime_state->set_desc_tbl(desc_tbl);
 
     // set up plan
@@ -147,13 +147,8 @@ Status PlanFragmentExecutor::prepare(const TExecPlanFragmentParams& request) {
         static_cast<ExchangeNode*>(exch_node)->set_num_senders(num_senders);
     }
 
-    // when has adapter node, set the batch_size with the config::vector_chunk_size
-    // otherwise the adapter node will crash when convert
     std::vector<ExecNode*> adaptor_nodes;
     _plan->collect_nodes(TPlanNodeType::ADAPTER_NODE, &adaptor_nodes);
-    if (!adaptor_nodes.empty()) {
-        _runtime_state->set_batch_size(config::vector_chunk_size);
-    }
 
     RETURN_IF_ERROR(_plan->prepare(_runtime_state));
     // set scan ranges

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -79,7 +79,7 @@ RuntimeState::RuntimeState(const TUniqueId& query_id, const TUniqueId& fragment_
 RuntimeState::RuntimeState(const TQueryGlobals& query_globals)
         : _unreported_error_idx(0), _obj_pool(new ObjectPool()), _is_cancelled(false), _per_fragment_instance_idx(0) {
     _profile = std::make_shared<RuntimeProfile>("<unnamed>");
-    _query_options.chunk_size = DEFAULT_CHUNK_SIZE;
+    _query_options.batch_size = DEFAULT_CHUNK_SIZE;
     if (query_globals.__isset.time_zone) {
         _timezone = query_globals.time_zone;
         _timestamp_ms = query_globals.timestamp_ms;
@@ -147,8 +147,8 @@ Status RuntimeState::init(const TUniqueId& fragment_instance_id, const TQueryOpt
         _query_options.max_errors = 100;
     }
 
-    if (_query_options.chunk_size <= 0) {
-        _query_options.chunk_size = DEFAULT_CHUNK_SIZE;
+    if (_query_options.batch_size <= 0) {
+        _query_options.batch_size = DEFAULT_CHUNK_SIZE;
     }
 
     // Register with the thread mgr

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -79,7 +79,7 @@ RuntimeState::RuntimeState(const TUniqueId& query_id, const TUniqueId& fragment_
 RuntimeState::RuntimeState(const TQueryGlobals& query_globals)
         : _unreported_error_idx(0), _obj_pool(new ObjectPool()), _is_cancelled(false), _per_fragment_instance_idx(0) {
     _profile = std::make_shared<RuntimeProfile>("<unnamed>");
-    _query_options.batch_size = DEFAULT_BATCH_SIZE;
+    _query_options.chunk_size = DEFAULT_CHUNK_SIZE;
     if (query_globals.__isset.time_zone) {
         _timezone = query_globals.time_zone;
         _timestamp_ms = query_globals.timestamp_ms;
@@ -147,8 +147,8 @@ Status RuntimeState::init(const TUniqueId& fragment_instance_id, const TQueryOpt
         _query_options.max_errors = 100;
     }
 
-    if (_query_options.batch_size <= 0) {
-        _query_options.batch_size = DEFAULT_BATCH_SIZE;
+    if (_query_options.chunk_size <= 0) {
+        _query_options.chunk_size = DEFAULT_CHUNK_SIZE;
     }
 
     // Register with the thread mgr

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -91,8 +91,8 @@ public:
 
     const DescriptorTbl& desc_tbl() const { return *_desc_tbl; }
     void set_desc_tbl(DescriptorTbl* desc_tbl) { _desc_tbl = desc_tbl; }
-    int chunk_size() const { return _query_options.chunk_size; }
-    void set_chunk_size(int chunk_size) { _query_options.chunk_size = chunk_size; }
+    int chunk_size() const { return _query_options.batch_size; }
+    void set_chunk_size(int chunk_size) { _query_options.batch_size = chunk_size; }
     bool abort_on_default_limit_exceeded() const { return _query_options.abort_on_default_limit_exceeded; }
     int64_t timestamp_ms() const { return _timestamp_ms; }
     const std::string& timezone() const { return _timezone; }

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -91,8 +91,8 @@ public:
 
     const DescriptorTbl& desc_tbl() const { return *_desc_tbl; }
     void set_desc_tbl(DescriptorTbl* desc_tbl) { _desc_tbl = desc_tbl; }
-    int batch_size() const { return _query_options.batch_size; }
-    void set_batch_size(int batch_size) { _query_options.batch_size = batch_size; }
+    int chunk_size() const { return _query_options.chunk_size; }
+    void set_chunk_size(int chunk_size) { _query_options.chunk_size = chunk_size; }
     bool abort_on_default_limit_exceeded() const { return _query_options.abort_on_default_limit_exceeded; }
     int64_t timestamp_ms() const { return _timestamp_ms; }
     const std::string& timezone() const { return _timezone; }
@@ -283,7 +283,7 @@ private:
 
     Status _build_global_dict(const GlobalDictLists& global_dict_list, vectorized::GlobalDictMaps* result);
 
-    static const int DEFAULT_BATCH_SIZE = 2048;
+    static const int DEFAULT_CHUNK_SIZE = 2048;
 
     // put runtime state before _obj_pool, so that it will be deconstructed after
     // _obj_pool. Because some of object in _obj_pool will use profile when deconstructing.

--- a/be/src/runtime/vectorized/sorted_chunks_merger.cpp
+++ b/be/src/runtime/vectorized/sorted_chunks_merger.cpp
@@ -6,7 +6,8 @@
 
 namespace starrocks::vectorized {
 
-SortedChunksMerger::SortedChunksMerger(bool is_pipeline) : _is_pipeline(is_pipeline) {}
+SortedChunksMerger::SortedChunksMerger(RuntimeState* state, bool is_pipeline)
+        : _state(state), _is_pipeline(is_pipeline) {}
 
 SortedChunksMerger::~SortedChunksMerger() = default;
 
@@ -130,11 +131,11 @@ Status SortedChunksMerger::get_next(ChunkPtr* chunk, bool* eos) {
     // multiple sources
     *eos = false;
     ChunkCursor* cursor = _min_heap[0];
-    *chunk = cursor->clone_empty_chunk(config::vector_chunk_size);
+    *chunk = cursor->clone_empty_chunk(_state->chunk_size());
 
     ChunkPtr current_chunk = cursor->get_current_chunk();
     std::vector<uint32_t> selective_values; // for append_selective call
-    selective_values.reserve(config::vector_chunk_size);
+    selective_values.reserve(_state->chunk_size());
     selective_values.push_back(cursor->get_current_position_in_chunk());
     size_t row_number = 1;
 
@@ -146,7 +147,7 @@ Status SortedChunksMerger::get_next(ChunkPtr* chunk, bool* eos) {
         _min_heap.pop_back();
     }
 
-    while (row_number < config::vector_chunk_size && !_min_heap.empty()) {
+    while (row_number < _state->chunk_size() && !_min_heap.empty()) {
         cursor = _min_heap[0];
         const auto& ptr = cursor->get_current_chunk();
         if (current_chunk == ptr) {
@@ -212,7 +213,7 @@ Status SortedChunksMerger::get_next_for_pipeline(ChunkPtr* chunk, std::atomic<bo
         if (_wait_for_data) {
             _wait_for_data = false;
             move_cursor_and_adjust_min_heap(eos);
-            if (_row_number >= config::vector_chunk_size || _min_heap.empty()) {
+            if (_row_number >= _state->chunk_size() || _min_heap.empty()) {
                 collect_merged_chunks(chunk);
                 break;
             }
@@ -222,10 +223,10 @@ Status SortedChunksMerger::get_next_for_pipeline(ChunkPtr* chunk, std::atomic<bo
         // Guarantee: min_heap is keep min heap property, and it isn't empty.
         _cursor = _min_heap[0];
         if (!_row_number) {
-            _result_chunk = _cursor->clone_empty_chunk(config::vector_chunk_size);
+            _result_chunk = _cursor->clone_empty_chunk(_state->chunk_size());
             _current_chunk = _cursor->get_current_chunk();
             _selective_values.clear();
-            _selective_values.reserve(config::vector_chunk_size);
+            _selective_values.reserve(_state->chunk_size());
             _selective_values.push_back(_cursor->get_current_position_in_chunk());
         } else {
             const auto& ptr = _cursor->get_current_chunk();
@@ -255,7 +256,7 @@ Status SortedChunksMerger::get_next_for_pipeline(ChunkPtr* chunk, std::atomic<bo
             // move to next row
             _wait_for_data = false;
             move_cursor_and_adjust_min_heap(eos);
-            if (_row_number >= config::vector_chunk_size || _min_heap.empty()) {
+            if (_row_number >= _state->chunk_size() || _min_heap.empty()) {
                 collect_merged_chunks(chunk);
                 break;
             }

--- a/be/src/runtime/vectorized/sorted_chunks_merger.h
+++ b/be/src/runtime/vectorized/sorted_chunks_merger.h
@@ -16,7 +16,7 @@ namespace vectorized {
 // Merge a group of sorted Chunks to one Chunk in order.
 class SortedChunksMerger {
 public:
-    SortedChunksMerger(bool is_pipeline);
+    SortedChunksMerger(RuntimeState* state, bool is_pipeline);
     ~SortedChunksMerger();
 
     Status init(const ChunkSuppliers& chunk_suppliers, const ChunkProbeSuppliers& chunk_probe_suppliers,
@@ -35,6 +35,7 @@ public:
     Status get_next_for_pipeline(ChunkPtr* chunk, std::atomic<bool>* eos, bool* should_exit);
 
 private:
+    RuntimeState* _state;
     void collect_merged_chunks(ChunkPtr* chunk);
     void move_cursor_and_adjust_min_heap(std::atomic<bool>* eos);
 

--- a/be/src/storage/vectorized/chunk_helper.cpp
+++ b/be/src/storage/vectorized/chunk_helper.cpp
@@ -93,7 +93,7 @@ ColumnId ChunkHelper::max_column_id(const starrocks::vectorized::Schema& schema)
 
 template <typename T>
 struct ColumnDeleter {
-    ColumnDeleter(size_t chunk_size) : chunk_size(chunk_size) {}
+    ColumnDeleter(uint32_t chunk_size) : chunk_size(chunk_size) {}
     void operator()(Column* ptr) const { return_column<T>(down_cast<T*>(ptr), chunk_size); }
     uint32_t chunk_size;
 };

--- a/be/src/storage/vectorized/push_handler.cpp
+++ b/be/src/storage/vectorized/push_handler.cpp
@@ -41,7 +41,8 @@ Status PushBrokerReader::init(const TBrokerScanRange& t_scan_range, const TDescr
                                            query_options, query_globals, ExecEnv::GetInstance());
 
     DescriptorTbl* desc_tbl = nullptr;
-    RETURN_IF_ERROR(DescriptorTbl::create(_runtime_state->obj_pool(), t_desc_tbl, &desc_tbl));
+    RETURN_IF_ERROR(
+            DescriptorTbl::create(_runtime_state->obj_pool(), t_desc_tbl, &desc_tbl, config::vector_chunk_size));
     _runtime_state->set_desc_tbl(desc_tbl);
 
     _runtime_profile = _runtime_state->runtime_profile();
@@ -81,7 +82,7 @@ Status PushBrokerReader::init(const TBrokerScanRange& t_scan_range, const TDescr
 }
 
 ColumnPtr PushBrokerReader::_build_object_column(const ColumnPtr& column) {
-    ColumnBuilder<TYPE_OBJECT> builder;
+    ColumnBuilder<TYPE_OBJECT> builder(config::vector_chunk_size);
     ColumnViewer<TYPE_VARCHAR> viewer(column);
 
     if (!column->has_null()) {
@@ -107,7 +108,7 @@ ColumnPtr PushBrokerReader::_build_object_column(const ColumnPtr& column) {
 }
 
 ColumnPtr PushBrokerReader::_build_hll_column(const ColumnPtr& column) {
-    ColumnBuilder<TYPE_HLL> builder;
+    ColumnBuilder<TYPE_HLL> builder(config::vector_chunk_size);
     ColumnViewer<TYPE_VARCHAR> viewer(column);
 
     if (!column->has_null()) {

--- a/be/src/testutil/desc_tbl_builder.cc
+++ b/be/src/testutil/desc_tbl_builder.cc
@@ -78,7 +78,7 @@ DescriptorTbl* DescriptorTblBuilder::build() {
         build_tuple(_tuples_desc->slot_types(), &thrift_desc_tbl, &tuple_id, &slot_id);
     }
 
-    Status status = DescriptorTbl::create(_obj_pool, thrift_desc_tbl, &desc_tbl);
+    Status status = DescriptorTbl::create(_obj_pool, thrift_desc_tbl, &desc_tbl, config::vector_chunk_size);
     DCHECK(status.ok());
     return desc_tbl;
 }

--- a/be/src/util/batch_process_thread_pool.hpp
+++ b/be/src/util/batch_process_thread_pool.hpp
@@ -47,12 +47,12 @@ public:
     //     queue exceeds this size, subsequent calls to Offer will block until there is
     //     capacity available.
     //  -- work_function: the function to run every time an item is consumed from the queue
-    BatchProcessThreadPool(uint32_t num_threads, uint32_t queue_size, uint32_t batch_size,
+    BatchProcessThreadPool(uint32_t num_threads, uint32_t queue_size, uint32_t chunk_size,
         BatchProcessFunction work_func) :
             _thread_num(num_threads),
             _work_queue(queue_size),
             _shutdown(false),
-            _batch_size(batch_size),
+            _chunk_size(chunk_size),
             _work_func(work_func) {
         for (int i = 0; i < num_threads; ++i) {
             _threads.create_thread(
@@ -127,7 +127,7 @@ private:
             std::vector<T> tasks;
             T task;
             int32_t task_counter = 0;
-            while (task_counter < _batch_size) {
+            while (task_counter < _chunk_size) {
                 bool has_task = false;
                 if (task_counter == 0) {
                     // the first task should blocking, or the tasks queue is empty
@@ -177,7 +177,7 @@ private:
     // Signalled when the queue becomes empty
     std::condition_variable _empty_cv;
 
-    uint32_t _batch_size;
+    uint32_t _chunk_size;
 
     BatchProcessFunction _work_func;
 };

--- a/be/test/column/column_pool_test.cpp
+++ b/be/test/column/column_pool_test.cpp
@@ -40,7 +40,7 @@ TEST_F(ColumnPoolTest, single_thread) {
     c1->append_datum(Datum((int32_t)1));
     c1->append_datum(Datum((int32_t)2));
     c1->set_delete_state(DEL_PARTIAL_SATISFIED);
-    return_column<Int32Column>(c1);
+    return_column<Int32Column>(c1, config::vector_chunk_size);
 
     auto c2 = get_column<Int32Column>();
     ASSERT_EQ(c1, c2);
@@ -60,8 +60,8 @@ TEST_F(ColumnPoolTest, single_thread) {
     auto c6 = get_column<Int32Column>();
     ASSERT_NE(c5, c6);
 
-    return_column<Int32Column>(c6);
-    return_column<Int32Column>(c5);
+    return_column<Int32Column>(c6, config::vector_chunk_size);
+    return_column<Int32Column>(c5, config::vector_chunk_size);
 
     auto c7 = get_column<Int32Column>();
     auto c8 = get_column<Int32Column>();
@@ -70,8 +70,8 @@ TEST_F(ColumnPoolTest, single_thread) {
     c5 = nullptr;
     c6 = nullptr;
 
-    return_column<Int32Column>(c8);
-    return_column<Int32Column>(c7);
+    return_column<Int32Column>(c8, config::vector_chunk_size);
+    return_column<Int32Column>(c7, config::vector_chunk_size);
 
     delete c2;
     delete c3;

--- a/be/test/exec/parquet/file_reader_test.cpp
+++ b/be/test/exec/parquet/file_reader_test.cpp
@@ -329,7 +329,7 @@ HdfsFileReaderParam* FileReaderTest::_create_file2_base_param() {
     std::vector<TTupleId> row_tuples = std::vector<TTupleId>{0};
     std::vector<bool> nullable_tuples = std::vector<bool>{true};
     DescriptorTbl* tbl = nullptr;
-    DescriptorTbl::create(&_pool, table_desc_builder.desc_tbl(), &tbl);
+    DescriptorTbl::create(&_pool, table_desc_builder.desc_tbl(), &tbl, config::vector_chunk_size);
     _row_desc = std::make_shared<RowDescriptor>(*tbl, row_tuples, nullable_tuples);
     auto* tuple_desc = _row_desc->tuple_descriptors()[0];
     param->tuple_desc = tuple_desc;
@@ -398,7 +398,7 @@ HdfsFileReaderParam* FileReaderTest::_create_param_for_min_max() {
     std::vector<TTupleId> row_tuples = std::vector<TTupleId>{0};
     std::vector<bool> nullable_tuples = std::vector<bool>{true};
     DescriptorTbl* tbl = nullptr;
-    DescriptorTbl::create(&_pool, table_desc_builder.desc_tbl(), &tbl);
+    DescriptorTbl::create(&_pool, table_desc_builder.desc_tbl(), &tbl, config::vector_chunk_size);
     _row_desc = std::make_shared<RowDescriptor>(*tbl, row_tuples, nullable_tuples);
     auto* tuple_desc = _row_desc->tuple_descriptors()[0];
     param->min_max_tuple_desc = tuple_desc;
@@ -450,7 +450,7 @@ HdfsFileReaderParam* FileReaderTest::_create_param_for_filter_file() {
     std::vector<TTupleId> row_tuples = std::vector<TTupleId>{0};
     std::vector<bool> nullable_tuples = std::vector<bool>{true};
     DescriptorTbl* tbl = nullptr;
-    DescriptorTbl::create(&_pool, table_desc_builder.desc_tbl(), &tbl);
+    DescriptorTbl::create(&_pool, table_desc_builder.desc_tbl(), &tbl, config::vector_chunk_size);
     _row_desc = std::make_shared<RowDescriptor>(*tbl, row_tuples, nullable_tuples);
     auto* tuple_desc = _row_desc->tuple_descriptors()[0];
     param->tuple_desc = tuple_desc;

--- a/be/test/exec/parquet_scanner_test.cpp
+++ b/be/test/exec/parquet_scanner_test.cpp
@@ -261,7 +261,7 @@ void ParquetSannerTest::init_desc_table() {
 
     next_slot_id = create_src_tuple(t_desc_table, next_slot_id);
 
-    DescriptorTbl::create(&_obj_pool, t_desc_table, &_desc_tbl);
+    DescriptorTbl::create(&_obj_pool, t_desc_table, &_desc_tbl, config::vector_chunk_size);
 
     _runtime_state.set_desc_tbl(_desc_tbl);
 }

--- a/be/test/exec/pipeline/pipeline_control_flow_test.cpp
+++ b/be/test/exec/pipeline/pipeline_control_flow_test.cpp
@@ -4,6 +4,7 @@
 #include <random>
 
 #include "exec/pipeline/pipeline.h"
+#include "exec/pipeline/pipeline_builder.h"
 #include "pipeline_test_base.h"
 #include "util/thrift_util.h"
 
@@ -344,7 +345,7 @@ TEST_F(TestPipelineControlFlow, test_two_operatories) {
     CounterPtr sourceCounter = std::make_shared<Counter>();
     CounterPtr sinkCounter = std::make_shared<Counter>();
 
-    _pipeline_builder = [&]() {
+    _pipeline_builder = [&](RuntimeState* state) {
         OpFactories op_factories;
 
         op_factories.push_back(std::make_shared<TestSourceOperatorFactory>(
@@ -372,7 +373,7 @@ TEST_F(TestPipelineControlFlow, test_three_operatories) {
     CounterPtr normalCounter = std::make_shared<Counter>();
     CounterPtr sinkCounter = std::make_shared<Counter>();
 
-    _pipeline_builder = [&]() {
+    _pipeline_builder = [&](RuntimeState* state) {
         OpFactories op_factories;
 
         op_factories.push_back(std::make_shared<TestSourceOperatorFactory>(
@@ -409,7 +410,7 @@ TEST_F(TestPipelineControlFlow, test_multi_operators) {
             normalCounters.push_back(std::make_shared<Counter>());
         }
 
-        _pipeline_builder = [&]() {
+        _pipeline_builder = [&](RuntimeState* state) {
             OpFactories op_factories;
 
             op_factories.push_back(std::make_shared<TestSourceOperatorFactory>(
@@ -445,7 +446,7 @@ TEST_F(TestPipelineControlFlow, test_full_chunk_size) {
     CounterPtr normalCounter = std::make_shared<Counter>();
     CounterPtr sinkCounter = std::make_shared<Counter>();
 
-    _pipeline_builder = [&]() {
+    _pipeline_builder = [&](RuntimeState* state) {
         OpFactories op_factories;
 
         op_factories.push_back(std::make_shared<TestSourceOperatorFactory>(
@@ -476,7 +477,7 @@ TEST_F(TestPipelineControlFlow, test_multi_chunks) {
     CounterPtr normalCounter = std::make_shared<Counter>();
     CounterPtr sinkCounter = std::make_shared<Counter>();
 
-    _pipeline_builder = [&]() {
+    _pipeline_builder = [&](RuntimeState* state) {
         OpFactories op_factories;
 
         op_factories.push_back(std::make_shared<TestSourceOperatorFactory>(
@@ -510,7 +511,7 @@ TEST_F(TestPipelineControlFlow, test_local_exchange_operator_with_non_full_chunk
         CounterPtr normalCounter = std::make_shared<Counter>();
         CounterPtr sinkCounter = std::make_shared<Counter>();
 
-        _pipeline_builder = [&]() {
+        _pipeline_builder = [&](RuntimeState* state) {
             OpFactories op_factories;
 
             auto source_op_factory = std::make_shared<TestSourceOperatorFactory>(
@@ -562,7 +563,7 @@ TEST_F(TestPipelineControlFlow, test_local_exchange_operator_with_full_chunk) {
         CounterPtr normalCounter = std::make_shared<Counter>();
         CounterPtr sinkCounter = std::make_shared<Counter>();
 
-        _pipeline_builder = [&]() {
+        _pipeline_builder = [&](RuntimeState* state) {
             OpFactories op_factories;
 
             auto source_op_factory = std::make_shared<TestSourceOperatorFactory>(

--- a/be/test/exec/pipeline/pipeline_test_base.cpp
+++ b/be/test/exec/pipeline/pipeline_test_base.cpp
@@ -75,7 +75,7 @@ void PipelineTestBase::_prepare() {
     _fragment_future = _fragment_ctx->finish_future();
     _runtime_state = _fragment_ctx->runtime_state();
 
-    _runtime_state->set_batch_size(config::vector_chunk_size);
+    _runtime_state->set_chunk_size(config::vector_chunk_size);
     _runtime_state->init_mem_trackers(query_id);
     _runtime_state->set_be_number(_request.backend_num);
 
@@ -83,7 +83,7 @@ void PipelineTestBase::_prepare() {
 
     ASSERT_TRUE(_pipeline_builder != nullptr);
     _pipelines.clear();
-    _pipeline_builder();
+    _pipeline_builder(_fragment_ctx->runtime_state());
     _pipelines[_pipelines.size() - 1]->set_root();
     _fragment_ctx->set_pipelines(std::move(_pipelines));
     ASSERT_TRUE(_fragment_ctx->prepare_all_pipelines().ok());

--- a/be/test/exec/pipeline/pipeline_test_base.h
+++ b/be/test/exec/pipeline/pipeline_test_base.h
@@ -46,7 +46,7 @@ protected:
     virtual void _prepare_request() {}
 
     // lambda used to init _pipelines
-    std::function<void()> _pipeline_builder;
+    std::function<void(RuntimeState*)> _pipeline_builder;
     Pipelines _pipelines;
 
 private:

--- a/be/test/exec/tablet_sink_test.cpp
+++ b/be/test/exec/tablet_sink_test.cpp
@@ -292,7 +292,7 @@ public:
 TEST_F(OlapTableSinkTest, init_fail1) {
     TUniqueId fragment_id;
     TQueryOptions query_options;
-    query_options.chunk_size = 1;
+    query_options.batch_size = 1;
     RuntimeState state(fragment_id, query_options, TQueryGlobals(), _env);
     state.init_mem_trackers(TUniqueId());
 
@@ -350,7 +350,7 @@ TEST_F(OlapTableSinkTest, init_fail1) {
 TEST_F(OlapTableSinkTest, init_fail3) {
     TUniqueId fragment_id;
     TQueryOptions query_options;
-    query_options.chunk_size = 1;
+    query_options.batch_size = 1;
     RuntimeState state(fragment_id, query_options, TQueryGlobals(), _env);
     state.init_mem_trackers(TUniqueId());
 
@@ -409,7 +409,7 @@ TEST_F(OlapTableSinkTest, init_fail3) {
 TEST_F(OlapTableSinkTest, init_fail4) {
     TUniqueId fragment_id;
     TQueryOptions query_options;
-    query_options.chunk_size = 1;
+    query_options.batch_size = 1;
     RuntimeState state(fragment_id, query_options, TQueryGlobals(), _env);
     state.init_mem_trackers(TUniqueId());
 

--- a/be/test/exec/tablet_sink_test.cpp
+++ b/be/test/exec/tablet_sink_test.cpp
@@ -292,7 +292,7 @@ public:
 TEST_F(OlapTableSinkTest, init_fail1) {
     TUniqueId fragment_id;
     TQueryOptions query_options;
-    query_options.batch_size = 1;
+    query_options.chunk_size = 1;
     RuntimeState state(fragment_id, query_options, TQueryGlobals(), _env);
     state.init_mem_trackers(TUniqueId());
 
@@ -302,7 +302,7 @@ TEST_F(OlapTableSinkTest, init_fail1) {
 
     // crate desc_tabl
     DescriptorTbl* desc_tbl = nullptr;
-    auto st = DescriptorTbl::create(&obj_pool, tdesc_tbl, &desc_tbl);
+    auto st = DescriptorTbl::create(&obj_pool, tdesc_tbl, &desc_tbl, config::vector_chunk_size);
     ASSERT_TRUE(st.ok());
     state._desc_tbl = desc_tbl;
 
@@ -350,7 +350,7 @@ TEST_F(OlapTableSinkTest, init_fail1) {
 TEST_F(OlapTableSinkTest, init_fail3) {
     TUniqueId fragment_id;
     TQueryOptions query_options;
-    query_options.batch_size = 1;
+    query_options.chunk_size = 1;
     RuntimeState state(fragment_id, query_options, TQueryGlobals(), _env);
     state.init_mem_trackers(TUniqueId());
 
@@ -360,7 +360,7 @@ TEST_F(OlapTableSinkTest, init_fail3) {
 
     // crate desc_tabl
     DescriptorTbl* desc_tbl = nullptr;
-    auto st = DescriptorTbl::create(&obj_pool, tdesc_tbl, &desc_tbl);
+    auto st = DescriptorTbl::create(&obj_pool, tdesc_tbl, &desc_tbl, config::vector_chunk_size);
     ASSERT_TRUE(st.ok());
     state._desc_tbl = desc_tbl;
 
@@ -409,7 +409,7 @@ TEST_F(OlapTableSinkTest, init_fail3) {
 TEST_F(OlapTableSinkTest, init_fail4) {
     TUniqueId fragment_id;
     TQueryOptions query_options;
-    query_options.batch_size = 1;
+    query_options.chunk_size = 1;
     RuntimeState state(fragment_id, query_options, TQueryGlobals(), _env);
     state.init_mem_trackers(TUniqueId());
 
@@ -419,7 +419,7 @@ TEST_F(OlapTableSinkTest, init_fail4) {
 
     // crate desc_tabl
     DescriptorTbl* desc_tbl = nullptr;
-    auto st = DescriptorTbl::create(&obj_pool, tdesc_tbl, &desc_tbl);
+    auto st = DescriptorTbl::create(&obj_pool, tdesc_tbl, &desc_tbl, config::vector_chunk_size);
     ASSERT_TRUE(st.ok());
     state._desc_tbl = desc_tbl;
 

--- a/be/test/exec/vectorized/chunks_sorter_heapsorter_test.cpp
+++ b/be/test/exec/vectorized/chunks_sorter_heapsorter_test.cpp
@@ -45,7 +45,7 @@ struct HeapChunkSorterTest : public testing::Test {
     std::shared_ptr<RuntimeState> _create_runtime_state() {
         TUniqueId fragment_id;
         TQueryOptions query_options;
-        query_options.chunk_size = config::vector_chunk_size;
+        query_options.batch_size = config::vector_chunk_size;
         TQueryGlobals query_globals;
         auto runtime_state = std::make_shared<RuntimeState>(fragment_id, query_options, query_globals, nullptr);
         runtime_state->init_instance_mem_tracker();

--- a/be/test/exec/vectorized/chunks_sorter_test.cpp
+++ b/be/test/exec/vectorized/chunks_sorter_test.cpp
@@ -130,7 +130,7 @@ protected:
     std::shared_ptr<RuntimeState> _create_runtime_state() {
         TUniqueId fragment_id;
         TQueryOptions query_options;
-        query_options.chunk_size = config::vector_chunk_size;
+        query_options.batch_size = config::vector_chunk_size;
         TQueryGlobals query_globals;
         auto runtime_state = std::make_shared<RuntimeState>(fragment_id, query_options, query_globals, nullptr);
         runtime_state->init_instance_mem_tracker();

--- a/be/test/exec/vectorized/chunks_sorter_test.cpp
+++ b/be/test/exec/vectorized/chunks_sorter_test.cpp
@@ -7,6 +7,7 @@
 #include "exec/vectorized/chunks_sorter_full_sort.h"
 #include "exec/vectorized/chunks_sorter_topn.h"
 #include "exprs/slot_ref.h"
+#include "runtime/runtime_state.h"
 
 namespace starrocks::vectorized {
 
@@ -129,6 +130,7 @@ protected:
     std::shared_ptr<RuntimeState> _create_runtime_state() {
         TUniqueId fragment_id;
         TQueryOptions query_options;
+        query_options.chunk_size = config::vector_chunk_size;
         TQueryGlobals query_globals;
         auto runtime_state = std::make_shared<RuntimeState>(fragment_id, query_options, query_globals, nullptr);
         runtime_state->init_instance_mem_tracker();
@@ -149,7 +151,6 @@ void clear_sort_exprs(std::vector<ExprContext*>& exprs) {
 
 // NOLINTNEXTLINE
 TEST_F(ChunksSorterTest, full_sort_by_2_columns_null_first) {
-    auto runtime_state = _create_runtime_state();
     std::vector<bool> is_asc, is_null_first;
     is_asc.push_back(false); // region
     is_asc.push_back(true);  // cust_key
@@ -159,7 +160,7 @@ TEST_F(ChunksSorterTest, full_sort_by_2_columns_null_first) {
     sort_exprs.push_back(new ExprContext(_expr_region.get()));
     sort_exprs.push_back(new ExprContext(_expr_cust_key.get()));
 
-    ChunksSorterFullSort sorter(&sort_exprs, &is_asc, &is_null_first, 2);
+    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, 2);
     size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
     sorter.update(_runtime_state.get(), _chunk_1);
     sorter.update(_runtime_state.get(), _chunk_2);
@@ -199,7 +200,7 @@ TEST_F(ChunksSorterTest, full_sort_by_2_columns_null_last) {
     sort_exprs.push_back(new ExprContext(_expr_region.get()));
     sort_exprs.push_back(new ExprContext(_expr_cust_key.get()));
 
-    ChunksSorterFullSort sorter(&sort_exprs, &is_asc, &is_null_first, 2);
+    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, 2);
     size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
     sorter.update(_runtime_state.get(), _chunk_1);
     sorter.update(_runtime_state.get(), _chunk_2);
@@ -242,7 +243,7 @@ TEST_F(ChunksSorterTest, full_sort_by_3_columns) {
     sort_exprs.push_back(new ExprContext(_expr_nation.get()));
     sort_exprs.push_back(new ExprContext(_expr_cust_key.get()));
 
-    ChunksSorterFullSort sorter(&sort_exprs, &is_asc, &is_null_first, 2);
+    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, 2);
     size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
     sorter.update(_runtime_state.get(), _chunk_1);
     sorter.update(_runtime_state.get(), _chunk_2);
@@ -286,7 +287,7 @@ TEST_F(ChunksSorterTest, full_sort_by_4_columns) {
     sort_exprs.push_back(new ExprContext(_expr_nation.get()));
     sort_exprs.push_back(new ExprContext(_expr_cust_key.get()));
 
-    ChunksSorterFullSort sorter(&sort_exprs, &is_asc, &is_null_first, 2);
+    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, 2);
     size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
     sorter.update(_runtime_state.get(), _chunk_1);
     sorter.update(_runtime_state.get(), _chunk_2);
@@ -329,7 +330,7 @@ TEST_F(ChunksSorterTest, part_sort_by_3_columns_null_fisrt) {
     sort_exprs.push_back(new ExprContext(_expr_nation.get()));
     sort_exprs.push_back(new ExprContext(_expr_cust_key.get()));
 
-    ChunksSorterTopn sorter(&sort_exprs, &is_asc, &is_null_first, 2, 7, 2);
+    ChunksSorterTopn sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, 2, 7, 2);
     size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
     sorter.update(_runtime_state.get(), _chunk_1);
     sorter.update(_runtime_state.get(), _chunk_2);
@@ -371,7 +372,7 @@ TEST_F(ChunksSorterTest, part_sort_by_3_columns_null_last) {
     sort_exprs.push_back(new ExprContext(_expr_nation.get()));
     sort_exprs.push_back(new ExprContext(_expr_cust_key.get()));
 
-    ChunksSorterTopn sorter(&sort_exprs, &is_asc, &is_null_first, 7, 7, 2);
+    ChunksSorterTopn sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, 7, 7, 2);
     size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
     sorter.update(_runtime_state.get(), _chunk_1);
     sorter.update(_runtime_state.get(), _chunk_2);
@@ -397,7 +398,7 @@ TEST_F(ChunksSorterTest, part_sort_by_3_columns_null_last) {
     }
 
     // part sort with large offset
-    ChunksSorterTopn sorter2(&sort_exprs, &is_asc, &is_null_first, 100, 2, 2);
+    ChunksSorterTopn sorter2(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, 100, 2, 2);
     sorter2.update(_runtime_state.get(), _chunk_1);
     sorter2.update(_runtime_state.get(), _chunk_2);
     sorter2.update(_runtime_state.get(), _chunk_3);
@@ -423,7 +424,7 @@ TEST_F(ChunksSorterTest, order_by_with_unequal_sized_chunks) {
     sort_exprs.push_back(new ExprContext(_expr_cust_key.get()));
 
     // partial sort
-    ChunksSorterTopn full_sorter(&sort_exprs, &is_asc, &is_null_first, 1, 6, 2);
+    ChunksSorterTopn full_sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, 1, 6, 2);
     ChunkPtr chunk_1 = _chunk_1->clone_empty();
     ChunkPtr chunk_2 = _chunk_2->clone_empty();
     for (size_t i = 0; i < _chunk_1->num_columns(); ++i) {

--- a/be/test/exec/vectorized/csv_scanner_test.cpp
+++ b/be/test/exec/vectorized/csv_scanner_test.cpp
@@ -35,7 +35,7 @@ protected:
         tuple_desc_builder.build(&desc_tbl_builder);
 
         DescriptorTbl* desc_tbl = nullptr;
-        Status st = DescriptorTbl::create(&_obj_pool, desc_tbl_builder.desc_tbl(), &desc_tbl);
+        Status st = DescriptorTbl::create(&_obj_pool, desc_tbl_builder.desc_tbl(), &desc_tbl, config::vector_chunk_size);
         CHECK(st.ok()) << st.to_string();
 
         /// Init RuntimeState

--- a/be/test/exec/vectorized/hdfs_scan_node_test.cpp
+++ b/be/test/exec/vectorized/hdfs_scan_node_test.cpp
@@ -229,7 +229,7 @@ DescriptorTbl* HdfsScanNodeTest::_create_table_desc() {
     tuple_desc_builder.add_slot(slot4);
     tuple_desc_builder.build(&table_desc_builder);
     DescriptorTbl* tbl = nullptr;
-    DescriptorTbl::create(_pool, table_desc_builder.desc_tbl(), &tbl);
+    DescriptorTbl::create(_pool, table_desc_builder.desc_tbl(), &tbl, config::vector_chunk_size);
 
     THdfsPartition partition;
     std::map<int64_t, THdfsPartition> p_map;
@@ -265,7 +265,7 @@ DescriptorTbl* HdfsScanNodeTest::_create_table_desc_for_filter_partition() {
     tuple_desc_builder.add_slot(slot4);
     tuple_desc_builder.build(&table_desc_builder);
     DescriptorTbl* tbl = nullptr;
-    DescriptorTbl::create(_pool, table_desc_builder.desc_tbl(), &tbl);
+    DescriptorTbl::create(_pool, table_desc_builder.desc_tbl(), &tbl, config::vector_chunk_size);
 
     // hdfs table
     THdfsTable t_hdfs_table;

--- a/be/test/exec/vectorized/hdfs_scanner_test.cpp
+++ b/be/test/exec/vectorized/hdfs_scanner_test.cpp
@@ -161,7 +161,7 @@ TupleDescriptor* HdfsScannerTest::_create_tuple_desc(SlotDesc* descs) {
     std::vector<TTupleId> row_tuples = std::vector<TTupleId>{0};
     std::vector<bool> nullable_tuples = std::vector<bool>{true};
     DescriptorTbl* tbl = nullptr;
-    DescriptorTbl::create(&_pool, table_desc_builder.desc_tbl(), &tbl);
+    DescriptorTbl::create(&_pool, table_desc_builder.desc_tbl(), &tbl, config::vector_chunk_size);
     _row_desc = std::make_shared<RowDescriptor>(*tbl, row_tuples, nullable_tuples);
     auto* tuple_desc = _row_desc->tuple_descriptors()[0];
     return tuple_desc;

--- a/be/test/exec/vectorized/join_hash_map_test.cpp
+++ b/be/test/exec/vectorized/join_hash_map_test.cpp
@@ -502,7 +502,7 @@ void JoinHashMapTest::prepare_table_items(JoinHashTableItems* table_items, uint3
 void JoinHashMapTest::prepare_probe_state(HashTableProbeState* probe_state, uint32_t probe_row_count) {
     probe_state->probe_row_count = probe_row_count;
     probe_state->cur_probe_index = 0;
-    JoinHashMapHelper::prepare_map_index(probe_state);
+    JoinHashMapHelper::prepare_map_index(probe_state, config::vector_chunk_size);
 
     for (size_t i = 0; i < probe_row_count; i++) {
         probe_state->next[i] = 1 + 2 * config::vector_chunk_size + i;
@@ -663,7 +663,7 @@ std::shared_ptr<RowDescriptor> JoinHashMapTest::create_row_desc(const std::share
     std::vector<TTupleId> row_tuples = std::vector<TTupleId>{0, 1};
     std::vector<bool> nullable_tuples = std::vector<bool>{nullable, nullable};
     DescriptorTbl* tbl = nullptr;
-    DescriptorTbl::create(object_pool.get(), table_desc_builder->desc_tbl(), &tbl);
+    DescriptorTbl::create(object_pool.get(), table_desc_builder->desc_tbl(), &tbl, config::vector_chunk_size);
 
     return std::make_shared<RowDescriptor>(*tbl, row_tuples, nullable_tuples);
 }
@@ -674,7 +674,7 @@ std::shared_ptr<RowDescriptor> JoinHashMapTest::create_probe_desc(const std::sha
     std::vector<TTupleId> row_tuples = std::vector<TTupleId>{0};
     std::vector<bool> nullable_tuples = std::vector<bool>{nullable};
     DescriptorTbl* tbl = nullptr;
-    DescriptorTbl::create(object_pool.get(), probe_desc_builder->desc_tbl(), &tbl);
+    DescriptorTbl::create(object_pool.get(), probe_desc_builder->desc_tbl(), &tbl, config::vector_chunk_size);
 
     return std::make_shared<RowDescriptor>(*tbl, row_tuples, nullable_tuples);
 }
@@ -685,7 +685,7 @@ std::shared_ptr<RowDescriptor> JoinHashMapTest::create_build_desc(const std::sha
     std::vector<TTupleId> row_tuples = std::vector<TTupleId>{1};
     std::vector<bool> nullable_tuples = std::vector<bool>{nullable};
     DescriptorTbl* tbl = nullptr;
-    DescriptorTbl::create(object_pool.get(), build_desc_builder->desc_tbl(), &tbl);
+    DescriptorTbl::create(object_pool.get(), build_desc_builder->desc_tbl(), &tbl, config::vector_chunk_size);
 
     return std::make_shared<RowDescriptor>(*tbl, row_tuples, nullable_tuples);
 }
@@ -693,6 +693,7 @@ std::shared_ptr<RowDescriptor> JoinHashMapTest::create_build_desc(const std::sha
 std::shared_ptr<RuntimeState> JoinHashMapTest::create_runtime_state() {
     TUniqueId fragment_id;
     TQueryOptions query_options;
+    query_options.chunk_size = config::vector_chunk_size;
     TQueryGlobals query_globals;
     auto runtime_state = std::make_shared<RuntimeState>(fragment_id, query_options, query_globals, nullptr);
     runtime_state->init_instance_mem_tracker();
@@ -740,7 +741,7 @@ TEST_F(JoinHashMapTest, CalcBucketNums) {
 // NOLINTNEXTLINE
 TEST_F(JoinHashMapTest, PrepareMapIndex) {
     HashTableProbeState probe_state;
-    JoinHashMapHelper::prepare_map_index(&probe_state);
+    JoinHashMapHelper::prepare_map_index(&probe_state, config::vector_chunk_size);
 
     ASSERT_EQ(probe_state.build_index.size(), config::vector_chunk_size + 8);
     ASSERT_EQ(probe_state.probe_index.size(), config::vector_chunk_size + 8);
@@ -865,8 +866,8 @@ TEST_F(JoinHashMapTest, JoinBuildProbeFunc) {
 
     auto status = JoinBuildFunc<PrimitiveType::TYPE_INT>::prepare(nullptr, &table_items, &probe_state);
     ASSERT_TRUE(status.ok());
-    JoinBuildFunc<PrimitiveType::TYPE_INT>::construct_hash_table(&table_items, &probe_state);
-    JoinProbeFunc<PrimitiveType::TYPE_INT>::prepare(&table_items, &probe_state);
+    JoinBuildFunc<PrimitiveType::TYPE_INT>::construct_hash_table(runtime_state.get(), &table_items, &probe_state);
+    JoinProbeFunc<PrimitiveType::TYPE_INT>::prepare(runtime_state.get(), &table_items, &probe_state);
     JoinProbeFunc<PrimitiveType::TYPE_INT>::lookup_init(table_items, &probe_state);
 
     for (size_t i = 0; i < 10; i++) {
@@ -908,8 +909,8 @@ TEST_F(JoinHashMapTest, JoinBuildProbeFuncNullable) {
 
     auto status = JoinBuildFunc<TYPE_INT>::prepare(nullptr, &table_items, &probe_state);
     ASSERT_TRUE(status.ok());
-    JoinBuildFunc<TYPE_INT>::construct_hash_table(&table_items, &probe_state);
-    JoinProbeFunc<TYPE_INT>::prepare(&table_items, &probe_state);
+    JoinBuildFunc<TYPE_INT>::construct_hash_table(runtime_state.get(), &table_items, &probe_state);
+    JoinProbeFunc<TYPE_INT>::prepare(runtime_state.get(), &table_items, &probe_state);
     JoinProbeFunc<TYPE_INT>::lookup_init(table_items, &probe_state);
 
     for (size_t i = 0; i < 10; i++) {
@@ -967,9 +968,9 @@ TEST_F(JoinHashMapTest, FixedSizeJoinBuildProbeFunc) {
 
     auto status = FixedSizeJoinBuildFunc<TYPE_BIGINT>::prepare(runtime_state.get(), &table_items, &probe_state);
     ASSERT_TRUE(status.ok());
-    FixedSizeJoinBuildFunc<TYPE_BIGINT>::construct_hash_table(&table_items, &probe_state);
+    FixedSizeJoinBuildFunc<TYPE_BIGINT>::construct_hash_table(runtime_state.get(), &table_items, &probe_state);
 
-    status = FixedSizeJoinProbeFunc<TYPE_BIGINT>::prepare(&table_items, &probe_state);
+    status = FixedSizeJoinProbeFunc<TYPE_BIGINT>::prepare(runtime_state.get(), &table_items, &probe_state);
     ASSERT_TRUE(status.ok());
     FixedSizeJoinProbeFunc<TYPE_BIGINT>::lookup_init(table_items, &probe_state);
 
@@ -1024,9 +1025,9 @@ TEST_F(JoinHashMapTest, FixedSizeJoinBuildProbeFuncNullable) {
 
     auto status = FixedSizeJoinBuildFunc<TYPE_BIGINT>::prepare(runtime_state.get(), &table_items, &probe_state);
     ASSERT_TRUE(status.ok());
-    FixedSizeJoinBuildFunc<TYPE_BIGINT>::construct_hash_table(&table_items, &probe_state);
+    FixedSizeJoinBuildFunc<TYPE_BIGINT>::construct_hash_table(runtime_state.get(), &table_items, &probe_state);
 
-    status = FixedSizeJoinProbeFunc<TYPE_BIGINT>::prepare(&table_items, &probe_state);
+    status = FixedSizeJoinProbeFunc<TYPE_BIGINT>::prepare(runtime_state.get(), &table_items, &probe_state);
     ASSERT_TRUE(status.ok());
     FixedSizeJoinProbeFunc<TYPE_BIGINT>::lookup_init(table_items, &probe_state);
 
@@ -1089,8 +1090,8 @@ TEST_F(JoinHashMapTest, SerializedJoinBuildProbeFunc) {
     auto status = SerializedJoinBuildFunc::prepare(runtime_state.get(), &table_items, &probe_state);
     ASSERT_TRUE(status.ok());
 
-    SerializedJoinBuildFunc::construct_hash_table(&table_items, &probe_state);
-    SerializedJoinProbeFunc::prepare(&table_items, &probe_state);
+    SerializedJoinBuildFunc::construct_hash_table(runtime_state.get(), &table_items, &probe_state);
+    SerializedJoinProbeFunc::prepare(runtime_state.get(), &table_items, &probe_state);
     SerializedJoinProbeFunc::lookup_init(table_items, &probe_state);
 
     for (size_t i = 0; i < 10; i++) {
@@ -1150,8 +1151,8 @@ TEST_F(JoinHashMapTest, SerializedJoinBuildProbeFuncNullable) {
     auto status = SerializedJoinBuildFunc::prepare(runtime_state.get(), &table_items, &probe_state);
     ASSERT_TRUE(status.ok());
 
-    SerializedJoinBuildFunc::construct_hash_table(&table_items, &probe_state);
-    SerializedJoinProbeFunc::prepare(&table_items, &probe_state);
+    SerializedJoinBuildFunc::construct_hash_table(runtime_state.get(), &table_items, &probe_state);
+    SerializedJoinProbeFunc::prepare(runtime_state.get(), &table_items, &probe_state);
     SerializedJoinProbeFunc::lookup_init(table_items, &probe_state);
 
     Columns probe_data_columns;
@@ -1190,7 +1191,7 @@ TEST_F(JoinHashMapTest, ProbeFromHtFirstOneToOneAllMatch) {
     probe_state.next.resize(config::vector_chunk_size);
     table_items.next.resize(8193);
     table_items.join_keys.emplace_back(JoinKeyDesc{TYPE_INT, false});
-    JoinHashMapHelper::prepare_map_index(&probe_state);
+    JoinHashMapHelper::prepare_map_index(&probe_state, config::vector_chunk_size);
     auto runtime_state = create_runtime_state();
     runtime_state->init_instance_mem_tracker();
 
@@ -1211,7 +1212,7 @@ TEST_F(JoinHashMapTest, ProbeFromHtFirstOneToOneAllMatch) {
     }
 
     auto join_hash_map = std::make_unique<JoinHashMapForOneKey(TYPE_INT)>(&table_items, &probe_state);
-    join_hash_map->_probe_from_ht<true>(build_data, probe_data);
+    join_hash_map->_probe_from_ht<true>(runtime_state.get(), build_data, probe_data);
 
     ASSERT_EQ(probe_state.match_flag, JoinMatchFlag::ALL_MATCH_ONE);
     ASSERT_FALSE(probe_state.has_remain);
@@ -1233,7 +1234,7 @@ TEST_F(JoinHashMapTest, ProbeFromHtFirstOneToOneMostMatch) {
     probe_state.next.resize(config::vector_chunk_size);
     table_items.next.resize(8193);
     table_items.join_keys.emplace_back(JoinKeyDesc{TYPE_INT, false});
-    JoinHashMapHelper::prepare_map_index(&probe_state);
+    JoinHashMapHelper::prepare_map_index(&probe_state, config::vector_chunk_size);
     auto runtime_state = create_runtime_state();
     runtime_state->init_instance_mem_tracker();
 
@@ -1258,7 +1259,7 @@ TEST_F(JoinHashMapTest, ProbeFromHtFirstOneToOneMostMatch) {
     }
 
     auto join_hash_map = std::make_unique<JoinHashMapForOneKey(TYPE_INT)>(&table_items, &probe_state);
-    join_hash_map->_probe_from_ht<true>(build_data, probe_data);
+    join_hash_map->_probe_from_ht<true>(runtime_state.get(), build_data, probe_data);
 
     ASSERT_EQ(probe_state.match_flag, JoinMatchFlag::MOST_MATCH_ONE);
     ASSERT_FALSE(probe_state.has_remain);
@@ -1285,7 +1286,7 @@ TEST_F(JoinHashMapTest, ProbeFromHtFirstOneToMany) {
     probe_state.next.resize(config::vector_chunk_size);
     table_items.next.resize(8193);
     table_items.join_keys.emplace_back(JoinKeyDesc{TYPE_INT, false});
-    JoinHashMapHelper::prepare_map_index(&probe_state);
+    JoinHashMapHelper::prepare_map_index(&probe_state, config::vector_chunk_size);
     auto runtime_state = create_runtime_state();
     runtime_state->init_instance_mem_tracker();
 
@@ -1306,7 +1307,7 @@ TEST_F(JoinHashMapTest, ProbeFromHtFirstOneToMany) {
     }
 
     auto join_hash_map = std::make_unique<JoinHashMapForOneKey(TYPE_INT)>(&table_items, &probe_state);
-    join_hash_map->_probe_from_ht<true>(build_data, probe_data);
+    join_hash_map->_probe_from_ht<true>(runtime_state.get(), build_data, probe_data);
     ASSERT_EQ(probe_state.match_flag, JoinMatchFlag::NORMAL);
     ASSERT_TRUE(probe_state.has_remain);
     ASSERT_EQ(probe_state.cur_probe_index, 2048);
@@ -1321,7 +1322,7 @@ TEST_F(JoinHashMapTest, ProbeFromHtFirstOneToMany) {
     }
 
     join_hash_map = std::make_unique<JoinHashMapForOneKey(TYPE_INT)>(&table_items, &probe_state);
-    join_hash_map->_probe_from_ht<false>(build_data, probe_data);
+    join_hash_map->_probe_from_ht<false>(runtime_state.get(), build_data, probe_data);
     ASSERT_EQ(probe_state.match_flag, JoinMatchFlag::NORMAL);
     ASSERT_FALSE(probe_state.has_remain);
     ASSERT_EQ(probe_state.cur_probe_index, 0);
@@ -1345,7 +1346,7 @@ TEST_F(JoinHashMapTest, ProbeFromHtForLeftJoinFoundEmpty) {
     probe_state.next.resize(config::vector_chunk_size);
     table_items.next.resize(8193);
     table_items.join_keys.emplace_back(JoinKeyDesc{TYPE_INT, false});
-    JoinHashMapHelper::prepare_map_index(&probe_state);
+    JoinHashMapHelper::prepare_map_index(&probe_state, config::vector_chunk_size);
     auto runtime_state = create_runtime_state();
     runtime_state->init_instance_mem_tracker();
 
@@ -1369,7 +1370,7 @@ TEST_F(JoinHashMapTest, ProbeFromHtForLeftJoinFoundEmpty) {
     }
 
     auto join_hash_map = std::make_unique<JoinHashMapForOneKey(TYPE_INT)>(&table_items, &probe_state);
-    join_hash_map->_probe_from_ht_for_left_outer_join<true>(build_data, probe_data);
+    join_hash_map->_probe_from_ht_for_left_outer_join<true>(runtime_state.get(), build_data, probe_data);
     ASSERT_EQ(probe_state.match_flag, JoinMatchFlag::NORMAL);
     ASSERT_TRUE(probe_state.has_remain);
     ASSERT_EQ(probe_state.cur_probe_index, 2048);
@@ -1385,7 +1386,7 @@ TEST_F(JoinHashMapTest, ProbeFromHtForLeftJoinFoundEmpty) {
     }
 
     join_hash_map = std::make_unique<JoinHashMapForOneKey(TYPE_INT)>(&table_items, &probe_state);
-    join_hash_map->_probe_from_ht_for_left_outer_join<false>(build_data, probe_data);
+    join_hash_map->_probe_from_ht_for_left_outer_join<false>(runtime_state.get(), build_data, probe_data);
     ASSERT_EQ(probe_state.match_flag, JoinMatchFlag::NORMAL);
     ASSERT_FALSE(probe_state.has_remain);
     ASSERT_EQ(probe_state.cur_probe_index, 0);
@@ -1417,7 +1418,7 @@ TEST_F(JoinHashMapTest, ProbeFromHtForLeftJoinNextEmpty) {
     this->prepare_probe_data(&probe_data, probe_row_count);
 
     auto join_hash_map = std::make_unique<JoinHashMapForOneKey(TYPE_INT)>(&table_items, &probe_state);
-    join_hash_map->_probe_from_ht_for_left_outer_join_with_other_conjunct<true>(build_data, probe_data);
+    join_hash_map->_probe_from_ht_for_left_outer_join_with_other_conjunct<true>(_runtime_state.get(), build_data, probe_data);
 
     this->check_probe_state(table_items, probe_state, JoinMatchFlag::NORMAL, 0, match_count, probe_row_count, false);
     this->check_match_index(probe_state.probe_match_index, 0, config::vector_chunk_size, match_count);
@@ -1445,12 +1446,12 @@ TEST_F(JoinHashMapTest, ProbeFromHtForRightSemiJoinWithOtherConjunct) {
 
     // first probe
     auto join_hash_map = std::make_unique<JoinHashMapForOneKey(TYPE_INT)>(&table_items, &probe_state);
-    join_hash_map->_probe_from_ht_for_right_semi_join_with_other_conjunct<true>(build_data, probe_data);
+    join_hash_map->_probe_from_ht_for_right_semi_join_with_other_conjunct<true>(_runtime_state.get(), build_data, probe_data);
     this->check_probe_state(table_items, probe_state, JoinMatchFlag::NORMAL, 0, match_count, probe_row_count, false);
 
     // second probe
     join_hash_map = std::make_unique<JoinHashMapForOneKey(TYPE_INT)>(&table_items, &probe_state);
-    join_hash_map->_probe_from_ht_for_right_semi_join_with_other_conjunct<false>(build_data, probe_data);
+    join_hash_map->_probe_from_ht_for_right_semi_join_with_other_conjunct<false>(_runtime_state.get(), build_data, probe_data);
     this->check_probe_state(table_items, probe_state, JoinMatchFlag::NORMAL, 1, match_count, probe_row_count, false);
 }
 
@@ -1476,12 +1477,12 @@ TEST_F(JoinHashMapTest, ProbeFromHtForRightOuterJoinWithOtherConjunct) {
 
     // first probe
     auto join_hash_map = std::make_unique<JoinHashMapForOneKey(TYPE_INT)>(&table_items, &probe_state);
-    join_hash_map->_probe_from_ht_for_right_outer_join_with_other_conjunct<true>(build_data, probe_data);
+    join_hash_map->_probe_from_ht_for_right_outer_join_with_other_conjunct<true>(_runtime_state.get(), build_data, probe_data);
     this->check_probe_state(table_items, probe_state, JoinMatchFlag::NORMAL, 0, match_count, probe_row_count, false);
 
     // second probe
     join_hash_map = std::make_unique<JoinHashMapForOneKey(TYPE_INT)>(&table_items, &probe_state);
-    join_hash_map->_probe_from_ht_for_right_outer_join_with_other_conjunct<false>(build_data, probe_data);
+    join_hash_map->_probe_from_ht_for_right_outer_join_with_other_conjunct<false>(_runtime_state.get(), build_data, probe_data);
     this->check_probe_state(table_items, probe_state, JoinMatchFlag::NORMAL, 1, match_count, probe_row_count, false);
 }
 
@@ -1507,12 +1508,12 @@ TEST_F(JoinHashMapTest, ProbeFromHtForRightAntiJoinWithOtherConjunct) {
 
     // first probe
     auto join_hash_map = std::make_unique<JoinHashMapForOneKey(TYPE_INT)>(&table_items, &probe_state);
-    join_hash_map->_probe_from_ht_for_right_anti_join_with_other_conjunct<true>(build_data, probe_data);
+    join_hash_map->_probe_from_ht_for_right_anti_join_with_other_conjunct<true>(_runtime_state.get(), build_data, probe_data);
     this->check_probe_state(table_items, probe_state, JoinMatchFlag::NORMAL, 0, match_count, probe_row_count, false);
 
     // second probe
     join_hash_map = std::make_unique<JoinHashMapForOneKey(TYPE_INT)>(&table_items, &probe_state);
-    join_hash_map->_probe_from_ht_for_right_anti_join_with_other_conjunct<false>(build_data, probe_data);
+    join_hash_map->_probe_from_ht_for_right_anti_join_with_other_conjunct<false>(_runtime_state.get(), build_data, probe_data);
     this->check_probe_state(table_items, probe_state, JoinMatchFlag::NORMAL, 1, match_count, probe_row_count, false);
 }
 
@@ -1558,7 +1559,7 @@ TEST_F(JoinHashMapTest, OneKeyJoinHashTable) {
     ChunkPtr result_chunk = std::make_shared<Chunk>();
     bool eos = false;
 
-    ASSERT_TRUE(hash_table.probe(probe_key_columns, &probe_chunk, &result_chunk, &eos).ok());
+    ASSERT_TRUE(hash_table.probe(runtime_state.get(), probe_key_columns, &probe_chunk, &result_chunk, &eos).ok());
 
     ASSERT_EQ(result_chunk->num_columns(), 6);
 
@@ -1620,7 +1621,7 @@ TEST_F(JoinHashMapTest, OneNullableKeyJoinHashTable) {
     ChunkPtr result_chunk = std::make_shared<Chunk>();
     bool eos = false;
 
-    ASSERT_TRUE(hash_table.probe(probe_key_columns, &probe_chunk, &result_chunk, &eos).ok());
+    ASSERT_TRUE(hash_table.probe(runtime_state.get(), probe_key_columns, &probe_chunk, &result_chunk, &eos).ok());
 
     ASSERT_EQ(result_chunk->num_columns(), 6);
 
@@ -1686,7 +1687,7 @@ TEST_F(JoinHashMapTest, FixedSizeJoinHashTable) {
     ChunkPtr result_chunk = std::make_shared<Chunk>();
     bool eos = false;
 
-    ASSERT_TRUE(hash_table.probe(probe_key_columns, &probe_chunk, &result_chunk, &eos).ok());
+    ASSERT_TRUE(hash_table.probe(runtime_state.get(), probe_key_columns, &probe_chunk, &result_chunk, &eos).ok());
 
     ASSERT_EQ(result_chunk->num_columns(), 6);
 
@@ -1749,7 +1750,7 @@ TEST_F(JoinHashMapTest, SerializeJoinHashTable) {
     ChunkPtr result_chunk = std::make_shared<Chunk>();
     bool eos = false;
 
-    ASSERT_TRUE(hash_table.probe(probe_key_columns, &probe_chunk, &result_chunk, &eos).ok());
+    ASSERT_TRUE(hash_table.probe(runtime_state.get(), probe_key_columns, &probe_chunk, &result_chunk, &eos).ok());
 
     ASSERT_EQ(result_chunk->num_columns(), 6);
 
@@ -1796,7 +1797,7 @@ TEST_F(JoinHashMapTest, FixedSizeJoinBuildFuncForNotNullableColumn) {
     // Construct Hash Table
     Status status = FixedSizeJoinBuildFunc<TYPE_BIGINT>::prepare(_runtime_state.get(), &table_items, &probe_state);
     ASSERT_TRUE(status.ok());
-    FixedSizeJoinBuildFunc<TYPE_BIGINT>::construct_hash_table(&table_items, &probe_state);
+    FixedSizeJoinBuildFunc<TYPE_BIGINT>::construct_hash_table(_runtime_state.get(), &table_items, &probe_state);
 
     // Check
     check_build_index(table_items.first, table_items.next, build_row_count);
@@ -1832,7 +1833,7 @@ TEST_F(JoinHashMapTest, FixedSizeJoinBuildFuncForNullableColumn) {
     // Construct Hash Table
     Status status = FixedSizeJoinBuildFunc<TYPE_BIGINT>::prepare(_runtime_state.get(), &table_items, &probe_state);
     ASSERT_TRUE(status.ok());
-    FixedSizeJoinBuildFunc<TYPE_BIGINT>::construct_hash_table(&table_items, &probe_state);
+    FixedSizeJoinBuildFunc<TYPE_BIGINT>::construct_hash_table(_runtime_state.get(), &table_items, &probe_state);
 
     // Check
     check_build_index(table_items.first, table_items.next, build_row_count);
@@ -1868,7 +1869,7 @@ TEST_F(JoinHashMapTest, FixedSizeJoinBuildFuncForPartialNullableColumn) {
     // Construct Hash Table
     Status status = FixedSizeJoinBuildFunc<TYPE_BIGINT>::prepare(_runtime_state.get(), &table_items, &probe_state);
     ASSERT_TRUE(status.ok());
-    FixedSizeJoinBuildFunc<TYPE_BIGINT>::construct_hash_table(&table_items, &probe_state);
+    FixedSizeJoinBuildFunc<TYPE_BIGINT>::construct_hash_table(_runtime_state.get(), &table_items, &probe_state);
 
     // Check
     auto nulls = create_bools(build_row_count, 4);
@@ -1903,7 +1904,7 @@ TEST_F(JoinHashMapTest, SerializedJoinBuildFuncForNotNullableColumn) {
     // Construct Hash Table
     Status status = SerializedJoinBuildFunc::prepare(_runtime_state.get(), &table_items, &probe_state);
     ASSERT_TRUE(status.ok());
-    SerializedJoinBuildFunc::construct_hash_table(&table_items, &probe_state);
+    SerializedJoinBuildFunc::construct_hash_table(_runtime_state.get(), &table_items, &probe_state);
 
     // Check
     check_build_index(table_items.first, table_items.next, build_row_count);
@@ -1939,7 +1940,7 @@ TEST_F(JoinHashMapTest, SerializedJoinBuildFuncForNullableColumn) {
     // Construct Hash Table
     Status status = SerializedJoinBuildFunc::prepare(_runtime_state.get(), &table_items, &probe_state);
     ASSERT_TRUE(status.ok());
-    SerializedJoinBuildFunc::construct_hash_table(&table_items, &probe_state);
+    SerializedJoinBuildFunc::construct_hash_table(_runtime_state.get(), &table_items, &probe_state);
 
     // Check
     check_build_index(table_items.first, table_items.next, build_row_count);
@@ -1975,7 +1976,7 @@ TEST_F(JoinHashMapTest, SerializedJoinBuildFuncForPartialNullColumn) {
     // Construct Hash Table
     Status status = SerializedJoinBuildFunc::prepare(_runtime_state.get(), &table_items, &probe_state);
     ASSERT_TRUE(status.ok());
-    SerializedJoinBuildFunc::construct_hash_table(&table_items, &probe_state);
+    SerializedJoinBuildFunc::construct_hash_table(_runtime_state.get(), &table_items, &probe_state);
 
     // Check
     auto nulls = create_bools(build_row_count, 4);

--- a/be/test/exec/vectorized/join_hash_map_test.cpp
+++ b/be/test/exec/vectorized/join_hash_map_test.cpp
@@ -693,7 +693,7 @@ std::shared_ptr<RowDescriptor> JoinHashMapTest::create_build_desc(const std::sha
 std::shared_ptr<RuntimeState> JoinHashMapTest::create_runtime_state() {
     TUniqueId fragment_id;
     TQueryOptions query_options;
-    query_options.chunk_size = config::vector_chunk_size;
+    query_options.batch_size = config::vector_chunk_size;
     TQueryGlobals query_globals;
     auto runtime_state = std::make_shared<RuntimeState>(fragment_id, query_options, query_globals, nullptr);
     runtime_state->init_instance_mem_tracker();

--- a/be/test/exec/vectorized/json_scanner_test.cpp
+++ b/be/test/exec/vectorized/json_scanner_test.cpp
@@ -29,7 +29,7 @@ protected:
         tuple_desc_builder.build(&desc_tbl_builder);
 
         DescriptorTbl* desc_tbl = nullptr;
-        Status st = DescriptorTbl::create(&_pool, desc_tbl_builder.desc_tbl(), &desc_tbl);
+        Status st = DescriptorTbl::create(&_pool, desc_tbl_builder.desc_tbl(), &desc_tbl, config::vector_chunk_size);
         CHECK(st.ok()) << st.to_string();
 
         /// Init RuntimeState

--- a/be/test/exec/vectorized/orc_scanner_adapter_test.cpp
+++ b/be/test/exec/vectorized/orc_scanner_adapter_test.cpp
@@ -14,16 +14,33 @@
 #include "gutil/strings/substitute.h"
 #include "runtime/descriptor_helper.h"
 #include "runtime/descriptors.h"
+#include "runtime/runtime_state.h"
 
 namespace starrocks::vectorized {
 
 class OrcScannerAdapterTest : public testing::Test {
 public:
+    void SetUp() override {
+        _runtime_state = _create_runtime_state();
+    }
+
     OrcScannerAdapterTest();
 
 protected:
     std::vector<SlotDescriptor*> _src_slot_descs;
     ObjectPool _pool;
+
+    std::shared_ptr<RuntimeState> _create_runtime_state() {
+        TUniqueId fragment_id;
+        TQueryOptions query_options;
+        query_options.chunk_size = config::vector_chunk_size;
+        TQueryGlobals query_globals;
+        auto runtime_state = std::make_shared<RuntimeState>(fragment_id, query_options, query_globals, nullptr);
+        runtime_state->init_instance_mem_tracker();
+        return runtime_state;
+    }
+
+    std::shared_ptr<RuntimeState> _runtime_state;
 };
 
 struct SlotDesc {
@@ -43,7 +60,7 @@ void create_slot_descriptors(ObjectPool* pool, std::vector<SlotDescriptor*>* res
     }
     b3.build(&builder);
 
-    Status status = DescriptorTbl::create(pool, builder.desc_tbl(), &tbl);
+    Status status = DescriptorTbl::create(pool, builder.desc_tbl(), &tbl, config::vector_chunk_size);
     DCHECK(status.ok()) << status.get_error_msg();
     for (int i = 0; i < size; i++) {
         res->push_back(tbl->get_slot_descriptor(i));
@@ -170,7 +187,7 @@ static uint64_t get_hit_rows(OrcScannerAdapter* adapter) {
 }
 
 TEST_F(OrcScannerAdapterTest, Normal) {
-    OrcScannerAdapter adapter(_src_slot_descs);
+    OrcScannerAdapter adapter(_runtime_state.get(), _src_slot_descs);
     auto input_stream = orc::readLocalFile(input_orc_file);
     adapter.init(std::move(input_stream));
     uint64_t records = get_hit_rows(&adapter);
@@ -191,7 +208,7 @@ public:
 };
 
 TEST_F(OrcScannerAdapterTest, SkipStripe) {
-    OrcScannerAdapter adapter(_src_slot_descs);
+    OrcScannerAdapter adapter(_runtime_state.get(), _src_slot_descs);
     auto filter = std::make_shared<SkipStripeRowFilter>();
     adapter.set_row_reader_filter(filter);
 
@@ -305,7 +322,7 @@ static ExprContext* create_expr_context(ObjectPool* pool, const std::vector<TExp
 }
 
 TEST_F(OrcScannerAdapterTest, SkipFileByConjunctsEQ) {
-    OrcScannerAdapter adapter(_src_slot_descs);
+    OrcScannerAdapter adapter(_runtime_state.get(), _src_slot_descs);
 
     // lo_custkey == 0, min/max is 1,7.
     std::vector<TExprNode> nodes;
@@ -324,7 +341,7 @@ TEST_F(OrcScannerAdapterTest, SkipFileByConjunctsEQ) {
 }
 
 TEST_F(OrcScannerAdapterTest, SkipStripeByConjunctsEQ) {
-    OrcScannerAdapter adapter(_src_slot_descs);
+    OrcScannerAdapter adapter(_runtime_state.get(), _src_slot_descs);
 
     // lo_orderdate == 200000
     // stripe0 min/max = 9/199927 [5120]
@@ -350,7 +367,7 @@ TEST_F(OrcScannerAdapterTest, SkipStripeByConjunctsEQ) {
 }
 
 TEST_F(OrcScannerAdapterTest, SkipStripeByConjunctsInPred) {
-    OrcScannerAdapter adapter(_src_slot_descs);
+    OrcScannerAdapter adapter(_runtime_state.get(), _src_slot_descs);
 
     // lo_orderdate min/max = 9/200000
     std::vector<TExprNode> nodes;
@@ -401,7 +418,7 @@ private:
 };
 
 TEST_F(OrcScannerAdapterTest, SkipRowGroups) {
-    OrcScannerAdapter adapter(_src_slot_descs);
+    OrcScannerAdapter adapter(_runtime_state.get(), _src_slot_descs);
     auto filter = std::make_shared<SkipRowGroupRowFilter>();
     adapter.set_row_reader_filter(filter);
 
@@ -413,7 +430,7 @@ TEST_F(OrcScannerAdapterTest, SkipRowGroups) {
 }
 
 template <int ORC_PRECISION, int ORC_SCALE, typename ValueType>
-std::vector<DecimalV2Value> convert_orc_to_starrocks_decimalv2(ObjectPool* pool, const std::vector<ValueType>& values) {
+std::vector<DecimalV2Value> convert_orc_to_starrocks_decimalv2(RuntimeState* state, ObjectPool* pool, const std::vector<ValueType>& values) {
     std::cout << "orc precision=" << ORC_PRECISION << " scale=" << ORC_SCALE << std::endl;
     if constexpr (std::is_same_v<ValueType, int64_t>) {
         static_assert(ORC_PRECISION <= 18);
@@ -467,11 +484,11 @@ std::vector<DecimalV2Value> convert_orc_to_starrocks_decimalv2(ObjectPool* pool,
     b3.add_slot(b2.build());
     b3.build(&builder);
 
-    Status status = DescriptorTbl::create(pool, builder.desc_tbl(), &tbl);
+    Status status = DescriptorTbl::create(pool, builder.desc_tbl(), &tbl, config::vector_chunk_size);
     DCHECK(status.ok()) << status.get_error_msg();
     slots.push_back(tbl->get_slot_descriptor(0));
 
-    OrcScannerAdapter adapter(slots);
+    OrcScannerAdapter adapter(state, slots);
     adapter.init(std::move(reader));
     Status st = adapter.read_next();
     CHECK(st.ok()) << st.to_string();
@@ -529,7 +546,7 @@ TEST_F(OrcScannerAdapterTest, TestDecimal64) {
                 "1",
                 "999999999",
         };
-        auto real = convert_orc_to_starrocks_decimalv2<18, 9>(&pool, orc_values);
+        auto real = convert_orc_to_starrocks_decimalv2<18, 9>(_runtime_state.get(), &pool, orc_values);
         check_results(exp, real);
     }
     {
@@ -538,7 +555,7 @@ TEST_F(OrcScannerAdapterTest, TestDecimal64) {
                 "-9.99999999", "-9999999999.99999999", "9.99999999",  "9999999999.99999999", "10",
                 "9999999990",
         };
-        auto real = convert_orc_to_starrocks_decimalv2<18, 8>(&pool, orc_values);
+        auto real = convert_orc_to_starrocks_decimalv2<18, 8>(_runtime_state.get(), &pool, orc_values);
         check_results(exp, real);
     }
     {
@@ -555,7 +572,7 @@ TEST_F(OrcScannerAdapterTest, TestDecimal64) {
                 "100",
                 "99999999900",
         };
-        auto real = convert_orc_to_starrocks_decimalv2<18, 7>(&pool, orc_values);
+        auto real = convert_orc_to_starrocks_decimalv2<18, 7>(_runtime_state.get(), &pool, orc_values);
         check_results(exp, real);
     }
     {
@@ -572,7 +589,7 @@ TEST_F(OrcScannerAdapterTest, TestDecimal64) {
                 "1000000000",
                 "999999999000000000",
         };
-        auto real = convert_orc_to_starrocks_decimalv2<18, 0>(&pool, orc_values);
+        auto real = convert_orc_to_starrocks_decimalv2<18, 0>(_runtime_state.get(), &pool, orc_values);
         check_results(exp, real);
     }
     {
@@ -589,7 +606,7 @@ TEST_F(OrcScannerAdapterTest, TestDecimal64) {
                 "0.1",
                 "99999999.9",
         };
-        auto real = convert_orc_to_starrocks_decimalv2<18, 10>(&pool, orc_values);
+        auto real = convert_orc_to_starrocks_decimalv2<18, 10>(_runtime_state.get(), &pool, orc_values);
         check_results(exp, real);
     }
     {
@@ -606,7 +623,7 @@ TEST_F(OrcScannerAdapterTest, TestDecimal64) {
                 "0.01",
                 "9999999.99",
         };
-        auto real = convert_orc_to_starrocks_decimalv2<18, 11>(&pool, orc_values);
+        auto real = convert_orc_to_starrocks_decimalv2<18, 11>(_runtime_state.get(), &pool, orc_values);
         check_results(exp, real);
     }
     {
@@ -614,7 +631,7 @@ TEST_F(OrcScannerAdapterTest, TestDecimal64) {
                 "0",           "0",           "0",          "0",          "0.00000123", "-0.000000009", "-9.999999999",
                 "0.000000009", "9.999999999", "0.00000001", "9.99999999",
         };
-        auto real = convert_orc_to_starrocks_decimalv2<18, 17>(&pool, orc_values);
+        auto real = convert_orc_to_starrocks_decimalv2<18, 17>(_runtime_state.get(), &pool, orc_values);
         check_results(exp, real);
     }
 }
@@ -658,7 +675,7 @@ TEST_F(OrcScannerAdapterTest, TestDecimal128) {
                 "1",
                 "999999999",
         };
-        auto real = convert_orc_to_starrocks_decimalv2<27, 9>(&pool, orc_values);
+        auto real = convert_orc_to_starrocks_decimalv2<27, 9>(_runtime_state.get(), &pool, orc_values);
         check_results(exp, real);
     }
     {
@@ -675,7 +692,7 @@ TEST_F(OrcScannerAdapterTest, TestDecimal128) {
                 "10",
                 "9999999990",
         };
-        auto real = convert_orc_to_starrocks_decimalv2<27, 8>(&pool, orc_values);
+        auto real = convert_orc_to_starrocks_decimalv2<27, 8>(_runtime_state.get(), &pool, orc_values);
         check_results(exp, real);
     }
     {
@@ -692,7 +709,7 @@ TEST_F(OrcScannerAdapterTest, TestDecimal128) {
                 "100",
                 "99999999900",
         };
-        auto real = convert_orc_to_starrocks_decimalv2<27, 7>(&pool, orc_values);
+        auto real = convert_orc_to_starrocks_decimalv2<27, 7>(_runtime_state.get(), &pool, orc_values);
         check_results(exp, real);
     }
     {
@@ -709,7 +726,7 @@ TEST_F(OrcScannerAdapterTest, TestDecimal128) {
                 "1000000000",
                 "999999999000000000",
         };
-        auto real = convert_orc_to_starrocks_decimalv2<27, 0>(&pool, orc_values);
+        auto real = convert_orc_to_starrocks_decimalv2<27, 0>(_runtime_state.get(), &pool, orc_values);
         check_results(exp, real);
     }
     {
@@ -726,7 +743,7 @@ TEST_F(OrcScannerAdapterTest, TestDecimal128) {
                 "0.1",
                 "99999999.9",
         };
-        auto real = convert_orc_to_starrocks_decimalv2<27, 10>(&pool, orc_values);
+        auto real = convert_orc_to_starrocks_decimalv2<27, 10>(_runtime_state.get(), &pool, orc_values);
         check_results(exp, real);
     }
     {
@@ -743,19 +760,19 @@ TEST_F(OrcScannerAdapterTest, TestDecimal128) {
                 "0.01",
                 "9999999.99",
         };
-        auto real = convert_orc_to_starrocks_decimalv2<27, 11>(&pool, orc_values);
+        auto real = convert_orc_to_starrocks_decimalv2<27, 11>(_runtime_state.get(), &pool, orc_values);
         check_results(exp, real);
     }
     {
         std::vector<const char*> exp = {
                 "0", "0", "0", "0", "0", "0", "-9.999999999", "0", "9.999999999", "0", "0.000000009",
         };
-        auto real = convert_orc_to_starrocks_decimalv2<27, 26>(&pool, orc_values);
+        auto real = convert_orc_to_starrocks_decimalv2<27, 26>(_runtime_state.get(), &pool, orc_values);
         check_results(exp, real);
     }
 }
 
-std::vector<TimestampValue> convert_orc_to_starrocks_timestamp(ObjectPool* pool, const std::string& reader_tz,
+std::vector<TimestampValue> convert_orc_to_starrocks_timestamp(RuntimeState* state, ObjectPool* pool, const std::string& reader_tz,
                                                                const std::string& write_tz,
                                                                const std::vector<int64_t>& values) {
     const char* filename = "orc_scanner_test_timestamp.orc";
@@ -796,11 +813,11 @@ std::vector<TimestampValue> convert_orc_to_starrocks_timestamp(ObjectPool* pool,
     b3.add_slot(b2.build());
     b3.build(&builder);
 
-    Status status = DescriptorTbl::create(pool, builder.desc_tbl(), &tbl);
+    Status status = DescriptorTbl::create(pool, builder.desc_tbl(), &tbl, config::vector_chunk_size);
     DCHECK(status.ok()) << status.get_error_msg();
     slots.push_back(tbl->get_slot_descriptor(0));
 
-    OrcScannerAdapter adapter(slots);
+    OrcScannerAdapter adapter(state, slots);
     adapter.set_timezone(reader_tz);
     adapter.init(std::move(reader));
     Status st = adapter.read_next();
@@ -846,7 +863,7 @@ TEST_F(OrcScannerAdapterTest, TestTimestamp) {
     };
     // clang-format on
     ObjectPool pool;
-    auto res = convert_orc_to_starrocks_timestamp(&pool, "Asia/Shanghai", "UTC", orc_values);
+    auto res = convert_orc_to_starrocks_timestamp(_runtime_state.get(), &pool, "Asia/Shanghai", "UTC", orc_values);
     EXPECT_EQ(res.size(), orc_values.size());
     for (size_t i = 0; i < res.size(); i++) {
         std::string o = res[i].to_string();
@@ -892,7 +909,7 @@ TEST_F(OrcScannerAdapterTest, TestReadPositionalColumn) {
     create_slot_descriptors(&pool, &src_slot_descriptors, slot_descs, n);
 
     {
-        OrcScannerAdapter adapter(src_slot_descriptors);
+        OrcScannerAdapter adapter(_runtime_state.get(), src_slot_descriptors);
         auto input_stream = orc::readLocalFile(input_orc_file);
         Status st = adapter.init(std::move(input_stream));
         DCHECK(st.ok()) << st.get_error_msg();
@@ -919,7 +936,7 @@ TEST_F(OrcScannerAdapterTest, TestReadPositionalColumn) {
     }
 
     {
-        OrcScannerAdapter adapter(src_slot_descriptors);
+        OrcScannerAdapter adapter(_runtime_state.get(), src_slot_descriptors);
         std::vector<std::string> hive_column_names = {"mm", "b", "a", "c"};
         adapter.set_hive_column_names(&hive_column_names);
         auto input_stream = orc::readLocalFile(input_orc_file);
@@ -994,7 +1011,7 @@ TEST_F(OrcScannerAdapterTest, TestReadArrayBasic) {
     create_slot_descriptors(&pool, &src_slot_descriptors, slot_descs, n);
 
     {
-        OrcScannerAdapter adapter(src_slot_descriptors);
+        OrcScannerAdapter adapter(_runtime_state.get(), src_slot_descriptors);
         auto input_stream = orc::readLocalFile(input_orc_file);
         Status st = adapter.init(std::move(input_stream));
         DCHECK(st.ok()) << st.get_error_msg();
@@ -1062,7 +1079,7 @@ TEST_F(OrcScannerAdapterTest, TestReadPaddingChar) {
     create_slot_descriptors(&pool, &src_slot_descriptors, slot_descs, n);
 
     {
-        OrcScannerAdapter adapter(src_slot_descriptors);
+        OrcScannerAdapter adapter(_runtime_state.get(), src_slot_descriptors);
         auto input_stream = orc::readLocalFile(input_orc_file);
         Status st = adapter.init(std::move(input_stream));
         DCHECK(st.ok()) << st.get_error_msg();

--- a/be/test/exec/vectorized/orc_scanner_adapter_test.cpp
+++ b/be/test/exec/vectorized/orc_scanner_adapter_test.cpp
@@ -33,7 +33,7 @@ protected:
     std::shared_ptr<RuntimeState> _create_runtime_state() {
         TUniqueId fragment_id;
         TQueryOptions query_options;
-        query_options.chunk_size = config::vector_chunk_size;
+        query_options.batch_size = config::vector_chunk_size;
         TQueryGlobals query_globals;
         auto runtime_state = std::make_shared<RuntimeState>(fragment_id, query_options, query_globals, nullptr);
         runtime_state->init_instance_mem_tracker();

--- a/be/test/exec/vectorized/parquet_scanner_test.cpp
+++ b/be/test/exec/vectorized/parquet_scanner_test.cpp
@@ -65,7 +65,7 @@ class ParquetScannerTest : public ::testing::Test {
             generate_desc_tuple(dst_slot_infos, &desc_tbl_builder);
         }
         DescriptorTbl* desc_tbl = nullptr;
-        DescriptorTbl::create(&_obj_pool, desc_tbl_builder.desc_tbl(), &desc_tbl);
+        DescriptorTbl::create(&_obj_pool, desc_tbl_builder.desc_tbl(), &desc_tbl, config::vector_chunk_size);
         return desc_tbl;
     }
 

--- a/be/test/exec/vectorized/repeat_node_test.cpp
+++ b/be/test/exec/vectorized/repeat_node_test.cpp
@@ -118,7 +118,7 @@ protected:
             }
         }
 
-        DescriptorTbl::create(&_obj_pool, t_desc_table, &_desc_tbl);
+        DescriptorTbl::create(&_obj_pool, t_desc_table, &_desc_tbl, config::vector_chunk_size);
 
         _runtime_state.set_desc_tbl(_desc_tbl);
 

--- a/be/test/exprs/agg/aggregate_test.cpp
+++ b/be/test/exprs/agg/aggregate_test.cpp
@@ -632,7 +632,7 @@ TEST_F(AggregateTest, test_sum_distinct) {
 
 TEST_F(AggregateTest, test_dict_merge) {
     const AggregateFunction* func = get_aggregate_function("dict_merge", TYPE_ARRAY, TYPE_VARCHAR, false);
-    ColumnBuilder<TYPE_VARCHAR> builder;
+    ColumnBuilder<TYPE_VARCHAR> builder(config::vector_chunk_size);
     builder.append(Slice("key1"));
     builder.append(Slice("key2"));
     builder.append(Slice("starrocks-1"));

--- a/be/test/exprs/vectorized/compound_predicate_test.cpp
+++ b/be/test/exprs/vectorized/compound_predicate_test.cpp
@@ -21,7 +21,6 @@ public:
         expr_node.__isset.opcode = true;
         expr_node.__isset.child_type = true;
         expr_node.type = gen_type_desc(TPrimitiveType::BOOLEAN);
-        ColumnHelper::s_all_not_null_column = NullColumn::create(1024, 0);
     }
 
 public:

--- a/be/test/exprs/vectorized/condition_expr_test.cpp
+++ b/be/test/exprs/vectorized/condition_expr_test.cpp
@@ -179,15 +179,15 @@ private:
 TEST_F(VectorizedConditionExprTest, ifExpr) {
     std::default_random_engine e;
 
-    int batch_size = 4096 - 1;
+    int chunk_size = 4096 - 1;
 
     expr_node.type = gen_type_desc(TPrimitiveType::BOOLEAN);
-    RandomValueExpr<TYPE_BOOLEAN> select_col(expr_node, batch_size, e);
+    RandomValueExpr<TYPE_BOOLEAN> select_col(expr_node, chunk_size, e);
     // Test INT32
     expr_node.type = gen_type_desc(TPrimitiveType::INT);
     auto expr0 = std::unique_ptr<Expr>(VectorizedConditionExprFactory::create_if_expr(expr_node));
-    RandomValueExpr<TYPE_INT> col1(expr_node, batch_size, e);
-    RandomValueExpr<TYPE_INT> col2(expr_node, batch_size, e);
+    RandomValueExpr<TYPE_INT> col1(expr_node, chunk_size, e);
+    RandomValueExpr<TYPE_INT> col2(expr_node, chunk_size, e);
 
     expr0->_children.push_back(&select_col);
     expr0->_children.push_back(&col1);
@@ -203,8 +203,8 @@ TEST_F(VectorizedConditionExprTest, ifExpr) {
     // Test FLOAT
     expr_node.type = gen_type_desc(TPrimitiveType::FLOAT);
     auto expr1 = std::unique_ptr<Expr>(VectorizedConditionExprFactory::create_if_expr(expr_node));
-    RandomValueExpr<TYPE_FLOAT> col3(expr_node, batch_size, e);
-    RandomValueExpr<TYPE_FLOAT> col4(expr_node, batch_size, e);
+    RandomValueExpr<TYPE_FLOAT> col3(expr_node, chunk_size, e);
+    RandomValueExpr<TYPE_FLOAT> col4(expr_node, chunk_size, e);
     expr1->_children.push_back(&select_col);
     expr1->_children.push_back(&col3);
     expr1->_children.push_back(&col4);
@@ -219,8 +219,8 @@ TEST_F(VectorizedConditionExprTest, ifExpr) {
     // Test INT8
     expr_node.type = gen_type_desc(TPrimitiveType::TINYINT);
     auto expr2 = std::unique_ptr<Expr>(VectorizedConditionExprFactory::create_if_expr(expr_node));
-    RandomValueExpr<TYPE_TINYINT> col5(expr_node, batch_size, e);
-    RandomValueExpr<TYPE_TINYINT> col6(expr_node, batch_size, e);
+    RandomValueExpr<TYPE_TINYINT> col5(expr_node, chunk_size, e);
+    RandomValueExpr<TYPE_TINYINT> col6(expr_node, chunk_size, e);
     expr2->_children.push_back(&select_col);
     expr2->_children.push_back(&col5);
     expr2->_children.push_back(&col6);
@@ -234,7 +234,7 @@ TEST_F(VectorizedConditionExprTest, ifExpr) {
 
     // Test INT8 var const
     auto expr3 = std::unique_ptr<Expr>(VectorizedConditionExprFactory::create_if_expr(expr_node));
-    RandomValueExpr<TYPE_TINYINT> col7(expr_node, batch_size, e);
+    RandomValueExpr<TYPE_TINYINT> col7(expr_node, chunk_size, e);
     MockConstVectorizedExpr<TYPE_TINYINT> col8(expr_node, 123);
     auto copyed_data = select_col.get_data();
     expr3->_children.push_back(&select_col);
@@ -250,7 +250,7 @@ TEST_F(VectorizedConditionExprTest, ifExpr) {
     // Test INT8 const var
     auto expr4 = std::unique_ptr<Expr>(VectorizedConditionExprFactory::create_if_expr(expr_node));
     MockConstVectorizedExpr<TYPE_TINYINT> col9(expr_node, 123);
-    RandomValueExpr<TYPE_TINYINT> col10(expr_node, batch_size, e);
+    RandomValueExpr<TYPE_TINYINT> col10(expr_node, chunk_size, e);
     copyed_data = select_col.get_data();
     expr4->_children.push_back(&select_col);
     expr4->_children.push_back(&col9);
@@ -268,8 +268,8 @@ TEST_F(VectorizedConditionExprTest, ifExpr) {
     {
         expr_node.type = gen_type_desc(TPrimitiveType::TINYINT);
         auto if_expr = std::unique_ptr<Expr>(VectorizedConditionExprFactory::create_if_expr(expr_node));
-        RandomValueExpr<TYPE_TINYINT> v_col(expr_node, batch_size, e);
-        MakeNullableExpr<TYPE_TINYINT> col_x(expr_node, batch_size, &v_col);
+        RandomValueExpr<TYPE_TINYINT> v_col(expr_node, chunk_size, e);
+        MakeNullableExpr<TYPE_TINYINT> col_x(expr_node, chunk_size, &v_col);
         MockConstVectorizedExpr<TYPE_TINYINT> col_y(expr_node, 123);
 
         if_expr->_children.push_back(&select_col);
@@ -293,7 +293,7 @@ TEST_F(VectorizedConditionExprTest, ifExpr) {
     {
         expr_node.type = gen_type_desc(TPrimitiveType::TINYINT);
         auto if_expr = std::unique_ptr<Expr>(VectorizedConditionExprFactory::create_if_expr(expr_node));
-        MakeNullableExpr<TYPE_TINYINT> nullable_selector(expr_node, batch_size, &select_col);
+        MakeNullableExpr<TYPE_TINYINT> nullable_selector(expr_node, chunk_size, &select_col);
         MockConstVectorizedExpr<TYPE_TINYINT> col_x(expr_node, 123);
         MockConstVectorizedExpr<TYPE_TINYINT> col_y(expr_node, 4);
 

--- a/be/test/exprs/vectorized/string_fn_substr_test.cpp
+++ b/be/test/exprs/vectorized/string_fn_substr_test.cpp
@@ -337,7 +337,7 @@ TEST_F(StringFunctionSubstrTest, substringNullTest) {
     pos->append(5);
     len->append(2);
 
-    ColumnBuilder<TYPE_VARCHAR> b;
+    ColumnBuilder<TYPE_VARCHAR> b(config::vector_chunk_size);
 
     for (int j = 0; j < 20; ++j) {
         b.append("test" + std::to_string(j), j % 2 == 0);

--- a/be/test/exprs/vectorized/string_fn_test.cpp
+++ b/be/test/exprs/vectorized/string_fn_test.cpp
@@ -336,7 +336,7 @@ PARALLEL_TEST(VecStringFunctionsTest, substringNullTest) {
     pos->append(5);
     len->append(2);
 
-    ColumnBuilder<TYPE_VARCHAR> b;
+    ColumnBuilder<TYPE_VARCHAR> b(config::vector_chunk_size);
 
     for (int j = 0; j < 20; ++j) {
         b.append("test" + std::to_string(j), j % 2 == 0);

--- a/be/test/runtime/memory_scratch_sink_test.cpp
+++ b/be/test/runtime/memory_scratch_sink_test.cpp
@@ -115,7 +115,7 @@ void MemoryScratchSinkTest::init() {
 
 void MemoryScratchSinkTest::init_runtime_state() {
     TQueryOptions query_options;
-    query_options.batch_size = 1024;
+    query_options.chunk_size = 1024;
     TUniqueId query_id;
     query_id.lo = 10;
     query_id.hi = 100;
@@ -173,7 +173,7 @@ void MemoryScratchSinkTest::init_desc_tbl() {
     t_tuple_desc.__isset.tableId = true;
     _t_desc_table.tupleDescriptors.push_back(t_tuple_desc);
 
-    DescriptorTbl::create(&_obj_pool, _t_desc_table, &_desc_tbl);
+    DescriptorTbl::create(&_obj_pool, _t_desc_table, &_desc_tbl, config::vector_chunk_size);
 
     std::vector<TTupleId> row_tids;
     row_tids.push_back(0);
@@ -232,7 +232,7 @@ TEST_F(MemoryScratchSinkTest, work_flow_normal) {
     ASSERT_TRUE(status.ok());
 
     std::unique_ptr<MemTracker> mem_tracker(new MemTracker(-1));
-    RowBatch row_batch(scan_node._row_descriptor, _state->batch_size(), mem_tracker.get());
+    RowBatch row_batch(scan_node._row_descriptor, _state->chunk_size(), mem_tracker.get());
     bool eos = false;
 
     while (!eos) {

--- a/be/test/runtime/memory_scratch_sink_test.cpp
+++ b/be/test/runtime/memory_scratch_sink_test.cpp
@@ -115,7 +115,7 @@ void MemoryScratchSinkTest::init() {
 
 void MemoryScratchSinkTest::init_runtime_state() {
     TQueryOptions query_options;
-    query_options.chunk_size = 1024;
+    query_options.batch_size = 1024;
     TUniqueId query_id;
     query_id.lo = 10;
     query_id.hi = 100;

--- a/be/test/runtime/vectorized/sorted_chunks_merger_test.cpp
+++ b/be/test/runtime/vectorized/sorted_chunks_merger_test.cpp
@@ -8,6 +8,7 @@
 #include "column/datum_tuple.h"
 #include "exprs/expr_context.h"
 #include "exprs/slot_ref.h"
+#include "runtime/runtime_state.h"
 
 namespace starrocks::vectorized {
 
@@ -106,6 +107,8 @@ public:
         _is_null_first.push_back(true);
         _is_null_first.push_back(true);
         _is_null_first.push_back(true);
+
+        _runtime_state = _create_runtime_state();
     }
 
     void TearDown() {
@@ -122,6 +125,18 @@ protected:
     std::vector<Expr*> _exprs;
     std::vector<ExprContext*> _sort_exprs;
     std::vector<bool> _is_asc, _is_null_first;
+
+    std::shared_ptr<RuntimeState> _create_runtime_state() {
+        TUniqueId fragment_id;
+        TQueryOptions query_options;
+        query_options.chunk_size = config::vector_chunk_size;
+        TQueryGlobals query_globals;
+        auto runtime_state = std::make_shared<RuntimeState>(fragment_id, query_options, query_globals, nullptr);
+        runtime_state->init_instance_mem_tracker();
+        return runtime_state;
+    }
+
+    std::shared_ptr<RuntimeState> _runtime_state;
 };
 
 [[maybe_unused]] static void print_chunk(const ChunkPtr& chunk) {
@@ -167,7 +182,7 @@ TEST_F(SortedChunksMergerTest, one_supplier) {
     ChunkSuppliers suppliers = {supplier};
     ChunkProbeSuppliers probe_suppliers = {probe_supplier};
     ChunkHasSuppliers has_suppliers = {has_supplier};
-    SortedChunksMerger merger(false);
+    SortedChunksMerger merger(_runtime_state.get(), false);
     merger.init(suppliers, probe_suppliers, has_suppliers, &_sort_exprs, &_is_asc, &_is_null_first);
 
     bool eos = false;
@@ -214,7 +229,7 @@ TEST_F(SortedChunksMergerTest, two_suppliers) {
         has_suppliers.push_back(has_supplier);
     }
 
-    SortedChunksMerger merger(false);
+    SortedChunksMerger merger(_runtime_state.get(), false);
     merger.init(suppliers, probe_suppliers, has_suppliers, &_sort_exprs, &_is_asc, &_is_null_first);
 
     bool eos = false;
@@ -264,7 +279,7 @@ TEST_F(SortedChunksMergerTest, three_suppliers) {
         has_suppliers.push_back(has_supplier);
     }
 
-    SortedChunksMerger merger(false);
+    SortedChunksMerger merger(_runtime_state.get(), false);
     merger.init(suppliers, probe_suppliers, has_suppliers, &_sort_exprs, &_is_asc, &_is_null_first);
 
     bool eos = false;

--- a/be/test/runtime/vectorized/sorted_chunks_merger_test.cpp
+++ b/be/test/runtime/vectorized/sorted_chunks_merger_test.cpp
@@ -129,7 +129,7 @@ protected:
     std::shared_ptr<RuntimeState> _create_runtime_state() {
         TUniqueId fragment_id;
         TQueryOptions query_options;
-        query_options.chunk_size = config::vector_chunk_size;
+        query_options.batch_size = config::vector_chunk_size;
         TQueryGlobals query_globals;
         auto runtime_state = std::make_shared<RuntimeState>(fragment_id, query_options, query_globals, nullptr);
         runtime_state->init_instance_mem_tracker();

--- a/be/test/simd/simd_mulselector_test.cpp
+++ b/be/test/simd/simd_mulselector_test.cpp
@@ -63,12 +63,12 @@ bool test_function_wrapper() {
 
 template <PrimitiveType... TYPE>
 bool test_all() {
-    constexpr int batch_size = 4095;
+    constexpr int chunk_size = 4095;
 
-    return (... && test_function_wrapper<TYPE, 1, batch_size>()) &&
-           (... && test_function_wrapper<TYPE, 2, batch_size>()) &&
-           (... && test_function_wrapper<TYPE, 4, batch_size>()) &&
-           (... && test_function_wrapper<TYPE, 8, batch_size>());
+    return (... && test_function_wrapper<TYPE, 1, chunk_size>()) &&
+           (... && test_function_wrapper<TYPE, 2, chunk_size>()) &&
+           (... && test_function_wrapper<TYPE, 4, chunk_size>()) &&
+           (... && test_function_wrapper<TYPE, 8, chunk_size>());
 }
 
 PARALLEL_TEST(SIMDMultiSelectorTest, TestVarVar) {

--- a/be/test/simd/simd_selector_test.cpp
+++ b/be/test/simd/simd_selector_test.cpp
@@ -125,8 +125,8 @@ bool test_simd_select_if_wrapper() {
 
 template <PrimitiveType... TYPE>
 bool test_simd_select_if_all() {
-    constexpr int batch_size = 4095;
-    return (... && test_simd_select_if_wrapper<TYPE, batch_size>());
+    constexpr int chunk_size = 4095;
+    return (... && test_simd_select_if_wrapper<TYPE, chunk_size>());
 }
 
 PARALLEL_TEST(SIMDSelectorTest, SelectorTest) {

--- a/be/test/storage/vectorized/chunk_helper_test.cpp
+++ b/be/test/storage/vectorized/chunk_helper_test.cpp
@@ -65,7 +65,7 @@ TupleDescriptor* ChunkHelperTest::_create_tuple_desc() {
     std::vector<TTupleId> row_tuples = std::vector<TTupleId>{0};
     std::vector<bool> nullable_tuples = std::vector<bool>{true};
     DescriptorTbl* tbl = nullptr;
-    DescriptorTbl::create(&_pool, table_builder.desc_tbl(), &tbl);
+    DescriptorTbl::create(&_pool, table_builder.desc_tbl(), &tbl, config::vector_chunk_size);
 
     auto* row_desc = _pool.add(new RowDescriptor(*tbl, row_tuples, nullable_tuples));
     auto* tuple_desc = row_desc->tuple_descriptors()[0];

--- a/be/test/storage/vectorized/memtable_test.cpp
+++ b/be/test/storage/vectorized/memtable_test.cpp
@@ -141,7 +141,7 @@ static const std::vector<SlotDescriptor*>* create_tuple_desc_slots(const string&
     tuple_builder.build(&dtb);
     TDescriptorTable tdesc_tbl = dtb.desc_tbl();
     DescriptorTbl* desc_tbl = nullptr;
-    DescriptorTbl::create(&pool, tdesc_tbl, &desc_tbl);
+    DescriptorTbl::create(&pool, tdesc_tbl, &desc_tbl, config::vector_chunk_size);
     return &(desc_tbl->get_tuple_descriptor(0)->slots());
 }
 

--- a/be/test/test_main.cpp
+++ b/be/test/test_main.cpp
@@ -41,7 +41,6 @@ int main(int argc, char** argv) {
     starrocks::MemInfo::init();
     starrocks::UserFunctionCache::instance()->init(starrocks::config::user_function_dir);
 
-    starrocks::vectorized::ColumnHelper::init_static_variable();
     starrocks::vectorized::date::init_date_cache();
 
     std::vector<starrocks::StorePath> paths;

--- a/be/test/util/arrow/arrow_work_flow_test.cpp
+++ b/be/test/util/arrow/arrow_work_flow_test.cpp
@@ -91,7 +91,7 @@ void ArrowWorkFlowTest::init() {
 
 void ArrowWorkFlowTest::init_runtime_state() {
     TQueryOptions query_options;
-    query_options.batch_size = 1024;
+    query_options.chunk_size = 1024;
     TUniqueId query_id;
     query_id.lo = 10;
     query_id.hi = 100;
@@ -243,7 +243,7 @@ void ArrowWorkFlowTest::init_desc_tbl() {
     t_tuple_desc.__isset.tableId = true;
     _t_desc_table.tupleDescriptors.push_back(t_tuple_desc);
 
-    DescriptorTbl::create(&_obj_pool, _t_desc_table, &_desc_tbl);
+    DescriptorTbl::create(&_obj_pool, _t_desc_table, &_desc_tbl, config::vector_chunk_size);
 
     std::vector<TTupleId> row_tids;
     row_tids.push_back(0);

--- a/be/test/util/arrow/arrow_work_flow_test.cpp
+++ b/be/test/util/arrow/arrow_work_flow_test.cpp
@@ -91,7 +91,7 @@ void ArrowWorkFlowTest::init() {
 
 void ArrowWorkFlowTest::init_runtime_state() {
     TQueryOptions query_options;
-    query_options.chunk_size = 1024;
+    query_options.batch_size = 1024;
     TUniqueId query_id;
     query_id.lo = 10;
     query_id.hi = 100;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -73,7 +73,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String CODEGEN_LEVEL = "codegen_level";
     // mem limit can't smaller than bufferpool's default page size
     public static final int MIN_EXEC_MEM_LIMIT = 2097152;
-    public static final String CHUNK_SIZE = "chunk_size";
+    public static final String BATCH_SIZE = "batch_size";
     public static final String DISABLE_STREAMING_PREAGGREGATIONS = "disable_streaming_preaggregations";
     public static final String STREAMING_PREAGGREGATION_MODE = "streaming_preaggregation_mode";
     public static final String DISABLE_COLOCATE_JOIN = "disable_colocate_join";
@@ -278,8 +278,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = CODEGEN_LEVEL)
     private int codegenLevel = 0;
 
-    @VariableMgr.VarAttr(name = CHUNK_SIZE)
-    private int chunkSize = 4096;
+    @VariableMgr.VarAttr(name = BATCH_SIZE, alias = "chunk_size", flag = VariableMgr.INVISIBLE)
+    private int batchSize = 4096;
+    private static final int PIPELINE_BATCH_SIZE = 16384;
 
     @VariableMgr.VarAttr(name = DISABLE_STREAMING_PREAGGREGATIONS)
     private boolean disableStreamPreaggregations = false;
@@ -786,8 +787,11 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         tResult.setQuery_timeout(Math.min(Integer.MAX_VALUE / 1000, queryTimeoutS));
         tResult.setIs_report_success(isReportSucc);
         tResult.setCodegen_level(codegenLevel);
-
-        tResult.setChunk_size(chunkSize);
+        if (isEnablePipelineEngine()) {
+            tResult.setBatch_size(PIPELINE_BATCH_SIZE);
+        } else {
+            tResult.setBatch_size(batchSize);
+        }
         tResult.setDisable_stream_preaggregations(disableStreamPreaggregations);
         tResult.setLoad_mem_limit(loadMemLimit);
 
@@ -890,7 +894,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
                 collationServer = Text.readString(in);
             }
             if (Catalog.getCurrentCatalogJournalVersion() >= FeMetaVersion.VERSION_38) {
-                chunkSize = in.readInt();
+                batchSize = in.readInt();
                 disableStreamPreaggregations = in.readBoolean();
                 parallelExecInstanceNum = in.readInt();
             }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -73,7 +73,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String CODEGEN_LEVEL = "codegen_level";
     // mem limit can't smaller than bufferpool's default page size
     public static final int MIN_EXEC_MEM_LIMIT = 2097152;
-    public static final String BATCH_SIZE = "batch_size";
+    public static final String CHUNK_SIZE = "chunk_size";
     public static final String DISABLE_STREAMING_PREAGGREGATIONS = "disable_streaming_preaggregations";
     public static final String STREAMING_PREAGGREGATION_MODE = "streaming_preaggregation_mode";
     public static final String DISABLE_COLOCATE_JOIN = "disable_colocate_join";
@@ -278,8 +278,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = CODEGEN_LEVEL)
     private int codegenLevel = 0;
 
-    @VariableMgr.VarAttr(name = BATCH_SIZE)
-    private int batchSize = 4096;
+    @VariableMgr.VarAttr(name = CHUNK_SIZE)
+    private int chunkSize = 4096;
 
     @VariableMgr.VarAttr(name = DISABLE_STREAMING_PREAGGREGATIONS)
     private boolean disableStreamPreaggregations = false;
@@ -787,7 +787,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         tResult.setIs_report_success(isReportSucc);
         tResult.setCodegen_level(codegenLevel);
 
-        tResult.setBatch_size(batchSize);
+        tResult.setChunk_size(chunkSize);
         tResult.setDisable_stream_preaggregations(disableStreamPreaggregations);
         tResult.setLoad_mem_limit(loadMemLimit);
 
@@ -890,7 +890,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
                 collationServer = Text.readString(in);
             }
             if (Catalog.getCurrentCatalogJournalVersion() >= FeMetaVersion.VERSION_38) {
-                batchSize = in.readInt();
+                chunkSize = in.readInt();
                 disableStreamPreaggregations = in.readBoolean();
                 parallelExecInstanceNum = in.readInt();
             }

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -90,7 +90,7 @@ struct TQueryOptions {
   1: optional bool abort_on_error = 0
   2: optional i32 max_errors = 0
   3: optional bool disable_codegen = 1
-  4: optional i32 batch_size = 0
+  4: optional i32 chunk_size = 0
   5: optional i32 num_nodes = NUM_NODES_ALL
   6: optional i64 max_scan_range_length = 0
   7: optional i32 num_scanner_threads = 0

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -90,7 +90,7 @@ struct TQueryOptions {
   1: optional bool abort_on_error = 0
   2: optional i32 max_errors = 0
   3: optional bool disable_codegen = 1
-  4: optional i32 chunk_size = 0
+  4: optional i32 batch_size = 0
   5: optional i32 num_nodes = NUM_NODES_ALL
   6: optional i64 max_scan_range_length = 0
   7: optional i32 num_scanner_threads = 0


### PR DESCRIPTION
Use batch_size instead of config::vector_chunk_size.
This PR is consist of following changing:
- Config::vector_chunk_size in every ExecNode(Object), is instead by runtimeState->batch_size().
- Config::vector_chunk_size in context other than ExecNode, is instead by state->batch_size(), state is transfer by parameter.
- _batch_size is added to FunctionContext.
- Use actual size in ColumnBuilder, so we remove chunk_size here.
- ColumnHelper::init_static_variable is removed, so we directly construct nullcolumn instead of ColumnHelper::s_all_not_null_column.
- size_t batch_size is added to ColumnPool's return_column, So we use query's batch_size as the upper limit to reclaim unneed columns.
- Config::vector_chunk_size in exec/parquet/ and storage/ keep unchanged.
- change uts to adapt to the above modifications.
