### PR TITLE
Fix: use string as common type of exact number != string

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/BinaryPredicate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/BinaryPredicate.java
@@ -162,7 +162,7 @@ public class BinaryPredicate extends Predicate implements Writable {
             return this == NE;
         }
 
-        public boolean isEquivalenceOrUnequivalence() {
+        public boolean isNotRangeComparison() {
             return isEquivalence() || isUnequivalence();
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/BinaryPredicate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/BinaryPredicate.java
@@ -163,7 +163,7 @@ public class BinaryPredicate extends Predicate implements Writable {
         }
 
         public boolean isEquivalenceOrUnequivalence() {
-            return isEquivalence() || isEquivalenceOrUnequivalence();
+            return isEquivalence() || isUnequivalence();
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/BinaryPredicate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/BinaryPredicate.java
@@ -161,6 +161,10 @@ public class BinaryPredicate extends Predicate implements Writable {
         public boolean isUnequivalence() {
             return this == NE;
         }
+
+        public boolean isEquivalenceOrUnequivalence() {
+            return isEquivalence() || isEquivalenceOrUnequivalence();
+        }
     }
 
     private Operator op;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
@@ -315,6 +315,10 @@ public abstract class Type implements Cloneable {
         return isFixedPointType() || isFloatingPointType() || isDecimalV2() || isDecimalV3();
     }
 
+    public boolean isExactNumericType() {
+        return isFixedPointType() || isDecimalV2() || isDecimalV3();
+    }
+
     public boolean isNativeType() {
         return isFixedPointType() || isFloatingPointType() || isBoolean();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -228,7 +228,8 @@ public class ExpressionAnalyzer {
             Type type1 = node.getChild(0).getType();
             Type type2 = node.getChild(1).getType();
 
-            Type compatibleType = TypeManager.getCompatibleTypeForBinary(node.getOp().isEquivalence(), type1, type2);
+            boolean isEquivalenceOrUnequivalence = node.getOp().isEquivalence() || node.getOp().isUnequivalence();
+            Type compatibleType = TypeManager.getCompatibleTypeForBinary(isEquivalenceOrUnequivalence, type1, type2);
             // check child type can be cast
             if (!canCast(type1, compatibleType)) {
                 throw new SemanticException(

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -228,8 +228,8 @@ public class ExpressionAnalyzer {
             Type type1 = node.getChild(0).getType();
             Type type2 = node.getChild(1).getType();
 
-            boolean isEquivalenceOrUnequivalence = node.getOp().isEquivalence() || node.getOp().isUnequivalence();
-            Type compatibleType = TypeManager.getCompatibleTypeForBinary(isEquivalenceOrUnequivalence, type1, type2);
+            Type compatibleType =
+                    TypeManager.getCompatibleTypeForBinary(node.getOp().isEquivalenceOrUnequivalence(), type1, type2);
             // check child type can be cast
             if (!canCast(type1, compatibleType)) {
                 throw new SemanticException(

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -229,7 +229,7 @@ public class ExpressionAnalyzer {
             Type type2 = node.getChild(1).getType();
 
             Type compatibleType =
-                    TypeManager.getCompatibleTypeForBinary(node.getOp().isEquivalenceOrUnequivalence(), type1, type2);
+                    TypeManager.getCompatibleTypeForBinary(node.getOp().isNotRangeComparison(), type1, type2);
             // check child type can be cast
             if (!canCast(type1, compatibleType)) {
                 throw new SemanticException(

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/TypeManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/TypeManager.java
@@ -121,13 +121,14 @@ public class TypeManager {
         return compatibleType;
     }
 
-    public static Type getCompatibleTypeForBinary(boolean isEquivalenceOrUnequivalence, Type type1, Type type2) {
+    public static Type getCompatibleTypeForBinary(boolean isNotRangeComparison, Type type1, Type type2) {
         // 1. Many join on-clause use string = int predicate, follow mysql will cast to double, but
         //    starrocks cast to double will lose precision, the predicate result will error
         // 2. Why only support equivalence and unequivalence expression cast to string? Because string order is different
         //    with number order, like: '12' > '2' is false, but 12 > 2 is true
-        if (isEquivalenceOrUnequivalence) {
-            if ((type1.isStringType() && type2.isExactNumericType()) || (type1.isExactNumericType() && type2.isStringType())) {
+        if (isNotRangeComparison) {
+            if ((type1.isStringType() && type2.isExactNumericType()) ||
+                    (type1.isExactNumericType() && type2.isStringType())) {
                 return Type.STRING;
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/TypeManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/TypeManager.java
@@ -121,13 +121,13 @@ public class TypeManager {
         return compatibleType;
     }
 
-    public static Type getCompatibleTypeForBinary(boolean isEquivalence, Type type1, Type type2) {
+    public static Type getCompatibleTypeForBinary(boolean isEquivalenceOrUnequivalence, Type type1, Type type2) {
         // 1. Many join on-clause use string = int predicate, follow mysql will cast to double, but
         //    starrocks cast to double will lose precision, the predicate result will error
-        // 2. Why only support equivalence expression cast to string? Because string order is different
+        // 2. Why only support equivalence and unequivalence expression cast to string? Because string order is different
         //    with number order, like: '12' > '2' is false, but 12 > 2 is true
-        if (isEquivalence) {
-            if ((type1.isStringType() && type2.isNumericType()) || (type1.isNumericType() && type2.isStringType())) {
+        if (isEquivalenceOrUnequivalence) {
+            if ((type1.isStringType() && type2.isExactNumericType()) || (type1.isExactNumericType() && type2.isStringType())) {
                 return Type.STRING;
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/BinaryPredicateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/BinaryPredicateOperator.java
@@ -98,6 +98,10 @@ public class BinaryPredicateOperator extends PredicateOperator {
             return this == NE;
         }
 
+        public boolean isEquivalenceOrUnequivalence() {
+            return isEquivalence() || isEquivalenceOrUnequivalence();
+        }
+
         public boolean isRange() {
             return type.equals(LT.type)
                     || type.equals(LE.type)

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/BinaryPredicateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/BinaryPredicateOperator.java
@@ -94,6 +94,10 @@ public class BinaryPredicateOperator extends PredicateOperator {
             return this == EQ || this == EQ_FOR_NULL;
         }
 
+        public boolean isUnequivalence() {
+            return this == NE;
+        }
+
         public boolean isRange() {
             return type.equals(LT.type)
                     || type.equals(LE.type)

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/BinaryPredicateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/BinaryPredicateOperator.java
@@ -98,7 +98,7 @@ public class BinaryPredicateOperator extends PredicateOperator {
             return this == NE;
         }
 
-        public boolean isEquivalenceOrUnequivalence() {
+        public boolean isNotRangeComparison() {
             return isEquivalence() || isUnequivalence();
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/BinaryPredicateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/BinaryPredicateOperator.java
@@ -99,7 +99,7 @@ public class BinaryPredicateOperator extends PredicateOperator {
         }
 
         public boolean isEquivalenceOrUnequivalence() {
-            return isEquivalence() || isEquivalenceOrUnequivalence();
+            return isEquivalence() || isUnequivalence();
         }
 
         public boolean isRange() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ImplicitCastRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ImplicitCastRule.java
@@ -122,10 +122,8 @@ public class ImplicitCastRule extends TopDownScalarOperatorRewriteRule {
             }
         }
 
-        boolean isEquivalenceOrUnequivalence =
-                predicate.getBinaryType().isEquivalence() || predicate.getBinaryType().isUnequivalence();
-        Type compatibleType =
-                TypeManager.getCompatibleTypeForBinary(isEquivalenceOrUnequivalence, type1, type2);
+        Type compatibleType = TypeManager.getCompatibleTypeForBinary(
+                predicate.getBinaryType().isEquivalenceOrUnequivalence(), type1, type2);
 
         if (!type1.matchesType(compatibleType)) {
             addCastChild(compatibleType, predicate, 0);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ImplicitCastRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ImplicitCastRule.java
@@ -122,8 +122,10 @@ public class ImplicitCastRule extends TopDownScalarOperatorRewriteRule {
             }
         }
 
+        boolean isEquivalenceOrUnequivalence =
+                predicate.getBinaryType().isEquivalence() || predicate.getBinaryType().isUnequivalence();
         Type compatibleType =
-                TypeManager.getCompatibleTypeForBinary(predicate.getBinaryType().isEquivalence(), type1, type2);
+                TypeManager.getCompatibleTypeForBinary(isEquivalenceOrUnequivalence, type1, type2);
 
         if (!type1.matchesType(compatibleType)) {
             addCastChild(compatibleType, predicate, 0);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ImplicitCastRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ImplicitCastRule.java
@@ -123,7 +123,7 @@ public class ImplicitCastRule extends TopDownScalarOperatorRewriteRule {
         }
 
         Type compatibleType = TypeManager.getCompatibleTypeForBinary(
-                predicate.getBinaryType().isEquivalenceOrUnequivalence(), type1, type2);
+                predicate.getBinaryType().isNotRangeComparison(), type1, type2);
 
         if (!type1.matchesType(compatibleType)) {
             addCastChild(compatibleType, predicate, 0);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -5324,4 +5324,19 @@ public class PlanFragmentTest extends PlanTestBase {
                 "  |  output columns:\n" +
                 "  |  11 <-> day[([2: id_datetime, DATETIME, false]); args: DATETIME; result: TINYINT; args nullable: false; result nullable: false]"));
     }
+
+    public void testEqFloatCast() throws Exception {
+        String sql = "select 'a' = t1e from test_all_type";
+        String plan = getFragmentPlan(sql);
+        System.out.println(plan);
+        Assert.assertTrue(plan.contains("CAST(5: t1e AS DOUBLE) = CAST('a' AS DOUBLE)\n"));
+    }
+
+    @Test
+    public void testNotEqStringCast() throws Exception {
+        String sql = "select 'a' != v1 from t0";
+        String plan = getFragmentPlan(sql);
+        System.out.println(plan);
+        Assert.assertTrue(plan.contains("CAST(1: v1 AS VARCHAR(1048576)) != 'a'\n"));
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -5326,7 +5326,7 @@ public class PlanFragmentTest extends PlanTestBase {
     }
 
     @Test
-    public void testEqFloatCast() throws Exception {
+    public void testEqDoubleCast() throws Exception {
         String sql = "select 'a' = t1e from test_all_type";
         String plan = getFragmentPlan(sql);
         System.out.println(plan);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -5325,6 +5325,7 @@ public class PlanFragmentTest extends PlanTestBase {
                 "  |  11 <-> day[([2: id_datetime, DATETIME, false]); args: DATETIME; result: TINYINT; args nullable: false; result nullable: false]"));
     }
 
+    @Test
     public void testEqFloatCast() throws Exception {
         String sql = "select 'a' = t1e from test_all_type";
         String plan = getFragmentPlan(sql);


### PR DESCRIPTION
`c1 != 'abc'`, where the type of `c1` is `INT`, is converted to `CAST(c1, DOUBLE) != CAST('abc', DOUBLE)`, because the common type of `INT` and `STRING` is `DOUBLE`.

However, ` CAST('abc', DOUBLE)` is `NULL`, so the result of `c1 != 'abc'` is false.
Therefore, we should use `STRING` as common type in this case, similar as the `=` case in PR #2523.

In addition, `float` cannot use string common type. Otherwise, `1.0 = '1.00'` will return false.

Fix #2798  and #2800