### PR TITLE
Refactor: rename ScanOperator to OlapScanOperator

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -146,7 +146,7 @@ set(EXEC_FILES
     pipeline/project_operator.cpp
     pipeline/dict_decode_operator.cpp
     pipeline/result_sink_operator.cpp
-    pipeline/scan_operator.cpp
+    pipeline/olap_scan_operator.cpp
     pipeline/select_operator.cpp
     pipeline/crossjoin/cross_join_right_sink_operator.cpp
     pipeline/crossjoin/cross_join_left_operator.cpp

--- a/be/src/exec/pipeline/olap_scan_operator.h
+++ b/be/src/exec/pipeline/olap_scan_operator.h
@@ -22,10 +22,10 @@ class RuntimeFilterProbeCollector;
 
 namespace pipeline {
 
-class ScanOperator final : public SourceOperator {
+class OlapScanOperator final : public SourceOperator {
 public:
-    ScanOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id, const TOlapScanNode& olap_scan_node,
-                 const std::vector<ExprContext*>& conjunct_ctxs, int64_t limit)
+    OlapScanOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id, const TOlapScanNode& olap_scan_node,
+                     const std::vector<ExprContext*>& conjunct_ctxs, int64_t limit)
             : SourceOperator(factory, id, "olap_scan", plan_node_id),
               _olap_scan_node(olap_scan_node),
               _conjunct_ctxs(conjunct_ctxs),
@@ -33,7 +33,7 @@ public:
               _is_io_task_running(MAX_IO_TASKS_PER_OP),
               _chunk_sources(MAX_IO_TASKS_PER_OP) {}
 
-    ~ScanOperator() override = default;
+    ~OlapScanOperator() override = default;
 
     Status prepare(RuntimeState* state) override;
 
@@ -92,22 +92,22 @@ private:
     workgroup::WorkGroupPtr _workgroup = nullptr;
 };
 
-class ScanOperatorFactory final : public SourceOperatorFactory {
+class OlapScanOperatorFactory final : public SourceOperatorFactory {
 public:
-    ScanOperatorFactory(int32_t id, int32_t plan_node_id, const TOlapScanNode& olap_scan_node,
-                        std::vector<ExprContext*>&& conjunct_ctxs, int64_t limit)
+    OlapScanOperatorFactory(int32_t id, int32_t plan_node_id, const TOlapScanNode& olap_scan_node,
+                            std::vector<ExprContext*>&& conjunct_ctxs, int64_t limit)
             : SourceOperatorFactory(id, "olap_scan", plan_node_id),
               _olap_scan_node(olap_scan_node),
               _conjunct_ctxs(std::move(conjunct_ctxs)),
               _limit(limit) {}
 
-    ~ScanOperatorFactory() override = default;
+    ~OlapScanOperatorFactory() override = default;
 
     OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override {
-        return std::make_shared<ScanOperator>(this, _id, _plan_node_id, _olap_scan_node, _conjunct_ctxs, _limit);
+        return std::make_shared<OlapScanOperator>(this, _id, _plan_node_id, _olap_scan_node, _conjunct_ctxs, _limit);
     }
 
-    // ScanOperator needs to attach MorselQueue.
+    // OlapScanOperator needs to attach MorselQueue.
     bool with_morsels() const override { return true; }
 
     Status prepare(RuntimeState* state) override;

--- a/be/src/exec/pipeline/source_operator.h
+++ b/be/src/exec/pipeline/source_operator.h
@@ -37,7 +37,7 @@ public:
             : OperatorFactory(id, name, plan_node_id) {}
     bool is_source() const override { return true; }
     // with_morsels returning true means that the SourceOperator needs attach to MorselQueue, only
-    // ScanOperator needs to do so.
+    // OlapScanOperator needs to do so.
     virtual bool with_morsels() const { return false; }
     // Set the DOP(degree of parallelism) of the SourceOperator, SourceOperator's DOP determine the Pipeline's DOP.
     virtual void set_degree_of_parallelism(size_t degree_of_parallelism) {

--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -10,8 +10,8 @@
 #include "common/global_types.h"
 #include "common/status.h"
 #include "exec/pipeline/limit_operator.h"
+#include "exec/pipeline/olap_scan_operator.h"
 #include "exec/pipeline/pipeline_builder.h"
-#include "exec/pipeline/scan_operator.h"
 #include "exec/vectorized/olap_scan_prepare.h"
 #include "exprs/expr_context.h"
 #include "exprs/vectorized/in_const_predicate.hpp"
@@ -589,20 +589,20 @@ pipeline::OpFactories OlapScanNode::decompose_to_pipeline(pipeline::PipelineBuil
     OpFactories operators;
     // Create a shared RefCountedRuntimeFilterCollector
     auto&& rc_rf_probe_collector = std::make_shared<RcRfProbeCollector>(1, std::move(this->runtime_filter_collector()));
-    auto scan_operator = std::make_shared<ScanOperatorFactory>(context->next_operator_id(), id(), _olap_scan_node,
-                                                               std::move(_conjunct_ctxs), limit());
+    auto olap_scan_operator = std::make_shared<OlapScanOperatorFactory>(
+            context->next_operator_id(), id(), _olap_scan_node, std::move(_conjunct_ctxs), limit());
     // Initialize OperatorFactory's fields involving runtime filters.
-    this->init_runtime_filter_for_operator(scan_operator.get(), context, rc_rf_probe_collector);
+    this->init_runtime_filter_for_operator(olap_scan_operator.get(), context, rc_rf_probe_collector);
     auto& morsel_queues = context->fragment_context()->morsel_queues();
-    auto source_id = scan_operator->plan_node_id();
+    auto source_id = olap_scan_operator->plan_node_id();
     DCHECK(morsel_queues.count(source_id));
     auto& morsel_queue = morsel_queues[source_id];
-    // ScanOperator's degree_of_parallelism is not more than the number of morsels
+    // OlapScanOperator's degree_of_parallelism is not more than the number of morsels
     // If table is empty, then morsel size is zero and we still set degree of parallelism to 1
     const auto degree_of_parallelism =
             std::min<size_t>(std::max<size_t>(1, morsel_queue->num_morsels()), context->degree_of_parallelism());
-    scan_operator->set_degree_of_parallelism(degree_of_parallelism);
-    operators.emplace_back(std::move(scan_operator));
+    olap_scan_operator->set_degree_of_parallelism(degree_of_parallelism);
+    operators.emplace_back(std::move(olap_scan_operator));
     if (limit() != -1) {
         operators.emplace_back(std::make_shared<LimitOperatorFactory>(context->next_operator_id(), id(), limit()));
     }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [x] others

## Problem Summary：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Since `ScanOperator` corresponds to `OlapScanNode`, which only deals with StarRocks's own storage, rename `ScanOperator` to `OlapScanOperator`

