### PR TITLE
fix: use ptype instead of real_type to normalize predicate

### DIFF
--- a/be/src/exec/vectorized/olap_scan_prepare.cpp
+++ b/be/src/exec/vectorized/olap_scan_prepare.cpp
@@ -504,7 +504,7 @@ struct ColumnRangeBuilder {
                 range.set_precision(slot->type().precision);
                 range.set_scale(slot->type().scale);
             }
-            cm->normalize_predicate<real_type, value_type>(*slot, &range);
+            cm->normalize_predicate<ptype, value_type>(*slot, &range);
             return nullptr;
         }
     }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
Use `BOOL` conjuncts will cause BE crash.


## Problem Summary(Required) ：
#3341 introduce this bug. Root cause is that `TYPE_BOOLEAN` and `TYPE_TINYINT`  needs to be treated as `INT` when normalize, but `SlotType` should not be changed.
