### PR TITLE
optimize ORC late materialization

### DIFF
--- a/be/src/exec/vectorized/hdfs_scanner_orc.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_orc.cpp
@@ -21,7 +21,9 @@ public:
 
     uint64_t getLength() const override { return _length; }
 
-    uint64_t getNaturalReadSize() const override { return 2 * 1024 * 1024; }
+    uint64_t getNaturalReadSize() const override { return 1 * 1024 * 1024; }
+
+    uint64_t getNaturalReadSizeAfterSeek() const override { return 128 * 1024; }
 
     void read(void* buf, uint64_t length, uint64_t offset) override {
         SCOPED_RAW_TIMER(&_stats->io_ns);

--- a/be/src/exec/vectorized/hdfs_scanner_orc.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_orc.cpp
@@ -474,7 +474,7 @@ Status HdfsOrcScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk)
 
         // We batch skip num values beause we have opportunity to skip an entire stripe / row_group
         // And if that happens,  we can save IO at granuarity of strip / row_group
-        if (position.start_new_stripe || position.seek_to_row_group) {
+        if (position.start_new_stripe || position.seek_new_row_group) {
             skip_num_values = 0;
         }
         // if has lazy load fields, skip it if chunk_size == 0

--- a/be/src/exec/vectorized/hdfs_scanner_orc.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_orc.cpp
@@ -369,10 +369,12 @@ Status HdfsOrcScanner::do_open(RuntimeState* runtime_state) {
             VLOG_FILE << "[ORC] lazy load field = " << it->col_name();
             _lazy_load_ctx.lazy_load_slots.emplace_back(it);
             _lazy_load_ctx.lazy_load_indices.emplace_back(src_slot_index);
+            _lazy_load_ctx.lazy_load_orc_positions.emplace_back(0);
         } else {
             VLOG_FILE << "[ORC] active load field = " << it->col_name();
             _lazy_load_ctx.active_load_slots.emplace_back(it);
             _lazy_load_ctx.active_load_indices.emplace_back(src_slot_index);
+            _lazy_load_ctx.active_load_orc_positions.emplace_back(0);
         }
         _src_slot_descriptors.emplace_back(it);
         src_slot_index++;

--- a/be/src/exec/vectorized/hdfs_scanner_orc.h
+++ b/be/src/exec/vectorized/hdfs_scanner_orc.h
@@ -42,6 +42,7 @@ private:
     OrcScannerAdapter::LazyLoadContext _lazy_load_ctx;
     std::unique_ptr<OrcScannerAdapter> _orc_adapter;
     std::shared_ptr<OrcRowReaderFilter> _orc_row_reader_filter;
+    Filter _dict_filter;
     Filter _chunk_filter;
 };
 

--- a/be/src/exec/vectorized/orc_scanner_adapter.cpp
+++ b/be/src/exec/vectorized/orc_scanner_adapter.cpp
@@ -1471,8 +1471,8 @@ void OrcScannerAdapter::lazy_read_next(size_t numValues) {
     _row_reader->lazyLoadNext(*_batch, numValues);
 }
 
