### PR TITLE
limit scanner concurrency when scan too many columns

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -175,6 +175,7 @@ CONF_String(local_library_dir, "${UDF_RUNTIME_DIR}");
 CONF_mInt32(doris_scanner_thread_pool_thread_num, "48");
 // Number of olap scanner thread pool size.
 CONF_Int32(doris_scanner_thread_pool_queue_size, "102400");
+CONF_mDouble(scan_use_query_mem_ratio, "0.25");
 // Number of etl thread pool size.
 CONF_Int32(etl_thread_pool_size, "8");
 CONF_Int32(udf_thread_pool_size, "1");

--- a/be/src/exec/olap_common.h
+++ b/be/src/exec/olap_common.h
@@ -311,11 +311,7 @@ public:
         return _begin_scan_keys.size();
     }
 
-    void set_begin_include(bool begin_include) { _begin_include = begin_include; }
-
     bool begin_include() const { return _begin_include; }
-
-    void set_end_include(bool end_include) { _end_include = end_include; }
 
     bool end_include() const { return _end_include; }
 

--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -494,6 +494,7 @@ Status OlapScanNode::_start_scan_thread(RuntimeState* state) {
             segment_nums += rowset->num_segments();
         }
         int scanners_per_tablet = std::min(segment_nums, kMaxScannerPerRange / _scan_ranges.size());
+        scanners_per_tablet = std::max(1, scanners_per_tablet);
 
         int num_ranges = key_ranges.size();
         int ranges_per_scanner = std::max(1, num_ranges / scanners_per_tablet);

--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -495,7 +495,6 @@ Status OlapScanNode::_start_scan_thread(RuntimeState* state) {
             segment_nums += rowset->num_segments();
         }
         COUNTER_UPDATE(_segment_counter, segment_nums);
-
         int scanners_per_tablet = std::min(segment_nums, kMaxScannerPerRange / _scan_ranges.size());
 
         int num_ranges = key_ranges.size();
@@ -504,6 +503,9 @@ Status OlapScanNode::_start_scan_thread(RuntimeState* state) {
             std::vector<OlapScanRange*> agg_key_ranges;
             agg_key_ranges.push_back(key_ranges[i].get());
             i++;
+            // each scanner could only handle TabletReaderParams, so each scanner could only
+            // 'le' or 'lt' range
+            // TODO:fix limit
             for (int j = 1; i < num_ranges && j < ranges_per_scanner &&
                             key_ranges[i]->end_include == key_ranges[i - 1]->end_include;
                  ++j, ++i) {

--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -52,7 +52,6 @@ Status OlapScanNode::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(ScanNode::prepare(state));
 
     _tablet_counter = ADD_COUNTER(runtime_profile(), "TabletCount ", TUnit::UNIT);
-    _segment_counter = ADD_COUNTER(runtime_profile(), "SegmentCount ", TUnit::UNIT);
     _io_task_counter = ADD_COUNTER(runtime_profile(), "IOTaskCount ", TUnit::UNIT);
     _task_concurrency = ADD_COUNTER(runtime_profile(), "ScanConcurrency ", TUnit::UNIT);
     _tuple_desc = state->desc_tbl().get_tuple_descriptor(_olap_scan_node.tuple_id);
@@ -494,7 +493,6 @@ Status OlapScanNode::_start_scan_thread(RuntimeState* state) {
         for (const auto& rowset : tablet_rowset) {
             segment_nums += rowset->num_segments();
         }
-        COUNTER_UPDATE(_segment_counter, segment_nums);
         int scanners_per_tablet = std::min(segment_nums, kMaxScannerPerRange / _scan_ranges.size());
 
         int num_ranges = key_ranges.size();

--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -496,7 +496,7 @@ Status OlapScanNode::_start_scan_thread(RuntimeState* state) {
         }
         COUNTER_UPDATE(_segment_counter, segment_nums);
 
-        int scanners_per_tablet = segment_nums;
+        int scanners_per_tablet = std::min(segment_nums, kMaxScannerPerRange / _scan_ranges.size());
 
         int num_ranges = key_ranges.size();
         int ranges_per_scanner = std::max(1, num_ranges / scanners_per_tablet);
@@ -607,7 +607,7 @@ size_t OlapScanNode::_scanner_concurrency() {
     chunk_mem_usage = row_mem_usage * _runtime_state->chunk_size();
     DCHECK_GT(chunk_mem_usage, 0);
     // limit scan memory usage not greater than 1/4 query limit
-    int concurrency = std::max<int>(query_limit / 4 / chunk_mem_usage, 1);
+    int concurrency = std::max<int>(query_limit * config::scan_use_query_mem_ratio / chunk_mem_usage, 1);
     // limit concurrency not greater than scanner numbers
     concurrency = std::min<int>(concurrency, _num_scanners);
     concurrency = std::min<int>(concurrency, kMaxConcurrency);

--- a/be/src/exec/vectorized/olap_scan_node.h
+++ b/be/src/exec/vectorized/olap_scan_node.h
@@ -116,6 +116,9 @@ private:
     // the row sets being deleted. Should be called after set_scan_ranges.
     Status _capture_tablet_rowsets();
 
+    // scanner concurrency
+    size_t _scanner_concurrency();
+
     TOlapScanNode _olap_scan_node;
     std::vector<std::unique_ptr<TInternalScanRange>> _scan_ranges;
     RuntimeState* _runtime_state = nullptr;
@@ -158,6 +161,9 @@ private:
     RuntimeProfile::Counter* _scan_timer = nullptr;
     RuntimeProfile::Counter* _create_seg_iter_timer = nullptr;
     RuntimeProfile::Counter* _tablet_counter = nullptr;
+    RuntimeProfile::Counter* _io_task_counter = nullptr;
+    RuntimeProfile::Counter* _task_concurrency = nullptr;
+    RuntimeProfile::Counter* _segment_counter = nullptr;
     RuntimeProfile::Counter* _io_timer = nullptr;
     RuntimeProfile::Counter* _read_compressed_counter = nullptr;
     RuntimeProfile::Counter* _decompress_timer = nullptr;

--- a/be/src/exec/vectorized/olap_scan_node.h
+++ b/be/src/exec/vectorized/olap_scan_node.h
@@ -164,7 +164,6 @@ private:
     RuntimeProfile::Counter* _tablet_counter = nullptr;
     RuntimeProfile::Counter* _io_task_counter = nullptr;
     RuntimeProfile::Counter* _task_concurrency = nullptr;
-    RuntimeProfile::Counter* _segment_counter = nullptr;
     RuntimeProfile::Counter* _io_timer = nullptr;
     RuntimeProfile::Counter* _read_compressed_counter = nullptr;
     RuntimeProfile::Counter* _decompress_timer = nullptr;

--- a/be/src/exec/vectorized/olap_scan_node.h
+++ b/be/src/exec/vectorized/olap_scan_node.h
@@ -68,6 +68,7 @@ private:
     friend class TabletScanner;
 
     constexpr static const int kMaxConcurrency = 50;
+    constexpr static const int kMaxScannerPerRange = 64;
 
     template <typename T>
     class Stack {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
stage 1 for #4074 

## Problem Summary(Required) ：
1. limit scan range for each tablet
    each tablet could only split with `num_segments` scanner
2. limit scan concurrency to reduce memory usage
