### PR TITLE
fe: support http interface that forbit use global_dict to speed up sql 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -5936,15 +5936,15 @@ public class Catalog {
 
         Table table = db.getTable(tableName);
         if (table == null) {
-            throw new DdlException("the DB " + dbName +  " tabet: " + tableName + "isn't  exist"); 
+            throw new DdlException("the DB " + dbName +  " table: " + tableName + "isn't  exist"); 
         }
 
         OlapTable olapTable = (OlapTable) table;
         olapTable.setHasForbitGlobalDict(isForbit);
         if (isForbit) {
-            property.put("enable_low_card_dict", "0");
+            property.put(PropertyAnalyzer.ENABLE_LOW_CARD_DICT_TYPE, PropertyAnalyzer.DISABLE_LOW_CARD_DICT);
         } else {
-            property.put("enable_low_card_dict", "1");
+            property.put(PropertyAnalyzer.ENABLE_LOW_CARD_DICT_TYPE, PropertyAnalyzer.ABLE_LOW_CARD_DICT);
         }
         ModifyTablePropertyOperationLog info = new ModifyTablePropertyOperationLog(db.getId(), table.getId(), property);
         editLog.logSetHasForbitGlobalDict(info);
@@ -5960,12 +5960,10 @@ public class Catalog {
         try {
             OlapTable olapTable = (OlapTable) db.getTable(tableId);
             if (opCode == OperationType.OP_SET_FORBIT_GLOBAL_DICT) {
-                String enAble = properties.get("enable_low_card_dict");
-                if (enAble == null) {
-                    throw new Error("invalid args when replay log");
-                }
+                String enAble = properties.get(PropertyAnalyzer.ENABLE_LOW_CARD_DICT_TYPE);
+                Preconditions.checkState(enAble != null);
                 if (olapTable != null) {
-                    if (enAble == "0") {
+                    if (enAble == PropertyAnalyzer.DISABLE_LOW_CARD_DICT) {
                         olapTable.setHasForbitGlobalDict(true);
                     } else {
                         olapTable.setHasForbitGlobalDict(false);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -5939,15 +5939,17 @@ public class Catalog {
             throw new DdlException("the DB " + dbName +  " table: " + tableName + "isn't  exist"); 
         }
 
-        OlapTable olapTable = (OlapTable) table;
-        olapTable.setHasForbitGlobalDict(isForbit);
-        if (isForbit) {
-            property.put(PropertyAnalyzer.ENABLE_LOW_CARD_DICT_TYPE, PropertyAnalyzer.DISABLE_LOW_CARD_DICT);
-        } else {
-            property.put(PropertyAnalyzer.ENABLE_LOW_CARD_DICT_TYPE, PropertyAnalyzer.ABLE_LOW_CARD_DICT);
+        if (table instanceof OlapTable) {
+            OlapTable olapTable = (OlapTable) table;
+            olapTable.setHasForbitGlobalDict(isForbit);
+            if (isForbit) {
+                property.put(PropertyAnalyzer.ENABLE_LOW_CARD_DICT_TYPE, PropertyAnalyzer.DISABLE_LOW_CARD_DICT);
+            } else {
+                property.put(PropertyAnalyzer.ENABLE_LOW_CARD_DICT_TYPE, PropertyAnalyzer.ABLE_LOW_CARD_DICT);
+            }
+            ModifyTablePropertyOperationLog info = new ModifyTablePropertyOperationLog(db.getId(), table.getId(), property);
+            editLog.logSetHasForbitGlobalDict(info);
         }
-        ModifyTablePropertyOperationLog info = new ModifyTablePropertyOperationLog(db.getId(), table.getId(), property);
-        editLog.logSetHasForbitGlobalDict(info);
     }
 
     public void replayModifyTableProperty(short opCode, ModifyTablePropertyOperationLog info) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -7173,21 +7173,16 @@ public class Catalog {
         Map<String, String> emptyProperty = new HashMap<>();
         Database db = getDb(dbName);
         if (db == null) {
-            // just for debug
-            LOG.warn("db is NULL: ", dbName);
             throw new Error("the DB " + dbName + "isn't  exist");
         }
 
         Table table = db.getTable(tableName);
         if (table == null) {
-            // just for debug
-            LOG.warn("table is NULL: ", tableName);
             throw new Error("the DB " + dbName +  " tabet: " + tableName + "isn't  exist"); 
         }
 
         OlapTable olapTable = (OlapTable) table;
         olapTable.setHasForbitGlobalDict();
-        
         ModifyTablePropertyOperationLog info = new ModifyTablePropertyOperationLog(db.getId(), table.getId(), emptyProperty);
         editLog.logSetHasForbitGlobalDict(info);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -5970,8 +5970,6 @@ public class Catalog {
                     } else {
                         olapTable.setHasForbitGlobalDict(false);
                     }
-                    // just for debug 
-                    LOG.warn("modify setHasForbitGlobalDict:{} ", enAble);
                 }
             } else {
                 TableProperty tableProperty = olapTable.getTableProperty();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -5957,7 +5957,7 @@ public class Catalog {
 
         Database db = getDb(dbId);
         db.writeLock();
-        try {    
+        try {
             OlapTable olapTable = (OlapTable) db.getTable(tableId);
             if (opCode == OperationType.OP_SET_FORBIT_GLOBAL_DICT) {
                 String enAble = properties.get("enable_low_card_dict");

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -7169,6 +7169,46 @@ public class Catalog {
         db.replayDropFunction(functionSearchDesc);
     }
 
+    public void setHasForbitGlobalDict(String dbName, String tableName) {
+        Map<String, String> emptyProperty = new HashMap<>();
+        Database db = getDb(dbName);
+        if (db == null) {
+            // just for debug
+            LOG.warn("db is NULL: ", dbName);
+            throw new Error("the DB " + dbName + "isn't  exist");
+        }
+
+        Table table = db.getTable(tableName);
+        if (table == null) {
+            // just for debug
+            LOG.warn("table is NULL: ", tableName);
+            throw new Error("the DB " + dbName +  " tabet: " + tableName + "isn't  exist"); 
+        }
+
+        OlapTable olapTable = (OlapTable) table;
+        olapTable.setHasForbitGlobalDict();
+        
+        ModifyTablePropertyOperationLog info = new ModifyTablePropertyOperationLog(db.getId(), table.getId(), emptyProperty);
+        editLog.logSetHasForbitGlobalDict(info);
+    }
+
+    public void replaySetHasFotbitGlobalDict(ModifyTablePropertyOperationLog info) {
+        long dbId = info.getDbId();
+        long tableId = info.getTableId();
+        Map<String, String> properties = info.getProperties();
+
+        Database db = getDb(dbId);
+        db.writeLock();
+        try {
+            OlapTable olapTable = (OlapTable) db.getTable(tableId);
+            if (olapTable != null) {
+                olapTable.setHasForbitGlobalDict();
+            }
+        } finally {
+            db.writeUnlock();
+        }
+    }
+
     public void setConfig(AdminSetConfigStmt stmt) throws DdlException {
         Map<String, String> configs = stmt.getConfigs();
         Preconditions.checkState(configs.size() == 1);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -1479,8 +1479,8 @@ public class OlapTable extends Table {
         tableProperty.setHasDelete(true);
     }
 
-    public void setHasForbitGlobalDict() {
-        tableProperty.setHasForbitGlobalDict(true);
+    public void setHasForbitGlobalDict(boolean hasForbitGlobalDict) {
+        tableProperty.setHasForbitGlobalDict(hasForbitGlobalDict);
     }
 
     // return true if partition with given name already exist, both in partitions and temp partitions.

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -1476,10 +1476,23 @@ public class OlapTable extends Table {
     }
 
     public void setHasDelete() {
+        if (tableProperty == null) {
+            return;
+        }
         tableProperty.setHasDelete(true);
     }
 
+    public boolean hasForbitGlobalDict() {
+        if (tableProperty == null) {
+            return false;
+        }
+        return tableProperty.hasForbitGlobalDict();
+    }
+
     public void setHasForbitGlobalDict(boolean hasForbitGlobalDict) {
+        if (tableProperty == null) {
+            return;
+        }
         tableProperty.setHasForbitGlobalDict(hasForbitGlobalDict);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -1479,6 +1479,10 @@ public class OlapTable extends Table {
         tableProperty.setHasDelete(true);
     }
 
+    public void setHasForbitGlobalDict() {
+        tableProperty.setHasForbitGlobalDict(true);
+    }
+
     // return true if partition with given name already exist, both in partitions and temp partitions.
     // return false otherwise
     public boolean checkPartitionNameExist(String partitionName) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -71,6 +71,8 @@ public class TableProperty implements Writable {
     //    After checkpoint, we relay TableProperty::write to persist.
     private boolean hasDelete = false;
 
+    private boolean hasForbitGlobalDict = false;
+
     public TableProperty(Map<String, String> properties) {
         this.properties = properties;
     }
@@ -161,8 +163,17 @@ public class TableProperty implements Writable {
         return hasDelete;
     }
 
+
     public void setHasDelete(boolean hasDelete) {
         this.hasDelete = hasDelete;
+    }
+
+    public boolean hasForbitGlobalDict() {
+        return hasForbitGlobalDict;
+    }
+
+    public void setHasForbitGlobalDict(boolean hasForbitGlobalDict) {
+        this.hasForbitGlobalDict = hasForbitGlobalDict;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -87,6 +87,10 @@ public class PropertyAnalyzer {
 
     public static final String PROPERTIES_TYPE = "type";
 
+    public static final String ENABLE_LOW_CARD_DICT_TYPE = "enable_low_card_dict";
+    public static final String ABLE_LOW_CARD_DICT = "1";
+    public static final String DISABLE_LOW_CARD_DICT = "0";
+
     public static DataProperty analyzeDataProperty(Map<String, String> properties, DataProperty oldDataProperty)
             throws AnalysisException {
         if (properties == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/http/BaseRequest.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/BaseRequest.java
@@ -111,21 +111,13 @@ public class BaseRequest {
     // return null if key is not exist; return the first value if key is an array
     public String getSingleParameter(String key) {
         String uri = request.uri();
-        // just for debug 
-        LOG.warn("uri: ", uri);
         if (decoder == null) {
             decoder = new QueryStringDecoder(uri);
         }
         List<String> values = decoder.parameters().get(key);
         if (values != null && values.size() > 0) {
-            // just for debug 
-            LOG.warn("DDDDDDDDD: ", values.get(0).trim());
             return values.get(0);
         }
-
-        // just for debug 
-        LOG.warn("FUCKKKFFF: ", uri);
-
         return params.get(key);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/http/BaseRequest.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/BaseRequest.java
@@ -108,10 +108,12 @@ public class BaseRequest {
         if (decoder == null) {
             decoder = new QueryStringDecoder(uri);
         }
+
         List<String> values = decoder.parameters().get(key);
         if (values != null && values.size() > 0) {
             return values.get(0);
         }
+        
         return params.get(key);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/http/BaseRequest.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/BaseRequest.java
@@ -37,7 +37,6 @@ import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
 
-
 public class BaseRequest {
     protected ChannelHandlerContext context;
     protected HttpRequest request;

--- a/fe/fe-core/src/main/java/com/starrocks/http/BaseRequest.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/BaseRequest.java
@@ -31,16 +31,22 @@ import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.QueryStringDecoder;
 import io.netty.handler.codec.http.cookie.ClientCookieDecoder;
 import io.netty.handler.codec.http.cookie.Cookie;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.net.InetSocketAddress;
 import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
 
+
 public class BaseRequest {
     protected ChannelHandlerContext context;
     protected HttpRequest request;
     protected Map<String, String> params = Maps.newHashMap();
+
+    private static final Logger LOG = LogManager.getLogger(BaseRequest.class);
+
 
     private boolean isAuthorized = false;
     private QueryStringDecoder decoder;
@@ -105,14 +111,20 @@ public class BaseRequest {
     // return null if key is not exist; return the first value if key is an array
     public String getSingleParameter(String key) {
         String uri = request.uri();
+        // just for debug 
+        LOG.warn("uri: ", uri);
         if (decoder == null) {
             decoder = new QueryStringDecoder(uri);
         }
-
         List<String> values = decoder.parameters().get(key);
         if (values != null && values.size() > 0) {
+            // just for debug 
+            LOG.warn("DDDDDDDDD: ", values.get(0).trim());
             return values.get(0);
         }
+
+        // just for debug 
+        LOG.warn("FUCKKKFFF: ", uri);
 
         return params.get(key);
     }
@@ -129,7 +141,7 @@ public class BaseRequest {
     // get an array parameter.
     // eg.  ?a=1&a=2
     public List<String> getArrayParameter(String key) {
-        String uri = request.uri();
+        String uri = request.uri();        
         if (decoder == null) {
             decoder = new QueryStringDecoder(uri);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/http/BaseRequest.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/BaseRequest.java
@@ -31,8 +31,6 @@ import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.QueryStringDecoder;
 import io.netty.handler.codec.http.cookie.ClientCookieDecoder;
 import io.netty.handler.codec.http.cookie.Cookie;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.net.InetSocketAddress;
 import java.nio.charset.Charset;
@@ -44,9 +42,6 @@ public class BaseRequest {
     protected ChannelHandlerContext context;
     protected HttpRequest request;
     protected Map<String, String> params = Maps.newHashMap();
-
-    private static final Logger LOG = LogManager.getLogger(BaseRequest.class);
-
 
     private boolean isAuthorized = false;
     private QueryStringDecoder decoder;
@@ -133,7 +128,7 @@ public class BaseRequest {
     // get an array parameter.
     // eg.  ?a=1&a=2
     public List<String> getArrayParameter(String key) {
-        String uri = request.uri();        
+        String uri = request.uri();
         if (decoder == null) {
             decoder = new QueryStringDecoder(uri);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpServer.java
@@ -35,6 +35,7 @@ import com.starrocks.http.action.SystemAction;
 import com.starrocks.http.action.VariableAction;
 import com.starrocks.http.common.StarRocksHttpPostObjectAggregator;
 import com.starrocks.http.meta.ColocateMetaService;
+import com.starrocks.http.meta.GlobalDictMetaService;
 import com.starrocks.http.meta.MetaService.CheckAction;
 import com.starrocks.http.meta.MetaService.DumpAction;
 import com.starrocks.http.meta.MetaService.ImageAction;
@@ -151,6 +152,7 @@ public class HttpServer {
         ColocateMetaService.ColocateMetaAction.registerAction(controller);
         ColocateMetaService.MarkGroupStableAction.registerAction(controller);
         ColocateMetaService.MarkGroupUnstableAction.registerAction(controller);
+        GlobalDictMetaService.ForbitTableAction.registerAction(controller);
         ProfileAction.registerAction(controller);
         QueryDetailAction.registerAction(controller);
         ConnectionAction.registerAction(controller);

--- a/fe/fe-core/src/main/java/com/starrocks/http/meta/GlobalDictMetaService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/meta/GlobalDictMetaService.java
@@ -1,4 +1,4 @@
-// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
 
 package com.starrocks.http.meta;
 

--- a/fe/fe-core/src/main/java/com/starrocks/http/meta/GlobalDictMetaService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/meta/GlobalDictMetaService.java
@@ -3,7 +3,7 @@
 package com.starrocks.http.meta;
 
 import com.google.common.base.Strings;
-// import com.starrocks.catalog.Catalog;
+import com.starrocks.catalog.Catalog;
 import com.starrocks.common.DdlException;
 import com.starrocks.http.ActionController;
 import com.starrocks.http.BaseRequest;
@@ -17,6 +17,12 @@ import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+/**
+ *  eg:
+ *       POST    /api/global_dict/table/forbit?db_name=default_cluster:test&table_name=test_basic 
+ *               (mark forbit test_basic use global dict)
+ */
 
 public class GlobalDictMetaService {
     private static final String DB_NAME = "db_name";
@@ -46,7 +52,6 @@ public class GlobalDictMetaService {
         }
     }
 
-    /// mark a colocate group as stable
     public static class ForbitTableAction extends GlobalDictMetaServiceBaseAction {
         ForbitTableAction(ActionController controller) {
             super(controller);
@@ -54,7 +59,7 @@ public class GlobalDictMetaService {
 
         public static void registerAction(ActionController controller) throws IllegalArgException {
             ForbitTableAction action = new ForbitTableAction(controller);
-            controller.registerHandler(HttpMethod.POST, "/api/global_dict/table", action);
+            controller.registerHandler(HttpMethod.POST, "/api/global_dict/table/forbit", action);
         }
 
         @Override
@@ -62,7 +67,6 @@ public class GlobalDictMetaService {
                 throws DdlException {
             HttpMethod method = request.getRequest().method();
             if (method.equals(HttpMethod.POST)) {
-                LOG.warn("GlobalDictMetaService Do POST");
                 String tableName = request.getSingleParameter(TABLE_NAME);
                 String dbName = request.getSingleParameter(DB_NAME);
                 if (Strings.isNullOrEmpty(dbName) || Strings.isNullOrEmpty(tableName)) {
@@ -70,16 +74,11 @@ public class GlobalDictMetaService {
                     writeResponse(request, response, HttpResponseStatus.BAD_REQUEST);
                     return;
                 }
-                // just for debug
-                LOG.warn("GlobalDictMetaService ", dbName.trim());
-                LOG.warn("GlobalDictMetaService ", tableName.trim());
-                throw new DdlException("Not implemented");
-                // Catalog.getCurrentCatalog().setHasForbitGlobalDict(dbName, tableName);
+                Catalog.getCurrentCatalog().setHasForbitGlobalDict(dbName, tableName);
             } else {
                 response.appendContent(new RestBaseResult("HTTP method is not allowed.").toJson());
                 writeResponse(request, response, HttpResponseStatus.METHOD_NOT_ALLOWED);
             }
-
             sendResult(request, response);
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/http/meta/GlobalDictMetaService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/meta/GlobalDictMetaService.java
@@ -1,0 +1,86 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+package com.starrocks.http.meta;
+
+import com.google.common.base.Strings;
+// import com.starrocks.catalog.Catalog;
+import com.starrocks.common.DdlException;
+import com.starrocks.http.ActionController;
+import com.starrocks.http.BaseRequest;
+import com.starrocks.http.BaseResponse;
+import com.starrocks.http.IllegalArgException;
+import com.starrocks.http.rest.RestBaseAction;
+import com.starrocks.http.rest.RestBaseResult;
+import com.starrocks.mysql.privilege.PrivPredicate;
+import com.starrocks.qe.ConnectContext;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class GlobalDictMetaService {
+    private static final String DB_NAME = "db_name";
+    private static final String TABLE_NAME = "table_name";
+    private static final Logger LOG = LogManager.getLogger(GlobalDictMetaService.class);
+
+
+    public static class GlobalDictMetaServiceBaseAction extends RestBaseAction {
+        GlobalDictMetaServiceBaseAction(ActionController controller) {
+            super(controller);
+        }
+
+        @Override
+        public void executeWithoutPassword(BaseRequest request, BaseResponse response)
+                throws DdlException {
+            if (redirectToMaster(request, response)) {
+                return;
+            }
+            checkGlobalAuth(ConnectContext.get().getCurrentUserIdentity(), PrivPredicate.ADMIN);
+            executeInMasterWithAdmin(request, response);
+        }
+
+        // implement in derived classes
+        protected void executeInMasterWithAdmin(BaseRequest request, BaseResponse response)
+                throws DdlException {
+            throw new DdlException("Not implemented");
+        }
+    }
+
+    /// mark a colocate group as stable
+    public static class ForbitTableAction extends GlobalDictMetaServiceBaseAction {
+        ForbitTableAction(ActionController controller) {
+            super(controller);
+        }
+
+        public static void registerAction(ActionController controller) throws IllegalArgException {
+            ForbitTableAction action = new ForbitTableAction(controller);
+            controller.registerHandler(HttpMethod.POST, "/api/global_dict/table", action);
+        }
+
+        @Override
+        public void executeInMasterWithAdmin(BaseRequest request, BaseResponse response)
+                throws DdlException {
+            HttpMethod method = request.getRequest().method();
+            if (method.equals(HttpMethod.POST)) {
+                LOG.warn("GlobalDictMetaService Do POST");
+                String tableName = request.getSingleParameter(TABLE_NAME);
+                String dbName = request.getSingleParameter(DB_NAME);
+                if (Strings.isNullOrEmpty(dbName) || Strings.isNullOrEmpty(tableName)) {
+                    response.appendContent("Miss db_name parameter or table_name");
+                    writeResponse(request, response, HttpResponseStatus.BAD_REQUEST);
+                    return;
+                }
+                // just for debug
+                LOG.warn("GlobalDictMetaService ", dbName.trim());
+                LOG.warn("GlobalDictMetaService ", tableName.trim());
+                throw new DdlException("Not implemented");
+                // Catalog.getCurrentCatalog().setHasForbitGlobalDict(dbName, tableName);
+            } else {
+                response.appendContent(new RestBaseResult("HTTP method is not allowed.").toJson());
+                writeResponse(request, response, HttpResponseStatus.METHOD_NOT_ALLOWED);
+            }
+
+            sendResult(request, response);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/http/meta/GlobalDictMetaService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/meta/GlobalDictMetaService.java
@@ -20,13 +20,16 @@ import org.apache.logging.log4j.Logger;
 
 /**
  *  eg:
- *       POST    /api/global_dict/table/forbit?db_name=default_cluster:test&table_name=test_basic 
+ *       POST    /api/global_dict/table/forbit?db_name=default_cluster:test&table_name=test_basic&enable=0
  *               (mark forbit test_basic use global dict)
+ *       POST    /api/global_dict/table/forbit?db_name=default_cluster:test&table_name=test_basic&enable=1
+ *               (mark enable test_basic use global dict)
  */
 
 public class GlobalDictMetaService {
     private static final String DB_NAME = "db_name";
     private static final String TABLE_NAME = "table_name";
+    private static final String ENABLE = "enable";
     private static final Logger LOG = LogManager.getLogger(GlobalDictMetaService.class);
 
 
@@ -74,7 +77,10 @@ public class GlobalDictMetaService {
                     writeResponse(request, response, HttpResponseStatus.BAD_REQUEST);
                     return;
                 }
-                Catalog.getCurrentCatalog().setHasForbitGlobalDict(dbName, tableName);
+
+                long isEnable =  Long.valueOf(request.getSingleParameter(ENABLE).trim());
+
+                Catalog.getCurrentCatalog().setHasForbitGlobalDict(dbName, tableName, isEnable == 0);
             } else {
                 response.appendContent(new RestBaseResult("HTTP method is not allowed.").toJson());
                 writeResponse(request, response, HttpResponseStatus.METHOD_NOT_ALLOWED);

--- a/fe/fe-core/src/main/java/com/starrocks/journal/JournalEntity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/JournalEntity.java
@@ -521,12 +521,8 @@ public class JournalEntity implements Writable {
             }
             case OperationType.OP_DYNAMIC_PARTITION:
             case OperationType.OP_MODIFY_IN_MEMORY:
+            case OperationType.OP_SET_FORBIT_GLOBAL_DICT:
             case OperationType.OP_MODIFY_REPLICATION_NUM: {
-                data = ModifyTablePropertyOperationLog.read(in);
-                isRead = true;
-                break;
-            }
-            case OperationType.OP_SET_FORBIT_GLOBAL_DICT: {
                 data = ModifyTablePropertyOperationLog.read(in);
                 isRead = true;
                 break;

--- a/fe/fe-core/src/main/java/com/starrocks/journal/JournalEntity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/JournalEntity.java
@@ -526,6 +526,11 @@ public class JournalEntity implements Writable {
                 isRead = true;
                 break;
             }
+            case OperationType.OP_SET_FORBIT_GLOBAL_DICT: {
+                data = ModifyTablePropertyOperationLog.read(in);
+                isRead = true;
+                break;
+            }
             case OperationType.OP_REPLACE_TEMP_PARTITION: {
                 data = ReplacePartitionOperationLog.read(in);
                 isRead = true;

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -663,6 +663,11 @@ public class EditLog {
                     Catalog.getCurrentCatalog().replayDropFunction(function);
                     break;
                 }
+                case OperationType.OP_SET_FORBIT_GLOBAL_DICT: {
+                    ModifyTablePropertyOperationLog info = (ModifyTablePropertyOperationLog) journal.getData();
+                    Catalog.getCurrentCatalog().replaySetHasFotbitGlobalDict(info);
+                    break;
+                }
                 case OperationType.OP_BACKEND_TABLETS_INFO: {
                     BackendTabletsInfo backendTabletsInfo = (BackendTabletsInfo) journal.getData();
                     Catalog.getCurrentCatalog().replayBackendTabletsInfo(backendTabletsInfo);
@@ -1264,6 +1269,10 @@ public class EditLog {
 
     public void logDropFunction(FunctionSearchDesc function) {
         logEdit(OperationType.OP_DROP_FUNCTION, function);
+    }
+
+    public void logSetHasForbitGlobalDict(ModifyTablePropertyOperationLog info) {
+        logEdit(OperationType.OP_SET_FORBIT_GLOBAL_DICT, info);
     }
 
     public void logBackendTabletsInfo(BackendTabletsInfo backendTabletsInfo) {

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -663,11 +663,6 @@ public class EditLog {
                     Catalog.getCurrentCatalog().replayDropFunction(function);
                     break;
                 }
-                case OperationType.OP_SET_FORBIT_GLOBAL_DICT: {
-                    ModifyTablePropertyOperationLog info = (ModifyTablePropertyOperationLog) journal.getData();
-                    Catalog.getCurrentCatalog().replaySetHasFotbitGlobalDict(info);
-                    break;
-                }
                 case OperationType.OP_BACKEND_TABLETS_INFO: {
                     BackendTabletsInfo backendTabletsInfo = (BackendTabletsInfo) journal.getData();
                     Catalog.getCurrentCatalog().replayBackendTabletsInfo(backendTabletsInfo);
@@ -752,6 +747,7 @@ public class EditLog {
                 }
                 case OperationType.OP_DYNAMIC_PARTITION:
                 case OperationType.OP_MODIFY_IN_MEMORY:
+                case OperationType.OP_SET_FORBIT_GLOBAL_DICT:
                 case OperationType.OP_MODIFY_REPLICATION_NUM: {
                     ModifyTablePropertyOperationLog modifyTablePropertyOperationLog =
                             (ModifyTablePropertyOperationLog) journal.getData();

--- a/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
@@ -152,9 +152,6 @@ public class OperationType {
     public static final short OP_ADD_FUNCTION = 130;
     public static final short OP_DROP_FUNCTION = 131;
 
-    // global dict
-    public static final short OP_SET_FORBIT_GLOBAL_DICT = 140;
-
     // routine load 200
     public static final short OP_CREATE_ROUTINE_LOAD_JOB = 200;
     public static final short OP_CHANGE_ROUTINE_LOAD_JOB = 201;
@@ -178,6 +175,9 @@ public class OperationType {
     public static final short OP_MODIFY_REPLICATION_NUM = 266;
     // set table in memory
     public static final short OP_MODIFY_IN_MEMORY = 267;
+
+    // global dict
+    public static final short OP_SET_FORBIT_GLOBAL_DICT = 268;
 
     // plugin 270~275
     public static final short OP_INSTALL_PLUGIN = 270;

--- a/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
@@ -152,6 +152,9 @@ public class OperationType {
     public static final short OP_ADD_FUNCTION = 130;
     public static final short OP_DROP_FUNCTION = 131;
 
+    // global dict
+    public static final short OP_SET_FORBIT_GLOBAL_DICT = 140;
+
     // routine load 200
     public static final short OP_CREATE_ROUTINE_LOAD_JOB = 200;
     public static final short OP_CHANGE_ROUTINE_LOAD_JOB = 201;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/AddDecodeNodeForDictStringRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/AddDecodeNodeForDictStringRule.java
@@ -13,6 +13,7 @@ import com.starrocks.catalog.Catalog;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Type;
@@ -642,6 +643,13 @@ public class AddDecodeNodeForDictStringRule implements PhysicalOperatorTreeRewri
             OlapTable table = (OlapTable) scanOperator.getTable();
             long version = table.getPartitions().stream().map(Partition::getVisibleVersionTime)
                     .max(Long::compareTo).orElse(0L);
+
+            if ((table.getKeysType().equals(KeysType.PRIMARY_KEYS))) {
+                continue;
+            }
+            if ((table.getTableProperty().hasForbitGlobalDict())) {
+                continue;
+            }
             for (ColumnRefOperator column : scanOperator.getColRefToColumnMetaMap().keySet()) {
                 // Condition 1:
                 if (!column.getType().isVarchar()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/AddDecodeNodeForDictStringRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/AddDecodeNodeForDictStringRule.java
@@ -647,7 +647,7 @@ public class AddDecodeNodeForDictStringRule implements PhysicalOperatorTreeRewri
             if ((table.getKeysType().equals(KeysType.PRIMARY_KEYS))) {
                 continue;
             }
-            if ((table.getTableProperty().hasForbitGlobalDict())) {
+            if (table.hasForbitGlobalDict()) {
                 continue;
             }
             for (ColumnRefOperator column : scanOperator.getColRefToColumnMetaMap().keySet()) {


### PR DESCRIPTION
now,  the option cbo_enable_low_cardinality_optimize is set true default
it mean, if a column is varchar type and cardinality is less than 256， it will use global dict to speed up when sql execute.

if some thing go wrong or you don't want to use this options 
you can forbid it by http like
  
post   /api/global_dict/table/forbit?db_name=default_cluster:test&table_name=test_basic&enable=0

and open it like 

post   /api/global_dict/table/forbit?db_name=default_cluster:test&table_name=test_basic&enable=1
