### PR TITLE
BugFix : FE should clear txn about delete after restart

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/DeleteHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/DeleteHandler.java
@@ -22,7 +22,6 @@
 package com.starrocks.load;
 
 import com.google.common.base.Joiner;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
@@ -198,7 +197,7 @@ public class DeleteHandler implements Writable {
                 transactionId = Catalog.getCurrentGlobalTransactionMgr().beginTransaction(db.getId(),
                         Lists.newArrayList(table.getId()), label, null,
                         new TxnCoordinator(TxnSourceType.FE, FrontendOptions.getLocalHostAddress()),
-                        TransactionState.LoadJobSourceType.FRONTEND, jobId, Config.stream_load_default_timeout_second);
+                        TransactionState.LoadJobSourceType.DELETE, jobId, Config.stream_load_default_timeout_second);
 
                 MultiDeleteInfo deleteInfo =
                         new MultiDeleteInfo(db.getId(), olapTable.getId(), tableName, deleteConditions);
@@ -286,7 +285,6 @@ public class DeleteHandler implements Writable {
                 ok = countDownLatch.await(timeoutMs, TimeUnit.MILLISECONDS);
             } catch (InterruptedException e) {
                 LOG.warn("InterruptedException: ", e);
-                ok = false;
             }
 
             if (!ok) {
@@ -324,7 +322,7 @@ public class DeleteHandler implements Writable {
                                 deleteJob.checkAndUpdateQuorum();
                                 Thread.sleep(1000);
                                 nowQuorumTimeMs = System.currentTimeMillis();
-                                LOG.debug("wait for quorum finished delete job: {}, txn id: {}" + deleteJob.getId(),
+                                LOG.debug("wait for quorum finished delete job: {}, txn id: {}", deleteJob.getId(),
                                         transactionId);
                             }
                         } catch (MetaNotFoundException e) {
@@ -337,8 +335,7 @@ public class DeleteHandler implements Writable {
                         commitJob(deleteJob, db, timeoutMs);
                         break;
                     default:
-                        Preconditions.checkState(false, "wrong delete job state: " + state.name());
-                        break;
+                        throw new IllegalStateException("wrong delete job state: " + state.name());
                 }
             } else {
                 commitJob(deleteJob, db, timeoutMs);
@@ -381,8 +378,7 @@ public class DeleteHandler implements Writable {
                 throw new QueryStateException(MysqlStateType.OK, sb.toString());
             }
             default:
-                Preconditions.checkState(false, "wrong transaction status: " + status.name());
-                break;
+                throw new IllegalStateException("wrong transaction status: " + status.name());
         }
     }
 
