### PR TITLE
Improve Schema Scan by column prune

### DIFF
--- a/be/src/exec/vectorized/schema_scan_node.h
+++ b/be/src/exec/vectorized/schema_scan_node.h
@@ -59,6 +59,8 @@ private:
     // TODO(xueli): remove this when fe and be version both >= 1.19
     // Map from index in desc slots to column of src schema table.
     std::vector<int> _index_map;
+
+    RuntimeProfile::Counter* _filter_timer = nullptr;
 };
 
 } // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/schema_scanner/schema_charsets_scanner.cpp
+++ b/be/src/exec/vectorized/schema_scanner/schema_charsets_scanner.cpp
@@ -28,28 +28,47 @@ SchemaCharsetsScanner::SchemaCharsetsScanner()
 SchemaCharsetsScanner::~SchemaCharsetsScanner() = default;
 
 Status SchemaCharsetsScanner::fill_chunk(ChunkPtr* chunk) {
-    // variables names
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[0]->id());
-        Slice value(_s_charsets[_index].charset, strlen(_s_charsets[_index].charset));
-        fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
-    }
-    // DEFAULT_COLLATE_NAME
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[1]->id());
-        Slice value(_s_charsets[_index].default_collation, strlen(_s_charsets[_index].default_collation));
-        fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
-    }
-    // DESCRIPTION
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[2]->id());
-        Slice value(_s_charsets[_index].description, strlen(_s_charsets[_index].description));
-        fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
-    }
-    // maxlen
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[3]->id());
-        fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&_s_charsets[_index].maxlen);
+    const auto& slot_id_to_index_map = (*chunk)->get_slot_id_to_index_map();
+    for (const auto& [slot_id, index] : slot_id_to_index_map) {
+        switch (slot_id) {
+        case 1: {
+            // variables names
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(1);
+                Slice value(_s_charsets[_index].charset, strlen(_s_charsets[_index].charset));
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            }
+            break;
+        }
+        case 2: {
+            // DEFAULT_COLLATE_NAME
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(2);
+                Slice value(_s_charsets[_index].default_collation, strlen(_s_charsets[_index].default_collation));
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            }
+            break;
+        }
+        case 3: {
+            // DESCRIPTION
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(3);
+                Slice value(_s_charsets[_index].description, strlen(_s_charsets[_index].description));
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            }
+            break;
+        }
+        case 4: {
+            // maxlen
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(4);
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&_s_charsets[_index].maxlen);
+            }
+            break;
+        }
+        default:
+            break;
+        }
     }
     _index++;
     return Status::OK();

--- a/be/src/exec/vectorized/schema_scanner/schema_collations_scanner.cpp
+++ b/be/src/exec/vectorized/schema_scanner/schema_collations_scanner.cpp
@@ -30,40 +30,66 @@ SchemaCollationsScanner::SchemaCollationsScanner()
 SchemaCollationsScanner::~SchemaCollationsScanner() = default;
 
 Status SchemaCollationsScanner::fill_chunk(ChunkPtr* chunk) {
-    // COLLATION_NAME
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[0]->id());
-        Slice value(_s_collations[_index].name, strlen(_s_collations[_index].name));
-        fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+    const auto& slot_id_to_index_map = (*chunk)->get_slot_id_to_index_map();
+    for (const auto& [slot_id, index] : slot_id_to_index_map) {
+        switch (slot_id) {
+        case 1: {
+            // COLLATION_NAME
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(1);
+                Slice value(_s_collations[_index].name, strlen(_s_collations[_index].name));
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            }
+            break;
+        }
+        case 2: {
+            // charset
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(2);
+                Slice value(_s_collations[_index].charset, strlen(_s_collations[_index].charset));
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            }
+            break;
+        }
+        case 3: {
+            // id
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(3);
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&_s_collations[_index].id);
+            }
+            break;
+        }
+        case 4: {
+            // is_default
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(4);
+                Slice value(_s_collations[_index].is_default, strlen(_s_collations[_index].is_default));
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            }
+            break;
+        }
+        case 5: {
+            // IS_COMPILED
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(5);
+                Slice value(_s_collations[_index].is_compile, strlen(_s_collations[_index].is_compile));
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            }
+            break;
+        }
+        case 6: {
+            // sortlen
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(6);
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&_s_collations[_index].sortlen);
+            }
+            break;
+        }
+        default:
+            break;
+        }
     }
