### PR TITLE
IcebergScanNode support split files

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
@@ -22,6 +22,7 @@ import com.starrocks.thrift.TPlanNodeType;
 import com.starrocks.thrift.TScanRange;
 import com.starrocks.thrift.TScanRangeLocation;
 import com.starrocks.thrift.TScanRangeLocations;
+import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.Snapshot;
@@ -144,31 +145,33 @@ public class IcebergScanNode extends ScanNode {
             return;
         }
         preProcessConjuncts();
-        for (FileScanTask task : IcebergUtil.getTableScan(
+        for (CombinedScanTask combinedScanTask : IcebergUtil.getTableScan(
                 srIcebergTable.getIcebergTable(), snapshot.get(),
-                icebergPredicates, true).planFiles()) {
-            DataFile file = task.file();
-            LOG.debug("Scan with file " + file.path() + ", file record count " + file.recordCount());
+                icebergPredicates, true).planTasks()) {
+            for (FileScanTask task : combinedScanTask.files()) {
+                DataFile file = task.file();
+                LOG.debug("Scan with file " + file.path() + ", file record count " + file.recordCount());
 
-            TScanRangeLocations scanRangeLocations = new TScanRangeLocations();
+                TScanRangeLocations scanRangeLocations = new TScanRangeLocations();
 
-            THdfsScanRange hdfsScanRange = new THdfsScanRange();
-            hdfsScanRange.setFull_path(file.path().toString());
-            hdfsScanRange.setOffset(task.start());
-            hdfsScanRange.setLength(task.length());
-            // For iceberg table we do not need partition id
-            hdfsScanRange.setPartition_id(-1);
-            hdfsScanRange.setFile_length(file.fileSizeInBytes());
-            hdfsScanRange.setFile_format(IcebergUtil.getHdfsFileFormat(file.format()).toThrift());
-            TScanRange scanRange = new TScanRange();
-            scanRange.setHdfs_scan_range(hdfsScanRange);
-            scanRangeLocations.setScan_range(scanRange);
+                THdfsScanRange hdfsScanRange = new THdfsScanRange();
+                hdfsScanRange.setFull_path(file.path().toString());
+                hdfsScanRange.setOffset(task.start());
+                hdfsScanRange.setLength(task.length());
+                // For iceberg table we do not need partition id
+                hdfsScanRange.setPartition_id(-1);
+                hdfsScanRange.setFile_length(file.fileSizeInBytes());
+                hdfsScanRange.setFile_format(IcebergUtil.getHdfsFileFormat(file.format()).toThrift());
+                TScanRange scanRange = new TScanRange();
+                scanRange.setHdfs_scan_range(hdfsScanRange);
+                scanRangeLocations.setScan_range(scanRange);
 
-            // TODO: get hdfs block location information for scheduling, use iceberg meta cache
-            TScanRangeLocation scanRangeLocation = new TScanRangeLocation(new TNetworkAddress("-1", -1));
-            scanRangeLocations.addToLocations(scanRangeLocation);
+                // TODO: get hdfs block location information for scheduling, use iceberg meta cache
+                TScanRangeLocation scanRangeLocation = new TScanRangeLocation(new TNetworkAddress("-1", -1));
+                scanRangeLocations.addToLocations(scanRangeLocation);
 
-            result.add(scanRangeLocations);
+                result.add(scanRangeLocations);
+            }
         }
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
IcebergScanNode support split files. The default value of iceberg split size is 128MB. user can modify this value by execute 'alter table set properties'. the params key is 'read.split.target-size'.
## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
