### PR TITLE
Fix the bug of bitmap index

### DIFF
--- a/be/src/storage/rowset/index_page.cpp
+++ b/be/src/storage/rowset/index_page.cpp
@@ -87,6 +87,7 @@ Status IndexPageReader::parse(const Slice& body, const IndexPageFooterPB& footer
 }
 ///////////////////////////////////////////////////////////////////////////////
 
+// This function has the meaning of interval, in fact, it is to find first possible Page which <=search key
 Status IndexPageIterator::seek_at_or_before(const Slice& search_key) {
     int32_t left = 0;
     int32_t right = _reader->count() - 1;
@@ -113,6 +114,7 @@ Status IndexPageIterator::seek_at_or_before(const Slice& search_key) {
     return Status::OK();
 }
 
+// This function has the meaning of interval, in fact, it is to find first possible Page which >=search key
 Status IndexPageIterator::seek_at_or_after(const Slice& search_key) {
     size_t num_entries = _reader->count();
     DCHECK_GT(num_entries, 0);

--- a/be/src/storage/rowset/index_page.cpp
+++ b/be/src/storage/rowset/index_page.cpp
@@ -115,11 +115,12 @@ Status IndexPageIterator::seek_at_or_before(const Slice& search_key) {
 
 Status IndexPageIterator::seek_at_or_after(const Slice& search_key) {
     size_t num_entries = _reader->count();
+    DCHECK_GT(num_entries, 0);
+
     int32_t left = 0;
     int32_t right = num_entries - 1;
-    int32_t mid = 0;
     while (left <= right) {
-        mid = (right + left) / 2;
+        int32_t mid = (right + left) / 2;
         int cmp = search_key.compare(_reader->get_key(mid));
         if (cmp > 0) {
             left = mid + 1;
@@ -134,7 +135,11 @@ Status IndexPageIterator::seek_at_or_after(const Slice& search_key) {
     // index entry records the first key of the indexed page,
     // so can't use left as the final result
     // TODO: add page index entry for the end key of last page
-    _pos = mid;
+    if (right < 0) {
+        _pos = 0;
+    } else {
+        _pos = right;
+    }
     return Status::OK();
 }
 

--- a/be/src/storage/rowset/index_page.cpp
+++ b/be/src/storage/rowset/index_page.cpp
@@ -105,6 +105,7 @@ Status IndexPageIterator::seek_at_or_after(const Slice& search_key) {
     const auto& keys = _reader->get_keys();
     auto iter = std::upper_bound(keys.begin(), keys.end(), search_key);
     if (iter == keys.begin()) {
+        // all the key is larger then search key, so shoud the first entry
         _pos = 0;
     } else {
         // upper_bound is search the first key > search key, so should return last entry

--- a/be/src/storage/rowset/index_page.cpp
+++ b/be/src/storage/rowset/index_page.cpp
@@ -94,6 +94,7 @@ Status IndexPageIterator::seek_at_or_before(const Slice& search_key) {
     if (iter == keys.begin()) {
         return Status::NotFound("no page contains the given key");
     } else {
+        // upper_bound is search the first key > search key, so should return last entry
         _pos = iter - keys.begin() - 1;
         return Status::OK();
     }
@@ -106,6 +107,7 @@ Status IndexPageIterator::seek_at_or_after(const Slice& search_key) {
     if (iter == keys.begin()) {
         _pos = 0;
     } else {
+        // upper_bound is search the first key > search key, so should return last entry
         _pos = iter - keys.begin() - 1;
     }
     return Status::OK();

--- a/be/src/storage/rowset/index_page.h
+++ b/be/src/storage/rowset/index_page.h
@@ -135,9 +135,13 @@ public:
     // Find the largest index entry whose key is <= search_key.
     // Return OK status when such entry exists.
     // Return NotFound when no such entry is found (all keys > search_key).
-    // Return other error status otherwise.
+    // Index entry is the start key of page
+    // All the key in page is unique
     Status seek_at_or_before(const Slice& search_key);
 
+    // Find the smallest index entry whose key is >= search_key.
+    // Index entry is the start key of page
+    // All the key in page is unique
     Status seek_at_or_after(const Slice& search_key);
 
     // Move to the next index entry.

--- a/be/src/storage/rowset/index_page.h
+++ b/be/src/storage/rowset/index_page.h
@@ -154,6 +154,7 @@ public:
 
 private:
     const IndexPageReader* _reader;
+    void _seek(const Slice& search_key);
 
     size_t _pos;
 };

--- a/be/src/storage/rowset/index_page.h
+++ b/be/src/storage/rowset/index_page.h
@@ -118,6 +118,8 @@ public:
         return size;
     }
 
+    const std::vector<Slice>& get_keys() const { return _keys; }
+
 private:
     bool _parsed{false};
 
@@ -128,7 +130,7 @@ private:
 
 class IndexPageIterator {
 public:
-    explicit IndexPageIterator(const IndexPageReader* reader) : _reader(reader), _pos(0) {}
+    explicit IndexPageIterator(const IndexPageReader* reader) : _reader(reader) {}
 
     // Find the largest index entry whose key is <= search_key.
     // Return OK status when such entry exists.
@@ -154,9 +156,8 @@ public:
 
 private:
     const IndexPageReader* _reader;
-    void _seek(const Slice& search_key);
 
-    size_t _pos;
+    size_t _pos = 0;
 };
 
 } // namespace starrocks

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -148,6 +148,7 @@ set(EXEC_FILES
         ./storage/rowset/segment_iterator_test.cpp
         ./storage/rowset/zone_map_index_test.cpp
         ./storage/rowset/unique_rowset_id_generator_test.cpp
+        ./storage/rowset/index_page_test.cpp
         ./storage/selection_vector_test.cpp
         ./storage/snapshot_meta_test.cpp
         ./storage/short_key_index_test.cpp

--- a/be/test/storage/rowset/index_page_test.cpp
+++ b/be/test/storage/rowset/index_page_test.cpp
@@ -8,6 +8,62 @@ namespace starrocks {
 
 class IndexPageTest : public testing::Test {};
 
+TEST_F(IndexPageTest, test_seek_at_or_before) {
+    // one item
+    IndexPageReader reader1;
+    reader1._parsed = true;
+    reader1._keys = {"111"};
+    reader1._footer.set_num_entries(1);
+    std::vector<Slice> keys1 = {"000", "111", "222"};
+    std::vector<int> pos1 = {-1, 0, 0};
+    IndexPageIterator iter1(&reader1);
+
+    for (size_t i = 0; i < keys1.size(); i++) {
+        if (pos1[i] == -1) {
+            ASSERT_TRUE(!iter1.seek_at_or_before(keys1[i]).ok());
+        } else {
+            ASSERT_TRUE(iter1.seek_at_or_before(keys1[i]).ok());
+            ASSERT_EQ(iter1._pos, pos1[i]);
+        }
+    }
+
+    // two item
+    IndexPageReader reader2;
+    reader2._parsed = true;
+    reader2._keys = {"111", "333"};
+    reader2._footer.set_num_entries(2);
+    std::vector<Slice> keys2 = {"000", "111", "222", "333", "444"};
+    std::vector<int> pos2 = {-1, 0, 0, 1, 1};
+    IndexPageIterator iter2(&reader2);
+
+    for (size_t i = 0; i < keys2.size(); i++) {
+        if (pos2[i] == -1) {
+            ASSERT_TRUE(!iter2.seek_at_or_before(keys2[i]).ok());
+        } else {
+            ASSERT_TRUE(iter2.seek_at_or_before(keys2[i]).ok());
+            ASSERT_EQ(iter2._pos, pos2[i]);
+        }
+    }
+
+    // three item
+    IndexPageReader reader3;
+    reader3._parsed = true;
+    reader3._keys = {"111", "333", "555"};
+    reader3._footer.set_num_entries(3);
+    std::vector<Slice> keys3 = {"000", "111", "222", "333", "444", "555", "666"};
+    std::vector<int> pos3 = {-1, 0, 0, 1, 1, 2, 2};
+    IndexPageIterator iter3(&reader3);
+
+    for (size_t i = 0; i < keys3.size(); i++) {
+        if (pos3[i] == -1) {
+            ASSERT_TRUE(!iter3.seek_at_or_before(keys3[i]).ok());
+        } else {
+            ASSERT_TRUE(iter3.seek_at_or_before(keys3[i]).ok());
+            ASSERT_EQ(iter3._pos, pos3[i]);
+        }
+    }
+}
+
 TEST_F(IndexPageTest, test_seek_at_or_after) {
     // one item
     IndexPageReader reader1;
@@ -15,7 +71,7 @@ TEST_F(IndexPageTest, test_seek_at_or_after) {
     reader1._keys = {"111"};
     reader1._footer.set_num_entries(1);
     std::vector<Slice> keys1 = {"000", "111", "222"};
-    std::vector<size_t> pos1 = {0, 0, 0};
+    std::vector<int> pos1 = {0, 0, 0};
     IndexPageIterator iter1(&reader1);
 
     for (size_t i = 0; i < keys1.size(); i++) {
@@ -29,7 +85,7 @@ TEST_F(IndexPageTest, test_seek_at_or_after) {
     reader2._keys = {"111", "333"};
     reader2._footer.set_num_entries(2);
     std::vector<Slice> keys2 = {"000", "111", "222", "333", "444"};
-    std::vector<size_t> pos2 = {0, 0, 0, 1, 1};
+    std::vector<int> pos2 = {0, 0, 0, 1, 1};
     IndexPageIterator iter2(&reader2);
 
     for (size_t i = 0; i < keys2.size(); i++) {
@@ -43,7 +99,7 @@ TEST_F(IndexPageTest, test_seek_at_or_after) {
     reader3._keys = {"111", "333", "555"};
     reader3._footer.set_num_entries(3);
     std::vector<Slice> keys3 = {"000", "111", "222", "333", "444", "555", "666"};
-    std::vector<size_t> pos3 = {0, 0, 0, 1, 1, 2, 2};
+    std::vector<int> pos3 = {0, 0, 0, 1, 1, 2, 2};
     IndexPageIterator iter3(&reader3);
 
     for (size_t i = 0; i < keys3.size(); i++) {

--- a/be/test/storage/rowset/index_page_test.cpp
+++ b/be/test/storage/rowset/index_page_test.cpp
@@ -1,0 +1,55 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#include "storage/rowset/index_page.h"
+
+#include <gtest/gtest.h>
+
+namespace starrocks {
+
+class IndexPageTest : public testing::Test {};
+
+TEST_F(IndexPageTest, test_seek_at_or_after) {
+    // one item
+    IndexPageReader reader1;
+    reader1._parsed = true;
+    reader1._keys = {"111"};
+    reader1._footer.set_num_entries(1);
+    std::vector<Slice> keys1 = {"000", "111", "222"};
+    std::vector<size_t> pos1 = {0, 0, 0};
+    IndexPageIterator iter1(&reader1);
+
+    for (size_t i = 0; i < keys1.size(); i++) {
+        ASSERT_TRUE(iter1.seek_at_or_after(keys1[i]).ok());
+        ASSERT_EQ(iter1._pos, pos1[i]);
+    }
+
+    // two item
+    IndexPageReader reader2;
+    reader2._parsed = true;
+    reader2._keys = {"111", "333"};
+    reader2._footer.set_num_entries(2);
+    std::vector<Slice> keys2 = {"000", "111", "222", "333", "444"};
+    std::vector<size_t> pos2 = {0, 0, 0, 1, 1};
+    IndexPageIterator iter2(&reader2);
+
+    for (size_t i = 0; i < keys2.size(); i++) {
+        ASSERT_TRUE(iter2.seek_at_or_after(keys2[i]).ok());
+        ASSERT_EQ(iter2._pos, pos2[i]);
+    }
+
+    // three item
+    IndexPageReader reader3;
+    reader3._parsed = true;
+    reader3._keys = {"111", "333", "555"};
+    reader3._footer.set_num_entries(3);
+    std::vector<Slice> keys3 = {"000", "111", "222", "333", "444", "555", "666"};
+    std::vector<size_t> pos3 = {0, 0, 0, 1, 1, 2, 2};
+    IndexPageIterator iter3(&reader3);
+
+    for (size_t i = 0; i < keys3.size(); i++) {
+        ASSERT_TRUE(iter3.seek_at_or_after(keys3[i]).ok());
+        ASSERT_EQ(iter3._pos, pos3[i]);
+    }
+}
+
+} // namespace starrocks


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3299 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

index key  is the first key of page

old wrong algorithm

keys: 1, 3
search_key:2
the resutl pos will be: 1
the correct pos should be: 0
