### PR TITLE
Fix is null and is not null predicate thrift error

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -5578,4 +5578,11 @@ public class PlanFragmentTest extends PlanTestBase {
                 "     numNodes=0"));
         connectContext.getSessionVariable().setSingleNodeExecPlan(false);
     }
+
+    @Test
+    public void testIsNullPredicateFunctionThrift() throws Exception {
+        String sql = "select v1 from t0 where v1 is null";
+        String thrift = getThriftPlan(sql);
+        Assert.assertTrue(thrift.contains("fn:TFunction(name:TFunctionName(function_name:is_null_pred)"));
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

```
mysql> select * from reason where r_reason_sk is not null;
ERROR 1064 (HY000): Vectorized engine doesn't implement function
```

https://github.com/StarRocks/starrocks/pull/3145 introduce  a bug. is null or is not null predicate need to set function name to thrift.

```
        } else if (texpr_node.fn.name.function_name == "is_null_pred" ||
                   texpr_node.fn.name.function_name == "is_not_null_pred") {
            *expr = pool->add(vectorized::VectorizedIsNullPredicateFactory::from_thrift(texpr_node));
        } else {
            *expr = pool->add(new vectorized::VectorizedFunctionCallExpr(texpr_node));
        }
``` 