### PR TITLE
extend lifetime of query context if some fragments are pending on wire

### DIFF
--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -28,43 +28,121 @@ void QueryContext::cancel(const Status& status) {
     _fragment_mgr->cancel(status);
 }
 
-QueryContextManager::QueryContextManager() = default;
+static constexpr size_t QUERY_CONTEXT_MAP_SLOT_NUM = 64;
+static constexpr size_t QUERY_CONTEXT_MAP_SLOT_NUM_MASK = (1 << 6) - 1;
+QueryContextManager::QueryContextManager()
+        : _mutexes(QUERY_CONTEXT_MAP_SLOT_NUM),
+          _context_maps(QUERY_CONTEXT_MAP_SLOT_NUM),
+          _second_chance_maps(QUERY_CONTEXT_MAP_SLOT_NUM) {}
+
+#ifdef BE_TEST
+QueryContextManager::QueryContextManager(int) : QueryContextManager() {}
+#endif
+
 QueryContextManager::~QueryContextManager() = default;
 QueryContext* QueryContextManager::get_or_register(const TUniqueId& query_id) {
-    std::lock_guard lock(_lock);
-    auto iter = _contexts.find(query_id);
-    if (iter != _contexts.end()) {
-        iter->second->increment_num_fragments();
-        return iter->second.get();
-    }
+    size_t i = std::hash<size_t>()(query_id.lo) & QUERY_CONTEXT_MAP_SLOT_NUM_MASK;
+    auto& mutex = _mutexes[i];
+    auto& context_map = _context_maps[i];
+    auto& sc_map = _second_chance_maps[i];
 
-    auto&& ctx = std::make_shared<QueryContext>();
-    auto* ctx_raw_ptr = ctx.get();
-    ctx_raw_ptr->set_query_id(query_id);
-    ctx_raw_ptr->increment_num_fragments();
-    _contexts.emplace(query_id, std::move(ctx));
-    return ctx_raw_ptr;
+    {
+        // require read lock
+        std::shared_lock<std::shared_mutex> read_lock(mutex);
+        // lookup query context in context_map
+        auto it = context_map.find(query_id);
+        if (it != context_map.end()) {
+            it->second->increment_num_fragments();
+            return it->second.get();
+        }
+    }
+    {
+        // require write lock
+        std::unique_lock<std::shared_mutex> write_lock(mutex);
+        // lookup query context in context_map at first
+        auto it = context_map.find(query_id);
+        auto sc_it = sc_map.find(query_id);
+        if (it != context_map.end()) {
+            it->second->increment_num_fragments();
+            return it->second.get();
+        } else {
+            // lookup query context for the second chance in sc_map
+            if (sc_it != sc_map.end()) {
+                auto ctx = std::move(sc_it->second);
+                ctx->increment_num_fragments();
+                sc_map.erase(sc_it);
+                auto* raw_ctx_ptr = ctx.get();
+                context_map.emplace(query_id, std::move(ctx));
+                return raw_ctx_ptr;
+            }
+        }
+
+        // finally, find no query contexts, so create a new one
+        auto&& ctx = std::make_shared<QueryContext>();
+        auto* ctx_raw_ptr = ctx.get();
+        ctx_raw_ptr->set_query_id(query_id);
+        ctx_raw_ptr->increment_num_fragments();
+        context_map.emplace(query_id, std::move(ctx));
+        return ctx_raw_ptr;
+    }
 }
 
 QueryContextPtr QueryContextManager::get(const TUniqueId& query_id) {
-    std::lock_guard lock(_lock);
-    auto it = _contexts.find(query_id);
-    if (it != _contexts.end()) {
+    size_t i = std::hash<size_t>()(query_id.lo) & QUERY_CONTEXT_MAP_SLOT_NUM_MASK;
+    auto& mutex = _mutexes[i];
+    auto& context_map = _context_maps[i];
+    auto& sc_map = _second_chance_maps[i];
+    std::shared_lock<std::shared_mutex> read_lock(mutex);
+    // lookup query context in context_map for the first chance
+    auto it = context_map.find(query_id);
+    if (it != context_map.end()) {
         return it->second;
     } else {
-        return nullptr;
+        // lookup query context in context_map for the second chance
+        auto sc_it = sc_map.find(query_id);
+        if (sc_it != sc_map.end()) {
+            return sc_it->second;
+        } else {
+            return nullptr;
+        }
     }
 }
 
-QueryContextPtr QueryContextManager::remove(const TUniqueId& query_id) {
-    std::lock_guard lock(_lock);
-    auto it = _contexts.find(query_id);
-    if (it != _contexts.end()) {
-        auto ctx = std::move(it->second);
-        _contexts.erase(it);
-        return ctx;
+void QueryContextManager::remove(const TUniqueId& query_id) {
+    size_t i = std::hash<size_t>()(query_id.lo) & QUERY_CONTEXT_MAP_SLOT_NUM_MASK;
+    auto& mutex = _mutexes[i];
+    auto& context_map = _context_maps[i];
+    auto& sc_map = _second_chance_maps[i];
+
+    // require write lock
+    std::unique_lock<std::shared_mutex> write_lock(mutex);
+
+    // clean expired query contexts in sc_map
+    auto sc_it = sc_map.begin();
+    while (sc_it != sc_map.end()) {
+        if (sc_it->second->is_expired()) {
+            sc_it = sc_map.erase(sc_it);
+        } else {
+            ++sc_it;
+        }
+    }
+    // return directly if query_ctx is absent
+    auto it = context_map.find(query_id);
+    if (it == context_map.end()) {
+        return;
+    }
+
+    // the query context is really dead, so just cleanup
+    if (it->second->is_dead()) {
+        context_map.erase(it);
     } else {
-        return nullptr;
+        // although all of active fragments of the query context terminates, but some fragments maybe comes too late
+        // in the future, so extend the lifetime of query context and wait for some time till fragments on wire have
+        // vanished
+        auto ctx = std::move(it->second);
+        ctx->extend_lifetime();
+        context_map.erase(it);
+        sc_map.emplace(query_id, std::move(ctx));
     }
 }
 

--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -47,7 +47,6 @@ QueryContext* QueryContextManager::get_or_register(const TUniqueId& query_id) {
     auto& sc_map = _second_chance_maps[i];
 
     {
-        // require read lock
         std::shared_lock<std::shared_mutex> read_lock(mutex);
         // lookup query context in context_map
         auto it = context_map.find(query_id);
@@ -57,7 +56,6 @@ QueryContext* QueryContextManager::get_or_register(const TUniqueId& query_id) {
         }
     }
     {
-        // require write lock
         std::unique_lock<std::shared_mutex> write_lock(mutex);
         // lookup query context in context_map at first
         auto it = context_map.find(query_id);
@@ -114,7 +112,6 @@ void QueryContextManager::remove(const TUniqueId& query_id) {
     auto& context_map = _context_maps[i];
     auto& sc_map = _second_chance_maps[i];
 
-    // require write lock
     std::unique_lock<std::shared_mutex> write_lock(mutex);
 
     // clean expired query contexts in sc_map

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -38,6 +38,7 @@ set(EXEC_FILES
         ./exec/pipeline/pipeline_test_base.cpp
         ./exec/pipeline/pipeline_control_flow_test.cpp
         ./exec/pipeline/pipeline_driver_queue_test.cpp
+        ./exec/pipeline/query_context_manger_test.cpp
         ./exec/parquet/parquet_schema_test.cpp
         ./exec/parquet/encoding_test.cpp
         ./exec/parquet/page_reader_test.cpp

--- a/be/test/exec/pipeline/query_context_manger_test.cpp
+++ b/be/test/exec/pipeline/query_context_manger_test.cpp
@@ -1,0 +1,183 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#include <chrono>
+#include <random>
+
+#include "exec/pipeline/query_context.h"
+#include "gtest/gtest.h"
+
+namespace starrocks {
+namespace pipeline {
+TEST(QueryContextManagerTest, testSingleThreadOperations) {
+    {
+        auto query_ctx_mgr = std::make_shared<QueryContextManager>(0);
+        for (int i = 0; i < 100; ++i) {
+            TUniqueId query_id;
+            query_id.hi = 100;
+            query_id.lo = i;
+            auto* query_ctx = query_ctx_mgr->get_or_register(query_id);
+            ASSERT_TRUE(query_ctx != nullptr);
+            query_ctx->set_expire_seconds(300);
+            query_ctx->set_total_fragments(1);
+            query_ctx->extend_lifetime();
+            ASSERT_EQ(query_ctx->query_id(), query_id);
+            ASSERT_FALSE(query_ctx->is_expired());
+            ASSERT_FALSE(query_ctx->is_finished());
+            ASSERT_FALSE(query_ctx->is_dead());
+        }
+        for (int i = 1; i < 10; ++i) {
+            TUniqueId query_id;
+            query_id.hi = 100;
+            query_id.lo = i;
+            auto query_ctx = query_ctx_mgr->get(query_id);
+            ASSERT_TRUE(query_ctx);
+            ASSERT_EQ(query_ctx->query_id(), query_id);
+            ASSERT_FALSE(query_ctx->is_expired());
+            ASSERT_FALSE(query_ctx->is_finished());
+            ASSERT_FALSE(query_ctx->is_dead());
+            query_ctx->count_down_fragments();
+            ASSERT_TRUE(query_ctx->is_finished());
+            ASSERT_TRUE(query_ctx->is_dead());
+            query_ctx_mgr->remove(query_id);
+            query_ctx = query_ctx_mgr->get(query_id);
+            ASSERT_FALSE(query_ctx);
+        }
+
+        {
+            auto query_ctx_mgr = std::make_shared<QueryContextManager>(0);
+            TUniqueId query_id;
+            query_id.hi = 100;
+            query_id.lo = 1;
+            auto* query_ctx = query_ctx_mgr->get_or_register(query_id);
+            query_ctx->set_total_fragments(8);
+            query_ctx->set_expire_seconds(300);
+            query_ctx->extend_lifetime();
+            query_ctx->count_down_fragments();
+
+            for (int i = 0; i < 7; ++i) {
+                auto* tmp_query_ctx = query_ctx_mgr->get_or_register(query_id);
+                ASSERT_TRUE(tmp_query_ctx != nullptr);
+            }
+            for (int i = 0; i < 7; ++i) {
+                query_ctx->count_down_fragments();
+            }
+            ASSERT_TRUE(query_ctx->is_finished());
+            ASSERT_TRUE(query_ctx->is_dead());
+            query_ctx_mgr->remove(query_id);
+            ASSERT_TRUE(query_ctx_mgr->get(query_id) == nullptr);
+        }
+
+        {
+            auto query_ctx_mgr = std::make_shared<QueryContextManager>(0);
+            TUniqueId query_id;
+            query_id.hi = 100;
+            query_id.lo = 2;
+            auto* query_ctx = query_ctx_mgr->get_or_register(query_id);
+            query_ctx->set_total_fragments(8);
+            query_ctx->set_expire_seconds(300);
+            query_ctx->extend_lifetime();
+            query_ctx->count_down_fragments();
+
+            for (int i = 0; i < 3; ++i) {
+                auto* tmp_query_ctx = query_ctx_mgr->get_or_register(query_id);
+                ASSERT_TRUE(tmp_query_ctx != nullptr);
+            }
+            for (int i = 0; i < 3; ++i) {
+                query_ctx->count_down_fragments();
+            }
+            ASSERT_TRUE(query_ctx->is_finished());
+            ASSERT_FALSE(query_ctx->is_dead());
+            query_ctx_mgr->remove(query_id);
+            ASSERT_TRUE(query_ctx_mgr->get(query_id) != nullptr);
+            for (int i = 0; i < 3; ++i) {
+                auto* tmp_query_ctx = query_ctx_mgr->get_or_register(query_id);
+                ASSERT_TRUE(query_ctx != nullptr);
+                tmp_query_ctx->count_down_fragments();
+                query_ctx_mgr->remove(query_id);
+                ASSERT_TRUE(tmp_query_ctx->is_finished());
+                ASSERT_FALSE(tmp_query_ctx->is_dead());
+                ASSERT_TRUE(query_ctx_mgr->get(query_id) != nullptr);
+            }
+            query_ctx = query_ctx_mgr->get_or_register(query_id);
+            query_ctx->count_down_fragments();
+            ASSERT_TRUE(query_ctx->is_dead());
+            query_ctx_mgr->remove(query_id);
+            ASSERT_TRUE(query_ctx_mgr->get(query_id) == nullptr);
+        }
+
+        {
+            auto query_ctx_mgr = std::make_shared<QueryContextManager>(0);
+            TUniqueId query_id;
+            query_id.hi = 100;
+            query_id.lo = 3;
+            auto* query_ctx = query_ctx_mgr->get_or_register(query_id);
+            query_ctx->set_total_fragments(8);
+            query_ctx->set_expire_seconds(300);
+            query_ctx->extend_lifetime();
+            query_ctx->count_down_fragments();
+            for (int i = 0; i < 3; ++i) {
+                auto* tmp_query_ctx = query_ctx_mgr->get_or_register(query_id);
+                ASSERT_TRUE(tmp_query_ctx != nullptr);
+            }
+            for (int i = 0; i < 3; ++i) {
+                query_ctx->count_down_fragments();
+            }
+            ASSERT_TRUE(query_ctx->is_finished());
+            ASSERT_FALSE(query_ctx->is_dead());
+            query_ctx_mgr->remove(query_id);
+            ASSERT_TRUE(query_ctx_mgr->get(query_id) != nullptr);
+            ASSERT_FALSE(query_ctx->is_expired());
+            query_ctx->set_expire_seconds(1);
+            query_ctx->extend_lifetime();
+            sleep(2);
+            ASSERT_TRUE(query_ctx->is_expired());
+            TUniqueId query_id2;
+            query_id2.hi = 100;
+            query_id2.lo = 3;
+            query_ctx_mgr->remove(query_id2);
+            ASSERT_TRUE(query_ctx_mgr->get(query_id) == nullptr);
+        }
+    }
+}
+
+TEST(QueryContextManagerTest, testMulitiThreadOperations) {
+    auto query_ctx_mgr = std::make_shared<QueryContextManager>(0);
+    TUniqueId query_id;
+    query_id.lo = 100;
+    query_id.hi = 2;
+    auto* query_ctx = query_ctx_mgr->get_or_register(query_id);
+    query_ctx->set_total_fragments(202);
+    query_ctx->set_expire_seconds(300);
+    query_ctx->extend_lifetime();
+    query_ctx->count_down_fragments();
+    query_ctx_mgr->remove(query_id);
+    ASSERT_TRUE(query_ctx->is_finished());
+    ASSERT_FALSE(query_ctx->is_dead());
+    std::vector<std::thread> threads;
+    for (int i = 0; i < 10; ++i) {
+        threads.emplace_back([&query_ctx_mgr, &query_id]() {
+            std::random_device rd;
+            std::uniform_int_distribution<int> dist(1, 100);
+            for (int k = 0; k < 20; ++k) {
+                auto* query_ctx = query_ctx_mgr->get_or_register(query_id);
+                ASSERT_TRUE(query_ctx != nullptr);
+                ASSERT_FALSE(query_ctx->is_expired());
+                ASSERT_FALSE(query_ctx->is_dead());
+                std::this_thread::sleep_for(std::chrono::milliseconds(dist(rd)));
+                query_ctx->count_down_fragments();
+                query_ctx_mgr->remove(query_id);
+            }
+        });
+    }
+    for (int i = 0; i < 10; ++i) {
+        threads[i].join();
+    }
+
+    query_ctx = query_ctx_mgr->get_or_register(query_id);
+    query_ctx->count_down_fragments();
+    ASSERT_TRUE(query_ctx->is_dead());
+    query_ctx_mgr->remove(query_id);
+    ASSERT_TRUE(query_ctx_mgr->get(query_id) == nullptr);
+}
+} // namespace pipeline
+} // namespace starrocks


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://github.com/StarRocks/starrocks/issues/3734
## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

When FE delivers N fragment instance to BE, BE receives fist n fragment instance, so QueryContext keep n active fragment instance. when n active fragments are finished, then num_active_fragments counts down to zero, but there are still (N-n) fragments are pending on the wire, sometimes, one of the pending fragment instance is received and BE invoke QueryContextManager::instance()->get_or_register() to obtain the existing query context, but at the same moment, the query context is removed since one of pipeline executor thread to see that there are no active fragment instances in query context.

so, in this PR, two improvements are added:
1. a query context can be cleaned safely only if it receives all its fragment instances and all of its fragment instances are termintes, otherwise, the query context is moved to the second chance map to wait for its expiration. at the waiting time, if some   fragments comes, the query context would be put back into the context map. until the query context is expired, then it is removed. and the remove operation and get_or_registor operation are protected by the mutex.
2. when a query context is put into second chance map, extend its lifetime, so it can wait for late-coming fragment instances. later DescriptorTable cache PR will benifits from this mechanism.
