### PR TITLE
Fix overflow in while reading parquet file in external table

### DIFF
--- a/be/src/exec/vectorized/hdfs_scanner.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner.cpp
@@ -211,7 +211,7 @@ Status HdfsParquetScanner::do_init(RuntimeState* runtime_state, const HdfsScanne
 
 Status HdfsParquetScanner::do_open(RuntimeState* runtime_state) {
     // create file reader
-    _reader = std::make_shared<parquet::FileReader>(_scanner_params.fs.get(),
+    _reader = std::make_shared<parquet::FileReader>(runtime_state, _scanner_params.fs.get(),
                                                     _scanner_params.scan_ranges[0]->file_length);
 #ifndef BE_TEST
     SCOPED_TIMER(_scanner_params.parent->_reader_init_timer);


### PR DESCRIPTION
if session variable chunk_size less than config::vector_chunk_size,
data_stream_sender will only reserve `chunk_size` row_idxs, bug
hdfs_scan_node may return greater than `chunk_size` rows which will
cause a buffer-over-flow

will close #2732