### PR TITLE
Support array_sort

### DIFF
--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -144,6 +144,10 @@ public:
     // This function will copy the [3, 2] row of src to this column.
     virtual void append_selective(const Column& src, const uint32_t* indexes, uint32_t from, uint32_t size) = 0;
 
+    virtual void append_selective(const Column& src, const std::vector<uint32_t>& indexes) {
+        return append_selective(src, indexes.data(), 0, indexes.size());
+    }
+
     // This function will get row through 'from' index from src, and copy size elements to this column.
     virtual void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) = 0;
 

--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -198,6 +198,7 @@ public:
 
     ColumnPtr& data_column() { return _data_column; }
 
+    const NullColumn& null_column_ref() const { return *_null_column; }
     const NullColumnPtr& null_column() const { return _null_column; }
 
     Datum get(size_t n) const override {

--- a/be/src/exprs/vectorized/array_functions.h
+++ b/be/src/exprs/vectorized/array_functions.h
@@ -123,9 +123,6 @@ private:
                                                        const NullColumn::Container* null_elements,
                                                        std::vector<uint8_t>* null_ptr);
 
-    template <PrimitiveType PT>
-    static ColumnPtr array_sort(const Columns& columns);
-
     template <PrimitiveType type>
     static ColumnPtr array_sum(const Columns& columns);
 

--- a/be/src/exprs/vectorized/array_functions.h
+++ b/be/src/exprs/vectorized/array_functions.h
@@ -40,6 +40,27 @@ public:
 
 #undef DEFINE_ARRAY_DISTINCT_FN
 
+#define DEFINE_ARRAY_SORT_FN(NAME, PT)                                                     \
+    static ColumnPtr array_sort_##NAME(FunctionContext* context, const Columns& columns) { \
+        return ArraySort<PT>::process(context, columns);                                   \
+    }
+
+    DEFINE_ARRAY_SORT_FN(boolean, PrimitiveType::TYPE_BOOLEAN);
+    DEFINE_ARRAY_SORT_FN(tinyint, PrimitiveType::TYPE_TINYINT);
+    DEFINE_ARRAY_SORT_FN(smallint, PrimitiveType::TYPE_SMALLINT);
+    DEFINE_ARRAY_SORT_FN(int, PrimitiveType::TYPE_INT);
+    DEFINE_ARRAY_SORT_FN(bigint, PrimitiveType::TYPE_BIGINT);
+    DEFINE_ARRAY_SORT_FN(largeint, PrimitiveType::TYPE_LARGEINT);
+    DEFINE_ARRAY_SORT_FN(float, PrimitiveType::TYPE_FLOAT);
+    DEFINE_ARRAY_SORT_FN(double, PrimitiveType::TYPE_DOUBLE);
+    DEFINE_ARRAY_SORT_FN(varchar, PrimitiveType::TYPE_VARCHAR);
+    DEFINE_ARRAY_SORT_FN(char, PrimitiveType::TYPE_CHAR);
+    DEFINE_ARRAY_SORT_FN(decimalv2, PrimitiveType::TYPE_DECIMALV2);
+    DEFINE_ARRAY_SORT_FN(datetime, PrimitiveType::TYPE_DATETIME);
+    DEFINE_ARRAY_SORT_FN(date, PrimitiveType::TYPE_DATE);
+
+#undef DEFINE_ARRAY_SORT_FN
+
     DEFINE_VECTORIZED_FN(array_sum_boolean);
     DEFINE_VECTORIZED_FN(array_sum_tinyint);
     DEFINE_VECTORIZED_FN(array_sum_smallint);
@@ -101,6 +122,9 @@ private:
     static ColumnPtr _array_process_not_nullable_types(const Column* elements, const UInt32Column& offsets,
                                                        const NullColumn::Container* null_elements,
                                                        std::vector<uint8_t>* null_ptr);
+
+    template <PrimitiveType PT>
+    static ColumnPtr array_sort(const Columns& columns);
 
     template <PrimitiveType type>
     static ColumnPtr array_sum(const Columns& columns);

--- a/be/src/exprs/vectorized/array_functions.tpp
+++ b/be/src/exprs/vectorized/array_functions.tpp
@@ -3,6 +3,7 @@
 #include "column/array_column.h"
 #include "column/column_hash.h"
 #include "exprs/vectorized/function_helper.h"
