### PR TITLE
Fixup role match in classifier of resource_group

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/WorkGroupMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/WorkGroupMgr.java
@@ -119,8 +119,11 @@ public class WorkGroupMgr implements Writable {
                 //default_cluster:test
                 String[] userParts = qualifiedUser.split(":");
                 String user = userParts[userParts.length - 1];
-                String roleName = Catalog.getCurrentCatalog().getAuth()
+                String qualifiedRoleName = Catalog.getCurrentCatalog().getAuth()
                         .getRoleName(ConnectContext.get().getCurrentUserIdentity());
+                //default_cluster:role
+                String[] roleParts = qualifiedRoleName.split(":");
+                String roleName = roleParts[roleParts.length - 1];
                 String remoteIp = ConnectContext.get().getRemoteIP();
                 return workGroupList.stream().map(w -> w.showVisible(user, roleName, remoteIp))
                         .flatMap(Collection::stream).collect(Collectors.toList());

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/WorkGroupMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/WorkGroupMgr.java
@@ -119,13 +119,18 @@ public class WorkGroupMgr implements Writable {
                 //default_cluster:test
                 String[] userParts = qualifiedUser.split(":");
                 String user = userParts[userParts.length - 1];
+
+                String roleName = null;
                 String qualifiedRoleName = Catalog.getCurrentCatalog().getAuth()
                         .getRoleName(ConnectContext.get().getCurrentUserIdentity());
-                //default_cluster:role
-                String[] roleParts = qualifiedRoleName.split(":");
-                String roleName = roleParts[roleParts.length - 1];
+                if (qualifiedRoleName != null) {
+                    //default_cluster:role
+                    String[] roleParts = qualifiedRoleName.split(":");
+                    roleName = roleParts[roleParts.length - 1];
+                }
+                String role = roleName;
                 String remoteIp = ConnectContext.get().getRemoteIP();
-                return workGroupList.stream().map(w -> w.showVisible(user, roleName, remoteIp))
+                return workGroupList.stream().map(w -> w.showVisible(user, role, remoteIp))
                         .flatMap(Collection::stream).collect(Collectors.toList());
             }
         } finally {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
https://github.com/StarRocks/starrocks/issues/4381
## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When matching roleName to role condition of resource group classifier, use simple role name instead of qualified role name.