### PR TITLE
Bugfix: remove useless host column in TabletsProcDir

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/TabletsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/TabletsProcDir.java
@@ -89,7 +89,6 @@ public class TabletsProcDir implements ProcDirInterface {
                     tabletInfo.add(-1); // replica id
                     tabletInfo.add(-1); // backend id
                     tabletInfo.add(-1); // schema hash
-                    tabletInfo.add(FeConstants.null_string); // host name
                     tabletInfo.add(-1); // version
                     tabletInfo.add(0); // version hash
                     tabletInfo.add(-1); // lst success version


### PR DESCRIPTION

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

There is no host column in the title and it is useless.
