### PR TITLE
Forbidden non-number type cast reduce

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRule.java
@@ -110,17 +110,18 @@ public class ReduceCastRule extends TopDownScalarOperatorRewriteRule {
             return false;
         }
 
-        // decreasing cast cannot be reduced since be use operator not equal
-        // to perform cast from integral to boolean
-        // E.g. cast(cast(10000000000000 as int) as boolean)
-        if (parent.isBoolean() && childSlotSize < grandChildSlotSize) {
+        if (!(parent.isNumericType() || parent.isStringType()) ||
+                !(child.isNumericType() || child.isBoolean()) ||
+                !(grandChild.isNumericType() || grandChild.isBoolean())) {
             return false;
         }
 
         // cascaded cast cannot be reduced if middle type's size is smaller than two sides
+        // e.g. cast(cast(smallint as tinyint) as int)
         if (parentSlotSize > childSlotSize && childSlotSize < grandChildSlotSize) {
             return false;
         }
+
         Type childCompatibleType = Type.getAssignmentCompatibleType(grandChild, child, true);
         Type parentCompatibleType = Type.getAssignmentCompatibleType(child, parent, true);
         return childCompatibleType != Type.INVALID && parentCompatibleType != Type.INVALID;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -915,4 +915,57 @@ public class ExpressionTest extends PlanTestBase {
                 + "  |  <slot 11> : months_diff(12: cast, 12: cast)"));
     }
 
+    @Test
+    public void testReduceNonNumberCast() throws Exception {
+        String sql;
+        String plan;
+        sql = "select cast(cast(id_date as string) as boolean) from test_all_type;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "CAST(CAST(9: id_date AS VARCHAR(65533)) AS BOOLEAN)");
+
+        sql = "select cast(cast(id_date as datetime) as string) from test_all_type;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "CAST(CAST(9: id_date AS DATETIME) AS VARCHAR(65533))");
+
+        sql = "select cast(cast(id_date as boolean) as string) from test_all_type;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "CAST(CAST(9: id_date AS BOOLEAN) AS VARCHAR(65533))");
+
+        sql = "select cast(cast(id_datetime as string) as date) from test_all_type;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "CAST(CAST(8: id_datetime AS VARCHAR(65533)) AS DATE)");
+
+        sql = "select cast(cast(t1d as int) as boolean) from test_all_type;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "CAST(CAST(4: t1d AS INT) AS BOOLEAN)");
+
+        sql = "select cast(cast(t1a as int) as bigint) from test_all_type;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "CAST(CAST(1: t1a AS INT) AS BIGINT)");
+    }
+
+    @Test
+    public void testReduceNumberCast() throws Exception {
+        String sql;
+        String plan;
+        sql = "select cast(cast(t1c as bigint) as string) from test_all_type;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "CAST(3: t1c AS VARCHAR(65533))");
+
+        sql = "select cast(cast(t1c as bigint) as int) from test_all_type;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "OUTPUT EXPRS:3: t1c");
+
+        sql = "select cast(cast(id_bool as bigint) as int) from test_bool;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "CAST(11: id_bool AS INT)");
+
+        sql = "select cast(cast(id_bool as bigint) as string) from test_bool;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "CAST(11: id_bool AS VARCHAR(65533))");
+
+        sql = "select cast(cast(id_bool as boolean) as string) from test_bool;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "CAST(11: id_bool AS VARCHAR(65533))");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestBase.java
@@ -639,14 +639,14 @@ public class PlanTestBase {
 
         FeConstants.runningUnitTest = true;
         starRocksAssert.withResource("create external resource \"jdbc_test\"\n" +
-                        "PROPERTIES (\n" +
-                        "\"type\"=\"jdbc\",\n" +
-                        "\"user\"=\"test_user\",\n" +
-                        "\"password\"=\"test_passwd\",\n" +
-                        "\"driver_url\"=\"test_driver_url\",\n" +
-                        "\"driver_class\"=\"test.driver.class\",\n" +
-                        "\"jdbc_uri\"=\"test_uri\"\n" +
-                        ");")
+                "PROPERTIES (\n" +
+                "\"type\"=\"jdbc\",\n" +
+                "\"user\"=\"test_user\",\n" +
+                "\"password\"=\"test_passwd\",\n" +
+                "\"driver_url\"=\"test_driver_url\",\n" +
+                "\"driver_class\"=\"test.driver.class\",\n" +
+                "\"jdbc_uri\"=\"test_uri\"\n" +
+                ");")
                 .withTable("create external table test.jdbc_test\n" +
                         "(a int, b varchar(20), c float)\n" +
                         "ENGINE=jdbc\n" +
@@ -820,6 +820,10 @@ public class PlanTestBase {
     @AfterClass
     public static void afterClass() {
         connectContext.getSessionVariable().setEnableLowCardinalityOptimize(true);
+    }
+
+    public static void assertContains(String text, String pattern) {
+        Assert.assertTrue(text, text.contains(pattern));
     }
 
     protected static void setTableStatistics(OlapTable table, long rowCount) {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4011

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

`cast(cast(id_date as string) as boolean)` will optimize to `cast(id_date as boolean)`

```
mysql>    select cast(cast(cast('2020-02-02' AS date) as string) as boolean) ;
+---------------------------------------------------------------------+
| CAST(CAST(CAST('2020-02-02' AS DATE) AS VARCHAR(65533)) AS BOOLEAN) |
+---------------------------------------------------------------------+
|                                                                   1 |
+---------------------------------------------------------------------+
1 row in set (0.01 sec)

mysql>    select cast(cast('2020-02-02' as  string) as boolean) ;
+-------------------------------------------------------+
| CAST(CAST('2020-02-02' AS VARCHAR(65533)) AS BOOLEAN) |
+-------------------------------------------------------+
|                                                  NULL |
+-------------------------------------------------------+
1 row in set (0.01 sec)
```