### PR TITLE
Fix bitmap_hash rewrite error bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -175,7 +175,7 @@ public class FunctionSet {
     // This contains the nullable functions, which cannot return NULL result directly for the NULL parameter.
     // This does not contain any user defined functions. All UDFs handle null values by themselves.
     private final ImmutableSet<String> notAlwaysNullResultWithNullParamFunctions = ImmutableSet.of("if",
-            "concat_ws", "ifnull", "nullif", "null_or_empty", "coalesce");
+            "concat_ws", "ifnull", "nullif", "null_or_empty", "coalesce", "bitmap_hash", "percentile_hash", "hll_hash");
 
     // If low cardinality string column with global dict, for some string functions,
     // we could evaluate the function only with the dict content, not all string column data.

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
@@ -463,9 +463,11 @@ public class ScalarType extends Type implements Cloneable {
             return t1;
         }
 
-        if (t1.isOnlyMetricType() || t2.isOnlyMetricType()) {
-            if (t1.type == t2.type) {
-                return t1;
+        boolean t1IsHLL = t1.type == PrimitiveType.HLL;
+        boolean t2IsHLL = t2.type == PrimitiveType.HLL;
+        if (t1IsHLL || t2IsHLL) {
+            if (t1IsHLL && t2IsHLL) {
+                return createHllType();
             }
             return INVALID;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
@@ -379,7 +379,8 @@ public class ScalarType extends Type implements Cloneable {
         } else {
             // the common type's PrimitiveType of two decimal types should wide enough, i.e
             // the common type of (DECIMAL32, DECIMAL64) should be DECIMAL64
-            PrimitiveType primitiveType = PrimitiveType.getWiderDecimalV3Type(lhs.getPrimitiveType(), rhs.getPrimitiveType());
+            PrimitiveType primitiveType =
+                    PrimitiveType.getWiderDecimalV3Type(lhs.getPrimitiveType(), rhs.getPrimitiveType());
             // the narrowestType for specified precision and scale is just wide properly to hold a decimal value, i.e
             // DECIMAL128(7,4), DECIMAL64(7,4) and DECIMAL32(7,4) can all be held in a DECIMAL32(7,4) type without
             // precision loss.
@@ -462,11 +463,9 @@ public class ScalarType extends Type implements Cloneable {
             return t1;
         }
 
-        boolean t1IsHLL = t1.type == PrimitiveType.HLL;
-        boolean t2IsHLL = t2.type == PrimitiveType.HLL;
-        if (t1IsHLL || t2IsHLL) {
-            if (t1IsHLL && t2IsHLL) {
-                return createHllType();
+        if (t1.isOnlyMetricType() || t2.isOnlyMetricType()) {
+            if (t1.type == t2.type) {
+                return t1;
             }
             return INVALID;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -514,6 +514,17 @@ public class ExpressionAnalyzer {
                 throw unsupportedException("Table function cannot be used in expression");
             }
 
+            // check params type, don't check var args type
+            for (int i = 0; i < fn.getNumArgs(); i++) {
+                if (!argumentTypes[i].matchesType(fn.getArgs()[i]) &&
+                        !Type.canCastTo(argumentTypes[i], fn.getArgs()[i])) {
+                    throw new SemanticException("No matching function with signature: %s(%s).",
+                            node.getFnName().getFunction(),
+                            node.getParams().isStar() ? "*" : Joiner.on(", ")
+                                    .join(Arrays.stream(argumentTypes).map(Type::toSql).collect(Collectors.toList())));
+                }
+            }
+
             node.setFn(fn);
             node.setType(fn.getReturnType());
             FunctionAnalyzer.analyze(node);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeFunctionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeFunctionTest.java
@@ -75,4 +75,11 @@ public class AnalyzeFunctionTest {
         analyzeFail("select approx_count_distinct(b1) from test_object");
         analyzeFail("select ndv(b1) from test_object");
     }
+
+    @Test
+    public void testMatrixTypeCast() {
+        analyzeFail("select trim(b1) from test_object");
+        analyzeFail("select trim(h1) from test_object");
+        analyzeFail("select trim(p1) from test_object");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeTestUtil.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeTestUtil.java
@@ -100,7 +100,8 @@ public class AnalyzeTestUtil {
                 "  `h1` hll hll_union NULL,\n" +
                 "  `h2` hll hll_union NULL,\n" +
                 "  `h3` hll hll_union NULL,\n" +
-                "  `h4` hll hll_union NULL\n" +
+                "  `h4` hll hll_union NULL,\n" +
+                "  `p1` percentile PERCENTILE_UNION NULL\n" +
                 ") ENGINE=OLAP\n" +
                 "AGGREGATE KEY(`v1`, `v2`, `v3`, `v4`)\n" +
                 "DISTRIBUTED BY HASH(`v1`) BUCKETS 10\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
@@ -368,16 +368,13 @@ public class InsertPlanTest extends PlanTestBase {
         plan = getInsertExecPlan(sql);
         containsKeywords(plan, "OUTPUT EXPRS:1: id | 2: id2", "OLAP TABLE SINK", "0:OlapScanNode");
 
-        sql = "insert into test.bitmap_table select id, to_bitmap(id2) from test.bitmap_table_2;";
-        plan = getInsertExecPlan(sql);
-        containsKeywords(plan, "OUTPUT EXPRS:1: id | 3: to_bitmap", "OLAP TABLE SINK",
-                "1:Project", "<slot 1> : 1: id", "<slot 3> : to_bitmap(CAST(2: id2 AS VARCHAR))", "0:OlapScanNode",
-                "TABLE: bitmap_table_2");
+        Assert.assertThrows("No matching function with signature: to_bitmap(bitmap).", SemanticException.class,
+                () -> getInsertExecPlan(
+                        "insert into test.bitmap_table select id, to_bitmap(id2) from test.bitmap_table_2;"));
 
-        sql = "insert into test.bitmap_table select id, bitmap_hash(id2) from test.bitmap_table_2;";
-        plan = getInsertExecPlan(sql);
-        containsKeywords(plan, "OUTPUT EXPRS:1: id | 3: bitmap_hash", "OLAP TABLE SINK",
-                "1:Project", "<slot 1> : 1: id", "<slot 3> : bitmap_hash(CAST(2: id2 AS VARCHAR))");
+        Assert.assertThrows("No matching function with signature: bitmap_hash(bitmap).", SemanticException.class,
+                () -> getInsertExecPlan(
+                        "insert into test.bitmap_table select id, bitmap_hash(id2) from test.bitmap_table_2;"));
 
         sql = "insert into test.bitmap_table select id, id from test.bitmap_table_2;";
         plan = getInsertExecPlan(sql);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -5765,4 +5765,11 @@ public class PlanFragmentTest extends PlanTestBase {
         String plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("OUTPUT EXPRS:1: t1a | 12: sum | 12: sum"));
     }
+
+    @Test
+    public void testBitmapHashRewrite() throws Exception {
+        String sql = "select bitmap_hash(NULL)";
+        String plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("bitmap_hash(NULL)"));
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -2159,14 +2159,13 @@ public class PlanFragmentTest extends PlanTestBase {
                         "PREAGGREGATION: OFF. Reason: Aggregate Operator not match: COUNT <--> BITMAP_UNION");
 
         starRocksAssert.query("select group_concat(id2) from test.bitmap_table;")
-                .analysisError(
-                        "group_concat requires first parameter to be of getType() STRING: group_concat(`default_cluster:test`.`bitmap_table`.`id2`)");
+                .analysisError("No matching function with signature: group_concat(bitmap).");
 
         starRocksAssert.query("select sum(id2) from test.bitmap_table;").analysisError(
-                "sum requires a numeric parameter: sum(`default_cluster:test`.`bitmap_table`.`id2`)");
+                "No matching function with signature: sum(bitmap).");
 
         starRocksAssert.query("select avg(id2) from test.bitmap_table;")
-                .analysisError("avg requires a numeric parameter: avg(`default_cluster:test`.`bitmap_table`.`id2`)");
+                .analysisError("No matching function with signature: avg(bitmap).");
 
         starRocksAssert.query("select max(id2) from test.bitmap_table;").analysisError(Type.OnlyMetricTypeErrorMsg);
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3520 #3552

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Two bugs:
1. function type check error.
```
mysql> select  BITMAP_CONTAINS(BITMAP_HASH(t2.c_2_13) , -1905667682)  from t2;
ERROR 1064 (HY000): Vectorized engine does not support the operator
```

2.the result isn't NULL of bitmap_hash when args is NULL, but optimizer don't known
```
mysql>  select BITMAP_CONTAINS(NULL , -190566768), BITMAP_CONTAINS(BITMAP_HASH(NULL) , -1905667682) from t2;
+-----------------------------------+-------------------------------------------------+
| bitmap_contains(NULL, -190566768) | bitmap_contains(bitmap_hash(NULL), -1905667682) |
+-----------------------------------+-------------------------------------------------+
|                              NULL |                                               0 |
+-----------------------------------+-------------------------------------------------+
1 row in set (0.02 sec)
```
