### PR TITLE
BugFix: Modify the check of primarykey's compaction

### DIFF
--- a/be/src/storage/vectorized/rowset_merger.cpp
+++ b/be/src/storage/vectorized/rowset_merger.cpp
@@ -265,8 +265,7 @@ public:
                   << " algorithm=" << compaction_algorithm_to_string(cfg.algorithm)
                   << " column_group_size=" << column_groups.size() << " input("
                   << "entry=" << _entries.size() << " rows=" << stats.raw_rows_read
-                  << " del=" << stats.rows_del_vec_filtered
-                  << " actual=" << stats.raw_rows_read
+                  << " del=" << stats.rows_del_vec_filtered << " actual=" << stats.raw_rows_read
                   << " bytes=" << PrettyPrinter::print(total_input_size, TUnit::BYTES) << ") output(rows=" << total_rows
                   << " chunk=" << total_chunk
                   << " bytes=" << PrettyPrinter::print(writer->total_data_size(), TUnit::BYTES)
@@ -390,8 +389,8 @@ private:
         }
 
         if (stats->raw_rows_read != *total_rows) {
-            string msg = Substitute("update compaction rows read($0) != rows written($1)",
-                                    stats->raw_rows_read, *total_rows);
+            string msg = Substitute("update compaction rows read($0) != rows written($1)", stats->raw_rows_read,
+                                    *total_rows);
             LOG(WARNING) << msg;
             return Status::InternalError(msg);
         }

--- a/be/src/storage/vectorized/rowset_merger.cpp
+++ b/be/src/storage/vectorized/rowset_merger.cpp
@@ -266,7 +266,7 @@ public:
                   << " column_group_size=" << column_groups.size() << " input("
                   << "entry=" << _entries.size() << " rows=" << stats.raw_rows_read
                   << " del=" << stats.rows_del_vec_filtered
-                  << " actual=" << stats.raw_rows_read - stats.rows_del_vec_filtered
+                  << " actual=" << stats.raw_rows_read
                   << " bytes=" << PrettyPrinter::print(total_input_size, TUnit::BYTES) << ") output(rows=" << total_rows
                   << " chunk=" << total_chunk
                   << " bytes=" << PrettyPrinter::print(writer->total_data_size(), TUnit::BYTES)
@@ -389,9 +389,9 @@ private:
             }
         }
 
-        if (stats->raw_rows_read - stats->rows_del_vec_filtered != *total_rows) {
+        if (stats->raw_rows_read != *total_rows) {
             string msg = Substitute("update compaction rows read($0) != rows written($1)",
-                                    stats->raw_rows_read - stats->rows_del_vec_filtered, *total_rows);
+                                    stats->raw_rows_read, *total_rows);
             LOG(WARNING) << msg;
             return Status::InternalError(msg);
         }
@@ -485,9 +485,9 @@ private:
                 return st;
             }
 
-            if (non_key_stats.raw_rows_read - non_key_stats.rows_del_vec_filtered != *total_rows) {
+            if (non_key_stats.raw_rows_read != *total_rows) {
                 string msg = Substitute("update compaction rows read($0) != rows written($1) when merging non keys",
-                                        non_key_stats.raw_rows_read - non_key_stats.rows_del_vec_filtered, *total_rows);
+                                        non_key_stats.raw_rows_read, *total_rows);
                 LOG(WARNING) << msg;
                 return Status::InternalError(msg);
             }


### PR DESCRIPTION
The rows that have been deleted are filtered by del_vector before reading, so `rows_read` should be equal to `rows_written` in `rowset_merger`