### PR TITLE
[cherry-pick][branch-2.2] Persist meta once in publish version group (#3841)

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -64,6 +64,7 @@ namespace starrocks {
 const uint32_t TASK_FINISH_MAX_RETRY = 3;
 const uint32_t PUBLISH_VERSION_MAX_RETRY = 3;
 const uint32_t PUBLISH_VERSION_SUBMIT_MAX_RETRY = 10;
+const size_t PUBLISH_VERSION_BATCH_SIZE = 10;
 
 std::atomic_ulong TaskWorkerPool::_s_report_version(time(nullptr) * 10000);
 std::mutex TaskWorkerPool::_s_task_signatures_locks[TTaskType::type::NUM_TASK_TYPE];
@@ -707,7 +708,8 @@ void* TaskWorkerPool::_push_worker_thread_callback(void* arg_this) {
 }
 
 Status TaskWorkerPool::_publish_version_in_parallel(void* arg_this, std::unique_ptr<ThreadPool>& threadpool,
-                                                    const TPublishVersionRequest publish_version_req, size_t* tablet_n,
+                                                    const TPublishVersionRequest publish_version_req,
+                                                    std::set<TTabletId>* tablet_ids, size_t* tablet_n,
                                                     std::vector<TTabletId>* error_tablet_ids) {
     TaskWorkerPool* worker_pool_this = (TaskWorkerPool*)arg_this;
     int64_t transaction_id = publish_version_req.transaction_id;
@@ -797,8 +799,8 @@ Status TaskWorkerPool::_publish_version_in_parallel(void* arg_this, std::unique_
                     error_status = status;
                 }
             }
+            tablet_ids->insert(tablet_info.tablet_id);
         }
-        *tablet_n += tablet_infos.size();
     }
     return error_status;
 }
