### PR TITLE
Create BlockManager dynamically based on URI schema

### DIFF
--- a/be/src/env/env.cpp
+++ b/be/src/env/env.cpp
@@ -4,90 +4,100 @@
 
 #include <fmt/format.h>
 
-#include <regex>
 #include <type_traits>
 
 #include "env/env_hdfs.h"
 #include "env/env_posix.h"
 #include "env/env_s3.h"
-#include "gutil/macros.h"
 
 namespace starrocks {
 
-class EnvRegistry {
-public:
-    using FactoryFunc = Env::FactoryFunc;
+static thread_local std::shared_ptr<Env> tls_env_posix;
+static thread_local std::shared_ptr<Env> tls_env_s3;
+static thread_local std::shared_ptr<Env> tls_env_hdfs;
 
-    static EnvRegistry& Instance() {
-        static EnvRegistry instance;
-        return instance;
+inline std::shared_ptr<Env> get_tls_env_hdfs() {
+    if (tls_env_hdfs == nullptr) {
+        tls_env_hdfs.reset(new_env_hdfs().release());
     }
+    return tls_env_hdfs;
+}
 
-    DISALLOW_COPY_AND_ASSIGN(EnvRegistry);
-
-    void register_env(std::string_view pattern, FactoryFunc func) {
-        _entries.emplace_back(Entry{std::regex(pattern.begin(), pattern.end()), std::move(func)});
+inline std::shared_ptr<Env> get_tls_env_posix() {
+    if (tls_env_posix == nullptr) {
+        tls_env_posix.reset(new_env_posix().release());
     }
+    return tls_env_posix;
+}
 
-    auto create_env(std::string_view uri) -> std::invoke_result_t<FactoryFunc, std::string_view> {
-        for (auto&& [pattern, func] : _entries) {
-            if (std::regex_match(uri.begin(), uri.end(), pattern)) return func(uri);
-        }
-        return Status::NotFound(fmt::format("No registered Env for URI {}", uri));
+inline std::shared_ptr<Env> get_tls_env_s3() {
+    if (tls_env_s3 == nullptr) {
+        tls_env_s3.reset(new_env_s3().release());
     }
+    return tls_env_s3;
+}
 
-    auto create_env_or_default(std::string_view uri) -> std::invoke_result_t<FactoryFunc, std::string_view> {
-        for (auto&& [pattern, func] : _entries) {
-            if (std::regex_match(uri.begin(), uri.end(), pattern)) return func(uri);
-        }
-        return new_env_posix();
-    }
+inline bool starts_with(std::string_view s, std::string_view prefix) {
+    return (s.size() >= prefix.size()) && (memcmp(s.data(), prefix.data(), prefix.size()) == 0);
+}
 
-private:
-    EnvRegistry() = default;
+inline bool is_s3_uri(std::string_view uri) {
+    return starts_with(uri, "oss://") || starts_with(uri, "s3n://") || starts_with(uri, "s3a://") ||
+           starts_with(uri, "s3://");
+}
 
-    struct Entry {
-        std::regex pattern;
-        FactoryFunc func;
-    };
+inline bool is_hdfs_uri(std::string_view uri) {
+    return starts_with(uri, "hdfs://");
+}
 
-    std::vector<Entry> _entries;
-};
-
-void Env::Register(std::string_view pattern, FactoryFunc func) {
-    EnvRegistry::Instance().register_env(pattern, std::move(func));
+inline bool is_posix_uri(std::string_view uri) {
+    return (memchr(uri.data(), ':', uri.size()) == nullptr) || starts_with(uri, "posix://");
 }
 
 StatusOr<std::unique_ptr<Env>> Env::CreateUniqueFromString(std::string_view uri) {
-    return EnvRegistry::Instance().create_env(uri);
+    if (is_posix_uri(uri)) {
+        return new_env_posix();
+    }
+    if (is_hdfs_uri(uri)) {
+        return new_env_hdfs();
+    }
+    if (is_s3_uri(uri)) {
+        return new_env_s3();
+    }
+    return Status::NotSupported(fmt::format("No Env associated with {}", uri));
 }
 
 StatusOr<std::shared_ptr<Env>> Env::CreateSharedFromString(std::string_view uri) {
-    ASSIGN_OR_RETURN(auto ptr, CreateUniqueFromString(uri));
-    return std::shared_ptr<Env>(std::move(ptr));
+    if (is_posix_uri(uri)) {
+        return get_tls_env_posix();
+    }
+    if (is_hdfs_uri(uri)) {
+        return get_tls_env_hdfs();
+    }
+    if (is_s3_uri(uri)) {
+        return get_tls_env_s3();
+    }
+    return Status::NotSupported(fmt::format("No Env associated with {}", uri));
 }
 
 StatusOr<std::unique_ptr<Env>> Env::CreateUniqueFromStringOrDefault(std::string_view uri) {
-    return EnvRegistry::Instance().create_env_or_default(uri);
+    if (is_hdfs_uri(uri)) {
+        return new_env_hdfs();
+    }
+    if (is_s3_uri(uri)) {
+        return new_env_s3();
+    }
+    return new_env_posix();
 }
 
 StatusOr<std::shared_ptr<Env>> Env::CreateSharedFromStringOrDefault(std::string_view uri) {
-    ASSIGN_OR_RETURN(auto ptr, CreateUniqueFromStringOrDefault(uri));
-    return std::shared_ptr<Env>(std::move(ptr));
-}
-
-class EnvGlobalInitializer {
-public:
-    EnvGlobalInitializer() {
-        Env::Register("posix://.*", [](std::string_view /*uri*/) { return new_env_posix(); });
-        Env::Register("hdfs://.*", [](std::string_view /*uri*/) { return new_env_hdfs(); });
-        Env::Register("oss://.*", [](std::string_view /*uri*/) { return new_env_s3(); });
-        Env::Register("s3a://.*", [](std::string_view /*uri*/) { return new_env_s3(); });
-        Env::Register("s3n://.*", [](std::string_view /*uri*/) { return new_env_s3(); });
-        Env::Register("s3://.*", [](std::string_view /*uri*/) { return new_env_s3(); });
+    if (is_hdfs_uri(uri)) {
+        return get_tls_env_hdfs();
     }
-};
-
-static EnvGlobalInitializer obj;
+    if (is_s3_uri(uri)) {
+        return get_tls_env_s3();
+    }
+    return get_tls_env_posix();
+}
 
 } // namespace starrocks

--- a/be/src/env/env.h
+++ b/be/src/env/env.h
@@ -38,8 +38,6 @@ struct SpaceInfo {
 
 class Env {
 public:
-    using FactoryFunc = std::function<StatusOr<std::unique_ptr<Env>>(std::string_view uri)>;
-
     // Governs if/how the file is created.
     //
     // enum value                   | file exists       | file does not exist
@@ -52,8 +50,6 @@ public:
 
     Env() = default;
     virtual ~Env() = default;
-
-    static void Register(std::string_view pattern, FactoryFunc func);
 
     static StatusOr<std::unique_ptr<Env>> CreateUniqueFromString(std::string_view uri);
 

--- a/be/src/env/env_s3.cpp
+++ b/be/src/env/env_s3.cpp
@@ -276,7 +276,7 @@ public:
 
     Status delete_dir(const std::string& dirname) override;
 
-    Status sync_dir(const std::string& dirname) override { return Status::NotSupported("EnvS3::sync_dir"); }
+    Status sync_dir(const std::string& dirname) override;
 
     Status is_directory(const std::string& path, bool* is_dir) override;
 
@@ -537,6 +537,14 @@ Status EnvS3::delete_dir(const std::string& dirname) {
     } else {
         return to_status(del_outcome.GetError().GetErrorType(), del_outcome.GetError().GetMessage());
     }
+}
+
+Status EnvS3::sync_dir(const std::string& dirname) {
+    // The only thing we need to do is check whether the directory exist or not.
+    bool is_dir = false;
+    RETURN_IF_ERROR(is_directory(dirname, &is_dir));
+    if (is_dir) return Status::OK();
+    return Status::NotFound(fmt::format("{} not directory", dirname));
 }
 
 std::unique_ptr<Env> new_env_s3() {

--- a/be/src/storage/fs/file_block_manager.cpp
+++ b/be/src/storage/fs/file_block_manager.cpp
@@ -331,8 +331,8 @@ Status FileReadableBlock::readv(uint64_t offset, const Slice* results, size_t re
 FileBlockManager::FileBlockManager(std::shared_ptr<Env> env, BlockManagerOptions opts)
         : _env(std::move(env)), _opts(std::move(opts)) {
 #ifdef BE_TEST
-    _file_cache = std::make_unique<FileCache<RandomAccessFile>("Readable file cache",
-                                                               config::file_descriptor_cache_capacity);
+    _file_cache = std::make_unique <
+                  FileCache<RandomAccessFile>("Readable file cache", config::file_descriptor_cache_capacity);
 #else
     _file_cache = std::make_unique<FileCache<RandomAccessFile>>("Readable file cache",
                                                                 StorageEngine::instance()->file_cache());

--- a/be/src/storage/fs/file_block_manager.cpp
+++ b/be/src/storage/fs/file_block_manager.cpp
@@ -331,8 +331,8 @@ Status FileReadableBlock::readv(uint64_t offset, const Slice* results, size_t re
 FileBlockManager::FileBlockManager(std::shared_ptr<Env> env, BlockManagerOptions opts)
         : _env(std::move(env)), _opts(std::move(opts)) {
 #ifdef BE_TEST
-    _file_cache = std::make_unique <
-                  FileCache<RandomAccessFile>("Readable file cache", config::file_descriptor_cache_capacity);
+    _file_cache = std::make_unique<FileCache<RandomAccessFile>>("Readable file cache",
+                                                                config::file_descriptor_cache_capacity);
 #else
     _file_cache = std::make_unique<FileCache<RandomAccessFile>>("Readable file cache",
                                                                 StorageEngine::instance()->file_cache());

--- a/be/src/storage/fs/file_block_manager.h
+++ b/be/src/storage/fs/file_block_manager.h
@@ -65,9 +65,7 @@ struct BlockManagerMetrics;
 // The file-backed block manager.
 class FileBlockManager : public BlockManager {
 public:
-    // Note: all objects passed as pointers should remain alive for the lifetime
-    // of the block manager.
-    FileBlockManager(Env* env, BlockManagerOptions opts);
+    explicit FileBlockManager(std::shared_ptr<Env> env, BlockManagerOptions opts);
     ~FileBlockManager() override;
 
     Status open() override;
@@ -98,10 +96,10 @@ private:
     // Synchronizes the metadata for a block with the given location.
     Status _sync_metadata(const std::string& path);
 
-    Env* env() const { return _env; }
+    Env* env() const { return _env.get(); }
 
     // For manipulating files.
-    Env* _env;
+    std::shared_ptr<Env> _env;
 
     // The options that the FileBlockManager was created with.
     const BlockManagerOptions _opts;

--- a/be/src/storage/fs/fs_util.cpp
+++ b/be/src/storage/fs/fs_util.cpp
@@ -21,27 +21,13 @@
 
 #include "storage/fs/fs_util.h"
 
-#include "common/status.h"
-#include "env/env.h"
-#include "runtime/exec_env.h"
 #include "storage/fs/file_block_manager.h"
-#include "storage/storage_engine.h"
 
 namespace starrocks::fs::fs_util {
 
-BlockManager* block_manager() {
-#ifdef BE_TEST
-    return block_mgr_for_ut();
-#else
-    return ExecEnv::GetInstance()->storage_engine()->block_manager();
-#endif
-}
-
-BlockManager* block_mgr_for_ut() {
-    fs::BlockManagerOptions bm_opts;
-    bm_opts.read_only = false;
-    static FileBlockManager block_mgr(Env::Default(), std::move(bm_opts));
-    return &block_mgr;
+StatusOr<std::shared_ptr<BlockManager>> block_manager(std::string_view uri) {
+    ASSIGN_OR_RETURN(auto env, Env::CreateSharedFromStringOrDefault(uri));
+    return std::make_shared<FileBlockManager>(std::move(env), fs::BlockManagerOptions());
 }
 
 } // namespace starrocks::fs::fs_util

--- a/be/src/storage/fs/fs_util.h
+++ b/be/src/storage/fs/fs_util.h
@@ -21,19 +21,17 @@
 
 #pragma once
 
-#include "common/status.h"
+#include <memory>
+#include <string_view>
+
+#include "common/statusor.h"
 #include "storage/fs/block_manager.h"
 
 namespace starrocks {
 namespace fs {
 namespace fs_util {
 
-// Each BlockManager type may have different params, so we provide a separate
-// method for each type(instead of a factory method which require same params)
-BlockManager* block_manager();
-
-// For UnitTest.
-BlockManager* block_mgr_for_ut();
+StatusOr<std::shared_ptr<BlockManager>> block_manager(std::string_view uri);
 
 } // namespace fs_util
 } // namespace fs

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -440,9 +440,9 @@ public:
         _version = version;
         _idx_file_path = strings::Substitute("$0/index.l1.$1.$2", dir, version.major(), version.minor());
         _idx_file_path_tmp = _idx_file_path + ".tmp";
-        fs::BlockManager* block_mgr = fs::fs_util::block_manager();
+        ASSIGN_OR_RETURN(_block_mgr, fs::fs_util::block_manager(_idx_file_path_tmp));
         fs::CreateBlockOptions wblock_opts({_idx_file_path_tmp, Env::OpenMode::CREATE_OR_OPEN_WITH_TRUNCATE});
-        return block_mgr->create_block(wblock_opts, &_wb);
+        return _block_mgr->create_block(wblock_opts, &_wb);
     }
 
     Status write_shard(size_t key_size, size_t value_size, size_t npage_hint, const std::vector<KVRef>& kvs) {
@@ -505,6 +505,7 @@ private:
     EditVersion _version;
     string _idx_file_path_tmp;
     string _idx_file_path;
+    std::shared_ptr<fs::BlockManager> _block_mgr;
     std::unique_ptr<fs::WritableBlock> _wb;
     size_t _nshard = 0;
     size_t _fixed_key_size = 0;
@@ -999,7 +1000,6 @@ Status PersistentIndex::load(const PersistentIndexMetaPB& index_meta) {
     MutableIndexMetaPB l0_meta = index_meta.l0_meta();
     IndexSnapshotMetaPB snapshot_meta = l0_meta.snapshot();
     EditVersion start_version = snapshot_meta.version();
-    fs::BlockManager* block_mgr = fs::fs_util::block_manager();
     PagePointerPB page_pb = snapshot_meta.data();
     size_t snapshot_off = page_pb.offset();
     size_t snapshot_size = page_pb.size();
@@ -1010,7 +1010,8 @@ Status PersistentIndex::load(const PersistentIndexMetaPB& index_meta) {
         }
     });
     std::string l0_index_file_name = _get_l0_index_file_name(_path, start_version);
-    RETURN_IF_ERROR(block_mgr->open_block(l0_index_file_name, &rblock));
+    ASSIGN_OR_RETURN(_block_mgr, fs::fs_util::block_manager(l0_index_file_name));
+    RETURN_IF_ERROR(_block_mgr->open_block(l0_index_file_name, &rblock));
     // Assuming that the snapshot is always at the beginning of index file,
     // if not, we can't call phmap.load() directly because phmap.load() alaways
     // reads the contents of the file from the beginning
@@ -1057,7 +1058,7 @@ Status PersistentIndex::load(const PersistentIndexMetaPB& index_meta) {
     RETURN_IF_ERROR(FileSystemUtil::resize_file(l0_index_file_name, _offset));
     fs::CreateBlockOptions wblock_opts({l0_index_file_name});
     wblock_opts.mode = Env::MUST_EXIST;
-    RETURN_IF_ERROR(block_mgr->create_block(wblock_opts, &_index_block));
+    RETURN_IF_ERROR(_block_mgr->create_block(wblock_opts, &_index_block));
     RETURN_IF_ERROR(_delete_expired_index_file(start_version));
     return Status::OK();
 }
@@ -1120,12 +1121,14 @@ Status PersistentIndex::on_commited() {
     if (_dump_snapshot) {
         std::string expired_file_path = _index_block->path();
         std::string index_file_path = _get_l0_index_file_name(_path, _version);
-        fs::BlockManager* block_mgr = fs::fs_util::block_manager();
+        if (_block_mgr == nullptr) {
+            ASSIGN_OR_RETURN(_block_mgr, fs::fs_util::block_manager(index_file_path));
+        }
         std::unique_ptr<fs::WritableBlock> wblock;
         fs::CreateBlockOptions wblock_opts({index_file_path});
         // new index file should be created in commit() phase
         wblock_opts.mode = Env::MUST_EXIST;
-        RETURN_IF_ERROR(block_mgr->create_block(wblock_opts, &wblock));
+        RETURN_IF_ERROR(_block_mgr->create_block(wblock_opts, &wblock));
         _index_block = std::move(wblock);
         VLOG(1) << "delete expired l0 index file: " << expired_file_path;
         Env::Default()->delete_file(expired_file_path);

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -284,6 +284,7 @@ private:
     // |_page_size|: the size of last wal in index file
     uint64_t _offset = 0;
     uint32_t _page_size = 0;
+    std::shared_ptr<fs::BlockManager> _block_mgr;
     std::unique_ptr<fs::WritableBlock> _index_block;
 
     bool _dump_snapshot = false;

--- a/be/src/storage/rowset/beta_rowset_writer.cpp
+++ b/be/src/storage/rowset/beta_rowset_writer.cpp
@@ -31,6 +31,7 @@
 #include "gutil/strings/substitute.h"
 #include "runtime/exec_env.h"
 #include "serde/column_array_serde.h"
+#include "storage/fs/file_block_manager.h"
 #include "storage/fs/fs_util.h"
 #include "storage/olap_define.h"
 #include "storage/rowset/beta_rowset.h"
@@ -99,12 +100,14 @@ Status BetaRowsetWriter::init() {
         _rowset_txn_meta_pb = std::make_unique<RowsetTxnMetaPB>();
     }
 
+    ASSIGN_OR_RETURN(_env, Env::CreateSharedFromStringOrDefault(_context.rowset_path_prefix));
+    _block_mgr = std::make_shared<fs::FileBlockManager>(_env, fs::BlockManagerOptions());
     return Status::OK();
 }
 
 StatusOr<RowsetSharedPtr> BetaRowsetWriter::build() {
     if (_num_rows_written > 0) {
-        RETURN_IF_ERROR(_context.env->sync_dir(_context.rowset_path_prefix));
+        RETURN_IF_ERROR(_env->sync_dir(_context.rowset_path_prefix));
     }
     _rowset_meta->set_num_rows(_num_rows_written);
     _rowset_meta->set_total_row_size(_total_row_size);
@@ -152,7 +155,7 @@ Status BetaRowsetWriter::flush_src_rssids(uint32_t segment_id) {
                                                        static_cast<int>(segment_id));
     std::unique_ptr<fs::WritableBlock> wblock;
     fs::CreateBlockOptions opts({path});
-    RETURN_IF_ERROR(_context.block_mgr->create_block(opts, &wblock));
+    RETURN_IF_ERROR(_block_mgr->create_block(opts, &wblock));
     RETURN_IF_ERROR(wblock->append(Slice((const char*)(_src_rssids->data()), _src_rssids->size() * sizeof(uint32_t))));
     RETURN_IF_ERROR(wblock->finalize());
     RETURN_IF_ERROR(wblock->close());
@@ -173,7 +176,7 @@ HorizontalBetaRowsetWriter::~HorizontalBetaRowsetWriter() {
                 // Even if an error is encountered, these files that have not been cleaned up
                 // will be cleaned up by the GC background. So here we only print the error
                 // message when we encounter an error.
-                auto st = _context.env->delete_file(tmp_segment_file);
+                auto st = _env->delete_file(tmp_segment_file);
                 LOG_IF(WARNING, !st.ok()) << "Fail to delete file=" << tmp_segment_file << ", " << st.to_string();
             }
             _tmp_segment_files.clear();
@@ -182,13 +185,13 @@ HorizontalBetaRowsetWriter::~HorizontalBetaRowsetWriter() {
                 // Even if an error is encountered, these files that have not been cleaned up
                 // will be cleaned up by the GC background. So here we only print the error
                 // message when we encounter an error.
-                auto st = _context.env->delete_file(path);
+                auto st = _env->delete_file(path);
                 LOG_IF(WARNING, !st.ok()) << "Fail to delete file=" << path << ", " << st.to_string();
             }
             for (auto i = 0; i < _segment_has_deletes.size(); ++i) {
                 if (!_segment_has_deletes[i]) {
                     auto path = BetaRowset::segment_del_file_path(_context.rowset_path_prefix, _context.rowset_id, i);
-                    auto st = _context.env->delete_file(path);
+                    auto st = _env->delete_file(path);
                     LOG_IF(WARNING, !st.ok()) << "Fail to delete file=" << path << ", " << st.to_string();
                 }
             }
@@ -218,7 +221,7 @@ HorizontalBetaRowsetWriter::~HorizontalBetaRowsetWriter() {
                 // Even if an error is encountered, these files that have not been cleaned up
                 // will be cleaned up by the GC background. So here we only print the error
                 // message when we encounter an error.
-                auto st = _context.env->delete_file(path);
+                auto st = _env->delete_file(path);
                 LOG_IF(WARNING, !st.ok()) << "Fail to delete file=" << path << ", " << st.to_string();
             }
         }
@@ -241,7 +244,7 @@ StatusOr<std::unique_ptr<SegmentWriter>> HorizontalBetaRowsetWriter::_create_seg
     }
     std::unique_ptr<fs::WritableBlock> wblock;
     fs::CreateBlockOptions opts({path});
-    RETURN_IF_ERROR(_context.block_mgr->create_block(opts, &wblock));
+    RETURN_IF_ERROR(_block_mgr->create_block(opts, &wblock));
     DCHECK(wblock != nullptr);
     const auto* schema = _rowset_schema != nullptr ? _rowset_schema.get() : _context.tablet_schema;
     auto segment_writer = std::make_unique<SegmentWriter>(std::move(wblock), _num_segment, schema, _writer_options);
@@ -302,7 +305,7 @@ Status HorizontalBetaRowsetWriter::flush_chunk_with_deletes(const vectorized::Ch
         auto path = BetaRowset::segment_del_file_path(_context.rowset_path_prefix, _context.rowset_id, _num_segment);
         std::unique_ptr<fs::WritableBlock> wblock;
         fs::CreateBlockOptions opts({path});
-        RETURN_IF_ERROR(_context.block_mgr->create_block(opts, &wblock));
+        RETURN_IF_ERROR(_block_mgr->create_block(opts, &wblock));
         size_t sz = serde::ColumnArraySerde::max_serialized_size(deletes);
         // TODO(cbl): temp buffer doubles the memory usage, need to optimize
         std::vector<uint8_t> content(sz);
@@ -364,7 +367,7 @@ Status HorizontalBetaRowsetWriter::_final_merge() {
     if (_num_segment == 1) {
         auto old_path = BetaRowset::segment_temp_file_path(_context.rowset_path_prefix, _context.rowset_id, 0);
         auto new_path = BetaRowset::segment_file_path(_context.rowset_path_prefix, _context.rowset_id, 0);
-        auto st = _context.env->rename_file(old_path, new_path);
+        auto st = _env->rename_file(old_path, new_path);
         RETURN_IF_ERROR_WITH_WARN(st, "Fail to rename file");
         return Status::OK();
     }
@@ -382,7 +385,7 @@ Status HorizontalBetaRowsetWriter::_final_merge() {
     seg_iterators.reserve(_num_segment);
 
     vectorized::SegmentReadOptions seg_options;
-    seg_options.block_mgr = _context.block_mgr;
+    seg_options.block_mgr = _block_mgr;
 
     OlapReaderStatistics stats;
     seg_options.stats = &stats;
@@ -391,9 +394,8 @@ Status HorizontalBetaRowsetWriter::_final_merge() {
         std::string tmp_segment_file =
                 BetaRowset::segment_temp_file_path(_context.rowset_path_prefix, _context.rowset_id, seg_id);
 
-        auto segment_ptr =
-                Segment::open(ExecEnv::GetInstance()->tablet_meta_mem_tracker(), fs::fs_util::block_manager(),
-                              tmp_segment_file, seg_id, _context.tablet_schema);
+        auto segment_ptr = Segment::open(ExecEnv::GetInstance()->tablet_meta_mem_tracker(), _block_mgr,
+                                         tmp_segment_file, seg_id, _context.tablet_schema);
         if (!segment_ptr.ok()) {
             LOG(WARNING) << "Fail to open " << tmp_segment_file << ": " << segment_ptr.status();
             return segment_ptr.status();
@@ -427,7 +429,7 @@ Status HorizontalBetaRowsetWriter::_final_merge() {
                 auto old_path =
                         BetaRowset::segment_temp_file_path(_context.rowset_path_prefix, _context.rowset_id, seg_id);
                 auto new_path = BetaRowset::segment_file_path(_context.rowset_path_prefix, _context.rowset_id, seg_id);
-                RETURN_IF_ERROR_WITH_WARN(_context.env->rename_file(old_path, new_path), "Fail to rename file");
+                RETURN_IF_ERROR_WITH_WARN(_env->rename_file(old_path, new_path), "Fail to rename file");
             }
             _context.write_tmp = false;
             return Status::OK();
@@ -486,7 +488,7 @@ Status HorizontalBetaRowsetWriter::_final_merge() {
         // Even if an error is encountered, these files that have not been cleaned up
         // will be cleaned up by the GC background. So here we only print the error
         // message when we encounter an error.
-        auto st = _context.env->delete_file(tmp_segment_file);
+        auto st = _env->delete_file(tmp_segment_file);
         RETURN_IF_ERROR_WITH_WARN(st, "Fail to delete segment temp file");
     }
     _tmp_segment_files.clear();
@@ -544,7 +546,7 @@ VerticalBetaRowsetWriter::~VerticalBetaRowsetWriter() {
             // Even if an error is encountered, these files that have not been cleaned up
             // will be cleaned up by the GC background. So here we only print the error
             // message when we encounter an error.
-            auto st = _context.env->delete_file(path);
+            auto st = _env->delete_file(path);
             LOG_IF(WARNING, !st.ok()) << "Fail to delete file=" << path << ", " << st.to_string();
         }
     }
@@ -682,7 +684,7 @@ StatusOr<std::unique_ptr<SegmentWriter>> VerticalBetaRowsetWriter::_create_segme
     std::string path = BetaRowset::segment_file_path(_context.rowset_path_prefix, _context.rowset_id, _num_segment);
     std::unique_ptr<fs::WritableBlock> wblock;
     fs::CreateBlockOptions opts({path});
-    RETURN_IF_ERROR(_context.block_mgr->create_block(opts, &wblock));
+    RETURN_IF_ERROR(_block_mgr->create_block(opts, &wblock));
 
     DCHECK(wblock != nullptr);
     const auto* schema = _rowset_schema != nullptr ? _rowset_schema.get() : _context.tablet_schema;

--- a/be/src/storage/rowset/beta_rowset_writer.h
+++ b/be/src/storage/rowset/beta_rowset_writer.h
@@ -55,6 +55,8 @@ protected:
     Status flush_src_rssids(uint32_t segment_id);
 
     RowsetWriterContext _context;
+    std::shared_ptr<Env> _env;
+    std::shared_ptr<fs::BlockManager> _block_mgr;
     std::shared_ptr<RowsetMeta> _rowset_meta;
     std::unique_ptr<TabletSchema> _rowset_schema;
     std::unique_ptr<RowsetTxnMetaPB> _rowset_txn_meta_pb;

--- a/be/src/storage/rowset/rowset_writer_context.h
+++ b/be/src/storage/rowset/rowset_writer_context.h
@@ -46,8 +46,6 @@ public:
 
     std::string rowset_path_prefix;
 
-    Env* env = Env::Default();
-    fs::BlockManager* block_mgr = fs::fs_util::block_manager();
     const TabletSchema* tablet_schema = nullptr;
     std::shared_ptr<TabletSchema> partial_update_tablet_schema = nullptr;
     std::vector<int32_t> referenced_column_ids;

--- a/be/src/storage/rowset/segment.h
+++ b/be/src/storage/rowset/segment.h
@@ -75,7 +75,7 @@ class Segment : public std::enable_shared_from_this<Segment> {
     struct private_type;
 
 public:
-    static StatusOr<std::shared_ptr<Segment>> open(MemTracker* mem_tracker, fs::BlockManager* blk_mgr,
+    static StatusOr<std::shared_ptr<Segment>> open(MemTracker* mem_tracker, std::shared_ptr<fs::BlockManager> blk_mgr,
                                                    const std::string& filename, uint32_t segment_id,
                                                    const TabletSchema* tablet_schema,
                                                    size_t* footer_length_hint = nullptr,
@@ -84,7 +84,7 @@ public:
     static Status parse_segment_footer(fs::ReadableBlock* rblock, SegmentFooterPB* footer, size_t* footer_length_hint,
                                        const FooterPointerPB* partial_rowset_footer);
 
-    Segment(const private_type&, fs::BlockManager* blk_mgr, std::string fname, uint32_t segment_id,
+    Segment(const private_type&, std::shared_ptr<fs::BlockManager> blk_mgr, std::string fname, uint32_t segment_id,
             const TabletSchema* tablet_schema);
 
     ~Segment() = default;
@@ -166,7 +166,7 @@ private:
     friend class SegmentIterator;
     friend class vectorized::SegmentIterator;
 
-    fs::BlockManager* _block_mgr;
+    std::shared_ptr<fs::BlockManager> _block_mgr;
     std::string _fname;
     const TabletSchema* _tablet_schema;
     uint32_t _segment_id = 0;

--- a/be/src/storage/rowset/segment_rewriter.cpp
+++ b/be/src/storage/rowset/segment_rewriter.cpp
@@ -24,7 +24,7 @@ Status SegmentRewriter::rewrite(const std::string& src_path, const std::string& 
                                 std::vector<uint32_t>& column_ids,
                                 std::vector<std::unique_ptr<vectorized::Column>>& columns, size_t segment_id,
                                 const FooterPointerPB& partial_rowset_footer) {
-    fs::BlockManager* block_mgr = fs::fs_util::block_manager();
+    ASSIGN_OR_RETURN(auto block_mgr, fs::fs_util::block_manager(dest_path));
     std::unique_ptr<fs::WritableBlock> wblock;
     fs::CreateBlockOptions wblock_opts({dest_path});
     wblock_opts.mode = Env::CREATE_OR_OPEN_WITH_TRUNCATE;
@@ -76,7 +76,7 @@ Status SegmentRewriter::rewrite(const std::string& src_path, const TabletSchema&
                                 std::vector<uint32_t>& column_ids,
                                 std::vector<std::unique_ptr<vectorized::Column>>& columns, size_t segment_id,
                                 const FooterPointerPB& partial_rowset_footer) {
-    fs::BlockManager* block_mgr = fs::fs_util::block_manager();
+    ASSIGN_OR_RETURN(auto block_mgr, fs::fs_util::block_manager(src_path));
     std::unique_ptr<fs::ReadableBlock> rblock;
     RETURN_IF_ERROR(block_mgr->open_block(src_path, &rblock));
 

--- a/be/src/storage/rowset/vectorized/rowset_options.h
+++ b/be/src/storage/rowset/vectorized/rowset_options.h
@@ -34,8 +34,6 @@ public:
     ReaderType reader_type = READER_QUERY;
     int chunk_size = DEFAULT_CHUNK_SIZE;
 
-    fs::BlockManager* block_mgr = fs::fs_util::block_manager();
-
     std::vector<SeekRange> ranges;
 
     std::unordered_map<ColumnId, PredicateList> predicates;

--- a/be/src/storage/rowset/vectorized/segment_options.h
+++ b/be/src/storage/rowset/vectorized/segment_options.h
@@ -27,7 +27,7 @@ class SegmentReadOptions {
 public:
     using PredicateList = std::vector<const ColumnPredicate*>;
 
-    fs::BlockManager* block_mgr = fs::fs_util::block_manager();
+    std::shared_ptr<fs::BlockManager> block_mgr;
 
     std::vector<SeekRange> ranges;
 

--- a/be/src/storage/rowset_update_state.cpp
+++ b/be/src/storage/rowset_update_state.cpp
@@ -60,7 +60,7 @@ Status RowsetUpdateState::_do_load(Tablet* tablet, Rowset* rowset) {
         CHECK(false) << "create column for primary key encoder failed";
     }
 
-    auto block_manager = fs::fs_util::block_manager();
+    ASSIGN_OR_RETURN(auto block_manager, fs::fs_util::block_manager(rowset->rowset_path()));
     // always one file for now.
     for (auto i = 0; i < rowset->num_delete_files(); i++) {
         auto path = BetaRowset::segment_del_file_path(rowset->rowset_path(), rowset->rowset_id(), i);

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -44,7 +44,6 @@
 #include "runtime/exec_env.h"
 #include "storage/async_delta_writer_executor.h"
 #include "storage/data_dir.h"
-#include "storage/fs/file_block_manager.h"
 #include "storage/lru_cache.h"
 #include "storage/memtable_flush_executor.h"
 #include "storage/rowset/rowset_meta.h"
@@ -52,14 +51,10 @@
 #include "storage/rowset/unique_rowset_id_generator.h"
 #include "storage/tablet_meta.h"
 #include "storage/tablet_meta_manager.h"
-#include "storage/tablet_updates.h"
 #include "storage/update_manager.h"
-#include "storage/utils.h"
 #include "storage/vectorized/base_compaction.h"
 #include "storage/vectorized/cumulative_compaction.h"
-#include "util/defer_op.h"
 #include "util/file_utils.h"
-#include "util/pretty_printer.h"
 #include "util/scoped_cleanup.h"
 #include "util/starrocks_metrics.h"
 #include "util/thread.h"
@@ -98,7 +93,6 @@ StorageEngine::StorageEngine(const EngineOptions& options)
           _txn_manager(new TxnManager(config::txn_map_shard_size, config::txn_shard_size)),
           _rowset_id_generator(new UniqueRowsetIdGenerator(options.backend_uid)),
           _memtable_flush_executor(nullptr),
-          _block_manager(nullptr),
           _update_manager(new UpdateManager(options.update_mem_tracker)),
           _compaction_manager(new CompactionManager()) {
     if (_s_instance == nullptr) {
@@ -150,13 +144,6 @@ Status StorageEngine::_open() {
 
     _file_cache.reset(new_lru_cache(config::file_descriptor_cache_capacity));
 
-    fs::BlockManagerOptions bm_opts;
-    bm_opts.read_only = false;
-    // |_block_manager| depend on |_file_cache|.
-    _block_manager = std::make_unique<fs::FileBlockManager>(Env::Default(), std::move(bm_opts));
-
-    // |_update_manager| depend on |_block_manager|.
-    // |fs::fs_util::block_manager| depends on ExecEnv's storage engine
     starrocks::ExecEnv::GetInstance()->set_storage_engine(this);
     RETURN_IF_ERROR_WITH_WARN(_update_manager->init(), "init update_manager failed");
 

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -165,8 +165,6 @@ public:
 
     MemTableFlushExecutor* memtable_flush_executor() { return _memtable_flush_executor.get(); }
 
-    fs::BlockManager* block_manager() { return _block_manager.get(); }
-
     UpdateManager* update_manager() { return _update_manager.get(); }
 
     bool check_rowset_id_in_unused_rowsets(const RowsetId& rowset_id);
@@ -334,8 +332,6 @@ private:
     std::unique_ptr<AsyncDeltaWriterExecutor> _async_delta_writer_executor;
 
     std::unique_ptr<MemTableFlushExecutor> _memtable_flush_executor;
-
-    std::unique_ptr<fs::BlockManager> _block_manager;
 
     std::unique_ptr<UpdateManager> _update_manager;
 

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -2519,6 +2519,7 @@ Status TabletUpdates::get_column_values(std::vector<uint32_t>& column_ids, bool 
             _set_error(msg);
             return Status::InternalError(msg);
         }
+        // REQUIRE: all rowsets in this tablet have the same path prefix, i.e, can share the same block_mgr
         if (block_mgr == nullptr) {
             ASSIGN_OR_RETURN(block_mgr, fs::fs_util::block_manager(rowset->rowset_path()));
         }

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -2505,6 +2505,7 @@ Status TabletUpdates::get_column_values(std::vector<uint32_t>& column_ids, bool 
             }
         }
     }
+    std::shared_ptr<fs::BlockManager> block_mgr;
     for (const auto& [rssid, rowids] : rowids_by_rssid) {
         auto iter = rssid_to_rowsets.upper_bound(rssid);
         --iter;
@@ -2518,10 +2519,13 @@ Status TabletUpdates::get_column_values(std::vector<uint32_t>& column_ids, bool 
             _set_error(msg);
             return Status::InternalError(msg);
         }
+        if (block_mgr == nullptr) {
+            ASSIGN_OR_RETURN(block_mgr, fs::fs_util::block_manager(rowset->rowset_path()));
+        }
         std::string seg_path =
                 BetaRowset::segment_file_path(rowset->rowset_path(), rowset->rowset_id(), rssid - iter->first);
-        auto segment = Segment::open(ExecEnv::GetInstance()->tablet_meta_mem_tracker(), fs::fs_util::block_manager(),
-                                     seg_path, rssid - iter->first, &rowset->schema());
+        auto segment = Segment::open(ExecEnv::GetInstance()->tablet_meta_mem_tracker(), block_mgr, seg_path,
+                                     rssid - iter->first, &rowset->schema());
         if (!segment.ok()) {
             LOG(WARNING) << "Fail to open " << seg_path << ": " << segment.status();
             return segment.status();
@@ -2533,7 +2537,7 @@ Status TabletUpdates::get_column_values(std::vector<uint32_t>& column_ids, bool 
         OlapReaderStatistics stats;
         iter_opts.stats = &stats;
         std::unique_ptr<fs::ReadableBlock> rblock;
-        RETURN_IF_ERROR(fs::fs_util::block_manager()->open_block((*segment)->file_name(), &rblock));
+        RETURN_IF_ERROR(block_mgr->open_block((*segment)->file_name(), &rblock));
         iter_opts.rblock = rblock.get();
         for (auto i = 0; i < column_ids.size(); ++i) {
             ColumnIterator* col_iter_raw_ptr = nullptr;

--- a/be/src/storage/update_compaction_state.cpp
+++ b/be/src/storage/update_compaction_state.cpp
@@ -55,13 +55,14 @@ Status CompactionState::_do_load(Rowset* rowset) {
         CHECK(false) << "create column for primary key encoder failed";
     }
 
+    ASSIGN_OR_RETURN(auto block_mgr, fs::fs_util::block_manager(rowset->rowset_path()));
     auto update_manager = StorageEngine::instance()->update_manager();
     auto tracker = update_manager->compaction_state_mem_tracker();
     segment_states.resize(rowset->num_segments());
     for (auto i = 0; i < rowset->num_segments(); i++) {
         std::unique_ptr<fs::ReadableBlock> rblock;
         std::string rssid_file = BetaRowset::segment_srcrssid_file_path(rowset->rowset_path(), rowset->rowset_id(), i);
-        RETURN_IF_ERROR(fs::fs_util::block_manager()->open_block(rssid_file, &rblock));
+        RETURN_IF_ERROR(block_mgr->open_block(rssid_file, &rblock));
         uint64_t file_size = 0;
         RETURN_IF_ERROR(rblock->size(&file_size));
         std::vector<uint32_t>& src_rssids = segment_states[i].src_rssids;

--- a/be/src/storage/vectorized/meta_reader.cpp
+++ b/be/src/storage/vectorized/meta_reader.cpp
@@ -241,7 +241,7 @@ Status SegmentMetaCollecter::_init_return_column_iterators() {
     DCHECK_EQ(_params->fields.size(), _params->cids.size());
     DCHECK_EQ(_params->fields.size(), _params->read_page.size());
 
-    fs::BlockManager* block_mgr = fs::fs_util::block_manager();
+    ASSIGN_OR_RETURN(auto block_mgr, fs::fs_util::block_manager(_segment->file_name()));
     RETURN_IF_ERROR(block_mgr->open_block(_segment->file_name(), &_rblock));
 
     _column_iterators.resize(_params->max_cid + 1, nullptr);

--- a/be/src/tools/meta_tool.cpp
+++ b/be/src/tools/meta_tool.cpp
@@ -64,7 +64,6 @@ using starrocks::ColumnReader;
 using starrocks::BinaryPlainPageDecoder;
 using starrocks::PageHandle;
 using starrocks::PagePointer;
-using starrocks::ColumnReaderOptions;
 using starrocks::ColumnIteratorOptions;
 using starrocks::PageFooterPB;
 

--- a/be/test/storage/fs/file_block_manager_test.cpp
+++ b/be/test/storage/fs/file_block_manager_test.cpp
@@ -54,7 +54,7 @@ protected:
 TEST_F(FileBlockManagerTest, NormalTest) {
     fs::BlockManagerOptions bm_opts;
     bm_opts.read_only = false;
-    Env* env = Env::Default();
+    auto env = Env::CreateSharedFromString("posix://").value();
     std::unique_ptr<fs::FileBlockManager> fbm(new fs::FileBlockManager(env, std::move(bm_opts)));
 
     std::unique_ptr<fs::WritableBlock> wblock;

--- a/be/test/storage/rowset/bitmap_index_test.cpp
+++ b/be/test/storage/rowset/bitmap_index_test.cpp
@@ -45,20 +45,16 @@ public:
 protected:
     void SetUp() override {
         StoragePageCache::create_global_cache(&_tracker, 1000000000);
-        _env = new EnvMemory();
-        _block_mgr = new fs::FileBlockManager(_env, fs::BlockManagerOptions());
+        _env = std::make_shared<EnvMemory>();
+        _block_mgr = std::make_shared<fs::FileBlockManager>(_env, fs::BlockManagerOptions());
         ASSERT_TRUE(_env->create_dir(kTestDir).ok());
     }
-    void TearDown() override {
-        StoragePageCache::release_global_cache();
-        delete _block_mgr;
-        delete _env;
-    }
+    void TearDown() override { StoragePageCache::release_global_cache(); }
 
     void get_bitmap_reader_iter(std::string& file_name, const ColumnIndexMetaPB& meta, BitmapIndexReader** reader,
                                 BitmapIndexIterator** iter) {
         *reader = new BitmapIndexReader();
-        auto st = (*reader)->load(_block_mgr, file_name, &meta.bitmap_index(), true, false);
+        auto st = (*reader)->load(_block_mgr.get(), file_name, &meta.bitmap_index(), true, false);
         ASSERT_TRUE(st.ok());
 
         st = (*reader)->new_iterator(iter);
@@ -84,8 +80,8 @@ protected:
         }
     }
 
-    EnvMemory* _env = nullptr;
-    fs::FileBlockManager* _block_mgr = nullptr;
+    std::shared_ptr<EnvMemory> _env = nullptr;
+    std::shared_ptr<fs::FileBlockManager> _block_mgr = nullptr;
     MemTracker _tracker;
     MemPool _pool;
 };

--- a/be/test/storage/rowset/segment_iterator_test.cpp
+++ b/be/test/storage/rowset/segment_iterator_test.cpp
@@ -27,19 +27,15 @@ namespace starrocks {
 class SegmentIteratorTest : public ::testing::Test {
 public:
     void SetUp() override {
-        _env = new EnvMemory();
-        _block_mgr = new fs::FileBlockManager(_env, fs::BlockManagerOptions());
+        _env = std::make_shared<EnvMemory>();
+        _block_mgr = std::make_shared<fs::FileBlockManager>(_env, fs::BlockManagerOptions());
         ASSERT_TRUE(_env->create_dir(kSegmentDir).ok());
         _page_cache_mem_tracker = std::make_unique<MemTracker>();
         _tablet_meta_mem_tracker = std::make_unique<MemTracker>();
         StoragePageCache::create_global_cache(_page_cache_mem_tracker.get(), 1000000000);
     }
 
-    void TearDown() override {
-        delete _block_mgr;
-        delete _env;
-        StoragePageCache::release_global_cache();
-    }
+    void TearDown() override { StoragePageCache::release_global_cache(); }
 
     TabletSchema create_schema(const std::vector<TabletColumn>& columns, int num_short_key_columns = -1) {
         TabletSchema res;
@@ -56,8 +52,8 @@ public:
     }
 
     const std::string kSegmentDir = "/segment_test";
-    EnvMemory* _env = nullptr;
-    fs::FileBlockManager* _block_mgr = nullptr;
+    std::shared_ptr<EnvMemory> _env = nullptr;
+    std::shared_ptr<fs::FileBlockManager> _block_mgr = nullptr;
     std::unique_ptr<MemTracker> _page_cache_mem_tracker = nullptr;
     std::unique_ptr<MemTracker> _tablet_meta_mem_tracker = nullptr;
 };

--- a/be/test/storage/rowset/segment_rewriter_test.cpp
+++ b/be/test/storage/rowset/segment_rewriter_test.cpp
@@ -38,9 +38,10 @@ using std::vector;
 class SegmentRewriterTest : public ::testing::Test {
 protected:
     void SetUp() override {
-        _env = Env::Default();
-        _block_mgr = fs::fs_util::block_manager();
-        ASSERT_TRUE(_env->create_dir(kSegmentDir).ok());
+        _env = Env::CreateSharedFromString("posix://").value();
+        ASSIGN_OR_ABORT(_block_mgr, fs::fs_util::block_manager("posix://"));
+        bool created;
+        ASSERT_OK(_env->create_dir_if_missing(kSegmentDir, &created));
 
         _page_cache_mem_tracker = std::make_unique<MemTracker>();
         _tablet_meta_mem_tracker = std::make_unique<MemTracker>();
@@ -68,10 +69,10 @@ protected:
 
     const std::string kSegmentDir = "./ut_dir/segment_rewriter_test";
 
-    Env* _env = nullptr;
-    fs::BlockManager* _block_mgr = nullptr;
-    std::unique_ptr<MemTracker> _page_cache_mem_tracker = nullptr;
-    std::unique_ptr<MemTracker> _tablet_meta_mem_tracker = nullptr;
+    std::shared_ptr<Env> _env;
+    std::shared_ptr<fs::BlockManager> _block_mgr;
+    std::unique_ptr<MemTracker> _page_cache_mem_tracker;
+    std::unique_ptr<MemTracker> _tablet_meta_mem_tracker;
 };
 
 TEST_F(SegmentRewriterTest, rewrite_test) {

--- a/be/test/storage/rowset/segment_test.cpp
+++ b/be/test/storage/rowset/segment_test.cpp
@@ -64,19 +64,15 @@ static vectorized::Datum DefaultIntGenerator(size_t rid, int cid, int block_id) 
 class SegmentReaderWriterTest : public ::testing::Test {
 protected:
     void SetUp() override {
-        _env = new EnvMemory();
-        _block_mgr = new fs::FileBlockManager(_env, fs::BlockManagerOptions());
+        _env = std::make_shared<EnvMemory>();
+        _block_mgr = std::make_shared<fs::FileBlockManager>(_env, fs::BlockManagerOptions());
         ASSERT_TRUE(_env->create_dir(kSegmentDir).ok());
         _page_cache_mem_tracker = std::make_unique<MemTracker>();
         _tablet_meta_mem_tracker = std::make_unique<MemTracker>();
         StoragePageCache::create_global_cache(_page_cache_mem_tracker.get(), 1000000000);
     }
 
-    void TearDown() override {
-        delete _block_mgr;
-        delete _env;
-        StoragePageCache::release_global_cache();
-    }
+    void TearDown() override { StoragePageCache::release_global_cache(); }
 
     TabletSchema create_schema(const std::vector<TabletColumn>& columns, int num_short_key_columns = -1) {
         TabletSchema res;
@@ -124,8 +120,8 @@ protected:
 
     const std::string kSegmentDir = "/segment_test";
 
-    EnvMemory* _env = nullptr;
-    fs::FileBlockManager* _block_mgr = nullptr;
+    std::shared_ptr<EnvMemory> _env = nullptr;
+    std::shared_ptr<fs::FileBlockManager> _block_mgr = nullptr;
     std::unique_ptr<MemTracker> _page_cache_mem_tracker = nullptr;
     std::unique_ptr<MemTracker> _tablet_meta_mem_tracker = nullptr;
 };


### PR DESCRIPTION
## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

This modification will be used for the future implementation of decoupling storage and computing.

This modification will NOT affect the process of data loading and reading.

Instead of using a global-shared instance of BlockManager, create BlockManager dynamically based
on the scheme of a path or URI.

By doing this we can support saving segment files on remote storage by changing the value of `Tablet::schema_hash_path()`.  For example, if `Tablet::schema_hash_path()` returns a path
prefixed with `s3://`, the segment files will be stored on the remote S3 storage automatically.

## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] others



