### PR TITLE
misuse pipeleine engine

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -172,6 +172,10 @@ public class PlanFragment extends TreeNode<PlanFragment> {
         }
     }
 
+    public boolean canUsePipeline() {
+        return getPlanRoot().canUsePipeLine() && getSink().canUsePipeLine();
+    }
+
     /**
      * Assign ParallelExecNum by PARALLEL_FRAGMENT_EXEC_INSTANCE_NUM in SessionVariable for synchronous request
      * Assign ParallelExecNum by default value for Asynchronous request

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -469,7 +469,7 @@ public class Coordinator {
             // TODO: remove this when load supports pipeline engine.
             boolean isEnablePipelineEngine = ConnectContext.get() != null &&
                     ConnectContext.get().getSessionVariable().isEnablePipelineEngine() &&
-                    (fragments.get(0).getSink() instanceof ResultSink);
+                    (fragments.stream().allMatch(PlanFragment::canUsePipeline));
 
             for (PlanFragment fragment : fragments) {
                 FragmentExecParams params = fragmentExecParamsMap.get(fragment.getFragmentId());
@@ -1125,13 +1125,13 @@ public class Coordinator {
         // the latter might inherit the set of hosts from the former
         // compute hosts *bottom up*.
 
+        boolean dopAdaptionEnabled = ConnectContext.get() != null &&
+                ConnectContext.get().getSessionVariable().isPipelineDopAdaptionEnabled() &&
+                fragments.stream().allMatch(PlanFragment::canUsePipeline);
+
         for (int i = fragments.size() - 1; i >= 0; --i) {
             PlanFragment fragment = fragments.get(i);
             FragmentExecParams params = fragmentExecParamsMap.get(fragment.getFragmentId());
-
-            boolean dopAdaptionEnabled = ConnectContext.get() != null &&
-                    ConnectContext.get().getSessionVariable().isPipelineDopAdaptionEnabled() &&
-                    fragment.getPlanRoot().canUsePipeLine();
 
             if (fragment.getDataPartition() == DataPartition.UNPARTITIONED) {
                 Reference<Long> backendIdRef = new Reference<>();


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


## Problem Summary(Required) ：

when enable pipeline engine, query contains EsScanNode report error as follows:
```
mysql> SELECT * FROM external_es_table_join as a join join_test as b on a.id_int = b.k1;
ERROR 1064 (HY000): Failed to connect to ES server, errmsg is: The requested URL returned error: 400
```
Fix this bug, only query all of  whose PlanNodes and DataSinks can use pipeline engine, then the query use pipeline engine
