### PR TITLE
Feat: implement EmptySetOperator in pipeline engine

### DIFF
--- a/be/src/exec/empty_set_node.cpp
+++ b/be/src/exec/empty_set_node.cpp
@@ -37,15 +37,7 @@ Status EmptySetNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) {
 pipeline::OpFactories EmptySetNode::decompose_to_pipeline(pipeline::PipelineBuilderContext* context) {
     using namespace pipeline;
 
-    OpFactories ops;
-    ops.emplace_back(std::make_shared<EmptySetOperatorFactory>(context->next_operator_id(), id()));
-
-    // Create a shared RefCountedRuntimeFilterCollector
-    auto&& rc_rf_probe_collector = std::make_shared<RcRfProbeCollector>(1, std::move(this->runtime_filter_collector()));
-    // Initialize OperatorFactory's fields involving runtime filters.
-    this->init_runtime_filter_for_operator(ops.back().get(), context, rc_rf_probe_collector);
-
-    return ops;
+    return OpFactories{std::make_shared<EmptySetOperatorFactory>(context->next_operator_id(), id())};
 }
 
 } // namespace starrocks

--- a/be/src/exec/empty_set_node.h
+++ b/be/src/exec/empty_set_node.h
@@ -31,6 +31,8 @@ class EmptySetNode final : public ExecNode {
 public:
     EmptySetNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs);
     Status get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) override;
+
+    pipeline::OpFactories decompose_to_pipeline(pipeline::PipelineBuilderContext* context) override;
 };
 
 } // namespace starrocks

--- a/be/src/exec/pipeline/empty_set_operator.h
+++ b/be/src/exec/pipeline/empty_set_operator.h
@@ -1,0 +1,36 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+#pragma once
+
+#include "exec/pipeline/source_operator.h"
+
+namespace starrocks::pipeline {
+
+// EmptySetOperator returns an empty result set.
+class EmptySetOperator final : public SourceOperator {
+public:
+    EmptySetOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id)
+            : SourceOperator(factory, id, "empty_set", plan_node_id) {}
+
+    ~EmptySetOperator() override = default;
+
+    bool has_output() const override { return false; }
+
+    bool is_finished() const override { return true; }
+
+    StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override {
+        return Status::InternalError("Shouldn't pull chunk from empty set operator");
+    }
+};
+
+class EmptySetOperatorFactory final : public SourceOperatorFactory {
+public:
+    EmptySetOperatorFactory(int32_t id, int32_t plan_node_id) : SourceOperatorFactory(id, "empty_set", plan_node_id) {}
+
+    ~EmptySetOperatorFactory() override = default;
+
+    OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override {
+        return std::make_shared<EmptySetOperator>(this, _id, _plan_node_id);
+    }
+};
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/operator.h
+++ b/be/src/exec/pipeline/operator.h
@@ -258,14 +258,14 @@ protected:
     const std::string _name;
     const int32_t _plan_node_id;
     std::shared_ptr<RuntimeProfile> _runtime_profile;
-    RuntimeFilterHub* _runtime_filter_hub;
+    RuntimeFilterHub* _runtime_filter_hub = nullptr;
     std::vector<TupleId> _tuple_ids;
     // a set of TPlanNodeIds of HashJoinNode who generates Local RF that take effects on this operator.
     LocalRFWaitingSet _rf_waiting_set;
     std::once_flag _prepare_runtime_in_filters_once;
     RowDescriptor _row_desc;
     std::vector<ExprContext*> _runtime_in_filters;
-    std::shared_ptr<RefCountedRuntimeFilterProbeCollector> _runtime_filter_collector;
+    std::shared_ptr<RefCountedRuntimeFilterProbeCollector> _runtime_filter_collector = nullptr;
     std::vector<SlotId> _filter_null_value_columns;
     // Mappings from input slot to output slot of ancestor exec nodes (include itself).
     // It is used to rewrite runtime in filters.

--- a/fe/fe-core/src/main/java/com/starrocks/planner/EmptySetNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/EmptySetNode.java
@@ -69,4 +69,9 @@ public class EmptySetNode extends PlanNode {
     protected void toThrift(TPlanNode msg) {
         msg.node_type = TPlanNodeType.EMPTY_SET_NODE;
     }
+
+    @Override
+    public boolean canUsePipeLine() {
+        return true;
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
The SQL in #3494 contains an empty set node, which doesn't implement in pipeline engine.

## Problem Summary：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Implement EmptySetOperator in pipeline engine. 

**Note** that it is a source operator.
