### PR TITLE
Refactor tablet get data size

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
@@ -381,13 +381,21 @@ public class LocalTablet extends Tablet {
         return id == tablet.id;
     }
 
-    // Get total data size of all replicas which state is NORMAL or SCHEMA_CHANGE.
+    // Get total data size of all replicas if singleReplica is true, else get max replica data size.
+    // Replica state must be NORMAL or SCHEMA_CHANGE.
     @Override
-    public long getDataSize() {
+    public long getDataSize(boolean singleReplica) {
         long dataSize = 0;
         for (Replica replica : getReplicas()) {
             if (replica.getState() == ReplicaState.NORMAL || replica.getState() == ReplicaState.SCHEMA_CHANGE) {
-                dataSize += replica.getDataSize();
+                if (singleReplica) {
+                    long replicaDataSize = replica.getDataSize();
+                    if (replicaDataSize > dataSize) {
+                        dataSize = replicaDataSize;
+                    }
+                } else {
+                    dataSize += replica.getDataSize();
+                }
             }
         }
         return dataSize;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndex.java
@@ -213,7 +213,7 @@ public class MaterializedIndex extends MetaObject implements Writable, GsonPostP
     public long getDataSize() {
         long dataSize = 0;
         for (Tablet tablet : getTablets()) {
-            dataSize += tablet.getDataSize();
+            dataSize += tablet.getDataSize(false);
         }
         return dataSize;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/StarOSTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/StarOSTablet.java
@@ -38,8 +38,9 @@ public class StarOSTablet extends Tablet {
         return shardId;
     }
 
+    // singleReplica is not used
     @Override
-    public long getDataSize() {
+    public long getDataSize(boolean singleReplica) {
         return dataSize;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Tablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Tablet.java
@@ -44,7 +44,7 @@ public abstract class Tablet extends MetaObject implements Writable {
         return id;
     }
 
-    public abstract long getDataSize();
+    public abstract long getDataSize(boolean singleReplica);
 
     public abstract long getRowCount(long version);
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/TabletsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/TabletsProcDir.java
@@ -109,7 +109,7 @@ public class TabletsProcDir implements ProcDirInterface {
                     tabletInfo.add(-1); // lst failed version
                     tabletInfo.add(0); // lst failed version hash
                     tabletInfo.add(-1); // lst failed time
-                    tabletInfo.add(starOSTablet.getDataSize());
+                    tabletInfo.add(starOSTablet.getDataSize(true));
                     tabletInfo.add(starOSTablet.getRowCount(0L));
                     tabletInfo.add(FeConstants.null_string); // state
                     tabletInfo.add(-1); // lst consistency check time

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/ShowMetaInfoAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/ShowMetaInfoAction.java
@@ -24,13 +24,10 @@ package com.starrocks.http.rest;
 import com.google.gson.Gson;
 import com.starrocks.catalog.Catalog;
 import com.starrocks.catalog.Database;
-import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndex.IndexExtState;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
-import com.starrocks.catalog.Replica;
-import com.starrocks.catalog.Replica.ReplicaState;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Table.TableType;
 import com.starrocks.catalog.Tablet;
@@ -180,16 +177,7 @@ public class ShowMetaInfoAction extends RestBaseAction {
                     for (MaterializedIndex mIndex : partition.getMaterializedIndices(IndexExtState.VISIBLE)) {
                         long indexSize = 0;
                         for (Tablet tablet : mIndex.getTablets()) {
-                            long maxReplicaSize = 0;
-                            for (Replica replica : ((LocalTablet) tablet).getReplicas()) {
-                                if (replica.getState() == ReplicaState.NORMAL
-                                        || replica.getState() == ReplicaState.SCHEMA_CHANGE) {
-                                    if (replica.getDataSize() > maxReplicaSize) {
-                                        maxReplicaSize = replica.getDataSize();
-                                    }
-                                }
-                            } // end for replicas
-                            indexSize += maxReplicaSize;
+                            indexSize += tablet.getDataSize(true);
                         } // end for tablets
                         partitionSize += indexSize;
                     } // end for tables

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/LocalTabletTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/LocalTabletTest.java
@@ -89,7 +89,8 @@ public class LocalTabletTest {
         Assert.assertEquals(replica2, tablet.getReplicaByBackendId(replica2.getBackendId()));
         Assert.assertEquals(replica3, tablet.getReplicaByBackendId(replica3.getBackendId()));
 
-        Assert.assertEquals(600003L, tablet.getDataSize());
+        Assert.assertEquals(600003L, tablet.getDataSize(false));
+        Assert.assertEquals(200002L, tablet.getDataSize(true));
         Assert.assertEquals(3002L, tablet.getRowCount(100));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/StarOSTabletTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/StarOSTabletTest.java
@@ -58,7 +58,7 @@ public class StarOSTabletTest {
         Assert.assertNotNull(newTablet);
         Assert.assertEquals(1L, newTablet.getId());
         Assert.assertEquals(2L, newTablet.getShardId());
-        Assert.assertEquals(3L, newTablet.getDataSize());
+        Assert.assertEquals(3L, newTablet.getDataSize(true));
         Assert.assertEquals(4L, newTablet.getRowCount(0L));
 
         file.delete();


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Add singleReplica parameter.
For LocalTablet, get total data size of all replicas if singleReplica is true, else get max replica data size.
For StarOSTablet, singleReplica is not used.
