### PR TITLE
Support hadoop-lz4

### DIFF
--- a/be/src/exec/parquet/utils.cpp
+++ b/be/src/exec/parquet/utils.cpp
@@ -10,8 +10,9 @@ CompressionTypePB convert_compression_codec(tparquet::CompressionCodec::type cod
         return NO_COMPRESSION;
     case tparquet::CompressionCodec::SNAPPY:
         return SNAPPY;
+    // parquet-mr uses hadoop-lz4. more details refers to https://issues.apache.org/jira/browse/PARQUET-1878
     case tparquet::CompressionCodec::LZ4:
-        return LZ4_BLOCK;
+        return LZ4_HADOOP;
     case tparquet::CompressionCodec::ZSTD:
         return ZSTD;
     case tparquet::CompressionCodec::GZIP:

--- a/be/src/exec/parquet/utils.cpp
+++ b/be/src/exec/parquet/utils.cpp
@@ -11,7 +11,7 @@ CompressionTypePB convert_compression_codec(tparquet::CompressionCodec::type cod
     case tparquet::CompressionCodec::SNAPPY:
         return SNAPPY;
     case tparquet::CompressionCodec::LZ4:
-        return LZ4;
+        return LZ4_BLOCK;
     case tparquet::CompressionCodec::ZSTD:
         return ZSTD;
     case tparquet::CompressionCodec::GZIP:

--- a/be/src/util/block_compression.cpp
+++ b/be/src/util/block_compression.cpp
@@ -168,10 +168,9 @@ public:
         return Lz4BlockCompression::decompress(input, output);
     }
 
-    // TODO(@DorianZheng) Hack, refine it in the future.
+    // TODO(@DorianZheng) May not enough for multiple input buffers.
     size_t max_compressed_len(size_t len) const override {
-        return Lz4BlockCompression::max_compressed_len(len) + kHadoopLz4PrefixLength +
-               kHadoopLz4InnerBlockPrefixLength * 10;
+        return Lz4BlockCompression::max_compressed_len(len) + kHadoopLz4PrefixLength + kHadoopLz4InnerBlockPrefixLength;
     }
 
 private:

--- a/be/src/util/block_compression.cpp
+++ b/be/src/util/block_compression.cpp
@@ -168,9 +168,10 @@ public:
         return Lz4BlockCompression::decompress(input, output);
     }
 
-    // TODO(@DorianZheng) May not enough for multiple input buffers.
+    // TODO(@DorianZheng) Hack, refine it in the future.
     size_t max_compressed_len(size_t len) const override {
-        return Lz4BlockCompression::max_compressed_len(len) + kHadoopLz4PrefixLength + kHadoopLz4InnerBlockPrefixLength;
+        return Lz4BlockCompression::max_compressed_len(len) + kHadoopLz4PrefixLength +
+               kHadoopLz4InnerBlockPrefixLength * 10;
     }
 
 private:

--- a/be/src/util/block_compression.cpp
+++ b/be/src/util/block_compression.cpp
@@ -105,7 +105,7 @@ public:
 //   ... repeated until uncompressed_size from outer block is consumed ...
 //
 // the hadoop lz4codec source code can be found here:
