### PR TITLE
Reduce `ScannerQueueTime` in HdfsScanNode

### DIFF
--- a/be/src/exec/vectorized/hdfs_scanner.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner.cpp
@@ -143,6 +143,7 @@ Status HdfsScanner::get_next(RuntimeState* runtime_state, ChunkPtr* chunk) {
     if (_linger_chunk != nullptr) {
         (*chunk) = std::move(_linger_chunk);
         _linger_chunk = std::move(tmp);
+        return Status::OK();
     }
     return status;
 }

--- a/be/src/exec/vectorized/hdfs_scanner.h
+++ b/be/src/exec/vectorized/hdfs_scanner.h
@@ -232,7 +232,11 @@ private:
     bool _keep_priority = false;
     void _build_file_read_param();
     MonotonicStopWatch _pending_queue_sw;
-    void update_hdfs_counter(HdfsScanProfile* profile);
+    void _update_hdfs_counter(HdfsScanProfile* profile);
+    void _create_chunk(ChunkPtr* chunk);
+    Status _get_next_once(RuntimeState* runtime_state, ChunkPtr* chunk);
+    ChunkPtr _linger_chunk;
+    bool _eos = false;
 
 protected:
     std::atomic_bool _pending_token = false;


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [X] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：

This PR is to reduce `ScannerQueueTime` (it means how long scanner stays in pending queue). The less time a scanner in pending queue, the more CPU time it can have to run.

I run a test on ssb_100g_zlib(orc, hive table) wiht following query. 

```
SELECT     sum(LO_REVENUE),     (LO_ORDERDATE DIV 10000) AS year,     P_BRAND FROM lineorder_flat 
WHERE P_CATEGORY = 'MFGR#12' AND S_REGION = 'AMERICA' 
GROUP BY     year,     P_BRAND ORDER BY     year,     P_BRAND
```

The total time is cut from 2.328s down to 1.334s.  But there are some points can not be well explained:
- Although `ScannerQueueTime` is decreased, `IoTime` increases. But IoCounte does not change, it's hard to explain why `IoTime` changes a lot. So my guess the root cause of timing imprecision. 
- From `HDFS_SCAN_NODE` view, the time does not change a lot. But from `PROJECT_NODE` view,  the time has been reduced a lot. 
- I guess it's because we assmble small chunk into large chunk, project node can process chunk more efficiently.
- So in another word, the optimization does not come from reducing `ScannerQueueTime`, but from concating into big chunk and better CPU processing.

Before optimization, the profile is like. 

```
Query:
  Summary:
     - Query ID: ccf1b7c3-a900-11ec-999f-66fdb34ec0d4
     - Start Time: 2022-03-21 18:22:24
     - End Time: 2022-03-21 18:22:26
     - Total: 2s328ms
     - Query Type: Query
        AGGREGATION_NODE (id=2):(Active: 2s587ms[2587943415ns], % non-child: 21.84%)
          PROJECT_NODE (id=1):(Active: 2s18ms[2018652210ns], % non-child: 33.52%)
HDFS_SCAN_NODE (id=0):(Active: 954.834ms[954834489ns], % non-child: 41.04%)
               - Table: lineorder_flat
               - BytesRead: 4.00 GB
               - ColumnConvertTime: 2s849ms
               - ColumnReadTime: 1m33s
               - ExprFilterTime: 13.235ms
               - IoCounter: 23.958K (23958)
               - IoTime: 48s235ms
               - NumDiskAccess: 0
               - OpenFile: 97.225us
               - PeakMemoryUsage: 0.00
               - ReaderInit: 2s133ms
               - RowsRead: 4.7908M (4790800)
               - RowsReturned: 4.7908M (4790800)
               - RowsReturnedRate: 5.017414M /sec
               - ScanFiles: 186
               - ScanRanges: 820
               - ScanTime: 1m36s
               - ScannerQueueCounter: 1.009K (1009)
               - ScannerQueueTime: 3m55s
```

And after optimization, the profile is like.

