### PR TITLE
Fix bug CLONE is unsuccessful due to different storage medium during …

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/BackendLoadStatistic.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/BackendLoadStatistic.java
@@ -368,11 +368,10 @@ public class BackendLoadStatistic {
                                List<RootPathLoadStatistic> result, boolean isSupplement) {
         BalanceStatus status = new BalanceStatus(ErrCode.COMMON_ERROR);
         // try choosing path from first to end (low usage to high usage)
-        List<RootPathLoadStatistic> filteredPathStatistics = Lists.newArrayList();
+        List<RootPathLoadStatistic> mediumNotMatchedPath = Lists.newArrayList();
         for (RootPathLoadStatistic pathStatistic : pathStatistics) {
-            // if this is a supplement task, ignore the storage medium
-            if (!isSupplement && pathStatistic.getStorageMedium() != medium) {
-                filteredPathStatistics.add(pathStatistic);
+            if (pathStatistic.getStorageMedium() != medium) {
+                mediumNotMatchedPath.add(pathStatistic);
                 continue;
             }
 
@@ -386,8 +385,9 @@ public class BackendLoadStatistic {
             return BalanceStatus.OK;
         }
 
-        if (!Config.enable_strict_storage_medium_check) {
-            for (RootPathLoadStatistic filteredPathStatistic : filteredPathStatistics) {
+        // if this is a supplement task, ignore the storage medium
+        if (isSupplement || !Config.enable_strict_storage_medium_check) {
+            for (RootPathLoadStatistic filteredPathStatistic : mediumNotMatchedPath) {
                 BalanceStatus bStatus = filteredPathStatistic.isFit(tabletSize, isSupplement);
                 if (!bStatus.ok()) {
                     status.addErrMsgs(bStatus.getErrMsgs());

--- a/fe/fe-core/src/main/java/com/starrocks/clone/BackendLoadStatistic.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/BackendLoadStatistic.java
@@ -368,10 +368,11 @@ public class BackendLoadStatistic {
                                List<RootPathLoadStatistic> result, boolean isSupplement) {
         BalanceStatus status = new BalanceStatus(ErrCode.COMMON_ERROR);
         // try choosing path from first to end (low usage to high usage)
-        for (int i = 0; i < pathStatistics.size(); i++) {
-            RootPathLoadStatistic pathStatistic = pathStatistics.get(i);
+        List<RootPathLoadStatistic> filteredPathStatistics = Lists.newArrayList();
+        for (RootPathLoadStatistic pathStatistic : pathStatistics) {
             // if this is a supplement task, ignore the storage medium
             if (!isSupplement && pathStatistic.getStorageMedium() != medium) {
+                filteredPathStatistics.add(pathStatistic);
                 continue;
             }
 
@@ -383,6 +384,19 @@ public class BackendLoadStatistic {
 
             result.add(pathStatistic);
             return BalanceStatus.OK;
+        }
+
+        if (!Config.enable_strict_storage_medium_check) {
+            for (RootPathLoadStatistic filteredPathStatistic : filteredPathStatistics) {
+                BalanceStatus bStatus = filteredPathStatistic.isFit(tabletSize, isSupplement);
+                if (!bStatus.ok()) {
+                    status.addErrMsgs(bStatus.getErrMsgs());
+                    continue;
+                }
+
+                result.add(filteredPathStatistic);
+                return BalanceStatus.OK;
+            }
         }
         return status;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -725,8 +725,8 @@ public class TabletScheduler extends MasterDaemon {
                     tabletCtx.getTabletId());
         } catch (SchedException e) {
             if (e.getStatus() == Status.SCHEDULE_FAILED) {
-                LOG.info("failed to find version incomplete replica from tablet relocating. tablet id: {}, "
-                        + "try to find a new backend", tabletCtx.getTabletId());
+                LOG.info("failed to find version incomplete replica from tablet relocating. " +
+                        "reason : [{}], tablet id: [{}], try to find a new backend", e.getMessage(), tabletCtx.getTabletId());
                 // the dest or src slot may be taken after calling handleReplicaVersionIncomplete(),
                 // so we need to release these slots first.
                 // and reserve the tablet in TabletSchedCtx so that it can continue to be scheduled.


### PR DESCRIPTION
…DECOMMISSION operation

## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3762

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This is due to the default value of FE's configuration enable_strict_storage_medium_check is false.
But this parameter is not considered when doing clone .
So when enable_strict_storage_medium_check is true.  the same logic as before.
if enable_strict_storage_medium_check is false.
We will choose the same medium first, and if it cannot be selected, then choose those mediums that were ignored before.