### PR TITLE
Disable Debug Check in S2

### DIFF
--- a/be/src/geo/geo_types.cpp
+++ b/be/src/geo/geo_types.cpp
@@ -310,7 +310,7 @@ void GeoPolygon::encode(std::string* buf) {
 bool GeoPolygon::decode(const void* data, size_t size) {
     Decoder decoder(data, size);
     _polygon = std::make_unique<S2Polygon>();
-    return _polygon->Decode(&decoder);
+    return _polygon->Decode(&decoder) && _polygon->IsValid();
 }
 
 std::string GeoLine::as_wkt() const {
@@ -484,7 +484,7 @@ void GeoCircle::encode(std::string* buf) {
 bool GeoCircle::decode(const void* data, size_t size) {
     Decoder decoder(data, size);
     _cap = std::make_unique<S2Cap>();
-    return _cap->Decode(&decoder);
+    return _cap->Decode(&decoder) && _cap->is_valid();
 }
 
 std::string GeoCircle::as_wkt() const {

--- a/be/src/service/starrocks_main.cpp
+++ b/be/src/service/starrocks_main.cpp
@@ -57,6 +57,8 @@
 #include "util/thrift_util.h"
 #include "util/uid_util.h"
 
+DECLARE_bool(s2debug);
+
 static void help(const char*);
 
 #include <dlfcn.h>
@@ -95,6 +97,7 @@ int main(int argc, char** argv) {
         fprintf(stderr, "you need set STARROCKS_HOME environment variable.\n");
         exit(-1);
     }
+    FLAGS_s2debug = false;
 
     using starrocks::Status;
     using std::string;

--- a/be/src/service/starrocks_main.cpp
+++ b/be/src/service/starrocks_main.cpp
@@ -97,6 +97,8 @@ int main(int argc, char** argv) {
         fprintf(stderr, "you need set STARROCKS_HOME environment variable.\n");
         exit(-1);
     }
+
+    // S2 will crashes when deserialization fails and FLAGS_s2debug was true
     FLAGS_s2debug = false;
 
     using starrocks::Status;


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
will close #3020

## Problem Summary(Required) ：
S2Cap will Crash in S2 Debug Check, so we should disable it

```
  bool S2Cap::Decode(Decoder* decoder) {
    if (decoder->avail() < 4 * sizeof(double)) return false;
  
    double x = decoder->getdouble();
    double y = decoder->getdouble();
    double z = decoder->getdouble();
    center_ = S2Point(x, y, z);
    radius_ = S1ChordAngle::FromLength2(decoder->getdouble());
  
    if (FLAGS_s2debug) {
       S2_CHECK(is_valid()) << "Invalid S2Cap: " << *this;
    }
    return true;
  }
```
