### PR TITLE
BugFix: Fix the wrong checksum when exit be graceful

### DIFF
--- a/be/src/storage/task/engine_checksum_task.cpp
+++ b/be/src/storage/task/engine_checksum_task.cpp
@@ -126,6 +126,10 @@ Status EngineChecksumTask::_compute_checksum() {
         bg_worker_stopped = ExecEnv::GetInstance()->storage_engine()->bg_worker_stopped();
     }
 
+    if (bg_worker_stopped) {
+        return Status::InternalError("Process is going to quit. The checksum calculation will be stopped.");
+    }
+
     if (!st.is_end_of_file() && !st.ok()) {
         LOG(WARNING) << "Failed to do checksum. tablet=" << tablet->full_name() << ", error:=" << st.to_string();
         return st;

--- a/be/src/storage/task/engine_checksum_task.cpp
+++ b/be/src/storage/task/engine_checksum_task.cpp
@@ -127,7 +127,7 @@ Status EngineChecksumTask::_compute_checksum() {
     }
 
     if (bg_worker_stopped) {
-        return Status::InternalError("Process is going to quit. The checksum calculation will be stopped.");
+        return Status::InternalError("Process is going to quit. The checksum calculation will stop.");
     }
 
     if (!st.is_end_of_file() && !st.ok()) {

--- a/be/src/storage/task/engine_clone_task.cpp
+++ b/be/src/storage/task/engine_clone_task.cpp
@@ -301,7 +301,7 @@ Status EngineCloneTask::_make_snapshot(const std::string& ip, int port, TTableId
                                        std::string* snapshot_path, int32_t* snapshot_format) {
     bool bg_worker_stopped = ExecEnv::GetInstance()->storage_engine()->bg_worker_stopped();
     if (bg_worker_stopped) {
-        return Status::InternalError("Process is going to quit. The snapshot will be stopped.");
+        return Status::InternalError("Process is going to quit. The snapshot will stop.");
     }
 
     TSnapshotRequest request;
@@ -344,7 +344,7 @@ Status EngineCloneTask::_make_snapshot(const std::string& ip, int port, TTableId
 Status EngineCloneTask::_release_snapshot(const std::string& ip, int port, const std::string& snapshot_path) {
     bool bg_worker_stopped = ExecEnv::GetInstance()->storage_engine()->bg_worker_stopped();
     if (bg_worker_stopped) {
-        return Status::InternalError("Process is going to quit. The snapshot will be stopped.");
+        return Status::InternalError("Process is going to quit. The snapshot will stop.");
     }
 
     TAgentResult result;
@@ -359,7 +359,7 @@ Status EngineCloneTask::_download_files(DataDir* data_dir, const std::string& re
                                         const std::string& local_path) {
     bool bg_worker_stopped = ExecEnv::GetInstance()->storage_engine()->bg_worker_stopped();
     if (bg_worker_stopped) {
-        return Status::InternalError("Process is going to quit. The download will be stopped.");
+        return Status::InternalError("Process is going to quit. The download will stop.");
     }
 
     // Check local path exist, if exist, remove it, then create the dir
@@ -388,7 +388,7 @@ Status EngineCloneTask::_download_files(DataDir* data_dir, const std::string& re
     for (int i = 0; i < file_name_list.size() - 1; ++i) {
         bg_worker_stopped = ExecEnv::GetInstance()->storage_engine()->bg_worker_stopped();
         if (bg_worker_stopped) {
-            return Status::InternalError("Process is going to quit. The download will be stopped.");
+            return Status::InternalError("Process is going to quit. The download will stop.");
         }
         StringPiece sp(file_name_list[i]);
         if (sp.ends_with(".hdr")) {
@@ -463,7 +463,7 @@ Status EngineCloneTask::_finish_clone(Tablet* tablet, const string& clone_dir, i
                                       bool incremental_clone) {
     bool bg_worker_stopped = ExecEnv::GetInstance()->storage_engine()->bg_worker_stopped();
     if (bg_worker_stopped) {
-        return Status::InternalError("Process is going to quit. The clone will be stopped.");
+        return Status::InternalError("Process is going to quit. The clone will stop.");
     }
 
     if (tablet->updates() != nullptr) {
@@ -517,7 +517,7 @@ Status EngineCloneTask::_finish_clone(Tablet* tablet, const string& clone_dir, i
         for (const string& clone_file : clone_files) {
             bool bg_worker_stopped = ExecEnv::GetInstance()->storage_engine()->bg_worker_stopped();
             if (bg_worker_stopped) {
-                return Status::InternalError("Process is going to quit. The clone will be stopped.");
+                return Status::InternalError("Process is going to quit. The clone will stop.");
             }
 
             if (local_files.find(clone_file) != local_files.end()) {
@@ -564,7 +564,7 @@ Status EngineCloneTask::_clone_incremental_data(Tablet* tablet, const TabletMeta
                                                 int64_t committed_version) {
     bool bg_worker_stopped = ExecEnv::GetInstance()->storage_engine()->bg_worker_stopped();
     if (bg_worker_stopped) {
-        return Status::InternalError("Process is going to quit. The clone should will be stopped.");
+        return Status::InternalError("Process is going to quit. The clone should will stop.");
     }
 
     LOG(INFO) << "begin to incremental clone. tablet=" << tablet->full_name()
@@ -602,7 +602,7 @@ Status EngineCloneTask::_clone_incremental_data(Tablet* tablet, const TabletMeta
 Status EngineCloneTask::_clone_full_data(Tablet* tablet, TabletMeta* cloned_tablet_meta) {
     bool bg_worker_stopped = ExecEnv::GetInstance()->storage_engine()->bg_worker_stopped();
     if (bg_worker_stopped) {
-        return Status::InternalError("Process is going to quit. The clone will be stopped.");
+        return Status::InternalError("Process is going to quit. The clone will stop.");
     }
 
     Version cloned_max_version = cloned_tablet_meta->max_version();
@@ -697,7 +697,7 @@ Status EngineCloneTask::_clone_full_data(Tablet* tablet, TabletMeta* cloned_tabl
 Status EngineCloneTask::_finish_clone_primary(Tablet* tablet, const std::string& clone_dir) {
     bool bg_worker_stopped = ExecEnv::GetInstance()->storage_engine()->bg_worker_stopped();
     if (bg_worker_stopped) {
-        return Status::InternalError("Process is going to quit. The snapshot will be stopped.");
+        return Status::InternalError("Process is going to quit. The snapshot will stop.");
     }
 
     auto meta_file = strings::Substitute("$0/meta", clone_dir);

--- a/be/src/storage/task/engine_clone_task.cpp
+++ b/be/src/storage/task/engine_clone_task.cpp
@@ -301,7 +301,7 @@ Status EngineCloneTask::_make_snapshot(const std::string& ip, int port, TTableId
                                        std::string* snapshot_path, int32_t* snapshot_format) {
     bool bg_worker_stopped = ExecEnv::GetInstance()->storage_engine()->bg_worker_stopped();
     if (bg_worker_stopped) {
-        return Status::InternalError("Process is going to quit. The snapshot should be stopped as soon as possible.");
+        return Status::InternalError("Process is going to quit. The snapshot will be stopped.");
     }
 
     TSnapshotRequest request;
@@ -344,7 +344,7 @@ Status EngineCloneTask::_make_snapshot(const std::string& ip, int port, TTableId
 Status EngineCloneTask::_release_snapshot(const std::string& ip, int port, const std::string& snapshot_path) {
     bool bg_worker_stopped = ExecEnv::GetInstance()->storage_engine()->bg_worker_stopped();
     if (bg_worker_stopped) {
-        return Status::InternalError("Process is going to quit. The snapshot should be stopped as soon as possible.");
+        return Status::InternalError("Process is going to quit. The snapshot will be stopped.");
     }
 
     TAgentResult result;
@@ -359,7 +359,7 @@ Status EngineCloneTask::_download_files(DataDir* data_dir, const std::string& re
                                         const std::string& local_path) {
     bool bg_worker_stopped = ExecEnv::GetInstance()->storage_engine()->bg_worker_stopped();
     if (bg_worker_stopped) {
-        return Status::InternalError("Process is going to quit. The download should be stopped as soon as possible.");
+        return Status::InternalError("Process is going to quit. The download will be stopped.");
     }
 
     // Check local path exist, if exist, remove it, then create the dir
@@ -388,8 +388,7 @@ Status EngineCloneTask::_download_files(DataDir* data_dir, const std::string& re
     for (int i = 0; i < file_name_list.size() - 1; ++i) {
         bg_worker_stopped = ExecEnv::GetInstance()->storage_engine()->bg_worker_stopped();
         if (bg_worker_stopped) {
-            return Status::InternalError(
-                    "Process is going to quit. The download should be stopped as soon as possible.");
+            return Status::InternalError("Process is going to quit. The download will be stopped.");
         }
         StringPiece sp(file_name_list[i]);
         if (sp.ends_with(".hdr")) {
@@ -464,7 +463,7 @@ Status EngineCloneTask::_finish_clone(Tablet* tablet, const string& clone_dir, i
                                       bool incremental_clone) {
     bool bg_worker_stopped = ExecEnv::GetInstance()->storage_engine()->bg_worker_stopped();
     if (bg_worker_stopped) {
-        return Status::InternalError("Process is going to quit. The clone should be stopped as soon as possible.");
+        return Status::InternalError("Process is going to quit. The clone will be stopped.");
     }
 
     if (tablet->updates() != nullptr) {
@@ -518,8 +517,7 @@ Status EngineCloneTask::_finish_clone(Tablet* tablet, const string& clone_dir, i
         for (const string& clone_file : clone_files) {
             bool bg_worker_stopped = ExecEnv::GetInstance()->storage_engine()->bg_worker_stopped();
             if (bg_worker_stopped) {
-                return Status::InternalError(
-                        "Process is going to quit. The clone should be stopped as soon as possible.");
+                return Status::InternalError("Process is going to quit. The clone will be stopped.");
             }
 
             if (local_files.find(clone_file) != local_files.end()) {
@@ -566,7 +564,7 @@ Status EngineCloneTask::_clone_incremental_data(Tablet* tablet, const TabletMeta
                                                 int64_t committed_version) {
     bool bg_worker_stopped = ExecEnv::GetInstance()->storage_engine()->bg_worker_stopped();
     if (bg_worker_stopped) {
-        return Status::InternalError("Process is going to quit. The clone should be stopped as soon as possible.");
+        return Status::InternalError("Process is going to quit. The clone should will be stopped.");
     }
 
     LOG(INFO) << "begin to incremental clone. tablet=" << tablet->full_name()
@@ -604,7 +602,7 @@ Status EngineCloneTask::_clone_incremental_data(Tablet* tablet, const TabletMeta
 Status EngineCloneTask::_clone_full_data(Tablet* tablet, TabletMeta* cloned_tablet_meta) {
     bool bg_worker_stopped = ExecEnv::GetInstance()->storage_engine()->bg_worker_stopped();
     if (bg_worker_stopped) {
-        return Status::InternalError("Process is going to quit. The clone should be stopped as soon as possible.");
+        return Status::InternalError("Process is going to quit. The clone will be stopped.");
     }
 
     Version cloned_max_version = cloned_tablet_meta->max_version();
@@ -699,7 +697,7 @@ Status EngineCloneTask::_clone_full_data(Tablet* tablet, TabletMeta* cloned_tabl
 Status EngineCloneTask::_finish_clone_primary(Tablet* tablet, const std::string& clone_dir) {
     bool bg_worker_stopped = ExecEnv::GetInstance()->storage_engine()->bg_worker_stopped();
     if (bg_worker_stopped) {
-        return Status::InternalError("Process is going to quit. The snapshot should be stopped as soon as possible.");
+        return Status::InternalError("Process is going to quit. The snapshot will be stopped.");
     }
 
     auto meta_file = strings::Substitute("$0/meta", clone_dir);

--- a/be/src/storage/task/engine_storage_migration_task.cpp
+++ b/be/src/storage/task/engine_storage_migration_task.cpp
@@ -66,7 +66,7 @@ Status EngineStorageMigrationTask::execute() {
 Status EngineStorageMigrationTask::_storage_migrate(TabletSharedPtr tablet) {
     bool bg_worker_stopped = ExecEnv::GetInstance()->storage_engine()->bg_worker_stopped();
     if (bg_worker_stopped) {
-        LOG(WARNING) << "Process is going to quit. The migration will be stopped.";
+        LOG(WARNING) << "Process is going to quit. The migration will stop.";
         return Status::InternalError("Process is going to quit.");
     }
 
@@ -105,17 +105,13 @@ Status EngineStorageMigrationTask::_storage_migrate(TabletSharedPtr tablet) {
         // get all versions to be migrate
         {
             std::shared_lock header_rdlock(tablet->get_header_lock());
-            const RowsetSharedPtr lastest_version = tablet->rowset_with_max_version();
-            if (lastest_version == nullptr) {
-                LOG(WARNING) << "Not found version in tablet. tablet: " << tablet->tablet_id()
-                             << ", version: " << lastest_version->start_version() << "-"
-                             << lastest_version->end_version();
-                return Status::NotFound(fmt::format("Not found version in tablet. tablet: {}, version: {}-{}",
-                                                    tablet->tablet_id(), lastest_version->start_version(),
-                                                    lastest_version->end_version()));
+            const RowsetSharedPtr max_version = tablet->rowset_with_max_version();
+            if (max_version == nullptr) {
+                LOG(WARNING) << "Not found version in tablet. tablet: " << tablet->tablet_id();
+                return Status::NotFound(fmt::format("Not found version in tablet. tablet: {}", tablet->tablet_id()));
             }
 
-            end_version = lastest_version->end_version();
+            end_version = max_version->end_version();
             res = tablet->capture_consistent_rowsets(Version(0, end_version), &consistent_rowsets);
             if (!res.ok() || consistent_rowsets.empty()) {
                 LOG(WARNING) << "Fail to capture consistent rowsets. version=" << end_version;
@@ -210,18 +206,14 @@ Status EngineStorageMigrationTask::_storage_migrate(TabletSharedPtr tablet) {
         {
             // check version
             std::shared_lock header_rdlock(tablet->get_header_lock());
-            const RowsetSharedPtr lastest_version = tablet->rowset_with_max_version();
-            if (lastest_version == nullptr) {
-                LOG(WARNING) << "Not found version in tablet. tablet: " << tablet->tablet_id()
-                             << ", version: " << lastest_version->start_version() << "-"
-                             << lastest_version->end_version();
+            const RowsetSharedPtr max_version = tablet->rowset_with_max_version();
+            if (max_version == nullptr) {
+                LOG(WARNING) << "Not found version in tablet. tablet: " << tablet->tablet_id();
                 need_remove_new_path = true;
-                res = Status::NotFound(fmt::format("Not found version in tablet. tablet: {}, version: {}-{}",
-                                                   tablet->tablet_id(), lastest_version->start_version(),
-                                                   lastest_version->end_version()));
+                res = Status::NotFound(fmt::format("Not found version in tablet. tablet: {}", tablet->tablet_id()));
                 break;
             }
-            int32_t new_end_version = lastest_version->end_version();
+            int32_t new_end_version = max_version->end_version();
             if (end_version != new_end_version) {
                 LOG(WARNING) << "Version does not match. src_version: " << end_version
                              << ", dst_version: " << new_end_version;

--- a/be/src/storage/task/engine_storage_migration_task.cpp
+++ b/be/src/storage/task/engine_storage_migration_task.cpp
@@ -66,7 +66,7 @@ Status EngineStorageMigrationTask::execute() {
 Status EngineStorageMigrationTask::_storage_migrate(TabletSharedPtr tablet) {
     bool bg_worker_stopped = ExecEnv::GetInstance()->storage_engine()->bg_worker_stopped();
     if (bg_worker_stopped) {
-        LOG(WARNING) << "Process is going to quit. The migration should be stopped as soon as possible.";
+        LOG(WARNING) << "Process is going to quit. The migration will be stopped.";
         return Status::InternalError("Process is going to quit.");
     }
 

--- a/be/src/storage/vectorized/compaction.cpp
+++ b/be/src/storage/vectorized/compaction.cpp
@@ -224,7 +224,7 @@ Status Compaction::_merge_rowsets_horizontally(size_t segment_iterator_num, Stat
     }
 
     if (ExecEnv::GetInstance()->storage_engine()->bg_worker_stopped()) {
-        return Status::InternalError("Process is going to quit. The compaction should be stopped as soon as possible.");
+        return Status::InternalError("Process is going to quit. The compaction will be stopped.");
     }
 
     if (stats_output != nullptr) {
@@ -330,8 +330,7 @@ Status Compaction::_merge_rowsets_vertically(size_t segment_iterator_num, Statis
         }
 
         if (ExecEnv::GetInstance()->storage_engine()->bg_worker_stopped()) {
-            return Status::InternalError(
-                    "Process is going to quit. The compaction should be stopped as soon as possible.");
+            return Status::InternalError("Process is going to quit. The compaction will be stopped.");
         }
 
         if (is_key && stats_output != nullptr) {
@@ -363,7 +362,7 @@ Status Compaction::_merge_rowsets_vertically(size_t segment_iterator_num, Statis
 Status Compaction::modify_rowsets() {
     bool bg_worker_stopped = ExecEnv::GetInstance()->storage_engine()->bg_worker_stopped();
     if (bg_worker_stopped) {
-        return Status::InternalError("Process is going to quit. The compaction should be stopped as soon as possible.");
+        return Status::InternalError("Process is going to quit. The compaction will be stopped.");
     }
 
     std::vector<RowsetSharedPtr> output_rowsets;

--- a/be/src/storage/vectorized/compaction.cpp
+++ b/be/src/storage/vectorized/compaction.cpp
@@ -224,7 +224,7 @@ Status Compaction::_merge_rowsets_horizontally(size_t segment_iterator_num, Stat
     }
 
     if (ExecEnv::GetInstance()->storage_engine()->bg_worker_stopped()) {
-        return Status::InternalError("Process is going to quit. The compaction will be stopped.");
+        return Status::InternalError("Process is going to quit. The compaction will stop.");
     }
 
     if (stats_output != nullptr) {
@@ -330,7 +330,7 @@ Status Compaction::_merge_rowsets_vertically(size_t segment_iterator_num, Statis
         }
 
         if (ExecEnv::GetInstance()->storage_engine()->bg_worker_stopped()) {
-            return Status::InternalError("Process is going to quit. The compaction will be stopped.");
+            return Status::InternalError("Process is going to quit. The compaction will stop.");
         }
 
         if (is_key && stats_output != nullptr) {
@@ -362,7 +362,7 @@ Status Compaction::_merge_rowsets_vertically(size_t segment_iterator_num, Statis
 Status Compaction::modify_rowsets() {
     bool bg_worker_stopped = ExecEnv::GetInstance()->storage_engine()->bg_worker_stopped();
     if (bg_worker_stopped) {
-        return Status::InternalError("Process is going to quit. The compaction will be stopped.");
+        return Status::InternalError("Process is going to quit. The compaction will stop.");
     }
 
     std::vector<RowsetSharedPtr> output_rowsets;


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4373

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When exit BE graceful, the checksum will be wrong. Under this circumstance, the calculation should return error status instead of wrong checksum