### PR TITLE
Capture row sets of tablet in the preparation of OlapScanNode

### DIFF
--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -20,6 +20,9 @@
 #include "runtime/current_thread.h"
 #include "runtime/descriptors.h"
 #include "runtime/primitive_type.h"
+#include "storage/rowset/rowset.h"
+#include "storage/storage_engine.h"
+#include "storage/tablet.h"
 #include "storage/vectorized/chunk_helper.h"
 #include "util/defer_op.h"
 #include "util/priority_thread_pool.hpp"
@@ -58,6 +61,8 @@ Status OlapScanNode::prepare(RuntimeState* state) {
         _runtime_profile->add_info_string("Predicates", _olap_scan_node.sql_predicates);
     }
     _runtime_state = state;
+
+    RETURN_IF_ERROR(_capture_tablet_rowsets());
 
     return Status::OK();
 }
@@ -513,6 +518,37 @@ Status OlapScanNode::_start_scan_thread(RuntimeState* state) {
     for (int i = 0; i < concurrency; i++) {
         CHECK(_submit_scanner(_pending_scanners.pop(), true));
     }
+    return Status::OK();
+}
+
+Status OlapScanNode::_capture_tablet_rowsets() {
+    _tablet_rowsets.resize(_scan_ranges.size());
+    for (int i = 0; i < _scan_ranges.size(); ++i) {
+        const auto& scan_range = _scan_ranges[i];
+
+        // Get version.
+        int64_t version = strtoul(scan_range->version.c_str(), nullptr, 10);
+
+        // Get tablet.
+        TTabletId tablet_id = scan_range->tablet_id;
+        std::string err;
+        TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, true, &err);
+        if (!tablet) {
+            std::stringstream ss;
+            SchemaHash schema_hash = strtoul(scan_range->schema_hash.c_str(), nullptr, 10);
+            ss << "failed to get tablet. tablet_id=" << tablet_id << ", with schema_hash=" << schema_hash
+               << ", reason=" << err;
+            LOG(WARNING) << ss.str();
+            return Status::InternalError(ss.str());
+        }
+
+        // Capture row sets of this version tablet.
+        {
+            std::shared_lock l(tablet->get_header_lock());
+            RETURN_IF_ERROR(tablet->capture_consistent_rowsets(Version(0, version), &_tablet_rowsets[i]));
+        }
+    }
+
     return Status::OK();
 }
 

--- a/be/src/exec/vectorized/olap_scan_node.h
+++ b/be/src/exec/vectorized/olap_scan_node.h
@@ -17,6 +17,9 @@ namespace starrocks {
 class DescriptorTbl;
 class SlotDescriptor;
 class TupleDescriptor;
+
+class Rowset;
+using RowsetSharedPtr = std::shared_ptr<Rowset>;
 } // namespace starrocks
 
 namespace starrocks::vectorized {
@@ -107,6 +110,10 @@ private:
     void _close_pending_scanners();
     int _compute_priority(int32_t num_submitted_tasks);
 
+    // Reference the row sets into _tablet_rowsets in the preparation phase to avoid
+    // the row sets being deleted. Should be called after set_scan_ranges.
+    Status _capture_tablet_rowsets();
+
     TOlapScanNode _olap_scan_node;
     std::vector<std::unique_ptr<TInternalScanRange>> _scan_ranges;
     RuntimeState* _runtime_state = nullptr;
@@ -136,6 +143,12 @@ private:
     std::atomic<int32_t> _closed_scanners{0};
 
     std::vector<std::string> _unused_output_columns;
+
+    // The row sets of tablets will become stale and be deleted, if compaction occurs
+    // and these row sets aren't referenced, which will typically happen when the tablets
+    // of the left table are compacted at building the right hash table. Therefore, reference
+    // the row sets into _tablet_rowsets in the preparation phase to avoid the row sets being deleted.
+    std::vector<std::vector<RowsetSharedPtr>> _tablet_rowsets;
 
     // profile
     RuntimeProfile* _scan_profile = nullptr;

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -124,7 +124,6 @@ Status PlanFragmentExecutor::prepare(const TExecPlanFragmentParams& request) {
         static_cast<ExchangeNode*>(exch_node)->set_num_senders(num_senders);
     }
 
-    RETURN_IF_ERROR(_plan->prepare(_runtime_state));
     // set scan ranges
     std::vector<ExecNode*> scan_nodes;
     std::vector<TScanRangeParams> no_scan_ranges;
@@ -139,6 +138,8 @@ Status PlanFragmentExecutor::prepare(const TExecPlanFragmentParams& request) {
         scan_node->set_scan_ranges(scan_ranges);
         VLOG(1) << "scan_node_Id=" << scan_node->id() << " size=" << scan_ranges.size();
     }
+
+    RETURN_IF_ERROR(_plan->prepare(_runtime_state));
 
     _runtime_state->set_per_fragment_instance_idx(params.sender_id);
     _runtime_state->set_num_per_fragment_instances(params.num_senders);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3689.

## Problem Summary：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The row sets of tablets will become stale and be deleted, if compaction occurs and these row sets aren't referenced, which will typically happen when the tablets of the left table are compacted at building the right hash table.

Therefore, reference the row sets into _tablet_rowsets in the preparation phase to avoid the row sets being deleted.
