### PR TITLE
[ISSUE-2572] Set per scan node dop

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -168,11 +168,11 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
         morsel_queues.emplace(scan_node->id(), std::make_unique<MorselQueue>(std::move(morsels)));
     }
 
-    std::remove_cv_t<typeof(request.per_node_scan_dop)> per_node_scan_dop;
-    if (request.__isset.per_node_scan_dop) {
-        per_node_scan_dop = request.per_node_scan_dop;
+    std::remove_cv_t<typeof(request.per_scan_node_dop)> per_scan_node_dop;
+    if (request.__isset.per_scan_node_dop) {
+        per_scan_node_dop = request.per_scan_node_dop;
     }
-    PipelineBuilderContext context(_fragment_ctx, degree_of_parallelism, std::move(per_node_scan_dop));
+    PipelineBuilderContext context(_fragment_ctx, degree_of_parallelism, std::move(per_scan_node_dop));
     PipelineBuilder builder(context);
     _fragment_ctx->set_pipelines(builder.build(*_fragment_ctx, plan));
     // Set up sink, if required

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -168,7 +168,11 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
         morsel_queues.emplace(scan_node->id(), std::make_unique<MorselQueue>(std::move(morsels)));
     }
 
-    PipelineBuilderContext context(_fragment_ctx, degree_of_parallelism);
+    std::remove_cv_t<typeof(request.per_node_scan_dop)> per_node_scan_dop;
+    if (request.__isset.per_node_scan_dop) {
+        per_node_scan_dop = request.per_node_scan_dop;
+    }
+    PipelineBuilderContext context(_fragment_ctx, degree_of_parallelism, std::move(per_node_scan_dop));
     PipelineBuilder builder(context);
     _fragment_ctx->set_pipelines(builder.build(*_fragment_ctx, plan));
     // Set up sink, if required

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -283,7 +283,9 @@ public:
             if (_global_rf_descriptors.empty()) {
                 return false;
             }
