### PR TITLE
Optimize small read on ORC(small row group index/stripe/file) (#3962)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -665,6 +665,7 @@ CONF_String(object_storage_endpoint, "");
 CONF_Int64(object_storage_max_connection, "102400");
 
 CONF_Bool(enable_orc_late_materialization, "true");
+CONF_Int32(orc_file_cache_max_size, "2097152");
 
 // default: 16MB
 CONF_mInt64(experimental_s3_max_single_part_size, "16777216");

--- a/be/src/exec/vectorized/hdfs_scanner_orc.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_orc.cpp
@@ -15,7 +15,7 @@ class ORCHdfsFileStream : public orc::InputStream {
 public:
     // |file| must outlive ORCHdfsFileStream
     ORCHdfsFileStream(RandomAccessFile* file, uint64_t length, HdfsScanStats* stats)
-            : _file(std::move(file)), _length(length), _stats(stats) {}
+            : _file(std::move(file)), _length(length), _stats(stats), _cache_buffer(0), _cache_offset(0) {}
 
     ~ORCHdfsFileStream() override = default;
 
@@ -40,7 +40,40 @@ public:
 
     uint64_t getNaturalReadSizeAfterSeek() const override { return 256 * 1024; }
 
+    void prepareCache(orc::InputStream::PrepareCacheScope scope, uint64_t offset, uint64_t length) override {
+        const size_t cache_max_size = config::orc_file_cache_max_size;
+        if (length > cache_max_size) return;
+        if (canUseCacheBuffer(offset, length)) return;
+
+        // If this stripe is small, probably other stripes are also small
+        // we combine those reads into one, and try to read several stripes in one shot.
+        if (scope == orc::InputStream::PrepareCacheScope::READ_FULL_STRIPE) {
+            length = std::min(_length - offset, cache_max_size);
+        }
+
+        _cache_buffer.resize(length);
+        _cache_offset = offset;
+        doRead(_cache_buffer.data(), length, offset);
+    }
+
+    inline bool canUseCacheBuffer(uint64_t offset, uint64_t length) {
+        if ((_cache_buffer.size() != 0) && (offset >= _cache_offset) &&
+            ((offset + length) <= (_cache_offset + _cache_buffer.size()))) {
+            return true;
+        }
+        return false;
+    }
+
     void read(void* buf, uint64_t length, uint64_t offset) override {
+        if (canUseCacheBuffer(offset, length)) {
+            size_t idx = offset - _cache_offset;
+            memcpy(buf, _cache_buffer.data() + idx, length);
+        } else {
+            doRead(buf, length, offset);
+        }
+    }
+
+    void doRead(void* buf, uint64_t length, uint64_t offset) {
         SCOPED_RAW_TIMER(&_stats->io_ns);
         _stats->io_count += 1;
         if (buf == nullptr) {
@@ -61,6 +94,8 @@ private:
     RandomAccessFile* _file;
     uint64_t _length;
     HdfsScanStats* _stats;
+    std::vector<char> _cache_buffer;
+    uint64_t _cache_offset;
 };
 
 class OrcRowReaderFilter : public orc::RowReaderFilter {

--- a/be/src/formats/orc/apache-orc/c++/include/orc/OrcFile.hh
+++ b/be/src/formats/orc/apache-orc/c++/include/orc/OrcFile.hh
@@ -39,6 +39,12 @@ namespace orc {
    */
 class InputStream {
 public:
+    enum class PrepareCacheScope {
+        READ_FULL_FILE,
+        READ_FULL_STRIPE,
+        READ_ROW_GROUP_INDEX,
+    };
+
     virtual ~InputStream();
 
     /**
@@ -71,6 +77,8 @@ public:
      * Get the name of the stream for error messages.
      */
     virtual const std::string& getName() const = 0;
+
+    virtual void prepareCache(PrepareCacheScope scope, uint64_t offset, uint64_t length);
 };
 
 /**

--- a/be/src/formats/orc/apache-orc/c++/src/Reader.cc
+++ b/be/src/formats/orc/apache-orc/c++/src/Reader.cc
@@ -338,23 +338,8 @@ void RowReaderImpl::loadStripeIndex() {
 
     // obtain row indexes for selected columns
     uint64_t offset = currentStripeInfo.offset();
-
-    static const uint64_t MAX_ONE_READ_ROW_INDEX_SIZE = 1024 * 1024;
     uint64_t rowIndexSize = currentStripeInfo.indexlength();
-    uint64_t startOffset = offset;
-    // rowIndexBufferData is allocated in rowIndexInputStream
-    std::unique_ptr<SeekableFileInputStream> rowIndexInputStream = nullptr;
-    const char* rowIndexBufferData = nullptr;
-    if (rowIndexSize < MAX_ONE_READ_ROW_INDEX_SIZE) {
-        rowIndexInputStream = std::unique_ptr<SeekableFileInputStream>(new SeekableFileInputStream(
-                contents->stream.get(), startOffset, rowIndexSize, *contents->pool, rowIndexSize));
-        int size = 0;
-        const void* data = nullptr;
-        if (!rowIndexInputStream->Next(&data, &size) || static_cast<uint64_t>(size) != rowIndexSize) {
-            throw ParseError("Failed to read the row index data");
-        }
-        rowIndexBufferData = static_cast<const char*>(data);
-    }
+    contents->stream->prepareCache(InputStream::PrepareCacheScope::READ_ROW_GROUP_INDEX, offset, rowIndexSize);
 
     for (int i = 0; i < currentStripeFooter.streams_size(); ++i) {
         const proto::Stream& pbStream = currentStripeFooter.streams(i);
@@ -362,16 +347,11 @@ void RowReaderImpl::loadStripeIndex() {
         if (selectedColumns[colId] && pbStream.has_kind() &&
             (pbStream.kind() == proto::Stream_Kind_ROW_INDEX ||
              pbStream.kind() == proto::Stream_Kind_BLOOM_FILTER_UTF8)) {
-            std::unique_ptr<SeekableInputStream> inputStream = nullptr;
-            if (rowIndexBufferData) {
-                inputStream = std::unique_ptr<SeekableInputStream>(
-                        new SeekableArrayInputStream(rowIndexBufferData + offset - startOffset, pbStream.length()));
-            } else {
-                inputStream = std::unique_ptr<SeekableInputStream>(new SeekableFileInputStream(
-                        contents->stream.get(), offset, pbStream.length(), *contents->pool));
-            }
             std::unique_ptr<SeekableInputStream> inStream =
-                    createDecompressor(getCompression(), std::move(inputStream), getCompressionSize(), *contents->pool);
+                    createDecompressor(getCompression(),
+                                       std::unique_ptr<SeekableInputStream>(new SeekableFileInputStream(
+                                               contents->stream.get(), offset, pbStream.length(), *contents->pool)),
+                                       getCompressionSize(), *contents->pool);
 
             if (pbStream.kind() == proto::Stream_Kind_ROW_INDEX) {
                 proto::RowIndex rowIndex;
@@ -910,9 +890,9 @@ void RowReaderImpl::startNextStripe() {
     while (currentStripe < lastStripe) {
         currentStripeInfo = footer->stripes(static_cast<int>(currentStripe));
         uint64_t fileLength = contents->stream->getLength();
-        if (currentStripeInfo.offset() + currentStripeInfo.indexlength() + currentStripeInfo.datalength() +
-                    currentStripeInfo.footerlength() >=
-            fileLength) {
+        size_t stripeSize =
+                currentStripeInfo.indexlength() + currentStripeInfo.datalength() + currentStripeInfo.footerlength();
+        if ((currentStripeInfo.offset() + stripeSize) >= fileLength) {
             std::stringstream msg;
             msg << "Malformed StripeInformation at stripe index " << currentStripe << ": fileLength=" << fileLength
                 << ", StripeInfo=(offset=" << currentStripeInfo.offset()
@@ -930,6 +910,8 @@ void RowReaderImpl::startNextStripe() {
             }
         }
 
+        contents->stream->prepareCache(InputStream::PrepareCacheScope::READ_FULL_STRIPE, currentStripeInfo.offset(),
+                                       stripeSize);
         currentStripeFooter = getStripeFooter(currentStripeInfo, *contents);
         rowsInCurrentStripe = currentStripeInfo.numberofrows();
 
@@ -1272,6 +1254,7 @@ std::unique_ptr<Reader> createReader(std::unique_ptr<InputStream> stream, const 
             throw ParseError("File size too small");
         }
         std::unique_ptr<DataBuffer<char>> buffer(new DataBuffer<char>(*contents->pool, readSize));
+        stream->prepareCache(InputStream::PrepareCacheScope::READ_FULL_FILE, 0, fileLength);
         stream->read(buffer->data(), readSize, fileLength - readSize);
 
         postscriptLength = buffer->data()[readSize - 1] & 0xff;
@@ -1369,5 +1352,7 @@ InputStream::~InputStream(){
 uint64_t InputStream::getNaturalReadSizeAfterSeek() const {
     return 128 * 1024;
 }
+
+void InputStream::prepareCache(PrepareCacheScope scope, uint64_t offset, uint64_t length) {}
 
 } // namespace orc


### PR DESCRIPTION
This PR is to optimization read small orc file and small stripe. And what's more, we can put previous optimization on row group index into this framework.

Handle Small File
=======
I set up a test environment of a lot of small hdfs files. All of them are small files under 2MB.

```
-rw-r-----   3 hadoop hadoop    1332877 2022-03-09 12:10 /user/zya/tpch_100g/lineitem_smallfile_zlib/012314_0
-rw-r-----   3 hadoop hadoop    1328418 2022-03-09 12:11 /user/zya/tpch_100g/lineitem_smallfile_zlib/012315_0
-rw-r-----   3 hadoop hadoop    1312973 2022-03-09 12:11 /user/zya/tpch_100g/lineitem_smallfile_zlib/012316_0
-rw-r-----   3 hadoop hadoop    1304832 2022-03-09 12:11 /user/zya/tpch_100g/lineitem_smallfile_zlib/012317_0
-rw-r-----   3 hadoop hadoop     878983 2022-03-09 12:10 /user/zya/tpch_100g/lineitem_smallfile_zlib/012318_0
```

Running query
> select count(*) from lineitem_smallfile;

You can see although IOBytes increased, but IOCounte decreased. And average bytes per IO is increase from (629.1MB / 257.963K ~= 2.69KB) to (16.72GB / 12.319K ~= 1.35MB)

Before optimization

```
         HDFS_SCAN_NODE (id=0):(Active: 8s861ms[8861568366ns], % non-child: 98.73%)
             - BytesRead: 0.00
             - BytesReadDataNodeCache: 0.00
             - BytesReadFromDisk: 629.10 MB
             - BytesReadLocal: 0.00
             - BytesReadRemote: 629.10 MB
             - BytesReadShortCircuit: 0.00
             - BytesTotalRead: 629.10 MB
             - IoCounter: 257.063K (257063)
             - IoTime: 6m10s
```

After optimization
```
          HDFS_SCAN_NODE (id=0):(Active: 4s322ms[4322893106ns], % non-child: 97.17%)
             - Table: lineitem_smallfile
             - Predicates:
             - PredicatesPartition:
             - BytesRead: 16.72 GB
             - ColumnConvertTime: 1s250ms
             - ColumnReadTime: 16s355ms
             - ExprFilterTime: 8.39ms
             - HdfsIO: 0ns
               - TotalBytesRead: 17.957812729B (17957812729)
               - TotalLocalBytesRead: 0
               - TotalShortCircuitBytesRead: 0
               - TotalZeroCopyBytesRead: 0
             - IoCounter: 12.319K (12319) // <=== exact file number
             - IoTime: 2m17s
```

Handle Stripe Size
=======
I set up a test environment of a single file but with small stripe size. You can see a stripe size is abot 700K, and there are 350 stripes in a single file.

> java -jar ~/installed/orc-tools-1.7.0-SNAPSHOT-uber.jar meta test_many_columns.orc

```
  Stripe 348:
  Stripe 349:
  Stripe 350:
Stripes:
  Stripe: offset: 3 data: 722325 rows: 2864 tail: 1861 index: 9095
  Stripe: offset: 733284 data: 763098 rows: 2864 tail: 1907 index: 9096
  Stripe: offset: 1507385 data: 776631 rows: 2864 tail: 1880 index: 9097
```

Normally we don't have such small stripe size. Usually stripe size is about 256MB. But there are some bugs in SparkSQL may use small stripe size.
- https://community.cloudera.com/t5/Support-Questions/Spark-ORC-Stripe-Size/td-p/189844
- https://issues.apache.org/jira/browse/HIVE-13232

Running query
> select max(c1) from test_many_columns;

You can see IOCounter is cut from 2451 down to 351.

Before optimization

```
          HDFS_SCAN_NODE (id=0):(Active: 2s771ms[2771719221ns], % non-child: 99.20%)
             - BytesRead: 0.00
             - BytesReadDataNodeCache: 0.00
             - BytesReadFromDisk: 1.92 MB
             - BytesReadLocal: 0.00
             - BytesReadRemote: 1.92 MB
             - BytesReadShortCircuit: 0.00
             - BytesTotalRead: 1.92 MB
             - ColumnConvertTime: 20.341ms
             - ColumnReadTime: 1s814ms
             - ExprFilterTime: 0ns
             - GroupChunkRead: 0ns
             - GroupDictDecode: 0ns
             - GroupDictFilter: 0ns
             - IoCounter: 2.451K (2451)
             - IoTime: 1s772ms
```

After optimization

```
          HDFS_SCAN_NODE (id=0):(Active: 697.474ms[697474842ns], % non-child: 98.24%)
             - Table: test_many_columns
             - Predicates:
             - PredicatesPartition:
             - BytesRead: 255.89 MB
             - ColumnConvertTime: 20.537ms
             - ColumnReadTime: 676.219ms
             - ExprFilterTime: 15.637us
             - HdfsIO: 0ns
               - TotalBytesRead: 268.315441M (268315441)
               - TotalLocalBytesRead: 0
               - TotalShortCircuitBytesRead: 0
               - TotalZeroCopyBytesRead: 0
             - IoCounter: 351 // <== exact stripe size + file footer read.
             - IoTime: 612.488ms
```

And if we combine reads of stripes, we can save more IOCounter

```
          HDFS_SCAN_NODE (id=0):(Active: 643.709ms[643709229ns], % non-child: 97.69%)
             - Table: test_many_columns
             - Predicates:
             - PredicatesPartition:
             - BytesRead: 349.31 MB
             - ColumnConvertTime: 22.263ms
             - ColumnReadTime: 623.502ms
             - ExprFilterTime: 11.235us
             - HdfsIO: 0ns
               - TotalBytesRead: 366.282951M (366282951)
               - TotalLocalBytesRead: 0
               - TotalShortCircuitBytesRead: 0
               - TotalZeroCopyBytesRead: 0
             - IoCounter: 176
             - IoTime: 564.540ms
 ```

## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
