### PR TITLE
Fix routine load clear custom properties bug (#2695)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
@@ -540,7 +540,6 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
     @Override
     public void updateState(JobState jobState, ErrorReason reason, boolean isReplay) throws UserException {
         super.updateState(jobState, reason, isReplay);
-        customProperties.clear();
     }
 
     private void modifyPropertiesInternal(Map<String, String> jobProperties,


### PR DESCRIPTION
The initial thought was to clean up the convertedCustomProperties. But there's no need to clean it up because convertedCustomProperties will be recreated after the state change. Cleaning up customProperties was a pure mistake.