### PR TITLE
Record required property in physical operator And remove useles code for shuffle bucket join

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/HashJoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HashJoinNode.java
@@ -232,10 +232,6 @@ public class HashJoinNode extends PlanNode {
         return isLocalHashBucket;
     }
 
-    public boolean isShuffleHashBucket() {
-        return isShuffleHashBucket;
-    }
-
     public void setColocate(boolean colocate, String reason) {
         isColocate = colocate;
         colocateReason = reason;
@@ -243,10 +239,6 @@ public class HashJoinNode extends PlanNode {
 
     public void setLocalHashBucket(boolean localHashBucket) {
         isLocalHashBucket = localHashBucket;
-    }
-
-    public void setShuffleHashBucket(boolean runtimeBucketShuffle) {
-        isShuffleHashBucket = runtimeBucketShuffle;
     }
 
     public void setPartitionExprs(List<Expr> exprs) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/EnumeratePlan.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/EnumeratePlan.java
@@ -7,6 +7,7 @@ import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.base.OutputInputProperty;
 import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalOperator;
 
 import java.util.Collections;
 import java.util.List;
@@ -60,6 +61,9 @@ public class EnumeratePlan {
         for (Map.Entry<OutputInputProperty, Integer> entry : chooseGroupExpression
                 .getPropertiesPlanCountMap(requiredProperty).entrySet()) {
             List<PhysicalPropertySet> inputProperties = entry.getKey().getInputProperties();
+            // record inputProperties at operator, used for planFragment builder to determine join type
+            PhysicalOperator operator = (PhysicalOperator) chooseGroupExpression.getOp();
+            operator.setRequiredProperties(inputProperties);
 
             if (planCountOfKProperties + entry.getValue() >= localRankOfGroupExpression) {
                 // 4. compute the localProperty-rank in the property.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptExpression.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptExpression.java
@@ -6,6 +6,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.base.LogicalProperty;
+import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.statistics.Statistics;
 
@@ -33,6 +34,8 @@ public class OptExpression {
     // For easily convert a GroupExpression to OptExpression when pattern match
     // we just use OptExpression to wrap GroupExpression
     private GroupExpression groupExpression;
+    // required properties for children.
+    private List<PhysicalPropertySet> requiredProperties;
 
     public OptExpression() {
         this.inputs = Lists.newArrayList();
@@ -106,6 +109,14 @@ public class OptExpression {
     public ColumnRefSet getOutputColumns() {
         Preconditions.checkState(property != null);
         return property.getOutputColumns();
+    }
+
+    public void setRequiredProperties(List<PhysicalPropertySet> requiredProperties) {
+        this.requiredProperties = requiredProperties;
+    }
+
+    public List<PhysicalPropertySet> getRequiredProperties() {
+        return this.requiredProperties;
     }
 
     // This function assume the child expr logical property has been derived

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -8,6 +8,7 @@ import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalOperator;
 import com.starrocks.sql.optimizer.rewrite.AddDecodeNodeForDictStringRule;
 import com.starrocks.sql.optimizer.rewrite.ExchangeSortToMergeRule;
 import com.starrocks.sql.optimizer.rewrite.PruneAggregateNodeRule;
@@ -220,6 +221,9 @@ public class Optimizer {
             OptExpression childPlan = extractBestPlan(inputProperties.get(i), groupExpression.inputAt(i));
             childPlans.add(childPlan);
         }
+
+        PhysicalOperator operator = (PhysicalOperator) groupExpression.getOp();
+        operator.setRequiredProperties(inputProperties);
 
         OptExpression expression = OptExpression.create(groupExpression.getOp(),
                 childPlans);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -8,7 +8,6 @@ import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
-import com.starrocks.sql.optimizer.operator.physical.PhysicalOperator;
 import com.starrocks.sql.optimizer.rewrite.AddDecodeNodeForDictStringRule;
 import com.starrocks.sql.optimizer.rewrite.ExchangeSortToMergeRule;
 import com.starrocks.sql.optimizer.rewrite.PruneAggregateNodeRule;
@@ -221,12 +220,11 @@ public class Optimizer {
             OptExpression childPlan = extractBestPlan(inputProperties.get(i), groupExpression.inputAt(i));
             childPlans.add(childPlan);
         }
-        // record inputProperties at operator, used for planFragment builder to determine join type
-        PhysicalOperator operator = (PhysicalOperator) groupExpression.getOp();
-        operator.setRequiredProperties(inputProperties);
 
         OptExpression expression = OptExpression.create(groupExpression.getOp(),
                 childPlans);
+        // record inputProperties at optExpression, used for planFragment builder to determine join type
+        expression.setRequiredProperties(inputProperties);
         expression.setStatistics(groupExpression.getGroup().getConfidenceStatistics() != null ?
                 groupExpression.getGroup().getConfidenceStatistics() :
                 groupExpression.getGroup().getStatistics());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -221,7 +221,7 @@ public class Optimizer {
             OptExpression childPlan = extractBestPlan(inputProperties.get(i), groupExpression.inputAt(i));
             childPlans.add(childPlan);
         }
-
+        // record inputProperties at operator, used for planFragment builder to determine join type
         PhysicalOperator operator = (PhysicalOperator) groupExpression.getOp();
         operator.setRequiredProperties(inputProperties);
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalOperator.java
@@ -5,17 +5,14 @@ package com.starrocks.sql.optimizer.operator.physical;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.base.DistributionSpec;
 import com.starrocks.sql.optimizer.base.OrderSpec;
-import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 
-import java.util.List;
 import java.util.Set;
 
 public abstract class PhysicalOperator extends Operator {
     protected OrderSpec orderSpec;
     protected DistributionSpec distributionSpec;
-    private List<PhysicalPropertySet> requiredProperties;
 
     protected PhysicalOperator(OperatorType type) {
         this(type, DistributionSpec.createAnyDistributionSpec(), OrderSpec.createEmpty());
@@ -42,14 +39,6 @@ public abstract class PhysicalOperator extends Operator {
 
     public DistributionSpec getDistributionSpec() {
         return distributionSpec;
-    }
-
-    public void setRequiredProperties(List<PhysicalPropertySet> requiredProperties) {
-        this.requiredProperties = requiredProperties;
-    }
-
-    public List<PhysicalPropertySet> getRequiredProperties() {
-        return this.requiredProperties;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalOperator.java
@@ -5,14 +5,17 @@ package com.starrocks.sql.optimizer.operator.physical;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.base.DistributionSpec;
 import com.starrocks.sql.optimizer.base.OrderSpec;
+import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 
+import java.util.List;
 import java.util.Set;
 
 public abstract class PhysicalOperator extends Operator {
     protected OrderSpec orderSpec;
     protected DistributionSpec distributionSpec;
+    private List<PhysicalPropertySet> requiredProperties;
 
     protected PhysicalOperator(OperatorType type) {
         this(type, DistributionSpec.createAnyDistributionSpec(), OrderSpec.createEmpty());
@@ -39,6 +42,14 @@ public abstract class PhysicalOperator extends Operator {
 
     public DistributionSpec getDistributionSpec() {
         return distributionSpec;
+    }
+
+    public void setRequiredProperties(List<PhysicalPropertySet> requiredProperties) {
+        this.requiredProperties = requiredProperties;
+    }
+
+    public List<PhysicalPropertySet> getRequiredProperties() {
+        return this.requiredProperties;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1472,13 +1472,13 @@ public class PlanFragmentBuilder {
                     } else if (ConnectContext.get().getSessionVariable().isEnableReplicationJoin() &&
                             rightFragmentPlanRoot.canDoReplicatedJoin()) {
                         distributionMode = HashJoinNode.DistributionMode.REPLICATED;
-                    } else if (isPartitionShuffleJoin(node)) {
+                    } else if (isShuffleJoin(node)) {
                         distributionMode = HashJoinNode.DistributionMode.SHUFFLE_HASH_BUCKET;
                     } else {
                         Preconditions.checkState(false, "Must be replicate join or colocate join");
                         distributionMode = HashJoinNode.DistributionMode.COLOCATE;
                     }
-                } else if (isPartitionShuffleJoin(node)) {
+                } else if (isShuffleJoin(node)) {
                     distributionMode = HashJoinNode.DistributionMode.SHUFFLE_HASH_BUCKET;
                 } else {
                     distributionMode = HashJoinNode.DistributionMode.LOCAL_HASH_BUCKET;
@@ -1736,7 +1736,7 @@ public class PlanFragmentBuilder {
             return false;
         }
 
-        public boolean isPartitionShuffleJoin(PhysicalHashJoinOperator node) {
+        public boolean isShuffleJoin(PhysicalHashJoinOperator node) {
             return node.getRequiredProperties().stream().allMatch(
                     physicalPropertySet -> physicalPropertySet.getDistributionProperty().isShuffle() &&
                             ((HashDistributionSpec) (physicalPropertySet.getDistributionProperty().getSpec()))

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1472,13 +1472,13 @@ public class PlanFragmentBuilder {
                     } else if (ConnectContext.get().getSessionVariable().isEnableReplicationJoin() &&
                             rightFragmentPlanRoot.canDoReplicatedJoin()) {
                         distributionMode = HashJoinNode.DistributionMode.REPLICATED;
-                    } else if (isShuffleJoin(node)) {
+                    } else if (isShuffleJoin(optExpr)) {
                         distributionMode = HashJoinNode.DistributionMode.SHUFFLE_HASH_BUCKET;
                     } else {
                         Preconditions.checkState(false, "Must be replicate join or colocate join");
                         distributionMode = HashJoinNode.DistributionMode.COLOCATE;
                     }
-                } else if (isShuffleJoin(node)) {
+                } else if (isShuffleJoin(optExpr)) {
                     distributionMode = HashJoinNode.DistributionMode.SHUFFLE_HASH_BUCKET;
                 } else {
                     distributionMode = HashJoinNode.DistributionMode.LOCAL_HASH_BUCKET;
@@ -1736,8 +1736,8 @@ public class PlanFragmentBuilder {
             return false;
         }
 
-        public boolean isShuffleJoin(PhysicalHashJoinOperator node) {
-            return node.getRequiredProperties().stream().allMatch(
+        public boolean isShuffleJoin(OptExpression optExpression) {
+            return optExpression.getRequiredProperties().stream().allMatch(
                     physicalPropertySet -> physicalPropertySet.getDistributionProperty().isShuffle() &&
                             ((HashDistributionSpec) (physicalPropertySet.getDistributionProperty().getSpec()))
                                     .getHashDistributionDesc().getSourceType().equals(


### PR DESCRIPTION
#2701 
1. Record requiredd properties at physical operator, the join node can easily determine its own type
2. Rmove some useless code for shuffle bucket join