### PR TITLE
Bugfix: make sure __op always return 0/1 string in json_scanner

### DIFF
--- a/be/src/exec/vectorized/json_scanner.cpp
+++ b/be/src/exec/vectorized/json_scanner.cpp
@@ -325,15 +325,19 @@ Status JsonReader::read_chunk(Chunk* chunk, int32_t rows_to_read, const std::vec
                     }
                     rapidjson::Value* json_values = JsonFunctions::get_json_object_from_parsed_json(
                             _scanner->_json_paths[i], objectValue, _origin_json_doc.GetAllocator());
-                    if (json_values == nullptr) {
-                        if (strcmp(column_name, "__op") == 0) {
-                            // special treatment for __op column, fill default value '0' rather than null
-                            column->append_strings(literal_0_slice_vector);
+                    if (strcmp(column_name, "__op") == 0) {
+                        // special treatment for __op column, fill default value '0' rather than null
+                        if (json_values != nullptr && json_values->IsInt() && json_values->GetInt() == 1) {
+                            column->append_strings(literal_1_slice_vector);
                         } else {
-                            column->append_nulls(1);
+                            column->append_strings(literal_0_slice_vector);
                         }
                     } else {
-                        _construct_column(*json_values, column.get(), slot_descs[i]->type());
+                        if (json_values == nullptr) {
+                            column->append_nulls(1);
+                        } else {
+                            _construct_column(*json_values, column.get(), slot_descs[i]->type());
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3998 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
If json_path assigns a json_value not 0 or 1 to __op, currently it will cast to null in the responding slot/column, which causes error, this PR makes sure __op always return 0/1 string in json_scanner, if it's type is illegal, just using default value 0
