### PR TITLE
aes_encrypt return NULL if key is NULL

### DIFF
--- a/be/src/exprs/vectorized/encryption_functions.cpp
+++ b/be/src/exprs/vectorized/encryption_functions.cpp
@@ -23,17 +23,12 @@ ColumnPtr EncryptionFunctions::aes_encrypt(FunctionContext* ctx, const Columns& 
     const int size = columns[0]->size();
     ColumnBuilder<TYPE_VARCHAR> result(size);
     for (int row = 0; row < size; ++row) {
-        if (src_viewer.is_null(row)) {
+        if (src_viewer.is_null(row) || key_viewer.is_null(row)) {
             result.append_null();
             continue;
         }
 
         auto src_value = src_viewer.value(row);
-        if (src_value.size == 0) {
-            result.append_null();
-            continue;
-        }
-
         int cipher_len = src_value.size + 16;
         char p[cipher_len];
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
(https://github.com/StarRocks/starrocks/issues/3493)

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
1. if  the 2nd argument to aes_encrypt is NULL, then the result is NULL. e.g. aes_encrypt("abc", NULL) = NULL
2. if  the 1st argument to aes_encrypt is not NULL and the length is zero and 2nd argument is not NULL, then the result is NOT NULL. e.g. hex(aes_encrypt("", "")) = "0143DB63EE66B0CDFF9F69917680151E"