### PR TITLE
Fix: set scan_ranges after preparing node

### DIFF
--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -62,8 +62,6 @@ Status OlapScanNode::prepare(RuntimeState* state) {
     }
     _runtime_state = state;
 
-    RETURN_IF_ERROR(_capture_tablet_rowsets());
-
     return Status::OK();
 }
 
@@ -325,6 +323,8 @@ Status OlapScanNode::set_scan_ranges(const std::vector<TScanRangeParams>& scan_r
         _scan_ranges.emplace_back(std::make_unique<TInternalScanRange>(scan_range.scan_range.internal_scan_range));
         COUNTER_UPDATE(_tablet_counter, 1);
     }
+
+    RETURN_IF_ERROR(_capture_tablet_rowsets());
 
     return Status::OK();
 }

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -124,6 +124,7 @@ Status PlanFragmentExecutor::prepare(const TExecPlanFragmentParams& request) {
         static_cast<ExchangeNode*>(exch_node)->set_num_senders(num_senders);
     }
 
+    RETURN_IF_ERROR(_plan->prepare(_runtime_state));
     // set scan ranges
     std::vector<ExecNode*> scan_nodes;
     std::vector<TScanRangeParams> no_scan_ranges;
@@ -138,8 +139,6 @@ Status PlanFragmentExecutor::prepare(const TExecPlanFragmentParams& request) {
         scan_node->set_scan_ranges(scan_ranges);
         VLOG(1) << "scan_node_Id=" << scan_node->id() << " size=" << scan_ranges.size();
     }
-
-    RETURN_IF_ERROR(_plan->prepare(_runtime_state));
 
     _runtime_state->set_per_fragment_instance_idx(params.sender_id);
     _runtime_state->set_num_per_fragment_instances(params.num_senders);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

`OlapScanNode::set_scan_ranges` uses some variables init by `OlapScanNode::preapre`, so we must call `prepare` before `set_scan_ranges`.

The previous PR #3720 move `prepare` after `set_scan_ranges`, because `OlapScanNode::prepare()` calls `capture_tablet_rowsets`, which needs to be invoked after `set_scan_ranges`.
Therefore, we rearrange `prepare` before `set_scan_ranges`, and call `OlapScanNode::capture_tablet_rowset` in the last of `OlapScanNode::set_scan_ranges`.

