### PR TITLE
Support add context line number in Status

### DIFF
--- a/be/src/common/status.cpp
+++ b/be/src/common/status.cpp
@@ -25,7 +25,7 @@ inline const char* assemble_state(TStatusCode::type code, Slice msg, Slice ctx) 
     const uint16_t len2 = ctx.size;
     const uint32_t size = static_cast<uint32_t>(len1) + len2;
     auto result = new char[size + 5];
-    memcpy(result + 0, &len1, sizeof(len1));
+    memcpy(result, &len1, sizeof(len1));
     memcpy(result + 2, &len2, sizeof(len2));
     result[4] = static_cast<char>(code);
     strings::memcpy_inlined(result + 5, msg.data, len1);
@@ -36,7 +36,7 @@ inline const char* assemble_state(TStatusCode::type code, Slice msg, Slice ctx) 
 const char* Status::copy_state(const char* state) const {
     uint16_t len1;
     uint16_t len2;
-    strings::memcpy_inlined(&len1, state + 0, sizeof(len1));
+    strings::memcpy_inlined(&len1, state, sizeof(len1));
     strings::memcpy_inlined(&len2, state + sizeof(len1), sizeof(len2));
     uint32_t length = static_cast<uint32_t>(len1) + len2 + 5;
     auto result = new char[length];
@@ -47,7 +47,7 @@ const char* Status::copy_state(const char* state) const {
 const char* Status::copy_state_with_extra_ctx(const char* state, Slice ctx) const {
     uint16_t len1;
     uint16_t len2;
-    strings::memcpy_inlined(&len1, state + 0, sizeof(len1));
+    strings::memcpy_inlined(&len1, state, sizeof(len1));
     strings::memcpy_inlined(&len2, state + sizeof(len1), sizeof(len2));
     uint32_t old_length = static_cast<uint32_t>(len1) + len2 + 5;
     ctx.size = std::min<size_t>(ctx.size, std::numeric_limits<uint16_t>::max() - old_length);
@@ -205,7 +205,7 @@ Slice Status::detailed_message() const {
 
     uint16_t len1;
     uint16_t len2;
-    memcpy(&len1, _state + 0, sizeof(len1));
+    memcpy(&len1, _state, sizeof(len1));
     memcpy(&len2, _state + 2, sizeof(len2));
     uint32_t length = static_cast<uint32_t>(len1) + len2;
     return Slice(_state + 5, length);

--- a/be/src/common/status.cpp
+++ b/be/src/common/status.cpp
@@ -50,7 +50,7 @@ const char* Status::copy_state_with_extra_ctx(const char* state, Slice ctx) cons
     strings::memcpy_inlined(&len1, state, sizeof(len1));
     strings::memcpy_inlined(&len2, state + sizeof(len1), sizeof(len2));
     uint32_t old_length = static_cast<uint32_t>(len1) + len2 + 5;
-    ctx.size = std::min<size_t>(ctx.size, std::numeric_limits<uint16_t>::max() - old_length);
+    ctx.size = std::min<size_t>(ctx.size, std::numeric_limits<uint16_t>::max() - len2);
     uint32_t new_length = old_length + ctx.size;
     auto result = new char[new_length];
     strings::memcpy_inlined(result, state, old_length);

--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -60,84 +60,53 @@ public:
 
     static Status OK() { return Status(); }
 
-    static Status Unknown(const Slice& msg, int16_t precise_code = 1, const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::UNKNOWN, msg, precise_code, msg2);
-    }
+    static Status Unknown(const Slice& msg) { return Status(TStatusCode::UNKNOWN, msg); }
 
-    static Status PublishTimeout(const Slice& msg, int16_t precise_code = 1, const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::PUBLISH_TIMEOUT, msg, precise_code, msg2);
+    static Status PublishTimeout(const Slice& msg) { return Status(TStatusCode::PUBLISH_TIMEOUT, msg); }
+    static Status MemoryAllocFailed(const Slice& msg) { return Status(TStatusCode::MEM_ALLOC_FAILED, msg); }
+    static Status BufferAllocFailed(const Slice& msg) { return Status(TStatusCode::BUFFER_ALLOCATION_FAILED, msg); }
+    static Status InvalidArgument(const Slice& msg) { return Status(TStatusCode::INVALID_ARGUMENT, msg); }
+    static Status MinimumReservationUnavailable(const Slice& msg) {
+        return Status(TStatusCode::MINIMUM_RESERVATION_UNAVAILABLE, msg);
     }
-    static Status MemoryAllocFailed(const Slice& msg, int16_t precise_code = 1, const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::MEM_ALLOC_FAILED, msg, precise_code, msg2);
-    }
-    static Status BufferAllocFailed(const Slice& msg, int16_t precise_code = 1, const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::BUFFER_ALLOCATION_FAILED, msg, precise_code, msg2);
-    }
-    static Status InvalidArgument(const Slice& msg, int16_t precise_code = 1, const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::INVALID_ARGUMENT, msg, precise_code, msg2);
-    }
-    static Status MinimumReservationUnavailable(const Slice& msg, int16_t precise_code = 1,
-                                                const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::MINIMUM_RESERVATION_UNAVAILABLE, msg, precise_code, msg2);
-    }
-    static Status Corruption(const Slice& msg, int16_t precise_code = 1, const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::CORRUPTION, msg, precise_code, msg2);
-    }
-    static Status IOError(const Slice& msg, int16_t precise_code = 1, const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::IO_ERROR, msg, precise_code, msg2);
-    }
-    static Status NotFound(const Slice& msg, int16_t precise_code = 1, const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::NOT_FOUND, msg, precise_code, msg2);
-    }
-    static Status AlreadyExist(const Slice& msg, int16_t precise_code = 1, const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::ALREADY_EXIST, msg, precise_code, msg2);
-    }
-    static Status NotSupported(const Slice& msg, int16_t precise_code = 1, const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::NOT_IMPLEMENTED_ERROR, msg, precise_code, msg2);
-    }
-    static Status EndOfFile(const Slice& msg, int16_t precise_code = 1, const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::END_OF_FILE, msg, precise_code, msg2);
-    }
+    static Status Corruption(const Slice& msg) { return Status(TStatusCode::CORRUPTION, msg); }
+    static Status IOError(const Slice& msg) { return Status(TStatusCode::IO_ERROR, msg); }
+    static Status NotFound(const Slice& msg) { return Status(TStatusCode::NOT_FOUND, msg); }
+    static Status AlreadyExist(const Slice& msg) { return Status(TStatusCode::ALREADY_EXIST, msg); }
+    static Status NotSupported(const Slice& msg) { return Status(TStatusCode::NOT_IMPLEMENTED_ERROR, msg); }
+    static Status EndOfFile(const Slice& msg) { return Status(TStatusCode::END_OF_FILE, msg); }
     static Status InternalError(const Slice& msg, int16_t precise_code = 1, const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::INTERNAL_ERROR, msg, precise_code, msg2);
