### PR TITLE
Bugfix: set broker range start offset and size in spark load task

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadJob.java
@@ -490,10 +490,14 @@ public class SparkLoadJob extends BulkLoadJob {
                                         // update filePath fileSize
                                         TBrokerRangeDesc tBrokerRangeDesc = tBrokerScanRange.getRanges().get(0);
                                         tBrokerRangeDesc.setPath("");
+                                        tBrokerRangeDesc.setStart_offset(0);
+                                        tBrokerRangeDesc.setSize(0);
                                         tBrokerRangeDesc.setFile_size(-1);
                                         if (tabletMetaToFileInfo.containsKey(tabletMetaStr)) {
                                             Pair<String, Long> fileInfo = tabletMetaToFileInfo.get(tabletMetaStr);
                                             tBrokerRangeDesc.setPath(fileInfo.first);
+                                            tBrokerRangeDesc.setStart_offset(0);
+                                            tBrokerRangeDesc.setSize(fileInfo.second);
                                             tBrokerRangeDesc.setFile_size(fileInfo.second);
                                         }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4263

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

https://github.com/StarRocks/starrocks/pull/3945
This commit supports loading parquet file in parallel by splitting row group,
and requires that start offset and size must be set.

So set broker range start offset and size in spark load push task.