### PR TITLE
Fix crash when use hyperscan

### DIFF
--- a/be/src/exprs/vectorized/like_predicate.cpp
+++ b/be/src/exprs/vectorized/like_predicate.cpp
@@ -4,9 +4,6 @@
 
 #include <memory>
 
-#include "column/column_builder.h"
-#include "column/column_helper.h"
-#include "column/column_viewer.h"
 #include "exprs/vectorized/binary_function.h"
 #include "glog/logging.h"
 #include "gutil/strings/substitute.h"
@@ -337,6 +334,48 @@ ColumnPtr LikePredicate::regex_match(FunctionContext* context, const starrocks::
     }
 }
 
+ColumnPtr LikePredicate::_predicate_const_regex(FunctionContext* context, ColumnBuilder<TYPE_BOOLEAN>* result,
+                                                const ColumnViewer<TYPE_VARCHAR>& value_viewer,
+                                                const ColumnPtr& value_column) {
+    auto state = reinterpret_cast<LikePredicateState*>(context->get_function_state(FunctionContext::THREAD_LOCAL));
+
+    hs_scratch_t* scratch = nullptr;
+    hs_error_t status;
+    if ((status = hs_clone_scratch(state->scratch, &scratch)) != HS_SUCCESS) {
+        CHECK(false) << "ERROR: Unable to clone scratch space."
+                     << " status: " << status;
+    }
+
+    for (int row = 0; row < value_viewer.size(); ++row) {
+        if (value_viewer.is_null(row)) {
+            result->append_null();
+            continue;
+        }
+
+        bool v = false;
+        auto value_size = value_viewer.value(row).size;
+        auto status = hs_scan(
+                // Use &_DUMMY_STRING_FOR_EMPTY_PATTERN instead of nullptr to avoid crash.
+                state->database, (value_size) ? value_viewer.value(row).data : &_DUMMY_STRING_FOR_EMPTY_PATTERN,
+                value_size, 0, scratch,
+                [](unsigned int id, unsigned long long from, unsigned long long to, unsigned int flags,
+                   void* ctx) -> int {
+                    *((bool*)ctx) = true;
+                    return 1;
+                },
+                &v);
+
+        DCHECK(status == HS_SUCCESS || status == HS_SCAN_TERMINATED) << " status: " << status;
+        result->append(v);
+    }
+
+    if ((status = hs_free_scratch(scratch)) != HS_SUCCESS) {
+        CHECK(false) << "ERROR: free scratch space failure"
+                     << " status: " << status;
+    }
+    return result->build(value_column->is_constant());
+}
+
 ColumnPtr LikePredicate::regex_match_full(FunctionContext* context, const starrocks::vectorized::Columns& columns) {
     auto value_column = VECTORIZED_FN_ARGS(0);
     auto pattern_column = VECTORIZED_FN_ARGS(1);
@@ -346,47 +385,11 @@ ColumnPtr LikePredicate::regex_match_full(FunctionContext* context, const starro
 
     // pattern is constant value, use context's regex
     if (context->is_constant_column(1)) {
-        if (!pattern_column->is_nullable()) {
-            auto state =
-                    reinterpret_cast<LikePredicateState*>(context->get_function_state(FunctionContext::THREAD_LOCAL));
-
-            hs_scratch_t* scratch = nullptr;
-            hs_error_t status;
-            if ((status = hs_clone_scratch(state->scratch, &scratch)) != HS_SUCCESS) {
-                CHECK(false) << "ERROR: Unable to clone scratch space."
-                             << " status: " << status;
-            }
-
-            for (int row = 0; row < value_viewer.size(); ++row) {
-                if (value_viewer.is_null(row)) {
-                    result.append_null();
-                    continue;
-                }
-
-                bool v = false;
-                auto value_size = value_viewer.value(row).size;
-                auto status = hs_scan(
-                        state->database, (value_size) ? value_viewer.value(row).data : &_DUMMY_STRING_USE_WITH_HS_SCAN,
-                        value_size, 0, scratch,
-                        [](unsigned int id, unsigned long long from, unsigned long long to, unsigned int flags,
-                           void* ctx) -> int {
-                            *((bool*)ctx) = true;
-                            return 1;
-                        },
-                        &v);
-
-                DCHECK(status == HS_SUCCESS || status == HS_SCAN_TERMINATED) << " status: " << status;
-                result.append(v);
-            }
-
-            if ((status = hs_free_scratch(scratch)) != HS_SUCCESS) {
-                CHECK(false) << "ERROR: free scratch space failure"
-                             << " status: " << status;
-            }
-            return result.build(value_column->is_constant());
+        if (!pattern_column->only_null()) {
+            return _predicate_const_regex(context, &result, value_viewer, value_column);
         } else {
             // because pattern_column is constant, so if it is nullable means it is only_null.
-            return ColumnHelper::create_const_null_column(value_viewer.size());
+            return ColumnHelper::create_const_null_column(value_column->size());
         }
     }
 
@@ -428,47 +431,11 @@ ColumnPtr LikePredicate::regex_match_partial(FunctionContext* context, const sta
 
     // pattern is constant value, use context's regex
     if (context->is_constant_column(1)) {
-        if (!pattern_column->is_nullable()) {
-            auto state =
-                    reinterpret_cast<LikePredicateState*>(context->get_function_state(FunctionContext::THREAD_LOCAL));
-
-            hs_scratch_t* scratch = nullptr;
-            hs_error_t status;
-            if ((status = hs_clone_scratch(state->scratch, &scratch)) != HS_SUCCESS) {
-                CHECK(false) << "ERROR: Unable to clone scratch space."
-                             << " status: " << status;
-            }
-
-            for (int row = 0; row < value_viewer.size(); ++row) {
-                if (value_viewer.is_null(row)) {
-                    result.append_null();
-                    continue;
-                }
-
-                bool v = false;
-                auto value_size = value_viewer.value(row).size;
-                auto status = hs_scan(
-                        state->database, (value_size) ? value_viewer.value(row).data : &_DUMMY_STRING_USE_WITH_HS_SCAN,
-                        value_size, 0, scratch,
-                        [](unsigned int id, unsigned long long from, unsigned long long to, unsigned int flags,
-                           void* ctx) -> int {
-                            *((bool*)ctx) = true;
-                            return 1;
-                        },
-                        &v);
-
-                DCHECK(status == HS_SUCCESS || status == HS_SCAN_TERMINATED) << " status: " << status;
-                result.append(v);
-            }
-
-            if ((status = hs_free_scratch(scratch)) != HS_SUCCESS) {
-                CHECK(false) << "ERROR: free scratch space failure"
-                             << " status: " << status;
-            }
-            return result.build(value_column->is_constant());
+        if (!pattern_column->only_null()) {
+            return _predicate_const_regex(context, &result, value_viewer, value_column);
         } else {
             // because pattern_column is constant, so if it is nullable means it is only_null.
-            return ColumnHelper::create_const_null_column(value_viewer.size());
+            return ColumnHelper::create_const_null_column(value_column->size());
         }
     }
 

--- a/be/src/exprs/vectorized/like_predicate.h
+++ b/be/src/exprs/vectorized/like_predicate.h
@@ -139,6 +139,8 @@ private:
     static void remove_escape_character(std::string* search_string);
 
 private:
+    static inline char _DUMMY_STRING_USE_WITH_HS_SCAN = 'A';
+
     class LikePredicateState;
     static Status hs_compile_and_alloc_scratch(const std::string&, LikePredicateState*, starrocks_udf::FunctionContext*,
                                                const Slice& slice);

--- a/be/src/exprs/vectorized/like_predicate.h
+++ b/be/src/exprs/vectorized/like_predicate.h
@@ -8,6 +8,9 @@
 #include <memory>
 #include <string>
 
+#include "column/column_builder.h"
+#include "column/column_helper.h"
+#include "column/column_viewer.h"
 #include "exprs/vectorized/builtin_functions.h"
 #include "exprs/vectorized/function_helper.h"
 
@@ -139,7 +142,13 @@ private:
     static void remove_escape_character(std::string* search_string);
 
 private:
-    static inline char _DUMMY_STRING_USE_WITH_HS_SCAN = 'A';
+    static ColumnPtr _predicate_const_regex(FunctionContext* context, ColumnBuilder<TYPE_BOOLEAN>* result,
+                                            const ColumnViewer<TYPE_VARCHAR>& value_viewer,
+                                            const ColumnPtr& value_column);
+
+    // This is used when pattern is empty string, &_DUMMY_STRING_FOR_EMPTY_PATTERN used as not null pointer
+    // to avoid crash with hs_scan.
+    static inline char _DUMMY_STRING_FOR_EMPTY_PATTERN = 'A';
 
     class LikePredicateState;
     static Status hs_compile_and_alloc_scratch(const std::string&, LikePredicateState*, starrocks_udf::FunctionContext*,


### PR DESCRIPTION
- Because we can't transfer nullptr to hs_scan as data pointer, So we use a Pointer that will not be read.
- In the case that empyt string, It's size is 0 and data pointer is undefined(maybe nullptr or not), so we can't use data pointer  in this case.

Fix https://github.com/StarRocks/starrocks/issues/2830