### PR TITLE
CTAS enforces that the expression requires column name

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CTASAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CTASAnalyzer.java
@@ -90,8 +90,14 @@ public class CTASAnalyzer {
             }
             finalColumnNames.addAll(columnNames);
         } else {
-            for (Field allField : allFields) {
-                finalColumnNames.add(allField.getName());
+            for (Field oneField : allFields) {
+                Expr originExpression = oneField.getOriginExpression();
+                if (originExpression instanceof SlotRef) {
+                    finalColumnNames.add(oneField.getName());
+                } else {
+                    throw new SemanticException("Expression [%s] should have specification column name",
+                            oneField.getOriginExpression().toSql());
+                }
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CTASAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CTASAnalyzer.java
@@ -14,7 +14,6 @@ import com.starrocks.analysis.QueryStmt;
 import com.starrocks.analysis.SelectListItem;
 import com.starrocks.analysis.SelectStmt;
 import com.starrocks.analysis.SlotRef;
-import com.starrocks.analysis.TableName;
 import com.starrocks.analysis.TableRef;
 import com.starrocks.analysis.TypeDef;
 import com.starrocks.catalog.ArrayType;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CTASAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CTASAnalyzerTest.java
@@ -197,6 +197,19 @@ public class CTASAnalyzerTest {
         UtFrameUtils.parseStmtWithNewAnalyzer(CTASSQL3, ctx);
     }
 
+    @Test(expected = SemanticException.class)
+    public void testErrorCase() throws Exception {
+        ConnectContext ctx = starRocksAssert.getCtx();
+
+        String CTASSQL2 = "create table test6 as select c1+c2 from test3;";
+
+        UtFrameUtils.parseStmtWithNewAnalyzer(CTASSQL2, ctx);
+
+        String CTASSQL3 = "create table t1 as select k1,sum(k8) from duplicate_table_with_null group by k8;";
+
+        UtFrameUtils.parseStmtWithNewAnalyzer(CTASSQL3, ctx);
+    }
+
     @Test
     public void testSelectColumn() throws Exception {
         ConnectContext ctx = starRocksAssert.getCtx();


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3273

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The logic of generating column names before CTAS forcing expressions is not a good design, and it may be inconvenient for data governance.