### PR TITLE
remove unnecessary cast operator on date field

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
@@ -1100,7 +1100,7 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
                 "and cast(id_date as datetime) <= '1970-01-01'";
         plan = getFragmentPlan(sql);
         // check not prune tablet
-        Assert.assertTrue(plan.contains("tabletRatio=3/3"));
+        Assert.assertTrue(plan.contains("tabletRatio=1/3"));
 
         sql = "select * from test_all_type_distributed_by_date where cast(id_date as date) >= '1970-01-01' " +
                 "and cast(id_date as date) <= '1970-01-01'";

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -5686,4 +5686,11 @@ public class PlanFragmentTest extends PlanTestBase {
                 "  |    \n" +
                 "  0:OlapScanNode"));
     }
+
+    @Test
+    public void testRemoveCastDatetimeOperator() throws Exception {
+        String sql = "select * from test_all_type where cast(id_date as datetime) < '2021-01-01 00:00:00'";
+        String plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("id_date < '2021-01-01'"));
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
To remove unnecessary cast operator on date field.

## Problem Summary(Required) ：

Taks tpch/q05.sql for example,  the output `explain verbose` shows that

```
NON-PARTITION PREDICATES: 13: o_orderdate >= '1994-01-01', CAST(13: o_orderdate AS DATETIME) < '1995-01-01 00:00:00' |
```

If we could simplify predicates to 
- `o_orderdate >= '1994-01-01'`
- `o_orderdate < '1995-01-01`

The backend execution engine has more opportunites to do optimization. 

Right now, Hdfs scanner on ORC can use this simplified predicate to scan less data.

Another reason is that, many hive external tables are relying on date field as partition key..
