### PR TITLE
Execute framework of agg function  support processing without ignore null

### DIFF
--- a/be/src/exprs/agg/aggregate.h
+++ b/be/src/exprs/agg/aggregate.h
@@ -39,12 +39,18 @@ public:
     virtual void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
                         size_t row_num) const = 0;
 
+    // Update the aggregation state with null
+    virtual void update_null(FunctionContext* ctx, AggDataPtr __restrict state) const {}
+
     // Merge the aggregation state
     // columns points to columns containing merge input,
     // We maybe need deserialize input data firstly.
     // row_num is number of row which should be merged.
     virtual void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state,
                        size_t row_num) const = 0;
+
+    // Merge the aggregation state with null
+    virtual void merge_null(FunctionContext* ctx, AggDataPtr __restrict state) const {}
 
     // When transmit data over network, we need to serialize agg data.
     // We serialize the agg data to |to| column
@@ -99,6 +105,13 @@ public:
     virtual void update_batch_single_state(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
                                            int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
                                            int64_t frame_end) const {}
+
+    // For window functions
+    // A peer group is all of the rows that are peers within the specified ordering.
+    // Rows are peers if they compare equal to each other using the specified ordering expression.
+    // Update batch single state with null
+    virtual void update_batch_single_state_null(FunctionContext* ctx, AggDataPtr __restrict state,
+                                                int64_t peer_group_start, int64_t peer_group_end) const {}
 
     // Contains a loop with calls to "merge" function.
     // You can collect arguments into array "states"

--- a/be/src/exprs/agg/aggregate.h
+++ b/be/src/exprs/agg/aggregate.h
@@ -39,8 +39,8 @@ public:
     virtual void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
                         size_t row_num) const = 0;
 
-    // Update the aggregation state with null
-    virtual void update_null(FunctionContext* ctx, AggDataPtr __restrict state) const {}
+    // Update/Merge the aggregation state with null
+    virtual void process_null(FunctionContext* ctx, AggDataPtr __restrict state) const {}
 
     // Merge the aggregation state
     // columns points to columns containing merge input,
@@ -48,9 +48,6 @@ public:
     // row_num is number of row which should be merged.
     virtual void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state,
                        size_t row_num) const = 0;
-
-    // Merge the aggregation state with null
-    virtual void merge_null(FunctionContext* ctx, AggDataPtr __restrict state) const {}
 
     // When transmit data over network, we need to serialize agg data.
     // We serialize the agg data to |to| column

--- a/be/src/exprs/agg/aggregate.h
+++ b/be/src/exprs/agg/aggregate.h
@@ -110,8 +110,8 @@ public:
     // A peer group is all of the rows that are peers within the specified ordering.
     // Rows are peers if they compare equal to each other using the specified ordering expression.
     // Update batch single state with null
-    virtual void update_batch_single_state_null(FunctionContext* ctx, AggDataPtr __restrict state,
-                                                int64_t peer_group_start, int64_t peer_group_end) const {}
+    virtual void update_single_state_null(FunctionContext* ctx, AggDataPtr __restrict state, int64_t peer_group_start,
+                                          int64_t peer_group_end) const {}
 
     // Contains a loop with calls to "merge" function.
     // You can collect arguments into array "states"

--- a/be/src/exprs/agg/aggregate_factory.cpp
+++ b/be/src/exprs/agg/aggregate_factory.cpp
@@ -97,10 +97,10 @@ AggregateFunctionPtr AggregateFactory::MakeAnyValueAggregateFunction() {
             AnyValueAggregateFunction<PT, AnyValueAggregateData<PT>, AnyValueElement<PT, AnyValueAggregateData<PT>>>>();
 }
 
-template <typename NestedState>
+template <typename NestedState, bool IgnoreNull>
 AggregateFunctionPtr AggregateFactory::MakeNullableAggregateFunctionUnary(AggregateFunctionPtr nested_function) {
     using AggregateDataType = NullableAggregateFunctionState<NestedState>;
-    return std::make_shared<NullableAggregateFunctionUnary<AggregateDataType>>(nested_function);
+    return std::make_shared<NullableAggregateFunctionUnary<AggregateDataType, IgnoreNull>>(nested_function);
 }
 
 template <typename NestedState>

