### PR TITLE
Implement ORC late materialization mechanism

### DIFF
--- a/be/src/formats/orc/APACHE_ORC_VERSION
+++ b/be/src/formats/orc/APACHE_ORC_VERSION
@@ -1,11 +1,10 @@
 Merge:
 github: https://github.com/apache/orc
 commit: 68d88e876bccf89a7b306a9205624792bc7a04eb
+date: 2021-05-22
 
 Merge process is following:
-1. fork repo https://github.com/StarRocks/orc
-  - The main purpose of this repository is to merge branches, there are basically no code changes on it
-  - Some helper scripts are included below, such as the sync script and clang-format
-2. Merge apache/orc under StarRocks/orc, then run clang-format
-3. Merge StarRocks/orc with StarRocks/be/src/formats/orc code with `sync-to-starrocks.sh`
+1. fork repo https://github.com/dirtysalt/apache-orc. The main purpose of this repository is to trace apache/orc.
+2. Merge apache/orc under dirtysalt/apache-orc, and run `run-all.sh`(to normalize cpp/header files)
+3. Merge StarRocks/orc with StarRocks/be/src/formats/orc code with `copyto-starrocks.sh`
 4. After the merge is complete, you can verify it with `run-test.sh`

--- a/be/src/formats/orc/apache-orc/c++/include/orc/Reader.hh
+++ b/be/src/formats/orc/apache-orc/c++/include/orc/Reader.hh
@@ -276,8 +276,8 @@ public:
 
     RowReaderOptions& useWriterTimezone();
     bool getUseWriterTimezone() const;
-    RowReaderOptions& includeLazyLoadFields(const std::list<std::string>& include);
-    const std::list<std::string>& getLazyLoadNames() const;
+    RowReaderOptions& includeLazyLoadColumnNames(const std::list<std::string>& include);
+    const std::list<std::string>& getLazyLoadColumnNames() const;
 };
 
 class RowReader;
@@ -535,7 +535,8 @@ public:
     /**
      * Get the selected columns of the file.
      */
-    virtual const std::vector<bool> getSelectedColumns() const = 0;
+    virtual const std::vector<bool>& getSelectedColumns() const = 0;
+    virtual const std::vector<bool>& getLazyLoadColumns() const = 0;
 
     /**
      * Create a row batch for reading the selected columns of this file.
@@ -553,6 +554,9 @@ public:
      *   end of the file was reached.
      */
     virtual bool next(ColumnVectorBatch& data) = 0;
+
+    virtual void lazyLoadSkip(uint64_t numValues) = 0;
+    virtual void lazyLoadNext(ColumnVectorBatch& data, uint64_t numValues) = 0;
 
     /**
      * Get the row number of the first row in the previously read batch.

--- a/be/src/formats/orc/apache-orc/c++/include/orc/Reader.hh
+++ b/be/src/formats/orc/apache-orc/c++/include/orc/Reader.hh
@@ -36,21 +36,22 @@
 #include <set>
 #include <string>
 #include <vector>
+// clang-format on
 
 namespace orc {
 
-  // classes that hold data members so we can maintain binary compatibility
-  struct ReaderOptionsPrivate;
-  struct RowReaderOptionsPrivate;
+// classes that hold data members so we can maintain binary compatibility
+struct ReaderOptionsPrivate;
+struct RowReaderOptionsPrivate;
 
-  /**
+/**
    * Options for creating a Reader.
    */
