### PR TITLE
[ResourceIsolation] Add WorkGroupEntry in EditLog in advance to support rollback in the future

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/journal/JournalEntity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/JournalEntity.java
@@ -493,6 +493,11 @@ public class JournalEntity implements Writable {
                 isRead = true;
                 break;
             }
+            case OperationType.OP_WORKGROUP: {
+                Text.readString(in);
+                isRead = true;
+                break;
+            }
             case OperationType.OP_CREATE_SMALL_FILE:
             case OperationType.OP_DROP_SMALL_FILE: {
                 data = SmallFile.read(in);

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -709,6 +709,10 @@ public class EditLog {
                     catalog.getResourceMgr().replayDropResource(operationLog);
                     break;
                 }
+                case OperationType.OP_WORKGROUP: {
+                    // TODO(by satanson) read out workgroup entry and ignore it, go on processing sequential entries
+                    break;
+                }
                 case OperationType.OP_CREATE_SMALL_FILE: {
                     SmallFile smallFile = (SmallFile) journal.getData();
                     catalog.getSmallFileMgr().replayCreateFile(smallFile);

--- a/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
@@ -199,4 +199,7 @@ public class OperationType {
     // statistic 10010 ~ 10020
     public static final short OP_ADD_ANALYZER_JOB = 10010;
     public static final short OP_REMOVE_ANALYZER_JOB = 10011;
+
+    // workgroup 10021 ~ 10030
+    public static final short OP_WORKGROUP = 10021;
 }


### PR DESCRIPTION
https://github.com/StarRocks/starrocks/issues/2848

In order to support WorkGroup persistence in EditLog, WorkGroupEntry is added as a new type of log entries.  This PR is proposed in advance to read out WorkGroupEntries of the future version and ignore them, so EditLog replaying can go on processing safely when rollback from future version to this version.