### PR TITLE
Implement rowset reload in the final stage of apply.

### DIFF
--- a/be/src/storage/fs/block_manager.h
+++ b/be/src/storage/fs/block_manager.h
@@ -232,6 +232,8 @@ public:
     // Does not modify 'block' on error.
     virtual Status open_block(const std::string& path, std::unique_ptr<ReadableBlock>* block) = 0;
 
+    virtual void erase_block_cache(const std::string& path) = 0;
+
     // Retrieves the IDs of all blocks under management by this block manager.
     // These include ReadableBlocks as well as WritableBlocks.
     //

--- a/be/src/storage/fs/file_block_manager.cpp
+++ b/be/src/storage/fs/file_block_manager.cpp
@@ -408,6 +408,11 @@ Status FileBlockManager::open_block(const std::string& path, std::unique_ptr<Rea
     return Status::OK();
 }
 
+void FileBlockManager::erase_block_cache(const std::string& path) {
+    VLOG(1) << "erasing block cache with path at " << path;
+    _file_cache->erase(path);
+}
+
 // TODO(lingbin): We should do something to ensure that deletion can only be done
 // after the last reader or writer has finished
 Status FileBlockManager::_delete_block(const string& path) {

--- a/be/src/storage/fs/file_block_manager.h
+++ b/be/src/storage/fs/file_block_manager.h
@@ -76,6 +76,8 @@ public:
 
     Status open_block(const std::string& path, std::unique_ptr<ReadableBlock>* block) override;
 
+    void erase_block_cache(const std::string& path) override;
+
     Status get_all_block_ids(std::vector<BlockId>* block_ids) override {
         // TODO(lingbin): to be implemented after we assign each block an id
         return Status::OK();

--- a/be/src/util/file_cache.cpp
+++ b/be/src/util/file_cache.cpp
@@ -58,6 +58,13 @@ void FileCache<FileType>::insert(const std::string& file_name, FileType* file,
     *file_handle = OpenedFileHandle<FileType>(_cache.get(), lru_handle);
 }
 
+template <class FileType>
+void FileCache<FileType>::erase(const std::string& file_name) {
+    DCHECK(_cache != nullptr);
+    CacheKey key(file_name);
+    _cache->erase(key);
+}
+
 // Explicit specialization for callers outside this compilation unit.
 template class FileCache<RandomAccessFile>;
 

--- a/be/src/util/file_cache.h
+++ b/be/src/util/file_cache.h
@@ -135,6 +135,8 @@ public:
     // and return file_handle
     void insert(const std::string& file_name, FileType* file, OpenedFileHandle<FileType>* file_handle);
 
+    void erase(const std::string& file_name);
+
 private:
     // Name of the cache.
     std::string _cache_name;


### PR DESCRIPTION
After rewrite partial rowset to full rowset, need reload the rowset.
Specifically, reopen segments, and the file cache still existing after rename, need erase it manually.
resolve #2681 