### PR TITLE
Fix potential daadlock (#3811)

### DIFF
--- a/be/src/runtime/tablets_channel.cpp
+++ b/be/src/runtime/tablets_channel.cpp
@@ -105,11 +105,7 @@ void TabletsChannel::add_chunk(brpc::Controller* cntl, const PTabletWriterAddChu
     Sender& sender = _senders[request.sender_id()];
     std::lock_guard l(sender.lock);
 
-    if (sender.next_seq < 0) {
-        response->mutable_status()->set_status_code(TStatusCode::INTERNAL_ERROR);
-        response->mutable_status()->add_error_msgs("Tablet channel has been cancelled");
-        return;
-    } else if (request.packet_seq() == sender.next_seq) {
+    if (request.packet_seq() == sender.next_seq) {
         sender.next_seq++;
     } else if (request.packet_seq() < sender.next_seq) {
         LOG(INFO) << "Ignore outdated request from " << cntl->remote_side() << ". seq=" << request.packet_seq()
@@ -301,10 +297,6 @@ Status TabletsChannel::_open_all_writers(const PTabletWriterOpenRequest& params)
 }
 
 void TabletsChannel::cancel() {
-    for (auto& sender : _senders) {
-        std::lock_guard l(sender.lock);
-        sender.next_seq = -1;
-    }
     for (auto& it : _delta_writers) {
         (void)it.second->abort();
     }

--- a/be/src/runtime/tablets_channel.h
+++ b/be/src/runtime/tablets_channel.h
@@ -107,7 +107,7 @@ private:
 
     struct Sender {
         std::mutex lock;
-        int64_t next_seq = 0; // NOTE: -1 means this sender has closed
+        int64_t next_seq = 0;
         bool closed = false;
     };
 


### PR DESCRIPTION
The class `LocalChannel` has a mutex variable named `_lock` and class
`TabletsChannel::Sender` also has a mutex variable named `lock`.

It's possible to run `LoadChannel::cancel()` and `TabletsChannel::add_chunk()`
concurrently, and both of them will acquire the above-mentioned mutex variables,
with different orders, which may cause a deadlock.
