### PR TITLE
Cache desc tbl

### DIFF
--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -60,6 +60,17 @@ public:
 
     void set_is_runtime_filter_coordinator(bool flag) { _is_runtime_filter_coordinator = flag; }
 
+    ObjectPool* object_pool() { return &_object_pool; }
+    void set_desc_tbl(DescriptorTbl* desc_tbl) {
+        DCHECK(_desc_tbl == nullptr);
+        _desc_tbl = desc_tbl;
+    }
+
+    DescriptorTbl* desc_tbl() {
+        DCHECK(_desc_tbl != nullptr);
+        return _desc_tbl;
+    }
+
 private:
     ExecEnv* _exec_env = nullptr;
     TUniqueId _query_id;
@@ -70,6 +81,8 @@ private:
     int64_t _deadline;
     seconds _expire_seconds;
     bool _is_runtime_filter_coordinator = false;
+    ObjectPool _object_pool;
+    DescriptorTbl* _desc_tbl = nullptr;
 };
 
 class QueryContextManager {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -172,6 +172,10 @@ public class PlanFragment extends TreeNode<PlanFragment> {
         }
     }
 
+    public boolean canUsePipeline() {
+        return getPlanRoot().canUsePipeLine() && getSink().canUsePipeLine();
+    }
+
     /**
      * Assign ParallelExecNum by PARALLEL_FRAGMENT_EXEC_INSTANCE_NUM in SessionVariable for synchronous request
      * Assign ParallelExecNum by default value for Asynchronous request

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -114,6 +114,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -473,79 +474,118 @@ public class Coordinator {
             boolean isEnablePipelineEngine = ConnectContext.get() != null &&
                     ConnectContext.get().getSessionVariable().isEnablePipelineEngine() &&
                     (fragments.get(0).getSink() instanceof ResultSink);
+            boolean isSelect = isEnablePipelineEngine &&
+                    ConnectContext.get() != null && ConnectContext.get().getSessionVariable().isEnableDescTblCache();
 
+            Set<TNetworkAddress> firstDeliveryAddresses = new HashSet<>();
             for (PlanFragment fragment : fragments) {
                 FragmentExecParams params = fragmentExecParamsMap.get(fragment.getFragmentId());
 
                 // set up exec states
                 int instanceNum = params.instanceExecParams.size();
                 Preconditions.checkState(instanceNum > 0);
-                List<TExecPlanFragmentParams> tParams = params.toThrift(backendId, isEnablePipelineEngine);
-                List<Pair<BackendExecState, Future<PExecPlanFragmentResult>>> futures = Lists.newArrayList();
+                List<List<FInstanceExecParam>> infightFInstanceExecParamList = new LinkedList<>();
 
-                boolean needCheckBackendState = false;
-                if (queryOptions.getQuery_type() == TQueryType.LOAD && profileFragmentId == 0) {
-                    // this is a load process, and it is the first fragment.
-                    // we should add all BackendExecState of this fragment to needCheckBackendExecStates,
-                    // so that we can check these backends' state when joining this Coordinator
-                    needCheckBackendState = true;
-                }
+                if (isSelect) {
+                    List<FInstanceExecParam> firstFInstanceParamList = new ArrayList<>();
+                    List<FInstanceExecParam> remainingFInstanceParamList = new ArrayList<>();
 
-                int instanceId = 0;
-                for (TExecPlanFragmentParams tParam : tParams) {
-                    // TODO: pool of pre-formatted BackendExecStates?
-                    BackendExecState execState = new BackendExecState(fragment.getFragmentId(), instanceId++,
-                            profileFragmentId, tParam, this.addressToBackendID);
-                    backendExecStates.add(execState);
-                    if (needCheckBackendState) {
-                        needCheckBackendExecStates.add(execState);
-                        if (LOG.isDebugEnabled()) {
-                            LOG.debug("add need check backend {} for fragment, {} job: {}", execState.backend.getId(),
-                                    fragment.getFragmentId().asInt(), jobId);
+                    for (FInstanceExecParam fInstanceExecParam : params.instanceExecParams) {
+                        if (!firstDeliveryAddresses.contains(fInstanceExecParam.host)) {
+                            firstDeliveryAddresses.add(fInstanceExecParam.host);
+                            firstFInstanceParamList.add(fInstanceExecParam);
+                        } else {
+                            remainingFInstanceParamList.add(fInstanceExecParam);
                         }
                     }
-                    futures.add(Pair.create(execState, execState.execRemoteFragmentAsync()));
-
-                    backendId++;
+                    infightFInstanceExecParamList.add(firstFInstanceParamList);
+                    infightFInstanceExecParamList.add(remainingFInstanceParamList);
+                } else {
+                    infightFInstanceExecParamList.add(params.instanceExecParams);
                 }
-                for (Pair<BackendExecState, Future<PExecPlanFragmentResult>> pair : futures) {
-                    TStatusCode code;
-                    String errMsg = null;
-                    try {
-                        PExecPlanFragmentResult result = pair.second.get(queryOptions.query_timeout * 1000L,
-                                TimeUnit.MILLISECONDS);
-                        code = TStatusCode.findByValue(result.status.statusCode);
-                        if (result.status.errorMsgs != null && !result.status.errorMsgs.isEmpty()) {
-                            errMsg = result.status.errorMsgs.get(0);
-                        }
-                    } catch (ExecutionException e) {
-                        LOG.warn("catch a execute exception", e);
-                        code = TStatusCode.THRIFT_RPC_ERROR;
-                    } catch (InterruptedException e) {
-                        LOG.warn("catch a interrupt exception", e);
-                        code = TStatusCode.INTERNAL_ERROR;
-                    } catch (TimeoutException e) {
-                        LOG.warn("catch a timeout exception", e);
-                        code = TStatusCode.TIMEOUT;
+
+                boolean isFirst = true;
+                for (List<FInstanceExecParam> fInstanceExecParamList : infightFInstanceExecParamList) {
+                    TDescriptorTable descTable = new TDescriptorTable();
+                    descTable.setIs_cached(true);
+                    descTable.setTupleDescriptors(Collections.emptyList());
+                    if (isFirst) {
+                        descTable = this.descTable;
+                        isFirst = false;
                     }
 
-                    if (code != TStatusCode.OK) {
-                        if (errMsg == null) {
-                            errMsg = "exec rpc error. backend id: " + pair.first.backend.getId();
+                    if (fInstanceExecParamList.isEmpty()) {
+                        continue;
+                    }
+
+                    List<TExecPlanFragmentParams> tParams = params.toThrift(backendId,
+                            fInstanceExecParamList, descTable, isEnablePipelineEngine);
+                    List<Pair<BackendExecState, Future<PExecPlanFragmentResult>>> futures = Lists.newArrayList();
+
+                    boolean needCheckBackendState = false;
+                    if (queryOptions.getQuery_type() == TQueryType.LOAD && profileFragmentId == 0) {
+                        // this is a load process, and it is the first fragment.
+                        // we should add all BackendExecState of this fragment to needCheckBackendExecStates,
+                        // so that we can check these backends' state when joining this Coordinator
+                        needCheckBackendState = true;
+                    }
+
+                    int instanceId = 0;
+                    for (TExecPlanFragmentParams tParam : tParams) {
+                        // TODO: pool of pre-formatted BackendExecStates?
+                        BackendExecState execState = new BackendExecState(fragment.getFragmentId(), instanceId++,
+                                profileFragmentId, tParam, this.addressToBackendID);
+                        backendExecStates.add(execState);
+                        if (needCheckBackendState) {
+                            needCheckBackendExecStates.add(execState);
+                            if (LOG.isDebugEnabled()) {
+                                LOG.debug("add need check backend {} for fragment, {} job: {}", execState.backend.getId(),
+                                        fragment.getFragmentId().asInt(), jobId);
+                            }
                         }
-                        queryStatus.setStatus(errMsg);
-                        LOG.warn("exec plan fragment failed, errmsg={}, code: {}, fragmentId={}, backend={}:{}",
-                                errMsg, code, fragment.getFragmentId(),
-                                pair.first.address.hostname, pair.first.address.port);
-                        cancelInternal(PPlanFragmentCancelReason.INTERNAL_ERROR);
-                        switch (Objects.requireNonNull(code)) {
-                            case TIMEOUT:
-                                throw new UserException("query timeout. backend id: " + pair.first.backend.getId());
-                            case THRIFT_RPC_ERROR:
-                                SimpleScheduler.addToBlacklist(pair.first.backend.getId());
-                                throw new RpcException(pair.first.backend.getHost(), "rpc failed");
-                            default:
-                                throw new UserException(errMsg);
+                        futures.add(Pair.create(execState, execState.execRemoteFragmentAsync()));
+
+                        backendId++;
+                    }
+                    for (Pair<BackendExecState, Future<PExecPlanFragmentResult>> pair : futures) {
+                        TStatusCode code;
+                        String errMsg = null;
+                        try {
+                            PExecPlanFragmentResult result = pair.second.get(queryOptions.query_timeout * 1000L,
+                                    TimeUnit.MILLISECONDS);
+                            code = TStatusCode.findByValue(result.status.statusCode);
+                            if (result.status.errorMsgs != null && !result.status.errorMsgs.isEmpty()) {
+                                errMsg = result.status.errorMsgs.get(0);
+                            }
+                        } catch (ExecutionException e) {
+                            LOG.warn("catch a execute exception", e);
+                            code = TStatusCode.THRIFT_RPC_ERROR;
+                        } catch (InterruptedException e) {
+                            LOG.warn("catch a interrupt exception", e);
+                            code = TStatusCode.INTERNAL_ERROR;
+                        } catch (TimeoutException e) {
+                            LOG.warn("catch a timeout exception", e);
+                            code = TStatusCode.TIMEOUT;
+                        }
+
+                        if (code != TStatusCode.OK) {
+                            if (errMsg == null) {
+                                errMsg = "exec rpc error. backend id: " + pair.first.backend.getId();
+                            }
+                            queryStatus.setStatus(errMsg);
+                            LOG.warn("exec plan fragment failed, errmsg={}, code: {}, fragmentId={}, backend={}:{}",
+                                    errMsg, code, fragment.getFragmentId(),
+                                    pair.first.address.hostname, pair.first.address.port);
+                            cancelInternal(PPlanFragmentCancelReason.INTERNAL_ERROR);
+                            switch (Objects.requireNonNull(code)) {
+                                case TIMEOUT:
+                                    throw new UserException("query timeout. backend id: " + pair.first.backend.getId());
+                                case THRIFT_RPC_ERROR:
+                                    SimpleScheduler.addToBlacklist(pair.first.backend.getId());
+                                    throw new RpcException(pair.first.backend.getHost(), "rpc failed");
+                                default:
+                                    throw new UserException(errMsg);
+                            }
                         }
                     }
                 }
@@ -1923,7 +1963,10 @@ public class Coordinator {
             this.fragment = fragment;
         }
 
-        List<TExecPlanFragmentParams> toThrift(int backendNum, boolean isEnablePipelineEngine) throws Exception {
+        List<TExecPlanFragmentParams> toThrift(int backendNum,
+                                               List<FInstanceExecParam> fInstanceExecParamList,
+                                               TDescriptorTable descTable,
+                                               boolean isEnablePipelineEngine) throws Exception {
             // add instance number in file name prefix when export job
             DataSink sink = fragment.getSink();
             ExportSink exportSink = null;
@@ -1944,12 +1987,13 @@ public class Coordinator {
             }
 
             List<TExecPlanFragmentParams> paramsList = Lists.newArrayList();
-            for (int i = 0; i < instanceExecParams.size(); ++i) {
-                final FInstanceExecParam instanceExecParam = instanceExecParams.get(i);
+            int startIdx = backendNum;
+            for (int i = 0; i < fInstanceExecParamList.size(); ++i) {
+                final FInstanceExecParam instanceExecParam = fInstanceExecParamList.get(i);
                 TExecPlanFragmentParams params = new TExecPlanFragmentParams();
 
                 if (exportSink != null && fileNamePrefix != null) {
-                    exportSink.setFileNamePrefix(fileNamePrefix + i + "_");
+                    exportSink.setFileNamePrefix(fileNamePrefix + (startIdx + i) + "_");
                 }
 
                 params.setProtocol_version(InternalServiceVersion.V1);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -474,7 +474,7 @@ public class Coordinator {
             boolean isEnablePipelineEngine = ConnectContext.get() != null &&
                     ConnectContext.get().getSessionVariable().isEnablePipelineEngine() &&
                     (fragments.get(0).getSink() instanceof ResultSink);
-            boolean isSelect = isEnablePipelineEngine &&
+            boolean isEnableDescTblCache = isEnablePipelineEngine &&
                     ConnectContext.get() != null && ConnectContext.get().getSessionVariable().isEnableDescTblCache();
 
             Set<TNetworkAddress> firstDeliveryAddresses = new HashSet<>();
@@ -486,7 +486,7 @@ public class Coordinator {
                 Preconditions.checkState(instanceNum > 0);
                 List<List<FInstanceExecParam>> infightFInstanceExecParamList = new LinkedList<>();
 
-                if (isSelect) {
+                if (isEnableDescTblCache) {
                     List<FInstanceExecParam> firstFInstanceParamList = new ArrayList<>();
                     List<FInstanceExecParam> remainingFInstanceParamList = new ArrayList<>();
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -189,8 +189,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String SINGLE_NODE_EXEC_PLAN = "single_node_exec_plan";
 
-    public static final String ENABLE_DESC_TBL_CACHE = "enable_desc_tbl_cache";
-
     @VariableMgr.VarAttr(name = ENABLE_PIPELINE_ENGINE)
     private boolean enablePipelineEngine = false;
 
@@ -484,13 +482,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = SINGLE_NODE_EXEC_PLAN, flag = VariableMgr.INVISIBLE)
     private boolean singleNodeExecPlan = false;
-
-    @VariableMgr.VarAttr(name = ENABLE_DESC_TBL_CACHE)
-    private boolean enableDescTblCache = false;
-
-    public boolean isEnableDescTblCache() {
-        return enableDescTblCache;
-    }
 
     public long getMaxExecMemByte() {
         return maxExecMemByte;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -189,6 +189,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String SINGLE_NODE_EXEC_PLAN = "single_node_exec_plan";
 
+    public static final String ENABLE_DESC_TBL_CACHE = "enable_desc_tbl_cache";
+
     @VariableMgr.VarAttr(name = ENABLE_PIPELINE_ENGINE)
     private boolean enablePipelineEngine = false;
 
@@ -482,6 +484,13 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = SINGLE_NODE_EXEC_PLAN, flag = VariableMgr.INVISIBLE)
     private boolean singleNodeExecPlan = false;
+
+    @VariableMgr.VarAttr(name = ENABLE_DESC_TBL_CACHE)
+    private boolean enableDescTblCache = false;
+
+    public boolean isEnableDescTblCache() {
+        return enableDescTblCache;
+    }
 
     public long getMaxExecMemByte() {
         return maxExecMemByte;

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -365,4 +365,5 @@ struct TDescriptorTable {
 
   // all table descriptors referenced by tupleDescriptors
   3: optional list<TTableDescriptor> tableDescriptors;
+  4: optional bool is_cached;
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

https://github.com/StarRocks/starrocks/issues/3622
## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

In the previous PR that has been reverted, FE will deliver fragment instances to wrong be, because instances belonging to the same Fragment are splited into two sets, a temporary counter instanceId is used to determine which BE  the instance is sent to,   the instanceId assigned to the fragment instance should be the ordinal of this fragment instance in the FragmentExecParams.instanceExecParams, but the previous PR cannot guarantee this facts. so use of instanceId2host map instead, FE looks up the right BE' host by fragment instanceId.