### PR TITLE
Fix same window function transform bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/WindowTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/WindowTransformer.java
@@ -466,7 +466,9 @@ public class WindowTransformer {
         }
 
         public void addFunction(AnalyticExpr analyticExpr) {
-            windowFunctions.add(analyticExpr);
+            if (!windowFunctions.contains(analyticExpr)) {
+                windowFunctions.add(analyticExpr);
+            }
         }
 
         public List<AnalyticExpr> getWindowFunctions() {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -1333,6 +1333,34 @@ public class PlanFragmentTest extends PlanTestBase {
     }
 
     @Test
+    public void testSameWindowFunctionReuse() throws Exception {
+        String sql = "select sum(v1) over() as c1, sum(v1) over() as c2 from t0";
+        String plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("  3:Project\n" +
+                "  |  <slot 4> : 4: sum(1: v1)\n" +
+                "  |  \n" +
+                "  2:ANALYTIC\n" +
+                "  |  functions: [, sum(1: v1), ]"));
+
+        sql = "select c1+1, c2+2 from (select sum(v1) over() as c1, sum(v1) over() as c2 from t0) t";
+        plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("  3:Project\n" +
+                "  |  <slot 4> : 4: sum(1: v1)\n" +
+                "  |  \n" +
+                "  2:ANALYTIC\n" +
+                "  |  functions: [, sum(1: v1), ]"));
+
+        sql = "select c1+1, c2+2 from (select sum(v1) over() as c1, sum(v3) over() as c2 from t0) t";
+        plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("  3:Project\n" +
+                "  |  <slot 5> : 4: sum(1: v1) + 1\n" +
+                "  |  <slot 6> : 4: sum(1: v1) + 2\n" +
+                "  |  \n" +
+                "  2:ANALYTIC\n" +
+                "  |  functions: [, sum(1: v1), ]"));
+    }
+
+    @Test
     public void testJoinWithLimitSubQuery() throws Exception {
         String sql = "select * from (select v1, v2 from t0 limit 10) a join " +
                 "(select v1, v2 from t0 limit 1) b";

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -1345,7 +1345,8 @@ public class PlanFragmentTest extends PlanTestBase {
         sql = "select c1+1, c2+2 from (select sum(v1) over() as c1, sum(v1) over() as c2 from t0) t";
         plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("  3:Project\n" +
-                "  |  <slot 4> : 4: sum(1: v1)\n" +
+                "  |  <slot 5> : 4: sum(1: v1) + 1\n" +
+                "  |  <slot 6> : 4: sum(1: v1) + 2\n" +
                 "  |  \n" +
                 "  2:ANALYTIC\n" +
                 "  |  functions: [, sum(1: v1), ]"));
@@ -1353,11 +1354,11 @@ public class PlanFragmentTest extends PlanTestBase {
         sql = "select c1+1, c2+2 from (select sum(v1) over() as c1, sum(v3) over() as c2 from t0) t";
         plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("  3:Project\n" +
-                "  |  <slot 5> : 4: sum(1: v1) + 1\n" +
-                "  |  <slot 6> : 4: sum(1: v1) + 2\n" +
+                "  |  <slot 6> : 4: sum(1: v1) + 1\n" +
+                "  |  <slot 7> : 5: sum(3: v3) + 2\n" +
                 "  |  \n" +
                 "  2:ANALYTIC\n" +
-                "  |  functions: [, sum(1: v1), ]"));
+                "  |  functions: [, sum(1: v1), ], [, sum(3: v3), ]"));
     }
 
     @Test


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
If there are multiple repeated window functions in the output expression, the window functions are not deduplicated, resulting in an error in WindowTransform （java.lang.ClassCastException: com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator cannot be cast to com.starrocks.sql.optimizer.operator.scalar.CallOperator）.Because there is reuse in SqlToScalarOperatorTranslator.translate parsing, repeated window functions will be parsed into ColumnRef
