### PR TITLE
[pipeline] fix: num_morsels may be 0 in MorselQueue::split_by_size

### DIFF
--- a/be/src/exec/pipeline/morsel.h
+++ b/be/src/exec/pipeline/morsel.h
@@ -70,7 +70,7 @@ public:
     std::vector<MorselQueuePtr> split_by_size(size_t split_size) {
         // split_size is in (0, split_size].
         DCHECK_GT(split_size, 0);
-        DCHECK_LE(split_size, _num_morsels);
+        DCHECK(_num_morsels == 0 || split_size <= _num_morsels);
 
         std::vector<Morsels> split_morsels_list(split_size);
         for (int i = 0; i < _num_morsels; ++i) {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The number of tablets (morsels) may be zero for a scan node, and in this case DOP is 1, which doesn't satisfy that `split_size <= num_morsels` in `MorselQueue::split_by_size`.
