### PR TITLE
Fix the problem that Makefile is not executed correctly

### DIFF
--- a/gensrc/java/Makefile
+++ b/gensrc/java/Makefile
@@ -5,14 +5,17 @@ SRC_DIR = ${CURDIR}
 JAVAC = ${JAVA_HOME}/bin/javac
 JAR = ${JAVA_HOME}/bin/jar
 
-${BUILD_DIR}/gen_java:
-	mkdir -p $@
 
 ANALYZER_CLAZZ = ${BUILD_DIR}/gen_java/com/starrocks/udf/UDFClassAnalyzer.class
 ANALYZER_SRC = ${SRC_DIR}/com/starrocks/udf/UDFClassAnalyzer.java
 CLASSLOADER_CLAZZ = ${BUILD_DIR}/gen_java/com/starrocks/udf/UDFClassLoader.class
 CLASSLOADER_SRC = ${SRC_DIR}/com/starrocks/udf/UDFClassLoader.java
 TARGET = ${BUILD_DIR}/gen_java/udf-class-loader.jar
+
+all : ${TARGET}
+
+${BUILD_DIR}/gen_java:
+	mkdir -p $@
 
 ${ANALYZER_CLAZZ} : ${ANALYZER_SRC} ${BUILD_DIR}/gen_java
 	${JAVAC} -d ${BUILD_DIR}/gen_java ${ANALYZER_SRC}
@@ -23,7 +26,6 @@ ${CLASSLOADER_CLAZZ} : ${CLASSLOADER_SRC} ${BUILD_DIR}/gen_java
 ${TARGET} : ${ANALYZER_CLAZZ} ${CLASSLOADER_CLAZZ} 
 	cd ${BUILD_DIR}/gen_java && jar -cvf udf-class-loader.jar .
 
-all : ${TARGET}
 
 clean: 
 	rm -rf ${BUILD_DIR}/gen_java


### PR DESCRIPTION
Executing make by default builds to the first target,
 in the original script only the directory is created, and the target file is not created.
so we use make all as first target.