### PR TITLE
Support querying olap table with StarOSTablet

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
@@ -204,7 +204,7 @@ public class LocalTablet extends Tablet {
 
     // for query
     @Override
-    public void getQueryableReplicas(List<Replica> allQuerableReplica, List<Replica> localReplicas,
+    public void getQueryableReplicas(List<Replica> allQuerableReplicas, List<Replica> localReplicas,
                                      long visibleVersion, long localBeId, int schemaHash) {
         for (Replica replica : replicas) {
             if (replica.isBad()) {
@@ -221,7 +221,7 @@ public class LocalTablet extends Tablet {
                 // replica.getSchemaHash() == -1 is for compatibility
                 if (replica.checkVersionCatchUp(visibleVersion, false)
                         && (replica.getSchemaHash() == -1 || replica.getSchemaHash() == schemaHash)) {
-                    allQuerableReplica.add(replica);
+                    allQuerableReplicas.add(replica);
                     if (localBeId != -1 && replica.getBackendId() == localBeId) {
                         localReplicas.add(replica);
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
@@ -203,6 +203,7 @@ public class LocalTablet extends Tablet {
     }
 
     // for query
+    @Override
     public void getQueryableReplicas(List<Replica> allQuerableReplica, List<Replica> localReplicas,
                                      long visibleVersion, long localBeId, int schemaHash) {
         for (Replica replica : replicas) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/StarOSTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/StarOSTablet.java
@@ -68,11 +68,11 @@ public class StarOSTablet extends Tablet {
 
     // visibleVersion and schemaHash is not used
     @Override
-    public void getQueryableReplicas(List<Replica> allQuerableReplica, List<Replica> localReplicas,
+    public void getQueryableReplicas(List<Replica> allQuerableReplicas, List<Replica> localReplicas,
                                      long visibleVersion, long localBeId, int schemaHash) {
         for (long backendId : getBackendIds()) {
             Replica replica = new Replica(-1, backendId, -1, null);
-            allQuerableReplica.add(replica);
+            allQuerableReplicas.add(replica);
             if (localBeId != -1 && backendId == localBeId) {
                 localReplicas.add(replica);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/StarOSTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/StarOSTablet.java
@@ -9,6 +9,7 @@ import com.starrocks.persist.gson.GsonUtils;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -63,6 +64,19 @@ public class StarOSTablet extends Tablet {
     @Override
     public Set<Long> getBackendIds() {
         return Catalog.getCurrentCatalog().getStarOSAgent().getBackendIdsByShard(shardId);
+    }
+
+    // visibleVersion and schemaHash is not used
+    @Override
+    public void getQueryableReplicas(List<Replica> allQuerableReplica, List<Replica> localReplicas,
+                                     long visibleVersion, long localBeId, int schemaHash) {
+        for (long backendId : getBackendIds()) {
+            Replica replica = new Replica(-1, backendId, -1, null);
+            allQuerableReplica.add(replica);
+            if (localBeId != -1 && backendId == localBeId) {
+                localReplicas.add(replica);
+            }
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Tablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Tablet.java
@@ -50,7 +50,7 @@ public abstract class Tablet extends MetaObject implements Writable {
 
     public abstract Set<Long> getBackendIds();
 
-    public abstract void getQueryableReplicas(List<Replica> allQuerableReplica, List<Replica> localReplicas,
+    public abstract void getQueryableReplicas(List<Replica> allQuerableReplicas, List<Replica> localReplicas,
                                               long visibleVersion, long localBeId, int schemaHash);
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Tablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Tablet.java
@@ -24,6 +24,7 @@ package com.starrocks.catalog;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.io.Writable;
 
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -48,6 +49,9 @@ public abstract class Tablet extends MetaObject implements Writable {
     public abstract long getRowCount(long version);
 
     public abstract Set<Long> getBackendIds();
+
+    public abstract void getQueryableReplicas(List<Replica> allQuerableReplica, List<Replica> localReplicas,
+                                              long visibleVersion, long localBeId, int schemaHash);
 
     @Override
     public String toString() {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -53,6 +53,7 @@ import com.starrocks.catalog.PartitionType;
 import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.LocalTablet;
+import com.starrocks.catalog.StarOSTablet;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
@@ -191,7 +192,7 @@ public class OlapScanNode extends ScanNode {
     }
 
     private List<String> unUsedOutputStringColumns = new ArrayList<>();
-    
+
     public void setUnUsedOutputStringColumns(Set<Integer> unUsedOutputColumnIds) {
         for (SlotDescriptor slot : desc.getSlots()) {
             if (!slot.isMaterialized()) {
@@ -398,6 +399,7 @@ public class OlapScanNode extends ScanNode {
         String schemaHashStr = String.valueOf(schemaHash);
         long visibleVersion = partition.getVisibleVersion();
         String visibleVersionStr = String.valueOf(visibleVersion);
+        boolean useStarOS = partition.isUseStarOS();
 
         for (Tablet tablet : tablets) {
             long tabletId = tablet.getId();
@@ -412,17 +414,21 @@ public class OlapScanNode extends ScanNode {
             internalRange.setTablet_id(tabletId);
 
             // random shuffle List && only collect one copy
-            LocalTablet localTablet = (LocalTablet) tablet;
             List<Replica> allQueryableReplicas = Lists.newArrayList();
             List<Replica> localReplicas = Lists.newArrayList();
-            localTablet.getQueryableReplicas(allQueryableReplicas, localReplicas,
+            tablet.getQueryableReplicas(allQueryableReplicas, localReplicas,
                     visibleVersion, localBeId, schemaHash);
             if (allQueryableReplicas.isEmpty()) {
                 LOG.error("no queryable replica found in tablet {}. visible version {}-{}",
                         tabletId, visibleVersion);
                 if (LOG.isDebugEnabled()) {
-                    for (Replica replica : localTablet.getReplicas()) {
-                        LOG.debug("tablet {}, replica: {}", tabletId, replica.toString());
+                    if (useStarOS) {
+                        LOG.debug("tablet: {}, shard: {}, backends: {}", tabletId, ((StarOSTablet) tablet).getShardId(),
+                                tablet.getBackendIds());
+                    } else {
+                        for (Replica replica : ((LocalTablet) tablet).getReplicas()) {
+                            LOG.debug("tablet {}, replica: {}", tabletId, replica.toString());
+                        }
                     }
                 }
                 throw new UserException("Failed to get scan range, no queryable replica found in tablet: " + tabletId);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -444,6 +444,10 @@ public class Utils {
         int schemaHash = table.getSchemaHashByIndexId(selectedIndexId);
         for (Long partitionId : selectedPartitionId) {
             Partition partition = table.getPartition(partitionId);
+            if (partition.isUseStarOS()) {
+                // TODO(wyb): necessary to support?
+                return false;
+            }
             if (table.getPartitionInfo().getReplicationNum(partitionId) < backendSize) {
                 return false;
             }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/StarOSTabletTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/StarOSTabletTest.java
@@ -3,6 +3,7 @@
 package com.starrocks.catalog;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.common.FeConstants;
@@ -18,6 +19,7 @@ import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.util.List;
 import java.util.Map;
 
 public class StarOSTabletTest {
@@ -86,5 +88,12 @@ public class StarOSTabletTest {
         StarOSTablet tablet = new StarOSTablet(1L, 2L);
         Assert.assertEquals(Sets.newHashSet(backendId), tablet.getBackendIds());
         Assert.assertEquals(backendId, tablet.getPrimaryBackendId());
+        List<Replica> allQuerableReplicas = Lists.newArrayList();
+        List<Replica> localReplicas = Lists.newArrayList();
+        tablet.getQueryableReplicas(allQuerableReplicas, localReplicas, 0, backendId, 0);
+        Assert.assertEquals(1, allQuerableReplicas.size());
+        Assert.assertEquals(backendId, allQuerableReplicas.get(0).getBackendId());
+        Assert.assertEquals(1, localReplicas.size());
+        Assert.assertEquals(backendId, localReplicas.get(0).getBackendId());
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] others

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Select the all replicas in olap scan node for query plan.
The information of all replicas is obtained from StarOS.