### PR TITLE
Get hive column statistics downgrade policy

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaClient.java
@@ -48,6 +48,7 @@ import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.hadoop.utils.HoodieInputFormatUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.thrift.transport.TTransportException;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -357,6 +358,8 @@ public class HiveMetaClient {
         List<Partition> partitions;
         try (AutoCloseClient client = getClient()) {
             partitions = client.hiveClient.getPartitionsByNames(dbName, tableName, partNames);
+        } catch (TTransportException te) {
+            partitions = getPartitionsWithRetry(dbName, tableName, partNames, 1);
         } catch (Exception e) {
             LOG.warn("get table level column stats for partition table failed", e);
             throw new DdlException("get partitions from hive metastore failed: " + e.getMessage());
@@ -490,6 +493,45 @@ public class HiveMetaClient {
         }
 
         return result;
+    }
+
+    /**
+     * When the query scans many partitions in the table or the 'hive.metastore.try.direct.sql' in
+     * hive metastore is false. The hive metastore will throw StackOverFlow exception.
+     * We solve this problem by get partitions information multiple times.
+     * Each retry reduces the number of partitions fetched by half until only one partition is fetched at a time.
+     * @return Hive table partitions
+     * @throws DdlException If there is an exception with only one partition at a time when get partition,
+     * then we determine that there is a bug with the user's hive metastore.
+     */
+    private List<Partition> getPartitionsWithRetry(String dbName, String tableName,
+                                                   List<String> partNames, int retryNum) throws DdlException {
+        int subListSize = (int) Math.pow(2, retryNum);
+        int subListNum = partNames.size() / subListSize;
+        List<List<String>> partNamesList = Lists.partition(partNames, subListNum);
+        List<Partition> partitions = Lists.newArrayList();
+
+        LOG.warn("Execute getPartitionsByNames on [{}.{}] with {} times retry, slice size is {}, partName size is {}",
+                dbName, tableName, retryNum, subListSize, partNames.size());
+
+        try (AutoCloseClient client = getClient()) {
+            for (List<String> parts : partNamesList) {
+                partitions.addAll(client.hiveClient.getPartitionsByNames(dbName, tableName, parts));
+            }
+            LOG.info("Succeed to getPartitionByName on [{}.{}] with {} times retry, slice size is {}, partName size is {}",
+                    dbName, tableName, retryNum, subListSize, partNames.size());
+            return partitions;
+        } catch (TTransportException te) {
+            if (subListNum > 1) {
+                return getPartitionsWithRetry(dbName, tableName, partNames, retryNum + 1);
+            } else {
+                throw new DdlException(String.format("" +
+                        "Failed to getPartitionsByNames on [%s.%s] with slice size is %d", dbName, tableName, subListNum));
+            }
+        } catch (Exception e) {
+            throw new DdlException(String.format("Failed to getPartitionsNames on [%s.%s], msg: %s",
+                    dbName, tableName, e.getMessage()));
+        }
     }
 
     private boolean isStringType(String hiveType) {


### PR DESCRIPTION
## What type of PR is this：
- [ ] enhancement

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
When the `hive.metastore.try.direct.sql` is false in user's hive metastore and query scan many partitions. the hive metastore will throw stack overflow exception. we could this problem by get partitions information multiple times. 
![image](https://user-images.githubusercontent.com/91597003/159904640-4410366f-fce5-4f05-8c07-c2ce659215a3.png)
![image](https://user-images.githubusercontent.com/91597003/159905134-e7312e60-6b58-474d-8973-e5b0ee867d59.png)


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The user could set 'hive.metastore.try.direct.sql' to true to solve this problem. and also could inncrease the parameter value of -Xss in hive metastore startup options.