### PR TITLE
[cherry-pick] [branch-2.2]BugFix: error memory limitation of schema change (#4115)

### DIFF
--- a/be/src/storage/vectorized/schema_change.cpp
+++ b/be/src/storage/vectorized/schema_change.cpp
@@ -1182,8 +1182,9 @@ Status SchemaChangeHandler::_convert_historical_rowsets(SchemaChangeParams& sc_p
     auto chunk_changer = sc_params.chunk_changer.get();
     if (sc_params.sc_sorting) {
         LOG(INFO) << "doing schema change with sorting for base_tablet " << sc_params.base_tablet->full_name();
-        sc_procedure = std::make_unique<SchemaChangeWithSorting>(
-                chunk_changer, config::memory_limitation_per_thread_for_schema_change * 1024 * 1024 * 1024);
+        size_t memory_limitation =
+                static_cast<size_t>(config::memory_limitation_per_thread_for_schema_change) * 1024 * 1024 * 1024;
+        sc_procedure = std::make_unique<SchemaChangeWithSorting>(chunk_changer, memory_limitation);
     } else if (sc_params.sc_directly) {
         LOG(INFO) << "doing directly schema change for base_tablet " << sc_params.base_tablet->full_name();
         sc_procedure = std::make_unique<SchemaChangeDirectly>(chunk_changer);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The type of memory_limitation_per_thread_for_schema_change is int32 and upper limit is 2GB.

When memory_limitation_per_thread_for_schema_change is set to more than 4GB, the memory limitation of schema change will overflow and maybe set to 0.

Change the type of memory limitation to uint64