-  class ReaderOptions {
-  private:
+class ReaderOptions {
+private:
     ORC_UNIQUE_PTR<ReaderOptionsPrivate> privateBits;
 
-  public:
+public:
     ReaderOptions();
     ReaderOptions(const ReaderOptions&);
     ReaderOptions(ReaderOptions&);
@@ -106,16 +107,16 @@ namespace orc {
      * Get the memory allocator.
      */
     MemoryPool* getMemoryPool() const;
-  };
+};
 
-  /**
+/**
    * Options for creating a RowReader.
    */
-  class RowReaderOptions {
-  private:
+class RowReaderOptions {
+private:
     ORC_UNIQUE_PTR<RowReaderOptionsPrivate> privateBits;
 
-  public:
+public:
     RowReaderOptions();
     RowReaderOptions(const RowReaderOptions&);
     RowReaderOptions(RowReaderOptions&);
@@ -275,18 +276,18 @@ namespace orc {
 
     RowReaderOptions& useWriterTimezone();
     bool getUseWriterTimezone() const;
+    RowReaderOptions& includeLazyLoadFields(const std::list<std::string>& include);
+    const std::list<std::string>& getLazyLoadNames() const;
+};
 
-  };
+class RowReader;
 
-
-  class RowReader;
-
-  /**
+/**
    * The interface for reading ORC file meta-data and constructing RowReaders.
    * This is an an abstract class that will be subclassed as necessary.
    */
-  class Reader {
-  public:
+class Reader {
+public:
     virtual ~Reader();
 
     /**
@@ -370,8 +371,7 @@ namespace orc {
      * @param stripeIndex the index of the stripe (0 to N-1) to get information about
      * @return the information about that stripe
      */
-    virtual ORC_UNIQUE_PTR<StripeInformation>
-    getStripe(uint64_t stripeIndex) const = 0;
+    virtual ORC_UNIQUE_PTR<StripeInformation> getStripe(uint64_t stripeIndex) const = 0;
 
     /**
      * Get the number of stripe statistics in the file.
@@ -384,8 +384,7 @@ namespace orc {
      * @param stripeIndex the index of the stripe (0 to N-1) to get statistics about
      * @return the statistics about that stripe
      */
-    virtual ORC_UNIQUE_PTR<StripeStatistics>
-    getStripeStatistics(uint64_t stripeIndex) const = 0;
+    virtual ORC_UNIQUE_PTR<StripeStatistics> getStripeStatistics(uint64_t stripeIndex) const = 0;
 
     /**
      * Get the length of the data stripes in the file.
@@ -428,8 +427,7 @@ namespace orc {
      * @param columnId id of the column
      * @return the information about the column
      */
-    virtual ORC_UNIQUE_PTR<ColumnStatistics>
-    getColumnStatistics(uint32_t columnId) const = 0;
+    virtual ORC_UNIQUE_PTR<ColumnStatistics> getColumnStatistics(uint32_t columnId) const = 0;
 
     /**
      * Check if the file has correct column statistics.
@@ -480,7 +478,7 @@ namespace orc {
      *        all stripes are considered).
      * @return upper bound on memory use by all columns
      */
-    virtual uint64_t getMemoryUse(int stripeIx=-1) = 0;
+    virtual uint64_t getMemoryUse(int stripeIx = -1) = 0;
 
     /**
      * @param include Column Field Ids
@@ -488,7 +486,7 @@ namespace orc {
      *        all stripes are considered).
      * @return upper bound on memory use by selected columns
      */
-    virtual uint64_t getMemoryUseByFieldId(const std::list<uint64_t>& include, int stripeIx=-1) = 0;
+    virtual uint64_t getMemoryUseByFieldId(const std::list<uint64_t>& include, int stripeIx = -1) = 0;
 
     /**
      * @param names Column Names
@@ -496,7 +494,7 @@ namespace orc {
      *        all stripes are considered).
      * @return upper bound on memory use by selected columns
      */
-    virtual uint64_t getMemoryUseByName(const std::list<std::string>& names, int stripeIx=-1) = 0;
+    virtual uint64_t getMemoryUseByName(const std::list<std::string>& names, int stripeIx = -1) = 0;
 
     /**
      * @param include Column Type Ids
@@ -504,7 +502,7 @@ namespace orc {
      *        all stripes are considered).
      * @return upper bound on memory use by selected columns
      */
-    virtual uint64_t getMemoryUseByTypeId(const std::list<uint64_t>& include, int stripeIx=-1) = 0;
+    virtual uint64_t getMemoryUseByTypeId(const std::list<uint64_t>& include, int stripeIx = -1) = 0;
 
     /**
      * Get BloomFilters of all selected columns in the specified stripe
@@ -513,16 +511,16 @@ namespace orc {
      *        all columns that have bloom filters are considered).
      * @return map of bloom filters with the key standing for the index of column.
      */
-    virtual std::map<uint32_t, BloomFilterIndex>
-    getBloomFilters(uint32_t stripeIndex, const std::set<uint32_t>& included) const = 0;
-  };
+    virtual std::map<uint32_t, BloomFilterIndex> getBloomFilters(uint32_t stripeIndex,
+                                                                 const std::set<uint32_t>& included) const = 0;
+};
 
-  /**
+/**
    * The interface for reading rows in ORC files.
    * This is an an abstract class that will be subclassed as necessary.
    */
-  class RowReader {
-  public:
+class RowReader {
+public:
     virtual ~RowReader();
     /**
      * Get the selected type of the rows in the file. The file's row type
@@ -544,8 +542,7 @@ namespace orc {
      * @param size the number of rows to read
      * @return a new ColumnVectorBatch to read into
      */
-    virtual ORC_UNIQUE_PTR<ColumnVectorBatch> createRowBatch(uint64_t size
-                                                             ) const = 0;
+    virtual ORC_UNIQUE_PTR<ColumnVectorBatch> createRowBatch(uint64_t size) const = 0;
 
     /**
      * Read the next row batch from the current position.
@@ -568,6 +565,5 @@ namespace orc {
      * @param rowNumber the next row the reader should return
      */
     virtual void seekToRow(uint64_t rowNumber) = 0;
-
-  };
-}
+};
+} // namespace orc