--- a/be/src/exprs/agg/aggregate_factory.h
+++ b/be/src/exprs/agg/aggregate_factory.h
@@ -47,7 +47,7 @@ public:
     template <PrimitiveType PT>
     static AggregateFunctionPtr MakeAnyValueAggregateFunction();
 
-    template <typename NestedState>
+    template <typename NestedState, bool IgnoreNull = true>
     static AggregateFunctionPtr MakeNullableAggregateFunctionUnary(AggregateFunctionPtr nested_function);
 
     template <typename NestedState>

--- a/be/src/exprs/agg/nullable_aggregate.h
+++ b/be/src/exprs/agg/nullable_aggregate.h
@@ -487,8 +487,8 @@ public:
                                                                      i + 1);
                 } else if constexpr (!IgnoreNull) {
                     this->data(state).is_null = false;
-                    this->nested_function->update_batch_single_state_null(ctx, this->data(state).mutable_nest_state(),
-                                                                          peer_group_start, peer_group_end);
+                    this->nested_function->update_single_state_null(ctx, this->data(state).mutable_nest_state(),
+                                                                    peer_group_start, peer_group_end);
                 }
             }
         } else {

--- a/be/src/exprs/agg/nullable_aggregate.h
+++ b/be/src/exprs/agg/nullable_aggregate.h
@@ -66,7 +66,7 @@ public:
                 nested_function->merge(ctx, data_column, this->data(state).mutable_nest_state(), row_num);
             } else if constexpr (!IgnoreNull) {
                 this->data(state).is_null = false;
-                nested_function->merge_null(ctx, this->data(state).mutable_nest_state());
+                nested_function->process_null(ctx, this->data(state).mutable_nest_state());
             }
         } else {
             this->data(state).is_null = false;
@@ -247,7 +247,7 @@ public:
                     if constexpr (!IgnoreNull) {
                         for (size_t i = offset; i < offset + batch_nums; i++) {
                             this->data(states[i] + state_offset).is_null = false;
-                            this->nested_function->update_null(
+                            this->nested_function->process_null(
                                     ctx, this->data(states[i] + state_offset).mutable_nest_state());
                         }
                     }
@@ -259,7 +259,7 @@ public:
                                                           this->data(states[i] + state_offset).mutable_nest_state(), i);
                         } else if constexpr (!IgnoreNull) {
                             this->data(states[i] + state_offset).is_null = false;
-                            this->nested_function->update_null(
+                            this->nested_function->process_null(
                                     ctx, this->data(states[i] + state_offset).mutable_nest_state());
                         }
                     }
@@ -274,7 +274,7 @@ public:
                                                   this->data(states[i] + state_offset).mutable_nest_state(), i);
                 } else if constexpr (!IgnoreNull) {
                     this->data(states[i] + state_offset).is_null = false;
-                    this->nested_function->update_null(ctx, this->data(states[i] + state_offset).mutable_nest_state());
+                    this->nested_function->process_null(ctx, this->data(states[i] + state_offset).mutable_nest_state());
                 }
             }
         } else {
@@ -319,7 +319,7 @@ public:
                     if constexpr (!IgnoreNull) {
                         for (size_t i = offset; i < offset + batch_nums; i++) {
                             this->data(states[i] + state_offset).is_null = false;
-                            this->nested_function->update_null(
+                            this->nested_function->process_null(
                                     ctx, this->data(states[i] + state_offset).mutable_nest_state());
                         }
                     }
@@ -333,7 +333,7 @@ public:
                                             ctx, &data_column,
                                             this->data(states[i] + state_offset).mutable_nest_state(), i);
                                 } else {
-                                    this->nested_function->update_null(
+                                    this->nested_function->process_null(
                                             ctx, this->data(states[i] + state_offset).mutable_nest_state());
                                 }
                             }
@@ -359,7 +359,7 @@ public:
                             this->nested_function->update(ctx, &data_column,
                                                           this->data(states[i] + state_offset).mutable_nest_state(), i);
                         } else {
-                            this->nested_function->update_null(
+                            this->nested_function->process_null(
                                     ctx, this->data(states[i] + state_offset).mutable_nest_state());
                         }
                     }