+        return Status(TStatusCode::INTERNAL_ERROR, msg);
     }
     static Status RuntimeError(const Slice& msg, int16_t precise_code = 1, const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::RUNTIME_ERROR, msg, precise_code, msg2);
+        return Status(TStatusCode::RUNTIME_ERROR, msg);
     }
     static Status Cancelled(const Slice& msg, int16_t precise_code = 1, const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::CANCELLED, msg, precise_code, msg2);
+        return Status(TStatusCode::CANCELLED, msg);
     }
 
     static Status MemoryLimitExceeded(const Slice& msg, int16_t precise_code = 1, const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::MEM_LIMIT_EXCEEDED, msg, precise_code, msg2);
+        return Status(TStatusCode::MEM_LIMIT_EXCEEDED, msg);
     }
 
     static Status ThriftRpcError(const Slice& msg, int16_t precise_code = 1, const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::THRIFT_RPC_ERROR, msg, precise_code, msg2);
+        return Status(TStatusCode::THRIFT_RPC_ERROR, msg);
     }
     static Status TimedOut(const Slice& msg, int16_t precise_code = 1, const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::TIMEOUT, msg, precise_code, msg2);
+        return Status(TStatusCode::TIMEOUT, msg);
     }
     static Status TooManyTasks(const Slice& msg, int16_t precise_code = 1, const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::TOO_MANY_TASKS, msg, precise_code, msg2);
+        return Status(TStatusCode::TOO_MANY_TASKS, msg);
     }
