### PR TITLE
Replace OLAPStatus with Status in RowsetWriter

### DIFF
--- a/be/src/storage/memtable_flush_executor.h
+++ b/be/src/storage/memtable_flush_executor.h
@@ -25,7 +25,9 @@
 #include <memory>
 #include <vector>
 
+#include "common/status.h"
 #include "storage/olap_define.h"
+#include "util/spinlock.h"
 #include "util/threadpool.h"
 
 namespace starrocks {
@@ -58,7 +60,7 @@ std::ostream& operator<<(std::ostream& os, const FlushStatistic& stat);
 class FlushToken {
 public:
     explicit FlushToken(std::unique_ptr<ThreadPoolToken> flush_pool_token)
-            : _flush_token(std::move(flush_pool_token)), _flush_status(OLAP_SUCCESS) {}
+            : _flush_token(std::move(flush_pool_token)), _status() {}
 
     Status submit(std::unique_ptr<vectorized::MemTable> mem_table);
 
@@ -67,10 +69,21 @@ public:
     void cancel();
 
     // wait all tasks in token to be completed.
-    OLAPStatus wait();
+    Status wait();
 
     // get flush operations' statistics
     const FlushStatistic& get_stats() const { return _stats; }
+
+    Status status() const {
+        std::lock_guard l(_status_lock);
+        return _status;
+    }
+
+    void set_status(const Status& status) {
+        if (status.ok()) return;
+        std::lock_guard l(_status_lock);
+        if (_status.ok()) _status = status;
+    }
 
 private:
     friend class MemtableFlushTask;
@@ -79,9 +92,10 @@ private:
 
     std::unique_ptr<ThreadPoolToken> _flush_token;
 
+    mutable SpinLock _status_lock;
     // Records the current flush status of the tablet.
-    // Note: Once its value is set to Failed, it cannot return to SUCCESS.
-    std::atomic<OLAPStatus> _flush_status;
+    // Note: Once its value is set to Failed, it cannot return to OK.
+    Status _status;
 
     FlushStatistic _stats;
 };

--- a/be/src/storage/rowset/beta_rowset_writer.h
+++ b/be/src/storage/rowset/beta_rowset_writer.h
@@ -25,6 +25,7 @@
 #include <mutex>
 #include <vector>
 
+#include "common/statusor.h"
 #include "storage/rowset/rowset_writer.h"
 
 namespace starrocks {
@@ -40,9 +41,9 @@ public:
     explicit BetaRowsetWriter(const RowsetWriterContext& context);
     ~BetaRowsetWriter() override = default;
 
-    OLAPStatus init() override;
+    Status init() override;
 
-    RowsetSharedPtr build() override;
+    StatusOr<RowsetSharedPtr> build() override;
 
     Version version() override { return _context.version; }
     int64_t num_rows() override { return _num_rows_written; }
@@ -81,25 +82,24 @@ public:
     explicit HorizontalBetaRowsetWriter(const RowsetWriterContext& context);
     ~HorizontalBetaRowsetWriter() override;
 
-    OLAPStatus add_chunk(const vectorized::Chunk& chunk) override;
-    OLAPStatus add_chunk_with_rssid(const vectorized::Chunk& chunk, const vector<uint32_t>& rssid) override;
+    Status add_chunk(const vectorized::Chunk& chunk) override;
+    Status add_chunk_with_rssid(const vectorized::Chunk& chunk, const vector<uint32_t>& rssid) override;
 
-    OLAPStatus flush_chunk(const vectorized::Chunk& chunk) override;
-    OLAPStatus flush_chunk_with_deletes(const vectorized::Chunk& upserts, const vectorized::Column& deletes) override;
+    Status flush_chunk(const vectorized::Chunk& chunk) override;
+    Status flush_chunk_with_deletes(const vectorized::Chunk& upserts, const vectorized::Column& deletes) override;
 
     // add rowset by create hard link
-    OLAPStatus add_rowset(RowsetSharedPtr rowset) override;
-    OLAPStatus add_rowset_for_linked_schema_change(RowsetSharedPtr rowset,
-                                                   const SchemaMapping& schema_mapping) override;
+    Status add_rowset(RowsetSharedPtr rowset) override;
+    Status add_rowset_for_linked_schema_change(RowsetSharedPtr rowset, const SchemaMapping& schema_mapping) override;
 
-    OLAPStatus flush() override;
+    Status flush() override;
 
-    RowsetSharedPtr build() override;
+    StatusOr<RowsetSharedPtr> build() override;
 
 private:
-    std::unique_ptr<SegmentWriter> _create_segment_writer();
+    StatusOr<std::unique_ptr<SegmentWriter>> _create_segment_writer();
 
-    OLAPStatus _flush_segment_writer(std::unique_ptr<SegmentWriter>* segment_writer);
+    Status _flush_segment_writer(std::unique_ptr<SegmentWriter>* segment_writer);
 
     Status _final_merge();
 
@@ -112,18 +112,21 @@ public:
     explicit VerticalBetaRowsetWriter(const RowsetWriterContext& context);
     ~VerticalBetaRowsetWriter() override;
 
-    OLAPStatus add_columns(const vectorized::Chunk& chunk, const std::vector<uint32_t>& column_indexes,
-                           bool is_key) override;
-    OLAPStatus add_columns_with_rssid(const vectorized::Chunk& chunk, const std::vector<uint32_t>& column_indexes,
-                                      const std::vector<uint32_t>& rssid) override;
+    Status add_columns(const vectorized::Chunk& chunk, const std::vector<uint32_t>& column_indexes,
+                       bool is_key) override;
 
-    OLAPStatus flush_columns() override;
-    OLAPStatus final_flush() override;
+    Status add_columns_with_rssid(const vectorized::Chunk& chunk, const std::vector<uint32_t>& column_indexes,
+                                  const std::vector<uint32_t>& rssid) override;
+
+    Status flush_columns() override;
+
+    Status final_flush() override;
 
 private:
-    std::unique_ptr<SegmentWriter> _create_segment_writer(const std::vector<uint32_t>& column_indexes, bool is_key);
+    StatusOr<std::unique_ptr<SegmentWriter>> _create_segment_writer(const std::vector<uint32_t>& column_indexes,
+                                                                    bool is_key);
 
-    OLAPStatus _flush_columns(std::unique_ptr<SegmentWriter>* segment_writer);
+    Status _flush_columns(std::unique_ptr<SegmentWriter>* segment_writer);
 
     std::vector<std::unique_ptr<SegmentWriter>> _segment_writers;
     size_t _current_writer_index = 0;

--- a/be/src/storage/rowset/rowset_factory.cpp
+++ b/be/src/storage/rowset/rowset_factory.cpp
@@ -80,7 +80,7 @@ Status RowsetFactory::create_rowset_writer(const RowsetWriterContext& context, s
         DCHECK(context.writer_type == kVertical);
         *output = std::make_unique<VerticalBetaRowsetWriter>(context);
     }
-    return (*output)->init() == OLAP_SUCCESS ? Status::OK() : Status::InternalError("fail to init rowset writer");
+    return (*output)->init();
 }
 
 } // namespace starrocks

