### PR TITLE
io dispatcher doesn't prefetch schedule workgroups anymore

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -651,6 +651,8 @@ CONF_Int64(pipeline_scan_max_tasks_per_operator, "4");
 CONF_Int64(pipeline_scan_task_yield_max_tims_spent, "100000000");
 // the number of execution threads for pipeline engine.
 CONF_Int64(pipeline_exec_thread_pool_thread_num, "0");
+// The max schedule period for adjusting io weight of each workgroup.
+CONF_Int32(pipeline_max_io_schedule_num_period, "512");
 // the buffer size of io task
 CONF_Int64(pipeline_io_buffer_size, "64");
 // the buffer size of SinkBuffer

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -645,8 +645,10 @@ CONF_Int64(pipeline_yield_max_chunks_moved, "100");
 CONF_Int64(pipeline_yield_max_time_spent, "100000000");
 // the number of scan threads pipeline engine.
 CONF_Int64(pipeline_scan_thread_pool_thread_num, "0");
-// queue size of scan thread pool for pipeline engine.
-CONF_Int64(pipeline_scan_thread_pool_queue_size, "102400");
+// The max number of io tasks for each scan operator.
+CONF_Int64(pipeline_scan_max_tasks_per_operator, "4");
+// The max number of io tasks for each scan operator.
+CONF_Int64(pipeline_scan_task_yield_max_tims_spent, "100000000");
 // the number of execution threads for pipeline engine.
 CONF_Int64(pipeline_exec_thread_pool_thread_num, "0");
 // the buffer size of io task
@@ -655,8 +657,6 @@ CONF_Int64(pipeline_io_buffer_size, "64");
 CONF_Int64(pipeline_sink_buffer_size, "64");
 // the degree of parallelism of brpc
 CONF_Int64(pipeline_sink_brpc_dop, "8");
-
-CONF_Int64(pipeline_scan_max_tasks_per_operator, "4");
 
 // bitmap serialize version
 CONF_Int16(bitmap_serialize_version, "1");

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -114,14 +114,6 @@ void gc_tcmalloc_memory(void* arg_this) {
     }
 }
 
