### PR TITLE
Fix a bug in compaction_manager

### DIFF
--- a/be/src/storage/compaction_manager.cpp
+++ b/be/src/storage/compaction_manager.cpp
@@ -106,10 +106,10 @@ bool CompactionManager::register_task(CompactionTask* compaction_task) {
             LOG(WARNING) << "register compaction task failed for base limit:" << config::max_base_compaction_task;
             return false;
         }
-        if (config::cumulative_compaction_num_threads_per_disk >= 0 &&
-            _data_dir_to_base_task_num_map[data_dir] >= config::cumulative_compaction_num_threads_per_disk) {
-            LOG(WARNING) << "register compaction task failed for disk's running cumulative tasks reach limit:"
-                         << config::cumulative_compaction_num_threads_per_disk;
+        if (config::base_compaction_num_threads_per_disk >= 0 &&
+            _data_dir_to_base_task_num_map[data_dir] >= config::base_compaction_num_threads_per_disk) {
+            LOG(WARNING) << "register compaction task failed for disk's running base tasks reach limit:"
+                         << config::base_compaction_num_threads_per_disk;
             return false;
         }
     }


### PR DESCRIPTION
Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
_data_dir_to_base_task_num_map uses the wrong comparison condition (previously config::cumulative_compaction_num_threads_per_disk), it should be config::base_compaction_num_threads_per_disk
