### PR TITLE
Some minor refactors on class `HDFSScanNode`

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -91,6 +91,7 @@ set(EXEC_FILES
     vectorized/intersect_node.cpp
     vectorized/hdfs_scanner.cpp
     vectorized/hdfs_scanner_orc.cpp
+    vectorized/hdfs_scanner_parquet.cpp
     vectorized/hdfs_scanner_text.cpp
     vectorized/json_scanner.cpp
     vectorized/project_node.cpp

--- a/be/src/exec/scan_node.cpp
+++ b/be/src/exec/scan_node.cpp
@@ -30,7 +30,6 @@ const std::string ScanNode::_s_rows_read_counter = "RowsRead";
 const std::string ScanNode::_s_total_read_timer = "TotalRawReadTime(*)";
 const std::string ScanNode::_s_total_throughput_counter = "TotalReadThroughput";
 const std::string ScanNode::_s_materialize_tuple_timer = "MaterializeTupleTime(*)";
-const std::string ScanNode::_s_per_read_thread_throughput_counter = "PerReadThreadRawHdfsThroughput";
 const std::string ScanNode::_s_num_disks_accessed_counter = "NumDiskAccess";
 const std::string ScanNode::_s_scanner_thread_counters_prefix = "ScannerThreads";
 const std::string ScanNode::_s_scanner_thread_total_wallclock_time = "ScannerThreadsTotalWallClockTime";
@@ -50,12 +49,6 @@ Status ScanNode::prepare(RuntimeState* state) {
 #endif
     _materialize_tuple_timer =
             ADD_CHILD_TIMER(runtime_profile(), _s_materialize_tuple_timer, _s_scanner_thread_total_wallclock_time);
-    _per_read_thread_throughput_counter = runtime_profile()->add_derived_counter(
-            _s_per_read_thread_throughput_counter, TUnit::BYTES_PER_SECOND,
-            [capture0 = _bytes_read_counter, capture1 = _read_timer] {
-                return RuntimeProfile::units_per_second(capture0, capture1);
-            },
-            "");
     _num_disks_accessed_counter = ADD_COUNTER(runtime_profile(), _s_num_disks_accessed_counter, TUnit::UNIT);
 
     return Status::OK();

--- a/be/src/exec/scan_node.h
+++ b/be/src/exec/scan_node.h
@@ -65,7 +65,6 @@ public:
     RuntimeProfile::Counter* rows_read_counter() const { return _rows_read_counter; }
     RuntimeProfile::Counter* read_timer() const { return _read_timer; }
     RuntimeProfile::Counter* total_throughput_counter() const { return _total_throughput_counter; }
-    RuntimeProfile::Counter* per_read_thread_throughput_counter() const { return _per_read_thread_throughput_counter; }
     RuntimeProfile::Counter* materialize_tuple_timer() const { return _materialize_tuple_timer; }
     RuntimeProfile::ThreadCounters* scanner_thread_counters() const { return _scanner_thread_counters; }
 
@@ -74,7 +73,6 @@ public:
     static const std::string _s_rows_read_counter;
     static const std::string _s_total_read_timer;
     static const std::string _s_total_throughput_counter;
-    static const std::string _s_per_read_thread_throughput_counter;
     static const std::string _s_num_disks_accessed_counter;
     static const std::string _s_materialize_tuple_timer;
     static const std::string _s_scanner_thread_counters_prefix;
@@ -90,7 +88,6 @@ protected:
     // Wall based aggregate read throughput [bytes/sec]
     RuntimeProfile::Counter* _total_throughput_counter;
     // Per thread read throughput [bytes/sec]
-    RuntimeProfile::Counter* _per_read_thread_throughput_counter;
     RuntimeProfile::Counter* _num_disks_accessed_counter;
     RuntimeProfile::Counter* _materialize_tuple_timer; // time writing tuple slots
     // Aggregated scanner thread counters

--- a/be/src/exec/vectorized/hdfs_scan_node.cpp
+++ b/be/src/exec/vectorized/hdfs_scan_node.cpp
@@ -196,7 +196,7 @@ Status HdfsScanNode::_start_scan_thread(RuntimeState* state) {
     // start scanner
     std::lock_guard<std::mutex> l(_mtx);
     for (int i = 0; i < concurrency; i++) {
-        CHECK(_submit_scanner(_pending_scanners.pop(), true));
+        CHECK(_submit_scanner(_pop_pending_scanner(), true));
     }
 
     return Status::OK();
@@ -237,7 +237,7 @@ Status HdfsScanNode::_create_and_init_scanner(RuntimeState* state, const HdfsFil
     }
 
     RETURN_IF_ERROR(scanner->init(state, scanner_params));
-    _pending_scanners.push(scanner);
+    _push_pending_scanner(scanner);
 
     return Status::OK();
 }
@@ -331,7 +331,7 @@ void HdfsScanNode::_scanner_thread(HdfsScanner* scanner) {
             need_put = std::min(left_resource, need_put);
             std::lock_guard<std::mutex> l(_mtx);
             while (need_put-- > 0 && !_pending_scanners.empty()) {
-                if (!_submit_scanner(_pending_scanners.pop(), false)) {
+                if (!_submit_scanner(_pop_pending_scanner(), false)) {
                     break;
                 }
             }
@@ -348,7 +348,7 @@ void HdfsScanNode::_scanner_thread(HdfsScanner* scanner) {
     if (!scanner->is_open() && scanner->open_limit() > concurrency_limit) {
         if (!scanner->has_pending_token()) {
             std::lock_guard<std::mutex> l(_mtx);
-            _pending_scanners.push(scanner);
+            _push_pending_scanner(scanner);
             return;
         }
     }
@@ -367,7 +367,7 @@ void HdfsScanNode::_scanner_thread(HdfsScanner* scanner) {
             if (_chunk_pool.empty()) {
                 scanner->set_keep_priority(true);
                 scanner->release_pending_token(&_pending_token);
-                _pending_scanners.push(scanner);
+                _push_pending_scanner(scanner);
                 scanner = nullptr;
                 break;
             }
@@ -397,7 +397,7 @@ void HdfsScanNode::_scanner_thread(HdfsScanner* scanner) {
             if (!_submit_scanner(scanner, false)) {
                 std::lock_guard<std::mutex> l(_mtx);
                 scanner->release_pending_token(&_pending_token);
-                _pending_scanners.push(scanner);
+                _push_pending_scanner(scanner);
             }
         } else if (status.ok()) {
             DCHECK(scanner == nullptr);
@@ -406,9 +406,9 @@ void HdfsScanNode::_scanner_thread(HdfsScanner* scanner) {
             scanner->close(_runtime_state);
             _closed_scanners.fetch_add(1, std::memory_order_release);
             std::lock_guard<std::mutex> l(_mtx);
-            auto nscanner = _pending_scanners.empty() ? nullptr : _pending_scanners.pop();
+            auto nscanner = _pending_scanners.empty() ? nullptr : _pop_pending_scanner();
             if (nscanner != nullptr && !_submit_scanner(nscanner, false)) {
-                _pending_scanners.push(nscanner);
+                _push_pending_scanner(nscanner);
             }
         } else {
             _update_status(status);
@@ -431,10 +431,22 @@ void HdfsScanNode::_scanner_thread(HdfsScanner* scanner) {
 void HdfsScanNode::_close_pending_scanners() {
     std::lock_guard<std::mutex> l(_mtx);
     while (!_pending_scanners.empty()) {
-        auto* scanner = _pending_scanners.pop();
+        auto* scanner = _pop_pending_scanner();
         scanner->close(_runtime_state);
         _closed_scanners.fetch_add(1, std::memory_order_release);
     }
+}
+
+void HdfsScanNode::_push_pending_scanner(HdfsScanner* scanner) {
+    scanner->in_pending_queue();
+    _pending_scanners.push(scanner);
+}
+
+HdfsScanner* HdfsScanNode::_pop_pending_scanner() {
+    HdfsScanner* scanner = _pending_scanners.pop();
+    uint64_t time = scanner->out_pending_queue();
+    COUNTER_UPDATE(_scanner_queue_timer, time);
+    return scanner;
 }
 
 Status HdfsScanNode::_get_status() {
@@ -480,7 +492,7 @@ Status HdfsScanNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) {
         const int32_t num_running = _num_scanners - num_pending - num_closed;
         if ((num_pending > 0) && (num_running < kMaxConcurrency)) {
             if (_chunk_pool.size() >= (num_running + 1) * _chunks_per_scanner) {
-                (void)_submit_scanner(_pending_scanners.pop(), true);
+                (void)_submit_scanner(_pop_pending_scanner(), true);
             }
         }
     }
@@ -675,6 +687,7 @@ void HdfsScanNode::_update_status(const Status& status) {
 
 void HdfsScanNode::_init_counter(RuntimeState* state) {
     _scan_timer = ADD_TIMER(_runtime_profile, "ScanTime");
+    _scanner_queue_timer = ADD_TIMER(_runtime_profile, "ScannerQueueTime");
     _reader_init_timer = ADD_TIMER(_runtime_profile, "ReaderInit");
     _open_file_timer = ADD_TIMER(_runtime_profile, "OpenFile");
     _expr_filter_timer = ADD_TIMER(_runtime_profile, "ExprFilterTime");

--- a/be/src/exec/vectorized/hdfs_scan_node.cpp
+++ b/be/src/exec/vectorized/hdfs_scan_node.cpp
@@ -97,6 +97,7 @@ Status HdfsScanNode::init(const TPlanNode& tnode, RuntimeState* state) {
     }
     _scan_ranges_counter = ADD_COUNTER(_runtime_profile, "ScanRanges", TUnit::UNIT);
     _scan_files_counter = ADD_COUNTER(_runtime_profile, "ScanFiles", TUnit::UNIT);
+    _hdfs_io_profile.init(_runtime_profile.get());
 
     _mem_pool = std::make_unique<MemPool>();
 
@@ -223,6 +224,7 @@ Status HdfsScanNode::_create_and_init_scanner(RuntimeState* state, const HdfsFil
 
     HdfsScanner* scanner = nullptr;
     if (hdfs_file_desc.hdfs_file_format == THdfsFileFormat::PARQUET) {
+        _parquet_profile.init(_runtime_profile.get());
         scanner = _pool->add(new HdfsParquetScanner());
     } else if (hdfs_file_desc.hdfs_file_format == THdfsFileFormat::ORC) {
         scanner = _pool->add(new HdfsOrcScanner());
@@ -680,25 +682,7 @@ void HdfsScanNode::_init_counter(RuntimeState* state) {
     _io_timer = ADD_TIMER(_runtime_profile, "IoTime");
     _io_counter = ADD_COUNTER(_runtime_profile, "IoCounter", TUnit::UNIT);
     _column_read_timer = ADD_TIMER(_runtime_profile, "ColumnReadTime");
-    _level_decode_timer = ADD_TIMER(_runtime_profile, "LevelDecodeTime");
-    _value_decode_timer = ADD_TIMER(_runtime_profile, "ValueDecodeTime");
-    _page_read_timer = ADD_TIMER(_runtime_profile, "PageReadTime");
     _column_convert_timer = ADD_TIMER(_runtime_profile, "ColumnConvertTime");
-
-    _bytes_total_read = ADD_COUNTER(_runtime_profile, "BytesTotalRead", TUnit::BYTES);
-    _bytes_read_local = ADD_COUNTER(_runtime_profile, "BytesReadLocal", TUnit::BYTES);
-    _bytes_read_short_circuit = ADD_COUNTER(_runtime_profile, "BytesReadShortCircuit", TUnit::BYTES);
-    _bytes_read_dn_cache = ADD_COUNTER(_runtime_profile, "BytesReadDataNodeCache", TUnit::BYTES);
-    _bytes_read_remote = ADD_COUNTER(_runtime_profile, "BytesReadRemote", TUnit::BYTES);
-
-    // reader init
-    _footer_read_timer = ADD_TIMER(_runtime_profile, "ReaderInitFooterRead");
-    _column_reader_init_timer = ADD_TIMER(_runtime_profile, "ReaderInitColumnReaderInit");
-
-    // dict filter
-    _group_chunk_read_timer = ADD_TIMER(_runtime_profile, "GroupChunkRead");
-    _group_dict_filter_timer = ADD_TIMER(_runtime_profile, "GroupDictFilter");
-    _group_dict_decode_timer = ADD_TIMER(_runtime_profile, "GroupDictDecode");
 }
 
 } // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/hdfs_scan_node.cpp
+++ b/be/src/exec/vectorized/hdfs_scan_node.cpp
@@ -438,13 +438,13 @@ void HdfsScanNode::_close_pending_scanners() {
 }
 
 void HdfsScanNode::_push_pending_scanner(HdfsScanner* scanner) {
-    scanner->in_pending_queue();
+    scanner->enter_pending_queue();
     _pending_scanners.push(scanner);
 }
 
 HdfsScanner* HdfsScanNode::_pop_pending_scanner() {
     HdfsScanner* scanner = _pending_scanners.pop();
-    uint64_t time = scanner->out_pending_queue();
+    uint64_t time = scanner->exit_pending_queue();
     COUNTER_UPDATE(_scanner_queue_timer, time);
     return scanner;
 }

--- a/be/src/exec/vectorized/hdfs_scan_node.h
+++ b/be/src/exec/vectorized/hdfs_scan_node.h
@@ -93,6 +93,8 @@ private:
     Status _get_status();
     void _fill_chunk_pool(int count);
     void _close_pending_scanners();
+    void _push_pending_scanner(HdfsScanner* scanner);
+    HdfsScanner* _pop_pending_scanner();
     static int _compute_priority(int32_t num_submitted_tasks);
 
     void _init_counter(RuntimeState* state);
@@ -163,6 +165,7 @@ private:
     UnboundedBlockingQueue<ChunkPtr> _result_chunks;
 
     RuntimeProfile::Counter* _scan_timer = nullptr;
+    RuntimeProfile::Counter* _scanner_queue_timer = nullptr;
     RuntimeProfile::Counter* _scan_ranges_counter = nullptr;
     RuntimeProfile::Counter* _scan_files_counter = nullptr;
     RuntimeProfile::Counter* _reader_init_timer = nullptr;

--- a/be/src/exec/vectorized/hdfs_scan_node.h
+++ b/be/src/exec/vectorized/hdfs_scan_node.h
@@ -9,6 +9,8 @@
 #include "exec/scan_node.h"
 #include "exec/vectorized/hdfs_scanner.h"
 #include "exec/vectorized/hdfs_scanner_orc.h"
+#include "exec/vectorized/hdfs_scanner_parquet.h"
+#include "exec/vectorized/hdfs_scanner_text.h"
 #include "hdfs/hdfs.h"
 
 namespace starrocks::vectorized {
@@ -47,6 +49,7 @@ private:
     friend HdfsScanner;
     friend HdfsParquetScanner;
     friend HdfsOrcScanner;
+    friend HdfsTextScanner;
     int kMaxConcurrency = config::max_hdfs_scanner_num;
 
     template <typename T>
@@ -169,24 +172,9 @@ private:
     RuntimeProfile::Counter* _io_timer = nullptr;
     RuntimeProfile::Counter* _io_counter = nullptr;
     RuntimeProfile::Counter* _column_read_timer = nullptr;
-    RuntimeProfile::Counter* _level_decode_timer = nullptr;
-    RuntimeProfile::Counter* _value_decode_timer = nullptr;
-    RuntimeProfile::Counter* _page_read_timer = nullptr;
     RuntimeProfile::Counter* _column_convert_timer = nullptr;
 
-    RuntimeProfile::Counter* _bytes_total_read = nullptr;
-    RuntimeProfile::Counter* _bytes_read_local = nullptr;
-    RuntimeProfile::Counter* _bytes_read_short_circuit = nullptr;
-    RuntimeProfile::Counter* _bytes_read_dn_cache = nullptr;
-    RuntimeProfile::Counter* _bytes_read_remote = nullptr;
-
-    // reader init
-    RuntimeProfile::Counter* _footer_read_timer = nullptr;
-    RuntimeProfile::Counter* _column_reader_init_timer = nullptr;
-
-    // dict filter
-    RuntimeProfile::Counter* _group_chunk_read_timer = nullptr;
-    RuntimeProfile::Counter* _group_dict_filter_timer = nullptr;
-    RuntimeProfile::Counter* _group_dict_decode_timer = nullptr;
+    HdfsIOProfile _hdfs_io_profile;
+    HdfsParquetProfile _parquet_profile;
 };
 } // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/hdfs_scanner.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner.cpp
@@ -151,6 +151,14 @@ void HdfsScanner::close(RuntimeState* runtime_state) noexcept {
     _is_closed = true;
 }
 
+void HdfsScanner::in_pending_queue() {
+    _pending_queue_sw.start();
+}
+
+uint64_t HdfsScanner::out_pending_queue() {
+    return _pending_queue_sw.reset();
+}
+
 #ifndef BE_TEST
 struct HdfsReadStats {
     int64_t bytes_total_read = 0;

--- a/be/src/exec/vectorized/hdfs_scanner.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner.cpp
@@ -10,15 +10,8 @@
 #include <mutex>
 #include <thread>
 
-#include "common/status.h"
 #include "env/env_hdfs.h"
-#include "exec/exec_node.h"
-#include "exec/parquet/file_reader.h"
 #include "exec/vectorized/hdfs_scan_node.h"
-#include "exprs/expr.h"
-#include "runtime/runtime_state.h"
-#include "storage/vectorized/chunk_helper.h"
-#include "util/runtime_profile.h"
 
 namespace starrocks::vectorized {
 
@@ -197,59 +190,13 @@ void HdfsScanner::update_counter() {
         get_hdfs_statistics(hdfs_file, &hdfs_stats);
     }
 
-    COUNTER_UPDATE(_scanner_params.parent->_bytes_total_read, hdfs_stats.bytes_total_read);
-    COUNTER_UPDATE(_scanner_params.parent->_bytes_read_local, hdfs_stats.bytes_read_local);
-    COUNTER_UPDATE(_scanner_params.parent->_bytes_read_short_circuit, hdfs_stats.bytes_read_short_circuit);
-    COUNTER_UPDATE(_scanner_params.parent->_bytes_read_dn_cache, hdfs_stats.bytes_read_dn_cache);
-    COUNTER_UPDATE(_scanner_params.parent->_bytes_read_remote, hdfs_stats.bytes_read_remote);
+    auto& root = _scanner_params.parent->_hdfs_io_profile;
+    COUNTER_UPDATE(root.bytes_total_read, hdfs_stats.bytes_total_read);
+    COUNTER_UPDATE(root.bytes_read_local, hdfs_stats.bytes_read_local);
+    COUNTER_UPDATE(root.bytes_read_short_circuit, hdfs_stats.bytes_read_short_circuit);
+    COUNTER_UPDATE(root.bytes_read_dn_cache, hdfs_stats.bytes_read_dn_cache);
+    COUNTER_UPDATE(root.bytes_read_remote, hdfs_stats.bytes_read_remote);
 #endif
-}
-
-Status HdfsParquetScanner::do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) {
-    return Status::OK();
-}
-
-Status HdfsParquetScanner::do_open(RuntimeState* runtime_state) {
-    // create file reader
-    _reader = std::make_shared<parquet::FileReader>(runtime_state->chunk_size(), _scanner_params.fs.get(),
-                                                    _scanner_params.scan_ranges[0]->file_length);
-#ifndef BE_TEST
-    SCOPED_TIMER(_scanner_params.parent->_reader_init_timer);
-#endif
-    RETURN_IF_ERROR(_reader->init(_file_read_param));
-    return Status::OK();
-}
-
-Status HdfsParquetScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) {
-    Status status = _reader->get_next(chunk);
-    return status;
-}
-
-void HdfsParquetScanner::update_counter() {
-    HdfsScanner::update_counter();
-
-#ifndef BE_TEST
-    COUNTER_UPDATE(_scanner_params.parent->_rows_read_counter, _stats.raw_rows_read);
-    COUNTER_UPDATE(_scanner_params.parent->_expr_filter_timer, _stats.expr_filter_ns);
-    COUNTER_UPDATE(_scanner_params.parent->_io_timer, _stats.io_ns);
-    COUNTER_UPDATE(_scanner_params.parent->_io_counter, _stats.io_count);
-    COUNTER_UPDATE(_scanner_params.parent->_bytes_read_counter, _stats.bytes_read);
-    COUNTER_UPDATE(_scanner_params.parent->_column_read_timer, _stats.column_read_ns);
-    COUNTER_UPDATE(_scanner_params.parent->_column_convert_timer, _stats.column_convert_ns);
-    COUNTER_UPDATE(_scanner_params.parent->_value_decode_timer, _stats.value_decode_ns);
-    COUNTER_UPDATE(_scanner_params.parent->_level_decode_timer, _stats.level_decode_ns);
-    COUNTER_UPDATE(_scanner_params.parent->_page_read_timer, _stats.page_read_ns);
-    COUNTER_UPDATE(_scanner_params.parent->_footer_read_timer, _stats.footer_read_ns);
-    COUNTER_UPDATE(_scanner_params.parent->_column_reader_init_timer, _stats.column_reader_init_ns);
-    COUNTER_UPDATE(_scanner_params.parent->_group_chunk_read_timer, _stats.group_chunk_read_ns);
-    COUNTER_UPDATE(_scanner_params.parent->_group_dict_filter_timer, _stats.group_dict_filter_ns);
-    COUNTER_UPDATE(_scanner_params.parent->_group_dict_decode_timer, _stats.group_dict_decode_ns);
-#endif
-}
-
-void HdfsParquetScanner::do_close(RuntimeState* runtime_state) noexcept {
-    update_counter();
-    _reader.reset();
 }
 
 void HdfsFileReaderParam::set_columns_from_file(const std::unordered_set<std::string>& names) {
@@ -338,6 +285,19 @@ bool HdfsFileReaderParam::can_use_dict_filter_on_slot(SlotDescriptor* slot) cons
         }
     }
     return true;
+}
+
+static const std::string kHdfsIOProfileSectionPrefix = "HdfsIO";
+
+void HdfsIOProfile::init(RuntimeProfile* root) {
+    if (_toplev != nullptr) return;
+    _toplev = ADD_TIMER(root, kHdfsIOProfileSectionPrefix);
+    bytes_total_read = ADD_CHILD_COUNTER(root, "BytesTotalRead", TUnit::BYTES, kHdfsIOProfileSectionPrefix);
+    bytes_read_local = ADD_CHILD_COUNTER(root, "BytesReadLocal", TUnit::BYTES, kHdfsIOProfileSectionPrefix);
+    bytes_read_short_circuit =
+            ADD_CHILD_COUNTER(root, "BytesReadShortCircuit", TUnit::BYTES, kHdfsIOProfileSectionPrefix);
+    bytes_read_dn_cache = ADD_CHILD_COUNTER(root, "BytesReadDataNodeCache", TUnit::BYTES, kHdfsIOProfileSectionPrefix);
+    bytes_read_remote = ADD_CHILD_COUNTER(root, "BytesReadRemote", TUnit::BYTES, kHdfsIOProfileSectionPrefix);
 }
 
 } // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/hdfs_scanner.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner.cpp
@@ -151,11 +151,11 @@ void HdfsScanner::close(RuntimeState* runtime_state) noexcept {
     _is_closed = true;
 }
 
-void HdfsScanner::in_pending_queue() {
+void HdfsScanner::enter_pending_queue() {
     _pending_queue_sw.start();
 }
 
-uint64_t HdfsScanner::out_pending_queue() {
+uint64_t HdfsScanner::exit_pending_queue() {
     return _pending_queue_sw.reset();
 }
 

--- a/be/src/exec/vectorized/hdfs_scanner.h
+++ b/be/src/exec/vectorized/hdfs_scanner.h
@@ -202,9 +202,9 @@ public:
     virtual Status do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) = 0;
     virtual Status do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) = 0;
 
-    void in_pending_queue();
+    void enter_pending_queue();
     // how long it stays inside pending queue.
-    uint64_t out_pending_queue();
+    uint64_t exit_pending_queue();
 
 private:
     bool _is_open = false;

--- a/be/src/exec/vectorized/hdfs_scanner.h
+++ b/be/src/exec/vectorized/hdfs_scanner.h
@@ -18,6 +18,20 @@ namespace starrocks::vectorized {
 class HdfsScanNode;
 class RuntimeFilterProbeCollector;
 
+class HdfsIOProfile {
+public:
+    RuntimeProfile::Counter* bytes_total_read = nullptr;
+    RuntimeProfile::Counter* bytes_read_local = nullptr;
+    RuntimeProfile::Counter* bytes_read_short_circuit = nullptr;
+    RuntimeProfile::Counter* bytes_read_dn_cache = nullptr;
+    RuntimeProfile::Counter* bytes_read_remote = nullptr;
+
+    void init(RuntimeProfile* root);
+
+private:
+    RuntimeProfile::Counter* _toplev = nullptr;
+};
+
 struct HdfsScanStats {
     int64_t raw_rows_read = 0;
     int64_t expr_filter_ns = 0;
@@ -25,10 +39,13 @@ struct HdfsScanStats {
     int64_t io_count = 0;
     int64_t bytes_read = 0;
     int64_t column_read_ns = 0;
+    int64_t column_convert_ns = 0;
+
+    // parquet only!
+    // read & decode
     int64_t level_decode_ns = 0;
     int64_t value_decode_ns = 0;
     int64_t page_read_ns = 0;
-    int64_t column_convert_ns = 0;
     // reader init
     int64_t footer_read_ns = 0;
     int64_t column_reader_init_ns = 0;
@@ -206,25 +223,6 @@ protected:
     std::unordered_map<SlotId, std::vector<ExprContext*>> _conjunct_ctxs_by_slot;
     // predicate which havs min/max
     std::vector<ExprContext*> _min_max_conjunct_ctxs;
-};
-
-class HdfsParquetScanner final : public HdfsScanner {
-public:
-    HdfsParquetScanner() = default;
-    ~HdfsParquetScanner() override {
-        if (_runtime_state != nullptr) {
-            close(_runtime_state);
-        }
-    }
-
-    void update_counter();
-    Status do_open(RuntimeState* runtime_state) override;
-    void do_close(RuntimeState* runtime_state) noexcept override;
-    Status do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) override;
-    Status do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) override;
-
-private:
-    std::shared_ptr<parquet::FileReader> _reader = nullptr;
 };
 
 } // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/hdfs_scanner.h
+++ b/be/src/exec/vectorized/hdfs_scanner.h
@@ -202,11 +202,16 @@ public:
     virtual Status do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) = 0;
     virtual Status do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) = 0;
 
+    void in_pending_queue();
+    // how long it stays inside pending queue.
+    uint64_t out_pending_queue();
+
 private:
     bool _is_open = false;
     bool _is_closed = false;
     bool _keep_priority = false;
     void _build_file_read_param();
+    MonotonicStopWatch _pending_queue_sw;
 
 protected:
     std::atomic_bool _pending_token = false;

--- a/be/src/exec/vectorized/hdfs_scanner_orc.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_orc.cpp
@@ -325,14 +325,15 @@ void HdfsOrcScanner::update_counter() {
     COUNTER_UPDATE(_scanner_params.parent->_bytes_read_counter, _stats.bytes_read);
     COUNTER_UPDATE(_scanner_params.parent->_column_read_timer, _stats.column_read_ns);
     COUNTER_UPDATE(_scanner_params.parent->_column_convert_timer, _stats.column_convert_ns);
-    COUNTER_UPDATE(_scanner_params.parent->_value_decode_timer, _stats.value_decode_ns);
-    COUNTER_UPDATE(_scanner_params.parent->_level_decode_timer, _stats.level_decode_ns);
 #endif
 }
 
 Status HdfsOrcScanner::do_open(RuntimeState* runtime_state) {
     auto input_stream = std::make_unique<ORCHdfsFileStream>(_scanner_params.fs,
                                                             _scanner_params.scan_ranges[0]->file_length, &_stats);
+#ifndef BE_TEST
+    SCOPED_TIMER(_scanner_params.parent->_reader_init_timer);
+#endif
     std::unique_ptr<orc::Reader> reader;
     try {
         orc::ReaderOptions options;
@@ -408,16 +409,9 @@ Status HdfsOrcScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk)
     {
         SCOPED_RAW_TIMER(&_stats.column_convert_ns);
         ChunkPtr ptr = _orc_adapter->create_chunk();
-        // reuse these counter.
-        {
-            SCOPED_RAW_TIMER(&_stats.value_decode_ns);
-            RETURN_IF_ERROR(_orc_adapter->fill_chunk(&ptr));
-        }
-        {
-            SCOPED_RAW_TIMER(&_stats.level_decode_ns);
-            ChunkPtr result = _orc_adapter->cast_chunk(&ptr);
-            *chunk = std::move(result);
-        }
+        RETURN_IF_ERROR(_orc_adapter->fill_chunk(&ptr));
+        ChunkPtr result = _orc_adapter->cast_chunk(&ptr);
+        *chunk = std::move(result);
     }
     ChunkPtr ck = *chunk;
     // important to add columns before evaluation

--- a/be/src/exec/vectorized/hdfs_scanner_parquet.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_parquet.cpp
@@ -1,4 +1,4 @@
-// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present StarRocks Limited.
 
 #include "exec/vectorized/hdfs_scanner_parquet.h"
 

--- a/be/src/exec/vectorized/hdfs_scanner_parquet.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_parquet.cpp
@@ -1,0 +1,78 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#include "exec/vectorized/hdfs_scanner_parquet.h"
+
+#include "exec/parquet/file_reader.h"
+#include "exec/vectorized/hdfs_scan_node.h"
+#include "util/runtime_profile.h"
+
+namespace starrocks::vectorized {
+
+Status HdfsParquetScanner::do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) {
+    return Status::OK();
+}
+
+Status HdfsParquetScanner::do_open(RuntimeState* runtime_state) {
+    // create file reader
+    _reader = std::make_shared<parquet::FileReader>(_scanner_params.fs.get(),
+                                                    _scanner_params.scan_ranges[0]->file_length);
+#ifndef BE_TEST
+    SCOPED_TIMER(_scanner_params.parent->_reader_init_timer);
+#endif
+    RETURN_IF_ERROR(_reader->init(_file_read_param));
+    return Status::OK();
+}
+
+Status HdfsParquetScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) {
+    Status status = _reader->get_next(chunk);
+    return status;
+}
+
+void HdfsParquetScanner::update_counter() {
+    HdfsScanner::update_counter();
+
+#ifndef BE_TEST
+    COUNTER_UPDATE(_scanner_params.parent->_rows_read_counter, _stats.raw_rows_read);
+    COUNTER_UPDATE(_scanner_params.parent->_expr_filter_timer, _stats.expr_filter_ns);
+    COUNTER_UPDATE(_scanner_params.parent->_io_timer, _stats.io_ns);
+    COUNTER_UPDATE(_scanner_params.parent->_io_counter, _stats.io_count);
+    COUNTER_UPDATE(_scanner_params.parent->_bytes_read_counter, _stats.bytes_read);
+    COUNTER_UPDATE(_scanner_params.parent->_column_read_timer, _stats.column_read_ns);
+    COUNTER_UPDATE(_scanner_params.parent->_column_convert_timer, _stats.column_convert_ns);
+
+    const auto& parquet_profile = _scanner_params.parent->_parquet_profile;
+
+    COUNTER_UPDATE(parquet_profile.value_decode_timer, _stats.value_decode_ns);
+    COUNTER_UPDATE(parquet_profile.level_decode_timer, _stats.level_decode_ns);
+    COUNTER_UPDATE(parquet_profile.page_read_timer, _stats.page_read_ns);
+    COUNTER_UPDATE(parquet_profile.footer_read_timer, _stats.footer_read_ns);
+    COUNTER_UPDATE(parquet_profile.column_reader_init_timer, _stats.column_reader_init_ns);
+    COUNTER_UPDATE(parquet_profile.group_chunk_read_timer, _stats.group_chunk_read_ns);
+    COUNTER_UPDATE(parquet_profile.group_dict_filter_timer, _stats.group_dict_filter_ns);
+    COUNTER_UPDATE(parquet_profile.group_dict_decode_timer, _stats.group_dict_decode_ns);
+#endif
+}
+
+void HdfsParquetScanner::do_close(RuntimeState* runtime_state) noexcept {
+    update_counter();
+    _reader.reset();
+}
+
+static const std::string kParquetProfileSectionPrefix = "Parquet";
+
+void HdfsParquetProfile::init(RuntimeProfile* root) {
+    if (_toplev != nullptr) return;
+    _toplev = ADD_TIMER(root, kParquetProfileSectionPrefix);
+    level_decode_timer = ADD_CHILD_TIMER(root, "LevelDecodeTime", kParquetProfileSectionPrefix);
+    value_decode_timer = ADD_CHILD_TIMER(root, "ValueDecodeTime", kParquetProfileSectionPrefix);
+
+    page_read_timer = ADD_CHILD_TIMER(root, "PageReadTime", kParquetProfileSectionPrefix);
+    footer_read_timer = ADD_CHILD_TIMER(root, "ReaderInitFooterRead", kParquetProfileSectionPrefix);
+    column_reader_init_timer = ADD_CHILD_TIMER(root, "ReaderInitColumnReaderInit", kParquetProfileSectionPrefix);
+
+    group_chunk_read_timer = ADD_CHILD_TIMER(root, "GroupChunkRead", kParquetProfileSectionPrefix);
+    group_dict_filter_timer = ADD_CHILD_TIMER(root, "GroupDictFilter", kParquetProfileSectionPrefix);
+    group_dict_decode_timer = ADD_CHILD_TIMER(root, "GroupDictDecode", kParquetProfileSectionPrefix);
+}
+
+} // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/hdfs_scanner_parquet.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_parquet.cpp
@@ -14,7 +14,7 @@ Status HdfsParquetScanner::do_init(RuntimeState* runtime_state, const HdfsScanne
 
 Status HdfsParquetScanner::do_open(RuntimeState* runtime_state) {
     // create file reader
-    _reader = std::make_shared<parquet::FileReader>(_scanner_params.fs.get(),
+    _reader = std::make_shared<parquet::FileReader>(runtime_state->chunk_size(), _scanner_params.fs.get(),
                                                     _scanner_params.scan_ranges[0]->file_length);
 #ifndef BE_TEST
     SCOPED_TIMER(_scanner_params.parent->_reader_init_timer);

--- a/be/src/exec/vectorized/hdfs_scanner_parquet.h
+++ b/be/src/exec/vectorized/hdfs_scanner_parquet.h
@@ -1,0 +1,50 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#pragma once
+
+#include "exec/vectorized/hdfs_scanner.h"
+
+namespace starrocks::vectorized {
+
+class HdfsParquetProfile {
+public:
+    // read & decode
+    RuntimeProfile::Counter* level_decode_timer = nullptr;
+    RuntimeProfile::Counter* value_decode_timer = nullptr;
+    RuntimeProfile::Counter* page_read_timer = nullptr;
+
+    // reader init
+    RuntimeProfile::Counter* footer_read_timer = nullptr;
+    RuntimeProfile::Counter* column_reader_init_timer = nullptr;
+
+    // dict filter
+    RuntimeProfile::Counter* group_chunk_read_timer = nullptr;
+    RuntimeProfile::Counter* group_dict_filter_timer = nullptr;
+    RuntimeProfile::Counter* group_dict_decode_timer = nullptr;
+
+    void init(RuntimeProfile* root);
+
+private:
+    RuntimeProfile::Counter* _toplev = nullptr;
+};
+
+class HdfsParquetScanner final : public HdfsScanner {
+public:
+    HdfsParquetScanner() = default;
+    ~HdfsParquetScanner() override {
+        if (_runtime_state != nullptr) {
+            close(_runtime_state);
+        }
+    }
+
+    void update_counter();
+    Status do_open(RuntimeState* runtime_state) override;
+    void do_close(RuntimeState* runtime_state) noexcept override;
+    Status do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) override;
+    Status do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) override;
+
+private:
+    std::shared_ptr<parquet::FileReader> _reader = nullptr;
+};
+
+} // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/hdfs_scanner_parquet.h
+++ b/be/src/exec/vectorized/hdfs_scanner_parquet.h
@@ -1,4 +1,4 @@
-// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present StarRocks Limited.
 
 #pragma once
 

--- a/be/src/exec/vectorized/hdfs_scanner_text.h
+++ b/be/src/exec/vectorized/hdfs_scanner_text.h
@@ -20,29 +20,7 @@ public:
     Status _parse_csv(int chunk_size, ChunkPtr* chunk);
 
 private:
-    class HdfsScannerCSVReader : public CSVReader {
-    public:
-        HdfsScannerCSVReader(std::shared_ptr<RandomAccessFile> file, char record_delimiter, string field_delimiter,
-                             size_t offset, size_t remain_length, size_t file_length)
-                : CSVReader(record_delimiter, field_delimiter) {
-            _file = file;
-            _offset = offset;
-            _remain_length = remain_length;
-            _file_length = file_length;
-        }
-
-        Status _fill_buffer() override;
-
-    private:
-        std::shared_ptr<RandomAccessFile> _file;
-        size_t _offset = 0;
-        size_t _remain_length = 0;
-        size_t _file_length = 0;
-        bool _should_stop_scan = false;
-    };
-
     using ConverterPtr = std::unique_ptr<csv::Converter>;
-
     char _record_delimiter;
     string _field_delimiter;
     std::vector<Column*> _column_raw_ptrs;

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -1,4 +1,4 @@
-// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present StarRocks Limited.
 
 #include "exec/workgroup/work_group.h"
 

--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -1,4 +1,4 @@
-// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present StarRocks Limited.
 
 #pragma once
 #include <atomic>

--- a/be/test/exec/vectorized/hdfs_scanner_test.cpp
+++ b/be/test/exec/vectorized/hdfs_scanner_test.cpp
@@ -8,6 +8,7 @@
 
 #include "column/column_helper.h"
 #include "exec/vectorized/hdfs_scanner_orc.h"
+#include "exec/vectorized/hdfs_scanner_parquet.h"
 #include "runtime/descriptor_helper.h"
 #include "runtime/runtime_state.h"
 #include "storage/vectorized/chunk_helper.h"


### PR DESCRIPTION
ref: #2661 

This PR tries to:
1. extract `HdfsParquetScanner` to a standalone cpp file
2. create self-owned profile section.
3. move `HdfsScannerCSVReader` from header file to cpp file, since it's only used internally.