### PR TITLE
Fix multi-aggregate function on arithmetic expression bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -105,7 +105,6 @@ public class ExpressionAnalyzer {
         private final ConnectContext session;
         private final Catalog catalog;
 
-
         public Visitor(AnalyzeState analyzeState, Catalog catalog, ConnectContext session) {
             this.analyzeState = analyzeState;
             this.session = session;
@@ -284,7 +283,7 @@ public class ExpressionAnalyzer {
                     // (both precision and and scale are -1, only used in function instance resolution), it's
                     // illegal for a function and expression to has a wildcard decimal type as its type in BE,
                     // so here substitute wildcard decimal types with real decimal types.
-                    Function newFn = new Function(fn.getFunctionName(), args, resultType, fn.hasVarArgs());
+                    Function newFn = new ScalarFunction(fn.getFunctionName(), args, resultType, fn.hasVarArgs());
                     node.setType(resultType);
                     node.setFn(newFn);
                     return null;
@@ -620,7 +619,6 @@ public class ExpressionAnalyzer {
             }
             return fn;
         }
-
 
         @Override
         public Void visitGroupingFunctionCall(GroupingFunctionCallExpr node, Scope scope) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -5740,4 +5740,12 @@ public class PlanFragmentTest extends PlanTestBase {
                 "         1 | 2 | 3\n" +
                 "     limit: 1"));
     }
+
+    @Test
+    public void testArithmeticDecimalReuse() throws Exception {
+        String sql = "select t1a, sum(id_decimal * t1f), sum(id_decimal * t1f)" +
+                "from test_all_type group by t1a";
+        String plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("OUTPUT EXPRS:1: t1a | 12: sum | 12: sum"));
+    }
 }


### PR DESCRIPTION
…uble

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3459

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Bug:
```
mysql> explain SELECT id
    , SUM(id_decimal * id_double)
    , SUM(id_decimal * id_double)
FROM all_type;
ERROR 1064 (HY000): Unknown error
```

the reason about:
1. `id_decimal * id_double` use `new Function` when analyze select expression
2. The common type of decimal and double is double, then children of expression will set type to double
3. But `SUM(id_decimal * id_double)` use `Expr.getBuiltinFunction`(return a scalar function) when analyze aggregate expression, because the function children type was set to double not decimal.
4. The select expression can't find aggregate output expression when generate project node, becuase the arithmetic function is different(Function vs ScalarFunction)