### PR TITLE
Fix BE crash

### DIFF
--- a/be/src/storage/rowset/column_writer.cpp
+++ b/be/src/storage/rowset/column_writer.cpp
@@ -720,7 +720,7 @@ Status ScalarColumnWriter::append(const uint8_t* data, const uint8_t* null_flags
                 auto [run, is_null] = pair;
                 size_t num_add = run;
                 if (!is_null) {
-                    if(_page_builder == nullptr) {
+                    if (_page_builder == nullptr) {
                         set_encoding(DEFAULT_ENCODING);
                     }
                     num_add = _page_builder->add(ptr, run);

--- a/be/src/storage/rowset/column_writer.cpp
+++ b/be/src/storage/rowset/column_writer.cpp
@@ -720,6 +720,9 @@ Status ScalarColumnWriter::append(const uint8_t* data, const uint8_t* null_flags
                 auto [run, is_null] = pair;
                 size_t num_add = run;
                 if (!is_null) {
+                    if(_page_builder == nullptr) {
+                        set_encoding(DEFAULT_ENCODING);
+                    }
                     num_add = _page_builder->add(ptr, run);
                     _null_map_builder_v1->add_run(false, run);
                 } else {


### PR DESCRIPTION
_page_builder is not init , dereference a nullptr will crash.

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #4166 `, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4166 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Init _page_builder before dereferenceing it 
