### PR TITLE
[ResourceIsolation] make one scan operator able to commit multiple i/o tasks

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -643,10 +643,10 @@ CONF_Int64(pipeline_yield_max_chunks_moved, "100");
 CONF_Int64(pipeline_yield_max_time_spent, "100000000");
 // the number of scan threads pipeline engine.
 CONF_Int64(pipeline_scan_thread_pool_thread_num, "0");
-// queue size of scan thread pool for pipeline engine.
-CONF_Int64(pipeline_scan_thread_pool_queue_size, "102400");
 // The max number of io tasks for each scan operator.
 CONF_Int64(pipeline_scan_max_tasks_per_operator, "4");
+// The max number of io tasks for each scan operator.
+CONF_Int64(pipeline_scan_task_yield_max_tims_spent, "100000000");
 // the number of execution threads for pipeline engine.
 CONF_Int64(pipeline_exec_thread_pool_thread_num, "0");
 // the buffer size of io task
@@ -656,6 +656,7 @@ CONF_Int64(pipeline_sink_buffer_size, "64");
 // the degree of parallelism of brpc
 CONF_Int64(pipeline_sink_brpc_dop, "8");
 
+// cpu_limit for each workgroup. It's just for test.
 CONF_Int16(wg0_cpu_limit, "1");
 CONF_Int16(wg1_cpu_limit, "2");
 CONF_Int16(wg2_cpu_limit, "4");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -653,6 +653,11 @@ CONF_Int64(pipeline_io_buffer_size, "64");
 CONF_Int64(pipeline_sink_buffer_size, "64");
 // the degree of parallelism of brpc
 CONF_Int64(pipeline_sink_brpc_dop, "8");
+
+CONF_Int16(wg0_cpu_limit, "1");
+CONF_Int16(wg1_cpu_limit, "2");
+CONF_Int16(wg2_cpu_limit, "4");
+
 // bitmap serialize version
 CONF_Int16(bitmap_serialize_version, "1");
 // max hdfs file handle

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -645,6 +645,8 @@ CONF_Int64(pipeline_yield_max_time_spent, "100000000");
 CONF_Int64(pipeline_scan_thread_pool_thread_num, "0");
 // queue size of scan thread pool for pipeline engine.
 CONF_Int64(pipeline_scan_thread_pool_queue_size, "102400");
+// The max number of io tasks for each scan operator.
+CONF_Int64(pipeline_scan_max_tasks_per_operator, "4");
 // the number of execution threads for pipeline engine.
 CONF_Int64(pipeline_exec_thread_pool_thread_num, "0");
 // the buffer size of io task

--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -187,6 +187,7 @@ set(EXEC_FILES
     pipeline/set/intersect_probe_sink_operator.cpp
     pipeline/set/intersect_output_source_operator.cpp
     workgroup/work_group.cpp
+    workgroup/io_dispatcher.cpp
 )
 
 # simdjson Runtime Implement Dispatch: https://github.com/simdjson/simdjson/blob/master/doc/implementation-selection.md#runtime-cpu-detection

--- a/be/src/exec/pipeline/chunk_source.h
+++ b/be/src/exec/pipeline/chunk_source.h
@@ -34,7 +34,7 @@ public:
 
     virtual StatusOr<vectorized::ChunkPtr> get_next_chunk_from_buffer() = 0;
 
-    virtual Status buffer_next_batch_chunks_blocking(size_t chunk_size, bool& can_finish) = 0;
+    virtual Status buffer_next_batch_chunks_blocking(size_t chunk_size, bool& can_finish, size_t* read_size) = 0;
 
 protected:
     // The morsel will own by pipeline driver

--- a/be/src/exec/pipeline/chunk_source.h
+++ b/be/src/exec/pipeline/chunk_source.h
@@ -34,7 +34,7 @@ public:
 
     virtual StatusOr<vectorized::ChunkPtr> get_next_chunk_from_buffer() = 0;
 
-    virtual Status buffer_next_batch_chunks_blocking(size_t chunk_size, bool& can_finish, size_t* read_size) = 0;
+    virtual Status buffer_next_batch_chunks_blocking(size_t chunk_size, bool& can_finish, size_t* num_read_chunks) = 0;
 
 protected:
     // The morsel will own by pipeline driver

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -230,10 +230,7 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
                                                                     driver_id++, is_root);
                 driver->set_morsel_queue(morsel_queue.get());
                 auto* scan_operator = down_cast<ScanOperator*>(driver->source_operator());
-                scan_operator->set_io_threads(exec_env->pipeline_scan_io_thread_pool());
-                if (wg) {
-                    scan_operator->set_workgroup(wg);
-                }
+                scan_operator->set_workgroup(wg);
                 setup_profile_hierarchy(pipeline, driver);
                 drivers.emplace_back(std::move(driver));
             }

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -231,6 +231,9 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
                 driver->set_morsel_queue(morsel_queue.get());
                 auto* scan_operator = down_cast<ScanOperator*>(driver->source_operator());
                 scan_operator->set_io_threads(exec_env->pipeline_scan_io_thread_pool());
+                if (wg) {
+                    scan_operator->set_workgroup(wg);
+                }
                 setup_profile_hierarchy(pipeline, driver);
                 drivers.emplace_back(std::move(driver));
             }

--- a/be/src/exec/pipeline/morsel.h
+++ b/be/src/exec/pipeline/morsel.h
@@ -57,6 +57,8 @@ public:
         }
     }
 
+    bool empty() const { return _pop_index >= _num_morsels; }
+
 private:
     Morsels _morsels;
     const size_t _num_morsels;

--- a/be/src/exec/pipeline/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/olap_chunk_source.cpp
@@ -294,7 +294,8 @@ StatusOr<vectorized::ChunkPtr> OlapChunkSource::get_next_chunk_from_buffer() {
     return chunk;
 }
 
-Status OlapChunkSource::buffer_next_batch_chunks_blocking(size_t batch_size, bool& can_finish, size_t* read_size) {
+Status OlapChunkSource::buffer_next_batch_chunks_blocking(size_t batch_size, bool& can_finish,
+                                                          size_t* num_read_chunks) {
     if (!_status.ok()) {
         return _status;
     }
@@ -307,13 +308,15 @@ Status OlapChunkSource::buffer_next_batch_chunks_blocking(size_t batch_size, boo
             // end of file is normal case, need process chunk
             if (_status.is_end_of_file()) {
                 _chunk_buffer.put(std::move(chunk));
-                (*read_size)++;
+                ++(*num_read_chunks);
             }
             break;
         }
+
         _chunk_buffer.put(std::move(chunk));
-        (*read_size)++;
+        ++(*num_read_chunks);
     }
+
     return _status;
 }
 

--- a/be/src/exec/pipeline/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/olap_chunk_source.cpp
@@ -307,14 +307,14 @@ Status OlapChunkSource::buffer_next_batch_chunks_blocking(size_t batch_size, boo
         if (!_status.ok()) {
             // end of file is normal case, need process chunk
             if (_status.is_end_of_file()) {
+                (*num_read_chunks) += chunk->num_rows();
                 _chunk_buffer.put(std::move(chunk));
-                ++(*num_read_chunks);
             }
             break;
         }
 
+        (*num_read_chunks) += chunk->num_rows();
         _chunk_buffer.put(std::move(chunk));
-        ++(*num_read_chunks);
     }
 
     return _status;

--- a/be/src/exec/pipeline/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/olap_chunk_source.cpp
@@ -300,21 +300,32 @@ Status OlapChunkSource::buffer_next_batch_chunks_blocking(size_t batch_size, boo
         return _status;
     }
     using namespace vectorized;
+    int64_t time_spent = 0;
+    int64_t total_time_spent = 0;
     for (size_t i = 0; i < batch_size && !can_finish; ++i) {
-        ChunkUniquePtr chunk(
-                ChunkHelper::new_chunk_pooled(_prj_iter->encoded_schema(), _runtime_state->chunk_size(), true));
-        _status = _read_chunk_from_storage(_runtime_state, chunk.get());
-        if (!_status.ok()) {
-            // end of file is normal case, need process chunk
-            if (_status.is_end_of_file()) {
-                (*num_read_chunks) += chunk->num_rows();
-                _chunk_buffer.put(std::move(chunk));
+        {
+            SCOPED_RAW_TIMER(&time_spent);
+
+            ChunkUniquePtr chunk(
+                    ChunkHelper::new_chunk_pooled(_prj_iter->encoded_schema(), _runtime_state->chunk_size(), true));
+            _status = _read_chunk_from_storage(_runtime_state, chunk.get());
+            if (!_status.ok()) {
+                // end of file is normal case, need process chunk
+                if (_status.is_end_of_file()) {
+                    ++(*num_read_chunks);
+                    _chunk_buffer.put(std::move(chunk));
+                }
+                break;
             }
-            break;
+
+            ++(*num_read_chunks);
+            _chunk_buffer.put(std::move(chunk));
         }
 
-        (*num_read_chunks) += chunk->num_rows();
-        _chunk_buffer.put(std::move(chunk));
+        total_time_spent += time_spent;
+        if (total_time_spent >= config::pipeline_scan_task_yield_max_tims_spent) {
+            break;
+        }
     }
 
     return _status;

--- a/be/src/exec/pipeline/olap_chunk_source.h
+++ b/be/src/exec/pipeline/olap_chunk_source.h
@@ -60,7 +60,7 @@ public:
 
     StatusOr<vectorized::ChunkPtr> get_next_chunk_from_buffer() override;
 
-    Status buffer_next_batch_chunks_blocking(size_t chunk_size, bool& can_finish) override;
+    Status buffer_next_batch_chunks_blocking(size_t chunk_size, bool& can_finish, size_t* read_size) override;
 
 private:
     Status _get_tablet(const TInternalScanRange* scan_range);

--- a/be/src/exec/pipeline/olap_chunk_source.h
+++ b/be/src/exec/pipeline/olap_chunk_source.h
@@ -60,7 +60,7 @@ public:
 
     StatusOr<vectorized::ChunkPtr> get_next_chunk_from_buffer() override;
 
-    Status buffer_next_batch_chunks_blocking(size_t chunk_size, bool& can_finish, size_t* read_size) override;
+    Status buffer_next_batch_chunks_blocking(size_t chunk_size, bool& can_finish, size_t* num_read_chunks) override;
 
 private:
     Status _get_tablet(const TInternalScanRange* scan_range);

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -32,7 +32,7 @@ Status PipelineDriver::prepare(RuntimeState* runtime_state) {
     _schedule_counter = ADD_COUNTER(_runtime_profile, "ScheduleCounter", TUnit::UNIT);
     _schedule_effective_counter = ADD_COUNTER(_runtime_profile, "ScheduleEffectiveCounter", TUnit::UNIT);
     _schedule_rows_per_chunk = ADD_COUNTER(_runtime_profile, "ScheduleAccumulatedRowsPerChunk", TUnit::UNIT);
-    _schedule_accumulated_chunk_moved = ADD_COUNTER(_runtime_profile, "ScheduleAccumulatedChunkMoved", TUnit::UNIT);
+    _schedule_accumulated_chunks_moved = ADD_COUNTER(_runtime_profile, "ScheduleAccumulatedChunkMoved", TUnit::UNIT);
 
     DCHECK(_state == DriverState::NOT_READY);
     // fill OperatorWithDependency instances into _dependencies from _operators.
@@ -97,7 +97,7 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state) {
     while (true) {
         RETURN_IF_LIMIT_EXCEEDED(runtime_state, "Pipeline");
 
-        size_t num_chunk_moved = 0;
+        size_t num_chunks_moved = 0;
         bool should_yield = false;
         size_t num_operators = _operators.size();
         size_t _new_first_unfinished = _first_unfinished;
@@ -124,6 +124,7 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state) {
                 }
 
                 if (_check_fragment_is_canceled(runtime_state)) {
+                    _update_statistics(total_chunks_moved, total_rows_moved, time_spent);
                     return _state;
                 }
 
@@ -141,6 +142,7 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state) {
                 }
 
                 if (_check_fragment_is_canceled(runtime_state)) {
+                    _update_statistics(total_chunks_moved, total_rows_moved, time_spent);
                     return _state;
                 }
 
@@ -163,7 +165,7 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state) {
                         COUNTER_UPDATE(next_op->_push_chunk_num_counter, 1);
                         COUNTER_UPDATE(next_op->_push_row_num_counter, row_num);
                     }
-                    num_chunk_moved += 1;
+                    num_chunks_moved += 1;
                     total_chunks_moved += 1;
                 }
 
