### PR TITLE
Add Retention for aggregation

### DIFF
--- a/be/src/exprs/agg/aggregate_factory.cpp
+++ b/be/src/exprs/agg/aggregate_factory.cpp
@@ -23,6 +23,7 @@
 #include "exprs/agg/maxmin.h"
 #include "exprs/agg/nullable_aggregate.h"
 #include "exprs/agg/percentile_approx.h"
+#include "exprs/agg/retention.h"
 #include "exprs/agg/sum.h"
 #include "exprs/agg/variance.h"
 #include "exprs/agg/window.h"
@@ -137,6 +138,10 @@ AggregateFunctionPtr AggregateFactory::MakeSumDistinctAggregateFunctionV2() {
 
 AggregateFunctionPtr AggregateFactory::MakeDictMergeAggregateFunction() {
     return std::make_shared<DictMergeAggregateFunction>();
+}
+
+AggregateFunctionPtr AggregateFactory::MakeRetentionAggregateFunction() {
+    return std::make_shared<RetentionAggregateFunction>();
 }
 
 AggregateFunctionPtr AggregateFactory::MakeHllUnionAggregateFunction() {
@@ -308,10 +313,15 @@ public:
             if (name == "dict_merge") {
                 auto dict_merge = AggregateFactory::MakeDictMergeAggregateFunction();
                 return AggregateFactory::MakeNullableAggregateFunctionUnary<DictMergeState>(dict_merge);
+            } else if (name == "retention") {
+                auto retentoin = AggregateFactory::MakeRetentionAggregateFunction();
+                return AggregateFactory::MakeNullableAggregateFunctionUnary<RetentionState>(retentoin);
             }
         } else {
             if (name == "dict_merge") {
                 return AggregateFactory::MakeDictMergeAggregateFunction();
+            } else if (name == "retention") {
+                return AggregateFactory::MakeRetentionAggregateFunction();
             }
         }
 
@@ -816,6 +826,7 @@ AggregateFuncResolver::AggregateFuncResolver() {
     add_object_mapping<TYPE_PERCENTILE, TYPE_PERCENTILE>("percentile_union");
 
     add_array_mapping<TYPE_ARRAY, TYPE_VARCHAR>("dict_merge");
+    add_array_mapping<TYPE_ARRAY, TYPE_ARRAY>("retention");
 }
 
 #undef ADD_ALL_TYPE

--- a/be/src/exprs/agg/aggregate_factory.h
+++ b/be/src/exprs/agg/aggregate_factory.h
@@ -68,6 +68,7 @@ public:
     static AggregateFunctionPtr MakeSumDistinctAggregateFunctionV2();
 
     static AggregateFunctionPtr MakeDictMergeAggregateFunction();
+    static AggregateFunctionPtr MakeRetentionAggregateFunction();
 
     // Hyperloglog functions:
     static AggregateFunctionPtr MakeHllUnionAggregateFunction();

--- a/be/src/exprs/agg/retention.h
+++ b/be/src/exprs/agg/retention.h
@@ -82,8 +82,8 @@ struct RetentionState {
  * 
  * for example, we could compute the Retention of 2020-01-02 from 2020-01-01, through following sql:
  * 
- *              select sum(retention[2]) / sum(retention[1]) as retention from (select retention([event_type = '点击' and time
- *              = '2020-01-01', event_type = '支付' and time = '2020-01-02']) as retention from test_retention 
+ *              select sum(retention[2]) / sum(retention[1]) as retention from (select retention([event_type = 'click' and time
+ *              = '2020-01-01', event_type = 'payment' and time = '2020-01-02']) as retention from test_retention 
  *              where time = '2020-01-01' or time = '2020-01-02' group by uid) t;
  */
 class RetentionAggregateFunction final

--- a/be/src/exprs/agg/retention.h
+++ b/be/src/exprs/agg/retention.h
@@ -1,0 +1,129 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#pragma once
+
+#include <cstring>
+#include <limits>
+#include <type_traits>
+
+#include "column/array_column.h"
+#include "column/binary_column.h"
+#include "column/datum.h"
+#include "column/fixed_length_column.h"
+#include "column/type_traits.h"
+#include "column/vectorized_fwd.h"
+#include "exprs/agg/aggregate.h"
+#include "gen_cpp/Data_types.h"
+#include "glog/logging.h"
+#include "gutil/casts.h"
+#include "runtime/mem_pool.h"
+#include "thrift/protocol/TJSONProtocol.h"
+#include "udf/udf_internal.h"
+#include "util/phmap/phmap_dump.h"
+#include "util/slice.h"
+
+namespace starrocks::vectorized {
+struct RetentionState {
+    void merge_array_element(const DatumArray& datum_array) {
+        auto size = datum_array.size();
+        if (!is_initial) {
+            is_initial = true;
+            boolean_vector.resize(size);
+        }
+
+        // All array conditions' size is equal.
+        DCHECK_EQ(boolean_vector.size(), datum_array.size());
+
+        for (int i = 0; i < size; ++i) {
+            // Use union operation between different rows of the same condition.
+            boolean_vector[i] |= datum_array[i].is_null() ? 0 : datum_array[i].get_uint8();
+        }
+    }
+
+    template <bool finalize>
+    void serialize_to_array_column(ArrayColumn* array_column) const {
+        if (is_initial) {
+            size_t size = boolean_vector.size();
+            DatumArray array;
+            array.reserve(size);
+            for (int i = 0; i < size; i++) {
+                if constexpr (finalize) {
+                    // Get final result through remove values that first condition is not satisfied.
+                    array.emplace_back((uint8_t)(boolean_vector[0] & boolean_vector[i]));
+                } else {
+                    array.emplace_back(boolean_vector[i]);
+                }
+            }
+            array_column->append_datum(array);
+        }
+    }
+
+    bool is_initial = false;
+
+    /*
+     * The nth element of boolean_vector is the partial result of 
+     * nth condition in retention definition:
+     * 
+     * ARRAY retention(Array[cond1, cond2, cond3, cond4...]);
+     * 
+     */
+    std::vector<uint8_t> boolean_vector;
+};
+
+/*
+ * retention is a aggregate function to compute from input(array) to output(array), result is consist of (0|1) value, 
+ * It's definition is follows:
+ * 
+ *  ARRAY retention(Array[cond1, cond2, cond3, cond4...])
+ * 
+ *  cond is predicates, and 
+ *  The 1th element of output ARRAY is compute with cond1.
+ *  The nth(n > 1) element of output ARRAY is compute with(cond1 && condn).
+ * 
+ * for example, we could compute the Retention of 2020-01-02 from 2020-01-01, through following sql:
+ * 
+ *              select sum(retention[2]) / sum(retention[1]) as retention from (select retention([event_type = '点击' and time
+ *              = '2020-01-01', event_type = '支付' and time = '2020-01-02']) as retention from test_retention 
+ *              where time = '2020-01-01' or time = '2020-01-02' group by uid) t;
+ */
+class RetentionAggregateFunction final
+        : public AggregateFunctionBatchHelper<RetentionState, RetentionAggregateFunction> {
+public:
+    void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
+                size_t row_num) const override {
+        const auto* column = down_cast<const ArrayColumn*>(columns[0]);
+        auto ele_vector = column->get(row_num).get_array();
+        this->data(state).merge_array_element(ele_vector);
+    }
+
+    void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
+        const auto* input_column = down_cast<const ArrayColumn*>(column);
+        auto ele_vector = input_column->get(row_num).get_array();
+        this->data(state).merge_array_element(ele_vector);
+    }
+
+    void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
+        auto* column = down_cast<ArrayColumn*>(to);
+        this->data(state).serialize_to_array_column<false>(column);
+    }
+
+    void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
+        auto* array_column = down_cast<ArrayColumn*>(to);
+        this->data(state).serialize_to_array_column<true>(array_column);
+    }
+
+    void convert_to_serialize_format(const Columns& src, size_t chunk_size, ColumnPtr* dst) const override {
+        auto* dst_column = down_cast<ArrayColumn*>((*dst).get());
+        dst_column->reserve(chunk_size);
+
+        const auto* src_column = down_cast<const ArrayColumn*>(src[0].get());
+        for (size_t i = 0; i < chunk_size; ++i) {
+            auto ele_vector = src_column->get(i).get_array();
+            dst_column->append_datum(ele_vector);
+        }
+    }
+
+    std::string get_name() const override { return "retention"; }
+};
+
+} // namespace starrocks::vectorized

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -74,6 +74,7 @@ public class FunctionSet {
     public static final String MULTI_DISTINCT_SUM = "multi_distinct_sum";
     public static final String DICT_MERGE = "dict_merge";
     public static final String ANY_VALUE = "any_value";
+    public static final String RETENTION = "retention";
     public static final String GROUP_CONCAT = "group_concat";
     public static final String ARRAY_AGG = "array_agg";
 
@@ -595,6 +596,9 @@ public class FunctionSet {
         addBuiltin(AggregateFunction.createBuiltin("percentile_union",
                 Lists.newArrayList(Type.PERCENTILE), Type.PERCENTILE, Type.PERCENTILE,
                 false, false, false));
+
+        addBuiltin(AggregateFunction.createBuiltin(RETENTION, Lists.newArrayList(Type.ARRAY_BOOLEAN),
+                Type.ARRAY_BOOLEAN, Type.ARRAY_BOOLEAN, false, false, false));
 
         // Avg
         // TODO: switch to CHAR(sizeof(AvgIntermediateType) when that becomes available

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -1,6 +1,5 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
 package com.starrocks.sql.analyzer;
-
 import com.google.common.collect.Lists;
 import com.starrocks.analysis.CastExpr;
 import com.starrocks.analysis.Expr;
@@ -10,6 +9,7 @@ import com.starrocks.analysis.FunctionParams;
 import com.starrocks.analysis.NullLiteral;
 import com.starrocks.analysis.StringLiteral;
 import com.starrocks.catalog.AggregateFunction;
+import com.starrocks.catalog.ArrayType;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.ScalarFunction;
@@ -188,6 +188,17 @@ public class FunctionAnalyzer {
             if (arg.getType().isDecimalV3()) {
                 throw new SemanticException("array_agg does not support DecimalV3");
             }
+        }
+
+        if (fnName.getFunction().equalsIgnoreCase(FunctionSet.RETENTION)) {
+            if (!arg.getType().isArrayType()) {
+                throw new SemanticException("retention only support Array<BOOLEAN>");
+            }
+            ArrayType type = (ArrayType) arg.getType();
+            if (!type.getItemType().isBoolean()) {
+                throw new SemanticException("retention only support Array<BOOLEAN>");
+            }
+            // For Array<BOOLEAN> that have different size, we just extend result array to Compatible with it
         }
 
         // SUM and AVG cannot be applied to non-numeric types


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
## Problem Summary(Required) ：
- Add Retention to calculate retention rate.
- input/output of Retention is both Array.

**retention** is a **aggregate** function to compute from input(array) to output(array), result is consist of **(0|1)** value, It's format is follows:

`ARRAY retention(Array[cond1, cond2, cond3, cond4...]);
`

cond is predicates, and 

- The 1th element of output ARRAY is compute with cond1.
- The nth(n > 1) element of output ARRAY is compute with(cond1 && condn).

Its' usage, For example,
**Get the proportion of people who place payments on January 2, 2020 that included by total people click on January 1, 2020:**

<pre><code>
SELECT retention[1],
       retention[2],
       retention[2] / retention[1] AS retention
FROM
  (SELECT retention((toDate(TIME) = '2020-01-02' AND event_type = '点击'), 
  (toDate(TIME) = '2020-01-03' AND event_type = '支付')) AS retention
   FROM test_retention where toDate(TIME) IN ('2020-01-02', '2020-01-03')
   GROUP BY UID) t;
</code></pre>
