### PR TITLE
fix: extract object field in json array

### DIFF
--- a/be/src/exprs/vectorized/jsonpath.cpp
+++ b/be/src/exprs/vectorized/jsonpath.cpp
@@ -17,6 +17,7 @@
 #include "glog/logging.h"
 #include "gutil/strings/split.h"
 #include "gutil/strings/substitute.h"
+#include "util/json.h"
 #include "velocypack/vpack.h"
 
 namespace starrocks::vectorized {
@@ -198,7 +199,9 @@ vpack::Slice JsonPathPiece::extract(vpack::Slice root, const std::vector<JsonPat
                 vpack::ArrayBuilder ab(builder);
                 array_selector->iterate(next_item, [&](vpack::Slice array_item) {
                     auto sub = extract(array_item, jsonpath, i + 1, builder);
-                    builder->add(sub);
+                    if (!sub.isNone()) {
+                        builder->add(sub);
+                    }
                 });
             }
             return builder->slice();


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Fix: `parse_json('[{"k1": 1}, {"k2": 2}}]' -> '$[*].k1`

