### PR TITLE
fix issue #3785

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/ScalarOperatorToExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/ScalarOperatorToExpr.java
@@ -60,6 +60,7 @@ import java.util.stream.Collectors;
 
 public class ScalarOperatorToExpr {
     private static final Logger LOG = LogManager.getLogger(ScalarOperatorToExpr.class);
+
     public static Expr buildExecExpression(ScalarOperator expression, FormatterContext descTbl) {
         return expression.accept(new Formatter(), descTbl);
     }
@@ -255,9 +256,7 @@ public class ScalarOperatorToExpr {
         @Override
         public Expr visitInPredicate(InPredicateOperator predicate, FormatterContext context) {
             List<Expr> args = Lists.newArrayList();
-            boolean allConstant = true;
             for (int i = 1; i < predicate.getChildren().size(); ++i) {
-                allConstant &= predicate.getChild(i).isConstant();
                 args.add(buildExecExpression(predicate.getChild(i), context));
             }
 
@@ -265,21 +264,17 @@ public class ScalarOperatorToExpr {
             InPredicate expr =
                     new InPredicate(buildExecExpression(predicate.getChild(0), context), args, predicate.isNotIn());
 
-            if (allConstant) {
-                expr.setOpcode(expr.isNotIn() ? TExprOpcode.FILTER_NOT_IN : TExprOpcode.FILTER_IN);
-            } else {
-                throw new UnsupportedOperationException("in predicate could only handle constant, " + predicate);
-            }
+            expr.setOpcode(expr.isNotIn() ? TExprOpcode.FILTER_NOT_IN : TExprOpcode.FILTER_IN);
 
             expr.setType(Type.BOOLEAN);
             return expr;
         }
 
-
         static Function isNullFN = new Function(new FunctionName("is_null_pred"),
                 new Type[] {Type.INVALID}, Type.BOOLEAN, false);
         static Function isNotNullFN = new Function(new FunctionName("is_not_null_pred"),
                 new Type[] {Type.INVALID}, Type.BOOLEAN, false);
+
         {
             isNullFN.setBinaryType(TFunctionBinaryType.BUILTIN);
             isNotNullFN.setBinaryType(TFunctionBinaryType.BUILTIN);

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/JDBCTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/JDBCTableTest.java
@@ -5,16 +5,12 @@ package com.starrocks.catalog;
 import com.clearspring.analytics.util.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.common.DdlException;
-import com.sun.org.apache.bcel.internal.generic.ATHROW;
 import mockit.Expectations;
-import mockit.Mock;
 import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.internal.runners.statements.ExpectException;
 
-import java.io.*;
 import java.util.List;
 import java.util.Map;
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -5787,10 +5787,8 @@ public class PlanFragmentTest extends PlanTestBase {
 
     @Test
     public void testInPredicateNormalize() throws Exception {
-        //        connectContext.setDatabase("default_cluster:test");
-
         starRocksAssert.withTable("create table test_in_pred_norm" +
-                "(c0 INT, c1 INT, c2 INT, c3 INT) " +
+                "(c0 INT, c1 INT, c2 INT, c3 INT, c4 DATE, c5 DATE) " +
                 " duplicate key(c0) distributed by hash(c0) buckets 1 " +
                 "properties('replication_num'='1');");
 
@@ -5814,6 +5812,27 @@ public class PlanFragmentTest extends PlanTestBase {
         testPlanContains("SELECT * FROM test_in_pred_norm WHERE c0 NOT IN (0, c1) ", "1: c0 != 0, 1: c0 != 2: c1");
         testPlanContains("SELECT * FROM test_in_pred_norm WHERE c0 NOT IN (0, c1, c2) ",
                 "1: c0 != 0, 1: c0 != 2: c1, 1: c0 != 3: c2");
+
+        // contains cast expression
+        testPlanContains("SELECT * FROM test_in_pred_norm WHERE c4 IN ('1970-01-01', '1970-01-01', '1970-02-01') ",
+                "c4 IN ('1970-01-01', '1970-01-01', '1970-02-01')");
+        testPlanContains("SELECT * FROM test_in_pred_norm WHERE c4 IN ('292278994-08-17', '1970-01-01', '1970-02-01') ",
+                "c4 IN (CAST('292278994-08-17' AS DATE), '1970-01-01', '1970-02-01')");
+
+        // common expression
+        testPlanContains("SELECT " +
+                        "c4 IN ('292278994-08-17', '1970-02-01') AND " +
+                        "c5 IN ('292278994-08-17', '1970-02-01') AND " +
+                        "c5 IN ('292278994-08-17', '1970-02-01')  " +
+                        " FROM test_in_pred_norm",
+                "<slot 7> : ((5: c4 = 8: cast) OR (5: c4 = '1970-02-01')) AND ((6: c5 = 8: cast) OR (6: c5 = '1970-02-01'))");
+
+        testPlanContains("SELECT " +
+                        "c4 IN ('292278994-08-17', '1970-02-01') AND c4 IN ('292278994-08-18', '1970-02-01') AND " +
+                        "c5 IN ('292278994-08-17', '1970-02-01') AND c5 IN ('292278994-08-18', '1970-02-01') AND " +
+                        "c5 IN ('292278994-08-17', '1970-02-01') AND c5 IN ('292278994-08-17', '1970-02-01')  " +
+                        " FROM test_in_pred_norm",
+                "<slot 7> : (((5: c4 = 9: cast) OR (5: c4 = '1970-02-01')) AND ((5: c4 = 8: cast) OR (5: c4 = '1970-02-01'))) AND (((6: c5 = 9: cast) OR (6: c5 = '1970-02-01')) AND ((6: c5 = 8: cast) OR (6: c5 = '1970-02-01')))");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentTest.java
@@ -5827,12 +5827,14 @@ public class PlanFragmentTest extends PlanTestBase {
                         " FROM test_in_pred_norm",
                 "<slot 7> : ((5: c4 = 8: cast) OR (5: c4 = '1970-02-01')) AND ((6: c5 = 8: cast) OR (6: c5 = '1970-02-01'))");
 
-        testPlanContains("SELECT " +
-                        "c4 IN ('292278994-08-17', '1970-02-01') AND c4 IN ('292278994-08-18', '1970-02-01') AND " +
-                        "c5 IN ('292278994-08-17', '1970-02-01') AND c5 IN ('292278994-08-18', '1970-02-01') AND " +
-                        "c5 IN ('292278994-08-17', '1970-02-01') AND c5 IN ('292278994-08-17', '1970-02-01')  " +
-                        " FROM test_in_pred_norm",
-                "<slot 7> : (((5: c4 = 9: cast) OR (5: c4 = '1970-02-01')) AND ((5: c4 = 8: cast) OR (5: c4 = '1970-02-01'))) AND (((6: c5 = 9: cast) OR (6: c5 = '1970-02-01')) AND ((6: c5 = 8: cast) OR (6: c5 = '1970-02-01')))");
+        String plan = getFragmentPlan("SELECT " +
+                "c4 IN ('292278994-08-17', '1970-02-01') AND c4 IN ('292278994-08-18', '1970-02-01') AND " +
+                "c5 IN ('292278994-08-17', '1970-02-01') AND c5 IN ('292278994-08-18', '1970-02-01') AND " +
+                "c5 IN ('292278994-08-17', '1970-02-01') AND c5 IN ('292278994-08-17', '1970-02-01')  " +
+                " FROM test_in_pred_norm");
+        Assert.assertTrue("plan is " + plan, plan.contains("common expressions:"));
+        Assert.assertTrue("plan is \n" + plan, plan.contains("<slot 8> "));
+        Assert.assertTrue("plan is \n" + plan, plan.contains("<slot 9> "));
     }
 
     @Test


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
#3785 and #3759


## Problem Summary(Required) ：
The original expression is `x in ('123', '1970-01-01)`, NormalizePredicate recognize it as a constant expression, so do not rewrite it into conjunct expression. But following rule will add typecast to it, `x in (cast('123' as date), '1970-01-01')`, and if it contains common expression, it will be further rewritten into `x in ((slot: 8), '1970-01-01')` , which becomes an InPredicate with ColumnRef, which could not execute on BE.

## Fix
Apply the `NormalizePredicateRule` again after `ScalarOperatorsReuseRule`.



