### PR TITLE
Refactor Env: Return objects through StatusOr<T> instead of output pa…

### DIFF
--- a/be/src/env/env.h
+++ b/be/src/env/env.h
@@ -12,7 +12,7 @@
 #include <memory>
 #include <string>
 
-#include "common/status.h"
+#include "common/statusor.h"
 #include "util/slice.h"
 
 namespace starrocks {
@@ -46,49 +46,42 @@ public:
     static Env* Default();
 
     // Create a brand new sequentially-readable file with the specified name.
-    // On success, stores a pointer to the new file in *result and returns OK.
-    // On failure stores NULL in *result and returns non-OK.  If the file does
-    // not exist, returns a non-OK status.
+    //  If the file does not exist, returns a non-OK status.
     //
     // The returned file will only be accessed by one thread at a time.
-    virtual Status new_sequential_file(const std::string& fname, std::unique_ptr<SequentialFile>* result) = 0;
+    virtual StatusOr<std::unique_ptr<SequentialFile>> new_sequential_file(const std::string& fname) = 0;
 
     // Create a brand new random access read-only file with the
-    // specified name.  On success, stores a pointer to the new file in
-    // *result and returns OK.  On failure stores nullptr in *result and
-    // returns non-OK.  If the file does not exist, returns a non-OK
-    // status.
+    // specified name.
     //
-    // The returned file may be concurrently accessed by multiple threads.
-    virtual Status new_random_access_file(const std::string& fname, std::unique_ptr<RandomAccessFile>* result) = 0;
+    // The returned file will only be accessed by one thread at a time.
+    virtual StatusOr<std::unique_ptr<RandomAccessFile>> new_random_access_file(const std::string& fname) = 0;
 
-    virtual Status new_random_access_file(const RandomAccessFileOptions& opts, const std::string& fname,
-                                          std::unique_ptr<RandomAccessFile>* result) = 0;
+    virtual StatusOr<std::unique_ptr<RandomAccessFile>> new_random_access_file(const RandomAccessFileOptions& opts,
+                                                                               const std::string& fname) = 0;
 
     // Create an object that writes to a new file with the specified
     // name.  Deletes any existing file with the same name and creates a
-    // new file.  On success, stores a pointer to the new file in
-    // *result and returns OK.  On failure stores NULL in *result and
-    // returns non-OK.
+    // new file.
     //
     // The returned file will only be accessed by one thread at a time.
-    virtual Status new_writable_file(const std::string& fname, std::unique_ptr<WritableFile>* result) = 0;
+    virtual StatusOr<std::unique_ptr<WritableFile>> new_writable_file(const std::string& fname) = 0;
 
     // Like the previous new_writable_file, but allows options to be
     // specified.
-    virtual Status new_writable_file(const WritableFileOptions& opts, const std::string& fname,
-                                     std::unique_ptr<WritableFile>* result) = 0;
+    virtual StatusOr<std::unique_ptr<WritableFile>> new_writable_file(const WritableFileOptions& opts,
+                                                                      const std::string& fname) = 0;
 
     // Creates a new readable and writable file. If a file with the same name
     // already exists on disk, it is deleted.
     //
     // Some of the methods of the new file may be accessed concurrently,
     // while others are only safe for access by one thread at a time.
-    virtual Status new_random_rw_file(const std::string& fname, std::unique_ptr<RandomRWFile>* result) = 0;
+    virtual StatusOr<std::unique_ptr<RandomRWFile>> new_random_rw_file(const std::string& fname) = 0;
 
     // Like the previous new_random_rw_file, but allows options to be specified.
-    virtual Status new_random_rw_file(const RandomRWFileOptions& opts, const std::string& fname,
-                                      std::unique_ptr<RandomRWFile>* result) = 0;
+    virtual StatusOr<std::unique_ptr<RandomRWFile>> new_random_rw_file(const RandomRWFileOptions& opts,
+                                                                       const std::string& fname) = 0;
 
     // Returns OK if the path exists.
     //         NotFound if the named file does not exist,

--- a/be/src/env/env_broker.h
+++ b/be/src/env/env_broker.h
@@ -20,22 +20,22 @@ public:
               int timeout_ms = DEFAULT_TIMEOUT_MS)
             : _broker_addr(broker_addr), _properties(std::move(properties)), _timeout_ms(timeout_ms) {}
 
-    Status new_sequential_file(const std::string& path, std::unique_ptr<SequentialFile>* file) override;
+    StatusOr<std::unique_ptr<SequentialFile>> new_sequential_file(const std::string& path) override;
 
-    Status new_random_access_file(const std::string& path, std::unique_ptr<RandomAccessFile>* file) override;
+    StatusOr<std::unique_ptr<RandomAccessFile>> new_random_access_file(const std::string& path) override;
 
-    Status new_random_access_file(const RandomAccessFileOptions& opts, const std::string& path,
-                                  std::unique_ptr<RandomAccessFile>* file) override;
+    StatusOr<std::unique_ptr<RandomAccessFile>> new_random_access_file(const RandomAccessFileOptions& opts,
+                                                                       const std::string& path) override;
 
-    Status new_writable_file(const std::string& path, std::unique_ptr<WritableFile>* file) override;
+    StatusOr<std::unique_ptr<WritableFile>> new_writable_file(const std::string& path) override;
 
