### PR TITLE
Capture row sets of tablet in the preparation of ScanOperawtor

### DIFF
--- a/be/src/exec/pipeline/morsel.h
+++ b/be/src/exec/pipeline/morsel.h
@@ -42,7 +42,10 @@ class MorselQueue {
 public:
     MorselQueue(Morsels&& morsels) : _morsels(std::move(morsels)), _num_morsels(_morsels.size()), _pop_index(0) {}
 
+    const Morsels& morsels() const { return _morsels; }
+
     size_t num_morsels() const { return _num_morsels; }
+
     std::optional<MorselPtr> try_get() {
         auto idx = _pop_index.load();
         // prevent _num_morsels from superfluous addition


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3689.

## Problem Summary(Required) ：
The row sets of tablets will become stale and be deleted, if compaction occurs and these row sets aren't referenced, which will typically happen when the tablets of the left table are compacted at building the right hash table. 

Therefore, reference  the row sets into _tablet_rowsets in the preparation phase to avoid the row sets being deleted.


