### PR TITLE
Profile add metrics

### DIFF
--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -355,7 +355,7 @@ Status ExchangeSinkOperator::prepare(RuntimeState* state) {
             },
             "");
     _network_timer = ADD_TIMER(_unique_metrics, "NetworkTime");
-    _network_wait_timer = ADD_TIMER(_unique_metrics, "NetworkWaitTime");
+    _exchange_timer = ADD_TIMER(_unique_metrics, "ExchangeTime");
 
     for (auto& _channel : _channels) {
         RETURN_IF_ERROR(_channel->init(state));
@@ -535,7 +535,7 @@ Status ExchangeSinkOperator::set_finishing(RuntimeState* state) {
 
 void ExchangeSinkOperator::close(RuntimeState* state) {
     COUNTER_SET(_network_timer, _buffer->network_time());
-    COUNTER_SET(_network_wait_timer, _buffer->network_wait_time());
+    COUNTER_SET(_exchange_timer, _buffer->lifecycle_time());
     Operator::close(state);
 }
 

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -220,7 +220,9 @@ Status ExchangeSinkOperator::Channel::send_one_chunk(const vectorized::Chunk* ch
         _parent->construct_brpc_attachment(_chunk_request, attachment);
         TransmitChunkInfo info = {this->_fragment_instance_id, _brpc_stub, std::move(_chunk_request), attachment};
         _parent->_buffer->add_request(info);
-        COUNTER_UPDATE(_parent->_request_sent_counter, 1);
+        if (!info.attachment.empty()) {
+            COUNTER_UPDATE(_parent->_request_sent_counter, 1);
+        }
         _current_request_bytes = 0;
         _chunk_request.reset();
         *is_real_sent = true;
@@ -239,7 +241,9 @@ Status ExchangeSinkOperator::Channel::send_chunk_request(PTransmitChunkParamsPtr
 
     TransmitChunkInfo info = {this->_fragment_instance_id, _brpc_stub, std::move(chunk_request), attachment};
     _parent->_buffer->add_request(info);
-    COUNTER_UPDATE(_parent->_request_sent_counter, 1);
+    if (!info.attachment.empty()) {
+        COUNTER_UPDATE(_parent->_request_sent_counter, 1);
+    }
 
     return Status::OK();
 }

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -355,7 +355,7 @@ Status ExchangeSinkOperator::prepare(RuntimeState* state) {
             },
             "");
     _network_timer = ADD_TIMER(_unique_metrics, "NetworkTime");
-    _exchange_timer = ADD_TIMER(_unique_metrics, "ExchangeTime");
+    _wait_timer = ADD_TIMER(_unique_metrics, "WaitTime");
 
     for (auto& _channel : _channels) {
         RETURN_IF_ERROR(_channel->init(state));
@@ -535,7 +535,7 @@ Status ExchangeSinkOperator::set_finishing(RuntimeState* state) {
 
 void ExchangeSinkOperator::close(RuntimeState* state) {
     COUNTER_SET(_network_timer, _buffer->network_time());
-    COUNTER_SET(_exchange_timer, _buffer->lifecycle_time());
+    COUNTER_SET(_wait_timer, _buffer->wait_time());
     Operator::close(state);
 }
 

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -220,9 +220,6 @@ Status ExchangeSinkOperator::Channel::send_one_chunk(const vectorized::Chunk* ch
         _parent->construct_brpc_attachment(_chunk_request, attachment);
         TransmitChunkInfo info = {this->_fragment_instance_id, _brpc_stub, std::move(_chunk_request), attachment};
         _parent->_buffer->add_request(info);
-        if (!info.attachment.empty()) {
-            COUNTER_UPDATE(_parent->_request_sent_counter, 1);
-        }
         _current_request_bytes = 0;
         _chunk_request.reset();
         *is_real_sent = true;
@@ -241,9 +238,6 @@ Status ExchangeSinkOperator::Channel::send_chunk_request(PTransmitChunkParamsPtr
 
     TransmitChunkInfo info = {this->_fragment_instance_id, _brpc_stub, std::move(chunk_request), attachment};
     _parent->_buffer->add_request(info);
-    if (!info.attachment.empty()) {
-        COUNTER_UPDATE(_parent->_request_sent_counter, 1);
-    }
 
     return Status::OK();
 }
@@ -348,21 +342,11 @@ Status ExchangeSinkOperator::prepare(RuntimeState* state) {
     srand(reinterpret_cast<uint64_t>(this));
     std::shuffle(_channel_indices.begin(), _channel_indices.end(), std::mt19937(std::random_device()()));
 
-    _request_sent_counter = ADD_COUNTER(_unique_metrics, "RequestSent", TUnit::UNIT);
-    _bytes_sent_counter = ADD_COUNTER(_unique_metrics, "BytesSent", TUnit::BYTES);
     _bytes_pass_through_counter = ADD_COUNTER(_unique_metrics, "BytesPassThrough", TUnit::BYTES);
     _uncompressed_bytes_counter = ADD_COUNTER(_unique_metrics, "UncompressedBytes", TUnit::BYTES);
     _serialize_batch_timer = ADD_TIMER(_unique_metrics, "SerializeBatchTime");
     _shuffle_hash_timer = ADD_TIMER(_unique_metrics, "ShuffleHashTime");
     _compress_timer = ADD_TIMER(_unique_metrics, "CompressTime");
-    _overall_throughput = _unique_metrics->add_derived_counter(
-            "OverallThroughput", TUnit::BYTES_PER_SECOND,
-            [capture0 = _bytes_sent_counter, capture1 = _total_timer] {
-                return RuntimeProfile::units_per_second(capture0, capture1);
-            },
-            "");
-    _network_timer = ADD_TIMER(_unique_metrics, "NetworkTime");
-    _wait_timer = ADD_TIMER(_unique_metrics, "WaitTime");
 
     for (auto& _channel : _channels) {
         RETURN_IF_ERROR(_channel->init(state));
@@ -541,8 +525,7 @@ Status ExchangeSinkOperator::set_finishing(RuntimeState* state) {
 }
 
 void ExchangeSinkOperator::close(RuntimeState* state) {
-    COUNTER_SET(_network_timer, _buffer->network_time());
-    COUNTER_SET(_wait_timer, _buffer->wait_time());
+    _buffer->update_profile(_unique_metrics.get());
     Operator::close(state);
 }
 
@@ -597,7 +580,6 @@ Status ExchangeSinkOperator::serialize_chunk(const vectorized::Chunk* src, Chunk
     size_t chunk_size = dst->data().size();
     VLOG_ROW << "chunk data size " << chunk_size;
 
-    COUNTER_UPDATE(_bytes_sent_counter, chunk_size * num_receivers);
     COUNTER_UPDATE(_uncompressed_bytes_counter, uncompressed_size * num_receivers);
     return Status::OK();
 }

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -355,6 +355,7 @@ Status ExchangeSinkOperator::prepare(RuntimeState* state) {
             },
             "");
     _network_timer = ADD_TIMER(_unique_metrics, "NetworkTime");
+    _network_wait_timer = ADD_TIMER(_unique_metrics, "NetworkWaitTime");
 
     for (auto& _channel : _channels) {
         RETURN_IF_ERROR(_channel->init(state));
@@ -534,6 +535,7 @@ Status ExchangeSinkOperator::set_finishing(RuntimeState* state) {
 
 void ExchangeSinkOperator::close(RuntimeState* state) {
     COUNTER_SET(_network_timer, _buffer->network_time());
+    COUNTER_SET(_network_wait_timer, _buffer->network_wait_time());
     Operator::close(state);
 }
 

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.h
@@ -125,7 +125,7 @@ private:
     // Throughput per total time spent in sender
     RuntimeProfile::Counter* _overall_throughput = nullptr;
     RuntimeProfile::Counter* _network_timer = nullptr;
-    RuntimeProfile::Counter* _network_wait_timer = nullptr;
+    RuntimeProfile::Counter* _exchange_timer = nullptr;
 
     std::atomic<bool> _is_finished = false;
     std::atomic<bool> _is_cancelled = false;

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.h
@@ -118,6 +118,7 @@ private:
     RuntimeProfile::Counter* _serialize_batch_timer = nullptr;
     RuntimeProfile::Counter* _shuffle_hash_timer = nullptr;
     RuntimeProfile::Counter* _compress_timer = nullptr;
+    RuntimeProfile::Counter* _request_sent_counter = nullptr;
     RuntimeProfile::Counter* _bytes_sent_counter = nullptr;
     RuntimeProfile::Counter* _bytes_pass_through_counter = nullptr;
     RuntimeProfile::Counter* _uncompressed_bytes_counter = nullptr;

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.h
@@ -118,15 +118,8 @@ private:
     RuntimeProfile::Counter* _serialize_batch_timer = nullptr;
     RuntimeProfile::Counter* _shuffle_hash_timer = nullptr;
     RuntimeProfile::Counter* _compress_timer = nullptr;
-    RuntimeProfile::Counter* _request_sent_counter = nullptr;
-    RuntimeProfile::Counter* _bytes_sent_counter = nullptr;
     RuntimeProfile::Counter* _bytes_pass_through_counter = nullptr;
     RuntimeProfile::Counter* _uncompressed_bytes_counter = nullptr;
-
-    // Throughput per total time spent in sender
-    RuntimeProfile::Counter* _overall_throughput = nullptr;
-    RuntimeProfile::Counter* _network_timer = nullptr;
-    RuntimeProfile::Counter* _wait_timer = nullptr;
 
     std::atomic<bool> _is_finished = false;
     std::atomic<bool> _is_cancelled = false;

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.h
@@ -125,7 +125,7 @@ private:
     // Throughput per total time spent in sender
     RuntimeProfile::Counter* _overall_throughput = nullptr;
     RuntimeProfile::Counter* _network_timer = nullptr;
-    RuntimeProfile::Counter* _exchange_timer = nullptr;
+    RuntimeProfile::Counter* _wait_timer = nullptr;
 
     std::atomic<bool> _is_finished = false;
     std::atomic<bool> _is_cancelled = false;

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.h
@@ -125,6 +125,7 @@ private:
     // Throughput per total time spent in sender
     RuntimeProfile::Counter* _overall_throughput = nullptr;
     RuntimeProfile::Counter* _network_timer = nullptr;
+    RuntimeProfile::Counter* _network_wait_timer = nullptr;
 
     std::atomic<bool> _is_finished = false;
     std::atomic<bool> _is_cancelled = false;

--- a/be/src/exec/pipeline/exchange/sink_buffer.h
+++ b/be/src/exec/pipeline/exchange/sink_buffer.h
@@ -56,11 +56,18 @@ public:
     // among all destinations as the overall network time
     int64_t network_time();
 
+    // Roughly estimate network wait time
+    // For simplicity, we just sum the network wait time for each destination, and pick the maximum one
+    // among all destinations as the overall network wait time
+    int64_t network_wait_time();
+
     // When all the ExchangeSinkOperator shared this SinkBuffer are cancelled,
     // the rest chunk request and EOS request needn't be sent anymore.
     void cancel_one_sinker();
 
 private:
+    void _update_network_wait_start_timestamp(const TUniqueId& instance_id);
+    void _update_network_wait_time(const TUniqueId& instance_id);
     void _update_network_time(const TUniqueId& instance_id, const int64_t send_timestamp,
                               const int64_t receive_timestamp);
     // Update the discontinuous acked window, here are the invariants:
@@ -100,7 +107,9 @@ private:
     phmap::flat_hash_map<int64_t, std::queue<TransmitChunkInfo, std::list<TransmitChunkInfo>>> _buffers;
     phmap::flat_hash_map<int64_t, int32_t> _num_finished_rpcs;
     phmap::flat_hash_map<int64_t, int32_t> _num_in_flight_rpcs;
-    phmap::flat_hash_map<int64_t, int64_t> _network_time;
+    phmap::flat_hash_map<int64_t, int64_t> _network_times;
+    phmap::flat_hash_map<int64_t, int64_t> _network_wait_times;
+    phmap::flat_hash_map<int64_t, int64_t> _network_wait_start_timestamps;
     phmap::flat_hash_map<int64_t, std::unique_ptr<std::mutex>> _mutexes;
 
     // True means that SinkBuffer needn't input chunk and send chunk anymore,

--- a/be/src/exec/pipeline/exchange/sink_buffer.h
+++ b/be/src/exec/pipeline/exchange/sink_buffer.h
@@ -61,12 +61,15 @@ public:
     // among all destinations as the overall network time
     int64_t network_time();
 
-    // Roughly estimate whole lifecycle time
+    // Roughly estimate whole wait time including
+    // 1. the time waiting in the queue
+    // 2. the network time
+    // 3. the processing time at the receiving side
     // For each destination, we may send multiply packages at the same time,
     // but it's hard to calculate the actual average concurrency. So, for simplicity,
-    // we just sum the lifecycle time for each destination, and pick the maximum one
-    // among all destinations as the overall lifecycle time
-    int64_t lifecycle_time();
+    // we just sum the wait time for each destination, and pick the maximum one
+    // among all destinations as the overall wait time
+    int64_t wait_time();
 
     // When all the ExchangeSinkOperator shared this SinkBuffer are cancelled,
     // the rest chunk request and EOS request needn't be sent anymore.
@@ -113,7 +116,7 @@ private:
     phmap::flat_hash_map<int64_t, int32_t> _num_finished_rpcs;
     phmap::flat_hash_map<int64_t, int32_t> _num_in_flight_rpcs;
     phmap::flat_hash_map<int64_t, int64_t> _network_times;
-    phmap::flat_hash_map<int64_t, int64_t> _lifecycle_times;
+    phmap::flat_hash_map<int64_t, int64_t> _wait_times;
     phmap::flat_hash_map<int64_t, std::unique_ptr<std::mutex>> _mutexes;
 
     // True means that SinkBuffer needn't input chunk and send chunk anymore,

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -41,10 +41,10 @@ static void setup_profile_hierarchy(RuntimeState* runtime_state, const PipelineP
 
 static void setup_profile_hierarchy(const PipelinePtr& pipeline, const DriverPtr& driver) {
     pipeline->runtime_profile()->add_child(driver->runtime_profile(), true, nullptr);
-    auto* dop_counter = pipeline->runtime_profile()->add_counter("DegreeOfParallelism", TUnit::UNIT);
-    dop_counter->set(static_cast<int64_t>(pipeline->source_operator_factory()->degree_of_parallelism()));
-    auto* total_dop_counter = pipeline->runtime_profile()->add_counter("TotalDegreeOfParallelism", TUnit::UNIT);
-    total_dop_counter->set(dop_counter->value());
+    auto* dop_counter = ADD_COUNTER(pipeline->runtime_profile(), "DegreeOfParallelism", TUnit::UNIT);
+    COUNTER_SET(dop_counter, static_cast<int64_t>(pipeline->source_operator_factory()->degree_of_parallelism()));
+    auto* total_dop_counter = ADD_COUNTER(pipeline->runtime_profile(), "TotalDegreeOfParallelism", TUnit::UNIT);
+    COUNTER_SET(total_dop_counter, dop_counter->value());
     auto& operators = driver->operators();
     for (int32_t i = operators.size() - 1; i >= 0; --i) {
         auto& curr_op = operators[i];

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -41,8 +41,10 @@ static void setup_profile_hierarchy(RuntimeState* runtime_state, const PipelineP
 
 static void setup_profile_hierarchy(const PipelinePtr& pipeline, const DriverPtr& driver) {
     pipeline->runtime_profile()->add_child(driver->runtime_profile(), true, nullptr);
-    auto* counter = pipeline->runtime_profile()->add_counter("DegreeOfParallelism", TUnit::UNIT);
-    counter->set(static_cast<int64_t>(pipeline->source_operator_factory()->degree_of_parallelism()));
+    auto* dop_counter = pipeline->runtime_profile()->add_counter("DegreeOfParallelism", TUnit::UNIT);
+    dop_counter->set(static_cast<int64_t>(pipeline->source_operator_factory()->degree_of_parallelism()));
+    auto* total_dop_counter = pipeline->runtime_profile()->add_counter("TotalDegreeOfParallelism", TUnit::UNIT);
+    total_dop_counter->set(dop_counter->value());
     auto& operators = driver->operators();
     for (int32_t i = operators.size() - 1; i >= 0; --i) {
         auto& curr_op = operators[i];

--- a/be/src/exec/pipeline/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/olap_chunk_source.cpp
@@ -42,6 +42,12 @@ Status OlapChunkSource::prepare(RuntimeState* state) {
     _slots = &tuple_desc->slots();
 
     _runtime_profile->add_info_string("Table", tuple_desc->table_desc()->name());
+    if (thrift_olap_scan_node.__isset.rollup_name) {
+        _runtime_profile->add_info_string("Rollup", thrift_olap_scan_node.rollup_name);
+    }
+    if (thrift_olap_scan_node.__isset.sql_predicates) {
+        _runtime_profile->add_info_string("Predicates", thrift_olap_scan_node.sql_predicates);
+    }
 
     _init_counter(state);
 

--- a/be/src/exec/pipeline/sort/partition_sort_sink_operator.h
+++ b/be/src/exec/pipeline/sort/partition_sort_sink_operator.h
@@ -89,7 +89,7 @@ public:
     PartitionSortSinkOperatorFactory(
             int32_t id, int32_t plan_node_id, std::shared_ptr<SortContextFactory> sort_context_factory,
             SortExecExprs& sort_exec_exprs, std::vector<bool> is_asc_order, std::vector<bool> is_null_first,
-            int64_t offset, int64_t limit, const std::vector<OrderByType>& order_by_types,
+            const std::string& sort_keys, int64_t offset, int64_t limit, const std::vector<OrderByType>& order_by_types,
             TupleDescriptor* materialized_tuple_desc, const RowDescriptor& parent_node_row_desc,
             const RowDescriptor& parent_node_child_row_desc, const std::vector<ExprContext*>& analytic_partition_exprs)
             : OperatorFactory(id, "partition_sort_sink", plan_node_id),
@@ -97,6 +97,7 @@ public:
               _sort_exec_exprs(sort_exec_exprs),
               _is_asc_order(is_asc_order),
               _is_null_first(is_null_first),
+              _sort_keys(sort_keys),
               _offset(offset),
               _limit(limit),
               _order_by_types(order_by_types),
@@ -118,6 +119,7 @@ private:
     SortExecExprs& _sort_exec_exprs;
     std::vector<bool> _is_asc_order;
     std::vector<bool> _is_null_first;
+    const std::string _sort_keys;
     int64_t _offset;
     int64_t _limit;
     const std::vector<OrderByType>& _order_by_types;

--- a/be/src/exec/vectorized/analytor.cpp
+++ b/be/src/exec/vectorized/analytor.cpp
@@ -90,6 +90,13 @@ Status Analytor::prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile* 
     _pool = pool;
     _runtime_profile = runtime_profile;
     _limit = _tnode.limit;
+    // add profile attributes
+    if (_tnode.analytic_node.__isset.sql_partition_keys) {
+        _runtime_profile->add_info_string("PartitionKeys", _tnode.analytic_node.sql_partition_keys);
+    }
+    if (_tnode.analytic_node.__isset.sql_aggregate_functions) {
+        _runtime_profile->add_info_string("AggregateFunctions", _tnode.analytic_node.sql_aggregate_functions);
+    }
     _rows_returned_counter = ADD_COUNTER(_runtime_profile, "RowsReturned", TUnit::UNIT);
     _mem_pool = std::make_unique<MemPool>();
 

--- a/be/src/exec/vectorized/chunk_sorter_heapsorter.cpp
+++ b/be/src/exec/vectorized/chunk_sorter_heapsorter.cpp
@@ -239,9 +239,9 @@ int HeapChunkSorter::_filter_data(detail::ChunkHolder* chunk_holder, int row_sz)
     return chunk_holder->value()->chunk->filter(filter);
 }
 
-void HeapChunkSorter::setup_runtime(RuntimeProfile* profile, const std::string& parent_profile) {
-    ChunksSorter::setup_runtime(profile, parent_profile);
-    _sort_filter_costs = ADD_CHILD_TIMER(profile, "SortFilterCost", parent_profile);
+void HeapChunkSorter::setup_runtime(RuntimeProfile* profile) {
+    ChunksSorter::setup_runtime(profile);
+    _sort_filter_costs = ADD_TIMER(profile, "SortFilterCost");
     _sort_filter_rows = ADD_COUNTER(profile, "SortFilterRows", TUnit::UNIT);
 }
 

--- a/be/src/exec/vectorized/chunk_sorter_heapsorter.h
+++ b/be/src/exec/vectorized/chunk_sorter_heapsorter.h
@@ -213,8 +213,9 @@ class HeapChunkSorter final : public ChunksSorter {
 public:
     using DataSegmentPtr = std::shared_ptr<DataSegment>;
     HeapChunkSorter(RuntimeState* state, const std::vector<ExprContext*>* sort_exprs, const std::vector<bool>* is_asc,
-                    const std::vector<bool>* is_null_first, size_t offset, size_t limit, size_t size_of_chunk_batch)
-            : ChunksSorter(state, sort_exprs, is_asc, is_null_first, size_of_chunk_batch),
+                    const std::vector<bool>* is_null_first, const std::string& sort_keys, size_t offset, size_t limit,
+                    size_t size_of_chunk_batch)
+            : ChunksSorter(state, sort_exprs, is_asc, is_null_first, sort_keys, true, size_of_chunk_batch),
               _offset(offset),
               _limit(limit) {}
     ~HeapChunkSorter() = default;
@@ -234,7 +235,7 @@ public:
     uint64_t get_partition_rows() const override;
     Permutation* get_permutation() const override { return nullptr; }
 
-    void setup_runtime(RuntimeProfile* profile, const std::string& parent_profile) override;
+    void setup_runtime(RuntimeProfile* profile) override;
 
 private:
     inline size_t _number_of_rows_to_sort() const { return _offset + _limit; }

--- a/be/src/exec/vectorized/chunks_sorter.cpp
+++ b/be/src/exec/vectorized/chunks_sorter.cpp
@@ -127,8 +127,12 @@ Status DataSegment::get_filter_array(std::vector<DataSegment>& data_segments, si
 
 ChunksSorter::ChunksSorter(RuntimeState* state, const std::vector<ExprContext*>* sort_exprs,
                            const std::vector<bool>* is_asc, const std::vector<bool>* is_null_first,
-                           size_t size_of_chunk_batch)
-        : _state(state), _sort_exprs(sort_exprs), _size_of_chunk_batch(size_of_chunk_batch) {
+                           const std::string& sort_keys, const bool is_topn, size_t size_of_chunk_batch)
+        : _state(state),
+          _sort_exprs(sort_exprs),
+          _sort_keys(sort_keys),
+          _is_topn(is_topn),
+          _size_of_chunk_batch(size_of_chunk_batch) {
     DCHECK(_sort_exprs != nullptr);
     DCHECK(is_asc != nullptr);
     DCHECK(is_null_first != nullptr);
@@ -150,11 +154,13 @@ ChunksSorter::ChunksSorter(RuntimeState* state, const std::vector<ExprContext*>*
 
 ChunksSorter::~ChunksSorter() {}
 
-void ChunksSorter::setup_runtime(RuntimeProfile* profile, const std::string& parent_timer) {
-    _build_timer = ADD_CHILD_TIMER(profile, "1-BuildingTime", parent_timer);
-    _sort_timer = ADD_CHILD_TIMER(profile, "2-SortingTime", parent_timer);
-    _merge_timer = ADD_CHILD_TIMER(profile, "3-MergingTime", parent_timer);
-    _output_timer = ADD_CHILD_TIMER(profile, "4-OutputTime", parent_timer);
+void ChunksSorter::setup_runtime(RuntimeProfile* profile) {
+    _build_timer = ADD_TIMER(profile, "BuildingTime");
+    _sort_timer = ADD_TIMER(profile, "SortingTime");
+    _merge_timer = ADD_TIMER(profile, "MergingTime");
+    _output_timer = ADD_TIMER(profile, "OutputTime");
+    profile->add_info_string("SortKeys", _sort_keys);
+    profile->add_info_string("SortType", _is_topn ? "TopN" : "All");
 }
 
 Status ChunksSorter::finish(RuntimeState* state) {

--- a/be/src/exec/vectorized/chunks_sorter.h
+++ b/be/src/exec/vectorized/chunks_sorter.h
@@ -91,7 +91,8 @@ public:
      * @param size_of_chunk_batch  In the case of a positive limit, this parameter limits the size of the batch in Chunk unit.
      */
     ChunksSorter(RuntimeState* state, const std::vector<ExprContext*>* sort_exprs, const std::vector<bool>* is_asc,
-                 const std::vector<bool>* is_null_first, size_t size_of_chunk_batch = 1000);
+                 const std::vector<bool>* is_null_first, const std::string& sort_keys, const bool is_topn,
+                 size_t size_of_chunk_batch = 1000);
     virtual ~ChunksSorter();
 
     static vectorized::ChunkPtr materialize_chunk_before_sort(vectorized::Chunk* chunk,
@@ -99,7 +100,7 @@ public:
                                                               const SortExecExprs& sort_exec_exprs,
                                                               const std::vector<OrderByType>& order_by_types);
 
-    virtual void setup_runtime(RuntimeProfile* profile, const std::string& parent_timer);
+    virtual void setup_runtime(RuntimeProfile* profile);
 
     // Append a Chunk for sort.
     virtual Status update(RuntimeState* state, const ChunkPtr& chunk) = 0;
@@ -138,6 +139,8 @@ protected:
     const std::vector<ExprContext*>* _sort_exprs;
     std::vector<int> _sort_order_flag; // 1 for ascending, -1 for descending.
     std::vector<int> _null_first_flag; // 1 for greatest, -1 for least.
+    const std::string _sort_keys;
+    const bool _is_topn;
 
     size_t _next_output_row = 0;
 

--- a/be/src/exec/vectorized/chunks_sorter_full_sort.cpp
+++ b/be/src/exec/vectorized/chunks_sorter_full_sort.cpp
@@ -16,8 +16,8 @@ namespace starrocks::vectorized {
 
 ChunksSorterFullSort::ChunksSorterFullSort(RuntimeState* state, const std::vector<ExprContext*>* sort_exprs,
                                            const std::vector<bool>* is_asc, const std::vector<bool>* is_null_first,
-                                           size_t size_of_chunk_batch)
-        : ChunksSorter(state, sort_exprs, is_asc, is_null_first, size_of_chunk_batch) {
+                                           const std::string& sort_keys, size_t size_of_chunk_batch)
+        : ChunksSorter(state, sort_exprs, is_asc, is_null_first, sort_keys, false, size_of_chunk_batch) {
     _selective_values.resize(_state->chunk_size());
 }
 

--- a/be/src/exec/vectorized/chunks_sorter_full_sort.h
+++ b/be/src/exec/vectorized/chunks_sorter_full_sort.h
@@ -21,7 +21,7 @@ public:
      */
     ChunksSorterFullSort(RuntimeState* state, const std::vector<ExprContext*>* sort_exprs,
                          const std::vector<bool>* is_asc, const std::vector<bool>* is_null_first,
-                         size_t size_of_chunk_batch);
+                         const std::string& sort_keys, size_t size_of_chunk_batch);
     ~ChunksSorterFullSort() override;
 
     // Append a Chunk for sort.

--- a/be/src/exec/vectorized/chunks_sorter_topn.cpp
+++ b/be/src/exec/vectorized/chunks_sorter_topn.cpp
@@ -13,8 +13,9 @@ namespace starrocks::vectorized {
 
 ChunksSorterTopn::ChunksSorterTopn(RuntimeState* state, const std::vector<ExprContext*>* sort_exprs,
                                    const std::vector<bool>* is_asc, const std::vector<bool>* is_null_first,
-                                   size_t offset, size_t limit, size_t size_of_chunk_batch)
-        : ChunksSorter(state, sort_exprs, is_asc, is_null_first, size_of_chunk_batch),
+                                   const std::string& sort_keys, size_t offset, size_t limit,
+                                   size_t size_of_chunk_batch)
+        : ChunksSorter(state, sort_exprs, is_asc, is_null_first, sort_keys, true, size_of_chunk_batch),
           _offset(offset),
           _limit(limit),
           _init_merged_segment(false) {

--- a/be/src/exec/vectorized/chunks_sorter_topn.h
+++ b/be/src/exec/vectorized/chunks_sorter_topn.h
@@ -21,8 +21,8 @@ public:
      * @param size_of_chunk_batch  In the case of a positive limit, this parameter limits the size of the batch in Chunk unit.
      */
     ChunksSorterTopn(RuntimeState* state, const std::vector<ExprContext*>* sort_exprs, const std::vector<bool>* is_asc,
-                     const std::vector<bool>* is_null_first, size_t offset = 0, size_t limit = 0,
-                     size_t size_of_chunk_batch = 1000);
+                     const std::vector<bool>* is_null_first, const std::string& sort_keys, size_t offset = 0,
+                     size_t limit = 0, size_t size_of_chunk_batch = 1000);
     ~ChunksSorterTopn() override;
 
     // Append a Chunk for sort.

--- a/be/src/exec/vectorized/topn_node.cpp
+++ b/be/src/exec/vectorized/topn_node.cpp
@@ -21,7 +21,7 @@
 namespace starrocks::vectorized {
 
 TopNNode::TopNNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs)
-        : ExecNode(pool, tnode, descs) {
+        : ExecNode(pool, tnode, descs), _tnode(tnode) {
     _offset = tnode.sort_node.__isset.offset ? tnode.sort_node.offset : 0;
     _materialized_tuple_desc = nullptr;
     _sort_timer = nullptr;
@@ -147,23 +147,23 @@ Status TopNNode::_consume_chunks(RuntimeState* state, ExecNode* child) {
         // HeapChunkSorter has higher performance when sorting fewer elements,
         // after testing we think 1024 is a good threshold
         if (_limit <= ChunksSorter::USE_HEAP_SORTER_LIMIT_SZ) {
-            _chunks_sorter = std::make_unique<HeapChunkSorter>(state, &(_sort_exec_exprs.lhs_ordering_expr_ctxs()),
-                                                               &_is_asc_order, &_is_null_first, _offset, _limit,
-                                                               SIZE_OF_CHUNK_FOR_TOPN);
+            _chunks_sorter = std::make_unique<HeapChunkSorter>(
+                    state, &(_sort_exec_exprs.lhs_ordering_expr_ctxs()), &_is_asc_order, &_is_null_first,
+                    _tnode.sort_node.sql_sort_keys, _offset, _limit, SIZE_OF_CHUNK_FOR_TOPN);
         } else {
-            _chunks_sorter = std::make_unique<ChunksSorterTopn>(state, &(_sort_exec_exprs.lhs_ordering_expr_ctxs()),
-                                                                &_is_asc_order, &_is_null_first, _offset, _limit,
-                                                                SIZE_OF_CHUNK_FOR_TOPN);
+            _chunks_sorter = std::make_unique<ChunksSorterTopn>(
+                    state, &(_sort_exec_exprs.lhs_ordering_expr_ctxs()), &_is_asc_order, &_is_null_first,
+                    _tnode.sort_node.sql_sort_keys, _offset, _limit, SIZE_OF_CHUNK_FOR_TOPN);
         }
 
     } else {
-        _chunks_sorter =
-                std::make_unique<ChunksSorterFullSort>(state, &(_sort_exec_exprs.lhs_ordering_expr_ctxs()),
-                                                       &_is_asc_order, &_is_null_first, SIZE_OF_CHUNK_FOR_FULL_SORT);
+        _chunks_sorter = std::make_unique<ChunksSorterFullSort>(
+                state, &(_sort_exec_exprs.lhs_ordering_expr_ctxs()), &_is_asc_order, &_is_null_first,
+                _tnode.sort_node.sql_sort_keys, SIZE_OF_CHUNK_FOR_FULL_SORT);
     }
 
     bool eos = false;
-    _chunks_sorter->setup_runtime(runtime_profile(), "ChunksSorter");
+    _chunks_sorter->setup_runtime(runtime_profile());
     do {
         RETURN_IF_CANCELLED(state);
         ChunkPtr chunk;
@@ -205,8 +205,8 @@ pipeline::OpFactories TopNNode::decompose_to_pipeline(pipeline::PipelineBuilderC
     auto&& rc_rf_probe_collector = std::make_shared<RcRfProbeCollector>(2, std::move(this->runtime_filter_collector()));
     auto partition_sort_sink_operator = std::make_shared<PartitionSortSinkOperatorFactory>(
             context->next_operator_id(), id(), sort_context_factory, _sort_exec_exprs, _is_asc_order, _is_null_first,
-            _offset, _limit, _order_by_types, _materialized_tuple_desc, child(0)->row_desc(), _row_descriptor,
-            _analytic_partition_exprs);
+            _tnode.sort_node.sql_sort_keys, _offset, _limit, _order_by_types, _materialized_tuple_desc,
+            child(0)->row_desc(), _row_descriptor, _analytic_partition_exprs);
     // Initialize OperatorFactory's fields involving runtime filters.
     this->init_runtime_filter_for_operator(partition_sort_sink_operator.get(), context, rc_rf_probe_collector);
 

--- a/be/src/exec/vectorized/topn_node.h
+++ b/be/src/exec/vectorized/topn_node.h
@@ -32,6 +32,7 @@ public:
 private:
     Status _consume_chunks(RuntimeState* state, ExecNode* child);
 
+    const TPlanNode& _tnode;
     int64_t _offset;
 
     // _sort_exec_exprs contains the ordering expressions

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -21,8 +21,6 @@
 
 #include "service/internal_service.h"
 
-#include <chrono>
-
 #include "common/closure_guard.h"
 #include "common/config.h"
 #include "exec/pipeline/fragment_context.h"
@@ -90,9 +88,7 @@ void PInternalServiceImpl<T>::transmit_chunk(google::protobuf::RpcController* cn
     // transmit_data(), which will cause a dirty memory access.
     brpc::Controller* cntl = static_cast<brpc::Controller*>(cntl_base);
     PTransmitChunkParams* req = const_cast<PTransmitChunkParams*>(request);
-    const auto receive_timestamp =
-            std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch())
-                    .count();
+    const auto receive_timestamp = GetCurrentTimeNanos();
     response->set_receive_timestamp(receive_timestamp);
     if (cntl->request_attachment().size() > 0) {
         const butil::IOBuf& io_buf = cntl->request_attachment();

--- a/be/src/util/disposable_closure.h
+++ b/be/src/util/disposable_closure.h
@@ -16,11 +16,7 @@ namespace starrocks {
 template <typename T, typename C = void>
 class DisposableClosure : public google::protobuf::Closure {
 public:
-    DisposableClosure(const C& ctx) : _ctx(ctx) {
-        _send_timestamp = std::chrono::duration_cast<std::chrono::nanoseconds>(
-                                  std::chrono::system_clock::now().time_since_epoch())
-                                  .count();
-    }
+    DisposableClosure(const C& ctx) : _ctx(ctx) {}
     ~DisposableClosure() override = default;
 
     // Disallow copy and assignment.
@@ -28,9 +24,7 @@ public:
     DisposableClosure& operator=(const DisposableClosure& other) = delete;
 
     void addFailedHandler(std::function<void(const C&)> fn) { _failed_handler = std::move(fn); }
-    void addSuccessHandler(std::function<void(const C&, const T&, const int64_t send_timestamp)> fn) {
-        _success_handler = fn;
-    }
+    void addSuccessHandler(std::function<void(const C&, const T&)> fn) { _success_handler = fn; }
 
     void Run() noexcept override {
         try {
@@ -39,7 +33,7 @@ public:
                              << ", error_text=" << cntl.ErrorText();
                 _failed_handler(_ctx);
             } else {
-                _success_handler(_ctx, result, _send_timestamp);
+                _success_handler(_ctx, result);
             }
             delete this;
         } catch (const std::exception& exp) {
@@ -54,8 +48,7 @@ public:
 
 private:
     const C _ctx;
-    int64_t _send_timestamp;
     std::function<void(const C&)> _failed_handler;
-    std::function<void(const C&, const T&, const int64_t send_timestamp)> _success_handler;
+    std::function<void(const C&, const T&)> _success_handler;
 };
 } // namespace starrocks

--- a/be/src/util/runtime_profile.cpp
+++ b/be/src/util/runtime_profile.cpp
@@ -977,8 +977,8 @@ void RuntimeProfile::merge_isomorphic_profiles(std::vector<RuntimeProfile*>& pro
             counter0->set(merged_value);
 
             // If the values vary greatly, we need to save extra info (min value and max value) of this counter
-            // TODO(hcf) is there a better way to tell whether save extra info or not
-            if (is_average_type(counter0->type()) && max_value - min_value > 2 * merged_value) {
+            const auto diff = max_value - min_value;
+            if (is_average_type(counter0->type()) && (diff > 5'000'000L && diff > merged_value / 5)) {
                 auto* min_counter = profile0->add_counter(strings::Substitute("__MIN_OF_$0", name), type, name);
                 auto* max_counter = profile0->add_counter(strings::Substitute("__MAX_OF_$0", name), type, name);
                 min_counter->set(min_value);

--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -28,6 +28,7 @@
 #include <functional>
 #include <iostream>
 #include <thread>
+#include <unordered_set>
 #include <utility>
 
 #include "common/compiler_util.h"
@@ -619,6 +620,7 @@ public:
     static void merge_isomorphic_profiles(std::vector<RuntimeProfile*>& profiles);
 
 private:
+    static const std::unordered_set<std::string> NON_MERGE_COUNTER_NAMES;
     // Merge all the isomorphic counters
     // The exact semantics of merge depends on TUnit::type
     // TODO(hcf) is the classification right?

--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -461,7 +461,7 @@ public:
 
 private:
     // vector of (profile, indentation flag)
-    typedef std::vector<std::pair<RuntimeProfile*, bool> > ChildVector;
+    typedef std::vector<std::pair<RuntimeProfile*, bool>> ChildVector;
 
     void add_child_unlock(RuntimeProfile* child, bool indent, ChildVector::iterator pos);
 
@@ -491,7 +491,7 @@ private:
 
     // Map from parent counter name to a set of child counter name.
     // All top level counters are the child of "" (root).
-    typedef std::map<std::string, std::set<std::string> > ChildCounterMap;
+    typedef std::map<std::string, std::set<std::string>> ChildCounterMap;
     ChildCounterMap _child_counter_map;
 
     // A set of bucket counters registered in this runtime profile.
@@ -632,7 +632,8 @@ private:
     // average:
     //     CPU_TICKS / TIME_NS / TIME_MS / TIME_S
     typedef std::tuple<int64_t, int64_t, int64_t> MergedInfo;
-    static MergedInfo merge_isomorphic_counters(TUnit::type type, std::vector<Counter*>& counters);
+    static MergedInfo merge_isomorphic_counters(TUnit::type type,
+                                                std::vector<std::tuple<Counter*, Counter*, Counter*>>& counters);
 
     static bool is_average_type(TUnit::type type) {
         return TUnit::type::CPU_TICKS == type || TUnit::type::TIME_NS == type || TUnit::type::TIME_MS == type ||

--- a/be/test/exec/vectorized/chunks_sorter_bench_test.cpp
+++ b/be/test/exec/vectorized/chunks_sorter_bench_test.cpp
@@ -136,19 +136,19 @@ static void do_bench(benchmark::State& state, SortAlgorithm sorter_algo, Compare
 
         switch (sorter_algo) {
         case FullSort: {
-            sorter.reset(new ChunksSorterFullSort(suite._runtime_state.get(), &sort_exprs, &asc_arr, &null_first,
+            sorter.reset(new ChunksSorterFullSort(suite._runtime_state.get(), &sort_exprs, &asc_arr, &null_first, "",
                                                   config::vector_chunk_size));
             expected_rows = total_rows;
             break;
         }
         case HeapSort: {
-            sorter.reset(new HeapChunkSorter(suite._runtime_state.get(), &sort_exprs, &asc_arr, &null_first, 0,
+            sorter.reset(new HeapChunkSorter(suite._runtime_state.get(), &sort_exprs, &asc_arr, &null_first, "", 0,
                                              limit_rows, config::vector_chunk_size));
             expected_rows = limit_rows;
             break;
         }
         case MergeSort: {
-            sorter.reset(new ChunksSorterTopn(suite._runtime_state.get(), &sort_exprs, &asc_arr, &null_first, 0,
+            sorter.reset(new ChunksSorterTopn(suite._runtime_state.get(), &sort_exprs, &asc_arr, &null_first, "", 0,
                                               limit_rows));
             expected_rows = limit_rows;
             break;

--- a/be/test/exec/vectorized/chunks_sorter_heapsorter_test.cpp
+++ b/be/test/exec/vectorized/chunks_sorter_heapsorter_test.cpp
@@ -161,8 +161,8 @@ TEST_F(HeapChunkSorterTest, single_column_order_by_notnull_test) {
         {
             std::vector<ExprContext*> sort_exprs;
             sort_exprs.push_back(_pool.add(new ExprContext(fake_chunks.slot_refs()[0])));
-            HeapChunkSorter sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, 0, 1024, 1024);
-            sorter.setup_runtime(_pool.add(new RuntimeProfile("")), "");
+            HeapChunkSorter sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, 1024, 1024);
+            sorter.setup_runtime(_pool.add(new RuntimeProfile("")));
             sorter.update(nullptr, fake_chunks.next_chunk(1024));
             sorter.done(nullptr);
 
@@ -179,8 +179,8 @@ TEST_F(HeapChunkSorterTest, single_column_order_by_notnull_test) {
         {
             std::vector<ExprContext*> sort_exprs;
             sort_exprs.push_back(_pool.add(new ExprContext(fake_chunks.slot_refs()[0])));
-            HeapChunkSorter sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, 0, 1024, 1024);
-            sorter.setup_runtime(_pool.add(new RuntimeProfile("")), "");
+            HeapChunkSorter sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, 1024, 1024);
+            sorter.setup_runtime(_pool.add(new RuntimeProfile("")));
             sorter.update(nullptr, fake_chunks.next_chunk(1023));
             sorter.update(nullptr, fake_chunks.next_chunk(1023));
             sorter.done(nullptr);
@@ -200,8 +200,8 @@ TEST_F(HeapChunkSorterTest, single_column_order_by_notnull_test) {
         {
             std::vector<ExprContext*> sort_exprs;
             sort_exprs.push_back(_pool.add(new ExprContext(fake_chunks.slot_refs()[1])));
-            HeapChunkSorter sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, 0, 1024, 1024);
-            sorter.setup_runtime(_pool.add(new RuntimeProfile("")), "");
+            HeapChunkSorter sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, 1024, 1024);
+            sorter.setup_runtime(_pool.add(new RuntimeProfile("")));
             sorter.update(nullptr, fake_chunks.next_chunk(1024));
             sorter.update(nullptr, fake_chunks.next_chunk(1023));
             sorter.done(nullptr);
@@ -233,8 +233,8 @@ TEST_F(HeapChunkSorterTest, single_column_order_by_nullable_test) {
             sort_exprs.push_back(_pool.add(new ExprContext(fake_chunks.slot_refs()[0])));
             // limit 5
             int limit_sz = 5;
-            HeapChunkSorter sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, 0, limit_sz, 1024);
-            sorter.setup_runtime(_pool.add(new RuntimeProfile("")), "");
+            HeapChunkSorter sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, limit_sz, 1024);
+            sorter.setup_runtime(_pool.add(new RuntimeProfile("")));
             sorter.update(nullptr, fake_chunks.next_chunk(10));
             sorter.done(nullptr);
 
@@ -256,8 +256,8 @@ TEST_F(HeapChunkSorterTest, single_column_order_by_nullable_test) {
             sort_exprs.push_back(_pool.add(new ExprContext(fake_chunks.slot_refs()[0])));
             // limit 5
             int limit_sz = 10;
-            HeapChunkSorter sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, 0, limit_sz, 1024);
-            sorter.setup_runtime(_pool.add(new RuntimeProfile("")), "");
+            HeapChunkSorter sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, limit_sz, 1024);
+            sorter.setup_runtime(_pool.add(new RuntimeProfile("")));
             sorter.update(nullptr, fake_chunks.next_chunk(10));
             sorter.done(nullptr);
 
@@ -280,8 +280,8 @@ TEST_F(HeapChunkSorterTest, single_column_order_by_nullable_test) {
             sort_exprs.push_back(_pool.add(new ExprContext(fake_chunks.slot_refs()[0])));
             // limit 5
             int limit_sz = 5;
-            HeapChunkSorter sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, 0, limit_sz, 1024);
-            sorter.setup_runtime(_pool.add(new RuntimeProfile("")), "");
+            HeapChunkSorter sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, limit_sz, 1024);
+            sorter.setup_runtime(_pool.add(new RuntimeProfile("")));
             sorter.update(nullptr, fake_chunks.next_chunk(10));
             sorter.done(nullptr);
 

--- a/be/test/exec/vectorized/chunks_sorter_test.cpp
+++ b/be/test/exec/vectorized/chunks_sorter_test.cpp
@@ -289,7 +289,7 @@ TEST_F(ChunksSorterTest, topn_sort_with_limit) {
         constexpr int kTotalRows = 16;
         for (int limit = 1; limit < kTotalRows; limit++) {
             std::cerr << fmt::format("order by column {} limit {}", name, limit) << std::endl;
-            ChunksSorterTopn sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, 0, limit);
+            ChunksSorterTopn sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 0, limit);
             sorter.set_compare_strategy(ColumnInc);
             size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
             sorter.update(_runtime_state.get(), ChunkPtr(_chunk_1->clone_unique().release()));

--- a/be/test/exec/vectorized/chunks_sorter_test.cpp
+++ b/be/test/exec/vectorized/chunks_sorter_test.cpp
@@ -171,7 +171,7 @@ TEST_F(ChunksSorterTest, full_sort_incremental) {
     sort_exprs.push_back(new ExprContext(_expr_region.get()));
     sort_exprs.push_back(new ExprContext(_expr_cust_key.get()));
 
-    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, 2);
+    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 2);
     sorter.set_compare_strategy(ColumnInc);
     size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
     sorter.update(_runtime_state.get(), _chunk_1);
@@ -338,7 +338,7 @@ TEST_F(ChunksSorterTest, full_sort_by_2_columns_null_first) {
 
     for (auto strategy : all_compare_strategy()) {
         std::cerr << "sort with strategy: " << strategy << std::endl;
-        ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, 2);
+        ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 2);
         sorter.set_compare_strategy(strategy);
         size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
         sorter.update(_runtime_state.get(), _chunk_1);
@@ -385,7 +385,7 @@ TEST_F(ChunksSorterTest, full_sort_by_2_columns_null_last) {
 
     for (auto strategy : all_compare_strategy()) {
         std::cerr << "sort with strategy: " << strategy << std::endl;
-        ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, 2);
+        ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 2);
         sorter.set_compare_strategy(strategy);
         size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
         sorter.update(_runtime_state.get(), _chunk_1);
@@ -434,7 +434,7 @@ TEST_F(ChunksSorterTest, full_sort_by_3_columns) {
 
     for (auto strategy : all_compare_strategy()) {
         std::cerr << "sort with strategy: " << strategy << std::endl;
-        ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, 2);
+        ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 2);
         sorter.set_compare_strategy(strategy);
         size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
         sorter.update(_runtime_state.get(), _chunk_1);
@@ -484,7 +484,7 @@ TEST_F(ChunksSorterTest, full_sort_by_4_columns) {
 
     for (auto strategy : all_compare_strategy()) {
         std::cerr << "sort with strategy: " << strategy << std::endl;
-        ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, 2);
+        ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 2);
         sorter.set_compare_strategy(strategy);
         size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
         sorter.update(_runtime_state.get(), _chunk_1);
@@ -533,7 +533,7 @@ TEST_F(ChunksSorterTest, part_sort_by_3_columns_null_fisrt) {
 
     for (auto strategy : all_compare_strategy()) {
         std::cerr << "sort with strategy: " << strategy << std::endl;
-        ChunksSorterTopn sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, 2, 7, 2);
+        ChunksSorterTopn sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 2, 7, 2);
         sorter.set_compare_strategy(strategy);
 
         size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
@@ -582,7 +582,7 @@ TEST_F(ChunksSorterTest, part_sort_by_3_columns_null_last) {
         int offset = 7;
         for (int limit = 8; limit + offset <= 16; limit++) {
             std::cerr << "sort with strategy: " << strategy << " limit:" << limit << std::endl;
-            ChunksSorterTopn sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, offset, limit, 2);
+            ChunksSorterTopn sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", offset, limit, 2);
             sorter.set_compare_strategy(strategy);
             size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
             sorter.update(_runtime_state.get(), ChunkPtr(_chunk_1->clone_unique().release()));
@@ -611,7 +611,7 @@ TEST_F(ChunksSorterTest, part_sort_by_3_columns_null_last) {
             EXPECT_EQ(permutation, result);
 
             // part sort with large offset
-            ChunksSorterTopn sorter2(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, 100, limit, 2);
+            ChunksSorterTopn sorter2(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 100, limit, 2);
             sorter2.set_compare_strategy(strategy);
             sorter.update(_runtime_state.get(), ChunkPtr(_chunk_1->clone_unique().release()));
             sorter.update(_runtime_state.get(), ChunkPtr(_chunk_2->clone_unique().release()));
@@ -640,7 +640,7 @@ TEST_F(ChunksSorterTest, order_by_with_unequal_sized_chunks) {
     sort_exprs.push_back(new ExprContext(_expr_cust_key.get()));
 
     // partial sort
-    ChunksSorterTopn full_sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, 1, 6, 2);
+    ChunksSorterTopn full_sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 1, 6, 2);
     ChunkPtr chunk_1 = _chunk_1->clone_empty();
     ChunkPtr chunk_2 = _chunk_2->clone_empty();
     for (size_t i = 0; i < _chunk_1->num_columns(); ++i) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/Counter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/Counter.java
@@ -22,6 +22,7 @@
 package com.starrocks.common.util;
 
 import com.starrocks.thrift.TUnit;
+import org.apache.commons.lang3.tuple.Triple;
 
 import java.util.List;
 
@@ -62,18 +63,30 @@ public class Counter {
      * Merge all the isomorphic counters
      * The exact semantics of merge depends on TUnit
      */
-    public static MergedInfo mergeIsomorphicCounters(TUnit type, List<Counter> counters) {
+    public static MergedInfo mergeIsomorphicCounters(TUnit type, List<Triple<Counter, Counter, Counter>> counters) {
         long mergedValue = 0;
         long minValue = Long.MAX_VALUE;
         long maxValue = Long.MIN_VALUE;
 
-        for (Counter counter : counters) {
+        for (Triple<Counter, Counter, Counter> triple : counters) {
+            Counter counter = triple.getLeft();
+            Counter minCounter = triple.getMiddle();
+            Counter maxCounter = triple.getRight();
+
+            if (minCounter != null && minCounter.getValue() < minValue) {
+                minValue = minCounter.getValue();
+            }
             if (counter.getValue() < minValue) {
                 minValue = counter.getValue();
+            }
+
+            if (maxCounter != null && maxCounter.getValue() > maxValue) {
+                maxValue = maxCounter.getValue();
             }
             if (counter.getValue() > maxValue) {
                 maxValue = counter.getValue();
             }
+
             mergedValue += counter.getValue();
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -1687,6 +1687,20 @@ public class Coordinator {
                 fragmentProfile.addChild(pipelineProfile);
             });
         }
+
+        // Set backend number
+        for (int i = 0; i < fragments.size(); i++) {
+            PlanFragment fragment = fragments.get(i);
+            RuntimeProfile profile = fragmentProfiles.get(i);
+
+            Set<TNetworkAddress> networkAddresses =
+                    fragmentExecParamsMap.get(fragment.getFragmentId()).instanceExecParams.stream()
+                            .map(param -> param.host)
+                            .collect(Collectors.toSet());
+
+            Counter backendNum = profile.addCounter("BackendNum", TUnit.UNIT);
+            backendNum.setValue(networkAddresses.size());
+        }
     }
 
     /*

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -550,7 +550,8 @@ public class Coordinator {
                         if (needCheckBackendState) {
                             needCheckBackendExecStates.add(execState);
                             if (LOG.isDebugEnabled()) {
-                                LOG.debug("add need check backend {} for fragment, {} job: {}", execState.backend.getId(),
+                                LOG.debug("add need check backend {} for fragment, {} job: {}",
+                                        execState.backend.getId(),
                                         fragment.getFragmentId().asInt(), jobId);
                             }
                         }
@@ -1669,7 +1670,7 @@ public class Coordinator {
             List<RuntimeProfile> instanceProfiles = fragmentProfile.getChildList().stream()
                     .map(pair -> pair.first)
                     .collect(Collectors.toList());
-            Counter counter = fragmentProfile.addCounter("InstanceNum", TUnit.UNIT, "");
+            Counter counter = fragmentProfile.addCounter("InstanceNum", TUnit.UNIT);
             counter.setValue(instanceProfiles.size());
 
             // After merge, all merged metrics will gather into the first profile
@@ -1813,7 +1814,8 @@ public class Coordinator {
             this.address = host;
             this.backend = idToBackend.get(addressToBackendID.get(address));
 
-            String name = "Instance " + DebugUtil.printId(rpcParams.params.fragment_instance_id) + " (host=" + address + ")";
+            String name =
+                    "Instance " + DebugUtil.printId(rpcParams.params.fragment_instance_id) + " (host=" + address + ")";
             this.profile = new RuntimeProfile(name);
             this.hasCanceled = false;
             this.lastMissingHeartbeatTime = backend.getLastMissingHeartbeatTime();

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -649,6 +649,11 @@ struct TAnalyticNode {
   // should be evaluated over a row that is composed of the child tuple and the buffered
   // tuple
   9: optional Exprs.TExpr order_by_eq
+
+  // For profile attributes' printing: `Partition Keys` `Aggregate Functions`
+  10: optional string sql_partition_keys
+  11: optional string sql_aggregate_functions
+
   20: optional bool has_outer_join_child
 }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

1. `ANALYTIC_SINK`
    * add `PartitionKeys`
    * add `AggregateFunctions`
2. `EXCHANGE_SINK`
    * add `WaitTime`,  which including
        * the time waiting in the queue
        * the network time
        * the processing time at receiver side
    * add `RequestSent`
    * add `BytesUnsent`
    * add `RequestUnsent`
3. fragment level
    * add `BackendNum`
4. `PARTITION_SORT_SINK`
    * add `SortType`
    * add `SortKeys`
5. `OLAO_SCAN`
    * add `Rollup`
    * add `Predicates`
7. Let `DegreeOfParallelism` stable when merge isomorphic profiles, and add another `TotalDegreeOfParallelism` to denote the total parallelism of all the merged pipeline profiles
