### PR TITLE
Support creating and dropping olap table with StarOSTablet

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -448,6 +448,8 @@ public class Catalog {
 
     private WorkGroupMgr workGroupMgr;
 
+    private StarOSAgent starOSAgent;
+
     public List<Frontend> getFrontends(FrontendNodeType nodeType) {
         if (nodeType == null) {
             // get all
@@ -623,6 +625,8 @@ public class Catalog {
         this.pluginMgr = new PluginMgr();
         this.auditEventProcessor = new AuditEventProcessor(this.pluginMgr);
         this.analyzeManager = new AnalyzeManager();
+
+        this.starOSAgent = new StarOSAgent();
     }
 
     public static void destroyCheckpoint() {
@@ -753,6 +757,10 @@ public class Catalog {
 
     public static AuditEventProcessor getCurrentAuditEventProcessor() {
         return getCurrentCatalog().getAuditEventProcessor();
+    }
+
+    public StarOSAgent getStarOSAgent() {
+        return starOSAgent;
     }
 
     // Use tryLock to avoid potential dead lock
@@ -1608,6 +1616,7 @@ public class Catalog {
                     long partitionId = partition.getId();
                     TStorageMedium medium = olapTable.getPartitionInfo().getDataProperty(
                             partitionId).getStorageMedium();
+                    boolean useStarOS = partition.isUseStarOS();
                     for (MaterializedIndex index : partition.getMaterializedIndices(IndexExtState.ALL)) {
                         long indexId = index.getId();
                         int schemaHash = olapTable.getSchemaHashByIndexId(indexId);
@@ -1615,11 +1624,13 @@ public class Catalog {
                         for (Tablet tablet : index.getTablets()) {
                             long tabletId = tablet.getId();
                             invertedIndex.addTablet(tabletId, tabletMeta);
-                            for (Replica replica : ((LocalTablet) tablet).getReplicas()) {
-                                invertedIndex.addReplica(tabletId, replica);
-                                if (MetaContext.get().getMetaVersion() < FeMetaVersion.VERSION_48) {
-                                    // set replica's schema hash
-                                    replica.setSchemaHash(schemaHash);
+                            if (!useStarOS) {
+                                for (Replica replica : ((LocalTablet) tablet).getReplicas()) {
+                                    invertedIndex.addReplica(tabletId, replica);
+                                    if (MetaContext.get().getMetaVersion() < FeMetaVersion.VERSION_48) {
+                                        // set replica's schema hash
+                                        replica.setSchemaHash(schemaHash);
+                                    }
                                 }
                             }
                         }
@@ -3620,29 +3631,31 @@ public class Catalog {
 
     private Partition createPartition(Database db, OlapTable table, long partitionId, String partitionName,
                                       Long version, Set<Long> tabletIdSet) throws DdlException {
-        return createPartitionCommon(db, table, partitionId, partitionName,
-                table.getPartitionInfo().getReplicationNum(partitionId),
-                table.getPartitionInfo().getDataProperty(partitionId).getStorageMedium(),
-                version, tabletIdSet);
+        return createPartitionCommon(db, table, partitionId, partitionName, table.getPartitionInfo(), version,
+                tabletIdSet);
     }
 
     private Partition createPartitionCommon(Database db, OlapTable table, long partitionId, String partitionName,
-                                            short replicationNum, TStorageMedium storageMedium,
-                                            Long version, Set<Long> tabletIdSet) throws DdlException {
+                                            PartitionInfo partitionInfo, Long version, Set<Long> tabletIdSet)
+            throws DdlException {
         Map<Long, MaterializedIndex> indexMap = new HashMap<>();
         for (long indexId : table.getIndexIdToMeta().keySet()) {
             MaterializedIndex rollup = new MaterializedIndex(indexId, IndexState.NORMAL);
+            rollup.setUseStarOS(partitionInfo.isUseStarOS(partitionId));
             indexMap.put(indexId, rollup);
         }
         DistributionInfo distributionInfo = table.getDefaultDistributionInfo();
         Partition partition =
                 new Partition(partitionId, partitionName, indexMap.get(table.getBaseIndexId()), distributionInfo);
+        partition.setPartitionInfo(partitionInfo);
 
         // version
         if (version != null) {
             partition.updateVisibleVersion(version);
         }
 
+        short replicationNum = partitionInfo.getReplicationNum(partitionId);
+        TStorageMedium storageMedium = partitionInfo.getDataProperty(partitionId).getStorageMedium();
         for (Map.Entry<Long, MaterializedIndex> entry : indexMap.entrySet()) {
             long indexId = entry.getKey();
             MaterializedIndex index = entry.getValue();
@@ -3796,11 +3809,12 @@ public class Catalog {
     private List<CreateReplicaTask> buildCreateReplicaTasks(long dbId, OlapTable table, Partition partition,
                                                             MaterializedIndex index) {
         List<CreateReplicaTask> tasks = new ArrayList<>((int) index.getReplicaCount());
+        boolean useStarOS = partition.isUseStarOS();
         MaterializedIndexMeta indexMeta = table.getIndexMetaByIndexId(index.getId());
         for (Tablet tablet : index.getTablets()) {
-            for (Replica replica : ((LocalTablet) tablet).getReplicas()) {
+            if (useStarOS) {
                 CreateReplicaTask task = new CreateReplicaTask(
-                        replica.getBackendId(),
+                        ((StarOSTablet) tablet).getPrimaryBackendId(),
                         dbId,
                         table.getId(),
                         partition.getId(),
@@ -3820,6 +3834,30 @@ public class Catalog {
                         table.getPartitionInfo().getIsInMemory(partition.getId()),
                         table.getPartitionInfo().getTabletType(partition.getId()));
                 tasks.add(task);
+            } else {
+                for (Replica replica : ((LocalTablet) tablet).getReplicas()) {
+                    CreateReplicaTask task = new CreateReplicaTask(
+                            replica.getBackendId(),
+                            dbId,
+                            table.getId(),
+                            partition.getId(),
+                            index.getId(),
+                            tablet.getId(),
+                            indexMeta.getShortKeyColumnCount(),
+                            indexMeta.getSchemaHash(),
+                            partition.getVisibleVersion(),
+                            indexMeta.getKeysType(),
+                            indexMeta.getStorageType(),
+                            table.getPartitionInfo().getDataProperty(partition.getId()).getStorageMedium(),
+                            indexMeta.getSchema(),
+                            table.getBfColumns(),
+                            table.getBfFpp(),
+                            null,
+                            table.getIndexes(),
+                            table.getPartitionInfo().getIsInMemory(partition.getId()),
+                            table.getPartitionInfo().getTabletType(partition.getId()));
+                    tasks.add(task);
+                }
             }
         }
         return tasks;
@@ -4764,6 +4802,7 @@ public class Catalog {
                     long partitionId = partition.getId();
                     TStorageMedium medium = olapTable.getPartitionInfo().getDataProperty(
                             partitionId).getStorageMedium();
+                    boolean useStarOS = partition.isUseStarOS();
                     for (MaterializedIndex mIndex : partition.getMaterializedIndices(IndexExtState.ALL)) {
                         long indexId = mIndex.getId();
                         int schemaHash = olapTable.getSchemaHashByIndexId(indexId);
@@ -4771,8 +4810,10 @@ public class Catalog {
                         for (Tablet tablet : mIndex.getTablets()) {
                             long tabletId = tablet.getId();
                             invertedIndex.addTablet(tabletId, tabletMeta);
-                            for (Replica replica : ((LocalTablet) tablet).getReplicas()) {
-                                invertedIndex.addReplica(tabletId, replica);
+                            if (!useStarOS) {
+                                for (Replica replica : ((LocalTablet) tablet).getReplicas()) {
+                                    invertedIndex.addReplica(tabletId, replica);
+                                }
                             }
                         }
                     }
@@ -4788,7 +4829,21 @@ public class Catalog {
         Preconditions.checkArgument(replicationNum > 0);
 
         DistributionInfoType distributionInfoType = distributionInfo.getType();
-        if (distributionInfoType == DistributionInfoType.HASH) {
+        if (distributionInfoType != DistributionInfoType.HASH) {
+            throw new DdlException("Unknown distribution type: " + distributionInfoType);
+        }
+
+        if (tabletMeta.isUseStarOS()) {
+            // TODO: support colocate table and drop shards when creating table failed
+            int bucketNum = distributionInfo.getBucketNum();
+            List<Long> shardIds = starOSAgent.createShards(bucketNum);
+            Preconditions.checkState(bucketNum == shardIds.size());
+            for (long shardId : shardIds) {
+                Tablet tablet = new StarOSTablet(getNextId(), shardId);
+                index.addTablet(tablet, tabletMeta);
+                tabletIdSet.add(tablet.getId());
+            }
+        } else {
             ColocateTableIndex colocateIndex = Catalog.getCurrentColocateIndex();
             List<List<Long>> backendsPerBucketSeq = null;
             GroupId groupId = null;
@@ -4855,9 +4910,6 @@ public class Catalog {
                         ColocatePersistInfo.createForBackendsPerBucketSeq(groupId, backendsPerBucketSeq);
                 editLog.logColocateBackendsPerBucketSeq(info);
             }
-
-        } else {
-            throw new DdlException("Unknown distribution type: " + distributionInfoType);
         }
     }
 
@@ -7509,12 +7561,18 @@ public class Catalog {
                     int schemaHash = olapTable.getSchemaHashByIndexId(indexId);
                     for (Tablet tablet : materializedIndex.getTablets()) {
                         long tabletId = tablet.getId();
-                        List<Replica> replicas = ((LocalTablet) tablet).getReplicas();
-                        for (Replica replica : replicas) {
-                            long backendId = replica.getBackendId();
-                            DropReplicaTask dropTask = new DropReplicaTask(backendId, tabletId, schemaHash, true);
+                        if (partition.isUseStarOS()) {
+                            DropReplicaTask dropTask = new DropReplicaTask(
+                                    ((StarOSTablet) tablet).getPrimaryBackendId(), tabletId, schemaHash, true);
                             batchTask.addTask(dropTask);
-                        } // end for replicas
+                        } else {
+                            List<Replica> replicas = ((LocalTablet) tablet).getReplicas();
+                            for (Replica replica : replicas) {
+                                long backendId = replica.getBackendId();
+                                DropReplicaTask dropTask = new DropReplicaTask(backendId, tabletId, schemaHash, true);
+                                batchTask.addTask(dropTask);
+                            } // end for replicas
+                        }
                     } // end for tablets
                 } // end for indices
             } // end for partitions

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
@@ -596,6 +596,7 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
             for (Partition partition : olapTable.getAllPartitions()) {
                 long partitionId = partition.getId();
                 TStorageMedium medium = olapTable.getPartitionInfo().getDataProperty(partitionId).getStorageMedium();
+                boolean useStarOS = partition.isUseStarOS();
                 for (MaterializedIndex index : partition.getMaterializedIndices(IndexExtState.ALL)) {
                     long indexId = index.getId();
                     int schemaHash = olapTable.getSchemaHashByIndexId(indexId);
@@ -603,8 +604,10 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
                     for (Tablet tablet : index.getTablets()) {
                         long tabletId = tablet.getId();
                         invertedIndex.addTablet(tabletId, tabletMeta);
-                        for (Replica replica : ((LocalTablet) tablet).getReplicas()) {
-                            invertedIndex.addReplica(tabletId, replica);
+                        if (!useStarOS) {
+                            for (Replica replica : ((LocalTablet) tablet).getReplicas()) {
+                                invertedIndex.addReplica(tabletId, replica);
+                            }
                         }
                     }
                 } // end for indices
@@ -617,6 +620,7 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
             long tableId = partitionInfo.getTableId();
             Partition partition = partitionInfo.getPartition();
             long partitionId = partition.getId();
+            boolean useStarOS = partition.isUseStarOS();
 
             // we need to get olap table to get schema hash info
             // first find it in catalog. if not found, it should be in recycle bin
@@ -655,8 +659,10 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
                 for (Tablet tablet : index.getTablets()) {
                     long tabletId = tablet.getId();
                     invertedIndex.addTablet(tabletId, tabletMeta);
-                    for (Replica replica : ((LocalTablet) tablet).getReplicas()) {
-                        invertedIndex.addReplica(tabletId, replica);
+                    if (!useStarOS) {
+                        for (Replica replica : ((LocalTablet) tablet).getReplicas()) {
+                            invertedIndex.addReplica(tabletId, replica);
+                        }
                     }
                 }
             } // end for indices

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndex.java
@@ -219,6 +219,10 @@ public class MaterializedIndex extends MetaObject implements Writable, GsonPostP
     }
 
     public long getReplicaCount() {
+        if (useStarOS) {
+            return tablets.size();
+        }
+
         long replicaCount = 0;
         for (Tablet tablet : getTablets()) {
             LocalTablet localTablet = (LocalTablet) tablet;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/StarOSAgent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/StarOSAgent.java
@@ -1,0 +1,93 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.catalog;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.starrocks.system.Backend;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * StarOSAgent is responsible for
+ * 1. Encapsulation of StarClient api.
+ * 2. Maintenance of StarOS worker to StarRocks backend map.
+ */
+public class StarOSAgent {
+    private StarClient client;
+    // private Map<Long, Long> workerIdToBeId;
+
+    public StarOSAgent() {
+        client = new StarClient();
+    }
+
+    public List<Long> createShards(int numShards) {
+        // TODO: support shardGroup, numReplicasPerShard and shardStorageType
+        return client.createShards(numShards);
+    }
+
+    public long getPrimaryBackendIdByShard(long shardId) {
+        long workerId = client.getPrimaryWorkerIdByShard(shardId);
+        Worker worker = client.getWorker(workerId);
+        return Catalog.getCurrentSystemInfo().getBackendIdByHost(worker.getHost());
+    }
+
+    // Mock StarClient
+    private class StarClient {
+        // private Map<Long, List<Replica>> shardIdToWorkerIds;
+        private Map<Long, Worker> idToWorker;
+
+        private long id = System.currentTimeMillis();
+
+        public StarClient() {
+            idToWorker = Maps.newHashMap();
+        }
+
+        public synchronized List<Long> createShards(int numShards) {
+            // Get shard and workers from StarOS and update shardIdToWorkerIds
+            List<Long> shards = Lists.newArrayList();
+            for (int i = 0; i < numShards; ++i) {
+                shards.add(id++);
+            }
+            return shards;
+        }
+
+        public synchronized long getPrimaryWorkerIdByShard(long shardId) {
+            // Use primary replica of shard from StarOS
+            return getWorkerIdsByShard(shardId).get(0);
+        }
+
+        public synchronized List<Long> getWorkerIdsByShard(long shardId) {
+            // Use workers from StarOS
+            idToWorker.clear();
+            ImmutableMap<Long, Backend> idToBackend = Catalog.getCurrentSystemInfo().getIdToBackend();
+            for (Map.Entry<Long, Backend> entry : idToBackend.entrySet()) {
+                idToWorker.put(entry.getKey(), new Worker(entry.getKey(), entry.getValue().getHost()));
+            }
+            List<Long> workerIds = idToWorker.keySet().stream().sorted().collect(Collectors.toList());
+            return Lists.newArrayList(workerIds.get((int) shardId % workerIds.size()));
+        }
+
+        public synchronized Worker getWorker(long id) {
+            return idToWorker.get(id);
+        }
+    }
+
+    // Mock StarOS Worker
+    private class Worker {
+        private long id;
+        private String host;
+
+        public Worker(long id, String host) {
+            this.id = id;
+            this.host = host;
+        }
+
+        public String getHost() {
+            return host;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/StarOSTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/StarOSTablet.java
@@ -55,6 +55,10 @@ public class StarOSTablet extends Tablet {
         this.rowCount = rowCount;
     }
 
+    public long getPrimaryBackendId() {
+        return Catalog.getCurrentCatalog().getStarOSAgent().getPrimaryBackendIdByShard(shardId);
+    }
+
     @Override
     public void write(DataOutput out) throws IOException {
         String json = GsonUtils.GSON.toJson(this);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletMeta.java
@@ -82,6 +82,10 @@ public class TabletMeta {
         this.storageMedium = storageMedium;
     }
 
+    public boolean isUseStarOS() {
+        return CatalogUtils.isUseStarOS(storageMedium);
+    }
+
     public int getNewSchemaHash() {
         lock.readLock().lock();
         try {

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1407,4 +1407,11 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = true)
     public static int heartbeat_retry_times = 3;
+
+    /**
+     * Temporary use, it will be removed later.
+     * Set true if using StarOS to manage tablets, such as storage medium is S3.
+     */
+    @ConfField(mutable = true)
+    public static boolean use_staros = false;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -111,6 +111,8 @@ public class PropertyAnalyzer {
                     storageMedium = TStorageMedium.SSD;
                 } else if (value.equalsIgnoreCase(TStorageMedium.HDD.name())) {
                     storageMedium = TStorageMedium.HDD;
+                } else if (value.equalsIgnoreCase(TStorageMedium.S3.name()) && Config.use_staros) {
+                    storageMedium = TStorageMedium.S3;
                 } else {
                     throw new AnalysisException("Invalid storage medium: " + value);
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/master/MasterImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/master/MasterImpl.java
@@ -309,10 +309,10 @@ public class MasterImpl {
                         task.getBackendId() + ": " + request.getTask_status().getError_msgs().toString());
             } else {
                 long tabletId = createReplicaTask.getTabletId();
-
-                if (request.isSetFinish_tablet_infos()) {
-                    Replica replica = Catalog.getCurrentInvertedIndex().getReplica(createReplicaTask.getTabletId(),
-                            createReplicaTask.getBackendId());
+                TabletInvertedIndex invertedIndex = Catalog.getCurrentInvertedIndex();
+                TabletMeta tabletMeta = invertedIndex.getTabletMeta(tabletId);
+                if (!tabletMeta.isUseStarOS() && request.isSetFinish_tablet_infos()) {
+                    Replica replica = Catalog.getCurrentInvertedIndex().getReplica(tabletId, createReplicaTask.getBackendId());
                     replica.setPathHash(request.getFinish_tablet_infos().get(0).getPath_hash());
 
                     if (createReplicaTask.isRecoverTask()) {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinTest.java
@@ -7,10 +7,17 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
 import com.starrocks.analysis.PartitionValue;
+import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.load.loadv2.SparkLoadAppHandle;
 import com.starrocks.thrift.TStorageMedium;
+import com.starrocks.thrift.TStorageType;
+import com.starrocks.thrift.TTabletType;
+import mockit.Expectations;
+import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class CatalogRecycleBinTest {
@@ -99,4 +106,140 @@ public class CatalogRecycleBinTest {
         Assert.assertEquals(0, tables.size());
     }
 
+    @Test
+    public void testAddTabletToInvertedIndexWithLocalTablet(@Mocked Catalog catalog, @Mocked Database db) {
+        long dbId = 1L;
+        long tableId = 2L;
+        long partitionId = 3L;
+        long indexId = 4L;
+        long tabletId = 5L;
+        long replicaId = 10L;
+        long backendId = 20L;
+
+        // Columns
+        List<Column> columns = new ArrayList<Column>();
+        Column k1 = new Column("k1", Type.INT, true, null, "", "");
+        columns.add(k1);
+        columns.add(new Column("k2", Type.BIGINT, true, null, "", ""));
+        columns.add(new Column("v", Type.BIGINT, false, AggregateType.SUM, "0", ""));
+
+        // Replica
+        Replica replica1 = new Replica(replicaId, backendId, Replica.ReplicaState.NORMAL, 1, 0);
+        Replica replica2 = new Replica(replicaId + 1, backendId + 1, Replica.ReplicaState.NORMAL, 1, 0);
+        Replica replica3 = new Replica(replicaId + 2, backendId + 2, Replica.ReplicaState.NORMAL, 1, 0);
+
+        // Tablet
+        LocalTablet tablet = new LocalTablet(tabletId);
+        tablet.addReplica(replica1);
+        tablet.addReplica(replica2);
+        tablet.addReplica(replica3);
+
+        // Partition info and distribution info
+        DistributionInfo distributionInfo = new HashDistributionInfo(10, Lists.newArrayList(k1));
+        PartitionInfo partitionInfo = new SinglePartitionInfo();
+        partitionInfo.setDataProperty(partitionId, new DataProperty(TStorageMedium.SSD));
+        partitionInfo.setIsInMemory(partitionId, false);
+        partitionInfo.setTabletType(partitionId, TTabletType.TABLET_TYPE_DISK);
+        partitionInfo.setReplicationNum(partitionId, (short) 3);
+
+        // Index
+        MaterializedIndex index = new MaterializedIndex(indexId, MaterializedIndex.IndexState.NORMAL);
+        TabletMeta tabletMeta = new TabletMeta(dbId, tableId, partitionId, indexId, 0, TStorageMedium.SSD);
+        index.addTablet(tablet, tabletMeta);
+
+        // Partition
+        Partition partition = new Partition(partitionId, "p1", index, distributionInfo);
+        partition.setPartitionInfo(partitionInfo);
+
+        // Table
+        OlapTable table = new OlapTable(tableId, "t1", columns, KeysType.AGG_KEYS, partitionInfo, distributionInfo);
+        Deencapsulation.setField(table, "baseIndexId", indexId);
+        table.addPartition(partition);
+        table.setIndexMeta(indexId, "t1", columns, 0, 0, (short) 3, TStorageType.COLUMN, KeysType.AGG_KEYS);
+
+        TabletInvertedIndex invertedIndex = new TabletInvertedIndex();
+        new Expectations() {
+            {
+                Catalog.getCurrentInvertedIndex();
+                result = invertedIndex;
+            }
+        };
+
+        CatalogRecycleBin bin = new CatalogRecycleBin();
+        bin.recycleTable(dbId, table);
+        bin.addTabletToInvertedIndex();
+
+        // Check
+        TabletMeta tabletMeta1 = invertedIndex.getTabletMeta(tabletId);
+        Assert.assertTrue(tabletMeta1 != null);
+        Assert.assertFalse(tabletMeta1.isUseStarOS());
+        Assert.assertEquals(TStorageMedium.SSD, tabletMeta1.getStorageMedium());
+        Assert.assertEquals(replica1, invertedIndex.getReplica(tabletId, backendId));
+        Assert.assertEquals(replica2, invertedIndex.getReplica(tabletId, backendId + 1));
+        Assert.assertEquals(replica3, invertedIndex.getReplica(tabletId, backendId + 2));
+    }
+
+    @Test
+    public void testAddTabletToInvertedIndexWithStarOSTablet(@Mocked Catalog catalog, @Mocked Database db) {
+        long dbId = 1L;
+        long tableId = 2L;
+        long partitionId = 3L;
+        long indexId = 4L;
+        long tablet1Id = 10L;
+        long tablet2Id = 11L;
+
+        // Columns
+        List<Column> columns = new ArrayList<Column>();
+        Column k1 = new Column("k1", Type.INT, true, null, "", "");
+        columns.add(k1);
+        columns.add(new Column("k2", Type.BIGINT, true, null, "", ""));
+        columns.add(new Column("v", Type.BIGINT, false, AggregateType.SUM, "0", ""));
+
+        // Tablet
+        Tablet tablet1 = new StarOSTablet(tablet1Id, 0L);
+        Tablet tablet2 = new StarOSTablet(tablet2Id, 1L);
+
+        // Partition info and distribution info
+        DistributionInfo distributionInfo = new HashDistributionInfo(10, Lists.newArrayList(k1));
+        PartitionInfo partitionInfo = new SinglePartitionInfo();
+        partitionInfo.setDataProperty(partitionId, new DataProperty(TStorageMedium.S3));
+        partitionInfo.setIsInMemory(partitionId, false);
+        partitionInfo.setTabletType(partitionId, TTabletType.TABLET_TYPE_DISK);
+        partitionInfo.setReplicationNum(partitionId, (short) 3);
+
+        // Index
+        MaterializedIndex index = new MaterializedIndex(indexId, MaterializedIndex.IndexState.NORMAL);
+        index.setUseStarOS(partitionInfo.isUseStarOS(partitionId));
+        TabletMeta tabletMeta = new TabletMeta(dbId, tableId, partitionId, indexId, 0, TStorageMedium.S3);
+        index.addTablet(tablet1, tabletMeta);
+        index.addTablet(tablet2, tabletMeta);
+
+        // Partition
+        Partition partition = new Partition(partitionId, "p1", index, distributionInfo);
+        partition.setPartitionInfo(partitionInfo);
+
+        // Table
+        OlapTable table = new OlapTable(tableId, "t1", columns, KeysType.AGG_KEYS, partitionInfo, distributionInfo);
+        Deencapsulation.setField(table, "baseIndexId", indexId);
+        table.addPartition(partition);
+        table.setIndexMeta(indexId, "t1", columns, 0, 0, (short) 3, TStorageType.COLUMN, KeysType.AGG_KEYS);
+
+        TabletInvertedIndex invertedIndex = new TabletInvertedIndex();
+        new Expectations() {
+            {
+                Catalog.getCurrentInvertedIndex();
+                result = invertedIndex;
+            }
+        };
+
+        CatalogRecycleBin bin = new CatalogRecycleBin();
+        bin.recycleTable(dbId, table);
+        bin.addTabletToInvertedIndex();
+
+        // Check
+        TabletMeta tabletMeta1 = invertedIndex.getTabletMeta(tablet1Id);
+        Assert.assertTrue(tabletMeta1 != null);
+        Assert.assertTrue(tabletMeta1.isUseStarOS());
+        Assert.assertEquals(TStorageMedium.S3, tabletMeta1.getStorageMedium());
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] others

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

1. Support creating olap table with StarOSTablet when the user specifies
   the S3 storage medium.
2. Support dropping olap table with StarOSTablet.
3. Add a new class StarOSAgent to encapsulate StarClient interface.
4. Mock StarClient and StarOS worker.