### PR TITLE
Remove unused operator's mem_tracker and modify the meaning of mem_limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ fs_brokers/apache_hdfs_broker/src/main/thrift/
 dependency-reduced-pom.xml
 tags
 .tags
+.cache
 *.vim
 compile_commands.json
 

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.cpp
@@ -8,7 +8,7 @@ namespace starrocks::pipeline {
 
 Status AggregateBlockingSinkOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(Operator::prepare(state));
-    RETURN_IF_ERROR(_aggregator->prepare(state, state->obj_pool(), get_runtime_profile(), _mem_tracker.get()));
+    RETURN_IF_ERROR(_aggregator->prepare(state, state->obj_pool(), get_runtime_profile(), _mem_tracker));
     return _aggregator->open(state);
 }
 

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.cpp
@@ -8,7 +8,7 @@ namespace starrocks::pipeline {
 
 Status AggregateDistinctBlockingSinkOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(Operator::prepare(state));
-    RETURN_IF_ERROR(_aggregator->prepare(state, state->obj_pool(), get_runtime_profile(), _mem_tracker.get()));
+    RETURN_IF_ERROR(_aggregator->prepare(state, state->obj_pool(), get_runtime_profile(), _mem_tracker));
     return _aggregator->open(state);
 }
 

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.cpp
@@ -8,7 +8,7 @@ namespace starrocks::pipeline {
 
 Status AggregateDistinctStreamingSinkOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(Operator::prepare(state));
-    RETURN_IF_ERROR(_aggregator->prepare(state, state->obj_pool(), get_runtime_profile(), _mem_tracker.get()));
+    RETURN_IF_ERROR(_aggregator->prepare(state, state->obj_pool(), get_runtime_profile(), _mem_tracker));
     return _aggregator->open(state);
 }
 

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
@@ -8,7 +8,7 @@ namespace starrocks::pipeline {
 
 Status AggregateStreamingSinkOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(Operator::prepare(state));
-    RETURN_IF_ERROR(_aggregator->prepare(state, state->obj_pool(), get_runtime_profile(), _mem_tracker.get()));
+    RETURN_IF_ERROR(_aggregator->prepare(state, state->obj_pool(), get_runtime_profile(), _mem_tracker));
     return _aggregator->open(state);
 }
 

--- a/be/src/exec/pipeline/operator.cpp
+++ b/be/src/exec/pipeline/operator.cpp
@@ -28,10 +28,10 @@ Operator::Operator(OperatorFactory* factory, int32_t id, const std::string& name
     }
     _runtime_profile = std::make_shared<RuntimeProfile>(profile_name);
     _runtime_profile->set_metadata(_id);
-    _mem_tracker = std::make_unique<MemTracker>(_runtime_profile.get(), -1, _runtime_profile->name(), nullptr);
 }
 
 Status Operator::prepare(RuntimeState* state) {
+    _mem_tracker = state->instance_mem_tracker();
     _total_timer = ADD_TIMER(_runtime_profile, "OperatorTotalTime");
     _push_timer = ADD_TIMER(_runtime_profile, "PushTotalTime");
     _pull_timer = ADD_TIMER(_runtime_profile, "PullTotalTime");

--- a/be/src/exec/pipeline/operator.h
+++ b/be/src/exec/pipeline/operator.h
@@ -141,7 +141,7 @@ protected:
     // Which plan node this operator belongs to
     const int32_t _plan_node_id;
     std::shared_ptr<RuntimeProfile> _runtime_profile;
-    std::unique_ptr<MemTracker> _mem_tracker;
+    MemTracker* _mem_tracker = nullptr;
     bool _conjuncts_and_in_filters_is_cached = false;
     std::vector<ExprContext*> _cached_conjuncts_and_in_filters;
 

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -100,7 +100,7 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state) {
         size_t num_chunk_moved = 0;
         bool should_yield = false;
         size_t num_operators = _operators.size();
-        size_t _new_first_unfinished = _first_unfinished;
+        size_t new_first_unfinished = _first_unfinished;
         for (size_t i = _first_unfinished; i < num_operators - 1; ++i) {
             {
                 SCOPED_RAW_TIMER(&time_spent);
@@ -114,7 +114,7 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state) {
                         _mark_operator_finishing(curr_op, runtime_state);
                     }
                     _mark_operator_finishing(next_op, runtime_state);
-                    _new_first_unfinished = i + 1;
+                    new_first_unfinished = i + 1;
                     continue;
                 }
 
@@ -174,7 +174,7 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state) {
                         _mark_operator_finishing(curr_op, runtime_state);
                     }
                     _mark_operator_finishing(next_op, runtime_state);
-                    _new_first_unfinished = i + 1;
+                    new_first_unfinished = i + 1;
                     continue;
                 }
             }
@@ -186,10 +186,10 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state) {
             }
         }
         // close finished operators and update _first_unfinished index
-        for (auto i = _first_unfinished; i < _new_first_unfinished; ++i) {
+        for (auto i = _first_unfinished; i < new_first_unfinished; ++i) {
             _mark_operator_finished(_operators[i], runtime_state);
         }
-        _first_unfinished = _new_first_unfinished;
+        _first_unfinished = new_first_unfinished;
 
         if (sink_operator()->is_finished()) {
             finish_operators(runtime_state);

--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -557,10 +557,6 @@ pipeline::OpFactories OlapScanNode::decompose_to_pipeline(pipeline::PipelineBuil
                                                                std::move(_conjunct_ctxs), limit());
     // Initialize OperatorFactory's fields involving runtime filters.
     this->init_runtime_filter_for_operator(scan_operator.get(), context, rc_rf_probe_collector);
-    auto& morsel_queues = context->fragment_context()->morsel_queues();
-    auto source_id = scan_operator->plan_node_id();
-    DCHECK(morsel_queues.count(source_id));
-    auto& morsel_queue = morsel_queues[source_id];
     scan_operator->set_degree_of_parallelism(context->get_dop_of_scan_node(this->id()));
     operators.emplace_back(std::move(scan_operator));
     if (limit() != -1) {


### PR DESCRIPTION
# Remove unused operator's mem_tracker

Operator's `_mem_tracker` is unused, and replace it with instance's `mem_tracker`

# Modify the meaning of mem_limit

Session variable `exec_mem_limit` means the largest bytes that one fragment instance can use.
* For non-pipeline engine, it is ok. For example, `mem_limit` set to 2G, `parallel_fragment_exec_instance_num` set to 3, so the amount of memory limitation is 6G
* For pipeline engine, one fragment instance can have multipy pipeline drivers which share the `exec_mem_limit`. For example, `mem_limit` set to 2G, `parallel_fragment_exec_instance_num` set to 1 and `pipeline_dop` set to 3, the amount of memory limitation is still 2G (regardless of `pipeline_dop`)

So why  multiply by `degree_of_parallelism`? Make sure that user change from non-pipeline engine to pipeline engine without modifying session variable `exec_mem_limit`

Therefore, the meaning of `exec_mem_limit` becomes the largest bytes that the maximum number of bytes per degree of parallelism can use