### PR TITLE
Bugfix: change apply thread name to be less than 16 bytes

### DIFF
--- a/be/src/storage/update_manager.cpp
+++ b/be/src/storage/update_manager.cpp
@@ -54,7 +54,7 @@ UpdateManager::~UpdateManager() {
 }
 
 Status UpdateManager::init() {
-    auto st = ThreadPoolBuilder("UpdateApplyThreadPool").build(&_apply_thread_pool);
+    auto st = ThreadPoolBuilder("update_apply").build(&_apply_thread_pool);
     return st;
 }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Problem Summary(Required) ：
Apply thread was too long and set_thread_name method will print warning log about this, this PR change the name to be less than 16 bytes.
