### PR TITLE
Integrate `HdfsScanNode` to pipeline execution engine

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -148,6 +148,7 @@ set(EXEC_FILES
     pipeline/result_sink_operator.cpp
     pipeline/scan_operator.cpp
     pipeline/olap_scan_operator.cpp
+    pipeline/hdfs_scan_operator.cpp
     pipeline/select_operator.cpp
     pipeline/crossjoin/cross_join_right_sink_operator.cpp
     pipeline/crossjoin/cross_join_left_operator.cpp

--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -149,6 +149,7 @@ set(EXEC_FILES
     pipeline/scan_operator.cpp
     pipeline/olap_scan_operator.cpp
     pipeline/hdfs_scan_operator.cpp
+    pipeline/hdfs_chunk_source.cpp
     pipeline/select_operator.cpp
     pipeline/crossjoin/cross_join_right_sink_operator.cpp
     pipeline/crossjoin/cross_join_left_operator.cpp

--- a/be/src/exec/pipeline/hdfs_chunk_source.cpp
+++ b/be/src/exec/pipeline/hdfs_chunk_source.cpp
@@ -316,6 +316,10 @@ Status HdfsChunkSource::_init_scanner(RuntimeState* state) {
     return Status::OK();
 }
 
+void HdfsChunkSource::_init_chunk(ChunkPtr* chunk) {
+    *chunk = ChunkHelper::new_chunk(*_tuple_desc, _runtime_state->chunk_size());
+}
+
 void HdfsChunkSource::close(RuntimeState* state) {
     if (_closed) return;
     if (_scanner != nullptr) {
@@ -414,6 +418,7 @@ Status HdfsChunkSource::_read_chunk_from_storage(RuntimeState* state, vectorized
     if (state->is_cancelled()) {
         return Status::Cancelled("canceled state");
     }
+    _init_chunk(chunk);
     SCOPED_TIMER(_profile.scan_timer);
     do {
         RETURN_IF_ERROR(_scanner->get_next(state, chunk));

--- a/be/src/exec/pipeline/hdfs_chunk_source.cpp
+++ b/be/src/exec/pipeline/hdfs_chunk_source.cpp
@@ -1,0 +1,484 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#include "exec/pipeline/hdfs_chunk_source.h"
+
+#include "env/env_hdfs.h"
+#include "env/env_s3.h"
+#include "exec/pipeline/scan_operator.h"
+#include "exec/vectorized/hdfs_scan_node.h"
+#include "exec/workgroup/work_group.h"
+#include "exprs/vectorized/runtime_filter.h"
+#include "gutil/map_util.h"
+#include "runtime/current_thread.h"
+#include "runtime/descriptors.h"
+#include "runtime/exec_env.h"
+#include "storage/vectorized/chunk_helper.h"
+#include "util/hdfs_util.h"
+
+namespace starrocks::pipeline {
+using namespace vectorized;
+
+class OpenLimitAllocator {
+public:
+    OpenLimitAllocator() = default;
+    ~OpenLimitAllocator() = default;
+
+    OpenLimitAllocator(const OpenLimitAllocator&) = delete;
+    void operator=(const OpenLimitAllocator&) = delete;
+
+    static OpenLimitAllocator& instance() {
+        static OpenLimitAllocator obj;
+        return obj;
+    }
+
+    std::atomic<int32_t>* allocate(const std::string& key);
+
+private:
+    std::mutex _lock;
+    std::unordered_map<std::string, std::atomic<int32_t>*> _data;
+};
+
+std::atomic<int32_t>* OpenLimitAllocator::allocate(const std::string& key) {
+    std::lock_guard l(_lock);
+    return LookupOrInsertNew(&_data, key, 0);
+}
+
+HdfsChunkSource::HdfsChunkSource(MorselPtr&& morsel, ScanOperator* op, vectorized::HdfsScanNode* scan_node)
+        : ChunkSource(std::move(morsel)),
+          _scan_node(scan_node),
+          _limit(scan_node->limit()),
+          _runtime_in_filters(op->runtime_in_filters()),
+          _runtime_bloom_filters(op->runtime_bloom_filters()),
+          _runtime_profile(op->unique_metrics()) {
+    _conjunct_ctxs = scan_node->conjunct_ctxs();
+    _conjunct_ctxs.insert(_conjunct_ctxs.end(), _runtime_in_filters.begin(), _runtime_in_filters.end());
+    ScanMorsel* scan_morsel = (ScanMorsel*)_morsel.get();
+    _scan_range = scan_morsel->get_hdfs_scan_range();
+}
+
+Status HdfsChunkSource::prepare(RuntimeState* state) {
+    // right now we don't force user to set JAVA_HOME.
+    // but when we access hdfs via JNI, we have to make sure JAVA_HOME is set,
+    // otherwise be will crash because of failure to create JVM.
+    const char* p = std::getenv("JAVA_HOME");
+    if (p == nullptr) {
+        return Status::RuntimeError("env 'JAVA_HOME' is not set");
+    }
+
+    const auto& hdfs_scan_node = _scan_node->thrift_hdfs_scan_node();
+    _runtime_state = state;
+    _tuple_desc = state->desc_tbl().get_tuple_descriptor(hdfs_scan_node.tuple_id);
+    _lake_table = dynamic_cast<const LakeTableDescriptor*>(_tuple_desc->table_desc());
+    if (_lake_table == nullptr) {
+        return Status::RuntimeError("Invalid table type. Only hive/iceberg/hudi table are supported");
+    }
+
+    RETURN_IF_ERROR(_init_conjunct_ctxs(state));
+    _init_tuples_and_slots(state);
+    _init_counter(state);
+
+    _init_partition_values();
+    if (_filter_by_eval_partition_conjuncts) return Status::OK();
+
+    return Status::OK();
+}
+
+Status HdfsChunkSource::_init_conjunct_ctxs(RuntimeState* state) {
+    const auto& hdfs_scan_node = _scan_node->thrift_hdfs_scan_node();
+    if (hdfs_scan_node.__isset.min_max_conjuncts) {
+        RETURN_IF_ERROR(Expr::create_expr_trees(_pool, hdfs_scan_node.min_max_conjuncts, &_min_max_conjunct_ctxs));
+    }
+
+    if (hdfs_scan_node.__isset.partition_conjuncts) {
+        RETURN_IF_ERROR(Expr::create_expr_trees(_pool, hdfs_scan_node.partition_conjuncts, &_partition_conjunct_ctxs));
+        _has_partition_conjuncts = true;
+    }
+    RETURN_IF_ERROR(Expr::prepare(_min_max_conjunct_ctxs, state));
+    RETURN_IF_ERROR(Expr::prepare(_partition_conjunct_ctxs, state));
+    RETURN_IF_ERROR(Expr::open(_min_max_conjunct_ctxs, state));
+    RETURN_IF_ERROR(Expr::open(_partition_conjunct_ctxs, state));
+
+    _decompose_conjunct_ctxs();
+    return Status::OK();
+}
+
+void HdfsChunkSource::_init_partition_values() {
+    if (!(_lake_table != nullptr && _has_partition_columns && _has_partition_conjuncts)) return;
+
+    auto* partition_desc = _lake_table->get_partition(_scan_range->partition_id);
+    const auto& partition_values = partition_desc->partition_key_value_evals();
+    ChunkPtr partition_chunk = ChunkHelper::new_chunk(_partition_slots, 1);
+
+    // append partition data
+    for (size_t i = 0; i < _partition_slots.size(); i++) {
+        SlotId slot_id = _partition_slots[i]->id();
+        int partition_col_idx = _partition_index_in_hdfs_partition_columns[i];
+        auto partition_value_col = partition_values[partition_col_idx]->evaluate(nullptr);
+        assert(partition_value_col->is_constant());
+        auto* const_column = ColumnHelper::as_raw_column<ConstColumn>(partition_value_col);
+        ColumnPtr data_column = const_column->data_column();
+        ColumnPtr chunk_part_column = _partition_chunk->get_column_by_slot_id(slot_id);
+        if (data_column->is_nullable()) {
+            chunk_part_column->append_nulls(1);
+        } else {
+            chunk_part_column->append(*data_column, 0, 1);
+        }
+    }
+
+    // eval conjuncts and skip if no rows.
+    ExecNode::eval_conjuncts(_partition_conjunct_ctxs, partition_chunk.get());
+    if (partition_chunk->has_rows()) {
+        _partition_values = partition_values;
+    } else {
+        _filter_by_eval_partition_conjuncts = true;
+    }
+}
+
+void HdfsChunkSource::_init_tuples_and_slots(RuntimeState* state) {
+    const auto& hdfs_scan_node = _scan_node->thrift_hdfs_scan_node();
+    if (hdfs_scan_node.__isset.min_max_tuple_id) {
+        _min_max_tuple_id = hdfs_scan_node.min_max_tuple_id;
+        _min_max_tuple_desc = state->desc_tbl().get_tuple_descriptor(_min_max_tuple_id);
+    }
+
+    const auto& slots = _tuple_desc->slots();
+    for (size_t i = 0; i < slots.size(); i++) {
+        if (_lake_table != nullptr && _lake_table->is_partition_col(slots[i])) {
+            _partition_slots.push_back(slots[i]);
+            _partition_index_in_chunk.push_back(i);
+            _partition_index_in_hdfs_partition_columns.push_back(_lake_table->get_partition_col_index(slots[i]));
+            _has_partition_columns = true;
+        } else {
+            _materialize_slots.push_back(slots[i]);
+            _materialize_index_in_chunk.push_back(i);
+        }
+    }
+
+    if (hdfs_scan_node.__isset.hive_column_names) {
+        _hive_column_names = hdfs_scan_node.hive_column_names;
+    }
+}
+
+void HdfsChunkSource::_decompose_conjunct_ctxs() {
+    if (_conjunct_ctxs.empty()) {
+        return;
+    }
+
+    std::unordered_map<SlotId, SlotDescriptor*> slot_by_id;
+    for (SlotDescriptor* slot : _tuple_desc->slots()) {
+        slot_by_id[slot->id()] = slot;
+    }
+
+    for (ExprContext* ctx : _conjunct_ctxs) {
+        const Expr* root_expr = ctx->root();
+        std::vector<SlotId> slot_ids;
+        if (root_expr->get_slot_ids(&slot_ids) != 1) {
+            _scanner_conjunct_ctxs.emplace_back(ctx);
+            continue;
+        }
+
+        SlotId slot_id = slot_ids[0];
+        if (slot_by_id.find(slot_id) != slot_by_id.end()) {
+            if (_conjunct_ctxs_by_slot.find(slot_id) == _conjunct_ctxs_by_slot.end()) {
+                _conjunct_ctxs_by_slot.insert({slot_id, std::vector<ExprContext*>()});
+            }
+            _conjunct_ctxs_by_slot[slot_id].emplace_back(ctx);
+        }
+    }
+}
+
+void HdfsChunkSource::_init_counter(RuntimeState* state) {
+    const auto& hdfs_scan_node = _scan_node->thrift_hdfs_scan_node();
+
+    _scan_timer = ADD_TIMER(_runtime_profile, "ScanTime");
+    _scanner_queue_timer = ADD_TIMER(_runtime_profile, "ScannerQueueTime");
+    _reader_init_timer = ADD_TIMER(_runtime_profile, "ReaderInit");
+    _open_file_timer = ADD_TIMER(_runtime_profile, "OpenFile");
+    _expr_filter_timer = ADD_TIMER(_runtime_profile, "ExprFilterTime");
+
+    _io_timer = ADD_TIMER(_runtime_profile, "IoTime");
+    _io_counter = ADD_COUNTER(_runtime_profile, "IoCounter", TUnit::UNIT);
+    _column_read_timer = ADD_TIMER(_runtime_profile, "ColumnReadTime");
+    _column_convert_timer = ADD_TIMER(_runtime_profile, "ColumnConvertTime");
+
+    if (hdfs_scan_node.__isset.table_name) {
+        _runtime_profile->add_info_string("Table", hdfs_scan_node.table_name);
+    }
+    if (hdfs_scan_node.__isset.sql_predicates) {
+        _runtime_profile->add_info_string("Predicates", hdfs_scan_node.sql_predicates);
+    }
+    if (hdfs_scan_node.__isset.min_max_sql_predicates) {
+        _runtime_profile->add_info_string("PredicatesMinMax", hdfs_scan_node.min_max_sql_predicates);
+    }
+    if (hdfs_scan_node.__isset.partition_sql_predicates) {
+        _runtime_profile->add_info_string("PredicatesPartition", hdfs_scan_node.partition_sql_predicates);
+    }
+    _scan_ranges_counter = ADD_COUNTER(_runtime_profile, "ScanRanges", TUnit::UNIT);
+    _scan_files_counter = ADD_COUNTER(_runtime_profile, "ScanFiles", TUnit::UNIT);
+}
+
+Status HdfsChunkSource::_init_scanner(RuntimeState* state) {
+    const auto& scan_range = *_scan_range;
+    std::string scan_range_path = scan_range.full_path;
+    if (_lake_table != nullptr && _lake_table->has_partition()) {
+        scan_range_path = scan_range.relative_path;
+    }
+
+    COUNTER_UPDATE(_scan_files_counter, 1);
+    std::string native_file_path = scan_range.full_path;
+    if (_lake_table != nullptr) {
+        auto* partition_desc = _lake_table->get_partition(scan_range.partition_id);
+
+        SCOPED_TIMER(_open_file_timer);
+
+        std::filesystem::path file_path(partition_desc->location());
+        file_path /= scan_range.relative_path;
+        native_file_path = file_path.native();
+    }
+
+    Env* env = nullptr;
+    if (is_hdfs_path(native_file_path.c_str())) {
+        env = _pool->add(new EnvHdfs());
+    } else if (is_object_storage_path(native_file_path.c_str())) {
+#ifdef STARROCKS_WITH_AWS
+        env = _pool->add(new EnvS3());
+#else
+        return Status::NotSupported("Does not support read S3 file");
+#endif
+    } else {
+        env = Env::Default();
+    }
+
+    std::string name_node;
+    RETURN_IF_ERROR(get_namenode_from_path(native_file_path, &name_node));
+
+    auto* hdfs_file_desc = _pool->add(new HdfsFileDesc());
+    hdfs_file_desc->env = env;
+    hdfs_file_desc->path = native_file_path;
+    hdfs_file_desc->partition_id = scan_range.partition_id;
+    hdfs_file_desc->scan_range_path = scan_range_path;
+    hdfs_file_desc->file_length = scan_range.file_length;
+    hdfs_file_desc->splits.emplace_back(&scan_range);
+    hdfs_file_desc->hdfs_file_format = scan_range.file_format;
+    hdfs_file_desc->open_limit = OpenLimitAllocator::instance().allocate(name_node);
+
+    HdfsScannerParams scanner_params;
+    scanner_params.runtime_filter_collector = _runtime_bloom_filters;
+    scanner_params.scan_ranges = hdfs_file_desc.splits;
+    scanner_params.env = hdfs_file_desc.env;
+    scanner_params.path = hdfs_file_desc.path;
+    scanner_params.tuple_desc = _tuple_desc;
+    scanner_params.materialize_slots = _materialize_slots;
+    scanner_params.materialize_index_in_chunk = _materialize_index_in_chunk;
+    scanner_params.partition_slots = _partition_slots;
+    scanner_params.partition_index_in_chunk = _partition_index_in_chunk;
+    scanner_params._partition_index_in_hdfs_partition_columns = _partition_index_in_hdfs_partition_columns;
+    scanner_params.partition_values = _partition_values_map[hdfs_file_desc.partition_id];
+    scanner_params.conjunct_ctxs = _scanner_conjunct_ctxs;
+    scanner_params.conjunct_ctxs_by_slot = _conjunct_ctxs_by_slot;
+    scanner_params.min_max_conjunct_ctxs = _min_max_conjunct_ctxs;
+    scanner_params.min_max_tuple_desc = _min_max_tuple_desc;
+    scanner_params.hive_column_names = &_hive_column_names;
+    scanner_params.parent = this;
+    scanner_params.open_limit = hdfs_file_desc.open_limit;
+
+    HdfsScanner* scanner = nullptr;
+    if (hdfs_file_desc.hdfs_file_format == THdfsFileFormat::PARQUET) {
+        _parquet_profile.init(_runtime_profile);
+        scanner = _pool->add(new HdfsParquetScanner());
+    } else if (hdfs_file_desc.hdfs_file_format == THdfsFileFormat::ORC) {
+        scanner = _pool->add(new HdfsOrcScanner());
+    } else if (hdfs_file_desc.hdfs_file_format == THdfsFileFormat::TEXT) {
+        scanner = _pool->add(new HdfsTextScanner());
+    } else {
+        std::string msg = fmt::format("unsupported hdfs file format: {}", hdfs_file_desc.hdfs_file_format);
+        LOG(WARNING) << msg;
+        return Status::NotSupported(msg);
+    }
+    RETURN_IF_ERROR(scanner->init(state, scanner_params));
+
+    return Status::OK();
+}
+
+// ===================================================================
+
+bool HdfsChunkSource::has_next_chunk() const {
+    // If we need and could get next chunk from storage engine,
+    // the _status must be ok.
+    return _status.ok();
+}
+
+bool HdfsChunkSource::has_output() const {
+    return !_chunk_buffer.empty();
+}
+
+size_t HdfsChunkSource::get_buffer_size() const {
+    return _chunk_buffer.get_size();
+}
+
+StatusOr<vectorized::ChunkPtr> HdfsChunkSource::get_next_chunk_from_buffer() {
+    vectorized::ChunkPtr chunk = nullptr;
+    _chunk_buffer.try_get(&chunk);
+    return chunk;
+}
+
+Status HdfsChunkSource::buffer_next_batch_chunks_blocking(size_t batch_size, bool& can_finish) {
+    if (!_status.ok()) {
+        return _status;
+    }
+    using namespace vectorized;
+
+    for (size_t i = 0; i < batch_size && !can_finish; ++i) {
+        ChunkUniquePtr chunk(
+                ChunkHelper::new_chunk_pooled(_prj_iter->encoded_schema(), _runtime_state->chunk_size(), true));
+        _status = _read_chunk_from_storage(_runtime_state, chunk.get());
+        if (!_status.ok()) {
+            // end of file is normal case, need process chunk
+            if (_status.is_end_of_file()) {
+                _chunk_buffer.put(std::move(chunk));
+            }
+            break;
+        }
+        _chunk_buffer.put(std::move(chunk));
+    }
+    return _status;
+}
+
+Status HdfsChunkSource::buffer_next_batch_chunks_blocking_for_workgroup(size_t batch_size, bool& can_finish,
+                                                                        size_t* num_read_chunks, int worker_id,
+                                                                        workgroup::WorkGroupPtr running_wg) {
+    if (!_status.ok()) {
+        return _status;
+    }
+
+    using namespace vectorized;
+    int64_t time_spent = 0;
+    for (size_t i = 0; i < batch_size && !can_finish; ++i) {
+        {
+            SCOPED_RAW_TIMER(&time_spent);
+
+            ChunkUniquePtr chunk(
+                    ChunkHelper::new_chunk_pooled(_prj_iter->encoded_schema(), _runtime_state->chunk_size(), true));
+            _status = _read_chunk_from_storage(_runtime_state, chunk.get());
+            if (!_status.ok()) {
+                // end of file is normal case, need process chunk
+                if (_status.is_end_of_file()) {
+                    ++(*num_read_chunks);
+                    _chunk_buffer.put(std::move(chunk));
+                }
+                break;
+            }
+
+            ++(*num_read_chunks);
+            _chunk_buffer.put(std::move(chunk));
+        }
+
+        if (time_spent >= YIELD_MAX_TIME_SPENT) {
+            break;
+        }
+
+        if (time_spent >= YIELD_PREEMPT_MAX_TIME_SPENT &&
+            workgroup::WorkGroupManager::instance()->get_owners_of_scan_worker(worker_id, running_wg)) {
+            break;
+        }
+    }
+
+    return _status;
+}
+
+Status HdfsChunkSource::_read_chunk_from_storage(RuntimeState* state, vectorized::Chunk* chunk) {
+    if (state->is_cancelled()) {
+        return Status::Cancelled("canceled state");
+    }
+    SCOPED_TIMER(_scan_timer);
+    do {
+        // TODO(yan):
+    } while (chunk->num_rows() == 0);
+    _update_realtime_counter(chunk);
+    // Improve for select * from table limit x, x is small
+    if (_limit != -1 && _num_rows_read >= _limit) {
+        return Status::EndOfFile("limit reach");
+    }
+    return Status::OK();
+}
+
+Status HdfsChunkSource::close(RuntimeState* state) {
+    _update_counter();
+    return Status::OK();
+}
+
+void HdfsChunkSource::_update_realtime_counter(vectorized::Chunk* chunk) {
+    COUNTER_UPDATE(_read_compressed_counter, _reader->stats().compressed_bytes_read);
+    _compressed_bytes_read += _reader->stats().compressed_bytes_read;
+    _reader->mutable_stats()->compressed_bytes_read = 0;
+
+    COUNTER_UPDATE(_raw_rows_counter, _reader->stats().raw_rows_read);
+    _raw_rows_read += _reader->stats().raw_rows_read;
+    _reader->mutable_stats()->raw_rows_read = 0;
+    _num_rows_read += chunk->num_rows();
+}
+
+void HdfsChunkSource::_update_counter() {
+    COUNTER_UPDATE(_create_seg_iter_timer, _reader->stats().create_segment_iter_ns);
+    COUNTER_UPDATE(_rows_read_counter, _num_rows_read);
+
+    COUNTER_UPDATE(_io_timer, _reader->stats().io_ns);
+    COUNTER_UPDATE(_read_compressed_counter, _reader->stats().compressed_bytes_read);
+    _compressed_bytes_read += _reader->stats().compressed_bytes_read;
+    COUNTER_UPDATE(_decompress_timer, _reader->stats().decompress_ns);
+    COUNTER_UPDATE(_read_uncompressed_counter, _reader->stats().uncompressed_bytes_read);
+    COUNTER_UPDATE(_bytes_read_counter, _reader->stats().bytes_read);
+
+    COUNTER_UPDATE(_block_load_timer, _reader->stats().block_load_ns);
+    COUNTER_UPDATE(_block_load_counter, _reader->stats().blocks_load);
+    COUNTER_UPDATE(_block_fetch_timer, _reader->stats().block_fetch_ns);
+    COUNTER_UPDATE(_block_seek_timer, _reader->stats().block_seek_ns);
+
+    COUNTER_UPDATE(_raw_rows_counter, _reader->stats().raw_rows_read);
+    _raw_rows_read += _reader->mutable_stats()->raw_rows_read;
+    COUNTER_UPDATE(_chunk_copy_timer, _reader->stats().vec_cond_chunk_copy_ns);
+
+    COUNTER_UPDATE(_seg_init_timer, _reader->stats().segment_init_ns);
+
+    COUNTER_UPDATE(_pred_filter_timer, _reader->stats().vec_cond_evaluate_ns);
+    COUNTER_UPDATE(_pred_filter_counter, _reader->stats().rows_vec_cond_filtered);
+    COUNTER_UPDATE(_del_vec_filter_counter, _reader->stats().rows_del_vec_filtered);
+
+    COUNTER_UPDATE(_zm_filtered_counter, _reader->stats().rows_stats_filtered);
+    COUNTER_UPDATE(_bf_filtered_counter, _reader->stats().rows_bf_filtered);
+    COUNTER_UPDATE(_sk_filtered_counter, _reader->stats().rows_key_range_filtered);
+    COUNTER_UPDATE(_index_load_timer, _reader->stats().index_load_ns);
+
+    COUNTER_UPDATE(_read_pages_num_counter, _reader->stats().total_pages_num);
+    COUNTER_UPDATE(_cached_pages_num_counter, _reader->stats().cached_pages_num);
+
+    COUNTER_UPDATE(_bi_filtered_counter, _reader->stats().rows_bitmap_index_filtered);
+    COUNTER_UPDATE(_bi_filter_timer, _reader->stats().bitmap_index_filter_timer);
+    COUNTER_UPDATE(_block_seek_counter, _reader->stats().block_seek_num);
+
+    COUNTER_UPDATE(_rowsets_read_count, _reader->stats().rowsets_read_count);
+    COUNTER_UPDATE(_segments_read_count, _reader->stats().segments_read_count);
+    COUNTER_UPDATE(_total_columns_data_page_count, _reader->stats().total_columns_data_page_count);
+
+    COUNTER_SET(_pushdown_predicates_counter, (int64_t)_params.predicates.size());
+
+    StarRocksMetrics::instance()->query_scan_bytes.increment(_compressed_bytes_read);
+    StarRocksMetrics::instance()->query_scan_rows.increment(_raw_rows_read);
+
+    if (_reader->stats().decode_dict_ns > 0) {
+        RuntimeProfile::Counter* c = ADD_TIMER(_scan_profile, "DictDecode");
+        COUNTER_UPDATE(c, _reader->stats().decode_dict_ns);
+    }
+    if (_reader->stats().late_materialize_ns > 0) {
+        RuntimeProfile::Counter* c = ADD_TIMER(_scan_profile, "LateMaterialize");
+        COUNTER_UPDATE(c, _reader->stats().late_materialize_ns);
+    }
+    if (_reader->stats().del_filter_ns > 0) {
+        RuntimeProfile::Counter* c1 = ADD_TIMER(_scan_profile, "DeleteFilter");
+        RuntimeProfile::Counter* c2 = ADD_COUNTER(_scan_profile, "DeleteFilterRows", TUnit::UNIT);
+        COUNTER_UPDATE(c1, _reader->stats().del_filter_ns);
+        COUNTER_UPDATE(c2, _reader->stats().rows_del_filtered);
+    }
+}
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/hdfs_chunk_source.cpp
+++ b/be/src/exec/pipeline/hdfs_chunk_source.cpp
@@ -396,16 +396,11 @@ Status HdfsChunkSource::_read_chunk_from_storage(RuntimeState* state, vectorized
     do {
         RETURN_IF_ERROR(_scanner->get_next(state, chunk));
     } while ((*chunk)->num_rows() == 0);
-    _update_realtime_counter((*chunk).get());
     // Improve for select * from table limit x, x is small
-    if (_limit != -1 && _num_rows_read >= _limit) {
+    if (_limit != -1 && _scanner->num_rows_read() >= _limit) {
         return Status::EndOfFile("limit reach");
     }
     return Status::OK();
-}
-
-void HdfsChunkSource::_update_realtime_counter(vectorized::Chunk* chunk) {
-    _num_rows_read += chunk->num_rows();
 }
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/hdfs_chunk_source.cpp
+++ b/be/src/exec/pipeline/hdfs_chunk_source.cpp
@@ -263,6 +263,7 @@ Status HdfsChunkSource::_init_scanner(RuntimeState* state) {
         env = Env::Default();
     }
 
+    COUNTER_UPDATE(_profile.scan_ranges_counter, 1);
     std::string name_node;
     RETURN_IF_ERROR(get_namenode_from_path(native_file_path, &name_node));
 

--- a/be/src/exec/pipeline/hdfs_chunk_source.h
+++ b/be/src/exec/pipeline/hdfs_chunk_source.h
@@ -63,7 +63,7 @@ private:
     Status _init_scanner(RuntimeState* state);
 
     // =====================================
-    Status _read_chunk_from_storage([[maybe_unused]] RuntimeState* state, vectorized::Chunk* chunk);
+    Status _read_chunk_from_storage([[maybe_unused]] RuntimeState* state, vectorized::ChunkPtr* chunk);
     void _update_realtime_counter(vectorized::Chunk* chunk);
 
     // =====================================

--- a/be/src/exec/pipeline/hdfs_chunk_source.h
+++ b/be/src/exec/pipeline/hdfs_chunk_source.h
@@ -1,0 +1,157 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#pragma once
+
+#include <utility>
+
+#include "exec/pipeline/chunk_source.h"
+#include "exec/vectorized/hdfs_scan_node.h"
+#include "exec/vectorized/hdfs_scanner.h"
+#include "exec/vectorized/hdfs_scanner_orc.h"
+#include "exec/vectorized/hdfs_scanner_parquet.h"
+#include "exec/vectorized/hdfs_scanner_text.h"
+#include "exec/workgroup/work_group_fwd.h"
+#include "exprs/expr.h"
+#include "exprs/expr_context.h"
+#include "runtime/runtime_state.h"
+
+namespace starrocks {
+
+class SlotDescriptor;
+
+namespace vectorized {
+class RuntimeFilterProbeCollector;
+}
+
+namespace pipeline {
+
+class ScanOperator;
+class HdfsChunkSource final : public ChunkSource {
+public:
+    HdfsChunkSource(MorselPtr&& morsel, ScanOperator* op, vectorized::HdfsScanNode* scan_node);
+
+    ~HdfsChunkSource() override = default;
+
+    Status prepare(RuntimeState* state) override;
+
+    Status close(RuntimeState* state) override;
+
+    bool has_next_chunk() const override;
+
+    bool has_output() const override;
+
+    virtual size_t get_buffer_size() const override;
+
+    StatusOr<vectorized::ChunkPtr> get_next_chunk_from_buffer() override;
+
+    Status buffer_next_batch_chunks_blocking(size_t chunk_size, bool& can_finish) override;
+    Status buffer_next_batch_chunks_blocking_for_workgroup(size_t chunk_size, bool& can_finish, size_t* num_read_chunks,
+                                                           int worker_id, workgroup::WorkGroupPtr running_wg) override;
+
+private:
+    friend HdfsScanner;
+    friend HdfsParquetScanner;
+    friend HdfsOrcScanner;
+    friend HdfsTextScanner;
+
+    // Yield scan io task when maximum time in nano-seconds has spent in current execution round.
+    static constexpr int64_t YIELD_MAX_TIME_SPENT = 100'000'000L;
+    // Yield scan io task when maximum time in nano-seconds has spent in current execution round,
+    // if it runs in the worker thread owned by other workgroup, which has running drivers.
+    static constexpr int64_t YIELD_PREEMPT_MAX_TIME_SPENT = 20'000'000L;
+
+    // ============= init func =============
+    Status _init_conjunct_ctxs(RuntimeState* state);
+    void _decompose_conjunct_ctxs();
+    void _init_tuples_and_slots(RuntimeState* state);
+    void _init_counter(RuntimeState* state);
+
+    void _init_partition_values();
+    Status _init_scanner();
+
+    // =====================================
+    Status _read_chunk_from_storage([[maybe_unused]] RuntimeState* state, vectorized::Chunk* chunk);
+    void _update_counter();
+    void _update_realtime_counter(vectorized::Chunk* chunk);
+
+    // =====================================
+    vectorized::HdfsScanNode* _scan_node;
+    const int64_t _limit; // -1: no limit
+    const std::vector<ExprContext*>& _runtime_in_filters;
+    const vectorized::RuntimeFilterProbeCollector* _runtime_bloom_filters;
+    THdfsScanRange* _scan_range;
+
+    Status _status = Status::OK();
+    UnboundedBlockingQueue<vectorized::ChunkPtr> _chunk_buffer;
+
+    ObjectPool _obj_pool;
+    ObjectPool* _pool = &_obj_pool;
+    RuntimeState* _runtime_state = nullptr;
+
+    // =============== conjuncts =====================
+    // copied from scan node and merge predicates from runtime filter.
+    std::vector<ExprContext*> _conjunct_ctxs;
+
+    std::vector<ExprContext*> _min_max_conjunct_ctxs;
+
+    // complex conjuncts, such as contains multi slot, are evaled in scanner.
+    std::vector<ExprContext*> _scanner_conjunct_ctxs;
+    // conjuncts that contains only one slot.
+    // 1. conjuncts that column is not exist in file, are used to filter file in file reader.
+    // 2. conjuncts that column is materialized, are evaled in group reader.
+    std::unordered_map<SlotId, std::vector<ExprContext*>> _conjunct_ctxs_by_slot;
+
+    // partition conjuncts of each partition slot.
+    std::vector<ExprContext*> _partition_conjunct_ctxs;
+    std::vector<ExprContext*> _partition_values;
+    bool _has_partition_conjuncts = false;
+    bool _filter_by_eval_partition_conjuncts = false;
+
+    // ============ tuples and slots ==========
+    const TupleDescriptor* _tuple_desc = nullptr;
+
+    int _min_max_tuple_id = 0;
+    TupleDescriptor* _min_max_tuple_desc = nullptr;
+
+    // materialized columns.
+    std::vector<SlotDescriptor*> _materialize_slots;
+    std::vector<int> _materialize_index_in_chunk;
+
+    // partition columns.
+    std::vector<SlotDescriptor*> _partition_slots;
+
+    // partition column index in `tuple_desc`
+    std::vector<int> _partition_index_in_chunk;
+    // partition index in hdfs partition columns
+    std::vector<int> _partition_index_in_hdfs_partition_columns;
+    bool _has_partition_columns = false;
+
+    std::vector<std::string> _hive_column_names;
+    const LakeTableDescriptor* _lake_table = nullptr;
+
+    // ======================================
+    // The following are profile metrics
+    int64_t _num_rows_read = 0;
+    int64_t _raw_rows_read = 0;
+
+    RuntimeProfile* _runtime_profile;
+    RuntimeProfile::Counter* _bytes_read_counter = nullptr;
+    RuntimeProfile::Counter* _rows_read_counter = nullptr;
+
+    RuntimeProfile::Counter* _scan_timer = nullptr;
+    RuntimeProfile::Counter* _scanner_queue_timer = nullptr;
+    RuntimeProfile::Counter* _scan_ranges_counter = nullptr;
+    RuntimeProfile::Counter* _scan_files_counter = nullptr;
+    RuntimeProfile::Counter* _reader_init_timer = nullptr;
+    RuntimeProfile::Counter* _open_file_timer = nullptr;
+    RuntimeProfile::Counter* _expr_filter_timer = nullptr;
+
+    RuntimeProfile::Counter* _io_timer = nullptr;
+    RuntimeProfile::Counter* _io_counter = nullptr;
+    RuntimeProfile::Counter* _column_read_timer = nullptr;
+    RuntimeProfile::Counter* _column_convert_timer = nullptr;
+
+    HdfsParquetProfile _parquet_profile;
+};
+} // namespace pipeline
+} // namespace starrocks

--- a/be/src/exec/pipeline/hdfs_chunk_source.h
+++ b/be/src/exec/pipeline/hdfs_chunk_source.h
@@ -101,6 +101,7 @@ private:
     std::vector<ExprContext*> _partition_values;
     bool _has_partition_conjuncts = false;
     bool _filter_by_eval_partition_conjuncts = false;
+    bool _no_data = false;
 
     // ============ tuples and slots ==========
     const TupleDescriptor* _tuple_desc = nullptr;

--- a/be/src/exec/pipeline/hdfs_chunk_source.h
+++ b/be/src/exec/pipeline/hdfs_chunk_source.h
@@ -61,6 +61,7 @@ private:
 
     void _init_partition_values();
     Status _init_scanner(RuntimeState* state);
+    void _init_chunk(ChunkPtr* chunk);
 
     // =====================================
     Status _read_chunk_from_storage([[maybe_unused]] RuntimeState* state, vectorized::ChunkPtr* chunk);

--- a/be/src/exec/pipeline/hdfs_chunk_source.h
+++ b/be/src/exec/pipeline/hdfs_chunk_source.h
@@ -65,7 +65,6 @@ private:
 
     // =====================================
     Status _read_chunk_from_storage([[maybe_unused]] RuntimeState* state, vectorized::ChunkPtr* chunk);
-    void _update_realtime_counter(vectorized::Chunk* chunk);
 
     // =====================================
     vectorized::HdfsScanNode* _scan_node;
@@ -128,7 +127,6 @@ private:
     // ======================================
     // The following are profile metrics
     RuntimeProfile* _runtime_profile;
-    int64_t _num_rows_read = 0;
     vectorized::HdfsScanProfile _profile;
 };
 } // namespace pipeline

--- a/be/src/exec/pipeline/hdfs_scan_operator.cpp
+++ b/be/src/exec/pipeline/hdfs_scan_operator.cpp
@@ -1,0 +1,44 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#include "exec/pipeline/hdfs_scan_operator.h"
+
+#include "column/chunk.h"
+// #include "exec/pipeline/hdfs_chunk_source.h"
+#include "exec/vectorized/hdfs_scan_node.h"
+#include "runtime/exec_env.h"
+#include "runtime/runtime_state.h"
+namespace starrocks::pipeline {
+
+// ==================== HdfsScanOperatorFactory ====================
+
+HdfsScanOperatorFactory::HdfsScanOperatorFactory(int32_t id, ScanNode* scan_node)
+        : ScanOperatorFactory(id, scan_node) {}
+
+Status HdfsScanOperatorFactory::do_prepare(RuntimeState* state) {
+    return Status::OK();
+}
+
+void HdfsScanOperatorFactory::do_close(RuntimeState*) {}
+
+OperatorPtr HdfsScanOperatorFactory::do_create(int32_t dop, int32_t driver_sequence) {
+    return std::make_shared<HdfsScanOperator>(this, _id, _scan_node);
+}
+
+// ==================== HdfsScanOperator ====================
+
+HdfsScanOperator::HdfsScanOperator(OperatorFactory* factory, int32_t id, ScanNode* scan_node)
+        : ScanOperator(factory, id, scan_node) {}
+
+Status HdfsScanOperator::do_prepare(RuntimeState*) {
+    return Status::OK();
+}
+
+void HdfsScanOperator::do_close(RuntimeState*) {}
+
+ChunkSourcePtr HdfsScanOperator::create_chunk_source(MorselPtr morsel) {
+    // vectorized::HdfsScanNode* hdfs_scan_node = down_cast<vectorized::HdfsScanNode*>(_scan_node);
+    // return std::make_shared<HdfsChunkSource>(std::move(morsel), this, hdfs_scan_node);
+    return nullptr;
+}
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/hdfs_scan_operator.cpp
+++ b/be/src/exec/pipeline/hdfs_scan_operator.cpp
@@ -3,7 +3,7 @@
 #include "exec/pipeline/hdfs_scan_operator.h"
 
 #include "column/chunk.h"
-// #include "exec/pipeline/hdfs_chunk_source.h"
+#include "exec/pipeline/hdfs_chunk_source.h"
 #include "exec/vectorized/hdfs_scan_node.h"
 #include "runtime/exec_env.h"
 #include "runtime/runtime_state.h"
@@ -36,9 +36,8 @@ Status HdfsScanOperator::do_prepare(RuntimeState*) {
 void HdfsScanOperator::do_close(RuntimeState*) {}
 
 ChunkSourcePtr HdfsScanOperator::create_chunk_source(MorselPtr morsel) {
-    // vectorized::HdfsScanNode* hdfs_scan_node = down_cast<vectorized::HdfsScanNode*>(_scan_node);
-    // return std::make_shared<HdfsChunkSource>(std::move(morsel), this, hdfs_scan_node);
-    return nullptr;
+    vectorized::HdfsScanNode* hdfs_scan_node = down_cast<vectorized::HdfsScanNode*>(_scan_node);
+    return std::make_shared<HdfsChunkSource>(std::move(morsel), this, hdfs_scan_node);
 }
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/hdfs_scan_operator.h
+++ b/be/src/exec/pipeline/hdfs_scan_operator.h
@@ -1,0 +1,37 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#pragma once
+
+#include "exec/pipeline/pipeline_builder.h"
+#include "exec/pipeline/scan_operator.h"
+
+namespace starrocks {
+class ScanNode;
+}
+namespace starrocks::pipeline {
+
+class HdfsScanOperatorFactory final : public ScanOperatorFactory {
+public:
+    HdfsScanOperatorFactory(int32_t id, ScanNode* scan_node);
+
+    ~HdfsScanOperatorFactory() override = default;
+
+    Status do_prepare(RuntimeState* state) override;
+    void do_close(RuntimeState* state) override;
+    OperatorPtr do_create(int32_t dop, int32_t driver_sequence) override;
+};
+
+class HdfsScanOperator final : public ScanOperator {
+public:
+    HdfsScanOperator(OperatorFactory* factory, int32_t id, ScanNode* scan_node);
+
+    ~HdfsScanOperator() override = default;
+
+    Status do_prepare(RuntimeState* state) override;
+    void do_close(RuntimeState* state) override;
+    ChunkSourcePtr create_chunk_source(MorselPtr morsel) override;
+
+private:
+};
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/morsel.h
+++ b/be/src/exec/pipeline/morsel.h
@@ -36,6 +36,8 @@ public:
 
     TInternalScanRange* get_olap_scan_range() { return &(_scan_range->internal_scan_range); }
 
+    THdfsScanRange* get_hdfs_scan_range() { return &(_scan_range->hdfs_scan_range); }
+
 private:
     std::unique_ptr<TScanRange> _scan_range;
 };

--- a/be/src/exec/pipeline/olap_scan_operator.h
+++ b/be/src/exec/pipeline/olap_scan_operator.h
@@ -4,10 +4,10 @@
 
 #include "exec/pipeline/pipeline_builder.h"
 #include "exec/pipeline/scan_operator.h"
-#include "exec/scan_node.h"
 
 namespace starrocks {
 
+class ScanNode;
 class Rowset;
 using RowsetSharedPtr = std::shared_ptr<Rowset>;
 

--- a/be/src/exec/pipeline/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan_operator.cpp
@@ -274,4 +274,32 @@ void ScanOperatorFactory::close(RuntimeState* state) {
     OperatorFactory::close(state);
 }
 
+// ====================
+
+pipeline::OpFactories decompose_scan_node_to_pipeline(std::shared_ptr<ScanOperatorFactory> scan_operator,
+                                                      ScanNode* scan_node, pipeline::PipelineBuilderContext* context) {
+    OpFactories operators;
+    // Create a shared RefCountedRuntimeFilterCollector
+    auto&& rc_rf_probe_collector =
+            std::make_shared<RcRfProbeCollector>(1, std::move(scan_node->runtime_filter_collector()));
+    // Initialize OperatorFactory's fields involving runtime filters.
+    scan_node->init_runtime_filter_for_operator(scan_operator.get(), context, rc_rf_probe_collector);
+    auto& morsel_queues = context->fragment_context()->morsel_queues();
+    auto source_id = scan_operator->plan_node_id();
+    DCHECK(morsel_queues.count(source_id));
+    auto& morsel_queue = morsel_queues[source_id];
+    // ScanOperator's degree_of_parallelism is not more than the number of morsels
+    // If table is empty, then morsel size is zero and we still set degree of parallelism to 1
+    const auto degree_of_parallelism =
+            std::min<size_t>(std::max<size_t>(1, morsel_queue->num_morsels()), context->degree_of_parallelism());
+    scan_operator->set_degree_of_parallelism(degree_of_parallelism);
+    operators.emplace_back(std::move(scan_operator));
+    size_t limit = scan_node->limit();
+    if (limit != -1) {
+        operators.emplace_back(
+                std::make_shared<pipeline::LimitOperatorFactory>(context->next_operator_id(), scan_node->id(), limit));
+    }
+    return operators;
+}
+
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan_operator.cpp
@@ -18,7 +18,7 @@ using starrocks::workgroup::WorkGroupManager;
 // ========== ScanOperator ==========
 
 ScanOperator::ScanOperator(OperatorFactory* factory, int32_t id, ScanNode* scan_node)
-        : SourceOperator(factory, id, "olap_scan", scan_node->id()),
+        : SourceOperator(factory, id, scan_node->name(), scan_node->id()),
           _scan_node(scan_node),
           _is_io_task_running(MAX_IO_TASKS_PER_OP),
           _chunk_sources(MAX_IO_TASKS_PER_OP) {}
@@ -252,7 +252,7 @@ Status ScanOperator::_pickup_morsel(RuntimeState* state, int chunk_source_index)
 // ========== ScanOperatorFactory ==========
 
 ScanOperatorFactory::ScanOperatorFactory(int32_t id, ScanNode* scan_node)
-        : SourceOperatorFactory(id, "olap_scan", scan_node->id()), _scan_node(scan_node) {}
+        : SourceOperatorFactory(id, scan_node->name(), scan_node->id()), _scan_node(scan_node) {}
 
 Status ScanOperatorFactory::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(OperatorFactory::prepare(state));

--- a/be/src/exec/pipeline/scan_operator.h
+++ b/be/src/exec/pipeline/scan_operator.h
@@ -87,5 +87,8 @@ protected:
     ScanNode* _scan_node;
 };
 
+pipeline::OpFactories decompose_scan_node_to_pipeline(std::shared_ptr<ScanOperatorFactory> factory, ScanNode* scan_node,
+                                                      pipeline::PipelineBuilderContext* context);
+
 } // namespace pipeline
 } // namespace starrocks

--- a/be/src/exec/pipeline/source_operator.h
+++ b/be/src/exec/pipeline/source_operator.h
@@ -14,7 +14,7 @@ using SourceOperatorPtr = std::shared_ptr<SourceOperator>;
 
 class SourceOperator : public Operator {
 public:
-    SourceOperator(OperatorFactory* factory, int32_t id, std::string name, int32_t plan_node_id)
+    SourceOperator(OperatorFactory* factory, int32_t id, const std::string& name, int32_t plan_node_id)
             : Operator(factory, id, name, plan_node_id) {}
     ~SourceOperator() override = default;
 

--- a/be/src/exec/scan_node.cpp
+++ b/be/src/exec/scan_node.cpp
@@ -53,5 +53,4 @@ Status ScanNode::prepare(RuntimeState* state) {
 
     return Status::OK();
 }
-
 } // namespace starrocks

--- a/be/src/exec/scan_node.h
+++ b/be/src/exec/scan_node.h
@@ -80,6 +80,8 @@ public:
     static const std::string _s_average_io_mgr_queue_capacity;
     static const std::string _s_num_scanner_threads_started;
 
+    const std::string& name() const { return _name; }
+
 protected:
     RuntimeProfile::Counter* _bytes_read_counter; // # bytes read from the scanner
     // # rows/tuples read from the scanner (including those discarded by eval_conjucts())
@@ -93,6 +95,7 @@ protected:
     // Aggregated scanner thread counters
     RuntimeProfile::ThreadCounters* _scanner_thread_counters;
     RuntimeProfile::Counter* _num_scanner_threads_started_counter;
+    std::string _name;
 };
 
 } // namespace starrocks

--- a/be/src/exec/vectorized/hdfs_scan_node.cpp
+++ b/be/src/exec/vectorized/hdfs_scan_node.cpp
@@ -62,7 +62,9 @@ std::atomic<int32_t>* OpenLimitAllocator::allocate(const std::string& key) {
 }
 
 HdfsScanNode::HdfsScanNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs)
-        : ScanNode(pool, tnode, descs), _hdfs_scan_node(tnode.hdfs_scan_node) {}
+        : ScanNode(pool, tnode, descs), _hdfs_scan_node(tnode.hdfs_scan_node), _status(Status::OK()) {
+    _name = "hdfs_scan";
+}
 
 HdfsScanNode::~HdfsScanNode() {
     if (runtime_state() != nullptr) {

--- a/be/src/exec/vectorized/hdfs_scan_node.cpp
+++ b/be/src/exec/vectorized/hdfs_scan_node.cpp
@@ -7,6 +7,7 @@
 
 #include "env/env_hdfs.h"
 #include "env/env_s3.h"
+#include "exec/pipeline/hdfs_scan_operator.h"
 #include "exec/vectorized/hdfs_scanner.h"
 #include "exec/vectorized/hdfs_scanner_orc.h"
 #include "exec/vectorized/hdfs_scanner_parquet.h"
@@ -61,7 +62,7 @@ std::atomic<int32_t>* OpenLimitAllocator::allocate(const std::string& key) {
 }
 
 HdfsScanNode::HdfsScanNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs)
-        : ScanNode(pool, tnode, descs) {}
+        : ScanNode(pool, tnode, descs), _hdfs_scan_node(tnode.hdfs_scan_node) {}
 
 HdfsScanNode::~HdfsScanNode() {
     if (runtime_state() != nullptr) {
@@ -158,10 +159,8 @@ Status HdfsScanNode::open(RuntimeState* state) {
 
     RETURN_IF_ERROR(Expr::open(_min_max_conjunct_ctxs, state));
     RETURN_IF_ERROR(Expr::open(_partition_conjunct_ctxs, state));
-
     _decompose_conjunct_ctxs();
     if (_lake_table != nullptr) _init_partition_values_map();
-
     for (auto& scan_range : _scan_ranges) {
         RETURN_IF_ERROR(_find_and_insert_hdfs_file(scan_range));
     }
@@ -534,9 +533,7 @@ Status HdfsScanNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) {
 
     if (_result_chunks.blocking_get(chunk)) {
         TRY_CATCH_BAD_ALLOC(_fill_chunk_pool(1));
-
         eval_join_runtime_filters(chunk);
-
         _num_rows_returned += (*chunk)->num_rows();
         COUNTER_SET(_rows_returned_counter, _num_rows_returned);
         if (reached_limit()) {
@@ -661,9 +658,7 @@ Status HdfsScanNode::_find_and_insert_hdfs_file(const THdfsScanRange& scan_range
     std::string native_file_path = scan_range.full_path;
     if (_lake_table != nullptr && _lake_table->has_partition()) {
         auto* partition_desc = _lake_table->get_partition(scan_range.partition_id);
-
         SCOPED_TIMER(_profile.open_file_timer);
-
         std::filesystem::path file_path(partition_desc->location());
         file_path /= scan_range.relative_path;
         native_file_path = file_path.native();
@@ -722,6 +717,11 @@ void HdfsScanNode::_init_counter() {
     _profile.io_counter = ADD_COUNTER(_runtime_profile, "IoCounter", TUnit::UNIT);
     _profile.column_read_timer = ADD_TIMER(_runtime_profile, "ColumnReadTime");
     _profile.column_convert_timer = ADD_TIMER(_runtime_profile, "ColumnConvertTime");
+}
+
+pipeline::OpFactories HdfsScanNode::decompose_to_pipeline(pipeline::PipelineBuilderContext* context) {
+    auto factory = std::make_shared<pipeline::HdfsScanOperatorFactory>(context->next_operator_id(), this);
+    return pipeline::decompose_scan_node_to_pipeline(factory, this, context);
 }
 
 } // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/hdfs_scan_node.h
+++ b/be/src/exec/vectorized/hdfs_scan_node.h
@@ -96,7 +96,6 @@ private:
     Status _init_table();
 
     THdfsScanNode _hdfs_scan_node;
-    int _tuple_id = 0;
     const TupleDescriptor* _tuple_desc = nullptr;
 
     int _min_max_tuple_id = 0;

--- a/be/src/exec/vectorized/hdfs_scan_node.h
+++ b/be/src/exec/vectorized/hdfs_scan_node.h
@@ -38,6 +38,11 @@ public:
 
     Status set_scan_ranges(const std::vector<TScanRangeParams>& scan_ranges) override;
 
+    std::vector<std::shared_ptr<pipeline::OperatorFactory>> decompose_to_pipeline(
+            pipeline::PipelineBuilderContext* context) override;
+
+    const THdfsScanNode& thrift_hdfs_scan_node() const { return _hdfs_scan_node; }
+
 private:
     int kMaxConcurrency = config::max_hdfs_scanner_num;
 
@@ -90,6 +95,8 @@ private:
 
     Status _init_table();
 
+    THdfsScanNode _hdfs_scan_node;
+    int _tuple_id = 0;
     const TupleDescriptor* _tuple_desc = nullptr;
 
     int _min_max_tuple_id = 0;

--- a/be/src/exec/vectorized/hdfs_scanner.h
+++ b/be/src/exec/vectorized/hdfs_scanner.h
@@ -74,7 +74,7 @@ struct HdfsScannerParams {
     std::vector<const THdfsScanRange*> scan_ranges;
 
     // runtime bloom filter.
-    RuntimeFilterProbeCollector* runtime_filter_collector;
+    const RuntimeFilterProbeCollector* runtime_filter_collector;
 
     // should clone in scanner
     std::vector<ExprContext*> conjunct_ctxs;

--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -11,6 +11,7 @@
 #include "common/status.h"
 #include "exec/pipeline/limit_operator.h"
 #include "exec/pipeline/olap_scan_operator.h"
+#include "exec/pipeline/pipeline_builder.h"
 #include "exec/vectorized/olap_scan_prepare.h"
 #include "exprs/expr_context.h"
 #include "exprs/vectorized/in_const_predicate.hpp"
@@ -152,12 +153,12 @@ Status OlapScanNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) {
         *eos = false;
         DCHECK_CHUNK(*chunk);
         return Status::OK();
-    } else {
-        _update_status(Status::EndOfFile("EOF of OlapScanNode"));
-        *eos = true;
-        status = _get_status();
-        return status.is_end_of_file() ? Status::OK() : status;
     }
+
+    _update_status(Status::EndOfFile("EOF of OlapScanNode"));
+    *eos = true;
+    status = _get_status();
+    return status.is_end_of_file() ? Status::OK() : status;
 }
 
 Status OlapScanNode::close(RuntimeState* state) {
@@ -583,29 +584,8 @@ void OlapScanNode::_close_pending_scanners() {
 }
 
 pipeline::OpFactories OlapScanNode::decompose_to_pipeline(pipeline::PipelineBuilderContext* context) {
-    ScanNode* scan_node = this;
-    OpFactories operators;
-    // Create a shared RefCountedRuntimeFilterCollector
-    auto&& rc_rf_probe_collector = std::make_shared<RcRfProbeCollector>(1, std::move(this->runtime_filter_collector()));
-    auto scan_operator = std::make_shared<pipeline::OlapScanOperatorFactory>(context->next_operator_id(), scan_node);
-    // Initialize OperatorFactory's fields involving runtime filters.
-    this->init_runtime_filter_for_operator(scan_operator.get(), context, rc_rf_probe_collector);
-    auto& morsel_queues = context->fragment_context()->morsel_queues();
-    auto source_id = scan_operator->plan_node_id();
-    DCHECK(morsel_queues.count(source_id));
-    auto& morsel_queue = morsel_queues[source_id];
-    // ScanOperator's degree_of_parallelism is not more than the number of morsels
-    // If table is empty, then morsel size is zero and we still set degree of parallelism to 1
-    const auto degree_of_parallelism =
-            std::min<size_t>(std::max<size_t>(1, morsel_queue->num_morsels()), context->degree_of_parallelism());
-    scan_operator->set_degree_of_parallelism(degree_of_parallelism);
-    operators.emplace_back(std::move(scan_operator));
-    size_t limit = scan_node->limit();
-    if (limit != -1) {
-        operators.emplace_back(
-                std::make_shared<pipeline::LimitOperatorFactory>(context->next_operator_id(), scan_node->id(), limit));
-    }
-    return operators;
+    auto factory = std::make_shared<pipeline::OlapScanOperatorFactory>(context->next_operator_id(), this);
+    return pipeline::decompose_scan_node_to_pipeline(factory, this, context);
 }
 
 } // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -29,7 +29,9 @@
 namespace starrocks::vectorized {
 
 OlapScanNode::OlapScanNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs)
-        : ScanNode(pool, tnode, descs), _olap_scan_node(tnode.olap_scan_node), _status(Status::OK()) {}
+        : ScanNode(pool, tnode, descs), _olap_scan_node(tnode.olap_scan_node), _status(Status::OK()) {
+    _name = "olap_scan";
+}
 
 Status OlapScanNode::init(const TPlanNode& tnode, RuntimeState* state) {
     RETURN_IF_ERROR(ExecNode::init(tnode, state));

--- a/be/src/exec/vectorized/orc_scanner_adapter.cpp
+++ b/be/src/exec/vectorized/orc_scanner_adapter.cpp
@@ -1898,7 +1898,7 @@ void OrcScannerAdapter::set_conjuncts(const std::vector<Expr*>& conjuncts) {
 }
 
 void OrcScannerAdapter::set_conjuncts_and_runtime_filters(const std::vector<Expr*>& conjuncts,
-                                                          RuntimeFilterProbeCollector* rf_collector) {
+                                                          const RuntimeFilterProbeCollector* rf_collector) {
     std::unique_ptr<orc::SearchArgumentBuilder> builder = orc::SearchArgumentFactory::newBuilder();
     int ok = 0;
     builder->startAnd();

--- a/be/src/exec/vectorized/orc_scanner_adapter.h
+++ b/be/src/exec/vectorized/orc_scanner_adapter.h
@@ -59,7 +59,7 @@ public:
     void set_row_reader_filter(std::shared_ptr<orc::RowReaderFilter> filter);
     void set_conjuncts(const std::vector<Expr*>& conjuncts);
     void set_conjuncts_and_runtime_filters(const std::vector<Expr*>& conjuncts,
-                                           RuntimeFilterProbeCollector* rf_collector);
+                                           const RuntimeFilterProbeCollector* rf_collector);
     Status set_timezone(const std::string& tz);
     int num_columns() const { return _src_slot_descriptors.size(); }
 

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -24,7 +24,6 @@ set(EXEC_FILES
         ./env/env_broker_test.cpp
         ./env/env_posix_test.cpp
         ./env/env_memory_test.cpp
-        ./env/env_s3_test.cpp
         ./env/output_stream_wrapper_test.cpp
         ./exec/buffered_reader_test.cpp
         ./exec/es_query_builder_test.cpp
@@ -269,6 +268,11 @@ if ("${CMAKE_BUILD_TARGET_ARCH}" STREQUAL "x86" OR "${CMAKE_BUILD_TARGET_ARCH}" 
         set_source_files_properties(./formats/json/binary_column_test.cpp PROPERTIES COMPILE_FLAGS -mno-avx2)
         set_source_files_properties(./formats/json/numeric_column_test.cpp PROPERTIES COMPILE_FLAGS -mno-avx2)
         set_source_files_properties(./formats/json/nullable_column_test.cpp PROPERTIES COMPILE_FLAGS -mno-avx2)
+endif()
+
+if (WITH_AWS)
+    set(EXEC_FILES ${EXEC_FILES} ./io/s3_output_stream_test.cpp ./io/s3_input_stream_test.cpp
+        ./env/env_s3_test.cpp)
 endif()
 
 if (USE_AVX2)

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -24,6 +24,7 @@ set(EXEC_FILES
         ./env/env_broker_test.cpp
         ./env/env_posix_test.cpp
         ./env/env_memory_test.cpp
+        ./env/env_s3_test.cpp
         ./env/output_stream_wrapper_test.cpp
         ./exec/buffered_reader_test.cpp
         ./exec/es_query_builder_test.cpp
@@ -268,11 +269,6 @@ if ("${CMAKE_BUILD_TARGET_ARCH}" STREQUAL "x86" OR "${CMAKE_BUILD_TARGET_ARCH}" 
         set_source_files_properties(./formats/json/binary_column_test.cpp PROPERTIES COMPILE_FLAGS -mno-avx2)
         set_source_files_properties(./formats/json/numeric_column_test.cpp PROPERTIES COMPILE_FLAGS -mno-avx2)
         set_source_files_properties(./formats/json/nullable_column_test.cpp PROPERTIES COMPILE_FLAGS -mno-avx2)
-endif()
-
-if (WITH_AWS)
-    set(EXEC_FILES ${EXEC_FILES} ./io/s3_output_stream_test.cpp ./io/s3_input_stream_test.cpp
-        ./env/env_s3_test.cpp)
 endif()
 
 if (USE_AVX2)

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
@@ -430,4 +430,8 @@ public class HdfsScanNode extends ScanNode {
         }
     }
 
+    @Override
+    public boolean canUsePipeLine() {
+        return true;
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：

## Problem Summary(Required) ：
This PR is trying to port `HdfsScanNode` to pipeline execution engine, including:
1.  `HdfsScanOperator` and
2. `HdfsChunkSource`
