### PR TITLE
Fix BE heartbeat thrift server exit unexpected after network failure injection

### DIFF
--- a/be/src/util/thrift_server.h
+++ b/be/src/util/thrift_server.h
@@ -106,6 +106,9 @@ private:
     // True if the server has been successfully started, for internal use only
     bool _started;
 
+    // True if the server has been stop()
+    bool _stopped = false;
+
     // The port on which the server interface is exposed
     int _port;
 


### PR DESCRIPTION
BE heartbeat thrift server exit unexpected after network failure injection, so will retry after exception until the stop() has been called.

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3726 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
BE heartbeat thrift server exit unexpected after network failure injection, so will retry after exception until the stop() has been called