### PR TITLE
EnvS3: support open file for write with mode MUST_CREATE

### DIFF
--- a/be/src/env/env_s3.cpp
+++ b/be/src/env/env_s3.cpp
@@ -226,7 +226,10 @@ StatusOr<std::unique_ptr<WritableFile>> EnvS3::new_writable_file(const WritableF
     if (!uri.parse(fname)) {
         return Status::InvalidArgument(fmt::format("Invalid S3 URI {}", fname));
     }
-    if (opts.mode != Env::CREATE_OR_OPEN_WITH_TRUNCATE) {
+    // NOTE: if the open mode is MUST_CREATE, technology we should send a head object request first
+    // before creating the S3OutputStream, but since this API only used in test environment now,
+    // here we assume that the caller can ensure that the file does not exist by themself.
+    if (opts.mode != Env::CREATE_OR_OPEN_WITH_TRUNCATE && opts.mode != Env::MUST_CREATE) {
         return Status::NotSupported(fmt::format("EnvS3 does not support open mode {}", opts.mode));
     }
     auto client = new_s3client(uri);


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Support open file for write with mode MUST_CREATE in EnvS3.
