### PR TITLE
Fix window with project child error bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/ExpressionMapping.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/ExpressionMapping.java
@@ -1,6 +1,7 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
 package com.starrocks.sql.optimizer.transformer;
 
+import com.google.common.collect.Lists;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FieldReference;
 import com.starrocks.analysis.SlotRef;
@@ -109,5 +110,9 @@ public class ExpressionMapping {
 
     public ColumnRefOperator get(Expr expression) {
         return expressionToColumns.get(expression);
+    }
+
+    public List<Expr> getAllExpressions() {
+        return Lists.newArrayList(expressionToColumns.keySet());
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
@@ -228,6 +228,15 @@ class QueryTransformer {
                 projections.put(variable, expression);
                 fieldMappings.add(variable);
             }
+
+            // child output expressions
+            for (Expr expression : subOpt.getExpressionMapping().getAllExpressions()) {
+                ColumnRefOperator columnRef = findOrCreateColumnRefForExpr(expression,
+                        subOpt.getExpressionMapping(), projections, columnRefFactory);
+                fieldMappings.add(columnRef);
+                outputTranslations.put(expression, columnRef);
+            }
+
             for (Expr expression : projectExpressions) {
                 ColumnRefOperator columnRef = findOrCreateColumnRefForExpr(expression,
                         subOpt.getExpressionMapping(), projections, columnRefFactory);
@@ -426,7 +435,7 @@ class QueryTransformer {
                 groupingTranslations.put(groupingFunction, grouping);
 
                 groupingIds.add(tempGroupingIdsBitSets.stream().map(bitset ->
-                                Utils.convertBitSetToLong(bitset, groupingFunction.getChildren().size()))
+                        Utils.convertBitSetToLong(bitset, groupingFunction.getChildren().size()))
                         .collect(Collectors.toList()));
                 groupByColumnRefs.add(grouping);
                 repeatOutput.add(grouping);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -5561,7 +5561,7 @@ public class PlanFragmentTest extends PlanTestBase {
     }
 
     @Test
-    public void testSingleNodeExecPlan() throws  Exception {
+    public void testSingleNodeExecPlan() throws Exception {
         String sql = "select v1,v2,v3 from t0";
         connectContext.getSessionVariable().setSingleNodeExecPlan(true);
         String plan = getFragmentPlan(sql);
@@ -5603,5 +5603,16 @@ public class PlanFragmentTest extends PlanTestBase {
                 "  |  \n" +
                 "  3:HASH JOIN\n" +
                 "  |  join op: LEFT OUTER JOIN"));
+    }
+
+    @Test
+    public void testWindowWithChildProjectAgg() throws Exception {
+        String sql = "SELECT v1, sum(v2) as x1, row_number() over (ORDER BY CASE WHEN v1 THEN 1 END DESC) AS rank " +
+                "FROM t0 group BY v1";
+        String plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("  2:Project\n" +
+                "  |  <slot 1> : 1: v1\n" +
+                "  |  <slot 4> : 4: sum\n" +
+                "  |  <slot 8> : if(CAST(1: v1 AS BOOLEAN), 1, NULL)"));
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Like SQL:
```
SELECT v1, sum(v2) as x1, row_number() over (ORDER BY CASE WHEN v1 THEN 1 END DESC) AS rank
FROM t0 group BY v1
```

Analyze window will check `Order by`/`Partition By` contains expressions, then will add project node if contains expressions, but the expression of child outputs will lose here