### PR TITLE
[UT] fix BE UT crash in some case

### DIFF
--- a/be/src/runtime/routine_load/routine_load_task_executor.cpp
+++ b/be/src/runtime/routine_load/routine_load_task_executor.cpp
@@ -327,6 +327,7 @@ void RoutineLoadTaskExecutor::err_handler(StreamLoadContext* ctx, const Status& 
 
 // for test only
 Status RoutineLoadTaskExecutor::_execute_plan_for_test(StreamLoadContext* ctx) {
+    ctx->ref();
     auto mock_consumer = [this, ctx]() {
         std::shared_ptr<StreamLoadPipe> pipe = _exec_env->load_stream_mgr()->get(ctx->id);
         bool eof = false;
@@ -353,6 +354,9 @@ Status RoutineLoadTaskExecutor::_execute_plan_for_test(StreamLoadContext* ctx) {
             } else {
                 ss << one;
             }
+        }
+        if (ctx->unref()) {
+            delete ctx;
         }
     };
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [x] others

## Fix UT Error:
```
21:11:28 ==12690==ERROR: AddressSanitizer: heap-use-after-free on address 0x620000001df0 at pc 0x000000a9a497 bp 0x7fef424dae90 sp 0x7fef424dae88
21:11:28 READ of size 8 at 0x620000001df0 thread T22
21:11:28     #0 0xa9a496 in std::__shared_ptr<std::__future_base::_State_baseV2, (__gnu_cxx::_Lock_policy)2>::get() const /usr/include/c++/10.3.0/bits/shared_ptr_base.h:1325
21:11:29     #1 0xa92be3 in std::__shared_ptr_access<std::__future_base::_State_baseV2, (__gnu_cxx::_Lock_policy)2, false, false>::_M_get() const /usr/include/c++/10.3.0/bits/shared_ptr_base.h:1024
21:11:29     #2 0xa8becd in std::__shared_ptr_access<std::__future_base::_State_baseV2, (__gnu_cxx::_Lock_policy)2, false, false>::operator->() const /usr/include/c++/10.3.0/bits/shared_ptr_base.h:1018
21:11:29     #3 0xb067ef in std::promise<starrocks::Status>::set_value(starrocks::Status const&) /usr/include/c++/10.3.0/future:1121
21:11:29     #4 0xb21212 in operator() /root/starrocks/be/src/runtime/routine_load/routine_load_task_executor.cpp:340
21:11:29     #5 0xb23fbb in __invoke_impl<void, starrocks::RoutineLoadTaskExecutor::_execute_plan_for_test(starrocks::StreamLoadContext*)::<lambda()> > /usr/include/c++/10.3.0/bits/invoke.h:60
21:11:29     #6 0xb23f62 in __invoke<starrocks::RoutineLoadTaskExecutor::_execute_plan_for_test(starrocks::StreamLoadContext*)::<lambda()> > /usr/include/c++/10.3.0/bits/invoke.h:95
21:11:29     #7 0xb23f0f in _M_invoke<0> /usr/include/c++/10.3.0/thread:264
21:11:29     #8 0xb23ee3 in operator() /usr/include/c++/10.3.0/thread:271
```

## Problem Summary(Required) ：
`mock_consumer` may be schedule after submit_task.
