### PR TITLE
[cherry-pick] PrimaryKey table is forbidden to backup/restore (#3985)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
@@ -39,6 +39,7 @@ import com.starrocks.backup.BackupJob.BackupJobState;
 import com.starrocks.backup.BackupJobInfo.BackupTableInfo;
 import com.starrocks.catalog.Catalog;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.MaterializedIndex.IndexExtState;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
@@ -292,6 +293,10 @@ public class BackupHandler extends MasterDaemon implements Writable {
                 }
 
                 OlapTable olapTbl = (OlapTable) tbl;
+                if (olapTbl.getKeysType() == KeysType.PRIMARY_KEYS) {
+                    ErrorReport.reportDdlException(ErrorCode.ERR_COMMON_ERROR,
+                            "backup do not support primary key table: " + tblName);
+                }
                 if (olapTbl.existTempPartitions()) {
                     ErrorReport.reportDdlException(ErrorCode.ERR_COMMON_ERROR,
                             "Do not support backup table with temp partitions");

--- a/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
@@ -375,7 +375,6 @@ public class RestoreJob extends AbstractJob {
                     status = new Status(ErrCode.NOT_FOUND, "table " + idChain.getTblId() + " has been dropped");
                     return;
                 }
-
                 Partition part = tbl.getPartition(idChain.getPartId());
                 if (part == null) {
                     status = new Status(ErrCode.NOT_FOUND, "partition " + idChain.getPartId() + " has been dropped");

--- a/fe/fe-core/src/test/java/com/starrocks/backup/BackupHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/BackupHandlerTest.java
@@ -307,6 +307,19 @@ public class BackupHandlerTest {
             Assert.fail();
         }
 
+        {
+            // process backup for primary key, will be forbidden
+            List<TableRef> tblRefs1 = Lists.newArrayList();
+            tblRefs1.add(new TableRef(new TableName(CatalogMocker.TEST_DB_NAME, CatalogMocker.TEST_TBL3_NAME), null));
+            BackupStmt backupStmt1 = new BackupStmt(new LabelName(CatalogMocker.TEST_DB_NAME, "label2"), "repo", tblRefs1,
+                    null);
+            try {
+                handler.process(backupStmt1);
+            } catch (DdlException e1) {
+                Assert.assertEquals(e1.toString(), "com.starrocks.common.DdlException: backup do not support primary key table: test_tbl3");
+            }
+        }
+
         // process restore
         List<TableRef> tblRefs2 = Lists.newArrayList();
         tblRefs2.add(new TableRef(new TableName(CatalogMocker.TEST_DB_NAME, CatalogMocker.TEST_TBL_NAME), null));

--- a/fe/fe-core/src/test/java/com/starrocks/backup/CatalogMocker.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/CatalogMocker.java
@@ -108,6 +108,10 @@ public class CatalogMocker {
     public static final String TEST_TBL2_NAME = "test_tbl2";
     public static final long TEST_TBL2_ID = 30002;
 
+    // primary key olap table
+    public static final String TEST_TBL3_NAME = "test_tbl3";
+    public static final long TEST_TBL3_ID = 30003;
+
     public static final String TEST_PARTITION1_NAME = "p1";
     public static final long TEST_PARTITION1_ID = 40001;
     public static final String TEST_PARTITION2_NAME = "p2";
@@ -318,6 +322,10 @@ public class CatalogMocker {
                 KeysType.AGG_KEYS, rangePartitionInfo, distributionInfo2);
         Deencapsulation.setField(olapTable2, "baseIndexId", TEST_TBL2_ID);
 
+        OlapTable olapTable3 = new OlapTable(TEST_TBL3_ID, TEST_TBL3_NAME, TEST_TBL_BASE_SCHEMA,
+                KeysType.PRIMARY_KEYS, partitionInfo, distributionInfo);
+        Deencapsulation.setField(olapTable3, "baseIndexId", TEST_TBL3_ID);
+
         LocalTablet baseTabletP1 = new LocalTablet(TEST_BASE_TABLET_P1_ID);
         TabletMeta tabletMetaBaseTabletP1 = new TabletMeta(TEST_DB_ID, TEST_TBL2_ID, TEST_PARTITION1_ID,
                 TEST_TBL2_ID, SCHEMA_HASH, TStorageMedium.HDD);
@@ -383,6 +391,7 @@ public class CatalogMocker {
         olapTable2.setIndexMeta(TEST_ROLLUP_ID, TEST_ROLLUP_NAME, TEST_ROLLUP_SCHEMA, 0, ROLLUP_SCHEMA_HASH,
                 (short) 1, TStorageType.COLUMN, KeysType.AGG_KEYS);
         db.createTable(olapTable2);
+        db.createTable(olapTable3);
 
         return db;
     }


### PR DESCRIPTION
Backup/restore does not support the PrimaryKey table. So the two operations are forbidden.

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3984
