### PR TITLE
use batch call to optimize UDF

### DIFF
--- a/be/src/exprs/agg/java_window_function.cpp
+++ b/be/src/exprs/agg/java_window_function.cpp
@@ -4,9 +4,6 @@
 
 #include <vector>
 
-#include "column/binary_column.h"
-#include "column/fixed_length_column.h"
-#include "column/nullable_column.h"
 #include "runtime/user_function_cache.h"
 
 namespace starrocks::vectorized {
@@ -24,7 +21,6 @@ Status window_init_jvm_context(int fid, const std::string& url, const std::strin
     auto* udaf_ctx = context->impl()->udaf_ctxs();
     udaf_ctx->udf_classloader = std::make_unique<ClassLoader>(std::move(libpath));
     RETURN_IF_ERROR(udaf_ctx->udf_classloader->init());
-    udaf_ctx->udf_helper = std::make_unique<UDFHelper>();
     udaf_ctx->analyzer = std::make_unique<ClassAnalyzer>();
 
     udaf_ctx->udaf_class = udaf_ctx->udf_classloader->getClass(symbol);
@@ -51,6 +47,7 @@ Status window_init_jvm_context(int fid, const std::string& url, const std::strin
         (*res)->name = std::move(method_name);
         (*res)->signature = std::move(signature);
         (*res)->method_desc = std::move(mtdesc);
+        ASSIGN_OR_RETURN((*res)->method, analyzer->get_method_object(clazz, name));
         return Status::OK();
     };
 
@@ -60,24 +57,8 @@ Status window_init_jvm_context(int fid, const std::string& url, const std::strin
     RETURN_IF_ERROR(add_method("getValues", udaf_ctx->udaf_class.clazz(), &udaf_ctx->get_values));
     RETURN_IF_ERROR(add_method("batchUpdate", udaf_ctx->udaf_class.clazz(), &udaf_ctx->window_update));
 
-    udaf_ctx->_func = std::make_unique<UDAFFunction>(udaf_ctx->udaf_state_class.clazz(), udaf_ctx->udaf_class.clazz(),
-                                                     udaf_ctx->handle, udaf_ctx);
+    udaf_ctx->_func = std::make_unique<UDAFFunction>(udaf_ctx->handle, udaf_ctx);
 
     return Status::OK();
 }
-
-Status ConvertDirectBufferVistor::do_visit(const NullableColumn& column) {
-    const auto& null_data = column.immutable_null_column_data();
-    _buffers.emplace_back((void*)null_data.data(), null_data.size());
-    return column.data_column()->accept(this);
-}
-
-Status ConvertDirectBufferVistor::do_visit(const BinaryColumn& column) {
-    const auto& offsets = column.get_offset();
-    _buffers.emplace_back((void*)offsets.data(), offsets.size() * 4);
-    const auto& bytes = column.get_bytes();
-    _buffers.emplace_back((void*)bytes.data(), bytes.size());
-    return Status::OK();
-}
-
 } // namespace starrocks::vectorized

--- a/be/src/exprs/vectorized/java_function_call_expr.cpp
+++ b/be/src/exprs/vectorized/java_function_call_expr.cpp
@@ -18,6 +18,7 @@
 #include "column/type_traits.h"
 #include "column/vectorized_fwd.h"
 #include "common/status.h"
+#include "common/statusor.h"
 #include "exprs/anyval_util.h"
 #include "exprs/vectorized/java_function_call_expr.h"
 #include "fmt/compile.h"
@@ -29,6 +30,7 @@
 #include "runtime/primitive_type.h"
 #include "runtime/types.h"
 #include "runtime/user_function_cache.h"
+#include "udf/java/java_data_converter.h"
 #include "udf/java/java_udf.h"
 #include "udf/udf.h"
 #include "util/slice.h"
@@ -46,353 +48,99 @@
 namespace starrocks::vectorized {
 
 struct UDFFunctionCallHelper {
-    FunctionContext* fn_ctx;
     JavaUDFContext* fn_desc;
     JavaMethodDescriptor* call_desc;
     std::vector<std::string> _data_buffer;
 
-    using VariantContainer = std::variant<
-#define M(NAME) RunTimeColumnType<NAME>::Container,
-            APPLY_FOR_NUMBERIC_TYPE(M)
-#undef M
-                    std::vector<jobject>>;
-
-    // Now we only support String/int
-    ColumnPtr call(FunctionContext* ctxs, Columns& columns, size_t size) {
+    // Now we don't support primitive type function
+    ColumnPtr call(FunctionContext* ctx, Columns& columns, size_t size) {
         auto& helper = JVMFunctionHelper::getInstance();
-
-        size_t num_cols = columns.size();
-
-        std::vector<VariantContainer> casts_values;
-
-        do_resize(&casts_values, size);
-
-        // step 1
-        // cast column to jvalue vector
-        for (int i = 0; i < num_cols; ++i) {
-            cast_type_to_jvalue(&casts_values[i], columns[i].get(), i, size);
+        JNIEnv* env = helper.getEnv();
+        std::vector<DirectByteBuffer> buffers;
+        std::vector<jobject> args;
+        int num_cols = ctx->get_num_args();
+        std::vector<const Column*> input_cols;
+        for (auto col : columns) {
+            input_cols.emplace_back(col.get());
         }
+        // convert input columns to object columns
+        std::vector<jobject> input_col_objs;
+        JavaDataTypeConverter::convert_to_boxed_array(ctx, &buffers, input_cols.data(), num_cols, size,
+                                                      &input_col_objs);
+        // call UDF method
+        jobject res = helper.batch_call(ctx, fn_desc->udf_handle, fn_desc->evaluate->method, input_col_objs.data(),
+                                        input_col_objs.size(), size);
 
-        // step 2
-        // combine input jvalue to jvalue array
-        std::vector<jvalue> params(num_cols * size);
-        for (int i = 0; i < num_cols; ++i) {
-            combine_inputs(&params, casts_values[i], columns[i].get(), i, num_cols, size);
-        }
-        // step 3
-        // call evalute
-        VariantContainer results;
-        call_evaluate(&results, params, num_cols, size);
-
-        // step 4
+        env->PushLocalFrame(size * (num_cols + 1));
         // get result
-        auto res = get_result(results);
-
-        // TODO: add error message to Context
-        if (auto jthr = helper.getEnv()->ExceptionOccurred(); jthr != nullptr) {
-            std::string err = fmt::format("execute UDF Function meet Exception:{}", helper.dumpExceptionString(jthr));
-            LOG(WARNING) << err;
-            ctxs->set_error(err.c_str());
-            helper.getEnv()->ExceptionClear();
+        auto result_cols = get_boxed_result(res, size);
+        // call clear
+        env->PopLocalFrame(nullptr);
+        for (auto ref : args) {
+            env->DeleteLocalRef(ref);
         }
+        env->DeleteLocalRef(res);
 
-        // step 5
-        // do clear
-        for (int i = 0; i < num_cols; ++i) {
-            do_clear(&casts_values[i]);
-        }
-        do_clear(&results);
-
-        return res;
+        return result_cols;
     }
 
-    void do_resize(std::vector<VariantContainer>* container, int num_rows) {
-        int num_cols = call_desc->method_desc.size();
-        container->reserve(num_cols);
-        for (int i = 0; i < num_cols; ++i) {
-            if (call_desc->method_desc[i + 1].is_box) {
-                container->emplace_back(std::vector<jobject>());
-            } else {
-                switch (call_desc->method_desc[i + 1].type) {
-#define M(NAME)                                                        \
-    case NAME: {                                                       \
-        container->emplace_back(RunTimeColumnType<NAME>::Container()); \
-        break;                                                         \
-    }
-                    APPLY_FOR_NUMBERIC_TYPE(M)
-#undef M
-                default:
-                    break;
-                }
-            }
-        }
-
-        for (int i = 0; i < num_cols; ++i) {
-            std::visit([=](auto& container) { container.resize(num_rows); }, (*container)[i]);
-        }
-    }
-
-    void do_clear(VariantContainer* values) {
-        std::visit(
-                [](auto&& container) {
-                    using ContainerType = decay_t<decltype(container)>;
-                    if constexpr (std::is_same_v<std::vector<jobject>, ContainerType>) {
-                        auto& helper = JVMFunctionHelper::getInstance();
-                        JNIEnv* env = helper.getEnv();
-                        for (int i = 0; i < container.size(); ++i) {
-                            env->DeleteLocalRef(container[i]);
-                        }
-                    }
-                },
-                *values);
-    }
-
-    template <PrimitiveType TYPE>
-    ColumnPtr get_primtive_result(const VariantContainer& result, int num_rows) {
-        auto res = RunTimeColumnType<TYPE>::create(num_rows);
-        auto& res_data = res->get_data();
-        std::visit(
-                [&](auto&& container) {
-                    memcpy(res_data.data(), container.data(), sizeof(RunTimeCppType<TYPE>) * num_rows);
-                },
-                result);
-        return res;
-    }
-
-    ColumnPtr get_result(const VariantContainer& result) {
-        int num_rows = std::visit([](auto&& container) { return container.size(); }, result);
-        auto& helper = JVMFunctionHelper::getInstance();
-        if (!call_desc->method_desc[0].is_box) {
-            switch (call_desc->method_desc[0].type) {
-#define M(NAME)                                             \
-    case NAME: {                                            \
-        return get_primtive_result<NAME>(result, num_rows); \
-    }
-                APPLY_FOR_NUMBERIC_TYPE(M)
-#undef M
-            default:
-                DCHECK(false) << "Not support type";
-                break;
-            }
-        } else {
 #define GET_BOX_RESULT(NAME, cxx_type)                                           \
     case NAME: {                                                                 \
         auto null_col = NullColumn::create(num_rows);                            \
         auto data_col = RunTimeColumnType<NAME>::create(num_rows);               \
         auto& null_data = null_col->get_data();                                  \
         auto& container = data_col->get_data();                                  \
-        const auto& result_data = std::get<std::vector<jobject>>(result);        \
         for (int i = 0; i < num_rows; ++i) {                                     \
-            if (result_data[i] != nullptr) {                                     \
-                container[i] = helper.val##cxx_type(result_data[i]);             \
+            auto data = env->GetObjectArrayElement((jobjectArray)result, i);     \
+            if (data != nullptr) {                                               \
+                container[i] = helper.val##cxx_type(data);                       \
             } else {                                                             \
                 null_data[i] = true;                                             \
             }                                                                    \
         }                                                                        \
         return NullableColumn::create(std::move(data_col), std::move(null_col)); \
     }
-            // Now result was always nullable
-            switch (call_desc->method_desc[0].type) {
-                GET_BOX_RESULT(TYPE_BOOLEAN, uint8_t)
-                GET_BOX_RESULT(TYPE_TINYINT, int8_t)
-                GET_BOX_RESULT(TYPE_SMALLINT, int16_t)
-                GET_BOX_RESULT(TYPE_INT, int32_t)
-                GET_BOX_RESULT(TYPE_BIGINT, int64_t)
-                GET_BOX_RESULT(TYPE_FLOAT, float)
-                GET_BOX_RESULT(TYPE_DOUBLE, double)
-            case TYPE_VARCHAR: {
-                _data_buffer.resize(num_rows);
-                auto null_col = NullColumn::create(num_rows);
-                auto& null_data = null_col->get_data();
-                std::vector<Slice> slices;
-                slices.resize(num_rows);
-                const auto& result_data = std::get<std::vector<jobject>>(result);
-                for (int i = 0; i < num_rows; ++i) {
-                    if (result_data[i] != nullptr) {
-                        slices[i] = helper.sliceVal((jstring)result_data[i], &_data_buffer[i]);
-                    } else {
-                        null_data[i] = true;
-                    }
-                }
-                auto data_col = BinaryColumn::create();
-                data_col->append_strings(slices);
-                return NullableColumn::create(std::move(data_col), std::move(null_col));
-            }
-            default:
-                DCHECK(false) << "Not support type";
-                break;
-            }
+
+    ColumnPtr get_boxed_result(jobject result, size_t num_rows) {
+        if (result == nullptr) {
+            return ColumnHelper::create_const_null_column(num_rows);
         }
-        return nullptr;
-    }
-
-#define CALL_PRIMITIVE_METHOD(TYPE, RES, RES_TYPE)                                                 \
-    case TYPE: {                                                                                   \
-        *result = RunTimeColumnType<TYPE>::Container(num_rows);                                    \
-        auto& res_data = std::get<RunTimeColumnType<TYPE>::Container>(*result);                    \
-        for (int i = 0, j = 0; i < num_rows; ++i, j += num_cols) {                                 \
-            res_data[i] = env->Call##RES_TYPE##MethodA(fn_desc->udf_handle, methodID, &params[j]); \
-        }                                                                                          \
-        break;                                                                                     \
-    }
-
-    void call_evaluate(VariantContainer* result, const std::vector<jvalue>& params, int num_cols, int num_rows) {
         auto& helper = JVMFunctionHelper::getInstance();
         JNIEnv* env = helper.getEnv();
-        jmethodID methodID = env->GetMethodID(fn_desc->udf_class.clazz(), fn_desc->evaluate->name.c_str(),
-                                              fn_desc->evaluate->signature.c_str());
-        DCHECK(methodID != nullptr);
-        if (!call_desc->method_desc[0].is_box) {
-            switch (call_desc->method_desc[0].type) {
-                CALL_PRIMITIVE_METHOD(TYPE_BOOLEAN, z, Boolean)
-                CALL_PRIMITIVE_METHOD(TYPE_TINYINT, b, Byte)
-                CALL_PRIMITIVE_METHOD(TYPE_SMALLINT, s, Short)
-                CALL_PRIMITIVE_METHOD(TYPE_INT, i, Int)
-                CALL_PRIMITIVE_METHOD(TYPE_BIGINT, j, Long)
-                CALL_PRIMITIVE_METHOD(TYPE_FLOAT, f, Float)
-                CALL_PRIMITIVE_METHOD(TYPE_DOUBLE, d, Double)
-            default:
-                DCHECK(false) << "Java UDF Not Support Type" << call_desc->method_desc[0].type;
-                break;
+        DCHECK(call_desc->method_desc[0].is_box);
+        switch (call_desc->method_desc[0].type) {
+            GET_BOX_RESULT(TYPE_BOOLEAN, uint8_t)
+            GET_BOX_RESULT(TYPE_TINYINT, int8_t)
+            GET_BOX_RESULT(TYPE_SMALLINT, int16_t)
+            GET_BOX_RESULT(TYPE_INT, int32_t)
+            GET_BOX_RESULT(TYPE_BIGINT, int64_t)
+            GET_BOX_RESULT(TYPE_FLOAT, float)
+            GET_BOX_RESULT(TYPE_DOUBLE, double)
+        case TYPE_VARCHAR: {
+            _data_buffer.resize(num_rows);
+            auto null_col = NullColumn::create(num_rows);
+            auto& null_data = null_col->get_data();
+            std::vector<Slice> slices;
+            slices.resize(num_rows);
+            for (int i = 0; i < num_rows; ++i) {
+                auto data = env->GetObjectArrayElement((jobjectArray)result, i);
+                if (data != nullptr) {
+                    LOG(WARNING) << "result:" << helper.to_string(data);
+                    slices[i] = helper.sliceVal((jstring)data, &_data_buffer[i]);
+                } else {
+                    null_data[i] = true;
+                }
             }
-
-        } else {
-            *result = std::vector<jobject>(num_rows);
-            auto& res_data = std::get<std::vector<jobject>>(*result);
-            for (int i = 0, j = 0; i < num_rows; ++i, j += num_cols) {
-                res_data[i] = env->CallObjectMethodA(fn_desc->udf_handle, methodID, &params[j]);
-            }
+            auto data_col = BinaryColumn::create();
+            data_col->append_strings(slices);
+            return NullableColumn::create(std::move(data_col), std::move(null_col));
         }
-    }
-
-    void combine_inputs(std::vector<jvalue>* res, VariantContainer& data, Column* col, int col_idx, int num_cols,
-                        int num_rows) {
-        if (col->only_null()) {
-            return;
-        }
-        if (col->is_nullable()) {
-            std::visit(
-                    [&](auto&& container) {
-                        using Container = std::decay_t<decltype(container)>;
-                        using ValueType = typename Container::value_type;
-                        auto* null_col = down_cast<NullableColumn*>(col);
-
-                        const NullData& null_data = null_col->immutable_null_column_data();
-                        for (int i = 0, j = col_idx; i < num_rows; ++i, j += num_cols) {
-                            if (null_data[i]) {
-                                (*res)[j].l = nullptr;
-                            } else {
-                                memcpy(&(*res)[j], &container[i], sizeof(ValueType));
-                            }
-                        }
-                    },
-                    data);
-        } else {
-            std::visit(
-                    [&](auto&& container) {
-                        using Container = std::decay_t<decltype(container)>;
-                        using ValueType = typename Container::value_type;
-                        for (int i = 0, j = col_idx; i < num_rows; ++i, j += num_cols) {
-                            memcpy(&(*res)[j], &container[i], sizeof(ValueType));
-                        }
-                    },
-                    data);
-        }
-    }
-
-    // cast type to jvalue
-    void cast_type_to_jvalue(VariantContainer* res, Column* column, int col_idx, size_t num_rows) {
-        // handle nullable func
-        switch (call_desc->method_desc[col_idx + 1].type) {
-#define M(NAME)                                                                                   \
-    case NAME: {                                                                                  \
-        do_cast_type_to_jvalue<NAME>(res, call_desc->method_desc[col_idx + 1], column, num_rows); \
-        break;                                                                                    \
-    }
-            APPLY_FOR_NUMBERIC_TYPE(M)
-#undef M
-        case TYPE_VARCHAR:
-            do_cast_type_to_jvalue<TYPE_VARCHAR>(res, call_desc->method_desc[col_idx + 1], column, num_rows);
-            break;
         default:
-            break;
+            DCHECK(false) << "unsupport type:" << call_desc->method_desc[0].type;
         }
-    }
-
-    // cast data type to boxed type
-    template <PrimitiveType TYPE>
-    jobject transfer(RunTimeCppType<TYPE> data_value, JVMFunctionHelper& helper);
-
-    template <PrimitiveType TYPE>
-    void do_cast_type_to_jvalue(VariantContainer* res, const MethodTypeDescriptor& desc, Column* column, int size) {
-        auto& helper = JVMFunctionHelper::getInstance();
-
-        auto do_cast = [&](const RunTimeColumnType<TYPE>* spec_col, int size) {
-            const auto& container = spec_col->get_data();
-            if (desc.is_box) {
-                // has null
-                // not has null
-                auto& res_data = std::get<std::vector<jobject>>(*res);
-                for (int i = 0; i < size; i++) {
-                    res_data[i] = transfer<TYPE>(container[i], helper);
-                }
-            } else {
-                if constexpr (isArithmeticPT<TYPE>) {
-                    auto& res_data = std::get<typename RunTimeColumnType<TYPE>::Container>(*res);
-                    for (int i = 0; i < size; i++) {
-                        res_data[i] = container[i];
-                    }
-                }
-            }
-        };
-
-        if (column->only_null()) {
-            // use default value, nothing to do
-            return;
-        }
-
-        ColumnPtr guard;
-        if (column->is_constant()) {
-            auto data_col = ColumnHelper::get_data_column(column);
-            const auto* spec_col = down_cast<RunTimeColumnType<TYPE>*>(data_col);
-            do_cast(spec_col, 1);
-
-            std::visit(
-                    [&](auto&& res_data) {
-                        for (int i = 0; i < size; ++i) {
-                            res_data[i] = res_data[0];
-                        }
-                    },
-                    *res);
-            return;
-        }
-
-        if (column->is_nullable()) {
-            NullableColumn* nullable_col = down_cast<NullableColumn*>(column);
-            const auto& spec_col = down_cast<RunTimeColumnType<TYPE>*>(nullable_col->data_column().get());
-            // TODO:
-            do_cast(spec_col, size);
-        } else {
-            const auto* spec_col = down_cast<RunTimeColumnType<TYPE>*>(column);
-            do_cast(spec_col, size);
-        }
+        return ColumnHelper::create_const_null_column(num_rows);
     }
 };
-
-#define DEFINE_TRANSTER(TYPE, APPLY_FUNC)                                                                        \
-    template <>                                                                                                  \
-    jobject UDFFunctionCallHelper::transfer<TYPE>(RunTimeCppType<TYPE> data_value, JVMFunctionHelper & helper) { \
-        return APPLY_FUNC;                                                                                       \
-    }
-
-DEFINE_TRANSTER(TYPE_BOOLEAN, helper.newBoolean(data_value));
-DEFINE_TRANSTER(TYPE_TINYINT, helper.newByte(data_value));
-DEFINE_TRANSTER(TYPE_SMALLINT, helper.newShort(data_value));
-DEFINE_TRANSTER(TYPE_INT, helper.newInteger(data_value));
-DEFINE_TRANSTER(TYPE_FLOAT, helper.newFloat(data_value));
-DEFINE_TRANSTER(TYPE_BIGINT, helper.newLong(data_value));
-DEFINE_TRANSTER(TYPE_DOUBLE, helper.newDouble(data_value));
-DEFINE_TRANSTER(TYPE_VARCHAR, helper.newString(data_value.get_data(), data_value.get_size()));
 
 JavaFunctionCallExpr::JavaFunctionCallExpr(const TExprNode& node) : Expr(node) {}
 
@@ -481,6 +229,8 @@ Status JavaFunctionCallExpr::open(RuntimeState* state, ExprContext* context,
             (*res)->name = std::move(method_name);
             (*res)->signature = std::move(signature);
             (*res)->method_desc = std::move(mtdesc);
+            ASSIGN_OR_RETURN((*res)->method,
+                             _func_desc->analyzer->get_method_object(_func_desc->udf_class.clazz(), name));
         }
         return Status::OK();
     };
@@ -494,7 +244,6 @@ Status JavaFunctionCallExpr::open(RuntimeState* state, ExprContext* context,
     RETURN_IF_ERROR(_func_desc->udf_class.newInstance(&_func_desc->udf_handle));
 
     _call_helper = std::make_shared<UDFFunctionCallHelper>();
-    _call_helper->fn_ctx = context->fn_context(_fn_context_index);
     _call_helper->fn_desc = _func_desc.get();
     _call_helper->call_desc = _func_desc->evaluate.get();
 

--- a/be/src/udf/CMakeLists.txt
+++ b/be/src/udf/CMakeLists.txt
@@ -33,6 +33,7 @@ set(EXECUTABLE_OUTPUT_PATH "${BUILD_DIR}/src/udf")
 IF (WITH_HDFS)
     set(UDF_FILES
       java/java_udf.cpp
+      java/java_data_converter.cpp
     )
 endif()
 

--- a/be/src/udf/java/java_data_converter.cpp
+++ b/be/src/udf/java/java_data_converter.cpp
@@ -1,3 +1,5 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
 #include "udf/java/java_data_converter.h"
 
 #include "column/binary_column.h"

--- a/be/src/udf/java/java_data_converter.cpp
+++ b/be/src/udf/java/java_data_converter.cpp
@@ -1,0 +1,49 @@
+#include "udf/java/java_data_converter.h"
+
+#include "column/binary_column.h"
+#include "column/fixed_length_column.h"
+#include "column/nullable_column.h"
+
+namespace starrocks::vectorized {
+
+Status ConvertDirectBufferVistor::do_visit(const NullableColumn& column) {
+    const auto& null_data = column.immutable_null_column_data();
+    _buffers.emplace_back((void*)null_data.data(), null_data.size());
+    return column.data_column()->accept(this);
+}
+
+Status ConvertDirectBufferVistor::do_visit(const BinaryColumn& column) {
+    const auto& offsets = column.get_offset();
+    _buffers.emplace_back((void*)offsets.data(), offsets.size() * 4);
+    const auto& bytes = column.get_bytes();
+    _buffers.emplace_back((void*)bytes.data(), bytes.size());
+    return Status::OK();
+}
+
+jobject JavaDataTypeConverter::convert_to_object_array(uint8_t** data, size_t offset, int num_rows) {
+    auto& helper = JVMFunctionHelper::getInstance();
+    auto* env = helper.getEnv();
+    jobjectArray arr = env->NewObjectArray(num_rows, helper.object_class(), nullptr);
+    for (int i = 0; i < num_rows; ++i) {
+        env->SetObjectArrayElement(arr, i, reinterpret_cast<JavaUDAFState*>(data[i] + offset)->handle);
+    }
+    return arr;
+}
+
+void JavaDataTypeConverter::convert_to_boxed_array(FunctionContext* ctx, std::vector<DirectByteBuffer>* buffers,
+                                                   const Column** columns, int num_cols, int num_rows,
+                                                   std::vector<jobject>* res) {
+    auto& helper = JVMFunctionHelper::getInstance();
+    ConvertDirectBufferVistor vistor(*buffers);
+    PrimitiveType types[num_cols];
+    for (int i = 0; i < num_cols; ++i) {
+        types[i] = ctx->get_arg_type(i)->type;
+        int buffers_offset = buffers->size();
+        columns[i]->accept(&vistor);
+        int buffers_sz = buffers->size() - buffers_offset;
+        auto arg = helper.create_boxed_array(types[i], num_rows, columns[i]->is_nullable(), &(*buffers)[buffers_offset],
+                                             buffers_sz);
+        res->emplace_back(arg);
+    }
+}
+} // namespace starrocks::vectorized

--- a/be/src/udf/java/java_data_converter.h
+++ b/be/src/udf/java/java_data_converter.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "column/binary_column.h"
+#include "column/column_visitor.h"
+#include "column/column_visitor_adapter.h"
+#include "column/fixed_length_column.h"
+#include "common/status.h"
+#include "common/statusor.h"
+#include "runtime/primitive_type.h"
+#include "udf/java/java_udf.h"
+
+namespace starrocks::vectorized {
+struct JavaUDAFState {
+    JavaUDAFState(jobject&& handle_) : handle(std::move(handle_)){};
+    ~JavaUDAFState() = default;
+    // UDAF State
+    jobject handle;
+};
+// Column to DirectByteBuffer, which could avoid some memory copy,
+// directly access the C++ address space in Java
+// Because DirectBuffer does not hold the referece of these memory,
+// we must ensure that it is valid during accesses to it
+
+class ConvertDirectBufferVistor : public ColumnVisitorAdapter<ConvertDirectBufferVistor> {
+public:
+    ConvertDirectBufferVistor(std::vector<DirectByteBuffer>& buffers) : ColumnVisitorAdapter(this), _buffers(buffers) {}
+    Status do_visit(const NullableColumn& column);
+    Status do_visit(const BinaryColumn& column);
+
+    template <typename T>
+    Status do_visit(const vectorized::FixedLengthColumn<T>& column) {
+        get_buffer_data(column, &_buffers);
+        return Status::OK();
+    }
+
+    template <typename T>
+    Status do_visit(const T& column) {
+        return Status::NotSupported("UDF Not Support Type");
+    }
+
+private:
+    template <class ColumnType>
+    void get_buffer_data(const ColumnType& column, std::vector<DirectByteBuffer>* buffers) {
+        const auto& container = column.get_data();
+        buffers->emplace_back((void*)container.data(), container.size() * sizeof(typename ColumnType::ValueType));
+    }
+
+private:
+    std::vector<DirectByteBuffer>& _buffers;
+};
+
+class JavaDataTypeConverter {
+public:
+    static jobject convert_to_object_array(uint8_t** data, size_t offset, int num_rows);
+
+    static void convert_to_boxed_array(FunctionContext* ctx, std::vector<DirectByteBuffer>* buffers,
+                                       const Column** columns, int num_cols, int num_rows, std::vector<jobject>* res);
+};
+} // namespace starrocks::vectorized

--- a/gensrc/java/com/starrocks/udf/UDFClassAnalyzer.java
+++ b/gensrc/java/com/starrocks/udf/UDFClassAnalyzer.java
@@ -69,5 +69,14 @@ public class UDFClassAnalyzer {
         }
         throw new NoSuchMethodException("Not Found Method:" + methodName);
     }
+    
+    public static Method getMethodObject(String methodName, Class clazz) {
+        for (Method declaredMethod : clazz.getDeclaredMethods()) {
+            if (declaredMethod.getName().equals(methodName)) {
+                return declaredMethod;
+            }
+        }
+        return null;
+    }
 }
 

--- a/gensrc/java/com/starrocks/udf/UDFHelper.java
+++ b/gensrc/java/com/starrocks/udf/UDFHelper.java
@@ -6,6 +6,9 @@ import java.nio.IntBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
 public class UDFHelper {
     public static final int TYPE_BOOLEAN = 2;
     public static final int TYPE_TINYINT = 3;
@@ -19,25 +22,26 @@ public class UDFHelper {
     public static final int TYPE_ARRAY = 15;
 
     // create boxed array
+    // 
     public static Object[] createBoxedArray(int type, int numRows, boolean nullable, ByteBuffer... buffer) {
         switch (type) {
             case TYPE_BOOLEAN: {
                 if (!nullable) {
-                    return createBoxedBoolArray(numRows, null, buffer[1]);
+                    return createBoxedBoolArray(numRows, null, buffer[0]);
                 } else {
                     return createBoxedBoolArray(numRows, buffer[0], buffer[1]);
                 }
             }
             case TYPE_TINYINT: {
                 if (!nullable) {
-                    return createBoxedByteArray(numRows, null, buffer[1]);
+                    return createBoxedByteArray(numRows, null, buffer[0]);
                 } else {
                     return createBoxedByteArray(numRows, buffer[0], buffer[1]);
                 }
             }
             case TYPE_SMALLINT: {
                 if (!nullable) {
-                    return createBoxedShortArray(numRows, null, buffer[1]);
+                    return createBoxedShortArray(numRows, null, buffer[0]);
                 } else {
                     return createBoxedShortArray(numRows, buffer[0], buffer[1]);
                 }
@@ -230,7 +234,7 @@ public class UDFHelper {
 
     public static Object[] createBoxedStringArray(int numRows, ByteBuffer nullBuffer, ByteBuffer offsetBuffer,
                                                   ByteBuffer dataBuffer) {
-        final IntBuffer intBuffer = offsetBuffer.asIntBuffer();
+        final IntBuffer intBuffer = offsetBuffer.order(ByteOrder.LITTLE_ENDIAN).asIntBuffer();
         int[] offsets = new int[numRows + 1];
         intBuffer.get(offsets);
         final int byteSize = offsets[offsets.length - 1];
@@ -253,6 +257,49 @@ public class UDFHelper {
         }
 
         return strings;
+    }
+
+    // use batch reflect batch call method to reduce JNI call costs
+    // TODO: we need to find a more efficient way of calling
+    public static void batchUpdateSingle(Object o, Method method, Object state, Object[] column)
+            throws InvocationTargetException, IllegalAccessException {
+        Object[][] inputs = (Object[][])column;
+        Object[] parameter = new Object[inputs.length + 1];
+        int numRows = inputs[0].length;
+        parameter[0] = state;
+        for(int i = 0;i < numRows; ++i) {
+            for(int j = 0;j < column.length; ++j) {
+                parameter[j + 1] = inputs[j][i];
+            }
+            method.invoke(o, parameter);
+        }
+    }
+
+    public static void batchUpdate(Object o, Method method, Object[] column)
+            throws InvocationTargetException, IllegalAccessException {
+        Object[][] inputs = (Object[][])column;
+        Object[] parameter = new Object[inputs.length];        
+        int numRows = inputs[0].length;
+        for(int i = 0;i < numRows; ++i) {
+            for(int j = 0;j < column.length; ++j) {
+                parameter[j] = inputs[j][i];
+            }
+            method.invoke(o, parameter);
+        }
+    }
+
+    public static Object[] batchCall(Object o, Method method, int batchSize, Object[] column) 
+            throws InvocationTargetException, IllegalAccessException {
+        Object[][] inputs = (Object[][])column;
+        Object[] parameter = new Object[inputs.length];   
+        Object[] res = new Object[batchSize];     
+        for(int i = 0;i < batchSize; ++i) {
+            for(int j = 0;j < column.length; ++j) {
+                parameter[j] = inputs[j][i];
+            }
+            res[i] = method.invoke(o, parameter);
+        }
+        return res;
     }
 
 }

--- a/gensrc/java/com/starrocks/udf/UDFHelper.java
+++ b/gensrc/java/com/starrocks/udf/UDFHelper.java
@@ -1,3 +1,5 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
 package com.starrocks.udf;
 
 import java.nio.ByteBuffer;


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
#2742 


## 
JNI calls are very expensive, so we need to reduce the frequency of JNI calls.
We can significantly improve UDF performance by batching columns into Object arrays and then batching UDF method calls via reflection