### PR TITLE
Fix canColocateJoin not check orders of predicate columns when tables are the same

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ChildOutputPropertyGuarantor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ChildOutputPropertyGuarantor.java
@@ -100,21 +100,21 @@ public class ChildOutputPropertyGuarantor extends OperatorVisitor<Void, Expressi
 
             Preconditions.checkState(leftLocalDistributionDesc.getColumns().size() ==
                     rightLocalDistributionDesc.getColumns().size());
+        }
+        // check orders of predicate columns is right
+        // check predicate columns is satisfy bucket hash columns
+        for (int i = 0; i < leftLocalDistributionDesc.getColumns().size(); ++i) {
+            int leftScanColumnId = leftLocalDistributionDesc.getColumns().get(i);
+            int leftIndex = leftShuffleColumns.indexOf(leftScanColumnId);
 
-            // check orders of predicate columns is right
-            // check predicate columns is satisfy bucket hash columns
-            for (int i = 0; i < leftLocalDistributionDesc.getColumns().size(); ++i) {
-                int leftScanColumnId = leftLocalDistributionDesc.getColumns().get(i);
-                int leftIndex = leftShuffleColumns.indexOf(leftScanColumnId);
+            int rightScanColumnId = rightLocalDistributionDesc.getColumns().get(i);
+            int rightIndex = rightShuffleColumns.indexOf(rightScanColumnId);
 
-                int rightScanColumnId = rightLocalDistributionDesc.getColumns().get(i);
-                int rightIndex = rightShuffleColumns.indexOf(rightScanColumnId);
-
-                if (leftIndex != rightIndex) {
-                    return false;
-                }
+            if (leftIndex != rightIndex) {
+                return false;
             }
         }
+
         return true;
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4318 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This bug can be reproduce by:
```
select a.t1a from test_all_type a join test_all_type b on a.t1a = b.t1b and a.t1b = b.t1a
```
The test_all_type is distributed by key t1a, this sql should **not** use **colocate join** because of the **order** of shuffle columns are not **match**, we should check this in canColocateJoin when table are the same
