### PR TITLE
don't check memory limit of load

### DIFF
--- a/be/src/runtime/current_thread.h
+++ b/be/src/runtime/current_thread.h
@@ -11,8 +11,22 @@
 #include "util/defer_op.h"
 #include "util/uid_util.h"
 
+#define SCOPED_THREAD_LOCAL_MEM_SETTER(mem_tracker, check)                             \
+    auto VARNAME_LINENUM(tracker_setter) = CurrentThreadMemTrackerSetter(mem_tracker); \
+    auto VARNAME_LINENUM(check_setter) = CurrentThreadCheckMemLimitSetter(check);
+
 #define SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(mem_tracker) \
     auto VARNAME_LINENUM(tracker_setter) = CurrentThreadMemTrackerSetter(mem_tracker)
+
+#define SCOPED_THREAD_LOCAL_CHECK_MEM_LIMIT_SETTER(check) \
+    auto VARNAME_LINENUM(check_setter) = CurrentThreadCheckMemLimitSetter(check)
+
+#define CHECK_MEM_LIMIT(err_msg)                                                     \
+    do {                                                                             \
+        if (tls_thread_status.check_mem_limit()) {                                   \
+            RETURN_IF_ERROR(CurrentThread::mem_tracker()->check_mem_limit(err_msg)); \
+        }                                                                            \
+    } while (0)
 
 namespace starrocks {
 
@@ -46,6 +60,14 @@ public:
         tls_mem_tracker = mem_tracker;
         return prev;
     }
+
+    bool set_check_mem_limit(bool check) {
+        bool tmp_check = _check;
+        _check = check;
+        return tmp_check;
+    }
+
+    bool check_mem_limit() { return _check; }
 
     static starrocks::MemTracker* mem_tracker() {
         if (UNLIKELY(tls_mem_tracker == nullptr)) {
@@ -132,6 +154,7 @@ private:
     int64_t _cache_size = 0;
     TUniqueId _query_id;
     bool _is_catched = false;
+    bool _check = true;
 };
 
 inline thread_local CurrentThread tls_thread_status;
@@ -151,6 +174,23 @@ public:
 
 private:
     MemTracker* _old_mem_tracker;
+};
+
+class CurrentThreadCheckMemLimitSetter {
+public:
+    explicit CurrentThreadCheckMemLimitSetter(bool check) {
+        _prev_check = tls_thread_status.set_check_mem_limit(check);
+    }
+
+    ~CurrentThreadCheckMemLimitSetter() { (void)tls_thread_status.set_check_mem_limit(_prev_check); }
+
+    CurrentThreadCheckMemLimitSetter(const CurrentThreadCheckMemLimitSetter&) = delete;
+    void operator=(const CurrentThreadCheckMemLimitSetter&) = delete;
+    CurrentThreadCheckMemLimitSetter(CurrentThreadCheckMemLimitSetter&&) = delete;
+    void operator=(CurrentThreadCheckMemLimitSetter&&) = delete;
+
+private:
+    bool _prev_check;
 };
 
 #define TRY_CATCH_BAD_ALLOC(stmt)                                            \

--- a/be/src/runtime/current_thread.h
+++ b/be/src/runtime/current_thread.h
@@ -62,9 +62,9 @@ public:
     }
 
     bool set_check_mem_limit(bool check) {
-        bool tmp_check = _check;
+        bool prev_check = _check;
         _check = check;
-        return tmp_check;
+        return prev_check;
     }
 
     bool check_mem_limit() { return _check; }

--- a/be/src/storage/memtable_flush_executor.cpp
+++ b/be/src/storage/memtable_flush_executor.cpp
@@ -36,7 +36,7 @@ public:
     ~MemtableFlushTask() = default;
 
     void run() override {
-        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_memtable->mem_tracker());
+        SCOPED_THREAD_LOCAL_MEM_SETTER(_memtable->mem_tracker(), false);
 
         _flush_token->_stats.cur_flush_count++;
         _flush_token->_flush_memtable(_memtable.get());
