### PR TITLE
Convert `tparquet::CompressionCodec::type` to `CompressionTypePB` type anyway

### DIFF
--- a/be/src/exec/parquet/utils.cpp
+++ b/be/src/exec/parquet/utils.cpp
@@ -14,6 +14,12 @@ CompressionTypePB convert_compression_codec(tparquet::CompressionCodec::type cod
         return LZ4;
     case tparquet::CompressionCodec::ZSTD:
         return ZSTD;
+    case tparquet::CompressionCodec::GZIP:
+        return GZIP;
+    case tparquet::CompressionCodec::LZO:
+        return LZO;
+    case tparquet::CompressionCodec::BROTLI:
+        return BROTLI;
     default:
         return UNKNOWN_COMPRESSION;
     }

--- a/gensrc/proto/types.proto
+++ b/gensrc/proto/types.proto
@@ -80,5 +80,6 @@ enum CompressionTypePB {
     DEFLATE = 9;
     BZIP2 = 10;
     LZO = 11; // Deprecated
+    BROTLI = 12;
 }
 


### PR DESCRIPTION
Convert `tparquet::CompressionCodec::type` to `CompressionTypePB` type even though it's not implemented yet, so that we can know exactly what compression type it is in case of unimplemented error. Otherwise, we can only get something like `ERROR 1064 (HY000): unknown compression type(0)`