### PR TITLE
Add the interface::update_rows to support column modification

### DIFF
--- a/be/src/column/array_column.cpp
+++ b/be/src/column/array_column.cpp
@@ -123,6 +123,49 @@ void ArrayColumn::append_default(size_t count) {
     _offsets->append_value_multiple_times(&offset, count);
 }
 
+Status ArrayColumn::replace_rows(const Column& src, const uint32_t* replace_idxes) {
+    const auto& array_column = down_cast<const ArrayColumn&>(src);
+
+    const UInt32Column& src_offsets = array_column.offsets();
+    size_t replace_num = src.size();
+    bool need_resize = false;
+    for (size_t i = 0; i < replace_num; ++i) {
+        if (_offsets->get_data()[replace_idxes[i] + 1] - _offsets->get_data()[replace_idxes[i]] !=
+            src_offsets.get_data()[i + 1] - src_offsets.get_data()[i]) {
+            need_resize = true;
+            break;
+        }
+    }
+
+    if (!need_resize) {
+        std::vector<uint32_t> element_idxes;
+        for (size_t i = 0; i < replace_num; ++i) {
+            size_t element_count = src_offsets.get_data()[i + 1] - src_offsets.get_data()[i];
+            size_t element_offset = _offsets->get_data()[replace_idxes[i]];
+            for (size_t j = 0; j < element_count; j++) {
+                element_idxes.emplace_back(element_offset + j);
+            }
+        }
+        RETURN_IF_ERROR(_elements->replace_rows(array_column.elements(), element_idxes.data()));
+    } else {
+        MutableColumnPtr new_array_column = clone_empty();
+        size_t idx_begin = 0;
+        for (size_t i = 0; i < replace_num; ++i) {
+            size_t count = replace_idxes[i] - idx_begin;
+            new_array_column->append(*this, idx_begin, count);
+            new_array_column->append(src, i, 1);
+            idx_begin = replace_idxes[i] + 1;
+        }
+        int32_t remain_count = _offsets->size() - idx_begin - 1;
+        if (remain_count > 0) {
+            new_array_column->append(*this, idx_begin, remain_count);
+        }
+        swap_column(*new_array_column.get());
+    }
+
+    return Status::OK();
+}
+
 uint32_t ArrayColumn::serialize(size_t idx, uint8_t* pos) {
     uint32_t offset = _offsets->get_data()[idx];
     uint32_t array_size = _offsets->get_data()[idx + 1] - offset;

--- a/be/src/column/array_column.h
+++ b/be/src/column/array_column.h
@@ -80,6 +80,8 @@ public:
 
     void append_default(size_t count) override;
 
+    Status replace_rows(const Column& src, const uint32_t* replace_idxes) override;
+
     void remove_first_n_values(size_t count) override {}
 
     uint32_t max_one_element_serialize_size() const override;

--- a/be/src/column/array_column.h
+++ b/be/src/column/array_column.h
@@ -80,7 +80,7 @@ public:
 
     void append_default(size_t count) override;
 
-    Status replace_rows(const Column& src, const uint32_t* replace_idxes) override;
+    Status update_rows(const Column& src, const uint32_t* indexes) override;
 
     void remove_first_n_values(size_t count) override {}
 

--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -208,7 +208,6 @@ Status BinaryColumn::update_rows(const Column& src, const uint32_t* indexes) {
             uint32_t str_size = src_offsets[i + 1] - src_offsets[i];
             strings::memcpy_inlined(dest_bytes + _offsets[indexes[i]], src_bytes.data() + src_offsets[i], str_size);
         }
-        _slices_cache = false;
     } else {
         auto new_binary_column = BinaryColumn::create();
         size_t idx_begin = 0;

--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -167,6 +167,8 @@ public:
         _slices_cache = false;
     }
 
+    Status replace_rows(const Column& src, const uint32_t* replace_idxes) override;
+
     uint32_t max_one_element_serialize_size() const override;
 
     uint32_t serialize(size_t idx, uint8_t* pos) override;

--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -167,7 +167,7 @@ public:
         _slices_cache = false;
     }
 
