### PR TITLE
Improve retention

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -597,7 +597,7 @@ public class FunctionSet {
                 false, false, false));
 
         addBuiltin(AggregateFunction.createBuiltin(RETENTION, Lists.newArrayList(Type.ARRAY_BOOLEAN),
-                Type.ARRAY_BOOLEAN, Type.ARRAY_BOOLEAN, false, false, false));
+                Type.ARRAY_BOOLEAN, Type.BIGINT, false, false, false));
 
         // Avg
         // TODO: switch to CHAR(sizeof(AvgIntermediateType) when that becomes available


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

- Use uint64_t instead of vector<uint8_t> to avoid memory access.
- So we use Type.BIGINT instead of Type.ARRAY_BOOLEAN as intermediate type to void array type.
- Conditions' size is changed to at most 31.
**These changes could improve performance**

tests: https://github.com/StarRocks/StarRocksTest/pull/112
