### PR TITLE
Fix union resolve bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CTERelation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CTERelation.java
@@ -70,8 +70,4 @@ public class CTERelation extends Relation {
             return new TableName(null, name);
         }
     }
-
-    public List<String> getColLabels() {
-        return columnOutputNames;
-    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/QueryRelation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/QueryRelation.java
@@ -5,6 +5,7 @@ import com.google.common.collect.Maps;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.LimitElement;
 import com.starrocks.analysis.OrderByElement;
+import com.starrocks.sql.analyzer.Field;
 import com.starrocks.sql.analyzer.FieldId;
 
 import java.util.ArrayList;
@@ -13,28 +14,12 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 public abstract class QueryRelation extends Relation {
-
-    /**
-     * columnOutputNames is the output column header on the terminal,
-     * and outputExpr is the output expression.
-     * Because outputExpr may be rewritten, we recorded the primitive SQL column name
-     * The alias will also be recorded in columnOutputNames
-     */
-    private List<String> columnOutputNames;
     protected List<OrderByElement> sortClause;
     protected LimitElement limit;
     private final List<CTERelation> cteRelations = new ArrayList<>();
 
-    public QueryRelation(List<String> columnOutputNames) {
-        this.columnOutputNames = columnOutputNames;
-    }
-
     public List<String> getColumnOutputNames() {
-        return columnOutputNames;
-    }
-
-    public void setColumnOutputNames(List<String> columnOutputNames) {
-        this.columnOutputNames = columnOutputNames;
+        return getScope().getRelationFields().getAllFields().stream().map(Field::getName).collect(Collectors.toList());
     }
 
     public Map<Expr, FieldId> getColumnReferences() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SelectRelation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SelectRelation.java
@@ -68,7 +68,6 @@ public class SelectRelation extends QueryRelation {
             Expr predicate,
             GroupByClause groupByClause,
             Expr having) {
-        super(null);
         this.selectList = selectList;
         this.relation = fromRelation;
         this.predicate = predicate;
@@ -84,8 +83,6 @@ public class SelectRelation extends QueryRelation {
                           List<OrderByElement> orderBy, Expr having,
                           List<AnalyticExpr> outputAnalytic, List<AnalyticExpr> orderByAnalytic,
                           Map<Expr, FieldId> columnReferences) {
-        super(columnOutputNames);
-
         this.outputExpr = outputExpr;
         this.isDistinct = isDistinct;
         this.orderScope = orderScope;
@@ -109,7 +106,6 @@ public class SelectRelation extends QueryRelation {
     }
 
     public void fillResolvedAST(AnalyzeState analyzeState) {
-        super.setColumnOutputNames(analyzeState.getColumnOutputNames());
         this.outputExpr = analyzeState.getOutputExpressions();
         this.isDistinct = analyzeState.isDistinct();
         this.orderScope = analyzeState.getOrderScope();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SetOperationRelation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SetOperationRelation.java
@@ -12,8 +12,6 @@ public abstract class SetOperationRelation extends QueryRelation {
     private final SetQualifier qualifier;
 
     public SetOperationRelation(List<QueryRelation> relations, SetQualifier qualifier) {
-        //Use the first column names as the column name of the set-operation
-        super(relations.get(0).getColumnOutputNames());
         this.relations = new ArrayList<>(relations);
         this.qualifier = qualifier;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ValuesRelation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ValuesRelation.java
@@ -8,10 +8,11 @@ import java.util.List;
 
 public class ValuesRelation extends QueryRelation {
     private final List<List<Expr>> rows;
+    private final List<String> columnOutputNames;
 
     public ValuesRelation(List<ArrayList<Expr>> rows, List<String> columnOutputNames) {
-        super(columnOutputNames);
         this.rows = new ArrayList<>(rows);
+        this.columnOutputNames = columnOutputNames;
     }
 
     public void addRow(ArrayList<Expr> row) {
@@ -24,6 +25,11 @@ public class ValuesRelation extends QueryRelation {
 
     public List<List<Expr>> getRows() {
         return rows;
+    }
+
+    @Override
+    public List<String> getColumnOutputNames() {
+        return columnOutputNames;
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSetOperationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSetOperationTest.java
@@ -92,4 +92,17 @@ public class AnalyzeSetOperationTest {
         Assert.assertEquals(Type.TINYINT, outColumns.get(1).getType());
         Assert.assertTrue(outColumns.get(1).isNullable());
     }
+
+    @Test
+    public void testWithSort() {
+        analyzeSuccess("select t0.v1 from t0,t1 union all select v7 from t2 order by v1");
+        analyzeSuccess("select v1 from t0,t1 union all select v7 from t2 order by v1");
+        analyzeSuccess("select t0.v1 from t0,t1 union all select v7 from t2 order by t0.v1");
+        analyzeSuccess("select t0.v1,v2 from t0,t1 union all select v7,v8 from t2 order by v2");
+        analyzeFail("select t0.v1 from t0,t1 union all select v7 from t2 order by v2");
+        analyzeFail("select t0.v1 from t0,t1 union all select v7 from t2 order by t1.v4");
+        analyzeFail("select t0.v1 from t0,t1 union all select v7 from t2 order by t2.v7");
+        analyzeFail("select t0.v1 from t0,t1 union all select v7 from t2 order by v7");
+        analyzeFail("select t0.v1 from t0,t1 union all select v7 from t2 order by v8");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SetTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SetTest.java
@@ -491,7 +491,6 @@ public class SetTest extends PlanTestBase {
 
         sql = "select * from (select * from t0 order by v1 limit 1) t union select * from t1";
         plan = getFragmentPlan(sql);
-        System.out.println(plan);
         Assert.assertTrue(plan.contains("  2:TOP-N\n" +
                 "  |  order by: <slot 1> 1: v1 ASC\n" +
                 "  |  offset: 0\n" +
@@ -499,5 +498,12 @@ public class SetTest extends PlanTestBase {
                 "  |  \n" +
                 "  1:OlapScanNode\n" +
                 "     TABLE: t0"));
+
+        sql = "select v1+v2 from t0 union all select v4 from t1 order by 1";
+        plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("  6:SORT\n" +
+                "  |  order by: <slot 8> 8: expr ASC"));
+        Assert.assertTrue(plan.contains("  2:Project\n" +
+                "  |  <slot 4> : 1: v1 + 2: v2"));
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4059

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

1. Fix bugs, such as sql : select v1+v2 from t0 union all select v4 from t1 order by 1, order by 1 should be parsed as FieldReference, not read from output expression, because v1 and v2 can no longer be visible in the Scope of SetOp
2. Refactor the outputScope code of selectStatement, the original code misses the TableName of the field in outputScope
3. Delete ColumnOutputNames and expandStar, because after binding the relationship between Scope and Relation, the name and output name in the scope field are exactly the same, so it is no longer necessary to store ColumnOutputNames separately