### PR TITLE
Optimize performance of small int join with direct mapping hash map

### DIFF
--- a/be/src/column/fixed_length_column_base.h
+++ b/be/src/column/fixed_length_column_base.h
@@ -85,6 +85,8 @@ public:
 
     void append(const T value) { _data.emplace_back(value); }
 
+    void append(const Buffer<T>& values) { _data.insert(_data.end(), values.begin(), values.end()); }
+
     void append_datum(const Datum& datum) override { _data.emplace_back(datum.get<ValueType>()); }
 
     void append(const Column& src, size_t offset, size_t count) override;

--- a/be/src/exec/vectorized/join_hash_map.tpp
+++ b/be/src/exec/vectorized/join_hash_map.tpp
@@ -47,7 +47,8 @@ Status JoinBuildFunc<PT>::construct_hash_table(RuntimeState* state, JoinHashTabl
 
 template <PrimitiveType PT>
 void DirectMappingJoinBuildFunc<PT>::prepare(RuntimeState* runtime, JoinHashTableItems* table_items) {
-    static constexpr size_t BUCKET_SIZE = 1L << std::numeric_limits<CppType>::digits;
+    static constexpr size_t BUCKET_SIZE =
+            (int64_t)(RunTimeTypeLimits<PT>::max_value()) - (int64_t)(RunTimeTypeLimits<PT>::min_value()) + 1L;
     table_items->bucket_size = BUCKET_SIZE;
     table_items->first.resize(table_items->bucket_size, 0);
     table_items->next.resize(table_items->row_count + 1, 0);

--- a/be/src/exec/vectorized/join_hash_map.tpp
+++ b/be/src/exec/vectorized/join_hash_map.tpp
@@ -73,14 +73,14 @@ Status DirectMappingJoinBuildFunc<PT>::construct_hash_table(RuntimeState* state,
         auto& null_array = nullable_column->null_column()->get_data();
         for (size_t i = 1; i < table_items->row_count + 1; i++) {
             if (null_array[i] == 0) {
-                auto buckets = data[i] - RunTimeTypeLimits<PT>::min_value();
+                size_t buckets = data[i] - RunTimeTypeLimits<PT>::min_value();
                 table_items->next[i] = table_items->first[buckets];
                 table_items->first[buckets] = i;
             }
         }
     } else {
         for (size_t i = 1; i < table_items->row_count + 1; i++) {
-            auto buckets = data[i] - RunTimeTypeLimits<PT>::min_value();
+            size_t buckets = data[i] - RunTimeTypeLimits<PT>::min_value();
             table_items->next[i] = table_items->first[buckets];
             table_items->first[buckets] = i;
         }

--- a/be/src/exec/vectorized/join_hash_map.tpp
+++ b/be/src/exec/vectorized/join_hash_map.tpp
@@ -193,7 +193,7 @@ Status DirectMappingJoinProbeFunc<PT>::lookup_init(const JoinHashTableItems& tab
             auto& null_array = nullable_column->null_column()->get_data();
             for (size_t i = 0; i < probe_row_count; i++) {
                 if (null_array[i] == 0) {
-                    probe_state->next[i] = table_items.first[data[i] - RunTimeTypeTraits<PT>::min_value()];
+                    probe_state->next[i] = table_items.first[data[i] - RunTimeTypeLimits<PT>::min_value()];
                 } else {
                     probe_state->next[i] = 0;
                 }

--- a/be/src/exec/vectorized/join_hash_map.tpp
+++ b/be/src/exec/vectorized/join_hash_map.tpp
@@ -47,7 +47,8 @@ Status JoinBuildFunc<PT>::construct_hash_table(RuntimeState* state, JoinHashTabl
 
 template <PrimitiveType PT>
 void DirectMappingJoinBuildFunc<PT>::prepare(RuntimeState* runtime, JoinHashTableItems* table_items) {
-    table_items->bucket_size = (int64_t)(std::numeric_limits<CppType>::max()) - (int64_t)(std::numeric_limits<CppType>::min() + 1l);
+    table_items->bucket_size =
+            (int64_t)(std::numeric_limits<CppType>::max()) - (int64_t)(std::numeric_limits<CppType>::min() + 1l);
     table_items->first.resize(table_items->bucket_size, 0);
     table_items->next.resize(table_items->row_count + 1, 0);
 }
@@ -180,7 +181,8 @@ void FixedSizeJoinBuildFunc<PT>::_build_nullable_columns(JoinHashTableItems* tab
 }
 
 template <PrimitiveType PT>
-Status DirectMappingJoinProbeFunc<PT>::lookup_init(const JoinHashTableItems& table_items, HashTableProbeState* probe_state) {
+Status DirectMappingJoinProbeFunc<PT>::lookup_init(const JoinHashTableItems& table_items,
+                                                   HashTableProbeState* probe_state) {
     size_t probe_row_count = probe_state->probe_row_count;
     auto& data = get_key_data(*probe_state);
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3954 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

smallint/tinyint/bool can use direct mapping hash map to optimize performance.
This optimization only works if the user explicitly defines it as a specific data type (boolean/tinyint/smallint).
It may be used with low cardinality or statistics in the future

```
select count(lo_revenue), count(d_year)  from lineorder_small join dates_small on lo_orderdate=d_datekey
```

before optimize: 1.27s
after optimize: 0.80s

