### PR TITLE
Fix insert into outfile memory overflow in float type

### DIFF
--- a/be/src/formats/csv/output_stream.h
+++ b/be/src/formats/csv/output_stream.h
@@ -38,13 +38,13 @@ public:
     }
 
     Status write(float f) {
-        RETURN_IF_ERROR(_reserve(std::numeric_limits<float>::digits10 + 2));
+        RETURN_IF_ERROR(_reserve(MAX_FLOAT_STR_LENGTH));
         _pos += f2s_buffered_n(f, _pos);
         return Status::OK();
     }
 
     Status write(double d) {
-        RETURN_IF_ERROR(_reserve(std::numeric_limits<double>::digits10 + 2));
+        RETURN_IF_ERROR(_reserve(MAX_DOUBLE_STR_LENGTH));
         _pos += d2s_buffered_n(d, _pos);
         return Status::OK();
     }

--- a/be/src/runtime/file_result_writer.cpp
+++ b/be/src/runtime/file_result_writer.cpp
@@ -43,7 +43,8 @@ FileResultWriter::FileResultWriter(const ResultFileOptions* file_opts,
         _env = Env::Default();
     } else {
         // TODO(@c1oudman) Do you only need first element of broker addresses?
-        _env = new EnvBroker(*_file_opts->broker_addresses.begin(), _file_opts->broker_properties);
+        _env = new EnvBroker(*_file_opts->broker_addresses.begin(), _file_opts->broker_properties,
+                             config::broker_write_timeout_seconds * 1000);
         _owned_env.reset(_env);
     }
 }
@@ -112,7 +113,7 @@ std::string FileResultWriter::_file_format_to_name() {
 
 Status FileResultWriter::append_chunk(vectorized::Chunk* chunk) {
     assert(_file_builder != nullptr);
-    _file_builder->add_chunk(chunk);
+    RETURN_IF_ERROR(_file_builder->add_chunk(chunk));
 
     // split file if exceed limit
     RETURN_IF_ERROR(_create_new_file_if_exceed_size());


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
Fixes #1567

## Problem Summary(Required) ：
std::numeric_limits<float>::digits10 + 2 was less than `MAX_FLOAT_STR_LENGTH`. which may cause a overflow