@@ -814,12 +816,16 @@ void* TaskWorkerPool::_publish_version_worker_thread_callback(void* arg_this) {
                     // The ideal queue size of threadpool should be larger than the maximum number of tablet of a partition.
                     // But it seems that there's no limit for the number of tablets of a partition.
                     // Since a large queue size brings a little overhead, a big one is chosen here.
-                    .set_max_queue_size(256)
+                    .set_max_queue_size(2048)
                     .build(&threadpool);
+    assert(st.ok());
+
+    std::vector<TAgentTaskRequest> task_requests;
+    std::vector<TFinishTaskRequest> finish_task_requests;
+    std::set<TTabletId> tablet_ids;
+    std::vector<TabletSharedPtr> tablets;
 
     while (true) {
-        TAgentTaskRequest agent_task_req;
-        TPublishVersionRequest publish_version_req;
         {
             std::unique_lock l(worker_pool_this->_worker_thread_lock);
             while (worker_pool_this->_tasks.empty() && !(worker_pool_this->_stopped)) {
@@ -829,54 +835,86 @@ void* TaskWorkerPool::_publish_version_worker_thread_callback(void* arg_this) {
                 break;
             }
 
-            agent_task_req = worker_pool_this->_tasks.front();
-            publish_version_req = agent_task_req.publish_version_req;
-            worker_pool_this->_tasks.pop_front();
-        }
-
-        StarRocksMetrics::instance()->publish_task_request_total.increment(1);
-        LOG(INFO) << "get publish version task, signature:" << agent_task_req.signature;
-
-        std::vector<TTabletId> error_tablet_ids;
-        uint32_t retry_time = 0;
-        Status status;
-
-        size_t tablet_n = 0;
-        while (retry_time < PUBLISH_VERSION_MAX_RETRY) {
-            error_tablet_ids.clear();
-            status = _publish_version_in_parallel(arg_this, threadpool, publish_version_req, &tablet_n,
-                                                  &error_tablet_ids);
-            if (status.ok()) {
-                break;
-            } else {
-                LOG(WARNING) << "publish version error, retry. [transaction_id=" << publish_version_req.transaction_id
-                             << ", error_tablets_size=" << error_tablet_ids.size() << "]";
-                ++retry_time;
-                SleepFor(MonoDelta::FromSeconds(1));
+            while (!worker_pool_this->_tasks.empty() && task_requests.size() < PUBLISH_VERSION_BATCH_SIZE) {
+                // collect some publish version tasks as a group.
+                task_requests.push_back(worker_pool_this->_tasks.front());
+                worker_pool_this->_tasks.pop_front();
             }
         }
 
-        TFinishTaskRequest finish_task_request;
-        if (!status.ok()) {
-            StarRocksMetrics::instance()->publish_task_failed_total.increment(1);
-            // if publish failed, return failed, FE will ignore this error and
-            // check error tablet ids and FE will also republish this task
-            LOG(WARNING) << "Fail to publish version. signature:" << agent_task_req.signature
-                         << " related tablet num: " << tablet_n;
-            finish_task_request.__set_error_tablet_ids(error_tablet_ids);
-        } else {
-            LOG(INFO) << "publish_version success. signature:" << agent_task_req.signature
-                      << " related tablet num: " << tablet_n;
+        for (size_t i = 0; i < task_requests.size(); ++i) {
+            auto& publish_version_task = task_requests[i];
+            StarRocksMetrics::instance()->publish_task_request_total.increment(1);
+            LOG(INFO) << "get publish version task, signature:" << publish_version_task.signature << " index: " << i
+                      << " group size: " << task_requests.size();
+
+            auto& publish_version_req = publish_version_task.publish_version_req;
+            std::vector<TTabletId> error_tablet_ids;
+            uint32_t retry_time = 0;
+            Status status;
+
+            size_t tablet_n = 0;
+            while (retry_time < PUBLISH_VERSION_MAX_RETRY) {
+                error_tablet_ids.clear();
+                status = _publish_version_in_parallel(arg_this, threadpool, publish_version_req, &tablet_ids, &tablet_n,
+                                                      &error_tablet_ids);
+                if (status.ok()) {
+                    break;
+                } else {
+                    LOG(WARNING) << "publish version error, retry. [transaction_id="
+                                 << publish_version_req.transaction_id
+                                 << ", error_tablets_size=" << error_tablet_ids.size() << "]";
+                    ++retry_time;
+                    SleepFor(MonoDelta::FromSeconds(1));
+                }
+            }
+
+            TFinishTaskRequest finish_task_request;
+            if (!status.ok()) {
+                StarRocksMetrics::instance()->publish_task_failed_total.increment(1);
+                // if publish failed, return failed, FE will ignore this error and
+                // check error tablet ids and FE will also republish this task
+                LOG(WARNING) << "Fail to publish version. signature:" << publish_version_task.signature
+                             << " related tablet num: " << tablet_n;
+                finish_task_request.__set_error_tablet_ids(error_tablet_ids);
+            } else {
+                LOG(INFO) << "publish_version success. signature:" << publish_version_task.signature
+                          << " related tablet num: " << tablet_n;
+            }
+
+            status.to_thrift(&finish_task_request.task_status);
+            finish_task_request.__set_backend(worker_pool_this->_backend);
+            finish_task_request.__set_task_type(publish_version_task.task_type);
+            finish_task_request.__set_signature(publish_version_task.signature);
+            finish_task_request.__set_report_version(_s_report_version);
+
+            finish_task_requests.emplace_back(std::move(finish_task_request));
         }
 
-        status.to_thrift(&finish_task_request.task_status);
-        finish_task_request.__set_backend(worker_pool_this->_backend);
-        finish_task_request.__set_task_type(agent_task_req.task_type);
-        finish_task_request.__set_signature(agent_task_req.signature);
-        finish_task_request.__set_report_version(_s_report_version);
+        // persist all related meta once in a group.
+        tablets.reserve(tablet_ids.size());
+        for (const auto tablet_id : tablet_ids) {
+            TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id);
+            if (tablet != nullptr) {
+                tablets.push_back(tablet);
+            }
+        }
 
-        worker_pool_this->_finish_task(finish_task_request);
-        worker_pool_this->_remove_task_info(agent_task_req.task_type, agent_task_req.signature);
+        auto st = StorageEngine::instance()->txn_manager()->persist_tablet_related_txns(tablets);
+        if (!st.ok()) {
+            LOG(WARNING) << "failed to persist transactions, tablets num: " << tablets.size() << " err: " << st;
+        }
+
+        tablet_ids.clear();
+        tablets.clear();
+
+        // notify FE when all tasks of group have been finished.
+        for (auto& finish_task_request : finish_task_requests) {
+            worker_pool_this->_finish_task(finish_task_request);
+            worker_pool_this->_remove_task_info(finish_task_request.task_type, finish_task_request.signature);
+        }
+        task_requests.clear();
+        finish_task_requests.clear();
     }
     threadpool->shutdown();
     return (void*)nullptr;

--- a/be/src/agent/task_worker_pool.h
+++ b/be/src/agent/task_worker_pool.h
@@ -99,7 +99,8 @@ private:
     static void* _drop_tablet_worker_thread_callback(void* arg_this);
     static void* _push_worker_thread_callback(void* arg_this);
     static Status _publish_version_in_parallel(void* arg_this, std::unique_ptr<ThreadPool>& threadpool,
-                                               const TPublishVersionRequest publish_version_req, size_t* tablet_n,
+                                               const TPublishVersionRequest publish_version_req,
+                                               std::set<TTabletId>* tablet_ids, size_t* tablet_n,
                                                std::vector<TTabletId>* error_tablet_ids);
     static void* _publish_version_worker_thread_callback(void* arg_this);
     static void* _clear_transaction_task_worker_thread_callback(void* arg_this);

--- a/be/src/storage/kv_store.cpp
+++ b/be/src/storage/kv_store.cpp
@@ -264,6 +264,10 @@ Status KVStore::compact(uint64_t* size_before, uint64_t* size_after) {
     return to_status(st);
 }
 
+Status KVStore::flush() {
+    return to_status(_db->FlushWAL(true));
+}
+
 std::string KVStore::get_stats() {
     rocksdb::ColumnFamilyHandle* handle = _handles[META_COLUMN_FAMILY_INDEX];
     std::string stats;

--- a/be/src/storage/kv_store.h
+++ b/be/src/storage/kv_store.h
@@ -66,6 +66,8 @@ public:
 
     Status compact(uint64_t* size_before, uint64_t* size_after);
 
+    Status flush();
+
     std::string get_stats();
 
     std::string get_root_path();

--- a/be/src/storage/rowset/rowset_meta_manager.cpp
+++ b/be/src/storage/rowset/rowset_meta_manager.cpp
@@ -51,6 +51,10 @@ Status RowsetMetaManager::save(KVStore* meta, const TabletUid& tablet_uid, const
     return meta->put(META_COLUMN_FAMILY_INDEX, key, value);
 }
 
+Status RowsetMetaManager::flush(KVStore* meta) {
+    return meta->flush();
+}
+
 Status RowsetMetaManager::remove(KVStore* meta, const TabletUid& tablet_uid, const RowsetId& rowset_id) {
     std::string key = get_rowset_meta_key(tablet_uid, rowset_id);
     return meta->remove(META_COLUMN_FAMILY_INDEX, key);

--- a/be/src/storage/rowset/rowset_meta_manager.h
+++ b/be/src/storage/rowset/rowset_meta_manager.h
@@ -38,6 +38,8 @@ public:
     static Status save(KVStore* meta, const TabletUid& tablet_uid, const RowsetId& rowset_id,
                        const RowsetMetaPB& rowset_meta_pb);
 
+    static Status flush(KVStore* meta);
+
     static Status remove(KVStore* meta, const TabletUid& tablet_uid, const RowsetId& rowset_id);
 
     static string get_rowset_meta_key(const TabletUid& tablet_uid, const RowsetId& rowset_id);

--- a/be/src/storage/txn_manager.cpp
+++ b/be/src/storage/txn_manager.cpp
@@ -323,6 +323,32 @@ Status TxnManager::publish_txn2(TTransactionId transaction_id, TPartitionId part
     }
 }
 
+Status TxnManager::persist_tablet_related_txns(const std::vector<TabletSharedPtr>& tablets) {
+    int64_t duration_ns = 0;
+    SCOPED_RAW_TIMER(&duration_ns);
+
+    std::unordered_set<std::string> persited;
+    for (auto& tablet : tablets) {
+        if (tablet == nullptr) {
+            continue;
+        }
+        auto path = tablet->data_dir()->path();
+        // skip persisted meta.
+        if (persited.find(path) != persited.end()) continue;
+
+        auto st = tablet->data_dir()->get_meta()->flush();
+        if (!st.ok()) {
+            LOG(WARNING) << "Failed to persist tablet meta, tablet_id: " << tablet->table_id() << " res: " << st;
+            return st;
+        }
+        persited.insert(path);
+    }
+
+    StarRocksMetrics::instance()->txn_persist_total.increment(1);
+    StarRocksMetrics::instance()->txn_persist_duration_us.increment(duration_ns / 1000);
+    return Status::OK();
+}
+
 // txn could be rollbacked if it does not have related rowset
 // if the txn has related rowset then could not rollback it, because it
 // may be committed in another thread and our current thread meets errors when writing to data file

--- a/be/src/storage/txn_manager.h
+++ b/be/src/storage/txn_manager.h
@@ -80,6 +80,9 @@ public:
     Status publish_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, TTransactionId transaction_id,
                        const Version& version);
 
+    // persist_tablet_related_txns persists the tablets' meta and make it crash-safe.
+    Status persist_tablet_related_txns(const std::vector<TabletSharedPtr>& tablets);
+
     // publish_txn for updatable tablet
     Status publish_txn2(TTransactionId transaction_id, TPartitionId partition_id, const TabletSharedPtr& tablet,
                         int64_t version);

--- a/be/src/util/starrocks_metrics.h
+++ b/be/src/util/starrocks_metrics.h
@@ -136,6 +136,10 @@ public:
     METRIC_DEFINE_INT_COUNTER(txn_commit_request_total, MetricUnit::OPERATIONS);
     METRIC_DEFINE_INT_COUNTER(txn_rollback_request_total, MetricUnit::OPERATIONS);
     METRIC_DEFINE_INT_COUNTER(txn_exec_plan_total, MetricUnit::OPERATIONS);
+
+    METRIC_DEFINE_INT_COUNTER(txn_persist_total, MetricUnit::OPERATIONS);
+    METRIC_DEFINE_INT_COUNTER(txn_persist_duration_us, MetricUnit::MICROSECONDS);
+
     METRIC_DEFINE_INT_COUNTER(stream_receive_bytes_total, MetricUnit::BYTES);
     METRIC_DEFINE_INT_COUNTER(stream_load_rows_total, MetricUnit::ROWS);
     METRIC_DEFINE_INT_COUNTER(load_rows_total, MetricUnit::ROWS);


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3140

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Flush the WAL of RocksDB after saving the meta. There are two flush operations during load.
One is the commit, and the other is the publish. To alleviate the I/O operations, we batch the flush operations.