### PR TITLE
Support alter load description for routine load (#3018)

### DIFF
--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -794,10 +794,12 @@ alter_stmt ::=
     {:
         RESULT = new AlterUserStmt(user);
     :}
-    | KW_ALTER KW_ROUTINE KW_LOAD KW_FOR job_label:jobLabel opt_properties:jobProperties
+    | KW_ALTER KW_ROUTINE KW_LOAD KW_FOR job_label:jobLabel
+      opt_load_property_list:loadPropertyList
+      opt_properties:jobProperties
       opt_datasource_properties:datasourceProperties
     {:
-        RESULT = new AlterRoutineLoadStmt(jobLabel, jobProperties, datasourceProperties);
+        RESULT = new AlterRoutineLoadStmt(jobLabel, loadPropertyList, jobProperties, datasourceProperties);
     :}
     ;
 

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/CreateRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/CreateRoutineLoadStmt.java
@@ -266,6 +266,10 @@ public class CreateRoutineLoadStmt extends DdlStmt {
         return customKafkaProperties;
     }
 
+    public List<ParseNode> getLoadPropertyList() {
+        return loadPropertyList;
+    }
+
     @Override
     public void analyze(Analyzer analyzer) throws UserException {
         super.analyze(analyzer);
@@ -274,7 +278,7 @@ public class CreateRoutineLoadStmt extends DdlStmt {
         // check name
         FeNameFormat.checkCommonName(NAME_TYPE, name);
         // check load properties include column separator etc.
-        checkLoadProperties();
+        routineLoadDesc = buildLoadDesc(loadPropertyList);
         // check routine load job properties include desired concurrent number etc.
         checkJobProperties();
         // check data source properties
@@ -290,9 +294,9 @@ public class CreateRoutineLoadStmt extends DdlStmt {
         }
     }
 
-    public void checkLoadProperties() throws UserException {
+    public static RoutineLoadDesc buildLoadDesc(List<ParseNode> loadPropertyList) throws UserException {
         if (loadPropertyList == null) {
-            return;
+            return null;
         }
         ColumnSeparator columnSeparator = null;
         RowDelimiter rowDelimiter = null;
@@ -335,7 +339,7 @@ public class CreateRoutineLoadStmt extends DdlStmt {
                 partitionNames.analyze(null);
             }
         }
-        routineLoadDesc = new RoutineLoadDesc(columnSeparator, rowDelimiter, importColumnsStmt, importWhereStmt,
+        return new RoutineLoadDesc(columnSeparator, rowDelimiter, importColumnsStmt, importWhereStmt,
                 partitionNames);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadManager.java
@@ -29,6 +29,8 @@ import com.starrocks.analysis.AlterRoutineLoadStmt;
 import com.starrocks.analysis.CreateRoutineLoadStmt;
 import com.starrocks.analysis.PauseRoutineLoadStmt;
 import com.starrocks.analysis.ResumeRoutineLoadStmt;
+import com.starrocks.analysis.SqlParser;
+import com.starrocks.analysis.SqlScanner;
 import com.starrocks.analysis.StopRoutineLoadStmt;
 import com.starrocks.catalog.Catalog;
 import com.starrocks.catalog.Database;
@@ -43,10 +45,14 @@ import com.starrocks.common.UserException;
 import com.starrocks.common.io.Writable;
 import com.starrocks.common.util.LogBuilder;
 import com.starrocks.common.util.LogKey;
+import com.starrocks.common.util.SqlParserUtils;
+import com.starrocks.load.RoutineLoadDesc;
 import com.starrocks.mysql.privilege.PrivPredicate;
 import com.starrocks.persist.AlterRoutineLoadJobOperationLog;
 import com.starrocks.persist.RoutineLoadOperation;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.qe.SqlModeHelper;
 import com.starrocks.sql.optimizer.statistics.IDictManager;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -54,6 +60,7 @@ import org.apache.logging.log4j.Logger;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -546,17 +553,45 @@ public class RoutineLoadManager implements Writable {
      */
     public void alterRoutineLoadJob(AlterRoutineLoadStmt stmt) throws UserException {
         RoutineLoadJob job = checkPrivAndGetJob(stmt.getDbName(), stmt.getLabel());
+        if (job.getState() != RoutineLoadJob.JobState.PAUSED) {
+            throw new DdlException("Only supports modification of PAUSED jobs");
+        }
         if (stmt.hasDataSourceProperty()
                 && !stmt.getDataSourceProperties().getType().equalsIgnoreCase(job.dataSourceType.name())) {
             throw new DdlException("The specified job type is not: " + stmt.getDataSourceProperties().getType());
         }
-        job.modifyProperties(stmt);
+        job.modifyJob(stmt.getRoutineLoadDesc(), stmt.getAnalyzedJobProperties(),
+                stmt.getDataSourceProperties(), stmt.getOrigStmt(), false);
     }
 
-    public void replayAlterRoutineLoadJob(AlterRoutineLoadJobOperationLog log) {
+    public void replayAlterRoutineLoadJob(AlterRoutineLoadJobOperationLog log) throws UserException, IOException {
         RoutineLoadJob job = getJob(log.getJobId());
         Preconditions.checkNotNull(job, log.getJobId());
-        job.replayModifyProperties(log);
+
+        // NOTE: we use the origin statement to get the RoutineLoadDesc
+        RoutineLoadDesc routineLoadDesc = null;
+        if (log.getOriginStatement() != null) {
+            long sqlMode;
+            if (job.getSessionVariables() != null && job.getSessionVariables().containsKey(SessionVariable.SQL_MODE)) {
+                sqlMode = Long.parseLong(job.getSessionVariables().get(SessionVariable.SQL_MODE));
+            } else {
+                sqlMode = SqlModeHelper.MODE_DEFAULT;
+            }
+            try {
+                SqlParser parser = new SqlParser(
+                        new SqlScanner(new StringReader(log.getOriginStatement().originStmt), sqlMode));
+                AlterRoutineLoadStmt stmt = (AlterRoutineLoadStmt) SqlParserUtils.getStmt(
+                        parser, log.getOriginStatement().idx);
+                if (stmt.getLoadPropertyList() != null) {
+                    routineLoadDesc = CreateRoutineLoadStmt.buildLoadDesc(stmt.getLoadPropertyList());
+                }
+            } catch (Exception e) {
+                throw new IOException("error happens when parsing alter routine load stmt: "
+                        + log.getOriginStatement().originStmt, e);
+            }
+        }
+        job.modifyJob(routineLoadDesc, log.getJobProperties(),
+                log.getDataSourceProperties(), log.getOriginStatement(), true);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/persist/AlterRoutineLoadJobOperationLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/AlterRoutineLoadJobOperationLog.java
@@ -26,6 +26,7 @@ import com.starrocks.analysis.RoutineLoadDataSourceProperties;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.qe.OriginStatement;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -40,12 +41,16 @@ public class AlterRoutineLoadJobOperationLog implements Writable {
     private Map<String, String> jobProperties;
     @SerializedName(value = "dataSourceProperties")
     private RoutineLoadDataSourceProperties dataSourceProperties;
+    @SerializedName(value = "originStatement")
+    private OriginStatement originStatement;
 
     public AlterRoutineLoadJobOperationLog(long jobId, Map<String, String> jobProperties,
-                                           RoutineLoadDataSourceProperties dataSourceProperties) {
+                                           RoutineLoadDataSourceProperties dataSourceProperties,
+                                           OriginStatement originStatement) {
         this.jobId = jobId;
         this.jobProperties = jobProperties;
         this.dataSourceProperties = dataSourceProperties;
+        this.originStatement = originStatement;
     }
 
     public long getJobId() {
@@ -58,6 +63,10 @@ public class AlterRoutineLoadJobOperationLog implements Writable {
 
     public RoutineLoadDataSourceProperties getDataSourceProperties() {
         return dataSourceProperties;
+    }
+
+    public OriginStatement getOriginStatement() {
+        return originStatement;
     }
 
     public static AlterRoutineLoadJobOperationLog read(DataInput in) throws IOException {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterRoutineLoadStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterRoutineLoadStmtTest.java
@@ -83,7 +83,7 @@ public class AlterRoutineLoadStmtTest {
             RoutineLoadDataSourceProperties routineLoadDataSourceProperties = new RoutineLoadDataSourceProperties(
                     typeName, dataSourceProperties);
             AlterRoutineLoadStmt stmt = new AlterRoutineLoadStmt(new LabelName("db1", "label1"),
-                    jobProperties, routineLoadDataSourceProperties);
+                    null, jobProperties, routineLoadDataSourceProperties);
             try {
                 stmt.analyze(analyzer);
             } catch (UserException e) {
@@ -105,7 +105,7 @@ public class AlterRoutineLoadStmtTest {
 
     @Test(expected = AnalysisException.class)
     public void testNoPproperties() throws AnalysisException, UserException {
-        AlterRoutineLoadStmt stmt = new AlterRoutineLoadStmt(new LabelName("db1", "label1"),
+        AlterRoutineLoadStmt stmt = new AlterRoutineLoadStmt(new LabelName("db1", "label1"), null,
                 Maps.newHashMap(), new RoutineLoadDataSourceProperties());
         stmt.analyze(analyzer);
     }
@@ -115,7 +115,7 @@ public class AlterRoutineLoadStmtTest {
         {
             Map<String, String> jobProperties = Maps.newHashMap();
             jobProperties.put(CreateRoutineLoadStmt.FORMAT, "csv");
-            AlterRoutineLoadStmt stmt = new AlterRoutineLoadStmt(new LabelName("db1", "label1"),
+            AlterRoutineLoadStmt stmt = new AlterRoutineLoadStmt(new LabelName("db1", "label1"), null,
                     jobProperties, new RoutineLoadDataSourceProperties());
             try {
                 stmt.analyze(analyzer);
@@ -135,7 +135,7 @@ public class AlterRoutineLoadStmtTest {
             dataSourceProperties.put(CreateRoutineLoadStmt.KAFKA_TOPIC_PROPERTY, "new_topic");
             RoutineLoadDataSourceProperties routineLoadDataSourceProperties = new RoutineLoadDataSourceProperties(
                     typeName, dataSourceProperties);
-            AlterRoutineLoadStmt stmt = new AlterRoutineLoadStmt(new LabelName("db1", "label1"),
+            AlterRoutineLoadStmt stmt = new AlterRoutineLoadStmt(new LabelName("db1", "label1"), null,
                     jobProperties, routineLoadDataSourceProperties);
 
             try {
@@ -156,7 +156,7 @@ public class AlterRoutineLoadStmtTest {
             dataSourceProperties.put(CreateRoutineLoadStmt.KAFKA_PARTITIONS_PROPERTY, "1,2,3");
             RoutineLoadDataSourceProperties routineLoadDataSourceProperties = new RoutineLoadDataSourceProperties(
                     typeName, dataSourceProperties);
-            AlterRoutineLoadStmt stmt = new AlterRoutineLoadStmt(new LabelName("db1", "label1"),
+            AlterRoutineLoadStmt stmt = new AlterRoutineLoadStmt(new LabelName("db1", "label1"), null,
                     jobProperties, routineLoadDataSourceProperties);
             try {
                 stmt.analyze(analyzer);
@@ -177,7 +177,7 @@ public class AlterRoutineLoadStmtTest {
             dataSourceProperties.put(CreateRoutineLoadStmt.KAFKA_OFFSETS_PROPERTY, "1000, 2000");
             RoutineLoadDataSourceProperties routineLoadDataSourceProperties = new RoutineLoadDataSourceProperties(
                     typeName, dataSourceProperties);
-            AlterRoutineLoadStmt stmt = new AlterRoutineLoadStmt(new LabelName("db1", "label1"),
+            AlterRoutineLoadStmt stmt = new AlterRoutineLoadStmt(new LabelName("db1", "label1"), null,
                     jobProperties, routineLoadDataSourceProperties);
             try {
                 stmt.analyze(analyzer);
@@ -197,7 +197,7 @@ public class AlterRoutineLoadStmtTest {
             dataSourceProperties.put(CreateRoutineLoadStmt.KAFKA_OFFSETS_PROPERTY, "1000, 2000, 3000");
             RoutineLoadDataSourceProperties routineLoadDataSourceProperties = new RoutineLoadDataSourceProperties(
                     typeName, dataSourceProperties);
-            AlterRoutineLoadStmt stmt = new AlterRoutineLoadStmt(new LabelName("db1", "label1"),
+            AlterRoutineLoadStmt stmt = new AlterRoutineLoadStmt(new LabelName("db1", "label1"), null,
                     jobProperties, routineLoadDataSourceProperties);
             try {
                 stmt.analyze(analyzer);

--- a/fe/fe-core/src/test/java/com/starrocks/persist/AlterRoutineLoadOperationLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/AlterRoutineLoadOperationLogTest.java
@@ -61,7 +61,7 @@ public class AlterRoutineLoadOperationLogTest {
         routineLoadDataSourceProperties.analyze();
 
         AlterRoutineLoadJobOperationLog log = new AlterRoutineLoadJobOperationLog(jobId,
-                jobProperties, routineLoadDataSourceProperties);
+                jobProperties, routineLoadDataSourceProperties, null);
         log.write(out);
         out.flush();
         out.close();


### PR DESCRIPTION
1. RoutineLoadDesc is not easy to serialize because too many objects are involved. Referring to creating routine load, we persist the OriginStatement of the AlterRoutineLoadStmt into the bdb log and the checkpoint image.
2. Fix a modifyProperties bug: the property `strip_outer_array` can not be modified because the key in the analyzedJobProperties was incorrectly set to the value of strip_outer_array.
3. Add some UT for RoutineLoadJob.modifyJob().

Use the following command to alter routine load description: 
``` SQL
Alter routine load for job_name
[column_separator],
[columns_mapping],
[where_predicates],
[partitions]
```
`column_separator` specifies the column separator, for example:
``` SQL
COLUMNS TERMINATED BY ","
```
`columns_mapping` specifies the columns mapping relation, for example:
``` SQL
COLUMNS (k2, k1, xxx, v1, v2 = k1 + k2)
```
`where_predicates` specifies the filter conditions, for example:
```SQL
WHERE k1 > 10
```
`partitions` specifies the partitions to be imported, for example:
```SQL
PARTITION (p1, p2)
```