### PR TITLE
Fix create hive external table bug in higher jdk version (#2864)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaStoreThriftClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaStoreThriftClient.java
@@ -300,7 +300,7 @@ public class HiveMetaStoreThriftClient implements IMetaStoreClient, AutoCloseabl
             if (MetastoreConf.getVar(conf, ConfVars.THRIFT_URI_SELECTION).equalsIgnoreCase("RANDOM")) {
                 List<URI> uriList = Arrays.asList(metastoreUris);
                 Collections.shuffle(uriList);
-                metastoreUris = (URI[]) uriList.toArray();
+                metastoreUris = uriList.toArray(metastoreUris);
             }
         } catch (IllegalArgumentException e) {
             throw (e);


### PR DESCRIPTION
For higher versions of jdk (higher than 8), The class Object[] can not be cast to URI[], although the object is an instance of URI[]. When calling toArray, we need to specify the actual type in the parameter.