### PR TITLE
fix compiling mariadb-connector-c failure due to openssl relocation symbol OPENSSL_armcap_P

### DIFF
--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -179,7 +179,7 @@ build_openssl() {
     LDFLAGS="-L${TP_LIB_DIR}" \
     CFLAGS="-fPIC" \
     LIBDIR="lib" \
-    ./Configure --prefix=$TP_INSTALL_DIR -zlib -shared ${OPENSSL_PLATFORM}
+    ./Configure --prefix=$TP_INSTALL_DIR -zlib -shared no-asm ${OPENSSL_PLATFORM}
     make -j$PARALLEL && make install
     if [ -f $TP_INSTALL_DIR/lib64/libcrypto.a ]; then
         mkdir -p $TP_INSTALL_DIR/lib && \


### PR DESCRIPTION
fix compiling mariadb-connector-c failure due to openssl relocation of symbol OPENSSL_armcap_P

1. When compile third-party libraries under ARM platform, it failed on mariadb-connector-c component with following error message:
thirdparty/installed/lib/libcrypto.a(sha1-armv8.o): relocation R_AARCH64_PREL64 against symbol `OPENSSL_armcap_P' which may bind externally can not be used when making a shared object; recompile with -fPIC

2. While after checking compilation process and found that openssl-1.0.2k compilation was compiled with the -fPIC flag.
3. This is a bug of openssl which has been fixed by https://github.com/openssl/openssl/pull/13056 and merged to v1.1.1.
4. For a workaround solution, just disable the asm part of openssl-1.0.2k.
5. To fix this issue completely, maybe upgrade openssl from 1.0.2k to 1.1.1i+ is a better choice, this fix is just a workaround.