### PR TITLE
make analyze manager thread pool as a static field

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeManager.java
@@ -35,11 +35,11 @@ public class AnalyzeManager implements Writable {
 
     private final Map<Long, AnalyzeJob> analyzeJobMap;
 
-    private ExecutorService executor;
+    private static final ExecutorService executor =
+            ThreadPoolManager.newDaemonFixedThreadPool(1, 16, "analyze-replay-pool", true);
 
     public AnalyzeManager() {
         analyzeJobMap = Maps.newConcurrentMap();
-        executor = ThreadPoolManager.newDaemonFixedThreadPool(1, 16, "analyze-replay-pool", true);
     }
 
     public void addAnalyzeJob(AnalyzeJob job) {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
Fixes #4438

## Problem Summary(Required) ：

Analyze Manager will be create in Catalog. when FE do checkpoint, Analyze Manager will be create multimes.
So FE may create multiple thread pool. which may cause a thread leak.