--- a/be/src/formats/orc/apache-orc/c++/src/ColumnReader.hh
+++ b/be/src/formats/orc/apache-orc/c++/src/ColumnReader.hh
@@ -41,7 +41,8 @@ public:
      * @return the address of an array which contains true at the index of
      *    each columnId is selected.
      */
-    virtual const std::vector<bool> getSelectedColumns() const = 0;
+    virtual const std::vector<bool>& getSelectedColumns() const = 0;
+    virtual const std::vector<bool>& getLazyLoadColumns() const = 0;
 
     /**
      * Get the encoding for the given column for this stripe.
@@ -139,6 +140,14 @@ public:
     virtual void nextEncoded(ColumnVectorBatch& rowBatch, uint64_t numValues, char* notNull) {
         rowBatch.isEncoded = false;
         next(rowBatch, numValues, notNull);
+    }
+
+    // Functions for lazy load fields.
+    virtual void lazyLoadSkip(uint64_t numValues);
+    virtual void lazyLoadNext(ColumnVectorBatch& rowBatch, uint64_t numValues, char* notNull);
+    virtual void lazyLoadNextEncoded(ColumnVectorBatch& rowBatch, uint64_t numValues, char* notNull) {
+        rowBatch.isEncoded = false;
+        lazyLoadNext(rowBatch, numValues, notNull);
     }
 
     /**

--- a/be/src/formats/orc/apache-orc/c++/src/Options.hh
+++ b/be/src/formats/orc/apache-orc/c++/src/Options.hh
@@ -29,105 +29,103 @@
 
 #include <limits>
 #include <utility>
+// clang-format on
 
 namespace orc {
 
-  enum ColumnSelection {
+enum ColumnSelection {
     ColumnSelection_NONE = 0,
     ColumnSelection_NAMES = 1,
     ColumnSelection_FIELD_IDS = 2,
     ColumnSelection_TYPE_IDS = 3,
-  };
+};
 
 /**
  * ReaderOptions Implementation
  */
-  struct ReaderOptionsPrivate {
+struct ReaderOptionsPrivate {
     uint64_t tailLocation;
     std::ostream* errorStream;
     MemoryPool* memoryPool;
     std::string serializedTail;
 
     ReaderOptionsPrivate() {
-      tailLocation = std::numeric_limits<uint64_t>::max();
-      errorStream = &std::cerr;
-      memoryPool = getDefaultPool();
+        tailLocation = std::numeric_limits<uint64_t>::max();
+        errorStream = &std::cerr;
+        memoryPool = getDefaultPool();
     }
-  };
+};
 
-  ReaderOptions::ReaderOptions():
-    privateBits(std::unique_ptr<ReaderOptionsPrivate>
-                (new ReaderOptionsPrivate())) {
+ReaderOptions::ReaderOptions() : privateBits(std::unique_ptr<ReaderOptionsPrivate>(new ReaderOptionsPrivate())) {
     // PASS
-  }
+}
 
-  ReaderOptions::ReaderOptions(const ReaderOptions& rhs):
-    privateBits(std::unique_ptr<ReaderOptionsPrivate>
-                (new ReaderOptionsPrivate(*(rhs.privateBits.get())))) {
+ReaderOptions::ReaderOptions(const ReaderOptions& rhs)
+        : privateBits(std::unique_ptr<ReaderOptionsPrivate>(new ReaderOptionsPrivate(*(rhs.privateBits.get())))) {
     // PASS
-  }
+}
 
-  ReaderOptions::ReaderOptions(ReaderOptions& rhs) {
+ReaderOptions::ReaderOptions(ReaderOptions& rhs) {
     // swap privateBits with rhs
     privateBits.swap(rhs.privateBits);
-  }
+}
 
-  ReaderOptions& ReaderOptions::operator=(const ReaderOptions& rhs) {
+ReaderOptions& ReaderOptions::operator=(const ReaderOptions& rhs) {
     if (this != &rhs) {
-      privateBits.reset(new ReaderOptionsPrivate(*(rhs.privateBits.get())));
+        privateBits.reset(new ReaderOptionsPrivate(*(rhs.privateBits.get())));
     }
     return *this;
-  }
+}
 
-  ReaderOptions::~ReaderOptions() {
+ReaderOptions::~ReaderOptions() {
     // PASS
-  }
+}
 
-  ReaderOptions& ReaderOptions::setMemoryPool(MemoryPool& pool) {
+ReaderOptions& ReaderOptions::setMemoryPool(MemoryPool& pool) {
     privateBits->memoryPool = &pool;
     return *this;
-  }
+}
 
-  MemoryPool* ReaderOptions::getMemoryPool() const{
+MemoryPool* ReaderOptions::getMemoryPool() const {
     return privateBits->memoryPool;
-  }
+}
 
