### PR TITLE
fixup: QueryContext is removed accidently

### DIFF
--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -30,6 +30,7 @@ void QueryContext::cancel(const Status& status) {
 
 static constexpr size_t QUERY_CONTEXT_MAP_SLOT_NUM = 64;
 static constexpr size_t QUERY_CONTEXT_MAP_SLOT_NUM_MASK = (1 << 6) - 1;
+
 QueryContextManager::QueryContextManager()
         : _mutexes(QUERY_CONTEXT_MAP_SLOT_NUM),
           _context_maps(QUERY_CONTEXT_MAP_SLOT_NUM),
@@ -132,7 +133,7 @@ void QueryContextManager::remove(const TUniqueId& query_id) {
     // the query context is really dead, so just cleanup
     if (it->second->is_dead()) {
         context_map.erase(it);
-    } else {
+    } else if (it->second->is_finished()) {
         // although all of active fragments of the query context terminates, but some fragments maybe comes too late
         // in the future, so extend the lifetime of query context and wait for some time till fragments on wire have
         // vanished

--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -45,7 +45,7 @@ public:
     // now time point pass by deadline point.
     bool is_expired() {
         auto now = duration_cast<milliseconds>(steady_clock::now().time_since_epoch()).count();
-        return now > _deadline;
+        return is_finished() && now > _deadline;
     }
 
     bool is_dead() { return _num_active_fragments == 0 && _num_fragments == _total_fragments; }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

https://github.com/StarRocks/starrocks/issues/4007
https://github.com/StarRocks/starrocks/issues/3999

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

QueryContextManager::remove functions maybe remove an active QueryContext, so add two invariants:
1. a QueryContext in _second_chance_maps is removed only if it has no active fragment instances and its lifetime is expired.
2. a QueryContext can be tranfered from _context_maps to _second_change_maps only if it has no active fragment instances and is not dead.