### PR TITLE
Improve GroupingSet local plan

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OutputPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OutputPropertyDeriver.java
@@ -271,7 +271,7 @@ public class OutputPropertyDeriver extends OperatorVisitor<PhysicalPropertySet, 
     @Override
     public PhysicalPropertySet visitPhysicalRepeat(PhysicalRepeatOperator node, ExpressionContext context) {
         Preconditions.checkState(this.childrenOutputProperties.size() == 1);
-        return childrenOutputProperties.get(0);
+        return requirements;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/RequiredPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/RequiredPropertyDeriver.java
@@ -158,8 +158,9 @@ public class RequiredPropertyDeriver extends OperatorVisitor<Void, ExpressionCon
         List<ColumnRefOperator> subRefs = Lists.newArrayList(node.getRepeatColumnRef().get(0));
         node.getRepeatColumnRef().forEach(subRefs::retainAll);
 
+        requiredProperties.add(Lists.newArrayList(PhysicalPropertySet.EMPTY));
         if (subRefs.isEmpty()) {
-            return visitOperator(node, context);
+            return null;
         }
 
         DistributionProperty property = new DistributionProperty(DistributionSpec.createHashDistributionSpec(

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/EnforceAndCostTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/EnforceAndCostTask.java
@@ -161,7 +161,7 @@ public class EnforceAndCostTask extends OptimizerTask implements Cloneable {
                                 childrenBestExprList, requiredProperties, childrenOutputProperties, curTotalCost);
 
                 // compute the output property
-                OutputPropertyDeriver outputPropertyDeriver = new OutputPropertyDeriver(context);
+                OutputPropertyDeriver outputPropertyDeriver = new OutputPropertyDeriver();
                 Pair<PhysicalPropertySet, Double> outputPropertyWithCost = outputPropertyDeriver
                         .getOutputPropertyWithCost(context.getRequiredProperty(), groupExpression, childrenBestExprList,
                                 childrenOutputProperties, curTotalCost);

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlServerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlServerTest.java
@@ -23,58 +23,57 @@ package com.starrocks.mysql;
 
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.ConnectScheduler;
-import mockit.Delegate;
-import mockit.Expectations;
 import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
+import java.nio.ByteBuffer;
 import java.nio.channels.SocketChannel;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class MysqlServerTest {
-    private static final Logger LOG = LoggerFactory.getLogger(MysqlServerTest.class);
-
     private final AtomicInteger submitNum = new AtomicInteger(0);
     private final AtomicInteger submitFailNum = new AtomicInteger(0);
     @Mocked
-    private ConnectScheduler scheduler;
+    private final ConnectScheduler scheduler = new ConnectScheduler(10) {
+        @Override
+        public boolean submit(ConnectContext context) {
+            submitNum.getAndIncrement();
+            try {
+                ByteBuffer writer = ByteBuffer.allocate(10);
+                writer.put((byte) 1);
+                context.getMysqlChannel().sendAndFlush(writer);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+            return true;
+        }
+    };
+
     @Mocked
-    private ConnectScheduler badScheduler;
+    private final ConnectScheduler badScheduler = new ConnectScheduler(10) {
+        @Override
+        public boolean submit(ConnectContext context) {
+            submitFailNum.getAndIncrement();
+            try {
+                ByteBuffer writer = ByteBuffer.allocate(10);
+                writer.put((byte) 1);
+                context.getMysqlChannel().sendAndFlush(writer);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+            return false;
+        }
+    };
 
     @Before
     public void setUp() {
         submitNum.set(0);
         submitFailNum.set(0);
-        new Expectations() {
-            {
-                scheduler.submit((ConnectContext) any);
-                minTimes = 0;
-                result = new Delegate() {
-                    public Boolean answer() throws Throwable {
-                        LOG.info("answer.");
-                        submitNum.getAndIncrement();
-                        return Boolean.TRUE;
-                    }
-                };
-
-                badScheduler.submit((ConnectContext) any);
-                minTimes = 0;
-                result = new Delegate() {
-                    public Boolean answer() throws Throwable {
-                        LOG.info("answer.");
-                        submitFailNum.getAndIncrement();
-                        return Boolean.FALSE;
-                    }
-                };
-            }
-        };
     }
 
     @Test
@@ -112,14 +111,20 @@ public class MysqlServerTest {
         SocketChannel channel = SocketChannel.open();
         channel.connect(new InetSocketAddress("127.0.0.1", port));
         // sleep to wait mock process
-        Thread.sleep(1000);
+        ByteBuffer reader = ByteBuffer.allocate(10);
+        while (channel.read(reader) < 0) {
+            Thread.sleep(100);
+        }
         channel.close();
 
         // submit twice
         channel = SocketChannel.open();
         channel.connect(new InetSocketAddress("127.0.0.1", port));
         // sleep to wait mock process
-        Thread.sleep(1000);
+        reader = ByteBuffer.allocate(10);
+        while (channel.read(reader) < 0) {
+            Thread.sleep(100);
+        }
         channel.close();
 
         // stop and join

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetTest.java
@@ -121,7 +121,6 @@ public class GroupingSetTest extends PlanTestBase {
                 ") t\n" +
                 "WHERE IF(k2 IS NULL, 'ALL', k2) = 'ALL'";
         String plan = getFragmentPlan(sql1);
-        System.out.println(plan);
         Assert.assertTrue(plan.contains("  5:Project\n" +
                 "  |  <slot 5> : 5: sum\n" +
                 "  |  <slot 7> : if(2: k2 IS NULL, 'ALL', 2: k2)\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetTest.java
@@ -121,6 +121,7 @@ public class GroupingSetTest extends PlanTestBase {
                 ") t\n" +
                 "WHERE IF(k2 IS NULL, 'ALL', k2) = 'ALL'";
         String plan = getFragmentPlan(sql1);
+        System.out.println(plan);
         Assert.assertTrue(plan.contains("  5:Project\n" +
                 "  |  <slot 5> : 5: sum\n" +
                 "  |  <slot 7> : if(2: k2 IS NULL, 'ALL', 2: k2)\n" +


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Support colocate plan when the common column sub-list of grouping set satisfy property requirement

like sql: 
`select v1, v2 from t0 group by grouping sets ((v1, v2), (v1, v3), (v1));`

and t0 distribute by v1 column, can be get a colocate plan like:

```
  STREAM DATA SINK
    EXCHANGE ID: 03
    HASH_PARTITIONED: 1: v1, 2: v2, 3: v3, 4: GROUPING_ID

  2:AGGREGATE (update serialize)
  |  STREAMING
  |  group by: 1: v1, 2: v2, 3: v3, 4: GROUPING_ID
  |  
  1:REPEAT_NODE
  |  repeat: repeat 2 lines [[1, 2], [1, 3], [1]]
  |  
  0:OlapScanNode
     TABLE: t0
     PREAGGREGATION: ON
```