-  ReaderOptions& ReaderOptions::setTailLocation(uint64_t offset) {
+ReaderOptions& ReaderOptions::setTailLocation(uint64_t offset) {
     privateBits->tailLocation = offset;
     return *this;
-  }
+}
 
-  uint64_t ReaderOptions::getTailLocation() const {
+uint64_t ReaderOptions::getTailLocation() const {
     return privateBits->tailLocation;
-  }
+}
 
-  ReaderOptions& ReaderOptions::setSerializedFileTail(const std::string& value
-                                                      ) {
+ReaderOptions& ReaderOptions::setSerializedFileTail(const std::string& value) {
     privateBits->serializedTail = value;
     return *this;
-  }
+}
 
-  std::string ReaderOptions::getSerializedFileTail() const {
+std::string ReaderOptions::getSerializedFileTail() const {
     return privateBits->serializedTail;
-  }
+}
 
-  ReaderOptions& ReaderOptions::setErrorStream(std::ostream& stream) {
+ReaderOptions& ReaderOptions::setErrorStream(std::ostream& stream) {
     privateBits->errorStream = &stream;
     return *this;
-  }
+}
 
-  std::ostream* ReaderOptions::getErrorStream() const {
+std::ostream* ReaderOptions::getErrorStream() const {
     return privateBits->errorStream;
-  }
+}
 
 /**
  * RowReaderOptions Implementation
  */
 
