### PR TITLE
Add profile of hash joiner to pipeline

### DIFF
--- a/be/src/exec/pipeline/hashjoin/hash_join_build_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/hash_join_build_operator.cpp
@@ -31,7 +31,9 @@ Status HashJoinBuildOperator::prepare(RuntimeState* state) {
         read_only_join_prober->ref();
     }
 
-    return _join_builder->prepare(state);
+    RETURN_IF_ERROR(_join_builder->prepare_builder(state, _unique_metrics.get()));
+
+    return Status::OK();
 }
 void HashJoinBuildOperator::close(RuntimeState* state) {
     for (auto& read_only_join_prober : _read_only_join_probers) {

--- a/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.cpp
@@ -29,11 +29,7 @@ Status HashJoinProbeOperator::prepare(RuntimeState* state) {
     }
     _join_prober->ref();
 
-    // The buildable hash joiner is prepared in HashJoinBuildOperator::prepare,
-    // while the read only hash joiner is prepared in HashJoinProbeOperator::prepare.
-    if (!_join_prober->is_buildable()) {
-        RETURN_IF_ERROR(_join_prober->prepare(state));
-    }
+    RETURN_IF_ERROR(_join_prober->prepare_prober(state, _unique_metrics.get()));
 
     return Status::OK();
 }

--- a/be/src/exec/vectorized/hash_join_node.cpp
+++ b/be/src/exec/vectorized/hash_join_node.cpp
@@ -465,10 +465,10 @@ pipeline::OpFactories HashJoinNode::decompose_to_pipeline(pipeline::PipelineBuil
     }
 
     auto* pool = context->fragment_context()->runtime_state()->obj_pool();
-    HashJoinerParam param(pool, _hash_join_node, _id, _type, limit(), _is_null_safes, _build_expr_ctxs,
-                          _probe_expr_ctxs, _other_join_conjunct_ctxs, _conjunct_ctxs, child(1)->row_desc(),
-                          child(0)->row_desc(), _row_descriptor, child(1)->type(), child(0)->type(),
-                          child(1)->conjunct_ctxs().empty(), _build_runtime_filters, _output_slots, _distribution_mode);
+    HashJoinerParam param(pool, _hash_join_node, _id, _type, _is_null_safes, _build_expr_ctxs, _probe_expr_ctxs,
+                          _other_join_conjunct_ctxs, _conjunct_ctxs, child(1)->row_desc(), child(0)->row_desc(),
+                          _row_descriptor, child(1)->type(), child(0)->type(), child(1)->conjunct_ctxs().empty(),
+                          _build_runtime_filters, _output_slots, _distribution_mode);
     auto hash_joiner_factory = std::make_shared<starrocks::pipeline::HashJoinerFactory>(param, num_left_partitions);
 
     // add placeholder into RuntimeFilterHub, HashJoinBuildOperator will generate runtime filters and fill it,

--- a/be/src/exec/vectorized/hash_joiner.cpp
+++ b/be/src/exec/vectorized/hash_joiner.cpp
@@ -69,8 +69,6 @@ Status HashJoiner::prepare_builder(RuntimeState* state, RuntimeProfile* runtime_
     _build_ht_timer = ADD_TIMER(runtime_profile, "BuildHashTableTime");
     _build_runtime_filter_timer = ADD_TIMER(runtime_profile, "RuntimeFilterBuildTime");
     _build_conjunct_evaluate_timer = ADD_TIMER(runtime_profile, "BuildConjunctEvaluateTime");
-
-    _build_rows_counter = ADD_COUNTER(runtime_profile, "BuildRows", TUnit::UNIT);
     _build_buckets_counter = ADD_COUNTER(runtime_profile, "BuildBuckets", TUnit::UNIT);
     _runtime_filter_num = ADD_COUNTER(runtime_profile, "RuntimeFilterNum", TUnit::UNIT);
     runtime_profile->add_info_string("JoinType", _get_join_type_str(_join_type));
@@ -156,7 +154,6 @@ Status HashJoiner::append_chunk_to_ht(RuntimeState* state, const ChunkPtr& chunk
 Status HashJoiner::build_ht(RuntimeState* state) {
     if (_phase == HashJoinPhase::BUILD) {
         RETURN_IF_ERROR(_build(state));
-        COUNTER_SET(_build_rows_counter, static_cast<int64_t>(_ht.get_row_count()));
         COUNTER_SET(_build_buckets_counter, static_cast<int64_t>(_ht.get_bucket_size()));
     }
 

--- a/be/src/exec/vectorized/hash_joiner.h
+++ b/be/src/exec/vectorized/hash_joiner.h
@@ -373,7 +373,6 @@ private:
     RuntimeProfile::Counter* _copy_right_table_chunk_timer = nullptr;
     RuntimeProfile::Counter* _build_runtime_filter_timer = nullptr;
     RuntimeProfile::Counter* _output_build_column_timer = nullptr;
-    RuntimeProfile::Counter* _build_rows_counter = nullptr;
     RuntimeProfile::Counter* _build_buckets_counter = nullptr;
     RuntimeProfile::Counter* _runtime_filter_num = nullptr;
 

--- a/be/src/exec/vectorized/hash_joiner.h
+++ b/be/src/exec/vectorized/hash_joiner.h
@@ -45,19 +45,19 @@ enum HashJoinPhase {
 };
 struct HashJoinerParam {
     HashJoinerParam(ObjectPool* pool, const THashJoinNode& hash_join_node, TPlanNodeId node_id,
-                    TPlanNodeType::type node_type, int64_t limit, const std::vector<bool>& is_null_safes,
+                    TPlanNodeType::type node_type, const std::vector<bool>& is_null_safes,
                     const std::vector<ExprContext*>& build_expr_ctxs, const std::vector<ExprContext*>& probe_expr_ctxs,
                     const std::vector<ExprContext*>& other_join_conjunct_ctxs,
                     const std::vector<ExprContext*>& conjunct_ctxs, const RowDescriptor& build_row_descriptor,
                     const RowDescriptor& probe_row_descriptor, const RowDescriptor& row_descriptor,
                     TPlanNodeType::type build_node_type, TPlanNodeType::type probe_node_type,
-                    bool build_conjunct_ctxs_is_empty, std::list<RuntimeFilterBuildDescriptor*> build_runtime_filters,
+                    bool build_conjunct_ctxs_is_empty,
+                    const std::list<RuntimeFilterBuildDescriptor*>& build_runtime_filters,
                     const std::set<SlotId>& output_slots, const TJoinDistributionMode::type distribution_mode)
             : _pool(pool),
               _hash_join_node(hash_join_node),
               _node_id(node_id),
               _node_type(node_type),
-              _limit(limit),
               _is_null_safes(is_null_safes),
               _build_expr_ctxs(build_expr_ctxs),
               _probe_expr_ctxs(probe_expr_ctxs),
@@ -81,7 +81,6 @@ struct HashJoinerParam {
     const THashJoinNode& _hash_join_node;
     TPlanNodeId _node_id;
     TPlanNodeType::type _node_type;
-    int64_t _limit;
     const std::vector<bool> _is_null_safes;
     const std::vector<ExprContext*> _build_expr_ctxs;
     const std::vector<ExprContext*> _probe_expr_ctxs;
@@ -110,8 +109,10 @@ public:
         }
     }
 
-    Status prepare(RuntimeState* state);
+    Status prepare_builder(RuntimeState* state, RuntimeProfile* runtime_profile);
+    Status prepare_prober(RuntimeState* state, RuntimeProfile* runtime_profile);
     void close(RuntimeState* state) override;
+
     bool need_input() const;
     bool has_output() const;
     bool is_build_done() const { return _phase != HashJoinPhase::BUILD; }
@@ -148,10 +149,11 @@ public:
 
     Status create_runtime_filters(RuntimeState* state);
 
-    void reference_hash_table(HashJoiner* src_joiner);
+    void reference_hash_table(HashJoiner* src_join_builder);
 
     bool is_buildable() const { return _is_buildable; }
 
+    // These two methods are used only by the hash join builder.
     void set_builder_finished();
     void set_prober_finished();
 
@@ -159,8 +161,6 @@ private:
     static bool _has_null(const ColumnPtr& column);
 
     void _init_hash_table_param(HashTableParam* param);
-
-    bool _reached_limit() { return _limit != -1 && _num_rows_returned >= _limit; }
 
     void _prepare_key_columns(Columns& key_columns, const ChunkPtr& chunk, const vector<ExprContext*>& expr_ctxs) {
         key_columns.resize(0);
@@ -181,10 +181,14 @@ private:
     }
 
     void _prepare_build_key_columns() {
+        SCOPED_TIMER(_build_conjunct_evaluate_timer);
         _prepare_key_columns(_ht.get_key_columns(), _ht.get_build_chunk(), _build_expr_ctxs);
     }
 
-    void _prepare_probe_key_columns() { _prepare_key_columns(_key_columns, _probe_input_chunk, _probe_expr_ctxs); }
+    void _prepare_probe_key_columns() {
+        SCOPED_TIMER(_probe_conjunct_evaluate_timer);
+        _prepare_key_columns(_key_columns, _probe_input_chunk, _probe_expr_ctxs);
+    }
 
     bool _need_post_probe() const {
         return _join_type == TJoinOp::RIGHT_OUTER_JOIN || _join_type == TJoinOp::RIGHT_ANTI_JOIN ||
@@ -229,6 +233,7 @@ private:
     void _process_semi_join_with_other_conjunct(ChunkPtr* chunk);
     void _process_right_anti_join_with_other_conjunct(ChunkPtr* chunk);
     void _process_other_conjunct(ChunkPtr* chunk);
+    void _process_where_conjunct(ChunkPtr* chunk);
 
     void _filter_probe_output_chunk(ChunkPtr& chunk) {
         // Probe in JoinHashMap is divided into probe with other_conjuncts and without other_conjuncts.
@@ -241,7 +246,7 @@ private:
 
         // TODO(satanson): _conjunct_ctxs shouldn't include local runtime in-filters.
         if (chunk && !chunk->is_empty() && !_conjunct_ctxs.empty()) {
-            ExecNode::eval_conjuncts(_conjunct_ctxs, chunk.get());
+            _process_where_conjunct(&chunk);
         }
     }
     void _filter_post_probe_output_chunk(ChunkPtr& chunk) {
@@ -249,7 +254,7 @@ private:
         // are `ON` predicates, which need to be processed only on probe phase.
         if (chunk && !chunk->is_empty() && !_conjunct_ctxs.empty()) {
             // TODO(satanson): _conjunct_ctxs should including local runtime in-filters.
-            ExecNode::eval_conjuncts(_conjunct_ctxs, chunk.get());
+            _process_where_conjunct(&chunk);
         }
     }
 
@@ -311,15 +316,14 @@ private:
         return Status::OK();
     }
 
+private:
+    const THashJoinNode& _hash_join_node;
     ObjectPool* _pool;
 
     RuntimeState* _runtime_state = nullptr;
 
     TJoinOp::type _join_type = TJoinOp::INNER_JOIN;
-    const int64_t _limit; // -1: no limit
-    int64_t _num_rows_returned;
     std::atomic<HashJoinPhase> _phase = HashJoinPhase::BUILD;
-    std::shared_ptr<RuntimeProfile> _runtime_profile;
     bool _is_closed = false;
 
     ChunkPtr _probe_input_chunk;
@@ -359,26 +363,24 @@ private:
     // right table have not output data for right outer join/right semi join/right anti join/full outer join
 
     const bool _is_buildable;
-    // These two fields are for hash join builder.
-    const std::vector<HashJoinerPtr>& _read_only_join_probers;
-    std::atomic<size_t> _num_unfinished_prober = 0;
 
-    RuntimeProfile::Counter* _build_timer = nullptr;
+    // These two fields are used only by the hash join builder.
+    const std::vector<HashJoinerPtr>& _read_only_join_probers;
+    std::atomic<size_t> _num_unfinished_probers = 0;
+
+    // Profile for hash join builder.
     RuntimeProfile::Counter* _build_ht_timer = nullptr;
     RuntimeProfile::Counter* _copy_right_table_chunk_timer = nullptr;
     RuntimeProfile::Counter* _build_runtime_filter_timer = nullptr;
-    RuntimeProfile::Counter* _merge_input_chunk_timer = nullptr;
-    RuntimeProfile::Counter* _probe_timer = nullptr;
-    RuntimeProfile::Counter* _search_ht_timer = nullptr;
     RuntimeProfile::Counter* _output_build_column_timer = nullptr;
-    RuntimeProfile::Counter* _output_probe_column_timer = nullptr;
-    RuntimeProfile::Counter* _output_tuple_column_timer = nullptr;
     RuntimeProfile::Counter* _build_rows_counter = nullptr;
-    RuntimeProfile::Counter* _probe_rows_counter = nullptr;
     RuntimeProfile::Counter* _build_buckets_counter = nullptr;
     RuntimeProfile::Counter* _runtime_filter_num = nullptr;
-    RuntimeProfile::Counter* _avg_input_probe_chunk_size = nullptr;
-    RuntimeProfile::Counter* _avg_output_chunk_size = nullptr;
+
+    // Profile for hash join prober.
+    RuntimeProfile::Counter* _search_ht_timer = nullptr;
+    RuntimeProfile::Counter* _output_probe_column_timer = nullptr;
+    RuntimeProfile::Counter* _output_tuple_column_timer = nullptr;
     RuntimeProfile::Counter* _build_conjunct_evaluate_timer = nullptr;
     RuntimeProfile::Counter* _probe_conjunct_evaluate_timer = nullptr;
     RuntimeProfile::Counter* _other_join_conjunct_evaluate_timer = nullptr;

--- a/be/src/exec/vectorized/join_hash_map.cpp
+++ b/be/src/exec/vectorized/join_hash_map.cpp
@@ -228,6 +228,14 @@ JoinHashTable JoinHashTable::clone_readable_table() {
     return ht;
 }
 
+void JoinHashTable::set_probe_profile(RuntimeProfile::Counter* search_ht_timer,
+                                      RuntimeProfile::Counter* output_probe_column_timer,
+                                      RuntimeProfile::Counter* output_tuple_column_timer) {
+    _probe_state->search_ht_timer = search_ht_timer;
+    _probe_state->output_probe_column_timer = output_probe_column_timer;
+    _probe_state->output_tuple_column_timer = output_tuple_column_timer;
+}
+
 void JoinHashTable::close() {
     _table_items.reset();
     _probe_state.reset();
@@ -258,13 +266,13 @@ void JoinHashTable::create(const HashTableParam& param) {
         _table_items->left_to_nullable = true;
         _table_items->right_to_nullable = true;
     }
-    _table_items->search_ht_timer = param.search_ht_timer;
     _table_items->output_build_column_timer = param.output_build_column_timer;
-    _table_items->output_probe_column_timer = param.output_probe_column_timer;
-    _table_items->output_tuple_column_timer = param.output_tuple_column_timer;
     _table_items->join_keys = param.join_keys;
 
     _probe_state->probe_pool = std::make_unique<MemPool>();
+    _probe_state->search_ht_timer = param.search_ht_timer;
+    _probe_state->output_probe_column_timer = param.output_probe_column_timer;
+    _probe_state->output_tuple_column_timer = param.output_tuple_column_timer;
 
     const auto& probe_desc = *param.probe_row_desc;
     for (const auto& tuple_desc : probe_desc.tuple_descriptors()) {

--- a/be/src/exec/vectorized/join_hash_map.h
+++ b/be/src/exec/vectorized/join_hash_map.h
@@ -108,10 +108,7 @@ struct JoinHashTableItems {
     std::unique_ptr<MemPool> build_pool = nullptr;
     std::vector<JoinKeyDesc> join_keys;
 
-    RuntimeProfile::Counter* search_ht_timer = nullptr;
     RuntimeProfile::Counter* output_build_column_timer = nullptr;
-    RuntimeProfile::Counter* output_probe_column_timer = nullptr;
-    RuntimeProfile::Counter* output_tuple_column_timer = nullptr;
 };
 
 struct HashTableProbeState {
@@ -153,6 +150,10 @@ struct HashTableProbeState {
 
     std::unique_ptr<MemPool> probe_pool = nullptr;
 
+    RuntimeProfile::Counter* search_ht_timer = nullptr;
+    RuntimeProfile::Counter* output_probe_column_timer = nullptr;
+    RuntimeProfile::Counter* output_tuple_column_timer = nullptr;
+
     HashTableProbeState() = default;
     ~HashTableProbeState() = default;
 
@@ -177,7 +178,10 @@ struct HashTableProbeState {
               has_remain(rhs.has_remain),
               cur_probe_index(rhs.cur_probe_index),
               cur_row_match_count(rhs.cur_row_match_count),
-              probe_pool(rhs.probe_pool == nullptr ? nullptr : std::make_unique<MemPool>()) {}
+              probe_pool(rhs.probe_pool == nullptr ? nullptr : std::make_unique<MemPool>()),
+              search_ht_timer(rhs.search_ht_timer),
+              output_probe_column_timer(rhs.output_probe_column_timer),
+              output_tuple_column_timer(rhs.output_tuple_column_timer) {}
 
     // Disable copy assignment.
     HashTableProbeState& operator=(const HashTableProbeState& rhs) = delete;
@@ -558,6 +562,8 @@ public:
     // Clone a new hash table with the same hash table as this,
     // and the different probe state from this.
     JoinHashTable clone_readable_table();
+    void set_probe_profile(RuntimeProfile::Counter* search_ht_timer, RuntimeProfile::Counter* output_probe_column_timer,
+                           RuntimeProfile::Counter* output_tuple_column_timer);
 
     void create(const HashTableParam& param);
     void close();

--- a/be/src/exec/vectorized/join_hash_map.tpp
+++ b/be/src/exec/vectorized/join_hash_map.tpp
@@ -276,7 +276,7 @@ Status JoinHashMap<PT, BuildFunc, ProbeFunc>::probe(RuntimeState* state, const C
                                                     bool* has_remain) {
     _probe_state->key_columns = &key_columns;
     {
-        SCOPED_TIMER(_table_items->search_ht_timer);
+        SCOPED_TIMER(_probe_state->search_ht_timer);
         RETURN_IF_ERROR(_search_ht(state, probe_chunk));
         if (_probe_state->count <= 0) {
             *has_remain = false;
@@ -292,7 +292,7 @@ Status JoinHashMap<PT, BuildFunc, ProbeFunc>::probe(RuntimeState* state, const C
         // don't need output the real probe column
         {
             // output default values for probe-columns as placeholder.
-            SCOPED_TIMER(_table_items->output_probe_column_timer);
+            SCOPED_TIMER(_probe_state->output_probe_column_timer);
             if (!_table_items->with_other_conjunct) {
                 RETURN_IF_ERROR(_probe_null_output(chunk, _probe_state->count));
             } else {
@@ -304,7 +304,7 @@ Status JoinHashMap<PT, BuildFunc, ProbeFunc>::probe(RuntimeState* state, const C
             RETURN_IF_ERROR(_build_output(chunk));
         }
         {
-            SCOPED_TIMER(_table_items->output_tuple_column_timer);
+            SCOPED_TIMER(_probe_state->output_tuple_column_timer);
             if (_table_items->need_create_tuple_columns) {
                 _build_tuple_output(chunk);
             }
@@ -316,7 +316,7 @@ Status JoinHashMap<PT, BuildFunc, ProbeFunc>::probe(RuntimeState* state, const C
         // anti anti join without other join conjunct
         // don't need output the real build column
         {
-            SCOPED_TIMER(_table_items->output_probe_column_timer);
+            SCOPED_TIMER(_probe_state->output_probe_column_timer);
             RETURN_IF_ERROR(_probe_output(probe_chunk, chunk));
         }
         {
@@ -329,14 +329,14 @@ Status JoinHashMap<PT, BuildFunc, ProbeFunc>::probe(RuntimeState* state, const C
             }
         }
         {
-            SCOPED_TIMER(_table_items->output_tuple_column_timer);
+            SCOPED_TIMER(_probe_state->output_tuple_column_timer);
             if (_table_items->need_create_tuple_columns) {
                 _probe_tuple_output(probe_chunk, chunk);
             }
         }
     } else {
         {
-            SCOPED_TIMER(_table_items->output_probe_column_timer);
+            SCOPED_TIMER(_probe_state->output_probe_column_timer);
             RETURN_IF_ERROR(_probe_output(probe_chunk, chunk));
         }
         {
@@ -344,7 +344,7 @@ Status JoinHashMap<PT, BuildFunc, ProbeFunc>::probe(RuntimeState* state, const C
             RETURN_IF_ERROR(_build_output(chunk));
         }
         {
-            SCOPED_TIMER(_table_items->output_tuple_column_timer);
+            SCOPED_TIMER(_probe_state->output_tuple_column_timer);
             if (_table_items->need_create_tuple_columns) {
                 _probe_tuple_output(probe_chunk, chunk);
                 _build_tuple_output(chunk);

--- a/be/test/exec/vectorized/join_hash_map_test.cpp
+++ b/be/test/exec/vectorized/join_hash_map_test.cpp
@@ -67,7 +67,7 @@ private:
     // used for build func
     void prepare_table_items(JoinHashTableItems* table_items, uint32_t row_count);
 
-    static void prepare_probe_state(HashTableProbeState* probe_state, uint32_t probe_row_count);
+    void prepare_probe_state(HashTableProbeState* probe_state, uint32_t probe_row_count);
     static void prepare_build_data(Buffer<int32_t>* build_data, uint32_t batch_count);
     static void prepare_probe_data(Buffer<int32_t>* probe_data, uint32_t probe_row_count);
 
@@ -492,16 +492,16 @@ void JoinHashMapTest::prepare_table_items(JoinHashTableItems* table_items, uint3
     table_items->row_count = row_count;
     table_items->next.resize(row_count + 1);
     table_items->build_pool = std::make_unique<MemPool>();
-    table_items->search_ht_timer = ADD_TIMER(_runtime_profile, "SearchHashTableTimer");
     table_items->output_build_column_timer = ADD_TIMER(_runtime_profile, "OutputBuildColumnTimer");
-    table_items->output_probe_column_timer = ADD_TIMER(_runtime_profile, "OutputProbeColumnTimer");
-    table_items->output_tuple_column_timer = ADD_TIMER(_runtime_profile, "OutputTupleColumnTimer");
 }
 
 void JoinHashMapTest::prepare_probe_state(HashTableProbeState* probe_state, uint32_t probe_row_count) {
     probe_state->probe_row_count = probe_row_count;
     probe_state->cur_probe_index = 0;
     probe_state->probe_pool = std::make_unique<MemPool>();
+    probe_state->search_ht_timer = ADD_TIMER(_runtime_profile, "SearchHashTableTimer");
+    probe_state->output_probe_column_timer = ADD_TIMER(_runtime_profile, "OutputProbeColumnTimer");
+    probe_state->output_tuple_column_timer = ADD_TIMER(_runtime_profile, "OutputTupleColumnTimer");
     JoinHashMapHelper::prepare_map_index(probe_state, config::vector_chunk_size);
 
     for (size_t i = 0; i < probe_row_count; i++) {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [x] others

## Motivation
`HashJoiner::_runtime_profile` isn't added to the profile tree of pipeline.

## Modification
- Split profile metrics of `HashJoiner` into two parts about join builder and prober, respectively.
- Split `HashJoiner::prepare()` into `prepare_builder()` and `prepare_prober()`.
    - `prepare_builder()` prepares metrics of builder and the hash table.
    - `prepare_prober()` prepares metrics of prober.
- Move `_search_ht_timer`, `_output_probe_column_timer`, and `_output_tuple_column_timer` from class `TableItem` to `ProbeState`, and set them after cloning readable table.