### PR TITLE
Add new compaction execution framework

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -299,7 +299,6 @@ CONF_Int64(vertical_compaction_max_columns_per_group, "5");
 CONF_mBool(enable_compaction, "true");
 CONF_Bool(enable_new_compaction_framework, "false");
 CONF_mInt32(max_compaction_task_num, "4");
-CONF_mInt32(max_compaction_task_per_disk, "2");
 // < 0 means no limit
 CONF_mInt32(max_cumulative_compaction_task, "-1");
 CONF_mInt32(max_base_compaction_task, "1");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -298,15 +298,15 @@ CONF_Int64(vertical_compaction_max_columns_per_group, "5");
 
 CONF_mBool(enable_compaction, "true");
 CONF_Bool(enable_new_compaction_framework, "false");
-CONF_mInt32(max_compaction_task_num, "2");
-CONF_mInt32(max_compaction_task_per_disk, "1");
+CONF_mInt32(max_compaction_task_num, "4");
+CONF_mInt32(max_compaction_task_per_disk, "2");
 // < 0 means no limit
-CONF_mInt32(max_level_0_compaction_task, "-1");
-CONF_mInt32(max_level_1_compaction_task, "1");
+CONF_mInt32(max_cumulative_compaction_task, "-1");
+CONF_mInt32(max_base_compaction_task, "1");
 // 5GB
-CONF_mInt64(min_level_0_compaction_size, "5368709120");
+CONF_mInt64(min_cumulative_compaction_size, "5368709120");
 // 20GB
-CONF_mInt64(min_level_1_compaction_size, "21474836480");
+CONF_mInt64(min_base_compaction_size, "21474836480");
 
 // Max row source mask memory bytes, default is 200M.
 // Should be smaller than compaction_mem_limit.

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -296,6 +296,18 @@ CONF_mInt32(update_compaction_trace_threshold, "20");
 // the columns will be divided into groups for vertical compaction.
 CONF_Int64(vertical_compaction_max_columns_per_group, "5");
 
+CONF_mBool(enable_compaction, "true");
+CONF_Bool(enable_new_compaction_framework, "false");
+CONF_mInt32(max_compaction_task_num, "2");
+CONF_mInt32(max_compaction_task_per_disk, "1");
+// < 0 means no limit
+CONF_mInt32(max_level_0_compaction_task, "-1");
+CONF_mInt32(max_level_1_compaction_task, "1");
+// 5GB
+CONF_mInt64(min_level_0_compaction_size, "5368709120");
+// 20GB
+CONF_mInt64(min_level_1_compaction_size, "21474836480");
+
 // Max row source mask memory bytes, default is 200M.
 // Should be smaller than compaction_mem_limit.
 // When the row source mask buffer exceeds this, it will be persisted to a temporary file on the disk.

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -147,4 +147,10 @@ add_library(Storage STATIC
     vectorized/rowset_merger.cpp
     vectorized/column_predicate_rewriter.cpp
     vectorized/column_predicate_dict_conjuct.cpp
+    compaction_context.cpp
+    compaction_task.cpp
+    compaction_utils.cpp
+    compaction_manager.cpp
+    compaction_scheduler.cpp
+    compaction_task_factory.cpp
 )

--- a/be/src/storage/backgroud_task.h
+++ b/be/src/storage/backgroud_task.h
@@ -1,4 +1,4 @@
-// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
 
 #pragma once
 

--- a/be/src/storage/backgroud_task.h
+++ b/be/src/storage/backgroud_task.h
@@ -1,0 +1,29 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#pragma once
+
+#include <atomic>
+
+namespace starrocks {
+
+class BackgroudTask {
+public:
+    BackgroudTask() : _stopped(false) {}
+
+    virtual ~BackgroudTask() = default;
+
+    virtual void run() = 0;
+
+    void start() { run(); }
+
+    // just set the _stopped flag to true
+    // the task should check the flag to stop
+    void stop() { _stopped = true; }
+
+    virtual bool should_stop() const { return _stopped; }
+
+protected:
+    std::atomic_bool _stopped;
+};
+
+} // namespace starrocks

