### PR TITLE
[JDBC External Table] Phase 2: support create jdbc table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/CreateTableStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/CreateTableStmt.java
@@ -92,6 +92,7 @@ public class CreateTableStmt extends DdlStmt {
         engineNames.add("hive");
         engineNames.add("iceberg");
         engineNames.add("hudi");
+        engineNames.add("jdbc");
     }
 
     // for backup. set to -1 for normal use
@@ -267,7 +268,7 @@ public class CreateTableStmt extends DdlStmt {
         // analyze key desc
         if (!(engineName.equals("mysql") || engineName.equals("broker") ||
                 engineName.equals("hive") || engineName.equals("iceberg")) ||
-                engineName.equals("hudi")) {
+                engineName.equals("hudi") || engineName.equals("jdbc")) {
             // olap table
             if (keysDesc == null) {
                 List<String> keysColumnNames = Lists.newArrayList();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -4668,11 +4668,7 @@ public class Catalog {
             // properties
             sb.append("\nPROPERTIES (\n");
             sb.append("\"resource\" = \"").append(jdbcTable.getResourceName()).append("\",\n");
-            sb.append("\"database\" = \"").append(jdbcTable.getJdbcDatabase()).append("\",\n");
             sb.append("\"table\" = \"").append(jdbcTable.getJdbcTable()).append("\"");
-            if (!jdbcTable.getJdbcProperties().isEmpty()) {
-                sb.append(",\n").append(new PrintableMap<>(jdbcTable.getJdbcProperties(), " = ", true, true, false).toString());
-            }
             sb.append("\n)");
         }
         sb.append(";");

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
@@ -24,9 +24,6 @@ import java.util.Map;
 public class JDBCTable extends Table {
     private static final Logger LOG = LogManager.getLogger(JDBCTable.class);
 
-    private static final String PROPERTY_MISSING_MSG =
-            "JDBC %s is null. Please add properties('%s'='xxx') when create table";
-
     private static final String TABLE = "table";
     private static final String RESOURCE = "resource";
 
@@ -53,12 +50,12 @@ public class JDBCTable extends Table {
 
     private void validate(Map<String, String> properties) throws DdlException {
         if (properties == null) {
-            throw new DdlException("Please set properties of jdbc table, they are: jdbc.database, jdbc.table and jdbc.resource");
+            throw new DdlException("Please set properties of jdbc table, they are: table and resource");
         }
 
         jdbcTable = properties.get(TABLE);
         if (Strings.isNullOrEmpty(jdbcTable)) {
-            throw new DdlException(String.format(PROPERTY_MISSING_MSG, TABLE, TABLE));
+            throw new DdlException("property " + TABLE + " must be set");
         }
 
         resourceName = properties.get(RESOURCE);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
@@ -103,8 +103,6 @@ public class JDBCTable extends Table {
         String jsonStr = Text.readString(in);
         JsonObject obj = JsonParser.parseString(jsonStr).getAsJsonObject();
         jdbcTable = obj.getAsJsonPrimitive(TABLE).getAsString();
-        obj.remove(TABLE);
         resourceName = obj.getAsJsonPrimitive(RESOURCE).getAsString();
-        obj.remove(RESOURCE);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
@@ -6,10 +6,13 @@ import com.google.common.collect.Maps;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.starrocks.analysis.DescriptorTable;
 import com.starrocks.catalog.Resource.ResourceType;
 import com.starrocks.common.DdlException;
-//import com.starrocks.thrift.TTableDescriptor;
 import com.starrocks.common.io.Text;
+import com.starrocks.thrift.TJDBCTable;
+import com.starrocks.thrift.TTableDescriptor;
+import com.starrocks.thrift.TTableType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.parquet.Strings;
@@ -97,6 +100,21 @@ public class JDBCTable extends Table {
     }
 
     // @TODO implement toThrift function
+
+    @Override
+    public TTableDescriptor toThrift(List<DescriptorTable.ReferencedPartitionInfo> partitions) {
+        JDBCResource resource = (JDBCResource) (Catalog.getCurrentCatalog().getResourceMgr().getResource(resourceName));
+        TJDBCTable tJDBCTable = new TJDBCTable();
+        tJDBCTable.setJdbc_driver(resource.getProperty(JDBCResource.DRIVER));
+        tJDBCTable.setJdbc_url(resource.getProperty(JDBCResource.URI));
+        tJDBCTable.setJdbc_database(jdbcDatabase);
+        tJDBCTable.setJdbc_table(jdbcTable);
+        tJDBCTable.setJdbc_properties(jdbcProperties);
+        TTableDescriptor tTableDescriptor = new TTableDescriptor(getId(), TTableType.JDBC_TABLE,
+                fullSchema.size(), 0, getName(), "");
+        tTableDescriptor.setJdbcTable(tJDBCTable);
+        return tTableDescriptor;
+    }
 
     @Override
     public void write(DataOutput out) throws IOException {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
@@ -1,0 +1,129 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.catalog;
+
+import com.google.common.collect.Maps;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.starrocks.catalog.Resource.ResourceType;
+import com.starrocks.common.DdlException;
+//import com.starrocks.thrift.TTableDescriptor;
+import com.starrocks.common.io.Text;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.parquet.Strings;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class JDBCTable extends Table {
+    private static final Logger LOG = LogManager.getLogger(JDBCTable.class);
+
+    private static final String PROPERTY_MISSING_MSG =
+            "JDBC %s is null. Please add properties('%s'='xxx') when create table";
+
+    private static final String DB = "database";
+    private static final String TABLE = "table";
+    private static final String RESOURCE = "resource";
+
+
+    private String resourceName;
+    private String jdbcDatabase;
+    private String jdbcTable;
+    private Map<String, String> jdbcProperties = Maps.newHashMap();
+
+    public JDBCTable() {
+        super(TableType.JDBC);
+    }
+
+    public JDBCTable(long id, String name, List<Column> schema, Map<String, String> properties) throws DdlException {
+        super(id, name, TableType.JDBC, schema);
+        validate(properties);
+    }
+
+    public String getResourceName() {
+        return resourceName;
+    }
+
+    public String getJdbcDatabase() {
+        return jdbcDatabase;
+    }
+
+    public String getJdbcTable() {
+        return jdbcTable;
+    }
+
+    public Map<String, String> getJdbcProperties() {
+        return jdbcProperties;
+    }
+
+    private void validate(Map<String, String> properties) throws DdlException {
+        if (properties == null) {
+            throw new DdlException("Please set properties of jdbc table, they are: jdbc.database, jdbc.table and jdbc.resource");
+        }
+
+        Map<String, String> copiedProps = Maps.newHashMap(properties);
+        jdbcDatabase = copiedProps.get(DB);
+        if (Strings.isNullOrEmpty(jdbcDatabase)) {
+            throw new DdlException(String.format(PROPERTY_MISSING_MSG, DB, DB));
+        }
+        copiedProps.remove(DB);
+
+        jdbcTable = copiedProps.get(TABLE);
+        if (Strings.isNullOrEmpty(jdbcTable)) {
+            throw new DdlException(String.format(PROPERTY_MISSING_MSG, TABLE, TABLE));
+        }
+        copiedProps.remove(TABLE);
+
+        resourceName = copiedProps.get(RESOURCE);
+        if (Strings.isNullOrEmpty(resourceName)) {
+            throw new DdlException("property " + RESOURCE + " must be set");
+        }
+        copiedProps.remove(RESOURCE);
+
+        Resource resource = Catalog.getCurrentCatalog().getResourceMgr().getResource(resourceName);
+        if (resource == null) {
+            throw new DdlException("jdbc resource [" + resourceName + "] not exists");
+        }
+        if (resource.getType() != ResourceType.JDBC) {
+            throw new DdlException("resource [" + resourceName + "] is not jdbc resource");
+        }
+        jdbcProperties = copiedProps;
+
+    }
+
+    @Override
+    public void write(DataOutput out) throws IOException {
+        super.write(out);
+
+        JsonObject obj = new JsonObject();
+        obj.addProperty(DB, jdbcDatabase);
+        obj.addProperty(TABLE, jdbcTable);
+        obj.addProperty(RESOURCE, resourceName);
+        for (Map.Entry<String, String> entry : jdbcProperties.entrySet()) {
+            obj.addProperty(entry.getKey(), entry.getValue());
+        }
+        Text.writeString(out, obj.toString());
+    }
+
+    public void readFields(DataInput in) throws IOException {
+        super.readFields(in);
+        String jsonStr = Text.readString(in);
+        JsonObject obj = JsonParser.parseString(jsonStr).getAsJsonObject();
+        jdbcDatabase = obj.getAsJsonPrimitive(DB).getAsString();
+        obj.remove(DB);
+        jdbcTable = obj.getAsJsonPrimitive(TABLE).getAsString();
+        obj.remove(TABLE);
+        resourceName = obj.getAsJsonPrimitive(RESOURCE).getAsString();
+        obj.remove(RESOURCE);
+
+        jdbcProperties.clear();
+        for (Map.Entry<String, JsonElement> entry : obj.entrySet()) {
+            jdbcProperties.put(entry.getKey(), entry.getValue().getAsString());
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
@@ -96,6 +96,8 @@ public class JDBCTable extends Table {
 
     }
 
+    // @TODO implement toThrift function
+
     @Override
     public void write(DataOutput out) throws IOException {
         super.write(out);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
@@ -246,7 +246,6 @@ public class Table extends MetaObject implements Writable {
         super.readFields(in);
 
         this.id = in.readLong();
-        LOG.info("read id [{}]", this.id);
         this.name = Text.readString(in);
 
         // base schema

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
@@ -60,7 +60,8 @@ public class Table extends MetaObject implements Writable {
         HIVE,
         ICEBERG,
         HUDI,
-        ODBC
+        ODBC,
+        JDBC,
     }
 
     protected long id;
@@ -201,6 +202,8 @@ public class Table extends MetaObject implements Writable {
             table = new ExternalOlapTable();
         } else if (type == TableType.ICEBERG) {
             table = new IcebergTable();
+        } else if (type == TableType.JDBC) {
+            table = new JDBCTable();
         } else {
             throw new IOException("Unknown table type: " + type.name());
         }
@@ -243,6 +246,7 @@ public class Table extends MetaObject implements Writable {
         super.readFields(in);
 
         this.id = in.readLong();
+        LOG.info("read id [{}]", this.id);
         this.name = Text.readString(in);
 
         // base schema

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/JDBCTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/JDBCTableTest.java
@@ -1,0 +1,143 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.catalog;
+
+import com.clearspring.analytics.util.Lists;
+import com.google.common.collect.Maps;
+import com.starrocks.common.DdlException;
+import com.sun.org.apache.bcel.internal.generic.ATHROW;
+import mockit.Expectations;
+import mockit.Mock;
+import mockit.Mocked;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.internal.runners.statements.ExpectException;
+
+import java.io.*;
+import java.util.List;
+import java.util.Map;
+
+public class JDBCTableTest {
+    private String database;
+    private String table;
+    private String resourceName;
+    private List<Column> columns;
+    private Map<String, String> properties;
+
+    @Before
+    public void setUp() {
+        database = "db0";
+        table = "table0";
+        resourceName = "jdbc0";
+
+        columns = Lists.newArrayList();
+        Column column = new Column("col1", Type.BIGINT, true);
+        columns.add(column);
+
+        properties = Maps.newHashMap();
+        properties.put("database", database);
+        properties.put("table", table);
+        properties.put("resource", resourceName);
+    }
+
+    private Resource getMockedJDBCResource(String name) throws Exception {
+        Resource jdbcResource = new JDBCResource(name);
+        Map<String, String> resourceProperties = Maps.newHashMap();
+        resourceProperties.put("hosts", "host0,host1");
+        resourceProperties.put("user", "user0");
+        resourceProperties.put("password", "password0");
+        resourceProperties.put("driver", "driver0");
+        resourceProperties.put("jdbc_type", "jdbc_type0");
+        jdbcResource.setProperties(resourceProperties);
+        return jdbcResource;
+    }
+
+    @Test
+    public void testWithProperties(@Mocked Catalog catalog,
+                                   @Mocked ResourceMgr resourceMgr) throws Exception {
+        new Expectations() {
+            {
+                Catalog.getCurrentCatalog();
+                result = catalog;
+
+                catalog.getResourceMgr();
+                result = resourceMgr;
+
+                resourceMgr.getResource("jdbc0");
+                result = getMockedJDBCResource(resourceName);
+            }
+        };
+        // put jdbc properties
+        Map<String, String> jdbcProperties = Maps.newHashMap();
+        jdbcProperties.put("socketTimeout", "1000");
+        jdbcProperties.put("connectionTimeout", "1000");
+        properties.putAll(jdbcProperties);
+
+        JDBCTable table = new JDBCTable(1000, "jdbc_table", columns, properties);
+        Assert.assertEquals(this.resourceName, table.getResourceName());
+        Assert.assertEquals(this.database, table.getJdbcDatabase());
+        Assert.assertEquals(this.table, table.getJdbcTable());
+        Assert.assertEquals(jdbcProperties, table.getJdbcProperties());
+    }
+
+
+    @Test(expected = DdlException.class)
+    public void testWithIlegalResourceName(@Mocked Catalog catalog,
+                                           @Mocked ResourceMgr resourceMgr) throws Exception {
+        new Expectations() {
+            {
+                Catalog.getCurrentCatalog();
+                result = catalog;
+
+                catalog.getResourceMgr();
+                result = resourceMgr;
+
+                resourceMgr.getResource("jdbc0");
+                result = null;
+            }
+        };
+        new JDBCTable(1000, "jdbc_table", columns, properties);
+        Assert.fail("No exception throws.");
+    }
+
+    @Test(expected = DdlException.class)
+    public void testWithIlegalResourceType(@Mocked Catalog catalog,
+                                           @Mocked ResourceMgr resourceMgr) throws Exception {
+        new Expectations() {
+            {
+                Catalog.getCurrentCatalog();
+                result = catalog;
+
+                catalog.getResourceMgr();
+                result = resourceMgr;
+
+                resourceMgr.getResource("jdbc0");
+                result = new SparkResource("jdbc0");
+            }
+        };
+        new JDBCTable(1000, "jdbc_table", columns, properties);
+        Assert.fail("No exception throws.");
+    }
+
+    @Test(expected = DdlException.class)
+    public void testNoResource() throws Exception {
+        properties.remove("resource");
+        new JDBCTable(1000, "jdbc_table", columns, properties);
+        Assert.fail("No exception throws.");
+    }
+
+    @Test(expected = DdlException.class)
+    public void testNoDatabase() throws Exception {
+        properties.remove("database");
+        new JDBCTable(1000, "jdbc_table", columns, properties);
+        Assert.fail("No exception throws.");
+    }
+
+    @Test(expected = DdlException.class)
+    public void testNoTable() throws Exception {
+        properties.remove("table");
+        new JDBCTable(1000, "jdbc_table", columns, properties);
+        Assert.fail("No exception throws.");
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/JDBCTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/JDBCTableTest.java
@@ -19,7 +19,6 @@ import java.util.List;
 import java.util.Map;
 
 public class JDBCTableTest {
-    private String database;
     private String table;
     private String resourceName;
     private List<Column> columns;
@@ -27,7 +26,6 @@ public class JDBCTableTest {
 
     @Before
     public void setUp() {
-        database = "db0";
         table = "table0";
         resourceName = "jdbc0";
 
@@ -36,7 +34,6 @@ public class JDBCTableTest {
         columns.add(column);
 
         properties = Maps.newHashMap();
-        properties.put("database", database);
         properties.put("table", table);
         properties.put("resource", resourceName);
     }
@@ -44,11 +41,10 @@ public class JDBCTableTest {
     private Resource getMockedJDBCResource(String name) throws Exception {
         Resource jdbcResource = new JDBCResource(name);
         Map<String, String> resourceProperties = Maps.newHashMap();
-        resourceProperties.put("hosts", "host0,host1");
+        resourceProperties.put("jdbc_uri", "jdbc_uri");
         resourceProperties.put("user", "user0");
         resourceProperties.put("password", "password0");
         resourceProperties.put("driver", "driver0");
-        resourceProperties.put("jdbc_type", "jdbc_type0");
         jdbcResource.setProperties(resourceProperties);
         return jdbcResource;
     }
@@ -68,17 +64,9 @@ public class JDBCTableTest {
                 result = getMockedJDBCResource(resourceName);
             }
         };
-        // put jdbc properties
-        Map<String, String> jdbcProperties = Maps.newHashMap();
-        jdbcProperties.put("socketTimeout", "1000");
-        jdbcProperties.put("connectionTimeout", "1000");
-        properties.putAll(jdbcProperties);
-
         JDBCTable table = new JDBCTable(1000, "jdbc_table", columns, properties);
         Assert.assertEquals(this.resourceName, table.getResourceName());
-        Assert.assertEquals(this.database, table.getJdbcDatabase());
         Assert.assertEquals(this.table, table.getJdbcTable());
-        Assert.assertEquals(jdbcProperties, table.getJdbcProperties());
     }
 
 
@@ -123,13 +111,6 @@ public class JDBCTableTest {
     @Test(expected = DdlException.class)
     public void testNoResource() throws Exception {
         properties.remove("resource");
-        new JDBCTable(1000, "jdbc_table", columns, properties);
-        Assert.fail("No exception throws.");
-    }
-
-    @Test(expected = DdlException.class)
-    public void testNoDatabase() throws Exception {
-        properties.remove("database");
         new JDBCTable(1000, "jdbc_table", columns, properties);
         Assert.fail("No exception throws.");
     }

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -322,6 +322,14 @@ struct THudiTable {
     5: optional list<string> partition_prefixes
 }
 
+struct TJDBCTable {
+    1: optional string jdbc_driver
+    2: optional string jdbc_url
+    3: optional string jdbc_database;
+    4: optional string jdbc_table;
+    5: optional map<string, string> jdbc_properties;
+}
+
 // "Union" of all table types.
 struct TTableDescriptor {
   1: required Types.TTableId id
@@ -339,6 +347,7 @@ struct TTableDescriptor {
   12: optional TSchemaTable schemaTable
   14: optional TBrokerTable BrokerTable
   15: optional TEsTable esTable
+  16: optional TJDBCTable jdbcTable
 
   // Hdfs Table schema
   30: optional THdfsTable hdfsTable

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -325,9 +325,9 @@ struct THudiTable {
 struct TJDBCTable {
     1: optional string jdbc_driver
     2: optional string jdbc_url
-    3: optional string jdbc_database;
-    4: optional string jdbc_table;
-    5: optional map<string, string> jdbc_properties;
+    3: optional string jdbc_table
+    4: optional string jdbc_user
+    5: optional string jdbc_passwd
 }
 
 // "Union" of all table types.

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -60,6 +60,7 @@ enum TPlanNodeType {
   PROJECT_NODE,
   TABLE_FUNCTION_NODE,
   DECODE_NODE,
+  JDBC_SCAN_NODE,
 }
 
 // phases of an execution node
@@ -341,6 +342,16 @@ struct TOlapScanNode {
   // which columns only be used to filter data in the stage of scan data
   24: optional list<string> unused_output_column_name
 }
+
+struct TJDBCScanNode {
+  1: required Types.TTupleId tuple_id
+  2: required string table_name
+  3: required list<string> columns
+  4: required list<string> filters
+  5: optional i64 limit
+}
+
+
 struct TEqJoinCondition {
   // left-hand side of "<a> = <b>"
   1: required Exprs.TExpr left;
@@ -895,6 +906,8 @@ struct TPlanNode {
   58: optional list<Types.TSlotId> filter_null_value_columns;
   // for outer join and cross join
   59: optional bool need_create_tuple_columns;
+  // Scan node for jdbc
+  60: optional TJDBCScanNode jdbc_scan_node;
 }
 
 // A flattened representation of a tree of PlanNodes, obtained by depth-first

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -344,10 +344,10 @@ struct TOlapScanNode {
 }
 
 struct TJDBCScanNode {
-  1: required Types.TTupleId tuple_id
-  2: required string table_name
-  3: required list<string> columns
-  4: required list<string> filters
+  1: optional Types.TTupleId tuple_id
+  2: optional string table_name
+  3: optional list<string> columns
+  4: optional list<string> filters
   5: optional i64 limit
 }
 

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -356,6 +356,7 @@ enum TTableType {
     HDFS_TABLE,
     ICEBERG_TABLE,
     HUDI_TABLE,
+    JDBC_TABLE,
     VIEW = 20
 }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
support create jdbc table, syntax is the same as other create external table statement, the only difference is the properties setting.

```sql
create external table [TABLE] (
(column_definition1[, column_definition2, ...]
) engine=jdbc properties (
    "resource" = "jdbc resource name",
    "table" = "external table name"
);
```
