### PR TITLE
add level compaction policy

### DIFF
--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -151,4 +151,5 @@ add_library(Storage STATIC
     vectorized/rowset_merger.cpp
     vectorized/column_predicate_rewriter.cpp
     vectorized/column_predicate_dict_conjuct.cpp
+    level_compaction_policy.cpp
 )

--- a/be/src/storage/level_compaction_policy.cpp
+++ b/be/src/storage/level_compaction_policy.cpp
@@ -1,0 +1,285 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+#include "storage/level_compaction_policy.h"
+
+#include <sstream>
+#include <vector>
+
+#include "storage/compaction_context.h"
+#include "storage/compaction_task.h"
+#include "storage/compaction_task_factory.h"
+#include "storage/rowset/rowset.h"
+#include "util/time.h"
+
+namespace starrocks {
+
+// should calculate the compaction score of each level
+// and decide the level to compact
+bool LevelCompactionPolicy::need_compaction() {
+    uint8_t selected_level = -1;
+    double max_compaction_score = 0.0;
+    double level_compaction_score = 0.0;
+    VLOG(2) << "need_compaction compaction context:" << _compaction_context->to_string();
+    for (int i = 0; i < LEVEL_NUMBER - 1; ++i) {
+        if (i == 0) {
+            // level 0
+            level_compaction_score = _get_level_0_compaction_score();
+            _compaction_context->compaction_scores[0] = level_compaction_score;
+        } else if (i == 1) {
+            // level 1
+            level_compaction_score = _get_level_1_compaction_score();
+            _compaction_context->compaction_scores[1] = level_compaction_score;
+        } else {
+            LOG(WARNING) << "invalid compaction level:" << i;
+            continue;
+        }
+        if (level_compaction_score > max_compaction_score) {
+            max_compaction_score = level_compaction_score;
+            selected_level = i;
+        }
+    }
+    _compaction_context->current_level = selected_level;
+    // for max_compaction_score is double, use 0.999 instead of 1
+    return max_compaction_score > 0.999;
+}
+
+double LevelCompactionPolicy::compaction_score() {
+    if (_compaction_context->current_level < 0 || _compaction_context->current_level > LEVEL_NUMBER - 1) {
+        return 0;
+    }
+    return _compaction_context->compaction_scores[_compaction_context->current_level];
+}
+
+std::shared_ptr<CompactionTask> LevelCompactionPolicy::create_compaction() {
+    // construct CompactionTask
+    // return nullptr if can not find enough rowsets
+    VLOG(2) << "compaction context:" << _compaction_context->to_string();
+    if (_compaction_context->current_level == 0) {
+        return _create_level_0_compaction();
+    } else if (_compaction_context->current_level == 1) {
+        return _create_level_1_compaction();
+    }
+    return nullptr;
+}
+
+// the first rowset in level-0 may be compacted already, and the creation_time may be larger than
+// the rowsets behind. when pick level-0 rowsets, the first compacted rowset should be picked no matter
+// whether the creation time is older enough.
+bool LevelCompactionPolicy::_is_rowset_creation_time_ordered(
+        const std::set<Rowset*, RowsetComparator>& level_0_rowsets) {
+    if (level_0_rowsets.size() <= 1) {
+        return true;
+    }
+    // the compacted rowset can only be the first one, so just compare the first two rowsets
+    auto iter = level_0_rowsets.begin();
+    Rowset* first_rowset = *iter;
+    Rowset* second_rowset = *(++iter);
+    return first_rowset->creation_time() <= second_rowset->creation_time();
+}
+
+void LevelCompactionPolicy::_pick_level_0_rowsets(bool* has_delete_version, size_t* rowsets_compaction_score,
+                                                  std::vector<RowsetSharedPtr>* rowsets) {
+    int64_t now = UnixSeconds();
+    if (_compaction_context->rowset_levels[0].size() == 0) {
+        return;
+    }
+    bool is_creation_time_ordered = _is_rowset_creation_time_ordered(_compaction_context->rowset_levels[0]);
+    int index = 0;
+    for (auto rowset : _compaction_context->rowset_levels[0]) {
+        if (_compaction_context->tablet->version_for_delete_predicate(rowset->version())) {
+            *has_delete_version = true;
+            break;
+        }
+        // For level-0, should consider the rowset creation time.
+        // newly-created rowsets should be skipped.
+        if ((is_creation_time_ordered || (!is_creation_time_ordered && index != 0)) &&
+            rowset->creation_time() + config::cumulative_compaction_skip_window_seconds > now) {
+            // rowset in rowset_levels is ordered
+            LOG(INFO) << "rowset:" << rowset->rowset_id() << ", version:" << rowset->version()
+                      << " is newly created. creation time:" << rowset->creation_time()
+                      << ", threshold:" << config::cumulative_compaction_skip_window_seconds
+                      << ", rowset overlapping:" << rowset->rowset_meta()->segments_overlap() << ", index:" << index
+                      << ", is_creation_time_ordered:" << is_creation_time_ordered;
+            break;
+        }
+        rowsets->emplace_back(std::move(rowset->shared_from_this()));
+        *rowsets_compaction_score += rowset->rowset_meta()->get_compaction_score();
+        if (*rowsets_compaction_score >= config::max_cumulative_compaction_num_singleton_deltas) {
+            LOG(INFO) << "rowsets_compaction_score:" << *rowsets_compaction_score
+                      << " is larger than config:" << config::max_cumulative_compaction_num_singleton_deltas
+                      << ", level 0 rowset size:" << _compaction_context->rowset_levels[0].size();
+            break;
+        }
+        ++index;
+    }
+}
+
+Status LevelCompactionPolicy::_check_version_continuity(const std::vector<RowsetSharedPtr>& rowsets) {
+    if (rowsets.empty()) {
+        return Status::OK();
+    }
+    for (int i = 0; i < rowsets.size() - 1; ++i) {
+        auto& current_rowset = rowsets[i];
+        auto& next_rowset = rowsets[i + 1];
+        if (next_rowset->start_version() != current_rowset->end_version() + 1) {
+            LOG(WARNING) << "There are missed versions among rowsets. "
+                         << "current_rowset version=" << current_rowset->start_version() << "-"
+                         << current_rowset->end_version() << ", rowset version=" << next_rowset->start_version() << "-"
+                         << next_rowset->end_version();
+            return Status::InternalError("level compaction miss versions error.");
+        }
+    }
+
+    return Status::OK();
+}
+
+std::shared_ptr<CompactionTask> LevelCompactionPolicy::_create_level_0_compaction() {
+    if (_compaction_context->rowset_levels[0].size() == 0) {
+        LOG(WARNING) << "no level 0 rowsets to create compaction task.";
+        return nullptr;
+    }
+    // decide which rowsets to compaction
+    // TODO: 需要考虑加锁
+    std::vector<RowsetSharedPtr> input_rowsets;
+    bool has_delete_version = false;
+    size_t rowsets_compaction_score = 0;
+    _pick_level_0_rowsets(&has_delete_version, &rowsets_compaction_score, &input_rowsets);
+    if (!has_delete_version && rowsets_compaction_score < config::min_cumulative_compaction_num_singleton_deltas) {
+        // There is no enough qualified rowsets, just skip compaction by return nullptr.
+        // If has_delete_version is true, input_rowsets.size() will be large than 0, because
+        // the leading rowsets can not be 'delete' rowset, which is guaranteed in Tablet::get_compaction_context
+        LOG(INFO) << "rowsets_compaction_score:" << rowsets_compaction_score
+                  << " is smaller than threshold:" << config::min_cumulative_compaction_num_singleton_deltas;
+        return nullptr;
+    }
+    DCHECK(input_rowsets.size() > 0) << "input rowsets size can not be empty";
+
+    if (input_rowsets.size() < 1) {
+        LOG(INFO) << "no suitable rowsets for level 0 compaction";
+        return nullptr;
+    }
+
+    auto st = _check_version_continuity(input_rowsets);
+    if (!st.ok()) {
+        return nullptr;
+    }
+
+    Version output_version;
+    output_version.first = (*input_rowsets.begin())->start_version();
+    output_version.second = (*input_rowsets.rbegin())->end_version();
+
+    CompactionTaskFactory factory(output_version, _compaction_context->tablet, std::move(input_rowsets),
+                                  _compaction_context->get_score(), 0);
+    std::shared_ptr<CompactionTask> compaction_task = factory.create_compaction_task();
+    return compaction_task;
+}
+
+void LevelCompactionPolicy::_pick_level_1_rowsets(std::vector<RowsetSharedPtr>* rowsets) {
+    uint32_t input_rows_num = 0;
+    size_t input_size = 0;
+    // add the base rowset to input_rowsets
+    Rowset* base_rowset = *_compaction_context->rowset_levels[2].begin();
+    rowsets->push_back(base_rowset->shared_from_this());
+    input_rows_num += base_rowset->num_rows();
+    input_size += base_rowset->data_disk_size();
+    // add level-1 rowsets
+    for (auto rowset : _compaction_context->rowset_levels[1]) {
+        rowsets->push_back(rowset->shared_from_this());
+        input_rows_num += rowset->num_rows();
+        input_size += rowset->data_disk_size();
+    }
+}
+
+std::shared_ptr<CompactionTask> LevelCompactionPolicy::_create_level_1_compaction() {
+    std::vector<RowsetSharedPtr> input_rowsets;
+    _pick_level_1_rowsets(&input_rowsets);
+    if (input_rowsets.size() <= 1) {
+        LOG(INFO) << "no suitable version for compaction. size:" << input_rowsets.size();
+        return nullptr;
+    }
+
+    if (input_rowsets.size() == 2 && input_rowsets[0]->empty()) {
+        // the tablet is with rowset: [0-x], [x+1-y], and [0-x] is empty,
+        // no need to do base compaction.
+        LOG(INFO) << "only two rowset. one is [0-x] and it is empty. do not compact. tablet:"
+                  << _compaction_context->tablet->tablet_id();
+        return nullptr;
+    }
+    DCHECK(input_rowsets.size() > 0) << "input rowsets size can not be empty";
+    auto st = _check_version_continuity(input_rowsets);
+    if (!st.ok()) {
+        return nullptr;
+    }
+
+    Version output_version;
+    output_version.first = (*input_rowsets.begin())->start_version();
+    output_version.second = (*input_rowsets.rbegin())->end_version();
+
+    CompactionTaskFactory factory(output_version, _compaction_context->tablet, std::move(input_rowsets),
+                                  _compaction_context->get_score(), 1);
+    std::shared_ptr<CompactionTask> compaction_task = factory.create_compaction_task();
+    return compaction_task;
+}
+
+double LevelCompactionPolicy::_get_level_0_compaction_score() {
+    uint32_t segment_num_score = 0;
+    size_t rowsets_size = 0;
+    for (auto& rowset : _compaction_context->rowset_levels[0]) {
+        segment_num_score += rowset->rowset_meta()->get_compaction_score();
+        rowsets_size += rowset->rowset_meta()->total_disk_size();
+    }
+
+    double num_score = static_cast<double>(segment_num_score) / config::min_cumulative_compaction_num_singleton_deltas;
+    double size_score = static_cast<double>(rowsets_size) / config::min_level_0_compaction_size;
+    double score = std::max(num_score, size_score);
+    VLOG(2) << "tablet:" << _compaction_context->tablet->tablet_id() << ", compaction score:" << score
+            << ", size_score:" << size_score << ", num_score:" << num_score << ", rowsets_size:" << rowsets_size;
+    return score;
+}
+
+double LevelCompactionPolicy::_get_level_1_compaction_score() {
+    uint32_t segment_num_score = 0;
+    size_t level_1_rowsets_size = 0;
+    for (auto& rowset : _compaction_context->rowset_levels[1]) {
+        segment_num_score += rowset->rowset_meta()->get_compaction_score();
+        level_1_rowsets_size += rowset->data_disk_size();
+    }
+
+    double num_score = static_cast<double>(segment_num_score) / config::base_compaction_num_cumulative_deltas;
+    double size_score = static_cast<double>(level_1_rowsets_size) / config::min_level_1_compaction_size;
+
+    double time_delta = 0;
+    double size_delta = 0;
+    if (_compaction_context->rowset_levels[2].size() > 0) {
+        DCHECK(_compaction_context->rowset_levels[2].size() == 1)
+                << "invalide rowset size. " << _compaction_context->rowset_levels[2].size();
+        Rowset* base_rowset = *_compaction_context->rowset_levels[2].begin();
+        if (base_rowset->data_disk_size() > 0) {
+            double size_ratio = level_1_rowsets_size / base_rowset->data_disk_size();
+            if (size_ratio >= config::base_cumulative_delta_ratio) {
+                size_delta = 1.0;
+            }
+        }
+
+        int64_t base_creation_time = base_rowset->creation_time();
+        int64_t interval_since_last_base_compaction = time(nullptr) - base_creation_time;
+        if (interval_since_last_base_compaction > config::base_compaction_interval_seconds_since_last_operation &&
+            (_compaction_context->rowset_levels[1].size() > 1 ||
+             (_compaction_context->rowset_levels[1].size() == 1 && !base_rowset->empty()))) {
+            // the tablet is with rowsets: [0-x], [x+1-y], and [0-x] is empty.
+            // in this situation, no need to do base compaction.
+            LOG(INFO) << "satisfy the base compaction policy. tablet=" << _compaction_context->tablet->tablet_id()
+                      << ", interval_since_last_base_compaction=" << interval_since_last_base_compaction
+                      << ", interval_threshold=" << config::base_compaction_interval_seconds_since_last_operation
+                      << ", level 1 rowsets size:" << _compaction_context->rowset_levels[1].size()
+                      << ", level_1_rowsets_size:" << level_1_rowsets_size;
+            time_delta = 1.0;
+        }
+    }
+    double score = std::max(num_score, size_score + size_delta) + time_delta;
+    VLOG(2) << "tablet:" << _compaction_context->tablet->tablet_id() << ", compaction score:" << score
+            << ", size_score:" << size_score << ", num_score:" << num_score << ", time_delta:" << time_delta
+            << ", size_delta:" << size_delta;
+    return score;
+}
+
+} // namespace starrocks

