### PR TITLE
fix load compatibility between version 2.1 and previous version due t…

### DIFF
--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -126,6 +126,9 @@ void NodeChannel::open() {
         request.set_load_mem_limit(_parent->_load_mem_limit);
     }
     request.set_load_channel_timeout_s(_parent->_load_channel_timeout_s);
+    // when load coordinator BE have upgrade to 2.1 but other BE still in 2.0 or previous
+    // we need use is_vectorized to make other BE open vectorized delta writer
+    request.set_is_vectorized(true);
 
     // set global dict
     const auto& global_dict = _runtime_state->get_load_global_dict_map();

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -139,7 +139,7 @@ message PTabletWriterOpenRequest {
     required bool need_gen_rollup = 7; // Deprecated
     optional int64 load_mem_limit = 8;
     optional int64 load_channel_timeout_s = 9;
-    optional bool is_vectorized = 20 [deprecated = true];
+    optional bool is_vectorized = 20; // Deprecate if we confirm all customer have upgrade to 2.1
 };
 
 message PTabletWriterOpenResult {


### PR DESCRIPTION
…o is_vectorized

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
Fixes #3828 

## Problem Summary(Required) ：
when load coordinator BE have upgrade to 2.1 but other BE still in 2.0 or previous
we need use is_vectorized to make other BE open vectorized delta writer
