### PR TITLE
BugFix: fix the wrong checksum between different replicas

### DIFF
--- a/be/src/column/array_column.cpp
+++ b/be/src/column/array_column.cpp
@@ -387,7 +387,12 @@ void ArrayColumn::crc32_hash(uint32_t* hash, uint32_t from, uint32_t to) const {
 int64_t ArrayColumn::xor_checksum() const {
     // The XOR of ArrayColumn
     // XOR the offsets column and elements column
-    int64_t xor_checksum = _offsets->xor_checksum();
+    int64_t xor_checksum = 0;
+    size_t num = _offsets->size() - 1;
+    for (size_t idx = 0; idx < num; ++idx) {
+        int64_t array_size = _offsets->get_data()[idx + 1] - _offsets->get_data()[idx];
+        xor_checksum ^= array_size;
+    }
     return (xor_checksum ^ _elements->xor_checksum());
 }
 

--- a/be/src/column/array_column.cpp
+++ b/be/src/column/array_column.cpp
@@ -384,6 +384,13 @@ void ArrayColumn::crc32_hash(uint32_t* hash, uint32_t from, uint32_t to) const {
     }
 }
 
+int64_t ArrayColumn::xor_checksum() const {
+    // The XOR of ArrayColumn
+    // XOR the offsets column and elements column
+    int64_t xor_checksum = _offsets->xor_checksum();
+    return (xor_checksum ^ _elements->xor_checksum());
+}
+
 void ArrayColumn::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx) const {
     DCHECK_LT(idx, size());
     const size_t offset = _offsets->get_data()[idx];

--- a/be/src/column/array_column.h
+++ b/be/src/column/array_column.h
@@ -111,6 +111,8 @@ public:
 
     void crc32_hash(uint32_t* hash, uint32_t from, uint32_t to) const override;
 
+    int64_t xor_checksum() const override;
+
     void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx) const override;
 
     std::string get_name() const override { return "array"; }

--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -465,7 +465,7 @@ int64_t BinaryColumn::xor_checksum() const {
             num -= step;
         }
         int64_t* checksum_vec = reinterpret_cast<int64_t*>(&avx2_checksum);
-        size_t eight_byte_step = step / 8;
+        size_t eight_byte_step = sizeof(__m256i) / sizeof(int64_t);
         for (size_t i = 0; i < eight_byte_step; ++i) {
             xor_checksum ^= checksum_vec[i];
         }

--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -441,6 +441,49 @@ void BinaryColumn::crc32_hash(uint32_t* hashes, uint32_t from, uint32_t to) cons
     }
 }
 
+int64_t BinaryColumn::xor_checksum() const {
+    // The XOR of BinaryColumn
+    // For one string, treat it as a number of 64-bit integers and 8-bit integers.
+    // XOR all of the integers to get a checksum for one string.
+    // XOR all of the checksums to get xor_checksum.
+    int64_t xor_checksum = 0;
+    size_t size = _offsets.size() - 1;
+
+    for (size_t i = 0; i < size; ++i) {
+        size_t num = _offsets[i + 1] - _offsets[i];
+        const uint8_t* src = reinterpret_cast<const uint8_t*>(_bytes.data() + _offsets[i]);
+
+#ifdef __AVX2__
+        // AVX2 intructions can improve the speed of XOR procedure of one string.
+        __m256i avx2_checksum = _mm256_setzero_si256();
+        size_t step = sizeof(__m256i) / sizeof(uint8_t);
+
+        while (num >= step) {
+            const __m256i left = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src));
+            avx2_checksum = _mm256_xor_si256(left, avx2_checksum);
+            src += step;
+            num -= step;
+        }
+        int64_t* checksum_vec = reinterpret_cast<int64_t*>(&avx2_checksum);
+        size_t eight_byte_step = step / 8;
+        for (size_t i = 0; i < eight_byte_step; ++i) {
+            xor_checksum ^= checksum_vec[i];
+        }
+#endif
+
+        while (num >= 8) {
+            xor_checksum ^= *reinterpret_cast<const int64_t*>(src);
+            src += 8;
+            num -= 8;
+        }
+        for (size_t i = 0; i < num; ++i) {
+            xor_checksum ^= src[i];
+        }
+    }
+
+    return xor_checksum;
+}
+
 void BinaryColumn::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx) const {
     uint32_t start = _offsets[idx];
     uint32_t len = _offsets[idx + 1] - start;

--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -466,8 +466,8 @@ int64_t BinaryColumn::xor_checksum() const {
         }
         int64_t* checksum_vec = reinterpret_cast<int64_t*>(&avx2_checksum);
         size_t eight_byte_step = sizeof(__m256i) / sizeof(int64_t);
-        for (size_t i = 0; i < eight_byte_step; ++i) {
-            xor_checksum ^= checksum_vec[i];
+        for (size_t j = 0; j < eight_byte_step; ++j) {
+            xor_checksum ^= checksum_vec[j];
         }
 #endif
 
@@ -476,8 +476,8 @@ int64_t BinaryColumn::xor_checksum() const {
             src += 8;
             num -= 8;
         }
-        for (size_t i = 0; i < num; ++i) {
-            xor_checksum ^= src[i];
+        for (size_t j = 0; j < num; ++j) {
+            xor_checksum ^= src[j];
         }
     }
 

--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -197,6 +197,8 @@ public:
 
     void crc32_hash(uint32_t* hash, uint32_t from, uint32_t to) const override;
 
+    int64_t xor_checksum() const override;
+
     void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx) const override;
 
     std::string get_name() const override { return "binary"; }

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -302,6 +302,8 @@ public:
 
     virtual void fnv_hash_at(uint32_t* seed, int32_t idx) const { fnv_hash(seed - idx, idx, idx + 1); }
 
+    virtual int64_t xor_checksum() const = 0;
+
     // Push one row to MysqlRowBuffer
     virtual void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx) const = 0;
 

