### PR TITLE
Disable global dictionary optimization in case of large dictionary data

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CacheDictManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CacheDictManager.java
@@ -132,27 +132,27 @@ public class CacheDictManager implements IDictManager {
             ColumnIdentifier columnIdentifier = new ColumnIdentifier(statisticData.tableId, statisticData.columnName);
             if (dictSize > 256) {
                 noDictStringColumns.add(columnIdentifier);
+            } else {
+                int dictDataSize = 0;
+                for (int i = 0; i < dictSize; i++) {
+                    // a UTF-8 code may take up to 3 bytes
+                    dictDataSize += tGlobalDict.strings.get(i).length() * 3;
+                    // string offsets
+                    dictDataSize += 4;
+                }
+                // 1M
+                final int DICT_PAGE_MAX_SIZE = 1024 * 1024;
+                // If the dictionary data size exceeds 1M,
+                // we won't use the global dictionary optimization.
+                // In this case BE cannot guarantee that the dictionary page
+                // will be generated after the compaction.
+                // Additional 32 bytes reserved for security.
+                if (dictDataSize > DICT_PAGE_MAX_SIZE - 32) {
+                    noDictStringColumns.add(columnIdentifier);
+                }
             }
-            int dictDataSize = 0;
-            for (int i = 0; i < dictSize; i++) {
-                // a UTF-8 code may take up to 3 bytes
-                dictDataSize += tGlobalDict.strings.get(i).length() * 3;
-                // string offsets
-                dictDataSize += 4;
-            }
-            // 1M
-            final int DICT_PAGE_MAX_SIZE = 1024 * 1024;
-            // If the dictionary data size exceeds 1M,
-            // we won't use the global dictionary optimization.
-            // In this case BE cannot guarantee that the dictionary page
-            // will be generated after the compaction
-            if (dictDataSize > DICT_PAGE_MAX_SIZE) {
-                noDictStringColumns.add(columnIdentifier);
-            }
+            
 
-            for (int i = 0; i < dictSize; ++i) {
-                dicts.put(tGlobalDict.strings.get(i), tGlobalDict.ids.get(i));
-            }
             for (int i = 0; i < dictSize; ++i) {
                 dicts.put(tGlobalDict.strings.get(i), tGlobalDict.ids.get(i));
             }


### PR DESCRIPTION
Both segments that have dictionary pages may not have dictionaries after compact.

will close #2699 