```
Query:
  Summary:
     - Query ID: ef10c3b3-a900-11ec-999f-66fdb34ec0d4
     - Start Time: 2022-03-21 18:23:21
     - End Time: 2022-03-21 18:23:23
     - Total: 1s334ms
     - Query Type: Query
        AGGREGATION_NODE (id=2):(Active: 1s314ms[1314242677ns], % non-child: 12.99%)
          PROJECT_NODE (id=1):(Active: 1s141ms[1141304914ns], % non-child: 8.70%)
HDFS_SCAN_NODE (id=0):(Active: 1s25ms[1025373654ns], % non-child: 76.99%)
               - Table: lineorder_flat
               - BytesRead: 4.00 GB
               - ColumnConvertTime: 2s739ms
               - ColumnReadTime: 3m14s
               - ExprFilterTime: 19.155ms
               - IoCounter: 23.958K (23958)
               - IoTime: 2m5s
               - NumDiskAccess: 0
               - OpenFile: 98.880us
               - PeakMemoryUsage: 0.00
               - ReaderInit: 1s919ms
               - RowsRead: 4.7908M (4790800)
               - RowsReturned: 4.410672M (4410672)
               - RowsReturnedRate: 4.301526M /sec
               - ScanFiles: 186
               - ScanRanges: 820
               - ScanTime: 3m17s
               - ScannerQueueCounter: 186
               - ScannerQueueTime: 1s726ms
```

IO time distribution
===============


Why same IOCounter leads to different IOTime? I run bpf trace to see distribution of io time per read.

```
run-bpftrace -e 'uprobe:/home/disk2/zy/DorisDB/output/be/lib/starrocks_be:_ZN9starrocks10vectorized17ORCHdfsFileStream4readEPvmm { @ts[tid] = nsecs; } uretprobe:/home/disk2/zy/DorisDB/output/be/lib/starrocks_be:_ZN9starrocks10vectorized17ORCHdfsFileStream4readEPvmm { @=hist((nsecs-@ts[tid])/1000); delete(@ts[tid]) } '
```

I see distribution does change, and after patching this PR IO latency increases. However I'm not sure the increase is significant. Since there is no any evidence to improve HDFSScanNode active time, we'd better close this PR.

Before
```
[1]                   10 |                                                    |
[2, 4)             24700 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@                   |
[4, 8)              6606 |@@@@@@@@@                                           |
[8, 16)              169 |                                                    |
[16, 32)              81 |                                                    |
[32, 64)              16 |                                                    |
[64, 128)              7 |                                                    |
[128, 256)             5 |                                                    |
[256, 512)             3 |                                                    |
[512, 1K)          38084 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
[1K, 2K)           14449 |@@@@@@@@@@@@@@@@@@@                                 |
[2K, 4K)            8312 |@@@@@@@@@@@                                         |
[4K, 8K)            2757 |@@@                                                 |
[8K, 16K)           1447 |@                                                   |
[16K, 32K)           812 |@                                                   |
[32K, 64K)           561 |                                                    |
[64K, 128K)           52 |                                                    |
[128K, 256K)           0 |                                                    |
[256K, 512K)           0 |                                                    |
[512K, 1M)             0 |                                                    |
[1M, 2M)               0 |                                                    |
[2M, 4M)               0 |                                                    |
[4M, 8M)               0 |                                                    |
[8M, 16M)              0 |                                                    |
[16M, 32M)             0 |                                                    |
[32M, 64M)             0 |                                                    |
[64M, 128M)            0 |                                                    |
[128M, 256M)           0 |                                                    |
[256M, 512M)           0 |                                                    |
[512M, 1G)             0 |                                                    |
[1G, 2G)               0 |                                                    |
[2G, 4G)              12 |                                                    |
```

After:

```
[1]                    2 |                                                    |
[2, 4)             18746 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@       |
[4, 8)             11162 |@@@@@@@@@@@@@@@@@@@@@@@@@@@                         |
[8, 16)              285 |                                                    |
[16, 32)             144 |                                                    |
[32, 64)              51 |                                                    |
[64, 128)             33 |                                                    |
[128, 256)            11 |                                                    |
[256, 512)            13 |                                                    |
[512, 1K)          21394 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
[1K, 2K)           14302 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@                  |
[2K, 4K)           10393 |@@@@@@@@@@@@@@@@@@@@@@@@@                           |
[4K, 8K)            7189 |@@@@@@@@@@@@@@@@@                                   |
[8K, 16K)           4990 |@@@@@@@@@@@@                                        |
[16K, 32K)          3105 |@@@@@@@                                             |
[32K, 64K)          2136 |@@@@@                                               |
[64K, 128K)         1114 |@@                                                  |
[128K, 256K)         238 |                                                    |
[256K, 512K)          90 |                                                    |
[512K, 1M)             0 |                                                    |
[1M, 2M)               0 |                                                    |
[2M, 4M)               0 |                                                    |
[4M, 8M)               0 |                                                    |
[8M, 16M)              0 |                                                    |
[16M, 32M)             0 |                                                    |
[32M, 64M)             0 |                                                    |
[64M, 128M)            0 |                                                    |
[128M, 256M)           0 |                                                    |
[256M, 512M)           0 |                                                    |
[512M, 1G)             0 |                                                    |
[1G, 2G)               0 |                                                    |
[2G, 4G)             318 |                                                    |

```
