### PR TITLE
Avoid inconsistent when send eos quickly

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -347,8 +347,10 @@ void FragmentExecutor::_decompose_data_sink_to_operator(RuntimeState* runtime_st
         int32_t dest_dop = -1;
         if (sender->get_partition_type() == TPartitionType::HASH_PARTITIONED ||
             sender->get_partition_type() == TPartitionType::BUCKET_SHUFFLE_HASH_PARTITIONED) {
-            is_pipeline_level_shuffle = true;
             dest_dop = t_stream_sink.dest_dop;
+            if (dest_dop > 1) {
+                is_pipeline_level_shuffle = true;
+            }
             DCHECK_GT(dest_dop, 0);
         }
 

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -348,6 +348,9 @@ void FragmentExecutor::_decompose_data_sink_to_operator(RuntimeState* runtime_st
         if (sender->get_partition_type() == TPartitionType::HASH_PARTITIONED ||
             sender->get_partition_type() == TPartitionType::BUCKET_SHUFFLE_HASH_PARTITIONED) {
             dest_dop = t_stream_sink.dest_dop;
+
+            // When pipeline_dop == 1, sender side willn't execute in pipeline level shuffle way, 
+            // so at receiver side, we should disable is_pipeline_level_shuffle.
             if (dest_dop > 1) {
                 is_pipeline_level_shuffle = true;
             }

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -349,7 +349,7 @@ void FragmentExecutor::_decompose_data_sink_to_operator(RuntimeState* runtime_st
             sender->get_partition_type() == TPartitionType::BUCKET_SHUFFLE_HASH_PARTITIONED) {
             dest_dop = t_stream_sink.dest_dop;
 
-            // When pipeline_dop == 1, sender side willn't execute in pipeline level shuffle way, 
+            // When pipeline_dop == 1, sender side willn't execute in pipeline level shuffle way,
             // so at receiver side, we should disable is_pipeline_level_shuffle.
             if (dest_dop > 1) {
                 is_pipeline_level_shuffle = true;

--- a/be/src/runtime/data_stream_recvr.cc
+++ b/be/src/runtime/data_stream_recvr.cc
@@ -520,6 +520,8 @@ Status DataStreamRecvr::SenderQueue::add_chunks(const PTransmitChunkParams& requ
                     _short_circuit_driver_sequences.end()) {
                     continue;
                 }
+            }
+            if (item.driver_sequence >= 0) {
                 _has_chunks_per_driver_sequence[item.driver_sequence] = true;
             }
             _chunk_queue.emplace_back(std::move(item));

--- a/be/src/runtime/data_stream_recvr.cc
+++ b/be/src/runtime/data_stream_recvr.cc
@@ -520,8 +520,6 @@ Status DataStreamRecvr::SenderQueue::add_chunks(const PTransmitChunkParams& requ
                     _short_circuit_driver_sequences.end()) {
                     continue;
                 }
-            }
-            if (item.driver_sequence >= 0) {
                 _has_chunks_per_driver_sequence[item.driver_sequence] = true;
             }
             _chunk_queue.emplace_back(std::move(item));


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
pre-condition: use pipeline and set pipeline_dop = 1
sql: **SELECT 1 EXCEPT SELECT 1;**
This query maybe never done, and pipeline's thread execute forever with has_output_for_pipeline.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
**When query like "SELECT 1 EXCEPT SELECT 1", and we use pipeline engine with pipeline_dop = 1.**

ExchangeSinkOperator will send **2 requests**, The first request is one line data '1' **with is_pipeline_level_shuffle = false**, second request is **Eos** with **is_pipeline_level_shuffle = true**, So this lead to a corner case with **chunk_queue isn't empty**, **is_pipeline_level_shuffle = true** and **_has_chunks_per_driver_sequence[item.driver_sequence]==false**, so we can't get data through ExchangeSourceOperator's has_output.

Just set **has_chunks_per_driver_sequence[item.driver_sequence] = true** when push data into _chunk_queue, to fix this.