### PR TITLE
Fix aggregate node not set local aggregation when global aggregate node and scan node is in the same plan fragment

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1172,9 +1172,6 @@ public class PlanFragmentBuilder {
                     aggregationNode =
                             new AggregationNode(context.getNextNodeId(), inputFragment.getPlanRoot(),
                                     aggInfo);
-                    if (hasColocateOlapScanChildInFragment(aggregationNode)) {
-                        aggregationNode.setColocate(true);
-                    }
                 } else {
                     aggregateExprList.forEach(FunctionCallExpr::setMergeAggFn);
                     AggregateInfo aggInfo = AggregateInfo.create(
@@ -1185,6 +1182,10 @@ public class PlanFragmentBuilder {
                     aggregationNode =
                             new AggregationNode(context.getNextNodeId(), inputFragment.getPlanRoot(),
                                     aggInfo);
+                }
+                // set aggregate node can use local aggregate
+                if (hasColocateOlapScanChildInFragment(aggregationNode)) {
+                    aggregationNode.setColocate(true);
                 }
 
                 // set predicate

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestBase.java
@@ -878,6 +878,10 @@ public class PlanTestBase {
         }
     }
 
+    public ExecPlan getExecPlan(String sql) throws Exception {
+        return UtFrameUtils.getPlanAndFragment(connectContext, sql).second;
+    }
+
     public String getFragmentPlan(String sql) throws Exception {
         String s = UtFrameUtils.getPlanAndFragment(connectContext, sql).second.
                 getExplainString(TExplainLevel.NORMAL);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4342 


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
In PR #4343 
we generate one stage plan for get right result, but the wrong plan is still in plan search space, we need to ensure the local agg can be set right even if the multi stage aggregate plan has been choosen(eg, use session variable new_planner_agg_stage)