### PR TITLE
Fix aggregate cannot generate one stage plan with array type params

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
@@ -129,11 +129,12 @@ public class CostModel {
                 return false;
             }
 
-            // 2. Must do two stage aggregate is aggregate function has array type
+            // 2. Must do multi stage aggregate when aggregate distinct function has array type
             if (context.getOp() instanceof PhysicalHashAggregateOperator) {
                 PhysicalHashAggregateOperator operator = (PhysicalHashAggregateOperator) context.getOp();
                 if (operator.getAggregations().values().stream().anyMatch(callOperator
-                        -> callOperator.getChildren().stream().anyMatch(c -> c.getType().isArrayType()))) {
+                        -> callOperator.getChildren().stream().anyMatch(c -> c.getType().isArrayType()) &&
+                        callOperator.isDistinct())) {
                     return false;
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
@@ -77,9 +77,10 @@ public class SplitAggregateRule extends TransformationRule {
         if (input.inputAt(0).getOp() instanceof LogicalRepeatOperator) {
             return true;
         }
-        // 2 Must do two stage aggregate is aggregate function has array type
+        // 2 Must do multi stage aggregate when aggregate distinct function has array type
         if (aggregationOperator.getAggregations().values().stream().anyMatch(callOperator
-                -> callOperator.getChildren().stream().anyMatch(c -> c.getType().isArrayType()))) {
+                -> callOperator.getChildren().stream().anyMatch(c -> c.getType().isArrayType()) &&
+                callOperator.isDistinct())) {
             return true;
         }
         // 3. Must generate three, four phase aggregate for distinct aggregate with multi columns

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -654,4 +654,20 @@ public class AggregateTest extends PlanTestBase {
                 "  |  group by: [4: expr, BOOLEAN, false]"));
     }
 
+    @Test
+    public void testArrayAggFunctionWithColocateTable() throws Exception {
+        FeConstants.runningUnitTest = true;
+        String sql = "select L_ORDERKEY,retention([true,true]) from lineitem_partition_colocate group by L_ORDERKEY;";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "partitions=7/7");
+        assertContains(plan, "1:AGGREGATE (update finalize)\n" +
+                "  |  output: retention([TRUE,TRUE])\n" +
+                "  |  group by: 1: L_ORDERKEY");
+
+        sql = "select v1,retention([true,true]) from t0 group by v1";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "1:AGGREGATE (update finalize)\n" +
+                "  |  output: retention([TRUE,TRUE])");
+        FeConstants.runningUnitTest = false;
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -867,7 +867,7 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
 
         sql = "select * from test_mv limit 10";
         planFragment = getFragmentPlan(sql);
