### PR TITLE
[ResourceIsolation] add enable_resource_group session variable

### DIFF
--- a/be/src/exec/pipeline/fragment_context.h
+++ b/be/src/exec/pipeline/fragment_context.h
@@ -121,6 +121,10 @@ public:
     void prepare_pass_through_chunk_buffer();
     void destroy_pass_through_chunk_buffer();
 
+    void set_enable_resource_group() { _enable_resource_group = true; }
+
+    bool enable_resource_group() const { return _enable_resource_group; }
+
 private:
     // Id of this query
     TUniqueId _query_id;
@@ -158,6 +162,8 @@ private:
     std::atomic<Status*> _final_status;
     std::atomic<bool> _cancel_flag;
     Status _s_status;
+
+    bool _enable_resource_group = false;
 };
 
 class FragmentContextManager {

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -350,11 +350,11 @@ std::string PipelineDriver::to_readable_string() const {
 
 starrocks::workgroup::WorkGroup* PipelineDriver::workgroup() {
     DCHECK(_workgroup != nullptr);
-    return _workgroup;
+    return _workgroup.get();
 }
 
-void PipelineDriver::set_workgroup(starrocks::workgroup::WorkGroup* wg) {
-    this->_workgroup = wg;
+void PipelineDriver::set_workgroup(workgroup::WorkGroupPtr wg) {
+    this->_workgroup = std::move(wg);
 }
 
 bool PipelineDriver::_check_fragment_is_canceled(RuntimeState* runtime_state) {

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -15,11 +15,11 @@
 #include "exec/pipeline/query_context.h"
 #include "exec/pipeline/runtime_filter_types.h"
 #include "exec/pipeline/source_operator.h"
+#include "exec/workgroup/work_group_fwd.h"
 #include "util/phmap/phmap.h"
+
 namespace starrocks {
-namespace workgroup {
-class WorkGroup;
-}
+
 namespace pipeline {
 
 class PipelineDriver;
@@ -338,9 +338,9 @@ public:
 
     std::string to_readable_string() const;
 
-    starrocks::workgroup::WorkGroup* workgroup();
+    workgroup::WorkGroup* workgroup();
 
-    void set_workgroup(starrocks::workgroup::WorkGroup* wg);
+    void set_workgroup(workgroup::WorkGroupPtr wg);
 
 private:
     // check whether fragment is cancelled. It is used before pull_chunk and push_chunk.

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -385,7 +385,7 @@ private:
 
     phmap::flat_hash_map<int32_t, OperatorStage> _operator_stages;
 
-    starrocks::workgroup::WorkGroup* _workgroup = nullptr;
+    workgroup::WorkGroupPtr _workgroup = nullptr;
 
     // metrics
     RuntimeProfile::Counter* _total_timer = nullptr;

--- a/be/src/exec/pipeline/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan_operator.cpp
@@ -219,6 +219,10 @@ Status ScanOperator::_pickup_morsel(RuntimeState* state, int chunk_source_index)
     return Status::OK();
 }
 
+void ScanOperator::set_workgroup(workgroup::WorkGroupPtr wg) {
+    _workgroup = std::move(wg);
+}
+
 Status ScanOperatorFactory::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(OperatorFactory::prepare(state));
     RETURN_IF_ERROR(Expr::prepare(_conjunct_ctxs, state));

--- a/be/src/exec/pipeline/scan_operator.h
+++ b/be/src/exec/pipeline/scan_operator.h
@@ -5,15 +5,18 @@
 #include <optional>
 
 #include "exec/pipeline/source_operator.h"
+#include "exec/workgroup/work_group_fwd.h"
 #include "exprs/vectorized/runtime_filter_bank.h"
 #include "runtime/global_dicts.h"
 #include "util/blocking_queue.hpp"
 #include "util/priority_thread_pool.hpp"
 
 namespace starrocks {
+
 namespace vectorized {
 class RuntimeFilterProbeCollector;
 }
+
 namespace pipeline {
 
 class ScanOperator final : public SourceOperator {
@@ -44,6 +47,8 @@ public:
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
     void set_io_threads(PriorityThreadPool* io_threads) { _io_threads = io_threads; }
 
+    void set_workgroup(workgroup::WorkGroupPtr wg);
+
 private:
     const size_t _buffer_size = config::pipeline_io_buffer_size;
     const int _max_io_tasks_per_op = config::pipeline_scan_max_tasks_per_operator;
@@ -71,6 +76,8 @@ private:
     std::atomic<int> _num_running_io_tasks = 0;
     std::vector<std::atomic<bool>> _is_io_task_running;
     std::vector<ChunkSourcePtr> _chunk_sources;
+
+    workgroup::WorkGroupPtr _workgroup = nullptr;
 };
 
 class ScanOperatorFactory final : public SourceOperatorFactory {

--- a/be/src/exec/workgroup/work_group_fwd.h
+++ b/be/src/exec/workgroup/work_group_fwd.h
@@ -1,0 +1,12 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#pragma once
+
+namespace starrocks::workgroup {
+
+class WorkGroup;
+class WorkGroupManager;
+
+using WorkGroupPtr = std::shared_ptr<WorkGroup>;
+
+} // namespace starrocks::workgroup

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -1952,7 +1952,7 @@ public class Coordinator {
                         }
                         params.setPipeline_dop(fragment.getPipelineDop());
 
-                        boolean enableResourceGroup = ConnectContext.get().getSessionVariable().isEnableResourceGroup();
+                        boolean enableResourceGroup = sessionVariable.isEnableResourceGroup();
                         params.setEnable_resource_group(enableResourceGroup);
                         // TODO: set params.workgroup, when enableResourceGroup is true.
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -1951,6 +1951,10 @@ public class Coordinator {
                             params.getQuery_options().setBatch_size(SessionVariable.PIPELINE_BATCH_SIZE);
                         }
                         params.setPipeline_dop(fragment.getPipelineDop());
+
+                        boolean enableResourceGroup = ConnectContext.get().getSessionVariable().isEnableResourceGroup();
+                        params.setEnable_resource_group(enableResourceGroup);
+                        // TODO: set params.workgroup, when enableResourceGroup is true.
                     }
 
                     if (sessionVariable.isEnableExchangePassThrough()) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -115,6 +115,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // them do the real work on core.
     public static final String ENABLE_PIPELINE_ENGINE = "enable_pipeline_engine";
 
+    // Use resource group. It will influence the CPU schedule, I/O scheduler, and
+    // memory limit etc. in BE.
+    public static final String ENABLE_RESOURCE_GROUP = "enable_resource_group";
+
     public static final String PIPELINE_DOP = "pipeline_dop";
 
     public static final String PIPELINE_PROFILE_MODE = "pipeline_profile_mode";
@@ -181,6 +185,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = ENABLE_PIPELINE_ENGINE)
     private boolean enablePipelineEngine = false;
+
+    @VariableMgr.VarAttr(name = ENABLE_RESOURCE_GROUP)
+    private boolean enableResourceGroup = false;
 
     // max memory used on every backend.
     @VariableMgr.VarAttr(name = EXEC_MEM_LIMIT)
@@ -758,6 +765,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setEnablePipelineEngine(boolean enablePipelineEngine) {
         this.enablePipelineEngine = enablePipelineEngine;
+    }
+
+    public boolean isEnableResourceGroup() {
+        return enableResourceGroup;
+    }
+
+    public void setEnableResourceGroup(boolean enableResourceGroup) {
+        this.enableResourceGroup = enableResourceGroup;
     }
 
     public int getPipelineDop() {

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -297,7 +297,9 @@ struct TExecPlanFragmentParams {
   50: optional bool is_pipeline
   51: optional i32 pipeline_dop
   52: optional map<Types.TPlanNodeId, i32> per_scan_node_dop
+
   53: optional WorkGroup.TWorkGroup workgroup
+  54: optional bool enable_resource_group
 }
 
 struct TExecPlanFragmentResult {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] others

## Problem Summary：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Add `enable_resource_group` session variable, and pass it to `TExecPlanFragmentParams::enable_resource_group`.
When it is true, `wg` must be set (this is to do in the future PR), and this `wg` will be passed to `PipelineDriver` and `ScanOperator`.

