### PR TITLE
disable column expr min/max value on zonemap filter when slot type is…

### DIFF
--- a/be/src/exec/vectorized/olap_scan_prepare.cpp
+++ b/be/src/exec/vectorized/olap_scan_prepare.cpp
@@ -803,6 +803,9 @@ void OlapScanConjunctsManager::build_column_expr_predicates() {
         const SlotDescriptor* slot_desc = slots[index];
         PrimitiveType ptype = slot_desc->type().type;
         if (!is_scalar_primitive_type(ptype)) continue;
+        // disable on float/double type because min/max value may lose precision
+        // The fix should be on storage layer, and this is just a temporary fix.
+        if (ptype == PrimitiveType::TYPE_FLOAT || ptype == PrimitiveType::TYPE_DOUBLE) continue;
         {
             auto iter = slot_index_to_expr_ctxs.find(index);
             if (iter == slot_index_to_expr_ctxs.end()) {


### PR DESCRIPTION
ref: #2543 

The root cause is min/max value in zonemap is incorrect when type is float/double. 

We should fix this problem on storage layer, but before that we just disable zonemap filtering if slot type is float/double.

Following is the desired value

![middle_img_v2_a10ba309-c1fe-44a3-b781-a8eb4088207g](https://user-images.githubusercontent.com/1081215/147810198-f397aa4a-6474-4f3a-aac0-1b61a590d1c0.png)

And following is max value read from zonemap

![middle_img_v2_3350abc8-f56f-4b7e-b3c0-bd217c15769g](https://user-images.githubusercontent.com/1081215/147810211-dfec2ed8-9ddd-42de-b55a-5d29c5ef05e5.png)


