### PR TITLE
Support cleaning up expired transactions by number (#2414)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -119,8 +119,6 @@ public class PublishVersionDaemon extends MasterDaemon {
                 globalTransactionMgr.finishTransaction(transactionState.getDbId(), transactionState.getTransactionId(),
                         publishErrorReplicaIds);
                 if (transactionState.getTransactionStatus() != TransactionStatus.VISIBLE) {
-                    // if finish transaction state failed, then update publish version time, should check 
-                    // to finish after some interval
                     transactionState.updateSendTaskTime();
                     LOG.debug("publish version for transation {} failed, has {} error replicas during publish",
                             transactionState, publishErrorReplicaIds.size());
@@ -128,6 +126,8 @@ public class PublishVersionDaemon extends MasterDaemon {
                     for (PublishVersionTask task : transactionState.getPublishVersionTasks().values()) {
                         AgentTaskQueue.removeTask(task.getBackendId(), TTaskType.PUBLISH_VERSION, task.getSignature());
                     }
+                    // clear publish version tasks to reduce memory usage when state changed to visible.
+                    transactionState.clearPublishVersionTasks();
                 }
             }
         } // end for readyTransactionStates

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -183,9 +183,9 @@ public class TransactionState implements Writable {
     private List<Long> tableIdList;
     private long transactionId;
     private String label;
-    // requsetId is used to judge whether a begin request is a internal retry request.
+    // requestId is used to judge whether a begin request is a internal retry request.
     // no need to persist it.
-    private TUniqueId requsetId;
+    private TUniqueId requestId;
     private Map<Long, TableCommitInfo> idToTableCommitInfos;
     // coordinator is show who begin this txn (FE, or one of BE, etc...)
     private TxnCoordinator txnCoordinator;
@@ -244,14 +244,14 @@ public class TransactionState implements Writable {
         this.latch = new CountDownLatch(1);
     }
 
-    public TransactionState(long dbId, List<Long> tableIdList, long transactionId, String label, TUniqueId requsetId,
+    public TransactionState(long dbId, List<Long> tableIdList, long transactionId, String label, TUniqueId requestId,
                             LoadJobSourceType sourceType, TxnCoordinator txnCoordinator, long callbackId,
                             long timeoutMs) {
         this.dbId = dbId;
         this.tableIdList = (tableIdList == null ? Lists.newArrayList() : tableIdList);
         this.transactionId = transactionId;
         this.label = label;
-        this.requsetId = requsetId;
+        this.requestId = requestId;
         this.idToTableCommitInfos = Maps.newHashMap();
         this.txnCoordinator = txnCoordinator;
         this.transactionStatus = TransactionStatus.PREPARE;
@@ -298,8 +298,8 @@ public class TransactionState implements Writable {
         return this.hasSendTask;
     }
 
-    public TUniqueId getRequsetId() {
-        return requsetId;
+    public TUniqueId getRequestId() {
+        return requestId;
     }
 
     public long getTransactionId() {
@@ -562,6 +562,10 @@ public class TransactionState implements Writable {
 
     public Map<Long, PublishVersionTask> getPublishVersionTasks() {
         return publishVersionTasks;
+    }
+
+    public void clearPublishVersionTasks() {
+        publishVersionTasks.clear();
     }
 
     @Override


### PR DESCRIPTION
Currently, FE can only clean load transactions at the specified interval, default three days.
The memory usage is relatively large if the load frequency is high, triggering FE Full GC.
The pull request adds two strategies to reclaim the memory.
1. Support cleaning up expired transactions by number.
2. For non-expired transactions, clear publish version tasks when the transaction state change to be visible.