### PR TITLE
Fix wrong default delimiter for textfile (#3640)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaClient.java
@@ -461,7 +461,7 @@ public class HiveMetaClient {
         List<HdfsFileDesc> fileDescs = Lists.newArrayList();
         // get properties like 'field.delim' and 'line.delim' from StorageDescriptor
         TextFileFormatDesc textFileFormatDesc = new TextFileFormatDesc(
-                sd.getSerdeInfo().getParameters().getOrDefault("field.delim", ","),
+                sd.getSerdeInfo().getParameters().getOrDefault("field.delim", "\001"),
                 sd.getSerdeInfo().getParameters().getOrDefault("line.delim", "\n"));
 
         // fileSystem.listLocatedStatus is an api to list all statuses and


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
default delimiter for text file is '\000' instead of ','
refer to: https://stackoverflow.com/questions/48616464/what-is-the-default-delimiter-for-hive-tables/48616635