### PR TITLE
Fix wrong reuse of TQueryOptions

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -1947,7 +1947,11 @@ public class Coordinator {
                 params.setCoord(coordAddress);
                 params.setBackend_num(backendNum++);
                 params.setQuery_globals(queryGlobals);
-                params.setQuery_options(new TQueryOptions(queryOptions));
+                if (isEnablePipelineEngine) {
+                    params.setQuery_options(new TQueryOptions(queryOptions));
+                } else {
+                    params.setQuery_options(queryOptions);
+                }
                 params.params.setSend_query_statistics_with_every_batch(
                         fragment.isTransferQueryStatisticsWithEveryBatch());
                 if (queryOptions.getQuery_type() == TQueryType.LOAD) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -1947,7 +1947,7 @@ public class Coordinator {
                 params.setCoord(coordAddress);
                 params.setBackend_num(backendNum++);
                 params.setQuery_globals(queryGlobals);
-                params.setQuery_options(queryOptions);
+                params.setQuery_options(new TQueryOptions(queryOptions));
                 params.params.setSend_query_statistics_with_every_batch(
                         fragment.isTransferQueryStatisticsWithEveryBatch());
                 if (queryOptions.getQuery_type() == TQueryType.LOAD) {
@@ -1969,7 +1969,7 @@ public class Coordinator {
                                 fragment.getPlanRoot().canUsePipeLine() && fragment.getSink().canUsePipeLine();
                         params.setIs_pipeline(isPipeline);
                         if (isPipeline) {
-                            queryOptions.setBatch_size(SessionVariable.PIPELINE_BATCH_SIZE);
+                            params.getQuery_options().setBatch_size(SessionVariable.PIPELINE_BATCH_SIZE);
                         }
                         params.setPipeline_dop(fragment.getPipelineDop());
                         params.setPer_scan_node_dop(instanceExecParam.perScanNodeDop);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes Wrong reuse of TQueryOptions

## Problem Summary(Required) ：
When enable pipeline engine, if some fragment instance is executed with pipeline engine and others with non-pipeline engine, they(**include non-pipeline fragment**) may use both 16384 as chunk_size caused by use with the same TQueryOptoins.
