### PR TITLE
Optimize the string compare of Slice in hash join

### DIFF
--- a/be/src/exec/vectorized/join_hash_map.cpp
+++ b/be/src/exec/vectorized/join_hash_map.cpp
@@ -459,7 +459,7 @@ JoinHashMapType JoinHashTable::_choose_join_hash_map() {
     size_t size = _table_items->join_keys.size();
     DCHECK_GT(size, 0);
 
-    for (size_t i = 0; i < _table_items->join_keys.size(); i++) {
+    for (size_t i = 0; i < size; i++) {
         if (!_table_items->key_columns[i]->has_null()) {
             _table_items->join_keys[i].is_null_safe_equal = false;
         }

--- a/be/src/exec/vectorized/join_hash_map.h
+++ b/be/src/exec/vectorized/join_hash_map.h
@@ -239,18 +239,6 @@ struct JoinKeyHash<Slice> {
     std::size_t operator()(const Slice& slice) const { return crc_hash_32(slice.data, slice.size, CRC_SEED); }
 };
 
-template <typename T>
-struct JoinKeyEqual {
-    bool operator()(const T& x, const T& y) const { return x == y; }
-};
-
-template <>
-struct JoinKeyEqual<Slice> {
-    bool operator()(const Slice& x, const Slice& y) const {
-        return (x.size == y.size) && (memcmp(x.data, y.data, x.size) == 0);
-    }
-};
-
 class JoinHashMapHelper {
 public:
     // maxinum bucket size
@@ -369,6 +357,8 @@ public:
     static Status lookup_init(const JoinHashTableItems& table_items, HashTableProbeState* probe_state);
 
     static const Buffer<CppType>& get_key_data(const HashTableProbeState& probe_state);
+
+    static bool equal(const CppType& x, const CppType& y) { return x == y; }
 };
 
 template <PrimitiveType PT>
@@ -389,6 +379,8 @@ public:
         return ColumnHelper::as_raw_column<ColumnType>(probe_state.probe_key_column)->get_data();
     }
 
+    static bool equal(const CppType& x, const CppType& y) { return x == y; }
+
 private:
     static void _probe_column(const JoinHashTableItems& table_items, HashTableProbeState* probe_state,
                               const Columns& data_columns);
@@ -407,6 +399,8 @@ public:
     }
 
     static Status lookup_init(const JoinHashTableItems& table_items, HashTableProbeState* probe_state);
+
+    static bool equal(const Slice& x, const Slice& y) { return x == y; }
 
 private:
     static void _probe_column(const JoinHashTableItems& table_items, HashTableProbeState* probe_state,

--- a/be/src/exec/vectorized/join_hash_map.tpp
+++ b/be/src/exec/vectorized/join_hash_map.tpp
@@ -837,7 +837,7 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht(RuntimeState* state, 
         size_t build_index = _probe_state->next[i];
         if (build_index != 0) {
             do {
-                if (JoinKeyEqual<CppType>()(build_data[build_index], probe_data[i])) {
+                if (ProbeFunc().equal(build_data[build_index], probe_data[i])) {
                     _probe_state->probe_index[match_count] = i;
                     _probe_state->build_index[match_count] = build_index;
                     match_count++;
@@ -901,7 +901,7 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_outer_join(R
             RETURN_IF_CHUNK_FULL()
         } else {
             while (build_index != 0) {
-                if (JoinKeyEqual<CppType>()(build_data[build_index], probe_data[i])) {
+                if (ProbeFunc().equal(build_data[build_index], probe_data[i])) {
                     _probe_state->probe_index[match_count] = i;
                     _probe_state->build_index[match_count] = build_index;
                     match_count++;
@@ -949,7 +949,7 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_semi_join(Ru
         }
 
         while (index != 0) {
-            if (JoinKeyEqual<CppType>()(build_data[index], probe_data[i])) {
+            if (ProbeFunc().equal(build_data[index], probe_data[i])) {
                 _probe_state->probe_index[match_count] = i;
                 match_count++;
                 break;
@@ -987,7 +987,7 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_anti_join(Ru
 
             bool found = false;
             while (index != 0) {
-                if (JoinKeyEqual<CppType>()(build_data[index], probe_data[i])) {
+                if (ProbeFunc().equal(build_data[index], probe_data[i])) {
                     found = true;
                     break;
                 }
@@ -1008,7 +1008,7 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_anti_join(Ru
             }
             bool found = false;
             while (index != 0) {
-                if (JoinKeyEqual<CppType>()(build_data[index], probe_data[i])) {
+                if (ProbeFunc().equal(build_data[index], probe_data[i])) {
                     found = true;
                     break;
                 }
@@ -1050,7 +1050,7 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_right_outer_join(
         }
 
         while (build_index != 0) {
-            if (JoinKeyEqual<CppType>()(build_data[build_index], probe_data[i])) {
+            if (ProbeFunc().equal(build_data[build_index], probe_data[i])) {
                 _probe_state->probe_index[match_count] = i;
                 _probe_state->build_index[match_count] = build_index;
                 _probe_state->build_match_index[build_index] = 1;
@@ -1088,7 +1088,7 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_right_semi_join(R
         }
 
         while (build_index != 0) {
-            if (JoinKeyEqual<CppType>()(build_data[build_index], probe_data[i])) {
+            if (ProbeFunc().equal(build_data[build_index], probe_data[i])) {
                 if (_probe_state->build_match_index[build_index] == 0) {
                     _probe_state->probe_index[match_count] = i;
                     _probe_state->build_index[match_count] = build_index;
@@ -1118,7 +1118,7 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_right_anti_join(R
         }
 
         while (index != 0) {
-            if (JoinKeyEqual<CppType>()(build_data[index], probe_data[i])) {
+            if (ProbeFunc().equal(build_data[index], probe_data[i])) {
                 _probe_state->build_match_index[index] = 1;
             }
             index = _table_items->next[index];
@@ -1158,7 +1158,7 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_full_outer_join(R
             RETURN_IF_CHUNK_FULL()
         } else {
             while (build_index != 0) {
-                if (JoinKeyEqual<CppType>()(build_data[build_index], probe_data[i])) {
+                if (ProbeFunc().equal(build_data[build_index], probe_data[i])) {
                     _probe_state->probe_index[match_count] = i;
                     _probe_state->build_index[match_count] = build_index;
                     _probe_state->build_match_index[build_index] = 1;
@@ -1218,7 +1218,7 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_outer_join_w
         }
 
         while (build_index != 0) {
-            if (JoinKeyEqual<CppType>()(build_data[build_index], probe_data[i])) {
+            if (ProbeFunc().equal(build_data[build_index], probe_data[i])) {
                 _probe_state->probe_index[match_count] = i;
                 _probe_state->build_index[match_count] = build_index;
                 _probe_state->probe_match_index[i]++;
@@ -1272,7 +1272,7 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_semi_join_wi
         }
 
         while (build_index != 0) {
-            if (JoinKeyEqual<CppType>()(build_data[build_index], probe_data[i])) {
+            if (ProbeFunc().equal(build_data[build_index], probe_data[i])) {
                 _probe_state->probe_index[match_count] = i;
                 _probe_state->build_index[match_count] = build_index;
                 match_count++;
@@ -1322,7 +1322,7 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_anti_join_wi
         }
 
         while (build_index != 0) {
-            if (JoinKeyEqual<CppType>()(build_data[build_index], probe_data[i])) {
+            if (ProbeFunc().equal(build_data[build_index], probe_data[i])) {
                 _probe_state->probe_index[match_count] = i;
                 _probe_state->build_index[match_count] = build_index;
                 _probe_state->probe_match_index[i]++;
@@ -1364,7 +1364,7 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_right_outer_join_
         }
 
         while (build_index != 0) {
-            if (JoinKeyEqual<CppType>()(build_data[build_index], probe_data[i])) {
+            if (ProbeFunc().equal(build_data[build_index], probe_data[i])) {
                 _probe_state->probe_index[match_count] = i;
                 _probe_state->build_index[match_count] = build_index;
                 match_count++;
@@ -1395,7 +1395,7 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_right_semi_join_w
         }
 
         while (build_index != 0) {
-            if (JoinKeyEqual<CppType>()(build_data[build_index], probe_data[i])) {
+            if (ProbeFunc().equal(build_data[build_index], probe_data[i])) {
                 _probe_state->probe_index[match_count] = i;
                 _probe_state->build_index[match_count] = build_index;
                 match_count++;
@@ -1426,7 +1426,7 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_right_anti_join_w
         }
 
         while (build_index != 0) {
-            if (JoinKeyEqual<CppType>()(build_data[build_index], probe_data[i])) {
+            if (ProbeFunc().equal(build_data[build_index], probe_data[i])) {
                 _probe_state->probe_index[match_count] = i;
                 _probe_state->build_index[match_count] = build_index;
                 match_count++;
@@ -1473,7 +1473,7 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_full_outer_join_w
             RETURN_IF_CHUNK_FULL()
         } else {
             while (build_index != 0) {
-                if (JoinKeyEqual<CppType>()(build_data[build_index], probe_data[i])) {
+                if (ProbeFunc().equal(build_data[build_index], probe_data[i])) {
                     _probe_state->probe_index[match_count] = i;
                     _probe_state->build_index[match_count] = build_index;
                     _probe_state->probe_match_index[i]++;

--- a/be/test/exec/vectorized/join_hash_map_test.cpp
+++ b/be/test/exec/vectorized/join_hash_map_test.cpp
@@ -550,7 +550,7 @@ void JoinHashMapTest::check_binary_column(const ColumnPtr& column, uint32_t row_
         Slice check_slice;
         check_slice.data = str.data();
         check_slice.size = str.size();
-        ASSERT_TRUE(JoinKeyEqual<Slice>()(check_slice, data[i]));
+        ASSERT_TRUE(check_slice == data[i]);
     }
 }
 
@@ -719,15 +719,6 @@ TEST_F(JoinHashMapTest, JoinKeyHash) {
 }
 
 // NOLINTNEXTLINE
-TEST_F(JoinHashMapTest, JoinKeyEqual) {
-    ASSERT_TRUE(JoinKeyEqual<int32_t>()(1, 1));
-    ASSERT_FALSE(JoinKeyEqual<int32_t>()(1, 2));
-    ASSERT_TRUE(JoinKeyEqual<Slice>()(Slice{"abcd", 4}, Slice{"abcd", 4}));
-    ASSERT_FALSE(JoinKeyEqual<Slice>()(Slice{"abcd", 4}, Slice{"efgh", 4}));
-    ASSERT_FALSE(JoinKeyEqual<Slice>()(Slice{"abcd", 4}, Slice{"abc", 3}));
-}
-
-// NOLINTNEXTLINE
 TEST_F(JoinHashMapTest, CalcBucketNum) {
     uint32_t bucket_num = JoinHashMapHelper::calc_bucket_num(1, 4);
     ASSERT_EQ(2, bucket_num);
@@ -883,7 +874,7 @@ TEST_F(JoinHashMapTest, JoinBuildProbeFunc) {
         size_t probe_index = probe_state.next[i];
         auto data = ColumnHelper::as_raw_column<Int32Column>(table_items.key_columns[0])->get_data();
         while (probe_index != 0) {
-            if (JoinKeyEqual<int32_t>()(i, data[probe_index])) {
+            if (i == data[probe_index]) {
                 found_count++;
             }
             probe_index = table_items.next[probe_index];
@@ -926,7 +917,7 @@ TEST_F(JoinHashMapTest, JoinBuildProbeFuncNullable) {
         auto data_column = ColumnHelper::as_raw_column<NullableColumn>(table_items.key_columns[0])->data_column();
         auto data = ColumnHelper::as_raw_column<Int32Column>(data_column)->get_data();
         while (probe_index != 0) {
-            if (JoinKeyEqual<int32_t>()(i, data[probe_index])) {
+            if (i == data[probe_index]) {
                 found_count++;
             }
             probe_index = table_items.next[probe_index];
@@ -984,7 +975,7 @@ TEST_F(JoinHashMapTest, FixedSizeJoinBuildProbeFunc) {
         auto* data_column = ColumnHelper::as_raw_column<Int64Column>(table_items.build_key_column);
         auto data = data_column->get_data();
         while (probe_index != 0) {
-            if (JoinKeyEqual<int64_t>()((100 + i) * (1ul << 32u) + i, data[probe_index])) {
+            if ((100 + i) * (1ul << 32u) + i == data[probe_index]) {
                 found_count++;
             }
             probe_index = table_items.next[probe_index];

--- a/be/test/exec/vectorized/join_hash_map_test.cpp
+++ b/be/test/exec/vectorized/join_hash_map_test.cpp
@@ -1038,7 +1038,7 @@ TEST_F(JoinHashMapTest, FixedSizeJoinBuildProbeFuncNullable) {
         auto* data_column = ColumnHelper::as_raw_column<Int64Column>(table_items.build_key_column);
         auto data = data_column->get_data();
         while (probe_index != 0) {
-            if (JoinKeyEqual<int64_t>()((100 + i) * (1ul << 32ul) + i, data[probe_index])) {
+            if ((100 + i) * (1ul << 32ul) + i == data[probe_index]) {
                 found_count++;
             }
             probe_index = table_items.next[probe_index];
@@ -1098,8 +1098,7 @@ TEST_F(JoinHashMapTest, SerializedJoinBuildProbeFunc) {
         size_t probe_index = probe_state.next[i];
         auto data = table_items.build_slice;
         while (probe_index != 0) {
-            if (JoinKeyEqual<Slice>()(JoinHashMapHelper::get_hash_key(*probe_state.key_columns, i, buffer.data()),
-                                      data[probe_index])) {
+            if (JoinHashMapHelper::get_hash_key(*probe_state.key_columns, i, buffer.data()) == data[probe_index]) {
                 found_count++;
             }
             probe_index = table_items.next[probe_index];
@@ -1164,7 +1163,7 @@ TEST_F(JoinHashMapTest, SerializedJoinBuildProbeFuncNullable) {
         auto data = table_items.build_slice;
         while (probe_index != 0) {
             auto probe_slice = JoinHashMapHelper::get_hash_key(probe_data_columns, i, buffer.data());
-            if (JoinKeyEqual<Slice>()(probe_slice, data[probe_index])) {
+            if (probe_slice == data[probe_index]) {
                 found_count++;
             }
             probe_index = table_items.next[probe_index];


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3905 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Slice operator== has two optimization for string compare
* If the length is equal and larger than 16, use SSE4.1
* If the length is small than 16, convert the address to int16/int32/int64 to comparasion

so i use it to replace the manual implement in HashJoin.

When the cardinality is relatively small, string comparison is the main performance bottleneck, so the optimization effect is very good. When the cardinality is relatively large, cache locality is the main factor, so the performance impact is not large.

```
select count(lo_revenue), count(p_size) from lineorder_str join part_str on lo_partkey=p_partkey;
``` 
* cardinality: 1,400,000
* avg string length: 6.2 byte
* before optimization: 31.82s
* after optimization: 29.48s

```
select count(lo_revenue), count(s_city) from lineorder_str join supplier_str on lo_suppkey=s_suppkey;
```
* cardinality: 200,000
* avg string length: 5.4 byte
* before optimization: 15.98s
* after optimization: 14.39s

```
select count(lo_revenue), count(d_year) from lineorder_str join dates on lo_orderdate=d_datekey;
```
* cardinality: 2556
* avg string length: 8 byte
* before optimization: 4.16s
* after optimization: 3.60s

```
select count(lo_revenue), count(d_year) from lineorder_str join dates on repeat(lo_orderdate,10)=repeat(d_datekey,10);
```
* cardinality: 2556
* avg string length: 80 byte
* before optimization: 13.63s
* after optimization: 10.96s

```
select count(lo_revenue), count(s_city) from lineorder_str join supplier_str on repeat(lo_suppkey,5)=repeat(s_suppkey,5);
```
* cardinality: 200,000
* avg string length: 27 byte
* before optimization: 27.85s
* after optimization: 25.09s

```
select count(lo_revenue), count(s_city) from lineorder_str join supplier_str on repeat(lo_suppkey,10)=repeat(s_suppkey,10);
```
* cardinality: 200,000
* avg string length: 54 byte
* before optimization: 32.72s
* after optimization: 29.54s
