### PR TITLE
[ResourceIsolation ] add driver dispatcher for workgroup

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -286,9 +286,17 @@ Status FragmentExecutor::execute(ExecEnv* exec_env) {
     for (const auto& driver : _fragment_ctx->drivers()) {
         RETURN_IF_ERROR(driver->prepare(_fragment_ctx->runtime_state()));
     }
-    for (const auto& driver : _fragment_ctx->drivers()) {
-        exec_env->driver_dispatcher()->dispatch(driver.get());
+
+    if (_fragment_ctx->enable_resource_group()) {
+        for (const auto& driver : _fragment_ctx->drivers()) {
+            exec_env->wg_driver_dispatcher()->dispatch(driver.get());
+        }
+    } else {
+        for (const auto& driver : _fragment_ctx->drivers()) {
+            exec_env->driver_dispatcher()->dispatch(driver.get());
+        }
     }
+
     return Status::OK();
 }
 

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -13,6 +13,13 @@
 #include "runtime/runtime_state.h"
 
 namespace starrocks::pipeline {
+
+PipelineDriver::~PipelineDriver() noexcept {
+    if (_workgroup != nullptr) {
+        _workgroup->decrease_num_drivers();
+    }
+}
+
 Status PipelineDriver::prepare(RuntimeState* runtime_state) {
     _runtime_state = runtime_state;
 
@@ -32,7 +39,7 @@ Status PipelineDriver::prepare(RuntimeState* runtime_state) {
     _schedule_counter = ADD_COUNTER(_runtime_profile, "ScheduleCounter", TUnit::UNIT);
     _schedule_effective_counter = ADD_COUNTER(_runtime_profile, "ScheduleEffectiveCounter", TUnit::UNIT);
     _schedule_rows_per_chunk = ADD_COUNTER(_runtime_profile, "ScheduleAccumulatedRowsPerChunk", TUnit::UNIT);
-    _schedule_accumulated_chunk_moved = ADD_COUNTER(_runtime_profile, "ScheduleAccumulatedChunkMoved", TUnit::UNIT);
+    _schedule_accumulated_chunks_moved = ADD_COUNTER(_runtime_profile, "ScheduleAccumulatedChunkMoved", TUnit::UNIT);
 
     DCHECK(_state == DriverState::NOT_READY);
     // fill OperatorWithDependency instances into _dependencies from _operators.
@@ -88,7 +95,7 @@ Status PipelineDriver::prepare(RuntimeState* runtime_state) {
     return Status::OK();
 }
 
-StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state) {
+StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state, int dispatcher_id) {
     SCOPED_TIMER(_active_timer);
     set_driver_state(DriverState::RUNNING);
     size_t total_chunks_moved = 0;
@@ -97,7 +104,7 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state) {
     while (true) {
         RETURN_IF_LIMIT_EXCEEDED(runtime_state, "Pipeline");
 
-        size_t num_chunk_moved = 0;
+        size_t num_chunks_moved = 0;
         bool should_yield = false;
         size_t num_operators = _operators.size();
         size_t new_first_unfinished = _first_unfinished;
@@ -124,6 +131,7 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state) {
                 }
 
                 if (_check_fragment_is_canceled(runtime_state)) {
+                    _update_statistics(total_chunks_moved, total_rows_moved, time_spent);
                     return _state;
                 }
 
@@ -141,6 +149,7 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state) {
                 }
 
                 if (_check_fragment_is_canceled(runtime_state)) {
+                    _update_statistics(total_chunks_moved, total_rows_moved, time_spent);
                     return _state;
                 }
 
@@ -163,7 +172,7 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state) {
                         COUNTER_UPDATE(next_op->_push_chunk_num_counter, 1);
                         COUNTER_UPDATE(next_op->_push_row_num_counter, row_num);
                     }
-                    num_chunk_moved += 1;
+                    num_chunks_moved += 1;
                     total_chunks_moved += 1;
                 }
 
@@ -184,6 +193,12 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state) {
                 should_yield = true;
                 break;
             }
