### PR TITLE
BugFix: stack overflow in copy_file

### DIFF
--- a/be/src/storage/rowset/beta_rowset.cpp
+++ b/be/src/storage/rowset/beta_rowset.cpp
@@ -41,6 +41,7 @@
 #include "storage/vectorized/merge_iterator.h"
 #include "storage/vectorized/projection_iterator.h"
 #include "storage/vectorized/union_iterator.h"
+#include "util/file_utils.h"
 
 namespace starrocks {
 
@@ -157,7 +158,7 @@ Status BetaRowset::copy_files_to(const std::string& dir) {
             return Status::AlreadyExist(fmt::format("Path already exist: {}", dst_path));
         }
         std::string src_path = segment_file_path(_rowset_path, rowset_id(), i);
-        if (!copy_file(src_path, dst_path).ok()) {
+        if (!FileUtils::copy_file(src_path, dst_path).ok()) {
             LOG(WARNING) << "Error to copy file. src:" << src_path << ", dst:" << dst_path << ", errno=" << Errno::no();
             return Status::IOError(fmt::format("Error to copy file. src: {}, dst: {}, error:{} ", src_path, dst_path,
                                                std::strerror(Errno::no())));
@@ -171,7 +172,7 @@ Status BetaRowset::copy_files_to(const std::string& dir) {
                 LOG(WARNING) << "Path already exist: " << dst_path;
                 return Status::AlreadyExist(fmt::format("Path already exist: {}", dst_path));
             }
-            if (!copy_file(src_path, dst_path).ok()) {
+            if (!FileUtils::copy_file(src_path, dst_path).ok()) {
                 LOG(WARNING) << "Error to copy file. src:" << src_path << ", dst:" << dst_path
                              << ", errno=" << Errno::no();
                 return Status::IOError(fmt::format("Error to copy file. src: {}, dst: {}, error:{} ", src_path,

--- a/be/src/storage/utils.cpp
+++ b/be/src/storage/utils.cpp
@@ -119,7 +119,7 @@ Status move_to_trash(const std::filesystem::path& file_path) {
 Status copy_file(const string& src, const string& dest) {
     int src_fd = -1;
     int dest_fd = -1;
-    char buf[1024 * 1024];
+    char* buf = new char[1024 * 1024];
     Status res = Status::OK();
 
     src_fd = ::open(src.c_str(), O_RDONLY);
@@ -162,7 +162,7 @@ COPY_EXIT:
     }
 
     VLOG(3) << "copy file success. [src=" << src << " dest=" << dest << "]";
-
+    delete[] buf;
     return res;
 }
 

--- a/be/src/storage/utils.h
+++ b/be/src/storage/utils.h
@@ -73,8 +73,6 @@ Status gen_timestamp_string(std::string* out_string);
 // move file to storage_root/trash, file can be a directory
 Status move_to_trash(const std::filesystem::path& tablet_id_path);
 
-Status copy_file(const std::string& src, const std::string& dest);
-
 Status copy_dir(const std::string& src_dir, const std::string& dst_dir);
 
 bool check_datapath_rw(const std::string& path);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4279

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

The stack memory limit set by the operating system can be changed using `ulimit -s` and allocate memoy greater or equal to the stack memory limit will cause be crash.

If  stack memory limit is no more than 1MB, be will crash because try to alloc 1MB stack memory in function `copy_files`.

We should not alloc large memory in stack, alloc memory from heap to solve this problem.

This code is duplicated with function `copy_file` in  utils/file_utils.cpp, merge the two copy_file function in utils/file_utils.cpp and storage/utils.cpp