### PR TITLE
Fix: finish analytic sink after reached limit

### DIFF
--- a/be/src/exec/pipeline/analysis/analytic_sink_operator.cpp
+++ b/be/src/exec/pipeline/analysis/analytic_sink_operator.cpp
@@ -92,6 +92,10 @@ Status AnalyticSinkOperator::push_chunk(RuntimeState* state, const vectorized::C
 
 Status AnalyticSinkOperator::_process_by_partition_if_necessary() {
     while (_analytor->has_output()) {
+        if (_analytor->reached_limit()) {
+            return Status::OK();
+        }
+
         int64_t found_partition_end = _analytor->find_partition_end();
         // Only process after all the data in a partition is reached
         if (!_analytor->is_partition_finished(found_partition_end)) {
@@ -114,9 +118,6 @@ Status AnalyticSinkOperator::_process_by_partition_if_necessary() {
             vectorized::ChunkPtr chunk;
             RETURN_IF_ERROR(_analytor->output_result_chunk(&chunk));
             _analytor->offer_chunk_to_buffer(chunk);
-            if (_analytor->reached_limit()) {
-                return Status::OK();
-            }
         }
     }
     return Status::OK();

--- a/be/src/exec/pipeline/analysis/analytic_sink_operator.h
+++ b/be/src/exec/pipeline/analysis/analytic_sink_operator.h
@@ -17,7 +17,7 @@ public:
 
     bool has_output() const override { return false; }
     bool need_input() const override { return !is_finished(); }
-    bool is_finished() const override { return _is_finished || _analytor->is_finished(); }
+    bool is_finished() const override { return _is_finished || _analytor->reached_limit() || _analytor->is_finished(); }
     void set_finishing(RuntimeState* state) override;
 
     Status prepare(RuntimeState* state) override;


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3995.

## Problem Summary ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

`AnalyticSinkOperator` could call `analytor->output_result_chunk()`, although it has already reached limit in the last `output_result_chunk()`. When triggering `reached_limit()` twice, `num_rows_over = _num_rows_returned - _limit` will be greater than the size of output_chunk, which causes `output_chunk->num_rows() - num_rows_over` overflows.

This bug was hidden util the PR #3848, because `_process_by_partition_if_necessary` could only be invoked  one time by `set_finishing` before.


