### PR TITLE
rewrite columnRef in predicate

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/ScalarOperatorToExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/ScalarOperatorToExpr.java
@@ -268,7 +268,7 @@ public class ScalarOperatorToExpr {
             if (allConstant) {
                 expr.setOpcode(expr.isNotIn() ? TExprOpcode.FILTER_NOT_IN : TExprOpcode.FILTER_IN);
             } else {
-                expr.setOpcode(expr.isNotIn() ? TExprOpcode.FILTER_NEW_NOT_IN : TExprOpcode.FILTER_NEW_IN);
+                throw new UnsupportedOperationException("in predicate could only handle constant, " + predicate);
             }
 
             expr.setType(Type.BOOLEAN);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/NormalizePredicateRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/NormalizePredicateRuleTest.java
@@ -7,6 +7,7 @@ import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriteContext;
 import org.junit.Test;
@@ -59,5 +60,24 @@ public class NormalizePredicateRuleTest {
         ScalarOperator result = rule.apply(bpo, context);
 
         assertEquals(bpo, result);
+    }
+
+    @Test
+    public void testInPredicate() {
+        NormalizePredicateRule rule = new NormalizePredicateRule();
+        ScalarOperatorRewriteContext context = new ScalarOperatorRewriteContext();
+
+        InPredicateOperator inOp = new InPredicateOperator(
+                ConstantOperator.createInt(1),
+                new ColumnRefOperator(0, Type.INT, "col1", true)
+        );
+
+        ScalarOperator result = rule.apply(inOp, context);
+        BinaryPredicateOperator eqOp = new BinaryPredicateOperator(BinaryPredicateOperator.BinaryType.EQ,
+                ConstantOperator.createInt(1),
+                new ColumnRefOperator(0, Type.INT, "col1", true)
+        );
+
+        assertEquals(eqOp, result);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
@@ -1003,7 +1003,8 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
 
         sql = "select * from lineitem where L_LINENUMBER in (L_RETURNFLAG+1,2+1)";
         plan = getCostExplain(sql);
-        Assert.assertTrue(plan.contains("* L_LINENUMBER-->[1.0, 7.0, 0.0, 4.0, 4.0] ESTIMATE"));
+        Assert.assertTrue("plan is " + plan,
+                plan.contains("* L_LINENUMBER-->[1.0, 7.0, 0.0, 4.0, 3.0] ESTIMATE"));
 
         sql = "select * from lineitem where L_LINENUMBER + 1 in (L_RETURNFLAG+1,2+1)";
         plan = getCostExplain(sql);

--- a/gensrc/thrift/Opcodes.thrift
+++ b/gensrc/thrift/Opcodes.thrift
@@ -29,8 +29,8 @@ enum TExprOpcode {
     CAST,
     FILTER_IN,
     FILTER_NOT_IN,
-    FILTER_NEW_IN,
-    FILTER_NEW_NOT_IN,
+    FILTER_NEW_IN, // deprecated
+    FILTER_NEW_NOT_IN, // deprecated
     EQ,
     NE,
     LT,


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Motivation
Rewrite `a in (b, c)` to `a = b OR a = c` if b or c is `columnRef`.

After this, we could remove the `FILTER_IN` predicate in BE>