### PR TITLE
Disable help module

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/QeService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QeService.java
@@ -42,11 +42,11 @@ public class QeService {
 
     public QeService(int port, boolean nioEnabled, ConnectScheduler scheduler) {
         // Set up help module
-        try {
-            HelpModule.getInstance().setUpModule();
-        } catch (Exception e) {
-            LOG.error("Help module failed, because:", e);
-        }
+        // try {
+        //     HelpModule.getInstance().setUpModule();
+        // } catch (Exception e) {
+        //     LOG.error("Help module failed, because:", e);
+        // }
         this.port = port;
         if (nioEnabled) {
             mysqlServer = new NMysqlServer(port, scheduler);


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [x] others

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Help module has been no longer used.
Disable help module to prevent this error log bellow.
```
ERROR (UNKNOWN 172.26.92.139_9019_1640274227166(-1)|1) [QeService.<init>():48] Help module failed, because:
java.io.IOException: Can not find help zip file: help-resource.zip
        at com.starrocks.qe.HelpModule.setUpModule(HelpModule.java:267) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.QeService.<init>(QeService.java:46) [starrocks-fe.jar:?]
        at com.starrocks.StarRocksFE.start(StarRocksFE.java:118) [starrocks-fe.jar:?]
        at com.starrocks.StarRocksFE.main(StarRocksFE.java:65) [starrocks-fe.jar:?]
```
