### PR TITLE
Disable colocate/bucket join when table with empty partition

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OutputPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OutputPropertyDeriver.java
@@ -107,16 +107,16 @@ public class OutputPropertyDeriver extends OperatorVisitor<PhysicalPropertySet, 
                 return createPropertySetByDistribution(leftScanDistributionSpec);
             }
 
-            DistributionSpec.PropertyInfo newPhysicalPropertyInfo = new DistributionSpec.PropertyInfo();
-
-            newPhysicalPropertyInfo.tableId = leftTableId;
+            DistributionSpec.PropertyInfo newPhysicalPropertyInfo;
             HashDistributionDesc outputDesc;
             if (requiredShuffleDesc.get().getColumns().containsAll(rightShuffleColumns)) {
                 outputDesc =
                         new HashDistributionDesc(rightShuffleColumns, HashDistributionDesc.SourceType.LOCAL);
+                newPhysicalPropertyInfo = rightScanDistributionSpec.getPropertyInfo();
             } else {
                 outputDesc =
                         new HashDistributionDesc(leftShuffleColumns, HashDistributionDesc.SourceType.LOCAL);
+                newPhysicalPropertyInfo = leftScanDistributionSpec.getPropertyInfo();
             }
             return createPropertySetByDistribution(new HashDistributionSpec(outputDesc, newPhysicalPropertyInfo));
         }
