### PR TITLE
Remove unused search bushy tree for greedy join reorder

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinReorderGreedy.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinReorderGreedy.java
@@ -30,23 +30,12 @@ public class JoinReorderGreedy extends JoinOrder {
     protected void enumerate() {
         for (int curJoinLevel = 2; curJoinLevel <= atomSize; curJoinLevel++) {
             searchJoinOrders(curJoinLevel - 1, 1);
-            searchBushyJoinOrders(curJoinLevel);
         }
     }
 
     @Override
     public List<OptExpression> getResult() {
         return topKExpr.stream().map(p -> p.expr).collect(Collectors.toList());
-    }
-
-    private void searchBushyJoinOrders(int curJoinLevel) {
-        // Search bushy joins tree fro level x and y, where
-        // x + y = curJoinLevel and x > 1 and y > 1 and x >= y.
-        // Note that join trees of level 3 and below are never bushy,
-        // so this loop only executes at curJoinLevel >= 4
-        for (int rightLevel = 2; rightLevel <= curJoinLevel / 2; rightLevel++) {
-            searchJoinOrders(curJoinLevel - rightLevel, rightLevel);
-        }
     }
 
     private void searchJoinOrders(int leftLevel, int rightLevel) {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4340 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
searchBushyJoinOrders in JoinReorder greedy is not used, because greedy always choose the join which cost is lowest, eg. level 1 choose A, level 2 choose AB, level 3 chosse ABC... so the level k >=2 always contiains the A, this will result in can not build valid bushy tree which start from level 4, beacuse all join contains A in levele 2 
![image](https://user-images.githubusercontent.com/9495145/159257154-384cf1af-bcd3-46c1-ab63-cf3217cb3d0b.png)
