### PR TITLE
Add QueryableReadWriteLock for find lock conflict problem easily

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/QueryableReentrantReadWriteLock.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/QueryableReentrantReadWriteLock.java
@@ -1,0 +1,21 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.common.util;
+
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/*
+ * This Lock is for exposing the getOwner() method,
+ * which is a protected method of ReentrantReadWriteLock
+ */
+public class QueryableReentrantReadWriteLock extends ReentrantReadWriteLock {
+
+    public QueryableReentrantReadWriteLock(boolean fair) {
+        super(fair);
+    }
+
+    @Override
+    public Thread getOwner() {
+        return super.getOwner();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -354,7 +354,7 @@ public class GlobalTransactionMgr implements Writable {
         stopWatch.start();
         if (!db.tryWriteLock(timeoutMillis, TimeUnit.MILLISECONDS)) {
             throw new UserException("get database write lock timeout, database="
-                    + db.getFullName() + " ,timeoutMillis=" + timeoutMillis);
+                    + db.getFullName() + ", timeoutMillis=" + timeoutMillis);
         }
         try {
             commitTransaction(db.getId(), transactionId, tabletCommitInfos, txnCommitAttachment);

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -353,7 +353,8 @@ public class GlobalTransactionMgr implements Writable {
         StopWatch stopWatch = new StopWatch();
         stopWatch.start();
         if (!db.tryWriteLock(timeoutMillis, TimeUnit.MILLISECONDS)) {
-            throw new UserException("get database write lock timeout, database=" + db.getFullName());
+            throw new UserException("get database write lock timeout, database="
+                    + db.getFullName() + " ,timeoutMillis=" + timeoutMillis);
         }
         try {
             commitTransaction(db.getId(), transactionId, tabletCommitInfos, txnCommitAttachment);


### PR DESCRIPTION
Fix #2932
Some users will encounter some lock conflicts when using StarRocks.
To make it easier to spot problems, add more concise lock logs to determine the root cause of the problem.