### PR TITLE
Support array_agg

### DIFF
--- a/be/src/exprs/agg/aggregate.h
+++ b/be/src/exprs/agg/aggregate.h
@@ -49,9 +49,6 @@ public:
     virtual void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state,
                        size_t row_num) const = 0;
 
-    // Merge the aggregation state with null
-    virtual void merge_null(FunctionContext* ctx, AggDataPtr __restrict state) const {}
-
     // When transmit data over network, we need to serialize agg data.
     // We serialize the agg data to |to| column
     // @param[out] to: maybe nullable

--- a/be/src/exprs/agg/aggregate.h
+++ b/be/src/exprs/agg/aggregate.h
@@ -49,6 +49,9 @@ public:
     virtual void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state,
                        size_t row_num) const = 0;
 
+    // Merge the aggregation state with null
+    virtual void merge_null(FunctionContext* ctx, AggDataPtr __restrict state) const {}
+
     // When transmit data over network, we need to serialize agg data.
     // We serialize the agg data to |to| column
     // @param[out] to: maybe nullable

--- a/be/src/exprs/agg/aggregate_factory.cpp
+++ b/be/src/exprs/agg/aggregate_factory.cpp
@@ -7,6 +7,7 @@
 
 #include "column/type_traits.h"
 #include "exprs/agg/any_value.h"
+#include "exprs/agg/array_agg.h"
 #include "exprs/agg/avg.h"
 #include "exprs/agg/bitmap_intersect.h"
 #include "exprs/agg/bitmap_union.h"
@@ -157,6 +158,11 @@ AggregateFunctionPtr AggregateFactory::MakePercentileApproxAggregateFunction() {
 
 AggregateFunctionPtr AggregateFactory::MakePercentileUnionAggregateFunction() {
     return std::make_shared<PercentileUnionAggregateFunction>();
+}
+
+template <PrimitiveType PT>
+AggregateFunctionPtr AggregateFactory::MakeArrayAggAggregateFunction() {
+    return std::make_shared<ArrayAggAggregateFunction<PT>>();
 }
 
 // Windows functions:
@@ -374,6 +380,10 @@ public:
             } else if (name == "any_value") {
                 auto any_value = AggregateFactory::MakeAnyValueAggregateFunction<ArgPT>();
                 return AggregateFactory::MakeNullableAggregateFunctionUnary<AnyValueAggregateData<ArgPT>>(any_value);
+            } else if (name == "array_agg") {
+                auto array_agg = AggregateFactory::MakeArrayAggAggregateFunction<ArgPT>();
+                return AggregateFactory::MakeNullableAggregateFunctionUnary<ArrayAggAggregateState<ArgPT>, false>(
+                        array_agg);
             }
         } else {
             if (name == "count") {
@@ -408,6 +418,8 @@ public:
                 return AggregateFactory::MakeGroupConcatAggregateFunction<ArgPT>();
             } else if (name == "any_value") {
                 return AggregateFactory::MakeAnyValueAggregateFunction<ArgPT>();
+            } else if (name == "array_agg") {
+                return AggregateFactory::MakeArrayAggAggregateFunction<ArgPT>();
             }
         }
 
@@ -453,6 +465,10 @@ public:
             } else if (name == "any_value") {
                 auto any_value = AggregateFactory::MakeAnyValueAggregateFunction<ArgPT>();
                 return AggregateFactory::MakeNullableAggregateFunctionUnary<AnyValueAggregateData<ArgPT>>(any_value);
+            } else if (name == "array_agg") {
+                auto array_agg_value = AggregateFactory::MakeArrayAggAggregateFunction<ArgPT>();
+                return AggregateFactory::MakeNullableAggregateFunctionUnary<ArrayAggAggregateState<ArgPT>, false>(
+                        array_agg_value);
             }
         } else {
             if (name == "avg") {
@@ -469,6 +485,8 @@ public:
                 return AggregateFactory::MakeGroupConcatAggregateFunction<ArgPT>();
             } else if (name == "any_value") {
                 return AggregateFactory::MakeAnyValueAggregateFunction<ArgPT>();
+            } else if (name == "array_agg") {
+                return AggregateFactory::MakeArrayAggAggregateFunction<ArgPT>();
             }
         }
 
