### PR TITLE
Fix enforcer use wrong group and child group when merge group

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Group.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Group.java
@@ -189,7 +189,13 @@ public class Group {
         physicalExpressions.addAll(other.getPhysicalExpressions());
         for (Map.Entry<PhysicalPropertySet, Pair<Double, GroupExpression>> entry : other.lowestCostExpressions
                 .entrySet()) {
-            setBestExpressionWithStatistics(entry.getValue().second, entry.getValue().first, entry.getKey(),
+            GroupExpression bestGroupExpression = entry.getValue().second;
+            // change the enforcer itself group and child group to dst group if enforcer's group is other.
+            if (bestGroupExpression.getGroup() == other) {
+                bestGroupExpression.setGroup(this);
+                bestGroupExpression.getInputs().set(0, this);
+            }
+            setBestExpressionWithStatistics(bestGroupExpression, entry.getValue().first, entry.getKey(),
                     other.hasConfidenceStatistic(entry.getKey()) ? other.getConfidenceStatistic(entry.getKey()) :
                             other.statistics);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/EnumeratePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/EnumeratePlanTest.java
@@ -320,7 +320,7 @@ public class EnumeratePlanTest extends DistributedEnvPlanTestBase {
                 "    numwait desc,\n" +
                 "    s_name limit 100;";
         int planCount = getPlanCount(sql);
-        Assert.assertEquals(183, planCount);
+        Assert.assertEquals(203, planCount);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -387,4 +387,13 @@ public class ReplayFromDumpTest {
                 "  |  <slot 24> : 21: bitmap_union\n" +
                 "  |  <slot 32> : 32: bitmap_union"));
     }
+
+    @Test
+    public void testTPCHRandom() throws Exception {
+        Pair<QueryDumpInfo, String> replayPair =
+                getPlanFragment(getDumpInfoFromFile("query_dump/tpch_random"), null, TExplainLevel.NORMAL);
+        // check optimizer could extract best plan
+        Assert.assertTrue(replayPair.second.contains("11:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (BUCKET_SHUFFLE)"));
+    }
 }

--- a/fe/fe-core/src/test/resources/sql/query_dump/tpch_random.json
+++ b/fe/fe-core/src/test/resources/sql/query_dump/tpch_random.json
@@ -1,0 +1,56 @@
+{
+  "statement":"select \n  random() as c0, \n  subq_0.c0 as c1, \n  ref_2.r_regionkey as c2, \n  ref_4.o_clerk as c3 \nfrom \n  (\n    select \n      ref_1.s_nationkey as c0, \n      ref_0.ps_suppkey as c1, \n      ref_1.s_comment as c2, \n      ref_1.s_name as c3, \n      100 as c4 \n    from \n      partsupp as ref_0 \n      inner join supplier as ref_1 on (\n        ref_0.ps_availqty \u003d ref_1.s_suppkey\n      ) \n    where \n      ref_0.ps_partkey \u003c\u003e ref_1.s_suppkey\n  ) as subq_0 \n  inner join region as ref_2 on (subq_0.c1 \u003d ref_2.r_regionkey) \n  inner join nation as ref_3 on (subq_0.c3 \u003d ref_3.n_name) \n  inner join orders as ref_4 on (subq_0.c1 \u003d ref_4.o_orderkey) \nwhere \n  ref_2.r_comment \u003e ref_4.o_orderpriority;\n",
+  "table_meta":{
+    "tpch.region":"CREATE TABLE `region` (\n  `R_REGIONKEY` int(11) NOT NULL COMMENT \"\",\n  `R_NAME` char(25) NOT NULL COMMENT \"\",\n  `R_COMMENT` varchar(152) NULL COMMENT \"\",\n  `PAD` char(1) NOT NULL COMMENT \"\"\n) ENGINE\u003dOLAP \nDUPLICATE KEY(`R_REGIONKEY`)\nCOMMENT \"OLAP\"\nDISTRIBUTED BY HASH(`R_REGIONKEY`) BUCKETS 1 \nPROPERTIES (\n\"replication_num\" \u003d \"1\",\n\"in_memory\" \u003d \"false\",\n\"storage_format\" \u003d \"DEFAULT\"\n);",
+    "tpch.supplier":"CREATE TABLE `supplier` (\n  `S_SUPPKEY` int(11) NOT NULL COMMENT \"\",\n  `S_NAME` char(25) NOT NULL COMMENT \"\",\n  `S_ADDRESS` varchar(40) NOT NULL COMMENT \"\",\n  `S_NATIONKEY` int(11) NOT NULL COMMENT \"\",\n  `S_PHONE` char(15) NOT NULL COMMENT \"\",\n  `S_ACCTBAL` double NOT NULL COMMENT \"\",\n  `S_COMMENT` varchar(101) NOT NULL COMMENT \"\",\n  `PAD` char(1) NOT NULL COMMENT \"\"\n) ENGINE\u003dOLAP \nDUPLICATE KEY(`S_SUPPKEY`)\nCOMMENT \"OLAP\"\nDISTRIBUTED BY HASH(`S_SUPPKEY`) BUCKETS 1 \nPROPERTIES (\n\"replication_num\" \u003d \"1\",\n\"in_memory\" \u003d \"false\",\n\"storage_format\" \u003d \"DEFAULT\"\n);",
+    "tpch.nation":"CREATE TABLE `nation` (\n  `N_NATIONKEY` int(11) NOT NULL COMMENT \"\",\n  `N_NAME` char(25) NOT NULL COMMENT \"\",\n  `N_REGIONKEY` int(11) NOT NULL COMMENT \"\",\n  `N_COMMENT` varchar(152) NULL COMMENT \"\",\n  `PAD` char(1) NOT NULL COMMENT \"\"\n) ENGINE\u003dOLAP \nDUPLICATE KEY(`N_NATIONKEY`)\nCOMMENT \"OLAP\"\nDISTRIBUTED BY HASH(`N_NATIONKEY`) BUCKETS 1 \nPROPERTIES (\n\"replication_num\" \u003d \"1\",\n\"in_memory\" \u003d \"false\",\n\"storage_format\" \u003d \"DEFAULT\"\n);",
+    "tpch.partsupp":"CREATE TABLE `partsupp` (\n  `PS_PARTKEY` int(11) NOT NULL COMMENT \"\",\n  `PS_SUPPKEY` int(11) NOT NULL COMMENT \"\",\n  `PS_AVAILQTY` int(11) NOT NULL COMMENT \"\",\n  `PS_SUPPLYCOST` double NOT NULL COMMENT \"\",\n  `PS_COMMENT` varchar(199) NOT NULL COMMENT \"\",\n  `PAD` char(1) NOT NULL COMMENT \"\"\n) ENGINE\u003dOLAP \nDUPLICATE KEY(`PS_PARTKEY`)\nCOMMENT \"OLAP\"\nDISTRIBUTED BY HASH(`PS_PARTKEY`) BUCKETS 10 \nPROPERTIES (\n\"replication_num\" \u003d \"1\",\n\"in_memory\" \u003d \"false\",\n\"storage_format\" \u003d \"DEFAULT\"\n);",
+    "tpch.orders":"CREATE TABLE `orders` (\n  `O_ORDERKEY` int(11) NOT NULL COMMENT \"\",\n  `O_CUSTKEY` int(11) NOT NULL COMMENT \"\",\n  `O_ORDERSTATUS` char(1) NOT NULL COMMENT \"\",\n  `O_TOTALPRICE` double NOT NULL COMMENT \"\",\n  `O_ORDERDATE` date NOT NULL COMMENT \"\",\n  `O_ORDERPRIORITY` char(15) NOT NULL COMMENT \"\",\n  `O_CLERK` char(15) NOT NULL COMMENT \"\",\n  `O_SHIPPRIORITY` int(11) NOT NULL COMMENT \"\",\n  `O_COMMENT` varchar(79) NOT NULL COMMENT \"\",\n  `PAD` char(1) NOT NULL COMMENT \"\"\n) ENGINE\u003dOLAP \nDUPLICATE KEY(`O_ORDERKEY`)\nCOMMENT \"OLAP\"\nDISTRIBUTED BY HASH(`O_ORDERKEY`) BUCKETS 10 \nPROPERTIES (\n\"replication_num\" \u003d \"1\",\n\"in_memory\" \u003d \"false\",\n\"storage_format\" \u003d \"DEFAULT\"\n);"
+  },
+  "table_row_count":{
+    "tpch.nation":{
+      "nation":25
+    },
+    "tpch.orders":{
+      "orders":15000000
+    },
+    "tpch.partsupp":{
+      "partsupp":8000000
+    },
+    "tpch.region":{
+      "region":5
+    },
+    "tpch.supplier":{
+      "supplier":100000
+    }
+  },
+  "session_variables":"{\"enable_resource_group\":false,\"chunk_size\":4096,\"disable_bucket_join\":false,\"runtime_join_filter_push_down_limit\":1024000,\"global_runtime_filter_probe_min_selectivity\":0.5,\"codegen_level\":0,\"cbo_cte_reuse\":false,\"character_set_connection\":\"utf8\",\"cbo_use_correlated_join_estimate\":true,\"enable_insert_strict\":true,\"enable_filter_unused_columns_in_scan_stage\":false,\"div_precision_increment\":4,\"tx_isolation\":\"REPEATABLE-READ\",\"wait_timeout\":28800,\"cbo_cte_reuse_rate\":1.2,\"auto_increment_increment\":1,\"foreign_key_checks\":true,\"character_set_client\":\"utf8\",\"autocommit\":true,\"enable_column_expr_predicate\":false,\"character_set_results\":\"utf8\",\"pipeline_profile_level\":1,\"parallel_fragment_exec_instance_num\":1,\"max_scan_key_num\":-1,\"enable_global_runtime_filter\":true,\"forward_to_master\":false,\"net_read_timeout\":60,\"streaming_preaggregation_mode\":\"auto\",\"storage_engine\":\"olap\",\"cbo_enable_dp_join_reorder\":true,\"cbo_enable_low_cardinality_optimize\":true,\"tx_visible_wait_timeout\":10,\"cbo_max_reorder_node_use_exhaustive\":4,\"new_planner_optimize_timeout\":3000,\"force_schedule_local\":false,\"pipeline_dop\":0,\"enable_query_dump\":false,\"cbo_enable_greedy_join_reorder\":true,\"prefer_join_method\":\"broadcast\",\"single_node_exec_plan\":false,\"load_mem_limit\":0,\"global_runtime_filter_build_max_size\":67108864,\"sql_select_limit\":9223372036854775807,\"profiling\":false,\"sql_safe_updates\":0,\"enable_pipeline_engine\":false,\"query_cache_type\":0,\"disable_colocate_join\":false,\"max_pushdown_conditions_per_column\":-1,\"global_runtime_filter_probe_min_size\":102400,\"enable_vectorized_engine\":true,\"net_write_timeout\":60,\"collation_database\":\"utf8_general_ci\",\"hash_join_push_down_right_table\":true,\"enable_exchange_pass_through\":true,\"new_planner_agg_stage\":0,\"collation_connection\":\"utf8_general_ci\",\"resource_group\":\"normal\",\"broadcast_row_limit\":15000000,\"workgroup_id\":0,\"exec_mem_limit\":2147483648,\"cbo_max_reorder_node_use_dp\":10,\"disable_join_reorder\":false,\"is_report_success\":true,\"enable_groupby_use_output_alias\":false,\"net_buffer_length\":16384,\"transmission_compression_type\":\"LZ4\",\"enable_vectorized_insert\":true,\"interactive_timeout\":3600,\"enable_spilling\":false,\"batch_size\":1024,\"cbo_enable_replicated_join\":true,\"max_allowed_packet\":1048576,\"query_timeout\":30000,\"enable_cbo\":true,\"collation_server\":\"utf8_general_ci\",\"time_zone\":\"Asia/Shanghai\",\"max_execution_time\":3000000,\"character_set_server\":\"utf8\",\"cbo_use_nth_exec_plan\":0,\"rewrite_count_distinct_to_bitmap_hll\":true,\"parallel_exchange_instance_num\":-1,\"sql_mode\":34,\"SQL_AUTO_IS_NULL\":false,\"event_scheduler\":\"OFF\",\"disable_streaming_preaggregations\":false}",
+  "column_statistics":{
+    "tpch.nation":{
+      "N_NAME":"[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN"
+    },
+    "tpch.orders":{
+      "O_ORDERKEY":"[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN",
+      "O_CLERK":"[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN",
+      "O_ORDERPRIORITY":"[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN"
+    },
+    "tpch.partsupp":{
+      "PS_SUPPKEY":"[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN",
+      "PS_AVAILQTY":"[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN",
+      "PS_PARTKEY":"[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN"
+    },
+    "tpch.region":{
+      "R_REGIONKEY":"[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN",
+      "R_COMMENT":"[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN"
+    },
+    "tpch.supplier":{
+      "S_NATIONKEY":"[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN",
+      "S_NAME":"[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN",
+      "S_SUPPKEY":"[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN"
+    }
+  },
+  "be_number":1,
+  "exception":[
+
+  ]
+}


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4161 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
enforcer in the Group would not change itself group and child group when merge group occurs, this would result in using the group which has been merged when extract best plan. we need to change the enforcer and child group when merge goup