### PR TITLE
Fix wrong plain encoder of boolean column for parquet

### DIFF
--- a/be/src/exec/parquet/encoding_plain.h
+++ b/be/src/exec/parquet/encoding_plain.h
@@ -252,6 +252,8 @@ private:
         _decoded_values_offset = 0;
     }
 
+    // BatchedBitReader::unpack_batch may drop trailing bits, for safety, we should decode 32*n value a batch
+    // and buffer it.
     std::size_t unpack_batch(std::size_t num_values, uint8_t* v) {
         // if _decoded_values has remaining unread values, read it first
         auto read_count = read_decoded_values(num_values, v);

--- a/be/src/exec/parquet/encoding_plain.h
+++ b/be/src/exec/parquet/encoding_plain.h
@@ -6,11 +6,14 @@
 #include "common/status.h"
 #include "exec/parquet/encoding.h"
 #include "gutil/strings/substitute.h"
+#include "util/bit_stream_utils.h"
 #include "util/coding.h"
 #include "util/faststring.h"
 #include "util/slice.h"
 
 namespace starrocks::parquet {
+
+static constexpr int kBooleanBitPackedBitWidth = 1;
 
 template <typename T>
 class PlainEncoder final : public Encoder {
@@ -51,6 +54,30 @@ public:
 
 private:
     faststring _buffer;
+};
+
+template <>
+class PlainEncoder<bool> final : public Encoder {
+public:
+    PlainEncoder() : _bit_writer(&_buffer) {}
+    ~PlainEncoder() override = default;
+
+    Status append(const uint8_t* vals, size_t count) override {
+        // TODO(@DorianZheng) Plain boolean encoder is using by UT currently, optimize it in the future.
+        for (int i = 0; i < count; i++) {
+            _bit_writer.PutValue(vals[i], kBooleanBitPackedBitWidth);
+        }
+        return Status::OK();
+    }
+
+    Slice build() override {
+        _bit_writer.Flush();
+        return {_buffer.data(), _buffer.size()};
+    }
+
+private:
+    faststring _buffer;
+    BitWriter _bit_writer;
 };
 
 template <typename T>
@@ -162,6 +189,91 @@ public:
 private:
     Slice _data;
     size_t _offset = 0;
+};
+
+// plain encoding for boolean type is stored as `Bit Packed`, `LSB` first format
+// more details refer to: https://github.com/apache/parquet-format/blob/master/Encodings.md#PLAIN
+template <>
+class PlainDecoder<bool> final : public Decoder {
+public:
+    PlainDecoder() = default;
+    ~PlainDecoder() override = default;
+
+    Status set_data(const Slice& data) override {
+        _batched_bit_reader.reset(reinterpret_cast<const uint8_t*>(data.data), data.size);
+        return Status::OK();
+    }
+
+    Status next_batch(size_t count, ColumnContentType content_type, vectorized::Column* dst) override {
+        dst->resize(count);
+        auto num_unpacked_values = unpack_batch(count, dst->mutable_raw_data());
+        if (num_unpacked_values < count) {
+            return Status::InternalError(strings::Substitute(
+                    "going to read out-of-bounds data, count=$1,num_unpacked_values=$2", count, num_unpacked_values));
+        }
+        return Status::OK();
+    }
+
+    Status next_batch(size_t count, uint8_t* dst) override {
+        auto num_unpacked_values = unpack_batch(count, dst);
+        if (num_unpacked_values < count) {
+            return Status::InternalError(strings::Substitute(
+                    "going to read out-of-bounds data, count=$1,num_unpacked_values=$2", count, num_unpacked_values));
+        }
+        return Status::OK();
+    }
+
+private:
+    static const int kBitPackedBatchSize = 32;
+    static const int kBitPackedDefaultValue = 8;
+
+    BatchedBitReader _batched_bit_reader;
+
+    std::unique_ptr<uint8_t[]> _decoded_values;
+    int _decoded_values_size;
+    int _decoded_values_offset;
+
+    std::size_t read_decoded_values(std::size_t num_values, uint8_t* v) {
+        if (_decoded_values && _decoded_values_offset < _decoded_values_size) {
+            auto read_count = std::min(static_cast<int>(num_values), _decoded_values_size - _decoded_values_offset);
+            memcpy(v, &_decoded_values[_decoded_values_offset], read_count * sizeof(uint8_t));
+            _decoded_values_offset += read_count;
+            return read_count;
+        } else {
+            return 0;
+        }
+    }
+
+    void unpack_round_up_num_values(int bit_width, std::size_t num_values) {
+        auto round_up_num_values = BitUtil::round_up_numi32(num_values);
+        _decoded_values = std::make_unique<uint8_t[]>(round_up_num_values);
+        _decoded_values_size = _batched_bit_reader.unpack_batch(bit_width, static_cast<int>(round_up_num_values),
+                                                                _decoded_values.get());
+        _decoded_values_offset = 0;
+    }
+
+    std::size_t unpack_batch(std::size_t num_values, uint8_t* v) {
+        // if _decoded_values has remaining unread values, read it first
+        auto read_count = read_decoded_values(num_values, v);
+        if (read_count == num_values) {
+            return num_values;
+        }
+        num_values -= read_count;
+
+        // If 'num_values' is a multiple of 32 or 'bit_width' * 'num_values' must be a multiple of 8.
+        // We will not drop any trailing bits.
+        if (num_values % kBitPackedBatchSize == 0 ||
+            num_values * kBooleanBitPackedBitWidth % kBitPackedDefaultValue == 0) {
+            read_count += _batched_bit_reader.unpack_batch(kBooleanBitPackedBitWidth,
+                                                                 static_cast<int>(num_values), v + read_count);
+        } else {
+            // Else, read round up number to 32 of values and buffer it
+            unpack_round_up_num_values(kBooleanBitPackedBitWidth, num_values);
+            read_count += read_decoded_values(num_values, v + read_count);
+        }
+
+        return read_count;
+    }
 };
 
 // Fixed length byte array encoder and decoder

--- a/be/src/exec/parquet/encoding_plain.h
+++ b/be/src/exec/parquet/encoding_plain.h
@@ -205,8 +205,9 @@ public:
     }
 
     Status next_batch(size_t count, ColumnContentType content_type, vectorized::Column* dst) override {
-        dst->resize(count);
-        auto num_unpacked_values = unpack_batch(count, dst->mutable_raw_data());
+        auto original_size = dst->size();
+        dst->resize(original_size + count);
+        auto num_unpacked_values = unpack_batch(count, dst->mutable_raw_data() + original_size);
         if (num_unpacked_values < count) {
             return Status::InternalError(strings::Substitute(
                     "going to read out-of-bounds data, count=$0,num_unpacked_values=$1", count, num_unpacked_values));

--- a/be/src/exec/parquet/encoding_plain.h
+++ b/be/src/exec/parquet/encoding_plain.h
@@ -245,7 +245,7 @@ private:
     }
 
     void unpack_round_up_num_values(int bit_width, std::size_t num_values) {
-        auto round_up_num_values = BitUtil::round_up_numi32(num_values) * 32;
+        auto round_up_num_values = BitUtil::round_up_numi32(num_values) << 5;
         _decoded_values = std::make_unique<uint8_t[]>(round_up_num_values);
         _decoded_values_size = _batched_bit_reader.unpack_batch(bit_width, static_cast<int>(round_up_num_values),
                                                                 _decoded_values.get());

--- a/be/src/exec/parquet/encoding_plain.h
+++ b/be/src/exec/parquet/encoding_plain.h
@@ -250,8 +250,8 @@ private:
         auto round_up_num_values = BitUtil::round_up_numi32(num_values) << 5;
         if (_decoded_values_buffer == nullptr || _decoded_buffer_size < round_up_num_values) {
             _decoded_values_buffer = std::make_unique<uint8_t[]>(round_up_num_values);
+            _decoded_buffer_size = round_up_num_values;
         }
-        _decoded_buffer_size = round_up_num_values;
         _decoded_values_size = _batched_bit_reader.unpack_batch(bit_width, static_cast<int>(round_up_num_values),
                                                                 _decoded_values_buffer.get());
         _decoded_values_offset = 0;

--- a/be/test/exec/parquet/encoding_test.cpp
+++ b/be/test/exec/parquet/encoding_test.cpp
@@ -354,44 +354,6 @@ TEST_F(ParquetEncodingTest, Boolean) {
 
         DecoderChecker<uint8_t, false>::check(values, encoder->build(), decoder.get());
     }
-
-    const EncodingInfo* dict_encoding = nullptr;
-    EncodingInfo::get(tparquet::Type::BOOLEAN, tparquet::Encoding::RLE_DICTIONARY, &dict_encoding);
-    ASSERT_TRUE(dict_encoding != nullptr);
-    // dict
-    {
-        std::unique_ptr<Decoder> decoder;
-        auto st = dict_encoding->create_decoder(&decoder);
-        ASSERT_TRUE(st.ok());
-
-        std::unique_ptr<Encoder> encoder;
-        st = dict_encoding->create_encoder(&encoder);
-        ASSERT_TRUE(st.ok());
-
-        st = encoder->append(reinterpret_cast<uint8_t*>(&values[0]), 20);
-        ASSERT_TRUE(st.ok());
-
-        // construct dictionary encoder
-        std::unique_ptr<Encoder> dict_encoder;
-        st = plain_encoding->create_encoder(&dict_encoder);
-        ASSERT_TRUE(st.ok());
-
-        size_t num_dicts = 0;
-        st = encoder->encode_dict(dict_encoder.get(), &num_dicts);
-        ASSERT_TRUE(st.ok());
-
-        // construct dictionary decoder
-        std::unique_ptr<Decoder> dict_decoder;
-        st = plain_encoding->create_decoder(&dict_decoder);
-        ASSERT_TRUE(st.ok());
-
-        dict_decoder->set_data(dict_encoder->build());
-
-        st = decoder->set_dict(config::vector_chunk_size, num_dicts, dict_decoder.get());
-        ASSERT_TRUE(st.ok());
-
-        DecoderChecker<uint8_t, true>::check(values, encoder->build(), decoder.get());
-    }
 }
 
 } // namespace starrocks::parquet

