### PR TITLE
Don't create tuple columns for join node again

### DIFF
--- a/be/src/exec/pipeline/crossjoin/cross_join_left_operator.cpp
+++ b/be/src/exec/pipeline/crossjoin/cross_join_left_operator.cpp
@@ -27,19 +27,6 @@ void CrossJoinLeftOperator::_init_chunk(vectorized::ChunkPtr* chunk, RuntimeStat
         new_chunk->append_column(std::move(new_col), slot->id());
     }
 
-    for (int tuple_id : _output_probe_tuple_ids) {
-        if (_probe_chunk->is_tuple_exist(tuple_id)) {
-            vectorized::ColumnPtr dest_col = vectorized::BooleanColumn::create();
-            new_chunk->append_tuple_column(dest_col, tuple_id);
-        }
-    }
-    for (int tuple_id : _output_build_tuple_ids) {
-        if (_curr_build_chunk->is_tuple_exist(tuple_id)) {
-            vectorized::ColumnPtr dest_col = vectorized::BooleanColumn::create();
-            new_chunk->append_tuple_column(dest_col, tuple_id);
-        }
-    }
-
     *chunk = std::move(new_chunk);
     (*chunk)->reserve(state->chunk_size());
 }
@@ -59,31 +46,6 @@ void CrossJoinLeftOperator::_copy_joined_rows_with_index_base_probe(vectorized::
         vectorized::ColumnPtr& src_col = _curr_build_chunk->get_column_by_slot_id(slot->id());
         _copy_build_rows_with_index_base_probe(dest_col, src_col, build_index, row_count);
     }
-
-    for (int tuple_id : _output_probe_tuple_ids) {
-        if (_probe_chunk->is_tuple_exist(tuple_id)) {
-            vectorized::ColumnPtr& src_col = _probe_chunk->get_tuple_column_by_id(tuple_id);
-            auto& src_data = vectorized::ColumnHelper::as_raw_column<vectorized::BooleanColumn>(src_col)->get_data();
-            vectorized::ColumnPtr& dest_col = chunk->get_tuple_column_by_id(tuple_id);
-            auto& dest_data = vectorized::ColumnHelper::as_raw_column<vectorized::BooleanColumn>(dest_col)->get_data();
-            for (size_t i = 0; i < row_count; i++) {
-                dest_data.emplace_back(src_data[probe_index]);
-            }
-        }
-    }
-
-    for (int tuple_id : _output_build_tuple_ids) {
-        if (_curr_build_chunk->is_tuple_exist(tuple_id)) {
-            vectorized::ColumnPtr& src_col = _curr_build_chunk->get_tuple_column_by_id(tuple_id);
-            auto& src_data = vectorized::ColumnHelper::as_raw_column<vectorized::BooleanColumn>(src_col)->get_data();
-            vectorized::ColumnPtr& dest_col = chunk->get_tuple_column_by_id(tuple_id);
-            auto& dest_data = vectorized::ColumnHelper::as_raw_column<vectorized::BooleanColumn>(dest_col)->get_data();
-
-            for (size_t i = 0; i < row_count; i++) {
-                dest_data.emplace_back(src_data[build_index + i]);
-            }
-        }
-    }
 }
 
 void CrossJoinLeftOperator::_copy_joined_rows_with_index_base_build(vectorized::ChunkPtr& chunk, size_t row_count,
@@ -101,31 +63,6 @@ void CrossJoinLeftOperator::_copy_joined_rows_with_index_base_build(vectorized::
         DCHECK(_curr_build_chunk != nullptr);
         vectorized::ColumnPtr& src_col = _curr_build_chunk->get_column_by_slot_id(slot->id());
         _copy_build_rows_with_index_base_build(dest_col, src_col, build_index, row_count);
-    }
-
-    for (int tuple_id : _output_probe_tuple_ids) {
-        if (_probe_chunk->is_tuple_exist(tuple_id)) {
-            vectorized::ColumnPtr& src_col = _probe_chunk->get_tuple_column_by_id(tuple_id);
-            auto& src_data = vectorized::ColumnHelper::as_raw_column<vectorized::BooleanColumn>(src_col)->get_data();
-            vectorized::ColumnPtr& dest_col = chunk->get_tuple_column_by_id(tuple_id);
-            auto& dest_data = vectorized::ColumnHelper::as_raw_column<vectorized::BooleanColumn>(dest_col)->get_data();
-            for (size_t i = 0; i < row_count; i++) {
-                dest_data.emplace_back(src_data[probe_index + i]);
-            }
-        }
-    }
-
-    for (int tuple_id : _output_build_tuple_ids) {
-        if (_curr_build_chunk->is_tuple_exist(tuple_id)) {
-            vectorized::ColumnPtr& src_col = _curr_build_chunk->get_tuple_column_by_id(tuple_id);
-            auto& src_data = vectorized::ColumnHelper::as_raw_column<vectorized::BooleanColumn>(src_col)->get_data();
-            vectorized::ColumnPtr& dest_col = chunk->get_tuple_column_by_id(tuple_id);
-            auto& dest_data = vectorized::ColumnHelper::as_raw_column<vectorized::BooleanColumn>(dest_col)->get_data();
-
-            for (size_t i = 0; i < row_count; i++) {
-                dest_data.emplace_back(src_data[build_index]);
-            }
-        }
     }
 }
 
@@ -380,17 +317,11 @@ void CrossJoinLeftOperatorFactory::_init_row_desc() {
             _col_types.emplace_back(slot);
             _probe_column_count++;
         }