-    // charset
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[1]->id());
-        Slice value(_s_collations[_index].charset, strlen(_s_collations[_index].charset));
-        fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
-    }
-    // id
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[2]->id());
-        fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&_s_collations[_index].id);
-    }
-    // is_default
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[3]->id());
-        Slice value(_s_collations[_index].is_default, strlen(_s_collations[_index].is_default));
-        fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
-    }
-    // IS_COMPILED
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[4]->id());
-        Slice value(_s_collations[_index].is_compile, strlen(_s_collations[_index].is_compile));
-        fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
-    }
-    // sortlen
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[5]->id());
-        fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&_s_collations[_index].sortlen);
-    }
+
     _index++;
     return Status::OK();
 }

--- a/be/src/exec/vectorized/schema_scanner/schema_schemata_scanner.cpp
+++ b/be/src/exec/vectorized/schema_scanner/schema_schemata_scanner.cpp
@@ -52,36 +52,58 @@ Status SchemaSchemataScanner::start(RuntimeState* state) {
 }
 
 Status SchemaSchemataScanner::fill_chunk(ChunkPtr* chunk) {
-    // catalog
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[0]->id());
-        fill_data_column_with_null(column.get());
-    }
-    // schema
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[1]->id());
-        std::string db_name = SchemaHelper::extract_db_name(_db_result.dbs[_db_index]);
-        Slice value(db_name.c_str(), db_name.length());
-        fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
-    }
-    // DEFAULT_CHARACTER_SET_NAME
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[2]->id());
-        const char* str = "utf8";
-        Slice value(str, strlen(str));
-        fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
-    }
-    // DEFAULT_COLLATION_NAME
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[3]->id());
-        const char* str = "utf8_general_ci";
-        Slice value(str, strlen(str));
-        fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
-    }
-    // SQL_PATH
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[4]->id());
-        fill_data_column_with_null(column.get());
+    const auto& slot_id_to_index_map = (*chunk)->get_slot_id_to_index_map();
+    for (const auto& [slot_id, index] : slot_id_to_index_map) {
+        switch (slot_id) {
+        case 1: {
+            // catalog
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(1);
+                fill_data_column_with_null(column.get());
+            }
+            break;
+        }
+        case 2: {
+            // schema
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(2);
+                std::string db_name = SchemaHelper::extract_db_name(_db_result.dbs[_db_index]);
+                Slice value(db_name.c_str(), db_name.length());
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            }
+            break;
+        }
+        case 3: {
+            // DEFAULT_CHARACTER_SET_NAME
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(3);
+                const char* str = "utf8";
+                Slice value(str, strlen(str));
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            }
+            break;
+        }
+        case 4: {
+            // DEFAULT_COLLATION_NAME
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(4);
+                const char* str = "utf8_general_ci";
+                Slice value(str, strlen(str));
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            }
+            break;
+        }
+        case 5: {
+            // SQL_PATH
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(5);
+                fill_data_column_with_null(column.get());
+            }
+            break;
+        }
+        default:
+            break;
+        }
     }
     _db_index++;
     return Status::OK();

