### PR TITLE
Fix non-pipeline fragment crash when enable pipeline level shuffle

### DIFF
--- a/be/src/runtime/data_stream_recvr.cc
+++ b/be/src/runtime/data_stream_recvr.cc
@@ -460,7 +460,8 @@ Status DataStreamRecvr::SenderQueue::add_chunks(const PTransmitChunkParams& requ
     ChunkQueue chunks;
     size_t total_chunk_bytes = 0;
     faststring uncompressed_buffer;
-    _is_pipeline_level_shuffle = request.has_is_pipeline_level_shuffle() && request.is_pipeline_level_shuffle();
+    _is_pipeline_level_shuffle =
+            _recvr->_is_pipeline && request.has_is_pipeline_level_shuffle() && request.is_pipeline_level_shuffle();
 
     if (use_pass_through) {
         ChunkUniquePtrVector swap_chunks;
@@ -587,7 +588,8 @@ Status DataStreamRecvr::SenderQueue::add_chunks_and_keep_order(const PTransmitCh
     size_t total_chunk_bytes = 0;
     faststring uncompressed_buffer;
     ChunkQueue local_chunk_queue;
-    _is_pipeline_level_shuffle = request.has_is_pipeline_level_shuffle() && request.is_pipeline_level_shuffle();
+    _is_pipeline_level_shuffle =
+            _recvr->_is_pipeline && request.has_is_pipeline_level_shuffle() && request.is_pipeline_level_shuffle();
 
     if (use_pass_through) {
         ChunkUniquePtrVector swap_chunks;


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3037

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

A physical plan may contains multiply fragments, in some cases, some fragments will execute by pipeline engine while others execute by non-pipeline engine. For example, join from native table with external mysql table. And pipeline fragment may interact with non-pipeline fragment through brpc as follows:

```
DataSink(pipeline, using pipeline level shuffle)   --brpc-->  Exchange(non-pipeline)
```

It is expected to work, but some conditions were not handled properly(non-pipeline access `_has_chunks_per_driver_sequence` which is uninitialized and only used in pipeline mode), leading to be crash



