### PR TITLE
Disable some commands on StarOS table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/AbstractBackupStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/AbstractBackupStmt.java
@@ -26,6 +26,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.Catalog;
+import com.starrocks.catalog.CatalogUtils;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.ErrorCode;
@@ -101,6 +102,8 @@ public class AbstractBackupStmt extends DdlStmt {
             } else {
                 throw new AnalysisException("Duplicated restore table: " + tblName);
             }
+
+            CatalogUtils.checkOlapTableHasStarOSPartition(labelName.getDbName(), tblName);
         }
 
         // update table ref

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/AdminShowReplicaDistributionStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/AdminShowReplicaDistributionStmt.java
@@ -24,6 +24,7 @@ package com.starrocks.analysis;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.starrocks.catalog.Catalog;
+import com.starrocks.catalog.CatalogUtils;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.cluster.ClusterNamespace;
@@ -66,6 +67,8 @@ public class AdminShowReplicaDistributionStmt extends ShowStmt {
         }
 
         tblRef.getName().setDb(dbName);
+
+        CatalogUtils.checkOlapTableHasStarOSPartition(dbName, tblRef.getName().getTbl());
     }
 
     public String getDbName() {

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/AdminShowReplicaStatusStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/AdminShowReplicaStatusStmt.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.starrocks.analysis.BinaryPredicate.Operator;
 import com.starrocks.catalog.Catalog;
+import com.starrocks.catalog.CatalogUtils;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Replica.ReplicaStatus;
 import com.starrocks.catalog.ScalarType;
@@ -79,6 +80,8 @@ public class AdminShowReplicaStatusStmt extends ShowStmt {
         }
 
         tblRef.getName().setDb(dbName);
+
+        CatalogUtils.checkOlapTableHasStarOSPartition(dbName, tblRef.getName().getTbl());
 
         PartitionNames partitionNames = tblRef.getPartitionNames();
         if (partitionNames != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/AlterTableStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/AlterTableStmt.java
@@ -22,6 +22,7 @@
 package com.starrocks.analysis;
 
 import com.starrocks.catalog.Catalog;
+import com.starrocks.catalog.CatalogUtils;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.UserException;
@@ -59,6 +60,9 @@ public class AlterTableStmt extends DdlStmt {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_NO_TABLES_USED);
         }
         tbl.analyze(analyzer);
+
+        CatalogUtils.checkOlapTableHasStarOSPartition(tbl.getDb(), tbl.getTbl());
+
         if (!Catalog.getCurrentCatalog().getAuth().checkTblPriv(ConnectContext.get(), tbl.getDb(), tbl.getTbl(),
                 PrivPredicate.ALTER)) {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_TABLEACCESS_DENIED_ERROR, "ALTER TABLE",

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/CreateMaterializedViewStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/CreateMaterializedViewStmt.java
@@ -26,6 +26,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.catalog.AggregateType;
+import com.starrocks.catalog.CatalogUtils;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.KeysType;
@@ -257,6 +258,8 @@ public class CreateMaterializedViewStmt extends DdlStmt {
         TableName tableName = tableRefList.get(0).getName();
         baseIndexName = tableName.getTbl();
         dbName = tableName.getDb();
+
+        CatalogUtils.checkOlapTableHasStarOSPartition(dbName, baseIndexName);
     }
 
     private void analyzeOrderByClause() throws AnalysisException {

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/DeleteStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/DeleteStmt.java
@@ -25,6 +25,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import com.starrocks.analysis.CompoundPredicate.Operator;
 import com.starrocks.catalog.Catalog;
+import com.starrocks.catalog.CatalogUtils;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.ErrorCode;
@@ -86,6 +87,8 @@ public class DeleteStmt extends DdlStmt {
         }
 
         tbl.analyze(analyzer);
+
+        CatalogUtils.checkOlapTableHasStarOSPartition(tbl.getDb(), tbl.getTbl());
 
         if (partitionNames != null) {
             partitionNames.analyze(analyzer);

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/LoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/LoadStmt.java
@@ -26,6 +26,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.Catalog;
+import com.starrocks.catalog.CatalogUtils;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.UserException;
@@ -302,6 +303,12 @@ public class LoadStmt extends DdlStmt {
             // if cluster is null, use default hadoop cluster
             // if cluster is not null, use this hadoop cluster
             etlJobType = EtlJobType.HADOOP;
+        }
+
+        if (etlJobType == EtlJobType.SPARK) {
+            for (DataDescription dataDescription : dataDescriptions) {
+                CatalogUtils.checkOlapTableHasStarOSPartition(label.getDbName(), dataDescription.getTableName());
+            }
         }
 
         try {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewStmtTest.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Lists;
 import com.starrocks.catalog.AggregateFunction;
 import com.starrocks.catalog.AggregateType;
 import com.starrocks.catalog.Catalog;
+import com.starrocks.catalog.CatalogUtils;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
@@ -63,6 +64,8 @@ public class CreateMaterializedViewStmtTest {
     private ConnectContext connectContext;
     @Mocked
     private Config config;
+    @Mocked
+    private CatalogUtils catalogUtils;
 
     private static String runningDir = "fe/mocked/CreateMaterializedViewStmtTest/" + UUID.randomUUID().toString() + "/";
     private static ConnectContext connectContext2;

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
@@ -309,6 +309,14 @@ public class CreateTableTest {
         for (Partition partition : olapTable.getAllPartitions()) {
             Assert.assertTrue(partition.isUseStarOS());
         }
+
+        boolean throwException = false;
+        try {
+            CatalogUtils.checkOlapTableHasStarOSPartition(fullDbName, tableName);
+        } catch (AnalysisException e) {
+            throwException = true;
+        }
+        Assert.assertTrue(throwException);
     }
 
     private void dropOlapTableWithStarOSTablet(String dbName, String tableName) {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] others

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Disable the following commands:
1. Alter table
2. Backup and restore
3. Create materialized view
4. Delete
5. Spark load
6. Admin show tablet status
7. Admin show tablet distribution

Some of them will be supported later.