### PR TITLE
Fix bug to get column names correctly in the ORC scanner 

### DIFF
--- a/be/src/exec/vectorized/orc_scanner_adapter.cpp
+++ b/be/src/exec/vectorized/orc_scanner_adapter.cpp
@@ -1046,7 +1046,7 @@ void OrcScannerAdapter::build_column_name_set(std::unordered_set<std::string>* n
                                               const std::vector<std::string>* hive_column_names,
                                               const orc::Type& root_type) {
     name_set->clear();
-    if (hive_column_names != nullptr) {
+    if (hive_column_names != nullptr && hive_column_names->size() > 0) {
         // build hive column names index.
         int size = std::min(hive_column_names->size(), root_type.getSubtypeCount());
         for (int i = 0; i < size; i++) {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2939

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Fix bug to get column names correctly in the ORC scanner.