### PR TITLE
Add separated hdfs scan pipeline thread pool

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -636,6 +636,7 @@ CONF_mBool(enable_bitmap_union_disk_format_with_set, "false");
 
 // The number of scan threads pipeline engine.
 CONF_Int64(pipeline_scan_thread_pool_thread_num, "0");
+CONF_Int64(pipeline_hdfs_scan_thread_pool_thread_num, "48");
 // Queue size of scan thread pool for pipeline engine.
 CONF_Int64(pipeline_scan_thread_pool_queue_size, "102400");
 // The number of execution threads for pipeline engine.

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -9,6 +9,7 @@
 #include "exec/pipeline/exchange/multi_cast_local_exchange.h"
 #include "exec/pipeline/exchange/sink_buffer.h"
 #include "exec/pipeline/fragment_context.h"
+#include "exec/pipeline/hdfs_scan_operator.h"
 #include "exec/pipeline/morsel.h"
 #include "exec/pipeline/pipeline_builder.h"
 #include "exec/pipeline/pipeline_driver_executor.h"
@@ -267,7 +268,11 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
                     // Workgroup uses scan_executor instead of pipeline_scan_io_thread_pool.
                     scan_operator->set_workgroup(wg);
                 } else {
-                    scan_operator->set_io_threads(exec_env->pipeline_scan_io_thread_pool());
+                    if (dynamic_cast<HdfsScanOperator*>(scan_operator) != nullptr) {
+                        scan_operator->set_io_threads(exec_env->pipeline_hdfs_scan_io_thread_pool());
+                    } else {
+                        scan_operator->set_io_threads(exec_env->pipeline_scan_io_thread_pool());
+                    }
                 }
                 setup_profile_hierarchy(pipeline, driver);
                 drivers.emplace_back(std::move(driver));

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -125,6 +125,8 @@ public:
     ThreadResourceMgr* thread_mgr() { return _thread_mgr; }
     PriorityThreadPool* thread_pool() { return _thread_pool; }
     PriorityThreadPool* pipeline_scan_io_thread_pool() { return _pipeline_scan_io_thread_pool; }
+    PriorityThreadPool* pipeline_hdfs_scan_io_thread_pool() { return _pipeline_hdfs_scan_io_thread_pool; }
+
     size_t increment_num_scan_operators(size_t n) { return _num_scan_operators.fetch_add(n); }
     size_t decrement_num_scan_operators(size_t n) { return _num_scan_operators.fetch_sub(n); }
     PriorityThreadPool* etl_thread_pool() { return _etl_thread_pool; }
@@ -142,6 +144,7 @@ public:
     SmallFileMgr* small_file_mgr() { return _small_file_mgr; }
 
     starrocks::workgroup::ScanExecutor* scan_executor() { return _scan_executor; }
+    starrocks::workgroup::ScanExecutor* hdfs_scan_executor() { return _hdfs_scan_executor; }
 
     const std::vector<StorePath>& store_paths() const { return _store_paths; }
     void set_store_paths(const std::vector<StorePath>& paths) { _store_paths = paths; }
@@ -207,6 +210,7 @@ private:
     ThreadResourceMgr* _thread_mgr = nullptr;
     PriorityThreadPool* _thread_pool = nullptr;
     PriorityThreadPool* _pipeline_scan_io_thread_pool = nullptr;
+    PriorityThreadPool* _pipeline_hdfs_scan_io_thread_pool = nullptr;
     std::atomic<size_t> _num_scan_operators;
     PriorityThreadPool* _etl_thread_pool = nullptr;
     PriorityThreadPool* _udf_call_pool = nullptr;
@@ -217,6 +221,7 @@ private:
     LoadPathMgr* _load_path_mgr = nullptr;
 
     starrocks::workgroup::ScanExecutor* _scan_executor = nullptr;
+    starrocks::workgroup::ScanExecutor* _hdfs_scan_executor = nullptr;
 
     BfdParser* _bfd_parser = nullptr;
     BrokerMgr* _broker_mgr = nullptr;


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

In default settings of pipeline/workgroup framework, scan io thread number is set to `hardware_concurrency`, which is quite small for filesystem of high latency such as HDFS/S3.  And it's quite risky to increase this default thread number up to value like 48, because it will affect resource isolation. So a compromised solution is to add a seperated thread pool only for Hdfs Scan Operator.

It's worth to note that, this solution is temporary.  We hope to see a unified pipeline/resource group framework to incorporate this case.
