### PR TITLE
Add try catch bad alloc for hash join build and probe

### DIFF
--- a/be/src/exec/vectorized/hash_join_node.cpp
+++ b/be/src/exec/vectorized/hash_join_node.cpp
@@ -220,13 +220,13 @@ Status HashJoinNode::open(RuntimeState* state) {
         {
             // copy chunk of right table
             SCOPED_TIMER(_copy_right_table_chunk_timer);
-            TRY_CATCH_BAD_ALLOC(RETURN_IF_ERROR(_ht.append_chunk(state, chunk)));
+            TRY_CATCH_BAD_ALLOC(_ht.append_chunk(state, chunk));
         }
     }
 
     {
         // build hash table: compute key columns, and then build the hash table.
-        TRY_CATCH_BAD_ALLOC(RETURN_IF_ERROR(_build(state)));
+        RETURN_IF_ERROR(_build(state));
         COUNTER_SET(_build_rows_counter, static_cast<int64_t>(_ht.get_row_count()));
         COUNTER_SET(_build_buckets_counter, static_cast<int64_t>(_ht.get_bucket_size()));
     }
@@ -549,7 +549,7 @@ Status HashJoinNode::_build(RuntimeState* state) {
 
     {
         SCOPED_TIMER(_build_ht_timer);
-        RETURN_IF_ERROR(_ht.build(state));
+        TRY_CATCH_BAD_ALLOC(_ht.build(state));
     }
 
     return Status::OK();
@@ -651,7 +651,7 @@ Status HashJoinNode::_probe(RuntimeState* state, ScopedTimer<MonotonicStopWatch>
             }
         }
 
-        RETURN_IF_ERROR(_ht.probe(state, _key_columns, &_probing_chunk, chunk, &_ht_has_remain));
+        TRY_CATCH_BAD_ALLOC(_ht.probe(state, _key_columns, &_probing_chunk, chunk, &_ht_has_remain));
         if (!_ht_has_remain) {
             _probing_chunk = nullptr;
         }
@@ -689,7 +689,7 @@ Status HashJoinNode::_probe_remain(ChunkPtr* chunk, bool& eos) {
     ScopedTimer<MonotonicStopWatch> probe_timer(_probe_timer);
 
     while (!_build_eos) {
-        RETURN_IF_ERROR(_ht.probe_remain(runtime_state(), chunk, &_right_table_has_remain));
+        TRY_CATCH_BAD_ALLOC(_ht.probe_remain(runtime_state(), chunk, &_right_table_has_remain));
 
         eval_join_runtime_filters(chunk);
 

--- a/be/src/exec/vectorized/join_hash_map.h
+++ b/be/src/exec/vectorized/join_hash_map.h
@@ -303,8 +303,8 @@ public:
 
     static void prepare(RuntimeState* runtime, JoinHashTableItems* table_items);
     static const Buffer<CppType>& get_key_data(const JoinHashTableItems& table_items);
-    static Status construct_hash_table(RuntimeState* state, JoinHashTableItems* table_items,
-                                       HashTableProbeState* probe_state);
+    static void construct_hash_table(RuntimeState* state, JoinHashTableItems* table_items,
+                                     HashTableProbeState* probe_state);
 };
 
 template <PrimitiveType PT>
@@ -315,8 +315,8 @@ public:
 
     static void prepare(RuntimeState* runtime, JoinHashTableItems* table_items);
     static const Buffer<CppType>& get_key_data(const JoinHashTableItems& table_items);
-    static Status construct_hash_table(RuntimeState* state, JoinHashTableItems* table_items,
-                                       HashTableProbeState* probe_state);
+    static void construct_hash_table(RuntimeState* state, JoinHashTableItems* table_items,
+                                     HashTableProbeState* probe_state);
 };
 
 template <PrimitiveType PT>
@@ -330,8 +330,8 @@ public:
     static const Buffer<CppType>& get_key_data(const JoinHashTableItems& table_items) {
         return ColumnHelper::as_raw_column<const ColumnType>(table_items.build_key_column)->get_data();
     }
