### PR TITLE
Fix overflow in ColumnRange when extend scan key

### DIFF
--- a/be/src/exec/olap_common.h
+++ b/be/src/exec/olap_common.h
@@ -521,6 +521,13 @@ inline void ColumnValueRange<T>::convert_to_fixed_value() {
     }
 
     if (_low_op == FILTER_LARGER) {
+        // if _low_value was type::max(), _low_value + 1 will overflow to type::min(),
+        // there will be a very large number of elements added to the _fixed_values set.
+        // If there is a condition > type::max we simply return an empty scan range.
+        if (_low_value == _type_max) {
+            _fixed_values.clear();
+            return;
+        }
         helper::increase(_low_value);
     }
 

--- a/be/test/exec/column_value_range_test.cpp
+++ b/be/test/exec/column_value_range_test.cpp
@@ -135,6 +135,16 @@ TEST(NormalizeRangeTest, ExtendScanKeyTest) {
         bool res = scan_keys.extend_scan_key(range, 1024).ok();
         ASSERT_TRUE(res);
     }
+    {
+        ColumnValueRange<CppType> range("test", Type, std::numeric_limits<CppType>::lowest(),
+                                        std::numeric_limits<CppType>::max());
+        range.add_range(SQLFilterOp::FILTER_LARGER, std::numeric_limits<CppType>::max());
+        OlapScanKeys scan_keys;
+        scan_keys._begin_scan_keys.emplace_back();
+        scan_keys._begin_scan_keys.emplace_back();
+        bool res = scan_keys.extend_scan_key(range, 1024).ok();
+        ASSERT_TRUE(res);
+    }
 }
 
 } // namespace starrocks::vectorized


### PR DESCRIPTION
if a range was `> type_limit::max()`, then scan range was (type::max, type::max].
convert_to_fixed_value will convert it to [type::max + 1, type::max], it
will cause a overflow, so real range was [type::min, type::max],
there will be a very large number of elements added to the _fixed_values set


will close #2615