--- a/be/src/storage/level_compaction_policy.h
+++ b/be/src/storage/level_compaction_policy.h
@@ -1,0 +1,52 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#pragma once
+
+#include <vector>
+
+#include "storage/compaction_context.h"
+#include "storage/compaction_policy.h"
+
+namespace starrocks {
+
+class CompactionTask;
+
+// Tablet构造CompactionContext，然后交给CompactionPolicy实时计算，不需要在tablet保留CompactionContext，这样子不会带来太大的内存开销
+
+// Lazy level compaction policy for tablet
+// Ref: Dostoevsky: Better Space-Time Trade-Offs for LSM-Tree Based Key-Value Stores via Adaptive Removal of Superfluous Merging
+class LevelCompactionPolicy : public CompactionPolicy {
+public:
+    LevelCompactionPolicy(CompactionContext* compaction_context) : _compaction_context(compaction_context) {}
+    ~LevelCompactionPolicy() = default;
+
+    // used to judge whether a tablet should do compaction or not
+    bool need_compaction() override;
+
+    // to calculate the compaction score of a tablet
+    // which is used to decide the compaction sequence of tablets
+    double compaction_score() override;
+
+    // used to generator a CompactionTask for tablet
+    std::shared_ptr<CompactionTask> create_compaction() override;
+
+private:
+    double _get_level_0_compaction_score();
+    void _pick_level_0_rowsets(bool* has_delete_version, size_t* rowsets_compaction_score,
+                               std::vector<RowsetSharedPtr>* rowsets);
+    bool _is_rowset_creation_time_ordered(const std::set<Rowset*, RowsetComparator>& level_0_rowsets);
+
+    double _get_level_1_compaction_score();
+    void _pick_level_1_rowsets(std::vector<RowsetSharedPtr>* rowsets);
+
+    Status _check_version_continuity(const std::vector<RowsetSharedPtr>& rowsets);
+
+    std::shared_ptr<CompactionTask> _create_level_0_compaction();
+
+    std::shared_ptr<CompactionTask> _create_level_1_compaction();
+
+private:
+    CompactionContext* _compaction_context;
+};
+
+} // namespace starrocks

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -159,6 +159,7 @@ set(EXEC_FILES
         ./storage/tablet_updates_test.cpp
         ./storage/update_manager_test.cpp
         ./storage/compaction_utils_test.cpp
+        ./storage/level_compaction_policy_test.cpp
         ./storage/vectorized/aggregate_iterator_test.cpp
         ./storage/vectorized/chunk_aggregator_test.cpp
         ./storage/vectorized/chunk_helper_test.cpp

--- a/be/test/storage/level_compaction_policy_test.cpp
+++ b/be/test/storage/level_compaction_policy_test.cpp
@@ -70,7 +70,6 @@ TEST(LevelCompactionPolicyTest, test_need_compaction) {
     }
     LevelCompactionPolicy policy(compaction_context.get());
     ASSERT_TRUE(policy.need_compaction());
-    std::cout << "compaction score:" << policy.compaction_score() << std::endl;
 }
 
 } // namespace starrocks