-    static Status construct_hash_table(RuntimeState* state, JoinHashTableItems* table_items,
-                                       HashTableProbeState* probe_state);
+    static void construct_hash_table(RuntimeState* state, JoinHashTableItems* table_items,
+                                     HashTableProbeState* probe_state);
 
 private:
     static void _build_columns(JoinHashTableItems* table_items, HashTableProbeState* probe_state,
@@ -346,8 +346,8 @@ class SerializedJoinBuildFunc {
 public:
     static void prepare(RuntimeState* state, JoinHashTableItems* table_items);
     static const Buffer<Slice>& get_key_data(const JoinHashTableItems& table_items) { return table_items.build_slice; }
-    static Status construct_hash_table(RuntimeState* state, JoinHashTableItems* table_items,
-                                       HashTableProbeState* probe_state);
+    static void construct_hash_table(RuntimeState* state, JoinHashTableItems* table_items,
+                                     HashTableProbeState* probe_state);
 
 private:
     static void _build_columns(JoinHashTableItems* table_items, HashTableProbeState* probe_state,
@@ -365,7 +365,7 @@ public:
     using ColumnType = typename RunTimeTypeTraits<PT>::ColumnType;
 
     static void prepare(RuntimeState* state, HashTableProbeState* probe_state) {}
-    static Status lookup_init(const JoinHashTableItems& table_items, HashTableProbeState* probe_state);
+    static void lookup_init(const JoinHashTableItems& table_items, HashTableProbeState* probe_state);
     static const Buffer<CppType>& get_key_data(const HashTableProbeState& probe_state);
     static bool equal(const CppType& x, const CppType& y) { return x == y; }
 };
@@ -377,7 +377,7 @@ public:
     using ColumnType = typename RunTimeTypeTraits<PT>::ColumnType;
 
     static void prepare(RuntimeState* state, HashTableProbeState* probe_state) {}
-    static Status lookup_init(const JoinHashTableItems& table_items, HashTableProbeState* probe_state);
+    static void lookup_init(const JoinHashTableItems& table_items, HashTableProbeState* probe_state);
     static const Buffer<CppType>& get_key_data(const HashTableProbeState& probe_state);
     static bool equal(const CppType& x, const CppType& y) { return true; }
 };
@@ -394,7 +394,7 @@ public:
     }
 
     // serialize and calculate hash values for probe keys.
-    static Status lookup_init(const JoinHashTableItems& table_items, HashTableProbeState* probe_state);
+    static void lookup_init(const JoinHashTableItems& table_items, HashTableProbeState* probe_state);
 
     static const Buffer<CppType>& get_key_data(const HashTableProbeState& probe_state) {
         return ColumnHelper::as_raw_column<ColumnType>(probe_state.probe_key_column)->get_data();
@@ -419,7 +419,7 @@ public:
         probe_state->is_nulls.resize(state->chunk_size());
     }
 
-    static Status lookup_init(const JoinHashTableItems& table_items, HashTableProbeState* probe_state);
+    static void lookup_init(const JoinHashTableItems& table_items, HashTableProbeState* probe_state);
 
     static bool equal(const Slice& x, const Slice& y) { return x == y; }
 
@@ -441,19 +441,19 @@ public:
     void build_prepare(RuntimeState* state);
     void probe_prepare(RuntimeState* state);
 
-    Status build(RuntimeState* state);
-    Status probe(RuntimeState* state, const Columns& key_columns, ChunkPtr* probe_chunk, ChunkPtr* chunk,
-                 bool* has_remain);
-    Status probe_remain(RuntimeState* state, ChunkPtr* chunk, bool* has_remain);
+    void build(RuntimeState* state);
+    void probe(RuntimeState* state, const Columns& key_columns, ChunkPtr* probe_chunk, ChunkPtr* chunk,
+               bool* has_remain);
+    void probe_remain(RuntimeState* state, ChunkPtr* chunk, bool* has_remain);
 
 private:
-    Status _probe_output(ChunkPtr* probe_chunk, ChunkPtr* chunk);
+    void _probe_output(ChunkPtr* probe_chunk, ChunkPtr* chunk);
     void _probe_tuple_output(ChunkPtr* probe_chunk, ChunkPtr* chunk);
-    Status _probe_null_output(ChunkPtr* chunk, size_t count);
+    void _probe_null_output(ChunkPtr* chunk, size_t count);
 
-    Status _build_output(ChunkPtr* chunk);
+    void _build_output(ChunkPtr* chunk);
     void _build_tuple_output(ChunkPtr* chunk);
-    Status _build_default_output(ChunkPtr* chunk, size_t count);
+    void _build_default_output(ChunkPtr* chunk, size_t count);
 
     void _copy_probe_column(ColumnPtr* src_column, ChunkPtr* chunk, const SlotDescriptor* slot, bool to_nullable);
 
@@ -463,7 +463,7 @@ private:
 
     void _copy_build_nullable_column(const ColumnPtr& src_column, ChunkPtr* chunk, const SlotDescriptor* slot);
 
