### PR TITLE
Tiny refactor: rename file_name() to filename()

### DIFF
--- a/be/src/env/env.h
+++ b/be/src/env/env.h
@@ -244,7 +244,7 @@ public:
     virtual Status size(uint64_t* size) const = 0;
 
     // Return name of this file
-    virtual const std::string& file_name() const = 0;
+    virtual const std::string& filename() const = 0;
 
     // Get statistics about the reads which this RandomAccessFile has done.
     // If the RandomAccessFile implementation doesn't support statistics, a null pointer or

--- a/be/src/env/env_broker.cpp
+++ b/be/src/env/env_broker.cpp
@@ -204,7 +204,7 @@ public:
         return Status::OK();
     }
 
-    const std::string& file_name() const override { return _path; }
+    const std::string& filename() const override { return _path; }
 
 private:
     TNetworkAddress _broker;
@@ -230,7 +230,7 @@ public:
         return Status::OK();
     }
 
-    const std::string& filename() const override { return _file->file_name(); }
+    const std::string& filename() const override { return _file->filename(); }
 
 private:
     std::unique_ptr<RandomAccessFile> _file;

--- a/be/src/env/env_hdfs.cpp
+++ b/be/src/env/env_hdfs.cpp
@@ -27,7 +27,7 @@ public:
     Status read_at_fully(int64_t offset, void* data, int64_t size) const override;
     Status readv_at(uint64_t offset, const Slice* res, size_t res_cnt) const override;
     Status size(uint64_t* size) const override;
-    const std::string& file_name() const override { return _file_name; }
+    const std::string& filename() const override { return _file_name; }
     StatusOr<std::unique_ptr<NumericStatistics>> get_numeric_statistics() override;
 
 private:

--- a/be/src/env/env_memory.cpp
+++ b/be/src/env/env_memory.cpp
@@ -69,7 +69,7 @@ public:
         return Status::OK();
     }
 
-    const std::string& file_name() const override { return _path; }
+    const std::string& filename() const override { return _path; }
 
 private:
     std::string _path;
@@ -88,7 +88,7 @@ public:
         return nread;
     }
 
-    const std::string& filename() const override { return _random_file.file_name(); }
+    const std::string& filename() const override { return _random_file.filename(); }
 
     Status skip(uint64_t n) override {
         uint64_t size = 0;

--- a/be/src/env/env_memory.h
+++ b/be/src/env/env_memory.h
@@ -51,7 +51,7 @@ public:
         return Status::OK();
     }
 
-    const std::string& file_name() const override {
+    const std::string& filename() const override {
         static std::string s_name = "StringRandomAccessFile";
         return s_name;
     }

--- a/be/src/env/env_posix.cpp
+++ b/be/src/env/env_posix.cpp
@@ -289,7 +289,7 @@ public:
         return Status::OK();
     }
 
-    const std::string& file_name() const override { return _filename; }
+    const std::string& filename() const override { return _filename; }
 
 private:
     std::string _filename;

--- a/be/src/env/env_s3.cpp
+++ b/be/src/env/env_s3.cpp
@@ -45,7 +45,7 @@ public:
     Status read_at_fully(int64_t offset, void* data, int64_t size) const override;
     Status readv_at(uint64_t offset, const Slice* res, size_t res_cnt) const override;
     Status size(uint64_t* size) const override;
-    const std::string& file_name() const override { return _object_path; }
+    const std::string& filename() const override { return _object_path; }
 
 private:
     std::unique_ptr<io::SeekableInputStream> _input;

--- a/be/src/exec/parquet/column_chunk_reader.cpp
+++ b/be/src/exec/parquet/column_chunk_reader.cpp
@@ -56,7 +56,7 @@ public:
     Status size(uint64_t* size) const override { return _file->size(size); }
 
     // Return name of this file
-    const std::string& file_name() const override { return _file->file_name(); }
+    const std::string& filename() const override { return _file->filename(); }
 
 private:
     RandomAccessFile* _file;

