### PR TITLE
Realize concurrent repeated request verification based on sliding window mechanism, thus supporting RPC retry

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -684,6 +684,8 @@ CONF_mInt64(experimental_s3_max_single_part_size, "16777216");
 // default: 16MB
 CONF_mInt64(experimental_s3_min_upload_part_size, "16777216");
 
+CONF_Int64(max_load_dop, "16");
+
 } // namespace config
 
 } // namespace starrocks

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -114,8 +114,7 @@ Status NodeChannel::init(RuntimeState* state) {
     if (state->query_options().__isset.load_dop) {
         _max_parallel_request_size = state->query_options().load_dop;
         if (_max_parallel_request_size > config::max_load_dop || _max_parallel_request_size < 1) {
-            _err_st = Status::InternalError(
-                    fmt::format("load_parallel_request_size should between [1-%ld]", config::max_load_dop));
+            _err_st = Status::InternalError(fmt::format("load_dop should between [1-%ld]", config::max_load_dop));
             return _err_st;
         }
     }

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -113,8 +113,9 @@ Status NodeChannel::init(RuntimeState* state) {
 
     if (state->query_options().__isset.load_dop) {
         _max_parallel_request_size = state->query_options().load_dop;
-        if (_max_parallel_request_size > 16 || _max_parallel_request_size < 1) {
-            _err_st = Status::InternalError(fmt::format("load_parallel_request_size should between [1-16]"));
+        if (_max_parallel_request_size > config::max_load_dop || _max_parallel_request_size < 1) {
+            _err_st = Status::InternalError(
+                    fmt::format("load_parallel_request_size should between [1-%ld]", config::max_load_dop));
             return _err_st;
         }
     }
@@ -850,6 +851,9 @@ Status OlapTableSink::_send_chunk_by_node(vectorized::Chunk* chunk, IndexChannel
                                   false /* eos */);
 
         if (!st.ok()) {
+            LOG(WARNING) << node->name() << ", tablet add chunk failed, " << node->print_load_info()
+                         << ", node=" << node->node_info()->host << ":" << node->node_info()->brpc_port
+                         << ", errmsg=" << st.get_error_msg();
             channel->mark_as_failed(node);
             err_st = st;
         }

--- a/be/src/runtime/tablets_channel.cpp
+++ b/be/src/runtime/tablets_channel.cpp
@@ -104,6 +104,46 @@ void TabletsChannel::add_chunk(brpc::Controller* cntl, const PTabletWriterAddChu
         return;
     }
 
+    {
+        std::lock_guard<bthread::Mutex> lock(_senders[request.sender_id()].lock);
+
+        // receive exists packet
+        if (_senders[request.sender_id()]._receive_sliding_window.count(request.packet_seq()) != 0) {
+            if (_senders[request.sender_id()]._success_sliding_window.count(request.packet_seq()) == 0 ||
+                request.eos()) {
+                // still in process
+                response->mutable_status()->set_status_code(TStatusCode::DUPLICATE_RPC_INVOCATION);
+                response->mutable_status()->add_error_msgs(fmt::format(
+                        "packet_seq {} in PTabletWriterAddChunkRequest already process", request.packet_seq()));
+                return;
+            } else {
+                // already success
+                LOG(INFO) << "packet_seq " << request.packet_seq()
+                          << " in PTabletWriterAddChunkRequest already success";
+                response->mutable_status()->set_status_code(TStatusCode::OK);
+                return;
+            }
+        } else {
+            // receive packet before sliding window
+            if (request.packet_seq() <= _senders[request.sender_id()]._last_sliding_packet_seq) {
+                LOG(INFO) << "packet_seq " << request.packet_seq()
+                          << " in PTabletWriterAddChunkRequest less than last success packet_seq "
+                          << _senders[request.sender_id()]._last_sliding_packet_seq;
+                response->mutable_status()->set_status_code(TStatusCode::OK);
+                return;
+            } else if (request.packet_seq() >
+                       _senders[request.sender_id()]._last_sliding_packet_seq + _max_sliding_window_size) {
+                response->mutable_status()->set_status_code(TStatusCode::INVALID_ARGUMENT);
+                response->mutable_status()->add_error_msgs(fmt::format(
+                        "packet_seq {} in PTabletWriterAddChunkRequest forward last success packet_seq {} too much",
+                        request.packet_seq(), _senders[request.sender_id()]._last_sliding_packet_seq));
+                return;
+            } else {
+                _senders[request.sender_id()]._receive_sliding_window.insert(request.packet_seq());
+            }
+        }
+    }
+
     auto res = _create_write_context(request, response, done);
     if (!res.ok()) {
         res.status().to_protobuf(response->mutable_status());
@@ -177,6 +217,22 @@ void TabletsChannel::add_chunk(brpc::Controller* cntl, const PTabletWriterAddChu
 
     // This will only block the bthread, will not block the pthread
     count_down_latch.wait();
+
+    {
+        std::lock_guard<bthread::Mutex> lock(_senders[request.sender_id()].lock);
+
+        _senders[request.sender_id()]._success_sliding_window.insert(request.packet_seq());
+        while (_senders[request.sender_id()]._success_sliding_window.size() > _max_sliding_window_size / 2) {
+            auto last_success_iter = _senders[request.sender_id()]._success_sliding_window.cbegin();
+            auto last_receive_iter = _senders[request.sender_id()]._receive_sliding_window.cbegin();
+            if (_senders[request.sender_id()]._last_sliding_packet_seq + 1 == *last_success_iter &&
+                *last_success_iter == *last_receive_iter) {
+                _senders[request.sender_id()]._receive_sliding_window.erase(last_receive_iter);
+                _senders[request.sender_id()]._success_sliding_window.erase(last_success_iter);
+                _senders[request.sender_id()]._last_sliding_packet_seq++;
+            }
+        }
+    }
 
     auto t1 = std::chrono::steady_clock::now();
     response->set_execution_time_us(std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count());

--- a/be/src/runtime/tablets_channel.h
+++ b/be/src/runtime/tablets_channel.h
@@ -108,10 +108,10 @@ private:
     struct Sender {
         bthread::Mutex lock;
 
-        std::set<int64_t> _receive_sliding_window;
-        std::set<int64_t> _success_sliding_window;
+        std::set<int64_t> receive_sliding_window;
+        std::set<int64_t> success_sliding_window;
 
-        int64_t _last_sliding_packet_seq = -1;
+        int64_t last_sliding_packet_seq = -1;
     };
 
     class WriteContext : public RefCountedThreadSafe<WriteContext> {

--- a/be/src/runtime/tablets_channel.h
+++ b/be/src/runtime/tablets_channel.h
@@ -106,7 +106,12 @@ private:
     static std::atomic<uint64_t> _s_tablet_writer_count;
 
     struct Sender {
-        std::mutex lock;
+        bthread::Mutex lock;
+
+        std::set<int64_t> _receive_sliding_window;
+        std::set<int64_t> _success_sliding_window;
+
+        int64_t _last_sliding_packet_seq = -1;
     };
 
     class WriteContext : public RefCountedThreadSafe<WriteContext> {
@@ -199,6 +204,7 @@ private:
     // next sequence we expect
     std::atomic<int> _num_remaining_senders;
     std::vector<Sender> _senders;
+    size_t _max_sliding_window_size = config::max_load_dop * 3;
 
     mutable std::mutex _partitions_ids_lock;
     std::unordered_set<int64_t> _partition_ids;

--- a/be/src/util/brpc_stub_cache.h
+++ b/be/src/util/brpc_stub_cache.h
@@ -57,6 +57,10 @@ public:
         }
         // new one stub and insert into map
         brpc::ChannelOptions options;
+        options.connect_timeout_ms = 3000;
+        // Explicitly set the max_retry
+        // TODO(meegoo): The retry strategy can be customized in the future
+        options.max_retry = 3;
         std::unique_ptr<brpc::Channel> channel(new brpc::Channel());
         if (channel->Init(endpoint, &options)) {
             return nullptr;


### PR DESCRIPTION

## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4177 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
StarRocks currently supports concurrent RPC data writing, but lacks verification of repeated data requests, so there may be problems with retrying.
Therefore, the concurrent repeated request verification is realized through the sliding window mechanism, thereby supporting RPC retry.