### PR TITLE
[cherry-pick] [branch 2.2] BugFix: Memory leak of rowsetid and stack overflow in copy_file

### DIFF
--- a/be/src/storage/rowset/beta_rowset.cpp
+++ b/be/src/storage/rowset/beta_rowset.cpp
@@ -41,6 +41,7 @@
 #include "storage/vectorized/merge_iterator.h"
 #include "storage/vectorized/projection_iterator.h"
 #include "storage/vectorized/union_iterator.h"
+#include "util/file_utils.h"
 
 namespace starrocks {
 
@@ -158,7 +159,7 @@ Status BetaRowset::copy_files_to(const std::string& dir) {
             return Status::AlreadyExist(fmt::format("Path already exist: {}", dst_path));
         }
         std::string src_path = segment_file_path(_rowset_path, rowset_id(), i);
-        if (!copy_file(src_path, dst_path).ok()) {
+        if (!FileUtils::copy_file(src_path, dst_path).ok()) {
             LOG(WARNING) << "Error to copy file. src:" << src_path << ", dst:" << dst_path << ", errno=" << Errno::no();
             return Status::IOError(fmt::format("Error to copy file. src: {}, dst: {}, error:{} ", src_path, dst_path,
                                                std::strerror(Errno::no())));
@@ -172,7 +173,7 @@ Status BetaRowset::copy_files_to(const std::string& dir) {
                 LOG(WARNING) << "Path already exist: " << dst_path;
                 return Status::AlreadyExist(fmt::format("Path already exist: {}", dst_path));
             }
-            if (!copy_file(src_path, dst_path).ok()) {
+            if (!FileUtils::copy_file(src_path, dst_path).ok()) {
                 LOG(WARNING) << "Error to copy file. src:" << src_path << ", dst:" << dst_path
                              << ", errno=" << Errno::no();
                 return Status::IOError(fmt::format("Error to copy file. src: {}, dst: {}, error:{} ", src_path,

--- a/be/src/storage/rowset/beta_rowset_writer.cpp
+++ b/be/src/storage/rowset/beta_rowset_writer.cpp
@@ -222,6 +222,8 @@ HorizontalBetaRowsetWriter::~HorizontalBetaRowsetWriter() {
                 LOG_IF(WARNING, !st.ok()) << "Fail to delete file=" << path << ", " << st.to_string();
             }
         }
+        // if _already_built is false, we need to release rowset_id to avoid rowset_id leak
+        StorageEngine::instance()->release_rowset_id(_context.rowset_id);
     }
 }
 
@@ -547,6 +549,8 @@ VerticalBetaRowsetWriter::~VerticalBetaRowsetWriter() {
             auto st = _context.env->delete_file(path);
             LOG_IF(WARNING, !st.ok()) << "Fail to delete file=" << path << ", " << st.to_string();
         }
+        // if _already_built is false, we need to release rowset_id to avoid rowset_id leak
+        StorageEngine::instance()->release_rowset_id(_context.rowset_id);
     }
 }
 

--- a/be/src/storage/utils.cpp
+++ b/be/src/storage/utils.cpp
@@ -116,56 +116,6 @@ Status move_to_trash(const std::filesystem::path& file_path) {
     return st;
 }
 
-Status copy_file(const string& src, const string& dest) {
-    int src_fd = -1;
-    int dest_fd = -1;
-    char buf[1024 * 1024];
-    Status res = Status::OK();
-
-    src_fd = ::open(src.c_str(), O_RDONLY);
-    if (src_fd < 0) {
-        PLOG(WARNING) << "Not found file: " << src;
-        res = Status::NotFound(fmt::format("Not found file: {}", src));
-        goto COPY_EXIT;
-    }
-
-    dest_fd = ::open(dest.c_str(), O_WRONLY | O_CREAT, S_IRUSR | S_IWUSR);
-    if (dest_fd < 0) {
-        PLOG(WARNING) << "Not found file: " << dest;
-        res = Status::NotFound(fmt::format("Not found file: {}", dest));
-        goto COPY_EXIT;
-    }
-
-    while (true) {
-        ssize_t rd_size = ::read(src_fd, buf, sizeof(buf));
-        if (rd_size < 0) {
-            res = Status::IOError(fmt::format("Error to read file: {}, error:{} ", src, std::strerror(Errno::no())));
-            goto COPY_EXIT;
-        } else if (0 == rd_size) {
-            break;
-        }
-
-        ssize_t wr_size = ::write(dest_fd, buf, rd_size);
-        if (wr_size != rd_size) {
-            res = Status::IOError(fmt::format("Error to write file: {}, error:{} ", dest, std::strerror(Errno::no())));
-            goto COPY_EXIT;
-        }
-    }
-
-COPY_EXIT:
-    if (src_fd >= 0) {
-        ::close(src_fd);
-    }
-
-    if (dest_fd >= 0) {
-        ::close(dest_fd);
-    }
-
-    VLOG(3) << "copy file success. [src=" << src << " dest=" << dest << "]";
-
-    return res;
-}
-
 Status read_write_test_file(const string& test_file_path) {
     if (access(test_file_path.c_str(), F_OK) == 0) {
         if (remove(test_file_path.c_str()) != 0) {

--- a/be/src/storage/utils.h
+++ b/be/src/storage/utils.h
@@ -73,8 +73,6 @@ Status gen_timestamp_string(std::string* out_string);
 // move file to storage_root/trash, file can be a directory
 Status move_to_trash(const std::filesystem::path& tablet_id_path);
 
-Status copy_file(const std::string& src, const std::string& dest);
-
 Status copy_dir(const std::string& src_dir, const std::string& dst_dir);
 
 bool check_datapath_rw(const std::string& path);

--- a/be/src/storage/vectorized/delta_writer.cpp
+++ b/be/src/storage/vectorized/delta_writer.cpp
@@ -37,8 +37,9 @@ DeltaWriter::~DeltaWriter() {
     switch (_get_state()) {
     case kUninitialized:
     case kCommitted:
+    case kInitialized:
         break;
-    case kWriting:
+    case kPrepared:
     case kClosed:
     case kAborted:
         _garbage_collection();
@@ -68,7 +69,7 @@ Status DeltaWriter::_init() {
     TabletManager* tablet_mgr = _storage_engine->tablet_manager();
     _tablet = tablet_mgr->get_tablet(_opt.tablet_id, false);
     if (_tablet == nullptr) {
-        _set_state(kAborted);
+        _set_state(kUninitialized);
         std::stringstream ss;
         ss << "Fail to get tablet. tablet_id=" << _opt.tablet_id;
         LOG(WARNING) << ss.str();
@@ -77,7 +78,7 @@ Status DeltaWriter::_init() {
     if (_tablet->updates() != nullptr) {
         auto tracker = _storage_engine->update_manager()->mem_tracker();
         if (tracker->limit_exceeded()) {
-            _set_state(kAborted);
+            _set_state(kUninitialized);
             auto msg = Substitute(
                     "Primary-key index exceeds the limit. tablet_id: $0, consumption: $1, limit: $2."
                     " Memory stats of top five tablets: $3",
@@ -87,14 +88,14 @@ Status DeltaWriter::_init() {
             return Status::MemoryLimitExceeded(msg);
         }
         if (_tablet->updates()->is_error()) {
-            _set_state(kAborted);
+            _set_state(kUninitialized);
             auto msg = fmt::format("Tablet is in error state. This is a primary key table. tablet_id: {}",
                                    _tablet->tablet_id());
             return Status::ServiceUnavailable(msg);
         }
     }
     if (_tablet->version_count() > config::tablet_max_versions) {
-        _set_state(kAborted);
+        _set_state(kUninitialized);
         auto msg = fmt::format("Too many versions. tablet_id: {}, version_count: {}, limit: {}", _opt.tablet_id,
                                _tablet->version_count(), config::tablet_max_versions);
         LOG(ERROR) << msg;
@@ -120,13 +121,6 @@ Status DeltaWriter::_init() {
                 _tablet = new_tablet;
                 continue;
             }
-        }
-
-        std::lock_guard push_lock(_tablet->get_push_lock());
-        Status st = _storage_engine->txn_manager()->prepare_txn(_opt.partition_id, _tablet, _opt.txn_id, _opt.load_id);
-        if (!st.ok()) {
-            _set_state(kAborted);
-            return st;
         }
         break;
     }
@@ -172,7 +166,7 @@ Status DeltaWriter::_init() {
     writer_context.global_dicts = _opt.global_dicts;
     Status st = RowsetFactory::create_rowset_writer(writer_context, &_rowset_writer);
     if (!st.ok()) {
-        _set_state(kAborted);
+        _set_state(kUninitialized);
         auto msg = strings::Substitute("Fail to create rowset writer. tablet_id: $0, error: $1", _opt.tablet_id,
                                        st.to_string());
         LOG(WARNING) << msg;
@@ -182,12 +176,11 @@ Status DeltaWriter::_init() {
     _tablet_schema = writer_context.tablet_schema;
     _reset_mem_table();
     _flush_token = _storage_engine->memtable_flush_executor()->create_flush_token();
-    _set_state(kWriting);
+    _set_state(kInitialized);
     return Status::OK();
 }
 
-Status DeltaWriter::write(const Chunk& chunk, const uint32_t* indexes, uint32_t from, uint32_t size) {
-    SCOPED_THREAD_LOCAL_MEM_SETTER(_mem_tracker, false);
+Status DeltaWriter::_prepare() {
     Status st;
     auto state = _get_state();
     switch (state) {
@@ -196,26 +189,44 @@ Status DeltaWriter::write(const Chunk& chunk, const uint32_t* indexes, uint32_t 
     case kAborted:
     case kClosed:
         return Status::InternalError(
-                fmt::format("Fail to write delta. tablet_id: {}, state: {}", _opt.tablet_id, _state_name(state)));
-    case kWriting:
-        bool full = _mem_table->insert(chunk, indexes, from, size);
-        if (_mem_tracker->limit_exceeded()) {
-            VLOG(2) << "Flushing memory table due to memory limit exceeded";
-            st = _flush_memtable();
-            _reset_mem_table();
-        } else if (_mem_tracker->parent() && _mem_tracker->parent()->limit_exceeded()) {
-            VLOG(2) << "Flushing memory table due to parent memory limit exceeded";
-            st = _flush_memtable();
-            _reset_mem_table();
-        } else if (full) {
-            st = _flush_memtable_async();
-            _reset_mem_table();
-        }
+                fmt::format("Fail to prepare. tablet_id: {}, state: {}", _opt.tablet_id, _state_name(state)));
+    case kPrepared:
+        return Status::OK();
+    case kInitialized: {
+        std::shared_lock base_migration_rlock(_tablet->get_migration_lock());
+        std::lock_guard push_lock(_tablet->get_push_lock());
+        st = _storage_engine->txn_manager()->prepare_txn(_opt.partition_id, _tablet, _opt.txn_id, _opt.load_id);
         if (!st.ok()) {
             _set_state(kAborted);
+            return st;
         }
+        _set_state(kPrepared);
+    } break;
     }
     return Status::OK();
+}
+
+Status DeltaWriter::write(const Chunk& chunk, const uint32_t* indexes, uint32_t from, uint32_t size) {
+    SCOPED_THREAD_LOCAL_MEM_SETTER(_mem_tracker, false);
+    RETURN_IF_ERROR(_prepare());
+    Status st;
+    bool full = _mem_table->insert(chunk, indexes, from, size);
+    if (_mem_tracker->limit_exceeded()) {
+        VLOG(2) << "Flushing memory table due to memory limit exceeded";
+        st = _flush_memtable();
+        _reset_mem_table();
+    } else if (_mem_tracker->parent() && _mem_tracker->parent()->limit_exceeded()) {
+        VLOG(2) << "Flushing memory table due to parent memory limit exceeded";
+        st = _flush_memtable();
+        _reset_mem_table();
+    } else if (full) {
+        st = _flush_memtable_async();
+        _reset_mem_table();
+    }
+    if (!st.ok()) {
+        _set_state(kAborted);
+    }
+    return st;
 }
 
 Status DeltaWriter::close() {
@@ -230,7 +241,10 @@ Status DeltaWriter::close() {
                                                  _state_name(state)));
     case kClosed:
         return Status::OK();
-    case kWriting:
+    case kInitialized:
+        _set_state(kClosed);
+        return st;
+    case kPrepared:
         st = _flush_memtable_async();
         _set_state(st.ok() ? kClosed : kAborted);
         return st;
@@ -258,8 +272,9 @@ Status DeltaWriter::commit() {
     auto state = _get_state();
     switch (state) {
     case kUninitialized:
+    case kInitialized:
     case kAborted:
-    case kWriting:
+    case kPrepared:
         return Status::InternalError(fmt::format("Fail to commit delta writer. tablet_id: {}, state: {}",
                                                  _opt.tablet_id, _state_name(state)));
     case kCommitted:
@@ -323,10 +338,12 @@ const char* DeltaWriter::_state_name(State state) const {
     switch (state) {
     case kUninitialized:
         return "kUninitialized";
+    case kInitialized:
+        return "kInitialized";
     case kAborted:
         return "kAborted";
-    case kWriting:
-        return "kWriting";
+    case kPrepared:
+        return "kPrepared";
     case kCommitted:
         return "kCommitted";
     case kClosed:

--- a/be/src/storage/vectorized/delta_writer.h
+++ b/be/src/storage/vectorized/delta_writer.h
@@ -89,7 +89,8 @@ public:
 private:
     enum State {
         kUninitialized,
-        kWriting,
+        kInitialized,
+        kPrepared,
         kClosed,
         kAborted,
         kCommitted, // committed state can transfer to kAborted state
@@ -98,6 +99,7 @@ private:
     DeltaWriter(const DeltaWriterOptions& opt, MemTracker* parent, StorageEngine* storage_engine);
 
     Status _init();
+    Status _prepare();
     Status _flush_memtable_async();
     Status _flush_memtable();
     const char* _state_name(State state) const;


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4277 #4292 #4279

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

BugFix:
+ Memory leak of rowset_id
   + Rowset id cache will leak in some scenarios:

        + allocate rowset id success, but create rowset writer failed
        +  create rowset writer success, but no data written
             ....
        Anyway, if allocate rowset id success, but does not generate rowset_ptr, we don't release the rowset_id, resulting in a memory leak.

        In addition, when we do load data, we create a delta_writer for each tablet in advance, but only a few of the delta_writer may have data written to them. This speeds up memory leak and output a lot of useless rollback logs in be.INFO

+ Stack overflow in `copy_file`
   + The stack memory limit set by the operating system can be changed using ulimit -s and allocate memoy greater or equal to the stack memory limit will cause be crash. If stack memory limit is no more than 1MB, be will crash because try to alloc 1MB stack memory in function copy_files. We should not alloc large memory in stack, alloc memory from heap to solve this problem. This code is duplicated with function copy_file in utils/file_utils.cpp, merge the two copy_file function in utils/file_utils.cpp and storage/utils.cpp

