### PR TITLE
[cherry-pick]Do not send migrate task when BE only have 1 storage medium (#4002)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
@@ -30,6 +30,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Table;
 import com.starrocks.catalog.Replica.ReplicaState;
 import com.starrocks.common.Pair;
+import com.starrocks.system.Backend;
 import com.starrocks.thrift.TPartitionVersionInfo;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TTablet;
@@ -128,6 +129,12 @@ public class TabletInvertedIndex {
             }
         }
 
+        int backendStorageTypeCnt = -1;
+        Backend be = Catalog.getCurrentSystemInfo().getBackend(backendId);
+        if (be != null) {
+            backendStorageTypeCnt = be.getAvailableBackendStorageTypeCnt();
+        }
+
         readLock();
         long start = System.currentTimeMillis();
         try {
@@ -167,7 +174,7 @@ public class TabletInvertedIndex {
 
                                 if (needRecover(replica, tabletMeta.getOldSchemaHash(), backendTabletInfo)) {
                                     LOG.warn("replica {} of tablet {} on backend {} need recovery. "
-                                                    + "replica in FE: {}, report version {}-{}, report schema hash: {},"
+                                                    + "replica in FE: {}, report version {}, report schema hash: {},"
                                                     + " is bad: {}, is version missing: {}",
                                             replica.getId(), tabletId, backendId, replica,
                                             backendTabletInfo.getVersion(),
@@ -183,8 +190,16 @@ public class TabletInvertedIndex {
                                 long partitionId = tabletMeta.getPartitionId();
                                 TStorageMedium storageMedium = storageMediumMap.get(partitionId);
                                 if (storageMedium != null && backendTabletInfo.isSetStorage_medium()) {
+                                    // If storage medium is less than 1, there is no need to send migration tasks to BE.
+                                    // Because BE will ignore this request.
                                     if (storageMedium != backendTabletInfo.getStorage_medium()) {
-                                        tabletMigrationMap.put(storageMedium, tabletId);
+                                        if (backendStorageTypeCnt <= 1) {
+                                            LOG.debug("available storage medium type count is less than 1, " +
+                                                            "no need to send migrate task. tabletId={}, backendId={}.",
+                                                            tabletId, backendId);
+                                        } else {
+                                            tabletMigrationMap.put(storageMedium, tabletId);
+                                        }
                                     }
                                     if (storageMedium != tabletMeta.getStorageMedium()) {
                                         tabletMeta.setStorageMedium(storageMedium);

--- a/fe/fe-core/src/main/java/com/starrocks/system/Backend.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/Backend.java
@@ -24,6 +24,7 @@ package com.starrocks.system;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.starrocks.alter.DecommissionBackendJob.DecommissionType;
 import com.starrocks.catalog.Catalog;
 import com.starrocks.catalog.DiskInfo;
@@ -43,6 +44,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -691,6 +693,20 @@ public class Backend implements Writable {
 
     private long getDiskNumByStorageMedium(TStorageMedium storageMedium) {
         return disksRef.values().stream().filter(v -> v.getStorageMedium() == storageMedium).count();
+    }
+
+    public int getAvailableBackendStorageTypeCnt() {
+        if (!this.isAlive.get()) {
+            return 0;
+        }
+        ImmutableMap<String, DiskInfo> disks = this.getDisks();
+        Set<TStorageMedium> set = Sets.newHashSet();
+        for (DiskInfo diskInfo : disks.values()) {
+            if (diskInfo.getState() == DiskState.ONLINE) {
+                set.add(diskInfo.getStorageMedium());
+            }
+        }
+        return set.size();
     }
 
     private int getDiskNum() {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/BackendTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/BackendTest.java
@@ -21,10 +21,12 @@
 
 package com.starrocks.catalog;
 
+import com.google.common.collect.ImmutableMap;
 import com.starrocks.analysis.AccessTestUtil;
 import com.starrocks.common.FeConstants;
 import com.starrocks.system.Backend;
 import com.starrocks.thrift.TDisk;
+import com.starrocks.thrift.TStorageMedium;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -183,6 +185,43 @@ public class BackendTest {
         // 3. delete files
         dis.close();
         file.delete();
+    }
+
+    @Test
+    public void testGetBackendStorageTypeCnt() {
+
+        int backendStorageTypeCnt;
+        Backend backend = new Backend(100L, "192.168.1.1", 9050);
+        backendStorageTypeCnt = backend.getAvailableBackendStorageTypeCnt();
+        Assert.assertEquals(0, backendStorageTypeCnt);
+
+        backend.setAlive(true);
+        DiskInfo diskInfo1 = new DiskInfo("/tmp/abc");
+        diskInfo1.setStorageMedium(TStorageMedium.HDD);
+        ImmutableMap<String, DiskInfo> disks = ImmutableMap.of("/tmp/abc", diskInfo1);
+        backend.setDisks(disks);
+        backendStorageTypeCnt = backend.getAvailableBackendStorageTypeCnt();
+        Assert.assertEquals(1, backendStorageTypeCnt);
+
+        DiskInfo diskInfo2 = new DiskInfo("/tmp/abc");
+        diskInfo2.setStorageMedium(TStorageMedium.SSD);
+        disks = ImmutableMap.of("/tmp/abc", diskInfo1, "/tmp/abcd", diskInfo2);
+        backend.setDisks(disks);
+        backendStorageTypeCnt = backend.getAvailableBackendStorageTypeCnt();
+        Assert.assertEquals(2, backendStorageTypeCnt);
+
+        diskInfo2.setStorageMedium(TStorageMedium.HDD);
+        disks = ImmutableMap.of("/tmp/abc", diskInfo1, "/tmp/abcd", diskInfo2);
+        backend.setDisks(disks);
+        backendStorageTypeCnt = backend.getAvailableBackendStorageTypeCnt();
+        Assert.assertEquals(1, backendStorageTypeCnt);
+
+        diskInfo1.setState(DiskInfo.DiskState.OFFLINE);
+        disks = ImmutableMap.of("/tmp/abc", diskInfo1);
+        backend.setDisks(disks);
+        backendStorageTypeCnt = backend.getAvailableBackendStorageTypeCnt();
+        Assert.assertEquals(0, backendStorageTypeCnt);
+
     }
 
 }


### PR DESCRIPTION
when be report tablet info to fe.
If we know that this BE must have no other medium, then only write a log as a reminder, not to send a task.

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
