### PR TITLE
[ResourceIsolation] fix: update sum_cpu_runtime when workgroup is put back to _ready_wgs

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver_queue.h
+++ b/be/src/exec/pipeline/pipeline_driver_queue.h
@@ -136,7 +136,7 @@ private:
 
     std::mutex _global_mutex;
     std::condition_variable _cv;
-    // _ready_wgs contains the workgroup which including the drivers need to be run.
+    // _ready_wgs contains the workgroups which include the drivers need to be run.
     std::unordered_set<workgroup::WorkGroup*> _ready_wgs;
     size_t _sum_cpu_limit = 0;
 

--- a/be/src/exec/pipeline/pipeline_driver_queue.h
+++ b/be/src/exec/pipeline/pipeline_driver_queue.h
@@ -136,7 +136,8 @@ private:
 
     std::mutex _global_mutex;
     std::condition_variable _cv;
-    std::unordered_set<workgroup::WorkGroup*> _wgs;
+    // _ready_wgs contains the workgroup which including the drivers need to be run.
+    std::unordered_set<workgroup::WorkGroup*> _ready_wgs;
     size_t _sum_cpu_limit = 0;
 
     bool _is_closed = false;

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -60,7 +60,11 @@ double WorkGroup::get_cpu_expected_use_ratio() const {
 }
 
 double WorkGroup::get_cpu_actual_use_ratio() const {
-    return static_cast<double>(get_real_runtime_ns()) / WorkGroupManager::instance()->get_sum_cpu_runtime_ns();
+    int64_t sum_cpu_runtime_ns = WorkGroupManager::instance()->get_sum_cpu_runtime_ns();
+    if (sum_cpu_runtime_ns == 0) {
+        return 0;
+    }
+    return static_cast<double>(get_real_runtime_ns()) / sum_cpu_runtime_ns;
 }
 
 WorkGroupManager::WorkGroupManager() {}


### PR DESCRIPTION
### Introduction
In `DriverQueueWithWorkGroup::_put_back`, the `runtime` of `wg` may be adjusted if it is put back to `_ready_wgs`. Therefore, `WorkGroupMannger::_sum_real_runtime_ns` should be also adjusted in the meanwhile.

### Changes
- Update `WorkGroupMannger::_sum_real_runtime_ns` in `DriverQueueWithWorkGroup::_put_back`.
- Rename `DriverQueueWithWorkGroup::_wgs` to `DriverQueueWithWorkGroup::_ready_wgs`.
- Return 0 if `_sum_real_runtime_ns==0` in `WorkGroup::get_cpu_actual_use_ratio()`.