### PR TITLE
Support auto __op mapping for json format when jsonpaths is specified

### DIFF
--- a/be/src/exec/vectorized/json_scanner.cpp
+++ b/be/src/exec/vectorized/json_scanner.cpp
@@ -523,17 +523,28 @@ Status JsonReader::_construct_row(simdjson::ondemand::object* row, Chunk* chunk,
             if (slot_descs[i] == nullptr) {
                 continue;
             }
+            const char* column_name = slot_descs[i]->col_name().c_str();
 
             // The columns in JsonReader's chunk are all in NullableColumn type;
             auto column = down_cast<NullableColumn*>(chunk->get_column_by_slot_id(slot_descs[i]->id()).get());
             if (i >= jsonpath_size) {
-                column->append_nulls(1);
+                if (strcmp(column_name, "__op") == 0) {
+                    // special treatment for __op column, fill default value '0' rather than null
+                    column->append_strings(std::vector{Slice{"0"}});
+                } else {
+                    column->append_nulls(1);
+                }
                 continue;
             }
 
             simdjson::ondemand::value val;
             if (!JsonFunctions::extract_from_object(*row, _scanner->_json_paths[i], val)) {
-                column->append_nulls(1);
+                if (strcmp(column_name, "__op") == 0) {
+                    // special treatment for __op column, fill default value '0' rather than null
+                    column->append_strings(std::vector{Slice{"0"}});
+                } else {
+                    column->append_nulls(1);
+                }
             } else {
                 RETURN_IF_ERROR(_construct_column(val, column, slot_descs[i]->type(), slot_descs[i]->col_name()));
             }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3405
Cherry-pick #3406 to branch-2.1

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When load using json format, SR currently support auto __op mapping, but if jsonpaths is specified, auto mapping will be disabled, this PR enables auto __op mapping even if jsonpaths are specified.