### PR TITLE
use chunk_size with parquet format

### DIFF
--- a/be/src/exec/parquet/column_chunk_reader.h
+++ b/be/src/exec/parquet/column_chunk_reader.h
@@ -36,7 +36,7 @@ public:
                       const ColumnChunkReaderOptions& opts);
     ~ColumnChunkReader();
 
-    Status init();
+    Status init(int chunk_size);
 
     Status next_page();
 
@@ -98,7 +98,7 @@ private:
     Status _parse_page_header();
     Status _parse_page_data();
 
-    Status _try_load_dictionary();
+    Status _try_load_dictionary(int chunk_size);
     Status _read_and_decompress_page_data();
     Status _parse_data_page();
     Status _parse_dict_page();

--- a/be/src/exec/parquet/column_reader.h
+++ b/be/src/exec/parquet/column_reader.h
@@ -32,7 +32,7 @@ public:
     // TODO(zc): review this,
     // create a column reader
     static Status create(RandomAccessFile* file, const ParquetField* field, const tparquet::RowGroup& row_group,
-                         const TypeDescriptor& col_type, const ColumnReaderOptions& opts,
+                         const TypeDescriptor& col_type, const ColumnReaderOptions& opts, int chunk_size,
                          std::unique_ptr<ColumnReader>* reader);
 
     virtual ~ColumnReader() = default;

--- a/be/src/exec/parquet/encoding.h
+++ b/be/src/exec/parquet/encoding.h
@@ -40,7 +40,7 @@ public:
     Decoder() = default;
     virtual ~Decoder() = default;
 