@@ -523,6 +541,21 @@ AggregateFuncResolver::AggregateFuncResolver() {
     add_aggregate_mapping<TYPE_DECIMAL32, TYPE_DECIMAL128>("avg");
     add_aggregate_mapping<TYPE_DECIMAL64, TYPE_DECIMAL128>("avg");
     add_aggregate_mapping<TYPE_DECIMAL128, TYPE_DECIMAL128>("avg");
+
+    add_aggregate_mapping<TYPE_BOOLEAN, TYPE_ARRAY>("array_agg");
+    add_aggregate_mapping<TYPE_TINYINT, TYPE_ARRAY>("array_agg");
+    add_aggregate_mapping<TYPE_SMALLINT, TYPE_ARRAY>("array_agg");
+    add_aggregate_mapping<TYPE_INT, TYPE_ARRAY>("array_agg");
+    add_aggregate_mapping<TYPE_BIGINT, TYPE_ARRAY>("array_agg");
+    add_aggregate_mapping<TYPE_LARGEINT, TYPE_ARRAY>("array_agg");
+    add_aggregate_mapping<TYPE_FLOAT, TYPE_ARRAY>("array_agg");
+    add_aggregate_mapping<TYPE_DOUBLE, TYPE_ARRAY>("array_agg");
+    add_aggregate_mapping<TYPE_VARCHAR, TYPE_ARRAY>("array_agg");
+    add_aggregate_mapping<TYPE_CHAR, TYPE_ARRAY>("array_agg");
+    add_aggregate_mapping<TYPE_DECIMAL32, TYPE_ARRAY>("array_agg");
+    add_aggregate_mapping<TYPE_DATETIME, TYPE_ARRAY>("array_agg");
+    add_aggregate_mapping<TYPE_DATE, TYPE_ARRAY>("array_agg");
+    // TYPE_DECIMAL32, TYPE_DECIMAL64, TYPE_DECIMAL128 is not supported now for array_agg
 
     add_aggregate_mapping<TYPE_TINYINT, TYPE_BIGINT>("bitmap_union_int");
     add_aggregate_mapping<TYPE_SMALLINT, TYPE_BIGINT>("bitmap_union_int");

--- a/be/src/exprs/agg/aggregate_factory.h
+++ b/be/src/exprs/agg/aggregate_factory.h
@@ -81,6 +81,9 @@ public:
 
     static AggregateFunctionPtr MakePercentileUnionAggregateFunction();
 
+    template <PrimitiveType PT>
+    static AggregateFunctionPtr MakeArrayAggAggregateFunction();
+
     // Windows functions:
     static AggregateFunctionPtr MakeDenseRankWindowFunction();
 

--- a/be/src/exprs/agg/array_agg.h
+++ b/be/src/exprs/agg/array_agg.h
@@ -17,9 +17,7 @@ template <PrimitiveType PT>
 struct ArrayAggAggregateState<PT, FixedLengthPTGuard<PT>> {
     using CppType = RunTimeCppType<PT>;
 
-    void update(MemPool* mem_pool, CppType key) {
-        items.emplace_back(key);
-    }
+    void update(MemPool* mem_pool, CppType key) { items.emplace_back(key); }
 
     std::vector<CppType> items;
     size_t null_count = 0;
@@ -49,7 +47,7 @@ public:
     void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
                 size_t row_num) const override {
         const auto& column = down_cast<const InputColumnType&>(*columns[0]);
-        if constexpr(IsSlice<InputCppType>) {
+        if constexpr (IsSlice<InputCppType>) {
             this->data(state).update(ctx->impl()->mem_pool(), column.get_slice(row_num));
         } else {
             this->data(state).update(ctx->impl()->mem_pool(), column.get_data()[row_num]);

--- a/be/src/exprs/agg/array_agg.h
+++ b/be/src/exprs/agg/array_agg.h
@@ -1,0 +1,135 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#pragma once
+
+#include "column/array_column.h"
+#include "column/type_traits.h"
+#include "exprs/agg/aggregate.h"
+#include "runtime/mem_pool.h"
+#include "udf/udf_internal.h"
+
+namespace starrocks::vectorized {
+
+template <PrimitiveType PT, typename = guard::Guard>
+struct ArrayAggAggregateState {};
+
+template <PrimitiveType PT>
+struct ArrayAggAggregateState<PT, FixedLengthPTGuard<PT>> {
+    using CppType = RunTimeCppType<PT>;
+
+    void update(MemPool* mem_pool, CppType key) {
+        items.emplace_back(key);
+    }
+
+    std::vector<CppType> items;
+    size_t null_count = 0;
+};
+
+template <PrimitiveType PT>
+struct ArrayAggAggregateState<PT, BinaryPTGuard<PT>> {
+    using CppType = RunTimeCppType<PT>;
+
+    void update(MemPool* mem_pool, Slice key) {
+        uint8_t* pos = mem_pool->allocate(key.size);
+        memcpy(pos, key.data, key.size);
+        items.emplace_back(Slice(pos, key.size));
+    }
+
+    std::vector<CppType> items;
+    size_t null_count = 0;
+};
+
+template <PrimitiveType PT>
+class ArrayAggAggregateFunction
+        : public AggregateFunctionBatchHelper<ArrayAggAggregateState<PT>, ArrayAggAggregateFunction<PT>> {
+public:
+    using InputCppType = RunTimeCppType<PT>;
+    using InputColumnType = RunTimeColumnType<PT>;
+
+    void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
+                size_t row_num) const override {
+        const auto& column = down_cast<const InputColumnType&>(*columns[0]);
+        if constexpr(IsSlice<InputCppType>) {
+            this->data(state).update(ctx->impl()->mem_pool(), column.get_slice(row_num));
+        } else {
+            this->data(state).update(ctx->impl()->mem_pool(), column.get_data()[row_num]);
+        }
+    }
+
+    void process_null(FunctionContext* ctx, AggDataPtr __restrict state) const override {
+        this->data(state).null_count++;
+    }
+
+    void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
+        const auto* input_column = down_cast<const ArrayColumn*>(column);
+        auto datum_array = input_column->get(row_num).get_array();
+
+        for (size_t i = 0; i < datum_array.size(); i++) {
+            if (datum_array[i].is_null()) {
+                this->data(state).null_count++;
+            } else {
+                this->data(state).update(ctx->impl()->mem_pool(), datum_array[i].get<InputCppType>());
+            }
+        }
+    }
+
+    void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
+        const auto& data = this->data(state).items;
+        const size_t null_count = this->data(state).null_count;
+
+        auto* column = down_cast<ArrayColumn*>(to);
+        auto& offsets = column->offsets_column()->get_data();
+        auto& elements_column = column->elements_column();
+
+        for (size_t i = 0; i < data.size(); i++) {
+            elements_column->append_datum(data[i]);
+        }
+        if (null_count > 0) {
+            elements_column->append_nulls(null_count);
+        }
+        offsets.emplace_back(offsets.back() + data.size() + null_count);
+    }
+
+    void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
+        const auto& data = this->data(state).items;
+        const size_t null_count = this->data(state).null_count;
+
+        auto* column = down_cast<ArrayColumn*>(to);
+        auto& offsets = column->offsets_column()->get_data();
+        auto& elements_column = column->elements_column();
+
+        for (size_t i = 0; i < data.size(); i++) {
+            elements_column->append_datum(data[i]);
+        }
+        if (null_count > 0) {
+            elements_column->append_nulls(null_count);
+        }
+        offsets.emplace_back(offsets.back() + data.size() + null_count);
+    }
+
+    void convert_to_serialize_format(const Columns& src, size_t chunk_size, ColumnPtr* dst) const override {
+        auto* column = down_cast<ArrayColumn*>(dst->get());
+        auto& offsets = column->offsets_column()->get_data();
+        auto& elements_column = column->elements_column();
+
+        if (!src[0]->is_nullable()) {
+            const auto* input_column = down_cast<const InputColumnType*>(src[0].get());
+
+            for (size_t i = 0; i < chunk_size; i++) {
+                elements_column->append_datum(input_column->get(i));
+                offsets.emplace_back(offsets.back() + 1);
+            }
+        } else {
+            const auto* input_column = down_cast<const NullableColumn*>(src[0].get());
+
+            for (size_t i = 0; i < chunk_size; i++) {
+                elements_column->append_datum(input_column->get(i));
+                offsets.emplace_back(offsets.back() + 1);
+            }
+        }
+    }
+
+    std::string get_name() const override { return "array_agg"; }
+};
+
+} // namespace starrocks::vectorized

