### PR TITLE
Fix iceberg table can not be recognized error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -10,6 +10,7 @@ import com.starrocks.analysis.GroupingFunctionCallExpr;
 import com.starrocks.catalog.AggregateFunction;
 import com.starrocks.catalog.EsTable;
 import com.starrocks.catalog.HiveTable;
+import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.MysqlTable;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.SchemaTable;
@@ -49,6 +50,6 @@ public class AnalyzerUtils {
 
     public static boolean isSupportedTable(Table table) {
         return table instanceof OlapTable || table instanceof HiveTable || table instanceof SchemaTable ||
-                table instanceof MysqlTable || table instanceof EsTable;
+                table instanceof MysqlTable || table instanceof EsTable || table instanceof IcebergTable;
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related with #3339 which remove iceberg table from isSupportedTable list

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
```
2022-02-15 11:38:05,011 WARN (starrocks-mysql-nio-pool-0|148) [StmtExecutor.execute():305] New planner error: select * from ex_iceberg_tbl0 order by col_int limit 5
com.starrocks.sql.common.UnsupportedException: unsupported scan table type: ICEBERG
        at com.starrocks.sql.common.UnsupportedException.unsupportedException(UnsupportedException.java:12) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.analyzer.QueryAnalyzer.resolveTableRef(QueryAnalyzer.java:608) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.analyzer.QueryAnalyzer.analyzeFrom(QueryAnalyzer.java:358) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.analyzer.QueryAnalyzer.transformSelectStmt(QueryAnalyzer.java:159) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.analyzer.QueryAnalyzer.transformQueryStmt(QueryAnalyzer.java:143) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.analyzer.Analyzer.analyze(Analyzer.java:50) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:34) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:291) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:268) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.dispatch(ConnectProcessor.java:415) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.processOnce(ConnectProcessor.java:651) ~[starrocks-fe.jar:?]
        at com.starrocks.mysql.nio.ReadListener.lambda$handleEvent$0(ReadListener.java:55) ~[starrocks-fe.jar:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_262]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_262]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_262]
2022-02-15 11:38:05,011 WARN (starrocks-mysql-nio-pool-0|148) [StmtExecutor.execute():452] execute Exception, sql select * from ex_iceberg_tbl0 order by col_int limit 5
com.starrocks.sql.common.UnsupportedException: unsupported scan table type: ICEBERG
        at com.starrocks.sql.common.UnsupportedException.unsupportedException(UnsupportedException.java:12) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.analyzer.QueryAnalyzer.resolveTableRef(QueryAnalyzer.java:608) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.analyzer.QueryAnalyzer.analyzeFrom(QueryAnalyzer.java:358) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.analyzer.QueryAnalyzer.transformSelectStmt(QueryAnalyzer.java:159) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.analyzer.QueryAnalyzer.transformQueryStmt(QueryAnalyzer.java:143) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.analyzer.Analyzer.analyze(Analyzer.java:50) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:34) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:291) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:268) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.dispatch(ConnectProcessor.java:415) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.processOnce(ConnectProcessor.java:651) ~[starrocks-fe.jar:?]
        at com.starrocks.mysql.nio.ReadListener.lambda$handleEvent$0(ReadListener.java:55) ~[starrocks-fe.jar:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_262]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_262]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_262]
```