### PR TITLE
Fix hang in select into outfile

### DIFF
--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -542,7 +542,7 @@ Status FragmentMgr::trigger_profile_report(const PTriggerProfileReportRequest* r
                 std::lock_guard<std::mutex> lock(_lock);
                 auto iter = _fragment_map.find(id);
                 if (iter != _fragment_map.end()) {
-                    need_report_exec_states.emplace_back(iter->second->executor());
+                    need_report_exec_states.emplace_back(iter->second);
                 }
             }
         }
@@ -550,7 +550,7 @@ Status FragmentMgr::trigger_profile_report(const PTriggerProfileReportRequest* r
         std::lock_guard<std::mutex> lock(_lock);
         auto iter = _fragment_map.begin();
         for (; iter != _fragment_map.end(); iter++) {
-            need_report_exec_states.emplace_back(iter->second->executor());
+            need_report_exec_states.emplace_back(iter->second);
         }
     }
 

--- a/be/src/runtime/fragment_mgr.h
+++ b/be/src/runtime/fragment_mgr.h
@@ -90,7 +90,7 @@ public:
                                        std::vector<TScanColumnDesc>* selected_columns);
 
 private:
-    void exec_actual(std::shared_ptr<FragmentExecState>* exec_state, const FinishCallback& cb);
+    void exec_actual(std::shared_ptr<FragmentExecState> exec_state, const FinishCallback& cb);
 
     // This is input params
     ExecEnv* _exec_env;


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3350 

## Problem Summary(Required) ：
now the parameter of FragmentMgr::exec_actual was a pointer of
`std::shared_ptr<FragmentExecState>`. which will bring two problems

1. wild pointer
```
        auto exec_state_iter = _fragment_map.insert(std::make_pair(fragment_instance_id, exec_state));
        // if _fragment_map resize in another thread. exec_state_ptr
        // will be a wild pointer
        exec_state_ptr = &exec_state_iter.first->second;
```
2. did too much work when hold a lock
```
        std::lock_guard<std::mutex> lock(_lock);
        auto iter = _fragment_map.find(exec_state->fragment_instance_id());
        // when we erase iter from _fragment_map.
        // FragmentExecState's destructor will be called. will may hold
        // lock too much time
        if (iter != _fragment_map.end()) {
            _fragment_map.erase(iter);
```
