### PR TITLE
Consider streaming mode and limit for multi distinct function extra costs compute

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
@@ -3,6 +3,7 @@
 package com.starrocks.sql.optimizer.cost;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
 import com.starrocks.catalog.Catalog;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.qe.ConnectContext;
@@ -37,6 +38,8 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.rule.transformation.JoinPredicateUtils;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
 import com.starrocks.sql.optimizer.statistics.Statistics;
+import com.starrocks.sql.optimizer.statistics.StatisticsCalculator;
+import com.starrocks.sql.optimizer.statistics.StatisticsEstimateCoefficient;
 import com.starrocks.statistic.Constants;
 
 import java.util.List;
@@ -203,8 +206,24 @@ public class CostModel {
 
                     ColumnRefOperator distinctColumn = (ColumnRefOperator) aggregation.getChild(0);
                     distinctColumnStats = inputStatistics.getColumnStatistic(distinctColumn);
-                    // use output row count as bucket
-                    double buckets = statistics.getOutputRowCount();
+                    // Use the number of aggregated rows as buckets, does not equal statistics.getOutputRowCount(),
+                    // Because limit is computed in statistics.getOutputRowCount().
+                    double buckets = StatisticsCalculator.computeGroupByStatistics(node.getGroupBys(), inputStatistics,
+                            Maps.newHashMap());
+                    // If the Local aggregate node enable streaming mode, this aggregation could not compute the extra
+                    // costs when the cardinality GE (child output rows count) * STREAMING_EXTRA_COST_THRESHOLD_COEFFICIENT.
+                    // We estimate this aggregate node use streaming mode, so there is no extra overhead of multi
+                    // distinct functions.
+                    String streamingPreAggregationMode =
+                            ConnectContext.get().getSessionVariable().getStreamingPreaggregationMode();
+                    if (node.getType().isLocal() && (streamingPreAggregationMode.equals("auto") ||
+                            streamingPreAggregationMode.equals("force_streaming"))) {
+                        if (buckets >= inputStatistics.getOutputRowCount() *
+                                StatisticsEstimateCoefficient.STREAMING_EXTRA_COST_THRESHOLD_COEFFICIENT) {
+                            return CostEstimate.zero();
+                        }
+                    }
+
                     double rowSize = distinctColumnStats.getAverageRowSize();
                     // In second phase of aggregation, do not compute extra row size costs
                     if (distinctColumn.getType().isStringType() && !(node.getType().isGlobal() && node.isSplit())) {
@@ -230,7 +249,8 @@ public class CostModel {
                         // 40 bytes is the state cost of hashset
                         hashSetSize = rowSize * distinctValuesPerBucket + 40;
                     }
-                    costEstimate = CostEstimate.addCost(costEstimate, CostEstimate.ofMemory(buckets * hashSetSize));
+                    costEstimate = CostEstimate
+                            .addCost(costEstimate, CostEstimate.ofMemory(statistics.getOutputRowCount() * hashSetSize));
                 }
             }
             return costEstimate;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -583,6 +583,25 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
 
         //Update the statistics of the GroupBy column
         Map<ColumnRefOperator, ColumnStatistic> groupStatisticsMap = new HashMap<>();
+        double rowCount = computeGroupByStatistics(groupBys, inputStatistics, groupStatisticsMap);
+
+        //Update Node Statistics
+        builder.addColumnStatistics(groupStatisticsMap);
+        rowCount = min(inputStatistics.getOutputRowCount(), rowCount);
+        builder.setOutputRowCount(rowCount);
+        // use inputStatistics and aggregateNode cardinality to estimate aggregate call operator column statistics.
+        // because of we need cardinality to estimate count function.
+        double estimateCount = rowCount;
+        aggregations.forEach((key, value) -> builder
+                .addColumnStatistic(key,
+                        ExpressionStatisticCalculator.calculate(value, inputStatistics, estimateCount)));
+
+        context.setStatistics(builder.build());
+        return visitOperator(node, context);
+    }
+
+    public static double computeGroupByStatistics(List<ColumnRefOperator> groupBys, Statistics inputStatistics,
+                                         Map<ColumnRefOperator, ColumnStatistic> groupStatisticsMap) {
         for (ColumnRefOperator groupByColumn : groupBys) {
             ColumnStatistic groupByColumnStatics = inputStatistics.getColumnStatistic(groupByColumn);
             ColumnStatistic.Builder statsBuilder = buildFrom(groupByColumnStatics);
@@ -627,20 +646,7 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
                 }
             }
         }
