### PR TITLE
remove unused code of aggr

### DIFF
--- a/be/src/exec/vectorized/aggregator.h
+++ b/be/src/exec/vectorized/aggregator.h
@@ -333,8 +333,8 @@ public:
                 }
             } else {
                 for (size_t i = 0; i < _agg_fn_ctxs.size(); i++) {
-                    _agg_functions[i]->batch_serialize(read_index, _tmp_agg_states, _agg_states_offsets[i],
-                                                       agg_result_column[i].get());
+                    _agg_functions[i]->batch_serialize(_agg_fn_ctxs[i], read_index, _tmp_agg_states,
+                                                       _agg_states_offsets[i], agg_result_column[i].get());
                 }
             }
         }

--- a/be/src/exprs/agg/aggregate.h
+++ b/be/src/exprs/agg/aggregate.h
@@ -52,8 +52,8 @@ public:
     virtual void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const = 0;
 
     // batch serialize aggregate state to reduce virtual function call
-    virtual void batch_serialize(size_t chunk_size, const Buffer<AggDataPtr>& agg_states, size_t state_offsets,
-                                 Column* to) const = 0;
+    virtual void batch_serialize(FunctionContext* ctx, size_t chunk_size, const Buffer<AggDataPtr>& agg_states,
+                                 size_t state_offsets, Column* to) const = 0;
 
     // Change the aggregation state to final result if necessary
     virtual void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const = 0;
@@ -182,10 +182,10 @@ class AggregateFunctionBatchHelper : public AggregateFunctionStateHelper<State> 
         }
     }
 
-    void batch_serialize(size_t chunk_size, const Buffer<AggDataPtr>& agg_states, size_t state_offset,
-                         Column* to) const override {
+    void batch_serialize(FunctionContext* ctx, size_t chunk_size, const Buffer<AggDataPtr>& agg_states,
+                         size_t state_offset, Column* to) const override {
         for (size_t i = 0; i < chunk_size; i++) {
-            static_cast<const Derived*>(this)->serialize_to_column(nullptr, agg_states[i] + state_offset, to);
+            static_cast<const Derived*>(this)->serialize_to_column(ctx, agg_states[i] + state_offset, to);
         }
     }
 

--- a/be/src/exprs/agg/count.h
+++ b/be/src/exprs/agg/count.h
@@ -70,11 +70,6 @@ public:
         down_cast<Int64Column*>(to)->append(this->data(state).count);
     }
 
-    void batch_finalize(FunctionContext* ctx __attribute__((unused)), size_t chunk_size,
-                        const Buffer<AggDataPtr>& agg_states, size_t state_offsets, Column* to) const override {
-        batch_serialize(chunk_size, agg_states, state_offsets, to);
-    }
-
     void convert_to_serialize_format(const Columns& src, size_t chunk_size, ColumnPtr* dst) const override {
         auto* column = down_cast<Int64Column*>((*dst).get());
         column->get_data().assign(chunk_size, 1);
@@ -163,11 +158,6 @@ public:
     void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         DCHECK(to->is_numeric());
         down_cast<Int64Column*>(to)->append(this->data(state).count);
-    }
-
-    void batch_finalize(FunctionContext* ctx __attribute__((unused)), size_t chunk_size,
-                        const Buffer<AggDataPtr>& agg_states, size_t state_offsets, Column* to) const override {
-        batch_serialize(chunk_size, agg_states, state_offsets, to);
     }
 
     void convert_to_serialize_format(const Columns& src, size_t chunk_size, ColumnPtr* dst) const override {

--- a/be/src/exprs/agg/count.h
+++ b/be/src/exprs/agg/count.h
@@ -70,13 +70,13 @@ public:
         down_cast<Int64Column*>(to)->append(this->data(state).count);
     }
 
-    void batch_finalize(size_t chunk_size, const Buffer<AggDataPtr>& agg_states, size_t state_offsets,
-                        Column* to) const {
+    void batch_finalize(FunctionContext* ctx __attribute__((unused)), size_t chunk_size,
+                        const Buffer<AggDataPtr>& agg_states, size_t state_offsets, Column* to) const override {
         batch_serialize(chunk_size, agg_states, state_offsets, to);
     }
 
     void convert_to_serialize_format(const Columns& src, size_t chunk_size, ColumnPtr* dst) const override {
-        Int64Column* column = down_cast<Int64Column*>((*dst).get());
+        auto* column = down_cast<Int64Column*>((*dst).get());
         column->get_data().assign(chunk_size, 1);
     }
 
@@ -165,8 +165,8 @@ public:
         down_cast<Int64Column*>(to)->append(this->data(state).count);
     }
 
-    void batch_finalize(size_t chunk_size, const Buffer<AggDataPtr>& agg_states, size_t state_offsets,
-                        Column* to) const {
+    void batch_finalize(FunctionContext* ctx __attribute__((unused)), size_t chunk_size,
+                        const Buffer<AggDataPtr>& agg_states, size_t state_offsets, Column* to) const override {
         batch_serialize(chunk_size, agg_states, state_offsets, to);
     }
 

--- a/be/src/exprs/agg/count.h
+++ b/be/src/exprs/agg/count.h
@@ -56,8 +56,8 @@ public:
         down_cast<Int64Column*>(to)->append(this->data(state).count);
     }
 
