### PR TITLE
Disable replicate join temporarily

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -765,7 +765,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     }
 
     public boolean isEnableReplicationJoin() {
-        return enableReplicationJoin;
+        return false;
     }
 
     public boolean isSetUseNthExecPlan() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ChildPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ChildPropertyDeriver.java
@@ -123,6 +123,7 @@ public class ChildPropertyDeriver extends OperatorVisitor<Void, ExpressionContex
                 getEqConj(leftChildColumns, rightChildColumns, Utils.extractConjuncts(node.getOnPredicate()));
 
         if (Utils.canOnlyDoBroadcast(node, equalOnPredicate, hint)) {
+            tryReplicatedCrossJoin(context);
             return visitJoinRequirements(node, context, false);
         }
 
@@ -152,6 +153,7 @@ public class ChildPropertyDeriver extends OperatorVisitor<Void, ExpressionContex
 
         // Colocate join and bucket shuffle join only support column to column binary predicate
         if (equalOnPredicate.stream().anyMatch(p -> !isColumnToColumnBinaryPredicate(p))) {
+            tryReplicatedHashJoin(context, node.getJoinType(), leftDistribution);
             return visitJoinRequirements(node, context, false);
         }
 
@@ -159,6 +161,9 @@ public class ChildPropertyDeriver extends OperatorVisitor<Void, ExpressionContex
         // 3 For colocate join
         if (!"BUCKET".equalsIgnoreCase(hint)) {
             canDoColocatedJoin = tryColocate(leftDistribution, rightDistribution);
+            if (!canDoColocatedJoin) {
+                tryReplicatedHashJoin(context, node.getJoinType(), leftDistribution);
+            }
         }
 
         // 4 For bucket shuffle join

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ChildPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ChildPropertyDeriver.java
@@ -123,7 +123,6 @@ public class ChildPropertyDeriver extends OperatorVisitor<Void, ExpressionContex
                 getEqConj(leftChildColumns, rightChildColumns, Utils.extractConjuncts(node.getOnPredicate()));
 
         if (Utils.canOnlyDoBroadcast(node, equalOnPredicate, hint)) {
-            tryReplicatedCrossJoin(context);
             return visitJoinRequirements(node, context, false);
         }
 
@@ -153,7 +152,6 @@ public class ChildPropertyDeriver extends OperatorVisitor<Void, ExpressionContex
 
         // Colocate join and bucket shuffle join only support column to column binary predicate
         if (equalOnPredicate.stream().anyMatch(p -> !isColumnToColumnBinaryPredicate(p))) {
-            tryReplicatedHashJoin(context, node.getJoinType(), leftDistribution);
             return visitJoinRequirements(node, context, false);
         }
 
@@ -161,9 +159,6 @@ public class ChildPropertyDeriver extends OperatorVisitor<Void, ExpressionContex
         // 3 For colocate join
         if (!"BUCKET".equalsIgnoreCase(hint)) {
             canDoColocatedJoin = tryColocate(leftDistribution, rightDistribution);
-            if (!canDoColocatedJoin) {
-                tryReplicatedHashJoin(context, node.getJoinType(), leftDistribution);
-            }
         }
 
         // 4 For bucket shuffle join

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -68,7 +68,7 @@ public class PlanFragmentTest extends PlanTestBase {
         String sql = "select * from colocate1 left join colocate2 on colocate1.k1=colocate2.k1;";
         String plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("colocate: false"));
-        Assert.assertTrue(plan.contains("join op: LEFT OUTER JOIN (REPLICATED)"));
+        Assert.assertTrue(plan.contains("join op: LEFT OUTER JOIN (BROADCAST)"));
 
         sql = "select * from colocate1 left join colocate2 on colocate1.k1=colocate2.k1 and colocate1.k2=colocate2.k2;";
         plan = getFragmentPlan(sql);
@@ -4015,7 +4015,7 @@ public class PlanFragmentTest extends PlanTestBase {
                 "  0:OlapScanNode"));
     }
 
-    @Test
+    // todo(ywb) disable replicate join temporarily
     public void testReplicatedJoin() throws Exception {
         connectContext.getSessionVariable().setEnableReplicationJoin(true);
         String sql = "select * from join1 join join2 on join1.id = join2.id;";
@@ -4067,7 +4067,7 @@ public class PlanFragmentTest extends PlanTestBase {
         connectContext.getSessionVariable().setEnableReplicationJoin(false);
     }
 
-    @Test
+    // todo(ywb) disable replicate join temporarily
     public void testReplicationJoinWithEmptyNode() throws Exception {
         // check replicate join without exception
         connectContext.getSessionVariable().setEnableReplicationJoin(true);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -484,7 +484,7 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
         Assert.assertTrue(planFragment.contains("rollup: bitmap_mv"));
     }
 
-    @Test
+    // todo(ywb) disable replicate join temporarily
     public void testReplicatedJoin() throws Exception {
         connectContext.getSessionVariable().setEnableReplicationJoin(true);
         String sql = "select s_name, s_address from supplier, nation where s_suppkey in " +


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [x] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
choose replicate join is not the best plan in most cases, such as bucket shuffle may be a better choice, so we disable replicate join  temporarily