### PR TITLE
fix the bug of not init _table_function

### DIFF
--- a/be/src/exec/vectorized/table_function_node.cpp
+++ b/be/src/exec/vectorized/table_function_node.cpp
@@ -7,7 +7,6 @@
 #include "exec/pipeline/operator.h"
 #include "exec/pipeline/pipeline_builder.h"
 #include "exec/pipeline/table_function_operator.h"
-#include "exprs/table_function/java_udtf_function.h"
 #include "runtime/runtime_state.h"
 
 namespace starrocks::vectorized {

--- a/be/src/exec/vectorized/table_function_node.cpp
+++ b/be/src/exec/vectorized/table_function_node.cpp
@@ -12,9 +12,7 @@
 
 namespace starrocks::vectorized {
 TableFunctionNode::TableFunctionNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& desc)
-        : ExecNode(pool, tnode, desc), _tnode(tnode) {
-    _input_chunk_ptr = nullptr;
-}
+        : ExecNode(pool, tnode, desc), _tnode(tnode) {}
 
 TableFunctionNode::~TableFunctionNode() {
     if (runtime_state() != nullptr) {
@@ -209,8 +207,8 @@ Status TableFunctionNode::close(RuntimeState* state) {
     if (is_closed()) {
         return Status::OK();
     }
-    if (_table_function != nullptr) {
-        RETURN_IF_ERROR(_table_function->close(state, _table_function_state));
+    if (_table_function != nullptr && _table_function_state != nullptr) {
+        _table_function->close(state, _table_function_state);
     }
     return ExecNode::close(state);
 }

--- a/be/src/exec/vectorized/table_function_node.h
+++ b/be/src/exec/vectorized/table_function_node.h
@@ -2,7 +2,6 @@
 
 #pragma once
 
-#include "column/column_helper.h"
 #include "column/type_traits.h"
 #include "column/vectorized_fwd.h"
 #include "exec/exec_node.h"
@@ -34,7 +33,7 @@ public:
 
 private:
     const TPlanNode& _tnode;
-    const TableFunction* _table_function;
+    const TableFunction* _table_function = nullptr;
 
     //Slots of output by table function
     std::vector<SlotId> _fn_result_slots;
@@ -43,20 +42,18 @@ private:
     //Slots of table function input parameters
     std::vector<SlotId> _param_slots;
 
-    //Chunk context between multi get_next
-
     //Input chunk currently being processed
-    ChunkPtr _input_chunk_ptr;
+    ChunkPtr _input_chunk_ptr = nullptr;
     //The current chunk is processed to which row
-    int _input_chunk_seek_rows;
+    int _input_chunk_seek_rows = 0;
     //The current outer line needs to be repeated several times
-    int _outer_column_remain_repeat_times;
+    int _outer_column_remain_repeat_times = 0;
     //table function result
     std::pair<Columns, ColumnPtr> _table_function_result;
     //table function return result end ?
-    bool _table_function_result_eos;
+    bool _table_function_result_eos = false;
     //table function param and return offset
-    TableFunctionState* _table_function_state;
+    TableFunctionState* _table_function_state = nullptr;
 
     //Profile
     RuntimeProfile::Counter* _table_function_exec_timer = nullptr;

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -37,6 +37,7 @@ set(EXEC_FILES
         ./exec/vectorized/json_scanner_test.cpp
         ./exec/vectorized/hdfs_scanner_test.cpp
         ./exec/vectorized/orc_scanner_adapter_test.cpp
+        ./exec/vectorized/table_function_node_test.cpp
         ./exec/pipeline/pipeline_test_base.cpp
         ./exec/pipeline/pipeline_control_flow_test.cpp
         ./exec/pipeline/pipeline_driver_queue_test.cpp

--- a/be/test/exec/vectorized/table_function_node_test.cpp
+++ b/be/test/exec/vectorized/table_function_node_test.cpp
@@ -1,0 +1,70 @@
+#include "exec/vectorized/table_function_node.h"
+
+#include "gtest/gtest.h"
+
+namespace starrocks::vectorized {
+class TableFunctionNodeTest : public testing::Test {
+public:
+    TableFunctionNodeTest() : _runtime_state(TQueryGlobals()) {}
+
+protected:
+    virtual void SetUp() override;
+
+private:
+    RuntimeState _runtime_state;
+    ObjectPool _object_pool;
+    DescriptorTbl* _desc_tbl = nullptr;
+    TPlanNode _tnode;
+};
+
+void TableFunctionNodeTest::SetUp() {
+    TTableDescriptor t_table_desc;
+    t_table_desc.id = 0;
+    t_table_desc.tableType = TTableType::OLAP_TABLE;
+    t_table_desc.numCols = 0;
+    t_table_desc.numClusteringCols = 0;
+
+    TDescriptorTable t_desc_table;
+    t_desc_table.tableDescriptors.push_back(t_table_desc);
+    t_desc_table.__isset.tableDescriptors = true;
+
+    TTupleDescriptor t_tuple_desc;
+    t_tuple_desc.id = 1;
+    t_desc_table.tupleDescriptors.push_back(t_tuple_desc);
+
+    TTypeDesc type;
+    {
+        TTypeNode node;
+        node.__set_type(TTypeNodeType::SCALAR);
+        TScalarType scalar_type;
+        scalar_type.__set_type(TPrimitiveType::INT);
+        scalar_type.__set_len(0);
+        node.__set_scalar_type(scalar_type);
+        type.types.push_back(node);
+    }
+
+    for (int i = 0; i < 3; i++) {
+        TSlotDescriptor slot_desc;
+        slot_desc.id = 2 + i;
+
+        slot_desc.parent = 1;
+        slot_desc.slotType = type;
+        t_desc_table.slotDescriptors.push_back(slot_desc);
+    }
+
+    DescriptorTbl::create(&_object_pool, t_desc_table, &_desc_tbl, config::vector_chunk_size);
+    _runtime_state.set_desc_tbl(_desc_tbl);
+
+    _tnode.node_id = 1;
+    _tnode.node_type = TPlanNodeType::TABLE_FUNCTION_NODE;
+    _tnode.num_children = 1;
+
+    _tnode.row_tuples.push_back(1);
+    _tnode.nullable_tuples.push_back(false);
+}
+
+TEST_F(TableFunctionNodeTest, close_after_not_init) {
+    TableFunctionNode table_function_node(&_object_pool, _tnode, *_desc_tbl);
+    ASSERT_TRUE(table_function_node.close(&_runtime_state).ok());
+}
+} // namespace starrocks::vectorized


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4185 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

_table_function is not set to nullptr when construct, so it will crash in TableFunction::close() if table function not init;

but it will not happend in main, 2.1, because of current don't support auto cast from bitmap to string now

