### PR TITLE
Fix for overflow of exp

### DIFF
--- a/be/src/exprs/vectorized/math_functions.cpp
+++ b/be/src/exprs/vectorized/math_functions.cpp
@@ -23,6 +23,10 @@ DEFINE_UNARY_FN_WITH_IMPL(NanCheck, value) {
     return std::isnan(value);
 }
 
+DEFINE_UNARY_FN_WITH_IMPL(ExpCheck, value) {
+    return std::isnan(value) || value > MathFunctions::MAX_EXP_PARAMETER;
+}
+
 DEFINE_UNARY_FN_WITH_IMPL(ZeroCheck, value) {
     return value == 0;
 }
@@ -65,6 +69,12 @@ DEFINE_UNARY_FN_WITH_IMPL(ZeroCheck, value) {
         return VectorizedUnaryFunction::evaluate<TYPE, RESULT_TYPE>(VECTORIZED_FN_ARGS(0));                  \
     }
 
+#define DEFINE_MATH_UNARY_WITH_OUTPUT_CHECK_FN(NAME, TYPE, RESULT_TYPE, NULL_FN)                             \
+    ColumnPtr MathFunctions::NAME(FunctionContext* context, const starrocks::vectorized::Columns& columns) { \
+        using VectorizedUnaryFunction = VectorizedOutputCheckUnaryFunction<NAME##Impl, NULL_FN>;             \
+        return VectorizedUnaryFunction::evaluate<TYPE, RESULT_TYPE>(VECTORIZED_FN_ARGS(0));                  \
+    }
+
 #define DEFINE_MATH_BINARY_WITH_OUTPUT_NAN_CHECK_FN(NAME, LTYPE, RTYPE, RESULT_TYPE)                         \
     ColumnPtr MathFunctions::NAME(FunctionContext* context, const starrocks::vectorized::Columns& columns) { \
         using VectorizedBinaryFunction = VectorizedOuputCheckBinaryFunction<NAME##Impl, NanCheck>;           \
@@ -103,6 +113,10 @@ DEFINE_UNARY_FN_WITH_IMPL(ZeroCheck, value) {
 #define DEFINE_MATH_UNARY_WITH_OUTPUT_NAN_CHECK_FN_WITH_IMPL(NAME, TYPE, RESULT_TYPE, FN) \
     DEFINE_UNARY_FN(NAME##Impl, FN);                                                      \
     DEFINE_MATH_UNARY_WITH_OUTPUT_NAN_CHECK_FN(NAME, TYPE, RESULT_TYPE);
+
+#define DEFINE_MATH_UNARY_WITH_OUTPUT_CHECK_FN_WITH_IMPL(NAME, TYPE, RESULT_TYPE, FN, NULL_FN) \
+    DEFINE_UNARY_FN(NAME##Impl, FN);                                                           \
+    DEFINE_MATH_UNARY_WITH_OUTPUT_CHECK_FN(NAME, TYPE, RESULT_TYPE, NULL_FN);
 
 #define DEFINE_MATH_BINARY_WITH_OUTPUT_NAN_CHECK_FN_WITH_IMPL(NAME, LTYPE, RTYPE, RESULT_TYPE, FN) \
     DEFINE_BINARY_FUNCTION(NAME##Impl, FN);                                                        \
@@ -232,7 +246,7 @@ DEFINE_MATH_UNARY_WITH_OUTPUT_NAN_CHECK_FN_WITH_IMPL(tan, TYPE_DOUBLE, TYPE_DOUB
 DEFINE_MATH_UNARY_WITH_OUTPUT_NAN_CHECK_FN_WITH_IMPL(atan, TYPE_DOUBLE, TYPE_DOUBLE, std::atan);
 DEFINE_MATH_UNARY_WITH_OUTPUT_NAN_CHECK_FN_WITH_IMPL(ceil, TYPE_DOUBLE, TYPE_BIGINT, std::ceil);
 DEFINE_MATH_UNARY_WITH_OUTPUT_NAN_CHECK_FN_WITH_IMPL(floor, TYPE_DOUBLE, TYPE_BIGINT, std::floor);
-DEFINE_MATH_UNARY_WITH_OUTPUT_NAN_CHECK_FN_WITH_IMPL(exp, TYPE_DOUBLE, TYPE_DOUBLE, std::exp);
+DEFINE_MATH_UNARY_WITH_OUTPUT_CHECK_FN_WITH_IMPL(exp, TYPE_DOUBLE, TYPE_DOUBLE, std::exp, ExpCheck);
 
 DEFINE_MATH_UNARY_WITH_NON_POSITIVE_CHECK_FN_WITH_IMPL(ln, TYPE_DOUBLE, TYPE_DOUBLE, std::log);
 DEFINE_MATH_UNARY_WITH_NON_POSITIVE_CHECK_FN_WITH_IMPL(log10, TYPE_DOUBLE, TYPE_DOUBLE, std::log10);

--- a/be/src/exprs/vectorized/math_functions.h
+++ b/be/src/exprs/vectorized/math_functions.h
@@ -455,6 +455,7 @@ public:
     static bool decimal_in_base_to_decimal(int64_t src_num, int8_t src_base, int64_t* result);
     static bool handle_parse_result(int8_t dest_base, int64_t* num, StringParser::ParseResult parse_res);
     static std::string decimal_to_base(int64_t src_num, int8_t dest_base);
+    static constexpr double MAX_EXP_PARAMETER = std::log(std::numeric_limits<double>::max());
 
 private:
     static const int32_t MIN_BASE = 2;

--- a/be/test/exprs/vectorized/math_functions_test.cpp
+++ b/be/test/exprs/vectorized/math_functions_test.cpp
@@ -551,6 +551,41 @@ TEST_F(VecMathFunctionsTest, LnTest) {
     }
 }
 
+TEST_F(VecMathFunctionsTest, ExpTest) {
+    {
+        Columns columns;
+
+        auto tc1 = DoubleColumn::create();
+        tc1->append(0);
+        tc1->append(2.0);
+        columns.emplace_back(tc1);
+
+        std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
+        ColumnPtr result_exp = MathFunctions::exp(ctx.get(), columns);
+
+        ASSERT_EQ(false, result_exp->is_null(0));
+        ASSERT_EQ(std::exp(0), result_exp->get(0).get_double());
+        ASSERT_EQ(std::exp(2), result_exp->get(1).get_double());
+    }
+}
+
+TEST_F(VecMathFunctionsTest, ExpOverflowTest) {
+    {
+        Columns columns;
+
+        auto tc1 = DoubleColumn::create();
+        tc1->append(2.47498282E8);
+        tc1->append(2.47498282E3);
+        columns.emplace_back(tc1);
+
+        std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
+        ColumnPtr result_exp = MathFunctions::exp(ctx.get(), columns);
+
+        ASSERT_EQ(true, result_exp->is_null(0));
+        ASSERT_EQ(true, result_exp->is_null(1));
+    }
+}
+
 TEST_F(VecMathFunctionsTest, squareTest) {
     {
         Columns columns;


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/3244.
## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Fix overflow of function exp, for example 'DEXP(2.47498282E8)', 2.47498282E8 is too big to use as paramter.