### PR TITLE
Do not support non-nullable column for iceberg table (#3214)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -166,6 +166,10 @@ public class IcebergTable extends Table {
                 throw new DdlException("can not convert iceberg column type [" + icebergColumn.type() + "] to " +
                         "starrocks type [" + column.getPrimitiveType() + "], column name: " + column.getName());
             }
+            if (!column.isAllowNull()) {
+                throw new DdlException(
+                        "iceberg extern table not support no-nullable column: [" + icebergColumn.name() + "]");
+            }
         }
 
         if (!copiedProps.isEmpty()) {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/IcebergTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/IcebergTableTest.java
@@ -108,4 +108,14 @@ public class IcebergTableTest {
         new IcebergTable(1000, "iceberg_table", columns, properties);
         Assert.fail("No exception throws.");
     }
+
+    @Test(expected = DdlException.class)
+    public void testNonNullAbleColumn() throws DdlException {
+        List<Column> columns1 = Lists.newArrayList();
+        Column column = new Column("col1", Type.BIGINT, false);
+        columns1.add(column);
+        properties.remove("table");
+        new IcebergTable(1000, "iceberg_table", columns1, properties);
+        Assert.fail("No exception throws.");
+    }
 }


### PR DESCRIPTION
since parquet converters can not support non-nullable column now

before this pr we can create table with non-nullable column which will cause be crash since parquet converters can not support non-nullable column now
```
create external table ex_iceberg_tbl3 (
col_int int not null,
col_boolean boolean not null,
col_decimal decimal(38,18) not null,
col_long bigint not null,
col_float float not null comment "column float",
col_double double not null,
col_date date not null,
col_string varchar(200) not null comment "column string-varchar")
ENGINE=iceberg
properties (
"resource" = "iceberg_emr_tn",
"table" = "iceberg_parquet_snappy",
"database" = "iceberg_db");
```
after this pr we can  only create table like below:
```
MySQL [external_db]> create external table ex_iceberg_tbl_3003 (
    -> col_int int,
    -> col_boolean boolean,
    -> col_decimal decimal(38,18),
    -> col_long bigint,
    -> col_float float comment "column float",
    -> col_double double,
    -> col_date date,
    -> col_string varchar(200) comment "column string-varchar")
    -> ENGINE=iceberg
    -> properties (
    -> "resource" = "iceberg0",
    -> "table" = "iceberg_parquet_snappy_core",
    -> "database" = "iceberg");
Query OK, 0 rows affected (0.05 sec)

MySQL [external_db]> select col_date from ex_iceberg_tbl_3003;
+------------+
| col_date   |
+------------+
| 2020-01-01 |
| NULL       |
| 2020-10-01 |
| 2020-02-01 |
| 2020-06-01 |
| 2020-11-01 |
| 2020-03-01 |
| 2020-04-01 |
| 2020-07-01 |
| 2020-12-01 |
| 2020-08-01 |
| 2020-05-01 |
| 2020-09-01 |
+------------+
```

## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
