### PR TITLE
Fix sql split bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
@@ -85,9 +85,13 @@ public class SqlParser {
         List<String> sqlLists = Lists.newArrayList();
         boolean inString = false;
         int sqlStartOffset = 0;
+        char inStringStart = '-';
         for (int i = 0; i < sql.length(); ++i) {
-            if (sql.charAt(i) == '\"' || sql.charAt(i) == '\'' || sql.charAt(i) == '`') {
-                inString = !inString;
+            if (!inString && (sql.charAt(i) == '\"' || sql.charAt(i) == '\'' || sql.charAt(i) == '`')) {
+                inString = true;
+                inStringStart = sql.charAt(i);
+            } else if (inString && (sql.charAt(i) == inStringStart)) {
+                inString = false;
             }
 
             if (sql.charAt(i) == ';') {
@@ -97,7 +101,11 @@ public class SqlParser {
                 }
             }
         }
-        sqlLists.add(sql.substring(sqlStartOffset));
+
+        String last = sql.substring(sqlStartOffset).trim();
+        if (!last.isEmpty()) {
+            sqlLists.add(last);
+        }
         return sqlLists;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectSchedulerTest.java
@@ -84,6 +84,7 @@ public class ConnectSchedulerTest {
                         }
                     }
                 };
+                minTimes = 0;
             }
         };
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

For sql: `select * from t1;`
After parse will return two statement