--- a/be/src/column/const_column.cpp
+++ b/be/src/column/const_column.cpp
@@ -49,6 +49,11 @@ void ConstColumn::crc32_hash(uint32_t* hash, uint32_t from, uint32_t to) const {
     DCHECK(false) << "Const column shouldn't call crc32 hash";
 }
 
+int64_t ConstColumn::xor_checksum() const {
+    DCHECK(false) << "Const column shouldn't call xor_checksum";
+    return 0;
+}
+
 size_t ConstColumn::filter_range(const Column::Filter& filter, size_t from, size_t to) {
     size_t count = SIMD::count_nonzero(&filter[from], to - from);
     this->resize(from + count);

--- a/be/src/column/const_column.h
+++ b/be/src/column/const_column.h
@@ -163,6 +163,8 @@ public:
 
     void crc32_hash(uint32_t* hash, uint32_t from, uint32_t to) const override;
 
+    int64_t xor_checksum() const override;
+
     void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx) const override { _data->put_mysql_row_buffer(buf, 0); }
 
     std::string get_name() const override { return "const-" + _data->get_name(); }

--- a/be/src/column/decimalv3_column.h
+++ b/be/src/column/decimalv3_column.h
@@ -33,6 +33,7 @@ public:
     void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx) const override;
     std::string debug_item(uint32_t idx) const override;
     void crc32_hash(uint32_t* hash, uint32_t from, uint32_t to) const override;
+    int64_t xor_checksum() const override;
 
 private:
     int _precision;

--- a/be/src/column/fixed_length_column_base.h
+++ b/be/src/column/fixed_length_column_base.h
@@ -159,6 +159,8 @@ public:
 
     void crc32_hash(uint32_t* hash, uint32_t from, uint32_t to) const override;
 
+    int64_t xor_checksum() const override;
+
     void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx) const override;
 
     std::string get_name() const override;

--- a/be/src/column/nullable_column.cpp
+++ b/be/src/column/nullable_column.cpp
@@ -314,6 +314,39 @@ void NullableColumn::crc32_hash(uint32_t* hash, uint32_t from, uint32_t to) cons
     }
 }
 
