### PR TITLE
Provide right offset delta to protect Array

### DIFF
--- a/be/src/exprs/vectorized/array_functions.tpp
+++ b/be/src/exprs/vectorized/array_functions.tpp
@@ -331,7 +331,10 @@ private:
                 dest_data_column->append_datum(items[i]);
             }
         }
-        dest_offsets.emplace_back(dest_offsets.back() + (end - offset));
+
+        // Protect when length < 0.
+        auto offset_delta = ((end < offset) ? 0 : end - offset);
+        dest_offsets.emplace_back(dest_offsets.back() + offset_delta);
     }
 };
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/4348

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Provide right offset delta when end is less than offset.
