### PR TITLE
Fix low cardinality opmize crash in pipeline when enable cache table …

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -147,6 +147,7 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
     auto* runtime_state = _fragment_ctx->runtime_state();
     runtime_state->init_mem_trackers(query_id, wg != nullptr ? wg->mem_tracker() : nullptr);
     runtime_state->set_be_number(backend_num);
+    runtime_state->set_query_ctx(_query_ctx);
 
     // RuntimeFilterWorker::open_query is idempotent
     if (params.__isset.runtime_filter_params && params.runtime_filter_params.id_to_prober_params.size() != 0) {

--- a/be/src/runtime/global_dicts.cpp
+++ b/be/src/runtime/global_dicts.cpp
@@ -379,7 +379,7 @@ void DictOptimizeParser::rewrite_descriptor(RuntimeState* runtime_state, const s
     if (global_dict.empty()) return;
 
     for (size_t i = 0; i < slot_descs->size(); ++i) {
-        if (global_dict.count((*slot_descs)[i]->id()) && (*slot_descs)[i]->type().type == TYPE_INT) {
+        if (global_dict.count((*slot_descs)[i]->id()) && (*slot_descs)[i]->type().type == LowCardDictType) {
             SlotDescriptor* newSlot = runtime_state->global_obj_pool()->add(new SlotDescriptor(*(*slot_descs)[i]));
             newSlot->type().type = TYPE_VARCHAR;
             (*slot_descs)[i] = newSlot;

--- a/be/src/runtime/global_dicts.cpp
+++ b/be/src/runtime/global_dicts.cpp
@@ -379,8 +379,8 @@ void DictOptimizeParser::rewrite_descriptor(RuntimeState* runtime_state, const s
     if (global_dict.empty()) return;
 
     for (size_t i = 0; i < slot_descs->size(); ++i) {
-        if (global_dict.count((*slot_descs)[i]->id())) {
-            SlotDescriptor* newSlot = runtime_state->obj_pool()->add(new SlotDescriptor(*(*slot_descs)[i]));
+        if (global_dict.count((*slot_descs)[i]->id()) && (*slot_descs)[i]->type().type == TYPE_INT) {
+            SlotDescriptor* newSlot = runtime_state->global_obj_pool()->add(new SlotDescriptor(*(*slot_descs)[i]));
             newSlot->type().type = TYPE_VARCHAR;
             (*slot_descs)[i] = newSlot;
         }

--- a/be/src/runtime/global_dicts.h
+++ b/be/src/runtime/global_dicts.h
@@ -22,6 +22,7 @@ class RuntimeState;
 namespace vectorized {
 class ColumnRef;
 
+constexpr auto LowCardDictType = TYPE_INT;
 // TODO: we need to change the dict type to int16 later
 using DictId = int32_t;
 
@@ -178,7 +179,7 @@ struct DictDecoder {
     }
 };
 
-using DefaultDecoder = DictDecoder<TYPE_INT, RGlobalDictMap, TYPE_VARCHAR>;
+using DefaultDecoder = DictDecoder<LowCardDictType, RGlobalDictMap, TYPE_VARCHAR>;
 using DefaultDecoderPtr = std::unique_ptr<DefaultDecoder>;
 
 } // namespace vectorized

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -32,6 +32,7 @@
 #include "common/object_pool.h"
 #include "common/status.h"
 #include "exec/exec_node.h"
+#include "exec/pipeline/query_context.h"
 #include "runtime/descriptors.h"
 #include "runtime/exec_env.h"
 #include "runtime/load_path_mgr.h"
@@ -185,6 +186,13 @@ Status RuntimeState::init_instance_mem_tracker() {
     _instance_mem_tracker = std::make_unique<MemTracker>(-1);
     _instance_mem_pool = std::make_unique<MemPool>();
     return Status::OK();
+}
+
+ObjectPool* RuntimeState::global_obj_pool() const {
+    if (_query_ctx == nullptr) {
+        return obj_pool();
+    }
+    return _query_ctx->object_pool();
 }
 
 std::string RuntimeState::error_log() {

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -33,6 +33,7 @@
 #include "common/constexpr.h"
 #include "common/global_types.h"
 #include "common/object_pool.h"
+#include "exec/pipeline/pipeline_fwd.h"
 #include "gen_cpp/InternalService_types.h" // for TQueryOptions
 #include "gen_cpp/Types_types.h"           // for TUniqueId
 #include "runtime/global_dicts.h"
@@ -55,6 +56,10 @@ class ResultBufferMgr;
 class LoadErrorHub;
 class RowDescriptor;
 class RuntimeFilterPort;
+
+namespace pipeline {
+class QueryContext;
+}
 
 // A collection of items that are part of the global state of a
 // query and shared across all execution nodes of that query.
@@ -89,6 +94,8 @@ public:
 
     const TQueryOptions& query_options() const { return _query_options; }
     ObjectPool* obj_pool() const { return _obj_pool.get(); }
+    ObjectPool* global_obj_pool() const;
+    void set_query_ctx(pipeline::QueryContext* ctx) { _query_ctx = ctx; }
 
     const DescriptorTbl& desc_tbl() const { return *_desc_tbl; }
     void set_desc_tbl(DescriptorTbl* desc_tbl) { _desc_tbl = desc_tbl; }
@@ -369,6 +376,8 @@ private:
 
     vectorized::GlobalDictMaps _query_global_dicts;
     vectorized::GlobalDictMaps _load_global_dicts;
+
+    pipeline::QueryContext* _query_ctx = nullptr;
 };
 
 #define LIMIT_EXCEEDED(tracker, state, msg)                                                                         \


### PR DESCRIPTION
…desc

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
Fixes #https://github.com/StarRocks/starrocks/issues/3896

## Problem Summary(Required) ：
when we rewrite decoded slot descriptor, we add the new slot descritpor
to runtime_state.object_pool. but this slot descriptor may be accessed
in other thread. which will cause a use-after-free
