### PR TITLE
Add limit to reduce the input rowsets for base compaction (#3466)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -267,7 +267,8 @@ CONF_Bool(disable_storage_page_cache, "true");
 CONF_Bool(disable_column_pool, "false");
 
 CONF_mInt32(base_compaction_check_interval_seconds, "60");
-CONF_mInt64(base_compaction_num_cumulative_deltas, "5");
+CONF_mInt64(min_base_compaction_num_singleton_deltas, "5");
+CONF_mInt64(max_base_compaction_num_singleton_deltas, "100");
 CONF_Int32(base_compaction_num_threads_per_disk, "1");
 CONF_mDouble(base_cumulative_delta_ratio, "0.3");
 CONF_mInt64(base_compaction_interval_seconds_since_last_operation, "86400");


### PR DESCRIPTION
Add configuration for base compaction and do not pick more input rowsets from candidate rowsets when getting enough segments.

## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