--- a/be/src/exec/parquet/file_reader.cpp
+++ b/be/src/exec/parquet/file_reader.cpp
@@ -85,12 +85,11 @@ Status FileReader::_parse_footer() {
     // if local buf is not large enough, we have to allocate on heap and re-read.
     // 4 bytes magic number, 4 bytes for footer_size, so total size is footer_size + 8.
     if ((footer_size + 8) > to_read) {
-        VLOG_FILE << "parquet file has large footer. name = " << _file->file_name()
-                  << ", footer_size = " << footer_size;
+        VLOG_FILE << "parquet file has large footer. name = " << _file->filename() << ", footer_size = " << footer_size;
         to_read = footer_size + 8;
         if (_file_size < to_read) {
             return Status::Corruption(strings::Substitute("Invalid parquet file: name=$0, file_size=$1, footer_size=$2",
-                                                          _file->file_name(), _file_size, to_read));
+                                                          _file->filename(), _file_size, to_read));
         }
         footer_buf = new uint8[to_read];
         {

--- a/be/src/exec/vectorized/hdfs_scanner_orc.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_orc.cpp
@@ -49,13 +49,13 @@ public:
 
         Status status = _file->read_at_fully(offset, buf, length);
         if (!status.ok()) {
-            auto msg = strings::Substitute("Failed to read $0: $1", _file->file_name(), status.to_string());
+            auto msg = strings::Substitute("Failed to read $0: $1", _file->filename(), status.to_string());
             throw orc::ParseError(msg);
         }
         _stats->bytes_read += length;
     }
 
-    const std::string& getName() const override { return _file->file_name(); }
+    const std::string& getName() const override { return _file->filename(); }
 
 private:
     RandomAccessFile* _file;

--- a/be/src/exec/vectorized/hdfs_scanner_text.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_text.cpp
@@ -72,7 +72,7 @@ Status HdfsScannerCSVReader::_fill_buffer() {
         // Has reached the end of file and the buffer is empty.
         _should_stop_scan = true;
         LOG(INFO) << "Reach end of file!";
-        return Status::EndOfFile(_file->file_name());
+        return Status::EndOfFile(_file->filename());
     } else if (s.size == 0 && _buff.position()[n - 1] != _record_delimiter) {
         // Has reached the end of file but still no record delimiter found, which
         // is valid, according the RFC, add the record delimiter ourself.

--- a/be/src/exec/vectorized/orc_scanner.cpp
+++ b/be/src/exec/vectorized/orc_scanner.cpp
@@ -54,7 +54,7 @@ public:
 
         Status status = _file->read_at_fully(offset, buf, length);
         if (!status.ok()) {
-            auto msg = strings::Substitute("Failed to read $0: $1", _file->file_name(), status.to_string());
+            auto msg = strings::Substitute("Failed to read $0: $1", _file->filename(), status.to_string());
             throw orc::ParseError(msg);
         }
     }
@@ -62,7 +62,7 @@ public:
     /**
      * Get the name of the stream for error messages.
      */
-    const std::string& getName() const override { return _file->file_name(); }
+    const std::string& getName() const override { return _file->filename(); }
 
 private:
     std::shared_ptr<RandomAccessFile> _file;
@@ -217,14 +217,14 @@ Status ORCScanner::_open_next_orc_reader() {
             LOG(WARNING) << "Failed to create random-access files. status: " << st.to_string();
             return st;
         }
-        const std::string& file_name = file->file_name();
+        const std::string& file_name = file->filename();
         auto inStream = std::make_unique<ORCFileStream>(file, _counter);
         _next_range++;
         _orc_adapter->set_read_chunk_size(_max_chunk_size);
         _orc_adapter->set_current_file_name(file_name);
         st = _orc_adapter->init(std::move(inStream));
         if (st.is_end_of_file()) {
-            LOG(WARNING) << "Failed to init orc adapter. file_name: " << file_name << ", status: " << st.to_string();
+            LOG(WARNING) << "Failed to init orc adapter. filename: " << file_name << ", status: " << st.to_string();
             continue;
         }
         return st;

