### PR TITLE
Preempt driver and scan dispatcher

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -645,6 +645,9 @@ CONF_Int64(pipeline_yield_max_chunks_moved, "100");
 // yield PipelineDriver when maximum time in nano-seconds has spent
 // in current execution round.
 CONF_Int64(pipeline_yield_max_time_spent, "100000000");
+// yield PipelineDriver when maximum time in nano-seconds has spent in current execution round,
+// if it runs in the dispatcher owned by other workgroup, which has running drivers.
+CONF_Int64(pipeline_yield_preempt_max_time_spent, "20000000");
 // the number of scan threads pipeline engine.
 CONF_Int64(pipeline_scan_thread_pool_thread_num, "0");
 // queue size of scan thread pool for pipeline engine.

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -656,6 +656,9 @@ CONF_Int64(pipeline_scan_thread_pool_queue_size, "102400");
 CONF_Int64(pipeline_scan_max_tasks_per_operator, "4");
 // The max number of io tasks for each scan operator.
 CONF_Int64(pipeline_scan_task_yield_max_tims_spent, "100000000");
+// yield scan io task when maximum time in nano-seconds has spent in current execution round,
+// if it runs in the dispatcher owned by other workgroup, which has running drivers.
+CONF_Int64(pipeline_scan_task_yield_preempt_max_time_spent, "20000000");
 // the number of execution threads for pipeline engine.
 CONF_Int64(pipeline_exec_thread_pool_thread_num, "0");
 // The max schedule period for adjusting io weight of each workgroup.

