### PR TITLE
BugFix: Rowset id cache leak

### DIFF
--- a/be/src/storage/rowset/beta_rowset_writer.cpp
+++ b/be/src/storage/rowset/beta_rowset_writer.cpp
@@ -224,6 +224,8 @@ HorizontalBetaRowsetWriter::~HorizontalBetaRowsetWriter() {
                 LOG_IF(WARNING, !st.ok()) << "Fail to delete file=" << path << ", " << st.to_string();
             }
         }
+        // if _already_built is false, we need to release rowset_id to avoid rowset_id leak
+        StorageEngine::instance()->release_rowset_id(_context.rowset_id);
     }
 }
 
@@ -548,6 +550,8 @@ VerticalBetaRowsetWriter::~VerticalBetaRowsetWriter() {
             auto st = _env->delete_file(path);
             LOG_IF(WARNING, !st.ok()) << "Fail to delete file=" << path << ", " << st.to_string();
         }
+        // if _already_built is false, we need to release rowset_id to avoid rowset_id leak
+        StorageEngine::instance()->release_rowset_id(_context.rowset_id);
     }
 }
 

--- a/be/src/storage/vectorized/delta_writer.cpp
+++ b/be/src/storage/vectorized/delta_writer.cpp
@@ -195,17 +195,15 @@ Status DeltaWriter::_prepare() {
                 fmt::format("Fail to prepare. tablet_id: {}, state: {}", _opt.tablet_id, _state_name(state)));
     case kWriting:
         return Status::OK();
-    case kPrepared:
-        {
-            std::lock_guard push_lock(_tablet->get_push_lock());
-            st = _storage_engine->txn_manager()->prepare_txn(_opt.partition_id, _tablet, _opt.txn_id, _opt.load_id);
-            if (!st.ok()) {
-                _set_state(kAborted);
-                return st;
-            }
-            _set_state(kWriting);
+    case kPrepared: {
+        std::lock_guard push_lock(_tablet->get_push_lock());
+        st = _storage_engine->txn_manager()->prepare_txn(_opt.partition_id, _tablet, _opt.txn_id, _opt.load_id);
+        if (!st.ok()) {
+            _set_state(kAborted);
+            return st;
         }
-        break;
+        _set_state(kWriting);
+    } break;
     }
     return Status::OK();
 }

--- a/be/src/storage/vectorized/delta_writer.cpp
+++ b/be/src/storage/vectorized/delta_writer.cpp
@@ -228,7 +228,7 @@ Status DeltaWriter::write(const Chunk& chunk, const uint32_t* indexes, uint32_t 
     if (!st.ok()) {
         _set_state(kAborted);
     }
-    return Status::OK();
+    return st;
 }
 
 Status DeltaWriter::close() {

--- a/be/src/storage/vectorized/delta_writer.h
+++ b/be/src/storage/vectorized/delta_writer.h
@@ -89,8 +89,8 @@ public:
 private:
     enum State {
         kUninitialized,
+        kInitialized,
         kPrepared,
-        kWriting,
         kClosed,
         kAborted,
         kCommitted, // committed state can transfer to kAborted state

--- a/be/src/storage/vectorized/delta_writer.h
+++ b/be/src/storage/vectorized/delta_writer.h
@@ -89,6 +89,7 @@ public:
 private:
     enum State {
         kUninitialized,
+        kPrepared,
         kWriting,
         kClosed,
         kAborted,
@@ -98,6 +99,7 @@ private:
     DeltaWriter(const DeltaWriterOptions& opt, MemTracker* parent, StorageEngine* storage_engine);
 
     Status _init();
+    Status _prepare();
     Status _flush_memtable_async();
     Status _flush_memtable();
     const char* _state_name(State state) const;


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4277 #4292

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Rowset id cache will leak in some scenarios:
+ allocate rowset id success, but create rowset writer failed
+ create rowset writer success, but no data written
....

Anyway, if allocate rowset id success, but does not generate `rowset_ptr`, we don't release the rowset_id, resulting in a memory leak.

In addition, when we do load data, we create a `delta_writer` for each tablet in advance, but only a few of the `delta_writer` may have data written to them.  This speeds up memory leak and output a lot of useless `rollback` logs in `be.INFO`

This pr will call `release_rowset_id` in deconstruct function of `delta_writer` if rowset is not built and reduce the `rollback` log.
