### PR TITLE
Add object metastore based on aws s3

### DIFF
--- a/be/src/env/env_s3.cpp
+++ b/be/src/env/env_s3.cpp
@@ -211,7 +211,7 @@ S3ClientFactory::S3ClientPtr S3ClientFactory::new_client(const ClientConfigurati
     return client;
 }
 
-static std::shared_ptr<Aws::S3::S3Client> new_s3client(const S3URI& uri) {
+std::shared_ptr<Aws::S3::S3Client> new_s3client(const S3URI& uri) {
     Aws::Client::ClientConfiguration config = S3ClientFactory::getClientConfig();
     config.scheme = Aws::Http::Scheme::HTTP; // TODO: use the scheme in uri
     if (!uri.endpoint().empty()) {

--- a/be/src/env/env_s3.h
+++ b/be/src/env/env_s3.h
@@ -2,10 +2,15 @@
 
 #pragma once
 
+#include <aws/s3/S3Client.h>
+
+#include "common/s3_uri.h"
 #include "env/env.h"
 
 namespace starrocks {
 
 std::unique_ptr<Env> new_env_s3();
+
+std::shared_ptr<Aws::S3::S3Client> new_s3client(const S3URI& uri);
 
 } // namespace starrocks

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -39,6 +39,7 @@ add_library(Storage STATIC
     memtable_flush_executor.cpp
     null_predicate.cpp
     kv_store.cpp
+    object_metastore.cpp
     olap_server.cpp
     options.cpp
     page_cache.cpp

--- a/be/src/storage/metastore.h
+++ b/be/src/storage/metastore.h
@@ -1,0 +1,38 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#pragma once
+
+#include "common/statusor.h"
+#include "gen_cpp/Types_types.h"
+#include "storage/olap_common.h"
+#include "storage/tablet_meta.h"
+
+namespace starrocks {
+
+// Metastore provides abstract interface for meta operations, such as tablet meta and rowset meta.
+class Metastore {
+public:
+    virtual ~Metastore() = default;
+
+    // Add a new tablet meta.
+    virtual Status add_tablet_meta(const TabletMeta& tablet_meta) = 0;
+    // Update the tablet meta that already exist.
+    virtual Status update_tablet_meta(const TabletMeta& tablet_meta) = 0;
+    // Get a tablet meta by tablet id and schema hash.
+    virtual StatusOr<TabletMetaSharedPtr> get_tablet_meta(TTabletId tablet_id, TSchemaHash schema_hash) = 0;
+    // Remove the tablet meta by tablet id and schema hash.
+    virtual Status remove_tablet_meta(TTabletId tablet_id, TSchemaHash schema_hash) = 0;
+
+    // Add a new rowset meta.
+    virtual Status add_rowset_meta(const RowsetMeta& rowset_meta) = 0;
+    // Update the rowset meta that already exist.
+    virtual Status update_rowset_meta(const RowsetMeta& rowset_meta) = 0;
+    // Get a rowset meta by tablet uid and rowset id.
+    virtual StatusOr<RowsetMetaSharedPtr> get_rowset_meta(const TabletUid& tablet_uid, const RowsetId& rowset_id) = 0;
+    // Get all rowset metas by tablet uid.
+    virtual StatusOr<std::vector<RowsetMetaSharedPtr>> get_rowset_metas(const TabletUid& tablet_uid) = 0;
+    // Remove the rowset meta by tablet uid and rowset id.
+    virtual Status remove_rowset_meta(const TabletUid& tablet_uid, const RowsetId& rowset_id) = 0;
+};
+
+} // namespace starrocks

--- a/be/src/storage/metastore.h
+++ b/be/src/storage/metastore.h
@@ -5,9 +5,13 @@
 #include "common/statusor.h"
 #include "gen_cpp/Types_types.h"
 #include "storage/olap_common.h"
-#include "storage/tablet_meta.h"
 
 namespace starrocks {
+
+class RowsetMeta;
+class TabletMeta;
+using RowsetMetaSharedPtr = std::shared_ptr<RowsetMeta>;
+using TabletMetaSharedPtr = std::shared_ptr<TabletMeta>;
 
 // Metastore provides abstract interface for meta operations, such as tablet meta and rowset meta.
 class Metastore {

--- a/be/src/storage/object_metastore.cpp
+++ b/be/src/storage/object_metastore.cpp
@@ -1,0 +1,198 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#include "storage/object_metastore.h"
+
+#include <aws/core/Aws.h>
+#include <aws/core/auth/AWSCredentialsProvider.h>
+#include <aws/core/utils/threading/Executor.h>
+#include <aws/s3/model/ListObjectsV2Request.h>
+#include <aws/s3/model/ListObjectsV2Result.h>
+
+#include "env/env_s3.h"
+#include "gutil/strings/util.h"
+
+namespace starrocks {
+
+static const char* kTabletMeta = "tabletmeta_";
+static const char* kRowsetMetaPrefix = "rst_";
+
+// Metastore based on AWS S3.
+class ObjectMetastore : public Metastore {
+public:
+    explicit ObjectMetastore(const std::string& meta_dir) : _meta_dir(meta_dir) {}
+    ~ObjectMetastore() override = default;
+
+    ObjectMetastore(const ObjectMetastore&) = delete;
+    void operator=(const ObjectMetastore&) = delete;
+    ObjectMetastore(ObjectMetastore&&) = delete;
+    void operator=(ObjectMetastore&&) = delete;
+
+    // put object
+    Status add_tablet_meta(const TabletMeta& tablet_meta) override;
+    Status update_tablet_meta(const TabletMeta& tablet_meta) override;
+    // get object
+    StatusOr<TabletMetaSharedPtr> get_tablet_meta(TTabletId tablet_id, TSchemaHash schema_hash) override;
+    // delete object
+    Status remove_tablet_meta(TTabletId tablet_id, TSchemaHash schema_hash) override;
+
+    // put object
+    Status add_rowset_meta(const RowsetMeta& rowset_meta) override;
+    Status update_rowset_meta(const RowsetMeta& rowset_meta) override;
+    // get object
+    StatusOr<RowsetMetaSharedPtr> get_rowset_meta(const TabletUid& tablet_uid, const RowsetId& rowset_id) override;
+    // list objects and get object
+    StatusOr<std::vector<RowsetMetaSharedPtr>> get_rowset_metas(const TabletUid& tablet_uid) override;
+    // delete object
+    Status remove_rowset_meta(const TabletUid& tablet_uid, const RowsetId& rowset_id) override;
+
+private:
+    StatusOr<RowsetMetaSharedPtr> get_rowset_meta(const std::string& path);
+
+    Status put_object(const std::string& path, const std::string& object);
+    StatusOr<std::string> get_object(const std::string& path);
+    StatusOr<std::vector<std::string>> list_objects_by_prefix(const std::string& prefix_path);
+    Status delete_object(const std::string& path);
+
+    std::string _meta_dir;
+};
+
+Status ObjectMetastore::add_tablet_meta(const TabletMeta& tablet_meta) {
+    auto path = fmt::format("{}/{}{}", _meta_dir, kTabletMeta, tablet_meta.tablet_id());
+    TabletMetaPB tablet_meta_pb;
+    tablet_meta.to_meta_pb(&tablet_meta_pb);
+    auto object = tablet_meta_pb.SerializeAsString();
+    return put_object(path, object);
+}
+
+Status ObjectMetastore::update_tablet_meta(const TabletMeta& tablet_meta) {
+    return add_tablet_meta(tablet_meta);
+}
+
+StatusOr<TabletMetaSharedPtr> ObjectMetastore::get_tablet_meta(TTabletId tablet_id, TSchemaHash schema_hash) {
+    auto path = fmt::format("{}/{}{}", _meta_dir, kTabletMeta, tablet_id);
+    ASSIGN_OR_RETURN(auto meta_binary, get_object(path));
+    auto tablet_meta = std::make_shared<TabletMeta>();
+    RETURN_IF_ERROR(tablet_meta->deserialize(meta_binary));
+    return tablet_meta;
+}
+
+Status ObjectMetastore::remove_tablet_meta(TTabletId tablet_id, TSchemaHash schema_hash) {
+    auto path = fmt::format("{}/{}{}", _meta_dir, kTabletMeta, tablet_id);
+    return delete_object(path);
+}
+
+Status ObjectMetastore::add_rowset_meta(const RowsetMeta& rowset_meta) {
+    auto path = fmt::format("{}/{}{}_{}", _meta_dir, kRowsetMetaPrefix, rowset_meta.tablet_uid().to_string(),
+                            rowset_meta.rowset_id().to_string());
+    RowsetMetaPB rowset_meta_pb;
+    rowset_meta.to_rowset_pb(&rowset_meta_pb);
+    auto object = rowset_meta_pb.SerializeAsString();
+    return put_object(path, object);
+}
+
+Status ObjectMetastore::update_rowset_meta(const RowsetMeta& rowset_meta) {
+    return add_rowset_meta(rowset_meta);
+}
+
+StatusOr<RowsetMetaSharedPtr> ObjectMetastore::get_rowset_meta(const TabletUid& tablet_uid, const RowsetId& rowset_id) {
+    auto path = fmt::format("{}/{}{}_{}", _meta_dir, kRowsetMetaPrefix, tablet_uid.to_string(), rowset_id.to_string());
+    return get_rowset_meta(path);
+}
+
+StatusOr<RowsetMetaSharedPtr> ObjectMetastore::get_rowset_meta(const std::string& path) {
+    ASSIGN_OR_RETURN(auto meta_binary, get_object(path));
+    RowsetMetaPB rowset_meta_pb;
+    if (!rowset_meta_pb.ParseFromString(meta_binary)) {
+        return Status::InternalError("failed to parse RowsetMetaPB from string");
+    }
+    auto rowset_meta = std::make_shared<RowsetMeta>();
+    if (!rowset_meta->init_from_pb(rowset_meta_pb)) {
+        return Status::InternalError("failed to init RowsetMeta from pb");
+    }
+    return rowset_meta;
+}
+
+StatusOr<std::vector<RowsetMetaSharedPtr>> ObjectMetastore::get_rowset_metas(const TabletUid& tablet_uid) {
+    auto object_prefix = fmt::format("{}/{}{}_", _meta_dir, kRowsetMetaPrefix, tablet_uid.to_string());
+    ASSIGN_OR_RETURN(auto objects, list_objects_by_prefix(object_prefix));
+    std::vector<RowsetMetaSharedPtr> rowset_metas;
+    rowset_metas.reserve(objects.size());
+    for (const auto& object : objects) {
+        auto path = fmt::format("{}/{}", _meta_dir, object);
+        auto rowset_meta_st = get_rowset_meta(path);
+        if (!rowset_meta_st.ok()) {
+            return rowset_meta_st.status();
+        }
+        rowset_metas.emplace_back(rowset_meta_st.value());
+    }
+    return std::move(rowset_metas);
+}
+
+Status ObjectMetastore::remove_rowset_meta(const TabletUid& tablet_uid, const RowsetId& rowset_id) {
+    auto path = fmt::format("{}/{}{}_{}", _meta_dir, kRowsetMetaPrefix, tablet_uid.to_string(), rowset_id.to_string());
+    return delete_object(path);
+}
+
+Status ObjectMetastore::put_object(const std::string& path, const std::string& object) {
+    ASSIGN_OR_RETURN(auto env, Env::CreateUniqueFromString(path));
+    ASSIGN_OR_RETURN(auto file, env->new_writable_file(path));
+    RETURN_IF_ERROR(file->append(Slice(object)));
+    RETURN_IF_ERROR(file->sync());
+    return file->close();
+}
+
+StatusOr<std::string> ObjectMetastore::get_object(const std::string& path) {
+    ASSIGN_OR_RETURN(auto env, Env::CreateUniqueFromString(path));
+    ASSIGN_OR_RETURN(auto file, env->new_random_access_file(path));
+    ASSIGN_OR_RETURN(auto size, file->get_size());
+    std::vector<char> content;
+    raw::stl_vector_resize_uninitialized(&content, size);
+    RETURN_IF_ERROR(file->read_at_fully(0, content.data(), size));
+    return std::string(content.data(), content.size());
+}
+
+StatusOr<std::vector<std::string>> ObjectMetastore::list_objects_by_prefix(const std::string& prefix_path) {
+    S3URI uri;
+    if (!uri.parse(prefix_path)) {
+        return Status::InvalidArgument(fmt::format("Invalid S3 URI {}", prefix_path));
+    }
+
+    std::vector<std::string> objects;
+    auto client = new_s3client(uri);
+    Aws::S3::Model::ListObjectsV2Request request;
+    Aws::S3::Model::ListObjectsV2Result result;
+    request.WithBucket(uri.bucket()).WithPrefix(uri.key()).WithDelimiter("/");
+    do {
+        auto outcome = client->ListObjectsV2(request);
+        if (!outcome.IsSuccess()) {
+            return Status::IOError(
+                    fmt::format("S3: fail to list {}: {}", prefix_path, outcome.GetError().GetMessage()));
+        }
+        result = outcome.GetResultWithOwnership();
+        request.SetContinuationToken(result.GetNextContinuationToken());
+        // Get file objects except directory.
+        for (auto&& obj : result.GetContents()) {
+            DCHECK(HasPrefixString(obj.GetKey(), uri.key()));
+            std::string_view key = obj.GetKey();
+            size_t pos = key.find_last_of("/");
+            if (pos == std::string::npos) {
+                objects.emplace_back(key);
+            } else {
+                objects.emplace_back(key.substr(pos + 1));
+            }
+        }
+    } while (result.GetIsTruncated());
+
+    return std::move(objects);
+}
+
+Status ObjectMetastore::delete_object(const std::string& path) {
+    ASSIGN_OR_RETURN(auto env, Env::CreateUniqueFromString(path));
+    return env->delete_file(path);
+}
+
+std::unique_ptr<Metastore> new_object_metastore(const std::string& meta_dir) {
+    return std::make_unique<ObjectMetastore>(meta_dir);
+}
+
+} // namespace starrocks

--- a/be/src/storage/object_metastore.cpp
+++ b/be/src/storage/object_metastore.cpp
@@ -10,6 +10,7 @@
 
 #include "env/env_s3.h"
 #include "gutil/strings/util.h"
+#include "storage/tablet_meta.h"
 
 namespace starrocks {
 

--- a/be/src/storage/object_metastore.h
+++ b/be/src/storage/object_metastore.h
@@ -1,0 +1,11 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#pragma once
+
+#include "storage/metastore.h"
+
+namespace starrocks {
+
+std::unique_ptr<Metastore> new_object_metastore(const std::string& meta_dir);
+
+} // namespace starrocks

--- a/be/src/storage/tablet_meta.cpp
+++ b/be/src/storage/tablet_meta.cpp
@@ -497,7 +497,7 @@ void TabletMeta::init_from_pb(TabletMetaPB* ptablet_meta_pb) {
     }
 }
 
-void TabletMeta::to_meta_pb(TabletMetaPB* tablet_meta_pb) {
+void TabletMeta::to_meta_pb(TabletMetaPB* tablet_meta_pb) const {
     tablet_meta_pb->set_table_id(table_id());
     tablet_meta_pb->set_partition_id(partition_id());
     tablet_meta_pb->set_tablet_id(tablet_id());

--- a/be/src/storage/tablet_meta.h
+++ b/be/src/storage/tablet_meta.h
@@ -137,7 +137,7 @@ public:
     Status deserialize(const std::string& meta_binary);
     void init_from_pb(TabletMetaPB* ptablet_meta_pb);
 
-    void to_meta_pb(TabletMetaPB* tablet_meta_pb);
+    void to_meta_pb(TabletMetaPB* tablet_meta_pb) const;
     void to_json(std::string* json_string, json2pb::Pb2JsonOptions& options);
 
     inline TabletTypePB tablet_type() const { return _tablet_type; }

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -131,6 +131,7 @@ set(EXEC_FILES
         ./storage/key_coder_test.cpp
         ./storage/lru_cache_test.cpp
         ./storage/kv_store_test.cpp
+        ./storage/object_metastore_test.cpp
         ./storage/protobuf_file_test.cpp
         ./storage/page_cache_test.cpp
         ./storage/persistent_index_test.cpp

--- a/be/test/storage/object_metastore_test.cpp
+++ b/be/test/storage/object_metastore_test.cpp
@@ -7,6 +7,7 @@
 #include <gtest/gtest.h>
 
 #include "common/config.h"
+#include "storage/tablet_meta.h"
 #include "testutil/assert.h"
 
 namespace starrocks {

--- a/be/test/storage/object_metastore_test.cpp
+++ b/be/test/storage/object_metastore_test.cpp
@@ -15,10 +15,10 @@ namespace starrocks {
 constexpr static const char* kBucketName = "starrocks-env-s3-unit-test";
 constexpr static const std::string_view kTabletObjectMetastore = "/tablet_object_metastore_test";
 
-class ObjectMetastoreTest : public testing::Test {
+class S3ObjectMetastoreTest : public testing::Test {
 public:
-    ObjectMetastoreTest() = default;
-    ~ObjectMetastoreTest() override = default;
+    S3ObjectMetastoreTest() = default;
+    ~S3ObjectMetastoreTest() override = default;
     void SetUp() override { Aws::InitAPI(_options); }
     void TearDown() override { Aws::ShutdownAPI(_options); }
 
@@ -30,7 +30,7 @@ private:
     Aws::SDKOptions _options;
 };
 
-TEST_F(ObjectMetastoreTest, test_tablet_meta) {
+TEST_F(S3ObjectMetastoreTest, test_tablet_meta) {
     // Create a new TabletMeta
     TCreateTabletReq request;
     request.__set_tablet_id(1000001);
@@ -94,7 +94,7 @@ TEST_F(ObjectMetastoreTest, test_tablet_meta) {
     ASSERT_FALSE(metastore->get_tablet_meta(tablet_meta->tablet_id(), tablet_meta->schema_hash()).ok());
 }
 
-TEST_F(ObjectMetastoreTest, test_rowset_meta) {
+TEST_F(S3ObjectMetastoreTest, test_rowset_meta) {
     // Create a new RowsetMeta
     RowsetMeta rowset_meta1;
     rowset_meta1.set_tablet_uid(TabletUid(1, 1));

--- a/be/test/storage/object_metastore_test.cpp
+++ b/be/test/storage/object_metastore_test.cpp
@@ -1,0 +1,160 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#include "storage/object_metastore.h"
+
+#include <aws/core/Aws.h>
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+
+#include "common/config.h"
+#include "testutil/assert.h"
+
+namespace starrocks {
+
+// NOTE: The bucket must be created before running this test.
+constexpr static const char* kBucketName = "starrocks-env-s3-unit-test";
+constexpr static const std::string_view kTabletObjectMetastore = "/tablet_object_metastore_test";
+
+class ObjectMetastoreTest : public testing::Test {
+public:
+    ObjectMetastoreTest() = default;
+    ~ObjectMetastoreTest() override = default;
+    void SetUp() override { Aws::InitAPI(_options); }
+    void TearDown() override { Aws::ShutdownAPI(_options); }
+
+    std::string S3Path(std::string_view path) {
+        return fmt::format("s3://{}.{}{}", kBucketName, config::object_storage_endpoint, path);
+    }
+
+private:
+    Aws::SDKOptions _options;
+};
+
+TEST_F(ObjectMetastoreTest, test_tablet_meta) {
+    // Create a new TabletMeta
+    TCreateTabletReq request;
+    request.__set_tablet_id(1000001);
+    request.__set_partition_id(1);
+    request.__set_tablet_type(TTabletType::TABLET_TYPE_DISK);
+    request.__set_tablet_schema(TTabletSchema());
+
+    TTabletSchema& schema = request.tablet_schema;
+    schema.__set_schema_hash(12345);
+    schema.__set_is_in_memory(false);
+    schema.__set_keys_type(TKeysType::DUP_KEYS);
+    schema.__set_short_key_column_count(1);
+
+    // c0 int key
+    schema.columns.emplace_back();
+    {
+        TTypeNode type;
+        type.__set_type(TTypeNodeType::SCALAR);
+        type.__set_scalar_type(TScalarType());
+        type.scalar_type.__set_type(TPrimitiveType::INT);
+
+        schema.columns.back().__set_column_name("c0");
+        schema.columns.back().__set_is_key(true);
+        schema.columns.back().__set_index_len(sizeof(int32_t));
+        schema.columns.back().__set_aggregation_type(TAggregationType::NONE);
+        schema.columns.back().__set_is_allow_null(true);
+        schema.columns.back().__set_type_desc(TTypeDesc());
+        schema.columns.back().type_desc.__set_types({type});
+    }
+
+    std::unordered_map<uint32_t, uint32_t> col_ordinal_to_unique_id;
+    col_ordinal_to_unique_id[0] = 0;
+
+    std::unique_ptr<MemTracker> mem_tracker = std::make_unique<MemTracker>(-1);
+    TabletMetaSharedPtr tablet_meta;
+    Status st = TabletMeta::create(mem_tracker.get(), request, TabletUid(1, 1), 2,1, col_ordinal_to_unique_id,
+                                   RowsetTypePB::BETA_ROWSET, &tablet_meta);
+    ASSERT_TRUE(st.ok());
+    ASSERT_TRUE(tablet_meta != nullptr);
+    tablet_meta->set_tablet_state(TabletState::TABLET_RUNNING);
+
+    // Test: add and get tablet meta
+    // s3://starrocks-env-s3-unit-test/tablet_object_metastore_test/tabletmeta_1000001
+    auto metastore = new_object_metastore(S3Path(kTabletObjectMetastore));
+    ASSERT_OK(metastore->add_tablet_meta(*tablet_meta));
+    ASSIGN_OR_ABORT(auto new_tablet_meta,
+                    metastore->get_tablet_meta(tablet_meta->tablet_id(), tablet_meta->schema_hash()));
+    ASSERT_TRUE(new_tablet_meta != nullptr);
+    ASSERT_EQ(TabletState::TABLET_RUNNING, new_tablet_meta->tablet_state());
+
+    // Test: update and get tablet meta
+    tablet_meta->set_tablet_state(TabletState::TABLET_SHUTDOWN);
+    ASSERT_OK(metastore->update_tablet_meta(*tablet_meta));
+    ASSIGN_OR_ABORT(auto new_tablet_meta2,
+                    metastore->get_tablet_meta(tablet_meta->tablet_id(), tablet_meta->schema_hash()));
+    ASSERT_TRUE(new_tablet_meta2 != nullptr);
+    ASSERT_EQ(TabletState::TABLET_SHUTDOWN, new_tablet_meta2->tablet_state());
+
+    // Test: remove tablet meta
+    ASSERT_OK(metastore->remove_tablet_meta(tablet_meta->tablet_id(), tablet_meta->schema_hash()));
+    ASSERT_FALSE(metastore->get_tablet_meta(tablet_meta->tablet_id(), tablet_meta->schema_hash()).ok());
+}
+
+TEST_F(ObjectMetastoreTest, test_rowset_meta) {
+    // Create a new RowsetMeta
+    RowsetMeta rowset_meta1;
+    rowset_meta1.set_tablet_uid(TabletUid(1, 1));
+    rowset_meta1.set_start_version(1);
+    rowset_meta1.set_end_version(1);
+    rowset_meta1.set_num_rows(1000);
+    rowset_meta1.set_num_segments(1);
+    rowset_meta1.set_data_disk_size(1024);
+    rowset_meta1.set_rowset_seg_id(1);
+    RowsetId rowsetId1;
+    rowsetId1.init(2, 1, 0, 0);
+    rowset_meta1.set_rowset_id(rowsetId1);
+    rowset_meta1.set_rowset_state(RowsetStatePB::COMMITTED);
+
+    // Test: add and get rowset meta
+    // s3://starrocks-env-s3-unit-test/tablet_object_metastore_test/rst_00...01-00...01_020000000000000100...
+    auto metastore = new_object_metastore(S3Path(kTabletObjectMetastore));
+    ASSERT_OK(metastore->add_rowset_meta(rowset_meta1));
+    ASSIGN_OR_ABORT(auto new_rowset_meta1,
+                    metastore->get_rowset_meta(rowset_meta1.tablet_uid(), rowset_meta1.rowset_id()));
+    ASSERT_TRUE(new_rowset_meta1 != nullptr);
+    ASSERT_EQ(RowsetStatePB::COMMITTED, new_rowset_meta1->rowset_state());
+
+    // Test: update and get rowset meta
+    rowset_meta1.set_rowset_state(RowsetStatePB::VISIBLE);
+    ASSERT_OK(metastore->update_rowset_meta(rowset_meta1));
+    ASSIGN_OR_ABORT(auto new_rowset_meta2,
+                    metastore->get_rowset_meta(rowset_meta1.tablet_uid(), rowset_meta1.rowset_id()));
+    ASSERT_TRUE(new_rowset_meta2 != nullptr);
+    ASSERT_EQ(RowsetStatePB::VISIBLE, new_rowset_meta2->rowset_state());
+
+    // Create another new RowsetMeta
+    // s3://starrocks-env-s3-unit-test/tablet_object_metastore_test/rst_00...01-00...01_020000000000000200...
+    RowsetMeta rowset_meta2;
+    rowset_meta2.set_tablet_uid(TabletUid(1, 1));
+    rowset_meta2.set_start_version(2);
+    rowset_meta2.set_end_version(2);
+    rowset_meta2.set_num_rows(1000);
+    rowset_meta2.set_num_segments(1);
+    rowset_meta2.set_data_disk_size(1024);
+    rowset_meta2.set_rowset_seg_id(1);
+    RowsetId rowsetId2;
+    rowsetId2.init(2, 2, 0, 0);
+    rowset_meta2.set_rowset_id(rowsetId2);
+    rowset_meta2.set_rowset_state(RowsetStatePB::COMMITTED);
+
+    // Test: add and get rowset metas
+    ASSERT_OK(metastore->add_rowset_meta(rowset_meta2));
+    ASSIGN_OR_ABORT(auto new_rowset_metas,
+                    metastore->get_rowset_metas(rowset_meta2.tablet_uid()));
+    ASSERT_EQ(2, new_rowset_metas.size());
+    ASSERT_EQ(RowsetStatePB::VISIBLE, new_rowset_metas[0]->rowset_state());
+    ASSERT_EQ(RowsetStatePB::COMMITTED, new_rowset_metas[1]->rowset_state());
+
+    // Test: remove rowset meta
+    ASSERT_OK(metastore->remove_rowset_meta(rowset_meta1.tablet_uid(), rowset_meta1.rowset_id()));
+    ASSERT_OK(metastore->remove_rowset_meta(rowset_meta2.tablet_uid(), rowset_meta2.rowset_id()));
+    ASSIGN_OR_ABORT(auto new_rowset_metas2,
+                    metastore->get_rowset_metas(rowset_meta2.tablet_uid()));
+    ASSERT_EQ(0, new_rowset_metas2.size());
+}
+
+} // namespace starrocks


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] others

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Support managing tablet meta and rowset meta based on aws s3,
such as add meta, update meta, get meta(s) and remove meta.