-
-        //Update Node Statistics
-        builder.addColumnStatistics(groupStatisticsMap);
-        rowCount = min(inputStatistics.getOutputRowCount(), rowCount);
-        builder.setOutputRowCount(rowCount);
-        // use inputStatistics and aggregateNode cardinality to estimate aggregate call operator column statistics.
-        // because of we need cardinality to estimate count function.
-        double estimateCount = rowCount;
-        aggregations.forEach((key, value) -> builder
-                .addColumnStatistic(key,
-                        ExpressionStatisticCalculator.calculate(value, inputStatistics, estimateCount)));
-
-        context.setStatistics(builder.build());
-        return visitOperator(node, context);
+        return rowCount;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsEstimateCoefficient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsEstimateCoefficient.java
@@ -12,13 +12,15 @@ public class StatisticsEstimateCoefficient {
     // expand estimate aggregates row count with default group by columns statistics
     public static final double DEFAULT_GROUP_BY_EXPAND_COEFFICIENT = 1.05;
     // IN predicate default filter rate
-    public static final Double IN_PREDICATE_DEFAULT_FILTER_COEFFICIENT = 0.5;
+    public static final double IN_PREDICATE_DEFAULT_FILTER_COEFFICIENT = 0.5;
     // Is null predicate default filter rate
-    public static final Double IS_NULL_PREDICATE_DEFAULT_FILTER_COEFFICIENT = 0.1;
+    public static final double IS_NULL_PREDICATE_DEFAULT_FILTER_COEFFICIENT = 0.1;
     // unknown filter coefficient for now
-    public static final Double PREDICATE_UNKNOWN_FILTER_COEFFICIENT = 0.25;
+    public static final double PREDICATE_UNKNOWN_FILTER_COEFFICIENT = 0.25;
     // constant value compare constant value filter coefficient
-    public static final Double CONSTANT_TO_CONSTANT_PREDICATE_COEFFICIENT = 0.5;
+    public static final double CONSTANT_TO_CONSTANT_PREDICATE_COEFFICIENT = 0.5;
     // coefficient of overlap percent which overlap range is infinite
-    public static final Double OVERLAP_INFINITE_RANGE_FILTER_COEFFICIENT = 0.5;
+    public static final double OVERLAP_INFINITE_RANGE_FILTER_COEFFICIENT = 0.5;
+    // used in compute extra cost for multi distinct function, estimate whether to trigger streaming
+    public static final double STREAMING_EXTRA_COST_THRESHOLD_COEFFICIENT = 0.8;
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -327,12 +327,25 @@ public class ReplayFromDumpTest {
     }
 
     @Test
-    public void test() throws Exception {
+    public void testDecodeLimitWithProject() throws Exception {
         FeConstants.USE_MOCK_DICT_MANAGER = true;
         Pair<QueryDumpInfo, String> replayPair =
                 getPlanFragment(getDumpInfoFromFile("query_dump/decode_limit_with_project"), null, TExplainLevel.NORMAL);
         Assert.assertTrue(replayPair.second.contains("  12:Decode\n" +
                 "  |  <dict id 42> : <string id 18>"));
         FeConstants.USE_MOCK_DICT_MANAGER = false;
+    }
+
+    @Test
+    public void testCountDistinctWithLimit() throws Exception {
+        // check use two stage agg
+        Pair<QueryDumpInfo, String> replayPair =
+                getPlanFragment(getDumpInfoFromFile("query_dump/count_distinct_limit"), null, TExplainLevel.NORMAL);
+       Assert.assertTrue(replayPair.second.contains("1:AGGREGATE (update serialize)\n" +
+               "  |  STREAMING\n" +
+               "  |  output: multi_distinct_count(5: lo_suppkey)"));
+       Assert.assertTrue(replayPair.second.contains("3:AGGREGATE (merge finalize)\n" +
+               "  |  output: multi_distinct_count(18: count)\n" +
+               "  |  group by: 10: lo_extendedprice, 13: lo_revenue"));
     }
 }

--- a/fe/fe-core/src/test/resources/sql/query_dump/count_distinct_limit.json
+++ b/fe/fe-core/src/test/resources/sql/query_dump/count_distinct_limit.json
@@ -1,0 +1,23 @@
+{
+  "statement":"SELECT COUNT (DISTINCT lo_suppkey), lo_extendedprice, lo_revenue \nFROM lineorder group by lo_extendedprice, lo_revenue \nLIMIT 1;\n",
+  "table_meta":{
+    "ssb_100g.lineorder":"CREATE TABLE `lineorder` (\n  `lo_orderkey` int(11) NOT NULL COMMENT \"\",\n  `lo_linenumber` int(11) NOT NULL COMMENT \"\",\n  `lo_custkey` int(11) NOT NULL COMMENT \"\",\n  `lo_partkey` int(11) NOT NULL COMMENT \"\",\n  `lo_suppkey` int(11) NOT NULL COMMENT \"\",\n  `lo_orderdate` int(11) NOT NULL COMMENT \"\",\n  `lo_orderpriority` varchar(16) NOT NULL COMMENT \"\",\n  `lo_shippriority` int(11) NOT NULL COMMENT \"\",\n  `lo_quantity` int(11) NOT NULL COMMENT \"\",\n  `lo_extendedprice` int(11) NOT NULL COMMENT \"\",\n  `lo_ordtotalprice` int(11) NOT NULL COMMENT \"\",\n  `lo_discount` int(11) NOT NULL COMMENT \"\",\n  `lo_revenue` int(11) NOT NULL COMMENT \"\",\n  `lo_supplycost` int(11) NOT NULL COMMENT \"\",\n  `lo_tax` int(11) NOT NULL COMMENT \"\",\n  `lo_commitdate` int(11) NOT NULL COMMENT \"\",\n  `lo_shipmode` varchar(11) NOT NULL COMMENT \"\"\n) ENGINE\u003dOLAP \nDUPLICATE KEY(`lo_orderkey`)\nCOMMENT \"OLAP\"\nDISTRIBUTED BY HASH(`lo_orderkey`) BUCKETS 192 \nPROPERTIES (\n\"replication_num\" \u003d \"1\",\n\"in_memory\" \u003d \"false\",\n\"storage_format\" \u003d \"DEFAULT\"\n);"
+  },
+  "table_row_count":{
+    "ssb_100g.lineorder":{
+      "lineorder":600037902
+    }
+  },
+  "session_variables":"{\"runtime_join_filter_push_down_limit\":1024000,\"codegen_level\":0,\"cbo_cte_reuse\":false,\"character_set_connection\":\"utf8\",\"cbo_use_correlated_join_estimate\":true,\"enable_insert_strict\":true,\"enable_filter_unused_columns_in_scan_stage\":false,\"div_precision_increment\":4,\"tx_isolation\":\"REPEATABLE-READ\",\"wait_timeout\":28800,\"auto_increment_increment\":1,\"foreign_key_checks\":true,\"character_set_client\":\"utf8\",\"autocommit\":true,\"enable_column_expr_predicate\":false,\"character_set_results\":\"utf8\",\"parallel_fragment_exec_instance_num\":8,\"max_scan_key_num\":-1,\"enable_global_runtime_filter\":true,\"forward_to_master\":false,\"net_read_timeout\":60,\"streaming_preaggregation_mode\":\"auto\",\"storage_engine\":\"olap\",\"cbo_enable_dp_join_reorder\":true,\"cbo_enable_low_cardinality_optimize\":false,\"tx_visible_wait_timeout\":10,\"cbo_max_reorder_node_use_exhaustive\":4,\"new_planner_optimize_timeout\":3000,\"force_schedule_local\":false,\"pipeline_dop\":1,\"enable_query_dump\":false,\"cbo_enable_greedy_join_reorder\":true,\"prefer_join_method\":\"broadcast\",\"load_mem_limit\":0,\"sql_select_limit\":9223372036854775807,\"profiling\":false,\"sql_safe_updates\":0,\"enable_pipeline_engine\":false,\"query_cache_type\":0,\"disable_colocate_join\":false,\"max_pushdown_conditions_per_column\":-1,\"enable_vectorized_engine\":true,\"net_write_timeout\":60,\"collation_database\":\"utf8_general_ci\",\"hash_join_push_down_right_table\":true,\"enable_exchange_pass_through\":true,\"new_planner_agg_stage\":0,\"pipeline_profile_mode\":\"brief\",\"collation_connection\":\"utf8_general_ci\",\"resource_group\":\"normal\",\"broadcast_row_limit\":15000000,\"exec_mem_limit\":21474836480,\"cbo_max_reorder_node_use_dp\":10,\"disable_join_reorder\":false,\"is_report_success\":true,\"enable_groupby_use_output_alias\":false,\"net_buffer_length\":16384,\"transmission_compression_type\":\"LZ4\",\"enable_vectorized_insert\":true,\"interactive_timeout\":3600,\"enable_spilling\":false,\"batch_size\":1024,\"cbo_enable_replicated_join\":true,\"max_allowed_packet\":1048576,\"query_timeout\":180,\"enable_cbo\":true,\"collation_server\":\"utf8_general_ci\",\"time_zone\":\"Asia/Shanghai\",\"max_execution_time\":3000000,\"character_set_server\":\"utf8\",\"cbo_use_nth_exec_plan\":0,\"rewrite_count_distinct_to_bitmap_hll\":true,\"parallel_exchange_instance_num\":-1,\"sql_mode\":2,\"SQL_AUTO_IS_NULL\":false,\"event_scheduler\":\"OFF\",\"disable_streaming_preaggregations\":false}",
+  "column_statistics":{
+    "ssb_100g.lineorder":{
+      "lo_revenue":"[84348.0, 1.035985E7, 0.0, 4.0, 4138926.0] ESTIMATE",
+      "lo_extendedprice":"[90697.0, 1.042475E7, 0.0, 4.0, 909913.0] ESTIMATE",
+      "lo_suppkey":"[1.0, 200000.0, 0.0, 4.0, 200496.0] ESTIMATE"
+    }
+  },
+  "be_number":3,
+  "exception":[
+
+  ]
+}


### PR DESCRIPTION
#2536 
In cost model for now., we will compute extra costs for multi distinct function because it used hashset which has additional memory overhead.
changes：
1. Because the Local Agg Node could use streaming Mode, these extra costs should not computed, So when meet the streaming mode requirements, extra costs will not computed.
2. In computeAggFunExtraCost we use statistics output row count as buckets which computed limit before,  use the number of aggregated rows as buckets now .
