### PR TITLE
replace validate ascii fast with not validate utf8

### DIFF
--- a/be/test/exprs/vectorized/string_fn_substr_test.cpp
+++ b/be/test/exprs/vectorized/string_fn_substr_test.cpp
@@ -193,16 +193,16 @@ TEST_F(StringFunctionSubstrTest, substrConstUtf8Test) {
     std::string s;
     s.append("\x7f");
     s.append("\xdf\xbf");
-    s.append("\xef\xbf\xbf");
-    s.append("\xf7\xbf\xbf\xbf");
+    s.append("\xe0\xbf\xbf");
+    s.append("\xf3\xbf\xbf\xbf");
     s.append("\x7f");
     s.append("\xdf\xbf");
-    s.append("\xef\xbf\xbf");
-    s.append("\xf7\xbf\xbf\xbf");
+    s.append("\xe0\xbf\xbf");
+    s.append("\xf3\xbf\xbf\xbf");
     s.append("\x7f");
     s.append("\xdf\xbf");
-    s.append("\xef\xbf\xbf");
-    s.append("\xf7\xbf\xbf\xbf");
+    s.append("\xe0\xbf\xbf");
+    s.append("\xf3\xbf\xbf\xbf");
 
     str->append(s);
     str->append("");
@@ -210,27 +210,27 @@ TEST_F(StringFunctionSubstrTest, substrConstUtf8Test) {
     std::vector<std::tuple<int, int, std::string>> cases = {
             {1, 1, "\x7f"},
             {1, 2, "\x7f\xdf\xbf"},
-            {1, 3, "\x7f\xdf\xbf\xef\xbf\xbf"},
-            {1, 4, "\x7f\xdf\xbf\xef\xbf\xbf\xf7\xbf\xbf\xbf"},
+            {1, 3, "\x7f\xdf\xbf\xe0\xbf\xbf"},
+            {1, 4, "\x7f\xdf\xbf\xe0\xbf\xbf\xf3\xbf\xbf\xbf"},
             {1, 100, s},
             {2, 1, "\xdf\xbf"},
-            {2, 2, "\xdf\xbf\xef\xbf\xbf"},
-            {2, 3, "\xdf\xbf\xef\xbf\xbf\xf7\xbf\xbf\xbf"},
-            {2, 4, "\xdf\xbf\xef\xbf\xbf\xf7\xbf\xbf\xbf\x7f"},
+            {2, 2, "\xdf\xbf\xe0\xbf\xbf"},
+            {2, 3, "\xdf\xbf\xe0\xbf\xbf\xf3\xbf\xbf\xbf"},
+            {2, 4, "\xdf\xbf\xe0\xbf\xbf\xf3\xbf\xbf\xbf\x7f"},
             {2, 100, s.substr(1)},
-            {3, 1, "\xef\xbf\xbf"},
-            {3, 2, "\xef\xbf\xbf\xf7\xbf\xbf\xbf"},
-            {3, 3, "\xef\xbf\xbf\xf7\xbf\xbf\xbf\x7f"},
-            {3, 4, "\xef\xbf\xbf\xf7\xbf\xbf\xbf\x7f\xdf\xbf"},
+            {3, 1, "\xe0\xbf\xbf"},
+            {3, 2, "\xe0\xbf\xbf\xf3\xbf\xbf\xbf"},
+            {3, 3, "\xe0\xbf\xbf\xf3\xbf\xbf\xbf\x7f"},
+            {3, 4, "\xe0\xbf\xbf\xf3\xbf\xbf\xbf\x7f\xdf\xbf"},
             {3, 100, s.substr(3)},
-            {4, 2, "\xf7\xbf\xbf\xbf\x7f"},
-            {4, 3, "\xf7\xbf\xbf\xbf\x7f\xdf\xbf"},
-            {4, 4, "\xf7\xbf\xbf\xbf\x7f\xdf\xbf\xef\xbf\xbf"},
+            {4, 2, "\xf3\xbf\xbf\xbf\x7f"},
+            {4, 3, "\xf3\xbf\xbf\xbf\x7f\xdf\xbf"},
+            {4, 4, "\xf3\xbf\xbf\xbf\x7f\xdf\xbf\xe0\xbf\xbf"},
             {4, 100, s.substr(6)},
             {5, 1, "\x7f"},
             {5, 2, "\x7f\xdf\xbf"},
-            {5, 3, "\x7f\xdf\xbf\xef\xbf\xbf"},
-            {5, 4, "\x7f\xdf\xbf\xef\xbf\xbf\xf7\xbf\xbf\xbf"},
+            {5, 3, "\x7f\xdf\xbf\xe0\xbf\xbf"},
+            {5, 4, "\x7f\xdf\xbf\xe0\xbf\xbf\xf3\xbf\xbf\xbf"},
             {5, 100, s.substr(10)},
             {-12, 2, s.substr(0, 3)},
             {-11, 3, s.substr(1, 9)},

--- a/be/test/exprs/vectorized/string_fn_test.cpp
+++ b/be/test/exprs/vectorized/string_fn_test.cpp
@@ -194,16 +194,16 @@ PARALLEL_TEST(VecStringFunctionsTest, substrConstUtf8Test) {
     std::string s;
     s.append("\x7f");
     s.append("\xdf\xbf");
-    s.append("\xef\xbf\xbf");
-    s.append("\xf7\xbf\xbf\xbf");
+    s.append("\xe0\xbf\xbf");
+    s.append("\xf3\xbf\xbf\xbf");
     s.append("\x7f");
     s.append("\xdf\xbf");
-    s.append("\xef\xbf\xbf");
-    s.append("\xf7\xbf\xbf\xbf");
+    s.append("\xe0\xbf\xbf");
+    s.append("\xf3\xbf\xbf\xbf");
     s.append("\x7f");
     s.append("\xdf\xbf");
-    s.append("\xef\xbf\xbf");
-    s.append("\xf7\xbf\xbf\xbf");
+    s.append("\xe0\xbf\xbf");
+    s.append("\xf3\xbf\xbf\xbf");
 
     str->append(s);
     str->append("");
@@ -211,27 +211,27 @@ PARALLEL_TEST(VecStringFunctionsTest, substrConstUtf8Test) {
     std::vector<std::tuple<int, int, std::string>> cases = {
             {1, 1, "\x7f"},
             {1, 2, "\x7f\xdf\xbf"},
-            {1, 3, "\x7f\xdf\xbf\xef\xbf\xbf"},
-            {1, 4, "\x7f\xdf\xbf\xef\xbf\xbf\xf7\xbf\xbf\xbf"},
+            {1, 3, "\x7f\xdf\xbf\xe0\xbf\xbf"},
+            {1, 4, "\x7f\xdf\xbf\xe0\xbf\xbf\xf3\xbf\xbf\xbf"},
             {1, 100, s},
             {2, 1, "\xdf\xbf"},
-            {2, 2, "\xdf\xbf\xef\xbf\xbf"},
-            {2, 3, "\xdf\xbf\xef\xbf\xbf\xf7\xbf\xbf\xbf"},
-            {2, 4, "\xdf\xbf\xef\xbf\xbf\xf7\xbf\xbf\xbf\x7f"},
+            {2, 2, "\xdf\xbf\xe0\xbf\xbf"},
+            {2, 3, "\xdf\xbf\xe0\xbf\xbf\xf3\xbf\xbf\xbf"},
+            {2, 4, "\xdf\xbf\xe0\xbf\xbf\xf3\xbf\xbf\xbf\x7f"},
             {2, 100, s.substr(1)},
-            {3, 1, "\xef\xbf\xbf"},
-            {3, 2, "\xef\xbf\xbf\xf7\xbf\xbf\xbf"},
-            {3, 3, "\xef\xbf\xbf\xf7\xbf\xbf\xbf\x7f"},
-            {3, 4, "\xef\xbf\xbf\xf7\xbf\xbf\xbf\x7f\xdf\xbf"},
+            {3, 1, "\xe0\xbf\xbf"},
+            {3, 2, "\xe0\xbf\xbf\xf3\xbf\xbf\xbf"},
+            {3, 3, "\xe0\xbf\xbf\xf3\xbf\xbf\xbf\x7f"},
+            {3, 4, "\xe0\xbf\xbf\xf3\xbf\xbf\xbf\x7f\xdf\xbf"},
             {3, 100, s.substr(3)},
-            {4, 2, "\xf7\xbf\xbf\xbf\x7f"},
-            {4, 3, "\xf7\xbf\xbf\xbf\x7f\xdf\xbf"},
-            {4, 4, "\xf7\xbf\xbf\xbf\x7f\xdf\xbf\xef\xbf\xbf"},
+            {4, 2, "\xf3\xbf\xbf\xbf\x7f"},
+            {4, 3, "\xf3\xbf\xbf\xbf\x7f\xdf\xbf"},
+            {4, 4, "\xf3\xbf\xbf\xbf\x7f\xdf\xbf\xe0\xbf\xbf"},
             {4, 100, s.substr(6)},
             {5, 1, "\x7f"},
             {5, 2, "\x7f\xdf\xbf"},
-            {5, 3, "\x7f\xdf\xbf\xef\xbf\xbf"},
-            {5, 4, "\x7f\xdf\xbf\xef\xbf\xbf\xf7\xbf\xbf\xbf"},
+            {5, 3, "\x7f\xdf\xbf\xe0\xbf\xbf"},
+            {5, 4, "\x7f\xdf\xbf\xe0\xbf\xbf\xf3\xbf\xbf\xbf"},
             {5, 100, s.substr(10)},
             {-12, 2, s.substr(0, 3)},
             {-11, 3, s.substr(1, 9)},


### PR DESCRIPTION
https://github.com/StarRocks/starrocks/issues/3248

Builtin functions aes_encrypt, st_circle and etc. generates  binary column, which is neither ascii string nor utf8 string. when validate_ascii_fast applying to a string return false, the string may be a illegal utf8 string that cannot be handled by string function in a utf8 way. so use !validate_utf8 instead of validate_ascii_fast, a binary string contains illegal utf8 chars can be handled as ascii   string.