### PR TITLE
Aws sdk can be slow when get ec2 metadata in Aws::Client::ClientConfiguration

### DIFF
--- a/be/src/env/env_s3.cpp
+++ b/be/src/env/env_s3.cpp
@@ -131,12 +131,6 @@ public:
     using ClientConfiguration = Aws::Client::ClientConfiguration;
     using S3Client = Aws::S3::S3Client;
     using S3ClientPtr = std::shared_ptr<S3Client>;
-    // We cached config here and make a deep copy each time.Since aws sdk has changed the
-    // Aws::Client::ClientConfiguration default constructor to search for the region
-    // (where as before 1.8 it has been hard coded default of "us-east-1").
-    // Part of that change is looking through the ec2 metadata, which can take a long time.
-    // For more details, please refer https://github.com/aws/aws-sdk-cpp/issues/1440
-    static Aws::Client::ClientConfiguration s_config;
 
     static S3ClientFactory& instance() {
         static S3ClientFactory obj;
@@ -197,8 +191,15 @@ S3ClientFactory::S3ClientPtr S3ClientFactory::new_client(const ClientConfigurati
     return client;
 }
 
+// We cached config here and make a deep copy each time.Since aws sdk has changed the
+// Aws::Client::ClientConfiguration default constructor to search for the region
+// (where as before 1.8 it has been hard coded default of "us-east-1").
+// Part of that change is looking through the ec2 metadata, which can take a long time.
+// For more details, please refer https://github.com/aws/aws-sdk-cpp/issues/1440
+static Aws::Client::ClientConfiguration s_config;
+
 static std::shared_ptr<Aws::S3::S3Client> new_s3client(const S3URI& uri) {
-    Aws::Client::ClientConfiguration config = S3ClientFactory::s_config;
+    Aws::Client::ClientConfiguration config = s_config;
     config.scheme = Aws::Http::Scheme::HTTP; // TODO: use the scheme in uri
     if (!uri.endpoint().empty()) {
         config.endpointOverride = uri.endpoint();

--- a/be/src/env/env_s3.cpp
+++ b/be/src/env/env_s3.cpp
@@ -128,6 +128,13 @@ bool operator==(const Aws::Client::ClientConfiguration& lhs, const Aws::Client::
 
 class S3ClientFactory {
 public:
+    // We cached config here and make a deep copy each time.Since aws sdk has changed the
+    // Aws::Client::ClientConfiguration default constructor to search for the region
+    // (where as before 1.8 it has been hard coded default of "us-east-1").
+    // Part of that change is looking through the ec2 metadata, which can take a long time.
+    // For more details, please refer https://github.com/aws/aws-sdk-cpp/issues/1440
+    static Aws::Client::ClientConfiguration s_config;
+
     using ClientConfiguration = Aws::Client::ClientConfiguration;
     using S3Client = Aws::S3::S3Client;
     using S3ClientPtr = std::shared_ptr<S3Client>;
@@ -158,6 +165,8 @@ private:
     S3ClientPtr _clients[kMaxItems];
     Random _rand;
 };
+
+Aws::Client::ClientConfiguration S3ClientFactory::s_config;
 
 S3ClientFactory::S3ClientFactory() : _items(0), _rand((int)::time(NULL)) {}
 
@@ -191,15 +200,8 @@ S3ClientFactory::S3ClientPtr S3ClientFactory::new_client(const ClientConfigurati
     return client;
 }
 
-// We cached config here and make a deep copy each time.Since aws sdk has changed the
-// Aws::Client::ClientConfiguration default constructor to search for the region
-// (where as before 1.8 it has been hard coded default of "us-east-1").
-// Part of that change is looking through the ec2 metadata, which can take a long time.
-// For more details, please refer https://github.com/aws/aws-sdk-cpp/issues/1440
-static Aws::Client::ClientConfiguration s_config;
-
 static std::shared_ptr<Aws::S3::S3Client> new_s3client(const S3URI& uri) {
-    Aws::Client::ClientConfiguration config = s_config;
+    Aws::Client::ClientConfiguration config = S3ClientFactory::s_config;
     config.scheme = Aws::Http::Scheme::HTTP; // TODO: use the scheme in uri
     if (!uri.endpoint().empty()) {
         config.endpointOverride = uri.endpoint();

--- a/be/src/env/env_s3.cpp
+++ b/be/src/env/env_s3.cpp
@@ -14,7 +14,6 @@
 #include <aws/s3/model/ListObjectsRequest.h>
 #include <aws/s3/model/PutObjectRequest.h>
 #include <fmt/core.h>
-#include <stdlib.h>
 #include <time.h>
 
 #include <limits>

--- a/be/src/env/env_s3.h
+++ b/be/src/env/env_s3.h
@@ -6,8 +6,6 @@
 
 #include "env/env.h"
 
-#include <aws/core/Aws.h>
-
 namespace starrocks {
 
 // NOTE: Many methods in this class are unimplemented
@@ -15,13 +13,6 @@ namespace starrocks {
 // definition to cpp file.
 class EnvS3 : public Env {
 public:
-    // We cached config here and make a deep copy each time.Since aws sdk has changed the
-    // Aws::Client::ClientConfiguration default constructor to search for the region
-    // (where as before 1.8 it has been hard coded default of "us-east-1").
-    // Part of that change is looking through the ec2 metadata, which can take a long time.
-    // For more details, please refer https://github.com/aws/aws-sdk-cpp/issues/1440
-    static Aws::Client::ClientConfiguration s_config;
-
     EnvS3() {}
     ~EnvS3() override = default;
 

--- a/be/src/env/env_s3.h
+++ b/be/src/env/env_s3.h
@@ -6,6 +6,8 @@
 
 #include "env/env.h"
 
+#include <aws/core/Aws.h>
+
 namespace starrocks {
 
 // NOTE: Many methods in this class are unimplemented
@@ -13,6 +15,13 @@ namespace starrocks {
 // definition to cpp file.
 class EnvS3 : public Env {
 public:
+    // We cached config here and make a deep copy each time.Since aws sdk has changed the
+    // Aws::Client::ClientConfiguration default constructor to search for the region
+    // (where as before 1.8 it has been hard coded default of "us-east-1").
+    // Part of that change is looking through the ec2 metadata, which can take a long time.
+    // For more details, please refer https://github.com/aws/aws-sdk-cpp/issues/1440
+    static Aws::Client::ClientConfiguration s_config;
+    
     EnvS3() {}
     ~EnvS3() override = default;
 

--- a/be/src/env/env_s3.h
+++ b/be/src/env/env_s3.h
@@ -21,7 +21,7 @@ public:
     // Part of that change is looking through the ec2 metadata, which can take a long time.
     // For more details, please refer https://github.com/aws/aws-sdk-cpp/issues/1440
     static Aws::Client::ClientConfiguration s_config;
-    
+
     EnvS3() {}
     ~EnvS3() override = default;
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When we init ClientConfiguration with default constructor, it will try to get current region use ec2 metadata.And there is an exclusive lock in the sdk code which will cause query slow when we have many files to scan.
```
ClientConfiguration::ClientConfiguration()
{
    setLegacyClientConfigurationParameters(*this);
    retryStrategy = InitRetryStrategy();

    if (region.empty() &&
        Aws::Utils::StringUtils::ToLower(Aws::Environment::GetEnv("AWS_EC2_METADATA_DISABLED").c_str()) != "true")
    {
        auto client = Aws::Internal::GetEC2MetadataClient();
        if (client)
        {
            region = client->GetCurrentRegion();
        }
    }
    if (!region.empty())
    {
        return;
    }
    region = Aws::String(Aws::Region::US_EAST_1);
}
```
```
Aws::String EC2MetadataClient::GetCurrentRegion() const
        {
            if (!m_region.empty())
            {
                return m_region;
            }

            AWS_LOGSTREAM_TRACE(m_logtag.c_str(), "Getting current region for ec2 instance");

            Aws::StringStream ss;
            ss << m_endpoint << EC2_REGION_RESOURCE;
            std::shared_ptr<HttpRequest> regionRequest(CreateHttpRequest(ss.str(), HttpMethod::HTTP_GET,
                                                                         Aws::Utils::Stream::DefaultResponseStreamFactoryMethod));
            {
                std::lock_guard<std::recursive_mutex> locker(m_tokenMutex);
                if (m_tokenRequired)
                {
                    regionRequest->SetHeaderValue(EC2_IMDS_TOKEN_HEADER, m_token);
                }
            }
```
I have a test results, for the query below the time cost can optimized from 200s+ to < 10s. The reason is that we can increase the concurrency and we remove the time-cost operation during ClientConfiguration initialization  after this pr
```
MySQL [iceberg_10t]> SELECT sum(LO_EXTENDEDPRICE * LO_DISCOUNT) AS revenue FROM lineorder_flat WHERE LO_ORDERDATE = 19970101 AND LO_DISCOUNT BETWEEN 1 AND 3 AND LO_QUANTITY < 25;
```
you can also refer to:
https://github.com/aws/aws-sdk-cpp/issues/1511
https://github.com/aws/aws-sdk-cpp/issues/1440