### PR TITLE
Fix hive table can not join reorder

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveColumnStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveColumnStats.java
@@ -84,11 +84,11 @@ public class HiveColumnStats {
 
     public boolean init(String hiveType, ColumnStatisticsData statsData) {
         hiveType = Utils.getTypeKeyword(hiveType);
-        boolean isCompatible = false;
+        boolean isValid = false;
         switch (hiveType.toUpperCase()) {
             case "BOOLEAN":
-                isCompatible = statsData.isSetBooleanStats();
-                if (isCompatible) {
+                isValid = statsData.isSetBooleanStats();
+                if (isValid) {
                     BooleanColumnStatsData boolStats = statsData.getBooleanStats();
                     numNulls = boolStats.getNumNulls();
                     // If we have numNulls, we can infer NDV from that.
@@ -106,8 +106,8 @@ public class HiveColumnStats {
             case "INT":
             case "BIGINT":
             case "TIMESTAMP": // Hive use LongColumnStatsData for timestamps.
-                isCompatible = statsData.isSetLongStats();
-                if (isCompatible) {
+                isValid = statsData.isSetLongStats();
+                if (isValid) {
                     LongColumnStatsData longStats = statsData.getLongStats();
                     numDistinctValues = longStats.getNumDVs();
                     numNulls = longStats.getNumNulls();
@@ -121,8 +121,8 @@ public class HiveColumnStats {
                 break;
             case "FLOAT":
             case "DOUBLE":
-                isCompatible = statsData.isSetDoubleStats();
-                if (isCompatible) {
+                isValid = statsData.isSetDoubleStats();
+                if (isValid) {
                     DoubleColumnStatsData doubleStats = statsData.getDoubleStats();
                     numDistinctValues = doubleStats.getNumDVs();
                     numNulls = doubleStats.getNumNulls();
@@ -135,8 +135,8 @@ public class HiveColumnStats {
                 }
                 break;
             case "DATE":
-                isCompatible = statsData.isSetDateStats();
-                if (isCompatible) {
+                isValid = statsData.isSetDateStats();
+                if (isValid) {
                     DateColumnStatsData dateStats = statsData.getDateStats();
                     numDistinctValues = dateStats.getNumDVs();
                     numNulls = dateStats.getNumNulls();
@@ -151,8 +151,8 @@ public class HiveColumnStats {
             case "CHAR":
             case "VARCHAR":
             case "STRING":
-                isCompatible = statsData.isSetStringStats();
-                if (isCompatible) {
+                isValid = statsData.isSetStringStats();
+                if (isValid) {
                     StringColumnStatsData stringStats = statsData.getStringStats();
                     numDistinctValues = stringStats.getNumDVs();
                     numNulls = stringStats.getNumNulls();
@@ -160,8 +160,8 @@ public class HiveColumnStats {
                 }
                 break;
             case "DECIMAL":
-                isCompatible = statsData.isSetDecimalStats();
-                if (isCompatible) {
+                isValid = statsData.isSetDecimalStats();
+                if (isValid) {
                     DecimalColumnStatsData decimalStats = statsData.getDecimalStats();
                     numNulls = decimalStats.getNumNulls();
                     numDistinctValues = decimalStats.getNumDVs();
@@ -171,10 +171,10 @@ public class HiveColumnStats {
                 LOG.warn("unexpected column type {}", hiveType);
                 break;
         }
-        if (isCompatible) {
+        if (isValid) {
             type = StatisticType.ESTIMATE;
         }
-        return isCompatible;
+        return isValid;
     }
 
     public double getAvgSize() {

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveColumnStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveColumnStats.java
@@ -15,19 +15,24 @@ import org.apache.logging.log4j.Logger;
 public class HiveColumnStats {
     private static final Logger LOG = LogManager.getLogger(HiveColumnStats.class);
 
+    private enum StatisticType {
+        UNKNOWN,
+        ESTIMATE
+    }
+
     // only valid for string type
     private double avgSize = -1.0f;
     private long numNulls = -1L;
     private long numDistinctValues = -1L;
     private double minValue = Double.NEGATIVE_INFINITY;
     private double maxValue = Double.POSITIVE_INFINITY;
+    private StatisticType type = StatisticType.UNKNOWN;
 
     public HiveColumnStats() {
     }
 
-    public boolean isDefaultValue() {
-        return avgSize == -0.1f && numNulls == -1L && numDistinctValues == -1L && minValue == Double.NEGATIVE_INFINITY
-                && maxValue == Double.POSITIVE_INFINITY;
+    public boolean isUnknown() {
+        return this.type == StatisticType.UNKNOWN;
     }
 
     @Override
@@ -165,6 +170,9 @@ public class HiveColumnStats {
             default:
                 LOG.warn("unexpected column type {}", hiveType);
                 break;
+        }
+        if (isCompatible) {
+            type = StatisticType.ESTIMATE;
         }
         return isCompatible;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveColumnStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveColumnStats.java
@@ -25,6 +25,11 @@ public class HiveColumnStats {
     public HiveColumnStats() {
     }
 
+    public boolean isDefaultValue() {
+        return avgSize == -0.1f && numNulls == -1L && numDistinctValues == -1L && minValue == Double.NEGATIVE_INFINITY
+                && maxValue == Double.POSITIVE_INFINITY;
+    }
+
     @Override
     public String toString() {
         return String.format("avgSize: %.2f, numNulls: %d, numDistinctValues: %d, minValue: %.2f, maxValue: %.2f",

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -339,8 +339,7 @@ public class Utils {
                 HiveTable hiveTable = (HiveTable) scanOperator.getTable();
                 try {
                     Map<String, HiveColumnStats> hiveColumnStatisticMap = hiveTable.getTableLevelColumnStats(colNames);
-                    return hiveColumnStatisticMap.entrySet().stream()
-                            .anyMatch(entry -> entry.getValue().isDefaultValue());
+                    return hiveColumnStatisticMap.values().stream().anyMatch(HiveColumnStats::isUnknown);
                 } catch (Exception e) {
                     LOG.warn("hive table {} get column failed. error : {}", hiveTable.getName(), e);
                     return true;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -7,14 +7,17 @@ import com.google.common.collect.Lists;
 import com.starrocks.analysis.JoinOperator;
 import com.starrocks.catalog.Catalog;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.Type;
+import com.starrocks.external.hive.HiveColumnStats;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.logical.LogicalApplyOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalHiveScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOperator;
@@ -26,6 +29,8 @@ import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -36,12 +41,14 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 public class Utils {
+    private static final Logger LOG = LogManager.getLogger(Utils.class);
 
     public static List<ScalarOperator> extractConjuncts(ScalarOperator root) {
         if (null == root) {
@@ -324,10 +331,24 @@ public class Utils {
             List<String> colNames =
                     scanOperator.getColRefToColumnMetaMap().values().stream().map(Column::getName).collect(
                             Collectors.toList());
-
-            List<ColumnStatistic> columnStatisticList =
-                    Catalog.getCurrentStatisticStorage().getColumnStatistics(scanOperator.getTable(), colNames);
-            return columnStatisticList.stream().anyMatch(ColumnStatistic::isUnknown);
+            if (operator instanceof LogicalOlapScanOperator) {
+                List<ColumnStatistic> columnStatisticList =
+                        Catalog.getCurrentStatisticStorage().getColumnStatistics(scanOperator.getTable(), colNames);
+                return columnStatisticList.stream().anyMatch(ColumnStatistic::isUnknown);
+            } else if (operator instanceof LogicalHiveScanOperator) {
+                HiveTable hiveTable = (HiveTable) scanOperator.getTable();
+                try {
+                    Map<String, HiveColumnStats> hiveColumnStatisticMap = hiveTable.getTableLevelColumnStats(colNames);
+                    return hiveColumnStatisticMap.entrySet().stream()
+                            .anyMatch(entry -> entry.getValue().isDefaultValue());
+                } catch (Exception e) {
+                    LOG.warn("hive table {} get column failed. error : {}", hiveTable.getName(), e);
+                    return true;
+                }
+            } else {
+                // For other scan operators, we do not know the column statistics.
+                return true;
+            }
         }
 
         return root.getInputs().stream().anyMatch(Utils::hasUnknownColumnsStats);


### PR DESCRIPTION
For Dp and greedy join reorder，we check the column statistics is unknown firstly. For olap scan and hive scan, there are different column statistcs cache.  we should use hive table columns statistics cache to get it own column statistics