### PR TITLE
Support refresh external command and getting metadata from hudi meta client

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -6577,14 +6577,14 @@ public class Catalog {
         if (db == null) {
             throw new DdlException("db: " + dbName + " not exists");
         }
-        HiveTable table;
+        HiveMetaStoreTable table;
         db.readLock();
         try {
             Table tbl = db.getTable(tableName);
-            if (!(tbl instanceof HiveTable)) {
-                throw new DdlException("table : " + tableName + " not exists, or is not hive external table");
+            if (!(tbl instanceof HiveMetaStoreTable)) {
+                throw new DdlException("table : " + tableName + " not exists, or is not hive/hudi external table");
             }
-            table = (HiveTable) tbl;
+            table = (HiveMetaStoreTable) tbl;
         } finally {
             db.readUnlock();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveMetaStoreTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveMetaStoreTable.java
@@ -23,4 +23,10 @@ public interface HiveMetaStoreTable {
     List<Column> getPartitionColumns();
 
     Map<PartitionKey, Long> getPartitionKeys() throws DdlException;
+
+    void refreshTableCache() throws DdlException;
+
+    void refreshPartCache(List<String> partNames) throws DdlException;
+
+    void refreshTableColumnStats() throws DdlException;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
@@ -175,17 +175,20 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
                 this.nameToColumn, columnNames, getPartitionColumns());
     }
 
+    @Override
     public void refreshTableCache() throws DdlException {
         Catalog.getCurrentCatalog().getHiveRepository()
                 .refreshTableCache(resourceName, hiveDb, hiveTable, getPartitionColumns(),
                         new ArrayList<>(nameToColumn.keySet()));
     }
 
+    @Override
     public void refreshPartCache(List<String> partNames) throws DdlException {
         Catalog.getCurrentCatalog().getHiveRepository()
                 .refreshPartitionCache(resourceName, hiveDb, hiveTable, partNames);
     }
 
+    @Override
     public void refreshTableColumnStats() throws DdlException {
         Catalog.getCurrentCatalog().getHiveRepository()
                 .refreshTableColumnStats(resourceName, hiveDb, hiveTable, getPartitionColumns(),

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HudiTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HudiTable.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hudi.avro.HoodieAvroUtils;
 import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.TableSchemaResolver;
 import org.apache.hudi.common.util.Option;
@@ -218,24 +219,25 @@ public class HudiTable extends Table implements HiveMetaStoreTable {
 
         Configuration conf = new Configuration();
         HoodieTableMetaClient metaClient = HoodieTableMetaClient.builder().setConf(conf).setBasePath(hudiBasePath).build();
+        HoodieTableConfig hudiTableConfig = metaClient.getTableConfig();
 
-        HoodieTableType hudiTableType = metaClient.getTableConfig().getTableType();
+        HoodieTableType hudiTableType = hudiTableConfig.getTableType();
         if (hudiTableType == HoodieTableType.MERGE_ON_READ) {
             throw new DdlException("MERGE_ON_READ type of hudi table is NOT supported.");
         }
         hudiProperties.put(HUDI_TABLE_TYPE, hudiTableType.name());
 
-        Option<String[]> hudiTablePrimaryKey = metaClient.getTableConfig().getRecordKeyFields();
+        Option<String[]> hudiTablePrimaryKey = hudiTableConfig.getRecordKeyFields();
         if (hudiTablePrimaryKey.isPresent()) {
-            hudiProperties.put(HUDI_TABLE_PRIMARY_KEY, metaClient.getTableConfig().getRecordKeyFieldProp());
+            hudiProperties.put(HUDI_TABLE_PRIMARY_KEY, hudiTableConfig.getRecordKeyFieldProp());
         }
 
-        String hudiTablePreCombineField = metaClient.getTableConfig().getPreCombineField();
+        String hudiTablePreCombineField = hudiTableConfig.getPreCombineField();
         if (!Strings.isNullOrEmpty(hudiTablePreCombineField)) {
             hudiProperties.put(HUDI_TABLE_PRE_COMBINE_FIELD, hudiTablePreCombineField);
         }
 
-        HoodieFileFormat hudiBaseFileFormat = metaClient.getTableConfig().getBaseFileFormat();
+        HoodieFileFormat hudiBaseFileFormat = hudiTableConfig.getBaseFileFormat();
         hudiProperties.put(HUDI_TABLE_BASE_FILE_FORMAT, hudiBaseFileFormat.name());
 
         TableSchemaResolver schemaUtil = new TableSchemaResolver(metaClient);
@@ -246,7 +248,7 @@ public class HudiTable extends Table implements HiveMetaStoreTable {
             throw new DdlException("Cannot get hudi table schema.");
         }
 
-        Option<String[]> hudiPartitionFields = metaClient.getTableConfig().getPartitionFields();
+        Option<String[]> hudiPartitionFields = hudiTableConfig.getPartitionFields();
         if (hudiPartitionFields.isPresent()) {
             for (String partField : hudiPartitionFields.get()) {
                 Column partColumn = this.nameToColumn.get(partField);

--- a/fe/fe-core/src/main/java/com/starrocks/external/HiveMetaStoreTableUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/HiveMetaStoreTableUtils.java
@@ -48,11 +48,12 @@ public class HiveMetaStoreTableUtils {
     }
 
     public static List<HivePartitionStats> getPartitionsStats(String resourceName,
-                                                       String db,
-                                                       String table,
-                                                       List<PartitionKey> partitionKeys) throws DdlException {
+                                                              String db,
+                                                              String table,
+                                                              List<PartitionKey> partitionKeys,
+                                                              boolean isHudiTable) throws DdlException {
         return Catalog.getCurrentCatalog().getHiveRepository()
-                .getPartitionsStats(resourceName, db, table, partitionKeys);
+                .getPartitionsStats(resourceName, db, table, partitionKeys, isHudiTable);
     }
 
     public static HiveTableStats getTableStats(String resourceName,
@@ -62,18 +63,25 @@ public class HiveMetaStoreTableUtils {
     }
 
     public static List<HivePartition> getPartitions(String resourceName,
-                                             String db,
-                                             String table,
-                                             List<PartitionKey> partitionKeys)
-            throws DdlException {
+                                                    String db,
+                                                    String table,
+                                                    List<PartitionKey> partitionKeys) throws DdlException {
+        return getPartitions(resourceName, db, table, partitionKeys, false);
+    }
+
+    public static List<HivePartition> getPartitions(String resourceName,
+                                                    String db,
+                                                    String table,
+                                                    List<PartitionKey> partitionKeys,
+                                                    boolean isHudiTable) throws DdlException {
         return Catalog.getCurrentCatalog().getHiveRepository()
-                .getPartitions(resourceName, db, table, partitionKeys);
+                .getPartitions(resourceName, db, table, partitionKeys, isHudiTable);
     }
 
     public static Map<PartitionKey, Long> getPartitionKeys(String resourceName,
-                                                    String db,
-                                                    String table,
-                                                    List<Column> partColumns) throws DdlException {
+                                                           String db,
+                                                           String table,
+                                                           List<Column> partColumns) throws DdlException {
         return Catalog.getCurrentCatalog().getHiveRepository()
                 .getPartitionKeys(resourceName, db, table, partColumns);
     }
@@ -83,6 +91,15 @@ public class HiveMetaStoreTableUtils {
                                                  String table,
                                                  List<PartitionKey> partitions,
                                                  List<Column> partColumns) {
+        return getPartitionStatsRowCount(resourceName, db, table, partitions, partColumns, false);
+    }
+
+    public static long getPartitionStatsRowCount(String resourceName,
+                                                 String db,
+                                                 String table,
+                                                 List<PartitionKey> partitions,
+                                                 List<Column> partColumns,
+                                                 boolean isHudiTable) {
         if (partitions == null) {
             try {
                 partitions = Lists.newArrayList(getPartitionKeys(resourceName, db, table, partColumns).keySet());
@@ -99,7 +116,7 @@ public class HiveMetaStoreTableUtils {
 
         List<HivePartitionStats> partitionsStats = Lists.newArrayList();
         try {
-            partitionsStats = getPartitionsStats(resourceName, db, table, partitions);
+            partitionsStats = getPartitionsStats(resourceName, db, table, partitions, isHudiTable);
         } catch (DdlException e) {
             LOG.warn("Failed to get table {} partitions stats.", table, e);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HdfsFileFormat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HdfsFileFormat.java
@@ -6,16 +6,14 @@ import com.google.common.collect.ImmutableMap;
 import com.starrocks.thrift.THdfsFileFormat;
 
 public enum HdfsFileFormat {
-    UNKNOWN("unknown"),
-    PARQUET("org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat"),
-    HUDI_PARQUET("org.apache.hudi.hadoop.HoodieParquetInputFormat"),
-    ORC("org.apache.hadoop.hive.ql.io.orc.OrcInputFormat"),
-    TEXT("org.apache.hadoop.mapred.TextInputFormat");
+    UNKNOWN,
+    PARQUET,
+    ORC,
+    TEXT;
 
     private static final ImmutableMap<String, HdfsFileFormat> validInputFormats =
             new ImmutableMap.Builder<String, HdfsFileFormat>()
                     .put("org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat", PARQUET)
-                    .put("org.apache.hudi.hadoop.HoodieParquetInputFormat", HUDI_PARQUET)
                     .put("org.apache.hadoop.hive.ql.io.orc.OrcInputFormat", ORC)
                     .put("org.apache.hadoop.mapred.TextInputFormat", TEXT)
                     .build();
@@ -26,12 +24,6 @@ public enum HdfsFileFormat {
                     .put("org.apache.hadoop.hive.ql.io.orc.OrcInputFormat", true)
                     .put("org.apache.hadoop.mapred.TextInputFormat", true)
                     .build();
-
-    private final String inputFormat;
-
-    HdfsFileFormat(String inputFormat) {
-        this.inputFormat = inputFormat;
-    }
 
     public static HdfsFileFormat fromHdfsInputFormatClass(String className) {
         return validInputFormats.get(className);
@@ -44,7 +36,6 @@ public enum HdfsFileFormat {
     public THdfsFileFormat toThrift() {
         switch (this) {
             case PARQUET:
-            case HUDI_PARQUET:
                 return THdfsFileFormat.PARQUET;
             case ORC:
                 return THdfsFileFormat.ORC;

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaClient.java
@@ -42,9 +42,13 @@ import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.engine.HoodieLocalEngineContext;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieBaseFile;
+import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.view.FileSystemViewManager;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.hadoop.utils.HoodieInputFormatUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -236,12 +240,23 @@ public class HiveMetaClient {
                 sd = partition.getSd();
                 partName = FSUtils.getRelativePartitionPath(new Path(basePath), new Path(sd.getLocation()));
             }
-            HdfsFileFormat format = HdfsFileFormat.fromHdfsInputFormatClass(sd.getInputFormat());
-            if (format == null) {
-                throw new DdlException("unsupported file format [" + sd.getInputFormat() + "]");
+            Configuration conf = new Configuration();
+            HoodieTableMetaClient metaClient = HoodieTableMetaClient.builder().setConf(conf).setBasePath(basePath).build();
+            HoodieFileFormat hudiBaseFileFormat = metaClient.getTableConfig().getBaseFileFormat();
+
+            HdfsFileFormat format;
+            switch (hudiBaseFileFormat) {
+                case PARQUET:
+                    format = HdfsFileFormat.PARQUET;
+                    break;
+                case ORC:
+                    format = HdfsFileFormat.ORC;
+                    break;
+                default:
+                    throw new DdlException("unsupported file format [" + hudiBaseFileFormat.name() + "]");
             }
             String path = ObjectStorageUtils.formatObjectStoragePath(sd.getLocation());
-            List<HdfsFileDesc> fileDescs = getHudiFileDescs(sd, basePath, partName);
+            List<HdfsFileDesc> fileDescs = getHudiFileDescs(sd, metaClient, partName);
             return new HivePartition(format, ImmutableList.copyOf(fileDescs), path);
         } catch (NoSuchObjectException e) {
             throw new DdlException("Get hudi partition meta data failed: "
@@ -253,17 +268,19 @@ public class HiveMetaClient {
         }
     }
 
-    private List<HdfsFileDesc> getHudiFileDescs(StorageDescriptor sd, String basePath, String partName) throws Exception {
+    private List<HdfsFileDesc> getHudiFileDescs(StorageDescriptor sd, HoodieTableMetaClient metaClient,
+                                                String partName) throws Exception {
         List<HdfsFileDesc> fileDescs = Lists.newArrayList();
-
-        FileSystem fileSystem = getFileSystem(new URI(basePath));
-        Configuration conf = new Configuration();
-        HoodieTableMetaClient metaClient = HoodieTableMetaClient.builder().setConf(conf).setBasePath(basePath).build();
+        FileSystem fileSystem = metaClient.getRawFs();
         HoodieEngineContext engineContext = new HoodieLocalEngineContext(conf);
         HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder().build();
         HoodieTableFileSystemView fileSystemView = FileSystemViewManager.createInMemoryFileSystemView(engineContext,
                 metaClient, metadataConfig);
-        Iterator<HoodieBaseFile> hoodieBaseFileIterator = fileSystemView.getLatestBaseFiles(partName).iterator();
+        HoodieTimeline activeInstants = metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants();
+        Option<HoodieInstant> latestInstant = activeInstants.lastInstant();
+        String queryInstant = latestInstant.get().getTimestamp();
+        Iterator<HoodieBaseFile> hoodieBaseFileIterator = fileSystemView
+                .getLatestBaseFilesBeforeOrOn(partName, queryInstant).iterator();
         while (hoodieBaseFileIterator.hasNext()) {
             HoodieBaseFile baseFile = hoodieBaseFileIterator.next();
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/HudiTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/HudiTableTest.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.TableSchemaResolver;
+import org.apache.hudi.common.util.Option;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -93,6 +94,8 @@ public class HudiTableTest {
         msTable.setTableType("MANAGED_TABLE");
         msTable.setParameters(new HashMap<>());
 
+        String[] hudiPartFields = new String[] {"col1", "col2"};
+
         new Expectations() {
             {
                 Catalog.getCurrentCatalog();
@@ -113,6 +116,9 @@ public class HudiTableTest {
 
                 schemaUtil.getTableAvroSchema();
                 result = hudiSchema;
+
+                metaClient.getTableConfig().getPartitionFields();
+                result = Option.of(hudiPartFields);
             }
         };
         HudiTable table = null;

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/HudiTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/HudiTableTest.java
@@ -94,7 +94,7 @@ public class HudiTableTest {
         msTable.setTableType("MANAGED_TABLE");
         msTable.setParameters(new HashMap<>());
 
-        String[] hudiPartFields = new String[] {"col1", "col2"};
+        String[] hudiPartFields = new String[] {"col1"};
 
         new Expectations() {
             {

--- a/fe/fe-core/src/test/java/com/starrocks/external/hive/HiveMetaCacheTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/external/hive/HiveMetaCacheTest.java
@@ -68,13 +68,13 @@ public class HiveMetaCacheTest {
         HiveMetaCache metaCache = new HiveMetaCache(metaClient, Executors.newFixedThreadPool(10));
 
         HivePartition partition = metaCache.getPartition("db", "tbl",
-                Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns));
+                Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns), false);
         Assert.assertEquals(1, partition.getFiles().size());
         Assert.assertEquals(HdfsFileFormat.PARQUET, partition.getFormat());
         Assert.assertEquals(partitionPath, partition.getFullPath());
 
         partition = metaCache.getPartition("db", "tbl",
-                Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns));
+                Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns), false);
         Assert.assertEquals(1, partition.getFiles().size());
         Assert.assertEquals(HdfsFileFormat.PARQUET, partition.getFormat());
         Assert.assertEquals(partitionPath, partition.getFullPath());
@@ -104,12 +104,12 @@ public class HiveMetaCacheTest {
         HiveMetaCache metaCache = new HiveMetaCache(metaClient, Executors.newFixedThreadPool(10));
 
         HivePartitionStats partitionStats = metaCache.getPartitionStats("db", "tbl",
-                Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns));
+                Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns), false);
         Assert.assertEquals(10000L, partitionStats.getNumRows());
         Assert.assertEquals(10000L, partitionStats.getTotalFileBytes());
 
         partitionStats = metaCache.getPartitionStats("db", "tbl",
-                Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns));
+                Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns), false);
         Assert.assertEquals(10000L, partitionStats.getNumRows());
         Assert.assertEquals(10000L, partitionStats.getTotalFileBytes());
 
@@ -145,7 +145,7 @@ public class HiveMetaCacheTest {
         HiveMetaClient metaClient = new MockedHiveMetaClient();
         HiveMetaCache metaCache = new HiveMetaCache(metaClient, Executors.newFixedThreadPool(10));
         HivePartitionStats partitionStats = metaCache.getPartitionStats("db", "tbl",
-                Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns));
+                Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns), false);
         Assert.assertEquals(10000L, partitionStats.getNumRows());
         Assert.assertEquals(10000L, partitionStats.getTotalFileBytes());
 
@@ -174,9 +174,9 @@ public class HiveMetaCacheTest {
         metaCache.alterPartitionByEvent(partitionKey, sd, params);
 
         partitionStats = metaCache.getPartitionStats("db", "tbl",
-                Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns));
+                Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns), false);
         HivePartition partition = metaCache.getPartition("db", "tbl",
-                Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns));
+                Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns),false);
         Assert.assertTrue(metaCache.partitionExistInCache(partitionKey));
         Assert.assertEquals(5, partitionStats.getNumRows());
         Assert.assertSame(partition.getFormat(), HdfsFileFormat.TEXT);
@@ -217,11 +217,11 @@ public class HiveMetaCacheTest {
 
         metaCache.getPartitionKeys("db", "tbl", partColumns);
         metaCache.getPartition("db", "tbl",
-                Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns));
+                Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns) ,false);
         metaCache.getTableStats("db", "tbl");
 
         metaCache.getPartitionStats("db", "tbl",
-                Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns));
+                Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns), false);
 
         Assert.assertEquals(1, clientMethodGetPartitionKeysCalledTimes);
         Assert.assertEquals(1, clientMethodGetPartitionCalledTimes);
@@ -232,11 +232,11 @@ public class HiveMetaCacheTest {
 
         metaCache.getPartitionKeys("db", "tbl", partColumns);
         metaCache.getPartition("db", "tbl",
-                Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns));
+                Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns), false);
         metaCache.getTableStats("db", "tbl");
 
         metaCache.getPartitionStats("db", "tbl",
-                Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns));
+                Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns), false);
 
         Assert.assertEquals(2, clientMethodGetPartitionKeysCalledTimes);
         Assert.assertEquals(2, clientMethodGetPartitionCalledTimes);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [x] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
close #4404
close #4430  


## Problem Summary(Required) ：
Feature
- support fresh external table

Bug
- currently metadata info of file format and partition in metastore is missing or wrong if hudi table is created by spark-shell or spark-sql with custom configuration, so all of these should be accessed from hudi meta client
