### PR TITLE
Make APIs of RandomAccessFile similar to those of io::RandomAccessFile

### DIFF
--- a/be/src/env/env.h
+++ b/be/src/env/env.h
@@ -182,16 +182,14 @@ public:
     SequentialFile() = default;
     virtual ~SequentialFile() = default;
 
-    // Read up to "result.size" bytes from the file.
-    // Copies the resulting data into "result.data".
+    // Read up to "size" bytes from the file.
+    // Copies the resulting data into "data".
     //
-    // If an error was encountered, returns a non-OK status
-    // and the contents of "result" are invalid.
-    //
-    // Return OK if reached the end of file.
+    // On success, return the number of bytes read, otherwise return
+    // an error and the contents of "result" are invalid.
     //
     // REQUIRES: External synchronization
-    virtual Status read(Slice* result) = 0;
+    virtual StatusOr<int64_t> read(void* data, int64_t size) = 0;
 
     // Skip "n" bytes from the file. This is guaranteed to be no
     // slower that reading the same data, but may be faster.
@@ -216,23 +214,18 @@ public:
     RandomAccessFile() = default;
     virtual ~RandomAccessFile() = default;
 
-    // Read up to "result.size" bytes from the file.
-    // Copies the resulting data into "result.data".
+    // Read up to "size" bytes from the file.
+    // Copies the resulting data into "data".
     //
-    // Return OK if reached the end of file.
-    virtual Status read(uint64_t offset, Slice* res) const = 0;
+    // Return the number of bytes read or error.
+    virtual StatusOr<int64_t> read_at(int64_t offset, void* data, int64_t size) const = 0;
 
-    // Read "result.size" bytes from the file starting at "offset".
-    // Copies the resulting data into "result.data".
-    //
-    // If an error was encountered, returns a non-OK status.
-    //
-    // This method will internally retry on EINTR and "short reads" in order to
-    // fully read the requested number of bytes. In the event that it is not
-    // possible to read exactly 'length' bytes, an IOError is returned.
-    //
-    // Safe for concurrent use by multiple threads.
-    virtual Status read_at(uint64_t offset, const Slice& result) const = 0;
+    // Read exactly the number of "size" bytes data from given position "offset".
+    // This method does not return the number of bytes read because either
+    // (1) the entire "size" bytes is read
+    // (2) the end of the stream is reached
+    // If the eof is reached, an IO error is returned.
+    virtual Status read_at_fully(int64_t offset, void* data, int64_t size) const = 0;
 
     // Reads up to the "results" aggregate size, based on each Slice's "size",
     // from the file starting at 'offset'. The Slices must point to already-allocated

--- a/be/src/env/env_memory.h
+++ b/be/src/env/env_memory.h
@@ -14,22 +14,20 @@ public:
     explicit StringRandomAccessFile(std::string str) : _str(std::move(str)) {}
     ~StringRandomAccessFile() override = default;
 
