### PR TITLE
Fix concurrently create table bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -4126,7 +4126,7 @@ public class Catalog {
                 throw new DdlException("Failed to acquire catalog lock. Try again");
             }
             try {
-                if (getDb(db.getFullName()) == null) {
+                if (getDb(db.getId()) == null) {
                     throw new DdlException("database has been dropped when creating table");
                 }
                 createTblSuccess = db.createTableWithLock(olapTable, false);
@@ -4185,7 +4185,7 @@ public class Catalog {
             throw new DdlException("Failed to acquire catalog lock. Try again");
         }
         try {
-            if (getDb(db.getFullName()) == null) {
+            if (getDb(db.getId()) == null) {
                 throw new DdlException("database has been dropped when creating table");
             }
             if (!db.createTableWithLock(mysqlTable, false)) {
@@ -4232,7 +4232,7 @@ public class Catalog {
             throw new DdlException("Failed to acquire catalog lock. Try again");
         }
         try {
-            if (getDb(db.getFullName()) == null) {
+            if (getDb(db.getId()) == null) {
                 throw new DdlException("database has been dropped when creating table");
             }
             if (!db.createTableWithLock(esTable, false)) {
@@ -4268,7 +4268,7 @@ public class Catalog {
             throw new DdlException("Failed to acquire catalog lock. Try again");
         }
         try {
-            if (getDb(db.getFullName()) == null) {
+            if (getDb(db.getId()) == null) {
                 throw new DdlException("database has been dropped when creating table");
             }
             if (!db.createTableWithLock(hiveTable, false)) {
@@ -4300,7 +4300,7 @@ public class Catalog {
             throw new DdlException("Failed to acquire catalog lock. Try again");
         }
         try {
-            if (getDb(db.getFullName()) == null) {
+            if (getDb(db.getId()) == null) {
                 throw new DdlException("database has been dropped when creating table");
             }
             if (!db.createTableWithLock(icebergTable, false)) {
@@ -6123,7 +6123,7 @@ public class Catalog {
             throw new DdlException("Failed to acquire catalog lock. Try again");
         }
         try {
-            if (getDb(db.getFullName()) == null) {
+            if (getDb(db.getId()) == null) {
                 throw new DdlException("database has been dropped when creating view");
             }
             if (!db.createTableWithLock(newView, false)) {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3357

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Use db.getId() to check the existence of the database, to avoid recreating(drop and create) of the database during the process of creating the table.
