### PR TITLE
Rename driver/scan dispatcher to driver/scan executor

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -661,7 +661,7 @@ CONF_Int64(pipeline_sink_brpc_dop, "8");
 // The max number of io tasks for each scan operator.
 CONF_Int64(pipeline_scan_max_tasks_per_operator, "4");
 // yield scan io task when maximum time in nano-seconds has spent in current execution round,
-// if it runs in the dispatcher owned by other workgroup, which has running drivers.
+// if it runs in the worker thread owned by other workgroup, which has running drivers.
 CONF_Int64(pipeline_scan_task_yield_max_tims_spent, "100000000");
 // The max schedule period for adjusting io weight of each workgroup.
 CONF_Int64(pipeline_scan_task_yield_preempt_max_time_spent, "20000000");

--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -153,7 +153,7 @@ set(EXEC_FILES
     pipeline/sort/partition_sort_sink_operator.cpp
     pipeline/sort/local_merge_sort_source_operator.cpp
     pipeline/sort/sort_context.cpp
-    pipeline/pipeline_driver_dispatcher.cpp
+    pipeline/pipeline_driver_executor.cpp
     pipeline/pipeline_driver_queue.cpp
     pipeline/pipeline_driver_poller.cpp
     pipeline/pipeline_driver.cpp
@@ -187,7 +187,7 @@ set(EXEC_FILES
     pipeline/set/intersect_probe_sink_operator.cpp
     pipeline/set/intersect_output_source_operator.cpp
     workgroup/work_group.cpp
-    workgroup/scan_worker.cpp
+    workgroup/scan_executor.cpp
 )
 
 # simdjson Runtime Implement Dispatch: https://github.com/simdjson/simdjson/blob/master/doc/implementation-selection.md#runtime-cpu-detection

--- a/be/src/exec/pipeline/chunk_source.h
+++ b/be/src/exec/pipeline/chunk_source.h
@@ -38,7 +38,7 @@ public:
 
     virtual Status buffer_next_batch_chunks_blocking(size_t chunk_size, bool& can_finish) = 0;
     virtual Status buffer_next_batch_chunks_blocking_for_workgroup(size_t chunk_size, bool& can_finish,
-                                                                   size_t* num_read_chunks, int dispatcher_id,
+                                                                   size_t* num_read_chunks, int worker_id,
                                                                    workgroup::WorkGroupPtr running_wg) = 0;
 
 protected:

--- a/be/src/exec/pipeline/context_with_dependency.h
+++ b/be/src/exec/pipeline/context_with_dependency.h
@@ -36,7 +36,7 @@ public:
     // when the last running related operator is closed.
     // - ref is called by operator::constructor() at the preparation stage.
     // - unref is called by operator::close() at the close stage.
-    // It is the guaranteed by the dispatcher queue that the increment operations
+    // It is the guaranteed by the driver queue that the increment operations
     // by ref() are visible to unref(), so we needn't barrier here.
     void ref() { _num_running_operators.fetch_add(1, std::memory_order_relaxed); }
 

--- a/be/src/exec/pipeline/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/olap_chunk_source.cpp
@@ -318,7 +318,7 @@ Status OlapChunkSource::buffer_next_batch_chunks_blocking(size_t batch_size, boo
 }
 
 Status OlapChunkSource::buffer_next_batch_chunks_blocking_for_workgroup(size_t batch_size, bool& can_finish,
-                                                                        size_t* num_read_chunks, int dispatcher_id,
+                                                                        size_t* num_read_chunks, int worker_id,
                                                                         workgroup::WorkGroupPtr running_wg) {
     if (!_status.ok()) {
         return _status;
@@ -351,7 +351,7 @@ Status OlapChunkSource::buffer_next_batch_chunks_blocking_for_workgroup(size_t b
         }
 
         if (time_spent >= config::pipeline_scan_task_yield_preempt_max_time_spent &&
-            workgroup::WorkGroupManager::instance()->should_yield_io_dispatcher(dispatcher_id, running_wg)) {
+            workgroup::WorkGroupManager::instance()->get_owners_of_scan_worker(worker_id, running_wg)) {
             break;
         }
     }

--- a/be/src/exec/pipeline/olap_chunk_source.h
+++ b/be/src/exec/pipeline/olap_chunk_source.h
@@ -66,8 +66,7 @@ public:
 
     Status buffer_next_batch_chunks_blocking(size_t chunk_size, bool& can_finish) override;
     Status buffer_next_batch_chunks_blocking_for_workgroup(size_t chunk_size, bool& can_finish, size_t* num_read_chunks,
-                                                           int dispatcher_id,
-                                                           workgroup::WorkGroupPtr running_wg) override;
+                                                           int worker_id, workgroup::WorkGroupPtr running_wg) override;
 
 private:
     Status _get_tablet(const TInternalScanRange* scan_range);

--- a/be/src/exec/pipeline/pipeline_driver_executor.h
+++ b/be/src/exec/pipeline/pipeline_driver_executor.h
@@ -18,16 +18,17 @@
 
 namespace starrocks {
 namespace pipeline {
-class DriverDispatcher;
-using DriverDispatcherPtr = std::shared_ptr<DriverDispatcher>;
 
-class DriverDispatcher {
+class DriverExecutor;
+using DriverExecutorPtr = std::shared_ptr<DriverExecutor>;
+
+class DriverExecutor {
 public:
-    DriverDispatcher() = default;
-    virtual ~DriverDispatcher() = default;
+    DriverExecutor() = default;
+    virtual ~DriverExecutor() = default;
     virtual void initialize(int32_t num_threads) {}
     virtual void change_num_threads(int32_t num_threads) {}
-    virtual void dispatch(DriverRawPtr driver){};
+    virtual void submit(DriverRawPtr driver){};
 
     // When all the root drivers (the drivers have no successors in the same fragment) have finished,
     // just notify FE timely the completeness of fragment via invocation of report_exec_state, but
@@ -37,17 +38,17 @@ public:
     virtual void report_exec_state(FragmentContext* fragment_ctx, const Status& status, bool done) = 0;
 };
 
-class GlobalDriverDispatcher final : public FactoryMethod<DriverDispatcher, GlobalDriverDispatcher> {
+class GlobalDriverExecutor final : public FactoryMethod<DriverExecutor, GlobalDriverExecutor> {
 public:
-    GlobalDriverDispatcher(std::unique_ptr<ThreadPool> thread_pool, bool enable_resource_group);
-    ~GlobalDriverDispatcher() override;
+    GlobalDriverExecutor(std::unique_ptr<ThreadPool> thread_pool, bool enable_resource_group);
+    ~GlobalDriverExecutor() override;
     void initialize(int32_t num_threads) override;
     void change_num_threads(int32_t num_threads) override;
-    void dispatch(DriverRawPtr driver) override;
+    void submit(DriverRawPtr driver) override;
     void report_exec_state(FragmentContext* fragment_ctx, const Status& status, bool done) override;
 
 private:
-    void run();
+    void worker_thread();
     void finalize_driver(DriverRawPtr driver, RuntimeState* runtime_state, DriverState state);
     void update_profile_by_mode(FragmentContext* fragment_ctx, bool done);
     void remove_non_core_metrics(FragmentContext* fragment_ctx, std::vector<RuntimeProfile*>& driver_profiles);

--- a/be/src/exec/pipeline/pipeline_driver_poller.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_poller.cpp
@@ -115,7 +115,7 @@ void PipelineDriverPoller::run_internal() {
         } else {
             spin_count = 0;
 
-            _dispatch_queue->put_back(ready_drivers);
+            _driver_queue->put_back(ready_drivers);
             ready_drivers.clear();
         }
 

--- a/be/src/exec/pipeline/pipeline_driver_poller.h
+++ b/be/src/exec/pipeline/pipeline_driver_poller.h
@@ -11,14 +11,17 @@
 #include "pipeline_driver.h"
 #include "pipeline_driver_queue.h"
 #include "util/thread.h"
+
 namespace starrocks {
 namespace pipeline {
+
 class PipelineDriverPoller;
 using PipelineDriverPollerPtr = std::unique_ptr<PipelineDriverPoller>;
+
 class PipelineDriverPoller {
 public:
-    explicit PipelineDriverPoller(DriverQueue* dispatch_queue)
-            : _dispatch_queue(dispatch_queue),
+    explicit PipelineDriverPoller(DriverQueue* driver_queue)
+            : _driver_queue(driver_queue),
               _polling_thread(nullptr),
               _is_polling_thread_initialized(false),
               _is_shutdown(false) {}
@@ -43,7 +46,7 @@ private:
     std::mutex _mutex;
     std::condition_variable _cond;
     DriverList _blocked_drivers;
-    DriverQueue* _dispatch_queue;
+    DriverQueue* _driver_queue;
     scoped_refptr<Thread> _polling_thread;
     std::atomic<bool> _is_polling_thread_initialized;
     std::atomic<bool> _is_shutdown;

--- a/be/src/exec/pipeline/pipeline_fwd.h
+++ b/be/src/exec/pipeline/pipeline_fwd.h
@@ -29,8 +29,8 @@ using OpFactories = std::vector<OpFactoryPtr>;
 class Operator;
 using OperatorPtr = std::shared_ptr<Operator>;
 using Operators = std::vector<OperatorPtr>;
-class DriverDispatcher;
-using DriverDispatcherPtr = std::shared_ptr<DriverDispatcher>;
-class GlobalDriverDispatcher;
+class DriverExecutor;
+using DriverExecutorPtr = std::shared_ptr<DriverExecutor>;
+class GlobalDriverExecutor;
 class ExecStateReporter;
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/runtime_filter_types.h
+++ b/be/src/exec/pipeline/runtime_filter_types.h
@@ -147,7 +147,7 @@ private:
 };
 
 // A ExecNode in non-pipeline engine can be decomposed into more than one OperatorFactories in pipeline engine.
-// Dispatcher framework do not care about that runtime filters take affects on which OperatorFactories, since
+// Pipeline framework do not care about that runtime filters take affects on which OperatorFactories, since
 // it depends on Operators' implementation. so each OperatorFactory from the same ExecNode shared a
 // RefCountedRuntimeFilterProbeCollector, in which refcount is introduced to guarantee that both prepare and
 // close method of the RuntimeFilterProbeCollector inside this wrapper object is called only exactly-once.

--- a/be/src/exec/pipeline/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan_operator.cpp
@@ -167,13 +167,13 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
 
     bool offer_task_success = false;
     if (_workgroup != nullptr) {
-        auto task = [this, state, chunk_source_index](int dispatcher_id) {
+        auto task = [this, state, chunk_source_index](int worker_id) {
             {
                 SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(state->instance_mem_tracker());
 
                 size_t num_read_chunks = 0;
                 _chunk_sources[chunk_source_index]->buffer_next_batch_chunks_blocking_for_workgroup(
-                        _buffer_size, _is_finished, &num_read_chunks, dispatcher_id, _workgroup);
+                        _buffer_size, _is_finished, &num_read_chunks, worker_id, _workgroup);
                 // TODO (by laotan332): More detailed information is needed
                 _workgroup->incr_period_scaned_chunk_num(num_read_chunks);
             }

--- a/be/src/exec/workgroup/scan_executor.cpp
+++ b/be/src/exec/workgroup/scan_executor.cpp
@@ -1,45 +1,45 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021-present StarRocks Limited.
 
-#include "scan_worker.h"
+#include "scan_executor.h"
 
 namespace starrocks::workgroup {
 
-ScanWorker::ScanWorker(std::unique_ptr<ThreadPool> thread_pool) : _thread_pool(std::move(thread_pool)) {}
+ScanExecutor::ScanExecutor(std::unique_ptr<ThreadPool> thread_pool) : _thread_pool(std::move(thread_pool)) {}
 
-ScanWorker::~ScanWorker() {
+ScanExecutor::~ScanExecutor() {
     workgroup::WorkGroupManager::instance()->close();
 }
 
-void ScanWorker::initialize(int num_threads) {
+void ScanExecutor::initialize(int num_threads) {
     _num_threads_setter.set_actual_num(num_threads);
     for (auto i = 0; i < num_threads; ++i) {
-        _thread_pool->submit_func([this]() { this->run(); });
+        _thread_pool->submit_func([this]() { this->worker_thread(); });
     }
 }
 
-void ScanWorker::change_num_threads(int32_t num_threads) {
+void ScanExecutor::change_num_threads(int32_t num_threads) {
     int32_t old_num_threads = 0;
     if (!_num_threads_setter.adjust_expect_num(num_threads, &old_num_threads)) {
         return;
     }
     for (int i = old_num_threads; i < num_threads; ++i) {
-        _thread_pool->submit_func([this]() { this->run(); });
+        _thread_pool->submit_func([this]() { this->worker_thread(); });
     }
 }
 
-void ScanWorker::run() {
-    const int dispatcher_id = _next_id++;
+void ScanExecutor::worker_thread() {
+    const int worker_id = _next_id++;
     while (true) {
         if (_num_threads_setter.should_shrink()) {
             break;
         }
 
-        auto maybe_task = WorkGroupManager::instance()->pick_next_task_for_io(dispatcher_id);
+        auto maybe_task = WorkGroupManager::instance()->pick_next_task_for_io(worker_id);
         if (maybe_task.status().is_cancelled()) {
             return;
         }
 
-        maybe_task.value()(dispatcher_id);
+        maybe_task.value()(worker_id);
     }
 }
 

--- a/be/src/exec/workgroup/scan_executor.h
+++ b/be/src/exec/workgroup/scan_executor.h
@@ -2,19 +2,22 @@
 #include "util/limit_setter.h"
 #include "util/threadpool.h"
 #include "work_group.h"
+
 namespace starrocks {
 namespace workgroup {
-class ScanWorker;
+
+class ScanExecutor;
 class WorkGroupManager;
-class ScanWorker {
+
+class ScanExecutor {
 public:
-    explicit ScanWorker(std::unique_ptr<ThreadPool> thread_pool);
-    virtual ~ScanWorker();
+    explicit ScanExecutor(std::unique_ptr<ThreadPool> thread_pool);
+    virtual ~ScanExecutor();
     void initialize(int32_t num_threads);
     void change_num_threads(int32_t num_threads);
 
 private:
-    void run();
+    void worker_thread();
 
 private:
     LimitSetter _num_threads_setter;

--- a/be/src/exec/workgroup/work_group_fwd.h
+++ b/be/src/exec/workgroup/work_group_fwd.h
@@ -6,7 +6,7 @@ namespace starrocks::workgroup {
 
 class WorkGroup;
 class WorkGroupManager;
-class ScanWorker;
+class ScanExecutor;
 
 using WorkGroupPtr = std::shared_ptr<WorkGroup>;
 

--- a/be/src/runtime/data_stream_recvr.cc
+++ b/be/src/runtime/data_stream_recvr.cc
@@ -192,8 +192,8 @@ void DataStreamRecvr::SenderQueue::short_circuit_for_pipeline(const int32_t driv
 
 bool DataStreamRecvr::SenderQueue::has_output_for_pipeline(const int32_t driver_sequence) {
     // First check without lock to avoid competition
-    // This method may be invoked by PipelineDriverPoller and GlobalDriverDispatcher simultaneously
-    // when some of the driver_sequences has no chunks to get but the others do, then GlobalDriverDispatcher
+    // This method may be invoked by PipelineDriverPoller and GlobalDriverExecutor simultaneously
+    // when some driver_sequences has no chunks to get but the others do, then GlobalDriverExecutor
     // may be starved because PipelineDriverPoller will call this method repeatedly with almost no interval
     // Both false positives and false negatives are allowed here
     {

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -26,9 +26,9 @@
 #include "column/column_pool.h"
 #include "common/config.h"
 #include "common/logging.h"
-#include "exec/pipeline/pipeline_driver_dispatcher.h"
+#include "exec/pipeline/pipeline_driver_executor.h"
 #include "exec/pipeline/pipeline_fwd.h"
-#include "exec/workgroup/scan_worker.h"
+#include "exec/workgroup/scan_executor.h"
 #include "exec/workgroup/work_group.h"
 #include "gen_cpp/BackendService.h"
 #include "gen_cpp/FrontendService.h"
@@ -143,43 +143,43 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths) {
             new PriorityThreadPool("pip_scan_io", // pipeline scan io
                                    num_io_threads, config::pipeline_scan_thread_pool_queue_size);
     std::unique_ptr<ThreadPool> scan_worker_thread_pool;
-    RETURN_IF_ERROR(ThreadPoolBuilder("scan_worker") // scan_worker
+    RETURN_IF_ERROR(ThreadPoolBuilder("scan_executor") // scan io task executor
                             .set_min_threads(0)
                             .set_max_threads(num_io_threads)
                             .set_max_queue_size(1000)
                             .set_idle_timeout(MonoDelta::FromMilliseconds(2000))
                             .build(&scan_worker_thread_pool));
-    _scan_worker = new workgroup::ScanWorker(std::move(scan_worker_thread_pool));
-    _scan_worker->initialize(num_io_threads);
+    _scan_executor = new workgroup::ScanExecutor(std::move(scan_worker_thread_pool));
+    _scan_executor->initialize(num_io_threads);
 
     _num_scan_operators = 0;
     _etl_thread_pool = new PriorityThreadPool("elt", config::etl_thread_pool_size, config::etl_thread_pool_queue_size);
     _fragment_mgr = new FragmentMgr(this);
 
-    std::unique_ptr<ThreadPool> driver_dispatcher_thread_pool;
+    std::unique_ptr<ThreadPool> driver_executor_thread_pool;
     auto max_thread_num = std::thread::hardware_concurrency();
     if (config::pipeline_exec_thread_pool_thread_num > 0) {
         max_thread_num = config::pipeline_exec_thread_pool_thread_num;
     }
     LOG(INFO) << strings::Substitute("[PIPELINE] Exec thread pool: thread_num=$0", max_thread_num);
-    RETURN_IF_ERROR(ThreadPoolBuilder("pip_dispatcher") // pipeline dispatcher
+    RETURN_IF_ERROR(ThreadPoolBuilder("pip_executor") // pipeline executor
                             .set_min_threads(0)
                             .set_max_threads(max_thread_num)
                             .set_max_queue_size(1000)
                             .set_idle_timeout(MonoDelta::FromMilliseconds(2000))
-                            .build(&driver_dispatcher_thread_pool));
-    _driver_dispatcher = new pipeline::GlobalDriverDispatcher(std::move(driver_dispatcher_thread_pool), false);
-    _driver_dispatcher->initialize(max_thread_num);
+                            .build(&driver_executor_thread_pool));
+    _driver_executor = new pipeline::GlobalDriverExecutor(std::move(driver_executor_thread_pool), false);
+    _driver_executor->initialize(max_thread_num);
 
-    std::unique_ptr<ThreadPool> wg_driver_dispatcher_thread_pool;
-    RETURN_IF_ERROR(ThreadPoolBuilder("pip_wg_dispatcher") // pipeline dispatcher
+    std::unique_ptr<ThreadPool> wg_driver_executor_thread_pool;
+    RETURN_IF_ERROR(ThreadPoolBuilder("pip_wg_executor") // pipeline executor for workgroup
                             .set_min_threads(0)
                             .set_max_threads(max_thread_num)
                             .set_max_queue_size(1000)
                             .set_idle_timeout(MonoDelta::FromMilliseconds(2000))
-                            .build(&wg_driver_dispatcher_thread_pool));
-    _wg_driver_dispatcher = new pipeline::GlobalDriverDispatcher(std::move(wg_driver_dispatcher_thread_pool), true);
-    _wg_driver_dispatcher->initialize(max_thread_num);
+                            .build(&wg_driver_executor_thread_pool));
+    _wg_driver_executor = new pipeline::GlobalDriverExecutor(std::move(wg_driver_executor_thread_pool), true);
+    _wg_driver_executor->initialize(max_thread_num);
 
     _master_info = new TMasterInfo();
     _load_path_mgr = new LoadPathMgr(this);
@@ -355,13 +355,13 @@ void ExecEnv::_destroy() {
         delete _master_info;
         _master_info = nullptr;
     }
-    if (_driver_dispatcher) {
-        delete _driver_dispatcher;
-        _driver_dispatcher = nullptr;
+    if (_driver_executor) {
+        delete _driver_executor;
+        _driver_executor = nullptr;
     }
-    if (_wg_driver_dispatcher) {
-        delete _wg_driver_dispatcher;
-        _wg_driver_dispatcher = nullptr;
+    if (_wg_driver_executor) {
+        delete _wg_driver_executor;
+        _wg_driver_executor = nullptr;
     }
     if (_fragment_mgr) {
         delete _fragment_mgr;
@@ -375,9 +375,9 @@ void ExecEnv::_destroy() {
         delete _pipeline_scan_io_thread_pool;
         _pipeline_scan_io_thread_pool = nullptr;
     }
-    if (_scan_worker) {
-        delete _scan_worker;
-        _scan_worker = nullptr;
+    if (_scan_executor) {
+        delete _scan_executor;
+        _scan_executor = nullptr;
     }
     if (_thread_pool) {
         delete _thread_pool;

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -65,7 +65,7 @@ class ClientCache;
 class HeartbeatFlags;
 
 namespace pipeline {
-class DriverDispatcher;
+class DriverExecutor;
 }
 
 // Execution environment for queries/plan fragments.
@@ -129,8 +129,8 @@ public:
     size_t decrement_num_scan_operators(size_t n) { return _num_scan_operators.fetch_sub(n); }
     PriorityThreadPool* etl_thread_pool() { return _etl_thread_pool; }
     FragmentMgr* fragment_mgr() { return _fragment_mgr; }
-    starrocks::pipeline::DriverDispatcher* driver_dispatcher() { return _driver_dispatcher; }
-    starrocks::pipeline::DriverDispatcher* wg_driver_dispatcher() { return _wg_driver_dispatcher; }
+    starrocks::pipeline::DriverExecutor* driver_executor() { return _driver_executor; }
+    starrocks::pipeline::DriverExecutor* wg_driver_executor() { return _wg_driver_executor; }
     TMasterInfo* master_info() { return _master_info; }
     LoadPathMgr* load_path_mgr() { return _load_path_mgr; }
     BfdParser* bfd_parser() const { return _bfd_parser; }
@@ -140,7 +140,7 @@ public:
     LoadStreamMgr* load_stream_mgr() { return _load_stream_mgr; }
     SmallFileMgr* small_file_mgr() { return _small_file_mgr; }
 
-    starrocks::workgroup::ScanWorker* scan_worker() { return _scan_worker; }
+    starrocks::workgroup::ScanExecutor* scan_executor() { return _scan_executor; }
 
     const std::vector<StorePath>& store_paths() const { return _store_paths; }
     void set_store_paths(const std::vector<StorePath>& paths) { _store_paths = paths; }
@@ -209,12 +209,12 @@ private:
     std::atomic<size_t> _num_scan_operators;
     PriorityThreadPool* _etl_thread_pool = nullptr;
     FragmentMgr* _fragment_mgr = nullptr;
-    starrocks::pipeline::DriverDispatcher* _driver_dispatcher = nullptr;
-    pipeline::DriverDispatcher* _wg_driver_dispatcher = nullptr;
+    starrocks::pipeline::DriverExecutor* _driver_executor = nullptr;
+    pipeline::DriverExecutor* _wg_driver_executor = nullptr;
     TMasterInfo* _master_info = nullptr;
     LoadPathMgr* _load_path_mgr = nullptr;
 
-    starrocks::workgroup::ScanWorker* _scan_worker = nullptr;
+    starrocks::workgroup::ScanExecutor* _scan_executor = nullptr;
 
     BfdParser* _bfd_parser = nullptr;
     BrokerMgr* _broker_mgr = nullptr;

--- a/be/src/util/json.h
+++ b/be/src/util/json.h
@@ -215,8 +215,8 @@ struct less<starrocks::JsonValue> {
     }
 
     bool operator()(const starrocks::JsonValue* lhs, const starrocks::JsonValue* rhs) const {
-        DCHECK_NOTNULL(lhs);
-        DCHECK_NOTNULL(rhs);
+        DCHECK(lhs != nullptr);
+        DCHECK(rhs != nullptr);
         return starrocks::JsonValue::compare(lhs->get_slice(), rhs->get_slice()) < 0;
     }
 
@@ -232,8 +232,8 @@ struct less_equal<starrocks::JsonValue> {
     }
 
     bool operator()(const starrocks::JsonValue* lhs, const starrocks::JsonValue* rhs) const {
-        DCHECK_NOTNULL(lhs);
-        DCHECK_NOTNULL(rhs);
+        DCHECK(lhs != nullptr);
+        DCHECK(rhs != nullptr);
         return starrocks::JsonValue::compare(lhs->get_slice(), rhs->get_slice()) <= 0;
     }
 
@@ -248,8 +248,8 @@ struct greater<starrocks::JsonValue> {
         return lhs.compare(rhs) > 0;
     }
     bool operator()(const starrocks::JsonValue* lhs, const starrocks::JsonValue* rhs) const {
-        DCHECK_NOTNULL(lhs);
-        DCHECK_NOTNULL(rhs);
+        DCHECK(lhs != nullptr);
+        DCHECK(rhs != nullptr);
         return starrocks::JsonValue::compare(lhs->get_slice(), rhs->get_slice()) > 0;
     }
 
@@ -264,8 +264,8 @@ struct greater_equal<starrocks::JsonValue> {
     }
 
     bool operator()(const starrocks::JsonValue* lhs, const starrocks::JsonValue* rhs) const {
-        DCHECK_NOTNULL(lhs);
-        DCHECK_NOTNULL(rhs);
+        DCHECK(lhs != nullptr);
+        DCHECK(rhs != nullptr);
         return starrocks::JsonValue::compare(lhs->get_slice(), rhs->get_slice()) >= 0;
     }
 
@@ -280,8 +280,8 @@ struct equal_to<starrocks::JsonValue> {
     }
 
     bool operator()(const starrocks::JsonValue* lhs, const starrocks::JsonValue* rhs) const {
-        DCHECK_NOTNULL(lhs);
-        DCHECK_NOTNULL(rhs);
+        DCHECK(lhs != nullptr);
+        DCHECK(rhs != nullptr);
         return starrocks::JsonValue::compare(lhs->get_slice(), rhs->get_slice()) == 0;
     }
 
@@ -296,8 +296,8 @@ struct not_equal_to<starrocks::JsonValue> {
     }
 
     bool operator()(const starrocks::JsonValue* lhs, const starrocks::JsonValue* rhs) const {
-        DCHECK_NOTNULL(lhs);
-        DCHECK_NOTNULL(rhs);
+        DCHECK(lhs != nullptr);
+        DCHECK(rhs != nullptr);
         return starrocks::JsonValue::compare(lhs->get_slice(), rhs->get_slice()) != 0;
     }
 

--- a/be/test/exec/pipeline/pipeline_test_base.cpp
+++ b/be/test/exec/pipeline/pipeline_test_base.cpp
@@ -6,7 +6,7 @@
 
 #include "column/nullable_column.h"
 #include "exec/pipeline/fragment_context.h"
-#include "exec/pipeline/pipeline_driver_dispatcher.h"
+#include "exec/pipeline/pipeline_driver_executor.h"
 #include "runtime/date_value.h"
 #include "runtime/timestamp_value.h"
 #include "storage/vectorized/chunk_helper.h"
@@ -123,7 +123,7 @@ void PipelineTestBase::_execute() {
         ASSERT_TRUE(driver->prepare(_fragment_ctx->runtime_state()).ok());
     }
     for (const auto& driver : _fragment_ctx->drivers()) {
-        _exec_env->driver_dispatcher()->dispatch(driver.get());
+        _exec_env->driver_executor()->submit(driver.get());
     }
 }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [x] others


## Problem Summary：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Rename `DriverDispatcher` to `DriverExecutor`, `DriverDispatcher::run` to `DriverExecutor::worker_thread` , `ScanWorker` to `ScanExecutor`, `ScanWorker::run` to `ScanExecutor::worker_thread`.
The reason is that `DriverExecutor` or `ScanExecutor` includes multiple worker threads, so using `Worker` or `Dispatcher` maybe isn't improper.
