### PR TITLE
use decimal128 instead decimal64 for aggr sum

### DIFF
--- a/be/src/exprs/agg/aggregate_factory.cpp
+++ b/be/src/exprs/agg/aggregate_factory.cpp
@@ -39,6 +39,10 @@ template <PrimitiveType PT>
 AggregateFunctionPtr AggregateFactory::MakeAvgAggregateFunction() {
     return std::make_shared<AvgAggregateFunction<PT>>();
 }
+template <PrimitiveType PT>
+AggregateFunctionPtr AggregateFactory::MakeDecimalAvgAggregateFunction() {
+    return std::make_shared<DecimalAvgAggregateFunction<PT>>();
+}
 
 template <PrimitiveType PT>
 AggregateFunctionPtr AggregateFactory::MakeBitmapUnionIntAggregateFunction() {
@@ -118,6 +122,11 @@ AggregateFunctionPtr AggregateFactory::MakeSumAggregateFunction() {
     return std::make_shared<SumAggregateFunction<PT>>();
 }
 
+template <PrimitiveType PT>
+AggregateFunctionPtr AggregateFactory::MakeDecimalSumAggregateFunction() {
+    return std::make_shared<DecimalSumAggregateFunction<PT>>();
+}
+
 template <PrimitiveType PT, bool is_sample>
 AggregateFunctionPtr AggregateFactory::MakeVarianceAggregateFunction() {
     return std::make_shared<VarianceAggregateFunction<PT, is_sample>>();
@@ -136,6 +145,11 @@ AggregateFunctionPtr AggregateFactory::MakeSumDistinctAggregateFunction() {
 template <PrimitiveType PT>
 AggregateFunctionPtr AggregateFactory::MakeSumDistinctAggregateFunctionV2() {
     return std::make_shared<DistinctAggregateFunctionV2<PT, AggDistinctType::SUM>>();
+}
+
+template <PrimitiveType PT>
+AggregateFunctionPtr AggregateFactory::MakeDecimalSumDistinctAggregateFunction() {
+    return std::make_shared<DecimalDistinctAggregateFunction<PT, AggDistinctType::SUM>>();
 }
 
 AggregateFunctionPtr AggregateFactory::MakeDictMergeAggregateFunction() {
@@ -251,6 +265,14 @@ public:
                                create_array_function<arg_type, return_type, true>(name));
     }
 
+    template <PrimitiveType arg_type, PrimitiveType return_type>
+    void add_decimal_mapping(std::string&& name) {
+        _infos_mapping.emplace(std::make_tuple(name, arg_type, return_type, false),
+                               create_decimal_function<arg_type, return_type, false>(name));
+        _infos_mapping.emplace(std::make_tuple(name, arg_type, return_type, true),
+                               create_decimal_function<arg_type, return_type, true>(name));
+    }
+
     template <PrimitiveType arg_type, PrimitiveType return_type, bool is_null>
     AggregateFunctionPtr create_object_function(std::string& name) {
         if constexpr (is_null) {
@@ -330,6 +352,34 @@ public:
         return nullptr;
     }
 
+    template <PrimitiveType ArgPT, PrimitiveType ResultPT, bool is_null>
+    std::enable_if_t<isArithmeticPT<ArgPT>, AggregateFunctionPtr> create_decimal_function(std::string& name) {
+        static_assert(pt_is_decimal128<ResultPT>);
+        if constexpr (is_null) {
+            using ResultType = RunTimeCppType<ResultPT>;
+            if (name == "decimal_avg") {
+                auto avg = AggregateFactory::MakeDecimalAvgAggregateFunction<ArgPT>();
+                return AggregateFactory::MakeNullableAggregateFunctionUnary<AvgAggregateState<ResultType>>(avg);
+            } else if (name == "decimal_sum") {
+                auto sum = AggregateFactory::MakeDecimalSumAggregateFunction<ArgPT>();
+                return AggregateFactory::MakeNullableAggregateFunctionUnary<AvgAggregateState<ResultType>>(sum);
+            } else if (name == "decimal_multi_distinct_sum") {
+                auto distinct_sum = AggregateFactory::MakeDecimalSumDistinctAggregateFunction<ArgPT>();
+                return AggregateFactory::MakeNullableAggregateFunctionUnary<DistinctAggregateState<ArgPT, ResultPT>>(
+                        distinct_sum);
+            }
+        } else {
+            if (name == "decimal_avg") {
+                return AggregateFactory::MakeDecimalAvgAggregateFunction<ArgPT>();
+            } else if (name == "decimal_sum") {
+                return AggregateFactory::MakeDecimalSumAggregateFunction<ArgPT>();
+            } else if (name == "decimal_multi_distinct_sum") {
+                return AggregateFactory::MakeDecimalSumDistinctAggregateFunction<ArgPT>();
+            }
+        }
+        return nullptr;
+    }
+
     // TODO(kks): simplify create_function method
     template <PrimitiveType ArgPT, PrimitiveType ReturnPT, bool is_null>
     std::enable_if_t<isArithmeticPT<ArgPT>, AggregateFunctionPtr> create_function(std::string& name) {
@@ -376,16 +426,20 @@ public:
                 return AggregateFactory::MakeNullableAggregateFunctionUnary<AvgAggregateState<ResultType>>(avg);
             } else if (name == "multi_distinct_count") {
                 auto distinct = AggregateFactory::MakeCountDistinctAggregateFunction<ArgPT>();
-                return AggregateFactory::MakeNullableAggregateFunctionUnary<DistinctAggregateState<ArgPT>>(distinct);
+                return AggregateFactory::MakeNullableAggregateFunctionUnary<
+                        DistinctAggregateState<ArgPT, SumResultPT<ArgPT>>>(distinct);
             } else if (name == "multi_distinct_count2") {
                 auto distinct = AggregateFactory::MakeCountDistinctAggregateFunctionV2<ArgPT>();
-                return AggregateFactory::MakeNullableAggregateFunctionUnary<DistinctAggregateStateV2<ArgPT>>(distinct);
+                return AggregateFactory::MakeNullableAggregateFunctionUnary<
+                        DistinctAggregateStateV2<ArgPT, SumResultPT<ArgPT>>>(distinct);
             } else if (name == "multi_distinct_sum") {
                 auto distinct = AggregateFactory::MakeSumDistinctAggregateFunction<ArgPT>();
-                return AggregateFactory::MakeNullableAggregateFunctionUnary<DistinctAggregateState<ArgPT>>(distinct);
+                return AggregateFactory::MakeNullableAggregateFunctionUnary<
+                        DistinctAggregateState<ArgPT, SumResultPT<ArgPT>>>(distinct);
             } else if (name == "multi_distinct_sum2") {
                 auto distinct = AggregateFactory::MakeSumDistinctAggregateFunctionV2<ArgPT>();
-                return AggregateFactory::MakeNullableAggregateFunctionUnary<DistinctAggregateStateV2<ArgPT>>(distinct);
+                return AggregateFactory::MakeNullableAggregateFunctionUnary<
+                        DistinctAggregateStateV2<ArgPT, SumResultPT<ArgPT>>>(distinct);
             } else if (name == "group_concat") {
                 auto group_count = AggregateFactory::MakeGroupConcatAggregateFunction<ArgPT>();
                 return AggregateFactory::MakeNullableAggregateFunctionVariadic<GroupConcatAggregateState>(group_count);
@@ -467,10 +521,12 @@ public:
                 return AggregateFactory::MakeNullableAggregateFunctionUnary<MinAggregateData<ArgPT>>(min);
             } else if (name == "multi_distinct_count") {
                 auto distinct = AggregateFactory::MakeCountDistinctAggregateFunction<ArgPT>();
-                return AggregateFactory::MakeNullableAggregateFunctionUnary<DistinctAggregateState<ArgPT>>(distinct);
+                return AggregateFactory::MakeNullableAggregateFunctionUnary<
+                        DistinctAggregateState<ArgPT, SumResultPT<ArgPT>>>(distinct);
             } else if (name == "multi_distinct_count2") {
                 auto distinct = AggregateFactory::MakeCountDistinctAggregateFunctionV2<ArgPT>();
-                return AggregateFactory::MakeNullableAggregateFunctionUnary<DistinctAggregateStateV2<ArgPT>>(distinct);
+                return AggregateFactory::MakeNullableAggregateFunctionUnary<
+                        DistinctAggregateStateV2<ArgPT, SumResultPT<ArgPT>>>(distinct);
             } else if (name == "group_concat") {
                 auto group_count = AggregateFactory::MakeGroupConcatAggregateFunction<ArgPT>();
                 return AggregateFactory::MakeNullableAggregateFunctionVariadic<GroupConcatAggregateState>(group_count);
@@ -829,6 +885,17 @@ AggregateFuncResolver::AggregateFuncResolver() {
 
     add_array_mapping<TYPE_ARRAY, TYPE_VARCHAR>("dict_merge");
     add_array_mapping<TYPE_ARRAY, TYPE_ARRAY>("retention");
+
+    // sum, avg, distinct_sum use decimal128 as intermediate or result type to avoid overflow
+    add_decimal_mapping<TYPE_DECIMAL32, TYPE_DECIMAL128>("decimal_avg");
+    add_decimal_mapping<TYPE_DECIMAL64, TYPE_DECIMAL128>("decimal_avg");
+    add_decimal_mapping<TYPE_DECIMAL128, TYPE_DECIMAL128>("decimal_avg");
+    add_decimal_mapping<TYPE_DECIMAL32, TYPE_DECIMAL128>("decimal_sum");
+    add_decimal_mapping<TYPE_DECIMAL64, TYPE_DECIMAL128>("decimal_sum");
+    add_decimal_mapping<TYPE_DECIMAL128, TYPE_DECIMAL128>("decimal_sum");
+    add_decimal_mapping<TYPE_DECIMAL32, TYPE_DECIMAL128>("decimal_multi_distinct_sum");
+    add_decimal_mapping<TYPE_DECIMAL64, TYPE_DECIMAL128>("decimal_multi_distinct_sum");
+    add_decimal_mapping<TYPE_DECIMAL128, TYPE_DECIMAL128>("decimal_multi_distinct_sum");
 }
 
 #undef ADD_ALL_TYPE
@@ -844,6 +911,19 @@ const AggregateFunction* get_aggregate_function(const std::string& name, Primiti
             func_name = "multi_distinct_sum2";
         } else if (name == "multi_distinct_count") {
             func_name = "multi_distinct_count2";
+        }
+    }
+
+    auto is_decimal_type = [](PrimitiveType pt) {
+        return pt == TYPE_DECIMAL32 || pt == TYPE_DECIMAL64 || pt == TYPE_DECIMAL128;
+    };
+    if (agg_func_set_version > 2 && is_decimal_type(arg_type)) {
+        if (name == "sum") {
+            func_name = "decimal_sum";
+        } else if (name == "avg") {
+            func_name = "decimal_avg";
+        } else if (name == "multi_distinct_sum2") {
+            func_name = "decimal_multi_distinct_sum";
         }
     }
 

--- a/be/src/exprs/agg/aggregate_factory.cpp
+++ b/be/src/exprs/agg/aggregate_factory.cpp
@@ -922,7 +922,7 @@ const AggregateFunction* get_aggregate_function(const std::string& name, Primiti
             func_name = "decimal_sum";
         } else if (name == "avg") {
             func_name = "decimal_avg";
-        } else if (name == "multi_distinct_sum2") {
+        } else if (name == "multi_distinct_sum") {
             func_name = "decimal_multi_distinct_sum";
         }
     }

--- a/be/src/exprs/agg/aggregate_factory.h
+++ b/be/src/exprs/agg/aggregate_factory.h
@@ -15,6 +15,9 @@ public:
     static AggregateFunctionPtr MakeAvgAggregateFunction();
 
     template <PrimitiveType PT>
+    static AggregateFunctionPtr MakeDecimalAvgAggregateFunction();
+
+    template <PrimitiveType PT>
     static AggregateFunctionPtr MakeBitmapUnionIntAggregateFunction();
 
     static AggregateFunctionPtr MakeBitmapUnionAggregateFunction();
@@ -53,8 +56,11 @@ public:
     template <typename NestedState>
     static AggregateFunctionPtr MakeNullableAggregateFunctionVariadic(AggregateFunctionPtr nested_function);
 
-    template <PrimitiveType T>
+    template <PrimitiveType PT>
     static AggregateFunctionPtr MakeSumAggregateFunction();
+
+    template <PrimitiveType PT>
+    static AggregateFunctionPtr MakeDecimalSumAggregateFunction();
 
     template <PrimitiveType PT, bool is_sample>
     static AggregateFunctionPtr MakeVarianceAggregateFunction();
@@ -66,6 +72,8 @@ public:
     static AggregateFunctionPtr MakeSumDistinctAggregateFunction();
     template <PrimitiveType PT>
     static AggregateFunctionPtr MakeSumDistinctAggregateFunctionV2();
+    template <PrimitiveType PT>
+    static AggregateFunctionPtr MakeDecimalSumDistinctAggregateFunction();
 
     static AggregateFunctionPtr MakeDictMergeAggregateFunction();
     static AggregateFunctionPtr MakeRetentionAggregateFunction();

--- a/be/src/exprs/agg/avg.h
+++ b/be/src/exprs/agg/avg.h
@@ -257,5 +257,8 @@ public:
 
     std::string get_name() const override { return "avg"; }
 };
+template <PrimitiveType PT, typename = DecimalPTGuard<PT>>
+using DecimalAvgAggregateFunction =
+        AvgAggregateFunction<PT, RunTimeCppType<PT>, TYPE_DECIMAL128, RunTimeCppType<TYPE_DECIMAL128>>;
 
 } // namespace starrocks::vectorized

