### PR TITLE
Relax string/varchar length restrictions to 1MB

### DIFF
--- a/be/src/runtime/types.h
+++ b/be/src/runtime/types.h
@@ -42,7 +42,7 @@ struct TypeDescriptor {
     PrimitiveType type{INVALID_TYPE};
     /// Only meaningful for type TYPE_CHAR/TYPE_VARCHAR/TYPE_HLL
     int len{-1};
-    static constexpr int MAX_VARCHAR_LENGTH = 65533;
+    static constexpr int MAX_VARCHAR_LENGTH = 1048576;
     static constexpr int MAX_CHAR_LENGTH = 255;
     static constexpr int MAX_CHAR_INLINE_LENGTH = 128;
 

--- a/be/src/storage/olap_define.h
+++ b/be/src/storage/olap_define.h
@@ -39,7 +39,7 @@ static const size_t OLAP_PAGE_SIZE = 65536;
 static const uint64_t OLAP_FIX_HEADER_MAGIC_NUMBER = 0;
 
 // the max length supported for varchar type
-static const uint16_t OLAP_STRING_MAX_LENGTH = 65535;
+static const uint32_t OLAP_STRING_MAX_LENGTH = 1048576;
 
 // the max bytes for stored string length
 using StringLengthType = uint16_t;

--- a/be/test/exprs/vectorized/string_fn_pad_test.cpp
+++ b/be/test/exprs/vectorized/string_fn_pad_test.cpp
@@ -124,8 +124,8 @@ TEST_F(StringFunctionPadTest, padNotConstASCIITest) {
     std::string x65531(65531, 'x');
     TestCaseArray cases = {
             {"test", 10, "123", false, "123123test", "test123123"},
-            {"test", 65536, "123", true, "", ""},
-            {"test", -65536, "123", true, "", ""},
+            {"test", OLAP_STRING_MAX_LENGTH + 1, "123", true, "", ""},
+            {"test", -OLAP_STRING_MAX_LENGTH - 1, "123", true, "", ""},
             {"test", -1, "123", true, "", ""},
             {"test", 0, "x", false, "", ""},
             {"test", 10, "", false, "test", "test"},
@@ -169,8 +169,8 @@ TEST_F(StringFunctionPadTest, padNotConstUTF8Test) {
     std::string x65531(65531, 'x');
     TestCaseArray cases = {
             {"test", 10, "123", false, "123123test", "test123123"},
-            {"test", 65536, "123", true, "", ""},
-            {"test", -65536, "123", true, "", ""},
+            {"test", OLAP_STRING_MAX_LENGTH + 1, "123", true, "", ""},
+            {"test", -OLAP_STRING_MAX_LENGTH - 1, "123", true, "", ""},
             {"test", -1, "123", true, "", ""},
             {"test", 0, "x", false, "", ""},
             {"test", 10, "", false, "test", "test"},
@@ -254,8 +254,8 @@ TEST_F(StringFunctionPadTest, padConstPadTest) {
     std::string x65531(65531, 'x');
     TestCaseArray cases = {
             {"test", 10, "123", false, "123123test", "test123123"},
-            {"test", 65536, "123", true, "", ""},
-            {"test", -65536, "123", true, "", ""},
+            {"test", OLAP_STRING_MAX_LENGTH + 1, "123", true, "", ""},
+            {"test", -OLAP_STRING_MAX_LENGTH - 1, "123", true, "", ""},
             {"test", -1, "123", true, "", ""},
             {"test", 0, "x", false, "", ""},
             {"test", 10, "", false, "test", "test"},
@@ -352,8 +352,8 @@ TEST_F(StringFunctionPadTest, padConstLenAndPadTest) {
     std::string x65531(65531, 'x');
     TestCaseArray cases = {
             {"test", 10, "123", false, "123123test", "test123123"},
-            {"test", 65536, "123", true, "", ""},
-            {"test", -65536, "123", true, "", ""},
+            {"test", OLAP_STRING_MAX_LENGTH + 1, "123", true, "", ""},
+            {"test", -OLAP_STRING_MAX_LENGTH - 1, "123", true, "", ""},
             {"test", -1, "123", true, "", ""},
             {"test", 0, "x", false, "", ""},
             {"test", 10, "", false, "test", "test"},

--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -4080,7 +4080,7 @@ type ::=
   | KW_PERCENTILE
   {: RESULT = Type.PERCENTILE; :}
   | KW_STRING
-  {: ScalarType type = ScalarType.createVarcharType(ScalarType.MAX_VARCHAR_LENGTH);
+  {: ScalarType type = ScalarType.createVarcharType(ScalarType.DEFAULT_STRING_LENGTH);
      type.setAssignedStrLenInColDefinition();
      RESULT = type;
   :}

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
@@ -53,6 +53,7 @@ public class ScalarType extends Type implements Cloneable {
     public static final int DEFAULT_PRECISION = 9;
     public static final int DEFAULT_SCALE = 0; // SQL standard
     // Longest supported VARCHAR and CHAR, chosen to match Hive.
+    public static final int DEFAULT_STRING_LENGTH = 65533;
     public static final int MAX_VARCHAR_LENGTH = 1048576;
     public static final int MAX_CHAR_LENGTH = 255;
     // HLL DEFAULT LENGTH  2^14(registers) + 1(type)

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
@@ -53,7 +53,7 @@ public class ScalarType extends Type implements Cloneable {
     public static final int DEFAULT_PRECISION = 9;
     public static final int DEFAULT_SCALE = 0; // SQL standard
     // Longest supported VARCHAR and CHAR, chosen to match Hive.
-    public static final int MAX_VARCHAR_LENGTH = 65533;
+    public static final int MAX_VARCHAR_LENGTH = 1048576;
     public static final int MAX_CHAR_LENGTH = 255;
     // HLL DEFAULT LENGTH  2^14(registers) + 1(type)
     public static final int MAX_HLL_LENGTH = 16385;

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ColumnDefTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ColumnDefTest.java
@@ -164,7 +164,7 @@ public class ColumnDefTest {
 
     @Test(expected = AnalysisException.class)
     public void testInvalidVarcharInsideArray() throws AnalysisException {
-        Type tooLongVarchar = ScalarType.createVarchar(ScalarType.MAX_VARCHAR_LENGTH + 1);
+        Type tooLongVarchar = ScalarType.createVarchar(ScalarType.DEFAULT_STRING_LENGTH + 1);
         ColumnDef column = new ColumnDef("col", new TypeDef(new ArrayType(tooLongVarchar)), false, null, true,
                 DefaultValueDef.NOT_SET, "");
         column.analyze(true);

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ColumnDefTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ColumnDefTest.java
@@ -164,7 +164,7 @@ public class ColumnDefTest {
 
     @Test(expected = AnalysisException.class)
     public void testInvalidVarcharInsideArray() throws AnalysisException {
-        Type tooLongVarchar = ScalarType.createVarchar(100000);
+        Type tooLongVarchar = ScalarType.createVarchar(1024*1024+1);
         ColumnDef column = new ColumnDef("col", new TypeDef(new ArrayType(tooLongVarchar)), false, null, true,
                 DefaultValueDef.NOT_SET, "");
         column.analyze(true);

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ColumnDefTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ColumnDefTest.java
@@ -164,7 +164,7 @@ public class ColumnDefTest {
 
     @Test(expected = AnalysisException.class)
     public void testInvalidVarcharInsideArray() throws AnalysisException {
-        Type tooLongVarchar = ScalarType.createVarchar(ScalarType.DEFAULT_STRING_LENGTH + 1);
+        Type tooLongVarchar = ScalarType.createVarchar(ScalarType.MAX_VARCHAR_LENGTH + 1);
         ColumnDef column = new ColumnDef("col", new TypeDef(new ArrayType(tooLongVarchar)), false, null, true,
                 DefaultValueDef.NOT_SET, "");
         column.analyze(true);

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ColumnDefTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ColumnDefTest.java
@@ -164,7 +164,7 @@ public class ColumnDefTest {
 
     @Test(expected = AnalysisException.class)
     public void testInvalidVarcharInsideArray() throws AnalysisException {
-        Type tooLongVarchar = ScalarType.createVarchar(1024*1024+1);
+        Type tooLongVarchar = ScalarType.createVarchar(ScalarType.MAX_VARCHAR_LENGTH + 1);
         ColumnDef column = new ColumnDef("col", new TypeDef(new ArrayType(tooLongVarchar)), false, null, true,
                 DefaultValueDef.NOT_SET, "");
         column.analyze(true);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecodeRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecodeRewriteTest.java
@@ -653,7 +653,7 @@ public class DecodeRewriteTest extends PlanTestBase {
         Assert.assertTrue(plan.contains("  1:AGGREGATE (update finalize)\n" +
                 "  |  aggregate: count[(NULL); args: BOOLEAN; result: BIGINT; args nullable: true; result nullable: false]\n" +
                 "  |  group by: [10: S_ADDRESS, INT, false]\n" +
-                "  |  having: cast([9: count, BIGINT, false] as VARCHAR(" + ScalarType.MAX_VARCHAR_LENGTH + ")) = ''"));
+                "  |  having: cast([9: count, BIGINT, false] as VARCHAR(" + ScalarType.DEFAULT_STRING_LENGTH + ")) = ''"));
         Assert.assertTrue(plan.contains("  3:Decode\n" +
                 "  |  <dict id 10> : <string id 3>\n" +
                 "  |  cardinality: 1"));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecodeRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecodeRewriteTest.java
@@ -652,7 +652,7 @@ public class DecodeRewriteTest extends PlanTestBase {
         Assert.assertTrue(plan.contains("  1:AGGREGATE (update finalize)\n" +
                 "  |  aggregate: count[(NULL); args: BOOLEAN; result: BIGINT; args nullable: true; result nullable: false]\n" +
                 "  |  group by: [10: S_ADDRESS, INT, false]\n" +
-                "  |  having: cast([9: count, BIGINT, false] as VARCHAR(65533)) = ''"));
+                "  |  having: cast([9: count, BIGINT, false] as VARCHAR(1048576)) = ''"));
         Assert.assertTrue(plan.contains("  3:Decode\n" +
                 "  |  <dict id 10> : <string id 3>\n" +
                 "  |  cardinality: 1"));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecodeRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecodeRewriteTest.java
@@ -2,6 +2,7 @@
 
 package com.starrocks.sql.plan;
 
+import com.starrocks.catalog.ScalarType;
 import com.starrocks.common.FeConstants;
 import com.starrocks.utframe.StarRocksAssert;
 import org.junit.Assert;
@@ -652,7 +653,7 @@ public class DecodeRewriteTest extends PlanTestBase {
         Assert.assertTrue(plan.contains("  1:AGGREGATE (update finalize)\n" +
                 "  |  aggregate: count[(NULL); args: BOOLEAN; result: BIGINT; args nullable: true; result nullable: false]\n" +
                 "  |  group by: [10: S_ADDRESS, INT, false]\n" +
-                "  |  having: cast([9: count, BIGINT, false] as VARCHAR(1048576)) = ''"));
+                "  |  having: cast([9: count, BIGINT, false] as VARCHAR(" + ScalarType.MAX_VARCHAR_LENGTH + ")) = ''"));
         Assert.assertTrue(plan.contains("  3:Decode\n" +
                 "  |  <dict id 10> : <string id 3>\n" +
                 "  |  cardinality: 1"));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -1261,7 +1261,7 @@ public class PlanFragmentTest extends PlanTestBase {
         Assert.assertTrue(plan.contains("|  equal join conjunct: 1: v1 = 4: v4"));
         Assert.assertTrue(plan.contains("     TABLE: t0\n"
                 + "     PREAGGREGATION: ON\n"
-                + "     PREDICATES: CAST(CAST(1: v1 AS VARCHAR(" + ScalarType.MAX_VARCHAR_LENGTH
+                + "     PREDICATES: CAST(CAST(1: v1 AS VARCHAR(" + ScalarType.DEFAULT_STRING_LENGTH
                 + ")) AS DOUBLE) = CAST(1: v1 AS DOUBLE)\n"
                 + "     partitions=0/1"));
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -1260,7 +1260,7 @@ public class PlanFragmentTest extends PlanTestBase {
         Assert.assertTrue(plan.contains("|  equal join conjunct: 1: v1 = 4: v4"));
         Assert.assertTrue(plan.contains("     TABLE: t0\n"
                 + "     PREAGGREGATION: ON\n"
-                + "     PREDICATES: CAST(CAST(1: v1 AS VARCHAR(65533)) AS DOUBLE) = CAST(1: v1 AS DOUBLE)\n"
+                + "     PREDICATES: CAST(CAST(1: v1 AS VARCHAR(1048576)) AS DOUBLE) = CAST(1: v1 AS DOUBLE)\n"
                 + "     partitions=0/1"));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -11,6 +11,7 @@ import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Replica;
+import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.Type;
@@ -1260,7 +1261,8 @@ public class PlanFragmentTest extends PlanTestBase {
         Assert.assertTrue(plan.contains("|  equal join conjunct: 1: v1 = 4: v4"));
         Assert.assertTrue(plan.contains("     TABLE: t0\n"
                 + "     PREAGGREGATION: ON\n"
-                + "     PREDICATES: CAST(CAST(1: v1 AS VARCHAR(1048576)) AS DOUBLE) = CAST(1: v1 AS DOUBLE)\n"
+                + "     PREDICATES: CAST(CAST(1: v1 AS VARCHAR(" + ScalarType.MAX_VARCHAR_LENGTH
+                + ")) AS DOUBLE) = CAST(1: v1 AS DOUBLE)\n"
                 + "     partitions=0/1"));
     }
 


### PR DESCRIPTION
Previously varchar only supported 64K. 
Now let’s release this limit to 1MB to support more scenarios. 
We need to test more to see if there will be any problems after release.