### PR TITLE
Support building PersistentIndex from pre-existing tablet data

### DIFF
--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -1128,7 +1128,7 @@ Status PersistentIndex::_build_commit(Tablet* tablet, PersistentIndexMetaPB& ind
     return status;
 }
 
-Status PersistentIndex::_upsert_rowsets(Tablet* tablet, std::vector<RowsetSharedPtr>& rowsets,
+Status PersistentIndex::_insert_rowsets(Tablet* tablet, std::vector<RowsetSharedPtr>& rowsets,
                                         const vectorized::Schema& pkey_schema, int64_t apply_version,
                                         std::unique_ptr<vectorized::Column> pk_column) {
     OlapReaderStatistics stats;
@@ -1297,7 +1297,7 @@ Status PersistentIndex::build(Tablet* tablet) {
             CHECK(false) << "create column for primary key encoder failed";
         }
     }
-    RETURN_IF_ERROR(_upsert_rowsets(tablet, rowsets, pkey_schema, apply_version, std::move(pk_column)));
+    RETURN_IF_ERROR(_insert_rowsets(tablet, rowsets, pkey_schema, apply_version, std::move(pk_column)));
     if (size() != total_rows - total_dels) {
         LOG(WARNING) << strings::Substitute("load primary index row count not match tablet:$0 index:$1 != stats:$2",
                                             tablet->tablet_id(), size(), total_rows - total_dels);

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -1119,9 +1119,6 @@ Status PersistentIndex::_build_commit(Tablet* tablet, PersistentIndexMetaPB& ind
         }
     }
 
-    std::string l0_index_file_path = _get_l0_index_file_name(_path, _version);
-    std::string l1_index_file_path = _get_l0_index_file_name(_path, _l1_version);
-    LOG(INFO) << "l0_index_file: " << l0_index_file_path << ", l1_index_file: " << l1_index_file_path;
     RETURN_IF_ERROR(_delete_expired_index_file(_version, _l1_version));
     _dump_snapshot = false;
     _flushed = false;

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -7,6 +7,12 @@
 
 #include "gutil/strings/substitute.h"
 #include "storage/fs/fs_util.h"
+#include "storage/primary_key_encoder.h"
+#include "storage/rowset/beta_rowset.h"
+#include "storage/tablet.h"
+#include "storage/tablet_meta_manager.h"
+#include "storage/tablet_updates.h"
+#include "storage/vectorized/chunk_helper.h"
 #include "util/bit_util.h"
 #include "util/coding.h"
 #include "util/crc32c.h"
@@ -657,6 +663,8 @@ public:
 
     size_t capacity() { return _map.capacity(); }
 
+    void reserve(size_t size) { _map.reserve(size); }
+
     std::vector<std::vector<KVRef>> get_kv_refs_by_shard(size_t nshard, size_t num_entry,
                                                          bool without_null) const override {
         std::vector<std::vector<KVRef>> ret(nshard);
@@ -1082,6 +1090,225 @@ Status PersistentIndex::_load(const PersistentIndexMetaPB& index_meta) {
     return Status::OK();
 }
 
+Status PersistentIndex::_build_commit(Tablet* tablet, PersistentIndexMetaPB& index_meta) {
+    // commit: flush _l0 and build _l1
+    // write PersistentIndexMetaPB in RocksDB
+    Status status = commit(&index_meta);
+    if (!status.ok()) {
+        LOG(WARNING) << "build persistent index failed because commit failed: " << status.to_string();
+        return status;
+    }
+    // write pesistent index meta
+    status = TabletMetaManager::write_persistent_index_meta(tablet->data_dir(), tablet->tablet_id(), index_meta);
+    if (!status.ok()) {
+        LOG(WARNING) << "build persistent index failed because write persistent index meta failed: "
+                     << status.to_string();
+        return status;
+    }
+
+    if (!_flushed) {
+        std::string l0_index_file_path = _get_l0_index_file_name(_path, _version);
+        std::string l0_index_file_path_tmp = l0_index_file_path + ".tmp";
+        fs::CreateBlockOptions wblock_opts({l0_index_file_path});
+        wblock_opts.mode = Env::MUST_EXIST;
+        if (_dump_snapshot) {
+            RETURN_IF_ERROR(_block_mgr->create_block(wblock_opts, &_index_block));
+        } else {
+            RETURN_IF_ERROR(Env::Default()->rename_file(l0_index_file_path_tmp, l0_index_file_path));
+            RETURN_IF_ERROR(_block_mgr->create_block(wblock_opts, &_index_block));
+        }
+    }
+
+    std::string l0_index_file_path = _get_l0_index_file_name(_path, _version);
+    std::string l1_index_file_path = _get_l0_index_file_name(_path, _l1_version);
+    LOG(INFO) << "l0_index_file: " << l0_index_file_path << ", l1_index_file: " << l1_index_file_path;
+    RETURN_IF_ERROR(_delete_expired_index_file(_version, _l1_version));
+    _dump_snapshot = false;
+    _flushed = false;
+    return status;
+}
+
+Status PersistentIndex::_upsert_rowsets(Tablet* tablet, std::vector<RowsetSharedPtr>& rowsets,
+                                        const vectorized::Schema& pkey_schema, int64_t apply_version,
+                                        std::unique_ptr<vectorized::Column> pk_column) {
+    OlapReaderStatistics stats;
+    std::vector<uint32_t> rowids;
+    rowids.reserve(4096);
+    auto chunk_shared_ptr = vectorized::ChunkHelper::new_chunk(pkey_schema, 4096);
+    auto chunk = chunk_shared_ptr.get();
+    for (auto& rowset : rowsets) {
+        RowsetReleaseGuard guard(rowset);
+        auto beta_rowset = down_cast<BetaRowset*>(rowset.get());
+        auto res =
+                beta_rowset->get_segment_iterators2(pkey_schema, tablet->data_dir()->get_meta(), apply_version, &stats);
+        if (!res.ok()) {
+            return res.status();
+        }
+        auto& itrs = res.value();
+        CHECK(itrs.size() == rowset->num_segments()) << "itrs.size != num_segments";
+        for (size_t i = 0; i < itrs.size(); i++) {
+            auto itr = itrs[i].get();
+            if (itr == nullptr) {
+                continue;
+            }
+            while (true) {
+                chunk->reset();
+                rowids.clear();
+                auto st = itr->get_next(chunk, &rowids);
+                if (st.is_end_of_file()) {
+                    break;
+                } else if (!st.ok()) {
+                    return st;
+                } else {
+                    vectorized::Column* pkc = nullptr;
+                    if (pk_column != nullptr) {
+                        pk_column->reset_column();
+                        PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, chunk->num_rows(), pk_column.get());
+                        pkc = pk_column.get();
+                    } else {
+                        pkc = chunk->columns()[0].get();
+                    }
+                    uint32_t rssid = rowset->rowset_meta()->get_rowset_seg_id() + i;
+                    uint64_t base = ((uint64_t)rssid) << 32;
+                    std::vector<IndexValue> values;
+                    values.reserve(pkc->size());
+                    DCHECK(pkc->size() <= rowids.size());
+                    for (uint32_t i = 0; i < pkc->size(); i++) {
+                        values.emplace_back(base + rowids[i]);
+                    }
+                    auto st = insert(pkc->size(), pkc->raw_data(), values.data(), false);
+
+                    if (!st.ok()) {
+                        LOG(ERROR) << "load index failed: tablet=" << tablet->tablet_id()
+                                   << " rowsets num:" << rowsets.size()
+                                   << " rowset:" << rowset->rowset_meta()->get_rowset_seg_id() << " segment:" << i
+                                   << " reason: " << st.to_string() << " current_size:" << size()
+                                   << " updates: " << tablet->updates()->debug_string();
+                        return st;
+                    }
+                }
+            }
+            itr->close();
+        }
+    }
+    return Status::OK();
+}
+
+Status PersistentIndex::build(Tablet* tablet) {
+    MonotonicStopWatch timer;
+    timer.start();
+    if (tablet->keys_type() != PRIMARY_KEYS) {
+        LOG(WARNING) << "tablet: " << tablet->tablet_id() << " is not primary key tablet";
+        return Status::NotSupported("Only PrimaryKey table is supported to use persistent index");
+    }
+
+    const TabletSchema& tablet_schema = tablet->tablet_schema();
+    vector<ColumnId> pk_columns(tablet_schema.num_key_columns());
+    for (auto i = 0; i < tablet_schema.num_key_columns(); i++) {
+        pk_columns[i] = (ColumnId)i;
+    }
+    auto pkey_schema = vectorized::ChunkHelper::convert_schema_to_format_v2(tablet_schema, pk_columns);
+    size_t fix_size = PrimaryKeyEncoder::get_encoded_fixed_size(pkey_schema);
+
+    PersistentIndexMetaPB index_meta;
+    Status status = TabletMetaManager::get_persistent_index_meta(tablet->data_dir(), tablet->tablet_id(), &index_meta);
+    if (!status.ok() && !status.is_not_found()) {
+        return Status::InternalError("get tablet persistent index meta failed");
+    }
+
+    // There are three conditions
+    // First is we do not find PersistentIndexMetaPB in TabletMeta, it maybe the first time to
+    // enable persistent index
+    // Second is we find PersistentIndexMetaPB in TabletMeta, but it's version is behind applied_version
+    // in TabletMeta. It could be happened as below:
+    //    1. Enable persistent index and apply rowset, applied_version is 1-0
+    //    2. Restart be and disable persistent index, applied_version is update to 2-0
+    //    3. Restart be and enable persistent index
+    // In this case, we don't have all rowset data in persistent index files, so we also need to rebuild it
+    // The last is we find PersistentIndexMetaPB and it's version is equal to latest applied version. In this case,
+    // we can load from index file directly
+    EditVersion lastest_applied_version;
+    tablet->updates()->get_latest_applied_version(&lastest_applied_version);
+    RETURN_IF_ERROR(create(fix_size, lastest_applied_version));
+    if (status.ok()) {
+        // all applied rowsets has save in existing persistent index meta
+        // so we can load persistent index according to PersistentIndexMetaPB
+        EditVersion version = index_meta.version();
+        if (version == lastest_applied_version) {
+            status = load(index_meta);
+            LOG(INFO) << "load persistent index #tablet:" << tablet->tablet_id() << " #version:" << version.to_string()
+                      << " #status: " << status.to_string() << " #cost_time:" << timer.elapsed_time() / 1000000 << "ms";
+            return status;
+        }
+    }
+    // Init PersistentIndexMetaPB
+    //   1. reset |version| |key_size|
+    //   2. delete WALs because maybe PersistentIndexMetaPB has expired wals
+    //   3. reset SnapshotMeta
+    //   4. write all data into new tmp _l0 index file (tmp file will be delete in _build_commit())
+    index_meta.set_key_size(_key_size);
+    lastest_applied_version.to_pb(index_meta.mutable_version());
+    MutableIndexMetaPB* l0_meta = index_meta.mutable_l0_meta();
+    l0_meta->clear_wals();
+    IndexSnapshotMetaPB* snapshot = l0_meta->mutable_snapshot();
+    lastest_applied_version.to_pb(snapshot->mutable_version());
+    PagePointerPB* data = snapshot->mutable_data();
+    data->set_offset(0);
+    data->set_size(0);
+
+    std::string l0_index_file_name = _get_l0_index_file_name(_path, _version) + ".tmp";
+    fs::CreateBlockOptions wblock_opts({l0_index_file_name});
+    wblock_opts.mode = Env::CREATE_OR_OPEN_WITH_TRUNCATE;
+    RETURN_IF_ERROR(_block_mgr->create_block(wblock_opts, &_index_block));
+
+    int64_t apply_version = 0;
+    std::vector<RowsetSharedPtr> rowsets;
+    std::vector<uint32_t> rowset_ids;
+    RETURN_IF_ERROR(tablet->updates()->_get_apply_version_and_rowsets(&apply_version, &rowsets, &rowset_ids));
+
+    size_t total_data_size = 0;
+    size_t total_segments = 0;
+    size_t total_rows = 0;
+    for (auto& rowset : rowsets) {
+        total_data_size += rowset->data_disk_size();
+        total_segments += rowset->num_segments();
+        total_rows += rowset->num_rows();
+    }
+    size_t total_rows2 = 0;
+    size_t total_dels = 0;
+    auto st = tablet->updates()->get_rowsets_total_stats(rowset_ids, &total_rows2, &total_dels);
+    if (!st.ok() || total_rows2 != total_rows) {
+        LOG(WARNING) << "load primary index get_rowsets_total_stats error: " << st;
+    }
+    DCHECK(total_rows2 == total_rows);
+    if (total_data_size > 4000000000 || total_rows > 10000000 || total_segments > 400) {
+        LOG(INFO) << "load large primary index start tablet:" << tablet->tablet_id() << " version:" << apply_version
+                  << " #rowset:" << rowsets.size() << " #segment:" << total_segments << " #row:" << total_rows << " -"
+                  << total_dels << "=" << total_rows - total_dels << " bytes:" << total_data_size;
+    }
+    if (total_rows > total_dels) {
+        _l0->reserve(total_rows - total_dels);
+    }
+
+    OlapReaderStatistics stats;
+    std::unique_ptr<vectorized::Column> pk_column;
+    if (pk_columns.size() > 1) {
+        if (!PrimaryKeyEncoder::create_column(pkey_schema, &pk_column).ok()) {
+            CHECK(false) << "create column for primary key encoder failed";
+        }
+    }
+    RETURN_IF_ERROR(_upsert_rowsets(tablet, rowsets, pkey_schema, apply_version, std::move(pk_column)));
+    if (size() != total_rows - total_dels) {
+        LOG(WARNING) << strings::Substitute("load primary index row count not match tablet:$0 index:$1 != stats:$2",
+                                            tablet->tablet_id(), size(), total_rows - total_dels);
+    }
+    RETURN_IF_ERROR(_build_commit(tablet, index_meta));
+    LOG(INFO) << "build persistent index finish tablet: " << tablet->tablet_id() << " version:" << apply_version
+              << " #rowset:" << rowsets.size() << " #segment:" << total_segments << " data_size:" << total_data_size
+              << " cost time: " << timer.elapsed_time() / 1000000 << "ms";
+    return Status::OK();
+}
+
 Status PersistentIndex::prepare(const EditVersion& version) {
     _dump_snapshot = false;
     _version = version;
@@ -1102,6 +1329,7 @@ Status PersistentIndex::abort() {
 // case3 will write a new snapshot l0
 // case4 will append wals into l0 file
 Status PersistentIndex::commit(PersistentIndexMetaPB* index_meta) {
+    DCHECK_EQ(index_meta->key_size(), _key_size);
     RETURN_IF_ERROR(_check_and_flush_l0());
     // for case1 and case2
     if (_flushed) {
@@ -1120,6 +1348,7 @@ Status PersistentIndex::commit(PersistentIndexMetaPB* index_meta) {
         // update PersistentIndexMetaPB
         VLOG(1) << "new l0 file path(flush) is " << file_name;
         index_meta->set_size(_size);
+        _version.to_pb(index_meta->mutable_version());
         _version.to_pb(index_meta->mutable_l1_version());
         MutableIndexMetaPB* l0_meta = index_meta->mutable_l0_meta();
         l0_meta->clear_wals();
@@ -1146,6 +1375,7 @@ Status PersistentIndex::commit(PersistentIndexMetaPB* index_meta) {
         }
         // update PersistentIndexMetaPB
         index_meta->set_size(_size);
+        _version.to_pb(index_meta->mutable_version());
         MutableIndexMetaPB* l0_meta = index_meta->mutable_l0_meta();
         l0_meta->clear_wals();
         IndexSnapshotMetaPB* snapshot = l0_meta->mutable_snapshot();

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -227,7 +227,7 @@ public:
     Status load(const PersistentIndexMetaPB& index_meta);
 
     // build PersistentIndex from pre-existing tablet data
-    Status build(Tablet* tablet);
+    Status load_from_tablet(Tablet* tablet);
 
     // start modification with intended version
     Status prepare(const EditVersion& version);

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -307,7 +307,7 @@ private:
     Status _build_commit(Tablet* tablet, PersistentIndexMetaPB& index_meta);
 
     // insert rowset data into persistent index
-    Status _upsert_rowsets(Tablet* tablet, std::vector<RowsetSharedPtr>& rowsets, const vectorized::Schema& pkey_schema,
+    Status _insert_rowsets(Tablet* tablet, std::vector<RowsetSharedPtr>& rowsets, const vectorized::Schema& pkey_schema,
                            int64_t apply_version, std::unique_ptr<vectorized::Column> pk_column);
 
     // index storage directory

--- a/be/src/storage/primary_key_encoder.cpp
+++ b/be/src/storage/primary_key_encoder.cpp
@@ -271,7 +271,7 @@ size_t PrimaryKeyEncoder::get_encoded_fixed_size(const vectorized::Schema& schem
     for (size_t i = 0; i < n; i++) {
         auto t = schema.field(i)->type()->type();
         if (t == OLAP_FIELD_TYPE_VARCHAR || t == OLAP_FIELD_TYPE_CHAR) {
-            return -1;
+            return 0;
         }
         ret += TabletColumn::get_field_length_by_type(t, 0);
     }

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -688,7 +688,7 @@ void TabletUpdates::_stop_and_wait_apply_done() {
     }
 }
 
-void TabletUpdates::_get_latest_applied_version(EditVersion* latest_applied_version) {
+void TabletUpdates::get_latest_applied_version(EditVersion* latest_applied_version) {
     std::lock_guard l(_lock);
     *latest_applied_version = _edit_version_infos[_apply_version_idx]->version;
 }
@@ -738,7 +738,7 @@ void TabletUpdates::_apply_rowset_commit(const EditVersionInfo& version_info) {
 
     int64_t t_load = MonotonicMillis();
     EditVersion latest_applied_version;
-    _get_latest_applied_version(&latest_applied_version);
+    get_latest_applied_version(&latest_applied_version);
     st = state.apply(&_tablet, rowset.get(), rowset_id, latest_applied_version, index);
     if (!st.ok()) {
         manager->update_state_cache().remove(state_entry);

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -18,6 +18,7 @@
 namespace starrocks {
 
 class PrimaryIndex;
+class PersistentIndex;
 class Rowset;
 using RowsetSharedPtr = std::shared_ptr<Rowset>;
 class DelVector;
@@ -155,6 +156,8 @@ public:
 
     Status load_snapshot(const SnapshotMeta& snapshot_meta);
 
+    void get_latest_applied_version(EditVersion* latest_applied_version);
+
     // Clear both in-memory cached and permanently stored meta data:
     //  - primary index
     //  - delete vectors
@@ -217,6 +220,7 @@ public:
 private:
     friend class Tablet;
     friend class PrimaryIndex;
+    friend class PersistentIndex;
     friend class RowsetUpdateState;
 
     template <typename K, typename V>
@@ -260,8 +264,6 @@ private:
     void _try_commit_pendings_unlocked();
 
     void _ignore_rowset_commit(int64_t version, const RowsetSharedPtr& rowset);
-
-    void _get_latest_applied_version(EditVersion* latest_applied_version);
 
     void _apply_rowset_commit(const EditVersionInfo& version_info);
 

--- a/be/test/storage/persistent_index_test.cpp
+++ b/be/test/storage/persistent_index_test.cpp
@@ -22,7 +22,7 @@
 #include "util/file_utils.h"
 
 namespace starrocks {
-/*
+
 PARALLEL_TEST(PersistentIndexTest, test_mutable_index) {
     using Key = uint64_t;
     vector<Key> keys;
@@ -275,7 +275,7 @@ PARALLEL_TEST(PersistentIndexTest, test_mutable_flush_to_immutable) {
     }
     ASSERT_TRUE(idx_loaded->check_not_exist(10, check_not_exist_keys.data()).ok());
 }
-*/
+
 TabletSharedPtr create_tablet(int64_t tablet_id, int32_t schema_hash) {
     TCreateTabletReq request;
     request.tablet_id = tablet_id;
@@ -352,7 +352,6 @@ void build_persistent_index_from_tablet(size_t N) {
 
     TabletSharedPtr tablet = create_tablet(rand(), rand());
     ASSERT_EQ(1, tablet->updates()->version_history_count());
-    //const int64_t N = 250000;
     std::vector<int64_t> keys(N);
     for (int64_t i = 0; i < N; ++i) {
         keys[i] = i;
@@ -415,7 +414,6 @@ void build_persistent_index_from_tablet(size_t N) {
     {
         // load data from index file
         PersistentIndex persistent_index(kPersistentIndexDir);
-        //ASSERT_TRUE(persistent_index.build(tablet.get()).ok());
         Status st = persistent_index.build(tablet.get());
         if (!st.ok()) {
             LOG(WARNING) << "build persistent index failed: " << st.to_string();
@@ -443,8 +441,11 @@ void build_persistent_index_from_tablet(size_t N) {
 }
 
 PARALLEL_TEST(PersistentIndexTest, test_build_from_tablet) {
-    //build_persistent_index_from_tablet(100000);
-    //build_persistent_index_from_tablet(250000);
+    // dump snapshot
+    build_persistent_index_from_tablet(100000);
+    // write wal
+    build_persistent_index_from_tablet(250000);
+    // flush l1
     build_persistent_index_from_tablet(1000000);
 }
 

--- a/be/test/storage/persistent_index_test.cpp
+++ b/be/test/storage/persistent_index_test.cpp
@@ -151,7 +151,7 @@ PARALLEL_TEST(PersistentIndexTest, test_mutable_index_wal) {
         version.to_pb(snapshot_meta->mutable_version());
 
         PersistentIndex index(kPersistentIndexDir);
-        ASSERT_TRUE(index.create(sizeof(Key), version).ok());
+        //ASSERT_TRUE(index.create(sizeof(Key), version).ok());
 
         ASSERT_TRUE(index.load(index_meta).ok());
         ASSERT_TRUE(index.prepare(EditVersion(1, 0)).ok());
@@ -186,7 +186,7 @@ PARALLEL_TEST(PersistentIndexTest, test_mutable_index_wal) {
     {
         // rebuild mutableindex according PersistentIndexMetaPB
         PersistentIndex new_index(kPersistentIndexDir);
-        ASSERT_TRUE(new_index.create(sizeof(Key), EditVersion(3, 0)).ok());
+        //ASSERT_TRUE(new_index.create(sizeof(Key), EditVersion(3, 0)).ok());
         ASSERT_TRUE(new_index.load(index_meta).ok());
         std::vector<IndexValue> get_values(keys.size());
 
@@ -210,7 +210,7 @@ PARALLEL_TEST(PersistentIndexTest, test_mutable_index_wal) {
     // rebuild mutableindex according to PersistentIndexMetaPB
     {
         PersistentIndex index(kPersistentIndexDir);
-        ASSERT_TRUE(index.create(sizeof(Key), EditVersion(4, 0)).ok());
+        //ASSERT_TRUE(index.create(sizeof(Key), EditVersion(4, 0)).ok());
         ASSERT_TRUE(index.load(index_meta).ok());
         std::vector<IndexValue> get_values(keys.size());
 
@@ -391,7 +391,7 @@ void build_persistent_index_from_tablet(size_t N) {
     const std::vector<ColumnUniquePtr>& upserts = state.upserts();
 
     PersistentIndex persistent_index(kPersistentIndexDir);
-    ASSERT_TRUE(persistent_index.build(tablet.get()).ok());
+    ASSERT_TRUE(persistent_index.load_from_tablet(tablet.get()).ok());
 
     // check data in persistent index
     for (size_t i = 0; i < upserts.size(); ++i) {
@@ -414,7 +414,7 @@ void build_persistent_index_from_tablet(size_t N) {
     {
         // load data from index file
         PersistentIndex persistent_index(kPersistentIndexDir);
-        Status st = persistent_index.build(tablet.get());
+        Status st = persistent_index.load_from_tablet(tablet.get());
         if (!st.ok()) {
             LOG(WARNING) << "build persistent index failed: " << st.to_string();
             ASSERT_TRUE(false);

--- a/be/test/storage/persistent_index_test.cpp
+++ b/be/test/storage/persistent_index_test.cpp
@@ -7,7 +7,14 @@
 #include "env/env_memory.h"
 #include "storage/fs/file_block_manager.h"
 #include "storage/fs/fs_util.h"
+#include "storage/rowset/beta_rowset.h"
+#include "storage/rowset/rowset_factory.h"
+#include "storage/rowset/rowset_writer.h"
+#include "storage/rowset/rowset_writer_context.h"
+#include "storage/rowset_update_state.h"
 #include "storage/storage_engine.h"
+#include "storage/update_manager.h"
+#include "storage/vectorized/chunk_helper.h"
 #include "testutil/assert.h"
 #include "testutil/parallel_test.h"
 #include "util/coding.h"
@@ -15,7 +22,7 @@
 #include "util/file_utils.h"
 
 namespace starrocks {
-
+/*
 PARALLEL_TEST(PersistentIndexTest, test_mutable_index) {
     using Key = uint64_t;
     vector<Key> keys;
@@ -267,6 +274,178 @@ PARALLEL_TEST(PersistentIndexTest, test_mutable_flush_to_immutable) {
         check_not_exist_keys[i] = N + i;
     }
     ASSERT_TRUE(idx_loaded->check_not_exist(10, check_not_exist_keys.data()).ok());
+}
+*/
+TabletSharedPtr create_tablet(int64_t tablet_id, int32_t schema_hash) {
+    TCreateTabletReq request;
+    request.tablet_id = tablet_id;
+    request.__set_version(1);
+    request.__set_version_hash(0);
+    request.tablet_schema.schema_hash = schema_hash;
+    request.tablet_schema.short_key_column_count = 6;
+    request.tablet_schema.keys_type = TKeysType::PRIMARY_KEYS;
+    request.tablet_schema.storage_type = TStorageType::COLUMN;
+
+    TColumn k1;
+    k1.column_name = "pk";
+    k1.__set_is_key(true);
+    k1.column_type.type = TPrimitiveType::BIGINT;
+    request.tablet_schema.columns.push_back(k1);
+
+    TColumn k2;
+    k2.column_name = "v1";
+    k2.__set_is_key(false);
+    k2.column_type.type = TPrimitiveType::SMALLINT;
+    request.tablet_schema.columns.push_back(k2);
+
+    TColumn k3;
+    k3.column_name = "v2";
+    k3.__set_is_key(false);
+    k3.column_type.type = TPrimitiveType::INT;
+    request.tablet_schema.columns.push_back(k3);
+    auto st = StorageEngine::instance()->create_tablet(request);
+    CHECK(st.ok()) << st.to_string();
+    return StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, false);
+}
+
+RowsetSharedPtr create_rowset(const TabletSharedPtr& tablet, const vector<int64_t>& keys,
+                              vectorized::Column* one_delete = nullptr) {
+    RowsetWriterContext writer_context(kDataFormatV2, config::storage_format_version);
+    RowsetId rowset_id = StorageEngine::instance()->next_rowset_id();
+    writer_context.rowset_id = rowset_id;
+    writer_context.tablet_id = tablet->tablet_id();
+    writer_context.tablet_schema_hash = tablet->schema_hash();
+    writer_context.partition_id = 0;
+    writer_context.rowset_type = BETA_ROWSET;
+    writer_context.rowset_path_prefix = tablet->schema_hash_path();
+    writer_context.rowset_state = COMMITTED;
+    writer_context.tablet_schema = &tablet->tablet_schema();
+    writer_context.version.first = 0;
+    writer_context.version.second = 0;
+    writer_context.segments_overlap = NONOVERLAPPING;
+    std::unique_ptr<RowsetWriter> writer;
+    EXPECT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &writer).ok());
+    auto schema = vectorized::ChunkHelper::convert_schema(tablet->tablet_schema());
+    auto chunk = vectorized::ChunkHelper::new_chunk(schema, keys.size());
+    auto& cols = chunk->columns();
+    size_t size = keys.size();
+    for (size_t i = 0; i < size; i++) {
+        cols[0]->append_datum(vectorized::Datum(keys[i]));
+        cols[1]->append_datum(vectorized::Datum((int16_t)(keys[i] % size + 1)));
+        cols[2]->append_datum(vectorized::Datum((int32_t)(keys[i] % size + 2)));
+    }
+    if (one_delete == nullptr && !keys.empty()) {
+        CHECK_OK(writer->flush_chunk(*chunk));
+    } else if (one_delete == nullptr) {
+        CHECK_OK(writer->flush());
+    } else if (one_delete != nullptr) {
+        CHECK_OK(writer->flush_chunk_with_deletes(*chunk, *one_delete));
+    }
+    return *writer->build();
+}
+
+void build_persistent_index_from_tablet(size_t N) {
+    Env* env = Env::Default();
+    const std::string kPersistentIndexDir = "./ut_dir/persistent_index_test";
+    bool created;
+    ASSERT_OK(env->create_dir_if_missing(kPersistentIndexDir, &created));
+
+    TabletSharedPtr tablet = create_tablet(rand(), rand());
+    ASSERT_EQ(1, tablet->updates()->version_history_count());
+    //const int64_t N = 250000;
+    std::vector<int64_t> keys(N);
+    for (int64_t i = 0; i < N; ++i) {
+        keys[i] = i;
+    }
+
+    RowsetSharedPtr rowset = create_rowset(tablet, keys);
+    auto pool = StorageEngine::instance()->update_manager()->apply_thread_pool();
+    auto version = 2;
+    auto st = tablet->rowset_commit(version, rowset);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    // Ensure that there is at most one thread doing the version apply job.
+    ASSERT_LE(pool->num_threads(), 1);
+    ASSERT_EQ(version, tablet->updates()->max_version());
+    ASSERT_EQ(version, tablet->updates()->version_history_count());
+    // call `get_applied_rowsets` to wait rowset apply finish
+    std::vector<RowsetSharedPtr> rowsets;
+    EditVersion full_edit_version;
+    ASSERT_TRUE(tablet->updates()->get_applied_rowsets(version, &rowsets, &full_edit_version).ok());
+
+    auto manager = StorageEngine::instance()->update_manager();
+    auto index_entry = manager->index_cache().get_or_create(tablet->tablet_id());
+    index_entry->update_expire_time(MonotonicMillis() + manager->get_cache_expire_ms());
+    auto& primary_index = index_entry->value();
+    st = primary_index.load(tablet.get());
+    if (!st.ok()) {
+        LOG(WARNING) << "load primary index from tablet failed";
+        ASSERT_TRUE(false);
+    }
+
+    RowsetUpdateState state;
+    st = state.load(tablet.get(), rowset.get());
+    if (!st.ok()) {
+        LOG(WARNING) << "failed to load rowset update state: " << st.to_string();
+        ASSERT_TRUE(false);
+    }
+    using ColumnUniquePtr = std::unique_ptr<vectorized::Column>;
+    const std::vector<ColumnUniquePtr>& upserts = state.upserts();
+
+    PersistentIndex persistent_index(kPersistentIndexDir);
+    ASSERT_TRUE(persistent_index.build(tablet.get()).ok());
+
+    // check data in persistent index
+    for (size_t i = 0; i < upserts.size(); ++i) {
+        auto& pks = *upserts[i];
+
+        std::vector<uint64_t> primary_results;
+        std::vector<uint64_t> persistent_results;
+        primary_results.resize(pks.size());
+        persistent_results.resize(pks.size());
+        primary_index.get(pks, &primary_results);
+        persistent_index.get(pks.size(), pks.raw_data(), persistent_results.data());
+        ASSERT_EQ(primary_results.size(), persistent_results.size());
+        for (size_t j = 0; j < primary_results.size(); ++j) {
+            ASSERT_EQ(primary_results[i], persistent_results[i]);
+        }
+        primary_results.clear();
+        persistent_results.clear();
+    }
+
+    {
+        // load data from index file
+        PersistentIndex persistent_index(kPersistentIndexDir);
+        //ASSERT_TRUE(persistent_index.build(tablet.get()).ok());
+        Status st = persistent_index.build(tablet.get());
+        if (!st.ok()) {
+            LOG(WARNING) << "build persistent index failed: " << st.to_string();
+            ASSERT_TRUE(false);
+        }
+        for (size_t i = 0; i < upserts.size(); ++i) {
+            auto& pks = *upserts[i];
+            std::vector<uint64_t> primary_results;
+            std::vector<uint64_t> persistent_results;
+            primary_results.resize(pks.size());
+            persistent_results.resize(pks.size());
+            primary_index.get(pks, &primary_results);
+            persistent_index.get(pks.size(), pks.raw_data(), persistent_results.data());
+            ASSERT_EQ(primary_results.size(), persistent_results.size());
+            for (size_t j = 0; j < primary_results.size(); ++j) {
+                ASSERT_EQ(primary_results[i], persistent_results[i]);
+            }
+            primary_results.clear();
+            persistent_results.clear();
+        }
+    }
+
+    manager->index_cache().release(index_entry);
+    ASSERT_TRUE(FileUtils::remove_all(kPersistentIndexDir).ok());
+}
+
+PARALLEL_TEST(PersistentIndexTest, test_build_from_tablet) {
+    //build_persistent_index_from_tablet(100000);
+    //build_persistent_index_from_tablet(250000);
+    build_persistent_index_from_tablet(1000000);
 }
 
 } // namespace starrocks


### PR DESCRIPTION
support building PersistentIndex from pre-existing tablet data

## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [x] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3950

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered, and what measures have you taken to fix the bug?) -->

PersistentIndex should be built from the tablet's rowset data; there are two conditions:
+ BE is upgraded from versions without PersistentIndex support
+ In some scenarios, the index may be corrupt due to bugs or other issues, so rebuilding from original data is also required.
