### PR TITLE
fixup NPE in getDegreeOfParallelism in data loading scenarios

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -1085,7 +1085,6 @@ public class Coordinator {
 
         boolean dopAdaptionEnabled = ConnectContext.get() != null &&
                 ConnectContext.get().getSessionVariable().isPipelineDopAdaptionEnabled();
-        int degreeOfParallelism = ConnectContext.get().getSessionVariable().getDegreeOfParallelism();
         for (int i = fragments.size() - 1; i >= 0; --i) {
             PlanFragment fragment = fragments.get(i);
             FragmentExecParams params = fragmentExecParamsMap.get(fragment.getFragmentId());
@@ -1160,6 +1159,7 @@ public class Coordinator {
                 }
 
                 if (dopAdaptionEnabled) {
+                    int degreeOfParallelism = ConnectContext.get().getSessionVariable().getDegreeOfParallelism();
                     Preconditions.checkArgument(leftMostNode instanceof ExchangeNode);
                     DataSink sink = getDataStreamSink(maxParallelismFragmentExecParams.fragment, fragment);
                     Preconditions.checkArgument(sink != null);
@@ -1266,6 +1266,7 @@ public class Coordinator {
                 }
                 // ensure numInstances * pipelineDop = degreeOfParallelism when dop adaptation is enabled
                 if (dopAdaptionEnabled) {
+                    int degreeOfParallelism = ConnectContext.get().getSessionVariable().getDegreeOfParallelism();
                     FragmentExecParams param = fragmentExecParamsMap.get(fragment.getFragmentId());
                     int numBackends = param.scanRangeAssignment.size();
                     int numInstances = param.instanceExecParams.size();


### PR DESCRIPTION
## Bugfix

In LoadLoadingTask, Coordinator.computeFragmentHosts is invoked, in this function, ConnectContext.get().getSessionVariable().getDegreeOfParalllelism() throw NPE, this stmt is just used by pipeline dop adaptation feature, so move the stmt into dop adaption block.

```
java.lang.NullPointerException: null
   at com.starrocks.qe.Coordinator.computeFragmentHosts(Coordinator.java:1125) ~[starrocks-fe.jar:?]
   at com.starrocks.qe.Coordinator.computeFragmentExecParams(Coordinator.java:817) ~[starrocks-fe.jar:?]
   at com.starrocks.qe.Coordinator.exec(Coordinator.java:405) ~[starrocks-fe.jar:?]
   at com.starrocks.load.loadv2.LoadLoadingTask.actualExecute(LoadLoadingTask.java:154) ~[starrocks-fe.jar:?]
   at com.starrocks.load.loadv2.LoadLoadingTask.executeOnce(LoadLoadingTask.java:135) ~[starrocks-fe.jar:?]
   at com.starrocks.load.loadv2.LoadLoadingTask.executeTask(LoadLoadingTask.java:113) ~[starrocks-fe.jar:?]
   at com.starrocks.load.loadv2.LoadTask.exec(LoadTask.java:59) [starrocks-fe.jar:?]
```