### PR TITLE
Support for modifying hive external table resource properties through SQL

### DIFF
--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -826,6 +826,11 @@ alter_stmt ::=
     {:
         RESULT = new AlterRoutineLoadStmt(jobLabel, loadPropertyList, jobProperties, datasourceProperties);
     :}
+    /* resource */
+    | KW_ALTER KW_RESOURCE ident_or_text:resourceName opt_properties:properties
+    {:
+        RESULT = new AlterResourceStmt(resourceName,properties);
+    :}
     | alter_resource_group_stmt:stmt
     {:
         RESULT = stmt;

--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -827,7 +827,7 @@ alter_stmt ::=
         RESULT = new AlterRoutineLoadStmt(jobLabel, loadPropertyList, jobProperties, datasourceProperties);
     :}
     /* resource */
-    | KW_ALTER KW_RESOURCE ident_or_text:resourceName opt_properties:properties
+    | KW_ALTER KW_RESOURCE ident_or_text:resourceName KW_SET opt_properties:properties
     {:
         RESULT = new AlterResourceStmt(resourceName, properties);
     :}

--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -829,7 +829,7 @@ alter_stmt ::=
     /* resource */
     | KW_ALTER KW_RESOURCE ident_or_text:resourceName opt_properties:properties
     {:
-        RESULT = new AlterResourceStmt(resourceName,properties);
+        RESULT = new AlterResourceStmt(resourceName, properties);
     :}
     | alter_resource_group_stmt:stmt
     {:

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/AlterResourceStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/AlterResourceStmt.java
@@ -60,7 +60,7 @@ public class AlterResourceStmt extends DdlStmt {
         StringBuilder sb = new StringBuilder();
         sb.append("ALTER ");
         sb.append("RESOURCE '").append(resourceName).append("' ");
-        sb.append("PROPERTIES(").append(new PrintableMap<>(properties, "=", true, false)).append(")");
+        sb.append("SET PROPERTIES(").append(new PrintableMap<>(properties, "=", true, false)).append(")");
         return sb.toString();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/AlterResourceStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/AlterResourceStmt.java
@@ -39,7 +39,7 @@ public class AlterResourceStmt extends DdlStmt {
     private final String resourceName;
     private final Map<String, String> properties;
 
-    public AlterResourceStmt(String resourceName,Map<String, String> properties) {
+    public AlterResourceStmt(String resourceName, Map<String, String> properties) {
         this.resourceName = resourceName;
         this.properties = properties;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/AlterResourceStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/AlterResourceStmt.java
@@ -2,7 +2,6 @@
 package com.starrocks.analysis;
 
 import com.starrocks.catalog.Catalog;
-import com.starrocks.catalog.Resource.ResourceType;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/AlterResourceStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/AlterResourceStmt.java
@@ -1,23 +1,3 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateResourceStmt.java
-
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
 
 package com.starrocks.analysis;
 

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/AlterResourceStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/AlterResourceStmt.java
@@ -11,6 +11,7 @@ import com.starrocks.common.UserException;
 import com.starrocks.common.util.PrintableMap;
 import com.starrocks.mysql.privilege.PrivPredicate;
 import com.starrocks.qe.ConnectContext;
+
 import java.util.Map;
 
 public class AlterResourceStmt extends DdlStmt {

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/AlterResourceStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/AlterResourceStmt.java
@@ -71,7 +71,7 @@ public class AlterResourceStmt extends DdlStmt {
 
         // not allow to modify the resource type
         if (properties.get(TYPE) != null) {
-            throw  new AnalysisException("Not allow to modify the resource type ! ");
+            throw new AnalysisException("Not allow to modify the resource type");
         }
 
     }

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/AlterResourceStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/AlterResourceStmt.java
@@ -1,3 +1,4 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
 
 package com.starrocks.analysis;
 

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/AlterResourceStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/AlterResourceStmt.java
@@ -1,0 +1,88 @@
+// This file is made available under Elastic License 2.0.
+// This file is based on code available under the Apache license here:
+//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateResourceStmt.java
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.analysis;
+
+import com.starrocks.catalog.Catalog;
+import com.starrocks.catalog.Resource.ResourceType;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.common.ErrorCode;
+import com.starrocks.common.ErrorReport;
+import com.starrocks.common.FeNameFormat;
+import com.starrocks.common.UserException;
+import com.starrocks.common.util.PrintableMap;
+import com.starrocks.mysql.privilege.PrivPredicate;
+import com.starrocks.qe.ConnectContext;
+import java.util.Map;
+
+public class AlterResourceStmt extends DdlStmt {
+    private static final String TYPE = "type";
+
+    private final String resourceName;
+    private final Map<String, String> properties;
+
+    public AlterResourceStmt(String resourceName,Map<String, String> properties) {
+        this.resourceName = resourceName;
+        this.properties = properties;
+    }
+
+    public String getResourceName() {
+        return resourceName;
+    }
+
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    @Override
+    public void analyze(Analyzer analyzer) throws UserException {
+        super.analyze(analyzer);
+
+        // check auth
+        if (!Catalog.getCurrentCatalog().getAuth().checkGlobalPriv(ConnectContext.get(), PrivPredicate.ADMIN)) {
+            ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "ADMIN");
+        }
+
+        // check name
+        FeNameFormat.checkResourceName(resourceName);
+
+        // check properties
+        if (properties == null || properties.isEmpty()) {
+            throw new AnalysisException("Resource properties can't be null");
+        }
+
+        // not allow to modify the resource type
+        if (properties.get(TYPE) != null) {
+            throw  new AnalysisException("Not allow to modify the resource type ! ");
+        }
+
+    }
+
+    @Override
+    public String toSql() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("ALTER ");
+        sb.append("RESOURCE '").append(resourceName).append("' ");
+        sb.append("PROPERTIES(").append(new PrintableMap<>(properties, "=", true, false)).append(")");
+        return sb.toString();
+    }
+}
+

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveResource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveResource.java
@@ -51,8 +51,8 @@ public class HiveResource extends Resource {
         this.properties = properties;
     }
 
-    protected Map<String, String> getProperties(){
-        return this.properties ;
+    protected Map<String, String> getProperties() {
+        return this.properties;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveResource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveResource.java
@@ -4,13 +4,11 @@ package com.starrocks.catalog;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.proc.BaseProcResult;
 import org.apache.commons.lang.StringUtils;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import static com.starrocks.common.util.Util.validateMetastoreUris;
@@ -29,17 +27,15 @@ import static com.starrocks.common.util.Util.validateMetastoreUris;
  * DROP RESOURCE "hive0";
  */
 public class HiveResource extends Resource {
+
+    // require only one property currently
     private static final String HIVE_METASTORE_URIS = "hive.metastore.uris";
 
     @SerializedName(value = "metastoreURIs")
     private String metastoreURIs;
 
-    @SerializedName(value = "properties")
-    private Map<String, String> properties;
-
     public HiveResource(String name) {
         super(name, ResourceType.HIVE);
-        this.properties = new HashMap<>();
     }
 
     @Override
@@ -51,8 +47,6 @@ public class HiveResource extends Resource {
             throw new DdlException(HIVE_METASTORE_URIS + " must be set in properties");
         }
         validateMetastoreUris(metastoreURIs);
-
-        this.properties = properties;
     }
 
     @Override
@@ -65,16 +59,24 @@ public class HiveResource extends Resource {
         return metastoreURIs;
     }
 
-    public HiveResource copyOne() throws DdlException {
-        HiveResource hiveResource = new HiveResource(this.name);
-        hiveResource.setProperties(this.properties);
-        return hiveResource ;
-    }
-
-    public HiveResource upsert(Map<String, String> properties){
+    /**
+     * <p>alter the resource properties.</p>
+     * <p>the user can not alter the property that the system does not support.
+     * currently , hive resource only support 'hive.metastore.uris' property to alter.
+     * @param properties the properties that user uses to alter </p>
+     * @throws DdlException
+     */
+    public void alterProperties(Map<String, String> properties) throws DdlException {
         Preconditions.checkState(properties != null, "properties can not be null");
-        properties.forEach((k, v) -> properties.put(k, v));
-        return this ;
-    }
 
+        for (Map.Entry<String, String> entry : properties.entrySet()) {
+            String key = entry.getKey();
+            String value = entry.getValue();
+            if (HIVE_METASTORE_URIS.equals(key)) {
+                this.metastoreURIs = value;
+            } else {
+                throw new DdlException(String.format("property %s has not support yet", key));
+            }
+        }
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveResource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveResource.java
@@ -73,6 +73,10 @@ public class HiveResource extends Resource {
             String key = entry.getKey();
             String value = entry.getValue();
             if (HIVE_METASTORE_URIS.equals(key)) {
+                if (StringUtils.isBlank(value)) {
+                    throw new DdlException(HIVE_METASTORE_URIS + " can not be null");
+                }
+                validateMetastoreUris(value);
                 this.metastoreURIs = value;
             } else {
                 throw new DdlException(String.format("property %s has not support yet", key));

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveResource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveResource.java
@@ -30,9 +30,6 @@ import static com.starrocks.common.util.Util.validateMetastoreUris;
 public class HiveResource extends Resource {
     private static final String HIVE_METASTORE_URIS = "hive.metastore.uris";
 
-    @SerializedName(value = "metastoreURIs")
-    private String metastoreURIs;
-
     @SerializedName(value = "properties")
     private Map<String, String> properties;
 
@@ -45,20 +42,27 @@ public class HiveResource extends Resource {
     protected void setProperties(Map<String, String> properties) throws DdlException {
         Preconditions.checkState(properties != null);
 
-        metastoreURIs = properties.get(HIVE_METASTORE_URIS);
+        String metastoreURIs = properties.get(HIVE_METASTORE_URIS);
         if (StringUtils.isBlank(metastoreURIs)) {
             throw new DdlException(HIVE_METASTORE_URIS + " must be set in properties");
         }
         validateMetastoreUris(metastoreURIs);
+
+        this.properties = properties;
+    }
+
+    protected Map<String, String> getProperties(){
+        return this.properties ;
     }
 
     @Override
     protected void getProcNodeData(BaseProcResult result) {
-        String lowerCaseType = type.name().toLowerCase();
-        result.addRow(Lists.newArrayList(name, lowerCaseType, HIVE_METASTORE_URIS, metastoreURIs));
+        String lowerCaseType = super.type.name().toLowerCase();
+        result.addRow(Lists.newArrayList(super.name, lowerCaseType,
+                HIVE_METASTORE_URIS, this.properties.get(HIVE_METASTORE_URIS)));
     }
 
     public String getHiveMetastoreURIs() {
-        return metastoreURIs;
+        return this.properties.get(HIVE_METASTORE_URIS);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveResource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveResource.java
@@ -62,8 +62,9 @@ public class HiveResource extends Resource {
     /**
      * <p>alter the resource properties.</p>
      * <p>the user can not alter the property that the system does not support.
-     * currently , hive resource only support 'hive.metastore.uris' property to alter.
-     * @param properties the properties that user uses to alter </p>
+     * currently , hive resource only support 'hive.metastore.uris' property to alter. </p>
+     *
+     * @param properties the properties that user uses to alter
      * @throws DdlException
      */
     public void alterProperties(Map<String, String> properties) throws DdlException {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
@@ -268,7 +268,6 @@ public class HiveTable extends Table {
             LOG.warn("table {} gets partitions stats failed.", name, e);
         }
 
-
         for (int i = 0; i < partitionsStats.size(); i++) {
             long partNumRows = partitionsStats.get(i).getNumRows();
             long partTotalFileBytes = partitionsStats.get(i).getTotalFileBytes();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
@@ -147,6 +147,13 @@ public class HiveTable extends Table {
     }
 
     public Map<String, String> getHiveProperties() {
+        // The user may alter the resource properties
+        // So we do this to get the fresh properties
+        Resource resource = Catalog.getCurrentCatalog().getResourceMgr().getResource(resourceName);
+        if (resource != null) {
+            HiveResource hiveResource = (HiveResource) resource;
+            hiveProperties.put(HIVE_METASTORE_URIS, hiveResource.getHiveMetastoreURIs());
+        }
         return hiveProperties;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceMgr.java
@@ -61,7 +61,6 @@ public class ResourceMgr implements Writable {
     @SerializedName(value = "nameToResource")
     private final Hashtable<String, Resource> nameToResource = new Hashtable<>();
     private final ResourceProcNode procNode = new ResourceProcNode();
-    private final String TYPE = "type";
 
     public ResourceMgr() {
     }
@@ -122,10 +121,10 @@ public class ResourceMgr implements Writable {
 
         if (resource instanceof HiveResource) {
             // update the properties
-            Map<String,String> properties = ((HiveResource)resource).getProperties();
+            Map<String, String> properties = ((HiveResource) resource).getProperties();
             for (Map.Entry<String, String> entry : stmt.getProperties().entrySet()) {
-                String key = entry.getKey() ;
-                if (!properties.containsKey(key)){
+                String key = entry.getKey();
+                if (!properties.containsKey(key)) {
                     throw new DdlException("Property(" + key + ") does not support");
                 }
                 properties.put(key, entry.getValue());
@@ -133,14 +132,14 @@ public class ResourceMgr implements Writable {
             resource.setProperties(properties);
 
             // update the nameToResource
-            nameToResource.put(name,resource);
+            nameToResource.put(name, resource);
 
             // drop the cache
             Catalog.getCurrentCatalog().getHiveRepository().clearCache(resource.getName());
 
             // update edit log
             Catalog.getCurrentCatalog().getEditLog().logCreateResource(resource);
-        }else{
+        } else {
             throw new DdlException("Alter resource statement only support external hive now");
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceMgr.java
@@ -42,9 +42,10 @@ import org.apache.logging.log4j.Logger;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
-import java.util.Hashtable;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  * Resource manager is responsible for managing external resources used by StarRocks.
@@ -59,21 +60,28 @@ public class ResourceMgr implements Writable {
             .build();
 
     @SerializedName(value = "nameToResource")
-    private final Hashtable<String, Resource> nameToResource = new Hashtable<>();
+    private final HashMap<String, Resource> nameToResource = new HashMap<>();
     private final ResourceProcNode procNode = new ResourceProcNode();
+    private final ReentrantReadWriteLock rwlock = new ReentrantReadWriteLock();
 
     public ResourceMgr() {
+
     }
 
     public void createResource(CreateResourceStmt stmt) throws DdlException {
-        Resource resource = Resource.fromStmt(stmt);
-        String resourceName = stmt.getResourceName();
-        if (nameToResource.putIfAbsent(resourceName, resource) != null) {
-            throw new DdlException("Resource(" + resourceName + ") already exist");
+        rwlock.writeLock().lock();
+        try {
+            Resource resource = Resource.fromStmt(stmt);
+            String resourceName = stmt.getResourceName();
+            if (nameToResource.putIfAbsent(resourceName, resource) != null) {
+                throw new DdlException("Resource(" + resourceName + ") already exist");
+            }
+            // log add
+            Catalog.getCurrentCatalog().getEditLog().logCreateResource(resource);
+            LOG.info("create resource success. resource: {}", resource);
+        } finally {
+            rwlock.writeLock().unlock();
         }
-        // log add
-        Catalog.getCurrentCatalog().getEditLog().logCreateResource(resource);
-        LOG.info("create resource success. resource: {}", resource);
     }
 
     public void replayCreateResource(Resource resource) {
@@ -81,17 +89,22 @@ public class ResourceMgr implements Writable {
     }
 
     public void dropResource(DropResourceStmt stmt) throws DdlException {
-        String name = stmt.getResourceName();
-        Resource resource = nameToResource.remove(name);
-        if (resource == null) {
-            throw new DdlException("Resource(" + name + ") does not exist");
+        rwlock.writeLock().lock();
+        try {
+            String name = stmt.getResourceName();
+            Resource resource = nameToResource.remove(name);
+            if (resource == null) {
+                throw new DdlException("Resource(" + name + ") does not exist");
+            }
+
+            onDropResource(resource);
+
+            // log drop
+            Catalog.getCurrentCatalog().getEditLog().logDropResource(new DropResourceOperationLog(name));
+            LOG.info("drop resource success. resource name: {}", name);
+        } finally {
+            rwlock.writeLock().lock();
         }
-
-        onDropResource(resource);
-
-        // log drop
-        Catalog.getCurrentCatalog().getEditLog().logDropResource(new DropResourceOperationLog(name));
-        LOG.info("drop resource success. resource name: {}", name);
     }
 
     public void replayDropResource(DropResourceOperationLog operationLog) {
@@ -106,13 +119,22 @@ public class ResourceMgr implements Writable {
     }
 
     public boolean containsResource(String name) {
-        return nameToResource.containsKey(name);
+        rwlock.readLock().lock();
+        try {
+            return nameToResource.containsKey(name);
+        } finally {
+            rwlock.readLock().unlock();
+        }
     }
 
     public Resource getResource(String name) {
-        return nameToResource.get(name);
+        rwlock.readLock().lock();
+        try {
+            return nameToResource.get(name);
+        } finally {
+            rwlock.readLock().unlock();
+        }
     }
-
 
     /**
      * alter resource statement only support external hive now .
@@ -120,34 +142,48 @@ public class ResourceMgr implements Writable {
      * @throws DdlException
      */
     public void alterResource(AlterResourceStmt stmt) throws DdlException {
-        String name = stmt.getResourceName();
+        rwlock.writeLock().lock();
+        try {
+            // check if the target resource exists .
+            String name = stmt.getResourceName();
+            Resource resource = this.getResource(name);
+            if (resource == null) {
+                throw new DdlException("Resource(" + name + ") does not exist");
+            }
 
-        //check if the target resource exists .
-        Resource resource = this.getResource(name);
-        if (resource == null) {
-            throw new DdlException("Resource(" + name + ") does not exist");
-        }
-
-        if (resource instanceof HiveResource) {
-            // 1. upsert the resource properties
-            // 2. update the nameToResource
-            // 3. drop the cache
-            // 4. update the edit log
-            HiveResource copiedRes = ((HiveResource) resource).copyOne().upsert(stmt.getProperties());
-            nameToResource.put(name, copiedRes);
-            Catalog.getCurrentCatalog().getHiveRepository().clearCache(resource.getName());
-            Catalog.getCurrentCatalog().getEditLog().logCreateResource(resource);
-        } else {
-            throw new DdlException("Alter resource statement only support external hive now");
+            if (resource instanceof HiveResource) {
+                // 1. alter the resource properties
+                // 2. update the nameToResource
+                // 3. drop the cache
+                // 4. update the edit log
+                ((HiveResource) resource).alterProperties(stmt.getProperties());
+                nameToResource.put(name, resource);
+                Catalog.getCurrentCatalog().getHiveRepository().clearCache(resource.getName());
+                Catalog.getCurrentCatalog().getEditLog().logCreateResource(resource);
+            } else {
+                throw new DdlException("Alter resource statement only support external hive now");
+            }
+        } finally {
+            rwlock.writeLock().unlock();
         }
     }
 
     public int getResourceNum() {
-        return nameToResource.size();
+        rwlock.readLock().lock();
+        try {
+            return nameToResource.size();
+        } finally {
+            rwlock.readLock().unlock();
+        }
     }
 
     public List<List<String>> getResourcesInfo() {
-        return procNode.fetchResult().getRows();
+        rwlock.readLock().lock();
+        try {
+            return procNode.fetchResult().getRows();
+        } finally {
+            rwlock.readLock().unlock();
+        }
     }
 
     public ResourceProcNode getProcNode() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceMgr.java
@@ -138,6 +138,7 @@ public class ResourceMgr implements Writable {
 
     /**
      * alter resource statement only support external hive now .
+     *
      * @param stmt
      * @throws DdlException
      */

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceMgr.java
@@ -107,7 +107,7 @@ public class ResourceMgr implements Writable {
     }
 
     /**
-     * alter resource statement only support hive now .
+     * alter resource statement only support external hive now .
      * @param stmt
      * @throws DdlException
      */
@@ -126,7 +126,7 @@ public class ResourceMgr implements Writable {
             for (Map.Entry<String, String> entry : stmt.getProperties().entrySet()) {
                 String key = entry.getKey() ;
                 if (!properties.containsKey(key)){
-                    throw new DdlException("Property(" + key + ") does not exist");
+                    throw new DdlException("Property(" + key + ") does not support");
                 }
                 properties.put(key, entry.getValue());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceMgr.java
@@ -153,11 +153,9 @@ public class ResourceMgr implements Writable {
 
             if (resource instanceof HiveResource) {
                 // 1. alter the resource properties
-                // 2. update the nameToResource
-                // 3. drop the cache
-                // 4. update the edit log
+                // 2. clear the cache
+                // 3. update the edit log
                 ((HiveResource) resource).alterProperties(stmt.getProperties());
-                nameToResource.put(name, resource);
                 Catalog.getCurrentCatalog().getHiveRepository().clearCache(resource.getName());
                 Catalog.getCurrentCatalog().getEditLog().logCreateResource(resource);
             } else {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DdlExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DdlExecutor.java
@@ -29,6 +29,7 @@ import com.starrocks.analysis.AdminSetReplicaStatusStmt;
 import com.starrocks.analysis.AlterClusterStmt;
 import com.starrocks.analysis.AlterDatabaseQuotaStmt;
 import com.starrocks.analysis.AlterDatabaseRename;
+import com.starrocks.analysis.AlterResourceStmt;
 import com.starrocks.analysis.AlterRoutineLoadStmt;
 import com.starrocks.analysis.AlterSystemStmt;
 import com.starrocks.analysis.AlterTableStmt;
@@ -225,6 +226,8 @@ public class DdlExecutor {
             catalog.getResourceMgr().createResource((CreateResourceStmt) ddlStmt);
         } else if (ddlStmt instanceof DropResourceStmt) {
             catalog.getResourceMgr().dropResource((DropResourceStmt) ddlStmt);
+        }else if (ddlStmt instanceof AlterResourceStmt) {
+            catalog.getResourceMgr().alterResource((AlterResourceStmt) ddlStmt);
         } else if (ddlStmt instanceof CancelExportStmt) {
             catalog.getExportMgr().cancelExportJob((CancelExportStmt) ddlStmt);
         } else if (ddlStmt instanceof CreateAnalyzeJobStmt) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DdlExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DdlExecutor.java
@@ -226,7 +226,7 @@ public class DdlExecutor {
             catalog.getResourceMgr().createResource((CreateResourceStmt) ddlStmt);
         } else if (ddlStmt instanceof DropResourceStmt) {
             catalog.getResourceMgr().dropResource((DropResourceStmt) ddlStmt);
-        }else if (ddlStmt instanceof AlterResourceStmt) {
+        } else if (ddlStmt instanceof AlterResourceStmt) {
             catalog.getResourceMgr().alterResource((AlterResourceStmt) ddlStmt);
         } else if (ddlStmt instanceof CancelExportStmt) {
             catalog.getExportMgr().cancelExportJob((CancelExportStmt) ddlStmt);

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterResourceStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterResourceStmtTest.java
@@ -28,7 +28,7 @@ public class AlterResourceStmtTest {
 
     @Test
     public void testAlterResourceProperties(@Mocked Catalog catalog, @Injectable Auth auth) throws UserException {
-        this.expectations(catalog,auth);
+        this.expectations(catalog, auth);
         Map<String, String> properties = Maps.newHashMap();
         properties.put("hive.metastore.uris", "thrift://10.10.44.98:9083");
         AlterResourceStmt stmt = new AlterResourceStmt("hive0",properties);

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterResourceStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterResourceStmtTest.java
@@ -1,23 +1,4 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateResourceStmt.java
-
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
 
 package com.starrocks.analysis;
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterResourceStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterResourceStmtTest.java
@@ -1,3 +1,24 @@
+// This file is made available under Elastic License 2.0.
+// This file is based on code available under the Apache license here:
+//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateResourceStmt.java
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package com.starrocks.analysis;
 
 import com.google.common.collect.Maps;

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterResourceStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterResourceStmtTest.java
@@ -53,7 +53,7 @@ public class AlterResourceStmtTest {
         AlterResourceStmt stmt = new AlterResourceStmt("hive0",properties);
         stmt.analyze(analyzer);
         Assert.assertEquals("hive0", stmt.getResourceName());
-        Assert.assertEquals("ALTER RESOURCE 'hive0' PROPERTIES(\"hive.metastore.uris\" = \"thrift://10.10.44.98:9083\")", stmt.toSql());
+        Assert.assertEquals("ALTER RESOURCE 'hive0' SET PROPERTIES(\"hive.metastore.uris\" = \"thrift://10.10.44.98:9083\")", stmt.toSql());
     }
 
     @Test(expected = AnalysisException.class)

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterResourceStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterResourceStmtTest.java
@@ -15,6 +15,7 @@ import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
 import java.util.Map;
 
 public class AlterResourceStmtTest {
@@ -31,31 +32,32 @@ public class AlterResourceStmtTest {
         this.expectations(catalog, auth);
         Map<String, String> properties = Maps.newHashMap();
         properties.put("hive.metastore.uris", "thrift://10.10.44.98:9083");
-        AlterResourceStmt stmt = new AlterResourceStmt("hive0",properties);
+        AlterResourceStmt stmt = new AlterResourceStmt("hive0", properties);
         stmt.analyze(analyzer);
         Assert.assertEquals("hive0", stmt.getResourceName());
-        Assert.assertEquals("ALTER RESOURCE 'hive0' SET PROPERTIES(\"hive.metastore.uris\" = \"thrift://10.10.44.98:9083\")", stmt.toSql());
+        Assert.assertEquals(
+                "ALTER RESOURCE 'hive0' SET PROPERTIES(\"hive.metastore.uris\" = \"thrift://10.10.44.98:9083\")",
+                stmt.toSql());
     }
 
     @Test(expected = AnalysisException.class)
     public void testNotAllowModifyResourceType(@Mocked Catalog catalog, @Injectable Auth auth) throws UserException {
-        this.expectations(catalog,auth);
+        this.expectations(catalog, auth);
         Map<String, String> properties = Maps.newHashMap();
         properties.put("type", "hive");
-        AlterResourceStmt stmt = new AlterResourceStmt("hive0",properties);
+        AlterResourceStmt stmt = new AlterResourceStmt("hive0", properties);
         stmt.analyze(analyzer);
     }
 
     @Test(expected = AnalysisException.class)
     public void testResourcePropertiesNotEmpty(@Mocked Catalog catalog, @Injectable Auth auth) throws UserException {
-        this.expectations(catalog,auth);
+        this.expectations(catalog, auth);
         Map<String, String> properties = Maps.newHashMap();
-        AlterResourceStmt stmt = new AlterResourceStmt("hive0",properties);
+        AlterResourceStmt stmt = new AlterResourceStmt("hive0", properties);
         stmt.analyze(analyzer);
     }
 
-
-    private void expectations(Catalog catalog, Auth auth){
+    private void expectations(Catalog catalog, Auth auth) {
         new Expectations() {
             {
                 catalog.getAuth();

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterResourceStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterResourceStmtTest.java
@@ -1,0 +1,67 @@
+package com.starrocks.analysis;
+
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.Catalog;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.common.UserException;
+import com.starrocks.mysql.privilege.Auth;
+import com.starrocks.mysql.privilege.PrivPredicate;
+import com.starrocks.qe.ConnectContext;
+import mockit.Expectations;
+import mockit.Injectable;
+import mockit.Mocked;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import java.util.Map;
+
+public class AlterResourceStmtTest {
+
+    private Analyzer analyzer;
+
+    @Before()
+    public void setUp() {
+        analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
+    }
+
+    @Test
+    public void testAlterResourceProperties(@Mocked Catalog catalog, @Injectable Auth auth) throws UserException {
+        this.expectations(catalog,auth);
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("hive.metastore.uris", "thrift://10.10.44.98:9083");
+        AlterResourceStmt stmt = new AlterResourceStmt("hive0",properties);
+        stmt.analyze(analyzer);
+        Assert.assertEquals("hive0", stmt.getResourceName());
+        Assert.assertEquals("ALTER RESOURCE 'hive0' PROPERTIES(\"hive.metastore.uris\" = \"thrift://10.10.44.98:9083\")", stmt.toSql());
+    }
+
+    @Test(expected = AnalysisException.class)
+    public void testNotAllowModifyResourceType(@Mocked Catalog catalog, @Injectable Auth auth) throws UserException {
+        this.expectations(catalog,auth);
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("type", "hive");
+        AlterResourceStmt stmt = new AlterResourceStmt("hive0",properties);
+        stmt.analyze(analyzer);
+    }
+
+    @Test(expected = AnalysisException.class)
+    public void testResourcePropertiesNotEmpty(@Mocked Catalog catalog, @Injectable Auth auth) throws UserException {
+        this.expectations(catalog,auth);
+        Map<String, String> properties = Maps.newHashMap();
+        AlterResourceStmt stmt = new AlterResourceStmt("hive0",properties);
+        stmt.analyze(analyzer);
+    }
+
+
+    private void expectations(Catalog catalog, Auth auth){
+        new Expectations() {
+            {
+                catalog.getAuth();
+                result = auth;
+                auth.checkGlobalPriv((ConnectContext) any, PrivPredicate.ADMIN);
+                result = true;
+            }
+        };
+    }
+
+}

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ResourceMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ResourceMgrTest.java
@@ -116,7 +116,7 @@ public class ResourceMgrTest {
         addHiveResource(mgr,editLog,catalog,auth) ;
 
         // alter hive resource
-        String newThriftPath = "thrift://10.10.44.xxx:9083" ;
+        String newThriftPath = "thrift://10.10.44.xxx:9083";
         Map<String,String> properties = new HashMap<>();
         properties.put("hive.metastore.uris", newThriftPath);
         AlterResourceStmt stmt = new AlterResourceStmt(name,properties);
@@ -127,10 +127,8 @@ public class ResourceMgrTest {
         Resource resource = mgr.getResource(name);
         Assert.assertTrue(resource instanceof HiveResource);
 
-        Map<String,String> proMapper = ((HiveResource)resource).getProperties();
-        Assert.assertEquals(2,proMapper.size());
-        Assert.assertEquals(newThriftPath,proMapper.get("hive.metastore.uris"));
-        Assert.assertEquals(type,proMapper.get("type"));
+        String metastoreURIs = ((HiveResource) resource).getHiveMetastoreURIs();
+        Assert.assertEquals(newThriftPath, metastoreURIs);
     }
 
     @Test(expected = DdlException.class)
@@ -176,7 +174,7 @@ public class ResourceMgrTest {
         // add hive resource
         name = "hive0";
         type = "hive" ;
-        addHiveResource(mgr,editLog,catalog,auth) ;
+        addHiveResource(mgr,editLog,catalog,auth);
 
         // alter hive resource
         Map<String,String> properties = new HashMap<>();
@@ -210,12 +208,6 @@ public class ResourceMgrTest {
 
         Resource resource = mgr.getResource(name);
         Assert.assertTrue(resource instanceof HiveResource);
-
-        Map<String,String> proMapper = ((HiveResource)resource).getProperties();
-        Assert.assertEquals(2,proMapper.size());
-        Assert.assertEquals("thrift://10.10.44.98:9083",proMapper.get("hive.metastore.uris"));
-        Assert.assertEquals(type,proMapper.get("type"));
-
         return stmt ;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ResourceMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ResourceMgrTest.java
@@ -73,10 +73,10 @@ public class ResourceMgrTest {
     @Test
     public void testAddDropResource(@Injectable BrokerMgr brokerMgr, @Injectable EditLog editLog,
                                     @Mocked Catalog catalog, @Injectable Auth auth) throws UserException {
-        ResourceMgr mgr = new ResourceMgr() ;
+        ResourceMgr mgr = new ResourceMgr();
 
         // add
-        addSparkResource(mgr,brokerMgr,editLog,catalog,auth);
+        addSparkResource(mgr, brokerMgr, editLog, catalog, auth);
 
         // drop
         DropResourceStmt dropStmt = new DropResourceStmt(name);
@@ -90,7 +90,7 @@ public class ResourceMgrTest {
         ResourceMgr mgr = new ResourceMgr();
 
         // add
-        CreateResourceStmt stmt = addSparkResource(mgr,brokerMgr,editLog,catalog,auth);
+        CreateResourceStmt stmt = addSparkResource(mgr, brokerMgr, editLog, catalog, auth);
 
         // add again
         mgr.createResource(stmt);
@@ -112,14 +112,14 @@ public class ResourceMgrTest {
 
         // add hive resource
         name = "hive0";
-        type = "hive" ;
-        addHiveResource(mgr,editLog,catalog,auth) ;
+        type = "hive";
+        addHiveResource(mgr, editLog, catalog, auth);
 
         // alter hive resource
         String newThriftPath = "thrift://10.10.44.xxx:9083";
-        Map<String,String> properties = new HashMap<>();
+        Map<String, String> properties = new HashMap<>();
         properties.put("hive.metastore.uris", newThriftPath);
-        AlterResourceStmt stmt = new AlterResourceStmt(name,properties);
+        AlterResourceStmt stmt = new AlterResourceStmt(name, properties);
         stmt.analyze(analyzer);
         mgr.alterResource(stmt);
 
@@ -137,12 +137,12 @@ public class ResourceMgrTest {
         ResourceMgr mgr = new ResourceMgr();
 
         // add spark resource
-        addSparkResource(mgr,brokerMgr,editLog,catalog,auth);
+        addSparkResource(mgr, brokerMgr, editLog, catalog, auth);
 
         // alter spark resource
-        Map<String,String> properties = new HashMap<>();
-        properties.put("broker","broker2") ;
-        AlterResourceStmt stmt = new AlterResourceStmt(name,properties);
+        Map<String, String> properties = new HashMap<>();
+        properties.put("broker", "broker2");
+        AlterResourceStmt stmt = new AlterResourceStmt(name, properties);
         stmt.analyze(analyzer);
         mgr.alterResource(stmt);
     }
@@ -154,38 +154,38 @@ public class ResourceMgrTest {
 
         // add hive resource
         name = "hive0";
-        type = "hive" ;
-        addHiveResource(mgr,editLog,catalog,auth) ;
+        type = "hive";
+        addHiveResource(mgr, editLog, catalog, auth);
 
         // alter hive resource
-        Map<String,String> properties = new HashMap<>();
+        Map<String, String> properties = new HashMap<>();
         properties.put("hive.metastore.uris", "thrift://10.10.44.xxx:9083");
-        String noExistName = "hive1" ;
-        AlterResourceStmt stmt = new AlterResourceStmt(noExistName ,properties);
+        String noExistName = "hive1";
+        AlterResourceStmt stmt = new AlterResourceStmt(noExistName, properties);
         stmt.analyze(analyzer);
         mgr.alterResource(stmt);
     }
 
     @Test(expected = DdlException.class)
     public void testAlterResourcePropertyNotExist(@Injectable EditLog editLog, @Mocked Catalog catalog,
-                                          @Injectable Auth auth) throws UserException {
+                                                  @Injectable Auth auth) throws UserException {
         ResourceMgr mgr = new ResourceMgr();
 
         // add hive resource
         name = "hive0";
-        type = "hive" ;
-        addHiveResource(mgr,editLog,catalog,auth);
+        type = "hive";
+        addHiveResource(mgr, editLog, catalog, auth);
 
         // alter hive resource
-        Map<String,String> properties = new HashMap<>();
+        Map<String, String> properties = new HashMap<>();
         properties.put("hive.metastore.uris.xxx", "thrift://10.10.44.xxx:9083");
-        AlterResourceStmt stmt = new AlterResourceStmt(name ,properties);
+        AlterResourceStmt stmt = new AlterResourceStmt(name, properties);
         stmt.analyze(analyzer);
         mgr.alterResource(stmt);
     }
 
-    private CreateResourceStmt addHiveResource(ResourceMgr mgr,EditLog editLog,
-                                 Catalog catalog, Auth auth) throws UserException {
+    private CreateResourceStmt addHiveResource(ResourceMgr mgr, EditLog editLog,
+                                               Catalog catalog, Auth auth) throws UserException {
         new Expectations() {
             {
                 catalog.getEditLog();
@@ -208,11 +208,11 @@ public class ResourceMgrTest {
 
         Resource resource = mgr.getResource(name);
         Assert.assertTrue(resource instanceof HiveResource);
-        return stmt ;
+        return stmt;
     }
 
-    private CreateResourceStmt addSparkResource(ResourceMgr mgr,BrokerMgr brokerMgr, EditLog editLog,
-                             Catalog catalog, Auth auth) throws UserException {
+    private CreateResourceStmt addSparkResource(ResourceMgr mgr, BrokerMgr brokerMgr, EditLog editLog,
+                                                Catalog catalog, Auth auth) throws UserException {
         new Expectations() {
             {
                 catalog.getBrokerMgr();
@@ -238,7 +238,7 @@ public class ResourceMgrTest {
         Assert.assertNotNull(resource);
         Assert.assertEquals(broker, resource.getBroker());
 
-        return stmt ;
+        return stmt;
     }
 
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ResourceMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ResourceMgrTest.java
@@ -49,7 +49,7 @@ public class ResourceMgrTest {
     private String master;
     private String workingDir;
     private String broker;
-    private String hiveThriftPath ;
+    private String hiveMetastoreUris;
     private Map<String, String> properties;
     private Analyzer analyzer;
 
@@ -67,7 +67,7 @@ public class ResourceMgrTest {
         properties.put("working_dir", workingDir);
         properties.put("broker", broker);
         analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
-        hiveThriftPath = "thrift://10.10.44.98:9083" ;
+        hiveMetastoreUris = "thrift://10.10.44.98:9083";
     }
 
     @Test
@@ -199,7 +199,7 @@ public class ResourceMgrTest {
 
         Map<String, String> properties = Maps.newHashMap();
         properties.put("type", type);
-        properties.put("hive.metastore.uris", hiveThriftPath);
+        properties.put("hive.metastore.uris", hiveMetastoreUris);
         CreateResourceStmt stmt = new CreateResourceStmt(true, name, properties);
         stmt.analyze(analyzer);
         Assert.assertEquals(0, mgr.getResourceNum());


### PR DESCRIPTION
## What type of PR is this
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] others

## What feature

Support for modifying hive external table resource properties through SQL

## How to use 
```sql

ALTER RESOURCE 'hive0' SET PROPERTIES ("hive.metastore.uris" = "thrift://10.10.44.97:9083")

```

## Why support this feature

When using hive external tables, sometimes the uri of the metastore is changed. The existing method can only recreate the hive external resources, and rebuild all the downstream tables.

But now , you can use sql to dynamically modify the metastore uri ,but not need rebuild table downstreams .

close #3928 