-    Status _search_ht(RuntimeState* state, ChunkPtr* probe_chunk);
+    void _search_ht(RuntimeState* state, ChunkPtr* probe_chunk);
     void _search_ht_remain(RuntimeState* state);
 
     template <bool first_probe>
@@ -573,11 +573,11 @@ public:
     void create(const HashTableParam& param);
     void close();
 
-    Status build(RuntimeState* state);
-    Status probe(RuntimeState* state, const Columns& key_columns, ChunkPtr* probe_chunk, ChunkPtr* chunk, bool* eos);
-    Status probe_remain(RuntimeState* state, ChunkPtr* chunk, bool* eos);
+    void build(RuntimeState* state);
+    void probe(RuntimeState* state, const Columns& key_columns, ChunkPtr* probe_chunk, ChunkPtr* chunk, bool* eos);
+    void probe_remain(RuntimeState* state, ChunkPtr* chunk, bool* eos);
 
-    Status append_chunk(RuntimeState* state, const ChunkPtr& chunk);
+    void append_chunk(RuntimeState* state, const ChunkPtr& chunk);
 
     const ChunkPtr& get_build_chunk() const { return _table_items->build_chunk; }
     Columns& get_key_columns() { return _table_items->key_columns; }
@@ -588,25 +588,7 @@ public:
 
     void remove_duplicate_index(Column::Filter* filter);
 
-    int64_t mem_usage() {
-        int64_t usage = 0;
-        if (_table_items->build_chunk != nullptr) {
-            usage += _table_items->build_chunk->memory_usage();
-        }
-        usage += _table_items->first.capacity() * sizeof(uint32_t);
-        usage += _table_items->next.capacity() * sizeof(uint32_t);
-        if (_table_items->build_pool != nullptr) {
-            usage += _table_items->build_pool->total_reserved_bytes();
-        }
-        if (_probe_state->probe_pool != nullptr) {
-            usage += _probe_state->probe_pool->total_reserved_bytes();
-        }
-        if (_table_items->build_key_column != nullptr) {
-            usage += _table_items->build_key_column->memory_usage();
-        }
-        usage += _table_items->build_slice.size() * sizeof(Slice);
-        return usage;
-    }
+    int64_t mem_usage();
 
 private:
     JoinHashMapType _choose_join_hash_map();

--- a/be/src/exec/vectorized/join_hash_map.tpp
+++ b/be/src/exec/vectorized/join_hash_map.tpp
@@ -22,8 +22,8 @@ const Buffer<typename JoinBuildFunc<PT>::CppType>& JoinBuildFunc<PT>::get_key_da
 }
 
 template <PrimitiveType PT>
-Status JoinBuildFunc<PT>::construct_hash_table(RuntimeState* state, JoinHashTableItems* table_items,
-                                               HashTableProbeState* probe_state) {
+void JoinBuildFunc<PT>::construct_hash_table(RuntimeState* state, JoinHashTableItems* table_items,
+                                             HashTableProbeState* probe_state) {
     auto& data = get_key_data(*table_items);
     if (table_items->key_columns[0]->is_nullable()) {
         auto* nullable_column = ColumnHelper::as_raw_column<NullableColumn>(table_items->key_columns[0]);
@@ -42,7 +42,6 @@ Status JoinBuildFunc<PT>::construct_hash_table(RuntimeState* state, JoinHashTabl
             table_items->first[bucket_num] = i;
         }
     }
-    return Status::OK();
 }
 
 template <PrimitiveType PT>
@@ -66,8 +65,8 @@ const Buffer<typename DirectMappingJoinBuildFunc<PT>::CppType>& DirectMappingJoi
 }
 
 template <PrimitiveType PT>
-Status DirectMappingJoinBuildFunc<PT>::construct_hash_table(RuntimeState* state, JoinHashTableItems* table_items,
-                                                            HashTableProbeState* probe_state) {
+void DirectMappingJoinBuildFunc<PT>::construct_hash_table(RuntimeState* state, JoinHashTableItems* table_items,
+                                                          HashTableProbeState* probe_state) {
     static constexpr CppType MIN_VALUE = RunTimeTypeLimits<PT>::min_value();
 
     auto& data = get_key_data(*table_items);
@@ -88,7 +87,6 @@ Status DirectMappingJoinBuildFunc<PT>::construct_hash_table(RuntimeState* state,
             table_items->first[buckets] = i;
         }
     }
-    return Status::OK();
 }
 
 template <PrimitiveType PT>
@@ -100,8 +98,8 @@ void FixedSizeJoinBuildFunc<PT>::prepare(RuntimeState* state, JoinHashTableItems
 }
 
 template <PrimitiveType PT>