--- a/be/src/storage/rowset/vectorized/rowset_writer_adapter.h
+++ b/be/src/storage/rowset/vectorized/rowset_writer_adapter.h
@@ -21,28 +21,27 @@ public:
 
     ~RowsetWriterAdapter() override = default;
 
-    OLAPStatus init() override;
+    Status init() override;
 
-    OLAPStatus add_chunk(const vectorized::Chunk& chunk) override;
+    Status add_chunk(const vectorized::Chunk& chunk) override;
 
-    OLAPStatus add_chunk_with_rssid(const vectorized::Chunk& chunk, const vector<uint32_t>& rssid) override {
+    Status add_chunk_with_rssid(const vectorized::Chunk& chunk, const vector<uint32_t>& rssid) override {
         return _writer->add_chunk_with_rssid(chunk, rssid);
     }
 
-    OLAPStatus flush_chunk(const vectorized::Chunk& chunk) override;
+    Status flush_chunk(const vectorized::Chunk& chunk) override;
 
-    OLAPStatus flush_chunk_with_deletes(const vectorized::Chunk& upserts, const vectorized::Column& deletes) override;
+    Status flush_chunk_with_deletes(const vectorized::Chunk& upserts, const vectorized::Column& deletes) override;
 
-    OLAPStatus add_rowset(RowsetSharedPtr rowset) override { return _writer->add_rowset(rowset); }
+    Status add_rowset(RowsetSharedPtr rowset) override { return _writer->add_rowset(rowset); }
 
-    OLAPStatus add_rowset_for_linked_schema_change(RowsetSharedPtr rowset,
-                                                   const SchemaMapping& schema_mapping) override {
+    Status add_rowset_for_linked_schema_change(RowsetSharedPtr rowset, const SchemaMapping& schema_mapping) override {
         return _writer->add_rowset_for_linked_schema_change(std::move(rowset), schema_mapping);
     }
 
-    OLAPStatus flush() override { return _writer->flush(); }
+    Status flush() override { return _writer->flush(); }
 
-    RowsetSharedPtr build() override { return _writer->build(); }
+    StatusOr<RowsetSharedPtr> build() override { return _writer->build(); }
 
     Version version() override { return _writer->version(); }
 
@@ -53,14 +52,14 @@ public:
     RowsetId rowset_id() override { return _writer->rowset_id(); }
 
 private:
-    OLAPStatus _init_chunk_converter();
+    Status _init_chunk_converter();
 
     std::unique_ptr<TabletSchema> _in_schema;
     std::unique_ptr<TabletSchema> _out_schema;
     std::unique_ptr<RowsetWriter> _writer;
     std::unique_ptr<ChunkConverter> _chunk_converter;
 
-    OLAPStatus _status = OLAP_SUCCESS;
+    Status _status;
 };
 
 } // namespace starrocks::vectorized