-            _global_rf_wait_timeout_ns += _precondition_block_timer_sw->elapsed_time() + 5000000;
+            // wait global rf to be ready for at most _global_rf_wait_time_out_ns after
+            // both dependencies_block and local_rf_block return false.
+            _global_rf_wait_timeout_ns += _precondition_block_timer_sw->elapsed_time();
             return global_rf_block();
         } else {
             return global_rf_block();

--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -561,15 +561,12 @@ pipeline::OpFactories OlapScanNode::decompose_to_pipeline(pipeline::PipelineBuil
     auto source_id = scan_operator->plan_node_id();
     DCHECK(morsel_queues.count(source_id));
     auto& morsel_queue = morsel_queues[source_id];
-    // ScanOperator's degree_of_parallelism is not more than the number of morsels
-    // If table is empty, then morsel size is zero and we still set degree of parallelism to 1
-    const auto degree_of_parallelism =
-            std::min<size_t>(std::max<size_t>(1, morsel_queue->num_morsels()), context->degree_of_parallelism());
-    scan_operator->set_degree_of_parallelism(degree_of_parallelism);
+    scan_operator->set_degree_of_parallelism(context->get_dop_of_scan_node(this->id()));
     operators.emplace_back(std::move(scan_operator));
     if (limit() != -1) {
         operators.emplace_back(std::make_shared<LimitOperatorFactory>(context->next_operator_id(), id(), limit()));
     }
+    operators = context->maybe_interpolate_local_passthrough_exchange(operators, context->degree_of_parallelism());
     return operators;
 }
 

--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -566,7 +566,8 @@ pipeline::OpFactories OlapScanNode::decompose_to_pipeline(pipeline::PipelineBuil
     if (limit() != -1) {
         operators.emplace_back(std::make_shared<LimitOperatorFactory>(context->next_operator_id(), id(), limit()));
     }
-    operators = context->maybe_interpolate_local_passthrough_exchange(operators, context->degree_of_parallelism());
+    operators = context->maybe_interpolate_local_passthrough_exchange(context->fragment_context()->runtime_state(),
+                                                                      operators, context->degree_of_parallelism());
     return operators;
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -199,10 +199,6 @@ public class PlanFragment extends TreeNode<PlanFragment> {
             return Lists.newArrayList(root);
         }
 
-        if (root.getChildren().isEmpty()) {
-            return Lists.newArrayList();
-        }
-
         List<PlanNode> scanNodes = Lists.newArrayList();
         for (PlanNode child : root.getChildren()) {
             scanNodes.addAll(getOlapScanNodes(child));

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -194,16 +194,15 @@ public class PlanFragment extends TreeNode<PlanFragment> {
         return destNode;
     }
 
-    public List<PlanNode> getOlapScanNodes(PlanNode root) {
+    public void getOlapScanNodes(PlanNode root, List<PlanNode> scanNodes) {
         if (root instanceof OlapScanNode) {
-            return Lists.newArrayList(root);
+            scanNodes.add(root);
+            return;
         }
 
-        List<PlanNode> scanNodes = Lists.newArrayList();
         for (PlanNode child : root.getChildren()) {
-            scanNodes.addAll(getOlapScanNodes(child));
+            getOlapScanNodes(child, scanNodes);
         }
-        return scanNodes;
     }
 
     public ArrayList<Expr> getOutputExprs() {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -194,6 +194,22 @@ public class PlanFragment extends TreeNode<PlanFragment> {
         return destNode;
     }
 
+    public List<PlanNode> getOlapScanNodes(PlanNode root) {
+        if (root instanceof OlapScanNode) {
+            return Lists.newArrayList(root);
+        }
+
+        if (root.getChildren().isEmpty()) {
+            return Lists.newArrayList();
+        }
+
+        List<PlanNode> scanNodes = Lists.newArrayList();
+        for (PlanNode child : root.getChildren()) {
+            scanNodes.addAll(getOlapScanNodes(child));
+        }
+        return scanNodes;
+    }
+
     public ArrayList<Expr> getOutputExprs() {
         return outputExprs;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -939,8 +939,8 @@ public class Coordinator {
                 int maxNumScanOperators = Math.max(1, (int) (numRows / maxRowCountPerScanOperator));
                 for (FInstanceExecParam instanceExecParam : params.instanceExecParams) {
                     int numScanRanges = 0;
-                    if (instanceExecParam.perNodeScanRanges.containsKey(scanNode.getId())) {
-                        numScanRanges = instanceExecParam.perNodeScanRanges.get(scanNode.getId()).size();
+                    if (instanceExecParam.perNodeScanRanges.containsKey(scanNode.getId().asInt())) {
+                        numScanRanges = instanceExecParam.perNodeScanRanges.get(scanNode.getId().asInt()).size();
                     }
                     int scanDop = maxNumScanOperators * numScanRanges / totalNumScanRanges;
                     int scanDopLimit = Math.max(1, Math.min(dop, numScanRanges));

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -936,16 +936,16 @@ public class Coordinator {
                 if (scanNode.hasLimit()) {
                     numRows = Math.min(scanNode.getLimit(), numRows);
                 }
-                int maxNumScanOperators = Math.min(1, (int) (numRows / maxRowCountPerScanOperator));
+                int maxNumScanOperators = Math.max(1, (int) (numRows / maxRowCountPerScanOperator));
                 for (FInstanceExecParam instanceExecParam : params.instanceExecParams) {
                     int numScanRanges = 0;
                     if (instanceExecParam.perNodeScanRanges.containsKey(scanNode.getId())) {
                         numScanRanges = instanceExecParam.perNodeScanRanges.get(scanNode.getId()).size();
                     }
                     int scanDop = maxNumScanOperators * numScanRanges / totalNumScanRanges;
-                    int scanDopLimit = Math.min(dop, numScanRanges);
+                    int scanDopLimit = Math.max(1, Math.min(dop, numScanRanges));
                     scanDop = Math.min(scanDopLimit, Math.max(1, scanDop));
-                    instanceExecParam.perNodeScanDop.put(scanNode.getId().asInt(), scanDop);
+                    instanceExecParam.perScanNodeDop.put(scanNode.getId().asInt(), scanDop);
                 }
             }
         }
@@ -1746,7 +1746,7 @@ public class Coordinator {
         TUniqueId instanceId;
         TNetworkAddress host;
         Map<Integer, List<TScanRangeParams>> perNodeScanRanges = Maps.newHashMap();
-        Map<Integer, Integer> perNodeScanDop = Maps.newHashMap();
+        Map<Integer, Integer> perScanNodeDop = Maps.newHashMap();
 
         int perFragmentInstanceIdx;
 
@@ -2035,7 +2035,7 @@ public class Coordinator {
                         params.setIs_pipeline(
                                 fragment.getPlanRoot().canUsePipeLine() && fragment.getSink().canUsePipeLine());
                         params.setPipeline_dop(fragment.getPipelineDop());
-                        params.setPer_node_scan_dop(instanceExecParam.perNodeScanDop);
+                        params.setPer_scan_node_dop(instanceExecParam.perScanNodeDop);
                     }
 
                     if (sessionVariable.isEnableExchangePassThrough()) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -1309,8 +1309,12 @@ public class Coordinator {
                     FragmentExecParams param = fragmentExecParamsMap.get(fragment.getFragmentId());
                     int numBackends = param.scanRangeAssignment.size();
                     int numInstances = param.instanceExecParams.size();
+                    OlapScanNode scanNode = (OlapScanNode) leftMostNode;
+                    int numScanRangesPerInstance = numInstances / scanNode.getScanRangeLocations(0).size();
+                    numScanRangesPerInstance = Math.max(1, numScanRangesPerInstance);
                     int pipelineDop =
                             Math.max(1, degreeOfParallelism / Math.max(1, numInstances / Math.max(1, numBackends)));
+                    pipelineDop = Math.max(1, Math.max(pipelineDop, numScanRangesPerInstance));
                     param.fragment.setPipelineDop(pipelineDop);
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -318,7 +318,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private int pipelineDop = 0;
 
     @VariableMgr.VarAttr(name = PIPELINE_MAX_INPUT_BYTES_PER_OPERATOR, flag = VariableMgr.INVISIBLE)
-    private long pipelineMaxInputBytesPerOperator = 1000000;
+    private long pipelineMaxInputBytesPerOperator = 100000000;
 
     @VariableMgr.VarAttr(name = PIPELINE_PROFILE_MODE)
     private String pipelineProfileMode = "brief";

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -118,6 +118,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String PIPELINE_MAX_ROW_COUNT_PER_SCAN_OPERATOR = "pipeline_max_row_count_per_scan_operator";
 
+    public static final String PIPELINE_MAX_INPUT_BYTES_PER_OPERATOR = "pipeline_max_input_bytes_per_operator";
+
     public static final String PIPELINE_PROFILE_MODE = "pipeline_profile_mode";
 
     // hash join right table push down
@@ -319,6 +321,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = PIPELINE_MAX_ROW_COUNT_PER_SCAN_OPERATOR)
     private long pipelineMaxRowCountPerScanOperator = 262144;
+
+    @VariableMgr.VarAttr(name = PIPELINE_MAX_INPUT_BYTES_PER_OPERATOR)
+    private long pipelineMaxInputBytesPerOperator = 1000000;
 
     @VariableMgr.VarAttr(name = PIPELINE_PROFILE_MODE)
     private String pipelineProfileMode = "brief";
@@ -729,6 +734,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public long getPipelineMaxRowCountPerScanOperator() {
         return pipelineMaxRowCountPerScanOperator;
+    }
+
+    public long getPipelineMaxInputBytesPerOperator() {
+        return pipelineMaxInputBytesPerOperator;
     }
 
     public boolean isEnableReplicationJoin() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -116,6 +116,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String PIPELINE_DOP = "pipeline_dop";
 
+    public static final String PIPELINE_MAX_ROW_COUNT_PER_SCAN_OPERATOR = "pipeline_max_row_count_per_scan_operator";
+
     public static final String PIPELINE_PROFILE_MODE = "pipeline_profile_mode";
 
     // hash join right table push down
@@ -314,6 +316,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = PIPELINE_DOP)
     private int pipelineDop = 0;
+
+    @VariableMgr.VarAttr(name = PIPELINE_MAX_ROW_COUNT_PER_SCAN_OPERATOR)
+    private long pipelineMaxRowCountPerScanOperator = 262144;
 
     @VariableMgr.VarAttr(name = PIPELINE_PROFILE_MODE)
     private String pipelineProfileMode = "brief";
@@ -720,6 +725,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public int getPipelineDop() {
         return this.pipelineDop;
+    }
+
+    public long getPipelineMaxRowCountPerScanOperator() {
+        return pipelineMaxRowCountPerScanOperator;
     }
 
     public boolean isEnableReplicationJoin() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -116,8 +116,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String PIPELINE_DOP = "pipeline_dop";
 
-    public static final String PIPELINE_MAX_ROW_COUNT_PER_SCAN_OPERATOR = "pipeline_max_row_count_per_scan_operator";
-
     public static final String PIPELINE_MAX_INPUT_BYTES_PER_OPERATOR = "pipeline_max_input_bytes_per_operator";
 
     public static final String PIPELINE_PROFILE_MODE = "pipeline_profile_mode";
@@ -319,10 +317,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = PIPELINE_DOP)
     private int pipelineDop = 0;
 
-    @VariableMgr.VarAttr(name = PIPELINE_MAX_ROW_COUNT_PER_SCAN_OPERATOR)
-    private long pipelineMaxRowCountPerScanOperator = 262144;
-
-    @VariableMgr.VarAttr(name = PIPELINE_MAX_INPUT_BYTES_PER_OPERATOR)
+    @VariableMgr.VarAttr(name = PIPELINE_MAX_INPUT_BYTES_PER_OPERATOR, flag = VariableMgr.INVISIBLE)
     private long pipelineMaxInputBytesPerOperator = 1000000;
 
     @VariableMgr.VarAttr(name = PIPELINE_PROFILE_MODE)
@@ -730,10 +725,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public int getPipelineDop() {
         return this.pipelineDop;
-    }
-
-    public long getPipelineMaxRowCountPerScanOperator() {
-        return pipelineMaxRowCountPerScanOperator;
     }
 
     public long getPipelineMaxInputBytesPerOperator() {

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -295,7 +295,7 @@ struct TExecPlanFragmentParams {
 
   50: optional bool is_pipeline
   51: optional i32 pipeline_dop
-  52: optional map<Types.TPlanNodeId, i32> per_node_scan_dop;
+  52: optional map<Types.TPlanNodeId, i32> per_scan_node_dop;
 }
 
 struct TExecPlanFragmentResult {

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -295,6 +295,7 @@ struct TExecPlanFragmentParams {
 
   50: optional bool is_pipeline
   51: optional i32 pipeline_dop
+  52: optional map<Types.TPlanNodeId, i32> per_node_scan_dop;
 }
 
 struct TExecPlanFragmentResult {


### PR DESCRIPTION
## Enhancement

For ScanOperator in pipeline engine, the number of concurrent io tasks is equivalant to the number of ScanOperator instances in a pipeline, the number of tablets, rows and fragment instances detemine how many rows will be fetched by ScanOperaors in a fragment instance. Different ScanOperators have different number of tablets, if the the number of tablets of some ScanOperator is quite large, then the ScanOperator should be assigned a large ScanNode-specific dop.

FE computes degree of parallelism(dop) for each OlapScanNode in a fragment instance. the maxScanOperators is numRows of ScanNode divided by session variable pipelineMaxRowCountPerScanOperator, then each fragment instance take the share of itself own numScanRanges divided by totalNumScanRanges, and the dop of OlapScanNode is at least 1 and at most minimum(itself own numScanRanges, half the avg number of be cores).

If a operator following a ScanOperator directly has a different dop with the ScanOperator, then a Passthrougth operator is interpolated in the middle.
