### PR TITLE
Expression stats default compute return unknown instead of children stats

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -120,6 +120,9 @@ public class FunctionSet {
     public static final String UNIX_TIMESTAMP = "unix_timestamp";
     public static final String UTC_TIMESTAMP = "utc_timestamp";
 
+    // string functions
+    public static final String SUBSTRING = "substring";
+
     private static final Logger LOG = LogManager.getLogger(FunctionSet.class);
 
     private static final Map<Type, Type> MULTI_DISTINCT_SUM_RETURN_TYPE =

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -204,9 +204,15 @@ public class ExpressionStatisticCalculator {
                 case FunctionSet.COUNT:
                     return new ColumnStatistic(0, inputStatistics.getOutputRowCount(), 0,
                             callOperator.getType().getSlotSize(), rowCount);
-                default:
-                    // return child column statistic default
+                case FunctionSet.MULTI_DISTINCT_COUNT:
+                    return new ColumnStatistic(0, columnStatistic.getDistinctValuesCount(), 0,
+                            callOperator.getType().getSlotSize(), rowCount);
+                // use child column statistics for now
+                case FunctionSet.SUM:
+                case FunctionSet.AVG:
                     return columnStatistic;
+                default:
+                    return ColumnStatistic.unknown();
             }
         }
 
@@ -250,9 +256,11 @@ public class ExpressionStatisticCalculator {
                     return new ColumnStatistic(divideMinValue, divideMaxValue, nullsFraction,
                             callOperator.getType().getSlotSize(),
                             distinctValues);
-                default:
-                    // return child column statistic default
+                // use child column statistics for now
+                case FunctionSet.SUBSTRING:
                     return left;
+                default:
+                    return ColumnStatistic.unknown();
             }
         }
 
@@ -264,8 +272,11 @@ public class ExpressionStatisticCalculator {
                             childColumnStatisticList.get(2).getDistinctValuesCount();
                     return new ColumnStatistic(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, 0,
                             callOperator.getType().getSlotSize(), distinctValues);
-                default:
+                // use child column statistics for now
+                case FunctionSet.SUBSTRING:
                     return childColumnStatisticList.get(0);
+                default:
+                    return ColumnStatistic.unknown();
             }
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
@@ -731,6 +731,18 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
     }
 
     @Test
+    public void testDateFunctionBinaryPredicate() throws Exception {
+        // check cardinality is not 0
+        String sql = "SELECT sum(L_DISCOUNT * L_TAX) AS revenue FROM lineitem WHERE weekofyear(L_RECEIPTDATE) = 6";
+        String plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("cardinality=300000000"));
+
+        sql = "SELECT sum(L_DISCOUNT * L_TAX) AS revenue FROM lineitem WHERE weekofyear(L_RECEIPTDATE) in (6)";
+        plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("cardinality=300000000"));
+    }
+
+    @Test
     public void testColumnNotEqualsConstant() throws Exception {
         // check cardinality not 0
         String sql =

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -222,7 +222,8 @@ public class ReplayFromDumpTest {
         // This test has column statistics and accurate table row count
         SessionVariable sessionVariable = VariableMgr.newSessionVariable();
         sessionVariable.setNewPlanerAggStage(1);
-        Pair<QueryDumpInfo, String> replayPair = getCostPlanFragment(getDumpInfoFromFile("query_dump/groupby_limit"), sessionVariable);
+        Pair<QueryDumpInfo, String> replayPair =
+                getCostPlanFragment(getDumpInfoFromFile("query_dump/groupby_limit"), sessionVariable);
         Assert.assertTrue(replayPair.second.contains("2:AGGREGATE (update finalize)"));
     }
 
@@ -330,7 +331,8 @@ public class ReplayFromDumpTest {
     public void test() throws Exception {
         FeConstants.USE_MOCK_DICT_MANAGER = true;
         Pair<QueryDumpInfo, String> replayPair =
-                getPlanFragment(getDumpInfoFromFile("query_dump/decode_limit_with_project"), null, TExplainLevel.NORMAL);
+                getPlanFragment(getDumpInfoFromFile("query_dump/decode_limit_with_project"), null,
+                        TExplainLevel.NORMAL);
         Assert.assertTrue(replayPair.second.contains("  12:Decode\n" +
                 "  |  <dict id 42> : <string id 18>"));
         FeConstants.USE_MOCK_DICT_MANAGER = false;


### PR DESCRIPTION
ExpressionStatisticCalculator are used to calculate an expression statistics, before the default return are the statistics of the children, when actual statistics and default child statistics difference is bigger, can cause to estimate the disparity is bigger, eg，weekofYear (L_RECEIPTDATE) = 6.  We can not use L_RECEIPTDATE column statistics as weekofYear(L_RECEIPTDATE) expression statistics.