### PR TITLE
Fix date formatter different from be

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/DateUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/DateUtils.java
@@ -9,7 +9,6 @@ import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.SignStyle;
-import java.time.format.TextStyle;
 import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
 
@@ -89,18 +88,6 @@ public class DateUtils {
                     case 'j': // %j Day of year (001..366)
                         builder.appendValue(ChronoField.DAY_OF_YEAR, 3);
                         break;
-                    case 'p': // %p AM or PM
-                        builder.appendText(ChronoField.AMPM_OF_DAY, TextStyle.FULL);
-                        break;
-                    case 'r': // %r Time, 12-hour (hh:mm:ss followed by AM or PM)
-                        builder.appendValue(ChronoField.CLOCK_HOUR_OF_AMPM, 2)
-                                .appendLiteral(':')
-                                .appendValue(ChronoField.MINUTE_OF_HOUR, 2)
-                                .appendLiteral(':')
-                                .appendValue(ChronoField.SECOND_OF_MINUTE, 2)
-                                .appendLiteral(' ')
-                                .appendText(ChronoField.AMPM_OF_DAY, TextStyle.FULL);
-                        break;
                     case 'S': // %S Seconds (00..59)
                     case 's': // %s Seconds (00..59)
                         builder.appendValue(ChronoField.SECOND_OF_MINUTE, 2);
@@ -121,15 +108,15 @@ public class DateUtils {
                     case 'y': // %y Year, numeric (two digits)
                         builder.appendValueReduced(ChronoField.YEAR_OF_ERA, 2, 2, 1970);
                         break;
-                    case 'w': // %w Day of the week (0=Sunday..6=Saturday)
-                        builder.appendValue(ChronoField.DAY_OF_WEEK, 1);
-                        break;
                     case 'f': // %f Microseconds (000000..999999)
-                        builder.appendValue(ChronoField.MICRO_OF_SECOND, 1, 6, SignStyle.NORMAL);
+                        builder.padNext(6, '0').appendValue(ChronoField.MICRO_OF_SECOND, 1, 6, SignStyle.NORMAL);
                         break;
                     case 'u': // %u Week (00..53), where Monday is the first day of the week
                         builder.appendValueReduced(ChronoField.ALIGNED_WEEK_OF_YEAR, 2, 2, 0);
                         break;
+                    case 'r': // %r Time, 12-hour (hh:mm:ss followed by AM or PM), Java can't convert language
+                    case 'p': // %p AM or PM, Java can't convert language
+                    case 'w': // %w Day of the week (0=Sunday..6=Saturday), Java only support 1~7
                     case 'U': // %U Week (00..53), where Sunday is the first day of the week
                     case 'W': // %W Weekday name (Sunday..Saturday)
                     case 'x': // %x Year for the week, where Monday is the first day of the week, numeric, four digits; used with %v

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
@@ -20,6 +20,8 @@ import java.math.BigInteger;
 import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.SignStyle;
+import java.time.temporal.ChronoField;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -55,8 +57,10 @@ public final class ConstantOperator extends ScalarOperator implements Comparable
     private static final LocalDateTime MAX_DATETIME = LocalDateTime.of(9999, 12, 31, 23, 59, 59);
     private static final LocalDateTime MIN_DATETIME = LocalDateTime.of(0, 1, 1, 0, 0, 0);
 
-    private static final DateTimeFormatter DATE_TIME_FORMATTER_MS
-            = DateUtils.unixDatetimeFormatBuilder("%Y-%m-%d %H:%i:%s.%f").toFormatter();
+    // Don't need fixWidth
+    private static final DateTimeFormatter DATE_TIME_FORMATTER_MS =
+            DateUtils.unixDatetimeFormatBuilder("%Y-%m-%d %H:%i:%s")
+                    .appendValue(ChronoField.MICRO_OF_SECOND, 1, 6, SignStyle.NORMAL).toFormatter();
 
     private static void requiredValid(LocalDateTime dateTime) throws SemanticException {
         if (null == dateTime || dateTime.isBefore(MIN_DATETIME) || dateTime.isAfter(MAX_DATETIME)) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
@@ -59,7 +59,7 @@ public final class ConstantOperator extends ScalarOperator implements Comparable
 
     // Don't need fixWidth
     private static final DateTimeFormatter DATE_TIME_FORMATTER_MS =
-            DateUtils.unixDatetimeFormatBuilder("%Y-%m-%d %H:%i:%s")
+            DateUtils.unixDatetimeFormatBuilder("%Y-%m-%d %H:%i:%s.")
                     .appendValue(ChronoField.MICRO_OF_SECOND, 1, 6, SignStyle.NORMAL).toFormatter();
 
     private static void requiredValid(LocalDateTime dateTime) throws SemanticException {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
@@ -19,6 +19,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -54,7 +55,7 @@ public final class ConstantOperator extends ScalarOperator implements Comparable
     private static final LocalDateTime MAX_DATETIME = LocalDateTime.of(9999, 12, 31, 23, 59, 59);
     private static final LocalDateTime MIN_DATETIME = LocalDateTime.of(0, 1, 1, 0, 0, 0);
 
-    private static java.time.format.DateTimeFormatter DATE_TIME_FORMATTER_MS
+    private static final DateTimeFormatter DATE_TIME_FORMATTER_MS
             = DateUtils.unixDatetimeFormatBuilder("%Y-%m-%d %H:%i:%s.%f").toFormatter();
 
     private static void requiredValid(LocalDateTime dateTime) throws SemanticException {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
@@ -6,7 +6,6 @@ import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
-import com.starrocks.common.Config;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import org.junit.Assert;
@@ -19,7 +18,6 @@ import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.time.format.DateTimeParseException;
 import java.util.Locale;
 
 import static org.junit.Assert.assertEquals;
@@ -146,10 +144,6 @@ public class ScalarOperatorFunctionsTest {
                 ScalarOperatorFunctions.dateFormat(testDate, ConstantOperator.createVarchar("%l")).getVarchar());
         assertEquals("01",
                 ScalarOperatorFunctions.dateFormat(testDate, ConstantOperator.createVarchar("%m")).getVarchar());
-        assertEquals("PM",
-                ScalarOperatorFunctions.dateFormat(testDate, ConstantOperator.createVarchar("%p")).getVarchar());
-        assertEquals("01:04:05 PM",
-                ScalarOperatorFunctions.dateFormat(testDate, ConstantOperator.createVarchar("%r")).getVarchar());
         assertEquals("05",
                 ScalarOperatorFunctions.dateFormat(testDate, ConstantOperator.createVarchar("%S")).getVarchar());
         assertEquals("05",
@@ -192,9 +186,9 @@ public class ScalarOperatorFunctionsTest {
                 ScalarOperatorFunctions.dateFormat(ConstantOperator.createDate(LocalDateTime.of(2001, 1, 9, 13, 4, 5)),
                         ConstantOperator.createVarchar("%Y-%m-%d"))
                         .getVarchar());
-        assertEquals("5",
-                ScalarOperatorFunctions.dateFormat(ConstantOperator.createDate(LocalDateTime.of(2020, 2, 21, 13, 4, 5)),
-                        ConstantOperator.createVarchar("%w")).getVarchar());
+        assertEquals("000123", ScalarOperatorFunctions
+                .dateFormat(ConstantOperator.createDate(LocalDateTime.of(2022, 3, 13, 0, 0, 0, 123000)),
+                        ConstantOperator.createVarchar("%f")).getVarchar());
 
         assertEquals("asdfafdfsçv",
                 ScalarOperatorFunctions.dateFormat(ConstantOperator.createDate(LocalDateTime.of(2020, 2, 21, 13, 4, 5)),
@@ -210,6 +204,12 @@ public class ScalarOperatorFunctionsTest {
                 ScalarOperatorFunctions.dateFormat(testDate, ConstantOperator.createVarchar("%W")).getVarchar());
         Assert.assertThrows("%x not supported in date format string", IllegalArgumentException.class, () ->
                 ScalarOperatorFunctions.dateFormat(testDate, ConstantOperator.createVarchar("%x")).getVarchar());
+        Assert.assertThrows("%w not supported in date format string", IllegalArgumentException.class, () ->
+                ScalarOperatorFunctions.dateFormat(testDate, ConstantOperator.createVarchar("%w")).getVarchar());
+        Assert.assertThrows("%p not supported in date format string", IllegalArgumentException.class, () ->
+                ScalarOperatorFunctions.dateFormat(testDate, ConstantOperator.createVarchar("%p")).getVarchar());
+        Assert.assertThrows("%r not supported in date format string", IllegalArgumentException.class, () ->
+                ScalarOperatorFunctions.dateFormat(testDate, ConstantOperator.createVarchar("%r")).getVarchar());
 
         Assert.assertThrows(IllegalArgumentException.class, () -> ScalarOperatorFunctions
                 .dateFormat(ConstantOperator.createDate(LocalDateTime.of(2020, 2, 21, 13, 4, 5)),
@@ -259,11 +259,11 @@ public class ScalarOperatorFunctionsTest {
                 .dateParse(ConstantOperator.createVarchar("20190507"),
                         ConstantOperator.createVarchar("%Y%m")).getDatetime());
 
-        Assert.assertThrows(DateTimeParseException.class,
+        Assert.assertThrows(IllegalArgumentException.class,
                 () -> ScalarOperatorFunctions.dateParse(ConstantOperator.createVarchar("2020-2-21"),
                         ConstantOperator.createVarchar("%w")).getVarchar());
 
-        Assert.assertThrows(DateTimeParseException.class,
+        Assert.assertThrows(IllegalArgumentException.class,
                 () -> ScalarOperatorFunctions.dateParse(ConstantOperator.createVarchar("2020-02-21"),
                         ConstantOperator.createVarchar("%w")).getVarchar());
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

bugs:
```
mysql> select date_format('2021-03-04 22:37:45', '%w') from tt;
+------------------------------------------+
| date_format('2021-03-04 22:37:45', '%w') |
+------------------------------------------+
| 7                                     |
+------------------------------------------+

mysql> select date_format('2021-03-04 22:37:45', '%p') from tt;
+------------------------------------------+
| date_format('2021-03-04 22:37:45', '%p') |
+------------------------------------------+
| 下午                                     |
+------------------------------------------+
```


except:
```
mysql> select date_format('2021-03-04 22:37:45', '%w') from tt;
+------------------------------------------+
| date_format('2021-03-04 22:37:45', '%w') |
+------------------------------------------+
| 0                                     |
+------------------------------------------+

mysql> select date_format('2021-03-04 22:37:45', '%p') from tt;
+------------------------------------------+
| date_format('2021-03-04 22:37:45', '%p') |
+------------------------------------------+
| PM                                     |
+------------------------------------------+
```