### PR TITLE
Fix PruneHDFSScanColumnRule containColumns condition

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneHDFSScanColumnRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneHDFSScanColumnRule.java
@@ -123,7 +123,7 @@ public class PruneHDFSScanColumnRule extends TransformationRule {
 
     private boolean containsMaterializedColumn(LogicalScanOperator scanOperator, Set<ColumnRefOperator> scanColumns) {
         if (scanOperator instanceof LogicalHiveScanOperator) {
-            return scanColumns.size() == 0 && ((LogicalHiveScanOperator) scanOperator).getPartitionColumns().containsAll(
+            return scanColumns.size() != 0 && !((LogicalHiveScanOperator) scanOperator).getPartitionColumns().containsAll(
                     scanColumns.stream().map(ColumnRefOperator::getName).collect(Collectors.toList()));
         }
         return scanColumns.size() == 0;


### PR DESCRIPTION
No data returned when select count(*) from hive external table.
ref: https://github.com/StarRocks/starrocks/issues/2968