+int64_t NullableColumn::xor_checksum() const {
+    if (!_has_null) {
+        return _data_column->xor_checksum();
+    }
+
+    int64_t xor_checksum = 0;
+    size_t num = _null_column->size();
+    uint8_t* src = _null_column->get_data().data();
+
+    // The XOR of NullableColumn
+    // XOR all the 8-bit integers one by one
+#ifdef __AVX2__
+    __m256i avx2_checksum = _mm256_setzero_si256();
+    size_t step = sizeof(__m256i) / sizeof(uint8_t);
+    while (num >= step) {
+        const __m256i left = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src));
+        avx2_checksum = _mm256_xor_si256(left, avx2_checksum);
+        src += step;
+        num -= step;
+    }
+    uint8_t* checksum_vec = reinterpret_cast<uint8_t*>(&avx2_checksum);
+    for (size_t i = 0; i < step; ++i) {
+        xor_checksum ^= checksum_vec[i];
+    }
+#endif
+
+    for (size_t i = 0; i < num; ++i) {
+        xor_checksum ^= src[i];
+    }
+
+    return (xor_checksum ^ _data_column->xor_checksum());
+}
+
 void NullableColumn::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx) const {
     if (_has_null && _null_column->get_data()[idx]) {
         buf->push_null();

--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -181,6 +181,8 @@ public:
 
     void crc32_hash(uint32_t* hash, uint32_t from, uint32_t to) const override;
 
+    int64_t xor_checksum() const override;
+
     void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx) const override;
 
     std::string get_name() const override { return "nullable-" + _data_column->get_name(); }

--- a/be/src/column/object_column.cpp
+++ b/be/src/column/object_column.cpp
@@ -218,6 +218,12 @@ void ObjectColumn<T>::crc32_hash(uint32_t* hash, uint32_t from, uint32_t to) con
 }
 
 template <typename T>
+int64_t ObjectColumn<T>::xor_checksum() const {
+    DCHECK(false) << "object column shouldn't call xor_checksum";
+    return 0;
+}
+
+template <typename T>
 void ObjectColumn<T>::put_mysql_row_buffer(starrocks::MysqlRowBuffer* buf, size_t idx) const {
     buf->push_null();
 }

--- a/be/src/column/object_column.h
+++ b/be/src/column/object_column.h
@@ -128,6 +128,8 @@ public:
 
     void crc32_hash(uint32_t* hash, uint32_t from, uint32_t to) const override;
 
+    int64_t xor_checksum() const override;
+
     void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx) const override;
 
     std::string get_name() const override { return std::string{"object"}; }

--- a/be/src/storage/task/engine_checksum_task.cpp
+++ b/be/src/storage/task/engine_checksum_task.cpp
@@ -102,7 +102,6 @@ Status EngineChecksumTask::_compute_checksum() {
         return st;
     }
 
-    uint32_t num_rows = 0;
     int64_t checksum = 0;
 
     auto chunk = vectorized::ChunkHelper::new_chunk(schema, reader_params.chunk_size);
@@ -118,7 +117,6 @@ Status EngineChecksumTask::_compute_checksum() {
         }
 #endif
 
-        num_rows = chunk->num_rows();
         for (auto& column : chunk->columns()) {
             checksum ^= column->xor_checksum();
         }

--- a/be/test/column/array_column_test.cpp
+++ b/be/test/column/array_column_test.cpp
@@ -820,7 +820,7 @@ PARALLEL_TEST(ArrayColumnTest, test_xor_checksum) {
     auto* offsets = down_cast<UInt32Column*>(c0->offsets_column().get());
     auto* elements = down_cast<Int32Column*>(c0->elements_column().get());
 
-    // insert [1, 2, 3], [4, 5, 6]
+    // insert [1, 2, 3], [4, 5, 6, 7]
     elements->append(1);
     elements->append(2);
     elements->append(3);
@@ -829,10 +829,12 @@ PARALLEL_TEST(ArrayColumnTest, test_xor_checksum) {
     elements->append(4);
     elements->append(5);
     elements->append(6);
-    offsets->append(6);
+    elements->append(7);
+    elements->append(8);
+    offsets->append(8);
 
     int64_t checksum = c0->xor_checksum();
-    int64_t expected_checksum = 7;
+    int64_t expected_checksum = 14;
 
     ASSERT_EQ(checksum, expected_checksum);
 }

--- a/be/test/column/array_column_test.cpp
+++ b/be/test/column/array_column_test.cpp
@@ -814,6 +814,29 @@ PARALLEL_TEST(ArrayColumnTest, test_array_hash) {
     ASSERT_EQ(hash_value_overflow, hash_value_overflow_test[2]);
 }
 
+PARALLEL_TEST(ArrayColumnTest, test_xor_checksum) {
+    auto c0 = ArrayColumn::create(Int32Column::create(), UInt32Column::create());
+
+    auto* offsets = down_cast<UInt32Column*>(c0->offsets_column().get());
+    auto* elements = down_cast<Int32Column*>(c0->elements_column().get());
+
+    // insert [1, 2, 3], [4, 5, 6]
+    elements->append(1);
+    elements->append(2);
+    elements->append(3);
+    offsets->append(3);
+
+    elements->append(4);
+    elements->append(5);
+    elements->append(6);
+    offsets->append(6);
+
+    int64_t checksum = c0->xor_checksum();
+    int64_t expected_checksum = 7;
+
+    ASSERT_EQ(checksum, expected_checksum);
+}
+
 PARALLEL_TEST(ArrayColumnTest, test_update_rows) {
     auto offsets = UInt32Column::create();
     auto elements = Int32Column::create();

--- a/be/test/column/binary_column_test.cpp
+++ b/be/test/column/binary_column_test.cpp
@@ -528,4 +528,17 @@ PARALLEL_TEST(BinaryColumnTest, test_update_rows) {
     ASSERT_EQ("mno", slices[4]);
 }
 
+PARALLEL_TEST(BinaryColumnTest, test_xor_checksum) {
+    auto column = BinaryColumn::create();
+    std::string str;
+    str.reserve(3000);
+    for (int i = 0; i <= 1000; i++) {
+        str.append(std::to_string(i));
+    }
+    column->append(str);
+    int64_t checksum = column->xor_checksum();
+    int64_t expected_checksum = 3546653113525744178L;
+    ASSERT_EQ(checksum, expected_checksum);
+}
+
 } // namespace starrocks::vectorized

--- a/be/test/column/decimalv3_column_test.cpp
+++ b/be/test/column/decimalv3_column_test.cpp
@@ -4,6 +4,7 @@
 
 #include <gtest/gtest.h>
 
+#include <iostream>
 #include <string>
 #include <vector>
 
@@ -76,6 +77,14 @@ TEST(DecimalV3ColumnTest, test_crc32_hash_decimal64p15s6) {
     for (auto i = 0; i < num_rows; ++i) {
         ASSERT_EQ(hash0[i], hash1[i]);
     }
+}
+
+TEST(DecimalV3ColumnTest, test_xor_checksum_decimal128p27s10) {
+    constexpr auto num_rows = 101;
+    auto col0 = create_decimal_column<int128_t>(27, 10, num_rows, "18446744073709551616.1");
+    int64_t checksum = col0->xor_checksum();
+    int64_t expected_checksum = 9995422848;
+    ASSERT_EQ(checksum, expected_checksum);
 }
 
 } // namespace starrocks::vectorized