-    Status new_writable_file(const WritableFileOptions& opts, const std::string& path,
-                             std::unique_ptr<WritableFile>* file) override;
+    StatusOr<std::unique_ptr<WritableFile>> new_writable_file(const WritableFileOptions& opts,
+                                                              const std::string& path) override;
 
-    Status new_random_rw_file(const std::string& path, std::unique_ptr<RandomRWFile>* file) override;
+    StatusOr<std::unique_ptr<RandomRWFile>> new_random_rw_file(const std::string& path) override;
 
-    Status new_random_rw_file(const RandomRWFileOptions& opts, const std::string& path,
-                              std::unique_ptr<RandomRWFile>* file) override;
+    StatusOr<std::unique_ptr<RandomRWFile>> new_random_rw_file(const RandomRWFileOptions& opts,
+                                                               const std::string& path) override;
 
     Status path_exists(const std::string& path) override;
 

--- a/be/src/env/env_memory.h
+++ b/be/src/env/env_memory.h
@@ -109,22 +109,22 @@ public:
     EnvMemory(const EnvMemory&) = delete;
     void operator=(const EnvMemory&) = delete;
 
-    Status new_sequential_file(const std::string& url, std::unique_ptr<SequentialFile>* file) override;
+    StatusOr<std::unique_ptr<SequentialFile>> new_sequential_file(const std::string& url) override;
 
-    Status new_random_access_file(const std::string& url, std::unique_ptr<RandomAccessFile>* file) override;
+    StatusOr<std::unique_ptr<RandomAccessFile>> new_random_access_file(const std::string& url) override;
 
-    Status new_random_access_file(const RandomAccessFileOptions& opts, const std::string& url,
-                                  std::unique_ptr<RandomAccessFile>* file) override;
+    StatusOr<std::unique_ptr<RandomAccessFile>> new_random_access_file(const RandomAccessFileOptions& opts,
+                                                                       const std::string& url) override;
 
-    Status new_writable_file(const std::string& url, std::unique_ptr<WritableFile>* file) override;
+    StatusOr<std::unique_ptr<WritableFile>> new_writable_file(const std::string& url) override;
 
-    Status new_writable_file(const WritableFileOptions& opts, const std::string& url,
-                             std::unique_ptr<WritableFile>* file) override;
+    StatusOr<std::unique_ptr<WritableFile>> new_writable_file(const WritableFileOptions& opts,
+                                                              const std::string& url) override;
 
-    Status new_random_rw_file(const std::string& url, std::unique_ptr<RandomRWFile>* file) override;
+    StatusOr<std::unique_ptr<RandomRWFile>> new_random_rw_file(const std::string& url) override;
 
-    Status new_random_rw_file(const RandomRWFileOptions& opts, const std::string& url,
-                              std::unique_ptr<RandomRWFile>* file) override;
+    StatusOr<std::unique_ptr<RandomRWFile>> new_random_rw_file(const RandomRWFileOptions& opts,
+                                                               const std::string& url) override;
 
     Status path_exists(const std::string& url) override;
 

