### PR TITLE
Fix error return value of containsMaterializedColumn for iceberg

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
@@ -132,9 +132,6 @@ public class IcebergScanNode extends ScanNode {
             return;
         }
         preProcessConjuncts();
-        icebergPredicates.forEach(icebergPredicate -> {
-            LOG.info("Predicate " + icebergPredicate);
-        });
         for (FileScanTask task : IcebergUtil.getTableScan(
                 srIcebergTable.getIcebergTable(), snapshot.get(),
                 icebergPredicates, true).planFiles()) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
@@ -132,6 +132,9 @@ public class IcebergScanNode extends ScanNode {
             return;
         }
         preProcessConjuncts();
+        icebergPredicates.forEach(icebergPredicate -> {
+            LOG.info("Predicate " + icebergPredicate);
+        });
         for (FileScanTask task : IcebergUtil.getTableScan(
                 srIcebergTable.getIcebergTable(), snapshot.get(),
                 icebergPredicates, true).planFiles()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneHDFSScanColumnRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneHDFSScanColumnRule.java
@@ -126,7 +126,7 @@ public class PruneHDFSScanColumnRule extends TransformationRule {
             return scanColumns.size() != 0 && !((LogicalHiveScanOperator) scanOperator).getPartitionColumns().containsAll(
                     scanColumns.stream().map(ColumnRefOperator::getName).collect(Collectors.toList()));
         }
-        return scanColumns.size() == 0;
+        return scanColumns.size() != 0;
     }
 
     private boolean isPartitionColumn(LogicalScanOperator scanOperator, String columnName) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/PruneHDFSScanColumnRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/PruneHDFSScanColumnRuleTest.java
@@ -2,14 +2,91 @@
 
 package com.starrocks.sql.optimizer.rule.transformation;
 
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.IcebergTable;
+import com.starrocks.catalog.Table;
+import com.starrocks.catalog.Type;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.logical.LogicalIcebergScanOperator;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.task.TaskContext;
+import mockit.Expectations;
 import mockit.Mocked;
