### PR TITLE
Support reading parquet file with gzip compression (#2739)

### DIFF
--- a/be/test/util/block_compression_test.cpp
+++ b/be/test/util/block_compression_test.cpp
@@ -84,7 +84,8 @@ void test_single_slice(starrocks::CompressionTypePB type) {
                 ASSERT_FALSE(st.ok());
             }
             // corrupt compressed data
-            if (type != starrocks::CompressionTypePB::SNAPPY) {
+            // we use inflate for gzip decompressor, it will return Z_OK for this case
+            if (type != starrocks::CompressionTypePB::SNAPPY && type != starrocks::CompressionTypePB::GZIP) {
                 Slice uncompressed_slice(uncompressed);
                 compressed_slice.size -= 1;
                 st = codec->decompress(compressed_slice, &uncompressed_slice);
@@ -107,6 +108,7 @@ TEST_F(BlockCompressionTest, single) {
     test_single_slice(starrocks::CompressionTypePB::ZLIB);
     test_single_slice(starrocks::CompressionTypePB::LZ4);
     test_single_slice(starrocks::CompressionTypePB::LZ4_FRAME);
+    test_single_slice(starrocks::CompressionTypePB::GZIP);
 }
 
 void test_multi_slices(starrocks::CompressionTypePB type) {
@@ -163,6 +165,7 @@ TEST_F(BlockCompressionTest, multi) {
     test_multi_slices(starrocks::CompressionTypePB::LZ4);
     test_multi_slices(starrocks::CompressionTypePB::LZ4_FRAME);
     test_multi_slices(starrocks::CompressionTypePB::ZSTD);
+    test_multi_slices(starrocks::CompressionTypePB::GZIP);
 }
 
 } // namespace starrocks


### PR DESCRIPTION
try to support read iceberg table which use default gzip compression algorithm

before this pr:
```
MySQL [external_db]> select * from iceberg_tbl;
ERROR 1064 (HY000): Fail to do Gzip decompress use zlib, error=data error
```
after this pr:
```
MySQL [external_db]> select * from iceberg_tbl;
+------+------+
| id   | data |
+------+------+
|    3 | c    |
|    1 | a    |
|    2 | b    |
+------+------+
```

## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
