### PR TITLE
Don't let BE crash when misconfiguration of aws section

### DIFF
--- a/be/src/env/env_s3.cpp
+++ b/be/src/env/env_s3.cpp
@@ -90,12 +90,15 @@ StatusOr<std::unique_ptr<RandomAccessFile>> EnvS3::new_random_access_file(const 
     std::string object = path.substr(namenode.size(), path.size() - namenode.size());
     Aws::Client::ClientConfiguration config;
     config.scheme = Aws::Http::Scheme::HTTP;
-    config.endpointOverride = config::aws_s3_endpoint;
+    if (!config::aws_s3_endpoint.empty()) {
+        config.endpointOverride = config::aws_s3_endpoint;
+    }
     config.maxConnections = config::aws_s3_max_connection;
     S3Credential cred;
     cred.access_key_id = config::aws_access_key_id;
     cred.secret_access_key = config::aws_secret_access_key;
-    auto store = std::make_unique<S3ObjectStore>(config, &cred, false);
+    auto store = std::make_unique<S3ObjectStore>(config);
+    RETURN_IF_ERROR(store->init(&cred, false));
     return std::make_unique<S3RandomAccessFile>(std::move(store), std::move(bucket), std::move(object));
 }
 

--- a/be/src/object_store/s3_object_store.h
+++ b/be/src/object_store/s3_object_store.h
@@ -21,9 +21,9 @@ public:
 
 class S3ObjectStore final : public ObjectStore {
 public:
-    S3ObjectStore(const Aws::Client::ClientConfiguration& config, const S3Credential* cred = nullptr,
-                  bool use_transfer_manager = false);
+    S3ObjectStore(const Aws::Client::ClientConfiguration& config);
     ~S3ObjectStore() = default;
+    Status init(const S3Credential* cred = nullptr, bool use_transfer_manager = false);
 
     /*
      *  Bucket Operation


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
Fixes #3416

## Problem Summary(Required) ：

This PR:
1. move error prone part from ctor to `init`.  So we can return status error if anything misconfiguration happens
2. if user does not configure aws credential,  we use default credential provided by environment. 

If any error happens,  there are error messages like following, which is sufficient enough to figure out why.

```
ERROR 1064 (HY000): HdfsOrcScanner::do_open failed. reason = Failed to read s3://zhangyan-zy/oss-read-perf/000003_0: IO error: Get Object Range oss-read-perf/000003_0 failed. You have no right to access this object because of bucket acl..
/home/disk2/zy/DorisDB/be/src/env/env_s3.cpp:54 _client->get_object_range(_bucket, _object, offset, res.size, res.data, &read_size)

ERROR 1064 (HY000): HdfsOrcScanner::do_open failed. reason = Failed to read s3://zhangyan-zy/oss-read-perf/000003_0: IO error: Get Object Range oss-read-perf/000003_0 failed. The AWS Access Key Id you provided does not exist in our records..
/home/disk2/zy/DorisDB/be/src/env/env_s3.cpp:54 _client->get_object_range(_bucket, _object, offset, res.size, res.data, &read_size)
```

