### PR TITLE
Support colocate table for RestoreJob

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
@@ -278,6 +278,15 @@ public class ColocateTableIndex implements Writable {
         }
     }
 
+    public boolean isGroupExist(String fullGroupName) {
+        readLock();
+        try {
+            return groupName2Id.containsKey(fullGroupName);
+        } finally {
+            readUnlock();
+        }
+    }
+
     public boolean isSameGroup(long table1, long table2) {
         readLock();
         try {
@@ -374,6 +383,23 @@ public class ColocateTableIndex implements Writable {
                 sets.add(Sets.newHashSet(backends));
             }
             return sets;
+        } finally {
+            readUnlock();
+        }
+    }
+
+    public List<List<Long>> getBackendsPerBucketSeq(String fullGroupName) {
+        readLock();
+        try {
+            GroupId groupId = groupName2Id.get(fullGroupName);
+            if (groupId == null) {
+                return Lists.newArrayList();
+            }
+            List<List<Long>> backendsPerBucketSeq = group2BackendsPerBucketSeq.get(groupId);
+            if (backendsPerBucketSeq == null) {
+                return Lists.newArrayList();
+            }
+            return backendsPerBucketSeq;
         } finally {
             readUnlock();
         }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
At the PENDING stage:
1. determine if the colocate group already exists, and if so, check if the restored table matches the distribution info and replication number of the existing colocate group.
2. When creating the replica of a table, the distribution of backends should be the same as in the colocate group. 

At the COMMITTING stage:
Add the table to the colocate group.

Key points:
If the colocate does not exist in the system, creates the replicas of all partitions with any backends sequence at PENDING stage, and creates a new colocate group at the COMMITTING stage,  and then set the backends sequence of the PENDING stage to the colocate group.