### PR TITLE
merge null column of result column with null columns of operands

### DIFF
--- a/be/src/exprs/vectorized/arithmetic_expr.cpp
+++ b/be/src/exprs/vectorized/arithmetic_expr.cpp
@@ -98,7 +98,7 @@ public:
         auto r = _children[1]->evaluate(context, ptr);
 
         if constexpr (pt_is_decimal<Type>) {
-            using VectorizedDiv = VectorizedUnstrictDecimalBinaryFunction<Type, ModOp, false>;
+            using VectorizedDiv = VectorizedUnstrictDecimalBinaryFunction<Type, ModOp, true>;
             return VectorizedDiv::template evaluate<Type>(l, r);
         } else {
             using RightZeroCheck = ArithmeticRightZeroCheck<Type>;

--- a/be/src/exprs/vectorized/binary_function.h
+++ b/be/src/exprs/vectorized/binary_function.h
@@ -172,8 +172,10 @@ public:
 
         ColumnPtr data_result = FN::template evaluate<LType, RType, ResultType>(data1, data2);
         if (v1->has_null() || v2->has_null()) {
+            // two NOT-nullable column can generate a {nullable, not-nullable, const, const-null} column
+            // because when decimal overflow checking is enabled, overflow results will yield NULL.
             NullColumnPtr null_flags = FunctionHelper::union_nullable_column(v1, v2);
-            return NullableColumn::create(std::move(data_result), std::move(null_flags));
+            return FunctionHelper::merge_column_and_null_column(std::move(data_result), std::move(null_flags));
         } else {
             return data_result;
         }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

When overflow check is enable, decimal arithmetic applying two not-nullable columns can also yield a nullable column, const-null column,  and const column. so in UnionNullableColumnBinaryFunction::evaluate function, the two not-nullable column yields a not-nullable column assumption is violated,  so we must merge NullColumn of operands with NullColumn of result.