### PR TITLE
Fix: save TFunction objects to _fns correctly

### DIFF
--- a/be/src/exec/vectorized/aggregator.cpp
+++ b/be/src/exec/vectorized/aggregator.cpp
@@ -236,9 +236,9 @@ Status Aggregator::prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile
     }
 
     // save TFunction object
-    _fns.resize(_agg_fn_ctxs.size());
+    _fns.reserve(_agg_fn_ctxs.size());
     for (int i = 0; i < _agg_fn_ctxs.size(); ++i) {
-        _fns.push_back(_tnode.analytic_node.analytic_functions[i].nodes[0].fn);
+        _fns.emplace_back(_tnode.agg_node.aggregate_functions[i].nodes[0].fn);
     }
 
     return Status::OK();

--- a/be/src/exec/vectorized/analytor.cpp
+++ b/be/src/exec/vectorized/analytor.cpp
@@ -240,9 +240,9 @@ Status Analytor::prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile* 
     }
 
     // save TFunction object
-    _fns.resize(_agg_fn_ctxs.size());
+    _fns.reserve(_agg_fn_ctxs.size());
     for (int i = 0; i < _agg_fn_ctxs.size(); ++i) {
-        _fns.push_back(_tnode.analytic_node.analytic_functions[i].nodes[0].fn);
+        _fns.emplace_back(_tnode.analytic_node.analytic_functions[i].nodes[0].fn);
     }
 
     return Status::OK();


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fix #3171.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
We should  use `_tnode.agg_node.aggregate_functions` instead of `_tnode.analytic_node.analytic_functions` to full `Aggregator::_fns`.
