### PR TITLE
Implement predicate for json type 

### DIFF
--- a/be/src/exec/pipeline/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/olap_chunk_source.cpp
@@ -151,7 +151,7 @@ Status OlapChunkSource::_init_reader_params(const std::vector<OlapScanRange*>& k
 
     PredicateParser parser(_tablet->tablet_schema());
     std::vector<PredicatePtr> preds;
-    _conjuncts_manager.get_column_predicates(&parser, &preds);
+    RETURN_IF_ERROR(_conjuncts_manager.get_column_predicates(&parser, &preds));
     for (auto& p : preds) {
         if (parser.can_pushdown(p.get())) {
             _params.predicates.push_back(p.get());

--- a/be/src/exec/vectorized/olap_scan_prepare.cpp
+++ b/be/src/exec/vectorized/olap_scan_prepare.cpp
@@ -598,15 +598,17 @@ Status OlapScanConjunctsManager::build_scan_keys(bool unlimited, int32_t max_sca
     return Status::OK();
 }
 
-void OlapScanConjunctsManager::get_column_predicates(PredicateParser* parser,
-                                                     std::vector<std::unique_ptr<ColumnPredicate>>* preds) {
+Status OlapScanConjunctsManager::get_column_predicates(PredicateParser* parser,
+                                                       std::vector<std::unique_ptr<ColumnPredicate>>* preds) {
     for (auto& f : olap_filters) {
         std::unique_ptr<ColumnPredicate> p(parser->parse_thrift_cond(f));
+        RETURN_IF(!p, Status::RuntimeError("invalid filter"));
         p->set_index_filter_only(f.is_index_filter_only);
         preds->emplace_back(std::move(p));
     }
     for (auto& f : is_null_vector) {
         std::unique_ptr<ColumnPredicate> p(parser->parse_thrift_cond(f));
+        RETURN_IF(!p, Status::RuntimeError("invalid filter"));
         preds->emplace_back(std::move(p));
     }
 
@@ -620,6 +622,7 @@ void OlapScanConjunctsManager::get_column_predicates(PredicateParser* parser,
             preds->emplace_back(std::move(p));
         }
     }
+    return Status::OK();
 }
 
 void OlapScanConjunctsManager::eval_const_conjuncts(const std::vector<ExprContext*>& conjunct_ctxs, Status* status) {

--- a/be/src/exec/vectorized/olap_scan_prepare.h
+++ b/be/src/exec/vectorized/olap_scan_prepare.h
@@ -38,7 +38,7 @@ private:
 public:
     static void eval_const_conjuncts(const std::vector<ExprContext*>& conjunct_ctxs, Status* status);
 
-    void get_column_predicates(PredicateParser* parser, std::vector<std::unique_ptr<ColumnPredicate>>* preds);
+    Status get_column_predicates(PredicateParser* parser, std::vector<std::unique_ptr<ColumnPredicate>>* preds);
 
     Status get_key_ranges(std::vector<std::unique_ptr<OlapScanRange>>* key_ranges);
 

--- a/be/src/exec/vectorized/tablet_scanner.cpp
+++ b/be/src/exec/vectorized/tablet_scanner.cpp
@@ -90,7 +90,9 @@ Status TabletScanner::close(RuntimeState* state) {
     if (_is_closed) {
         return Status::OK();
     }
-    _prj_iter->close();
+    if (_prj_iter) {
+        _prj_iter->close();
+    }
     update_counter();
     _reader.reset();
     _predicate_free_pool.clear();
@@ -108,7 +110,7 @@ Status TabletScanner::_get_tablet(const TInternalScanRange* scan_range) {
     std::string err;
     _tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, true, &err);
     if (!_tablet) {
-        auto msg = strings::Substitute("Not found tablet. tablet_id: $0, error: $1", _tablet->tablet_id(), err);
+        auto msg = strings::Substitute("Not found tablet. tablet_id: $0, error: $1", tablet_id, err);
         LOG(WARNING) << msg;
         return Status::InternalError(msg);
     }
@@ -134,7 +136,7 @@ Status TabletScanner::_init_reader_params(const std::vector<OlapScanRange*>* key
 
     PredicateParser parser(_tablet->tablet_schema());
     std::vector<PredicatePtr> preds;
-    _parent->_conjuncts_manager.get_column_predicates(&parser, &preds);
+    RETURN_IF_ERROR(_parent->_conjuncts_manager.get_column_predicates(&parser, &preds));
     for (auto& p : preds) {
         if (parser.can_pushdown(p.get())) {
             _params.predicates.push_back(p.get());
@@ -288,6 +290,9 @@ void TabletScanner::_update_realtime_counter(Chunk* chunk) {
 
 void TabletScanner::update_counter() {
     if (_has_update_counter) {
+        return;
+    }
+    if (!_reader) {
         return;
     }
     COUNTER_UPDATE(_parent->_create_seg_iter_timer, _reader->stats().create_segment_iter_ns);

--- a/be/src/runtime/primitive_type.h
+++ b/be/src/runtime/primitive_type.h
@@ -122,6 +122,7 @@ inline bool is_scalar_primitive_type(PrimitiveType ptype) {
     case TYPE_DECIMAL32:  /* 24 */
     case TYPE_DECIMAL64:  /* 25 */
     case TYPE_DECIMAL128: /* 26 */
+    case TYPE_JSON:
         return true;
     default:
         return false;

--- a/be/src/runtime/primitive_type.h
+++ b/be/src/runtime/primitive_type.h
@@ -122,7 +122,6 @@ inline bool is_scalar_primitive_type(PrimitiveType ptype) {
     case TYPE_DECIMAL32:  /* 24 */
     case TYPE_DECIMAL64:  /* 25 */
     case TYPE_DECIMAL128: /* 26 */
-    case TYPE_JSON:       /* 27 */
         return true;
     default:
         return false;

--- a/be/src/storage/types.h
+++ b/be/src/storage/types.h
@@ -592,18 +592,6 @@ struct CppColumnTraits<OLAP_FIELD_TYPE_JSON> {
     using ColumnType = vectorized::JsonColumn;
 };
 
-constexpr bool type_support_bloom_filter(FieldType ftype) {
-    switch (ftype) {
-    case OLAP_FIELD_TYPE_JSON:
-    case OLAP_FIELD_TYPE_OBJECT:
-    case OLAP_FIELD_TYPE_HLL:
-    case OLAP_FIELD_TYPE_PERCENTILE:
-        return false;
-    default:
-        return true;
-    }
-}
-
 // Instantiate this template to get static access to the type traits.
 template <FieldType field_type>
 struct TypeTraits {

--- a/be/src/storage/types.h
+++ b/be/src/storage/types.h
@@ -35,6 +35,7 @@
 #include "gen_cpp/segment.pb.h" // for ColumnMetaPB
 #include "runtime/mem_pool.h"
 #include "storage/collection.h"
+#include "storage/olap_common.h"
 #include "util/mem_util.hpp"
 #include "util/unaligned_access.h"
 
@@ -590,6 +591,18 @@ template <>
 struct CppColumnTraits<OLAP_FIELD_TYPE_JSON> {
     using ColumnType = vectorized::JsonColumn;
 };
+
+constexpr bool type_support_bloom_filter(FieldType ftype) {
+    switch (ftype) {
+    case OLAP_FIELD_TYPE_JSON:
+    case OLAP_FIELD_TYPE_OBJECT:
+    case OLAP_FIELD_TYPE_HLL:
+    case OLAP_FIELD_TYPE_PERCENTILE:
+        return false;
+    default:
+        return true;
+    }
+}
 
 // Instantiate this template to get static access to the type traits.
 template <FieldType field_type>

--- a/be/src/storage/vectorized/column_predicate.h
+++ b/be/src/storage/vectorized/column_predicate.h
@@ -11,11 +11,19 @@
 #include "column/chunk.h"
 #include "column/column.h" // Column
 #include "column/datum.h"
+#include "column/type_traits.h"
 #include "common/object_pool.h"
+<<<<<<< HEAD
 #include "gen_cpp/Opcodes_types.h"
+=======
+#include "common/status.h"
+#include "runtime/primitive_type.h"
+>>>>>>> 08b3b0e5 (implement binary predicate for json)
 #include "storage/olap_common.h" // ColumnId
+#include "storage/types.h"
 #include "storage/vectorized/range.h"
 #include "storage/vectorized/zone_map_detail.h"
+#include "util/json.h"
 #include "util/string_parser.hpp"
 
 class Roaring;
@@ -32,6 +40,26 @@ class BloomFilter;
 } // namespace starrocks
 
 namespace starrocks::vectorized {
+
+template <FieldType ftype>
+struct PredicateCmpTypeForField {
+    using ValueType = typename CppTypeTraits<ftype>::CppType;
+};
+
+template <>
+struct PredicateCmpTypeForField<OLAP_FIELD_TYPE_JSON> {
+    using ValueType = JsonValue;
+};
+
+template <PrimitiveType ptype>
+struct PredicateCmpType {
+    using CmpType = RunTimeCppType<ptype>;
+};
+
+template <>
+struct PredicateCmpType<TYPE_JSON> {
+    using CmpType = JsonValue;
+};
 
 enum class PredicateType {
     kUnknown = 0,

--- a/be/src/storage/vectorized/column_predicate.h
+++ b/be/src/storage/vectorized/column_predicate.h
@@ -13,12 +13,9 @@
 #include "column/datum.h"
 #include "column/type_traits.h"
 #include "common/object_pool.h"
-<<<<<<< HEAD
-#include "gen_cpp/Opcodes_types.h"
-=======
 #include "common/status.h"
+#include "gen_cpp/Opcodes_types.h"
 #include "runtime/primitive_type.h"
->>>>>>> 08b3b0e5 (implement binary predicate for json)
 #include "storage/olap_common.h" // ColumnId
 #include "storage/types.h"
 #include "storage/vectorized/range.h"

--- a/be/src/storage/vectorized/column_predicate.h
+++ b/be/src/storage/vectorized/column_predicate.h
@@ -51,16 +51,6 @@ struct PredicateCmpTypeForField<OLAP_FIELD_TYPE_JSON> {
     using ValueType = JsonValue;
 };
 
-template <PrimitiveType ptype>
-struct PredicateCmpType {
-    using CmpType = RunTimeCppType<ptype>;
-};
-
-template <>
-struct PredicateCmpType<TYPE_JSON> {
-    using CmpType = JsonValue;
-};
-
 enum class PredicateType {
     kUnknown = 0,
     kEQ = 1,

--- a/be/src/util/json.h
+++ b/be/src/util/json.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <ostream>
 #include <string>
 
@@ -8,6 +9,7 @@
 #include "common/status.h"
 #include "common/statusor.h"
 #include "fmt/format.h"
+#include "glog/logging.h"
 #include "simdjson.h"
 #include "util/coding.h"
 #include "velocypack/vpack.h"
@@ -96,6 +98,7 @@ public:
     StatusOr<std::string> to_string() const;
     std::string to_string_uncheck() const;
     int compare(const JsonValue& rhs) const;
+    static int compare(const Slice& lhs, const Slice& rhs);
     int64_t hash() const;
 
 private:
@@ -170,6 +173,9 @@ std::ostream& operator<<(std::ostream& os, const JsonValue& json);
 inline bool operator==(const JsonValue& lhs, const JsonValue& rhs) {
     return lhs.compare(rhs) == 0;
 }
+inline bool operator!=(const JsonValue& lhs, const JsonValue& rhs) {
+    return lhs.compare(rhs) != 0;
+}
 inline bool operator<(const JsonValue& lhs, const JsonValue& rhs) {
     return lhs.compare(rhs) < 0;
 }
@@ -197,7 +203,107 @@ struct formatter<starrocks::JsonValue> : formatter<std::string> {
 } // namespace fmt
 
 namespace std {
+
 inline std::string to_string(const starrocks::JsonValue& value) {
     return value.to_string_uncheck();
 }
+
+template <>
+struct less<starrocks::JsonValue> {
+    bool operator()(const starrocks::JsonValue& lhs, const starrocks::JsonValue& rhs) const {
+        return lhs.compare(rhs) < 0;
+    }
+
+    bool operator()(const starrocks::JsonValue* lhs, const starrocks::JsonValue* rhs) const {
+        DCHECK_NOTNULL(lhs);
+        DCHECK_NOTNULL(rhs);
+        return starrocks::JsonValue::compare(lhs->get_slice(), rhs->get_slice()) < 0;
+    }
+
+    bool operator()(const starrocks::Slice& lhs, const starrocks::Slice& rhs) const {
+        return starrocks::JsonValue::compare(lhs, rhs) < 0;
+    }
+};
+
+template <>
+struct less_equal<starrocks::JsonValue> {
+    bool operator()(const starrocks::JsonValue& lhs, const starrocks::JsonValue& rhs) const {
+        return lhs.compare(rhs) <= 0;
+    }
+
+    bool operator()(const starrocks::JsonValue* lhs, const starrocks::JsonValue* rhs) const {
+        DCHECK_NOTNULL(lhs);
+        DCHECK_NOTNULL(rhs);
+        return starrocks::JsonValue::compare(lhs->get_slice(), rhs->get_slice()) <= 0;
+    }
+
+    bool operator()(const starrocks::Slice& lhs, const starrocks::Slice& rhs) const {
+        return starrocks::JsonValue::compare(lhs, rhs) <= 0;
+    }
+};
+
+template <>
+struct greater<starrocks::JsonValue> {
+    bool operator()(const starrocks::JsonValue& lhs, const starrocks::JsonValue& rhs) const {
+        return lhs.compare(rhs) > 0;
+    }
+    bool operator()(const starrocks::JsonValue* lhs, const starrocks::JsonValue* rhs) const {
+        DCHECK_NOTNULL(lhs);
+        DCHECK_NOTNULL(rhs);
+        return starrocks::JsonValue::compare(lhs->get_slice(), rhs->get_slice()) > 0;
+    }
+
+    bool operator()(const starrocks::Slice& lhs, const starrocks::Slice& rhs) const {
+        return starrocks::JsonValue::compare(lhs, rhs) > 0;
+    }
+};
+template <>
+struct greater_equal<starrocks::JsonValue> {
+    bool operator()(const starrocks::JsonValue& lhs, const starrocks::JsonValue& rhs) const {
+        return lhs.compare(rhs) >= 0;
+    }
+
+    bool operator()(const starrocks::JsonValue* lhs, const starrocks::JsonValue* rhs) const {
+        DCHECK_NOTNULL(lhs);
+        DCHECK_NOTNULL(rhs);
+        return starrocks::JsonValue::compare(lhs->get_slice(), rhs->get_slice()) >= 0;
+    }
+
+    bool operator()(const starrocks::Slice& lhs, const starrocks::Slice& rhs) const {
+        return starrocks::JsonValue::compare(lhs, rhs) >= 0;
+    }
+};
+template <>
+struct equal_to<starrocks::JsonValue> {
+    bool operator()(const starrocks::JsonValue& lhs, const starrocks::JsonValue& rhs) const {
+        return lhs.compare(rhs) == 0;
+    }
+
+    bool operator()(const starrocks::JsonValue* lhs, const starrocks::JsonValue* rhs) const {
+        DCHECK_NOTNULL(lhs);
+        DCHECK_NOTNULL(rhs);
+        return starrocks::JsonValue::compare(lhs->get_slice(), rhs->get_slice()) == 0;
+    }
+
+    bool operator()(const starrocks::Slice& lhs, const starrocks::Slice& rhs) const {
+        return starrocks::JsonValue::compare(lhs, rhs) == 0;
+    }
+};
+template <>
+struct not_equal_to<starrocks::JsonValue> {
+    bool operator()(const starrocks::JsonValue& lhs, const starrocks::JsonValue& rhs) const {
+        return lhs.compare(rhs) != 0;
+    }
+
+    bool operator()(const starrocks::JsonValue* lhs, const starrocks::JsonValue* rhs) const {
+        DCHECK_NOTNULL(lhs);
+        DCHECK_NOTNULL(rhs);
+        return starrocks::JsonValue::compare(lhs->get_slice(), rhs->get_slice()) != 0;
+    }
+
+    bool operator()(const starrocks::Slice& lhs, const starrocks::Slice& rhs) const {
+        return starrocks::JsonValue::compare(lhs, rhs) != 0;
+    }
+};
+
 } // namespace std

--- a/be/test/column/json_column_test.cpp
+++ b/be/test/column/json_column_test.cpp
@@ -124,22 +124,22 @@ PARALLEL_TEST(JsonColumnTest, test_compare) {
     // object
     column.push_back(JsonValue::parse(R"({"a": {"b": 1}})").value());
     column.push_back(JsonValue::parse(R"({"a": {"b": 2}})").value());
-    // double
-    column.push_back(JsonValue::parse(R"({"a": 1.0})").value());
-    column.push_back(JsonValue::parse(R"({"a": 2.0})").value());
-    // int
-    column.push_back(JsonValue::parse(R"({"a": 0})").value());
-    column.push_back(JsonValue::parse(R"({"a": 1})").value());
     // string
     column.push_back(JsonValue::parse(R"({"a": "a"})").value());
     column.push_back(JsonValue::parse(R"({"a": "b"})").value());
+    // double
+    column.push_back(JsonValue::parse(R"({"a": 1.0})").value());
+    column.push_back(JsonValue::parse(R"({"a": 2.0})").value());
+    // small int
+    column.push_back(JsonValue::parse(R"({"a": 3})").value());
+    column.push_back(JsonValue::parse(R"({"a": 4})").value());
+    // int
+    column.push_back(JsonValue::parse(R"({"a": 3046})").value());
+    column.push_back(JsonValue::parse(R"({"a": 4048})").value());
 
     // same type
     std::vector<std::pair<int, int>> same_type_cases = {
-            {0, 1},
-            {2, 3},
-            {4, 5},
-            {6, 7},
+            {0, 1}, {2, 3}, {4, 5}, {6, 7}, {8, 9}, {10, 11},
     };
     for (auto p : same_type_cases) {
         int lhs = p.first;
@@ -159,17 +159,26 @@ PARALLEL_TEST(JsonColumnTest, test_compare) {
     std::vector<std::pair<int, int>> diff_type_cases = {
             {0, 2},
             {2, 4},
-            {4, 6},
+            {6, 4},
     };
     for (auto p : diff_type_cases) {
         int lhs = p.first;
         int rhs = p.second;
-        ASSERT_LT(column[lhs].compare(column[rhs]), 0);
-        ASSERT_GT(column[rhs].compare(column[lhs]), 0);
+        EXPECT_LT(column[lhs].compare(column[rhs]), 0);
+        EXPECT_GT(column[rhs].compare(column[lhs]), 0);
 
         // operators
-        ASSERT_LT(column[lhs], column[rhs]);
-        ASSERT_GT(column[rhs], column[lhs]);
+        EXPECT_LT(column[lhs], column[rhs]);
+        EXPECT_GT(column[rhs], column[lhs]);
+    }
+
+    // numbers of different types
+    for (int i = 6; i <= 11; i++) {
+        for (int j = i + 1; j <= 11; j++) {
+            EXPECT_LT(column[i], column[j]);
+            EXPECT_GT(column[j], column[i]);
+            EXPECT_NE(column[i], column[j]);
+        }
     }
 }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Summary
Implement predicate for json:
1. Predicate type: `<, >, <=, >=, =, <>`
2. Compare rule: 
    1. If both json are scalar type( number, bool, string), compare using scalar type
    2. If both are object/array, compare by element-wise
    3. If type are different, compare by type order

## Use example
```sql
select * from tablej where j->'age' < parse_json('35');
```

## Limitation
1. In predicate is not supported
2. Bloomfilter or zonemap is not employed

## Implementation considerations
The most struggle problem is type specialization:
- In vectorized expression, the column type of JSON is `JsonColumn`, so the datum is `JsonValue*`
- But `JsonValue` is dynamic-length type, which could not fit in old-style `TypeInfo` framework
- So type `Slice` become the bridge between expression framework and storage
- But `Slice` could not meet the requirement of comparison for json

As a result, JSON consists of several formats:
1. In expression, `JsonColumn` and `JsonValue*` 
2. In binary predicate, datum is `JsonValue*`, but compared as `Jsonvalue`
3. In encoding of storage, treat json as `Slice`
3. Related traits are `RunTimeTypeTraits`, `CppTypeTraits`, `PredicateCmpType`, `RangeTypeConverter` 

