### PR TITLE
fix be crash in passthrough logic

### DIFF
--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -373,7 +373,6 @@ void PlanFragmentExecutor::cancel() {
     if (_is_runtime_filter_merge_node) {
         _runtime_state->exec_env()->runtime_filter_worker()->close_query(_query_id);
     }
-    _runtime_state->exec_env()->stream_mgr()->destroy_pass_through_chunk_buffer(_query_id);
 }
 
 const RowDescriptor& PlanFragmentExecutor::row_desc() {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
Fixes #3749 

## Problem Summary(Required) ：
PlanFragmentExecutor::close will call destroy_pass_through_chunk_buffer.

for a query:
Fragment1 and Fragment2
Fragment1 call prepare. then pass_through ref ==1
Fragment2 call prepare and blocking. then pass_through ref == 2
cancel Fragment 1, call cancel then pass_through ref ==1, call close then pass_through ref == 0. and then pass_through released.
Fragment2 awake and coun't got a pass_through

