### PR TITLE
Bugfix: FE report Decimal's precision should range 1 to 38

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
@@ -267,7 +267,8 @@ public class ScalarType extends Type implements Cloneable {
     }
 
     public static ScalarType createDecimalV3Type(PrimitiveType type, int precision, int scale) {
-        Preconditions.checkArgument(0 < precision && precision <= PrimitiveType.getMaxPrecisionOfDecimal(type));
+        Preconditions.checkArgument(0 < precision && precision <= PrimitiveType.getMaxPrecisionOfDecimal(type),
+                "DECIMAL's precision should range from 1 to 38");
         Preconditions.checkArgument(0 <= scale && scale <= precision,
                 "DECIMAL(P[,S]) type P must be greater than or equal to the value of S");
 


### PR DESCRIPTION
https://github.com/StarRocks/starrocks/issues/3095

FE report "Decimal's precision should range 1 to 38" instead of "Internal Error"  when create decimal whose precision >38 (e.g. decimal(40,20))