### PR TITLE
Fix binary predicate operator nullable

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/FunctionCallExpr.java
@@ -178,6 +178,9 @@ public class FunctionCallExpr extends Expr {
                     .add(FunctionSet.MONTH)
                     .add(FunctionSet.DAY)
                     .add(FunctionSet.HOUR)
+                    .add(FunctionSet.ADD)
+                    .add(FunctionSet.SUBTRACT)
+                    .add(FunctionSet.MULTIPLY)
                     .build();
 
     public boolean isMergeAggFn() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/BinaryPredicateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/BinaryPredicateOperator.java
@@ -149,4 +149,9 @@ public class BinaryPredicateOperator extends PredicateOperator {
     public int hashCode() {
         return Objects.hash(super.hashCode(), type);
     }
+
+    @Override
+    public boolean isNullable() {
+        return !this.type.equals(BinaryType.EQ_FOR_NULL) && super.isNullable();
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CallOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CallOperator.java
@@ -114,6 +114,10 @@ public class CallOperator extends ScalarOperator {
         if (fn != null && !fn.isNullable()) {
             return false;
         }
+        // decimal operation may overflow
+        if (arguments.stream().anyMatch(argument -> argument.getType().isDecimalOfAnyVersion())) {
+            return true;
+        }
         // check children nullable
         if (FunctionCallExpr.nullableSameWithChildrenFunctions.contains(fnName)) {
             return arguments.stream().anyMatch(ScalarOperator::isNullable);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CallOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CallOperator.java
@@ -114,13 +114,11 @@ public class CallOperator extends ScalarOperator {
         if (fn != null && !fn.isNullable()) {
             return false;
         }
-        // decimal operation may overflow
-        if (arguments.stream().anyMatch(argument -> argument.getType().isDecimalOfAnyVersion())) {
-            return true;
-        }
         // check children nullable
         if (FunctionCallExpr.nullableSameWithChildrenFunctions.contains(fnName)) {
-            return arguments.stream().anyMatch(ScalarOperator::isNullable);
+            // decimal operation may overflow
+            return arguments.stream()
+                    .anyMatch(argument -> argument.isNullable() || argument.getType().isDecimalOfAnyVersion());
         }
         return true;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -331,7 +331,7 @@ public class PlanFragmentBuilder {
 
                 SlotDescriptor slotDescriptor =
                         context.getDescTbl().addSlotDescriptor(tupleDescriptor, new SlotId(entry.getKey().getId()));
-                slotDescriptor.setIsNullable(expr.isNullable());
+                slotDescriptor.setIsNullable(entry.getValue().isNullable());
                 slotDescriptor.setIsMaterialized(false);
                 slotDescriptor.setType(expr.getType());
                 context.getColRefToExpr().put(entry.getKey(), new SlotRef(entry.getKey().toString(), slotDescriptor));
@@ -346,7 +346,7 @@ public class PlanFragmentBuilder {
 
                 SlotDescriptor slotDescriptor =
                         context.getDescTbl().addSlotDescriptor(tupleDescriptor, new SlotId(entry.getKey().getId()));
-                slotDescriptor.setIsNullable(expr.isNullable());
+                slotDescriptor.setIsNullable(entry.getValue().isNullable());
                 slotDescriptor.setIsMaterialized(true);
                 slotDescriptor.setType(expr.getType());
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -5333,6 +5333,16 @@ public class PlanFragmentTest extends PlanTestBase {
         Assert.assertTrue(plan.contains(" 1:Project\n" +
                 "  |  output columns:\n" +
                 "  |  11 <-> day[([2: id_datetime, DATETIME, false]); args: DATETIME; result: TINYINT; args nullable: false; result nullable: false]"));
+
+        sql = "select distinct 2 * v1 from t0_not_null";
+        plan = getVerboseExplain(sql);
+        Assert.assertTrue(plan.contains("2:AGGREGATE (update finalize)\n" +
+                "  |  group by: [4: expr, BIGINT, false]"));
+
+        sql = "select distinct cast(2.0 as decimal) * v1 from t0_not_null";
+        plan = getVerboseExplain(sql);
+        Assert.assertTrue(plan.contains("2:AGGREGATE (update finalize)\n" +
+                "  |  group by: [4: expr, DECIMAL64(18,0), true]"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -5328,6 +5328,7 @@ public class PlanFragmentTest extends PlanTestBase {
 
     @Test
     public void testNullableSameWithChildrenFunctions() throws Exception {
+        Config.enable_decimal_v3 = true;
         String sql = "select distinct day(id_datetime) from test_all_type_partition_by_datetime";
         String plan = getVerboseExplain(sql);
         Assert.assertTrue(plan.contains(" 1:Project\n" +
@@ -5343,6 +5344,7 @@ public class PlanFragmentTest extends PlanTestBase {
         plan = getVerboseExplain(sql);
         Assert.assertTrue(plan.contains("2:AGGREGATE (update finalize)\n" +
                 "  |  group by: [4: expr, DECIMAL64(18,0), true]"));
+        Config.enable_decimal_v3 = false;
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -5395,6 +5395,19 @@ public class PlanFragmentTest extends PlanTestBase {
     }
 
     @Test
+    public void testBinaryPredicateNullable() throws Exception {
+        String sql = "select distinct L_ORDERKEY < L_PARTKEY from lineitem";
+        String plan = getVerboseExplain(sql);
+        Assert.assertTrue(plan.contains(" 2:AGGREGATE (update finalize)\n" +
+                "  |  group by: [18: expr, BOOLEAN, false]"));
+
+        sql = "select distinct v1 <=> v2 from t0";
+        plan = getVerboseExplain(sql);
+        Assert.assertTrue(plan.contains("2:AGGREGATE (update finalize)\n" +
+                "  |  group by: [4: expr, BOOLEAN, false]"));
+    }
+
+    @Test
     public void testSemiJoinReorder() throws Exception {
         String sql = "SELECT \n" +
                 "  v2 \n" +


### PR DESCRIPTION
Fix #2879 

In #2770 , we use scalarOperaotr isNullale instead of expr at relation transform, but we do not use scalarOperator nullable at planFragement builder which is used for translate scalarOperator to expr, we should unify this logical.
The isNullable method of the binaryPredicateOperator has also been overridden
