### PR TITLE
cherry-pick:Don't obtain hms event id when the hive_incremental_sync is false

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaClient.java
@@ -99,7 +99,9 @@ public class HiveMetaClient {
                 String.valueOf(Config.hive_meta_store_timeout_s));
         this.conf = conf;
 
-        init();
+        if (Config.enable_hms_events_incremental_sync) {
+            init();
+        }
     }
 
     private void init() throws DdlException {


### PR DESCRIPTION
## What type of PR is this：

- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
