### PR TITLE
[ISSUE-2721] turn DecimalLiteral into NullLiteral when it overflows

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
@@ -747,6 +747,8 @@ public abstract class Type implements Cloneable {
                 return 10;
             case BIGINT:
                 return 19;
+            case LARGEINT:
+                return 39;
             case FLOAT:
                 return 7;
             case DOUBLE:

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
@@ -471,10 +471,6 @@ public abstract class Type implements Cloneable {
         return false;
     }
 
-    public boolean isExactNumericType() {
-        return isIntegerType() || isLargeIntType() || isDecimalV3();
-    }
-
     // isAssignable means that assigning or casting rhs to lhs never overflows.
     // only both integer part width and fraction part width of lhs is not narrower than counterparts
     // of rhs, then rhs can be assigned to lhs. for integer types, integer part width is computed by
@@ -484,7 +480,7 @@ public abstract class Type implements Cloneable {
         int lhsScale;
         int rhsIntPartWidth;
         int rhsScale;
-        if (lhs.isIntegerType() || lhs.isLargeIntType()) {
+        if (lhs.isFixedPointType()) {
             lhsIntPartWidth = lhs.getPrecision();
             lhsScale = 0;
         } else {
@@ -492,7 +488,7 @@ public abstract class Type implements Cloneable {
             lhsScale = lhs.getScalarScale();
         }
 
-        if (rhs.isIntegerType() || lhs.isLargeIntType()) {
+        if (rhs.isFixedPointType()) {
             rhsIntPartWidth = rhs.getPrecision();
             rhsScale = 0;
         } else {
@@ -502,7 +498,7 @@ public abstract class Type implements Cloneable {
 
         // when lhs is integer, for instance, tinyint, lhsIntPartWidth is 3, it cannot holds
         // a DECIMAL(3, 0).
-        if (lhs.isIntegerType() && rhs.isDecimalOfAnyVersion()) {
+        if (lhs.isFixedPointType() && rhs.isDecimalOfAnyVersion()) {
             return lhsIntPartWidth > rhsIntPartWidth && lhsScale >= rhsScale;
         } else {
             return lhsIntPartWidth >= rhsIntPartWidth && lhsScale >= rhsScale;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -460,7 +460,7 @@ public class Utils {
     // only both integer part width and fraction part width of lhs is not narrower than counterparts
     // of rhs, then rhs can be assigned to lhs. for integer types, integer part width is computed by
     // calling Type::getPrecision and its scale is 0.
-    private static boolean isAssignable(ScalarType lhs, ScalarType rhs) {
+    private static boolean isAssignable2Decimal(ScalarType lhs, ScalarType rhs) {
         int lhsIntPartWidth;
         int lhsScale;
         int rhsIntPartWidth;
@@ -509,8 +509,8 @@ public class Utils {
         }
         // Guarantee that both childType casting to lhsType and rhsType casting to childType are
         // lossless
-        if (!isAssignable((ScalarType) lhsType, (ScalarType) childType) ||
-                !isAssignable((ScalarType) childType, (ScalarType) rhsType)) {
+        if (!isAssignable2Decimal((ScalarType) lhsType, (ScalarType) childType) ||
+                !isAssignable2Decimal((ScalarType) childType, (ScalarType) rhsType)) {
             return Optional.empty();
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
@@ -381,8 +381,11 @@ public final class ConstantOperator extends ScalarOperator implements Comparable
             BigDecimal decimal = new BigDecimal(childString);
             try {
                 ScalarType scalarType = (ScalarType) desc;
-                DecimalLiteral.checkLiteralOverflow(decimal, scalarType);
-
+                try {
+                    DecimalLiteral.checkLiteralOverflow(decimal, scalarType);
+                } catch (AnalysisException ignored) {
+                    return ConstantOperator.createNull(desc);
+                }
                 int realScale = DecimalLiteral.getRealScale(decimal);
                 int scale = scalarType.getScalarScale();
                 if (scale <= realScale) {
@@ -392,8 +395,9 @@ public final class ConstantOperator extends ScalarOperator implements Comparable
                 if (scalarType.getScalarScale() == 0 && scalarType.getScalarPrecision() == 0) {
                     throw new SemanticException("Forbidden cast to decimal(precision=0, scale=0)");
                 }
-            } catch (AnalysisException e) {
-                return ConstantOperator.createNull(desc);
+            } catch (Exception e) {
+                throw e;
+                //return ConstantOperator.createNull(desc);
             }
 
             return ConstantOperator.createDecimal(decimal, desc);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
@@ -393,7 +393,8 @@ public final class ConstantOperator extends ScalarOperator implements Comparable
                     throw new SemanticException("Forbidden cast to decimal(precision=0, scale=0)");
                 }
             } catch (AnalysisException e) {
-                throw new SemanticException(e.getMessage());
+                throw e;
+                //return ConstantOperator.createNull(desc);
             }
 
             return ConstantOperator.createDecimal(decimal, desc);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
@@ -393,8 +393,7 @@ public final class ConstantOperator extends ScalarOperator implements Comparable
                     throw new SemanticException("Forbidden cast to decimal(precision=0, scale=0)");
                 }
             } catch (AnalysisException e) {
-                throw e;
-                //return ConstantOperator.createNull(desc);
+                return ConstantOperator.createNull(desc);
             }
 
             return ConstantOperator.createDecimal(decimal, desc);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
@@ -379,25 +379,20 @@ public final class ConstantOperator extends ScalarOperator implements Comparable
             return ConstantOperator.createDecimal(BigDecimal.valueOf(Double.parseDouble(childString)), Type.DECIMALV2);
         } else if (desc.isDecimalV3()) {
             BigDecimal decimal = new BigDecimal(childString);
+            ScalarType scalarType = (ScalarType) desc;
             try {
-                ScalarType scalarType = (ScalarType) desc;
-                try {
-                    DecimalLiteral.checkLiteralOverflow(decimal, scalarType);
-                } catch (AnalysisException ignored) {
-                    return ConstantOperator.createNull(desc);
-                }
-                int realScale = DecimalLiteral.getRealScale(decimal);
-                int scale = scalarType.getScalarScale();
-                if (scale <= realScale) {
-                    decimal = decimal.setScale(scale, RoundingMode.HALF_UP);
-                }
+                DecimalLiteral.checkLiteralOverflow(decimal, scalarType);
+            } catch (AnalysisException ignored) {
+                return ConstantOperator.createNull(desc);
+            }
+            int realScale = DecimalLiteral.getRealScale(decimal);
+            int scale = scalarType.getScalarScale();
+            if (scale <= realScale) {
+                decimal = decimal.setScale(scale, RoundingMode.HALF_UP);
+            }
 
-                if (scalarType.getScalarScale() == 0 && scalarType.getScalarPrecision() == 0) {
-                    throw new SemanticException("Forbidden cast to decimal(precision=0, scale=0)");
-                }
-            } catch (Exception e) {
-                throw e;
-                //return ConstantOperator.createNull(desc);
+            if (scalarType.getScalarScale() == 0 && scalarType.getScalarPrecision() == 0) {
+                throw new SemanticException("Forbidden cast to decimal(precision=0, scale=0)");
             }
 
             return ConstantOperator.createDecimal(decimal, desc);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRule.java
@@ -7,6 +7,7 @@ import com.starrocks.catalog.Type;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriteContext;
 
@@ -68,9 +69,15 @@ public class ReduceCastRule extends TopDownScalarOperatorRewriteRule {
 
         ScalarOperator castChild = child1.getChild(0);
 
-        // Cast is allowed to change the precision in Decimal, so it should not be allowed to eliminate Cast
-        if (castChild.getType().isDecimalOfAnyVersion()) {
-            return operator;
+        // BinaryPredicate involving Decimal
+        if (castChild.getType().isDecimalOfAnyVersion()
+                || child1.getType().isDecimalOfAnyVersion()
+                || child2.getType().isDecimalOfAnyVersion()) {
+            Optional<ScalarOperator> resultChild2 =
+                    Utils.tryDecimalCastConstant((CastOperator) child1, (ConstantOperator) child2);
+            return resultChild2
+                    .map(scalarOperator -> new BinaryPredicateOperator(operator.getBinaryType(), castChild, scalarOperator))
+                    .orElse(operator);
         }
 
         if (!(castChild.getType().isNumericType() && child2.getType().isNumericType())) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/ScalarOperatorToExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/ScalarOperatorToExpr.java
@@ -47,6 +47,8 @@ import com.starrocks.sql.optimizer.operator.scalar.PredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
 import com.starrocks.thrift.TExprOpcode;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.time.LocalDateTime;
 import java.util.HashMap;
@@ -55,6 +57,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 public class ScalarOperatorToExpr {
+    private static final Logger LOG = LogManager.getLogger(ScalarOperatorToExpr.class);
     public static Expr buildExecExpression(ScalarOperator expression, FormatterContext descTbl) {
         return expression.accept(new Formatter(), descTbl);
     }
@@ -407,6 +410,7 @@ public class ScalarOperatorToExpr {
         @Override
         public Expr visitCastOperator(CastOperator operator, FormatterContext context) {
             CastExpr expr = new CastExpr(operator.getType(), buildExecExpression(operator.getChild(0), context));
+            LOG.warn(String.format("[SATANSON] castExpr=%s", expr.toSql()));
             expr.setImplicit(context.implicitCast);
             return expr;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/ScalarOperatorToExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/ScalarOperatorToExpr.java
@@ -410,7 +410,6 @@ public class ScalarOperatorToExpr {
         @Override
         public Expr visitCastOperator(CastOperator operator, FormatterContext context) {
             CastExpr expr = new CastExpr(operator.getType(), buildExecExpression(operator.getChild(0), context));
-            LOG.warn(String.format("[SATANSON] castExpr=%s", expr.toSql()));
             expr.setImplicit(context.implicitCast);
             return expr;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRuleTest.java
@@ -2,13 +2,20 @@
 
 package com.starrocks.sql.optimizer.rewrite.scalar;
 
+import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Type;
 import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriteRule;
+import javassist.expr.Cast;
+import org.junit.Assert;
 import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -60,5 +67,75 @@ public class ReduceCastRuleTest {
 
         assertTrue(result.getType().isChar());
         assertEquals(OperatorType.CONSTANT, result.getOpType());
+    }
+
+    private ConstantOperator createConstOperatorFromType(Type type) {
+        if (type.isTinyint()) {
+            return ConstantOperator.createTinyInt(Byte.MAX_VALUE);
+        }
+        if (type.isSmallint()) {
+            return ConstantOperator.createSmallInt(Short.MAX_VALUE);
+        }
+        if (type.isInt()) {
+            return ConstantOperator.createInt(Integer.MAX_VALUE);
+        }
+        if (type.isBigint()) {
+            return ConstantOperator.createBigint(Long.MAX_VALUE);
+        }
+        if (type.isLargeint()) {
+            return ConstantOperator.createLargeInt(BigInteger.ONE);
+        }
+        if (type.isDecimalV3()) {
+            return ConstantOperator.createDecimal(BigDecimal.ONE, type);
+        }
+        return ConstantOperator.createNull(type);
+    }
+
+    @Test
+    public void testBinaryPredicateInvolvingDecimalSuccess() {
+        Type[][] typeListList = new Type[][]{
+                {Type.TINYINT, Type.SMALLINT, ScalarType.createDecimalV3NarrowestType(16,9)},
+                {Type.TINYINT, Type.SMALLINT, ScalarType.createDecimalV3NarrowestType(9,0)},
+                {ScalarType.createDecimalV3NarrowestType(4,0), Type.SMALLINT, Type.BIGINT},
+                {ScalarType.createDecimalV3NarrowestType(18, 0), Type.BIGINT, Type.LARGEINT},
+                {ScalarType.createDecimalV3NarrowestType(2, 0), Type.TINYINT, Type.INT},
+        };
+
+        ScalarOperatorRewriteRule reduceCastRule = new ReduceCastRule();
+        ScalarOperatorRewriteRule foldConstantsRule = new FoldConstantsRule();
+        for (Type[] types : typeListList) {
+            ScalarOperator binPredRhs = createConstOperatorFromType(types[0]);
+            ScalarOperator castChild = createConstOperatorFromType(types[1]);
+            CastOperator binPredLhs = new CastOperator(types[2], castChild);
+            BinaryPredicateOperator binPred = new BinaryPredicateOperator(
+                    BinaryPredicateOperator.BinaryType.GE, binPredLhs, binPredRhs);
+            ScalarOperator result = reduceCastRule.apply(binPred, null);
+            result = foldConstantsRule.apply(result, null);
+            Assert.assertTrue(result instanceof ConstantOperator);
+        }
+    }
+
+    @Test
+    public void testBinaryPredicateInvolvingDecimalFail() {
+        Type[][] typeListList = new Type[][]{
+                {Type.TINYINT, Type.SMALLINT, ScalarType.createDecimalV3NarrowestType(13,9)},
+                {Type.INT, Type.SMALLINT, ScalarType.createDecimalV3NarrowestType(9,0)},
+                {ScalarType.createDecimalV3NarrowestType(6,0), Type.SMALLINT, Type.BIGINT},
+                {ScalarType.createDecimalV3NarrowestType(19, 0), Type.BIGINT, Type.LARGEINT},
+                {ScalarType.createDecimalV3NarrowestType(10, 0), Type.TINYINT, Type.INT},
+        };
+
+        ScalarOperatorRewriteRule reduceCastRule = new ReduceCastRule();
+        ScalarOperatorRewriteRule foldConstantsRule = new FoldConstantsRule();
+        for (Type[] types : typeListList) {
+            ScalarOperator binPredRhs = createConstOperatorFromType(types[0]);
+            ScalarOperator castChild = createConstOperatorFromType(types[1]);
+            CastOperator binPredLhs = new CastOperator(types[2], castChild);
+            BinaryPredicateOperator binPred = new BinaryPredicateOperator(
+                    BinaryPredicateOperator.BinaryType.GE, binPredLhs, binPredRhs);
+            ScalarOperator result = reduceCastRule.apply(binPred, null);
+            result = foldConstantsRule.apply(result, null);
+            Assert.assertTrue(!(result instanceof ConstantOperator));
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/CastExprPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/CastExprPruneTest.java
@@ -1,0 +1,73 @@
+package com.starrocks.sql.plan;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class CastExprPruneTest extends PlanTestBase {
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+        starRocksAssert.withTable("CREATE TABLE tab0 (" +
+                "c_0_0 DECIMAL(26, 2) NOT NULL ," +
+                "c_0_1 DECIMAL128(19, 3) NOT NULL ," +
+                "c_0_2 DECIMAL128(4, 3) NULL ," +
+                "c_0_3 BOOLEAN NOT NULL ," +
+                "c_0_4 DECIMAL128(25, 19) NOT NULL ," +
+                "c_0_5 BOOLEAN REPLACE NOT NULL ," +
+                "c_0_6 DECIMAL32(8, 5) MIN NULL ," +
+                "c_0_7 BOOLEAN REPLACE NULL ," +
+                "c_0_8 PERCENTILE PERCENTILE_UNION NULL ," +
+                "c_0_9 LARGEINT SUM NULL ," +
+                "c_0_10 PERCENTILE PERCENTILE_UNION NOT NULL ," +
+                "c_0_11 BITMAP BITMAP_UNION NULL ," +
+                "c_0_12 HLL HLL_UNION NOT NULL ," +
+                "c_0_13 DECIMAL(16, 3) MIN NULL ," +
+                "c_0_14 DECIMAL128(18, 6) MAX NOT NULL " +
+                ") AGGREGATE KEY (c_0_0,c_0_1,c_0_2,c_0_3,c_0_4) " +
+                "DISTRIBUTED BY HASH (c_0_3,c_0_0,c_0_2) " +
+                "properties(\"replication_num\"=\"1\") ;");
+
+        starRocksAssert.withTable("CREATE TABLE IF NOT EXISTS tab1 (" +
+                "c_1_0 DECIMAL64(9, 9) NULL ," +
+                "c_1_1 CHAR(1) NOT NULL ," +
+                "c_1_2 DECIMAL32(5, 4) NOT NULL ," +
+                "c_1_3 DECIMAL32(4, 0) NOT NULL ," +
+                "c_1_4 CHAR(11) NOT NULL ," +
+                "c_1_5 DATE NOT NULL ," +
+                "c_1_6 DECIMAL128(20, 5) NULL ) " +
+                "UNIQUE KEY (c_1_0,c_1_1) " +
+                "DISTRIBUTED BY HASH (c_1_0) " +
+                "properties(\"replication_num\"=\"1\") ;");
+
+        starRocksAssert.withTable("CREATE TABLE tab2 (" +
+                "c_2_0 BOOLEAN NULL ) " +
+                "AGGREGATE KEY (c_2_0) " +
+                "DISTRIBUTED BY HASH (c_2_0) " +
+                "properties(\"replication_num\"=\"1\") ;");
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        PlanTestBase.tearDown();
+    }
+
+    @Test
+    public void testQuery() throws Exception {
+        String sql = "SELECT DISTINCT subt2.c_2_0 FROM tab0, " +
+                "(SELECT tab2.c_2_0 FROM tab2 " +
+                "WHERE ( ( tab2.c_2_0 ) = ( true ) ) < ( ((tab2.c_2_0) IN (false) ) BETWEEN (tab2.c_2_0) AND (tab2.c_2_0) ) ) subt2" +
+                " FULL OUTER JOIN (SELECT tab1.c_1_0, tab1.c_1_1, tab1.c_1_2, tab1.c_1_3, tab1.c_1_4, tab1.c_1_5, tab1.c_1_6 FROM tab1 " +
+                " ORDER BY tab1.c_1_4, tab1.c_1_2) subt1 ON subt2.c_2_0 = subt1.c_1_2 AND (6453) IN (4861, 4302) < subt1.c_1_2 " +
+                " AND subt2.c_2_0 != subt1.c_1_1 AND subt2.c_2_0 <= subt1.c_1_1 AND subt2.c_2_0 > subt1.c_1_0 AND subt2.c_2_0 = subt1.c_1_0 " +
+                " WHERE (((0.00) BETWEEN (CASE WHEN (subt1.c_1_5) BETWEEN (subt1.c_1_5) AND (subt1.c_1_5) THEN CAST(151971657 AS DECIMAL32 ) " +
+                " WHEN false THEN CASE WHEN NULL THEN 0.03 ELSE 0.02 END ELSE 0.04 END) AND (0.04) ) IS NULL)";
+        String explain = getFragmentPlan(sql);
+        String snippet = "  6:OlapScanNode\n" +
+                "     TABLE: tab1\n" +
+                "     PREAGGREGATION: OFF. Reason: Has can not pre-aggregation Join\n" +
+                "     PREDICATES: CAST(151971657 AS DECIMAL32(9,9)) <= 0 IS NULL";
+        Assert.assertTrue(explain.contains(snippet));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/CastExprPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/CastExprPruneTest.java
@@ -64,10 +64,18 @@ public class CastExprPruneTest extends PlanTestBase {
                 " WHERE (((0.00) BETWEEN (CASE WHEN (subt1.c_1_5) BETWEEN (subt1.c_1_5) AND (subt1.c_1_5) THEN CAST(151971657 AS DECIMAL32 ) " +
                 " WHEN false THEN CASE WHEN NULL THEN 0.03 ELSE 0.02 END ELSE 0.04 END) AND (0.04) ) IS NULL)";
         String explain = getFragmentPlan(sql);
-        String snippet = "  6:OlapScanNode\n" +
+        String snippet = "  0:OlapScanNode\n" +
                 "     TABLE: tab1\n" +
-                "     PREAGGREGATION: OFF. Reason: Has can not pre-aggregation Join\n" +
-                "     PREDICATES: CAST(151971657 AS DECIMAL32(9,9)) <= 0 IS NULL";
+                "     PREAGGREGATION: OFF. Reason: None aggregate function\n" +
+                "     PREDICATES: TRUE\n" +
+                "     partitions=0/1\n" +
+                "     rollup: tab1\n" +
+                "     tabletRatio=0/0\n" +
+                "     tabletList=\n" +
+                "     cardinality=1\n" +
+                "     avgRowSize=3.0\n" +
+                "     numNodes=0";
+        System.out.println(explain);
         Assert.assertTrue(explain.contains(snippet));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConstantExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConstantExpressionTest.java
@@ -131,6 +131,17 @@ public class ConstantExpressionTest {
     }
 
     @Test
+    public void testCastToDecimalLiteral() throws Exception {
+        testFragmentPlanContainsConstExpr(
+                "select cast(151971657 as decimal32);",
+                "NULL");
+
+        testFragmentPlanContainsConstExpr(
+                "select cast('0.5' as decimal32);",
+                "0.5");
+    }
+
+    @Test
     public void testArithmetic() throws Exception {
         testFragmentPlanContainsConstExpr(
                 "select 1 + 10;",


### PR DESCRIPTION
https://github.com/StarRocks/starrocks/issues/2721

ReduceCastRule behaves incorrectly when it apply to cast(1000000(int) as DECIMAL32(9,9)) <= 0(int), it reduces this binary predicate to 1000000<= 0. because cast(1000000(int) as DECIMAL32(9,9)) overflows and NULL is generated, so the final result should be NULL.

so tryDecimalCastConstant function is added to process BinaryPredicate involves decimal types in ReduceCastRule.

tryDecimalCastConstant is employed by ReduceCastRule to reduce BinaryPredicateOperator involving DecimalV3 ReduceCastRule try to reduce `CAST(Expr<T> as U) BINOP LITERAL<S>` to `EXPR<T> BINOP CAST(LITERAL<S> as T>`, only T->U casting and S->T casting are both legal, then this reduction is legal, so for numerical types, S is not wider than T and T is not wider than U, that is to say, U should is assignable to T, T is assignable to S losslessly.

for examples:
   1. CAST(IntLiteral(100,TINYINT) as DECIMAL32(9,9)) < IntLiteral(0x10000, SMALLINT) cannot be reduced.
   2. CAST(IntLiteral(100,SMALLINT) as DECIMAL64(13,10)) < IntLiteral(101, TINYINT) can be reduced.