### PR TITLE
Reduce threads competition on method has_output_for_pipeline

### DIFF
--- a/be/src/exec/exchange_node.cpp
+++ b/be/src/exec/exchange_node.cpp
@@ -71,7 +71,7 @@ Status ExchangeNode::prepare(RuntimeState* state) {
     _stream_recvr = state->exec_env()->stream_mgr()->create_recvr(
             state, _input_row_desc, state->fragment_instance_id(), _id, _num_senders,
             config::exchg_node_buffer_size_bytes, _runtime_profile, _is_merging, _sub_plan_query_statistics_recvr,
-            false, false);
+            false, -1, false);
     if (_is_merging) {
         RETURN_IF_ERROR(_sort_exec_exprs.prepare(state, _row_descriptor, _row_descriptor));
     }

--- a/be/src/exec/exchange_node.cpp
+++ b/be/src/exec/exchange_node.cpp
@@ -71,7 +71,7 @@ Status ExchangeNode::prepare(RuntimeState* state) {
     _stream_recvr = state->exec_env()->stream_mgr()->create_recvr(
             state, _input_row_desc, state->fragment_instance_id(), _id, _num_senders,
             config::exchg_node_buffer_size_bytes, _runtime_profile, _is_merging, _sub_plan_query_statistics_recvr,
-            false, -1, false);
+            false, DataStreamRecvr::INVALID_DOP_FOR_NON_PIPELINE_LEVEL_SHUFFLE, false);
     if (_is_merging) {
         RETURN_IF_ERROR(_sort_exec_exprs.prepare(state, _row_descriptor, _row_descriptor));
     }

--- a/be/src/exec/pipeline/exchange/exchange_merge_sort_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_merge_sort_source_operator.cpp
@@ -15,7 +15,7 @@ Status ExchangeMergeSortSourceOperator::prepare(RuntimeState* state) {
     SourceOperator::prepare(state);
     _stream_recvr = state->exec_env()->stream_mgr()->create_recvr(
             state, _row_desc, state->fragment_instance_id(), _plan_node_id, _num_sender,
-            config::exchg_node_buffer_size_bytes, _runtime_profile, true, nullptr, true, true);
+            config::exchg_node_buffer_size_bytes, _runtime_profile, true, nullptr, true, -1, true);
     _stream_recvr->create_merger_for_pipeline(state, _sort_exec_exprs, &_is_asc_order, &_nulls_first);
     return Status::OK();
 }

--- a/be/src/exec/pipeline/exchange/exchange_merge_sort_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_merge_sort_source_operator.cpp
@@ -15,7 +15,9 @@ Status ExchangeMergeSortSourceOperator::prepare(RuntimeState* state) {
     SourceOperator::prepare(state);
     _stream_recvr = state->exec_env()->stream_mgr()->create_recvr(
             state, _row_desc, state->fragment_instance_id(), _plan_node_id, _num_sender,
-            config::exchg_node_buffer_size_bytes, _runtime_profile, true, nullptr, true, -1, true);
+            config::exchg_node_buffer_size_bytes, _runtime_profile, true, nullptr, true,
+            // ExchangeMergeSort will never perform pipeline level shuffle
+            DataStreamRecvr::INVALID_DOP_FOR_NON_PIPELINE_LEVEL_SHUFFLE, true);
     _stream_recvr->create_merger_for_pipeline(state, _sort_exec_exprs, &_is_asc_order, &_nulls_first);
     return Status::OK();
 }

--- a/be/src/exec/pipeline/exchange/exchange_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_source_operator.cpp
@@ -44,7 +44,7 @@ std::shared_ptr<DataStreamRecvr> ExchangeSourceOperatorFactory::create_stream_re
     }
     _stream_recvr = state->exec_env()->stream_mgr()->create_recvr(
             state, _row_desc, state->fragment_instance_id(), _plan_node_id, _num_sender,
-            config::exchg_node_buffer_size_bytes, profile, false, nullptr, true, false);
+            config::exchg_node_buffer_size_bytes, profile, false, nullptr, true, _degree_of_parallelism, false);
     return _stream_recvr;
 }
 

