### PR TITLE
fix: column predicate for bitmap index

### DIFF
--- a/be/src/storage/vectorized/column_predicate_cmp.cpp
+++ b/be/src/storage/vectorized/column_predicate_cmp.cpp
@@ -321,7 +321,7 @@ public:
         bool exact_match = false;
         Status st = iter->seek_dictionary(&this->_value, &exact_match);
         if (st.ok()) {
-            rowid_t seeked_ordinal = iter->current_ordinal();
+            rowid_t seeked_ordinal = iter->current_ordinal() + exact_match;
             range->add(Range(0, seeked_ordinal));
         } else if (st.is_not_found()) {
             range->add(Range(0, iter->bitmap_nums() - iter->has_null_bitmap()));
@@ -357,7 +357,7 @@ public:
         bool exact_match = false;
         Status st = iter->seek_dictionary(&this->_value, &exact_match);
         if (st.ok()) {
-            rowid_t seeked_ordinal = iter->current_ordinal() + exact_match;
+            rowid_t seeked_ordinal = iter->current_ordinal();
             range->add(Range(0, seeked_ordinal));
         } else if (st.is_not_found()) {
             range->add(Range(0, iter->bitmap_nums() - iter->has_null_bitmap()));


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
Fix the column predicate for bitmap index, calculate the wrong result for less and less equal predicate.



## Problem Summary(Required) ：
Related test case: 
- [test_create_bitmap_index.TestCreateBitmapIndex.test_bitmap_index_for_datetime]
- [test_drop_bitmap_index.TestDropBitmapIndex.test_drop_bitmap_index_for_datetime]
- [test_update_basic.TestUpdateBasic.test_bitmap_index]