### PR TITLE
BugFix: Fix the wrong logger class name in BlockedPolicy

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/ThreadPoolManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ThreadPoolManager.java
@@ -178,7 +178,7 @@ public class ThreadPoolManager {
      */
     static class BlockedPolicy implements RejectedExecutionHandler {
 
-        private static final Logger LOG = LogManager.getLogger(LogDiscardPolicy.class);
+        private static final Logger LOG = LogManager.getLogger(BlockedPolicy.class);
 
         private String threadPoolName;
 


### PR DESCRIPTION
BugFix: Fix the wrong logger class name in BlockedPolicy