-  struct RowReaderOptionsPrivate {
+struct RowReaderOptionsPrivate {
     ColumnSelection selection;
     std::list<uint64_t> includedColumnIndexes;
     std::list<std::string> includedColumnNames;
+    std::list<std::string> lazyLoadColumnNames;
     uint64_t dataStart;
     uint64_t dataLength;
     bool throwOnHive11DecimalOverflow;
@@ -139,160 +137,166 @@ namespace orc {
     bool useWriterTimezone;
 
     RowReaderOptionsPrivate() {
-      selection = ColumnSelection_NONE;
-      dataStart = 0;
-      dataLength = std::numeric_limits<uint64_t>::max();
-      throwOnHive11DecimalOverflow = true;
-      forcedScaleOnHive11Decimal = 6;
-      enableLazyDecoding = false;
-      readerTimezone = "GMT";
-      useWriterTimezone = false;
+        selection = ColumnSelection_NONE;
+        dataStart = 0;
+        dataLength = std::numeric_limits<uint64_t>::max();
+        throwOnHive11DecimalOverflow = true;
+        forcedScaleOnHive11Decimal = 6;
+        enableLazyDecoding = false;
+        readerTimezone = "GMT";
+        useWriterTimezone = false;
     }
-  };
+};
 
-  RowReaderOptions::RowReaderOptions():
-    privateBits(std::unique_ptr<RowReaderOptionsPrivate>
-                (new RowReaderOptionsPrivate())) {
+RowReaderOptions::RowReaderOptions()
+        : privateBits(std::unique_ptr<RowReaderOptionsPrivate>(new RowReaderOptionsPrivate())) {
     // PASS
-  }
+}
 
-  RowReaderOptions::RowReaderOptions(const RowReaderOptions& rhs):
-    privateBits(std::unique_ptr<RowReaderOptionsPrivate>
-                (new RowReaderOptionsPrivate(*(rhs.privateBits.get())))) {
+RowReaderOptions::RowReaderOptions(const RowReaderOptions& rhs)
+        : privateBits(std::unique_ptr<RowReaderOptionsPrivate>(new RowReaderOptionsPrivate(*(rhs.privateBits.get())))) {
     // PASS
-  }
+}
 
-  RowReaderOptions::RowReaderOptions(RowReaderOptions& rhs) {
+RowReaderOptions::RowReaderOptions(RowReaderOptions& rhs) {
     // swap privateBits with rhs
     privateBits.swap(rhs.privateBits);
-  }
+}
 
-  RowReaderOptions& RowReaderOptions::operator=(const RowReaderOptions& rhs) {
+RowReaderOptions& RowReaderOptions::operator=(const RowReaderOptions& rhs) {
     if (this != &rhs) {
-      privateBits.reset(new RowReaderOptionsPrivate(*(rhs.privateBits.get())));
+        privateBits.reset(new RowReaderOptionsPrivate(*(rhs.privateBits.get())));
     }
     return *this;
-  }
+}
 
-  RowReaderOptions::~RowReaderOptions() {
+RowReaderOptions::~RowReaderOptions() {
     // PASS
-  }
+}
 
-  RowReaderOptions& RowReaderOptions::include(const std::list<uint64_t>& include) {
+RowReaderOptions& RowReaderOptions::include(const std::list<uint64_t>& include) {
     privateBits->selection = ColumnSelection_FIELD_IDS;
     privateBits->includedColumnIndexes.assign(include.begin(), include.end());
     privateBits->includedColumnNames.clear();
     return *this;
-  }
+}
 
-  RowReaderOptions& RowReaderOptions::include(const std::list<std::string>& include) {
+RowReaderOptions& RowReaderOptions::include(const std::list<std::string>& include) {
     privateBits->selection = ColumnSelection_NAMES;
     privateBits->includedColumnNames.assign(include.begin(), include.end());
     privateBits->includedColumnIndexes.clear();
     return *this;
-  }
+}
 
-  RowReaderOptions& RowReaderOptions::includeTypes(const std::list<uint64_t>& types) {
+RowReaderOptions& RowReaderOptions::includeLazyLoadFields(const std::list<std::string>& include) {
+    privateBits->lazyLoadColumnNames.assign(include.begin(), include.end());
+    return *this;
+}
+
+RowReaderOptions& RowReaderOptions::includeTypes(const std::list<uint64_t>& types) {
     privateBits->selection = ColumnSelection_TYPE_IDS;
     privateBits->includedColumnIndexes.assign(types.begin(), types.end());
     privateBits->includedColumnNames.clear();
     return *this;
-  }
+}
 
-  RowReaderOptions& RowReaderOptions::range(uint64_t offset, uint64_t length) {
+RowReaderOptions& RowReaderOptions::range(uint64_t offset, uint64_t length) {
     privateBits->dataStart = offset;
     privateBits->dataLength = length;
     return *this;
-  }
+}
 
-  bool RowReaderOptions::getIndexesSet() const {
+bool RowReaderOptions::getIndexesSet() const {
     return privateBits->selection == ColumnSelection_FIELD_IDS;
-  }
+}
 
-  bool RowReaderOptions::getTypeIdsSet() const {
+bool RowReaderOptions::getTypeIdsSet() const {
     return privateBits->selection == ColumnSelection_TYPE_IDS;
-  }
+}
 
-  const std::list<uint64_t>& RowReaderOptions::getInclude() const {
+const std::list<uint64_t>& RowReaderOptions::getInclude() const {
     return privateBits->includedColumnIndexes;
-  }
+}
 
-  bool RowReaderOptions::getNamesSet() const {
+bool RowReaderOptions::getNamesSet() const {
     return privateBits->selection == ColumnSelection_NAMES;
-  }
+}
 
-  const std::list<std::string>& RowReaderOptions::getIncludeNames() const {
+const std::list<std::string>& RowReaderOptions::getIncludeNames() const {
     return privateBits->includedColumnNames;
-  }
+}
 
-  uint64_t RowReaderOptions::getOffset() const {
+const std::list<std::string>& RowReaderOptions::getLazyLoadNames() const {
+    return privateBits->lazyLoadColumnNames;
+}
+
+uint64_t RowReaderOptions::getOffset() const {
     return privateBits->dataStart;
-  }
+}
 
-  uint64_t RowReaderOptions::getLength() const {
+uint64_t RowReaderOptions::getLength() const {
     return privateBits->dataLength;
-  }
+}
 
-  RowReaderOptions& RowReaderOptions::throwOnHive11DecimalOverflow(bool shouldThrow){
+RowReaderOptions& RowReaderOptions::throwOnHive11DecimalOverflow(bool shouldThrow) {
     privateBits->throwOnHive11DecimalOverflow = shouldThrow;
     return *this;
-  }
+}
 
-  bool RowReaderOptions::getThrowOnHive11DecimalOverflow() const {
+bool RowReaderOptions::getThrowOnHive11DecimalOverflow() const {
     return privateBits->throwOnHive11DecimalOverflow;
-  }
+}
 
-  RowReaderOptions& RowReaderOptions::forcedScaleOnHive11Decimal(int32_t forcedScale
-                                                           ) {
+RowReaderOptions& RowReaderOptions::forcedScaleOnHive11Decimal(int32_t forcedScale) {
     privateBits->forcedScaleOnHive11Decimal = forcedScale;
     return *this;
-  }
+}
 
-  int32_t RowReaderOptions::getForcedScaleOnHive11Decimal() const {
+int32_t RowReaderOptions::getForcedScaleOnHive11Decimal() const {
     return privateBits->forcedScaleOnHive11Decimal;
-  }
+}
 
-  bool RowReaderOptions::getEnableLazyDecoding() const {
+bool RowReaderOptions::getEnableLazyDecoding() const {
     return privateBits->enableLazyDecoding;
-  }
+}
 
-  RowReaderOptions& RowReaderOptions::setEnableLazyDecoding(bool enable) {
+RowReaderOptions& RowReaderOptions::setEnableLazyDecoding(bool enable) {
     privateBits->enableLazyDecoding = enable;
     return *this;
-  }
+}
 
-  RowReaderOptions& RowReaderOptions::searchArgument(std::unique_ptr<SearchArgument> sargs) {
+RowReaderOptions& RowReaderOptions::searchArgument(std::unique_ptr<SearchArgument> sargs) {
     privateBits->sargs = std::move(sargs);
     return *this;
-  }
+}
 
-  std::shared_ptr<SearchArgument> RowReaderOptions::getSearchArgument() const {
+std::shared_ptr<SearchArgument> RowReaderOptions::getSearchArgument() const {
     return privateBits->sargs;
-  }
+}
 
-  RowReaderOptions& RowReaderOptions::rowReaderFilter(std::shared_ptr<RowReaderFilter> filter) {
+RowReaderOptions& RowReaderOptions::rowReaderFilter(std::shared_ptr<RowReaderFilter> filter) {
     privateBits->filter = std::move(filter);
     return *this;
-  }
+}
 
-  std::shared_ptr<RowReaderFilter> RowReaderOptions::getRowReaderFilter() const {
+std::shared_ptr<RowReaderFilter> RowReaderOptions::getRowReaderFilter() const {
     return privateBits->filter;
-  }
+}
 
-  RowReaderOptions& RowReaderOptions::setTimezoneName(const std::string& zoneName) {
+RowReaderOptions& RowReaderOptions::setTimezoneName(const std::string& zoneName) {
     privateBits->readerTimezone = zoneName;
     return *this;
-  }
-
-  const std::string& RowReaderOptions::getTimezoneName() const {
-    return privateBits->readerTimezone;
-  }
-   RowReaderOptions& RowReaderOptions::useWriterTimezone() {
-     privateBits->useWriterTimezone = true;
-     return *this;
-   }
-
-    bool RowReaderOptions::getUseWriterTimezone() const {
-      return privateBits->useWriterTimezone;
-    }
 }
+
+const std::string& RowReaderOptions::getTimezoneName() const {
+    return privateBits->readerTimezone;
+}
+RowReaderOptions& RowReaderOptions::useWriterTimezone() {
+    privateBits->useWriterTimezone = true;
+    return *this;
+}
+
+bool RowReaderOptions::getUseWriterTimezone() const {
+    return privateBits->useWriterTimezone;
+}
+} // namespace orc

