### PR TITLE
BugFix: make the variable take effect immediately when set as global

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SetExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SetExecutor.java
@@ -42,7 +42,7 @@ public class SetExecutor {
         this.stmt = stmt;
     }
 
-    private void setVariable(SetVar var) throws DdlException {
+    private void setVariablesOfAllType(SetVar var) throws DdlException {
         if (var instanceof SetPassVar) {
             // Set password
             SetPassVar setPassVar = (SetPassVar) var;
@@ -54,13 +54,31 @@ public class SetExecutor {
             // do nothing
             return;
         } else {
-            VariableMgr.setVar(ctx.getSessionVariable(), var);
+            VariableMgr.setVar(ctx.getSessionVariable(), var, false);
         }
     }
 
+    private boolean isSessionVar(SetVar var) {
+        return !(var instanceof SetPassVar
+                || var instanceof SetNamesVar
+                || var instanceof SetTransaction);
+    }
+
+    /**
+     * SetExecutor will set the session variables and password
+     * @throws DdlException
+     */
     public void execute() throws DdlException {
         for (SetVar var : stmt.getSetVars()) {
-            setVariable(var);
+            setVariablesOfAllType(var);
+        }
+    }
+
+    public void setSessionVars() throws DdlException {
+        for (SetVar var : stmt.getSetVars()) {
+            if (isSessionVar(var)) {
+                VariableMgr.setVar(ctx.getSessionVariable(), var, true);
+            }
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -278,7 +278,7 @@ public class StmtExecutor {
                 if (optHints != null) {
                     SessionVariable sessionVariable = (SessionVariable) sessionVariableBackup.clone();
                     for (String key : optHints.keySet()) {
-                        VariableMgr.setVar(sessionVariable, new SetVar(key, new StringLiteral(optHints.get(key))));
+                        VariableMgr.setVar(sessionVariable, new SetVar(key, new StringLiteral(optHints.get(key))), true);
                     }
                     context.setSessionVariable(sessionVariable);
                 }
@@ -537,7 +537,7 @@ public class StmtExecutor {
 
     private void forwardToMaster() throws Exception {
         boolean isQuery = parsedStmt instanceof QueryStmt;
-        masterOpExecutor = new MasterOpExecutor(originStmt, context, redirectStatus, isQuery);
+        masterOpExecutor = new MasterOpExecutor(parsedStmt, originStmt, context, redirectStatus, isQuery);
         LOG.debug("need to transfer to Master. stmt: {}", context.getStmtId());
         masterOpExecutor.execute();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/VariableMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/VariableMgr.java
@@ -252,7 +252,7 @@ public class VariableMgr {
     // Input:
     //      sessionVariable: the variable of current session
     //      setVar: variable information that needs to be set
-    public static void setVar(SessionVariable sessionVariable, SetVar setVar) throws DdlException {
+    public static void setVar(SessionVariable sessionVariable, SetVar setVar, boolean onlySetSessionVar) throws DdlException {
         VarContext ctx = getVarContext(setVar.getVariable());
         if (ctx == null) {
             ErrorReport.reportDdlException(ErrorCode.ERR_UNKNOWN_SYSTEM_VARIABLE, setVar.getVariable());
@@ -273,7 +273,7 @@ public class VariableMgr {
             }
         }
 
-        if (setVar.getType() == SetType.GLOBAL) {
+        if (!onlySetSessionVar && setVar.getType() == SetType.GLOBAL) {
             wlock.lock();
             try {
                 setValue(ctx.getObj(), ctx.getField(), value);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/VariableMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/VariableMgrTest.java
@@ -107,28 +107,28 @@ public class VariableMgrTest {
         // Set global variable
         SetVar setVar = new SetVar(SetType.GLOBAL, "exec_mem_limit", new IntLiteral(1234L));
         setVar.analyze(null);
-        VariableMgr.setVar(var, setVar);
+        VariableMgr.setVar(var, setVar, false);
         Assert.assertEquals(1234L, var.getMaxExecMemByte());
         var = VariableMgr.newSessionVariable();
         Assert.assertEquals(1234L, var.getMaxExecMemByte());
 
         SetVar setVar2 = new SetVar(SetType.GLOBAL, "parallel_fragment_exec_instance_num", new IntLiteral(5L));
         setVar2.analyze(null);
-        VariableMgr.setVar(var, setVar2);
+        VariableMgr.setVar(var, setVar2, false);
         Assert.assertEquals(5L, var.getParallelExecInstanceNum());
         var = VariableMgr.newSessionVariable();
         Assert.assertEquals(5L, var.getParallelExecInstanceNum());
 
         SetVar setVar3 = new SetVar(SetType.GLOBAL, "time_zone", new StringLiteral("Asia/Shanghai"));
         setVar3.analyze(null);
-        VariableMgr.setVar(var, setVar3);
+        VariableMgr.setVar(var, setVar3, false);
         Assert.assertEquals("Asia/Shanghai", var.getTimeZone());
         var = VariableMgr.newSessionVariable();
         Assert.assertEquals("Asia/Shanghai", var.getTimeZone());
 
         setVar3 = new SetVar(SetType.GLOBAL, "time_zone", new StringLiteral("CST"));
         setVar3.analyze(null);
-        VariableMgr.setVar(var, setVar3);
+        VariableMgr.setVar(var, setVar3, false);
         Assert.assertEquals("CST", var.getTimeZone());
         var = VariableMgr.newSessionVariable();
         Assert.assertEquals("CST", var.getTimeZone());
@@ -136,12 +136,20 @@ public class VariableMgrTest {
         // Set session variable
         setVar = new SetVar(SetType.GLOBAL, "exec_mem_limit", new IntLiteral(1234L));
         setVar.analyze(null);
-        VariableMgr.setVar(var, setVar);
+        VariableMgr.setVar(var, setVar, false);
+        Assert.assertEquals(1234L, var.getMaxExecMemByte());
+
+        // onlySessionVar
+        setVar = new SetVar(SetType.GLOBAL, "exec_mem_limit", new IntLiteral(4321L));
+        setVar.analyze(null);
+        VariableMgr.setVar(var, setVar, true);
+        Assert.assertEquals(4321L, var.getMaxExecMemByte());
+        var = VariableMgr.newSessionVariable();
         Assert.assertEquals(1234L, var.getMaxExecMemByte());
 
         setVar3 = new SetVar(SetType.SESSION, "time_zone", new StringLiteral("Asia/Jakarta"));
         setVar3.analyze(null);
-        VariableMgr.setVar(var, setVar3);
+        VariableMgr.setVar(var, setVar3, false);
         Assert.assertEquals("Asia/Jakarta", var.getTimeZone());
 
         // Get from name
@@ -151,23 +159,23 @@ public class VariableMgrTest {
         SetVar setVar4 = new SetVar(SetType.SESSION, "sql_mode", new StringLiteral(
                 SqlModeHelper.encode("PIPES_AS_CONCAT").toString()));
         setVar4.analyze(null);
-        VariableMgr.setVar(var, setVar4);
+        VariableMgr.setVar(var, setVar4, false);
         Assert.assertEquals(2L, var.getSqlMode());
 
         // Test checkTimeZoneValidAndStandardize
         SetVar setVar5 = new SetVar(SetType.GLOBAL, "time_zone", new StringLiteral("+8:00"));
         setVar5.analyze(null);
-        VariableMgr.setVar(var, setVar5);
+        VariableMgr.setVar(var, setVar5, false);
         Assert.assertEquals("+08:00", VariableMgr.newSessionVariable().getTimeZone());
 
         SetVar setVar6 = new SetVar(SetType.GLOBAL, "time_zone", new StringLiteral("8:00"));
         setVar6.analyze(null);
-        VariableMgr.setVar(var, setVar6);
+        VariableMgr.setVar(var, setVar6, false);
         Assert.assertEquals("+08:00", VariableMgr.newSessionVariable().getTimeZone());
 
         SetVar setVar7 = new SetVar(SetType.GLOBAL, "time_zone", new StringLiteral("-8:00"));
         setVar7.analyze(null);
-        VariableMgr.setVar(var, setVar7);
+        VariableMgr.setVar(var, setVar7, false);
         Assert.assertEquals("-08:00", VariableMgr.newSessionVariable().getTimeZone());
     }
 
@@ -215,7 +223,7 @@ public class VariableMgrTest {
 
         // Set global variable
         SetVar setVar = new SetVar(SetType.SESSION, "version_comment", null);
-        VariableMgr.setVar(null, setVar);
+        VariableMgr.setVar(null, setVar, false);
         Assert.fail("No exception throws.");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -356,7 +356,7 @@ public class UtFrameUtils {
                 if (optHints != null) {
                     SessionVariable sessionVariable = (SessionVariable) oldSessionVariable.clone();
                     for (String key : optHints.keySet()) {
-                        VariableMgr.setVar(sessionVariable, new SetVar(key, new StringLiteral(optHints.get(key))));
+                        VariableMgr.setVar(sessionVariable, new SetVar(key, new StringLiteral(optHints.get(key))), true);
                     }
                     connectContext.setSessionVariable(sessionVariable);
                 }


### PR DESCRIPTION
The follower forward `set global` to the master node. For the non-master node, the execution will not change the variables of the current session. The SetStmt needs to be executed again for the current session after success.