### PR TITLE
Fix Fe ut

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -205,8 +205,9 @@ public class ExpressionStatisticCalculator {
                     return new ColumnStatistic(0, inputStatistics.getOutputRowCount(), 0,
                             callOperator.getType().getTypeSize(), rowCount);
                 case FunctionSet.MULTI_DISTINCT_COUNT:
+                    // use child column averageRowSize instead call operator type size
                     return new ColumnStatistic(0, columnStatistic.getDistinctValuesCount(), 0,
-                            callOperator.getType().getTypeSize(), rowCount);
+                            columnStatistic.getAverageRowSize(), rowCount);
                 // use child column statistics for now
                 case FunctionSet.SUM:
                 case FunctionSet.AVG:


### PR DESCRIPTION
compute MULTI_DISTINCT_COUNT function average size error, shold use child statistics instead of call operator type size