### PR TITLE
BugFix: dynamic_partition.buckets should equal the distribution buckets if creating a colocate table

### DIFF
--- a/be/test/exprs/vectorized/array_functions_test.cpp
+++ b/be/test/exprs/vectorized/array_functions_test.cpp
@@ -580,7 +580,6 @@ TEST_F(ArrayFunctionsTest, array_contains_nullable_array) {
     }
 }
 
-
 // NOLINTNEXTLINE
 TEST_F(ArrayFunctionsTest, array_position_empty_array) {
     // array_position([], 1) : 0
@@ -887,7 +886,7 @@ TEST_F(ArrayFunctionsTest, array_position_has_null_target) {
         EXPECT_EQ(0, result->get(0).get_int32());
     }
     // array_position(ARRAY<TINYINT>[1, 2, 3], 2): 2
-    // array_position(ARRAY<TINYINT>[1, 2, 3], 4): 0 
+    // array_position(ARRAY<TINYINT>[1, 2, 3], 4): 0
     // array_position(ARRAY<TINYINT>[1, 2, 3], NULL): 0
     {
         auto array = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, false);
@@ -1018,7 +1017,6 @@ TEST_F(ArrayFunctionsTest, array_position_nullable_array) {
         EXPECT_TRUE(result->get(2).is_null());
     }
 }
-
 
 // NOLINTNEXTLINE
 TEST_F(ArrayFunctionsTest, array_remove_empty_array) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -4078,6 +4078,13 @@ public class Catalog {
                         DataProperty dataProperty = PropertyAnalyzer.analyzeDataProperty(properties,
                                 DataProperty.DEFAULT_DATA_PROPERTY);
                         DynamicPartitionUtil.checkAndSetDynamicPartitionProperty(olapTable, properties);
+                        if (olapTable.dynamicPartitionExists() && olapTable.getColocateGroup() != null) {
+                            HashDistributionInfo info = (HashDistributionInfo) distributionInfo;
+                            if (info.getBucketNum() != olapTable.getTableProperty().getDynamicPartitionProperty().getBuckets()) {
+                                throw new DdlException("dynamic_partition.buckets should equal the distribution buckets"
+                                                       + " if creating a colocate table");
+                            }
+                        }
                         if (hasMedium) {
                             olapTable.setStorageMedium(dataProperty.getStorageMedium());
                         }


### PR DESCRIPTION
```
CREATE TABLE `auto_partition_day` (
  `k1` date NULL COMMENT "",
  `k2` datetime NULL COMMENT "",
  `k3` char(20) NULL COMMENT "",
  `k4` varchar(1048576) NULL COMMENT "",
  `k5` boolean NULL COMMENT ""
) ENGINE=OLAP
DUPLICATE KEY(`k1`, `k2`, `k3`)
COMMENT "OLAP"
PARTITION BY RANGE(`k1`)
(PARTITION `p20200801` VALUES LESS THAN ("2020-08-01"),
PARTITION `p20200802` VALUES LESS THAN ("2020-08-02"))
DISTRIBUTED BY HASH(`k1`) BUCKETS 1
PROPERTIES (
"dynamic_partition.buckets" = "32",
"colocate_with" = "group2"
);
```

The buckets in distribution info are 1, but dynamic_partition.buckets are 32.
The numbers inf colocate table are not equal.
The DDL statement should throw an error to be avoid undefined behavior.
