### PR TITLE
Union/Values support SqlSelectLimit

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/QueryRelation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/QueryRelation.java
@@ -24,8 +24,6 @@ public abstract class QueryRelation extends Relation {
     protected LimitElement limit;
     private final List<CTERelation> cteRelations = new ArrayList<>();
 
-
-
     public QueryRelation(List<String> columnOutputNames) {
         this.columnOutputNames = columnOutputNames;
     }
@@ -46,8 +44,16 @@ public abstract class QueryRelation extends Relation {
         return sortClause;
     }
 
-    public void setLimitElement(LimitElement limit) {
+    public LimitElement getLimit() {
+        return limit;
+    }
+
+    public void setLimit(LimitElement limit) {
         this.limit = limit;
+    }
+
+    public boolean hasLimit() {
+        return limit != null;
     }
 
     public void addCTERelation(CTERelation cteRelation) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SelectRelation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SelectRelation.java
@@ -125,18 +125,6 @@ public class SelectRelation extends QueryRelation {
         return isDistinct;
     }
 
-    public LimitElement getLimit() {
-        return limit;
-    }
-
-    public void setLimit(LimitElement limit) {
-        this.limit = limit;
-    }
-
-    public boolean hasLimit() {
-        return limit != null;
-    }
-
     public List<FunctionCallExpr> getAggregate() {
         return aggregate;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -182,7 +182,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
 
         QueryRelation term = (QueryRelation) visit(context.queryTerm());
         term.setOrderBy(orderByElements);
-        term.setLimitElement(limitElement);
+        term.setLimit(limitElement);
         return term;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -2386,8 +2386,6 @@ public class PlanFragmentTest extends PlanTestBase {
 
         String sql10 = "select 499 union select 670 except select 499";
         String plan = getFragmentPlan(sql10);
-        System.out.println("=========================");
-        System.out.println(plan);
         Assert.assertTrue(plan.contains("  10:UNION\n" +
                 "     constant exprs: \n" +
                 "         499"));


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3426

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

```
mysql> set sql_select_limit=2;
Query OK, 0 rows affected (0.00 sec)

mysql> select * from t0 union all select * from t0;
+-------+-------+------+
| v1    | v2    | v3   |
+-------+-------+------+
|     1 |     1 |    1 |
|     2 |     2 |    2 |
|     3 |     3 |    3 |
| 12000 | 10000 | 1000 |
|     1 |     1 |    1 |
|     2 |     2 |    2 |
|     3 |     3 |    3 |
| 12000 | 10000 | 1000 |
+-------+-------+------+
8 rows in set (0.02 sec)
```

sql_select_limit doesn't effect