### PR TITLE
Support reading parquet file with gzip compression

### DIFF
--- a/be/src/util/block_compression.cpp
+++ b/be/src/util/block_compression.cpp
@@ -473,6 +473,7 @@ public:
         std::vector<Slice> orig_slices;
         orig_slices.emplace_back(input);
         RETURN_IF_ERROR(ZlibBlockCompression::compress(orig_slices, output));
+        return Status::OK();
     }
 
     Status decompress(const Slice& input, Slice* output) const override {

--- a/be/src/util/block_compression.cpp
+++ b/be/src/util/block_compression.cpp
@@ -499,7 +499,8 @@ public:
         VLOG(10) << "gzip dec ret: " << ret;
         if (ret != Z_OK && ret != Z_STREAM_END) {
             (void)inflateEnd(&z_strm);
-            return Status::InternalError(strings::Substitute("Fail to do ZLib stream compress, error=$0, res=$1", zError(ret), ret));
+            return Status::InternalError(
+                    strings::Substitute("Fail to do ZLib stream compress, error=$0, res=$1", zError(ret), ret));
         }
         (void)inflateEnd(&z_strm);
 
@@ -514,12 +515,15 @@ public:
         auto zres = deflateInit2(&zstrm, Z_DEFAULT_COMPRESSION, Z_DEFLATED, MAX_WBITS + 16, 8, Z_DEFAULT_STRATEGY);
         if (zres != Z_OK) {
             // Fall back to zlib estimate logic for deflate, notice this may cause decompress error
-            LOG(WARNING) << strings::Substitute("Fail to do ZLib stream compress, error=$0, res=$1", zError(zres), zres).c_str();
+            LOG(WARNING) << strings::Substitute("Fail to do ZLib stream compress, error=$0, res=$1", zError(zres), zres)
+                                    .c_str();
             return ZlibBlockCompression::max_compressed_len(len);
         } else {
             zres = deflateEnd(&zstrm);
             if (zres != Z_OK) {
-                LOG(WARNING) << strings::Substitute("Fail to do deflateEnd on ZLib stream, error=$0, res=$1", zError(zres), zres).c_str();
+                LOG(WARNING) << strings::Substitute("Fail to do deflateEnd on ZLib stream, error=$0, res=$1",
+                                                    zError(zres), zres)
+                                        .c_str();
             }
             // Mark, maintainer of zlib, has stated that 12 needs to be added to result for gzip
             // http://compgroups.net/comp.unix.programmer/gzip-compressing-an-in-memory-string-usi/54854

--- a/be/src/util/block_compression.cpp
+++ b/be/src/util/block_compression.cpp
@@ -483,7 +483,8 @@ public:
 
         int ret = inflateInit2(&z_strm, MAX_WBITS + 16);
         if (ret < 0) {
-            return Status::InternalError(strings::Substitute("Fail to do ZLib stream compress, error=$0, res=$1", zError(ret), ret));
+            return Status::InternalError(
+                    strings::Substitute("Fail to do ZLib stream compress, error=$0, res=$1", zError(ret), ret));
         }
 
         // 1. set input and output

--- a/be/src/util/block_compression.cpp
+++ b/be/src/util/block_compression.cpp
@@ -483,7 +483,7 @@ public:
         z_strm.opaque = Z_NULL;
 
         int ret = inflateInit2(&z_strm, MAX_WBITS + 16);
-        if (ret < 0) {
+        if (ret != Z_OK) {
             return Status::InternalError(
                     strings::Substitute("Fail to do ZLib stream compress, error=$0, res=$1", zError(ret), ret));
         }

--- a/be/src/util/block_compression.cpp
+++ b/be/src/util/block_compression.cpp
@@ -494,13 +494,15 @@ public:
         z_strm.next_out = reinterpret_cast<Bytef*>(output->data);
         z_strm.avail_out = output->size;
 
-        // We only support non-streaming use case  for block decompressor
-        ret = inflate(&z_strm, Z_FINISH);
-        VLOG(10) << "gzip dec ret: " << ret;
-        if (ret != Z_OK && ret != Z_STREAM_END) {
-            (void)inflateEnd(&z_strm);
-            return Status::InternalError(
-                    strings::Substitute("Fail to do ZLib stream compress, error=$0, res=$1", zError(ret), ret));
+        if (z_strm.avail_out > 0) {
+            // We only support non-streaming use case  for block decompressor
+            ret = inflate(&z_strm, Z_FINISH);
+            VLOG(10) << "gzip dec ret: " << ret;
+            if (ret != Z_OK && ret != Z_STREAM_END) {
+                (void)inflateEnd(&z_strm);
+                return Status::InternalError(
+                        strings::Substitute("Fail to do ZLib stream compress, error=$0, res=$1", zError(ret), ret));
+            }
         }
         (void)inflateEnd(&z_strm);
 

--- a/be/src/util/block_compression.cpp
+++ b/be/src/util/block_compression.cpp
@@ -324,10 +324,7 @@ public:
 
     Status compress(const std::vector<Slice>& inputs, Slice* output) const override {
         z_stream zstrm;
-        Status st = init_compress_stream(zstrm);
-        if (!st.ok()) {
-            return st;
-        }
+        RETURN_IF_ERROR(init_compress_stream(zstrm));
         // we assume that output is e
         zstrm.next_out = (Bytef*)output->data;
         zstrm.avail_out = output->size;

--- a/be/src/util/block_compression.cpp
+++ b/be/src/util/block_compression.cpp
@@ -461,7 +461,7 @@ public:
         zstrm.zalloc = Z_NULL;
         zstrm.zfree = Z_NULL;
         zstrm.opaque = Z_NULL;
-        auto zres = deflateInit2(&zstrm, Z_DEFAULT_COMPRESSION, Z_DEFLATED, MAX_WBITS + 16, 8, Z_DEFAULT_STRATEGY);
+        auto zres = deflateInit2(&zstrm, Z_DEFAULT_COMPRESSION, Z_DEFLATED, MAX_WBITS + GZIP_CODEC, MEM_LEVEL, Z_DEFAULT_STRATEGY);
         if (zres != Z_OK) {
             return Status::InvalidArgument(
                     strings::Substitute("Fail to do ZLib stream compress, error=$0, res=$1", zError(zres), zres));
@@ -482,7 +482,7 @@ public:
         z_strm.zfree = Z_NULL;
         z_strm.opaque = Z_NULL;
 
-        int ret = inflateInit2(&z_strm, MAX_WBITS + 16);
+        int ret = inflateInit2(&z_strm, MAX_WBITS + GZIP_CODEC);
         if (ret != Z_OK) {
             return Status::InternalError(
                     strings::Substitute("Fail to do ZLib stream compress, error=$0, res=$1", zError(ret), ret));
@@ -514,7 +514,7 @@ public:
         zstrm.zalloc = Z_NULL;
         zstrm.zfree = Z_NULL;
         zstrm.opaque = Z_NULL;
-        auto zres = deflateInit2(&zstrm, Z_DEFAULT_COMPRESSION, Z_DEFLATED, MAX_WBITS + 16, 8, Z_DEFAULT_STRATEGY);
+        auto zres = deflateInit2(&zstrm, Z_DEFAULT_COMPRESSION, Z_DEFLATED, MAX_WBITS + GZIP_CODEC, MEM_LEVEL, Z_DEFAULT_STRATEGY);
         if (zres != Z_OK) {
             // Fall back to zlib estimate logic for deflate, notice this may cause decompress error
             LOG(WARNING) << strings::Substitute("Fail to do ZLib stream compress, error=$0, res=$1", zError(zres), zres)
@@ -534,6 +534,12 @@ public:
             return upper_bound;
         }
     }
+
+private:
+    // Magic number for zlib, see https://zlib.net/manual.html for more details.
+    const static int GZIP_CODEC = 16; // gzip
+    // The memLevel parameter specifies how much memory should be allocated for the internal compression state.
+    const static int MEM_LEVEL = 8;
 };
 
 Status get_block_compression_codec(CompressionTypePB type, const BlockCompressionCodec** codec) {

--- a/be/src/util/block_compression.cpp
+++ b/be/src/util/block_compression.cpp
@@ -461,7 +461,8 @@ public:
         zstrm.zalloc = Z_NULL;
         zstrm.zfree = Z_NULL;
         zstrm.opaque = Z_NULL;
-        auto zres = deflateInit2(&zstrm, Z_DEFAULT_COMPRESSION, Z_DEFLATED, MAX_WBITS + GZIP_CODEC, MEM_LEVEL, Z_DEFAULT_STRATEGY);
+        auto zres = deflateInit2(&zstrm, Z_DEFAULT_COMPRESSION, Z_DEFLATED, MAX_WBITS + GZIP_CODEC, MEM_LEVEL,
+                                 Z_DEFAULT_STRATEGY);
         if (zres != Z_OK) {
             return Status::InvalidArgument(
                     strings::Substitute("Fail to do ZLib stream compress, error=$0, res=$1", zError(zres), zres));
@@ -514,7 +515,8 @@ public:
         zstrm.zalloc = Z_NULL;
         zstrm.zfree = Z_NULL;
         zstrm.opaque = Z_NULL;
-        auto zres = deflateInit2(&zstrm, Z_DEFAULT_COMPRESSION, Z_DEFLATED, MAX_WBITS + GZIP_CODEC, MEM_LEVEL, Z_DEFAULT_STRATEGY);
+        auto zres = deflateInit2(&zstrm, Z_DEFAULT_COMPRESSION, Z_DEFLATED, MAX_WBITS + GZIP_CODEC, MEM_LEVEL,
+                                 Z_DEFAULT_STRATEGY);
         if (zres != Z_OK) {
             // Fall back to zlib estimate logic for deflate, notice this may cause decompress error
             LOG(WARNING) << strings::Substitute("Fail to do ZLib stream compress, error=$0, res=$1", zError(zres), zres)

--- a/be/src/util/block_compression.cpp
+++ b/be/src/util/block_compression.cpp
@@ -483,9 +483,7 @@ public:
 
         int ret = inflateInit2(&z_strm, MAX_WBITS + 16);
         if (ret < 0) {
-            std::stringstream ss;
-            ss << strings::Substitute("Fail to do ZLib stream compress, error=$0, res=$1", zError(ret), ret);
-            return Status::InternalError(ss.str());
+            return Status::InternalError(strings::Substitute("Fail to do ZLib stream compress, error=$0, res=$1", zError(ret), ret));
         }
 
         // 1. set input and output

--- a/be/test/util/block_compression_test.cpp
+++ b/be/test/util/block_compression_test.cpp
@@ -84,7 +84,7 @@ void test_single_slice(starrocks::CompressionTypePB type) {
                 ASSERT_FALSE(st.ok());
             }
             // corrupt compressed data
-            // we use inflate for gzip decompressor, it will return Status::OK for this case
+            // we use inflate for gzip decompressor, it will return Z_OK for this case
             if (type != starrocks::CompressionTypePB::SNAPPY && type != starrocks::CompressionTypePB::GZIP) {
                 Slice uncompressed_slice(uncompressed);
                 compressed_slice.size -= 1;

--- a/be/test/util/block_compression_test.cpp
+++ b/be/test/util/block_compression_test.cpp
@@ -84,7 +84,7 @@ void test_single_slice(starrocks::CompressionTypePB type) {
                 ASSERT_FALSE(st.ok());
             }
             // corrupt compressed data
-            if (type != starrocks::CompressionTypePB::SNAPPY) {
+            if (type != starrocks::CompressionTypePB::SNAPPY && type != starrocks::CompressionTypePB::GZIP) {
                 Slice uncompressed_slice(uncompressed);
                 compressed_slice.size -= 1;
                 st = codec->decompress(compressed_slice, &uncompressed_slice);
@@ -107,6 +107,7 @@ TEST_F(BlockCompressionTest, single) {
     test_single_slice(starrocks::CompressionTypePB::ZLIB);
     test_single_slice(starrocks::CompressionTypePB::LZ4);
     test_single_slice(starrocks::CompressionTypePB::LZ4_FRAME);
+    test_single_slice(starrocks::CompressionTypePB::GZIP);
 }
 
 void test_multi_slices(starrocks::CompressionTypePB type) {
@@ -163,6 +164,7 @@ TEST_F(BlockCompressionTest, multi) {
     test_multi_slices(starrocks::CompressionTypePB::LZ4);
     test_multi_slices(starrocks::CompressionTypePB::LZ4_FRAME);
     test_multi_slices(starrocks::CompressionTypePB::ZSTD);
+    test_multi_slices(starrocks::CompressionTypePB::GZIP);
 }
 
 } // namespace starrocks

--- a/be/test/util/block_compression_test.cpp
+++ b/be/test/util/block_compression_test.cpp
@@ -84,6 +84,7 @@ void test_single_slice(starrocks::CompressionTypePB type) {
                 ASSERT_FALSE(st.ok());
             }
             // corrupt compressed data
+            // we use inflate for gzip decompressor, it will return Status::OK for this case
             if (type != starrocks::CompressionTypePB::SNAPPY && type != starrocks::CompressionTypePB::GZIP) {
                 Slice uncompressed_slice(uncompressed);
                 compressed_slice.size -= 1;

--- a/fe/fe-core/src/main/java/com/starrocks/common/StarRocksFEMetaVersion.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/StarRocksFEMetaVersion.java
@@ -11,8 +11,7 @@ public class StarRocksFEMetaVersion {
 
     //support hive external read
     public static final int VERSION_3 = 3;
-    public static final int VERSION_4 = 4;
 
     // note: when increment meta version, should assign the latest version to VERSION_CURRENT
-    public static final int VERSION_CURRENT = VERSION_4;
+    public static final int VERSION_CURRENT = VERSION_3;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/StarRocksFEMetaVersion.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/StarRocksFEMetaVersion.java
@@ -11,7 +11,8 @@ public class StarRocksFEMetaVersion {
 
     //support hive external read
     public static final int VERSION_3 = 3;
+    public static final int VERSION_4 = 4;
 
     // note: when increment meta version, should assign the latest version to VERSION_CURRENT
-    public static final int VERSION_CURRENT = VERSION_3;
+    public static final int VERSION_CURRENT = VERSION_4;
 }


### PR DESCRIPTION
related with #1030
try to support read iceberg table which use default gzip compression algorithm

before this pr:
```
MySQL [external_db]> select * from iceberg_tbl;
ERROR 1064 (HY000): Fail to do Gzip decompress use zlib, error=data error
```
after this pr:
```
MySQL [external_db]> select * from iceberg_tbl;
+------+------+
| id   | data |
+------+------+
|    3 | c    |
|    1 | a    |
|    2 | b    |
+------+------+
```