### PR TITLE
Improve statistic table rebuild if replicate miss

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
@@ -200,8 +200,7 @@ public class CachedStatisticStorage implements StatisticStorage {
             return ColumnStatistic.unknown();
         }
 
-        Table statisticsTable = StatisticUtils.getStatisticsTable();
-        if (statisticsTable == null) {
+        if (!StatisticUtils.checkStatisticTableStateNormal()) {
             return ColumnStatistic.unknown();
         }
 
@@ -237,8 +236,7 @@ public class CachedStatisticStorage implements StatisticStorage {
             return getDefaultColumnStatisticList(columns);
         }
 
-        Table statisticsTable = StatisticUtils.getStatisticsTable();
-        if (statisticsTable == null) {
+        if (!StatisticUtils.checkStatisticTableStateNormal()) {
             return getDefaultColumnStatisticList(columns);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticAutoCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticAutoCollector.java
@@ -62,8 +62,8 @@ public class StatisticAutoCollector extends MasterDaemon {
             return;
         }
 
-        // none statistic table
-        if (null == StatisticUtils.getStatisticsTable()) {
+        // check statistic table state
+        if (!StatisticUtils.checkStatisticTableStateNormal()) {
             return;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
@@ -25,9 +25,7 @@ import com.starrocks.qe.Coordinator;
 import com.starrocks.qe.OriginStatement;
 import com.starrocks.qe.QueryState;
 import com.starrocks.qe.RowBatch;
-import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.StmtExecutor;
-import com.starrocks.qe.VariableMgr;
 import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.ast.QueryRelation;
 import com.starrocks.sql.optimizer.OptExpression;
@@ -306,7 +304,6 @@ public class StatisticExecutor {
 
     private static ExecPlan getExecutePlan(Map<String, Database> dbs, ConnectContext context,
                                            StatementBase parsedStmt, boolean isStatistic) {
-        SessionVariable sessionVariable = VariableMgr.newSessionVariable();
         ExecPlan execPlan;
         try {
             lock(dbs);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -75,6 +75,31 @@ public class StatisticUtils {
         return false;
     }
 
+    public static boolean checkStatisticTableStateNormal() {
+        Database db = Catalog.getCurrentCatalog().getDb(Constants.StatisticsDBName);
+
+        // check database
+        if (db == null) {
+            return false;
+        }
+
+        // check table
+        OlapTable table = (OlapTable) db.getTable(Constants.StatisticsTableName);
+        if (table == null) {
+            return false;
+        }
+
+        // check replicate miss
+        for (Partition partition : table.getPartitions()) {
+            if (partition.getBaseIndex().getTablets().stream()
+                    .anyMatch(t -> t.getNormalReplicaBackendIds().isEmpty())) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     public static LocalDateTime getTableLastUpdateTime(Table table) {
         long maxTime = ((OlapTable) table).getPartitions().stream().map(Partition::getVisibleVersionTime)
                 .max(Long::compareTo).orElse(0L);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Some users will add/drop BE node multiple times, it's will lose replicas of `table_statistic_v1` table when the initial cluster has only one BE node. 
This PR will check replica stats and rebuild `table_statistic_v1` when `StatisticMetaManager` working.
