### PR TITLE
make FunctionContext::set_error/has_error/error_msg thread-safe in pipeline engine

### DIFF
--- a/be/src/exprs/expr_context.cpp
+++ b/be/src/exprs/expr_context.cpp
@@ -185,12 +185,6 @@ std::string ExprContext::get_error_msg() const {
     return "";
 }
 
-void ExprContext::clear_error_msg() {
-    for (auto fn_ctx : _fn_contexts) {
-        fn_ctx->clear_error_msg();
-    }
-}
-
 ColumnPtr ExprContext::evaluate(vectorized::Chunk* chunk) {
     return evaluate(_root, chunk);
 }

--- a/be/src/exprs/expr_context.h
+++ b/be/src/exprs/expr_context.h
@@ -125,9 +125,6 @@ public:
 
     std::string get_error_msg() const;
 
-    // when you reused this expr context, you maybe need clear the error status and message.
-    void clear_error_msg();
-
     // vector query engine
     ColumnPtr evaluate(vectorized::Chunk* chunk);
 

--- a/be/src/udf/udf_internal.h
+++ b/be/src/udf/udf_internal.h
@@ -107,6 +107,9 @@ public:
     bool check_local_allocations_empty();
 
     RuntimeState* state() { return _state; }
+    void set_error(const char* error_msg);
+    bool has_error();
+    const char* error_msg();
 
 #ifdef STARROCKS_WITH_HDFS
     vectorized::JavaUDAFContext* udaf_ctxs() { return _jvm_udaf_ctxs.get(); }
@@ -149,6 +152,7 @@ private:
 
     // Empty if there's no error
     std::string _error_msg;
+    std::atomic<std::string*> _optional_error_msg{nullptr};
 
     // The number of warnings reported.
     int64_t _num_warnings;

--- a/be/src/udf/udf_internal.h
+++ b/be/src/udf/udf_internal.h
@@ -25,6 +25,7 @@
 #include <cstring>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -151,8 +152,8 @@ private:
     starrocks_udf::FunctionContext::StarRocksVersion _version;
 
     // Empty if there's no error
+    std::mutex _error_msg_mutex;
     std::string _error_msg;
-    std::atomic<std::string*> _optional_error_msg{nullptr};
 
     // The number of warnings reported.
     int64_t _num_warnings;


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

FunctionContext is shared among multiple operators, FunctionContext::set_error may be invoked by Operator::pull_chunk/push_chunk concurrently. this method is not thread-safe, so this PR make this method thread-safe, in addition, FunctionContext::clear_error_msg and ExprContext::clear_error_msg is unused,so remove these code.

