### PR TITLE
Fix routine load clear custom properties bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
@@ -540,7 +540,7 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
     @Override
     public void updateState(JobState jobState, ErrorReason reason, boolean isReplay) throws UserException {
         super.updateState(jobState, reason, isReplay);
-        customProperties.clear();
+        convertedCustomProperties.clear();
     }
 
     private void modifyPropertiesInternal(Map<String, String> jobProperties,

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
@@ -540,7 +540,6 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
     @Override
     public void updateState(JobState jobState, ErrorReason reason, boolean isReplay) throws UserException {
         super.updateState(jobState, reason, isReplay);
-        convertedCustomProperties.clear();
     }
 
     private void modifyPropertiesInternal(Map<String, String> jobProperties,


### PR DESCRIPTION
Bugs introduced from PR #2404.
The initial thought was to clean up the convertedCustomProperties. But there's no need to clean it up because convertedCustomProperties will be recreated after the state change. Cleaning up customProperties was a pure mistake.