### PR TITLE
Fix bug the function in the window is incorrectly transform

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
@@ -258,8 +258,7 @@ class QueryTransformer {
         for (AnalyticExpr analyticExpr : window) {
             WindowTransformer.WindowOperator rewriteOperator = WindowTransformer.standardize(analyticExpr);
             if (windowOperators.contains(rewriteOperator)) {
-                windowOperators.get(windowOperators.indexOf(rewriteOperator))
-                        .addFunction(analyticExpr.getFnCall(), analyticExpr);
+                windowOperators.get(windowOperators.indexOf(rewriteOperator)).addFunction(analyticExpr);
             } else {
                 windowOperators.add(rewriteOperator);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
@@ -3,6 +3,7 @@ package com.starrocks.sql.optimizer.transformer;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import com.starrocks.analysis.AnalyticExpr;
 import com.starrocks.analysis.ArithmeticExpr;
 import com.starrocks.analysis.ArrayElementExpr;
 import com.starrocks.analysis.ArrayExpr;
@@ -380,6 +381,20 @@ public final class SqlToScalarOperatorTranslator {
                     arguments,
                     expr.getFn(),
                     expr.getParams().isDistinct());
+        }
+
+        @Override
+        public ScalarOperator visitAnalyticExpr(AnalyticExpr expr, Void context) {
+            FunctionCallExpr functionCallExpr = expr.getFnCall();
+
+            List<ScalarOperator> arguments =
+                    functionCallExpr.getChildren().stream().map(this::visit).collect(Collectors.toList());
+            return new CallOperator(
+                    functionCallExpr.getFnName().getFunction(),
+                    functionCallExpr.getType(),
+                    arguments,
+                    functionCallExpr.getFn(),
+                    functionCallExpr.getParams().isDistinct());
         }
 
         @Override

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -5610,6 +5610,17 @@ public class PlanFragmentTest extends PlanTestBase {
     }
 
     @Test
+    public void testWindowWithAgg() throws Exception {
+        String sql = "SELECT v1, sum(v2),  sum(v2) over (ORDER BY v1) AS rank  FROM t0 group BY v1, v2";
+        String plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("window: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW"));
+
+        sql = "SELECT v1, sum(v2),  sum(v2) over (ORDER BY CASE WHEN v1 THEN 1 END DESC) AS rank  FROM t0 group BY v1, v2";
+        plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW"));
+    }
+
+    @Test
     public void testWindowWithChildProjectAgg() throws Exception {
         String sql = "SELECT v1, sum(v2) as x1, row_number() over (ORDER BY CASE WHEN v1 THEN 1 END DESC) AS rank " +
                 "FROM t0 group BY v1";


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
#3201 
Fixes #

## Problem Summary(Required) ：
The function in the window is incorrectly cast because it conflicts with the function of the same name in the aggregate.
This PR is changed to AnalyticExpr and FunctionCallExpr cannot be mixed and converted
