### PR TITLE
Fe abides by Be on decimal overflow checking

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/DecimalLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/DecimalLiteral.java
@@ -39,6 +39,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.math.RoundingMode;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -384,12 +385,14 @@ public class DecimalLiteral extends LiteralExpr {
     public static void checkLiteralOverflow(BigDecimal value, ScalarType scalarType) throws AnalysisException {
         int realPrecision = getRealPrecision(value);
         int realScale = getRealScale(value);
-        int realIntegerPartWidth = realPrecision - realScale;
-        int precision = scalarType.getScalarPrecision();
-        int scale = scalarType.getScalarScale();
-        int maxIntegerPartWidth = precision - scale;
-        // integer part of decimal literal should not exceed precision - scale
-        if (realIntegerPartWidth > maxIntegerPartWidth) {
+        BigInteger underlyingInt = value.setScale(scalarType.getScalarScale(), RoundingMode.HALF_UP).unscaledValue();
+        int numBytes = scalarType.getPrimitiveType().getTypeSize();
+        // In BE, Overflow checking uses maximum/minimum binary values instead of maximum/minimum decimal values.
+        // for instance: if PrimitiveType is decimal32, then 2147483647/-2147483648 is used instead of
+        // 999999999/-999999999.
+        BigInteger maxBinary = BigInteger.ONE.shiftLeft(numBytes * 8 - 1).subtract(BigInteger.ONE);
+        BigInteger minBinary = BigInteger.ONE.shiftLeft(numBytes * 8 - 1).negate();
+        if (underlyingInt.compareTo(minBinary) < 0 || underlyingInt.compareTo(maxBinary) > 0) {
             String errMsg = String.format(
                     "Typed decimal literal(%s) is overflow, value='%s' (precision=%d, scale=%d)",
                     scalarType.toString(), value.toPlainString(), realPrecision, realScale);

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/DecimalLiteralTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/DecimalLiteralTest.java
@@ -230,7 +230,116 @@ public class DecimalLiteralTest {
     @Test(expected = Throwable.class)
     public void testDealWithSingularDecimalLiteralAbnormal3() throws AnalysisException {
         Type type = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 9, 2);
-        DecimalLiteral decimalLiteral = new DecimalLiteral("1234567890.1235");
+        DecimalLiteral decimalLiteral = new DecimalLiteral("92233720368547758.08");
         decimalLiteral.uncheckedCastTo(type);
+    }
+
+    @Test
+    public void testCheckLiteralOverflowFail() throws AnalysisException {
+        BigDecimal decimal32Values[] = {
+                new BigDecimal("2147483.6476"),
+                new BigDecimal("-2147483.6489"),
+                new BigDecimal("2147483.648"),
+                new BigDecimal("-2147483.649"),
+        };
+        ScalarType decimal32p4s3 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 4, 3);
+        for (BigDecimal dec32 : decimal32Values) {
+            try {
+                DecimalLiteral.checkLiteralOverflow(dec32, decimal32p4s3);
+                Assert.fail("should throw exception");
+            } catch (Exception ignored){}
+        }
+
+        BigDecimal decimal64Values[] = {
+                new BigDecimal("9223372036854.775808"),
+                new BigDecimal("9223372036854.7758085"),
+                new BigDecimal("-9223372036854.775809"),
+                new BigDecimal("-9223372036854.7758086"),
+        };
+        ScalarType decimal64p10s6 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, 6);
+        for (BigDecimal dec64 : decimal64Values) {
+            try {
+                DecimalLiteral.checkLiteralOverflow(dec64, decimal64p10s6);
+                Assert.fail("should throw exception");
+            }catch (Exception ignored) { }
+        }
+
+        BigDecimal decimal128Values[] = {
+                new BigDecimal("1701411834604692317316873037.15884105728"),
+                new BigDecimal("1701411834604692317316873037.158841057285"),
+                new BigDecimal("-1701411834604692317316873037.15884105729"),
+                new BigDecimal("-1701411834604692317316873037.158841057286"),
+        };
+        ScalarType decimal128p36s11 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 36, 11);
+        for (BigDecimal dec128 : decimal128Values) {
+            try {
+                DecimalLiteral.checkLiteralOverflow(dec128, decimal128p36s11);
+                Assert.fail("should throw exception");
+            }catch (Exception ignored) { }
+        }
+    }
+
+    @Test
+    public void testCheckLiteralOverflowSuccess() throws AnalysisException {
+        BigDecimal decimal32Values[] = {
+                new BigDecimal("2147483.647"),
+                new BigDecimal("2147483.6474"),
+                new BigDecimal("2147483.6465"),
+                new BigDecimal("2147483.0001"),
+                new BigDecimal("0.0001"),
+                new BigDecimal("0.0"),
+                new BigDecimal("-2147483.648"),
+                new BigDecimal("-2147483.6484"),
+                new BigDecimal("-2147483.6475"),
+                new BigDecimal("-0.0001"),
+        };
+        ScalarType decimal32p4s3 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 4, 3);
+        for (BigDecimal dec32 : decimal32Values) {
+            try {
+                DecimalLiteral.checkLiteralOverflow(dec32, decimal32p4s3);
+            }catch (Exception ignored) {
+                Assert.fail("should not throw exception");
+            }
+        }
+
+        BigDecimal decimal64Values[] = {
+                new BigDecimal("9223372036854.775807"),
+                new BigDecimal("9223372036854.7758074"),
+                new BigDecimal("9223372036854.7758065"),
+                new BigDecimal("-9223372036854.775808"),
+                new BigDecimal("-9223372036854.7758084"),
+                new BigDecimal("-9223372036854.7758079"),
+                new BigDecimal("-0.000001"),
+                new BigDecimal("0.000001"),
+                new BigDecimal("0.0"),
+        };
+        ScalarType decimal64p10s6 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, 6);
+        for (BigDecimal dec64 : decimal64Values) {
+            try {
+                DecimalLiteral.checkLiteralOverflow(dec64, decimal64p10s6);
+            }catch (Exception ignored) {
+                Assert.fail("should not throw exception");
+            }
+        }
+
+        BigDecimal decimal128Values[] = {
+                new BigDecimal("1701411834604692317316873037.15884105727"),
+                new BigDecimal("1701411834604692317316873037.158841057274"),
+                new BigDecimal("1701411834604692317316873037.158841057265"),
+                new BigDecimal("-1701411834604692317316873037.15884105728"),
+                new BigDecimal("-1701411834604692317316873037.158841057284"),
+                new BigDecimal("-1701411834604692317316873037.158841057275"),
+                new BigDecimal("-0.00000000001"),
+                new BigDecimal("0.00000000001"),
+                new BigDecimal("0.0"),
+        };
+        ScalarType decimal128p36s11 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 36, 11);
+        for (BigDecimal dec128 : decimal128Values) {
+            try {
+                DecimalLiteral.checkLiteralOverflow(dec128, decimal128p36s11);
+            }catch (Exception ignored) {
+                Assert.fail("should not throw exception");
+            }
+        }
     }
 }


### PR DESCRIPTION
https://github.com/StarRocks/starrocks/issues/3246

for the purpose of performance, BE adopts binary overflow checking on decimal, for an example:
```
cast(21474836.47 as decimal32(4,2)) 
```
1. when evaluated at BE (binary overflow checking), result is 21474836.47
2. when evaluated at FE (decimal overflow checking), result is NULL.

so rewrite overflow checking logic in FE to make it abide by BE on this point.