### PR TITLE
Add mem restrict for chunk queue of FileScanNode

### DIFF
--- a/be/src/exec/vectorized/file_scan_node.cpp
+++ b/be/src/exec/vectorized/file_scan_node.cpp
@@ -6,7 +6,6 @@
 #include <sstream>
 
 #include "column/chunk.h"
-#include "common/object_pool.h"
 #include "env/env.h"
 #include "env/env_broker.h"
 #include "exec/vectorized/csv_scanner.h"
@@ -15,7 +14,6 @@
 #include "exec/vectorized/parquet_scanner.h"
 #include "exprs/expr.h"
 #include "runtime/current_thread.h"
-#include "runtime/exec_env.h"
 #include "runtime/runtime_state.h"
 #include "util/defer_op.h"
 #include "util/runtime_profile.h"
@@ -24,12 +22,7 @@
 namespace starrocks::vectorized {
 
 FileScanNode::FileScanNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs)
-        : ScanNode(pool, tnode, descs),
-          _tuple_id(tnode.file_scan_node.tuple_id),
-          _tuple_desc(nullptr),
-          _max_queue_size(32),
-          _num_running_scanners(0),
-          _scan_finished(false) {}
+        : ScanNode(pool, tnode, descs), _tuple_id(tnode.file_scan_node.tuple_id) {}
 
 FileScanNode::~FileScanNode() {
     if (runtime_state() != nullptr) {
@@ -76,17 +69,17 @@ Status FileScanNode::open(RuntimeState* state) {
     RETURN_IF_ERROR(exec_debug_action(TExecNodePhase::OPEN));
     RETURN_IF_CANCELLED(state);
 
-    RETURN_IF_ERROR(start_scanners());
+    RETURN_IF_ERROR(_start_scanners());
 
     return Status::OK();
 }
 
-Status FileScanNode::start_scanners() {
+Status FileScanNode::_start_scanners() {
     {
         std::unique_lock<std::mutex> l(_chunk_queue_lock);
 
         _num_running_scanners = 1;
-        _scanner_threads.emplace_back(&FileScanNode::scanner_worker, this, 0, _scan_ranges.size());
+        _scanner_threads.emplace_back(&FileScanNode::_scanner_worker, this, 0, _scan_ranges.size());
         Thread::set_thread_name(_scanner_threads.back(), "file_scanner");
     }
     return Status::OK();
@@ -97,7 +90,7 @@ Status FileScanNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) {
     // check if CANCELLED.
     if (state->is_cancelled()) {
         std::unique_lock<std::mutex> l(_chunk_queue_lock);
-        if (update_status(Status::Cancelled("Cancelled FileScanNode::get_next"))) {
+        if (_update_status(Status::Cancelled("Cancelled FileScanNode::get_next"))) {
             // Notify all scanners
             _queue_writer_cond.notify_all();
             return _process_status;
@@ -122,13 +115,14 @@ Status FileScanNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) {
             return _process_status;
         }
         if (runtime_state()->is_cancelled()) {
-            if (update_status(Status::Cancelled("Cancelled FileScanNode::get_next"))) {
+            if (_update_status(Status::Cancelled("Cancelled FileScanNode::get_next"))) {
                 _queue_writer_cond.notify_all();
             }
             return _process_status;
         }
         if (!_chunk_queue.empty()) {
             temp_chunk = _chunk_queue.front();
+            _cur_mem_usage -= temp_chunk->memory_usage();
             _chunk_queue.pop_front();
         }
     }
@@ -180,6 +174,7 @@ Status FileScanNode::close(RuntimeState* state) {
     while (!_chunk_queue.empty()) {
         _chunk_queue.pop_front();
     }
+    _cur_mem_usage = 0;
 
     return ExecNode::close(state);
 }
@@ -194,7 +189,8 @@ void FileScanNode::debug_string(int ident_level, std::stringstream* out) const {
     (*out) << "FileScanNode";
 }
 
-std::unique_ptr<FileScanner> FileScanNode::create_scanner(const TBrokerScanRange& scan_range, ScannerCounter* counter) {
+std::unique_ptr<FileScanner> FileScanNode::_create_scanner(const TBrokerScanRange& scan_range,
+                                                           ScannerCounter* counter) {
     if (scan_range.ranges[0].format_type == TFileFormatType::FORMAT_ORC) {
         return std::make_unique<ORCScanner>(runtime_state(), runtime_profile(), scan_range, counter);
     } else if (scan_range.ranges[0].format_type == TFileFormatType::FORMAT_PARQUET) {
@@ -206,13 +202,13 @@ std::unique_ptr<FileScanner> FileScanNode::create_scanner(const TBrokerScanRange
     }
 }
 
-Status FileScanNode::scanner_scan(const TBrokerScanRange& scan_range, const std::vector<ExprContext*>& conjunct_ctxs,
-                                  ScannerCounter* counter) {
+Status FileScanNode::_scanner_scan(const TBrokerScanRange& scan_range, const std::vector<ExprContext*>& conjunct_ctxs,
+                                   ScannerCounter* counter) {
     if (scan_range.ranges.empty()) {
         return Status::EndOfFile("scan range is empty");
     }
     //create scanner object and open
-    std::unique_ptr<FileScanner> scanner = create_scanner(scan_range, counter);
+    std::unique_ptr<FileScanner> scanner = _create_scanner(scan_range, counter);
     if (scanner == nullptr) {
         return Status::InternalError("Failed to create scanner");
     }
@@ -244,7 +240,7 @@ Status FileScanNode::scanner_scan(const TBrokerScanRange& scan_range, const std:
                    // 1. too many batches in queue, or
                    // 2. at least one batch in queue and memory exceed limit.
                    (_chunk_queue.size() >= _max_queue_size ||
-                    (runtime_state()->instance_mem_tracker()->any_limit_exceeded() && !_chunk_queue.empty()))) {
+                    (_cur_mem_usage >= _max_mem_usage && !_chunk_queue.empty()))) {
                 _queue_writer_cond.wait_for(l, std::chrono::seconds(1));
             }
             // Process already set failed, so we just return OK
@@ -260,6 +256,7 @@ Status FileScanNode::scanner_scan(const TBrokerScanRange& scan_range, const std:
                 return Status::Cancelled("Cancelled FileScanNode::scanner_scan");
             }
             // Queue size Must be smaller than _max_queue_size
+            _cur_mem_usage += temp_chunk->memory_usage();
             _chunk_queue.push_back(std::move(temp_chunk));
 
             // Notify reader to
@@ -270,7 +267,7 @@ Status FileScanNode::scanner_scan(const TBrokerScanRange& scan_range, const std:
     return Status::OK();
 }
 
-void FileScanNode::scanner_worker(int start_idx, int length) {
+void FileScanNode::_scanner_worker(int start_idx, int length) {
     SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(runtime_state()->instance_mem_tracker());
 
     // Clone expr context
@@ -296,7 +293,7 @@ void FileScanNode::scanner_worker(int start_idx, int length) {
                 }
                 new_scan_range.ranges.emplace_back(range_desc);
             }
-            status = scanner_scan(new_scan_range, scanner_expr_ctxs, &counter);
+            status = _scanner_scan(new_scan_range, scanner_expr_ctxs, &counter);
 
             // todo: break if failed ?
             if (!status.ok() && !status.is_end_of_file()) {
@@ -324,7 +321,7 @@ void FileScanNode::scanner_worker(int start_idx, int length) {
     {
         std::lock_guard<std::mutex> l(_chunk_queue_lock);
         if (!status.ok() && !status.is_end_of_file()) {
-            update_status(status);
+            _update_status(status);
         }
         // This scanner will finish
         _num_running_scanners--;

--- a/be/src/exec/vectorized/file_scan_node.h
+++ b/be/src/exec/vectorized/file_scan_node.h
@@ -66,7 +66,7 @@ private:
 
     // Scan one range
     Status _scanner_scan(const TBrokerScanRange& scan_range, const std::vector<ExprContext*>& conjunct_ctxs,
-                        ScannerCounter* counter);
+                         ScannerCounter* counter);
 
     std::unique_ptr<FileScanner> _create_scanner(const TBrokerScanRange& scan_range, ScannerCounter* counter);
 

--- a/be/src/exec/vectorized/file_scan_node.h
+++ b/be/src/exec/vectorized/file_scan_node.h
@@ -4,15 +4,12 @@
 
 #include <atomic>
 #include <condition_variable>
-#include <map>
 #include <mutex>
-#include <string>
 #include <thread>
 #include <vector>
 
 #include "column/chunk.h"
 #include "common/status.h"
-#include "exec/decompressor.h"
 #include "exec/scan_node.h"
 #include "exec/vectorized/file_scanner.h"
 #include "gen_cpp/InternalService_types.h"
@@ -20,16 +17,11 @@
 namespace starrocks {
 
 class RuntimeState;
-class PartRangeKey;
-class PartitionInfo;
-class RandomAccessFile;
 struct ScannerCounter;
-class SequentialFile;
-class RandomAccessFile;
 
 namespace vectorized {
 
-class FileScanNode : public ScanNode {
+class FileScanNode final : public ScanNode {
 public:
     FileScanNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs);
     ~FileScanNode() override;
@@ -58,7 +50,7 @@ protected:
 private:
     // Update process status to one failed status,
     // NOTE: Must hold the mutex of this scan node
-    bool update_status(const Status& new_status) {
+    bool _update_status(const Status& new_status) {
         if (_process_status.ok()) {
             _process_status = new_status;
             return true;
@@ -67,20 +59,19 @@ private:
     }
 
     // Create scanners to do scan job
-    Status start_scanners();
+    Status _start_scanners();
 
     // One scanner worker, This scanner will handle 'length' ranges start from start_idx
-    void scanner_worker(int start_idx, int length);
+    void _scanner_worker(int start_idx, int length);
 
     // Scan one range
-    Status scanner_scan(const TBrokerScanRange& scan_range, const std::vector<ExprContext*>& conjunct_ctxs,
+    Status _scanner_scan(const TBrokerScanRange& scan_range, const std::vector<ExprContext*>& conjunct_ctxs,
                         ScannerCounter* counter);
 
-    std::unique_ptr<FileScanner> create_scanner(const TBrokerScanRange& scan_range, ScannerCounter* counter);
+    std::unique_ptr<FileScanner> _create_scanner(const TBrokerScanRange& scan_range, ScannerCounter* counter);
 
-private:
     TupleId _tuple_id;
-    TupleDescriptor* _tuple_desc;
+    TupleDescriptor* _tuple_desc = nullptr;
     std::vector<TScanRangeParams> _scan_ranges;
 
     std::mutex _chunk_queue_lock;
@@ -89,11 +80,14 @@ private:
 
     std::deque<ChunkPtr> _chunk_queue;
 
-    int _max_queue_size;
+    int64_t _cur_mem_usage = 0;
 
-    int _num_running_scanners;
+    static const int _max_queue_size = 32;
+    static const int64_t _max_mem_usage = 64 * 1024 * 1024;
 
-    std::atomic<bool> _scan_finished;
+    int _num_running_scanners = 0;
+
+    std::atomic<bool> _scan_finished{false};
 
     Status _process_status;
 


### PR DESCRIPTION
for #2658 

Current FileScanNode ChunkQueue limits the memory according to the number of Chunks. When there are many columns in the Chunk, it will still occupy a lot of memory. Now add an upper limit of memory usage (64M)
