### PR TITLE
Change returned type of Operator::close from Status to void

### DIFF
--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.cpp
@@ -12,9 +12,9 @@ Status AggregateBlockingSinkOperator::prepare(RuntimeState* state) {
     return _aggregator->open(state);
 }
 
-Status AggregateBlockingSinkOperator::close(RuntimeState* state) {
-    RETURN_IF_ERROR(_aggregator->unref(state));
-    return Operator::close(state);
+void AggregateBlockingSinkOperator::close(RuntimeState* state) {
+    _aggregator->unref(state);
+    Operator::close(state);
 }
 
 void AggregateBlockingSinkOperator::set_finishing(RuntimeState* state) {

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.h
@@ -23,7 +23,7 @@ public:
     void set_finishing(RuntimeState* state) override;
 
     Status prepare(RuntimeState* state) override;
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
     Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override;

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.cpp
@@ -18,9 +18,9 @@ void AggregateBlockingSourceOperator::set_finished(RuntimeState* state) {
     _aggregator->set_finished();
 }
 
-Status AggregateBlockingSourceOperator::close(RuntimeState* state) {
-    RETURN_IF_ERROR(_aggregator->unref(state));
-    return SourceOperator::close(state);
+void AggregateBlockingSourceOperator::close(RuntimeState* state) {
+    _aggregator->unref(state);
+    SourceOperator::close(state);
 }
 
 StatusOr<vectorized::ChunkPtr> AggregateBlockingSourceOperator::pull_chunk(RuntimeState* state) {

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.h
@@ -24,7 +24,7 @@ public:
 
     void set_finished(RuntimeState* state) override;
 
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.cpp
@@ -12,9 +12,9 @@ Status AggregateDistinctBlockingSinkOperator::prepare(RuntimeState* state) {
     return _aggregator->open(state);
 }
 
-Status AggregateDistinctBlockingSinkOperator::close(RuntimeState* state) {
-    RETURN_IF_ERROR(_aggregator->unref(state));
-    return Operator::close(state);
+void AggregateDistinctBlockingSinkOperator::close(RuntimeState* state) {
+    _aggregator->unref(state);
+    Operator::close(state);
 }
 
 void AggregateDistinctBlockingSinkOperator::set_finishing(RuntimeState* state) {

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.h
@@ -25,7 +25,7 @@ public:
     void set_finishing(RuntimeState* state) override;
 
     Status prepare(RuntimeState* state) override;
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
     Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override;

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.cpp
@@ -18,9 +18,9 @@ void AggregateDistinctBlockingSourceOperator::set_finished(RuntimeState* state) 
     _aggregator->set_finished();
 }
 
-Status AggregateDistinctBlockingSourceOperator::close(RuntimeState* state) {
-    RETURN_IF_ERROR(_aggregator->unref(state));
-    return SourceOperator::close(state);
+void AggregateDistinctBlockingSourceOperator::close(RuntimeState* state) {
+    _aggregator->unref(state);
+    SourceOperator::close(state);
 }
 
 StatusOr<vectorized::ChunkPtr> AggregateDistinctBlockingSourceOperator::pull_chunk(RuntimeState* state) {

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.h
@@ -24,7 +24,7 @@ public:
 
     void set_finished(RuntimeState* state) override;
 
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.cpp
@@ -12,9 +12,9 @@ Status AggregateDistinctStreamingSinkOperator::prepare(RuntimeState* state) {
     return _aggregator->open(state);
 }
 
-Status AggregateDistinctStreamingSinkOperator::close(RuntimeState* state) {
-    RETURN_IF_ERROR(_aggregator->unref(state));
-    return Operator::close(state);
+void AggregateDistinctStreamingSinkOperator::close(RuntimeState* state) {
+    _aggregator->unref(state);
+    Operator::close(state);
 }
 
 void AggregateDistinctStreamingSinkOperator::set_finishing(RuntimeState* state) {

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.h
@@ -25,7 +25,7 @@ public:
     void set_finishing(RuntimeState* state) override;
 
     Status prepare(RuntimeState* state) override;
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
     Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override;

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.cpp
@@ -33,9 +33,9 @@ void AggregateDistinctStreamingSourceOperator::set_finished(RuntimeState* state)
     _aggregator->set_finished();
 }
 
-Status AggregateDistinctStreamingSourceOperator::close(RuntimeState* state) {
-    RETURN_IF_ERROR(_aggregator->unref(state));
-    return SourceOperator::close(state);
+void AggregateDistinctStreamingSourceOperator::close(RuntimeState* state) {
+    _aggregator->unref(state);
+    SourceOperator::close(state);
 }
 
 StatusOr<vectorized::ChunkPtr> AggregateDistinctStreamingSourceOperator::pull_chunk(RuntimeState* state) {

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.h
@@ -24,7 +24,7 @@ public:
 
     void set_finished(RuntimeState* state) override;
 
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
@@ -12,9 +12,9 @@ Status AggregateStreamingSinkOperator::prepare(RuntimeState* state) {
     return _aggregator->open(state);
 }
 
-Status AggregateStreamingSinkOperator::close(RuntimeState* state) {
-    RETURN_IF_ERROR(_aggregator->unref(state));
-    return Operator::close(state);
+void AggregateStreamingSinkOperator::close(RuntimeState* state) {
+    _aggregator->unref(state);
+    Operator::close(state);
 }
 
 void AggregateStreamingSinkOperator::set_finishing(RuntimeState* state) {

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.h
@@ -23,7 +23,7 @@ public:
     void set_finishing(RuntimeState* state) override;
 
     Status prepare(RuntimeState* state) override;
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
     Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override;

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.cpp
@@ -51,9 +51,9 @@ void AggregateStreamingSourceOperator::set_finished(RuntimeState* state) {
     _aggregator->set_finished();
 }
 
-Status AggregateStreamingSourceOperator::close(RuntimeState* state) {
-    RETURN_IF_ERROR(_aggregator->unref(state));
-    return SourceOperator::close(state);
+void AggregateStreamingSourceOperator::close(RuntimeState* state) {
+    _aggregator->unref(state);
+    SourceOperator::close(state);
 }
 
 StatusOr<vectorized::ChunkPtr> AggregateStreamingSourceOperator::pull_chunk(RuntimeState* state) {

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.h
@@ -24,7 +24,7 @@ public:
     void set_finishing(RuntimeState* state) override;
     void set_finished(RuntimeState* state) override;
 
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/analysis/analytic_sink_operator.cpp
+++ b/be/src/exec/pipeline/analysis/analytic_sink_operator.cpp
@@ -38,9 +38,9 @@ Status AnalyticSinkOperator::prepare(RuntimeState* state) {
     return Status::OK();
 }
 
-Status AnalyticSinkOperator::close(RuntimeState* state) {
-    RETURN_IF_ERROR(_analytor->unref(state));
-    return Operator::close(state);
+void AnalyticSinkOperator::close(RuntimeState* state) {
+    _analytor->unref(state);
+    Operator::close(state);
 }
 
 void AnalyticSinkOperator::set_finishing(RuntimeState* state) {

--- a/be/src/exec/pipeline/analysis/analytic_sink_operator.h
+++ b/be/src/exec/pipeline/analysis/analytic_sink_operator.h
@@ -21,7 +21,7 @@ public:
     void set_finishing(RuntimeState* state) override;
 
     Status prepare(RuntimeState* state) override;
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
     Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override;

--- a/be/src/exec/pipeline/analysis/analytic_source_operator.cpp
+++ b/be/src/exec/pipeline/analysis/analytic_source_operator.cpp
@@ -16,9 +16,9 @@ void AnalyticSourceOperator::set_finished(RuntimeState* state) {
     _analytor->set_finished();
 }
 
-Status AnalyticSourceOperator::close(RuntimeState* state) {
-    RETURN_IF_ERROR(_analytor->unref(state));
-    return SourceOperator::close(state);
+void AnalyticSourceOperator::close(RuntimeState* state) {
+    _analytor->unref(state);
+    SourceOperator::close(state);
 }
 
 StatusOr<vectorized::ChunkPtr> AnalyticSourceOperator::pull_chunk(RuntimeState* state) {

--- a/be/src/exec/pipeline/analysis/analytic_source_operator.h
+++ b/be/src/exec/pipeline/analysis/analytic_source_operator.h
@@ -21,7 +21,7 @@ public:
 
     void set_finished(RuntimeState* state) override;
 
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/assert_num_rows_operator.cpp
+++ b/be/src/exec/pipeline/assert_num_rows_operator.cpp
@@ -24,8 +24,8 @@ Status AssertNumRowsOperator::prepare(RuntimeState* state) {
     return Status::OK();
 }
 
-Status AssertNumRowsOperator::close(RuntimeState* state) {
-    return Operator::close(state);
+void AssertNumRowsOperator::close(RuntimeState* state) {
+    Operator::close(state);
 }
 
 StatusOr<vectorized::ChunkPtr> AssertNumRowsOperator::pull_chunk(RuntimeState* state) {

--- a/be/src/exec/pipeline/assert_num_rows_operator.h
+++ b/be/src/exec/pipeline/assert_num_rows_operator.h
@@ -31,7 +31,7 @@ public:
 
     Status prepare(RuntimeState* state) override;
 
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
 
     bool has_output() const override;
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;

--- a/be/src/exec/pipeline/chunk_source.h
+++ b/be/src/exec/pipeline/chunk_source.h
@@ -23,7 +23,7 @@ public:
 
     virtual Status prepare(RuntimeState* state) = 0;
 
-    virtual Status close(RuntimeState* state) = 0;
+    virtual void close(RuntimeState* state) = 0;
 
     // Return true if eos is not reached
     // Return false if eos is reached or error occurred

--- a/be/src/exec/pipeline/context_with_dependency.h
+++ b/be/src/exec/pipeline/context_with_dependency.h
@@ -30,7 +30,7 @@ public:
     // For pipeline, it is called by unref() when the last operator is unreffed.
     // For non-pipeline, it is called by close() of the exec node directly
     // without calling ref and unref. For example, AggregateBaseNode uses Aggregator.
-    virtual Status close(RuntimeState* state) = 0;
+    virtual void close(RuntimeState* state) = 0;
 
     // ref and unref are used to close context
     // when the last running related operator is closed.
@@ -41,11 +41,10 @@ public:
     void ref() { _num_running_operators.fetch_add(1, std::memory_order_relaxed); }
 
     // Called by operator::close. Close the context when the last running operator is closed.
-    Status unref(RuntimeState* state) {
+    void unref(RuntimeState* state) {
         if (_num_running_operators.fetch_sub(1, std::memory_order_acq_rel) == 1) {
-            return close(state);
+            close(state);
         }
-        return Status::OK();
     }
 
     // When the output operator is finished, the context can be finished regardless of other running operators.

--- a/be/src/exec/pipeline/crossjoin/cross_join_context.h
+++ b/be/src/exec/pipeline/crossjoin/cross_join_context.h
@@ -16,7 +16,7 @@ public:
     explicit CrossJoinContext(const int32_t num_right_sinkers)
             : _num_right_sinkers(num_right_sinkers), _build_chunks(num_right_sinkers) {}
 
-    Status close(RuntimeState* state) override { return Status::OK(); }
+    void close(RuntimeState* state) override {}
 
     bool is_build_chunk_empty() const {
         return std::all_of(_build_chunks.begin(), _build_chunks.end(),

--- a/be/src/exec/pipeline/crossjoin/cross_join_left_operator.h
+++ b/be/src/exec/pipeline/crossjoin/cross_join_left_operator.h
@@ -30,9 +30,9 @@ public:
 
     ~CrossJoinLeftOperator() override = default;
 
-    Status close(RuntimeState* state) override {
-        RETURN_IF_ERROR(_cross_join_context->unref(state));
-        return Operator::close(state);
+    void close(RuntimeState* state) override {
+        _cross_join_context->unref(state);
+        Operator::close(state);
     }
 
     bool is_ready() const override { return _cross_join_context->is_right_finished(); }

--- a/be/src/exec/pipeline/crossjoin/cross_join_right_sink_operator.h
+++ b/be/src/exec/pipeline/crossjoin/cross_join_right_sink_operator.h
@@ -23,9 +23,9 @@ public:
 
     ~CrossJoinRightSinkOperator() override = default;
 
-    Status close(RuntimeState* state) override {
-        RETURN_IF_ERROR(_cross_join_context->unref(state));
-        return Operator::close(state);
+    void close(RuntimeState* state) override {
+        _cross_join_context->unref(state);
+        Operator::close(state);
     }
 
     bool has_output() const override { return false; }

--- a/be/src/exec/pipeline/dict_decode_operator.cpp
+++ b/be/src/exec/pipeline/dict_decode_operator.cpp
@@ -12,9 +12,8 @@ Status DictDecodeOperator::prepare(RuntimeState* state) {
     return Status::OK();
 }
 
-Status DictDecodeOperator::close(RuntimeState* state) {
+void DictDecodeOperator::close(RuntimeState* state) {
     Operator::close(state);
-    return Status::OK();
 }
 
 StatusOr<vectorized::ChunkPtr> DictDecodeOperator::pull_chunk(RuntimeState* state) {

--- a/be/src/exec/pipeline/dict_decode_operator.h
+++ b/be/src/exec/pipeline/dict_decode_operator.h
@@ -33,7 +33,7 @@ public:
 
     Status prepare(RuntimeState* state) override;
 
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
 
     bool has_output() const override { return _cur_chunk != nullptr; }
 

--- a/be/src/exec/pipeline/exchange/exchange_merge_sort_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_merge_sort_source_operator.cpp
@@ -22,9 +22,8 @@ Status ExchangeMergeSortSourceOperator::prepare(RuntimeState* state) {
     return Status::OK();
 }
 
-Status ExchangeMergeSortSourceOperator::close(RuntimeState* state) {
+void ExchangeMergeSortSourceOperator::close(RuntimeState* state) {
     Operator::close(state);
-    return Status::OK();
 }
 
 bool ExchangeMergeSortSourceOperator::has_output() const {

--- a/be/src/exec/pipeline/exchange/exchange_merge_sort_source_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_merge_sort_source_operator.h
@@ -30,7 +30,7 @@ public:
 
     Status prepare(RuntimeState* state) override;
 
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
 
     bool has_output() const override;
 

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -541,8 +541,8 @@ void ExchangeSinkOperator::set_finishing(RuntimeState* state) {
     }
 }
 
-Status ExchangeSinkOperator::close(RuntimeState* state) {
-    return Operator::close(state);
+void ExchangeSinkOperator::close(RuntimeState* state) {
+    Operator::close(state);
 }
 
 Status ExchangeSinkOperator::serialize_chunk(const vectorized::Chunk* src, ChunkPB* dst, bool* is_first_chunk,

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.h
@@ -41,7 +41,7 @@ public:
 
     Status prepare(RuntimeState* state) override;
 
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
 
     bool has_output() const override { return false; }
 

--- a/be/src/exec/pipeline/hashjoin/hash_join_build_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/hash_join_build_operator.cpp
@@ -33,13 +33,13 @@ Status HashJoinBuildOperator::prepare(RuntimeState* state) {
 
     return _join_builder->prepare(state);
 }
-Status HashJoinBuildOperator::close(RuntimeState* state) {
+void HashJoinBuildOperator::close(RuntimeState* state) {
     for (auto& read_only_join_prober : _read_only_join_probers) {
-        RETURN_IF_ERROR(read_only_join_prober->unref(state));
+        read_only_join_prober->unref(state);
     }
-    RETURN_IF_ERROR(_join_builder->unref(state));
+    _join_builder->unref(state);
 
-    return Operator::close(state);
+    Operator::close(state);
 }
 
 StatusOr<vectorized::ChunkPtr> HashJoinBuildOperator::pull_chunk(RuntimeState* state) {

--- a/be/src/exec/pipeline/hashjoin/hash_join_build_operator.h
+++ b/be/src/exec/pipeline/hashjoin/hash_join_build_operator.h
@@ -27,7 +27,7 @@ public:
     ~HashJoinBuildOperator() override = default;
 
     Status prepare(RuntimeState* state) override;
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
 
     bool has_output() const override {
         CHECK(false) << "has_output not supported in HashJoinBuildOperator";

--- a/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.cpp
@@ -12,13 +12,13 @@ HashJoinProbeOperator::HashJoinProbeOperator(OperatorFactory* factory, int32_t i
           _join_prober(std::move(join_prober)),
           _join_builder(std::move(join_builder)) {}
 
-Status HashJoinProbeOperator::close(RuntimeState* state) {
-    RETURN_IF_ERROR(_join_prober->unref(state));
+void HashJoinProbeOperator::close(RuntimeState* state) {
+    _join_prober->unref(state);
     if (_join_builder != _join_prober) {
-        RETURN_IF_ERROR(_join_builder->unref(state));
+        _join_builder->unref(state);
     }
 
-    return OperatorWithDependency::close(state);
+    OperatorWithDependency::close(state);
 }
 
 Status HashJoinProbeOperator::prepare(RuntimeState* state) {

--- a/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.h
+++ b/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.h
@@ -21,7 +21,7 @@ public:
 
     Status prepare(RuntimeState* state) override;
 
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
 
     bool has_output() const override;
     bool need_input() const override;

--- a/be/src/exec/pipeline/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/olap_chunk_source.cpp
@@ -445,13 +445,12 @@ Status OlapChunkSource::_read_chunk_from_storage(RuntimeState* state, vectorized
     return Status::OK();
 }
 
-Status OlapChunkSource::close(RuntimeState* state) {
+void OlapChunkSource::close(RuntimeState* state) {
     _update_counter();
     _prj_iter->close();
     _reader.reset();
     _predicate_free_pool.clear();
     _dict_optimize_parser.close(state);
-    return Status::OK();
 }
 
 void OlapChunkSource::_update_realtime_counter(vectorized::Chunk* chunk) {

--- a/be/src/exec/pipeline/olap_chunk_source.h
+++ b/be/src/exec/pipeline/olap_chunk_source.h
@@ -36,7 +36,7 @@ public:
 
     Status prepare(RuntimeState* state) override;
 
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
 
     bool has_next_chunk() const override;
 

--- a/be/src/exec/pipeline/operator.cpp
+++ b/be/src/exec/pipeline/operator.cpp
@@ -65,7 +65,7 @@ RuntimeFilterHub* Operator::runtime_filter_hub() {
     return _factory->runtime_filter_hub();
 }
 
-Status Operator::close(RuntimeState* state) {
+void Operator::close(RuntimeState* state) {
     if (auto* rf_bloom_filters = runtime_bloom_filters()) {
         _init_rf_counters(false);
         _runtime_in_filter_num_counter->set((int64_t)runtime_in_filters().size());
@@ -76,7 +76,6 @@ Status Operator::close(RuntimeState* state) {
     _runtime_profile->total_time_counter()->set(0L);
     _common_metrics->total_time_counter()->set(0L);
     _unique_metrics->total_time_counter()->set(0L);
-    return Status::OK();
 }
 
 std::vector<ExprContext*>& Operator::runtime_in_filters() {

--- a/be/src/exec/pipeline/operator.h
+++ b/be/src/exec/pipeline/operator.h
@@ -72,7 +72,7 @@ public:
     // close is used to do the cleanup work
     // It's one of the stages of the operator life cycle（prepare -> finishing -> finished -> [cancelled] -> closed)
     // This method will be exactly invoked once in the whole life cycle
-    virtual Status close(RuntimeState* state);
+    virtual void close(RuntimeState* state);
 
     // Whether we could pull chunk from this operator
     virtual bool has_output() const = 0;

--- a/be/src/exec/pipeline/project_operator.cpp
+++ b/be/src/exec/pipeline/project_operator.cpp
@@ -14,8 +14,8 @@ Status ProjectOperator::prepare(RuntimeState* state) {
     return Operator::prepare(state);
 }
 
-Status ProjectOperator::close(RuntimeState* state) {
-    return Operator::close(state);
+void ProjectOperator::close(RuntimeState* state) {
+    Operator::close(state);
 }
 
 StatusOr<vectorized::ChunkPtr> ProjectOperator::pull_chunk(RuntimeState* state) {

--- a/be/src/exec/pipeline/project_operator.h
+++ b/be/src/exec/pipeline/project_operator.h
@@ -25,7 +25,7 @@ public:
 
     Status prepare(RuntimeState* state) override;
 
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
 
     bool has_output() const override { return _cur_chunk != nullptr; }
 

--- a/be/src/exec/pipeline/result_sink_operator.cpp
+++ b/be/src/exec/pipeline/result_sink_operator.cpp
@@ -30,7 +30,7 @@ Status ResultSinkOperator::prepare(RuntimeState* state) {
     return Status::OK();
 }
 
-Status ResultSinkOperator::close(RuntimeState* state) {
+void ResultSinkOperator::close(RuntimeState* state) {
     Status st;
     // Close the writer
     if (_writer != nullptr) {
@@ -57,7 +57,6 @@ Status ResultSinkOperator::close(RuntimeState* state) {
     }
 
     Operator::close(state);
-    return Status::OK();
 }
 
 StatusOr<vectorized::ChunkPtr> ResultSinkOperator::pull_chunk(RuntimeState* state) {

--- a/be/src/exec/pipeline/result_sink_operator.h
+++ b/be/src/exec/pipeline/result_sink_operator.h
@@ -33,7 +33,7 @@ public:
 
     Status prepare(RuntimeState* state) override;
 
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
 
     // Result sink will send result chunk to BufferControlBlock directly,
     // Then FE will pull result from BufferControlBlock

--- a/be/src/exec/pipeline/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan_operator.cpp
@@ -42,7 +42,7 @@ Status ScanOperator::prepare(RuntimeState* state) {
     return Status::OK();
 }
 
-Status ScanOperator::close(RuntimeState* state) {
+void ScanOperator::close(RuntimeState* state) {
     DCHECK(_num_running_io_tasks == 0);
 
     if (_workgroup == nullptr) {
@@ -56,7 +56,7 @@ Status ScanOperator::close(RuntimeState* state) {
     }
 
     do_close(state);
-    return Operator::close(state);
+    Operator::close(state);
 }
 
 bool ScanOperator::has_output() const {

--- a/be/src/exec/pipeline/scan_operator.h
+++ b/be/src/exec/pipeline/scan_operator.h
@@ -20,7 +20,7 @@ public:
 
     Status prepare(RuntimeState* state) override;
 
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
 
     bool has_output() const override;
 

--- a/be/src/exec/pipeline/select_operator.cpp
+++ b/be/src/exec/pipeline/select_operator.cpp
@@ -12,8 +12,8 @@ Status SelectOperator::prepare(RuntimeState* state) {
     return Operator::prepare(state);
 }
 
-Status SelectOperator::close(RuntimeState* state) {
-    return Operator::close(state);
+void SelectOperator::close(RuntimeState* state) {
+    Operator::close(state);
 }
 
 StatusOr<vectorized::ChunkPtr> SelectOperator::pull_chunk(RuntimeState* state) {

--- a/be/src/exec/pipeline/select_operator.h
+++ b/be/src/exec/pipeline/select_operator.h
@@ -18,7 +18,7 @@ public:
 
     ~SelectOperator() override = default;
     Status prepare(RuntimeState* state) override;
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
     bool has_output() const override { return _curr_chunk != nullptr || _pre_output_chunk != nullptr; }
     bool need_input() const override;
     bool is_finished() const override { return _is_finished && !_curr_chunk && !_pre_output_chunk; }

--- a/be/src/exec/pipeline/set/except_build_sink_operator.cpp
+++ b/be/src/exec/pipeline/set/except_build_sink_operator.cpp
@@ -18,9 +18,9 @@ Status ExceptBuildSinkOperator::prepare(RuntimeState* state) {
     return _except_ctx->prepare(state, _dst_exprs);
 }
 
-Status ExceptBuildSinkOperator::close(RuntimeState* state) {
-    RETURN_IF_ERROR(_except_ctx->unref(state));
-    return Operator::close(state);
+void ExceptBuildSinkOperator::close(RuntimeState* state) {
+    _except_ctx->unref(state);
+    Operator::close(state);
 }
 
 Status ExceptBuildSinkOperatorFactory::prepare(RuntimeState* state) {

--- a/be/src/exec/pipeline/set/except_build_sink_operator.h
+++ b/be/src/exec/pipeline/set/except_build_sink_operator.h
@@ -45,7 +45,7 @@ public:
     }
 
     Status prepare(RuntimeState* state) override;
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/set/except_context.cpp
+++ b/be/src/exec/pipeline/set/except_context.cpp
@@ -20,12 +20,10 @@ Status ExceptContext::prepare(RuntimeState* state, const std::vector<ExprContext
     return Status::OK();
 }
 
-Status ExceptContext::close(RuntimeState* state) {
+void ExceptContext::close(RuntimeState* state) {
     if (_build_pool != nullptr) {
         _build_pool->free_all();
     }
-
-    return Status::OK();
 }
 
 Status ExceptContext::append_chunk_to_ht(RuntimeState* state, const ChunkPtr& chunk,

--- a/be/src/exec/pipeline/set/except_context.h
+++ b/be/src/exec/pipeline/set/except_context.h
@@ -48,7 +48,7 @@ public:
     Status prepare(RuntimeState* state, const std::vector<ExprContext*>& build_exprs);
 
     // Called in the close phase of ExceptOutputSourceOperator.
-    Status close(RuntimeState* state);
+    void close(RuntimeState* state);
 
     Status append_chunk_to_ht(RuntimeState* state, const ChunkPtr& chunk, const std::vector<ExprContext*>& dst_exprs);
 

--- a/be/src/exec/pipeline/set/except_output_source_operator.cpp
+++ b/be/src/exec/pipeline/set/except_output_source_operator.cpp
@@ -8,9 +8,9 @@ StatusOr<vectorized::ChunkPtr> ExceptOutputSourceOperator::pull_chunk(RuntimeSta
     return _except_ctx->pull_chunk(state);
 }
 
-Status ExceptOutputSourceOperator::close(RuntimeState* state) {
-    RETURN_IF_ERROR(_except_ctx->unref(state));
-    return Operator::close(state);
+void ExceptOutputSourceOperator::close(RuntimeState* state) {
+    _except_ctx->unref(state);
+    Operator::close(state);
 }
 
 void ExceptOutputSourceOperatorFactory::close(RuntimeState* state) {

--- a/be/src/exec/pipeline/set/except_output_source_operator.h
+++ b/be/src/exec/pipeline/set/except_output_source_operator.h
@@ -32,7 +32,7 @@ public:
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
 
 private:
     std::shared_ptr<ExceptContext> _except_ctx;

--- a/be/src/exec/pipeline/set/except_probe_sink_operator.cpp
+++ b/be/src/exec/pipeline/set/except_probe_sink_operator.cpp
@@ -4,9 +4,9 @@
 
 namespace starrocks::pipeline {
 
-Status ExceptProbeSinkOperator::close(RuntimeState* state) {
-    RETURN_IF_ERROR(_except_ctx->unref(state));
-    return Operator::close(state);
+void ExceptProbeSinkOperator::close(RuntimeState* state) {
+    _except_ctx->unref(state);
+    Operator::close(state);
 }
 
 StatusOr<vectorized::ChunkPtr> ExceptProbeSinkOperator::pull_chunk(RuntimeState* state) {

--- a/be/src/exec/pipeline/set/except_probe_sink_operator.h
+++ b/be/src/exec/pipeline/set/except_probe_sink_operator.h
@@ -21,7 +21,7 @@ public:
         _except_ctx->ref();
     }
 
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
 
     bool need_input() const override {
         return _except_ctx->is_dependency_finished(_dependency_index) && !(_is_finished || _except_ctx->is_ht_empty());

--- a/be/src/exec/pipeline/set/intersect_build_sink_operator.cpp
+++ b/be/src/exec/pipeline/set/intersect_build_sink_operator.cpp
@@ -18,9 +18,9 @@ Status IntersectBuildSinkOperator::prepare(RuntimeState* state) {
     return _intersect_ctx->prepare(state, _dst_exprs);
 }
 
-Status IntersectBuildSinkOperator::close(RuntimeState* state) {
-    RETURN_IF_ERROR(_intersect_ctx->unref(state));
-    return Operator::close(state);
+void IntersectBuildSinkOperator::close(RuntimeState* state) {
+    _intersect_ctx->unref(state);
+    Operator::close(state);
 }
 
 Status IntersectBuildSinkOperatorFactory::prepare(RuntimeState* state) {

--- a/be/src/exec/pipeline/set/intersect_build_sink_operator.h
+++ b/be/src/exec/pipeline/set/intersect_build_sink_operator.h
@@ -48,7 +48,7 @@ public:
     }
 
     Status prepare(RuntimeState* state) override;
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/set/intersect_context.cpp
+++ b/be/src/exec/pipeline/set/intersect_context.cpp
@@ -19,12 +19,10 @@ Status IntersectContext::prepare(RuntimeState* state, const std::vector<ExprCont
     return Status::OK();
 }
 
-Status IntersectContext::close(RuntimeState* state) {
+void IntersectContext::close(RuntimeState* state) {
     if (_build_pool != nullptr) {
         _build_pool->free_all();
     }
-
-    return Status::OK();
 }
 
 Status IntersectContext::append_chunk_to_ht(RuntimeState* state, const ChunkPtr& chunk,

--- a/be/src/exec/pipeline/set/intersect_context.h
+++ b/be/src/exec/pipeline/set/intersect_context.h
@@ -49,7 +49,7 @@ public:
     // Called in the preparation phase of IntersectBuildSinkOperator.
     Status prepare(RuntimeState* state, const std::vector<ExprContext*>& build_exprs);
 
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
 
     Status append_chunk_to_ht(RuntimeState* state, const ChunkPtr& chunk, const std::vector<ExprContext*>& dst_exprs);
 

--- a/be/src/exec/pipeline/set/intersect_output_source_operator.cpp
+++ b/be/src/exec/pipeline/set/intersect_output_source_operator.cpp
@@ -8,9 +8,9 @@ StatusOr<vectorized::ChunkPtr> IntersectOutputSourceOperator::pull_chunk(Runtime
     return _intersect_ctx->pull_chunk(state);
 }
 
-Status IntersectOutputSourceOperator::close(RuntimeState* state) {
-    RETURN_IF_ERROR(_intersect_ctx->unref(state));
-    return Operator::close(state);
+void IntersectOutputSourceOperator::close(RuntimeState* state) {
+    _intersect_ctx->unref(state);
+    Operator::close(state);
 }
 
 void IntersectOutputSourceOperatorFactory::close(RuntimeState* state) {

--- a/be/src/exec/pipeline/set/intersect_output_source_operator.h
+++ b/be/src/exec/pipeline/set/intersect_output_source_operator.h
@@ -33,7 +33,7 @@ public:
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
 
 private:
     std::shared_ptr<IntersectContext> _intersect_ctx;

--- a/be/src/exec/pipeline/set/intersect_probe_sink_operator.cpp
+++ b/be/src/exec/pipeline/set/intersect_probe_sink_operator.cpp
@@ -4,9 +4,9 @@
 
 namespace starrocks::pipeline {
 
-Status IntersectProbeSinkOperator::close(RuntimeState* state) {
-    RETURN_IF_ERROR(_intersect_ctx->unref(state));
-    return Operator::close(state);
+void IntersectProbeSinkOperator::close(RuntimeState* state) {
+    _intersect_ctx->unref(state);
+    Operator::close(state);
 }
 
 StatusOr<vectorized::ChunkPtr> IntersectProbeSinkOperator::pull_chunk(RuntimeState* state) {

--- a/be/src/exec/pipeline/set/intersect_probe_sink_operator.h
+++ b/be/src/exec/pipeline/set/intersect_probe_sink_operator.h
@@ -43,7 +43,7 @@ public:
         _intersect_ctx->finish_probe_ht();
     }
 
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
 
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/sort/local_merge_sort_source_operator.cpp
+++ b/be/src/exec/pipeline/sort/local_merge_sort_source_operator.cpp
@@ -13,9 +13,9 @@
 
 namespace starrocks::pipeline {
 
-Status LocalMergeSortSourceOperator::close(RuntimeState* state) {
-    RETURN_IF_ERROR(_sort_context->unref(state));
-    return Operator::close(state);
+void LocalMergeSortSourceOperator::close(RuntimeState* state) {
+    _sort_context->unref(state);
+    Operator::close(state);
 }
 
 StatusOr<vectorized::ChunkPtr> LocalMergeSortSourceOperator::pull_chunk(RuntimeState* state) {

--- a/be/src/exec/pipeline/sort/local_merge_sort_source_operator.h
+++ b/be/src/exec/pipeline/sort/local_merge_sort_source_operator.h
@@ -25,7 +25,7 @@ public:
 
     ~LocalMergeSortSourceOperator() override = default;
 
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
 
     bool has_output() const override;
 

--- a/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
@@ -25,9 +25,9 @@ Status PartitionSortSinkOperator::prepare(RuntimeState* state) {
     return Status::OK();
 }
 
-Status PartitionSortSinkOperator::close(RuntimeState* state) {
-    RETURN_IF_ERROR(_sort_context->unref(state));
-    return Operator::close(state);
+void PartitionSortSinkOperator::close(RuntimeState* state) {
+    _sort_context->unref(state);
+    Operator::close(state);
 }
 
 StatusOr<vectorized::ChunkPtr> PartitionSortSinkOperator::pull_chunk(RuntimeState* state) {

--- a/be/src/exec/pipeline/sort/partition_sort_sink_operator.h
+++ b/be/src/exec/pipeline/sort/partition_sort_sink_operator.h
@@ -51,7 +51,7 @@ public:
 
     Status prepare(RuntimeState* state) override;
 
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
 
     bool has_output() const override { return false; }
 

--- a/be/src/exec/pipeline/sort/sort_context.h
+++ b/be/src/exec/pipeline/sort/sort_context.h
@@ -35,7 +35,7 @@ public:
         _data_segment_heaps.reserve(num_right_sinkers);
     }
 
-    Status close(RuntimeState* state) override { return Status::OK(); }
+    void close(RuntimeState* state) override {}
 
     void finish_partition(uint64_t partition_rows) {
         _total_rows.fetch_add(partition_rows, std::memory_order_relaxed);

--- a/be/src/exec/vectorized/aggregator.cpp
+++ b/be/src/exec/vectorized/aggregator.cpp
@@ -244,9 +244,9 @@ Status Aggregator::prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile
     return Status::OK();
 }
 
-Status Aggregator::close(RuntimeState* state) {
+void Aggregator::close(RuntimeState* state) {
     if (_is_closed) {
-        return Status::OK();
+        return;
     }
 
     _is_closed = true;
@@ -284,8 +284,6 @@ Status Aggregator::close(RuntimeState* state) {
         Expr::close(i, state);
     }
     Expr::close(_conjunct_ctxs, state);
-
-    return Status::OK();
 }
 
 bool Aggregator::is_chunk_buffer_empty() {

--- a/be/src/exec/vectorized/aggregator.h
+++ b/be/src/exec/vectorized/aggregator.h
@@ -68,7 +68,7 @@ public:
     Status open(RuntimeState* state);
     Status prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile* runtime_profile, MemTracker* mem_tracker);
 
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
 
     std::unique_ptr<MemPool>& mem_pool() { return _mem_pool; };
     bool is_none_group_by_exprs() { return _group_by_expr_ctxs.empty(); }

--- a/be/src/exec/vectorized/analytor.cpp
+++ b/be/src/exec/vectorized/analytor.cpp
@@ -273,9 +273,9 @@ Status Analytor::open(RuntimeState* state) {
     return Status::OK();
 }
 
-Status Analytor::close(RuntimeState* state) {
+void Analytor::close(RuntimeState* state) {
     if (_is_closed) {
-        return Status::OK();
+        return;
     }
 
     _is_closed = true;
@@ -299,8 +299,6 @@ Status Analytor::close(RuntimeState* state) {
     for (const auto& i : _agg_expr_ctxs) {
         Expr::close(i, state);
     }
-
-    return Status::OK();
 }
 
 bool Analytor::is_chunk_buffer_empty() {

--- a/be/src/exec/vectorized/analytor.h
+++ b/be/src/exec/vectorized/analytor.h
@@ -47,7 +47,7 @@ public:
 
     Status prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile* runtime_profile);
     Status open(RuntimeState* state);
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
 
     enum FrameType {
         Unbounded,               // BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING

--- a/be/src/exec/vectorized/hash_joiner.cpp
+++ b/be/src/exec/vectorized/hash_joiner.cpp
@@ -241,9 +241,8 @@ StatusOr<ChunkPtr> HashJoiner::_pull_probe_output_chunk(RuntimeState* state) {
     return chunk;
 }
 
-Status HashJoiner::close(RuntimeState* state) {
+void HashJoiner::close(RuntimeState* state) {
     _ht.close();
-    return Status::OK();
 }
 
 Status HashJoiner::create_runtime_filters(RuntimeState* state) {

--- a/be/src/exec/vectorized/hash_joiner.h
+++ b/be/src/exec/vectorized/hash_joiner.h
@@ -111,7 +111,7 @@ public:
     }
 
     Status prepare(RuntimeState* state);
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
     bool need_input() const;
     bool has_output() const;
     bool is_build_done() const { return _phase != HashJoinPhase::BUILD; }

--- a/be/test/exec/pipeline/pipeline_control_flow_test.cpp
+++ b/be/test/exec/pipeline/pipeline_control_flow_test.cpp
@@ -110,12 +110,12 @@ public:
         _is_finished = true;
     }
 
-    Status close(RuntimeState* state) override {
+    void close(RuntimeState* state) override {
         if (_is_closed) {
             ++lifecycle_error_num;
         }
         _is_closed = true;
-        return Operator::close(state);
+        Operator::close(state);
     }
 
 private:
@@ -174,7 +174,7 @@ public:
         _is_finished = true;
     }
 
-    Status close(RuntimeState* state) override {
+    void close(RuntimeState* state) override {
         if (_pending_finish_cnt >= 0) {
             ++lifecycle_error_num;
         }
@@ -182,7 +182,7 @@ public:
             ++lifecycle_error_num;
         }
         _is_closed = true;
-        return SourceOperator::close(state);
+        SourceOperator::close(state);
     }
 
     bool has_output() const override { return _index < _chunks.size(); }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [x] others

## Problem Summary：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Remove `RETURN_IF_ERROR` in `Operator::close`. Otherwise, the close operations after `RETURN_IF_ERROR` maybe couldn't be executed.

