### PR TITLE
Support loading parquet file in parallel by splitting row group

### DIFF
--- a/be/src/exec/parquet_reader.h
+++ b/be/src/exec/parquet_reader.h
@@ -72,8 +72,10 @@ private:
 // Reader of broker parquet file
 class ParquetReaderWrap {
 public:
-    ParquetReaderWrap(FileReader* file_reader, int32_t num_of_columns_from_file);
-    ParquetReaderWrap(std::shared_ptr<arrow::io::RandomAccessFile>&& parquet_file, int32_t num_of_columns_from_file);
+    ParquetReaderWrap(FileReader* file_reader, int32_t num_of_columns_from_file, int64_t read_offset,
+                      int64_t read_size);
+    ParquetReaderWrap(std::shared_ptr<arrow::io::RandomAccessFile>&& parquet_file, int32_t num_of_columns_from_file,
+                      int64_t read_offset, int64_t read_size);
     virtual ~ParquetReaderWrap();
 
     void close();
@@ -85,6 +87,7 @@ public:
 private:
     Status column_indices(const std::vector<SlotDescriptor*>& tuple_slot_descs);
     Status handle_timestamp(const std::shared_ptr<arrow::TimestampArray>& ts_array, uint8_t* buf, int32_t* wbtyes);
+    Status next_selected_row_group();
 
     const int32_t _num_of_columns_from_file;
     parquet::ReaderProperties _properties;
@@ -105,6 +108,9 @@ private:
     int _rows_of_group; // rows in a group.
     int _current_line_of_group;
     int _current_line_of_batch;
+
+    int64_t _read_offset;
+    int64_t _read_size;
 
     std::string _timezone;
 };

--- a/be/src/exec/vectorized/file_scanner.cpp
+++ b/be/src/exec/vectorized/file_scanner.cpp
@@ -286,9 +286,6 @@ Status FileScanner::create_random_access_file(const TBrokerRangeDesc& range_desc
     case TFileType::FILE_BROKER: {
         EnvBroker env_broker(address, params.properties);
         ASSIGN_OR_RETURN(auto broker_file, env_broker.new_random_access_file(range_desc.path));
-        if (range_desc.start_offset != 0) {
-            return Status::NotSupported("non-zero start offset");
-        }
         src_file = std::shared_ptr<RandomAccessFile>(std::move(broker_file));
         break;
     }

--- a/be/src/exec/vectorized/parquet_scanner.cpp
+++ b/be/src/exec/vectorized/parquet_scanner.cpp
@@ -352,7 +352,8 @@ Status ParquetScanner::open_next_reader() {
         }
         _conv_ctx.current_file = file->filename();
         auto parquet_file = std::make_shared<ParquetChunkFile>(file, 0);
-        auto parquet_reader = std::make_shared<ParquetReaderWrap>(std::move(parquet_file), _num_of_columns_from_file);
+        auto parquet_reader = std::make_shared<ParquetReaderWrap>(std::move(parquet_file), _num_of_columns_from_file,
+                                                                  range_desc.start_offset, range_desc.size);
         _next_file++;
         int64_t file_size;
         RETURN_IF_ERROR(parquet_reader->size(&file_size));

--- a/be/test/storage/vectorized/push_handler_test.cpp
+++ b/be/test/storage/vectorized/push_handler_test.cpp
@@ -297,7 +297,7 @@ TEST_F(PushHandlerTest, PushBrokerReaderNormal) {
     broker_scan_range.params = _params;
     TBrokerRangeDesc range;
     range.start_offset = 0;
-    range.size = -1;
+    range.size = LONG_MAX;
     range.format_type = TFileFormatType::FORMAT_PARQUET;
     range.splittable = false;
     range.path = "./be/test/storage/test_data/push_broker_reader.parquet";

--- a/fe/fe-core/src/main/java/com/starrocks/planner/FileScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FileScanNode.java
@@ -508,8 +508,8 @@ public class FileScanNode extends LoadScanNode {
             // The rest of the file belongs to one range
             boolean isEndOfFile = false;
             if (smallestLocations.second + leftBytes > bytesPerInstance &&
-                    (formatType == TFileFormatType.FORMAT_CSV_PLAIN && fileStatus.isSplitable)) {
-                // Now only support split plain text
+                    ((formatType == TFileFormatType.FORMAT_CSV_PLAIN || formatType == TFileFormatType.FORMAT_PARQUET)
+                            && fileStatus.isSplitable)) {
                 rangeBytes = bytesPerInstance - smallestLocations.second;
             } else {
                 rangeBytes = leftBytes;


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3942 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
StarRocks broker load granularity of parallel scan is file. So that load one large file will be only one parallel process.
According to this problem, we support split parquet file using parquet row group and scan parallel.
In the case of FE setting parameter `load_parallel_instance_num=8`, the load performance of a single Parquet file is improved by `6x times`
