### PR TITLE
Fix the bug set thread name

### DIFF
--- a/be/src/util/thread.cpp
+++ b/be/src/util/thread.cpp
@@ -215,15 +215,30 @@ int64_t Thread::current_thread_id() {
     return syscall(SYS_gettid);
 }
 
-void Thread::set_thread_name(pthread_t t, const std::string name) {
-    int ret = pthread_setname_np(t, name.data());
+void Thread::set_thread_name(pthread_t t, const std::string& name) {
+    // pthread_setname_np's length is restricted to 16 bytes, including the terminating null byte ('\0')
+    int ret;
+    if (name.length() < 16) {
+        ret = pthread_setname_np(t, name.data());
+    } else {
+        std::string str = name;
+        str.at(15) = '\0';
+        ret = pthread_setname_np(t, str.data());
+    }
     if (ret) {
         LOG(WARNING) << "failed to set thread name: " << name;
     }
 }
 
 void Thread::set_thread_name(std::thread& t, std::string name) {
-    Thread::set_thread_name(t.native_handle(), std::move(name));
+    // pthread_setname_np's length is restricted to 16 bytes, including the terminating null byte ('\0')
+    if (name.length() >= 16) {
+        name.at(15) = '\0';
+    }
+    int ret = pthread_setname_np(t.native_handle(), name.data());
+    if (ret) {
+        LOG(WARNING) << "failed to set thread name: " << name;
+    }
 }
 
 int64_t Thread::wait_for_tid() const {

--- a/be/src/util/thread.h
+++ b/be/src/util/thread.h
@@ -136,7 +136,7 @@ public:
 
     // Set name for thread
     // name's size should be less than 16, otherwise it will be truncated
-    static void set_thread_name(pthread_t t, const std::string name);
+    static void set_thread_name(pthread_t t, const std::string& name);
     static void set_thread_name(std::thread& t, std::string name);
 
 private:


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3969 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

pthread_setname_np's length is restricted to 16 bytes, including the terminating null byte ('\0')

So should truncate the str when length >=16;