### PR TITLE
Primary key not exhibit aggregation type when executing show column statement

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/CreateTableStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/CreateTableStmt.java
@@ -412,7 +412,7 @@ public class CreateTableStmt extends DdlStmt {
 
         for (ColumnDef columnDef : columnDefs) {
             Column col = columnDef.toColumn();
-            if (keysDesc != null && keysDesc.getKeysType() == KeysType.UNIQUE_KEYS) {
+            if (keysDesc != null && (keysDesc.getKeysType() == KeysType.UNIQUE_KEYS || keysDesc.getKeysType() == KeysType.PRIMARY_KEYS)) {
                 if (!col.isKey()) {
                     col.setAggregationTypeImplicit(true);
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/CreateTableStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/CreateTableStmt.java
@@ -412,7 +412,8 @@ public class CreateTableStmt extends DdlStmt {
 
         for (ColumnDef columnDef : columnDefs) {
             Column col = columnDef.toColumn();
-            if (keysDesc != null && (keysDesc.getKeysType() == KeysType.UNIQUE_KEYS || keysDesc.getKeysType() == KeysType.PRIMARY_KEYS)) {
+            if (keysDesc != null && (keysDesc.getKeysType() == KeysType.UNIQUE_KEYS
+                    || keysDesc.getKeysType() == KeysType.PRIMARY_KEYS || keysDesc.getKeysType() == KeysType.DUP_KEYS)) {
                 if (!col.isKey()) {
                     col.setAggregationTypeImplicit(true);
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -86,6 +86,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DynamicPartitionProperty;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.Index;
+import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndex.IndexExtState;
 import com.starrocks.catalog.MaterializedIndexMeta;
@@ -676,6 +677,8 @@ public class ShowExecutor {
                         matcher = PatternMatcher.createMysqlPattern(showStmt.getPattern(),
                                 CaseSensibility.COLUMN.getCaseSensibility());
                     }
+                    boolean isPrimaryKey = table.getType() == Table.TableType.OLAP
+                            && ((OlapTable) table).getKeysType() == KeysType.PRIMARY_KEYS;
                     List<Column> columns = table.getBaseSchema();
                     for (Column col : columns) {
                         if (matcher != null && !matcher.match(col.getName())) {
@@ -686,7 +689,8 @@ public class ShowExecutor {
                         final String isAllowNull = col.isAllowNull() ? "YES" : "NO";
                         final String isKey = col.isKey() ? "YES" : "NO";
                         final String defaultValue = col.getMetaDefaultValue(Lists.newArrayList());
-                        final String aggType = col.getAggregationType() == null ? "" : col.getAggregationType().toSql();
+                        final String aggType = col.getAggregationType() == null
+                                || isPrimaryKey ? "" : col.getAggregationType().toSql();
                         if (showStmt.isVerbose()) {
                             // Field Type Collation Null Key Default Extra
                             // Privileges Comment

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -86,7 +86,6 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DynamicPartitionProperty;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.Index;
-import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndex.IndexExtState;
 import com.starrocks.catalog.MaterializedIndexMeta;
@@ -677,8 +676,6 @@ public class ShowExecutor {
                         matcher = PatternMatcher.createMysqlPattern(showStmt.getPattern(),
                                 CaseSensibility.COLUMN.getCaseSensibility());
                     }
-                    boolean isPrimaryKey = table.getType() == Table.TableType.OLAP
-                            && ((OlapTable) table).getKeysType() == KeysType.PRIMARY_KEYS;
                     List<Column> columns = table.getBaseSchema();
                     for (Column col : columns) {
                         if (matcher != null && !matcher.match(col.getName())) {
@@ -690,7 +687,7 @@ public class ShowExecutor {
                         final String isKey = col.isKey() ? "YES" : "NO";
                         final String defaultValue = col.getMetaDefaultValue(Lists.newArrayList());
                         final String aggType = col.getAggregationType() == null
-                                || isPrimaryKey ? "" : col.getAggregationType().toSql();
+                                || col.isAggregationTypeImplicit() ? "" : col.getAggregationType().toSql();
                         if (showStmt.isVerbose()) {
                             // Field Type Collation Null Key Default Extra
                             // Privileges Comment

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
@@ -257,8 +257,8 @@ public class CreateTableAnalyzer {
 
         for (ColumnDef columnDef : columnDefs) {
             Column col = columnDef.toColumn();
-            if (keysDesc != null &&
-                    (keysDesc.getKeysType() == KeysType.UNIQUE_KEYS || keysDesc.getKeysType() == KeysType.PRIMARY_KEYS)) {
+            if (keysDesc != null && (keysDesc.getKeysType() == KeysType.UNIQUE_KEYS
+                    || keysDesc.getKeysType() == KeysType.PRIMARY_KEYS || keysDesc.getKeysType() == KeysType.DUP_KEYS)) {
                 if (!col.isKey()) {
                     col.setAggregationTypeImplicit(true);
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
@@ -257,7 +257,8 @@ public class CreateTableAnalyzer {
 
         for (ColumnDef columnDef : columnDefs) {
             Column col = columnDef.toColumn();
-            if (keysDesc.getKeysType() == KeysType.UNIQUE_KEYS) {
+            if (keysDesc != null &&
+                    (keysDesc.getKeysType() == KeysType.UNIQUE_KEYS || keysDesc.getKeysType() == KeysType.PRIMARY_KEYS)) {
                 if (!col.isKey()) {
                     col.setAggregationTypeImplicit(true);
                 }


### PR DESCRIPTION
remember issue #799 ? there is another case, show column statement, so this PR is a supplement of PR #800.

before this PR:
```
mysql> create table test (`pk` int not null, `col1` int) ENGINE=OLAP primary key (`pk`) COMMENT "OLAP" DISTRIBUTED BY HASH(`pk`) BUCKETS 1 PROPERTIES("replication_num" = "1", "storage_format" = "v2");
Query OK, 0 rows affected (0.00 sec)

mysql> show columns from test;
+-------+------+------+------+---------+-------+
| Field | Type | Null | Key  | Default | Extra |
+-------+------+------+------+---------+-------+
| pk    | int  | NO   | YES  | NULL    |       |
| col1  | int  | YES  | NO   | NULL    |REPLACE|
+-------+------+------+------+---------+-------+
2 rows in set (0.00 sec)

mysql>
```

after this PR:
```
mysql> create table test (`pk` int not null, `col1` int) ENGINE=OLAP primary key (`pk`) COMMENT "OLAP" DISTRIBUTED BY HASH(`pk`) BUCKETS 1 PROPERTIES("replication_num" = "1", "storage_format" = "v2");
Query OK, 0 rows affected (0.00 sec)

mysql> show columns from test;
+-------+------+------+------+---------+-------+
| Field | Type | Null | Key  | Default | Extra |
+-------+------+------+------+---------+-------+
| pk    | int  | NO   | YES  | NULL    |       |
| col1  | int  | YES  | NO   | NULL    |       |
+-------+------+------+------+---------+-------+
2 rows in set (0.00 sec)

mysql>
```