### PR TITLE
Enhance: reduce times of copy column for union passthrough

### DIFF
--- a/be/src/exec/pipeline/set/union_passthrough_operator.h
+++ b/be/src/exec/pipeline/set/union_passthrough_operator.h
@@ -25,7 +25,9 @@ class UnionPassthroughOperator final : public Operator {
 public:
     struct SlotItem {
         SlotId slot_id;
-        size_t ref_count;
+        // Only one of the dest slots mapping to the same src slot can move
+        // the src column directly, the others must clone the src column.
+        bool moveable;
     };
 
     using SlotMap = std::unordered_map<SlotId, SlotItem>;


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Problem Summary：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
There may be multiple dest slots mapped to the same source slot for UNION ALL, eg. `SELECT x, x from t1`.
We clone the source column `N` times, if `N` dest slots mapped to the same source slot.
We could reduce one time copy, that is, clone the source column `N-1` times, and move the source column one time.

