### PR TITLE
Support cancel delete after failure

### DIFF
--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -270,7 +270,7 @@ void AgentServer::submit_tasks(TAgentResult& agent_result, const std::vector<TAg
             break;
         }
         case TTaskType::ALTER:
-            _create_tablet_workers->submit_tasks(&all_tasks);
+            _alter_tablet_workers->submit_tasks(&all_tasks);
             break;
         default:
             ret_st = Status::InvalidArgument(strings::Substitute("tasks(type=$0) has wrong task type", task_type));

--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -178,9 +178,8 @@ void AgentServer::submit_tasks(TAgentResult& agent_result, const std::vector<TAg
                         strings::Substitute("task(signature=$0) has wrong request member", signature));
                 break;
             }
-            if (task.push_req.push_type == TPushType::LOAD_V2 ||
-                    task.push_req.push_type == TPushType::DELETE ||
-                       task.push_req.push_type == TPushType::CANCEL_DELETE) {
+            if (task.push_req.push_type == TPushType::LOAD_V2 || task.push_req.push_type == TPushType::DELETE ||
+                task.push_req.push_type == TPushType::CANCEL_DELETE) {
                 push_divider[task.push_req.push_type].push_back(task);
             } else {
                 ret_st = Status::InvalidArgument(
@@ -219,56 +218,84 @@ void AgentServer::submit_tasks(TAgentResult& agent_result, const std::vector<TAg
     }
 
     // batch submit tasks
-    for(const auto& task_item: task_divider) {
+    for (const auto& task_item : task_divider) {
         const auto& task_type = task_item.first;
         auto all_tasks = task_item.second;
         switch (task_type) {
-            case TTaskType::CREATE: _create_tablet_workers->submit_tasks(&all_tasks); break;
-            case TTaskType::DROP:   _drop_tablet_workers->submit_tasks(&all_tasks); break;
-            case TTaskType::PUBLISH_VERSION: {
-                for (const auto& task: all_tasks) {
-                    _publish_version_workers->submit_task(task);
-                }
-                break;
+        case TTaskType::CREATE:
+            _create_tablet_workers->submit_tasks(&all_tasks);
+            break;
+        case TTaskType::DROP:
+            _drop_tablet_workers->submit_tasks(&all_tasks);
+            break;
+        case TTaskType::PUBLISH_VERSION: {
+            for (const auto& task : all_tasks) {
+                _publish_version_workers->submit_task(task);
             }
-            case TTaskType::CLEAR_TRANSACTION_TASK:  _clear_transaction_task_workers->submit_tasks(&all_tasks); break;
-            case TTaskType::CLONE:                   _clone_workers->submit_tasks(&all_tasks); break;
-            case TTaskType::STORAGE_MEDIUM_MIGRATE:  _storage_medium_migrate_workers->submit_tasks(&all_tasks); break;
-            case TTaskType::CHECK_CONSISTENCY:       _check_consistency_workers->submit_tasks(&all_tasks); break;
-            case TTaskType::UPLOAD:                  _upload_workers->submit_tasks(&all_tasks); break;
-            case TTaskType::DOWNLOAD:                _download_workers->submit_tasks(&all_tasks); break;
-            case TTaskType::MAKE_SNAPSHOT:           _make_snapshot_workers->submit_tasks(&all_tasks); break;
-            case TTaskType::RELEASE_SNAPSHOT:        _release_snapshot_workers->submit_tasks(&all_tasks); break;
-            case TTaskType::MOVE:                    _move_dir_workers->submit_tasks(&all_tasks); break;
-            case TTaskType::UPDATE_TABLET_META_INFO: _update_tablet_meta_info_workers->submit_tasks(&all_tasks); break;
-            case TTaskType::REALTIME_PUSH:
-            case TTaskType::PUSH: {
-                // should not run here
-                break;
-            }
-            case TTaskType::ALTER: _create_tablet_workers->submit_tasks(&all_tasks); break;
-            default:
-                ret_st = Status::InvalidArgument(
-                        strings::Substitute("tasks(type=$0) has wrong task type", task_type));
-                LOG(WARNING) << "fail to batch submit task. reason: " << ret_st.get_error_msg();
+            break;
+        }
+        case TTaskType::CLEAR_TRANSACTION_TASK:
+            _clear_transaction_task_workers->submit_tasks(&all_tasks);
+            break;
+        case TTaskType::CLONE:
+            _clone_workers->submit_tasks(&all_tasks);
+            break;
+        case TTaskType::STORAGE_MEDIUM_MIGRATE:
+            _storage_medium_migrate_workers->submit_tasks(&all_tasks);
+            break;
+        case TTaskType::CHECK_CONSISTENCY:
+            _check_consistency_workers->submit_tasks(&all_tasks);
+            break;
+        case TTaskType::UPLOAD:
+            _upload_workers->submit_tasks(&all_tasks);
+            break;
+        case TTaskType::DOWNLOAD:
+            _download_workers->submit_tasks(&all_tasks);
+            break;
+        case TTaskType::MAKE_SNAPSHOT:
+            _make_snapshot_workers->submit_tasks(&all_tasks);
+            break;
+        case TTaskType::RELEASE_SNAPSHOT:
+            _release_snapshot_workers->submit_tasks(&all_tasks);
+            break;
+        case TTaskType::MOVE:
+            _move_dir_workers->submit_tasks(&all_tasks);
+            break;
+        case TTaskType::UPDATE_TABLET_META_INFO:
+            _update_tablet_meta_info_workers->submit_tasks(&all_tasks);
+            break;
+        case TTaskType::REALTIME_PUSH:
+        case TTaskType::PUSH: {
+            // should not run here
+            break;
+        }
+        case TTaskType::ALTER:
+            _create_tablet_workers->submit_tasks(&all_tasks);
+            break;
+        default:
+            ret_st = Status::InvalidArgument(strings::Substitute("tasks(type=$0) has wrong task type", task_type));
+            LOG(WARNING) << "fail to batch submit task. reason: " << ret_st.get_error_msg();
         }
     }
 
     // batch submit push tasks
     if (!push_divider.empty()) {
         LOG(INFO) << "begin batch submit task: " << tasks[0].task_type;
-        for (const auto& push_item: push_divider) {
+        for (const auto& push_item : push_divider) {
             const auto& push_type = push_item.first;
             auto all_push_tasks = push_item.second;
             switch (push_type) {
-                case TPushType::LOAD_V2: _push_workers->submit_tasks(&all_push_tasks); break;
-                case TPushType::DELETE:
-                case TPushType::CANCEL_DELETE: _delete_workers->submit_tasks(&all_push_tasks); break;
-                default:
-                    ret_st = Status::InvalidArgument(
-                            strings::Substitute("tasks(type=$0, push_type=$1) has wrong task type",
-                                                TTaskType::PUSH, push_type));
-                    LOG(WARNING) << "fail to batch submit push task. reason: " << ret_st.get_error_msg();
+            case TPushType::LOAD_V2:
+                _push_workers->submit_tasks(&all_push_tasks);
+                break;
+            case TPushType::DELETE:
+            case TPushType::CANCEL_DELETE:
+                _delete_workers->submit_tasks(&all_push_tasks);
+                break;
+            default:
+                ret_st = Status::InvalidArgument(strings::Substitute("tasks(type=$0, push_type=$1) has wrong task type",
+                                                                     TTaskType::PUSH, push_type));
+                LOG(WARNING) << "fail to batch submit push task. reason: " << ret_st.get_error_msg();
             }
         }
     }

--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -136,6 +136,9 @@ void AgentServer::submit_tasks(TAgentResult& agent_result, const std::vector<TAg
         return;
     }
 
+    phmap::flat_hash_map<TTaskType::type, std::vector<TAgentTaskRequest>> task_divider;
+    phmap::flat_hash_map<TPushType::type, std::vector<TAgentTaskRequest>> push_divider;
+
     for (const auto& task : tasks) {
         VLOG_RPC << "submit one task: " << apache::thrift::ThriftDebugString(task).c_str();
         TTaskType::type task_type = task.task_type;
@@ -144,7 +147,7 @@ void AgentServer::submit_tasks(TAgentResult& agent_result, const std::vector<TAg
 #define HANDLE_TYPE(t_task_type, work_pool, req_member)                                             \
     case t_task_type:                                                                               \
         if (task.__isset.req_member) {                                                              \
-            work_pool->submit_task(task);                                                           \
+            task_divider[t_task_type].push_back(task);                                              \
         } else {                                                                                    \
             ret_st = Status::InvalidArgument(                                                       \
                     strings::Substitute("task(signature=$0) has wrong request member", signature)); \
@@ -175,10 +178,10 @@ void AgentServer::submit_tasks(TAgentResult& agent_result, const std::vector<TAg
                         strings::Substitute("task(signature=$0) has wrong request member", signature));
                 break;
             }
-            if (task.push_req.push_type == TPushType::LOAD_V2) {
-                _push_workers->submit_task(task);
-            } else if (task.push_req.push_type == TPushType::DELETE) {
-                _delete_workers->submit_task(task);
+            if (task.push_req.push_type == TPushType::LOAD_V2 ||
+                    task.push_req.push_type == TPushType::DELETE ||
+                       task.push_req.push_type == TPushType::CANCEL_DELETE) {
+                push_divider[task.push_req.push_type].push_back(task);
             } else {
                 ret_st = Status::InvalidArgument(
                         strings::Substitute("task(signature=$0, type=$1, push_type=$2) has wrong push_type", signature,
@@ -187,7 +190,7 @@ void AgentServer::submit_tasks(TAgentResult& agent_result, const std::vector<TAg
             break;
         case TTaskType::ALTER:
             if (task.__isset.alter_tablet_req || task.__isset.alter_tablet_req_v2) {
-                _alter_tablet_workers->submit_task(task);
+                task_divider[TTaskType::ALTER].push_back(task);
             } else {
                 ret_st = Status::InvalidArgument(
                         strings::Substitute("task(signature=$0) has wrong request member", signature));
@@ -212,6 +215,61 @@ void AgentServer::submit_tasks(TAgentResult& agent_result, const std::vector<TAg
             // ret_st can be error only when it encounters an wrong task_type and
             // req-member in TAgentTaskRequest, which is basically impossible.
             // TODO(lingbin): check the logic in FE again later.
+        }
+    }
+
+    // batch submit tasks
+    for(const auto& task_item: task_divider) {
+        const auto& task_type = task_item.first;
+        auto all_tasks = task_item.second;
+        switch (task_type) {
+            case TTaskType::CREATE: _create_tablet_workers->submit_tasks(&all_tasks); break;
+            case TTaskType::DROP:   _drop_tablet_workers->submit_tasks(&all_tasks); break;
+            case TTaskType::PUBLISH_VERSION: {
+                for (const auto& task: all_tasks) {
+                    _publish_version_workers->submit_task(task);
+                }
+                break;
+            }
+            case TTaskType::CLEAR_TRANSACTION_TASK:  _clear_transaction_task_workers->submit_tasks(&all_tasks); break;
+            case TTaskType::CLONE:                   _clone_workers->submit_tasks(&all_tasks); break;
+            case TTaskType::STORAGE_MEDIUM_MIGRATE:  _storage_medium_migrate_workers->submit_tasks(&all_tasks); break;
+            case TTaskType::CHECK_CONSISTENCY:       _check_consistency_workers->submit_tasks(&all_tasks); break;
+            case TTaskType::UPLOAD:                  _upload_workers->submit_tasks(&all_tasks); break;
+            case TTaskType::DOWNLOAD:                _download_workers->submit_tasks(&all_tasks); break;
+            case TTaskType::MAKE_SNAPSHOT:           _make_snapshot_workers->submit_tasks(&all_tasks); break;
+            case TTaskType::RELEASE_SNAPSHOT:        _release_snapshot_workers->submit_tasks(&all_tasks); break;
+            case TTaskType::MOVE:                    _move_dir_workers->submit_tasks(&all_tasks); break;
+            case TTaskType::UPDATE_TABLET_META_INFO: _update_tablet_meta_info_workers->submit_tasks(&all_tasks); break;
+            case TTaskType::REALTIME_PUSH:
+            case TTaskType::PUSH: {
+                // should not run here
+                break;
+            }
+            case TTaskType::ALTER: _create_tablet_workers->submit_tasks(&all_tasks); break;
+            default:
+                ret_st = Status::InvalidArgument(
+                        strings::Substitute("tasks(type=$0) has wrong task type", task_type));
+                LOG(WARNING) << "fail to batch submit task. reason: " << ret_st.get_error_msg();
+        }
+    }
+
+    // batch submit push tasks
+    if (!push_divider.empty()) {
+        LOG(INFO) << "begin batch submit task: " << tasks[0].task_type;
+        for (const auto& push_item: push_divider) {
+            const auto& push_type = push_item.first;
+            auto all_push_tasks = push_item.second;
+            switch (push_type) {
+                case TPushType::LOAD_V2: _push_workers->submit_tasks(&all_push_tasks); break;
+                case TPushType::DELETE:
+                case TPushType::CANCEL_DELETE: _delete_workers->submit_tasks(&all_push_tasks); break;
+                default:
+                    ret_st = Status::InvalidArgument(
+                            strings::Substitute("tasks(type=$0, push_type=$1) has wrong task type",
+                                                TTaskType::PUSH, push_type));
+                    LOG(WARNING) << "fail to batch submit push task. reason: " << ret_st.get_error_msg();
+            }
         }
     }
 

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -198,7 +198,6 @@ void TaskWorkerPool::submit_task(const TAgentTaskRequest& task) {
 }
 
 void TaskWorkerPool::submit_tasks(std::vector<TAgentTaskRequest>* tasks) {
-
     DCHECK(!tasks->empty());
     std::string type_str;
     const TTaskType::type task_type = (*tasks)[0].task_type;
@@ -211,7 +210,7 @@ void TaskWorkerPool::submit_tasks(std::vector<TAgentTaskRequest>* tasks) {
             LOG(INFO) << "submitting task. type=" << type_str << ", signature=" << signature;
 
             // batch register task info
-            std::set<int64_t> &signature_set = _s_task_signatures[task_type];
+            std::set<int64_t>& signature_set = _s_task_signatures[task_type];
             if (signature_set.insert(signature).second) {
                 (const_cast<TAgentTaskRequest&>(task_req)).__set_recv_time(time(nullptr));
                 ++it;
@@ -224,8 +223,8 @@ void TaskWorkerPool::submit_tasks(std::vector<TAgentTaskRequest>* tasks) {
 
     {
         std::unique_lock l(_worker_thread_lock);
-        if (UNLIKELY(task_type == TTaskType::REALTIME_PUSH
-                     && (*tasks)[0].push_req.push_type == TPushType::CANCEL_DELETE)) {
+        if (UNLIKELY(task_type == TTaskType::REALTIME_PUSH &&
+                     (*tasks)[0].push_req.push_type == TPushType::CANCEL_DELETE)) {
             for (auto const& task : *tasks) {
                 _tasks.push_front(task);
             }
@@ -240,7 +239,8 @@ void TaskWorkerPool::submit_tasks(std::vector<TAgentTaskRequest>* tasks) {
         int64_t signature = task.signature;
 
         LOG(INFO) << "success to submit task. type=" << type_str << ", signature=" << signature
-                  << ", task_count_in_queue=" << _tasks.size();;
+                  << ", task_count_in_queue=" << _tasks.size();
+        ;
     }
 }
 
@@ -600,9 +600,8 @@ void* TaskWorkerPool::_push_worker_thread_callback(void* arg_this) {
 
             int num_of_remove_task = 0;
             if (push_req.push_type == TPushType::CANCEL_DELETE) {
-
                 LOG(INFO) << "get push task. remove delete task transaction_id: " << push_req.transaction_id
-                << " priority: " << priority << " push_type: " << push_req.push_type;
+                          << " priority: " << priority << " push_type: " << push_req.push_type;
 
                 const auto& tasks = worker_pool_this->_tasks;
                 for (auto it = tasks.begin(); it != tasks.end();) {
@@ -619,8 +618,8 @@ void* TaskWorkerPool::_push_worker_thread_callback(void* arg_this) {
                     }
                 }
                 LOG(INFO) << "finish remove delete task transaction_id: " << push_req.transaction_id
-                << " num_of_remove_task: " << num_of_remove_task << " priority: " << priority
-                << " push_type: " << push_req.push_type;
+                          << " num_of_remove_task: " << num_of_remove_task << " priority: " << priority
+                          << " push_type: " << push_req.push_type;
             }
         } while (false);
 

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -240,7 +240,6 @@ void TaskWorkerPool::submit_tasks(std::vector<TAgentTaskRequest>* tasks) {
 
         LOG(INFO) << "success to submit task. type=" << type_str << ", signature=" << signature
                   << ", task_count_in_queue=" << _tasks.size();
-        ;
     }
 }
 

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -197,6 +197,53 @@ void TaskWorkerPool::submit_task(const TAgentTaskRequest& task) {
     }
 }
 
+void TaskWorkerPool::submit_tasks(std::vector<TAgentTaskRequest>* tasks) {
+
+    DCHECK(!tasks->empty());
+    std::string type_str;
+    const TTaskType::type task_type = (*tasks)[0].task_type;
+    EnumToString(TTaskType, task_type, type_str);
+    {
+        std::lock_guard task_signatures_lock(_s_task_signatures_lock);
+        for (auto it = tasks->begin(); it != tasks->end();) {
+            TAgentTaskRequest task_req = *it;
+            int64_t signature = task_req.signature;
+            LOG(INFO) << "submitting task. type=" << type_str << ", signature=" << signature;
+
+            // batch register task info
+            std::set<int64_t> &signature_set = _s_task_signatures[task_type];
+            if (signature_set.insert(signature).second) {
+                (const_cast<TAgentTaskRequest&>(task_req)).__set_recv_time(time(nullptr));
+                ++it;
+            } else {
+                it = tasks->erase(it);
+                LOG(INFO) << "fail to register task. type=" << type_str << ", signature=" << signature;
+            }
+        }
+    }
+
+    {
+        std::unique_lock l(_worker_thread_lock);
+        if (UNLIKELY(task_type == TTaskType::REALTIME_PUSH
+                     && (*tasks)[0].push_req.push_type == TPushType::CANCEL_DELETE)) {
+            for (auto const& task : *tasks) {
+                _tasks.push_front(task);
+            }
+        } else {
+            for (auto const& task : *tasks) {
+                _tasks.push_back(task);
+            }
+        }
+        _worker_thread_condition_variable->notify_one();
+    }
+    for (auto const& task : *tasks) {
+        int64_t signature = task.signature;
+
+        LOG(INFO) << "success to submit task. type=" << type_str << ", signature=" << signature
+                  << ", task_count_in_queue=" << _tasks.size();;
+    }
+}
+
 bool TaskWorkerPool::_register_task_info(const TTaskType::type task_type, int64_t signature) {
     std::lock_guard task_signatures_lock(_s_task_signatures_lock);
     std::set<int64_t>& signature_set = _s_task_signatures[task_type];
@@ -513,7 +560,7 @@ void* TaskWorkerPool::_push_worker_thread_callback(void* arg_this) {
     TaskWorkerPool* worker_pool_this = (TaskWorkerPool*)arg_this;
 
     TPriority::type priority = TPriority::NORMAL;
-    // https://starrocks.atlassian.net/browse/DSDB-991
+
     if (worker_pool_this->_task_worker_type != DELETE) {
         int32_t push_worker_count_high_priority = config::push_worker_count_high_priority;
         std::lock_guard worker_thread_lock(worker_pool_this->_worker_thread_lock);
@@ -550,7 +597,37 @@ void* TaskWorkerPool::_push_worker_thread_callback(void* arg_this) {
             agent_task_req = worker_pool_this->_tasks[index];
             push_req = agent_task_req.push_req;
             worker_pool_this->_tasks.erase(worker_pool_this->_tasks.begin() + index);
+
+            int num_of_remove_task = 0;
+            if (push_req.push_type == TPushType::CANCEL_DELETE) {
+
+                LOG(INFO) << "get push task. remove delete task transaction_id: " << push_req.transaction_id
+                << " priority: " << priority << " push_type: " << push_req.push_type;
+
+                const auto& tasks = worker_pool_this->_tasks;
+                for (auto it = tasks.begin(); it != tasks.end();) {
+                    TAgentTaskRequest task_req = *it;
+                    if (task_req.task_type == TTaskType::REALTIME_PUSH) {
+                        const TPushReq& push_task_in_queue = task_req.push_req;
+                        if (push_task_in_queue.push_type == TPushType::DELETE &&
+                            push_task_in_queue.transaction_id == push_req.transaction_id) {
+                            it = worker_pool_this->_tasks.erase(it);
+                            ++num_of_remove_task;
+                        } else {
+                            ++it;
+                        }
+                    }
+                }
+                LOG(INFO) << "finish remove delete task transaction_id: " << push_req.transaction_id
+                << " num_of_remove_task: " << num_of_remove_task << " priority: " << priority
+                << " push_type: " << push_req.push_type;
+            }
         } while (false);
+
+        if (push_req.push_type == TPushType::CANCEL_DELETE) {
+            // cancel task already done and continue to get the next task.
+            continue;
+        }
 
         if (worker_pool_this->_stopped) {
             break;

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -623,11 +623,6 @@ void* TaskWorkerPool::_push_worker_thread_callback(void* arg_this) {
             }
         } while (false);
 
-        if (push_req.push_type == TPushType::CANCEL_DELETE) {
-            // cancel task already done and continue to get the next task.
-            continue;
-        }
-
         if (worker_pool_this->_stopped) {
             break;
         }

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -204,6 +204,7 @@ void TaskWorkerPool::submit_tasks(std::vector<TAgentTaskRequest>* tasks) {
     EnumToString(TTaskType, task_type, type_str);
     {
         std::lock_guard task_signatures_lock(_s_task_signatures_lock);
+        const auto recv_time = time(nullptr);
         for (auto it = tasks->begin(); it != tasks->end();) {
             TAgentTaskRequest& task_req = *it;
             int64_t signature = task_req.signature;
@@ -212,7 +213,7 @@ void TaskWorkerPool::submit_tasks(std::vector<TAgentTaskRequest>* tasks) {
             // batch register task info
             std::set<int64_t>& signature_set = _s_task_signatures[task_type];
             if (signature_set.insert(signature).second) {
-                (const_cast<TAgentTaskRequest&>(task_req)).__set_recv_time(time(nullptr));
+                task_req.__set_recv_time(recv_time);
                 ++it;
             } else {
                 it = tasks->erase(it);

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -205,7 +205,7 @@ void TaskWorkerPool::submit_tasks(std::vector<TAgentTaskRequest>* tasks) {
     {
         std::lock_guard task_signatures_lock(_s_task_signatures_lock);
         for (auto it = tasks->begin(); it != tasks->end();) {
-            TAgentTaskRequest task_req = *it;
+            TAgentTaskRequest& task_req = *it;
             int64_t signature = task_req.signature;
             LOG(INFO) << "submitting task. type=" << type_str << ", signature=" << signature;
 
@@ -602,9 +602,9 @@ void* TaskWorkerPool::_push_worker_thread_callback(void* arg_this) {
                 LOG(INFO) << "get push task. remove delete task transaction_id: " << push_req.transaction_id
                           << " priority: " << priority << " push_type: " << push_req.push_type;
 
-                const auto& tasks = worker_pool_this->_tasks;
+                auto& tasks = worker_pool_this->_tasks;
                 for (auto it = tasks.begin(); it != tasks.end();) {
-                    TAgentTaskRequest task_req = *it;
+                    TAgentTaskRequest& task_req = *it;
                     if (task_req.task_type == TTaskType::REALTIME_PUSH) {
                         const TPushReq& push_task_in_queue = task_req.push_req;
                         if (push_task_in_queue.push_type == TPushType::DELETE &&

--- a/be/src/agent/task_worker_pool.h
+++ b/be/src/agent/task_worker_pool.h
@@ -84,6 +84,7 @@ public:
     // Input parameters:
     // * task: the task need callback thread to do
     void submit_task(const TAgentTaskRequest& task);
+    void submit_tasks(std::vector<TAgentTaskRequest>* task);
 
 private:
     bool _register_task_info(const TTaskType::type task_type, int64_t signature);

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/DeleteStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/DeleteStmt.java
@@ -39,15 +39,23 @@ import java.util.List;
 public class DeleteStmt extends DdlStmt {
     private final TableName tbl;
     private final PartitionNames partitionNames;
-    private Expr wherePredicate;
+    private final Expr wherePredicate;
 
-    private List<Predicate> deleteConditions;
+    private final List<Predicate> deleteConditions;
+    // Each deleteStmt corresponds to a DeleteJob.
+    // The JobID is generated here for easy correlation when cancel Delete
+    private final long jobId;
 
     public DeleteStmt(TableName tableName, PartitionNames partitionNames, Expr wherePredicate) {
         this.tbl = tableName;
         this.partitionNames = partitionNames;
         this.wherePredicate = wherePredicate;
-        this.deleteConditions = new LinkedList<Predicate>();
+        this.deleteConditions = Lists.newLinkedList();
+        this.jobId = Catalog.getCurrentCatalog().getNextId();
+    }
+
+    public long getJobId() {
+        return jobId;
     }
 
     public String getTableName() {

--- a/fe/fe-core/src/main/java/com/starrocks/load/DeleteHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/DeleteHandler.java
@@ -297,14 +297,7 @@ public class DeleteHandler implements Writable {
                 while (countDownTime > 0) {
                     if (countDownTime > CHECK_INTERVAL) {
                         countDownTime -= CHECK_INTERVAL;
-                        if (killJobSet.contains(deleteJob.getId())) {
-                            Iterator<Long> iterator = killJobSet.iterator();
-                            while (iterator.hasNext()) {
-                                if (iterator.next().equals(deleteJob.getId())) {
-                                    iterator.remove();
-                                    break;
-                                }
-                            }
+                        if (killJobSet.remove(deleteJob.getId())) {
                             cancelJob(deleteJob, CancelType.USER, "user cancelled");
                             throw new DdlException("Cancelled");
                         }

--- a/fe/fe-core/src/main/java/com/starrocks/load/DeleteJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/DeleteJob.java
@@ -88,7 +88,6 @@ public class DeleteJob extends AbstractTxnStateChangeCallback {
      */
     public void checkAndUpdateQuorum() throws MetaNotFoundException {
         long dbId = deleteInfo.getDbId();
-        long tableId = deleteInfo.getTableId();
         Database db = Catalog.getCurrentCatalog().getDb(dbId);
         if (db == null) {
             throw new MetaNotFoundException("can not find database " + dbId + " when commit delete");

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -23,6 +23,7 @@ package com.starrocks.qe;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import com.starrocks.analysis.DeleteStmt;
 import com.starrocks.analysis.UserIdentity;
 import com.starrocks.catalog.Catalog;
 import com.starrocks.cluster.ClusterNamespace;
@@ -452,7 +453,12 @@ public class ConnectContext {
         // Now, cancel running process.
         StmtExecutor executorRef = executor;
         if (executorRef != null) {
-            executorRef.cancel();
+            if (executorRef.getParsedStmt() instanceof DeleteStmt) {
+                DeleteStmt deleteStmt = (DeleteStmt) executorRef.getParsedStmt();
+                catalog.getDeleteHandler().killJob(deleteStmt.getJobId());
+            } else {
+                executorRef.cancel();
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -23,7 +23,6 @@ package com.starrocks.qe;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import com.starrocks.analysis.DeleteStmt;
 import com.starrocks.analysis.UserIdentity;
 import com.starrocks.catalog.Catalog;
 import com.starrocks.cluster.ClusterNamespace;
@@ -453,12 +452,7 @@ public class ConnectContext {
         // Now, cancel running process.
         StmtExecutor executorRef = executor;
         if (executorRef != null) {
-            if (executorRef.getParsedStmt() instanceof DeleteStmt) {
-                DeleteStmt deleteStmt = (DeleteStmt) executorRef.getParsedStmt();
-                catalog.getDeleteHandler().killJob(deleteStmt.getJobId());
-            } else {
-                executorRef.cancel();
-            }
+            executorRef.cancel();
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -32,6 +32,7 @@ import com.starrocks.analysis.CreateAnalyzeJobStmt;
 import com.starrocks.analysis.CreateTableAsSelectStmt;
 import com.starrocks.analysis.DdlStmt;
 import com.starrocks.analysis.DelSqlBlackListStmt;
+import com.starrocks.analysis.DeleteStmt;
 import com.starrocks.analysis.EnterStmt;
 import com.starrocks.analysis.ExportStmt;
 import com.starrocks.analysis.Expr;
@@ -605,9 +606,14 @@ public class StmtExecutor {
 
     // Because this is called by other thread
     public void cancel() {
-        Coordinator coordRef = coord;
-        if (coordRef != null) {
-            coordRef.cancel();
+        if (parsedStmt instanceof DeleteStmt) {
+            DeleteStmt deleteStmt = (DeleteStmt) parsedStmt;
+            Catalog.getCurrentCatalog().getDeleteHandler().killJob(deleteStmt.getJobId());
+        } else {
+            Coordinator coordRef = coord;
+            if (coordRef != null) {
+                coordRef.cancel();
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/task/PushTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/PushTask.java
@@ -61,7 +61,7 @@ public class PushTask extends AgentTask {
     private boolean isSyncDelete;
     private long asyncDeleteJobId;
 
-    private long transactionId;
+    private final long transactionId;
     private boolean isSchemaChanging;
 
     // for load v2 (spark load)
@@ -90,6 +90,16 @@ public class PushTask extends AgentTask {
         this.tBrokerScanRange = null;
         this.tDescriptorTable = null;
         this.useVectorized = true;
+    }
+
+    // for cancel delete
+    public PushTask(long backendId, TPushType pushType, TPriority priority, TTaskType taskType,
+                    long transactionId, long signature) {
+        super(null, backendId, taskType, -1, -1, -1, -1, -1);
+        this.pushType = pushType;
+        this.priority = priority;
+        this.transactionId = transactionId;
+        this.signature = signature;
     }
 
     // for load v2 (SparkLoadJob)
@@ -163,6 +173,9 @@ public class PushTask extends AgentTask {
                 request.setBroker_scan_range(tBrokerScanRange);
                 request.setDesc_tbl(tDescriptorTable);
                 request.setUse_vectorized(useVectorized);
+                break;
+            case CANCEL_DELETE:
+                request.setTransaction_id(transactionId);
                 break;
             default:
                 LOG.warn("unknown push type. type: " + pushType.name());

--- a/fe/fe-core/src/test/java/com/starrocks/load/DeleteHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/DeleteHandlerTest.java
@@ -27,6 +27,7 @@ import com.starrocks.mysql.privilege.Auth;
 import com.starrocks.persist.EditLog;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.QueryStateException;
+import com.starrocks.system.SystemInfoService;
 import com.starrocks.task.AgentBatchTask;
 import com.starrocks.task.AgentTask;
 import com.starrocks.task.AgentTaskExecutor;
@@ -147,6 +148,7 @@ public class DeleteHandlerTest {
         };
         globalTransactionMgr.addDatabaseTransactionMgr(db.getId());
 
+        SystemInfoService systemInfoService = new SystemInfoService();
         new Expectations() {
             {
                 Catalog.getCurrentCatalog();
@@ -167,6 +169,14 @@ public class DeleteHandlerTest {
                 AgentTaskQueue.addTask((AgentTask) any);
                 minTimes = 0;
                 result = true;
+
+                Catalog.getCurrentSystemInfo();
+                minTimes = 0;
+                result = systemInfoService;
+
+                systemInfoService.getBackendIds(true);
+                minTimes = 0;
+                result = Lists.newArrayList();
             }
         };
     }

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -149,7 +149,8 @@ enum TPushType {
     DELETE,
     LOAD_DELETE,
     // for spark load push request
-    LOAD_V2
+    LOAD_V2,
+    CANCEL_DELETE
 }
 
 enum TTaskType {


### PR DESCRIPTION
Fix #2934
If the delete statement corresponds to many partitions, the remaining task may still exist after failure in the client.
This PR allows users to kill all FE and BE tasks.
When users use the MySQL client, they can use Ctrl+C to cancel this operation.
You can also use the following command.
```
kill $query_id
```
It's just that the client may retry the delete operation three times. At this time, it may need to kill three times.
All tasks will be automatically erased if the client is directly closed or the delete execution times out.

The task_worker_pool of BE has multiple tasks with different types.
Refactoring the TaskWorkerPool is necessary to support operation in one batch to accomplish this work.
