### PR TITLE
Disable compute extra cost when can not get accurate table row count

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
@@ -188,6 +188,10 @@ public class CostModel {
         public CostEstimate computeAggFunExtraCost(PhysicalHashAggregateOperator node, Statistics statistics,
                                                    Statistics inputStatistics) {
             CostEstimate costEstimate = CostEstimate.zero();
+            // If the statistics with inaccurate row count，It don't need to compute the extra cost.
+            if (statistics.isTableRowCountMayInaccurate()) {
+                return costEstimate;
+            }
             int distinctCount =
                     (int) node.getAggregations().values().stream()
                             .filter(aggregation -> isDistinctAggFun(aggregation, node)).count();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -595,7 +595,7 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
         Assert.assertTrue(plan.contains("3:AGGREGATE (merge finalize)"));
         sql = "select count(distinct O_ORDERKEY) from orders group by O_CUSTKEY, O_ORDERDATE";
         plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("3:AGGREGATE (merge serialize)"));
+        Assert.assertTrue(plan.contains("3:AGGREGATE (merge finalize)"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -364,4 +364,13 @@ public class ReplayFromDumpTest {
         Assert.assertTrue(replayPair.second.contains("52:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (COLOCATE)"));
     }
+
+    @Test
+    public void testLocalAggregateWithoutTableRowCount() throws Exception {
+        Pair<QueryDumpInfo, String> replayPair =
+                getPlanFragment(getDumpInfoFromFile("query_dump/local_agg_without_table_rowcount"), null, TExplainLevel.NORMAL);
+        // check local aggregate
+        Assert.assertTrue(replayPair.second.contains("1:AGGREGATE (update finalize)\n" +
+                "  |  output: multi_distinct_count(4: lo_partkey)"));
+    }
 }

--- a/fe/fe-core/src/test/resources/sql/query_dump/local_agg_without_table_rowcount.json
+++ b/fe/fe-core/src/test/resources/sql/query_dump/local_agg_without_table_rowcount.json
@@ -1,0 +1,28 @@
+{
+  "statement":"SELECT COUNT (DISTINCT lo_partkey), lo_orderkey FROM lineorder group by lo_orderkey limit 1;\n",
+  "table_meta":{
+    "ssb_100g.lineorder":"CREATE TABLE `lineorder` (\n  `lo_orderkey` int(11) NOT NULL COMMENT \"\",\n  `lo_linenumber` int(11) NOT NULL COMMENT \"\",\n  `lo_custkey` int(11) NOT NULL COMMENT \"\",\n  `lo_partkey` int(11) NOT NULL COMMENT \"\",\n  `lo_suppkey` int(11) NOT NULL COMMENT \"\",\n  `lo_orderdate` int(11) NOT NULL COMMENT \"\",\n  `lo_orderpriority` varchar(16) NOT NULL COMMENT \"\",\n  `lo_shippriority` int(11) NOT NULL COMMENT \"\",\n  `lo_quantity` int(11) NOT NULL COMMENT \"\",\n  `lo_extendedprice` int(11) NOT NULL COMMENT \"\",\n  `lo_ordtotalprice` int(11) NOT NULL COMMENT \"\",\n  `lo_discount` int(11) NOT NULL COMMENT \"\",\n  `lo_revenue` int(11) NOT NULL COMMENT \"\",\n  `lo_supplycost` int(11) NOT NULL COMMENT \"\",\n  `lo_tax` int(11) NOT NULL COMMENT \"\",\n  `lo_commitdate` int(11) NOT NULL COMMENT \"\",\n  `lo_shipmode` varchar(11) NOT NULL COMMENT \"\"\n) ENGINE\u003dOLAP \nDUPLICATE KEY(`lo_orderkey`)\nCOMMENT \"OLAP\"\nPARTITION BY RANGE(`lo_orderdate`)\n(PARTITION p1 VALUES [(\"-2147483648\"), (\"19930101\")),\nPARTITION p2 VALUES [(\"19930101\"), (\"19940101\")),\nPARTITION p3 VALUES [(\"19940101\"), (\"19950101\")),\nPARTITION p4 VALUES [(\"19950101\"), (\"19960101\")),\nPARTITION p5 VALUES [(\"19960101\"), (\"19970101\")),\nPARTITION p6 VALUES [(\"19970101\"), (\"19980101\")),\nPARTITION p7 VALUES [(\"19980101\"), (\"19990101\")))\nDISTRIBUTED BY HASH(`lo_orderkey`) BUCKETS 48 \nPROPERTIES (\n\"replication_num\" \u003d \"1\",\n\"colocate_with\" \u003d \"groupa1\",\n\"in_memory\" \u003d \"false\",\n\"storage_format\" \u003d \"DEFAULT\"\n);"
+  },
+  "table_row_count":{
+    "ssb_100g.lineorder":{
+      "p1":0,
+      "p2":0,
+      "p3":0,
+      "p4":0,
+      "p5":0,
+      "p6":0,
+      "p7":0
+    }
+  },
+  "session_variables":"{\"enable_resource_group\":false,\"chunk_size\":4096,\"disable_bucket_join\":false,\"runtime_join_filter_push_down_limit\":1024000,\"global_runtime_filter_probe_min_selectivity\":0.5,\"codegen_level\":0,\"cbo_cte_reuse\":false,\"character_set_connection\":\"utf8\",\"cbo_use_correlated_join_estimate\":true,\"enable_insert_strict\":true,\"enable_filter_unused_columns_in_scan_stage\":false,\"div_precision_increment\":4,\"tx_isolation\":\"REPEATABLE-READ\",\"wait_timeout\":28800,\"cbo_cte_reuse_rate\":1.2,\"auto_increment_increment\":1,\"foreign_key_checks\":true,\"character_set_client\":\"utf8\",\"autocommit\":true,\"enable_column_expr_predicate\":true,\"character_set_results\":\"utf8\",\"pipeline_profile_level\":1,\"parallel_fragment_exec_instance_num\":4,\"max_scan_key_num\":-1,\"enable_global_runtime_filter\":true,\"forward_to_master\":false,\"net_read_timeout\":60,\"streaming_preaggregation_mode\":\"auto\",\"storage_engine\":\"olap\",\"cbo_enable_dp_join_reorder\":true,\"cbo_enable_low_cardinality_optimize\":true,\"tx_visible_wait_timeout\":10,\"cbo_max_reorder_node_use_exhaustive\":4,\"new_planner_optimize_timeout\":3000,\"force_schedule_local\":false,\"pipeline_dop\":0,\"enable_query_dump\":false,\"cbo_enable_greedy_join_reorder\":true,\"prefer_join_method\":\"broadcast\",\"single_node_exec_plan\":false,\"load_mem_limit\":0,\"global_runtime_filter_build_max_size\":67108864,\"sql_select_limit\":9223372036854775807,\"profiling\":false,\"sql_safe_updates\":0,\"enable_pipeline_engine\":false,\"query_cache_type\":0,\"disable_colocate_join\":false,\"max_pushdown_conditions_per_column\":-1,\"global_runtime_filter_probe_min_size\":102400,\"enable_vectorized_engine\":true,\"net_write_timeout\":60,\"collation_database\":\"utf8_general_ci\",\"hash_join_push_down_right_table\":true,\"enable_exchange_pass_through\":true,\"new_planner_agg_stage\":0,\"collation_connection\":\"utf8_general_ci\",\"resource_group\":\"normal\",\"broadcast_row_limit\":15000000,\"workgroup_id\":0,\"exec_mem_limit\":48318382080,\"cbo_max_reorder_node_use_dp\":10,\"disable_join_reorder\":false,\"is_report_success\":true,\"enable_groupby_use_output_alias\":false,\"net_buffer_length\":16384,\"transmission_compression_type\":\"LZ4\",\"enable_vectorized_insert\":true,\"interactive_timeout\":3600,\"enable_spilling\":false,\"batch_size\":1024,\"cbo_enable_replicated_join\":true,\"max_allowed_packet\":1048576,\"query_timeout\":180,\"enable_cbo\":true,\"collation_server\":\"utf8_general_ci\",\"time_zone\":\"Asia/Shanghai\",\"max_execution_time\":3000000,\"character_set_server\":\"utf8\",\"cbo_use_nth_exec_plan\":0,\"rewrite_count_distinct_to_bitmap_hll\":true,\"parallel_exchange_instance_num\":-1,\"sql_mode\":34,\"SQL_AUTO_IS_NULL\":false,\"event_scheduler\":\"OFF\",\"disable_streaming_preaggregations\":false}",
+  "column_statistics":{
+    "ssb_100g.lineorder":{
+      "lo_partkey":"[1.0, 1000000.0, 0.0, 4.0, 999528.0] ESTIMATE",
+      "lo_orderkey":"[1.0, 6.0E8, 0.0, 4.0, 1.48064528E8] ESTIMATE"
+    }
+  },
+  "be_number":3,
+  "exception":[
+
+  ]
+}


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3817 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

We will get a bad plan at startup for FE
The slow query explain：
```
PLAN FRAGMENT 0
 OUTPUT EXPRS:18: count | 1: lo_orderkey
  PARTITION: UNPARTITIONED

  RESULT SINK

  3:EXCHANGE
     limit: 1

PLAN FRAGMENT 1
 OUTPUT EXPRS:
  PARTITION: RANDOM

  STREAM DATA SINK
    EXCHANGE ID: 03
    UNPARTITIONED

  2:AGGREGATE (update finalize)
  |  output: count(4: lo_partkey)
  |  group by: 1: lo_orderkey
  |  limit: 1
  |  
  1:AGGREGATE (update serialize)
  |  group by: 1: lo_orderkey, 4: lo_partkey
  |  
  0:OlapScanNode
     TABLE: lineorder
     PREAGGREGATION: ON
     partitions=7/7
     rollup: lineorder
     tabletRatio=336/336
     tabletList=10037,10039,10041,10043,10045,10047,10049,10051,10053,10055 ...
     cardinality=1
     avgRowSize=8.0
     numNodes=0
```
When Fe startup, before the row count get from BE, the cost will makes no sense, we useually give a plan that does not seriously degrade performance. 

The optimizer choose 3 stage instead of 1 stage aggregate because of one stage will compute extra cost for multi_distinct_count function, but it's useless when table row count are not get from BE