@@ -58,7 +58,7 @@ std::ostream& operator<<(std::ostream& os, const FlushStatistic& stat) {
 Status FlushToken::submit(std::unique_ptr<vectorized::MemTable> memtable) {
     RETURN_IF_ERROR(status());
     // Does not acount the size of MemtableFlushTask into any memory tracker
-    SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(nullptr);
+    SCOPED_THREAD_LOCAL_MEM_SETTER(nullptr, false);
     auto task = std::make_shared<MemtableFlushTask>(this, std::move(memtable));
     return _flush_token->submit(std::move(task));
 }

--- a/be/src/storage/rowset/page_io.cpp
+++ b/be/src/storage/rowset/page_io.cpp
@@ -113,7 +113,9 @@ Status PageIO::write_page(fs::WritableBlock* wblock, const std::vector<Slice>& b
 
 Status PageIO::read_and_decompress_page(const PageReadOptions& opts, PageHandle* handle, Slice* body,
                                         PageFooterPB* footer) {
-    RETURN_IF_ERROR(CurrentThread::mem_tracker()->check_mem_limit("read and decompress page"));
+    // the function will be used by query or load, current load is not allowed to fail when memory reach the limit,
+    // so don't check when tls_thread_state.check is set to false
+    CHECK_MEM_LIMIT("read and decompress page");
 
     opts.sanity_check();
     opts.stats->total_pages_num++;

--- a/be/src/storage/vectorized/delta_writer.cpp
+++ b/be/src/storage/vectorized/delta_writer.cpp
@@ -15,7 +15,7 @@ namespace starrocks::vectorized {
 
 StatusOr<std::unique_ptr<DeltaWriter>> DeltaWriter::open(const DeltaWriterOptions& opt, MemTracker* mem_tracker) {
     std::unique_ptr<DeltaWriter> writer(new DeltaWriter(opt, mem_tracker, StorageEngine::instance()));
-    SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(mem_tracker);
+    SCOPED_THREAD_LOCAL_MEM_SETTER(mem_tracker, false);
     RETURN_IF_ERROR(writer->_init());
     return std::move(writer);
 }
@@ -33,7 +33,7 @@ DeltaWriter::DeltaWriter(const DeltaWriterOptions& opt, MemTracker* mem_tracker,
           _flush_token(nullptr) {}
 
 DeltaWriter::~DeltaWriter() {
-    SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_mem_tracker);
+    SCOPED_THREAD_LOCAL_MEM_SETTER(_mem_tracker, false);
     switch (_get_state()) {
     case kUninitialized:
     case kCommitted:
@@ -64,7 +64,7 @@ void DeltaWriter::_garbage_collection() {
 }
 
 Status DeltaWriter::_init() {
-    SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_mem_tracker);
+    SCOPED_THREAD_LOCAL_MEM_SETTER(_mem_tracker, false);
     TabletManager* tablet_mgr = _storage_engine->tablet_manager();
     _tablet = tablet_mgr->get_tablet(_opt.tablet_id, false);
     if (_tablet == nullptr) {
@@ -189,7 +189,7 @@ Status DeltaWriter::_init() {
 }
 
 Status DeltaWriter::write(const Chunk& chunk, const uint32_t* indexes, uint32_t from, uint32_t size) {
-    SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_mem_tracker);
+    SCOPED_THREAD_LOCAL_MEM_SETTER(_mem_tracker, false);
     Status st;
     auto state = _get_state();
     switch (state) {
@@ -220,7 +220,7 @@ Status DeltaWriter::write(const Chunk& chunk, const uint32_t* indexes, uint32_t 
 }
 
 Status DeltaWriter::close() {
-    SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_mem_tracker);
+    SCOPED_THREAD_LOCAL_MEM_SETTER(_mem_tracker, false);
     Status st;
     auto state = _get_state();
     switch (state) {
@@ -254,7 +254,7 @@ void DeltaWriter::_reset_mem_table() {
 }
 
 Status DeltaWriter::commit() {
-    SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_mem_tracker);
+    SCOPED_THREAD_LOCAL_MEM_SETTER(_mem_tracker, false);
     auto state = _get_state();
     switch (state) {
     case kUninitialized:


### PR DESCRIPTION
for #2743 

Current, Load is not allowed to fail when mem usage reach limit;

the function read_and_decompress_page will be both used by query and load (primary model), so shoud be add one option for check or not