### PR TITLE
Upgrade protobuf-java due to CVE-2021-22569

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -419,7 +419,7 @@ under the License.
             <dependency>
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-java</artifactId>
-                <version>3.5.1</version>
+                <version>3.16.1</version>
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/com.squareup/protoparser -->

--- a/fs_brokers/apache_hdfs_broker/pom.xml
+++ b/fs_brokers/apache_hdfs_broker/pom.xml
@@ -39,7 +39,7 @@ under the License.
         <hadoop.version>2.10.1</hadoop.version>
         <guava.version>30.1.1-jre</guava.version>
         <zookeeper.version>3.4.14</zookeeper.version>
-        <protobuf.version>2.5.0</protobuf.version>
+        <protobuf.version>3.16.1</protobuf.version>
         <thrift.version>0.14.1</thrift.version>
         <tomcat.version>8.5.70</tomcat.version>
         <log4j.version>2.17.1</log4j.version>


### PR DESCRIPTION
more detail:
https://github.com/advisories/GHSA-wrvw-hg22-4m67