--- a/be/src/storage/vectorized/memtable.h
+++ b/be/src/storage/vectorized/memtable.h
@@ -23,6 +23,7 @@ public:
              RowsetWriter* rowset_writer, MemTracker* mem_tracker);
 
     ~MemTable();
+
     int64_t tablet_id() const { return _tablet_id; }
 
     // the total memory used (contain tmp chunk and aggregator chunk)
@@ -35,7 +36,7 @@ public:
     // return true suggests caller should flush this memory table
     bool insert(const Chunk& chunk, const uint32_t* indexes, uint32_t from, uint32_t size);
 
-    OLAPStatus flush();
+    Status flush();
 
     Status finalize();
 

--- a/be/src/testutil/assert.h
+++ b/be/src/testutil/assert.h
@@ -1,0 +1,28 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#pragma once
+
+#define CHECK_OK(stmt)        \
+    do {                      \
+        Status st = (stmt);   \
+        CHECK(st.ok()) << st; \
+    } while (0)
+
+#define ASSERT_OK(stmt)             \
+    do {                            \
+        Status st = (stmt);         \
+        ASSERT_TRUE(st.ok()) << st; \
+    } while (0)
+
+#define EXPECT_OK(stmt)             \
+    do {                            \
+        Status st = (stmt);         \
+        EXPECT_TRUE(st.ok()) << st; \
+    } while (0)
+
+#define EXPECT_STATUS(expect, stmt)                                  \
+    do {                                                             \
+        Status exp = (expect);                                       \
+        Status real = (stmt);                                        \
+        EXPECT_EQ(exp.code(), real.code()) << exp << " vs " << real; \
+    } while (0)

--- a/be/test/env/env_broker_test.cpp
+++ b/be/test/env/env_broker_test.cpp
@@ -12,15 +12,10 @@
 #include "gen_cpp/FileBrokerService_types.h"
 #include "gen_cpp/TFileBrokerService.h"
 #include "gutil/strings/substitute.h"
