### PR TITLE
Fix REGEXP_EXTRACT may access overflow when input was binary data

### DIFF
--- a/be/src/exprs/vectorized/string_functions.cpp
+++ b/be/src/exprs/vectorized/string_functions.cpp
@@ -2535,7 +2535,7 @@ Status StringFunctions::regexp_prepare(starrocks_udf::FunctionContext* context,
 
     if (!state->regex->ok()) {
         std::stringstream error;
-        error << "Invalid regex expression: " << pattern.data;
+        error << "Invalid regex expression: " << pattern.to_string();
         context->set_error(error.str().c_str());
         return Status::InvalidArgument(error.str());
     }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
Fixes #3193



