### PR TITLE
Fix the bug of null pointer exception when cleaning up spark loading task (#2583)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -7457,10 +7457,30 @@ public class Catalog {
     }
 
     public void clearExpiredJobs() {
-        loadManager.removeOldLoadJob();
-        exportMgr.removeOldExportJobs();
-        deleteHandler.removeOldDeleteInfo();
-        globalTransactionMgr.removeExpiredTxns();
-        routineLoadManager.cleanOldRoutineLoadJobs();
+        try {
+            loadManager.removeOldLoadJob();
+        } catch (Throwable t) {
+            LOG.warn("load manager remove old load jobs failed", t);
+        }
+        try {
+            exportMgr.removeOldExportJobs();
+        } catch (Throwable t) {
+            LOG.warn("export manager remove old export jobs failed", t);
+        }
+        try {
+            deleteHandler.removeOldDeleteInfo();
+        } catch (Throwable t) {
+            LOG.warn("delete handler remove old delete info failed", t);
+        }
+        try {
+            globalTransactionMgr.removeExpiredTxns();
+        } catch (Throwable t) {
+            LOG.warn("transaction manager remove expired txns failed", t);
+        }
+        try {
+            routineLoadManager.cleanOldRoutineLoadJobs();
+        } catch (Throwable t) {
+            LOG.warn("routine load manager clean old routine load jobs failed", t);
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadJob.java
@@ -128,11 +128,10 @@ public class SparkLoadJob extends BulkLoadJob {
     // members below updated when job state changed to loading
     // { tableId.partitionId.indexId.bucket.schemaHash -> (etlFilePath, etlFileSize) }
     private Map<String, Pair<String, Long>> tabletMetaToFileInfo = Maps.newHashMap();
+    private SparkLoadAppHandle sparkLoadAppHandle = new SparkLoadAppHandle();
 
     // --- members below not persist ---
     private ResourceDesc resourceDesc;
-    // for spark standalone
-    private SparkLoadAppHandle sparkLoadAppHandle = new SparkLoadAppHandle();
     // for straggler wait long time to commit transaction
     private long quorumFinishTimestamp = -1;
     // below for push task
@@ -695,7 +694,6 @@ public class SparkLoadJob extends BulkLoadJob {
                 }
             }
             // clear job infos that not persist
-            sparkLoadAppHandle = null;
             resourceDesc = null;
             tableToLoadPartitions.clear();
             indexToPushBrokerReaderParams.clear();
@@ -760,6 +758,10 @@ public class SparkLoadJob extends BulkLoadJob {
     }
 
     public void clearSparkLauncherLog() {
+        if (sparkLoadAppHandle == null) {
+            return;
+        }
+
         String logPath = sparkLoadAppHandle.getLogPath();
         if (!Strings.isNullOrEmpty(logPath)) {
             File file = new File(logPath);


### PR DESCRIPTION
1. Check if sparkLoadAppHandle is null before clearing the spark load log.
2. Catch task exceptions in advance to avoid blocking the cleanup of other tasks.