### PR TITLE
fixup: decimal * decimal(0,0) error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
@@ -214,13 +214,13 @@ public class ScalarType extends Type implements Cloneable {
     }
 
     public static ScalarType createDecimalV3Type(PrimitiveType type, int precision, int scale) {
-        Preconditions.checkArgument(0 < precision && precision <= PrimitiveType.getMaxPrecisionOfDecimal(type),
+        Preconditions.checkArgument(0 <= precision && precision <= PrimitiveType.getMaxPrecisionOfDecimal(type),
                 "DECIMAL's precision should range from 1 to 38");
         Preconditions.checkArgument(0 <= scale && scale <= precision,
                 "DECIMAL(P[,S]) type P must be greater than or equal to the value of S");
 
         ScalarType scalarType = new ScalarType(type);
-        scalarType.precision = precision;
+        scalarType.precision = Math.max(precision, 1);
         scalarType.scale = scale;
         return scalarType;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithDecimalTypesNewPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithDecimalTypesNewPlannerTest.java
@@ -283,5 +283,120 @@ public class SelectStmtWithDecimalTypesNewPlannerTest {
         String snippet = "variance[(cast([2: col_decimal32p9s2, DECIMAL32(9,2), false] as DECIMAL128(38,9))); args: DECIMAL128; result: DECIMAL128(38,9)";
         Assert.assertTrue(plan.contains(snippet));
     }
+
+
+    @Test
+    public void testDecimalAddNULL()throws Exception {
+        String sql = "select col_decimal32p9s2 + NULL from db1.decimal_table";
+        String plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
+        String snippet = "6 <-> cast([2: col_decimal32p9s2, DECIMAL32(9,2), false] as DECIMAL64(18,2)) + NULL";
+        Assert.assertTrue(plan.contains(snippet));
+    }
+
+    @Test
+    public void testDecimalSubNULL()throws Exception {
+        String sql = "select col_decimal32p9s2 - NULL from db1.decimal_table";
+        String plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
+        String snippet = "6 <-> cast([2: col_decimal32p9s2, DECIMAL32(9,2), false] as DECIMAL64(18,2)) - NULL";
+        Assert.assertTrue(plan.contains(snippet));
+    }
+
+    @Test
+    public void testDecimalMulNULL()throws Exception {
+        String sql = "select col_decimal32p9s2 * NULL from db1.decimal_table";
+        String plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
+        System.out.println(plan);
+        String snippet = "6 <-> [2: col_decimal32p9s2, DECIMAL32(9,2), false] * NULL";
+        Assert.assertTrue(plan.contains(snippet));
+    }
+
+    @Test
+    public void testDecimalDivNULL()throws Exception {
+        String sql = "select col_decimal32p9s2 / NULL from db1.decimal_table";
+        String plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
+        String snippet = "6 <-> cast([2: col_decimal32p9s2, DECIMAL32(9,2), false] as DECIMAL128(38,2)) / NULL";
+        Assert.assertTrue(plan.contains(snippet));
+    }
+
+    @Test
+    public void testDecimalModNULL()throws Exception {
+        String sql = "select col_decimal32p9s2 % NULL from db1.decimal_table";
+        String plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
+        String snippet = "6 <-> cast([2: col_decimal32p9s2, DECIMAL32(9,2), false] as DECIMAL64(18,2)) % NULL";
+        Assert.assertTrue(plan.contains(snippet));
+    }
+
+    @Test
+    public void testNULLDivDecimal()throws Exception {
+        String sql = "select NULL / col_decimal32p9s2 from db1.decimal_table";
+        String plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
+        String snippet = "6 <-> NULL / cast([2: col_decimal32p9s2, DECIMAL32(9,2), false] as DECIMAL128(38,2))";
+        Assert.assertTrue(plan.contains(snippet));
+    }
+
+    @Test
+    public void testNULLModDecimal()throws Exception {
+        String sql = "select NULL % col_decimal32p9s2 from db1.decimal_table";
+        String plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
+        String snippet = "6 <-> NULL % cast([2: col_decimal32p9s2, DECIMAL32(9,2), false] as DECIMAL64(18,2))";
+        Assert.assertTrue(plan.contains(snippet));
+    }
+
+    @Test
+    public void testDecimalAddZero()throws Exception {
+        String sql = "select col_decimal32p9s2 + 0.0 from db1.decimal_table";
+        String plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
+        String snippet = "6 <-> cast([2: col_decimal32p9s2, DECIMAL32(9,2), false] as DECIMAL64(18,2)) + 0";
+        Assert.assertTrue(plan.contains(snippet));
+    }
+
+    @Test
+    public void testDecimalSubZero()throws Exception {
+        String sql = "select col_decimal32p9s2 - 0.0 from db1.decimal_table";
+        String plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
+        String snippet = "6 <-> cast([2: col_decimal32p9s2, DECIMAL32(9,2), false] as DECIMAL64(18,2)) - 0";
+        Assert.assertTrue(plan.contains(snippet));
+    }
+
+    @Test
+    public void testDecimalMulZero()throws Exception {
+        String sql = "select col_decimal32p9s2 * 0.0 from db1.decimal_table";
+        String plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
+        System.out.println(plan);
+        String snippet = "6 <-> [2: col_decimal32p9s2, DECIMAL32(9,2), false] * 0";
+        Assert.assertTrue(plan.contains(snippet));
+    }
+
+    @Test
+    public void testDecimalDivZero()throws Exception {
+        String sql = "select col_decimal32p9s2 / 0.0 from db1.decimal_table";
+        String plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
+        String snippet = "6 <-> cast([2: col_decimal32p9s2, DECIMAL32(9,2), false] as DECIMAL128(38,2)) / 0";
+        Assert.assertTrue(plan.contains(snippet));
+    }
+
+    @Test
+    public void testDecimalModZero()throws Exception {
+        String sql = "select col_decimal32p9s2 % 0.0 from db1.decimal_table";
+        String plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
+        String snippet = "6 <-> cast([2: col_decimal32p9s2, DECIMAL32(9,2), false] as DECIMAL64(18,2)) % 0";
+        Assert.assertTrue(plan.contains(snippet));
+    }
+
+    @Test
+    public void testZeroDivDecimal()throws Exception {
+        String sql = "select 0.0 / col_decimal32p9s2 from db1.decimal_table";
+        String plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
+        String snippet = "6 <-> 0 / cast([2: col_decimal32p9s2, DECIMAL32(9,2), false] as DECIMAL128(38,2))";
+        Assert.assertTrue(plan.contains(snippet));
+    }
+
+    @Test
+    public void testZeroModDecimal()throws Exception {
+        String sql = "select 0.0 % col_decimal32p9s2 from db1.decimal_table";
+        String plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
+        String snippet = "6 <-> 0 % cast([2: col_decimal32p9s2, DECIMAL32(9,2), false] as DECIMAL64(18,2))";
+        Assert.assertTrue(plan.contains(snippet));
+    }
 }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

select id_decimal  * NULL from t;
select id_decimal  * 0.0 from t

Queries above report error "DECIMAL's precision should range from 1 to 38",  before resolving multiplication function, use DECIMAL32(0,0) as type of NullLiteral,   then invoking ScalarType.createDecimalV3Type(PrimitiveType type, int precision, int scale) on argument list (DECIMAL64, 0, 0), but the precision can not be zero, so in this function, when precision is zero, use 1 instead.