### PR TITLE
Fix join predicate calculate multi times bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/Explain.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/Explain.java
@@ -306,7 +306,7 @@ public class Explain {
             PhysicalHashJoinOperator join = (PhysicalHashJoinOperator) optExpression.getOp();
             StringBuilder sb = new StringBuilder("- ").append(join.getJoinType());
             if (!join.getJoinType().isCrossJoin()) {
-                sb.append(" [").append(new ExpressionPrinter().print(join.getJoinPredicate())).append("]");
+                sb.append(" [").append(new ExpressionPrinter().print(join.getOnPredicate())).append("]");
             }
             sb.append(buildOutputColumns(join, ""));
             sb.append("\n");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ChildPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ChildPropertyDeriver.java
@@ -120,7 +120,7 @@ public class ChildPropertyDeriver extends OperatorVisitor<Void, ExpressionContex
         ColumnRefSet leftChildColumns = context.getChildOutputColumns(0);
         ColumnRefSet rightChildColumns = context.getChildOutputColumns(1);
         List<BinaryPredicateOperator> equalOnPredicate =
-                getEqConj(leftChildColumns, rightChildColumns, Utils.extractConjuncts(node.getJoinPredicate()));
+                getEqConj(leftChildColumns, rightChildColumns, Utils.extractConjuncts(node.getOnPredicate()));
 
         if (Utils.canOnlyDoBroadcast(node, equalOnPredicate, hint)) {
             tryReplicatedCrossJoin(context);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
@@ -310,7 +310,7 @@ public class CostModel {
 
             List<BinaryPredicateOperator> eqOnPredicates = JoinPredicateUtils.getEqConj(leftStatistics.getUsedColumns(),
                     rightStatistics.getUsedColumns(),
-                    Utils.extractConjuncts(join.getJoinPredicate()));
+                    Utils.extractConjuncts(join.getOnPredicate()));
 
             if (join.getJoinType().isCrossJoin() || eqOnPredicates.isEmpty()) {
                 return CostEstimate.of(leftStatistics.getOutputSize(context.getChildOutputColumns(0))

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalHashJoinOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalHashJoinOperator.java
@@ -17,18 +17,18 @@ import java.util.Set;
 
 public class PhysicalHashJoinOperator extends PhysicalOperator {
     private final JoinOperator joinType;
-    private final ScalarOperator joinPredicate;
+    private final ScalarOperator onPredicate;
     private final String joinHint;
 
     public PhysicalHashJoinOperator(JoinOperator joinType,
-                                    ScalarOperator joinPredicate,
+                                    ScalarOperator onPredicate,
                                     String joinHint,
                                     long limit,
                                     ScalarOperator predicate,
                                     Projection projection) {
         super(OperatorType.PHYSICAL_HASH_JOIN);
         this.joinType = joinType;
-        this.joinPredicate = joinPredicate;
+        this.onPredicate = onPredicate;
         this.joinHint = joinHint;
         this.limit = limit;
         this.predicate = predicate;
@@ -39,8 +39,8 @@ public class PhysicalHashJoinOperator extends PhysicalOperator {
         return joinType;
     }
 
-    public ScalarOperator getJoinPredicate() {
-        return joinPredicate;
+    public ScalarOperator getOnPredicate() {
+        return onPredicate;
     }
 
     public String getJoinHint() {
@@ -61,7 +61,7 @@ public class PhysicalHashJoinOperator extends PhysicalOperator {
     public String toString() {
         return "PhysicalHashJoinOperator{" +
                 "joinType=" + joinType +
-                ", joinPredicate=" + joinPredicate +
+                ", joinPredicate=" + onPredicate +
                 ", limit=" + limit +
                 ", predicate=" + predicate +
                 '}';
@@ -70,8 +70,8 @@ public class PhysicalHashJoinOperator extends PhysicalOperator {
     @Override
     public ColumnRefSet getUsedColumns() {
         ColumnRefSet refs = super.getUsedColumns();
-        if (joinPredicate != null) {
-            refs.union(joinPredicate.getUsedColumns());
+        if (onPredicate != null) {
+            refs.union(onPredicate.getUsedColumns());
         }
         return refs;
     }
@@ -88,12 +88,12 @@ public class PhysicalHashJoinOperator extends PhysicalOperator {
             return false;
         }
         PhysicalHashJoinOperator that = (PhysicalHashJoinOperator) o;
-        return joinType == that.joinType && Objects.equals(joinPredicate, that.joinPredicate);
+        return joinType == that.joinType && Objects.equals(onPredicate, that.onPredicate);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), joinType, joinPredicate);
+        return Objects.hash(super.hashCode(), joinType, onPredicate);
     }
 
     @Override
@@ -108,7 +108,7 @@ public class PhysicalHashJoinOperator extends PhysicalOperator {
             return false;
         }
 
-        if (joinPredicate != null && joinPredicate.getUsedColumns().isIntersect(dictSet)) {
+        if (onPredicate != null && onPredicate.getUsedColumns().isIntersect(dictSet)) {
             return false;
         }
 
@@ -120,8 +120,8 @@ public class PhysicalHashJoinOperator extends PhysicalOperator {
             columnRefSet.union(predicate.getUsedColumns());
         }
 
-        if (joinPredicate != null) {
-            columnRefSet.union(joinPredicate.getUsedColumns());
+        if (onPredicate != null) {
+            columnRefSet.union(onPredicate.getUsedColumns());
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/PreAggregateTurnOnRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/PreAggregateTurnOnRule.java
@@ -300,7 +300,7 @@ public class PreAggregateTurnOnRule {
             ColumnRefSet rightOutputColumns = optExpression.getInputs().get(1).getOutputColumns();
 
             List<BinaryPredicateOperator> eqOnPredicates = JoinPredicateUtils.getEqConj(leftOutputColumns,
-                    rightOutputColumns, Utils.extractConjuncts(hashJoinOperator.getJoinPredicate()));
+                    rightOutputColumns, Utils.extractConjuncts(hashJoinOperator.getOnPredicate()));
             // cross join can not do pre-aggregation
             if (hashJoinOperator.getJoinType().isCrossJoin() || eqOnPredicates.isEmpty()) {
                 context.notPreAggregationJoin = true;
@@ -334,8 +334,8 @@ public class PreAggregateTurnOnRule {
             boolean checkLeft = leftOutputColumns.containsAll(aggregationColumns);
             boolean checkRight = rightOutputColumns.containsAll(aggregationColumns);
             // Add join on predicate and predicate to context
-            if (hashJoinOperator.getJoinPredicate() != null) {
-                context.joinPredicates.add(hashJoinOperator.getJoinPredicate().clone());
+            if (hashJoinOperator.getOnPredicate() != null) {
+                context.joinPredicates.add(hashJoinOperator.getOnPredicate().clone());
             }
             if (hashJoinOperator.getPredicate() != null) {
                 context.joinPredicates.add(hashJoinOperator.getPredicate().clone());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -666,18 +666,15 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
 
     @Override
     public Void visitLogicalJoin(LogicalJoinOperator node, ExpressionContext context) {
-        return computeJoinNode(context, node.getOnPredicate(), node.getPredicate(), node.getJoinType(),
-                node.getLimit());
+        return computeJoinNode(context, node.getJoinType(), node.getOnPredicate());
     }
 
     @Override
     public Void visitPhysicalHashJoin(PhysicalHashJoinOperator node, ExpressionContext context) {
-        return computeJoinNode(context, node.getJoinPredicate(), node.getPredicate(), node.getJoinType(),
-                node.getLimit());
+        return computeJoinNode(context, node.getJoinType(), node.getOnPredicate());
     }
 
-    private Void computeJoinNode(ExpressionContext context, ScalarOperator joinOnPredicate, ScalarOperator predicate,
-                                 JoinOperator joinType, long limit) {
+    private Void computeJoinNode(ExpressionContext context, JoinOperator joinType, ScalarOperator joinOnPredicate) {
         Preconditions.checkState(context.arity() == 2);
 
         Statistics leftStatistics = context.getChildStatistics(0);
@@ -772,7 +769,6 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
 
         List<ScalarOperator> notEqJoin = Utils.extractConjuncts(joinOnPredicate);
         notEqJoin.removeAll(eqOnPredicates);
-        notEqJoin.add(predicate);
 
         Statistics estimateStatistics = estimateStatistics(notEqJoin, joinStats);
         context.setStatistics(estimateStatistics);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/EnforceAndCostTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/EnforceAndCostTask.java
@@ -215,7 +215,7 @@ public class EnforceAndCostTask extends OptimizerTask implements Cloneable {
         ColumnRefSet leftChildColumns = groupExpression.getChildOutputColumns(0);
         ColumnRefSet rightChildColumns = groupExpression.getChildOutputColumns(1);
         List<BinaryPredicateOperator> equalOnPredicate =
-                getEqConj(leftChildColumns, rightChildColumns, Utils.extractConjuncts(node.getJoinPredicate()));
+                getEqConj(leftChildColumns, rightChildColumns, Utils.extractConjuncts(node.getOnPredicate()));
         if (Utils.canOnlyDoBroadcast(node, equalOnPredicate, node.getJoinHint())) {
             return true;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1396,7 +1396,7 @@ public class PlanFragmentBuilder {
             List<BinaryPredicateOperator> eqOnPredicates = getEqConj(
                     leftChildColumns,
                     rightChildColumns,
-                    Utils.extractConjuncts(node.getJoinPredicate()));
+                    Utils.extractConjuncts(node.getOnPredicate()));
 
             if (node.getJoinType().isCrossJoin() ||
                     (node.getJoinType().isInnerJoin() && eqOnPredicates.isEmpty())) {
@@ -1411,8 +1411,8 @@ public class PlanFragmentBuilder {
                                 new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
                         .collect(Collectors.toList());
                 joinNode.addConjuncts(conjuncts);
-                List<Expr> onConjuncts = Utils.extractConjuncts(node.getJoinPredicate()).stream()
-                        .map(e -> ScalarOperatorToExpr.buildExecExpression(node.getJoinPredicate(),
+                List<Expr> onConjuncts = Utils.extractConjuncts(node.getOnPredicate()).stream()
+                        .map(e -> ScalarOperatorToExpr.buildExecExpression(node.getOnPredicate(),
                                 new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
                         .collect(Collectors.toList());
                 joinNode.addConjuncts(onConjuncts);
@@ -1501,7 +1501,7 @@ public class PlanFragmentBuilder {
                     }
                 }
 
-                List<ScalarOperator> otherJoin = Utils.extractConjuncts(node.getJoinPredicate());
+                List<ScalarOperator> otherJoin = Utils.extractConjuncts(node.getOnPredicate());
                 otherJoin.removeAll(eqOnPredicates);
                 List<Expr> otherJoinConjuncts = otherJoin.stream().map(e -> ScalarOperatorToExpr.buildExecExpression(e,
                         new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
@@ -1700,7 +1700,7 @@ public class PlanFragmentBuilder {
             ColumnRefSet rightChildColumns = optExpression.getInputs().get(1).getOutputColumns();
             List<BinaryPredicateOperator> equalOnPredicate =
                     JoinPredicateUtils.getEqConj(leftChildColumns, rightChildColumns,
-                            Utils.extractConjuncts(joinNode.getJoinPredicate()));
+                            Utils.extractConjuncts(joinNode.getOnPredicate()));
 
             List<Integer> leftOnPredicateColumns = new ArrayList<>();
             List<Integer> rightOnPredicateColumns = new ArrayList<>();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/OperatorStrings.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/OperatorStrings.java
@@ -267,7 +267,7 @@ public class OperatorStrings {
 
             PhysicalHashJoinOperator join = (PhysicalHashJoinOperator) optExpression.getOp();
             StringBuilder sb = new StringBuilder("").append(join.getJoinType()).append(" (");
-            sb.append("join-predicate [").append(join.getJoinPredicate()).append("] ");
+            sb.append("join-predicate [").append(join.getOnPredicate()).append("] ");
             sb.append("post-join-predicate [").append(join.getPredicate()).append("]");
             sb.append(")");
 


### PR DESCRIPTION
- The core change point is line 775 in StatisticsCalculator.java. At present, predicate will be uniformly calculated in the visitOperator. Here, calling notEqJoin.add(predicate); will cause the filter predicate of the predicate to be calculated twice, resulting in inaccurate statistics.
- Minor name modification, the on predicates of LogicalJoin and PhysicalJoin are unified to be called onPredicate