### PR TITLE
Fix colocate checker concurrent modify exception

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
@@ -312,7 +312,8 @@ public class ColocateTableIndex implements Writable {
     public Set<GroupId> getAllGroupIds() {
         readLock();
         try {
-            return group2Tables.keySet();
+            // make a copy set to avoid ConcurrentModificationException
+            return new HashSet<>(group2Tables.keySet());
         } finally {
             readUnlock();
         }


### PR DESCRIPTION
Make a copy set of groupIds to avoid ConcurrentModificationException