--- a/be/src/exec/vectorized/schema_scanner/schema_table_privileges_scanner.cpp
+++ b/be/src/exec/vectorized/schema_scanner/schema_table_privileges_scanner.cpp
@@ -43,46 +43,72 @@ Status SchemaTablePrivilegesScanner::start(RuntimeState* state) {
 
 Status SchemaTablePrivilegesScanner::fill_chunk(ChunkPtr* chunk) {
     const TTablePrivDesc& table_priv_desc = _table_privs_result.table_privs[_table_priv_index];
-    // GRANTEE
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[0]->id());
-        const std::string* str = &table_priv_desc.user_ident_str;
-        Slice value(str->c_str(), str->length());
-        fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+    const auto& slot_id_to_index_map = (*chunk)->get_slot_id_to_index_map();
+    for (const auto& [slot_id, index] : slot_id_to_index_map) {
+        switch (slot_id) {
+        case 1: {
+            // GRANTEE
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(1);
+                const std::string* str = &table_priv_desc.user_ident_str;
+                Slice value(str->c_str(), str->length());
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            }
+            break;
+        }
+        case 2: {
+            // TABLE_CATALOG
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(2);
+                fill_data_column_with_null(column.get());
+            }
+            break;
+        }
+        case 3: {
+            // TABLE_SCHEMA
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(3);
+                const std::string* str = &table_priv_desc.db_name;
+                Slice value(str->c_str(), str->length());
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            }
+            break;
+        }
+        case 4: {
+            // TABLE_NAME
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(4);
+                const std::string* str = &table_priv_desc.table_name;
+                Slice value(str->c_str(), str->length());
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            }
+            break;
+        }
+        case 5: {
+            // PRIVILEGE_TYPE
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(5);
+                const std::string* str = &table_priv_desc.priv;
+                Slice value(str->c_str(), str->length());
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            }
+            break;
+        }
+        case 6: {
+            // IS_GRANTABLE
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(6);
+                const char* str = table_priv_desc.is_grantable ? "YES" : "NO";
+                Slice value(str, strlen(str));
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            }
+            break;
+        }
+        default:
+            break;
+        }
     }
-    // TABLE_CATALOG
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[1]->id());
-        fill_data_column_with_null(column.get());
-    }
-    // TABLE_SCHEMA
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[2]->id());
-        const std::string* str = &table_priv_desc.db_name;
-        Slice value(str->c_str(), str->length());
-        fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
-    }
-    // TABLE_NAME
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[3]->id());
-        const std::string* str = &table_priv_desc.table_name;
-        Slice value(str->c_str(), str->length());
-        fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
-    }
-    // PRIVILEGE_TYPE
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[4]->id());
-        const std::string* str = &table_priv_desc.priv;
-        Slice value(str->c_str(), str->length());
-        fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
-    }
-    // IS_GRANTABLE
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[5]->id());
-        const char* str = table_priv_desc.is_grantable ? "YES" : "NO";
-        Slice value(str, strlen(str));
-        fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
-    }
+
     _table_priv_index++;
     return Status::OK();
 }

