### PR TITLE
fix compile proto file column_data_file.

### DIFF
--- a/be/src/gen_cpp/CMakeLists.txt
+++ b/be/src/gen_cpp/CMakeLists.txt
@@ -75,7 +75,6 @@ set(SRC_FILES
     ${GEN_CPP_DIR}/parquet_types.cpp
     ${GEN_CPP_DIR}/olap_common.pb.cc
     ${GEN_CPP_DIR}/olap_file.pb.cc
-    ${GEN_CPP_DIR}/column_data_file.pb.cc
     ${GEN_CPP_DIR}/data.pb.cc
     ${GEN_CPP_DIR}/descriptors.pb.cc
     ${GEN_CPP_DIR}/internal_service.pb.cc


### PR DESCRIPTION
the last PR #2526 did not remove proto in cmake file in the meanwhile, CI and me not clean the build, so do not find out the compile error.
this PR can be merged easily.