### PR TITLE
Add hdfs latency config value for testing

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -667,6 +667,7 @@ CONF_String(object_storage_region, "");
 CONF_Int64(object_storage_max_connection, "102400");
 
 CONF_Bool(enable_orc_late_materialization, "true");
+CONF_Int32(add_hdfs_read_latency_ms, "0");
 
 // default: 16MB
 CONF_mInt64(experimental_s3_max_single_part_size, "16777216");


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [x] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：

This purpose of introducing this config value is for testing, because we find latency mismatch between customer's HDFS cluster and our own HDFS cluster.
