### PR TITLE
[cherry-pick][branch-2.1] Fix be crash when parquet files are deleted wrong during loading #3484

### DIFF
--- a/be/src/exec/parquet_reader.cpp
+++ b/be/src/exec/parquet_reader.cpp
@@ -200,6 +200,15 @@ Status ParquetReaderWrap::read_record_batch(const std::vector<SlotDescriptor*>& 
         if (!status.ok()) {
             return Status::InternalError("Read Batch Error With Libarrow.");
         }
+
+        // arrow::RecordBatchReader::ReadNext returns null at end of stream.
+        // Since we count the batches read, EOF implies reader source failure.
+        if (_batch == nullptr) {
+            LOG(WARNING) << "Unexpected EOF. Row groups less than expected. expected: " << _total_groups
+                         << " got: " << _current_group;
+            return Status::InternalError("Unexpected EOF");
+        }
+
         _current_line_of_batch = 0;
     } else if (_current_line_of_batch >= _batch->num_rows()) {
         VLOG(7) << "read_record_batch, current group id:" << _current_group
@@ -209,6 +218,15 @@ Status ParquetReaderWrap::read_record_batch(const std::vector<SlotDescriptor*>& 
         if (!status.ok()) {
             return Status::InternalError("Read Batch Error With Libarrow.");
         }
+
+        // arrow::RecordBatchReader::ReadNext returns null at end of stream.
+        // Since we count the batches read, EOF implies reader source failure.
+        if (_batch == nullptr) {
+            LOG(WARNING) << "Unexpected EOF. Row groups less than expected. expected: " << _total_groups
+                         << " got: " << _current_group;
+            return Status::InternalError("Unexpected EOF");
+        }
+
         _current_line_of_batch = 0;
     }
     return Status::OK();

--- a/be/src/exec/vectorized/parquet_reader.cpp
+++ b/be/src/exec/vectorized/parquet_reader.cpp
@@ -44,6 +44,8 @@ Status ParquetChunkReader::next_batch(RecordBatchPtr* batch) {
             *batch = nullptr;
             _state = END_OF_FILE;
             return Status::EndOfFile(Slice());
+        } else if (!status.ok()) {
+            return status;
         }
         break;
     }
@@ -113,7 +115,8 @@ arrow::Result<int64_t> ParquetChunkFile::ReadAt(int64_t position, int64_t nbytes
     s.data = (char*)out;
     s.size = nbytes;
     auto status = _file->read_at(position, s);
-    return status.ok() ? nbytes : -1;
+    return status.ok() ? nbytes
+                       : arrow::Result<int64_t>(arrow::Status(arrow::StatusCode::IOError, status.get_error_msg()));
 }
 
 arrow::Result<int64_t> ParquetChunkFile::GetSize() {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
cherry-pick of #3484 to branch-2.1

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
