### PR TITLE
[ResourceIsolation] make ScanExecutor own ScanTaskQueue instead of WorkGroupManager

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -665,8 +665,6 @@ CONF_Int64(pipeline_scan_max_tasks_per_operator, "4");
 CONF_Int64(pipeline_scan_task_yield_max_tims_spent, "100000000");
 // The max schedule period for adjusting io weight of each workgroup.
 CONF_Int64(pipeline_scan_task_yield_preempt_max_time_spent, "20000000");
-// The max schedule period for adjusting io weight of each workgroup.
-CONF_Int32(pipeline_max_io_schedule_num_period, "512");
 
 // bitmap serialize version
 CONF_Int16(bitmap_serialize_version, "1");

--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -188,6 +188,7 @@ set(EXEC_FILES
     pipeline/set/intersect_output_source_operator.cpp
     workgroup/work_group.cpp
     workgroup/scan_executor.cpp
+    workgroup/scan_task_queue.cpp
 )
 
 # simdjson Runtime Implement Dispatch: https://github.com/simdjson/simdjson/blob/master/doc/implementation-selection.md#runtime-cpu-detection

--- a/be/src/exec/workgroup/scan_executor.cpp
+++ b/be/src/exec/workgroup/scan_executor.cpp
@@ -8,7 +8,7 @@
 namespace starrocks::workgroup {
 
 ScanExecutor::ScanExecutor(std::unique_ptr<ThreadPool> thread_pool)
-        : _thread_pool(std::move(thread_pool)), _task_queue(std::make_unique<ScanTaskQueueWithWorkGroup>()) {}
+        : _task_queue(std::make_unique<ScanTaskQueueWithWorkGroup>()), _thread_pool(std::move(thread_pool)) {}
 
 ScanExecutor::~ScanExecutor() {
     _task_queue->close();

--- a/be/src/exec/workgroup/scan_executor.h
+++ b/be/src/exec/workgroup/scan_executor.h
@@ -24,10 +24,10 @@ public:
 private:
     void worker_thread();
 
-private:
     LimitSetter _num_threads_setter;
-    std::unique_ptr<ThreadPool> _thread_pool;
     std::unique_ptr<ScanTaskQueue> _task_queue;
+    // _thread_pool must be placed after _task_queue, because worker threads in _thread_pool use _task_queue.
+    std::unique_ptr<ThreadPool> _thread_pool;
     std::atomic<int> _next_id = 0;
 };
 

--- a/be/src/exec/workgroup/scan_executor.h
+++ b/be/src/exec/workgroup/scan_executor.h
@@ -8,13 +8,18 @@ namespace workgroup {
 
 class ScanExecutor;
 class WorkGroupManager;
+class ScanTask;
+class ScanTaskQueue;
 
 class ScanExecutor {
 public:
     explicit ScanExecutor(std::unique_ptr<ThreadPool> thread_pool);
     virtual ~ScanExecutor();
+
     void initialize(int32_t num_threads);
     void change_num_threads(int32_t num_threads);
+
+    bool submit(ScanTask task);
 
 private:
     void worker_thread();
@@ -22,6 +27,7 @@ private:
 private:
     LimitSetter _num_threads_setter;
     std::unique_ptr<ThreadPool> _thread_pool;
+    std::unique_ptr<ScanTaskQueue> _task_queue;
     std::atomic<int> _next_id = 0;
 };
 

--- a/be/src/exec/workgroup/scan_task_queue.cpp
+++ b/be/src/exec/workgroup/scan_task_queue.cpp
@@ -1,0 +1,172 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present StarRocks Limited.
+
+#include "exec/workgroup/scan_task_queue.h"
+
+#include "exec/workgroup/work_group.h"
+
+namespace starrocks::workgroup {
+
+StatusOr<ScanTask> FifoScanTaskQueue::take(int worker_id) {
+    auto task = std::move(_queue.front());
+    _queue.pop();
+    return task;
+}
+
+bool FifoScanTaskQueue::try_offer(ScanTask task) {
+    _queue.emplace(std::move(task));
+    return true;
+}
+
+void ScanTaskQueueWithWorkGroup::close() {
+    std::lock_guard<std::mutex> lock(_global_mutex);
+
+    if (_is_closed) {
+        return;
+    }
+
+    _is_closed = true;
+    _cv.notify_all();
+}
+
+StatusOr<ScanTask> ScanTaskQueueWithWorkGroup::take(int worker_id) {
+    std::unique_lock<std::mutex> lock(_global_mutex);
+
+    if (_is_closed) {
+        return Status::Cancelled("Shutdown");
+    }
+    while (_ready_wgs.empty()) {
+        _cv.wait(lock);
+        if (_is_closed) {
+            return Status::Cancelled("Shutdown");
+        }
+    }
+
+    _maybe_adjust_weight();
+
+    WorkGroupPtr wg = _select_next_wg(worker_id);
+    if (wg->scan_task_queue()->size() == 1) {
+        _ready_wgs.erase(wg);
+    }
+
+    _total_task_num--;
+
+    return wg->scan_task_queue()->take(worker_id);
+}
+
+bool ScanTaskQueueWithWorkGroup::try_offer(ScanTask task) {
+    std::lock_guard<std::mutex> lock(_global_mutex);
+
+    WorkGroupPtr wg = task.workgroup;
+    wg->scan_task_queue()->try_offer(std::move(task));
+    if (_ready_wgs.find(wg) == _ready_wgs.end()) {
+        _ready_wgs.emplace(wg);
+    }
+
+    _total_task_num++;
+    _cv.notify_one();
+    return true;
+}
+
+void ScanTaskQueueWithWorkGroup::_maybe_adjust_weight() {
+    if (--_remaining_schedule_num_period > 0) {
+        return;
+    }
+
+    int num_tasks = 0;
+    // calculate all wg factors
+    for (auto& wg : _ready_wgs) {
+        wg->estimate_trend_factor_period();
+        num_tasks += wg->scan_task_queue()->size();
+    }
+
+    _remaining_schedule_num_period = std::min(MAX_SCHEDULE_NUM_PERIOD, num_tasks);
+
+    // negative_total_diff_factor Accumulate All Under-resourced WorkGroup
+    // positive_total_diff_factor Cumulative All Resource Excess WorkGroup
+    double positive_total_diff_factor = 0.0;
+    double negative_total_diff_factor = 0.0;
+    for (auto const& wg : _ready_wgs) {
+        if (wg->get_diff_factor() > 0) {
+            positive_total_diff_factor += wg->get_diff_factor();
+        } else {
+            negative_total_diff_factor += wg->get_diff_factor();
+        }
+    }
+
+    // If positive_total_diff_factor <= 0, This means that all WorkGs have no excess resources
+    // So we don't need to adjust it and keep the original limit
+    if (positive_total_diff_factor <= 0) {
+        for (auto& wg : _ready_wgs) {
+            wg->set_select_factor(wg->get_cpu_expected_use_ratio());
+        }
+        return;
+    }
+
+    // As an example
+    // There are two WorkGroups A and B
+    // A _expect_factor : 0.18757812499999998, and _cpu_expect_use_ratio : 0.7, _diff_factor : 0.512421875
+    // B _expect_factor : 0.6749999999999999, and _cpu_expect_use_ratio : 0.3, _diff_factor :  -0.37499999999999994
+    // so 0.18757812499999998 + 0.6749999999999999 < 1.0, it mean resource is enough, and available is  -0.37499999999999994 + 0.512421875
+
+    if (positive_total_diff_factor + negative_total_diff_factor > 0) {
+        // if positive_total_diff_factor + negative_total_diff_factor > 0
+        // This means that the resources are sufficient
+        // So we can reduce the proportion of resources in the WorkGroup that are over-resourced
+        // Then increase the proportion of resources for those WorkGs that are under-resourced
+        for (auto& wg : _ready_wgs) {
+            if (wg->get_diff_factor() < 0) {
+                wg->update_select_factor(0 - negative_total_diff_factor * wg->get_diff_factor() /
+                                                     negative_total_diff_factor);
+            } else if (wg->get_diff_factor() > 0) {
+                wg->update_select_factor(negative_total_diff_factor * wg->get_diff_factor() /
+                                         positive_total_diff_factor);
+            }
+        }
+    } else {
+        // if positive_total_diff_factor + negative_total_diff_factor <= 0
+        // This means that there are not enough resources, but some WorkGs are still over-resourced
+        // So we can reduce the proportion of resources in the WorkGroup that are over-resourced
+        // Then increase the proportion of resources for those WorkGs that are under-resourced
+        for (auto& wg : _ready_wgs) {
+            if (wg->get_diff_factor() < 0) {
+                wg->update_select_factor(positive_total_diff_factor * wg->get_diff_factor() /
+                                         negative_total_diff_factor);
+            } else if (wg->get_diff_factor() > 0) {
+                wg->update_select_factor(0 - positive_total_diff_factor * wg->get_diff_factor() /
+                                                     positive_total_diff_factor);
+            }
+        }
+    }
+}
+
+WorkGroupPtr ScanTaskQueueWithWorkGroup::_select_next_wg(int worker_id) {
+    auto owner_wgs = workgroup::WorkGroupManager::instance()->get_owners_of_scan_worker(worker_id);
+
+    WorkGroupPtr max_owner_wg = nullptr;
+    WorkGroupPtr max_other_wg = nullptr;
+    double total = 0;
+    for (auto wg : _ready_wgs) {
+        wg->update_cur_select_factor(wg->get_select_factor());
+        total += wg->get_select_factor();
+
+        if (owner_wgs->find(wg) != owner_wgs->end()) {
+            if (max_owner_wg == nullptr || wg->get_cur_select_factor() > max_owner_wg->get_cur_select_factor()) {
+                max_owner_wg = wg;
+            }
+        } else if (max_other_wg == nullptr || wg->get_cur_select_factor() > max_other_wg->get_cur_select_factor()) {
+            max_other_wg = wg;
+        }
+    }
+
+    // Try to take task from any owner workgroup first.
+    if (max_owner_wg != nullptr) {
+        max_owner_wg->update_cur_select_factor(0 - total);
+        return max_owner_wg;
+    }
+
+    // All the owner workgroups don't have ready tasks, so select the other workgroup.
+    max_other_wg->update_cur_select_factor(0 - total);
+    return max_other_wg;
+}
+
+} // namespace starrocks::workgroup

--- a/be/src/exec/workgroup/scan_task_queue.h
+++ b/be/src/exec/workgroup/scan_task_queue.h
@@ -1,0 +1,97 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present StarRocks Limited.
+
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include <queue>
+#include <unordered_set>
+
+#include "common/statusor.h"
+#include "exec/workgroup/work_group_fwd.h"
+
+namespace starrocks::workgroup {
+
+struct ScanTask {
+public:
+    using WorkFunction = std::function<void(int)>;
+
+    ScanTask() : ScanTask(nullptr, nullptr) {}
+    ScanTask(WorkGroupPtr workgroup, WorkFunction work_function)
+            : workgroup(std::move(workgroup)), work_function(std::move(work_function)) {}
+    ~ScanTask() = default;
+
+    // Disable copy constructor and assignment.
+    ScanTask(const ScanTask&) = delete;
+    ScanTask& operator=(const ScanTask&) = delete;
+    // Enable move constructor and assignment.
+    ScanTask(ScanTask&&) = default;
+    ScanTask& operator=(ScanTask&&) = default;
+
+    WorkGroupPtr workgroup;
+    WorkFunction work_function;
+};
+
+class ScanTaskQueue {
+public:
+    ScanTaskQueue() = default;
+    virtual ~ScanTaskQueue() = default;
+
+    virtual void close() = 0;
+
+    virtual StatusOr<ScanTask> take(int worker_id) = 0;
+    virtual bool try_offer(ScanTask task) = 0;
+
+    virtual size_t size() const = 0;
+};
+
+class FifoScanTaskQueue final : public ScanTaskQueue {
+public:
+    FifoScanTaskQueue() = default;
+    ~FifoScanTaskQueue() override = default;
+
+    // This method do nothing.
+    void close() override {}
+
+    StatusOr<ScanTask> take(int worker_id) override;
+    bool try_offer(ScanTask task) override;
+
+    size_t size() const override { return _queue.size(); }
+
+private:
+    std::queue<ScanTask> _queue;
+};
+
+class ScanTaskQueueWithWorkGroup final : public ScanTaskQueue {
+public:
+    ScanTaskQueueWithWorkGroup() = default;
+    ~ScanTaskQueueWithWorkGroup() override = default;
+
+    void close() override;
+
+    StatusOr<ScanTask> take(int worker_id) override;
+    bool try_offer(ScanTask task) override;
+
+    size_t size() const override { return _total_task_num.load(std::memory_order_acquire); }
+
+private:
+    // _maybe_adjust_weight and _select_next_wg are guarded by the ourside _global_mutex.
+    void _maybe_adjust_weight();
+    WorkGroupPtr _select_next_wg(int worker_id);
+
+    static constexpr int MAX_SCHEDULE_NUM_PERIOD = 512;
+
+    std::mutex _global_mutex;
+    std::condition_variable _cv;
+
+    bool _is_closed = false;
+
+    std::unordered_set<WorkGroupPtr> _ready_wgs;
+    std::atomic<size_t> _total_task_num = 0;
+
+    // Adjust select factor of each wg after every `min(MAX_SCHEDULE_NUM_PERIOD, num_tasks)` schedule times.
+    int _remaining_schedule_num_period = 0;
+};
+
+} // namespace starrocks::workgroup


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [x] others


## Motivation
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

`ScanTaskQueue` is owned by `WorkGroupManager`, so `WorkGroupManager` need provide bridge interfaces like `pick_next_task_for_io` and `try_offer_io_task` between `ScanTaskQueue` and `ScanExecutor`.

To be consistent with the logic of `DriverExecutor`, we could make `ScanExecutor` own the `ScanTaskQueue`.

In addition, `IoWorkGroupQueue` extend `WorkGroupQueue`. However, the override methods (`add`, `remove`, `pickup`) are never used, while the non-override mthoeds `pick_next_task` and `try_offer_io_task` are used. So maybe we could remove the virtual class `WorkGroupQueue`, and rename `IoWorkGroupQueue` to `ScanTaskQueue.

## Modification
- Rename `IoWorkGroupQueu` to `ScanTaskQueueWithGroup`.
- Make `ScanTaskQueueWithGroup` and `FifoScanTaskQueue` extend virtual class `ScanTaskQueue`.
- `WorkGroup` owns `FifoScanTaskQueue`, and `ScanExecutor` owns `ScanTaskQueueWithGroup`.



