### PR TITLE
fix: check integer overflow when casting json

### DIFF
--- a/be/src/column/type_traits.h
+++ b/be/src/column/type_traits.h
@@ -320,6 +320,14 @@ struct RunTimeTypeLimits<ptype, ArithmeticPTGuard<ptype>> {
     static constexpr value_type max_value() { return std::numeric_limits<value_type>::max(); }
 };
 
+template <>
+struct RunTimeTypeLimits<TYPE_LARGEINT> {
+    using value_type = RunTimeCppType<TYPE_LARGEINT>;
+
+    static constexpr value_type min_value() { return MIN_INT128; }
+    static constexpr value_type max_value() { return MAX_INT128; }
+};
+
 template <PrimitiveType ptype>
 struct RunTimeTypeLimits<ptype, BinaryPTGuard<ptype>> {
     using value_type = RunTimeCppType<ptype>;

--- a/be/src/util/json.h
+++ b/be/src/util/json.h
@@ -49,7 +49,9 @@ public:
     }
 
     JsonValue& operator=(JsonValue&& rhs) {
-        binary_ = std::move(rhs.binary_);
+        if (this != &rhs) {
+            binary_ = std::move(rhs.binary_);
+        }
         return *this;
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others


## Problem Summary(Required) ：
Check overflow when casting json between SQL numeric types.