-        if (_row_descriptor.get_tuple_idx(tuple_desc->id()) != RowDescriptor::INVALID_IDX) {
-            _output_probe_tuple_ids.emplace_back(tuple_desc->id());
-        }
     }
     for (auto& tuple_desc : _right_row_desc.tuple_descriptors()) {
         for (auto& slot : tuple_desc->slots()) {
             _col_types.emplace_back(slot);
             _build_column_count++;
-        }
-        if (_row_descriptor.get_tuple_idx(tuple_desc->id()) != RowDescriptor::INVALID_IDX) {
-            _output_build_tuple_ids.emplace_back(tuple_desc->id());
         }
     }
 }

--- a/be/src/exec/pipeline/crossjoin/cross_join_left_operator.h
+++ b/be/src/exec/pipeline/crossjoin/cross_join_left_operator.h
@@ -17,14 +17,10 @@ class CrossJoinLeftOperator final : public OperatorWithDependency {
 public:
     CrossJoinLeftOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id,
                           const std::vector<ExprContext*>& conjunct_ctxs,
-                          const vectorized::Buffer<SlotDescriptor*>& col_types,
-                          const vectorized::Buffer<TupleId>& output_build_tuple_ids,
-                          const vectorized::Buffer<TupleId>& output_probe_tuple_ids, const size_t& probe_column_count,
+                          const vectorized::Buffer<SlotDescriptor*>& col_types, const size_t& probe_column_count,
                           const size_t& build_column_count, const std::shared_ptr<CrossJoinContext>& cross_join_context)
             : OperatorWithDependency(factory, id, "cross_join_left", plan_node_id),
               _col_types(col_types),
-              _output_build_tuple_ids(output_build_tuple_ids),
-              _output_probe_tuple_ids(output_probe_tuple_ids),
               _probe_column_count(probe_column_count),
               _build_column_count(build_column_count),
               _conjunct_ctxs(conjunct_ctxs),
@@ -107,8 +103,6 @@ private:
                                                 size_t start_row, size_t row_count);
 
     const vectorized::Buffer<SlotDescriptor*>& _col_types;
-    const vectorized::Buffer<TupleId>& _output_build_tuple_ids;
-    const vectorized::Buffer<TupleId>& _output_probe_tuple_ids;
     const size_t& _probe_column_count;
     const size_t& _build_column_count;
 
@@ -166,7 +160,6 @@ public:
 
     OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override {
         return std::make_shared<CrossJoinLeftOperator>(this, _id, _plan_node_id, _conjunct_ctxs, _col_types,
-                                                       _output_build_tuple_ids, _output_probe_tuple_ids,
                                                        _probe_column_count, _build_column_count, _cross_join_context);
     }
 
@@ -181,8 +174,6 @@ private:
     const RowDescriptor& _right_row_desc;
 
     vectorized::Buffer<SlotDescriptor*> _col_types;
-    vectorized::Buffer<TupleId> _output_build_tuple_ids;
-    vectorized::Buffer<TupleId> _output_probe_tuple_ids;
     size_t _probe_column_count = 0;
     size_t _build_column_count = 0;
 

--- a/be/src/exec/vectorized/cross_join_node.cpp
+++ b/be/src/exec/vectorized/cross_join_node.cpp
@@ -19,6 +19,9 @@ CrossJoinNode::CrossJoinNode(ObjectPool* pool, const TPlanNode& tnode, const Des
 
 Status CrossJoinNode::init(const TPlanNode& tnode, RuntimeState* state) {
     RETURN_IF_ERROR(ExecNode::init(tnode, state));
+    if (tnode.__isset.need_create_tuple_columns) {
+        _need_create_tuple_columns = tnode.need_create_tuple_columns;
+    }
     return Status::OK();
 }
 
@@ -444,8 +447,10 @@ void CrossJoinNode::_init_row_desc() {
             _col_types.emplace_back(slot);
             _probe_column_count++;
         }
-        if (_row_descriptor.get_tuple_idx(tuple_desc->id()) != RowDescriptor::INVALID_IDX) {
-            _output_probe_tuple_ids.emplace_back(tuple_desc->id());
+        if (_need_create_tuple_columns) {
+            if (_row_descriptor.get_tuple_idx(tuple_desc->id()) != RowDescriptor::INVALID_IDX) {
+                _output_probe_tuple_ids.emplace_back(tuple_desc->id());
+            }
         }
     }
     for (auto& tuple_desc : child(1)->row_desc().tuple_descriptors()) {
@@ -453,8 +458,10 @@ void CrossJoinNode::_init_row_desc() {
             _col_types.emplace_back(slot);
             _build_column_count++;
         }
-        if (_row_descriptor.get_tuple_idx(tuple_desc->id()) != RowDescriptor::INVALID_IDX) {
-            _output_build_tuple_ids.emplace_back(tuple_desc->id());
+        if (_need_create_tuple_columns) {
+            if (_row_descriptor.get_tuple_idx(tuple_desc->id()) != RowDescriptor::INVALID_IDX) {
+                _output_build_tuple_ids.emplace_back(tuple_desc->id());
+            }
         }
     }
 }

--- a/be/src/exec/vectorized/cross_join_node.h
+++ b/be/src/exec/vectorized/cross_join_node.h
@@ -79,6 +79,7 @@ private:
     size_t _probe_rows_index = 0;
 
     bool _eos = false;
+    bool _need_create_tuple_columns = true;
 
     Buffer<SlotDescriptor*> _col_types;
     Buffer<TupleId> _output_build_tuple_ids;

--- a/be/src/exec/vectorized/hash_join_node.cpp
+++ b/be/src/exec/vectorized/hash_join_node.cpp
@@ -82,6 +82,9 @@ Status HashJoinNode::init(const TPlanNode& tnode, RuntimeState* state) {
         _runtime_join_filter_pushdown_limit = state->query_options().runtime_join_filter_pushdown_limit;
     }
 
+    if (tnode.__isset.need_create_tuple_columns) {
+        _need_create_tuple_columns = tnode.need_create_tuple_columns;
+    }
     return Status::OK();
 }
 
