### PR TITLE
Set default value of pipeline scan thread pool size to 48

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -635,7 +635,7 @@ CONF_Int16(tablet_max_versions, "1000");
 CONF_mBool(enable_bitmap_union_disk_format_with_set, "false");
 
 // The number of scan threads pipeline engine.
-CONF_Int64(pipeline_scan_thread_pool_thread_num, "0");
+CONF_Int64(pipeline_scan_thread_pool_thread_num, "48");
 // Queue size of scan thread pool for pipeline engine.
 CONF_Int64(pipeline_scan_thread_pool_queue_size, "102400");
 // The number of execution threads for pipeline engine.

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -135,9 +135,7 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths) {
                                           config::doris_scanner_thread_pool_thread_num,
                                           config::doris_scanner_thread_pool_queue_size);
 
-    int num_io_threads = config::pipeline_scan_thread_pool_thread_num <= 0
-                                 ? std::thread::hardware_concurrency()
-                                 : config::pipeline_scan_thread_pool_thread_num;
+    int num_io_threads = config::pipeline_scan_thread_pool_thread_num;
 
     _pipeline_scan_io_thread_pool =
             new PriorityThreadPool("pip_scan_io", // pipeline scan io


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：

Set default value of pipeline scan thread pool.  

Old default value is 0, which means it will be `hardware_concurrency` and probably it's quite low for accessing high-latency storage like HDFS/S3.

The reason why choose 48 is just because it's same to non-pipeline engine scann thread pool size.

