### PR TITLE
Revert "[pipeline] avoid local shuffle for scan followed by aggregate (#2357)"

### DIFF
--- a/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
@@ -6,7 +6,6 @@
 #include "exec/pipeline/aggregate/aggregate_blocking_source_operator.h"
 #include "exec/pipeline/operator.h"
 #include "exec/pipeline/pipeline_builder.h"
-#include "exec/pipeline/scan_operator.h"
 #include "exec/vectorized/aggregator.h"
 #include "runtime/current_thread.h"
 #include "simd/simd.h"
@@ -169,15 +168,10 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > AggregateBlockingNode::
     if (agg_node.need_finalize) {
         // If finalize aggregate with group by clause, then it can be paralized
         if (agg_node.__isset.grouping_exprs && !_tnode.agg_node.grouping_exprs.empty()) {
-            // The san operator followed by an aggregate operator indicates the aggregating key is the same as
-            // the bucket key of this table, so we needn't local shuffle for this case.
-            auto* source_op = operators_with_sink[0].get();
-            if (typeid(*source_op) != typeid(pipeline::ScanOperatorFactory)) {
-                std::vector<ExprContext*> group_by_expr_ctxs;
-                Expr::create_expr_trees(_pool, _tnode.agg_node.grouping_exprs, &group_by_expr_ctxs);
-                operators_with_sink =
-                        context->maybe_interpolate_local_shuffle_exchange(operators_with_sink, group_by_expr_ctxs);
-            }
+            std::vector<ExprContext*> group_by_expr_ctxs;
+            Expr::create_expr_trees(_pool, _tnode.agg_node.grouping_exprs, &group_by_expr_ctxs);
+            operators_with_sink =
+                    context->maybe_interpolate_local_shuffle_exchange(operators_with_sink, group_by_expr_ctxs);
         } else {
             operators_with_sink = context->maybe_interpolate_local_passthrough_exchange(operators_with_sink);
         }

--- a/be/src/exec/vectorized/aggregate/distinct_blocking_node.cpp
+++ b/be/src/exec/vectorized/aggregate/distinct_blocking_node.cpp
@@ -6,7 +6,6 @@
 #include "exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.h"
 #include "exec/pipeline/operator.h"
 #include "exec/pipeline/pipeline_builder.h"
-#include "exec/pipeline/scan_operator.h"
 #include "exec/vectorized/aggregator.h"
 #include "runtime/current_thread.h"
 
@@ -153,14 +152,7 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > DistinctBlockingNode::d
     // Initialize OperatorFactory's fields involving runtime filters.
     this->init_runtime_filter_for_operator(source_operator.get(), context, rc_rf_probe_collector);
 
-    // The san operator followed by an aggregate operator indicates the aggregating key is the same as
-    // the bucket key of this table, so we needn't local shuffle for this case.
-    auto* source_op = operators_with_sink[0].get();
-    if (typeid(*source_op) != typeid(pipeline::ScanOperatorFactory)) {
-        operators_with_sink =
-                context->maybe_interpolate_local_shuffle_exchange(operators_with_sink, partition_expr_ctxs);
-    }
-
+    operators_with_sink = context->maybe_interpolate_local_shuffle_exchange(operators_with_sink, partition_expr_ctxs);
     operators_with_sink.push_back(std::move(sink_operator));
     context->add_pipeline(operators_with_sink);
     // Aggregator must be used by a pair of sink and source operators,


### PR DESCRIPTION
This reverts commit 7436cafb90dc3ab4210ef2165b986f3bdfc828de.

Avoiding local shuffle between scan and aggregate requires the aggregate key only occurs in one tablet.
If the scan table has `PARTITION BY`, the bucket hash key maybe has in one tablet in every partitions.

Therefore, we cannot avoid local shuffle between scan and aggregate. On the other hand, we can use DOP adaptation (#2409) to avoid local shuffle.

