### PR TITLE
Implement MutableIndex Snapshot

### DIFF
--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -719,7 +719,7 @@ Status PersistentIndex::load(const PersistentIndexMetaPB& index_meta) {
     });
     std::string l0_index_file_name = _get_l0_index_file_name(_path, start_version);
     RETURN_IF_ERROR(block_mgr->open_block(l0_index_file_name, &rblock));
-    // Assuming that the snapshot is alaways at the beginning of index file,
+    // Assuming that the snapshot is always at the beginning of index file,
     // if not, we can't call phmap.load() directly because phmap.load() alaways
     // reads the contents of the file from the beginning
     phmap::BinaryInputArchive ar_in(l0_index_file_name.data());

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -27,6 +27,7 @@ constexpr size_t pack_size = 16;
 constexpr size_t page_pack_limit = (page_size - page_header_size) / pack_size;
 constexpr uint64_t seed0 = 12980785309524476958ULL;
 constexpr uint64_t seed1 = 9110941936030554525ULL;
+const size_t kSnapshotSize = 10 * 1024 * 1024;
 
 using KVPairPtr = const uint8_t*;
 
@@ -605,6 +606,15 @@ public:
         *num_found = nfound;
         return Status::OK();
     }
+
+    size_t dump_bound() { return _map.dump_bound(); }
+
+    bool dump(phmap::BinaryOutputArchive& ar_out) { return _map.dump(ar_out); }
+
+    bool load_snapshot(phmap::BinaryInputArchive& ar_in) { return _map.load(ar_in); }
+
+    size_t size() { return _map.size(); }
+    size_t capacity() { return _map.capacity(); }
 };
 
 StatusOr<std::unique_ptr<MutableIndex>> MutableIndex::create(size_t key_size) {
@@ -706,7 +716,17 @@ Status PersistentIndex::load(const PersistentIndexMetaPB& index_meta) {
     });
     std::string l0_index_file_name = _get_l0_index_file_name(_path, start_version);
     RETURN_IF_ERROR(block_mgr->open_block(l0_index_file_name, &rblock));