-    Status read(uint64_t offset, Slice* res) const override {
+    StatusOr<int64_t> read_at(int64_t offset, void* data, int64_t size) const override {
         if (offset >= _str.size()) {
-            res->size = 0;
-            return Status::OK();
+            return 0;
         }
-        size_t to_read = std::min<size_t>(res->size, _str.size() - offset);
-        memcpy(res->data, _str.data() + offset, to_read);
-        res->size = to_read;
-        return Status::OK();
+        size_t to_read = std::min<size_t>(size, _str.size() - offset);
+        memcpy(data, _str.data() + offset, to_read);
+        return to_read;
     }
 
-    Status read_at(uint64_t offset, const Slice& result) const override {
-        if (offset + result.size > _str.size()) {
+    Status read_at_fully(int64_t offset, void* data, int64_t size) const override {
+        if (offset + size > _str.size()) {
             return Status::InternalError("");
         }
-        memcpy(result.data, _str.data() + offset, result.size);
+        memcpy(data, _str.data() + offset, size);
         return Status::OK();
     }
 
@@ -67,12 +65,10 @@ public:
     explicit StringSequentialFile(std::string str) : _random_file(std::move(str)) {}
     ~StringSequentialFile() override = default;
 
-    Status read(Slice* res) override {
-        Status st = _random_file.read(_offset, res);
-        if (st.ok()) {
-            _offset += res->size;
-        }
-        return st;
+    StatusOr<int64_t> read(void* data, int64_t size) override {
+        ASSIGN_OR_RETURN(auto nread, _random_file.read_at(_offset, data, size));
+        _offset += nread;
+        return nread;
     }
 
     const std::string& filename() const override {

--- a/be/src/env/env_stream_pipe.cpp
+++ b/be/src/env/env_stream_pipe.cpp
@@ -14,9 +14,11 @@ StreamPipeSequentialFile::~StreamPipeSequentialFile() {
     _file->close();
 }
 
-Status StreamPipeSequentialFile::read(Slice* result) {
+StatusOr<int64_t> StreamPipeSequentialFile::read(void* data, int64_t size) {
     bool eof = false;
-    return _file->read(reinterpret_cast<uint8_t*>(result->data), &(result->size), &eof);
+    size_t nread = size;
+    RETURN_IF_ERROR(_file->read(static_cast<uint8_t*>(data), &nread, &eof));
+    return nread;
 }
 
 Status StreamPipeSequentialFile::read_one_message(std::unique_ptr<uint8_t[]>* buf, size_t* length, size_t padding) {

--- a/be/src/env/env_stream_pipe.h
+++ b/be/src/env/env_stream_pipe.h
@@ -15,7 +15,8 @@ public:
     explicit StreamPipeSequentialFile(std::shared_ptr<StreamLoadPipe> file);
     ~StreamPipeSequentialFile() override;
 
-    Status read(Slice* result) override;
+    StatusOr<int64_t> read(void* data, int64_t size) override;
+
     Status read_one_message(std::unique_ptr<uint8_t[]>* buf, size_t* length, size_t padding = 0);
 
     Status skip(uint64_t n) override;

--- a/be/src/exec/parquet/file_reader.cpp
+++ b/be/src/exec/parquet/file_reader.cpp
@@ -75,8 +75,7 @@ Status FileReader::_parse_footer() {
     uint64_t to_read = std::min(_file_size, footer_buf_size);
     {
         SCOPED_RAW_TIMER(&_param.stats->footer_read_ns);
-        Slice slice(footer_buf, to_read);
-        RETURN_IF_ERROR(_file->read_at(_file_size - to_read, slice));
+        RETURN_IF_ERROR(_file->read_at_fully(_file_size - to_read, footer_buf, to_read));
     }
     // check magic
     RETURN_IF_ERROR(_check_magic(footer_buf + to_read - 4));
@@ -96,8 +95,7 @@ Status FileReader::_parse_footer() {
         footer_buf = new uint8[to_read];
         {
             SCOPED_RAW_TIMER(&_param.stats->footer_read_ns);
-            Slice slice(footer_buf, to_read);
-            RETURN_IF_ERROR(_file->read_at(_file_size - to_read, slice));
+            RETURN_IF_ERROR(_file->read_at_fully(_file_size - to_read, footer_buf, to_read));
         }
     }
 

--- a/be/src/exec/vectorized/csv_scanner.cpp
+++ b/be/src/exec/vectorized/csv_scanner.cpp
@@ -16,14 +16,16 @@ Status CSVScanner::ScannerCSVReader::_fill_buffer() {
 
     DCHECK(_buff.free_space() > 0);
     Slice s(_buff.limit(), _buff.free_space());
-    Status st = _file->read(&s);
+    auto res = _file->read(s.data, s.size);
     // According to the specification of `Env::read`, when reached the end of
     // a file, the returned status will be OK instead of EOF, but here we check
     // EOF also for safety.
-    if (st.is_end_of_file()) {
+    if (res.status().is_end_of_file()) {
         s.size = 0;
-    } else if (!st.ok()) {
-        return st;
+    } else if (!res.ok()) {
+        return res.status();
+    } else {
+        s.size = *res;
     }
     _buff.add_limit(s.size);
     auto n = _buff.available();

--- a/be/src/exec/vectorized/hdfs_scanner_orc.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_orc.cpp
@@ -47,7 +47,7 @@ public:
             throw orc::ParseError("Buffer is null");
         }
 
-        Status status = _file->read_at(offset, Slice((char*)buf, length));
+        Status status = _file->read_at_fully(offset, buf, length);
         if (!status.ok()) {
             auto msg = strings::Substitute("Failed to read $0: $1", _file->file_name(), status.to_string());
             throw orc::ParseError(msg);

--- a/be/src/exec/vectorized/json_scanner.cpp
+++ b/be/src/exec/vectorized/json_scanner.cpp
@@ -664,14 +664,13 @@ Status JsonReader::_read_and_parse_json() {
 #ifdef BE_TEST
 
     [[maybe_unused]] size_t message_size = 0;
-    Slice result(_buf.data(), _buf_size);
-    RETURN_IF_ERROR(_file->read(&result));
-    if (result.size == 0) {
+    ASSIGN_OR_RETURN(auto nread, _file->read(_buf.data(), _buf_size));
+    if (nread == 0) {
         return Status::EndOfFile("EOF of reading file");
     }
 
-    data = reinterpret_cast<uint8_t*>(result.data);
-    length = result.size;
+    data = reinterpret_cast<uint8_t*>(_buf.data());
+    length = nread;
 
 #else
 

--- a/be/src/exec/vectorized/orc_scanner.cpp
+++ b/be/src/exec/vectorized/orc_scanner.cpp
@@ -52,7 +52,7 @@ public:
             throw orc::ParseError("Buffer is null");
         }
 
-        Status status = _file->read_at(offset, Slice((char*)buf, length));
+        Status status = _file->read_at_fully(offset, buf, length);
         if (!status.ok()) {
             auto msg = strings::Substitute("Failed to read $0: $1", _file->file_name(), status.to_string());
             throw orc::ParseError(msg);

--- a/be/src/exec/vectorized/parquet_reader.cpp
+++ b/be/src/exec/vectorized/parquet_reader.cpp
@@ -111,10 +111,7 @@ arrow::Result<int64_t> ParquetChunkFile::Read(int64_t nbytes, void* buffer) {
 
 arrow::Result<int64_t> ParquetChunkFile::ReadAt(int64_t position, int64_t nbytes, void* out) {
     _pos += nbytes;
-    Slice s;
-    s.data = (char*)out;
-    s.size = nbytes;
-    auto status = _file->read_at(position, s);
+    auto status = _file->read_at_fully(position, out, nbytes);
     return status.ok() ? nbytes
                        : arrow::Result<int64_t>(arrow::Status(arrow::StatusCode::IOError, status.get_error_msg()));
 }

--- a/be/src/storage/snapshot_meta.cpp
+++ b/be/src/storage/snapshot_meta.cpp
@@ -94,7 +94,7 @@ Status SnapshotMeta::parse_from_file(RandomAccessFile* file) {
     std::string buff;
     raw::stl_string_resize_uninitialized(&buff, 16);
 
-    RETURN_IF_ERROR(file->read_at(file_length - 16, buff));
+    RETURN_IF_ERROR(file->read_at_fully(file_length - 16, buff.data(), buff.size()));
     // Parse SnapshotMetaFooterPB
     auto footer_limit = static_cast<int64_t>(file_length) - 16;
     auto footer_offset = static_cast<int64_t>(BigEndian::ToHost64(UNALIGNED_LOAD64(buff.data())));
@@ -106,7 +106,7 @@ Status SnapshotMeta::parse_from_file(RandomAccessFile* file) {
         return Status::Corruption("invalid footer offset");
     }
     raw::stl_string_resize_uninitialized(&buff, footer_limit - footer_offset);
-    RETURN_IF_ERROR(file->read_at(footer_offset, buff));
+    RETURN_IF_ERROR(file->read_at_fully(footer_offset, buff.data(), buff.size()));
     SnapshotMetaFooterPB footer;
     if (!footer.ParseFromString(buff)) {
         return Status::Corruption("parse snapshot meta footer failed");
@@ -147,7 +147,7 @@ Status SnapshotMeta::parse_from_file(RandomAccessFile* file) {
         auto start = footer.rowset_meta_offsets(i);
         auto end = footer.rowset_meta_offsets(i + 1);
         raw::stl_string_resize_uninitialized(&buff, end - start);
-        RETURN_IF_ERROR(file->read_at(start, buff));
+        RETURN_IF_ERROR(file->read_at_fully(start, buff.data(), buff.size()));
         if (!_rowset_metas[i].ParseFromString(buff)) {
             return Status::InternalError("parse rowset meta failed");
         }
@@ -161,7 +161,7 @@ Status SnapshotMeta::parse_from_file(RandomAccessFile* file) {
         auto start = footer.delvec_offsets(i);
         auto end = footer.delvec_offsets(i + 1);
         raw::stl_string_resize_uninitialized(&buff, end - start);
-        RETURN_IF_ERROR(file->read_at(start, buff));
+        RETURN_IF_ERROR(file->read_at_fully(start, buff.data(), buff.size()));
         DelVector delvec;
         RETURN_IF_ERROR(delvec.load(version, buff.data(), buff.size()));
         (void)_delete_vectors.emplace(static_cast<uint32_t>(segment_id), std::move(delvec));
@@ -175,7 +175,7 @@ Status SnapshotMeta::parse_from_file(RandomAccessFile* file) {
     // Tablet meta
     auto tablet_meta_offset = footer.tablet_meta_offset();
     raw::stl_string_resize_uninitialized(&buff, footer_offset - tablet_meta_offset);
-    RETURN_IF_ERROR(file->read_at(tablet_meta_offset, buff));
+    RETURN_IF_ERROR(file->read_at_fully(tablet_meta_offset, buff.data(), buff.size()));
     if (!_tablet_meta.ParseFromString(buff)) {
         return Status::InternalError("parse tablet meta failed");
     }

--- a/be/src/tools/meta_tool.cpp
+++ b/be/src/tools/meta_tool.cpp
@@ -371,7 +371,7 @@ Status get_segment_footer(RandomAccessFile* input_file, SegmentFooterPB* footer)
     }
 
     uint8_t fixed_buf[12];
-    RETURN_IF_ERROR(input_file->read_at(file_size - 12, Slice(fixed_buf, 12)));
+    RETURN_IF_ERROR(input_file->read_at_fully(file_size - 12, fixed_buf, 12));
 
     // validate magic number
     const char* k_segment_magic = "D0R1";
@@ -388,7 +388,7 @@ Status get_segment_footer(RandomAccessFile* input_file, SegmentFooterPB* footer)
     }
     std::string footer_buf;
     footer_buf.resize(footer_length);
-    RETURN_IF_ERROR(input_file->read_at(file_size - 12 - footer_length, footer_buf));
+    RETURN_IF_ERROR(input_file->read_at_fully(file_size - 12 - footer_length, footer_buf.data(), footer_buf.size()));
 
     // validate footer PB's checksum
     uint32_t expect_checksum = starrocks::decode_fixed32_le(fixed_buf + 4);

--- a/be/src/util/buffered_stream.cpp
+++ b/be/src/util/buffered_stream.cpp
@@ -60,11 +60,7 @@ void BufferedInputStream::_reserve(size_t nbytes) {
 Status BufferedInputStream::_read_data() {
     size_t bytes_read = std::min(left_capactiy(), _end_offset - _file_offset);
     Slice slice(_buf.get() + _buf_written, bytes_read);
-    auto st = _file->read(_file_offset, &slice);
-    if (!st.ok() && !st.is_end_of_file()) {
-        return st;
-    }
-
+    ASSIGN_OR_RETURN(slice.size, _file->read_at(_file_offset, slice.data, slice.size));
     _file_offset += slice.size;
     _buf_written += slice.size;
     return Status::OK();

--- a/be/src/util/file_utils.cpp
+++ b/be/src/util/file_utils.cpp
@@ -214,13 +214,12 @@ StatusOr<int64_t> FileUtils::copy(SequentialFile* src, WritableFile* dest, size_
     std::unique_ptr<char[]> guard(buf);
     int64_t ncopy = 0;
     while (true) {
-        Slice read_buf(buf, buff_size);
-        RETURN_IF_ERROR(src->read(&read_buf));
-        if (read_buf.size == 0) {
+        ASSIGN_OR_RETURN(auto nread, src->read(buf, buff_size));
+        if (nread == 0) {
             break;
         }
-        ncopy += read_buf.size;
-        RETURN_IF_ERROR(dest->append(read_buf));
+        ncopy += nread;
+        RETURN_IF_ERROR(dest->append(Slice(buf, nread)));
     }
     return ncopy;
 }

--- a/be/test/env/env_posix_test.cpp
+++ b/be/test/env/env_posix_test.cpp
@@ -25,6 +25,7 @@
 
 #include "common/logging.h"
 #include "env/env.h"
+#include "testutil/assert.h"
 #include "util/file_utils.h"
 
 namespace starrocks {
@@ -87,13 +88,12 @@ TEST_F(EnvPosixTest, random_access) {
         ASSERT_STREQ("123456789", std::string(slice1.data, slice1.size).c_str());
         ASSERT_STREQ("abc", std::string(slice3.data, slice3.size).c_str());
 
-        Slice slice4(mem, 3);
-        st = rfile->read_at(112, slice4);
-        ASSERT_TRUE(st.ok());
-        ASSERT_STREQ("bcd", std::string(slice4.data, slice4.size).c_str());
+        st = rfile->read_at_fully(112, mem, 3);
+        ASSERT_TRUE(st.ok()) << st;
+        ASSERT_STREQ("bcd", std::string(mem, 3).c_str());
 
         // end of file
-        st = rfile->read_at(114, slice4);
+        st = rfile->read_at_fully(114, mem, 3);
         ASSERT_EQ(TStatusCode::END_OF_FILE, st.code());
         LOG(INFO) << "st=" << st.to_string();
     }
@@ -104,25 +104,20 @@ TEST_F(EnvPosixTest, random_access) {
 
         // normal read
         {
-            Slice slice(mem, 9);
-            st = rfile->read(0, &slice);
-            ASSERT_TRUE(st.ok());
-            ASSERT_EQ(9, slice.size);
-            ASSERT_STREQ("123456789", slice.to_string().c_str());
+            ASSIGN_OR_ABORT(auto nread, rfile->read_at(0, mem, 9));
+            ASSERT_EQ(9, nread);
+            ASSERT_EQ("123456789", std::string_view(mem, 9));
         }
         // read too many
         {
-            Slice slice(mem, 100);
-            st = rfile->read(16, &slice);
-            ASSERT_TRUE(st.ok());
-            ASSERT_EQ(99, slice.size);
+            ASSIGN_OR_ABORT(auto nread, rfile->read_at(16, mem, 100));
+            ASSERT_EQ(99, nread);
         }
         // read empty
         {
             Slice slice(mem, 100);
-            st = rfile->read(115, &slice);
-            ASSERT_TRUE(st.ok());
-            ASSERT_EQ(0, slice.size);
+            ASSIGN_OR_ABORT(auto nread, rfile->read_at(115, mem, 100));
+            ASSERT_EQ(0, nread);
         }
     }
 }
@@ -197,29 +192,25 @@ TEST_F(EnvPosixTest, random_rw) {
         char mem[1024];
         auto rfile = *env->new_sequential_file(fname);
 
-        Slice slice1(mem, 3);
-        st = rfile->read(&slice1);
-        ASSERT_TRUE(st.ok());
-        ASSERT_STREQ("abc", std::string(slice1.data, slice1.size).c_str());
+        ASSIGN_OR_ABORT(auto nread, rfile->read(mem, 3));
+        ASSERT_EQ(3, nread);
+        ASSERT_EQ("abc", std::string_view(mem, nread));
 
         st = rfile->skip(3);
         ASSERT_TRUE(st.ok());
 
-        Slice slice3(mem, 3);
-        st = rfile->read(&slice3);
-        ASSERT_STREQ("789", std::string(slice3.data, slice3.size).c_str());
+        ASSIGN_OR_ABORT(nread, rfile->read(mem, 3));
+        ASSERT_EQ(3, nread);
+        ASSERT_EQ("789", std::string_view(mem, 3));
 
         st = rfile->skip(90);
         ASSERT_TRUE(st.ok());
 
-        Slice slice4(mem, 15);
-        st = rfile->read(&slice4);
-        ASSERT_TRUE(st.ok());
-        ASSERT_EQ(10, slice4.size);
+        ASSIGN_OR_ABORT(nread, rfile->read(mem, 15));
+        ASSERT_EQ(10, nread);
 
-        st = rfile->read(&slice4);
-        ASSERT_TRUE(st.ok());
-        ASSERT_EQ(0, slice4.size);
+        ASSIGN_OR_ABORT(nread, rfile->read(mem, 15));
+        ASSERT_EQ(0, nread);
     }
 }
 

--- a/be/test/env/output_stream_wrapper_test.cpp
+++ b/be/test/env/output_stream_wrapper_test.cpp
@@ -63,7 +63,7 @@ TEST_F(OutputStreamWrapperTest, test_write) {
     ASSERT_TRUE(st.ok()) << st;
     ASSERT_EQ(21, size);
 
-    st = rf->read_at(0, slice);
+    st = rf->read_at_fully(0, slice.data, slice.size);
     ASSERT_TRUE(st.ok()) << st;
     ASSERT_EQ("10 hello world! apple", buff);
 }

--- a/be/test/exec/parquet/group_reader_test.cpp
+++ b/be/test/exec/parquet/group_reader_test.cpp
@@ -17,8 +17,8 @@ public:
     MockFile() = default;
     ~MockFile() override = default;
 
-    Status read(uint64_t offset, Slice* res) const override { return Status::OK(); }
-    Status read_at(uint64_t offset, const Slice& result) const override { return Status::OK(); }
+    StatusOr<int64_t> read_at(int64_t offset, void* data, int64_t size) const override { return size; }
+    Status read_at_fully(int64_t offset, void* data, int64_t size) const override { return Status::OK(); }
     Status readv_at(uint64_t offset, const Slice* res, size_t res_cnt) const override { return Status::OK(); }
     Status size(uint64_t* size) const override { return Status::OK(); }
     const std::string& file_name() const override { return _file; }

--- a/be/test/util/zip_util_test.cpp
+++ b/be/test/util/zip_util_test.cpp
@@ -33,6 +33,7 @@
 
 #include "env/env.h"
 #include "gutil/strings/util.h"
+#include "testutil/assert.h"
 #include "util/file_utils.h"
 #include "util/logging.h"
 
@@ -58,7 +59,7 @@ TEST(ZipUtilTest, basic) {
 
     char f[11];
     Slice slice(f, 11);
-    file->read_at(0, slice);
+    ASSIGN_OR_ABORT(slice.size, file->read_at(0, slice.data, slice.size));
 
     ASSERT_EQ("hello world", slice.to_string());
 
@@ -89,7 +90,7 @@ TEST(ZipUtilTest, dir) {
 
     char f[4];
     Slice slice(f, 4);
-    file->read_at(0, slice);
+    file->read_at_fully(0, slice.data, slice.size);
 
     ASSERT_EQ("test", slice.to_string());
 


### PR DESCRIPTION
## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
- Redefine `Status RandomAccessFile::read(Slice* result)` as `StatusOr<int64_t> RandomAccessFile::read(void* data, int64_t size)`;
- Redefine `Status RandomAccessFile::read_at(uint64_t off, const Slice& result)` as `StatusOr RandomAccessFile::read_at_fully(int64_t off, void* data, int64_t size)`;
- Redefine `Status SequentialFile::read(Slice* res)` as `StatusOr<int64_t> SequentialFile::read(void* data, int64_t size)`;

The final goal is to delete the class RandomAccessFile defined
in env.h and leave only the class io::RandomAccessFile defined
in io/random_access_file.h. To achieve this, the first step is
making those two classes have similar APIs, and the next step
would be replacing the usage of the first class with the second one.

## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [x] others



