### PR TITLE
[ResourceIsolation] fix: set workgroup.id from session to thrift correctly

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -1998,8 +1998,8 @@ public class Coordinator {
                         params.setPipeline_dop(fragment.getPipelineDop());
                         // TODO (by satanson): just for verification of resource isolation.
                         TWorkGroup wg = new TWorkGroup();
-                        wg.name = "";
-                        wg.id = ConnectContext.get().getSessionVariable().getWorkgroupId();
+                        wg.setName("");
+                        wg.setId(ConnectContext.get().getSessionVariable().getWorkgroupId());
                         params.setWorkgroup(wg);
                     }
 


### PR DESCRIPTION
Because `TWorkGroup.id` is `int`, use `wg.id=xxx` cannot determine whether `id` is set or not.
Instead of that, we must use the method `setId()` to set id.
```Java
  public TWorkGroup setId(int id) {
    this.id = id;
    setIdIsSet(true);
    return this;
  }
```