### PR TITLE
Fix: add builtin MULTI_DISTINCT_COUNT function for float argument

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -419,7 +419,8 @@ public class FunctionSet {
                         Type.BIGINT,
                         Type.VARCHAR,
                         false, true, true));
-            } else if (t.isBoolean() || t.isTinyint() || t.isSmallint() || t.isInt() || t.isBigint() || t.isLargeint() || t.isDouble()) {
+            } else if (t.isBoolean() || t.isTinyint() || t.isSmallint() || t.isInt() || t.isBigint() ||
+                    t.isLargeint() || t.isFloat() || t.isDouble()) {
                 addBuiltin(AggregateFunction.createBuiltin(FunctionSet.MULTI_DISTINCT_COUNT, Lists.newArrayList(t),
                         Type.BIGINT,
                         Type.VARCHAR,

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -4672,6 +4672,16 @@ public class PlanFragmentTest extends PlanTestBase {
     }
 
     @Test
+    public void testCountDistinctFloatTwoPhase() throws Exception {
+        connectContext.getSessionVariable().setNewPlanerAggStage(2);
+        String sql = "select count(distinct t1e) from test_all_type";
+        String plan = getCostExplain(sql);
+        Assert.assertTrue(plan.contains("aggregate: multi_distinct_count[([5: t1e, FLOAT, true]); " +
+                "args: FLOAT; result: VARCHAR; args nullable: true; result nullable: false"));
+        connectContext.getSessionVariable().setNewPlanerAggStage(0);
+    }
+
+    @Test
     public void testCastDecimalZero() throws Exception {
         Config.enable_decimal_v3 = true;
         String sql = "select (CASE WHEN CAST(t0.v1 AS BOOLEAN ) THEN 0.00 END) BETWEEN (0.07) AND (0.04) from t0;";


### PR DESCRIPTION
Builtin `MULTI_DISTINCT_COUNT` function misses the function signature with the float argument. 
Therefore, the query like `COUNT( DISTINCT c1 ) FROM t1` where the type of `c1` is `FLOAT` will use the `MULTI_DISTINCT_COUNT` function instance with double argument.

Fix #2740.