### PR TITLE
Fix sql mode bug in parser

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -79,7 +79,6 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.NotImplementedException;
-import com.starrocks.qe.SqlModeHelper;
 import com.starrocks.sql.analyzer.AST2SQL;
 import com.starrocks.sql.analyzer.RelationId;
 import com.starrocks.sql.analyzer.SemanticException;
@@ -118,10 +117,7 @@ import java.util.stream.Collectors;
 import static java.util.stream.Collectors.toList;
 
 public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
-    private long sqlMode;
-
-    public AstBuilder(long sqlMode) {
-        this.sqlMode = sqlMode;
+    public AstBuilder() {
     }
 
     @Override
@@ -921,11 +917,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
         Expr right = (Expr) visit(context.right);
 
         if (context.operator.getType() == StarRocksLexer.LOGICAL_OR) {
-            if ((this.sqlMode & SqlModeHelper.MODE_PIPES_AS_CONCAT) == 0) {
-                return new CompoundPredicate(CompoundPredicate.Operator.OR, left, right);
-            } else {
-                return new FunctionCallExpr("concat", new FunctionParams(Lists.newArrayList(left, right)));
-            }
+            return new CompoundPredicate(CompoundPredicate.Operator.OR, left, right);
         } else {
             return new CompoundPredicate(getLogicalBinaryOperator(context.operator), left, right);
         }
@@ -1251,6 +1243,13 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
             return new InformationFunction(context.name.getText().toUpperCase());
         }
         throw new ParsingException("Unknown special function " + context.name.getText());
+    }
+
+    @Override
+    public ParseNode visitConcat(StarRocksParser.ConcatContext context) {
+        Expr left = (Expr) visit(context.left);
+        Expr right = (Expr) visit(context.right);
+        return new FunctionCallExpr("concat", new FunctionParams(Lists.newArrayList(left, right)));
     }
 
     // ------------------------------------------- Literal -------------------------------------------

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
@@ -29,10 +29,11 @@ public class SqlParser {
                 StarRocksLexer lexer = new StarRocksLexer(new CaseInsensitiveStream(CharStreams.fromString(sql)));
                 CommonTokenStream tokenStream = new CommonTokenStream(lexer);
                 StarRocksParser parser = new StarRocksParser(tokenStream);
+                StarRocksParser.sqlMode = sqlMode;
                 parser.removeErrorListeners();
                 parser.addErrorListener(new ErrorHandler());
                 StarRocksParser.SqlStatementsContext sqlStatements = parser.sqlStatements();
-                statements.add((StatementBase) new AstBuilder(sqlMode)
+                statements.add((StatementBase) new AstBuilder()
                         .visitSingleStatement(sqlStatements.singleStatement(0)));
             } catch (ParsingException parsingException) {
                 StatementBase statement = parseWithOldParser(sql, sqlMode);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -271,7 +271,8 @@ valueExpression
         PERCENT_SYMBOL | INT_DIV | BITAND| BITOR | BITXOR)
       right = valueExpression                                                             #arithmeticBinary
     | left = valueExpression operator =
-        (PLUS_SYMBOL | MINUS_SYMBOL) right=valueExpression                                #arithmeticBinary
+        (PLUS_SYMBOL | MINUS_SYMBOL) right = valueExpression                              #arithmeticBinary
+    | left = valueExpression CONCAT right = valueExpression                               #concat
     ;
 
 primaryExpression

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocksLex.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocksLex.g4
@@ -1,6 +1,10 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
 
 lexer grammar StarRocksLex;
+@parser::members {public static long sqlMode;}
+tokens {
+    CONCAT
+}
 
 ALL: 'ALL';
 ALTER: 'ALTER';
@@ -158,7 +162,7 @@ MINUS_SYMBOL: '-';
 ASTERISK_SYMBOL: '*';
 SLASH_SYMBOL: '/';
 PERCENT_SYMBOL: '%';
-LOGICAL_OR: '||';
+LOGICAL_OR: '||' {setType((StarRocksParser.sqlMode & com.starrocks.qe.SqlModeHelper.MODE_PIPES_AS_CONCAT) == 0 ? LOGICAL_OR : StarRocksParser.CONCAT);};
 
 INT_DIV: 'DIV';
 BITAND: '&';


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3888 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The original sqlmode processing method mixes the LOGICAL_OR keyword and the CONCAT keyword. This leads to the fact that when MODE_PIPES_AS_CONCAT is turned on, concat is treated as an "or" priority. For example, expr like 'a' || 'b' is parsed as concat (expr like 'a' , ' b'), which will lead to semantic errors