SQLancer find this bug as follows:
```
start time: Sat Mar 5 01:00:52 CST 2022
I0000 00:00:00.000000 170728 vlog_is_on.cc:197] RAW: Set VLOG level for "*" to 10
=================================================================
==170728==ERROR: AddressSanitizer: attempting double-free on 0x60b0015ad420 in thread T413 (pip_executor):
    #0 0x426cb97 in operator delete(void*) ../../../../libsanitizer/asan/asan_new_delete.cpp:160
    #1 0xb87d52f in __gnu_cxx::new_allocator<char>::deallocate(char*, unsigned long) /home/disk2/zc/tools/toolchain/build/gcc-10.3.0/build/x86_64-pc-linux-gnu/libstdc++-v3/include/ext/new_allocator.h:133
    #2 0xb87d52f in std::allocator_traits<std::allocator<char> >::deallocate(std::allocator<char>&, char*, unsigned long) /home/disk2/zc/tools/toolchain/build/gcc-10.3.0/build/x86_64-pc-linux-gnu/libstdc++-v3/include/bits/alloc_traits.h:492
    #3 0xb87d52f in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_destroy(unsigned long) /home/disk2/zc/tools/toolchain/build/gcc-10.3.0/build/x86_64-pc-linux-gnu/libstdc++-v3/include/bits/basic_string.h:237
    #4 0xb87d52f in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_dispose() /home/disk2/zc/tools/toolchain/build/gcc-10.3.0/build/x86_64-pc-linux-gnu/libstdc++-v3/include/bits/basic_string.h:232
    #5 0xb87d52f in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_mutate(unsigned long, unsigned long, char const*, unsigned long) /home/disk2/zc/tools/toolchain/build/gcc-10.3.0/build/x86_64-pc-linux-gnu/libstdc++-v3/include/bits/basic_string.tcc:327
    #6 0xb87e285 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_replace(unsigned long, unsigned long, char const*, unsigned long) /home/disk2/zc/tools/toolchain/build/gcc-10.3.0/build/x86_64-pc-linux-gnu/libstdc++-v3/include/bits/basic_string.tcc:468
    #7 0x8fa37c1 in starrocks_udf::FunctionContext::set_error(char const*) /home/disk2/rpf/DorisDB_rpf/be/src/udf/udf.cpp:324
    #8 0x93a7440 in starrocks::vectorized::BitmapFunctions::to_bitmap(starrocks_udf::FunctionContext*, std::vector<std::shared_ptr<starrocks::vectorized::Column>, std::allocator<std::shared_ptr<starrocks::vectorized::Column> > > const&) /home/disk2/rpf/DorisDB_rpf/be/src/exprs/vectorized/bitmap_functions.cpp:34
    #9 0x8b304b0 in starrocks::vectorized::VectorizedFunctionCallExpr::evaluate(starrocks::ExprContext*, starrocks::vectorized::Chunk*) /home/disk2/rpf/DorisDB_rpf/be/src/exprs/vectorized/function_call_expr.cpp:141
    #10 0x8060a6f in starrocks::ExprContext::evaluate(starrocks::Expr*, starrocks::vectorized::Chunk*) /home/disk2/rpf/DorisDB_rpf/be/src/exprs/expr_context.cpp:205
    #11 0x8060820 in starrocks::ExprContext::evaluate(starrocks::vectorized::Chunk*) /home/disk2/rpf/DorisDB_rpf/be/src/exprs/expr_context.cpp:195
    #12 0x6ee01d2 in starrocks::pipeline::ProjectOperator::push_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::vectorized::Chunk> const&) /home/disk2/rpf/DorisDB_rpf/be/src/exec/pipeline/project_operator.cpp:27
    #13 0x6f5c04a in starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int) /home/disk2/rpf/DorisDB_rpf/be/src/exec/pipeline/pipeline_driver.cpp:163
    #14 0x6f356fb in starrocks::pipeline::GlobalDriverExecutor::worker_thread() /home/disk2/rpf/DorisDB_rpf/be/src/exec/pipeline/pipeline_driver_executor.cpp:93
    #15 0x6f34711 in operator() /home/disk2/rpf/DorisDB_rpf/be/src/exec/pipeline/pipeline_driver_executor.cpp:28
    #16 0x6f39a73 in __invoke_impl<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::<lambda()>&> /home/disk1/doris-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/invoke.h:60
    #17 0x6f39541 in __invoke_r<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::<lambda()>&> /home/disk1/doris-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/invoke.h:110
    #18 0x6f38f9b in _M_invoke /home/disk1/doris-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/std_function.h:291
    #19 0x42df999 in std::function<void ()>::operator()() const /home/disk1/doris-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/std_function.h:622
    #20 0x58a3827 in starrocks::FunctionRunnable::run() /home/disk2/rpf/DorisDB_rpf/be/src/util/threadpool.cpp:45
    #21 0x58a035b in starrocks::ThreadPool::dispatch_thread() /home/disk2/rpf/DorisDB_rpf/be/src/util/threadpool.cpp:514
    #22 0x58bd94f in void std::__invoke_impl<void, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(std::__invoke_memfun_deref, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&) /home/disk1/doris-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/invoke.h:73
    #23 0x58bd232 in std::__invoke_result<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>::type std::__invoke<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&) /home/disk1/doris-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/invoke.h:95
    #24 0x58bc649 in void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) /home/disk1/doris-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/functional:416
    #25 0x58bb1b5 in void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::operator()<, void>() /home/disk1/doris-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/functional:499
    #26 0x58b809b in void std::__invoke_impl<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&) /home/disk1/doris-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/invoke.h:60
    #27 0x58b6063 in std::enable_if<is_invocable_r_v<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&) /home/disk1/doris-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/invoke.h:110
    #28 0x58b17fe in std::_Function_handler<void (), std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()> >::_M_invoke(std::_Any_data const&) /home/disk1/doris-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/std_function.h:291
    #29 0x42df999 in std::function<void ()>::operator()() const /home/disk1/doris-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/std_function.h:622
    #30 0x588a8de in starrocks::Thread::supervise_thread(void*) /home/disk2/rpf/DorisDB_rpf/be/src/util/thread.cpp:312
    #31 0x7f97abd84ea4 in start_thread (/lib64/libpthread.so.0+0x7ea4)
    #32 0x7f97ab39fb0c in clone (/lib64/libc.so.6+0xfeb0c)
```