@@ -418,7 +418,7 @@ public:
                     if constexpr (!IgnoreNull) {
                         this->data(state).is_null = false;
                         for (size_t i = offset; i < offset + batch_nums; i++) {
-                            this->nested_function->update_null(ctx, this->data(state).mutable_nest_state());
+                            this->nested_function->process_null(ctx, this->data(state).mutable_nest_state());
                         }
                     }
                 } else {
@@ -429,7 +429,7 @@ public:
                         } else {
                             if constexpr (!IgnoreNull) {
                                 this->data(state).is_null = false;
-                                this->nested_function->update_null(ctx, this->data(state).mutable_nest_state());
+                                this->nested_function->process_null(ctx, this->data(state).mutable_nest_state());
                             }
                         }
                     }
@@ -444,7 +444,7 @@ public:
                     this->data(state).is_null = false;
                 } else if constexpr (!IgnoreNull) {
                     this->data(state).is_null = false;
-                    this->nested_function->update_null(ctx, this->data(state).mutable_nest_state());
+                    this->nested_function->process_null(ctx, this->data(state).mutable_nest_state());
                 }
             }
         } else {

--- a/be/src/exprs/agg/nullable_aggregate.h
+++ b/be/src/exprs/agg/nullable_aggregate.h
@@ -42,7 +42,7 @@ struct NullableAggregateFunctionState {
 // If an aggregate function has at least one nullable argument, we should use this class.
 // If all row all are NULL, we will return NULL.
 // The State must be NullableAggregateFunctionState
-template <typename State>
+template <typename State, bool IgnoreNull = true>
 class NullableAggregateFunctionBase : public AggregateFunctionStateHelper<State> {
 public:
     explicit NullableAggregateFunctionBase(AggregateFunctionPtr nested_function_)
@@ -56,15 +56,17 @@ public:
     }
 
     void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
-        const Column* data_column = nullptr;
         // Scalar function compute will return non-nullable column
         // for nullable column when the real whole chunk data all not-null.
         if (column->is_nullable()) {
             const auto* nullable_column = down_cast<const NullableColumn*>(column);
             if (!nullable_column->null_column()->get_data()[row_num]) {
                 this->data(state).is_null = false;
-                data_column = nullable_column->data_column().get();
+                const Column* data_column = nullable_column->data_column().get();
                 nested_function->merge(ctx, data_column, this->data(state).mutable_nest_state(), row_num);
+            } else if constexpr (!IgnoreNull) {
+                this->data(state).is_null = false;
+                nested_function->merge_null(ctx, this->data(state).mutable_nest_state());
             }
         } else {
             this->data(state).is_null = false;
@@ -125,10 +127,15 @@ public:
                 } else {
                     NullData& dst_null_data = dst_nullable_column->null_column_data();
                     dst_null_data = src_null_data;
-                    Columns src_data_columns(1);
-                    src_data_columns[0] = nullable_column->data_column();
-                    nested_function->convert_to_serialize_format(src_data_columns, chunk_size,
-                                                                 &dst_nullable_column->data_column());
+                    if constexpr (IgnoreNull) {
+                        Columns src_data_columns(1);
+                        src_data_columns[0] = nullable_column->data_column();
+                        nested_function->convert_to_serialize_format(src_data_columns, chunk_size,
+                                                                     &dst_nullable_column->data_column());
+                    } else {
+                        nested_function->convert_to_serialize_format(src, chunk_size,
+                                                                     &dst_nullable_column->data_column());
+                    }
                 }
             } else {
                 dst_nullable_column->null_column_data().resize(chunk_size);
@@ -201,11 +208,11 @@ protected:
     AggregateFunctionPtr nested_function;
 };
 
-template <typename State>
-class NullableAggregateFunctionUnary final : public NullableAggregateFunctionBase<State> {
+template <typename State, bool IgnoreNull = true>
+class NullableAggregateFunctionUnary final : public NullableAggregateFunctionBase<State, IgnoreNull> {
 public:
     explicit NullableAggregateFunctionUnary(const AggregateFunctionPtr& nested_function)
-            : NullableAggregateFunctionBase<State>(nested_function) {}
+            : NullableAggregateFunctionBase<State, IgnoreNull>(nested_function) {}
 
     void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
                 size_t row_num) const override {}
@@ -228,21 +235,32 @@ public:
                 // TODO(kks): when our memory allocate could align 32-byte, we could use _mm256_load_si256
                 __m256i f = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(f_data + offset));
                 int mask = _mm256_movemask_epi8(_mm256_cmpgt_epi8(f, all0));
-                // all not null
                 if (mask == 0) {
+                    // all not null
                     for (size_t i = offset; i < offset + batch_nums; i++) {
                         this->data(states[i] + state_offset).is_null = false;
                         this->nested_function->update(ctx, &data_column,
                                                       this->data(states[i] + state_offset).mutable_nest_state(), i);
                     }
-                    // all null
                 } else if (mask == 0xffffffff) {
+                    // all null
+                    if constexpr (!IgnoreNull) {
+                        for (size_t i = offset; i < offset + batch_nums; i++) {
+                            this->data(states[i] + state_offset).is_null = false;
+                            this->nested_function->update_null(
+                                    ctx, this->data(states[i] + state_offset).mutable_nest_state());
+                        }
+                    }
                 } else {
                     for (size_t i = offset; i < offset + batch_nums; i++) {
                         if (f_data[i] == 0) {
                             this->data(states[i] + state_offset).is_null = false;
                             this->nested_function->update(ctx, &data_column,
                                                           this->data(states[i] + state_offset).mutable_nest_state(), i);
+                        } else if constexpr (!IgnoreNull) {
+                            this->data(states[i] + state_offset).is_null = false;
+                            this->nested_function->update_null(
+                                    ctx, this->data(states[i] + state_offset).mutable_nest_state());
                         }
                     }
                 }
@@ -254,6 +272,9 @@ public:
                     this->data(states[i] + state_offset).is_null = false;
                     this->nested_function->update(ctx, &data_column,
                                                   this->data(states[i] + state_offset).mutable_nest_state(), i);
+                } else if constexpr (!IgnoreNull) {
+                    this->data(states[i] + state_offset).is_null = false;
+                    this->nested_function->update_null(ctx, this->data(states[i] + state_offset).mutable_nest_state());
                 }
             }
         } else {
@@ -283,8 +304,8 @@ public:
                 // TODO(kks): when our memory allocate could align 32-byte, we could use _mm256_load_si256
                 __m256i f = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(f_data + offset));
                 int mask = _mm256_movemask_epi8(_mm256_cmpgt_epi8(f, all0));
