### PR TITLE
BugFix: dead lock of schema change

### DIFF
--- a/be/src/storage/vectorized/schema_change.cpp
+++ b/be/src/storage/vectorized/schema_change.cpp
@@ -1007,7 +1007,7 @@ Status SchemaChangeHandler::_do_process_alter_tablet_v2_normal(const TAlterTable
     {
         std::lock_guard l1(base_tablet->get_push_lock());
         std::lock_guard l2(new_tablet->get_push_lock());
-        std::lock_guard l3(base_tablet->get_header_lock());
+        std::shared_lock l3(base_tablet->get_header_lock());
         std::lock_guard l4(new_tablet->get_header_lock());
 
         std::vector<Version> versions_to_be_changed;


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/3503

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When do schema change, we first lock `head_lock` of base_tablet in function `_do_process_alter_tablet_v2_normal` and lock it again in function `TabletReader::prepare()` which cause be crash

Actually, we don't modify the metadata of base_tablet when doing schema change, so we can use `shared_lock` instead of `lock_guard` to avoid dead lock