+#include "util/orlp/pdqsort.h"
 
 namespace starrocks::vectorized {
 template <PrimitiveType PT>
@@ -99,6 +100,129 @@ private:
             ++iter;
         }
         dest_offsets.emplace_back(dest_offsets.back() + hash_set->size() + has_null);
+    }
+};
+
+template <PrimitiveType PT>
+class ArraySort {
+public:
+    using ColumnType = RunTimeColumnType<PT>;
+
+    static ColumnPtr process(FunctionContext* ctx, const Columns& columns) {
+        DCHECK_EQ(columns.size(), 1);
+
+        size_t chunk_size = columns[0]->size();
+        // TODO: For fixed-length types, you can operate directly on the original column without using sort index,
+        //  which will be optimized later
+        std::vector<uint32_t> sort_index;
+        ColumnPtr src_column = ColumnHelper::unpack_and_duplicate_const_column(chunk_size, columns[0]);
+        ColumnPtr dest_column = src_column->clone_empty();
+
+        if (src_column->is_nullable()) {
+            const auto& src_nullable_column = *down_cast<const NullableColumn*>(src_column.get());
+            const auto& src_data_column = src_nullable_column.data_column_ref();
+            const auto& src_null_column = src_nullable_column.null_column_ref();
+
+            auto* dest_nullable_column = down_cast<NullableColumn*>(dest_column.get());
+            auto* dest_data_column = dest_nullable_column->mutable_data_column();
+            auto* dest_null_column = dest_nullable_column->mutable_null_column();
+
+            if (src_column->has_null()) {
+                dest_null_column->get_data() = src_null_column.get_data();
+            } else {
+                dest_null_column->get_data().resize(chunk_size, 0);
+            }
+            dest_nullable_column->set_has_null(src_nullable_column.has_null());
+
+            _sort_array_column(dest_data_column, &sort_index, src_data_column);
+        } else {
+            _sort_array_column(dest_column.get(), &sort_index, *src_column);
+        }
+        return dest_column;
+    }
+
+private:
+    static void _sort_column(std::vector<uint32_t>* sort_index, const Column& src_column, size_t offset, size_t count) {
+        const auto& data = down_cast<const ColumnType&>(src_column).get_data();
+
+        auto less_fn = [&data](uint32_t l, uint32_t r) -> bool { return data[l] < data[r]; };
+        pdqsort(false, sort_index->begin() + offset, sort_index->begin() + offset + count, less_fn);
+    }
+
+    static void _sort_item(std::vector<uint32_t>* sort_index, const Column& src_column,
+                                      const UInt32Column& offset_column, size_t index) {
+        const auto& offsets = offset_column.get_data();
+
+        size_t start = offsets[index];
+        size_t count = offsets[index + 1] - offsets[index];
+        if (count <= 0) {
+            return;
+        }
+
+        _sort_column(sort_index, src_column, start, count);
+
+    }
+
+    static void _sort_nullable_item(std::vector<uint32_t>* sort_index, const Column& src_data_column,
+                                               const NullColumn& src_null_column, const UInt32Column& offset_column,
+                                               size_t index) {
+        const auto& offsets = offset_column.get_data();
+        size_t start = offsets[index];
+        size_t count = offsets[index + 1] - offsets[index];
+
+        if (count <= 0) {
+            return;
+        }
+
+        auto null_first_fn = [src_null_column](size_t i) -> bool { return src_null_column.get_data()[i] == 1; };
+
+        auto begin_of_not_null =
+                std::partition(sort_index->begin() + start, sort_index->begin() + start + count, null_first_fn);
+        size_t data_offset = begin_of_not_null - sort_index->begin();
+        size_t null_count = data_offset - start;
+        _sort_column(sort_index, src_data_column, start + null_count, count - null_count);
+    }
+
+    static void _sort_array_column(Column* dest_array_column, std::vector<uint32_t>* sort_index,
+                                   const Column& src_array_column) {
+        const auto& src_elements_column = down_cast<const ArrayColumn&>(src_array_column).elements();
+        const auto& offsets_column = down_cast<const ArrayColumn&>(src_array_column).offsets();
+
+        auto* dest_elements_column = down_cast<ArrayColumn*>(dest_array_column)->elements_column().get();
+        auto* dest_offsets_column = down_cast<ArrayColumn*>(dest_array_column)->offsets_column().get();
+        dest_offsets_column->get_data() = offsets_column.get_data();
+
+        size_t chunk_size = src_array_column.size();
+        _init_sort_index(sort_index, src_elements_column.size());
+
+        if (src_elements_column.is_nullable()) {
+            if (src_elements_column.has_null()) {
+                const auto& src_data_column = down_cast<const NullableColumn&>(src_elements_column).data_column_ref();
+                const auto& null_column = down_cast<const NullableColumn&>(src_elements_column).null_column_ref();
+
+                for (size_t i = 0; i < chunk_size; i++) {
+                    _sort_nullable_item(sort_index, src_data_column, null_column, offsets_column, i);
+                }
+            } else {
+                const auto& src_data_column = down_cast<const NullableColumn&>(src_elements_column).data_column_ref();
+
+                for (size_t i = 0; i < chunk_size; i++) {
+                    _sort_item(sort_index, src_data_column, offsets_column, i);
+                }
+            }
+        } else {
+            for (size_t i = 0; i < chunk_size; i++) {
+                _sort_item(sort_index, src_elements_column, offsets_column, i);
+            }
+        }
+        dest_elements_column->append_selective(src_elements_column, *sort_index);
+    }
+
+    static void _init_sort_index(std::vector<uint32_t>* sort_index, size_t count) {
+        sort_index->resize(count);
+        for (size_t i = 0; i < count; i++) {
+            (*sort_index)[i] = i;
+        }
     }
 };
 } // namespace starrocks::vectorized

