### PR TITLE
Fix CallOperator equal method error and Analyze bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CallOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CallOperator.java
@@ -147,6 +147,7 @@ public class CallOperator extends ScalarOperator {
         CallOperator other = (CallOperator) obj;
         return isDistinct == other.isDistinct &&
                 Objects.equals(fnName, other.fnName) &&
+                Objects.equals(type, other.type) &&
                 Objects.equals(arguments, other.arguments);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
@@ -7,7 +7,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import com.starrocks.analysis.QueryStmt;
 import com.starrocks.analysis.StatementBase;
 import com.starrocks.catalog.Catalog;
 import com.starrocks.catalog.Column;
@@ -24,7 +23,9 @@ import com.starrocks.qe.QueryState;
 import com.starrocks.qe.RowBatch;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.sql.analyzer.Analyzer;
+import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.ast.QueryRelation;
+import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.Optimizer;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
@@ -115,7 +116,9 @@ public class StatisticExecutor {
         StatementBase parsedStmt;
         try {
             parsedStmt = parseSQL(sql, context);
-            ((QueryStmt) parsedStmt).getDbs(context, dbs);
+            if (parsedStmt instanceof QueryStatement) {
+                dbs = AnalyzerUtils.collectAllDatabase(context, parsedStmt);
+            }
         } catch (Exception e) {
             LOG.warn("Parse statistic table query fail.", e);
             throw e;
@@ -167,7 +170,9 @@ public class StatisticExecutor {
         StatementBase parsedStmt;
         try {
             parsedStmt = parseSQL(sql, context);
-            ((QueryStmt) parsedStmt).getDbs(context, dbs);
+            if (parsedStmt instanceof QueryStatement) {
+                dbs = AnalyzerUtils.collectAllDatabase(context, parsedStmt);
+            }
             Preconditions.checkState(dbs.size() == 1);
         } catch (Exception e) {
             LOG.warn("Parse statistic dict query {} fail.", sql, e);
@@ -272,7 +277,9 @@ public class StatisticExecutor {
         StatementBase parsedStmt;
         try {
             parsedStmt = parseSQL(sql.toString(), context);
-            ((QueryStmt) parsedStmt).getDbs(context, dbs);
+            if (parsedStmt instanceof QueryStatement) {
+                dbs = AnalyzerUtils.collectAllDatabase(context, parsedStmt);
+            }
         } catch (Exception e) {
             LOG.warn("Parse statistic table query fail. SQL: " + sql, e);
             throw e;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecodeRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecodeRewriteTest.java
@@ -263,7 +263,12 @@ public class DecodeRewriteTest extends PlanTestBase {
     public void testDecodeNodeRewriteTwoPhaseAgg() throws Exception {
         String sql = "select lower(upper(S_ADDRESS)) as a, upper(S_ADDRESS) as b, count(*) from supplier group by a,b";
         connectContext.getSessionVariable().setNewPlanerAggStage(2);
-        String plan = getThriftPlan(sql);
+        String plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("  1:Project\n" +
+                "  |  <slot 13> : lower(upper(12: S_ADDRESS))\n" +
+                "  |  <slot 14> : upper(12: S_ADDRESS)"));
+        Assert.assertFalse(plan.contains("common expressions"));
+        plan = getThriftPlan(sql);
         Assert.assertTrue(plan.contains("global_dicts:[TGlobalDict(columnId:12, strings:[mock], ids:[1])]"));
         Assert.assertTrue(plan.contains("global_dicts:[TGlobalDict(columnId:12, strings:[mock], ids:[1])]"));
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
For https://github.com/StarRocks/starrocks/issues/3691

bug 2:

```
Caused by: java.lang.ClassCastException: com.starrocks.sql.ast.QueryStatement cannot be cast to com.starrocks.analysis.QueryStmt
        at com.starrocks.statistic.StatisticExecutor.queryStatisticSync(StatisticExecutor.java:118)
        at com.starrocks.sql.optimizer.statistics.CachedStatisticStorage.queryStatisticsData(CachedStatisticStorage.java:135)
        at com.starrocks.sql.optimizer.statistics.CachedStatisticStorage.access$200(CachedStatisticStorage.java:44)
        at com.starrocks.sql.optimizer.statistics.CachedStatisticStorage$1.lambda$asyncLoadAll$1(CachedStatisticStorage.java:83)
        at java.util.c
```