### PR TITLE
Add horizontal and vertical compaction tasks for event_based compaction framework

### DIFF
--- a/be/src/storage/compaction_task_factory.cpp
+++ b/be/src/storage/compaction_task_factory.cpp
@@ -2,12 +2,78 @@
 
 #include "storage/compaction_task_factory.h"
 
+#include "column/schema.h"
+#include "runtime/exec_env.h"
+#include "storage/compaction_manager.h"
 #include "storage/compaction_task.h"
+#include "storage/compaction_utils.h"
+#include "storage/horizontal_compaction_task.h"
+#include "storage/olap_common.h"
+#include "storage/rowset/rowset.h"
+#include "storage/tablet.h"
+#include "storage/vectorized/chunk_helper.h"
+#include "storage/vectorized/tablet_reader.h"
+#include "storage/vectorized/tablet_reader_params.h"
+#include "storage/vertical_compaction_task.h"
 
 namespace starrocks {
 
 std::shared_ptr<CompactionTask> CompactionTaskFactory::create_compaction_task() {
-    return nullptr;
+    auto iterator_num_res = _get_segment_iterator_num();
+    if (!iterator_num_res.ok()) {
+        LOG(WARNING) << "fail to get segment iterator num. tablet=" << _tablet->tablet_id()
+                     << ", err=" << iterator_num_res.status().to_string();
+        return nullptr;
+    }
+    size_t segment_iterator_num = iterator_num_res.value();
+    int64_t max_columns_per_group = config::vertical_compaction_max_columns_per_group;
+    size_t num_columns = _tablet->num_columns();
+    CompactionAlgorithm algorithm =
+            CompactionUtils::choose_compaction_algorithm(num_columns, max_columns_per_group, segment_iterator_num);
+    std::shared_ptr<CompactionTask> compaction_task;
+    VLOG(2) << "choose algorithm:" << CompactionUtils::compaction_algorithm_to_string(algorithm)
+            << ", for tablet:" << _tablet->tablet_id() << ", segment_iterator_num:" << segment_iterator_num
+            << ", max_columns_per_group:" << max_columns_per_group << ", num_columns:" << num_columns;
+    if (algorithm == HORIZONTAL_COMPACTION) {
+        compaction_task = std::make_shared<HorizontalCompactionTask>();
+    } else if (algorithm == VERTICAL_COMPACTION) {
+        compaction_task = std::make_shared<VerticalCompactionTask>();
+    }
+    // init the compaction task
+    size_t input_rows_num = 0;
+    size_t input_rowsets_size = 0;
+    size_t input_segments_num = 0;
+    for (auto& rowset : _input_rowsets) {
+        input_rows_num += rowset->num_rows();
+        input_rowsets_size += rowset->data_disk_size();
+        input_segments_num += rowset->num_segments();
+    }
+    compaction_task->set_compaction_score(_compaction_score);
+    compaction_task->set_compaction_type(_compaction_type);
+    compaction_task->set_input_rows_num(input_rows_num);
+    compaction_task->set_input_rowsets(std::move(_input_rowsets));
+    compaction_task->set_input_rowsets_size(input_rowsets_size);
+    compaction_task->set_input_segments_num(input_segments_num);
+    compaction_task->set_output_version(_output_version);
+    compaction_task->set_tablet(_tablet);
+    compaction_task->set_segment_iterator_num(segment_iterator_num);
+    std::unique_ptr<MemTracker> mem_tracker = std::make_unique<MemTracker>(
+            MemTracker::COMPACTION, -1, "Compaction-" + std::to_string(compaction_task->task_id()),
+            ExecEnv::GetInstance()->compaction_mem_tracker());
+    compaction_task->set_mem_tracker(mem_tracker.release());
+    return compaction_task;
+}
+
+StatusOr<size_t> CompactionTaskFactory::_get_segment_iterator_num() {
+    vectorized::Schema schema = vectorized::ChunkHelper::convert_schema_to_format_v2(_tablet->tablet_schema());
+    vectorized::TabletReader reader(_tablet, _output_version, schema);
+    vectorized::TabletReaderParams reader_params;
+    reader_params.reader_type =
+            _compaction_type == CUMULATIVE_COMPACTION ? READER_CUMULATIVE_COMPACTION : READER_BASE_COMPACTION;
+    RETURN_IF_ERROR(reader.prepare());
+    std::vector<ChunkIteratorPtr> seg_iters;
+    RETURN_IF_ERROR(reader.get_segment_iterators(reader_params, &seg_iters));
+    return seg_iters.size();
 }
 
 } // namespace starrocks