--- a/be/test/exec/parquet/encoding_test.cpp
+++ b/be/test/exec/parquet/encoding_test.cpp
@@ -331,4 +331,67 @@ TEST_F(ParquetEncodingTest, FixedString) {
     }
 }
 
+TEST_F(ParquetEncodingTest, Boolean) {
+    std::vector<uint8_t> values;
+    for (int i = 0; i < 20; i++) {
+        values.push_back(i % 3);
+    }
+
+    const EncodingInfo* plain_encoding = nullptr;
+    EncodingInfo::get(tparquet::Type::BOOLEAN, tparquet::Encoding::PLAIN, &plain_encoding);
+    ASSERT_TRUE(plain_encoding != nullptr);
+    // plain
+    {
+        std::unique_ptr<Decoder> decoder;
+        auto st = plain_encoding->create_decoder(&decoder);
+        ASSERT_TRUE(st.ok());
+
+        std::unique_ptr<Encoder> encoder;
+        st = plain_encoding->create_encoder(&encoder);
+
+        st = encoder->append(reinterpret_cast<uint8_t*>(&values[0]), 20);
+        ASSERT_TRUE(st.ok());
+
+        DecoderChecker<uint8_t, false>::check(values, encoder->build(), decoder.get());
+    }
+
+    const EncodingInfo* dict_encoding = nullptr;
+    EncodingInfo::get(tparquet::Type::BOOLEAN, tparquet::Encoding::RLE_DICTIONARY, &dict_encoding);
+    ASSERT_TRUE(dict_encoding != nullptr);
+    // dict
+    {
+        std::unique_ptr<Decoder> decoder;
+        auto st = dict_encoding->create_decoder(&decoder);
+        ASSERT_TRUE(st.ok());
+
+        std::unique_ptr<Encoder> encoder;
+        st = dict_encoding->create_encoder(&encoder);
+        ASSERT_TRUE(st.ok());
+
+        st = encoder->append(reinterpret_cast<uint8_t*>(&values[0]), 20);
+        ASSERT_TRUE(st.ok());
+
+        // construct dictionary encoder
+        std::unique_ptr<Encoder> dict_encoder;
+        st = plain_encoding->create_encoder(&dict_encoder);
+        ASSERT_TRUE(st.ok());
+
+        size_t num_dicts = 0;
+        st = encoder->encode_dict(dict_encoder.get(), &num_dicts);
+        ASSERT_TRUE(st.ok());
+
+        // construct dictionary decoder
+        std::unique_ptr<Decoder> dict_decoder;
+        st = plain_encoding->create_decoder(&dict_decoder);
+        ASSERT_TRUE(st.ok());
+
+        dict_decoder->set_data(dict_encoder->build());
+
+        st = decoder->set_dict(config::vector_chunk_size, num_dicts, dict_decoder.get());
+        ASSERT_TRUE(st.ok());
+
+        DecoderChecker<uint8_t, true>::check(values, encoder->build(), decoder.get());
+    }
+}
+
 } // namespace starrocks::parquet

