### PR TITLE
Fix chunk size cause crash when rolling upgrade

### DIFF
--- a/be/src/common/constexpr.h
+++ b/be/src/common/constexpr.h
@@ -1,0 +1,8 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#pragma once
+
+namespace starrocks {
+// default value of chunk_size, it's a value decided at compile time
+constexpr const int DEFAULT_CHUNK_SIZE = 4096;
+} // namespace starrocks

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -147,7 +147,7 @@ Status RuntimeState::init(const TUniqueId& fragment_instance_id, const TQueryOpt
         _query_options.max_errors = 100;
     }
 
-    // if BE was in grayscale upgrade. old BE chunk size was 4094.
+    // if BE was in grayscale upgrade. old BE chunk size was 4096.
     // if FE set a zero batch_size, batch_size will be set to DEFAULT_CHUNK_SIZE
     // (DEFAULT_CHUNK_SIZE was 2048 before version 2.0/2.1.0). which will cause overflow
     if (_query_options.batch_size <= DEFAULT_CHUNK_SIZE) {

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -147,7 +147,10 @@ Status RuntimeState::init(const TUniqueId& fragment_instance_id, const TQueryOpt
         _query_options.max_errors = 100;
     }
 
-    if (_query_options.batch_size <= 0) {
+    // if BE was in grayscale upgrade. old BE chunk size was 4094.
+    // if FE set a zero batch_size, batch_size will be set to DEFAULT_CHUNK_SIZE
+    // (DEFAULT_CHUNK_SIZE was 2048 before version 2.0/2.1.0). which will cause overflow
+    if (_query_options.batch_size <= DEFAULT_CHUNK_SIZE) {
         _query_options.batch_size = DEFAULT_CHUNK_SIZE;
     }
 

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -275,8 +275,6 @@ private:
 
     Status _build_global_dict(const GlobalDictLists& global_dict_list, vectorized::GlobalDictMaps* result);
 
-    static const int DEFAULT_CHUNK_SIZE = 4096;
-
     // put runtime state before _obj_pool, so that it will be deconstructed after
     // _obj_pool. Because some of object in _obj_pool will use profile when deconstructing.
     std::shared_ptr<RuntimeProfile> _profile;

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -30,6 +30,7 @@
 #include <vector>
 
 #include "cctz/time_zone.h"
+#include "common/constexpr.h"
 #include "common/global_types.h"
 #include "common/object_pool.h"
 #include "gen_cpp/InternalService_types.h" // for TQueryOptions

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -275,7 +275,7 @@ private:
 
     Status _build_global_dict(const GlobalDictLists& global_dict_list, vectorized::GlobalDictMaps* result);
 
-    static const int DEFAULT_CHUNK_SIZE = 2048;
+    static const int DEFAULT_CHUNK_SIZE = 4096;
 
     // put runtime state before _obj_pool, so that it will be deconstructed after
     // _obj_pool. Because some of object in _obj_pool will use profile when deconstructing.

--- a/be/src/storage/olap_define.h
+++ b/be/src/storage/olap_define.h
@@ -72,7 +72,7 @@ static const uint64_t GB_EXCHANGE_BYTE = 1024 * 1024 * 1024;
 static const double BLOOM_FILTER_DEFAULT_FPP = 0.05;
 
 // default value of chunk_size, it's a value decided at compile time
-static const int32_t DEFAULT_CHUNK_SIZE = 4096;
+constexpr const int32_t DEFAULT_CHUNK_SIZE = 4096;
 
 #define OLAP_GOTO(label) goto label
 

--- a/be/src/storage/olap_define.h
+++ b/be/src/storage/olap_define.h
@@ -26,6 +26,8 @@
 #include <sstream>
 #include <string>
 
+#include "common/constexpr.h"
+
 namespace starrocks {
 
 // The block size of the column storage file, which may be loaded into memory in its entirety, needs to be strictly controlled, defined here as 256MB
@@ -70,9 +72,6 @@ static const uint64_t GB_EXCHANGE_BYTE = 1024 * 1024 * 1024;
 
 // bloom filter fpp
 static const double BLOOM_FILTER_DEFAULT_FPP = 0.05;
-
-// default value of chunk_size, it's a value decided at compile time
-constexpr const int32_t DEFAULT_CHUNK_SIZE = 4096;
 
 #define OLAP_GOTO(label) goto label
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
Fixes #3834 

## Problem Summary(Required) ：
old BE config::chunk_size was 4096, but old FE not set batch_size. so BE chunk size was DEFAULT_CHUNK_SIZE.
so if new BE DEFAULT_CHUNK_SIZE less than old BE. which may cause heap-buffer-overflow