-void log_workgroup(void* arg_this) {
-    Daemon* daemon = static_cast<Daemon*>(arg_this);
-    while (!daemon->stopped()) {
-        workgroup::WorkGroupManager::instance()->log_cpu();
-        sleep(1); // 1 second
-    }
-}
-
 /*
  * this thread will calculate some metrics at a fix interval(15 sec)
  * 1. push bytes per second
@@ -284,10 +276,6 @@ void Daemon::init(int argc, char** argv, const std::vector<StorePath>& paths) {
         Thread::set_thread_name(calculate_metrics_thread, "metrics_daemon");
         _daemon_threads.emplace_back(std::move(calculate_metrics_thread));
     }
-
-    std::thread log_workgroup_thread(log_workgroup, this);
-    Thread::set_thread_name(log_workgroup_thread, "log_workgroup");
-    _daemon_threads.emplace_back(std::move(log_workgroup_thread));
 
     init_signals();
     init_minidump();

--- a/be/src/exec/pipeline/chunk_source.h
+++ b/be/src/exec/pipeline/chunk_source.h
@@ -34,7 +34,7 @@ public:
 
     virtual StatusOr<vectorized::ChunkPtr> get_next_chunk_from_buffer() = 0;
 
-    virtual Status buffer_next_batch_chunks_blocking(size_t chunk_size, bool& can_finish, size_t* read_size) = 0;
+    virtual Status buffer_next_batch_chunks_blocking(size_t chunk_size, bool& can_finish, size_t* num_read_chunks) = 0;
 
 protected:
     // The morsel will own by pipeline driver

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -245,10 +245,7 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
                                                                     driver_id++, is_root);
                 driver->set_morsel_queue(std::move(morsel_queue_per_driver[i]));
                 auto* scan_operator = down_cast<ScanOperator*>(driver->source_operator());
-                scan_operator->set_io_threads(exec_env->pipeline_scan_io_thread_pool());
-                if (wg) {
-                    scan_operator->set_workgroup(wg);
-                }
+                scan_operator->set_workgroup(wg);
                 setup_profile_hierarchy(pipeline, driver);
                 drivers.emplace_back(std::move(driver));
             }

--- a/be/src/exec/pipeline/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/olap_chunk_source.cpp
@@ -300,21 +300,34 @@ Status OlapChunkSource::buffer_next_batch_chunks_blocking(size_t batch_size, boo
         return _status;
     }
     using namespace vectorized;
+    int64_t time_spent = 0;
+    int64_t total_time_spent = 0;
     for (size_t i = 0; i < batch_size && !can_finish; ++i) {
-        ChunkUniquePtr chunk(
-                ChunkHelper::new_chunk_pooled(_prj_iter->encoded_schema(), _runtime_state->chunk_size(), true));
-        _status = _read_chunk_from_storage(_runtime_state, chunk.get());
-        if (!_status.ok()) {
-            // end of file is normal case, need process chunk
-            if (_status.is_end_of_file()) {
-                _chunk_buffer.put(std::move(chunk));
-                ++(*num_read_chunks);
+        {
+            SCOPED_RAW_TIMER(&time_spent);
+
+            ChunkUniquePtr chunk(
+                    ChunkHelper::new_chunk_pooled(_prj_iter->encoded_schema(), _runtime_state->chunk_size(), true));
+            _status = _read_chunk_from_storage(_runtime_state, chunk.get());
+            if (!_status.ok()) {
+                // end of file is normal case, need process chunk
+                if (_status.is_end_of_file()) {
+                    ++(*num_read_chunks);
+                    _chunk_buffer.put(std::move(chunk));
+                }
+                break;
             }
+
+            ++(*num_read_chunks);
+            _chunk_buffer.put(std::move(chunk));
+        }
+
+        total_time_spent += time_spent;
+        if (total_time_spent >= config::pipeline_scan_task_yield_max_tims_spent) {
             break;
         }
-        _chunk_buffer.put(std::move(chunk));
-        ++(*num_read_chunks);
     }
+
     return _status;
 }
 

--- a/be/src/exec/pipeline/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/olap_chunk_source.cpp
@@ -294,7 +294,8 @@ StatusOr<vectorized::ChunkPtr> OlapChunkSource::get_next_chunk_from_buffer() {
     return chunk;
 }
 
-Status OlapChunkSource::buffer_next_batch_chunks_blocking(size_t batch_size, bool& can_finish, size_t* read_size) {
+Status OlapChunkSource::buffer_next_batch_chunks_blocking(size_t batch_size, bool& can_finish,
+                                                          size_t* num_read_chunks) {
     if (!_status.ok()) {
         return _status;
     }
@@ -307,12 +308,12 @@ Status OlapChunkSource::buffer_next_batch_chunks_blocking(size_t batch_size, boo
             // end of file is normal case, need process chunk
             if (_status.is_end_of_file()) {
                 _chunk_buffer.put(std::move(chunk));
-                (*read_size)++;
+                ++(*num_read_chunks);
             }
             break;
         }
         _chunk_buffer.put(std::move(chunk));
-        (*read_size)++;
+        ++(*num_read_chunks);
     }
     return _status;
 }

--- a/be/src/exec/pipeline/olap_chunk_source.h
+++ b/be/src/exec/pipeline/olap_chunk_source.h
@@ -60,7 +60,7 @@ public:
 
     StatusOr<vectorized::ChunkPtr> get_next_chunk_from_buffer() override;
 
-    Status buffer_next_batch_chunks_blocking(size_t chunk_size, bool& can_finish, size_t* read_size) override;
+    Status buffer_next_batch_chunks_blocking(size_t chunk_size, bool& can_finish, size_t* num_read_chunks) override;
 
 private:
     Status _get_tablet(const TInternalScanRange* scan_range);

--- a/be/src/exec/pipeline/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan_operator.cpp
@@ -158,10 +158,8 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
             size_t num_read_chunks = 0;
             _chunk_sources[chunk_source_index]->buffer_next_batch_chunks_blocking(_buffer_size, _is_finished,
                                                                                   &num_read_chunks);
-            if (this->_workgroup != nullptr) {
-                // TODO (by laotan332): More detailed information is needed
-                this->_workgroup->increase_chunk_num(num_read_chunks);
-            }
+            // TODO (by laotan332): More detailed information is needed
+            _workgroup->increase_chunk_num(num_read_chunks);
         }
 
         _num_running_io_tasks--;

--- a/be/src/exec/pipeline/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan_operator.cpp
@@ -119,16 +119,17 @@ void ScanOperator::set_finishing(RuntimeState* state) {
 StatusOr<vectorized::ChunkPtr> ScanOperator::pull_chunk(RuntimeState* state) {
     RETURN_IF_ERROR(_try_to_trigger_next_scan(state));
 
+    _workgroup->decrease_chunk_num(1);
+
     for (auto& chunk_source : _chunk_sources) {
         if (chunk_source != nullptr && chunk_source->has_output()) {
             auto&& chunk = chunk_source->get_next_chunk_from_buffer();
             eval_runtime_bloom_filters(chunk.value().get());
-            _workgroup->decrease_chunk_num(1);
+
             return std::move(chunk);
         }
     }
 
-    _workgroup->decrease_chunk_num(1);
     return nullptr;
 }
 

--- a/be/src/exec/pipeline/scan_operator.h
+++ b/be/src/exec/pipeline/scan_operator.h
@@ -46,7 +46,6 @@ public:
     void set_finishing(RuntimeState* state) override;
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
-    void set_io_threads(PriorityThreadPool* io_threads) { _io_threads = io_threads; }
 
     void set_workgroup(starrocks::workgroup::WorkGroupPtr wg);
 
@@ -68,7 +67,6 @@ private:
 
     const TOlapScanNode& _olap_scan_node;
     const std::vector<ExprContext*>& _conjunct_ctxs;
-    PriorityThreadPool* _io_threads = nullptr;
     std::vector<std::string> _unused_output_columns;
     // Pass limit info to scan operator in order to improve sql:
     // select * from table limit x;

--- a/be/src/exec/workgroup/io_dispatcher.h
+++ b/be/src/exec/workgroup/io_dispatcher.h
@@ -14,7 +14,8 @@ class WorkGroupManager;
 class IoDispatcher {
 public:
     explicit IoDispatcher(std::unique_ptr<ThreadPool> thread_pool);
-    virtual ~IoDispatcher() = default;
+    virtual ~IoDispatcher();
+
     void initialize(int32_t num_threads);
     void change_num_threads(int32_t num_threads);
 

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -13,10 +13,10 @@ WorkGroup::WorkGroup(const std::string& name, int id, size_t cpu_limit, size_t m
                      WorkGroupType type)
         : _name(name),
           _id(id),
-          _type(type),
           _cpu_limit(cpu_limit),
           _memory_limit(memory_limit),
-          _concurrency(concurrency) {}
+          _concurrency(concurrency),
+          _type(type) {}
 
 WorkGroup::WorkGroup(const TWorkGroup& twg) : _name(twg.name), _id(twg.id) {
     if (twg.__isset.cpu_limit) {

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -13,14 +13,10 @@ WorkGroup::WorkGroup(const std::string& name, int id, size_t cpu_limit, size_t m
                      WorkGroupType type)
         : _name(name),
           _id(id),
+          _type(type),
           _cpu_limit(cpu_limit),
           _memory_limit(memory_limit),
-          _concurrency(concurrency),
-          _type(type) {
-    _expect_factor = _cpu_expect_use_ratio;
-    _select_factor = _expect_factor;
-    _cur_select_factor = _select_factor;
-}
+          _concurrency(concurrency) {}
 
 WorkGroup::WorkGroup(const TWorkGroup& twg) : _name(twg.name), _id(twg.id) {
     if (twg.__isset.cpu_limit) {
@@ -81,41 +77,6 @@ double WorkGroup::get_cpu_actual_use_ratio() const {
     return static_cast<double>(get_real_runtime_ns()) / sum_cpu_runtime_ns;
 }
 
-WorkGroupManager::WorkGroupManager() {}
-WorkGroupManager::~WorkGroupManager() {}
-void WorkGroupManager::destroy() {
-    std::lock_guard<std::mutex> lock(_mutex);
-    this->_workgroups.clear();
-}
-
-WorkGroupPtr WorkGroupManager::add_workgroup(const WorkGroupPtr& wg) {
-    std::lock_guard<std::mutex> lock(_mutex);
-    if (!_workgroups.count(wg->id())) {
-        _workgroups[wg->id()] = wg;
-        _wg_io_queue.add(wg);
-        _sum_cpu_limit += wg->get_cpu_limit();
-        return wg;
-    } else {
-        return _workgroups[wg->id()];
-    }
-}
-
-WorkGroupPtr WorkGroupManager::get_default_workgroup() {
-    std::lock_guard<std::mutex> lock(_mutex);
-    DCHECK(_workgroups.count(WorkGroup::DEFAULT_WG_ID));
-    return _workgroups[WorkGroup::DEFAULT_WG_ID];
-}
-
-void WorkGroupManager::remove_workgroup(int wg_id) {
-    std::lock_guard<std::mutex> lock(_mutex);
-    if (_workgroups.count(wg_id)) {
-        auto wg = std::move(_workgroups[wg_id]);
-        _sum_cpu_limit -= wg->get_cpu_limit();
-        _workgroups.erase(wg_id);
-        _wg_io_queue.remove(wg);
-    }
-}
-
 bool WorkGroup::try_offer_io_task(const PriorityThreadPool::Task& task) {
     _io_work_queue.emplace(std::move(task));
     return true;
@@ -127,7 +88,7 @@ PriorityThreadPool::Task WorkGroup::pick_io_task() {
     return task;
 }
 
-// shuold be call when read chunk_num from disk
+// Should be call when read chunk_num from disk.
 void WorkGroup::increase_chunk_num(int32_t chunk_num) {
     _cur_hold_total_chunk_num += chunk_num;
     _increase_chunk_num_period += chunk_num;
@@ -188,28 +149,15 @@ void WorkGroup::estimate_trend_factor_period() {
     // If it is positive, it means that its resources are sufficient and can be reduced by a fraction
     //_diff_factor = get_cpu_expected_use_ratio() - _expect_factor;
     _diff_factor = _select_factor - _expect_factor;
-
-    // reset
-    _decrease_chunk_num_period = 1;
-    _increase_chunk_num_period = 1;
 }
 
 size_t WorkGroup::io_task_queue_size() {
     return _io_work_queue.size();
 }
 
-void IoWorkGroupQueue::adjust_weight_if_need() {
-    if (--_cur_schedule_num > 0) {
-        return;
-    }
-
-    _io_wgs.clear();
-    for (const auto& wg : _ready_wgs) {
-        _io_wgs.push_back(wg);
-    }
-
+void IoWorkGroupQueue::_adjust_weight() {
     // calculate all wg factors
-    for (auto const& wg : _io_wgs) {
+    for (auto& wg : _ready_wgs) {
         wg->estimate_trend_factor_period();
     }
 
@@ -217,7 +165,7 @@ void IoWorkGroupQueue::adjust_weight_if_need() {
     // positive_total_diff_factor Cumulative All Resource Excess WorkGroup
     double positive_total_diff_factor = 0.0;
     double negative_total_diff_factor = 0.0;
-    for (auto const& wg : _io_wgs) {
+    for (auto const& wg : _ready_wgs) {
         if (wg->get_diff_factor() > 0) {
             positive_total_diff_factor += wg->get_diff_factor();
         } else {
@@ -225,20 +173,12 @@ void IoWorkGroupQueue::adjust_weight_if_need() {
         }
     }
 
-    if (_schedule_num_period > _total_task_num) {
-        _cur_schedule_num_period = _total_task_num;
-    } else {
-        _cur_schedule_num_period = _schedule_num_period;
-    }
-
     // If positive_total_diff_factor <= 0, it This means that all WorkGs have no excess resources
     // So we don't need to adjust it and keep the original limit
     if (positive_total_diff_factor <= 0) {
-        for (auto const& wg : _io_wgs) {
+        for (auto& wg : _ready_wgs) {
             wg->set_select_factor(wg->get_cpu_expected_use_ratio());
         }
-        schedule_io_task();
-        _cur_schedule_num = _cur_schedule_num_period;
         return;
     }
 
@@ -253,7 +193,7 @@ void IoWorkGroupQueue::adjust_weight_if_need() {
         // This means that the resources are sufficient
         // So we can reduce the proportion of resources in the WorkGroup that are over-resourced
         // Then increase the proportion of resources for those WorkGs that are under-resourced
-        for (auto const& wg : _io_wgs) {
+        for (auto& wg : _ready_wgs) {
             if (wg->get_diff_factor() < 0) {
                 wg->update_select_factor(0 - negative_total_diff_factor * wg->get_diff_factor() /
                                                      negative_total_diff_factor);
@@ -267,7 +207,7 @@ void IoWorkGroupQueue::adjust_weight_if_need() {
         // This means that there are not enough resources, but some WorkGs are still over-resourced
         // So we can reduce the proportion of resources in the WorkGroup that are over-resourced
         // Then increase the proportion of resources for those WorkGs that are under-resourced
-        for (auto const& wg : _io_wgs) {
+        for (auto& wg : _ready_wgs) {
             if (wg->get_diff_factor() < 0) {
                 wg->update_select_factor(positive_total_diff_factor * wg->get_diff_factor() /
                                          negative_total_diff_factor);
@@ -277,72 +217,50 @@ void IoWorkGroupQueue::adjust_weight_if_need() {
             }
         }
     }
-
-    schedule_io_task();
-    _cur_schedule_num = _cur_schedule_num_period;
 }
 
-void IoWorkGroupQueue::schedule_io_task() {
-    // In a scheduling period, we calculate in advance
-    for (size_t i = 0; i < _cur_schedule_num_period; i++) {
-        size_t idx = get_next_wg_index();
-        _cur_wait_run_wgs[i] = _io_wgs[idx];
-    }
-    _cur_index = 0;
-}
-
-size_t IoWorkGroupQueue::get_next_wg_index() {
-    int index = -1;
+WorkGroupPtr IoWorkGroupQueue::_select_next_wg() {
+    WorkGroupPtr max_wg = nullptr;
     double total = 0;
-    for (int i = 0; i < _io_wgs.size(); i++) {
-        _io_wgs[i]->update_cur_select_factor(_io_wgs[i]->get_select_factor());
-        total += _io_wgs[i]->get_select_factor();
-        if (index == -1 || _io_wgs[i]->get_cur_select_factor() > _io_wgs[index]->get_cur_select_factor()) {
-            index = i;
+    for (auto wg : _ready_wgs) {
+        wg->update_cur_select_factor(wg->get_select_factor());
+        total += wg->get_select_factor();
+        if (max_wg == nullptr || wg->get_cur_select_factor() > max_wg->get_cur_select_factor()) {
+            max_wg = wg;
         }
     }
-    _io_wgs[index]->update_cur_select_factor(0 - total);
-    return index;
+    max_wg->update_cur_select_factor(0 - total);
+    return max_wg;
 }
 
-WorkGroupPtr IoWorkGroupQueue::get_next_wg() {
-    int index = _cur_index++;
-    if (index < _cur_schedule_num_period) {
-        return _cur_wait_run_wgs[index];
-    }
-
-    return nullptr;
-}
-
-PriorityThreadPool::Task IoWorkGroupQueue::pick_next_task() {
+StatusOr<PriorityThreadPool::Task> IoWorkGroupQueue::pick_next_task() {
     std::unique_lock<std::mutex> lock(_global_io_mutex);
+
+    if (_is_closed) {
+        return Status::Cancelled("Shutdown");
+    }
     while (_ready_wgs.empty()) {
         _cv.wait(lock);
+        if (_is_closed) {
+            return Status::Cancelled("Shutdown");
+        }
     }
-    WorkGroupPtr wg = nullptr;
-    do {
-        adjust_weight_if_need();
-        wg = get_next_wg();
-    } while (wg == nullptr || wg->io_task_queue_size() == 0);
 
+    _adjust_weight();
+    WorkGroupPtr wg = _select_next_wg();
+    ++wg->num_selected_io_times;
     if (wg->io_task_queue_size() == 1) {
         _ready_wgs.erase(wg);
     }
+
     _total_task_num--;
 
     return wg->pick_io_task();
 }
 
-PriorityThreadPool::Task WorkGroupManager::pick_next_task_for_io() {
-    return _wg_io_queue.pick_next_task();
-}
-
-WorkGroupQueue& WorkGroupManager::get_io_queue() {
-    return _wg_io_queue;
-}
-
 bool IoWorkGroupQueue::try_offer_io_task(WorkGroupPtr wg, const PriorityThreadPool::Task& task) {
     std::lock_guard<std::mutex> lock(_global_io_mutex);
+
     wg->try_offer_io_task(task);
     if (_ready_wgs.find(wg) == _ready_wgs.end()) {
         _ready_wgs.emplace(wg);
@@ -351,6 +269,61 @@ bool IoWorkGroupQueue::try_offer_io_task(WorkGroupPtr wg, const PriorityThreadPo
     _total_task_num++;
     _cv.notify_one();
     return true;
+}
+
+void IoWorkGroupQueue::close() {
+    std::lock_guard<std::mutex> lock(_global_io_mutex);
+
+    if (_is_closed) {
+        return;
+    }
+
+    _is_closed = true;
+    _cv.notify_all();
+}
+
+WorkGroupManager::WorkGroupManager() {}
+WorkGroupManager::~WorkGroupManager() {}
+
+void WorkGroupManager::destroy() {
+    std::lock_guard<std::mutex> lock(_mutex);
+    this->_workgroups.clear();
+}
+
+WorkGroupPtr WorkGroupManager::add_workgroup(const WorkGroupPtr& wg) {
+    std::lock_guard<std::mutex> lock(_mutex);
+    if (!_workgroups.count(wg->id())) {
+        _workgroups[wg->id()] = wg;
+        _wg_io_queue.add(wg);
+        _sum_cpu_limit += wg->get_cpu_limit();
+        return wg;
+    } else {
+        return _workgroups[wg->id()];
+    }
+}
+
+WorkGroupPtr WorkGroupManager::get_default_workgroup() {
+    std::lock_guard<std::mutex> lock(_mutex);
+    DCHECK(_workgroups.count(WorkGroup::DEFAULT_WG_ID));
+    return _workgroups[WorkGroup::DEFAULT_WG_ID];
+}
+
+void WorkGroupManager::remove_workgroup(int wg_id) {
+    std::lock_guard<std::mutex> lock(_mutex);
+    if (_workgroups.count(wg_id)) {
+        auto wg = std::move(_workgroups[wg_id]);
+        _sum_cpu_limit -= wg->get_cpu_limit();
+        _workgroups.erase(wg_id);
+        _wg_io_queue.remove(wg);
+    }
+}
+
+void WorkGroupManager::close() {
+    _wg_io_queue.close();
+}
+
+StatusOr<PriorityThreadPool::Task> WorkGroupManager::pick_next_task_for_io() {
+    return _wg_io_queue.pick_next_task();
 }
 
 bool WorkGroupManager::try_offer_io_task(WorkGroupPtr wg, const PriorityThreadPool::Task& task) {
@@ -368,8 +341,9 @@ void WorkGroupManager::log_cpu() {
                      << "[expected_ratio=" << wg->get_cpu_expected_use_ratio() << "] "
                      << "[real_ratio=" << wg->get_cpu_unadjusted_actual_use_ratio() << "] ";
         LOG(WARNING) << "[TEST] io "
-                     << "select_factor: " << wg->get_select_factor() << " cur_hold_total_chunk_num "
-                     << wg->get_cur_hold_total_chunk_num();
+                     << "[select_factor=" << wg->get_select_factor() << "] "
+                     << "[cur_hold_total_chunk_num " << wg->get_cur_hold_total_chunk_num() << "] "
+                     << "[selected_io_times=" << wg->num_selected_io_times << "] ";
     }
     LOG(WARNING) << "[TEST] ===============================";
 }

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -248,7 +248,6 @@ StatusOr<PriorityThreadPool::Task> IoWorkGroupQueue::pick_next_task() {
 
     _adjust_weight();
     WorkGroupPtr wg = _select_next_wg();
-    ++wg->num_selected_io_times;
     if (wg->io_task_queue_size() == 1) {
         _ready_wgs.erase(wg);
     }
@@ -328,24 +327,6 @@ StatusOr<PriorityThreadPool::Task> WorkGroupManager::pick_next_task_for_io() {
 
 bool WorkGroupManager::try_offer_io_task(WorkGroupPtr wg, const PriorityThreadPool::Task& task) {
     return _wg_io_queue.try_offer_io_task(wg, task);
-}
-
-void WorkGroupManager::log_cpu() {
-    LOG(WARNING) << "[TEST] ===============================";
-    for (auto [_, wg] : _workgroups) {
-        LOG(WARNING) << "[TEST] cpu "
-                     << "[wg=" << wg->name() << "] "
-                     << "[cpu_limit=" << wg->get_cpu_limit() << "] "
-                     << "[runtime=" << wg->get_real_runtime_ns() / 1000'000.0L << "] "
-                     << "[vruntime=" << wg->get_vruntime_ns() / 1000'000.0L << "] "
-                     << "[expected_ratio=" << wg->get_cpu_expected_use_ratio() << "] "
-                     << "[real_ratio=" << wg->get_cpu_unadjusted_actual_use_ratio() << "] ";
-        LOG(WARNING) << "[TEST] io "
-                     << "[select_factor=" << wg->get_select_factor() << "] "
-                     << "[cur_hold_total_chunk_num " << wg->get_cur_hold_total_chunk_num() << "] "
-                     << "[selected_io_times=" << wg->num_selected_io_times << "] ";
-    }
-    LOG(WARNING) << "[TEST] ===============================";
 }
 
 DefaultWorkGroupInitialization::DefaultWorkGroupInitialization() {

--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -27,42 +27,41 @@ class WorkGroupQueue {
 public:
     WorkGroupQueue() = default;
     virtual ~WorkGroupQueue() = default;
+
     virtual void add(const WorkGroupPtr& wg) = 0;
     virtual void remove(const WorkGroupPtr& wg) = 0;
     virtual WorkGroupPtr pick_next() = 0;
+
+    virtual void close() = 0;
 };
 
 class IoWorkGroupQueue final : public WorkGroupQueue {
 public:
-    IoWorkGroupQueue() : _schedule_num_period(1024) { _cur_wait_run_wgs.resize(_schedule_num_period, nullptr); };
-    ~IoWorkGroupQueue() = default;
+    IoWorkGroupQueue() = default;
+    ~IoWorkGroupQueue() override = default;
+
     void add(const WorkGroupPtr& wg) override {}
     void remove(const WorkGroupPtr& wg) override {}
     WorkGroupPtr pick_next() override { return nullptr; };
 
-    PriorityThreadPool::Task pick_next_task();
+    StatusOr<PriorityThreadPool::Task> pick_next_task();
     bool try_offer_io_task(WorkGroupPtr wg, const PriorityThreadPool::Task& task);
 
-private:
-    void adjust_weight_if_need();
-    void schedule_io_task();
+    void close() override;
 
-    size_t get_next_wg_index();
-    WorkGroupPtr get_next_wg();
+private:
+    void _adjust_weight();
+
+    WorkGroupPtr _select_next_wg();
 
 private:
     std::mutex _global_io_mutex;
     std::condition_variable _cv;
 
-    std::vector<WorkGroupPtr> _io_wgs;
+    bool _is_closed = false;
+
     std::unordered_set<WorkGroupPtr> _ready_wgs;
     std::atomic<size_t> _total_task_num = 0;
-    std::atomic<size_t> _cur_index = 0;
-    std::vector<WorkGroupPtr> _cur_wait_run_wgs;
-
-    const size_t _schedule_num_period;
-    std::atomic<int> _cur_schedule_num = 0;
-    size_t _cur_schedule_num_period = 0;
 };
 
 class WorkGroupManager;
@@ -90,11 +89,6 @@ public:
     int id() const { return _id; }
 
     const std::string& name() const { return _name; }
-
-    int get_io_priority() {
-        // TODO: implement io priority computation
-        return 0;
-    }
 
     size_t get_cpu_limit() const { return _cpu_limit; }
     int64_t get_vruntime_ns() const { return _vruntime_ns; }
@@ -136,6 +130,8 @@ public:
     double get_cur_select_factor() const;
     void update_cur_select_factor(double value);
 
+    // TODO(ZiheLiu): remove them. They are just for test.
+    std::atomic<int> num_selected_io_times = 0;
 private:
     std::string _name;
     int _id;
@@ -161,20 +157,15 @@ private:
     // BlockingPriorityQueue<PriorityThreadPool::Task> _io_work_queue;
     std::queue<PriorityThreadPool::Task> _io_work_queue;
 
-    std::atomic<double> _cpu_expect_use_ratio;
-    std::atomic<double> _cpu_actual_use_ratio;
-
     //  some variables for io schedule
     std::atomic<int64_t> _cur_hold_total_chunk_num = 0; // total chunk num wait for consume
     std::atomic<size_t> _increase_chunk_num_period = 1;
     std::atomic<size_t> _decrease_chunk_num_period = 1;
 
-    std::atomic<bool> _is_estimate = false;
-
-    double _expect_factor; // the factor which should be selected to run by scheduler
-    double _diff_factor;
-    double _select_factor;
-    double _cur_select_factor;
+    double _expect_factor = 0; // the factor which should be selected to run by scheduler
+    double _diff_factor = 0;
+    double _select_factor = 0;
+    double _cur_select_factor = 0;
 };
 
 // WorkGroupManager is a singleton used to manage WorkGroup instances in BE, it has an io queue and a cpu queues for
@@ -192,13 +183,11 @@ public:
     // remove already-existing workgroup from WorkGroupManager
     void remove_workgroup(int wg_id);
 
+    void close();
+
     // get next workgroup for io
-    PriorityThreadPool::Task pick_next_task_for_io();
+    StatusOr<PriorityThreadPool::Task> pick_next_task_for_io();
     bool try_offer_io_task(WorkGroupPtr wg, const PriorityThreadPool::Task& task);
-
-    WorkGroupQueue& get_cpu_queue();
-
-    WorkGroupQueue& get_io_queue();
 
     size_t get_sum_cpu_limit() const { return _sum_cpu_limit; }
     void increment_cpu_runtime_ns(int64_t cpu_runtime_ns) { _sum_cpu_runtime_ns += cpu_runtime_ns; }
@@ -207,7 +196,6 @@ public:
         _sum_unadjusted_cpu_runtime_ns += cpu_runtime_ns;
     }
     int64_t get_sum_unadjusted_cpu_runtime_ns() const { return _sum_unadjusted_cpu_runtime_ns; }
-    double get_cpu_unadjusted_actual_use_ratio() const;
 
     void log_cpu();
 

--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -50,11 +50,9 @@ public:
     void close() override;
 
 private:
-    void _adjust_weight();
-
+    void _maybe_adjust_weight();
     WorkGroupPtr _select_next_wg();
 
-private:
     std::mutex _global_io_mutex;
     std::condition_variable _cv;
 
@@ -62,6 +60,10 @@ private:
 
     std::unordered_set<WorkGroupPtr> _ready_wgs;
     std::atomic<size_t> _total_task_num = 0;
+
+    const int _max_schedule_num_period = config::pipeline_max_io_schedule_num_period;
+    // Adjust select factor of each wg after every `min(_max_schedule_num_period, num_tasks)` schedule times.
+    int _remaining_schedule_num_period = 0;
 };
 
 class WorkGroupManager;

--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -130,8 +130,6 @@ public:
     double get_cur_select_factor() const;
     void update_cur_select_factor(double value);
 
-    // TODO(ZiheLiu): remove them. They are just for test.
-    std::atomic<int> num_selected_io_times = 0;
 private:
     std::string _name;
     int _id;
@@ -196,8 +194,6 @@ public:
         _sum_unadjusted_cpu_runtime_ns += cpu_runtime_ns;
     }
     int64_t get_sum_unadjusted_cpu_runtime_ns() const { return _sum_unadjusted_cpu_runtime_ns; }
-
-    void log_cpu();
 
 private:
     std::mutex _mutex;

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -134,11 +134,6 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths) {
     _thread_pool = new PriorityThreadPool("olap_scan_io", // olap scan io
                                           config::doris_scanner_thread_pool_thread_num,
                                           config::doris_scanner_thread_pool_queue_size);
-    _pipeline_scan_io_thread_pool = new PriorityThreadPool("pip_scan_io", // pipeline scan io
-                                                           config::pipeline_scan_thread_pool_thread_num <= 0
-                                                                   ? std::thread::hardware_concurrency()
-                                                                   : config::pipeline_scan_thread_pool_thread_num,
-                                                           config::pipeline_scan_thread_pool_queue_size);
 
     _num_scan_operators = 0;
     _etl_thread_pool = new PriorityThreadPool("elt", config::etl_thread_pool_size, config::etl_thread_pool_queue_size);
@@ -363,14 +358,6 @@ void ExecEnv::_destroy() {
     if (_etl_thread_pool) {
         delete _etl_thread_pool;
         _etl_thread_pool = nullptr;
-    }
-    if (_pipeline_scan_io_thread_pool) {
-        delete _pipeline_scan_io_thread_pool;
-        _pipeline_scan_io_thread_pool = nullptr;
-    }
-    if (_io_dispatcher) {
-        delete _io_dispatcher;
-        _io_dispatcher = nullptr;
     }
     if (_thread_pool) {
         delete _thread_pool;

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -127,9 +127,6 @@ public:
 
     ThreadResourceMgr* thread_mgr() { return _thread_mgr; }
     PriorityThreadPool* thread_pool() { return _thread_pool; }
-    PriorityThreadPool* pipeline_scan_io_thread_pool() { return _pipeline_scan_io_thread_pool; }
-    size_t increment_num_scan_operators(size_t n) { return _num_scan_operators.fetch_add(n); }
-    size_t decrement_num_scan_operators(size_t n) { return _num_scan_operators.fetch_sub(n); }
     PriorityThreadPool* etl_thread_pool() { return _etl_thread_pool; }
     FragmentMgr* fragment_mgr() { return _fragment_mgr; }
     starrocks::pipeline::DriverDispatcher* driver_dispatcher() { return _driver_dispatcher; }
@@ -207,7 +204,6 @@ private:
 
     ThreadResourceMgr* _thread_mgr = nullptr;
     PriorityThreadPool* _thread_pool = nullptr;
-    PriorityThreadPool* _pipeline_scan_io_thread_pool = nullptr;
     std::atomic<size_t> _num_scan_operators;
     PriorityThreadPool* _etl_thread_pool = nullptr;
     FragmentMgr* _fragment_mgr = nullptr;


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Problem Summary ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Remove prefetch of next to be executed num_schedule workgroups for i/o dispatcher, because the overhead of calculating which workgroup to be executed is not large, and a new ready workgroup may be delayed num_schedule times.

Fix the BE uint test by adding close logic for io dispatcher.

Yield i/o task when it spent `pipeline_scan_task_yield_max_tims_spent` time, default is 100ms.
