### PR TITLE
Downgrading libmariadb to avoid problems accessing other MYSQL protocol

### DIFF
--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -711,21 +711,19 @@ build_hyperscan() {
 }
 
 #mariadb-connector-c
-# static link plugins refer to:
-# https://mariadb.com/kb/en/configuration-settings-for-building-connectorc/
 build_mariadb() {
     check_if_source_exist $MARIADB_SOURCE
     cd $TP_SOURCE_DIR/$MARIADB_SOURCE
     mkdir -p build && cd build
     $CMAKE_CMD .. -DCMAKE_BUILD_TYPE=Release                \
-                  -DCMAKE_INSTALL_PREFIX=${TP_INSTALL_DIR}  \
-                  -DCLIENT_PLUGIN_SHA256_PASSWORD=STATIC    \
-                  -DCLIENT_PLUGIN_AUTH_GSSAPI=STATIC        \
-                  -DCLIENT_PLUGIN_CLEARTEXT=STATIC          \
-                  -DCLIENT_PLUGIN_DIALOG=STATIC             \
-                  -DOPENSSL_ROOT_DIR=${TP_INSTALL_DIR}      \
-                  -DOPENSSL_LIBRARYIES=${TP_INSTALL_DIR}/lib
-    make -j$PARALLEL && make install
+                  -DCMAKE_INSTALL_PREFIX=${TP_INSTALL_DIR}
+    # we only need build libmariadbclient and headers
+    make -j$PARALLEL mariadbclient
+    cd $TP_SOURCE_DIR/$MARIADB_SOURCE/build/libmariadb
+    make install
+    # install mariadb headers
+    cd $TP_SOURCE_DIR/$MARIADB_SOURCE/build/include
+    make install
 }
 
 # aliyun_oss_jars

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -270,10 +270,10 @@ RAGEL_SOURCE="ragel-6.10"
 RAGEL_MD5SUM="748cae8b50cffe9efcaa5acebc6abf0d"
 
 # mariadb-connector-c
-MARIADB_DOWNLOAD="https://github.com/mariadb-corporation/mariadb-connector-c/archive/refs/tags/v3.2.5.tar.gz"
-MARIADB_NAME="mariadb-connector-c-3.2.5.tar.gz"
-MARIADB_SOURCE="mariadb-connector-c-3.2.5"
-MARIADB_MD5SUM="9ab9205418a933b0a7920e7cf424cc36"
+MARIADB_DOWNLOAD="https://github.com/mariadb-corporation/mariadb-connector-c/archive/refs/tags/v3.1.14.tar.gz"
+MARIADB_NAME="mariadb-connector-c-3.1.14.tar.gz"
+MARIADB_SOURCE="mariadb-connector-c-3.1.14"
+MARIADB_MD5SUM="86c4052adeb8447900bf33b4e2ddd1f9"
 
 # aliyun_oss_jars
 ALIYUN_OSS_JARS_DOWNLOAD="http://cdn-thirdparty.starrocks.com/aliyun-oss-sdk-3.7.2.tar.gz"


### PR DESCRIPTION

## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Problem Summary(Required) ：
fix the problem `mysql set character set failed.` when access TiDB
