### PR TITLE
optimize string type args in thread pool

### DIFF
--- a/be/src/util/priority_thread_pool.hpp
+++ b/be/src/util/priority_thread_pool.hpp
@@ -59,8 +59,8 @@ public:
     //     queue exceeds this size, subsequent calls to Offer will block until there is
     //     capacity available.
     //  -- work_function: the function to run every time an item is consumed from the queue
-    PriorityThreadPool(const std::string& name, uint32_t num_threads, uint32_t queue_size)
-            : _name(name), _work_queue(queue_size), _shutdown(false) {
+    PriorityThreadPool(std::string name, uint32_t num_threads, uint32_t queue_size)
+            : _name(std::move(name)), _work_queue(queue_size), _shutdown(false) {
         for (int i = 0; i < num_threads; ++i) {
             new_thread(++_current_thread_id);
         }

--- a/be/src/util/priority_thread_pool.hpp
+++ b/be/src/util/priority_thread_pool.hpp
@@ -59,7 +59,7 @@ public:
     //     queue exceeds this size, subsequent calls to Offer will block until there is
     //     capacity available.
     //  -- work_function: the function to run every time an item is consumed from the queue
-    PriorityThreadPool(const std::string name, uint32_t num_threads, uint32_t queue_size)
+    PriorityThreadPool(const std::string& name, uint32_t num_threads, uint32_t queue_size)
             : _name(name), _work_queue(queue_size), _shutdown(false) {
         for (int i = 0; i < num_threads; ++i) {
             new_thread(++_current_thread_id);

--- a/be/src/util/thread.cpp
+++ b/be/src/util/thread.cpp
@@ -215,14 +215,14 @@ int64_t Thread::current_thread_id() {
     return syscall(SYS_gettid);
 }
 
-void Thread::set_thread_name(pthread_t t, const std::string name) {
+void Thread::set_thread_name(pthread_t t, const std::string& name) {
     int ret = pthread_setname_np(t, name.data());
     if (ret) {
         LOG(WARNING) << "failed to set thread name: " << name;
     }
 }
 
-void Thread::set_thread_name(std::thread& t, const std::string name) {
+void Thread::set_thread_name(std::thread& t, const std::string& name) {
     Thread::set_thread_name(t.native_handle(), name);
 }
 

--- a/be/src/util/thread.cpp
+++ b/be/src/util/thread.cpp
@@ -215,15 +215,15 @@ int64_t Thread::current_thread_id() {
     return syscall(SYS_gettid);
 }
 
-void Thread::set_thread_name(pthread_t t, const std::string& name) {
+void Thread::set_thread_name(pthread_t t, const std::string name) {
     int ret = pthread_setname_np(t, name.data());
     if (ret) {
         LOG(WARNING) << "failed to set thread name: " << name;
     }
 }
 
-void Thread::set_thread_name(std::thread& t, const std::string& name) {
-    Thread::set_thread_name(t.native_handle(), name);
+void Thread::set_thread_name(std::thread& t, std::string name) {
+    Thread::set_thread_name(t.native_handle(), std::move(name));
 }
 
 int64_t Thread::wait_for_tid() const {

--- a/be/src/util/thread.h
+++ b/be/src/util/thread.h
@@ -136,7 +136,7 @@ public:
 
     // Set name for thread
     // name's size should be less than 16, otherwise it will be truncated
-    static void set_thread_name(pthread_t t, const std::strings& name);
+    static void set_thread_name(pthread_t t, const std::string& name);
     static void set_thread_name(std::thread& t, const std::string& name);
 
 private:

--- a/be/src/util/thread.h
+++ b/be/src/util/thread.h
@@ -136,8 +136,8 @@ public:
 
     // Set name for thread
     // name's size should be less than 16, otherwise it will be truncated
-    static void set_thread_name(pthread_t t, const std::string& name);
-    static void set_thread_name(std::thread& t, const std::string& name);
+    static void set_thread_name(pthread_t t, const std::string name);
+    static void set_thread_name(std::thread& t, std::string name);
 
 private:
     friend class ThreadJoiner;

--- a/be/src/util/thread.h
+++ b/be/src/util/thread.h
@@ -136,8 +136,8 @@ public:
 
     // Set name for thread
     // name's size should be less than 16, otherwise it will be truncated
-    static void set_thread_name(pthread_t t, const std::string name);
-    static void set_thread_name(std::thread& t, const std::string name);
+    static void set_thread_name(pthread_t t, const std::strings& name);
+    static void set_thread_name(std::thread& t, const std::string& name);
 
 private:
     friend class ThreadJoiner;


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [X] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3370

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Now some string type args in thread related api are passed by value, which is not that efficient. It is optimized by using value + std::move.