### PR TITLE
Reduce the max number of files opened by meta scan

### DIFF
--- a/be/src/exec/vectorized/olap_meta_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_meta_scan_node.cpp
@@ -1,8 +1,6 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
 #include "exec/vectorized/olap_meta_scan_node.h"
 
-#include "glog/logging.h"
-
 namespace starrocks {
 namespace vectorized {
 
@@ -60,9 +58,8 @@ Status OlapMetaScanNode::prepare(RuntimeState* state) {
 
 Status OlapMetaScanNode::open(RuntimeState* state) {
     if (!_is_init) {
-        return Status::InternalError("MetaScan open called repeatedly.");
+        return Status::InternalError("Open before Init.");
     }
-
     for (auto& scan_range : _scan_ranges) {
         OlapMetaScannerParams scanner_params;
         scanner_params.scan_range = scan_range.get();
@@ -75,9 +72,10 @@ Status OlapMetaScanNode::open(RuntimeState* state) {
         return Status::InternalError("Invalid ScanRange.");
     }
 
-    _cursor_idx = 0;
     DCHECK_GT(_scanners.size(), 0);
     RETURN_IF_ERROR(_scanners[_cursor_idx]->open(state));
+
+    _cursor_idx = 0;
 
     RETURN_IF_CANCELLED(state);
     RETURN_IF_ERROR(ExecNode::open(state));
@@ -87,6 +85,7 @@ Status OlapMetaScanNode::open(RuntimeState* state) {
 Status OlapMetaScanNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) {
     DCHECK(state != nullptr && chunk != nullptr && eos != nullptr);
     RETURN_IF_CANCELLED(state);
+
     if (!_scanners[_cursor_idx]->has_more()) {
         _scanners[_cursor_idx]->close(state);
         _cursor_idx++;
@@ -95,6 +94,7 @@ Status OlapMetaScanNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool* eo
         *eos = true;
         return Status::OK();
     }
+
     RETURN_IF_ERROR(_scanners[_cursor_idx]->open(state));
     RETURN_IF_ERROR(_scanners[_cursor_idx]->get_chunk(state, chunk));
     return Status::OK();
@@ -103,10 +103,6 @@ Status OlapMetaScanNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool* eo
 Status OlapMetaScanNode::close(RuntimeState* state) {
     if (is_closed()) {
         return Status::OK();
-    }
-
-    for (auto scanner : _scanners) {
-        scanner->close(state);
     }
 
     SCOPED_TIMER(_runtime_profile->total_time_counter());

--- a/be/src/exec/vectorized/olap_meta_scanner.h
+++ b/be/src/exec/vectorized/olap_meta_scanner.h
@@ -46,7 +46,6 @@ private:
 
     OlapMetaScanNode* _parent;
     RuntimeState* _runtime_state;
-    OlapMetaScannerParams _params;
     TabletSharedPtr _tablet;
 
     MetaReaderParams _reader_params;

--- a/be/src/exec/vectorized/olap_meta_scanner.h
+++ b/be/src/exec/vectorized/olap_meta_scanner.h
@@ -15,7 +15,6 @@ class OlapMetaScanNode;
 
 struct OlapMetaScannerParams {
     const TInternalScanRange* scan_range = nullptr;
-    const std::vector<OlapScanRange*>* key_ranges = nullptr;
 };
 
 class OlapMetaScanner {
@@ -32,7 +31,7 @@ public:
 
     Status open(RuntimeState* state);
 
-    Status close(RuntimeState* state);
+    void close(RuntimeState* state);
 
     Status get_chunk(RuntimeState* state, ChunkPtr* chunk);
 
@@ -47,6 +46,7 @@ private:
 
     OlapMetaScanNode* _parent;
     RuntimeState* _runtime_state;
+    OlapMetaScannerParams _params;
     TabletSharedPtr _tablet;
 
     MetaReaderParams _reader_params;

--- a/be/src/storage/vectorized/meta_reader.cpp
+++ b/be/src/storage/vectorized/meta_reader.cpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "column/datum_convert.h"
+#include "common/status.h"
 #include "storage/rowset/beta_rowset.h"
 #include "storage/rowset/column_iterator.h"
 #include "storage/rowset/column_reader.h"
@@ -190,6 +191,13 @@ Status MetaReader::do_get_next(ChunkPtr* result) {
     return Status::OK();
 }
 
+Status MetaReader::open() {
+    for (auto collector : _collect_context.seg_collecters) {
+        RETURN_IF_ERROR(collector->open());
+    }
+    return Status::OK();
+}
+
 Status MetaReader::_read(Chunk* chunk, size_t n) {
     std::vector<vectorized::Column*> columns;
     for (size_t i = 0; i < _collect_context.seg_collecter_params.fields.size(); ++i) {
@@ -221,8 +229,11 @@ SegmentMetaCollecter::~SegmentMetaCollecter() {}
 
 Status SegmentMetaCollecter::init(const SegmentMetaCollecterParams* params) {
     _params = params;
-    RETURN_IF_ERROR(_init_return_column_iterators());
+    return Status::OK();
+}
 
+Status SegmentMetaCollecter::open() {
+    RETURN_IF_ERROR(_init_return_column_iterators());
     return Status::OK();
 }
 

--- a/be/src/storage/vectorized/meta_reader.h
+++ b/be/src/storage/vectorized/meta_reader.h
@@ -74,6 +74,8 @@ public:
 
     TabletSharedPtr tablet() { return _tablet; }
 
+    Status open();
+
     Status do_get_next(ChunkPtr* chunk);
 
     bool has_more();
@@ -117,6 +119,7 @@ public:
     SegmentMetaCollecter(SegmentSharedPtr segment);
     ~SegmentMetaCollecter();
     Status init(const SegmentMetaCollecterParams* params);
+    Status open();
     Status collect(std::vector<vectorized::Column*>* dsts);
 
 public:


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
Fixes #3243 

## Problem Summary(Required) ：
Reduce the number of files open at the same time

be.conf:
file_descriptor_cache_capacity=10
dump fd size used in process:
```c++
    // =============
    std::filesystem::path pt = "/proc/" + std::to_string(getpid()) + "/fd";
    size_t sz = 0;
    for(const auto& _:std::filesystem::directory_iterator(pt)) {
        sz++;
    }
    LOG(WARNING) << "proc size:" << sz;
    // ============
```

max fds before | max fds after
-- | --
743 | 203
