### PR TITLE
Not generate columns generate when there is no column prune requirement for join

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1391,9 +1391,6 @@ public class PlanFragmentBuilder {
 
             ColumnRefSet leftChildColumns = optExpr.inputAt(0).getLogicalProperty().getOutputColumns();
             ColumnRefSet rightChildColumns = optExpr.inputAt(1).getLogicalProperty().getOutputColumns();
-            ColumnRefSet inputColumns = new ColumnRefSet();
-            inputColumns.union(leftChildColumns);
-            inputColumns.union(rightChildColumns);
 
             // 2. Get eqJoinConjuncts
             List<BinaryPredicateOperator> eqOnPredicates = getEqConj(
@@ -1552,9 +1549,6 @@ public class PlanFragmentBuilder {
                     outputColumns.except(new ArrayList<>(node.getProjection().getCommonSubOperatorMap().keySet()));
                     hashJoinNode.setOutputSlots(
                             outputColumns.getStream().boxed().collect(Collectors.toList()));
-                } else {
-                    hashJoinNode.setOutputSlots(
-                            inputColumns.getStream().boxed().collect(Collectors.toList()));
                 }
 
                 hashJoinNode.setDistributionMode(distributionMode);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -5553,6 +5553,10 @@ public class PlanFragmentTest extends PlanTestBase {
                 "  |  8 <-> [2: v2, BIGINT, true] + [6: v6, BIGINT, true]\n" +
                 "  |  cardinality: 1"));
         Assert.assertTrue(plan.contains("output columns: 2, 6"));
+
+        sql = "select * from t0,t1 where v1 = v4";
+        plan = getVerboseExplain(sql);
+        Assert.assertFalse(plan.contains("output columns"));
     }
 
     @Test


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3174

The issue introduces a low cardinality optimization bug. When there is low cardinality optimization, the output slot id of scan will be modified. If you continue to use getLogicalProperty().getOutputColumns(), it will cause an error corresponding to the id.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
