### PR TITLE
fix sha2 function crash with null parameter

### DIFF
--- a/be/src/exprs/vectorized/encryption_functions.cpp
+++ b/be/src/exprs/vectorized/encryption_functions.cpp
@@ -319,7 +319,7 @@ ColumnPtr EncryptionFunctions::sha512(FunctionContext* ctx, const Columns& colum
 }
 
 ColumnPtr EncryptionFunctions::sha2(FunctionContext* ctx, const Columns& columns) {
-    if (!ctx->is_constant_column(1)) {
+    if (!ctx->is_notnull_constant_column(1)) {
         auto src_viewer = ColumnViewer<TYPE_VARCHAR>(columns[0]);
         auto length_viewer = ColumnViewer<TYPE_INT>(columns[1]);
 

--- a/be/src/exprs/vectorized/encryption_functions.cpp
+++ b/be/src/exprs/vectorized/encryption_functions.cpp
@@ -327,7 +327,7 @@ ColumnPtr EncryptionFunctions::sha2(FunctionContext* ctx, const Columns& columns
         ColumnBuilder<TYPE_VARCHAR> result(size);
 
         for (int row = 0; row < size; row++) {
-            if (src_viewer.is_null(row)) {
+            if (src_viewer.is_null(row) || length_viewer.is_null(row)) {
                 result.append_null();
                 continue;
             }

--- a/be/test/exprs/vectorized/encryption_functions_test.cpp
+++ b/be/test/exprs/vectorized/encryption_functions_test.cpp
@@ -734,34 +734,43 @@ TEST_F(EncryptionFunctionsTest, md5sumNullTest) {
     }
 }
 
-TEST_F(EncryptionFunctionsTest, sha224Test) {
+class ShaTestFixture : public ::testing::TestWithParam<std::tuple<std::string, int, std::string>> {};
+
+TEST_P(ShaTestFixture, test_sha2) {
+    auto [str, len, expected] = GetParam();
+
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;
+
     auto plain = BinaryColumn::create();
+    plain->append(str);
 
-    std::string plains[] = {"starrocks", "20211119"};
+    ColumnPtr hash_length =
+            len == -1 ? ColumnHelper::create_const_null_column(1) : ColumnHelper::create_const_column<TYPE_INT>(len, 1);
 
-    for (int j = 0; j < sizeof(plains) / sizeof(plains[0]); ++j) {
-        plain->append(plains[j]);
+    if (str == "NULL") {
+        columns.emplace_back(ColumnHelper::create_const_null_column(1));
+    } else {
+        columns.emplace_back(plain);
     }
-
-    auto hash_length = ColumnHelper::create_const_column<TYPE_INT>(224, 1);
-
-    columns.emplace_back(plain);
     columns.emplace_back(hash_length);
 
     ctx->impl()->set_constant_columns(columns);
     ASSERT_TRUE(EncryptionFunctions::sha2_prepare(ctx.get(), FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
 
-    ASSERT_NE(nullptr, ctx->get_function_state(FunctionContext::FRAGMENT_LOCAL));
+    if (len != -1) {
+        ASSERT_NE(nullptr, ctx->get_function_state(FunctionContext::FRAGMENT_LOCAL));
+    } else {
+        ASSERT_EQ(nullptr, ctx->get_function_state(FunctionContext::FRAGMENT_LOCAL));
+    }
 
     ColumnPtr result = EncryptionFunctions::sha2(ctx.get(), columns);
-    auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-
-    std::string check_result[2] = {"0057da608f56e8cdd3c22208a93cdda3e142279a694dfc53007e80f3",
-                                   "b080f0657e5b67fd52b2f010328d2fad10775f81aa71c05313d46a24"};
-    for (int j = 0; j < sizeof(check_result) / sizeof(check_result[0]); ++j) {
-        ASSERT_EQ(check_result[j], v->get_data()[j].to_string());
+    if (expected == "NULL") {
+        std::cerr << result->debug_string() << std::endl;
+        EXPECT_TRUE(result->is_null(0));
+    } else {
+        auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
+        EXPECT_EQ(expected, v->get_data()[0].to_string());
     }
 
     ASSERT_TRUE(EncryptionFunctions::sha2_close(ctx.get(),
@@ -769,145 +778,31 @@ TEST_F(EncryptionFunctionsTest, sha224Test) {
                         .ok());
 }
 
-TEST_F(EncryptionFunctionsTest, sha256Test) {
-    std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
-    Columns columns;
-    auto plain = BinaryColumn::create();
+INSTANTIATE_TEST_SUITE_P(
+        ShaTest, ShaTestFixture,
+        ::testing::Values(
+                // Invalid cases
+                // -1 means null
+                std::make_tuple("starrocks", -1, "NULL"), std::make_tuple("starrocks", 225, "NULL"),
+                std::make_tuple("NULL", 1, "NULL"),
 
-    std::string plains[] = {"starrocks", "20211119"};
-
-    for (int j = 0; j < sizeof(plains) / sizeof(plains[0]); ++j) {
-        plain->append(plains[j]);
-    }
-
-    auto hash_length = ColumnHelper::create_const_column<TYPE_INT>(256, 1);
-
-    columns.emplace_back(plain);
-    columns.emplace_back(hash_length);
-
-    ctx->impl()->set_constant_columns(columns);
-    ASSERT_TRUE(EncryptionFunctions::sha2_prepare(ctx.get(), FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
-
-    ColumnPtr result = EncryptionFunctions::sha2(ctx.get(), columns);
-
-    auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-
-    std::string check_result[2] = {"87da3b6aefc0bd626a32626685dad2dba7435095f26c5a9628a6b13ced5721b0",
-                                   "1deab4a6f88c6cbab900c2ae0a1da4f0e7e981f8b0f0680d8ec6c25155ab4885"};
-    for (int j = 0; j < sizeof(check_result) / sizeof(check_result[0]); ++j) {
-        ASSERT_EQ(check_result[j], v->get_data()[j].to_string());
-    }
-
-    ASSERT_TRUE(EncryptionFunctions::sha2_close(ctx.get(),
-                                                FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
-                        .ok());
-}
-
-TEST_F(EncryptionFunctionsTest, sha384Test) {
-    std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
-    Columns columns;
-    auto plain = BinaryColumn::create();
-
-    std::string plains[] = {"starrocks", "20211119"};
-
-    for (int j = 0; j < sizeof(plains) / sizeof(plains[0]); ++j) {
-        plain->append(plains[j]);
-    }
-
-    auto hash_length = ColumnHelper::create_const_column<TYPE_INT>(384, 1);
-
-    columns.emplace_back(plain);
-    columns.emplace_back(hash_length);
-
-    ctx->impl()->set_constant_columns(columns);
-    ASSERT_TRUE(EncryptionFunctions::sha2_prepare(ctx.get(), FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
-
-    ColumnPtr result = EncryptionFunctions::sha2(ctx.get(), columns);
-
-    auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-
-    std::string check_result[2] = {
-            "eda8e790960d9ff4fdc6f481ec57bf443c147bf092086006e98a2ab0108afbaaf8e6f51d197f988dd798d2524b12de2c",
-            "6195d65242957bdf844e6623acabf2b0879c9cb282a9490ed332f7fdc41aedbda7802af06d07f38d7ed69449d3ff5bf8"};
-    for (int j = 0; j < sizeof(check_result) / sizeof(check_result[0]); ++j) {
-        ASSERT_EQ(check_result[j], v->get_data()[j].to_string());
-    }
-
-    ASSERT_TRUE(EncryptionFunctions::sha2_close(ctx.get(),
-                                                FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
-                        .ok());
-}
-
-TEST_F(EncryptionFunctionsTest, sha512Test) {
-    std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
-    Columns columns;
-    auto plain = BinaryColumn::create();
-
-    std::string plains[] = {"starrocks", "20211119"};
-
-    for (int j = 0; j < sizeof(plains) / sizeof(plains[0]); ++j) {
-        plain->append(plains[j]);
-    }
-
-    auto hash_length = ColumnHelper::create_const_column<TYPE_INT>(512, 1);
-
-    columns.emplace_back(plain);
-    columns.emplace_back(hash_length);
-
-    ctx->impl()->set_constant_columns(columns);
-    ASSERT_TRUE(EncryptionFunctions::sha2_prepare(ctx.get(), FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
-
-    ColumnPtr result = EncryptionFunctions::sha2(ctx.get(), columns);
-
-    auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-
-    std::string check_result[2] = {
-            "9df77afa38c688166eaa7511440dd3a0b1c32918e9ae60b8c74e4b0f530852cd1a0facc610b71ebfcbe345f5fa40983fe68a686144"
-            "d2c6981b8a3fab1b045cd0",
-            "eaf18d26b2976216790d95b2942d15b7db5f926c7d62d35f24c98b8eedbe96f2e6241e5e4fdc6b7d9e7893d94d86cd8a6f3bb6b180"
-            "4c22097b337ecc24f6015e"};
-    for (int j = 0; j < sizeof(check_result) / sizeof(check_result[0]); ++j) {
-        ASSERT_EQ(check_result[j], v->get_data()[j].to_string());
-    }
-
-    ASSERT_TRUE(EncryptionFunctions::sha2_close(ctx.get(),
-                                                FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
-                        .ok());
-}
-
-TEST_F(EncryptionFunctionsTest, invalidSHATest) {
-    std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
-    Columns columns;
-    auto plain = BinaryColumn::create();
-
-    std::string plains[] = {"starrocks", "20211119"};
-
-    for (int j = 0; j < sizeof(plains) / sizeof(plains[0]); ++j) {
-        plain->append(plains[j]);
-    }
-
-    auto hash_length = ColumnHelper::create_const_column<TYPE_INT>(225, 1);
-
-    columns.emplace_back(plain);
-    columns.emplace_back(hash_length);
-
-    ctx->impl()->set_constant_columns(columns);
-    ASSERT_TRUE(EncryptionFunctions::sha2_prepare(ctx.get(), FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
-
-    ASSERT_NE(nullptr, ctx->get_function_state(FunctionContext::FRAGMENT_LOCAL));
-
-    ColumnPtr result = EncryptionFunctions::sha2(ctx.get(), columns);
-
-    std::string check_result[2] = {"0057da608f56e8cdd3c22208a93cdda3e142279a694dfc53007e80f3",
-                                   "b080f0657e5b67fd52b2f010328d2fad10775f81aa71c05313d46a24"};
-    for (int j = 0; j < sizeof(check_result) / sizeof(check_result[0]); ++j) {
-        ASSERT_TRUE(result->is_null(j));
-    }
-
-    ASSERT_TRUE(EncryptionFunctions::sha2_close(ctx.get(),
-                                                FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
-                        .ok());
-}
+                // Normal cases
+                std::make_tuple("starrocks", 224, "0057da608f56e8cdd3c22208a93cdda3e142279a694dfc53007e80f3"),
+                std::make_tuple("20211119", 224, "b080f0657e5b67fd52b2f010328d2fad10775f81aa71c05313d46a24"),
+                std::make_tuple("starrocks", 256, "87da3b6aefc0bd626a32626685dad2dba7435095f26c5a9628a6b13ced5721b0"),
+                std::make_tuple("20211119", 256, "1deab4a6f88c6cbab900c2ae0a1da4f0e7e981f8b0f0680d8ec6c25155ab4885"),
+                std::make_tuple("starrocks", 384,
+                                "eda8e790960d9ff4fdc6f481ec57bf443c147bf092086006e98a2ab0108afbaaf8e6f51d197f988dd798d2"
+                                "524b12de2c"),
+                std::make_tuple("20211119", 384,
+                                "6195d65242957bdf844e6623acabf2b0879c9cb282a9490ed332f7fdc41aedbda7802af06d07f38d7ed694"
+                                "49d3ff5bf8"),
+                std::make_tuple("starrocks", 512,
+                                "9df77afa38c688166eaa7511440dd3a0b1c32918e9ae60b8c74e4b0f530852cd1a0facc610b71ebfcbe345"
+                                "f5fa40983fe68a686144d2c6981b8a3fab1b045cd0"),
+                std::make_tuple("20211119", 512,
+                                "eaf18d26b2976216790d95b2942d15b7db5f926c7d62d35f24c98b8eedbe96f2e6241e5e4fdc6b7d9e7893"
+                                "d94d86cd8a6f3bb6b1804c22097b337ecc24f6015e")));
 
 } // namespace vectorized
 } // namespace starrocks


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：


## Problem Summary(Required) ：
Fix `sha2` function crash on null parameter .

```sql
select (sha2(id_varchar, id_int)) <=> (sha2(NULL, NULL)) from test_all_null;
select (sha2(id_varchar, id_int)) <=> (sha2(id_varchar, NULL)) from test_all_null;
select (sha2(id_varchar, id_int)) <=> (sha2(NULL, id_int)) from test_all_null;
```
