### PR TITLE
Fix: decrease memory usage of Analytor

### DIFF
--- a/be/src/exec/pipeline/analysis/analytic_sink_operator.cpp
+++ b/be/src/exec/pipeline/analysis/analytic_sink_operator.cpp
@@ -90,15 +90,15 @@ Status AnalyticSinkOperator::push_chunk(RuntimeState* state, const vectorized::C
 
 Status AnalyticSinkOperator::_process_by_partition_if_necessary() {
     while (_analytor->has_output()) {
+        int64_t found_partition_end = _analytor->find_partition_end();
         // Only process after all the data in a partition is reached
-        if (!_analytor->is_partition_finished()) {
+        if (!_analytor->is_partition_finished(found_partition_end)) {
             return Status::OK();
         }
 
         size_t chunk_size = _analytor->input_chunks()[_analytor->output_chunk_index()]->num_rows();
         _analytor->create_agg_result_columns(chunk_size);
 
-        int64_t found_partition_end = _analytor->find_partition_end();
         bool is_new_partition = _analytor->is_new_partition(found_partition_end);
         if (is_new_partition) {
             _analytor->reset_state_for_new_partition(found_partition_end);

--- a/be/src/exec/pipeline/analysis/analytic_sink_operator.cpp
+++ b/be/src/exec/pipeline/analysis/analytic_sink_operator.cpp
@@ -59,6 +59,8 @@ Status AnalyticSinkOperator::push_chunk(RuntimeState* state, const vectorized::C
     size_t chunk_size = chunk->num_rows();
     _analytor->update_input_rows(chunk_size);
 
+    _analytor->remove_unused_buffer_values(state);
+
     for (size_t i = 0; i < _analytor->agg_fn_ctxs().size(); i++) {
         for (size_t j = 0; j < _analytor->agg_expr_ctxs()[i].size(); j++) {
             ColumnPtr column = _analytor->agg_expr_ctxs()[i][j]->evaluate(chunk.get());

--- a/be/src/exec/pipeline/analysis/analytic_source_operator.cpp
+++ b/be/src/exec/pipeline/analysis/analytic_source_operator.cpp
@@ -5,7 +5,7 @@
 namespace starrocks::pipeline {
 
 bool AnalyticSourceOperator::has_output() const {
-    return _analytor->is_sink_complete() && !_analytor->is_chunk_buffer_empty();
+    return !_analytor->is_chunk_buffer_empty();
 }
 
 bool AnalyticSourceOperator::is_finished() const {

--- a/be/src/exec/vectorized/analytic_node.cpp
+++ b/be/src/exec/vectorized/analytic_node.cpp
@@ -292,7 +292,7 @@ Status AnalyticNode::_get_next_for_unbounded_preceding_rows_frame(RuntimeState* 
 
 Status AnalyticNode::_try_fetch_next_partition_data(RuntimeState* state, int64_t* partition_end) {
     *partition_end = _analytor->find_partition_end();
-    while (!_analytor->is_partition_finished()) {
+    while (!_analytor->is_partition_finished(*partition_end)) {
         RETURN_IF_ERROR(state->check_mem_limit("analytic node fetch next partition data"));
         RETURN_IF_ERROR(_fetch_next_chunk(state));
         *partition_end = _analytor->find_partition_end();

--- a/be/src/exec/vectorized/analytor.cpp
+++ b/be/src/exec/vectorized/analytor.cpp
@@ -379,17 +379,19 @@ void Analytor::get_window_function_result(int32_t start, int32_t end) {
     }
 }
 
-bool Analytor::is_partition_finished() {
+bool Analytor::is_partition_finished(int64_t found_partition_end) {
     if (_input_eos) {
         return true;
     }
 
-    // No partition or hasn't fecth one chunk
-    if (_partition_ctxs.empty() || _partition_end == 0) {
+    // There is no partition, or it hasn't fetched any chunk.
+    if (_partition_ctxs.empty() || found_partition_end == 0) {
         return false;
     }
 
-    return _current_row_position >= _partition_end;
+    // If found_partition_end == _partition_columns[0]->size(),
+    // the next chunk maybe also belongs to the current partition.
+    return found_partition_end != _partition_columns[0]->size();
 }
 
 Status Analytor::output_result_chunk(vectorized::ChunkPtr* chunk) {

--- a/be/src/exec/vectorized/analytor.h
+++ b/be/src/exec/vectorized/analytor.h
@@ -101,7 +101,7 @@ public:
     void reset_window_state();
     void get_window_function_result(int32_t start, int32_t end);
 
-    bool is_partition_finished();
+    bool is_partition_finished(int64_t found_partition_end);
     Status output_result_chunk(vectorized::ChunkPtr* chunk);
     size_t compute_memory_usage();
     void create_agg_result_columns(int64_t chunk_size);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Problem Summary：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

### Fix is_partition_finished()
`Analytor::is_partition_finished()` always returns false, when `_partition_end==0` or `_current_row_position < _partition_end`. However, the init value of `_partition_end` and `_current_row_position` is 0, and they are only updated if `Analytor::is_partition_finished()` returns true.

As a result, all the finished partitions cannot be processed timely. They must wait util EOS (that is, there is no more chunk coming).

### call remove_unused_buffer_values()
Call `_analytor->remove_unused_buffer_values()` before processing an input chunk in `AnalyticSinkOperator::push_chunk()`

### AnalyticSourceOperator needn't wait sink finished.
As long as `AnalyticSinkOperator` generates any output chunk, `AnalyticSourceOperator` can output this chunk immediately.