### PR TITLE
[WIP] Remove tuple column from hash join

### DIFF
--- a/be/src/exec/vectorized/hash_join_node.h
+++ b/be/src/exec/vectorized/hash_join_node.h
@@ -96,7 +96,6 @@ private:
     std::set<SlotId> _output_slots;
 
     bool _is_push_down = false;
-    bool _need_create_tuple_columns = true;
 
     JoinHashTable _ht;
 
@@ -128,7 +127,6 @@ private:
     RuntimeProfile::Counter* _search_ht_timer = nullptr;
     RuntimeProfile::Counter* _output_build_column_timer = nullptr;
     RuntimeProfile::Counter* _output_probe_column_timer = nullptr;
-    RuntimeProfile::Counter* _output_tuple_column_timer = nullptr;
     RuntimeProfile::Counter* _build_rows_counter = nullptr;
     RuntimeProfile::Counter* _probe_rows_counter = nullptr;
     RuntimeProfile::Counter* _build_buckets_counter = nullptr;

--- a/be/src/exec/vectorized/hash_joiner.cpp
+++ b/be/src/exec/vectorized/hash_joiner.cpp
@@ -94,7 +94,6 @@ Status HashJoiner::prepare_prober(RuntimeState* state, RuntimeProfile* runtime_p
     _search_ht_timer = ADD_TIMER(runtime_profile, "SearchHashTableTimer");
     _output_build_column_timer = ADD_TIMER(runtime_profile, "OutputBuildColumnTimer");
     _output_probe_column_timer = ADD_TIMER(runtime_profile, "OutputProbeColumnTimer");
-    _output_tuple_column_timer = ADD_TIMER(runtime_profile, "OutputTupleColumnTimer");
     _probe_conjunct_evaluate_timer = ADD_TIMER(runtime_profile, "ProbeConjunctEvaluateTime");
     _other_join_conjunct_evaluate_timer = ADD_TIMER(runtime_profile, "OtherJoinConjunctEvaluateTime");
     _where_conjunct_evaluate_timer = ADD_TIMER(runtime_profile, "WhereConjunctEvaluateTime");
@@ -103,8 +102,6 @@ Status HashJoiner::prepare_prober(RuntimeState* state, RuntimeProfile* runtime_p
 }
 
 void HashJoiner::_init_hash_table_param(HashTableParam* param) {
-    // Pipeline query engine always needn't create tuple columns
-    param->need_create_tuple_columns = false;
     param->with_other_conjunct = !_other_join_conjunct_ctxs.empty();
     param->join_type = _join_type;
     param->row_desc = &_row_descriptor;
@@ -113,7 +110,6 @@ void HashJoiner::_init_hash_table_param(HashTableParam* param) {
     param->search_ht_timer = _search_ht_timer;
     param->output_build_column_timer = _output_build_column_timer;
     param->output_probe_column_timer = _output_probe_column_timer;
-    param->output_tuple_column_timer = _output_tuple_column_timer;
 
     param->output_slots = _output_slots;
     std::set<SlotId> predicate_slots;
@@ -271,7 +267,7 @@ Status HashJoiner::create_runtime_filters(RuntimeState* state) {
 
 void HashJoiner::reference_hash_table(HashJoiner* src_join_builder) {
     _ht = src_join_builder->_ht.clone_readable_table();
-    _ht.set_probe_profile(_search_ht_timer, _output_probe_column_timer, _output_tuple_column_timer);
+    _ht.set_probe_profile(_search_ht_timer, _output_probe_column_timer);
 
     _probe_column_count = src_join_builder->_probe_column_count;
     _build_column_count = src_join_builder->_build_column_count;

--- a/be/src/exec/vectorized/hash_joiner.h
+++ b/be/src/exec/vectorized/hash_joiner.h
@@ -379,7 +379,6 @@ private:
     // Profile for hash join prober.
     RuntimeProfile::Counter* _search_ht_timer = nullptr;
     RuntimeProfile::Counter* _output_probe_column_timer = nullptr;
-    RuntimeProfile::Counter* _output_tuple_column_timer = nullptr;
     RuntimeProfile::Counter* _build_conjunct_evaluate_timer = nullptr;
     RuntimeProfile::Counter* _probe_conjunct_evaluate_timer = nullptr;
     RuntimeProfile::Counter* _other_join_conjunct_evaluate_timer = nullptr;

--- a/be/src/exec/vectorized/join_hash_map.cpp
+++ b/be/src/exec/vectorized/join_hash_map.cpp
@@ -207,8 +207,6 @@ JoinHashTable JoinHashTable::clone_readable_table() {
     JoinHashTable ht;
 
     ht._hash_map_type = this->_hash_map_type;
-    ht._need_create_tuple_columns = this->_need_create_tuple_columns;
-
     ht._table_items = this->_table_items;
     // Clone a new probe state.
     ht._probe_state = std::make_unique<HashTableProbeState>(*this->_probe_state);
@@ -231,11 +229,9 @@ JoinHashTable JoinHashTable::clone_readable_table() {
 }
 
 void JoinHashTable::set_probe_profile(RuntimeProfile::Counter* search_ht_timer,
-                                      RuntimeProfile::Counter* output_probe_column_timer,
-                                      RuntimeProfile::Counter* output_tuple_column_timer) {
+                                      RuntimeProfile::Counter* output_probe_column_timer) {
     _probe_state->search_ht_timer = search_ht_timer;
     _probe_state->output_probe_column_timer = output_probe_column_timer;
-    _probe_state->output_tuple_column_timer = output_tuple_column_timer;
 }
 
 void JoinHashTable::close() {
@@ -244,11 +240,9 @@ void JoinHashTable::close() {
 }
 
 void JoinHashTable::create(const HashTableParam& param) {
-    _need_create_tuple_columns = param.need_create_tuple_columns;
     _table_items = std::make_shared<JoinHashTableItems>();
     _probe_state = std::make_unique<HashTableProbeState>();
 
-    _table_items->need_create_tuple_columns = _need_create_tuple_columns;
     _table_items->build_chunk = std::make_shared<Chunk>();
     _table_items->with_other_conjunct = param.with_other_conjunct;
     _table_items->join_type = param.join_type;
@@ -270,7 +264,6 @@ void JoinHashTable::create(const HashTableParam& param) {
 
     _probe_state->search_ht_timer = param.search_ht_timer;
     _probe_state->output_probe_column_timer = param.output_probe_column_timer;
-    _probe_state->output_tuple_column_timer = param.output_tuple_column_timer;
 
     const auto& probe_desc = *param.probe_row_desc;
     for (const auto& tuple_desc : probe_desc.tuple_descriptors()) {
@@ -289,9 +282,6 @@ void JoinHashTable::create(const HashTableParam& param) {
 
             _table_items->probe_slots.emplace_back(hash_table_slot);
             _table_items->probe_column_count++;
-        }
-        if (_table_items->row_desc->get_tuple_idx(tuple_desc->id()) != RowDescriptor::INVALID_IDX) {
-            _table_items->output_probe_tuple_ids.emplace_back(tuple_desc->id());
         }
     }
 
@@ -320,9 +310,6 @@ void JoinHashTable::create(const HashTableParam& param) {
             }
             _table_items->build_chunk->append_column(std::move(column), slot->id());
             _table_items->build_column_count++;
-        }
-        if (_table_items->row_desc->get_tuple_idx(tuple_desc->id()) != RowDescriptor::INVALID_IDX) {
-            _table_items->output_build_tuple_ids.emplace_back(tuple_desc->id());
         }
     }
 }
@@ -399,26 +386,6 @@ Status JoinHashTable::append_chunk(RuntimeState* state, const ChunkPtr& chunk) {
             columns[i]->append(*column, 0, chunk->num_rows());
         } else {
             columns[i]->append(*column, 0, chunk->num_rows());
-        }
-    }
-
-    if (_need_create_tuple_columns) {
-        const auto& tuple_id_map = chunk->get_tuple_id_to_index_map();
-        for (auto iter = tuple_id_map.begin(); iter != tuple_id_map.end(); iter++) {
-            if (_table_items->row_desc->get_tuple_idx(iter->first) != RowDescriptor::INVALID_IDX) {
-                if (_table_items->build_chunk->is_tuple_exist(iter->first)) {
-                    ColumnPtr& src_column = chunk->get_tuple_column_by_id(iter->first);
-                    ColumnPtr& dest_column = _table_items->build_chunk->get_tuple_column_by_id(iter->first);
-                    dest_column->append(*src_column, 0, src_column->size());
-                    chunk_memory_size += src_column->memory_usage();
-                } else {
-                    ColumnPtr& src_column = chunk->get_tuple_column_by_id(iter->first);
-                    ColumnPtr dest_column = BooleanColumn::create(_table_items->row_count + 1, 1);
-                    dest_column->append(*src_column, 0, src_column->size());
-                    _table_items->build_chunk->append_tuple_column(dest_column, iter->first);
-                    chunk_memory_size += src_column->memory_usage();
-                }
-            }
         }
     }
 

--- a/be/test/exec/vectorized/join_hash_map_test.cpp
+++ b/be/test/exec/vectorized/join_hash_map_test.cpp
@@ -51,7 +51,7 @@ private:
                                   uint32_t match_count);
     static void check_probe_state(const JoinHashTableItems& table_items, const HashTableProbeState& probe_state,
                                   JoinMatchFlag match_flag, uint32_t step, uint32_t match_count,
-                                  uint32_t probe_row_count, bool has_null_build_tuple);
+                                  uint32_t probe_row_count);
     static void check_build_index(const Buffer<uint32_t>& first, const Buffer<uint32_t>& next, uint32_t row_count);
     static void check_build_index(const Buffer<uint8_t>& nulls, const Buffer<uint32_t>& first,
                                   const Buffer<uint32_t>& next, uint32_t row_count);
@@ -75,7 +75,6 @@ private:
 
     // flag: 0(all 0), 1(all 1), 2(half 0), 3(one third 0)
     static Buffer<uint8_t> create_bools(uint32_t count, int32_t flag);
-    static ColumnPtr create_tuple_column(const Buffer<uint8_t>& data);
     static ColumnPtr create_column(PrimitiveType PT);
     static ColumnPtr create_column(PrimitiveType PT, uint32_t start, uint32_t count);
     static ColumnPtr create_nullable_column(PrimitiveType PT);
@@ -87,14 +86,6 @@ private:
     std::shared_ptr<RuntimeProfile> _runtime_profile = nullptr;
     std::shared_ptr<RuntimeState> _runtime_state = nullptr;
 };
-
-ColumnPtr JoinHashMapTest::create_tuple_column(const Buffer<uint8_t>& data) {
-    ColumnPtr column = BooleanColumn::create();
-    for (auto v : data) {
-        column->append_datum(v);
-    }
-    return column;
-}
 
 Buffer<uint8_t> JoinHashMapTest::create_bools(uint32_t count, int32_t flag) {
     Buffer<uint8_t> nulls(count);
@@ -431,10 +422,9 @@ void JoinHashMapTest::check_match_index(const Buffer<uint32_t>& probe_match_inde
 
 void JoinHashMapTest::check_probe_state(const JoinHashTableItems& table_items, const HashTableProbeState& probe_state,
                                         JoinMatchFlag match_flag, uint32_t step, uint32_t match_count,
-                                        uint32_t probe_row_count, bool has_null_build_tuple) {
+                                        uint32_t probe_row_count) {
     ASSERT_EQ(probe_state.match_flag, match_flag);
     ASSERT_EQ(probe_state.has_remain, (step + 1) * config::vector_chunk_size < probe_row_count * match_count);
-    ASSERT_EQ(probe_state.has_null_build_tuple, has_null_build_tuple);
     if (probe_row_count * match_count > (step + 1) * config::vector_chunk_size) {
         ASSERT_EQ(probe_state.count, config::vector_chunk_size);
         if (is_check_cur_row_match_count(table_items.join_type, table_items.with_other_conjunct)) {
@@ -501,7 +491,6 @@ void JoinHashMapTest::prepare_probe_state(HashTableProbeState* probe_state, uint
     probe_state->probe_pool = std::make_unique<MemPool>();
     probe_state->search_ht_timer = ADD_TIMER(_runtime_profile, "SearchHashTableTimer");
     probe_state->output_probe_column_timer = ADD_TIMER(_runtime_profile, "OutputProbeColumnTimer");
-    probe_state->output_tuple_column_timer = ADD_TIMER(_runtime_profile, "OutputTupleColumnTimer");
     probe_state->build_index.resize(config::vector_chunk_size + 8);
     probe_state->probe_index.resize(config::vector_chunk_size + 8);
     probe_state->next.resize(config::vector_chunk_size);
@@ -936,7 +925,6 @@ TEST_F(JoinHashMapTest, DirectMappingJoinBuildProbeFunc) {
     auto build_row_desc = create_build_desc(_object_pool, &row_desc_builder, false);
 
     HashTableParam param;
-    param.need_create_tuple_columns = false;
     param.with_other_conjunct = false;
     param.join_type = TJoinOp::INNER_JOIN;
     param.row_desc = row_desc.get();
@@ -947,7 +935,6 @@ TEST_F(JoinHashMapTest, DirectMappingJoinBuildProbeFunc) {
     param.search_ht_timer = ADD_TIMER(_runtime_profile, "search_ht");
     param.output_build_column_timer = ADD_TIMER(_runtime_profile, "output_build_column");
     param.output_probe_column_timer = ADD_TIMER(_runtime_profile, "output_probe_column");
-    param.output_build_column_timer = ADD_TIMER(_runtime_profile, "output_tuple_column");
 
     JoinHashTable ht;
 
@@ -994,7 +981,6 @@ TEST_F(JoinHashMapTest, DirectMappingJoinBuildProbeFuncNullable) {
     auto build_row_desc = create_build_desc(_object_pool, &row_desc_builder, true);
 
     HashTableParam param;
-    param.need_create_tuple_columns = false;
     param.with_other_conjunct = false;
     param.join_type = TJoinOp::INNER_JOIN;
     param.row_desc = row_desc.get();
@@ -1005,7 +991,6 @@ TEST_F(JoinHashMapTest, DirectMappingJoinBuildProbeFuncNullable) {
     param.search_ht_timer = ADD_TIMER(_runtime_profile, "search_ht");
     param.output_build_column_timer = ADD_TIMER(_runtime_profile, "output_build_column");
     param.output_probe_column_timer = ADD_TIMER(_runtime_profile, "output_probe_column");
-    param.output_build_column_timer = ADD_TIMER(_runtime_profile, "output_tuple_column");
 
     JoinHashTable ht;
 
@@ -1487,7 +1472,6 @@ TEST_F(JoinHashMapTest, ProbeFromHtForLeftJoinFoundEmpty) {
     ASSERT_EQ(probe_state.cur_probe_index, 2048);
     ASSERT_EQ(probe_state.count, 4096);
     ASSERT_EQ(probe_state.cur_row_match_count, 1);
-    ASSERT_FALSE(probe_state.has_null_build_tuple);
     for (uint32_t i = 0; i < 2048; i += 1) {
         ASSERT_EQ(probe_state.probe_index[2 * i], i);
         ASSERT_EQ(probe_state.build_index[2 * i], i + 1 + 4096);
@@ -1503,7 +1487,6 @@ TEST_F(JoinHashMapTest, ProbeFromHtForLeftJoinFoundEmpty) {
     ASSERT_EQ(probe_state.cur_probe_index, 0);
     ASSERT_EQ(probe_state.count, 1904);
     ASSERT_EQ(probe_state.cur_row_match_count, 0);
-    ASSERT_FALSE(probe_state.has_null_build_tuple);
     for (uint32_t i = 0; i < 952; i += 1) {
         ASSERT_EQ(probe_state.probe_index[2 * i], i + 2048);
         ASSERT_EQ(probe_state.build_index[2 * i], i + 1 + 4096 + 2048);
@@ -1532,7 +1515,7 @@ TEST_F(JoinHashMapTest, ProbeFromHtForLeftJoinNextEmpty) {
     join_hash_map->_probe_from_ht_for_left_outer_join_with_other_conjunct<true>(_runtime_state.get(), build_data,
                                                                                 probe_data);
 
-    this->check_probe_state(table_items, probe_state, JoinMatchFlag::NORMAL, 0, match_count, probe_row_count, false);
+    this->check_probe_state(table_items, probe_state, JoinMatchFlag::NORMAL, 0, match_count, probe_row_count);
     this->check_match_index(probe_state.probe_match_index, 0, config::vector_chunk_size, match_count);
 }
 
@@ -1560,13 +1543,13 @@ TEST_F(JoinHashMapTest, ProbeFromHtForRightSemiJoinWithOtherConjunct) {
     auto join_hash_map = std::make_unique<JoinHashMapForOneKey(TYPE_INT)>(&table_items, &probe_state);
     join_hash_map->_probe_from_ht_for_right_semi_join_with_other_conjunct<true>(_runtime_state.get(), build_data,
                                                                                 probe_data);
-    this->check_probe_state(table_items, probe_state, JoinMatchFlag::NORMAL, 0, match_count, probe_row_count, false);
+    this->check_probe_state(table_items, probe_state, JoinMatchFlag::NORMAL, 0, match_count, probe_row_count);
 
     // second probe
     join_hash_map = std::make_unique<JoinHashMapForOneKey(TYPE_INT)>(&table_items, &probe_state);
     join_hash_map->_probe_from_ht_for_right_semi_join_with_other_conjunct<false>(_runtime_state.get(), build_data,
                                                                                  probe_data);
-    this->check_probe_state(table_items, probe_state, JoinMatchFlag::NORMAL, 1, match_count, probe_row_count, false);
+    this->check_probe_state(table_items, probe_state, JoinMatchFlag::NORMAL, 1, match_count, probe_row_count);
 }
 
 // Test case for right outer join with other conjunct.
@@ -1593,13 +1576,13 @@ TEST_F(JoinHashMapTest, ProbeFromHtForRightOuterJoinWithOtherConjunct) {
     auto join_hash_map = std::make_unique<JoinHashMapForOneKey(TYPE_INT)>(&table_items, &probe_state);
     join_hash_map->_probe_from_ht_for_right_outer_join_with_other_conjunct<true>(_runtime_state.get(), build_data,
                                                                                  probe_data);
-    this->check_probe_state(table_items, probe_state, JoinMatchFlag::NORMAL, 0, match_count, probe_row_count, false);
+    this->check_probe_state(table_items, probe_state, JoinMatchFlag::NORMAL, 0, match_count, probe_row_count);
 
     // second probe
     join_hash_map = std::make_unique<JoinHashMapForOneKey(TYPE_INT)>(&table_items, &probe_state);
     join_hash_map->_probe_from_ht_for_right_outer_join_with_other_conjunct<false>(_runtime_state.get(), build_data,
                                                                                   probe_data);
-    this->check_probe_state(table_items, probe_state, JoinMatchFlag::NORMAL, 1, match_count, probe_row_count, false);
+    this->check_probe_state(table_items, probe_state, JoinMatchFlag::NORMAL, 1, match_count, probe_row_count);
 }
 
 // Test case for right anti join with other conjunct.
@@ -1626,13 +1609,13 @@ TEST_F(JoinHashMapTest, ProbeFromHtForRightAntiJoinWithOtherConjunct) {
     auto join_hash_map = std::make_unique<JoinHashMapForOneKey(TYPE_INT)>(&table_items, &probe_state);
     join_hash_map->_probe_from_ht_for_right_anti_join_with_other_conjunct<true>(_runtime_state.get(), build_data,
                                                                                 probe_data);
-    this->check_probe_state(table_items, probe_state, JoinMatchFlag::NORMAL, 0, match_count, probe_row_count, false);
+    this->check_probe_state(table_items, probe_state, JoinMatchFlag::NORMAL, 0, match_count, probe_row_count);
 
     // second probe
     join_hash_map = std::make_unique<JoinHashMapForOneKey(TYPE_INT)>(&table_items, &probe_state);
     join_hash_map->_probe_from_ht_for_right_anti_join_with_other_conjunct<false>(_runtime_state.get(), build_data,
                                                                                  probe_data);
-    this->check_probe_state(table_items, probe_state, JoinMatchFlag::NORMAL, 1, match_count, probe_row_count, false);
+    this->check_probe_state(table_items, probe_state, JoinMatchFlag::NORMAL, 1, match_count, probe_row_count);
 }
 
 // NOLINTNEXTLINE
@@ -1660,7 +1643,6 @@ TEST_F(JoinHashMapTest, OneKeyJoinHashTable) {
     param.search_ht_timer = ADD_TIMER(runtime_profile, "SearchHashTableTimer");
     param.output_build_column_timer = ADD_TIMER(runtime_profile, "OutputBuildColumnTimer");
     param.output_probe_column_timer = ADD_TIMER(runtime_profile, "OutputProbeColumnTimer");
-    param.output_tuple_column_timer = ADD_TIMER(runtime_profile, "OutputTupleColumnTimer");
 
     JoinHashTable hash_table;
     hash_table.create(param);
@@ -1722,7 +1704,6 @@ TEST_F(JoinHashMapTest, OneNullableKeyJoinHashTable) {
     param.search_ht_timer = ADD_TIMER(runtime_profile, "SearchHashTableTimer");
     param.output_build_column_timer = ADD_TIMER(runtime_profile, "OutputBuildColumnTimer");
     param.output_probe_column_timer = ADD_TIMER(runtime_profile, "OutputProbeColumnTimer");
-    param.output_tuple_column_timer = ADD_TIMER(runtime_profile, "OutputTupleColumnTimer");
 
     JoinHashTable hash_table;
     hash_table.create(param);
@@ -1786,7 +1767,6 @@ TEST_F(JoinHashMapTest, FixedSizeJoinHashTable) {
     param.search_ht_timer = ADD_TIMER(runtime_profile, "SearchHashTableTimer");
     param.output_build_column_timer = ADD_TIMER(runtime_profile, "OutputBuildColumnTimer");
     param.output_probe_column_timer = ADD_TIMER(runtime_profile, "OutputProbeColumnTimer");
-    param.output_tuple_column_timer = ADD_TIMER(runtime_profile, "OutputTupleColumnTimer");
 
     JoinHashTable hash_table;
     hash_table.create(param);
@@ -1849,7 +1829,6 @@ TEST_F(JoinHashMapTest, SerializeJoinHashTable) {
     param.search_ht_timer = ADD_TIMER(runtime_profile, "SearchHashTableTimer");
     param.output_build_column_timer = ADD_TIMER(runtime_profile, "OutputBuildColumnTimer");
     param.output_probe_column_timer = ADD_TIMER(runtime_profile, "OutputProbeColumnTimer");
-    param.output_tuple_column_timer = ADD_TIMER(runtime_profile, "OutputTupleColumnTimer");
 
     JoinHashTable hash_table;
     hash_table.create(param);
@@ -2094,208 +2073,6 @@ TEST_F(JoinHashMapTest, SerializedJoinBuildFuncForPartialNullColumn) {
     auto nulls = create_bools(build_row_count, 4);
     check_build_index(nulls, table_items.first, table_items.next, build_row_count);
     check_build_slice(nulls, table_items.build_slice, build_row_count);
-}
-
-// NOLINTNEXTLINE
-TEST_F(JoinHashMapTest, BuildTupleOutputForTupleNotExist1) {
-    uint32_t build_row_count = 10;
-    uint32_t probe_row_count = 5;
-    auto uint8_array_1 = create_bools(build_row_count, 2);
-    auto uint8_array_2 = create_bools(build_row_count, 3);
-
-    ColumnPtr build_tuple_column_1 = create_tuple_column(uint8_array_1);
-    ColumnPtr build_tuple_column_2 = create_tuple_column(uint8_array_2);
-
-    JoinHashTableItems table_items;
-    table_items.build_chunk = std::make_shared<Chunk>();
-    table_items.build_chunk->append_tuple_column(build_tuple_column_1, 0);
-    table_items.build_chunk->append_tuple_column(build_tuple_column_2, 1);
-    table_items.output_build_tuple_ids = {0, 1};
-
-    HashTableProbeState probe_state;
-    probe_state.has_null_build_tuple = false;
-    probe_state.count = probe_row_count;
-    for (uint32_t i = 0; i < probe_row_count; i++) {
-        probe_state.build_index.emplace_back(i + 1);
-    }
-
-    ChunkPtr probe_chunk = std::make_shared<Chunk>();
-    auto join_hash_map = std::make_unique<JoinHashMapForOneKey(TYPE_INT)>(&table_items, &probe_state);
-    join_hash_map->_build_tuple_output(&probe_chunk);
-
-    // check
-    ASSERT_EQ(probe_chunk->num_columns(), 2);
-    ColumnPtr probe_tuple_column_1 = probe_chunk->get_tuple_column_by_id(0);
-    ColumnPtr probe_tuple_column_2 = probe_chunk->get_tuple_column_by_id(1);
-
-    for (uint32_t i = 0; i < probe_row_count; i++) {
-        ASSERT_EQ(probe_tuple_column_1->get(i).get_int8(), (i + 1) % 2 == 0);
-    }
-    for (uint32_t i = 0; i < probe_row_count; i++) {
-        ASSERT_EQ(probe_tuple_column_2->get(i).get_int8(), (i + 1) % 3 == 0);
-    }
-}
-
-// NOLINTNEXTLINE
-TEST_F(JoinHashMapTest, BuildTupleOutputForTupleNotExist2) {
-    // prepare data
-    uint32_t build_row_count = 10;
-    uint32_t probe_row_count = 5;
-    auto uint8_array_1 = create_bools(build_row_count, 2);
-    auto uint8_array_2 = create_bools(build_row_count, 3);
-
-    ColumnPtr build_tuple_column_1 = create_tuple_column(uint8_array_1);
-    ColumnPtr build_tuple_column_2 = create_tuple_column(uint8_array_2);
-
-    JoinHashTableItems table_items;
-    table_items.build_chunk = std::make_shared<Chunk>();
-    table_items.build_chunk->append_tuple_column(build_tuple_column_1, 0);
-    table_items.build_chunk->append_tuple_column(build_tuple_column_2, 1);
-    table_items.output_build_tuple_ids = {0, 1};
-
-    HashTableProbeState probe_state;
-    probe_state.has_null_build_tuple = true;
-    probe_state.count = probe_row_count;
-    for (uint32_t i = 0; i < probe_row_count; i++) {
-        if (i == 1 || i == 2) {
-            probe_state.build_index.emplace_back(0);
-        } else {
-            probe_state.build_index.emplace_back(i + 1);
-        }
-    }
-
-    // exec
-    ChunkPtr probe_chunk = std::make_shared<Chunk>();
-    auto join_hash_map = std::make_unique<JoinHashMapForOneKey(TYPE_INT)>(&table_items, &probe_state);
-    join_hash_map->_build_tuple_output(&probe_chunk);
-
-    // check
-    ASSERT_EQ(probe_chunk->num_columns(), 2);
-    ColumnPtr probe_tuple_column_1 = probe_chunk->get_tuple_column_by_id(0);
-    ColumnPtr probe_tuple_column_2 = probe_chunk->get_tuple_column_by_id(1);
-
-    for (uint32_t i = 0; i < probe_row_count; i++) {
-        if (i == 1 || i == 2) {
-            ASSERT_EQ(probe_tuple_column_1->get(i).get_int8(), 0);
-        } else {
-            ASSERT_EQ(probe_tuple_column_1->get(i).get_int8(), (i + 1) % 2 == 0);
-        }
-    }
-    for (uint32_t i = 0; i < probe_row_count; i++) {
-        if (i == 1 || i == 2) {
-            ASSERT_EQ(probe_tuple_column_2->get(i).get_int8(), 0);
-        } else {
-            ASSERT_EQ(probe_tuple_column_2->get(i).get_int8(), (i + 1) % 3 == 0);
-        }
-    }
-}
-
-// NOLINTNEXTLINE
-TEST_F(JoinHashMapTest, BuildTupleOutputForTupleExist1) {
-    // prepare data
-    uint32_t probe_row_count = 5;
-
-    JoinHashTableItems table_items;
-    table_items.build_chunk = std::make_shared<Chunk>();
-    table_items.output_build_tuple_ids = {0, 1};
-    table_items.right_to_nullable = true;
-
-    HashTableProbeState probe_state;
-    probe_state.has_null_build_tuple = true;
-    probe_state.count = probe_row_count;
-    for (uint32_t i = 0; i < probe_row_count; i++) {
-        probe_state.build_index.emplace_back(i + 1);
-    }
-
-    // exec
-    ChunkPtr probe_chunk = std::make_shared<Chunk>();
-    auto join_hash_map = std::make_unique<JoinHashMapForOneKey(TYPE_INT)>(&table_items, &probe_state);
-    join_hash_map->_build_tuple_output(&probe_chunk);
-
-    // check
-    ASSERT_EQ(probe_chunk->num_columns(), 2);
-    ColumnPtr probe_tuple_column_1 = probe_chunk->get_tuple_column_by_id(0);
-    ColumnPtr probe_tuple_column_2 = probe_chunk->get_tuple_column_by_id(1);
-
-    for (uint32_t i = 0; i < probe_row_count; i++) {
-        ASSERT_EQ(probe_tuple_column_1->get(i).get_int8(), 1);
-    }
-    for (uint32_t i = 0; i < probe_row_count; i++) {
-        ASSERT_EQ(probe_tuple_column_2->get(i).get_int8(), 1);
-    }
-}
-
-// NOLINTNEXTLINE
-TEST_F(JoinHashMapTest, BuildTupleOutputForTupleExist2) {
-    // prepare data
-    uint32_t probe_row_count = 5;
-
-    JoinHashTableItems table_items;
-    table_items.build_chunk = std::make_shared<Chunk>();
-    table_items.output_build_tuple_ids = {0, 1};
-    table_items.right_to_nullable = true;
-
-    HashTableProbeState probe_state;
-    probe_state.has_null_build_tuple = true;
-    probe_state.count = probe_row_count;
-    for (uint32_t i = 0; i < probe_row_count; i++) {
-        if (i == 1 || i == 2) {
-            probe_state.build_index.emplace_back(0);
-        } else {
-            probe_state.build_index.emplace_back(1);
-        }
-    }
-
-    // exec
-    ChunkPtr probe_chunk = std::make_shared<Chunk>();
-    auto join_hash_map = std::make_unique<JoinHashMapForOneKey(TYPE_INT)>(&table_items, &probe_state);
-    join_hash_map->_build_tuple_output(&probe_chunk);
-
-    // check
-    ASSERT_EQ(probe_chunk->num_columns(), 2);
-    ColumnPtr probe_tuple_column_1 = probe_chunk->get_tuple_column_by_id(0);
-    ColumnPtr probe_tuple_column_2 = probe_chunk->get_tuple_column_by_id(1);
-
-    for (uint32_t i = 0; i < probe_row_count; i++) {
-        if (i == 1 || i == 2) {
-            ASSERT_EQ(probe_tuple_column_1->get(i).get_int8(), 0);
-        } else {
-            ASSERT_EQ(probe_tuple_column_1->get(i).get_int8(), 1);
-        }
-    }
-    for (uint32_t i = 0; i < probe_row_count; i++) {
-        if (i == 1 || i == 2) {
-            ASSERT_EQ(probe_tuple_column_1->get(i).get_int8(), 0);
-        } else {
-            ASSERT_EQ(probe_tuple_column_2->get(i).get_int8(), 1);
-        }
-    }
-}
-
-// NOLINTNEXTLINE
-TEST_F(JoinHashMapTest, BuildTupleOutputForTupleExist3) {
-    // prepare data
-    uint32_t probe_row_count = 5;
-
-    JoinHashTableItems table_items;
-    table_items.build_chunk = std::make_shared<Chunk>();
-    table_items.output_build_tuple_ids = {0, 1};
-    table_items.right_to_nullable = false;
-
-    HashTableProbeState probe_state;
-    probe_state.has_null_build_tuple = true;
-    probe_state.count = probe_row_count;
-    for (uint32_t i = 0; i < probe_row_count; i++) {
-        probe_state.build_index.emplace_back(i + 1);
-    }
-
-    // exec
-    ChunkPtr probe_chunk = std::make_shared<Chunk>();
-    auto join_hash_map = std::make_unique<JoinHashMapForOneKey(TYPE_INT)>(&table_items, &probe_state);
-    join_hash_map->_build_tuple_output(&probe_chunk);
-
-    // check
-    ASSERT_EQ(probe_chunk->num_columns(), 0);
 }
 
 } // namespace starrocks::vectorized


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [x] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #467

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

_need_create_tuple_columns has already set to false in version 2.1
tuple column can be remove from hash join node in version 2.3
