### PR TITLE
Code refactor on `HdfsScanNode`

### DIFF
--- a/be/src/exec/vectorized/hdfs_scan_node.cpp
+++ b/be/src/exec/vectorized/hdfs_scan_node.cpp
@@ -127,8 +127,6 @@ Status HdfsScanNode::init(const TPlanNode& tnode, RuntimeState* state) {
         _runtime_profile->add_info_string("PredicatesPartition", hdfs_scan_node.partition_sql_predicates);
     }
 
-    // _mem_pool = std::make_unique<MemPool>();
-
     return Status::OK();
 }
 

--- a/be/src/exec/vectorized/hdfs_scan_node.cpp
+++ b/be/src/exec/vectorized/hdfs_scan_node.cpp
@@ -249,6 +249,7 @@ Status HdfsScanNode::_create_and_init_scanner(RuntimeState* state, const HdfsFil
     scanner_params.min_max_tuple_desc = _min_max_tuple_desc;
     scanner_params.hive_column_names = &_hive_column_names;
     scanner_params.open_limit = hdfs_file_desc.open_limit;
+    scanner_params.profile = &_profile;
 
     HdfsScanner* scanner = nullptr;
     if (hdfs_file_desc.hdfs_file_format == THdfsFileFormat::PARQUET) {

--- a/be/src/exec/vectorized/hdfs_scan_node.cpp
+++ b/be/src/exec/vectorized/hdfs_scan_node.cpp
@@ -251,8 +251,6 @@ Status HdfsScanNode::_create_and_init_scanner(RuntimeState* state, const HdfsFil
 
     HdfsScanner* scanner = nullptr;
     if (hdfs_file_desc.hdfs_file_format == THdfsFileFormat::PARQUET) {
-        _profile.parquet_profile = _pool->add(new HdfsParquetProfile());
-        _profile.parquet_profile->init(_runtime_profile.get());
         scanner = _pool->add(new HdfsParquetScanner());
     } else if (hdfs_file_desc.hdfs_file_format == THdfsFileFormat::ORC) {
         scanner = _pool->add(new HdfsOrcScanner());
@@ -700,6 +698,7 @@ void HdfsScanNode::_update_status(const Status& status) {
 
 void HdfsScanNode::_init_counter() {
     _profile.runtime_profile = _runtime_profile.get();
+    _profile.pool = _pool;
 
     // inherited from scan node.
     _profile.rows_read_counter = _rows_read_counter;

--- a/be/src/exec/vectorized/hdfs_scan_node.cpp
+++ b/be/src/exec/vectorized/hdfs_scan_node.cpp
@@ -8,6 +8,8 @@
 #include "env/env_hdfs.h"
 #include "env/env_s3.h"
 #include "exec/vectorized/hdfs_scanner.h"
+#include "exec/vectorized/hdfs_scanner_orc.h"
+#include "exec/vectorized/hdfs_scanner_parquet.h"
 #include "exec/vectorized/hdfs_scanner_text.h"
 #include "exprs/expr.h"
 #include "exprs/expr_context.h"
@@ -119,10 +121,8 @@ Status HdfsScanNode::init(const TPlanNode& tnode, RuntimeState* state) {
     if (hdfs_scan_node.__isset.partition_sql_predicates) {
         _runtime_profile->add_info_string("PredicatesPartition", hdfs_scan_node.partition_sql_predicates);
     }
-    _scan_ranges_counter = ADD_COUNTER(_runtime_profile, "ScanRanges", TUnit::UNIT);
-    _scan_files_counter = ADD_COUNTER(_runtime_profile, "ScanFiles", TUnit::UNIT);
 
-    _mem_pool = std::make_unique<MemPool>();
+    // _mem_pool = std::make_unique<MemPool>();
 
     return Status::OK();
 }
@@ -139,7 +139,7 @@ Status HdfsScanNode::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(ScanNode::prepare(state));
     RETURN_IF_ERROR(Expr::prepare(_min_max_conjunct_ctxs, state));
     RETURN_IF_ERROR(Expr::prepare(_partition_conjunct_ctxs, state));
-    _init_counter(state);
+    _init_counter();
     _runtime_state = state;
     return Status::OK();
 }
@@ -152,7 +152,7 @@ Status HdfsScanNode::open(RuntimeState* state) {
     RETURN_IF_ERROR(Expr::open(_min_max_conjunct_ctxs, state));
     RETURN_IF_ERROR(Expr::open(_partition_conjunct_ctxs, state));
 
-    _pre_process_conjunct_ctxs();
+    _decompose_conjunct_ctxs();
     if (_lake_table != nullptr) _init_partition_values_map();
 
     for (auto& scan_range : _scan_ranges) {
@@ -162,7 +162,7 @@ Status HdfsScanNode::open(RuntimeState* state) {
     return Status::OK();
 }
 
-void HdfsScanNode::_pre_process_conjunct_ctxs() {
+void HdfsScanNode::_decompose_conjunct_ctxs() {
     if (_conjunct_ctxs.empty()) {
         return;
     }
@@ -243,12 +243,11 @@ Status HdfsScanNode::_create_and_init_scanner(RuntimeState* state, const HdfsFil
     scanner_params.min_max_conjunct_ctxs = _min_max_conjunct_ctxs;
     scanner_params.min_max_tuple_desc = _min_max_tuple_desc;
     scanner_params.hive_column_names = &_hive_column_names;
-    scanner_params.parent = this;
     scanner_params.open_limit = hdfs_file_desc.open_limit;
 
     HdfsScanner* scanner = nullptr;
     if (hdfs_file_desc.hdfs_file_format == THdfsFileFormat::PARQUET) {
-        _parquet_profile.init(_runtime_profile.get());
+        _profile.parquet_profile = _pool->add(new HdfsParquetProfile());
         scanner = _pool->add(new HdfsParquetScanner());
     } else if (hdfs_file_desc.hdfs_file_format == THdfsFileFormat::ORC) {
         scanner = _pool->add(new HdfsOrcScanner());
@@ -469,7 +468,7 @@ void HdfsScanNode::_push_pending_scanner(HdfsScanner* scanner) {
 HdfsScanner* HdfsScanNode::_pop_pending_scanner() {
     HdfsScanner* scanner = _pending_scanners.pop();
     uint64_t time = scanner->exit_pending_queue();
-    COUNTER_UPDATE(_scanner_queue_timer, time);
+    COUNTER_UPDATE(_profile.scanner_queue_timer, time);
     return scanner;
 }
 
@@ -568,7 +567,7 @@ Status HdfsScanNode::close(RuntimeState* state) {
 Status HdfsScanNode::set_scan_ranges(const std::vector<TScanRangeParams>& scan_ranges) {
     for (const auto& scan_range : scan_ranges) {
         _scan_ranges.emplace_back(scan_range.scan_range.hdfs_scan_range);
-        COUNTER_UPDATE(_scan_ranges_counter, 1);
+        COUNTER_UPDATE(_profile.scan_ranges_counter, 1);
     }
 
     return Status::OK();
@@ -646,12 +645,12 @@ Status HdfsScanNode::_find_and_insert_hdfs_file(const THdfsScanRange& scan_range
         }
     }
 
-    COUNTER_UPDATE(_scan_files_counter, 1);
+    COUNTER_UPDATE(_profile.scan_files_counter, 1);
     std::string native_file_path = scan_range.full_path;
     if (_lake_table != nullptr) {
         auto* partition_desc = _lake_table->get_partition(scan_range.partition_id);
 
-        SCOPED_TIMER(_open_file_timer);
+        SCOPED_TIMER(_profile.open_file_timer);
 
         std::filesystem::path file_path(partition_desc->location());
         file_path /= scan_range.relative_path;
@@ -694,17 +693,26 @@ void HdfsScanNode::_update_status(const Status& status) {
     }
 }
 
-void HdfsScanNode::_init_counter(RuntimeState* state) {
-    _scan_timer = ADD_TIMER(_runtime_profile, "ScanTime");
-    _scanner_queue_timer = ADD_TIMER(_runtime_profile, "ScannerQueueTime");
-    _reader_init_timer = ADD_TIMER(_runtime_profile, "ReaderInit");
-    _open_file_timer = ADD_TIMER(_runtime_profile, "OpenFile");
-    _expr_filter_timer = ADD_TIMER(_runtime_profile, "ExprFilterTime");
+void HdfsScanNode::_init_counter() {
+    _profile.runtime_profile = _runtime_profile.get();
 
-    _io_timer = ADD_TIMER(_runtime_profile, "IoTime");
-    _io_counter = ADD_COUNTER(_runtime_profile, "IoCounter", TUnit::UNIT);
-    _column_read_timer = ADD_TIMER(_runtime_profile, "ColumnReadTime");
-    _column_convert_timer = ADD_TIMER(_runtime_profile, "ColumnConvertTime");
+    // inherited from scan node.
+    _profile.rows_read_counter = _rows_read_counter;
+    _profile.bytes_read_counter = _bytes_read_counter;
+
+    _profile.scan_timer = ADD_TIMER(_runtime_profile, "ScanTime");
+    _profile.scanner_queue_timer = ADD_TIMER(_runtime_profile, "ScannerQueueTime");
+    _profile.scan_ranges_counter = ADD_COUNTER(_runtime_profile, "ScanRanges", TUnit::UNIT);
+    _profile.scan_files_counter = ADD_COUNTER(_runtime_profile, "ScanFiles", TUnit::UNIT);
+
+    _profile.reader_init_timer = ADD_TIMER(_runtime_profile, "ReaderInit");
+    _profile.open_file_timer = ADD_TIMER(_runtime_profile, "OpenFile");
+    _profile.expr_filter_timer = ADD_TIMER(_runtime_profile, "ExprFilterTime");
+
+    _profile.io_timer = ADD_TIMER(_runtime_profile, "IoTime");
+    _profile.io_counter = ADD_COUNTER(_runtime_profile, "IoCounter", TUnit::UNIT);
+    _profile.column_read_timer = ADD_TIMER(_runtime_profile, "ColumnReadTime");
+    _profile.column_convert_timer = ADD_TIMER(_runtime_profile, "ColumnConvertTime");
 }
 
 } // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/hdfs_scan_node.h
+++ b/be/src/exec/vectorized/hdfs_scan_node.h
@@ -28,11 +28,7 @@ struct HdfsFileDesc {
 class HdfsScanNode final : public starrocks::ScanNode {
 public:
     HdfsScanNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs);
-    ~HdfsScanNode() override {
-        if (runtime_state() != nullptr) {
-            close(runtime_state());
-        }
-    }
+    ~HdfsScanNode() override;
 
     Status init(const TPlanNode& tnode, RuntimeState* state) override;
     Status prepare(RuntimeState* state) override;
@@ -94,7 +90,6 @@ private:
 
     Status _init_table();
 
-    int _tuple_id = 0;
     const TupleDescriptor* _tuple_desc = nullptr;
 
     int _min_max_tuple_id = 0;
@@ -131,10 +126,6 @@ private:
     std::vector<HdfsFileDesc*> _hdfs_files;
     const LakeTableDescriptor* _lake_table = nullptr;
     std::vector<std::string> _hive_column_names;
-
-    // std::unique_ptr<MemPool> _mem_pool;
-
-    bool _eos = false;
 
     std::mutex _mtx;
     Stack<ChunkPtr> _chunk_pool;

--- a/be/src/exec/vectorized/hdfs_scan_node.h
+++ b/be/src/exec/vectorized/hdfs_scan_node.h
@@ -8,9 +8,6 @@
 #include "env/env.h"
 #include "exec/scan_node.h"
 #include "exec/vectorized/hdfs_scanner.h"
-#include "exec/vectorized/hdfs_scanner_orc.h"
-#include "exec/vectorized/hdfs_scanner_parquet.h"
-#include "exec/vectorized/hdfs_scanner_text.h"
 #include "hdfs/hdfs.h"
 
 namespace starrocks::vectorized {
@@ -46,10 +43,6 @@ public:
     Status set_scan_ranges(const std::vector<TScanRangeParams>& scan_ranges) override;
 
 private:
-    friend HdfsScanner;
-    friend HdfsParquetScanner;
-    friend HdfsOrcScanner;
-    friend HdfsTextScanner;
     int kMaxConcurrency = config::max_hdfs_scanner_num;
 
     template <typename T>
@@ -79,11 +72,10 @@ private:
     // create
     // 1. _scanner_conjunct_ctxs evaled in scanner.
     // 2. _conjunct_ctxs_by_slot evaled in parquet file reader or group reader.
-    void _pre_process_conjunct_ctxs();
+    void _decompose_conjunct_ctxs();
 
     Status _start_scan_thread(RuntimeState* state);
     void _init_partition_values_map();
-    void _init_hudi_partition_expr_map();
     bool _filter_partition(const std::vector<ExprContext*>& partition_exprs);
     Status _find_and_insert_hdfs_file(const THdfsScanRange& scan_range);
     Status _create_and_init_scanner(RuntimeState* state, const HdfsFileDesc& hdfs_file_desc);
@@ -98,7 +90,7 @@ private:
     HdfsScanner* _pop_pending_scanner();
     static int _compute_priority(int32_t num_submitted_tasks);
 
-    void _init_counter(RuntimeState* state);
+    void _init_counter();
 
     Status _init_table();
 
@@ -140,7 +132,7 @@ private:
     const LakeTableDescriptor* _lake_table = nullptr;
     std::vector<std::string> _hive_column_names;
 
-    std::unique_ptr<MemPool> _mem_pool;
+    // std::unique_ptr<MemPool> _mem_pool;
 
     bool _eos = false;
 
@@ -161,19 +153,6 @@ private:
 
     UnboundedBlockingQueue<ChunkPtr> _result_chunks;
 
-    RuntimeProfile::Counter* _scan_timer = nullptr;
-    RuntimeProfile::Counter* _scanner_queue_timer = nullptr;
-    RuntimeProfile::Counter* _scan_ranges_counter = nullptr;
-    RuntimeProfile::Counter* _scan_files_counter = nullptr;
-    RuntimeProfile::Counter* _reader_init_timer = nullptr;
-    RuntimeProfile::Counter* _open_file_timer = nullptr;
-    RuntimeProfile::Counter* _expr_filter_timer = nullptr;
-
-    RuntimeProfile::Counter* _io_timer = nullptr;
-    RuntimeProfile::Counter* _io_counter = nullptr;
-    RuntimeProfile::Counter* _column_read_timer = nullptr;
-    RuntimeProfile::Counter* _column_convert_timer = nullptr;
-
-    HdfsParquetProfile _parquet_profile;
+    HdfsScanProfile _profile;
 };
 } // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/hdfs_scanner.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner.cpp
@@ -2,17 +2,7 @@
 
 #include "exec/vectorized/hdfs_scanner.h"
 
-#include <hdfs/hdfs.h>
-#include <unistd.h>
-
-#include <algorithm>
-#include <memory>
-#include <mutex>
-#include <thread>
-
-#include "env/env_hdfs.h"
 #include "exec/vectorized/hdfs_scan_node.h"
-#include "exec/vectorized/hdfs_scanner_parquet.h"
 
 namespace starrocks::vectorized {
 
@@ -144,6 +134,12 @@ void HdfsScanner::close(RuntimeState* runtime_state) noexcept {
     _is_closed = true;
     if (_is_open && _scanner_params.open_limit != nullptr) {
         _scanner_params.open_limit->fetch_sub(1, std::memory_order_relaxed);
+    }
+}
+
+void HdfsScanner::cleanup() {
+    if (_runtime_state != nullptr) {
+        close(_runtime_state);
     }
 }
 

--- a/be/src/exec/vectorized/hdfs_scanner.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner.cpp
@@ -191,16 +191,17 @@ void HdfsScanner::update_counter() {
     COUNTER_UPDATE(profile->column_read_timer, _stats.column_read_ns);
     COUNTER_UPDATE(profile->column_convert_timer, _stats.column_convert_ns);
 
-    const auto& parquet_profile = profile->parquet_profile;
-
-    COUNTER_UPDATE(parquet_profile->value_decode_timer, _stats.value_decode_ns);
-    COUNTER_UPDATE(parquet_profile->level_decode_timer, _stats.level_decode_ns);
-    COUNTER_UPDATE(parquet_profile->page_read_timer, _stats.page_read_ns);
-    COUNTER_UPDATE(parquet_profile->footer_read_timer, _stats.footer_read_ns);
-    COUNTER_UPDATE(parquet_profile->column_reader_init_timer, _stats.column_reader_init_ns);
-    COUNTER_UPDATE(parquet_profile->group_chunk_read_timer, _stats.group_chunk_read_ns);
-    COUNTER_UPDATE(parquet_profile->group_dict_filter_timer, _stats.group_dict_filter_ns);
-    COUNTER_UPDATE(parquet_profile->group_dict_decode_timer, _stats.group_dict_decode_ns);
+    HdfsParquetProfile* parquet_profile = profile->parquet_profile;
+    if (parquet_profile != nullptr) {
+        COUNTER_UPDATE(parquet_profile->value_decode_timer, _stats.value_decode_ns);
+        COUNTER_UPDATE(parquet_profile->level_decode_timer, _stats.level_decode_ns);
+        COUNTER_UPDATE(parquet_profile->page_read_timer, _stats.page_read_ns);
+        COUNTER_UPDATE(parquet_profile->footer_read_timer, _stats.footer_read_ns);
+        COUNTER_UPDATE(parquet_profile->column_reader_init_timer, _stats.column_reader_init_ns);
+        COUNTER_UPDATE(parquet_profile->group_chunk_read_timer, _stats.group_chunk_read_ns);
+        COUNTER_UPDATE(parquet_profile->group_dict_filter_timer, _stats.group_dict_filter_ns);
+        COUNTER_UPDATE(parquet_profile->group_dict_decode_timer, _stats.group_dict_decode_ns);
+    }
 #endif
 }
 

--- a/be/src/exec/vectorized/hdfs_scanner.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner.cpp
@@ -16,12 +16,6 @@
 
 namespace starrocks::vectorized {
 
-HdfsScanner::~HdfsScanner() {
-    if (_runtime_state != nullptr) {
-        close(_runtime_state);
-    }
-}
-
 Status HdfsScanner::init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) {
     _runtime_state = runtime_state;
     _scanner_params = scanner_params;

--- a/be/src/exec/vectorized/hdfs_scanner.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner.cpp
@@ -165,7 +165,7 @@ void HdfsScanner::update_hdfs_counter() {
     std::unique_ptr<NumericStatistics> statistics = std::move(res).value();
     if (statistics == nullptr || statistics->size() == 0) return;
 
-    RuntimeProfile* profile = _scanner_params.parent_profile->runtime_profile;
+    RuntimeProfile* profile = _scanner_params.profile->runtime_profile;
     [[maybe_unused]] auto&& toplev = ADD_TIMER(profile, kHdfsIOProfileSectionPrefix);
     for (int64_t i = 0, sz = statistics->size(); i < sz; i++) {
         auto&& name = statistics->name(i);
@@ -179,7 +179,7 @@ void HdfsScanner::update_counter() {
 
     update_hdfs_counter();
 
-    HdfsScanProfile* profile = _scanner_params.parent_profile;
+    HdfsScanProfile* profile = _scanner_params.profile;
     COUNTER_UPDATE(profile->scan_timer, _stats.scan_ns);
     COUNTER_UPDATE(profile->reader_init_timer, _stats.reader_init_ns);
 

--- a/be/src/exec/vectorized/hdfs_scanner.h
+++ b/be/src/exec/vectorized/hdfs_scanner.h
@@ -47,8 +47,7 @@ struct HdfsScanStats {
 
 class HdfsParquetProfile;
 
-class HdfsScanProfile {
-public:
+struct HdfsScanProfile {
     RuntimeProfile* runtime_profile = nullptr;
 
     RuntimeProfile::Counter* rows_read_counter = nullptr;
@@ -178,7 +177,7 @@ inline bool atomic_cas(std::atomic_bool* lvalue, std::atomic_bool* rvalue, bool 
 class HdfsScanner {
 public:
     HdfsScanner() = default;
-    virtual ~HdfsScanner();
+    virtual ~HdfsScanner() = default;
 
     Status open(RuntimeState* runtime_state);
     void close(RuntimeState* runtime_state) noexcept;

--- a/be/src/exec/vectorized/hdfs_scanner.h
+++ b/be/src/exec/vectorized/hdfs_scanner.h
@@ -108,7 +108,7 @@ struct HdfsScannerParams {
 
     std::vector<std::string>* hive_column_names;
 
-    HdfsScanProfile* parent_profile = nullptr;
+    HdfsScanProfile* profile = nullptr;
 
     std::atomic<int32_t>* open_limit;
 };

--- a/be/src/exec/vectorized/hdfs_scanner.h
+++ b/be/src/exec/vectorized/hdfs_scanner.h
@@ -49,6 +49,7 @@ class HdfsParquetProfile;
 
 struct HdfsScanProfile {
     RuntimeProfile* runtime_profile = nullptr;
+    ObjectPool* pool = nullptr;
 
     RuntimeProfile::Counter* rows_read_counter = nullptr;
     RuntimeProfile::Counter* bytes_read_counter = nullptr;
@@ -215,6 +216,7 @@ public:
     virtual void do_close(RuntimeState* runtime_state) noexcept = 0;
     virtual Status do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) = 0;
     virtual Status do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) = 0;
+    virtual void do_update_counter(HdfsScanProfile* profile);
 
     void enter_pending_queue();
     // how long it stays inside pending queue.
@@ -226,7 +228,7 @@ private:
     bool _keep_priority = false;
     void _build_file_read_param();
     MonotonicStopWatch _pending_queue_sw;
-    void update_hdfs_counter();
+    void update_hdfs_counter(HdfsScanProfile* profile);
 
 protected:
     std::atomic_bool _pending_token = false;

--- a/be/src/exec/vectorized/hdfs_scanner.h
+++ b/be/src/exec/vectorized/hdfs_scanner.h
@@ -184,6 +184,7 @@ public:
     void close(RuntimeState* runtime_state) noexcept;
     Status get_next(RuntimeState* runtime_state, ChunkPtr* chunk);
     Status init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params);
+    void cleanup();
 
     int64_t raw_rows_read() const { return _stats.raw_rows_read; }
     void set_keep_priority(bool v) { _keep_priority = v; }

--- a/be/src/exec/vectorized/hdfs_scanner_orc.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_orc.cpp
@@ -324,26 +324,10 @@ bool OrcRowReaderFilter::filterOnPickStringDictionary(
     return false;
 }
 
-void HdfsOrcScanner::update_counter() {
-    HdfsScanner::update_counter();
-
-#ifndef BE_TEST
-    COUNTER_UPDATE(_scanner_params.parent->_rows_read_counter, _stats.raw_rows_read);
-    COUNTER_UPDATE(_scanner_params.parent->_expr_filter_timer, _stats.expr_filter_ns);
-    COUNTER_UPDATE(_scanner_params.parent->_io_timer, _stats.io_ns);
-    COUNTER_UPDATE(_scanner_params.parent->_io_counter, _stats.io_count);
-    COUNTER_UPDATE(_scanner_params.parent->_bytes_read_counter, _stats.bytes_read);
-    COUNTER_UPDATE(_scanner_params.parent->_column_read_timer, _stats.column_read_ns);
-    COUNTER_UPDATE(_scanner_params.parent->_column_convert_timer, _stats.column_convert_ns);
-#endif
-}
-
 Status HdfsOrcScanner::do_open(RuntimeState* runtime_state) {
     auto input_stream =
             std::make_unique<ORCHdfsFileStream>(_file.get(), _scanner_params.scan_ranges[0]->file_length, &_stats);
-#ifndef BE_TEST
-    SCOPED_TIMER(_scanner_params.parent->_reader_init_timer);
-#endif
+    SCOPED_RAW_TIMER(&_stats.reader_init_ns);
     std::unique_ptr<orc::Reader> reader;
     try {
         orc::ReaderOptions options;
@@ -415,7 +399,6 @@ Status HdfsOrcScanner::do_open(RuntimeState* runtime_state) {
 
 void HdfsOrcScanner::do_close(RuntimeState* runtime_state) noexcept {
     _orc_adapter.reset(nullptr);
-    update_counter();
 }
 
 Status HdfsOrcScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) {

--- a/be/src/exec/vectorized/hdfs_scanner_orc.h
+++ b/be/src/exec/vectorized/hdfs_scanner_orc.h
@@ -14,13 +14,8 @@ class OrcRowReaderFilter;
 class HdfsOrcScanner final : public HdfsScanner {
 public:
     HdfsOrcScanner() = default;
-    ~HdfsOrcScanner() override {
-        if (_runtime_state != nullptr) {
-            close(_runtime_state);
-        }
-    }
+    ~HdfsOrcScanner() override = default;
 
-    void update_counter();
     Status do_open(RuntimeState* runtime_state) override;
     void do_close(RuntimeState* runtime_state) noexcept override;
     Status do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) override;

--- a/be/src/exec/vectorized/hdfs_scanner_orc.h
+++ b/be/src/exec/vectorized/hdfs_scanner_orc.h
@@ -14,11 +14,7 @@ class OrcRowReaderFilter;
 class HdfsOrcScanner final : public HdfsScanner {
 public:
     HdfsOrcScanner() = default;
-    ~HdfsOrcScanner() override {
-        if (_runtime_state != nullptr) {
-            close(_runtime_state);
-        }
-    }
+    ~HdfsOrcScanner() override { cleanup(); }
 
     Status do_open(RuntimeState* runtime_state) override;
     void do_close(RuntimeState* runtime_state) noexcept override;

--- a/be/src/exec/vectorized/hdfs_scanner_orc.h
+++ b/be/src/exec/vectorized/hdfs_scanner_orc.h
@@ -14,7 +14,11 @@ class OrcRowReaderFilter;
 class HdfsOrcScanner final : public HdfsScanner {
 public:
     HdfsOrcScanner() = default;
-    ~HdfsOrcScanner() override = default;
+    ~HdfsOrcScanner() override {
+        if (_runtime_state != nullptr) {
+            close(_runtime_state);
+        }
+    }
 
     Status do_open(RuntimeState* runtime_state) override;
     void do_close(RuntimeState* runtime_state) noexcept override;

--- a/be/src/exec/vectorized/hdfs_scanner_parquet.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_parquet.cpp
@@ -8,8 +8,63 @@
 
 namespace starrocks::vectorized {
 
+class HdfsParquetProfile {
+public:
+    // read & decode
+    RuntimeProfile::Counter* level_decode_timer = nullptr;
+    RuntimeProfile::Counter* value_decode_timer = nullptr;
+    RuntimeProfile::Counter* page_read_timer = nullptr;
+
+    // reader init
+    RuntimeProfile::Counter* footer_read_timer = nullptr;
+    RuntimeProfile::Counter* column_reader_init_timer = nullptr;
+
+    // dict filter
+    RuntimeProfile::Counter* group_chunk_read_timer = nullptr;
+    RuntimeProfile::Counter* group_dict_filter_timer = nullptr;
+    RuntimeProfile::Counter* group_dict_decode_timer = nullptr;
+
+    void init(RuntimeProfile* root);
+};
+
+static const std::string kParquetProfileSectionPrefix = "Parquet";
+
+void HdfsParquetProfile::init(RuntimeProfile* root) {
+    ADD_TIMER(root, kParquetProfileSectionPrefix);
+    level_decode_timer = ADD_CHILD_TIMER(root, "LevelDecodeTime", kParquetProfileSectionPrefix);
+    value_decode_timer = ADD_CHILD_TIMER(root, "ValueDecodeTime", kParquetProfileSectionPrefix);
+
+    page_read_timer = ADD_CHILD_TIMER(root, "PageReadTime", kParquetProfileSectionPrefix);
+    footer_read_timer = ADD_CHILD_TIMER(root, "ReaderInitFooterRead", kParquetProfileSectionPrefix);
+    column_reader_init_timer = ADD_CHILD_TIMER(root, "ReaderInitColumnReaderInit", kParquetProfileSectionPrefix);
+
+    group_chunk_read_timer = ADD_CHILD_TIMER(root, "GroupChunkRead", kParquetProfileSectionPrefix);
+    group_dict_filter_timer = ADD_CHILD_TIMER(root, "GroupDictFilter", kParquetProfileSectionPrefix);
+    group_dict_decode_timer = ADD_CHILD_TIMER(root, "GroupDictDecode", kParquetProfileSectionPrefix);
+}
+
 Status HdfsParquetScanner::do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) {
+    HdfsScanProfile* profile = scanner_params.profile;
+    // initialized once.
+    if (profile != nullptr && profile->parquet_profile == nullptr) {
+        profile->parquet_profile = profile->pool->add(new HdfsParquetProfile());
+        profile->parquet_profile->init(profile->runtime_profile);
+    }
     return Status::OK();
+}
+
+void HdfsParquetScanner::do_update_counter(HdfsScanProfile* profile) {
+    HdfsParquetProfile* parquet_profile = profile->parquet_profile;
+    if (parquet_profile != nullptr) {
+        COUNTER_UPDATE(parquet_profile->value_decode_timer, _stats.value_decode_ns);
+        COUNTER_UPDATE(parquet_profile->level_decode_timer, _stats.level_decode_ns);
+        COUNTER_UPDATE(parquet_profile->page_read_timer, _stats.page_read_ns);
+        COUNTER_UPDATE(parquet_profile->footer_read_timer, _stats.footer_read_ns);
+        COUNTER_UPDATE(parquet_profile->column_reader_init_timer, _stats.column_reader_init_ns);
+        COUNTER_UPDATE(parquet_profile->group_chunk_read_timer, _stats.group_chunk_read_ns);
+        COUNTER_UPDATE(parquet_profile->group_dict_filter_timer, _stats.group_dict_filter_ns);
+        COUNTER_UPDATE(parquet_profile->group_dict_decode_timer, _stats.group_dict_decode_ns);
+    }
 }
 
 Status HdfsParquetScanner::do_open(RuntimeState* runtime_state) {
@@ -28,23 +83,6 @@ Status HdfsParquetScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* ch
 
 void HdfsParquetScanner::do_close(RuntimeState* runtime_state) noexcept {
     _reader.reset();
-}
-
-static const std::string kParquetProfileSectionPrefix = "Parquet";
-
-void HdfsParquetProfile::init(RuntimeProfile* root) {
-    if (_toplev != nullptr) return;
-    _toplev = ADD_TIMER(root, kParquetProfileSectionPrefix);
-    level_decode_timer = ADD_CHILD_TIMER(root, "LevelDecodeTime", kParquetProfileSectionPrefix);
-    value_decode_timer = ADD_CHILD_TIMER(root, "ValueDecodeTime", kParquetProfileSectionPrefix);
-
-    page_read_timer = ADD_CHILD_TIMER(root, "PageReadTime", kParquetProfileSectionPrefix);
-    footer_read_timer = ADD_CHILD_TIMER(root, "ReaderInitFooterRead", kParquetProfileSectionPrefix);
-    column_reader_init_timer = ADD_CHILD_TIMER(root, "ReaderInitColumnReaderInit", kParquetProfileSectionPrefix);
-
-    group_chunk_read_timer = ADD_CHILD_TIMER(root, "GroupChunkRead", kParquetProfileSectionPrefix);
-    group_dict_filter_timer = ADD_CHILD_TIMER(root, "GroupDictFilter", kParquetProfileSectionPrefix);
-    group_dict_decode_timer = ADD_CHILD_TIMER(root, "GroupDictDecode", kParquetProfileSectionPrefix);
 }
 
 } // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/hdfs_scanner_parquet.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_parquet.cpp
@@ -16,9 +16,7 @@ Status HdfsParquetScanner::do_open(RuntimeState* runtime_state) {
     // create file reader
     _reader = std::make_shared<parquet::FileReader>(runtime_state->chunk_size(), _file.get(),
                                                     _scanner_params.scan_ranges[0]->file_length);
-#ifndef BE_TEST
-    SCOPED_TIMER(_scanner_params.parent->_reader_init_timer);
-#endif
+    SCOPED_RAW_TIMER(&_stats.reader_init_ns);
     RETURN_IF_ERROR(_reader->init(_file_read_param));
     return Status::OK();
 }
@@ -28,33 +26,7 @@ Status HdfsParquetScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* ch
     return status;
 }
 
-void HdfsParquetScanner::update_counter() {
-    HdfsScanner::update_counter();
-
-#ifndef BE_TEST
-    COUNTER_UPDATE(_scanner_params.parent->_rows_read_counter, _stats.raw_rows_read);
-    COUNTER_UPDATE(_scanner_params.parent->_expr_filter_timer, _stats.expr_filter_ns);
-    COUNTER_UPDATE(_scanner_params.parent->_io_timer, _stats.io_ns);
-    COUNTER_UPDATE(_scanner_params.parent->_io_counter, _stats.io_count);
-    COUNTER_UPDATE(_scanner_params.parent->_bytes_read_counter, _stats.bytes_read);
-    COUNTER_UPDATE(_scanner_params.parent->_column_read_timer, _stats.column_read_ns);
-    COUNTER_UPDATE(_scanner_params.parent->_column_convert_timer, _stats.column_convert_ns);
-
-    const auto& parquet_profile = _scanner_params.parent->_parquet_profile;
-
-    COUNTER_UPDATE(parquet_profile.value_decode_timer, _stats.value_decode_ns);
-    COUNTER_UPDATE(parquet_profile.level_decode_timer, _stats.level_decode_ns);
-    COUNTER_UPDATE(parquet_profile.page_read_timer, _stats.page_read_ns);
-    COUNTER_UPDATE(parquet_profile.footer_read_timer, _stats.footer_read_ns);
-    COUNTER_UPDATE(parquet_profile.column_reader_init_timer, _stats.column_reader_init_ns);
-    COUNTER_UPDATE(parquet_profile.group_chunk_read_timer, _stats.group_chunk_read_ns);
-    COUNTER_UPDATE(parquet_profile.group_dict_filter_timer, _stats.group_dict_filter_ns);
-    COUNTER_UPDATE(parquet_profile.group_dict_decode_timer, _stats.group_dict_decode_ns);
-#endif
-}
-
 void HdfsParquetScanner::do_close(RuntimeState* runtime_state) noexcept {
-    update_counter();
     _reader.reset();
 }
 

--- a/be/src/exec/vectorized/hdfs_scanner_parquet.h
+++ b/be/src/exec/vectorized/hdfs_scanner_parquet.h
@@ -6,28 +6,6 @@
 
 namespace starrocks::vectorized {
 
-class HdfsParquetProfile {
-public:
-    // read & decode
-    RuntimeProfile::Counter* level_decode_timer = nullptr;
-    RuntimeProfile::Counter* value_decode_timer = nullptr;
-    RuntimeProfile::Counter* page_read_timer = nullptr;
-
-    // reader init
-    RuntimeProfile::Counter* footer_read_timer = nullptr;
-    RuntimeProfile::Counter* column_reader_init_timer = nullptr;
-
-    // dict filter
-    RuntimeProfile::Counter* group_chunk_read_timer = nullptr;
-    RuntimeProfile::Counter* group_dict_filter_timer = nullptr;
-    RuntimeProfile::Counter* group_dict_decode_timer = nullptr;
-
-    void init(RuntimeProfile* root);
-
-private:
-    RuntimeProfile::Counter* _toplev = nullptr;
-};
-
 class HdfsParquetScanner final : public HdfsScanner {
 public:
     HdfsParquetScanner() = default;
@@ -41,6 +19,7 @@ public:
     void do_close(RuntimeState* runtime_state) noexcept override;
     Status do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) override;
     Status do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) override;
+    void do_update_counter(HdfsScanProfile* profile) override;
 
 private:
     std::shared_ptr<parquet::FileReader> _reader = nullptr;

--- a/be/src/exec/vectorized/hdfs_scanner_parquet.h
+++ b/be/src/exec/vectorized/hdfs_scanner_parquet.h
@@ -31,13 +31,8 @@ private:
 class HdfsParquetScanner final : public HdfsScanner {
 public:
     HdfsParquetScanner() = default;
-    ~HdfsParquetScanner() override {
-        if (_runtime_state != nullptr) {
-            close(_runtime_state);
-        }
-    }
+    ~HdfsParquetScanner() override = default;
 
-    void update_counter();
     Status do_open(RuntimeState* runtime_state) override;
     void do_close(RuntimeState* runtime_state) noexcept override;
     Status do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) override;

--- a/be/src/exec/vectorized/hdfs_scanner_parquet.h
+++ b/be/src/exec/vectorized/hdfs_scanner_parquet.h
@@ -31,7 +31,11 @@ private:
 class HdfsParquetScanner final : public HdfsScanner {
 public:
     HdfsParquetScanner() = default;
-    ~HdfsParquetScanner() override = default;
+    ~HdfsParquetScanner() override {
+        if (_runtime_state != nullptr) {
+            close(_runtime_state);
+        }
+    }
 
     Status do_open(RuntimeState* runtime_state) override;
     void do_close(RuntimeState* runtime_state) noexcept override;

--- a/be/src/exec/vectorized/hdfs_scanner_parquet.h
+++ b/be/src/exec/vectorized/hdfs_scanner_parquet.h
@@ -9,11 +9,7 @@ namespace starrocks::vectorized {
 class HdfsParquetScanner final : public HdfsScanner {
 public:
     HdfsParquetScanner() = default;
-    ~HdfsParquetScanner() override {
-        if (_runtime_state != nullptr) {
-            close(_runtime_state);
-        }
-    }
+    ~HdfsParquetScanner() override { cleanup(); }
 
     Status do_open(RuntimeState* runtime_state) override;
     void do_close(RuntimeState* runtime_state) noexcept override;

--- a/be/src/exec/vectorized/hdfs_scanner_text.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_text.cpp
@@ -108,9 +108,7 @@ Status HdfsTextScanner::do_init(RuntimeState* runtime_state, const HdfsScannerPa
 
 Status HdfsTextScanner::do_open(RuntimeState* runtime_state) {
     RETURN_IF_ERROR(_create_or_reinit_reader());
-#ifndef BE_TEST
-    SCOPED_TIMER(_scanner_params.parent->_reader_init_timer);
-#endif
+    SCOPED_RAW_TIMER(&_stats.reader_init_ns);
     for (int i = 0; i < _scanner_params.materialize_slots.size(); i++) {
         auto slot = _scanner_params.materialize_slots[i];
         ConverterPtr conv = csv::get_converter(slot->type(), true);
@@ -124,7 +122,6 @@ Status HdfsTextScanner::do_open(RuntimeState* runtime_state) {
 }
 
 void HdfsTextScanner::do_close(RuntimeState* runtime_state) noexcept {
-    update_counter();
     _reader.reset();
 }
 

--- a/be/src/exec/vectorized/hdfs_scanner_text.h
+++ b/be/src/exec/vectorized/hdfs_scanner_text.h
@@ -11,7 +11,11 @@ namespace starrocks::vectorized {
 class HdfsTextScanner final : public HdfsScanner {
 public:
     HdfsTextScanner() = default;
-    ~HdfsTextScanner() override = default;
+    ~HdfsTextScanner() override {
+        if (_runtime_state != nullptr) {
+            close(_runtime_state);
+        }
+    }
 
     Status do_open(RuntimeState* runtime_state) override;
     void do_close(RuntimeState* runtime_state) noexcept override;

--- a/be/src/exec/vectorized/hdfs_scanner_text.h
+++ b/be/src/exec/vectorized/hdfs_scanner_text.h
@@ -11,11 +11,7 @@ namespace starrocks::vectorized {
 class HdfsTextScanner final : public HdfsScanner {
 public:
     HdfsTextScanner() = default;
-    ~HdfsTextScanner() override {
-        if (_runtime_state != nullptr) {
-            close(_runtime_state);
-        }
-    }
+    ~HdfsTextScanner() override { cleanup(); }
 
     Status do_open(RuntimeState* runtime_state) override;
     void do_close(RuntimeState* runtime_state) noexcept override;


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：

## Problem Summary(Required) ：
The main purpose of this PR is trying to decouple `HdfsScanner` & `HdfsScanNode`,  on behalf of further working on porting hdfs scan node to pipeline engine. It includes:

- put `update_counter` back into `HdfsScanner`, and call it when doing `close`
- extract class `HdfsScanProfile` from `HdfsScanNode`. It's the main reason why `HdfsScanner` refers to `HdfsScanNode`.  So `HdfsScaner` only needs to refer to `HdfsScanProfile`.
- call `close` when calling destructor function.
