### PR TITLE
[cherry-pick 2.1]Fix bug CLONE is unsuccessful duo to different storage medium during …

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -725,8 +725,8 @@ public class TabletScheduler extends MasterDaemon {
                     tabletCtx.getTabletId());
         } catch (SchedException e) {
             if (e.getStatus() == Status.SCHEDULE_FAILED) {
-                LOG.info("failed to find version incomplete replica from tablet relocating. tablet id: {}, "
-                        + "try to find a new backend", tabletCtx.getTabletId());
+                LOG.info("failed to find version incomplete replica from tablet relocating. " +
+                        "reason : [{}], tablet id: [{}], try to find a new backend", e.getMessage(), tabletCtx.getTabletId());
                 // the dest or src slot may be taken after calling handleReplicaVersionIncomplete(),
                 // so we need to release these slots first.
                 // and reserve the tablet in TabletSchedCtx so that it can continue to be scheduled.


### PR DESCRIPTION
…… (#3763)

This is due to the default value of FE's configuration enable_strict_storage_medium_check is false.
But this parameter is not considered when doing clone .
So when enable_strict_storage_medium_check is true. the same logic as before.
if enable_strict_storage_medium_check is false.
We will choose the same medium first, and if it cannot be selected, then choose those mediums that were ignored before.

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