--- a/be/src/runtime/data_stream_mgr.cpp
+++ b/be/src/runtime/data_stream_mgr.cpp
@@ -56,14 +56,15 @@ std::shared_ptr<DataStreamRecvr> DataStreamMgr::create_recvr(
         RuntimeState* state, const RowDescriptor& row_desc, const TUniqueId& fragment_instance_id,
         PlanNodeId dest_node_id, int num_senders, int buffer_size, const std::shared_ptr<RuntimeProfile>& profile,
         bool is_merging, std::shared_ptr<QueryStatisticsRecvr> sub_plan_query_statistics_recvr, bool is_pipeline,
-        bool keep_order) {
+        int32_t degree_of_parallelism, bool keep_order) {
     DCHECK(profile != nullptr);
     VLOG_FILE << "creating receiver for fragment=" << fragment_instance_id << ", node=" << dest_node_id;
     PassThroughChunkBuffer* pass_through_chunk_buffer = get_pass_through_chunk_buffer(state->query_id());
     DCHECK(pass_through_chunk_buffer != nullptr);
-    std::shared_ptr<DataStreamRecvr> recvr(new DataStreamRecvr(
-            this, state, row_desc, fragment_instance_id, dest_node_id, num_senders, is_merging, buffer_size, profile,
-            std::move(sub_plan_query_statistics_recvr), is_pipeline, keep_order, pass_through_chunk_buffer));
+    std::shared_ptr<DataStreamRecvr> recvr(
+            new DataStreamRecvr(this, state, row_desc, fragment_instance_id, dest_node_id, num_senders, is_merging,
+                                buffer_size, profile, std::move(sub_plan_query_statistics_recvr), is_pipeline,
+                                degree_of_parallelism, keep_order, pass_through_chunk_buffer));
     uint32_t hash_value = get_hash_value(fragment_instance_id, dest_node_id);
     std::lock_guard<std::mutex> l(_lock);
     _fragment_stream_set.emplace(fragment_instance_id, dest_node_id);

--- a/be/src/runtime/data_stream_mgr.h
+++ b/be/src/runtime/data_stream_mgr.h
@@ -81,7 +81,7 @@ public:
                                                   int num_senders, int buffer_size,
                                                   const std::shared_ptr<RuntimeProfile>& profile, bool is_merging,
                                                   std::shared_ptr<QueryStatisticsRecvr> sub_plan_query_statistics_recvr,
-                                                  bool is_pipeline, bool keep_order);
+                                                  bool is_pipeline, int32_t degree_of_parallelism, bool keep_order);
 
     Status transmit_data(const PTransmitDataParams* request, ::google::protobuf::Closure** done);
 

