### PR TITLE
Fix bucket join when dynamic partition has different bucket nums

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -2232,6 +2232,12 @@ public class Coordinator {
                 fragmentIdToBackendIdBucketCountMap.put(fragmentId, new HashMap<>());
                 fragmentIdToBucketNumMap.put(fragmentId,
                         scanNode.getOlapTable().getDefaultDistributionInfo().getBucketNum());
+                if (scanNode.getSelectedPartitionIds().size() <= 1) {
+                    for (Long pid : scanNode.getSelectedPartitionIds()) {
+                        fragmentIdToBucketNumMap.put(fragmentId,
+                                scanNode.getOlapTable().getPartition(pid).getDistributionInfo().getBucketNum());
+                    }
+                }
             }
             Map<Integer, TNetworkAddress> bucketSeqToAddress =
                     fragmentIdToSeqToAddressMap.get(fragmentId);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3739

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
![middle_img_v2_6eb69ce7-6442-43e9-a6e6-8e8f62ef5cag](https://user-images.githubusercontent.com/5609319/155317082-a2c99786-ec7b-4507-b2f8-1422e73c9c6c.png)

we create table with different buckets partitions:
```
CREATE TABLE `t0` (
  `v1` bigint(20) NULL COMMENT "",
  `d1` date NULL COMMENT "",
  `v2` bigint(20) NULL COMMENT "",
  `v3` bigint(20) NULL COMMENT ""
) ENGINE=OLAP
DUPLICATE KEY(`v1`, `d1`)
COMMENT "OLAP"
PARTITION BY RANGE(`d1`)
(PARTITION p20200321 VALUES [('0000-01-01'), ('2022-02-20')),
PARTITION p2 VALUES [('2022-02-20'), ('2022-02-23')))
DISTRIBUTED BY HASH(`v1`) BUCKETS 3
PROPERTIES (
"replication_num" = "1",
"in_memory" = "false",
"storage_format" = "DEFAULT"
);

mysql> show partitions from t0;

+-------------+---------------+------------------+-----------------+---------+
| PartitionId | PartitionName | Range            | DistributionKey | Buckets |
+-------------+---------------+------------------+-----------------+---------+
| 3136496     | p20200321     | [types:02-20]; ) | v1              | 3       |
| 3136505     | p2            | [types:02-23]; ) | v1              | 5       |
+-------------+---------------+------------------+-----------------+---------+
2 rows in set (0.00 sec)

```

Then, the query if use BUCKET_SHUFFLE join, the hash method will be error