### PR TITLE
Fix date cast to datetime bug when datetime is null

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -276,8 +276,8 @@ public class Utils {
     //  or   or
     //  /\   /\
     // a  b c  d
-    private static ScalarOperator createCompound(CompoundPredicateOperator.CompoundType type,
-                                                 List<ScalarOperator> nodes) {
+    public static ScalarOperator createCompound(CompoundPredicateOperator.CompoundType type,
+                                                List<ScalarOperator> nodes) {
         LinkedList<ScalarOperator> link =
                 nodes.stream().filter(Objects::nonNull).collect(Collectors.toCollection(Lists::newLinkedList));
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/BinaryPredicateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/BinaryPredicateOperator.java
@@ -154,4 +154,28 @@ public class BinaryPredicateOperator extends PredicateOperator {
     public boolean isNullable() {
         return !this.type.equals(BinaryType.EQ_FOR_NULL) && super.isNullable();
     }
+
+    public static BinaryPredicateOperator eq(ScalarOperator... arguments) {
+        return new BinaryPredicateOperator(BinaryType.EQ, arguments);
+    }
+
+    public static BinaryPredicateOperator ge(ScalarOperator... arguments) {
+        return new BinaryPredicateOperator(BinaryType.GE, arguments);
+    }
+
+    public static BinaryPredicateOperator gt(ScalarOperator... arguments) {
+        return new BinaryPredicateOperator(BinaryType.GT, arguments);
+    }
+
+    public static BinaryPredicateOperator ne(ScalarOperator... arguments) {
+        return new BinaryPredicateOperator(BinaryType.NE, arguments);
+    }
+
+    public static BinaryPredicateOperator le(ScalarOperator... arguments) {
+        return new BinaryPredicateOperator(BinaryType.LE, arguments);
+    }
+
+    public static BinaryPredicateOperator lt(ScalarOperator... arguments) {
+        return new BinaryPredicateOperator(BinaryType.LT, arguments);
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/BinaryPredicateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/BinaryPredicateOperator.java
@@ -155,27 +155,27 @@ public class BinaryPredicateOperator extends PredicateOperator {
         return !this.type.equals(BinaryType.EQ_FOR_NULL) && super.isNullable();
     }
 
-    public static BinaryPredicateOperator eq(ScalarOperator... arguments) {
-        return new BinaryPredicateOperator(BinaryType.EQ, arguments);
+    public static BinaryPredicateOperator eq(ScalarOperator lhs, ScalarOperator rhs) {
+        return new BinaryPredicateOperator(BinaryType.EQ, lhs, rhs);
     }
 
-    public static BinaryPredicateOperator ge(ScalarOperator... arguments) {
-        return new BinaryPredicateOperator(BinaryType.GE, arguments);
+    public static BinaryPredicateOperator ge(ScalarOperator lhs, ScalarOperator rhs) {
+        return new BinaryPredicateOperator(BinaryType.GE, lhs, rhs);
     }
 
-    public static BinaryPredicateOperator gt(ScalarOperator... arguments) {
-        return new BinaryPredicateOperator(BinaryType.GT, arguments);
+    public static BinaryPredicateOperator gt(ScalarOperator lhs, ScalarOperator rhs) {
+        return new BinaryPredicateOperator(BinaryType.GT, lhs, rhs);
     }
 
-    public static BinaryPredicateOperator ne(ScalarOperator... arguments) {
-        return new BinaryPredicateOperator(BinaryType.NE, arguments);
+    public static BinaryPredicateOperator ne(ScalarOperator lhs, ScalarOperator rhs) {
+        return new BinaryPredicateOperator(BinaryType.NE, lhs, rhs);
     }
 
-    public static BinaryPredicateOperator le(ScalarOperator... arguments) {
-        return new BinaryPredicateOperator(BinaryType.LE, arguments);
+    public static BinaryPredicateOperator le(ScalarOperator lhs, ScalarOperator rhs) {
+        return new BinaryPredicateOperator(BinaryType.LE, lhs, rhs);
     }
 
-    public static BinaryPredicateOperator lt(ScalarOperator... arguments) {
-        return new BinaryPredicateOperator(BinaryType.LT, arguments);
+    public static BinaryPredicateOperator lt(ScalarOperator lhs, ScalarOperator rhs) {
+        return new BinaryPredicateOperator(BinaryType.LT, lhs, rhs);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CompoundPredicateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CompoundPredicateOperator.java
@@ -2,8 +2,11 @@
 package com.starrocks.sql.optimizer.operator.scalar;
 
 import com.google.common.base.Preconditions;
+import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 
 public class CompoundPredicateOperator extends PredicateOperator {
@@ -78,5 +81,21 @@ public class CompoundPredicateOperator extends PredicateOperator {
     @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(), type);
+    }
+
+    public static ScalarOperator or(List<ScalarOperator> nodes) {
+        return Utils.createCompound(CompoundPredicateOperator.CompoundType.OR, nodes);
+    }
+
+    public static ScalarOperator or(ScalarOperator... nodes) {
+        return Utils.createCompound(CompoundPredicateOperator.CompoundType.OR, Arrays.asList(nodes));
+    }
+
+    public static ScalarOperator and(List<ScalarOperator> nodes) {
+        return Utils.createCompound(CompoundPredicateOperator.CompoundType.AND, nodes);
+    }
+
+    public static ScalarOperator and(ScalarOperator... nodes) {
+        return Utils.createCompound(CompoundPredicateOperator.CompoundType.AND, Arrays.asList(nodes));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRuleTest.java
@@ -301,8 +301,7 @@ public class ReduceCastRuleTest {
             CastOperator castOperator =
                     new CastOperator(Type.DATETIME, new ColumnRefOperator(0, Type.DATE, "id_date", false));
             ConstantOperator constantOperator = ConstantOperator.createNull(Type.DATETIME);
-            BinaryPredicateOperator beforeOptimize =
-                    new BinaryPredicateOperator(BinaryPredicateOperator.BinaryType.GE, castOperator, constantOperator);
+            BinaryPredicateOperator beforeOptimize = BinaryPredicateOperator.ge(castOperator, constantOperator);
             ScalarOperator afterOptimize = reduceCastRule.apply(
                     beforeOptimize,
                     null);
@@ -425,8 +424,7 @@ public class ReduceCastRuleTest {
             CastOperator castOperator =
                     new CastOperator(Type.DATE, new ColumnRefOperator(0, Type.DATETIME, "id_datetime", false));
             ConstantOperator constantOperator = ConstantOperator.createNull(Type.DATE);
-            BinaryPredicateOperator beforeOptimize =
-                    new BinaryPredicateOperator(BinaryPredicateOperator.BinaryType.LT, castOperator, constantOperator);
+            BinaryPredicateOperator beforeOptimize = BinaryPredicateOperator.lt(castOperator, constantOperator);
             ScalarOperator afterOptimize = reduceCastRule.apply(beforeOptimize, null);
             Assert.assertSame(beforeOptimize, afterOptimize);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRuleTest.java
@@ -297,6 +297,17 @@ public class ReduceCastRuleTest {
 
             Assert.assertSame(beforeOptimize, afterOptimize);
         }
+        {
+            CastOperator castOperator =
+                    new CastOperator(Type.DATETIME, new ColumnRefOperator(0, Type.DATE, "id_date", false));
+            ConstantOperator constantOperator = ConstantOperator.createNull(Type.DATETIME);
+            BinaryPredicateOperator beforeOptimize =
+                    new BinaryPredicateOperator(BinaryPredicateOperator.BinaryType.GE, castOperator, constantOperator);
+            ScalarOperator afterOptimize = reduceCastRule.apply(
+                    beforeOptimize,
+                    null);
+            Assert.assertSame(beforeOptimize, afterOptimize);
+        }
     }
 
     @Test
@@ -409,6 +420,15 @@ public class ReduceCastRuleTest {
             Assert.assertTrue(right.getChild(1) instanceof ConstantOperator);
             Assert.assertEquals("2021-12-29 00:00:00",
                     ((ConstantOperator) right.getChild(1)).getDatetime().format(formatter));
+        }
+        {
+            CastOperator castOperator =
+                    new CastOperator(Type.DATE, new ColumnRefOperator(0, Type.DATETIME, "id_datetime", false));
+            ConstantOperator constantOperator = ConstantOperator.createNull(Type.DATE);
+            BinaryPredicateOperator beforeOptimize =
+                    new BinaryPredicateOperator(BinaryPredicateOperator.BinaryType.LT, castOperator, constantOperator);
+            ScalarOperator afterOptimize = reduceCastRule.apply(beforeOptimize, null);
+            Assert.assertSame(beforeOptimize, afterOptimize);
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
@@ -1105,8 +1105,15 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
                 "select * from test_partition_prune_optimize_by_date where dt >= timestamp('2021-12-27 00:00:00.123456') " +
                         "and dt <= timestamp('2021-12-29 00:00:00.123456')";
         String plan = getFragmentPlan(sql);
+        System.out.println(plan);
         Assert.assertTrue(plan.contains("partitions=2/4"));
-
+/*
+                "(PARTITION p_20211227 VALUES [('2021-12-27'), ('2021-12-28')),\n" +
+                "PARTITION p_20211228 VALUES [('2021-12-28'), ('2021-12-29')),\n" +
+                "PARTITION p_20211229 VALUES [('2021-12-29'), ('2021-12-30')),\n" +
+                "PARTITION p_20211230 VALUES [('2021-12-30'), ('2021-12-31'))\n" +
+                ")\n" +
+ */
         sql =
                 "select * from test_partition_prune_optimize_by_date where dt > timestamp('2021-12-27 00:00:00.123456') " +
                         "and dt < timestamp('2021-12-29 00:00:00.123456')";

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
@@ -1105,15 +1105,8 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
                 "select * from test_partition_prune_optimize_by_date where dt >= timestamp('2021-12-27 00:00:00.123456') " +
                         "and dt <= timestamp('2021-12-29 00:00:00.123456')";
         String plan = getFragmentPlan(sql);
-        System.out.println(plan);
         Assert.assertTrue(plan.contains("partitions=2/4"));
-/*
-                "(PARTITION p_20211227 VALUES [('2021-12-27'), ('2021-12-28')),\n" +
-                "PARTITION p_20211228 VALUES [('2021-12-28'), ('2021-12-29')),\n" +
-                "PARTITION p_20211229 VALUES [('2021-12-29'), ('2021-12-30')),\n" +
-                "PARTITION p_20211230 VALUES [('2021-12-30'), ('2021-12-31'))\n" +
-                ")\n" +
- */
+        
         sql =
                 "select * from test_partition_prune_optimize_by_date where dt > timestamp('2021-12-27 00:00:00.123456') " +
                         "and dt < timestamp('2021-12-29 00:00:00.123456')";


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3783

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Will throw exception
```
select * from t1 where cast(v1 as datetime) < NULL;
```