-    Status replace_rows(const Column& src, const uint32_t* replace_idxes) override;
+    Status update_rows(const Column& src, const uint32_t* indexes) override;
 
     uint32_t max_one_element_serialize_size() const override;
 

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -124,6 +124,15 @@ public:
 
     virtual void append(const Column& src) { append(src, 0, src.size()); }
 
+    // This function will replace data from src according to the replace_idxes. 'replace_idxes' contains
+    // the row index will be replaced
+    // For example:
+    //      input idxes: [0, 3]
+    //      column data: [0, 1, 2, 3, 4]
+    //      src_column data: [5, 6]
+    // After call this function, column data will be set as [5, 1, 2, 6, 4]
+    virtual Status replace_rows(const Column& src, const uint32_t* replace_idxes) = 0;
+
     // This function will append data from src according to the input indexes. 'indexes' contains
     // the row index of the src.
     // This function will get row index from indexes and append the data to this column.

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -124,14 +124,14 @@ public:
 
     virtual void append(const Column& src) { append(src, 0, src.size()); }
 
-    // This function will replace data from src according to the replace_idxes. 'replace_idxes' contains
-    // the row index will be replaced
+    // This function will update data from src according to the input indexes. 'indexes' contains
+    // the row index will be update
     // For example:
-    //      input idxes: [0, 3]
+    //      input indexes: [0, 3]
     //      column data: [0, 1, 2, 3, 4]
     //      src_column data: [5, 6]
     // After call this function, column data will be set as [5, 1, 2, 6, 4]
-    virtual Status replace_rows(const Column& src, const uint32_t* replace_idxes) = 0;
+    virtual Status update_rows(const Column& src, const uint32_t* indexes) = 0;
 
     // This function will append data from src according to the input indexes. 'indexes' contains
     // the row index of the src.

