### PR TITLE
[DynamicPartition] Making the dynamic partition bucket num configurable by default bucketNum

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/DistributionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/DistributionDesc.java
@@ -47,6 +47,10 @@ public class DistributionDesc implements Writable {
         throw new NotImplementedException();
     }
 
+    public int getBuckets() {
+        throw new NotImplementedException();
+    }
+
     public String toSql() {
         throw new NotImplementedException();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/HashDistributionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/HashDistributionDesc.java
@@ -56,6 +56,7 @@ public class HashDistributionDesc extends DistributionDesc {
         return distributionColumnNames;
     }
 
+    @Override
     public int getBuckets() {
         return numBucket;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/RandomDistributionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/RandomDistributionDesc.java
@@ -52,6 +52,11 @@ public class RandomDistributionDesc extends DistributionDesc {
     }
 
     @Override
+    public int getBuckets() {
+        return numBucket;
+    }
+
+    @Override
     public String toSql() {
         StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append("DISTRIBUTED BY RANDOM\n")

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -4077,6 +4077,7 @@ public class Catalog {
                         }
                         DataProperty dataProperty = PropertyAnalyzer.analyzeDataProperty(properties,
                                 DataProperty.DEFAULT_DATA_PROPERTY);
+                        DynamicPartitionUtil.checkAndSetDynamicPartitionBuckets(properties, distributionDesc.getBuckets());
                         DynamicPartitionUtil.checkAndSetDynamicPartitionProperty(olapTable, properties);
                         if (olapTable.dynamicPartitionExists() && olapTable.getColocateGroup() != null) {
                             HashDistributionInfo info = (HashDistributionInfo) distributionInfo;

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/DynamicPartitionUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/DynamicPartitionUtil.java
@@ -354,8 +354,10 @@ public class DynamicPartitionUtil {
     }
 
     public static void checkAndSetDynamicPartitionBuckets(Map<String, String> properties, int bucketNum) {
-        if (properties != null && !properties.isEmpty()
-                && Strings.isNullOrEmpty(properties.get(DynamicPartitionProperty.ENABLE))) {
+        if (properties == null || properties.isEmpty()) {
+            return;
+        }
+        if (!Strings.isNullOrEmpty(properties.get(DynamicPartitionProperty.ENABLE))) {
             properties.putIfAbsent(DynamicPartitionProperty.BUCKETS, String.valueOf(bucketNum));
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/DynamicPartitionUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/DynamicPartitionUtil.java
@@ -353,6 +353,13 @@ public class DynamicPartitionUtil {
         }
     }
 
+    public static void checkAndSetDynamicPartitionBuckets(Map<String, String> properties, int bucketNum) {
+        if (properties != null && !properties.isEmpty()
+                && Strings.isNullOrEmpty(properties.get(DynamicPartitionProperty.ENABLE))) {
+            properties.putIfAbsent(DynamicPartitionProperty.BUCKETS, String.valueOf(bucketNum));
+        }
+    }
+
     public static String getPartitionFormat(Column column) throws DdlException {
         if (column.getPrimitiveType().equals(PrimitiveType.DATE)) {
             return DATE_FORMAT;

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/DynamicPartitionTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/DynamicPartitionTableTest.java
@@ -223,8 +223,6 @@ public class DynamicPartitionTableTest {
 
     @Test
     public void testMissBuckets() throws Exception {
-        expectedException.expect(DdlException.class);
-        expectedException.expectMessage("Must assign dynamic_partition.buckets properties");
         starRocksAssert.withTable("CREATE TABLE test.`dynamic_partition_buckets` (\n" +
                 "  `k1` date NULL COMMENT \"\",\n" +
                 "  `k2` int NULL COMMENT \"\",\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/DynamicPartitionTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/DynamicPartitionTableTest.java
@@ -247,13 +247,16 @@ public class DynamicPartitionTableTest {
                 "\"dynamic_partition.time_unit\" = \"day\",\n" +
                 "\"dynamic_partition.prefix\" = \"p\"\n" +
                 ");");
+        Database db = Catalog.getCurrentCatalog().getDb("default_cluster:test");
+        OlapTable table = (OlapTable) db.getTable("dynamic_partition_buckets");
+        Assert.assertEquals(table.getTableProperty().getDynamicPartitionProperty().getBuckets(), 32);
     }
 
     @Test
     public void testNotAllowed() throws Exception {
         expectedException.expect(DdlException.class);
         expectedException.expectMessage("Only support dynamic partition properties on range partition table");
-        starRocksAssert.withTable("CREATE TABLE test.`dynamic_partition_buckets` (\n" +
+        starRocksAssert.withTable("CREATE TABLE test.`dynamic_partition_non_range` (\n" +
                 "  `k1` date NULL COMMENT \"\",\n" +
                 "  `k2` int NULL COMMENT \"\",\n" +
                 "  `k3` smallint NULL COMMENT \"\",\n" +


### PR DESCRIPTION
Now create a dynamic partition table that should indicate two bucketNum in the create statement, like blow:
```sql
CREATE TABLE `src` (
  `__time` datetime NULL COMMENT "",
  `count` bigint(20) SUM NULL DEFAULT "1" COMMENT ""
) ENGINE=OLAP
AGGREGATE KEY(`__time`)
COMMENT "OLAP"
PARTITION BY RANGE(`__time`)
(PARTITION p20220118 VALUES [('0000-01-01 00:00:00'), ('2022-01-19 00:00:00')),
PARTITION p20220122 VALUES [('2022-01-22 00:00:00'), ('2022-01-23 00:00:00')))
DISTRIBUTED BY HASH(`__time`) BUCKETS 140
PROPERTIES (
"replication_num" = "1",
"dynamic_partition.enable" = "true",
"dynamic_partition.time_unit" = "DAY",
"dynamic_partition.time_zone" = "Asia/Shanghai",
"dynamic_partition.start" = "-6",
"dynamic_partition.end" = "3",
"dynamic_partition.prefix" = "p",
"dynamic_partition.buckets" = "140",
"in_memory" = "false",
"storage_format" = "DEFAULT"
);
```
Both `"dynamic_partition.buckets" = "140",` and  `BUCKETS 140` should be set, and this may be a little confused when these two nums are different.
So just make `dynamic_partition.buckets` configurable. If it's missing, use the `bucketNum` to fill this property automatically.