--- a/be/test/column/fixed_length_column_test.cpp
+++ b/be/test/column/fixed_length_column_test.cpp
@@ -541,4 +541,16 @@ TEST(FixedLengthColumnTest, test_update_rows) {
     }
 }
 
+TEST(FixedLengthColumnTest, test_xor_checksum) {
+    auto column = FixedLengthColumn<int32_t>::create();
+    for (int i = 0; i <= 100; i++) {
+        column->append(i);
+    }
+
+    int64_t checksum = column->xor_checksum();
+    int64_t expected_checksum = 100;
+
+    ASSERT_EQ(checksum, expected_checksum);
+}
+
 } // namespace starrocks::vectorized

--- a/be/test/column/nullable_column_test.cpp
+++ b/be/test/column/nullable_column_test.cpp
@@ -249,4 +249,18 @@ PARALLEL_TEST(NullableColumnTest, test_update_rows) {
     ASSERT_EQ("jk", column1->get(4).get_slice().to_string());
 }
 
+PARALLEL_TEST(NullableColumnTest, test_xor_checksum) {
+    auto c0 = NullableColumn::create(Int32Column::create(), NullColumn::create());
+
+    c0->append_datum({}); // NULL
+    for (int i = 0; i <= 1000; i++) {
+        c0->append_datum((int32_t)i);
+    }
+
+    int64_t checksum = c0->xor_checksum();
+    int64_t expected_checksum = 1001;
+
+    ASSERT_EQ(checksum, expected_checksum);
+}
+
 } // namespace starrocks::vectorized


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3438 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
    
StarRocks uses the CRC algorithm to get the checksums to check the consistency between replicas.
There are two problems. Firstly, the size of chunks between different replicas is not the same.
Secondly, the order of data is not the same because of the out-of-step compaction procedures.

To solve the problem, I change the checksum algorithm to XOR. The result will be stored as a 64-bit integer.
Since the data between replicas is not the same, the checksum will reflect this problem, and the error probability is 1/(2^64).
XOR also obeys the commutative law. I can calculate the checksum Rowset by Rowset. XOR will improve performance and reduce memory consumption. 
    
Using the lineorder table(TPC-H), I test it with 100 million rows and 20 rowsets.
The test indicates that the memory consumption reduced from 500MB to 140MB. And the time is reduced from 24s to 9s.
As the number of rowsets grows, the performance improvement effect will be more obvious.