### PR TITLE
support LocalDataTime type && add some runtime profiles for jdbc scan

### DIFF
--- a/be/src/exec/pipeline/jdbc_scan_operator.cpp
+++ b/be/src/exec/pipeline/jdbc_scan_operator.cpp
@@ -95,7 +95,7 @@ void JDBCScanOperator::_start_scanner(RuntimeState* state) {
     scan_ctx.passwd = jdbc_table->jdbc_passwd();
     scan_ctx.sql = get_jdbc_sql(jdbc_table->jdbc_table(), _jdbc_scan_node.columns, _jdbc_scan_node.filters, _limit);
 
-    _scanner.reset(new vectorized::JDBCScanner(scan_ctx, _result_tuple_desc));
+    _scanner.reset(new vectorized::JDBCScanner(scan_ctx, _result_tuple_desc, this));
 
     if (status = _scanner->open(state); !status.ok()) {
         _set_scanner_state(true, status);

--- a/be/src/exec/vectorized/jdbc_scan_node.cpp
+++ b/be/src/exec/vectorized/jdbc_scan_node.cpp
@@ -10,7 +10,9 @@
 namespace starrocks::vectorized {
 
 JDBCScanNode::JDBCScanNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs)
-        : ScanNode(pool, tnode, descs), _jdbc_scan_node(tnode.jdbc_scan_node) {}
+        : ScanNode(pool, tnode, descs), _jdbc_scan_node(tnode.jdbc_scan_node) {
+    _name = "jdbc_scan";
+}
 
 Status JDBCScanNode::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(ScanNode::prepare(state));

--- a/jdbc_bridge/src/main/java/com/starrocks/jdbcbridge/JDBCUtil.java
+++ b/jdbc_bridge/src/main/java/com/starrocks/jdbcbridge/JDBCUtil.java
@@ -4,11 +4,18 @@ package com.starrocks.jdbcbridge;
 
 import java.sql.Date;
 import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 public class JDBCUtil {
     private static final SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+    private static final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     // format Date to 'YYYY-MM-dd'
     static String formatDate(Date date) {
         return format.format(date);
+    }
+    // format LocalDateTime to 'yyyy-MM-dd HH:mm:ss'
+    static String formatLocalDatetime(LocalDateTime localDateTime) {
+        return dateTimeFormatter.format(localDateTime);
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Major Changes:

* support new JDBC result type `LocalDateTime`
* fix the misjudged issue for tinyint type in `JDBCScanner::_precheck_data_type`
* add some runtime profile for `JDBCScanner`