### PR TITLE
Fix end of file reached before reading fully for csv scanner and only process scan range with offset 0

### DIFF
--- a/be/src/exec/vectorized/hdfs_scanner_text.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_text.cpp
@@ -65,10 +65,7 @@ Status HdfsTextScanner::do_open(RuntimeState* runtime_state) {
                                                      scan_range->offset, scan_range->length, scan_range->file_length);
     if (scan_range->offset != 0) {
         CSVReader::Record dummy;
-        Status st = _reader->next_record(&dummy);
-        if (!st.ok()) {
-            return st;
-        }
+        RETURN_IF_ERROR(_reader->next_record(&dummy));
     }
     for (int i = 0; i < _scanner_params.materialize_slots.size(); i++) {
         auto slot = _scanner_params.materialize_slots[i];

--- a/be/src/exec/vectorized/hdfs_scanner_text.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_text.cpp
@@ -43,7 +43,7 @@ Status HdfsTextScanner::HdfsScannerCSVReader::_fill_buffer() {
         _buff.append(_record_delimiter);
     }
 
-    if ((_remain_length < 0 && _buff.find(_record_delimiter, n) != nullptr)
+    if ((_remain_length < 0 && _buff.find(_record_delimiter, 0) != nullptr)
         || (_offset >= _file_length)) {
         _should_stop_scan = true;
     }

--- a/be/src/exec/vectorized/hdfs_scanner_text.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_text.cpp
@@ -67,6 +67,7 @@ Status HdfsTextScanner::do_open(RuntimeState* runtime_state) {
                                                      scan_range->offset, scan_range->length, scan_range->file_length);
     if (scan_range->offset != 0) {
         // Always skip first record of scan range with non-zero offset.
+        // Notice that the first record will read by previous scan range.
         CSVReader::Record dummy;
         RETURN_IF_ERROR(_reader->next_record(&dummy));
     }

--- a/be/src/exec/vectorized/hdfs_scanner_text.h
+++ b/be/src/exec/vectorized/hdfs_scanner_text.h
@@ -23,11 +23,12 @@ private:
     class HdfsScannerCSVReader : public CSVReader {
     public:
         HdfsScannerCSVReader(std::shared_ptr<RandomAccessFile> file, char record_delimiter, string field_delimiter,
-                             size_t offset, size_t length)
+                             size_t offset, size_t remain_length, size_t file_length)
                 : CSVReader(record_delimiter, field_delimiter) {
             _file = file;
             _offset = offset;
-            _length = length;
+            _remain_length = remain_length;
+            _file_length = file_length;
         }
 
         Status _fill_buffer() override;
@@ -35,7 +36,9 @@ private:
     private:
         std::shared_ptr<RandomAccessFile> _file;
         size_t _offset = 0;
-        size_t _length = 0;
+        size_t _remain_length = 0;
+        size_t _file_length = 0;
+        bool _should_stop_scan = false;
     };
 
     using ConverterPtr = std::unique_ptr<csv::Converter>;

--- a/be/src/exec/vectorized/hdfs_scanner_text.h
+++ b/be/src/exec/vectorized/hdfs_scanner_text.h
@@ -23,10 +23,11 @@ private:
     class HdfsScannerCSVReader : public CSVReader {
     public:
         HdfsScannerCSVReader(std::shared_ptr<RandomAccessFile> file, char record_delimiter, string field_delimiter,
-                             size_t offset)
+                             size_t offset, size_t length)
                 : CSVReader(record_delimiter, field_delimiter) {
             _file = file;
             _offset = offset;
+            _length = length;
         }
 
         Status _fill_buffer() override;
@@ -34,6 +35,7 @@ private:
     private:
         std::shared_ptr<RandomAccessFile> _file;
         size_t _offset = 0;
+        size_t _length = 0;
     };
 
     using ConverterPtr = std::unique_ptr<csv::Converter>;


### PR DESCRIPTION
close #2668 
we should not use hdfsPreadFully for CSV scanner since it will always return error below
```
WARN (starrocks-mysql-nio-pool-0|136) [Coordinator.getNext():748] query failed: fail to hdfsPreadFully file, file=hdfs://emr-header-1.cluster-259859:9000/user/hive/warehouse/countries_list_yuzhou/000000_0, error=error=Error(255): Unknown error 255, root_cause=EOFException: End of file reached before reading fully.
```
by the way, we should only process scan range with offset 0 for text file.
we can also send scan range to be used getSplits of input format later