### PR TITLE
Remove the destroy thread assert of librdkafka

### DIFF
--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -344,7 +344,7 @@ echo "Finished patching $GPERFTOOLS_SOURCE"
 # patch librdkafka
 cd $TP_SOURCE_DIR/$LIBRDKAFKA_SOURCE
 if [ ! -f $PATCHED_MARK ] && [ $LIBRDKAFKA_SOURCE = "librdkafka-1.7.0" ]; then
-    patch -p1 < $TP_PATCH_DIR/librdkafka.patch
+    patch -p0 < $TP_PATCH_DIR/librdkafka.patch
     touch $PATCHED_MARK
 fi
 cd -

--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -341,6 +341,15 @@ fi
 cd -
 echo "Finished patching $GPERFTOOLS_SOURCE"
 
+# patch librdkafka
+cd $TP_SOURCE_DIR/$LIBRDKAFKA_SOURCE
+if [ ! -f $PATCHED_MARK ] && [ $LIBRDKAFKA_SOURCE = "librdkafka-1.7.0" ]; then
+    patch -p1 < $TP_PATCH_DIR/librdkafka.patch
+    touch $PATCHED_MARK
+fi
+cd -
+echo "Finished patching $LIBRDKAFKA_SOURCE"
+
 # patch mariadb-connector-c-3.2.5
 cd $TP_SOURCE_DIR/$MARIADB_SOURCE
 if [ ! -f $PATCHED_MARK ] && [ $MARIADB_SOURCE = "mariadb-connector-c-3.2.5" ]; then

--- a/thirdparty/patches/librdkafka.patch
+++ b/thirdparty/patches/librdkafka.patch
@@ -1,0 +1,11 @@
+--- librdkafka-1.7.0/src/rdkafka_broker.c
++++ librdkafka-1.7.0/src/rdkafka_broker.c
+@@ -5409,7 +5409,7 @@ static int rd_kafka_broker_thread_main (void *arg) {
+  */
+ void rd_kafka_broker_destroy_final (rd_kafka_broker_t *rkb) {
+ 
+-        rd_assert(thrd_is_current(rkb->rkb_thread));
++        //rd_assert(thrd_is_current(rkb->rkb_thread));
+         rd_assert(TAILQ_EMPTY(&rkb->rkb_monitors));
+         rd_assert(TAILQ_EMPTY(&rkb->rkb_outbufs.rkbq_bufs));
+         rd_assert(TAILQ_EMPTY(&rkb->rkb_waitresps.rkbq_bufs));

--- a/thirdparty/patches/librdkafka.patch
+++ b/thirdparty/patches/librdkafka.patch
@@ -1,5 +1,5 @@
---- librdkafka-1.7.0/src/rdkafka_broker.c
-+++ librdkafka-1.7.0/src/rdkafka_broker.c
+--- src/rdkafka_broker.c
++++ src/rdkafka_broker.c
 @@ -5409,7 +5409,7 @@ static int rd_kafka_broker_thread_main (void *arg) {
   */
  void rd_kafka_broker_destroy_final (rd_kafka_broker_t *rkb) {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3484 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

For the problem of librdkafka crash, there is still no reason for it, but there is no risk in removing the assert (a structure can only be destroyed by the owner),  In the crash case, the thread  has exited without destroying the struct which is referenced by another thread. But I have not yet found why the owner exited first).  can we remove the assert first to ensure that it does not crash, and then continue to trace the reason.  This modification has been tested with users, and there is no problem.