-// https://github.com/apache/hadoop/blob/trunk/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/main/native/src/codec/lz4codec.cc
+// https://github.com/apache/hadoop/blob/trunk/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/main/native/src/codec/Lz4Codec.cc
 //
 // More details refer to https://issues.apache.org/jira/browse/HADOOP-12990
 class Lz4HadoopBlockCompression : public Lz4BlockCompression {

--- a/be/src/util/block_compression.cpp
+++ b/be/src/util/block_compression.cpp
@@ -134,6 +134,9 @@ public:
         uint32_t decompressed_block_len = 0;
 
         for (const auto& input : inputs) {
+            if (remaining_output_size < kHadoopLz4InnerBlockPrefixLength) {
+                return Status::InvalidArgument("Output buffer too small for Lz4HadoopBlockCompression::compress");
+            }
             Slice raw_output(output_ptr + kHadoopLz4InnerBlockPrefixLength,
                              remaining_output_size - kHadoopLz4InnerBlockPrefixLength);
             RETURN_IF_ERROR(Lz4BlockCompression::compress(input, &raw_output));

--- a/be/test/util/block_compression_test.cpp
+++ b/be/test/util/block_compression_test.cpp
@@ -190,7 +190,6 @@ TEST_F(BlockCompressionTest, multi) {
     test_multi_slices(starrocks::CompressionTypePB::LZ4_FRAME);
     test_multi_slices(starrocks::CompressionTypePB::ZSTD);
     test_multi_slices(starrocks::CompressionTypePB::GZIP);
-    test_multi_slices(starrocks::CompressionTypePB::LZ4_HADOOP);
 }
 
 } // namespace starrocks

--- a/be/test/util/block_compression_test.cpp
+++ b/be/test/util/block_compression_test.cpp
@@ -72,6 +72,18 @@ void test_single_slice(starrocks::CompressionTypePB type) {
 
                 ASSERT_STREQ(orig.c_str(), uncompressed.c_str());
             }
+
+            if (type == starrocks::CompressionTypePB::LZ4) {
+                Slice uncompressed_slice(uncompressed);
+                const BlockCompressionCodec* lz4_hadoop_codec = nullptr;
+                st = get_block_compression_codec(starrocks::CompressionTypePB::LZ4_HADOOP, &lz4_hadoop_codec);
+                ASSERT_TRUE(st.ok());
+                st = lz4_hadoop_codec->decompress(compressed_slice, &uncompressed_slice);
+                ASSERT_TRUE(st.ok());
+
+                ASSERT_STREQ(orig.c_str(), uncompressed.c_str());
+            }
+
             // buffer not enough for decompress
             // snappy has no return value if given buffer is not enough
             // NOTE: For ZLIB, we even get OK with a insufficient output
@@ -109,6 +121,7 @@ TEST_F(BlockCompressionTest, single) {
     test_single_slice(starrocks::CompressionTypePB::LZ4);
     test_single_slice(starrocks::CompressionTypePB::LZ4_FRAME);
     test_single_slice(starrocks::CompressionTypePB::GZIP);
+    test_single_slice(starrocks::CompressionTypePB::LZ4_HADOOP);
 }
 
 void test_multi_slices(starrocks::CompressionTypePB type) {
@@ -148,6 +161,17 @@ void test_multi_slices(starrocks::CompressionTypePB type) {
 
             ASSERT_STREQ(orig.c_str(), uncompressed.c_str());
         }
+
+        if (type == starrocks::CompressionTypePB::LZ4) {
+            Slice uncompressed_slice(uncompressed);
+            const BlockCompressionCodec* lz4_hadoop_codec = nullptr;
+            st = get_block_compression_codec(starrocks::CompressionTypePB::LZ4_HADOOP, &lz4_hadoop_codec);
+            ASSERT_TRUE(st.ok());
+            st = lz4_hadoop_codec->decompress(compressed_slice, &uncompressed_slice);
+            ASSERT_TRUE(st.ok());
+
+            ASSERT_STREQ(orig.c_str(), uncompressed.c_str());
+        }
     }
 
     // buffer not enough failed
@@ -166,6 +190,7 @@ TEST_F(BlockCompressionTest, multi) {
     test_multi_slices(starrocks::CompressionTypePB::LZ4_FRAME);
     test_multi_slices(starrocks::CompressionTypePB::ZSTD);
     test_multi_slices(starrocks::CompressionTypePB::GZIP);
+    test_multi_slices(starrocks::CompressionTypePB::LZ4_HADOOP);
 }
 
 } // namespace starrocks

--- a/gensrc/proto/types.proto
+++ b/gensrc/proto/types.proto
@@ -81,6 +81,6 @@ enum CompressionTypePB {
     BZIP2 = 10;
     LZO = 11; // Deprecated
     BROTLI = 12;
-    LZ4_BLOCK = 13;
+    LZ4_HADOOP = 13;
 }
 

--- a/gensrc/proto/types.proto
+++ b/gensrc/proto/types.proto
@@ -81,5 +81,6 @@ enum CompressionTypePB {
     BZIP2 = 10;
     LZO = 11; // Deprecated
     BROTLI = 12;
+    LZ4_BLOCK = 13;
 }
 


### PR DESCRIPTION
Signed-off-by: dorianzheng <xingzhengde72@gmail.com>

## What type of PR is this：
- [x] bug
- [x] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://github.com/StarRocks/starrocks/issues/3008

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
hadoop-lz4 is not compatible with lz4 CLI.
hadoop-lz4 uses a block compression scheme on top of lz4.  As per the hadoop docs
(BlockCompressorStream.java and BlockDecompressorStream.java) the input is split
into blocks.  Each block "contains the uncompressed length for the block followed
by one of more length-prefixed blocks of compressed data."
This is essentially blocks of blocks.
The outer block consists of:
  - 4 byte big endian uncompressed_size
  < inner blocks >
  ... repeated until input_len is consumed ...
The inner blocks have:
  - 4-byte big endian compressed_size
  < lz4 compressed block >
  - 4-byte big endian compressed_size
  < lz4 compressed block >
  ... repeated until uncompressed_size from outer block is consumed ...

the hadoop lz4codec source code can be found here:
https://github.com/apache/hadoop/blob/trunk/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/main/native/src/codec/lz4codec.cc

More details refer to https://issues.apache.org/jira/browse/HADOOP-12990