--- a/be/src/exec/vectorized/schema_scanner/schema_tables_scanner.cpp
+++ b/be/src/exec/vectorized/schema_scanner/schema_tables_scanner.cpp
@@ -71,152 +71,223 @@ Status SchemaTablesScanner::start(RuntimeState* state) {
 
 Status SchemaTablesScanner::fill_chunk(ChunkPtr* chunk) {
     const TTableStatus& tbl_status = _table_result.tables[_table_index];
-    // catalog
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[0]->id());
-        fill_data_column_with_null(column.get());
-    }
-    // schema
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[1]->id());
-        std::string db_name = SchemaHelper::extract_db_name(_db_result.dbs[_db_index - 1]);
-        Slice value(db_name.c_str(), db_name.length());
-        fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
-    }
-    // name
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[2]->id());
-        const std::string* str = &tbl_status.name;
-        Slice value(str->c_str(), str->length());
-        fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
-    }
-    // type
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[3]->id());
-        const std::string* str = &tbl_status.type;
-        Slice value(str->c_str(), str->length());
-        fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
-    }
-    // engine
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[4]->id());
-        if (tbl_status.__isset.engine) {
-            const std::string* str = &tbl_status.engine;
-            Slice value(str->c_str(), str->length());
-            fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
-        } else {
-            NullableColumn* nullable_column = down_cast<NullableColumn*>(column.get());
-            nullable_column->append_nulls(1);
-        }
-    }
-    // version
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[5]->id());
-        fill_data_column_with_null(column.get());
-    }
-    // row_format
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[6]->id());
-        fill_data_column_with_null(column.get());
-    }
-    // rows
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[7]->id());
-        fill_data_column_with_null(column.get());
-    }
-    // avg_row_length
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[8]->id());
-        fill_data_column_with_null(column.get());
-    }
-    // data_length
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[9]->id());
-        fill_data_column_with_null(column.get());
-    }
-    // max_data_length
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[10]->id());
-        fill_data_column_with_null(column.get());
-    }
-    // index_length
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[11]->id());
-        fill_data_column_with_null(column.get());
-    }
-    // data_free
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[12]->id());
-        fill_data_column_with_null(column.get());
-    }
-    // auto_increment
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[13]->id());
-        fill_data_column_with_null(column.get());
-    }
-    // creation_time
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[14]->id());
-        NullableColumn* nullable_column = down_cast<NullableColumn*>(column.get());
-        if (tbl_status.__isset.create_time) {
-            int64_t create_time = tbl_status.create_time;
-            if (create_time <= 0) {
-                nullable_column->append_nulls(1);
-            } else {
-                DateTimeValue t;
-                t.from_unixtime(create_time, TimezoneUtils::default_time_zone);
-                fill_column_with_slot<TYPE_DATETIME>(column.get(), (void*)&t);
+    const auto& slot_id_to_index_map = (*chunk)->get_slot_id_to_index_map();
+    for (const auto& [slot_id, index] : slot_id_to_index_map) {
+        switch (slot_id) {
+        case 1: {
+            // catalog
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(1);
+                fill_data_column_with_null(column.get());
             }
-        } else {
-            nullable_column->append_nulls(1);
+            break;
         }
-    }
-    // update_time
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[15]->id());
-        fill_data_column_with_null(column.get());
-    }
-    // check_time
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[16]->id());
-        NullableColumn* nullable_column = down_cast<NullableColumn*>(column.get());
-        if (tbl_status.__isset.last_check_time) {
-            int64_t check_time = tbl_status.last_check_time;
-            if (check_time <= 0) {
-                nullable_column->append_nulls(1);
-            } else {
-                DateTimeValue t;
-                t.from_unixtime(check_time, TimezoneUtils::default_time_zone);
-                fill_column_with_slot<TYPE_DATETIME>(column.get(), (void*)&t);
+        case 2: {
+            // schema
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(2);
+                std::string db_name = SchemaHelper::extract_db_name(_db_result.dbs[_db_index - 1]);
+                Slice value(db_name.c_str(), db_name.length());
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
             }
-        } else {
-            nullable_column->append_nulls(1);
+            break;
+        }
+        case 3: {
+            // name
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(3);
+                const std::string* str = &tbl_status.name;
+                Slice value(str->c_str(), str->length());
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            }
+            break;
+        }
+        case 4: {
+            // type
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(4);
+                const std::string* str = &tbl_status.type;
+                Slice value(str->c_str(), str->length());
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            }
+            break;
+        }
+        case 5: {
+            // engine
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(5);
+                if (tbl_status.__isset.engine) {
+                    const std::string* str = &tbl_status.engine;
+                    Slice value(str->c_str(), str->length());
+                    fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+                } else {
+                    NullableColumn* nullable_column = down_cast<NullableColumn*>(column.get());
+                    nullable_column->append_nulls(1);
+                }
+            }
+            break;
+        }
+        case 6: {
+            // version
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(6);
+                fill_data_column_with_null(column.get());
+            }
+            break;
+        }
+        case 7: {
+            // row_format
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(7);
+                fill_data_column_with_null(column.get());
+            }
+            break;
+        }
+        case 8: {
+            // rows
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(8);
+                fill_data_column_with_null(column.get());
+            }
+            break;
+        }
+        case 9: {
+            // avg_row_length
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(9);
+                fill_data_column_with_null(column.get());
+            }
+            break;
+        }
+        case 10: {
+            // data_length
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(10);
+                fill_data_column_with_null(column.get());
+            }
+            break;
+        }
+        case 11: {
+            // max_data_length
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(11);
+                fill_data_column_with_null(column.get());
+            }
+            break;
+        }
+        case 12: {
+            // index_length
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(12);
+                fill_data_column_with_null(column.get());
+            }
+            break;
+        }
+        case 13: {
+            // data_free
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(13);
+                fill_data_column_with_null(column.get());
+            }
+            break;
+        }
+        case 14: {
+            // auto_increment
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(14);
+                fill_data_column_with_null(column.get());
+            }
+            break;
+        }
+        case 15: {
+            // creation_time
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(15);
+                NullableColumn* nullable_column = down_cast<NullableColumn*>(column.get());
+                if (tbl_status.__isset.create_time) {
+                    int64_t create_time = tbl_status.create_time;
+                    if (create_time <= 0) {
+                        nullable_column->append_nulls(1);
+                    } else {
+                        DateTimeValue t;
+                        t.from_unixtime(create_time, TimezoneUtils::default_time_zone);
+                        fill_column_with_slot<TYPE_DATETIME>(column.get(), (void*)&t);
+                    }
+                } else {
+                    nullable_column->append_nulls(1);
+                }
+            }
+            break;
+        }
+        case 16: {
+            // update_time
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(16);
+                fill_data_column_with_null(column.get());
+            }
+            break;
+        }
+        case 17: {
+            // check_time
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(17);
+                NullableColumn* nullable_column = down_cast<NullableColumn*>(column.get());
+                if (tbl_status.__isset.last_check_time) {
+                    int64_t check_time = tbl_status.last_check_time;
+                    if (check_time <= 0) {
+                        nullable_column->append_nulls(1);
+                    } else {
+                        DateTimeValue t;
+                        t.from_unixtime(check_time, TimezoneUtils::default_time_zone);
+                        fill_column_with_slot<TYPE_DATETIME>(column.get(), (void*)&t);
+                    }
+                } else {
+                    nullable_column->append_nulls(1);
+                }
+            }
+            break;
+        }
+        case 18: {
+            // collation
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(18);
+                const char* collation_str = "utf8_general_ci";
+                Slice value(collation_str, strlen(collation_str));
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            }
+            break;
+        }
+        case 19: {
+            // checksum
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(19);
+                fill_data_column_with_null(column.get());
+            }
+            break;
+        }
+        case 20: {
+            // create_options
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(20);
+                fill_data_column_with_null(column.get());
+            }
+            break;
+        }
+        case 21: {
+            // create_comment
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(21);
+                const std::string* str = &tbl_status.comment;
+                Slice value(str->c_str(), str->length());
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            }
+            break;
+        }
+        default:
+            break;
         }
     }