-void OrcScannerAdapter::lazy_skip_next(size_t numValues) {
-    _row_reader->lazyLoadSkip(numValues);
+void OrcScannerAdapter::lazy_sync_to(size_t rowInStripe) {
+    _row_reader->lazyLoadSyncTo(rowInStripe);
 }
 
 void OrcScannerAdapter::set_row_reader_filter(std::shared_ptr<orc::RowReaderFilter> filter) {

--- a/be/src/exec/vectorized/orc_scanner_adapter.cpp
+++ b/be/src/exec/vectorized/orc_scanner_adapter.cpp
@@ -1169,6 +1169,19 @@ Status OrcScannerAdapter::_init_position_in_orc() {
         SlotId id = slot_desc->id();
         _slot_id_to_position[id] = pos;
     }
+
+    if (_lazy_load_ctx != nullptr) {
+        for (int i = 0; i < _lazy_load_ctx->active_load_slots.size(); i++) {
+            int src_index = _lazy_load_ctx->active_load_indices[i];
+            int pos = _position_in_orc[src_index];
+            _lazy_load_ctx->active_load_orc_positions[i] = pos;
+        }
+        for (int i = 0; i < _lazy_load_ctx->lazy_load_slots.size(); i++) {
+            int src_index = _lazy_load_ctx->lazy_load_indices[i];
+            int pos = _position_in_orc[src_index];
+            _lazy_load_ctx->lazy_load_orc_positions[i] = pos;
+        }
+    }
     return Status::OK();
 }
 
@@ -1456,7 +1469,8 @@ StatusOr<ChunkPtr> OrcScannerAdapter::get_active_chunk() {
 void OrcScannerAdapter::lazy_filter_on_cvb(Filter* filter) {
     size_t true_size = SIMD::count_nonzero(*filter);
     if (filter->size() != true_size) {
-        _batch->filter(filter->data(), filter->size(), true_size);
+        _batch->filterOnFields(filter->data(), filter->size(), true_size, _lazy_load_ctx->lazy_load_orc_positions,
+                               true);
     }
 }
 
@@ -2121,7 +2135,12 @@ Status OrcScannerAdapter::apply_dict_filter_eval_cache(
     if (!filter_all) {
         uint32_t one_count = filter->size() - SIMD::count_zero(*filter);
         if (one_count != filter->size()) {
-            _batch->filter(filter->data(), filter->size(), one_count);
+            if (has_lazy_load_context()) {
+                _batch->filterOnFields(filter->data(), filter->size(), one_count,
+                                       _lazy_load_ctx->active_load_orc_positions, false);
+            } else {
+                _batch->filter(filter->data(), filter->size(), one_count);
+            }
         }
     } else {
         _batch->numElements = 0;

--- a/be/src/exec/vectorized/orc_scanner_adapter.cpp
+++ b/be/src/exec/vectorized/orc_scanner_adapter.cpp
@@ -1485,8 +1485,8 @@ void OrcScannerAdapter::lazy_read_next(size_t numValues) {
     _row_reader->lazyLoadNext(*_batch, numValues);
 }
 
-void OrcScannerAdapter::lazy_sync_to(size_t rowInStripe) {
-    _row_reader->lazyLoadSyncTo(rowInStripe);
+void OrcScannerAdapter::lazy_seek_to(size_t rowInStripe) {
+    _row_reader->lazyLoadSeekTo(rowInStripe);
 }
 
 void OrcScannerAdapter::set_row_reader_filter(std::shared_ptr<orc::RowReaderFilter> filter) {

--- a/be/src/exec/vectorized/orc_scanner_adapter.h
+++ b/be/src/exec/vectorized/orc_scanner_adapter.h
@@ -108,7 +108,8 @@ public:
     StatusOr<ChunkPtr> get_active_chunk();
     void lazy_read_next(size_t numValues);
     void lazy_skip_next(size_t numValues);
-    StatusOr<ChunkPtr> get_lazy_chunk(Filter* filter, size_t chunk_size);
+    void lazy_filter_on_cvb(Filter* filter);
+    StatusOr<ChunkPtr> get_lazy_chunk();
 
 private:
     ChunkPtr _create_chunk(const std::vector<SlotDescriptor*>& slots, const std::vector<int>* indices);

--- a/be/src/exec/vectorized/orc_scanner_adapter.h
+++ b/be/src/exec/vectorized/orc_scanner_adapter.h
@@ -36,8 +36,10 @@ public:
     struct LazyLoadContext {
         std::vector<SlotDescriptor*> active_load_slots;
         std::vector<int> active_load_indices;
+        std::vector<int> active_load_orc_positions;
         std::vector<SlotDescriptor*> lazy_load_slots;
         std::vector<int> lazy_load_indices;
+        std::vector<int> lazy_load_orc_positions;
     };
 
     // src slot descriptors should exactly matches columns in row readers.

--- a/be/src/exec/vectorized/orc_scanner_adapter.h
+++ b/be/src/exec/vectorized/orc_scanner_adapter.h
@@ -107,7 +107,7 @@ public:
     StatusOr<ChunkPtr> get_chunk();
     StatusOr<ChunkPtr> get_active_chunk();
     void lazy_read_next(size_t numValues);
-    void lazy_skip_next(size_t numValues);
+    void lazy_sync_to(uint64_t rowInStripe);
     void lazy_filter_on_cvb(Filter* filter);
     StatusOr<ChunkPtr> get_lazy_chunk();
 

--- a/be/src/exec/vectorized/orc_scanner_adapter.h
+++ b/be/src/exec/vectorized/orc_scanner_adapter.h
@@ -109,7 +109,7 @@ public:
     StatusOr<ChunkPtr> get_chunk();
     StatusOr<ChunkPtr> get_active_chunk();
     void lazy_read_next(size_t numValues);
-    void lazy_sync_to(uint64_t rowInStripe);
+    void lazy_seek_to(uint64_t rowInStripe);
     void lazy_filter_on_cvb(Filter* filter);
     StatusOr<ChunkPtr> get_lazy_chunk();
 

--- a/be/src/formats/orc/apache-orc/c++/include/orc/OrcFile.hh
+++ b/be/src/formats/orc/apache-orc/c++/include/orc/OrcFile.hh
@@ -53,6 +53,12 @@ public:
     virtual uint64_t getNaturalReadSize() const = 0;
 
     /**
+     * Get the natural size for reads afrer seek.
+     * @return the number of bytes that should be read at once
+     */
+    virtual uint64_t getNaturalReadSizeAfterSeek() const;
+
+    /**
      * Read length bytes from the file starting at offset into
      * the buffer starting at buf.
      * @param buf the starting position of a buffer.

--- a/be/src/formats/orc/apache-orc/c++/include/orc/Reader.hh
+++ b/be/src/formats/orc/apache-orc/c++/include/orc/Reader.hh
@@ -565,7 +565,7 @@ public:
     bool next(ColumnVectorBatch& data);
     virtual bool next(ColumnVectorBatch& data, ReadPosition* pos) = 0;
 
-    virtual void lazyLoadSyncTo(uint64_t rowInStripe) = 0;
+    virtual void lazyLoadSeekTo(uint64_t rowInStripe) = 0;
     virtual void lazyLoadNext(ColumnVectorBatch& data, uint64_t numValues) = 0;
 
     /**

--- a/be/src/formats/orc/apache-orc/c++/include/orc/Reader.hh
+++ b/be/src/formats/orc/apache-orc/c++/include/orc/Reader.hh
@@ -523,9 +523,9 @@ class RowReader {
 public:
     struct ReadPosition {
         bool start_new_stripe = false;
-        bool seek_new_row_group = false;
         uint64_t stripe_index = 0;
         uint64_t num_values = 0;
+        uint64_t row_in_stripe = 0;
     };
 
     virtual ~RowReader();
@@ -565,7 +565,7 @@ public:
     bool next(ColumnVectorBatch& data);
     virtual bool next(ColumnVectorBatch& data, ReadPosition* pos) = 0;
 
-    virtual void lazyLoadSkip(uint64_t numValues) = 0;
+    virtual void lazyLoadSyncTo(uint64_t rowInStripe) = 0;
     virtual void lazyLoadNext(ColumnVectorBatch& data, uint64_t numValues) = 0;
 
     /**

--- a/be/src/formats/orc/apache-orc/c++/include/orc/Reader.hh
+++ b/be/src/formats/orc/apache-orc/c++/include/orc/Reader.hh
@@ -522,10 +522,10 @@ public:
 class RowReader {
 public:
     struct ReadPosition {
-        uint64_t strip_index = 0;
-        uint64_t num_values = 0;
         bool start_new_stripe = false;
-        bool seek_to_row_group = false;
+        bool seek_new_row_group = false;
+        uint64_t stripe_index = 0;
+        uint64_t num_values = 0;
     };
 
     virtual ~RowReader();

--- a/be/src/formats/orc/apache-orc/c++/include/orc/Vector.hh
+++ b/be/src/formats/orc/apache-orc/c++/include/orc/Vector.hh
@@ -91,6 +91,8 @@ struct ColumnVectorBatch {
     // f_size: filter size
     // true_size: number of ones in filter data.
     virtual void filter(uint8_t* f_data, uint32_t f_size, uint32_t true_size);
+    virtual void filterOnFields(uint8_t* f_data, uint32_t f_size, uint32_t true_size, const std::vector<int>& fields,
+                                bool onLazyLoad);
 
 private:
     ColumnVectorBatch(const ColumnVectorBatch&) = delete;
@@ -188,6 +190,8 @@ struct StructVectorBatch : public ColumnVectorBatch {
 
     std::vector<ColumnVectorBatch*> fields;
     void filter(uint8_t* f_data, uint32_t f_size, uint32_t true_size) override;
+    void filterOnFields(uint8_t* f_data, uint32_t f_size, uint32_t true_size, const std::vector<int>& fields,
+                        bool onLazyLoad) override;
 };
 
 struct ListVectorBatch : public ColumnVectorBatch {

--- a/be/src/formats/orc/apache-orc/c++/src/ColumnReader.cc
+++ b/be/src/formats/orc/apache-orc/c++/src/ColumnReader.cc
@@ -998,11 +998,15 @@ public:
     void nextEncoded(ColumnVectorBatch& rowBatch, uint64_t numValues, char* notNull) override;
 
     void seekToRowGroup(PositionProviderMap* positions) override;
-    void lazyLoadSeekToRowGroup(PositionProviderMap* providers) override;
 
     const size_t size() { return children.size(); }
     ColumnReader* childReaderAt(size_t idx) { return children[idx].get(); }
 
+    // The pace of lazy load fields and active load fields are different.
+    // We read `active load fields` first, if predicates on them are true
+    // then we read `lazy load fields`.
+    // And that's why we need standalone methods just for lazy load fields.
+    void lazyLoadSeekToRowGroup(PositionProviderMap* providers) override;
     void lazyLoadSkip(uint64_t numValues) override;
     void lazyLoadNext(ColumnVectorBatch& rowBatch, uint64_t numValues, char* notNull) override;
     void lazyLoadNextEncoded(ColumnVectorBatch& rowBatch, uint64_t numValues, char* notNull) override;

--- a/be/src/formats/orc/apache-orc/c++/src/ColumnReader.cc
+++ b/be/src/formats/orc/apache-orc/c++/src/ColumnReader.cc
@@ -117,6 +117,10 @@ void ColumnReader::seekToRowGroup(PositionProviderMap* positions) {
     }
 }
 
+void ColumnReader::lazyLoadSeekToRowGroup(PositionProviderMap* positions) {
+    throw ParseError("ColumnReader::lazyLoadSeekToRowGroup not implemented");
+}
+
 void ColumnReader::lazyLoadSkip(uint64_t numValues) {
     throw ParseError("ColumnReader::lazyLoadSkip not implemented");
 }
@@ -983,8 +987,6 @@ private:
     std::vector<uint64_t> fieldIndex;
     std::vector<std::unique_ptr<ColumnReader>> lazyLoadChildren;
     std::vector<uint64_t> lazyLoadFieldIndex;
-    PositionProviderMap pendingSeekToRowGroupRequest;
-    bool hasPendingSeekToRowGroupRequest = false;
 
 public:
     StructColumnReader(const Type& type, StripeStreams& stipe);
@@ -996,11 +998,11 @@ public:
     void nextEncoded(ColumnVectorBatch& rowBatch, uint64_t numValues, char* notNull) override;
 
     void seekToRowGroup(PositionProviderMap* positions) override;
+    void lazyLoadSeekToRowGroup(PositionProviderMap* providers) override;
 
     const size_t size() { return children.size(); }
     ColumnReader* childReaderAt(size_t idx) { return children[idx].get(); }
 
-    void applyLastSeekToRowGroupRequest();
     void lazyLoadSkip(uint64_t numValues) override;
     void lazyLoadNext(ColumnVectorBatch& rowBatch, uint64_t numValues, char* notNull) override;
     void lazyLoadNextEncoded(ColumnVectorBatch& rowBatch, uint64_t numValues, char* notNull) override;
@@ -1077,39 +1079,29 @@ void StructColumnReader::nextInternal(const std::vector<std::unique_ptr<ColumnRe
     }
 }
 
-void StructColumnReader::applyLastSeekToRowGroupRequest() {
-    if (hasPendingSeekToRowGroupRequest) {
-        hasPendingSeekToRowGroupRequest = false;
-        for (auto& ptr : lazyLoadChildren) {
-            ptr->seekToRowGroup(&pendingSeekToRowGroupRequest);
-        }
-    }
-}
-
 void StructColumnReader::seekToRowGroup(PositionProviderMap* positions) {
     ColumnReader::seekToRowGroup(positions);
     for (auto& ptr : children) {
         ptr->seekToRowGroup(positions);
     }
-    if (lazyLoadChildren.size() != 0) {
-        pendingSeekToRowGroupRequest.copyFrom(*positions);
-        hasPendingSeekToRowGroupRequest = true;
+}
+
+void StructColumnReader::lazyLoadSeekToRowGroup(PositionProviderMap* positions) {
+    for (auto& ptr : lazyLoadChildren) {
+        ptr->seekToRowGroup(positions);
     }
 }
 
 void StructColumnReader::lazyLoadSkip(uint64_t numValues) {
-    applyLastSeekToRowGroupRequest();
     for (auto& ptr : lazyLoadChildren) {
         ptr->skip(numValues);
     }
 }
 void StructColumnReader::lazyLoadNext(ColumnVectorBatch& rowBatch, uint64_t numValues, char* notNull) {
-    applyLastSeekToRowGroupRequest();
     nextInternal<false, true>(lazyLoadChildren, lazyLoadFieldIndex, rowBatch, numValues, notNull);
 }
 
 void StructColumnReader::lazyLoadNextEncoded(ColumnVectorBatch& rowBatch, uint64_t numValues, char* notNull) {
-    applyLastSeekToRowGroupRequest();
     nextInternal<true, true>(lazyLoadChildren, lazyLoadFieldIndex, rowBatch, numValues, notNull);
 }
 

--- a/be/src/formats/orc/apache-orc/c++/src/ColumnReader.hh
+++ b/be/src/formats/orc/apache-orc/c++/src/ColumnReader.hh
@@ -156,6 +156,7 @@ public:
      * @param positions a list of PositionProviders storing the positions
      */
     virtual void seekToRowGroup(PositionProviderMap* providers);
+    virtual void lazyLoadSeekToRowGroup(PositionProviderMap* providers);
 
     uint64_t getColumnId() { return columnId; }
 };

--- a/be/src/formats/orc/apache-orc/c++/src/Reader.cc
+++ b/be/src/formats/orc/apache-orc/c++/src/Reader.cc
@@ -1063,7 +1063,7 @@ void RowReaderImpl::lazyLoadNext(ColumnVectorBatch& data, uint64_t numValues) {
     lazyLoadLastUsedRowInStripe += numValues;
 }
 
-void RowReaderImpl::lazyLoadSyncTo(uint64_t toRow) {
+void RowReaderImpl::lazyLoadSeekTo(uint64_t toRow) {
     uint64_t costDirectSkip = (toRow - lazyLoadLastUsedRowInStripe);
     if (costDirectSkip == 0) {
         return;

--- a/be/src/formats/orc/apache-orc/c++/src/Reader.cc
+++ b/be/src/formats/orc/apache-orc/c++/src/Reader.cc
@@ -1074,7 +1074,7 @@ void RowReaderImpl::lazyLoadSkip(uint64_t numValues) {
     uint64_t toRow = lazyLoadRowInStripe + numValues;
     // we have two options to locate `toRow`:
     // 1. use seek to row group, and skip rest rows(# = toRow % rowindexstripe)
-    // 2. or skip rest rows directly(# = roRow - lazyLoadLastUsedRowInStripe)
+    // 2. or skip rest rows directly(# = toRow - lazyLoadLastUsedRowInStripe)
     // we can assume `seek to row group` costs skipping X rows
     // then #1 cost is X + toRow % rowindexstripe
     // #2 cost is (row - lazyLoadLastUsedRowInStripe)

--- a/be/src/formats/orc/apache-orc/c++/src/Reader.hh
+++ b/be/src/formats/orc/apache-orc/c++/src/Reader.hh
@@ -131,7 +131,6 @@ private:
     uint64_t currentStripe;
     uint64_t lastStripe; // the stripe AFTER the last one
     uint64_t currentRowInStripe;
-    uint64_t lazyLoadRowInStripe;         // which row in stripe lazy load fields are going to use.
     uint64_t lazyLoadLastUsedRowInStripe; // which row in stripe loazy load files are used in last time.
 
     uint64_t rowsInCurrentStripe;
@@ -201,7 +200,7 @@ public:
     std::unique_ptr<ColumnVectorBatch> createRowBatch(uint64_t size) const override;
 
     bool next(ColumnVectorBatch& data, ReadPosition* pos) override;
-    void lazyLoadSkip(uint64_t numValues) override;
+    void lazyLoadSyncTo(uint64_t rowInStripe) override;
     void lazyLoadNext(ColumnVectorBatch& data, uint64_t numValues) override;
 
     CompressionKind getCompression() const;

--- a/be/src/formats/orc/apache-orc/c++/src/Reader.hh
+++ b/be/src/formats/orc/apache-orc/c++/src/Reader.hh
@@ -131,6 +131,9 @@ private:
     uint64_t currentStripe;
     uint64_t lastStripe; // the stripe AFTER the last one
     uint64_t currentRowInStripe;
+    uint64_t lazyLoadRowInStripe;         // which row in stripe lazy load fields are going to use.
+    uint64_t lazyLoadLastUsedRowInStripe; // which row in stripe loazy load files are used in last time.
+
     uint64_t rowsInCurrentStripe;
     proto::StripeInformation currentStripeInfo;
     proto::StripeFooter currentStripeFooter;
@@ -177,8 +180,9 @@ private:
     /**
      * Seek to the start of a row group in the current stripe
      * @param rowGroupEntryId the row group id to seek to
+     * @param onLazyLoadFields seek to row group for lazy load fields
      */
-    void seekToRowGroup(uint32_t rowGroupEntryId);
+    void seekToRowGroup(uint32_t rowGroupEntryId, bool onLazyLoadFields = false);
 
 public:
     /**

--- a/be/src/formats/orc/apache-orc/c++/src/Reader.hh
+++ b/be/src/formats/orc/apache-orc/c++/src/Reader.hh
@@ -179,9 +179,9 @@ private:
     /**
      * Seek to the start of a row group in the current stripe
      * @param rowGroupEntryId the row group id to seek to
-     * @param onLazyLoadFields seek to row group for lazy load fields
      */
-    void seekToRowGroup(uint32_t rowGroupEntryId, bool onLazyLoadFields = false);
+    void seekToRowGroup(uint32_t rowGroupEntryId);
+    void getRowGroupPosition(uint32_t rowGroupEntryId, PositionProviderMap* map);
 
 public:
     /**

--- a/be/src/formats/orc/apache-orc/c++/src/Reader.hh
+++ b/be/src/formats/orc/apache-orc/c++/src/Reader.hh
@@ -200,7 +200,7 @@ public:
     std::unique_ptr<ColumnVectorBatch> createRowBatch(uint64_t size) const override;
 
     bool next(ColumnVectorBatch& data, ReadPosition* pos) override;
-    void lazyLoadSyncTo(uint64_t rowInStripe) override;
+    void lazyLoadSeekTo(uint64_t rowInStripe) override;
     void lazyLoadNext(ColumnVectorBatch& data, uint64_t numValues) override;
 
     CompressionKind getCompression() const;

--- a/be/src/formats/orc/apache-orc/c++/src/Vector.cc
+++ b/be/src/formats/orc/apache-orc/c++/src/Vector.cc
@@ -75,6 +75,11 @@ void ColumnVectorBatch::filter(uint8_t* f_data, uint32_t f_size, uint32_t true_s
     }
 }
 
+void ColumnVectorBatch::filterOnFields(uint8_t* f_data, uint32_t f_size, uint32_t true_size,
+                                       const std::vector<int>& fields, bool onLazyLoad) {
+    throw ParseError("ColumnVectorBatch::filterOnFields not implemented");
+}
+
 LongVectorBatch::LongVectorBatch(uint64_t _capacity, MemoryPool& pool)
         : ColumnVectorBatch(_capacity, pool), data(pool, _capacity) {
     // PASS
@@ -275,6 +280,19 @@ bool StructVectorBatch::hasVariableLength() {
 void StructVectorBatch::filter(uint8_t* f_data, uint32_t f_size, uint32_t true_size) {
     ColumnVectorBatch::filter(f_data, f_size, true_size);
     for (ColumnVectorBatch* cvb : fields) {
+        cvb->filter(f_data, f_size, true_size);
+    }
+}
+
+void StructVectorBatch::filterOnFields(uint8_t* f_data, uint32_t f_size, uint32_t true_size,
+                                       const std::vector<int>& positions, bool onLazyLoad) {
+    if (!onLazyLoad) {
+        ColumnVectorBatch::filter(f_data, f_size, true_size);
+    } else {
+        numElements = true_size;
+    }
+    for (int p : positions) {
+        ColumnVectorBatch* cvb = fields[p];
         cvb->filter(f_data, f_size, true_size);
     }
 }

--- a/be/src/formats/orc/apache-orc/c++/src/io/InputStream.cc
+++ b/be/src/formats/orc/apache-orc/c++/src/io/InputStream.cc
@@ -143,7 +143,7 @@ SeekableFileInputStream::SeekableFileInputStream(InputStream* stream, uint64_t o
     position = 0;
     buffer.reset(new DataBuffer<char>(pool));
     pushBack = 0;
-    pendingSeek = false;
+    hasSeek = false;
 }
 
 SeekableFileInputStream::~SeekableFileInputStream() {
@@ -157,8 +157,8 @@ bool SeekableFileInputStream::Next(const void** data, int* size) {
         bytesRead = pushBack;
     } else {
         bytesRead = std::min(length - position, blockSize);
-        if (pendingSeek) {
-            pendingSeek = false;
+        if (hasSeek) {
+            hasSeek = false;
             bytesRead = std::min(bytesRead, input->getNaturalReadSizeAfterSeek());
         }
         buffer->resize(bytesRead);
@@ -209,7 +209,7 @@ void SeekableFileInputStream::seek(PositionProvider& location) {
         throw std::logic_error("seek too far");
     }
     pushBack = 0;
-    pendingSeek = true;
+    hasSeek = true;
 }
 
 std::string SeekableFileInputStream::getName() const {

--- a/be/src/formats/orc/apache-orc/c++/src/io/InputStream.cc
+++ b/be/src/formats/orc/apache-orc/c++/src/io/InputStream.cc
@@ -61,17 +61,6 @@ PositionProvider& PositionProviderMap::at(uint64_t columnId) {
     return providers.at(columnId);
 }
 
-void PositionProviderMap::copyFrom(const PositionProviderMap& map) {
-    positions = map.positions;
-    columnIdToPositionIndex = map.columnIdToPositionIndex;
-    providers.clear();
-    for (auto& it : columnIdToPositionIndex) {
-        uint64_t colId = it.first;
-        size_t index = it.second;
-        providers.insert(std::make_pair(colId, PositionProvider(positions[index])));
-    }
-}
-
 SeekableInputStream::~SeekableInputStream() {
     // PASS
 }

--- a/be/src/formats/orc/apache-orc/c++/src/io/InputStream.hh
+++ b/be/src/formats/orc/apache-orc/c++/src/io/InputStream.hh
@@ -100,6 +100,7 @@ private:
     std::unique_ptr<DataBuffer<char>> buffer;
     uint64_t position;
     uint64_t pushBack;
+    bool pendingSeek;
 
 public:
     SeekableFileInputStream(InputStream* input, uint64_t offset, uint64_t byteCount, MemoryPool& pool,

--- a/be/src/formats/orc/apache-orc/c++/src/io/InputStream.hh
+++ b/be/src/formats/orc/apache-orc/c++/src/io/InputStream.hh
@@ -49,10 +49,8 @@ public:
 class PositionProviderMap {
 public:
     std::unordered_map<uint64_t, PositionProvider> providers;
-    std::unordered_map<uint64_t, size_t> columnIdToPositionIndex;
     std::vector<std::list<uint64_t>> positions;
     PositionProvider& at(uint64_t columnId);
-    void copyFrom(const PositionProviderMap& map);
 };
 
 /**

--- a/be/src/formats/orc/apache-orc/c++/src/io/InputStream.hh
+++ b/be/src/formats/orc/apache-orc/c++/src/io/InputStream.hh
@@ -100,7 +100,7 @@ private:
     std::unique_ptr<DataBuffer<char>> buffer;
     uint64_t position;
     uint64_t pushBack;
-    bool pendingSeek;
+    bool hasSeek;
 
 public:
     SeekableFileInputStream(InputStream* input, uint64_t offset, uint64_t byteCount, MemoryPool& pool,

--- a/be/src/formats/orc/apache-orc/c++/test/TestLazyLoad.cc
+++ b/be/src/formats/orc/apache-orc/c++/test/TestLazyLoad.cc
@@ -80,7 +80,7 @@ TEST(TestLazyLoad, TestNormal) {
                     ASSERT_EQ(c1->data[i], 0);
                     index += 1;
                 }
-                rr->lazyLoadSyncTo(pos.row_in_stripe);
+                rr->lazyLoadSeekTo(pos.row_in_stripe);
             } else {
                 rr->lazyLoadNext(*batch, batch->numElements);
                 for (size_t i = 0; i < batchSize; i++) {
@@ -175,7 +175,7 @@ TEST(TestLazyLoad, TestWithSearchArgument) {
         // we don't need to skip first stripe.
         EXPECT_EQ(rr->next(*batch, &pos), true);
         EXPECT_EQ(batch->numElements, readSize);
-        rr->lazyLoadSyncTo(pos.row_in_stripe);
+        rr->lazyLoadSeekTo(pos.row_in_stripe);
         rr->lazyLoadNext(*batch, readSize);
 
         size_t index = batchSize + readSize;


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Problem Summary(Required) ：

### Optimize `lazyLoadSkip`

We find `lazyLoadSkip` size is very large, which means we don't use `RowGroupIndex` to seek.  Before optimization, we can see size is very large. 

```
     size                : count     distribution
         0 -> 1          : 0        |                                        |
         2 -> 3          : 0        |                                        |
         4 -> 7          : 0        |                                        |
         8 -> 15         : 0        |                                        |
        16 -> 31         : 0        |                                        |
        32 -> 63         : 0        |                                        |
        64 -> 127        : 0        |                                        |
       128 -> 255        : 0        |                                        |
       256 -> 511        : 0        |                                        |
       512 -> 1023       : 0        |                                        |
      1024 -> 2047       : 0        |                                        |
      2048 -> 4095       : 0        |                                        |
      4096 -> 8191       : 10       |*                                       |
      8192 -> 16383      : 20       |**                                      |
     16384 -> 32767      : 38       |***                                     |
     32768 -> 65535      : 74       |*******                                 |
     65536 -> 131071     : 144      |**************                          |
    131072 -> 262143     : 262      |***************************             |
    262144 -> 524287     : 352      |************************************    |
    524288 -> 1048575    : 385      |****************************************|
   1048576 -> 2097151    : 55       |*****                                   |
```

And after optimization, we can see size has been reduced a lot

```
     size                : count     distribution
         0 -> 1          : 0        |                                        |
         2 -> 3          : 0        |                                        |
         4 -> 7          : 0        |                                        |
         8 -> 15         : 0        |                                        |
        16 -> 31         : 4        |                                        |
        32 -> 63         : 4        |                                        |
        64 -> 127        : 12       |*                                       |
       128 -> 255        : 10       |                                        |
       256 -> 511        : 22       |*                                       |
       512 -> 1023       : 68       |******                                  |
      1024 -> 2047       : 116      |**********                              |
      2048 -> 4095       : 236      |*********************                   |
      4096 -> 8191       : 443      |****************************************|
      8192 -> 16383      : 222      |********************                    |
```
