### PR TITLE
[BugFix] Schema change failed because rowsets are compacted

### DIFF
--- a/be/src/storage/vectorized/schema_change.cpp
+++ b/be/src/storage/vectorized/schema_change.cpp
@@ -1020,7 +1020,8 @@ Status SchemaChangeHandler::_do_process_alter_tablet_v2_normal(const TAlterTable
         for (auto& version : versions_to_be_changed) {
             rowsets_to_change.push_back(base_tablet->get_rowset_by_version(version));
             // prepare tablet_reader to prevent rowsets being compacted
-            std::unique_ptr<vectorized::TabletReader> tablet_reader = std::make_unique<TabletReader>(base_tablet, rowset->version(), base_schema);
+            std::unique_ptr<vectorized::TabletReader> tablet_reader =
+                    std::make_unique<TabletReader>(base_tablet, rowset->version(), base_schema);
             RETURN_IF_ERROR(tablet_reader->prepare());
             readers.emplace_back(std::move(tablet_reader));
         }

--- a/be/src/storage/vectorized/schema_change.cpp
+++ b/be/src/storage/vectorized/schema_change.cpp
@@ -1020,7 +1020,6 @@ Status SchemaChangeHandler::_do_process_alter_tablet_v2_normal(const TAlterTable
         for (auto& version : versions_to_be_changed) {
             rowsets_to_change.push_back(base_tablet->get_rowset_by_version(version));
             // prepare tablet_reader to prevent rowsets being compacted
-            vectorized::TabletReader* tablet_reader = new TabletReader(base_tablet, version, base_schema);
             std::unique_ptr<vectorized::TabletReader> tablet_reader = std::make_unique<TabletReader>(base_tablet, rowset->version(), base_schema);
             RETURN_IF_ERROR(tablet_reader->prepare());
             readers.emplace_back(std::move(tablet_reader));


### PR DESCRIPTION
## What type of PR is this：
- [X] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3397 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
schema change may fail because that rowsets to change may be compacted. Fix this bug by preparing tablet reader ahead inside tablet meta lock.