### PR TITLE
Fix BE heartbeat thrift server exit unexpected after network failure injection

### DIFF
--- a/be/src/util/thrift_server.cpp
+++ b/be/src/util/thrift_server.cpp
@@ -132,11 +132,30 @@ Status ThriftServer::ThriftServerEventProcessor::start_and_wait_for_server() {
 void ThriftServer::ThriftServerEventProcessor::supervise() {
     DCHECK(_thrift_server->_server.get() != nullptr);
 
+    // serve() will call preServe() internal to set _started = true before serve loop start
     try {
         _thrift_server->_server->serve();
     } catch (apache::thrift::TException& e) {
         LOG(ERROR) << "ThriftServer '" << _thrift_server->_name << "' (on port: " << _thrift_server->_port
                    << ") exited due to TException: " << e.what();
+    }
+    // There are three scenario of serve loop
+    // 1. Accept timeout and client disconnect - ThriftServer continue processing.
+    // 2. Server was interrupted.  This only happens when stop() called. - ThriftServer serve return
+    // 3. All other transport exceptions are only logged. - ThriftServer serve return.
+    // In scenario 3 we prefer to retry before stop() called, it will reset the transport
+    while (!_thrift_server->_stopped && _thrift_server->_started) {
+        try {
+            _thrift_server->_server->serve();
+            if (!_thrift_server->_stopped) {
+                LOG(ERROR) << "ThriftServer '" << _thrift_server->_name << "' (on port: " << _thrift_server->_port
+                           << ") exited unexpected. ";
+            }
+        } catch (apache::thrift::TException& e) {
+            LOG(ERROR) << "ThriftServer '" << _thrift_server->_name << "' (on port: " << _thrift_server->_port
+                       << ") exited due to TException: " << e.what();
+        }
+        SleepFor(MonoDelta::FromSeconds(3));
     }
 
     {
@@ -357,6 +376,7 @@ Status ThriftServer::start() {
 }
 
 void ThriftServer::stop() {
+    _stopped = true;
     _server->stop();
 }
 

--- a/be/src/util/thrift_server.h
+++ b/be/src/util/thrift_server.h
@@ -107,6 +107,9 @@ private:
     // True if the server has been successfully started, for internal use only
     bool _started;
 
+    // True if the server has been stop()
+    bool _stopped = false;
+
     // The port on which the server interface is exposed
     int _port;
 


### PR DESCRIPTION
…injection (#3727)

BE heartbeat thrift server exit unexpected after network failure injection, so will retry after exception until the stop() has been called.

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3726 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
BE heartbeat thrift server exit unexpected after network failure injection, so will retry after exception until the stop() has been called