### PR TITLE
Bugfix: check geo-function except st_astext generted invalid utf8 string

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/FunctionCallExpr.java
@@ -45,6 +45,7 @@ import com.starrocks.mysql.privilege.PrivPredicate;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.analyzer.DecimalV3FunctionAnalyzer;
 import com.starrocks.sql.analyzer.ExprVisitor;
+import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.thrift.TAggregateExpr;
 import com.starrocks.thrift.TExprNode;
 import com.starrocks.thrift.TExprNodeType;
@@ -57,6 +58,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 
 // Our new cost based query optimizer is more powerful and stable than old query optimizer,
 // The old query optimizer related codes could be deleted safely.

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -123,6 +123,10 @@ public class FunctionSet {
     // string functions
     public static final String SUBSTRING = "substring";
 
+    // geo functions
+    public static final String ST_ASTEXT = "st_astext";
+    public static final String GEO_FUNCTION_PREFIX = "st_";
+
     private static final Logger LOG = LogManager.getLogger(FunctionSet.class);
 
     private static final Map<Type, Type> MULTI_DISTINCT_SUM_RETURN_TYPE =

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -103,6 +103,7 @@ public class ExpressionAnalyzer {
         private final ConnectContext session;
         private final Catalog catalog;
 
+
         public Visitor(AnalyzeState analyzeState, Catalog catalog, ConnectContext session) {
             this.analyzeState = analyzeState;
             this.session = session;
@@ -602,6 +603,7 @@ public class ExpressionAnalyzer {
             }
             return fn;
         }
+
 
         @Override
         public Void visitGroupingFunctionCall(GroupingFunctionCallExpr node, Scope scope) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/TestCheckGeoFunctionGeneratedInvalidUtfString.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/TestCheckGeoFunctionGeneratedInvalidUtfString.java
@@ -1,0 +1,58 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.sql.plan;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class TestCheckGeoFunctionGeneratedInvalidUtfString extends PlanTestBase {
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        PlanTestBase.tearDown();
+    }
+
+    @Test
+    public void testFailCases() {
+        String[] cases = new String[]{
+                "select reverse(st_circle(0.2,0.3,0.4))",
+                "select substr(st_circle(0.2,0.3,0.4), 1, 2)",
+                "select concat('abc', 'bcd', 'efg', cast(1 as varchar), st_circle(0.2,0.3,0.4))",
+                "select reverse(cast(st_circle(0.2,0.3,0.4) as varchar))",
+                "select substr(cast(cast(st_circle(0.2,0.3,0.4) as varchar) as varchar), 1, 2)",
+                "select concat('abc', 'bcd', 'efg', cast(1 as varchar), " +
+                        "cast(cast(st_circle(0.2,0.3,0.4) as varchar) as varchar))",
+        };
+        for (String sql : cases) {
+            try {
+                String explain = getFragmentPlan(sql);
+                Assert.fail("should throw SemanticException");
+            } catch (Exception ex) {
+                Assert.assertTrue(ex.getMessage().matches("Function.*cannot invoke.*"));
+            }
+        }
+    }
+
+    @Test
+    public void testSuccessCases() throws Exception {
+        String[] cases = new String[]{
+                "select reverse(st_astext(st_circle(0.2,0.3,0.4)))",
+                "select substr(st_astext(st_circle(0.2,0.3,0.4)), 1, 2)",
+                "select concat('abc', 'bcd', 'efg', cast(1 as varchar), st_astext(st_circle(0.2,0.3,0.4)))",
+                "select reverse(cast(st_astext(st_circle(0.2,0.3,0.4)) as varchar))",
+                "select substr(cast(cast(st_astext(st_circle(0.2,0.3,0.4)) as varchar) as varchar), 1, 2)",
+                "select concat('abc', 'bcd', 'efg', cast(1 as varchar), " +
+                        "cast(cast(st_astext(st_circle(0.2,0.3,0.4)) as varchar) as varchar))",
+        };
+        for (String sql : cases) {
+            String explain = getFragmentPlan(sql);
+            Assert.assertTrue(explain.contains("st_astext(st_circle"));
+        }
+    }
+}


### PR DESCRIPTION
https://github.com/StarRocks/starrocks/issues/3009
Geo functions (except st_astext) that return invalid utf8 string can not be arguments to string-typed parameters of another functions(except at_astext). 
such as: 

1. select as_astext(st_circle(0.1, 0.2, 0.4)) valid
2. select reverse(st_circle(0.1, 0.2, 0.4)) invalid
3. select reverse(as_astext(st_circle(0.1, 0.2, 0.4))) valid