@@ -426,9 +422,7 @@ public class DeleteHandler implements Writable {
     private void clearJob(DeleteJob job) {
         if (job != null) {
             long signature = job.getTransactionId();
-            if (idToDeleteJob.containsKey(signature)) {
-                idToDeleteJob.remove(signature);
-            }
+            idToDeleteJob.remove(signature);
             for (PushTask pushTask : job.getPushTasks()) {
                 AgentTaskQueue.removePushTask(pushTask.getBackendId(), pushTask.getSignature(),
                         pushTask.getVersion(),
@@ -468,13 +462,15 @@ public class DeleteHandler implements Writable {
      * @return
      */
     public boolean cancelJob(DeleteJob job, CancelType cancelType, String reason) {
+        if (job == null) {
+            LOG.warn("cancel a null job, cancelType: {}, reason: {}", cancelType.name(), reason);
+            return true;
+        }
         LOG.info("start to cancel delete job, transactionId: {}, cancelType: {}", job.getTransactionId(),
                 cancelType.name());
         GlobalTransactionMgr globalTransactionMgr = Catalog.getCurrentGlobalTransactionMgr();
         try {
-            if (job != null) {
-                globalTransactionMgr.abortTransaction(job.getDeleteInfo().getDbId(), job.getTransactionId(), reason);
-            }
+            globalTransactionMgr.abortTransaction(job.getDeleteInfo().getDbId(), job.getTransactionId(), reason);
         } catch (Exception e) {
             TransactionState state =
                     globalTransactionMgr.getTransactionState(job.getDeleteInfo().getDbId(), job.getTransactionId());
@@ -483,7 +479,7 @@ public class DeleteHandler implements Writable {
             } else if (state.getTransactionStatus() == TransactionStatus.COMMITTED ||
                     state.getTransactionStatus() == TransactionStatus.VISIBLE) {
                 LOG.warn("cancel delete job {} failed because it has been committed, transactionId: {}",
-                        job.getTransactionId());
+                        job.getId(), job.getTransactionId());
                 return false;
             } else {
                 LOG.warn("errors while abort transaction", e);

--- a/fe/fe-core/src/main/java/com/starrocks/load/DeleteHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/DeleteHandler.java
@@ -197,7 +197,9 @@ public class DeleteHandler implements Writable {
                 transactionId = Catalog.getCurrentGlobalTransactionMgr().beginTransaction(db.getId(),
                         Lists.newArrayList(table.getId()), label, null,
                         new TxnCoordinator(TxnSourceType.FE, FrontendOptions.getLocalHostAddress()),
-                        TransactionState.LoadJobSourceType.DELETE, jobId, Config.stream_load_default_timeout_second);
+                        // For version compatibility, keep this set to FRONTEND,
+                        // and set it to DELETE in the next release
+                        TransactionState.LoadJobSourceType.FRONTEND, jobId, Config.stream_load_default_timeout_second);
 
                 MultiDeleteInfo deleteInfo =
                         new MultiDeleteInfo(db.getId(), olapTable.getId(), tableName, deleteConditions);

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -68,11 +68,12 @@ public class TransactionState implements Writable {
     public static final TxnStateComparator TXN_ID_COMPARATOR = new TxnStateComparator();
 
     public enum LoadJobSourceType {
-        FRONTEND(1),        // old dpp load, mini load, insert stmt(not streaming type) use this type
-        BACKEND_STREAMING(2),         // streaming load use this type
-        INSERT_STREAMING(3), // insert stmt (streaming type) use this type
-        ROUTINE_LOAD_TASK(4), // routine load task use this type
-        BATCH_LOAD_JOB(5); // load job v2 for broker load
+        FRONTEND(1),                    // old dpp load, mini load, insert stmt(not streaming type) use this type
+        BACKEND_STREAMING(2),           // streaming load use this type
+        INSERT_STREAMING(3),            // insert stmt (streaming type) use this type
+        ROUTINE_LOAD_TASK(4),           // routine load task use this type
+        BATCH_LOAD_JOB(5),              // load job v2 for broker load
+        DELETE(6);                      // synchronization delete job use this type
 
         private final int flag;
 
@@ -96,6 +97,8 @@ public class TransactionState implements Writable {
                     return ROUTINE_LOAD_TASK;
                 case 5:
                     return BATCH_LOAD_JOB;
+                case 6:
+                    return DELETE;
                 default:
                     return null;
             }
@@ -551,7 +554,7 @@ public class TransactionState implements Writable {
         sb.append(", finish time: ").append(finishTime);
         sb.append(", reason: ").append(reason);
         if (txnCommitAttachment != null) {
-            sb.append(" attactment: ").append(txnCommitAttachment);
+            sb.append(" attachment: ").append(txnCommitAttachment);
         }
         return sb.toString();
     }
@@ -586,8 +589,8 @@ public class TransactionState implements Writable {
         out.writeLong(finishTime);
         Text.writeString(out, reason);
         out.writeInt(errorReplicas.size());
-        for (long errorReplciaId : errorReplicas) {
-            out.writeLong(errorReplciaId);
+        for (long errorReplicaId : errorReplicas) {
+            out.writeLong(errorReplicaId);
         }
 
         if (txnCommitAttachment == null) {
@@ -599,8 +602,8 @@ public class TransactionState implements Writable {
         out.writeLong(callbackId);
         out.writeLong(timeoutMs);
         out.writeInt(tableIdList.size());
-        for (int i = 0; i < tableIdList.size(); i++) {
-            out.writeLong(tableIdList.get(i));
+        for (Long tableId : tableIdList) {
+            out.writeLong(tableId);
         }
     }
 


### PR DESCRIPTION
Fix: #2750 
The transaction type of Delete is FRONTEND. 
For the FRONTEND type, only asynchronous operations need to write logs, that is, 
```
editLog.logInsertTransactionState(transactionState)
```
 in line 917 of DatabaseTransactionMgr.java;

Now DELETE is a synchronous operation. 
If FE writes this log and restarts during delete, the transaction state will exist until the transaction timeout.

so I add a new type for mark delete to solve this problem.
