### PR TITLE
Remove taskContext list of optimizeContext

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -71,7 +71,6 @@ public class Optimizer {
         context = new OptimizerContext(memo, columnRefFactory, connectContext);
         TaskContext rootTaskContext =
                 new TaskContext(context, requiredProperty, (ColumnRefSet) requiredColumns.clone(), Double.MAX_VALUE);
-        context.addTaskContext(rootTaskContext);
 
         // Note: root group of memo maybe change after rewrite,
         // so we should always get root group and root group expression

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
@@ -2,7 +2,6 @@
 
 package com.starrocks.sql.optimizer;
 
-import com.google.common.collect.Lists;
 import com.starrocks.catalog.Catalog;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
@@ -14,24 +13,21 @@ import com.starrocks.sql.optimizer.task.SeriallyTaskScheduler;
 import com.starrocks.sql.optimizer.task.TaskContext;
 import com.starrocks.sql.optimizer.task.TaskScheduler;
 
-import java.util.List;
-
 public class OptimizerContext {
     private final Memo memo;
     private final RuleSet ruleSet;
     private final Catalog catalog;
-    private final List<TaskContext> taskContext;
     private final TaskScheduler taskScheduler;
     private final ColumnRefFactory columnRefFactory;
     private SessionVariable sessionVariable;
     private DumpInfo dumpInfo;
     private CTEContext cteContext;
+    private TaskContext currentTaskContext;
 
     public OptimizerContext(Memo memo, ColumnRefFactory columnRefFactory) {
         this.memo = memo;
         this.ruleSet = new RuleSet();
         this.catalog = Catalog.getCurrentCatalog();
-        this.taskContext = Lists.newArrayList();
         this.taskScheduler = SeriallyTaskScheduler.create();
         this.columnRefFactory = columnRefFactory;
         this.sessionVariable = VariableMgr.newSessionVariable();
@@ -41,7 +37,6 @@ public class OptimizerContext {
         this.memo = memo;
         this.ruleSet = new RuleSet();
         this.catalog = Catalog.getCurrentCatalog();
-        this.taskContext = Lists.newArrayList();
         this.taskScheduler = SeriallyTaskScheduler.create();
         this.columnRefFactory = columnRefFactory;
         this.sessionVariable = connectContext.getSessionVariable();
@@ -62,14 +57,6 @@ public class OptimizerContext {
 
     public Catalog getCatalog() {
         return catalog;
-    }
-
-    public List<TaskContext> getTaskContext() {
-        return taskContext;
-    }
-
-    public void addTaskContext(TaskContext context) {
-        taskContext.add(context);
     }
 
     public TaskScheduler getTaskScheduler() {
@@ -94,5 +81,13 @@ public class OptimizerContext {
 
     public CTEContext getCteContext() {
         return cteContext;
+    }
+
+    public void setTaskContext(TaskContext context) {
+        this.currentTaskContext = context;
+    }
+
+    public TaskContext getTaskContext() {
+        return currentTaskContext;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneAggregateColumnsRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneAggregateColumnsRule.java
@@ -32,7 +32,7 @@ public class PruneAggregateColumnsRule extends TransformationRule {
 
         ColumnRefSet requiredInputColumns = new ColumnRefSet(aggOperator.getGroupingKeys());
 
-        ColumnRefSet requiredOutputColumns = context.getTaskContext().get(0).getRequiredColumns();
+        ColumnRefSet requiredOutputColumns = context.getTaskContext().getRequiredColumns();
 
         // Agg required input provide the having used columns
         if (aggOperator.getPredicate() != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneCTEConsumeColumnsRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneCTEConsumeColumnsRule.java
@@ -27,7 +27,7 @@ public class PruneCTEConsumeColumnsRule extends TransformationRule {
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
         LogicalCTEConsumeOperator consume = (LogicalCTEConsumeOperator) input.getOp();
 
-        ColumnRefSet requiredConsumeOutput = context.getTaskContext().get(0).getRequiredColumns();
+        ColumnRefSet requiredConsumeOutput = context.getTaskContext().getRequiredColumns();
 
         // predicate
         if (null != consume.getPredicate()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneExceptColumnsRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneExceptColumnsRule.java
@@ -23,7 +23,7 @@ public class PruneExceptColumnsRule extends TransformationRule {
 
     @Override
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
-        ColumnRefSet requiredOutputColumns = context.getTaskContext().get(0).getRequiredColumns();
+        ColumnRefSet requiredOutputColumns = context.getTaskContext().getRequiredColumns();
 
         LogicalSetOperator lso = (LogicalSetOperator) input.getOp();
         List<ColumnRefOperator> outputs = lso.getOutputColumnRefOp();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneFilterColumnsRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneFilterColumnsRule.java
@@ -24,7 +24,7 @@ public class PruneFilterColumnsRule extends TransformationRule {
         LogicalFilterOperator filterOperator = (LogicalFilterOperator) input.getOp();
         ColumnRefSet requiredInputColumns = filterOperator.getRequiredChildInputColumns();
 
-        ColumnRefSet requiredOutputColumns = context.getTaskContext().get(0).getRequiredColumns();
+        ColumnRefSet requiredOutputColumns = context.getTaskContext().getRequiredColumns();
 
         // Change the requiredOutputColumns in context
         requiredOutputColumns.union(requiredInputColumns);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneHDFSScanColumnRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneHDFSScanColumnRule.java
@@ -39,7 +39,7 @@ public class PruneHDFSScanColumnRule extends TransformationRule {
     @Override
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
         LogicalScanOperator scanOperator = (LogicalScanOperator) input.getOp();
-        ColumnRefSet requiredOutputColumns = context.getTaskContext().get(0).getRequiredColumns();
+        ColumnRefSet requiredOutputColumns = context.getTaskContext().getRequiredColumns();
 
         Set<ColumnRefOperator> scanColumns =
                 scanOperator.getColRefToColumnMetaMap().keySet().stream().filter(requiredOutputColumns::contains)

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneIntersectColumnsRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneIntersectColumnsRule.java
@@ -23,7 +23,7 @@ public class PruneIntersectColumnsRule extends TransformationRule {
 
     @Override
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
-        ColumnRefSet requiredOutputColumns = context.getTaskContext().get(0).getRequiredColumns();
+        ColumnRefSet requiredOutputColumns = context.getTaskContext().getRequiredColumns();
 
         LogicalSetOperator lso = (LogicalSetOperator) input.getOp();
         List<ColumnRefOperator> outputs = lso.getOutputColumnRefOp();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneJoinColumnsRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneJoinColumnsRule.java
@@ -24,7 +24,7 @@ public class PruneJoinColumnsRule extends TransformationRule {
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
         LogicalJoinOperator joinOperator = (LogicalJoinOperator) input.getOp();
 
-        ColumnRefSet requiredColumns = context.getTaskContext().get(0).getRequiredColumns();
+        ColumnRefSet requiredColumns = context.getTaskContext().getRequiredColumns();
         requiredColumns.union(joinOperator.getRequiredChildInputColumns());
 
         return Collections.emptyList();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneProjectColumnsRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneProjectColumnsRule.java
@@ -29,7 +29,7 @@ public class PruneProjectColumnsRule extends TransformationRule {
         LogicalProjectOperator projectOperator = (LogicalProjectOperator) input.getOp();
 
         ColumnRefSet requiredInputColumns = new ColumnRefSet();
-        ColumnRefSet requiredOutputColumns = context.getTaskContext().get(0).getRequiredColumns();
+        ColumnRefSet requiredOutputColumns = context.getTaskContext().getRequiredColumns();
 
         Map<ColumnRefOperator, ScalarOperator> newMap = Maps.newHashMap();
         projectOperator.getColumnRefMap().forEach(((columnRefOperator, operator) -> {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneRepeatColumnsRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneRepeatColumnsRule.java
@@ -22,7 +22,7 @@ public class PruneRepeatColumnsRule extends TransformationRule {
     @Override
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
         LogicalRepeatOperator repeatOperator = (LogicalRepeatOperator) input.getOp();
-        ColumnRefSet requiredOutputColumns = context.getTaskContext().get(0).getRequiredColumns();
+        ColumnRefSet requiredOutputColumns = context.getTaskContext().getRequiredColumns();
         requiredOutputColumns.union(repeatOperator.getOutputColumns(null));
         return Collections.emptyList();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneScanColumnRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneScanColumnRule.java
@@ -42,7 +42,7 @@ public class PruneScanColumnRule extends TransformationRule {
     @Override
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
         LogicalScanOperator scanOperator = (LogicalScanOperator) input.getOp();
-        ColumnRefSet requiredOutputColumns = context.getTaskContext().get(0).getRequiredColumns();
+        ColumnRefSet requiredOutputColumns = context.getTaskContext().getRequiredColumns();
 
         // The `outputColumns`s are some columns required but not specified by `requiredOutputColumns`.
         // including columns in predicate or some specialized columns defined by scan operator.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneTableFunctionColumnRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneTableFunctionColumnRule.java
@@ -26,7 +26,7 @@ public class PruneTableFunctionColumnRule extends TransformationRule {
     @Override
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
         LogicalTableFunctionOperator logicalTableFunctionOperator = (LogicalTableFunctionOperator) input.getOp();
-        ColumnRefSet requiredOutputColumns = context.getTaskContext().get(0).getRequiredColumns();
+        ColumnRefSet requiredOutputColumns = context.getTaskContext().getRequiredColumns();
 
         ColumnRefSet newOuterColumnRefSet = new ColumnRefSet();
         for (int columnId : logicalTableFunctionOperator.getOuterColumnRefSet().getColumnIds()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneTopNColumnsRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneTopNColumnsRule.java
@@ -24,7 +24,7 @@ public class PruneTopNColumnsRule extends TransformationRule {
         LogicalTopNOperator topNOperator = (LogicalTopNOperator) input.getOp();
         ColumnRefSet requiredInputColumns = topNOperator.getRequiredChildInputColumns();
 
-        ColumnRefSet requiredOutputColumns = context.getTaskContext().get(0).getRequiredColumns();
+        ColumnRefSet requiredOutputColumns = context.getTaskContext().getRequiredColumns();
 
         // Change the requiredOutputColumns in context
         requiredOutputColumns.union(requiredInputColumns);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneUnionColumnsRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneUnionColumnsRule.java
@@ -24,7 +24,7 @@ public class PruneUnionColumnsRule extends TransformationRule {
 
     @Override
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
-        ColumnRefSet requiredOutputColumns = context.getTaskContext().get(0).getRequiredColumns();
+        ColumnRefSet requiredOutputColumns = context.getTaskContext().getRequiredColumns();
 
         LogicalSetOperator lso = (LogicalSetOperator) input.getOp();
         List<ColumnRefOperator> outputs = lso.getOutputColumnRefOp();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneValuesColumnsRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneValuesColumnsRule.java
@@ -29,7 +29,7 @@ public class PruneValuesColumnsRule extends TransformationRule {
 
     @Override
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
-        ColumnRefSet requiredOutputColumns = context.getTaskContext().get(0).getRequiredColumns();
+        ColumnRefSet requiredOutputColumns = context.getTaskContext().getRequiredColumns();
 
         LogicalValuesOperator valuesOperator = (LogicalValuesOperator) input.getOp();
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneWindowColumnsRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneWindowColumnsRule.java
@@ -28,7 +28,7 @@ public class PruneWindowColumnsRule extends TransformationRule {
     @Override
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
         LogicalWindowOperator windowOperator = (LogicalWindowOperator) input.getOp();
-        ColumnRefSet requiredOutputColumns = context.getTaskContext().get(0).getRequiredColumns();
+        ColumnRefSet requiredOutputColumns = context.getTaskContext().getRequiredColumns();
         ColumnRefSet requiredInputColumns = new ColumnRefSet();
         requiredInputColumns.union(requiredOutputColumns);
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownJoinAggRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownJoinAggRule.java
@@ -135,7 +135,7 @@ public class PushDownJoinAggRule extends TransformationRule {
         }
 
         List<ScalarOperator> requiredOutput =
-                Arrays.stream(context.getTaskContext().get(0).getRequiredColumns().getColumnIds())
+                Arrays.stream(context.getTaskContext().getRequiredColumns().getColumnIds())
                         .mapToObj(factory::getColumnRef).collect(Collectors.toList());
 
         ScalarEquivalenceExtractor equivalenceExtractor = new ScalarEquivalenceExtractor();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/EnforceAndCostTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/EnforceAndCostTask.java
@@ -188,7 +188,6 @@ public class EnforceAndCostTask extends OptimizerTask implements Cloneable {
         TaskContext taskContext = new TaskContext(context.getOptimizerContext(),
                 inputProperty, context.getRequiredColumns(), newUpperBound, context.getAllScanOperators());
         pushTask(new OptimizeGroupTask(taskContext, childGroup));
-        context.getOptimizerContext().addTaskContext(taskContext);
     }
 
     // Check if the broadcast table row count exceeds the broadcastRowCountLimit.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/SeriallyTaskScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/SeriallyTaskScheduler.java
@@ -37,7 +37,9 @@ public class SeriallyTaskScheduler implements TaskScheduler {
                 }
                 break;
             }
-            tasks.pop().execute();
+            OptimizerTask task = tasks.pop();
+            context.getOptimizerContext().setTaskContext(context);
+            task.execute();
         }
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

1. The task context only use on column prune now, and only one task context. Other optimize task ask task context don't by optimize context. So the list of task context is unless.
2. The list of task context will be longer and longer with the complex of plan（because the EnforceTask always save a new task context）, the copy cost of ArrayList will be more and more expensive
