### PR TITLE
Add session variable enable_hive_column_stats

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -494,7 +494,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = SINGLE_NODE_EXEC_PLAN, flag = VariableMgr.INVISIBLE)
     private boolean singleNodeExecPlan = false;
 
-    @VariableMgr.VarAttr(name = ENABLE_HIVE_COLUMN_STATS, flag = VariableMgr.SESSION)
+    @VariableMgr.VarAttr(name = ENABLE_HIVE_COLUMN_STATS)
     private boolean enableHiveColumnStats = true;
 
     public boolean enableHiveColumnStats() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -192,6 +192,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ALLOW_DEFAULT_PARTITION = "allow_default_partition";
 
+    public static final String ENABLE_HIVE_COLUMN_STATS = "enable_hive_column_stats";
+
     @VariableMgr.VarAttr(name = ENABLE_PIPELINE_ENGINE)
     private boolean enablePipelineEngine = false;
 
@@ -491,6 +493,13 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = SINGLE_NODE_EXEC_PLAN, flag = VariableMgr.INVISIBLE)
     private boolean singleNodeExecPlan = false;
+
+    @VariableMgr.VarAttr(name = ENABLE_HIVE_COLUMN_STATS, flag = VariableMgr.SESSION)
+    private boolean enableHiveColumnStats = true;
+
+    public boolean enableHiveColumnStats() {
+        return enableHiveColumnStats;
+    }
 
     public long getMaxExecMemByte() {
         return maxExecMemByte;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -29,6 +29,7 @@ import com.starrocks.external.hive.HivePartition;
 import com.starrocks.external.hive.HiveTableStats;
 import com.starrocks.external.iceberg.cost.IcebergTableStatisticCalculator;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.ExpressionContext;
@@ -298,7 +299,11 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
         List<ColumnRefOperator> requiredColumns = new ArrayList<>(colRefToColumnMetaMap.keySet());
 
         List<ColumnStatistic> columnStatisticList;
+
         try {
+            if (!optimizerContext.getSessionVariable().enableHiveColumnStats()) {
+                throw new Exception("Session variable " + SessionVariable.ENABLE_HIVE_COLUMN_STATS + " is false");
+            }
             Map<String, HiveColumnStats> hiveColumnStatisticMap =
                     tableWithStats.getTableLevelColumnStats(requiredColumns.stream().
                             map(ColumnRefOperator::getName).collect(Collectors.toList()));


### PR DESCRIPTION
## What type of PR is this：
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
Fe will get hive columns stats when user query hive external table. If user's hms pressure is very high, fe will failed to get the hive column stats. Also affects the execution time of the query. Add a session variable here, the user skips acquire hive columns stats in cbo process.
## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
