### PR TITLE
[ISSUE-2618] [ResourceIsolation] Add WorkGroup class to support resource isolation in BE

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -185,6 +185,7 @@ set(EXEC_FILES
     pipeline/set/intersect_build_sink_operator.cpp
     pipeline/set/intersect_probe_sink_operator.cpp
     pipeline/set/intersect_output_source_operator.cpp
+    workgroup/work_group.cpp
 )
 
 # simdjson Runtime Implement Dispatch: https://github.com/simdjson/simdjson/blob/master/doc/implementation-selection.md#runtime-cpu-detection

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -8,6 +8,7 @@
 #include "column/chunk.h"
 #include "exec/pipeline/pipeline_driver_dispatcher.h"
 #include "exec/pipeline/source_operator.h"
+#include "exec/workgroup/work_group.h"
 #include "runtime/exec_env.h"
 #include "runtime/runtime_state.h"
 

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -347,6 +347,15 @@ std::string PipelineDriver::to_readable_string() const {
     return ss.str();
 }
 
+starrocks::workgroup::WorkGroup* PipelineDriver::workgroup() {
+    DCHECK(_workgroup != nullptr);
+    return _workgroup;
+}
+
+void PipelineDriver::set_workgroup(starrocks::workgroup::WorkGroup* wg) {
+    this->_workgroup = wg;
+}
+
 bool PipelineDriver::_check_fragment_is_canceled(RuntimeState* runtime_state) {
     if (_fragment_ctx->is_canceled()) {
         cancel_operators(runtime_state);

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -15,9 +15,11 @@
 #include "exec/pipeline/query_context.h"
 #include "exec/pipeline/runtime_filter_types.h"
 #include "exec/pipeline/source_operator.h"
-#include "exec/workgroup/work_group.h"
 #include "util/phmap/phmap.h"
 namespace starrocks {
+namespace workgroup {
+class WorkGroup;
+}
 namespace pipeline {
 
 class PipelineDriver;

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -15,6 +15,7 @@
 #include "exec/pipeline/query_context.h"
 #include "exec/pipeline/runtime_filter_types.h"
 #include "exec/pipeline/source_operator.h"
+#include "exec/workgroup/work_group.h"
 #include "util/phmap/phmap.h"
 namespace starrocks {
 namespace pipeline {
@@ -319,6 +320,10 @@ public:
 
     std::string to_readable_string() const;
 
+    starrocks::workgroup::WorkGroup* workgroup();
+
+    void set_workgroup(starrocks::workgroup::WorkGroup* wg);
+
 private:
     // check whether fragment is cancelled. It is used before pull_chunk and push_chunk.
     bool _check_fragment_is_canceled(RuntimeState* runtime_state);
@@ -360,6 +365,8 @@ private:
     const int64_t _yield_max_time_spent;
 
     phmap::flat_hash_map<int32_t, OperatorStage> _operator_stages;
+
+    starrocks::workgroup::WorkGroup* _workgroup = nullptr;
 
     // metrics
     RuntimeProfile::Counter* _total_timer = nullptr;

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -26,7 +26,7 @@ void WorkGroupManager::add_workgroup(const WorkGroupPtr& wg) {
     if (!_workgroups.count(wg->id())) {
         _workgroups[wg->id()] = wg;
         _wg_cpu_queue.push(wg);
-        _wg_cpu_queue.push(wg);
+        _wg_io_queue.push(wg);
     }
 }
 

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -1,0 +1,73 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#include "exec/workgroup/work_group.h"
+
+#include "runtime/exec_env.h"
+
+namespace starrocks {
+namespace workgroup {
+WorkGroup::WorkGroup(const std::string& name, int id, size_t cpu_limit, size_t memory_limit, size_t concurrency,
+                     WorkGroupType type)
+        : _name(name),
+          _id(id),
+          _cpu_limit(cpu_limit),
+          _memory_limit(memory_limit),
+          _concurrency(concurrency),
+          _type(type) {
+    _mem_tracker = std::make_shared<starrocks::MemTracker>(memory_limit, name,
+                                                           ExecEnv::GetInstance()->query_pool_mem_tracker());
+    _driver_queue = std::make_unique<starrocks::pipeline::QuerySharedDriverQueue>();
+}
+WorkGroupManager::WorkGroupManager() {}
+WorkGroupManager::~WorkGroupManager() {}
+
+void WorkGroupManager::add_workgroup(const WorkGroupPtr& wg) {
+    std::lock_guard<std::mutex> lock(_mutex);
+    if (!_workgroups.count(wg->id())) {
+        _workgroups[wg->id()] = wg;
+        _wg_cpu_queue.push(wg);
+        _wg_cpu_queue.push(wg);
+    }
+}
+
+void WorkGroupManager::remove_workgroup(int wg_id) {
+    std::lock_guard<std::mutex> lock(_mutex);
+    if (_workgroups.count(wg_id)) {
+        auto wg = std::move(_workgroups[wg_id]);
+        _workgroups.erase(wg_id);
+        wg->mark_del();
+    }
+}
+
+WorkGroupPtr WorkGroupManager::pick_next_wg_for_cpu() {
+    std::lock_guard<std::mutex> lock(_mutex);
+    while (!_wg_cpu_queue.empty()) {
+        auto wg = std::move(_wg_cpu_queue.top());
+        if (!wg->is_mark_del()) {
+            return wg;
+        }
+    }
+    return nullptr;
+}
+
+WorkGroupPtr WorkGroupManager::pick_next_wg_for_io() {
+    std::lock_guard<std::mutex> lock(_mutex);
+    while (!_wg_io_queue.empty()) {
+        auto wg = std::move(_wg_io_queue.top());
+        if (!wg->is_mark_del()) {
+            return wg;
+        }
+    }
+    return nullptr;
+}
+
+class DefaultWorkGroupInitialization {
+public:
+    DefaultWorkGroupInitialization() {
+        auto default_wg = std::make_shared<WorkGroup>("default_wg", 1, 10, 10, 10, WorkGroupType::WG_DEFAULT);
+        WorkGroupManager::instance()->add_workgroup(default_wg);
+    }
+} init;
+
+} // namespace workgroup
+} // namespace starrocks

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -51,6 +51,14 @@ WorkGroupPtr WorkGroupManager::pick_next_wg_for_io() {
     return _wg_io_queue.pick_next();
 }
 
+WorkGroupQueue& WorkGroupManager::get_cpu_queue() {
+    return _wg_cpu_queue;
+}
+
+WorkGroupQueue& WorkGroupManager::get_io_queue() {
+    return _wg_io_queue;
+}
+
 namespace {
 class DefaultWorkGroupInitialization {
 public:

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -13,11 +13,14 @@ WorkGroup::WorkGroup(const std::string& name, int id, size_t cpu_limit, size_t m
           _cpu_limit(cpu_limit),
           _memory_limit(memory_limit),
           _concurrency(concurrency),
-          _type(type) {
-    _mem_tracker = std::make_shared<starrocks::MemTracker>(memory_limit, name,
+          _type(type) {}
+
+void WorkGroup::init() {
+    _mem_tracker = std::make_shared<starrocks::MemTracker>(_memory_limit, _name,
                                                            ExecEnv::GetInstance()->query_pool_mem_tracker());
     _driver_queue = std::make_unique<starrocks::pipeline::QuerySharedDriverQueue>();
 }
+
 WorkGroupManager::WorkGroupManager() {}
 WorkGroupManager::~WorkGroupManager() {}
 
@@ -48,13 +51,16 @@ WorkGroupPtr WorkGroupManager::pick_next_wg_for_io() {
     return _wg_io_queue.pick_next();
 }
 
+namespace {
 class DefaultWorkGroupInitialization {
 public:
     DefaultWorkGroupInitialization() {
         auto default_wg = std::make_shared<WorkGroup>("default_wg", 1, 10, 10, 10, WorkGroupType::WG_DEFAULT);
+        default_wg->init();
         WorkGroupManager::instance()->add_workgroup(default_wg);
     }
-} init;
+} _;
+} // namespace
 
 } // namespace workgroup
 } // namespace starrocks

--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -24,12 +24,15 @@ using CpuWorkGroupQueue = WorkGroupQueue<CpuPriorityComparator>;
 using IoWorkQroupQueue = WorkGroupQueue<IoPriorityComparator>;
 
 class WorkGroupManager;
-enum WorkGroupType {
-    WG_NORMAL = 0,
-    WG_DEFAULT = 1,
-    WG_REALTIME = 2,
-};
 
+enum WorkGroupType {
+    WG_NORMAL = 0, // normal work group, maybe added to the BE dynamically
+    WG_DEFAULT = 1, // default work group
+    WG_REALTIME = 2, // realtime work group, maybe reserved beforehand
+};
+// WorkGroup is the unit of resource isolation, it has {CPU, Memory, Concurrency} quotas which limit the
+// resource usage of the queries belonging to the WorkGroup. Each user has be bound to a WorkGroup, when
+// the user issues a query, then the corresponding WorkGroup is chosen to manage the query.
 class WorkGroup {
 public:
     WorkGroup(const std::string& name, int id, size_t cpu_limit, size_t memory_limit, size_t concurrency,
@@ -91,6 +94,8 @@ public:
     }
 };
 
+// WorkGroupManager is a singleton used to manage WorkGroup instances in BE, it has an io queue and a cpu queues for
+// pick next workgroup for computation and launching io tasks.
 class WorkGroupManager {
     DECLARE_SINGLETON(WorkGroupManager);
 

--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -20,13 +20,13 @@ using WorkGroupPtr = std::shared_ptr<WorkGroup>;
 class WorkGroupQueue {
 public:
     WorkGroupQueue() = default;
-    ~WorkGroupQueue() = default;
-    virtual void add(const WorkGroupPtr& wg);
-    virtual void remove(const WorkGroupPtr& wg);
-    virtual WorkGroupPtr pick_next();
+    virtual ~WorkGroupQueue() = default;
+    virtual void add(const WorkGroupPtr& wg) = 0;
+    virtual void remove(const WorkGroupPtr& wg) = 0;
+    virtual WorkGroupPtr pick_next() = 0;
 };
 
-class CpuWorkGroupQueue : public WorkGroupQueue {
+class CpuWorkGroupQueue final : public WorkGroupQueue {
 public:
     CpuWorkGroupQueue() = default;
     ~CpuWorkGroupQueue() = default;
@@ -35,7 +35,7 @@ public:
     WorkGroupPtr pick_next() override { return nullptr; }
 };
 
-class IoWorkGroupQueue : public WorkGroupQueue {
+class IoWorkGroupQueue final : public WorkGroupQueue {
 public:
     IoWorkGroupQueue() = default;
     ~IoWorkGroupQueue() = default;
@@ -59,6 +59,8 @@ public:
     WorkGroup(const std::string& name, int id, size_t cpu_limit, size_t memory_limit, size_t concurrency,
               WorkGroupType type);
     ~WorkGroup() = default;
+
+    void init();
 
     starrocks::MemTracker* mem_tracker() { return _mem_tracker.get(); }
     starrocks::pipeline::DriverQueue* driver_queue() { return _driver_queue.get(); }

--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -1,0 +1,115 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#pragma once
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <queue>
+#include <unordered_map>
+
+#include "exec/pipeline/pipeline_driver_queue.h"
+#include "runtime/mem_tracker.h"
+#include "storage/olap_define.h"
+
+namespace starrocks {
+namespace workgroup {
+
+class WorkGroup;
+using WorkGroupPtr = std::shared_ptr<WorkGroup>;
+template <typename Compare>
+using WorkGroupQueue = std::priority_queue<WorkGroupPtr, std::vector<WorkGroupPtr>, Compare>;
+class CpuPriorityComparator;
+class IoPriorityComparator;
+using CpuWorkGroupQueue = WorkGroupQueue<CpuPriorityComparator>;
+using IoWorkQroupQueue = WorkGroupQueue<IoPriorityComparator>;
+
+class WorkGroupManager;
+enum WorkGroupType {
+    WG_NORMAL = 0,
+    WG_DEFAULT = 1,
+    WG_REALTIME = 2,
+};
+
+class WorkGroup {
+public:
+    WorkGroup(const std::string& name, int id, size_t cpu_limit, size_t memory_limit, size_t concurrency,
+              WorkGroupType type);
+    ~WorkGroup() = default;
+
+    starrocks::MemTracker* mem_tracker() { return _mem_tracker.get(); }
+    starrocks::pipeline::DriverQueue* driver_queue() { return _driver_queue.get(); }
+
+    int id() const { return _id; }
+    bool is_mark_del() { return _mark_del.load(std::memory_order_acquire); }
+    void mark_del() { return _mark_del.store(true, std::memory_order_release); }
+    int get_cpu_priority() {
+        // TODO: implement cpu priority computation
+        return 0;
+    }
+    int get_io_priority() {
+        // TODO: implement io priority computation
+        return 0;
+    }
+
+private:
+    std::string _name;
+    int _id;
+    size_t _cpu_limit;
+    size_t _memory_limit;
+    size_t _concurrency;
+    WorkGroupType _type;
+    std::atomic<bool> _mark_del{false};
+    std::shared_ptr<starrocks::MemTracker> _mem_tracker;
+    starrocks::pipeline::DriverQueuePtr _driver_queue;
+    // it's proper to define Context as a Thrift or protobuf struct.
+    // WorkGroupContext _context;
+};
+
+class CpuPriorityComparator {
+public:
+    bool operator()(const WorkGroupPtr& lhs, const WorkGroupPtr& rhs) const {
+        if (lhs->is_mark_del()) {
+            return true;
+        }
+        if (rhs->is_mark_del()) {
+            return false;
+        }
+        return lhs->get_cpu_priority() < rhs->get_cpu_priority();
+    }
+};
+
+class IoPriorityComparator {
+public:
+    bool operator()(const WorkGroupPtr& lhs, const WorkGroupPtr& rhs) const {
+        if (lhs->is_mark_del()) {
+            return true;
+        }
+        if (rhs->is_mark_del()) {
+            return false;
+        }
+        return lhs->get_io_priority() < rhs->get_io_priority();
+    }
+};
+
+class WorkGroupManager {
+    DECLARE_SINGLETON(WorkGroupManager);
+
+public:
+    // add a new workgroup to WorkGroupManger
+    void add_workgroup(const WorkGroupPtr& wg);
+    // remove already-existing workgroup from WorkGroupManager
+    void remove_workgroup(int wg_id);
+    // get next workgroup for computation
+    WorkGroupPtr pick_next_wg_for_cpu();
+    // get next workgroup for io
+    WorkGroupPtr pick_next_wg_for_io();
+
+private:
+    std::mutex _mutex;
+    std::unordered_map<int, WorkGroupPtr> _workgroups;
+    CpuWorkGroupQueue _wg_cpu_queue;
+    IoWorkQroupQueue _wg_io_queue;
+};
+
+} // namespace workgroup
+} // namespace starrocks

--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -103,6 +103,10 @@ public:
     // get next workgroup for io
     WorkGroupPtr pick_next_wg_for_io();
 
+    WorkGroupQueue& get_cpu_queue();
+
+    WorkGroupQueue& get_io_queue();
+
 private:
     std::mutex _mutex;
     std::unordered_map<int, WorkGroupPtr> _workgroups;


### PR DESCRIPTION
## Enhancement

Hybrid workloads can be executed meanwhile, WorkGroup class is added to isolate different workloads and a WorkGroup have its own {memory, CPU, IO} quotas. A user is bounded to a specified a WorkGroup, when a query is issued by a user, the resource usage of this query execution is limited by the corresponding WorkGroup.