### PR TITLE
Disable ColumnInc strategy in ChunkSorter by default

### DIFF
--- a/be/src/exec/vectorized/chunks_sorter_full_sort.cpp
+++ b/be/src/exec/vectorized/chunks_sorter_full_sort.cpp
@@ -357,7 +357,7 @@ Status ChunksSorterFullSort::_sort_chunks(RuntimeState* state) {
         } else {
             strategy = RowWise;
         }
-        strategy = ColumnInc;
+        // strategy = ColumnInc;
     }
     if (strategy == ColumnInc) {
         return _sort_by_column_inc(state);

--- a/be/src/exec/vectorized/sorting/sort_helper.h
+++ b/be/src/exec/vectorized/sorting/sort_helper.h
@@ -98,7 +98,7 @@ static inline Status sort_and_tie_helper_nullable(const bool& cancel, const Null
             int notnull_end = is_null_first ? range_last : pivot_start;
 
             if (notnull_start < notnull_end) {
-                tie[pivot_start] = 0;
+                tie[notnull_start] = 0;
                 RETURN_IF_ERROR(sort_and_tie_column(cancel, column->data_column(), is_asc_order, is_null_first,
                                                     permutation, tie, {notnull_start, notnull_end}, build_tie));
             }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：


## Problem Summary(Required) ：
Disable the `ColumnInc` sort strategy by default.

Issue:
```sql
create table t0(c0 INT, c1 ARRAY<double> not null, c2 array<double> not null, c3 ARRAY<ARRAY<double>> not null, c4 array<array<double>> not null, c5 ARRAY<ARRAY<ARRAY<ARRAY<ARRAY<double>>>>> not null, c6 array<array<array<array<array<double>>>>> not null)duplicate key(c0) distributed by hash(c0) buckets 1 properties('replication_num'='1');

insert into t0 values(1,[-611.78],[-611.78],[[-611.78]],[[-611.78]],[[[[[-611.78]]]]],[[[[[-611.78]]]]]),(2,[398391541.5063392],[398391541.5063392],[[398391541.5063392]],[[398391541.5063392]],[[[[[398391541.5063392]]]]],[[[[[398391541.5063392]]]]]);

select * from t0 order by c0 asc nulls last;

```
