### PR TITLE
fix: overflow when checking length in repeat_const_not_null

### DIFF
--- a/be/src/exprs/vectorized/string_functions.cpp
+++ b/be/src/exprs/vectorized/string_functions.cpp
@@ -909,11 +909,11 @@ static inline ColumnPtr repeat_const_not_null(const Columns& columns, const Bina
     } else {
         raw::make_room(&dst_offsets, num_rows + 1);
         dst_offsets[0] = 0;
-        size_t reserved = times * src_offsets.back();
+        size_t reserved = static_cast<size_t>(times) * src_offsets.back();
         if (reserved > OLAP_STRING_MAX_LENGTH * num_rows) {
             reserved = 0;
             for (int i = 0; i < num_rows; ++i) {
-                auto slice_sz = src_offsets[i + 1] - src_offsets[i];
+                size_t slice_sz = src_offsets[i + 1] - src_offsets[i];
                 if (slice_sz * times < OLAP_STRING_MAX_LENGTH) {
                     reserved += slice_sz * times;
                 }


### PR DESCRIPTION
`repeat_const_not_null()` checks whether the sum length of string after repeated is less than `OLAP_STRING_MAX_LENGTH * num_rows` as follows.
The types of `times` and `src_offset` are `int` and `uint32_t`, respectively, so the result type is `uint32_t`. Therefore, If `times` is very big, the result may be overflow.


```C++
        raw::make_room(&dst_offsets, num_rows + 1);
        dst_offsets[0] = 0;
        // ****** here ******
        size_t reserved = times * src_offsets.back();
        if (reserved > OLAP_STRING_MAX_LENGTH * num_rows) {
            reserved = 0;
            for (int i = 0; i < num_rows; ++i) {
                auto slice_sz = src_offsets[i + 1] - src_offsets[i];
                if (slice_sz * times < OLAP_STRING_MAX_LENGTH) {
                    reserved += slice_sz * times;
                }
            }
        }
        dst_bytes.resize(reserved);
```