### PR TITLE
Fix the bug of unregistering clone tablet when clone task fails(#3134)

### DIFF
--- a/be/src/storage/task/engine_clone_task.cpp
+++ b/be/src/storage/task/engine_clone_task.cpp
@@ -72,13 +72,12 @@ EngineCloneTask::EngineCloneTask(MemTracker* mem_tracker, const TCloneReq& clone
 Status EngineCloneTask::execute() {
     MemTracker* prev_tracker = tls_thread_status.set_mem_tracker(_mem_tracker.get());
     auto tablet_manager = StorageEngine::instance()->tablet_manager();
+    // Prevent the snapshot directory from been removed by the path GC worker.
+    tablet_manager->register_clone_tablet(_clone_req.tablet_id);
     DeferOp op([&] {
         tls_thread_status.set_mem_tracker(prev_tracker);
         tablet_manager->unregister_clone_tablet(_clone_req.tablet_id);
     });
-
-    // Prevent the snapshot directory from been removed by the path GC worker.
-    tablet_manager->register_clone_tablet(_clone_req.tablet_id);
     auto tablet = tablet_manager->get_tablet(_clone_req.tablet_id, false);
     if (tablet != nullptr) {
         std::shared_lock rlock(tablet->get_migration_lock(), std::try_to_lock);

--- a/be/src/storage/task/engine_clone_task.cpp
+++ b/be/src/storage/task/engine_clone_task.cpp
@@ -74,7 +74,7 @@ Status EngineCloneTask::execute() {
     auto tablet_manager = StorageEngine::instance()->tablet_manager();
     DeferOp op([&] {
         tls_thread_status.set_mem_tracker(prev_tracker);
-        tablet_manager->unregister_clone_tablet(_clone_req.tablet_id);    
+        tablet_manager->unregister_clone_tablet(_clone_req.tablet_id);
     });
 
     // Prevent the snapshot directory from been removed by the path GC worker.
@@ -94,7 +94,7 @@ Status EngineCloneTask::execute() {
         auto st = _do_clone(nullptr);
         _set_tablet_info(st, true);
     }
-    
+
     return Status::OK();
 }
 

--- a/be/src/storage/task/engine_clone_task.cpp
+++ b/be/src/storage/task/engine_clone_task.cpp
@@ -71,9 +71,12 @@ EngineCloneTask::EngineCloneTask(MemTracker* mem_tracker, const TCloneReq& clone
 
 Status EngineCloneTask::execute() {
     MemTracker* prev_tracker = tls_thread_status.set_mem_tracker(_mem_tracker.get());
-    DeferOp op([&] { tls_thread_status.set_mem_tracker(prev_tracker); });
-
     auto tablet_manager = StorageEngine::instance()->tablet_manager();
+    DeferOp op([&] {
+        tls_thread_status.set_mem_tracker(prev_tracker);
+        tablet_manager->unregister_clone_tablet(_clone_req.tablet_id);    
+    });
+
     // Prevent the snapshot directory from been removed by the path GC worker.
     tablet_manager->register_clone_tablet(_clone_req.tablet_id);
     auto tablet = tablet_manager->get_tablet(_clone_req.tablet_id, false);
@@ -91,7 +94,7 @@ Status EngineCloneTask::execute() {
         auto st = _do_clone(nullptr);
         _set_tablet_info(st, true);
     }
-    tablet_manager->unregister_clone_tablet(_clone_req.tablet_id);
+    
     return Status::OK();
 }
 


### PR DESCRIPTION
## What type of PR is this：
- [X] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3134 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
clone task do not deregister itself when fails, which will lead to the fact that the tablet can not be GCed when dropped.