--- a/gensrc/script/vectorized/vectorized_functions.py
+++ b/gensrc/script/vectorized/vectorized_functions.py
@@ -597,4 +597,17 @@ vectorized_functions = [
     [150099, 'array_distinct', 'ARRAY_DECIMALV2', ['ARRAY_DECIMALV2'], 'ArrayFunctions::array_distinct_decimalv2'],
     [150100, 'array_distinct', 'ARRAY_DATETIME',  ['ARRAY_DATETIME'],  'ArrayFunctions::array_distinct_datetime'],
     [150101, 'array_distinct', 'ARRAY_DATE',      ['ARRAY_DATE'],      'ArrayFunctions::array_distinct_date'],
+
+    [150110, 'array_sort', 'ARRAY_BOOLEAN',   ['ARRAY_BOOLEAN'],   'ArrayFunctions::array_sort_boolean'],
+    [150111, 'array_sort', 'ARRAY_TINYINT',   ['ARRAY_TINYINT'],   'ArrayFunctions::array_sort_tinyint'],
+    [150112, 'array_sort', 'ARRAY_SMALLINT',  ['ARRAY_SMALLINT'],  'ArrayFunctions::array_sort_smallint'],
+    [150113, 'array_sort', 'ARRAY_INT',       ['ARRAY_INT'],       'ArrayFunctions::array_sort_int'],
+    [150114, 'array_sort', 'ARRAY_BIGINT',    ['ARRAY_BIGINT'],    'ArrayFunctions::array_sort_bigint'],
+    [150115, 'array_sort', 'ARRAY_LARGEINT',  ['ARRAY_LARGEINT'],  'ArrayFunctions::array_sort_largeint'],
+    [150116, 'array_sort', 'ARRAY_FLOAT',     ['ARRAY_FLOAT'],     'ArrayFunctions::array_sort_float'],
+    [150117, 'array_sort', 'ARRAY_DOUBLE',    ['ARRAY_DOUBLE'],    'ArrayFunctions::array_sort_double'],
+    [150118, 'array_sort', 'ARRAY_VARCHAR',   ['ARRAY_VARCHAR'],   'ArrayFunctions::array_sort_varchar'],
+    [150119, 'array_sort', 'ARRAY_DECIMALV2', ['ARRAY_DECIMALV2'], 'ArrayFunctions::array_sort_decimalv2'],
+    [150120, 'array_sort', 'ARRAY_DATETIME',  ['ARRAY_DATETIME'],  'ArrayFunctions::array_sort_datetime'],
+    [150121, 'array_sort', 'ARRAY_DATE',      ['ARRAY_DATE'],      'ArrayFunctions::array_sort_date'],
 ]


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

for #648

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

usage:

```
mysql> select b from m4;
+--------------+
| b            |
+--------------+
| [4,3,null,1] |
+--------------+
1 row in set (0.01 sec)

mysql> select array_sort(b) from m4;
+-----------------+
| array_sort(`b`) |
+-----------------+
| [null,1,3,4]    |
+-----------------+
1 row in set (0.01 sec)
```

* null will put first
* only support asc, can use revese function to implement desc (will pull pr later)
* the implement of fixed size column may have performance problems, ignore them first, and optimize them later
