### PR TITLE
Imporve CTE local coordinate

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/DataPartition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DataPartition.java
@@ -54,13 +54,18 @@ public class DataPartition {
     private ImmutableList<Expr> partitionExprs;
 
     public DataPartition(TPartitionType type, List<Expr> exprs) {
-        Preconditions.checkNotNull(exprs);
-        Preconditions.checkState(!exprs.isEmpty());
-        Preconditions.checkState(
-                type == TPartitionType.HASH_PARTITIONED || type == TPartitionType.RANGE_PARTITIONED
-                        || type == TPartitionType.BUCKET_SHFFULE_HASH_PARTITIONED);
-        this.type = type;
-        this.partitionExprs = ImmutableList.copyOf(exprs);
+        if (type != TPartitionType.UNPARTITIONED && type != TPartitionType.RANDOM) {
+            Preconditions.checkNotNull(exprs);
+            Preconditions.checkState(!exprs.isEmpty());
+            Preconditions.checkState(
+                    type == TPartitionType.HASH_PARTITIONED || type == TPartitionType.RANGE_PARTITIONED
+                            || type == TPartitionType.BUCKET_SHFFULE_HASH_PARTITIONED);
+            this.type = type;
+            this.partitionExprs = ImmutableList.copyOf(exprs);
+        } else {
+            this.type = type;
+            this.partitionExprs = ImmutableList.of();
+        }
     }
 
     public void substitute(ExprSubstitutionMap smap, Analyzer analyzer) throws AnalysisException {
@@ -101,16 +106,6 @@ public class DataPartition {
             result.setPartition_exprs(Expr.treesToThrift(partitionExprs));
         }
         return result;
-    }
-
-    /**
-     * Returns true if 'this' is a partition that is compatible with the
-     * requirements of 's'.
-     * TODO: specify more clearly and implement
-     */
-    public boolean isCompatible(DataPartition s) {
-        // TODO: implement
-        return true;
     }
 
     public String getExplainString(TExplainLevel explainLevel) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/MultiCastPlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/MultiCastPlanFragment.java
@@ -52,7 +52,7 @@ public class MultiCastPlanFragment extends PlanFragment {
 
         for (ExchangeNode f : destNodeList) {
             DataStreamSink streamSink = new DataStreamSink(f.getId());
-            streamSink.setPartition(f.getFragment().getOutputPartition());
+            streamSink.setPartition(DataPartition.RANDOM);
             streamSink.setFragment(this);
             multiCastDataSink.getDataStreamSinks().add(streamSink);
             multiCastDataSink.getDestinations().add(Lists.newArrayList());

--- a/fe/fe-core/src/main/java/com/starrocks/planner/MultiCastPlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/MultiCastPlanFragment.java
@@ -30,7 +30,8 @@ public class MultiCastPlanFragment extends PlanFragment {
 
     public MultiCastPlanFragment(PlanFragment planFragment) {
         super(planFragment.fragmentId, planFragment.planRoot, planFragment.getDataPartition());
-        this.outputPartition = planFragment.getOutputPartition();
+        // Use random, only send to self
+        this.outputPartition = DataPartition.RANDOM;
         this.children.addAll(planFragment.getChildren());
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -118,6 +118,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
 
 public class Coordinator {
     private static final Logger LOG = LogManager.getLogger(Coordinator.class);
@@ -876,11 +877,12 @@ public class Coordinator {
             }
 
             PlanNodeId exchId = sink.getExchNodeId();
-            // we might have multiple fragments sending to this exchange node
-            // (distributed MERGE), which is why we need to add up the #senders
             if (destParams.perExchNumSenders.get(exchId.asInt()) == null) {
                 destParams.perExchNumSenders.put(exchId.asInt(), params.instanceExecParams.size());
             } else {
+                // we might have multiple fragments sending to this exchange node
+                // (distributed MERGE), which is why we need to add up the #senders
+                // e.g. sort-merge
                 destParams.perExchNumSenders.put(exchId.asInt(),
                         params.instanceExecParams.size() + destParams.perExchNumSenders.get(exchId.asInt()));
             }
@@ -945,14 +947,10 @@ public class Coordinator {
                 FragmentExecParams destParams = fragmentExecParamsMap.get(destFragment.getFragmentId());
 
                 PlanNodeId exchId = sink.getExchNodeId();
-                // we might have multiple fragments sending to this exchange node
-                // (distributed MERGE), which is why we need to add up the #senders
-                if (destParams.perExchNumSenders.get(exchId.asInt()) == null) {
-                    destParams.perExchNumSenders.put(exchId.asInt(), params.instanceExecParams.size());
-                } else {
-                    destParams.perExchNumSenders.put(exchId.asInt(),
-                            params.instanceExecParams.size() + destParams.perExchNumSenders.get(exchId.asInt()));
-                }
+                // MultiCastSink only send to itself, destination exchange only one senders
+                // and it's don't support sort-merge
+                Preconditions.checkState(!destParams.perExchNumSenders.containsKey(exchId.asInt()));
+                destParams.perExchNumSenders.put(exchId.asInt(), 1);
 
                 if (needScheduleByShuffleJoin(destFragment.getFragmentId().asInt(), sink)) {
                     int bucketSeq = 0;
@@ -1852,7 +1850,7 @@ public class Coordinator {
             this.fragment = fragment;
         }
 
-        List<TExecPlanFragmentParams> toThrift(int backendNum, boolean isEnablePipelineEngine) {
+        List<TExecPlanFragmentParams> toThrift(int backendNum, boolean isEnablePipelineEngine) throws Exception {
             // add instance number in file name prefix when export job
             DataSink sink = fragment.getSink();
             ExportSink exportSink = null;
@@ -1873,6 +1871,23 @@ public class Coordinator {
 
                 params.setProtocol_version(InternalServiceVersion.V1);
                 params.setFragment(fragment.toThrift());
+
+                /* For MultiCastDataFragment, output only send to itself */
+                if (fragment instanceof MultiCastPlanFragment) {
+                    List<List<TPlanFragmentDestination>> multiFragmentDestinations =
+                            params.getFragment().getOutput_sink().getMulti_cast_stream_sink().getDestinations();
+                    List<List<TPlanFragmentDestination>> newDestinations = Lists.newArrayList();
+                    for (List<TPlanFragmentDestination> destinations : multiFragmentDestinations) {
+                        TNetworkAddress localRpc = toRpcHost(instanceExecParam.host);
+                        List<TPlanFragmentDestination> ndes =
+                                destinations.stream().filter(des -> des.server.equals(localRpc))
+                                        .collect(Collectors.toList());
+                        Preconditions.checkState(ndes.size() == 1);
+                        newDestinations.add(ndes);
+                    }
+                    params.getFragment().getOutput_sink().getMulti_cast_stream_sink().setDestinations(newDestinations);
+                }
+
                 params.setDesc_tbl(descTable);
                 params.setParams(new TPlanFragmentExecParams());
                 params.setResource_info(tResourceInfo);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -318,8 +318,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = CBO_CTE_REUSE)
     private boolean cboCteReuse = false;
 
-    @VarAttr(name = CBO_CTE_REUSE_RATE)
-    private double cboCTERuseRatio = 2.0;
+    @VarAttr(name = CBO_CTE_REUSE_RATE, flag = VariableMgr.INVISIBLE)
+    private double cboCTERuseRatio = 1.2;
 
     /*
      * the parallel exec instance num for one Fragment in one BE

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -158,6 +158,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String CBO_ENABLE_LOW_CARDINALITY_OPTIMIZE = "cbo_enable_low_cardinality_optimize";
     public static final String CBO_USE_NTH_EXEC_PLAN = "cbo_use_nth_exec_plan";
     public static final String CBO_CTE_REUSE = "cbo_cte_reuse";
+    public static final String CBO_CTE_REUSE_RATE = "cbo_cte_reuse_rate";
     // --------  New planner session variables end --------
 
     // Type of compression of transmitted data
@@ -316,6 +317,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = CBO_CTE_REUSE)
     private boolean cboCteReuse = false;
+
+    @VarAttr(name = CBO_CTE_REUSE_RATE)
+    private double cboCTERuseRatio = 2.0;
 
     /*
      * the parallel exec instance num for one Fragment in one BE
@@ -821,6 +825,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean isSingleNodeExecPlan() {
         return singleNodeExecPlan;
+    }
+    
+    public double getCboCTERuseRatio() {
+        return cboCTERuseRatio;
+    }
+
+    public void setCboCTERuseRatio(double cboCTERuseRatio) {
+        this.cboCTERuseRatio = cboCTERuseRatio;
     }
 
     // Serialize to thrift object

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CTEContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CTEContext.java
@@ -5,7 +5,6 @@ package com.starrocks.sql.optimizer;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import org.apache.logging.log4j.LogManager;
@@ -14,7 +13,6 @@ import org.apache.logging.log4j.Logger;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /*
  * Recorder CTE node info, contains:
@@ -197,6 +195,10 @@ public class CTEContext {
 
         Preconditions.checkState(produceCosts.containsKey(cteId));
         Preconditions.checkState(consumeInlineCosts.containsKey(cteId));
+
+        if (inlineCTERatio <= 0) {
+            return false;
+        }
 
         double p = produceCosts.get(cteId);
         double c = consumeInlineCosts.get(cteId).stream().reduce(Double::sum).orElse(Double.MAX_VALUE);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CTEContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CTEContext.java
@@ -7,7 +7,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
-import com.starrocks.sql.optimizer.statistics.StatisticsEstimateCoefficient;
 
 import java.util.Collections;
 import java.util.List;
@@ -48,6 +47,8 @@ public class CTEContext {
 
     private boolean enableCTE;
 
+    private double inlineCTERatio = 2.0;
+
     public CTEContext() {
     }
 
@@ -64,6 +65,10 @@ public class CTEContext {
 
     public void setEnableCTE(boolean enableCTE) {
         this.enableCTE = enableCTE;
+    }
+
+    public void setInlineCTERatio(double ratio) {
+        this.inlineCTERatio = inlineCTERatio;
     }
 
     public void addCTEProduce(int cteId, OptExpression produce) {
@@ -178,7 +183,7 @@ public class CTEContext {
 
         // 3. CTE produce cost > sum of all consume inline costs
         // Consume output rows less produce rows * rate choose inline
-        return p * StatisticsEstimateCoefficient.DEFAULT_CTE_INLINE_COST_RATE >= c;
+        return p * inlineCTERatio >= c;
     }
 
     public boolean hasInlineCTE() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CTEContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CTEContext.java
@@ -203,7 +203,12 @@ public class CTEContext {
         double p = produceCosts.get(cteId);
         double c = consumeInlineCosts.get(cteId).stream().reduce(Double::sum).orElse(Double.MAX_VALUE);
 
-        // 3. CTE produce cost > sum of all consume inline costs
+        // 3. Statistic is unknown, must inline
+        if (p <= 0 || c <= 0) {
+            return true;
+        }
+
+        // 4. CTE produce cost > sum of all consume inline costs
         // Consume output rows less produce rows * rate choose inline
         return p * (inlineCTERatio + produceComplexityScores.getOrDefault(cteId, 0D)) > c;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CTEContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CTEContext.java
@@ -68,7 +68,7 @@ public class CTEContext {
     }
 
     public void setInlineCTERatio(double ratio) {
-        this.inlineCTERatio = inlineCTERatio;
+        this.inlineCTERatio = ratio;
     }
 
     public void addCTEProduce(int cteId, OptExpression produce) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CTEUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CTEUtils.java
@@ -15,6 +15,10 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class CTEUtils {
+    /*
+     * The score refers to the complexity of the operator and the probability of CTE reuse.
+     * The higher the score, the greater the probability of CTE reuse
+     */
     private static final Map<OperatorType, Integer> OPERATOR_SCORES = ImmutableMap.<OperatorType, Integer>builder()
             .put(OperatorType.LOGICAL_JOIN, 4)
             .put(OperatorType.LOGICAL_AGGR, 6)
@@ -74,7 +78,8 @@ public class CTEUtils {
             AtomicInteger scores = new AtomicInteger(0);
             cteProduceEstimate(entry.getValue().getGroupExpression().getGroup(), scores);
 
-            // score 15 = 1 join + 2 scan + 3 project = 1 agg + 1 scan + 2 project = (1 scan + 1 project) * 3
+            // score 15 meanings (1 join + 2 scan + 3 project), (1 agg + 1 scan + 2 project)
+            // A lower score will make a higher penalty factor
             cteContext.addCTEProduceComplexityScores(entry.getKey(), 15.0 / scores.intValue());
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CTEUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CTEUtils.java
@@ -19,6 +19,7 @@ public class CTEUtils {
             .put(OperatorType.LOGICAL_JOIN, 4)
             .put(OperatorType.LOGICAL_AGGR, 6)
             .put(OperatorType.LOGICAL_OLAP_SCAN, 4)
+            .put(OperatorType.LOGICAL_UNION, 4)
             .put(OperatorType.LOGICAL_CTE_PRODUCE, 0)
             .build();
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CTEUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CTEUtils.java
@@ -181,7 +181,8 @@ public class CTEUtils {
         if (OperatorType.LOGICAL_OLAP_SCAN.equals(expr.getOp().getOpType()) &&
                 expressionContext.getStatistics().getColumnStatistics().values().stream()
                         .anyMatch(ColumnStatistic::isUnknown)) {
-            // Mark output rows is zero, inline CTE
+            // Can't evaluated the effect of CTE if don't know statistic,
+            // Mark output rows is zero, will choose inline when CTEContext check output rows
             expr.setStatistics(Statistics.buildFrom(expressionContext.getStatistics()).setOutputRowCount(0).build());
         } else {
             expr.setStatistics(expressionContext.getStatistics());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CTEUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CTEUtils.java
@@ -134,7 +134,7 @@ public class CTEUtils {
             context.getCteContext().getRequiredColumns().put(consume.getCteId(), requiredColumnRef);
 
             // inline costs
-            if (collectCosts) {
+            if (collectCosts && !expression.getInputs().isEmpty()) {
                 context.getCteContext().addCTEConsumeInlineCost(consume.getCteId(),
                         calculateStatistics(expression.getInputs().get(0), context).getComputeSize());
             }
@@ -173,8 +173,9 @@ public class CTEUtils {
                 expressionContext, context.getColumnRefFactory(), context);
         statisticsCalculator.estimatorStats();
 
-        if (expressionContext.getStatistics().getColumnStatistics().values().stream()
-                .anyMatch(ColumnStatistic::isUnknown)) {
+        if (OperatorType.LOGICAL_OLAP_SCAN.equals(expr.getOp().getOpType()) &&
+                expressionContext.getStatistics().getColumnStatistics().values().stream()
+                        .anyMatch(ColumnStatistic::isUnknown)) {
             // Mark output rows is zero, inline CTE
             expr.setStatistics(Statistics.buildFrom(expressionContext.getStatistics()).setOutputRowCount(0).build());
         } else {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
@@ -49,6 +49,7 @@ public class OptimizerContext {
         this.cteContext = new CTEContext();
         cteContext.reset();
         this.cteContext.setEnableCTE(sessionVariable.isCboCteReuse());
+        this.cteContext.setInlineCTERatio(sessionVariable.getCboCTERuseRatio());
     }
 
     public Memo getMemo() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarRangePredicateExtractor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarRangePredicateExtractor.java
@@ -19,6 +19,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -122,7 +123,7 @@ public class ScalarRangePredicateExtractor {
         return re.apply(scalarOperator, null);
     }
 
-    private class RangeExtractor extends ScalarOperatorVisitor<Void, Void> {
+    private static class RangeExtractor extends ScalarOperatorVisitor<Void, Void> {
         private final Map<ScalarOperator, ValueDescriptor> descMap = Maps.newHashMap();
 
         public Map<ScalarOperator, ValueDescriptor> apply(ScalarOperator scalarOperator, Void context) {
@@ -295,7 +296,7 @@ public class ScalarRangePredicateExtractor {
     }
 
     private static class MultiValuesDescriptor extends ValueDescriptor {
-        protected List<ConstantOperator> values = Lists.newArrayList();
+        protected Set<ConstantOperator> values = new LinkedHashSet<>();
 
         public MultiValuesDescriptor(ScalarOperator ref) {
             super(ref);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushLimitAndFilterToCTEProduceRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushLimitAndFilterToCTEProduceRule.java
@@ -14,6 +14,7 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalFilterOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalLimitOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rewrite.ScalarRangePredicateExtractor;
 import com.starrocks.sql.optimizer.rule.RuleType;
 
 import java.util.Collections;
@@ -64,7 +65,8 @@ public class PushLimitAndFilterToCTEProduceRule extends TransformationRule {
         OptExpression child = input.getInputs().get(0);
         if (consumeNums == predicates.size()) {
             ScalarOperator orPredicate = Utils.compoundOr(Lists.newArrayList(new LinkedHashSet<>(predicates)));
-            child = OptExpression.create(new LogicalFilterOperator(orPredicate), child);
+            ScalarRangePredicateExtractor extractor = new ScalarRangePredicateExtractor();
+            child = OptExpression.create(new LogicalFilterOperator(extractor.rewriteAll(orPredicate)), child);
         }
 
         if (consumeNums == limits.size()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -116,7 +116,7 @@ public class ExpressionStatisticCalculator {
                     min = min.castTo(cast.getType());
                 }
             } catch (Exception e) {
-                LOG.warn("expression statistic compute cast failed: " + max.toString() + ", " + min.toString() +
+                LOG.debug("expression statistic compute cast failed: " + max.toString() + ", " + min.toString() +
                         ", to type: " + cast.getType());
                 return childStatistic;
             }
@@ -179,7 +179,7 @@ public class ExpressionStatisticCalculator {
                         minValue = getDatetimeFromLong((long) columnStatistic.getMinValue()).getYear();
                         maxValue = getDatetimeFromLong((long) columnStatistic.getMaxValue()).getYear();
                     } catch (DateTimeException e) {
-                        LOG.warn("get date type column statistics min/max failed. " + e);
+                        LOG.debug("get date type column statistics min/max failed. " + e);
                     }
                     return new ColumnStatistic(minValue, maxValue, 0,
                             callOperator.getType().getTypeSize(),

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsEstimateCoefficient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsEstimateCoefficient.java
@@ -23,7 +23,4 @@ public class StatisticsEstimateCoefficient {
     public static final double OVERLAP_INFINITE_RANGE_FILTER_COEFFICIENT = 0.5;
     // used in compute extra cost for multi distinct function, estimate whether to trigger streaming
     public static final double STREAMING_EXTRA_COST_THRESHOLD_COEFFICIENT = 0.8;
-
-    // used in compute cte choose reuse or inline
-    public static double DEFAULT_CTE_INLINE_COST_RATE = 1.5;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -2117,7 +2117,7 @@ public class PlanFragmentBuilder {
                     cteFragment.getPlanRoot(), false, DistributionSpec.DistributionType.SHUFFLE);
             exchangeNode.setNumInstances(cteFragment.getPlanRoot().getNumInstances());
 
-            PlanFragment consumeFragment = new PlanFragment(context.getPlanCtx().getNextFragmentId(), exchangeNode,
+            PlanFragment consumeFragment = new PlanFragment(context.getNextFragmentId(), exchangeNode,
                     cteFragment.getDataPartition());
 
             Map<ColumnRefOperator, ScalarOperator> projectMap = Maps.newHashMap();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -2117,12 +2117,12 @@ public class PlanFragmentBuilder {
                     cteFragment.getPlanRoot(), false, DistributionSpec.DistributionType.SHUFFLE);
             exchangeNode.setNumInstances(cteFragment.getPlanRoot().getNumInstances());
 
-            PlanFragment consumeFragment = new PlanFragment(context.getNextFragmentId(), exchangeNode,
-                    DataPartition.hashPartitioned(cteFragment.getOutputExprs()));
+            PlanFragment consumeFragment = new PlanFragment(context.getPlanCtx().getNextFragmentId(), exchangeNode,
+                    cteFragment.getDataPartition());
 
             Map<ColumnRefOperator, ScalarOperator> projectMap = Maps.newHashMap();
             consume.getCteOutputColumnRefMap().forEach(projectMap::put);
-            buildProjectNode(optExpression, new Projection(projectMap), consumeFragment, context);
+            consumeFragment = buildProjectNode(optExpression, new Projection(projectMap), consumeFragment, context);
 
             // add filter node
             if (consume.getPredicate() != null) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -903,7 +903,7 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
         Catalog catalog = connectContext.getCatalog();
         connectContext.getSessionVariable().setCboCteReuse(true);
         connectContext.getSessionVariable().setEnablePipelineEngine(true);
-
+        connectContext.getSessionVariable().setCboCTERuseRatio(0);
 
         OlapTable t1 = (OlapTable) catalog.getDb("default_cluster:test").getTable("t1");
         OlapTable t2 = (OlapTable) catalog.getDb("default_cluster:test").getTable("t2");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestBase.java
@@ -789,8 +789,10 @@ public class PlanTestBase {
     }
 
     public String getFragmentPlan(String sql) throws Exception {
-        return UtFrameUtils.getPlanAndFragment(connectContext, sql).second.
+        String s= UtFrameUtils.getPlanAndFragment(connectContext, sql).second.
                 getExplainString(TExplainLevel.NORMAL);
+        System.out.println(s);
+        return s;
     }
 
     public String getVerboseExplain(String sql) throws Exception {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCDSCTETest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCDSCTETest.java
@@ -2,7 +2,6 @@
 
 package com.starrocks.sql.plan;
 
-import com.starrocks.sql.optimizer.statistics.StatisticsEstimateCoefficient;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -15,12 +14,12 @@ public class TPCDSCTETest extends TPCDSPlanTestBase {
         TPCDSPlanTestBase.beforeClass();
         connectContext.getSessionVariable().setCboCteReuse(true);
         connectContext.getSessionVariable().setEnablePipelineEngine(true);
-        StatisticsEstimateCoefficient.DEFAULT_CTE_INLINE_COST_RATE = 0;
+        connectContext.getSessionVariable().setCboCTERuseRatio(0);
     }
 
     @AfterClass
     public static void afterClass() {
-        StatisticsEstimateCoefficient.DEFAULT_CTE_INLINE_COST_RATE = 1.5;
+        connectContext.getSessionVariable().setCboCTERuseRatio(1.5);
     }
 
     public void testCTE(String sql) throws Exception {


### PR DESCRIPTION
before:
* MultiCastFragment will send data to all instance 

after
* MultiCastFragment will send data to itself instance
 
In fact, the output fragment of MultiCastFragment always keep same with MultiCastFragment, and they don't need to shuffle data in a specific way. So the best way is just send to itself direct, it's can be avoid data hash compute and network

Other, add CTE produce complexity score, avoid some simplier plan(one join/one agg) reuse cte direct
