### PR TITLE
Relax the conditions for enabling local shuffle optimization

### DIFF
--- a/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
@@ -176,8 +176,7 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > AggregateBlockingNode::
             // 2. Otherwise, add LocalExchangeOperator
             // to shuffle multi-stream into #degree_of_parallelism# streams each of that pipes into AggregateBlockingSinkOperator.
             bool need_local_shuffle = true;
-            if (operators_with_sink.size() == 1 &&
-                typeid(*operators_with_sink[0]) == typeid(pipeline::ExchangeSourceOperatorFactory)) {
+            if (typeid(*operators_with_sink[0]) == typeid(pipeline::ExchangeSourceOperatorFactory)) {
                 auto* exchange_op = static_cast<pipeline::ExchangeSourceOperatorFactory*>(operators_with_sink[0].get());
                 auto& texchange_node = exchange_op->texchange_node();
                 DCHECK(texchange_node.__isset.partition_type);

--- a/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
@@ -176,8 +176,9 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > AggregateBlockingNode::
             // 2. Otherwise, add LocalExchangeOperator
             // to shuffle multi-stream into #degree_of_parallelism# streams each of that pipes into AggregateBlockingSinkOperator.
             bool need_local_shuffle = true;
-            if (typeid(*operators_with_sink[0]) == typeid(pipeline::ExchangeSourceOperatorFactory)) {
-                auto* exchange_op = static_cast<pipeline::ExchangeSourceOperatorFactory*>(operators_with_sink[0].get());
+            if (auto* exchange_op =
+                        dynamic_cast<pipeline::ExchangeSourceOperatorFactory*>(operators_with_sink[0].get());
+                exchange_op != nullptr) {
                 auto& texchange_node = exchange_op->texchange_node();
                 DCHECK(texchange_node.__isset.partition_type);
                 if (texchange_node.partition_type == TPartitionType::HASH_PARTITIONED ||

--- a/be/src/exec/vectorized/hash_join_node.cpp
+++ b/be/src/exec/vectorized/hash_join_node.cpp
@@ -396,8 +396,8 @@ pipeline::OpFactories HashJoinNode::decompose_to_pipeline(pipeline::PipelineBuil
             // to shuffle multi-stream into #degree_of_parallelism# streams each of that pipes into HashJoin{Build, Probe}Operator.
             TPartitionType::type part_type = TPartitionType::type::HASH_PARTITIONED;
             bool rhs_need_local_shuffle = true;
-            if (typeid(*rhs_operators[0]) == typeid(pipeline::ExchangeSourceOperatorFactory)) {
-                auto* exchange_op = static_cast<pipeline::ExchangeSourceOperatorFactory*>(rhs_operators[0].get());
+            if (auto* exchange_op = dynamic_cast<pipeline::ExchangeSourceOperatorFactory*>(rhs_operators[0].get());
+                exchange_op != nullptr) {
                 auto& texchange_node = exchange_op->texchange_node();
                 DCHECK(texchange_node.__isset.partition_type);
                 if (texchange_node.partition_type == TPartitionType::HASH_PARTITIONED ||
@@ -407,8 +407,8 @@ pipeline::OpFactories HashJoinNode::decompose_to_pipeline(pipeline::PipelineBuil
                 }
             }
             bool lhs_need_local_shuffle = true;
-            if (typeid(*lhs_operators[0]) == typeid(pipeline::ExchangeSourceOperatorFactory)) {
-                auto* exchange_op = static_cast<pipeline::ExchangeSourceOperatorFactory*>(lhs_operators[0].get());
+            if (auto* exchange_op = dynamic_cast<pipeline::ExchangeSourceOperatorFactory*>(lhs_operators[0].get());
+                exchange_op != nullptr) {
                 auto& texchange_node = exchange_op->texchange_node();
                 DCHECK(texchange_node.__isset.partition_type);
                 if (texchange_node.partition_type == TPartitionType::HASH_PARTITIONED ||

--- a/be/src/exec/vectorized/hash_join_node.cpp
+++ b/be/src/exec/vectorized/hash_join_node.cpp
@@ -396,8 +396,7 @@ pipeline::OpFactories HashJoinNode::decompose_to_pipeline(pipeline::PipelineBuil
             // to shuffle multi-stream into #degree_of_parallelism# streams each of that pipes into HashJoin{Build, Probe}Operator.
             TPartitionType::type part_type = TPartitionType::type::HASH_PARTITIONED;
             bool rhs_need_local_shuffle = true;
-            if (rhs_operators.size() == 1 &&
-                typeid(*rhs_operators[0]) == typeid(pipeline::ExchangeSourceOperatorFactory)) {
+            if (typeid(*rhs_operators[0]) == typeid(pipeline::ExchangeSourceOperatorFactory)) {
                 auto* exchange_op = static_cast<pipeline::ExchangeSourceOperatorFactory*>(rhs_operators[0].get());
                 auto& texchange_node = exchange_op->texchange_node();
                 DCHECK(texchange_node.__isset.partition_type);
@@ -408,8 +407,7 @@ pipeline::OpFactories HashJoinNode::decompose_to_pipeline(pipeline::PipelineBuil
                 }
             }
             bool lhs_need_local_shuffle = true;
-            if (lhs_operators.size() == 1 &&
-                typeid(*lhs_operators[0]) == typeid(pipeline::ExchangeSourceOperatorFactory)) {
+            if (typeid(*lhs_operators[0]) == typeid(pipeline::ExchangeSourceOperatorFactory)) {
                 auto* exchange_op = static_cast<pipeline::ExchangeSourceOperatorFactory*>(lhs_operators[0].get());
                 auto& texchange_node = exchange_op->texchange_node();
                 DCHECK(texchange_node.__isset.partition_type);


### PR DESCRIPTION
# Enhancement

Operators between `ExchangeSourceOperator` and `HashJoinProbe/HashJoinBuilder`, such as `ProjectOperator`, will not change the data's distribution. So there is no need to perform local shuffle in such situation