### PR TITLE
[ISSUE-2567] Not needs local shuffle for scan node is followed directly by aggregate block

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
@@ -92,6 +92,10 @@ public class AggregationNode extends PlanNode {
         updateplanNodeName();
     }
 
+    public boolean isNeedsFinalize() {
+        return needsFinalize;
+    }
+
     /**
      * Sets this node as a preaggregation. Only valid to call this if it is not marked
      * as a preaggregation

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -126,6 +126,12 @@ public class PlanFragment extends TreeNode<PlanFragment> {
     protected int pipelineDop = 1;
     protected boolean dopEstimated = false;
 
+    // if ScanNode is followed directly by a global AggregateNode that needs no finalization,
+    // then in pipeline engine(dop adaptation enabled), needsLocalShuffle is set to be false to
+    // indicate that the pipelineDop should be 1 to prevent local shuffle interpolated between
+    // ScanOperator and AggregateBlockSourceOperator/DistinctBlockSourceOperator.
+    private boolean needsLocalShuffle = true;
+
     protected final Map<Integer, RuntimeFilterDescription> buildRuntimeFilters = Maps.newTreeMap();
     protected final Map<Integer, RuntimeFilterDescription> probeRuntimeFilters = Maps.newTreeMap();
 
@@ -224,6 +230,14 @@ public class PlanFragment extends TreeNode<PlanFragment> {
     }
     public boolean isDopEstimated() {
         return dopEstimated;
+    }
+
+    public void setNeedsLocalShuffle(boolean need) {
+        this.needsLocalShuffle = need;
+    }
+
+    public boolean isNeedsLocalShuffle() {
+        return needsLocalShuffle;
     }
 
     public void setOutputExprs(List<Expr> outputExprs) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -236,6 +236,8 @@ public class PlanFragment extends TreeNode<PlanFragment> {
         this.needsLocalShuffle = need;
     }
 
+
+
     public boolean isNeedsLocalShuffle() {
         return needsLocalShuffle;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -1469,7 +1469,7 @@ public class Coordinator {
         boolean dopAdaptionEnabled = ConnectContext.get() != null &&
                 ConnectContext.get().getSessionVariable().isPipelineDopAdaptionEnabled();
         // ensure numInstances * pipelineDop = degreeOfParallelism when dop adaptation is enabled
-        if (dopAdaptionEnabled) {
+        if (dopAdaptionEnabled && params.fragment.isNeedsLocalShuffle()) {
             int numInstances = params.instanceExecParams.size();
             int numBackends = addressToScanRanges.size();
             int degreeOfParallelism = ConnectContext.get().getSessionVariable().getDegreeOfParallelism();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -1265,7 +1265,7 @@ public class Coordinator {
                     }
                 }
                 // ensure numInstances * pipelineDop = degreeOfParallelism when dop adaptation is enabled
-                if (dopAdaptionEnabled) {
+                if (dopAdaptionEnabled && fragment.isNeedsLocalShuffle()) {
                     int degreeOfParallelism = ConnectContext.get().getSessionVariable().getDegreeOfParallelism();
                     FragmentExecParams param = fragmentExecParamsMap.get(fragment.getFragmentId());
                     int numBackends = param.scanRangeAssignment.size();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1033,6 +1033,15 @@ public class PlanFragmentBuilder {
                     getSessionVariable().getStreamingPreaggregationMode());
             aggregationNode.setHasNullableGenerateChild();
             aggregationNode.computeStatistics(optExpr.getStatistics());
+
+            boolean notNeedLocalShuffle = aggregationNode.isNeedsFinalize() &&
+                    inputFragment.getPlanRoot() instanceof OlapScanNode;
+            boolean pipelineDopEnabled = ConnectContext.get() != null &&
+                    ConnectContext.get().getSessionVariable().isPipelineDopAdaptionEnabled();
+            if (pipelineDopEnabled && notNeedLocalShuffle) {
+                inputFragment.setNeedsLocalShuffle(false);
+            }
+
             inputFragment.setPlanRoot(aggregationNode);
             return inputFragment;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1034,8 +1034,9 @@ public class PlanFragmentBuilder {
             aggregationNode.setHasNullableGenerateChild();
             aggregationNode.computeStatistics(optExpr.getStatistics());
 
-            boolean notNeedLocalShuffle = aggregationNode.isNeedsFinalize() &&
-                    inputFragment.getPlanRoot() instanceof OlapScanNode;
+            PlanNode rootNode = inputFragment.getPlanRoot();
+            boolean notNeedLocalShuffle = aggregationNode.isNeedsFinalize() && (rootNode instanceof OlapScanNode ||
+                    rootNode instanceof ProjectNode && rootNode.getChild(0) instanceof OlapScanNode);
             boolean pipelineDopEnabled = ConnectContext.get() != null &&
                     ConnectContext.get().getSessionVariable().isPipelineDopAdaptionEnabled();
             if (pipelineDopEnabled && notNeedLocalShuffle) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -868,16 +868,13 @@ public class PlanFragmentBuilder {
             }
         }
 
-        // return true if all leaf offspring of the root are OlapScanNodes.
-        public static boolean allLeafAreOlapScanNodes(PlanNode root) {
-            if (root instanceof OlapScanNode) {
-                return true;
-            }
-            if (root.getChildren().isEmpty()) {
+        // return true if all leaf offspring are not ExchangeNode
+        public static boolean hasNoExchangeNodes(PlanNode root) {
+            if (root instanceof ExchangeNode) {
                 return false;
             }
             for (PlanNode childNode : root.getChildren()) {
-                if (!allLeafAreOlapScanNodes(childNode)) {
+                if (!hasNoExchangeNodes(childNode)) {
                     return false;
                 }
             }
@@ -1051,7 +1048,7 @@ public class PlanFragmentBuilder {
             aggregationNode.computeStatistics(optExpr.getStatistics());
 
             boolean notNeedLocalShuffle = aggregationNode.isNeedsFinalize() &&
-                    allLeafAreOlapScanNodes(inputFragment.getPlanRoot());
+                    hasNoExchangeNodes(inputFragment.getPlanRoot());
             boolean pipelineDopEnabled = ConnectContext.get() != null &&
                     ConnectContext.get().getSessionVariable().isPipelineDopAdaptionEnabled();
             if (pipelineDopEnabled && notNeedLocalShuffle) {


### PR DESCRIPTION
## Enhancement

For a ScanNode is followed directly by AggregateBlockNode/DistinctBlockNode, when it decomposed into pipelines, if pipelineDop>1, then LocalShuffle is interpolated in the middle of two adjacent Operators: ScanOperator->AggregateBlockSourceOperator/AggregateBlockSourceOperator. the LocalShuffle has a significant cost, so set the pipelineDop to 1 to prevent LocalShuffle interpolation.