### PR TITLE
Fix percentile_approx_raw not support null value

### DIFF
--- a/be/src/exprs/vectorized/percentile_functions.cpp
+++ b/be/src/exprs/vectorized/percentile_functions.cpp
@@ -42,8 +42,12 @@ ColumnPtr PercentileFunctions::percentile_approx_raw(FunctionContext* context, c
     size_t size = columns[0]->size();
     ColumnBuilder<TYPE_DOUBLE> builder(size);
     for (int row = 0; row < size; ++row) {
-        double result = viewer1.value(row)->quantile(viewer2.value(row));
-        builder.append(result);
+        if (viewer1.is_null(row) || viewer2.is_null(row)) {
+            builder.append_null();
+        } else {
+            double result = viewer1.value(row)->quantile(viewer2.value(row));
+            builder.append(result);
+        }
     }
     return builder.build(columns[0]->is_constant());
 }

--- a/be/test/exprs/vectorized/percentile_functions_test.cpp
+++ b/be/test/exprs/vectorized/percentile_functions_test.cpp
@@ -49,5 +49,23 @@ TEST_F(PercentileFunctionsTest, percentileHashTest) {
     ASSERT_EQ(3, percentile->get_object(2)->quantile(1));
 }
 
+TEST_F(PercentileFunctionsTest, percentileNullTest) {
+    Columns columns;
+    auto c1 = PercentileColumn::create();
+    auto c1_null = NullableColumn::create(c1, NullColumn::create());
+    c1_null->append_nulls(1);
+    columns.push_back(c1_null);
+
+    auto c2 = DoubleColumn::create();
+    auto c2_null = NullableColumn::create(c2, NullColumn::create());
+    c2_null->append_nulls(1);
+    columns.push_back(c2_null);
+
+    ColumnPtr column = PercentileFunctions::percentile_approx_raw(ctx, columns);
+    ASSERT_TRUE(column->is_nullable());
+    auto result = ColumnHelper::as_column<NullableColumn>(column);
+    ASSERT_TRUE(result->is_null(0));
+}
+
 } // namespace vectorized
 } // namespace starrocks


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4142

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