+
+            if (_workgroup != nullptr && time_spent >= YIELD_PREEMPT_MAX_TIME_SPENT &&
+                workgroup::WorkGroupManager::instance()->should_yield_driver_dispatcher(dispatcher_id, _workgroup)) {
+                should_yield = true;
+                break;
+            }
         }
         // close finished operators and update _first_unfinished index
         for (auto i = _first_unfinished; i < new_first_unfinished; ++i) {
@@ -194,6 +209,7 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state) {
         if (sink_operator()->is_finished()) {
             finish_operators(runtime_state);
             set_driver_state(is_still_pending_finish() ? DriverState::PENDING_FINISH : DriverState::FINISH);
+            _update_statistics(total_chunks_moved, total_rows_moved, time_spent);
             return _state;
         }
 
@@ -201,11 +217,7 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state) {
         // should yield means that the CPU core is occupied the driver for a
         // very long time so that the driver should switch off the core and
         // give chance for another ready driver to run.
-        if (num_chunk_moved == 0 || should_yield) {
-            driver_acct().increment_schedule_times();
-            driver_acct().update_last_chunks_moved(total_chunks_moved);
-            driver_acct().update_accumulated_rows_moved(total_rows_moved);
-            driver_acct().update_last_time_spent(time_spent);
+        if (num_chunks_moved == 0 || should_yield) {
             if (is_precondition_block()) {
                 set_driver_state(DriverState::PRECONDITION_BLOCK);
             } else if (!sink_operator()->is_finished() && !sink_operator()->need_input()) {
@@ -215,6 +227,7 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state) {
             } else {
                 set_driver_state(DriverState::READY);
             }
+            _update_statistics(total_chunks_moved, total_rows_moved, time_spent);
             return _state;
         }
     }
@@ -294,7 +307,7 @@ void PipelineDriver::finalize(RuntimeState* runtime_state, DriverState state) {
     COUNTER_UPDATE(_schedule_counter, driver_acct().get_schedule_times());
     COUNTER_UPDATE(_schedule_effective_counter, driver_acct().get_schedule_effective_times());
     COUNTER_UPDATE(_schedule_rows_per_chunk, driver_acct().get_rows_per_chunk());
-    COUNTER_UPDATE(_schedule_accumulated_chunk_moved, driver_acct().get_accumulated_chunk_moved());
+    COUNTER_UPDATE(_schedule_accumulated_chunks_moved, driver_acct().get_accumulated_chunks_moved());
     _update_overhead_timer();
 
     // last root driver cancel the all drivers' execution and notify FE the
@@ -348,13 +361,14 @@ std::string PipelineDriver::to_readable_string() const {
     return ss.str();
 }
 
-starrocks::workgroup::WorkGroup* PipelineDriver::workgroup() {
+workgroup::WorkGroup* PipelineDriver::workgroup() {
     DCHECK(_workgroup != nullptr);
     return _workgroup.get();
 }
 
 void PipelineDriver::set_workgroup(workgroup::WorkGroupPtr wg) {
     this->_workgroup = std::move(wg);
+    this->_workgroup->increase_num_drivers();
 }
 
 bool PipelineDriver::_check_fragment_is_canceled(RuntimeState* runtime_state) {

--- a/be/src/exec/pipeline/pipeline_driver_dispatcher.h
+++ b/be/src/exec/pipeline/pipeline_driver_dispatcher.h
@@ -39,7 +39,7 @@ public:
 
 class GlobalDriverDispatcher final : public FactoryMethod<DriverDispatcher, GlobalDriverDispatcher> {
 public:
-    explicit GlobalDriverDispatcher(std::unique_ptr<ThreadPool> thread_pool);
+    GlobalDriverDispatcher(std::unique_ptr<ThreadPool> thread_pool, bool enable_resource_group);
     ~GlobalDriverDispatcher() override;
     void initialize(int32_t num_threads) override;
     void change_num_threads(int32_t num_threads) override;
@@ -53,10 +53,14 @@ private:
 
 private:
     LimitSetter _num_threads_setter;
+    const bool _enable_resource_group;
     std::unique_ptr<DriverQueue> _driver_queue;
+    // _thread_pool must be placed after _driver_queue, because worker threads in _thread_pool use _driver_queue.
     std::unique_ptr<ThreadPool> _thread_pool;
     PipelineDriverPollerPtr _blocked_driver_poller;
     std::unique_ptr<ExecStateReporter> _exec_state_reporter;
+
+    std::atomic<int> _next_id = 0;
 };
 
 } // namespace pipeline

--- a/be/src/exec/pipeline/pipeline_driver_queue.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_queue.cpp
@@ -88,6 +88,14 @@ StatusOr<DriverRawPtr> QuerySharedDriverQueue::take(int dispatcher_id) {
     return driver_ptr;
 }
 
+size_t QuerySharedDriverQueue::size() {
+    size_t size = 0;
+    for (const auto& sub_queue : _queues) {
+        size += sub_queue.queue.size();
+    }
+    return size;
+}
+
 void QuerySharedDriverQueue::update_statistics(const DriverRawPtr driver) {
     _queues[driver->get_dispatch_queue_index()].update_accu_time(driver);
 }

--- a/be/src/exec/pipeline/pipeline_driver_queue.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_queue.cpp
@@ -2,8 +2,11 @@
 
 #include "exec/pipeline/pipeline_driver_queue.h"
 
+#include "exec/workgroup/work_group.h"
 #include "gutil/strings/substitute.h"
+
 namespace starrocks::pipeline {
+
 void QuerySharedDriverQueue::close() {
     std::lock_guard<std::mutex> lock(_global_mutex);
     _is_closed = true;
@@ -11,10 +14,11 @@ void QuerySharedDriverQueue::close() {
 }
 
 void QuerySharedDriverQueue::put_back(const DriverRawPtr driver) {
-    int level = driver->driver_acct().get_level();
+    int level = driver->driver_acct().get_level() % QUEUE_SIZE;
+    driver->set_dispatch_queue_index(level);
     {
         std::lock_guard<std::mutex> lock(_global_mutex);
-        _queues[level % QUEUE_SIZE].queue.emplace(driver);
+        _queues[level].queue.emplace(driver);
         _cv.notify_one();
     }
 }
@@ -22,17 +26,28 @@ void QuerySharedDriverQueue::put_back(const DriverRawPtr driver) {
 void QuerySharedDriverQueue::put_back(const std::vector<DriverRawPtr>& drivers) {
     std::vector<int> levels(drivers.size());
     for (int i = 0; i < drivers.size(); i++) {
-        levels[i] = drivers[i]->driver_acct().get_level();
+        levels[i] = drivers[i]->driver_acct().get_level() % QUEUE_SIZE;
+        drivers[i]->set_dispatch_queue_index(levels[i]);
     }
 
     std::lock_guard<std::mutex> lock(_global_mutex);
     for (int i = 0; i < drivers.size(); i++) {
-        _queues[levels[i] % QUEUE_SIZE].queue.emplace(drivers[i]);
+        _queues[levels[i]].queue.emplace(drivers[i]);
         _cv.notify_one();
     }
 }
 
-StatusOr<DriverRawPtr> QuerySharedDriverQueue::take(size_t* queue_index) {
+void QuerySharedDriverQueue::put_back_from_dispatcher(const DriverRawPtr driver) {
+    // QuerySharedDriverQueue::put_back_from_dispatcher is identical to put_back.
+    put_back(driver);
+}
+
+void QuerySharedDriverQueue::put_back_from_dispatcher(const std::vector<DriverRawPtr>& drivers) {
+    // QuerySharedDriverQueue::put_back_from_dispatcher is identical to put_back.
+    put_back(drivers);
+}
+
+StatusOr<DriverRawPtr> QuerySharedDriverQueue::take(int dispatcher_id) {
     // -1 means no candidates; else has candidate.
     int queue_idx = -1;
     double target_accu_time = 0;
@@ -65,7 +80,6 @@ StatusOr<DriverRawPtr> QuerySharedDriverQueue::take(size_t* queue_index) {
             _cv.wait(lock);
         }
         // record queue's index to accumulate time for it.
-        *queue_index = queue_idx;
         driver_ptr = _queues[queue_idx].queue.front();
         _queues[queue_idx].queue.pop();
     }
@@ -74,8 +88,210 @@ StatusOr<DriverRawPtr> QuerySharedDriverQueue::take(size_t* queue_index) {
     return driver_ptr;
 }
 
-SubQuerySharedDriverQueue* QuerySharedDriverQueue::get_sub_queue(size_t index) {
-    return _queues + index;
+void QuerySharedDriverQueue::update_statistics(const DriverRawPtr driver) {
+    _queues[driver->get_dispatch_queue_index()].update_accu_time(driver);
+}
+
+void QuerySharedDriverQueueWithoutLock::put_back(const DriverRawPtr driver) {
+    _put_back(driver);
+}
+
+void QuerySharedDriverQueueWithoutLock::put_back(const std::vector<DriverRawPtr>& drivers) {
+    for (auto driver : drivers) {
+        _put_back(driver);
+    }
+}
+
+void QuerySharedDriverQueueWithoutLock::put_back_from_dispatcher(const DriverRawPtr driver) {
+    // QuerySharedDriverQueueWithoutLock::put_back_from_dispatcher is identical to put_back.
+    put_back(driver);
+}
+
+void QuerySharedDriverQueueWithoutLock::put_back_from_dispatcher(const std::vector<DriverRawPtr>& drivers) {
+    // QuerySharedDriverQueueWithoutLock::put_back_from_dispatcher is identical to put_back.
+    put_back(drivers);
+}
+
+StatusOr<DriverRawPtr> QuerySharedDriverQueueWithoutLock::take(int dispatcher_id) {
+    // -1 means no candidates; else has candidate.
+    int queue_idx = -1;
+    double target_accu_time = 0;
+    DriverRawPtr driver_ptr;
+
+    for (int i = 0; i < QUEUE_SIZE; ++i) {
+        // we just search for queue has element
+        if (!_queues[i].queue.empty()) {
+            double local_target_time = _queues[i].accu_time_after_divisor();
+            // if this is first queue that has element, we select it;
+            // else we choose queue that the execution time is less sufficient,
+            // and record time.
+            if (queue_idx < 0 || local_target_time < target_accu_time) {
+                target_accu_time = local_target_time;
+                queue_idx = i;
+            }
+        }
+    }
+
+    // Always return non-null driver, which is guaranteed be the callee, e.g. DriverQueueWithWorkGroup::take().
+    DCHECK(queue_idx >= 0);
+
+    driver_ptr = _queues[queue_idx].queue.front();
+    _queues[queue_idx].queue.pop();
+
+    --_size;
+
+    return driver_ptr;
+}
+
+void QuerySharedDriverQueueWithoutLock::update_statistics(const DriverRawPtr driver) {
+    _queues[driver->get_dispatch_queue_index()].update_accu_time(driver);
+}
+
+void QuerySharedDriverQueueWithoutLock::_put_back(const DriverRawPtr driver) {
+    int level = driver->driver_acct().get_level() % QUEUE_SIZE;
+    driver->set_dispatch_queue_index(level);
+    _queues[level].queue.emplace(driver);
+    ++_size;
+}
+
+void DriverQueueWithWorkGroup::close() {
+    std::lock_guard<std::mutex> lock(_global_mutex);
+    _is_closed = true;
+    _cv.notify_all();
+}
+
+void DriverQueueWithWorkGroup::put_back(const DriverRawPtr driver) {
+    std::lock_guard<std::mutex> lock(_global_mutex);
+    _put_back<false>(driver);
+}
+
+void DriverQueueWithWorkGroup::put_back(const std::vector<DriverRawPtr>& drivers) {
+    std::lock_guard<std::mutex> lock(_global_mutex);
+
+    for (const auto driver : drivers) {
+        _put_back<false>(driver);
+    }
+}
+
+void DriverQueueWithWorkGroup::put_back_from_dispatcher(const DriverRawPtr driver) {
+    std::lock_guard<std::mutex> lock(_global_mutex);
+    _put_back<true>(driver);
+}
+
+void DriverQueueWithWorkGroup::put_back_from_dispatcher(const std::vector<DriverRawPtr>& drivers) {
+    std::lock_guard<std::mutex> lock(_global_mutex);
+
+    for (const auto driver : drivers) {
+        _put_back<true>(driver);
+    }
+}
+
+StatusOr<DriverRawPtr> DriverQueueWithWorkGroup::take(int dispatcher_id) {
+    std::unique_lock<std::mutex> lock(_global_mutex);
+
+    if (_is_closed) {
+        return Status::Cancelled("Shutdown");
+    }
+
+    while (_ready_wgs.empty()) {
+        _cv.wait(lock);
+        if (_is_closed) {
+            return Status::Cancelled("Shutdown");
+        }
+    }
+
+    // Try to take driver from any owner workgroup first.
+    auto wg = _find_min_owner_wg(dispatcher_id);
+    if (wg == nullptr) {
+        // All the owner workgroups don't have ready drivers, so select the other workgroup.
+        wg = _find_min_wg();
+    }
+
+    if (wg->driver_queue()->size() == 1) {
+        _sum_cpu_limit -= wg->cpu_limit();
+        _ready_wgs.erase(wg);
+    }
+
+    return wg->driver_queue()->take(dispatcher_id);
+}
+
+void DriverQueueWithWorkGroup::update_statistics(const DriverRawPtr driver) {
+    std::unique_lock<std::mutex> lock(_global_mutex);
+
+    int64_t runtime_ns = driver->driver_acct().get_last_time_spent();
+    auto* wg = driver->workgroup();
+    wg->driver_queue()->update_statistics(driver);
+    wg->increment_real_runtime_ns(runtime_ns);
+    workgroup::WorkGroupManager::instance()->increment_cpu_runtime_ns(runtime_ns);
+}
+
+size_t DriverQueueWithWorkGroup::size() {
+    std::lock_guard<std::mutex> lock(_global_mutex);
+
+    size_t size = 0;
+    for (auto wg : _ready_wgs) {
+        size += wg->driver_queue()->size();
+    }
+
+    return size;
+}
+
+template <bool from_dispatcher>
+void DriverQueueWithWorkGroup::_put_back(const DriverRawPtr driver) {
+    auto* wg = driver->workgroup();
+    if (_ready_wgs.find(wg) == _ready_wgs.end()) {
+        _sum_cpu_limit += wg->cpu_limit();
+        if constexpr (!from_dispatcher) {
+            auto* min_wg = _find_min_wg();
+            if (min_wg != nullptr) {
+                int64_t origin_real_runtime_ns = wg->real_runtime_ns();
+                int64_t new_vruntime_ns =
+                        std::min(min_wg->vruntime_ns() - _ideal_runtime_ns(wg) / 2,
+                                 min_wg->vruntime_ns() * int64_t(min_wg->cpu_limit()) / int64_t(wg->cpu_limit()));
+                wg->set_vruntime_ns(std::max(wg->vruntime_ns(), new_vruntime_ns));
+                int64_t diff_real_runtime_ns = wg->real_runtime_ns() - origin_real_runtime_ns;
+                workgroup::WorkGroupManager::instance()->increment_cpu_runtime_ns(diff_real_runtime_ns);
+            }
+        }
+        _ready_wgs.emplace(wg);
+    }
+    wg->driver_queue()->put_back(driver);
+    _cv.notify_one();
+}
+
+workgroup::WorkGroup* DriverQueueWithWorkGroup::_find_min_owner_wg(int dispatcher_id) {
+    workgroup::WorkGroup* min_wg = nullptr;
+    int64_t min_vruntime_ns = 0;
+
+    auto owner_wgs = workgroup::WorkGroupManager::instance()->get_owners_of_driver_dispatcher(dispatcher_id);
+    if (owner_wgs != nullptr) {
+        for (const auto& wg : *owner_wgs) {
+            if (_ready_wgs.find(wg.get()) != _ready_wgs.end() &&
+                (min_wg == nullptr || min_vruntime_ns > wg->vruntime_ns())) {
+                min_wg = wg.get();
+                min_vruntime_ns = wg->vruntime_ns();
+            }
+        }
+    }
+
+    return min_wg;
+}
+
+workgroup::WorkGroup* DriverQueueWithWorkGroup::_find_min_wg() {
+    workgroup::WorkGroup* min_wg = nullptr;
+    int64_t min_vruntime_ns = 0;
+
+    for (auto wg : _ready_wgs) {
+        if (min_wg == nullptr || min_vruntime_ns > wg->vruntime_ns()) {
+            min_wg = wg;
+            min_vruntime_ns = wg->vruntime_ns();
+        }
+    }
+    return min_wg;
+}
+
+int64_t DriverQueueWithWorkGroup::_ideal_runtime_ns(workgroup::WorkGroup* wg) {
+    return DISPATCH_PERIOD_PER_WG_NS * _ready_wgs.size() * wg->cpu_limit() / _sum_cpu_limit;
 }
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/pipeline_driver_queue.h
+++ b/be/src/exec/pipeline/pipeline_driver_queue.h
@@ -82,7 +82,7 @@ public:
     // return nullptr if queue is closed;
     StatusOr<DriverRawPtr> take(int dispatcher_id) override;
 
-    size_t size() override { return 0; }
+    size_t size() override;
 
 private:
     SubQuerySharedDriverQueue _queues[QUEUE_SIZE];

--- a/be/src/exec/pipeline/pipeline_driver_queue.h
+++ b/be/src/exec/pipeline/pipeline_driver_queue.h
@@ -79,7 +79,7 @@ public:
 
     void update_statistics(const DriverRawPtr driver) override;
 
-    // return nullptr if queue is closed;
+    // Return cancelled status, if the queue is closed.
     StatusOr<DriverRawPtr> take(int dispatcher_id) override;
 
     size_t size() override;
@@ -114,7 +114,7 @@ public:
     void put_back_from_dispatcher(const DriverRawPtr driver) override;
     void put_back_from_dispatcher(const std::vector<DriverRawPtr>& drivers) override;
 
-    // return nullptr if queue is closed;
+    // Always return non-nullable value.
     StatusOr<DriverRawPtr> take(int dispatcher_id) override;
 
     void update_statistics(const DriverRawPtr driver) override;
@@ -150,6 +150,7 @@ public:
     void put_back_from_dispatcher(const DriverRawPtr driver) override;
     void put_back_from_dispatcher(const std::vector<DriverRawPtr>& drivers) override;
 
+    // Return cancelled status, if the queue is closed.
     // Firstly, select the work group with the minimum vruntime.
     // Secondly, select the proper driver from the driver queue of this work group.
     StatusOr<DriverRawPtr> take(int dispatcher_id) override;

--- a/be/src/exec/pipeline/pipeline_driver_queue.h
+++ b/be/src/exec/pipeline/pipeline_driver_queue.h
@@ -5,11 +5,35 @@
 #include <queue>
 
 #include "exec/pipeline/pipeline_driver.h"
+#include "exec/workgroup/work_group_fwd.h"
 #include "util/factory_method.h"
+
 namespace starrocks {
 namespace pipeline {
+
 class DriverQueue;
 using DriverQueuePtr = std::unique_ptr<DriverQueue>;
+
+class DriverQueue {
+public:
+    virtual ~DriverQueue() = default;
+    virtual void close() = 0;
+
+    virtual void put_back(const DriverRawPtr driver) = 0;
+    virtual void put_back(const std::vector<DriverRawPtr>& drivers) = 0;
+    // *from_dispatcher* means that the dispatcher thread puts the driver back to the queue.
+    virtual void put_back_from_dispatcher(const DriverRawPtr driver) = 0;
+    virtual void put_back_from_dispatcher(const std::vector<DriverRawPtr>& drivers) = 0;
+
+    virtual StatusOr<DriverRawPtr> take(int dispatcher_id) = 0;
+
+    // Update statistics of the driver's workgroup,
+    // when yielding the driver in the dispatcher thread.
+    virtual void update_statistics(const DriverRawPtr driver) = 0;
+
+    virtual size_t size() = 0;
+    bool empty() { return size() == 0; }
+};
 
 class SubQuerySharedDriverQueue {
 public:
@@ -27,21 +51,11 @@ private:
     std::atomic<int64_t> _accu_consume_time = 0;
 };
 
-class DriverQueue {
-public:
-    virtual void put_back(const DriverRawPtr driver) = 0;
-    virtual void put_back(const std::vector<DriverRawPtr>& drivers) = 0;
-    virtual StatusOr<DriverRawPtr> take(size_t* queue_index) = 0;
-    virtual ~DriverQueue() = default;
-    virtual void close() = 0;
-    virtual SubQuerySharedDriverQueue* get_sub_queue(size_t) = 0;
-};
-
 class QuerySharedDriverQueue : public FactoryMethod<DriverQueue, QuerySharedDriverQueue> {
     friend class FactoryMethod<DriverQueue, QuerySharedDriverQueue>;
 
 public:
-    QuerySharedDriverQueue() : _is_closed(false) {
+    QuerySharedDriverQueue() {
         double factor = 1;
         for (int i = QUEUE_SIZE - 1; i >= 0; --i) {
             // initialize factor for every sub queue,
@@ -59,15 +73,111 @@ public:
     static constexpr double RATIO_OF_ADJACENT_QUEUE = 1.2;
     void put_back(const DriverRawPtr driver) override;
     void put_back(const std::vector<DriverRawPtr>& drivers) override;
+
+    void put_back_from_dispatcher(const DriverRawPtr driver) override;
+    void put_back_from_dispatcher(const std::vector<DriverRawPtr>& drivers) override;
+
+    void update_statistics(const DriverRawPtr driver) override;
+
     // return nullptr if queue is closed;
-    StatusOr<DriverRawPtr> take(size_t* queue_index) override;
-    SubQuerySharedDriverQueue* get_sub_queue(size_t) override;
+    StatusOr<DriverRawPtr> take(int dispatcher_id) override;
+
+    size_t size() override { return 0; }
 
 private:
     SubQuerySharedDriverQueue _queues[QUEUE_SIZE];
     std::mutex _global_mutex;
     std::condition_variable _cv;
-    bool _is_closed;
+    bool _is_closed = false;
+};
+
+// All the QuerySharedDriverQueueWithoutLock's methods MUST be guarded by the outside lock.
+class QuerySharedDriverQueueWithoutLock : public FactoryMethod<DriverQueue, QuerySharedDriverQueueWithoutLock> {
+    friend class FactoryMethod<DriverQueue, QuerySharedDriverQueueWithoutLock>;
+
+public:
+    QuerySharedDriverQueueWithoutLock() {
+        double factor = 1;
+        for (int i = QUEUE_SIZE - 1; i >= 0; --i) {
+            // initialize factor for every sub queue,
+            // Higher priority queues have more execution time,
+            // so they have a larger factor.
+            _queues[i].factor_for_normal = factor;
+            factor *= RATIO_OF_ADJACENT_QUEUE;
+        }
+    }
+    ~QuerySharedDriverQueueWithoutLock() override = default;
+    void close() override {}
+
+    void put_back(const DriverRawPtr driver) override;
+    void put_back(const std::vector<DriverRawPtr>& drivers) override;
+    void put_back_from_dispatcher(const DriverRawPtr driver) override;
+    void put_back_from_dispatcher(const std::vector<DriverRawPtr>& drivers) override;
+
+    // return nullptr if queue is closed;
+    StatusOr<DriverRawPtr> take(int dispatcher_id) override;
+
+    void update_statistics(const DriverRawPtr driver) override;
+
+    size_t size() override { return _size; }
+
+private:
+    void _put_back(const DriverRawPtr driver);
+
+    static constexpr size_t QUEUE_SIZE = 8;
+    static constexpr double RATIO_OF_ADJACENT_QUEUE = 1.2;
+
+    SubQuerySharedDriverQueue _queues[QUEUE_SIZE];
+
+    size_t _size = 0;
+};
+
+// DriverQueueWithWorkGroup contains two levels of queues.
+// The first level is the work group queue, and the second level is the driver queue in a work group.
+class DriverQueueWithWorkGroup : public FactoryMethod<DriverQueue, DriverQueueWithWorkGroup> {
+    friend class FactoryMethod<DriverQueue, DriverQueueWithWorkGroup>;
+
+public:
+    ~DriverQueueWithWorkGroup() override = default;
+    void close() override;
+
+    void put_back(const DriverRawPtr driver) override;
+    void put_back(const std::vector<DriverRawPtr>& drivers) override;
+    // When the driver's workgroup is not in the workgroup queue
+    // and the driver isn't from a dispatcher thread (that is, from the poller or new driver),
+    // the workgroup's vruntime is adjusted to workgroup_queue.min_vruntime-ideal_runtime/2,
+    // to avoid sloping too much time to this workgroup.
+    void put_back_from_dispatcher(const DriverRawPtr driver) override;
+    void put_back_from_dispatcher(const std::vector<DriverRawPtr>& drivers) override;
+
+    // Firstly, select the work group with the minimum vruntime.
+    // Secondly, select the proper driver from the driver queue of this work group.
+    StatusOr<DriverRawPtr> take(int dispatcher_id) override;
+
+    void update_statistics(const DriverRawPtr driver) override;
+
+    size_t size() override;
+
+private:
+    // The schedule period is equal to DISPATCH_PERIOD_PER_WG_NS * num_workgroups.
+    static constexpr int64_t DISPATCH_PERIOD_PER_WG_NS = 200'1000'1000;
+
+    // This method should be guarded by the outside _global_mutex.
+    template <bool from_dispatcher>
+    void _put_back(const DriverRawPtr driver);
+    // This method should be guarded by the outside _global_mutex.
+    workgroup::WorkGroup* _find_min_owner_wg(int dispatcher_id);
+    workgroup::WorkGroup* _find_min_wg();
+    // The ideal runtime of a work group is the weighted average of the schedule period.
+    int64_t _ideal_runtime_ns(workgroup::WorkGroup* wg);
+
+    std::mutex _global_mutex;
+    std::condition_variable _cv;
+    // _ready_wgs contains the workgroups which include the drivers need to be run.
+    std::unordered_set<workgroup::WorkGroup*> _ready_wgs;
+    size_t _sum_cpu_limit = 0;
+
+    bool _is_closed = false;
 };
 
 } // namespace pipeline

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -84,11 +84,21 @@ double WorkGroup::get_cpu_actual_use_ratio() const {
     return static_cast<double>(real_runtime_ns()) / sum_cpu_runtime_ns;
 }
 
-WorkGroupManager::WorkGroupManager() {}
+WorkGroupManager::WorkGroupManager()
+        : _driver_dispatcher_owner_manager(std::make_unique<DispatcherOwnerManager>(
+                  config::pipeline_exec_thread_pool_thread_num > 0 ? config::pipeline_exec_thread_pool_thread_num
+                                                                   : std::thread::hardware_concurrency())),
+          _io_dispatcher_owner_manager(std::make_unique<DispatcherOwnerManager>(
+                  config::pipeline_scan_thread_pool_thread_num > 0 ? config::pipeline_scan_thread_pool_thread_num
+                                                                   : std::thread::hardware_concurrency())) {}
+
 WorkGroupManager::~WorkGroupManager() {}
 void WorkGroupManager::destroy() {
     std::unique_lock write_lock(_mutex);
-    this->_workgroups.clear();
+
+    _driver_dispatcher_owner_manager.reset(nullptr);
+    _io_dispatcher_owner_manager.reset(nullptr);
+    _workgroups.clear();
 }
 
 WorkGroupPtr WorkGroupManager::add_workgroup(const WorkGroupPtr& wg) {
@@ -122,6 +132,7 @@ StatusOr<PriorityThreadPool::Task> IoWorkGroupQueue::pick_next_task() {
 void WorkGroupManager::apply(const std::vector<TWorkGroupOp>& ops) {
     std::unique_lock write_lock(_mutex);
 
+    size_t original_num_workgroups = _workgroups.size();
     auto it = _workgroup_expired_versions.begin();
     // collect removable workgroups
     while (it != _workgroup_expired_versions.end()) {
@@ -135,6 +146,9 @@ void WorkGroupManager::apply(const std::vector<TWorkGroupOp>& ops) {
         } else {
             ++it;
         }
+    }
+    if (original_num_workgroups != _workgroups.size()) {
+        reassign_dispatcher_to_wgs();
     }
 
     for (const auto& op : ops) {
@@ -163,6 +177,7 @@ void WorkGroupManager::create_workgroup_unlocked(const WorkGroupPtr& wg) {
     wg->init();
     _workgroups[unique_id] = wg;
     _sum_cpu_limit += wg->cpu_limit();
+    reassign_dispatcher_to_wgs();
 
     // old version exists, so mark the stale version delete
     if (_workgroup_versions.count(wg->id())) {
@@ -242,8 +257,25 @@ bool WorkGroupManager::try_offer_io_task(WorkGroupPtr wg, IoWorkGroupQueue::Task
     return true;
 }
 
+void WorkGroupManager::reassign_dispatcher_to_wgs() {
+    _driver_dispatcher_owner_manager->reassign_to_wgs(_workgroups, _sum_cpu_limit);
+    _io_dispatcher_owner_manager->reassign_to_wgs(_workgroups, _sum_cpu_limit);
+}
+
+std::shared_ptr<WorkGroupPtrSet> WorkGroupManager::get_owners_of_driver_dispatcher(int dispatcher_id) {
+    return _driver_dispatcher_owner_manager->get_owners(dispatcher_id);
+}
+
+bool WorkGroupManager::should_yield_driver_dispatcher(int dispatcher_id, WorkGroupPtr running_wg) {
+    return _driver_dispatcher_owner_manager->should_yield(dispatcher_id, std::move(running_wg));
+}
+
+std::shared_ptr<WorkGroupPtrSet> WorkGroupManager::get_owners_of_io_dispatcher(int dispatcher_id) {
+    return _io_dispatcher_owner_manager->get_owners(dispatcher_id);
+}
+
 bool WorkGroupManager::should_yield_io_dispatcher(int dispatcher_id, WorkGroupPtr running_wg) {
-    return true;
+    return _io_dispatcher_owner_manager->should_yield(dispatcher_id, std::move(running_wg));
 }
 
 DefaultWorkGroupInitialization::DefaultWorkGroupInitialization() {
@@ -254,6 +286,52 @@ DefaultWorkGroupInitialization::DefaultWorkGroupInitialization() {
     WorkGroupManager::instance()->add_workgroup(default_wg);
     WorkGroupManager::instance()->add_workgroup(wg1);
     WorkGroupManager::instance()->add_workgroup(wg2);
+}
+
+DispatcherOwnerManager::DispatcherOwnerManager(int num_total_dispatchers)
+        : _num_total_dispatchers(num_total_dispatchers) {
+    for (int i = 0; i < 2; ++i) {
+        _dispatcher_id2owner_wgs[i] = std::vector<std::shared_ptr<WorkGroupPtrSet>>(_num_total_dispatchers);
+    }
+}
+
+void DispatcherOwnerManager::reassign_to_wgs(const std::unordered_map<int128_t, WorkGroupPtr>& workgroups,
+                                             int sum_cpu_limit) {
+    auto& dispatcher_id2owner_wgs = _dispatcher_id2owner_wgs[(_index + 1) % 2];
+    for (auto& owner_wgs : dispatcher_id2owner_wgs) {
+        owner_wgs = std::make_shared<WorkGroupPtrSet>();
+    }
+
+    int dispatcher_id = 0;
+    for (const auto& [_, wg] : workgroups) {
+        int num_dispatchers = std::max(1, _num_total_dispatchers * int(wg->cpu_limit()) / sum_cpu_limit);
+        for (int i = 0; i < num_dispatchers; ++i) {
+            dispatcher_id2owner_wgs[(dispatcher_id++) % _num_total_dispatchers]->emplace(wg);
+        }
+    }
+
+    _index++;
+}
+
+bool DispatcherOwnerManager::should_yield(int dispatcher_id, const WorkGroupPtr& running_wg) const {
+    if (dispatcher_id >= _num_total_dispatchers) {
+        return false;
+    }
+
+    auto wgs = _dispatcher_id2owner_wgs[_index % 2][dispatcher_id];
+    // This dispatcher doesn't belong to any workgroup, or running_wg is the owner of it.
+    if (wgs == nullptr || wgs->empty() || wgs->find(running_wg) != wgs->end()) {
+        return false;
+    }
+
+    // Any owner of this dispatcher has running drivers.
+    for (const auto& wg : *wgs) {
+        if (wg->num_drivers() > 0) {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 } // namespace workgroup

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -69,7 +69,7 @@ void WorkGroup::init() {
     int64_t limit = ExecEnv::GetInstance()->query_pool_mem_tracker()->limit() * _memory_limit;
     _mem_tracker =
             std::make_shared<starrocks::MemTracker>(limit, _name, ExecEnv::GetInstance()->query_pool_mem_tracker());
-    _driver_queue = std::make_unique<starrocks::pipeline::QuerySharedDriverQueue>();
+    _driver_queue = std::make_unique<pipeline::QuerySharedDriverQueueWithoutLock>();
 }
 
 double WorkGroup::get_cpu_expected_use_ratio() const {

--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -176,8 +176,11 @@ public:
         return _dispatcher_id2owner_wgs[_index % 2][dispatcher_id];
     }
 
+    // Labels which workgroups each dispatcher belongs to based on the cpu limit of each workgroup.
     void reassign_to_wgs(const std::unordered_map<int128_t, WorkGroupPtr>& workgroups, int sum_cpu_limit);
 
+    // Return true, when the dispatcher is running the workgroup which it doesn't belong to,
+    // and any owner workgroups of it has running drivers.
     bool should_yield(int dispatcher_id, const WorkGroupPtr& running_wg) const;
 
 private:

--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -172,6 +172,8 @@ public:
     DispatcherOwnerManager(DispatcherOwnerManager&&) = delete;
     DispatcherOwnerManager& operator=(DispatcherOwnerManager&&) = delete;
 
+    int num_total_dispatchers() const { return _num_total_dispatchers; }
+
     std::shared_ptr<WorkGroupPtrSet> get_owners(int dispatcher_id) const {
         return _dispatcher_id2owner_wgs[_index % 2][dispatcher_id];
     }
@@ -221,6 +223,8 @@ public:
 
     std::shared_ptr<WorkGroupPtrSet> get_owners_of_io_dispatcher(int dispatcher_id);
     bool should_yield_io_dispatcher(int dispatcher_id, WorkGroupPtr running_wg);
+
+    int num_total_driver_dispatchers() const { return _driver_dispatcher_owner_manager->num_total_dispatchers(); }
 
 private:
     // {create, alter,delete}_workgroup_unlocked is used to replay WorkGroupOps.

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -130,6 +130,7 @@ public:
     PriorityThreadPool* etl_thread_pool() { return _etl_thread_pool; }
     FragmentMgr* fragment_mgr() { return _fragment_mgr; }
     starrocks::pipeline::DriverDispatcher* driver_dispatcher() { return _driver_dispatcher; }
+    starrocks::pipeline::DriverDispatcher* wg_driver_dispatcher() { return _wg_driver_dispatcher; }
     TMasterInfo* master_info() { return _master_info; }
     LoadPathMgr* load_path_mgr() { return _load_path_mgr; }
     BfdParser* bfd_parser() const { return _bfd_parser; }
@@ -209,6 +210,7 @@ private:
     PriorityThreadPool* _etl_thread_pool = nullptr;
     FragmentMgr* _fragment_mgr = nullptr;
     starrocks::pipeline::DriverDispatcher* _driver_dispatcher = nullptr;
+    pipeline::DriverDispatcher* _wg_driver_dispatcher = nullptr;
     TMasterInfo* _master_info = nullptr;
     LoadPathMgr* _load_path_mgr = nullptr;
 

--- a/be/src/service/starrocks_main.cpp
+++ b/be/src/service/starrocks_main.cpp
@@ -210,7 +210,7 @@ int main(int argc, char** argv) {
     }
 
     // init exec env
-    starrocks::ExecEnv::init(exec_env, paths);
+    EXIT_IF_ERROR(starrocks::ExecEnv::init(exec_env, paths));
     exec_env->set_storage_engine(engine);
     engine->set_heartbeat_flags(exec_env->heartbeat_flags());
 

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -41,6 +41,7 @@ set(EXEC_FILES
         ./exec/vectorized/orc_scanner_adapter_test.cpp
         ./exec/pipeline/pipeline_test_base.cpp
         ./exec/pipeline/pipeline_control_flow_test.cpp
+        ./exec/pipeline/pipeline_driver_queue_test.cpp
         ./exec/parquet/parquet_schema_test.cpp
         ./exec/parquet/encoding_test.cpp
         ./exec/parquet/page_reader_test.cpp

--- a/be/test/exec/pipeline/pipeline_driver_queue_test.cpp
+++ b/be/test/exec/pipeline/pipeline_driver_queue_test.cpp
@@ -1,0 +1,247 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#include "exec/pipeline/pipeline_driver_queue.h"
+
+#include <gtest/gtest.h>
+
+#include <thread>
+
+#include "exec/pipeline/pipeline_fwd.h"
+#include "exec/workgroup/work_group.h"
+#include "testutil/parallel_test.h"
+
+namespace starrocks::pipeline {
+
+class MockEmptyOperator final : public Operator {
+public:
+    MockEmptyOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id)
+            : Operator(factory, id, "mock_empty_operator", plan_node_id) {}
+
+    ~MockEmptyOperator() override = default;
+
+    bool has_output() const override { return true; }
+    bool need_input() const override { return true; }
+    bool is_finished() const override { return true; }
+
+    StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override { return nullptr; }
+    Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override { return Status::OK(); }
+};
+
+Operators _gen_operators() {
+    Operators operators;
+    operators.emplace_back(std::make_shared<MockEmptyOperator>(nullptr, 1, 1));
+    return operators;
+}
+
+void _set_driver_level(DriverRawPtr driver, int level) {
+    driver->set_dispatch_queue_index(level % QuerySharedDriverQueue::QUEUE_SIZE);
+    while (driver->driver_acct().get_level() < level) {
+        driver->driver_acct().increment_schedule_times();
+    }
+}
+
+PARALLEL_TEST(QuerySharedDriverQueueTest, test_basic) {
+    QuerySharedDriverQueue queue;
+
+    // Prepare drivers.
+    auto driver71 = std::make_shared<PipelineDriver>(_gen_operators(), nullptr, nullptr, -1, true);
+    _set_driver_level(driver71.get(), 7);
+    driver71->driver_acct().update_last_time_spent(5'000'000L * 1);
+
+    auto driver72 = std::make_shared<PipelineDriver>(_gen_operators(), nullptr, nullptr, -1, true);
+    _set_driver_level(driver72.get(), 7 + QuerySharedDriverQueue::QUEUE_SIZE);
+    driver72->driver_acct().update_last_time_spent(5'000'000L * 1);
+
+    auto driver61 = std::make_shared<PipelineDriver>(_gen_operators(), nullptr, nullptr, -1, true);
+    _set_driver_level(driver61.get(), 6);
+    driver61->driver_acct().update_last_time_spent(30'000'000L * QuerySharedDriverQueue::RATIO_OF_ADJACENT_QUEUE);
+
+    auto driver51 = std::make_shared<PipelineDriver>(_gen_operators(), nullptr, nullptr, -1, true);
+    _set_driver_level(driver51.get(), 5);
+    driver51->driver_acct().update_last_time_spent(20'000'000L * QuerySharedDriverQueue::RATIO_OF_ADJACENT_QUEUE *
+                                                   QuerySharedDriverQueue::RATIO_OF_ADJACENT_QUEUE);
+
+    std::vector<DriverRawPtr> in_drivers = {driver71.get(), driver72.get(), driver61.get(), driver51.get()};
+    std::vector<DriverRawPtr> out_drivers = {driver71.get(), driver72.get(), driver51.get(), driver61.get()};
+
+    // Put back drivers to queue.
+    for (auto* in_driver : in_drivers) {
+        queue.update_statistics(in_driver);
+        queue.put_back(in_driver);
+    }
+
+    // Take drivers from queue.
+    for (auto* out_driver : out_drivers) {
+        auto maybe_driver = queue.take(0);
+        ASSERT_TRUE(maybe_driver.ok());
+        ASSERT_EQ(out_driver, maybe_driver.value());
+    }
+}
+
+PARALLEL_TEST(QuerySharedDriverQueueTest, test_take_block) {
+    QuerySharedDriverQueue queue;
+
+    // Prepare drivers.
+    auto driver1 = std::make_shared<PipelineDriver>(_gen_operators(), nullptr, nullptr, -1, true);
+    _set_driver_level(driver1.get(), 1);
+
+    auto consumer_thread = std::make_shared<std::thread>([&queue, &driver1] {
+        auto maybe_driver = queue.take(0);
+        ASSERT_TRUE(maybe_driver.ok());
+        ASSERT_EQ(driver1.get(), maybe_driver.value());
+    });
+
+    sleep(1);
+    queue.update_statistics(driver1.get());
+    queue.put_back(driver1.get());
+
+    consumer_thread->join();
+}
+
+PARALLEL_TEST(QuerySharedDriverQueueTest, test_take_close) {
+    QuerySharedDriverQueue queue;
+
+    auto consumer_thread = std::make_shared<std::thread>([&queue] {
+        auto maybe_driver = queue.take(0);
+        ASSERT_TRUE(maybe_driver.status().is_cancelled());
+    });
+
+    sleep(1);
+    queue.close();
+
+    consumer_thread->join();
+}
+
+class DriverQueueWithWorkGroupTest : public ::testing::Test {
+public:
+    void SetUp() override {
+        _wg1 = std::make_shared<workgroup::WorkGroup>("wg100", 100, workgroup::WorkGroup::DEFAULT_VERSION, 1, 0.5, 10,
+                                                      workgroup::WorkGroupType::WG_NORMAL);
+        _wg2 = std::make_shared<workgroup::WorkGroup>("wg200", 200, workgroup::WorkGroup::DEFAULT_VERSION, 2, 0.5, 10,
+                                                      workgroup::WorkGroupType::WG_NORMAL);
+        _wg3 = std::make_shared<workgroup::WorkGroup>("wg200", 300, workgroup::WorkGroup::DEFAULT_VERSION, 1, 0.5, 10,
+                                                      workgroup::WorkGroupType::WG_NORMAL);
+        _wg1 = workgroup::WorkGroupManager::instance()->add_workgroup(_wg1);
+        _wg2 = workgroup::WorkGroupManager::instance()->add_workgroup(_wg2);
+        _wg3 = workgroup::WorkGroupManager::instance()->add_workgroup(_wg3);
+    }
+
+protected:
+    workgroup::WorkGroupPtr _wg1 = nullptr;
+    workgroup::WorkGroupPtr _wg2 = nullptr;
+    workgroup::WorkGroupPtr _wg3 = nullptr;
+
+    int _get_any_dispatcher_from_owner(const workgroup::WorkGroupPtr& wg) {
+        for (int i = 0; i < workgroup::WorkGroupManager::instance()->num_total_driver_dispatchers(); ++i) {
+            auto wgs = workgroup::WorkGroupManager::instance()->get_owners_of_driver_dispatcher(i);
+            if (wgs != nullptr && wgs->find(wg) != wgs->end()) {
+                return i;
+            }
+        }
+        return -1;
+    }
+};
+
+TEST_F(DriverQueueWithWorkGroupTest, test_basic) {
+    DriverQueueWithWorkGroup queue;
+
+    int dispatcher_id = _get_any_dispatcher_from_owner(_wg3);
+    ASSERT_GE(dispatcher_id, 0);
+
+    // Prepare drivers for _wg2.
+    int64_t sum_wg2_time_spent = 0;
+    auto driver271 = std::make_shared<PipelineDriver>(_gen_operators(), nullptr, nullptr, -1, true);
+    _set_driver_level(driver271.get(), 7);
+    driver271->driver_acct().update_last_time_spent(5'000'000L * 1);
+    driver271->set_workgroup(_wg2);
+    sum_wg2_time_spent += 5'000'000L * 1;
+
+    auto driver272 = std::make_shared<PipelineDriver>(_gen_operators(), nullptr, nullptr, -1, true);
+    _set_driver_level(driver272.get(), 7 + QuerySharedDriverQueue::QUEUE_SIZE);
+    driver272->driver_acct().update_last_time_spent(5'000'000L * 1);
+    driver272->set_workgroup(_wg2);
+    sum_wg2_time_spent += 5'000'000L * 1;
+
+    auto driver261 = std::make_shared<PipelineDriver>(_gen_operators(), nullptr, nullptr, -1, true);
+    _set_driver_level(driver261.get(), 6);
+    driver261->driver_acct().update_last_time_spent(30'000'000L * QuerySharedDriverQueue::RATIO_OF_ADJACENT_QUEUE);
+    driver261->set_workgroup(_wg2);
+    sum_wg2_time_spent += 30'000'000L * QuerySharedDriverQueue::RATIO_OF_ADJACENT_QUEUE;
+
+    auto driver251 = std::make_shared<PipelineDriver>(_gen_operators(), nullptr, nullptr, -1, true);
+    _set_driver_level(driver251.get(), 5);
+    driver251->driver_acct().update_last_time_spent(20'000'000L * QuerySharedDriverQueue::RATIO_OF_ADJACENT_QUEUE *
+                                                    QuerySharedDriverQueue::RATIO_OF_ADJACENT_QUEUE);
+    driver251->set_workgroup(_wg2);
+    sum_wg2_time_spent += 20'000'000L * QuerySharedDriverQueue::RATIO_OF_ADJACENT_QUEUE *
+                          QuerySharedDriverQueue::RATIO_OF_ADJACENT_QUEUE;
+
+    // Prepare drivers for _wg1.
+    auto driver1 = std::make_shared<PipelineDriver>(_gen_operators(), nullptr, nullptr, -1, true);
+    _set_driver_level(driver1.get(), 1);
+    driver1->driver_acct().update_last_time_spent(sum_wg2_time_spent / 2 - 10'000'000L);
+    driver1->set_workgroup(_wg1);
+
+    // Prepare drivers for _wg3.
+    auto driver3 = std::make_shared<PipelineDriver>(_gen_operators(), nullptr, nullptr, -1, true);
+    _set_driver_level(driver3.get(), 2);
+    driver3->driver_acct().update_last_time_spent(sum_wg2_time_spent * 2);
+    driver3->set_workgroup(_wg3);
+
+    std::vector<DriverRawPtr> in_drivers = {driver271.get(), driver272.get(), driver261.get(),
+                                            driver251.get(), driver1.get(),   driver3.get()};
+    // driver3 is from owner workgroup.
+    // the workgroup of driver1 has higher priority than that of driver2xx.
+    std::vector<DriverRawPtr> out_drivers = {driver3.get(),   driver1.get(),   driver271.get(),
+                                             driver272.get(), driver251.get(), driver261.get()};
+
+    // Put back drivers to queue.
+    for (auto* in_driver : in_drivers) {
+        queue.update_statistics(in_driver);
+        queue.put_back(in_driver);
+    }
+
+    // Take drivers from queue.
+    for (auto* out_driver : out_drivers) {
+        auto maybe_driver = queue.take(dispatcher_id);
+        ASSERT_TRUE(maybe_driver.ok());
+        ASSERT_EQ(out_driver, maybe_driver.value());
+    }
+}
+
+TEST_F(DriverQueueWithWorkGroupTest, test_take_block) {
+    DriverQueueWithWorkGroup queue;
+
+    // Prepare drivers.
+    auto driver1 = std::make_shared<PipelineDriver>(_gen_operators(), nullptr, nullptr, -1, true);
+    _set_driver_level(driver1.get(), 1);
+    driver1->set_workgroup(_wg1);
+
+    auto consumer_thread = std::make_shared<std::thread>([&queue, &driver1] {
+        auto maybe_driver = queue.take(0);
+        ASSERT_TRUE(maybe_driver.ok());
+        ASSERT_EQ(driver1.get(), maybe_driver.value());
+    });
+
+    sleep(1);
+    queue.update_statistics(driver1.get());
+    queue.put_back(driver1.get());
+
+    consumer_thread->join();
+}
+
+TEST_F(DriverQueueWithWorkGroupTest, test_take_close) {
+    DriverQueueWithWorkGroup queue;
+
+    auto consumer_thread = std::make_shared<std::thread>([&queue] {
+        auto maybe_driver = queue.take(0);
+        ASSERT_TRUE(maybe_driver.status().is_cancelled());
+    });
+
+    sleep(1);
+    queue.close();
+
+    consumer_thread->join();
+}
+
+} // namespace starrocks::pipeline


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] others

## Problem Summary：
- Implement `DriverQueueWithWorkGroup`, which dispatch drivers on multiple workgroups according to the algorithm inspired by Linux CFS.
- Add a new thread pool `wg_driver_dispatcher`, where drivers run when `enable_resource_group` is true.
- Add `DispatcherOwnerManager` to label each dispatcher threads belonging to which workgroups.
   If the dispatcher runs the driver of other workgroups, and its owner workgroup has coming driver, it will yield 20ms instead of 100ms.

