### PR TITLE
Fix the mem leak of table function node

### DIFF
--- a/be/src/exec/pipeline/table_function_operator.cpp
+++ b/be/src/exec/pipeline/table_function_operator.cpp
@@ -4,6 +4,13 @@
 
 namespace starrocks::pipeline {
 
+void TableFunctionOperator::close(RuntimeState* state) {
+    if (_table_function != nullptr && _table_function_state != nullptr) {
+        _table_function->close(state, _table_function_state);
+    }
+    Operator::close(state);
+}
+
 bool TableFunctionOperator::has_output() const {
     return _input_chunk != nullptr && (_remain_repeat_times > 0 || _input_chunk_index < _input_chunk->num_rows());
 }

--- a/be/src/exec/pipeline/table_function_operator.h
+++ b/be/src/exec/pipeline/table_function_operator.h
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#include "column/column_helper.h"
-#include "column/type_traits.h"
 #include "column/vectorized_fwd.h"
 #include "exec/pipeline/operator.h"
 #include "exprs/expr.h"
@@ -20,6 +18,8 @@ public:
     ~TableFunctionOperator() override = default;
 
     Status prepare(RuntimeState* state) override;
+
+    void close(RuntimeState* state) override;
 
     bool has_output() const override;
 
@@ -38,7 +38,7 @@ private:
     void _process_table_function();
 
     const TPlanNode& _tnode;
-    const vectorized::TableFunction* _table_function;
+    const vectorized::TableFunction* _table_function = nullptr;
 
     //Slots of output by table function
     std::vector<SlotId> _fn_result_slots;
@@ -52,15 +52,15 @@ private:
     //Input chunk currently being processed
     vectorized::ChunkPtr _input_chunk;
     //The current chunk is processed to which row
-    size_t _input_chunk_index;
+    size_t _input_chunk_index = 0;
     //The current outer line needs to be repeated several times
-    size_t _remain_repeat_times;
+    size_t _remain_repeat_times = 0;
     //table function result
     std::pair<vectorized::Columns, vectorized::ColumnPtr> _table_function_result;
     //table function return result end ?
-    bool _table_function_result_eos;
+    bool _table_function_result_eos = false;
     //table function param and return offset
-    vectorized::TableFunctionState* _table_function_state;
+    vectorized::TableFunctionState* _table_function_state = nullptr;
 
     //Profile
     RuntimeProfile::Counter* _table_function_exec_timer = nullptr;

--- a/be/src/exec/vectorized/table_function_node.cpp
+++ b/be/src/exec/vectorized/table_function_node.cpp
@@ -61,7 +61,6 @@ Status TableFunctionNode::init(const TPlanNode& tnode, RuntimeState* state) {
     if (_table_function == nullptr) {
         return Status::InternalError("can't find table function " + table_function_name);
     }
-    RETURN_IF_ERROR(_table_function->init(table_fn, &_table_function_state));
     _input_chunk_seek_rows = 0;
     _table_function_result_eos = true;
     _outer_column_remain_repeat_times = 0;
@@ -72,6 +71,8 @@ Status TableFunctionNode::init(const TPlanNode& tnode, RuntimeState* state) {
 Status TableFunctionNode::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(ExecNode::prepare(state));
     _table_function_exec_timer = ADD_TIMER(_runtime_profile, "TableFunctionTime");
+    TFunction table_fn = _tnode.table_function_node.table_function.nodes[0].fn;
+    RETURN_IF_ERROR(_table_function->init(table_fn, &_table_function_state));
     RETURN_IF_ERROR(_table_function->prepare(_table_function_state));
     return Status::OK();
 }

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -42,6 +42,7 @@ set(EXEC_FILES
         ./exec/pipeline/pipeline_control_flow_test.cpp
         ./exec/pipeline/pipeline_driver_queue_test.cpp
         ./exec/pipeline/query_context_manger_test.cpp
+        ./exec/pipeline/table_function_operator_test.cpp
         ./exec/parquet/parquet_schema_test.cpp
         ./exec/parquet/encoding_test.cpp
         ./exec/parquet/page_reader_test.cpp

--- a/be/test/exec/pipeline/table_function_operator_test.cpp
+++ b/be/test/exec/pipeline/table_function_operator_test.cpp
@@ -1,0 +1,163 @@
+#include "exec/pipeline/table_function_operator.h"
+
+#include "gen_cpp/RuntimeProfile_types.h"
+#include "gtest/gtest.h"
+
+namespace starrocks::pipeline {
+class TableFunctionOperatorTest : public testing::Test {
+public:
+    TableFunctionOperatorTest() : _runtime_state(TQueryGlobals()) {}
+
+protected:
+    virtual void SetUp() override;
+
+private:
+    RuntimeState _runtime_state;
+    ObjectPool _object_pool;
+    DescriptorTbl* _desc_tbl = nullptr;
+    TPlanNode _tnode;
+};
+
+class Counter {
+public:
+    void process_push(const vectorized::ChunkPtr& chunk) {
+        std::lock_guard<std::mutex> l(_mutex);
+        ++_push_chunk_num;
+        _push_chunk_row_num += chunk->num_rows();
+    }
+
+    void process_pull(const vectorized::ChunkPtr& chunk) {
+        std::lock_guard<std::mutex> l(_mutex);
+        ++_pull_chunk_num;
+        _pull_chunk_row_num += chunk->num_rows();
+    }
+
+    size_t push_chunk_num() {
+        std::lock_guard<std::mutex> l(_mutex);
+        return _push_chunk_num;
+    }
+
+    size_t pull_chunk_num() {
+        std::lock_guard<std::mutex> l(_mutex);
+        return _pull_chunk_num;
+    }
+
+    size_t push_chunk_row_num() {
+        std::lock_guard<std::mutex> l(_mutex);
+        return _push_chunk_row_num;
+    }
+
+    size_t pull_chunk_row_num() {
+        std::lock_guard<std::mutex> l(_mutex);
+        return _pull_chunk_row_num;
+    }
+
+private:
+    std::mutex _mutex;
+    size_t _push_chunk_num = 0;
+    size_t _pull_chunk_num = 0;
+    size_t _push_chunk_row_num = 0;
+    size_t _pull_chunk_row_num = 0;
+};
+
+using CounterPtr = std::shared_ptr<Counter>;
+
+class TestNormalOperatorFactory final : public OperatorFactory {
+public:
+    TestNormalOperatorFactory(int32_t id, int32_t plan_node_id, CounterPtr counter, TPlanNode* tnode)
+            : OperatorFactory(id, "test_normal", plan_node_id), _counter(counter), _tnode(tnode) {}
+
+    ~TestNormalOperatorFactory() override = default;
+
+    OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override {
+        return std::make_shared<TableFunctionOperator>(this, _id, _plan_node_id, *_tnode);
+    }
+
+private:
+    CounterPtr _counter;
+    TPlanNode* _tnode = nullptr;
+};
+
+void TableFunctionOperatorTest::SetUp() {
+    TTableDescriptor t_table_desc;
+    t_table_desc.id = 0;
+    t_table_desc.tableType = TTableType::OLAP_TABLE;
+    t_table_desc.numCols = 0;
+    t_table_desc.numClusteringCols = 0;
+
+    TDescriptorTable t_desc_table;
+    t_desc_table.tableDescriptors.push_back(t_table_desc);
+    t_desc_table.__isset.tableDescriptors = true;
+
+    TTupleDescriptor t_tuple_desc;
+    t_tuple_desc.id = 1;
+    t_desc_table.tupleDescriptors.push_back(t_tuple_desc);
+
+    // ARRAY<int>
+    TTypeDesc array_ttype;
+    {
+        array_ttype.__isset.types = true;
+        array_ttype.types.resize(2);
+        array_ttype.types[0].__set_type(TTypeNodeType::ARRAY);
+        array_ttype.types[1].__set_type(TTypeNodeType::SCALAR);
+        array_ttype.types[1].__set_scalar_type(TScalarType());
+        array_ttype.types[1].scalar_type.__set_type(TPrimitiveType::INT);
+        array_ttype.types[1].scalar_type.__set_len(0);
+    }
+
+    // int
+    TTypeDesc int_ttype;
+    {
+        int_ttype.__isset.types = true;
+        int_ttype.types.emplace_back();
+        int_ttype.types.back().__set_type(TTypeNodeType::SCALAR);
+        int_ttype.types.back().__set_scalar_type(TScalarType());
+        int_ttype.types.back().scalar_type.__set_type(TPrimitiveType::INT);
+    }
+
+    for (int i = 0; i < 3; i++) {
+        TSlotDescriptor slot_desc;
+        slot_desc.id = 2 + i;
+
+        slot_desc.parent = 1;
+        slot_desc.slotType = int_ttype;
+        t_desc_table.slotDescriptors.push_back(slot_desc);
+    }
+
+    DescriptorTbl::create(&_object_pool, t_desc_table, &_desc_tbl, config::vector_chunk_size);
+    _runtime_state.set_desc_tbl(_desc_tbl);
+
+    _tnode.node_id = 1;
+    _tnode.node_type = TPlanNodeType::TABLE_FUNCTION_NODE;
+    _tnode.num_children = 1;
+
+    _tnode.row_tuples.push_back(1);
+    _tnode.nullable_tuples.push_back(false);
+
+    TExprNode expr_node;
+    expr_node.__isset.fn = true;
+    expr_node.fn.name.function_name = "unnest";
+    expr_node.fn.arg_types.push_back(array_ttype);
+    expr_node.fn.table_fn.ret_types.push_back(int_ttype);
+
+    _tnode.table_function_node.table_function.nodes.push_back(expr_node);
+
+    _tnode.table_function_node.__isset.param_columns = true;
+    _tnode.table_function_node.param_columns.emplace_back(1);
+
+    _tnode.table_function_node.__isset.outer_columns = true;
+    _tnode.table_function_node.outer_columns.emplace_back(2);
+
+    _tnode.table_function_node.__isset.fn_result_columns = true;
+    _tnode.table_function_node.fn_result_columns.emplace_back(3);
+}
+
+TEST_F(TableFunctionOperatorTest, check_mem_leak) {
+    CounterPtr counter_ptr = std::make_shared<Counter>();
+    TestNormalOperatorFactory factory(1, 1, counter_ptr, &_tnode);
+    TableFunctionOperator op(&factory, 1, 1, _tnode);
+    ASSERT_TRUE(op.prepare(&_runtime_state).ok());
+    op.close(&_runtime_state);
+}
+
+} // namespace starrocks::pipeline


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4185 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

* TableFunctionOperator will create table function state in prepare(), but not destroy it in close()
* move _table_function::init() from TableFunctionOperator::init() to TableFunctionOperation::prepare();, otherise it will init twice in pipeline engine
