### PR TITLE
fix coredump in _close_jdbc_scanner when opening JDBCScanner failed 

### DIFF
--- a/be/src/exec/vectorized/jdbc_scanner.cpp
+++ b/be/src/exec/vectorized/jdbc_scanner.cpp
@@ -152,7 +152,6 @@ Status JDBCScanner::_init_jdbc_scanner() {
     _jni_env->CallVoidMethod(_jdbc_scanner, scanner_open);
     CHECK_JAVA_EXCEPTION("open JDBCScanner failed")
 
-
     return Status::OK();
 }
 

--- a/be/src/exec/vectorized/jdbc_scanner.cpp
+++ b/be/src/exec/vectorized/jdbc_scanner.cpp
@@ -135,16 +135,8 @@ Status JDBCScanner::_init_jdbc_scanner() {
     _jni_env->DeleteLocalRef(_jdbc_bridge);
     CHECK_JAVA_EXCEPTION("get JDBCScanner failed")
 
-    // open scanner
     _jdbc_scanner_cls = _jni_env->FindClass(JDBC_SCANNER_CLASS_NAME);
     DCHECK(_jdbc_scanner_cls != nullptr);
-
-    jmethodID scanner_open = _jni_env->GetMethodID(_jdbc_scanner_cls, "open", "()V");
-    DCHECK(scanner_open != nullptr);
-
-    _jni_env->CallVoidMethod(_jdbc_scanner, scanner_open);
-    CHECK_JAVA_EXCEPTION("open JDBCScanner failed")
-
     // init jmethod
     _scanner_has_next = _jni_env->GetMethodID(_jdbc_scanner_cls, "hasNext", "()Z");
     DCHECK(_scanner_has_next != nullptr);
@@ -152,6 +144,14 @@ Status JDBCScanner::_init_jdbc_scanner() {
     DCHECK(_scanner_get_next_chunk != nullptr);
     _scanner_close = _jni_env->GetMethodID(_jdbc_scanner_cls, "close", "()V");
     DCHECK(_scanner_close != nullptr);
+
+    // open scanner
+    jmethodID scanner_open = _jni_env->GetMethodID(_jdbc_scanner_cls, "open", "()V");
+    DCHECK(scanner_open != nullptr);
+
+    _jni_env->CallVoidMethod(_jdbc_scanner, scanner_open);
+    CHECK_JAVA_EXCEPTION("open JDBCScanner failed")
+
 
     return Status::OK();
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
We should make sure all jmethods of JDBCScanner are initialized before use, otherwise, coredump may happen when `_close_jdbc_scanner` is called