### PR TITLE
[WIP] change default dop strategy in pipeline engine

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -32,6 +32,7 @@ import com.starrocks.common.TreeNode;
 import com.starrocks.common.UserException;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.statistics.ColumnDict;
+import com.starrocks.system.BackendCoreStat;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.thrift.TGlobalDict;
 import com.starrocks.thrift.TNetworkAddress;
@@ -41,7 +42,6 @@ import com.starrocks.thrift.TResultSinkType;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.jcodings.util.Hash;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -141,6 +141,7 @@ public class PlanFragment extends TreeNode<PlanFragment> {
     protected List<Pair<Integer, ColumnDict>> queryGlobalDicts = Lists.newArrayList();
     protected List<Pair<Integer, ColumnDict>> loadGlobalDicts = Lists.newArrayList();
     private Set<Integer> hashJoinNodeIds = Sets.newHashSet();
+
     /**
      * C'tor for fragment with specific partition; the output is by default broadcast.
      */
@@ -153,7 +154,6 @@ public class PlanFragment extends TreeNode<PlanFragment> {
         // when dop adaptation is enabled, parallelExecNum and pipelineDop set to degreeOfParallelism and 1 respectively
         // in default. these values just a hint to help determine numInstances and pipelineDop of a PlanFragment.
         setParallelExecNumIfExists();
-        setPipelineDopIfPipelineEngineEnabled();
         setFragmentInPlanTree(planRoot);
     }
 
@@ -162,7 +162,7 @@ public class PlanFragment extends TreeNode<PlanFragment> {
      * Does not traverse the children of ExchangeNodes because those must belong to a
      * different fragment.
      */
-    public void setFragmentInPlanTree(PlanNode node) {
+    private void setFragmentInPlanTree(PlanNode node) {
         if (node == null) {
             return;
         }
@@ -183,18 +183,54 @@ public class PlanFragment extends TreeNode<PlanFragment> {
      * Assign ParallelExecNum by PARALLEL_FRAGMENT_EXEC_INSTANCE_NUM in SessionVariable for synchronous request
      * Assign ParallelExecNum by default value for Asynchronous request
      */
-    public void setParallelExecNumIfExists() {
+    private void setParallelExecNumIfExists() {
         if (ConnectContext.get() != null) {
-            int pipelineDop = ConnectContext.get().getSessionVariable().getPipelineDop();
             int instanceNum = ConnectContext.get().getSessionVariable().getParallelExecInstanceNum();
-            int degreeOfParallelism = ConnectContext.get().getSessionVariable().getDegreeOfParallelism();
 
             if (ConnectContext.get().getSessionVariable().isEnablePipelineEngine()) {
-                parallelExecNum = pipelineDop > 0 ? instanceNum : degreeOfParallelism;
+                // In pipeline engine, we prefer inter-pipeline parallelism to inter-fragment parallelism
+                // So in default case, instanceNum should be 1, and DOP should be cores/2
+                int pipelineDop = ConnectContext.get().getSessionVariable().getPipelineDop();
+                if (pipelineDop > 0) {
+                    this.parallelExecNum = instanceNum;
+                    this.pipelineDop = pipelineDop;
+                } else {
+                    this.parallelExecNum = 1;
+                    this.pipelineDop = BackendCoreStat.getDefaultDOP();
+                }
             } else {
-                parallelExecNum = instanceNum;
+                this.parallelExecNum = instanceNum;
+                this.pipelineDop = 1;
             }
         }
+    }
+
+    /**
+     * Adapt dop according to number of backends and number of instances
+     *
+     * @param numBackends  total number of backends
+     * @param numInstances total number of fragment instances
+     */
+    public void adaptPipelineDop(int numBackends, int numInstances) {
+        Preconditions.checkState(ConnectContext.get() != null &&
+                ConnectContext.get().getSessionVariable().isPipelineDopAdaptionEnabled() &&
+                getPlanRoot().canUsePipeLine());
+
+        int degreeOfParallelism = ConnectContext.get().getSessionVariable().getDegreeOfParallelism();
+        this.pipelineDop = Math.max(1, degreeOfParallelism / Math.max(1, numInstances / Math.max(1, numBackends)));
+        this.parallelExecNum = degreeOfParallelism / pipelineDop;
+    }
+
+    public void preferInstanceParallel() {
+        this.parallelExecNum = BackendCoreStat.getDefaultDOP();
+        this.pipelineDop = 1;
+        this.dopEstimated = true;
+    }
+
+    public void preferPipelineParallel() {
+        this.parallelExecNum = 1;
+        this.pipelineDop = BackendCoreStat.getDefaultDOP();
+        this.dopEstimated = true;
     }
 
     public ExchangeNode getDestNode() {
@@ -216,24 +252,8 @@ public class PlanFragment extends TreeNode<PlanFragment> {
         this.parallelExecNum = parallelExecNum;
     }
 
-    public void setPipelineDopIfPipelineEngineEnabled() {
-        if (ConnectContext.get() == null || !ConnectContext.get().getSessionVariable().isEnablePipelineEngine()) {
-            return;
-        }
-        int dop = ConnectContext.get().getSessionVariable().getPipelineDop();
-        this.pipelineDop = dop > 0 ? dop : 1;
-    }
-
-    public void setPipelineDop(int dop) {
-        this.pipelineDop = dop;
-    }
-
     public int getPipelineDop() {
         return pipelineDop;
-    }
-
-    public void setDopEstimated() {
-        dopEstimated = true;
     }
 
     public void computeLocalRfWaitingSet(PlanNode root, boolean clearGlobalRuntimeFilter) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -1162,10 +1162,8 @@ public class Coordinator {
                 }
 
                 if (dopAdaptionEnabled) {
-                    int degreeOfParallelism = ConnectContext.get().getSessionVariable().getDegreeOfParallelism();
                     Preconditions.checkArgument(leftMostNode instanceof ExchangeNode);
                     maxParallelism = hostSet.size();
-                    fragment.setPipelineDop(degreeOfParallelism);
                 }
 
                 // AddAll() soft copy()
@@ -1254,13 +1252,10 @@ public class Coordinator {
                 }
                 // ensure numInstances * pipelineDop = degreeOfParallelism when dop adaptation is enabled
                 if (dopAdaptionEnabled && fragment.isNeedsLocalShuffle()) {
-                    int degreeOfParallelism = ConnectContext.get().getSessionVariable().getDegreeOfParallelism();
                     FragmentExecParams param = fragmentExecParamsMap.get(fragment.getFragmentId());
                     int numBackends = param.scanRangeAssignment.size();
                     int numInstances = param.instanceExecParams.size();
-                    int pipelineDop =
-                            Math.max(1, degreeOfParallelism / Math.max(1, numInstances / Math.max(1, numBackends)));
-                    param.fragment.setPipelineDop(pipelineDop);
+                    param.fragment.adaptPipelineDop(numBackends, numInstances);
                 }
             }
 
@@ -1460,11 +1455,7 @@ public class Coordinator {
                 params.fragment.getPlanRoot().canUsePipeLine();
         // ensure numInstances * pipelineDop = degreeOfParallelism when dop adaptation is enabled
         if (dopAdaptionEnabled && params.fragment.isNeedsLocalShuffle()) {
-            int numInstances = params.instanceExecParams.size();
-            int numBackends = addressToScanRanges.size();
-            int degreeOfParallelism = ConnectContext.get().getSessionVariable().getDegreeOfParallelism();
-            int pipelineDop = Math.max(1, degreeOfParallelism / Math.max(1, numInstances / numBackends));
-            params.fragment.setPipelineDop(pipelineDop);
+            params.fragment.adaptPipelineDop(addressToScanRanges.size(), params.instanceExecParams.size());
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -616,8 +616,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
             if (pipelineDop > 0) {
                 return pipelineDop * parallelExecInstanceNum;
             }
-            int avgNumOfCores = BackendCoreStat.getAvgNumOfHardwareCoresOfBe();
-            return avgNumOfCores < 2 ? 1 : avgNumOfCores / 2;
+            return BackendCoreStat.getDefaultDOP();
         } else {
             return parallelExecInstanceNum;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1496,9 +1496,7 @@ public class PlanFragmentBuilder {
             if (!isDopAutoEstimate() || fragment.isDopEstimated()) {
                 return;
             }
-            fragment.setPipelineDop(fragment.getParallelExecNum());
-            fragment.setParallelExecNum(1);
-            fragment.setDopEstimated();
+            fragment.preferPipelineParallel();
         }
 
         /**
@@ -1511,9 +1509,7 @@ public class PlanFragmentBuilder {
             if (!isDopAutoEstimate() || fragment.isDopEstimated()) {
                 return;
             }
-            fragment.setPipelineDop(fragment.getParallelExecNum());
-            fragment.setParallelExecNum(1);
-            fragment.setDopEstimated();
+            fragment.preferPipelineParallel();
         }
 
         /**
@@ -1526,8 +1522,7 @@ public class PlanFragmentBuilder {
             if (!isDopAutoEstimate() || fragment.isDopEstimated()) {
                 return;
             }
-            // To prevent ancestor nodes from adjusting parallelExecNum and pipelineDop.
-            fragment.setDopEstimated();
+            fragment.preferInstanceParallel();
         }
 
         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/system/BackendCoreStat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/BackendCoreStat.java
@@ -37,4 +37,9 @@ public class BackendCoreStat {
         cachedAvgNumOfHardwareCores.compareAndSet(snapshotAvg, newAvg);
         return newAvg;
     }
+
+    public static int getDefaultDOP() {
+        int avgNumOfCores = BackendCoreStat.getAvgNumOfHardwareCoresOfBe();
+        return Math.max(1, avgNumOfCores / 2);
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Change calculation of pipeline dop and fragment instances when `dop=0`
1. Set `fragmentInstances=1`
2. Pipeline dop is set to `cores/2`

Original value of `fragmentInstances` is `cores/2`, which also make `dop=1`, and miss the opportunity of inter-pipeline parallelism. 

This issue is significant when local merge operator participates, which could merge multiple pipelines into one at local. E.g a simple query `select * from t0 order by a`. But  it could work at inter-pipeline parallelism, not inter-fragment parallelism. 


## Effect
For query `select * from order by x`, with `dop=0, parallel_fragment_exec_instance_num=1` and one 20-core backend:
1. Before,  plan contains 10 fragment instances of partition sort and local merge, in which local merge has no contribution to the plan
2. After, plan consists of 1 fragment instance of local merge, and 10 pipelines of partition sort, in which local merge could reduce the runs of sorting


