### PR TITLE
Fix cross join on-predicate bugs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownJoinOnClauseRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownJoinOnClauseRule.java
@@ -27,7 +27,7 @@ public class PushDownJoinOnClauseRule extends TransformationRule {
     public boolean check(final OptExpression input, OptimizerContext context) {
         LogicalJoinOperator joinOperator = (LogicalJoinOperator) input.getOp();
 
-        if (joinOperator.getJoinType().isCrossJoin() || joinOperator.isHasPushDownJoinOnClause()) {
+        if (joinOperator.isHasPushDownJoinOnClause()) {
             return false;
         }
         return joinOperator.getOnPredicate() != null;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownLimitJoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownLimitJoinRule.java
@@ -44,6 +44,14 @@ public class PushDownLimitJoinRule extends TransformationRule {
             return Lists.newArrayList(child);
         }
 
+        if (joinType.isSemiAntiJoin()) {
+            return Lists.newArrayList(child);
+        } else if (joinType.isInnerJoin() && join.getOnPredicate() != null) {
+            return Lists.newArrayList(child);
+        } else if (joinType.isCrossJoin() && join.getOnPredicate() != null) {
+            return Lists.newArrayList(child);
+        }
+
         // Cross-Join || Full-Outer-Join
         int[] pushDownChildIdx = {0, 1};
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownLimitJoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownLimitJoinRule.java
@@ -40,10 +40,6 @@ public class PushDownLimitJoinRule extends TransformationRule {
         // set limit
         join.setLimit(limit.getLimit());
 
-        if (joinType.isInnerJoin() || joinType.isSemiAntiJoin()) {
-            return Lists.newArrayList(child);
-        }
-
         if (joinType.isSemiAntiJoin()) {
             return Lists.newArrayList(child);
         } else if (joinType.isInnerJoin() && join.getOnPredicate() != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -250,7 +250,7 @@ public class PlanFragmentBuilder {
             }
         }
 
-        private void setUnUsedOutputColumns(PhysicalOlapScanOperator node, OlapScanNode scanNode, 
+        private void setUnUsedOutputColumns(PhysicalOlapScanOperator node, OlapScanNode scanNode,
                                             List<ScalarOperator> predicates) {
             if (ConnectContext.get().getSessionVariable().isAbleFilterUnusedColumnsInScanStage()) {
                 List<ColumnRefOperator> outputColumns = node.getOutputColumns();
@@ -1414,12 +1414,12 @@ public class PlanFragmentBuilder {
                 joinNode.setLimit(node.getLimit());
                 joinNode.computeStatistics(optExpr.getStatistics());
                 List<Expr> conjuncts = Utils.extractConjuncts(node.getPredicate()).stream()
-                        .map(e -> ScalarOperatorToExpr.buildExecExpression(node.getPredicate(),
+                        .map(e -> ScalarOperatorToExpr.buildExecExpression(e,
                                 new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
                         .collect(Collectors.toList());
                 joinNode.addConjuncts(conjuncts);
                 List<Expr> onConjuncts = Utils.extractConjuncts(node.getOnPredicate()).stream()
-                        .map(e -> ScalarOperatorToExpr.buildExecExpression(node.getOnPredicate(),
+                        .map(e -> ScalarOperatorToExpr.buildExecExpression(e,
                                 new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
                         .collect(Collectors.toList());
                 joinNode.addConjuncts(onConjuncts);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2606

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

There contains three bugs：

1. on-predicate of cross join will repeat add in PlanFragementBuilder, like:
```
select * from t1 cross join t2 on t1.v1 != t2.v2 and t1.v2 != t2.v2
```

will produce plan:
```
|   2:CROSS JOIN                                                                                |
|   |  cross join:                                                                              |
|   |  predicates: (1: v1 != 4: v1) AND (2: v2 != 5: v2), (1: v1 != 4: v1) AND (2: v2 != 5: v2)
```

2. cross join with on-predicate can't transform to inner join, like
```
select * from t1 cross join t2 on t1.v1 = t2.v2
```

the plan:
```
|   2:CROSS JOIN                                                                                |
|   |  cross join:                                                                              |
|   |  predicates: 1: v1 = 4: v1
```

3. cross join with on-predicate will push down limit, will return error result