--- a/be/test/storage/level_compaction_policy_test.cpp
+++ b/be/test/storage/level_compaction_policy_test.cpp
@@ -1,0 +1,76 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#include "storage/level_compaction_policy.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+#include <random>
+
+#include "storage/compaction_context.h"
+#include "storage/compaction_utils.h"
+#include "storage/rowset/beta_rowset.h"
+#include "storage/tablet.h"
+#include "storage/tablet_schema_helper.h"
+#include "storage/tablet_updates.h"
+
+namespace starrocks {
+
+TEST(LevelCompactionPolicyTest, test_need_compaction) {
+    TabletSharedPtr tablet = std::make_shared<Tablet>();
+    TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
+    tablet_meta->set_tablet_id(100);
+    tablet->set_tablet_meta(tablet_meta);
+    std::unique_ptr<CompactionContext> compaction_context = std::make_unique<CompactionContext>();
+    compaction_context->tablet = tablet.get();
+
+    std::vector<RowsetSharedPtr> rowsets;
+    TabletSchema tablet_schema;
+    create_tablet_schema(&tablet_schema);
+
+    int64_t base_time = UnixMillis() - 100 * 1000;
+    RowsetMetaSharedPtr base_rowset_meta = std::make_shared<RowsetMeta>();
+    base_rowset_meta->set_start_version(0);
+    base_rowset_meta->set_end_version(9);
+    base_rowset_meta->set_creation_time(base_time);
+    base_rowset_meta->set_segments_overlap(NONOVERLAPPING);
+    base_rowset_meta->set_num_segments(1);
+    base_rowset_meta->set_total_disk_size(100 * 1024 * 1024);
+    base_rowset_meta->set_empty(false);
+    RowsetSharedPtr base_rowset = std::make_shared<BetaRowset>(&tablet_schema, "./rowset_0", base_rowset_meta);
+    compaction_context->rowset_levels[2].insert(base_rowset.get());
+    rowsets.emplace_back(std::move(base_rowset));
+    for (int i = 1; i <= 10; i++) {
+        RowsetMetaSharedPtr rowset_meta = std::make_shared<RowsetMeta>();
+        rowset_meta->set_start_version(i * 10);
+        rowset_meta->set_end_version((i + 1) * 10 - 1);
+        rowset_meta->set_creation_time(base_time + i);
+        rowset_meta->set_segments_overlap(NONOVERLAPPING);
+        rowset_meta->set_num_segments(1);
+        rowset_meta->set_total_disk_size(1024 * 1024);
+        RowsetSharedPtr rowset =
+                std::make_shared<BetaRowset>(&tablet_schema, "./rowset" + std::to_string(i), rowset_meta);
+        compaction_context->rowset_levels[1].insert(rowset.get());
+        rowsets.emplace_back(std::move(rowset));
+    }
+
+    for (int i = 110; i < 120; i++) {
+        RowsetMetaSharedPtr rowset_meta = std::make_shared<RowsetMeta>();
+        rowset_meta->set_start_version(i);
+        rowset_meta->set_end_version(i);
+        rowset_meta->set_creation_time(base_time + i);
+        rowset_meta->set_segments_overlap(NONOVERLAPPING);
+        rowset_meta->set_num_segments(1);
+        rowset_meta->set_total_disk_size(1024 * 1024);
+        RowsetSharedPtr rowset =
+                std::make_shared<BetaRowset>(&tablet_schema, "./rowset" + std::to_string(i), rowset_meta);
+        compaction_context->rowset_levels[0].insert(rowset.get());
+        rowsets.emplace_back(std::move(rowset));
+    }
+    LevelCompactionPolicy policy(compaction_context.get());
+    ASSERT_TRUE(policy.need_compaction());
+    std::cout << "compaction score:" << policy.compaction_score() << std::endl;
+}
+
+} // namespace starrocks


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [X] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3362 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Add LevelCompactionPolicy for new compaction execution framework. LevelCompactionPolicy is created based on CompactionContext to decide whether the tablet should be compacted, which level should be compacted, and how many rowsets in that level should be compacted. And LevelCompactionPolicy use the same strategy as before. The details are as follows: when the compaction score is above threshold, it is considered to be compaction candidate. It use the same strategy to pick rowsets from level. But the difference is there are no cumulative compaction or base compaction. Now it is replaced by level compaction. And there are only three levels and also two types of compaction(level-0 and level-1 compaction) to keep compatible. Level-0 compaction is equivalent to cumulative compaction as before; Level-1 compaction is equivalent to base compaction. Maybe it can be extended to more levels in the future.