-    void batch_serialize(size_t chunk_size, const Buffer<AggDataPtr>& agg_states, size_t state_offset,
-                         Column* to) const override {
+    void batch_serialize(FunctionContext* ctx, size_t chunk_size, const Buffer<AggDataPtr>& agg_states,
+                         size_t state_offset, Column* to) const override {
         Int64Column* column = down_cast<Int64Column*>(to);
         Buffer<int64_t>& result_data = column->get_data();
         for (size_t i = 0; i < chunk_size; i++) {
@@ -146,8 +146,8 @@ public:
         down_cast<Int64Column*>(to)->append(this->data(state).count);
     }
 
-    void batch_serialize(size_t chunk_size, const Buffer<AggDataPtr>& agg_states, size_t state_offset,
-                         Column* to) const override {
+    void batch_serialize(FunctionContext* ctx, size_t chunk_size, const Buffer<AggDataPtr>& agg_states,
+                         size_t state_offset, Column* to) const override {
         Int64Column* column = down_cast<Int64Column*>(to);
         Buffer<int64_t>& result_data = column->get_data();
         for (size_t i = 0; i < chunk_size; i++) {

--- a/be/src/exprs/agg/nullable_aggregate.h
+++ b/be/src/exprs/agg/nullable_aggregate.h
@@ -99,10 +99,10 @@ public:
         }
     }
 
-    void batch_serialize(size_t chunk_size, const Buffer<AggDataPtr>& agg_states, size_t state_offset,
-                         Column* to) const override {
+    void batch_serialize(FunctionContext* ctx, size_t chunk_size, const Buffer<AggDataPtr>& agg_states,
+                         size_t state_offset, Column* to) const override {
         for (size_t i = 0; i < chunk_size; i++) {
-            serialize_to_column(nullptr, agg_states[i] + state_offset, to);
+            serialize_to_column(ctx, agg_states[i] + state_offset, to);
         }
     }
 

--- a/be/src/exprs/agg/sum.h
+++ b/be/src/exprs/agg/sum.h
@@ -91,8 +91,8 @@ public:
         down_cast<ResultColumnType*>(to)->append(this->data(state).sum);
     }
 
-    void batch_serialize(size_t chunk_size, const Buffer<AggDataPtr>& agg_states, size_t state_offset,
-                         Column* to) const override {
+    void batch_serialize(FunctionContext* ctx, size_t chunk_size, const Buffer<AggDataPtr>& agg_states,
+                         size_t state_offset, Column* to) const override {
         ResultColumnType* column = down_cast<ResultColumnType*>(to);
         Buffer<ResultType>& result_data = column->get_data();
         for (size_t i = 0; i < chunk_size; i++) {

--- a/be/src/exprs/agg/sum.h
+++ b/be/src/exprs/agg/sum.h
@@ -106,11 +106,6 @@ public:
         down_cast<ResultColumnType*>(to)->append(this->data(state).sum);
     }
 
-    void batch_finalize(FunctionContext* ctx __attribute__((unused)), size_t chunk_size,
-                        const Buffer<AggDataPtr>& agg_states, size_t state_offset, Column* to) const override {
-        batch_serialize(chunk_size, agg_states, state_offset, to);
-    }
-
     void convert_to_serialize_format(const Columns& src, size_t chunk_size, ColumnPtr* dst) const override {
         Buffer<ResultType>& dst_data = down_cast<ResultColumnType*>((*dst).get())->get_data();
         const auto* src_data = down_cast<const InputColumnType*>(src[0].get())->get_data().data();

--- a/be/src/exprs/agg/sum.h
+++ b/be/src/exprs/agg/sum.h
@@ -106,8 +106,8 @@ public:
         down_cast<ResultColumnType*>(to)->append(this->data(state).sum);
     }
 
-    void batch_finalize(size_t chunk_size, const Buffer<AggDataPtr>& agg_states, size_t state_offset,
-                        Column* to) const {
+    void batch_finalize(FunctionContext* ctx __attribute__((unused)), size_t chunk_size,
+                        const Buffer<AggDataPtr>& agg_states, size_t state_offset, Column* to) const override {
         batch_serialize(chunk_size, agg_states, state_offset, to);
     }
 

--- a/be/src/exprs/agg/window.h
+++ b/be/src/exprs/agg/window.h
@@ -56,8 +56,8 @@ class WindowFunction : public AggregateFunctionStateHelper<State> {
         DCHECK(false) << "Shouldn't call this method for window function!";
     }
 
-    void batch_serialize(size_t chunk_size, const Buffer<AggDataPtr>& agg_states, size_t state_offset,
-                         Column* to) const override {
+    void batch_serialize(FunctionContext* ctx, size_t chunk_size, const Buffer<AggDataPtr>& agg_states,
+                         size_t state_offset, Column* to) const override {
         DCHECK(false) << "Shouldn't call this method for window function!";
     }
 


### PR DESCRIPTION
the batch_finalize of aggregator is not override

the interface is

```
void batch_finalize(FunctionContext* ctx, size_t chunk_size, const Buffer<AggDataPtr>& agg_states,
                        size_t state_offset, Column* to) const
```

but the implement is 

```
void batch_finalize(size_t chunk_size, const Buffer<AggDataPtr>& agg_states, size_t state_offsets,
                        Column* to) const
```

override the batch_finalize has no improve on performance