### PR TITLE
Fix: bitmap_count(null) returns 0 instead of null

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/ExpressionFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/ExpressionFunctions.java
@@ -72,9 +72,10 @@ public enum ExpressionFunctions {
 
             // return NullLiteral directly iff:
             // 1. Not UDF
-            // 2. Not in NonNullResultWithNullParamFunctions
+            // 2. Not in isNotAlwaysNullResultWithNullParamFunctions
             // 3. Has null parameter
-            if (!Catalog.getCurrentCatalog().isNonNullResultWithNullParamFunction(fn.getFunctionName().getFunction())
+            if (!Catalog.getCurrentCatalog()
+                    .isNotAlwaysNullResultWithNullParamFunction(fn.getFunctionName().getFunction())
                     && !fn.isUdf()) {
                 for (Expr e : constExpr.getChildren()) {
                     if (e instanceof NullLiteral) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -6159,8 +6159,8 @@ public class Catalog {
         return functionSet.getBuiltinFunctions();
     }
 
-    public boolean isNonNullResultWithNullParamFunction(String funcName) {
-        return functionSet.isNonNullResultWithNullParamFunctions(funcName);
+    public boolean isNotAlwaysNullResultWithNullParamFunction(String funcName) {
+        return functionSet.isNotAlwaysNullResultWithNullParamFunctions(funcName);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -172,7 +172,7 @@ public class FunctionSet {
     private final Map<String, List<Function>> vectorizedFunctions;
     // This does not contain any user defined functions. All UDFs handle null values by themselves.
     private final ImmutableSet<String> nonNullResultWithNullParamFunctions = ImmutableSet.of("if", "hll_hash",
-            "concat_ws", "ifnull", "nullif", "null_or_empty", "coalesce", "md5sum");
+            "concat_ws", "ifnull", "nullif", "null_or_empty", "coalesce", "md5sum", "bitmap_count");
 
     // If low cardinality string column with global dict, for some string functions,
     // we could evaluate the function only with the dict content, not all string column data.

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -173,7 +173,7 @@ public class FunctionSet {
     private final Map<String, List<Function>> vectorizedFunctions;
     // This contains the nullable functions, which cannot return NULL result directly for the NULL parameter.
     // This does not contain any user defined functions. All UDFs handle null values by themselves.
-    private final ImmutableSet<String> nonNullResultWithNullParamNullFunctions = ImmutableSet.of("if",
+    private final ImmutableSet<String> notAlwaysNullResultWithNullParamFunctions = ImmutableSet.of("if",
             "concat_ws", "ifnull", "nullif", "null_or_empty", "coalesce");
 
     // If low cardinality string column with global dict, for some string functions,
@@ -287,8 +287,8 @@ public class FunctionSet {
         initAggregateBuiltins();
     }
 
-    public boolean isNonNullResultWithNullParamFunctions(String funcName) {
-        return nonNullResultWithNullParamNullFunctions.contains(funcName)
+    public boolean isNotAlwaysNullResultWithNullParamFunctions(String funcName) {
+        return notAlwaysNullResultWithNullParamFunctions.contains(funcName)
                 || alwaysReturnNonNullableFunctions.contains(funcName);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -89,6 +89,7 @@ public class FunctionSet {
     public static final String NULL_OR_EMPTY = "null_or_empty";
     public static final String IF = "if";
     public static final String IF_NULL = "ifnull";
+    public static final String MD5_SUM = "md5sum";
 
     // Arithmetic functions:
     public static final String ADD = "add";
@@ -170,9 +171,10 @@ public class FunctionSet {
      * to row function when init.
      */
     private final Map<String, List<Function>> vectorizedFunctions;
+    // This contains the nullable functions, which cannot return NULL result directly for the NULL parameter.
     // This does not contain any user defined functions. All UDFs handle null values by themselves.
-    private final ImmutableSet<String> nonNullResultWithNullParamFunctions = ImmutableSet.of("if", "hll_hash",
-            "concat_ws", "ifnull", "nullif", "null_or_empty", "coalesce", "md5sum", "bitmap_count");
+    private final ImmutableSet<String> nonNullResultWithNullParamNullFunctions = ImmutableSet.of("if",
+            "concat_ws", "ifnull", "nullif", "null_or_empty", "coalesce");
 
     // If low cardinality string column with global dict, for some string functions,
     // we could evaluate the function only with the dict content, not all string column data.
@@ -216,6 +218,7 @@ public class FunctionSet {
                     .add(FunctionSet.CURRENT_TIME)
                     .add(FunctionSet.NOW)
                     .add(FunctionSet.UTC_TIMESTAMP)
+                    .add(FunctionSet.MD5_SUM)
                     .build();
 
     public FunctionSet() {
@@ -285,7 +288,8 @@ public class FunctionSet {
     }
 
     public boolean isNonNullResultWithNullParamFunctions(String funcName) {
-        return nonNullResultWithNullParamFunctions.contains(funcName);
+        return nonNullResultWithNullParamNullFunctions.contains(funcName)
+                || alwaysReturnNonNullableFunctions.contains(funcName);
     }
 
     public Function getFunction(Function desc, Function.CompareMode mode) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorEvaluator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorEvaluator.java
@@ -103,9 +103,9 @@ public enum ScalarOperatorEvaluator {
 
         // return Null directly iff:
         // 1. Not UDF
-        // 2. Not in NonNullResultWithNullParamFunctions
+        // 2. Not in isNotAlwaysNullResultWithNullParamFunctions
         // 3. Has null parameter
-        if (!Catalog.getCurrentCatalog().isNonNullResultWithNullParamFunction(fn.getFunctionName().getFunction())
+        if (!Catalog.getCurrentCatalog().isNotAlwaysNullResultWithNullParamFunction(fn.getFunctionName().getFunction())
                 && !fn.isUdf()) {
             for (ScalarOperator op : root.getChildren()) {
                 if (((ConstantOperator) op).isNull()) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorEvaluatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorEvaluatorTest.java
@@ -118,4 +118,22 @@ public class ScalarOperatorEvaluatorTest {
         assertEquals(LocalDateTime.of(2003, 10, 11, 23, 56, 25), ((ConstantOperator) result).getDatetime());
     }
 
+    @Test
+    public void evaluationNonNullableFunc() {
+        CallOperator operator = new CallOperator("bitmap_count", Type.BIGINT,
+                Lists.newArrayList(ConstantOperator.createNull(Type.BITMAP)));
+
+        Function fn = new Function(new FunctionName("bitmap_count"), new Type[] {Type.BITMAP}, Type.BIGINT, false);
+        new Expectations(operator) {
+            {
+                operator.getFunction();
+                result = fn;
+            }
+        };
+
+        ScalarOperator result = ScalarOperatorEvaluator.INSTANCE.evaluation(operator);
+
+        assertEquals(result, operator);
+    }
+
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -5630,4 +5630,14 @@ public class PlanFragmentTest extends PlanTestBase {
                 "  |  <slot 4> : 4: sum\n" +
                 "  |  <slot 8> : if(CAST(1: v1 AS BOOLEAN), 1, NULL)"));
     }
+
+    @Test
+    public void testBitmapCount() throws Exception {
+        String sql = "SELECT 1 FROM t0 LEFT OUTER JOIN t1 ON t0.v1=t1.v4 " +
+                "WHERE NOT CAST(bitmap_count(CASE WHEN t1.v4 in (10000) THEN bitmap_hash('abc') END) AS BOOLEAN)";
+        String plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("join op: LEFT OUTER JOIN (BROADCAST)"));
+        Assert.assertTrue(plan.contains(
+                "other predicates: NOT (CAST(bitmap_count(if(4: v4 = 10000, bitmap_hash('abc'), NULL)) AS BOOLEAN))"));
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fix #3247.

## Problem Summary：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
`BITMAP_COUNT(NULL)` should return `0` not `NULL`, because this function is non-nullable.
However, `ScalarOperatorEvaluator` rewrites the result of function to `NULL`, if the function isn't in `NonNullResultWithNullParamFunctions`, which doesn't consider the function may be non-nullable.


