### PR TITLE
Fix concurrently create table bug (#3400)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -4118,7 +4118,7 @@ public class Catalog {
                 throw new DdlException("Failed to acquire catalog lock. Try again");
             }
             try {
-                if (getDb(db.getFullName()) == null) {
+                if (getDb(db.getId()) == null) {
                     throw new DdlException("database has been dropped when creating table");
                 }
                 createTblSuccess = db.createTableWithLock(olapTable, false);
@@ -4177,7 +4177,7 @@ public class Catalog {
             throw new DdlException("Failed to acquire catalog lock. Try again");
         }
         try {
-            if (getDb(db.getFullName()) == null) {
+            if (getDb(db.getId()) == null) {
                 throw new DdlException("database has been dropped when creating table");
             }
             if (!db.createTableWithLock(mysqlTable, false)) {
@@ -4224,7 +4224,7 @@ public class Catalog {
             throw new DdlException("Failed to acquire catalog lock. Try again");
         }
         try {
-            if (getDb(db.getFullName()) == null) {
+            if (getDb(db.getId()) == null) {
                 throw new DdlException("database has been dropped when creating table");
             }
             if (!db.createTableWithLock(esTable, false)) {
@@ -4260,7 +4260,7 @@ public class Catalog {
             throw new DdlException("Failed to acquire catalog lock. Try again");
         }
         try {
-            if (getDb(db.getFullName()) == null) {
+            if (getDb(db.getId()) == null) {
                 throw new DdlException("database has been dropped when creating table");
             }
             if (!db.createTableWithLock(hiveTable, false)) {
@@ -4292,7 +4292,7 @@ public class Catalog {
             throw new DdlException("Failed to acquire catalog lock. Try again");
         }
         try {
-            if (getDb(db.getFullName()) == null) {
+            if (getDb(db.getId()) == null) {
                 throw new DdlException("database has been dropped when creating table");
             }
             if (!db.createTableWithLock(icebergTable, false)) {
@@ -6111,7 +6111,7 @@ public class Catalog {
             throw new DdlException("Failed to acquire catalog lock. Try again");
         }
         try {
-            if (getDb(db.getFullName()) == null) {
+            if (getDb(db.getId()) == null) {
                 throw new DdlException("database has been dropped when creating view");
             }
             if (!db.createTableWithLock(newView, false)) {


### PR DESCRIPTION
Use db.getId() to check the existence of the database, to avoid recreating(drop and create) of the database during the process of creating the table.

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