-Status FixedSizeJoinBuildFunc<PT>::construct_hash_table(RuntimeState* state, JoinHashTableItems* table_items,
-                                                        HashTableProbeState* probe_state) {
+void FixedSizeJoinBuildFunc<PT>::construct_hash_table(RuntimeState* state, JoinHashTableItems* table_items,
+                                                      HashTableProbeState* probe_state) {
     uint32_t row_count = table_items->row_count;
 
     // prepare columns
@@ -138,7 +136,6 @@ Status FixedSizeJoinBuildFunc<PT>::construct_hash_table(RuntimeState* state, Joi
         }
         _build_columns(table_items, probe_state, data_columns, 1 + state->chunk_size() * quo, rem);
     }
-    return Status::OK();
 }
 
 template <PrimitiveType PT>
@@ -184,8 +181,8 @@ void FixedSizeJoinBuildFunc<PT>::_build_nullable_columns(JoinHashTableItems* tab
 }
 
 template <PrimitiveType PT>
-Status DirectMappingJoinProbeFunc<PT>::lookup_init(const JoinHashTableItems& table_items,
-                                                   HashTableProbeState* probe_state) {
+void DirectMappingJoinProbeFunc<PT>::lookup_init(const JoinHashTableItems& table_items,
+                                                 HashTableProbeState* probe_state) {
     static constexpr CppType MIN_VALUE = RunTimeTypeLimits<PT>::min_value();
     size_t probe_row_count = probe_state->probe_row_count;
     auto& data = get_key_data(*probe_state);
@@ -209,14 +206,13 @@ Status DirectMappingJoinProbeFunc<PT>::lookup_init(const JoinHashTableItems& tab
             }
             probe_state->null_array = nullptr;
         }
-        return Status::OK();
+        return;
     }
 
     for (size_t i = 0; i < probe_row_count; i++) {
         probe_state->next[i] = table_items.first[data[i] - MIN_VALUE];
     }
     probe_state->null_array = nullptr;
-    return Status::OK();
 }
 
 template <PrimitiveType PT>
@@ -231,7 +227,7 @@ const Buffer<typename DirectMappingJoinProbeFunc<PT>::CppType>& DirectMappingJoi
 }
 
 template <PrimitiveType PT>
-Status JoinProbeFunc<PT>::lookup_init(const JoinHashTableItems& table_items, HashTableProbeState* probe_state) {
+void JoinProbeFunc<PT>::lookup_init(const JoinHashTableItems& table_items, HashTableProbeState* probe_state) {
     size_t probe_row_count = probe_state->probe_row_count;
     auto& data = get_key_data(*probe_state);
     JoinHashMapHelper::calc_bucket_nums<CppType>(data, table_items.bucket_size, &probe_state->buckets, 0, data.size());
@@ -255,14 +251,13 @@ Status JoinProbeFunc<PT>::lookup_init(const JoinHashTableItems& table_items, Has
             }
             probe_state->null_array = nullptr;
         }
-        return Status::OK();
+        return;
     }
 
     for (size_t i = 0; i < probe_row_count; i++) {
         probe_state->next[i] = table_items.first[probe_state->buckets[i]];
     }
     probe_state->null_array = nullptr;
-    return Status::OK();
 }
 
 template <PrimitiveType PT>
@@ -277,8 +272,7 @@ const Buffer<typename JoinProbeFunc<PT>::CppType>& JoinProbeFunc<PT>::get_key_da
 }
 
 template <PrimitiveType PT>
