### PR TITLE
resource_iso: more_accurate_cpu_use_for_wg

### DIFF
--- a/be/src/exec/pipeline/chunk_source.h
+++ b/be/src/exec/pipeline/chunk_source.h
@@ -40,6 +40,7 @@ public:
     virtual Status buffer_next_batch_chunks_blocking_for_workgroup(size_t chunk_size, bool& can_finish,
                                                                    size_t* num_read_chunks, int worker_id,
                                                                    workgroup::WorkGroupPtr running_wg) = 0;
+    virtual int64_t last_spent_cpu_time_ns() { return 0; }
 
 protected:
     // The morsel will own by pipeline driver

--- a/be/src/exec/pipeline/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/olap_chunk_source.cpp
@@ -461,6 +461,14 @@ void OlapChunkSource::_update_realtime_counter(vectorized::Chunk* chunk) {
     _num_rows_read += chunk->num_rows();
 }
 
+int64_t OlapChunkSource::last_spent_cpu_time_ns() {
+    int64_t time_ns = _last_spent_cpu_time_ns;
+    _last_spent_cpu_time_ns += _reader->stats().decompress_ns;
+    _last_spent_cpu_time_ns += _reader->stats().vec_cond_ns;
+    _last_spent_cpu_time_ns += _reader->stats().del_filter_ns;
+    return _last_spent_cpu_time_ns - time_ns;
+}
+
 void OlapChunkSource::_update_counter() {
     COUNTER_UPDATE(_create_seg_iter_timer, _reader->stats().create_segment_iter_ns);
     COUNTER_UPDATE(_rows_read_counter, _num_rows_read);

--- a/be/src/exec/pipeline/olap_chunk_source.h
+++ b/be/src/exec/pipeline/olap_chunk_source.h
@@ -49,6 +49,7 @@ public:
     Status buffer_next_batch_chunks_blocking(size_t chunk_size, bool& can_finish) override;
     Status buffer_next_batch_chunks_blocking_for_workgroup(size_t chunk_size, bool& can_finish, size_t* num_read_chunks,
                                                            int worker_id, workgroup::WorkGroupPtr running_wg) override;
+    int64_t last_spent_cpu_time_ns() override;
 
 private:
     // Yield scan io task when maximum time in nano-seconds has spent in current execution round.
@@ -119,6 +120,9 @@ private:
     RuntimeProfile::Counter* _bytes_read_counter = nullptr;
     RuntimeProfile::Counter* _rows_read_counter = nullptr;
 
+    int64_t _last_spent_cpu_time_ns = 0;
+
+    RuntimeProfile* _scan_profile = nullptr;
     RuntimeProfile::Counter* _expr_filter_timer = nullptr;
     RuntimeProfile::Counter* _scan_timer = nullptr;
     RuntimeProfile::Counter* _create_seg_iter_timer = nullptr;

--- a/be/src/exec/pipeline/pipeline_driver_queue.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_queue.cpp
@@ -284,6 +284,7 @@ void DriverQueueWithWorkGroup::_put_back(const DriverRawPtr driver) {
                 int64_t new_vruntime_ns = std::min(min_wg->vruntime_ns() - _ideal_runtime_ns(wg) / 2,
                                                    min_wg->real_runtime_ns() / int64_t(wg->cpu_limit()));
                 wg->set_vruntime_ns(std::max(wg->vruntime_ns(), new_vruntime_ns));
+                wg->update_last_real_runtime_ns(wg->real_runtime_ns());
 
                 int64_t diff_real_runtime_ns = wg->real_runtime_ns() - origin_real_runtime_ns;
                 workgroup::WorkGroupManager::instance()->increment_cpu_runtime_ns(diff_real_runtime_ns);

--- a/be/src/exec/pipeline/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan_operator.cpp
@@ -176,12 +176,12 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
         workgroup::ScanTask task = workgroup::ScanTask(_workgroup, [this, state, chunk_source_index](int worker_id) {
             {
                 SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(state->instance_mem_tracker());
-
                 size_t num_read_chunks = 0;
                 _chunk_sources[chunk_source_index]->buffer_next_batch_chunks_blocking_for_workgroup(
                         _buffer_size, _is_finished, &num_read_chunks, worker_id, _workgroup);
                 // TODO (by laotan332): More detailed information is needed
                 _workgroup->incr_period_scaned_chunk_num(num_read_chunks);
+                _workgroup->increment_real_runtime_ns(_chunk_sources[chunk_source_index]->last_spent_cpu_time_ns());
             }
 
             _num_running_io_tasks--;

--- a/be/src/exec/workgroup/scan_task_queue.cpp
+++ b/be/src/exec/workgroup/scan_task_queue.cpp
@@ -28,6 +28,25 @@ void ScanTaskQueueWithWorkGroup::close() {
     _cv.notify_all();
 }
 
+void ScanTaskQueueWithWorkGroup::cal_wg_cpu_real_use_ratio() {
+    int64_t total_run_time = 0;
+    std::vector<int64_t> growth_times;
+    growth_times.reserve(_ready_wgs.size());
+
+    for (auto& wg : _ready_wgs) {
+        growth_times.emplace_back(wg->growth_vruntime_ns());
+        total_run_time += growth_times.back();
+        wg->update_last_vruntime_ns(wg->real_runtime_ns());
+    }
+
+    int i = 0;
+    for (auto& wg : _ready_wgs) {
+        double cpu_actual_use_ratio = ((double)growth_times[i] / (total_run_time));
+        wg->set_cpu_actual_use_ratio(cpu_actual_use_ratio);
+        i++;
+    }
+}
+
 StatusOr<ScanTask> ScanTaskQueueWithWorkGroup::take(int worker_id) {
     std::unique_lock<std::mutex> lock(_global_mutex);
 
@@ -71,6 +90,8 @@ void ScanTaskQueueWithWorkGroup::_maybe_adjust_weight() {
     if (--_remaining_schedule_num_period > 0) {
         return;
     }
+
+    cal_wg_cpu_real_use_ratio();
 
     int num_tasks = 0;
     // calculate all wg factors

--- a/be/src/exec/workgroup/scan_task_queue.cpp
+++ b/be/src/exec/workgroup/scan_task_queue.cpp
@@ -28,15 +28,15 @@ void ScanTaskQueueWithWorkGroup::close() {
     _cv.notify_all();
 }
 
-void ScanTaskQueueWithWorkGroup::cal_wg_cpu_real_use_ratio() {
+void ScanTaskQueueWithWorkGroup::_cal_wg_cpu_real_use_ratio() {
     int64_t total_run_time = 0;
     std::vector<int64_t> growth_times;
     growth_times.reserve(_ready_wgs.size());
 
     for (auto& wg : _ready_wgs) {
-        growth_times.emplace_back(wg->growth_vruntime_ns());
+        growth_times.emplace_back(wg->growth_real_runtime_ns());
         total_run_time += growth_times.back();
-        wg->update_last_vruntime_ns(wg->real_runtime_ns());
+        wg->update_last_real_runtime_ns(wg->real_runtime_ns());
     }
 
     int i = 0;
@@ -91,7 +91,7 @@ void ScanTaskQueueWithWorkGroup::_maybe_adjust_weight() {
         return;
     }
 
-    cal_wg_cpu_real_use_ratio();
+    _cal_wg_cpu_real_use_ratio();
 
     int num_tasks = 0;
     // calculate all wg factors

--- a/be/src/exec/workgroup/scan_task_queue.cpp
+++ b/be/src/exec/workgroup/scan_task_queue.cpp
@@ -32,7 +32,6 @@ void ScanTaskQueueWithWorkGroup::_cal_wg_cpu_real_use_ratio() {
     int64_t total_run_time = 0;
     std::vector<int64_t> growth_times;
     growth_times.reserve(_ready_wgs.size());
-
     for (auto& wg : _ready_wgs) {
         growth_times.emplace_back(wg->growth_real_runtime_ns());
         total_run_time += growth_times.back();

--- a/be/src/exec/workgroup/scan_task_queue.h
+++ b/be/src/exec/workgroup/scan_task_queue.h
@@ -77,7 +77,7 @@ public:
 
 private:
     // Calculate the actual cpu used by all wg
-    void cal_wg_cpu_real_use_ratio();
+    void _cal_wg_cpu_real_use_ratio();
 
     // _maybe_adjust_weight and _select_next_wg are guarded by the ourside _global_mutex.
     void _maybe_adjust_weight();

--- a/be/src/exec/workgroup/scan_task_queue.h
+++ b/be/src/exec/workgroup/scan_task_queue.h
@@ -76,6 +76,9 @@ public:
     size_t size() const override { return _total_task_num.load(std::memory_order_acquire); }
 
 private:
+    // Calculate the actual cpu used by all wg
+    void cal_wg_cpu_real_use_ratio();
+
     // _maybe_adjust_weight and _select_next_wg are guarded by the ourside _global_mutex.
     void _maybe_adjust_weight();
     WorkGroupPtr _select_next_wg(int worker_id);

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -78,11 +78,7 @@ double WorkGroup::get_cpu_expected_use_ratio() const {
 }
 
 double WorkGroup::get_cpu_actual_use_ratio() const {
-    int64_t sum_cpu_runtime_ns = WorkGroupManager::instance()->sum_cpu_runtime_ns();
-    if (sum_cpu_runtime_ns == 0) {
-        return 0;
-    }
-    return static_cast<double>(real_runtime_ns()) / sum_cpu_runtime_ns;
+    return _cpu_actual_use_ratio;
 }
 
 WorkGroupManager::WorkGroupManager()

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -169,7 +169,7 @@ void WorkGroup::estimate_trend_factor_period() {
 
     double increase_factor = _period_scaned_chunk_num / get_cpu_actual_use_ratio();
 
-    _expect_factor = decrease_factor / increase_factor * get_cpu_expected_use_ratio();
+    _expect_factor = decrease_factor / increase_factor * get_cpu_actual_use_ratio();
 
     // diff_factor indicates the difference between the actual percentage of io resources used and the limited cpu percentage
     // If it is negative, it means that there are not enough resources and more resources are needed

--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -60,8 +60,8 @@ public:
     int64_t vruntime_ns() const { return _vruntime_ns; }
     int64_t real_runtime_ns() const { return _vruntime_ns * _cpu_limit; }
 
-    int64_t growth_vruntime_ns() const { return _vruntime_ns * _cpu_limit - _last_vruntime_ns; }
-    void update_last_vruntime_ns(int64_t last_vruntime_ns) { _last_vruntime_ns = last_vruntime_ns; }
+    int64_t growth_real_runtime_ns() const { return _vruntime_ns * _cpu_limit - _last_vruntime_ns; }
+    void update_last_real_runtime_ns(int64_t last_vruntime_ns) { _last_vruntime_ns = last_vruntime_ns; }
 
     // Accumulate virtual runtime divided by _cpu_limit, so that the larger _cpu_limit,
     // the more cpu time can be consumed proportionally.

--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -59,6 +59,10 @@ public:
 
     int64_t vruntime_ns() const { return _vruntime_ns; }
     int64_t real_runtime_ns() const { return _vruntime_ns * _cpu_limit; }
+
+    int64_t growth_vruntime_ns() const { return _vruntime_ns * _cpu_limit - _last_vruntime_ns; }
+    void update_last_vruntime_ns(int64_t last_vruntime_ns) { _last_vruntime_ns = last_vruntime_ns; }
+
     // Accumulate virtual runtime divided by _cpu_limit, so that the larger _cpu_limit,
     // the more cpu time can be consumed proportionally.
     void increment_real_runtime_ns(int64_t real_runtime_ns) { _vruntime_ns += real_runtime_ns / _cpu_limit; }
@@ -66,6 +70,7 @@ public:
 
     double get_cpu_expected_use_ratio() const;
     double get_cpu_actual_use_ratio() const;
+    void set_cpu_actual_use_ratio(double ratio) { _cpu_actual_use_ratio = ratio; }
 
     // If the scan layer generates data, then this interface should be called
     void incr_period_scaned_chunk_num(int32_t chunk_num);
@@ -137,6 +142,7 @@ private:
 
     pipeline::DriverQueuePtr _driver_queue = nullptr;
     int64_t _vruntime_ns = 0;
+    int64_t _last_vruntime_ns = 0;
 
     std::atomic<bool> _is_marked_del = false;
     std::atomic<size_t> _num_drivers = 0;
@@ -153,6 +159,8 @@ private:
     double _diff_factor = 0;
     double _select_factor = 0;
     double _cur_select_factor = 0;
+
+    double _cpu_actual_use_ratio = 0;
 };
 
 class WorkerOwnerManager {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
for Resource Isolation：
Previously, the cpu usage ratio was calculated using the cumulative value, which is actually unfair to many inactive workgroups
Now，It makes more sense to use the statistics of the period to calculate the proportion of resources