--- a/be/src/env/env_util.cpp
+++ b/be/src/env/env_util.cpp
@@ -31,22 +31,19 @@ Status open_file_for_write(Env* env, const std::string& path, std::shared_ptr<Wr
 
 Status open_file_for_write(const WritableFileOptions& opts, Env* env, const std::string& path,
                            std::shared_ptr<WritableFile>* file) {
-    std::unique_ptr<WritableFile> w;
-    RETURN_IF_ERROR(env->new_writable_file(opts, path, &w));
+    ASSIGN_OR_RETURN(auto w, env->new_writable_file(opts, path));
     file->reset(w.release());
     return Status::OK();
 }
 
 Status open_file_for_sequential(Env* env, const std::string& path, std::shared_ptr<SequentialFile>* file) {
-    std::unique_ptr<SequentialFile> r;
-    RETURN_IF_ERROR(env->new_sequential_file(path, &r));
+    ASSIGN_OR_RETURN(auto r, env->new_sequential_file(path));
     file->reset(r.release());
     return Status::OK();
 }
 
 Status open_file_for_random(Env* env, const std::string& path, std::shared_ptr<RandomAccessFile>* file) {
-    std::unique_ptr<RandomAccessFile> r;
-    RETURN_IF_ERROR(env->new_random_access_file(path, &r));
+    ASSIGN_OR_RETURN(auto r, env->new_random_access_file(path));
     file->reset(r.release());
     return Status::OK();
 }

--- a/be/src/env/output_stream_wrapper.h
+++ b/be/src/env/output_stream_wrapper.h
@@ -14,8 +14,7 @@ namespace starrocks {
 // Example usage:
 // #1. Write to file as std::ostream
 // ```
-//   std::unique_ptr<WritableFile> f;
-//   Env::Default()->new_writable_file("a.txt", &f);
+//   ASSIGN_OR_RETURN(std::unique_ptr<WritableFile> f, Env::Default()->new_writable_file("a.txt"));
 //   OutputStreamWrapper wrapper(f.release(), kTakesOwnership);
 //   wrapper << "anything can be sent to std::ostream";
 // ```
@@ -24,8 +23,7 @@ namespace starrocks {
 // ```
 //   TabletMetaPB tablet_meta_pb;
 //
-//   std::unique_ptr<WritableFile> f;
-//   Env::Default()->new_writable_file("a.txt", &f);
+//   ASSIGN_OR_RETURN(std::unique_ptr<WritableFile> f, Env::Default()->new_writable_file("a.txt"));
 //   OutputStreamWrapper wrapper(f.release(), kTakesOwnership);
 //   tablet_meta.SerializeToOStream(&wrapper);
 // ```

--- a/be/src/exec/vectorized/file_scanner.cpp
+++ b/be/src/exec/vectorized/file_scanner.cpp
@@ -257,8 +257,7 @@ Status FileScanner::create_sequential_file(const TBrokerRangeDesc& range_desc, c
     }
     case TFileType::FILE_BROKER: {
         EnvBroker env_broker(address, params.properties);
-        std::unique_ptr<SequentialFile> broker_file;
-        RETURN_IF_ERROR(env_broker.new_sequential_file(range_desc.path, &broker_file));
+        ASSIGN_OR_RETURN(auto broker_file, env_broker.new_sequential_file(range_desc.path));
         src_file = std::shared_ptr<SequentialFile>(std::move(broker_file));
         break;
     }
@@ -286,8 +285,7 @@ Status FileScanner::create_random_access_file(const TBrokerRangeDesc& range_desc
     }
     case TFileType::FILE_BROKER: {
         EnvBroker env_broker(address, params.properties);
-        std::unique_ptr<RandomAccessFile> broker_file;
-        RETURN_IF_ERROR(env_broker.new_random_access_file(range_desc.path, &broker_file));
+        ASSIGN_OR_RETURN(auto broker_file, env_broker.new_random_access_file(range_desc.path));
         if (range_desc.start_offset != 0) {
             return Status::NotSupported("non-zero start offset");
         }

--- a/be/src/exec/vectorized/hdfs_scan_node.cpp
+++ b/be/src/exec/vectorized/hdfs_scan_node.cpp
@@ -645,8 +645,7 @@ Status HdfsScanNode::_find_and_insert_hdfs_file(const THdfsScanRange& scan_range
     if (namenode.compare("default") == 0) {
         // local file, current only for test
         auto* env = Env::Default();
-        std::unique_ptr<RandomAccessFile> file;
-        env->new_random_access_file(native_file_path, &file);
+        ASSIGN_OR_RETURN(auto file, env->new_random_access_file(native_file_path));
         auto* hdfs_file_desc = _pool->add(new HdfsFileDesc());
         hdfs_file_desc->fs = std::move(file);
         hdfs_file_desc->fs_handle_type = HdfsFsHandle::Type::LOCAL;

--- a/be/src/io/random_access_file.cpp
+++ b/be/src/io/random_access_file.cpp
@@ -7,7 +7,7 @@ namespace starrocks::io {
 Status RandomAccessFile::read_at_fully(int64_t offset, void* data, int64_t count) {
     int64_t nread = 0;
     while (nread < count) {
-        ASSIGN_OR_RETURN(auto n, read_at(offset + nread, data + nread, count - nread));
+        ASSIGN_OR_RETURN(auto n, read_at(offset + nread, static_cast<uint8_t*>(data) + nread, count - nread));
         nread += n;
         if (n == 0) {
             return Status::IOError("cannot read fully");

--- a/be/src/plugin/plugin_zip.cpp
+++ b/be/src/plugin/plugin_zip.cpp
@@ -85,9 +85,7 @@ Status PluginZip::download(const std::string& zip_path) {
     HttpClient client;
     Md5Digest digest;
 
-    std::unique_ptr<WritableFile> file;
-
-    RETURN_IF_ERROR(Env::Default()->new_writable_file(zip_path, &file));
+    ASSIGN_OR_RETURN(auto file, Env::Default()->new_writable_file(zip_path));
     RETURN_IF_ERROR(client.init(_source));
 
     auto download_cb = [&status, &digest, &file](const void* data, size_t length) {

--- a/be/src/runtime/export_sink.cpp
+++ b/be/src/runtime/export_sink.cpp
@@ -107,13 +107,14 @@ Status ExportSink::open_file_writer(int timeout_ms) {
 
     const auto& file_type = _t_export_sink.file_type;
     switch (file_type) {
-    case TFileType::FILE_LOCAL:
-        RETURN_IF_ERROR(Env::Default()->new_writable_file(options, file_path, &output_file));
+    case TFileType::FILE_LOCAL: {
+        ASSIGN_OR_RETURN(output_file, Env::Default()->new_writable_file(options, file_path));
         break;
+    }
     case TFileType::FILE_BROKER: {
         const TNetworkAddress& broker_addr = _t_export_sink.broker_addresses[0];
         EnvBroker env_broker(broker_addr, _t_export_sink.properties, timeout_ms);
-        RETURN_IF_ERROR(env_broker.new_writable_file(options, file_path, &output_file));
+        ASSIGN_OR_RETURN(output_file, env_broker.new_writable_file(options, file_path));
         break;
     }
     case TFileType::FILE_STREAM:

--- a/be/src/runtime/file_result_writer.cpp
+++ b/be/src/runtime/file_result_writer.cpp
@@ -73,7 +73,7 @@ void FileResultWriter::_init_profile() {
 Status FileResultWriter::_create_file_writer() {
     std::string file_name = _get_next_file_name();
     std::unique_ptr<WritableFile> writable_file;
-    RETURN_IF_ERROR(_env->new_writable_file(file_name, &writable_file));
+    ASSIGN_OR_RETURN(writable_file, _env->new_writable_file(file_name));
 
     switch (_file_opts->file_format) {
     case TFileFormatType::FORMAT_CSV_PLAIN:

--- a/be/src/runtime/snapshot_loader.cpp
+++ b/be/src/runtime/snapshot_loader.cpp
@@ -162,10 +162,9 @@ Status SnapshotLoader::upload(const std::map<std::string, std::string>& src_to_d
 
             EnvBroker env_broker(broker_addr, broker_prop);
             std::unique_ptr<WritableFile> broker_file;
-            RETURN_IF_ERROR(env_broker.new_writable_file(tmp_broker_file_name, &broker_file));
+            ASSIGN_OR_RETURN(broker_file, env_broker.new_writable_file(tmp_broker_file_name));
 
-            std::unique_ptr<SequentialFile> input_file;
-            RETURN_IF_ERROR(Env::Default()->new_sequential_file(local_file_path, &input_file));
+            ASSIGN_OR_RETURN(auto input_file, Env::Default()->new_sequential_file(local_file_path));
 
             auto res = FileUtils::copy(input_file.get(), broker_file.get(), 1024 * 1024);
             if (!res.ok()) {
@@ -313,8 +312,7 @@ Status SnapshotLoader::download(const std::map<std::string, std::string>& src_to
             }
 
             EnvBroker env_broker(broker_addr, broker_prop);
-            std::unique_ptr<SequentialFile> broker_file;
-            RETURN_IF_ERROR(env_broker.new_sequential_file(full_remote_file, &broker_file));
+            ASSIGN_OR_RETURN(auto broker_file, env_broker.new_sequential_file(full_remote_file));
 
             // remove file which will be downloaded now.
             // this file will be added to local_files if it be downloaded successfully.
@@ -322,7 +320,7 @@ Status SnapshotLoader::download(const std::map<std::string, std::string>& src_to
 
             // 3. open local file for write
             std::unique_ptr<WritableFile> local_file;
-            RETURN_IF_ERROR(Env::Default()->new_writable_file(full_local_file, &local_file));
+            ASSIGN_OR_RETURN(local_file, Env::Default()->new_writable_file(full_local_file));
 
             auto res = FileUtils::copy(broker_file.get(), local_file.get(), 1024 * 1024);
             if (!res.ok()) {

--- a/be/src/storage/fs/file_block_manager.cpp
+++ b/be/src/storage/fs/file_block_manager.cpp
@@ -401,8 +401,7 @@ Status FileBlockManager::open_block(const std::string& path, std::unique_ptr<Rea
     std::shared_ptr<OpenedFileHandle<RandomAccessFile>> file_handle(new OpenedFileHandle<RandomAccessFile>());
     bool found = _file_cache->lookup(path, file_handle.get());
     if (!found) {
-        std::unique_ptr<RandomAccessFile> file;
-        RETURN_IF_ERROR(_env->new_random_access_file(path, &file));
+        ASSIGN_OR_RETURN(auto file, _env->new_random_access_file(path));
         _file_cache->insert(path, file.release(), file_handle.get());
     }
 

--- a/be/src/storage/protobuf_file.cpp
+++ b/be/src/storage/protobuf_file.cpp
@@ -39,7 +39,7 @@ Status ProtobufFile::save(const ::google::protobuf::Message& message, bool sync)
     header.magic_number = OLAP_FIX_HEADER_MAGIC_NUMBER;
 
     std::unique_ptr<WritableFile> output_file;
-    RETURN_IF_ERROR(_env->new_writable_file(_path, &output_file));
+    ASSIGN_OR_RETURN(output_file, _env->new_writable_file(_path));
     RETURN_IF_ERROR(output_file->append(Slice((const char*)(&header), sizeof(header))));
     RETURN_IF_ERROR(output_file->append(Slice((const char*)(&unused_flag), sizeof(unused_flag))));
     RETURN_IF_ERROR(output_file->append(serialized_message));
@@ -47,8 +47,7 @@ Status ProtobufFile::save(const ::google::protobuf::Message& message, bool sync)
 }
 
 Status ProtobufFile::load(::google::protobuf::Message* message) {
-    std::unique_ptr<SequentialFile> input_file;
-    RETURN_IF_ERROR(_env->new_sequential_file(_path, &input_file));
+    ASSIGN_OR_RETURN(auto input_file, _env->new_sequential_file(_path));
 
     FixedFileHeader header;
     Slice buff((char*)&header, sizeof(header));

--- a/be/src/storage/snapshot_manager.cpp
+++ b/be/src/storage/snapshot_manager.cpp
@@ -504,7 +504,7 @@ Status SnapshotManager::make_snapshot_on_tablet_meta(SnapshotTypePB snapshot_typ
     }
 
     std::unique_ptr<WritableFile> f;
-    RETURN_IF_ERROR(Env::Default()->new_writable_file(snapshot_dir + "/meta", &f));
+    ASSIGN_OR_RETURN(f, Env::Default()->new_writable_file(snapshot_dir + "/meta"));
     RETURN_IF_ERROR(snapshot_meta.serialize_to_file(f.get()));
     RETURN_IF_ERROR(f->sync());
     RETURN_IF_ERROR(f->close());
@@ -514,8 +514,7 @@ Status SnapshotManager::make_snapshot_on_tablet_meta(SnapshotTypePB snapshot_typ
 // See `SnapshotManager::make_snapshot_on_tablet_meta` for the file format.
 StatusOr<SnapshotMeta> SnapshotManager::parse_snapshot_meta(const std::string& filename) {
     SnapshotMeta snapshot_meta;
-    std::unique_ptr<RandomAccessFile> file;
-    RETURN_IF_ERROR(Env::Default()->new_random_access_file(filename, &file));
+    ASSIGN_OR_RETURN(auto file, Env::Default()->new_random_access_file(filename));
     RETURN_IF_ERROR(snapshot_meta.parse_from_file(file.get()));
     return std::move(snapshot_meta);
 }

--- a/be/src/storage/snapshot_meta.cpp
+++ b/be/src/storage/snapshot_meta.cpp
@@ -11,7 +11,7 @@ namespace starrocks {
 
 Status SnapshotMeta::serialize_to_file(const std::string& file_path) {
     std::unique_ptr<WritableFile> f;
-    RETURN_IF_ERROR(Env::Default()->new_writable_file(file_path, &f));
+    ASSIGN_OR_RETURN(f, Env::Default()->new_writable_file(file_path));
     RETURN_IF_ERROR(serialize_to_file(f.get()));
     RETURN_IF_ERROR(f->sync());
     RETURN_IF_ERROR(f->close());

--- a/be/src/storage/utils.cpp
+++ b/be/src/storage/utils.cpp
@@ -178,12 +178,7 @@ Status read_write_test_file(const string& test_file_path) {
                     fmt::format("Error to access file: {}, error:{} ", test_file_path, std::strerror(Errno::no())));
         }
     }
-    std::unique_ptr<RandomRWFile> file;
-    Status st = Env::Default()->new_random_rw_file(test_file_path, &file);
-    if (!st.ok()) {
-        return Status::IOError(
-                fmt::format("Error to create test file: {}, error:{} ", test_file_path, std::strerror(Errno::no())));
-    }
+    ASSIGN_OR_RETURN(auto file, Env::Default()->new_random_rw_file(test_file_path));
     const size_t TEST_FILE_BUF_SIZE = 4096;
     const size_t DIRECT_IO_ALIGNMENT = 512;
     char* write_test_buff = nullptr;
@@ -204,7 +199,7 @@ Status read_write_test_file(const string& test_file_path) {
         int32_t tmp_value = rand_r(&rand_seed);
         write_test_buff[i] = static_cast<char>(tmp_value);
     }
-    st = file->write_at(0, Slice(write_buff.get(), TEST_FILE_BUF_SIZE));
+    auto st = file->write_at(0, Slice(write_buff.get(), TEST_FILE_BUF_SIZE));
     if (!st.ok()) {
         LOG(WARNING) << "Error to write " << test_file_path << ", error: " << st;
         return Status::IOError(

--- a/be/src/tools/meta_tool.cpp
+++ b/be/src/tools/meta_tool.cpp
@@ -408,14 +408,14 @@ Status get_segment_footer(RandomAccessFile* input_file, SegmentFooterPB* footer)
 }
 
 void show_segment_footer(const std::string& file_name) {
-    std::unique_ptr<RandomAccessFile> input_file;
-    Status status = starrocks::Env::Default()->new_random_access_file(file_name, &input_file);
-    if (!status.ok()) {
-        std::cout << "open file failed: " << status.to_string() << std::endl;
+    auto res = starrocks::Env::Default()->new_random_access_file(file_name);
+    if (!res.ok()) {
+        std::cout << "open file failed: " << res.status() << std::endl;
         return;
     }
+    auto input_file = std::move(res).value();
     SegmentFooterPB footer;
-    status = get_segment_footer(input_file.get(), &footer);
+    auto status = get_segment_footer(input_file.get(), &footer);
     if (!status.ok()) {
         std::cout << "get footer failed: " << status.to_string() << std::endl;
         return;

--- a/be/src/util/file_utils.cpp
+++ b/be/src/util/file_utils.cpp
@@ -202,11 +202,9 @@ Status FileUtils::split_pathes(const char* path, std::vector<std::string>* path_
 }
 
 Status FileUtils::copy_file(const std::string& src_path, const std::string& dest_path) {
-    std::unique_ptr<SequentialFile> src_file;
-    RETURN_IF_ERROR(Env::Default()->new_sequential_file(src_path, &src_file));
+    ASSIGN_OR_RETURN(auto src_file, Env::Default()->new_sequential_file(src_path));
 
-    std::unique_ptr<WritableFile> dest_file;
-    RETURN_IF_ERROR(Env::Default()->new_writable_file(dest_path, &dest_file));
+    ASSIGN_OR_RETURN(auto dest_file, Env::Default()->new_writable_file(dest_path));
 
     return copy(src_file.get(), dest_file.get()).status();
 }

--- a/be/src/util/zip_util.cpp
+++ b/be/src/util/zip_util.cpp
@@ -120,8 +120,7 @@ Status ZipFile::extract_file(const std::string& target_path) {
     ZPOS64_T file_size = std::min(file_info_inzip.uncompressed_size, DEFAULT_UNZIP_BUFFER);
     std::unique_ptr<char[]> file_data(new char[file_size]);
 
-    std::unique_ptr<WritableFile> wfile;
-    RETURN_IF_ERROR(Env::Default()->new_writable_file(path, &wfile));
+    ASSIGN_OR_RETURN(auto wfile, Env::Default()->new_writable_file(path));
 
     int size;
     do {

--- a/be/test/env/env_posix_test.cpp
+++ b/be/test/env/env_posix_test.cpp
@@ -42,9 +42,8 @@ TEST_F(EnvPosixTest, random_access) {
     WritableFileOptions ops;
     std::unique_ptr<WritableFile> wfile;
     auto env = Env::Default();
-    auto st = env->new_writable_file(fname, &wfile);
-    ASSERT_TRUE(st.ok());
-    st = wfile->pre_allocate(1024);
+    wfile = *env->new_writable_file(fname);
+    auto st = wfile->pre_allocate(1024);
     ASSERT_TRUE(st.ok());
     // wirte data
     Slice field1("123456789");
@@ -76,9 +75,7 @@ TEST_F(EnvPosixTest, random_access) {
     ASSERT_EQ(115, size);
     {
         char mem[1024];
-        std::unique_ptr<RandomAccessFile> rfile;
-        st = env->new_random_access_file(fname, &rfile);
-        ASSERT_TRUE(st.ok());
+        auto rfile = *env->new_random_access_file(fname);
 
         Slice slice1(mem, 9);
         Slice slice2(mem + 9, 100);
@@ -103,9 +100,7 @@ TEST_F(EnvPosixTest, random_access) {
     // test try read
     {
         char mem[1024];
-        std::unique_ptr<RandomAccessFile> rfile;
-        st = env->new_random_access_file(fname, &rfile);
-        ASSERT_TRUE(st.ok());
+        auto rfile = *env->new_random_access_file(fname);
 
         // normal read
         {
@@ -137,11 +132,10 @@ TEST_F(EnvPosixTest, random_rw) {
     WritableFileOptions ops;
     std::unique_ptr<RandomRWFile> wfile;
     auto env = Env::Default();
-    auto st = env->new_random_rw_file(fname, &wfile);
-    ASSERT_TRUE(st.ok());
+    wfile = *env->new_random_rw_file(fname);
     // wirte data
     Slice field1("123456789");
-    st = wfile->write_at(0, field1);
+    auto st = wfile->write_at(0, field1);
     ASSERT_TRUE(st.ok());
     std::string buf;
     for (int i = 0; i < 100; ++i) {
@@ -175,8 +169,7 @@ TEST_F(EnvPosixTest, random_rw) {
         std::unique_ptr<RandomRWFile> rfile;
         RandomRWFileOptions opts;
         opts.mode = Env::MUST_EXIST;
-        st = env->new_random_rw_file(opts, fname, &rfile);
-        ASSERT_TRUE(st.ok());
+        rfile = *env->new_random_rw_file(opts, fname);
 
         Slice slice1(mem, 3);
         Slice slice2(mem + 3, 3);
@@ -202,9 +195,7 @@ TEST_F(EnvPosixTest, random_rw) {
     // SequentialFile
     {
         char mem[1024];
-        std::unique_ptr<SequentialFile> rfile;
-        st = env->new_sequential_file(fname, &rfile);
-        ASSERT_TRUE(st.ok());
+        auto rfile = *env->new_sequential_file(fname);
 
         Slice slice1(mem, 3);
         st = rfile->read(&slice1);

--- a/be/test/env/output_stream_wrapper_test.cpp
+++ b/be/test/env/output_stream_wrapper_test.cpp
@@ -21,11 +21,12 @@ protected:
         }
 
         std::filesystem::path file = path / "test.txt";
-        auto st = Env::Default()->new_writable_file(file.string(), &_file);
-        if (!st.ok()) {
-            std::cerr << "Fail to create " << file << ": " << st.to_string() << std::endl;
-            LOG(FATAL) << "Fail to create " << file << ": " << st.to_string();
+        auto res = Env::Default()->new_writable_file(file.string());
+        if (!res.ok()) {
+            std::cerr << "Fail to create " << file << ": " << res.status() << std::endl;
+            LOG(FATAL) << "Fail to create " << file << ": " << res.status();
         }
+        _file = std::move(res).value();
         _stream = std::make_unique<OutputStreamWrapper>(_file.get());
     }
 
@@ -54,13 +55,11 @@ TEST_F(OutputStreamWrapperTest, test_write) {
     ASSERT_TRUE(stream.good());
     ASSERT_EQ(21, stream.size());
 
-    std::unique_ptr<RandomAccessFile> rf;
-    auto st = Env::Default()->new_random_access_file(_file->filename(), &rf);
-    ASSERT_TRUE(st.ok()) << st;
+    auto rf = *Env::Default()->new_random_access_file(_file->filename());
     std::string buff(21, 0);
     Slice slice(buff);
     uint64_t size = 0;
-    st = rf->size(&size);
+    auto st = rf->size(&size);
     ASSERT_TRUE(st.ok()) << st;
     ASSERT_EQ(21, size);
 

--- a/be/test/exec/parquet/file_reader_test.cpp
+++ b/be/test/exec/parquet/file_reader_test.cpp
@@ -216,10 +216,7 @@ void FileReaderTest::_create_conjunct_ctxs_for_dict_filter(std::vector<ExprConte
 }
 
 std::unique_ptr<RandomAccessFile> FileReaderTest::_create_file(const std::string& file_path) {
-    auto* env = Env::Default();
-    std::unique_ptr<RandomAccessFile> file;
-    env->new_random_access_file(file_path, &file);
-    return file;
+    return *Env::Default()->new_random_access_file(file_path);
 }
 
 HdfsFileReaderParam* FileReaderTest::_create_param() {

--- a/be/test/exec/vectorized/hdfs_scanner_test.cpp
+++ b/be/test/exec/vectorized/hdfs_scanner_test.cpp
@@ -62,8 +62,7 @@ void HdfsScannerTest::_create_runtime_state() {
 
 std::shared_ptr<RandomAccessFile> HdfsScannerTest::_create_file_handler(const std::string& name) {
     auto* env = Env::Default();
-    std::unique_ptr<RandomAccessFile> file;
-    env->new_random_access_file(name, &file);
+    auto file = *env->new_random_access_file(name);
     std::shared_ptr<RandomAccessFile> file2 = std::move(file);
     return file2;
 }

--- a/be/test/exprs/vectorized/json_functions_test.cpp
+++ b/be/test/exprs/vectorized/json_functions_test.cpp
@@ -334,7 +334,7 @@ TEST_P(JsonQueryTestFixture, json_query) {
 
 INSTANTIATE_TEST_SUITE_P(JsonQueryTest, JsonQueryTestFixture,
                          ::testing::Values(
-                                // empty
+                                 // empty
                                  std::make_tuple(R"( {"k1":1} )", "$", R"( {"k1": 1} )"),
                                  std::make_tuple(R"( {"k1":1} )", "", R"( {"k1": 1} )"),
 
@@ -442,8 +442,7 @@ INSTANTIATE_TEST_SUITE_P(JsonExistTest, JsonExistTestFixture,
 
                                            // special case
                                            std::make_tuple(R"({ "k1": {}})", "$", true),
-                                           std::make_tuple(R"({ "k1": {}})", "", true)
-                                           ));
+                                           std::make_tuple(R"({ "k1": {}})", "", true)));
 
 class JsonParseTestFixture : public ::testing::TestWithParam<std::tuple<std::string, bool>> {};
 

--- a/be/test/plugin/plugin_zip_test.cpp
+++ b/be/test/plugin/plugin_zip_test.cpp
@@ -101,8 +101,7 @@ TEST_F(PluginZipTest, local_normal) {
     ASSERT_TRUE(FileUtils::check_exist(_path + "/plugin_test/target/test"));
     ASSERT_TRUE(FileUtils::check_exist(_path + "/plugin_test/target/test/test.txt"));
 
-    std::unique_ptr<RandomAccessFile> file;
-    Env::Default()->new_random_access_file(_path + "/plugin_test/target/test/test.txt", &file);
+    auto file = *Env::Default()->new_random_access_file(_path + "/plugin_test/target/test/test.txt");
 
     char f[11];
     Slice s(f, 11);
@@ -124,8 +123,7 @@ TEST_F(PluginZipTest, http_normal) {
     ASSERT_TRUE(FileUtils::check_exist(_path + "/plugin_test/target/test"));
     ASSERT_TRUE(FileUtils::check_exist(_path + "/plugin_test/target/test/test.txt"));
 
-    std::unique_ptr<RandomAccessFile> file;
-    Env::Default()->new_random_access_file(_path + "/plugin_test/target/test/test.txt", &file);
+    auto file = *Env::Default()->new_random_access_file(_path + "/plugin_test/target/test/test.txt");
 
     char f[11];
     Slice s(f, 11);

--- a/be/test/storage/file_utils_test.cpp
+++ b/be/test/storage/file_utils_test.cpp
@@ -65,8 +65,7 @@ void save_string_file(const std::filesystem::path& p, const std::string& str) {
 
 TEST_F(FileUtilsTest, TestCopyFile) {
     std::string src_file_name = _s_test_data_path + "/abcd12345.txt";
-    std::unique_ptr<WritableFile> src_file;
-    ASSERT_TRUE(Env::Default()->new_writable_file(src_file_name, &src_file).ok());
+    std::unique_ptr<WritableFile> src_file = *Env::Default()->new_writable_file(src_file_name);
 
     char large_bytes2[(1 << 12)];
     memset(large_bytes2, 0, sizeof(char) * ((1 << 12)));

--- a/be/test/storage/protobuf_file_test.cpp
+++ b/be/test/storage/protobuf_file_test.cpp
@@ -56,8 +56,7 @@ TEST(ProtobufFileTest, test_corruption) {
 
     std::unique_ptr<WritableFile> f;
     WritableFileOptions opts{.sync_on_close = false, .mode = Env::CREATE_OR_OPEN};
-    st = Env::Default()->new_writable_file(opts, "ProtobufFileTest_test_corruption.bin", &f);
-    ASSERT_TRUE(st.ok()) << st;
+    f = *Env::Default()->new_writable_file(opts, "ProtobufFileTest_test_corruption.bin");
 
     f->append("xx");
     TabletMetaPB tablet_meta_2;

--- a/be/test/storage/snapshot_meta_test.cpp
+++ b/be/test/storage/snapshot_meta_test.cpp
@@ -92,14 +92,12 @@ protected:
 
 // NOLINTNEXTLINE
 TEST_F(SnapshotMetaTest, test_serialize_and_parse) {
-    std::unique_ptr<WritableFile> wf;
-    ASSERT_TRUE(Env::Default()->new_writable_file("test_serialize_and_parse.meta", &wf).ok());
+    auto wf = *Env::Default()->new_writable_file("test_serialize_and_parse.meta");
     ASSERT_TRUE(_snapshot_meta.serialize_to_file(wf.get()).ok());
     wf->close();
     DeferOp defer([&]() { std::filesystem::remove("test_serialize_and_parse.meta"); });
 
-    std::unique_ptr<RandomAccessFile> rf;
-    ASSERT_TRUE(Env::Default()->new_random_access_file("test_serialize_and_parse.meta", &rf).ok());
+    auto rf = *Env::Default()->new_random_access_file("test_serialize_and_parse.meta");
     SnapshotMeta meta;
     auto st = meta.parse_from_file(rf.get());
     ASSERT_TRUE(st.ok()) << st;

--- a/be/test/storage/vectorized/cumulative_compaction_test.cpp
+++ b/be/test/storage/vectorized/cumulative_compaction_test.cpp
@@ -261,17 +261,17 @@ TEST_F(CumulativeCompactionTest, test_read_chunk_size) {
     int64_t total_mem_footprint = 0;
     size_t source_num = 10;
     ASSERT_EQ(config_chunk_size, CompactionUtils::get_read_chunk_size(mem_limit, config_chunk_size, total_num_rows,
-                                                                 total_mem_footprint, source_num));
+                                                                      total_mem_footprint, source_num));
 
     // normal total memory footprint
     total_mem_footprint = 1073741824;
-    ASSERT_EQ(2001, CompactionUtils::get_read_chunk_size(mem_limit, config_chunk_size, total_num_rows, total_mem_footprint,
-                                                    source_num));
+    ASSERT_EQ(2001, CompactionUtils::get_read_chunk_size(mem_limit, config_chunk_size, total_num_rows,
+                                                         total_mem_footprint, source_num));
 
     // mem limit is 0
     mem_limit = 0;
     ASSERT_EQ(config_chunk_size, CompactionUtils::get_read_chunk_size(mem_limit, config_chunk_size, total_num_rows,
-                                                                 total_mem_footprint, source_num));
+                                                                      total_mem_footprint, source_num));
 }
 
 } // namespace starrocks::vectorized

--- a/be/test/util/file_cache_test.cpp
+++ b/be/test/util/file_cache_test.cpp
@@ -34,10 +34,8 @@ public:
     void SetUp() override {
         _file_cache.reset(new FileCache<RandomAccessFile>("test cache", 10000));
         _file_exist = "file_exist";
-        std::unique_ptr<WritableFile> file;
-        auto st = Env::Default()->new_writable_file(_file_exist, &file);
-        ASSERT_TRUE(st.ok());
-        st = file->close();
+        auto file = *Env::Default()->new_writable_file(_file_exist);
+        auto st = file->close();
         ASSERT_TRUE(st.ok());
     }
 
@@ -56,9 +54,7 @@ TEST_F(FileCacheTest, normal) {
     OpenedFileHandle<RandomAccessFile> file_handle;
     auto found = _file_cache->lookup(_file_exist, &file_handle);
     ASSERT_FALSE(found);
-    std::unique_ptr<RandomAccessFile> file;
-    auto st = Env::Default()->new_random_access_file(_file_exist, &file);
-    ASSERT_TRUE(st.ok());
+    auto file = *Env::Default()->new_random_access_file(_file_exist);
     RandomAccessFile* tmp_file = file.release();
     _file_cache->insert(_file_exist, tmp_file, &file_handle);
     ASSERT_EQ(tmp_file, file_handle.file());

--- a/be/test/util/zip_util_test.cpp
+++ b/be/test/util/zip_util_test.cpp
@@ -54,8 +54,7 @@ TEST(ZipUtilTest, basic) {
     ASSERT_TRUE(FileUtils::check_exist(path + "/test_data/target/zip_normal_data"));
     ASSERT_FALSE(FileUtils::is_dir(path + "/test_data/target/zip_normal_data"));
 
-    std::unique_ptr<RandomAccessFile> file;
-    Env::Default()->new_random_access_file(path + "/test_data/target/zip_normal_data", &file);
+    auto file = *Env::Default()->new_random_access_file(path + "/test_data/target/zip_normal_data");
 
     char f[11];
     Slice slice(f, 11);
@@ -86,8 +85,7 @@ TEST(ZipUtilTest, dir) {
     ASSERT_TRUE(FileUtils::check_exist(path + "/test_data/target/zip_test/two"));
     ASSERT_TRUE(FileUtils::is_dir(path + "/test_data/target/zip_test/two"));
 
-    std::unique_ptr<RandomAccessFile> file;
-    Env::Default()->new_random_access_file(path + "/test_data/target/zip_test/one/data", &file);
+    auto file = *Env::Default()->new_random_access_file(path + "/test_data/target/zip_test/one/data");
 
     char f[4];
     Slice slice(f, 4);


### PR DESCRIPTION
…rameters

Summary: return objects through StatusOr<T> instead of output parameters

## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [x] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
return objects through StatusOr instead of output parameters

