### PR TITLE
Don't obtain hms event id when the hive_incremental_sync is false

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaClient.java
@@ -99,7 +99,9 @@ public class HiveMetaClient {
                 String.valueOf(Config.hive_meta_store_timeout_s));
         this.conf = conf;
 
-        init();
+        if (Config.enable_hms_events_incremental_sync) {
+            init();
+        }
     }
 
     private void init() throws DdlException {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
In most case, if hive metastore does't turn on the event option, it will return 0 when the client  call the get_current_eventId interface.
but if the user's hms has some auth-related options, there will throw an internal error on hms. So we will don't to call the get_current_eventId to avoid that create table failed.

fe.log error:
![image](https://user-images.githubusercontent.com/91597003/158744965-eb51ba65-ec75-4182-ba1b-ecec8f9ed0f1.png)

hive metastore log error:
![image](https://user-images.githubusercontent.com/91597003/158745024-07db31c7-03bc-4225-93c5-d9a4615f3188.png)

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