@@ -194,6 +196,7 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state) {
         if (sink_operator()->is_finished()) {
             finish_operators(runtime_state);
             set_driver_state(is_still_pending_finish() ? DriverState::PENDING_FINISH : DriverState::FINISH);
+            _update_statistics(total_chunks_moved, total_rows_moved, time_spent);
             return _state;
         }
 
@@ -201,11 +204,7 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state) {
         // should yield means that the CPU core is occupied the driver for a
         // very long time so that the driver should switch off the core and
         // give chance for another ready driver to run.
-        if (num_chunk_moved == 0 || should_yield) {
-            driver_acct().increment_schedule_times();
-            driver_acct().update_last_chunks_moved(total_chunks_moved);
-            driver_acct().update_accumulated_rows_moved(total_rows_moved);
-            driver_acct().update_last_time_spent(time_spent);
+        if (num_chunks_moved == 0 || should_yield) {
             if (is_precondition_block()) {
                 set_driver_state(DriverState::PRECONDITION_BLOCK);
             } else if (!sink_operator()->is_finished() && !sink_operator()->need_input()) {
@@ -215,6 +214,7 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state) {
             } else {
                 set_driver_state(DriverState::READY);
             }
+            _update_statistics(total_chunks_moved, total_rows_moved, time_spent);
             return _state;
         }
     }
@@ -294,7 +294,7 @@ void PipelineDriver::finalize(RuntimeState* runtime_state, DriverState state) {
     COUNTER_UPDATE(_schedule_counter, driver_acct().get_schedule_times());
     COUNTER_UPDATE(_schedule_effective_counter, driver_acct().get_schedule_effective_times());
     COUNTER_UPDATE(_schedule_rows_per_chunk, driver_acct().get_rows_per_chunk());
-    COUNTER_UPDATE(_schedule_accumulated_chunk_moved, driver_acct().get_accumulated_chunk_moved());
+    COUNTER_UPDATE(_schedule_accumulated_chunks_moved, driver_acct().get_accumulated_chunks_moved());
     _update_overhead_timer();
 
     // last root driver cancel the all drivers' execution and notify FE the

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -17,9 +17,11 @@
 #include "exec/pipeline/source_operator.h"
 #include "util/phmap/phmap.h"
 namespace starrocks {
+
 namespace workgroup {
 class WorkGroup;
 }
+
 namespace pipeline {
 
 class PipelineDriver;
@@ -74,9 +76,7 @@ static inline std::string ds_to_string(DriverState ds) {
 // for schedule.
 class DriverAcct {
 public:
-    DriverAcct()
-
-    {}
+    DriverAcct() {}
     //TODO:
     // get_level return a non-negative value that is a hint used by DriverQueue to choose
     // the target internal queue for put_back.
@@ -91,7 +91,7 @@ public:
     }
     void update_last_chunks_moved(int64_t chunks_moved) {
         this->last_chunks_moved = chunks_moved;
-        this->accumulated_chunk_moved += chunks_moved;
+        this->accumulated_chunks_moved += chunks_moved;
         this->schedule_effective_times += (chunks_moved > 0) ? 1 : 0;
     }
     void update_accumulated_rows_moved(int64_t rows_moved) { this->accumulated_rows_moved += rows_moved; }
@@ -102,14 +102,14 @@ public:
     int64_t get_schedule_effective_times() { return schedule_effective_times; }
 
     int64_t get_rows_per_chunk() {
-        if (accumulated_chunk_moved > 0) {
-            return accumulated_rows_moved / accumulated_chunk_moved;
+        if (accumulated_chunks_moved > 0) {
+            return accumulated_rows_moved / accumulated_chunks_moved;
         } else {
             return 0;
         }
     }
 
-    int64_t get_accumulated_chunk_moved() { return accumulated_chunk_moved; }
+    int64_t get_accumulated_chunks_moved() { return accumulated_chunks_moved; }
 
 private:
     int64_t schedule_times{0};
@@ -117,7 +117,7 @@ private:
     int64_t last_time_spent{0};
     int64_t last_chunks_moved{0};
     int64_t accumulated_time_spent{0};
-    int64_t accumulated_chunk_moved{0};
+    int64_t accumulated_chunks_moved{0};
     int64_t accumulated_rows_moved{0};
 };
 
@@ -322,9 +322,11 @@ public:
 
     std::string to_readable_string() const;
 
-    starrocks::workgroup::WorkGroup* workgroup();
+    workgroup::WorkGroup* workgroup();
+    void set_workgroup(workgroup::WorkGroup* wg);
 
-    void set_workgroup(starrocks::workgroup::WorkGroup* wg);
+    size_t get_dispatch_queue_index() const { return _dispatch_queue_index; }
+    void set_dispatch_queue_index(size_t dispatch_queue_index) { _dispatch_queue_index = dispatch_queue_index; }
 
 private:
     // check whether fragment is cancelled. It is used before pull_chunk and push_chunk.
@@ -334,6 +336,14 @@ private:
     void _mark_operator_cancelled(OperatorPtr& op, RuntimeState* runtime_state);
     void _mark_operator_closed(OperatorPtr& op, RuntimeState* runtime_state);
     void _close_operators(RuntimeState* runtime_state);
+
+    // Update metrics when the driver yields.
+    void _update_statistics(size_t total_chunks_moved, size_t total_rows_moved, size_t time_spent) {
+        driver_acct().increment_schedule_times();
+        driver_acct().update_last_chunks_moved(total_chunks_moved);
+        driver_acct().update_accumulated_rows_moved(total_rows_moved);
+        driver_acct().update_last_time_spent(time_spent);
+    }
 
     RuntimeState* _runtime_state = nullptr;
     void _update_overhead_timer();
@@ -368,7 +378,9 @@ private:
 
     phmap::flat_hash_map<int32_t, OperatorStage> _operator_stages;
 
-    starrocks::workgroup::WorkGroup* _workgroup = nullptr;
+    workgroup::WorkGroup* _workgroup = nullptr;
+    // The index of QuerySharedDriverQueue._queues which this driver belongs to.
+    size_t _dispatch_queue_index = 0;
 
     // metrics
     RuntimeProfile::Counter* _total_timer = nullptr;
@@ -386,7 +398,7 @@ private:
     RuntimeProfile::Counter* _schedule_counter = nullptr;
     RuntimeProfile::Counter* _schedule_effective_counter = nullptr;
     RuntimeProfile::Counter* _schedule_rows_per_chunk = nullptr;
-    RuntimeProfile::Counter* _schedule_accumulated_chunk_moved = nullptr;
+    RuntimeProfile::Counter* _schedule_accumulated_chunks_moved = nullptr;
 
     MonotonicStopWatch* _total_timer_sw = nullptr;
     MonotonicStopWatch* _pending_timer_sw = nullptr;

--- a/be/src/exec/pipeline/pipeline_driver_dispatcher.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_dispatcher.cpp
@@ -7,8 +7,9 @@
 #include "util/defer_op.h"
 
 namespace starrocks::pipeline {
+
 GlobalDriverDispatcher::GlobalDriverDispatcher(std::unique_ptr<ThreadPool> thread_pool)
-        : _driver_queue(new QuerySharedDriverQueue()),
+        : _driver_queue(std::make_unique<DriverQueueWithWorkGroup>()),
           _thread_pool(std::move(thread_pool)),
           _blocked_driver_poller(new PipelineDriverPoller(_driver_queue.get())),
           _exec_state_reporter(new ExecStateReporter()) {}
@@ -51,8 +52,7 @@ void GlobalDriverDispatcher::run() {
             break;
         }
 
-        size_t queue_index;
-        auto maybe_driver = this->_driver_queue->take(&queue_index);
+        auto maybe_driver = this->_driver_queue->take();
         if (maybe_driver.status().is_cancelled()) {
             return;
         }
@@ -87,7 +87,7 @@ void GlobalDriverDispatcher::run() {
             // query context has ready drivers to run, so extend its lifetime.
             query_ctx->extend_lifetime();
             auto status = driver->process(runtime_state);
-            this->_driver_queue->get_sub_queue(queue_index)->update_accu_time(driver);
+            this->_driver_queue->update_statistics(driver);
 
             if (!status.ok()) {
                 LOG(WARNING) << "[Driver] Process error, query_id=" << print_id(driver->query_ctx()->query_id())
@@ -107,7 +107,7 @@ void GlobalDriverDispatcher::run() {
             switch (driver_state) {
             case READY:
             case RUNNING: {
-                this->_driver_queue->put_back(driver);
+                this->_driver_queue->put_back_from_dispatcher(driver);
                 break;
             }
             case FINISH:
@@ -214,4 +214,5 @@ void GlobalDriverDispatcher::update_profile_by_mode(FragmentContext* fragment_ct
         pipeline_profile->add_info_string("ContainsAllPipelineDrivers", "false");
     }
 }
+
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/pipeline_driver_queue.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_queue.cpp
@@ -163,10 +163,8 @@ void DriverQueueWithWorkGroup::_put_back(const DriverRawPtr driver) {
                 workgroup::WorkGroupManager::instance()->increment_cpu_runtime_ns(diff_real_runtime_ns);
             }
         }
-
         _ready_wgs.emplace(wg);
     }
-
     wg->driver_queue()->put_back(driver);
     _cv.notify_one();
 }

--- a/be/src/exec/pipeline/pipeline_driver_queue.h
+++ b/be/src/exec/pipeline/pipeline_driver_queue.h
@@ -6,10 +6,38 @@
 
 #include "exec/pipeline/pipeline_driver.h"
 #include "util/factory_method.h"
+
 namespace starrocks {
+
+namespace workgroup {
+class WorkGroup;
+}
+
 namespace pipeline {
+
 class DriverQueue;
 using DriverQueuePtr = std::unique_ptr<DriverQueue>;
+
+class DriverQueue {
+public:
+    virtual ~DriverQueue() = default;
+    virtual void close() = 0;
+
+    virtual void put_back(const DriverRawPtr driver) = 0;
+    virtual void put_back(const std::vector<DriverRawPtr>& drivers) = 0;
+    // *from_dispatcher* means that the dispatcher thread puts the driver back to the queue.
+    virtual void put_back_from_dispatcher(const DriverRawPtr driver) = 0;
+    virtual void put_back_from_dispatcher(const std::vector<DriverRawPtr>& drivers) = 0;
+
+    virtual StatusOr<DriverRawPtr> take() = 0;
+
+    // Update statistics of the driver's workgroup,
+    // when yielding the driver in the dispatcher thread.
+    virtual void update_statistics(const DriverRawPtr driver) = 0;
+
+    virtual size_t size() = 0;
+    bool empty() { return size() == 0; }
+};
 
 class SubQuerySharedDriverQueue {
 public:
@@ -27,21 +55,12 @@ private:
     std::atomic<int64_t> _accu_consume_time = 0;
 };
 
-class DriverQueue {
-public:
-    virtual void put_back(const DriverRawPtr driver) = 0;
-    virtual void put_back(const std::vector<DriverRawPtr>& drivers) = 0;
-    virtual StatusOr<DriverRawPtr> take(size_t* queue_index) = 0;
-    virtual ~DriverQueue() = default;
-    virtual void close() = 0;
-    virtual SubQuerySharedDriverQueue* get_sub_queue(size_t) = 0;
-};
-
+// All the QuerySharedDriverQueue's methods MUST be guarded by the outside lock.
 class QuerySharedDriverQueue : public FactoryMethod<DriverQueue, QuerySharedDriverQueue> {
     friend class FactoryMethod<DriverQueue, QuerySharedDriverQueue>;
 
 public:
-    QuerySharedDriverQueue() : _is_closed(false) {
+    QuerySharedDriverQueue() {
         double factor = 1;
         for (int i = QUEUE_SIZE - 1; i >= 0; --i) {
             // initialize factor for every sub queue,
@@ -52,22 +71,75 @@ public:
         }
     }
     ~QuerySharedDriverQueue() override = default;
-    void close() override;
+    void close() override {}
 
-    static const size_t QUEUE_SIZE = 8;
-    // maybe other value for ratio.
-    static constexpr double RATIO_OF_ADJACENT_QUEUE = 1.2;
     void put_back(const DriverRawPtr driver) override;
     void put_back(const std::vector<DriverRawPtr>& drivers) override;
+    void put_back_from_dispatcher(const DriverRawPtr driver) override;
+    void put_back_from_dispatcher(const std::vector<DriverRawPtr>& drivers) override;
+
     // return nullptr if queue is closed;
-    StatusOr<DriverRawPtr> take(size_t* queue_index) override;
-    SubQuerySharedDriverQueue* get_sub_queue(size_t) override;
+    StatusOr<DriverRawPtr> take() override;
+
+    void update_statistics(const DriverRawPtr driver) override;
+
+    size_t size() override { return _size; }
 
 private:
+    void _put_back(const DriverRawPtr driver);
+
+    static constexpr size_t QUEUE_SIZE = 8;
+    static constexpr double RATIO_OF_ADJACENT_QUEUE = 1.2;
+
     SubQuerySharedDriverQueue _queues[QUEUE_SIZE];
+
+    size_t _size = 0;
+};
+
+// DriverQueueWithWorkGroup contains two levels of queues.
+// The first level is the work group queue, and the second level is the driver queue in a work group.
+class DriverQueueWithWorkGroup : public FactoryMethod<DriverQueue, DriverQueueWithWorkGroup> {
+    friend class FactoryMethod<DriverQueue, DriverQueueWithWorkGroup>;
+
+public:
+    ~DriverQueueWithWorkGroup() override = default;
+    void close() override;
+
+    void put_back(const DriverRawPtr driver) override;
+    void put_back(const std::vector<DriverRawPtr>& drivers) override;
+    // When the driver's workgroup is not in the workgroup queue
+    // and the driver isn't from a dispatcher thread (that is, from the poller or new driver),
+    // the workgroup's vruntime is adjusted to workgroup_queue.min_vruntime-ideal_runtime/2,
+    // to avoid sloping too much time to this workgroup.
+    void put_back_from_dispatcher(const DriverRawPtr driver) override;
+    void put_back_from_dispatcher(const std::vector<DriverRawPtr>& drivers) override;
+
+    // Firstly, select the work group with the minimum vruntime.
+    // Secondly, select the proper driver from the driver queue of this work group.
+    StatusOr<DriverRawPtr> take() override;
+
+    void update_statistics(const DriverRawPtr driver) override;
+
+    size_t size() override;
+
+private:
+    // The schedule period is equal to DISPATCH_PERIOD_PER_WG_NS * num_workgroups.
+    static constexpr int64_t DISPATCH_PERIOD_PER_WG_NS = 200'1000'1000;
+
+    // This method should be guarded by the outside _global_mutex.
+    template <bool from_dispatcher>
+    void _put_back(const DriverRawPtr driver);
+    // This method should be guarded by the outside _global_mutex.
+    workgroup::WorkGroup* _find_min_wg();
+    // The ideal runtime of a work group is the weighted average of the schedule period.
+    int64_t _ideal_runtime_ns(workgroup::WorkGroup* wg);
+
     std::mutex _global_mutex;
     std::condition_variable _cv;
-    bool _is_closed;
+    std::unordered_set<workgroup::WorkGroup*> _wgs;
+    size_t _sum_cpu_limit = 0;
+
+    bool _is_closed = false;
 };
 
 } // namespace pipeline

--- a/be/src/exec/pipeline/pipeline_driver_queue.h
+++ b/be/src/exec/pipeline/pipeline_driver_queue.h
@@ -136,7 +136,8 @@ private:
 
     std::mutex _global_mutex;
     std::condition_variable _cv;
-    std::unordered_set<workgroup::WorkGroup*> _wgs;
+    // _ready_wgs contains the workgroups which include the drivers need to be run.
+    std::unordered_set<workgroup::WorkGroup*> _ready_wgs;
     size_t _sum_cpu_limit = 0;
 
     bool _is_closed = false;

--- a/be/src/exec/pipeline/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan_operator.cpp
@@ -4,6 +4,7 @@
 
 #include "column/chunk.h"
 #include "exec/pipeline/olap_chunk_source.h"
+#include "exec/workgroup/work_group.h"
 #include "runtime/current_thread.h"
 #include "runtime/descriptors.h"
 #include "runtime/exec_env.h"
@@ -11,6 +12,8 @@
 #include "util/defer_op.h"
 
 namespace starrocks::pipeline {
+
+using starrocks::workgroup::WorkGroupManager;
 
 Status ScanOperator::prepare(RuntimeState* state) {
     SourceOperator::prepare(state);
@@ -114,6 +117,9 @@ StatusOr<vectorized::ChunkPtr> ScanOperator::pull_chunk(RuntimeState* state) {
     }
 
     eval_runtime_bloom_filters(chunk.value().get());
+    if (_workgroup != nullptr) {
+        _workgroup->decrease_chunk_num(1);
+    }
 
     return chunk;
 }
@@ -127,14 +133,29 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state) {
         {
             SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(state->instance_mem_tracker());
             _chunk_source->buffer_next_batch_chunks_blocking(_buffer_size, _is_finished);
+            if (this->_workgroup != nullptr) {
+                // TODO (by laotan332): More detailed information is needed
+                this->_workgroup->increase_chunk_num(_buffer_size);
+            }
         }
         _is_io_task_active.store(false, std::memory_order_release);
     };
     // TODO(by satanson): set a proper priority
     task.priority = 20;
-    if (_io_threads->try_offer(task)) {
-        _io_task_retry_cnt = 0;
+    bool assign_ok = false;
+    if (_workgroup != nullptr) {
+        if (WorkGroupManager::instance()->try_offer_io_task(_workgroup, task)) {
+            _io_task_retry_cnt = 0;
+            assign_ok = true;
+        }
     } else {
+        if (_io_threads->try_offer(task)) {
+            _io_task_retry_cnt = 0;
+            assign_ok = true;
+        }
+    }
+
+    if (!assign_ok) {
         _is_io_task_active.store(false, std::memory_order_release);
         // TODO(hcf) set a proper retry times
         LOG(WARNING) << "ScanOperator failed to offer io task due to thread pool overload, retryCnt="
@@ -144,6 +165,10 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state) {
         }
     }
     return Status::OK();
+}
+
+void ScanOperator::set_workgroup(starrocks::workgroup::WorkGroupPtr wg) {
+    _workgroup = wg;
 }
 
 Status ScanOperator::_pickup_morsel(RuntimeState* state) {

--- a/be/src/exec/pipeline/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan_operator.cpp
@@ -132,10 +132,11 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state) {
     task.work_function = [this, state]() {
         {
             SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(state->instance_mem_tracker());
-            _chunk_source->buffer_next_batch_chunks_blocking(_buffer_size, _is_finished);
+            size_t read_size = 0;
+            _chunk_source->buffer_next_batch_chunks_blocking(_buffer_size, _is_finished, &read_size);
             if (this->_workgroup != nullptr) {
                 // TODO (by laotan332): More detailed information is needed
-                this->_workgroup->increase_chunk_num(_buffer_size);
+                this->_workgroup->increase_chunk_num(read_size);
             }
         }
         _is_io_task_active.store(false, std::memory_order_release);

--- a/be/src/exec/pipeline/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan_operator.cpp
@@ -96,7 +96,7 @@ StatusOr<vectorized::ChunkPtr> ScanOperator::pull_chunk(RuntimeState* state) {
             auto&& chunk = chunk_source->get_next_chunk_from_buffer();
 
             eval_runtime_bloom_filters(chunk.value().get());
-            _workgroup->decrease_chunk_num(chunk.value()->num_rows());
+            _workgroup->decrease_chunk_num(1);
 
             return std::move(chunk);
         }

--- a/be/src/exec/pipeline/scan_operator.h
+++ b/be/src/exec/pipeline/scan_operator.h
@@ -5,12 +5,16 @@
 #include <optional>
 
 #include "exec/pipeline/source_operator.h"
+#include "exec/workgroup/work_group.h"
 #include "exprs/vectorized/runtime_filter_bank.h"
 #include "runtime/global_dicts.h"
 #include "util/blocking_queue.hpp"
 #include "util/priority_thread_pool.hpp"
 
 namespace starrocks {
+namespace workgroup {
+class WorkGroup;
+}
 namespace vectorized {
 class RuntimeFilterProbeCollector;
 }
@@ -42,6 +46,8 @@ public:
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
     void set_io_threads(PriorityThreadPool* io_threads) { _io_threads = io_threads; }
 
+    void set_workgroup(starrocks::workgroup::WorkGroupPtr wg);
+
 private:
     // This method is only invoked when current morsel is reached eof
     // and all cached chunk of this morsel has benn read out
@@ -63,6 +69,8 @@ private:
     // Pass limit info to scan operator in order to improve sql:
     // select * from table limit x;
     int64_t _limit; // -1: no limit
+
+    starrocks::workgroup::WorkGroupPtr _workgroup = nullptr;
 };
 
 class ScanOperatorFactory final : public SourceOperatorFactory {

--- a/be/src/exec/pipeline/source_operator.h
+++ b/be/src/exec/pipeline/source_operator.h
@@ -28,7 +28,6 @@ public:
 
 protected:
     MorselQueue* _morsel_queue;
-    ChunkSourcePtr _chunk_source;
 };
 
 class SourceOperatorFactory : public OperatorFactory {

--- a/be/src/exec/workgroup/io_dispatcher.cpp
+++ b/be/src/exec/workgroup/io_dispatcher.cpp
@@ -1,0 +1,35 @@
+#include "io_dispatcher.h"
+
+namespace starrocks::workgroup {
+
+IoDispatcher::IoDispatcher(std::unique_ptr<ThreadPool> thread_pool) : _thread_pool(std::move(thread_pool)) {}
+
+void IoDispatcher::initialize(int num_threads) {
+    _num_threads_setter.set_actual_num(num_threads);
+    for (auto i = 0; i < num_threads; ++i) {
+        _thread_pool->submit_func([this]() { this->run(); });
+    }
+}
+
+void IoDispatcher::change_num_threads(int32_t num_threads) {
+    int32_t old_num_threads = 0;
+    if (!_num_threads_setter.adjust_expect_num(num_threads, &old_num_threads)) {
+        return;
+    }
+    for (int i = old_num_threads; i < num_threads; ++i) {
+        _thread_pool->submit_func([this]() { this->run(); });
+    }
+}
+
+void IoDispatcher::run() {
+    while (true) {
+        if (_num_threads_setter.should_shrink()) {
+            break;
+        }
+
+        auto task = WorkGroupManager::instance()->pick_next_task_for_io();
+        task.work_function();
+    }
+}
+
+} // namespace starrocks::workgroup

--- a/be/src/exec/workgroup/io_dispatcher.h
+++ b/be/src/exec/workgroup/io_dispatcher.h
@@ -14,7 +14,8 @@ class WorkGroupManager;
 class IoDispatcher {
 public:
     explicit IoDispatcher(std::unique_ptr<ThreadPool> thread_pool);
-    virtual ~IoDispatcher() = default;
+    virtual ~IoDispatcher();
+
     void initialize(int32_t num_threads);
     void change_num_threads(int32_t num_threads);
 

--- a/be/src/exec/workgroup/io_dispatcher.h
+++ b/be/src/exec/workgroup/io_dispatcher.h
@@ -1,0 +1,30 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+#pragma once
+#include <memory>
+
+#include "util/limit_setter.h"
+#include "util/threadpool.h"
+#include "work_group.h"
+
+namespace starrocks {
+namespace workgroup {
+class IoDispatcher;
+class WorkGroupManager;
+
+class IoDispatcher {
+public:
+    explicit IoDispatcher(std::unique_ptr<ThreadPool> thread_pool);
+    virtual ~IoDispatcher() = default;
+    void initialize(int32_t num_threads);
+    void change_num_threads(int32_t num_threads);
+
+private:
+    void run();
+
+private:
+    LimitSetter _num_threads_setter;
+    std::unique_ptr<ThreadPool> _thread_pool;
+};
+
+} // namespace workgroup
+} // namespace starrocks

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -2,8 +2,8 @@
 
 #include "exec/workgroup/work_group.h"
 
+#include "gen_cpp/internal_service.pb.h"
 #include "runtime/exec_env.h"
-
 namespace starrocks {
 namespace workgroup {
 WorkGroup::WorkGroup(const std::string& name, int id, size_t cpu_limit, size_t memory_limit, size_t concurrency,
@@ -15,6 +15,39 @@ WorkGroup::WorkGroup(const std::string& name, int id, size_t cpu_limit, size_t m
           _concurrency(concurrency),
           _type(type) {}
 
+WorkGroup::WorkGroup(const TWorkGroup& twg) : _name(twg.name), _id(twg.id) {
+    if (twg.__isset.cpu_limit) {
+        _cpu_limit = twg.cpu_limit;
+    } else {
+        _cpu_limit = -1;
+    }
+    if (twg.__isset.memory_limit) {
+        _memory_limit = twg.memory_limit;
+    } else {
+        _memory_limit = -1;
+    }
+    if (twg.__isset.concurrency) {
+        _concurrency = twg.concurrency;
+    } else {
+        _concurrency = -1;
+    }
+    if (twg.__isset.type) {
+        switch (twg.type) {
+        case TWorkGroupType::WG_NORMAL:
+            _type = WG_NORMAL;
+            break;
+        case TWorkGroupType::WG_DEFAULT:
+            _type = WG_DEFAULT;
+            break;
+        case TWorkGroupType::WG_REALTIME:
+            _type = WG_REALTIME;
+            break;
+        }
+    } else {
+        _type = WG_NORMAL;
+    }
+}
+
 void WorkGroup::init() {
     _mem_tracker = std::make_shared<starrocks::MemTracker>(_memory_limit, _name,
                                                            ExecEnv::GetInstance()->query_pool_mem_tracker());
@@ -23,14 +56,27 @@ void WorkGroup::init() {
 
 WorkGroupManager::WorkGroupManager() {}
 WorkGroupManager::~WorkGroupManager() {}
+void WorkGroupManager::destroy() {
+    std::lock_guard<std::mutex> lock(_mutex);
+    this->_workgroups.clear();
+}
 
-void WorkGroupManager::add_workgroup(const WorkGroupPtr& wg) {
+WorkGroupPtr WorkGroupManager::add_workgroup(const WorkGroupPtr& wg) {
     std::lock_guard<std::mutex> lock(_mutex);
     if (!_workgroups.count(wg->id())) {
         _workgroups[wg->id()] = wg;
         _wg_cpu_queue.add(wg);
         _wg_io_queue.add(wg);
+        return wg;
+    } else {
+        return _workgroups[wg->id()];
     }
+}
+
+WorkGroupPtr WorkGroupManager::get_default_workgroup() {
+    std::lock_guard<std::mutex> lock(_mutex);
+    DCHECK(_workgroups.count(WorkGroup::DEFAULT_WG_ID));
+    return _workgroups[WorkGroup::DEFAULT_WG_ID];
 }
 
 void WorkGroupManager::remove_workgroup(int wg_id) {
@@ -59,16 +105,17 @@ WorkGroupQueue& WorkGroupManager::get_io_queue() {
     return _wg_io_queue;
 }
 
-namespace {
-class DefaultWorkGroupInitialization {
-public:
-    DefaultWorkGroupInitialization() {
-        auto default_wg = std::make_shared<WorkGroup>("default_wg", 1, 10, 10, 10, WorkGroupType::WG_DEFAULT);
-        default_wg->init();
-        WorkGroupManager::instance()->add_workgroup(default_wg);
-    }
-} _;
-} // namespace
+DefaultWorkGroupInitialization::DefaultWorkGroupInitialization() {
+    auto default_wg = std::make_shared<WorkGroup>("default_wg", 0, 1, 20L * (1L << 30), 10, WorkGroupType::WG_DEFAULT);
+    default_wg->init();
+    auto wg1 = std::make_shared<WorkGroup>("wg1", 1, 2, 10L * (1L << 30), 10, WorkGroupType::WG_NORMAL);
+    wg1->init();
+    auto wg2 = std::make_shared<WorkGroup>("wg2", 2, 4, 30L * (1L << 30), 10, WorkGroupType::WG_NORMAL);
+    wg2->init();
+    WorkGroupManager::instance()->add_workgroup(default_wg);
+    WorkGroupManager::instance()->add_workgroup(wg1);
+    WorkGroupManager::instance()->add_workgroup(wg2);
+}
 
 } // namespace workgroup
 } // namespace starrocks

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -67,6 +67,14 @@ double WorkGroup::get_cpu_actual_use_ratio() const {
     return static_cast<double>(get_real_runtime_ns()) / sum_cpu_runtime_ns;
 }
 
+double WorkGroup::get_cpu_unadjusted_actual_use_ratio() const {
+    int64_t sum_cpu_runtime_ns = WorkGroupManager::instance()->get_sum_unadjusted_cpu_runtime_ns();
+    if (sum_cpu_runtime_ns == 0) {
+        return 0;
+    }
+    return static_cast<double>(_unadjusted_real_runtime_ns) / sum_cpu_runtime_ns;
+}
+
 WorkGroupManager::WorkGroupManager() {}
 WorkGroupManager::~WorkGroupManager() {}
 void WorkGroupManager::destroy() {

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -6,14 +6,15 @@
 #include "runtime/exec_env.h"
 namespace starrocks {
 namespace workgroup {
+
 WorkGroup::WorkGroup(const std::string& name, int id, size_t cpu_limit, size_t memory_limit, size_t concurrency,
                      WorkGroupType type)
         : _name(name),
           _id(id),
+          _type(type),
           _cpu_limit(cpu_limit),
           _memory_limit(memory_limit),
-          _concurrency(concurrency),
-          _type(type) {}
+          _concurrency(concurrency) {}
 
 WorkGroup::WorkGroup(const TWorkGroup& twg) : _name(twg.name), _id(twg.id) {
     if (twg.__isset.cpu_limit) {
@@ -54,6 +55,14 @@ void WorkGroup::init() {
     _driver_queue = std::make_unique<starrocks::pipeline::QuerySharedDriverQueue>();
 }
 
+double WorkGroup::get_cpu_expected_use_ratio() const {
+    return static_cast<double>(_cpu_limit) / WorkGroupManager::instance()->get_sum_cpu_limit();
+}
+
+double WorkGroup::get_cpu_actual_use_ratio() const {
+    return static_cast<double>(get_real_runtime_ns()) / WorkGroupManager::instance()->get_sum_cpu_runtime_ns();
+}
+
 WorkGroupManager::WorkGroupManager() {}
 WorkGroupManager::~WorkGroupManager() {}
 void WorkGroupManager::destroy() {
@@ -65,8 +74,8 @@ WorkGroupPtr WorkGroupManager::add_workgroup(const WorkGroupPtr& wg) {
     std::lock_guard<std::mutex> lock(_mutex);
     if (!_workgroups.count(wg->id())) {
         _workgroups[wg->id()] = wg;
-        _wg_cpu_queue.add(wg);
         _wg_io_queue.add(wg);
+        _sum_cpu_limit += wg->get_cpu_limit();
         return wg;
     } else {
         return _workgroups[wg->id()];
@@ -83,22 +92,14 @@ void WorkGroupManager::remove_workgroup(int wg_id) {
     std::lock_guard<std::mutex> lock(_mutex);
     if (_workgroups.count(wg_id)) {
         auto wg = std::move(_workgroups[wg_id]);
+        _sum_cpu_limit -= wg->get_cpu_limit();
         _workgroups.erase(wg_id);
-        _wg_cpu_queue.remove(wg);
         _wg_io_queue.remove(wg);
     }
 }
 
-WorkGroupPtr WorkGroupManager::pick_next_wg_for_cpu() {
-    return _wg_cpu_queue.pick_next();
-}
-
 WorkGroupPtr WorkGroupManager::pick_next_wg_for_io() {
     return _wg_io_queue.pick_next();
-}
-
-WorkGroupQueue& WorkGroupManager::get_cpu_queue() {
-    return _wg_cpu_queue;
 }
 
 WorkGroupQueue& WorkGroupManager::get_io_queue() {

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -60,7 +60,11 @@ double WorkGroup::get_cpu_expected_use_ratio() const {
 }
 
 double WorkGroup::get_cpu_actual_use_ratio() const {
-    return static_cast<double>(get_real_runtime_ns()) / WorkGroupManager::instance()->get_sum_cpu_runtime_ns();
+    int64_t sum_cpu_runtime_ns = WorkGroupManager::instance()->get_sum_cpu_runtime_ns();
+    if (sum_cpu_runtime_ns == 0) {
+        return 0;
+    }
+    return static_cast<double>(get_real_runtime_ns()) / sum_cpu_runtime_ns;
 }
 
 WorkGroupManager::WorkGroupManager() {}

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -3,7 +3,9 @@
 #include "exec/workgroup/work_group.h"
 
 #include "gen_cpp/internal_service.pb.h"
+#include "glog/logging.h"
 #include "runtime/exec_env.h"
+
 namespace starrocks {
 namespace workgroup {
 
@@ -11,10 +13,14 @@ WorkGroup::WorkGroup(const std::string& name, int id, size_t cpu_limit, size_t m
                      WorkGroupType type)
         : _name(name),
           _id(id),
-          _type(type),
           _cpu_limit(cpu_limit),
           _memory_limit(memory_limit),
-          _concurrency(concurrency) {}
+          _concurrency(concurrency),
+          _type(type) {
+    _expect_factor = _cpu_expect_use_ratio;
+    _select_factor = _expect_factor;
+    _cur_select_factor = _select_factor;
+}
 
 WorkGroup::WorkGroup(const TWorkGroup& twg) : _name(twg.name), _id(twg.id) {
     if (twg.__isset.cpu_limit) {
@@ -67,14 +73,6 @@ double WorkGroup::get_cpu_actual_use_ratio() const {
     return static_cast<double>(get_real_runtime_ns()) / sum_cpu_runtime_ns;
 }
 
-double WorkGroup::get_cpu_unadjusted_actual_use_ratio() const {
-    int64_t sum_cpu_runtime_ns = WorkGroupManager::instance()->get_sum_unadjusted_cpu_runtime_ns();
-    if (sum_cpu_runtime_ns == 0) {
-        return 0;
-    }
-    return static_cast<double>(_unadjusted_real_runtime_ns) / sum_cpu_runtime_ns;
-}
-
 WorkGroupManager::WorkGroupManager() {}
 WorkGroupManager::~WorkGroupManager() {}
 void WorkGroupManager::destroy() {
@@ -110,12 +108,245 @@ void WorkGroupManager::remove_workgroup(int wg_id) {
     }
 }
 
-WorkGroupPtr WorkGroupManager::pick_next_wg_for_io() {
-    return _wg_io_queue.pick_next();
+bool WorkGroup::try_offer_io_task(const PriorityThreadPool::Task& task) {
+    _io_work_queue.emplace(std::move(task));
+    return true;
+}
+
+PriorityThreadPool::Task WorkGroup::pick_io_task() {
+    PriorityThreadPool::Task task = std::move(_io_work_queue.front());
+    _io_work_queue.pop();
+    return task;
+}
+
+// shuold be call when read chunk_num from disk
+void WorkGroup::increase_chunk_num(int32_t chunk_num) {
+    _cur_hold_total_chunk_num += chunk_num;
+    _increase_chunk_num_period += chunk_num;
+}
+
+void WorkGroup::decrease_chunk_num(int32_t chunk_num) {
+    _cur_hold_total_chunk_num -= chunk_num;
+    _decrease_chunk_num_period += chunk_num;
+}
+
+double WorkGroup::get_expect_factor() const {
+    return _expect_factor;
+}
+
+double WorkGroup::get_diff_factor() const {
+    return _diff_factor;
+}
+
+double WorkGroup::get_select_factor() const {
+    return _select_factor;
+}
+
+void WorkGroup::set_select_factor(double value) {
+    _select_factor = value;
+}
+
+void WorkGroup::update_select_factor(double value) {
+    _select_factor += value;
+}
+
+double WorkGroup::get_cur_select_factor() const {
+    return _cur_select_factor;
+}
+
+void WorkGroup::update_cur_select_factor(double value) {
+    _cur_select_factor += value;
+}
+
+void WorkGroup::estimate_trend_factor_period() {
+    // As an example
+    // During the execution period, This WorkGroup actually consumes 70 chunks and uses 80% of the cpu resources
+    // But in reality, the WorkGroup's cpu resources are limited to 70% of
+    // At the same time, the WorkGroup reads 200 chunks from io_threads
+    // Therefore, we calculate the correlation factor as follows
+    // decrease_factor = 70 / 0.8 * (0.7 / 0.8)
+    // increase_factor = 200 / 0.7
+    // _expect_factor indicates the percentage of io resources we expect the WorkGroup to use so that it meets the 70% cpu limit
+    // so _expect_factor = decrease_factor / increase_factor * 70
+
+    double decrease_factor = _decrease_chunk_num_period / get_cpu_actual_use_ratio() * get_cpu_expected_use_ratio() /
+                             get_cpu_actual_use_ratio();
+    double increase_factor = _increase_chunk_num_period / get_cpu_actual_use_ratio();
+
+    _expect_factor = decrease_factor / increase_factor * get_cpu_expected_use_ratio();
+
+    // diff_factor indicates the difference between the actual percentage of io resources used and the limited cpu percentage
+    // If it is negative, it means that there are not enough resources and more resources are needed
+    // If it is positive, it means that its resources are sufficient and can be reduced by a fraction
+    //_diff_factor = get_cpu_expected_use_ratio() - _expect_factor;
+    _diff_factor = _select_factor - _expect_factor;
+
+    // reset
+    _decrease_chunk_num_period = 1;
+    _increase_chunk_num_period = 1;
+}
+
+size_t WorkGroup::io_task_queue_size() {
+    return _io_work_queue.size();
+}
+
+void IoWorkGroupQueue::adjust_weight_if_need() {
+    if (--_cur_schedule_num > 0) {
+        return;
+    }
+
+    _io_wgs.clear();
+    for (const auto& wg : _ready_wgs) {
+        _io_wgs.push_back(wg);
+    }
+
+    // calculate all wg factors
+    for (auto const& wg : _io_wgs) {
+        wg->estimate_trend_factor_period();
+    }
+
+    // negative_total_diff_factor Accumulate All Under-resourced WorkGroup
+    // positive_total_diff_factor Cumulative All Resource Excess WorkGroup
+    double positive_total_diff_factor = 0.0;
+    double negative_total_diff_factor = 0.0;
+    for (auto const& wg : _io_wgs) {
+        if (wg->get_diff_factor() > 0) {
+            positive_total_diff_factor += wg->get_diff_factor();
+        } else {
+            negative_total_diff_factor += wg->get_diff_factor();
+        }
+    }
+
+    if (_schedule_num_period > _total_task_num) {
+        _cur_schedule_num_period = _total_task_num;
+    } else {
+        _cur_schedule_num_period = _schedule_num_period;
+    }
+
+    // If positive_total_diff_factor <= 0, it This means that all WorkGs have no excess resources
+    // So we don't need to adjust it and keep the original limit
+    if (positive_total_diff_factor <= 0) {
+        for (auto const& wg : _io_wgs) {
+            wg->set_select_factor(wg->get_cpu_expected_use_ratio());
+        }
+        schedule_io_task();
+        _cur_schedule_num = _cur_schedule_num_period;
+        return;
+    }
+
+    // As an example
+    // There are two WorkGroups A and B
+    // A _expect_factor : 0.18757812499999998, and _cpu_expect_use_ratio : 0.7, _diff_factor : 0.512421875
+    // B _expect_factor : 0.6749999999999999, and _cpu_expect_use_ratio : 0.3, _diff_factor :  -0.37499999999999994
+    // so 0.18757812499999998 + 0.6749999999999999 < 1.0, it mean resource is enough, and available is  -0.37499999999999994 + 0.512421875
+
+    if (positive_total_diff_factor + negative_total_diff_factor > 0) {
+        // if positive_total_diff_factor + negative_total_diff_factor > 0
+        // This means that the resources are sufficient
+        // So we can reduce the proportion of resources in the WorkGroup that are over-resourced
+        // Then increase the proportion of resources for those WorkGs that are under-resourced
+        for (auto const& wg : _io_wgs) {
+            if (wg->get_diff_factor() < 0) {
+                wg->update_select_factor(0 - negative_total_diff_factor * wg->get_diff_factor() /
+                                                     negative_total_diff_factor);
+            } else if (wg->get_diff_factor() > 0) {
+                wg->update_select_factor(negative_total_diff_factor * wg->get_diff_factor() /
+                                         positive_total_diff_factor);
+            }
+        }
+    } else {
+        // if positive_total_diff_factor + negative_total_diff_factor <= 0
+        // This means that there are not enough resources, but some WorkGs are still over-resourced
+        // So we can reduce the proportion of resources in the WorkGroup that are over-resourced
+        // Then increase the proportion of resources for those WorkGs that are under-resourced
+        for (auto const& wg : _io_wgs) {
+            if (wg->get_diff_factor() < 0) {
+                wg->update_select_factor(positive_total_diff_factor * wg->get_diff_factor() /
+                                         negative_total_diff_factor);
+            } else if (wg->get_diff_factor() > 0) {
+                wg->update_select_factor(0 - positive_total_diff_factor * wg->get_diff_factor() /
+                                                     positive_total_diff_factor);
+            }
+        }
+    }
+
+    schedule_io_task();
+    _cur_schedule_num = _cur_schedule_num_period;
+}
+
+void IoWorkGroupQueue::schedule_io_task() {
+    // In a scheduling period, we calculate in advance
+    for (size_t i = 0; i < _cur_schedule_num_period; i++) {
+        size_t idx = get_next_wg_index();
+        _cur_wait_run_wgs[i] = _io_wgs[idx];
+    }
+    _cur_index = 0;
+}
+
+size_t IoWorkGroupQueue::get_next_wg_index() {
+    int index = -1;
+    double total = 0;
+    for (int i = 0; i < _io_wgs.size(); i++) {
+        _io_wgs[i]->update_cur_select_factor(_io_wgs[i]->get_select_factor());
+        total += _io_wgs[i]->get_select_factor();
+        if (index == -1 || _io_wgs[i]->get_cur_select_factor() > _io_wgs[index]->get_cur_select_factor()) {
+            index = i;
+        }
+    }
+    _io_wgs[index]->update_cur_select_factor(0 - total);
+    return index;
+}
+
+WorkGroupPtr IoWorkGroupQueue::get_next_wg() {
+    int index = _cur_index++;
+    if (index < _cur_schedule_num_period) {
+        return _cur_wait_run_wgs[index];
+    }
+
+    return nullptr;
+}
+
+PriorityThreadPool::Task IoWorkGroupQueue::pick_next_task() {
+    std::unique_lock<std::mutex> lock(_global_io_mutex);
+    while (_ready_wgs.empty()) {
+        _cv.wait(lock);
+    }
+    WorkGroupPtr wg = nullptr;
+    do {
+        adjust_weight_if_need();
+        wg = get_next_wg();
+    } while (wg == nullptr || wg->io_task_queue_size() == 0);
+
+    if (wg->io_task_queue_size() == 1) {
+        _ready_wgs.erase(wg);
+    }
+    _total_task_num--;
+
+    return wg->pick_io_task();
+}
+
+PriorityThreadPool::Task WorkGroupManager::pick_next_task_for_io() {
+    return _wg_io_queue.pick_next_task();
 }
 
 WorkGroupQueue& WorkGroupManager::get_io_queue() {
     return _wg_io_queue;
+}
+
+bool IoWorkGroupQueue::try_offer_io_task(WorkGroupPtr wg, const PriorityThreadPool::Task& task) {
+    std::lock_guard<std::mutex> lock(_global_io_mutex);
+    wg->try_offer_io_task(task);
+    if (_ready_wgs.find(wg) == _ready_wgs.end()) {
+        _ready_wgs.emplace(wg);
+    }
+
+    _total_task_num++;
+    _cv.notify_one();
+    return true;
+}
+
+bool WorkGroupManager::try_offer_io_task(WorkGroupPtr wg, const PriorityThreadPool::Task& task) {
+    return _wg_io_queue.try_offer_io_task(wg, task);
 }
 
 DefaultWorkGroupInitialization::DefaultWorkGroupInitialization() {
@@ -128,6 +359,10 @@ DefaultWorkGroupInitialization::DefaultWorkGroupInitialization() {
     WorkGroupManager::instance()->add_workgroup(default_wg);
     WorkGroupManager::instance()->add_workgroup(wg1);
     WorkGroupManager::instance()->add_workgroup(wg2);
+
+    default_wg->set_select_factor(default_wg->get_cpu_expected_use_ratio());
+    wg1->set_select_factor(wg1->get_cpu_expected_use_ratio());
+    wg2->set_select_factor(wg2->get_cpu_expected_use_ratio());
 }
 
 } // namespace workgroup

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -13,14 +13,10 @@ WorkGroup::WorkGroup(const std::string& name, int id, size_t cpu_limit, size_t m
                      WorkGroupType type)
         : _name(name),
           _id(id),
+          _type(type),
           _cpu_limit(cpu_limit),
           _memory_limit(memory_limit),
-          _concurrency(concurrency),
-          _type(type) {
-    _expect_factor = _cpu_expect_use_ratio;
-    _select_factor = _expect_factor;
-    _cur_select_factor = _select_factor;
-}
+          _concurrency(concurrency) {}
 
 WorkGroup::WorkGroup(const TWorkGroup& twg) : _name(twg.name), _id(twg.id) {
     if (twg.__isset.cpu_limit) {
@@ -81,41 +77,6 @@ double WorkGroup::get_cpu_actual_use_ratio() const {
     return static_cast<double>(get_real_runtime_ns()) / sum_cpu_runtime_ns;
 }
 
-WorkGroupManager::WorkGroupManager() {}
-WorkGroupManager::~WorkGroupManager() {}
-void WorkGroupManager::destroy() {
-    std::lock_guard<std::mutex> lock(_mutex);
-    this->_workgroups.clear();
-}
-
-WorkGroupPtr WorkGroupManager::add_workgroup(const WorkGroupPtr& wg) {
-    std::lock_guard<std::mutex> lock(_mutex);
-    if (!_workgroups.count(wg->id())) {
-        _workgroups[wg->id()] = wg;
-        _wg_io_queue.add(wg);
-        _sum_cpu_limit += wg->get_cpu_limit();
-        return wg;
-    } else {
-        return _workgroups[wg->id()];
-    }
-}
-
-WorkGroupPtr WorkGroupManager::get_default_workgroup() {
-    std::lock_guard<std::mutex> lock(_mutex);
-    DCHECK(_workgroups.count(WorkGroup::DEFAULT_WG_ID));
-    return _workgroups[WorkGroup::DEFAULT_WG_ID];
-}
-
-void WorkGroupManager::remove_workgroup(int wg_id) {
-    std::lock_guard<std::mutex> lock(_mutex);
-    if (_workgroups.count(wg_id)) {
-        auto wg = std::move(_workgroups[wg_id]);
-        _sum_cpu_limit -= wg->get_cpu_limit();
-        _workgroups.erase(wg_id);
-        _wg_io_queue.remove(wg);
-    }
-}
-
 bool WorkGroup::try_offer_io_task(const PriorityThreadPool::Task& task) {
     _io_work_queue.emplace(std::move(task));
     return true;
@@ -127,7 +88,7 @@ PriorityThreadPool::Task WorkGroup::pick_io_task() {
     return task;
 }
 
-// shuold be call when read chunk_num from disk
+// Should be call when read chunk_num from disk.
 void WorkGroup::increase_chunk_num(int32_t chunk_num) {
     _cur_hold_total_chunk_num += chunk_num;
     _increase_chunk_num_period += chunk_num;
@@ -188,28 +149,15 @@ void WorkGroup::estimate_trend_factor_period() {
     // If it is positive, it means that its resources are sufficient and can be reduced by a fraction
     //_diff_factor = get_cpu_expected_use_ratio() - _expect_factor;
     _diff_factor = _select_factor - _expect_factor;
-
-    // reset
-    _decrease_chunk_num_period = 1;
-    _increase_chunk_num_period = 1;
 }
 
 size_t WorkGroup::io_task_queue_size() {
     return _io_work_queue.size();
 }
 
-void IoWorkGroupQueue::adjust_weight_if_need() {
-    if (--_cur_schedule_num > 0) {
-        return;
-    }
-
-    _io_wgs.clear();
-    for (const auto& wg : _ready_wgs) {
-        _io_wgs.push_back(wg);
-    }
-
+void IoWorkGroupQueue::_adjust_weight() {
     // calculate all wg factors
-    for (auto const& wg : _io_wgs) {
+    for (auto& wg : _ready_wgs) {
         wg->estimate_trend_factor_period();
     }
 
@@ -217,7 +165,7 @@ void IoWorkGroupQueue::adjust_weight_if_need() {
     // positive_total_diff_factor Cumulative All Resource Excess WorkGroup
     double positive_total_diff_factor = 0.0;
     double negative_total_diff_factor = 0.0;
-    for (auto const& wg : _io_wgs) {
+    for (auto const& wg : _ready_wgs) {
         if (wg->get_diff_factor() > 0) {
             positive_total_diff_factor += wg->get_diff_factor();
         } else {
@@ -225,20 +173,12 @@ void IoWorkGroupQueue::adjust_weight_if_need() {
         }
     }
 
-    if (_schedule_num_period > _total_task_num) {
-        _cur_schedule_num_period = _total_task_num;
-    } else {
-        _cur_schedule_num_period = _schedule_num_period;
-    }
-
     // If positive_total_diff_factor <= 0, it This means that all WorkGs have no excess resources
     // So we don't need to adjust it and keep the original limit
     if (positive_total_diff_factor <= 0) {
-        for (auto const& wg : _io_wgs) {
+        for (auto& wg : _ready_wgs) {
             wg->set_select_factor(wg->get_cpu_expected_use_ratio());
         }
-        schedule_io_task();
-        _cur_schedule_num = _cur_schedule_num_period;
         return;
     }
 
@@ -253,7 +193,7 @@ void IoWorkGroupQueue::adjust_weight_if_need() {
         // This means that the resources are sufficient
         // So we can reduce the proportion of resources in the WorkGroup that are over-resourced
         // Then increase the proportion of resources for those WorkGs that are under-resourced
-        for (auto const& wg : _io_wgs) {
+        for (auto& wg : _ready_wgs) {
             if (wg->get_diff_factor() < 0) {
                 wg->update_select_factor(0 - negative_total_diff_factor * wg->get_diff_factor() /
                                                      negative_total_diff_factor);
@@ -267,7 +207,7 @@ void IoWorkGroupQueue::adjust_weight_if_need() {
         // This means that there are not enough resources, but some WorkGs are still over-resourced
         // So we can reduce the proportion of resources in the WorkGroup that are over-resourced
         // Then increase the proportion of resources for those WorkGs that are under-resourced
-        for (auto const& wg : _io_wgs) {
+        for (auto& wg : _ready_wgs) {
             if (wg->get_diff_factor() < 0) {
                 wg->update_select_factor(positive_total_diff_factor * wg->get_diff_factor() /
                                          negative_total_diff_factor);
@@ -277,74 +217,49 @@ void IoWorkGroupQueue::adjust_weight_if_need() {
             }
         }
     }
-
-    schedule_io_task();
-    _cur_schedule_num = _cur_schedule_num_period;
 }
 
-void IoWorkGroupQueue::schedule_io_task() {
-    // In a scheduling period, we calculate in advance
-    for (size_t i = 0; i < _cur_schedule_num_period; i++) {
-        size_t idx = get_next_wg_index();
-        _cur_wait_run_wgs[i] = _io_wgs[idx];
-    }
-    _cur_index = 0;
-}
-
-size_t IoWorkGroupQueue::get_next_wg_index() {
-    int index = -1;
+WorkGroupPtr IoWorkGroupQueue::_select_next_wg() {
+    WorkGroupPtr max_wg = nullptr;
     double total = 0;
-    for (int i = 0; i < _io_wgs.size(); i++) {
-        _io_wgs[i]->update_cur_select_factor(_io_wgs[i]->get_select_factor());
-        total += _io_wgs[i]->get_select_factor();
-        if (index == -1 || _io_wgs[i]->get_cur_select_factor() > _io_wgs[index]->get_cur_select_factor()) {
-            index = i;
+    for (auto wg : _ready_wgs) {
+        wg->update_cur_select_factor(wg->get_select_factor());
+        total += wg->get_select_factor();
+        if (max_wg == nullptr || wg->get_cur_select_factor() > max_wg->get_cur_select_factor()) {
+            max_wg = wg;
         }
     }
-    _io_wgs[index]->update_cur_select_factor(0 - total);
-    return index;
+    max_wg->update_cur_select_factor(0 - total);
+    return max_wg;
 }
 
-WorkGroupPtr IoWorkGroupQueue::get_next_wg() {
-    int index = _cur_index++;
-    if (index < _cur_schedule_num_period) {
-        return _cur_wait_run_wgs[index];
-    }
-
-    return nullptr;
-}
-
-PriorityThreadPool::Task IoWorkGroupQueue::pick_next_task() {
+StatusOr<PriorityThreadPool::Task> IoWorkGroupQueue::pick_next_task() {
     std::unique_lock<std::mutex> lock(_global_io_mutex);
+
+    if (_is_closed) {
+        return Status::Cancelled("Shutdown");
+    }
     while (_ready_wgs.empty()) {
         _cv.wait(lock);
+        if (_is_closed) {
+            return Status::Cancelled("Shutdown");
+        }
     }
-    WorkGroupPtr wg = nullptr;
-    do {
-        adjust_weight_if_need();
-        wg = get_next_wg();
-        wg->num_selected_io_times++;
-    } while (wg == nullptr || wg->io_task_queue_size() == 0);
-    wg->num_real_selected_io_times++;
 
+    _adjust_weight();
+    WorkGroupPtr wg = _select_next_wg();
     if (wg->io_task_queue_size() == 1) {
         _ready_wgs.erase(wg);
     }
+
     _total_task_num--;
 
     return wg->pick_io_task();
 }
 
-PriorityThreadPool::Task WorkGroupManager::pick_next_task_for_io() {
-    return _wg_io_queue.pick_next_task();
-}
-
-WorkGroupQueue& WorkGroupManager::get_io_queue() {
-    return _wg_io_queue;
-}
-
 bool IoWorkGroupQueue::try_offer_io_task(WorkGroupPtr wg, const PriorityThreadPool::Task& task) {
     std::lock_guard<std::mutex> lock(_global_io_mutex);
+
     wg->try_offer_io_task(task);
     if (_ready_wgs.find(wg) == _ready_wgs.end()) {
         _ready_wgs.emplace(wg);
@@ -353,6 +268,61 @@ bool IoWorkGroupQueue::try_offer_io_task(WorkGroupPtr wg, const PriorityThreadPo
     _total_task_num++;
     _cv.notify_one();
     return true;
+}
+
+void IoWorkGroupQueue::close() {
+    std::lock_guard<std::mutex> lock(_global_io_mutex);
+
+    if (_is_closed) {
+        return;
+    }
+
+    _is_closed = true;
+    _cv.notify_all();
+}
+
+WorkGroupManager::WorkGroupManager() {}
+WorkGroupManager::~WorkGroupManager() {}
+
+void WorkGroupManager::destroy() {
+    std::lock_guard<std::mutex> lock(_mutex);
+    this->_workgroups.clear();
+}
+
+WorkGroupPtr WorkGroupManager::add_workgroup(const WorkGroupPtr& wg) {
+    std::lock_guard<std::mutex> lock(_mutex);
+    if (!_workgroups.count(wg->id())) {
+        _workgroups[wg->id()] = wg;
+        _wg_io_queue.add(wg);
+        _sum_cpu_limit += wg->get_cpu_limit();
+        return wg;
+    } else {
+        return _workgroups[wg->id()];
+    }
+}
+
+WorkGroupPtr WorkGroupManager::get_default_workgroup() {
+    std::lock_guard<std::mutex> lock(_mutex);
+    DCHECK(_workgroups.count(WorkGroup::DEFAULT_WG_ID));
+    return _workgroups[WorkGroup::DEFAULT_WG_ID];
+}
+
+void WorkGroupManager::remove_workgroup(int wg_id) {
+    std::lock_guard<std::mutex> lock(_mutex);
+    if (_workgroups.count(wg_id)) {
+        auto wg = std::move(_workgroups[wg_id]);
+        _sum_cpu_limit -= wg->get_cpu_limit();
+        _workgroups.erase(wg_id);
+        _wg_io_queue.remove(wg);
+    }
+}
+
+void WorkGroupManager::close() {
+    _wg_io_queue.close();
+}
+
+StatusOr<PriorityThreadPool::Task> WorkGroupManager::pick_next_task_for_io() {
+    return _wg_io_queue.pick_next_task();
 }
 
 bool WorkGroupManager::try_offer_io_task(WorkGroupPtr wg, const PriorityThreadPool::Task& task) {
@@ -372,8 +342,7 @@ void WorkGroupManager::log_cpu() {
         LOG(WARNING) << "[TEST] io "
                      << "[select_factor=" << wg->get_select_factor() << "] "
                      << "[cur_hold_total_chunk_num " << wg->get_cur_hold_total_chunk_num() << "] "
-                     << "[selected_io_times=" << wg->num_selected_io_times << "] "
-                     << "[real_selected_io_times=" << wg->num_real_selected_io_times << "] ";
+                     << "[selected_io_times=" << wg->num_selected_io_times << "] ";
     }
     LOG(WARNING) << "[TEST] ===============================";
 }

--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -130,6 +130,7 @@ public:
     double get_expect_factor() const;
     double get_diff_factor() const;
     double get_select_factor() const;
+    int64_t get_cur_hold_total_chunk_num() const { return _cur_hold_total_chunk_num; }
     void set_select_factor(double value);
     void update_select_factor(double value);
     double get_cur_select_factor() const;
@@ -164,7 +165,7 @@ private:
     std::atomic<double> _cpu_actual_use_ratio;
 
     //  some variables for io schedule
-    std::atomic<size_t> _cur_hold_total_chunk_num = 0; // total chunk num wait for consume
+    std::atomic<int64_t> _cur_hold_total_chunk_num = 0; // total chunk num wait for consume
     std::atomic<size_t> _increase_chunk_num_period = 1;
     std::atomic<size_t> _decrease_chunk_num_period = 1;
 
@@ -206,6 +207,9 @@ public:
         _sum_unadjusted_cpu_runtime_ns += cpu_runtime_ns;
     }
     int64_t get_sum_unadjusted_cpu_runtime_ns() const { return _sum_unadjusted_cpu_runtime_ns; }
+    double get_cpu_unadjusted_actual_use_ratio() const;
+
+    void log_cpu();
 
 private:
     std::mutex _mutex;

--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -12,6 +12,7 @@
 #include "storage/olap_define.h"
 
 namespace starrocks {
+class TWorkGroup;
 namespace workgroup {
 
 class WorkGroup;
@@ -58,6 +59,7 @@ class WorkGroup {
 public:
     WorkGroup(const std::string& name, int id, size_t cpu_limit, size_t memory_limit, size_t concurrency,
               WorkGroupType type);
+    WorkGroup(const TWorkGroup& twg);
     ~WorkGroup() = default;
 
     void init();
@@ -74,6 +76,8 @@ public:
         // TODO: implement io priority computation
         return 0;
     }
+
+    static constexpr int DEFAULT_WG_ID = 0;
 
 private:
     std::string _name;
@@ -95,7 +99,11 @@ class WorkGroupManager {
 
 public:
     // add a new workgroup to WorkGroupManger
-    void add_workgroup(const WorkGroupPtr& wg);
+    WorkGroupPtr add_workgroup(const WorkGroupPtr& wg);
+    // return reserved beforehand default workgroup for query is not bound to any workgroup
+    WorkGroupPtr get_default_workgroup();
+    // destruct workgroups
+    void destroy();
     // remove already-existing workgroup from WorkGroupManager
     void remove_workgroup(int wg_id);
     // get next workgroup for computation
@@ -112,6 +120,11 @@ private:
     std::unordered_map<int, WorkGroupPtr> _workgroups;
     CpuWorkGroupQueue _wg_cpu_queue;
     IoWorkGroupQueue _wg_io_queue;
+};
+
+class DefaultWorkGroupInitialization {
+public:
+    DefaultWorkGroupInitialization();
 };
 
 } // namespace workgroup

--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -12,7 +12,9 @@
 #include "storage/olap_define.h"
 
 namespace starrocks {
+
 class TWorkGroup;
+
 namespace workgroup {
 
 class WorkGroup;
@@ -25,15 +27,6 @@ public:
     virtual void add(const WorkGroupPtr& wg) = 0;
     virtual void remove(const WorkGroupPtr& wg) = 0;
     virtual WorkGroupPtr pick_next() = 0;
-};
-
-class CpuWorkGroupQueue final : public WorkGroupQueue {
-public:
-    CpuWorkGroupQueue() = default;
-    ~CpuWorkGroupQueue() = default;
-    void add(const WorkGroupPtr& wg) override {}
-    void remove(const WorkGroupPtr& wg) override {}
-    WorkGroupPtr pick_next() override { return nullptr; }
 };
 
 class IoWorkGroupQueue final : public WorkGroupQueue {
@@ -64,30 +57,45 @@ public:
 
     void init();
 
-    starrocks::MemTracker* mem_tracker() { return _mem_tracker.get(); }
-    starrocks::pipeline::DriverQueue* driver_queue() { return _driver_queue.get(); }
+    MemTracker* mem_tracker() { return _mem_tracker.get(); }
+    pipeline::DriverQueue* driver_queue() { return _driver_queue.get(); }
 
     int id() const { return _id; }
-    int get_cpu_priority() {
-        // TODO: implement cpu priority computation
-        return 0;
-    }
+
+    const std::string& name() const { return _name; }
+
     int get_io_priority() {
         // TODO: implement io priority computation
         return 0;
     }
+
+    size_t get_cpu_limit() const { return _cpu_limit; }
+    int64_t get_vruntime_ns() const { return _vruntime_ns; }
+    int64_t get_real_runtime_ns() const { return _vruntime_ns * _cpu_limit; }
+    // Accumulate virtual runtime divided by _cpu_limit, so that the larger _cpu_limit,
+    // the more cpu time can be consumed proportionally.
+    void increment_real_runtime_ns(int64_t real_runtime_ns) { _vruntime_ns += real_runtime_ns / _cpu_limit; }
+    void set_vruntime_ns(int64_t vruntime_ns) { _vruntime_ns = vruntime_ns; }
+
+    double get_cpu_expected_use_ratio() const;
+    double get_cpu_actual_use_ratio() const;
 
     static constexpr int DEFAULT_WG_ID = 0;
 
 private:
     std::string _name;
     int _id;
+    WorkGroupType _type;
+
     size_t _cpu_limit;
     size_t _memory_limit;
     size_t _concurrency;
-    WorkGroupType _type;
-    std::shared_ptr<starrocks::MemTracker> _mem_tracker;
-    starrocks::pipeline::DriverQueuePtr _driver_queue;
+
+    std::shared_ptr<starrocks::MemTracker> _mem_tracker = nullptr;
+
+    pipeline::DriverQueuePtr _driver_queue = nullptr;
+    int64_t _vruntime_ns = 0;
+
     // it's proper to define Context as a Thrift or protobuf struct.
     // WorkGroupContext _context;
 };
@@ -106,20 +114,23 @@ public:
     void destroy();
     // remove already-existing workgroup from WorkGroupManager
     void remove_workgroup(int wg_id);
-    // get next workgroup for computation
-    WorkGroupPtr pick_next_wg_for_cpu();
+
     // get next workgroup for io
     WorkGroupPtr pick_next_wg_for_io();
-
-    WorkGroupQueue& get_cpu_queue();
-
     WorkGroupQueue& get_io_queue();
+
+    size_t get_sum_cpu_limit() const { return _sum_cpu_limit; }
+    void increment_cpu_runtime_ns(int64_t cpu_runtime_ns) { _sum_cpu_runtime_ns += cpu_runtime_ns; }
+    int64_t get_sum_cpu_runtime_ns() const { return _sum_cpu_runtime_ns; }
 
 private:
     std::mutex _mutex;
+
     std::unordered_map<int, WorkGroupPtr> _workgroups;
-    CpuWorkGroupQueue _wg_cpu_queue;
     IoWorkGroupQueue _wg_io_queue;
+
+    std::atomic<size_t> _sum_cpu_limit = 0;
+    std::atomic<int64_t> _sum_cpu_runtime_ns = 0;
 };
 
 class DefaultWorkGroupInitialization {

--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -136,6 +136,10 @@ public:
     double get_cur_select_factor() const;
     void update_cur_select_factor(double value);
 
+    // TODO(ZiheLiu): remove them. They are just for test.
+    std::atomic<int> num_selected_io_times = 0;
+    std::atomic<int> num_real_selected_io_times = 0;
+
 private:
     std::string _name;
     int _id;
@@ -209,6 +213,7 @@ public:
     int64_t get_sum_unadjusted_cpu_runtime_ns() const { return _sum_unadjusted_cpu_runtime_ns; }
     double get_cpu_unadjusted_actual_use_ratio() const;
 
+    // TODO(ZiheLiu): remove it. It is just for test.
     void log_cpu();
 
 private:

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -134,13 +134,7 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths) {
     _thread_pool = new PriorityThreadPool("olap_scan_io", // olap scan io
                                           config::doris_scanner_thread_pool_thread_num,
                                           config::doris_scanner_thread_pool_queue_size);
-    _pipeline_scan_io_thread_pool = new PriorityThreadPool("pip_scan_io", // pipeline scan io
-                                                           config::pipeline_scan_thread_pool_thread_num <= 0
-                                                                   ? std::thread::hardware_concurrency()
-                                                                   : config::pipeline_scan_thread_pool_thread_num,
-                                                           config::pipeline_scan_thread_pool_queue_size);
 
-    _num_scan_operators = 0;
     _etl_thread_pool = new PriorityThreadPool("elt", config::etl_thread_pool_size, config::etl_thread_pool_queue_size);
     _fragment_mgr = new FragmentMgr(this);
 
@@ -362,10 +356,6 @@ void ExecEnv::_destroy() {
     if (_etl_thread_pool) {
         delete _etl_thread_pool;
         _etl_thread_pool = nullptr;
-    }
-    if (_pipeline_scan_io_thread_pool) {
-        delete _pipeline_scan_io_thread_pool;
-        _pipeline_scan_io_thread_pool = nullptr;
     }
     if (_io_dispatcher) {
         delete _io_dispatcher;

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -28,6 +28,7 @@
 #include "common/logging.h"
 #include "exec/pipeline/pipeline_driver_dispatcher.h"
 #include "exec/pipeline/pipeline_fwd.h"
+#include "exec/workgroup/work_group.h"
 #include "gen_cpp/BackendService.h"
 #include "gen_cpp/FrontendService.h"
 #include "gen_cpp/HeartbeatService_types.h"
@@ -252,6 +253,8 @@ Status ExecEnv::init_mem_tracker() {
     SetMemTrackerForColumnPool op(_column_pool_mem_tracker);
     vectorized::ForEach<vectorized::ColumnPoolList>(op);
 
+    //TODO(by satanson): for verification of Resource Isolation.
+    starrocks::workgroup::DefaultWorkGroupInitialization default_workgroup_init;
     return Status::OK();
 }
 
@@ -393,6 +396,8 @@ void ExecEnv::_destroy() {
         delete _load_mem_tracker;
         _load_mem_tracker = nullptr;
     }
+    // WorkGroupManager should release MemTracker of WorkGroups belongs to itself before deallocate _query_pool_mem_tracker.
+    starrocks::workgroup::WorkGroupManager::instance()->destroy();
     if (_query_pool_mem_tracker) {
         delete _query_pool_mem_tracker;
         _query_pool_mem_tracker = nullptr;

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -67,6 +67,10 @@ namespace pipeline {
 class DriverDispatcher;
 }
 
+namespace workgroup {
+class IoDispatcher;
+}
+
 // Execution environment for queries/plan fragments.
 // Contains all required global structures, and handles to
 // singleton services. Clients must call StartServices exactly
@@ -137,6 +141,8 @@ public:
     LoadChannelMgr* load_channel_mgr() { return _load_channel_mgr; }
     LoadStreamMgr* load_stream_mgr() { return _load_stream_mgr; }
     SmallFileMgr* small_file_mgr() { return _small_file_mgr; }
+
+    starrocks::workgroup::IoDispatcher* io_dispatcher() { return _io_dispatcher; }
 
     const std::vector<StorePath>& store_paths() const { return _store_paths; }
     void set_store_paths(const std::vector<StorePath>& paths) { _store_paths = paths; }
@@ -225,6 +231,8 @@ private:
     PluginMgr* _plugin_mgr = nullptr;
 
     RuntimeFilterWorker* _runtime_filter_worker = nullptr;
+
+    starrocks::workgroup::IoDispatcher* _io_dispatcher = nullptr;
 };
 
 template <>

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -127,9 +127,6 @@ public:
 
     ThreadResourceMgr* thread_mgr() { return _thread_mgr; }
     PriorityThreadPool* thread_pool() { return _thread_pool; }
-    PriorityThreadPool* pipeline_scan_io_thread_pool() { return _pipeline_scan_io_thread_pool; }
-    size_t increment_num_scan_operators(size_t n) { return _num_scan_operators.fetch_add(n); }
-    size_t decrement_num_scan_operators(size_t n) { return _num_scan_operators.fetch_sub(n); }
     PriorityThreadPool* etl_thread_pool() { return _etl_thread_pool; }
     FragmentMgr* fragment_mgr() { return _fragment_mgr; }
     starrocks::pipeline::DriverDispatcher* driver_dispatcher() { return _driver_dispatcher; }
@@ -207,8 +204,6 @@ private:
 
     ThreadResourceMgr* _thread_mgr = nullptr;
     PriorityThreadPool* _thread_pool = nullptr;
-    PriorityThreadPool* _pipeline_scan_io_thread_pool = nullptr;
-    std::atomic<size_t> _num_scan_operators;
     PriorityThreadPool* _etl_thread_pool = nullptr;
     FragmentMgr* _fragment_mgr = nullptr;
     starrocks::pipeline::DriverDispatcher* _driver_dispatcher = nullptr;

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -81,7 +81,7 @@ public:
     // Specific parts of the fragment (i.e. exec nodes, sinks, data stream senders, etc)
     // will add a fourth level when they are initialized.
     // This function also initializes a user function mem tracker (in the fourth level).
-    void init_mem_trackers(const TUniqueId& query_id);
+    void init_mem_trackers(const TUniqueId& query_id, MemTracker* parent = nullptr);
 
     // for ut only
     Status init_instance_mem_tracker();

--- a/be/src/util/thread.cpp
+++ b/be/src/util/thread.cpp
@@ -23,6 +23,7 @@
 
 #include <fmt/format.h>
 #include <sys/prctl.h>
+#include <sys/resource.h>
 #include <sys/types.h>
 #include <unistd.h>
 
@@ -185,6 +186,18 @@ int64_t Thread::tid() const {
         return _tid;
     }
     return wait_for_tid();
+}
+
+Status Thread::set_os_priority(int32_t new_os_thread_priority) {
+    int64_t os_tid = tid();
+#if defined(OS_LINUX)
+    if (new_os_thread_priority) {
+        if (0 != setpriority(PRIO_PROCESS, os_tid, new_os_thread_priority)) {
+            return Status::NotSupported("Cannot setpriority");
+        }
+    }
+#endif
+    return Status::OK();
 }
 
 pthread_t Thread::pthread_id() const {

--- a/be/src/util/thread.h
+++ b/be/src/util/thread.h
@@ -98,6 +98,8 @@ public:
     // started.
     int64_t tid() const;
 
+    Status set_os_priority(int32_t new_os_thread_priority);
+
     // Returns the thread's pthread ID.
     pthread_t pthread_id() const;
 

--- a/be/src/util/threadpool.cpp
+++ b/be/src/util/threadpool.cpp
@@ -443,6 +443,13 @@ bool ThreadPool::wait_for(const MonoDelta& delta) {
                                [&]() { return _total_queued_tasks <= 0 && _active_threads <= 0; });
 }
 
+void ThreadPool::set_os_priority(int32_t new_os_thread_priority) {
+    std::unique_lock l(_lock);
+    for (auto& thread : _threads) {
+        thread->set_os_priority(new_os_thread_priority);
+    }
+}
+
 void ThreadPool::dispatch_thread() {
     std::unique_lock l(_lock);
     InsertOrDie(&_threads, Thread::current_thread());

--- a/be/src/util/threadpool.h
+++ b/be/src/util/threadpool.h
@@ -199,6 +199,8 @@ public:
         return _num_threads + _num_threads_pending_start;
     }
 
+    void set_os_priority(int32_t new_os_thread_priority);
+
 private:
     friend class ThreadPoolBuilder;
     friend class ThreadPoolToken;

--- a/be/test/exec/pipeline/pipeline_test_base.cpp
+++ b/be/test/exec/pipeline/pipeline_test_base.cpp
@@ -7,6 +7,7 @@
 #include "column/nullable_column.h"
 #include "exec/pipeline/fragment_context.h"
 #include "exec/pipeline/pipeline_driver_dispatcher.h"
+#include "exec/workgroup/work_group.h"
 #include "runtime/date_value.h"
 #include "runtime/timestamp_value.h"
 #include "storage/vectorized/chunk_helper.h"
@@ -116,6 +117,11 @@ void PipelineTestBase::_prepare() {
     }
 
     _fragment_ctx->set_drivers(std::move(drivers));
+
+    auto wg = workgroup::WorkGroupManager::instance()->get_default_workgroup();
+    for (auto& driver : _fragment_ctx->drivers()) {
+        driver->set_workgroup(wg.get());
+    }
 }
 
 void PipelineTestBase::_execute() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -2000,8 +2000,8 @@ public class Coordinator {
                         params.setPipeline_dop(fragment.getPipelineDop());
                         // TODO (by satanson): just for verification of resource isolation.
                         TWorkGroup wg = new TWorkGroup();
-                        wg.name = "";
-                        wg.id = ConnectContext.get().getSessionVariable().getWorkgroupId();
+                        wg.setName("");
+                        wg.setId(ConnectContext.get().getSessionVariable().getWorkgroupId());
                         params.setWorkgroup(wg);
                     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -95,6 +95,7 @@ import com.starrocks.thrift.TScanRangeParams;
 import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TTabletCommitInfo;
 import com.starrocks.thrift.TUniqueId;
+import com.starrocks.thrift.TWorkGroup;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
@@ -1997,6 +1998,11 @@ public class Coordinator {
                         params.setIs_pipeline(
                                 fragment.getPlanRoot().canUsePipeLine() && fragment.getSink().canUsePipeLine());
                         params.setPipeline_dop(fragment.getPipelineDop());
+                        // TODO (by satanson): just for verification of resource isolation.
+                        TWorkGroup wg = new TWorkGroup();
+                        wg.name = "";
+                        wg.id = ConnectContext.get().getSessionVariable().getWorkgroupId();
+                        params.setWorkgroup(wg);
                     }
 
                     if (sessionVariable.isEnableExchangePassThrough()) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -118,6 +118,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String PIPELINE_PROFILE_MODE = "pipeline_profile_mode";
 
+    public static final String WORKGROUP_ID = "workgroup_id";
+
     // hash join right table push down
     public static final String HASH_JOIN_PUSH_DOWN_RIGHT_TABLE = "hash_join_push_down_right_table";
 
@@ -317,6 +319,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = PIPELINE_PROFILE_MODE)
     private String pipelineProfileMode = "brief";
+
+    @VariableMgr.VarAttr(name = WORKGROUP_ID)
+    private int workgroupId = 0;
 
     @VariableMgr.VarAttr(name = ENABLE_INSERT_STRICT)
     private boolean enableInsertStrict = true;
@@ -720,6 +725,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public int getPipelineDop() {
         return this.pipelineDop;
+    }
+
+    public int getWorkgroupId() {
+        return workgroupId;
     }
 
     public boolean isEnableReplicationJoin() {

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -249,6 +249,21 @@ enum InternalServiceVersion {
   V1
 }
 
+enum TWorkGroupType {
+    WG_NORMAL,
+    WG_DEFAULT,
+    WG_REALTIME
+}
+
+struct TWorkGroup {
+    1: optional i32 id
+    2: optional string name
+    3: optional i64 cpu_limit
+    4: optional i64 memory_limit
+    5: optional i64 concurrency
+    6: optional TWorkGroupType type
+}
+
 // ExecPlanFragment
 
 struct TExecPlanFragmentParams {
@@ -295,6 +310,8 @@ struct TExecPlanFragmentParams {
 
   50: optional bool is_pipeline
   51: optional i32 pipeline_dop
+  52: optional map<Types.TPlanNodeId, i32> per_scan_node_dop
+  53: optional TWorkGroup workgroup
 }
 
 struct TExecPlanFragmentResult {
@@ -440,3 +457,4 @@ struct TExportStatusResult {
     2: required Types.TExportState state
     3: optional list<string> files
 }
+


### PR DESCRIPTION
## What type of PR is this
- [x] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Problem Summary
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The small query has too little scan operators, and the bottleneck of small query is at scan i/o task. Therefore, the workgroup with larger cpu_limit cannot get more io/task to execute, which causes there isn't resource isolation between different workgroups for small query.

In this PR, we make on scan operator able to commit at most 4 i/o tasks.

What's more, we remove prefetch of next to be executed `num_schedule` workgroups for i/o dispatcher, because the overhead of calculating which workgroup to be executed is not large, and a new ready workgroup may be delayed `num_schedule` times.



