### PR TITLE
Let SinkBuffer destroy correctly in any cases

### DIFF
--- a/be/src/exec/pipeline/exchange/sink_buffer.cpp
+++ b/be/src/exec/pipeline/exchange/sink_buffer.cpp
@@ -46,6 +46,10 @@ SinkBuffer::SinkBuffer(RuntimeState* state, const std::vector<TPlanFragmentDesti
 }
 
 SinkBuffer::~SinkBuffer() {
+    // In some extreme cases, the pipeline driver has not been created yet, and the query is over
+    // At this time, sink_buffer also needs to be able to be destructed correctly
+    _is_finishing = true;
+
     DCHECK(is_finished());
 
     for (auto& [_, buffer] : _buffers) {


### PR DESCRIPTION
# Related Issue

[issue-2589](https://github.com/StarRocks/starrocks/issues/2589)

# Root cause

`SinkBuffer` is created at `FragmentExecutor::prepare`, but if query failed at `FragmentExecutor::prepare`, then no `PipelineDriver` is created, so there is no change to finish the `SinkBuffer`

# How to fix

set `_is_finishing` to `true` at `~SinkBuffer()`, and let `DCHECK` pass


