### PR TITLE
Remove the check of has_null=true

### DIFF
--- a/be/src/column/nullable_column.cpp
+++ b/be/src/column/nullable_column.cpp
@@ -324,9 +324,8 @@ void NullableColumn::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx) const
 
 void NullableColumn::check_or_die() const {
     CHECK_EQ(_null_column->size(), _data_column->size());
-    if (_has_null) {
-        CHECK_GT(SIMD::count_nonzero(_null_column->get_data()), 0);
-    } else {
+    // when _has_null=true, the column may have no null value, so don't check.
+    if (!_has_null) {
         CHECK_EQ(SIMD::count_nonzero(_null_column->get_data()), 0);
     }
     _data_column->check_or_die();


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [x] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

when _has_null=true, the column may have no null value, to don't check.