### PR TITLE
fix null check in functions

### DIFF
--- a/be/src/column/const_column.h
+++ b/be/src/column/const_column.h
@@ -36,7 +36,7 @@ public:
 
     bool is_null(size_t index) const override { return _data->is_null(0); }
 
-    bool only_null() const override { return _data->is_nullable(); }
+    bool only_null() const override { return _data->is_null(0); }
 
     bool has_null() const override { return _data->has_null(); }
 

--- a/be/src/exprs/agg/group_concat.h
+++ b/be/src/exprs/agg/group_concat.h
@@ -39,8 +39,7 @@ public:
                 size_t row_num) const override {
         DCHECK(columns[0]->is_binary());
         if (ctx->get_num_args() > 1) {
-            auto const_column_sep = ctx->get_constant_column(1);
-            if (const_column_sep == nullptr) {
+            if (!ctx->is_notnull_constant_column(1)) {
                 const InputColumnType* column_val = down_cast<const InputColumnType*>(columns[0]);
                 const InputColumnType* column_sep = down_cast<const InputColumnType*>(columns[1]);
 
@@ -60,6 +59,7 @@ public:
                     result.append(sep.get_data(), sep.get_size()).append(val.get_data(), val.get_size());
                 }
             } else {
+                auto const_column_sep = ctx->get_constant_column(1);
                 const InputColumnType* column_val = down_cast<const InputColumnType*>(columns[0]);
                 std::string& result = this->data(state).intermediate_string;
 
@@ -102,12 +102,12 @@ public:
                                    AggDataPtr __restrict state) const override {
         if (ctx->get_num_args() > 1) {
             const InputColumnType* column_val = down_cast<const InputColumnType*>(columns[0]);
-            auto const_column_sep = ctx->get_constant_column(1);
-            if (const_column_sep == nullptr) {
+            if (!ctx->is_notnull_constant_column(1)) {
                 const InputColumnType* column_sep = down_cast<const InputColumnType*>(columns[1]);
                 this->data(state).intermediate_string.reserve(column_val->get_bytes().size() +
                                                               column_sep->get_bytes().size());
             } else {
+                auto const_column_sep = ctx->get_constant_column(1);
                 Slice sep = ColumnHelper::get_const_value<TYPE_VARCHAR>(const_column_sep);
                 this->data(state).intermediate_string.reserve(column_val->get_bytes().size() +
                                                               sep.get_size() * chunk_size);

--- a/be/src/exprs/vectorized/encryption_functions.cpp
+++ b/be/src/exprs/vectorized/encryption_functions.cpp
@@ -199,7 +199,7 @@ Status EncryptionFunctions::sha2_prepare(FunctionContext* context, FunctionConte
         return Status::OK();
     }
 
-    if (!context->is_constant_column(1)) {
+    if (!context->is_notnull_constant_column(1)) {
         return Status::OK();
     }
 

--- a/be/src/exprs/vectorized/geo_functions.cpp
+++ b/be/src/exprs/vectorized/geo_functions.cpp
@@ -89,8 +89,7 @@ Status GeoFunctions::st_circle_prepare(FunctionContext* ctx, FunctionContext::Fu
     auto lng = ctx->get_constant_column(0);
     auto lat = ctx->get_constant_column(1);
     auto radius = ctx->get_constant_column(2);
-    if (lng->only_null() || lng->is_null(0) || lat->only_null() || lat->is_null(0) || radius->only_null() ||
-        radius->is_null(0)) {
+    if (lng->only_null() || lat->only_null() || radius->only_null()) {
         state->is_null = true;
     } else {
         std::unique_ptr<GeoCircle> circle(new GeoCircle());
@@ -319,7 +318,7 @@ Status GeoFunctions::st_contains_prepare(FunctionContext* ctx, FunctionContext::
     for (int i = 0; !contains_ctx->is_null && i < 2; ++i) {
         if (ctx->is_constant_column(i)) {
             auto str_column = ctx->get_constant_column(i);
-            if (str_column->only_null() || str_column->is_null(0)) {
+            if (str_column->only_null()) {
                 contains_ctx->is_null = true;
             } else {
                 auto str_value = ColumnHelper::get_const_value<TYPE_VARCHAR>(str_column);
@@ -393,7 +392,7 @@ Status GeoFunctions::st_from_wkt_prepare_common(FunctionContext* ctx, FunctionCo
 
     auto state = new StConstructState();
     auto str_column = ctx->get_constant_column(0);
-    if (str_column->only_null() || str_column->is_null(0)) {
+    if (str_column->only_null()) {
         state->is_null = true;
     } else {
         auto str_value = ColumnHelper::get_const_value<TYPE_VARCHAR>(str_column);

--- a/be/src/exprs/vectorized/json_functions.cpp
+++ b/be/src/exprs/vectorized/json_functions.cpp
@@ -563,7 +563,7 @@ ColumnPtr JsonFunctions::json_object(FunctionContext* context, const Columns& co
                     ok = false;
                     break;
                 }
-                
+
                 JsonValue* field_name = viewers[i].value(row);
                 vpack::Slice field_name_slice = field_name->to_vslice();
                 DCHECK(field_name != nullptr);
@@ -578,7 +578,7 @@ ColumnPtr JsonFunctions::json_object(FunctionContext* context, const Columns& co
                     ok = false;
                     break;
                 }
-                if (i + 1 < viewers.size() && !viewers[i+1].is_null(row)) {
+                if (i + 1 < viewers.size() && !viewers[i + 1].is_null(row)) {
                     JsonValue* field_value = viewers[i + 1].value(row);
                     DCHECK(field_value != nullptr);
                     builder.add(field_name->to_vslice().stringRef(), field_value->to_vslice());

--- a/be/src/exprs/vectorized/json_functions.cpp
+++ b/be/src/exprs/vectorized/json_functions.cpp
@@ -559,6 +559,11 @@ ColumnPtr JsonFunctions::json_object(FunctionContext* context, const Columns& co
         {
             vpack::ObjectBuilder ob(&builder);
             for (int i = 0; i < viewers.size(); i += 2) {
+                if (viewers[i].is_null(row)) {
+                    ok = false;
+                    break;
+                }
+                
                 JsonValue* field_name = viewers[i].value(row);
                 vpack::Slice field_name_slice = field_name->to_vslice();
                 DCHECK(field_name != nullptr);
@@ -573,7 +578,7 @@ ColumnPtr JsonFunctions::json_object(FunctionContext* context, const Columns& co
                     ok = false;
                     break;
                 }
-                if (i + 1 < viewers.size()) {
+                if (i + 1 < viewers.size() && !viewers[i+1].is_null(row)) {
                     JsonValue* field_value = viewers[i + 1].value(row);
                     DCHECK(field_value != nullptr);
                     builder.add(field_name->to_vslice().stringRef(), field_value->to_vslice());

--- a/be/src/exprs/vectorized/json_functions.cpp
+++ b/be/src/exprs/vectorized/json_functions.cpp
@@ -71,15 +71,11 @@ Status JsonFunctions::json_path_prepare(starrocks_udf::FunctionContext* context,
         return Status::OK();
     }
 
-    if (!context->is_constant_column(1)) {
+    if (!context->is_notnull_constant_column(1)) {
         return Status::OK();
     }
 
     ColumnPtr path = context->get_constant_column(1);
-    if (path->only_null()) {
-        return Status::OK();
-    }
-
     auto path_value = ColumnHelper::get_const_value<TYPE_VARCHAR>(path);
     std::string path_str(path_value.data, path_value.size);
     // Must remove or replace the escape sequence.
@@ -412,8 +408,7 @@ static StatusOr<JsonPath*> get_prepared_or_parse(FunctionContext* context, Slice
 
 Status JsonFunctions::native_json_path_prepare(starrocks_udf::FunctionContext* context,
                                                starrocks_udf::FunctionContext::FunctionStateScope scope) {
-    if (scope != FunctionContext::FRAGMENT_LOCAL || context->get_constant_column(1)->only_null() ||
-        !context->is_constant_column(1)) {
+    if (scope != FunctionContext::FRAGMENT_LOCAL || !context->is_notnull_constant_column(1)) {
         return Status::OK();
     }
 

--- a/be/src/exprs/vectorized/like_predicate.cpp
+++ b/be/src/exprs/vectorized/like_predicate.cpp
@@ -71,15 +71,11 @@ Status LikePredicate::like_prepare(starrocks_udf::FunctionContext* context,
     context->set_function_state(scope, state);
 
     // go row regex
-    if (!context->is_constant_column(1)) {
+    if (!context->is_notnull_constant_column(1)) {
         return Status::OK();
     }
 
     auto column = context->get_constant_column(1);
-    if (column->only_null() || column->is_null(0)) {
-        return Status::OK();
-    }
-
     auto pattern = ColumnHelper::get_const_value<TYPE_VARCHAR>(column);
     std::string pattern_str = pattern.to_string();
     std::string search_string;
@@ -135,15 +131,11 @@ Status LikePredicate::regex_prepare(starrocks_udf::FunctionContext* context,
     state->function = &regex_fn;
 
     // go row regex
-    if (!context->is_constant_column(1)) {
+    if (!context->is_notnull_constant_column(1)) {
         return Status::OK();
     }
 
     auto column = context->get_constant_column(1);
-    if (column->only_null() || column->is_null(0)) {
-        return Status::OK();
-    }
-
     auto pattern = ColumnHelper::get_const_value<TYPE_VARCHAR>(column);
     std::string pattern_str = pattern.to_string();
     std::string search_string;

--- a/be/src/exprs/vectorized/math_functions.cpp
+++ b/be/src/exprs/vectorized/math_functions.cpp
@@ -653,7 +653,7 @@ Status MathFunctions::rand_prepare(starrocks_udf::FunctionContext* context,
             }
 
             auto seed_column = context->get_constant_column(0);
-            if (seed_column->only_null() || seed_column->is_null(0)) {
+            if (seed_column->only_null()) {
                 return Status::OK();
             }
 

--- a/be/src/exprs/vectorized/split.cpp
+++ b/be/src/exprs/vectorized/split.cpp
@@ -36,7 +36,7 @@ Status StringFunctions::split_prepare(starrocks_udf::FunctionContext* context,
     auto* state = new SplitState();
     context->set_function_state(scope, state);
 
-    if (context->is_constant_column(0) && context->is_constant_column(1)) {
+    if (context->is_notnull_constant_column(0) && context->is_notnull_constant_column(1)) {
         Slice haystack = ColumnHelper::get_const_value<TYPE_VARCHAR>(context->get_constant_column(0));
         Slice delimiter = ColumnHelper::get_const_value<TYPE_VARCHAR>(context->get_constant_column(1));
         std::vector<std::string> const_split_strings =
@@ -44,7 +44,7 @@ Status StringFunctions::split_prepare(starrocks_udf::FunctionContext* context,
                                StringPiece(delimiter.get_data(), delimiter.get_size()));
 
         state->const_split_strings = const_split_strings;
-    } else if (context->is_constant_column(1)) {
+    } else if (context->is_notnull_constant_column(1)) {
         Slice delimiter = ColumnHelper::get_const_value<TYPE_VARCHAR>(context->get_constant_column(1));
 
         state->delimiter = delimiter;
@@ -90,7 +90,7 @@ ColumnPtr StringFunctions::split(FunctionContext* context, const starrocks::vect
     BinaryColumn::Ptr array_binary_column = BinaryColumn::create();
 
     auto state = reinterpret_cast<SplitState*>(context->get_function_state(FunctionContext::FRAGMENT_LOCAL));
-    if (context->is_constant_column(0) && context->is_constant_column(1)) {
+    if (context->is_notnull_constant_column(0) && context->is_notnull_constant_column(1)) {
         std::vector<std::string> split_string = state->const_split_strings;
         array_binary_column->reserve(row_nums * split_string.size(), haystack_columns->get_bytes().size());
 

--- a/be/src/exprs/vectorized/string_functions.cpp
+++ b/be/src/exprs/vectorized/string_functions.cpp
@@ -238,24 +238,14 @@ Status StringFunctions::sub_str_prepare(starrocks_udf::FunctionContext* context,
         return Status::OK();
     }
 
-    if (!context->is_constant_column(1)) {
+    // TODO(kks): improve this case if necessary
+    if (!context->is_notnull_constant_column(1)) {
         return Status::OK();
-    } else {
-        // TODO(kks): improve this case if necessary
-        if (context->get_constant_column(1)->only_null()) {
-            return Status::OK();
-        }
     }
 
-    if (context->get_num_args() == 3) {
-        if (!context->is_constant_column(2)) {
-            return Status::OK();
-        } else {
-            // TODO(kks): improve this case if necessary
-            if (context->get_constant_column(2)->only_null()) {
-                return Status::OK();
-            }
-        }
+    // TODO(kks): improve this case if necessary
+    if (context->get_num_args() == 3 && !context->is_notnull_constant_column(2)) {
+        return Status::OK();
     }
 
     state->is_const = true;
@@ -291,12 +281,7 @@ Status StringFunctions::left_or_right_prepare(starrocks_udf::FunctionContext* co
         return Status::OK();
     }
     // const null case is handled by non_const implementation.
-    if (!context->is_constant_column(0) || context->get_constant_column(0)->only_null()) {
-        return Status::OK();
-    }
-
-    // const null case is handled by non_const implementation.
-    if (!context->is_constant_column(1) || context->get_constant_column(1)->only_null()) {
+    if (!context->is_notnull_constant_column(0) || !context->is_notnull_constant_column(1)) {
         return Status::OK();
     }
 
@@ -326,10 +311,9 @@ Status StringFunctions::concat_prepare(starrocks_udf::FunctionContext* context,
     state->is_oversize = false;
     const auto num_args = context->get_num_args();
     for (auto i = 1; i < num_args; ++i) {
-        if (!context->is_constant_column(i) ||
-            // For code simpleness, we only handle const varchar args in the following code.
-            // For only null column, we let concat_not_const function handle
-            context->get_constant_column(i)->only_null()) {
+        // For code simpleness, we only handle const varchar args in the following code.
+        // For only null column, we let concat_not_const function handle
+        if (!context->is_notnull_constant_column(i)) {
             state->is_const = false;
         }
     }
@@ -1038,7 +1022,7 @@ Status StringFunctions::pad_prepare(starrocks_udf::FunctionContext* context,
     context->set_function_state(FunctionContext::FRAGMENT_LOCAL, state);
 
     // const null case is handled by non_const implementation.
-    if (!context->is_constant_column(2) || context->get_constant_column(2)->only_null()) {
+    if (!context->is_notnull_constant_column(2)) {
         return Status::OK();
     }
 
@@ -1049,7 +1033,7 @@ Status StringFunctions::pad_prepare(starrocks_udf::FunctionContext* context,
     state->fill_is_utf8 = state->fill.size > get_utf8_index(state->fill, &state->fill_utf8_index);
 
     // const null case is handled by non_const implementation.
-    if (!context->is_constant_column(1) || context->get_constant_column(1)->only_null()) {
+    if (!context->is_notnull_constant_column(1)) {
         return Status::OK();
     }
 
@@ -2529,16 +2513,12 @@ Status StringFunctions::regexp_prepare(starrocks_udf::FunctionContext* context,
     state->options->set_dot_nl(true);
 
     // go row regex
-    if (!context->is_constant_column(1)) {
-        return Status::OK();
-    }
-
-    auto column = context->get_constant_column(1);
-    if (column->only_null() || column->is_null(0)) {
+    if (!context->is_notnull_constant_column(1)) {
         return Status::OK();
     }
 
     state->const_pattern = true;
+    auto column = context->get_constant_column(1);
     auto pattern = ColumnHelper::get_const_value<TYPE_VARCHAR>(column);
     std::string pattern_str = pattern.to_string();
     state->regex = std::make_unique<re2::RE2>(pattern_str, *(state->options));
@@ -2829,15 +2809,12 @@ Status StringFunctions::parse_url_prepare(starrocks_udf::FunctionContext* contex
     ParseUrlState* state = new ParseUrlState();
     context->set_function_state(scope, state);
 
-    if (!context->is_constant_column(1)) {
+    if (!context->is_notnull_constant_column(1)) {
         return Status::OK();
     }
 
-    auto column = context->get_constant_column(1);
-    if (column->only_null() || column->is_null(0)) {
-        return Status::OK();
-    }
     state->const_pattern = true;
+    auto column = context->get_constant_column(1);
     auto part = ColumnHelper::get_const_value<TYPE_VARCHAR>(column);
     state->url_part.reset(new UrlParser::UrlPart);
     *(state->url_part) = UrlParser::get_url_part(StringValue::from_slice(part));

--- a/be/src/exprs/vectorized/time_functions.cpp
+++ b/be/src/exprs/vectorized/time_functions.cpp
@@ -111,7 +111,7 @@ Status TimeFunctions::convert_tz_prepare(starrocks_udf::FunctionContext* context
 
     // find from timezone
     auto from = context->get_constant_column(1);
-    if (from->only_null() || from->is_null(0)) {
+    if (from->only_null()) {
         ctc->is_valid = false;
         return Status::OK();
     }
@@ -124,7 +124,7 @@ Status TimeFunctions::convert_tz_prepare(starrocks_udf::FunctionContext* context
 
     // find to timezone
     auto to = context->get_constant_column(2);
-    if (to->only_null() || to->is_null(0)) {
+    if (to->only_null()) {
         ctc->is_valid = false;
         return Status::OK();
     }
@@ -813,16 +813,12 @@ Status TimeFunctions::from_unix_prepare(starrocks_udf::FunctionContext* context,
     FromUnixState* state = new FromUnixState();
     context->set_function_state(scope, state);
 
-    if (!context->is_constant_column(1)) {
-        return Status::OK();
-    }
-
-    auto column = context->get_constant_column(1);
-    if (column->only_null() || column->is_null(0)) {
+    if (!context->is_notnull_constant_column(1)) {
         return Status::OK();
     }
 
     state->const_format = true;
+    auto column = context->get_constant_column(1);
     auto format = ColumnHelper::get_const_value<TYPE_VARCHAR>(column);
 
     if (format.size > DEFAULT_DATE_FORMAT_LIMIT) {
@@ -1017,15 +1013,11 @@ Status TimeFunctions::str_to_date_prepare(starrocks_udf::FunctionContext* contex
         return Status::OK();
     }
 
-    if (!context->is_constant_column(1)) {
+    if (!context->is_notnull_constant_column(1)) {
         return Status::OK();
     }
 
     ColumnPtr column = context->get_constant_column(1);
-    if (column->only_null()) {
-        return Status::OK();
-    }
-
     Slice slice = ColumnHelper::get_const_value<TYPE_VARCHAR>(column);
 
     // start point to the first unspace char in string format.
@@ -1527,16 +1519,11 @@ Status TimeFunctions::datetime_trunc_prepare(starrocks_udf::FunctionContext* con
         return Status::OK();
     }
 
-    if (!context->is_constant_column(0)) {
+    if (!context->is_notnull_constant_column(0)) {
         return Status::InternalError("datetime_trunc just support const format value");
     }
 
     ColumnPtr column = context->get_constant_column(0);
-
-    if (column->only_null()) {
-        return Status::InternalError("format value can't be null");
-    }
-
     Slice slice = ColumnHelper::get_const_value<TYPE_VARCHAR>(column);
     auto format_value = slice.to_string();
 

--- a/be/src/udf/udf.h
+++ b/be/src/udf/udf.h
@@ -207,6 +207,9 @@ public:
 
     bool is_constant_column(int arg_idx) const;
 
+    // Return true if it's constant and not null
+    bool is_notnull_constant_column(int i) const;
+
     std::shared_ptr<starrocks::vectorized::Column> get_constant_column(int arg_idx) const;
 
     bool is_udf() { return _is_udf; }

--- a/be/src/udf/udf_ir.cpp
+++ b/be/src/udf/udf_ir.cpp
@@ -63,7 +63,7 @@ bool FunctionContext::is_notnull_constant_column(int i) const {
     }
 
     auto& col = _impl->_constant_columns[i];
-    return !!col && col->is_constant() && !col->is_null(i);
+    return !!col && col->is_constant() && !col->is_null(0);
 }
 
 starrocks::vectorized::ColumnPtr FunctionContext::get_constant_column(int i) const {

--- a/be/src/udf/udf_ir.cpp
+++ b/be/src/udf/udf_ir.cpp
@@ -54,7 +54,16 @@ bool FunctionContext::is_constant_column(int i) const {
         return false;
     }
 
-    return _impl->_constant_columns[i] != nullptr && _impl->_constant_columns[i]->is_constant();
+    return !!_impl->_constant_columns[i] && _impl->_constant_columns[i]->is_constant();
+}
+
+bool FunctionContext::is_notnull_constant_column(int i) const {
+    if (i < 0 || i >= _impl->_constant_columns.size()) {
+        return false;
+    }
+
+    auto& col = _impl->_constant_columns[i];
+    return !!col && col->is_constant() && !col->is_null(i);
 }
 
 starrocks::vectorized::ColumnPtr FunctionContext::get_constant_column(int i) const {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -176,10 +176,12 @@ public class FunctionSet {
      * to row function when init.
      */
     private final Map<String, List<Function>> vectorizedFunctions;
+
     // This contains the nullable functions, which cannot return NULL result directly for the NULL parameter.
     // This does not contain any user defined functions. All UDFs handle null values by themselves.
     private final ImmutableSet<String> notAlwaysNullResultWithNullParamFunctions = ImmutableSet.of("if",
-            "concat_ws", "ifnull", "nullif", "null_or_empty", "coalesce", "bitmap_hash", "percentile_hash", "hll_hash");
+            "concat_ws", "ifnull", "nullif", "null_or_empty", "coalesce", "bitmap_hash", "percentile_hash", "hll_hash",
+            "json_array", "json_object");
 
     // If low cardinality string column with global dict, for some string functions,
     // we could evaluate the function only with the dict content, not all string column data.
@@ -558,7 +560,6 @@ public class FunctionSet {
             addBuiltin(AggregateFunction.createBuiltin(name,
                     Lists.newArrayList(Type.DECIMAL128), Type.DECIMAL128, Type.DECIMAL128, false, true, false));
         }
-
 
 
         // HLL_UNION_AGG


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
#4094 , #4092


## Problem Summary(Required) ：
Some functions does not check null parameter correctly, cause BE crash.

The correct way to check the const value is `FunctionContext::is_notnull_constant_column`.