--- a/be/src/exec/pipeline/chunk_source.h
+++ b/be/src/exec/pipeline/chunk_source.h
@@ -10,7 +10,14 @@
 #include "util/exclusive_ptr.h"
 
 namespace starrocks {
+
 class RuntimeState;
+
+namespace workgroup {
+class WorkGroup;
+using WorkGroupPtr = std::shared_ptr<WorkGroup>;
+} // namespace workgroup
+
 namespace pipeline {
 
 class ChunkSource {
@@ -36,7 +43,8 @@ public:
 
     virtual Status buffer_next_batch_chunks_blocking(size_t chunk_size, bool& can_finish) = 0;
     virtual Status buffer_next_batch_chunks_blocking_for_workgroup(size_t chunk_size, bool& can_finish,
-                                                                   size_t* num_read_chunks) = 0;
+                                                                   size_t* num_read_chunks, int dispatcher_id,
+                                                                   workgroup::WorkGroupPtr running_wg) = 0;
 
 protected:
     // The morsel will own by pipeline driver

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -279,7 +279,7 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
 
     if (wg != nullptr) {
         for (auto& driver : _fragment_ctx->drivers()) {
-            driver->set_workgroup(wg.get());
+            driver->set_workgroup(wg);
         }
     }
 

--- a/be/src/exec/pipeline/olap_chunk_source.h
+++ b/be/src/exec/pipeline/olap_chunk_source.h
@@ -17,10 +17,18 @@
 #include "storage/vectorized/tablet_reader.h"
 
 namespace starrocks {
+
 class SlotDescriptor;
+
 namespace vectorized {
 class RuntimeFilterProbeCollector;
 }
+
+namespace workgroup {
+class WorkGroup;
+using WorkGroupPtr = std::shared_ptr<WorkGroup>;
+} // namespace workgroup
+
 namespace pipeline {
 
 class OlapChunkSource final : public ChunkSource {
@@ -61,8 +69,9 @@ public:
     StatusOr<vectorized::ChunkPtr> get_next_chunk_from_buffer() override;
 
     Status buffer_next_batch_chunks_blocking(size_t chunk_size, bool& can_finish) override;
-    Status buffer_next_batch_chunks_blocking_for_workgroup(size_t chunk_size, bool& can_finish,
-                                                           size_t* num_read_chunks) override;
+    Status buffer_next_batch_chunks_blocking_for_workgroup(size_t chunk_size, bool& can_finish, size_t* num_read_chunks,
+                                                           int dispatcher_id,
+                                                           workgroup::WorkGroupPtr running_wg) override;
 
 private:
     Status _get_tablet(const TInternalScanRange* scan_range);

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -20,7 +20,8 @@ namespace starrocks {
 
 namespace workgroup {
 class WorkGroup;
-}
+using WorkGroupPtr = std::shared_ptr<WorkGroup>;
+} // namespace workgroup
 
 namespace pipeline {
 
@@ -168,7 +169,7 @@ public:
     DriverPtr clone() { return std::make_shared<PipelineDriver>(*this); }
     void set_morsel_queue(MorselQueuePtr morsel_queue) { _morsel_queue = std::move(morsel_queue); }
     Status prepare(RuntimeState* runtime_state);
-    StatusOr<DriverState> process(RuntimeState* runtime_state);
+    StatusOr<DriverState> process(RuntimeState* runtime_state, int dispatcher_id);
     void finalize(RuntimeState* runtime_state, DriverState state);
     DriverAcct& driver_acct() { return _driver_acct; }
     DriverState driver_state() const { return _state; }
@@ -340,7 +341,7 @@ public:
     std::string to_readable_string() const;
 
     workgroup::WorkGroup* workgroup();
-    void set_workgroup(workgroup::WorkGroup* wg);
+    void set_workgroup(workgroup::WorkGroupPtr wg);
 
     size_t get_dispatch_queue_index() const { return _dispatch_queue_index; }
     void set_dispatch_queue_index(size_t dispatch_queue_index) { _dispatch_queue_index = dispatch_queue_index; }
@@ -396,7 +397,7 @@ private:
 
     phmap::flat_hash_map<int32_t, OperatorStage> _operator_stages;
 
-    workgroup::WorkGroup* _workgroup = nullptr;
+    workgroup::WorkGroupPtr _workgroup = nullptr;
     // The index of QuerySharedDriverQueue{WithoutLock}._queues which this driver belongs to.
     size_t _dispatch_queue_index = 0;
 

--- a/be/src/exec/pipeline/pipeline_driver_dispatcher.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_dispatcher.cpp
@@ -50,12 +50,13 @@ void GlobalDriverDispatcher::finalize_driver(DriverRawPtr driver, RuntimeState* 
 }
 
 void GlobalDriverDispatcher::run() {
+    const int dispatcher_id = _next_id++;
     while (true) {
         if (_num_threads_setter.should_shrink()) {
             break;
         }
 
-        auto maybe_driver = this->_driver_queue->take();
+        auto maybe_driver = this->_driver_queue->take(dispatcher_id);
         if (maybe_driver.status().is_cancelled()) {
             return;
         }
@@ -89,7 +90,7 @@ void GlobalDriverDispatcher::run() {
 
             // query context has ready drivers to run, so extend its lifetime.
             query_ctx->extend_lifetime();
-            auto status = driver->process(runtime_state);
+            auto status = driver->process(runtime_state, dispatcher_id);
             this->_driver_queue->update_statistics(driver);
 
             if (!status.ok()) {

--- a/be/src/exec/pipeline/pipeline_driver_dispatcher.h
+++ b/be/src/exec/pipeline/pipeline_driver_dispatcher.h
@@ -59,6 +59,8 @@ private:
     std::unique_ptr<ThreadPool> _thread_pool;
     PipelineDriverPollerPtr _blocked_driver_poller;
     std::unique_ptr<ExecStateReporter> _exec_state_reporter;
+
+    std::atomic<int> _next_id = 0;
 };
 
 } // namespace pipeline

--- a/be/src/exec/pipeline/pipeline_driver_queue.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_queue.cpp
@@ -266,7 +266,7 @@ workgroup::WorkGroup* DriverQueueWithWorkGroup::_find_min_owner_wg(int dispatche
 
     auto owner_wgs = workgroup::WorkGroupManager::instance()->get_owners_of_driver_dispatcher(dispatcher_id);
     if (owner_wgs != nullptr) {
-        for (auto wg : *owner_wgs) {
+        for (const auto& wg : *owner_wgs) {
             if (_ready_wgs.find(wg.get()) != _ready_wgs.end() &&
                 (min_wg == nullptr || min_vruntime_ns > wg->get_vruntime_ns())) {
                 min_wg = wg.get();

--- a/be/src/exec/pipeline/pipeline_driver_queue.h
+++ b/be/src/exec/pipeline/pipeline_driver_queue.h
@@ -29,7 +29,7 @@ public:
     virtual void put_back_from_dispatcher(const DriverRawPtr driver) = 0;
     virtual void put_back_from_dispatcher(const std::vector<DriverRawPtr>& drivers) = 0;
 
-    virtual StatusOr<DriverRawPtr> take() = 0;
+    virtual StatusOr<DriverRawPtr> take(int dispatcher_id) = 0;
 
     // Update statistics of the driver's workgroup,
     // when yielding the driver in the dispatcher thread.
@@ -84,7 +84,7 @@ public:
     void update_statistics(const DriverRawPtr driver) override;
 
     // return nullptr if queue is closed;
-    StatusOr<DriverRawPtr> take() override;
+    StatusOr<DriverRawPtr> take(int dispatcher_id) override;
 
     size_t size() override { return 0; }
 
@@ -119,7 +119,7 @@ public:
     void put_back_from_dispatcher(const std::vector<DriverRawPtr>& drivers) override;
 
     // return nullptr if queue is closed;
-    StatusOr<DriverRawPtr> take() override;
+    StatusOr<DriverRawPtr> take(int dispatcher_id) override;
 
     void update_statistics(const DriverRawPtr driver) override;
 
@@ -156,7 +156,7 @@ public:
 
     // Firstly, select the work group with the minimum vruntime.
     // Secondly, select the proper driver from the driver queue of this work group.
-    StatusOr<DriverRawPtr> take() override;
+    StatusOr<DriverRawPtr> take(int dispatcher_id) override;
 
     void update_statistics(const DriverRawPtr driver) override;
 
@@ -170,6 +170,7 @@ private:
     template <bool from_dispatcher>
     void _put_back(const DriverRawPtr driver);
     // This method should be guarded by the outside _global_mutex.
+    workgroup::WorkGroup* _find_min_owner_wg(int dispatcher_id);
     workgroup::WorkGroup* _find_min_wg();
     // The ideal runtime of a work group is the weighted average of the schedule period.
     int64_t _ideal_runtime_ns(workgroup::WorkGroup* wg);

--- a/be/src/exec/workgroup/io_dispatcher.cpp
+++ b/be/src/exec/workgroup/io_dispatcher.cpp
@@ -26,17 +26,18 @@ void IoDispatcher::change_num_threads(int32_t num_threads) {
 }
 
 void IoDispatcher::run() {
+    const int dispatcher_id = _next_id++;
     while (true) {
         if (_num_threads_setter.should_shrink()) {
             break;
         }
 
-        auto maybe_task = WorkGroupManager::instance()->pick_next_task_for_io();
+        auto maybe_task = WorkGroupManager::instance()->pick_next_task_for_io(dispatcher_id);
         if (maybe_task.status().is_cancelled()) {
             return;
         }
 
-        maybe_task.value().work_function();
+        maybe_task.value()(dispatcher_id);
     }
 }
 

--- a/be/src/exec/workgroup/io_dispatcher.h
+++ b/be/src/exec/workgroup/io_dispatcher.h
@@ -25,6 +25,7 @@ private:
 private:
     LimitSetter _num_threads_setter;
     std::unique_ptr<ThreadPool> _thread_pool;
+    std::atomic<int> _next_id = 0;
 };
 
 } // namespace workgroup

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -195,6 +195,9 @@ void WorkGroup::estimate_trend_factor_period() {
     // If it is positive, it means that its resources are sufficient and can be reduced by a fraction
     //_diff_factor = get_cpu_expected_use_ratio() - _expect_factor;
     _diff_factor = _select_factor - _expect_factor;
+
+    _decrease_chunk_num_period = 1;
+    _increase_chunk_num_period = 1;
 }
 
 size_t WorkGroup::io_task_queue_size() {

--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -221,7 +221,7 @@ private:
 
 class DispatcherOwnerManager {
 public:
-    DispatcherOwnerManager(int num_total_dispatchers);
+    explicit DispatcherOwnerManager(int num_total_dispatchers);
     ~DispatcherOwnerManager() = default;
 
     // Disable copy/move ctor and assignment.
@@ -302,8 +302,8 @@ private:
     std::atomic<int64_t> _sum_cpu_runtime_ns = 0;
     std::atomic<int64_t> _sum_unadjusted_cpu_runtime_ns = 0;
 
-    DispatcherOwnerManager _driver_dispatcher_owner_manager;
-    DispatcherOwnerManager _io_dispatcher_owner_manager;
+    std::unique_ptr<DispatcherOwnerManager> _driver_dispatcher_owner_manager;
+    std::unique_ptr<DispatcherOwnerManager> _io_dispatcher_owner_manager;
 };
 
 class DefaultWorkGroupInitialization {

--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -23,9 +23,12 @@ using seconds = std::chrono::seconds;
 using milliseconds = std::chrono::microseconds;
 using steady_clock = std::chrono::steady_clock;
 using std::chrono::duration_cast;
+
 class WorkGroup;
+class DispatcherOwnerManager;
 class WorkGroupManager;
 using WorkGroupPtr = std::shared_ptr<WorkGroup>;
+using WorkGroupPtrSet = std::unordered_set<WorkGroupPtr>;
 
 class WorkGroupQueue {
 public:
@@ -70,7 +73,6 @@ private:
     int _remaining_schedule_num_period = 0;
 };
 
-class WorkGroupManager;
 using WorkGroupType = TWorkGroupType::type;
 // WorkGroup is the unit of resource isolation, it has {CPU, Memory, Concurrency} quotas which limit the
 // resource usage of the queries belonging to the WorkGroup. Each user has be bound to a WorkGroup, when
@@ -144,6 +146,8 @@ public:
     // decrease num_driver when the driver is detached from the workgroup
     void decrease_num_drivers() { --_num_drivers; }
 
+    int num_drivers() const { return _num_drivers; }
+
     // mark the workgroup is deleted, but at the present, it can not be removed from WorkGroupManager, because
     // 1. there exists pending drivers
     // 2. there is a race condition that a driver is attached to the workgroup after it is marked del.
@@ -213,6 +217,32 @@ private:
     int64_t _vacuum_ttl = std::numeric_limits<int64_t>::max();
 };
 
+class DispatcherOwnerManager {
+public:
+    DispatcherOwnerManager(int num_total_dispatchers);
+    ~DispatcherOwnerManager() = default;
+
+    // Disable copy/move ctor and assignment.
+    DispatcherOwnerManager(const DispatcherOwnerManager&) = delete;
+    DispatcherOwnerManager& operator=(const DispatcherOwnerManager&) = delete;
+    DispatcherOwnerManager(DispatcherOwnerManager&&) = delete;
+    DispatcherOwnerManager& operator=(DispatcherOwnerManager&&) = delete;
+
+    std::shared_ptr<WorkGroupPtrSet> get_owners(int dispatcher_id) const {
+        return _dispatcher_id2owner_wgs[_index % 2][dispatcher_id];
+    }
+
+    void reassign_to_wgs(const std::unordered_map<int128_t, WorkGroupPtr>& workgroups, int sum_cpu_limit);
+
+    bool should_yield(int dispatcher_id, const WorkGroupPtr& running_wg) const;
+
+private:
+    const int _num_total_dispatchers;
+    // Use two _dispatcher_id2owner_wgs and _index to insulate read and write.
+    std::vector<std::shared_ptr<WorkGroupPtrSet>> _dispatcher_id2owner_wgs[2]{};
+    std::atomic<size_t> _index = 0;
+};
+
 // WorkGroupManager is a singleton used to manage WorkGroup instances in BE, it has an io queue and a cpu queues for
 // pick next workgroup for computation and launching io tasks.
 class WorkGroupManager {
@@ -243,12 +273,20 @@ public:
     std::vector<TWorkGroup> list_workgroups();
     std::vector<TWorkGroup> list_all_workgroups();
 
+    std::shared_ptr<WorkGroupPtrSet> get_owners_of_driver_dispatcher(int dispatcher_id);
+    bool should_yield_driver_dispatcher(int dispatcher_id, WorkGroupPtr running_wg);
+
 private:
     // {create, alter,delete}_workgroup_unlocked is used to replay WorkGroupOps.
     // WorkGroupManager::_mutex is held when invoking these method.
     void create_workgroup_unlocked(const WorkGroupPtr& wg);
     void alter_workgroup_unlocked(const WorkGroupPtr& wg);
     void delete_workgroup_unlocked(const WorkGroupPtr& wg);
+
+    // Label each dispatcher thread to a specific workgroup by cpu limit.
+    // WorkGroupManager::_mutex is held when invoking this method.
+    void reassign_dispatcher_to_wgs();
+
     std::shared_mutex _mutex;
     std::unordered_map<int128_t, WorkGroupPtr> _workgroups;
     std::unordered_map<int64_t, int64_t> _workgroup_versions;
@@ -258,6 +296,8 @@ private:
     std::atomic<size_t> _sum_cpu_limit = 0;
     std::atomic<int64_t> _sum_cpu_runtime_ns = 0;
     std::atomic<int64_t> _sum_unadjusted_cpu_runtime_ns = 0;
+
+    DispatcherOwnerManager _driver_dispatcher_owner_manager;
 };
 
 class DefaultWorkGroupInitialization {

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -154,7 +154,7 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths) {
     _driver_dispatcher->initialize(max_thread_num);
 
     std::unique_ptr<ThreadPool> wg_driver_dispatcher_thread_pool;
-    RETURN_IF_ERROR(ThreadPoolBuilder("pip_wg_dispatcher") // pipeline dispatcher
+    RETURN_IF_ERROR(ThreadPoolBuilder("wg_dispatcher") // pipeline dispatcher
                             .set_min_threads(0)
                             .set_max_threads(max_thread_num)
                             .set_max_queue_size(1000)

--- a/be/src/util/threadpool.h
+++ b/be/src/util/threadpool.h
@@ -109,6 +109,7 @@ public:
 
 private:
     friend class ThreadPool;
+    // The max length of _name is 15 limited by linux.
     const std::string _name;
     int _min_threads;
     int _max_threads;

--- a/be/test/exec/pipeline/pipeline_test_base.cpp
+++ b/be/test/exec/pipeline/pipeline_test_base.cpp
@@ -120,7 +120,7 @@ void PipelineTestBase::_prepare() {
 
     auto wg = workgroup::WorkGroupManager::instance()->get_default_workgroup();
     for (auto& driver : _fragment_ctx->drivers()) {
-        driver->set_workgroup(wg.get());
+        driver->set_workgroup(wg);
     }
 }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Problem Summary：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Assign each driver/io dispatcher thread to workgroups according to cpu limit, so each dispatcher thread has as its owner wg list, which is maintained by `DispatcherOwnerManager::_dispatcher_id2owner_wgs`.

When driver/io dispatcher takes a task to run, it first tries to take from the owner workgroup. 
And a driver/io task will yield, when it is run in the thread belonging to other workgroups, which have running drivers.
