### PR TITLE
Fix Scalar Functions bugs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
@@ -113,6 +113,9 @@ public class ScalarOperatorFunctions {
     })
     public static ConstantOperator dateFormat(ConstantOperator date, ConstantOperator fmtLiteral) {
         String format = fmtLiteral.getVarchar();
+        if (format.isEmpty()) {
+            return ConstantOperator.createNull(Type.VARCHAR);
+        }
         // unix style
         if (!SUPPORT_JAVA_STYLE_DATETIME_FORMATTER.contains(format.trim())) {
             DateTimeFormatterBuilder builder = DateUtils.unixDatetimeFormatBuilder(fmtLiteral.getVarchar());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
@@ -35,7 +35,6 @@ import com.starrocks.rewrite.FEFunction;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 
 import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -401,14 +400,6 @@ public class ScalarOperatorFunctions {
         }
 
         return createDecimalConstant(first.getDecimal().remainder(second.getDecimal()));
-    }
-
-    @FEFunction(name = "mod", argTypes = {"LARGEINT", "LARGEINT"}, returnType = "LARGEINT")
-    public static ConstantOperator modLargeInt(ConstantOperator first, ConstantOperator second) {
-        if (second.getLargeInt().compareTo(BigInteger.ZERO) == 0) {
-            return ConstantOperator.createNull(Type.LARGEINT);
-        }
-        return ConstantOperator.createLargeInt(first.getLargeInt().mod(second.getLargeInt()));
     }
 
     @FEFunction(name = "concat", argTypes = {"VARCHAR"}, returnType = "VARCHAR")

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
@@ -219,6 +219,11 @@ public class ScalarOperatorFunctionsTest {
         Assert.assertThrows(IllegalArgumentException.class, () -> ScalarOperatorFunctions
                 .dateFormat(ConstantOperator.createDate(LocalDateTime.of(2020, 2, 21, 13, 4, 5)),
                         ConstantOperator.createVarchar("%X")).getVarchar());
+        assertTrue(ScalarOperatorFunctions.dateFormat(testDate, ConstantOperator.createVarchar(""))
+                .isNull());
+        assertEquals("  ",
+                ScalarOperatorFunctions.dateFormat(testDate, ConstantOperator.createVarchar("  "))
+                        .getVarchar());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
@@ -579,11 +579,6 @@ public class ScalarOperatorFunctionsTest {
     }
 
     @Test
-    public void modLargeInt() {
-        assertEquals("0", ScalarOperatorFunctions.modLargeInt(O_LI_100, O_LI_100).getLargeInt().toString());
-    }
-
-    @Test
     public void concat() {
         ConstantOperator[] arg = {ConstantOperator.createVarchar("1"),
                 ConstantOperator.createVarchar("2"),

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -5809,4 +5809,11 @@ public class PlanFragmentTest extends PlanTestBase {
                 "1: c0 != 0, 1: c0 != 2: c1, 1: c0 != 3: c2");
     }
 
+    @Test
+    public void testLargeIntMod() throws Exception {
+        String sql = "select -123 % 100000000000000000000000000000000000";
+        String plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("     constant exprs: \n" +
+                "         -123 % 100000000000000000000000000000000000"));
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestBase.java
@@ -811,7 +811,6 @@ public class PlanTestBase {
     public String getFragmentPlan(String sql) throws Exception {
         String s= UtFrameUtils.getPlanAndFragment(connectContext, sql).second.
                 getExplainString(TExplainLevel.NORMAL);
-        System.out.println(s);
         return s;
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3616 #3617 #3618

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

#3616 #3618
The LargeInt's mod method of FE is different from BE mod when the number is negative

#3617 
The result of date_fromat when format param is empty string
