### PR TITLE
BugFix: Fix data race between getting latest apply version of rowset and GC thread 

### DIFF
--- a/be/src/storage/rowset_update_state.cpp
+++ b/be/src/storage/rowset_update_state.cpp
@@ -270,7 +270,7 @@ Status RowsetUpdateState::_check_and_resolve_conflict(Tablet* tablet, Rowset* ro
         return Status::InternalError("write column is empty");
     }
 
-    // _read_version is equal to lastest_applied_version which means there is no other rowset is applied
+    // _read_version is equal to latest_applied_version which means there is no other rowset is applied
     // the data of write_columns can be write to segment file directly
     if (latest_applied_version == _read_version) {
         return Status::OK();
@@ -339,7 +339,7 @@ Status RowsetUpdateState::_check_and_resolve_conflict(Tablet* tablet, Rowset* ro
     return Status::OK();
 }
 
-Status RowsetUpdateState::apply(Tablet* tablet, Rowset* rowset, uint32_t rowset_id, EditVersion lastest_applied_version,
+Status RowsetUpdateState::apply(Tablet* tablet, Rowset* rowset, uint32_t rowset_id, EditVersion latest_applied_version,
                                 const PrimaryIndex& index) {
     const auto& rowset_meta_pb = rowset->rowset_meta()->get_meta_pb();
     if (!rowset_meta_pb.has_txn_meta()) {
@@ -370,7 +370,7 @@ Status RowsetUpdateState::apply(Tablet* tablet, Rowset* rowset, uint32_t rowset_
     });
     bool is_rewrite = config::rewrite_partial_segment;
     RETURN_IF_ERROR(
-            _check_and_resolve_conflict(tablet, rowset, rowset_id, lastest_applied_version, read_column_ids, index));
+            _check_and_resolve_conflict(tablet, rowset, rowset_id, latest_applied_version, read_column_ids, index));
 
     for (size_t i = 0; i < num_segments; i++) {
         auto src_path = BetaRowset::segment_file_path(tablet->schema_hash_path(), rowset->rowset_id(), i);

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -273,6 +273,8 @@ private:
 
     void _ignore_rowset_commit(int64_t version, const RowsetSharedPtr& rowset);
 
+    void _get_latest_applied_version(EditVersion* latest_applied_version);
+
     void _apply_rowset_commit(const EditVersionInfo& version_info);
 
     void _apply_compaction_commit(const EditVersionInfo& version_info);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When executing apply of partial_rowset, we need to get the latest applied version to check for conflicts; we may get an index out of boundary error when GC threads and apply threads are concurrent.
This pr avoids error by adding `lock` to get the latest applied version.