### PR TITLE
Fixup: mistaken partition exprs of local shuffle interpolated into left side of bucket shuffle join when SlotRef one same bucket key appear more than once in join eq_conjunctions

### DIFF
--- a/be/src/exec/vectorized/hash_join_node.cpp
+++ b/be/src/exec/vectorized/hash_join_node.cpp
@@ -88,9 +88,7 @@ Status HashJoinNode::init(const TPlanNode& tnode, RuntimeState* state) {
                     break;
                 }
             }
-            if (!match_exactly_once) {
-                return Status::InternalError("Invalid partition expr for bucket shuffle join");
-            }
+            DCHECK(match_exactly_once);
         }
     }
 

--- a/be/src/exec/vectorized/hash_join_node.cpp
+++ b/be/src/exec/vectorized/hash_join_node.cpp
@@ -71,13 +71,25 @@ Status HashJoinNode::init(const TPlanNode& tnode, RuntimeState* state) {
     }
 
     if (tnode.hash_join_node.__isset.partition_exprs) {
+        // the same column can appear more than once in either lateral side of eq_join_conjuncts, but multiple
+        // occurrences are accounted for once when determining local shuffle partition_exprs for bucket shuffle join.
+        // for an example:
+        // table t1 is bucketed by c1, the query 'select * from t1,t2 on t1.c1 = t2.c1 and t1.c1 in (TRUE, NULL) =
+        // t2.c1', SlotRef(t2.c1) appears twice, but the local shuffle partition_exprs should have the same number of
+        // exprs as partition_exprs used by ExchangeNode that sends data to right child of the HashJoin.
         for (const auto& partition_expr : tnode.hash_join_node.partition_exprs) {
+            bool match_exactly_once = false;
             for (auto i = 0; i < eq_join_conjuncts.size(); ++i) {
                 const auto& eq_join_conjunct = eq_join_conjuncts[i];
                 if (eq_join_conjunct.left == partition_expr || eq_join_conjunct.right == partition_expr) {
+                    match_exactly_once = true;
                     _probe_equivalence_partition_expr_ctxs.push_back(_probe_expr_ctxs[i]);
                     _build_equivalence_partition_expr_ctxs.push_back(_build_expr_ctxs[i]);
+                    break;
                 }
+            }
+            if (!match_exactly_once) {
+                return Status::InternalError("Invalid partition expr for bucket shuffle join");
             }
         }
     }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://github.com/StarRocks/starrocks/issues/4169
https://github.com/StarRocks/starrocks/issues/4170
## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

the same column can appear more than once in either lateral side of eq_join_conjuncts, but multiple  occurrences are accounted for once when determining local shuffle partition_exprs for bucket shuffle join.
for an example:
table t1 is bucketed by c1, the query 'select * from t1,t2 on t1.c1 = t2.c1 and t1.c1 in (TRUE, NULL) = t2.c1', SlotRef(t2.c1) appears twice, but the local shuffle partition_exprs should have the same number of exprs as partition_exprs used by ExchangeNode that sends data to right child of the HashJoin.

