### PR TITLE
Fix query error in global dictionary when replicas are inconsistent

### DIFF
--- a/be/src/runtime/global_dicts.h
+++ b/be/src/runtime/global_dicts.h
@@ -44,6 +44,15 @@ inline std::ostream& operator<<(std::ostream& stream, const RGlobalDictMap& map)
     return stream;
 }
 
+inline std::ostream& operator<<(std::ostream& stream, const GlobalDictMap& map) {
+    stream << "[";
+    for (const auto& [k, v] : map) {
+        stream << "(" << k << "," << v << "),";
+    }
+    stream << "]";
+    return stream;
+}
+
 // column-name -> GlobalDictMap
 using GlobalDictByNameMaps = phmap::flat_hash_map<std::string, GlobalDictMap>;
 

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -75,6 +75,7 @@ add_library(Storage STATIC
     rowset/column_iterator.cpp
     rowset/column_reader.cpp
     rowset/column_writer.cpp
+    rowset/column_decoder.cpp
     rowset/default_value_column_iterator.cpp
     rowset/dictcode_column_iterator.cpp
     rowset/encoding_info.cpp

--- a/be/src/storage/rowset/column_decoder.cpp
+++ b/be/src/storage/rowset/column_decoder.cpp
@@ -1,0 +1,65 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#include "storage/rowset/column_decoder.h"
+
+#include "column/binary_column.h"
+#include "column/nullable_column.h"
+#include "common/compiler_util.h"
+#include "fmt/core.h"
+#include "gutil/casts.h"
+#include "storage/rowset/dictcode_column_iterator.h"
+
+namespace starrocks {
+Status ColumnDecoder::encode_to_global_id(vectorized::Column* datas, vectorized::Column* codes) {
+    const auto ed = _global_dict->end();
+    size_t num_rows = datas->size();
+    codes->resize(num_rows);
+    if (datas->is_nullable()) {
+        auto* nullable_column = down_cast<vectorized::NullableColumn*>(datas);
+        auto* binary_column = down_cast<vectorized::BinaryColumn*>(nullable_column->data_column().get());
+        auto* lowcard_nullcolumn = down_cast<vectorized::NullableColumn*>(codes);
+        auto* lowcard_datacolumn = down_cast<vectorized::LowCardDictColumn*>(lowcard_nullcolumn->data_column().get());
+        auto& lowcard_data = lowcard_datacolumn->get_data();
+        const auto& null_data = nullable_column->null_column_data();
+        for (int i = 0; i < num_rows; ++i) {
+            if (null_data[i] == 0) {
+                auto iter = _global_dict->find(binary_column->get_slice(i));
+                if (LIKELY(iter != ed)) {
+                    lowcard_data[i] = iter->second;
+                } else {
+                    return Status::InternalError(fmt::format("Not Found string in global dict: {}",
+                                                             binary_column->get_slice(i).to_string()));
+                }
+            }
+        }
+    } else {
+        auto* binary_column = down_cast<vectorized::BinaryColumn*>(datas);
+        auto* lowcard_column = down_cast<vectorized::LowCardDictColumn*>(codes);
+        auto& lowcard_data = lowcard_column->get_data();
+        for (int i = 0; i < num_rows; ++i) {
+            auto iter = _global_dict->find(binary_column->get_slice(i));
+            if (LIKELY(iter != ed)) {
+                lowcard_data[i] = iter->second;
+            } else {
+                return Status::InternalError(
+                        fmt::format("Not Found string in global dict: {}", binary_column->get_slice(i).to_string()));
+            }
+        }
+    }
+    return Status::OK();
+}
+
+void ColumnDecoder::check_code_convert_map() {
+    if (_global_dict && _all_page_dict_encoded) {
+        std::vector<int16_t> code_convert_map;
+        auto* scalar_iter = down_cast<ScalarColumnIterator*>(_iter);
+        Status st = GlobalDictCodeColumnIterator::build_code_convert_map(&code_convert_map, scalar_iter, _global_dict);
+        if (st.ok()) {
+            _code_convert_map = std::move(code_convert_map);
+        } else {
+            LOG(INFO) << st.to_string() << " will force the use of the global dictionary encoding";
+        }
+    }
+}
+
+} // namespace starrocks

--- a/be/src/storage/rowset/column_decoder.cpp
+++ b/be/src/storage/rowset/column_decoder.cpp
@@ -49,11 +49,11 @@ Status ColumnDecoder::encode_to_global_id(vectorized::Column* datas, vectorized:
     return Status::OK();
 }
 
-void ColumnDecoder::check_code_convert_map() {
+void ColumnDecoder::check_global_dict() {
     if (_global_dict && _all_page_dict_encoded) {
         std::vector<int16_t> code_convert_map;
         auto* scalar_iter = down_cast<ScalarColumnIterator*>(_iter);
-        Status st = GlobalDictCodeColumnIterator::build_code_convert_map(&code_convert_map, scalar_iter, _global_dict);
+        Status st = GlobalDictCodeColumnIterator::build_code_convert_map(scalar_iter, _global_dict, &code_convert_map);
         if (st.ok()) {
             _code_convert_map = std::move(code_convert_map);
         } else {

--- a/be/src/storage/rowset/column_decoder.h
+++ b/be/src/storage/rowset/column_decoder.h
@@ -30,8 +30,8 @@ public:
 
     void set_all_page_dict_encoded(bool all_page_dict_encoded) { _all_page_dict_encoded = all_page_dict_encoded; }
     void set_global_dict(vectorized::GlobalDictMap* global_dict) { _global_dict = global_dict; }
-    // Check if the local dictionary can be covered by the global dictionary
-    void check_code_convert_map();
+    // check global dict is superset of local dict
+    void check_global_dict();
 
     Status encode_to_global_id(vectorized::Column* datas, vectorized::Column* codes);
     bool need_force_encode_to_global_id() const {

--- a/be/src/storage/rowset/column_decoder.h
+++ b/be/src/storage/rowset/column_decoder.h
@@ -2,6 +2,11 @@
 
 #pragma once
 
+#include <optional>
+
+#include "column/binary_column.h"
+#include "column/vectorized_fwd.h"
+#include "runtime/global_dicts.h"
 #include "storage/rowset/column_iterator.h"
 
 namespace starrocks {
@@ -9,8 +14,7 @@ namespace starrocks {
 // To handle DictDecode
 class ColumnDecoder {
 public:
-    ColumnDecoder() : _iter(nullptr) {}
-    explicit ColumnDecoder(ColumnIterator* iter) : _iter(iter) {}
+    ColumnDecoder() = default;
 
     void set_iterator(ColumnIterator* iter) { _iter = iter; }
 
@@ -21,12 +25,26 @@ public:
 
     Status decode_values_by_rowid(const vectorized::Column& rowids, vectorized::Column* values) {
         DCHECK(_iter != nullptr);
-        RETURN_IF_ERROR(_iter->fetch_values_by_rowid(rowids, values));
-        return Status::OK();
+        return _iter->fetch_values_by_rowid(rowids, values);
     }
 
+    void set_all_page_dict_encoded(bool all_page_dict_encoded) { _all_page_dict_encoded = all_page_dict_encoded; }
+    void set_global_dict(vectorized::GlobalDictMap* global_dict) { _global_dict = global_dict; }
+    // Check if the local dictionary can be covered by the global dictionary
+    void check_code_convert_map();
+
+    Status encode_to_global_id(vectorized::Column* datas, vectorized::Column* codes);
+    bool need_force_encode_to_global_id() const {
+        return (!_all_page_dict_encoded && _global_dict) || (!_code_convert_map.has_value() && _global_dict);
+    }
+
+    int16_t* code_convert_data() { return _code_convert_map.has_value() ? _code_convert_map->data() + 1 : nullptr; }
+
 private:
-    ColumnIterator* _iter;
+    std::optional<std::vector<int16_t>> _code_convert_map;
+    ColumnIterator* _iter = nullptr;
+    vectorized::GlobalDictMap* _global_dict = nullptr;
+    bool _all_page_dict_encoded = false;
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/dictcode_column_iterator.cpp
+++ b/be/src/storage/rowset/dictcode_column_iterator.cpp
@@ -7,14 +7,11 @@
 
 namespace starrocks {
 
-Status GlobalDictCodeColumnIterator::_build_to_global_dict() {
-    DCHECK(_col_iter->all_page_dict_encoded());
+Status GlobalDictCodeColumnIterator::build_code_convert_map(std::vector<int16_t>* code_convert_map,
+                                                            ScalarColumnIterator* file_column_iter,
+                                                            GlobalDictMap* global_dict) {
+    DCHECK(file_column_iter->all_page_dict_encoded());
 
-    // we only have to build code mapping once
-    if (_local_to_global_holder.size() > 0) {
-        return Status::OK();
-    }
-    auto file_column_iter = down_cast<ScalarColumnIterator*>(_col_iter);
     int dict_size = file_column_iter->dict_size();
 
     auto column = vectorized::BinaryColumn::create();
@@ -24,21 +21,21 @@ Status GlobalDictCodeColumnIterator::_build_to_global_dict() {
         dict_codes[i] = i;
     }
 
-    file_column_iter->decode_dict_codes(dict_codes, dict_size, column.get());
+    RETURN_IF_ERROR(file_column_iter->decode_dict_codes(dict_codes, dict_size, column.get()));
 
-    _local_to_global_holder.resize(dict_size + 2);
-    std::fill(_local_to_global_holder.begin(), _local_to_global_holder.end(), 0);
-    _local_to_global = _local_to_global_holder.data() + 1;
+    code_convert_map->resize(dict_size + 2);
+    std::fill(code_convert_map->begin(), code_convert_map->end(), 0);
+    auto* local_to_global = code_convert_map->data() + 1;
 
     for (int i = 0; i < dict_size; ++i) {
         auto slice = column->get_slice(i);
-        auto res = _global_dict->find(slice);
-        if (res == _global_dict->end()) {
+        auto res = global_dict->find(slice);
+        if (res == global_dict->end()) {
             if (slice.size > 0) {
-                return Status::InternalError(fmt::format("not found slice:{} in global dict", slice.data));
+                return Status::InternalError(fmt::format("not found slice:{} in global dict", slice.to_string()));
             }
         } else {
-            _local_to_global[dict_codes[i]] = res->second;
+            local_to_global[dict_codes[i]] = res->second;
         }
     }
     return Status::OK();

--- a/be/src/storage/rowset/dictcode_column_iterator.cpp
+++ b/be/src/storage/rowset/dictcode_column_iterator.cpp
@@ -7,9 +7,9 @@
 
 namespace starrocks {
 
-Status GlobalDictCodeColumnIterator::build_code_convert_map(std::vector<int16_t>* code_convert_map,
-                                                            ScalarColumnIterator* file_column_iter,
-                                                            GlobalDictMap* global_dict) {
+Status GlobalDictCodeColumnIterator::build_code_convert_map(ScalarColumnIterator* file_column_iter,
+                                                            GlobalDictMap* global_dict,
+                                                            std::vector<int16_t>* code_convert_map) {
     DCHECK(file_column_iter->all_page_dict_encoded());
 
     int dict_size = file_column_iter->dict_size();

--- a/be/src/storage/rowset/dictcode_column_iterator.h
+++ b/be/src/storage/rowset/dictcode_column_iterator.h
@@ -7,6 +7,7 @@
 #include "column/column.h"
 #include "runtime/global_dicts.h"
 #include "storage/rowset/column_iterator.h"
+#include "storage/rowset/scalar_column_iterator.h"
 #include "storage/vectorized/range.h"
 
 namespace starrocks {
@@ -76,8 +77,8 @@ public:
     using GlobalDictMap = starrocks::vectorized::GlobalDictMap;
     using LowCardDictColumn = starrocks::vectorized::LowCardDictColumn;
 
-    GlobalDictCodeColumnIterator(ColumnId cid, ColumnIterator* iter, GlobalDictMap* gdict)
-            : _cid(cid), _col_iter(iter), _global_dict(gdict) {}
+    GlobalDictCodeColumnIterator(ColumnId cid, ColumnIterator* iter, int16_t* code_convert_data, GlobalDictMap* gdict)
+            : _cid(cid), _col_iter(iter), _local_to_global(code_convert_data), _global_dict(gdict) {}
 
     ~GlobalDictCodeColumnIterator() = default;
 
@@ -124,7 +125,6 @@ public:
     }
 
     Status decode_dict_codes(const int32_t* codes, size_t size, vectorized::Column* words) override {
-        RETURN_IF_ERROR(_build_to_global_dict());
         LowCardDictColumn::Container* container = nullptr;
         bool output_nullable = words->is_nullable();
 
@@ -161,16 +161,16 @@ public:
         return _col_iter->get_row_ranges_by_zone_map(predicates, del_predicate, row_ranges);
     }
 
+    static Status build_code_convert_map(std::vector<int16_t>* code_convert_map, ScalarColumnIterator* file_column_iter,
+                                         GlobalDictMap* global_dict);
+
 private:
-    Status _build_to_global_dict();
     void _init_local_dict_col();
     void _acquire_null_data(Column* global_dict_column, Column* local_dict_column);
     const LowCardDictColumn::Container& _get_local_dict_col_container(Column* column);
 
     ColumnId _cid;
     ColumnIterator* _col_iter;
-
-    std::vector<int16_t> _local_to_global_holder;
 
     // _local_to_global[-1] is accessable
     int16_t* _local_to_global;

--- a/be/src/storage/rowset/dictcode_column_iterator.h
+++ b/be/src/storage/rowset/dictcode_column_iterator.h
@@ -161,8 +161,8 @@ public:
         return _col_iter->get_row_ranges_by_zone_map(predicates, del_predicate, row_ranges);
     }
 
-    static Status build_code_convert_map(std::vector<int16_t>* code_convert_map, ScalarColumnIterator* file_column_iter,
-                                         GlobalDictMap* global_dict);
+    static Status build_code_convert_map(ScalarColumnIterator* file_column_iter, GlobalDictMap* global_dict,
+                                         std::vector<int16_t>* code_convert_map);
 
 private:
     void _init_local_dict_col();

--- a/be/src/storage/rowset/vectorized/segment_iterator.cpp
+++ b/be/src/storage/rowset/vectorized/segment_iterator.cpp
@@ -96,8 +96,8 @@ private:
         void close() {
             _read_chunk.reset();
             _dict_chunk.reset();
-            _pre_final_chunk.reset();
             _final_chunk.reset();
+            _adapt_global_dict_chunk.reset();
         }
 
         Status seek_columns(ordinal_t pos) {
@@ -133,8 +133,9 @@ private:
             int64_t usage = 0;
             usage += (_read_chunk != nullptr) ? _read_chunk->memory_usage() : 0;
             usage += (_dict_chunk.get() != _read_chunk.get()) ? _dict_chunk->memory_usage() : 0;
-            usage += (_pre_final_chunk.get() != _dict_chunk.get()) ? _pre_final_chunk->memory_usage() : 0;
-            usage += (_pre_final_chunk.get() != _final_chunk.get()) ? _final_chunk->memory_usage() : 0;
+            usage += (_final_chunk.get() != _dict_chunk.get()) ? _final_chunk->memory_usage() : 0;
+            usage += (_adapt_global_dict_chunk.get() != _final_chunk.get()) ? _adapt_global_dict_chunk->memory_usage()
+                                                                            : 0;
             return usage;
         }
 
@@ -153,8 +154,8 @@ private:
 
         std::shared_ptr<Chunk> _read_chunk;
         std::shared_ptr<Chunk> _dict_chunk;
-        std::shared_ptr<Chunk> _pre_final_chunk;
         std::shared_ptr<Chunk> _final_chunk;
+        std::shared_ptr<Chunk> _adapt_global_dict_chunk;
 
         // true iff |_is_dict_column| contains at least one `true`, i.e,
         // |_column_iterators| contains at least one `DictCodeColumnIterator`.
@@ -204,7 +205,7 @@ private:
 
     Status _finish_late_materialization(ScanContext* ctx);
 
-    Status _build_pre_final_chunk(ScanContext* ctx);
+    Status _build_final_chunk(ScanContext* ctx);
 
     Status _encode_to_global_id(ScanContext* ctx);
 
@@ -664,8 +665,8 @@ Status SegmentIterator::_do_get_next(Chunk* result, vector<rowid_t>* rowid) {
 
     _context->_read_chunk->reset();
     _context->_dict_chunk->reset();
-    _context->_pre_final_chunk->reset();
     _context->_final_chunk->reset();
+    _context->_adapt_global_dict_chunk->reset();
 
     Chunk* chunk = _context->_read_chunk.get();
 
@@ -703,12 +704,12 @@ Status SegmentIterator::_do_get_next(Chunk* result, vector<rowid_t>* rowid) {
         RETURN_IF_ERROR(_decode_dict_codes(_context));
     }
 
-    _build_pre_final_chunk(_context);
-    chunk = _context->_pre_final_chunk.get();
+    _build_final_chunk(_context);
+    chunk = _context->_final_chunk.get();
 
     bool need_switch_context = false;
     if (_context->_late_materialize) {
-        chunk = _context->_pre_final_chunk.get();
+        chunk = _context->_final_chunk.get();
         SCOPED_RAW_TIMER(&_opts.stats->late_materialize_ns);
         RETURN_IF_ERROR(_finish_late_materialization(_context));
         if (_context->_next != nullptr && (chunk_size * 1000 > total_read * _late_materialization_ratio)) {
@@ -748,9 +749,9 @@ Status SegmentIterator::_do_get_next(Chunk* result, vector<rowid_t>* rowid) {
 
     if (_context->_has_force_dict_encode) {
         RETURN_IF_ERROR(_encode_to_global_id(_context));
+        chunk = _context->_adapt_global_dict_chunk.get();
     }
 
-    chunk = _context->_final_chunk.get();
     result->swap_chunk(*chunk);
 
     if (need_switch_context) {
@@ -793,13 +794,14 @@ void SegmentIterator::_switch_context(ScanContext* to) {
                 _encoded_schema.append(field);
             }
         }
-        to->_pre_final_chunk = ChunkHelper::new_chunk(this->_encoded_schema, _opts.chunk_size);
+        to->_final_chunk = ChunkHelper::new_chunk(this->_encoded_schema, _opts.chunk_size);
     } else {
-        to->_pre_final_chunk = ChunkHelper::new_chunk(this->output_schema(), _opts.chunk_size);
+        to->_final_chunk = ChunkHelper::new_chunk(this->output_schema(), _opts.chunk_size);
     }
 
-    to->_final_chunk = to->_has_force_dict_encode ? ChunkHelper::new_chunk(this->output_schema(), _opts.chunk_size)
-                                                  : to->_pre_final_chunk;
+    to->_adapt_global_dict_chunk = to->_has_force_dict_encode
+                                           ? ChunkHelper::new_chunk(this->output_schema(), _opts.chunk_size)
+                                           : to->_final_chunk;
 
     _context = to;
 }
@@ -1185,7 +1187,7 @@ Status SegmentIterator::_finish_late_materialization(ScanContext* ctx) {
     for (size_t i = m - 1, j = start_pos; i < n; i++, j++) {
         const FieldPtr& f = _schema.field(i);
         const ColumnId cid = f->id();
-        ColumnPtr& col = ctx->_pre_final_chunk->get_column_by_index(j);
+        ColumnPtr& col = ctx->_final_chunk->get_column_by_index(j);
         col->reserve(ordinals->size());
         col->resize(0);
 
@@ -1193,32 +1195,32 @@ Status SegmentIterator::_finish_late_materialization(ScanContext* ctx) {
         DCHECK_EQ(ordinals->size(), col->size());
         may_has_del_row |= (col->delete_state() != DEL_NOT_SATISFIED);
     }
-    ctx->_pre_final_chunk->set_delete_state(may_has_del_row ? DEL_PARTIAL_SATISFIED : DEL_NOT_SATISFIED);
-    ctx->_pre_final_chunk->check_or_die();
+    ctx->_final_chunk->set_delete_state(may_has_del_row ? DEL_PARTIAL_SATISFIED : DEL_NOT_SATISFIED);
+    ctx->_final_chunk->check_or_die();
 
     return Status::OK();
 }
 
-Status SegmentIterator::_build_pre_final_chunk(ScanContext* ctx) {
+Status SegmentIterator::_build_final_chunk(ScanContext* ctx) {
     // trim all use less columns
     Columns& input_columns = ctx->_dict_chunk->columns();
     for (size_t i = 0; i < ctx->_read_index_map.size(); i++) {
-        ctx->_pre_final_chunk->get_column_by_index(i).swap(input_columns[ctx->_read_index_map[i]]);
+        ctx->_final_chunk->get_column_by_index(i).swap(input_columns[ctx->_read_index_map[i]]);
     }
     bool may_has_del_row = ctx->_dict_chunk->delete_state() != DEL_NOT_SATISFIED;
-    ctx->_pre_final_chunk->set_delete_state(may_has_del_row ? DEL_PARTIAL_SATISFIED : DEL_NOT_SATISFIED);
+    ctx->_final_chunk->set_delete_state(may_has_del_row ? DEL_PARTIAL_SATISFIED : DEL_NOT_SATISFIED);
     return Status::OK();
 }
 
 Status SegmentIterator::_encode_to_global_id(ScanContext* ctx) {
-    int num_columns = ctx->_pre_final_chunk->num_columns();
-    auto final_chunk = ctx->_pre_final_chunk;
+    int num_columns = ctx->_final_chunk->num_columns();
+    auto final_chunk = ctx->_final_chunk;
 
     for (size_t i = 0; i < num_columns; i++) {
         const FieldPtr& f = _schema.field(i);
         const ColumnId cid = f->id();
-        ColumnPtr& col = ctx->_pre_final_chunk->get_column_by_index(i);
-        ColumnPtr& dst = ctx->_final_chunk->get_column_by_index(i);
+        ColumnPtr& col = ctx->_final_chunk->get_column_by_index(i);
+        ColumnPtr& dst = ctx->_adapt_global_dict_chunk->get_column_by_index(i);
         if (_column_decoders[cid].need_force_encode_to_global_id()) {
             RETURN_IF_ERROR(_column_decoders[cid].encode_to_global_id(col.get(), dst.get()));
         } else {

--- a/be/src/storage/vectorized/chunk_iterator.h
+++ b/be/src/storage/vectorized/chunk_iterator.h
@@ -67,7 +67,7 @@ public:
 
     // Returns the Schema of the result.
     // If a Field uses the global dictionary strategy, the field will be rewritten as INT
-    const Schema& encoded_schema() const { return _encoded_schema; }
+    const Schema& encoded_schema() const { return _encoded_schema.num_fields() == 0 ? _schema : _encoded_schema; }
 
     virtual Status init_encoded_schema(ColumnIdToGlobalDictMap& dict_maps) {
         _encoded_schema.reserve(schema().num_fields());

--- a/be/src/storage/vectorized/column_predicate_rewriter.h
+++ b/be/src/storage/vectorized/column_predicate_rewriter.h
@@ -7,6 +7,7 @@
 #include "column/schema.h"
 #include "common/object_pool.h"
 #include "storage/olap_common.h"
+#include "storage/rowset/column_decoder.h"
 #include "storage/rowset/column_reader.h"
 #include "storage/vectorized/column_predicate.h"
 #include "storage/vectorized/conjunctive_predicates.h"
@@ -58,15 +59,22 @@ private:
 class ConjunctivePredicatesRewriter {
 public:
     ConjunctivePredicatesRewriter(ConjunctivePredicates& predicates, const ColumnIdToGlobalDictMap& dict_maps)
-            : _predicates(predicates), _dict_maps(dict_maps) {}
+            : ConjunctivePredicatesRewriter(predicates, dict_maps, nullptr) {}
+    ConjunctivePredicatesRewriter(ConjunctivePredicates& predicates, const ColumnIdToGlobalDictMap& dict_maps,
+                                  std::vector<uint8_t>* disable_rewrite)
+            : _predicates(predicates), _dict_maps(dict_maps), _disable_rewrite(disable_rewrite) {}
 
     void rewrite_predicate(ObjectPool* pool);
 
-    bool column_need_rewrite(ColumnId cid) { return _dict_maps.count(cid); }
+    bool column_need_rewrite(ColumnId cid) {
+        if (_disable_rewrite && (*_disable_rewrite)[cid]) return false;
+        return _dict_maps.count(cid);
+    }
 
 private:
     ConjunctivePredicates& _predicates;
     const ColumnIdToGlobalDictMap& _dict_maps;
+    std::vector<uint8_t>* _disable_rewrite;
 };
 
 } // namespace starrocks::vectorized

--- a/be/src/storage/vectorized/column_predicate_rewriter.h
+++ b/be/src/storage/vectorized/column_predicate_rewriter.h
@@ -62,19 +62,19 @@ public:
             : ConjunctivePredicatesRewriter(predicates, dict_maps, nullptr) {}
     ConjunctivePredicatesRewriter(ConjunctivePredicates& predicates, const ColumnIdToGlobalDictMap& dict_maps,
                                   std::vector<uint8_t>* disable_rewrite)
-            : _predicates(predicates), _dict_maps(dict_maps), _disable_rewrite(disable_rewrite) {}
+            : _predicates(predicates), _dict_maps(dict_maps), _disable_dict_rewrite(disable_rewrite) {}
 
     void rewrite_predicate(ObjectPool* pool);
 
     bool column_need_rewrite(ColumnId cid) {
-        if (_disable_rewrite && (*_disable_rewrite)[cid]) return false;
+        if (_disable_dict_rewrite && (*_disable_dict_rewrite)[cid]) return false;
         return _dict_maps.count(cid);
     }
 
 private:
     ConjunctivePredicates& _predicates;
     const ColumnIdToGlobalDictMap& _dict_maps;
-    std::vector<uint8_t>* _disable_rewrite;
+    std::vector<uint8_t>* _disable_dict_rewrite;
 };
 
 } // namespace starrocks::vectorized


### PR DESCRIPTION
In some cases where replicas are inconsistent, the segment may
not have a dictionary encoding page, but at this time,
the FE holds the global dictionary, which will cause the query to fail.

We need to make some adjustments
Add a stage, when a column of the final chunk is a string
and the column needs to use the global dictionary,
we convert the string of this column to the global dictionary encoding.

will close #2873 