--- a/be/src/storage/compaction_task_factory.h
+++ b/be/src/storage/compaction_task_factory.h
@@ -28,6 +28,9 @@ public:
     std::shared_ptr<CompactionTask> create_compaction_task();
 
 private:
+    StatusOr<size_t> _get_segment_iterator_num();
+
+private:
     Version _output_version;
     TabletSharedPtr _tablet;
     std::vector<RowsetSharedPtr> _input_rowsets;

--- a/be/src/storage/compaction_task_factory.h
+++ b/be/src/storage/compaction_task_factory.h
@@ -30,7 +30,6 @@ public:
 private:
     StatusOr<size_t> _get_segment_iterator_num();
 
-private:
     Version _output_version;
     TabletSharedPtr _tablet;
     std::vector<RowsetSharedPtr> _input_rowsets;

--- a/be/src/storage/horizontal_compaction_task.cpp
+++ b/be/src/storage/horizontal_compaction_task.cpp
@@ -108,7 +108,7 @@ StatusOr<size_t> HorizontalCompactionTask::_compact_data(int32_t chunk_size, vec
     size_t output_rows = 0;
     auto char_field_indexes = vectorized::ChunkHelper::get_char_field_indexes(schema);
     auto chunk = vectorized::ChunkHelper::new_chunk(schema, chunk_size);
-    while (!should_stop()) {
+    while (LIKELY(!should_stop())) {
 #ifndef BE_TEST
         status = tls_thread_status.mem_tracker()->check_mem_limit("Compaction");
         if (!status.ok()) {

--- a/be/src/storage/horizontal_compaction_task.cpp
+++ b/be/src/storage/horizontal_compaction_task.cpp
@@ -141,7 +141,8 @@ StatusOr<size_t> HorizontalCompactionTask::_compact_data(int32_t chunk_size, vec
     TRACE("[Compaction] data compacted");
 
     if (should_stop()) {
-        LOG(INFO) << "horizontal compaction task_id:" << _task_info.task_id << " is stopped.";
+        LOG(INFO) << "horizontal compaction task_id:" << _task_info.task_id << ", tablet:" << _task_info.tablet_id
+                  << " is stopped.";
         return Status::Cancelled("horizontal compaction task is stopped.");
     }
     return output_rows;

--- a/be/src/storage/horizontal_compaction_task.cpp
+++ b/be/src/storage/horizontal_compaction_task.cpp
@@ -1,0 +1,150 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+#include "storage/horizontal_compaction_task.h"
+
+#include <vector>
+
+#include "column/schema.h"
+#include "common/statusor.h"
+#include "runtime/current_thread.h"
+#include "storage/olap_common.h"
+#include "storage/rowset/rowset.h"
+#include "storage/rowset/rowset_writer.h"
+#include "storage/storage_engine.h"
+#include "storage/tablet.h"
+#include "storage/vectorized/chunk_helper.h"
+#include "storage/vectorized/tablet_reader.h"
+#include "storage/vectorized/tablet_reader_params.h"
+#include "util/time.h"
+#include "util/trace.h"
+
+namespace starrocks {
+
+Status HorizontalCompactionTask::run_impl() {
+    Statistics statistics;
+    RETURN_IF_ERROR(_horizontal_compact_data(&statistics));
+
+    TRACE_COUNTER_INCREMENT("merged_rows", statistics.merged_rows);
+    TRACE_COUNTER_INCREMENT("filtered_rows", statistics.filtered_rows);
+    TRACE_COUNTER_INCREMENT("output_rows", statistics.output_rows);
+
+    RETURN_IF_ERROR(_validate_compaction(statistics));
+    TRACE("[Compaction] horizontal compaction validated");
+
+    _commit_compaction();
+    TRACE("[Compaction] horizontal compaction committed");
+
+    return Status::OK();
+}
+
+Status HorizontalCompactionTask::_horizontal_compact_data(Statistics* statistics) {
+    TRACE("[Compaction] start horizontal comapction data");
+    // 1: init
+    int64_t max_rows_per_segment = CompactionUtils::get_segment_max_rows(
+            config::max_segment_file_size, _task_info.input_rows_num, _task_info.input_rowsets_size);
+
+    std::unique_ptr<RowsetWriter> output_rs_writer;
+    RETURN_IF_ERROR(CompactionUtils::construct_output_rowset_writer(
+            _tablet.get(), max_rows_per_segment, _task_info.algorithm, _task_info.output_version, &output_rs_writer));
+
+    vectorized::Schema schema = vectorized::ChunkHelper::convert_schema_to_format_v2(_tablet->tablet_schema());
+    vectorized::TabletReader reader(std::static_pointer_cast<Tablet>(_tablet->shared_from_this()),
+                                    output_rs_writer->version(), schema);
+    vectorized::TabletReaderParams reader_params;
+    reader_params.reader_type = ReaderType::READER_LEVEL_COMPACTION;
+    reader_params.profile = _runtime_profile.create_child("merge_rowsets");
+
+    int32_t chunk_size = CompactionUtils::get_read_chunk_size(
+            config::compaction_memory_limit_per_worker, config::vector_chunk_size, _task_info.input_rows_num,
+            _task_info.input_rowsets_size, _task_info.segment_iterator_num);
+    VLOG(1) << "compaction task_id:" << _task_info.task_id << ", tablet=" << _tablet->tablet_id()
+            << ", reader chunk size=" << chunk_size;
+    reader_params.chunk_size = chunk_size;
+    RETURN_IF_ERROR(reader.prepare());
+    RETURN_IF_ERROR(reader.open(reader_params));
+    TRACE("[Compaction] compaction prepare finished, max_rows_per_segment:$0, chunk_size:$1", max_rows_per_segment,
+          chunk_size);
+
+    // 2: read data and output compacted data
+    StatusOr<size_t> res = _compact_data(chunk_size, reader, schema, output_rs_writer.get());
+    if (!res.ok()) {
+        return res.status();
+    }
+    TRACE("[Compaction] data compacted");
+
+    // 3: generate new rowset
+    RETURN_IF_ERROR(output_rs_writer->flush());
+
+    TRACE("[Compaction] writer flushed");
+
+    StatusOr<RowsetSharedPtr> build_res = output_rs_writer->build();
+    if (!build_res.ok()) {
+        LOG(WARNING) << "rowset writer build failed. compaction task_id:" << _task_info.task_id
+                     << ", tablet:" << _task_info.tablet_id << " output_version=" << _task_info.output_version;
+        return build_res.status();
+    } else {
+        _output_rowset = build_res.value();
+    }
+    _task_info.output_segments_num = _output_rowset->num_segments();
+    _task_info.output_rowset_size = _output_rowset->data_disk_size();
+    TRACE_COUNTER_INCREMENT("output_rowset_data_size", _output_rowset->data_disk_size());
+    TRACE_COUNTER_INCREMENT("output_segments_num", _output_rowset->num_segments());
+    TRACE("[Compaction] output rowset built");
+
+    // collect statistics if necessary
+    if (statistics) {
+        statistics->output_rows = res.value();
+        statistics->merged_rows = reader.merged_rows();
+        statistics->filtered_rows = reader.stats().rows_del_filtered;
+    }
+
+    return Status::OK();
+}
+
+StatusOr<size_t> HorizontalCompactionTask::_compact_data(int32_t chunk_size, vectorized::TabletReader& reader,
+                                                         const vectorized::Schema& schema,
+                                                         RowsetWriter* output_rs_writer) {
+    TRACE("[Compaction] start to compact data");
+    auto status = Status::OK();
+    size_t output_rows = 0;
+    auto char_field_indexes = vectorized::ChunkHelper::get_char_field_indexes(schema);
+    auto chunk = vectorized::ChunkHelper::new_chunk(schema, chunk_size);
+    while (!should_stop()) {
+#ifndef BE_TEST
+        status = tls_thread_status.mem_tracker()->check_mem_limit("Compaction");
+        if (!status.ok()) {
+            LOG(WARNING) << "fail to execute compaction: " << status.message() << std::endl;
+            return status;
+        }
+#endif
+
+        chunk->reset();
+        status = reader.get_next(chunk.get());
+        if (!status.ok()) {
+            if (status.is_end_of_file()) {
+                break;
+            } else {
+                LOG(WARNING) << "compaction reader get next error. tablet=" << _tablet->tablet_id()
+                             << ", err=" << status.to_string();
+                return Status::InternalError(fmt::format("reader get_next error: {}", status.to_string()));
+            }
+        }
+
+        vectorized::ChunkHelper::padding_char_columns(char_field_indexes, schema, _tablet->tablet_schema(),
+                                                      chunk.get());
+
+        RETURN_IF_ERROR(output_rs_writer->add_chunk(*chunk));
+        output_rows += chunk->num_rows();
+        _task_info.output_num_rows = output_rows;
+        _task_info.filtered_rows = reader.stats().rows_del_filtered;
+        _task_info.merged_rows = reader.merged_rows();
+    }
+    TRACE("[Compaction] data compacted");
+
+    if (should_stop()) {
+        LOG(INFO) << "horizontal compaction task_id:" << _task_info.task_id << " is stopped.";
+        return Status::Cancelled("horizontal compaction task is stopped.");
+    }
+    return output_rows;
+}
+
+} // namespace starrocks

--- a/be/src/storage/horizontal_compaction_task.h
+++ b/be/src/storage/horizontal_compaction_task.h
@@ -1,0 +1,34 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#pragma once
+
+#include <vector>
+
+#include "common/status.h"
+#include "storage/compaction_task.h"
+#include "storage/compaction_utils.h"
+#include "storage/olap_common.h"
+
+namespace starrocks {
+
+class RowsetWriter;
+
+namespace vectorized {
+class TabletReader;
+class Schema;
+} // namespace vectorized
+class HorizontalCompactionTask : public CompactionTask {
+public:
+    HorizontalCompactionTask() : CompactionTask(HORIZONTAL_COMPACTION) {}
+    ~HorizontalCompactionTask() = default;
+    Status run_impl() override;
+
+private:
+    Status _horizontal_compact_data(Statistics* statistics);
+    StatusOr<size_t> _compact_data(int32_t chunk_size, vectorized::TabletReader& reader,
+                                   const vectorized::Schema& schema, RowsetWriter* output_rs_writer);
+    void _failure_callback();
+    void _success_callback();
+};
+
+} // namespace starrocks

--- a/be/src/storage/vertical_compaction_task.cpp
+++ b/be/src/storage/vertical_compaction_task.cpp
@@ -175,7 +175,7 @@ StatusOr<int32_t> VerticalCompactionTask::_calculate_chunk_size_for_column_group
 
 StatusOr<size_t> VerticalCompactionTask::_compact_data(bool is_key, int32_t chunk_size,
                                                        const std::vector<uint32_t>& column_group,
-                                                       vectorized::TabletReader& reader,
+                                                       const vectorized::TabletReader& reader,
                                                        const vectorized::Schema& schema, RowsetWriter* output_rs_writer,
                                                        vectorized::RowSourceMaskBuffer* mask_buffer,
                                                        std::vector<vectorized::RowSourceMask>* source_masks) {

--- a/be/src/storage/vertical_compaction_task.cpp
+++ b/be/src/storage/vertical_compaction_task.cpp
@@ -229,7 +229,8 @@ StatusOr<size_t> VerticalCompactionTask::_compact_data(bool is_key, int32_t chun
         }
     }
     if (should_stop()) {
-        LOG(INFO) << "vertical compaction task_id:" << _task_info.task_id << " is stopped.";
+        LOG(INFO) << "vertical compaction task_id:" << _task_info.task_id << ", tablet:" << _task_info.tablet_id
+                  << " is stopped.";
         return Status::Cancelled("vertical compaction task is stopped.");
     }
     return output_rows;

--- a/be/src/storage/vertical_compaction_task.cpp
+++ b/be/src/storage/vertical_compaction_task.cpp
@@ -186,7 +186,7 @@ StatusOr<size_t> VerticalCompactionTask::_compact_data(bool is_key, int32_t chun
     Status status = Status::OK();
     size_t column_group_del_filtered_rows = 0;
     size_t column_group_merged_rows = 0;
-    while (!should_stop()) {
+    while (LIKELY(!should_stop())) {
 #ifndef BE_TEST
         status = tls_thread_status.mem_tracker()->check_mem_limit("Compaction");
         if (!status.ok()) {

--- a/be/src/storage/vertical_compaction_task.cpp
+++ b/be/src/storage/vertical_compaction_task.cpp
@@ -1,0 +1,238 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#include "storage/vertical_compaction_task.h"
+
+#include <vector>
+
+#include "column/schema.h"
+#include "runtime/current_thread.h"
+#include "storage/compaction_utils.h"
+#include "storage/olap_common.h"
+#include "storage/rowset/beta_rowset.h"
+#include "storage/rowset/column_reader.h"
+#include "storage/rowset/rowset.h"
+#include "storage/rowset/rowset_writer.h"
+#include "storage/storage_engine.h"
+#include "storage/vectorized/chunk_helper.h"
+#include "storage/vectorized/row_source_mask.h"
+#include "storage/vectorized/tablet_reader.h"
+#include "storage/vectorized/tablet_reader_params.h"
+#include "util/time.h"
+#include "util/trace.h"
+
+namespace starrocks {
+
+Status VerticalCompactionTask::run_impl() {
+    Statistics statistics;
+    RETURN_IF_ERROR(_vertical_compaction_data(&statistics));
+    TRACE_COUNTER_INCREMENT("merged_rows", statistics.merged_rows);
+    TRACE_COUNTER_INCREMENT("filtered_rows", statistics.filtered_rows);
+    TRACE_COUNTER_INCREMENT("output_rows", statistics.output_rows);
+
+    RETURN_IF_ERROR(_validate_compaction(statistics));
+    TRACE("[Compaction] vertical compaction validated");
+
+    _commit_compaction();
+    TRACE("[Compaction] vertical compaction committed");
+
+    return Status::OK();
+}
+
+Status VerticalCompactionTask::_vertical_compaction_data(Statistics* statistics) {
+    TRACE("[Compaction] start vertical comapction data");
+    int64_t max_rows_per_segment = CompactionUtils::get_segment_max_rows(
+            config::max_segment_file_size, _task_info.input_rows_num, _task_info.input_rowsets_size);
+
+    std::unique_ptr<RowsetWriter> output_rs_writer;
+    RETURN_IF_ERROR(CompactionUtils::construct_output_rowset_writer(
+            _tablet.get(), max_rows_per_segment, _task_info.algorithm, _task_info.output_version, &output_rs_writer));
+
+    std::vector<std::vector<uint32_t>> column_groups;
+    CompactionUtils::split_column_into_groups(_tablet->num_columns(), _tablet->num_key_columns(),
+                                              config::vertical_compaction_max_columns_per_group, &column_groups);
+    _task_info.column_group_size = column_groups.size();
+
+    auto mask_buffer =
+            std::make_unique<vectorized::RowSourceMaskBuffer>(_tablet->tablet_id(), _tablet->data_dir()->path());
+    auto source_masks = std::make_unique<std::vector<vectorized::RowSourceMask>>();
+    TRACE("[Compaction] compaction prepare finished, max_rows_per_segment:$0, column groups "
+          "size:$1",
+          max_rows_per_segment, column_groups.size());
+
+    for (size_t i = 0; i < column_groups.size(); ++i) {
+        if (should_stop()) {
+            LOG(INFO) << "vertical compaction task_id:" << _task_info.task_id << " is stopped.";
+            return Status::Cancelled("vertical compaction task is stopped.");
+        }
+        bool is_key = (i == 0);
+        if (!is_key) {
+            // read mask buffer from the beginning
+            mask_buffer->flip_to_read();
+        }
+        RETURN_IF_ERROR(_compact_column_group(is_key, i, column_groups[i], output_rs_writer.get(), mask_buffer.get(),
+                                              source_masks.get(), statistics));
+    }
+    TRACE("[Compaction] data compacted");
+
+    RETURN_IF_ERROR(output_rs_writer->final_flush());
+
+    TRACE("[Compaction] writer flushed");
+
+    StatusOr<RowsetSharedPtr> build_res = output_rs_writer->build();
+    if (!build_res.ok()) {
+        LOG(WARNING) << "rowset writer build failed. compaction task_id:" << _task_info.task_id
+                     << ", tablet:" << _task_info.tablet_id << " output_version=" << _task_info.output_version;
+        return build_res.status();
+    } else {
+        _output_rowset = build_res.value();
+    }
+    _task_info.output_num_rows = _output_rowset->num_rows();
+    _task_info.output_segments_num = _output_rowset->num_segments();
+    _task_info.output_rowset_size = _output_rowset->data_disk_size();
+    if (statistics) {
+        _task_info.filtered_rows = statistics->filtered_rows;
+        _task_info.merged_rows = statistics->merged_rows;
+    }
+    TRACE_COUNTER_INCREMENT("output_rowset_data_size", _output_rowset->data_disk_size());
+    TRACE_COUNTER_INCREMENT("output_segments_num", _output_rowset->num_segments());
+    TRACE("[Compaction] output rowset built");
+
+    return Status::OK();
+}
+
+Status VerticalCompactionTask::_compact_column_group(bool is_key, int column_group_index,
+                                                     const std::vector<uint32_t>& column_group,
+                                                     RowsetWriter* output_rs_writer,
+                                                     vectorized::RowSourceMaskBuffer* mask_buffer,
+                                                     std::vector<vectorized::RowSourceMask>* source_masks,
+                                                     Statistics* statistics) {
+    vectorized::Schema schema =
+            vectorized::ChunkHelper::convert_schema_to_format_v2(_tablet->tablet_schema(), column_group);
+    vectorized::TabletReader reader(std::static_pointer_cast<Tablet>(_tablet->shared_from_this()),
+                                    output_rs_writer->version(), schema, is_key, mask_buffer);
+    vectorized::TabletReaderParams reader_params;
+    reader_params.reader_type = ReaderType::READER_LEVEL_COMPACTION;
+    reader_params.profile = _runtime_profile.create_child("merge_rowsets");
+
+    StatusOr<int32_t> ret = _calculate_chunk_size_for_column_group(column_group);
+    if (!ret.ok()) {
+        return ret.status();
+    }
+    int32_t chunk_size = ret.value();
+    VLOG(1) << "compaction task_id:" << _task_info.task_id << ", tablet=" << _tablet->tablet_id()
+            << ", column group=" << column_group_index << ", reader chunk size=" << chunk_size;
+    reader_params.chunk_size = chunk_size;
+    RETURN_IF_ERROR(reader.prepare());
+    RETURN_IF_ERROR(reader.open(reader_params));
+
+    StatusOr<size_t> rows_st = _compact_data(is_key, chunk_size, column_group, reader, schema, output_rs_writer,
+                                             mask_buffer, source_masks);
+    if (!rows_st.ok()) {
+        return rows_st.status();
+    }
+
+    if (is_key && statistics) {
+        statistics->output_rows = rows_st.value();
+        statistics->merged_rows = reader.merged_rows();
+        statistics->filtered_rows = reader.stats().rows_del_filtered;
+    }
+
+    RETURN_IF_ERROR(output_rs_writer->flush_columns());
+
+    if (is_key) {
+        RETURN_IF_ERROR(mask_buffer->flush());
+    }
+    return Status::OK();
+}
+
+StatusOr<int32_t> VerticalCompactionTask::_calculate_chunk_size_for_column_group(
+        const std::vector<uint32_t>& column_group) {
+    int64_t total_num_rows = 0;
+    int64_t total_mem_footprint = 0;
+    for (auto& rowset : _input_rowsets) {
+        if (rowset->rowset_meta()->rowset_type() != BETA_ROWSET) {
+            LOG(WARNING) << "unsupported rowset type:" << rowset->rowset_meta()->rowset_type();
+            return Status::InternalError("unsupported rowset type");
+        }
+
+        total_num_rows += rowset->num_rows();
+        auto* beta_rowset = down_cast<BetaRowset*>(rowset.get());
+        for (auto& segment : beta_rowset->segments()) {
+            for (uint32_t column_index : column_group) {
+                const auto* column_reader = segment->column(column_index);
+                if (column_reader == nullptr) {
+                    continue;
+                }
+                total_mem_footprint += column_reader->total_mem_footprint();
+            }
+        }
+    }
+    int32_t chunk_size =
+            CompactionUtils::get_read_chunk_size(config::compaction_memory_limit_per_worker, config::vector_chunk_size,
+                                                 total_num_rows, total_mem_footprint, _task_info.input_segments_num);
+    return chunk_size;
+}
+
+StatusOr<size_t> VerticalCompactionTask::_compact_data(bool is_key, int32_t chunk_size,
+                                                       const std::vector<uint32_t>& column_group,
+                                                       vectorized::TabletReader& reader,
+                                                       const vectorized::Schema& schema, RowsetWriter* output_rs_writer,
+                                                       vectorized::RowSourceMaskBuffer* mask_buffer,
+                                                       std::vector<vectorized::RowSourceMask>* source_masks) {
+    size_t output_rows = 0;
+    auto chunk = vectorized::ChunkHelper::new_chunk(schema, chunk_size);
+    auto char_field_indexes = vectorized::ChunkHelper::get_char_field_indexes(schema);
+
+    Status status = Status::OK();
+    size_t column_group_del_filtered_rows = 0;
+    size_t column_group_merged_rows = 0;
+    while (!should_stop()) {
+#ifndef BE_TEST
+        status = tls_thread_status.mem_tracker()->check_mem_limit("Compaction");
+        if (!status.ok()) {
+            LOG(WARNING) << "fail to execute compaction: " << status.message() << std::endl;
+            return status;
+        }
+#endif
+
+        chunk->reset();
+        status = reader.get_next(chunk.get(), source_masks);
+        if (!status.ok()) {
+            if (status.is_end_of_file()) {
+                break;
+            } else {
+                LOG(WARNING) << "reader get next error. tablet=" << _tablet->tablet_id()
+                             << ", err=" << status.to_string();
+                return Status::InternalError(fmt::format("reader get_next error: {}", status.to_string()));
+            }
+        }
+
+        vectorized::ChunkHelper::padding_char_columns(char_field_indexes, schema, _tablet->tablet_schema(),
+                                                      chunk.get());
+
+        RETURN_IF_ERROR(output_rs_writer->add_columns(*chunk, column_group, is_key));
+
+        _task_info.total_output_num_rows += chunk->num_rows();
+        _task_info.total_del_filtered_rows += reader.stats().rows_del_filtered - column_group_del_filtered_rows;
+        _task_info.total_merged_rows += reader.merged_rows() - column_group_merged_rows;
+        column_group_del_filtered_rows = reader.stats().rows_del_filtered;
+        column_group_merged_rows = reader.merged_rows();
+
+        if (is_key) {
+            output_rows += chunk->num_rows();
+            if (!source_masks->empty()) {
+                RETURN_IF_ERROR(mask_buffer->write(*source_masks));
+            }
+        }
+        if (!source_masks->empty()) {
+            source_masks->clear();
+        }
+    }
+    if (should_stop()) {
+        LOG(INFO) << "vertical compaction task_id:" << _task_info.task_id << " is stopped.";
+        return Status::Cancelled("vertical compaction task is stopped.");
+    }
+    return output_rows;
+}
+
+} // namespace starrocks

--- a/be/src/storage/vertical_compaction_task.h
+++ b/be/src/storage/vertical_compaction_task.h
@@ -35,7 +35,7 @@ private:
                                  std::vector<vectorized::RowSourceMask>* source_masks, Statistics* statistics);
 
     StatusOr<size_t> _compact_data(bool is_key, int32_t chunk_size, const std::vector<uint32_t>& column_group,
-                                   vectorized::TabletReader& reader, const vectorized::Schema& schema,
+                                   const vectorized::TabletReader& reader, const vectorized::Schema& schema,
                                    RowsetWriter* output_rs_writer, vectorized::RowSourceMaskBuffer* mask_buffer,
                                    std::vector<vectorized::RowSourceMask>* source_masks);
 

--- a/be/src/storage/vertical_compaction_task.h
+++ b/be/src/storage/vertical_compaction_task.h
@@ -1,0 +1,45 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#pragma once
+
+#include <vector>
+
+#include "common/status.h"
+#include "common/statusor.h"
+#include "storage/compaction_task.h"
+#include "storage/olap_common.h"
+#include "storage/rowset/rowset.h"
+
+namespace starrocks {
+
+class RowsetWriter;
+namespace vectorized {
+class TabletReader;
+class RowSourceMaskBuffer;
+class RowSourceMask;
+} // namespace vectorized
+
+// need a factory of compaction task
+class VerticalCompactionTask : public CompactionTask {
+public:
+    VerticalCompactionTask() : CompactionTask(VERTICAL_COMPACTION) {}
+    ~VerticalCompactionTask() = default;
+
+    Status run_impl() override;
+
+private:
+    Status _vertical_compaction_data(Statistics* statistics);
+
+    Status _compact_column_group(bool is_key, int column_group_index, const std::vector<uint32_t>& column_group,
+                                 RowsetWriter* output_rs_writer, vectorized::RowSourceMaskBuffer* mask_buffer,
+                                 std::vector<vectorized::RowSourceMask>* source_masks, Statistics* statistics);
+
+    StatusOr<size_t> _compact_data(bool is_key, int32_t chunk_size, const std::vector<uint32_t>& column_group,
+                                   vectorized::TabletReader& reader, const vectorized::Schema& schema,
+                                   RowsetWriter* output_rs_writer, vectorized::RowSourceMaskBuffer* mask_buffer,
+                                   std::vector<vectorized::RowSourceMask>* source_masks);
+
+    StatusOr<int32_t> _calculate_chunk_size_for_column_group(const std::vector<uint32_t>& column_group);
+};
+
+} // namespace starrocks

--- a/be/test/storage/compaction_manager_test.cpp
+++ b/be/test/storage/compaction_manager_test.cpp
@@ -11,9 +11,9 @@
 #include "storage/compaction_context.h"
 #include "storage/compaction_task.h"
 #include "storage/compaction_utils.h"
+#include "storage/storage_engine.h"
 #include "storage/tablet.h"
 #include "storage/tablet_updates.h"
-#include "storage/storage_engine.h"
 
 namespace starrocks {
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [X] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3365 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The original compaction framework polled the candidate tablets one by one. The performance is low and overhead is high.
Now I change the mechanism of picking compaction candidates from polling to triggering by the event(#3311).
Considering StarRocks split the columns of a table into groups,  it can improve the performance(https://github.com/StarRocks/starrocks/pull/2189) of compaction. This pull request adds the horizontal and vertical compaction to the event_based compaction framework.