--- a/be/src/exprs/agg/array_agg.h
+++ b/be/src/exprs/agg/array_agg.h
@@ -81,11 +81,11 @@ public:
         auto& offsets = column->offsets_column()->get_data();
         auto& elements_column = column->elements_column();
 
-        for (size_t i = 0; i < data.size(); i++) {
-            elements_column->append_datum(data[i]);
-        }
         if (null_count > 0) {
             elements_column->append_nulls(null_count);
+        }
+        for (size_t i = 0; i < data.size(); i++) {
+            elements_column->append_datum(data[i]);
         }
         offsets.emplace_back(offsets.back() + data.size() + null_count);
     }
@@ -98,11 +98,11 @@ public:
         auto& offsets = column->offsets_column()->get_data();
         auto& elements_column = column->elements_column();
 
-        for (size_t i = 0; i < data.size(); i++) {
-            elements_column->append_datum(data[i]);
-        }
         if (null_count > 0) {
             elements_column->append_nulls(null_count);
+        }
+        for (size_t i = 0; i < data.size(); i++) {
+            elements_column->append_datum(data[i]);
         }
         offsets.emplace_back(offsets.back() + data.size() + null_count);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/FunctionCallExpr.java
@@ -396,7 +396,13 @@ public class FunctionCallExpr extends Expr {
             return;
         }
 
