### PR TITLE
support array_join

### DIFF
--- a/be/src/column/column_builder.h
+++ b/be/src/column/column_builder.h
@@ -76,6 +76,10 @@ public:
         }
     }
 
+    ColumnPtr build_nullable_column() {
+        return NullableColumn::create(_column, _null_column);
+    }
+
     void reserve(int size) {
         _column->reserve(size);
         _null_column->reserve(size);
@@ -142,9 +146,16 @@ public:
     // as the number of evolving columns; however, the offset is updated
     // only once, so we split the append into append_partial and append_complete
     // as follows
-    void append_partial(uint8_t* begin, uint8_t* end) {
+    void append_partial(const uint8_t* begin, const uint8_t* end) {
         Bytes& bytes = _column->get_bytes();
         bytes.insert(bytes.end(), begin, end);
+    }
+
+    void append_partial(const Slice& slice) {
+        const auto* begin = reinterpret_cast<const uint8_t*>(slice.data);
+        const auto* end = begin + slice.size;
+
+        append_partial(begin, end);
     }
 
     void append_complete(size_t i) {

--- a/be/src/column/column_builder.h
+++ b/be/src/column/column_builder.h
@@ -76,9 +76,7 @@ public:
         }
     }
 
-    ColumnPtr build_nullable_column() {
-        return NullableColumn::create(_column, _null_column);
-    }
+    ColumnPtr build_nullable_column() { return NullableColumn::create(_column, _null_column); }
 
     void reserve(int size) {
         _column->reserve(size);

--- a/be/src/column/nullable_column.cpp
+++ b/be/src/column/nullable_column.cpp
@@ -32,6 +32,13 @@ NullableColumn::NullableColumn(ColumnPtr data_column, NullColumnPtr null_column)
             << "nullable column's data must be single column";
 }
 
+size_t NullableColumn::null_count() const {
+    if (!_has_null) {
+        return 0;
+    }
+    return SIMD::count_nonzero(_null_column->get_data());
+}
+
 void NullableColumn::append_datum(const Datum& datum) {
     if (datum.is_null()) {
         append_nulls(1);

--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -201,6 +201,8 @@ public:
     const NullColumn& null_column_ref() const { return *_null_column; }
     const NullColumnPtr& null_column() const { return _null_column; }
 
+    size_t null_count() const;
+
     Datum get(size_t n) const override {
         if (_has_null && _null_column->get_data()[n]) {
             return Datum();

--- a/be/src/exprs/vectorized/array_functions.h
+++ b/be/src/exprs/vectorized/array_functions.h
@@ -82,6 +82,15 @@ public:
 
 #undef DEFINE_ARRAY_REVERSE_FN
 
+#define DEFINE_ARRAY_JOIN_FN(NAME)                                                         \
+    static ColumnPtr array_join_##NAME(FunctionContext* context, const Columns& columns) { \
+        return ArrayJoin::process(context, columns);                                       \
+    }
+
+    DEFINE_ARRAY_JOIN_FN(varchar);
+
+#undef DEFINE_ARRAY_JOIN_FN
+
     DEFINE_VECTORIZED_FN(array_sum_boolean);
     DEFINE_VECTORIZED_FN(array_sum_tinyint);
     DEFINE_VECTORIZED_FN(array_sum_smallint);

--- a/be/src/exprs/vectorized/array_functions.tpp
+++ b/be/src/exprs/vectorized/array_functions.tpp
@@ -341,7 +341,7 @@ public:
         DCHECK_GE(columns.size(), 2);
         size_t chunk_size = columns[0]->size();
 
-        if (std::any_of(columns.begin(),columns.end(),[](auto col) { return col->only_null();})) {
+        if (std::any_of(columns.begin(), columns.end(), [](const auto& col) { return col->only_null(); })) {
             return ColumnHelper::create_const_null_column(chunk_size);
         }
 

--- a/be/src/exprs/vectorized/array_functions.tpp
+++ b/be/src/exprs/vectorized/array_functions.tpp
@@ -367,7 +367,7 @@ private:
 
         for (size_t i = 0; i < chunk_size; i++) {
             if (src_column->is_null(i) || sep_column->is_null(i) || null_replace_column->is_null(i)) {
-                res.append_null();
+                res.set_null(i);
                 continue;
             }
             auto datum = src_column->get(i);
@@ -403,7 +403,7 @@ private:
 
         for (size_t i = 0; i < chunk_size; i++) {
             if (src_column->is_null(i) || sep_column->is_null(i)) {
-                res.append_null();
+                res.set_null(i);
                 continue;
             }
 

--- a/be/src/exprs/vectorized/array_functions.tpp
+++ b/be/src/exprs/vectorized/array_functions.tpp
@@ -341,7 +341,7 @@ public:
         DCHECK_GE(columns.size(), 2);
         size_t chunk_size = columns[0]->size();
 
-        if (columns[0]->only_null()) {
+        if (std::any_of(columns.begin(),columns.end(),[](auto col) { return col->only_null();})) {
             return ColumnHelper::create_const_null_column(chunk_size);
         }
 

--- a/be/test/exprs/vectorized/array_functions_test.cpp
+++ b/be/test/exprs/vectorized/array_functions_test.cpp
@@ -2906,4 +2906,105 @@ TEST_F(ArrayFunctionsTest, array_reverse_only_null) {
     ASSERT_TRUE(dest_column->get(2).is_null());
 }
 
+// NOLINTNEXTLINE
+TEST_F(ArrayFunctionsTest, array_join_string) {
+    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
+    src_column->append_datum(DatumArray{"352", "66", "4325"});
+    src_column->append_datum(DatumArray{"235", "99", "8", "43251"});
+    src_column->append_datum(DatumArray{"44", "33", "22", "112"});
+
+    Slice sep_str("__");
+    auto sep_column = ColumnHelper::create_const_column<PrimitiveType::TYPE_VARCHAR>(sep_str, 3);
+
+    Slice null_str("NULL");
+    auto null_column = ColumnHelper::create_const_column<PrimitiveType::TYPE_VARCHAR>(null_str, 3);
+
+    auto dest_column = ArrayJoin::process(nullptr, {src_column, sep_column});
+    ASSERT_EQ(dest_column->size(), 3);
+    ASSERT_EQ(Slice("352__66__4325"), dest_column->get(0).get_slice());
+    ASSERT_EQ(Slice("235__99__8__43251"), dest_column->get(1).get_slice());
+    ASSERT_EQ(Slice("44__33__22__112"), dest_column->get(2).get_slice());
+
+    dest_column = ArrayJoin::process(nullptr, {src_column, sep_column, null_column});
+    ASSERT_EQ(dest_column->size(), 3);
+    ASSERT_EQ(Slice("352__66__4325"), dest_column->get(0).get_slice());
+    ASSERT_EQ(Slice("235__99__8__43251"), dest_column->get(1).get_slice());
+    ASSERT_EQ(Slice("44__33__22__112"), dest_column->get(2).get_slice());
+}
+
+// NOLINTNEXTLINE
+TEST_F(ArrayFunctionsTest, array_join_nullable_elements) {
+    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
+    src_column->append_datum(DatumArray{"55", Datum(), "333", "6666"});
+    src_column->append_datum(DatumArray{"22", "333", Datum(), Datum()});
+    src_column->append_datum(DatumArray{Datum(), Datum(), Datum(), Datum()});
+
+    Slice sep_str("__");
+    auto sep_column = ColumnHelper::create_const_column<PrimitiveType::TYPE_VARCHAR>(sep_str, 3);
+
+    Slice null_str("NULL");
+    auto null_column = ColumnHelper::create_const_column<PrimitiveType::TYPE_VARCHAR>(null_str, 3);
+
+    auto dest_column = ArrayJoin::process(nullptr, {src_column, sep_column});
+    ASSERT_EQ(dest_column->size(), 3);
+    ASSERT_EQ(Slice("55__333__6666"), dest_column->get(0).get_slice());
+    ASSERT_EQ(Slice("22__333"), dest_column->get(1).get_slice());
+    ASSERT_EQ(Slice(""), dest_column->get(2).get_slice());
+
+    dest_column = ArrayJoin::process(nullptr, {src_column, sep_column, null_column});
+    ASSERT_EQ(dest_column->size(), 3);
+    ASSERT_EQ(Slice("55__NULL__333__6666"), dest_column->get(0).get_slice());
+    ASSERT_EQ(Slice("22__333__NULL__NULL"), dest_column->get(1).get_slice());
+    ASSERT_EQ(Slice("NULL__NULL__NULL__NULL"), dest_column->get(2).get_slice());
+}
+
+// NOLINTNEXTLINE
+TEST_F(ArrayFunctionsTest, array_join_nullable_array) {
+    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
+    src_column->append_datum(DatumArray{"5", Datum(), "33", "666"});
+    src_column->append_datum(Datum());
+    src_column->append_datum(DatumArray{Datum(), Datum(), Datum(), Datum()});
+
+    Slice sep_str("__");
+    auto sep_column = ColumnHelper::create_const_column<PrimitiveType::TYPE_VARCHAR>(sep_str, 3);
+
+    Slice null_str("NULL");
+    auto null_column = ColumnHelper::create_const_column<PrimitiveType::TYPE_VARCHAR>(null_str, 3);
+
+    auto dest_column = ArrayJoin::process(nullptr, {src_column, sep_column});
+    ASSERT_EQ(dest_column->size(), 3);
+    ASSERT_EQ(Slice("5__33__666"), dest_column->get(0).get_slice());
+    ASSERT_TRUE(dest_column->get(1).is_null());
+    ASSERT_EQ(Slice(""), dest_column->get(2).get_slice());
+
+    dest_column = ArrayJoin::process(nullptr, {src_column, sep_column, null_column});
+    ASSERT_EQ(dest_column->size(), 3);
+    ASSERT_EQ(Slice("5__NULL__33__666"), dest_column->get(0).get_slice());
+    ASSERT_TRUE(dest_column->get(1).is_null());
+    ASSERT_EQ(Slice("NULL__NULL__NULL__NULL"), dest_column->get(2).get_slice());
+}
+
+// NOLINTNEXTLINE
+TEST_F(ArrayFunctionsTest, array_join_only_null) {
+    auto src_column = ColumnHelper::create_const_null_column(3);
+
+    Slice sep_str("__");
+    auto sep_column = ColumnHelper::create_const_column<PrimitiveType::TYPE_VARCHAR>(sep_str, 3);
+
+    Slice null_str("NULL");
+    auto null_column = ColumnHelper::create_const_column<PrimitiveType::TYPE_VARCHAR>(null_str, 3);
+
+    auto dest_column = ArrayJoin::process(nullptr, {src_column, sep_column});
+    ASSERT_EQ(dest_column->size(), 3);
+    ASSERT_TRUE(dest_column->get(0).is_null());
+    ASSERT_TRUE(dest_column->get(1).is_null());
+    ASSERT_TRUE(dest_column->get(2).is_null());
+
+    dest_column = ArrayJoin::process(nullptr, {src_column, sep_column, null_column});
+    ASSERT_EQ(dest_column->size(), 3);
+    ASSERT_TRUE(dest_column->get(0).is_null());
+    ASSERT_TRUE(dest_column->get(1).is_null());
+    ASSERT_TRUE(dest_column->get(2).is_null());
+}
+
 } // namespace starrocks::vectorized

--- a/gensrc/script/vectorized/vectorized_functions.py
+++ b/gensrc/script/vectorized/vectorized_functions.py
@@ -634,4 +634,7 @@ vectorized_functions = [
     [150139, 'reverse', 'ARRAY_DECIMALV2', ['ARRAY_DECIMALV2'], 'ArrayFunctions::array_reverse_decimalv2'],
     [150140, 'reverse', 'ARRAY_DATETIME',  ['ARRAY_DATETIME'],  'ArrayFunctions::array_reverse_datetime'],
     [150141, 'reverse', 'ARRAY_DATE',      ['ARRAY_DATE'],      'ArrayFunctions::array_reverse_date'],
+
+    [150150, 'array_join', 'VARCHAR', ['ARRAY_VARCHAR', 'VARCHAR'],   'ArrayFunctions::array_join_varchar'],
+    [150151, 'array_join', 'VARCHAR', ['ARRAY_VARCHAR', 'VARCHAR', 'VARCHAR'],   'ArrayFunctions::array_join_varchar'],
 ]


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

for #648

convert array to string

first param: src array
second param: separator
thrid param: null replace str

if separator or null replace str is null, the result is null;

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

the usage is same as presto/DataBricks/Spark, it's named array_to_string in pg/druid/bigquery

usage:

```
mysql> select * from m4;
+------+--------------+
| a    | b            |
+------+--------------+
|    1 | [4,3,null,1] |
|    2 | NULL         |
|    3 | [null]       |
+------+--------------+
3 rows in set (0.01 sec)

mysql> select a, array_join(b, '__') from m4;
+------+-----------------------+
| a    | array_join(`b`, '__') |
+------+-----------------------+
|    1 | 4__3__1               |
|    2 | NULL                  |
|    3 |                       |
+------+-----------------------+
3 rows in set (0.00 sec)

mysql> select a, array_join(b, '__', 'N') from m4;
+------+----------------------------+
| a    | array_join(`b`, '__', 'N') |
+------+----------------------------+
|    1 | 4__3__N__1                 |
|    2 | NULL                       |
|    3 | N                          |
+------+----------------------------+
3 rows in set (0.00 sec)
```
