### PR TITLE
Fix the agg bug processing alloc mem failed

### DIFF
--- a/be/src/exec/vectorized/aggregate/agg_hash_map.h
+++ b/be/src/exec/vectorized/aggregate/agg_hash_map.h
@@ -112,7 +112,6 @@ struct AggHashMapWithOneNumberKey {
             FieldType key = column->get_data()[i];
             auto iter = hash_map.lazy_emplace_with_hash(key, hash_values[i], [&](const auto& ctor) {
                 AggDataPtr pv = allocate_func();
-                ERASE_AND_THROW_BAD_ALLOC_IF_NULL_WITH_HASH(hash_map, pv, key, hash_values[i]);
                 ctor(key, pv);
             });
             (*agg_states)[i] = iter->second;
@@ -168,7 +167,6 @@ struct AggHashMapWithOneNullableNumberKey {
         if (key_columns[0]->only_null()) {
             if (null_key_data == nullptr) {
                 null_key_data = allocate_func();
-                THROW_BAD_ALLOC_IF_NULL(null_key_data);
             }
             for (size_t i = 0; i < chunk_size; i++) {
                 (*agg_states)[i] = null_key_data;
@@ -185,7 +183,6 @@ struct AggHashMapWithOneNullableNumberKey {
                     auto key = data_column->get_data()[i];
                     auto iter = hash_map.lazy_emplace_with_hash(key, hash_values[i], [&](const auto& ctor) {
                         AggDataPtr pv = allocate_func();
-                        ERASE_AND_THROW_BAD_ALLOC_IF_NULL_WITH_HASH(hash_map, pv, key, hash_values[i]);
                         ctor(key, pv);
                     });
                     (*agg_states)[i] = iter->second;
@@ -197,7 +194,6 @@ struct AggHashMapWithOneNullableNumberKey {
                 if (key_columns[0]->is_null(i)) {
                     if (null_key_data == nullptr) {
                         null_key_data = allocate_func();
-                        THROW_BAD_ALLOC_IF_NULL(null_key_data);
                     }
                     (*agg_states)[i] = null_key_data;
                 } else {
@@ -218,7 +214,6 @@ struct AggHashMapWithOneNullableNumberKey {
         if (key_columns[0]->only_null()) {
             if (null_key_data == nullptr) {
                 null_key_data = allocate_func();
-                THROW_BAD_ALLOC_IF_NULL(null_key_data);
             }
             for (size_t i = 0; i < chunk_size; i++) {
                 (*agg_states)[i] = null_key_data;
@@ -242,7 +237,6 @@ struct AggHashMapWithOneNullableNumberKey {
                 if (key_columns[0]->is_null(i)) {
                     if (null_key_data == nullptr) {
                         null_key_data = allocate_func();
-                        THROW_BAD_ALLOC_IF_NULL(null_key_data);
                     }
                     (*agg_states)[i] = null_key_data;
                 } else {
@@ -258,7 +252,6 @@ struct AggHashMapWithOneNullableNumberKey {
         auto key = data_column->get_data()[row];
         auto iter = hash_map.lazy_emplace(key, [&](const auto& ctor) {
             AggDataPtr pv = allocate_func();
-            ERASE_AND_THROW_BAD_ALLOC_IF_NULL(hash_map, pv, key);
             ctor(key, pv);
         });
         (*agg_states)[row] = iter->second;
@@ -309,11 +302,9 @@ struct AggHashMapWithOneStringKey {
             auto iter = hash_map.lazy_emplace_with_hash(key, hash_values[i], [&](const auto& ctor) {
                 // we must persist the slice before insert
                 uint8_t* pos = pool->allocate(key.size);
-                ERASE_AND_THROW_BAD_ALLOC_IF_NULL_WITH_HASH(hash_map, pos, key, hash_values[i]);
                 strings::memcpy_inlined(pos, key.data, key.size);
                 Slice pk{pos, key.size};
                 AggDataPtr pv = allocate_func();
-                ERASE_AND_THROW_BAD_ALLOC_IF_NULL_WITH_HASH(hash_map, pv, key, hash_values[i]);
                 ctor(pk, pv);
             });
             (*agg_states)[i] = iter->second;
@@ -364,7 +355,6 @@ struct AggHashMapWithOneNullableStringKey {
         if (key_columns[0]->only_null()) {
             if (null_key_data == nullptr) {
                 null_key_data = allocate_func();
-                THROW_BAD_ALLOC_IF_NULL(null_key_data);
             }
             for (size_t i = 0; i < chunk_size; i++) {
                 (*agg_states)[i] = null_key_data;
@@ -382,11 +372,9 @@ struct AggHashMapWithOneNullableStringKey {
                     auto key = data_column->get_slice(i);
                     auto iter = hash_map.lazy_emplace_with_hash(key, hash_values[i], [&](const auto& ctor) {
                         uint8_t* pos = pool->allocate(key.size);
-                        ERASE_AND_THROW_BAD_ALLOC_IF_NULL_WITH_HASH(hash_map, pos, key, hash_values[i]);
                         strings::memcpy_inlined(pos, key.data, key.size);
                         Slice pk{pos, key.size};
                         AggDataPtr pv = allocate_func();
-                        ERASE_AND_THROW_BAD_ALLOC_IF_NULL_WITH_HASH(hash_map, pv, key, hash_values[i]);
                         ctor(pk, pv);
                     });
                     (*agg_states)[i] = iter->second;
@@ -398,7 +386,6 @@ struct AggHashMapWithOneNullableStringKey {
                 if (key_columns[0]->is_null(i)) {
                     if (null_key_data == nullptr) {
                         null_key_data = allocate_func();
-                        THROW_BAD_ALLOC_IF_NULL(null_key_data);
                     }
                     (*agg_states)[i] = null_key_data;
                 } else {
@@ -418,7 +405,6 @@ struct AggHashMapWithOneNullableStringKey {
         if (key_columns[0]->only_null()) {
             if (null_key_data == nullptr) {
                 null_key_data = allocate_func();
-                THROW_BAD_ALLOC_IF_NULL(null_key_data);
             }
             for (size_t i = 0; i < chunk_size; i++) {
                 (*agg_states)[i] = null_key_data;
@@ -440,7 +426,6 @@ struct AggHashMapWithOneNullableStringKey {
                 if (nullable_column->is_null(i)) {
                     if (null_key_data == nullptr) {
                         null_key_data = allocate_func();
-                        THROW_BAD_ALLOC_IF_NULL(null_key_data);
                     }
                     (*agg_states)[i] = null_key_data;
                 } else {
@@ -456,11 +441,9 @@ struct AggHashMapWithOneNullableStringKey {
         auto key = data_column->get_slice(row);
         auto iter = hash_map.lazy_emplace(key, [&](const auto& ctor) {
             uint8_t* pos = pool->allocate(key.size);
-            ERASE_AND_THROW_BAD_ALLOC_IF_NULL(hash_map, pos, key);
             strings::memcpy_inlined(pos, key.data, key.size);
             Slice pk{pos, key.size};
             AggDataPtr pv = allocate_func();
-            ERASE_AND_THROW_BAD_ALLOC_IF_NULL(hash_map, pv, key);
             ctor(pk, pv);
         });
         (*agg_states)[row] = iter->second;
@@ -499,9 +482,7 @@ struct AggHashMapWithSerializedKey {
     AggHashMapWithSerializedKey(int32_t chunk_size)
             : mem_pool(std::make_unique<MemPool>()),
               buffer(mem_pool->allocate(max_one_row_size * chunk_size)),
-              _chunk_size(chunk_size) {
-        THROW_BAD_ALLOC_IF_NULL(buffer);
-    }
+              _chunk_size(chunk_size) {}
 
     template <typename Func>
     void compute_agg_states(size_t chunk_size, const Columns& key_columns, MemPool* pool, Func&& allocate_func,
@@ -515,7 +496,6 @@ struct AggHashMapWithSerializedKey {
             // reserved extra SLICE_MEMEQUAL_OVERFLOW_PADDING bytes to prevent SIMD instructions
             // from accessing out-of-bound memory.
             buffer = mem_pool->allocate(max_one_row_size * _chunk_size + SLICE_MEMEQUAL_OVERFLOW_PADDING);
-            THROW_BAD_ALLOC_IF_NULL(buffer);
         }
 
         for (const auto& key_column : key_columns) {
@@ -527,11 +507,9 @@ struct AggHashMapWithSerializedKey {
             auto iter = hash_map.lazy_emplace(key, [&](const auto& ctor) {
                 // we must persist the slice before insert
                 uint8_t* pos = pool->allocate(key.size);
-                ERASE_AND_THROW_BAD_ALLOC_IF_NULL(hash_map, pos, key);
                 strings::memcpy_inlined(pos, key.data, key.size);
                 Slice pk{pos, key.size};
                 AggDataPtr pv = allocate_func();
-                ERASE_AND_THROW_BAD_ALLOC_IF_NULL(hash_map, pv, key);
                 ctor(pk, pv);
             });
             (*agg_states)[i] = iter->second;
@@ -551,7 +529,6 @@ struct AggHashMapWithSerializedKey {
             max_one_row_size = cur_max_one_row_size;
             mem_pool->clear();
             buffer = mem_pool->allocate(max_one_row_size * _chunk_size);
-            THROW_BAD_ALLOC_IF_NULL(buffer);
         }
 
         for (const auto& key_column : key_columns) {
@@ -668,7 +645,6 @@ struct AggHashMapWithSerializedKeyFixedSize {
             FixedSizeSliceKey& key = caches[i].key;
             auto iter = hash_map.lazy_emplace_with_hash(key, caches[i].hashval, [&](const auto& ctor) {
                 AggDataPtr pv = allocate_func();
-                ERASE_AND_THROW_BAD_ALLOC_IF_NULL_WITH_HASH(hash_map, pv, key, caches[i].hashval);
                 ctor(key, pv);
             });
             (*agg_states)[i] = iter->second;

--- a/be/src/exec/vectorized/aggregate/agg_hash_set.h
+++ b/be/src/exec/vectorized/aggregate/agg_hash_set.h
@@ -53,18 +53,6 @@ using SliceAggTwoLevelHashSet =
         phmap::parallel_flat_hash_set<TSliceWithHash<seed>, THashOnSliceWithHash<seed>, TEqualOnSliceWithHash<seed>,
                                       phmap::priv::Allocator<Slice>, 4>;
 
-#define ERASE_AND_THROW_BAD_ALLOC_IF_NULL(hash_set, pv, key) \
-    if (UNLIKELY(pv == nullptr)) {                           \
-        hash_set.erase(key);                                 \
-        throw std::bad_alloc();                              \
-    }
-
-#define ERASE_AND_THROW_BAD_ALLOC_IF_NULL_WITH_HASH(hash_set, pv, key, hash) \
-    if (UNLIKELY(pv == nullptr)) {                                           \
-        hash_set.erase_with_hash(key, hash);                                 \
-        throw std::bad_alloc();                                              \
-    }
-
 // ==============================================================
 // handle one number hash key
 template <PrimitiveType primitive_type, typename HashSet>
@@ -208,7 +196,6 @@ struct AggHashSetOfOneStringKey {
             hash_set.lazy_emplace(key, [&](const auto& ctor) {
                 // we must persist the slice before insert
                 uint8_t* pos = pool->allocate(key.size);
-                ERASE_AND_THROW_BAD_ALLOC_IF_NULL(hash_set, pos, key);
                 memcpy(pos, key.data, key.size);
                 ctor(pos, key.size, key.hash);
             });
@@ -306,7 +293,6 @@ struct AggHashSetOfOneNullableStringKey {
 
         hash_set.lazy_emplace(key, [&](const auto& ctor) {
             uint8_t* pos = pool->allocate(key.size);
-            ERASE_AND_THROW_BAD_ALLOC_IF_NULL(hash_set, pos, key);
             memcpy(pos, key.data, key.size);
             ctor(pos, key.size, key.hash);
         });
@@ -341,9 +327,7 @@ struct AggHashSetOfSerializedKey {
     AggHashSetOfSerializedKey(int32_t chunk_size)
             : _mem_pool(std::make_unique<MemPool>()),
               _buffer(_mem_pool->allocate(max_one_row_size * chunk_size)),
-              _chunk_size(chunk_size) {
-        THROW_BAD_ALLOC_IF_NULL(_buffer);
-    }
+              _chunk_size(chunk_size) {}
 
     void build_set(size_t chunk_size, const Columns& key_columns, MemPool* pool) {
         slice_sizes.assign(_chunk_size, 0);
@@ -355,7 +339,6 @@ struct AggHashSetOfSerializedKey {
             // reserved extra SLICE_MEMEQUAL_OVERFLOW_PADDING bytes to prevent SIMD instructions
             // from accessing out-of-bound memory.
             _buffer = _mem_pool->allocate(max_one_row_size * _chunk_size + SLICE_MEMEQUAL_OVERFLOW_PADDING);
-            THROW_BAD_ALLOC_IF_NULL(_buffer);
         }
 
         for (const auto& key_column : key_columns) {
@@ -369,7 +352,6 @@ struct AggHashSetOfSerializedKey {
             hash_set.lazy_emplace(key, [&](const auto& ctor) {
                 // we must persist the slice before insert
                 uint8_t* pos = pool->allocate(key.size);
-                ERASE_AND_THROW_BAD_ALLOC_IF_NULL(hash_set, pos, key);
                 memcpy(pos, key.data, key.size);
                 ctor(pos, key.size, key.hash);
             });
@@ -387,7 +369,6 @@ struct AggHashSetOfSerializedKey {
             max_one_row_size = cur_max_one_row_size;
             _mem_pool->clear();
             _buffer = _mem_pool->allocate(max_one_row_size * _chunk_size);
-            THROW_BAD_ALLOC_IF_NULL(_buffer);
         }
 
         for (const auto& key_column : key_columns) {
@@ -458,7 +439,6 @@ struct AggHashSetOfSerializedKeyFixedSize {
             : _mem_pool(std::make_unique<MemPool>()),
               buffer(_mem_pool->allocate(max_fixed_size * chunk_size)),
               _chunk_size(chunk_size) {
-        THROW_BAD_ALLOC_IF_NULL(buffer);
         memset(buffer, 0x0, max_fixed_size * _chunk_size);
     }
 

--- a/be/src/exec/vectorized/aggregator.h
+++ b/be/src/exec/vectorized/aggregator.h
@@ -266,7 +266,6 @@ public:
                 [this]() {
                     vectorized::AggDataPtr agg_state =
                             _mem_pool->allocate_aligned(_agg_states_total_size, _max_agg_state_align_size);
-                    RETURN_IF_UNLIKELY_NULL(agg_state, (uint8_t*)(nullptr));
                     for (int i = 0; i < _agg_functions.size(); i++) {
                         _agg_functions[i]->create(_agg_fn_ctxs[i], agg_state + _agg_states_offsets[i]);
                     }
@@ -282,7 +281,6 @@ public:
                 [this]() {
                     vectorized::AggDataPtr agg_state =
                             _mem_pool->allocate_aligned(_agg_states_total_size, _max_agg_state_align_size);
-                    RETURN_IF_UNLIKELY_NULL(agg_state, (uint8_t*)(nullptr));
                     for (int i = 0; i < _agg_functions.size(); i++) {
                         _agg_functions[i]->create(_agg_fn_ctxs[i], agg_state + _agg_states_offsets[i]);
                     }

--- a/be/src/exec/vectorized/except_hash_set.cpp
+++ b/be/src/exec/vectorized/except_hash_set.cpp
@@ -19,7 +19,6 @@ void ExceptHashSet<HashSet>::build_set(RuntimeState* state, const ChunkPtr& chun
         _max_one_row_size = cur_max_one_row_size;
         _mem_pool->clear();
         _buffer = _mem_pool->allocate(_max_one_row_size * state->chunk_size());
-        THROW_BAD_ALLOC_IF_NULL(_buffer);
     }
 
     _serialize_columns(chunk, exprs, chunk_size);
@@ -28,7 +27,6 @@ void ExceptHashSet<HashSet>::build_set(RuntimeState* state, const ChunkPtr& chun
         ExceptSliceFlag key(_buffer + i * _max_one_row_size, _slice_sizes[i]);
         _hash_set->lazy_emplace(key, [&](const auto& ctor) {
             uint8_t* pos = pool->allocate(key.slice.size);
-            ERASE_AND_THROW_BAD_ALLOC_IF_NULL((*_hash_set), pos, key);
             memcpy(pos, key.slice.data, key.slice.size);
             ctor(pos, key.slice.size);
         });

--- a/be/src/exec/vectorized/intersect_hash_set.cpp
+++ b/be/src/exec/vectorized/intersect_hash_set.cpp
@@ -27,7 +27,6 @@ void IntersectHashSet<HashSet>::build_set(RuntimeState* state, const ChunkPtr& c
         _max_one_row_size = cur_max_one_row_size;
         _mem_pool->clear();
         _buffer = _mem_pool->allocate(_max_one_row_size * state->chunk_size());
-        THROW_BAD_ALLOC_IF_NULL(_buffer);
     }
 
     _serialize_columns(chunkPtr, exprs, chunk_size);
@@ -37,7 +36,6 @@ void IntersectHashSet<HashSet>::build_set(RuntimeState* state, const ChunkPtr& c
         _hash_set->lazy_emplace(key, [&](const auto& ctor) {
             // we must persist the slice before insert
             uint8_t* pos = pool->allocate(key.slice.size);
-            ERASE_AND_THROW_BAD_ALLOC_IF_NULL((*_hash_set), pos, key);
             memcpy(pos, key.slice.data, key.slice.size);
             ctor(pos, key.slice.size);
         });

--- a/be/src/runtime/mem_pool.cpp
+++ b/be/src/runtime/mem_pool.cpp
@@ -25,6 +25,7 @@
 #include <cstdio>
 #include <sstream>
 
+#include "runtime/current_thread.h"
 #include "runtime/memory/chunk_allocator.h"
 #include "util/bit_util.h"
 #include "util/starrocks_metrics.h"
@@ -119,7 +120,11 @@ bool MemPool::find_chunk(size_t min_size, bool check_limits) {
     // Allocate a new chunk. Return early if allocate fails.
     Chunk chunk;
     if (!ChunkAllocator::instance()->allocate(chunk_size, &chunk)) {
-        return false;
+        if (tls_thread_status.is_catched()) {
+            throw std::bad_alloc();
+        } else {
+            return false;
+        }
     }
     ASAN_POISON_MEMORY_REGION(chunk.data, chunk_size);
     // Put it before the first free chunk. If no free chunks, it goes at the end.

--- a/be/src/util/phmap/phmap.h
+++ b/be/src/util/phmap/phmap.h
@@ -1370,19 +1370,31 @@ public:
     template <class K = key_type, class F>
     iterator lazy_emplace(const key_arg<K>& key, F&& f) {
         auto res = find_or_prepare_insert(key);
+        auto iter = iterator_at(res.first);
         if (res.second) {
-            lazy_emplace_at(res.first, std::forward<F>(f));
+            try {
+                lazy_emplace_at(res.first, std::forward<F>(f));
+            } catch (std::bad_alloc const& e) {
+                erase(iter);
+                throw e;
+            }
         }
-        return iterator_at(res.first);
+        return iter;
     }
 
     template <class K = key_type, class F>
     iterator lazy_emplace_with_hash(const key_arg<K>& key, size_t& hashval, F&& f) {
         auto res = find_or_prepare_insert(key, hashval);
+        auto iter = iterator_at(res.first);
         if (res.second) {
-            lazy_emplace_at(res.first, std::forward<F>(f));
+            try {
+                lazy_emplace_at(res.first, std::forward<F>(f));
+            } catch (std::bad_alloc const& e) {
+                erase(iter);
+                throw e;
+            }
         }
-        return iterator_at(res.first);
+        return iter;
     }
 
     template <class K = key_type, class F>


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3326 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

phmap::lazy_emplace() may fail caused by can't alloc memory  for key/value. meta has been created in hashmap, but the key/value is not constructed, so destroy will be crash. 

before, we use erase(key) to erash the invalid item, actually not remove the item, because the key is not insert yet, search will fail .

so we will add try catch std::bad_alloc() in lazy_emplace() to remove the invalid item