### PR TITLE
Add more info for schema change reach mem limit

### DIFF
--- a/be/src/runtime/mem_tracker.cpp
+++ b/be/src/runtime/mem_tracker.cpp
@@ -214,7 +214,7 @@ Status MemTracker::check_mem_limit(const std::string& msg) const {
 
 std::string MemTracker::err_msg(const std::string& msg) const {
     std::stringstream str;
-    str << "Memory exceed limit. " << msg << " ";
+    str << "Memory of " << label() << " exceed limit. " << msg << " ";
     str << "Used: " << consumption() << ", Limit: " << limit() << ". ";
     switch (type()) {
     case MemTracker::NO_SET:
@@ -234,6 +234,10 @@ std::string MemTracker::err_msg(const std::string& msg) const {
         break;
     case MemTracker::CONSISTENCY:
         str << "Mem usage has exceed the limit of consistency";
+        break;
+    case MemTracker::SCHEMA_CHANGE_TASK:
+        str << "Mem usage has exceed the limit of single schema change task, You can change the limit by modify BE "
+               "config [memory_limitation_per_thread_for_schema_change]";
         break;
     default:
         break;

--- a/be/src/runtime/mem_tracker.cpp
+++ b/be/src/runtime/mem_tracker.cpp
@@ -236,8 +236,7 @@ std::string MemTracker::err_msg(const std::string& msg) const {
         str << "Mem usage has exceed the limit of consistency";
         break;
     case MemTracker::SCHEMA_CHANGE_TASK:
-        str << "Mem usage has exceed the limit of single schema change task, You can change the limit by modify BE "
-               "config [memory_limitation_per_thread_for_schema_change]";
+        str << "You can change the limit by modify BE config [memory_limitation_per_thread_for_schema_change]";
         break;
     default:
         break;

--- a/be/src/runtime/mem_tracker.h
+++ b/be/src/runtime/mem_tracker.h
@@ -77,7 +77,7 @@ public:
         int64_t peak_consumption = 0;
     };
 
-    enum Type { NO_SET, PROCESS, QUERY_POOL, QUERY, LOAD, CONSISTENCY, COMPACTION };
+    enum Type { NO_SET, PROCESS, QUERY_POOL, QUERY, LOAD, CONSISTENCY, COMPACTION, SCHEMA_CHANGE_TASK };
 
     /// 'byte_limit' < 0 means no limit
     /// 'label' is the label used in the usage string (LogUsage())

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -372,38 +372,38 @@ private:
     vectorized::GlobalDictMaps _load_global_dicts;
 };
 
-#define LIMIT_EXCEEDED(tracker, state, msg)                                                                           \
-    do {                                                                                                              \
-        stringstream str;                                                                                             \
-        str << "Memory of " << tracker->label() << " exceed limit. " << msg << " ";                                   \
-        str << "Backend: " << BackendOptions::get_localhost() << ", ";                                                \
-        if (state != nullptr) {                                                                                       \
-            str << "fragment: " << print_id(state->fragment_instance_id()) << " ";                                    \
-        }                                                                                                             \
-        str << "Used: " << tracker->consumption() << ", Limit: " << tracker->limit() << ". ";                         \
-        switch (tracker->type()) {                                                                                    \
-        case MemTracker::NO_SET:                                                                                      \
-            break;                                                                                                    \
-        case MemTracker::QUERY:                                                                                       \
-            str << "Mem usage has exceed the limit of single query, You can change the limit by "                     \
-                   "set session variable exec_mem_limit.";                                                            \
-            break;                                                                                                    \
-        case MemTracker::PROCESS:                                                                                     \
-            str << "Mem usage has exceed the limit of BE";                                                            \
-            break;                                                                                                    \
-        case MemTracker::QUERY_POOL:                                                                                  \
-            str << "Mem usage has exceed the limit of query pool";                                                    \
-            break;                                                                                                    \
-        case MemTracker::LOAD:                                                                                        \
-            str << "Mem usage has exceed the limit of load";                                                          \
-            break;                                                                                                    \
-        case MemTracker::SCHEMA_CHANGE_TASK:                                                                          \
-            str << "You can change the limit by modify BE config [memory_limitation_per_thread_for_schema_change]";   \
-            break;                                                                                                    \
-        default:                                                                                                      \
-            break;                                                                                                    \
-        }                                                                                                             \
-        return Status::MemoryLimitExceeded(str.str());                                                                \
+#define LIMIT_EXCEEDED(tracker, state, msg)                                                                         \
+    do {                                                                                                            \
+        stringstream str;                                                                                           \
+        str << "Memory of " << tracker->label() << " exceed limit. " << msg << " ";                                 \
+        str << "Backend: " << BackendOptions::get_localhost() << ", ";                                              \
+        if (state != nullptr) {                                                                                     \
+            str << "fragment: " << print_id(state->fragment_instance_id()) << " ";                                  \
+        }                                                                                                           \
+        str << "Used: " << tracker->consumption() << ", Limit: " << tracker->limit() << ". ";                       \
+        switch (tracker->type()) {                                                                                  \
+        case MemTracker::NO_SET:                                                                                    \
+            break;                                                                                                  \
+        case MemTracker::QUERY:                                                                                     \
+            str << "Mem usage has exceed the limit of single query, You can change the limit by "                   \
+                   "set session variable exec_mem_limit.";                                                          \
+            break;                                                                                                  \
+        case MemTracker::PROCESS:                                                                                   \
+            str << "Mem usage has exceed the limit of BE";                                                          \
+            break;                                                                                                  \
+        case MemTracker::QUERY_POOL:                                                                                \
+            str << "Mem usage has exceed the limit of query pool";                                                  \
+            break;                                                                                                  \
+        case MemTracker::LOAD:                                                                                      \
+            str << "Mem usage has exceed the limit of load";                                                        \
+            break;                                                                                                  \
+        case MemTracker::SCHEMA_CHANGE_TASK:                                                                        \
+            str << "You can change the limit by modify BE config [memory_limitation_per_thread_for_schema_change]"; \
+            break;                                                                                                  \
+        default:                                                                                                    \
+            break;                                                                                                  \
+        }                                                                                                           \
+        return Status::MemoryLimitExceeded(str.str());                                                              \
     } while (false)
 
 #define RETURN_IF_LIMIT_EXCEEDED(state, msg)                                                \

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -372,35 +372,39 @@ private:
     vectorized::GlobalDictMaps _load_global_dicts;
 };
 
-#define LIMIT_EXCEEDED(tracker, state, msg)                                                       \
-    do {                                                                                          \
-        stringstream str;                                                                         \
-        str << "Memory exceed limit. " << msg << " ";                                             \
-        str << "Backend: " << BackendOptions::get_localhost() << ", ";                            \
-        if (state != nullptr) {                                                                   \
-            str << "fragment: " << print_id(state->fragment_instance_id()) << " ";                \
-        }                                                                                         \
-        str << "Used: " << tracker->consumption() << ", Limit: " << tracker->limit() << ". ";     \
-        switch (tracker->type()) {                                                                \
-        case MemTracker::NO_SET:                                                                  \
-            break;                                                                                \
-        case MemTracker::QUERY:                                                                   \
-            str << "Mem usage has exceed the limit of single query, You can change the limit by " \
-                   "set session variable exec_mem_limit.";                                        \
-            break;                                                                                \
-        case MemTracker::PROCESS:                                                                 \
-            str << "Mem usage has exceed the limit of BE";                                        \
-            break;                                                                                \
-        case MemTracker::QUERY_POOL:                                                              \
-            str << "Mem usage has exceed the limit of query pool";                                \
-            break;                                                                                \
-        case MemTracker::LOAD:                                                                    \
-            str << "Mem usage has exceed the limit of load";                                      \
-            break;                                                                                \
-        default:                                                                                  \
-            break;                                                                                \
-        }                                                                                         \
-        return Status::MemoryLimitExceeded(str.str());                                            \
+#define LIMIT_EXCEEDED(tracker, state, msg)                                                                           \
+    do {                                                                                                              \
+        stringstream str;                                                                                             \
+        str << "Memory of " << tracker->label() << " exceed limit. " << msg << " ";                                   \
+        str << "Backend: " << BackendOptions::get_localhost() << ", ";                                                \
+        if (state != nullptr) {                                                                                       \
+            str << "fragment: " << print_id(state->fragment_instance_id()) << " ";                                    \
+        }                                                                                                             \
+        str << "Used: " << tracker->consumption() << ", Limit: " << tracker->limit() << ". ";                         \
+        switch (tracker->type()) {                                                                                    \
+        case MemTracker::NO_SET:                                                                                      \
+            break;                                                                                                    \
+        case MemTracker::QUERY:                                                                                       \
+            str << "Mem usage has exceed the limit of single query, You can change the limit by "                     \
+                   "set session variable exec_mem_limit.";                                                            \
+            break;                                                                                                    \
+        case MemTracker::PROCESS:                                                                                     \
+            str << "Mem usage has exceed the limit of BE";                                                            \
+            break;                                                                                                    \
+        case MemTracker::QUERY_POOL:                                                                                  \
+            str << "Mem usage has exceed the limit of query pool";                                                    \
+            break;                                                                                                    \
+        case MemTracker::LOAD:                                                                                        \
+            str << "Mem usage has exceed the limit of load";                                                          \
+            break;                                                                                                    \
+        case MemTracker::SCHEMA_CHANGE_TASK:                                                                          \
+            str << "Mem usage has exceed the limit of single schema change task, You can change the limit by modify " \
+                   "BE config [memory_limitation_per_thread_for_schema_change]";                                      \
+            break;                                                                                                    \
+        default:                                                                                                      \
+            break;                                                                                                    \
+        }                                                                                                             \
+        return Status::MemoryLimitExceeded(str.str());                                                                \
     } while (false)
 
 #define RETURN_IF_LIMIT_EXCEEDED(state, msg)                                                \

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -398,8 +398,7 @@ private:
             str << "Mem usage has exceed the limit of load";                                                          \
             break;                                                                                                    \
         case MemTracker::SCHEMA_CHANGE_TASK:                                                                          \
-            str << "Mem usage has exceed the limit of single schema change task, You can change the limit by modify " \
-                   "BE config [memory_limitation_per_thread_for_schema_change]";                                      \
+            str << "You can change the limit by modify BE config [memory_limitation_per_thread_for_schema_change]";   \
             break;                                                                                                    \
         default:                                                                                                      \
             break;                                                                                                    \

--- a/be/src/storage/task/engine_alter_tablet_task.cpp
+++ b/be/src/storage/task/engine_alter_tablet_task.cpp
@@ -38,7 +38,8 @@ EngineAlterTabletTask::EngineAlterTabletTask(MemTracker* mem_tracker, const TAlt
           _error_msgs(error_msgs),
           _process_name(process_name) {
     size_t mem_limit = static_cast<size_t>(config::memory_limitation_per_thread_for_schema_change) * 1024 * 1024 * 1024;
-    _mem_tracker = std::make_unique<MemTracker>(mem_limit, "schema change task", mem_tracker);
+    _mem_tracker =
+            std::make_unique<MemTracker>(MemTracker::SCHEMA_CHANGE_TASK, mem_limit, "schema change task", mem_tracker);
 }
 
 Status EngineAlterTabletTask::execute() {

--- a/be/src/storage/vectorized/schema_change.cpp
+++ b/be/src/storage/vectorized/schema_change.cpp
@@ -685,7 +685,7 @@ bool SchemaChangeDirectly::process(vectorized::TabletReader* reader, RowsetWrite
             if (status.is_end_of_file()) {
                 break;
             } else {
-                LOG(WARNING) << "tablet reader failed to get next chunk, status: " << status.to_string();
+                LOG(WARNING) << "tablet reader failed to get next chunk, status: " << status.get_error_msg();
                 return false;
             }
         }


### PR DESCRIPTION
before modify

```
W0118 19:53:59.640015 113185 schema_change.cpp:688] tablet reader failed to get next chunk, status: Memory limit exceeded: Memory exceed limit. read and decompress page Used: 2257704, Limit: 1048576. 
```

after modify

```
W0118 19:53:59.640015 113185 schema_change.cpp:688] tablet reader failed to get next chunk, status: Memory of schema change task exceed limit. read and decompress page Used: 2257704, Limit: 1048576. You can change the limit by modify BE config [memory_limitation_per_thread_for_schema_change
```