### PR TITLE
fix the compile issue that sources need jni.h

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -453,9 +453,10 @@ if (WITH_HDFS)
         hdfs
         jvm
     )
-    set(JAVA_HOME ${THIRDPARTY_DIR}/java-se-8u41-ri/)
+    set(JAVA_HOME ${THIRDPARTY_DIR}/open_jdk/)
     add_library(jvm SHARED IMPORTED)
-    set_target_properties(jvm PROPERTIES IMPORTED_LOCATION ${JAVA_HOME}/jre/lib/amd64/server/libjvm.so)
+    FILE(GLOB_RECURSE LIB_JVM ${JAVA_HOME}/jre/lib/*/libjvm.so)
+    set_target_properties(jvm PROPERTIES IMPORTED_LOCATION ${LIB_JVM})
     include_directories(${JAVA_HOME}/include)
     include_directories(${JAVA_HOME}/include/linux)
 endif()

--- a/gensrc/Makefile
+++ b/gensrc/Makefile
@@ -23,7 +23,7 @@ all: subdirs
 .PHONY: all
 
 # build all subdir
-SUBDIR = script proto thrift
+SUBDIR = script proto thrift java
 subdirs: ${SUBDIR}
 .PHONY: subdirs ${SUBDIR}
 ${SUBDIR}:


### PR DESCRIPTION
When compiling be, it failed with following message:

[ 12%] Building CXX object src/exprs/CMakeFiles/Exprs.dir/vectorized/java_function_call_expr.cpp.o
/home/rzuo/tmp/starrocks/be/src/exprs/vectorized/java_function_call_expr.cpp:27:10: fatal error: jni.h: No such file or directory
27 | #include "jni.h"
| ^~~~~~~
compilation terminated.
make[2]: *** [src/exprs/CMakeFiles/Exprs.dir/build.make:641: src/exprs/CMakeFiles/Exprs.dir/vectorized/java_function_call_expr.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:823: src/exprs/CMakeFiles/Exprs.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
[ 34%] Built target Exec
make: *** [Makefile:171: all] Error 2