-        if (fnName.getFunction().equalsIgnoreCase("group_concat")) {
+        if (fnName.getFunction().equalsIgnoreCase(FunctionSet.ARRAY_AGG)) {
+            if (fnParams.isDistinct()) {
+                throw new AnalysisException("array_agg does not support DISTINCT");
+            }
+        }
+
+        if (fnName.getFunction().equalsIgnoreCase(FunctionSet.GROUP_CONCAT)) {
             if (children.size() > 2 || children.isEmpty()) {
                 throw new AnalysisException(
                         "group_concat requires one or two parameters: " + this.toSql());

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/FunctionCallExpr.java
@@ -396,12 +396,6 @@ public class FunctionCallExpr extends Expr {
             return;
         }
 
-        if (fnName.getFunction().equalsIgnoreCase(FunctionSet.ARRAY_AGG)) {
-            if (fnParams.isDistinct()) {
-                throw new AnalysisException("array_agg does not support DISTINCT");
-            }
-        }
-
         if (fnName.getFunction().equalsIgnoreCase(FunctionSet.GROUP_CONCAT)) {
             if (children.size() > 2 || children.isEmpty()) {
                 throw new AnalysisException(
@@ -459,6 +453,15 @@ public class FunctionCallExpr extends Expr {
         Expr arg = getChild(0);
         if (arg == null) {
             return;
+        }
+
+        if (fnName.getFunction().equalsIgnoreCase(FunctionSet.ARRAY_AGG)) {
+            if (fnParams.isDistinct()) {
+                throw new AnalysisException("array_agg does not support DISTINCT");
+            }
+            if (arg.type.isDecimalV3()) {
+                throw new AnalysisException("array_agg does not support DecimalV3");
+            }
         }
 
         // SUM and AVG cannot be applied to non-numeric types

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -74,6 +74,8 @@ public class FunctionSet {
     public static final String MULTI_DISTINCT_SUM = "multi_distinct_sum";
     public static final String DICT_MERGE = "dict_merge";
     public static final String ANY_VALUE = "any_value";
+    public static final String GROUP_CONCAT = "group_concat";
+    public static final String ARRAY_AGG = "array_agg";
 
     // Window functions:
     public static final String LEAD = "lead";
@@ -173,7 +175,7 @@ public class FunctionSet {
            "concat_ws",
            "hex",
            "left",
-           "like", 
+           "like",
            "lower",
            "lpad",
            "ltrim",
@@ -185,8 +187,8 @@ public class FunctionSet {
            "rpad",
            "rtrim",
            "split_part",
-           "substr", 
-           "substring", 
+           "substr",
+           "substring",
            "trim",
            "upper");
 
@@ -529,21 +531,21 @@ public class FunctionSet {
             addBuiltin(AggregateFunction.createBuiltin(name,
                     Lists.newArrayList(Type.SMALLINT), Type.BIGINT, Type.BIGINT, false, true, false));
             addBuiltin(AggregateFunction.createBuiltin(name,
-                    Lists.newArrayList(Type.INT), Type.BIGINT, Type.BIGINT,  false, true, false));
+                    Lists.newArrayList(Type.INT), Type.BIGINT, Type.BIGINT, false, true, false));
             addBuiltin(AggregateFunction.createBuiltin(name,
                     Lists.newArrayList(Type.DECIMAL32), Type.DECIMAL64, Type.DECIMAL64, false, true, false));
             addBuiltin(AggregateFunction.createBuiltin(name,
-                    Lists.newArrayList(Type.BIGINT), Type.BIGINT, Type.BIGINT,false, true, false));
+                    Lists.newArrayList(Type.BIGINT), Type.BIGINT, Type.BIGINT, false, true, false));
             addBuiltin(AggregateFunction.createBuiltin(name,
                     Lists.newArrayList(Type.DECIMAL64), Type.DECIMAL64, Type.DECIMAL64, false, true, false));
             addBuiltin(AggregateFunction.createBuiltin(name,
                     Lists.newArrayList(Type.FLOAT), Type.DOUBLE, Type.DOUBLE, false, true, false));
             addBuiltin(AggregateFunction.createBuiltin(name,
-                    Lists.newArrayList(Type.DOUBLE), Type.DOUBLE, Type.DOUBLE,  false, true, false));
+                    Lists.newArrayList(Type.DOUBLE), Type.DOUBLE, Type.DOUBLE, false, true, false));
             addBuiltin(AggregateFunction.createBuiltin(name,
-                    Lists.newArrayList(Type.DECIMALV2), Type.DECIMALV2, Type.DECIMALV2,  false, true, false));
+                    Lists.newArrayList(Type.DECIMALV2), Type.DECIMALV2, Type.DECIMALV2, false, true, false));
             addBuiltin(AggregateFunction.createBuiltin(name,
-                    Lists.newArrayList(Type.LARGEINT), Type.LARGEINT, Type.LARGEINT,  false, true, false));
+                    Lists.newArrayList(Type.LARGEINT), Type.LARGEINT, Type.LARGEINT, false, true, false));
             addBuiltin(AggregateFunction.createBuiltin(name,
                     Lists.newArrayList(Type.DECIMAL128), Type.DECIMAL128, Type.DECIMAL128, false, true, false));
         }