-    // collation
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[17]->id());
-        const char* collation_str = "utf8_general_ci";
-        Slice value(collation_str, strlen(collation_str));
-        fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
-    }
-    // checksum
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[18]->id());
-        fill_data_column_with_null(column.get());
-    }
-    // create_options
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[19]->id());
-        fill_data_column_with_null(column.get());
-    }
-    // create_comment
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[20]->id());
-        const std::string* str = &tbl_status.comment;
-        Slice value(str->c_str(), str->length());
-        fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
-    }
+
     _table_index++;
     return Status::OK();
 }

--- a/be/src/exec/vectorized/schema_scanner/schema_user_privileges_scanner.cpp
+++ b/be/src/exec/vectorized/schema_scanner/schema_user_privileges_scanner.cpp
@@ -41,31 +41,50 @@ Status SchemaUserPrivilegesScanner::start(RuntimeState* state) {
 
 Status SchemaUserPrivilegesScanner::fill_chunk(ChunkPtr* chunk) {
     const TUserPrivDesc& user_priv_desc = _user_privs_result.user_privs[_user_priv_index];
-    // GRANTEE
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[0]->id());
-        const std::string* str = &user_priv_desc.user_ident_str;
-        Slice value(str->c_str(), str->length());
-        fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
-    }
-    // TABLE_CATALOG
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[1]->id());
-        fill_data_column_with_null(column.get());
-    }
-    // PRIVILEGE_TYPE
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[2]->id());
-        const std::string* str = &user_priv_desc.priv;
-        Slice value(str->c_str(), str->length());
-        fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
-    }
-    // IS_GRANTABLE
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[3]->id());
-        const char* str = user_priv_desc.is_grantable ? "YES" : "NO";
-        Slice value(str, strlen(str));
-        fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+    const auto& slot_id_to_index_map = (*chunk)->get_slot_id_to_index_map();
+    for (const auto& [slot_id, index] : slot_id_to_index_map) {
+        switch (slot_id) {
+        case 1: {
+            // GRANTEE
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(1);
+                const std::string* str = &user_priv_desc.user_ident_str;
+                Slice value(str->c_str(), str->length());
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            }
+            break;
+        }
+        case 2: {
+            // TABLE_CATALOG
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(2);
+                fill_data_column_with_null(column.get());
+            }
+            break;
+        }
+        case 3: {
+            // PRIVILEGE_TYPE
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(3);
+                const std::string* str = &user_priv_desc.priv;
+                Slice value(str->c_str(), str->length());
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            }
+            break;
+        }
+        case 4: {
+            // IS_GRANTABLE
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(4);
+                const char* str = user_priv_desc.is_grantable ? "YES" : "NO";
+                Slice value(str, strlen(str));
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            }
+            break;
+        }
+        default:
+            break;
+        }
     }
     _user_priv_index++;
     return Status::OK();

