### PR TITLE
check decimal overflow in predicate in decimal style instead binary style

### DIFF
--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -67,6 +67,18 @@ public:
         return ConstColumn::create(ptr, chunk_size);
     }
 
+    template <PrimitiveType PT>
+    static inline ColumnPtr create_const_decimal_column(RunTimeCppType<PT> value, int precision, int scale,
+                                                        size_t size) {
+        static_assert(pt_is_decimal<PT>);
+        using ColumnType = RunTimeColumnType<PT>;
+        auto data_column = ColumnType::create(precision, scale, 1);
+        auto& data = ColumnHelper::cast_to_raw<PT>(data_column)->get_data();
+        DCHECK(data.size() == 1);
+        data[0] = value;
+        return ConstColumn::create(data_column, size);
+    }
+
     // If column is const column, duplicate the data column to chunk_size
     static ColumnPtr unpack_and_duplicate_const_column(size_t chunk_size, const ColumnPtr& column) {
         if (column->is_constant()) {

--- a/be/src/exprs/vectorized/literal.cpp
+++ b/be/src/exprs/vectorized/literal.cpp
@@ -26,7 +26,7 @@ static RunTimeCppType<PT> unpack_decimal(const std::string& s) {
 #ifdef IS_LITTLE_ENDIAN
     strings::memcpy_inlined(&value, &s.front(), sizeof(value));
 #else
-    std::copy(s.rbegin(), s.rend(), (char*)&datum);
+    std::copy(s.rbegin(), s.rend(), (char*)&value);
 #endif
     return value;
 }
@@ -108,13 +108,7 @@ VectorizedLiteral::VectorizedLiteral(const TExprNode& node) : Expr(node) {
         break;
     }
     case TYPE_DECIMALV2: {
-        DecimalV2Value datum;
-        if (node.decimal_literal.__isset.integer_value) {
-            datum = DecimalV2Value(unpack_decimal<TYPE_DECIMAL128>(node.decimal_literal.integer_value));
-        } else {
-            datum = DecimalV2Value(node.decimal_literal.value);
-        }
-        _value = ColumnHelper::create_const_column<TYPE_DECIMALV2>(datum, 1);
+        _value = ColumnHelper::create_const_column<TYPE_DECIMALV2>(DecimalV2Value(node.decimal_literal.value), 1);
         break;
     }
     case TYPE_DECIMAL32: {

--- a/be/src/exprs/vectorized/literal.cpp
+++ b/be/src/exprs/vectorized/literal.cpp
@@ -6,6 +6,8 @@
 #include "column/const_column.h"
 #include "column/fixed_length_column.h"
 #include "column/nullable_column.h"
+#include "gutil/port.h"
+#include "gutil/strings/fastmem.h"
 
 namespace starrocks::vectorized {
 
@@ -17,25 +19,40 @@ namespace starrocks::vectorized {
         break;                                                                              \
     }
 
+template <PrimitiveType PT>
+static RunTimeCppType<PT> unpack_decimal(const std::string& s) {
+    static_assert(pt_is_decimal<PT>);
+    RunTimeCppType<PT> value;
+#ifdef IS_LITTLE_ENDIAN
+    strings::memcpy_inlined(&value, &s.front(), sizeof(value));
+#else
+    std::copy(s.rbegin(), s.rend(), (char*)&datum);
+#endif
+    return value;
+}
+
 template <PrimitiveType DecimalType, typename = DecimalPTGuard<DecimalType>>
 static ColumnPtr const_column_from_literal(const TExprNode& node, int precision, int scale) {
     using CppType = RunTimeCppType<DecimalType>;
     using ColumnType = RunTimeColumnType<DecimalType>;
     CppType datum;
     DCHECK(node.__isset.decimal_literal);
+    // using TDecimalLiteral::integer_value take precedence over using TDecimalLiteral::value
+    if (node.decimal_literal.__isset.integer_value) {
+        const std::string& s = node.decimal_literal.integer_value;
+        datum = unpack_decimal<DecimalType>(s);
+        return ColumnHelper::create_const_decimal_column<DecimalType>(datum, precision, scale, 1);
+    }
     auto& literal_value = node.decimal_literal.value;
     auto fail =
             DecimalV3Cast::from_string<CppType>(&datum, precision, scale, literal_value.c_str(), literal_value.size());
     if (fail) {
         return ColumnHelper::create_const_null_column(1);
     } else {
-        auto data_column = ColumnType::create(precision, scale, 1);
-        auto& data = ColumnHelper::cast_to_raw<DecimalType>(data_column)->get_data();
-        DCHECK(data.size() == 1);
-        data[0] = datum;
-        return ConstColumn::create(data_column, 1);
+        return ColumnHelper::create_const_decimal_column<DecimalType>(datum, precision, scale, 1);
     }
 }
+
 VectorizedLiteral::VectorizedLiteral(const TExprNode& node) : Expr(node) {
     if (node.node_type == TExprNodeType::NULL_LITERAL) {
         _value = ColumnHelper::create_const_null_column(1);
@@ -91,7 +108,13 @@ VectorizedLiteral::VectorizedLiteral(const TExprNode& node) : Expr(node) {
         break;
     }
     case TYPE_DECIMALV2: {
-        _value = ColumnHelper::create_const_column<TYPE_DECIMALV2>(DecimalV2Value(node.decimal_literal.value), 1);
+        DecimalV2Value datum;
+        if (node.decimal_literal.__isset.integer_value) {
+            datum = DecimalV2Value(unpack_decimal<TYPE_DECIMAL128>(node.decimal_literal.integer_value));
+        } else {
+            datum = DecimalV2Value(node.decimal_literal.value);
+        }
+        _value = ColumnHelper::create_const_column<TYPE_DECIMALV2>(datum, 1);
         break;
     }
     case TYPE_DECIMAL32: {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -469,7 +469,7 @@ public class Utils {
                 return Optional.of(ConstantOperator.createNull(descType));
             }
 
-            ConstantOperator result = ((ConstantOperator) op).castTo(descType);
+            ConstantOperator result = ((ConstantOperator) op).castToStrictly(descType);
             if (result.toString().equalsIgnoreCase(op.toString())) {
                 return Optional.of(result);
             } else if (descType.isDate() && (op.getType().isIntegerType() || op.getType().isStringType())) {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/DecimalLiteralTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/DecimalLiteralTest.java
@@ -245,7 +245,7 @@ public class DecimalLiteralTest {
         ScalarType decimal32p4s3 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 4, 3);
         for (BigDecimal dec32 : decimal32Values) {
             try {
-                DecimalLiteral.checkLiteralOverflow(dec32, decimal32p4s3);
+                DecimalLiteral.checkLiteralOverflowInBinaryStyle(dec32, decimal32p4s3);
                 Assert.fail("should throw exception");
             } catch (Exception ignored){}
         }
@@ -259,7 +259,7 @@ public class DecimalLiteralTest {
         ScalarType decimal64p10s6 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, 6);
         for (BigDecimal dec64 : decimal64Values) {
             try {
-                DecimalLiteral.checkLiteralOverflow(dec64, decimal64p10s6);
+                DecimalLiteral.checkLiteralOverflowInBinaryStyle(dec64, decimal64p10s6);
                 Assert.fail("should throw exception");
             }catch (Exception ignored) { }
         }
@@ -273,7 +273,7 @@ public class DecimalLiteralTest {
         ScalarType decimal128p36s11 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 36, 11);
         for (BigDecimal dec128 : decimal128Values) {
             try {
-                DecimalLiteral.checkLiteralOverflow(dec128, decimal128p36s11);
+                DecimalLiteral.checkLiteralOverflowInBinaryStyle(dec128, decimal128p36s11);
                 Assert.fail("should throw exception");
             }catch (Exception ignored) { }
         }
@@ -296,7 +296,7 @@ public class DecimalLiteralTest {
         ScalarType decimal32p4s3 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 4, 3);
         for (BigDecimal dec32 : decimal32Values) {
             try {
-                DecimalLiteral.checkLiteralOverflow(dec32, decimal32p4s3);
+                DecimalLiteral.checkLiteralOverflowInBinaryStyle(dec32, decimal32p4s3);
             }catch (Exception ignored) {
                 Assert.fail("should not throw exception");
             }
@@ -316,7 +316,7 @@ public class DecimalLiteralTest {
         ScalarType decimal64p10s6 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, 6);
         for (BigDecimal dec64 : decimal64Values) {
             try {
-                DecimalLiteral.checkLiteralOverflow(dec64, decimal64p10s6);
+                DecimalLiteral.checkLiteralOverflowInBinaryStyle(dec64, decimal64p10s6);
             }catch (Exception ignored) {
                 Assert.fail("should not throw exception");
             }
@@ -336,8 +336,119 @@ public class DecimalLiteralTest {
         ScalarType decimal128p36s11 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 36, 11);
         for (BigDecimal dec128 : decimal128Values) {
             try {
-                DecimalLiteral.checkLiteralOverflow(dec128, decimal128p36s11);
+                DecimalLiteral.checkLiteralOverflowInBinaryStyle(dec128, decimal128p36s11);
             }catch (Exception ignored) {
+                Assert.fail("should not throw exception");
+            }
+        }
+    }
+
+    @Test
+    public void testCheckLiteralOverflowInDecimalStyleFail() throws AnalysisException {
+        BigDecimal decimal32Values[] = {
+                new BigDecimal("100000.0000"),
+                new BigDecimal("99999.99995"),
+                new BigDecimal("-100000.0000"),
+                new BigDecimal("-99999.99995"),
+        };
+        ScalarType decimal32p9s4 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 4);
+        for (BigDecimal dec32 : decimal32Values) {
+            try {
+                DecimalLiteral.checkLiteralOverflowInDecimalStyle(dec32, decimal32p9s4);
+                Assert.fail("should throw exception");
+            } catch (Exception ignored) {
+            }
+        }
+
+        BigDecimal decimal64Values[] = {
+                new BigDecimal("1000000000000.000000"),
+                new BigDecimal("999999999999.9999995"),
+                new BigDecimal("-1000000000000.000000"),
+                new BigDecimal("-999999999999.9999995"),
+        };
+        ScalarType decimal64p18s6 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 6);
+        for (BigDecimal dec64 : decimal64Values) {
+            try {
+                DecimalLiteral.checkLiteralOverflowInDecimalStyle(dec64, decimal64p18s6);
+                Assert.fail("should throw exception");
+            } catch (Exception ignored) {
+            }
+        }
+
+        BigDecimal decimal128Values[] = {
+                new BigDecimal("1000000000000000000000000000.00000000000"),
+                new BigDecimal("999999999999999999999999999.999999999995"),
+                new BigDecimal("-1000000000000000000000000000.00000000000"),
+                new BigDecimal("-999999999999999999999999999.999999999995"),
+        };
+        ScalarType decimal128p38s11 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 11);
+        for (BigDecimal dec128 : decimal128Values) {
+            try {
+                DecimalLiteral.checkLiteralOverflowInDecimalStyle(dec128, decimal128p38s11);
+                Assert.fail("should throw exception");
+            } catch (Exception ignored) {
+            }
+        }
+    }
+
+    @Test
+    public void testCheckLiteralOverflowInDecimalStyleSuccess() throws AnalysisException {
+        BigDecimal decimal32Values[] = {
+                new BigDecimal("99999.99994"),
+                new BigDecimal("99999.9999"),
+                new BigDecimal("99999.999"),
+                new BigDecimal("-99999.99994"),
+                new BigDecimal("-99999.9999"),
+                new BigDecimal("-99999.999"),
+                new BigDecimal("0.0001"),
+                new BigDecimal("0.0"),
+                new BigDecimal("-0.0001"),
+        };
+        ScalarType decimal32p9s4 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 4);
+        for (BigDecimal dec32 : decimal32Values) {
+            try {
+                DecimalLiteral.checkLiteralOverflowInDecimalStyle(dec32, decimal32p9s4);
+            } catch (Exception ignored) {
+                Assert.fail("should not throw exception");
+            }
+        }
+
+        BigDecimal decimal64Values[] = {
+                new BigDecimal("999999999999.9999994"),
+                new BigDecimal("999999999999.999999"),
+                new BigDecimal("999999999999.99999"),
+                new BigDecimal("-999999999999.9999994"),
+                new BigDecimal("-999999999999.999999"),
+                new BigDecimal("-999999999999.99999"),
+                new BigDecimal("-0.000001"),
+                new BigDecimal("0.000001"),
+                new BigDecimal("0.0"),
+        };
+        ScalarType decimal64p18s6 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 6);
+        for (BigDecimal dec64 : decimal64Values) {
+            try {
+                DecimalLiteral.checkLiteralOverflowInDecimalStyle(dec64, decimal64p18s6);
+            } catch (Exception ignored) {
+                Assert.fail("should not throw exception");
+            }
+        }
+
+        BigDecimal decimal128Values[] = {
+                new BigDecimal("999999999999999999999999999.999999999994"),
+                new BigDecimal("999999999999999999999999999.99999999999"),
+                new BigDecimal("999999999999999999999999999.9999999999"),
+                new BigDecimal("-999999999999999999999999999.999999999994"),
+                new BigDecimal("-999999999999999999999999999.99999999999"),
+                new BigDecimal("-999999999999999999999999999.9999999999"),
+                new BigDecimal("-0.00000000001"),
+                new BigDecimal("0.00000000001"),
+                new BigDecimal("0.0"),
+        };
+        ScalarType decimal128p38s11 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 11);
+        for (BigDecimal dec128 : decimal128Values) {
+            try {
+                DecimalLiteral.checkLiteralOverflowInDecimalStyle(dec128, decimal128p38s11);
+            } catch (Exception ignored) {
                 Assert.fail("should not throw exception");
             }
         }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/DecimalLiteralTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/DecimalLiteralTest.java
@@ -453,4 +453,40 @@ public class DecimalLiteralTest {
             }
         }
     }
+
+    @Test
+    public void testPackDecimal() {
+        BigInteger[] bigIntegers = new BigInteger[]{
+                BigInteger.ZERO,
+                BigInteger.ONE,
+                BigInteger.ONE.shiftLeft(31).subtract(BigInteger.ONE),
+                BigInteger.ONE.shiftLeft(31).negate(),
+                BigInteger.ONE.shiftLeft(32).subtract(BigInteger.ONE),
+                BigInteger.ONE.shiftLeft(32).negate(),
+                BigInteger.ONE.shiftLeft(63).subtract(BigInteger.ONE),
+                BigInteger.ONE.shiftLeft(63).negate(),
+                BigInteger.ONE.shiftLeft(64).subtract(BigInteger.ONE),
+                BigInteger.ONE.shiftLeft(64).negate(),
+                BigInteger.ONE.shiftLeft(126).subtract(BigInteger.ONE),
+                BigInteger.ONE.shiftLeft(126).negate(),
+        };
+        for (BigInteger integer : bigIntegers) {
+            BigDecimal decimal = new BigDecimal(integer, 3);
+            DecimalLiteral decimalLiteral = new DecimalLiteral(decimal);
+            ByteBuffer packed = decimalLiteral.packDecimal();
+            int numBytes = packed.limit();
+            byte[] bytes = new byte[numBytes];
+            packed.get(bytes);
+            int i = 0, j = numBytes - 1;
+            while (i < j) {
+                byte tmp = bytes[j];
+                bytes[j] = bytes[i];
+                bytes[i] = tmp;
+                ++i;
+                --j;
+            }
+            BigInteger expected = new BigInteger(bytes);
+            Assert.assertEquals(expected, integer);
+        }
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithDecimalTypesNewPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithDecimalTypesNewPlannerTest.java
@@ -130,11 +130,11 @@ public class SelectStmtWithDecimalTypesNewPlannerTest {
                 " TExprNode(node_type:CAST_EXPR, type:TTypeDesc(types:[TTypeNode(type:SCALAR, scalar_type:TScalarType(type:DECIMAL128, precision:38, scale:3))])," +
                 " opcode:INVALID_OPCODE, num_children:1, output_scale:-1, output_column:-1, child_type:DECIMAL128, has_nullable_child:true, is_nullable:true, is_monotonic:false), " +
                 "TExprNode(node_type:SLOT_REF, type:TTypeDesc(types:[TTypeNode(type:SCALAR, scalar_type:TScalarType" +
-                "(type:DECIMAL128, precision:20, scale:3))]), num_children:0, slot_ref:TSlotRef(slot_id:3, tuple_id:0)," +
+                "(type:DECIMAL128, precision:20, scale:3))]), num_children:0, slot_ref:TSlotRef(slot_id:4, tuple_id:0)," +
                 " output_scale:-1, output_column:-1, has_nullable_child:false, is_nullable:true, is_monotonic:true)," +
                 " TExprNode(node_type:DECIMAL_LITERAL, type:TTypeDesc(types:[TTypeNode(type:SCALAR, scalar_type:" +
                 "TScalarType(type:DECIMAL128, precision:38, scale:2))]), num_children:0, decimal_literal:" +
-                "TDecimalLiteral(value:3.14), output_scale:-1, has_nullable_child:false," +
+                "TDecimalLiteral(value:3.14, integer_value:3A 01 00 00 00 00 00 00 00 00 00 00 00 00 00 00), output_scale:-1, has_nullable_child:false," +
                 " is_nullable:false, is_monotonic:true)";
         String thrift = UtFrameUtils.getPlanThriftString(ctx, sql);
         Assert.assertTrue(thrift.contains(expectString));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -1152,7 +1152,7 @@ public class PlanFragmentTest extends PlanTestBase {
     public void testWindowFunctionTest() throws Exception {
         String sql = "select sum(id_decimal - ifnull(id_decimal, 0)) over (partition by t1c) from test_all_type";
         String plan = getThriftPlan(sql);
-        Assert.assertTrue(plan.contains("decimal_literal:TDecimalLiteral(value:0)"));
+        Assert.assertTrue(plan.contains("decimal_literal:TDecimalLiteral(value:0, integer_value:00 00 00 00 00 00 00 00)"));
     }
 
     @Test

--- a/gensrc/thrift/Exprs.thrift
+++ b/gensrc/thrift/Exprs.thrift
@@ -99,6 +99,7 @@ struct TFloatLiteral {
 
 struct TDecimalLiteral {
   1: required string value
+  2: optional binary integer_value
 }
 
 struct TIntLiteral {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
https://github.com/StarRocks/starrocks/issues/3342
Fixes #

## Problem Summary(Required) ：
for Predicates that contain constant operators of decimal type, the constant value is transferred to
to BE in string type, and in BE, an corresponding VectorizedLiteral is constructed after string value
is converted to decimal via the string-to-decimal casting function who checks decimal overflowing in
decimal style. but in FE, checking decimal overflow in binary style instead of decimal style would
given an incorrect result that overflow checking should fail(in decimal style) expectedly but succeeds
(in decimal style)actually. When checkLiteralOverflowInDecimalStyle fails, proper cast exprs are interpolated
into Predicates to cast the type of decimal constant value to a type wider enough to holds the value.

Why we needs two decimal overflow checking function?
1. for a Predicate like col_decimal32p9s0 > -2147483648, the type of col_decimal32p9s3 is DECIMAL32(9,0), the type of -2147483.648 is DECIMAL64(10,0).  Underlying integer value of -2147483.648 is -2147483648, becase  int32_t can holds this value, so overflow check in binary style tells that -2147483.648 not overflows, so change type of  -2147483.648 to DECIMAL32(9,0) in Predicate and turn it into string " -2147483.648" and transfer it to BE, on BE's receiving, BE try to parse "-2147483.648" into DECIMAL32(9,0), it fails because -2147483.648 is less than -99999.9999. so we should adopt overflow checking in decimal style which tells that -2147483.648 overflows, so common type DECIML64(10,0) is computed out, and both lhs and rhs of the predicate are casted into DECIMAL64(10, 0), ...., BE succeeds in parseing "-2147483.648" into DECIMAL64(10,0).
2. for ArithmeticExpr and CastExpr involving non-constant expr, correct result type is always computed, a decimal literal  that fails in overflow checking in decimal style are always cast to a wide type. But in BE, overflow checking in binary style is adopted  for performance purpose.
3. for ArithmeticExpr and CastExpr only involving constant expr, the evaluation happens on FE side, FE should abides by BE in overflow checking, so binary style is adopted.