### PR TITLE
phmap set to old capacity when resize failed

### DIFF
--- a/be/src/util/phmap/phmap.h
+++ b/be/src/util/phmap/phmap.h
@@ -1847,7 +1847,12 @@ private:
         auto* old_slots = slots_;
         const size_t old_capacity = capacity_;
         capacity_ = new_capacity;
-        initialize_slots();
+        try {
+            initialize_slots();
+        } catch (std::bad_alloc const& e) {
+            capacity_ = old_capacity;
+            throw e;
+        }
 
         for (size_t i = 0; i != old_capacity; ++i) {
             if (IsFull(old_ctrl[i])) {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3326 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

when phmap resize failed caused by memory allocate failed, the capacity is already to new capacity.

the end() interface use the new capacity is invalid;

```
    iterator begin() {
        auto it = iterator_at(0);
        it.skip_empty_or_deleted();
        return it;
    }
    iterator end() {
#if PHMAP_BIDIRECTIONAL
        return iterator_at(capacity_);
#else
        return {ctrl_ + capacity_};
#endif
    }
```

```
            auto it = hash_map_with_key->hash_map.begin();
            auto end = hash_map_with_key->hash_map.end();
            while (it != end) {
                for (int i = 0; i < _agg_functions.size(); i++) {
                    _agg_functions[i]->destroy(_agg_fn_ctxs[i], it->second + _agg_states_offsets[i]);
                }
                ++it;
            }
```
