### PR TITLE
Add evaluate logic for text scanner and fix partition column not retu…

### DIFF
--- a/be/src/exec/vectorized/hdfs_scanner_text.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_text.cpp
@@ -20,18 +20,37 @@ public:
         _file_length = file_length;
     }
 
+    void reset(size_t offset, size_t remain_length);
+
+    Status next_record(Record* record);
+
+protected:
     Status _fill_buffer() override;
 
 private:
     std::shared_ptr<RandomAccessFile> _file;
     size_t _offset = 0;
-    size_t _remain_length = 0;
+    int32_t _remain_length = 0;
     size_t _file_length = 0;
     bool _should_stop_scan = false;
 };
 
-Status HdfsScannerCSVReader::_fill_buffer() {
+void HdfsScannerCSVReader::reset(size_t offset, size_t remain_length) {
+    _offset = offset;
+    _remain_length = remain_length;
+    _should_stop_scan = false;
+    _buff.skip(_buff.limit() - _buff.position());
+}
+
+Status HdfsScannerCSVReader::next_record(Record* record) {
     if (_should_stop_scan) {
+        return Status::EndOfFile("Should stop for this reader!");
+    }
+    return CSVReader::next_record(record);
+}
+
+Status HdfsScannerCSVReader::_fill_buffer() {
+    if (_should_stop_scan || _offset >= _file_length) {
         return Status::EndOfFile("HdfsScannerCSVReader");
     }
 
@@ -40,7 +59,8 @@ Status HdfsScannerCSVReader::_fill_buffer() {
     if (_remain_length <= 0) {
         s = Slice(_buff.limit(), _buff.free_space());
     } else {
-        s = Slice(_buff.limit(), std::min(_buff.free_space(), _remain_length));
+        size_t slice_len = _remain_length;
+        s = Slice(_buff.limit(), std::min(_buff.free_space(), slice_len));
     }
     Status st = _file->read(_offset, &s);
     _offset += s.size;
@@ -51,12 +71,15 @@ Status HdfsScannerCSVReader::_fill_buffer() {
     if (st.is_end_of_file()) {
         s.size = 0;
     } else if (!st.ok()) {
+        LOG(WARNING) << "Status is not ok " << st.get_error_msg();
         return st;
     }
     _buff.add_limit(s.size);
     auto n = _buff.available();
     if (s.size == 0 && n == 0) {
         // Has reached the end of file and the buffer is empty.
+        _should_stop_scan = true;
+        LOG(INFO) << "Reach end of file!";
         return Status::EndOfFile(_file->file_name());
     } else if (s.size == 0 && _buff.position()[n - 1] != _record_delimiter) {
         // Has reached the end of file but still no record delimiter found, which
@@ -67,7 +90,7 @@ Status HdfsScannerCSVReader::_fill_buffer() {
     // For each scan range we always read the first record of next scan range,so _remain_length
     // may be negative here. Once we have read the first record of next scan range we
     // should stop scan in the next round.
-    if ((_remain_length < 0 && _buff.find(_record_delimiter, 0) != nullptr) || (_offset >= _file_length)) {
+    if ((_remain_length < 0 && _buff.find(_record_delimiter, 0) != nullptr)) {
         _should_stop_scan = true;
     }
 
@@ -83,15 +106,7 @@ Status HdfsTextScanner::do_init(RuntimeState* runtime_state, const HdfsScannerPa
 }
 
 Status HdfsTextScanner::do_open(RuntimeState* runtime_state) {
-    const THdfsScanRange* scan_range = _scanner_params.scan_ranges[0];
-    _reader = std::make_unique<HdfsScannerCSVReader>(_scanner_params.fs, _record_delimiter, _field_delimiter,
-                                                     scan_range->offset, scan_range->length, scan_range->file_length);
-    if (scan_range->offset != 0) {
-        // Always skip first record of scan range with non-zero offset.
-        // Notice that the first record will read by previous scan range.
-        CSVReader::Record dummy;
-        RETURN_IF_ERROR(_reader->next_record(&dummy));
-    }
+    RETURN_IF_ERROR(_create_or_reinit_reader());
 #ifndef BE_TEST
     SCOPED_TIMER(_scanner_params.parent->_reader_init_timer);
 #endif
@@ -113,10 +128,24 @@ void HdfsTextScanner::do_close(RuntimeState* runtime_state) noexcept {
 }
 
 Status HdfsTextScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) {
-    return _parse_csv(runtime_state->chunk_size(), chunk);
+    CHECK(chunk != nullptr);
+    RETURN_IF_ERROR(parse_csv(runtime_state->chunk_size(), chunk));
+
+    ChunkPtr ck = *chunk;
+    // do stats before we filter rows which does not match.
+    _stats.raw_rows_read += ck->num_rows();
+    for (auto& it : _file_read_param.conjunct_ctxs_by_slot) {
+        // do evaluation.
+        SCOPED_RAW_TIMER(&_stats.expr_filter_ns);
+        ExecNode::eval_conjuncts(it.second, ck.get());
+        if (ck->num_rows() == 0) {
+            break;
+        }
+    }
+    return Status::OK();
 }
 
-Status HdfsTextScanner::_parse_csv(int chunk_size, ChunkPtr* chunk) {
+Status HdfsTextScanner::parse_csv(int chunk_size, ChunkPtr* chunk) {
     DCHECK_EQ(0, chunk->get()->num_rows());
     Status status;
     CSVReader::Record record;
@@ -131,10 +160,19 @@ Status HdfsTextScanner::_parse_csv(int chunk_size, ChunkPtr* chunk) {
     csv::Converter::Options options;
 
     for (size_t num_rows = chunk->get()->num_rows(); num_rows < chunk_size; /**/) {
-        status = _reader->next_record(&record);
+        status = down_cast<HdfsScannerCSVReader*>(_reader.get())->next_record(&record);
         if (status.is_end_of_file()) {
-            break;
+            if (_current_range_index == _scanner_params.scan_ranges.size() - 1) {
+                break;
+            }
+            // End of file status indicate:
+            // 1. read end of file
+            // 2. should stop scan
+            _current_range_index++;
+            RETURN_IF_ERROR(_create_or_reinit_reader());
+            continue;
         } else if (!status.ok()) {
+            LOG(WARNING) << "Status is not ok " << status.get_error_msg();
             return status;
         } else if (record.empty()) {
             // always skip blank lines.
@@ -149,19 +187,56 @@ Status HdfsTextScanner::_parse_csv(int chunk_size, ChunkPtr* chunk) {
         }
 
         bool has_error = false;
-        for (int j = 0, k = 0; j < _scanner_params.materialize_slots.size(); j++) {
+        int num_materialize_columns = _scanner_params.materialize_slots.size();
+        for (int j = 0; j < num_materialize_columns; j++) {
+            int index = _scanner_params.materialize_index_in_chunk[j];
             const Slice& field = fields[_scanner_params.materialize_slots[j]->id() - 1];
             options.type_desc = &(_scanner_params.materialize_slots[j]->type());
-            if (!_converters[k]->read_string(_column_raw_ptrs[k], field, options)) {
+            if (!_converters[j]->read_string(_column_raw_ptrs[index], field, options)) {
                 chunk->get()->set_num_rows(num_rows);
                 has_error = true;
                 break;
             }
-            k++;
         }
         num_rows += !has_error;
+        if (!has_error) {
+            // Partition column not stored in text file, we should append these columns
+            // when we select partition column.
+            int num_part_columns = _file_read_param.partition_columns.size();
+            for (int p = 0; p < num_part_columns; ++p) {
+                int index = _scanner_params.partition_index_in_chunk[p];
+                Column* column = _column_raw_ptrs[index];
+                ColumnPtr partition_value = _file_read_param.partition_values[p];
+                DCHECK(partition_value->is_constant());
+                auto* const_column = vectorized::ColumnHelper::as_raw_column<vectorized::ConstColumn>(partition_value);
+                ColumnPtr data_column = const_column->data_column();
+                if (data_column->is_nullable()) {
+                    column->append_nulls(1);
+                } else {
+                    column->append(*data_column, 0, 1);
+                }
+            }
+        }
     }
     return chunk->get()->num_rows() > 0 ? Status::OK() : Status::EndOfFile("");
+}
+
+Status HdfsTextScanner::_create_or_reinit_reader() {
+    const THdfsScanRange* scan_range = _scanner_params.scan_ranges[_current_range_index];
+    if (_current_range_index == 0) {
+        _reader =
+                std::make_unique<HdfsScannerCSVReader>(_scanner_params.fs, _record_delimiter, _field_delimiter,
+                                                       scan_range->offset, scan_range->length, scan_range->file_length);
+    } else {
+        down_cast<HdfsScannerCSVReader*>(_reader.get())->reset(scan_range->offset, scan_range->length);
+    }
+    if (scan_range->offset != 0) {
+        // Always skip first record of scan range with non-zero offset.
+        // Notice that the first record will read by previous scan range.
+        CSVReader::Record dummy;
+        RETURN_IF_ERROR(down_cast<HdfsScannerCSVReader*>(_reader.get())->next_record(&dummy));
+    }
+    return Status::OK();
 }
 
 } // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/hdfs_scanner_text.h
+++ b/be/src/exec/vectorized/hdfs_scanner_text.h
@@ -17,14 +17,18 @@ public:
     void do_close(RuntimeState* runtime_state) noexcept override;
     Status do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) override;
     Status do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) override;
-    Status _parse_csv(int chunk_size, ChunkPtr* chunk);
+    Status parse_csv(int chunk_size, ChunkPtr* chunk);
 
 private:
+    // create a reader or re init reader
+    Status _create_or_reinit_reader();
+
     using ConverterPtr = std::unique_ptr<csv::Converter>;
     char _record_delimiter;
     string _field_delimiter;
     std::vector<Column*> _column_raw_ptrs;
     std::vector<ConverterPtr> _converters;
     std::shared_ptr<CSVReader> _reader = nullptr;
+    size_t _current_range_index = 0;
 };
 } // namespace starrocks::vectorized


### PR DESCRIPTION
…rn error (#2857)

This pr will close #2783 close #2791 close #2839.
Why we resolve these issues in this single pr?
Because we think the three bugs is related with each other.

More details about this change as below:
- Because we do not add project operator follow hdfs scan node, so we need add filter logic into text scanner.This will close #2791 
- For csv or text file we can not select partition column from original file. So we append partition columns manully to fix partition column can not be selected error. This will close #2783 
- Traverse all the scan ranges assigned to the scanner, and check end of file use offset to fix hdfs readfully error of #2839

## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