--- a/be/src/exec/vectorized/parquet_scanner.cpp
+++ b/be/src/exec/vectorized/parquet_scanner.cpp
@@ -350,7 +350,7 @@ Status ParquetScanner::open_next_reader() {
             LOG(WARNING) << "Failed to create random-access files. status: " << st.to_string();
             return st;
         }
-        _conv_ctx.current_file = file->file_name();
+        _conv_ctx.current_file = file->filename();
         auto parquet_file = std::make_shared<ParquetChunkFile>(file, 0);
         auto parquet_reader = std::make_shared<ParquetReaderWrap>(std::move(parquet_file), _num_of_columns_from_file);
         _next_file++;

--- a/be/src/http/utils.cpp
+++ b/be/src/http/utils.cpp
@@ -93,7 +93,7 @@ bool parse_basic_auth(const HttpRequest& req, AuthInfo* auth) {
 // Do a simple decision, only deal a few type
 std::string get_content_type(const std::string& file_name) {
     std::string file_ext = path_util::file_extension(file_name);
-    LOG(INFO) << "file_name: " << file_name << "; file extension: [" << file_ext << "]";
+    LOG(INFO) << "filename: " << file_name << "; file extension: [" << file_ext << "]";
     if (file_ext == std::string(".html") || file_ext == std::string(".htm")) {
         return std::string("text/html; charset=utf-8");
     } else if (file_ext == std::string(".js")) {

--- a/be/src/storage/utils.cpp
+++ b/be/src/storage/utils.cpp
@@ -212,7 +212,7 @@ Status read_write_test_file(const string& test_file_path) {
                 fmt::format("Error to read file: {}, error:{} ", test_file_path, std::strerror(Errno::no())));
     }
     if (memcmp(write_buff.get(), read_buff.get(), TEST_FILE_BUF_SIZE) != 0) {
-        LOG(WARNING) << "the test file write_buf and read_buf not equal, [file_name = " << test_file_path << "]";
+        LOG(WARNING) << "the test file write_buf and read_buf not equal, [filename = " << test_file_path << "]";
         return Status::InternalError("test file write_buf and read_buf not equal");
     }
     st = file->close();

--- a/be/src/tools/meta_tool.cpp
+++ b/be/src/tools/meta_tool.cpp
@@ -362,7 +362,7 @@ void batch_delete_meta(const std::string& tablet_file) {
 
 Status get_segment_footer(RandomAccessFile* input_file, SegmentFooterPB* footer) {
     // Footer := SegmentFooterPB, FooterPBSize(4), FooterPBChecksum(4), MagicNumber(4)
-    const std::string& file_name = input_file->file_name();
+    const std::string& file_name = input_file->filename();
     uint64_t file_size;
     RETURN_IF_ERROR(input_file->size(&file_size));
 

--- a/be/test/exec/parquet/group_reader_test.cpp
+++ b/be/test/exec/parquet/group_reader_test.cpp
@@ -21,7 +21,7 @@ public:
     Status read_at_fully(int64_t offset, void* data, int64_t size) const override { return Status::OK(); }
     Status readv_at(uint64_t offset, const Slice* res, size_t res_cnt) const override { return Status::OK(); }
     Status size(uint64_t* size) const override { return Status::OK(); }
-    const std::string& file_name() const override { return _file; }
+    const std::string& filename() const override { return _file; }
 
 private:
     std::string _file;


### PR DESCRIPTION
## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Rename `RandomAccessFile::file_name()` to `RandomAccessFile::filename()` for consistent
with `SequentialFile::filename()`、`WritableFile::filename(`) and `RandomRWFile::filename()`

## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [x] others



