### PR TITLE
bugfix:Cast EsScanNode to OlapScanNode mistakenly when pipelineDop adaptation is enabled

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -935,6 +935,9 @@ public class Coordinator {
         }
         int dop = ConnectContext.get().getSessionVariable().getDegreeOfParallelism();
         for (FragmentExecParams params : fragmentExecParamsMap.values()) {
+            if (!params.fragment.getPlanRoot().canUsePipeLine()) {
+                continue;
+            }
             List<PlanNode> scanNodes = new LinkedList<>();
             params.fragment.getOlapScanNodes(params.fragment.getPlanRoot(), scanNodes);
             for (PlanNode node : scanNodes) {
@@ -1122,11 +1125,13 @@ public class Coordinator {
         // the latter might inherit the set of hosts from the former
         // compute hosts *bottom up*.
 
-        boolean dopAdaptionEnabled = ConnectContext.get() != null &&
-                ConnectContext.get().getSessionVariable().isPipelineDopAdaptionEnabled();
         for (int i = fragments.size() - 1; i >= 0; --i) {
             PlanFragment fragment = fragments.get(i);
             FragmentExecParams params = fragmentExecParamsMap.get(fragment.getFragmentId());
+
+            boolean dopAdaptionEnabled = ConnectContext.get() != null &&
+                    ConnectContext.get().getSessionVariable().isPipelineDopAdaptionEnabled() &&
+                    fragment.getPlanRoot().canUsePipeLine();
 
             if (fragment.getDataPartition() == DataPartition.UNPARTITIONED) {
                 Reference<Long> backendIdRef = new Reference<>();
@@ -1517,7 +1522,8 @@ public class Coordinator {
             }
         }
         boolean dopAdaptionEnabled = ConnectContext.get() != null &&
-                ConnectContext.get().getSessionVariable().isPipelineDopAdaptionEnabled();
+                ConnectContext.get().getSessionVariable().isPipelineDopAdaptionEnabled() &&
+                params.fragment.getPlanRoot().canUsePipeLine();
         // ensure numInstances * pipelineDop = degreeOfParallelism when dop adaptation is enabled
         if (dopAdaptionEnabled && params.fragment.isNeedsLocalShuffle()) {
             int numInstances = params.instanceExecParams.size();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1131,7 +1131,8 @@ public class PlanFragmentBuilder {
             boolean notNeedLocalShuffle = aggregationNode.isNeedsFinalize() &&
                     hasNoExchangeNodes(inputFragment.getPlanRoot());
             boolean pipelineDopEnabled = ConnectContext.get() != null &&
-                    ConnectContext.get().getSessionVariable().isPipelineDopAdaptionEnabled();
+                    ConnectContext.get().getSessionVariable().isPipelineDopAdaptionEnabled() &&
+                    inputFragment.getPlanRoot().canUsePipeLine();
             if (pipelineDopEnabled && notNeedLocalShuffle) {
                 inputFragment.setNeedsLocalShuffle(false);
             }


### PR DESCRIPTION
…

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

The issue of casting an EsScanNode to OlapScanNode mistakenly is already fixed at main branch but other PRs, but main and branch-2.1 have a lot PRs between them, so modify branch-2.1 standalonely.