### PR TITLE
To align hive plan with native plan

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/FeConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/FeConstants.java
@@ -64,4 +64,6 @@ public class FeConstants {
     public static String null_string = "\\N";
 
     public static boolean USE_MOCK_DICT_MANAGER = false;
+
+    public static final int default_tablet_number = 128;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -78,6 +78,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String DISABLE_STREAMING_PREAGGREGATIONS = "disable_streaming_preaggregations";
     public static final String STREAMING_PREAGGREGATION_MODE = "streaming_preaggregation_mode";
     public static final String DISABLE_COLOCATE_JOIN = "disable_colocate_join";
+    public static final String DISABLE_BUCKET_JOIN = "disable_bucket_join";
     public static final String PARALLEL_FRAGMENT_EXEC_INSTANCE_NUM = "parallel_fragment_exec_instance_num";
     public static final String ENABLE_INSERT_STRICT = "enable_insert_strict";
     public static final String ENABLE_SPILLING = "enable_spilling";
@@ -124,7 +125,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // disable join reorder
     public static final String DISABLE_JOIN_REORDER = "disable_join_reorder";
 
-    public static final String ENABLE_FILTER_UNUSED_COLUMNS_IN_SCAN_STAGE = "enable_filter_unused_columns_in_scan_stage";
+    public static final String ENABLE_FILTER_UNUSED_COLUMNS_IN_SCAN_STAGE =
+            "enable_filter_unused_columns_in_scan_stage";
 
     // the maximum time, in seconds, waiting for an insert statement's transaction state
     // transfer from COMMITTED to VISIBLE.
@@ -295,6 +297,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = DISABLE_COLOCATE_JOIN)
     private boolean disableColocateJoin = false;
+
+    @VariableMgr.VarAttr(name = DISABLE_BUCKET_JOIN)
+    private boolean disableBucketJoin = false;
 
     @VariableMgr.VarAttr(name = CBO_USE_CORRELATED_JOIN_ESTIMATE)
     private boolean useCorrelatedJoinEstimate = true;
@@ -542,6 +547,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return disableColocateJoin;
     }
 
+    public boolean isDisableBucketJoin() {
+        return disableBucketJoin;
+    }
+
     public int getParallelExecInstanceNum() {
         return parallelExecInstanceNum;
     }
@@ -765,7 +774,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public boolean isEnableExchangePassThrough() {
         return enableExchangePassThrough;
     }
