### PR TITLE
improve TypeInfo::cmp performance

### DIFF
--- a/be/src/storage/rowset/bitshuffle_page.h
+++ b/be/src/storage/rowset/bitshuffle_page.h
@@ -319,11 +319,10 @@ public:
         // find the first value >= target. after loop,
         // - left == index of first value >= target when found
         // - left == _num_elements when not found (all values < target)
-        auto type_info = get_type_info(Type);
         while (left < right) {
             size_t mid = left + (right - left) / 2;
             const void* mid_value = get_data(mid * SIZE_OF_TYPE);
-            if (type_info->cmp(mid_value, value) < 0) {
+            if (TypeComparator<Type>::cmp(mid_value, value) < 0) {
                 left = mid + 1;
             } else {
                 right = mid;
@@ -333,7 +332,7 @@ public:
             return Status::NotFound("all value small than the value");
         }
         const void* find_value = get_data(left * SIZE_OF_TYPE);
-        *exact_match = type_info->cmp(find_value, value) == 0;
+        *exact_match = TypeComparator<Type>::cmp(find_value, value) == 0;
 
         _cur_index = left;
         return Status::OK();

--- a/be/src/storage/rowset/plain_page.h
+++ b/be/src/storage/rowset/plain_page.h
@@ -166,11 +166,10 @@ public:
         // find the first value >= target. after loop,
         // - left == index of first value >= target when found
         // - left == _num_elems when not found (all values < target)
-        auto type_info = get_type_info(Type);
         while (left < right) {
             size_t mid = left + (right - left) / 2;
             mid_value = &_data[PLAIN_PAGE_HEADER_SIZE + mid * SIZE_OF_TYPE];
-            if (type_info->cmp(mid_value, value) < 0) {
+            if (TypeComparator<Type>::cmp(mid_value, value) < 0) {
                 left = mid + 1;
             } else {
                 right = mid;
@@ -180,7 +179,7 @@ public:
             return Status::NotFound("all value small than the value");
         }
         const void* find_value = &_data[PLAIN_PAGE_HEADER_SIZE + left * SIZE_OF_TYPE];
-        if (type_info->cmp(find_value, value) == 0) {
+        if (TypeComparator<Type>::cmp(find_value, value) == 0) {
             *exact_match = true;
         } else {
             *exact_match = false;

--- a/be/src/storage/types.cpp
+++ b/be/src/storage/types.cpp
@@ -1041,4 +1041,15 @@ struct ScalarTypeInfoImpl<OLAP_FIELD_TYPE_JSON> : public ScalarTypeInfoImpl<OLAP
 
 void (*ScalarTypeInfoImpl<OLAP_FIELD_TYPE_CHAR>::set_to_max)(void*) = nullptr;
 
+// NOTE
+// These code could not be moved proceeding ScalarTypeInfoImpl speciliazation, otherwise
+// will encounter `specialization after instantiation` error
+template <FieldType ftype>
+int TypeComparator<ftype>::cmp(const void* lhs, const void* rhs) {
+    return ScalarTypeInfoImpl<ftype>::cmp(lhs, rhs);
+}
+#define M(ftype) template struct TypeComparator<ftype>;
+APPLY_FOR_SUPPORTED_FIELD_TYPE(M)
+#undef M
+
 } // namespace starrocks

--- a/be/src/storage/types.h
+++ b/be/src/storage/types.h
@@ -357,6 +357,13 @@ private:
     const size_t _item_size;
 };
 
+// TypeComparator
+// static compare functions for performance-critical scenario
+template <FieldType ftype>
+struct TypeComparator {
+    static int cmp(const void* lhs, const void* rhs);
+};
+
 bool is_scalar_field_type(FieldType field_type);
 
 bool is_complex_metric_type(FieldType field_type);


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
To improve performance of `TypeInfo::cmp`, eliminate possible virtual function call.

## Summary
Before, in `bitshuffle_page.h:325`, `TypeInfo::cmp` maybe compiled as virtual function call, since `get_type_info` return a pointer of base class `TypeInfo`.

After, a template function `TypeComparator::cmp` is employed to eliminated any possible virtual function call.

The template function is declared at `types.h`, implemented and explicitly instantiated at `types.cpp`.

## Related
The #3149 PR introduce this issue.