### PR TITLE
return NULL if input was empty string in FROM_UNIXTIME

### DIFF
--- a/be/src/exprs/vectorized/time_functions.cpp
+++ b/be/src/exprs/vectorized/time_functions.cpp
@@ -891,7 +891,7 @@ ColumnPtr TimeFunctions::from_unix_with_format_const(std::string& format_content
     auto size = columns[0]->size();
     ColumnBuilder<TYPE_VARCHAR> result(size);
     for (int row = 0; row < size; ++row) {
-        if (data_column.is_null(row)) {
+        if (data_column.is_null(row) || format_content.empty()) {
             result.append_null();
             continue;
         }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
Fixes #3246 case 2

## Problem Summary(Required) ：
behaviour for const and general was not the same.
so we will return null in const handler
