### PR TITLE
Fix some bugs found by sonar

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterHandler.java
@@ -366,7 +366,7 @@ public abstract class AlterHandler extends MasterDaemon {
     }
 
     @Override
-    public void start() {
+    public synchronized void start() {
         super.start();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJob.java
@@ -131,7 +131,7 @@ public abstract class AlterJob implements Writable {
         return this.type;
     }
 
-    public void setState(JobState state) {
+    public synchronized void setState(JobState state) {
         this.state = state;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/DecommissionBackendJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/DecommissionBackendJob.java
@@ -300,7 +300,7 @@ public class DecommissionBackendJob extends AlterJob {
      * @param in
      * @throws IOException
      */
-    public void readFields(DataInput in) throws IOException {
+    public synchronized void readFields(DataInput in) throws IOException {
         super.readFields(in);
 
         if (Catalog.getCurrentCatalogJournalVersion() >= FeMetaVersion.VERSION_30) {
@@ -342,7 +342,7 @@ public class DecommissionBackendJob extends AlterJob {
     }
 
     @Override
-    public void write(DataOutput out) throws IOException {
+    public synchronized void write(DataOutput out) throws IOException {
         super.write(out);
 
         out.writeLong(clusterBackendsMap.keySet().size());

--- a/fe/fe-core/src/main/java/com/starrocks/alter/RollupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/RollupJob.java
@@ -1049,7 +1049,7 @@ public class RollupJob extends AlterJob {
         }
     }
 
-    public void readFields(DataInput in) throws IOException {
+    public synchronized void readFields(DataInput in) throws IOException {
         super.readFields(in);
 
         int partitionNum = in.readInt();
@@ -1110,10 +1110,6 @@ public class RollupJob extends AlterJob {
         RollupJob rollupJob = new RollupJob();
         rollupJob.readFields(in);
         return rollupJob;
-    }
-
-    public boolean equals(Object obj) {
-        return true;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -1709,7 +1709,7 @@ public class SchemaChangeHandler extends AlterHandler {
 
             // estimate timeout
             long timeout = Config.tablet_create_timeout_second * 1000L * totalTaskNum;
-            timeout = Math.min(timeout, Config.max_create_table_timeout_second * 1000);
+            timeout = Math.min(timeout, Config.max_create_table_timeout_second * 1000L);
             boolean ok = false;
             try {
                 ok = countDownLatch.await(timeout, TimeUnit.MILLISECONDS);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJob.java
@@ -1264,7 +1264,7 @@ public class SchemaChangeJob extends AlterJob {
         }
     }
 
-    public void readFields(DataInput in) throws IOException {
+    public synchronized void readFields(DataInput in) throws IOException {
         super.readFields(in);
 
         tableName = Text.readString(in);
@@ -1357,10 +1357,6 @@ public class SchemaChangeJob extends AlterJob {
         SchemaChangeJob schemaChangeJob = new SchemaChangeJob();
         schemaChangeJob.readFields(in);
         return schemaChangeJob;
-    }
-
-    public boolean equals(Object obj) {
-        return true;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/AdminRepairTableStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/AdminRepairTableStmt.java
@@ -74,7 +74,7 @@ public class AdminRepairTableStmt extends DdlStmt {
             partitions.addAll(partitionNames.getPartitionNames());
         }
 
-        timeoutS = 4 * 3600; // default 4 hours
+        timeoutS = 4 * 3600L; // default 4 hours
     }
 
     public String getDbName() {

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/AnalyticWindow.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/AnalyticWindow.java
@@ -415,7 +415,7 @@ public class AnalyticWindow implements ParseNode {
                                 + "constant positive number: " + boundary.toSql());
             }
 
-            boundary.offsetValue = new BigDecimal(val);
+            boundary.offsetValue = BigDecimal.valueOf(val);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/DataDescription.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/DataDescription.java
@@ -442,7 +442,7 @@ public class DataDescription {
         }
 
         String precision = args.get(0).toLowerCase();
-        String regex = "^year|month|day|hour$";
+        String regex = "^(?:year|month|day|hour)$";
         if (!precision.matches(regex)) {
             throw new AnalysisException("Alignment precision error. regex: " + regex + ", arg: " + precision);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/DefaultValueExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/DefaultValueExpr.java
@@ -42,7 +42,7 @@ public class DefaultValueExpr extends Expr {
 
     @Override
     public Expr clone() {
-        return null;
+        return this;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/LoadColumnsInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/LoadColumnsInfo.java
@@ -69,7 +69,7 @@ public class LoadColumnsInfo implements ParseNode {
         sb.append(Joiner.on(",").join(columnNames));
         sb.append(")");
 
-        if (columnMappingList != null || columnMappingList.size() != 0) {
+        if (columnMappingList != null && columnMappingList.size() != 0) {
             sb.append(" SET (");
             sb.append(Joiner.on(",").join(columnMappingList.parallelStream()
                     .map(entity -> entity.toSql()).collect(Collectors.toList())));

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/OutFileClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/OutFileClause.java
@@ -47,7 +47,7 @@ public class OutFileClause implements ParseNode {
     private static final String PROP_LINE_DELIMITER = "line_delimiter";
     private static final String PROP_MAX_FILE_SIZE = "max_file_size";
 
-    private static final long DEFAULT_MAX_FILE_SIZE_BYTES = 1 * 1024 * 1024 * 1024; // 1GB
+    private static final long DEFAULT_MAX_FILE_SIZE_BYTES = 1024 * 1024 * 1024L; // 1GB
     private static final long MIN_FILE_SIZE_BYTES = 5 * 1024 * 1024L; // 5MB
     private static final long MAX_FILE_SIZE_BYTES = 2 * 1024 * 1024 * 1024L; // 2GB
 

--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupJob.java
@@ -73,6 +73,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class BackupJob extends AbstractJob {
     private static final Logger LOG = LogManager.getLogger(BackupJob.class);
@@ -556,9 +557,11 @@ public class BackupJob extends AbstractJob {
             File jobDir = new File(localJobDirPath.toString());
             if (jobDir.exists()) {
                 // if dir exists, delete it first
-                Files.walk(localJobDirPath,
-                        FileVisitOption.FOLLOW_LINKS).sorted(Comparator.reverseOrder()).map(Path::toFile)
-                        .forEach(File::delete);
+                try (Stream<Path> path = Files.walk(localJobDirPath,
+                        FileVisitOption.FOLLOW_LINKS)) {
+                    path.sorted(Comparator.reverseOrder()).map(Path::toFile)
+                            .forEach(File::delete);
+                }
             }
             if (!jobDir.mkdir()) {
                 status = new Status(ErrCode.COMMON_ERROR, "Failed to create tmp dir: " + localJobDirPath);
@@ -708,9 +711,11 @@ public class BackupJob extends AbstractJob {
             try {
                 File jobDir = new File(localJobDirPath.toString());
                 if (jobDir.exists()) {
-                    Files.walk(localJobDirPath,
-                            FileVisitOption.FOLLOW_LINKS).sorted(Comparator.reverseOrder()).map(Path::toFile)
-                            .forEach(File::delete);
+                    try (Stream<Path> path = Files.walk(localJobDirPath,
+                            FileVisitOption.FOLLOW_LINKS)) {
+                        path.sorted(Comparator.reverseOrder()).map(Path::toFile)
+                                .forEach(File::delete);
+                    }
                 }
             } catch (Exception e) {
                 LOG.warn("failed to clean the backup job dir: " + localJobDirPath.toString());

--- a/fe/fe-core/src/main/java/com/starrocks/backup/BlobStorage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BlobStorage.java
@@ -173,7 +173,7 @@ public class BlobStorage implements Writable {
             long leftSize = fileSize;
             long readOffset = 0;
             while (leftSize > 0) {
-                long readLen = leftSize > bufSize ? bufSize : leftSize;
+                long readLen = Math.min(leftSize, bufSize);
                 TBrokerReadResponse rep = null;
                 // We only retry if we encounter a timeout thrift exception.
                 int tryTimes = 0;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/AnyArrayType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/AnyArrayType.java
@@ -22,11 +22,6 @@
 package com.starrocks.catalog;
 
 public class AnyArrayType extends PseudoType {
-
-    public boolean equals(Type o) {
-        return o instanceof AnyArrayType;
-    }
-
     @Override
     public boolean matchesType(Type t) {
         return t instanceof AnyArrayType || t instanceof AnyElementType || t.isArrayType();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MetadataViewer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MetadataViewer.java
@@ -255,7 +255,7 @@ public class MetadataViewer {
 
     private static String graph(int num, int totalNum, int mod) {
         StringBuilder sb = new StringBuilder();
-        int normalized = (int) Math.ceil(num * mod / totalNum);
+        int normalized = (int) Math.ceil(num * mod * 1.0 / totalNum);
         for (int i = 0; i < normalized; ++i) {
             sb.append(">");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -256,13 +256,11 @@ public class OlapTable extends Table {
 
         // change single partition name
         if (this.partitionInfo.getType() == PartitionType.UNPARTITIONED) {
-            // use for loop, because if we use getPartition(partitionName),
-            // we may not be able to get partition because this is a bug fix
-            for (Partition partition : getPartitions()) {
+            if (getPartitions().stream().findFirst().isPresent()) {
+                Partition partition = getPartitions().stream().findFirst().get();
                 partition.setName(newName);
                 nameToPartition.clear();
                 nameToPartition.put(newName, partition);
-                break;
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
@@ -46,7 +46,7 @@ public class TabletStatMgr extends MasterDaemon {
     private static final Logger LOG = LogManager.getLogger(TabletStatMgr.class);
 
     public TabletStatMgr() {
-        super("tablet stat mgr", Config.tablet_stat_update_interval_second * 1000);
+        super("tablet stat mgr", Config.tablet_stat_update_interval_second * 1000L);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
@@ -1044,12 +1044,12 @@ public abstract class Type implements Cloneable {
                     type = ScalarType.createHllType();
                 } else if (scalarType.getType() == TPrimitiveType.DECIMAL) {
                     Preconditions.checkState(scalarType.isSetPrecision()
-                            && scalarType.isSetPrecision());
+                            && scalarType.isSetScale());
                     type = ScalarType.createDecimalV2Type(scalarType.getPrecision(),
                             scalarType.getScale());
                 } else if (scalarType.getType() == TPrimitiveType.DECIMALV2) {
                     Preconditions.checkState(scalarType.isSetPrecision()
-                            && scalarType.isSetPrecision());
+                            && scalarType.isSetScale());
                     type = ScalarType.createDecimalV2Type(scalarType.getPrecision(),
                             scalarType.getScale());
                 } else if (scalarType.getType() == TPrimitiveType.DECIMAL32 ||

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -941,7 +941,7 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
         // We should discard the clone replica with stale version.
         TTabletInfo reportedTablet = request.getFinish_tablet_infos().get(0);
         if (reportedTablet.getVersion() < visibleVersion) {
-            String msg = String.format("the clone replica's version is stale. %d-%d, task visible version: %d",
+            String msg = String.format("the clone replica's version is stale. %d, task visible version: %d",
                     reportedTablet.getVersion(),
                     visibleVersion);
             throw new SchedException(Status.RUNNING_FAILED, msg);

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/TimeUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/TimeUtils.java
@@ -40,7 +40,6 @@ import java.text.ParsePosition;
 import java.text.SimpleDateFormat;
 import java.time.DateTimeException;
 import java.time.ZoneId;
-import java.util.Calendar;
 import java.util.Date;
 import java.util.SimpleTimeZone;
 import java.util.TimeZone;
@@ -207,35 +206,6 @@ public class TimeUtils {
 
     public static synchronized String format(Date date, Type type) {
         return format(date, type.getPrimitiveType());
-    }
-
-    /*
-     * only used for ETL
-     */
-    public static long dateTransform(long time, PrimitiveType type) {
-        Calendar cal = Calendar.getInstance(TIME_ZONE);
-        cal.setTimeInMillis(time);
-
-        int year = cal.get(Calendar.YEAR);
-        int month = cal.get(Calendar.MONTH) + 1;
-        int day = cal.get(Calendar.DAY_OF_MONTH);
-
-        if (type == PrimitiveType.DATE) {
-            return year * 16 * 32L + month * 32 + day;
-        } else if (type == PrimitiveType.DATETIME) {
-            // datetime
-            int hour = cal.get(Calendar.HOUR_OF_DAY);
-            int minute = cal.get(Calendar.MINUTE);
-            int second = cal.get(Calendar.SECOND);
-            return (year * 10000 + month * 100 + day) * 1000000L + hour * 10000 + minute * 100 + second;
-        } else {
-            Preconditions.checkState(false, "invalid date type: " + type);
-            return -1L;
-        }
-    }
-
-    public static long dateTransform(long time, Type type) {
-        return dateTransform(time, type.getPrimitiveType());
     }
 
     public static long timeStringToLong(String timeStr) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/Util.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/Util.java
@@ -39,13 +39,14 @@ import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Predicate;
 import java.util.zip.Adler32;
 
@@ -79,6 +80,9 @@ public class Util {
         TYPE_STRING_MAP.put(PrimitiveType.BITMAP, "bitmap");
         TYPE_STRING_MAP.put(PrimitiveType.PERCENTILE, "percentile");
         TYPE_STRING_MAP.put(PrimitiveType.JSON, "json");
+    }
+
+    public Util() throws NoSuchAlgorithmException {
     }
 
     private static class CmdWorker extends Thread {
@@ -291,7 +295,7 @@ public class Util {
     }
 
     public static int generateSchemaHash() {
-        return Math.abs(new Random().nextInt());
+        return Math.abs(ThreadLocalRandom.current().nextInt());
     }
 
     public static String dumpThread(Thread t, int lineNum) {
@@ -342,7 +346,6 @@ public class Util {
                     stream.close();
                 } catch (IOException e) {
                     LOG.warn("failed to close stream when get result from url: {}", urlStr, e);
-                    return null;
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/external/elasticsearch/EsMajorVersion.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/elasticsearch/EsMajorVersion.java
@@ -105,10 +105,10 @@ public class EsMajorVersion {
             return false;
         }
 
-        EsMajorVersion version = (EsMajorVersion) o;
+        EsMajorVersion other = (EsMajorVersion) o;
 
-        return major == version.major &&
-                version.equals(version.version);
+        return major == other.major &&
+                version.equals(other.version);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/external/elasticsearch/EsShardPartitions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/elasticsearch/EsShardPartitions.java
@@ -33,7 +33,7 @@ import org.json.JSONObject;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class EsShardPartitions {
 
@@ -113,7 +113,7 @@ public class EsShardPartitions {
 
     public TNetworkAddress randomAddress(Map<String, EsNodeInfo> nodesInfo) {
         // return a random value between 0 and 32767 : [0, 32767)
-        int seed = new Random().nextInt(Short.MAX_VALUE) % nodesInfo.size();
+        int seed = ThreadLocalRandom.current().nextInt(Short.MAX_VALUE) % nodesInfo.size();
         EsNodeInfo[] nodeInfos = nodesInfo.values().toArray(new EsNodeInfo[0]);
         return nodeInfos[seed].getPublishAddress();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/external/elasticsearch/EsTablePartitions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/elasticsearch/EsTablePartitions.java
@@ -30,7 +30,6 @@ import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.SinglePartitionInfo;
 import com.starrocks.common.DdlException;
-import com.starrocks.thrift.TNetworkAddress;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -38,7 +37,6 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 
 /**
  * save the dynamic info parsed from es cluster state such as shard routing, partition info
@@ -110,22 +108,6 @@ public class EsTablePartitions {
             }
         }
         return esTablePartitions;
-    }
-
-    public void addHttpAddress(Map<String, EsNodeInfo> nodesInfo) {
-        for (EsShardPartitions indexState : partitionedIndexStates.values()) {
-            indexState.addHttpAddress(nodesInfo);
-        }
-        for (EsShardPartitions indexState : unPartitionedIndexStates.values()) {
-            indexState.addHttpAddress(nodesInfo);
-        }
-
-    }
-
-    public TNetworkAddress randomAddress(Map<String, EsNodeInfo> nodesInfo) {
-        int seed = new Random().nextInt() % nodesInfo.size();
-        EsNodeInfo[] nodeInfos = (EsNodeInfo[]) nodesInfo.values().toArray();
-        return nodeInfos[seed].getPublishAddress();
     }
 
     public PartitionInfo getPartitionInfo() {

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveColumnStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveColumnStats.java
@@ -141,10 +141,10 @@ public class HiveColumnStats {
                     numDistinctValues = dateStats.getNumDVs();
                     numNulls = dateStats.getNumNulls();
                     if (dateStats.isSetHighValue()) {
-                        maxValue = dateStats.getHighValue().getDaysSinceEpoch() * 24L * 3600L;
+                        maxValue = dateStats.getHighValue().getDaysSinceEpoch() * 24.0 * 3600L;
                     }
                     if (dateStats.isSetLowValue()) {
-                        minValue = dateStats.getLowValue().getDaysSinceEpoch() * 24L * 3600L;
+                        minValue = dateStats.getLowValue().getDaysSinceEpoch() * 24.0 * 3600L;
                     }
                 }
                 break;

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaClient.java
@@ -518,7 +518,7 @@ public class HiveMetaClient {
                 return literalExpr.getDoubleValue();
             case DATE:
             case DATETIME:
-                return (((DateLiteral) literalExpr).unixTimestamp(TimeZone.getDefault())) / 1000L;
+                return (((DateLiteral) literalExpr).unixTimestamp(TimeZone.getDefault())) / 1000.0;
             default:
                 return Double.NaN;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaStoreThriftClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaStoreThriftClient.java
@@ -158,7 +158,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.security.auth.login.LoginException;
@@ -338,8 +338,7 @@ public class HiveMetaStoreThriftClient implements IMetaStoreClient, AutoCloseabl
         if (metastoreUris.length <= 1) {
             return;
         }
-        Random rng = new Random();
-        int index = rng.nextInt(metastoreUris.length - 1) + 1;
+        int index = ThreadLocalRandom.current().nextInt(metastoreUris.length - 1) + 1;
         URI tmp = metastoreUris[0];
         metastoreUris[0] = metastoreUris[index];
         metastoreUris[index] = tmp;

--- a/fe/fe-core/src/main/java/com/starrocks/http/BaseAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/BaseAction.java
@@ -163,14 +163,15 @@ public abstract class BaseAction implements IAction {
             long contentLen = 0;
             boolean sslEnable = request.getContext().pipeline().get(SslHandler.class) != null;
             if (obj instanceof File) {
-                RandomAccessFile rafFile = new RandomAccessFile((File) obj, "r");
-                contentLen = rafFile.length();
-                if (!sslEnable) {
-                    // use zero-copy file transfer.
-                    writable = new DefaultFileRegion(rafFile.getChannel(), 0, contentLen);
-                } else {
-                    // cannot use zero-copy file transfer.
-                    writable = new ChunkedFile(rafFile, 0, contentLen, 8192);
+                try (RandomAccessFile rafFile = new RandomAccessFile((File) obj, "r")) {
+                    contentLen = rafFile.length();
+                    if (!sslEnable) {
+                        // use zero-copy file transfer.
+                        writable = new DefaultFileRegion(rafFile.getChannel(), 0, contentLen);
+                    } else {
+                        // cannot use zero-copy file transfer.
+                        writable = new ChunkedFile(rafFile, 0, contentLen, 8192);
+                    }
                 }
             } else if (obj instanceof byte[]) {
                 contentLen = ((byte[]) obj).length;

--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpServerHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpServerHandler.java
@@ -38,8 +38,6 @@ import io.netty.util.ReferenceCountUtil;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.net.URISyntaxException;
-
 public class HttpServerHandler extends ChannelInboundHandlerAdapter {
     private static final Logger LOG = LogManager.getLogger(HttpServerHandler.class);
 
@@ -63,10 +61,6 @@ public class HttpServerHandler extends ChannelInboundHandlerAdapter {
         if (msg instanceof HttpRequest) {
             this.request = (HttpRequest) msg;
             LOG.debug("request: url:[{}]", request.uri());
-            if (!isRequestValid(ctx, request)) {
-                writeResponse(ctx, HttpResponseStatus.BAD_REQUEST, "this is a bad request.");
-                return;
-            }
             BaseRequest req = new BaseRequest(ctx, request);
 
             action = getAction(req);
@@ -77,10 +71,6 @@ public class HttpServerHandler extends ChannelInboundHandlerAdapter {
         } else {
             ReferenceCountUtil.release(msg);
         }
-    }
-
-    private boolean isRequestValid(ChannelHandlerContext ctx, HttpRequest request) throws URISyntaxException {
-        return true;
     }
 
     private void writeResponse(ChannelHandlerContext context, HttpResponseStatus status, String content) {

--- a/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBJEJournal.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBJEJournal.java
@@ -163,11 +163,10 @@ public class BDBJEJournal implements Journal {
                 } catch (DatabaseException e) {
                     LOG.error("catch an exception when writing to database. sleep and retry. journal id {}", id, e);
                     try {
-                        Thread.sleep(5 * 1000);
+                        this.wait(5 * 1000);
                     } catch (InterruptedException e1) {
                         e1.printStackTrace();
                     }
-                    continue;
                 }
             }
         } finally {

--- a/fe/fe-core/src/main/java/com/starrocks/load/ExportJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/ExportJob.java
@@ -321,7 +321,7 @@ public class ExportJob implements Writable {
                 throw new UserException("Unsupported table type: " + exportTable.getType());
         }
 
-        scanNode.finalize(analyzer);
+        scanNode.finalizeStats(analyzer);
         return scanNode;
     }
 
@@ -461,7 +461,7 @@ public class ExportJob implements Writable {
         return columnNames;
     }
 
-    public int getProgress() {
+    public synchronized int getProgress() {
         return progress;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/Load.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/Load.java
@@ -79,7 +79,7 @@ public class Load {
 
     public static final String LOAD_OP_COLUMN = "__op";
     // load job meta
-    private volatile LoadErrorHub.Param loadErrorHubParam = new LoadErrorHub.Param();
+    private LoadErrorHub.Param loadErrorHubParam = new LoadErrorHub.Param();
 
     public Load() {
     }

--- a/fe/fe-core/src/main/java/com/starrocks/load/LoadErrorHub.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/LoadErrorHub.java
@@ -25,7 +25,6 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.MoreObjects.ToStringHelper;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.thrift.TErrorHubType;
@@ -37,7 +36,6 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 
 public abstract class LoadErrorHub {
     private static final Logger LOG = LogManager.getLogger(LoadErrorHub.class);
@@ -146,23 +144,6 @@ public abstract class LoadErrorHub {
                     Preconditions.checkState(false, "unknown hub type");
             }
             return info;
-        }
-
-        public Map<String, Object> toDppConfigInfo() {
-            Map<String, Object> dppHubInfo = Maps.newHashMap();
-            dppHubInfo.put("type", type.toString());
-            switch (type) {
-                case MYSQL_TYPE:
-                    dppHubInfo.put("info", mysqlParam);
-                    break;
-                case BROKER_TYPE:
-                    Preconditions.checkState(false, "hadoop load do not support broker error hub");
-                case NULL_TYPE:
-                    break;
-                default:
-                    Preconditions.checkState(false, "unknown hub type");
-            }
-            return dppHubInfo;
         }
 
         public List<String> getInfo() {

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingChecker.java
@@ -36,7 +36,7 @@ public class LoadLoadingChecker extends MasterDaemon {
     private LoadManager loadManager;
 
     public LoadLoadingChecker(LoadManager loadManager) {
-        super("Load loading checker", Config.load_checker_interval_second * 1000);
+        super("Load loading checker", Config.load_checker_interval_second * 1000L);
         this.loadManager = loadManager;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadTimeoutChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadTimeoutChecker.java
@@ -37,7 +37,7 @@ public class LoadTimeoutChecker extends MasterDaemon {
     private LoadManager loadManager;
 
     public LoadTimeoutChecker(LoadManager loadManager) {
-        super("Load job timeout checker", Config.load_checker_interval_second * 1000);
+        super("Load job timeout checker", Config.load_checker_interval_second * 1000L);
         this.loadManager = loadManager;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadingTaskPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadingTaskPlanner.java
@@ -162,7 +162,7 @@ public class LoadingTaskPlanner {
         scanNode.setLoadInfo(loadJobId, txnId, table, brokerDesc, fileGroups, strictMode, parallelInstanceNum);
         scanNode.setUseVectorizedLoad(true);
         scanNode.init(analyzer);
-        scanNode.finalize(analyzer);
+        scanNode.finalizeStats(analyzer);
         LOG.info("use vectorized load: {}, load job id: {}", true, loadJobId);
         scanNodes.add(scanNode);
         descTable.computeMemLayout();

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -790,9 +790,11 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
                 // find task in job
                 Optional<RoutineLoadTaskInfo> routineLoadTaskInfoOptional = routineLoadTaskInfoList.stream().filter(
                         entity -> entity.getTxnId() == txnState.getTransactionId()).findFirst();
-                RoutineLoadTaskInfo routineLoadTaskInfo = routineLoadTaskInfoOptional.get();
-                taskBeId = routineLoadTaskInfo.getBeId();
-                executeTaskOnTxnStatusChanged(routineLoadTaskInfo, txnState, TransactionStatus.COMMITTED, null);
+                if (routineLoadTaskInfoOptional.isPresent()) {
+                    RoutineLoadTaskInfo routineLoadTaskInfo = routineLoadTaskInfoOptional.get();
+                    taskBeId = routineLoadTaskInfo.getBeId();
+                    executeTaskOnTxnStatusChanged(routineLoadTaskInfo, txnState, TransactionStatus.COMMITTED, null);
+                }
                 ++committedTaskNum;
                 LOG.debug("routine load task committed. task id: {}, job id: {}", txnState.getLabel(), id);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/master/MasterImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/master/MasterImpl.java
@@ -1180,8 +1180,8 @@ public class MasterImpl {
             response.setStatus(status);
         } finally {
             db.readUnlock();
-            return response;
         }
+        return response;
     }
 
     public TBeginRemoteTxnResponse beginRemoteTxn(TBeginRemoteTxnRequest request) throws TException {

--- a/fe/fe-core/src/main/java/com/starrocks/metric/TableMetricsRegistry.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/TableMetricsRegistry.java
@@ -14,7 +14,7 @@ public final class TableMetricsRegistry {
 
     private final Map<Long, TableMetricsEntity> idToTableMetrics;
     private ScheduledThreadPoolExecutor timer;
-    private static volatile TableMetricsRegistry instance;
+    private static final TableMetricsRegistry instance = new TableMetricsRegistry();
 
     private TableMetricsRegistry() {
         idToTableMetrics = Maps.newHashMap();
@@ -24,13 +24,6 @@ public final class TableMetricsRegistry {
     }
 
     public static TableMetricsRegistry getInstance() {
-        if (null == instance) {
-            synchronized (TableMetricsRegistry.class) {
-                if (null == instance) {
-                    instance = new TableMetricsRegistry();
-                }
-            }
-        }
         return instance;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/monitor/unit/TimeValue.java
+++ b/fe/fe-core/src/main/java/com/starrocks/monitor/unit/TimeValue.java
@@ -23,14 +23,8 @@ package com.starrocks.monitor.unit;
 
 import com.starrocks.monitor.utils.Strings;
 
-import java.util.Collections;
-import java.util.EnumMap;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 public class TimeValue implements Comparable<TimeValue> {
@@ -40,70 +34,15 @@ public class TimeValue implements Comparable<TimeValue> {
      */
     public static final long NSEC_PER_MSEC = TimeUnit.NANOSECONDS.convert(1, TimeUnit.MILLISECONDS);
 
-    private static Map<TimeUnit, Byte> TIME_UNIT_BYTE_MAP;
-    private static Map<Byte, TimeUnit> BYTE_TIME_UNIT_MAP;
-
-    static {
-        final Map<TimeUnit, Byte> timeUnitByteMap = new EnumMap<>(TimeUnit.class);
-        timeUnitByteMap.put(TimeUnit.NANOSECONDS, (byte) 0);
-        timeUnitByteMap.put(TimeUnit.MICROSECONDS, (byte) 1);
-        timeUnitByteMap.put(TimeUnit.MILLISECONDS, (byte) 2);
-        timeUnitByteMap.put(TimeUnit.SECONDS, (byte) 3);
-        timeUnitByteMap.put(TimeUnit.MINUTES, (byte) 4);
-        timeUnitByteMap.put(TimeUnit.HOURS, (byte) 5);
-        timeUnitByteMap.put(TimeUnit.DAYS, (byte) 6);
-
-        final Set<Byte> bytes = new HashSet<>();
-        for (TimeUnit value : TimeUnit.values()) {
-            assert timeUnitByteMap.containsKey(value) : value;
-            assert bytes.add(timeUnitByteMap.get(value));
-        }
-
-        final Map<Byte, TimeUnit> byteTimeUnitMap = new HashMap<>();
-        for (Map.Entry<TimeUnit, Byte> entry : timeUnitByteMap.entrySet()) {
-            byteTimeUnitMap.put(entry.getValue(), entry.getKey());
-        }
-
-        TIME_UNIT_BYTE_MAP = Collections.unmodifiableMap(timeUnitByteMap);
-        BYTE_TIME_UNIT_MAP = Collections.unmodifiableMap(byteTimeUnitMap);
-    }
-
     public static final TimeValue MINUS_ONE = timeValueMillis(-1);
     public static final TimeValue ZERO = timeValueMillis(0);
-
-    public static TimeValue timeValueNanos(long nanos) {
-        return new TimeValue(nanos, TimeUnit.NANOSECONDS);
-    }
 
     public static TimeValue timeValueMillis(long millis) {
         return new TimeValue(millis, TimeUnit.MILLISECONDS);
     }
 
-    public static TimeValue timeValueSeconds(long seconds) {
-        return new TimeValue(seconds, TimeUnit.SECONDS);
-    }
-
-    public static TimeValue timeValueMinutes(long minutes) {
-        return new TimeValue(minutes, TimeUnit.MINUTES);
-    }
-
-    public static TimeValue timeValueHours(long hours) {
-        return new TimeValue(hours, TimeUnit.HOURS);
-    }
-
     private final long duration;
-
-    // visible for testing
-    long duration() {
-        return duration;
-    }
-
     private final TimeUnit timeUnit;
-
-    // visible for testing
-    TimeUnit timeUnit() {
-        return timeUnit;
-    }
 
     public TimeValue(long millis) {
         this(millis, TimeUnit.MILLISECONDS);

--- a/fe/fe-core/src/main/java/com/starrocks/persist/Storage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/Storage.java
@@ -33,8 +33,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.util.Properties;
-import java.util.Random;
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 
 // VERSION file contains clusterId. eg:
 //      clusterId=123456
@@ -84,23 +84,25 @@ public class Storage {
         Properties prop = new Properties();
         File versionFile = getVersionFile();
         if (versionFile.isFile()) {
-            FileInputStream in = new FileInputStream(versionFile);
-            prop.load(in);
-            in.close();
-            clusterID = Integer.parseInt(prop.getProperty(CLUSTER_ID));
-            if (prop.getProperty(TOKEN) != null) {
-                token = prop.getProperty(TOKEN);
+            try (FileInputStream in = new FileInputStream(versionFile)) {
+                prop.load(in);
+                in.close();
+                clusterID = Integer.parseInt(prop.getProperty(CLUSTER_ID));
+                if (prop.getProperty(TOKEN) != null) {
+                    token = prop.getProperty(TOKEN);
+                }
             }
         }
 
         File roleFile = getRoleFile();
         if (roleFile.isFile()) {
-            FileInputStream in = new FileInputStream(roleFile);
-            prop.load(in);
-            in.close();
-            role = FrontendNodeType.valueOf(prop.getProperty(FRONTEND_ROLE));
-            // For compatibility, NODE_NAME may not exist in ROLE file, set nodeName to null
-            nodeName = prop.getProperty(NODE_NAME, null);
+            try (FileInputStream in = new FileInputStream(roleFile)) {
+                prop.load(in);
+                in.close();
+                role = FrontendNodeType.valueOf(prop.getProperty(FRONTEND_ROLE));
+                // For compatibility, NODE_NAME may not exist in ROLE file, set nodeName to null
+                nodeName = prop.getProperty(NODE_NAME, null);
+            }
         }
 
         // Find the latest image
@@ -113,7 +115,8 @@ public class Storage {
                 String name = child.getName();
                 try {
                     if (!name.equals(IMAGE_NEW) && name.startsWith(IMAGE) && name.contains(".")) {
-                        imageJournalId = Math.max(Long.parseLong(name.substring(name.lastIndexOf('.') + 1)), imageJournalId);
+                        imageJournalId =
+                                Math.max(Long.parseLong(name.substring(name.lastIndexOf('.') + 1)), imageJournalId);
                     }
                 } catch (Exception e) {
                     LOG.warn(name + " is not a validate meta file, ignore it");
@@ -163,12 +166,9 @@ public class Storage {
     }
 
     public static int newClusterID() {
-        Random random = new Random();
-        random.setSeed(System.currentTimeMillis());
-
         int newID = 0;
         while (newID == 0) {
-            newID = random.nextInt(0x7FFFFFFF);
+            newID = ThreadLocalRandom.current().nextInt(0x7FFFFFFF);
         }
         return newID;
     }
@@ -190,19 +190,12 @@ public class Storage {
         Properties properties = new Properties();
         setFields(properties);
 
-        RandomAccessFile file = new RandomAccessFile(new File(metaDir, VERSION_FILE), "rws");
-        FileOutputStream out = null;
-
-        try {
+        try (RandomAccessFile file = new RandomAccessFile(new File(metaDir, VERSION_FILE), "rws")) {
             file.seek(0);
-            out = new FileOutputStream(file.getFD());
-            properties.store(out, null);
-            file.setLength(out.getChannel().position());
-        } finally {
-            if (out != null) {
-                out.close();
+            try (FileOutputStream out = new FileOutputStream(file.getFD())) {
+                properties.store(out, null);
+                file.setLength(out.getChannel().position());
             }
-            file.close();
         }
     }
 
@@ -212,19 +205,12 @@ public class Storage {
         properties.setProperty(FRONTEND_ROLE, role.name());
         properties.setProperty(NODE_NAME, nameNode);
 
-        RandomAccessFile file = new RandomAccessFile(new File(metaDir, ROLE_FILE), "rws");
-        FileOutputStream out = null;
-
-        try {
+        try (RandomAccessFile file = new RandomAccessFile(new File(metaDir, ROLE_FILE), "rws")) {
             file.seek(0);
-            out = new FileOutputStream(file.getFD());
-            properties.store(out, null);
-            file.setLength(out.getChannel().position());
-        } finally {
-            if (out != null) {
-                out.close();
+            try (FileOutputStream out = new FileOutputStream(file.getFD())) {
+                properties.store(out, null);
+                file.setLength(out.getChannel().position());
             }
-            file.close();
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/EsScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/EsScanNode.java
@@ -105,7 +105,7 @@ public class EsScanNode extends ScanNode {
     }
 
     @Override
-    public void finalize(Analyzer analyzer) throws UserException {
+    public void finalizeStats(Analyzer analyzer) throws UserException {
         if (isFinalized) {
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/FileScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FileScanNode.java
@@ -568,7 +568,7 @@ public class FileScanNode extends LoadScanNode {
     }
 
     @Override
-    public void finalize(Analyzer analyzer) throws UserException {
+    public void finalizeStats(Analyzer analyzer) throws UserException {
         locationsList = Lists.newArrayList();
         locationsHeap = new PriorityQueue<>(SCAN_RANGE_LOCATIONS_COMPARATOR);
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
@@ -110,7 +110,7 @@ public class IcebergScanNode extends ScanNode {
     }
 
     @Override
-    public void finalize(Analyzer analyzer) throws UserException {
+    public void finalizeStats(Analyzer analyzer) throws UserException {
         if (isFinalized) {
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/JDBCScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/JDBCScanNode.java
@@ -46,7 +46,7 @@ public class JDBCScanNode extends ScanNode {
     }
 
     @Override
-    public void finalize(Analyzer analyzer) throws UserException {
+    public void finalizeStats(Analyzer analyzer) throws UserException {
         createJDBCTableColumns();
         createJDBCTableFilters();
         computeStats(analyzer);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/MysqlScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/MysqlScanNode.java
@@ -72,7 +72,7 @@ public class MysqlScanNode extends ScanNode {
     }
 
     @Override
-    public void finalize(Analyzer analyzer) throws UserException {
+    public void finalizeStats(Analyzer analyzer) throws UserException {
         // Convert predicates to MySQL columns and filters.
         createMySQLColumns();
         createMySQLFilters();

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -317,7 +317,7 @@ public class OlapScanNode extends ScanNode {
     }
 
     @Override
-    public void finalize(Analyzer analyzer) throws UserException {
+    public void finalizeStats(Analyzer analyzer) throws UserException {
         if (isFinalized) {
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanNode.java
@@ -531,9 +531,9 @@ abstract public class PlanNode extends TreeNode<PlanNode> {
      * Call this once on the root of the plan tree before calling toThrift().
      * Subclasses need to override this.
      */
-    public void finalize(Analyzer analyzer) throws UserException {
+    public void finalizeStats(Analyzer analyzer) throws UserException {
         for (PlanNode child : children) {
-            child.finalize(analyzer);
+            child.finalizeStats(analyzer);
         }
         computeStats(analyzer);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/SchemaScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/SchemaScanNode.java
@@ -88,7 +88,7 @@ public class SchemaScanNode extends ScanNode {
     }
 
     @Override
-    public void finalize(Analyzer analyzer) throws UserException {
+    public void finalizeStats(Analyzer analyzer) throws UserException {
         // Convert predicates to MySQL columns and filters.
         schemaDb = analyzer.getSchemaDb();
         schemaTable = analyzer.getSchemaTable();

--- a/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadPlanner.java
@@ -71,7 +71,7 @@ import java.util.Optional;
 // TODO(zc): support other type table
 public class StreamLoadPlanner {
     private static final Logger LOG = LogManager.getLogger(StreamLoadPlanner.class);
-    private static final DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+    private final DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
 
     // destination Db and table get from request
     // Data will load to this table
@@ -154,7 +154,7 @@ public class StreamLoadPlanner {
                 new StreamLoadScanNode(loadId, new PlanNodeId(0), tupleDesc, destTable, streamLoadTask);
         scanNode.setUseVectorizedLoad(true);
         scanNode.init(analyzer);
-        scanNode.finalize(analyzer);
+        scanNode.finalizeStats(analyzer);
 
         descTable.computeMemLayout();
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadScanNode.java
@@ -190,7 +190,7 @@ public class StreamLoadScanNode extends LoadScanNode {
     }
 
     @Override
-    public void finalize(Analyzer analyzer) throws UserException, UserException {
+    public void finalizeStats(Analyzer analyzer) throws UserException, UserException {
         finalizeParams();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -74,7 +74,6 @@ import com.starrocks.thrift.FrontendService;
 import com.starrocks.thrift.FrontendServiceVersion;
 import com.starrocks.thrift.TAbortRemoteTxnRequest;
 import com.starrocks.thrift.TAbortRemoteTxnResponse;
-import com.starrocks.thrift.TAuthenticateParams;
 import com.starrocks.thrift.TBeginRemoteTxnRequest;
 import com.starrocks.thrift.TBeginRemoteTxnResponse;
 import com.starrocks.thrift.TColumnDef;
@@ -945,52 +944,23 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         return addr == null ? "unknown" : addr.hostname;
     }
 
-    private boolean authorizeRequest(TAuthenticateParams authInfo) {
-        // TODO
-        return true;
-    }
-
     @Override
     public TGetTableMetaResponse getTableMeta(TGetTableMetaRequest request) throws TException {
-        if (!authorizeRequest(request.getAuth_info())) {
-            TGetTableMetaResponse response = new TGetTableMetaResponse();
-            TStatus status = new TStatus(TStatusCode.NOT_AUTHORIZED);
-            status.setError_msgs(Lists.newArrayList("not authorized to call getTableMeta"));
-            response.setStatus(status);
-        }
         return masterImpl.getTableMeta(request);
     }
 
     @Override
     public TBeginRemoteTxnResponse beginRemoteTxn(TBeginRemoteTxnRequest request) throws TException {
-        if (!authorizeRequest(request.getAuth_info())) {
-            TBeginRemoteTxnResponse response = new TBeginRemoteTxnResponse();
-            TStatus status = new TStatus(TStatusCode.NOT_AUTHORIZED);
-            status.setError_msgs(Lists.newArrayList("not authorized to call beginReomteTxn"));
-            response.setStatus(status);
-        }
         return masterImpl.beginRemoteTxn(request);
     }
 
     @Override
     public TCommitRemoteTxnResponse commitRemoteTxn(TCommitRemoteTxnRequest request) throws TException {
-        if (!authorizeRequest(request.getAuth_info())) {
-            TCommitRemoteTxnResponse response = new TCommitRemoteTxnResponse();
-            TStatus status = new TStatus(TStatusCode.NOT_AUTHORIZED);
-            status.setError_msgs(Lists.newArrayList("not authorized to call commitReomteTxn"));
-            response.setStatus(status);
-        }
         return masterImpl.commitRemoteTxn(request);
     }
 
     @Override
     public TAbortRemoteTxnResponse abortRemoteTxn(TAbortRemoteTxnRequest request) throws TException {
-        if (!authorizeRequest(request.getAuth_info())) {
-            TAbortRemoteTxnResponse response = new TAbortRemoteTxnResponse();
-            TStatus status = new TStatus(TStatusCode.NOT_AUTHORIZED);
-            status.setError_msgs(Lists.newArrayList("not authorized to call abortReomteTxn"));
-            response.setStatus(status);
-        }
         return masterImpl.abortRemoteTxn(request);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyticAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyticAnalyzer.java
@@ -236,7 +236,7 @@ public class AnalyticAnalyzer {
                         + "constant positive number: " + boundary.toSql());
             }
 
-            boundary.setOffsetValue(new BigDecimal(val));
+            boundary.setOffsetValue(BigDecimal.valueOf(val));
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/QueryDumpInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/QueryDumpInfo.java
@@ -17,15 +17,15 @@ import java.util.Map;
 public class QueryDumpInfo implements DumpInfo {
     private String originStmt = "";
     // tableId-><dbName, table>
-    private Map<Long, Pair<String, Table>> tableMap = new HashMap<>();
+    private final Map<Long, Pair<String, Table>> tableMap = new HashMap<>();
     // tableName->partitionName->partitionRowCount
-    private Map<String, Map<String, Long>> partitionRowCountMap = new HashMap<>();
+    private final Map<String, Map<String, Long>> partitionRowCountMap = new HashMap<>();
     // tableName->columnName->column statistics
-    private Map<String, Map<String, ColumnStatistic>> tableStatisticsMap = new HashMap<>();
+    private final Map<String, Map<String, ColumnStatistic>> tableStatisticsMap = new HashMap<>();
     private SessionVariable sessionVariable;
     // tableName->createTableStmt
-    private Map<String, String> createTableStmtMap = new HashMap<>();
-    private List<String> exceptionList = new ArrayList<>();
+    private final Map<String, String> createTableStmtMap = new HashMap<>();
+    private final List<String> exceptionList = new ArrayList<>();
     private int beNum;
 
     public QueryDumpInfo(SessionVariable sessionVariable) {
@@ -83,10 +83,6 @@ public class QueryDumpInfo implements DumpInfo {
 
     public Map<String, Map<String, Long>> getPartitionRowCountMap() {
         return partitionRowCountMap;
-    }
-
-    public Long getRowCount(long tableId, String partition) {
-        return partitionRowCountMap.get(tableId).get(partition);
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogTest.java
@@ -182,7 +182,7 @@ public class CatalogTest {
 
         catalog.addCluster(cluster);
         catalog.unprotectCreateDb(db1);
-        SchemaChangeJob job1 = new SchemaChangeJob(db1.getId(), table.getId(), null, table.getName(), -1);
+        SchemaChangeJob job1 = new SchemaChangeJob(db1.getId(), table.getId(), null, table.getName(), 2022);
 
         catalog.getSchemaChangeHandler().replayInitJob(job1, catalog);
         long checksum1 = catalog.saveAlterJob(dos, 0, JobType.SCHEMA_CHANGE);
@@ -197,7 +197,7 @@ public class CatalogTest {
         Map<Long, AlterJob> map = catalog.getSchemaChangeHandler().unprotectedGetAlterJobs();
         Assert.assertEquals(1, map.size());
         SchemaChangeJob job2 = (SchemaChangeJob) map.get(table.getId());
-        Assert.assertTrue(job1.equals(job2));
+        Assert.assertEquals(job1.getTransactionId(), (job2.getTransactionId()));
         dis.close();
 
         deleteDir(dir);

--- a/fe/fe-core/src/test/java/com/starrocks/planner/FileScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/FileScanNodeTest.java
@@ -140,7 +140,7 @@ public class FileScanNodeTest {
         FileScanNode scanNode = new FileScanNode(new PlanNodeId(0), tupleDesc, "FileScanNode", fileStatusesList, 2);
         scanNode.setLoadInfo(jobId, txnId, table, brokerDesc, fileGroups, true, loadParallelInstanceNum);
         scanNode.init(analyzer);
-        scanNode.finalize(analyzer);
+        scanNode.finalizeStats(analyzer);
 
         // check
         List<TScanRangeLocations> locationsList = scanNode.getScanRangeLocations(0);
@@ -200,7 +200,7 @@ public class FileScanNodeTest {
         scanNode = new FileScanNode(new PlanNodeId(0), tupleDesc, "FileScanNode", fileStatusesList, 4);
         scanNode.setLoadInfo(jobId, txnId, table, brokerDesc, fileGroups, true, loadParallelInstanceNum);
         scanNode.init(analyzer);
-        scanNode.finalize(analyzer);
+        scanNode.finalizeStats(analyzer);
 
         // check
         locationsList = scanNode.getScanRangeLocations(0);
@@ -252,7 +252,7 @@ public class FileScanNodeTest {
         scanNode = new FileScanNode(new PlanNodeId(0), tupleDesc, "FileScanNode", fileStatusesList, 5);
         scanNode.setLoadInfo(jobId, txnId, table, brokerDesc, fileGroups, true, loadParallelInstanceNum);
         scanNode.init(analyzer);
-        scanNode.finalize(analyzer);
+        scanNode.finalizeStats(analyzer);
 
         // check
         locationsList = scanNode.getScanRangeLocations(0);
@@ -300,7 +300,7 @@ public class FileScanNodeTest {
         scanNode = new FileScanNode(new PlanNodeId(0), tupleDesc, "FileScanNode", fileStatusesList, 2);
         scanNode.setLoadInfo(jobId, txnId, table, brokerDesc, fileGroups, true, loadParallelInstanceNum);
         scanNode.init(analyzer);
-        scanNode.finalize(analyzer);
+        scanNode.finalizeStats(analyzer);
 
         // check
         locationsList = scanNode.getScanRangeLocations(0);
@@ -333,7 +333,7 @@ public class FileScanNodeTest {
         scanNode = new FileScanNode(new PlanNodeId(0), tupleDesc, "FileScanNode", fileStatusesList, 1);
         scanNode.setLoadInfo(jobId, txnId, table, brokerDesc, fileGroups, true, loadParallelInstanceNum);
         scanNode.init(analyzer);
-        scanNode.finalize(analyzer);
+        scanNode.finalizeStats(analyzer);
 
         // check
         locationsList = scanNode.getScanRangeLocations(0);

--- a/fe/fe-core/src/test/java/com/starrocks/planner/StreamLoadScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/StreamLoadScanNodeTest.java
@@ -196,7 +196,7 @@ public class StreamLoadScanNodeTest {
             result = columns.get(3);
         }};
         scanNode.init(analyzer);
-        scanNode.finalize(analyzer);
+        scanNode.finalizeStats(analyzer);
         scanNode.getNodeExplainString("", TExplainLevel.NORMAL);
         TPlanNode planNode = new TPlanNode();
         scanNode.toThrift(planNode);
@@ -229,7 +229,7 @@ public class StreamLoadScanNodeTest {
         StreamLoadScanNode scanNode = getStreamLoadScanNode(dstDesc, request);
 
         scanNode.init(analyzer);
-        scanNode.finalize(analyzer);
+        scanNode.finalizeStats(analyzer);
         scanNode.getNodeExplainString("", TExplainLevel.NORMAL);
         TPlanNode planNode = new TPlanNode();
         scanNode.toThrift(planNode);
@@ -259,7 +259,7 @@ public class StreamLoadScanNodeTest {
         StreamLoadScanNode scanNode = getStreamLoadScanNode(dstDesc, request);
 
         scanNode.init(analyzer);
-        scanNode.finalize(analyzer);
+        scanNode.finalizeStats(analyzer);
         scanNode.getNodeExplainString("", TExplainLevel.NORMAL);
         TPlanNode planNode = new TPlanNode();
         scanNode.toThrift(planNode);
@@ -304,7 +304,7 @@ public class StreamLoadScanNodeTest {
         StreamLoadTask streamLoadTask = StreamLoadTask.fromTStreamLoadPutRequest(request, null);
         StreamLoadScanNode scanNode = getStreamLoadScanNode(dstDesc, request);
         scanNode.init(analyzer);
-        scanNode.finalize(analyzer);
+        scanNode.finalizeStats(analyzer);
         scanNode.getNodeExplainString("", TExplainLevel.NORMAL);
         TPlanNode planNode = new TPlanNode();
         scanNode.toThrift(planNode);
@@ -380,7 +380,7 @@ public class StreamLoadScanNodeTest {
         StreamLoadScanNode scanNode = getStreamLoadScanNode(dstDesc, request);
 
         scanNode.init(analyzer);
-        scanNode.finalize(analyzer);
+        scanNode.finalizeStats(analyzer);
         scanNode.getNodeExplainString("", TExplainLevel.NORMAL);
         TPlanNode planNode = new TPlanNode();
         scanNode.toThrift(planNode);
@@ -435,7 +435,7 @@ public class StreamLoadScanNodeTest {
         StreamLoadScanNode scanNode = getStreamLoadScanNode(dstDesc, request);
 
         scanNode.init(analyzer);
-        scanNode.finalize(analyzer);
+        scanNode.finalizeStats(analyzer);
         scanNode.getNodeExplainString("", TExplainLevel.NORMAL);
         TPlanNode planNode = new TPlanNode();
         scanNode.toThrift(planNode);
@@ -465,7 +465,7 @@ public class StreamLoadScanNodeTest {
         StreamLoadScanNode scanNode = getStreamLoadScanNode(dstDesc, request);
 
         scanNode.init(analyzer);
-        scanNode.finalize(analyzer);
+        scanNode.finalizeStats(analyzer);
         scanNode.getNodeExplainString("", TExplainLevel.NORMAL);
         TPlanNode planNode = new TPlanNode();
         scanNode.toThrift(planNode);
@@ -495,7 +495,7 @@ public class StreamLoadScanNodeTest {
         StreamLoadScanNode scanNode = getStreamLoadScanNode(dstDesc, request);
 
         scanNode.init(analyzer);
-        scanNode.finalize(analyzer);
+        scanNode.finalizeStats(analyzer);
         scanNode.getNodeExplainString("", TExplainLevel.NORMAL);
         TPlanNode planNode = new TPlanNode();
         scanNode.toThrift(planNode);
@@ -544,7 +544,7 @@ public class StreamLoadScanNodeTest {
         StreamLoadScanNode scanNode = getStreamLoadScanNode(dstDesc, request);
 
         scanNode.init(analyzer);
-        scanNode.finalize(analyzer);
+        scanNode.finalizeStats(analyzer);
         scanNode.getNodeExplainString("", TExplainLevel.NORMAL);
         TPlanNode planNode = new TPlanNode();
         scanNode.toThrift(planNode);
@@ -594,7 +594,7 @@ public class StreamLoadScanNodeTest {
         StreamLoadScanNode scanNode = getStreamLoadScanNode(dstDesc, request);
 
         scanNode.init(analyzer);
-        scanNode.finalize(analyzer);
+        scanNode.finalizeStats(analyzer);
         scanNode.getNodeExplainString("", TExplainLevel.NORMAL);
         TPlanNode planNode = new TPlanNode();
         scanNode.toThrift(planNode);
@@ -647,7 +647,7 @@ public class StreamLoadScanNodeTest {
                         streamLoadTask);
 
         scanNode.init(analyzer);
-        scanNode.finalize(analyzer);
+        scanNode.finalizeStats(analyzer);
         scanNode.getNodeExplainString("", TExplainLevel.NORMAL);
         TPlanNode planNode = new TPlanNode();
         scanNode.toThrift(planNode);
@@ -697,7 +697,7 @@ public class StreamLoadScanNodeTest {
         StreamLoadScanNode scanNode = getStreamLoadScanNode(dstDesc, request);
 
         scanNode.init(analyzer);
-        scanNode.finalize(analyzer);
+        scanNode.finalizeStats(analyzer);
         scanNode.getNodeExplainString("", TExplainLevel.NORMAL);
         TPlanNode planNode = new TPlanNode();
         scanNode.toThrift(planNode);
@@ -744,7 +744,7 @@ public class StreamLoadScanNodeTest {
         };
 
         scanNode.init(analyzer);
-        scanNode.finalize(analyzer);
+        scanNode.finalizeStats(analyzer);
         scanNode.getNodeExplainString("", TExplainLevel.NORMAL);
         TPlanNode planNode = new TPlanNode();
         scanNode.toThrift(planNode);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

Fix some bugs found by sonar:

- Overrides should match their parent class methods in synchronization
- Getters and setters should be synchronized in pairs
- "equals(Object obj)" and "hashCode()" should be overridden in pairs
- Math operands should be cast before assignment
- "BigDecimal(double)" should not be used
- Alternatives in regular expressions should be grouped when used with anchors
- "toString()" and "clone()" methods should not return null
- Null pointers should not be dereferenced
- Conditionally executed code should be reachable

- Use try-with-resources or close this "Stream" in a "finally" clause.

- Either override Object.equals(Object), or rename the method to prevent any confusion.

- Remove this "break" statement or make it conditional.

- Correct one of the identical sub-expressions on both sides of operator "&&"

- Save and re-use this "Random".

- Remove this return statement from this finally block.

- Remove this call to "equals"; comparisons between unrelated types always return false.

- Cast one of the operands of this multiplication operation to a "double".

- Use a thread-safe type; adding "volatile" is not enough to make this field thread-safe.

- Call "routineLoadTaskInfoOptional.isPresent()" before accessing the value.

- Rename this method to avoid any possible confusion with Object.finalize().

- Make "DATE_FORMAT" an instance variable.