+import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.*;
+
 public class PruneHDFSScanColumnRuleTest {
+    private PruneHDFSScanColumnRule icebergRule = PruneHDFSScanColumnRule.ICEBERG_SCAN;
+
+    ColumnRefOperator intColumnOperator = new ColumnRefOperator(1, Type.INT, "id", true);
+    ColumnRefOperator strColumnOperator = new ColumnRefOperator(2, Type.STRING, "name", true);
+
+    Map<ColumnRefOperator, Column> scanColumnMap = new HashMap<ColumnRefOperator, Column>() {{
+        put(intColumnOperator, new Column("id", Type.INT));
+        put(strColumnOperator, new Column("name", Type.STRING));
+    }};
 
     @Test
-    public void transform(@Mocked LogicalIcebergScanOperator operator) {
+    public void transformIcebergWithPredicate(@Mocked IcebergTable table,
+                                 @Mocked OptimizerContext context,
+                                 @Mocked TaskContext taskContext) {
+        OptExpression scan = new OptExpression(
+                        new LogicalIcebergScanOperator(table, Table.TableType.ICEBERG,
+                                scanColumnMap, Maps.newHashMap(), -1,
+                                new BinaryPredicateOperator(BinaryPredicateOperator.BinaryType.EQ,
+                                        new ColumnRefOperator(1, Type.INT, "id", true),
+                                        ConstantOperator.createInt(1))));
 
+        List<TaskContext> taskContextList = new ArrayList<>();
+        taskContextList.add(taskContext);
+
+        ColumnRefSet requiredOutputColumns = new ColumnRefSet(new ArrayList<>(
+                Collections.singleton(new ColumnRefOperator(1, Type.INT, "id", true))));
+
+        doIcebergTransform(scan, context, requiredOutputColumns, taskContextList, taskContext);
+    }
+
+    @Test
+    public void transformIcebergWithNoScanColumn(@Mocked IcebergTable table,
+                                              @Mocked OptimizerContext context,
+                                              @Mocked TaskContext taskContext) {
+        OptExpression scan = new OptExpression(
+                        new LogicalIcebergScanOperator(table, Table.TableType.ICEBERG,
+                                scanColumnMap, Maps.newHashMap(), -1, null));
+
+        List<TaskContext> taskContextList = new ArrayList<>();
+        taskContextList.add(taskContext);
+
+        ColumnRefSet requiredOutputColumns = new ColumnRefSet(new ArrayList<>());
+
+        doIcebergTransform(scan, context, requiredOutputColumns, taskContextList, taskContext);
+    }
+
+    private void doIcebergTransform(OptExpression scan,
+                                    OptimizerContext context,
+                                    ColumnRefSet requiredOutputColumns,
+                                    List<TaskContext> taskContextList,
+                                    TaskContext taskContext) {
+        new Expectations() { {
+            context.getTaskContext();
+            minTimes = 0;
+            result = taskContextList;
+
+            taskContext.getRequiredColumns();
+            minTimes = 0;
+            result = requiredOutputColumns;
+        }};
+        List<OptExpression> list = icebergRule.transform(scan, context);
+        Map<ColumnRefOperator, Column> transferMap = ((LogicalIcebergScanOperator)list.get(0)
+                .getOp()).getColRefToColumnMetaMap();
+        Assert.assertEquals(transferMap.size(), 1);
+        Assert.assertEquals(transferMap.get(intColumnOperator).getName(), "id");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/PruneHDFSScanColumnRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/PruneHDFSScanColumnRuleTest.java
@@ -20,7 +20,11 @@ import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class PruneHDFSScanColumnRuleTest {
     private PruneHDFSScanColumnRule icebergRule = PruneHDFSScanColumnRule.ICEBERG_SCAN;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/PruneHDFSScanColumnRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/PruneHDFSScanColumnRuleTest.java
@@ -1,0 +1,15 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.sql.optimizer.rule.transformation;
+
+import com.starrocks.sql.optimizer.operator.logical.LogicalIcebergScanOperator;
+import mockit.Mocked;
+import org.junit.Test;
+
+public class PruneHDFSScanColumnRuleTest {
+
+    @Test
+    public void transform(@Mocked LogicalIcebergScanOperator operator) {
+
+    }
+}


### PR DESCRIPTION
## What type of PR is this：
- [x] enhancement

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
Fix error return value of containsMaterializedColumn for iceberg, which will cause this rule invalid for iceberg table
Related with #1030 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
```
MySQL [external_db]> explain select col_date from ex_iceberg_tbl8 where col_date >= '2020-01-01';
+----------------------------------------------+
| Explain String                               |
+----------------------------------------------+
| PLAN FRAGMENT 0                              |
|  OUTPUT EXPRS:7: col_date                    |
|   PARTITION: UNPARTITIONED                   |
|                                              |
|   RESULT SINK                                |
|                                              |
|   2:EXCHANGE                                 |
|                                              |
| PLAN FRAGMENT 1                              |
|  OUTPUT EXPRS:                               |
|   PARTITION: RANDOM                          |
|                                              |
|   STREAM DATA SINK                           |
|     EXCHANGE ID: 02                          |
|     UNPARTITIONED                            |
|                                              |
|   1:Project                                  |
|   |  <slot 7> : 7: col_date                  |
|   |                                          |
|   0:IcebergScanNode                          |
|      TABLE: ex_iceberg_tbl8                  |
|      PREDICATES: 7: col_date >= '2020-01-01' |
|      cardinality=1                           |
|      avgRowSize=2.0                          |
|      numNodes=0                              |
+----------------------------------------------+
```
to
```
MySQL [external_db]> explain select col_date from ex_iceberg_tbl8 where col_date >= '2020-01-01';
+----------------------------------------------+
| Explain String                               |
+----------------------------------------------+
| PLAN FRAGMENT 0                              |
|  OUTPUT EXPRS:7: col_date                    |
|   PARTITION: UNPARTITIONED                   |
|                                              |
|   RESULT SINK                                |
|                                              |
|   1:EXCHANGE                                 |
|                                              |
| PLAN FRAGMENT 1                              |
|  OUTPUT EXPRS:                               |
|   PARTITION: RANDOM                          |
|                                              |
|   STREAM DATA SINK                           |
|     EXCHANGE ID: 01                          |
|     UNPARTITIONED                            |
|                                              |
|   0:IcebergScanNode                          |
|      TABLE: ex_iceberg_tbl8                  |
|      PREDICATES: 7: col_date >= '2020-01-01' |
|      cardinality=1                           |
|      avgRowSize=1.0                          |
|      numNodes=0                              |
+----------------------------------------------+
```
