### PR TITLE
Fix semi-join handle expression bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SemiReorderRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SemiReorderRule.java
@@ -104,6 +104,9 @@ public class SemiReorderRule extends TransformationRule {
                 } else if (!isProjectToColumnRef &&
                         newSemiOutputColumns.containsAll(entry.getValue().getUsedColumns())) {
                     semiExpression.put(entry.getKey(), entry.getValue());
+                } else if (!isProjectToColumnRef && leftChildInputColumns.containsAll(entry.getValue().getUsedColumns())) {
+                    // left child projection produce
+                    semiExpression.put(entry.getKey(), entry.getValue());
                 }
             }
         }
@@ -116,7 +119,9 @@ public class SemiReorderRule extends TransformationRule {
             );
             projectMap.put(smallestColumnRef, smallestColumnRef);
         } else {
-            projectMap = newSemiOutputColumns.getStream().mapToObj(context.getColumnRefFactory()::getColumnRef)
+            projectMap = newSemiOutputColumns.getStream()
+                    .filter(c -> newTopJoin.getRequiredChildInputColumns().contains(c))
+                    .mapToObj(context.getColumnRefFactory()::getColumnRef)
                     .collect(Collectors.toMap(Function.identity(), Function.identity()));
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -3302,8 +3302,10 @@ public class PlanFragmentTest extends PlanTestBase {
                 "CASE WHEN CAST(substr(9: k7, 2, 1) AS BOOLEAN) THEN 3 WHEN TRUE THEN 1 ELSE 2 END"));
 
         // 1.9 test remove when clause when is false/null
-        String sql19 = "select case when substr(k7,2,1) then 3 when false then 1 when null then 5 else 2 end as col16 from test.baseall;";
-        Assert.assertTrue(StringUtils.containsIgnoreCase(getFragmentPlan(sql19), "if(CAST(substr(9: k7, 2, 1) AS BOOLEAN), 3, 2)"));
+        String sql19 =
+                "select case when substr(k7,2,1) then 3 when false then 1 when null then 5 else 2 end as col16 from test.baseall;";
+        Assert.assertTrue(StringUtils
+                .containsIgnoreCase(getFragmentPlan(sql19), "if(CAST(substr(9: k7, 2, 1) AS BOOLEAN), 3, 2)"));
 
         // test 2: case xxx when then
         // 2.1 test equal
@@ -3353,13 +3355,16 @@ public class PlanFragmentTest extends PlanTestBase {
                 "constant exprs: \n         'a'"));
 
         // 2.6 when expr equals case expr in middle
-        String sql26 = "select case 'a' when substr(k7,2,1) then 2 when 'a' then 'b' else 'other' end as col2 from test.baseall;";
+        String sql26 =
+                "select case 'a' when substr(k7,2,1) then 2 when 'a' then 'b' else 'other' end as col2 from test.baseall;";
         Assert.assertTrue(StringUtils.containsIgnoreCase(getFragmentPlan(sql26),
                 "CASE 'a' WHEN substr(9: k7, 2, 1) THEN '2' WHEN 'a' THEN 'b' ELSE 'other' END"));
 
         // 2.7 test remove when clause not equals case expr
-        String sql27 = "select case 'a' when substr(k7,2,1) then 3 when false then 1 when null then 5 else 2 end as col16 from test.baseall;";
-        Assert.assertTrue(StringUtils.containsIgnoreCase(getFragmentPlan(sql27), "if(substr(9: k7, 2, 1) = 'a', 3, 2)"));
+        String sql27 =
+                "select case 'a' when substr(k7,2,1) then 3 when false then 1 when null then 5 else 2 end as col16 from test.baseall;";
+        Assert.assertTrue(
+                StringUtils.containsIgnoreCase(getFragmentPlan(sql27), "if(substr(9: k7, 2, 1) = 'a', 3, 2)"));
 
         // 3.1 test float,float in case expr
         String sql31 = "select case cast(100 as float) when 1 then 'a' when 2 then 'b' else 'other' end as col31;";
@@ -3387,7 +3392,7 @@ public class PlanFragmentTest extends PlanTestBase {
         String sql423 = "select case 'a' when null then 'a' when false then 'b' end as col421";
         Assert.assertTrue(
                 StringUtils.containsIgnoreCase(getFragmentPlan(sql423), "constant exprs: \n         NULL"));
-     }
+    }
 
     @Test
     public void testJoinPredicateTransitivityWithSubqueryInWhereClause() throws Exception {
@@ -5053,7 +5058,7 @@ public class PlanFragmentTest extends PlanTestBase {
         Assert.assertTrue(plan.contains("  6:HASH JOIN\n" +
                 "  |  join op: LEFT OUTER JOIN (PARTITIONED)"));
     }
-    
+
     @Test
     public void testDeriveOutputColumns() throws Exception {
         String sql = "select \n" +
@@ -5584,5 +5589,19 @@ public class PlanFragmentTest extends PlanTestBase {
         String sql = "select v1 from t0 where v1 is null";
         String thrift = getThriftPlan(sql);
         Assert.assertTrue(thrift.contains("fn:TFunction(name:TFunctionName(function_name:is_null_pred)"));
+    }
+
+    @Test
+    public void testSemiJoinReorderWithProject() throws Exception {
+        String sql = "select x1.s1 from " +
+                "(select t0.v1 + 1 as s1, t0.v2 from t0 left join t1 on t0.v2 = t1.v4) as x1 " +
+                "left semi join t2 on x1.v2 = t2.v7";
+        String plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("  4:Project\n" +
+                "  |  <slot 2> : 2: v2\n" +
+                "  |  <slot 7> : 1: v1 + 1\n" +
+                "  |  \n" +
+                "  3:HASH JOIN\n" +
+                "  |  join op: LEFT OUTER JOIN"));
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

For SQL
```
select x1.s1 from 
(select t0.v1 + 1 as s1, t0.v2 from t0 left join t1 on t0.v2 = t1.v4) as x1 
left semi join t2 on x1.v2 = t2.v7
```

If top join node haven't use t0.v1 and only left child join node output contains an expression which use the column t0.v1, semi join reorder will lose the expression
