### PR TITLE
bugfix: cache desc tbl

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -156,18 +156,22 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
     }
     _fragment_ctx->prepare_pass_through_chunk_buffer();
 
-    // Set up desc tbl
     auto* obj_pool = runtime_state->obj_pool();
+    // Set up desc tbl
     DescriptorTbl* desc_tbl = nullptr;
-    if (t_desc_tbl.__isset.is_cached && t_desc_tbl.is_cached) {
-        desc_tbl = _query_ctx->desc_tbl();
-        if (desc_tbl == nullptr) {
-            return Status::Cancelled("Query terminates prematurely");
+    if (t_desc_tbl.__isset.is_cached) {
+        if (t_desc_tbl.is_cached) {
+            desc_tbl = _query_ctx->desc_tbl();
+            if (desc_tbl == nullptr) {
+                return Status::Cancelled("Query terminates prematurely");
+            }
+        } else {
+            RETURN_IF_ERROR(DescriptorTbl::create(_query_ctx->object_pool(), t_desc_tbl, &desc_tbl,
+                                                  runtime_state->chunk_size()));
+            _query_ctx->set_desc_tbl(desc_tbl);
         }
     } else {
-        RETURN_IF_ERROR(
-                DescriptorTbl::create(_query_ctx->object_pool(), t_desc_tbl, &desc_tbl, runtime_state->chunk_size()));
-        _query_ctx->set_desc_tbl(desc_tbl);
+        RETURN_IF_ERROR(DescriptorTbl::create(obj_pool, t_desc_tbl, &desc_tbl, runtime_state->chunk_size()));
     }
     runtime_state->set_desc_tbl(desc_tbl);
     // Set up plan

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -509,6 +509,7 @@ public class Coordinator {
                     descTable.setTupleDescriptors(Collections.emptyList());
                     if (isFirst) {
                         descTable = this.descTable;
+                        descTable.setIs_cached(false);
                         isFirst = false;
                     }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：

When desc tbl cache is enabled, BE cache desc tbl only once, there is a DCHECK guarantee this invariant. But in SR rolling upgrade, BE is upgraded at first, at this point,  every fragment instance delivered by the FE of previous version  would carry desc tbl, so the cache only once invariant is violated and the BE crashes. this PR fixed this problem.