### PR TITLE
Bugfix: reset RowsetTxnMetaPB if BetaRowsetWriter has final merge

### DIFF
--- a/be/src/storage/rowset/beta_rowset_writer.cpp
+++ b/be/src/storage/rowset/beta_rowset_writer.cpp
@@ -445,6 +445,9 @@ Status HorizontalBetaRowsetWriter::_final_merge() {
     _num_rows_written = 0;
     _total_data_size = 0;
     _total_index_size = 0;
+    if (_rowset_txn_meta_pb) {
+        _rowset_txn_meta_pb->clear_partial_rowset_footers();
+    }
 
     // since the segment already NONOVERLAPPING here, make the _create_segment_writer
     // method to create segment data files, rather than temporary segment files.


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Problem Summary(Required) ：
If BetaRowsetWriter has final merge, it will produce new partial rowset footers and append them to partial_rowset_footers array, but this array already have old entries, should clear those entries before write new segments for final merge.