--- a/be/src/column/const_column.cpp
+++ b/be/src/column/const_column.cpp
@@ -35,7 +35,7 @@ void ConstColumn::append_value_multiple_times(const Column& src, uint32_t index,
 }
 
 Status ConstColumn::update_rows(const Column& src, const uint32_t* indexes) {
-    return _data->update_rows(src, indexes);
+    return Status::NotSupported("ConstColumn does not support update");
 }
 
 void ConstColumn::fnv_hash(uint32_t* hash, uint32_t from, uint32_t to) const {

--- a/be/src/column/const_column.cpp
+++ b/be/src/column/const_column.cpp
@@ -34,8 +34,8 @@ void ConstColumn::append_value_multiple_times(const Column& src, uint32_t index,
     append(src, index, size);
 }
 
-Status ConstColumn::replace_rows(const Column& src, const uint32_t* replace_idxes) {
-    return _data->replace_rows(src, replace_idxes);
+Status ConstColumn::update_rows(const Column& src, const uint32_t* indexes) {
+    return _data->update_rows(src, indexes);
 }
 
 void ConstColumn::fnv_hash(uint32_t* hash, uint32_t from, uint32_t to) const {

--- a/be/src/column/const_column.cpp
+++ b/be/src/column/const_column.cpp
@@ -34,6 +34,10 @@ void ConstColumn::append_value_multiple_times(const Column& src, uint32_t index,
     append(src, index, size);
 }
 
+Status ConstColumn::replace_rows(const Column& src, const uint32_t* replace_idxes) {
+    return _data->replace_rows(src, replace_idxes);
+}
+
 void ConstColumn::fnv_hash(uint32_t* hash, uint32_t from, uint32_t to) const {
     DCHECK(_size > 0);
     for (uint32_t i = from; i < to; ++i) {

--- a/be/src/column/const_column.h
+++ b/be/src/column/const_column.h
@@ -115,6 +115,8 @@ public:
 
     void append_default(size_t count) override { _size += count; }
 
+    Status replace_rows(const Column& src, const uint32_t* replace_idxes) override;
+
     uint32_t serialize(size_t idx, uint8_t* pos) override { return _data->serialize(0, pos); }
 
     uint32_t serialize_default(uint8_t* pos) override { return _data->serialize_default(pos); }

--- a/be/src/column/const_column.h
+++ b/be/src/column/const_column.h
@@ -115,7 +115,7 @@ public:
 
     void append_default(size_t count) override { _size += count; }
 
-    Status replace_rows(const Column& src, const uint32_t* replace_idxes) override;
+    Status update_rows(const Column& src, const uint32_t* indexes) override;
 
     uint32_t serialize(size_t idx, uint8_t* pos) override { return _data->serialize(0, pos); }
 

--- a/be/src/column/fixed_length_column_base.cpp
+++ b/be/src/column/fixed_length_column_base.cpp
@@ -43,6 +43,17 @@ void FixedLengthColumnBase<T>::append_value_multiple_times(const Column& src, ui
 }
 
 template <typename T>
+Status FixedLengthColumnBase<T>::replace_rows(const Column& src, const uint32_t* replace_indexes) {
+    const T* src_data = reinterpret_cast<const T*>(src.raw_data());
+    size_t replace_num = src.size();
+    for (uint32_t i = 0; i < replace_num; ++i) {
+        DCHECK_LT(replace_indexes[i], _data.size());
+        _data[replace_indexes[i]] = src_data[i];
+    }
+    return Status::OK();
+}
+
+template <typename T>
 size_t FixedLengthColumnBase<T>::filter_range(const Column::Filter& filter, size_t from, size_t to) {
     auto size = ColumnHelper::filter_range<T>(filter, _data.data(), from, to);
     this->resize(size);

--- a/be/src/column/fixed_length_column_base.cpp
+++ b/be/src/column/fixed_length_column_base.cpp
@@ -43,12 +43,12 @@ void FixedLengthColumnBase<T>::append_value_multiple_times(const Column& src, ui
 }
 
 template <typename T>
-Status FixedLengthColumnBase<T>::replace_rows(const Column& src, const uint32_t* replace_indexes) {
+Status FixedLengthColumnBase<T>::update_rows(const Column& src, const uint32_t* indexes) {
     const T* src_data = reinterpret_cast<const T*>(src.raw_data());
     size_t replace_num = src.size();
     for (uint32_t i = 0; i < replace_num; ++i) {
-        DCHECK_LT(replace_indexes[i], _data.size());
-        _data[replace_indexes[i]] = src_data[i];
+        DCHECK_LT(indexes[i], _data.size());
+        _data[indexes[i]] = src_data[i];
     }
     return Status::OK();
 }

--- a/be/src/column/fixed_length_column_base.h
+++ b/be/src/column/fixed_length_column_base.h
@@ -126,7 +126,7 @@ public:
         _data.resize(_data.size() + count, DefaultValueGenerator<ValueType>::next_value());
     }
 
-    Status replace_rows(const Column& src, const uint32_t* replace_idxes) override;
+    Status update_rows(const Column& src, const uint32_t* indexes) override;
 
     uint32_t serialize(size_t idx, uint8_t* pos) override;
 

--- a/be/src/column/fixed_length_column_base.h
+++ b/be/src/column/fixed_length_column_base.h
@@ -126,6 +126,8 @@ public:
         _data.resize(_data.size() + count, DefaultValueGenerator<ValueType>::next_value());
     }
 
+    Status replace_rows(const Column& src, const uint32_t* replace_idxes) override;
+
     uint32_t serialize(size_t idx, uint8_t* pos) override;
 
     uint32_t serialize_default(uint8_t* pos) override;

--- a/be/src/column/nullable_column.cpp
+++ b/be/src/column/nullable_column.cpp
@@ -151,6 +151,66 @@ void NullableColumn::append_value_multiple_times(const void* value, size_t count
     null_column_data().insert(null_column_data().end(), count, 0);
 }
 
+bool NullableColumn::need_resize(const Column& src, const uint32_t* replace_idxes) {
+    size_t replace_num = src.size();
+    if (src.is_nullable()) {
+        const auto& c = down_cast<const NullableColumn&>(src);
+        for (size_t i = 0; i < replace_num; ++i) {
+            if (_null_column->get_data()[replace_idxes[i]] != c._null_column->get_data()[i]) {
+                return true;
+            }
+        }
+    } else {
+        for (size_t i = 0; i < replace_num; ++i) {
+            if (_null_column->get_data()[replace_idxes[i]]) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+Status NullableColumn::replace_rows(const Column& src, const uint32_t* replace_idxes) {
+    DCHECK_EQ(_null_column->size(), _data_column->size());
+
+    //bool resize = need_resize(src, replace_idxes);
+
+    size_t replace_num = src.size();
+    /*
+    if (resize) {
+        MutableColumnPtr new_nullable_column = clone_empty();
+        size_t idx_begin = 0;
+        for (size_t i = 0; i < replace_num; ++i) {
+            size_t count = replace_idxes[i] - idx_begin;
+            new_nullable_column->append(*this, idx_begin, count);
+            new_nullable_column->append(src, i, 1);
+            idx_begin = replace_idxes[i] + 1;
+        }
+        swap_column(*new_nullable_column.get());
+    } else {
+        if (src.is_nullable()) {
+            const auto& c = down_cast<const NullableColumn&>(src);
+            _data_column->replace_rows(*c._data_column, replace_idxes);
+        } else {
+            _data_column->replace_rows(src, replace_idxes);
+        }
+    }
+    */
+
+    if (src.is_nullable()) {
+        const auto& c = down_cast<const NullableColumn&>(src);
+        RETURN_IF_ERROR(_null_column->replace_rows(*c._null_column, replace_idxes));
+        RETURN_IF_ERROR(_data_column->replace_rows(*c._data_column, replace_idxes));
+    } else {
+        auto new_null_column = NullColumn::create();
+        new_null_column->get_data().insert(new_null_column->get_data().end(), replace_num, 0);
+        RETURN_IF_ERROR(_null_column->replace_rows(*new_null_column.get(), replace_idxes));
+        RETURN_IF_ERROR(_data_column->replace_rows(src, replace_idxes));
+    }
+
+    return Status::OK();
+}
+
 size_t NullableColumn::filter_range(const Column::Filter& filter, size_t from, size_t to) {
     auto s1 = _data_column->filter_range(filter, from, to);
     auto s2 = _null_column->filter_range(filter, from, to);

--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -142,9 +142,7 @@ public:
 
     void append_default(size_t count) override { append_nulls(count); }
 
-    bool need_resize(const Column& src, const uint32_t* replace_idxe);
-
-    Status replace_rows(const Column& src, const uint32_t* replace_idxes) override;
+    Status update_rows(const Column& src, const uint32_t* indexes) override;
 
     uint32_t max_one_element_serialize_size() const override {
         return sizeof(bool) + _data_column->max_one_element_serialize_size();

--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -142,6 +142,10 @@ public:
 
     void append_default(size_t count) override { append_nulls(count); }
 
+    bool need_resize(const Column& src, const uint32_t* replace_idxe);
+
+    Status replace_rows(const Column& src, const uint32_t* replace_idxes) override;
+
     uint32_t max_one_element_serialize_size() const override {
         return sizeof(bool) + _data_column->max_one_element_serialize_size();
     }

--- a/be/src/column/object_column.cpp
+++ b/be/src/column/object_column.cpp
@@ -125,6 +125,18 @@ void ObjectColumn<T>::append_default(size_t count) {
 }
 
 template <typename T>
+Status ObjectColumn<T>::replace_rows(const Column& src, const uint32_t* replace_idxes) {
+    const auto& obj_col = down_cast<const ObjectColumn<T>&>(src);
+    size_t replace_num = src.size();
+    for (size_t i = 0; i < replace_num; i++) {
+        DCHECK_LT(replace_idxes[i], _pool.size());
+        _pool[replace_idxes[i]] = *obj_col.get_object(i);
+    }
+    _cache_ok = false;
+    return Status::OK();
+}
+
+template <typename T>
 uint32_t ObjectColumn<T>::serialize(size_t idx, uint8_t* pos) {
     DCHECK(false) << "Don't support object column serialize";
     return 0;

--- a/be/src/column/object_column.cpp
+++ b/be/src/column/object_column.cpp
@@ -125,12 +125,12 @@ void ObjectColumn<T>::append_default(size_t count) {
 }
 
 template <typename T>
-Status ObjectColumn<T>::replace_rows(const Column& src, const uint32_t* replace_idxes) {
+Status ObjectColumn<T>::update_rows(const Column& src, const uint32_t* indexes) {
     const auto& obj_col = down_cast<const ObjectColumn<T>&>(src);
     size_t replace_num = src.size();
     for (size_t i = 0; i < replace_num; i++) {
-        DCHECK_LT(replace_idxes[i], _pool.size());
-        _pool[replace_idxes[i]] = *obj_col.get_object(i);
+        DCHECK_LT(indexes[i], _pool.size());
+        _pool[indexes[i]] = *obj_col.get_object(i);
     }
     _cache_ok = false;
     return Status::OK();

--- a/be/src/column/object_column.h
+++ b/be/src/column/object_column.h
@@ -100,6 +100,8 @@ public:
 
     void append_default(size_t count) override;
 
+    Status replace_rows(const Column& src, const uint32_t* replace_idxes) override;
+
     uint32_t serialize(size_t idx, uint8_t* pos) override;
     uint32_t serialize_default(uint8_t* pos) override;
 

--- a/be/src/column/object_column.h
+++ b/be/src/column/object_column.h
@@ -100,7 +100,7 @@ public:
 
     void append_default(size_t count) override;
 
-    Status replace_rows(const Column& src, const uint32_t* replace_idxes) override;
+    Status update_rows(const Column& src, const uint32_t* indexes) override;
 
     uint32_t serialize(size_t idx, uint8_t* pos) override;
     uint32_t serialize_default(uint8_t* pos) override;

--- a/be/test/column/array_column_test.cpp
+++ b/be/test/column/array_column_test.cpp
@@ -856,7 +856,7 @@ PARALLEL_TEST(ArrayColumnTest, test_array_hash) {
     offset_col1->append(4);
 
     std::vector<uint32_t> replace_idxes = {1, 3};
-    ASSERT_TRUE(column->replace_rows(*replace_col1.get(), replace_idxes.data()).ok());
+    ASSERT_TRUE(column->update_rows(*replace_col1.get(), replace_idxes.data()).ok());
 
     ASSERT_EQ(4, column->size());
     ASSERT_EQ("[1, 2, 3]", column->debug_item(0));
@@ -877,7 +877,7 @@ PARALLEL_TEST(ArrayColumnTest, test_array_hash) {
     element_col2->append(204);
     offset_col2->append(4);
 
-    ASSERT_TRUE(column->replace_rows(*replace_col2.get(), replace_idxes.data()).ok());
+    ASSERT_TRUE(column->update_rows(*replace_col2.get(), replace_idxes.data()).ok());
 
     ASSERT_EQ(4, column->size());
     ASSERT_EQ("[1, 2, 3]", column->debug_item(0));

--- a/be/test/column/array_column_test.cpp
+++ b/be/test/column/array_column_test.cpp
@@ -814,7 +814,7 @@ PARALLEL_TEST(ArrayColumnTest, test_array_hash) {
     ASSERT_EQ(hash_value_overflow, hash_value_overflow_test[2]);
 }
 
-PARALLEL_TEST(ArrayColumnTest, test_array_hash) {
+PARALLEL_TEST(ArrayColumnTest, test_update_rows) {
     auto offsets = UInt32Column::create();
     auto elements = Int32Column::create();
     auto column = ArrayColumn::create(elements, offsets);

--- a/be/test/column/binary_column_test.cpp
+++ b/be/test/column/binary_column_test.cpp
@@ -490,7 +490,7 @@ PARALLEL_TEST(BinaryColumnTest, test_replace_rows) {
     auto c2 = BinaryColumn::create();
     c2->append_datum("pq");
     c2->append_datum("rstu");
-    ASSERT_TRUE(c1->replace_rows(*c2.get(), replace_idxes.data()).ok());
+    ASSERT_TRUE(c1->update_rows(*c2.get(), replace_idxes.data()).ok());
 
     auto slices = c1->get_data();
     EXPECT_EQ(5, c1->size());
@@ -503,7 +503,7 @@ PARALLEL_TEST(BinaryColumnTest, test_replace_rows) {
     auto c3 = BinaryColumn::create();
     c3->append_datum("ab");
     c3->append_datum("cdef");
-    ASSERT_TRUE(c1->replace_rows(*c3.get(), replace_idxes.data()).ok());
+    ASSERT_TRUE(c1->update_rows(*c3.get(), replace_idxes.data()).ok());
 
     slices = c1->get_data();
     EXPECT_EQ(5, c1->size());
@@ -517,7 +517,7 @@ PARALLEL_TEST(BinaryColumnTest, test_replace_rows) {
     std::vector<uint32_t> new_replace_idxes = {0, 1};
     c4->append_datum("ab");
     c4->append_datum("cdef");
-    ASSERT_TRUE(c1->replace_rows(*c4.get(), new_replace_idxes.data()).ok());
+    ASSERT_TRUE(c1->update_rows(*c4.get(), new_replace_idxes.data()).ok());
 
     slices = c1->get_data();
     EXPECT_EQ(5, c1->size());

--- a/be/test/column/binary_column_test.cpp
+++ b/be/test/column/binary_column_test.cpp
@@ -478,7 +478,7 @@ PARALLEL_TEST(BinaryColumnTest, test_clone_empty) {
     ASSERT_EQ(0, c2->size());
 }
 
-PARALLEL_TEST(BinaryColumnTest, test_replace_rows) {
+PARALLEL_TEST(BinaryColumnTest, test_update_rows) {
     auto c1 = BinaryColumn::create();
     c1->append_datum("abc");
     c1->append_datum("def");

--- a/be/test/column/fixed_length_column_test.cpp
+++ b/be/test/column/fixed_length_column_test.cpp
@@ -510,4 +510,35 @@ TEST(FixedLengthColumnTest, test_swap_column) {
     ASSERT_EQ(3, c2->get_data()[2]);
 }
 
+TEST(FixedLengthColumnTest, test_replace_rows) {
+    auto column = FixedLengthColumn<int32_t>::create();
+    for (int i = 0; i < 100; i++) {
+        column->append(i);
+    }
+
+    ASSERT_EQ(true, column->is_numeric());
+    ASSERT_EQ(100, column->size());
+    ASSERT_EQ(100 * 4, column->byte_size());
+
+    for (int i = 0; i < 100; i++) {
+        ASSERT_EQ(column->get_data()[i], i);
+    }
+
+    auto replace_column = FixedLengthColumn<int32_t>::create();
+    for (int i = 0; i < 10; i++) {
+        replace_column->append(i + 100);
+    }
+
+    std::vector<uint32_t> replace_idxes = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+    ASSERT_TRUE(column->replace_rows(*replace_column.get(), replace_idxes.data()).ok());
+
+    for (int i = 0; i < 10; i++) {
+        ASSERT_EQ(column->get_data()[i], i + 100);
+    }
+
+    for (int i = 10; i < 100; i++) {
+        ASSERT_EQ(column->get_data()[i], i);
+    }
+}
+
 } // namespace starrocks::vectorized

--- a/be/test/column/fixed_length_column_test.cpp
+++ b/be/test/column/fixed_length_column_test.cpp
@@ -510,7 +510,7 @@ TEST(FixedLengthColumnTest, test_swap_column) {
     ASSERT_EQ(3, c2->get_data()[2]);
 }
 
-TEST(FixedLengthColumnTest, test_replace_rows) {
+TEST(FixedLengthColumnTest, test_update_rows) {
     auto column = FixedLengthColumn<int32_t>::create();
     for (int i = 0; i < 100; i++) {
         column->append(i);

--- a/be/test/column/fixed_length_column_test.cpp
+++ b/be/test/column/fixed_length_column_test.cpp
@@ -530,7 +530,7 @@ TEST(FixedLengthColumnTest, test_replace_rows) {
     }
 
     std::vector<uint32_t> replace_idxes = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
-    ASSERT_TRUE(column->replace_rows(*replace_column.get(), replace_idxes.data()).ok());
+    ASSERT_TRUE(column->update_rows(*replace_column.get(), replace_idxes.data()).ok());
 
     for (int i = 0; i < 10; i++) {
         ASSERT_EQ(column->get_data()[i], i + 100);

--- a/be/test/column/nullable_column_test.cpp
+++ b/be/test/column/nullable_column_test.cpp
@@ -211,7 +211,7 @@ PARALLEL_TEST(NullableColumnTest, test_replace_rows) {
     replace_col1->append_datum((int32_t)5);
 
     std::vector<uint32_t> replace_idxes = {1, 4};
-    ASSERT_TRUE(column->replace_rows(*replace_col1.get(), replace_idxes.data()).ok());
+    ASSERT_TRUE(column->update_rows(*replace_col1.get(), replace_idxes.data()).ok());
     ASSERT_EQ(5, column->size());
     ASSERT_TRUE(column->data_column().unique());
     ASSERT_TRUE(column->null_column().unique());
@@ -235,7 +235,7 @@ PARALLEL_TEST(NullableColumnTest, test_replace_rows) {
     replace_col2->append_datum({});
     replace_col2->append_datum("jk");
 
-    ASSERT_TRUE(column1->replace_rows(*replace_col2.get(), replace_idxes.data()).ok());
+    ASSERT_TRUE(column1->update_rows(*replace_col2.get(), replace_idxes.data()).ok());
     ASSERT_EQ(5, column1->size());
     ASSERT_TRUE(column1->data_column().unique());
     ASSERT_TRUE(column1->null_column().unique());

--- a/be/test/column/nullable_column_test.cpp
+++ b/be/test/column/nullable_column_test.cpp
@@ -198,7 +198,7 @@ PARALLEL_TEST(NullableColumnTest, test_clone_empty) {
     ASSERT_EQ(0, down_cast<NullableColumn*>(c2.get())->null_column()->size());
 }
 
-PARALLEL_TEST(NullableColumnTest, test_replace_rows) {
+PARALLEL_TEST(NullableColumnTest, test_update_rows) {
     auto column = NullableColumn::create(Int32Column::create(), NullColumn::create());
     column->append_datum((int32_t)1);
     column->append_datum((int32_t)2);

--- a/be/test/column/nullable_column_test.cpp
+++ b/be/test/column/nullable_column_test.cpp
@@ -4,6 +4,7 @@
 
 #include <gtest/gtest.h>
 
+#include "column/binary_column.h"
 #include "column/fixed_length_column.h"
 #include "testutil/parallel_test.h"
 
@@ -195,6 +196,57 @@ PARALLEL_TEST(NullableColumnTest, test_clone_empty) {
     ASSERT_TRUE(down_cast<NullableColumn*>(c2.get())->null_column().unique());
     ASSERT_EQ(0, down_cast<NullableColumn*>(c2.get())->data_column()->size());
     ASSERT_EQ(0, down_cast<NullableColumn*>(c2.get())->null_column()->size());
+}
+
+PARALLEL_TEST(NullableColumnTest, test_replace_rows) {
+    auto column = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    column->append_datum((int32_t)1);
+    column->append_datum((int32_t)2);
+    column->append_datum({});
+    column->append_datum((int32_t)4);
+    column->append_datum({});
+
+    auto replace_col1 = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    replace_col1->append_datum({});
+    replace_col1->append_datum((int32_t)5);
+
+    std::vector<uint32_t> replace_idxes = {1, 4};
+    ASSERT_TRUE(column->replace_rows(*replace_col1.get(), replace_idxes.data()).ok());
+    ASSERT_EQ(5, column->size());
+    ASSERT_TRUE(column->data_column().unique());
+    ASSERT_TRUE(column->null_column().unique());
+    ASSERT_EQ(5, column->data_column()->size());
+    ASSERT_EQ(5, column->null_column()->size());
+
+    ASSERT_EQ(1, column->get(0).get_int32());
+    ASSERT_TRUE(column->get(1).is_null());
+    ASSERT_TRUE(column->get(2).is_null());
+    ASSERT_EQ(4, column->get(3).get_int32());
+    ASSERT_EQ(5, column->get(4).get_int32());
+
+    auto column1 = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
+    column1->append_datum("abc");
+    column1->append_datum("def");
+    column1->append_datum({});
+    column1->append_datum("ghi");
+    column1->append_datum({});
+
+    auto replace_col2 = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
+    replace_col2->append_datum({});
+    replace_col2->append_datum("jk");
+
+    ASSERT_TRUE(column1->replace_rows(*replace_col2.get(), replace_idxes.data()).ok());
+    ASSERT_EQ(5, column1->size());
+    ASSERT_TRUE(column1->data_column().unique());
+    ASSERT_TRUE(column1->null_column().unique());
+    ASSERT_EQ(5, column1->data_column()->size());
+    ASSERT_EQ(5, column1->null_column()->size());
+
+    ASSERT_EQ("abc", column1->get(0).get_slice().to_string());
+    ASSERT_TRUE(column1->get(1).is_null());
+    ASSERT_TRUE(column1->get(2).is_null());
+    ASSERT_EQ("ghi", column1->get(3).get_slice().to_string());
+    ASSERT_EQ("jk", column1->get(4).get_slice().to_string());
 }
 
 } // namespace starrocks::vectorized

--- a/be/test/column/object_column_test.cpp
+++ b/be/test/column/object_column_test.cpp
@@ -24,7 +24,9 @@
 #include <gtest/gtest.h>
 
 #include "column/const_column.h"
+#include "exprs/vectorized/percentile_functions.h"
 #include "storage/hll.h"
+#include "util/percentile_value.h"
 
 namespace starrocks::vectorized {
 
@@ -185,6 +187,41 @@ TEST(ObjectColumnTest, HLL_test_swap_column) {
     ASSERT_EQ(1, c2->get_data().size());
     ASSERT_EQ(3, c1->size());
     ASSERT_EQ(3, c1->get_data().size());
+}
+
+TEST(ObjectColumnTest, Percentile_test_swap_column) {
+    Columns columns;
+    FunctionContext* ctx = FunctionContext::create_test_context();
+    auto s = DoubleColumn::create();
+    s->append(1);
+    s->append(2);
+    s->append(3);
+    columns.push_back(s);
+
+    auto column = PercentileFunctions::percentile_hash(ctx, columns);
+    ASSERT_TRUE(column->is_object());
+
+    auto percentile = ColumnHelper::cast_to<TYPE_PERCENTILE>(column);
+    ASSERT_EQ(1, percentile->get_object(0)->quantile(1));
+    ASSERT_EQ(2, percentile->get_object(1)->quantile(1));
+    ASSERT_EQ(3, percentile->get_object(2)->quantile(1));
+
+    auto s1 = DoubleColumn::create();
+    s1->append(4);
+    columns.clear();
+    columns.push_back(s1);
+    auto column1 = PercentileFunctions::percentile_hash(ctx, columns);
+    ASSERT_TRUE(column1->is_object());
+
+    std::vector<uint32_t> idx = {1};
+    ASSERT_TRUE(column->update_rows(*column1.get(), idx.data()).ok());
+
+    percentile = ColumnHelper::cast_to<TYPE_PERCENTILE>(column);
+    ASSERT_EQ(1, percentile->get_object(0)->quantile(1));
+    ASSERT_EQ(4, percentile->get_object(1)->quantile(1));
+    ASSERT_EQ(3, percentile->get_object(2)->quantile(1));
+
+    delete ctx;
 }
 
 } // namespace starrocks::vectorized


### PR DESCRIPTION
Add interface::update_rows into `Column` to support column modification
The function definition is shown below
```
// This function will update data from src according to the input indexes. 'indexes' contains
// the row indexes will be update
// For example:
//      input indexes: [0, 3]
//      column data: [0, 1, 2, 3, 4]
//      src_column data: [5, 6]
// After call this function, column data will be set as [5, 1, 2, 6, 4]
Status update_rows(const Column& src, const uint32_t* indexes);
```
