### PR TITLE
Put chunks of different driver_sequences in one request

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -1125,18 +1125,8 @@ public class Coordinator {
                 if (dopAdaptionEnabled) {
                     int degreeOfParallelism = ConnectContext.get().getSessionVariable().getDegreeOfParallelism();
                     Preconditions.checkArgument(leftMostNode instanceof ExchangeNode);
-                    // If the maximum parallel child fragment send data to the current PlanFragment via UNPARTITIONED
-                    // DataStreamSink, then fragment instance parallelization is leveraged, otherwise, pipeline parallelization
-                    // is adopted.
-                    if (maxParallelismFragmentExecParams.fragment.isPartitioned()) {
-                        // fragment instance parallelization (numInstances=N, pipelineDop=1)
-                        maxParallelism = Math.min(hostSet.size() * degreeOfParallelism, maxParallelism);
-                        fragment.setPipelineDop(1);
-                    } else {
-                        // pipeline parallelization (numInstances=|hostSet|, pipelineDop=degreeOfParallelism)
-                        maxParallelism = hostSet.size();
-                        fragment.setPipelineDop(degreeOfParallelism);
-                    }
+                    maxParallelism = hostSet.size();
+                    fragment.setPipelineDop(degreeOfParallelism);
                 }
 
                 // AddAll() soft copy()
@@ -1975,10 +1965,11 @@ public class Coordinator {
                     SessionVariable sessionVariable = ConnectContext.get().getSessionVariable();
 
                     if (isEnablePipelineEngine) {
-                        boolean isPipeline = fragment.getPlanRoot().canUsePipeLine() && fragment.getSink().canUsePipeLine();
+                        boolean isPipeline =
+                                fragment.getPlanRoot().canUsePipeLine() && fragment.getSink().canUsePipeLine();
                         params.setIs_pipeline(isPipeline);
                         if (isPipeline) {
-                            queryOptions.setBatch_size(SessionVariable.PIPELINE_BATCH_SIZE); 
+                            queryOptions.setBatch_size(SessionVariable.PIPELINE_BATCH_SIZE);
                         }
                         params.setPipeline_dop(fragment.getPipelineDop());
                         params.setPer_scan_node_dop(instanceExecParam.perScanNodeDop);

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -70,10 +70,12 @@ message PTransmitChunkParams {
 
     // Some statistics for the runing query
     optional PQueryStatistics query_statistics = 8;
-    optional bool use_pass_through = 9 [default = false] ;
+    optional bool use_pass_through = 9 [default = false];
 
-    // Pipeline level shuffle's id
-    optional int32 driver_sequence = 10;
+    // Whether enable pipeline level shuffle
+    optional bool is_pipeline_level_shuffle = 10 [default = false];
+    // Driver sequences of pipeline level shuffle
+    repeated int32 driver_sequences = 11;
 };
 
 message PTransmitDataResult {


### PR DESCRIPTION
## Background

For [issue-3013](https://github.com/StarRocks/starrocks/issues/3013)

When enable pipeline level shuffle, chunks will hash to N groups (N is the dop of dest pipeline). Each group will build the request independently. 

* When sending large amounts of data, the number of requests will not change significantly because each group will accumulate chunk until it exceeds a threshold before sending
* When sending small amounts of data, take the extreme case for example, assume the amount of data just fills one chunk, then each group will send one request, the requests to be sent changed from `1` to `N` which may lead to significant performance drop

## Solution

Put chunks of different driver_sequences in one request and add an auxiliary data structure `PTransmitChunkParams::driver_sequences`, indicating the `driver_sequence` to which the `i-th chunk` belongs

## Test

* 3be(64c/128G)
* 1fe(64c/128G)
* tpcds with scale factor=100

**Almost all the querys have performance improvements, and only a few are listed below.**

| TPCDS | Before | After |
|:--|:--|:--|
| Q12 | 0.299s | 0.19s |
| Q15 | 0.378s | 0.25s |
| Q20 | 0.25s | 0.16s |
| Q45 | 0.442s | 0.305s |
