### PR TITLE
Fix the mem leak of null_key_data

### DIFF
--- a/be/src/exec/vectorized/aggregate/agg_hash_map.h
+++ b/be/src/exec/vectorized/aggregate/agg_hash_map.h
@@ -99,6 +99,8 @@ struct AggHashMapWithOneNumberKey {
 
     AggHashMapWithOneNumberKey(int32_t chunk_size) {}
 
+    AggDataPtr get_null_key_data() { return nullptr; }
+
     template <typename Func>
     void compute_agg_states(size_t chunk_size, const Columns& key_columns, MemPool* pool, Func&& allocate_func,
                             Buffer<AggDataPtr>* agg_states) {
@@ -160,6 +162,8 @@ struct AggHashMapWithOneNullableNumberKey {
     static_assert(sizeof(FieldType) <= sizeof(KeyType), "hash map key size needs to be larger than the actual element");
 
     AggHashMapWithOneNullableNumberKey(int32_t chunk_size) {}
+
+    AggDataPtr get_null_key_data() { return null_key_data; }
 
     template <typename Func>
     void compute_agg_states(size_t chunk_size, const Columns& key_columns, MemPool* pool, Func&& allocate_func,
@@ -287,6 +291,8 @@ struct AggHashMapWithOneStringKey {
 
     AggHashMapWithOneStringKey(int32_t chunk_size) {}
 
+    AggDataPtr get_null_key_data() { return nullptr; }
+
     template <typename Func>
     void compute_agg_states(size_t chunk_size, const Columns& key_columns, MemPool* pool, Func&& allocate_func,
                             Buffer<AggDataPtr>* agg_states) {
@@ -348,6 +354,8 @@ struct AggHashMapWithOneNullableStringKey {
     HashMap hash_map;
 
     AggHashMapWithOneNullableStringKey(int32_t chunk_size) {}
+
+    AggDataPtr get_null_key_data() { return null_key_data; }
 
     template <typename Func>
     void compute_agg_states(size_t chunk_size, const Columns& key_columns, MemPool* pool, Func&& allocate_func,
@@ -484,6 +492,8 @@ struct AggHashMapWithSerializedKey {
               buffer(mem_pool->allocate(max_one_row_size * chunk_size)),
               _chunk_size(chunk_size) {}
 
+    AggDataPtr get_null_key_data() { return nullptr; }
+
     template <typename Func>
     void compute_agg_states(size_t chunk_size, const Columns& key_columns, MemPool* pool, Func&& allocate_func,
                             Buffer<AggDataPtr>* agg_states) {
@@ -611,6 +621,8 @@ struct AggHashMapWithSerializedKeyFixedSize {
         uint8_t* buffer = reinterpret_cast<uint8_t*>(caches.data());
         memset(buffer, 0x0, max_fixed_size * _chunk_size);
     }
+
+    AggDataPtr get_null_key_data() { return nullptr; }
 
     template <typename Func>
     void compute_agg_states(size_t chunk_size, const Columns& key_columns, MemPool* pool, Func&& allocate_func,

--- a/be/src/exec/vectorized/aggregator.h
+++ b/be/src/exec/vectorized/aggregator.h
@@ -477,6 +477,13 @@ private:
     template <typename HashMapWithKey>
     void _release_agg_memory(HashMapWithKey* hash_map_with_key) {
         if (hash_map_with_key != nullptr) {
+            auto null_data_ptr = hash_map_with_key->get_null_key_data();
+            if (null_data_ptr != nullptr) {
+                for (int i = 0; i < _agg_functions.size(); i++) {
+                    _agg_functions[i]->destroy(_agg_fn_ctxs[i], null_data_ptr + _agg_states_offsets[i]);
+                }
+            }
+
             auto it = hash_map_with_key->hash_map.begin();
             auto end = hash_map_with_key->hash_map.end();
             while (it != end) {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

for #3514 


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

![apLpenxQ1H](https://user-images.githubusercontent.com/11428742/154682293-e6484dc2-99e4-4189-bf73-81b86a525272.png)


```
 select a, PERCENTILE_APPROX(b, 0.99) from m1 group by a;
```

```
struct PercentileApproxState {
public:
    PercentileApproxState() : percentile(new PercentileValue()) {}
    ~PercentileApproxState() = default;

    std::unique_ptr<PercentileValue> percentile;
    double targetQuantile = -1.0;
    bool is_null = true;
};
```
