### PR TITLE
StarRocks support kerberos authentication

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/CreateUserStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/CreateUserStmt.java
@@ -24,11 +24,13 @@ package com.starrocks.analysis;
 import com.google.common.base.Strings;
 import com.starrocks.catalog.Catalog;
 import com.starrocks.cluster.ClusterNamespace;
+import com.starrocks.common.Config;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.FeNameFormat;
 import com.starrocks.common.UserException;
 import com.starrocks.mysql.MysqlPassword;
+import com.starrocks.mysql.privilege.Auth;
 import com.starrocks.mysql.privilege.Auth.PrivLevel;
 import com.starrocks.mysql.privilege.AuthPlugin;
 import com.starrocks.mysql.privilege.PrivPredicate;
@@ -161,6 +163,12 @@ public class CreateUserStmt extends DdlStmt {
                     }
                 } else {
                     scramblePassword = new byte[0];
+                }
+            } else if (AuthPlugin.AUTHENTICATION_KERBEROS.name().equals(authPlugin) && Auth.isSupportKerberosAuth()) {
+                if (userForAuthPlugin != null) {
+                    userForAuthPlugin = this.authString;
+                } else {
+                    userForAuthPlugin = Config.authentication_kerberos_service_principal.split("@")[1];
                 }
             } else {
                 ErrorReport.reportAnalysisException(ErrorCode.ERR_AUTH_PLUGIN_NOT_LOADED, authPlugin);

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/CreateUserStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/CreateUserStmt.java
@@ -165,7 +165,7 @@ public class CreateUserStmt extends DdlStmt {
                     scramblePassword = new byte[0];
                 }
             } else if (AuthPlugin.AUTHENTICATION_KERBEROS.name().equalsIgnoreCase(authPlugin) &&
-                    Auth.isSupportKerberosAuth()) {
+                    Catalog.getCurrentCatalog().getAuth().isSupportKerberosAuth()) {
                 // In kerberos authentication, userForAuthPlugin represents the user principal realm.
                 // If user realm is not specified when creating user, the service principal realm will be used as
                 // the user principal realm by default.

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/CreateUserStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/CreateUserStmt.java
@@ -149,9 +149,9 @@ public class CreateUserStmt extends DdlStmt {
          */
         if (!Strings.isNullOrEmpty(authPlugin)) {
             authPlugin = authPlugin.toUpperCase();
-            if (AuthPlugin.AUTHENTICATION_LDAP_SIMPLE.name().equals(authPlugin)) {
+            if (AuthPlugin.AUTHENTICATION_LDAP_SIMPLE.name().equalsIgnoreCase(authPlugin)) {
                 this.userForAuthPlugin = this.authString;
-            } else if (AuthPlugin.MYSQL_NATIVE_PASSWORD.name().equals(authPlugin)) {
+            } else if (AuthPlugin.MYSQL_NATIVE_PASSWORD.name().equalsIgnoreCase(authPlugin)) {
                 // in this case, authString is password
                 // convert password to hashed password
                 if (!Strings.isNullOrEmpty(authString)) {
@@ -164,7 +164,11 @@ public class CreateUserStmt extends DdlStmt {
                 } else {
                     scramblePassword = new byte[0];
                 }
-            } else if (AuthPlugin.AUTHENTICATION_KERBEROS.name().equals(authPlugin) && Auth.isSupportKerberosAuth()) {
+            } else if (AuthPlugin.AUTHENTICATION_KERBEROS.name().equalsIgnoreCase(authPlugin) &&
+                    Auth.isSupportKerberosAuth()) {
+                // In kerberos authentication, userForAuthPlugin represents the user principal realm.
+                // If user realm is not specified when creating user, the service principal realm will be used as
+                // the user principal realm by default.
                 if (userForAuthPlugin != null) {
                     userForAuthPlugin = this.authString;
                 } else {

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1154,6 +1154,24 @@ public class Config extends ConfigBase {
     public static String auth_token = "";
 
     /**
+     * If set to true and the jar that use to authentication is loaded in fe, kerberos authentication is supported.
+     */
+    @ConfField(mutable = true)
+    public static boolean authentication_kerberos_enabled = false;
+
+    /**
+     * Service principal name. like "starrocks-fe/hostname@STARROCKS.COM"
+     */
+    @ConfField(mutable = true)
+    public static String authentication_kerberos_service_principal = "";
+
+    /**
+     * Service principal key file path exported from kdc. like "$HOME/path/to/starrocks-fe.keytab"
+     */
+    @ConfField(mutable = true)
+    public static String authentication_kerberos_service_key_tab = "";
+
+    /**
      * In some cases, some tablets may have all replicas damaged or lost.
      * At this time, the data has been lost, and the damaged tablets
      * will cause the entire query to fail, and the remaining healthy tablets cannot be queried.

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1157,16 +1157,27 @@ public class Config extends ConfigBase {
      * If set to true and the jar that use to authentication is loaded in fe, kerberos authentication is supported.
      */
     @ConfField(mutable = true)
-    public static boolean authentication_kerberos_enabled = false;
+    public static boolean enable_authentication_kerberos = false;
 
     /**
-     * Service principal name. like "starrocks-fe/hostname@STARROCKS.COM"
+     * If kerberos authentication is enabled, the configuration must be filled.
+     * like "starrocks-fe/<HOSTNAME>@STARROCKS.COM".
+     *
+     * Service principal name (SPN) is sent to clients that attempt to authenticate using Kerberos.
+     * The SPN must be present in the database managed by the KDC server, and its key file
+     * needs to be exported and configured. See authentication_kerberos_service_key_tab for details.
      */
     @ConfField(mutable = true)
     public static String authentication_kerberos_service_principal = "";
 
     /**
-     * Service principal key file path exported from kdc. like "$HOME/path/to/starrocks-fe.keytab"
+     * If kerberos authentication is enabled, the configuration must be filled.
+     * like "$HOME/path/to/your/starrocks-fe.keytab"
+     *
+     * The keytab file for authenticating tickets received from clients.
+     * This file must exist and contain a valid key for the SPN or authentication of clients will fail.
+     * Export keytab file requires KDC administrator to operate.
+     * for example: ktadd -norandkey -k /path/to/starrocks-fe.keytab starrocks-fe/<HOSTNAME>@STARROCKS.COM
      */
     @ConfField(mutable = true)
     public static String authentication_kerberos_service_key_tab = "";

--- a/fe/fe-core/src/main/java/com/starrocks/common/FeNameFormat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/FeNameFormat.java
@@ -33,6 +33,7 @@ public class FeNameFormat {
     // so it can not distinguish whether it is an operator or a column name
     // the future new design will improve this problem and open this limitation
     private static final String COLUMN_NAME_REGEX = "^[^\0=<>!\\*]{1,64}$";
+    private static final String MYSQL_USER_NAME_REGEX = "^[a-zA-Z][a-zA-Z0-9_]{1,63}/?[.a-zA-Z0-9_-]{0,63}$";
 
     public static final String FORBIDDEN_PARTITION_NAME = "placeholder_";
 
@@ -92,7 +93,7 @@ public class FeNameFormat {
     }
 
     public static void checkUserName(String userName) throws AnalysisException {
-        if (Strings.isNullOrEmpty(userName) || !userName.matches(COMMON_NAME_REGEX)) {
+        if (Strings.isNullOrEmpty(userName) || !userName.matches(MYSQL_USER_NAME_REGEX) || userName.length() > 64) {
             throw new AnalysisException("invalid user name: " + userName);
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/common/FeNameFormat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/FeNameFormat.java
@@ -33,6 +33,8 @@ public class FeNameFormat {
     // so it can not distinguish whether it is an operator or a column name
     // the future new design will improve this problem and open this limitation
     private static final String COLUMN_NAME_REGEX = "^[^\0=<>!\\*]{1,64}$";
+
+    // The user name  by kerberos authentication may include the host name, so additional adaptation is required.
     private static final String MYSQL_USER_NAME_REGEX = "^[a-zA-Z][a-zA-Z0-9_]{1,63}/?[.a-zA-Z0-9_-]{0,63}$";
 
     public static final String FORBIDDEN_PARTITION_NAME = "placeholder_";

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlProto.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlProto.java
@@ -29,7 +29,6 @@ import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
-import com.starrocks.mysql.privilege.Auth;
 import com.starrocks.mysql.privilege.UserResource;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.system.SystemInfoService;
@@ -180,7 +179,7 @@ public class MysqlProto {
             serializer.reset();
             // 2. build the auth switch request and send to the client
             if (authPluginName.equals(AUTHENTICATION_KERBEROS_CLIENT)) {
-                if (Auth.isSupportKerberosAuth()) {
+                if (Catalog.getCurrentCatalog().getAuth().isSupportKerberosAuth()) {
                     try {
                         handshakePacket.buildKrb5AuthRequest(serializer, context.getRemoteIP(), authPacket.getUser());
                     } catch (Exception e) {

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Auth.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Auth.java
@@ -75,7 +75,7 @@ public class Auth implements Writable {
     public static final String ROOT_USER = "root";
     public static final String ADMIN_USER = "admin";
 
-    public static final String KRB5_AUTH_CLASS_NAME = "com.starrocks.auth.KerberosAuthentication";
+    public static final String KRB5_AUTH_CLASS_NAME = "com.starrocks.plugins.auth.KerberosAuthentication";
     public static final String KRB5_AUTH_JAR_PATH = StarRocksFE.STARROCKS_HOME_DIR + "/lib/starrocks-kerberos.jar";
 
     private UserPrivTable userPrivTable = new UserPrivTable();
@@ -1401,7 +1401,7 @@ public class Auth implements Writable {
     }
 
     public static boolean isSupportKerberosAuth() {
-        if (!Config.authentication_kerberos_enabled ||
+        if (!Config.enable_authentication_kerberos ||
                 Config.authentication_kerberos_service_key_tab.isEmpty() ||
                 Config.authentication_kerberos_service_principal.isEmpty()) {
             return false;

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/AuthPlugin.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/AuthPlugin.java
@@ -3,6 +3,7 @@
 package com.starrocks.mysql.privilege;
 
 public enum AuthPlugin {
+    MYSQL_NATIVE_PASSWORD,
     AUTHENTICATION_LDAP_SIMPLE,
-    MYSQL_NATIVE_PASSWORD
+    AUTHENTICATION_KERBEROS
 }

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Password.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Password.java
@@ -4,6 +4,7 @@ package com.starrocks.mysql.privilege;
 
 import com.google.common.base.Strings;
 import com.google.gson.annotations.SerializedName;
+import com.starrocks.common.Config;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.mysql.MysqlPassword;
@@ -14,9 +15,15 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+
+import static com.starrocks.mysql.privilege.Auth.KRB5_AUTH_JAR_PATH;
 
 public class Password implements Writable {
     private static final Logger LOG = LogManager.getLogger(Password.class);
@@ -101,6 +108,25 @@ public class Password implements Writable {
                 return LdapSecurity.checkPassword(userForAuthPlugin, new String(clearPassword, StandardCharsets.UTF_8));
             } else {
                 return LdapSecurity.checkPasswordByRoot(remoteUser, new String(clearPassword, StandardCharsets.UTF_8));
+            }
+        } else if (authPlugin == AuthPlugin.AUTHENTICATION_KERBEROS) {
+            try {
+                File jarFile = new File(KRB5_AUTH_JAR_PATH);
+                ClassLoader loader = URLClassLoader.newInstance(
+                        new URL[] { jarFile.toURL() },
+                        getClass().getClassLoader()
+                );
+
+                Class<?> authClazz = Class.forName(Auth.KRB5_AUTH_CLASS_NAME, true, loader);
+                Method method = authClazz.getMethod("authenticate",
+                        String.class, String.class, String.class, byte[].class);
+                return (boolean) method.invoke(null,
+                        Config.authentication_kerberos_service_principal,
+                        Config.authentication_kerberos_service_key_tab,
+                        remoteUser + "@" + userForAuthPlugin, remotePassword);
+            } catch (Exception e) {
+                LOG.error("Failed to authenticate for [user: {}] by kerberos, msg: ", remoteUser, e);
+                return false;
             }
         } else {
             LOG.warn("unknown auth plugin {} to check password", authPlugin);

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Password.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Password.java
@@ -4,6 +4,7 @@ package com.starrocks.mysql.privilege;
 
 import com.google.common.base.Strings;
 import com.google.gson.annotations.SerializedName;
+import com.starrocks.catalog.Catalog;
 import com.starrocks.common.Config;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
@@ -15,15 +16,11 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.DataInput;
 import java.io.DataOutput;
-import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Method;
-import java.net.URL;
-import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
-import static com.starrocks.mysql.privilege.Auth.KRB5_AUTH_JAR_PATH;
 
 public class Password implements Writable {
     private static final Logger LOG = LogManager.getLogger(Password.class);
@@ -111,13 +108,7 @@ public class Password implements Writable {
             }
         } else if (authPlugin == AuthPlugin.AUTHENTICATION_KERBEROS) {
             try {
-                File jarFile = new File(KRB5_AUTH_JAR_PATH);
-                ClassLoader loader = URLClassLoader.newInstance(
-                        new URL[] { jarFile.toURL() },
-                        getClass().getClassLoader()
-                );
-
-                Class<?> authClazz = Class.forName(Auth.KRB5_AUTH_CLASS_NAME, true, loader);
+                Class<?> authClazz = Catalog.getCurrentCatalog().getAuth().getAuthClazz();
                 Method method = authClazz.getMethod("authenticate",
                         String.class, String.class, String.class, byte[].class);
                 return (boolean) method.invoke(null,

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/UserPrivTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/UserPrivTable.java
@@ -71,6 +71,11 @@ public class UserPrivTable extends PrivTable {
         return null;
     }
 
+    /**
+     * Sometimes a password is required in the handshake process using plugin authentication,
+     * such as kerberos authentication. This interface is mainly used to obtain password information approximately
+     * before {@link Auth#checkPassword}. for sending handshake request.
+     */
     public Password getPasswordByApproximate(String remoteUser, String remoteHost) {
         for (PrivEntry entry : entries) {
             GlobalPrivEntry globalPrivEntry = (GlobalPrivEntry) entry;

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/UserPrivTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/UserPrivTable.java
@@ -71,6 +71,26 @@ public class UserPrivTable extends PrivTable {
         return null;
     }
 
+    public Password getPasswordByApproximate(String remoteUser, String remoteHost) {
+        for (PrivEntry entry : entries) {
+            GlobalPrivEntry globalPrivEntry = (GlobalPrivEntry) entry;
+
+            // check host
+            if (!globalPrivEntry.isAnyHost() && !globalPrivEntry.getHostPattern().match(remoteHost)) {
+                continue;
+            }
+
+            // check user
+            if (!globalPrivEntry.isAnyUser() && !globalPrivEntry.getUserPattern().match(remoteUser)) {
+                continue;
+            }
+
+            return globalPrivEntry.getPassword();
+        }
+
+        return null;
+    }
+
     /*
      * Check if user@host has specified privilege
      */


### PR DESCRIPTION
Kerberos is a computer network authentication protocol that allows an entity to communicate in a non-secure network environment and prove its identity to another entity in a secure way. Since Hadoop-related applications all support the Kerberos protocol, StarRocks Enterprise Edition also needs support for the Kerberos protocol.

usage:
- Only MySQL client 8.0.26 and above versions support Kerberos authentication.
- Only enterprise edition support Kerberos authentication.
- Support dynamic configuration and classes; no need to restart FE.
- You would add the following configuration by "admin set frontend config" clause or fe.conf:
   1. enable_authentication_kerberos=true
   2. authentication_kerberos_service_principal=<YOUR_SERVICE_PRINCIPAL>
   3. authentication_kerberos_service_key_tab=<YOUR_SERVICE_PRINCIPAL_KEYTAB_FILE_PATH>

syntax:
```SQL
CREATE USER
user_identity [auth_option]
[DEFAULT ROLE 'role_name']

user_identity:
    'user_name'@'host'

auth_option: {
    IDENTIFIED BY 'auth_string'
    IDENTIFIED WITH auth_plugin
    IDENTIFIED WITH auth_plugin BY 'auth_string'
    IDENTIFIED WITH auth_plugin AS 'auth_string'
}
```
The syntax remains the same, but `authentication_kerberos` is added to auth_plugin.
If you do not specify user realm to create a user, use service principal realm as the default value.

connect to starrocks fe:
If you have cached TGT, you can execute the following command:

```
mysql --default-auth=authentication_kerberos_client -u stephen
```
or
```
mysql --default-auth=authentication_kerberos_client -u stephen -p
```
Then input your user principal password.

The above principles need to be registered in advance with the KDC server.