@@ -145,11 +145,6 @@ public class OutputPropertyDeriver extends OperatorVisitor<PhysicalPropertySet, 
     @Override
     public PhysicalPropertySet visitPhysicalHashJoin(PhysicalHashJoinOperator node, ExpressionContext context) {
         Preconditions.checkState(childrenOutputProperties.size() == 2);
-
-        String hint = node.getJoinHint();
-        GroupExpression leftChild = childrenBestExprList.get(0);
-        GroupExpression rightChild = childrenBestExprList.get(1);
-
         PhysicalPropertySet leftChildOutputProperty = childrenOutputProperties.get(0);
         PhysicalPropertySet rightChildOutputProperty = childrenOutputProperties.get(1);
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/DistributionSpec.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/DistributionSpec.java
@@ -31,6 +31,10 @@ public class DistributionSpec {
         public boolean isSinglePartition() {
             return partitionIds.size() == 1;
         }
+
+        public boolean isEmptyPartition() {
+            return partitionIds.size() == 0;
+        }
     }
 
     public PropertyInfo getPropertyInfo() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/HashDistributionSpec.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/HashDistributionSpec.java
@@ -46,8 +46,10 @@ public class HashDistributionSpec extends DistributionSpec {
         if (thisSourceType == HashDistributionDesc.SourceType.LOCAL) {
             ColocateTableIndex colocateIndex = Catalog.getCurrentColocateIndex();
             long tableId = propertyInfo.tableId;
+            // Disable use colocate/bucket join when table with empty partition
             boolean satisfyColocate = (colocateIndex.isColocateTable(tableId) &&
-                    !colocateIndex.isGroupUnstable(colocateIndex.getGroup(tableId)))
+                    !colocateIndex.isGroupUnstable(colocateIndex.getGroup(tableId)) &&
+                    !propertyInfo.isEmptyPartition())
                     || propertyInfo.isSinglePartition();
             if (!satisfyColocate) {
                 return false;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
@@ -3,6 +3,7 @@ package com.starrocks.sql.plan;
 
 import com.starrocks.analysis.InsertStmt;
 import com.starrocks.analysis.StatementBase;
+import com.starrocks.common.FeConstants;
 import com.starrocks.sql.StatementPlanner;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.optimizer.dump.QueryDumpInfo;
@@ -375,6 +376,7 @@ public class InsertPlanTest extends PlanTestBase {
 
     @Test
     public void testInsertWithColocate() throws Exception {
+        FeConstants.runningUnitTest = true;
         starRocksAssert.withTable("CREATE TABLE `user_profile` (\n" +
                 "  `distinct_id` bigint(20) NULL ,\n" +
                 "  `user_id` varchar(128) NULL ,\n" +
@@ -548,6 +550,7 @@ public class InsertPlanTest extends PlanTestBase {
                 "  |  hash predicates:\n" +
                 "  |  colocate: true\n" +
                 "  |  equal join conjunct: 1: distinct_id = 41: distinct_id"));
+        FeConstants.runningUnitTest = false;
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 public class JoinTest extends PlanTestBase {
     @Test
     public void testColocateDistributeSatisfyShuffleColumns() throws Exception {
+        FeConstants.runningUnitTest = true;
         String sql = "select * from colocate1 left join colocate2 on colocate1.k1=colocate2.k1;";
         String plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("colocate: false"));
@@ -30,6 +31,7 @@ public class JoinTest extends PlanTestBase {
         plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("colocate: true"));
         Assert.assertTrue(plan.contains("join op: LEFT OUTER JOIN (COLOCATE)"));
+        FeConstants.runningUnitTest = false;
     }
 
     @Test
@@ -138,6 +140,7 @@ public class JoinTest extends PlanTestBase {
 
     @Test
     public void testColocateJoin() throws Exception {
+        FeConstants.runningUnitTest = true;
         String queryStr = "select * from test.colocate1 t1, test.colocate2 t2 " +
                 "where t1.k1 = t2.k1 and t1.k2 = t2.k2 and t1.k3 = t2.k3";
         String explainString = getFragmentPlan(queryStr);
@@ -161,10 +164,12 @@ public class JoinTest extends PlanTestBase {
                 "where t1.k1 = t2.k1 and t1.k2 = t2.k2 + 1";
         explainString = getFragmentPlan(queryStr);
         Assert.assertTrue(explainString.contains("colocate: false"));
+        FeConstants.runningUnitTest = false;
     }
 
     @Test
     public void testColocateJoinWithOneAggChild() throws Exception {
+        FeConstants.runningUnitTest = true;
         String queryStr =
                 "select * from test.colocate1 t1 left join (select k1, k2, count(k3) from test.colocate2 group by k1,"
                         + " k2) t2 on  "
@@ -228,10 +233,12 @@ public class JoinTest extends PlanTestBase {
                         "t1.k1 = t2.k2 and t1.k2 = t2.k1";
         explainString = getFragmentPlan(queryStr);
         Assert.assertTrue(explainString.contains("colocate: false"));
+        FeConstants.runningUnitTest = false;
     }
 
     @Test
     public void testColocateJoinWithTwoAggChild() throws Exception {
+        FeConstants.runningUnitTest = true;
         String queryStr =
                 "select * from (select k1, k2, count(k3) from test.colocate1 group by k1, k2) t1 left join (select "
                         + "k1, k2, count(k3) from test.colocate2 group by k1, k2) t2 on  "
@@ -287,6 +294,7 @@ public class JoinTest extends PlanTestBase {
                         "t1.k1 = t2.k1";
         explainString = getFragmentPlan(queryStr);
         Assert.assertTrue(explainString.contains("colocate: false"));
+        FeConstants.runningUnitTest = false;
     }
 
     @Test
@@ -1301,6 +1309,7 @@ public class JoinTest extends PlanTestBase {
 
     @Test
     public void testColocateJoin2() throws Exception {
+        FeConstants.runningUnitTest = true;
         String queryStr =
                 "select * from test.colocate1 t1, test.colocate2 t2 where t1.k1 = t2.k1 and t1.k2 = t2.k2 and t1.k3 = t2.k3";
         String explainString = getFragmentPlan(queryStr);
@@ -1344,6 +1353,7 @@ public class JoinTest extends PlanTestBase {
         queryStr = "select count(*) from test.colocate1 t1 group by t1.k1";
         explainString = getFragmentPlan(queryStr);
         Assert.assertTrue(explainString.contains("1:AGGREGATE (update finalize)"));
+        FeConstants.runningUnitTest = false;
     }
 
     @Test
@@ -2108,4 +2118,16 @@ public class JoinTest extends PlanTestBase {
                 "  |  <slot 2> : 2: v2"));
     }
 
+    @Test
+    public void testEmptyTableDisableBucketJoin() throws Exception {
+        String sql = "select colocate1.k1 from colocate1 join[bucket] test_agg on colocate1.k1 = test_agg.k1 and colocate1.k2 = test_agg.k2";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, " 4:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (PARTITIONED)");
+
+        sql = "select colocate1.k1 from colocate1 join[bucket] colocate2 on colocate1.k1 = colocate2.k2 and colocate1.k2 = colocate2.k3";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "4:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (PARTITIONED)");
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4265

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Disable colocate/bucket join when table with empty partition, because of this will result in hang when excution