### PR TITLE
Fix BE crash in graceful exit

### DIFF
--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -152,7 +152,6 @@ void QueryContextManager::clear() {
     }
     _second_chance_maps.clear();
     _context_maps.clear();
-    // std::unique_lock<std::shared_mutex> write_lock(mutex);
 }
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -144,4 +144,15 @@ void QueryContextManager::remove(const TUniqueId& query_id) {
     }
 }
 
+void QueryContextManager::clear() {
+    std::vector<std::unique_lock<std::shared_mutex>> locks;
+    locks.reserve(_mutexes.size());
+    for (int i = 0; i < _mutexes.size(); ++i) {
+        locks.emplace_back(_mutexes[i]);
+    }
+    _second_chance_maps.clear();
+    _context_maps.clear();
+    // std::unique_lock<std::shared_mutex> write_lock(mutex);
+}
+
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -95,6 +95,8 @@ public:
     QueryContext* get_or_register(const TUniqueId& query_id);
     QueryContextPtr get(const TUniqueId& query_id);
     void remove(const TUniqueId& query_id);
+    // used for graceful exit
+    void clear();
 
 private:
     std::vector<std::shared_mutex> _mutexes;

--- a/be/src/service/brpc_service.cpp
+++ b/be/src/service/brpc_service.cpp
@@ -63,6 +63,7 @@ Status BRpcService::start(int port) {
 }
 
 void BRpcService::join() {
+    _server->Stop(0);
     _server->Join();
 }
 

--- a/be/src/service/starrocks_main.cpp
+++ b/be/src/service/starrocks_main.cpp
@@ -40,6 +40,7 @@
 #include "common/daemon.h"
 #include "common/logging.h"
 #include "common/status.h"
+#include "exec/pipeline/query_context.h"
 #include "runtime/exec_env.h"
 #include "runtime/heartbeat_flags.h"
 #include "runtime/jdbc_driver_manager.h"
@@ -302,7 +303,7 @@ int main(int argc, char** argv) {
     engine->stop();
     delete engine;
     exec_env->set_storage_engine(nullptr);
-
+    starrocks::pipeline::QueryContextManager::instance()->clear();
     starrocks::ExecEnv::destroy(exec_env);
 
     return 0;

--- a/be/src/service/starrocks_main.cpp
+++ b/be/src/service/starrocks_main.cpp
@@ -294,6 +294,7 @@ int main(int argc, char** argv) {
     delete heartbeat_thrift_server;
 
     http_service.reset();
+    brpc_service->join();
     brpc_service.reset();
 
     be_server->stop();

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -214,6 +214,7 @@ Status StorageEngine::_init_store_map() {
         _store_map.emplace(store.second->path(), store.second);
         store.first = false;
     }
+    release_guard.cancel();
     return Status::OK();
 }
 

--- a/be/test/test_main.cpp
+++ b/be/test/test_main.cpp
@@ -4,6 +4,7 @@
 #include "column/column_helper.h"
 #include "column/column_pool.h"
 #include "common/config.h"
+#include "exec/pipeline/query_context.h"
 #include "gtest/gtest.h"
 #include "runtime/current_thread.h"
 #include "runtime/exec_env.h"
@@ -80,6 +81,7 @@ int main(int argc, char** argv) {
     engine->stop();
     delete engine;
     exec_env->set_storage_engine(nullptr);
+    starrocks::pipeline::QueryContextManager::instance()->clear();
     // destroy exec env
     starrocks::tls_thread_status.set_mem_tracker(nullptr);
     starrocks::ExecEnv::destroy(exec_env);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：

will close #4193

## Problem Summary(Required) ：

when BE graceful exiting. QueryContextManager should clean all of the QueryContext. which will release all of the query memory tracker. but root tracker will be release when ExecEnv destroy. which will cause a heap-buffer-overflow

when BE graceful exiting. DataDir was also used in compaction threads. so we shouldn't delete DataDir util compaction thread exited.
