### PR TITLE
fix the bug of not set is_null

### DIFF
--- a/be/src/exprs/agg/nullable_aggregate.h
+++ b/be/src/exprs/agg/nullable_aggregate.h
@@ -120,6 +120,7 @@ public:
         if (src[0]->is_nullable()) {
             const auto* nullable_column = down_cast<const NullableColumn*>(src[0].get());
             if (nullable_column->has_null()) {
+                dst_nullable_column->set_has_null(true);
                 const NullData& src_null_data = nullable_column->immutable_null_column_data();
                 size_t null_size = SIMD::count_nonzero(src_null_data);
                 if (null_size == chunk_size) {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

it's hard to write the test case, i will and check_or_die for column later

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

when run aggr streaming, dest column should set has_null in conistency with src column.

The reason why this bug is currently difficult to trigger:

* in streaming auto mode, null will be filtered
* Sink will direct use the null_data without use has null
* RuntimeFilter will push down direct to the lower scan node, so can't run runtime filter here
