### PR TITLE
use unqualified user and role name to choose resource_groups

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/WorkGroupClassifier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/WorkGroupClassifier.java
@@ -109,7 +109,7 @@ public class WorkGroupClassifier implements Writable {
         if (this.role != null && !this.role.equals(role)) {
             return false;
         }
-        if (this.sourceIp != null) {
+        if (this.sourceIp != null && sourceIp != null) {
             SubnetUtils.SubnetInfo subnetInfo = new SubnetUtils(this.sourceIp).getInfo();
             if (!subnetInfo.isInRange(sourceIp)) {
                 return false;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -1985,12 +1985,7 @@ public class Coordinator {
 
             WorkGroup workgroup = null;
             if (ConnectContext.get() != null) {
-                String user = ConnectContext.get().getCurrentUserIdentity().getQualifiedUser();
-                String roleName = Catalog.getCurrentCatalog().getAuth()
-                        .getRoleName(ConnectContext.get().getCurrentUserIdentity());
-                String remoteIp = ConnectContext.get().getRemoteIP();
-                workgroup = Catalog.getCurrentCatalog().getWorkGroupMgr().chooseWorkGroup(
-                        user, roleName, WorkGroupClassifier.QueryType.SELECT, remoteIp);
+                workgroup = Catalog.getCurrentCatalog().getWorkGroupMgr().chooseWorkGroup(WorkGroupClassifier.QueryType.SELECT);
             }
 
             List<TExecPlanFragmentParams> paramsList = Lists.newArrayList();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -1985,7 +1985,8 @@ public class Coordinator {
 
             WorkGroup workgroup = null;
             if (ConnectContext.get() != null) {
-                workgroup = Catalog.getCurrentCatalog().getWorkGroupMgr().chooseWorkGroup(WorkGroupClassifier.QueryType.SELECT);
+                workgroup = Catalog.getCurrentCatalog().getWorkGroupMgr().chooseWorkGroup(
+                        ConnectContext.get(), WorkGroupClassifier.QueryType.SELECT);
             }
 
             List<TExecPlanFragmentParams> paramsList = Lists.newArrayList();

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/WorkGroupStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/WorkGroupStmtTest.java
@@ -1,5 +1,8 @@
 package com.starrocks.analysis;
 
+import com.starrocks.catalog.Catalog;
+import com.starrocks.catalog.WorkGroup;
+import com.starrocks.catalog.WorkGroupClassifier;
 import com.starrocks.common.FeConstants;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.utframe.StarRocksAssert;
@@ -106,6 +109,8 @@ public class WorkGroupStmtTest {
         ConnectContext ctx = UtFrameUtils.createDefaultCtx();
         FeConstants.default_scheduler_interval_millisecond = 1;
         starRocksAssert = new StarRocksAssert(ctx);
+        starRocksAssert.withRole("rg1_role1");
+        starRocksAssert.withUser("rg1_user1", "rg1_role1");
     }
 
     private static String rowsToString(List<List<String>> rows) {
@@ -308,6 +313,39 @@ public class WorkGroupStmtTest {
         Assert.assertTrue(result.contains("rg2_user4"));
         Assert.assertTrue(result.contains("rg2_role5"));
         Assert.assertTrue(result.contains("192.169.6.1/16"));
+        dropResourceGroups();
+    }
+
+    @Test
+    public void testChooseResourceGroup() throws Exception {
+        createResourceGroups();
+        String qualifiedUser = "default_cluster:rg1_user1";
+        String remoteIp = "192.168.2.4";
+        starRocksAssert.getCtx().setQualifiedUser(qualifiedUser);
+        starRocksAssert.getCtx().setCurrentUserIdentity(new UserIdentity(qualifiedUser, "%"));
+        starRocksAssert.getCtx().setRemoteIP(remoteIp);
+        WorkGroup wg = Catalog.getCurrentCatalog().getWorkGroupMgr().chooseWorkGroup(
+                starRocksAssert.getCtx(),
+                WorkGroupClassifier.QueryType.SELECT);
+        Assert.assertEquals(wg.getName(), "rg1");
+        dropResourceGroups();
+    }
+
+    @Test
+    public void testShowVisibleResourceGroups() throws Exception {
+        createResourceGroups();
+        String qualifiedUser = "default_cluster:rg1_user1";
+        String remoteIp = "192.168.2.4";
+        starRocksAssert.getCtx().setQualifiedUser(qualifiedUser);
+        starRocksAssert.getCtx().setCurrentUserIdentity(new UserIdentity(qualifiedUser, "%"));
+        starRocksAssert.getCtx().setRemoteIP(remoteIp);
+        List<List<String>> rows = Catalog.getCurrentCatalog().getWorkGroupMgr().showAllWorkGroups(
+                starRocksAssert.getCtx(), false);
+        String result = rowsToString(rows);
+        String expect = "" +
+                "rg1|10|20.0%|11|NORMAL|(weight=4.409375, user=rg1_user1, role=rg1_role1, query_type in (INSERT, SELECT), source_ip=192.168.2.1/24)\n" +
+                "rg3|32|80.0%|10|NORMAL|(weight=1.05, query_type in (INSERT, SELECT))";
+        Assert.assertEquals(result, expect);
         dropResourceGroups();
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
@@ -27,11 +27,15 @@ import com.starrocks.analysis.AlterTableStmt;
 import com.starrocks.analysis.CreateDbStmt;
 import com.starrocks.analysis.CreateMaterializedViewStmt;
 import com.starrocks.analysis.CreateResourceStmt;
+import com.starrocks.analysis.CreateRoleStmt;
 import com.starrocks.analysis.CreateTableStmt;
+import com.starrocks.analysis.CreateUserStmt;
 import com.starrocks.analysis.CreateViewStmt;
 import com.starrocks.analysis.DdlStmt;
 import com.starrocks.analysis.DropDbStmt;
+import com.starrocks.analysis.DropRoleStmt;
 import com.starrocks.analysis.DropTableStmt;
+import com.starrocks.analysis.DropUserStmt;
 import com.starrocks.analysis.ShowWorkGroupStmt;
 import com.starrocks.analysis.SqlParser;
 import com.starrocks.analysis.SqlScanner;
@@ -90,6 +94,21 @@ public class StarRocksAssert {
         CreateDbStmt createDbStmt =
                 (CreateDbStmt) UtFrameUtils.parseAndAnalyzeStmt("create database " + dbName + ";", ctx);
         Catalog.getCurrentCatalog().createDb(createDbStmt);
+        return this;
+    }
+
+    public StarRocksAssert withRole(String roleName) throws Exception {
+        CreateRoleStmt createRoleStmt =
+                (CreateRoleStmt) UtFrameUtils.parseAndAnalyzeStmt("create role " + roleName + ";", ctx);
+        Catalog.getCurrentCatalog().getAuth().createRole(createRoleStmt);
+        return this;
+    }
+
+    public StarRocksAssert withUser(String user, String roleName) throws Exception {
+        CreateUserStmt createUserStmt =
+                (CreateUserStmt) UtFrameUtils.parseAndAnalyzeStmt(
+                        "create user " + user + " default role '" + roleName + "';", ctx);
+        Catalog.getCurrentCatalog().getAuth().createUser(createUserStmt);
         return this;
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：

when choose a resource_group for a query, we must use unqualified user and role.
