### PR TITLE
Optimize the expression converter for better scan planning in iceberg

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -123,6 +123,7 @@ public class FunctionSet {
 
     // string functions
     public static final String SUBSTRING = "substring";
+    public static final String STARTS_WITH = "starts_with";
 
     // geo functions
     public static final String ST_ASTEXT = "st_astext";

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -196,8 +196,6 @@ public class IcebergTable extends Table {
                 return primitiveType == PrimitiveType.INT ||
                         primitiveType == PrimitiveType.TINYINT ||
                         primitiveType == PrimitiveType.SMALLINT;
-            case TIME:
-            case TIMESTAMP:
             case LONG:
                 return primitiveType == PrimitiveType.BIGINT;
             case FLOAT:
@@ -205,8 +203,9 @@ public class IcebergTable extends Table {
             case DOUBLE:
                 return primitiveType == PrimitiveType.DOUBLE;
             case DATE:
-                return primitiveType == PrimitiveType.DATE ||
-                        primitiveType == PrimitiveType.DATETIME;
+                return primitiveType == PrimitiveType.DATE;
+            case TIMESTAMP:
+                return primitiveType == PrimitiveType.DATETIME;
             case STRING:
             case UUID:
                 return primitiveType == PrimitiveType.VARCHAR ||
@@ -216,6 +215,7 @@ public class IcebergTable extends Table {
                         primitiveType == PrimitiveType.DECIMAL32 ||
                         primitiveType == PrimitiveType.DECIMAL64 ||
                         primitiveType == PrimitiveType.DECIMAL128;
+            case TIME:
             case FIXED:
             case BINARY:
             case STRUCT:

--- a/fe/fe-core/src/main/java/com/starrocks/external/iceberg/ExpressionConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/iceberg/ExpressionConverter.java
@@ -4,110 +4,252 @@ package com.starrocks.external.iceberg;
 
 import com.starrocks.analysis.BinaryPredicate;
 import com.starrocks.analysis.BoolLiteral;
+import com.starrocks.analysis.CastExpr;
+import com.starrocks.analysis.CompoundPredicate;
 import com.starrocks.analysis.DateLiteral;
 import com.starrocks.analysis.DecimalLiteral;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FloatLiteral;
+import com.starrocks.analysis.FunctionCallExpr;
+import com.starrocks.analysis.InPredicate;
 import com.starrocks.analysis.IntLiteral;
+import com.starrocks.analysis.IsNullPredicate;
+import com.starrocks.analysis.LikePredicate;
 import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.analysis.SlotRef;
 import com.starrocks.analysis.StringLiteral;
-import org.apache.iceberg.expressions.Expression.Operation;
-import org.apache.iceberg.expressions.Expressions;
-import org.apache.iceberg.expressions.UnboundPredicate;
+import com.starrocks.catalog.FunctionSet;
+import com.starrocks.sql.ast.AstVisitor;
+import org.apache.iceberg.expressions.Expression;
 
-public class ExpressionConverter {
+import java.util.ArrayList;
+import java.util.List;
 
-    public static UnboundPredicate toIcebergExpression(Expr expr) {
-        if (!(expr instanceof BinaryPredicate)) {
+import static org.apache.iceberg.expressions.Expressions.and;
+import static org.apache.iceberg.expressions.Expressions.equal;
+import static org.apache.iceberg.expressions.Expressions.greaterThan;
+import static org.apache.iceberg.expressions.Expressions.greaterThanOrEqual;
+import static org.apache.iceberg.expressions.Expressions.in;
+import static org.apache.iceberg.expressions.Expressions.isNull;
+import static org.apache.iceberg.expressions.Expressions.lessThan;
+import static org.apache.iceberg.expressions.Expressions.lessThanOrEqual;
+import static org.apache.iceberg.expressions.Expressions.not;
+import static org.apache.iceberg.expressions.Expressions.notEqual;
+import static org.apache.iceberg.expressions.Expressions.notIn;
+import static org.apache.iceberg.expressions.Expressions.notNull;
+import static org.apache.iceberg.expressions.Expressions.or;
+import static org.apache.iceberg.expressions.Expressions.startsWith;
+
+/**
+ * Expressions currently supported in Iceberg, maps to StarRocks:
+ *
+ * Supported predicate expressions are:
+ *   isNull ->IsNullPredicate(..., false)
+ *   notNull ->IsNullPredicate(..., true)
+ *   equal -> BinaryPredicate(BinaryPredicate.Operator.EQ, ..., ...)
+ *   notEqual -> BinaryPredicate(BinaryPredicate.Operator.NE, ..., ...)
+ *   lessThan -> BinaryPredicate(BinaryPredicate.Operator.LT, ..., ...)
+ *   lessThanOrEqual -> BinaryPredicate(BinaryPredicate.Operator.LE, ..., ...)
+ *   greaterThan -> BinaryPredicate(BinaryPredicate.Operator.GT, ..., ...)
+ *   greaterThanOrEqual -> BinaryPredicate(BinaryPredicate.Operator.GE, ..., ...)
+ *   in -> InPredicate(..., ..., false)
+ *   notIn -> InPredicate(..., ..., true)
+ *   startsWith -> FunctionCallExpr("starts_with", ...) or LikePredicate(Operator.LIKE, ..., "prefix%")
+ *
+ * Supported expression operations are:
+ *   and -> CompoundPredicate(and, ..., ...)
+ *   or -> CompoundPredicate(or, ..., ...)
+ *   not -> CompoundPredicate(not, ...)
+ *
+ * Constant expressions are(Automatically merged in StarRocks, can be ignored):
+ *   alwaysTrue
+ *   alwaysFalse
+ */
+public class ExpressionConverter extends AstVisitor<Expression, Void> {
+
+    public Expression convert(Expr expr) {
+        if (expr == null) {
             return null;
         }
+        return visit(expr);
+    }
 
-        BinaryPredicate predicate = (BinaryPredicate) expr;
-        Operation op = getIcebergOperator(predicate.getOp());
-        if (op == null) {
-            return null;
-        }
-
-        if (!(predicate.getChild(0) instanceof SlotRef)) {
-            return null;
-        }
-        SlotRef ref = (SlotRef) predicate.getChild(0);
-
-        if (!(predicate.getChild(1) instanceof LiteralExpr)) {
-            return null;
-        }
-        LiteralExpr literal = (LiteralExpr) predicate.getChild(1);
-
-        String colName = ref.getDesc().getColumn().getName();
-        UnboundPredicate unboundPredicate = null;
-        switch (literal.getType().getPrimitiveType()) {
-            case BOOLEAN: {
-                unboundPredicate = Expressions.predicate(op, colName,
-                        ((BoolLiteral) literal).getValue());
-                break;
+    @Override
+    public Expression visitCompoundPredicate(CompoundPredicate node, Void context) {
+        CompoundPredicate.Operator op = node.getOp();
+        if (op == CompoundPredicate.Operator.NOT) {
+            if (node.getChild(0) instanceof FunctionCallExpr ||
+                    node.getChild(0) instanceof LikePredicate) {
+                // TODO: No negation for operation: STARTS_WITH in the Apache Iceberg 0.12.1
+                return null;
             }
+            Expression expression = node.getChild(0).accept(this, null);
+            if (expression != null) {
+                return not(expression);
+            }
+        } else {
+            Expression left = node.getChild(0).accept(this, null);
+            Expression right = node.getChild(1).accept(this, null);
+            if (left != null && right != null) {
+                return (op == CompoundPredicate.Operator.OR) ? or(left, right) : and(left, right);
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public Expression visitIsNullPredicate(IsNullPredicate node, Void context) {
+        String columnName = getColumnName(node.getChild(0));
+        if (columnName == null) {
+            return null;
+        }
+        if (node.isNotNull()) {
+            return notNull(columnName);
+        } else {
+            return isNull(columnName);
+        }
+    }
+
+    @Override
+    public Expression visitBinaryPredicate(BinaryPredicate node, Void context) {
+        String columnName = getColumnName(node.getChild(0));
+        if (columnName == null) {
+            return null;
+        }
+        Object literalValue = getLiteralValue(node.getChild(1));
+        if (literalValue == null) {
+            return null;
+        }
+        switch (node.getOp()) {
+            case LT:
+                return lessThan(columnName, literalValue);
+            case LE:
+                return lessThanOrEqual(columnName, literalValue);
+            case GT:
+                return greaterThan(columnName, literalValue);
+            case GE:
+                return greaterThanOrEqual(columnName, literalValue);
+            case EQ:
+                return equal(columnName, literalValue);
+            case NE:
+                return notEqual(columnName, literalValue);
+            default:
+                return null;
+        }
+    }
+
+    @Override
+    public Expression visitInPredicate(InPredicate node, Void context) {
+        String columnName = getColumnName(node.getChild(0));
+        if (columnName == null) {
+            return null;
+        }
+        List<Expr> valuesExprList = node.getListChildren();
+        List<Object> literalValues = new ArrayList<>(valuesExprList.size());
+        for (Expr valueExpr : valuesExprList) {
+            Object value = getLiteralValue(valueExpr);
+            if (value == null) {
+                return null;
+            }
+            literalValues.add(value);
+        }
+        if (node.isNotIn()) {
+            return notIn(columnName, literalValues);
+        }  else {
+            return in(columnName, literalValues);
+        }
+    }
+
+    @Override
+    public Expression visitFunctionCall(FunctionCallExpr node, Void context) {
+        String columnName = getColumnName(node.getChild(0));
+        if (columnName == null) {
+            return null;
+        }
+        if (!node.getFnName().getFunction().equalsIgnoreCase(FunctionSet.STARTS_WITH)) {
+            return null;
+        }
+        if (node.getChild(1) instanceof StringLiteral) {
+            StringLiteral stringLiteral = (StringLiteral) node.getChild(1);
+            return startsWith(columnName, stringLiteral.getStringValue());
+        }
+        return null;
+    }
+
+    @Override
+    public Expression visitLikePredicate(LikePredicate node, Void context) {
+        String columnName = getColumnName(node.getChild(0));
+        if (columnName == null) {
+            return null;
+        }
+        if (node.getOp().equals(LikePredicate.Operator.LIKE)) {
+            if (node.getChild(1) instanceof StringLiteral) {
+                StringLiteral stringLiteral = (StringLiteral) node.getChild(1);
+                String literal = stringLiteral.getUnescapedValue();
+                if (literal.indexOf("%") == literal.length() - 1) {
+                    return startsWith(columnName, literal.substring(0, literal.length() - 1));
+                }
+            }
+        }
+        return null;
+    }
+
+    private static Object getLiteralValue(Expr expr) {
+        if (expr == null || !(expr instanceof LiteralExpr)) {
+            return null;
+        }
+        LiteralExpr literalExpr = (LiteralExpr) expr;
+        switch (literalExpr.getType().getPrimitiveType()) {
+            case BOOLEAN:
+                return ((BoolLiteral) literalExpr).getValue();
             case TINYINT:
             case SMALLINT:
-            case INT: {
-                unboundPredicate = Expressions.predicate(op, colName,
-                        (int) ((IntLiteral) literal).getValue());
-                break;
-            }
-            case BIGINT: {
-                unboundPredicate = Expressions.predicate(op, colName,
-                        ((IntLiteral) literal).getValue());
-                break;
-            }
-            case FLOAT: {
-                unboundPredicate = Expressions.predicate(op, colName,
-                        (float) ((FloatLiteral) literal).getValue());
-                break;
-            }
-            case DOUBLE: {
-                unboundPredicate = Expressions.predicate(op, colName,
-                        ((FloatLiteral) literal).getValue());
-                break;
-            }
+            case INT:
+                return (int) ((IntLiteral) literalExpr).getValue();
+            case BIGINT:
+                return ((IntLiteral) literalExpr).getValue();
+            case FLOAT:
+                return (float) ((FloatLiteral) literalExpr).getValue();
+            case DOUBLE:
+                return ((FloatLiteral) literalExpr).getValue();
             case DECIMALV2:
             case DECIMAL32:
             case DECIMAL64:
-            case DECIMAL128: {
-                unboundPredicate = Expressions.predicate(op, colName,
-                        ((DecimalLiteral) literal).getValue());
-                break;
-            }
+            case DECIMAL128:
+                return ((DecimalLiteral) literalExpr).getValue();
             case HLL:
             case VARCHAR:
-            case CHAR: {
-                unboundPredicate = Expressions.predicate(op, colName,
-                        ((StringLiteral) literal).getUnescapedValue());
-                break;
-            }
-            case DATE: {
-                unboundPredicate = Expressions.predicate(op, colName,
-                        Math.toIntExact(((DateLiteral) literal).toLocalDateTime()
-                                .toLocalDate().toEpochDay()));
-                break;
-            }
+            case CHAR:
+                return ((StringLiteral) literalExpr).getUnescapedValue();
+            case DATE:
+                return Math.toIntExact(((DateLiteral) literalExpr).toLocalDateTime().toLocalDate().toEpochDay());
             case DATETIME:
+                return ((DateLiteral) literalExpr).toLocalDateTime().toLocalDate().toEpochDay();
             default:
-                break;
+                return null;
         }
-
-        return unboundPredicate;
     }
 
-    private static Operation getIcebergOperator(BinaryPredicate.Operator op) {
-        switch (op) {
-            case EQ: return Operation.EQ;
-            case NE: return Operation.NOT_EQ;
-            case LE: return Operation.LT_EQ;
-            case GE: return Operation.GT_EQ;
-            case LT: return Operation.LT;
-            case GT: return Operation.GT;
-            case EQ_FOR_NULL: return Operation.IS_NULL;
-            default: return null;
+    private static String getColumnName(Expr expr) {
+        if (expr == null) {
+            return null;
+        }
+        String columnName = new ExtractColumnName().visit(expr, null);
+        if (columnName == null || columnName.isEmpty()) {
+            return null;
+        }
+        return columnName;
+    }
+
+    private static class ExtractColumnName extends AstVisitor<String, Void> {
+        @Override
+        public String visitCastExpr(CastExpr node, Void context) {
+            return node.getChild(0).accept(this, null);
+        }
+
+        @Override
+        public String visitSlot(SlotRef node, Void context) {
+            return node.getColumn().getName();
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/external/iceberg/IcebergUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/iceberg/IcebergUtil.java
@@ -11,7 +11,8 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.TableScan;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.NoSuchTableException;
-import org.apache.iceberg.expressions.UnboundPredicate;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
 
 import java.util.List;
 import java.util.Optional;
@@ -94,17 +95,19 @@ public class IcebergUtil {
      */
     public static TableScan getTableScan(Table table,
                                          Snapshot snapshot,
-                                         List<UnboundPredicate> icebergPredicates,
+                                         List<Expression> icebergPredicates,
                                          boolean refresh) {
         if (refresh) {
             refreshTable(table);
         }
 
         TableScan tableScan = table.newScan().useSnapshot(snapshot.snapshotId()).includeColumnStats();
-        for (UnboundPredicate predicate : icebergPredicates) {
-            tableScan = tableScan.filter(predicate);
+        Expression filterExpressions = Expressions.alwaysTrue();
+        if (!icebergPredicates.isEmpty()) {
+            filterExpressions = icebergPredicates.stream().reduce(Expressions.alwaysTrue(), Expressions::and);
         }
-        return tableScan;
+
+        return tableScan.filter(filterExpressions);
     }
 
     private static void refreshTable(Table table) {

--- a/fe/fe-core/src/test/java/com/starrocks/external/iceberg/ExpressionConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/external/iceberg/ExpressionConverterTest.java
@@ -2,25 +2,26 @@
 
 package com.starrocks.external.iceberg;
 
+import com.google.common.collect.Lists;
 import com.starrocks.analysis.*;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import mockit.Expectations;
 import mockit.Mocked;
-import org.apache.iceberg.expressions.UnboundPredicate;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 public class ExpressionConverterTest {
 
-    @Mocked
-    private Expr expr;
-
-    @Mocked
-    private SlotRef ref;
-
     @Mocked Column col;
+
+    @Mocked SlotDescriptor desc;
 
     @Test
     public void testToIcebergExpression() throws AnalysisException {
@@ -28,33 +29,122 @@ public class ExpressionConverterTest {
             {
                 col.getName();
                 result = "col_name";
+                desc.getColumn();
             }
         };
 
-        UnboundPredicate unboundPredicate;
+        Expression convertedExpression = null;
+        Expression expectedExpression = null;
+        ExpressionConverter converter = new ExpressionConverter();
+        SlotRef ref = new SlotRef(desc);
 
-        expr = new BinaryPredicate(BinaryPredicate.Operator.EQ, ref, LiteralExpr.create("test", Type.VARCHAR));
-        unboundPredicate = ExpressionConverter.toIcebergExpression(expr);
-        Assert.assertTrue(unboundPredicate.literal().getClass().toString().contains("org.apache.iceberg.expressions.Literals$StringLiteral"));
+        // isNull
+        convertedExpression = converter.convert(new IsNullPredicate(ref, false));
+        expectedExpression = Expressions.isNull("col_name");
+        Assert.assertEquals("Generated isNull expression should be correct",
+                expectedExpression.toString(), convertedExpression.toString());
 
-        expr = new BinaryPredicate(BinaryPredicate.Operator.EQ, ref, LiteralExpr.create("true", Type.BOOLEAN));
-        unboundPredicate = ExpressionConverter.toIcebergExpression(expr);
-        Assert.assertTrue(unboundPredicate.literal().getClass().toString().contains("org.apache.iceberg.expressions.Literals$BooleanLiteral"));
+        // notNull
+        convertedExpression = converter.convert(new IsNullPredicate(ref, true));
+        expectedExpression = Expressions.notNull("col_name");
+        Assert.assertEquals("Generated notNull expression should be correct",
+                expectedExpression.toString(), convertedExpression.toString());
 
-        expr = new BinaryPredicate(BinaryPredicate.Operator.EQ, ref, LiteralExpr.create("111", Type.INT));
-        unboundPredicate = ExpressionConverter.toIcebergExpression(expr);
-        Assert.assertTrue(unboundPredicate.literal().getClass().toString().contains("org.apache.iceberg.expressions.Literals$IntegerLiteral"));
+        // equal
+        DateLiteral dateLiteral = (DateLiteral) LiteralExpr.create("2018-10-18", Type.DATE);
+        long epochDay = dateLiteral.toLocalDateTime().toLocalDate().toEpochDay();
 
-        expr = new BinaryPredicate(BinaryPredicate.Operator.EQ, ref, LiteralExpr.create("111.22", Type.FLOAT));
-        unboundPredicate = ExpressionConverter.toIcebergExpression(expr);
-        Assert.assertTrue(unboundPredicate.literal().getClass().toString().contains("org.apache.iceberg.expressions.Literals$DoubleLiteral"));
+        convertedExpression= converter.convert(new BinaryPredicate(BinaryPredicate.Operator.EQ, ref, dateLiteral));
+        expectedExpression = Expressions.equal("col_name", epochDay);
+        Assert.assertEquals("Generated equal expression should be correct",
+                expectedExpression.toString(), convertedExpression.toString());
 
-        expr = new BinaryPredicate(BinaryPredicate.Operator.EQ, ref, LiteralExpr.create("111.22", Type.DECIMALV2));
-        unboundPredicate = ExpressionConverter.toIcebergExpression(expr);
-        Assert.assertTrue(unboundPredicate.literal().getClass().toString().contains("org.apache.iceberg.expressions.Literals$DecimalLiteral"));
+        // notEqual
+        BoolLiteral boolLiteral = (BoolLiteral) BoolLiteral.create("true", Type.BOOLEAN);
 
-        expr = new IsNullPredicate(new NullLiteral(), false);
-        unboundPredicate = ExpressionConverter.toIcebergExpression(expr);
-        Assert.assertNull(unboundPredicate);
+        convertedExpression = converter.convert(new BinaryPredicate(BinaryPredicate.Operator.NE, ref, boolLiteral));
+        expectedExpression = Expressions.notEqual("col_name", true);
+        Assert.assertEquals("Generated notEqual expression should be correct",
+                expectedExpression.toString(), convertedExpression.toString());
+
+        // lessThan
+        IntLiteral intLiteral = (IntLiteral) IntLiteral.create("1", Type.INT);
+        int normalInt = (int) intLiteral.getValue();
+
+        convertedExpression = converter.convert(new BinaryPredicate(BinaryPredicate.Operator.LT, ref, intLiteral));
+        expectedExpression = Expressions.lessThan("col_name", normalInt);
+        Assert.assertEquals("Generated lessThan expression should be correct",
+                expectedExpression.toString(), convertedExpression.toString());
+
+        // lessThanOrEqual
+        intLiteral = (IntLiteral) IntLiteral.create("2", Type.SMALLINT);
+        int smallInt = (int) intLiteral.getValue();
+
+        convertedExpression = converter.convert(new BinaryPredicate(BinaryPredicate.Operator.LE, ref, intLiteral));
+        expectedExpression = Expressions.lessThanOrEqual("col_name", smallInt);
+        Assert.assertEquals("Generated lessThanOrEqual expression should be correct",
+                expectedExpression.toString(), convertedExpression.toString());
+
+        // greaterThan
+        intLiteral = (IntLiteral) IntLiteral.create("3", Type.TINYINT);
+        int tinyInt = (int) intLiteral.getValue();
+
+        convertedExpression = converter.convert(new BinaryPredicate(BinaryPredicate.Operator.GT, ref, intLiteral));
+        expectedExpression = Expressions.greaterThan("col_name", tinyInt);
+        Assert.assertEquals("Generated greaterThan expression should be correct",
+                expectedExpression.toString(), convertedExpression.toString());
+
+        // greaterThanOrEqual
+        intLiteral = (IntLiteral) IntLiteral.create("1", Type.BIGINT);
+        long bigInt = intLiteral.getValue();
+
+        convertedExpression = converter.convert(new BinaryPredicate(BinaryPredicate.Operator.GE, ref, intLiteral));
+        expectedExpression = Expressions.greaterThanOrEqual("col_name", bigInt);
+        Assert.assertEquals("Generated greaterThanOrEqual expression should be correct",
+                expectedExpression.toString(), convertedExpression.toString());
+        // in
+        List<Expr> inListExpr = Lists.newArrayList();
+        inListExpr.add(new StringLiteral("1234"));
+        inListExpr.add(new StringLiteral("5678"));
+        inListExpr.add(new StringLiteral("1314"));
+        inListExpr.add(new StringLiteral("8972"));
+        List<String> inList = inListExpr.stream().map(s ->((StringLiteral) s).getUnescapedValue()).collect(Collectors.toList());
+
+        convertedExpression = converter.convert(new InPredicate(ref, inListExpr, false));
+        expectedExpression = Expressions.in("col_name", inList);
+        Assert.assertEquals("Generated in expression should be correct",
+                expectedExpression.toString(), convertedExpression.toString());
+
+        // notIn
+        convertedExpression = converter.convert(new InPredicate(ref, inListExpr, true));
+        expectedExpression = Expressions.notIn("col_name", inList);
+        Assert.assertEquals("Generated notIn expression should be correct",
+                expectedExpression.toString(), convertedExpression.toString());
+
+        // startsWith
+        List<Expr> params = Lists.newArrayList();
+        params.add(0, ref);
+        params.add(new StringLiteral("a"));
+        StringLiteral stringLiteral = (StringLiteral) StringLiteral.create("a%", Type.STRING);
+        expectedExpression = Expressions.startsWith("col_name", "a");
+
+        convertedExpression = converter.convert(new FunctionCallExpr("starts_with", params));
+        Assert.assertEquals("Generated startsWith expression should be correct",
+                expectedExpression.toString(), convertedExpression.toString());
+
+        convertedExpression = converter.convert(new LikePredicate(LikePredicate.Operator.LIKE, ref, stringLiteral));
+        Assert.assertEquals("Generated startsWith expression should be correct",
+                expectedExpression.toString(), convertedExpression.toString());
+
+        // or
+        Expr expr1 = new BinaryPredicate(BinaryPredicate.Operator.GT, ref, IntLiteral.create("10", Type.BIGINT));
+        Expr expr2 = new BinaryPredicate(BinaryPredicate.Operator.LT, ref, IntLiteral.create("5", Type.BIGINT));
+        Expression expression1 = converter.convert(expr1);
+        Expression expression2 = converter.convert(expr2);
+
+        convertedExpression = converter.convert(new CompoundPredicate(CompoundPredicate.Operator.OR, expr1, expr2));
+        expectedExpression = Expressions.or(expression1, expression2);
+        Assert.assertEquals("Generated or expression should be correct",
+                expectedExpression.toString(), convertedExpression.toString());
     }
 }


### PR DESCRIPTION
Extracts predicates from conjuncts that can be pushed down to Iceberg in the IcebergScanNode.

Since Iceberg will filter data files by metadata instead of scan data files,
we pushdown all predicates to Iceberg to get the minimum data files to scan.
Here are three cases for predicate pushdown:
  1. The column is not part of any Iceberg partition expression
  2. The column is part of all partition keys without any transformation (i.e. IDENTITY)
  3. The column is part of all partition keys with transformation (i.e. MONTH/DAY/HOUR)
 
We can use case 1 and 3 to filter data files, but also need to evaluate it in the
scan, for case 2 we don't need to evaluate it in the scan. So we evaluate all
predicates in the scan to keep consistency. More details about Iceberg scanning,
please refer: https://iceberg.apache.org/spec/#scan-planning

### Expressions currently supported in Iceberg, maps to StarRocks:
Supported predicate expressions are:
- isNull ->IsNullPredicate(..., false)
- notNull ->IsNullPredicate(..., true)
- equal -> BinaryPredicate(BinaryPredicate.Operator.EQ, ..., ...)
- notEqual -> BinaryPredicate(BinaryPredicate.Operator.NE, ..., ...)
- lessThan -> BinaryPredicate(BinaryPredicate.Operator.LT, ..., ...)
- lessThanOrEqual -> BinaryPredicate(BinaryPredicate.Operator.LE, ..., ...)
- greaterThan -> BinaryPredicate(BinaryPredicate.Operator.GT, ..., ...)
- greaterThanOrEqual -> BinaryPredicate(BinaryPredicate.Operator.GE, ..., ...)
- in -> InPredicate(..., ..., false)
- notIn -> InPredicate(..., ..., true)
- startsWith -> FunctionCallExpr("starts_with", ...) or LikePredicate(Operator.LIKE, ..., "prefix%")

Supported expression operations are:
- and -> CompoundPredicate(and, ..., ...)
- or -> CompoundPredicate(or, ..., ...)
- not -> CompoundPredicate(not, ...)

Constant expressions are(Automatically merged in starrocks, can be ignored):
- alwaysTrue
- alwaysFalse

@DorianZheng @stephen-shelby 