### PR TITLE
Support bucket-level endpoint specification for aliyun OSS

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -657,11 +657,11 @@ CONF_Bool(use_hdfs_pread, "true");
 // default: true
 CONF_Bool(rewrite_partial_segment, "true");
 
-// Properties to access aws s3.
-CONF_String(aws_access_key_id, "");
-CONF_String(aws_secret_access_key, "");
-CONF_String(aws_s3_endpoint, "");
-CONF_Int64(aws_s3_max_connection, "102400");
+// Properties to access object storage
+CONF_String(object_storage_access_key_id, "");
+CONF_String(object_storage_secret_access_key, "");
+CONF_String(object_storage_endpoint, "");
+CONF_Int64(object_storage_max_connection, "102400");
 
 CONF_Bool(enable_orc_late_materialization, "true");
 

--- a/be/src/env/env_s3.cpp
+++ b/be/src/env/env_s3.cpp
@@ -78,11 +78,13 @@ StatusOr<std::unique_ptr<RandomAccessFile>> EnvS3::new_random_access_file(const 
     Aws::Client::ClientConfiguration config;
     config.scheme = Aws::Http::Scheme::HTTP;
     if (is_oss_path(namenode.c_str())) {
-        CHECK(!config::object_storage_access_key_id.empty()) << "Configuration object_storage_access_key_id is missing for OSS.";
-        CHECK(!config::object_storage_secret_access_key.empty()) << "Configuration object_storage_secret_access_key is missing for OSS.";
+        CHECK(!config::object_storage_access_key_id.empty())
+                << "Configuration object_storage_access_key_id is missing for OSS.";
+        CHECK(!config::object_storage_secret_access_key.empty())
+                << "Configuration object_storage_secret_access_key is missing for OSS.";
         CHECK(!config::object_storage_endpoint.empty()) << "Configuration object_storage_endpoint is missing for OSS.";
         config.endpointOverride = get_endpoint_from_oss_bucket(config::object_storage_endpoint, &bucket);
-    } else if (!config::object_storage_endpoint.empty()){
+    } else if (!config::object_storage_endpoint.empty()) {
         config.endpointOverride = config::object_storage_endpoint;
     }
     config.maxConnections = config::object_storage_max_connection;

--- a/be/src/env/env_s3.cpp
+++ b/be/src/env/env_s3.cpp
@@ -78,11 +78,12 @@ StatusOr<std::unique_ptr<RandomAccessFile>> EnvS3::new_random_access_file(const 
     Aws::Client::ClientConfiguration config;
     config.scheme = Aws::Http::Scheme::HTTP;
     if (is_oss_path(namenode.c_str())) {
-        CHECK(!config::object_storage_access_key_id.empty())
-                << "Configuration object_storage_access_key_id is missing for OSS.";
-        CHECK(!config::object_storage_secret_access_key.empty())
-                << "Configuration object_storage_secret_access_key is missing for OSS.";
-        CHECK(!config::object_storage_endpoint.empty()) << "Configuration object_storage_endpoint is missing for OSS.";
+        if (config::object_storage_access_key_id.empty() ||
+            config::object_storage_secret_access_key.empty() ||
+            config::object_storage_endpoint.empty()) {
+            return Status::RuntimeError("Configuration object_storage_access_key_id, "
+                    "object_storage_secret_access_key and object_storage_endpoint is required for OSS.");
+        }
         config.endpointOverride = get_endpoint_from_oss_bucket(config::object_storage_endpoint, &bucket);
     } else if (!config::object_storage_endpoint.empty()) {
         config.endpointOverride = config::object_storage_endpoint;

--- a/be/src/env/env_s3.cpp
+++ b/be/src/env/env_s3.cpp
@@ -78,11 +78,11 @@ StatusOr<std::unique_ptr<RandomAccessFile>> EnvS3::new_random_access_file(const 
     Aws::Client::ClientConfiguration config;
     config.scheme = Aws::Http::Scheme::HTTP;
     if (is_oss_path(namenode.c_str())) {
-        if (config::object_storage_access_key_id.empty() ||
-            config::object_storage_secret_access_key.empty() ||
+        if (config::object_storage_access_key_id.empty() || config::object_storage_secret_access_key.empty() ||
             config::object_storage_endpoint.empty()) {
-            return Status::RuntimeError("Configuration object_storage_access_key_id, "
-                    "object_storage_secret_access_key and object_storage_endpoint is required for OSS.");
+            return Status::RuntimeError(
+                    "Configuration object_storage_access_key_id, object_storage_secret_access_key "
+                    "and object_storage_endpoint is required for OSS.");
         }
         config.endpointOverride = get_endpoint_from_oss_bucket(config::object_storage_endpoint, &bucket);
     } else if (!config::object_storage_endpoint.empty()) {

--- a/be/src/object_store/s3_object_store.cpp
+++ b/be/src/object_store/s3_object_store.cpp
@@ -35,17 +35,11 @@ static inline Aws::String to_aws_string(const std::string& s) {
 S3ObjectStore::S3ObjectStore(const Aws::Client::ClientConfiguration& config) : _config(config) {}
 
 Status S3ObjectStore::init(bool use_transfer_manager) {
-    const char* env_access_key_id = getenv("AWS_ACCESS_KEY_ID");
-    const char* env_secret_access_key = getenv("AWS_SECRET_ACCESS_KEY");
-    const string be_conf_access_key_id = config::object_storage_access_key_id;
-    const string be_conf_secret_access_key = config::object_storage_secret_access_key;
-    if (!be_conf_access_key_id.empty() && !be_conf_secret_access_key.empty()) {
+    const string access_key_id = config::object_storage_access_key_id;
+    const string secret_access_key = config::object_storage_secret_access_key;
+    if (!access_key_id.empty() && !secret_access_key.empty()) {
         std::shared_ptr<Aws::Auth::AWSCredentialsProvider> credentials =
-                std::make_shared<Aws::Auth::SimpleAWSCredentialsProvider>(be_conf_access_key_id, be_conf_secret_access_key);
-        _client = std::make_shared<Aws::S3::S3Client>(credentials, _config);
-    } else if (strlen(env_access_key_id) > 0 && strlen(env_secret_access_key) > 0) {
-        std::shared_ptr<Aws::Auth::AWSCredentialsProvider> credentials =
-                std::make_shared<Aws::Auth::SimpleAWSCredentialsProvider>(env_secret_access_key, env_secret_access_key);
+                std::make_shared<Aws::Auth::SimpleAWSCredentialsProvider>(access_key_id, secret_access_key);
         _client = std::make_shared<Aws::S3::S3Client>(credentials, _config);
     } else {
         // if not cred provided, we can use default cred in aws profile.

--- a/be/src/object_store/s3_object_store.cpp
+++ b/be/src/object_store/s3_object_store.cpp
@@ -34,11 +34,18 @@ static inline Aws::String to_aws_string(const std::string& s) {
 
 S3ObjectStore::S3ObjectStore(const Aws::Client::ClientConfiguration& config) : _config(config) {}
 
-Status S3ObjectStore::init(const S3Credential* cred, bool use_transfer_manager) {
-    if (cred != nullptr) {
+Status S3ObjectStore::init(bool use_transfer_manager) {
+    const char* env_access_key_id = getenv("AWS_ACCESS_KEY_ID");
+    const char* env_secret_access_key = getenv("AWS_SECRET_ACCESS_KEY");
+    const string be_conf_access_key_id = config::object_storage_access_key_id;
+    const string be_conf_secret_access_key = config::object_storage_secret_access_key;
+    if (!be_conf_access_key_id.empty() && !be_conf_secret_access_key.empty()) {
         std::shared_ptr<Aws::Auth::AWSCredentialsProvider> credentials =
-                std::make_shared<Aws::Auth::SimpleAWSCredentialsProvider>(cred->access_key_id.c_str(),
-                                                                          cred->secret_access_key.c_str());
+                std::make_shared<Aws::Auth::SimpleAWSCredentialsProvider>(be_conf_access_key_id, be_conf_secret_access_key);
+        _client = std::make_shared<Aws::S3::S3Client>(credentials, _config);
+    } else if (strlen(env_access_key_id) > 0 && strlen(env_secret_access_key) > 0) {
+        std::shared_ptr<Aws::Auth::AWSCredentialsProvider> credentials =
+                std::make_shared<Aws::Auth::SimpleAWSCredentialsProvider>(env_secret_access_key, env_secret_access_key);
         _client = std::make_shared<Aws::S3::S3Client>(credentials, _config);
     } else {
         // if not cred provided, we can use default cred in aws profile.

--- a/be/src/object_store/s3_object_store.h
+++ b/be/src/object_store/s3_object_store.h
@@ -23,7 +23,7 @@ class S3ObjectStore final : public ObjectStore {
 public:
     S3ObjectStore(const Aws::Client::ClientConfiguration& config);
     ~S3ObjectStore() = default;
-    Status init(const S3Credential* cred = nullptr, bool use_transfer_manager = false);
+    Status init(bool use_transfer_manager = false);
 
     Status create_bucket(const std::string& bucket) override;
 

--- a/be/src/runtime/hdfs/hdfs_fs_cache.cpp
+++ b/be/src/runtime/hdfs/hdfs_fs_cache.cpp
@@ -3,13 +3,8 @@
 #include "runtime/hdfs/hdfs_fs_cache.h"
 
 #include <memory>
-#include <utility>
 
-#include "common/config.h"
 #include "gutil/strings/substitute.h"
-#ifdef STARROCKS_WITH_AWS
-#include "object_store/s3_object_store.h"
-#endif
 #include "util/hdfs_util.h"
 
 namespace starrocks {
@@ -26,25 +21,6 @@ static Status create_hdfs_fs_handle(const std::string& namenode, HdfsFsHandle* h
                                                              namenode, get_hdfs_err_msg()));
         }
 
-    } else if (is_s3a_path(nn) || is_oss_path(nn)) {
-#ifdef STARROCKS_WITH_AWS
-        handle->type = HdfsFsHandle::Type::S3;
-        Aws::Client::ClientConfiguration config;
-        config.scheme = Aws::Http::Scheme::HTTP;
-        if (!config::aws_s3_endpoint.empty()) {
-            config.endpointOverride = config::aws_s3_endpoint;
-        }
-        config.maxConnections = config::aws_s3_max_connection;
-
-        S3Credential cred;
-        cred.access_key_id = config::aws_access_key_id;
-        cred.secret_access_key = config::aws_secret_access_key;
-        auto store = std::make_unique<S3ObjectStore>(config);
-        RETURN_IF_ERROR(store->init(&cred, false));
-        handle->object_store = store.release();
-#else
-        return Status::NotSupported("Does not support S3");
-#endif
     } else {
         return Status::InternalError(strings::Substitute("failed to make client, namenode=$0", namenode));
     }

--- a/be/src/util/hdfs_util.cpp
+++ b/be/src/util/hdfs_util.cpp
@@ -64,6 +64,18 @@ std::string get_bucket_from_namenode(const std::string& namenode) {
     return namenode.substr(n, n2 - n);
 }
 
+std::string get_endpoint_from_oss_bucket(const std::string& default_bucket, std::string* bucket) {
+    auto endpoint_start_index = bucket->find('.');
+    if (endpoint_start_index == std::string::npos) {
+        return default_bucket;
+    }
+    endpoint_start_index = endpoint_start_index + 1;
+    auto endpoint_end_index = bucket->size();
+    std::string endpoint = bucket->substr(endpoint_start_index, endpoint_end_index - endpoint_start_index + 1);
+    *bucket = bucket->substr(0, endpoint_start_index - 1);
+    return endpoint;
+}
+
 static bool is_specific_path(const char* path, const char* specific_prefix) {
     size_t prefix_len = strlen(specific_prefix);
     return strncmp(path, specific_prefix, prefix_len) == 0;

--- a/be/src/util/hdfs_util.h
+++ b/be/src/util/hdfs_util.h
@@ -12,6 +12,7 @@ std::string get_hdfs_err_msg();
 
 Status get_namenode_from_path(const std::string& path, std::string* namenode);
 std::string get_bucket_from_namenode(const std::string& namenode);
+std::string get_endpoint_from_oss_bucket(const std::string& default_bucket, std::string* bucket);
 
 // Returns true if the path refers to a location on an HDFS filesystem.
 bool is_hdfs_path(const char* path);

--- a/fe/fe-core/src/main/java/com/starrocks/external/ObjectStorageUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/ObjectStorageUtils.java
@@ -6,7 +6,6 @@ public class ObjectStorageUtils {
     private static final String SCHEME_S3A = "s3a://";
     private static final String SCHEME_S3 = "s3://";
     private static final String SCHEME_S3N = "s3n://";
-    private static final String SCHEME_OSS = "oss://";
     private static final String SCHEME_S3_PREFIX = "s3";
     private static final String SCHEME_OSS_PREFIX = "oss";
 
@@ -20,10 +19,6 @@ public class ObjectStorageUtils {
         }
         if (path.startsWith(SCHEME_S3N)) {
             return SCHEME_S3A + path.substring(SCHEME_S3N.length());
-        }
-        // use s3a to access oss.
-        if (path.startsWith(SCHEME_OSS)) {
-            return SCHEME_S3A + path.substring(SCHEME_OSS.length());
         }
         return path;
     }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [x] feature
- [ ] enhancement
- [ ] others

## Problem Summary(Required) ：
1. fix long time block of FE while parsing oss path with bucket level endpoint.
2. support bucket-level endpoint specification for BE
3. refactor credentials initailization and remove unused codes

support bucket-level endpoint specification like `oss://<bucket>.<endpoint>/<object>` 

closes #1987 
