### PR TITLE
[pipeline] make one scan operator able to commit multiple i/o tasks

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -655,6 +655,9 @@ CONF_Int64(pipeline_io_buffer_size, "64");
 CONF_Int64(pipeline_sink_buffer_size, "64");
 // the degree of parallelism of brpc
 CONF_Int64(pipeline_sink_brpc_dop, "8");
+
+CONF_Int64(pipeline_scan_max_tasks_per_operator, "4");
+
 // bitmap serialize version
 CONF_Int16(bitmap_serialize_version, "1");
 // max hdfs file handle

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -180,11 +180,7 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
         morsel_queues.emplace(scan_node->id(), std::make_unique<MorselQueue>(std::move(morsels)));
     }
 
-    std::remove_cv_t<typeof(request.per_scan_node_dop)> per_scan_node_dop;
-    if (request.__isset.per_scan_node_dop) {
-        per_scan_node_dop = request.per_scan_node_dop;
-    }
-    PipelineBuilderContext context(_fragment_ctx, degree_of_parallelism, std::move(per_scan_node_dop));
+    PipelineBuilderContext context(_fragment_ctx, degree_of_parallelism);
     PipelineBuilder builder(context);
     _fragment_ctx->set_pipelines(builder.build(*_fragment_ctx, plan));
     // Set up sink, if required

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -219,7 +219,7 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
             if (morsel_queue->num_morsels() > 0) {
                 DCHECK(degree_of_parallelism <= morsel_queue->num_morsels());
             }
-            std::vector<MorselQueuePtr> morsel_queue_per_driver = morsel_queue->splitByNum(degree_of_parallelism);
+            std::vector<MorselQueuePtr> morsel_queue_per_driver = morsel_queue->split_by_size(degree_of_parallelism);
             DCHECK(morsel_queue_per_driver.size() == degree_of_parallelism);
 
             if (is_root) {

--- a/be/src/exec/pipeline/morsel.h
+++ b/be/src/exec/pipeline/morsel.h
@@ -57,6 +57,8 @@ public:
         }
     }
 
+    bool empty() const { return _pop_index >= _num_morsels; }
+
 private:
     Morsels _morsels;
     const size_t _num_morsels;

--- a/be/src/exec/pipeline/morsel.h
+++ b/be/src/exec/pipeline/morsel.h
@@ -59,6 +59,22 @@ public:
 
     bool empty() const { return _pop_index >= _num_morsels; }
 
+    std::vector<MorselQueuePtr> splitByNum(size_t num_dest_morsel_queues) {
+        const size_t num_morsels_per_queue = (_num_morsels + num_dest_morsel_queues - 1) / num_dest_morsel_queues;
+        std::vector<MorselQueuePtr> dest_morsel_queues;
+        for (int i = 0; i < num_dest_morsel_queues; ++i) {
+            Morsels morsels;
+            while (morsels.size() < num_morsels_per_queue && !empty()) {
+                auto maybe_morsel = try_get();
+                DCHECK(maybe_morsel.has_value());
+                morsels.emplace_back(std::move(maybe_morsel.value()));
+            }
+            dest_morsel_queues.emplace_back(std::make_unique<MorselQueue>(std::move(morsels)));
+        }
+
+        return dest_morsel_queues;
+    }
+
 private:
     Morsels _morsels;
     const size_t _num_morsels;

