### PR TITLE
Fix crash of pipeline caused by QueryContext destruct early

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -328,7 +328,12 @@ void PipelineDriver::finalize(RuntimeState* runtime_state, DriverState state) {
         _fragment_ctx->destroy_pass_through_chunk_buffer();
         auto status = _fragment_ctx->final_status();
         auto fragment_id = _fragment_ctx->fragment_instance_id();
-        _query_ctx->count_down_fragments();
+        if (_query_ctx->count_down_fragments()) {
+            DCHECK(_query_ctx->is_finished());
+            auto query_id = _query_ctx->query_id();
+            DCHECK(!this->is_still_pending_finish());
+            QueryContextManager::instance()->remove(query_id);
+        }
     }
 }
 

--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -42,11 +42,6 @@ void GlobalDriverExecutor::change_num_threads(int32_t num_threads) {
 void GlobalDriverExecutor::finalize_driver(DriverRawPtr driver, RuntimeState* runtime_state, DriverState state) {
     DCHECK(driver);
     driver->finalize(runtime_state, state);
-    if (driver->query_ctx()->is_finished()) {
-        auto query_id = driver->query_ctx()->query_id();
-        DCHECK(!driver->is_still_pending_finish());
-        QueryContextManager::instance()->remove(query_id);
-    }
 }
 
 void GlobalDriverExecutor::worker_thread() {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/3999
## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Fix crash of pipeline caused by QueryContext destruct early