-    // TODO: load snapshot first
+    // Assuming that the snapshot is alaways at the beginning of index file,
+    // if not, we can't call phmap.load() directly because phmap.load() alaways
+    // reads the contents of the file from the beginning
+    phmap::BinaryInputArchive ar_in(l0_index_file_name.data());
+    if (!_load_snapshot(ar_in)) {
+        std::string err_msg = strings::Substitute("failed load snapshot from file $0", l0_index_file_name);
+        LOG(WARNING) << err_msg;
+        return Status::InternalError(err_msg);
+    }
+    // if mutable index is empty, set _offset as 0, otherwise set _offset as snapshot size
+    _offset = (mutable_index_size() == 0) ? 0 : _dump_bound();
     int n = l0_meta.wals_size();
     // read wals and build l0
     for (int i = 0; i < n; i++) {
@@ -744,10 +764,13 @@ Status PersistentIndex::load(const PersistentIndexMetaPB& index_meta) {
     wblock_opts.mode = Env::MUST_EXIST;
     RETURN_IF_ERROR(block_mgr->create_block(wblock_opts, &_index_block));
 
+    // TODO: there may be expired l0 index files in the `_path` directory
+    // and they should be deleted to save disk usage
     return Status::OK();
 }
 
 Status PersistentIndex::prepare(const EditVersion& version) {
+    _dump_snapshot = false;
     _version = version;
     return Status::OK();
 }
@@ -758,19 +781,72 @@ Status PersistentIndex::abort() {
 
 Status PersistentIndex::commit(PersistentIndexMetaPB* index_meta) {
     // TODO: l0 may be need to flush
-    MutableIndexMetaPB* l0_meta = index_meta->mutable_l0_meta();
-    IndexWalMetaPB* wal_pb = l0_meta->add_wals();
-    _version.to_pb(wal_pb->mutable_version());
+    if (_dump_snapshot) {
+        // if _map size is small enough to dump directly, rewrite snapshot
+        std::string file_name = _get_l0_index_file_name(_path, _version);
+        // be maybe crash after create index file during last commit
+        // so we delete expired index file first to make sure no garbage left
+        Env::Default()->delete_file(file_name);
+        fs::BlockManager* block_mgr = fs::fs_util::block_manager();
+        std::unique_ptr<fs::WritableBlock> wblock;
+        fs::CreateBlockOptions wblock_opts({file_name});
+        RETURN_IF_ERROR(block_mgr->create_block(wblock_opts, &wblock));
+        DeferOp close_block([&wblock] {
+            if (wblock) {
+                wblock->close();
+            }
+        });
+        size_t snapshot_size = _dump_bound();
+        phmap::BinaryOutputArchive ar_out(file_name.data());
+        if (!_dump(ar_out)) {
+            std::string err_msg = strings::Substitute("faile to dump snapshot to file $0", file_name);
+            LOG(WARNING) << err_msg;
+            return Status::InternalError(err_msg);
+        }
+        // update PersistentIndexMetaPB
+        MutableIndexMetaPB* l0_meta = index_meta->mutable_l0_meta();
+        l0_meta->clear_wals();
+        IndexSnapshotMetaPB* snapshot = l0_meta->mutable_snapshot();
+        _version.to_pb(snapshot->mutable_version());
+        PagePointerPB* data = snapshot->mutable_data();
+        data->set_offset(0);
+        data->set_size(snapshot_size);
+        _offset += snapshot_size;
+        _page_size = 0;
+    } else {
+        MutableIndexMetaPB* l0_meta = index_meta->mutable_l0_meta();
+        IndexWalMetaPB* wal_pb = l0_meta->add_wals();
+        _version.to_pb(wal_pb->mutable_version());
 
-    PagePointerPB* data = wal_pb->mutable_data();
-    data->set_offset(_offset);
-    data->set_size(_page_size);
+        PagePointerPB* data = wal_pb->mutable_data();
+        data->set_offset(_offset);
+        data->set_size(_page_size);
 
-    _version.to_pb(index_meta->mutable_version());
-    index_meta->set_size(_size);
+        _version.to_pb(index_meta->mutable_version());
+        index_meta->set_size(_size);
 
-    _offset += _page_size;
-    _page_size = 0;
+        _offset += _page_size;
+        _page_size = 0;
+    }
+    return Status::OK();
+}
+
+Status PersistentIndex::apply() {
+    if (_dump_snapshot) {
+        std::string expired_file_path = _index_block->path();
+        std::string index_file_path = _get_l0_index_file_name(_path, _version);
+        fs::BlockManager* block_mgr = fs::fs_util::block_manager();
+        std::unique_ptr<fs::WritableBlock> wblock;
+        fs::CreateBlockOptions wblock_opts({index_file_path});
+        // new index file should be created in commit() phase
+        wblock_opts.mode = Env::MUST_EXIST;
+        RETURN_IF_ERROR(block_mgr->create_block(wblock_opts, &wblock));
+        _index_block = std::move(wblock);
+        VLOG(1) << "delete expired l0 index file: " << expired_file_path;
+        Env::Default()->delete_file(expired_file_path);
+    }
+    _dump_snapshot = false;
+
     return Status::OK();
 }
 
@@ -787,35 +863,44 @@ Status PersistentIndex::get(size_t n, const void* keys, IndexValue* values) {
 Status PersistentIndex::upsert(size_t n, const void* keys, const IndexValue* values, IndexValue* old_values) {
     KeysInfo l1_checks;
     size_t num_found = 0;
-    RETURN_IF_ERROR(_append_wal(n, keys, values));
     RETURN_IF_ERROR(_l0->upsert(n, keys, values, old_values, &l1_checks, &num_found));
+    _dump_snapshot |= _can_dump_directly();
     if (_l1) {
         RETURN_IF_ERROR(_l1->get(n, keys, l1_checks, old_values, &num_found));
     }
     _size += (n - num_found);
+    if (!_dump_snapshot) {
+        RETURN_IF_ERROR(_append_wal(n, keys, values));
+    }
     return Status::OK();
 }
 
 Status PersistentIndex::insert(size_t n, const void* keys, const IndexValue* values, bool check_l1) {
-    RETURN_IF_ERROR(_append_wal(n, keys, values));
     RETURN_IF_ERROR(_l0->insert(n, keys, values));
     if (_l1 && check_l1) {
         RETURN_IF_ERROR(_l1->check_not_exist(n, keys));
     }
+    _dump_snapshot |= _can_dump_directly();
     _size += n;
+    if (!_dump_snapshot) {
+        RETURN_IF_ERROR(_append_wal(n, keys, values));
+    }
     return Status::OK();
 }
 
 Status PersistentIndex::erase(size_t n, const void* keys, IndexValue* old_values) {
     KeysInfo l1_checks;
     size_t num_erased = 0;
-    RETURN_IF_ERROR(_append_wal(n, keys, nullptr));
     RETURN_IF_ERROR(_l0->erase(n, keys, old_values, &l1_checks, &num_erased));
+    _dump_snapshot |= _can_dump_directly();
     if (_l1) {
         RETURN_IF_ERROR(_l1->get(n, keys, l1_checks, old_values, &num_erased));
     }
     CHECK(_size >= num_erased) << strings::Substitute("_size($0) < num_erased($1)", _size, num_erased);
     _size -= num_erased;
+    if (!_dump_snapshot) {
+        RETURN_IF_ERROR(_append_wal(n, keys, nullptr));
+    }
     return Status::OK();
 }
 
@@ -844,6 +929,45 @@ Status PersistentIndex::_flush_l0() {
     RETURN_IF_ERROR(_l0->flush_to_immutable_index(_size, _version, *wblock));
     RETURN_IF_ERROR(Env::Default()->rename_file(idx_file_path_tmp, idx_file_path));
     return Status::OK();
+}
+
+size_t PersistentIndex::mutable_index_size() {
+    return (_l0 == nullptr) ? 0 : _l0->size();
+}
+
+size_t PersistentIndex::mutable_index_capacity() {
+    return (_l0 == nullptr) ? 0 : _l0->capacity();
+}
+
+size_t PersistentIndex::_dump_bound() {
+    if (_l0 == nullptr) {
+        return 0;
+    }
+    return _l0->dump_bound();
+}
+
+bool PersistentIndex::_dump(phmap::BinaryOutputArchive& ar_out) {
+    if (_l0 == nullptr) {
+        return false;
+    }
+    return _l0->dump(ar_out);
+}
+
+// TODO: maybe build snapshot is better than append wals when almost
+// operations are upsert or erase
+bool PersistentIndex::_can_dump_directly() {
+    // if _l0 is empty, we need to build snapshot first
+    if (_size == 0) {
+        return true;
+    }
+    return _dump_bound() <= kSnapshotSize;
+}
+
+bool PersistentIndex::_load_snapshot(phmap::BinaryInputArchive& ar) {
+    if (_l0 == nullptr) {
+        return false;
+    }
+    return _l0->load_snapshot(ar);
 }
 
 } // namespace starrocks

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -763,9 +763,6 @@ Status PersistentIndex::load(const PersistentIndexMetaPB& index_meta) {
     fs::CreateBlockOptions wblock_opts({l0_index_file_name});
     wblock_opts.mode = Env::MUST_EXIST;
     RETURN_IF_ERROR(block_mgr->create_block(wblock_opts, &_index_block));
-
-    // TODO: there may be expired l0 index files in the `_path` directory
-    // and they should be deleted to save disk usage
     RETURN_IF_ERROR(_delete_expired_index_file(start_version));
     return Status::OK();
 }
@@ -941,17 +938,11 @@ size_t PersistentIndex::mutable_index_capacity() {
 }
 
 size_t PersistentIndex::_dump_bound() {
-    if (_l0 == nullptr) {
-        return 0;
-    }
-    return _l0->dump_bound();
+    return (_l0 == nullptr) ? 0 : _l0->dump_bound();
 }
 
 bool PersistentIndex::_dump(phmap::BinaryOutputArchive& ar_out) {
-    if (_l0 == nullptr) {
-        return false;
-    }
-    return _l0->dump(ar_out);
+    return (_l0 == nullptr) ? false : _l0->dump(ar_out);
 }
 
 // TODO: maybe build snapshot is better than append wals when almost
@@ -965,10 +956,7 @@ bool PersistentIndex::_can_dump_directly() {
 }
 
 bool PersistentIndex::_load_snapshot(phmap::BinaryInputArchive& ar) {
-    if (_l0 == nullptr) {
-        return false;
-    }
-    return _l0->load_snapshot(ar);
+    return (_l0 == nullptr) ? false : _l0->load_snapshot(ar);
 }
 
 Status PersistentIndex::_delete_expired_index_file(const EditVersion& version) {

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -824,7 +824,7 @@ Status PersistentIndex::commit(PersistentIndexMetaPB* index_meta) {
     return Status::OK();
 }
 
-Status PersistentIndex::apply() {
+Status PersistentIndex::on_commited() {
     if (_dump_snapshot) {
         std::string expired_file_path = _index_block->path();
         std::string index_file_path = _get_l0_index_file_name(_path, _version);

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -209,6 +209,8 @@ private:
 
     bool _load_snapshot(phmap::BinaryInputArchive& ar_in);
 
+    Status _delete_expired_index_file(const EditVersion& version);
+
     // batch append wal
     // |n|: size of key/value array
     // |keys|: key array as raw buffer

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -126,8 +126,8 @@ public:
 //   if (pi.upsert(upsert_keys, values, old_values))
 //   pi.erase(delete_keys, old_values)
 //   pi.commit()
-//   pi.apply()
-// If any error occurred between prepare and apply, abort should be called, the
+//   pi.on_commited()
+// If any error occurred between prepare and on_commited, abort should be called, the
 // index maybe corrupted, currently for simplicity, the whole index is cleared and rebuilt.
 class PersistentIndex {
 public:
@@ -163,7 +163,7 @@ public:
     Status commit(PersistentIndexMetaPB* index_meta);
 
     // apply modification
-    Status apply();
+    Status on_commited();
 
     // batch index operations
 

--- a/be/test/storage/persistent_index_test.cpp
+++ b/be/test/storage/persistent_index_test.cpp
@@ -162,7 +162,8 @@ PARALLEL_TEST(PersistentIndexTest, test_mutable_index_wal) {
 
         fs::BlockManager* block_mgr = fs::fs_util::block_manager();
         std::unique_ptr<fs::WritableBlock> wblock;
-        fs::CreateBlockOptions wblock_opts({kIndexFile});
+        fs::CreateBlockOptions wblock_opts({"./ut_dir/persistent_index_test/index.l0.1.0"});
+        wblock_opts.mode = Env::MUST_EXIST;
         ASSERT_TRUE((block_mgr->create_block(wblock_opts, &wblock)).ok());
         ASSERT_TRUE(wblock->append(fixed_buf).ok());
         wblock->close();
@@ -209,7 +210,8 @@ PARALLEL_TEST(PersistentIndexTest, test_mutable_index_wal) {
             ASSERT_EQ(values[i], get_values[i]);
         }
     }
-    //FileUtils::remove_all(kPersistentIndexDir);
+
+    FileUtils::remove_all(kPersistentIndexDir);
 }
 
 PARALLEL_TEST(PersistentIndexTest, test_mutable_flush_to_immutable) {

--- a/be/test/storage/persistent_index_test.cpp
+++ b/be/test/storage/persistent_index_test.cpp
@@ -104,6 +104,7 @@ PARALLEL_TEST(PersistentIndexTest, test_mutable_index_wal) {
     std::unique_ptr<fs::WritableBlock> wblock;
     fs::CreateBlockOptions wblock_opts({kIndexFile});
     ASSERT_TRUE((block_mgr->create_block(wblock_opts, &wblock)).ok());
+    wblock->close();
 
     using Key = uint64_t;
     EditVersion version(0, 0);
@@ -121,13 +122,15 @@ PARALLEL_TEST(PersistentIndexTest, test_mutable_index_wal) {
     // insert
     vector<Key> keys;
     vector<IndexValue> values;
-    int N = 10000;
+    int N = 1000000;
     for (int i = 0; i < N; i++) {
         keys.emplace_back(i);
         values.emplace_back(i * 2);
     }
+    ASSERT_TRUE(index.prepare(EditVersion(1, 0)).ok());
     ASSERT_TRUE(index.insert(keys.size(), keys.data(), values.data(), false).ok());
     ASSERT_TRUE(index.commit(&index_meta).ok());
+    ASSERT_TRUE(index.apply().ok());
 
     // erase
     vector<Key> erase_keys;
@@ -135,9 +138,11 @@ PARALLEL_TEST(PersistentIndexTest, test_mutable_index_wal) {
         erase_keys.emplace_back(i);
     }
     vector<IndexValue> erase_old_values(erase_keys.size());
+    ASSERT_TRUE(index.prepare(EditVersion(2, 0)).ok());
     ASSERT_TRUE(index.erase(erase_keys.size(), erase_keys.data(), erase_old_values.data()).ok());
     // update PersistentMetaPB in memory
     ASSERT_TRUE(index.commit(&index_meta).ok());
+    ASSERT_TRUE(index.apply().ok());
 
     // append invalid wal
     std::vector<Key> invalid_keys;
@@ -147,17 +152,31 @@ PARALLEL_TEST(PersistentIndexTest, test_mutable_index_wal) {
         invalid_keys.emplace_back(i);
         invalid_values.emplace_back(i * 2);
     }
-    const uint8_t* fkeys = reinterpret_cast<const uint8_t*>(invalid_keys.data());
-    for (int i = 0; i < N / 2; i++) {
-        fixed_buf.append(fkeys + i * sizeof(Key), sizeof(Key));
-        put_fixed64_le(&fixed_buf, invalid_values[i]);
+
+    {
+        const uint8_t* fkeys = reinterpret_cast<const uint8_t*>(invalid_keys.data());
+        for (int i = 0; i < N / 2; i++) {
+            fixed_buf.append(fkeys + i * sizeof(Key), sizeof(Key));
+            put_fixed64_le(&fixed_buf, invalid_values[i]);
+        }
+
+        fs::BlockManager* block_mgr = fs::fs_util::block_manager();
+        std::unique_ptr<fs::WritableBlock> wblock;
+        fs::CreateBlockOptions wblock_opts({kIndexFile});
+        ASSERT_TRUE((block_mgr->create_block(wblock_opts, &wblock)).ok());
+        ASSERT_TRUE(wblock->append(fixed_buf).ok());
+        wblock->close();
     }
-    ASSERT_TRUE(wblock->append(fixed_buf).ok());
 
     // rebuild mutableindex according PersistentIndexMetaPB
     PersistentIndex new_index(kPersistentIndexDir);
-    ASSERT_TRUE(new_index.create(sizeof(Key), version).ok());
-    ASSERT_TRUE(new_index.load(index_meta).ok());
+    ASSERT_TRUE(new_index.create(sizeof(Key), EditVersion(2, 0)).ok());
+    //ASSERT_TRUE(new_index.load(index_meta).ok());
+    Status st = new_index.load(index_meta);
+    if (!st.ok()) {
+        LOG(WARNING) << "load failed, status is " << st.to_string();
+        ASSERT_TRUE(false);
+    }
     std::vector<IndexValue> get_values(keys.size());
 
     ASSERT_TRUE(new_index.get(keys.size(), keys.data(), get_values.data()).ok());
@@ -168,17 +187,19 @@ PARALLEL_TEST(PersistentIndexTest, test_mutable_index_wal) {
     for (int i = N / 2; i < values.size(); i++) {
         ASSERT_EQ(values[i], get_values[i]);
     }
-
     // upsert key/value to new_index
-    vector<IndexValue> old_values(invalid_keys.size());
-    ASSERT_TRUE(
-            new_index.upsert(invalid_keys.size(), invalid_keys.data(), invalid_values.data(), old_values.data()).ok());
-    ASSERT_TRUE(new_index.commit(&index_meta).ok());
-
+    {
+        vector<IndexValue> old_values(invalid_keys.size());
+        ASSERT_TRUE(new_index.prepare(EditVersion(3, 0)).ok());
+        ASSERT_TRUE(new_index.upsert(invalid_keys.size(), invalid_keys.data(), invalid_values.data(), old_values.data())
+                            .ok());
+        ASSERT_TRUE(new_index.commit(&index_meta).ok());
+        ASSERT_TRUE(new_index.apply().ok());
+    }
     // rebuild mutableindex according to PersistentIndexMetaPB
     {
         PersistentIndex index(kPersistentIndexDir);
-        ASSERT_TRUE(index.create(sizeof(Key), version).ok());
+        ASSERT_TRUE(index.create(sizeof(Key), EditVersion(3, 0)).ok());
         ASSERT_TRUE(index.load(index_meta).ok());
         std::vector<IndexValue> get_values(keys.size());
 
@@ -188,9 +209,7 @@ PARALLEL_TEST(PersistentIndexTest, test_mutable_index_wal) {
             ASSERT_EQ(values[i], get_values[i]);
         }
     }
-
-    wblock->close();
-    FileUtils::remove_all(kPersistentIndexDir);
+    //FileUtils::remove_all(kPersistentIndexDir);
 }
 
 PARALLEL_TEST(PersistentIndexTest, test_mutable_flush_to_immutable) {

--- a/be/test/storage/persistent_index_test.cpp
+++ b/be/test/storage/persistent_index_test.cpp
@@ -130,14 +130,14 @@ PARALLEL_TEST(PersistentIndexTest, test_mutable_index_wal) {
     ASSERT_TRUE(index.prepare(EditVersion(1, 0)).ok());
     ASSERT_TRUE(index.insert(100, keys.data(), values.data(), false).ok());
     ASSERT_TRUE(index.commit(&index_meta).ok());
-    ASSERT_TRUE(index.apply().ok());
+    ASSERT_TRUE(index.on_commited().ok());
 
     {
         std::vector<IndexValue> old_values(keys.size());
         ASSERT_TRUE(index.prepare(EditVersion(2, 0)).ok());
         ASSERT_TRUE(index.upsert(keys.size(), keys.data(), values.data(), old_values.data()).ok());
         ASSERT_TRUE(index.commit(&index_meta).ok());
-        ASSERT_TRUE(index.apply().ok());
+        ASSERT_TRUE(index.on_commited().ok());
     }
 
     // erase
@@ -150,7 +150,7 @@ PARALLEL_TEST(PersistentIndexTest, test_mutable_index_wal) {
     ASSERT_TRUE(index.erase(erase_keys.size(), erase_keys.data(), erase_old_values.data()).ok());
     // update PersistentMetaPB in memory
     ASSERT_TRUE(index.commit(&index_meta).ok());
-    ASSERT_TRUE(index.apply().ok());
+    ASSERT_TRUE(index.on_commited().ok());
 
     // append invalid wal
     std::vector<Key> invalid_keys;
@@ -203,7 +203,7 @@ PARALLEL_TEST(PersistentIndexTest, test_mutable_index_wal) {
         ASSERT_TRUE(new_index.upsert(invalid_keys.size(), invalid_keys.data(), invalid_values.data(), old_values.data())
                             .ok());
         ASSERT_TRUE(new_index.commit(&index_meta).ok());
-        ASSERT_TRUE(new_index.apply().ok());
+        ASSERT_TRUE(new_index.on_commited().ok());
     }
     // rebuild mutableindex according to PersistentIndexMetaPB
     {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [x] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3225

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
To reduce memory usage of the PrimaryKey tablet, use the persistent primary index to replace all-in-memory implementation.

A persistent primary index contains an in-memory L0 and an on-SSD/NVMe L1; this pr adds an L0 snapshot implementation.

Before insert/upsert/erase key/value to L0, if size of L0 is small enough, we will build snapshot of L0 instead of write WAL.

After Be restarted, the persistent index will load snapshot and WAL and rebuild L0 in memory.
