### PR TITLE
Implement PersistentIndex merge compaction

### DIFF
--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -441,7 +441,7 @@ public:
         _idx_file_path = strings::Substitute("$0/index.l1.$1.$2", dir, version.major(), version.minor());
         _idx_file_path_tmp = _idx_file_path + ".tmp";
         fs::BlockManager* block_mgr = fs::fs_util::block_manager();
-        fs::CreateBlockOptions wblock_opts({_idx_file_path_tmp});
+        fs::CreateBlockOptions wblock_opts({_idx_file_path_tmp, Env::OpenMode::CREATE_OR_OPEN_WITH_TRUNCATE});
         return block_mgr->create_block(wblock_opts, &_wb);
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [x] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3228

## Problem Summary(Required) ：
This PR implements PersistentIndex merge compaction, which merges l0 and l1 into a new persistent index l1.
This merge process first estimate the number of shards of the new l1 index, then merge each shard  sequentially
