### PR TITLE
AssertNodes should not output const column

### DIFF
--- a/be/src/exec/pipeline/assert_num_rows_operator.cpp
+++ b/be/src/exec/pipeline/assert_num_rows_operator.cpp
@@ -16,7 +16,7 @@ Status AssertNumRowsOperator::prepare(RuntimeState* state) {
 
     for (const auto& desc : _factory->row_desc()->tuple_descriptors()) {
         for (const auto& slot : desc->slots()) {
-            chunk->append_column(ColumnHelper::create_const_null_column(1), slot->id());
+            chunk->append_column(ColumnHelper::create_column(slot->type(), true, false, 1), slot->id());
         }
     }
 

--- a/be/src/exec/vectorized/assert_num_rows_node.cpp
+++ b/be/src/exec/vectorized/assert_num_rows_node.cpp
@@ -60,10 +60,11 @@ Status AssertNumRowsNode::open(RuntimeState* state) {
     if (_assertion == TAssertion::LE && _num_rows_returned == 0) {
         _input_chunks.clear();
 
-        vectorized::ChunkPtr chunk = std::make_shared<vectorized::Chunk>();
+        chunk = std::make_shared<vectorized::Chunk>();
         for (const auto& desc : row_desc().tuple_descriptors()) {
             for (const auto& slot : desc->slots()) {
-                chunk->append_column(ColumnHelper::create_const_null_column(_desired_num_rows), slot->id());
+                chunk->append_column(ColumnHelper::create_column(slot->type(), true, false, _desired_num_rows),
+                                     slot->id());
             }
         }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3819 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

All ExecNodes should not direct return const column
otherwise all exec nodes should check if it have const column