### PR TITLE
Remove gcc set but unused warning

### DIFF
--- a/be/src/storage/vectorized/chunk_helper.cpp
+++ b/be/src/storage/vectorized/chunk_helper.cpp
@@ -290,7 +290,7 @@ void ChunkHelper::padding_char_columns(const std::vector<size_t>& char_column_in
 struct ColumnBuilder {
     template <FieldType ftype>
     ColumnPtr operator()(bool nullable) {
-        auto NullableIfNeed = [&](ColumnPtr col) -> ColumnPtr {
+        [[maybe_unused]] auto NullableIfNeed = [&](ColumnPtr col) -> ColumnPtr {
             return nullable ? NullableColumn::create(std::move(col), NullColumn::create()) : col;
         };
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3177 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
fix the set but unused warning from gcc
