### PR TITLE
Restrict large deletes

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -782,6 +782,12 @@ public class Config extends ConfigBase {
     public static int max_allowed_in_element_num_of_delete = 10000;
 
     /**
+     * Used to limit element num of tablet mark in delete statement.
+     */
+    @ConfField(mutable = true)
+    public static int max_mark_delete_tablet_per_be = 1024;
+
+    /**
      * only limit for Row-based storage.
      * set to Integer.MAX_VALUE, cause starrocks is already Column-based storage
      */

--- a/fe/fe-core/src/main/java/com/starrocks/load/DeleteHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/DeleteHandler.java
@@ -229,6 +229,14 @@ public class DeleteHandler implements Writable {
                         }
                     }
                 }
+                //
+                int beCount = Catalog.getCurrentSystemInfo().getBackendIds(true).size();
+                int estimatedDeleteTaskLimit = beCount * Config.max_mark_delete_tablet_per_be;
+                if (totalReplicaNum > estimatedDeleteTaskLimit) {
+                    throw new DdlException("failed to execute delete because statement this operation is too large. " +
+                            "will mark " + totalReplicaNum + " tablet exceed limit " + estimatedDeleteTaskLimit +
+                            ". you can try to specify the delete partition to lower the mark tablet.");
+                }
 
                 countDownLatch = new MarkedCountDownLatch<>(totalReplicaNum);
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/DeleteHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/DeleteHandler.java
@@ -231,6 +231,11 @@ public class DeleteHandler implements Writable {
                 }
                 //
                 int beCount = Catalog.getCurrentSystemInfo().getBackendIds(true).size();
+
+                if (beCount == 0) {
+                    throw new DdlException("No backend alive.");
+                }
+
                 int estimatedDeleteTaskLimit = beCount * Config.max_mark_delete_tablet_per_be;
                 if (totalReplicaNum > estimatedDeleteTaskLimit) {
                     throw new DdlException("failed to execute delete because statement this operation is too large. " +

--- a/fe/fe-core/src/test/java/com/starrocks/load/DeleteHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/DeleteHandlerTest.java
@@ -1,5 +1,6 @@
 package com.starrocks.load;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.starrocks.analysis.AccessTestUtil;
@@ -44,6 +45,7 @@ import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.internal.runners.statements.ExpectException;
 
 import java.util.Collection;
 import java.util.List;
@@ -74,6 +76,8 @@ public class DeleteHandlerTest {
     private AgentTaskQueue agentTaskQueue;
     @Mocked
     private AgentTaskExecutor executor;
+    @Mocked
+    private SystemInfoService systemInfoService;
 
     private Database db;
     private Auth auth;
@@ -148,7 +152,17 @@ public class DeleteHandlerTest {
         };
         globalTransactionMgr.addDatabaseTransactionMgr(db.getId());
 
-        SystemInfoService systemInfoService = new SystemInfoService();
+        List<Long> ids = Lists.newArrayList();
+        ids.add(10000L);
+
+        new Expectations() {
+            {
+                systemInfoService.getBackendIds(true);
+                minTimes = 0;
+                result = ids;
+            }
+        };
+
         new Expectations() {
             {
                 Catalog.getCurrentCatalog();
@@ -173,12 +187,9 @@ public class DeleteHandlerTest {
                 Catalog.getCurrentSystemInfo();
                 minTimes = 0;
                 result = systemInfoService;
-
-                systemInfoService.getBackendIds(true);
-                minTimes = 0;
-                result = Lists.newArrayList();
             }
         };
+
     }
 
     @Test(expected = DdlException.class)


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3137

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

add config max_mark_delete_tablet_per_be default 1024 to avoid large delete send to be pool
