### PR TITLE
Fix concat_ws not return null when separator is null

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
@@ -418,6 +418,9 @@ public class ScalarOperatorFunctions {
     @FEFunction(name = "concat_ws", argTypes = {"VARCHAR", "VARCHAR"}, returnType = "VARCHAR")
     public static ConstantOperator concat_ws(ConstantOperator split, ConstantOperator... values) {
         Preconditions.checkArgument(values.length > 0);
+        if (split.isNull()) {
+            return ConstantOperator.createNull(Type.VARCHAR);
+        }
         final StringBuilder resultBuilder = new StringBuilder();
         for (int i = 0; i < values.length - 1; i++) {
             if (values[i].isNull()) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
@@ -671,16 +671,21 @@ public class ScalarOperatorFunctionsTest {
 
     @Test
     public void concat_ws_with_null() {
-        ConstantOperator[] arg = {ConstantOperator.createVarchar("star"),
+        ConstantOperator[] arg_with_null = {ConstantOperator.createVarchar("star"),
                 ConstantOperator.createNull(Type.VARCHAR),
                 ConstantOperator.createVarchar("cks")};
-        ConstantOperator result = ScalarOperatorFunctions.concat_ws(ConstantOperator.createVarchar("ro"), arg);
+        ConstantOperator result = ScalarOperatorFunctions.concat_ws(ConstantOperator.createVarchar("ro"), arg_with_null);
         assertEquals(Type.VARCHAR, result.getType());
         assertEquals("starrocks", result.getVarchar());
 
         result = ScalarOperatorFunctions.concat_ws(ConstantOperator.createVarchar(","),
                 ConstantOperator.createNull(Type.VARCHAR));
         assertEquals("", result.getVarchar());
+
+        ConstantOperator[] arg_without_null = {ConstantOperator.createVarchar("star"),
+                ConstantOperator.createVarchar("cks")};
+        result = ScalarOperatorFunctions.concat_ws(ConstantOperator.createNull(Type.VARCHAR), arg_without_null);
+        assertTrue(result.isNull());
     }
 
     @Test


### PR DESCRIPTION
concat_ws function should return null when separator is null