@@ -632,6 +634,51 @@ public class FunctionSet {
         addBuiltin(AggregateFunction.createBuiltin("avg",
                 Lists.newArrayList(Type.DATETIME), Type.DATETIME, Type.DATETIME,
                 false, true, false));
+
+        // array_agg
+        addBuiltin(AggregateFunction.createBuiltin("array_agg",
+                Lists.newArrayList(Type.BOOLEAN), Type.ARRAY_BOOLEAN, Type.ARRAY_BOOLEAN,
+                false, false, false));
+        addBuiltin(AggregateFunction.createBuiltin("array_agg",
+                Lists.newArrayList(Type.TINYINT), Type.ARRAY_TINYINT, Type.ARRAY_TINYINT,
+                false, false, false));
+        addBuiltin(AggregateFunction.createBuiltin("array_agg",
+                Lists.newArrayList(Type.SMALLINT), Type.ARRAY_SMALLINT, Type.ARRAY_SMALLINT,
+                false, false, false));
+        addBuiltin(AggregateFunction.createBuiltin("array_agg",
+                Lists.newArrayList(Type.INT), Type.ARRAY_INT, Type.ARRAY_INT,
+                false, false, false));
+        addBuiltin(AggregateFunction.createBuiltin("array_agg",
+                Lists.newArrayList(Type.BIGINT), Type.ARRAY_BIGINT, Type.ARRAY_BIGINT,
+                false, false, false));
+        addBuiltin(AggregateFunction.createBuiltin("array_agg",
+                Lists.newArrayList(Type.LARGEINT), Type.ARRAY_LARGEINT, Type.ARRAY_LARGEINT,
+                false, false, false));
+        addBuiltin(AggregateFunction.createBuiltin("array_agg",
+                Lists.newArrayList(Type.FLOAT), Type.ARRAY_FLOAT, Type.ARRAY_FLOAT,
+                false, false, false));
+        addBuiltin(AggregateFunction.createBuiltin("array_agg",
+                Lists.newArrayList(Type.DOUBLE), Type.ARRAY_DOUBLE, Type.ARRAY_DOUBLE,
+                false, false, false));
+        addBuiltin(AggregateFunction.createBuiltin("array_agg",
+                Lists.newArrayList(Type.VARCHAR), Type.ARRAY_VARCHAR, Type.ARRAY_VARCHAR,
+                false, false, false));
+        addBuiltin(AggregateFunction.createBuiltin("array_agg",
+                Lists.newArrayList(Type.CHAR), Type.ARRAY_VARCHAR, Type.ARRAY_VARCHAR,
+                false, false, false));
+        addBuiltin(AggregateFunction.createBuiltin("array_agg",
+                Lists.newArrayList(Type.DATE), Type.ARRAY_DATE, Type.ARRAY_DATE,
+                false, false, false));
+        addBuiltin(AggregateFunction.createBuiltin("array_agg",
+                Lists.newArrayList(Type.DATETIME), Type.ARRAY_DATETIME, Type.ARRAY_DATETIME,
+                false, false, false));
+        addBuiltin(AggregateFunction.createBuiltin("array_agg",
+                Lists.newArrayList(Type.DECIMAL32), Type.ARRAY_DECIMALV2, Type.ARRAY_DECIMALV2,
+                false, false, false));
+        addBuiltin(AggregateFunction.createBuiltin("array_agg",
+                Lists.newArrayList(Type.TIME), Type.ARRAY_DATETIME, Type.ARRAY_DATETIME,
+                false, false, false));
+
         // Group_concat(string)
         addBuiltin(AggregateFunction.createBuiltin("group_concat",
                 Lists.newArrayList(Type.VARCHAR), Type.VARCHAR, Type.VARCHAR,

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -636,46 +636,46 @@ public class FunctionSet {
                 false, true, false));
 
         // array_agg
-        addBuiltin(AggregateFunction.createBuiltin("array_agg",
+        addBuiltin(AggregateFunction.createBuiltin(FunctionSet.ARRAY_AGG,
                 Lists.newArrayList(Type.BOOLEAN), Type.ARRAY_BOOLEAN, Type.ARRAY_BOOLEAN,
                 false, false, false));
-        addBuiltin(AggregateFunction.createBuiltin("array_agg",
+        addBuiltin(AggregateFunction.createBuiltin(FunctionSet.ARRAY_AGG,
                 Lists.newArrayList(Type.TINYINT), Type.ARRAY_TINYINT, Type.ARRAY_TINYINT,
                 false, false, false));
-        addBuiltin(AggregateFunction.createBuiltin("array_agg",
+        addBuiltin(AggregateFunction.createBuiltin(FunctionSet.ARRAY_AGG,
                 Lists.newArrayList(Type.SMALLINT), Type.ARRAY_SMALLINT, Type.ARRAY_SMALLINT,
                 false, false, false));
-        addBuiltin(AggregateFunction.createBuiltin("array_agg",
+        addBuiltin(AggregateFunction.createBuiltin(FunctionSet.ARRAY_AGG,
                 Lists.newArrayList(Type.INT), Type.ARRAY_INT, Type.ARRAY_INT,
                 false, false, false));
-        addBuiltin(AggregateFunction.createBuiltin("array_agg",
+        addBuiltin(AggregateFunction.createBuiltin(FunctionSet.ARRAY_AGG,
                 Lists.newArrayList(Type.BIGINT), Type.ARRAY_BIGINT, Type.ARRAY_BIGINT,
                 false, false, false));
-        addBuiltin(AggregateFunction.createBuiltin("array_agg",
+        addBuiltin(AggregateFunction.createBuiltin(FunctionSet.ARRAY_AGG,
                 Lists.newArrayList(Type.LARGEINT), Type.ARRAY_LARGEINT, Type.ARRAY_LARGEINT,
                 false, false, false));
-        addBuiltin(AggregateFunction.createBuiltin("array_agg",
+        addBuiltin(AggregateFunction.createBuiltin(FunctionSet.ARRAY_AGG,
                 Lists.newArrayList(Type.FLOAT), Type.ARRAY_FLOAT, Type.ARRAY_FLOAT,
                 false, false, false));
-        addBuiltin(AggregateFunction.createBuiltin("array_agg",
+        addBuiltin(AggregateFunction.createBuiltin(FunctionSet.ARRAY_AGG,
                 Lists.newArrayList(Type.DOUBLE), Type.ARRAY_DOUBLE, Type.ARRAY_DOUBLE,
                 false, false, false));
-        addBuiltin(AggregateFunction.createBuiltin("array_agg",
+        addBuiltin(AggregateFunction.createBuiltin(FunctionSet.ARRAY_AGG,
                 Lists.newArrayList(Type.VARCHAR), Type.ARRAY_VARCHAR, Type.ARRAY_VARCHAR,
                 false, false, false));
-        addBuiltin(AggregateFunction.createBuiltin("array_agg",
+        addBuiltin(AggregateFunction.createBuiltin(FunctionSet.ARRAY_AGG,
                 Lists.newArrayList(Type.CHAR), Type.ARRAY_VARCHAR, Type.ARRAY_VARCHAR,
                 false, false, false));
-        addBuiltin(AggregateFunction.createBuiltin("array_agg",
+        addBuiltin(AggregateFunction.createBuiltin(FunctionSet.ARRAY_AGG,
                 Lists.newArrayList(Type.DATE), Type.ARRAY_DATE, Type.ARRAY_DATE,
                 false, false, false));
-        addBuiltin(AggregateFunction.createBuiltin("array_agg",
+        addBuiltin(AggregateFunction.createBuiltin(FunctionSet.ARRAY_AGG,
                 Lists.newArrayList(Type.DATETIME), Type.ARRAY_DATETIME, Type.ARRAY_DATETIME,
                 false, false, false));
-        addBuiltin(AggregateFunction.createBuiltin("array_agg",
+        addBuiltin(AggregateFunction.createBuiltin(FunctionSet.ARRAY_AGG,
                 Lists.newArrayList(Type.DECIMAL32), Type.ARRAY_DECIMALV2, Type.ARRAY_DECIMALV2,
                 false, false, false));
-        addBuiltin(AggregateFunction.createBuiltin("array_agg",
+        addBuiltin(AggregateFunction.createBuiltin(FunctionSet.ARRAY_AGG,
                 Lists.newArrayList(Type.TIME), Type.ARRAY_DATETIME, Type.ARRAY_DATETIME,
                 false, false, false));
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DecimalV3FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DecimalV3FunctionAnalyzer.java
@@ -28,7 +28,7 @@ public class DecimalV3FunctionAnalyzer {
                     .add(FunctionSet.MAX).add(FunctionSet.MIN)
                     .add(FunctionSet.LEAD).add(FunctionSet.LAG)
                     .add(FunctionSet.FIRST_VALUE).add(FunctionSet.LAST_VALUE)
-                    .add(FunctionSet.ANY_VALUE).build();
+                    .add(FunctionSet.ANY_VALUE).add(FunctionSet.ARRAY_AGG).build();
 
     public static final Set<String> DECIMAL_AGG_FUNCTION_WIDER_TYPE =
             new ImmutableSortedSet.Builder<>(String.CASE_INSENSITIVE_ORDER)

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -65,7 +65,13 @@ public class FunctionAnalyzer {
             return;
         }
 
-        if (fnName.getFunction().equalsIgnoreCase("group_concat")) {
+        if (fnName.getFunction().equalsIgnoreCase(FunctionSet.ARRAY_AGG)) {
+            if (fnParams.isDistinct()) {
+                throw new SemanticException("array_agg does not support DISTINCT");
+            }
+        }
+
+        if (fnName.getFunction().equalsIgnoreCase(FunctionSet.GROUP_CONCAT)) {
             if (functionCallExpr.getChildren().size() > 2 || functionCallExpr.getChildren().isEmpty()) {
                 throw new SemanticException(
                         "group_concat requires one or two parameters: " + functionCallExpr.toSql());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -65,12 +65,6 @@ public class FunctionAnalyzer {
             return;
         }
 
-        if (fnName.getFunction().equalsIgnoreCase(FunctionSet.ARRAY_AGG)) {
-            if (fnParams.isDistinct()) {
-                throw new SemanticException("array_agg does not support DISTINCT");
-            }
-        }
-
         if (fnName.getFunction().equalsIgnoreCase(FunctionSet.GROUP_CONCAT)) {
             if (functionCallExpr.getChildren().size() > 2 || functionCallExpr.getChildren().isEmpty()) {
                 throw new SemanticException(
@@ -129,6 +123,15 @@ public class FunctionAnalyzer {
         Expr arg = functionCallExpr.getChild(0);
         if (arg == null) {
             return;
+        }
+
+        if (fnName.getFunction().equalsIgnoreCase(FunctionSet.ARRAY_AGG)) {
+            if (fnParams.isDistinct()) {
+                throw new SemanticException("array_agg does not support DISTINCT");
+            }
+            if (arg.getType().isDecimalV3()) {
+                throw new SemanticException("array_agg does not support DecimalV3");
+            }
         }
 
         // SUM and AVG cannot be applied to non-numeric types


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

for #648 

support array_agg function

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

usage:

```
mysql> select c2, c10 from array_agg_null;
+------+------+
| c2   | c10  |
+------+------+
|    2 |  211 |
|    2 | NULL |
|    1 |  111 |
|    1 | NULL |
|    2 | NULL |
|    2 | NULL |
+------+------+
6 rows in set (0.01 sec)

mysql> select array_agg(c10) from array_agg_null;
+-------------------------------+
| array_agg(`c10`)              |
+-------------------------------+
| [null,null,null,null,111,211] |
+-------------------------------+
1 row in set (0.01 sec)


mysql> select c2, array_agg(c10) from array_agg_null group by c2;
+------+----------------------+
| c2   | array_agg(`c10`)     |
+------+----------------------+
|    2 | [null,null,null,211] |
|    1 | [null,111]           |
+------+----------------------+
2 rows in set (0.01 sec)

mysql> select array_agg(c10) from array_agg_null where c2 > 100;
+------------------+
| array_agg(`c10`) |
+------------------+
| NULL             |
+------------------+
1 row in set (0.01 sec)
```

implement:

source_column (source type) -> array_column (Intermediate result type) -> array_column (final result type)

* Some points have performance problems, ignore them first, and optimize them later
* This version does not support distinct and order by