@@ -130,6 +133,7 @@ Status HashJoinNode::prepare(RuntimeState* state) {
 
 void HashJoinNode::_init_hash_table_param(HashTableParam* param) {
     param->with_other_conjunct = !_other_join_conjunct_ctxs.empty();
+    param->need_create_tuple_columns = _need_create_tuple_columns;
     param->join_type = _join_type;
     param->row_desc = &_row_descriptor;
     param->build_row_desc = &child(1)->row_desc();

--- a/be/src/exec/vectorized/hash_join_node.h
+++ b/be/src/exec/vectorized/hash_join_node.h
@@ -90,6 +90,7 @@ private:
     TJoinDistributionMode::type _distribution_mode = TJoinDistributionMode::NONE;
 
     bool _is_push_down = false;
+    bool _need_create_tuple_columns = true;
 
     JoinHashTable _ht;
 

--- a/be/src/exec/vectorized/join_hash_map.h
+++ b/be/src/exec/vectorized/join_hash_map.h
@@ -94,6 +94,7 @@ struct JoinHashTableItems {
     size_t build_column_count = 0;
     size_t probe_column_count = 0;
     bool with_other_conjunct = false;
+    bool need_create_tuple_columns = true;
     bool left_to_nullable = false;
     bool right_to_nullable = false;
 
@@ -149,6 +150,7 @@ struct HashTableProbeState {
 
 struct HashTableParam {
     bool with_other_conjunct = false;
+    bool need_create_tuple_columns = true;
     TJoinOp::type join_type = TJoinOp::INNER_JOIN;
     const RowDescriptor* row_desc = nullptr;
     const RowDescriptor* build_row_desc = nullptr;
@@ -576,6 +578,7 @@ private:
     std::unique_ptr<JoinHashMapForFixedSizeKey(TYPE_LARGEINT)> _fixed128 = nullptr;
 
     JoinHashMapType _hash_map_type = JoinHashMapType::empty;
+    bool _need_create_tuple_columns = true;
 
     std::unique_ptr<JoinHashTableItems> _table_items;
     std::unique_ptr<HashTableProbeState> _probe_state;

--- a/be/src/exec/vectorized/join_hash_map.tpp
+++ b/be/src/exec/vectorized/join_hash_map.tpp
@@ -19,21 +19,18 @@ Status JoinBuildFunc<PT>::construct_hash_table(RuntimeState* state, JoinHashTabl
                                                HashTableProbeState* probe_state) {
     auto& data = get_key_data(*table_items);
     if (table_items->key_columns[0]->is_nullable()) {
-        auto* nullable_column =
-                ColumnHelper::as_raw_column<NullableColumn>(table_items->key_columns[0]);
+        auto* nullable_column = ColumnHelper::as_raw_column<NullableColumn>(table_items->key_columns[0]);
         auto& null_array = nullable_column->null_column()->get_data();
         for (size_t i = 1; i < table_items->row_count + 1; i++) {
             if (null_array[i] == 0) {
-                uint32_t bucket_num = JoinHashMapHelper::calc_bucket_num<CppType>(
-                        data[i], table_items->bucket_size);
+                uint32_t bucket_num = JoinHashMapHelper::calc_bucket_num<CppType>(data[i], table_items->bucket_size);
                 table_items->next[i] = table_items->first[bucket_num];
                 table_items->first[bucket_num] = i;
             }
         }
     } else {
         for (size_t i = 1; i < table_items->row_count + 1; i++) {
-            uint32_t bucket_num =
-                    JoinHashMapHelper::calc_bucket_num<CppType>(data[i], table_items->bucket_size);
+            uint32_t bucket_num = JoinHashMapHelper::calc_bucket_num<CppType>(data[i], table_items->bucket_size);
             table_items->next[i] = table_items->first[bucket_num];
             table_items->first[bucket_num] = i;
         }
@@ -62,8 +59,7 @@ Status FixedSizeJoinBuildFunc<PT>::construct_hash_table(RuntimeState* state, Joi
         if (table_items->join_keys[i].is_null_safe_equal) {
             data_columns.emplace_back(table_items->key_columns[i]);
         } else if (table_items->key_columns[i]->is_nullable()) {
-            auto* nullable_column =
-                    ColumnHelper::as_raw_column<NullableColumn>(table_items->key_columns[i]);
+            auto* nullable_column = ColumnHelper::as_raw_column<NullableColumn>(table_items->key_columns[i]);
             data_columns.emplace_back(nullable_column->data_column());
             if (table_items->key_columns[i]->has_null()) {
                 null_columns.emplace_back(nullable_column->null_column());
@@ -96,16 +92,13 @@ Status FixedSizeJoinBuildFunc<PT>::construct_hash_table(RuntimeState* state, Joi
 }
 
 template <PrimitiveType PT>
-void FixedSizeJoinBuildFunc<PT>::_build_columns(JoinHashTableItems* table_items,
-                                                HashTableProbeState* probe_state,
-                                                const Columns& data_columns, uint32_t start,
-                                                uint32_t count) {
-    JoinHashMapHelper::serialize_fixed_size_key_column<PT>(
-            data_columns, table_items->build_key_column.get(), start, count);
+void FixedSizeJoinBuildFunc<PT>::_build_columns(JoinHashTableItems* table_items, HashTableProbeState* probe_state,
+                                                const Columns& data_columns, uint32_t start, uint32_t count) {
+    JoinHashMapHelper::serialize_fixed_size_key_column<PT>(data_columns, table_items->build_key_column.get(), start,
+                                                           count);
 
     const auto& data = get_key_data(*table_items);
-    JoinHashMapHelper::calc_bucket_nums<CppType>(data, table_items->bucket_size,
-                                                 &probe_state->buckets, start, count);
+    JoinHashMapHelper::calc_bucket_nums<CppType>(data, table_items->bucket_size, &probe_state->buckets, start, count);
 
     for (uint32_t i = 0; i < count; i++) {
         table_items->next[start + i] = table_items->first[probe_state->buckets[i]];
@@ -115,10 +108,9 @@ void FixedSizeJoinBuildFunc<PT>::_build_columns(JoinHashTableItems* table_items,
 
 template <PrimitiveType PT>
 void FixedSizeJoinBuildFunc<PT>::_build_nullable_columns(JoinHashTableItems* table_items,
-                                                         HashTableProbeState* probe_state,
-                                                         const Columns& data_columns,
-                                                         const NullColumns& null_columns,
-                                                         uint32_t start, uint32_t count) {
+                                                         HashTableProbeState* probe_state, const Columns& data_columns,
+                                                         const NullColumns& null_columns, uint32_t start,
+                                                         uint32_t count) {
     for (uint32_t i = 0; i < count; i++) {
         probe_state->is_nulls[i] = null_columns[0]->get_data()[start + i];
     }
@@ -128,11 +120,10 @@ void FixedSizeJoinBuildFunc<PT>::_build_nullable_columns(JoinHashTableItems* tab
         }
     }
 
-    JoinHashMapHelper::serialize_fixed_size_key_column<PT>(
-            data_columns, table_items->build_key_column.get(), start, count);
+    JoinHashMapHelper::serialize_fixed_size_key_column<PT>(data_columns, table_items->build_key_column.get(), start,
+                                                           count);
     const auto& data = get_key_data(*table_items);
-    JoinHashMapHelper::calc_bucket_nums<CppType>(data, table_items->bucket_size,
-                                                 &probe_state->buckets, start, count);
+    JoinHashMapHelper::calc_bucket_nums<CppType>(data, table_items->bucket_size, &probe_state->buckets, start, count);
 
     for (size_t i = 0; i < count; i++) {
         if (probe_state->is_nulls[i] == 0) {
@@ -143,16 +134,13 @@ void FixedSizeJoinBuildFunc<PT>::_build_nullable_columns(JoinHashTableItems* tab
 }
 
 template <PrimitiveType PT>
-Status JoinProbeFunc<PT>::lookup_init(const JoinHashTableItems& table_items,
-                                      HashTableProbeState* probe_state) {
+Status JoinProbeFunc<PT>::lookup_init(const JoinHashTableItems& table_items, HashTableProbeState* probe_state) {
     size_t probe_row_count = probe_state->probe_row_count;
     auto& data = get_key_data(*probe_state);
-    JoinHashMapHelper::calc_bucket_nums<CppType>(data, table_items.bucket_size,
-                                                 &probe_state->buckets, 0, data.size());
+    JoinHashMapHelper::calc_bucket_nums<CppType>(data, table_items.bucket_size, &probe_state->buckets, 0, data.size());
 
     if ((*probe_state->key_columns)[0]->is_nullable()) {
-        auto* nullable_column =
-                ColumnHelper::as_raw_column<NullableColumn>((*probe_state->key_columns)[0]);
+        auto* nullable_column = ColumnHelper::as_raw_column<NullableColumn>((*probe_state->key_columns)[0]);
 
         if (nullable_column->has_null()) {
             auto& null_array = nullable_column->null_column()->get_data();
@@ -184,8 +172,7 @@ template <PrimitiveType PT>
 const Buffer<typename JoinProbeFunc<PT>::CppType>& JoinProbeFunc<PT>::get_key_data(
         const HashTableProbeState& probe_state) {
     if ((*probe_state.key_columns)[0]->is_nullable()) {
-        auto* nullable_column =
-                ColumnHelper::as_raw_column<NullableColumn>((*probe_state.key_columns)[0]);
+        auto* nullable_column = ColumnHelper::as_raw_column<NullableColumn>((*probe_state.key_columns)[0]);
         return ColumnHelper::as_raw_column<ColumnType>(nullable_column->data_column())->get_data();
     }
 
@@ -204,14 +191,12 @@ Status FixedSizeJoinProbeFunc<PT>::lookup_init(const JoinHashTableItems& table_i
             if ((*probe_state->key_columns)[i]->is_nullable()) {
                 data_columns.emplace_back((*probe_state->key_columns)[i]);
             } else {
-                auto tmp_column =
-                        NullableColumn::create((*probe_state->key_columns)[i],
-                                               NullColumn::create(probe_state->probe_row_count, 0));
+                auto tmp_column = NullableColumn::create((*probe_state->key_columns)[i],
+                                                         NullColumn::create(probe_state->probe_row_count, 0));
                 data_columns.emplace_back(tmp_column);
             }
         } else if ((*probe_state->key_columns)[i]->is_nullable()) {
-            auto* nullable_column =
-                    ColumnHelper::as_raw_column<NullableColumn>((*probe_state->key_columns)[i]);
+            auto* nullable_column = ColumnHelper::as_raw_column<NullableColumn>((*probe_state->key_columns)[i]);
             data_columns.emplace_back(nullable_column->data_column());
             if ((*probe_state->key_columns)[i]->has_null()) {
                 null_columns.emplace_back(nullable_column->null_column());
@@ -231,16 +216,14 @@ Status FixedSizeJoinProbeFunc<PT>::lookup_init(const JoinHashTableItems& table_i
 }
 
 template <PrimitiveType PT>
-void FixedSizeJoinProbeFunc<PT>::_probe_column(const JoinHashTableItems& table_items,
-                                               HashTableProbeState* probe_state,
+void FixedSizeJoinProbeFunc<PT>::_probe_column(const JoinHashTableItems& table_items, HashTableProbeState* probe_state,
                                                const Columns& data_columns) {
     uint32_t row_count = probe_state->probe_row_count;
 
-    JoinHashMapHelper::serialize_fixed_size_key_column<PT>(
-            data_columns, probe_state->probe_key_column.get(), 0, row_count);
+    JoinHashMapHelper::serialize_fixed_size_key_column<PT>(data_columns, probe_state->probe_key_column.get(), 0,
+                                                           row_count);
     const auto& data = get_key_data(*probe_state);
-    JoinHashMapHelper::calc_bucket_nums<CppType>(data, table_items.bucket_size,
-                                                 &probe_state->buckets, 0, row_count);
+    JoinHashMapHelper::calc_bucket_nums<CppType>(data, table_items.bucket_size, &probe_state->buckets, 0, row_count);
 
     for (uint32_t i = 0; i < row_count; i++) {
         probe_state->next[i] = table_items.first[probe_state->buckets[i]];
@@ -249,8 +232,7 @@ void FixedSizeJoinProbeFunc<PT>::_probe_column(const JoinHashTableItems& table_i
 
 template <PrimitiveType PT>
 void FixedSizeJoinProbeFunc<PT>::_probe_nullable_column(const JoinHashTableItems& table_items,
-                                                        HashTableProbeState* probe_state,
-                                                        const Columns& data_columns,
+                                                        HashTableProbeState* probe_state, const Columns& data_columns,
                                                         const NullColumns& null_columns) {
     uint32_t row_count = probe_state->probe_row_count;
 
@@ -263,11 +245,10 @@ void FixedSizeJoinProbeFunc<PT>::_probe_nullable_column(const JoinHashTableItems
         }
     }
 
-    JoinHashMapHelper::serialize_fixed_size_key_column<PT>(
-            data_columns, probe_state->probe_key_column.get(), 0, row_count);
+    JoinHashMapHelper::serialize_fixed_size_key_column<PT>(data_columns, probe_state->probe_key_column.get(), 0,
+                                                           row_count);
     const auto& data = get_key_data(*probe_state);
-    JoinHashMapHelper::calc_bucket_nums<CppType>(data, table_items.bucket_size,
-                                                 &probe_state->buckets, 0, row_count);
+    JoinHashMapHelper::calc_bucket_nums<CppType>(data, table_items.bucket_size, &probe_state->buckets, 0, row_count);
 
     for (uint32_t i = 0; i < row_count; i++) {
         if (probe_state->is_nulls[i] == 0) {
@@ -305,8 +286,7 @@ Status JoinHashMap<PT, BuildFunc, ProbeFunc>::probe(RuntimeState* state, const C
         *has_remain = _probe_state->has_remain;
     }
 
-    if (_table_items->join_type == TJoinOp::RIGHT_SEMI_JOIN ||
-        _table_items->join_type == TJoinOp::RIGHT_ANTI_JOIN) {
+    if (_table_items->join_type == TJoinOp::RIGHT_SEMI_JOIN || _table_items->join_type == TJoinOp::RIGHT_ANTI_JOIN) {
         // right semi join without other join conjunct
         // right anti join without other join conjunct
         // don't need output the real probe column
@@ -325,7 +305,9 @@ Status JoinHashMap<PT, BuildFunc, ProbeFunc>::probe(RuntimeState* state, const C
         }
         {
             SCOPED_TIMER(_table_items->output_tuple_column_timer);
-            _build_tuple_output(chunk);
+            if (_table_items->need_create_tuple_columns) {
+                _build_tuple_output(chunk);
+            }
         }
     } else if (_table_items->join_type == TJoinOp::LEFT_SEMI_JOIN ||
                _table_items->join_type == TJoinOp::LEFT_ANTI_JOIN ||
@@ -348,7 +330,9 @@ Status JoinHashMap<PT, BuildFunc, ProbeFunc>::probe(RuntimeState* state, const C
         }
         {
             SCOPED_TIMER(_table_items->output_tuple_column_timer);
-            _probe_tuple_output(probe_chunk, chunk);
+            if (_table_items->need_create_tuple_columns) {
+                _probe_tuple_output(probe_chunk, chunk);
+            }
         }
     } else {
         {
@@ -361,8 +345,10 @@ Status JoinHashMap<PT, BuildFunc, ProbeFunc>::probe(RuntimeState* state, const C
         }
         {
             SCOPED_TIMER(_table_items->output_tuple_column_timer);
-            _probe_tuple_output(probe_chunk, chunk);
-            _build_tuple_output(chunk);
+            if (_table_items->need_create_tuple_columns) {
+                _probe_tuple_output(probe_chunk, chunk);
+                _build_tuple_output(chunk);
+            }
         }
     }
 
@@ -378,31 +364,32 @@ Status JoinHashMap<PT, BuildFunc, ProbeFunc>::probe_remain(RuntimeState* state, 
     }
     *has_remain = _probe_state->has_remain;
 
-    if (_table_items->join_type == TJoinOp::RIGHT_ANTI_JOIN ||
-        _table_items->join_type == TJoinOp::RIGHT_SEMI_JOIN) {
+    if (_table_items->join_type == TJoinOp::RIGHT_ANTI_JOIN || _table_items->join_type == TJoinOp::RIGHT_SEMI_JOIN) {
         // right anti/semi join without other conjunct output default value of probe-columns as placeholder.
         RETURN_IF_ERROR(_probe_null_output(chunk, _probe_state->count));
         RETURN_IF_ERROR(_build_output(chunk));
 
-        _build_tuple_output(chunk);
+        if (_table_items->need_create_tuple_columns) {
+            _build_tuple_output(chunk);
+        }
     } else {
         // RIGHT_OUTER_JOIN || FULL_OUTER_JOIN
         RETURN_IF_ERROR(_probe_null_output(chunk, _probe_state->count));
         RETURN_IF_ERROR(_build_output(chunk));
 
-        for (int tuple_id : _table_items->output_probe_tuple_ids) {
-            ColumnPtr column = BooleanColumn::create(_probe_state->count, 0);
-            (*chunk)->append_tuple_column(column, tuple_id);
+        if (_table_items->need_create_tuple_columns) {
+            for (int tuple_id : _table_items->output_probe_tuple_ids) {
+                ColumnPtr column = BooleanColumn::create(_probe_state->count, 0);
+                (*chunk)->append_tuple_column(column, tuple_id);
+            }
+            _build_tuple_output(chunk);
         }
-        _build_tuple_output(chunk);
     }
-
     return Status::OK();
 }
 
 template <PrimitiveType PT, class BuildFunc, class ProbeFunc>
-Status JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_output(ChunkPtr* probe_chunk,
-                                                            ChunkPtr* chunk) {
+Status JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_output(ChunkPtr* probe_chunk, ChunkPtr* chunk) {
     bool to_nullable = _table_items->left_to_nullable;
 
     for (size_t i = 0; i < _table_items->probe_column_count; i++) {
@@ -419,8 +406,7 @@ Status JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_output(ChunkPtr* probe_chun
 }
 
 template <PrimitiveType PT, class BuildFunc, class ProbeFunc>
-void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_tuple_output(ChunkPtr* probe_chunk,
-                                                                ChunkPtr* chunk) {
+void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_tuple_output(ChunkPtr* probe_chunk, ChunkPtr* chunk) {
     bool to_nullable = _table_items->left_to_nullable;
 
     for (int tuple_id : _table_items->output_probe_tuple_ids) {
@@ -435,8 +421,7 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_tuple_output(ChunkPtr* probe_
             } else {
                 ColumnPtr dest_column = BooleanColumn::create(_probe_state->count);
                 auto& src_data = ColumnHelper::as_raw_column<BooleanColumn>(src_column)->get_data();
-                auto& dest_data =
-                        ColumnHelper::as_raw_column<BooleanColumn>(dest_column)->get_data();
+                auto& dest_data = ColumnHelper::as_raw_column<BooleanColumn>(dest_column)->get_data();
 
                 size_t end = _probe_state->count;
                 for (size_t i = 0; i < end; i++) {
@@ -503,8 +488,7 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_build_tuple_output(ChunkPtr* chunk)
                 }
             } else {
                 for (size_t i = 0; i < row_count; i++) {
-                    dest_data[i] = (_probe_state->build_index[i] != 0) &
-                                   src_data[_probe_state->build_index[i]];
+                    dest_data[i] = (_probe_state->build_index[i] != 0) & src_data[_probe_state->build_index[i]];
                 }
             }
             (*chunk)->append_tuple_column(dest_column, tuple_id);
@@ -517,8 +501,7 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_build_tuple_output(ChunkPtr* chunk)
                     (*chunk)->append_tuple_column(dest_column, tuple_id);
                 } else {
                     ColumnPtr dest_column = BooleanColumn::create(_probe_state->count);
-                    auto& dest_data =
-                            ColumnHelper::as_raw_column<BooleanColumn>(dest_column)->get_data();
+                    auto& dest_data = ColumnHelper::as_raw_column<BooleanColumn>(dest_column)->get_data();
 
                     size_t end = _probe_state->count;
                     for (size_t i = 0; i < end; i++) {
@@ -544,14 +527,11 @@ Status JoinHashMap<PT, BuildFunc, ProbeFunc>::_build_default_output(ChunkPtr* ch
 }
 
 template <PrimitiveType PT, class BuildFunc, class ProbeFunc>
-void JoinHashMap<PT, BuildFunc, ProbeFunc>::_copy_probe_column(ColumnPtr* src_column,
-                                                               ChunkPtr* chunk,
-                                                               const SlotDescriptor* slot,
-                                                               bool to_nullable) {
+void JoinHashMap<PT, BuildFunc, ProbeFunc>::_copy_probe_column(ColumnPtr* src_column, ChunkPtr* chunk,
+                                                               const SlotDescriptor* slot, bool to_nullable) {
     if (_probe_state->match_flag == JoinMatchFlag::ALL_MATCH_ONE) {
         if (to_nullable) {
-            ColumnPtr dest_column =
-                    NullableColumn::create(*src_column, NullColumn::create((*src_column)->size()));
+            ColumnPtr dest_column = NullableColumn::create(*src_column, NullColumn::create((*src_column)->size()));
             (*chunk)->append_column(std::move(dest_column), slot->id());
         } else {
             (*chunk)->append_column(*src_column, slot->id());
@@ -559,8 +539,7 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_copy_probe_column(ColumnPtr* src_co
     } else if (_probe_state->match_flag == JoinMatchFlag::MOST_MATCH_ONE) {
         if (to_nullable) {
             (*src_column)->filter(_probe_state->probe_match_filter, _probe_state->probe_row_count);
-            ColumnPtr dest_column =
-                    NullableColumn::create(*src_column, NullColumn::create((*src_column)->size()));
+            ColumnPtr dest_column = NullableColumn::create(*src_column, NullColumn::create((*src_column)->size()));
             (*chunk)->append_column(std::move(dest_column), slot->id());
         } else {
             (*src_column)->filter(_probe_state->probe_match_filter, _probe_state->probe_row_count);
@@ -568,15 +547,14 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_copy_probe_column(ColumnPtr* src_co
         }
     } else {
         ColumnPtr dest_column = ColumnHelper::create_column(slot->type(), to_nullable);
-        dest_column->append_selective(**src_column, _probe_state->probe_index.data(), 0,
-                                      _probe_state->count);
+        dest_column->append_selective(**src_column, _probe_state->probe_index.data(), 0, _probe_state->count);
         (*chunk)->append_column(std::move(dest_column), slot->id());
     }
 }
 
 template <PrimitiveType PT, class BuildFunc, class ProbeFunc>
-void JoinHashMap<PT, BuildFunc, ProbeFunc>::_copy_probe_nullable_column(
-        ColumnPtr* src_column, ChunkPtr* chunk, const SlotDescriptor* slot) {
+void JoinHashMap<PT, BuildFunc, ProbeFunc>::_copy_probe_nullable_column(ColumnPtr* src_column, ChunkPtr* chunk,
+                                                                        const SlotDescriptor* slot) {
     if (_probe_state->match_flag == JoinMatchFlag::ALL_MATCH_ONE) {
         (*chunk)->append_column(*src_column, slot->id());
     } else if (_probe_state->match_flag == JoinMatchFlag::MOST_MATCH_ONE) {
@@ -584,22 +562,18 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_copy_probe_nullable_column(
         (*chunk)->append_column(*src_column, slot->id());
     } else {
         ColumnPtr dest_column = ColumnHelper::create_column(slot->type(), true);
-        dest_column->append_selective(**src_column, _probe_state->probe_index.data(), 0,
-                                      _probe_state->count);
+        dest_column->append_selective(**src_column, _probe_state->probe_index.data(), 0, _probe_state->count);
         (*chunk)->append_column(std::move(dest_column), slot->id());
     }
 }
 
 template <PrimitiveType PT, class BuildFunc, class ProbeFunc>
-void JoinHashMap<PT, BuildFunc, ProbeFunc>::_copy_build_column(const ColumnPtr& src_column,
-                                                               ChunkPtr* chunk,
-                                                               const SlotDescriptor* slot,
-                                                               bool to_nullable) {
+void JoinHashMap<PT, BuildFunc, ProbeFunc>::_copy_build_column(const ColumnPtr& src_column, ChunkPtr* chunk,
+                                                               const SlotDescriptor* slot, bool to_nullable) {
     ColumnPtr dest_column = ColumnHelper::create_column(slot->type(), to_nullable);
 
     if (to_nullable) {
-        dest_column->append_selective(*src_column, _probe_state->build_index.data(), 0,
-                                      _probe_state->count);
+        dest_column->append_selective(*src_column, _probe_state->build_index.data(), 0, _probe_state->count);
 
         // When left outer join is executed,
         // build_index[i] Equal to 0 means it is not found in the hash table,
@@ -613,20 +587,18 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_copy_build_column(const ColumnPtr& 
             }
         }
     } else {
-        dest_column->append_selective(*src_column, _probe_state->build_index.data(), 0,
-                                      _probe_state->count);
+        dest_column->append_selective(*src_column, _probe_state->build_index.data(), 0, _probe_state->count);
     }
 
     (*chunk)->append_column(std::move(dest_column), slot->id());
 }
 
 template <PrimitiveType PT, class BuildFunc, class ProbeFunc>
-void JoinHashMap<PT, BuildFunc, ProbeFunc>::_copy_build_nullable_column(
-        const ColumnPtr& src_column, ChunkPtr* chunk, const SlotDescriptor* slot) {
+void JoinHashMap<PT, BuildFunc, ProbeFunc>::_copy_build_nullable_column(const ColumnPtr& src_column, ChunkPtr* chunk,
+                                                                        const SlotDescriptor* slot) {
     ColumnPtr dest_column = ColumnHelper::create_column(slot->type(), true);
 
-    dest_column->append_selective(*src_column, _probe_state->build_index.data(), 0,
-                                  _probe_state->count);
+    dest_column->append_selective(*src_column, _probe_state->build_index.data(), 0, _probe_state->count);
 
     // When left outer join is executed,
     // build_index[i] Equal to 0 means it is not found in the hash table,
@@ -760,15 +732,14 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_search_ht_impl(RuntimeState* state,
     }
 }
 
-#define CHECK_MATCH()                                                                              \
-    if (match_count > 0 && !one_to_many) {                                                         \
-        size_t zero_count =                                                                        \
-                SIMD::count_zero(_probe_state->probe_match_filter, _probe_state->probe_row_count); \
-        if (zero_count == 0) {                                                                     \
-            _probe_state->match_flag = JoinMatchFlag::ALL_MATCH_ONE;                               \
-        } else if (zero_count < _probe_state->probe_row_count - zero_count) {                      \
-            _probe_state->match_flag = JoinMatchFlag::MOST_MATCH_ONE;                              \
-        }                                                                                          \
+#define CHECK_MATCH()                                                                                          \
+    if (match_count > 0 && !one_to_many) {                                                                     \
+        size_t zero_count = SIMD::count_zero(_probe_state->probe_match_filter, _probe_state->probe_row_count); \
+        if (zero_count == 0) {                                                                                 \
+            _probe_state->match_flag = JoinMatchFlag::ALL_MATCH_ONE;                                           \
+        } else if (zero_count < _probe_state->probe_row_count - zero_count) {                                  \
+            _probe_state->match_flag = JoinMatchFlag::MOST_MATCH_ONE;                                          \
+        }                                                                                                      \
     }
 
 #define CHECK_ALL_MATCH()                                        \
@@ -866,7 +837,7 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht(RuntimeState* state, 
 
 template <PrimitiveType PT, class BuildFunc, class ProbeFunc>
 template <bool first_probe>
-void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_outer_join(RuntimeState* state, 
+void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_outer_join(RuntimeState* state,
         const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data) {
     _probe_state->match_flag = JoinMatchFlag::NORMAL;
     size_t match_count = 0;
@@ -931,7 +902,7 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_outer_join(R
 
 template <PrimitiveType PT, class BuildFunc, class ProbeFunc>
 template <bool first_probe>
-void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_semi_join(RuntimeState* state, 
+void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_semi_join(RuntimeState* state,
         const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data) {
     size_t match_count = 0;
     size_t probe_row_count = _probe_state->probe_row_count;
@@ -957,13 +928,13 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_semi_join(Ru
 
 template <PrimitiveType PT, class BuildFunc, class ProbeFunc>
 template <bool first_probe>
-void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_anti_join(RuntimeState* state, 
+void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_anti_join(RuntimeState* state,
         const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data) {
     size_t match_count = 0;
 
     size_t probe_row_count = _probe_state->probe_row_count;
-    if (_table_items->join_type == TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN &&
-        _probe_state->null_array != nullptr && _table_items->row_count != 0) {
+    if (_table_items->join_type == TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN && _probe_state->null_array != nullptr &&
+        _table_items->row_count != 0) {
         // process left anti join from not in
         for (size_t i = 0; i < probe_row_count; i++) {
             size_t index = _probe_state->next[i];
@@ -1019,7 +990,7 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_anti_join(Ru
 
 template <PrimitiveType PT, class BuildFunc, class ProbeFunc>
 template <bool first_probe>
-void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_right_outer_join(RuntimeState* state, 
+void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_right_outer_join(RuntimeState* state,
         const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data) {
     size_t match_count = 0;
     size_t i = _probe_state->cur_probe_index;
@@ -1059,7 +1030,7 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_right_outer_join(
 
 template <PrimitiveType PT, class BuildFunc, class ProbeFunc>
 template <bool first_probe>
-void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_right_semi_join(RuntimeState* state, 
+void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_right_semi_join(RuntimeState* state,
         const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data) {
     size_t match_count = 0;
     size_t i = _probe_state->cur_probe_index;
@@ -1097,7 +1068,7 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_right_semi_join(R
 
 template <PrimitiveType PT, class BuildFunc, class ProbeFunc>
 template <bool first_probe>
-void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_right_anti_join(RuntimeState* state, 
+void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_right_anti_join(RuntimeState* state,
         const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data) {
     size_t probe_row_count = _probe_state->probe_row_count;
     for (size_t i = 0; i < probe_row_count; i++) {
@@ -1118,7 +1089,7 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_right_anti_join(R
 
 template <PrimitiveType PT, class BuildFunc, class ProbeFunc>
 template <bool first_probe>
-void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_full_outer_join(RuntimeState* state, 
+void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_full_outer_join(RuntimeState* state,
         const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data) {
     size_t match_count = 0;
     size_t i = _probe_state->cur_probe_index;
@@ -1173,7 +1144,7 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_full_outer_join(R
 
 template <PrimitiveType PT, class BuildFunc, class ProbeFunc>
 template <bool first_probe>
-void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_outer_join_with_other_conjunct(RuntimeState* state, 
+void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_outer_join_with_other_conjunct(RuntimeState* state,
         const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data) {
     size_t match_count = 0;
 
@@ -1233,7 +1204,7 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_outer_join_w
 
 template <PrimitiveType PT, class BuildFunc, class ProbeFunc>
 template <bool first_probe>
-void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_semi_join_with_other_conjunct(RuntimeState* state, 
+void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_semi_join_with_other_conjunct(RuntimeState* state,
         const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data) {
     size_t match_count = 0;
 
@@ -1277,7 +1248,7 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_semi_join_wi
 
 template <PrimitiveType PT, class BuildFunc, class ProbeFunc>
 template <bool first_probe>
-void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_anti_join_with_other_conjunct(RuntimeState* state, 
+void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_anti_join_with_other_conjunct(RuntimeState* state,
         const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data) {
     size_t match_count = 0;
 
@@ -1337,7 +1308,7 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_anti_join_wi
 
 template <PrimitiveType PT, class BuildFunc, class ProbeFunc>
 template <bool first_probe>
-void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_right_outer_join_with_other_conjunct(RuntimeState* state, 
+void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_right_outer_join_with_other_conjunct(RuntimeState* state,
         const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data) {
     size_t match_count = 0;
     size_t i = _probe_state->cur_probe_index;
@@ -1368,7 +1339,7 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_right_outer_join_
 
 template <PrimitiveType PT, class BuildFunc, class ProbeFunc>
 template <bool first_probe>
-void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_right_semi_join_with_other_conjunct(RuntimeState* state, 
+void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_right_semi_join_with_other_conjunct(RuntimeState* state,
         const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data) {
     size_t match_count = 0;
     size_t i = _probe_state->cur_probe_index;
@@ -1399,7 +1370,7 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_right_semi_join_w
 
 template <PrimitiveType PT, class BuildFunc, class ProbeFunc>
 template <bool first_probe>
-void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_right_anti_join_with_other_conjunct(RuntimeState* state, 
+void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_right_anti_join_with_other_conjunct(RuntimeState* state,
         const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data) {
     size_t match_count = 0;
     size_t i = _probe_state->cur_probe_index;
@@ -1430,7 +1401,7 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_right_anti_join_w
 
 template <PrimitiveType PT, class BuildFunc, class ProbeFunc>
 template <bool first_probe>
-void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_full_outer_join_with_other_conjunct(RuntimeState* state, 
+void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_full_outer_join_with_other_conjunct(RuntimeState* state,
         const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data) {
     size_t match_count = 0;
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanNode.java
@@ -523,7 +523,7 @@ abstract public class PlanNode extends TreeNode<PlanNode> {
             }
             msg.setLocal_rf_waiting_set(waitingPlanNodeIds);
         }
-
+        msg.setNeed_create_tuple_columns(false);
     }
 
     /**

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -876,6 +876,8 @@ struct TPlanNode {
   57: optional set<Types.TPlanNodeId> local_rf_waiting_set
   // Columns that null values can be filtered out
   58: optional list<Types.TSlotId> filter_null_value_columns;
+  // for outer join and cross join
+  59: optional bool need_create_tuple_columns;
 }
 
 // A flattened representation of a tree of PlanNodes, obtained by depth-first


### PR DESCRIPTION
For new CBO query optimizer, won't generate tuple id columns, so we could safely remove the tuple id column from chunk and join.

But for compatibility，we need two steps:
1. Don't create tuple columns in chunk
2. Don't handle tuple columns in data receiver and remove all tuple columns codes.

Remove tuple columns for pipeline engine is safely.