--- a/be/src/exec/pipeline/pipeline_builder.h
+++ b/be/src/exec/pipeline/pipeline_builder.h
@@ -14,11 +14,8 @@ namespace pipeline {
 
 class PipelineBuilderContext {
 public:
-    PipelineBuilderContext(FragmentContext* fragment_context, size_t degree_of_parallelism,
-                           std::map<TPlanNodeId, int>&& per_scan_node_dop)
-            : _fragment_context(fragment_context),
-              _degree_of_parallelism(degree_of_parallelism),
-              _per_scan_node_dop(std::move(per_scan_node_dop)) {}
+    PipelineBuilderContext(FragmentContext* fragment_context, size_t degree_of_parallelism)
+            : _fragment_context(fragment_context), _degree_of_parallelism(degree_of_parallelism) {}
 
     void add_pipeline(const OpFactories& operators) {
         _pipelines.emplace_back(std::make_unique<Pipeline>(next_pipe_id(), operators));
@@ -61,14 +58,6 @@ public:
 
     FragmentContext* fragment_context() { return _fragment_context; }
 
-    size_t get_dop_of_scan_node(TPlanNodeId id) const {
-        if (_per_scan_node_dop.count(id)) {
-            return _per_scan_node_dop.at(id);
-        } else {
-            return _degree_of_parallelism;
-        }
-    }
-
 private:
     FragmentContext* _fragment_context;
     Pipelines _pipelines;
@@ -76,7 +65,6 @@ private:
     uint32_t _next_operator_id = 0;
     int32_t _next_pseudo_plan_node_id = Operator::s_pseudo_plan_node_id_upper_bound;
     size_t _degree_of_parallelism = 1;
-    std::map<TPlanNodeId, int> _per_scan_node_dop;
 };
 
 class PipelineBuilder {

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -60,7 +60,7 @@ Status PipelineDriver::prepare(RuntimeState* runtime_state) {
     _local_rf_waiting_set_counter->set((int64_t)all_local_rf_set.size());
     _local_rf_holders = fragment_ctx()->runtime_filter_hub()->gather_holders(all_local_rf_set);
 
-    source_operator()->add_morsel_queue(_morsel_queue);
+    source_operator()->add_morsel_queue(_morsel_queue.get());
     for (auto& op : _operators) {
         RETURN_IF_ERROR(op->prepare(runtime_state));
         _operator_stages[op->get_id()] = OperatorStage::PREPARED;

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -165,7 +165,7 @@ public:
     int32_t source_node_id() { return _source_node_id; }
     int32_t driver_id() const { return _driver_id; }
     DriverPtr clone() { return std::make_shared<PipelineDriver>(*this); }
-    void set_morsel_queue(MorselQueue* morsel_queue) { _morsel_queue = morsel_queue; }
+    void set_morsel_queue(MorselQueuePtr morsel_queue) { _morsel_queue = std::move(morsel_queue); }
     Status prepare(RuntimeState* runtime_state);
     StatusOr<DriverState> process(RuntimeState* runtime_state);
     void finalize(RuntimeState* runtime_state, DriverState state);
@@ -376,7 +376,7 @@ private:
     const bool _is_root;
     DriverAcct _driver_acct;
     // The first one is source operator
-    MorselQueue* _morsel_queue = nullptr;
+    MorselQueuePtr _morsel_queue = nullptr;
     // _state must be set by set_driver_state() to record state timer.
     DriverState _state;
     std::shared_ptr<RuntimeProfile> _runtime_profile = nullptr;

--- a/be/src/exec/pipeline/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan_operator.cpp
@@ -63,7 +63,14 @@ bool ScanOperator::has_output() const {
         return false;
     }
 
-    // Because commit i/o task is trigger in pull_chunk, return true if more i/o tasks can be committed.
+    // Because committing i/o task is trigger ONLY in pull_chunk,
+    // return true if more i/o tasks can be committed.
+
+    // Can pick up more morsels.
+    if (!_morsel_queue->empty()) {
+        return true;
+    }
+
     // Can trigger_next_scan for the picked-up morsel.
     for (int i = 0; i < _max_io_tasks_per_op; ++i) {
         if (_chunk_sources[i] != nullptr && !_is_io_task_running[i] && _chunk_sources[i]->has_next_chunk()) {
@@ -71,8 +78,7 @@ bool ScanOperator::has_output() const {
         }
     }
 
-    // Can pick up more morsels.
-    return !_morsel_queue->empty();
+    return false;
 }
 
 bool ScanOperator::pending_finish() const {

--- a/be/src/exec/pipeline/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan_operator.cpp
@@ -104,7 +104,7 @@ bool ScanOperator::is_finished() const {
         }
     }
 
-    // This can operator is finished, if no more io tasks are running
+    // This scan operator is finished, if no more io tasks are running
     // or need to run, and all the read chunks are consumed.
     return true;
 }

--- a/be/src/exec/pipeline/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan_operator.cpp
@@ -13,8 +13,10 @@
 namespace starrocks::pipeline {
 
 Status ScanOperator::prepare(RuntimeState* state) {
-    SourceOperator::prepare(state);
+    RETURN_IF_ERROR(SourceOperator::prepare(state));
+
     DCHECK(_io_threads != nullptr);
+
     _state = state;
     auto num_scan_operators = 1 + state->exec_env()->increment_num_scan_operators(1);
     if (num_scan_operators > _io_threads->get_queue_capacity()) {
@@ -33,13 +35,16 @@ Status ScanOperator::prepare(RuntimeState* state) {
 }
 
 Status ScanOperator::close(RuntimeState* state) {
-    // decrement global counter num_scan_operators.
+    DCHECK(_num_running_io_tasks == 0);
+
     state->exec_env()->decrement_num_scan_operators(1);
-    DCHECK(!_is_io_task_active.load(std::memory_order_acquire));
-    if (_chunk_source) {
-        _chunk_source->close(state);
-        _chunk_source = nullptr;
+    for (auto& chunk_source : _chunk_sources) {
+        if (chunk_source != nullptr) {
+            chunk_source->close(_state);
+            chunk_source = nullptr;
+        }
     }
+
     return Operator::close(state);
 }
 
@@ -48,41 +53,42 @@ bool ScanOperator::has_output() const {
         return false;
     }
 
-    // _chunk_source init at pull_chunk()
-    // so the the initialization of the first chunk_source needs
-    // to be driven by has_output() returning true
-    if (!_chunk_source) {
-        return true;
+    for (const auto& chunk_source : _chunk_sources) {
+        if (chunk_source != nullptr && chunk_source->has_output()) {
+            return true;
+        }
     }
 
-    DCHECK(_chunk_source != nullptr);
-
-    // Still have buffered chunks
-    if (_chunk_source->has_output()) {
-        return true;
-    }
-
-    // io task is busy reading chunks, so we just wait
-    if (_is_io_task_active.load(std::memory_order_acquire)) {
-        return false;
-    }
-
-    // Here are two situation
-    // 1. Cache is empty out and morsel is not eof, _trigger_next_scan is required
-    // 2. Cache is empty and morsel is eof, _pickup_morsel is required
-    // Either of which needs to be triggered in pull_chunk, so we return true here
-    return true;
+    // The io task is committed by pull_chunk, so return true here if more io tasks can be committed.
+    return _num_running_io_tasks < _max_io_tasks_per_op;
 }
 
 bool ScanOperator::pending_finish() const {
     DCHECK(_is_finished);
-    // If there is no next morsel, and io task is active
-    // we just wait for the io thread to end
-    return _is_io_task_active.load(std::memory_order_acquire);
+    // If there isn't next morsel, and any io task is active,
+    // we just wait for the io thread to end.
+    return _num_running_io_tasks > 0;
 }
 
 bool ScanOperator::is_finished() const {
-    return _is_finished;
+    if (_is_finished) {
+        return true;
+    }
+
+    // Any io task is running or needs to run.
+    if (_num_running_io_tasks > 0 || !_morsel_queue->empty()) {
+        return false;
+    }
+
+    for (const auto& chunk_source : _chunk_sources) {
+        if (chunk_source != nullptr && chunk_source->has_output()) {
+            return false;
+        }
+    }
+
+    // This can operator is finished, if no more io tasks are running
+    // or need to run, and all the read chunks are consumed.
+    return true;
 }
 
 void ScanOperator::set_finishing(RuntimeState* state) {
@@ -90,52 +96,66 @@ void ScanOperator::set_finishing(RuntimeState* state) {
 }
 
 StatusOr<vectorized::ChunkPtr> ScanOperator::pull_chunk(RuntimeState* state) {
-    if (!_chunk_source) {
-        RETURN_IF_ERROR(_pickup_morsel(state));
-        return nullptr;
-    }
+    RETURN_IF_ERROR(_try_to_trigger_next_scan(state));
 
-    DCHECK(_chunk_source != nullptr);
-    if (!_chunk_source->has_output()) {
-        if (_chunk_source->has_next_chunk()) {
-            RETURN_IF_ERROR(_trigger_next_scan(state));
-        } else {
-            RETURN_IF_ERROR(_pickup_morsel(state));
+    for (auto& chunk_source : _chunk_sources) {
+        if (chunk_source != nullptr && chunk_source->has_output()) {
+            auto&& chunk = chunk_source->get_next_chunk_from_buffer();
+            eval_runtime_bloom_filters(chunk.value().get());
+
+            return std::move(chunk);
         }
-        return nullptr;
     }
 
-    auto&& chunk = _chunk_source->get_next_chunk_from_buffer();
-    // If number of cached chunk is smaller than half of buffer_size,
-    // we can start the next scan task ahead of time to obtain better continuity
-    if (_chunk_source->get_buffer_size() < (_buffer_size >> 1) && !_is_io_task_active.load(std::memory_order_acquire) &&
-        _chunk_source->has_next_chunk()) {
-        RETURN_IF_ERROR(_trigger_next_scan(state));
-    }
-
-    eval_runtime_bloom_filters(chunk.value().get());
-
-    return chunk;
+    return nullptr;
 }
 
-Status ScanOperator::_trigger_next_scan(RuntimeState* state) {
-    DCHECK(!_is_io_task_active.load(std::memory_order_acquire));
+Status ScanOperator::_try_to_trigger_next_scan(RuntimeState* state) {
+    if (_num_running_io_tasks >= _max_io_tasks_per_op) {
+        return Status::OK();
+    }
+
+    // Firstly, find the picked-up morsel, whose can commit an io task.
+    for (int i = 0; i < _max_io_tasks_per_op && _num_running_io_tasks < _max_io_tasks_per_op; ++i) {
+        if (_chunk_sources[i] != nullptr && !_is_io_task_running[i] && _chunk_sources[i]->has_next_chunk()) {
+            RETURN_IF_ERROR(_trigger_next_scan(state, i));
+        }
+    }
+
+    // Secondly, find the unused position of _chunk_sources to pick up a new morsel.
+    if (!_morsel_queue->empty()) {
+        for (int i = 0; i < _max_io_tasks_per_op && _num_running_io_tasks < _max_io_tasks_per_op; ++i) {
+            if (_chunk_sources[i] == nullptr || (!_is_io_task_running[i] && !_chunk_sources[i]->has_output())) {
+                RETURN_IF_ERROR(_pickup_morsel(state, i));
+            }
+        }
+    }
+
+    return Status::OK();
+}
+
+Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_index) {
+    _num_running_io_tasks++;
+    _is_io_task_running[chunk_source_index] = true;
 
     PriorityThreadPool::Task task;
-    _is_io_task_active.store(true, std::memory_order_release);
-    task.work_function = [this, state]() {
+    task.work_function = [this, state, chunk_source_index]() {
         {
             SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(state->instance_mem_tracker());
-            _chunk_source->buffer_next_batch_chunks_blocking(_buffer_size, _is_finished);
+            _chunk_sources[chunk_source_index]->buffer_next_batch_chunks_blocking(_buffer_size, _is_finished);
         }
-        _is_io_task_active.store(false, std::memory_order_release);
+
+        _num_running_io_tasks--;
+        _is_io_task_running[chunk_source_index] = false;
     };
     // TODO(by satanson): set a proper priority
     task.priority = 20;
+
     if (_io_threads->try_offer(task)) {
         _io_task_retry_cnt = 0;
     } else {
-        _is_io_task_active.store(false, std::memory_order_release);
+        _num_running_io_tasks--;
+        _is_io_task_running[chunk_source_index] = false;
         // TODO(hcf) set a proper retry times
         LOG(WARNING) << "ScanOperator failed to offer io task due to thread pool overload, retryCnt="
                      << _io_task_retry_cnt;
@@ -143,40 +163,41 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state) {
             return Status::RuntimeError("ScanOperator failed to offer io task due to thread pool overload");
         }
     }
+
     return Status::OK();
 }
 
-Status ScanOperator::_pickup_morsel(RuntimeState* state) {
+Status ScanOperator::_pickup_morsel(RuntimeState* state, int chunk_source_index) {
     DCHECK(_morsel_queue != nullptr);
-    DCHECK(!_is_io_task_active.load(std::memory_order_acquire));
-    if (_chunk_source) {
-        _chunk_source->close(state);
-        _chunk_source = nullptr;
+    if (_chunk_sources[chunk_source_index] != nullptr) {
+        _chunk_sources[chunk_source_index]->close(state);
+        _chunk_sources[chunk_source_index] = nullptr;
     }
+
     auto maybe_morsel = _morsel_queue->try_get();
-    if (!maybe_morsel.has_value()) {
-        // release _chunk_source before _curr_morsel, because _chunk_source depends on _curr_morsel.
-        _chunk_source = nullptr;
-        _is_finished = true;
-    } else {
+    if (maybe_morsel.has_value()) {
         auto morsel = std::move(maybe_morsel.value());
         DCHECK(morsel);
+
         bool enable_column_expr_predicate = false;
         if (_olap_scan_node.__isset.enable_column_expr_predicate) {
             enable_column_expr_predicate = _olap_scan_node.enable_column_expr_predicate;
         }
-        _chunk_source = std::make_shared<OlapChunkSource>(
+
+        _chunk_sources[chunk_source_index] = std::make_shared<OlapChunkSource>(
                 std::move(morsel), _olap_scan_node.tuple_id, _limit, enable_column_expr_predicate, _conjunct_ctxs,
                 runtime_in_filters(), runtime_bloom_filters(), _olap_scan_node.key_column_name,
                 _olap_scan_node.is_preaggregation, &_unused_output_columns, _runtime_profile.get());
-        auto status = _chunk_source->prepare(state);
+        auto status = _chunk_sources[chunk_source_index]->prepare(state);
         if (!status.ok()) {
-            _chunk_source = nullptr;
+            _chunk_sources[chunk_source_index] = nullptr;
             _is_finished = true;
             return status;
         }
-        RETURN_IF_ERROR(_trigger_next_scan(state));
+
+        RETURN_IF_ERROR(_trigger_next_scan(state, chunk_source_index));
     }
+
     return Status::OK();
 }
 

--- a/be/src/exec/pipeline/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan_operator.cpp
@@ -59,17 +59,19 @@ bool ScanOperator::has_output() const {
         }
     }
 
-    // The io task is committed by pull_chunk, so return true here if more io tasks can be committed.
     if (_num_running_io_tasks >= _max_io_tasks_per_op) {
         return false;
     }
 
+    // Because commit i/o task is trigger in pull_chunk, return true if more i/o tasks can be committed.
+    // Can trigger_next_scan for the picked-up morsel.
     for (int i = 0; i < _max_io_tasks_per_op; ++i) {
         if (_chunk_sources[i] != nullptr && !_is_io_task_running[i] && _chunk_sources[i]->has_next_chunk()) {
             return true;
         }
     }
 
+    // Can pick up more morsels.
     return !_morsel_queue->empty();
 }
 

--- a/be/src/exec/pipeline/scan_operator.h
+++ b/be/src/exec/pipeline/scan_operator.h
@@ -23,7 +23,9 @@ public:
             : SourceOperator(factory, id, "olap_scan", plan_node_id),
               _olap_scan_node(olap_scan_node),
               _conjunct_ctxs(conjunct_ctxs),
-              _limit(limit) {}
+              _limit(limit),
+              _is_io_task_running(_max_io_tasks_per_op),
+              _chunk_sources(_max_io_tasks_per_op) {}
 
     ~ScanOperator() override = default;
 
@@ -43,19 +45,21 @@ public:
     void set_io_threads(PriorityThreadPool* io_threads) { _io_threads = io_threads; }
 
 private:
+    const size_t _buffer_size = config::pipeline_io_buffer_size;
+    const int _max_io_tasks_per_op = config::pipeline_scan_max_tasks_per_operator;
+
     // This method is only invoked when current morsel is reached eof
     // and all cached chunk of this morsel has benn read out
-    Status _pickup_morsel(RuntimeState* state);
-    Status _trigger_next_scan(RuntimeState* state);
+    Status _pickup_morsel(RuntimeState* state, int chunk_source_index);
+    Status _trigger_next_scan(RuntimeState* state, int chunk_source_index);
+    Status _try_to_trigger_next_scan(RuntimeState* state);
 
-private:
     // TODO(hcf) ugly, remove this later
     RuntimeState* _state = nullptr;
 
-    const size_t _buffer_size = config::pipeline_io_buffer_size;
-    mutable bool _is_finished = false;
-    std::atomic_bool _is_io_task_active = false;
+    bool _is_finished = false;
     int32_t _io_task_retry_cnt = 0;
+
     const TOlapScanNode& _olap_scan_node;
     const std::vector<ExprContext*>& _conjunct_ctxs;
     PriorityThreadPool* _io_threads = nullptr;
@@ -63,6 +67,10 @@ private:
     // Pass limit info to scan operator in order to improve sql:
     // select * from table limit x;
     int64_t _limit; // -1: no limit
+
+    std::atomic<int> _num_running_io_tasks = 0;
+    std::vector<std::atomic<bool>> _is_io_task_running;
+    std::vector<ChunkSourcePtr> _chunk_sources;
 };
 
 class ScanOperatorFactory final : public SourceOperatorFactory {

--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -557,13 +557,19 @@ pipeline::OpFactories OlapScanNode::decompose_to_pipeline(pipeline::PipelineBuil
                                                                std::move(_conjunct_ctxs), limit());
     // Initialize OperatorFactory's fields involving runtime filters.
     this->init_runtime_filter_for_operator(scan_operator.get(), context, rc_rf_probe_collector);
-    scan_operator->set_degree_of_parallelism(context->get_dop_of_scan_node(this->id()));
+    auto& morsel_queues = context->fragment_context()->morsel_queues();
+    auto source_id = scan_operator->plan_node_id();
+    DCHECK(morsel_queues.count(source_id));
+    auto& morsel_queue = morsel_queues[source_id];
+    // ScanOperator's degree_of_parallelism is not more than the number of morsels
+    // If table is empty, then morsel size is zero and we still set degree of parallelism to 1
+    const auto degree_of_parallelism =
+            std::min<size_t>(std::max<size_t>(1, morsel_queue->num_morsels()), context->degree_of_parallelism());
+    scan_operator->set_degree_of_parallelism(degree_of_parallelism);
     operators.emplace_back(std::move(scan_operator));
     if (limit() != -1) {
         operators.emplace_back(std::make_shared<LimitOperatorFactory>(context->next_operator_id(), id(), limit()));
     }
-    operators = context->maybe_interpolate_local_passthrough_exchange(context->fragment_context()->runtime_state(),
-                                                                      operators, context->degree_of_parallelism());
     return operators;
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -194,17 +194,6 @@ public class PlanFragment extends TreeNode<PlanFragment> {
         return destNode;
     }
 
-    public void getOlapScanNodes(PlanNode root, List<PlanNode> scanNodes) {
-        if (root instanceof OlapScanNode) {
-            scanNodes.add(root);
-            return;
-        }
-
-        for (PlanNode child : root.getChildren()) {
-            getOlapScanNodes(child, scanNodes);
-        }
-    }
-
     public ArrayList<Expr> getOutputExprs() {
         return outputExprs;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -107,7 +107,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -404,8 +403,6 @@ public class Coordinator {
         computeScanRangeAssignment();
 
         computeFragmentExecParams();
-
-        computeScanDop();
 
         traceInstance();
 
@@ -927,36 +924,6 @@ public class Coordinator {
 
     }
 
-    // compute degree of parallelism(dop) for each OlapScanNode in a fragment instance.
-    // the maxScanOperators is numRows of ScanNode divided by session variable pipelineMaxRowCountPerScanOperator,
-    // then each fragment instance take the share of itself own numScanRanges divided by totalNumScanRanges, and
-    // the dop of OlapScanNode is at least 1 and at most minimum(itself own numScanRanges, half the avg number of be cores).
-    private void computeScanDop() {
-        // only take effect in pipeline engine
-        if (ConnectContext.get() == null || !ConnectContext.get().getSessionVariable().isEnablePipelineEngine()) {
-            return;
-        }
-        int dop = ConnectContext.get().getSessionVariable().getDegreeOfParallelism();
-        for (FragmentExecParams params : fragmentExecParamsMap.values()) {
-            if (!params.fragment.getPlanRoot().canUsePipeLine()) {
-                continue;
-            }
-            List<PlanNode> scanNodes = new LinkedList<>();
-            params.fragment.getOlapScanNodes(params.fragment.getPlanRoot(), scanNodes);
-            for (PlanNode node : scanNodes) {
-                OlapScanNode scanNode = (OlapScanNode) node;
-                for (FInstanceExecParam instanceExecParam : params.instanceExecParams) {
-                    int numScanRanges = 0;
-                    if (instanceExecParam.perNodeScanRanges.containsKey(scanNode.getId().asInt())) {
-                        numScanRanges = instanceExecParam.perNodeScanRanges.get(scanNode.getId().asInt()).size();
-                    }
-                    int scanDopLimit = Math.max(1, Math.min(dop, numScanRanges));
-                    instanceExecParam.perScanNodeDop.put(scanNode.getId().asInt(), scanDopLimit);
-                }
-            }
-        }
-    }
-
     private void handleMultiCastFragmentParams() throws Exception {
         for (FragmentExecParams params : fragmentExecParamsMap.values()) {
             if (!(params.fragment instanceof MultiCastPlanFragment)) {
@@ -1223,31 +1190,9 @@ public class Coordinator {
                     int degreeOfParallelism = ConnectContext.get().getSessionVariable().getDegreeOfParallelism();
                     FragmentExecParams param = fragmentExecParamsMap.get(fragment.getFragmentId());
                     int numBackends = param.scanRangeAssignment.size();
-                    // param.instanceExecParams.size() maybe zero
-                    int numInstances = Math.max(1, param.instanceExecParams.size());
-                    OlapScanNode scanNode = (OlapScanNode) leftMostNode;
-                    int numScanRangesPerInstance = scanNode.getScanRangeLocations(0).size() / numInstances;
-                    numScanRangesPerInstance = Math.max(1, numScanRangesPerInstance);
-                    long numRows = scanNode.getCardinality();
-                    if (scanNode.hasLimit()) {
-                        numRows = Math.min(numRows, scanNode.getLimit());
-                    }
-
-                    float inputBytes = numRows * scanNode.getAvgRowSize();
-                    long maxBytesPerOperator =
-                            ConnectContext.get().getSessionVariable().getPipelineMaxInputBytesPerOperator();
-                    int numOperatorsPerInstance = Math.max(1, (int) (inputBytes / maxBytesPerOperator / numInstances));
+                    int numInstances = param.instanceExecParams.size();
                     int pipelineDop =
                             Math.max(1, degreeOfParallelism / Math.max(1, numInstances / Math.max(1, numBackends)));
-
-                    // Although 0 may be returned by scanNode.getCardinality(), scanNode still can produce rows for its
-                    // following operator.
-                    if (numRows > 0 && numScanRangesPerInstance < pipelineDop) {
-                        pipelineDop = Math.min(pipelineDop, numOperatorsPerInstance);
-                    } else {
-                        pipelineDop = Math.min(pipelineDop, numScanRangesPerInstance);
-                    }
-                    pipelineDop = Math.max(1, pipelineDop);
                     param.fragment.setPipelineDop(pipelineDop);
                 }
             }
@@ -1684,7 +1629,6 @@ public class Coordinator {
         TUniqueId instanceId;
         TNetworkAddress host;
         Map<Integer, List<TScanRangeParams>> perNodeScanRanges = Maps.newHashMap();
-        Map<Integer, Integer> perScanNodeDop = Maps.newHashMap();
 
         int perFragmentInstanceIdx;
 
@@ -1981,7 +1925,6 @@ public class Coordinator {
                             params.getQuery_options().setBatch_size(SessionVariable.PIPELINE_BATCH_SIZE);
                         }
                         params.setPipeline_dop(fragment.getPipelineDop());
-                        params.setPer_scan_node_dop(instanceExecParam.perScanNodeDop);
                     }
 
                     if (sessionVariable.isEnableExchangePassThrough()) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -117,8 +117,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String PIPELINE_DOP = "pipeline_dop";
 
-    public static final String PIPELINE_MAX_INPUT_BYTES_PER_OPERATOR = "pipeline_max_input_bytes_per_operator";
-
     public static final String PIPELINE_PROFILE_MODE = "pipeline_profile_mode";
 
     // hash join right table push down
@@ -328,9 +326,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = PIPELINE_DOP)
     private int pipelineDop = 0;
-
-    @VariableMgr.VarAttr(name = PIPELINE_MAX_INPUT_BYTES_PER_OPERATOR, flag = VariableMgr.INVISIBLE)
-    private long pipelineMaxInputBytesPerOperator = 100000000;
 
     @VariableMgr.VarAttr(name = PIPELINE_PROFILE_MODE)
     private String pipelineProfileMode = "brief";
@@ -763,10 +758,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public int getPipelineDop() {
         return this.pipelineDop;
-    }
-
-    public long getPipelineMaxInputBytesPerOperator() {
-        return pipelineMaxInputBytesPerOperator;
     }
 
     public boolean isEnableReplicationJoin() {

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -295,7 +295,6 @@ struct TExecPlanFragmentParams {
 
   50: optional bool is_pipeline
   51: optional i32 pipeline_dop
-  52: optional map<Types.TPlanNodeId, i32> per_scan_node_dop;
 }
 
 struct TExecPlanFragmentResult {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Problem Summary：
The small query has too little scan operators, and the bottleneck of small query is at scan i/o task. Therefore, the workgroup with larger cpu_limit cannot get more i/o tasks to execute, which causes there isn't resource isolation between different workgroups for small query.

In this PR, we make one scan operator able to commit at most 4 i/o tasks.
In this way, we increment the concurrency of i/o tasks of a ScanOperator, so maybe we could revert PR #2571

## Changes
- Make one scan operator able to commit at most 4 i/o tasks.
- Revert PR #2571.
- Assign range of tablets to the different ScanOperator instances in `ScanOperatorFactory::create()`, to avoid one ScanOperator consumes all the tablets, which reduces the degree of parallelism.

## TODO
This PR assigns each ScanOperator instance with a different range of tablets in BE. In the future, we could assign the range of tablets in FE to eliminate the local shuffle between scan and bucket shuffle join or colocate join.