--- a/be/src/exec/vectorized/schema_scanner/schema_variables_scanner.cpp
+++ b/be/src/exec/vectorized/schema_scanner/schema_variables_scanner.cpp
@@ -45,17 +45,30 @@ Status SchemaVariablesScanner::start(RuntimeState* state) {
 }
 
 Status SchemaVariablesScanner::fill_chunk(ChunkPtr* chunk) {
-    // variables names
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[0]->id());
-        Slice value(_begin->first.c_str(), _begin->first.length());
-        fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
-    }
-    // value
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[1]->id());
-        Slice value(_begin->second.c_str(), _begin->second.length());
-        fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+    const auto& slot_id_to_index_map = (*chunk)->get_slot_id_to_index_map();
+    for (const auto& [slot_id, index] : slot_id_to_index_map) {
+        switch (slot_id) {
+        case 1: {
+            // variables names
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(1);
+                Slice value(_begin->first.c_str(), _begin->first.length());
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            }
+            break;
+        }
+        case 2: {
+            // value
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(2);
+                Slice value(_begin->second.c_str(), _begin->second.length());
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            }
+            break;
+        }
+        default:
+            break;
+        }
     }
     ++_begin;
     return Status::OK();

--- a/be/src/exec/vectorized/schema_scanner/schema_views_scanner.cpp
+++ b/be/src/exec/vectorized/schema_scanner/schema_views_scanner.cpp
@@ -6,7 +6,6 @@
 #include "exec/vectorized/schema_scanner/schema_helper.h"
 #include "runtime/primitive_type.h"
 #include "runtime/string_value.h"
