### PR TITLE
Make DataDir does not rely on std::filesystem but Env.

### DIFF
--- a/be/src/env/env.h
+++ b/be/src/env/env.h
@@ -28,11 +28,11 @@ struct RandomRWFileOptions;
 
 struct SpaceInfo {
     // Total size of the filesystem, in bytes
-    int64_t capacity;
+    int64_t capacity = 0;
     // Free space on the filesystem, in bytes
-    int64_t free;
+    int64_t free = 0;
     // Free space available to a non-privileged process (may be equal or less than free)
-    int64_t available;
+    int64_t available = 0;
 };
 
 class Env {

--- a/be/src/env/env.h
+++ b/be/src/env/env.h
@@ -26,6 +26,15 @@ struct WritableFileOptions;
 struct RandomAccessFileOptions;
 struct RandomRWFileOptions;
 
+struct SpaceInfo {
+    // Total size of the filesystem, in bytes
+    int64_t capacity;
+    // Free space on the filesystem, in bytes
+    int64_t free;
+    // Free space available to a non-privileged process (may be equal or less than free)
+    int64_t available;
+};
+
 class Env {
 public:
     // Governs if/how the file is created.
@@ -154,6 +163,9 @@ public:
 
     // create a hard-link
     virtual Status link_file(const std::string& /*old_path*/, const std::string& /*new_path*/) = 0;
+
+    // Determines the information about the filesystem on which the pathname 'path' is located.
+    virtual StatusOr<SpaceInfo> space(const std::string& path) { return Status::NotSupported("Env::space()"); }
 };
 
 struct RandomAccessFileOptions {

--- a/be/src/env/env_s3.cpp
+++ b/be/src/env/env_s3.cpp
@@ -245,4 +245,10 @@ StatusOr<std::unique_ptr<WritableFile>> EnvS3::new_writable_file(const WritableF
     return std::make_unique<OutputStreamAdapter>(std::move(ostream), fname);
 }
 
+StatusOr<SpaceInfo> EnvS3::space(const std::string& path) {
+    return SpaceInfo{.capacity = std::numeric_limits<int64_t>::max(),
+                     .free = std::numeric_limits<int64_t>::max(),
+                     .available = std::numeric_limits<int64_t>::max()};
+}
+
 } // namespace starrocks

--- a/be/src/env/env_s3.h
+++ b/be/src/env/env_s3.h
@@ -89,6 +89,8 @@ public:
     Status link_file(const std::string& old_path, const std::string& new_path) override {
         return Status::NotSupported("EnvS3::link_file");
     }
+
+    StatusOr<SpaceInfo> space(const std::string& path) override;
 };
 
 } // namespace starrocks

--- a/be/src/storage/data_dir.cpp
+++ b/be/src/storage/data_dir.cpp
@@ -705,18 +705,11 @@ void DataDir::_process_garbage_path(const std::string& path) {
 }
 
 Status DataDir::update_capacity() {
-    try {
-        std::filesystem::space_info path_info = std::filesystem::space(_path);
-        _available_bytes = path_info.available;
-        _disk_capacity_bytes = path_info.capacity;
-    } catch (std::filesystem::filesystem_error& e) {
-        RETURN_IF_ERROR_WITH_WARN(Status::IOError(strings::Substitute("get path $0 available capacity failed, error=$1",
-                                                                      _path, e.what())),
-                                  "std::filesystem::space failed");
-    }
+    ASSIGN_OR_RETURN(auto space_info, Env::Default()->space(_path));
+    _available_bytes = space_info.available;
+    _disk_capacity_bytes = space_info.capacity;
     LOG(INFO) << "path: " << _path << " total capacity: " << _disk_capacity_bytes
               << ", available capacity: " << _available_bytes;
-
     return Status::OK();
 }
 


### PR DESCRIPTION
## Problem Summary(Required) ：
Make DataDir does not rely on std::filesystem but Env.
DataDir can be based on EnvS3 in the near future.

## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [x] others

