### PR TITLE
read index don't check mem limit

### DIFF
--- a/be/src/storage/rowset/column_reader.cpp
+++ b/be/src/storage/rowset/column_reader.cpp
@@ -279,6 +279,7 @@ Status ColumnReader::bloom_filter(const std::vector<const vectorized::ColumnPred
 Status ColumnReader::_load_ordinal_index(bool use_page_cache, bool kept_in_memory) {
     Status st;
     if (_flags[kHasOrdinalIndexMetaPos]) {
+        SCOPED_THREAD_LOCAL_CHECK_MEM_LIMIT_SETTER(false);
         std::unique_ptr<OrdinalIndexPB> index_meta(_ordinal_index.meta);
         _flags.set(kHasOrdinalIndexMetaPos, false);
         _mem_tracker->release(index_meta->SpaceUsedLong());
@@ -294,6 +295,7 @@ Status ColumnReader::_load_ordinal_index(bool use_page_cache, bool kept_in_memor
 Status ColumnReader::_load_zone_map_index(bool use_page_cache, bool kept_in_memory) {
     Status st;
     if (_flags[kHasZoneMapIndexMetaPos]) {
+        SCOPED_THREAD_LOCAL_CHECK_MEM_LIMIT_SETTER(false);
         std::unique_ptr<ZoneMapIndexPB> index_meta(_zone_map_index.meta);
         _flags.set(kHasZoneMapIndexMetaPos, false);
         _mem_tracker->release(index_meta->SpaceUsedLong());
@@ -309,6 +311,7 @@ Status ColumnReader::_load_zone_map_index(bool use_page_cache, bool kept_in_memo
 Status ColumnReader::_load_bitmap_index(bool use_page_cache, bool kept_in_memory) {
     Status st;
     if (_flags[kHasBitmapIndexMetaPos]) {
+        SCOPED_THREAD_LOCAL_CHECK_MEM_LIMIT_SETTER(false);
         std::unique_ptr<BitmapIndexPB> index_meta(_bitmap_index.meta);
         _flags.set(kHasBitmapIndexMetaPos, false);
         _mem_tracker->release(index_meta->SpaceUsedLong());
@@ -323,6 +326,7 @@ Status ColumnReader::_load_bitmap_index(bool use_page_cache, bool kept_in_memory
 Status ColumnReader::_load_bloom_filter_index(bool use_page_cache, bool kept_in_memory) {
     Status st;
     if (_flags[kHasBloomFilterIndexMetaPos]) {
+        SCOPED_THREAD_LOCAL_CHECK_MEM_LIMIT_SETTER(false);
         std::unique_ptr<BloomFilterIndexPB> index_meta(_bloom_filter_index.meta);
         _flags.set(kHasBloomFilterIndexMetaPos, false);
         _mem_tracker->release(index_meta->SpaceUsedLong());

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -216,6 +216,7 @@ StatusOr<ChunkIteratorPtr> Segment::new_iterator(const vectorized::Schema& schem
 
 Status Segment::_load_index(MemTracker* mem_tracker) {
     return _load_index_once.call([this, mem_tracker] {
+        SCOPED_THREAD_LOCAL_CHECK_MEM_LIMIT_SETTER(false);
         // read and parse short key index page
         std::unique_ptr<fs::ReadableBlock> rblock;
         RETURN_IF_ERROR(_block_mgr->open_block(_fname, &rblock));

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -69,6 +69,7 @@ Tablet::Tablet(TabletMetaSharedPtr tablet_meta, DataDir* data_dir)
 Tablet::~Tablet() {}
 
 Status Tablet::_init_once_action() {
+    SCOPED_THREAD_LOCAL_CHECK_MEM_LIMIT_SETTER(false);
     VLOG(3) << "begin to load tablet. tablet=" << full_name() << ", version_size=" << _tablet_meta->version_count();
     if (keys_type() == PRIMARY_KEYS) {
         _updates = std::make_unique<TabletUpdates>(*this);


### PR DESCRIPTION
for #2793 

Metadata memory such as the current Index will only be loaded once, and will not be reloaded after failure.

The reason for this change is that the loading process of index is difficult to achieve idempotent, and it may  introduce new problems.