-    static Status ServiceUnavailable(const Slice& msg, int16_t precise_code = -1, const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::SERVICE_UNAVAILABLE, msg, precise_code, msg2);
+    static Status ServiceUnavailable(const Slice& msg) { return Status(TStatusCode::SERVICE_UNAVAILABLE, msg); }
+    static Status Uninitialized(const Slice& msg) { return Status(TStatusCode::UNINITIALIZED, msg); }
+    static Status Aborted(const Slice& msg) { return Status(TStatusCode::ABORTED, msg); }
+    static Status DataQualityError(const Slice& msg) { return Status(TStatusCode::DATA_QUALITY_ERROR, msg); }
+    static Status VersionAlreadyMerged(const Slice& msg) {
+        return Status(TStatusCode::OLAP_ERR_VERSION_ALREADY_MERGED, msg);
     }
-    static Status Uninitialized(const Slice& msg, int16_t precise_code = -1, const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::UNINITIALIZED, msg, precise_code, msg2);
-    }
-    static Status Aborted(const Slice& msg, int16_t precise_code = -1, const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::ABORTED, msg, precise_code, msg2);
-    }
-    static Status DataQualityError(const Slice& msg, int16_t precise_code = -1, const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::DATA_QUALITY_ERROR, msg, precise_code, msg2);
-    }
-    static Status VersionAlreadyMerged(const Slice& msg, int16_t precise_code = -1, const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::OLAP_ERR_VERSION_ALREADY_MERGED, msg, precise_code, msg2);
-    }
-    static Status DuplicateRpcInvocation(const Slice& msg, int16_t precise_code = -1, const Slice& msg2 = Slice()) {
-        return Status(TStatusCode::DUPLICATE_RPC_INVOCATION, msg, precise_code, msg2);
+    static Status DuplicateRpcInvocation(const Slice& msg) {
+        return Status(TStatusCode::DUPLICATE_RPC_INVOCATION, msg);
     }
 
     bool ok() const { return _state == nullptr; }
@@ -195,7 +164,7 @@ public:
     std::string code_as_string() const;
 
     // This is similar to to_string, except that it does not include
-    // the stringified error code or sub code.
+    // the context info.
     //
     // @note The returned Slice is only valid as long as this Status object
     //   remains live and unchanged.
@@ -204,17 +173,11 @@ public:
     //   this returns an empty string.
     Slice message() const;
 
+    // error message with extra context info, like file name, line number
+    Slice detailed_message() const;
+
     TStatusCode::type code() const {
         return _state == nullptr ? TStatusCode::OK : static_cast<TStatusCode::type>(_state[4]);
-    }
-
-    int16_t precise_code() const {
-        if (_state == nullptr) {
-            return 0;
-        }
-        int16_t precise_code;
-        memcpy(&precise_code, _state + 5, sizeof(precise_code));
-        return precise_code;
     }
 
     /// Clone this status and add the specified prefix to the message.
@@ -237,23 +200,28 @@ public:
     ///   trailing message.
     Status clone_and_append(const Slice& msg) const;
 
+    Status clone_and_append_context(const char* filename, int line, const char* expr) const;
+
 private:
-    const char* copy_state(const char* state);
+    const char* copy_state(const char* state) const;
+    const char* copy_state_with_extra_ctx(const char* state, Slice ctx) const;
 
     // Indicates whether this Status was the rhs of a move operation.
     static bool is_moved_from(const char* state);
     static const char* moved_from_state();
 
-    Status(TStatusCode::type code, const Slice& msg, int16_t precise_code, const Slice& msg2);
+    Status(TStatusCode::type code, Slice msg) : Status(code, msg, {}) {}
+    Status(TStatusCode::type code, Slice msg, Slice ctx);
 
 private:
     // OK status has a nullptr _state.  Otherwise, _state is a new[] array
     // of the following form:
-    //    _state[0..3] == length of message
-    //    _state[4]    == code
-    //    _state[5..6] == precise_code
-    //    _state[7..]  == message
-    const char* _state{nullptr};
+    //    _state[0..1]                        == len1: length of message
+    //    _state[2..3]                        == len2: length of context
+    //    _state[4]                           == code
+    //    _state[5.. 5 + len1]                == message
+    //    _state[5 + len1 .. 5 + len1 + len2] == context
+    const char* _state = nullptr;
 };
 
 inline std::ostream& operator<<(std::ostream& os, const Status& st) {
@@ -269,13 +237,18 @@ inline const Status& to_status(const StatusOr<T>& st) {
     return st.status();
 }
 
+#ifndef AS_STRING
+#define AS_STRING(x) AS_STRING_INTERNAL(x)
+#define AS_STRING_INTERNAL(x) #x
+#endif
+
 // some generally useful macros
-#define RETURN_IF_ERROR(stmt)           \
-    do {                                \
-        const auto& _status_ = (stmt);  \
-        if (UNLIKELY(!_status_.ok())) { \
-            return to_status(_status_); \
-        }                               \
+#define RETURN_IF_ERROR(stmt)                                                                         \
+    do {                                                                                              \
+        const auto& _status_ = (stmt);                                                                \
+        if (UNLIKELY(!_status_.ok())) {                                                               \
+            return to_status(_status_).clone_and_append_context(__FILE__, __LINE__, AS_STRING(stmt)); \
+        }                                                                                             \
     } while (false)
 
 #define RETURN_IF_STATUS_ERROR(status, stmt) \

--- a/be/src/env/env_posix.cpp
+++ b/be/src/env/env_posix.cpp
@@ -9,6 +9,7 @@
 
 #include <dirent.h>
 #include <fcntl.h>
+#include <fmt/format.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/uio.h>
@@ -52,11 +53,11 @@ private:
 static Status io_error(const std::string& context, int err_number) {
     switch (err_number) {
     case ENOENT:
-        return Status::NotFound(context, static_cast<int16_t>(err_number), std::strerror(err_number));
+        return Status::NotFound(fmt::format("{}: {}", context, std::strerror(err_number)));
     case EEXIST:
-        return Status::AlreadyExist(context, static_cast<int16_t>(err_number), std::strerror(err_number));
+        return Status::AlreadyExist(fmt::format("{}: {}", context, std::strerror(err_number)));
     default:
-        return Status::IOError(context, static_cast<int16_t>(err_number), std::strerror(err_number));
+        return Status::IOError(fmt::format("{}: {}", context, std::strerror(err_number)));
     }
 }
 

--- a/be/src/util/thread.cpp
+++ b/be/src/util/thread.cpp
@@ -21,6 +21,7 @@
 
 #include "thread.h"
 
+#include <fmt/format.h>
 #include <sys/prctl.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -265,7 +266,7 @@ Status Thread::start_thread(const std::string& category, const std::string& name
 
     int ret = pthread_create(&t->_thread, nullptr, &Thread::supervise_thread, t.get());
     if (ret) {
-        return Status::RuntimeError("Could not create thread", ret, strerror(ret));
+        return Status::RuntimeError(fmt::format("Could not create thread: {}", strerror(ret)));
     }
 
     // The thread has been created and is now joinable.
@@ -360,7 +361,7 @@ ThreadJoiner& ThreadJoiner::give_up_after_ms(int ms) {
 
 Status ThreadJoiner::join() {
     if (Thread::current_thread() && Thread::current_thread()->tid() == _thread->tid()) {
-        return Status::InvalidArgument("Can't join on own thread", -1, _thread->_name);
+        return Status::InvalidArgument(fmt::format("Can't join on own thread: {}", _thread->_name));
     }
 
     // Early exit: double join is a no-op.
@@ -403,7 +404,7 @@ Status ThreadJoiner::join() {
         }
         waited_ms += wait_for;
     }
-    return Status::Aborted(strings::Substitute("Timed out after $0ms joining on $1", waited_ms, _thread->_name));
+    return Status::Aborted(fmt::format("Timed out after {}ms joining on {}", waited_ms, _thread->_name));
 }
 
 } // namespace starrocks

--- a/be/test/common/status_test.cpp
+++ b/be/test/common/status_test.cpp
@@ -21,6 +21,7 @@
 
 #include "common/status.h"
 
+#include <fmt/format.h>
 #include <gtest/gtest.h>
 
 #include "gen_cpp/Types_types.h"
@@ -56,26 +57,78 @@ TEST_F(StatusTest, Error) {
     Status st = Status::InternalError("123");
     ASSERT_FALSE(st.ok());
     ASSERT_EQ("123", st.get_error_msg());
+    ASSERT_EQ("123", st.message());
+    ASSERT_EQ("123", st.detailed_message());
     ASSERT_EQ("Internal error: 123", st.to_string());
     // copy
     {
         Status other = st;
         ASSERT_FALSE(other.ok());
         ASSERT_EQ("123", st.get_error_msg());
+        ASSERT_EQ("123", st.message());
+        ASSERT_EQ("123", st.detailed_message());
     }
     // move assign
     st = Status::InternalError("456");
     ASSERT_FALSE(st.ok());
     ASSERT_EQ("456", st.get_error_msg());
+    ASSERT_EQ("456", st.message());
     // move construct
     {
         Status other = std::move(st);
         ASSERT_FALSE(other.ok());
         ASSERT_EQ("456", other.get_error_msg());
+        ASSERT_EQ("456", other.message());
+        ASSERT_EQ("456", other.detailed_message());
         ASSERT_EQ("Internal error: 456", other.to_string());
         ASSERT_FALSE(st.ok());
         ASSERT_EQ(TStatusCode::INTERNAL_ERROR, st.code());
     }
 }
 
+TEST_F(StatusTest, ErrorWithContext) {
+    // default
+    Status st = Status::InternalError("123");
+    ASSERT_FALSE(st.ok());
+    ASSERT_EQ("123", st.get_error_msg());
+    ASSERT_EQ("123", st.message());
+    ASSERT_EQ("123", st.detailed_message());
+    ASSERT_EQ("Internal error: 123", st.to_string());
+
+    Status st1 = st.clone_and_append_context("a.cpp", 10, "expr1");
+    ASSERT_EQ("123", st1.get_error_msg());
+    ASSERT_EQ("123", st1.message());
+    ASSERT_EQ("123\na.cpp:10 expr1", st1.detailed_message());
+    ASSERT_EQ("Internal error: 123\na.cpp:10 expr1", st1.to_string());
+
+    Status st2 = st1.clone_and_append_context("b.cpp", 11, "expr2");
+    ASSERT_EQ("123", st2.get_error_msg());
+    ASSERT_EQ("123", st2.message());
+    ASSERT_EQ("123\na.cpp:10 expr1\nb.cpp:11 expr2", st2.detailed_message());
+    ASSERT_EQ("Internal error: 123\na.cpp:10 expr1\nb.cpp:11 expr2", st2.to_string());
+
+    Status st3 = st2.clone_and_append_context("c.cpp", 13, "expr3");
+    ASSERT_EQ("123", st3.get_error_msg());
+    ASSERT_EQ("123", st3.message());
+    ASSERT_EQ("123\na.cpp:10 expr1\nb.cpp:11 expr2\nc.cpp:13 expr3", st3.detailed_message());
+    ASSERT_EQ("Internal error: 123\na.cpp:10 expr1\nb.cpp:11 expr2\nc.cpp:13 expr3", st3.to_string());
+}
+
+TEST_F(StatusTest, LongContext) {
+    std::string message(std::numeric_limits<uint16_t>::max(), 'x');
+    std::string context(std::numeric_limits<uint16_t>::max() - 10, 'y');
+    // default
+    Status st = Status::InternalError(message);
+    ASSERT_FALSE(st.ok());
+    ASSERT_EQ(message, st.get_error_msg());
+    ASSERT_EQ(message, st.message());
+    ASSERT_EQ(message, st.detailed_message());
+    ASSERT_EQ(fmt::format("Internal error: {}", message), st.to_string());
+
+    Status st1 = st.clone_and_append_context("a.cpp", 10, context.data());
+    ASSERT_EQ(message, st1.get_error_msg());
+    ASSERT_EQ(message, st1.message());
+    ASSERT_EQ(fmt::format("{}\na.cpp:10 {}", message, context), st1.detailed_message());
+    ASSERT_EQ(fmt::format("Internal error: {}\na.cpp:10 {}", message, context), st1.to_string());
+}
 } // namespace starrocks


### PR DESCRIPTION
Summary: support save context line info in `Status`, for easier debugging.

This patch also removed the precise code from the Status.

The context line info will be saved in Status atomically by the macro `RETURN_IF_ERROR` and will be printed in the following methods:
- Status::detailed_message()
- Status::to_string()
- std::ostream operator<<(std::ostream&os, const Status& status)

Note that the following methods will NOT print the context info:
- Status::message()
- Status::to_thrift
- Status::to_protobuf
