### PR TITLE
Improve limit operator on hdfs scan node

### DIFF
--- a/be/src/exec/vectorized/hdfs_scan_node.cpp
+++ b/be/src/exec/vectorized/hdfs_scan_node.cpp
@@ -415,6 +415,11 @@ void HdfsScanNode::_scanner_thread(HdfsScanner* scanner) {
             status = Status::Aborted("result chunks has been shutdown");
             break;
         }
+        // Improve for select * from table limit x;
+        if (limit() != -1 && scanner->num_rows_read() >= limit()) {
+            status = Status::EndOfFile("limit reach");
+            break;
+        }
         if (scanner->raw_rows_read() >= raw_rows_threshold) {
             resubmit = true;
             break;

--- a/be/src/exec/vectorized/hdfs_scanner.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner.cpp
@@ -97,6 +97,7 @@ Status HdfsScanner::get_next(RuntimeState* runtime_state, ChunkPtr* chunk) {
     } else {
         LOG(ERROR) << "failed to read file: " << _scanner_params.path;
     }
+    _stats.num_rows_read += (*chunk)->num_rows();
     return status;
 }
 

--- a/be/src/exec/vectorized/hdfs_scanner.h
+++ b/be/src/exec/vectorized/hdfs_scanner.h
@@ -23,6 +23,7 @@ class RuntimeFilterProbeCollector;
 struct HdfsScanStats {
     int64_t scan_ns = 0;
     int64_t raw_rows_read = 0;
+    int64_t num_rows_read = 0;
     int64_t expr_filter_ns = 0;
     int64_t io_ns = 0;
     int64_t io_count = 0;
@@ -187,6 +188,7 @@ public:
     void cleanup();
 
     int64_t raw_rows_read() const { return _stats.raw_rows_read; }
+    int64_t num_rows_read() const { return _stats.num_rows_read; }
     void set_keep_priority(bool v) { _keep_priority = v; }
     bool keep_priority() const { return _keep_priority; }
     void update_counter();


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：

When scanner have returned enough rows, it can exit early. It borrows solution from PR: https://github.com/StarRocks/starrocks/pull/1649.
