### PR TITLE
[ResourceIsolation] cpu isolation for normal workgroup

### DIFF
--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -28,6 +28,7 @@
 #include "column/column_pool.h"
 #include "common/config.h"
 #include "common/minidump.h"
+#include "exec/workgroup/work_group.h"
 #include "runtime/exec_env.h"
 #include "runtime/mem_tracker.h"
 #include "runtime/memory/chunk_allocator.h"
@@ -133,6 +134,8 @@ void calculate_metrics(void* arg_this) {
     Daemon* daemon = static_cast<Daemon*>(arg_this);
     while (!daemon->stopped()) {
         StarRocksMetrics::instance()->metrics()->trigger_hook();
+
+        workgroup::WorkGroupManager::instance()->log_cpu();
 
         if (last_ts == -1L) {
             last_ts = MonotonicSeconds();

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -323,8 +323,10 @@ public:
     std::string to_readable_string() const;
 
     starrocks::workgroup::WorkGroup* workgroup();
-
     void set_workgroup(starrocks::workgroup::WorkGroup* wg);
+
+    size_t get_dispatch_queue_index() const { return _dispatch_queue_index; }
+    void set_dispatch_queue_index(size_t dispatch_queue_index) { _dispatch_queue_index = dispatch_queue_index; }
 
 private:
     // check whether fragment is cancelled. It is used before pull_chunk and push_chunk.
@@ -368,7 +370,8 @@ private:
 
     phmap::flat_hash_map<int32_t, OperatorStage> _operator_stages;
 
-    starrocks::workgroup::WorkGroup* _workgroup = nullptr;
+    workgroup::WorkGroup* _workgroup = nullptr;
+    size_t _dispatch_queue_index = 0;
 
     // metrics
     RuntimeProfile::Counter* _total_timer = nullptr;

--- a/be/src/exec/pipeline/pipeline_driver_dispatcher.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_dispatcher.cpp
@@ -51,8 +51,7 @@ void GlobalDriverDispatcher::run() {
             break;
         }
 
-        size_t queue_index;
-        auto maybe_driver = this->_driver_queue->take(&queue_index);
+        auto maybe_driver = this->_driver_queue->take();
         if (maybe_driver.status().is_cancelled()) {
             return;
         }
@@ -87,7 +86,7 @@ void GlobalDriverDispatcher::run() {
             // query context has ready drivers to run, so extend its lifetime.
             query_ctx->extend_lifetime();
             auto status = driver->process(runtime_state);
-            this->_driver_queue->get_sub_queue(queue_index)->update_accu_time(driver);
+            this->_driver_queue->yield_driver(driver);
 
             if (!status.ok()) {
                 LOG(WARNING) << "[Driver] Process error, query_id=" << print_id(driver->query_ctx()->query_id())

--- a/be/src/exec/pipeline/pipeline_driver_poller.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_poller.cpp
@@ -115,7 +115,7 @@ void PipelineDriverPoller::run_internal() {
         } else {
             spin_count = 0;
 
-            _dispatch_queue->put_back(ready_drivers);
+            _dispatch_queue->put_back(ready_drivers, false);
             ready_drivers.clear();
         }
 

--- a/be/src/exec/pipeline/pipeline_driver_queue.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_queue.cpp
@@ -2,34 +2,27 @@
 
 #include "exec/pipeline/pipeline_driver_queue.h"
 
+#include "exec/workgroup/work_group.h"
 #include "gutil/strings/substitute.h"
+
 namespace starrocks::pipeline {
-void QuerySharedDriverQueue::close() {
-    std::lock_guard<std::mutex> lock(_global_mutex);
-    _is_closed = true;
-    _cv.notify_all();
-}
 
-void QuerySharedDriverQueue::put_back(const DriverRawPtr driver) {
+void QuerySharedDriverQueue::put_back(const DriverRawPtr driver, bool from_dispatcher) {
     int level = driver->driver_acct().get_level();
-    {
-        std::lock_guard<std::mutex> lock(_global_mutex);
-        _queues[level % QUEUE_SIZE].queue.emplace(driver);
-        _cv.notify_one();
-    }
+    _queues[level % QUEUE_SIZE].queue.emplace(driver);
+    ++_size;
 }
 
-void QuerySharedDriverQueue::put_back(const std::vector<DriverRawPtr>& drivers) {
+void QuerySharedDriverQueue::put_back(const std::vector<DriverRawPtr>& drivers, bool from_dispatcher) {
     std::vector<int> levels(drivers.size());
     for (int i = 0; i < drivers.size(); i++) {
         levels[i] = drivers[i]->driver_acct().get_level();
     }
 
-    std::lock_guard<std::mutex> lock(_global_mutex);
     for (int i = 0; i < drivers.size(); i++) {
         _queues[levels[i] % QUEUE_SIZE].queue.emplace(drivers[i]);
-        _cv.notify_one();
     }
+    _size += drivers.size();
 }
 
 StatusOr<DriverRawPtr> QuerySharedDriverQueue::take() {
@@ -38,44 +31,129 @@ StatusOr<DriverRawPtr> QuerySharedDriverQueue::take() {
     double target_accu_time = 0;
     DriverRawPtr driver_ptr;
 
-    {
-        std::unique_lock<std::mutex> lock(_global_mutex);
-        while (true) {
-            if (_is_closed) {
-                return Status::Cancelled("Shutdown");
+    for (int i = 0; i < QUEUE_SIZE; ++i) {
+        // we just search for queue has element
+        if (!_queues[i].queue.empty()) {
+            double local_target_time = _queues[i].accu_time_after_divisor();
+            // if this is first queue that has element, we select it;
+            // else we choose queue that the execution time is less sufficient,
+            // and record time.
+            if (queue_idx < 0 || local_target_time < target_accu_time) {
+                target_accu_time = local_target_time;
+                queue_idx = i;
             }
-
-            for (int i = 0; i < QUEUE_SIZE; ++i) {
-                // we just search for queue has element
-                if (!_queues[i].queue.empty()) {
-                    double local_target_time = _queues[i].accu_time_after_divisor();
-                    // if this is first queue that has element, we select it;
-                    // else we choose queue that the execution time is less sufficient,
-                    // and record time.
-                    if (queue_idx < 0 || local_target_time < target_accu_time) {
-                        target_accu_time = local_target_time;
-                        queue_idx = i;
-                    }
-                }
-            }
-
-            if (queue_idx >= 0) {
-                break;
-            }
-            _cv.wait(lock);
         }
-
-        driver_ptr = _queues[queue_idx].queue.front();
-        driver_ptr->set_dispatch_queue_index(queue_idx);
-        _queues[queue_idx].queue.pop();
     }
 
-    // next pipeline driver to execute.
+    DCHECK(queue_idx >= 0);
+
+    driver_ptr = _queues[queue_idx].queue.front();
+    driver_ptr->set_dispatch_queue_index(queue_idx);
+    _queues[queue_idx].queue.pop();
+
+    --_size;
+
     return driver_ptr;
 }
 
 void QuerySharedDriverQueue::yield_driver(const DriverRawPtr driver) {
     _queues[driver->get_dispatch_queue_index()].update_accu_time(driver);
+}
+
+void DriverQueueWithWorkGroup::close() {
+    std::lock_guard<std::mutex> lock(_global_mutex);
+    _is_closed = true;
+    _cv.notify_all();
+}
+
+void DriverQueueWithWorkGroup::put_back(const DriverRawPtr driver, bool from_dispatcher) {
+    std::lock_guard<std::mutex> lock(_global_mutex);
+    _put_back(driver, from_dispatcher);
+}
+
+void DriverQueueWithWorkGroup::put_back(const std::vector<DriverRawPtr>& drivers, bool from_dispatcher) {
+    std::lock_guard<std::mutex> lock(_global_mutex);
+
+    for (const auto driver : drivers) {
+        _put_back(driver, from_dispatcher);
+    }
+}
+
+StatusOr<DriverRawPtr> DriverQueueWithWorkGroup::take() {
+    std::unique_lock<std::mutex> lock(_global_mutex);
+
+    if (_is_closed) {
+        return Status::Cancelled("Shutdown");
+    }
+
+    while (_wgs.empty()) {
+        _cv.wait(lock);
+        if (_is_closed) {
+            return Status::Cancelled("Shutdown");
+        }
+    }
+
+    auto wg = _get_min_wg();
+    if (wg->driver_queue()->size() == 1) {
+        _sum_cpu_limit -= wg->get_cpu_limit();
+        _wgs.erase(wg);
+    }
+
+    return wg->driver_queue()->take();
+}
+
+void DriverQueueWithWorkGroup::yield_driver(const DriverRawPtr driver) {
+    std::unique_lock<std::mutex> lock(_global_mutex);
+    auto* wg = driver->workgroup();
+
+    wg->driver_queue()->yield_driver(driver);
+    wg->increment_real_runtime(driver->driver_acct().get_last_time_spent());
+}
+
+size_t DriverQueueWithWorkGroup::size() {
+    std::lock_guard<std::mutex> lock(_global_mutex);
+
+    size_t size = 0;
+    for (auto wg : _wgs) {
+        size += wg->driver_queue()->size();
+    }
+
+    return size;
+}
+
+void DriverQueueWithWorkGroup::_put_back(const DriverRawPtr driver, bool from_dispatcher) {
+    auto* wg = driver->workgroup();
+    if (_wgs.find(wg) == _wgs.end()) {
+        _sum_cpu_limit += wg->get_cpu_limit();
+        if (!from_dispatcher) {
+            auto* min_wg = _get_min_wg();
+            if (min_wg != nullptr) {
+                wg->set_vruntime_ns(
+                        std::max(wg->get_vruntime_ns(), min_wg->get_vruntime_ns() - _ideal_runtime_ns(wg) / 2));
+            }
+        }
+
+        _wgs.emplace(wg);
+    }
+
+    wg->driver_queue()->put_back(driver, from_dispatcher);
+    _cv.notify_one();
+}
+
+workgroup::WorkGroup* DriverQueueWithWorkGroup::_get_min_wg() {
+    workgroup::WorkGroup* min_wg = nullptr;
+    int64_t min_vruntime_ns = 0;
+    for (auto wg : _wgs) {
+        if (min_wg == nullptr || min_vruntime_ns > wg->get_vruntime_ns()) {
+            min_wg = wg;
+            min_vruntime_ns = wg->get_vruntime_ns();
+        }
+    }
+    return min_wg;
+}
+
+int64_t DriverQueueWithWorkGroup::_ideal_runtime_ns(workgroup::WorkGroup* wg) {
+    return DISPATCH_LATENCY_NS * _wgs.size() * wg->get_cpu_limit() / _sum_cpu_limit;
 }
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/pipeline_driver_queue.h
+++ b/be/src/exec/pipeline/pipeline_driver_queue.h
@@ -82,7 +82,7 @@ private:
 
     SubQuerySharedDriverQueue _queues[QUEUE_SIZE];
 
-    size_t _size;
+    size_t _size = 0;
 };
 
 // DriverQueueWithWorkGroup contains two levels of queues.

--- a/be/src/exec/pipeline/pipeline_driver_queue.h
+++ b/be/src/exec/pipeline/pipeline_driver_queue.h
@@ -97,7 +97,7 @@ public:
     // When the driver's workgroup is not in the workgroup queue
     // and the driver isn't from a dispatcher thread (that is, from the poller or new driver),
     // the workgroup's vruntime is adjusted to workgroup_queue.min_vruntime-ideal_runtime/2,
-    // to avoid slope this workgroup too much time.
+    // to avoid sloping too much time to this workgroup .
     void put_back(const DriverRawPtr driver, bool from_dispatcher) override;
     void put_back(const std::vector<DriverRawPtr>& drivers, bool from_dispatcher) override;
 
@@ -105,7 +105,8 @@ public:
     // Secondly, select the proper driver from the driver queue of this work group.
     StatusOr<DriverRawPtr> take() override;
 
-    // Update statistics information of the queue.
+    // Update statistics information of the driver's workgroup
+    // when yielding the driver in the dispatcher thread.
     void yield_driver(const DriverRawPtr driver) override;
 
     size_t size() override;
@@ -114,7 +115,9 @@ private:
     // The schedule period is equal to DISPATCH_PERIOD_PER_WG_NS * num_workgroups.
     static constexpr int64_t DISPATCH_PERIOD_PER_WG_NS = 200'1000'1000;
 
+    // This method should be guarded by the outside _global_mutex.
     void _put_back(const DriverRawPtr driver, bool from_dispatcher);
+    // This method should be guarded by the outside _global_mutex.
     workgroup::WorkGroup* _find_min_wg();
     // The ideal runtime of a work group is the weighted average of the schedule period.
     int64_t _ideal_runtime_ns(workgroup::WorkGroup* wg);

--- a/be/src/exec/pipeline/pipeline_driver_queue.h
+++ b/be/src/exec/pipeline/pipeline_driver_queue.h
@@ -8,6 +8,11 @@
 #include "util/factory_method.h"
 
 namespace starrocks {
+
+namespace workgroup {
+class WorkGroup;
+}
+
 namespace pipeline {
 
 class DriverQueue;
@@ -18,11 +23,14 @@ public:
     virtual ~DriverQueue() = default;
     virtual void close() = 0;
 
-    virtual void put_back(const DriverRawPtr driver) = 0;
-    virtual void put_back(const std::vector<DriverRawPtr>& drivers) = 0;
+    virtual void put_back(const DriverRawPtr driver, bool from_dispatcher) = 0;
+    virtual void put_back(const std::vector<DriverRawPtr>& drivers, bool from_dispatcher) = 0;
     virtual StatusOr<DriverRawPtr> take() = 0;
 
     virtual void yield_driver(const DriverRawPtr driver) = 0;
+
+    virtual size_t size() = 0;
+    bool empty() { return size() == 0; }
 };
 
 class SubQuerySharedDriverQueue {
@@ -45,7 +53,7 @@ class QuerySharedDriverQueue : public FactoryMethod<DriverQueue, QuerySharedDriv
     friend class FactoryMethod<DriverQueue, QuerySharedDriverQueue>;
 
 public:
-    QuerySharedDriverQueue() : _is_closed(false) {
+    QuerySharedDriverQueue() {
         double factor = 1;
         for (int i = QUEUE_SIZE - 1; i >= 0; --i) {
             // initialize factor for every sub queue,
@@ -56,23 +64,54 @@ public:
         }
     }
     ~QuerySharedDriverQueue() override = default;
-    void close() override;
+    void close() override {}
 
-    void put_back(const DriverRawPtr driver) override;
-    void put_back(const std::vector<DriverRawPtr>& drivers) override;
+    void put_back(const DriverRawPtr driver, bool from_dispatcher) override;
+    void put_back(const std::vector<DriverRawPtr>& drivers, bool from_dispatcher) override;
     // return nullptr if queue is closed;
     StatusOr<DriverRawPtr> take() override;
 
     void yield_driver(const DriverRawPtr driver) override;
+
+    size_t size() override { return _size; }
 
 private:
     static constexpr size_t QUEUE_SIZE = 8;
     static constexpr double RATIO_OF_ADJACENT_QUEUE = 1.2;
 
     SubQuerySharedDriverQueue _queues[QUEUE_SIZE];
+
+    size_t _size;
+};
+
+class DriverQueueWithWorkGroup : public FactoryMethod<DriverQueue, DriverQueueWithWorkGroup> {
+    friend class FactoryMethod<DriverQueue, DriverQueueWithWorkGroup>;
+
+public:
+    ~DriverQueueWithWorkGroup() override = default;
+    void close() override;
+
+    void put_back(const DriverRawPtr driver, bool from_dispatcher) override;
+    void put_back(const std::vector<DriverRawPtr>& drivers, bool from_dispatcher) override;
+    StatusOr<DriverRawPtr> take() override;
+
+    void yield_driver(const DriverRawPtr driver) override;
+
+    size_t size() override;
+
+private:
+    static constexpr int64_t DISPATCH_LATENCY_NS = 200'1000'1000;
+
+    void _put_back(const DriverRawPtr driver, bool from_dispatcher);
+    workgroup::WorkGroup* _get_min_wg();
+    int64_t _ideal_runtime_ns(workgroup::WorkGroup* wg);
+
     std::mutex _global_mutex;
     std::condition_variable _cv;
-    bool _is_closed;
+    std::unordered_set<workgroup::WorkGroup*> _wgs;
+    size_t _sum_cpu_limit = 0;
+
+    bool _is_closed = false;
 };
 
 } // namespace pipeline

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -73,6 +73,10 @@ public:
         wg = std::make_shared<WorkGroup>("wg#2", 2, 2, 1, 1, WorkGroupType::WG_NORMAL);
         wg->init();
         WorkGroupManager::instance()->add_workgroup(wg);
+
+        wg = std::make_shared<WorkGroup>("wg#3", 3, 4, 1, 1, WorkGroupType::WG_NORMAL);
+        wg->init();
+        WorkGroupManager::instance()->add_workgroup(wg);
     }
 } _;
 } // namespace

--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -71,11 +71,9 @@ public:
 
     int64_t get_real_runtime_ns() const { return _vruntime_ns * _cpu_limit; }
 
-    void increment_real_runtime(int64_t real_runtime_ns) {
-        // Accumulate virtual runtime divided by _cpu_limit, so that the larger _cpu_limit,
-        // the more cpu time can be consumed proportionally.
-        _vruntime_ns += real_runtime_ns / _cpu_limit;
-    }
+    // Accumulate virtual runtime divided by _cpu_limit, so that the larger _cpu_limit,
+    // the more cpu time can be consumed proportionally.
+    void increment_real_runtime(int64_t real_runtime_ns) { _vruntime_ns += real_runtime_ns / _cpu_limit; }
 
     void set_vruntime_ns(int64_t vruntime_ns) { _vruntime_ns = vruntime_ns; }
 

--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -71,9 +71,13 @@ public:
 
     int64_t get_real_runtime_ns() const { return _vruntime_ns * _cpu_limit; }
 
-    void increment_real_runtime(int64_t real_runtime_ns) { _vruntime_ns += real_runtime_ns / _cpu_limit; }
+    void increment_real_runtime(int64_t real_runtime_ns) {
+        // Accumulate virtual runtime divided by _cpu_limit, so that the larger _cpu_limit,
+        // the more cpu time can be consumed proportionally.
+        _vruntime_ns += real_runtime_ns / _cpu_limit;
+    }
 
-    void set_vruntime_ns(double vruntime_ns) { _vruntime_ns = vruntime_ns; }
+    void set_vruntime_ns(int64_t vruntime_ns) { _vruntime_ns = vruntime_ns; }
 
 private:
     std::string _name;

--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -26,15 +26,6 @@ public:
     virtual WorkGroupPtr pick_next() = 0;
 };
 
-class CpuWorkGroupQueue final : public WorkGroupQueue {
-public:
-    CpuWorkGroupQueue() = default;
-    ~CpuWorkGroupQueue() = default;
-    void add(const WorkGroupPtr& wg) override {}
-    void remove(const WorkGroupPtr& wg) override {}
-    WorkGroupPtr pick_next() override { return nullptr; }
-};
-
 class IoWorkGroupQueue final : public WorkGroupQueue {
 public:
     IoWorkGroupQueue() = default;
@@ -62,28 +53,42 @@ public:
 
     void init();
 
-    starrocks::MemTracker* mem_tracker() { return _mem_tracker.get(); }
-    starrocks::pipeline::DriverQueue* driver_queue() { return _driver_queue.get(); }
+    MemTracker* mem_tracker() { return _mem_tracker.get(); }
+    pipeline::DriverQueue* driver_queue() { return _driver_queue.get(); }
 
     int id() const { return _id; }
-    int get_cpu_priority() {
-        // TODO: implement cpu priority computation
-        return 0;
-    }
+
+    const std::string& name() const { return _name; }
+
     int get_io_priority() {
         // TODO: implement io priority computation
         return 0;
     }
 
+    size_t get_cpu_limit() const { return _cpu_limit; }
+
+    int64_t get_vruntime_ns() const { return _vruntime_ns; }
+
+    int64_t get_real_runtime_ns() const { return _vruntime_ns * _cpu_limit; }
+
+    void increment_real_runtime(int64_t real_runtime_ns) { _vruntime_ns += real_runtime_ns / _cpu_limit; }
+
+    void set_vruntime_ns(double vruntime_ns) { _vruntime_ns = vruntime_ns; }
+
 private:
     std::string _name;
     int _id;
+    WorkGroupType _type;
+
     size_t _cpu_limit;
     size_t _memory_limit;
     size_t _concurrency;
-    WorkGroupType _type;
-    std::shared_ptr<starrocks::MemTracker> _mem_tracker;
-    starrocks::pipeline::DriverQueuePtr _driver_queue;
+
+    std::shared_ptr<starrocks::MemTracker> _mem_tracker = nullptr;
+
+    pipeline::DriverQueuePtr _driver_queue = nullptr;
+    int64_t _vruntime_ns = 0;
+
     // it's proper to define Context as a Thrift or protobuf struct.
     // WorkGroupContext _context;
 };
@@ -96,21 +101,29 @@ class WorkGroupManager {
 public:
     // add a new workgroup to WorkGroupManger
     void add_workgroup(const WorkGroupPtr& wg);
+
     // remove already-existing workgroup from WorkGroupManager
     void remove_workgroup(int wg_id);
-    // get next workgroup for computation
-    WorkGroupPtr pick_next_wg_for_cpu();
+
+    WorkGroupPtr get_workgroup(int wg_id);
+
     // get next workgroup for io
     WorkGroupPtr pick_next_wg_for_io();
-
-    WorkGroupQueue& get_cpu_queue();
-
     WorkGroupQueue& get_io_queue();
+
+    void log_cpu() {
+        for (const auto& [_, wg] : _workgroups) {
+            LOG(WARNING) << "[WorkGroup] "
+                         << "[name=" << wg->name() << "] "
+                         << "[cpu_limit=" << wg->get_cpu_limit() << "] "
+                         << "[vruntime_ms=" << wg->get_vruntime_ns() / 1000'000.0L << "] "
+                         << "[real_runtime_ms=" << wg->get_real_runtime_ns() / 1000'000.0L << "] ";
+        }
+    }
 
 private:
     std::mutex _mutex;
     std::unordered_map<int, WorkGroupPtr> _workgroups;
-    CpuWorkGroupQueue _wg_cpu_queue;
     IoWorkGroupQueue _wg_io_queue;
 };
 

--- a/be/test/exec/pipeline/pipeline_test_base.cpp
+++ b/be/test/exec/pipeline/pipeline_test_base.cpp
@@ -118,7 +118,7 @@ void PipelineTestBase::_prepare() {
 
     auto wg = workgroup::WorkGroupManager::instance()->get_workgroup(0);
     for (auto driver : drivers) {
-        driver->set_workgroup(wg);
+        driver->set_workgroup(wg.get());
     }
 
     _fragment_ctx->set_drivers(std::move(drivers));

--- a/be/test/exec/pipeline/pipeline_test_base.cpp
+++ b/be/test/exec/pipeline/pipeline_test_base.cpp
@@ -7,6 +7,7 @@
 #include "column/nullable_column.h"
 #include "exec/pipeline/fragment_context.h"
 #include "exec/pipeline/pipeline_driver_dispatcher.h"
+#include "exec/workgroup/work_group.h"
 #include "runtime/date_value.h"
 #include "runtime/timestamp_value.h"
 #include "storage/vectorized/chunk_helper.h"
@@ -113,6 +114,11 @@ void PipelineTestBase::_prepare() {
                 drivers.emplace_back(driver);
             }
         }
+    }
+
+    auto wg = workgroup::WorkGroupManager::instance()->get_workgroup(0);
+    for (auto driver : drivers) {
+        driver->set_workgroup(wg);
     }
 
     _fragment_ctx->set_drivers(std::move(drivers));

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -1995,6 +1995,7 @@ public class Coordinator {
                         params.setIs_pipeline(
                                 fragment.getPlanRoot().canUsePipeLine() && fragment.getSink().canUsePipeLine());
                         params.setPipeline_dop(fragment.getPipelineDop());
+                        params.setWorkgroup_id(sessionVariable.getWorkGroupID());
                     }
 
                     if (sessionVariable.isEnableExchangePassThrough()) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -117,6 +117,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String PIPELINE_PROFILE_MODE = "pipeline_profile_mode";
 
+    public static final String WORKGROUP_ID = "workgroup_id";
+
     // hash join right table push down
     public static final String HASH_JOIN_PUSH_DOWN_RIGHT_TABLE = "hash_join_push_down_right_table";
 
@@ -170,6 +172,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = ENABLE_PIPELINE_ENGINE)
     private boolean enablePipelineEngine = false;
+
+    @VariableMgr.VarAttr(name = WORKGROUP_ID)
+    private int workGroupID = 0;
 
     // max memory used on every backend.
     @VariableMgr.VarAttr(name = EXEC_MEM_LIMIT)
@@ -715,6 +720,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public int getPipelineDop() {
         return this.pipelineDop;
+    }
+
+    public int getWorkGroupID() {
+        return workGroupID;
+    }
+
+    public void setWorkGroupID(int workGroupID) {
+        this.workGroupID = workGroupID;
     }
 
     public boolean isEnableReplicationJoin() {

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -295,6 +295,8 @@ struct TExecPlanFragmentParams {
 
   50: optional bool is_pipeline
   51: optional i32 pipeline_dop
+
+  52: optional i32 workgroup_id
 }
 
 struct TExecPlanFragmentResult {


### PR DESCRIPTION
### Introduction
Use the two-level **global** queue instead of the one-level driver queue, containing the work group queue as the first level, and the driver queue int a work group as the second level.

The mainly workflow of the workgroup and driver schedule is as follows:
1. The running driver yields, when it costs 100ms or pulls and pushes chunk 100 times.
2. Accumulate the virtual runtime to the workgroup of this yielded driver.
3. Select the driver in the workgroup, whose virtual runtime is the smallest.


### Detail
Use `DriverQueueWithWorkGroup` instead of `QuerySharedDriverQueue` to schedule drivers running on the dispatcher threads.

`DriverQueueWithWorkGroup` contains two levels of queues. The first level is the work group queue, and the second level is the driver queue in a work group.

- `DriverQueueWithWorkGroup::take()`
    1.  Firstly, select the work group with the minimum vruntime.
    2. Secondly, select the proper driver from the driver queue of this work group.
- `DriverQueueWithWorkGroup::put_back()`
     When the driver's workgroup is not in the workgroup queue and the driver isn't from a dispatcher thread (that is, from the poller or new driver), the workgroup's `vruntime` is adjusted to `workgroup_queue.min_vruntime-ideal_runtime/2`, to avoid sloping too much time to this workgroup .

### TODO
In this PR, a driver maybe runs at most 100ms regardless of its cpu limit weight, so the schedule latency is about 100ms.
In the future, We can provide a workgroup queue per dispatcher thread instead of a global workgroup queue to schedule more accurately.