-//#include "runtime/datetime_value.h"
 
 namespace starrocks::vectorized {
 
@@ -58,75 +57,112 @@ Status SchemaViewsScanner::start(RuntimeState* state) {
 
 Status SchemaViewsScanner::fill_chunk(ChunkPtr* chunk) {
     const TTableStatus& tbl_status = _table_result.tables[_table_index];
-    // TABLE_CATALOG
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[0]->id());
-        fill_data_column_with_null(column.get());
-    }
-    // TABLE_SCHEMA
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[1]->id());
-        std::string db_name = SchemaHelper::extract_db_name(_db_result.dbs[_db_index - 1]);
-        Slice value(db_name.c_str(), db_name.length());
-        fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
-    }
-    // TABLE_NAME
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[2]->id());
-        const std::string* str = &tbl_status.name;
-        Slice value(str->c_str(), str->length());
-        fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
-    }
-    // VIEW_DEFINITION
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[3]->id());
-        const std::string* str = &tbl_status.ddl_sql;
-        Slice value(str->c_str(), str->length());
-        fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
-    }
-    // CHECK_OPTION
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[4]->id());
-        const char* str = "NONE";
-        Slice value(str, strlen(str));
-        fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
-    }
-    // IS_UPDATABLE
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[5]->id());
-        const char* str = "NO";
-        Slice value(str, strlen(str));
-        fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
-    }
-    // DEFINER
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[6]->id());
-        // since we did not record the creater of a certain `view` or `table` , just leave this column empty at this stage.
-        const char* str = "";
-        Slice value(str, strlen(str));
-        fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
-    }
-    // SECURITY_TYPE
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[7]->id());
-        // since we did not record the creater of a certain `view` or `table` , just leave this column empty at this stage.
-        const char* str = "";
-        Slice value(str, strlen(str));
-        fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
-    }
-    // CHARACTER_SET_CLIENT
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[8]->id());
-        const char* str = "utf8";
-        Slice value(str, strlen(str));
-        fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
-    }
-    // COLLATION_CONNECTION
-    {
-        ColumnPtr column = (*chunk)->get_column_by_slot_id(_slot_descs[9]->id());
-        const char* str = "utf8_general_ci";
-        Slice value(str, strlen(str));
-        fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+    const auto& slot_id_to_index_map = (*chunk)->get_slot_id_to_index_map();
+    for (const auto& [slot_id, index] : slot_id_to_index_map) {
+        switch (slot_id) {
+        case 1: {
+            // TABLE_CATALOG
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(1);
+                fill_data_column_with_null(column.get());
+            }
+            break;
+        }
+        case 2: {
+            // TABLE_SCHEMA
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(2);
+                std::string db_name = SchemaHelper::extract_db_name(_db_result.dbs[_db_index - 1]);
+                Slice value(db_name.c_str(), db_name.length());
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            }
+            break;
+        }
+        case 3: {
+            // TABLE_NAME
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(3);
+                const std::string* str = &tbl_status.name;
+                Slice value(str->c_str(), str->length());
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            }
+            break;
+        }
+        case 4: {
+            // VIEW_DEFINITION
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(4);
+                const std::string* str = &tbl_status.ddl_sql;
+                Slice value(str->c_str(), str->length());
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            }
+            break;
+        }
+        case 5: {
+            // CHECK_OPTION
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(5);
+                const char* str = "NONE";
+                Slice value(str, strlen(str));
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            }
+            break;
+        }
+        case 6: {
+            // IS_UPDATABLE
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(6);
+                const char* str = "NO";
+                Slice value(str, strlen(str));
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            }
+            break;
+        }
+        case 7: {
+            // DEFINER
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(7);
+                // since we did not record the creater of a certain `view` or `table` , just leave this column empty at this stage.
+                const char* str = "";
+                Slice value(str, strlen(str));
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            }
+            break;
+        }
+        case 8: {
+            // SECURITY_TYPE
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(8);
+                // since we did not record the creater of a certain `view` or `table` , just leave this column empty at this stage.
+                const char* str = "";
+                Slice value(str, strlen(str));
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            }
+            break;
+        }
+        case 9: {
+            // CHARACTER_SET_CLIENT
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(9);
+                const char* str = "utf8";
+                Slice value(str, strlen(str));
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            }
+            break;
+        }
+        case 10: {
+            // COLLATION_CONNECTION
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(10);
+                const char* str = "utf8_general_ci";
+                Slice value(str, strlen(str));
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            }
+            break;
+        }
+        default:
+            break;
+        }
     }
     _table_index++;
     return Status::OK();


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
For https://github.com/StarRocks/starrocks/issues/2976

## Problem Summary(Required) ：

Core improve point: Only fill necessary columns to result chunk.

For SQL:  select count(column_name from information_schema.columns.
Before this PR:  

```
       - FillChunk: 4s966ms
       - NumDiskAccess: 0
       - PeakMemoryUsage: 0
       - RowsRead: 0
       - RowsReturned: 6.08M
```
Afore this PR:  

```
       - FillChunk: 394.469ms
       - NumDiskAccess: 0
       - PeakMemoryUsage: 0
       - RowsRead: 0
       - RowsReturned: 6.08M
```