### PR TITLE
Add limit to reduce the input rowsets for base compaction

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -268,7 +268,8 @@ CONF_Bool(disable_storage_page_cache, "true");
 CONF_Bool(disable_column_pool, "false");
 
 CONF_mInt32(base_compaction_check_interval_seconds, "60");
-CONF_mInt64(base_compaction_num_cumulative_deltas, "5");
+CONF_mInt64(min_base_compaction_num_singleton_deltas, "5");
+CONF_mInt64(max_base_compaction_num_singleton_deltas, "100");
 CONF_Int32(base_compaction_num_threads_per_disk, "1");
 CONF_mDouble(base_cumulative_delta_ratio, "0.3");
 CONF_mInt64(base_compaction_interval_seconds_since_last_operation, "86400");

--- a/be/test/storage/vectorized/column_predicate_test.cpp
+++ b/be/test/storage/vectorized/column_predicate_test.cpp
@@ -2177,7 +2177,7 @@ TEST(ColumnPredicateTest, test_convert_cmp_predicate) {
                 new_column_cmp_predicate(predicate, get_type_info(OLAP_FIELD_TYPE_BOOL), 0, "1"));
         const ColumnPredicate* new_p;
         ObjectPool op;
-        
+
         // different type
         {
             TypeInfoPtr new_type = get_type_info(OLAP_FIELD_TYPE_INT);
@@ -2208,12 +2208,13 @@ TEST(ColumnPredicateTest, test_convert_cmp_binary_predicate) {
     // clang-format on
 
     for (auto predicate : testcases) {
-        std::unique_ptr<ColumnPredicate> p(new_column_cmp_predicate(predicate, get_type_info(OLAP_FIELD_TYPE_VARCHAR), 0, "1"));
+        std::unique_ptr<ColumnPredicate> p(
+                new_column_cmp_predicate(predicate, get_type_info(OLAP_FIELD_TYPE_VARCHAR), 0, "1"));
 
         const ColumnPredicate* new_p;
         TypeInfoPtr new_type = get_type_info(OLAP_FIELD_TYPE_VARCHAR);
         ObjectPool op;
-        
+
         ASSERT_OK(p->convert_to(&new_p, new_type, &op));
         EXPECT_EQ(new_p->type(), p->type());
     }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3432 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Add configuration for base compaction, when get enough segments, do not pick more input rowsets from candidate rowsets.