### PR TITLE
Fix BE heartbeat thrift server exit unexpected after network failure injection

### DIFF
--- a/be/src/util/thrift_server.h
+++ b/be/src/util/thrift_server.h
@@ -106,6 +106,9 @@ private:
     // True if the server has been successfully started, for internal use only
     bool _started;
 
+    // True if the server has been stop()
+    bool _stopped = false;
+
     // The port on which the server interface is exposed
     int _port;
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
Fixes #3726

## Problem Summary(Required) ：
BE heartbeat thrift server exit unexpected after network failure injection, so will retry after exception until the stop() has been called
