### PR TITLE
Make HdfsScanner does not rely on the implementation of RandomAccessFile

### DIFF
--- a/be/src/env/env_hdfs.h
+++ b/be/src/env/env_hdfs.h
@@ -37,6 +37,8 @@ public:
 
     hdfsFile hdfs_file() const { return _file; }
 
+    StatusOr<std::unique_ptr<NumericStatistics>> get_numeric_statistics() override;
+
 private:
     Status _read_at(int64_t offset, char* data, size_t size, size_t* read_size) const;
     bool _opened;

--- a/be/src/exec/vectorized/hdfs_scan_node.cpp
+++ b/be/src/exec/vectorized/hdfs_scan_node.cpp
@@ -96,7 +96,6 @@ Status HdfsScanNode::init(const TPlanNode& tnode, RuntimeState* state) {
     }
     _scan_ranges_counter = ADD_COUNTER(_runtime_profile, "ScanRanges", TUnit::UNIT);
     _scan_files_counter = ADD_COUNTER(_runtime_profile, "ScanFiles", TUnit::UNIT);
-    _hdfs_io_profile.init(_runtime_profile.get());
 
     _mem_pool = std::make_unique<MemPool>();
 

--- a/be/src/exec/vectorized/hdfs_scan_node.h
+++ b/be/src/exec/vectorized/hdfs_scan_node.h
@@ -174,7 +174,6 @@ private:
     RuntimeProfile::Counter* _column_read_timer = nullptr;
     RuntimeProfile::Counter* _column_convert_timer = nullptr;
 
-    HdfsIOProfile _hdfs_io_profile;
     HdfsParquetProfile _parquet_profile;
 };
 } // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/hdfs_scanner.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner.cpp
@@ -165,53 +165,23 @@ uint64_t HdfsScanner::exit_pending_queue() {
     return _pending_queue_sw.reset();
 }
 
-#ifndef BE_TEST
-struct HdfsReadStats {
-    int64_t bytes_total_read = 0;
-    int64_t bytes_read_local = 0;
-    int64_t bytes_read_short_circuit = 0;
-    int64_t bytes_read_dn_cache = 0;
-    int64_t bytes_read_remote = 0;
-};
-
-static void get_hdfs_statistics(hdfsFile file, HdfsReadStats* stats) {
-    struct hdfsReadStatistics* hdfs_stats = nullptr;
-    auto res = hdfsFileGetReadStatistics(file, &hdfs_stats);
-    if (res == 0) {
-        stats->bytes_total_read += hdfs_stats->totalBytesRead;
-        stats->bytes_read_local += hdfs_stats->totalLocalBytesRead;
-        stats->bytes_read_short_circuit += hdfs_stats->totalShortCircuitBytesRead;
-        stats->bytes_read_dn_cache += hdfs_stats->totalZeroCopyBytesRead;
-        stats->bytes_read_remote += hdfs_stats->totalBytesRead - hdfs_stats->totalLocalBytesRead;
-
-        hdfsFileFreeReadStatistics(hdfs_stats);
-    }
-    hdfsFileClearReadStatistics(file);
-}
-#endif
-
 void HdfsScanner::update_counter() {
-#ifndef BE_TEST
-    // _scanner_params.fs is null means scanner open failed
+    static const char* const kHdfsIOProfileSectionPrefix = "HdfsIO";
     if (_scanner_params.fs == nullptr) return;
 
-    HdfsReadStats hdfs_stats;
+    auto res = _scanner_params.fs->get_numeric_statistics();
+    if (!res.ok()) return;
 
-    if (_scanner_params.fs_handle_type == HdfsFsHandle::Type::HDFS) {
-        auto hdfs_file = down_cast<HdfsRandomAccessFile*>(_scanner_params.fs.get())->hdfs_file();
-        if (hdfs_file == nullptr) return;
-        // Hdfslib only supports obtaining statistics of hdfs file system.
-        // For other systems such as s3, calling this function will cause be crash.
-        get_hdfs_statistics(hdfs_file, &hdfs_stats);
+    std::unique_ptr<NumericStatistics> statistics = std::move(res).value();
+    if (statistics == nullptr || statistics->size() == 0) return;
+
+    auto&& profile = _scanner_params.parent->runtime_profile();
+    [[maybe_unused]] auto&& toplev = ADD_TIMER(profile, kHdfsIOProfileSectionPrefix);
+    for (int64_t i = 0, sz = statistics->size(); i < sz; i++) {
+        auto&& name = statistics->name(i);
+        auto&& counter = ADD_CHILD_COUNTER(profile, name, TUnit::UNIT, kHdfsIOProfileSectionPrefix);
+        COUNTER_UPDATE(counter, statistics->value(i));
     }
-
-    auto& root = _scanner_params.parent->_hdfs_io_profile;
-    COUNTER_UPDATE(root.bytes_total_read, hdfs_stats.bytes_total_read);
-    COUNTER_UPDATE(root.bytes_read_local, hdfs_stats.bytes_read_local);
-    COUNTER_UPDATE(root.bytes_read_short_circuit, hdfs_stats.bytes_read_short_circuit);
-    COUNTER_UPDATE(root.bytes_read_dn_cache, hdfs_stats.bytes_read_dn_cache);
-    COUNTER_UPDATE(root.bytes_read_remote, hdfs_stats.bytes_read_remote);
-#endif
 }
 
 void HdfsFileReaderParam::set_columns_from_file(const std::unordered_set<std::string>& names) {

--- a/be/src/exec/vectorized/hdfs_scanner.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner.cpp
@@ -273,5 +273,3 @@ bool HdfsFileReaderParam::can_use_dict_filter_on_slot(SlotDescriptor* slot) cons
 }
 
 } // namespace starrocks::vectorized