+#include "testutil/assert.h"
 #include "util/thrift_client.h"
 
 namespace starrocks {
-
-#define CHECK_OK(stmt)                                \
-    do {                                              \
-        Status __status = (stmt);                     \
-        CHECK(__status.ok()) << __status.to_string(); \
-    } while (0)
 
 class MockBrokerServer {
 public:
@@ -292,12 +287,6 @@ protected:
     MockBrokerServer* _server = nullptr;
     std::vector<char> _buff;
 };
-
-#define ASSERT_OK(stmt)                             \
-    do {                                            \
-        Status __st = (stmt);                       \
-        ASSERT_TRUE(__st.ok()) << __st.to_string(); \
-    } while (0)
 
 std::string read(std::unique_ptr<SequentialFile>& f, int len) {
     std::string s(len, '\0');

--- a/be/test/env/env_memory_test.cpp
+++ b/be/test/env/env_memory_test.cpp
@@ -6,27 +6,9 @@
 #include <gtest/gtest.h>
 
 #include "gutil/strings/join.h"
+#include "testutil/assert.h"
 
 namespace starrocks {
-
-#define CHECK_OK(stmt)                                \
-    do {                                              \
-        Status __status = (stmt);                     \
-        CHECK(__status.ok()) << __status.to_string(); \
-    } while (0)
-
-#define ASSERT_OK(stmt)                                    \
-    do {                                                   \
-        Status __status = (stmt);                          \
-        ASSERT_TRUE(_status.ok()) << __status.to_string(); \
-    }
-
-#define EXPECT_STATUS(expect, stmt)                                                          \
-    do {                                                                                     \
-        Status exp = (expect);                                                               \
-        Status real = (stmt);                                                                \
-        EXPECT_EQ(exp.code(), real.code()) << exp.to_string() << " vs " << real.to_string(); \
-    } while (0)
 
 class EnvMemoryTest : public ::testing::Test {
 protected:

--- a/be/test/storage/rowset/segment_rewriter_test.cpp
+++ b/be/test/storage/rowset/segment_rewriter_test.cpp
@@ -24,13 +24,8 @@
 #include "storage/tablet_schema_helper.h"
 #include "storage/vectorized/chunk_helper.h"
 #include "storage/vectorized/chunk_iterator.h"
+#include "testutil/assert.h"
 #include "util/file_utils.h"
-
-#define ASSERT_OK(expr)                                   \
-    do {                                                  \
-        Status _status = (expr);                          \
-        ASSERT_TRUE(_status.ok()) << _status.to_string(); \
-    } while (0)
 
 namespace starrocks {
 

--- a/be/test/storage/rowset/segment_test.cpp
+++ b/be/test/storage/rowset/segment_test.cpp
@@ -42,13 +42,8 @@
 #include "storage/tablet_schema_helper.h"
 #include "storage/vectorized/chunk_helper.h"
 #include "storage/vectorized/chunk_iterator.h"
+#include "testutil/assert.h"
 #include "util/file_utils.h"
-
-#define ASSERT_OK(expr)                                   \
-    do {                                                  \
-        Status _status = (expr);                          \
-        ASSERT_TRUE(_status.ok()) << _status.to_string(); \
-    } while (0)
 
 namespace starrocks {
 

--- a/be/test/storage/rowset/zone_map_index_test.cpp
+++ b/be/test/storage/rowset/zone_map_index_test.cpp
@@ -30,15 +30,10 @@
 #include "storage/fs/file_block_manager.h"
 #include "storage/page_cache.h"
 #include "storage/tablet_schema_helper.h"
+#include "testutil/assert.h"
 #include "util/file_utils.h"
 
 namespace starrocks {
-
-#define ASSERT_OK(expr)                                   \
-    do {                                                  \
-        Status _status = (expr);                          \
-        ASSERT_TRUE(_status.ok()) << _status.to_string(); \
-    } while (0)
 
 class ColumnZoneMapTest : public testing::Test {
 protected:

--- a/be/test/storage/update_manager_test.cpp
+++ b/be/test/storage/update_manager_test.cpp
@@ -14,6 +14,7 @@
 #include "storage/rowset/vectorized/rowset_options.h"
 #include "storage/storage_engine.h"
 #include "storage/vectorized/chunk_helper.h"
+#include "testutil/assert.h"
 #include "util/file_utils.h"
 
 using namespace std;
@@ -58,11 +59,11 @@ public:
             cols[2]->append_datum(vectorized::Datum((int32_t)(keys[i] % 1000 + 2)));
         }
         if (one_delete == nullptr) {
-            EXPECT_EQ(OLAP_SUCCESS, writer->flush_chunk(*chunk));
+            CHECK_OK(writer->flush_chunk(*chunk));
         } else {
-            EXPECT_EQ(OLAP_SUCCESS, writer->flush_chunk_with_deletes(*chunk, *one_delete));
+            CHECK_OK(writer->flush_chunk_with_deletes(*chunk, *one_delete));
         }
-        return writer->build();
+        return *writer->build();
     }
 
     void create_tablet(int64_t tablet_id, int32_t schema_hash) {

--- a/be/test/storage/vectorized/base_compaction_test.cpp
+++ b/be/test/storage/vectorized/base_compaction_test.cpp
@@ -14,6 +14,7 @@
 #include "storage/vectorized/chunk_helper.h"
 #include "storage/vectorized/compaction.h"
 #include "storage/vectorized/cumulative_compaction.h"
+#include "testutil/assert.h"
 #include "util/file_utils.h"
 
 namespace starrocks::vectorized {
@@ -111,7 +112,7 @@ public:
             cols[1]->append_datum(vectorized::Datum(field_1));
             cols[2]->append_datum(vectorized::Datum(static_cast<int32_t>(10000 + i)));
         }
-        EXPECT_EQ(OLAP_SUCCESS, writer->add_chunk(*chunk));
+        CHECK_OK(writer->add_chunk(*chunk));
     }
 
     void do_compaction() {
@@ -126,7 +127,7 @@ public:
         rowset_writer_add_rows(_rowset_writer);
 
         _rowset_writer->flush();
-        RowsetSharedPtr src_rowset = _rowset_writer->build();
+        RowsetSharedPtr src_rowset = *_rowset_writer->build();
         ASSERT_TRUE(src_rowset != nullptr);
         RowsetId src_rowset_id;
         src_rowset_id.init(10000);
@@ -150,7 +151,7 @@ public:
             rowset_writer_add_rows(_rowset_writer);
 
             _rowset_writer->flush();
-            RowsetSharedPtr src_rowset = _rowset_writer->build();
+            RowsetSharedPtr src_rowset = *_rowset_writer->build();
             ASSERT_TRUE(src_rowset != nullptr);
             ASSERT_EQ(src_rowset_id, src_rowset->rowset_id());
             ASSERT_EQ(1024, src_rowset->num_rows());
@@ -171,7 +172,7 @@ public:
             rowset_writer_add_rows(_rowset_writer);
 
             _rowset_writer->flush();
-            RowsetSharedPtr src_rowset = _rowset_writer->build();
+            RowsetSharedPtr src_rowset = *_rowset_writer->build();
             ASSERT_TRUE(src_rowset != nullptr);
             ASSERT_EQ(src_rowset_id, src_rowset->rowset_id());
             ASSERT_EQ(1024, src_rowset->num_rows());
@@ -271,7 +272,7 @@ TEST_F(BaseCompactionTest, test_input_rowsets_EQ_2) {
     rowset_writer_add_rows(_rowset_writer);
 
     _rowset_writer->flush();
-    RowsetSharedPtr src_rowset = _rowset_writer->build();
+    RowsetSharedPtr src_rowset = *_rowset_writer->build();
     ASSERT_TRUE(src_rowset != nullptr);
     RowsetId src_rowset_id;
     src_rowset_id.init(10000);
@@ -295,7 +296,7 @@ TEST_F(BaseCompactionTest, test_input_rowsets_EQ_2) {
         rowset_writer_add_rows(_rowset_writer);
 
         _rowset_writer->flush();
-        RowsetSharedPtr src_rowset = _rowset_writer->build();
+        RowsetSharedPtr src_rowset = *_rowset_writer->build();
         ASSERT_TRUE(src_rowset != nullptr);
         ASSERT_EQ(src_rowset_id, src_rowset->rowset_id());
         ASSERT_EQ(1024, src_rowset->num_rows());

--- a/be/test/storage/vectorized/cumulative_compaction_test.cpp
+++ b/be/test/storage/vectorized/cumulative_compaction_test.cpp
@@ -12,6 +12,7 @@
 #include "storage/tablet_meta.h"
 #include "storage/vectorized/chunk_helper.h"
 #include "storage/vectorized/compaction.h"
+#include "testutil/assert.h"
 #include "util/file_utils.h"
 
 namespace starrocks::vectorized {
@@ -108,7 +109,7 @@ public:
             cols[1]->append_datum(vectorized::Datum(field_1));
             cols[2]->append_datum(vectorized::Datum(static_cast<int32_t>(10000 + i)));
         }
-        EXPECT_EQ(OLAP_SUCCESS, writer->add_chunk(*chunk));
+        CHECK_OK(writer->add_chunk(*chunk));
     }
 
     void do_compaction() {
@@ -123,7 +124,7 @@ public:
         rowset_writer_add_rows(_rowset_writer);
 
         _rowset_writer->flush();
-        RowsetSharedPtr src_rowset = _rowset_writer->build();
+        RowsetSharedPtr src_rowset = *_rowset_writer->build();
         ASSERT_TRUE(src_rowset != nullptr);
         RowsetId src_rowset_id;
         src_rowset_id.init(10000);
@@ -147,7 +148,7 @@ public:
             rowset_writer_add_rows(_rowset_writer);
 
             _rowset_writer->flush();
-            RowsetSharedPtr src_rowset = _rowset_writer->build();
+            RowsetSharedPtr src_rowset = *_rowset_writer->build();
             ASSERT_TRUE(src_rowset != nullptr);
             ASSERT_EQ(src_rowset_id, src_rowset->rowset_id());
             ASSERT_EQ(1024, src_rowset->num_rows());

--- a/be/test/storage/vectorized/memtable_test.cpp
+++ b/be/test/storage/vectorized/memtable_test.cpp
@@ -16,6 +16,7 @@
 #include "storage/rowset/vectorized/rowset_options.h"
 #include "storage/schema.h"
 #include "storage/vectorized/chunk_helper.h"
+#include "testutil/assert.h"
 #include "util/file_utils.h"
 
 namespace starrocks::vectorized {
@@ -233,8 +234,8 @@ TEST_F(MemTableTest, testDupKeysInsertFlushRead) {
     std::random_shuffle(indexes.begin(), indexes.end());
     _mem_table->insert(*pchunk, indexes.data(), 0, indexes.size());
     ASSERT_TRUE(_mem_table->finalize().ok());
-    ASSERT_EQ(OLAP_SUCCESS, _mem_table->flush());
-    RowsetSharedPtr rowset = _writer->build();
+    ASSERT_OK(_mem_table->flush());
+    RowsetSharedPtr rowset = *_writer->build();
     unique_ptr<Schema> read_schema = create_schema("pk int", 1);
     OlapReaderStatistics stats;
     vectorized::RowsetReadOptions rs_opts;
@@ -280,8 +281,8 @@ TEST_F(MemTableTest, testUniqKeysInsertFlushRead) {
     std::random_shuffle(indexes.begin(), indexes.end());
     _mem_table->insert(*pchunk, indexes.data(), 0, indexes.size());
     ASSERT_TRUE(_mem_table->finalize().ok());
-    ASSERT_EQ(OLAP_SUCCESS, _mem_table->flush());
-    RowsetSharedPtr rowset = _writer->build();
+    ASSERT_OK(_mem_table->flush());
+    RowsetSharedPtr rowset = *_writer->build();
     unique_ptr<Schema> read_schema = create_schema("pk int", 1);
     OlapReaderStatistics stats;
     vectorized::RowsetReadOptions rs_opts;
@@ -334,8 +335,8 @@ TEST_F(MemTableTest, testPrimaryKeysWithDeletes) {
     std::random_shuffle(indexes.begin(), indexes.end());
     _mem_table->insert(*chunk, indexes.data(), 0, indexes.size());
     ASSERT_TRUE(_mem_table->finalize().ok());
-    ASSERT_EQ(OLAP_SUCCESS, _mem_table->flush());
-    RowsetSharedPtr rowset = _writer->build();
+    ASSERT_OK(_mem_table->flush());
+    RowsetSharedPtr rowset = *_writer->build();
     EXPECT_EQ(1, rowset->rowset_meta()->get_num_delete_files());
 }
 

--- a/be/test/storage/vectorized/schema_change_test.cpp
+++ b/be/test/storage/vectorized/schema_change_test.cpp
@@ -8,6 +8,7 @@
 #include "storage/storage_engine.h"
 #include "storage/vectorized/chunk_helper.h"
 #include "storage/vectorized/convert_helper.h"
+#include "testutil/assert.h"
 #include "util/file_utils.h"
 #include "util/logging.h"
 
@@ -76,9 +77,9 @@ class SchemaChangeTest : public testing::Test {
         writer_context.version = Version(3, 3);
         std::unique_ptr<RowsetWriter> rowset_writer;
         ASSERT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &rowset_writer).ok());
-        EXPECT_EQ(OLAP_SUCCESS, rowset_writer->add_chunk(*base_chunk));
-        EXPECT_EQ(OLAP_SUCCESS, rowset_writer->flush());
-        RowsetSharedPtr new_rowset = rowset_writer->build();
+        CHECK_OK(rowset_writer->add_chunk(*base_chunk));
+        CHECK_OK(rowset_writer->flush());
+        RowsetSharedPtr new_rowset = *rowset_writer->build();
         ASSERT_TRUE(new_rowset != nullptr);
         ASSERT_TRUE(tablet->add_rowset(new_rowset, false).ok());
     }


### PR DESCRIPTION
Issue #60

By replacing OLAPStatus with Status we have a chance
to give user more precise error messages