### PR TITLE
Disable tuple id columns for pipeline query engine

### DIFF
--- a/be/src/exec/vectorized/hash_joiner.cpp
+++ b/be/src/exec/vectorized/hash_joiner.cpp
@@ -100,6 +100,8 @@ Status HashJoiner::prepare(RuntimeState* state) {
 }
 
 void HashJoiner::_init_hash_table_param(HashTableParam* param) {
+    // Pipeline query engine always needn't create tuple columns
+    param->need_create_tuple_columns = false;
     param->with_other_conjunct = !_other_join_conjunct_ctxs.empty();
     param->join_type = _join_type;
     param->row_desc = &_row_descriptor;

--- a/be/src/exec/vectorized/join_hash_map.cpp
+++ b/be/src/exec/vectorized/join_hash_map.cpp
@@ -215,6 +215,7 @@ void JoinHashTable::create(const HashTableParam& param) {
 
     _table_items->row_count = 0;
     _table_items->bucket_size = 0;
+    _table_items->need_create_tuple_columns = _need_create_tuple_columns;
     _table_items->build_chunk = std::make_shared<Chunk>();
     _table_items->build_pool = std::make_unique<MemPool>();
     _table_items->probe_pool = std::make_unique<MemPool>();


### PR DESCRIPTION
For https://github.com/StarRocks/starrocks/issues/2569

Pipeline query engine always needn't create tuple columns.
