### PR TITLE
[ResourceIsolation] Bind Workgroup to PipelineDriver

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -16,6 +16,7 @@
 #include "exec/pipeline/result_sink_operator.h"
 #include "exec/pipeline/scan_operator.h"
 #include "exec/scan_node.h"
+#include "exec/workgroup/work_group.h"
 #include "gen_cpp/doris_internal_service.pb.h"
 #include "gutil/casts.h"
 #include "gutil/map_util.h"
@@ -29,6 +30,10 @@
 #include "util/uid_util.h"
 
 namespace starrocks::pipeline {
+
+using WorkGroupManager = starrocks::workgroup::WorkGroupManager;
+using WorkGroup = starrocks::workgroup::WorkGroup;
+using WorkGroupPtr = starrocks::workgroup::WorkGroupPtr;
 
 static void setup_profile_hierarchy(RuntimeState* runtime_state, const PipelinePtr& pipeline) {
     runtime_state->runtime_profile()->add_child(pipeline->runtime_profile(), true, nullptr);
@@ -104,12 +109,20 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
 
     LOG(INFO) << "Prepare(): query_id=" << print_id(query_id)
               << " fragment_instance_id=" << print_id(params.fragment_instance_id) << " backend_num=" << backend_num;
+    WorkGroupPtr wg;
+    if (request.__isset.workgroup && request.workgroup.id != WorkGroup::DEFAULT_WG_ID) {
+        wg = std::make_shared<WorkGroup>(request.workgroup);
+        wg = WorkGroupManager::instance()->add_workgroup(wg);
+    } else {
+        wg = WorkGroupManager::instance()->get_default_workgroup();
+    }
+    DCHECK(wg != nullptr);
 
     _fragment_ctx->set_runtime_state(
             std::make_unique<RuntimeState>(query_id, fragment_instance_id, query_options, query_globals, exec_env));
     auto* runtime_state = _fragment_ctx->runtime_state();
     runtime_state->set_chunk_size(query_options.batch_size);
-    runtime_state->init_mem_trackers(query_id);
+    runtime_state->init_mem_trackers(query_id, wg->mem_tracker());
     runtime_state->set_be_number(backend_num);
 
     // RuntimeFilterWorker::open_query is idempotent
@@ -241,7 +254,9 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
     _fragment_ctx->set_drivers(std::move(drivers));
 
     _query_ctx->fragment_mgr()->register_ctx(fragment_instance_id, std::move(fragment_ctx));
-
+    for (auto& driver : _fragment_ctx->drivers()) {
+        driver->set_workgroup(wg.get());
+    }
     return Status::OK();
 }
 

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -56,6 +56,10 @@ void WorkGroup::init() {
 
 WorkGroupManager::WorkGroupManager() {}
 WorkGroupManager::~WorkGroupManager() {}
+void WorkGroupManager::destroy() {
+    std::lock_guard<std::mutex> lock(_mutex);
+    this->_workgroups.clear();
+}
 
 WorkGroupPtr WorkGroupManager::add_workgroup(const WorkGroupPtr& wg) {
     std::lock_guard<std::mutex> lock(_mutex);
@@ -102,11 +106,11 @@ WorkGroupQueue& WorkGroupManager::get_io_queue() {
 }
 
 DefaultWorkGroupInitialization::DefaultWorkGroupInitialization() {
-    auto default_wg = std::make_shared<WorkGroup>("default_wg", 0, 1, 20L * (1L << 32), 10, WorkGroupType::WG_DEFAULT);
+    auto default_wg = std::make_shared<WorkGroup>("default_wg", 0, 1, 20L * (1L << 30), 10, WorkGroupType::WG_DEFAULT);
     default_wg->init();
-    auto wg1 = std::make_shared<WorkGroup>("wg1", 1, 2, 10L * (1L << 32), 10, WorkGroupType::WG_NORMAL);
+    auto wg1 = std::make_shared<WorkGroup>("wg1", 1, 2, 10L * (1L << 30), 10, WorkGroupType::WG_NORMAL);
     wg1->init();
-    auto wg2 = std::make_shared<WorkGroup>("wg2", 2, 4, 30L * (1L << 32), 10, WorkGroupType::WG_NORMAL);
+    auto wg2 = std::make_shared<WorkGroup>("wg2", 2, 4, 30L * (1L << 30), 10, WorkGroupType::WG_NORMAL);
     wg2->init();
     WorkGroupManager::instance()->add_workgroup(default_wg);
     WorkGroupManager::instance()->add_workgroup(wg1);

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -2,8 +2,8 @@
 
 #include "exec/workgroup/work_group.h"
 
+#include "gen_cpp/internal_service.pb.h"
 #include "runtime/exec_env.h"
-
 namespace starrocks {
 namespace workgroup {
 WorkGroup::WorkGroup(const std::string& name, int id, size_t cpu_limit, size_t memory_limit, size_t concurrency,
@@ -15,6 +15,39 @@ WorkGroup::WorkGroup(const std::string& name, int id, size_t cpu_limit, size_t m
           _concurrency(concurrency),
           _type(type) {}
 
+WorkGroup::WorkGroup(const TWorkGroup& twg) : _name(twg.name), _id(twg.id) {
+    if (twg.__isset.cpu_limit) {
+        _cpu_limit = twg.cpu_limit;
+    } else {
+        _cpu_limit = -1;
+    }
+    if (twg.__isset.memory_limit) {
+        _memory_limit = twg.memory_limit;
+    } else {
+        _memory_limit = -1;
+    }
+    if (twg.__isset.concurrency) {
+        _concurrency = twg.concurrency;
+    } else {
+        _concurrency = -1;
+    }
+    if (twg.__isset.type) {
+        switch (twg.type) {
+        case TWorkGroupType::WG_NORMAL:
+            _type = WG_NORMAL;
+            break;
+        case TWorkGroupType::WG_DEFAULT:
+            _type = WG_DEFAULT;
+            break;
+        case TWorkGroupType::WG_REALTIME:
+            _type = WG_REALTIME;
+            break;
+        }
+    } else {
+        _type = WG_NORMAL;
+    }
+}
+
 void WorkGroup::init() {
     _mem_tracker = std::make_shared<starrocks::MemTracker>(_memory_limit, _name,
                                                            ExecEnv::GetInstance()->query_pool_mem_tracker());
@@ -24,13 +57,22 @@ void WorkGroup::init() {
 WorkGroupManager::WorkGroupManager() {}
 WorkGroupManager::~WorkGroupManager() {}
 
-void WorkGroupManager::add_workgroup(const WorkGroupPtr& wg) {
+WorkGroupPtr WorkGroupManager::add_workgroup(const WorkGroupPtr& wg) {
     std::lock_guard<std::mutex> lock(_mutex);
     if (!_workgroups.count(wg->id())) {
         _workgroups[wg->id()] = wg;
         _wg_cpu_queue.add(wg);
         _wg_io_queue.add(wg);
+        return wg;
+    } else {
+        return _workgroups[wg->id()];
     }
+}
+
+WorkGroupPtr WorkGroupManager::get_default_workgroup() {
+    std::lock_guard<std::mutex> lock(_mutex);
+    DCHECK(_workgroups.count(WorkGroup::DEFAULT_WG_ID));
+    return _workgroups[WorkGroup::DEFAULT_WG_ID];
 }
 
 void WorkGroupManager::remove_workgroup(int wg_id) {
@@ -59,16 +101,17 @@ WorkGroupQueue& WorkGroupManager::get_io_queue() {
     return _wg_io_queue;
 }
 
-namespace {
-class DefaultWorkGroupInitialization {
-public:
-    DefaultWorkGroupInitialization() {
-        auto default_wg = std::make_shared<WorkGroup>("default_wg", 1, 10, 10, 10, WorkGroupType::WG_DEFAULT);
-        default_wg->init();
-        WorkGroupManager::instance()->add_workgroup(default_wg);
-    }
-} _;
-} // namespace
+DefaultWorkGroupInitialization::DefaultWorkGroupInitialization() {
+    auto default_wg = std::make_shared<WorkGroup>("default_wg", 0, 1, 20L * (1L << 32), 10, WorkGroupType::WG_DEFAULT);
+    default_wg->init();
+    auto wg1 = std::make_shared<WorkGroup>("wg1", 1, 2, 10L * (1L << 32), 10, WorkGroupType::WG_NORMAL);
+    wg1->init();
+    auto wg2 = std::make_shared<WorkGroup>("wg2", 2, 4, 30L * (1L << 32), 10, WorkGroupType::WG_NORMAL);
+    wg2->init();
+    WorkGroupManager::instance()->add_workgroup(default_wg);
+    WorkGroupManager::instance()->add_workgroup(wg1);
+    WorkGroupManager::instance()->add_workgroup(wg2);
+}
 
 } // namespace workgroup
 } // namespace starrocks

--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -102,6 +102,8 @@ public:
     WorkGroupPtr add_workgroup(const WorkGroupPtr& wg);
     // return reserved beforehand default workgroup for query is not bound to any workgroup
     WorkGroupPtr get_default_workgroup();
+    // destruct workgroups
+    void destroy();
     // remove already-existing workgroup from WorkGroupManager
     void remove_workgroup(int wg_id);
     // get next workgroup for computation

--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -12,6 +12,7 @@
 #include "storage/olap_define.h"
 
 namespace starrocks {
+class TWorkGroup;
 namespace workgroup {
 
 class WorkGroup;
@@ -58,6 +59,7 @@ class WorkGroup {
 public:
     WorkGroup(const std::string& name, int id, size_t cpu_limit, size_t memory_limit, size_t concurrency,
               WorkGroupType type);
+    WorkGroup(const TWorkGroup& twg);
     ~WorkGroup() = default;
 
     void init();
@@ -74,6 +76,8 @@ public:
         // TODO: implement io priority computation
         return 0;
     }
+
+    static constexpr int DEFAULT_WG_ID = 0;
 
 private:
     std::string _name;
@@ -95,7 +99,9 @@ class WorkGroupManager {
 
 public:
     // add a new workgroup to WorkGroupManger
-    void add_workgroup(const WorkGroupPtr& wg);
+    WorkGroupPtr add_workgroup(const WorkGroupPtr& wg);
+    // return reserved beforehand default workgroup for query is not bound to any workgroup
+    WorkGroupPtr get_default_workgroup();
     // remove already-existing workgroup from WorkGroupManager
     void remove_workgroup(int wg_id);
     // get next workgroup for computation
@@ -112,6 +118,11 @@ private:
     std::unordered_map<int, WorkGroupPtr> _workgroups;
     CpuWorkGroupQueue _wg_cpu_queue;
     IoWorkGroupQueue _wg_io_queue;
+};
+
+class DefaultWorkGroupInitialization {
+public:
+    DefaultWorkGroupInitialization();
 };
 
 } // namespace workgroup

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -28,6 +28,7 @@
 #include "common/logging.h"
 #include "exec/pipeline/pipeline_driver_dispatcher.h"
 #include "exec/pipeline/pipeline_fwd.h"
+#include "exec/workgroup/work_group.h"
 #include "gen_cpp/BackendService.h"
 #include "gen_cpp/FrontendService.h"
 #include "gen_cpp/HeartbeatService_types.h"
@@ -252,6 +253,8 @@ Status ExecEnv::init_mem_tracker() {
     SetMemTrackerForColumnPool op(_column_pool_mem_tracker);
     vectorized::ForEach<vectorized::ColumnPoolList>(op);
 
+    //TODO(by satanson): for verification of Resource Isolation.
+    starrocks::workgroup::DefaultWorkGroupInitialization default_workgroup_init;
     return Status::OK();
 }
 

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -396,6 +396,8 @@ void ExecEnv::_destroy() {
         delete _load_mem_tracker;
         _load_mem_tracker = nullptr;
     }
+    // WorkGroupManager should release MemTracker of WorkGroups belongs to itself before deallocate _query_pool_mem_tracker.
+    starrocks::workgroup::WorkGroupManager::instance()->destroy();
     if (_query_pool_mem_tracker) {
         delete _query_pool_mem_tracker;
         _query_pool_mem_tracker = nullptr;

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -81,7 +81,7 @@ public:
     // Specific parts of the fragment (i.e. exec nodes, sinks, data stream senders, etc)
     // will add a fourth level when they are initialized.
     // This function also initializes a user function mem tracker (in the fourth level).
-    void init_mem_trackers(const TUniqueId& query_id);
+    void init_mem_trackers(const TUniqueId& query_id, MemTracker* parent = nullptr);
 
     // for ut only
     Status init_instance_mem_tracker();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -95,6 +95,7 @@ import com.starrocks.thrift.TScanRangeParams;
 import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TTabletCommitInfo;
 import com.starrocks.thrift.TUniqueId;
+import com.starrocks.thrift.TWorkGroup;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
@@ -1995,6 +1996,10 @@ public class Coordinator {
                         params.setIs_pipeline(
                                 fragment.getPlanRoot().canUsePipeLine() && fragment.getSink().canUsePipeLine());
                         params.setPipeline_dop(fragment.getPipelineDop());
+                        TWorkGroup wg = new TWorkGroup();
+                        wg.name = "";
+                        wg.id = ConnectContext.get().getSessionVariable().getWorkgroupId();
+                        params.setWorkgroup(wg);
                     }
 
                     if (sessionVariable.isEnableExchangePassThrough()) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -1996,6 +1996,7 @@ public class Coordinator {
                         params.setIs_pipeline(
                                 fragment.getPlanRoot().canUsePipeLine() && fragment.getSink().canUsePipeLine());
                         params.setPipeline_dop(fragment.getPipelineDop());
+                        // TODO (by satanson): just for verification of resource isolation.
                         TWorkGroup wg = new TWorkGroup();
                         wg.name = "";
                         wg.id = ConnectContext.get().getSessionVariable().getWorkgroupId();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -117,6 +117,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String PIPELINE_PROFILE_MODE = "pipeline_profile_mode";
 
+    public static final String WORKGROUP_ID = "workgroup_id";
+
     // hash join right table push down
     public static final String HASH_JOIN_PUSH_DOWN_RIGHT_TABLE = "hash_join_push_down_right_table";
 
@@ -312,6 +314,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = PIPELINE_PROFILE_MODE)
     private String pipelineProfileMode = "brief";
+
+    @VariableMgr.VarAttr(name = WORKGROUP_ID)
+    private int workgroupId = 0;
 
     @VariableMgr.VarAttr(name = ENABLE_INSERT_STRICT)
     private boolean enableInsertStrict = true;
@@ -715,6 +720,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public int getPipelineDop() {
         return this.pipelineDop;
+    }
+
+    public int getWorkgroupId() {
+        return workgroupId;
     }
 
     public boolean isEnableReplicationJoin() {

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -256,8 +256,8 @@ enum TWorkGroupType {
 }
 
 struct TWorkGroup {
-    1: required i32 id
-    2: required string name
+    1: optional i32 id
+    2: optional string name
     3: optional i64 cpu_limit
     4: optional i64 memory_limit
     5: optional i64 concurrency

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -249,6 +249,21 @@ enum InternalServiceVersion {
   V1
 }
 
+enum TWorkGroupType {
+    WG_NORMAL,
+    WG_DEFAULT,
+    WG_REALTIME
+}
+
+struct TWorkGroup {
+    1: required i32 id
+    2: required string name
+    3: optional i64 cpu_limit
+    4: optional i64 memory_limit
+    5: optional i64 concurrency
+    6: optional TWorkGroupType type
+}
+
 // ExecPlanFragment
 
 struct TExecPlanFragmentParams {
@@ -295,6 +310,8 @@ struct TExecPlanFragmentParams {
 
   50: optional bool is_pipeline
   51: optional i32 pipeline_dop
+  52: optional map<Types.TPlanNodeId, i32> per_scan_node_dop
+  53: optional TWorkGroup workgroup
 }
 
 struct TExecPlanFragmentResult {
@@ -440,3 +457,4 @@ struct TExportStatusResult {
     2: required Types.TExportState state
     3: optional list<string> files
 }
+


### PR DESCRIPTION
## Enhancement

Each query belongs to a certain workgroups, so bind pipeline drivers originates from the same query to the workgroup. when prepare FragmentExecutor for a fragment instance, the MemTracker of the target workgroup is used to initialize the MemTracker of RuntimeState. in addition,

1. drivers have a field _workgroup to keep its target workgroup.
2. Initialization of workgroups for verification moved to ExecEnv::init since MemTracker of workgroups are children of query_pool_mem_tracker of ExecEnv and the latter should be initialized first.