### PR TITLE
Fix NodeChannel crash when open channel failed

### DIFF
--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -65,7 +65,7 @@ NodeChannel::~NodeChannel() {
         _open_closure = nullptr;
     }
 
-    for (size_t i = 0; i < _max_parallel_request_size; i++) {
+    for (size_t i = 0; i < _add_batch_closures.size(); i++) {
         if (_add_batch_closures[i] != nullptr) {
             if (_add_batch_closures[i]->unref()) {
                 delete _add_batch_closures[i];
@@ -114,6 +114,13 @@ Status NodeChannel::init(RuntimeState* state) {
             _err_st = Status::InternalError(fmt::format("load_parallel_request_size should between [1-16]"));
             return _err_st;
         }
+    }
+
+    // init add_chunk request closure
+    for (size_t i = 0; i < _max_parallel_request_size; i++) {
+        auto closure = new ReusableClosure<PTabletWriterAddBatchResult>();
+        closure->ref();
+        _add_batch_closures.emplace_back(closure);
     }
 
     // for get global_dict
@@ -189,13 +196,6 @@ Status NodeChannel::open_wait() {
         _cancelled = true;
         _err_st = status;
         return _err_st;
-    }
-
-    // add batch closure
-    for (size_t i = 0; i < _max_parallel_request_size; i++) {
-        auto closure = new ReusableClosure<PTabletWriterAddBatchResult>();
-        closure->ref();
-        _add_batch_closures.emplace_back(closure);
     }
 
     return status;


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4267

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
BE open NodeChannel failed before initialize _add_batch_closures, so that NodeChannel crash when release _add_batch_closures