### PR TITLE
Fix bug iterator pointer out of bound.

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -221,8 +221,8 @@ void TaskWorkerPool::submit_tasks(std::vector<TAgentTaskRequest>* tasks) {
                 task_req.__set_recv_time(recv_time);
                 ++it;
             } else {
-                it = tasks->erase(it);
                 failed_task_vec.push_back(*it);
+                it = tasks->erase(it);
             }
         }
     }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3636

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This because if push_back after erase it will make it point move to next cause the out of bound.