--- a/be/src/runtime/data_stream_recvr.cc
+++ b/be/src/runtime/data_stream_recvr.cc
@@ -872,7 +872,8 @@ DataStreamRecvr::DataStreamRecvr(DataStreamMgr* stream_mgr, RuntimeState* runtim
     _sender_queues.reserve(num_queues);
     int num_sender_per_queue = is_merging ? 1 : num_senders;
     for (int i = 0; i < num_queues; ++i) {
-        SenderQueue* queue = _sender_queue_pool.add(new SenderQueue(this, num_sender_per_queue, degree_of_parallelism));
+        SenderQueue* queue =
+                _sender_queue_pool.add(new SenderQueue(this, num_sender_per_queue, _degree_of_parallelism));
         _sender_queues.push_back(queue);
     }
 

--- a/be/src/runtime/data_stream_recvr.cc
+++ b/be/src/runtime/data_stream_recvr.cc
@@ -116,8 +116,7 @@ public:
 private:
     struct ChunkItem {
         int64_t chunk_bytes = 0;
-        // -1 means disable pipeline level shuffle
-        // >=0 means enable pipeline level shuffle
+        // Invalid if SenderQueue::_is_pipeline_level_shuffle is false
         int32_t driver_sequence = -1;
         ChunkUniquePtr chunk_ptr;
         // When the memory of the ChunkQueue exceeds the limit,
@@ -180,7 +179,7 @@ void DataStreamRecvr::SenderQueue::short_circuit_for_pipeline(const int32_t driv
 
     auto iter = _chunk_queue.begin();
     while (iter != _chunk_queue.end()) {
-        if (iter->driver_sequence == driver_sequence) {
+        if (_is_pipeline_level_shuffle && iter->driver_sequence == driver_sequence) {
             if (iter->closure != nullptr) {
                 iter->closure->Run();
             }
@@ -196,11 +195,15 @@ bool DataStreamRecvr::SenderQueue::has_output_for_pipeline(const int32_t driver_
     // This method may be invoked by PipelineDriverPoller and GlobalDriverDispatcher simultaneously
     // when some of the driver_sequences has no chunks to get but the others do, then GlobalDriverDispatcher
     // may be starved because PipelineDriverPoller will call this method repeatedly with almost no interval
+    // Both false positives and false negatives are allowed here
     {
         if (_is_cancelled) {
             return false;
         }
         if (_is_pipeline_level_shuffle && !_has_chunks_per_driver_sequence[driver_sequence]) {
+            return false;
+        }
+        if (_chunk_queue.empty()) {
             return false;
         }
     }
@@ -220,12 +223,10 @@ bool DataStreamRecvr::SenderQueue::has_output_for_pipeline(const int32_t driver_
             return false;
         }
 
-        auto iter = _chunk_queue.begin();
-        while (iter != _chunk_queue.end()) {
-            if (iter->driver_sequence == -1 || iter->driver_sequence == driver_sequence) {
+        for (auto& item : _chunk_queue) {
+            if (!_is_pipeline_level_shuffle || item.driver_sequence == driver_sequence) {
                 return true;
             }
-            ++iter;
         }
 
         if (_is_pipeline_level_shuffle) {
@@ -329,7 +330,7 @@ Status DataStreamRecvr::SenderQueue::get_chunk_for_pipeline(vectorized::Chunk** 
 
     auto iter = _chunk_queue.begin();
     while (iter != _chunk_queue.end()) {
-        if (iter->driver_sequence == -1 || iter->driver_sequence == driver_sequence) {
+        if (!_is_pipeline_level_shuffle || iter->driver_sequence == driver_sequence) {
             *chunk = iter->chunk_ptr.release();
             auto* closure = iter->closure;
             _recvr->_num_buffered_bytes -= iter->chunk_bytes;
@@ -511,11 +512,12 @@ Status DataStreamRecvr::SenderQueue::add_chunks(const PTransmitChunkParams& requ
         const auto original_size = _chunk_queue.size();
         for (auto& item : chunks) {
             // This chunks may contains different driver_sequence
-            if (item.driver_sequence >= 0 &&
-                _short_circuit_driver_sequences.find(item.driver_sequence) != _short_circuit_driver_sequences.end()) {
-                continue;
-            }
             if (_is_pipeline_level_shuffle) {
+                // Some pipelines may be short-circuit, so we just drop the chunk we received
+                if (_short_circuit_driver_sequences.find(item.driver_sequence) !=
+                    _short_circuit_driver_sequences.end()) {
+                    continue;
+                }
                 _has_chunks_per_driver_sequence[item.driver_sequence] = true;
             }
             _chunk_queue.emplace_back(std::move(item));
@@ -659,17 +661,19 @@ Status DataStreamRecvr::SenderQueue::add_chunks_and_keep_order(const PTransmitCh
             // Now, all the packets with sequance <= unprocessed_sequence have been received
             // so chunks of unprocessed_sequence can be flushed to ready queue
             for (auto& item : unprocessed_chunk_queue) {
-                // This chunks may contains different driver_sequence
-                if (item.driver_sequence >= 0 && _short_circuit_driver_sequences.find(item.driver_sequence) !=
-                                                         _short_circuit_driver_sequences.end()) {
-                    // We may buffered closure in last reception, but the branch of the driver_sequence may
-                    // become short-circuit now, so we make sure to invoke the closure
-                    if (item.closure != nullptr) {
-                        item.closure->Run();
-                    }
-                    continue;
-                }
+                // This chunks may contains different driver_sequence when enable local pass through
+                // So we use driver_sequence of each chunk instead of request's driver_sequence
                 if (_is_pipeline_level_shuffle) {
+                    // Some pipelines may be short-circuit, so we just drop the chunk we received
+                    if (_short_circuit_driver_sequences.find(item.driver_sequence) !=
+                        _short_circuit_driver_sequences.end()) {
+                        // We may buffered closure in last reception, but the branch of the driver_sequence may
+                        // become short-circuit now, so we make sure to invoke the closure
+                        if (item.closure != nullptr) {
+                            item.closure->Run();
+                        }
+                        continue;
+                    }
                     _has_chunks_per_driver_sequence[item.driver_sequence] = true;
                 }
                 _chunk_queue.emplace_back(std::move(item));

--- a/be/src/runtime/data_stream_recvr.cc
+++ b/be/src/runtime/data_stream_recvr.cc
@@ -60,7 +60,7 @@ using vectorized::ChunkUniquePtr;
 // rows from all senders are placed in the same queue.
 class DataStreamRecvr::SenderQueue {
 public:
-    SenderQueue(DataStreamRecvr* parent_recvr, int num_senders);
+    SenderQueue(DataStreamRecvr* parent_recvr, int32_t num_senders, int32_t degree_of_parallelism);
 
     ~SenderQueue() = default;
 
@@ -109,7 +109,7 @@ public:
 
     void short_circuit_for_pipeline(const int32_t driver_sequence);
 
-    bool has_output_for_pipeline(const int32_t driver_sequence) const;
+    bool has_output_for_pipeline(const int32_t driver_sequence);
 
     bool is_finished() const;
 
@@ -148,6 +148,8 @@ private:
 
     typedef std::list<ChunkItem> ChunkQueue;
     ChunkQueue _chunk_queue;
+    bool _is_pipeline_level_shuffle = false;
+    std::vector<bool> _has_chunks_per_driver_sequence;
     serde::ProtobufChunkMeta _chunk_meta;
 
     std::unordered_set<int> _sender_eos_set;          // sender_id
@@ -165,8 +167,12 @@ private:
     std::unordered_set<int32_t> _short_circuit_driver_sequences;
 };
 
-DataStreamRecvr::SenderQueue::SenderQueue(DataStreamRecvr* parent_recvr, int num_senders)
-        : _recvr(parent_recvr), _is_cancelled(false), _num_remaining_senders(num_senders) {}
+DataStreamRecvr::SenderQueue::SenderQueue(DataStreamRecvr* parent_recvr, int32_t num_senders,
+                                          int32_t degree_of_parallelism)
+        : _recvr(parent_recvr),
+          _is_cancelled(false),
+          _num_remaining_senders(num_senders),
+          _has_chunks_per_driver_sequence(degree_of_parallelism, false) {}
 
 void DataStreamRecvr::SenderQueue::short_circuit_for_pipeline(const int32_t driver_sequence) {
     std::lock_guard<std::mutex> l(_lock);
@@ -185,25 +191,48 @@ void DataStreamRecvr::SenderQueue::short_circuit_for_pipeline(const int32_t driv
     }
 }
 
-bool DataStreamRecvr::SenderQueue::has_output_for_pipeline(const int32_t driver_sequence) const {
-    std::lock_guard<std::mutex> l(_lock);
-    if (_is_cancelled) {
-        return false;
-    }
-
-    if (_chunk_queue.empty()) {
-        return false;
-    }
-
-    auto iter = _chunk_queue.begin();
-    while (iter != _chunk_queue.end()) {
-        if (iter->driver_sequence == -1 || iter->driver_sequence == driver_sequence) {
-            return true;
+bool DataStreamRecvr::SenderQueue::has_output_for_pipeline(const int32_t driver_sequence) {
+    // First check without lock to avoid competition
+    // This method may be invoked by PipelineDriverPoller and GlobalDriverDispatcher simultaneously
+    // when some of the driver_sequences has no chunks to get but the others do, then GlobalDriverDispatcher
+    // may be starved because PipelineDriverPoller will call this method repeatedly with almost no interval
+    {
+        if (_is_cancelled) {
+            return false;
         }
-        ++iter;
+        if (_is_pipeline_level_shuffle && !_has_chunks_per_driver_sequence[driver_sequence]) {
+            return false;
+        }
     }
 
-    return false;
+    // Second check under lock
+    {
+        std::lock_guard<std::mutex> l(_lock);
+
+        if (_is_cancelled) {
+            return false;
+        }
+        if (_is_pipeline_level_shuffle && !_has_chunks_per_driver_sequence[driver_sequence]) {
+            return false;
+        }
+
+        if (_chunk_queue.empty()) {
+            return false;
+        }
+
+        auto iter = _chunk_queue.begin();
+        while (iter != _chunk_queue.end()) {
+            if (iter->driver_sequence == -1 || iter->driver_sequence == driver_sequence) {
+                return true;
+            }
+            ++iter;
+        }
+
+        if (_is_pipeline_level_shuffle) {
+            _has_chunks_per_driver_sequence[driver_sequence] = false;
+        }
+        return false;
+    }
 }
 
 bool DataStreamRecvr::SenderQueue::is_finished() const {
@@ -430,6 +459,7 @@ Status DataStreamRecvr::SenderQueue::add_chunks(const PTransmitChunkParams& requ
     ChunkQueue chunks;
     size_t total_chunk_bytes = 0;
     faststring uncompressed_buffer;
+    _is_pipeline_level_shuffle = request.has_driver_sequence();
     int32_t driver_sequence = request.has_driver_sequence() ? request.driver_sequence() : -1;
 
     if (use_pass_through) {
@@ -484,6 +514,9 @@ Status DataStreamRecvr::SenderQueue::add_chunks(const PTransmitChunkParams& requ
             if (item.driver_sequence >= 0 &&
                 _short_circuit_driver_sequences.find(item.driver_sequence) != _short_circuit_driver_sequences.end()) {
                 continue;
+            }
+            if (_is_pipeline_level_shuffle) {
+                _has_chunks_per_driver_sequence[item.driver_sequence] = true;
             }
             _chunk_queue.emplace_back(std::move(item));
         }
@@ -551,6 +584,7 @@ Status DataStreamRecvr::SenderQueue::add_chunks_and_keep_order(const PTransmitCh
     size_t total_chunk_bytes = 0;
     faststring uncompressed_buffer;
     ChunkQueue local_chunk_queue;
+    _is_pipeline_level_shuffle = request.has_driver_sequence();
     int32_t driver_sequence = request.has_driver_sequence() ? request.driver_sequence() : -1;
 
     if (use_pass_through) {
@@ -634,6 +668,9 @@ Status DataStreamRecvr::SenderQueue::add_chunks_and_keep_order(const PTransmitCh
                         item.closure->Run();
                     }
                     continue;
+                }
+                if (_is_pipeline_level_shuffle) {
+                    _has_chunks_per_driver_sequence[item.driver_sequence] = true;
                 }
                 _chunk_queue.emplace_back(std::move(item));
             }
@@ -812,7 +849,8 @@ DataStreamRecvr::DataStreamRecvr(DataStreamMgr* stream_mgr, RuntimeState* runtim
                                  const TUniqueId& fragment_instance_id, PlanNodeId dest_node_id, int num_senders,
                                  bool is_merging, int total_buffer_limit, std::shared_ptr<RuntimeProfile> profile,
                                  std::shared_ptr<QueryStatisticsRecvr> sub_plan_query_statistics_recvr,
-                                 bool is_pipeline, bool keep_order, PassThroughChunkBuffer* pass_through_chunk_buffer)
+                                 bool is_pipeline, int32_t degree_of_parallelism, bool keep_order,
+                                 PassThroughChunkBuffer* pass_through_chunk_buffer)
         : _mgr(stream_mgr),
           _fragment_instance_id(fragment_instance_id),
           _dest_node_id(dest_node_id),
@@ -826,6 +864,7 @@ DataStreamRecvr::DataStreamRecvr(DataStreamMgr* stream_mgr, RuntimeState* runtim
           _instance_mem_tracker(runtime_state->instance_mem_tracker_ptr()),
           _sub_plan_query_statistics_recvr(std::move(sub_plan_query_statistics_recvr)),
           _is_pipeline(is_pipeline),
+          _degree_of_parallelism(degree_of_parallelism),
           _keep_order(keep_order),
           _pass_through_context(pass_through_chunk_buffer, fragment_instance_id, dest_node_id) {
     // Create one queue per sender if is_merging is true.
@@ -833,7 +872,7 @@ DataStreamRecvr::DataStreamRecvr(DataStreamMgr* stream_mgr, RuntimeState* runtim
     _sender_queues.reserve(num_queues);
     int num_sender_per_queue = is_merging ? 1 : num_senders;
     for (int i = 0; i < num_queues; ++i) {
-        SenderQueue* queue = _sender_queue_pool.add(new SenderQueue(this, num_sender_per_queue));
+        SenderQueue* queue = _sender_queue_pool.add(new SenderQueue(this, num_sender_per_queue, degree_of_parallelism));
         _sender_queues.push_back(queue);
     }
 

--- a/be/src/runtime/data_stream_recvr.h
+++ b/be/src/runtime/data_stream_recvr.h
@@ -72,6 +72,9 @@ class SortExecExprs;
 // recvr instance from the tracking structure of its DataStreamMgr in all cases.
 class DataStreamRecvr {
 public:
+    const static int32_t INVALID_DOP_FOR_NON_PIPELINE_LEVEL_SHUFFLE = 0;
+
+public:
     ~DataStreamRecvr();
 
     Status get_chunk(std::unique_ptr<vectorized::Chunk>* chunk);
@@ -192,6 +195,7 @@ private:
     // Sub plan query statistics receiver.
     std::shared_ptr<QueryStatisticsRecvr> _sub_plan_query_statistics_recvr;
     bool _is_pipeline;
+    // Invalid if _is_pipeline is false
     int32_t _degree_of_parallelism;
 
     // Invalid if _is_pipeline is false

--- a/be/src/runtime/data_stream_recvr.h
+++ b/be/src/runtime/data_stream_recvr.h
@@ -117,7 +117,7 @@ private:
                     const TUniqueId& fragment_instance_id, PlanNodeId dest_node_id, int num_senders, bool is_merging,
                     int total_buffer_limit, std::shared_ptr<RuntimeProfile> profile,
                     std::shared_ptr<QueryStatisticsRecvr> sub_plan_query_statistics_recvr, bool is_pipeline,
-                    bool keep_order, PassThroughChunkBuffer* pass_through_chunk_buffer);
+                    int32_t degree_of_parallelism, bool keep_order, PassThroughChunkBuffer* pass_through_chunk_buffer);
 
     // If receive queue is full, done is enqueue pending, and return with *done is nullptr
     Status add_chunks(const PTransmitChunkParams& request, ::google::protobuf::Closure** done);
@@ -192,6 +192,7 @@ private:
     // Sub plan query statistics receiver.
     std::shared_ptr<QueryStatisticsRecvr> _sub_plan_query_statistics_recvr;
     bool _is_pipeline;
+    int32_t _degree_of_parallelism;
 
     // Invalid if _is_pipeline is false
     // Pipeline will send packets out-of-order


### PR DESCRIPTION
# Enhancement

for [issue-2987](https://github.com/StarRocks/starrocks/issues/2987)

The method `DataStreamRecvr::SenderQueue::has_output_for_pipeline` may be invoked by `PipelineDriverPoller` and `GlobalDriverDispatcher` simultaneously when some of the driver_sequences has no chunks to get but the others do, then `GlobalDriverDispatcher` may be starved because `PipelineDriverPoller` will call this method repeatedly with almost no interval.

So we add an auxiliary data structure `_has_chunks_per_driver_sequence` to help first check without lock.

# Test

For query TPC-DS Q39

* before: query time not stable, range from 0.6s to 2s
* after: query time is stable, 0.6s