### PR TITLE
[Configuration]Make replication_num configurable

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/ModifyPartitionClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/ModifyPartitionClause.java
@@ -29,7 +29,7 @@ import com.google.common.collect.Maps;
 import com.starrocks.alter.AlterOpType;
 import com.starrocks.catalog.DataProperty;
 import com.starrocks.common.AnalysisException;
-import com.starrocks.common.FeConstants;
+import com.starrocks.common.Config;
 import com.starrocks.common.util.PrintableMap;
 import com.starrocks.common.util.PropertyAnalyzer;
 
@@ -109,7 +109,7 @@ public class ModifyPartitionClause extends AlterTableClause {
 
         // 2. replication num
         short newReplicationNum = (short) -1;
-        newReplicationNum = PropertyAnalyzer.analyzeReplicationNum(properties, FeConstants.default_replication_num);
+        newReplicationNum = PropertyAnalyzer.analyzeReplicationNum(properties, Config.default_cluster_replication_num);
         Preconditions.checkState(newReplicationNum != (short) -1);
 
         // 3. in memory

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/RestoreStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/RestoreStmt.java
@@ -25,9 +25,9 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Config;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
-import com.starrocks.common.FeConstants;
 import com.starrocks.common.UserException;
 import com.starrocks.common.util.PrintableMap;
 
@@ -43,7 +43,7 @@ public class RestoreStmt extends AbstractBackupStmt {
     private static final String PROP_STARROCKS_META_VERSION = "starrocks_meta_version";
 
     private boolean allowLoad = false;
-    private int replicationNum = FeConstants.default_replication_num;
+    private int replicationNum = Config.default_cluster_replication_num;
     private String backupTimestamp = null;
     private int metaVersion = -1;
     private int starrocksMetaVersion = -1;

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/SingleRangePartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/SingleRangePartitionDesc.java
@@ -28,12 +28,10 @@ import com.google.common.collect.Maps;
 import com.starrocks.analysis.PartitionKeyDesc.PartitionRangeType;
 import com.starrocks.catalog.DataProperty;
 import com.starrocks.common.AnalysisException;
-import com.starrocks.common.FeConstants;
+import com.starrocks.common.Config;
 import com.starrocks.common.FeNameFormat;
-import com.starrocks.common.Pair;
 import com.starrocks.common.util.PrintableMap;
 import com.starrocks.common.util.PropertyAnalyzer;
-import com.starrocks.sql.optimizer.base.Property;
 import com.starrocks.thrift.TTabletType;
 
 import java.util.Map;
@@ -64,7 +62,7 @@ public class SingleRangePartitionDesc extends PartitionDesc {
         this.properties = properties;
 
         this.partitionDataProperty = DataProperty.DEFAULT_DATA_PROPERTY;
-        this.replicationNum = FeConstants.default_replication_num;
+        this.replicationNum = Config.default_cluster_replication_num;
     }
 
     public boolean isSetIfNotExists() {
@@ -135,7 +133,7 @@ public class SingleRangePartitionDesc extends PartitionDesc {
         Preconditions.checkNotNull(partitionDataProperty);
 
         // analyze replication num
-        replicationNum = PropertyAnalyzer.analyzeReplicationNum(properties, FeConstants.default_replication_num);
+        replicationNum = PropertyAnalyzer.analyzeReplicationNum(properties, Config.default_cluster_replication_num);
         if (replicationNum == null) {
             throw new AnalysisException("Invalid replication number: " + replicationNum);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -3921,7 +3921,7 @@ public class Catalog {
         }
 
         // analyze replication_num
-        short replicationNum = FeConstants.default_replication_num;
+        short replicationNum = Config.default_cluster_replication_num;
         try {
             boolean isReplicationNumSet =
                     properties != null && properties.containsKey(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -39,8 +39,8 @@ import com.starrocks.catalog.Replica.ReplicaState;
 import com.starrocks.catalog.Tablet.TabletStatus;
 import com.starrocks.clone.TabletSchedCtx;
 import com.starrocks.clone.TabletScheduler;
+import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
-import com.starrocks.common.FeConstants;
 import com.starrocks.common.FeMetaVersion;
 import com.starrocks.common.Pair;
 import com.starrocks.common.io.DeepCopy;
@@ -1441,7 +1441,7 @@ public class OlapTable extends Table {
         if (tableProperty != null) {
             return tableProperty.getReplicationNum();
         }
-        return FeConstants.default_replication_num;
+        return Config.default_cluster_replication_num;
     }
 
     public Boolean isInMemory() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/RangePartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/RangePartitionInfo.java
@@ -28,8 +28,8 @@ import com.google.common.collect.Range;
 import com.starrocks.analysis.PartitionKeyDesc;
 import com.starrocks.analysis.SingleRangePartitionDesc;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
-import com.starrocks.common.FeConstants;
 import com.starrocks.common.FeMetaVersion;
 import com.starrocks.common.util.RangeUtils;
 import org.apache.logging.log4j.LogManager;
@@ -393,7 +393,7 @@ public class RangePartitionInfo extends PartitionInfo {
         String replicationNumStr = table.getTableProperty().getProperties().get("replication_num");
         short replicationNum;
         if (replicationNumStr == null) {
-            replicationNum = FeConstants.default_replication_num;
+            replicationNum = Config.default_cluster_replication_num;
         } else {
             replicationNum = Short.parseShort(replicationNumStr);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -23,7 +23,7 @@ package com.starrocks.catalog;
 
 import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
-import com.starrocks.common.FeConstants;
+import com.starrocks.common.Config;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.common.util.PropertyAnalyzer;
@@ -51,7 +51,7 @@ public class TableProperty implements Writable {
 
     private DynamicPartitionProperty dynamicPartitionProperty = new DynamicPartitionProperty(Maps.newHashMap());
     // table's default replication num
-    private Short replicationNum = FeConstants.default_replication_num;
+    private Short replicationNum = Config.default_cluster_replication_num;
 
     private boolean isInMemory = false;
 
@@ -116,7 +116,7 @@ public class TableProperty implements Writable {
 
     public TableProperty buildReplicationNum() {
         replicationNum = Short.parseShort(properties.getOrDefault(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM,
-                String.valueOf(FeConstants.default_replication_num)));
+                String.valueOf(Config.default_cluster_replication_num)));
         return this;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1357,4 +1357,7 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = true)
     public static long min_routine_load_lag_for_metrics = 10000;
+
+    @ConfField(mutable = true)
+    public static short default_cluster_replication_num = 3;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/FeConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/FeConstants.java
@@ -21,9 +21,8 @@
 
 package com.starrocks.common;
 
+// Database and table's default configurations, we will never change them
 public class FeConstants {
-    // Database and table's default configurations, we will never change them
-    public static short default_replication_num = 3;
     /*
      * Those two fields is responsible for determining the default key columns in duplicate table.
      * If user does not specify key of duplicate table in create table stmt,

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -104,11 +104,11 @@ import com.starrocks.cluster.BaseParam;
 import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.CaseSensibility;
+import com.starrocks.common.Config;
 import com.starrocks.common.ConfigBase;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
-import com.starrocks.common.FeConstants;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.PatternMatcher;
 import com.starrocks.common.proc.BackendsProcDir;
@@ -1439,7 +1439,7 @@ public class ShowExecutor {
                     String tableName = olapTable.getName();
                     int replicationNum = dynamicPartitionProperty.getReplicationNum();
                     replicationNum = (replicationNum == DynamicPartitionProperty.NOT_SET_REPLICATION_NUM) ?
-                            olapTable.getDefaultReplicationNum() : FeConstants.default_replication_num;
+                            olapTable.getDefaultReplicationNum() : Config.default_cluster_replication_num;
                     rows.add(Lists.newArrayList(
                             tableName,
                             String.valueOf(dynamicPartitionProperty.getEnable()),

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
@@ -18,6 +18,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarType;
+import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.UserException;
 import com.starrocks.common.util.MasterDaemon;
@@ -104,7 +105,7 @@ public class StatisticsMetaManager extends MasterDaemon {
         TableName tableName = new TableName(Constants.StatisticsDBName,
                 Constants.StatisticsTableName);
         Map<String, String> properties = Maps.newHashMap();
-        int defaultReplicationNum = Math.min(3,
+        int defaultReplicationNum = Math.min(Config.default_cluster_replication_num,
                 Catalog.getCurrentSystemInfo().getBackendIds(true).size());
         properties.put(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM, Integer.toString(defaultReplicationNum));
         CreateTableStmt stmt = new CreateTableStmt(false, false,


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Now the default `replication_num` is hard code in `FeConstans`, but some cluster may use flewer `replication_num` such as test cluster or the isolated cluster which user do not care the data reliability.

So make it configurable in `fe.conf` with name `default_cluster_replication_num`.
