### PR TITLE
[WIP] aborted routine load caused by discontinous kafka offset

### DIFF
--- a/be/src/runtime/routine_load/data_consumer.h
+++ b/be/src/runtime/routine_load/data_consumer.h
@@ -156,4 +156,54 @@ private:
     std::shared_ptr<KafkaConsumerPipe> _k_consumer_pipe;
 };
 
+class DummyKafkaMessage : public RdKafka::Message {
+public:
+    DummyKafkaMessage(int32_t partition, int64_t offset) : _partition(partition), _offset(offset){};
+    ~DummyKafkaMessage(){};
+
+    DummyKafkaMessage() = delete;
+    DummyKafkaMessage(const DummyKafkaMessage&) = delete;
+
+    std::string errstr() const override { return ""; }
+
+    RdKafka::ErrorCode err() const override { return RdKafka::ERR_NO_ERROR; }
+
+    RdKafka::Topic* topic() const override { return nullptr; }
+
+    std::string topic_name() const override { return ""; }
+
+    int32_t partition() const override { return _partition; }
+
+    void* payload() const override { return nullptr; }
+
+    size_t len() const override { return 0; }
+
+    const std::string* key() const override { return nullptr; }
+
+    const void* key_pointer() const override { return nullptr; }
+
+    size_t key_len() const override { return 0; }
+
+    int64_t offset() const override { return _offset; }
+
+    RdKafka::MessageTimestamp timestamp() const override { return RdKafka::MessageTimestamp{}; }
+
+    void* msg_opaque() const override { return nullptr; }
+
+    int64_t latency() const override { return 0; }
+
+    struct rd_kafka_message_s* c_ptr() override {
+        return nullptr;
+    }
+
+    RdKafka::Message::Status status() const override { return RdKafka::Message::MSG_STATUS_NOT_PERSISTED; }
+    RdKafka::Headers* headers() override { return nullptr; }
+    RdKafka::Headers* headers(RdKafka::ErrorCode* err) override { return nullptr; }
+    int32_t broker_id() const override { return 0; }
+
+private:
+    int32_t _partition;
+    int64_t _offset;
+};
+
 } // end namespace starrocks

--- a/be/src/runtime/routine_load/data_consumer_group.cpp
+++ b/be/src/runtime/routine_load/data_consumer_group.cpp
@@ -171,8 +171,10 @@ Status KafkaDataConsumerGroup::start_all(StreamLoadContext* ctx) {
             VLOG(3) << "get kafka message"
                     << ", partition: " << msg->partition() << ", offset: " << msg->offset() << ", len: " << msg->len();
 
-            (kafka_pipe.get()->*append_data)(static_cast<const char*>(msg->payload()), static_cast<size_t>(msg->len()),
-                                             row_delimiter);
+            if (!(msg->len() == 0 && dynamic_cast<DummyKafkaMessage*>(msg) != nullptr)) {
+                (kafka_pipe.get()->*append_data)(static_cast<const char*>(msg->payload()),
+                                                 static_cast<size_t>(msg->len()), row_delimiter);
+            }
 
             if (st.ok()) {
                 received_rows++;


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4151

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
BE generate dummy kafka message when the kafka consuming timeout, to let the FE get the correct kafka offset.