-    virtual Status set_dict(size_t num_values, Decoder* decoder) {
+    virtual Status set_dict(int chunk_size, size_t num_values, Decoder* decoder) {
         return Status::NotSupported("set_dict is not supported");
     }
 

--- a/be/src/exec/parquet/encoding_dict.h
+++ b/be/src/exec/parquet/encoding_dict.h
@@ -78,9 +78,9 @@ public:
     ~DictDecoder() override = default;
 
     // initialize dictionary
-    Status set_dict(size_t num_values, Decoder* decoder) override {
+    Status set_dict(int chunk_size, size_t num_values, Decoder* decoder) override {
         _dict.resize(num_values);
-        _indexes.resize(config::vector_chunk_size);
+        _indexes.resize(chunk_size);
         RETURN_IF_ERROR(decoder->next_batch(num_values, (uint8_t*)&_dict[0]));
         return Status::OK();
     }
@@ -140,9 +140,9 @@ public:
     DictDecoder() = default;
     ~DictDecoder() override = default;
 
-    Status set_dict(size_t num_values, Decoder* decoder) override {
-        _indexes.resize(config::vector_chunk_size);
-        _slices.resize(config::vector_chunk_size);
+    Status set_dict(int chunk_size, size_t num_values, Decoder* decoder) override {
+        _indexes.resize(chunk_size);
+        _slices.resize(chunk_size);
         std::vector<Slice> slices(num_values);
         RETURN_IF_ERROR(decoder->next_batch(num_values, (uint8_t*)&slices[0]));
 

--- a/be/src/exec/parquet/file_reader.cpp
+++ b/be/src/exec/parquet/file_reader.cpp
@@ -23,8 +23,8 @@ namespace starrocks::parquet {
 
 static constexpr uint32_t kFooterSize = 8;
 
-FileReader::FileReader(RuntimeState* runtime_state, RandomAccessFile* file, uint64_t file_size)
-        : _runtime_state(runtime_state), _file(file), _file_size(file_size) {}
+FileReader::FileReader(int chunk_size, RandomAccessFile* file, uint64_t file_size)
+        : _chunk_size(chunk_size), _file(file), _file_size(file_size) {}
 
 FileReader::~FileReader() = default;
 
@@ -112,7 +112,7 @@ Status FileReader::_parse_footer() {
 }
 
 std::shared_ptr<GroupReader> FileReader::_row_group(int i) {
-    return std::make_shared<GroupReader>(_runtime_state, _file, _file_metadata.get(), i);
+    return std::make_shared<GroupReader>(_chunk_size, _file, _file_metadata.get(), i);
 }
 
 Status FileReader::_check_magic(const uint8_t* file_magic) {
@@ -429,7 +429,7 @@ Status FileReader::_get_next_internal(vectorized::ChunkPtr* chunk) {
     }
 
     if (_cur_row_group_idx < _row_group_size) {
-        size_t row_count = _runtime_state->chunk_size();
+        size_t row_count = _chunk_size;
         Status status = _row_group_readers[_cur_row_group_idx]->get_next(chunk, &row_count);
         if (status.ok() || status.is_end_of_file()) {
             if (row_count > 0) {
@@ -452,8 +452,7 @@ Status FileReader::_get_next_internal(vectorized::ChunkPtr* chunk) {
 
 Status FileReader::_exec_only_partition_scan(vectorized::ChunkPtr* chunk) {
     if (_scan_row_count < _total_row_count) {
-        size_t read_size =
-                std::min(static_cast<size_t>(_runtime_state->chunk_size()), _total_row_count - _scan_row_count);
+        size_t read_size = std::min(static_cast<size_t>(_chunk_size), _total_row_count - _scan_row_count);
 
         _append_not_exist_column_to_chunk(chunk, read_size);
         _append_partition_column_to_chunk(chunk, read_size);

--- a/be/src/exec/parquet/file_reader.cpp
+++ b/be/src/exec/parquet/file_reader.cpp
@@ -23,7 +23,8 @@ namespace starrocks::parquet {
 
 static constexpr uint32_t kFooterSize = 8;
 
-FileReader::FileReader(RandomAccessFile* file, uint64_t file_size) : _file(file), _file_size(file_size) {}
+FileReader::FileReader(RuntimeState* runtime_state, RandomAccessFile* file, uint64_t file_size)
+        : _runtime_state(runtime_state), _file(file), _file_size(file_size) {}
 
 FileReader::~FileReader() = default;
 
@@ -111,7 +112,7 @@ Status FileReader::_parse_footer() {
 }
 
 std::shared_ptr<GroupReader> FileReader::_row_group(int i) {
-    return std::make_shared<GroupReader>(_file, _file_metadata.get(), i);
+    return std::make_shared<GroupReader>(_runtime_state, _file, _file_metadata.get(), i);
 }
 
 Status FileReader::_check_magic(const uint8_t* file_magic) {
@@ -428,7 +429,7 @@ Status FileReader::_get_next_internal(vectorized::ChunkPtr* chunk) {
     }
 
     if (_cur_row_group_idx < _row_group_size) {
-        size_t row_count = config::vector_chunk_size;
+        size_t row_count = _runtime_state->chunk_size();
         Status status = _row_group_readers[_cur_row_group_idx]->get_next(chunk, &row_count);
         if (status.ok() || status.is_end_of_file()) {
             if (row_count > 0) {
@@ -451,7 +452,8 @@ Status FileReader::_get_next_internal(vectorized::ChunkPtr* chunk) {
 
 Status FileReader::_exec_only_partition_scan(vectorized::ChunkPtr* chunk) {
     if (_scan_row_count < _total_row_count) {
-        size_t read_size = std::min(static_cast<size_t>(config::vector_chunk_size), _total_row_count - _scan_row_count);
+        size_t read_size =
+                std::min(static_cast<size_t>(_runtime_state->chunk_size()), _total_row_count - _scan_row_count);
 
         _append_not_exist_column_to_chunk(chunk, read_size);
         _append_partition_column_to_chunk(chunk, read_size);

--- a/be/src/exec/parquet/file_reader.h
+++ b/be/src/exec/parquet/file_reader.h
@@ -9,6 +9,7 @@
 #include "common/status.h"
 #include "exec/parquet/group_reader.h"
 #include "gen_cpp/parquet_types.h"
+#include "runtime/runtime_state.h"
 #include "util/runtime_profile.h"
 
 namespace starrocks {
@@ -27,13 +28,15 @@ class FileMetaData;
 
 class FileReader {
 public:
-    FileReader(RandomAccessFile* file, uint64_t file_size);
+    FileReader(RuntimeState* runtime_state, RandomAccessFile* file, uint64_t file_size);
     ~FileReader();
 
     Status init(const starrocks::vectorized::HdfsFileReaderParam& param);
     Status get_next(vectorized::ChunkPtr* chunk);
 
 private:
+    RuntimeState* _runtime_state;
+
     // parse footer of parquet file
     Status _parse_footer();
 

--- a/be/src/exec/parquet/file_reader.h
+++ b/be/src/exec/parquet/file_reader.h
@@ -28,14 +28,14 @@ class FileMetaData;
 
 class FileReader {
 public:
-    FileReader(RuntimeState* runtime_state, RandomAccessFile* file, uint64_t file_size);
+    FileReader(int chunk_size, RandomAccessFile* file, uint64_t file_size);
     ~FileReader();
 
     Status init(const starrocks::vectorized::HdfsFileReaderParam& param);
     Status get_next(vectorized::ChunkPtr* chunk);
 
 private:
-    RuntimeState* _runtime_state;
+    int _chunk_size;
 
     // parse footer of parquet file
     Status _parse_footer();

--- a/be/src/exec/parquet/group_reader.cpp
+++ b/be/src/exec/parquet/group_reader.cpp
@@ -15,8 +15,12 @@ namespace starrocks::parquet {
 constexpr static const PrimitiveType kDictCodePrimitiveType = TYPE_INT;
 constexpr static const FieldType kDictCodeFieldType = OLAP_FIELD_TYPE_INT;
 
-GroupReader::GroupReader(RandomAccessFile* file, FileMetaData* file_metadata, int row_group_number)
-        : _file(file), _file_metadata(file_metadata), _row_group_number(row_group_number) {
+GroupReader::GroupReader(RuntimeState* runtime_state, RandomAccessFile* file, FileMetaData* file_metadata,
+                         int row_group_number)
+        : _runtime_state(runtime_state),
+          _file(file),
+          _file_metadata(file_metadata),
+          _row_group_number(row_group_number) {
     _row_group_metadata =
             std::make_shared<tparquet::RowGroup>(_file_metadata->t_metadata().row_groups[row_group_number]);
 }
@@ -94,7 +98,7 @@ Status GroupReader::_create_column_reader(const GroupReaderParam::Column& column
     {
         SCOPED_RAW_TIMER(&_param.stats->column_reader_init_ns);
         RETURN_IF_ERROR(ColumnReader::create(_file, schema_node, *_row_group_metadata, column.col_type_in_chunk, opts,
-                                             &column_reader));
+                                             _runtime_state->chunk_size(), &column_reader));
     }
     _column_readers[column.slot_id] = std::move(column_reader);
     return Status::OK();
@@ -262,7 +266,7 @@ void GroupReader::_init_read_chunk() {
         read_slots.emplace_back(slots[chunk_index]);
     }
 
-    size_t chunk_size = config::vector_chunk_size;
+    size_t chunk_size = _runtime_state->chunk_size();
     _read_chunk = vectorized::ChunkHelper::new_chunk(read_slots, chunk_size);
     raw::stl_vector_resize_uninitialized(&_selection, chunk_size);
 

--- a/be/src/exec/parquet/group_reader.h
+++ b/be/src/exec/parquet/group_reader.h
@@ -9,6 +9,7 @@
 #include "exec/vectorized/hdfs_scanner.h"
 #include "gen_cpp/parquet_types.h"
 #include "runtime/descriptors.h"
+#include "runtime/runtime_state.h"
 #include "storage/vectorized/column_predicate.h"
 #include "util/runtime_profile.h"
 
@@ -53,7 +54,7 @@ struct GroupReaderParam {
 
 class GroupReader {
 public:
-    GroupReader(RandomAccessFile* file, FileMetaData* file_metadata, int row_group_number);
+    GroupReader(RuntimeState* runtime_state, RandomAccessFile* file, FileMetaData* file_metadata, int row_group_number);
     ~GroupReader() = default;
 
     Status init(const GroupReaderParam& _param);
@@ -76,6 +77,8 @@ private:
     Status _read(size_t* row_count);
     void _dict_filter();
     Status _dict_decode(vectorized::ChunkPtr* chunk);
+
+    RuntimeState* _runtime_state;
 
     RandomAccessFile* _file;
 

--- a/be/src/exec/parquet/group_reader.h
+++ b/be/src/exec/parquet/group_reader.h
@@ -54,7 +54,7 @@ struct GroupReaderParam {
 
 class GroupReader {
 public:
-    GroupReader(RuntimeState* runtime_state, RandomAccessFile* file, FileMetaData* file_metadata, int row_group_number);
+    GroupReader(int chunk_size, RandomAccessFile* file, FileMetaData* file_metadata, int row_group_number);
     ~GroupReader() = default;
 
     Status init(const GroupReaderParam& _param);
@@ -78,7 +78,7 @@ private:
     void _dict_filter();
     Status _dict_decode(vectorized::ChunkPtr* chunk);
 
-    RuntimeState* _runtime_state;
+    int _chunk_size;
 
     RandomAccessFile* _file;
 

--- a/be/src/exec/parquet/stored_column_reader.h
+++ b/be/src/exec/parquet/stored_column_reader.h
@@ -32,7 +32,7 @@ class StoredColumnReader {
 public:
     static Status create(RandomAccessFile* file, const ParquetField* field,
                          const tparquet::ColumnChunk* _chunk_metadata, const StoredColumnReaderOptions& opts,
-                         std::unique_ptr<StoredColumnReader>* out);
+                         int chunk_size, std::unique_ptr<StoredColumnReader>* out);
 
     virtual ~StoredColumnReader() = default;
 

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -108,7 +108,6 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
     _fragment_ctx->set_runtime_state(
             std::make_unique<RuntimeState>(query_id, fragment_instance_id, query_options, query_globals, exec_env));
     auto* runtime_state = _fragment_ctx->runtime_state();
-    runtime_state->set_chunk_size(query_options.batch_size);
     runtime_state->init_mem_trackers(query_id);
     runtime_state->set_be_number(backend_num);
 

--- a/be/src/exec/vectorized/hdfs_scanner.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner.cpp
@@ -211,7 +211,7 @@ Status HdfsParquetScanner::do_init(RuntimeState* runtime_state, const HdfsScanne
 
 Status HdfsParquetScanner::do_open(RuntimeState* runtime_state) {
     // create file reader
-    _reader = std::make_shared<parquet::FileReader>(_scanner_params.fs.get(),
+    _reader = std::make_shared<parquet::FileReader>(runtime_state, _scanner_params.fs.get(),
                                                     _scanner_params.scan_ranges[0]->file_length);
 #ifndef BE_TEST
     SCOPED_TIMER(_scanner_params.parent->_reader_init_timer);

--- a/be/src/exec/vectorized/hdfs_scanner.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner.cpp
@@ -211,7 +211,7 @@ Status HdfsParquetScanner::do_init(RuntimeState* runtime_state, const HdfsScanne
 
 Status HdfsParquetScanner::do_open(RuntimeState* runtime_state) {
     // create file reader
-    _reader = std::make_shared<parquet::FileReader>(runtime_state, _scanner_params.fs.get(),
+    _reader = std::make_shared<parquet::FileReader>(runtime_state->chunk_size(), _scanner_params.fs.get(),
                                                     _scanner_params.scan_ranges[0]->file_length);
 #ifndef BE_TEST
     SCOPED_TIMER(_scanner_params.parent->_reader_init_timer);

--- a/be/test/exec/parquet/encoding_test.cpp
+++ b/be/test/exec/parquet/encoding_test.cpp
@@ -188,7 +188,7 @@ TEST_F(ParquetEncodingTest, Int32) {
 
         dict_decoder->set_data(dict_encoder->build());
 
-        st = decoder->set_dict(num_dicts, dict_decoder.get());
+        st = decoder->set_dict(config::vector_chunk_size, num_dicts, dict_decoder.get());
         ASSERT_TRUE(st.ok());
 
         DecoderChecker<int32_t, true>::check(values, encoder->build(), decoder.get());
@@ -255,7 +255,7 @@ TEST_F(ParquetEncodingTest, String) {
 
         dict_decoder->set_data(dict_encoder->build());
 
-        st = decoder->set_dict(num_dicts, dict_decoder.get());
+        st = decoder->set_dict(config::vector_chunk_size, num_dicts, dict_decoder.get());
         ASSERT_TRUE(st.ok());
 
         DecoderChecker<Slice, true>::check(slices, encoder->build(), decoder.get());
@@ -324,7 +324,7 @@ TEST_F(ParquetEncodingTest, FixedString) {
         dict_decoder->set_data(dict_encoder->build());
         dict_decoder->set_type_legth(3);
 
-        st = decoder->set_dict(num_dicts, dict_decoder.get());
+        st = decoder->set_dict(config::vector_chunk_size, num_dicts, dict_decoder.get());
         ASSERT_TRUE(st.ok());
 
         DecoderChecker<Slice, true>::check(slices, encoder->build(), decoder.get());

--- a/be/test/exec/parquet/file_reader_test.cpp
+++ b/be/test/exec/parquet/file_reader_test.cpp
@@ -529,7 +529,7 @@ TEST_F(FileReaderTest, TestInit) {
     auto file = _create_file(_file_path);
 
     // create file reader
-    auto file_reader = std::make_shared<FileReader>(file.get(), _file_size);
+    auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(), _file_size);
 
     // init
     auto* param = _create_param();
@@ -542,7 +542,7 @@ TEST_F(FileReaderTest, TestGetNext) {
     auto file = _create_file(_file_path);
 
     // create file reader
-    auto file_reader = std::make_shared<FileReader>(file.get(), _file_size);
+    auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(), _file_size);
 
     // init
     auto* param = _create_param();
@@ -564,7 +564,7 @@ TEST_F(FileReaderTest, TestGetNextPartition) {
     auto file = _create_file(_file_path);
 
     // create file reader
-    auto file_reader = std::make_shared<FileReader>(file.get(), _file_size);
+    auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(), _file_size);
 
     // init
     auto* param = _create_param_for_partition();
@@ -586,7 +586,7 @@ TEST_F(FileReaderTest, TestGetNextEmpty) {
     auto file = _create_file(_file_path);
 
     // create file reader
-    auto file_reader = std::make_shared<FileReader>(file.get(), _file_size);
+    auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(), _file_size);
 
     // init
     auto* param = _create_param_for_not_exist();
@@ -608,7 +608,7 @@ TEST_F(FileReaderTest, TestMinMaxConjunct) {
     auto file = _create_file(_file_2_path);
 
     // create file reader
-    auto file_reader = std::make_shared<FileReader>(file.get(), _file_2_size);
+    auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(), _file_2_size);
 
     // init
     auto* param = _create_param_for_min_max();
@@ -633,7 +633,7 @@ TEST_F(FileReaderTest, TestFilterFile) {
     auto file = _create_file(_file_2_path);
 
     // create file reader
-    auto file_reader = std::make_shared<FileReader>(file.get(), _file_2_size);
+    auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(), _file_2_size);
 
     // init
     auto* param = _create_param_for_filter_file();
@@ -653,7 +653,7 @@ TEST_F(FileReaderTest, TestGetNextDictFilter) {
     auto file = _create_file(_file_2_path);
 
     // create file reader
-    auto file_reader = std::make_shared<FileReader>(file.get(), _file_2_size);
+    auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(), _file_2_size);
 
     // init
     auto* param = _create_param_for_dict_filter();

--- a/be/test/exec/parquet/group_reader_test.cpp
+++ b/be/test/exec/parquet/group_reader_test.cpp
@@ -356,7 +356,7 @@ TEST_F(GroupReaderTest, TestInit) {
     ASSERT_TRUE(status.ok());
 
     // create row group reader
-    auto* group_reader = _pool.add(new GroupReader(file, file_meta, 0));
+    auto* group_reader = _pool.add(new GroupReader(config::vector_chunk_size, file, file_meta, 0));
 
     // init row group reader
     status = group_reader->init(*param);
@@ -383,7 +383,7 @@ TEST_F(GroupReaderTest, TestGetNext) {
     ASSERT_TRUE(status.ok());
 
     // create row group reader
-    auto* group_reader = _pool.add(new GroupReader(file, file_meta, 0));
+    auto* group_reader = _pool.add(new GroupReader(config::vector_chunk_size, file, file_meta, 0));
 
     // init row group reader
     status = group_reader->init(*param);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -74,6 +74,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // mem limit can't smaller than bufferpool's default page size
     public static final int MIN_EXEC_MEM_LIMIT = 2097152;
     public static final String BATCH_SIZE = "batch_size";
+    public static final String CHUNK_SIZE = "chunk_size";
     public static final String DISABLE_STREAMING_PREAGGREGATIONS = "disable_streaming_preaggregations";
     public static final String STREAMING_PREAGGREGATION_MODE = "streaming_preaggregation_mode";
     public static final String DISABLE_COLOCATE_JOIN = "disable_colocate_join";
@@ -278,8 +279,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = CODEGEN_LEVEL)
     private int codegenLevel = 0;
 
-    @VariableMgr.VarAttr(name = BATCH_SIZE, alias = "chunk_size", flag = VariableMgr.INVISIBLE)
-    private int batchSize = 4096;
+    @VariableMgr.VarAttr(name = BATCH_SIZE, flag = VariableMgr.INVISIBLE)
+    private int batchSize = 0;
+
+    @VariableMgr.VarAttr(name = CHUNK_SIZE, flag = VariableMgr.INVISIBLE)
+    private int chunkSize = 4096;
+
     private static final int PIPELINE_BATCH_SIZE = 16384;
 
     @VariableMgr.VarAttr(name = DISABLE_STREAMING_PREAGGREGATIONS)
@@ -790,7 +795,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         if (isEnablePipelineEngine()) {
             tResult.setBatch_size(PIPELINE_BATCH_SIZE);
         } else {
-            tResult.setBatch_size(batchSize);
+            tResult.setBatch_size(chunkSize);
         }
         tResult.setDisable_stream_preaggregations(disableStreamPreaggregations);
         tResult.setLoad_mem_limit(loadMemLimit);


### PR DESCRIPTION
- use chunk_size instead of vector_chunk_size with parquet format to avoid heap-buffer-overflow.

reference https://github.com/StarRocks/starrocks/issues/2709