### PR TITLE
Fix default CURRENT_TIMESTAMP should not support change default value

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -40,8 +40,6 @@ import com.starrocks.common.util.TimeUtils;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.thrift.TColumn;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.io.DataInput;
 import java.io.DataOutput;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -342,7 +342,7 @@ public class Column implements Writable {
 
         // default value should same
         if (thisDefaultValueType == DefaultValueType.VARY) {
-            if (!this.getDefaultExpr().getExpr().equals(other.getDefaultExpr().getExpr())) {
+            if (!this.getDefaultExpr().getExpr().equalsIgnoreCase(other.getDefaultExpr().getExpr())) {
                 throw new DdlException(CAN_NOT_CHANGE_DEFAULT_VALUE);
             }
         } else if (this.getDefaultValueType() == DefaultValueType.CONST) {
@@ -351,7 +351,7 @@ public class Column implements Writable {
                     throw new DdlException(CAN_NOT_CHANGE_DEFAULT_VALUE);
                 }
             } else if (this.getDefaultExpr() != null && other.getDefaultExpr() != null) {
-                if (!this.getDefaultExpr().getExpr().equals(other.getDefaultExpr().getExpr())) {
+                if (!this.getDefaultExpr().getExpr().equalsIgnoreCase(other.getDefaultExpr().getExpr())) {
                     throw new DdlException(CAN_NOT_CHANGE_DEFAULT_VALUE);
                 }
             } else {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColumnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColumnTest.java
@@ -150,7 +150,7 @@ public class ColumnTest {
         }
 
         try {
-            Column oldColumn = new Column("user", ScalarType.createType(PrimitiveType.INT), true, null, false,
+            Column oldColumn = new Column("user", ScalarType.createType(PrimitiveType.DATETIME), true, null, false,
                     CURRENT_TIMESTAMP_VALUE, "");
             Column newColumn = new Column("user", ScalarType.createType(PrimitiveType.INT), true, null, false,
                     NOT_SET, "");

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColumnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColumnTest.java
@@ -22,6 +22,7 @@
 package com.starrocks.catalog;
 
 import com.starrocks.analysis.ColumnDef;
+import com.starrocks.analysis.FunctionCallExpr;
 import com.starrocks.analysis.StringLiteral;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.FeConstants;
@@ -35,6 +36,10 @@ import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+
+import static com.starrocks.analysis.ColumnDef.DefaultValueDef.CURRENT_TIMESTAMP_VALUE;
+import static com.starrocks.analysis.ColumnDef.DefaultValueDef.NOT_SET;
+import static com.starrocks.analysis.ColumnDef.DefaultValueDef.NULL_DEFAULT_VALUE;
 
 public class ColumnTest {
 
@@ -111,8 +116,104 @@ public class ColumnTest {
         file.delete();
     }
 
+    @Test
+    public void testSchemaChangeAllowNormal() throws DdlException {
+        Column oldColumn = new Column("user", ScalarType.createType(PrimitiveType.INT), true, null, false,
+                NULL_DEFAULT_VALUE, "");
+        Column newColumn = new Column("user", ScalarType.createType(PrimitiveType.VARCHAR), true, null, false,
+                NULL_DEFAULT_VALUE, "");
+        oldColumn.checkSchemaChangeAllowed(newColumn);
+
+        oldColumn = new Column("user", ScalarType.createType(PrimitiveType.VARCHAR), true, null, false,
+                new ColumnDef.DefaultValueDef(true, new StringLiteral("0")), "");
+        newColumn = new Column("user1", ScalarType.createType(PrimitiveType.VARCHAR), true, null, false,
+                new ColumnDef.DefaultValueDef(true, new StringLiteral("0")), "");
+        oldColumn.checkSchemaChangeAllowed(newColumn);
+
+        oldColumn = new Column("user", ScalarType.createType(PrimitiveType.DATETIME), true, null, false,
+                CURRENT_TIMESTAMP_VALUE, "");
+        newColumn = new Column("user1", ScalarType.createType(PrimitiveType.DATETIME), true, null, false,
+                CURRENT_TIMESTAMP_VALUE, "");
+        oldColumn.checkSchemaChangeAllowed(newColumn);
+    }
+
+    @Test
+    public void testSchemaChangeAllowedDefaultValue() throws DdlException {
+        try {
+            Column oldColumn = new Column("user", ScalarType.createType(PrimitiveType.INT), true, null, false,
+                    new ColumnDef.DefaultValueDef(true, new StringLiteral("0")), "");
+            Column newColumn = new Column("user", ScalarType.createType(PrimitiveType.INT), true, null, false,
+                    NOT_SET, "");
+            oldColumn.checkSchemaChangeAllowed(newColumn);
+            Assert.fail("No exception throws.");
+        } catch (DdlException ex) {
+        }
+
+        try {
+            Column oldColumn = new Column("user", ScalarType.createType(PrimitiveType.INT), true, null, false,
+                    CURRENT_TIMESTAMP_VALUE, "");
+            Column newColumn = new Column("user", ScalarType.createType(PrimitiveType.INT), true, null, false,
+                    NOT_SET, "");
+            oldColumn.checkSchemaChangeAllowed(newColumn);
+            Assert.fail("No exception throws.");
+        } catch (DdlException ex) {
+        }
+
+        try {
+            Column oldColumn = new Column("user", ScalarType.createType(PrimitiveType.INT), true, null, false,
+                    NOT_SET, "");
+            Column newColumn = new Column("user", ScalarType.createType(PrimitiveType.INT), true, null, false,
+                    new ColumnDef.DefaultValueDef(true, new StringLiteral("0")), "");
+            oldColumn.checkSchemaChangeAllowed(newColumn);
+            Assert.fail("No exception throws.");
+        } catch (DdlException ex) {
+        }
+
+        try {
+            Column oldColumn = new Column("user", ScalarType.createType(PrimitiveType.INT), true, null, false,
+                    NOT_SET, "");
+            Column newColumn = new Column("user", ScalarType.createType(PrimitiveType.INT), true, null, false,
+                    CURRENT_TIMESTAMP_VALUE, "");
+            oldColumn.checkSchemaChangeAllowed(newColumn);
+            Assert.fail("No exception throws.");
+        } catch (DdlException ex) {
+        }
+
+        try {
+            Column oldColumn = new Column("user", ScalarType.createType(PrimitiveType.INT), true, null, false,
+                    new ColumnDef.DefaultValueDef(true, new StringLiteral("0")), "");
+            Column newColumn = new Column("user", ScalarType.createType(PrimitiveType.INT), true, null, false,
+                    CURRENT_TIMESTAMP_VALUE, "");
+            oldColumn.checkSchemaChangeAllowed(newColumn);
+            Assert.fail("No exception throws.");
+        } catch (DdlException ex) {
+        }
+
+        try {
+            Column oldColumn = new Column("user", ScalarType.createType(PrimitiveType.INT), true, null, false,
+                    new ColumnDef.DefaultValueDef(true, new StringLiteral("0")), "");
+            Column newColumn = new Column("user", ScalarType.createType(PrimitiveType.INT), true, null, false,
+                    new ColumnDef.DefaultValueDef(true, new StringLiteral("1")), "");
+            oldColumn.checkSchemaChangeAllowed(newColumn);
+            Assert.fail("No exception throws.");
+        } catch (DdlException ex) {
+        }
+
+        try {
+            Column oldColumn = new Column("user", ScalarType.createType(PrimitiveType.INT), true, null, false,
+                    CURRENT_TIMESTAMP_VALUE, "");
+            Column newColumn = new Column("user", ScalarType.createType(PrimitiveType.INT), true, null, false,
+                    new ColumnDef.DefaultValueDef(true, new StringLiteral("0")), "");
+            oldColumn.checkSchemaChangeAllowed(newColumn);
+            Assert.fail("No exception throws.");
+        } catch (DdlException ex) {
+        }
+
+    }
+
+
     @Test(expected = DdlException.class)
-    public void testSchemaChangeAllowed() throws DdlException {
+    public void testSchemaChangeAllowedNullToNonNull() throws DdlException {
         Column oldColumn = new Column("user", ScalarType.createType(PrimitiveType.INT), true, null, true,
                 new ColumnDef.DefaultValueDef(true, new StringLiteral("0")), "");
         Column newColumn = new Column("user", ScalarType.createType(PrimitiveType.INT), true, null, false,

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColumnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColumnTest.java
@@ -126,13 +126,13 @@ public class ColumnTest {
 
         oldColumn = new Column("user", ScalarType.createType(PrimitiveType.VARCHAR), true, null, false,
                 new ColumnDef.DefaultValueDef(true, new StringLiteral("0")), "");
-        newColumn = new Column("user1", ScalarType.createType(PrimitiveType.VARCHAR), true, null, false,
+        newColumn = new Column("user", ScalarType.createType(PrimitiveType.VARCHAR), true, null, false,
                 new ColumnDef.DefaultValueDef(true, new StringLiteral("0")), "");
         oldColumn.checkSchemaChangeAllowed(newColumn);
 
         oldColumn = new Column("user", ScalarType.createType(PrimitiveType.DATETIME), true, null, false,
                 CURRENT_TIMESTAMP_VALUE, "");
-        newColumn = new Column("user1", ScalarType.createType(PrimitiveType.DATETIME), true, null, false,
+        newColumn = new Column("user", ScalarType.createType(PrimitiveType.DATETIME), true, null, false,
                 CURRENT_TIMESTAMP_VALUE, "");
         oldColumn.checkSchemaChangeAllowed(newColumn);
     }
@@ -200,7 +200,7 @@ public class ColumnTest {
         }
 
         try {
-            Column oldColumn = new Column("user", ScalarType.createType(PrimitiveType.INT), true, null, false,
+            Column oldColumn = new Column("user", ScalarType.createType(PrimitiveType.DATETIME), true, null, false,
                     CURRENT_TIMESTAMP_VALUE, "");
             Column newColumn = new Column("user", ScalarType.createType(PrimitiveType.INT), true, null, false,
                     new ColumnDef.DefaultValueDef(true, new StringLiteral("0")), "");

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColumnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColumnTest.java
@@ -138,7 +138,7 @@ public class ColumnTest {
     }
 
     @Test
-    public void testSchemaChangeAllowedDefaultValue() throws DdlException {
+    public void testSchemaChangeAllowedDefaultValue() {
         try {
             Column oldColumn = new Column("user", ScalarType.createType(PrimitiveType.INT), true, null, false,
                     new ColumnDef.DefaultValueDef(true, new StringLiteral("0")), "");
@@ -150,9 +150,9 @@ public class ColumnTest {
         }
 
         try {
-            Column oldColumn = new Column("user", ScalarType.createType(PrimitiveType.DATETIME), true, null, false,
+            Column oldColumn = new Column("dt", ScalarType.createType(PrimitiveType.DATETIME), true, null, false,
                     CURRENT_TIMESTAMP_VALUE, "");
-            Column newColumn = new Column("user", ScalarType.createType(PrimitiveType.INT), true, null, false,
+            Column newColumn = new Column("dt", ScalarType.createType(PrimitiveType.DATETIME), true, null, false,
                     NOT_SET, "");
             oldColumn.checkSchemaChangeAllowed(newColumn);
             Assert.fail("No exception throws.");
@@ -200,9 +200,9 @@ public class ColumnTest {
         }
 
         try {
-            Column oldColumn = new Column("user", ScalarType.createType(PrimitiveType.DATETIME), true, null, false,
+            Column oldColumn = new Column("dt", ScalarType.createType(PrimitiveType.DATETIME), true, null, false,
                     CURRENT_TIMESTAMP_VALUE, "");
-            Column newColumn = new Column("user", ScalarType.createType(PrimitiveType.INT), true, null, false,
+            Column newColumn = new Column("dt", ScalarType.createType(PrimitiveType.DATETIME), true, null, false,
                     new ColumnDef.DefaultValueDef(true, new StringLiteral("0")), "");
             oldColumn.checkSchemaChangeAllowed(newColumn);
             Assert.fail("No exception throws.");


### PR DESCRIPTION
Fix #2831

The previous design is that this column cannot be modified if there is a default value.
DEFAULT CURRENT_TIME should also be consistent; no exceptions should be made.