--- a/be/test/exec/parquet/encoding_test.cpp
+++ b/be/test/exec/parquet/encoding_test.cpp
@@ -334,7 +334,7 @@ TEST_F(ParquetEncodingTest, FixedString) {
 TEST_F(ParquetEncodingTest, Boolean) {
     std::vector<uint8_t> values;
     for (int i = 0; i < 20; i++) {
-        values.push_back(i % 3);
+        values.push_back(i % 3 == 0);
     }
 
     const EncodingInfo* plain_encoding = nullptr;

--- a/be/test/exec/parquet/encoding_test.cpp
+++ b/be/test/exec/parquet/encoding_test.cpp
@@ -333,7 +333,7 @@ TEST_F(ParquetEncodingTest, FixedString) {
 
 TEST_F(ParquetEncodingTest, Boolean) {
     std::vector<uint8_t> values;
-    for (int i = 0; i < 20; i++) {
+    for (int i = 0; i < 32; i++) {
         values.push_back(i % 3 == 0);
     }
 
@@ -348,10 +348,15 @@ TEST_F(ParquetEncodingTest, Boolean) {
 
         std::unique_ptr<Encoder> encoder;
         st = plain_encoding->create_encoder(&encoder);
-
-        st = encoder->append(reinterpret_cast<uint8_t*>(&values[0]), 20);
         ASSERT_TRUE(st.ok());
 
+        // decode without buffer
+        st = encoder->append(reinterpret_cast<uint8_t*>(&values[0]), 32);
+        ASSERT_TRUE(st.ok());
+        DecoderChecker<uint8_t, false>::check(values, encoder->build(), decoder.get());
+
+        // decode with buffer
+        values.resize(31);
         DecoderChecker<uint8_t, false>::check(values, encoder->build(), decoder.get());
     }
 }


### PR DESCRIPTION
Signed-off-by: dorianzheng <xingzhengde72@gmail.com>

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/3073

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
plain encoding for boolean type is stored as `Bit Packed`, `LSB` first format
more details refer to: https://github.com/apache/parquet-format/blob/master/Encodings.md#PLAIN