### PR TITLE
optimize the memory usage of flush memtable to segments, step 1/3

### DIFF
--- a/be/src/storage/rowset/column_writer.cpp
+++ b/be/src/storage/rowset/column_writer.cpp
@@ -575,6 +575,12 @@ Status ScalarColumnWriter::finish_current_page() {
         // page body is uncompressed
         double space_saving =
                 1.0 - static_cast<double>(encoded_values->size()) / static_cast<double>(encoded_values->capacity());
+        // when the page is first compressed by bitshuffle, the compression effect of lz4 is not obvious.
+        // Then the decompress page (may be much larger then the actual size,
+        // e.g. the page is 6K, but the compressed page allocated is 256K),
+        // is swaped to the encoded_values for opt the memory allocation.
+        // In this scenario, the page is all 256K, bug actual data size is 6K.
+        // So, we should shrink the page to the right size.
         if (space_saving >= _opts.compression_min_space_saving) {
             encoded_values->shrink_to_fit();
         }

--- a/be/src/storage/rowset/column_writer.cpp
+++ b/be/src/storage/rowset/column_writer.cpp
@@ -573,6 +573,12 @@ Status ScalarColumnWriter::finish_current_page() {
             PageIO::compress_page_body(_compress_codec, _opts.compression_min_space_saving, body, &compressed_body));
     if (compressed_body.size() == 0) {
         // page body is uncompressed
+        double space_saving =
+                1.0 - static_cast<double>(encoded_values->size()) / static_cast<double>(encoded_values->capacity());
+        if (space_saving >= _opts.compression_min_space_saving) {
+            encoded_values->shrink_to_fit();
+        }
+
         page->data.emplace_back(encoded_values->build());
         page->data.emplace_back(std::move(nullmap));
         // Move the ownership of the internal storage of |compressed_body| to |encoded_values|,

--- a/be/src/storage/rowset/column_writer.cpp
+++ b/be/src/storage/rowset/column_writer.cpp
@@ -576,7 +576,7 @@ Status ScalarColumnWriter::finish_current_page() {
         double space_saving =
                 1.0 - static_cast<double>(encoded_values->size()) / static_cast<double>(encoded_values->capacity());
         // when the page is first compressed by bitshuffle, the compression effect of lz4 is not obvious.
-        // Then the decompress page (may be much larger then the actual size,
+        // Then the compressed page (may be much larger then the actual size,
         // e.g. the page is 6K, but the compressed page allocated is 256K),
         // is swaped to the encoded_values for opt the memory allocation.
         // In this scenario, the page is all 256K, bug actual data size is 6K.


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3721 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

when the page is first compressed by bitshuffle, the compression effect of lz4 is not obvious.

Then the decompress page (maybe much larger then the actual size, the page is 6K, but the compressed page allocated is 256K), is swaped to the encoded_values for opt the memory allocation.

So, the page is all 256K, but actual data size is 6K.

the pr can opt the peak memory from 490MB to 315MB for one memtable flush

the pr has no performance effect on load