### PR TITLE
Compute the queue level of driver by time slice

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -341,8 +341,8 @@ public:
     workgroup::WorkGroup* workgroup();
     void set_workgroup(workgroup::WorkGroupPtr wg);
 
-    size_t get_driver_queue_level() const { return _driver_queue_index; }
-    void set_driver_queue_index(size_t driver_queue_index) { _driver_queue_index = driver_queue_index; }
+    size_t get_driver_queue_level() const { return _driver_queue_level; }
+    void set_driver_queue_level(size_t driver_queue_level) { _driver_queue_level = driver_queue_level; }
 
 private:
     // Yield PipelineDriver when maximum number of chunks has been moved in current execution round.
@@ -403,7 +403,7 @@ private:
 
     workgroup::WorkGroupPtr _workgroup = nullptr;
     // The index of QuerySharedDriverQueue{WithoutLock}._queues which this driver belongs to.
-    size_t _driver_queue_index = 0;
+    size_t _driver_queue_level = 0;
 
     // metrics
     RuntimeProfile::Counter* _total_timer = nullptr;

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -109,6 +109,8 @@ public:
 
     int64_t get_accumulated_chunks_moved() { return accumulated_chunks_moved; }
 
+    int64_t get_accumulated_time_spent() const { return accumulated_time_spent; }
+
 private:
     int64_t schedule_times{0};
     int64_t schedule_effective_times{0};
@@ -339,7 +341,7 @@ public:
     workgroup::WorkGroup* workgroup();
     void set_workgroup(workgroup::WorkGroupPtr wg);
 
-    size_t get_driver_queue_index() const { return _driver_queue_index; }
+    size_t get_driver_queue_level() const { return _driver_queue_index; }
     void set_driver_queue_index(size_t driver_queue_index) { _driver_queue_index = driver_queue_index; }
 
 private:

