### PR TITLE
Fix: unfold const result with has_null src for string_func_const (#3575)

### DIFF
--- a/be/src/exprs/vectorized/string_functions.cpp
+++ b/be/src/exprs/vectorized/string_functions.cpp
@@ -539,11 +539,17 @@ ColumnPtr string_func_const(StringConstFuncType func, const Columns& columns, Ar
             ColumnPtr binary = func(columns, src_binary, std::forward<Args>(args)...);
             NullColumnPtr src_null = NullColumn::create(*(src_nullable->null_column()));
 
-            // if binary is ConstColumn, just return it.
-            // if binary is NullableColumn, then the null column inside of the binary should
-            // be merged with the null column inside of columns[0].
-            if (binary->is_constant()) {
+            // - if binary is null ConstColumn, just return it.
+            // - if binary is non-null ConstColumn, unfold it and wrap with src_null.
+            // - if binary is NullableColumn, then the null column inside the binary should
+            //   be merged with the null column inside of columns[0].
+            if (binary->only_null()) {
                 return binary;
+            }
+            if (binary->is_constant()) {
+                ConstColumn* dst_const = down_cast<ConstColumn*>(binary.get());
+                dst_const->data_column()->assign(dst_const->size(), 0);
+                return NullableColumn::create(dst_const->data_column(), src_null);
             }
             if (binary->is_nullable()) {
                 NullableColumn* binary_nullable = down_cast<NullableColumn*>(binary.get());


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Problem Summary：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This is cherry-picked from PR #3575.