### PR TITLE
Ignore NoClassDefFoundError when loading custom audit log plugins 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/plugin/DynamicPluginLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/plugin/DynamicPluginLoader.java
@@ -208,8 +208,8 @@ public class DynamicPluginLoader extends PluginLoader {
         Class<? extends Plugin> pluginClass;
         try {
             pluginClass = loader.loadClass(pluginInfo.getClassName()).asSubclass(Plugin.class);
-        } catch (ClassNotFoundException e) {
-            throw new UserException("Could not find plugin class [" + pluginInfo.getClassName() + "]", e);
+        } catch (ClassNotFoundException | NoClassDefFoundError t) {
+            throw new UserException("Could not find plugin class [" + pluginInfo.getClassName() + "]", t);
         }
 
         return loadPluginClass(pluginClass);


### PR DESCRIPTION
Before 1.19, the custom plugin class needed to implement the org.apache.doris.plugin.AuditPlugin interface. AuditPlugin has been renamed to com.starrocks.AuditPlugin after 1.19, so NoClassDefFoundError will be thrown when loading the custom plugin class. In order to prioritize the cluster to work properly, we should ignore NoClassDefFoundError when loading custom audit log plugins.