--- a/be/src/exec/pipeline/pipeline_driver_queue.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_queue.cpp
@@ -15,7 +15,7 @@ void QuerySharedDriverQueue::close() {
 
 void QuerySharedDriverQueue::put_back(const DriverRawPtr driver) {
     int level = _compute_driver_level(driver);
-    driver->set_driver_queue_index(level);
+    driver->set_driver_queue_level(level);
     {
         std::lock_guard<std::mutex> lock(_global_mutex);
         _queues[level].queue.emplace(driver);
@@ -27,7 +27,7 @@ void QuerySharedDriverQueue::put_back(const std::vector<DriverRawPtr>& drivers) 
     std::vector<int> levels(drivers.size());
     for (int i = 0; i < drivers.size(); i++) {
         levels[i] = _compute_driver_level(drivers[i]);
-        drivers[i]->set_driver_queue_index(levels[i]);
+        drivers[i]->set_driver_queue_level(levels[i]);
     }
 
     std::lock_guard<std::mutex> lock(_global_mutex);
@@ -164,7 +164,7 @@ void QuerySharedDriverQueueWithoutLock::update_statistics(const DriverRawPtr dri
 
 void QuerySharedDriverQueueWithoutLock::_put_back(const DriverRawPtr driver) {
     int level = _compute_driver_level(driver);
-    driver->set_driver_queue_index(level);
+    driver->set_driver_queue_level(level);
     _queues[level].queue.emplace(driver);
     ++_size;
 }

--- a/be/src/exec/pipeline/pipeline_driver_queue.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_queue.cpp
@@ -14,7 +14,7 @@ void QuerySharedDriverQueue::close() {
 }
 
 void QuerySharedDriverQueue::put_back(const DriverRawPtr driver) {
-    int level = driver->driver_acct().get_level() % QUEUE_SIZE;
+    int level = _compute_driver_level(driver);
     driver->set_driver_queue_index(level);
     {
         std::lock_guard<std::mutex> lock(_global_mutex);
@@ -26,7 +26,7 @@ void QuerySharedDriverQueue::put_back(const DriverRawPtr driver) {
 void QuerySharedDriverQueue::put_back(const std::vector<DriverRawPtr>& drivers) {
     std::vector<int> levels(drivers.size());
     for (int i = 0; i < drivers.size(); i++) {
-        levels[i] = drivers[i]->driver_acct().get_level() % QUEUE_SIZE;
+        levels[i] = _compute_driver_level(drivers[i]);
         drivers[i]->set_driver_queue_index(levels[i]);
     }
 
@@ -95,7 +95,18 @@ size_t QuerySharedDriverQueue::size() {
 }
 
 void QuerySharedDriverQueue::update_statistics(const DriverRawPtr driver) {
-    _queues[driver->get_driver_queue_index()].update_accu_time(driver);
+    _queues[driver->get_driver_queue_level()].update_accu_time(driver);
+}
+
+int QuerySharedDriverQueue::_compute_driver_level(const DriverRawPtr driver) const {
+    int time_spent = driver->driver_acct().get_accumulated_time_spent();
+    for (int i = driver->get_driver_queue_level(); i < QUEUE_SIZE; ++i) {
+        if (time_spent < _level_time_slices[i]) {
+            return i;
+        }
+    }
+
+    return QUEUE_SIZE - 1;
 }
 
 void QuerySharedDriverQueueWithoutLock::put_back(const DriverRawPtr driver) {
@@ -148,14 +159,25 @@ StatusOr<DriverRawPtr> QuerySharedDriverQueueWithoutLock::take(int worker_id) {
 }
 
 void QuerySharedDriverQueueWithoutLock::update_statistics(const DriverRawPtr driver) {
-    _queues[driver->get_driver_queue_index()].update_accu_time(driver);
+    _queues[driver->get_driver_queue_level()].update_accu_time(driver);
 }
 
 void QuerySharedDriverQueueWithoutLock::_put_back(const DriverRawPtr driver) {
-    int level = driver->driver_acct().get_level() % QUEUE_SIZE;
+    int level = _compute_driver_level(driver);
     driver->set_driver_queue_index(level);
     _queues[level].queue.emplace(driver);
     ++_size;
+}
+
+int QuerySharedDriverQueueWithoutLock::_compute_driver_level(const DriverRawPtr driver) const {
+    int time_spent = driver->driver_acct().get_accumulated_time_spent();
+    for (int i = driver->get_driver_queue_level(); i < QUEUE_SIZE; ++i) {
+        if (time_spent < _level_time_slices[i]) {
+            return i;
+        }
+    }
+
+    return QUEUE_SIZE - 1;
 }
 
 void DriverQueueWithWorkGroup::close() {

--- a/be/src/exec/pipeline/pipeline_driver_queue.h
+++ b/be/src/exec/pipeline/pipeline_driver_queue.h
@@ -33,6 +33,12 @@ public:
 
     virtual size_t size() = 0;
     bool empty() { return size() == 0; }
+
+protected:
+    // The time slice of the i-th level is (i+1)*LEVEL_TIME_SLICE_BASE ns,
+    // so when a driver's execution time exceeds 0.2s, 0.6s, 1.2s, 2s, 3s, 4.2s, 5.6s, and 7.2s,
+    // it will move to next level.
+    static constexpr int64_t LEVEL_TIME_SLICE_BASE_NS = 200'000'000L;
 };
 
 class SubQuerySharedDriverQueue {
@@ -95,11 +101,6 @@ private:
     int _compute_driver_level(const DriverRawPtr driver) const;
 
 private:
-    // The time slice of the i-th level is (i+1)*LEVEL_TIME_SLICE_BASE ns,
-    // so when a driver's execution time exceeds 0.2s, 0.6s, 1.2s, 2s, 3s, 4.2s, 5.6s, and 7.2s,
-    // it will move to next level.
-    static constexpr int64_t LEVEL_TIME_SLICE_BASE_NS = 200'000'000L;
-
     SubQuerySharedDriverQueue _queues[QUEUE_SIZE];
     // The time slice of the i-th level is (i+1)*LEVEL_TIME_SLICE_BASE ns.
     int64_t _level_time_slices[QUEUE_SIZE];
@@ -154,10 +155,6 @@ private:
 private:
     static constexpr size_t QUEUE_SIZE = 8;
     static constexpr double RATIO_OF_ADJACENT_QUEUE = 1.2;
-    // The time slice of the i-th level is (i+1)*LEVEL_TIME_SLICE_BASE ns,
-    // so when a driver's execution time exceeds 0.2s, 0.6s, 1.2s, 2s, 3s, 4.2s, 5.6s, and 7.2s,
-    // it will move to next level.
-    static constexpr int64_t LEVEL_TIME_SLICE_BASE_NS = 200'000'000L;
 
     SubQuerySharedDriverQueue _queues[QUEUE_SIZE];
     // The time slice of the i-th level is (i+1)*LEVEL_TIME_SLICE_BASE ns.

--- a/be/src/exec/pipeline/pipeline_driver_queue.h
+++ b/be/src/exec/pipeline/pipeline_driver_queue.h
@@ -64,13 +64,15 @@ public:
             _queues[i].factor_for_normal = factor;
             factor *= RATIO_OF_ADJACENT_QUEUE;
         }
+
+        int64_t time_slice = 0;
+        for (int i = 0; i < QUEUE_SIZE; ++i) {
+            time_slice += LEVEL_TIME_SLICE_BASE_NS * (i + 1);
+            _level_time_slices[i] = time_slice;
+        }
     }
     ~QuerySharedDriverQueue() override = default;
     void close() override;
-
-    static const size_t QUEUE_SIZE = 8;
-    // maybe other value for ratio.
-    static constexpr double RATIO_OF_ADJACENT_QUEUE = 1.2;
     void put_back(const DriverRawPtr driver) override;
     void put_back(const std::vector<DriverRawPtr>& drivers) override;
 
@@ -84,8 +86,24 @@ public:
 
     size_t size() override;
 
+    static constexpr size_t QUEUE_SIZE = 8;
+    static constexpr double RATIO_OF_ADJACENT_QUEUE = 1.2;
+
 private:
+    // When the driver at the i-th level costs _level_time_slices[i],
+    // it will move to (i+1)-th level.
+    int _compute_driver_level(const DriverRawPtr driver) const;
+
+private:
+    // The time slice of the i-th level is (i+1)*LEVEL_TIME_SLICE_BASE ns,
+    // so when a driver's execution time exceeds 0.2s, 0.6s, 1.2s, 2s, 3s, 4.2s, 5.6s, and 7.2s,
+    // it will move to next level.
+    static constexpr int64_t LEVEL_TIME_SLICE_BASE_NS = 200'000'000L;
+
     SubQuerySharedDriverQueue _queues[QUEUE_SIZE];
+    // The time slice of the i-th level is (i+1)*LEVEL_TIME_SLICE_BASE ns.
+    int64_t _level_time_slices[QUEUE_SIZE];
+
     std::mutex _global_mutex;
     std::condition_variable _cv;
     bool _is_closed = false;
@@ -105,6 +123,12 @@ public:
             _queues[i].factor_for_normal = factor;
             factor *= RATIO_OF_ADJACENT_QUEUE;
         }
+
+        int64_t time_slice = 0;
+        for (int i = 0; i < QUEUE_SIZE; ++i) {
+            time_slice += LEVEL_TIME_SLICE_BASE_NS * (i + 1);
+            _level_time_slices[i] = time_slice;
+        }
     }
     ~QuerySharedDriverQueueWithoutLock() override = default;
     void close() override {}
@@ -123,11 +147,21 @@ public:
 
 private:
     void _put_back(const DriverRawPtr driver);
+    // When the driver at the i-th level costs _level_time_slices[i],
+    // it will move to (i+1)-th level.
+    int _compute_driver_level(const DriverRawPtr driver) const;
 
+private:
     static constexpr size_t QUEUE_SIZE = 8;
     static constexpr double RATIO_OF_ADJACENT_QUEUE = 1.2;
+    // The time slice of the i-th level is (i+1)*LEVEL_TIME_SLICE_BASE ns,
+    // so when a driver's execution time exceeds 0.2s, 0.6s, 1.2s, 2s, 3s, 4.2s, 5.6s, and 7.2s,
+    // it will move to next level.
+    static constexpr int64_t LEVEL_TIME_SLICE_BASE_NS = 200'000'000L;
 
     SubQuerySharedDriverQueue _queues[QUEUE_SIZE];
+    // The time slice of the i-th level is (i+1)*LEVEL_TIME_SLICE_BASE ns.
+    int64_t _level_time_slices[QUEUE_SIZE];
 
     size_t _size = 0;
 };

--- a/be/test/exec/pipeline/pipeline_driver_queue_test.cpp
+++ b/be/test/exec/pipeline/pipeline_driver_queue_test.cpp
@@ -35,9 +35,6 @@ Operators _gen_operators() {
 
 void _set_driver_level(DriverRawPtr driver, int level) {
     driver->set_driver_queue_index(level % QuerySharedDriverQueue::QUEUE_SIZE);
-    while (driver->driver_acct().get_level() < level) {
-        driver->driver_acct().increment_schedule_times();
-    }
 }
 
 PARALLEL_TEST(QuerySharedDriverQueueTest, test_basic) {

--- a/be/test/exec/pipeline/pipeline_driver_queue_test.cpp
+++ b/be/test/exec/pipeline/pipeline_driver_queue_test.cpp
@@ -34,7 +34,7 @@ Operators _gen_operators() {
 }
 
 void _set_driver_level(DriverRawPtr driver, int level) {
-    driver->set_driver_queue_index(level % QuerySharedDriverQueue::QUEUE_SIZE);
+    driver->set_driver_queue_level(level % QuerySharedDriverQueue::QUEUE_SIZE);
 }
 
 PARALLEL_TEST(QuerySharedDriverQueueTest, test_basic) {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others


## Problem Summary：
The queue level of driver is determined by the times it runs on the driver worker thread. That is , `level=log2(times)`.

However, if the driver costs only a little time for multiple times, it will move to the low-priority level queue quickly, although it only consumes a little time.

Therefore, we could determine the queue level of a driver by the driver consuming time instead of execution times. The time slice of the `i-th` level for a driver is `(i+1)*200`ms. That is, when a driver's execution time exceeds 0.2s, 0.6s, 1.2s, 2s, 3s, 4.2s, 5.6s, and 7.2s, it will move to next level.


