### PR TITLE
fix compaction bug when data dir reaches capacity limit

### DIFF
--- a/be/src/storage/olap_server.cpp
+++ b/be/src/storage/olap_server.cpp
@@ -181,6 +181,8 @@ void* StorageEngine::_base_compaction_thread_callback(void* arg, DataDir* data_d
         // must be here, because this thread is start on start and
         if (!data_dir->reach_capacity_limit(0)) {
             status = _perform_base_compaction(data_dir);
+        } else {
+            status = Status::InternalError("data dir out of capacity");
         }
         if (status.ok()) {
             continue;
@@ -304,6 +306,8 @@ void* StorageEngine::_cumulative_compaction_thread_callback(void* arg, DataDir* 
         // must be here, because this thread is start on start and
         if (!data_dir->reach_capacity_limit(0)) {
             status = _perform_cumulative_compaction(data_dir);
+        } else {
+            status = Status::InternalError("data dir out of capacity");
         }
         if (status.ok()) {
             continue;

--- a/be/src/storage/olap_server.cpp
+++ b/be/src/storage/olap_server.cpp
@@ -213,6 +213,8 @@ void* StorageEngine::_update_compaction_thread_callback(void* arg, DataDir* data
         // must be here, because this thread is start on start and
         if (!data_dir->reach_capacity_limit(0)) {
             status = _perform_update_compaction(data_dir);
+        } else {
+            status = Status::InternalError("data dir out of capacity");
         }
         if (status.ok()) {
             continue;


### PR DESCRIPTION
## What type of PR is this：
- [X] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3366 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When data dir reaches capacity limit, the polling thread of compaction will lead to dead loop, which will cost cpu.  Fix this bug by making compaction polling thread sleep when capacity limit is reached.