### PR TITLE
optimizate time function convert_tz

### DIFF
--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -48,6 +48,7 @@
 #include "util/thread.h"
 #include "util/thrift_util.h"
 #include "util/time.h"
+#include "util/timezone_utils.h"
 
 namespace starrocks {
 
@@ -263,6 +264,8 @@ void Daemon::init(int argc, char** argv, const std::vector<StorePath>& paths) {
     UserFunctionCache::instance()->init(config::user_function_dir);
 
     vectorized::date::init_date_cache();
+
+    TimezoneUtils::init_time_zones();
 
     std::thread tcmalloc_gc_thread(gc_tcmalloc_memory, this);
     Thread::set_thread_name(tcmalloc_gc_thread, "tcmalloc_daemon");

--- a/be/src/runtime/datetime_value.cpp
+++ b/be/src/runtime/datetime_value.cpp
@@ -26,6 +26,7 @@
 #include <ctime>
 #include <limits>
 #include <sstream>
+#include <string_view>
 
 #include "common/logging.h"
 #include "util/timezone_utils.h"
@@ -1538,7 +1539,7 @@ bool DateTimeValue::date_add_interval(const TimeInterval& interval, TimeUnit uni
     return true;
 }
 
-bool DateTimeValue::unix_timestamp(int64_t* timestamp, const std::string& timezone) const {
+bool DateTimeValue::unix_timestamp(int64_t* timestamp, const std::string_view& timezone) const {
     cctz::time_zone ctz;
     if (!TimezoneUtils::find_cctz_time_zone(timezone, ctz)) {
         return false;
@@ -1552,7 +1553,7 @@ bool DateTimeValue::unix_timestamp(int64_t* timestamp, const cctz::time_zone& ct
     return true;
 }
 
-bool DateTimeValue::from_cctz_timezone(const TimezoneHsScan& timezone_hsscan, const std::string& timezone,
+bool DateTimeValue::from_cctz_timezone(const TimezoneHsScan& timezone_hsscan, const std::string_view& timezone,
                                        cctz::time_zone& ctz) {
     return TimezoneUtils::find_cctz_time_zone(timezone_hsscan, timezone, ctz);
 }

--- a/be/src/runtime/datetime_value.h
+++ b/be/src/runtime/datetime_value.h
@@ -27,6 +27,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <iostream>
+#include <string_view>
 
 #include "cctz/civil_time.h"
 #include "cctz/time_zone.h"
@@ -315,12 +316,13 @@ public:
 
     //unix_timestamp is called with a timezone argument,
     //it returns seconds of the value of date literal since '1970-01-01 00:00:00' UTC
-    bool unix_timestamp(int64_t* timestamp, const std::string& timezone) const;
+    bool unix_timestamp(int64_t* timestamp, const std::string_view& timezone) const;
     bool unix_timestamp(int64_t* timestamp, const cctz::time_zone& ctz) const;
 
     //construct datetime_value from timestamp and timezone
     //timestamp is an internal timestamp value representing seconds since '1970-01-01 00:00:00' UTC
-    bool from_cctz_timezone(const TimezoneHsScan& timezone_hsscan, const std::string& timezone, cctz::time_zone& ctz);
+    bool from_cctz_timezone(const TimezoneHsScan& timezone_hsscan, const std::string_view& timezone,
+                            cctz::time_zone& ctz);
     bool from_unixtime(int64_t, const std::string& timezone);
     bool from_unixtime(int64_t, const cctz::time_zone& ctz);
 

--- a/be/src/util/slice.h
+++ b/be/src/util/slice.h
@@ -28,6 +28,7 @@
 #include <iostream>
 #include <map>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "util/memcmp.h"
@@ -85,6 +86,8 @@ public:
             : // NOLINT(runtime/explicit)
               data(const_cast<char*>(s)),
               size(strlen(s)) {}
+
+    inline operator std::string_view() const { return {data, size}; }
 
     /// @return A pointer to the beginning of the referenced data.
     const char* get_data() const { return data; }

--- a/be/src/util/timezone_utils.h
+++ b/be/src/util/timezone_utils.h
@@ -24,6 +24,8 @@
 
 #include <re2/re2.h>
 
+#include <string_view>
+
 #include "cctz/time_zone.h"
 #include "util/timezone_hsscan.h"
 
@@ -31,9 +33,11 @@ namespace starrocks {
 
 class TimezoneUtils {
 public:
-    static bool find_cctz_time_zone(const std::string& timezone, cctz::time_zone& ctz);
-    static bool find_cctz_time_zone(const TimezoneHsScan& timezone_hsscan, const std::string& timezone,
+    static bool find_cctz_time_zone(const TimezoneHsScan& timezone_hsscan, const std::string_view& timezone,
                                     cctz::time_zone& ctz);
+    static void init_time_zones();
+    static bool find_cctz_time_zone(const std::string_view& timezone, cctz::time_zone& ctz);
+    static bool timezone_offsets(const std::string_view& src, const std::string_view& dst, int64_t* offset);
     static int64_t to_utc_offset(const cctz::time_zone& ctz); // timezone offset in seconds.
 
 public:

--- a/be/test/exprs/vectorized/time_functions_test.cpp
+++ b/be/test/exprs/vectorized/time_functions_test.cpp
@@ -1433,19 +1433,26 @@ TEST_F(TimeFunctionsTest, convertTzGeneralTest) {
     tc->append(TimestampValue::create(2019, 8, 1, 13, 21, 3));
     tc->append(TimestampValue::create(2019, 8, 1, 13, 21, 3));
     tc->append(TimestampValue::create(2019, 8, 1, 13, 21, 3));
+    tc->append(TimestampValue::create(2019, 8, 1, 8, 21, 3));
+    tc->append(TimestampValue::create(2019, 8, 1, 8, 21, 3));
 
     auto tc_from = BinaryColumn::create();
     tc_from->append(Slice("Asia/Shanghai"));
     tc_from->append(Slice("Asia/Urumqi"));
     tc_from->append(Slice("America/Los_Angeles"));
+    tc_from->append(Slice("Asia/Shanghai"));
+    tc_from->append(Slice("Asia/Shanghai"));
 
     auto tc_to = BinaryColumn::create();
     tc_to->append(Slice("America/Los_Angeles"));
     tc_to->append(Slice("America/Los_Angeles"));
     tc_to->append(Slice("Asia/Urumqi"));
+    tc_to->append(Slice("UTC"));
+    tc_to->append(Slice("+08:00"));
 
     TimestampValue res[] = {TimestampValue::create(2019, 7, 31, 22, 21, 3),
-                            TimestampValue::create(2019, 8, 1, 0, 21, 3), TimestampValue::create(2019, 8, 2, 2, 21, 3)};
+                            TimestampValue::create(2019, 8, 1, 0, 21, 3), TimestampValue::create(2019, 8, 2, 2, 21, 3),
+                            TimestampValue::create(2019, 8, 1, 0, 21, 3), TimestampValue::create(2019, 8, 1, 8, 21, 3)};
     Columns columns;
     columns.emplace_back(tc);
     columns.emplace_back(tc_from);

--- a/be/test/test_main.cpp
+++ b/be/test/test_main.cpp
@@ -18,6 +18,7 @@
 #include "util/disk_info.h"
 #include "util/logging.h"
 #include "util/mem_info.h"
+#include "util/timezone_utils.h"
 
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
@@ -42,6 +43,7 @@ int main(int argc, char** argv) {
     starrocks::UserFunctionCache::instance()->init(starrocks::config::user_function_dir);
 
     starrocks::vectorized::date::init_date_cache();
+    starrocks::TimezoneUtils::init_time_zones();
 
     std::vector<starrocks::StorePath> paths;
     paths.emplace_back(starrocks::config::storage_root_path);


### PR DESCRIPTION
1FE 1BE

sql:
```
select count(a) from (select CONVERT_TZ(FROM_UNIXTIME(timestamp / 1000), @@session.time_zone, COALESCE(timezone, 'Asia/Shanghai')) a from t0) t1;
```

baseline: 5.03
after: 2.32