--- a/be/src/formats/orc/apache-orc/c++/src/Options.hh
+++ b/be/src/formats/orc/apache-orc/c++/src/Options.hh
@@ -188,7 +188,7 @@ RowReaderOptions& RowReaderOptions::include(const std::list<std::string>& includ
     return *this;
 }
 
-RowReaderOptions& RowReaderOptions::includeLazyLoadFields(const std::list<std::string>& include) {
+RowReaderOptions& RowReaderOptions::includeLazyLoadColumnNames(const std::list<std::string>& include) {
     privateBits->lazyLoadColumnNames.assign(include.begin(), include.end());
     return *this;
 }
@@ -226,7 +226,7 @@ const std::list<std::string>& RowReaderOptions::getIncludeNames() const {
     return privateBits->includedColumnNames;
 }
 
-const std::list<std::string>& RowReaderOptions::getLazyLoadNames() const {
+const std::list<std::string>& RowReaderOptions::getLazyLoadColumnNames() const {
     return privateBits->lazyLoadColumnNames;
 }
 

--- a/be/src/formats/orc/apache-orc/c++/src/Reader.hh
+++ b/be/src/formats/orc/apache-orc/c++/src/Reader.hh
@@ -103,10 +103,8 @@ public:
     ColumnSelector(const FileContents* contents);
 
     // Select the columns from the RowReaderoptions object
-    void updateSelected(std::vector<bool>& selectedColumns, const RowReaderOptions& options);
-
-    // Select the columns from the Readeroptions object
-    void updateSelected(std::vector<bool>& selectedColumns, const ReaderOptions& options);
+    void updateSelected(std::vector<bool>& selectedColumns, std::vector<bool>& lazyLoadColumns,
+                        const RowReaderOptions& options);
 };
 
 class RowReaderImpl : public RowReader {
@@ -120,6 +118,7 @@ private:
 
     // inputs
     std::vector<bool> selectedColumns;
+    std::vector<bool> lazyLoadColumns;
 
     // footer
     proto::Footer* footer;
@@ -190,13 +189,16 @@ public:
     RowReaderImpl(const std::shared_ptr<FileContents>& contents, const RowReaderOptions& options);
 
     // Select the columns from the options object
-    const std::vector<bool> getSelectedColumns() const override;
+    const std::vector<bool>& getSelectedColumns() const override;
+    const std::vector<bool>& getLazyLoadColumns() const override;
 
     const Type& getSelectedType() const override;
 
     std::unique_ptr<ColumnVectorBatch> createRowBatch(uint64_t size) const override;
 
     bool next(ColumnVectorBatch& data) override;
+    void lazyLoadSkip(uint64_t numValues) override;
+    void lazyLoadNext(ColumnVectorBatch& data, uint64_t numValues) override;
 
     CompressionKind getCompression() const;
 

--- a/be/src/formats/orc/apache-orc/c++/src/StripeStream.cc
+++ b/be/src/formats/orc/apache-orc/c++/src/StripeStream.cc
@@ -63,8 +63,12 @@ StreamInformationImpl::~StreamInformationImpl() {
     // PASS
 }
 
-const std::vector<bool> StripeStreamsImpl::getSelectedColumns() const {
+const std::vector<bool>& StripeStreamsImpl::getSelectedColumns() const {
     return reader.getSelectedColumns();
+}
+
+const std::vector<bool>& StripeStreamsImpl::getLazyLoadColumns() const {
+    return reader.getLazyLoadColumns();
 }
 
 proto::ColumnEncoding StripeStreamsImpl::getEncoding(uint64_t columnId) const {

--- a/be/src/formats/orc/apache-orc/c++/src/StripeStream.hh
+++ b/be/src/formats/orc/apache-orc/c++/src/StripeStream.hh
@@ -54,7 +54,8 @@ public:
 
     ~StripeStreamsImpl() override;
 
-    const std::vector<bool> getSelectedColumns() const override;
+    const std::vector<bool>& getSelectedColumns() const override;
+    const std::vector<bool>& getLazyLoadColumns() const override;
 
     proto::ColumnEncoding getEncoding(uint64_t columnId) const override;
 

--- a/be/src/formats/orc/apache-orc/c++/test/CMakeLists.txt
+++ b/be/src/formats/orc/apache-orc/c++/test/CMakeLists.txt
@@ -53,6 +53,7 @@ add_executable (orc-test
   TestTimezone.cc
   TestType.cc
   TestWriter.cc
+  TestLazyLoad.cc
 )
 
 target_link_libraries (orc-test

--- a/be/src/formats/orc/apache-orc/c++/test/TestLazyLoad.cc
+++ b/be/src/formats/orc/apache-orc/c++/test/TestLazyLoad.cc
@@ -1,0 +1,88 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#include <iostream>
+#include <vector>
+
+#include "MemoryInputStream.hh"
+#include "MemoryOutputStream.hh"
+#include "OrcTest.hh"
+#include "wrap/gtest-wrapper.h"
+
+namespace orc {
+
+TEST(TestLazyLoad, TestNormal) {
+    orc::MemoryOutputStream buffer(102400);
+    size_t batchSize = 1024;
+
+    // prepare data.
+    // size = 2 * batchSize
+    // c0 -> [0, 1, 2, i ... ]
+    // c1 -> [i * 10]
+    {
+        ORC_UNIQUE_PTR<orc::Type> schema(orc::Type::buildTypeFromString("struct<c0:int,c1:int>"));
+        ORC_UNIQUE_PTR<orc::Writer> writer = createWriter(*schema, &buffer, orc::WriterOptions{});
+
+        size_t numValues = batchSize * 2;
+        ORC_UNIQUE_PTR<orc::ColumnVectorBatch> batch = writer->createRowBatch(numValues);
+        auto* root = dynamic_cast<orc::StructVectorBatch*>(batch.get());
+        auto* c0 = dynamic_cast<orc::LongVectorBatch*>(root->fields[0]);
+        auto* c1 = dynamic_cast<orc::LongVectorBatch*>(root->fields[1]);
+        for (size_t i = 0; i < numValues; i++) {
+            c0->data[i] = i;
+            c1->data[i] = i * 10;
+        }
+        c0->numElements = numValues;
+        c1->numElements = numValues;
+        root->numElements = numValues;
+        writer->add(*batch);
+        writer->close();
+    }
+
+    // read data.
+    // we read first batch, and discard c1 field
+    // then read second batch, and verify c1 values.
+    {
+        orc::ReaderOptions readerOptions;
+        ORC_UNIQUE_PTR<orc::InputStream> inputStream(new orc::MemoryInputStream(buffer.getData(), buffer.getLength()));
+        ORC_UNIQUE_PTR<orc::Reader> reader = createReader(std::move(inputStream), readerOptions);
+
+        orc::RowReaderOptions options;
+        std::list<std::string> columns = {"c0", "c1"};
+        std::list<std::string> lazyColumns = {"c1"};
+        options.include(columns);
+        options.includeLazyLoadColumnNames(lazyColumns);
+        ORC_UNIQUE_PTR<orc::RowReader> rr = reader->createRowReader(options);
+
+        ORC_UNIQUE_PTR<orc::ColumnVectorBatch> batch = rr->createRowBatch(batchSize);
+        auto* root = dynamic_cast<orc::StructVectorBatch*>(batch.get());
+        auto* c0 = dynamic_cast<orc::LongVectorBatch*>(root->fields[0]);
+        auto* c1 = dynamic_cast<orc::LongVectorBatch*>(root->fields[1]);
+
+        // clear memory.
+        std::memset(c0->data.data(), 0x0, sizeof((c0->data[0])) * batchSize);
+        std::memset(c1->data.data(), 0x0, sizeof((c1->data[0])) * batchSize);
+
+        // there are 2 * batchSize, but we are going to read twice, each time read batchSize.
+        EXPECT_EQ(rr->next(*batch), true);
+        EXPECT_EQ(batch->numElements, batchSize);
+        for (size_t i = 0; i < batchSize; i++) {
+            ASSERT_EQ(c0->data[i], i);
+            // since c1 is lazy loaded, we don't read actual data.
+            ASSERT_EQ(c1->data[i], 0);
+        }
+        rr->lazyLoadSkip(batch->numElements);
+
+        EXPECT_EQ(rr->next(*batch), true);
+        EXPECT_EQ(batch->numElements, batchSize);
+        rr->lazyLoadNext(*batch, batch->numElements);
+        for (size_t i = 0, j = batchSize; i < batchSize; i++, j++) {
+            ASSERT_EQ(c0->data[i], j);
+            // since c1 is lazy loaded, we don't read actual data.
+            ASSERT_EQ(c1->data[i], j * 10);
+        }
+
+        EXPECT_EQ(rr->next(*batch), false);
+    }
+}
+
+} // namespace orc

--- a/be/test/exprs/vectorized/json_functions_test.cpp
+++ b/be/test/exprs/vectorized/json_functions_test.cpp
@@ -334,7 +334,7 @@ TEST_P(JsonQueryTestFixture, json_query) {
 
 INSTANTIATE_TEST_SUITE_P(JsonQueryTest, JsonQueryTestFixture,
                          ::testing::Values(
-                                // empty
+                                 // empty
                                  std::make_tuple(R"( {"k1":1} )", "$", R"( {"k1": 1} )"),
                                  std::make_tuple(R"( {"k1":1} )", "", R"( {"k1": 1} )"),
 
@@ -442,8 +442,7 @@ INSTANTIATE_TEST_SUITE_P(JsonExistTest, JsonExistTestFixture,
 
                                            // special case
                                            std::make_tuple(R"({ "k1": {}})", "$", true),
-                                           std::make_tuple(R"({ "k1": {}})", "", true)
-                                           ));
+                                           std::make_tuple(R"({ "k1": {}})", "", true)));
 
 class JsonParseTestFixture : public ::testing::TestWithParam<std::tuple<std::string, bool>> {};
 

--- a/be/test/storage/vectorized/cumulative_compaction_test.cpp
+++ b/be/test/storage/vectorized/cumulative_compaction_test.cpp
@@ -261,17 +261,17 @@ TEST_F(CumulativeCompactionTest, test_read_chunk_size) {
     int64_t total_mem_footprint = 0;
     size_t source_num = 10;
     ASSERT_EQ(config_chunk_size, CompactionUtils::get_read_chunk_size(mem_limit, config_chunk_size, total_num_rows,
-                                                                 total_mem_footprint, source_num));
+                                                                      total_mem_footprint, source_num));
 
     // normal total memory footprint
     total_mem_footprint = 1073741824;
-    ASSERT_EQ(2001, CompactionUtils::get_read_chunk_size(mem_limit, config_chunk_size, total_num_rows, total_mem_footprint,
-                                                    source_num));
+    ASSERT_EQ(2001, CompactionUtils::get_read_chunk_size(mem_limit, config_chunk_size, total_num_rows,
+                                                         total_mem_footprint, source_num));
 
     // mem limit is 0
     mem_limit = 0;
     ASSERT_EQ(config_chunk_size, CompactionUtils::get_read_chunk_size(mem_limit, config_chunk_size, total_num_rows,
-                                                                 total_mem_footprint, source_num));
+                                                                      total_mem_footprint, source_num));
 }
 
 } // namespace starrocks::vectorized


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：

https://github.com/StarRocks/starrocks/issues/3418

## Problem Summary(Required) ：

To Implement late materialization when reading ORC file. And this PR is to add some necessary interfaces and implementations in ORC module.  Later PRs will use this APIs to do late materialization when scanning ORC files.

NOTE: when you review this PR, please "hide whitespace difference" because there is a source code format changes indentation.

This PR addes following APIs:
- `RowReaderOptions& RowReaderOptions::includeLazyLoadColumnNames(const std::list<std::string>& include);`. It allows user to set which columns are lazily loaded.
- `void Reader::lazyLoadSkip(uint64_t numValues)` to skip reading those lazily loaded columns.
- `void Reader::lazyLoadNext(ColumnVectorBatch& data, uint64_t numValues)` to load lazily-loaded columns.

And you can refer `TestLazyLoad.cc` to see how to use those APIs.