### PR TITLE
Add evaluate logic for text scanner and fix partition column not return error

### DIFF
--- a/be/src/exec/vectorized/hdfs_scanner_text.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_text.cpp
@@ -46,22 +46,7 @@ Status HdfsScannerCSVReader::next_record(Record* record) {
     if (_should_stop_scan) {
         return Status::EndOfFile("Should stop for this reader!");
     }
-    char* d;
-    size_t pos = 0;
-    while ((d = _buff.find(_record_delimiter, pos)) == nullptr) {
-        pos = _buff.available();
-        _buff.compact();
-        if (_buff.free_space() == 0) {
-            RETURN_IF_ERROR(_expand_buffer());
-        }
-        RETURN_IF_ERROR(_fill_buffer());
-    }
-    size_t l = d - _buff.position();
-    *record = Record(_buff.position(), l);
-    _buff.skip(l + 1);
-    //               ^^ skip record delimiter.
-    _parsed_bytes += l + 1;
-    return Status::OK();
+    return CSVReader::next_record(record);
 }
 
 Status HdfsScannerCSVReader::_fill_buffer() {

--- a/be/src/exec/vectorized/hdfs_scanner_text.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_text.cpp
@@ -239,8 +239,9 @@ Status HdfsTextScanner::parse_csv(int chunk_size, ChunkPtr* chunk) {
 Status HdfsTextScanner::_create_or_reinit_reader() {
     const THdfsScanRange* scan_range = _scanner_params.scan_ranges[_current_range_index];
     if (_current_range_index == 0) {
-        _reader = std::make_unique<HdfsScannerCSVReader>(_scanner_params.fs, _record_delimiter, _field_delimiter,
-                                                         scan_range->offset, scan_range->length, scan_range->file_length);
+        _reader =
+                std::make_unique<HdfsScannerCSVReader>(_scanner_params.fs, _record_delimiter, _field_delimiter,
+                                                       scan_range->offset, scan_range->length, scan_range->file_length);
     } else {
         dynamic_cast<HdfsScannerCSVReader*>(_reader.get())->reset(scan_range->offset, scan_range->length);
     }

--- a/be/src/exec/vectorized/hdfs_scanner_text.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_text.cpp
@@ -124,7 +124,7 @@ Status HdfsTextScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk
         SCOPED_RAW_TIMER(&_stats.expr_filter_ns);
         ExecNode::eval_conjuncts(it.second, ck.get());
         if (ck->num_rows() == 0) {
-            return Status::OK();
+            break;
         }
     }
     return Status::OK();

--- a/be/src/exec/vectorized/hdfs_scanner_text.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_text.cpp
@@ -176,7 +176,7 @@ Status HdfsTextScanner::parse_csv(int chunk_size, ChunkPtr* chunk) {
         }
         num_rows += !has_error;
         if (!has_error) {
-            //Partition column not stored in text file, we should append these columns
+            // Partition column not stored in text file, we should append these columns
             // when we select partition column.
             int num_part_columns = _file_read_param.partition_columns.size();
             for (int p = 0; p < num_part_columns; ++p) {

--- a/be/src/exec/vectorized/hdfs_scanner_text.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_text.cpp
@@ -175,7 +175,7 @@ Status HdfsTextScanner::parse_csv(int chunk_size, ChunkPtr* chunk) {
     csv::Converter::Options options;
 
     for (size_t num_rows = chunk->get()->num_rows(); num_rows < chunk_size; /**/) {
-        status = dynamic_cast<HdfsScannerCSVReader*>(_reader.get())->next_record(&record);
+        status = down_cast<HdfsScannerCSVReader*>(_reader.get())->next_record(&record);
         if (status.is_end_of_file()) {
             if (_current_range_index == _scanner_params.scan_ranges.size() - 1) {
                 break;
@@ -243,13 +243,13 @@ Status HdfsTextScanner::_create_or_reinit_reader() {
                 std::make_unique<HdfsScannerCSVReader>(_scanner_params.fs, _record_delimiter, _field_delimiter,
                                                        scan_range->offset, scan_range->length, scan_range->file_length);
     } else {
-        dynamic_cast<HdfsScannerCSVReader*>(_reader.get())->reset(scan_range->offset, scan_range->length);
+        down_cast<HdfsScannerCSVReader*>(_reader.get())->reset(scan_range->offset, scan_range->length);
     }
     if (scan_range->offset != 0) {
         // Always skip first record of scan range with non-zero offset.
         // Notice that the first record will read by previous scan range.
         CSVReader::Record dummy;
-        RETURN_IF_ERROR(dynamic_cast<HdfsScannerCSVReader*>(_reader.get())->next_record(&dummy));
+        RETURN_IF_ERROR(down_cast<HdfsScannerCSVReader*>(_reader.get())->next_record(&dummy));
     }
     return Status::OK();
 }

--- a/be/src/exec/vectorized/hdfs_scanner_text.h
+++ b/be/src/exec/vectorized/hdfs_scanner_text.h
@@ -23,7 +23,7 @@ private:
     using ConverterPtr = std::unique_ptr<csv::Converter>;
     char _record_delimiter;
     string _field_delimiter;
-    std::map<std::string, Column*> _column_name_ptrs;
+    std::vector<Column*> _column_raw_ptrs;
     std::vector<ConverterPtr> _converters;
     std::shared_ptr<CSVReader> _reader = nullptr;
 };

--- a/be/src/exec/vectorized/hdfs_scanner_text.h
+++ b/be/src/exec/vectorized/hdfs_scanner_text.h
@@ -17,13 +17,13 @@ public:
     void do_close(RuntimeState* runtime_state) noexcept override;
     Status do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) override;
     Status do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) override;
-    Status _parse_csv(int chunk_size, ChunkPtr* chunk);
+    Status parse_csv(int chunk_size, ChunkPtr* chunk);
 
 private:
     using ConverterPtr = std::unique_ptr<csv::Converter>;
     char _record_delimiter;
     string _field_delimiter;
-    std::vector<Column*> _column_raw_ptrs;
+    std::map<std::string, Column*> _column_name_ptrs;
     std::vector<ConverterPtr> _converters;
     std::shared_ptr<CSVReader> _reader = nullptr;
 };

--- a/be/src/exec/vectorized/hdfs_scanner_text.h
+++ b/be/src/exec/vectorized/hdfs_scanner_text.h
@@ -20,7 +20,6 @@ public:
     Status parse_csv(int chunk_size, ChunkPtr* chunk);
 
 private:
-
     // create a reader or re init reader
     Status _create_or_reinit_reader();
 

--- a/be/src/exec/vectorized/hdfs_scanner_text.h
+++ b/be/src/exec/vectorized/hdfs_scanner_text.h
@@ -20,11 +20,16 @@ public:
     Status parse_csv(int chunk_size, ChunkPtr* chunk);
 
 private:
+
+    // create a reader or re init reader
+    Status _create_or_reinit_reader();
+
     using ConverterPtr = std::unique_ptr<csv::Converter>;
     char _record_delimiter;
     string _field_delimiter;
     std::vector<Column*> _column_raw_ptrs;
     std::vector<ConverterPtr> _converters;
     std::shared_ptr<CSVReader> _reader = nullptr;
+    size_t _current_range_index = 0;
 };
 } // namespace starrocks::vectorized

--- a/be/src/formats/csv/csv_reader.h
+++ b/be/src/formats/csv/csv_reader.h
@@ -82,6 +82,8 @@ public:
     void split_record(const Record& record, Fields* fields) const;
 
 protected:
+    Status _expand_buffer();
+    size_t _parsed_bytes = 0;
     // TODO: support string
     char _record_delimiter;
     string _field_delimiter;
@@ -91,9 +93,6 @@ protected:
     virtual Status _fill_buffer() { return Status::InternalError("unsupported csv reader!"); }
 
 private:
-    Status _expand_buffer();
-
-    size_t _parsed_bytes = 0;
     size_t _limit = 0;
     size_t _offset = 0;
 };

--- a/be/src/formats/csv/csv_reader.h
+++ b/be/src/formats/csv/csv_reader.h
@@ -82,8 +82,6 @@ public:
     void split_record(const Record& record, Fields* fields) const;
 
 protected:
-    Status _expand_buffer();
-    size_t _parsed_bytes = 0;
     // TODO: support string
     char _record_delimiter;
     string _field_delimiter;
@@ -93,6 +91,9 @@ protected:
     virtual Status _fill_buffer() { return Status::InternalError("unsupported csv reader!"); }
 
 private:
+    Status _expand_buffer();
+
+    size_t _parsed_bytes = 0;
     size_t _limit = 0;
     size_t _offset = 0;
 };


### PR DESCRIPTION
This pr will close #2783 close #2791 close #2839.
Why we resolve these issues in this single pr?
Because we think the three bugs is related with each other.

More details about this change as below:
- Because we do not add project operator follow hdfs scan node, so we need add filter logic into text scanner.This will close #2791 
- For csv or text file we can not select partition column from original file. So we append partition columns manully to fix partition column can not be selected error. This will close #2783 
- Traverse all the scan ranges assigned to the scanner, and check end of file use offset to fix hdfs readfully error of #2839 