### PR TITLE
Change the Catalog TryLock dump lineNum 10->50

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -754,7 +754,7 @@ public class Catalog {
                     // to see which thread held this lock for long time.
                     Thread owner = lock.getOwner();
                     if (owner != null) {
-                        LOG.warn("catalog lock is held by: {}", Util.dumpThread(owner, 10));
+                        LOG.warn("catalog lock is held by: {}", Util.dumpThread(owner, 50));
                     }
 
                     if (mustLock) {


### PR DESCRIPTION
When looking for some lock problems, 
```
[Catalog.tryLock():757] catalog lock is held by: dump thread: starrocks-mysql-nio-pool-255, id: 4481
    sun.nio.ch.FileDispatcherImpl.force0(Native Method)
    sun.nio.ch.FileDispatcherImpl.force(FileDispatcherImpl.java:80)
    sun.nio.ch.FileChannelImpl.force(FileChannelImpl.java:388)
    com.sleepycat.je.log.FileManager$LogEndFileDescriptor.force(FileManager.java:3094)
    com.sleepycat.je.log.FileManager$LogEndFileDescriptor.access$500(FileManager.java:2760)
    com.sleepycat.je.log.FileManager.syncLogEnd(FileManager.java:2046)
    com.sleepycat.je.log.FSyncManager.executeFSync(FSyncManager.java:399)
    com.sleepycat.je.log.FSyncManager.flushAndSync(FSyncManager.java:349)
    com.sleepycat.je.log.LogManager.log(LogManager.java:343)
    com.sleepycat.je.txn.Txn.logCommitEntry(Txn.java:1008)
```
the stack of 10 lines is not enough, so let the stack go to 50 lines