-                // all not null
                 if (mask == 0) {
+                    // all not null
                     for (size_t i = offset; i < offset + batch_nums; i++) {
                         // TODO: optimize with simd
                         if (!selection[i]) {
@@ -293,14 +314,36 @@ public:
                                                           this->data(states[i] + state_offset).mutable_nest_state(), i);
                         }
                     }
-                    // all null
                 } else if (mask == 0xffffffff) {
+                    // all null
+                    if constexpr (!IgnoreNull) {
+                        for (size_t i = offset; i < offset + batch_nums; i++) {
+                            this->data(states[i] + state_offset).is_null = false;
+                            this->nested_function->update_null(
+                                    ctx, this->data(states[i] + state_offset).mutable_nest_state());
+                        }
+                    }
                 } else {
                     for (size_t i = offset; i < offset + batch_nums; i++) {
-                        if (!f_data[i] & !selection[i]) {
-                            this->data(states[i] + state_offset).is_null = false;
-                            this->nested_function->update(ctx, &data_column,
-                                                          this->data(states[i] + state_offset).mutable_nest_state(), i);
+                        if constexpr (!IgnoreNull) {
+                            if (!selection[i]) {
+                                this->data(states[i] + state_offset).is_null = false;
+                                if (!f_data[i]) {
+                                    this->nested_function->update(
+                                            ctx, &data_column,
+                                            this->data(states[i] + state_offset).mutable_nest_state(), i);
+                                } else {
+                                    this->nested_function->update_null(
+                                            ctx, this->data(states[i] + state_offset).mutable_nest_state());
+                                }
+                            }
+                        } else {
+                            if (!f_data[i] & !selection[i]) {
+                                this->data(states[i] + state_offset).is_null = false;
+                                this->nested_function->update(ctx, &data_column,
+                                                              this->data(states[i] + state_offset).mutable_nest_state(),
+                                                              i);
+                            }
                         }
                     }
                 }
@@ -309,10 +352,23 @@ public:
 #endif
 
             for (size_t i = offset; i < chunk_size; ++i) {
-                if (!f_data[i] & !selection[i]) {
-                    this->data(states[i] + state_offset).is_null = false;
-                    this->nested_function->update(ctx, &data_column,
-                                                  this->data(states[i] + state_offset).mutable_nest_state(), i);
+                if constexpr (!IgnoreNull) {
+                    if (!selection[i]) {
+                        this->data(states[i] + state_offset).is_null = false;
+                        if (!f_data[i]) {
+                            this->nested_function->update(ctx, &data_column,
+                                                          this->data(states[i] + state_offset).mutable_nest_state(), i);
+                        } else {
+                            this->nested_function->update_null(
+                                    ctx, this->data(states[i] + state_offset).mutable_nest_state());
+                        }
+                    }
+                } else {
+                    if (!f_data[i] & !selection[i]) {
+                        this->data(states[i] + state_offset).is_null = false;
+                        this->nested_function->update(ctx, &data_column,
+                                                      this->data(states[i] + state_offset).mutable_nest_state(), i);
+                    }
                 }
             }
         } else {
@@ -351,19 +407,30 @@ public:
             while (offset + batch_nums < chunk_size) {
                 __m256i f = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(f_data + offset));
                 int mask = _mm256_movemask_epi8(_mm256_cmpgt_epi8(f, all0));
-                // all not null
                 if (mask == 0) {
+                    // all not null
                     this->data(state).is_null = false;
                     for (size_t i = offset; i < offset + batch_nums; i++) {
                         this->nested_function->update(ctx, &data_column, this->data(state).mutable_nest_state(), i);
                     }
-                    // all null
                 } else if (mask == 0xffffffff) {
+                    // all null
+                    if constexpr (!IgnoreNull) {
+                        this->data(state).is_null = false;
+                        for (size_t i = offset; i < offset + batch_nums; i++) {
+                            this->nested_function->update_null(ctx, this->data(state).mutable_nest_state());
+                        }
+                    }
                 } else {
                     for (size_t i = offset; i < offset + batch_nums; i++) {
                         if (f_data[i] == 0) {
                             this->nested_function->update(ctx, &data_column, this->data(state).mutable_nest_state(), i);
                             this->data(state).is_null = false;
+                        } else {
+                            if constexpr (!IgnoreNull) {
+                                this->data(state).is_null = false;
+                                this->nested_function->update_null(ctx, this->data(state).mutable_nest_state());
+                            }
                         }
                     }
                 }
@@ -375,6 +442,9 @@ public:
                 if (f_data[i] == 0) {
                     this->nested_function->update(ctx, &data_column, this->data(state).mutable_nest_state(), i);
                     this->data(state).is_null = false;
+                } else if constexpr (!IgnoreNull) {
+                    this->data(state).is_null = false;
+                    this->nested_function->update_null(ctx, this->data(state).mutable_nest_state());
                 }
             }
         } else {
@@ -415,6 +485,10 @@ public:
                     this->nested_function->update_batch_single_state(ctx, this->data(state).mutable_nest_state(),
                                                                      &data_column, peer_group_start, peer_group_end, i,
                                                                      i + 1);
+                } else if constexpr (!IgnoreNull) {
+                    this->data(state).is_null = false;
+                    this->nested_function->update_batch_single_state_null(ctx, this->data(state).mutable_nest_state(),
+                                                                          peer_group_start, peer_group_end);
                 }
             }
         } else {
@@ -426,7 +500,7 @@ public:
 };
 
 template <typename State>
-class NullableAggregateFunctionVariadic final : public NullableAggregateFunctionBase<State> {
+class NullableAggregateFunctionVariadic final : public NullableAggregateFunctionBase<State, true> {
 public:
     NullableAggregateFunctionVariadic(const AggregateFunctionPtr& nested_function)
             : NullableAggregateFunctionBase<State>(nested_function) {}


### PR DESCRIPTION
for #648 

The execution framework of the current aggregation function will directly discard Null and not participate in the calculation. However, some aggregation functions, such as array_agg, will not discard null, and it is necessary to add support for this aggregation function.

e.g. 
```
mysql> select * from m1;
+------+------+
| a    | b    |
+------+------+
|    1 |    1 |
|    1 |    2 |
|    3 | NULL |
|    2 |    1 |
|    2 | NULL |
+------+------+
5 rows in set (0.01 sec)

mysql> select array_agg(b) from m1;
+-------------------+
| array_agg(`b`)    |
+-------------------+
| [1,1,2,null,null] |
+-------------------+
1 row in set (0.02 sec)
```