### PR TITLE
opt the memory usage of memtable sort

### DIFF
--- a/be/src/column/chunk.cpp
+++ b/be/src/column/chunk.cpp
@@ -198,9 +198,10 @@ void Chunk::append_selective(const Chunk& src, const uint32_t* indexes, uint32_t
 }
 
 void Chunk::rolling_append_selective(Chunk& src, const uint32_t* indexes, uint32_t from, uint32_t size) {
-    DCHECK_EQ(_columns.size(), src.columns().size());
-    for (size_t i = 0; i < _columns.size(); ++i) {
-        _columns[i]->reserve(size);
+    size_t num_columns = _columns.size();
+    DCHECK_EQ(num_columns, src.columns().size());
+
+    for (size_t i = 0; i < num_columns; ++i) {
         _columns[i]->append_selective(*src.columns()[i].get(), indexes, from, size);
         src.columns()[i].reset();
     }

--- a/be/src/column/chunk.cpp
+++ b/be/src/column/chunk.cpp
@@ -197,6 +197,15 @@ void Chunk::append_selective(const Chunk& src, const uint32_t* indexes, uint32_t
     }
 }
 
+void Chunk::rolling_append_selective(Chunk& src, const uint32_t* indexes, uint32_t from, uint32_t size) {
+    DCHECK_EQ(_columns.size(), src.columns().size());
+    for (size_t i = 0; i < _columns.size(); ++i) {
+        _columns[i]->reserve(size);
+        _columns[i]->append_selective(*src.columns()[i].get(), indexes, from, size);
+        src.columns()[i].reset();
+    }
+}
+
 size_t Chunk::filter(const Buffer<uint8_t>& selection) {
     for (auto& column : _columns) {
         column->filter(selection);

--- a/be/src/column/chunk.h
+++ b/be/src/column/chunk.h
@@ -152,6 +152,11 @@ public:
     // This function will copy the [3, 2] row of src to this chunk.
     void append_selective(const Chunk& src, const uint32_t* indexes, uint32_t from, uint32_t size);
 
+    // This function will append data from src according to the input indexes.
+    // The columns of src chunk will be destroyed after append。
+    // Peak memory usage can be reduced when src chunk has a large number of rows and columns
+    void rolling_append_selective(Chunk& src, const uint32_t* indexes, uint32_t from, uint32_t size);
+
     // Remove rows from this chunk according to the vector |selection|.
     // The n-th row will be removed if selection[n] is zero.
     // The size of |selection| must be equal to the number of rows.

--- a/be/src/storage/vectorized/memtable.cpp
+++ b/be/src/storage/vectorized/memtable.cpp
@@ -278,7 +278,7 @@ void MemTable::_append_to_sorted_chunk(Chunk* src, Chunk* dest) {
     for (size_t i = 0; i < src->num_rows(); ++i) {
         _selective_values.push_back(_permutations[i].index_in_chunk);
     }
-    if constexpr(final) {
+    if constexpr (final) {
         dest->rolling_append_selective(*src, _selective_values.data(), 0, src->num_rows());
     } else {
         dest->append_selective(*src, _selective_values.data(), 0, src->num_rows());

--- a/be/src/storage/vectorized/memtable.h
+++ b/be/src/storage/vectorized/memtable.h
@@ -48,6 +48,7 @@ private:
     void _sort(bool is_final);
     void _sort_chunk_by_columns();
     void _sort_chunk_by_rows();
+    template <bool final>
     void _append_to_sorted_chunk(Chunk* src, Chunk* dest);
 
     void _aggregate(bool is_final);

--- a/be/src/storage/vectorized/memtable.h
+++ b/be/src/storage/vectorized/memtable.h
@@ -48,7 +48,7 @@ private:
     void _sort(bool is_final);
     void _sort_chunk_by_columns();
     void _sort_chunk_by_rows();
-    template <bool final>
+    template <bool is_final>
     void _append_to_sorted_chunk(Chunk* src, Chunk* dest);
 
     void _aggregate(bool is_final);


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3721 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Chunk::append_selective() will append all column and then return, so when chunk has many columns and rows, MemTable::sort will use a lot of memory.

The pr add one new function Chunk::rolling_append_selective, it will reserve, copy, destroy column one by one, it will save a lot of memory.

test with lineorder table of SSB (only one bucket, one memtable size limit is 100M):

before optimize: peak memory usage is 279M
after optimize: peak memory usage is 180M

