### PR TITLE
Remove duplicated slash in export path

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/ExportJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/ExportJob.java
@@ -115,6 +115,7 @@ public class ExportJob implements Writable {
     private String clusterName;
     private long tableId;
     private BrokerDesc brokerDesc;
+    // exportPath has "/" suffix
     private String exportPath;
     private String exportTempPath;
     private String fileNamePrefix;
@@ -183,7 +184,7 @@ public class ExportJob implements Writable {
 
         exportPath = stmt.getPath();
         Preconditions.checkArgument(!Strings.isNullOrEmpty(exportPath));
-        exportTempPath = this.exportPath + "/__starrocks_export_tmp_" + queryId.toString() + "/";
+        exportTempPath = this.exportPath + "__starrocks_export_tmp_" + queryId.toString();
         fileNamePrefix = stmt.getFileNamePrefix();
         Preconditions.checkArgument(!Strings.isNullOrEmpty(fileNamePrefix));
         if (includeQueryId) {

--- a/fe/fe-core/src/main/java/com/starrocks/task/ExportExportingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/ExportExportingTask.java
@@ -214,7 +214,7 @@ public class ExportExportingTask extends MasterTask {
             // remove timestamp suffix
             // data_f8d0f324-83b3-11eb-9e09-02425ee98b69_0_0_0.csv
             exportedFile = exportedFile.substring(0, exportedFile.lastIndexOf("."));
-            exportedFile = exportPath + "/" + exportedFile;
+            exportedFile = exportPath + exportedFile;
             boolean success = false;
             String failMsg = null;
 


### PR DESCRIPTION
When the user specifies oss://bucket/ as the export path,
StarRocks uses oss://bucket//__starrocks_export_tmp_uuid/file
as the export file path, and this is incorrect for OSS
and will cause the export job to fail.