### PR TITLE
support array reverse

### DIFF
--- a/be/src/exprs/vectorized/array_functions.h
+++ b/be/src/exprs/vectorized/array_functions.h
@@ -61,6 +61,27 @@ public:
 
 #undef DEFINE_ARRAY_SORT_FN
 
+#define DEFINE_ARRAY_REVERSE_FN(NAME, PT)                                                     \
+    static ColumnPtr array_reverse_##NAME(FunctionContext* context, const Columns& columns) { \
+        return ArrayReverse<PT>::process(context, columns);                                   \
+    }
+
+    DEFINE_ARRAY_REVERSE_FN(boolean, PrimitiveType::TYPE_BOOLEAN);
+    DEFINE_ARRAY_REVERSE_FN(tinyint, PrimitiveType::TYPE_TINYINT);
+    DEFINE_ARRAY_REVERSE_FN(smallint, PrimitiveType::TYPE_SMALLINT);
+    DEFINE_ARRAY_REVERSE_FN(int, PrimitiveType::TYPE_INT);
+    DEFINE_ARRAY_REVERSE_FN(bigint, PrimitiveType::TYPE_BIGINT);
+    DEFINE_ARRAY_REVERSE_FN(largeint, PrimitiveType::TYPE_LARGEINT);
+    DEFINE_ARRAY_REVERSE_FN(float, PrimitiveType::TYPE_FLOAT);
+    DEFINE_ARRAY_REVERSE_FN(double, PrimitiveType::TYPE_DOUBLE);
+    DEFINE_ARRAY_REVERSE_FN(varchar, PrimitiveType::TYPE_VARCHAR);
+    DEFINE_ARRAY_REVERSE_FN(char, PrimitiveType::TYPE_CHAR);
+    DEFINE_ARRAY_REVERSE_FN(decimalv2, PrimitiveType::TYPE_DECIMALV2);
+    DEFINE_ARRAY_REVERSE_FN(datetime, PrimitiveType::TYPE_DATETIME);
+    DEFINE_ARRAY_REVERSE_FN(date, PrimitiveType::TYPE_DATE);
+
+#undef DEFINE_ARRAY_REVERSE_FN
+
     DEFINE_VECTORIZED_FN(array_sum_boolean);
     DEFINE_VECTORIZED_FN(array_sum_tinyint);
     DEFINE_VECTORIZED_FN(array_sum_smallint);

--- a/gensrc/script/vectorized/vectorized_functions.py
+++ b/gensrc/script/vectorized/vectorized_functions.py
@@ -621,4 +621,17 @@ vectorized_functions = [
     [150119, 'array_sort', 'ARRAY_DECIMALV2', ['ARRAY_DECIMALV2'], 'ArrayFunctions::array_sort_decimalv2'],
     [150120, 'array_sort', 'ARRAY_DATETIME',  ['ARRAY_DATETIME'],  'ArrayFunctions::array_sort_datetime'],
     [150121, 'array_sort', 'ARRAY_DATE',      ['ARRAY_DATE'],      'ArrayFunctions::array_sort_date'],
+
+    [150130, 'reverse', 'ARRAY_BOOLEAN',   ['ARRAY_BOOLEAN'],   'ArrayFunctions::array_reverse_boolean'],
+    [150131, 'reverse', 'ARRAY_TINYINT',   ['ARRAY_TINYINT'],   'ArrayFunctions::array_reverse_tinyint'],
+    [150132, 'reverse', 'ARRAY_SMALLINT',  ['ARRAY_SMALLINT'],  'ArrayFunctions::array_reverse_smallint'],
+    [150133, 'reverse', 'ARRAY_INT',       ['ARRAY_INT'],       'ArrayFunctions::array_reverse_int'],
+    [150134, 'reverse', 'ARRAY_BIGINT',    ['ARRAY_BIGINT'],    'ArrayFunctions::array_reverse_bigint'],
+    [150135, 'reverse', 'ARRAY_LARGEINT',  ['ARRAY_LARGEINT'],  'ArrayFunctions::array_reverse_largeint'],
+    [150136, 'reverse', 'ARRAY_FLOAT',     ['ARRAY_FLOAT'],     'ArrayFunctions::array_reverse_float'],
+    [150137, 'reverse', 'ARRAY_DOUBLE',    ['ARRAY_DOUBLE'],    'ArrayFunctions::array_reverse_double'],
+    [150138, 'reverse', 'ARRAY_VARCHAR',   ['ARRAY_VARCHAR'],   'ArrayFunctions::array_reverse_varchar'],
+    [150139, 'reverse', 'ARRAY_DECIMALV2', ['ARRAY_DECIMALV2'], 'ArrayFunctions::array_reverse_decimalv2'],
+    [150140, 'reverse', 'ARRAY_DATETIME',  ['ARRAY_DATETIME'],  'ArrayFunctions::array_reverse_datetime'],
+    [150141, 'reverse', 'ARRAY_DATE',      ['ARRAY_DATE'],      'ArrayFunctions::array_reverse_date'],
 ]


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

for #648

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

usage: (the usage is same as presto and databricks) (it's named to array_reverse in BigQuery)

```
mysql> select b from m4;
+--------------+
| b            |
+--------------+
| [4,3,null,1] |
| NULL         |
| [null]       |
+--------------+
3 rows in set (0.00 sec)

mysql> select reverse(b) from m4;
+--------------+
| reverse(`b`) |
+--------------+
| [1,null,3,4] |
| NULL         |
| [null]       |
+--------------+
3 rows in set (0.01 sec)
```