-
-} // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/hdfs_scanner.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner.cpp
@@ -272,17 +272,6 @@ bool HdfsFileReaderParam::can_use_dict_filter_on_slot(SlotDescriptor* slot) cons
     return true;
 }
 
-static const std::string kHdfsIOProfileSectionPrefix = "HdfsIO";
-
-void HdfsIOProfile::init(RuntimeProfile* root) {
-    if (_toplev != nullptr) return;
-    _toplev = ADD_TIMER(root, kHdfsIOProfileSectionPrefix);
-    bytes_total_read = ADD_CHILD_COUNTER(root, "BytesTotalRead", TUnit::BYTES, kHdfsIOProfileSectionPrefix);
-    bytes_read_local = ADD_CHILD_COUNTER(root, "BytesReadLocal", TUnit::BYTES, kHdfsIOProfileSectionPrefix);
-    bytes_read_short_circuit =
-            ADD_CHILD_COUNTER(root, "BytesReadShortCircuit", TUnit::BYTES, kHdfsIOProfileSectionPrefix);
-    bytes_read_dn_cache = ADD_CHILD_COUNTER(root, "BytesReadDataNodeCache", TUnit::BYTES, kHdfsIOProfileSectionPrefix);
-    bytes_read_remote = ADD_CHILD_COUNTER(root, "BytesReadRemote", TUnit::BYTES, kHdfsIOProfileSectionPrefix);
-}
+} // namespace starrocks::vectorized
 
 } // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/hdfs_scanner.h
+++ b/be/src/exec/vectorized/hdfs_scanner.h
@@ -20,20 +20,6 @@ namespace starrocks::vectorized {
 class HdfsScanNode;
 class RuntimeFilterProbeCollector;
 
-class HdfsIOProfile {
-public:
-    RuntimeProfile::Counter* bytes_total_read = nullptr;
-    RuntimeProfile::Counter* bytes_read_local = nullptr;
-    RuntimeProfile::Counter* bytes_read_short_circuit = nullptr;
-    RuntimeProfile::Counter* bytes_read_dn_cache = nullptr;
-    RuntimeProfile::Counter* bytes_read_remote = nullptr;
-
-    void init(RuntimeProfile* root);
-
-private:
-    RuntimeProfile::Counter* _toplev = nullptr;
-};
-
 struct HdfsScanStats {
     int64_t raw_rows_read = 0;
     int64_t expr_filter_ns = 0;


### PR DESCRIPTION
Summary: Make HdfsScanner rely on the interfaces of RandomAccessFile, instead of
the implementations.

## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [x] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