-Status FixedSizeJoinProbeFunc<PT>::lookup_init(const JoinHashTableItems& table_items,
-                                               HashTableProbeState* probe_state) {
+void FixedSizeJoinProbeFunc<PT>::lookup_init(const JoinHashTableItems& table_items, HashTableProbeState* probe_state) {
     // prepare columns
     Columns data_columns;
     NullColumns null_columns;
@@ -309,7 +303,6 @@ Status FixedSizeJoinProbeFunc<PT>::lookup_init(const JoinHashTableItems& table_i
     } else {
         _probe_column(table_items, probe_state, data_columns);
     }
-    return Status::OK();
 }
 
 template <PrimitiveType PT>
@@ -381,20 +374,20 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::probe_prepare(RuntimeState* state) {
 }
 
 template <PrimitiveType PT, class BuildFunc, class ProbeFunc>
-Status JoinHashMap<PT, BuildFunc, ProbeFunc>::build(RuntimeState* state) {
-    return BuildFunc().construct_hash_table(state, _table_items, _probe_state);
+void JoinHashMap<PT, BuildFunc, ProbeFunc>::build(RuntimeState* state) {
+    BuildFunc().construct_hash_table(state, _table_items, _probe_state);
 }
 
 template <PrimitiveType PT, class BuildFunc, class ProbeFunc>
-Status JoinHashMap<PT, BuildFunc, ProbeFunc>::probe(RuntimeState* state, const Columns& key_columns,
-                                                    ChunkPtr* probe_chunk, ChunkPtr* chunk, bool* has_remain) {
+void JoinHashMap<PT, BuildFunc, ProbeFunc>::probe(RuntimeState* state, const Columns& key_columns,
+                                                  ChunkPtr* probe_chunk, ChunkPtr* chunk, bool* has_remain) {
     _probe_state->key_columns = &key_columns;
     {
         SCOPED_TIMER(_probe_state->search_ht_timer);
-        RETURN_IF_ERROR(_search_ht(state, probe_chunk));
+        _search_ht(state, probe_chunk);
         if (_probe_state->count <= 0) {
             *has_remain = false;
-            return Status::OK();
+            return;
         }
 
         *has_remain = _probe_state->has_remain;
@@ -408,14 +401,14 @@ Status JoinHashMap<PT, BuildFunc, ProbeFunc>::probe(RuntimeState* state, const C
             // output default values for probe-columns as placeholder.
             SCOPED_TIMER(_probe_state->output_probe_column_timer);
             if (!_table_items->with_other_conjunct) {
-                RETURN_IF_ERROR(_probe_null_output(chunk, _probe_state->count));
+                _probe_null_output(chunk, _probe_state->count);
             } else {
-                RETURN_IF_ERROR(_probe_output(probe_chunk, chunk));
+                _probe_output(probe_chunk, chunk);
             }
         }
         {
             SCOPED_TIMER(_table_items->output_build_column_timer);
-            RETURN_IF_ERROR(_build_output(chunk));
+            _build_output(chunk);
         }
         {
             SCOPED_TIMER(_probe_state->output_tuple_column_timer);
@@ -431,15 +424,15 @@ Status JoinHashMap<PT, BuildFunc, ProbeFunc>::probe(RuntimeState* state, const C
         // don't need output the real build column
         {
             SCOPED_TIMER(_probe_state->output_probe_column_timer);
-            RETURN_IF_ERROR(_probe_output(probe_chunk, chunk));
+            _probe_output(probe_chunk, chunk);
         }
         {
             // output default values for build-columns as placeholder.
             SCOPED_TIMER(_table_items->output_build_column_timer);
             if (!_table_items->with_other_conjunct) {
-                RETURN_IF_ERROR(_build_default_output(chunk, _probe_state->count));
+                _build_default_output(chunk, _probe_state->count);
             } else {
-                RETURN_IF_ERROR(_build_output(chunk));
+                _build_output(chunk);
             }
         }
         {
@@ -451,11 +444,11 @@ Status JoinHashMap<PT, BuildFunc, ProbeFunc>::probe(RuntimeState* state, const C
     } else {
         {
             SCOPED_TIMER(_probe_state->output_probe_column_timer);
-            RETURN_IF_ERROR(_probe_output(probe_chunk, chunk));
+            _probe_output(probe_chunk, chunk);
         }
         {
             SCOPED_TIMER(_table_items->output_build_column_timer);
-            RETURN_IF_ERROR(_build_output(chunk));
+            _build_output(chunk);
         }
         {
             SCOPED_TIMER(_probe_state->output_tuple_column_timer);
@@ -465,31 +458,29 @@ Status JoinHashMap<PT, BuildFunc, ProbeFunc>::probe(RuntimeState* state, const C
             }
         }
     }
-
-    return Status::OK();
 }
 
 template <PrimitiveType PT, class BuildFunc, class ProbeFunc>
-Status JoinHashMap<PT, BuildFunc, ProbeFunc>::probe_remain(RuntimeState* state, ChunkPtr* chunk, bool* has_remain) {
+void JoinHashMap<PT, BuildFunc, ProbeFunc>::probe_remain(RuntimeState* state, ChunkPtr* chunk, bool* has_remain) {
     _search_ht_remain(state);
     if (_probe_state->count <= 0) {
         *has_remain = false;
-        return Status::OK();
+        return;
     }
     *has_remain = _probe_state->has_remain;
 
     if (_table_items->join_type == TJoinOp::RIGHT_ANTI_JOIN || _table_items->join_type == TJoinOp::RIGHT_SEMI_JOIN) {
         // right anti/semi join without other conjunct output default value of probe-columns as placeholder.
-        RETURN_IF_ERROR(_probe_null_output(chunk, _probe_state->count));
-        RETURN_IF_ERROR(_build_output(chunk));
+        _probe_null_output(chunk, _probe_state->count);
+        _build_output(chunk);
 
         if (_table_items->need_create_tuple_columns) {
             _build_tuple_output(chunk);
         }
     } else {
         // RIGHT_OUTER_JOIN || FULL_OUTER_JOIN
-        RETURN_IF_ERROR(_probe_null_output(chunk, _probe_state->count));
-        RETURN_IF_ERROR(_build_output(chunk));
+        _probe_null_output(chunk, _probe_state->count);
+        _build_output(chunk);
 
         if (_table_items->need_create_tuple_columns) {
             for (int tuple_id : _table_items->output_probe_tuple_ids) {
@@ -499,11 +490,10 @@ Status JoinHashMap<PT, BuildFunc, ProbeFunc>::probe_remain(RuntimeState* state, 
             _build_tuple_output(chunk);
         }
     }
-    return Status::OK();
 }
 
 template <PrimitiveType PT, class BuildFunc, class ProbeFunc>
-Status JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_output(ChunkPtr* probe_chunk, ChunkPtr* chunk) {
+void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_output(ChunkPtr* probe_chunk, ChunkPtr* chunk) {
     bool to_nullable = _table_items->left_to_nullable;
 
     for (size_t i = 0; i < _table_items->probe_column_count; i++) {
@@ -522,8 +512,6 @@ Status JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_output(ChunkPtr* probe_chun
             (*chunk)->append_column(std::move(default_column), slot->id());
         }
     }
-
-    return Status::OK();
 }
 
 template <PrimitiveType PT, class BuildFunc, class ProbeFunc>
@@ -560,19 +548,17 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_tuple_output(ChunkPtr* probe_
 }
 
 template <PrimitiveType PT, class BuildFunc, class ProbeFunc>
-Status JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_null_output(ChunkPtr* chunk, size_t count) {
+void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_null_output(ChunkPtr* chunk, size_t count) {
     for (size_t i = 0; i < _table_items->probe_column_count; i++) {
         SlotDescriptor* slot = _table_items->probe_slots[i].slot;
         ColumnPtr column = ColumnHelper::create_column(slot->type(), true);
         column->append_nulls(count);
         (*chunk)->append_column(std::move(column), slot->id());
     }
-
-    return Status::OK();
 }
 
 template <PrimitiveType PT, class BuildFunc, class ProbeFunc>
-Status JoinHashMap<PT, BuildFunc, ProbeFunc>::_build_output(ChunkPtr* chunk) {
+void JoinHashMap<PT, BuildFunc, ProbeFunc>::_build_output(ChunkPtr* chunk) {
     bool to_nullable = _table_items->right_to_nullable;
     for (size_t i = 0; i < _table_items->build_column_count; i++) {
         HashTableSlotDescriptor hash_table_slot = _table_items->build_slots[i];
@@ -590,8 +576,6 @@ Status JoinHashMap<PT, BuildFunc, ProbeFunc>::_build_output(ChunkPtr* chunk) {
             (*chunk)->append_column(std::move(default_column), slot->id());
         }
     }
-
-    return Status::OK();
 }
 
 template <PrimitiveType PT, class BuildFunc, class ProbeFunc>
@@ -643,15 +627,13 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_build_tuple_output(ChunkPtr* chunk)
 }
 
 template <PrimitiveType PT, class BuildFunc, class ProbeFunc>
-Status JoinHashMap<PT, BuildFunc, ProbeFunc>::_build_default_output(ChunkPtr* chunk, size_t count) {
+void JoinHashMap<PT, BuildFunc, ProbeFunc>::_build_default_output(ChunkPtr* chunk, size_t count) {
     for (size_t i = 0; i < _table_items->build_column_count; i++) {
         SlotDescriptor* slot = _table_items->build_slots[i].slot;
         ColumnPtr column = ColumnHelper::create_column(slot->type(), true);
         column->append_nulls(count);
         (*chunk)->append_column(std::move(column), slot->id());
     }
-
-    return Status::OK();
 }
 
 template <PrimitiveType PT, class BuildFunc, class ProbeFunc>
@@ -744,10 +726,10 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_copy_build_nullable_column(const Co
 }
 
 template <PrimitiveType PT, class BuildFunc, class ProbeFunc>
-Status JoinHashMap<PT, BuildFunc, ProbeFunc>::_search_ht(RuntimeState* state, ChunkPtr* probe_chunk) {
+void JoinHashMap<PT, BuildFunc, ProbeFunc>::_search_ht(RuntimeState* state, ChunkPtr* probe_chunk) {
     if (!_probe_state->has_remain) {
         _probe_state->probe_row_count = (*probe_chunk)->num_rows();
-        RETURN_IF_ERROR(ProbeFunc().lookup_init(*_table_items, _probe_state));
+        ProbeFunc().lookup_init(*_table_items, _probe_state);
 
         auto& build_data = BuildFunc().get_key_data(*_table_items);
         auto& probe_data = ProbeFunc().get_key_data(*_probe_state);
@@ -757,7 +739,6 @@ Status JoinHashMap<PT, BuildFunc, ProbeFunc>::_search_ht(RuntimeState* state, Ch
         auto& probe_data = ProbeFunc().get_key_data(*_probe_state);
         _search_ht_impl<false>(state, build_data, probe_data);
     }
-    return Status::OK();
 }
 
 template <PrimitiveType PT, class BuildFunc, class ProbeFunc>

--- a/be/test/exec/vectorized/join_hash_map_test.cpp
+++ b/be/test/exec/vectorized/join_hash_map_test.cpp
@@ -970,10 +970,10 @@ TEST_F(JoinHashMapTest, DirectMappingJoinBuildProbeFunc) {
 
     // build and probe
     ht.create(param);
-    ASSERT_TRUE(ht.append_chunk(_runtime_state.get(), build_chunk).ok());
+    ht.append_chunk(_runtime_state.get(), build_chunk);
     ht.get_key_columns().emplace_back(ht._table_items->build_chunk->columns()[0]);
-    ASSERT_TRUE(ht.build(_runtime_state.get()).ok());
-    ASSERT_TRUE(ht.probe(_runtime_state.get(), probe_key_columns, &probe_chunk, &result_chunk, &eos).ok());
+    ht.build(_runtime_state.get());
+    ht.probe(_runtime_state.get(), probe_key_columns, &probe_chunk, &result_chunk, &eos);
 
     // check
     ASSERT_EQ(result_chunk->columns().size(), 2);
@@ -1034,10 +1034,10 @@ TEST_F(JoinHashMapTest, DirectMappingJoinBuildProbeFuncNullable) {
 
     // build and probe
     ht.create(param);
-    ASSERT_TRUE(ht.append_chunk(_runtime_state.get(), build_chunk).ok());
+    ht.append_chunk(_runtime_state.get(), build_chunk);
     ht.get_key_columns().emplace_back(ht._table_items->build_chunk->columns()[0]);
-    ASSERT_TRUE(ht.build(_runtime_state.get()).ok());
-    ASSERT_TRUE(ht.probe(_runtime_state.get(), probe_key_columns, &probe_chunk, &result_chunk, &eos).ok());
+    ht.build(_runtime_state.get());
+    ht.probe(_runtime_state.get(), probe_key_columns, &probe_chunk, &result_chunk, &eos);
 
     // check
     ASSERT_EQ(result_chunk->columns().size(), 2);
@@ -1670,14 +1670,14 @@ TEST_F(JoinHashMapTest, OneKeyJoinHashTable) {
     Columns probe_key_columns;
     probe_key_columns.emplace_back(probe_chunk->columns()[0]);
 
-    ASSERT_TRUE(hash_table.append_chunk(runtime_state.get(), build_chunk).ok());
+    hash_table.append_chunk(runtime_state.get(), build_chunk);
     hash_table.get_key_columns().emplace_back(hash_table.get_build_chunk()->columns()[0]);
-    ASSERT_TRUE(hash_table.build(runtime_state.get()).ok());
+    hash_table.build(runtime_state.get());
 
     ChunkPtr result_chunk = std::make_shared<Chunk>();
     bool eos = false;
 
-    ASSERT_TRUE(hash_table.probe(runtime_state.get(), probe_key_columns, &probe_chunk, &result_chunk, &eos).ok());
+    hash_table.probe(runtime_state.get(), probe_key_columns, &probe_chunk, &result_chunk, &eos);
 
     ASSERT_EQ(result_chunk->num_columns(), 6);
 
@@ -1732,14 +1732,14 @@ TEST_F(JoinHashMapTest, OneNullableKeyJoinHashTable) {
     Columns probe_key_columns;
     probe_key_columns.emplace_back(probe_chunk->columns()[0]);
 
-    ASSERT_TRUE(hash_table.append_chunk(runtime_state.get(), build_chunk).ok());
+    hash_table.append_chunk(runtime_state.get(), build_chunk);
     hash_table.get_key_columns().emplace_back(hash_table.get_build_chunk()->columns()[0]);
-    ASSERT_TRUE(hash_table.build(runtime_state.get()).ok());
+    hash_table.build(runtime_state.get());
 
     ChunkPtr result_chunk = std::make_shared<Chunk>();
     bool eos = false;
 
-    ASSERT_TRUE(hash_table.probe(runtime_state.get(), probe_key_columns, &probe_chunk, &result_chunk, &eos).ok());
+    hash_table.probe(runtime_state.get(), probe_key_columns, &probe_chunk, &result_chunk, &eos);
 
     ASSERT_EQ(result_chunk->num_columns(), 6);
 
@@ -1797,15 +1797,15 @@ TEST_F(JoinHashMapTest, FixedSizeJoinHashTable) {
     probe_key_columns.emplace_back(probe_chunk->columns()[0]);
     probe_key_columns.emplace_back(probe_chunk->columns()[1]);
 
-    ASSERT_TRUE(hash_table.append_chunk(runtime_state.get(), build_chunk).ok());
+    hash_table.append_chunk(runtime_state.get(), build_chunk);
     hash_table.get_key_columns().emplace_back(hash_table.get_build_chunk()->columns()[0]);
     hash_table.get_key_columns().emplace_back(hash_table.get_build_chunk()->columns()[1]);
-    ASSERT_TRUE(hash_table.build(runtime_state.get()).ok());
+    hash_table.build(runtime_state.get());
 
     ChunkPtr result_chunk = std::make_shared<Chunk>();
     bool eos = false;
 
-    ASSERT_TRUE(hash_table.probe(runtime_state.get(), probe_key_columns, &probe_chunk, &result_chunk, &eos).ok());
+    hash_table.probe(runtime_state.get(), probe_key_columns, &probe_chunk, &result_chunk, &eos);
 
     ASSERT_EQ(result_chunk->num_columns(), 6);
 
@@ -1860,15 +1860,15 @@ TEST_F(JoinHashMapTest, SerializeJoinHashTable) {
     probe_key_columns.emplace_back(probe_chunk->columns()[0]);
     probe_key_columns.emplace_back(probe_chunk->columns()[1]);
 
-    ASSERT_TRUE(hash_table.append_chunk(runtime_state.get(), build_chunk).ok());
+    hash_table.append_chunk(runtime_state.get(), build_chunk);
     hash_table.get_key_columns().emplace_back(hash_table.get_build_chunk()->columns()[0]);
     hash_table.get_key_columns().emplace_back(hash_table.get_build_chunk()->columns()[1]);
-    ASSERT_TRUE(hash_table.build(runtime_state.get()).ok());
+    hash_table.build(runtime_state.get());
 
     ChunkPtr result_chunk = std::make_shared<Chunk>();
     bool eos = false;
 
-    ASSERT_TRUE(hash_table.probe(runtime_state.get(), probe_key_columns, &probe_chunk, &result_chunk, &eos).ok());
+    hash_table.probe(runtime_state.get(), probe_key_columns, &probe_chunk, &result_chunk, &eos);
 
     ASSERT_EQ(result_chunk->num_columns(), 6);
 

--- a/be/test/exec/vectorized/join_hash_map_test.cpp
+++ b/be/test/exec/vectorized/join_hash_map_test.cpp
@@ -787,8 +787,7 @@ TEST_F(JoinHashMapTest, ProbeNullOutput) {
     auto join_hash_map = std::make_unique<JoinHashMapForOneKey(TYPE_INT)>(&table_items, &probe_state);
 
     auto chunk = std::make_shared<Chunk>();
-    auto status = join_hash_map->_probe_null_output(&chunk, 2);
-    ASSERT_TRUE(status.ok());
+    join_hash_map->_probe_null_output(&chunk, 2);
 
     ASSERT_EQ(chunk->num_columns(), 3);
 
@@ -823,8 +822,7 @@ TEST_F(JoinHashMapTest, BuildDefaultOutput) {
 
     auto chunk = std::make_shared<Chunk>();
     auto join_hash_map = std::make_unique<JoinHashMapForOneKey(TYPE_INT)>(&table_items, &probe_state);
-    auto status = join_hash_map->_build_default_output(&chunk, 2);
-    ASSERT_TRUE(status.ok());
+    join_hash_map->_build_default_output(&chunk, 2);
 
     ASSERT_EQ(chunk->num_columns(), 3);
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

HashTable for HashJoin is exception safe, add TryCatchBadAlloc for hash join build and probe to prohibit allocating excess memory
