### PR TITLE
Refactor decimal multiplication

### DIFF
--- a/be/src/exprs/vectorized/arithmetic_expr.cpp
+++ b/be/src/exprs/vectorized/arithmetic_expr.cpp
@@ -26,7 +26,8 @@ public:
         auto l = _children[0]->evaluate(context, ptr);
         auto r = _children[1]->evaluate(context, ptr);
         if constexpr (pt_is_decimal<Type>) {
-            return VectorizedStrictDecimalBinaryFunction<OP, false>::template evaluate<Type>(l, r);
+            // Enable overflow checking in decimal arithmetic
+            return VectorizedStrictDecimalBinaryFunction<OP, true>::template evaluate<Type>(l, r);
         } else {
             using ArithmeticOp = ArithmeticBinaryOperator<OP, Type>;
             return VectorizedStrictBinaryFunction<ArithmeticOp>::template evaluate<Type>(l, r);

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithDecimalTypesNewPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithDecimalTypesNewPlannerTest.java
@@ -125,18 +125,16 @@ public class SelectStmtWithDecimalTypesNewPlannerTest {
     @Test
     public void testMultiply() throws Exception {
         String sql = "select col_decimal128p20s3 * 3.14 from db1.decimal_table";
-        String expectString = "TExprNode(node_type:ARITHMETIC_EXPR, type:TTypeDesc(types:[TTypeNode(type:SCALAR, " +
-                "scalar_type:TScalarType(type:DECIMAL128, precision:38, scale:5))]), opcode:MULTIPLY, num_children:2," +
-                " output_scale:-1, output_column:-1, has_nullable_child:true, is_nullable:true, is_monotonic:false)," +
-                " TExprNode(node_type:CAST_EXPR, type:TTypeDesc(types:[TTypeNode(type:SCALAR, scalar_type:TScalarType(type:DECIMAL128, precision:38, scale:3))])," +
-                " opcode:INVALID_OPCODE, num_children:1, output_scale:-1, output_column:-1, child_type:DECIMAL128, has_nullable_child:true, is_nullable:true, is_monotonic:false), " +
-                "TExprNode(node_type:SLOT_REF, type:TTypeDesc(types:[TTypeNode(type:SCALAR, scalar_type:TScalarType" +
-                "(type:DECIMAL128, precision:20, scale:3))]), num_children:0, slot_ref:TSlotRef(slot_id:5, tuple_id:0)," +
-                " output_scale:-1, output_column:-1, has_nullable_child:false, is_nullable:true, is_monotonic:true)," +
-                " TExprNode(node_type:DECIMAL_LITERAL, type:TTypeDesc(types:[TTypeNode(type:SCALAR, scalar_type:" +
-                "TScalarType(type:DECIMAL128, precision:38, scale:2))]), num_children:0, decimal_literal:" +
-                "TDecimalLiteral(value:3.14, integer_value:3A 01 00 00 00 00 00 00 00 00 00 00 00 00 00 00), output_scale:-1, has_nullable_child:false," +
-                " is_nullable:false, is_monotonic:true)";
+        String expectString = "TExpr(nodes:[TExprNode(node_type:ARITHMETIC_EXPR, type:TTypeDesc(types:[TTypeNode(type:SCALAR," +
+                " scalar_type:TScalarType(type:DECIMAL128, precision:23, scale:5))]), opcode:MULTIPLY, num_children:2, " +
+                "output_scale:-1, output_column:-1, has_nullable_child:true, is_nullable:true, is_monotonic:true), " +
+                "TExprNode(node_type:SLOT_REF, type:TTypeDesc(types:[TTypeNode(type:SCALAR, scalar_type:TScalarType(type:" +
+                "DECIMAL128, precision:20, scale:3))]), num_children:0, slot_ref:TSlotRef(slot_id:5, tuple_id:0), " +
+                "output_scale:-1, output_column:-1, has_nullable_child:false, is_nullable:true, is_monotonic:true), " +
+                "TExprNode(node_type:DECIMAL_LITERAL, type:TTypeDesc(types:[TTypeNode(type:SCALAR, scalar_type:TScalarType" +
+                "(type:DECIMAL128, precision:3, scale:2))]), num_children:0, decimal_literal:TDecimalLiteral(value:3.14, " +
+                "integer_value:3A 01 00 00 00 00 00 00 00 00 00 00 00 00 00 00), output_scale:-1, has_nullable_child:false, " +
+                "is_nullable:false, is_monotonic:true)])})";
         String plan = UtFrameUtils.getPlanThriftString(ctx, sql);
         System.out.println(plan);
         Assert.assertTrue(plan.contains(expectString));

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithDecimalTypesTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithDecimalTypesTest.java
@@ -679,7 +679,7 @@ public class SelectStmtWithDecimalTypesTest {
             stmt.rewriteExprs(new Analyzer(ctx.getCatalog(), ctx).getExprRewriter());
             Expr expr = stmt.selectList.getItems().get(0).getExpr();
             Assert.assertEquals(expr.type, Type.BOOLEAN);
-            Type decimal128p38s5 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 12);
+            Type decimal128p38s5 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 24, 12);
             Assert.assertEquals(expr.getChild(0).type, decimal128p38s5);
             Assert.assertEquals(expr.getChild(1).type, decimal128p38s5);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeDecimalV3Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeDecimalV3Test.java
@@ -695,7 +695,7 @@ public class AnalyzeDecimalV3Test {
                     ((LogicalProjectOperator) logicalPlan.getRoot().getOp()).getColumnRefMap()
                             .get(logicalPlan.getOutputColumn().get(0));
 
-            Type decimal128p38s5 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 12);
+            Type decimal128p38s5 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 24, 12);
             Assert.assertEquals(op.getChild(0).getType(), decimal128p38s5);
             Assert.assertEquals(op.getChild(1).getType(), decimal128p38s5);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -248,8 +248,9 @@ public class AggregateTest extends PlanTestBase {
 
         sql = "select distinct cast(2.0 as decimal) * v1 from t0_not_null";
         plan = getVerboseExplain(sql);
+        System.out.println(plan);
         Assert.assertTrue(plan.contains("2:AGGREGATE (update finalize)\n" +
-                "  |  group by: [4: expr, DECIMAL64(18,0), true]"));
+                "  |  group by: [4: expr, DECIMAL128(28,0), true]"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -151,8 +151,8 @@ public class ExpressionTest extends PlanTestBase {
     public void testExpression8() throws Exception {
         String sql = "select cast(v1 as decimal128(10,5)) * cast(v2 as decimal64(9,7)) from t0";
         String planFragment = getFragmentPlan(sql);
-        Assert.assertTrue(planFragment.contains("  1:Project\n" +
-                "  |  <slot 4> : CAST(CAST(1: v1 AS DECIMAL128(10,5)) AS DECIMAL128(38,5)) * CAST(CAST(2: v2 AS DECIMAL64(9,7)) AS DECIMAL128(38,7))\n"));
+        Assert.assertTrue(planFragment.contains("1:Project\n" +
+                        "  |  <slot 4> : CAST(1: v1 AS DECIMAL128(10,5)) * CAST(CAST(2: v2 AS DECIMAL64(9,7)) AS DECIMAL128(9,7))"));
     }
 
     @Test
@@ -620,7 +620,7 @@ public class ExpressionTest extends PlanTestBase {
 
         sql = "select k5 from bigtable where k5 * 2 <= 3";
         planFragment = getFragmentPlan(sql);
-        Assert.assertTrue(planFragment.contains("PREDICATES: CAST(5: k5 AS DECIMAL64(18,3)) * 2 <= 3"));
+        Assert.assertTrue(planFragment.contains("PREDICATES: 5: k5 * 2 <= 3"));
 
         sql = "select k5 from bigtable where 2 / k5 <= 3";
         planFragment = getFragmentPlan(sql);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Old decimal multiplication scale adjust rules is not robust, becase of a narrow decimal multiplied by another narrow decimal yields a narrow decimal, too. for example decimal64(10,2) * decimal64(10,2) yields decimal32(18,4), the result maybe overflow. so we must cast the narrow decimal to wide decimal if necessary to void overflow.

New decimal multiplication scale adjust rules as follows:
decimal(p1,s1) * decimal(p2, s2) => decimal(p, s)
At first, denote p' = p1 + p2, s' = s1+s2;
1. in case of p' <= 38, result never overflows, use the narrowest decimal type that can holds the result. so:
    p = p1+ p2, s = s1+s2;
    for examples:
    decimal32(4,3) * decimal32(4,3) => decimal32(8,6);
    decimal64(15,3) * decimal32(9,4) => decimal128(24,7).
2. in case of p' > 38 and s' <=38, the multiplication is computable but the result maybe overflow, so use decimal128 arithmetic and adopt maximum decimal precision(38) as precision of the result. so:
    p = 38, s = s1 + s2
    for examples:
    decimal128(23,5) * decimal64(18,4) => decimal128(38, 9).
3. in case of s' > 38, the decimal is too large to hold in a decimal128, so report error. decimal's scale exceeds limit 38.

decimal arithmetic are testified both in disable/enable overflow check in BE, so now we turn on overflow check on BE for decimal arithmetic operations.