### PR TITLE
Fix overflow when rewrite local dict column predicate

### DIFF
--- a/be/src/storage/vectorized/column_predicate_rewriter.cpp
+++ b/be/src/storage/vectorized/column_predicate_rewriter.cpp
@@ -34,6 +34,9 @@ void ColumnPredicateRewriter::rewrite_predicate(ObjectPool* pool) {
         const FieldPtr& field = _schema.field(i);
         ColumnId cid = field->id();
         if (_need_rewrite[cid]) {
+            // a local dict size may greater than config::vector_chunk_size, so it may cause a overflow
+            // in Expr::evaluate (default s_all_not_null_column size was config::vector_chunk_size)
+            // so we will disable optimization when dict size greater than vector_chunk_size
             int dict_size = down_cast<ScalarColumnIterator*>(_column_iterators[cid])->dict_size();
             if (dict_size > config::vector_chunk_size) {
                 _need_rewrite[cid] = false;

--- a/be/src/storage/vectorized/column_predicate_rewriter.h
+++ b/be/src/storage/vectorized/column_predicate_rewriter.h
@@ -23,7 +23,7 @@ public:
     using PushDownPredicates = std::unordered_map<ColumnId, PredicateList>;
 
     ColumnPredicateRewriter(ColumnIterators& column_iterators, PushDownPredicates& pushdown_predicates,
-                            const Schema& schema, const std::vector<uint8_t>& need_rewrite, int column_size,
+                            const Schema& schema, std::vector<uint8_t>& need_rewrite, int column_size,
                             SparseRange& scan_range)
             : _column_iterators(column_iterators),
               _predicates(pushdown_predicates),
@@ -45,7 +45,7 @@ private:
     ColumnIterators& _column_iterators;
     PushDownPredicates& _predicates;
     const Schema& _schema;
-    const std::vector<uint8_t>& _need_rewrite;
+    std::vector<uint8_t>& _need_rewrite;
     const int _column_size;
     SparseRange& _scan_range;
 };


### PR DESCRIPTION
a local dict size may greater than config::vector_chunk_size, so it will
cause a overflow

we will disable optimization when dict size greater than
vector_chunk_size

will close #2547 