--- a/be/src/storage/base_tablet.h
+++ b/be/src/storage/base_tablet.h
@@ -38,9 +38,14 @@ class DataDir;
 class BaseTablet : public std::enable_shared_from_this<BaseTablet> {
 public:
     BaseTablet(const TabletMetaSharedPtr& tablet_meta, DataDir* data_dir);
+    // for ut
+    BaseTablet() = default;
+
     virtual ~BaseTablet() = default;
 
     inline DataDir* data_dir() const;
+
+    void set_data_dir(DataDir* data_dir) { _data_dir = data_dir; }
 
     // A tablet's data are stored in disk files under a directory with structure like:
     //   ${storage_root_path}/${shard_number}/${tablet_id}/${schema_hash}
@@ -64,6 +69,8 @@ public:
 
     // Property encapsulated in TabletMeta
     inline const TabletMetaSharedPtr tablet_meta();
+
+    void set_tablet_meta(const TabletMetaSharedPtr& tablet_meta) { _tablet_meta = tablet_meta; }
 
     inline TabletUid tablet_uid() const;
     inline int64_t table_id() const;

--- a/be/src/storage/compaction_candidate.h
+++ b/be/src/storage/compaction_candidate.h
@@ -43,7 +43,7 @@ struct CompactionCandidate {
 
     bool is_valid() { return tablet && level >= 0 && level <= 1; }
 
-    std::string to_string() {
+    std::string to_string() const {
         std::stringstream ss;
         if (tablet) {
             ss << "tablet_id:" << tablet->tablet_id();
@@ -62,7 +62,9 @@ struct CompactionCandidateComparator {
         int32_t left_score = static_cast<int32_t>(left.tablet->compaction_score(left.level) * 100);
         int32_t right_score = static_cast<int32_t>(right.tablet->compaction_score(right.level) * 100);
         return left_score > right_score ||
-               (left_score == right_score && left.tablet->tablet_id() < right.tablet->tablet_id());
+               (left_score == right_score && left.tablet->tablet_id() < right.tablet->tablet_id()) ||
+               (left_score == right_score && left.tablet->tablet_id() == right.tablet->tablet_id() &&
+                left.level < right.level);
     }
 };
 

--- a/be/src/storage/compaction_candidate.h
+++ b/be/src/storage/compaction_candidate.h
@@ -60,8 +60,8 @@ struct CompactionCandidate {
 // when compaction score and level are equal, use tablet id(to be unique) instead(ascending)
 struct CompactionCandidateComparator {
     bool operator()(const CompactionCandidate& left, const CompactionCandidate& right) const {
-        int32_t left_score = static_cast<int32_t>(left.tablet->compaction_score(left.level) * 100);
-        int32_t right_score = static_cast<int32_t>(right.tablet->compaction_score(right.level) * 100);
+        int64_t left_score = static_cast<int64_t>(left.tablet->compaction_score(left.level) * 100);
+        int64_t right_score = static_cast<int64_t>(right.tablet->compaction_score(right.level) * 100);
         return left_score > right_score ||
                (left_score == right_score && left.level < right.level) ||
                (left_score == right_score && left.level == right.level &&

--- a/be/src/storage/compaction_candidate.h
+++ b/be/src/storage/compaction_candidate.h
@@ -62,8 +62,7 @@ struct CompactionCandidateComparator {
     bool operator()(const CompactionCandidate& left, const CompactionCandidate& right) const {
         int64_t left_score = static_cast<int64_t>(left.tablet->compaction_score(left.level) * 100);
         int64_t right_score = static_cast<int64_t>(right.tablet->compaction_score(right.level) * 100);
-        return left_score > right_score ||
-               (left_score == right_score && left.level < right.level) ||
+        return left_score > right_score || (left_score == right_score && left.level < right.level) ||
                (left_score == right_score && left.level == right.level &&
                 left.tablet->tablet_id() < right.tablet->tablet_id());
     }

--- a/be/src/storage/compaction_candidate.h
+++ b/be/src/storage/compaction_candidate.h
@@ -5,43 +5,45 @@
 #include <set>
 #include <vector>
 
+#include "storage/olap_common.h"
 #include "storage/tablet.h"
 
 namespace starrocks {
 
 struct CompactionCandidate {
     TabletSharedPtr tablet;
-    int8_t level;
+    CompactionType type;
 
-    CompactionCandidate() : tablet(nullptr), level(-1) {}
+    CompactionCandidate() : tablet(nullptr), type(INVALID_COMPACTION) {}
 
-    CompactionCandidate(TabletSharedPtr t, int8_t l) : tablet(std::move(t)), level(l) {}
+    CompactionCandidate(TabletSharedPtr t, CompactionType compaction_type)
+            : tablet(std::move(t)), type(compaction_type) {}
 
-    CompactionCandidate(const TabletSharedPtr& t, int8_t l) : tablet(t), level(l) {}
+    CompactionCandidate(const TabletSharedPtr& t, CompactionType compaction_type) : tablet(t), type(compaction_type) {}
 
     CompactionCandidate(const CompactionCandidate& other) {
         tablet = other.tablet;
-        level = other.level;
+        type = other.type;
     }
 
     CompactionCandidate& operator=(const CompactionCandidate& rhs) {
         tablet = rhs.tablet;
-        level = rhs.level;
+        type = rhs.type;
         return *this;
     }
 
     CompactionCandidate(CompactionCandidate&& other) {
         tablet = std::move(other.tablet);
-        level = other.level;
+        type = other.type;
     }
 
     CompactionCandidate& operator=(CompactionCandidate&& rhs) {
         tablet = std::move(rhs.tablet);
-        level = rhs.level;
+        type = rhs.type;
         return *this;
     }
 
-    bool is_valid() { return tablet && level >= 0 && level <= 1; }
+    bool is_valid() { return tablet && (type == BASE_COMPACTION || type == CUMULATIVE_COMPACTION); }
 
     std::string to_string() const {
         std::stringstream ss;
@@ -50,7 +52,7 @@ struct CompactionCandidate {
         } else {
             ss << "nullptr tablet";
         }
-        ss << ", level:" << (int32_t)level;
+        ss << ", type:" << type;
         return ss.str();
     }
 };
@@ -60,10 +62,10 @@ struct CompactionCandidate {
 // when compaction score and level are equal, use tablet id(to be unique) instead(ascending)
 struct CompactionCandidateComparator {
     bool operator()(const CompactionCandidate& left, const CompactionCandidate& right) const {
-        int64_t left_score = static_cast<int64_t>(left.tablet->compaction_score(left.level) * 100);
-        int64_t right_score = static_cast<int64_t>(right.tablet->compaction_score(right.level) * 100);
-        return left_score > right_score || (left_score == right_score && left.level < right.level) ||
-               (left_score == right_score && left.level == right.level &&
+        int64_t left_score = static_cast<int64_t>(left.tablet->compaction_score(left.type) * 100);
+        int64_t right_score = static_cast<int64_t>(right.tablet->compaction_score(right.type) * 100);
+        return left_score > right_score || (left_score == right_score && left.type > right.type) ||
+               (left_score == right_score && left.type == right.type &&
                 left.tablet->tablet_id() < right.tablet->tablet_id());
     }
 };

--- a/be/src/storage/compaction_candidate.h
+++ b/be/src/storage/compaction_candidate.h
@@ -1,0 +1,69 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#pragma once
+#include <memory>
+#include <set>
+#include <vector>
+
+#include "storage/tablet.h"
+
+namespace starrocks {
+
+struct CompactionCandidate {
+    TabletSharedPtr tablet;
+    int8_t level;
+
+    CompactionCandidate() : tablet(nullptr), level(-1) {}
+
+    CompactionCandidate(TabletSharedPtr t, int8_t l) : tablet(std::move(t)), level(l) {}
+
+    CompactionCandidate(const TabletSharedPtr& t, int8_t l) : tablet(t), level(l) {}
+
+    CompactionCandidate(const CompactionCandidate& other) {
+        tablet = other.tablet;
+        level = other.level;
+    }
+
+    CompactionCandidate& operator=(const CompactionCandidate& rhs) {
+        tablet = rhs.tablet;
+        level = rhs.level;
+        return *this;
+    }
+
+    CompactionCandidate(CompactionCandidate&& other) {
+        tablet = std::move(other.tablet);
+        level = other.level;
+    }
+
+    CompactionCandidate& operator=(CompactionCandidate&& rhs) {
+        tablet = std::move(rhs.tablet);
+        level = rhs.level;
+        return *this;
+    }
+
+    bool is_valid() { return tablet && level >= 0 && level <= 1; }
+
+    std::string to_string() {
+        std::stringstream ss;
+        if (tablet) {
+            ss << "tablet_id:" << tablet->tablet_id();
+        } else {
+            ss << "nullptr tablet";
+        }
+        ss << ", level:" << (int32_t)level;
+        return ss.str();
+    }
+};
+
+// Comparator should compare tablet by compaction score in descending order
+// When compaction scores are equal, use tablet id(to be unique) instead(ascending)
+struct CompactionCandidateComparator {
+    bool operator()(const CompactionCandidate& left, const CompactionCandidate& right) const {
+        int32_t left_score = static_cast<int32_t>(left.tablet->compaction_score(left.level) * 100);
+        int32_t right_score = static_cast<int32_t>(right.tablet->compaction_score(right.level) * 100);
+        return left_score > right_score ||
+               (left_score == right_score && left.tablet->tablet_id() < right.tablet->tablet_id());
+    }
+};
+
+} // namespace starrocks

--- a/be/src/storage/compaction_candidate.h
+++ b/be/src/storage/compaction_candidate.h
@@ -56,15 +56,16 @@ struct CompactionCandidate {
 };
 
 // Comparator should compare tablet by compaction score in descending order
-// When compaction scores are equal, use tablet id(to be unique) instead(ascending)
+// When compaction scores are equal, put smaller level ahead
+// when compaction score and level are equal, use tablet id(to be unique) instead(ascending)
 struct CompactionCandidateComparator {
     bool operator()(const CompactionCandidate& left, const CompactionCandidate& right) const {
         int32_t left_score = static_cast<int32_t>(left.tablet->compaction_score(left.level) * 100);
         int32_t right_score = static_cast<int32_t>(right.tablet->compaction_score(right.level) * 100);
         return left_score > right_score ||
-               (left_score == right_score && left.tablet->tablet_id() < right.tablet->tablet_id()) ||
-               (left_score == right_score && left.tablet->tablet_id() == right.tablet->tablet_id() &&
-                left.level < right.level);
+               (left_score == right_score && left.level < right.level) ||
+               (left_score == right_score && left.level == right.level &&
+                left.tablet->tablet_id() < right.tablet->tablet_id());
     }
 };
 

--- a/be/src/storage/compaction_context.cpp
+++ b/be/src/storage/compaction_context.cpp
@@ -12,20 +12,20 @@ namespace starrocks {
 std::string CompactionContext::to_string() const {
     std::stringstream ss;
     ss << "tablet id:" << tablet->tablet_id() << "\n";
-    ss << "current level:" << (int32_t)current_level << "\n";
-    ss << "level 0 score:" << compaction_scores[0] << "\n";
-    ss << "level 1 score:" << compaction_scores[1] << "\n";
-    ss << "level 0:";
+    ss << "compaction type:" << chosen_compaction_type << "\n";
+    ss << "cumulative score:" << cumulative_score << "\n";
+    ss << "base score:" << base_score << "\n";
+    ss << "cumulative rowset candidates:";
     for (auto& rowset : rowset_levels[0]) {
         ss << rowset->version() << ";";
     }
     ss << "\n";
-    ss << "level 1:";
+    ss << "base rowset candidates:";
     for (auto& rowset : rowset_levels[1]) {
         ss << rowset->version() << ";";
     }
     ss << "\n";
-    ss << "level 2:";
+    ss << "base rowset:";
     for (auto& rowset : rowset_levels[2]) {
         ss << rowset->version() << ";";
     }

--- a/be/src/storage/compaction_context.cpp
+++ b/be/src/storage/compaction_context.cpp
@@ -13,6 +13,8 @@ std::string CompactionContext::to_string() const {
     std::stringstream ss;
     ss << "tablet id:" << tablet->tablet_id() << "\n";
     ss << "current level:" << (int32_t)current_level << "\n";
+    ss << "level 0 score:" << compaction_scores[0] << "\n";
+    ss << "level 1 score:" << compaction_scores[1] << "\n";
     ss << "level 0:";
     for (auto& rowset : rowset_levels[0]) {
         ss << rowset->version() << ";";

--- a/be/src/storage/compaction_context.cpp
+++ b/be/src/storage/compaction_context.cpp
@@ -1,0 +1,34 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#include "storage/compaction_context.h"
+
+#include <sstream>
+
+#include "storage/rowset/rowset.h"
+#include "storage/tablet.h"
+
+namespace starrocks {
+
+std::string CompactionContext::to_string() const {
+    std::stringstream ss;
+    ss << "tablet id:" << tablet->tablet_id() << "\n";
+    ss << "current level:" << (int32_t)current_level << "\n";
+    ss << "level 0:";
+    for (auto& rowset : rowset_levels[0]) {
+        ss << rowset->version() << ";";
+    }
+    ss << "\n";
+    ss << "level 1:";
+    for (auto& rowset : rowset_levels[1]) {
+        ss << rowset->version() << ";";
+    }
+    ss << "\n";
+    ss << "level 2:";
+    for (auto& rowset : rowset_levels[2]) {
+        ss << rowset->version() << ";";
+    }
+    ss << "\n";
+    return ss.str();
+}
+
+} // namespace starrocks

--- a/be/src/storage/compaction_context.h
+++ b/be/src/storage/compaction_context.h
@@ -24,6 +24,7 @@ struct RowsetComparator {
         return left->start_version() < right->start_version() && left->end_version() < right->start_version();
     }
 };
+
 struct CompactionContext {
     // sort rowsets by version
     std::set<Rowset*, RowsetComparator> rowset_levels[LEVEL_NUMBER];

--- a/be/src/storage/compaction_context.h
+++ b/be/src/storage/compaction_context.h
@@ -1,0 +1,41 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#pragma once
+#include <memory>
+#include <set>
+#include <vector>
+
+#include "storage/rowset/rowset.h"
+
+namespace starrocks {
+
+class Tablet;
+class RowsetReleaseGuard;
+
+#ifndef LEVEL_NUMBER
+#define LEVEL_NUMBER 3
+#endif
+
+struct RowsetComparator {
+    bool operator()(const Rowset* left, const Rowset* right) const {
+        return left->start_version() < right->start_version() && left->end_version() < right->start_version();
+    }
+};
+struct CompactionContext {
+    // sort rowsets by version
+    std::set<Rowset*, RowsetComparator> rowset_levels[LEVEL_NUMBER];
+    double compaction_scores[LEVEL_NUMBER - 1];
+    Tablet* tablet;
+    int8_t current_level = -1;
+
+    double get_score() {
+        if (current_level < 0 || current_level > 1) {
+            return 0;
+        }
+        return compaction_scores[current_level];
+    }
+
+    std::string to_string() const;
+};
+
+} // namespace starrocks

--- a/be/src/storage/compaction_context.h
+++ b/be/src/storage/compaction_context.h
@@ -6,15 +6,18 @@
 #include <vector>
 
 #include "storage/rowset/rowset.h"
+#include "storage/tablet.h"
 
 namespace starrocks {
 
-class Tablet;
 class RowsetReleaseGuard;
+class CompactionTask;
 
 #ifndef LEVEL_NUMBER
 #define LEVEL_NUMBER 3
 #endif
+
+const double COMPACTION_SCORE_THRESHOLD = 0.999;
 
 struct RowsetComparator {
     bool operator()(const Rowset* left, const Rowset* right) const {
@@ -25,15 +28,18 @@ struct CompactionContext {
     // sort rowsets by version
     std::set<Rowset*, RowsetComparator> rowset_levels[LEVEL_NUMBER];
     double compaction_scores[LEVEL_NUMBER - 1];
-    Tablet* tablet;
+    TabletSharedPtr tablet;
     int8_t current_level = -1;
 
+    /*
     double get_score() {
         if (current_level < 0 || current_level > 1) {
             return 0;
         }
         return compaction_scores[current_level];
-    }
+    }*/
+
+    bool need_compaction(uint8_t level) { return compaction_scores[level] > COMPACTION_SCORE_THRESHOLD; }
 
     std::string to_string() const;
 };

--- a/be/src/storage/compaction_context.h
+++ b/be/src/storage/compaction_context.h
@@ -19,9 +19,10 @@ class CompactionTask;
 
 const double COMPACTION_SCORE_THRESHOLD = 0.999;
 
+// rowsets here can never overlap
 struct RowsetComparator {
     bool operator()(const Rowset* left, const Rowset* right) const {
-        return left->start_version() < right->start_version() && left->end_version() < right->start_version();
+        return left->start_version() < right->start_version();
     }
 };
 
@@ -31,14 +32,6 @@ struct CompactionContext {
     double compaction_scores[LEVEL_NUMBER - 1];
     TabletSharedPtr tablet;
     int8_t current_level = -1;
-
-    /*
-    double get_score() {
-        if (current_level < 0 || current_level > 1) {
-            return 0;
-        }
-        return compaction_scores[current_level];
-    }*/
 
     bool need_compaction(uint8_t level) { return compaction_scores[level] > COMPACTION_SCORE_THRESHOLD; }
 

--- a/be/src/storage/compaction_manager.cpp
+++ b/be/src/storage/compaction_manager.cpp
@@ -1,0 +1,128 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#include "storage/compaction_manager.h"
+
+#include "storage/compaction_scheduler.h"
+#include "storage/data_dir.h"
+#include "util/thread.h"
+namespace starrocks {
+
+std::unique_ptr<CompactionManager> CompactionManager::_instance(new CompactionManager());
+
+CompactionManager* CompactionManager::instance() {
+    return _instance.get();
+}
+
+void CompactionManager::update_candidate_async(Tablet* tablet) {
+    PriorityThreadPool::Task task;
+    task.work_function = [tablet, this] { update_candidate(tablet); };
+    bool ret = _update_candidate_pool.try_offer(task);
+    if (!ret) {
+        LOG(WARNING) << "update candidate failed for queue is full. capacity:"
+                     << _update_candidate_pool.get_queue_capacity()
+                     << ", queue size:" << _update_candidate_pool.get_queue_size();
+    }
+}
+
+void CompactionManager::update_candidate(Tablet* tablet) {
+    bool should_notify = false;
+    {
+        std::lock_guard lg(_candidates_mutex);
+        size_t num = _candidate_tablets.erase(tablet);
+        should_notify = num == 0;
+        _candidate_tablets.insert(tablet);
+    }
+    if (should_notify) {
+        _notify_schedulers();
+    }
+}
+
+void CompactionManager::insert_candidates(const std::vector<Tablet*>& tablets) {
+    std::lock_guard lg(_candidates_mutex);
+    _candidate_tablets.insert(tablets.begin(), tablets.end());
+}
+
+Tablet* CompactionManager::pick_candidate() {
+    std::lock_guard lg(_candidates_mutex);
+    if (_candidate_tablets.empty()) {
+        // return nullptr if _candidate_tablets is empty
+        return nullptr;
+    }
+
+    auto iter = _candidate_tablets.begin();
+    Tablet* ret = *iter;
+    _candidate_tablets.erase(iter);
+    return ret;
+}
+
+bool CompactionManager::register_task(CompactionTask* compaction_task) {
+    if (!compaction_task) {
+        return false;
+    }
+    std::lock_guard lg(_tasks_mutex);
+    if (config::max_compaction_task_num >= 0 && _running_tasks.size() >= config::max_compaction_task_num) {
+        LOG(WARNING) << "register compaction task failed for running tasks reach max limit:"
+                     << config::max_compaction_task_num;
+        return false;
+    }
+    if (compaction_task->compaction_level() == 0 && config::max_level_0_compaction_task >= 0 &&
+        _level_to_task_num_map[0] >= config::max_level_0_compaction_task) {
+        LOG(WARNING) << "register compaction task failed for level 0 limit:" << config::max_level_0_compaction_task;
+        return false;
+    } else if (compaction_task->compaction_level() == 1 && config::max_level_1_compaction_task >= 0 &&
+               _level_to_task_num_map[1] >= config::max_level_1_compaction_task) {
+        LOG(WARNING) << "register compaction task failed for level 1 limit:" << config::max_level_1_compaction_task;
+        return false;
+    }
+    Tablet* tablet = compaction_task->tablet();
+    DataDir* data_dir = tablet->data_dir();
+    if (config::max_compaction_task_per_disk >= 0 &&
+        _data_dir_to_task_num_map[data_dir] >= config::max_compaction_task_per_disk) {
+        LOG(WARNING) << "register compaction task failed for disk's running tasks reach limit:"
+                     << config::max_compaction_task_per_disk;
+        return false;
+    }
+    auto p = _running_tasks.insert(compaction_task);
+    if (!p.second) {
+        // duplicate task
+        LOG(WARNING) << "duplicate task, compaction_task:" << compaction_task->task_id()
+                     << ", tablet:" << compaction_task->tablet()->tablet_id();
+        return false;
+    }
+    _level_to_task_num_map[compaction_task->compaction_level()]++;
+    _data_dir_to_task_num_map[data_dir]++;
+    _running_tasks_num++;
+    return true;
+}
+
+void CompactionManager::unregister_task(CompactionTask* compaction_task) {
+    if (!compaction_task) {
+        return;
+    }
+    std::lock_guard lg(_tasks_mutex);
+    auto size = _running_tasks.erase(compaction_task);
+    if (size > 0) {
+        Tablet* tablet = compaction_task->tablet();
+        DataDir* data_dir = tablet->data_dir();
+        _level_to_task_num_map[compaction_task->compaction_level()]--;
+        _data_dir_to_task_num_map[data_dir]--;
+        _running_tasks_num--;
+    }
+}
+
+void CompactionManager::clear_tasks() {
+    std::lock_guard lg(_tasks_mutex);
+    _running_tasks.clear();
+    _running_tasks_num = 0;
+    _data_dir_to_task_num_map.clear();
+    _level_to_task_num_map.clear();
+}
+
+void CompactionManager::_notify_schedulers() {
+    std::lock_guard lg(_scheduler_mutex);
+    for (auto& scheduler : _schedulers) {
+        scheduler->notify();
+    }
+}
+
+} // namespace starrocks

--- a/be/src/storage/compaction_manager.h
+++ b/be/src/storage/compaction_manager.h
@@ -56,14 +56,19 @@ public:
         return _running_tasks.size();
     }
 
-    uint16_t running_tasks_num_for_dir(DataDir* data_dir) {
+    uint16_t running_cumulative_tasks_num_for_dir(DataDir* data_dir) {
         std::lock_guard lg(_tasks_mutex);
-        return _data_dir_to_task_num_map[data_dir];
+        return _data_dir_to_cumulative_task_num_map[data_dir];
     }
 
-    uint16_t running_tasks_num_for_level(uint8_t level) {
+    uint16_t running_base_tasks_num_for_dir(DataDir* data_dir) {
         std::lock_guard lg(_tasks_mutex);
-        return _level_to_task_num_map[level];
+        return _data_dir_to_base_task_num_map[data_dir];
+    }
+
+    uint16_t running_tasks_num_for_type(CompactionType type) {
+        std::lock_guard lg(_tasks_mutex);
+        return _type_to_task_num_map[type];
     }
 
     uint64_t next_compaction_task_id() { return ++_next_task_id; }
@@ -84,8 +89,9 @@ private:
     std::mutex _tasks_mutex;
     std::atomic<uint64_t> _next_task_id;
     std::unordered_set<CompactionTask*> _running_tasks;
-    std::unordered_map<DataDir*, uint16_t> _data_dir_to_task_num_map;
-    std::unordered_map<uint8_t, uint16_t> _level_to_task_num_map;
+    std::unordered_map<DataDir*, uint16_t> _data_dir_to_cumulative_task_num_map;
+    std::unordered_map<DataDir*, uint16_t> _data_dir_to_base_task_num_map;
+    std::unordered_map<CompactionType, uint16_t> _type_to_task_num_map;
     PriorityThreadPool _update_candidate_pool;
 
     std::mutex _scheduler_mutex;

--- a/be/src/storage/compaction_manager.h
+++ b/be/src/storage/compaction_manager.h
@@ -1,0 +1,106 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#pragma once
+
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <unordered_set>
+#include <vector>
+
+#include "storage/compaction_task.h"
+#include "storage/olap_common.h"
+#include "storage/rowset/rowset.h"
+#include "storage/tablet.h"
+#include "util/priority_thread_pool.hpp"
+
+namespace starrocks {
+
+class CompactionScheduler;
+
+class CompactionManager {
+public:
+    ~CompactionManager() = default;
+
+    static CompactionManager* instance();
+
+    size_t candidates_size() {
+        std::lock_guard lg(_candidates_mutex);
+        return _candidate_tablets.size();
+    }
+
+    void update_candidate_async(Tablet* tablet);
+
+    void update_candidate(Tablet* tablet);
+
+    void insert_candidates(const std::vector<Tablet*>& tablets);
+
+    Tablet* pick_candidate();
+
+    void register_scheduler(CompactionScheduler* scheduler) {
+        std::lock_guard lg(_scheduler_mutex);
+        _schedulers.push_back(scheduler);
+    }
+
+    bool register_task(CompactionTask* compaction_task);
+
+    void unregister_task(CompactionTask* compaction_task);
+
+    void clear_tasks();
+
+    uint16_t running_tasks_num() {
+        std::lock_guard lg(_tasks_mutex);
+        return _running_tasks_num;
+    }
+
+    uint16_t running_tasks_num_for_dir(DataDir* data_dir) {
+        std::lock_guard lg(_tasks_mutex);
+        return _data_dir_to_task_num_map[data_dir];
+    }
+
+    uint16_t running_tasks_num_for_level(uint8_t level) {
+        std::lock_guard lg(_tasks_mutex);
+        return _level_to_task_num_map[level];
+    }
+
+    uint64_t next_compaction_task_id() { return ++_next_task_id; }
+
+private:
+    CompactionManager() : _next_task_id(0), _running_tasks_num(0), _update_candidate_pool("up_candidates", 1, 100000) {}
+    CompactionManager(const CompactionManager& compaction_manager) = delete;
+    CompactionManager(CompactionManager&& compaction_manager) = delete;
+    CompactionManager& operator=(const CompactionManager& compaction_manager) = delete;
+    CompactionManager& operator=(CompactionManager&& compaction_manager) = delete;
+
+    void _notify_schedulers();
+
+    // Comparator should compare tablet by compaction score in descending order
+    // When compaction scores are equal, use tablet id(to be unique) instead(ascending)
+    struct TabletCompactionComparator {
+        bool operator()(const Tablet* left, const Tablet* right) const {
+            int32_t left_score = static_cast<int32_t>(left->compaction_score() * 100);
+            int32_t right_score = static_cast<int32_t>(right->compaction_score() * 100);
+            return left_score > right_score || (left_score == right_score && left->tablet_id() < right->tablet_id());
+        }
+    };
+
+    std::mutex _candidates_mutex;
+    // protect by _mutex
+    std::set<Tablet*, TabletCompactionComparator> _candidate_tablets;
+
+    std::mutex _tasks_mutex;
+    std::atomic<uint64_t> _next_task_id;
+    std::atomic<uint16_t> _running_tasks_num;
+    std::unordered_set<CompactionTask*> _running_tasks;
+    std::unordered_map<DataDir*, uint16_t> _data_dir_to_task_num_map;
+    std::unordered_map<uint8_t, uint16_t> _level_to_task_num_map;
+    PriorityThreadPool _update_candidate_pool;
+
+    std::mutex _scheduler_mutex;
+    std::vector<CompactionScheduler*> _schedulers;
+
+    static std::unique_ptr<CompactionManager> _instance;
+};
+
+} // namespace starrocks

--- a/be/src/storage/compaction_policy.h
+++ b/be/src/storage/compaction_policy.h
@@ -1,0 +1,27 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#pragma once
+
+#include <vector>
+
+#include "storage/compaction_task.h"
+
+namespace starrocks {
+
+// Compaction policy for tablet
+class CompactionPolicy {
+public:
+    virtual ~CompactionPolicy() = default;
+
+    // used to judge whether a tablet should do compaction or not
+    virtual bool need_compaction() = 0;
+
+    // to calculate the compaction score of a tablet
+    // which is used to decide the compaction sequence of tablets
+    virtual double compaction_score() = 0;
+
+    // used to generate a CompactionTask for tablet
+    virtual std::shared_ptr<CompactionTask> create_compaction() = 0;
+};
+
+} // namespace starrocks

--- a/be/src/storage/compaction_policy.h
+++ b/be/src/storage/compaction_policy.h
@@ -16,10 +16,6 @@ public:
     // used to judge whether a tablet should do compaction or not
     virtual bool need_compaction() = 0;
 
-    // to calculate the compaction score of a tablet
-    // which is used to decide the compaction sequence of tablets
-    virtual double compaction_score() = 0;
-
     // used to generate a CompactionTask for tablet
     virtual std::shared_ptr<CompactionTask> create_compaction() = 0;
 };

--- a/be/src/storage/compaction_scheduler.cpp
+++ b/be/src/storage/compaction_scheduler.cpp
@@ -38,8 +38,7 @@ void CompactionScheduler::schedule() {
                       << ", task_id:" << compaction_task->task_id()
                       << ", tablet_id:" << compaction_task->tablet()->tablet_id()
                       << ", compaction level:" << (int32_t)compaction_task->compaction_level()
-                      << ", compaction score:" << compaction_task->compaction_score()
-                      << " for round:" << _round;
+                      << ", compaction score:" << compaction_task->compaction_score() << " for round:" << _round;
             bool ret = _compaction_pool.try_offer(task);
             if (!ret) {
                 LOG(WARNING) << "submit compaction task to compaction pool failed."

--- a/be/src/storage/compaction_scheduler.cpp
+++ b/be/src/storage/compaction_scheduler.cpp
@@ -1,0 +1,242 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#include "storage/compaction_scheduler.h"
+
+#include <chrono>
+#include <thread>
+
+#include "storage/compaction_manager.h"
+#include "storage/compaction_task.h"
+#include "storage/data_dir.h"
+#include "storage/storage_engine.h"
+#include "storage/tablet.h"
+
+using namespace std::chrono_literals;
+
+namespace starrocks {
+
+CompactionScheduler::CompactionScheduler() : _compaction_pool("compact_pool", config::max_compaction_task_num, 1000) {
+    CompactionManager::instance()->register_scheduler(this);
+}
+
+void CompactionScheduler::schedule() {
+    LOG(INFO) << "start compaction scheduler";
+    while (true) {
+        ++_round;
+        _wait_to_run();
+        Tablet* selected = _try_get_next_tablet();
+        if (!selected) {
+            std::unique_lock<std::mutex> lk(_mutex);
+            _cv.wait_for(lk, 10000ms);
+        } else {
+            std::shared_ptr<CompactionTask> compaction_task = selected->get_compaction(true);
+            compaction_task->set_compaction_scheduler(this);
+            compaction_task->set_task_id(CompactionManager::instance()->next_compaction_task_id());
+            PriorityThreadPool::Task task;
+            task.work_function = [compaction_task] { compaction_task->start(); };
+            LOG(INFO) << "start to run compaction."
+                      << ", task_id:" << compaction_task->task_id()
+                      << ", tablet_id:" << compaction_task->tablet()->tablet_id()
+                      << ", compaction score:" << selected->compaction_score() << " for round:" << _round;
+            bool ret = _compaction_pool.try_offer(task);
+            if (!ret) {
+                LOG(WARNING) << "submit compaction task to compaction pool failed."
+                             << ", pool queue size:" << _compaction_pool.get_queue_size()
+                             << ", queue capacity:" << _compaction_pool.get_queue_capacity();
+                selected->reset_compaction();
+                CompactionManager::instance()->update_candidate(selected);
+            }
+        }
+    }
+}
+
+void CompactionScheduler::notify() {
+    std::unique_lock<std::mutex> lk(_mutex);
+    _cv.notify_one();
+}
+
+bool CompactionScheduler::_can_schedule_next() {
+    int32_t max_task_num = std::min(
+            config::max_compaction_task_num,
+            static_cast<int32_t>(StorageEngine::instance()->get_store_num() * config::max_compaction_task_per_disk));
+    return config::enable_compaction && CompactionManager::instance()->running_tasks_num() < max_task_num &&
+           CompactionManager::instance()->candidates_size() > 0;
+}
+
+void CompactionScheduler::_wait_to_run() {
+    std::unique_lock<std::mutex> lk(_mutex);
+    // check _can_schedule_next every one second to avoid deadlock and support modifying config online
+    while (!_cv.wait_for(lk, 5000ms, [this] { return _can_schedule_next(); })) {
+    }
+}
+bool CompactionScheduler::_can_do_compaction_task(Tablet* tablet, CompactionTask* compaction_task) {
+    // create new compaction task successfully
+    bool need_reset_task = true;
+    DeferOp reset_op([&] {
+        if (need_reset_task) {
+            tablet->reset_compaction();
+        }
+    });
+    // to compatible with old compaction framework
+    // TODO: can be optimized to use just one lock
+    int64_t last_failure_ms = 0;
+    if (compaction_task->compaction_level() == 0) {
+        uint16_t level_num = CompactionManager::instance()->running_tasks_num_for_level(0);
+        if (config::max_level_0_compaction_task >= 0 && level_num >= config::max_level_0_compaction_task) {
+            LOG(INFO) << "skip tablet:" << tablet->tablet_id()
+                      << " for level 0 limit:" << config::max_level_0_compaction_task;
+            return false;
+        }
+        std::unique_lock lk(tablet->get_cumulative_lock(), std::try_to_lock);
+        if (!lk.owns_lock()) {
+            LOG(INFO) << "skip tablet:" << tablet->tablet_id() << " for cumulative lock";
+            return false;
+        }
+        last_failure_ms = tablet->last_cumu_compaction_failure_time();
+    } else {
+        uint16_t level_num = CompactionManager::instance()->running_tasks_num_for_level(1);
+        if (config::max_level_1_compaction_task >= 0 && level_num >= config::max_level_1_compaction_task) {
+            LOG(INFO) << "skip tablet:" << tablet->tablet_id()
+                      << " for level 1 limit:" << config::max_level_1_compaction_task;
+            return false;
+        }
+        std::unique_lock lk(tablet->get_base_lock(), std::try_to_lock);
+        if (!lk.owns_lock()) {
+            LOG(INFO) << "skip tablet:" << tablet->tablet_id() << " for base lock";
+            return false;
+        }
+        last_failure_ms = tablet->last_base_compaction_failure_time();
+    }
+    int64_t now_ms = UnixMillis();
+    if (now_ms - last_failure_ms <= config::min_compaction_failure_interval_sec * 1000) {
+        LOG(INFO) << "Too often to schedule compaction, skip it."
+                  << "compaction_level=" << compaction_task->compaction_level()
+                  << ", last_failure_time_ms=" << last_failure_ms << ", tablet_id=" << tablet->tablet_id();
+        return false;
+    }
+
+    DataDir* data_dir = tablet->data_dir();
+    // control the concurrent running tasks's limit
+    // just try best here for that there may be concurrent CompactionSchedulers
+    // hard limit will be checked when CompactionManager::register()
+    uint16_t num = CompactionManager::instance()->running_tasks_num_for_dir(data_dir);
+    if (config::max_compaction_task_per_disk >= 0 && num >= config::max_compaction_task_per_disk) {
+        LOG(INFO) << "skip tablet:" << tablet->tablet_id()
+                  << " for limit of compaction task per disk. disk path:" << data_dir->path()
+                  << ", running num:" << num;
+        return false;
+    }
+    // found a qualified tablet
+    // qualified tablet will be removed from candidates
+    need_reset_task = false;
+    return true;
+}
+
+bool CompactionScheduler::_check_precondition(Tablet* tablet) {
+    if (!tablet) {
+        LOG(WARNING) << "null tablet";
+        return false;
+    }
+    if (!tablet->need_compaction()) {
+        // check need compaction
+        // if it is false, skip this tablet and remove it from candidate
+        LOG(INFO) << "skip tablet:" << tablet->tablet_id() << " because need_compaction is false";
+        return false;
+    }
+
+    if (tablet->tablet_state() != TABLET_RUNNING) {
+        LOG(INFO) << "skip tablet:" << tablet->tablet_id() << " because tablet state is not RUNNING";
+        return false;
+    }
+
+    // check for alter task for safety
+    // maybe this logic can be removed if tablet is the schema change dest tablet, need_compaction will never return true
+    AlterTabletTaskSharedPtr cur_alter_task = tablet->alter_task();
+    if (cur_alter_task != nullptr && cur_alter_task->alter_state() != ALTER_FINISHED &&
+        cur_alter_task->alter_state() != ALTER_FAILED) {
+        TabletManager* tablet_manager = StorageEngine::instance()->tablet_manager();
+        TabletSharedPtr related_tablet = tablet_manager->get_tablet(cur_alter_task->related_tablet_id());
+        if (related_tablet != nullptr && tablet->creation_time() > related_tablet->creation_time()) {
+            // Current tablet is newly created during schema-change or rollup, skip it
+            LOG(INFO) << "skip tablet:" << tablet->tablet_id() << " because it is newly-created for schema change";
+            return false;
+        }
+    }
+
+    std::shared_ptr<CompactionTask> compaction_task = tablet->get_compaction(false);
+    if (compaction_task) {
+        // tablet already has a running compaction task, skip it
+        LOG(INFO) << "skip tablet:" << tablet->tablet_id()
+                  << " because there is another running compaction task:" << compaction_task->task_id();
+        return false;
+    }
+    return true;
+}
+
+bool CompactionScheduler::_can_do_compaction(Tablet* tablet, bool* need_reschedule) {
+    // when the following conditions fail, should not reschedule the candidate tablet
+    *need_reschedule = false;
+    bool precondition_ok = _check_precondition(tablet);
+    if (!precondition_ok) {
+        return false;
+    }
+
+    // when the following conditions fail, should reschedule the candidate tablet
+    *need_reschedule = true;
+    DataDir* data_dir = tablet->data_dir();
+    if (data_dir->reach_capacity_limit(0)) {
+        LOG(WARNING) << "skip tablet:" << tablet->tablet_id() << " because data dir reaches capacity limit";
+        return false;
+    }
+
+    // create a new compaction task
+    std::shared_ptr<CompactionTask> compaction_task = tablet->get_compaction(true);
+
+    if (compaction_task) {
+        bool can_do = _can_do_compaction_task(tablet, compaction_task.get());
+        *need_reschedule = !can_do;
+        return can_do;
+    } else {
+        VLOG(2) << "skip tablet:" << tablet->tablet_id() << " because creating compaction task failed.";
+        return false;
+    }
+}
+
+Tablet* CompactionScheduler::_try_get_next_tablet() {
+    VLOG(2) << "try to get next qualified tablet for round:" << _round;
+    // tmp_tablets save the tmp picked candidates tablets
+    std::vector<Tablet*> tmp_tablets;
+    Tablet* tablet = nullptr;
+    bool found = false;
+    while (true) {
+        if (!_can_schedule_next()) {
+            VLOG(2) << "_can_schedule_next is false. skip";
+            break;
+        }
+        tablet = CompactionManager::instance()->pick_candidate();
+        if (!tablet) {
+            // means there no candidate tablet, break
+            break;
+        }
+        VLOG(2) << "try tablet:" << tablet->tablet_id();
+        bool need_reschedule = true;
+        found = _can_do_compaction(tablet, &need_reschedule);
+        if (need_reschedule) {
+            tmp_tablets.push_back(tablet);
+        }
+        if (found) {
+            break;
+        }
+    }
+    VLOG(2) << "tmp tablets size:" << tmp_tablets.size();
+    CompactionManager::instance()->insert_candidates(tmp_tablets);
+    if (found) {
+        VLOG(2) << "get a qualified tablet:" << tablet->tablet_id();
+        return tablet;
+    } else {
+        VLOG(2) << "no qualified tablet.";
+        return nullptr;
+    }
+}
+
+} // namespace starrocks

--- a/be/src/storage/compaction_scheduler.cpp
+++ b/be/src/storage/compaction_scheduler.cpp
@@ -16,8 +16,14 @@ using namespace std::chrono_literals;
 
 namespace starrocks {
 
-CompactionScheduler::CompactionScheduler() : _compaction_pool("compact_pool", config::max_compaction_task_num, 1000) {
-    CompactionManager::instance()->register_scheduler(this);
+CompactionScheduler::CompactionScheduler() {
+    auto st = ThreadPoolBuilder("compact_pool")
+                      .set_min_threads(1)
+                      .set_max_threads(config::max_compaction_task_num)
+                      .set_max_queue_size(1000)
+                      .build(&_compaction_pool);
+    DCHECK(st.ok());
+    StorageEngine::instance()->compaction_manager()->register_scheduler(this);
 }
 
 void CompactionScheduler::schedule() {
@@ -31,24 +37,20 @@ void CompactionScheduler::schedule() {
             _cv.wait_for(lk, 10000ms);
         } else {
             compaction_task->set_compaction_scheduler(this);
-            compaction_task->set_task_id(CompactionManager::instance()->next_compaction_task_id());
-            PriorityThreadPool::Task task;
-            task.work_function = [compaction_task] { compaction_task->start(); };
+            compaction_task->set_task_id(StorageEngine::instance()->compaction_manager()->next_compaction_task_id());
             LOG(INFO) << "submit task to compaction pool"
                       << ", task_id:" << compaction_task->task_id()
                       << ", tablet_id:" << compaction_task->tablet()->tablet_id()
                       << ", compaction type:" << compaction_task->compaction_type()
                       << ", compaction score:" << compaction_task->compaction_score() << " for round:" << _round;
-            bool ret = _compaction_pool.try_offer(task);
-            if (!ret) {
-                LOG(WARNING) << "submit compaction task to compaction pool failed."
-                             << ", pool queue size:" << _compaction_pool.get_queue_size()
-                             << ", queue capacity:" << _compaction_pool.get_queue_capacity();
+            auto st = _compaction_pool->submit_func([compaction_task] { compaction_task->start(); });
+            if (!st.ok()) {
+                LOG(WARNING) << "submit compaction task to compaction pool failed. status:" << st.to_string();
                 compaction_task->tablet()->reset_compaction(compaction_task->compaction_type());
                 CompactionCandidate candidate;
                 candidate.tablet = compaction_task->tablet();
                 candidate.type = compaction_task->compaction_type();
-                CompactionManager::instance()->update_candidates({candidate});
+                StorageEngine::instance()->compaction_manager()->update_candidates({candidate});
             }
         }
     }
@@ -64,8 +66,9 @@ bool CompactionScheduler::_can_schedule_next() {
                                     static_cast<int32_t>(StorageEngine::instance()->get_store_num() *
                                                          (config::cumulative_compaction_num_threads_per_disk +
                                                           config::base_compaction_num_threads_per_disk)));
-    return config::enable_compaction && CompactionManager::instance()->running_tasks_num() < max_task_num &&
-           CompactionManager::instance()->candidates_size() > 0;
+    return config::enable_compaction &&
+           StorageEngine::instance()->compaction_manager()->running_tasks_num() < max_task_num &&
+           StorageEngine::instance()->compaction_manager()->candidates_size() > 0;
 }
 
 void CompactionScheduler::_wait_to_run() {
@@ -74,6 +77,7 @@ void CompactionScheduler::_wait_to_run() {
     while (!_cv.wait_for(lk, 5000ms, [this] { return _can_schedule_next(); })) {
     }
 }
+
 bool CompactionScheduler::_can_do_compaction_task(Tablet* tablet, CompactionTask* compaction_task) {
     // create new compaction task successfully
     DCHECK(tablet);
@@ -87,7 +91,8 @@ bool CompactionScheduler::_can_do_compaction_task(Tablet* tablet, CompactionTask
     // to compatible with old compaction framework
     // TODO: can be optimized to use just one lock
     int64_t last_failure_ms = 0;
-    uint16_t task_num = CompactionManager::instance()->running_tasks_num_for_type(compaction_task->compaction_type());
+    uint16_t task_num = StorageEngine::instance()->compaction_manager()->running_tasks_num_for_type(
+            compaction_task->compaction_type());
     DataDir* data_dir = tablet->data_dir();
     if (compaction_task->compaction_type() == CUMULATIVE_COMPACTION) {
         if (config::max_cumulative_compaction_task >= 0 && task_num >= config::max_cumulative_compaction_task) {
@@ -103,7 +108,7 @@ bool CompactionScheduler::_can_do_compaction_task(Tablet* tablet, CompactionTask
         // control the concurrent running tasks's limit
         // just try best here for that there may be concurrent CompactionSchedulers
         // hard limit will be checked when CompactionManager::register()
-        uint16_t num = CompactionManager::instance()->running_cumulative_tasks_num_for_dir(data_dir);
+        uint16_t num = StorageEngine::instance()->compaction_manager()->running_cumulative_tasks_num_for_dir(data_dir);
         if (config::cumulative_compaction_num_threads_per_disk >= 0 &&
             num >= config::cumulative_compaction_num_threads_per_disk) {
             LOG(INFO) << "skip tablet:" << tablet->tablet_id()
@@ -123,7 +128,7 @@ bool CompactionScheduler::_can_do_compaction_task(Tablet* tablet, CompactionTask
             LOG(INFO) << "skip tablet:" << tablet->tablet_id() << " for base lock";
             return false;
         }
-        uint16_t num = CompactionManager::instance()->running_base_tasks_num_for_dir(data_dir);
+        uint16_t num = StorageEngine::instance()->compaction_manager()->running_base_tasks_num_for_dir(data_dir);
         if (config::base_compaction_num_threads_per_disk >= 0 && num >= config::base_compaction_num_threads_per_disk) {
             LOG(INFO) << "skip tablet:" << tablet->tablet_id()
                       << " for limit of base compaction task per disk. disk path:" << data_dir->path()
@@ -163,20 +168,6 @@ bool CompactionScheduler::_check_precondition(const CompactionCandidate& candida
         LOG(INFO) << "skip tablet:" << tablet->tablet_id() << " because tablet state is:" << tablet->tablet_state()
                   << ", not RUNNING";
         return false;
-    }
-
-    // check for alter task for safety
-    // maybe this logic can be removed if tablet is the schema change dest tablet, need_compaction will never return true
-    AlterTabletTaskSharedPtr cur_alter_task = tablet->alter_task();
-    if (cur_alter_task != nullptr && cur_alter_task->alter_state() != ALTER_FINISHED &&
-        cur_alter_task->alter_state() != ALTER_FAILED) {
-        TabletManager* tablet_manager = StorageEngine::instance()->tablet_manager();
-        TabletSharedPtr related_tablet = tablet_manager->get_tablet(cur_alter_task->related_tablet_id());
-        if (related_tablet != nullptr && tablet->creation_time() > related_tablet->creation_time()) {
-            // Current tablet is newly created during schema-change or rollup, skip it
-            LOG(INFO) << "skip tablet:" << tablet->tablet_id() << " because it is newly-created for schema change";
-            return false;
-        }
     }
 
     std::shared_ptr<CompactionTask> compaction_task = tablet->get_compaction(candidate.type, false);
@@ -226,7 +217,7 @@ bool CompactionScheduler::_can_do_compaction(const CompactionCandidate& candidat
 
 std::shared_ptr<CompactionTask> CompactionScheduler::_try_get_next_compaction_task() {
     VLOG(2) << "try to get next qualified tablet for round:" << _round
-            << ", current candidates size:" << CompactionManager::instance()->candidates_size();
+            << ", current candidates size:" << StorageEngine::instance()->compaction_manager()->candidates_size();
     // tmp_tablets save the tmp picked candidates tablets
     std::vector<CompactionCandidate> tmp_candidates;
     CompactionCandidate compaction_candidate;
@@ -237,7 +228,7 @@ std::shared_ptr<CompactionTask> CompactionScheduler::_try_get_next_compaction_ta
             VLOG(2) << "_can_schedule_next is false. skip";
             break;
         }
-        compaction_candidate = CompactionManager::instance()->pick_candidate();
+        compaction_candidate = StorageEngine::instance()->compaction_manager()->pick_candidate();
         VLOG(2) << "get candidate:" << compaction_candidate.to_string();
         if (!compaction_candidate.is_valid()) {
             // means there no candidate tablet, break
@@ -258,7 +249,7 @@ std::shared_ptr<CompactionTask> CompactionScheduler::_try_get_next_compaction_ta
         }
     }
     VLOG(2) << "tmp tablets size:" << tmp_candidates.size();
-    CompactionManager::instance()->insert_candidates(std::move(tmp_candidates));
+    StorageEngine::instance()->compaction_manager()->insert_candidates(std::move(tmp_candidates));
     if (found) {
         VLOG(2) << "get a qualified tablet:" << compaction_candidate.tablet->tablet_id()
                 << ", compaction type:" << to_string(compaction_candidate.type)

--- a/be/src/storage/compaction_scheduler.cpp
+++ b/be/src/storage/compaction_scheduler.cpp
@@ -5,6 +5,7 @@
 #include <chrono>
 #include <thread>
 
+#include "storage/compaction_candidate.h"
 #include "storage/compaction_manager.h"
 #include "storage/compaction_task.h"
 #include "storage/data_dir.h"
@@ -24,27 +25,31 @@ void CompactionScheduler::schedule() {
     while (true) {
         ++_round;
         _wait_to_run();
-        Tablet* selected = _try_get_next_tablet();
-        if (!selected) {
+        std::shared_ptr<CompactionTask> compaction_task = _try_get_next_compaction_task();
+        if (!compaction_task) {
             std::unique_lock<std::mutex> lk(_mutex);
             _cv.wait_for(lk, 10000ms);
         } else {
-            std::shared_ptr<CompactionTask> compaction_task = selected->get_compaction(true);
             compaction_task->set_compaction_scheduler(this);
             compaction_task->set_task_id(CompactionManager::instance()->next_compaction_task_id());
             PriorityThreadPool::Task task;
             task.work_function = [compaction_task] { compaction_task->start(); };
-            LOG(INFO) << "start to run compaction."
+            LOG(INFO) << "submit task to compaction pool"
                       << ", task_id:" << compaction_task->task_id()
                       << ", tablet_id:" << compaction_task->tablet()->tablet_id()
-                      << ", compaction score:" << selected->compaction_score() << " for round:" << _round;
+                      << ", compaction level:" << (int32_t)compaction_task->compaction_level()
+                      << ", compaction score:" << compaction_task->compaction_score()
+                      << " for round:" << _round;
             bool ret = _compaction_pool.try_offer(task);
             if (!ret) {
                 LOG(WARNING) << "submit compaction task to compaction pool failed."
                              << ", pool queue size:" << _compaction_pool.get_queue_size()
                              << ", queue capacity:" << _compaction_pool.get_queue_capacity();
-                selected->reset_compaction();
-                CompactionManager::instance()->update_candidate(selected);
+                compaction_task->tablet()->reset_compaction(compaction_task->compaction_level());
+                CompactionCandidate candidate;
+                candidate.tablet = compaction_task->tablet();
+                candidate.level = compaction_task->compaction_level();
+                CompactionManager::instance()->update_candidates({candidate});
             }
         }
     }
@@ -65,16 +70,18 @@ bool CompactionScheduler::_can_schedule_next() {
 
 void CompactionScheduler::_wait_to_run() {
     std::unique_lock<std::mutex> lk(_mutex);
-    // check _can_schedule_next every one second to avoid deadlock and support modifying config online
+    // check _can_schedule_next every five second to avoid deadlock and support modifying config online
     while (!_cv.wait_for(lk, 5000ms, [this] { return _can_schedule_next(); })) {
     }
 }
 bool CompactionScheduler::_can_do_compaction_task(Tablet* tablet, CompactionTask* compaction_task) {
     // create new compaction task successfully
+    DCHECK(tablet);
+    DCHECK(compaction_task);
     bool need_reset_task = true;
     DeferOp reset_op([&] {
         if (need_reset_task) {
-            tablet->reset_compaction();
+            tablet->reset_compaction(compaction_task->compaction_level());
         }
     });
     // to compatible with old compaction framework
@@ -82,9 +89,9 @@ bool CompactionScheduler::_can_do_compaction_task(Tablet* tablet, CompactionTask
     int64_t last_failure_ms = 0;
     if (compaction_task->compaction_level() == 0) {
         uint16_t level_num = CompactionManager::instance()->running_tasks_num_for_level(0);
-        if (config::max_level_0_compaction_task >= 0 && level_num >= config::max_level_0_compaction_task) {
+        if (config::max_cumulative_compaction_task >= 0 && level_num >= config::max_cumulative_compaction_task) {
             LOG(INFO) << "skip tablet:" << tablet->tablet_id()
-                      << " for level 0 limit:" << config::max_level_0_compaction_task;
+                      << " for cumulative compaction limit:" << config::max_cumulative_compaction_task;
             return false;
         }
         std::unique_lock lk(tablet->get_cumulative_lock(), std::try_to_lock);
@@ -95,9 +102,9 @@ bool CompactionScheduler::_can_do_compaction_task(Tablet* tablet, CompactionTask
         last_failure_ms = tablet->last_cumu_compaction_failure_time();
     } else {
         uint16_t level_num = CompactionManager::instance()->running_tasks_num_for_level(1);
-        if (config::max_level_1_compaction_task >= 0 && level_num >= config::max_level_1_compaction_task) {
+        if (config::max_base_compaction_task >= 0 && level_num >= config::max_base_compaction_task) {
             LOG(INFO) << "skip tablet:" << tablet->tablet_id()
-                      << " for level 1 limit:" << config::max_level_1_compaction_task;
+                      << " for base compaction limit:" << config::max_base_compaction_task;
             return false;
         }
         std::unique_lock lk(tablet->get_base_lock(), std::try_to_lock);
@@ -132,12 +139,13 @@ bool CompactionScheduler::_can_do_compaction_task(Tablet* tablet, CompactionTask
     return true;
 }
 
-bool CompactionScheduler::_check_precondition(Tablet* tablet) {
-    if (!tablet) {
+bool CompactionScheduler::_check_precondition(const CompactionCandidate& candidate) {
+    if (!candidate.tablet) {
         LOG(WARNING) << "null tablet";
         return false;
     }
-    if (!tablet->need_compaction()) {
+    const TabletSharedPtr& tablet = candidate.tablet;
+    if (!tablet->need_compaction(candidate.level)) {
         // check need compaction
         // if it is false, skip this tablet and remove it from candidate
         LOG(INFO) << "skip tablet:" << tablet->tablet_id() << " because need_compaction is false";
@@ -145,7 +153,8 @@ bool CompactionScheduler::_check_precondition(Tablet* tablet) {
     }
 
     if (tablet->tablet_state() != TABLET_RUNNING) {
-        LOG(INFO) << "skip tablet:" << tablet->tablet_id() << " because tablet state is not RUNNING";
+        LOG(INFO) << "skip tablet:" << tablet->tablet_id() << " because tablet state is:" << tablet->tablet_state()
+                  << ", not RUNNING";
         return false;
     }
 
@@ -163,7 +172,7 @@ bool CompactionScheduler::_check_precondition(Tablet* tablet) {
         }
     }
 
-    std::shared_ptr<CompactionTask> compaction_task = tablet->get_compaction(false);
+    std::shared_ptr<CompactionTask> compaction_task = tablet->get_compaction(candidate.level, false);
     if (compaction_task) {
         // tablet already has a running compaction task, skip it
         LOG(INFO) << "skip tablet:" << tablet->tablet_id()
@@ -173,27 +182,33 @@ bool CompactionScheduler::_check_precondition(Tablet* tablet) {
     return true;
 }
 
-bool CompactionScheduler::_can_do_compaction(Tablet* tablet, bool* need_reschedule) {
+bool CompactionScheduler::_can_do_compaction(const CompactionCandidate& candidate, bool* need_reschedule,
+                                             std::shared_ptr<CompactionTask>* compaction_task) {
+    DCHECK(compaction_task);
     // when the following conditions fail, should not reschedule the candidate tablet
     *need_reschedule = false;
-    bool precondition_ok = _check_precondition(tablet);
+    bool precondition_ok = _check_precondition(candidate);
     if (!precondition_ok) {
         return false;
     }
 
     // when the following conditions fail, should reschedule the candidate tablet
     *need_reschedule = true;
-    DataDir* data_dir = tablet->data_dir();
-    if (data_dir->reach_capacity_limit(0)) {
-        LOG(WARNING) << "skip tablet:" << tablet->tablet_id() << " because data dir reaches capacity limit";
-        return false;
-    }
-
     // create a new compaction task
-    std::shared_ptr<CompactionTask> compaction_task = tablet->get_compaction(true);
-
-    if (compaction_task) {
-        bool can_do = _can_do_compaction_task(tablet, compaction_task.get());
+    const TabletSharedPtr& tablet = candidate.tablet;
+    std::shared_ptr<CompactionTask> tmp_task = tablet->get_compaction(candidate.level, true);
+    if (tmp_task) {
+        DataDir* data_dir = tablet->data_dir();
+        if (data_dir->reach_capacity_limit(tmp_task->input_rowsets_size())) {
+            LOG(WARNING) << "skip tablet:" << tablet->tablet_id()
+                         << " because data dir reaches capacity limit. input rowsets size:"
+                         << tmp_task->input_rowsets_size();
+            return false;
+        }
+        bool can_do = _can_do_compaction_task(tablet.get(), tmp_task.get());
+        if (can_do) {
+            *compaction_task = std::move(tmp_task);
+        }
         *need_reschedule = !can_do;
         return can_do;
     } else {
@@ -202,37 +217,46 @@ bool CompactionScheduler::_can_do_compaction(Tablet* tablet, bool* need_reschedu
     }
 }
 
-Tablet* CompactionScheduler::_try_get_next_tablet() {
-    VLOG(2) << "try to get next qualified tablet for round:" << _round;
+std::shared_ptr<CompactionTask> CompactionScheduler::_try_get_next_compaction_task() {
+    VLOG(2) << "try to get next qualified tablet for round:" << _round
+            << ", current candidates size:" << CompactionManager::instance()->candidates_size();
     // tmp_tablets save the tmp picked candidates tablets
-    std::vector<Tablet*> tmp_tablets;
-    Tablet* tablet = nullptr;
+    std::vector<CompactionCandidate> tmp_candidates;
+    CompactionCandidate compaction_candidate;
     bool found = false;
+    std::shared_ptr<CompactionTask> compaction_task;
     while (true) {
         if (!_can_schedule_next()) {
             VLOG(2) << "_can_schedule_next is false. skip";
             break;
         }
-        tablet = CompactionManager::instance()->pick_candidate();
-        if (!tablet) {
+        compaction_candidate = CompactionManager::instance()->pick_candidate();
+        VLOG(2) << "get candidate:" << compaction_candidate.to_string();
+        if (!compaction_candidate.is_valid()) {
             // means there no candidate tablet, break
+            LOG(INFO) << "do not get a qualified candidate";
             break;
         }
-        VLOG(2) << "try tablet:" << tablet->tablet_id();
+        VLOG(2) << "try tablet:" << compaction_candidate.tablet->tablet_id()
+                << ", level:" << (int32_t)compaction_candidate.level;
         bool need_reschedule = true;
-        found = _can_do_compaction(tablet, &need_reschedule);
+        found = _can_do_compaction(compaction_candidate, &need_reschedule, &compaction_task);
         if (need_reschedule) {
-            tmp_tablets.push_back(tablet);
+            tmp_candidates.emplace_back(std::move(compaction_candidate));
+        } else {
+            DCHECK(found);
         }
         if (found) {
             break;
         }
     }
-    VLOG(2) << "tmp tablets size:" << tmp_tablets.size();
-    CompactionManager::instance()->insert_candidates(tmp_tablets);
+    VLOG(2) << "tmp tablets size:" << tmp_candidates.size();
+    CompactionManager::instance()->insert_candidates(std::move(tmp_candidates));
     if (found) {
-        VLOG(2) << "get a qualified tablet:" << tablet->tablet_id();
-        return tablet;
+        VLOG(2) << "get a qualified tablet:" << compaction_candidate.tablet->tablet_id()
+                << ", level:" << (int32_t)compaction_candidate.level
+                << ", compaction task:" << compaction_task->get_task_info();
+        return compaction_task;
     } else {
         VLOG(2) << "no qualified tablet.";
         return nullptr;

--- a/be/src/storage/compaction_scheduler.h
+++ b/be/src/storage/compaction_scheduler.h
@@ -1,0 +1,53 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#pragma once
+
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <vector>
+
+#include "storage/olap_common.h"
+#include "storage/rowset/rowset.h"
+#include "util/priority_thread_pool.hpp"
+
+namespace starrocks {
+
+class Tablet;
+class DataDir;
+class CompactionTask;
+
+// to schedule tablet to run compaction task
+class CompactionScheduler {
+public:
+    CompactionScheduler();
+    ~CompactionScheduler() = default;
+
+    void schedule();
+
+    void notify();
+
+private:
+    // wait until current running tasks are below max_concurrent_num
+    void _wait_to_run();
+
+    bool _can_schedule_next();
+
+    Tablet* _try_get_next_tablet();
+
+    bool _can_do_compaction(Tablet* tablet, bool* need_reschedule);
+
+    // if check fails, should not reschedule the tablet
+    bool _check_precondition(Tablet* tablet);
+
+    bool _can_do_compaction_task(Tablet* tablet, CompactionTask* compaction_task);
+
+private:
+    PriorityThreadPool _compaction_pool;
+
+    std::mutex _mutex;
+    std::condition_variable _cv;
+    uint64_t _round;
+};
+
+} // namespace starrocks

--- a/be/src/storage/compaction_scheduler.h
+++ b/be/src/storage/compaction_scheduler.h
@@ -9,13 +9,14 @@
 
 #include "storage/olap_common.h"
 #include "storage/rowset/rowset.h"
+#include "storage/tablet.h"
 #include "util/priority_thread_pool.hpp"
 
 namespace starrocks {
 
-class Tablet;
 class DataDir;
 class CompactionTask;
+class CompactionCandidate;
 
 // to schedule tablet to run compaction task
 class CompactionScheduler {
@@ -33,12 +34,13 @@ private:
 
     bool _can_schedule_next();
 
-    Tablet* _try_get_next_tablet();
+    std::shared_ptr<CompactionTask> _try_get_next_compaction_task();
 
-    bool _can_do_compaction(Tablet* tablet, bool* need_reschedule);
+    bool _can_do_compaction(const CompactionCandidate& candidate, bool* need_reschedule,
+                            std::shared_ptr<CompactionTask>* compaction_task);
 
     // if check fails, should not reschedule the tablet
-    bool _check_precondition(Tablet* tablet);
+    bool _check_precondition(const CompactionCandidate& candidate);
 
     bool _can_do_compaction_task(Tablet* tablet, CompactionTask* compaction_task);
 

--- a/be/src/storage/compaction_scheduler.h
+++ b/be/src/storage/compaction_scheduler.h
@@ -10,7 +10,7 @@
 #include "storage/olap_common.h"
 #include "storage/rowset/rowset.h"
 #include "storage/tablet.h"
-#include "util/priority_thread_pool.hpp"
+#include "util/threadpool.h"
 
 namespace starrocks {
 
@@ -45,7 +45,7 @@ private:
     bool _can_do_compaction_task(Tablet* tablet, CompactionTask* compaction_task);
 
 private:
-    PriorityThreadPool _compaction_pool;
+    std::unique_ptr<ThreadPool> _compaction_pool;
 
     std::mutex _mutex;
     std::condition_variable _cv;

--- a/be/src/storage/compaction_task.cpp
+++ b/be/src/storage/compaction_task.cpp
@@ -1,0 +1,148 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+#include "storage/compaction_task.h"
+
+#include "runtime/current_thread.h"
+#include "storage/compaction_manager.h"
+#include "storage/compaction_scheduler.h"
+#include "storage/storage_engine.h"
+#include "util/scoped_cleanup.h"
+#include "util/time.h"
+#include "util/trace.h"
+
+namespace starrocks {
+
+void CompactionTask::run() {
+    LOG(INFO) << "start compaction. task_id:" << _task_info.task_id << ", tablet:" << _task_info.tablet_id
+              << ", algorithm:" << algorithm_to_string(_task_info.algorithm)
+              << ", compaction_level:" << (int)_task_info.compaction_level
+              << ", compaction_score:" << _task_info.compaction_score
+              << ", output_version:" << _task_info.output_version << ", input rowsets size:" << _input_rowsets.size();
+    _task_info.start_time = UnixMillis();
+    scoped_refptr<Trace> trace(new Trace);
+    SCOPED_CLEANUP({
+        uint64_t time_s = _watch.elapsed_time() / 1e9;
+        if ((compaction_level() == 0 && time_s > config::cumulative_compaction_trace_threshold) ||
+            (compaction_level() == 1 && time_s > config::base_compaction_trace_threshold)) {
+            LOG(INFO) << "Trace:" << std::endl << trace->DumpToString(Trace::INCLUDE_ALL);
+        }
+    });
+    ADOPT_TRACE(trace.get());
+    TRACE("[Compaction] start to perform compaction. task_id:$0, tablet:$1, algorithm::$2, compaction_level:$3, "
+          "compaction_score:$4",
+          _task_info.task_id, _task_info.tablet_id, algorithm_to_string(_task_info.algorithm),
+          (int)_task_info.compaction_level, _task_info.compaction_score);
+    std::stringstream ss;
+    ss << "output version:" << _task_info.output_version << ", input rowsets size:" << _input_rowsets.size()
+       << ", input versions:";
+
+    for (int i = 0; i < 5 && i < _input_rowsets.size(); ++i) {
+        ss << _input_rowsets[i]->version() << ";";
+    }
+    if (_input_rowsets.size() > 5) {
+        ss << ".." << (*_input_rowsets.rbegin())->version();
+    }
+    TRACE("[Compaction] $0", ss.str());
+    TRACE_COUNTER_INCREMENT("input_rowsets_count", _input_rowsets.size());
+    TRACE_COUNTER_INCREMENT("input_rowsets_data_size", _task_info.input_rowsets_size);
+    TRACE_COUNTER_INCREMENT("input_row_num", _task_info.input_rows_num);
+    TRACE_COUNTER_INCREMENT("input_segments_num", _task_info.input_segments_num);
+    SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_mem_tracker);
+
+    bool is_finished = false;
+    DeferOp op([&] {
+        TRACE("[Compaction] do compaction callback.");
+        if (!is_finished) {
+            set_compaction_task_state(COMPACTION_FAILED);
+        }
+        // reset compaction before judge need_compaction again
+        // because if there is a compaction task in a tablet, it will not be able to run another one
+        _tablet->reset_compaction();
+        _task_info.end_time = UnixMillis();
+        CompactionManager::instance()->unregister_task(this);
+        if (_tablet->need_compaction()) {
+            LOG(INFO) << "tablet:" << _tablet->tablet_id() << " compaction finished. and should do compaction again";
+            TRACE("[Compaction] compaction task finished. and will do compaction again.");
+            CompactionManager::instance()->update_candidate(_tablet);
+        }
+        // must be put after unregister_task
+        _scheduler->notify();
+        TRACE("[Compaction] $0", _task_info.to_string());
+    });
+    if (should_stop()) {
+        // should add task id to log
+        LOG(INFO) << "compaction task" << _task_info.task_id << " is stopped.";
+        return;
+    }
+
+    set_compaction_task_state(COMPACTION_RUNNING);
+    bool registered = CompactionManager::instance()->register_task(this);
+    if (!registered) {
+        LOG(WARNING) << "register compaction task failed. task_id:" << _task_info.task_id
+                     << ", tablet:" << _task_info.tablet_id;
+        return;
+    }
+    TRACE("[Compaction] compaction registered");
+
+    _try_lock();
+    if (!_compaction_lock.owns_lock()) {
+        return;
+    }
+    TRACE("[Compaction] got compaction lock");
+
+    Status status = run_impl();
+    if (status.ok()) {
+        _success_callback();
+    } else {
+        _failure_callback();
+    }
+    _watch.stop();
+    _task_info.end_time = UnixMillis();
+    // get elapsed_time in us
+    _task_info.elapsed_time = _watch.elapsed_time() / 1000;
+    is_finished = true;
+    LOG(INFO) << "compaction finish. status:" << status.to_string() << ", task info:" << _task_info.to_string();
+}
+
+bool CompactionTask::should_stop() const {
+    return StorageEngine::instance()->bg_worker_stopped() || !config::enable_compaction || BackgroudTask::should_stop();
+}
+
+void CompactionTask::_success_callback() {
+    set_compaction_task_state(COMPACTION_SUCCESS);
+    // for compatible, update compaction time
+    if (_task_info.compaction_level == 0) {
+        _tablet->set_last_cumu_compaction_success_time(UnixMillis());
+    } else {
+        _tablet->set_last_base_compaction_success_time(UnixMillis());
+    }
+
+    // for compatible
+    if (_task_info.compaction_level == 0) {
+        StarRocksMetrics::instance()->cumulative_compaction_deltas_total.increment(_input_rowsets.size());
+        StarRocksMetrics::instance()->cumulative_compaction_bytes_total.increment(_task_info.input_rowsets_size);
+    } else {
+        StarRocksMetrics::instance()->base_compaction_deltas_total.increment(_input_rowsets.size());
+        StarRocksMetrics::instance()->base_compaction_bytes_total.increment(_task_info.input_rowsets_size);
+    }
+
+    // preload the rowset
+    // warm-up this rowset
+    auto st = _output_rowset->load();
+    if (!st.ok()) {
+        // only log load failure
+        LOG(WARNING) << "ignore load rowset error tablet:" << _tablet->tablet_id()
+                     << ", rowset:" << _output_rowset->rowset_id() << ", status:" << st;
+    }
+}
+
+void CompactionTask::_failure_callback() {
+    set_compaction_task_state(COMPACTION_FAILED);
+    if (_task_info.compaction_level == 0) {
+        _tablet->set_last_cumu_compaction_failure_time(UnixMillis());
+    } else {
+        _tablet->set_last_base_compaction_failure_time(UnixMillis());
+    }
+    LOG(WARNING) << "compaction task:" << _task_info.task_id << ", tablet:" << _task_info.tablet_id << " failed.";
+}
+
+} // namespace starrocks

--- a/be/src/storage/compaction_task.cpp
+++ b/be/src/storage/compaction_task.cpp
@@ -60,10 +60,10 @@ void CompactionTask::run() {
         // it will not be able to run another one for that type
         _tablet->reset_compaction(compaction_type());
         _task_info.end_time = UnixMillis();
-        CompactionManager::instance()->unregister_task(this);
+        StorageEngine::instance()->compaction_manager()->unregister_task(this);
         // compaction context has been updated when commit
         // so do not update context here
-        CompactionManager::instance()->update_tablet_async(_tablet, false, true);
+        StorageEngine::instance()->compaction_manager()->update_tablet_async(_tablet, false, true);
         // must be put after unregister_task
         _scheduler->notify();
         TRACE("[Compaction] $0", _task_info.to_string());
@@ -74,7 +74,7 @@ void CompactionTask::run() {
     }
 
     set_compaction_task_state(COMPACTION_RUNNING);
-    bool registered = CompactionManager::instance()->register_task(this);
+    bool registered = StorageEngine::instance()->compaction_manager()->register_task(this);
     if (!registered) {
         LOG(WARNING) << "register compaction task failed. task_id:" << _task_info.task_id
                      << ", tablet:" << _task_info.tablet_id;

--- a/be/src/storage/compaction_task.cpp
+++ b/be/src/storage/compaction_task.cpp
@@ -13,7 +13,7 @@ namespace starrocks {
 
 void CompactionTask::run() {
     LOG(INFO) << "start compaction. task_id:" << _task_info.task_id << ", tablet:" << _task_info.tablet_id
-              << ", algorithm:" << algorithm_to_string(_task_info.algorithm)
+              << ", algorithm:" << CompactionUtils::compaction_algorithm_to_string(_task_info.algorithm)
               << ", compaction_level:" << (int)_task_info.compaction_level
               << ", compaction_score:" << _task_info.compaction_score
               << ", output_version:" << _task_info.output_version << ", input rowsets size:" << _input_rowsets.size();
@@ -29,8 +29,9 @@ void CompactionTask::run() {
     ADOPT_TRACE(trace.get());
     TRACE("[Compaction] start to perform compaction. task_id:$0, tablet:$1, algorithm::$2, compaction_level:$3, "
           "compaction_score:$4",
-          _task_info.task_id, _task_info.tablet_id, algorithm_to_string(_task_info.algorithm),
-          (int)_task_info.compaction_level, _task_info.compaction_score);
+          _task_info.task_id, _task_info.tablet_id,
+          CompactionUtils::compaction_algorithm_to_string(_task_info.algorithm), (int)_task_info.compaction_level,
+          _task_info.compaction_score);
     std::stringstream ss;
     ss << "output version:" << _task_info.output_version << ", input rowsets size:" << _input_rowsets.size()
        << ", input versions:";

--- a/be/src/storage/compaction_task.h
+++ b/be/src/storage/compaction_task.h
@@ -1,0 +1,275 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+#pragma once
+
+#include <mutex>
+#include <sstream>
+#include <vector>
+
+#include "storage/backgroud_task.h"
+#include "storage/compaction_utils.h"
+#include "storage/olap_common.h"
+#include "storage/rowset/rowset.h"
+#include "storage/tablet.h"
+#include "util/runtime_profile.h"
+#include "util/time.h"
+
+namespace starrocks {
+
+class CompactionScheduler;
+
+enum CompactionTaskState { COMPACTION_INIT, COMPACTION_RUNNING, COMPACTION_FAILED, COMPACTION_SUCCESS };
+
+static const char* compaction_state_to_string(CompactionTaskState state) {
+    switch (state) {
+    case COMPACTION_INIT:
+        return "COMPACTION_INIT";
+    case COMPACTION_RUNNING:
+        return "COMPACTION_RUNNING";
+    case COMPACTION_FAILED:
+        return "COMPACTION_FAILED";
+    case COMPACTION_SUCCESS:
+        return "COMPACTION_SUCCESS";
+    default:
+        return "UNKNOWN_STATE";
+    }
+}
+
+struct CompactionTaskInfo {
+    CompactionTaskInfo(CompactionAlgorithm algo)
+            : algorithm(algo),
+              state(COMPACTION_INIT),
+              task_id(0),
+              elapsed_time(0),
+              start_time(0),
+              end_time(0),
+              output_segments_num(0),
+              output_rowset_size(0),
+              merged_rows(0),
+              filtered_rows(0),
+              output_num_rows(0),
+              column_group_size(0),
+              total_output_num_rows(0),
+              total_merged_rows(0),
+              total_del_filtered_rows(0) {}
+    CompactionAlgorithm algorithm;
+    CompactionTaskState state;
+    uint64_t task_id;
+    Version output_version;
+    uint64_t elapsed_time;
+    int64_t tablet_id;
+    double compaction_score;
+    int64_t start_time;
+    int64_t end_time;
+    size_t input_rows_num;
+    uint32_t input_rowsets_num;
+    size_t input_rowsets_size;
+    size_t input_segments_num;
+    uint32_t segment_iterator_num;
+    uint32_t output_segments_num;
+    uint32_t output_rowset_size;
+    size_t merged_rows;
+    size_t filtered_rows;
+    size_t output_num_rows;
+    uint8_t compaction_level;
+
+    // for vertical compaction
+    size_t column_group_size;
+    size_t total_output_num_rows;
+    size_t total_merged_rows;
+    size_t total_del_filtered_rows;
+
+    // return [0-100] to indicate progress
+    int get_progress() const {
+        if (input_rows_num == 0) {
+            return 100;
+        }
+        if (algorithm == HORIZONTAL_COMPACTION) {
+            return (output_num_rows + merged_rows + filtered_rows) * 100 / input_rows_num;
+        } else {
+            if (column_group_size == 0) {
+                return 0;
+            }
+            return (total_output_num_rows + total_merged_rows + total_del_filtered_rows) * 100 /
+                   (input_rows_num * column_group_size);
+        }
+    }
+
+    std::string to_string() const {
+        std::stringstream ss;
+        ss << "[CompactionTaskInfo]";
+        ss << " task_id:" << task_id;
+        ss << ", tablet_id:" << tablet_id;
+        ss << ", compaction score:" << compaction_score;
+        ss << ", algorithm:" << algorithm_to_string(algorithm);
+        ss << ", state:" << compaction_state_to_string(state);
+        ss << ", compaction_level:" << (int32_t)compaction_level;
+        ss << ", output_version:" << output_version;
+        ss << ", start_time:" << ToStringFromUnixMillis(start_time);
+        ss << ", end_time:" << ToStringFromUnixMillis(end_time);
+        ss << ", elapsed_time:" << elapsed_time << " us";
+        ss << ", input_rowsets_size:" << input_rowsets_size;
+        ss << ", input_segments_num:" << input_segments_num;
+        ss << ", input_rowsets_num:" << input_rowsets_num;
+        ss << ", input_rows_num:" << input_rows_num;
+        ss << ", output_num_rows:" << output_num_rows;
+        ss << ", merged_rows:" << merged_rows;
+        ss << ", filtered_rows:" << filtered_rows;
+        ss << ", output_segments_num:" << output_segments_num;
+        ss << ", output_rowset_size:" << output_rowset_size;
+        ss << ", column_group_size:" << column_group_size;
+        ss << ", total_output_num_rows:" << total_output_num_rows;
+        ss << ", total_merged_rows:" << total_merged_rows;
+        ss << ", total_del_filtered_rows:" << total_del_filtered_rows;
+        ss << ", progress:" << get_progress();
+        return ss.str();
+    }
+};
+
+class CompactionTask : public BackgroudTask {
+public:
+    CompactionTask(CompactionAlgorithm algorithm)
+            : _task_info(algorithm), _runtime_profile("compaction"), _mem_tracker(nullptr) {
+        _watch.start();
+    }
+    virtual ~CompactionTask() {
+        if (_mem_tracker) {
+            delete _mem_tracker;
+        }
+    }
+
+    void run() override;
+
+    bool should_stop() const override;
+
+    void set_input_rowsets(std::vector<RowsetSharedPtr>&& input_rowsets) {
+        _input_rowsets = input_rowsets;
+        _task_info.input_rowsets_num = _input_rowsets.size();
+    }
+
+    void set_compaction_task_state(CompactionTaskState state) { _task_info.state = state; }
+
+    const std::vector<RowsetSharedPtr>& input_rowsets() const { return _input_rowsets; }
+
+    void set_output_version(const Version& version) { _task_info.output_version = version; }
+
+    const Version& output_version() const { return _task_info.output_version; }
+
+    void set_input_rows_num(size_t input_rows_num) { _task_info.input_rows_num = input_rows_num; }
+
+    size_t input_rows_num() const { return _task_info.input_rows_num; }
+
+    void set_input_rowsets_size(size_t input_rowsets_size) { _task_info.input_rowsets_size = input_rowsets_size; }
+
+    size_t input_rowsets_size() const { return _task_info.input_rowsets_size; }
+
+    void set_compaction_level(uint8_t compaction_level) { _task_info.compaction_level = compaction_level; }
+
+    uint8_t compaction_level() const { return _task_info.compaction_level; }
+
+    void set_tablet(Tablet* tablet) {
+        _tablet = tablet;
+        _task_info.tablet_id = _tablet->tablet_id();
+    }
+
+    Tablet* tablet() { return _tablet; }
+
+    void set_task_id(uint64_t task_id) { _task_info.task_id = task_id; }
+
+    uint64_t task_id() { return _task_info.task_id; }
+
+    void set_compaction_score(double compaction_score) { _task_info.compaction_score = compaction_score; }
+
+    double compaction_score() { return _task_info.compaction_score; }
+
+    void set_segment_iterator_num(size_t segment_iterator_num) {
+        _task_info.segment_iterator_num = segment_iterator_num;
+    }
+
+    size_t segment_iterator_num() { return _task_info.segment_iterator_num; }
+
+    void set_input_segments_num(size_t input_segments_num) { _task_info.input_segments_num = input_segments_num; }
+
+    void set_start_time(int64_t start_time) { _task_info.start_time = start_time; }
+
+    void set_end_time(int64_t end_time) { _task_info.end_time = end_time; }
+
+    void set_output_segments_num(uint32_t output_segments_num) { _task_info.output_segments_num = output_segments_num; }
+
+    void set_output_rowset_size(uint32_t output_rowset_size) { _task_info.output_rowset_size = output_rowset_size; }
+
+    void set_merged_rows(size_t merged_rows) { _task_info.merged_rows = merged_rows; }
+
+    void set_filtered_rows(size_t filtered_rows) { _task_info.filtered_rows = filtered_rows; }
+
+    void set_output_num_rows(size_t output_num_rows) { _task_info.output_num_rows = output_num_rows; }
+
+    void set_mem_tracker(MemTracker* mem_tracker) { _mem_tracker = mem_tracker; }
+
+    std::string get_task_info() {
+        _task_info.elapsed_time = _watch.elapsed_time() / 1000;
+        return _task_info.to_string();
+    }
+
+    void set_compaction_scheduler(CompactionScheduler* scheduler) { _scheduler = scheduler; }
+
+protected:
+    virtual Status run_impl() = 0;
+
+    void _try_lock() {
+        if (_task_info.compaction_level == 0) {
+            _compaction_lock = std::unique_lock(_tablet->get_cumulative_lock(), std::try_to_lock);
+        } else {
+            _compaction_lock = std::unique_lock(_tablet->get_base_lock(), std::try_to_lock);
+        }
+    }
+
+    Status _validate_compaction(const Statistics& stats) {
+        // check row number
+        DCHECK(_output_rowset) << "_output_rowset is null";
+        LOG(INFO) << "validate compaction, _input_rows_num:" << _task_info.input_rows_num
+                  << ", output rowset rows:" << _output_rowset->num_rows() << ", merged_rows:" << stats.merged_rows
+                  << ", filtered_rows:" << stats.filtered_rows;
+        if (_task_info.input_rows_num != _output_rowset->num_rows() + stats.merged_rows + stats.filtered_rows) {
+            LOG(WARNING) << "row_num does not match between cumulative input and output! "
+                         << "input_row_num=" << _task_info.input_rows_num << ", merged_row_num=" << stats.merged_rows
+                         << ", filtered_row_num=" << stats.filtered_rows
+                         << ", output_row_num=" << _output_rowset->num_rows();
+
+            return Status::InternalError("compaction check lines error.");
+        }
+        return Status::OK();
+    }
+
+    void _commit_compaction() {
+        std::unique_lock wrlock(_tablet->get_header_lock());
+        std::stringstream input_stream_info;
+        for (int i = 0; i < 5 && i < _input_rowsets.size(); ++i) {
+            input_stream_info << _input_rowsets[i]->version() << ";";
+        }
+        if (_input_rowsets.size() > 5) {
+            input_stream_info << ".." << (*_input_rowsets.rbegin())->version();
+        }
+        _tablet->modify_rowsets({_output_rowset}, _input_rowsets);
+        _tablet->save_meta();
+        LOG(INFO) << "commit compaction. output version:" << _task_info.output_version
+                  << ", output rowset version:" << _output_rowset->version()
+                  << ", input rowsets:" << input_stream_info.str() << ", input rowsets size:" << _input_rowsets.size();
+    }
+
+    void _success_callback();
+
+    void _failure_callback();
+
+protected:
+    CompactionTaskInfo _task_info;
+    RuntimeProfile _runtime_profile;
+    std::vector<RowsetSharedPtr> _input_rowsets;
+    Tablet* _tablet;
+    RowsetSharedPtr _output_rowset;
+    std::unique_lock<std::mutex> _compaction_lock;
+    MonotonicStopWatch _watch;
+    MemTracker* _mem_tracker;
+    CompactionScheduler* _scheduler;
+};
+
+} // namespace starrocks

--- a/be/src/storage/compaction_task.h
+++ b/be/src/storage/compaction_task.h
@@ -70,7 +70,7 @@ struct CompactionTaskInfo {
     size_t merged_rows;
     size_t filtered_rows;
     size_t output_num_rows;
-    int8_t compaction_level;
+    CompactionType compaction_type;
 
     // for vertical compaction
     size_t column_group_size;
@@ -102,7 +102,7 @@ struct CompactionTaskInfo {
         ss << ", compaction score:" << compaction_score;
         ss << ", algorithm:" << CompactionUtils::compaction_algorithm_to_string(algorithm);
         ss << ", state:" << compaction_state_to_string(state);
-        ss << ", compaction_level:" << (int32_t)compaction_level;
+        ss << ", compaction_type:" << compaction_type;
         ss << ", output_version:" << output_version;
         ss << ", start_time:" << ToStringFromUnixMillis(start_time);
         ss << ", end_time:" << ToStringFromUnixMillis(end_time);
@@ -166,9 +166,9 @@ public:
 
     size_t input_rowsets_size() const { return _task_info.input_rowsets_size; }
 
-    void set_compaction_level(int8_t compaction_level) { _task_info.compaction_level = compaction_level; }
+    void set_compaction_type(CompactionType type) { _task_info.compaction_type = type; }
 
-    int8_t compaction_level() const { return _task_info.compaction_level; }
+    CompactionType compaction_type() const { return _task_info.compaction_type; }
 
     void set_tablet(const TabletSharedPtr& tablet) {
         _tablet = tablet;
@@ -220,7 +220,7 @@ protected:
     virtual Status run_impl() = 0;
 
     void _try_lock() {
-        if (_task_info.compaction_level == 0) {
+        if (_task_info.compaction_type == CUMULATIVE_COMPACTION) {
             _compaction_lock = std::unique_lock(_tablet->get_cumulative_lock(), std::try_to_lock);
         } else {
             _compaction_lock = std::unique_lock(_tablet->get_base_lock(), std::try_to_lock);

--- a/be/src/storage/compaction_task.h
+++ b/be/src/storage/compaction_task.h
@@ -70,7 +70,7 @@ struct CompactionTaskInfo {
     size_t merged_rows;
     size_t filtered_rows;
     size_t output_num_rows;
-    uint8_t compaction_level;
+    int8_t compaction_level;
 
     // for vertical compaction
     size_t column_group_size;
@@ -148,6 +148,10 @@ public:
 
     void set_compaction_task_state(CompactionTaskState state) { _task_info.state = state; }
 
+    bool is_compaction_finished() const {
+        return _task_info.state == COMPACTION_FAILED || _task_info.state == COMPACTION_SUCCESS;
+    }
+
     const std::vector<RowsetSharedPtr>& input_rowsets() const { return _input_rowsets; }
 
     void set_output_version(const Version& version) { _task_info.output_version = version; }
@@ -162,16 +166,16 @@ public:
 
     size_t input_rowsets_size() const { return _task_info.input_rowsets_size; }
 
-    void set_compaction_level(uint8_t compaction_level) { _task_info.compaction_level = compaction_level; }
+    void set_compaction_level(int8_t compaction_level) { _task_info.compaction_level = compaction_level; }
 
-    uint8_t compaction_level() const { return _task_info.compaction_level; }
+    int8_t compaction_level() const { return _task_info.compaction_level; }
 
-    void set_tablet(Tablet* tablet) {
+    void set_tablet(const TabletSharedPtr& tablet) {
         _tablet = tablet;
         _task_info.tablet_id = _tablet->tablet_id();
     }
 
-    Tablet* tablet() { return _tablet; }
+    TabletSharedPtr& tablet() { return _tablet; }
 
     void set_task_id(uint64_t task_id) { _task_info.task_id = task_id; }
 
@@ -264,7 +268,7 @@ protected:
     CompactionTaskInfo _task_info;
     RuntimeProfile _runtime_profile;
     std::vector<RowsetSharedPtr> _input_rowsets;
-    Tablet* _tablet;
+    TabletSharedPtr _tablet;
     RowsetSharedPtr _output_rowset;
     std::unique_lock<std::mutex> _compaction_lock;
     MonotonicStopWatch _watch;

--- a/be/src/storage/compaction_task.h
+++ b/be/src/storage/compaction_task.h
@@ -100,7 +100,7 @@ struct CompactionTaskInfo {
         ss << " task_id:" << task_id;
         ss << ", tablet_id:" << tablet_id;
         ss << ", compaction score:" << compaction_score;
-        ss << ", algorithm:" << algorithm_to_string(algorithm);
+        ss << ", algorithm:" << CompactionUtils::compaction_algorithm_to_string(algorithm);
         ss << ", state:" << compaction_state_to_string(state);
         ss << ", compaction_level:" << (int32_t)compaction_level;
         ss << ", output_version:" << output_version;

--- a/be/src/storage/compaction_task_factory.cpp
+++ b/be/src/storage/compaction_task_factory.cpp
@@ -1,0 +1,13 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#include "storage/compaction_task_factory.h"
+
+#include "storage/compaction_task.h"
+
+namespace starrocks {
+
+std::shared_ptr<CompactionTask> CompactionTaskFactory::create_compaction_task() {
+    return nullptr;
+}
+
+} // namespace starrocks

--- a/be/src/storage/compaction_task_factory.h
+++ b/be/src/storage/compaction_task_factory.h
@@ -17,12 +17,12 @@ class CompactionTaskFactory {
 public:
     CompactionTaskFactory(Version output_version, const TabletSharedPtr& tablet,
                           std::vector<RowsetSharedPtr>&& input_rowsets, double compaction_score,
-                          uint8_t compaction_level)
+                          CompactionType compaction_type)
             : _output_version(output_version),
               _tablet(tablet),
               _input_rowsets(std::move(input_rowsets)),
               _compaction_score(compaction_score),
-              _compaction_level(compaction_level) {}
+              _compaction_type(compaction_type) {}
     ~CompactionTaskFactory() = default;
 
     std::shared_ptr<CompactionTask> create_compaction_task();
@@ -32,7 +32,7 @@ private:
     TabletSharedPtr _tablet;
     std::vector<RowsetSharedPtr> _input_rowsets;
     double _compaction_score;
-    uint8_t _compaction_level;
+    CompactionType _compaction_type;
 };
 
 } // namespace starrocks

--- a/be/src/storage/compaction_task_factory.h
+++ b/be/src/storage/compaction_task_factory.h
@@ -1,0 +1,37 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#pragma once
+
+#include <vector>
+
+#include "common/statusor.h"
+#include "storage/olap_common.h"
+#include "storage/rowset/rowset.h"
+
+namespace starrocks {
+
+class Tablet;
+class CompactionTask;
+
+class CompactionTaskFactory {
+public:
+    CompactionTaskFactory(Version output_version, Tablet* tablet, std::vector<RowsetSharedPtr>&& input_rowsets,
+                          double compaction_score, uint8_t compaction_level)
+            : _output_version(output_version),
+              _tablet(tablet),
+              _input_rowsets(std::move(input_rowsets)),
+              _compaction_score(compaction_score),
+              _compaction_level(compaction_level) {}
+    ~CompactionTaskFactory() = default;
+
+    std::shared_ptr<CompactionTask> create_compaction_task();
+
+private:
+    Version _output_version;
+    Tablet* _tablet;
+    std::vector<RowsetSharedPtr> _input_rowsets;
+    double _compaction_score;
+    uint8_t _compaction_level;
+};
+
+} // namespace starrocks

--- a/be/src/storage/compaction_task_factory.h
+++ b/be/src/storage/compaction_task_factory.h
@@ -7,16 +7,17 @@
 #include "common/statusor.h"
 #include "storage/olap_common.h"
 #include "storage/rowset/rowset.h"
+#include "storage/tablet.h"
 
 namespace starrocks {
 
-class Tablet;
 class CompactionTask;
 
 class CompactionTaskFactory {
 public:
-    CompactionTaskFactory(Version output_version, Tablet* tablet, std::vector<RowsetSharedPtr>&& input_rowsets,
-                          double compaction_score, uint8_t compaction_level)
+    CompactionTaskFactory(Version output_version, const TabletSharedPtr& tablet,
+                          std::vector<RowsetSharedPtr>&& input_rowsets, double compaction_score,
+                          uint8_t compaction_level)
             : _output_version(output_version),
               _tablet(tablet),
               _input_rowsets(std::move(input_rowsets)),
@@ -28,7 +29,7 @@ public:
 
 private:
     Version _output_version;
-    Tablet* _tablet;
+    TabletSharedPtr _tablet;
     std::vector<RowsetSharedPtr> _input_rowsets;
     double _compaction_score;
     uint8_t _compaction_level;

--- a/be/src/storage/compaction_utils.cpp
+++ b/be/src/storage/compaction_utils.cpp
@@ -121,4 +121,4 @@ std::unique_ptr<CompactionPolicy> CompactionUtils::create_compaction_policy(Comp
     return nullptr;
 }
 
-} // namespace starrocks 
+} // namespace starrocks

--- a/be/src/storage/compaction_utils.cpp
+++ b/be/src/storage/compaction_utils.cpp
@@ -2,6 +2,8 @@
 
 #include "storage/compaction_utils.h"
 
+#include "storage/compaction_context.h"
+#include "storage/compaction_policy.h"
 #include "storage/rowset/rowset_factory.h"
 #include "storage/rowset/rowset_writer.h"
 #include "storage/rowset/rowset_writer_context.h"
@@ -114,4 +116,9 @@ CompactionAlgorithm CompactionUtils::choose_compaction_algorithm(size_t num_colu
     return VERTICAL_COMPACTION;
 }
 
-} // namespace starrocks
+std::unique_ptr<CompactionPolicy> CompactionUtils::create_compaction_policy(CompactionContext* context) {
+    // now only support LevelCompactionPolicy
+    return nullptr;
+}
+
+} // namespace starrocks 

--- a/be/src/storage/compaction_utils.h
+++ b/be/src/storage/compaction_utils.h
@@ -49,6 +49,8 @@ public:
     // 2. if source_num is less than or equal to 1, or is more than MAX_SOURCES, use HORIZONTAL_COMPACTION.
     static CompactionAlgorithm choose_compaction_algorithm(size_t num_columns, int64_t max_columns_per_group,
                                                            size_t source_num);
+
+    static std::unique_ptr<CompactionPolicy> create_compaction_policy(CompactionContext* context);
 };
 
 } // namespace starrocks

--- a/be/src/storage/compaction_utils.h
+++ b/be/src/storage/compaction_utils.h
@@ -10,6 +10,8 @@
 
 namespace starrocks {
 
+class CompactionPolicy;
+class CompactionContext;
 class RowsetWriter;
 class Tablet;
 

--- a/be/src/storage/level_compaction_policy.cpp
+++ b/be/src/storage/level_compaction_policy.cpp
@@ -1,0 +1,271 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+#include "storage/level_compaction_policy.h"
+
+#include <sstream>
+#include <vector>
+
+#include "storage/compaction_context.h"
+#include "storage/compaction_task.h"
+#include "storage/compaction_task_factory.h"
+#include "storage/rowset/rowset.h"
+#include "util/time.h"
+
+namespace starrocks {
+
+// should calculate the compaction score of each level
+bool LevelCompactionPolicy::need_compaction() {
+    _compaction_context->cumulative_score = _get_cumulative_compaction_score();
+    _compaction_context->base_score = _get_base_compaction_score();
+
+    VLOG(2) << "need_compaction compaction context:" << _compaction_context->to_string();
+    // for max_compaction_score is double type, use 0.999 instead of 1
+    return _compaction_context->cumulative_score > COMPACTION_SCORE_THRESHOLD ||
+           _compaction_context->base_score > COMPACTION_SCORE_THRESHOLD;
+}
+
+// // create CompactionTask for chosen_compaction_type in _compaction_context
+std::shared_ptr<CompactionTask> LevelCompactionPolicy::create_compaction() {
+    // return nullptr if can not find enough rowsets
+    VLOG(2) << "compaction context:" << _compaction_context->to_string();
+    if (_compaction_context->chosen_compaction_type == CUMULATIVE_COMPACTION) {
+        return _create_cumulative_compaction();
+    } else if (_compaction_context->chosen_compaction_type == BASE_COMPACTION) {
+        return _create_base_compaction();
+    } else {
+        LOG(WARNING) << "invalid compaction type:" << _compaction_context->chosen_compaction_type
+                     << ", tablet:" << _compaction_context->tablet->tablet_id();
+    }
+    return nullptr;
+}
+
+// the first rowset in level-0 may be compacted already, and the creation_time may be larger than
+// the rowsets behind. when pick level-0 rowsets, the first compacted rowset should be picked no matter
+// whether the creation time is older enough.
+bool LevelCompactionPolicy::_is_rowset_creation_time_ordered(
+        const std::set<Rowset*, RowsetComparator>& cumulative_rowsets) {
+    if (cumulative_rowsets.size() <= 1) {
+        return true;
+    }
+    // the compacted rowset can only be the first one, so just compare the first two rowsets
+    auto iter = cumulative_rowsets.begin();
+    Rowset* first_rowset = *iter;
+    Rowset* second_rowset = *(++iter);
+    return first_rowset->creation_time() <= second_rowset->creation_time();
+}
+
+void LevelCompactionPolicy::_pick_cumulative_rowsets(bool* has_delete_version, size_t* rowsets_compaction_score,
+                                                     std::vector<RowsetSharedPtr>* rowsets) {
+    int64_t now = UnixSeconds();
+    if (_compaction_context->rowset_levels[0].size() == 0) {
+        return;
+    }
+    bool is_creation_time_ordered = _is_rowset_creation_time_ordered(_compaction_context->rowset_levels[0]);
+    int index = 0;
+    for (auto rowset : _compaction_context->rowset_levels[0]) {
+        if (_compaction_context->tablet->version_for_delete_predicate(rowset->version())) {
+            *has_delete_version = true;
+            break;
+        }
+        // For level-0, should consider the rowset creation time.
+        // newly-created rowsets should be skipped.
+        if ((is_creation_time_ordered || (!is_creation_time_ordered && index != 0)) &&
+            rowset->creation_time() + config::cumulative_compaction_skip_window_seconds > now) {
+            // rowset in rowset_levels is ordered
+            LOG(INFO) << "rowset:" << rowset->rowset_id() << ", version:" << rowset->version()
+                      << " is newly created. creation time:" << rowset->creation_time()
+                      << ", threshold:" << config::cumulative_compaction_skip_window_seconds
+                      << ", rowset overlapping:" << rowset->rowset_meta()->segments_overlap() << ", index:" << index
+                      << ", is_creation_time_ordered:" << is_creation_time_ordered;
+            break;
+        }
+        rowsets->emplace_back(std::move(rowset->shared_from_this()));
+        *rowsets_compaction_score += rowset->rowset_meta()->get_compaction_score();
+        if (*rowsets_compaction_score >= config::max_cumulative_compaction_num_singleton_deltas) {
+            LOG(INFO) << "rowsets_compaction_score:" << *rowsets_compaction_score
+                      << " is larger than config:" << config::max_cumulative_compaction_num_singleton_deltas
+                      << ", cumulative rowset size:" << _compaction_context->rowset_levels[0].size();
+            break;
+        }
+        ++index;
+    }
+}
+
+Status LevelCompactionPolicy::_check_version_continuity(const std::vector<RowsetSharedPtr>& rowsets) {
+    if (rowsets.empty()) {
+        return Status::OK();
+    }
+    for (int i = 0; i < rowsets.size() - 1; ++i) {
+        auto& current_rowset = rowsets[i];
+        auto& next_rowset = rowsets[i + 1];
+        if (next_rowset->start_version() != current_rowset->end_version() + 1) {
+            LOG(WARNING) << "There are missed versions among rowsets. "
+                         << "current_rowset version=" << current_rowset->start_version() << "-"
+                         << current_rowset->end_version() << ", rowset version=" << next_rowset->start_version() << "-"
+                         << next_rowset->end_version();
+            return Status::InternalError("level compaction miss versions error.");
+        }
+    }
+
+    return Status::OK();
+}
+
+std::shared_ptr<CompactionTask> LevelCompactionPolicy::_create_cumulative_compaction() {
+    if (_compaction_context->rowset_levels[0].size() == 0) {
+        LOG(WARNING) << "no cumulative rowsets to create compaction task.";
+        return nullptr;
+    }
+    // decide which rowsets to compaction
+    // TODO: 需要考虑加锁
+    std::vector<RowsetSharedPtr> input_rowsets;
+    bool has_delete_version = false;
+    size_t rowsets_compaction_score = 0;
+    _pick_cumulative_rowsets(&has_delete_version, &rowsets_compaction_score, &input_rowsets);
+    if (!has_delete_version && rowsets_compaction_score < config::min_cumulative_compaction_num_singleton_deltas) {
+        // There is no enough qualified rowsets, just skip compaction by return nullptr.
+        // If has_delete_version is true, input_rowsets.size() will be large than 0, because
+        // the leading rowsets can not be 'delete' rowset, which is guaranteed in Tablet::get_compaction_context
+        LOG(INFO) << "rowsets_compaction_score:" << rowsets_compaction_score
+                  << " is smaller than threshold:" << config::min_cumulative_compaction_num_singleton_deltas;
+        return nullptr;
+    }
+    DCHECK(input_rowsets.size() > 0) << "input rowsets size can not be empty";
+
+    if (input_rowsets.size() < 1) {
+        LOG(INFO) << "no suitable rowsets for cumulative compaction";
+        return nullptr;
+    }
+
+    auto st = _check_version_continuity(input_rowsets);
+    if (!st.ok()) {
+        return nullptr;
+    }
+
+    Version output_version;
+    output_version.first = (*input_rowsets.begin())->start_version();
+    output_version.second = (*input_rowsets.rbegin())->end_version();
+
+    CompactionTaskFactory factory(output_version, _compaction_context->tablet, std::move(input_rowsets),
+                                  _compaction_context->cumulative_score, CUMULATIVE_COMPACTION);
+    std::shared_ptr<CompactionTask> compaction_task = factory.create_compaction_task();
+    return compaction_task;
+}
+
+void LevelCompactionPolicy::_pick_base_rowsets(std::vector<RowsetSharedPtr>* rowsets) {
+    uint32_t input_rows_num = 0;
+    size_t input_size = 0;
+    // add the base rowset to input_rowsets
+    Rowset* base_rowset = *_compaction_context->rowset_levels[2].begin();
+    rowsets->push_back(base_rowset->shared_from_this());
+    input_rows_num += base_rowset->num_rows();
+    input_size += base_rowset->data_disk_size();
+    // add level-1 rowsets
+    for (auto rowset : _compaction_context->rowset_levels[1]) {
+        rowsets->push_back(rowset->shared_from_this());
+        input_rows_num += rowset->num_rows();
+        input_size += rowset->data_disk_size();
+    }
+}
+
+std::shared_ptr<CompactionTask> LevelCompactionPolicy::_create_base_compaction() {
+    std::vector<RowsetSharedPtr> input_rowsets;
+    _pick_base_rowsets(&input_rowsets);
+    if (input_rowsets.size() <= 1) {
+        LOG(INFO) << "no suitable version for compaction. size:" << input_rowsets.size();
+        return nullptr;
+    }
+
+    if (input_rowsets.size() == 2 && input_rowsets[0]->empty()) {
+        // the tablet is with rowset: [0-x], [x+1-y], and [0-x] is empty,
+        // no need to do base compaction.
+        LOG(INFO) << "only two rowset. one is [0-x] and it is empty. do not compact. tablet:"
+                  << _compaction_context->tablet->tablet_id();
+        return nullptr;
+    }
+    DCHECK(input_rowsets.size() > 0) << "input rowsets size can not be empty";
+    auto st = _check_version_continuity(input_rowsets);
+    if (!st.ok()) {
+        return nullptr;
+    }
+
+    Version output_version;
+    output_version.first = (*input_rowsets.begin())->start_version();
+    output_version.second = (*input_rowsets.rbegin())->end_version();
+
+    CompactionTaskFactory factory(output_version, _compaction_context->tablet, std::move(input_rowsets),
+                                  _compaction_context->base_score, BASE_COMPACTION);
+    std::shared_ptr<CompactionTask> compaction_task = factory.create_compaction_task();
+    return compaction_task;
+}
+
+double LevelCompactionPolicy::_get_cumulative_compaction_score() {
+    uint32_t segment_num_score = 0;
+    size_t rowsets_size = 0;
+    for (auto& rowset : _compaction_context->rowset_levels[0]) {
+        segment_num_score += rowset->rowset_meta()->get_compaction_score();
+        rowsets_size += rowset->rowset_meta()->total_disk_size();
+    }
+
+    double num_score = static_cast<double>(segment_num_score) / config::min_cumulative_compaction_num_singleton_deltas;
+    double size_score = static_cast<double>(rowsets_size) / config::min_cumulative_compaction_size;
+    double score = std::max(num_score, size_score);
+    VLOG(2) << "tablet:" << _compaction_context->tablet->tablet_id() << ", cumulative compaction score:" << score
+            << ", size_score:" << size_score << ", num_score:" << num_score << ", rowsets_size:" << rowsets_size;
+    return score;
+}
+
+double LevelCompactionPolicy::_get_base_compaction_score() {
+    uint32_t segment_num_score = 0;
+    size_t level_1_rowsets_size = 0;
+    for (auto& rowset : _compaction_context->rowset_levels[1]) {
+        segment_num_score += rowset->rowset_meta()->get_compaction_score();
+        level_1_rowsets_size += rowset->data_disk_size();
+    }
+
+    double num_score = static_cast<double>(segment_num_score) / config::base_compaction_num_cumulative_deltas;
+    double size_score = static_cast<double>(level_1_rowsets_size) / config::min_base_compaction_size;
+
+    double score = std::max(num_score, size_score);
+    VLOG(2) << "tablet:" << _compaction_context->tablet->tablet_id() << ", base compaction score:" << score
+            << ", size_score:" << size_score << ", num_score:" << num_score
+            << ", segment_num_score:" << segment_num_score << ", level_1_rowsets_size:" << level_1_rowsets_size;
+    if (score > COMPACTION_SCORE_THRESHOLD) {
+        return score;
+    }
+    if (_compaction_context->rowset_levels[2].size() > 0) {
+        DCHECK(_compaction_context->rowset_levels[2].size() == 1)
+                << "invalid rowset size. " << _compaction_context->rowset_levels[2].size();
+        Rowset* base_rowset = *_compaction_context->rowset_levels[2].begin();
+        if (base_rowset->data_disk_size() > 0) {
+            double size_ratio = level_1_rowsets_size / base_rowset->data_disk_size();
+            if (size_ratio >= config::base_cumulative_delta_ratio) {
+                score = 1.0;
+                LOG(INFO) << "satisfy the base compaction size ratio policy. tablet="
+                          << _compaction_context->tablet->tablet_id()
+                          << ", base disk size:" << base_rowset->data_disk_size()
+                          << ", base rowsets num:" << _compaction_context->rowset_levels[1].size()
+                          << ", base rowsets size:" << level_1_rowsets_size << ", size_ratio:" << size_ratio;
+                return score;
+            }
+        }
+
+        int64_t base_creation_time = base_rowset->creation_time();
+        int64_t interval_since_last_base_compaction = time(nullptr) - base_creation_time;
+        if (interval_since_last_base_compaction > config::base_compaction_interval_seconds_since_last_operation &&
+            (_compaction_context->rowset_levels[1].size() > 1 ||
+             (_compaction_context->rowset_levels[1].size() == 1 && !base_rowset->empty()))) {
+            // the tablet is with rowsets: [0-x], [x+1-y], and [0-x] is empty.
+            // in this situation, no need to do base compaction.
+            LOG(INFO) << "satisfy the base compaction time policy. tablet=" << _compaction_context->tablet->tablet_id()
+                      << ", interval_since_last_base_compaction=" << interval_since_last_base_compaction
+                      << ", interval_threshold=" << config::base_compaction_interval_seconds_since_last_operation
+                      << ", base rowsets num:" << _compaction_context->rowset_levels[1].size()
+                      << ", base rowsets size:" << level_1_rowsets_size;
+            score = 1.0;
+            return score;
+        }
+    }
+
+    return score;
+}
+
+} // namespace starrocks

--- a/be/src/storage/level_compaction_policy.h
+++ b/be/src/storage/level_compaction_policy.h
@@ -1,0 +1,45 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#pragma once
+
+#include <vector>
+
+#include "storage/compaction_context.h"
+#include "storage/compaction_policy.h"
+
+namespace starrocks {
+
+class CompactionTask;
+
+// Lazy level compaction policy for tablet
+class LevelCompactionPolicy : public CompactionPolicy {
+public:
+    LevelCompactionPolicy(CompactionContext* compaction_context) : _compaction_context(compaction_context) {}
+    ~LevelCompactionPolicy() = default;
+
+    // used to judge whether a tablet should do compaction or not
+    bool need_compaction() override;
+
+    // used to generate a CompactionTask for tablet
+    std::shared_ptr<CompactionTask> create_compaction() override;
+
+private:
+    double _get_cumulative_compaction_score();
+    void _pick_cumulative_rowsets(bool* has_delete_version, size_t* rowsets_compaction_score,
+                                  std::vector<RowsetSharedPtr>* rowsets);
+    bool _is_rowset_creation_time_ordered(const std::set<Rowset*, RowsetComparator>& level_0_rowsets);
+
+    double _get_base_compaction_score();
+    void _pick_base_rowsets(std::vector<RowsetSharedPtr>* rowsets);
+
+    Status _check_version_continuity(const std::vector<RowsetSharedPtr>& rowsets);
+
+    std::shared_ptr<CompactionTask> _create_cumulative_compaction();
+
+    std::shared_ptr<CompactionTask> _create_base_compaction();
+
+private:
+    CompactionContext* _compaction_context;
+};
+
+} // namespace starrocks

--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -53,7 +53,7 @@ typedef unsigned __int128 uint128_t;
 
 typedef UniqueId TabletUid;
 
-enum CompactionType { BASE_COMPACTION = 1, CUMULATIVE_COMPACTION = 2, UPDATE_COMPACTION = 3 };
+enum CompactionType { BASE_COMPACTION = 1, CUMULATIVE_COMPACTION = 2, UPDATE_COMPACTION = 3, INVALID_COMPACTION };
 
 inline std::string to_string(CompactionType type) {
     switch (type) {
@@ -63,6 +63,8 @@ inline std::string to_string(CompactionType type) {
         return "cumulative";
     case UPDATE_COMPACTION:
         return "update";
+    case INVALID_COMPACTION:
+        return "invalid";
     default:
         return "unknown";
     }

--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -339,6 +339,7 @@ enum ReaderType {
     READER_BASE_COMPACTION = 2,
     READER_CUMULATIVE_COMPACTION = 3,
     READER_CHECKSUM = 4,
+    READER_LEVEL_COMPACTION = 5,
 };
 
 inline bool is_query(ReaderType reader_type) {
@@ -346,7 +347,8 @@ inline bool is_query(ReaderType reader_type) {
 }
 
 inline bool is_compaction(ReaderType reader_type) {
-    return reader_type == READER_BASE_COMPACTION || reader_type == READER_CUMULATIVE_COMPACTION;
+    return reader_type == READER_BASE_COMPACTION || reader_type == READER_CUMULATIVE_COMPACTION ||
+           reader_type == READER_LEVEL_COMPACTION;
 }
 
 // <start_version_id, end_version_id>, such as <100, 110>
@@ -358,6 +360,12 @@ struct Version {
 
     Version(int64_t first_, int64_t second_) : first(first_), second(second_) {}
     Version() {}
+
+    Version& operator=(const Version& version) {
+        first = version.first;
+        second = version.second;
+        return *this;
+    }
 
     friend std::ostream& operator<<(std::ostream& os, const Version& version);
 

--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -341,7 +341,6 @@ enum ReaderType {
     READER_BASE_COMPACTION = 2,
     READER_CUMULATIVE_COMPACTION = 3,
     READER_CHECKSUM = 4,
-    READER_LEVEL_COMPACTION = 5,
 };
 
 inline bool is_query(ReaderType reader_type) {
@@ -349,8 +348,7 @@ inline bool is_query(ReaderType reader_type) {
 }
 
 inline bool is_compaction(ReaderType reader_type) {
-    return reader_type == READER_BASE_COMPACTION || reader_type == READER_CUMULATIVE_COMPACTION ||
-           reader_type == READER_LEVEL_COMPACTION;
+    return reader_type == READER_BASE_COMPACTION || reader_type == READER_CUMULATIVE_COMPACTION;
 }
 
 // <start_version_id, end_version_id>, such as <100, 110>

--- a/be/src/storage/rowset/rowset_meta.h
+++ b/be/src/storage/rowset/rowset_meta.h
@@ -40,6 +40,9 @@ using RowsetMetaSharedPtr = std::shared_ptr<RowsetMeta>;
 
 class RowsetMeta {
 public:
+    // for ut
+    RowsetMeta() = default;
+
     ~RowsetMeta() = default;
 
     bool init(const std::string_view& pb_rowset_meta) {

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -99,7 +99,8 @@ StorageEngine::StorageEngine(const EngineOptions& options)
           _rowset_id_generator(new UniqueRowsetIdGenerator(options.backend_uid)),
           _memtable_flush_executor(nullptr),
           _block_manager(nullptr),
-          _update_manager(new UpdateManager(options.update_mem_tracker)) {
+          _update_manager(new UpdateManager(options.update_mem_tracker)),
+          _compaction_manager(new CompactionManager()) {
     if (_s_instance == nullptr) {
         _s_instance = this;
     }

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -89,6 +89,8 @@ public:
     template <bool include_unused = false>
     std::vector<DataDir*> get_stores();
 
+    size_t get_store_num() { return _store_map.size(); }
+
     Status get_all_data_dir_info(std::vector<DataDirInfo>* data_dir_infos, bool need_update);
 
     // get root path for creating tablet. The returned vector of root path should be random,

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -41,6 +41,7 @@
 #include "gen_cpp/BackendService_types.h"
 #include "gen_cpp/MasterService_types.h"
 #include "runtime/heartbeat_flags.h"
+#include "storage/compaction_manager.h"
 #include "storage/fs/fs_util.h"
 #include "storage/kv_store.h"
 #include "storage/olap_common.h"
@@ -157,6 +158,8 @@ public:
     TabletManager* tablet_manager() { return _tablet_manager.get(); }
 
     TxnManager* txn_manager() { return _txn_manager.get(); }
+
+    CompactionManager* compaction_manager() { return _compaction_manager.get(); }
 
     AsyncDeltaWriterExecutor* async_delta_writer_executor() { return _async_delta_writer_executor.get(); }
 
@@ -335,6 +338,8 @@ private:
     std::unique_ptr<fs::BlockManager> _block_manager;
 
     std::unique_ptr<UpdateManager> _update_manager;
+
+    std::unique_ptr<CompactionManager> _compaction_manager;
 
     HeartbeatFlags* _heartbeat_flags = nullptr;
 

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -194,8 +194,8 @@ Status Tablet::revise_tablet_meta(MemTracker* mem_tracker, const std::vector<Row
     }
 
     if (config::enable_new_compaction_framework) {
-        CompactionManager::instance()->update_tablet_async(std::static_pointer_cast<Tablet>(shared_from_this()), true,
-                                                           false);
+        StorageEngine::instance()->compaction_manager()->update_tablet_async(
+                std::static_pointer_cast<Tablet>(shared_from_this()), true, false);
     }
 
     // reconstruct from tablet meta
@@ -274,8 +274,8 @@ void Tablet::modify_rowsets(const std::vector<RowsetSharedPtr>& to_add, const st
 
     // must be put after modify_rs_metas
     if (config::enable_new_compaction_framework) {
-        CompactionManager::instance()->update_tablet_async(std::static_pointer_cast<Tablet>(shared_from_this()), true,
-                                                           false);
+        StorageEngine::instance()->compaction_manager()->update_tablet_async(
+                std::static_pointer_cast<Tablet>(shared_from_this()), true, false);
     }
 
     // add rs_metas_to_delete to tracker
@@ -354,8 +354,8 @@ Status Tablet::add_inc_rowset(const RowsetSharedPtr& rowset) {
 
     _timestamped_version_tracker.add_version(rowset->version());
     if (config::enable_new_compaction_framework) {
-        CompactionManager::instance()->update_tablet_async(std::static_pointer_cast<Tablet>(shared_from_this()), true,
-                                                           false);
+        StorageEngine::instance()->compaction_manager()->update_tablet_async(
+                std::static_pointer_cast<Tablet>(shared_from_this()), true, false);
     }
 
     RETURN_IF_ERROR(_tablet_meta->add_inc_rs_meta(rowset->rowset_meta()));

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -1351,7 +1351,7 @@ bool Tablet::_need_compaction_unlock() const {
     for (int i = 0; i < LEVEL_NUMBER - 1; i++) {
         ret |= _need_compaction_unlock(i);
     }
-    return  ret;
+    return ret;
 }
 
 void Tablet::stop_compaction() {

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -1317,7 +1317,7 @@ std::shared_ptr<CompactionTask> Tablet::get_compaction(int8_t level, bool create
 
 std::vector<CompactionCandidate> Tablet::_get_compaction_candidates() {
     std::vector<CompactionCandidate> candidates;
-    for (int i = 0; i < 2; i++) {
+    for (int i = 0; i < LEVEL_NUMBER - 1; i++) {
         if (_need_compaction_unlock(i)) {
             CompactionCandidate candidate;
             candidate.tablet = std::static_pointer_cast<Tablet>(shared_from_this());
@@ -1347,12 +1347,16 @@ bool Tablet::_need_compaction_unlock(uint8_t level) const {
 }
 
 bool Tablet::_need_compaction_unlock() const {
-    return _need_compaction_unlock(0) || _need_compaction_unlock(1);
+    bool ret = false;
+    for (int i = 0; i < LEVEL_NUMBER - 1; i++) {
+        ret |= _need_compaction_unlock(i);
+    }
+    return  ret;
 }
 
 void Tablet::stop_compaction() {
     std::unique_lock wrlock(_meta_lock);
-    for (int i = 0; i < 2; i++) {
+    for (int i = 0; i < LEVEL_NUMBER - 1; i++) {
         if (_compaction_tasks[i]) {
             _compaction_tasks[i]->stop();
             _compaction_tasks[i].reset();

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -36,7 +36,6 @@
 #include "storage/compaction_manager.h"
 #include "storage/compaction_policy.h"
 #include "storage/compaction_task.h"
-#include "storage/compaction_policy.h"
 #include "storage/olap_common.h"
 #include "storage/olap_define.h"
 #include "storage/rowset/rowset_factory.h"

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -33,6 +33,10 @@
 
 #include "runtime/current_thread.h"
 #include "runtime/exec_env.h"
+#include "storage/compaction_manager.h"
+#include "storage/compaction_policy.h"
+#include "storage/compaction_task.h"
+#include "storage/compaction_policy.h"
 #include "storage/olap_common.h"
 #include "storage/olap_define.h"
 #include "storage/rowset/rowset_factory.h"
@@ -188,6 +192,13 @@ Status Tablet::revise_tablet_meta(MemTracker* mem_tracker, const std::vector<Row
         _rs_version_map[version] = std::move(rowset);
     }
 
+    if (config::enable_new_compaction_framework) {
+        update_tablet_compaction_context();
+        if (need_compaction_unlock()) {
+            CompactionManager::instance()->update_candidate_async(this);
+        }
+    }
+
     // reconstruct from tablet meta
     _timestamped_version_tracker.construct_versioned_tracker(_tablet_meta->all_rs_metas());
 
@@ -261,6 +272,14 @@ void Tablet::modify_rowsets(const std::vector<RowsetSharedPtr>& to_add, const st
     }
 
     _tablet_meta->modify_rs_metas(rs_metas_to_add, rs_metas_to_delete);
+
+    // must be put after modify_rs_metas
+    if (config::enable_new_compaction_framework) {
+        update_tablet_compaction_context();
+        if (need_compaction_unlock()) {
+            CompactionManager::instance()->update_candidate_async(this);
+        }
+    }
 
     // add rs_metas_to_delete to tracker
     _timestamped_version_tracker.add_stale_path_version(rs_metas_to_delete);
@@ -337,6 +356,12 @@ Status Tablet::add_inc_rowset(const RowsetSharedPtr& rowset) {
     _inc_rs_version_map[rowset->version()] = rowset;
 
     _timestamped_version_tracker.add_version(rowset->version());
+    if (config::enable_new_compaction_framework) {
+        update_tablet_compaction_context();
+        if (need_compaction_unlock()) {
+            CompactionManager::instance()->update_candidate_async(this);
+        }
+    }
 
     RETURN_IF_ERROR(_tablet_meta->add_inc_rs_meta(rowset->rowset_meta()));
 
@@ -601,8 +626,7 @@ bool Tablet::check_migrate(const TabletSharedPtr& tablet) {
     return false;
 }
 
-bool Tablet::can_do_compaction() {
-    std::shared_lock rdlock(_meta_lock);
+bool Tablet::_check_versions_completeness() {
     const RowsetSharedPtr lastest_delta = rowset_with_max_version();
     if (lastest_delta == nullptr) {
         return false;
@@ -610,6 +634,11 @@ bool Tablet::can_do_compaction() {
 
     Version test_version = Version(0, lastest_delta->end_version());
     return capture_consistent_versions(test_version, nullptr).ok();
+}
+
+bool Tablet::can_do_compaction() {
+    std::shared_lock rdlock(_meta_lock);
+    return _check_versions_completeness();
 }
 
 const uint32_t Tablet::calc_cumulative_compaction_score() const {
@@ -1168,6 +1197,124 @@ Version Tablet::max_version() const {
     } else {
         return _tablet_meta->max_version();
     }
+}
+
+void Tablet::update_tablet_compaction_context() {
+    if (_updates || _state == TABLET_NOTREADY || !is_used() || !init_succeeded()) {
+        _compaction_context.reset();
+        return;
+    }
+    if (!_check_versions_completeness()) {
+        _compaction_context.reset();
+        // when versions are not complete, just return
+        return;
+    }
+    std::unique_ptr<CompactionContext> compaction_context = _get_compaction_context();
+    std::unique_ptr<CompactionPolicy> compaction_policy =
+            CompactionUtils::create_compaction_policy(compaction_context.get());
+    if (compaction_policy->need_compaction()) {
+        _compaction_context.swap(compaction_context);
+    } else {
+        _compaction_context.reset();
+    }
+}
+
+bool Tablet::_is_compacted_singleton(Rowset* rowset) {
+    DCHECK(rowset) << "invalid rowset";
+    return rowset->num_segments() > 1 && rowset->rowset_meta()->segments_overlap() == NONOVERLAPPING;
+}
+
+// protected by meta lock
+std::unique_ptr<CompactionContext> Tablet::_get_compaction_context() {
+    // construct compaction context from tablet
+    std::unique_ptr<CompactionContext> compaction_context(new CompactionContext());
+    for (auto& it : _rs_version_map) {
+        if (it.second->start_version() == it.second->end_version()) {
+            // level 0
+            compaction_context->rowset_levels[0].insert(it.second.get());
+        } else if (it.second->start_version() != 0) {
+            // level 1
+            compaction_context->rowset_levels[1].insert(it.second.get());
+        } else {
+            // level 2
+            compaction_context->rowset_levels[2].insert(it.second.get());
+        }
+    }
+    compaction_context->tablet = this;
+
+    // For leading 'delete' or 'compacted' rowset in level 0, move it to level 1
+    // because they should be compacted by base compaction
+    auto& level_0_rowsets = compaction_context->rowset_levels[0];
+    auto& level_1_rowsets = compaction_context->rowset_levels[1];
+    size_t not_delete_index = 0;
+    for (auto iter = level_0_rowsets.begin(); iter != level_0_rowsets.end();) {
+        if (version_for_delete_predicate((*iter)->version())) {
+            // move 'delete' or 'compacted' rowset to level 1
+            Rowset* rowset = *iter;
+            iter = level_0_rowsets.erase(iter);
+            level_1_rowsets.insert(rowset);
+            VLOG(2) << "move delete rowset:" << rowset->version() << " from level 0 to level 1";
+        } else if (not_delete_index == 0 && !(*iter)->rowset_meta()->is_segments_overlapping()) {
+            // rowsets like: nonoverlapping singleton, delete singleton
+            // the leading nonoverlapping singleton should be moved to level 1
+            auto next_iter = iter;
+            next_iter++;
+            if (next_iter == level_0_rowsets.end()) {
+                break;
+            }
+            auto next_rowset = *next_iter;
+            if (!version_for_delete_predicate(next_rowset->version())) {
+                break;
+            }
+            Rowset* rowset = *iter;
+            iter = level_0_rowsets.erase(iter);
+            level_1_rowsets.insert(rowset);
+            VLOG(2) << "move leading nonoverlapping singleton rowset:" << rowset->version()
+                    << " before delete version from level 0 to level 1";
+        } else {
+            not_delete_index++;
+            break;
+        }
+    }
+    return compaction_context;
+}
+
+double Tablet::compaction_score() const {
+    std::unique_lock wrlock(_meta_lock);
+    if (!_compaction_context) {
+        return 0;
+    }
+    return _compaction_context->get_score();
+}
+
+std::shared_ptr<CompactionTask> Tablet::get_compaction(bool create_if_not_exist) {
+    std::shared_lock wrlock(_meta_lock);
+    if (!_compaction_context) {
+        return nullptr;
+    }
+
+    if (!_compaction_task && create_if_not_exist) {
+        std::unique_ptr<CompactionContext> compaction_context =
+                std::make_unique<CompactionContext>(*_compaction_context);
+        std::unique_ptr<CompactionPolicy> compaction_policy =
+                CompactionUtils::create_compaction_policy(compaction_context.get());
+        _compaction_task = compaction_policy->create_compaction();
+    }
+    return _compaction_task;
+}
+
+void Tablet::stop_compaction() {
+    std::unique_lock wrlock(_meta_lock);
+    if (!_compaction_task) {
+        return;
+    }
+    _compaction_task->stop();
+    _compaction_task.reset();
+}
+
+void Tablet::reset_compaction() {
+    std::unique_lock wrlock(_meta_lock);
+    _compaction_task.reset();
 }
 
 } // namespace starrocks

--- a/be/src/storage/tablet.h
+++ b/be/src/storage/tablet.h
@@ -252,9 +252,9 @@ public:
 
     // if there is _compaction_task running
     // do not do compaction
-    bool need_compaction(uint8_t level) const {
+    bool need_compaction(CompactionType type) const {
         std::unique_lock wrlock(_meta_lock);
-        return _need_compaction_unlock(level);
+        return _need_compaction_unlock(type);
     }
 
     // for ut
@@ -262,13 +262,13 @@ public:
 
     std::vector<CompactionCandidate> get_compaction_candidates(bool need_update_context);
 
-    double compaction_score(uint8_t level) const;
+    double compaction_score(CompactionType type) const;
 
-    std::shared_ptr<CompactionTask> get_compaction(int8_t level, bool create_if_not_exist);
+    std::shared_ptr<CompactionTask> get_compaction(CompactionType type, bool create_if_not_exist);
 
     void stop_compaction();
 
-    void reset_compaction(uint8_t level);
+    void reset_compaction(CompactionType type);
 
 protected:
     void on_shutdown() override;
@@ -297,7 +297,7 @@ private:
     void _update_tablet_compaction_context();
     std::vector<CompactionCandidate> _get_compaction_candidates();
     bool _need_compaction_unlock() const;
-    bool _need_compaction_unlock(uint8_t level) const;
+    bool _need_compaction_unlock(CompactionType type) const;
 
     friend class TabletUpdates;
     static const int64_t kInvalidCumulativePoint = -1;
@@ -340,7 +340,8 @@ private:
 
     // compaction related
     std::unique_ptr<CompactionContext> _compaction_context;
-    std::shared_ptr<CompactionTask> _compaction_tasks[2];
+    std::shared_ptr<CompactionTask> _base_compaction_task;
+    std::shared_ptr<CompactionTask> _cumulative_compaction_task;
 
     // if this tablet is broken, set to true. default is false
     // timestamp of last cumu compaction failure

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -738,7 +738,7 @@ Status TabletManager::load_tablet_from_meta(DataDir* data_dir, TTabletId tablet_
     LOG_IF(WARNING, !st.ok()) << "Fail to add tablet " << tablet->full_name();
     // no concurrent access here
     if (config::enable_new_compaction_framework) {
-        CompactionManager::instance()->update_tablet_async(tablet, true, false);
+        StorageEngine::instance()->compaction_manager()->update_tablet_async(tablet, true, false);
     }
 
     return st;

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -738,10 +738,7 @@ Status TabletManager::load_tablet_from_meta(DataDir* data_dir, TTabletId tablet_
     LOG_IF(WARNING, !st.ok()) << "Fail to add tablet " << tablet->full_name();
     // no concurrent access here
     if (config::enable_new_compaction_framework) {
-        tablet->update_tablet_compaction_context();
-        if (tablet->need_compaction_unlock()) {
-            CompactionManager::instance()->update_candidate_async(tablet.get());
-        }
+        CompactionManager::instance()->update_tablet_async(tablet, true, false);
     }
 
     return st;

--- a/be/src/storage/tablet_meta.h
+++ b/be/src/storage/tablet_meta.h
@@ -145,6 +145,7 @@ public:
     inline int64_t table_id() const;
     inline int64_t partition_id() const;
     inline int64_t tablet_id() const;
+    void set_tablet_id(int64_t tablet_id) { _tablet_id = tablet_id; }
     inline int32_t schema_hash() const;
     inline int16_t shard_id() const;
     inline void set_shard_id(int32_t shard_id);

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -164,6 +164,8 @@ set(EXEC_FILES
         ./storage/tablet_updates_test.cpp
         ./storage/update_manager_test.cpp
         ./storage/compaction_utils_test.cpp
+        ./storage/compaction_context_test.cpp
+        ./storage/compaction_manager_test.cpp
         ./storage/vectorized/aggregate_iterator_test.cpp
         ./storage/vectorized/chunk_aggregator_test.cpp
         ./storage/vectorized/chunk_helper_test.cpp

--- a/be/test/storage/compaction_context_test.cpp
+++ b/be/test/storage/compaction_context_test.cpp
@@ -1,0 +1,71 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#include "storage/compaction_context.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+#include <random>
+
+#include "storage/rowset/beta_rowset.h"
+#include "storage/tablet_schema.h"
+#include "storage/tablet_schema_helper.h"
+
+namespace starrocks {
+
+TEST(CompactionContextTest, test_rowset_comparator) {
+    std::set<Rowset*, RowsetComparator> sorted_rowsets_set;
+
+    std::vector<RowsetSharedPtr> rowsets;
+    TabletSchema tablet_schema;
+    create_tablet_schema(&tablet_schema);
+
+    RowsetMetaSharedPtr base_rowset_meta = std::make_shared<RowsetMeta>();
+    base_rowset_meta->set_start_version(0);
+    base_rowset_meta->set_end_version(9);
+    RowsetSharedPtr base_rowset = std::make_shared<BetaRowset>(&tablet_schema, "./rowset_0", base_rowset_meta);
+    rowsets.emplace_back(std::move(base_rowset));
+
+    for (int i = 1; i <= 10; i++) {
+        RowsetMetaSharedPtr rowset_meta = std::make_shared<RowsetMeta>();
+        rowset_meta->set_start_version(i * 10);
+        rowset_meta->set_end_version((i + 1) * 10 - 1);
+        RowsetSharedPtr rowset =
+                std::make_shared<BetaRowset>(&tablet_schema, "./rowset" + std::to_string(i), rowset_meta);
+        rowsets.emplace_back(std::move(rowset));
+    }
+
+    for (int i = 110; i < 120; i++) {
+        RowsetMetaSharedPtr rowset_meta = std::make_shared<RowsetMeta>();
+        rowset_meta->set_start_version(i);
+        rowset_meta->set_end_version(i);
+        RowsetSharedPtr rowset =
+                std::make_shared<BetaRowset>(&tablet_schema, "./rowset" + std::to_string(i), rowset_meta);
+        rowsets.emplace_back(std::move(rowset));
+    }
+
+    std::random_device rd;
+    std::mt19937 g(rd());
+    std::shuffle(rowsets.begin(), rowsets.end(), g);
+
+    for (auto& rowset : rowsets) {
+        sorted_rowsets_set.insert(rowset.get());
+    }
+
+    bool is_sorted = true;
+    Rowset* pre_rowset = nullptr;
+    for (auto& rowset : sorted_rowsets_set) {
+        if (pre_rowset != nullptr) {
+            if (!(rowset->start_version() == pre_rowset->end_version() + 1 &&
+                  rowset->start_version() <= rowset->end_version())) {
+                is_sorted = false;
+                break;
+            }
+        }
+        pre_rowset = rowset;
+    }
+    ASSERT_EQ(true, is_sorted);
+}
+
+} // namespace starrocks

--- a/be/test/storage/compaction_manager_test.cpp
+++ b/be/test/storage/compaction_manager_test.cpp
@@ -13,6 +13,7 @@
 #include "storage/compaction_utils.h"
 #include "storage/tablet.h"
 #include "storage/tablet_updates.h"
+#include "storage/storage_engine.h"
 
 namespace starrocks {
 

--- a/be/test/storage/compaction_manager_test.cpp
+++ b/be/test/storage/compaction_manager_test.cpp
@@ -123,30 +123,30 @@ TEST(CompactionManagerTest, test_compaction_tasks) {
     CompactionManager::instance()->clear_tasks();
     ASSERT_EQ(0, CompactionManager::instance()->running_tasks_num());
 
-    config::max_level_0_compaction_task = 1;
-    for (int i = 0; i < config::max_level_0_compaction_task; i++) {
+    config::max_cumulative_compaction_task = 1;
+    for (int i = 0; i < config::max_cumulative_compaction_task; i++) {
         bool ret = CompactionManager::instance()->register_task(tasks[i].get());
         ASSERT_TRUE(ret);
     }
 
-    ret = CompactionManager::instance()->register_task(tasks[config::max_level_0_compaction_task].get());
+    ret = CompactionManager::instance()->register_task(tasks[config::max_cumulative_compaction_task].get());
     ASSERT_FALSE(ret);
 
-    ASSERT_EQ(config::max_level_0_compaction_task, CompactionManager::instance()->running_tasks_num());
+    ASSERT_EQ(config::max_cumulative_compaction_task, CompactionManager::instance()->running_tasks_num());
     ASSERT_EQ(1, CompactionManager::instance()->running_tasks_num_for_level(0));
     CompactionManager::instance()->clear_tasks();
 
-    config::max_level_1_compaction_task = 1;
-    for (int i = 0; i < config::max_level_1_compaction_task + 1; i++) {
+    config::max_base_compaction_task = 1;
+    for (int i = 0; i < config::max_base_compaction_task + 1; i++) {
         tasks[i]->set_compaction_level(1);
         bool ret = CompactionManager::instance()->register_task(tasks[i].get());
-        if (i < config::max_level_1_compaction_task) {
+        if (i < config::max_base_compaction_task) {
             ASSERT_TRUE(ret);
         } else {
             ASSERT_FALSE(ret);
         }
     }
-    ASSERT_EQ(config::max_level_1_compaction_task, CompactionManager::instance()->running_tasks_num());
+    ASSERT_EQ(config::max_base_compaction_task, CompactionManager::instance()->running_tasks_num());
     ASSERT_EQ(1, CompactionManager::instance()->running_tasks_num_for_level(1));
 }
 

--- a/be/test/storage/compaction_manager_test.cpp
+++ b/be/test/storage/compaction_manager_test.cpp
@@ -1,0 +1,158 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#include "storage/compaction_manager.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+#include <random>
+
+#include "storage/compaction_context.h"
+#include "storage/compaction_task.h"
+#include "storage/compaction_utils.h"
+#include "storage/tablet.h"
+#include "storage/tablet_updates.h"
+
+namespace starrocks {
+
+TEST(CompactionManagerTest, test_candidates) {
+    std::vector<TabletSharedPtr> tablets;
+    DataDir data_dir("./data_dir");
+    for (int i = 0; i <= 10; i++) {
+        TabletSharedPtr tablet = std::make_shared<Tablet>();
+        TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
+        tablet_meta->set_tablet_id(i);
+        tablet->set_tablet_meta(tablet_meta);
+        tablet->set_data_dir(&data_dir);
+        std::unique_ptr<CompactionContext> compaction_context = std::make_unique<CompactionContext>();
+        compaction_context->tablet = tablet.get();
+        compaction_context->current_level = 0;
+        // for i == 9 and i == 10, compaction scores are equal
+        if (i == 10) {
+            compaction_context->compaction_scores[0] = 10;
+        } else {
+            compaction_context->compaction_scores[0] = 1 + i;
+        }
+        compaction_context->compaction_scores[1] = 1 + 0.5 * i;
+        tablet->set_compaction_context(compaction_context);
+        tablets.push_back(tablet);
+    }
+
+    std::random_device rd;
+    std::mt19937 g(rd());
+    std::shuffle(tablets.begin(), tablets.end(), g);
+
+    for (auto& tablet : tablets) {
+        CompactionManager::instance()->update_candidate(tablet.get());
+    }
+
+    ASSERT_EQ(11, CompactionManager::instance()->candidates_size());
+    Tablet* candidate_1 = CompactionManager::instance()->pick_candidate();
+    ASSERT_EQ(9, candidate_1->tablet_id());
+    Tablet* candidate_2 = CompactionManager::instance()->pick_candidate();
+    ASSERT_EQ(10, candidate_2->tablet_id());
+    ASSERT_EQ(candidate_1->compaction_score(), candidate_2->compaction_score());
+    double last_score = candidate_2->compaction_score();
+    for (int i = 8; i >= 0; i--) {
+        Tablet* candidate = CompactionManager::instance()->pick_candidate();
+        ASSERT_EQ(i, candidate->tablet_id());
+        ASSERT_LT(candidate->compaction_score(), last_score);
+        last_score = candidate->compaction_score();
+    }
+}
+
+class MockCompactionTask : public CompactionTask {
+    MockCompactionTask() : CompactionTask(HORIZONTAL_COMPACTION) {}
+
+    ~MockCompactionTask() = default;
+
+    Status run_impl() override { return Status::OK(); }
+};
+
+TEST(CompactionManagerTest, test_compaction_tasks) {
+    std::vector<TabletSharedPtr> tablets;
+    std::vector<std::shared_ptr<MockCompactionTask>> tasks;
+    DataDir data_dir("./data_dir");
+    // generate compaction task
+    config::max_compaction_task_num = 2;
+    config::max_compaction_task_per_disk = config::max_compaction_task_num;
+    for (int i = 0; i < config::max_compaction_task_num + 1; i++) {
+        TabletSharedPtr tablet = std::make_shared<Tablet>();
+        TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
+        tablet_meta->set_tablet_id(i);
+        tablet->set_tablet_meta(tablet_meta);
+        tablet->set_data_dir(&data_dir);
+        std::unique_ptr<CompactionContext> compaction_context = std::make_unique<CompactionContext>();
+        compaction_context->tablet = tablet.get();
+        compaction_context->current_level = 0;
+        compaction_context->compaction_scores[0] = 1 + i;
+        compaction_context->compaction_scores[1] = 1 + 0.5 * i;
+        tablet->set_compaction_context(compaction_context);
+        tablets.push_back(tablet);
+        std::shared_ptr<MockCompactionTask> task = std::make_shared<MockCompactionTask>();
+        task->set_tablet(tablet.get());
+        task->set_task_id(i);
+        task->set_compaction_level(0);
+        tasks.emplace_back(std::move(task));
+    }
+
+    for (int i = 0; i < config::max_compaction_task_num; i++) {
+        bool ret = CompactionManager::instance()->register_task(tasks[i].get());
+        ASSERT_TRUE(ret);
+    }
+    bool ret = CompactionManager::instance()->register_task(tasks[config::max_compaction_task_num].get());
+    ASSERT_FALSE(ret);
+
+    ASSERT_EQ(config::max_compaction_task_num, CompactionManager::instance()->running_tasks_num());
+    ASSERT_EQ(config::max_compaction_task_num, CompactionManager::instance()->running_tasks_num_for_level(0));
+    ASSERT_EQ(0, CompactionManager::instance()->running_tasks_num_for_level(1));
+    CompactionManager::instance()->clear_tasks();
+    ASSERT_EQ(0, CompactionManager::instance()->running_tasks_num());
+
+    config::max_compaction_task_per_disk = 1;
+    for (int i = 0; i < config::max_compaction_task_num; i++) {
+        bool ret = CompactionManager::instance()->register_task(tasks[i].get());
+        if (i == 0) {
+            ASSERT_TRUE(ret);
+        } else {
+            ASSERT_FALSE(ret);
+        }
+    }
+    ASSERT_EQ(1, CompactionManager::instance()->running_tasks_num());
+    CompactionManager::instance()->clear_tasks();
+    ASSERT_EQ(0, CompactionManager::instance()->running_tasks_num());
+
+    config::max_level_0_compaction_task = 1;
+    for (int i = 0; i < config::max_level_0_compaction_task; i++) {
+        bool ret = CompactionManager::instance()->register_task(tasks[i].get());
+        ASSERT_TRUE(ret);
+    }
+
+    ret = CompactionManager::instance()->register_task(tasks[config::max_level_0_compaction_task].get());
+    ASSERT_FALSE(ret);
+
+    ASSERT_EQ(config::max_level_0_compaction_task, CompactionManager::instance()->running_tasks_num());
+    ASSERT_EQ(1, CompactionManager::instance()->running_tasks_num_for_level(0));
+    CompactionManager::instance()->clear_tasks();
+
+    config::max_level_1_compaction_task = 1;
+    for (int i = 0; i < config::max_level_1_compaction_task + 1; i++) {
+        tasks[i]->set_compaction_level(1);
+        bool ret = CompactionManager::instance()->register_task(tasks[i].get());
+        if (i < config::max_level_1_compaction_task) {
+            ASSERT_TRUE(ret);
+        } else {
+            ASSERT_FALSE(ret);
+        }
+    }
+    ASSERT_EQ(config::max_level_1_compaction_task, CompactionManager::instance()->running_tasks_num());
+    ASSERT_EQ(1, CompactionManager::instance()->running_tasks_num_for_level(1));
+}
+
+TEST(CompactionManagerTest, test_next_compaction_task_id) {
+    uint64_t start_task_id = CompactionManager::instance()->next_compaction_task_id();
+    ASSERT_LT(0, start_task_id);
+}
+
+} // namespace starrocks

--- a/be/test/storage/tablet_schema_helper.h
+++ b/be/test/storage/tablet_schema_helper.h
@@ -28,6 +28,49 @@
 
 namespace starrocks {
 
+// (k1 int, k2 varchar(20), k3 int) duplicated key (k1, k2)
+void inline create_tablet_schema(TabletSchema* tablet_schema) {
+    TabletSchemaPB tablet_schema_pb;
+    tablet_schema_pb.set_keys_type(DUP_KEYS);
+    tablet_schema_pb.set_num_short_key_columns(2);
+    tablet_schema_pb.set_num_rows_per_row_block(1024);
+    tablet_schema_pb.set_compress_kind(COMPRESS_NONE);
+    tablet_schema_pb.set_next_column_unique_id(4);
+
+    ColumnPB* column_1 = tablet_schema_pb.add_column();
+    column_1->set_unique_id(1);
+    column_1->set_name("k1");
+    column_1->set_type("INT");
+    column_1->set_is_key(true);
+    column_1->set_length(4);
+    column_1->set_index_length(4);
+    column_1->set_is_nullable(true);
+    column_1->set_is_bf_column(false);
+
+    ColumnPB* column_2 = tablet_schema_pb.add_column();
+    column_2->set_unique_id(2);
+    column_2->set_name("k2");
+    column_2->set_type("INT"); // TODO change to varchar(20) when dict encoding for string is supported
+    column_2->set_length(4);
+    column_2->set_index_length(4);
+    column_2->set_is_nullable(true);
+    column_2->set_is_key(true);
+    column_2->set_is_nullable(true);
+    column_2->set_is_bf_column(false);
+
+    ColumnPB* column_3 = tablet_schema_pb.add_column();
+    column_3->set_unique_id(3);
+    column_3->set_name("v1");
+    column_3->set_type("INT");
+    column_3->set_length(4);
+    column_3->set_is_key(false);
+    column_3->set_is_nullable(false);
+    column_3->set_is_bf_column(false);
+    column_3->set_aggregation("SUM");
+
+    tablet_schema->init_from_pb(tablet_schema_pb);
+}
+
 inline TabletColumn create_int_key(int32_t id, bool is_nullable = true, bool is_bf_column = false,
                                    bool has_bitmap_index = false) {
     TabletColumn column;


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [X] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3301 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->


Add a new compaction execution framework. The main modifications are as follows:
1. pick the compaction candidate tablet by triggering instead of polling to solve the CPU cost problem of compaction. The candidate tablets will be a subset of total tablets, which will save a lot of scheduler computation in situations with large tablets num. The tablet will be judged whether to be compacted when there is rowsets modification, including new rowset loaded, schema change finished, compaction task finished, clone finished.
2. add CompactionPolicy to decide which tablet should be compacted and which rowsets in a tablet should be compacted. Now LevelCompactionPolicy is created based on CompactionContext to decide whether the tablet should be compacted, which level should be compacted, and how many rowsets in that level should be compacted. CompactionContext contains infos about the detail rowsets in different levels, ordered by version. Now LevelCompactionPolicy uses the same strategy as before. The details are as follows: when the compaction score is above the threshold, it is considered to be a compaction candidate. It uses the same strategy to pick rowsets from level. But the difference is there is no cumulative compaction or base compaction. Now it is replaced by level compaction. And there are only three levels and also two types of compaction(level-0 and level-1 compaction) to keep compatible. Level-0 compaction is equivalent to cumulative compaction as before; Level-1 compaction is equivalent to base compaction. Maybe it can be extended to more levels in the future.
3. add CompactionScheduler to pick the candidate tablet by compaction score descendingly to run compaction task and control the concurrency of compaction tasks.
4. add CompactionTask to abstract the basic compaction task logics, and realize the functions including stop compaction task, get task progress and so on. Now there are two type of compaction task, VerticalCompactionTask and HorizontalCompactionTask. Realize CompactionTaskFactory to create compaction task according to the context
5. add CompactionManager to manager the candidate tablets which are stored as set ordered by compaction score descendingly, and compaction tasks. the http apis to get candidates info, compaction tasks info and the detail of a compaction task will be developed later accordingly.

And According to my tests, the problem of cpu cost is solved. And the compaction performance is near the same as the before(The results are tested by same size of data compacted, same hardware environment for vertical and horizontal compaction each):
                              before		after
vertical compaction  		  20S		 14S
horizontal compaction         5.0S       4.9S
