### PR TITLE
Support load data to json type

### DIFF
--- a/be/src/formats/json/binary_column.cpp
+++ b/be/src/formats/json/binary_column.cpp
@@ -122,4 +122,14 @@ Status add_native_json_column(Column* column, const TypeDescriptor& type_desc, c
     return Status::OK();
 }
 
+Status add_native_json_column(Column* column, const TypeDescriptor& type_desc, const std::string& name,
+                              simdjson::ondemand::object* value) {
+    auto json_column = down_cast<JsonColumn*>(column);
+
+    auto json_value = JsonValue::from_simdjson(value);
+    RETURN_IF(!json_value.ok(), json_value.status());
+    json_column->append(&json_value.value());
+    return Status::OK();
+}
+
 } // namespace starrocks::vectorized

--- a/be/src/formats/json/binary_column.cpp
+++ b/be/src/formats/json/binary_column.cpp
@@ -128,7 +128,7 @@ Status add_native_json_column(Column* column, const TypeDescriptor& type_desc, c
 
     auto json_value = JsonValue::from_simdjson(value);
     RETURN_IF(!json_value.ok(), json_value.status());
-    json_column->append(&json_value.value());
+    json_column->append(std::move(json_value).value());
     return Status::OK();
 }
 

--- a/be/src/formats/json/binary_column.h
+++ b/be/src/formats/json/binary_column.h
@@ -16,5 +16,7 @@ Status add_binary_column(Column* column, const TypeDescriptor& type_desc, const 
 
 Status add_native_json_column(Column* column, const TypeDescriptor& type_desc, const std::string& name,
                               simdjson::ondemand::value* value);
+Status add_native_json_column(Column* column, const TypeDescriptor& type_desc, const std::string& name,
+                              simdjson::ondemand::object* value);
 
 } // namespace starrocks::vectorized

--- a/be/src/formats/json/nullable_column.h
+++ b/be/src/formats/json/nullable_column.h
@@ -16,4 +16,6 @@ namespace starrocks::vectorized {
 Status add_nullable_column(Column* column, const TypeDescriptor& type_desc, const std::string& name,
                            simdjson::ondemand::value* value, bool invalid_as_null);
 
+Status add_nullable_column(Column* column, const TypeDescriptor& type_desc, const std::string& name,
+                           simdjson::ondemand::object* value, bool invalid_as_null);
 } // namespace starrocks::vectorized

--- a/be/src/util/json.cpp
+++ b/be/src/util/json.cpp
@@ -109,6 +109,18 @@ StatusOr<JsonValue> JsonValue::from_simdjson(simdjson::ondemand::value* value) {
     return Status::OK();
 }
 
+StatusOr<JsonValue> JsonValue::from_simdjson(simdjson::ondemand::object* obj) {
+    // TODO(mofei) optimize this, avoid convert to string then parse it
+    std::string_view view = obj->raw_json();
+    try {
+        return parse(Slice(view.data(), view.size()));
+    } catch (simdjson::simdjson_error& e) {
+        auto err_msg = strings::Substitute("Failed to parse value, json=$0, error=$1", view.data(),
+                                           simdjson::error_message(e.error()));
+        return Status::DataQualityError(err_msg);
+    }
+}
+
 StatusOr<JsonValue> JsonValue::parse(const Slice& src) {
     JsonValue json;
     RETURN_IF_ERROR(parse(src, &json));

--- a/be/src/util/json.h
+++ b/be/src/util/json.h
@@ -68,6 +68,7 @@ public:
 
     // construct a JsonValue from simdjson::value
     static StatusOr<JsonValue> from_simdjson(simdjson::ondemand::value* value);
+    static StatusOr<JsonValue> from_simdjson(simdjson::ondemand::object* obj);
 
     ////////////////// parsing  //////////////////////
     static Status parse(const Slice& src, JsonValue* out);


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
Load json data into `JSON` column with `$` jsonpath.

In stream load, jsonpath could be specified to map json field to table column. For `JSON` type, which could store the whole object, so we need a special syntax. 

## Use case
The input json file could be ndjson(newline delimited) formats or json array formats:
```json
{"k1": 1, "k2": 2, "k3": {"k4": 3}}
{"k1": 5, "k2": 6, "k3": {"k4": 7}}
```

The table schema is :
```sql
CREATE TABLE tjson (
  k1 INT NOT NULL,
  k2 INT NOT NULL,
  j JSON
)
DUPLICATED KEY (k1, k2)
DISTRIBUTED BY HASH(k1, k2);
```

To load the json file into table, mapping `k1` field to `k1` column, `k2` field to `k2` column, and the full json object to `j` column, the stream load parameter could be `{format: "json", jsonpaths: '["$.k1", "$.k2", "$"]', columns: [k1,k2,j]}`.

In which, the `$` jsonpath represent the full json object.