--- a/be/src/exprs/agg/sum.h
+++ b/be/src/exprs/agg/sum.h
@@ -120,4 +120,8 @@ public:
     std::string get_name() const override { return "sum"; }
 };
 
+template <PrimitiveType PT, typename = DecimalPTGuard<PT>>
+using DecimalSumAggregateFunction =
+        SumAggregateFunction<PT, RunTimeCppType<PT>, TYPE_DECIMAL128, RunTimeCppType<TYPE_DECIMAL128>>;
+
 } // namespace starrocks::vectorized

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -48,6 +48,7 @@ set(EXEC_FILES
         ./exec/parquet/group_reader_test.cpp
         ./exec/parquet/file_reader_test.cpp
         ./exprs/agg/json_each_test.cpp
+        ./exprs/agg/aggregate_test.cpp
         ./exprs/vectorized/arithmetic_expr_test.cpp
         ./exprs/vectorized/arithmetic_operation_test.cpp
         ./exprs/vectorized/array_element_expr_test.cpp

--- a/be/test/exprs/agg/aggregate_test.cpp
+++ b/be/test/exprs/agg/aggregate_test.cpp
@@ -56,6 +56,17 @@ ColumnPtr gen_input_column1() {
     return column;
 }
 
+template <PrimitiveType PT>
+ColumnPtr gen_input_decimal_column1(const FunctionContext::TypeDesc* type_desc) {
+    auto column = RunTimeColumnType<PT>::create(type_desc->precision, type_desc->scale);
+    for (int i = 0; i < 1024; i++) {
+        column->append(i);
+    }
+    column->append(100);
+    column->append(200);
+    return column;
+}
+
 template <typename T>
 ColumnPtr gen_input_column2() {
     using DataColumn = typename ColumnTraits<T>::ColumnType;
@@ -144,26 +155,42 @@ ColumnPtr gen_input_column2<DateValue>() {
     return column;
 }
 
+template <PrimitiveType PT>
+ColumnPtr gen_input_decimal_column2(const FunctionContext::TypeDesc* type_desc) {
+    auto column = RunTimeColumnType<PT>::create(type_desc->precision, type_desc->scale);
+    for (int i = 2000; i < 3000; i++) {
+        column->append(i);
+    }
+    return column;
+}
+
 template <typename T, typename TResult>
 void test_agg_function(FunctionContext* ctx, const AggregateFunction* func, TResult update_result1,
                        TResult update_result2, TResult merge_result) {
     using ResultColumn = typename ColumnTraits<TResult>::ColumnType;
+    auto mem_pool = std::make_unique<MemPool>();
     auto result_column = ResultColumn::create();
 
     // update input column 1
-    std::unique_ptr<ManagedAggregateState> state = ManagedAggregateState::Make(func);
-    ColumnPtr column = gen_input_column1<T>();
+    auto* aggr_state = mem_pool->allocate_aligned(func->size(), func->alignof_size());
+    ASSERT_TRUE(aggr_state != nullptr);
+    func->create(ctx, aggr_state);
+    ColumnPtr column;
+    column = gen_input_column1<T>();
     const Column* row_column = column.get();
-    func->update_batch_single_state(ctx, row_column->size(), &row_column, state->mutable_data());
-    func->finalize_to_column(ctx, state->data(), result_column.get());
+    func->update_batch_single_state(ctx, row_column->size(), &row_column, aggr_state);
+    func->finalize_to_column(ctx, aggr_state, result_column.get());
     ASSERT_EQ(update_result1, result_column->get_data()[0]);
 
     // update input column 2
-    std::unique_ptr<ManagedAggregateState> state2 = ManagedAggregateState::Make(func);
-    ColumnPtr column2 = gen_input_column2<T>();
+    auto* aggr_state2 = mem_pool->allocate_aligned(func->size(), func->alignof_size());
+    ASSERT_TRUE(aggr_state2 != nullptr);
+    func->create(ctx, aggr_state2);
+    ColumnPtr column2;
+    column2 = gen_input_column2<T>();
     row_column = column2.get();
-    func->update_batch_single_state(ctx, row_column->size(), &row_column, state2->mutable_data());
-    func->finalize_to_column(ctx, state2->data(), result_column.get());
+    func->update_batch_single_state(ctx, row_column->size(), &row_column, aggr_state2);
+    func->finalize_to_column(ctx, aggr_state2, result_column.get());
     ASSERT_EQ(update_result2, result_column->get_data()[1]);
 
     // merge column 1 and column 2
@@ -172,9 +199,51 @@ void test_agg_function(FunctionContext* ctx, const AggregateFunction* func, TRes
     if (func_name == "count" || func_name == "sum" || func_name == "maxmin") {
         serde_column = ResultColumn::create();
     }
-    func->serialize_to_column(ctx, state->data(), serde_column.get());
-    func->merge(ctx, serde_column.get(), state2->data(), 0);
-    func->finalize_to_column(ctx, state2->data(), result_column.get());
+
+    func->serialize_to_column(ctx, aggr_state, serde_column.get());
+    func->merge(ctx, serde_column.get(), aggr_state2, 0);
+    func->finalize_to_column(ctx, aggr_state2, result_column.get());
+    ASSERT_EQ(merge_result, result_column->get_data()[2]);
+}
+
+template <PrimitiveType PT, typename TResult = RunTimeCppType<TYPE_DECIMAL128>, typename = DecimalPTGuard<PT>>
+void test_decimal_agg_function(FunctionContext* ctx, const AggregateFunction* func, TResult update_result1,
+                               TResult update_result2, TResult merge_result) {
+    auto mem_pool = std::make_unique<MemPool>();
+    using ResultColumn = RunTimeColumnType<TYPE_DECIMAL128>;
+    const auto& result_type = ctx->get_return_type();
+    auto result_column = ResultColumn::create(result_type.precision, result_type.scale);
+
+    // update input column 1
+    auto* aggr_state = mem_pool->allocate_aligned(func->size(), func->alignof_size());
+    ASSERT_TRUE(aggr_state != nullptr);
+    func->create(ctx, aggr_state);
+    ColumnPtr column = gen_input_decimal_column1<PT>(ctx->get_arg_type(0));
+    const Column* row_column = column.get();
+    func->update_batch_single_state(ctx, row_column->size(), &row_column, aggr_state);
+    func->finalize_to_column(ctx, aggr_state, result_column.get());
+    ASSERT_EQ(update_result1, result_column->get_data()[0]);
+
+    // update input column 2
+    auto* aggr_state2 = mem_pool->allocate_aligned(func->size(), func->alignof_size());
+    ASSERT_TRUE(aggr_state2 != nullptr);
+    func->create(ctx, aggr_state2);
+    ColumnPtr column2 = gen_input_decimal_column2<PT>(ctx->get_arg_type(0));
+    row_column = column2.get();
+    func->update_batch_single_state(ctx, row_column->size(), &row_column, aggr_state2);
+    func->finalize_to_column(ctx, aggr_state2, result_column.get());
+    ASSERT_EQ(update_result2, result_column->get_data()[1]);
+
+    // merge column 1 and column 2
+    ColumnPtr serde_column = BinaryColumn::create();
+    std::string func_name = func->get_name();
+    if (func_name == "count" || func_name == "sum" || func_name == "decimal_sum" || func_name == "maxmin") {
+        serde_column = ResultColumn::create(result_type.precision, result_type.scale);
+    }
+
+    func->serialize_to_column(ctx, aggr_state, serde_column.get());
+    func->merge(ctx, serde_column.get(), aggr_state2, 0);
+    func->finalize_to_column(ctx, aggr_state2, result_column.get());
     ASSERT_EQ(merge_result, result_column->get_data()[2]);
 }
 
@@ -183,28 +252,33 @@ void test_agg_variance_function(FunctionContext* ctx, const AggregateFunction* f
                                 TResult update_result2, TResult merge_result) {
     using ResultColumn = typename ColumnTraits<TResult>::ColumnType;
     auto result_column = ResultColumn::create();
+    auto mem_pool = std::make_unique<MemPool>();
 
+    auto* state = mem_pool->allocate_aligned(func->size(), func->alignof_size());
+    ASSERT_TRUE(state != nullptr);
+    func->create(ctx, state);
     // update input column 1
-    std::unique_ptr<ManagedAggregateState> state = ManagedAggregateState::Make(func);
     ColumnPtr column = gen_input_column1<T>();
     const Column* row_column = column.get();
-    func->update_batch_single_state(ctx, row_column->size(), &row_column, state->mutable_data());
-    func->finalize_to_column(ctx, state->data(), result_column.get());
+    func->update_batch_single_state(ctx, row_column->size(), &row_column, state);
+    func->finalize_to_column(ctx, state, result_column.get());
     ASSERT_EQ(update_result1, result_column->get_data()[0]);
 
     // update input column 2
-    std::unique_ptr<ManagedAggregateState> state2 = ManagedAggregateState::Make(func);
+    auto* state2 = mem_pool->allocate_aligned(func->size(), func->alignof_size());
+    ASSERT_TRUE(state2 != nullptr);
+    func->create(ctx, state2);
     ColumnPtr column2 = gen_input_column2<T>();
     row_column = column2.get();
-    func->update_batch_single_state(ctx, row_column->size(), &row_column, state2->mutable_data());
-    func->finalize_to_column(ctx, state2->data(), result_column.get());
+    func->update_batch_single_state(ctx, row_column->size(), &row_column, state2);
+    func->finalize_to_column(ctx, state2, result_column.get());
     ASSERT_EQ(update_result2, result_column->get_data()[1]);
 
     // merge column 1 and column 2
     ColumnPtr serde_column = BinaryColumn::create();
-    func->serialize_to_column(ctx, state->data(), serde_column.get());
-    func->merge(ctx, serde_column.get(), state2->data(), 0);
-    func->finalize_to_column(ctx, state2->data(), result_column.get());
+    func->serialize_to_column(ctx, state, serde_column.get());
+    func->merge(ctx, serde_column.get(), state2, 0);
+    func->finalize_to_column(ctx, state2, result_column.get());
     ASSERT_TRUE(abs(merge_result - result_column->get_data()[2]) < 1e-8);
 }
 
@@ -246,6 +320,36 @@ TEST_F(AggregateTest, test_sum) {
                                                       DecimalV2Value{24});
 }
 
+TEST_F(AggregateTest, test_decimal_sum) {
+    {
+        const auto* func = get_aggregate_function("decimal_sum", TYPE_DECIMAL32, TYPE_DECIMAL128, false,
+                                                  TFunctionBinaryType::BUILTIN, 3);
+        auto* ctx = FunctionContext::create_test_context(
+                {FunctionContext::TypeDesc{.type = TYPE_DECIMAL32, .precision = 9, .scale = 9}},
+                FunctionContext::TypeDesc{.type = TYPE_DECIMAL128, .precision = 38, .scale = 9});
+        std::unique_ptr<FunctionContext> gc_ctx(ctx);
+        test_decimal_agg_function<TYPE_DECIMAL32>(ctx, func, 524076, 2499500, 3023576);
+    }
+    {
+        const auto* func = get_aggregate_function("decimal_sum", TYPE_DECIMAL64, TYPE_DECIMAL128, false,
+                                                  TFunctionBinaryType::BUILTIN, 3);
+        auto* ctx = FunctionContext::create_test_context(
+                {FunctionContext::TypeDesc{.type = TYPE_DECIMAL64, .precision = 9, .scale = 3}},
+                FunctionContext::TypeDesc{.type = TYPE_DECIMAL128, .precision = 38, .scale = 3});
+        std::unique_ptr<FunctionContext> gc_ctx(ctx);
+        test_decimal_agg_function<TYPE_DECIMAL64>(ctx, func, 524076, 2499500, 3023576);
+    }
+    {
+        const auto* func = get_aggregate_function("decimal_sum", TYPE_DECIMAL128, TYPE_DECIMAL128, false,
+                                                  TFunctionBinaryType::BUILTIN, 3);
+        auto* ctx = FunctionContext::create_test_context(
+                {FunctionContext::TypeDesc{.type = TYPE_DECIMAL128, .precision = 38, .scale = 15}},
+                FunctionContext::TypeDesc{.type = TYPE_DECIMAL128, .precision = 38, .scale = 15});
+        std::unique_ptr<FunctionContext> gc_ctx(ctx);
+        test_decimal_agg_function<TYPE_DECIMAL128>(ctx, func, 524076, 2499500, 3023576);
+    }
+}
+
 TEST_F(AggregateTest, test_avg) {
     const AggregateFunction* func = get_aggregate_function("avg", TYPE_SMALLINT, TYPE_DOUBLE, false);
     test_agg_function<int16_t, double>(ctx, func, 524076 / 1026.0, 2499500 / 1000.0, 3023576 / 2026.0);
@@ -276,6 +380,45 @@ TEST_F(AggregateTest, test_avg) {
 
     func = get_aggregate_function("avg", TYPE_DATE, TYPE_DATE, false);
     test_agg_function<DateValue, DateValue>(ctx, func, DateValue{2454716}, DateValue{2106058}, DateValue{2280387});
+}
+
+TEST_F(AggregateTest, test_decimal_avg) {
+    {
+        const auto* func = get_aggregate_function("decimal_avg", TYPE_DECIMAL32, TYPE_DECIMAL128, false,
+                                                  TFunctionBinaryType::BUILTIN, 3);
+        auto* ctx = FunctionContext::create_test_context(
+                {FunctionContext::TypeDesc{.type = TYPE_DECIMAL32, .precision = 9, .scale = 9}},
+                FunctionContext::TypeDesc{.type = TYPE_DECIMAL128, .precision = 38, .scale = 12});
+        std::unique_ptr<FunctionContext> gc_ctx(ctx);
+        auto update_result1 = decimal_div_integer<int128_t>(524076, 1026, 9);
+        auto update_result2 = decimal_div_integer<int128_t>(2499500, 1000, 9);
+        auto merge_result = decimal_div_integer<int128_t>(3023576, 2026, 9);
+        test_decimal_agg_function<TYPE_DECIMAL32>(ctx, func, update_result1, update_result2, merge_result);
+    }
+    {
+        const auto* func = get_aggregate_function("decimal_avg", TYPE_DECIMAL64, TYPE_DECIMAL128, false,
+                                                  TFunctionBinaryType::BUILTIN, 3);
+        auto* ctx = FunctionContext::create_test_context(
+                {FunctionContext::TypeDesc{.type = TYPE_DECIMAL64, .precision = 9, .scale = 3}},
+                FunctionContext::TypeDesc{.type = TYPE_DECIMAL128, .precision = 38, .scale = 9});
+        std::unique_ptr<FunctionContext> gc_ctx(ctx);
+        auto update_result1 = decimal_div_integer<int128_t>(524076, 1026, 3);
+        auto update_result2 = decimal_div_integer<int128_t>(2499500, 1000, 3);
+        auto merge_result = decimal_div_integer<int128_t>(3023576, 2026, 3);
+        test_decimal_agg_function<TYPE_DECIMAL64>(ctx, func, update_result1, update_result2, merge_result);
+    }
+    {
+        const auto* func = get_aggregate_function("decimal_avg", TYPE_DECIMAL128, TYPE_DECIMAL128, false,
+                                                  TFunctionBinaryType::BUILTIN, 3);
+        auto* ctx = FunctionContext::create_test_context(
+                {FunctionContext::TypeDesc{.type = TYPE_DECIMAL128, .precision = 38, .scale = 15}},
+                FunctionContext::TypeDesc{.type = TYPE_DECIMAL128, .precision = 38, .scale = 15});
+        std::unique_ptr<FunctionContext> gc_ctx(ctx);
+        auto update_result1 = decimal_div_integer<int128_t>(524076, 1026, 15);
+        auto update_result2 = decimal_div_integer<int128_t>(2499500, 1000, 15);
+        auto merge_result = decimal_div_integer<int128_t>(3023576, 2026, 15);
+        test_decimal_agg_function<TYPE_DECIMAL128>(ctx, func, update_result1, update_result2, merge_result);
+    }
 }
 
 TEST_F(AggregateTest, test_variance) {
@@ -630,6 +773,36 @@ TEST_F(AggregateTest, test_sum_distinct) {
                                                       DecimalV2Value(21));
 }
 
+TEST_F(AggregateTest, test_decimal_multi_distinct_sum) {
+    {
+        const auto* func = get_aggregate_function("decimal_multi_distinct_sum", TYPE_DECIMAL32, TYPE_DECIMAL128, false,
+                                                  TFunctionBinaryType::BUILTIN, 3);
+        auto* ctx = FunctionContext::create_test_context(
+                {FunctionContext::TypeDesc{.type = TYPE_DECIMAL32, .precision = 9, .scale = 9}},
+                FunctionContext::TypeDesc{.type = TYPE_DECIMAL128, .precision = 38, .scale = 9});
+        std::unique_ptr<FunctionContext> gc_ctx(ctx);
+        test_decimal_agg_function<TYPE_DECIMAL32>(ctx, func, 523776, 2499500, 3023276);
+    }
+    {
+        const auto* func = get_aggregate_function("decimal_multi_distinct_sum", TYPE_DECIMAL64, TYPE_DECIMAL128, false,
+                                                  TFunctionBinaryType::BUILTIN, 3);
+        auto* ctx = FunctionContext::create_test_context(
+                {FunctionContext::TypeDesc{.type = TYPE_DECIMAL64, .precision = 9, .scale = 3}},
+                FunctionContext::TypeDesc{.type = TYPE_DECIMAL128, .precision = 38, .scale = 3});
+        std::unique_ptr<FunctionContext> gc_ctx(ctx);
+        test_decimal_agg_function<TYPE_DECIMAL64>(ctx, func, 523776, 2499500, 3023276);
+    }
+    {
+        const auto* func = get_aggregate_function("decimal_multi_distinct_sum", TYPE_DECIMAL128, TYPE_DECIMAL128, false,
+                                                  TFunctionBinaryType::BUILTIN, 3);
+        auto* ctx = FunctionContext::create_test_context(
+                {FunctionContext::TypeDesc{.type = TYPE_DECIMAL128, .precision = 38, .scale = 15}},
+                FunctionContext::TypeDesc{.type = TYPE_DECIMAL128, .precision = 38, .scale = 15});
+        std::unique_ptr<FunctionContext> gc_ctx(ctx);
+        test_decimal_agg_function<TYPE_DECIMAL128>(ctx, func, 523776, 2499500, 3023276);
+    }
+}
+
 TEST_F(AggregateTest, test_dict_merge) {
     const AggregateFunction* func = get_aggregate_function("dict_merge", TYPE_ARRAY, TYPE_VARCHAR, false);
     ColumnBuilder<TYPE_VARCHAR> builder(config::vector_chunk_size);
@@ -650,11 +823,13 @@ TEST_F(AggregateTest, test_dict_merge) {
     // [sr-1, sr-2, sr-3]
     auto col = ArrayColumn::create(data_col, offsets);
     const Column* column = col.get();
-    std::unique_ptr<ManagedAggregateState> state = ManagedAggregateState::Make(func);
-    func->update_batch_single_state(ctx, col->size(), &column, state->mutable_data());
+    auto mem_pool = std::make_unique<MemPool>();
+    auto* state = mem_pool->allocate_aligned(func->size(), func->alignof_size());
+    func->create(ctx, state);
+    func->update_batch_single_state(ctx, col->size(), &column, state);
 
     auto res = BinaryColumn::create();
-    func->finalize_to_column(ctx, state->data(), res.get());
+    func->finalize_to_column(ctx, state, res.get());
 
     ASSERT_EQ(res->size(), 1);
     auto slice = res->get_slice(0);
@@ -685,7 +860,9 @@ TEST_F(AggregateTest, test_dict_merge) {
 TEST_F(AggregateTest, test_sum_nullable) {
     using NullableSumInt64 = NullableAggregateFunctionState<SumAggregateState<int64_t>>;
     const AggregateFunction* sum_null = get_aggregate_function("sum", TYPE_INT, TYPE_BIGINT, true);
-    std::unique_ptr<ManagedAggregateState> state = ManagedAggregateState::Make(sum_null);
+    auto mem_pool = std::make_unique<MemPool>();
+    auto* state = mem_pool->allocate_aligned(sum_null->size(), sum_null->alignof_size());
+    sum_null->create(ctx, state);
 
     auto data_column = Int32Column::create();
     auto null_column = NullColumn::create();
@@ -698,17 +875,18 @@ TEST_F(AggregateTest, test_sum_nullable) {
     const Column* row_column = column.get();
 
     // test update
-    sum_null->update_batch_single_state(ctx, column->size(), &row_column, state->mutable_data());
-    auto* null_state = (NullableSumInt64*)state->mutable_data();
+    sum_null->update_batch_single_state(ctx, column->size(), &row_column, state);
+    auto* null_state = (NullableSumInt64*)state;
     int64_t result = *reinterpret_cast<const int64_t*>(null_state->nested_state());
     ASSERT_EQ(2450, result);
 
     // test serialize
     auto serde_column2 = NullableColumn::create(Int64Column::create(), NullColumn::create());
-    sum_null->serialize_to_column(ctx, state->data(), serde_column2.get());
+    sum_null->serialize_to_column(ctx, state, serde_column2.get());
 
     // test merge
-    std::unique_ptr<ManagedAggregateState> state2 = ManagedAggregateState::Make(sum_null);
+    auto* state2 = mem_pool->allocate_aligned(sum_null->size(), sum_null->alignof_size());
+    sum_null->create(ctx, state2);
 
     auto data_column2 = Int32Column::create();
     auto null_column2 = NullColumn::create();
@@ -719,12 +897,12 @@ TEST_F(AggregateTest, test_sum_nullable) {
     auto column2 = NullableColumn::create(std::move(data_column2), std::move(null_column2));
     const Column* row_column2 = column2.get();
 
-    sum_null->update_batch_single_state(ctx, column2->size(), &row_column2, state2->mutable_data());
+    sum_null->update_batch_single_state(ctx, column2->size(), &row_column2, state2);
 
-    sum_null->merge(ctx, serde_column2.get(), state2->mutable_data(), 0);
+    sum_null->merge(ctx, serde_column2.get(), state2, 0);
 
     auto result_column = NullableColumn::create(Int64Column::create(), NullColumn::create());
-    sum_null->finalize_to_column(ctx, state2->data(), result_column.get());
+    sum_null->finalize_to_column(ctx, state2, result_column.get());
 
     const Column& result_data_column = result_column->data_column_ref();
     const auto& result_data = static_cast<const Int64Column&>(result_data_column);
@@ -733,7 +911,9 @@ TEST_F(AggregateTest, test_sum_nullable) {
 
 TEST_F(AggregateTest, test_count_nullable) {
     const AggregateFunction* func = get_aggregate_function("count", TYPE_BIGINT, TYPE_BIGINT, true);
-    std::unique_ptr<ManagedAggregateState> state = ManagedAggregateState::Make(func);
+    auto mem_pool = std::make_unique<MemPool>();
+    auto* state = mem_pool->allocate_aligned(func->size(), func->alignof_size());
+    func->create(ctx, state);
 
     auto data_column = Int32Column::create();
     auto null_column = NullColumn::create();
@@ -746,15 +926,17 @@ TEST_F(AggregateTest, test_count_nullable) {
     auto column = NullableColumn::create(std::move(data_column), std::move(null_column));
 
     const Column* row_column = column.get();
-    func->update_batch_single_state(ctx, column->size(), &row_column, state->mutable_data());
+    func->update_batch_single_state(ctx, column->size(), &row_column, state);
 
-    int64_t result = *reinterpret_cast<int64_t*>(state->mutable_data());
+    int64_t result = *reinterpret_cast<int64_t*>(state);
     ASSERT_EQ(512, result);
 }
 
 TEST_F(AggregateTest, test_bitmap_nullable) {
     const AggregateFunction* bitmap_null = get_aggregate_function("bitmap_union_int", TYPE_INT, TYPE_BIGINT, true);
-    std::unique_ptr<ManagedAggregateState> state = ManagedAggregateState::Make(bitmap_null);
+    auto mem_pool = std::make_unique<MemPool>();
+    auto* state = mem_pool->allocate_aligned(bitmap_null->size(), bitmap_null->alignof_size());
+    bitmap_null->create(ctx, state);
 
     auto data_column = Int32Column::create();
     auto null_column = NullColumn::create();
@@ -768,10 +950,10 @@ TEST_F(AggregateTest, test_bitmap_nullable) {
     const Column* row_column = column.get();
 
     // test update
-    bitmap_null->update_batch_single_state(ctx, column->size(), &row_column, state->mutable_data());
+    bitmap_null->update_batch_single_state(ctx, column->size(), &row_column, state);
 
     auto result_column = NullableColumn::create(Int64Column::create(), NullColumn::create());
-    bitmap_null->finalize_to_column(ctx, state->data(), result_column.get());
+    bitmap_null->finalize_to_column(ctx, state, result_column.get());
 
     const Column& result_data_column = result_column->data_column_ref();
     const auto& result_data = static_cast<const Int64Column&>(result_data_column);
@@ -782,7 +964,9 @@ TEST_F(AggregateTest, test_bitmap_nullable) {
 TEST_F(AggregateTest, test_group_concat) {
     const AggregateFunction* group_concat_function =
             get_aggregate_function("group_concat", TYPE_VARCHAR, TYPE_VARCHAR, false);
-    std::unique_ptr<ManagedAggregateState> state = ManagedAggregateState::Make(group_concat_function);
+    auto mem_pool = std::make_unique<MemPool>();
+    auto* state = mem_pool->allocate_aligned(group_concat_function->size(), group_concat_function->alignof_size());
+    group_concat_function->create(ctx, state);
 
     auto data_column = BinaryColumn::create();
 
@@ -795,10 +979,10 @@ TEST_F(AggregateTest, test_group_concat) {
     const Column* row_column = data_column.get();
 
     // test update
-    group_concat_function->update_batch_single_state(ctx, data_column->size(), &row_column, state->mutable_data());
+    group_concat_function->update_batch_single_state(ctx, data_column->size(), &row_column, state);
 
     auto result_column = BinaryColumn::create();
-    group_concat_function->finalize_to_column(ctx, state->data(), result_column.get());
+    group_concat_function->finalize_to_column(ctx, state, result_column.get());
 
     ASSERT_EQ("starrocks0, starrocks1, starrocks2, starrocks3, starrocks4, starrocks5", result_column->get_data()[0]);
 }
@@ -808,11 +992,14 @@ TEST_F(AggregateTest, test_group_concat_const_seperator) {
             AnyValUtil::column_type_to_type_desc(TypeDescriptor::from_primtive_type(TYPE_VARCHAR)),
             AnyValUtil::column_type_to_type_desc(TypeDescriptor::from_primtive_type(TYPE_VARCHAR))};
 
-    std::unique_ptr<FunctionContext> local_ctx(FunctionContext::create_test_context(std::move(arg_types)));
+    auto return_type = AnyValUtil::column_type_to_type_desc(TypeDescriptor::from_primtive_type(TYPE_VARCHAR));
+    std::unique_ptr<FunctionContext> local_ctx(FunctionContext::create_test_context(std::move(arg_types), return_type));
 
     const AggregateFunction* group_concat_function =
             get_aggregate_function("group_concat", TYPE_VARCHAR, TYPE_VARCHAR, false);
-    std::unique_ptr<ManagedAggregateState> state = ManagedAggregateState::Make(group_concat_function);
+    auto mem_pool = std::make_unique<MemPool>();
+    auto* state = mem_pool->allocate_aligned(group_concat_function->size(), group_concat_function->alignof_size());
+    group_concat_function->create(ctx, state);
 
     auto data_column = BinaryColumn::create();
 
@@ -839,11 +1026,10 @@ TEST_F(AggregateTest, test_group_concat_const_seperator) {
     local_ctx->impl()->set_constant_columns(const_columns);
 
     // test update
-    group_concat_function->update_batch_single_state(local_ctx.get(), data_column->size(), raw_columns.data(),
-                                                     state->mutable_data());
+    group_concat_function->update_batch_single_state(local_ctx.get(), data_column->size(), raw_columns.data(), state);
 
     auto result_column = BinaryColumn::create();
-    group_concat_function->finalize_to_column(local_ctx.get(), state->data(), result_column.get());
+    group_concat_function->finalize_to_column(local_ctx.get(), state, result_column.get());
 
     ASSERT_EQ("abcbcdcdedefefgfghghihijijk", result_column->get_data()[0]);
 }
@@ -851,7 +1037,9 @@ TEST_F(AggregateTest, test_group_concat_const_seperator) {
 TEST_F(AggregateTest, test_intersect_count) {
     const AggregateFunction* group_concat_function =
             get_aggregate_function("intersect_count", TYPE_INT, TYPE_BIGINT, false);
-    std::unique_ptr<ManagedAggregateState> state = ManagedAggregateState::Make(group_concat_function);
+    auto mem_pool = std::make_unique<MemPool>();
+    auto* state = mem_pool->allocate_aligned(group_concat_function->size(), group_concat_function->alignof_size());
+    group_concat_function->create(ctx, state);
 
     auto data_column = BitmapColumn::create();
     auto int_column = Int32Column::create();
@@ -895,11 +1083,10 @@ TEST_F(AggregateTest, test_intersect_count) {
     ctx->impl()->set_constant_columns(const_columns);
 
     // test update
-    group_concat_function->update_batch_single_state(ctx, data_column->size(), raw_columns.data(),
-                                                     state->mutable_data());
+    group_concat_function->update_batch_single_state(ctx, data_column->size(), raw_columns.data(), state);
 
     auto result_column = Int64Column::create();
-    group_concat_function->finalize_to_column(ctx, state->data(), result_column.get());
+    group_concat_function->finalize_to_column(ctx, state, result_column.get());
 
     ASSERT_EQ(1, result_column->get_data()[0]);
 }
@@ -907,7 +1094,9 @@ TEST_F(AggregateTest, test_intersect_count) {
 TEST_F(AggregateTest, test_bitmap_intersect) {
     const AggregateFunction* group_concat_function =
             get_aggregate_function("bitmap_intersect", TYPE_OBJECT, TYPE_OBJECT, false);
-    std::unique_ptr<ManagedAggregateState> state = ManagedAggregateState::Make(group_concat_function);
+    auto mem_pool = std::make_unique<MemPool>();
+    auto* state = mem_pool->allocate_aligned(group_concat_function->size(), group_concat_function->alignof_size());
+    group_concat_function->create(ctx, state);
 
     auto data_column = BitmapColumn::create();
 
@@ -928,10 +1117,10 @@ TEST_F(AggregateTest, test_bitmap_intersect) {
     const Column* row_column = data_column.get();
 
     // test update
-    group_concat_function->update_batch_single_state(ctx, data_column->size(), &row_column, state->mutable_data());
+    group_concat_function->update_batch_single_state(ctx, data_column->size(), &row_column, state);
 
     auto result_column = BitmapColumn::create();
-    group_concat_function->finalize_to_column(ctx, state->data(), result_column.get());
+    group_concat_function->finalize_to_column(ctx, state, result_column.get());
 
     ASSERT_EQ("1", result_column->get_pool()[0].to_string());
 }
@@ -939,7 +1128,9 @@ TEST_F(AggregateTest, test_bitmap_intersect) {
 TEST_F(AggregateTest, test_bitmap_intersect_nullable) {
     const AggregateFunction* group_concat_function =
             get_aggregate_function("bitmap_intersect", TYPE_OBJECT, TYPE_OBJECT, true);
-    std::unique_ptr<ManagedAggregateState> state = ManagedAggregateState::Make(group_concat_function);
+    auto mem_pool = std::make_unique<MemPool>();
+    auto* state = mem_pool->allocate_aligned(group_concat_function->size(), group_concat_function->alignof_size());
+    group_concat_function->create(ctx, state);
 
     auto data_column = BitmapColumn::create();
     auto null_column = NullColumn::create();
@@ -965,10 +1156,10 @@ TEST_F(AggregateTest, test_bitmap_intersect_nullable) {
     const Column* row_column = column.get();
 
     // test update
-    group_concat_function->update_batch_single_state(ctx, column->size(), &row_column, state->mutable_data());
+    group_concat_function->update_batch_single_state(ctx, column->size(), &row_column, state);
 
     auto result_column = NullableColumn::create(BitmapColumn::create(), NullColumn::create());
-    group_concat_function->finalize_to_column(ctx, state->data(), result_column.get());
+    group_concat_function->finalize_to_column(ctx, state, result_column.get());
 
     const Column& result_data_column = result_column->data_column_ref();
     const auto& result_data = static_cast<const BitmapColumn&>(result_data_column);
@@ -980,34 +1171,36 @@ template <typename T, typename TResult>
 void test_non_deterministic_agg_function(FunctionContext* ctx, const AggregateFunction* func) {
     using ResultColumn = typename ColumnTraits<TResult>::ColumnType;
     using ExpeactedResultColumnType = typename ColumnTraits<T>::ColumnType;
-
+    auto mem_pool = std::make_unique<MemPool>();
     // update input column 1
     auto result_column1 = ResultColumn::create();
-    std::unique_ptr<ManagedAggregateState> state = ManagedAggregateState::Make(func);
+    auto* state = mem_pool->allocate_aligned(func->size(), func->alignof_size());
+    func->create(ctx, state);
     ColumnPtr column = gen_input_column1<T>();
     const Column* row_column = column.get();
-    func->update_batch_single_state(ctx, row_column->size(), &row_column, state->mutable_data());
-    func->finalize_to_column(ctx, state->data(), result_column1.get());
+    func->update_batch_single_state(ctx, row_column->size(), &row_column, state);
+    func->finalize_to_column(ctx, state, result_column1.get());
 
     auto expected_column1 = down_cast<const ExpeactedResultColumnType&>(row_column[0]);
     ASSERT_EQ(expected_column1.get_data()[0], result_column1->get_data()[0]);
 
     // update input column 2
     auto result_column2 = ResultColumn::create();
-    std::unique_ptr<ManagedAggregateState> state2 = ManagedAggregateState::Make(func);
+    auto* state2 = mem_pool->allocate_aligned(func->size(), func->alignof_size());
+    func->create(ctx, state2);
     ColumnPtr column2 = gen_input_column2<T>();
     row_column = column2.get();
-    func->update_batch_single_state(ctx, row_column->size(), &row_column, state2->mutable_data());
-    func->finalize_to_column(ctx, state2->data(), result_column2.get());
+    func->update_batch_single_state(ctx, row_column->size(), &row_column, state2);
+    func->finalize_to_column(ctx, state2, result_column2.get());
 
     auto expected_column2 = down_cast<const ExpeactedResultColumnType&>(row_column[0]);
     ASSERT_EQ(expected_column2.get_data()[0], result_column2->get_data()[0]);
 
     // merge column 1 and column 2
     auto final_result_column = ResultColumn::create();
-    func->serialize_to_column(ctx, state->data(), final_result_column.get());
-    func->merge(ctx, final_result_column.get(), state2->data(), 0);
-    func->finalize_to_column(ctx, state2->data(), final_result_column.get());
+    func->serialize_to_column(ctx, state, final_result_column.get());
+    func->merge(ctx, final_result_column.get(), state2, 0);
+    func->finalize_to_column(ctx, state2, final_result_column.get());
 
     ASSERT_EQ(final_result_column->get_data()[0], result_column1->get_data()[0]);
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -151,8 +151,8 @@ public class FunctionSet {
                     .put(Type.DOUBLE, Type.DOUBLE)
                     .put(Type.LARGEINT, Type.LARGEINT)
                     .put(Type.DECIMALV2, Type.DECIMALV2)
-                    .put(Type.DECIMAL32, Type.DECIMAL64)
-                    .put(Type.DECIMAL64, Type.DECIMAL64)
+                    .put(Type.DECIMAL32, Type.DECIMAL128)
+                    .put(Type.DECIMAL64, Type.DECIMAL128)
                     .put(Type.DECIMAL128, Type.DECIMAL128)
                     .build();
 
@@ -542,11 +542,11 @@ public class FunctionSet {
             addBuiltin(AggregateFunction.createBuiltin(name,
                     Lists.newArrayList(Type.INT), Type.BIGINT, Type.BIGINT, false, true, false));
             addBuiltin(AggregateFunction.createBuiltin(name,
-                    Lists.newArrayList(Type.DECIMAL32), Type.DECIMAL64, Type.DECIMAL64, false, true, false));
+                    Lists.newArrayList(Type.DECIMAL32), Type.DECIMAL128, Type.DECIMAL128, false, true, false));
             addBuiltin(AggregateFunction.createBuiltin(name,
                     Lists.newArrayList(Type.BIGINT), Type.BIGINT, Type.BIGINT, false, true, false));
             addBuiltin(AggregateFunction.createBuiltin(name,
-                    Lists.newArrayList(Type.DECIMAL64), Type.DECIMAL64, Type.DECIMAL64, false, true, false));
+                    Lists.newArrayList(Type.DECIMAL64), Type.DECIMAL128, Type.DECIMAL128, false, true, false));
             addBuiltin(AggregateFunction.createBuiltin(name,
                     Lists.newArrayList(Type.FLOAT), Type.DOUBLE, Type.DOUBLE, false, true, false));
             addBuiltin(AggregateFunction.createBuiltin(name,
@@ -558,6 +558,8 @@ public class FunctionSet {
             addBuiltin(AggregateFunction.createBuiltin(name,
                     Lists.newArrayList(Type.DECIMAL128), Type.DECIMAL128, Type.DECIMAL128, false, true, false));
         }
+
+
 
         // HLL_UNION_AGG
         addBuiltin(AggregateFunction.createBuiltin("hll_union_agg",
@@ -619,13 +621,13 @@ public class FunctionSet {
                 Lists.newArrayList(Type.INT), Type.DOUBLE, Type.VARCHAR,
                 false, true, false));
         addBuiltin(AggregateFunction.createBuiltin("avg",
-                Lists.newArrayList(Type.DECIMAL32), Type.DECIMAL64, Type.VARCHAR,
+                Lists.newArrayList(Type.DECIMAL32), Type.DECIMAL128, Type.VARCHAR,
                 false, true, false));
         addBuiltin(AggregateFunction.createBuiltin("avg",
                 Lists.newArrayList(Type.BIGINT), Type.DOUBLE, Type.VARCHAR,
                 false, true, false));
         addBuiltin(AggregateFunction.createBuiltin("avg",
-                Lists.newArrayList(Type.DECIMAL64), Type.DECIMAL64, Type.VARCHAR,
+                Lists.newArrayList(Type.DECIMAL64), Type.DECIMAL128, Type.VARCHAR,
                 false, true, false));
         addBuiltin(AggregateFunction.createBuiltin("avg",
                 Lists.newArrayList(Type.FLOAT), Type.DOUBLE, Type.VARCHAR,

--- a/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
@@ -282,7 +282,7 @@ public class AggregationNode extends PlanNode {
         } else {
             msg.agg_node.setStreaming_preaggregation_mode(TStreamingPreaggregationMode.AUTO);
         }
-        msg.agg_node.setAgg_func_set_version(2);
+        msg.agg_node.setAgg_func_set_version(3);
     }
 
     protected String getDisplayLabelDetail() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DecimalV3FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DecimalV3FunctionAnalyzer.java
@@ -72,14 +72,11 @@ public class DecimalV3FunctionAnalyzer {
                 return ScalarType.INVALID;
             }
             ScalarType argScalarType = (ScalarType) argType;
-            // use a wider type to prevent accumulation from overflowing
-            PrimitiveType widerPrimitiveType = PrimitiveType.getWiderDecimalV3Type(
-                    PrimitiveType.DECIMAL64, argScalarType.getPrimitiveType());
-            int precision = PrimitiveType.getMaxPrecisionOfDecimal(widerPrimitiveType);
+            int precision = PrimitiveType.getMaxPrecisionOfDecimal(PrimitiveType.DECIMAL128);
             int scale = argScalarType.getScalarScale();
             // TODO(by satanson): Maybe accumulating narrower decimal types to wider decimal types directly w/o
             //  casting the narrower type to the wider type is sound and efficient.
-            return ScalarType.createDecimalV3Type(widerPrimitiveType, precision, scale);
+            return ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, precision, scale);
         }
 
         if (FunctionSet.TRUNCATE_DECIMAL.equalsIgnoreCase(fnName)) {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithDecimalTypesTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithDecimalTypesTest.java
@@ -219,8 +219,8 @@ public class SelectStmtWithDecimalTypesTest {
         ).toArray(new Type[0]);
 
         Type[] expectReturnTypes = Arrays.asList(
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 4),
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 10),
+                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 4),
+                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 10),
                 ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 30)
         ).toArray(new Type[0]);
         Assert.assertTrue(items.size() == 9);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeDecimalV3Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeDecimalV3Test.java
@@ -235,8 +235,8 @@ public class AnalyzeDecimalV3Test {
         ).toArray(new Type[0]);
 
         Type[] expectReturnTypes = Arrays.asList(
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 4),
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 10),
+                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 4),
+                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 10),
                 ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 30)
         ).toArray(new Type[0]);
         Assert.assertTrue(items.size() == 9);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
-
when aggregation function sum is applied to billions of rows of decimal64 or decimal32  values, the result would overflows, so use decimal128 instead of decimal64 for sum.