-        Assert.assertTrue(planFragment.contains("tabletList=11356,11358,11360,"));
+        Assert.assertTrue(planFragment.contains("tabletList=12038,12040,12042,"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestBase.java
@@ -384,6 +384,43 @@ public class PlanTestBase {
                 "\"storage_format\" = \"DEFAULT\"\n" +
                 ");");
 
+        starRocksAssert.withTable("CREATE TABLE `lineitem_partition_colocate` (\n" +
+                "  `L_ORDERKEY` int(11) NOT NULL COMMENT \"\",\n" +
+                "  `L_PARTKEY` int(11) NOT NULL COMMENT \"\",\n" +
+                "  `L_SUPPKEY` int(11) NOT NULL COMMENT \"\",\n" +
+                "  `L_LINENUMBER` int(11) NOT NULL COMMENT \"\",\n" +
+                "  `L_QUANTITY` double NOT NULL COMMENT \"\",\n" +
+                "  `L_EXTENDEDPRICE` double NOT NULL COMMENT \"\",\n" +
+                "  `L_DISCOUNT` double NOT NULL COMMENT \"\",\n" +
+                "  `L_TAX` double NOT NULL COMMENT \"\",\n" +
+                "  `L_RETURNFLAG` char(1) NOT NULL COMMENT \"\",\n" +
+                "  `L_LINESTATUS` char(1) NOT NULL COMMENT \"\",\n" +
+                "  `L_SHIPDATE` date NOT NULL COMMENT \"\",\n" +
+                "  `L_COMMITDATE` date NOT NULL COMMENT \"\",\n" +
+                "  `L_RECEIPTDATE` date NOT NULL COMMENT \"\",\n" +
+                "  `L_SHIPINSTRUCT` char(25) NOT NULL COMMENT \"\",\n" +
+                "  `L_SHIPMODE` char(10) NOT NULL COMMENT \"\",\n" +
+                "  `L_COMMENT` varchar(44) NOT NULL COMMENT \"\",\n" +
+                "  `PAD` char(1) NOT NULL COMMENT \"\"\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`L_ORDERKEY`, `L_PARTKEY`, `L_SUPPKEY`)\n" +
+                "COMMENT \"OLAP\"\n" +
+                "PARTITION BY RANGE(`L_SHIPDATE`)\n" +
+                "(PARTITION p1992 VALUES [('1992-01-01'), ('1993-01-01')),\n" +
+                "PARTITION p1993 VALUES [('1993-01-01'), ('1994-01-01')),\n" +
+                "PARTITION p1994 VALUES [('1994-01-01'), ('1995-01-01')),\n" +
+                "PARTITION p1995 VALUES [('1995-01-01'), ('1996-01-01')),\n" +
+                "PARTITION p1996 VALUES [('1996-01-01'), ('1997-01-01')),\n" +
+                "PARTITION p1997 VALUES [('1997-01-01'), ('1998-01-01')),\n" +
+                "PARTITION p1998 VALUES [('1998-01-01'), ('1999-01-01')))\n" +
+                "DISTRIBUTED BY HASH(`L_ORDERKEY`) BUCKETS 48\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"in_memory\" = \"false\",\n" +
+                "\"colocate_with\" = \"colocate_group\",\n" +
+                "\"storage_format\" = \"DEFAULT\"\n" +
+                ");");
+
         starRocksAssert.withTable("CREATE TABLE `emp` (\n" +
                 "  `id` bigint NULL COMMENT \"\",\n" +
                 "  `emp_name` varchar(20) NULL COMMENT \"\",\n" +


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4342 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Aggregate with array type can not generate one stage plan which could use local agg(set colocate at planFragmentBuilder).
After Fix, Explain :
```

mysql> explain select L_ORDERKEY,retention([true,true]) from lineitem_par_co where L_ORDERKEY = 59633893 group by L_ORDERKEY;
+-------------------------------------------------------------------------+
| Explain String                                                          |
+-------------------------------------------------------------------------+
| PLAN FRAGMENT 0                                                         |
|  OUTPUT EXPRS:1: L_ORDERKEY | 17: retention                             |
|   PARTITION: UNPARTITIONED                                              |
|                                                                         |
|   RESULT SINK                                                           |
|                                                                         |
|   2:EXCHANGE                                                            |
|                                                                         |
| PLAN FRAGMENT 1                                                         |
|  OUTPUT EXPRS:                                                          |
|   PARTITION: RANDOM                                                     |
|                                                                         |
|   STREAM DATA SINK                                                      |
|     EXCHANGE ID: 02                                                     |
|     UNPARTITIONED                                                       |
|                                                                         |
|   1:AGGREGATE (update finalize)                                         |
|   |  output: retention([TRUE,TRUE])                                     |
|   |  group by: 1: L_ORDERKEY                                            |
|   |                                                                     |
|   0:OlapScanNode                                                        |
|      TABLE: lineitem_par_co                                             |
|      PREAGGREGATION: ON                                                 |
|      PREDICATES: 1: L_ORDERKEY = 59633893                               |
|      partitions=7/7                                                     |
|      rollup: lineitem_par_co                                            |
|      tabletRatio=7/336                                                  |
|      tabletList=1902048,1902240,1902144,1902432,1902336,1902624,1902528 |
|      cardinality=29993026                                               |
|      avgRowSize=1.0                                                     |
|      numNodes=0                                                         |
+-------------------------------------------------------------------------+
31 rows in set (0.01 sec)
```  