-
 
     /**
      * check cbo_cte_reuse && enable_pipeline

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -298,7 +298,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = DISABLE_COLOCATE_JOIN)
     private boolean disableColocateJoin = false;
 
-    @VariableMgr.VarAttr(name = DISABLE_BUCKET_JOIN)
+    @VariableMgr.VarAttr(name = DISABLE_BUCKET_JOIN, flag = VariableMgr.INVISIBLE)
     private boolean disableBucketJoin = false;
 
     @VariableMgr.VarAttr(name = CBO_USE_CORRELATED_JOIN_ESTIMATE)

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ChildPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ChildPropertyDeriver.java
@@ -425,6 +425,10 @@ public class ChildPropertyDeriver extends OperatorVisitor<Void, ExpressionContex
      * */
     private void tryBucketShuffle(PhysicalHashJoinOperator node, HashDistributionSpec leftShuffleDistribution,
                                   HashDistributionSpec rightShuffleDistribution) {
+        if (ConnectContext.get().getSessionVariable().isDisableColocateJoin()) {
+            return;
+        }
+
         JoinOperator nodeJoinType = node.getJoinType();
         if (nodeJoinType.isCrossJoin()) {
             return;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ChildPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ChildPropertyDeriver.java
@@ -425,7 +425,7 @@ public class ChildPropertyDeriver extends OperatorVisitor<Void, ExpressionContex
      * */
     private void tryBucketShuffle(PhysicalHashJoinOperator node, HashDistributionSpec leftShuffleDistribution,
                                   HashDistributionSpec rightShuffleDistribution) {
-        if (ConnectContext.get().getSessionVariable().isDisableColocateJoin()) {
+        if (ConnectContext.get().getSessionVariable().isDisableBucketJoin()) {
             return;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/LogicalProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/LogicalProperty.java
@@ -85,8 +85,11 @@ public class LogicalProperty implements Property {
             if (node instanceof LogicalOlapScanOperator) {
                 return ((LogicalOlapScanOperator) node).getSelectedTabletId().size();
             } else {
-                // other scan operator, this is not 1 because avoid to generate 1 phase agg
-                return 2;
+                // It's very hard to estimate how many tablets scanned by this operator, because some operator
+                // even does not have the concept of tablets. Since this number will affect parallelism,
+                // so the value should not be too low.
+                // A thing to be noted that, this tablet number is better not to be 1, to avoid generate 1 phase agg.
+                return 32;
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/LogicalProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/LogicalProperty.java
@@ -85,11 +85,11 @@ public class LogicalProperty implements Property {
             if (node instanceof LogicalOlapScanOperator) {
                 return ((LogicalOlapScanOperator) node).getSelectedTabletId().size();
             } else {
-                // It's very hard to estimate how many tablets scanned by this operator, because some operator
-                // even does not have the concept of tablets. Since this number will affect parallelism,
-                // so the value should not be too low.
+                // It's very hard to estimate how many tablets scanned by this operator,
+                // because some operator even does not have the concept of tablets.
+                // The value should not be too low, otherwise it will make cost optimizer to underestimate the cost of broadcast.
                 // A thing to be noted that, this tablet number is better not to be 1, to avoid generate 1 phase agg.
-                return 32;
+                return 128;
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/LogicalProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/LogicalProperty.java
@@ -3,6 +3,7 @@
 package com.starrocks.sql.optimizer.base;
 
 import com.google.common.base.Preconditions;
+import com.starrocks.common.FeConstants;
 import com.starrocks.sql.optimizer.ExpressionContext;
 import com.starrocks.sql.optimizer.operator.AggType;
 import com.starrocks.sql.optimizer.operator.Operator;
@@ -89,7 +90,7 @@ public class LogicalProperty implements Property {
                 // because some operator even does not have the concept of tablets.
                 // The value should not be too low, otherwise it will make cost optimizer to underestimate the cost of broadcast.
                 // A thing to be noted that, this tablet number is better not to be 1, to avoid generate 1 phase agg.
-                return 128;
+                return FeConstants.default_tablet_number;
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
@@ -88,8 +88,7 @@ public class CostModel {
             Statistics statistics = context.getStatistics();
             Preconditions.checkNotNull(statistics);
 
-            return CostEstimate.of(statistics.getComputeSize(), statistics.getComputeSize(),
-                    statistics.getComputeSize());
+            return CostEstimate.of(statistics.getComputeSize(), 0, 0);
         }
 
         @Override
@@ -246,7 +245,7 @@ public class CostModel {
             Statistics inputStatistics = context.getChildStatistics(0);
             CostEstimate otherExtraCost = computeAggFunExtraCost(node, statistics, inputStatistics);
             return CostEstimate.addCost(CostEstimate.of(inputStatistics.getComputeSize(),
-                    CostEstimate.isZero(otherExtraCost) ? statistics.getComputeSize() : 0, 0),
+                            CostEstimate.isZero(otherExtraCost) ? statistics.getComputeSize() : 0, 0),
                     otherExtraCost);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
@@ -88,7 +88,8 @@ public class CostModel {
             Statistics statistics = context.getStatistics();
             Preconditions.checkNotNull(statistics);
 
-            return CostEstimate.of(statistics.getComputeSize(), 0, 0);
+            return CostEstimate.of(statistics.getComputeSize(), statistics.getComputeSize(),
+                    statistics.getComputeSize());
         }
 
         @Override


### PR DESCRIPTION
This PR is to align hive plan with native plan. 

There are many unique traits of native plan:
- colocate join
- bucket join
- replicated join
- tablets number in scan node(which will affect cost of broadcast)

To compare hive and native plan in an apple-to-apple way, we have to 
1. disable colocate and bucket and replicated join (`disable_colocate_join=true,cbo_enable_replicated_join=false,disable_bucket_join=true`)
2. tablets number of hive scan operator is large enough, otherwise the cost of broadcast will be underestimated.