### PR TITLE
Fix the bug of multi column in one chunk ref the same decimalv3 column

### DIFF
--- a/be/src/exprs/vectorized/decimal_cast_expr.h
+++ b/be/src/exprs/vectorized/decimal_cast_expr.h
@@ -26,8 +26,9 @@ struct DecimalDecimalCast {
 
         // source type and target type has the same primitive type and scale
         if (to_scale == from_scale && Type == ResultType) {
-            data_column->set_precision(to_precision);
-            return column;
+            auto result = column->clone_shared();
+            ColumnHelper::cast_to_raw<Type>(result)->set_precision(to_precision);
+            return result;
         }
 
         const auto data = &data_column->get_data().front();


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3250 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

cast DECIMAL64(5, 4) to DECIMAL(7, 4),  have the same scale, so the two column ptr in on chunk ref to the same column

```
|   |  <slot 19> : 19: c_1_0                                                            |
|   |  <slot 24> : CAST(19: c_1_0 AS DECIMAL64(7,4))      
```

```
CREATE TABLE `t1` (
  `c_1_0` decimal64(5, 4) NOT NULL COMMENT "",
  `c_1_1` bitmap BITMAP_UNION NULL COMMENT "",
  `c_1_2` varchar(1) REPLACE NOT NULL COMMENT ""
) ENGINE=OLAP 
AGGREGATE KEY(`c_1_0`)
COMMENT "OLAP"
DISTRIBUTED BY HASH(`c_1_0`) BUCKETS 10 
PROPERTIES (
"replication_num" = "1",
"in_memory" = "false",
"storage_format" = "DEFAULT"
);

mysql> explain SELECT COUNT(*) FROM t0 INNER JOIN t1 subt1 ON t0.c_0_8 > subt1.c_1_0 AND  t0.c_0_8 = CAST(subt1.c_1_0 AS DECIMAL(7, 4));
+---------------------------------------------------------------------------------------+
| Explain String                                                                        |
+---------------------------------------------------------------------------------------+
| PLAN FRAGMENT 0                                                                       |
|  OUTPUT EXPRS:22: count                                                               |
|   PARTITION: UNPARTITIONED                                                            |
|                                                                                       |
|   RESULT SINK                                                                         |
|                                                                                       |
|   9:AGGREGATE (merge finalize)                                                        |
|   |  output: count(22: count)                                                         |
|   |  group by:                                                                        |
|   |                                                                                   |
|   8:EXCHANGE                                                                          |
|                                                                                       |
| PLAN FRAGMENT 1                                                                       |
|  OUTPUT EXPRS:                                                                        |
|   PARTITION: RANDOM                                                                   |
|                                                                                       |
|   STREAM DATA SINK                                                                    |
|     EXCHANGE ID: 08                                                                   |
|     UNPARTITIONED                                                                     |
|                                                                                       |
|   7:AGGREGATE (update serialize)                                                      |
|   |  output: count(*)                                                                 |
|   |  group by:                                                                        |
|   |                                                                                   |
|   6:Project                                                                           |
|   |  <slot 9> : 9: c_0_8                                                              |
|   |                                                                                   |
|   5:HASH JOIN                                                                         |
|   |  join op: INNER JOIN (BROADCAST)                                                  |
|   |  hash predicates:                                                                 |
|   |  colocate: false, reason:                                                         |
|   |  equal join conjunct: 24: cast = 23: cast                                         |
|   |  other join predicates: CAST(9: c_0_8 AS DECIMAL64(5,4)) > 19: c_1_0              |
|   |                                                                                   |
|   |----4:EXCHANGE                                                                     |
|   |                                                                                   |
|   1:Project                                                                           |
|   |  <slot 19> : 19: c_1_0                                                            |
|   |  <slot 24> : CAST(19: c_1_0 AS DECIMAL64(7,4))                                    |
|   |                                                                                   |
|   0:OlapScanNode                                                                      |
|      TABLE: t1                                                                        |
|      PREAGGREGATION: OFF. Reason: Aggregate function has more than one parameter      |
|      partitions=1/1                                                                   |
|      rollup: t1                                                                       |
|      tabletRatio=10/10                                                                |
|      tabletList=252664,252666,252668,252670,252672,252674,252676,252678,252680,252682 |
|      cardinality=9                                                                    |
|      avgRowSize=2.0                                                                   |
|      numNodes=0                                                                       |
|                                                                                       |
| PLAN FRAGMENT 2                                                                       |
|  OUTPUT EXPRS:                                                                        |
|   PARTITION: RANDOM                                                                   |
|                                                                                       |
|   STREAM DATA SINK                                                                    |
|     EXCHANGE ID: 04                                                                   |
|     UNPARTITIONED                                                                     |
|                                                                                       |
|   3:Project                                                                           |
|   |  <slot 9> : 9: c_0_8                                                              |
|   |  <slot 23> : CAST(9: c_0_8 AS DECIMAL64(7,4))                                     |
|   |                                                                                   |
|   2:OlapScanNode                                                                      |
|      TABLE: t0                                                                        |
|      PREAGGREGATION: OFF. Reason: Has can not pre-aggregation Join                    |
|      partitions=1/1                                                                   |
|      rollup: t0                                                                       |
|      tabletRatio=10/10                                                                |
|      tabletList=252641,252643,252645,252647,252649,252651,252653,252655,252657,252659 |
|      cardinality=6                                                                    |
|      avgRowSize=2.0                                                                   |
|      numNodes=0                                                                       |
+---------------------------------------------------------------------------------------+
73 rows in set (0.01 sec)

```
