### PR TITLE
Add delete syntax for primary key table

### DIFF
--- a/be/src/storage/rowset_update_state.cpp
+++ b/be/src/storage/rowset_update_state.cpp
@@ -93,27 +93,26 @@ Status RowsetUpdateState::_do_load(Tablet* tablet, Rowset* rowset) {
     auto chunk_shared_ptr = ChunkHelper::new_chunk(pkey_schema, 4096);
     auto chunk = chunk_shared_ptr.get();
     for (size_t i = 0; i < itrs.size(); i++) {
-        auto itr = itrs[i].get();
-        if (itr == nullptr) {
-            continue;
-        }
         auto& dest = _upserts[i];
         auto col = pk_column->clone();
-        auto num_rows = beta_rowset->segments()[i]->num_rows();
-        col->reserve(num_rows);
-        while (true) {
-            chunk->reset();
-            auto st = itr->get_next(chunk);
-            if (st.is_end_of_file()) {
-                break;
-            } else if (!st.ok()) {
-                return st;
-            } else {
-                PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, chunk->num_rows(), col.get());
+        auto itr = itrs[i].get();
+        if (itr != nullptr) {
+            auto num_rows = beta_rowset->segments()[i]->num_rows();
+            col->reserve(num_rows);
+            while (true) {
+                chunk->reset();
+                auto st = itr->get_next(chunk);
+                if (st.is_end_of_file()) {
+                    break;
+                } else if (!st.ok()) {
+                    return st;
+                } else {
+                    PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, chunk->num_rows(), col.get());
+                }
             }
+            itr->close();
+            CHECK(col->size() == num_rows) << "read segment: iter rows != num rows";
         }
-        itr->close();
-        CHECK(col->size() == num_rows) << "read segment: iter rows != num rows";
         dest = std::move(col);
     }
     for (const auto& upsert : upserts()) {

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/DeleteStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/DeleteStmt.java
@@ -26,6 +26,7 @@ import com.google.common.collect.Lists;
 import com.starrocks.analysis.CompoundPredicate.Operator;
 import com.starrocks.catalog.Catalog;
 import com.starrocks.catalog.CatalogUtils;
+import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.ErrorCode;
@@ -33,22 +34,28 @@ import com.starrocks.common.ErrorReport;
 import com.starrocks.common.UserException;
 import com.starrocks.mysql.privilege.PrivPredicate;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.ast.AstVisitor;
+import com.starrocks.sql.ast.QueryStatement;
 
-import java.util.LinkedList;
 import java.util.List;
 
-public class DeleteStmt extends DdlStmt {
-    private final TableName tbl;
+public class DeleteStmt extends DmlStmt {
+    private final TableName tblName;
     private final PartitionNames partitionNames;
     private final Expr wherePredicate;
 
+    // fields for new planer, primary key table
+    private Table table;
+    private QueryStatement queryStatement;
+
+    // fields for old planer, non-primary key table
     private final List<Predicate> deleteConditions;
     // Each deleteStmt corresponds to a DeleteJob.
     // The JobID is generated here for easy correlation when cancel Delete
     private long jobId = -1;
 
     public DeleteStmt(TableName tableName, PartitionNames partitionNames, Expr wherePredicate) {
-        this.tbl = tableName;
+        this.tblName = tableName;
         this.partitionNames = partitionNames;
         this.wherePredicate = wherePredicate;
         this.deleteConditions = Lists.newLinkedList();
@@ -62,12 +69,13 @@ public class DeleteStmt extends DdlStmt {
         this.jobId = jobId;
     }
 
-    public String getTableName() {
-        return tbl.getTbl();
+    @Override
+    public TableName getTableName() {
+        return tblName;
     }
 
-    public String getDbName() {
-        return tbl.getDb();
+    public Expr getWherePredicate() {
+        return wherePredicate;
     }
 
     public List<String> getPartitionNames() {
@@ -82,13 +90,13 @@ public class DeleteStmt extends DdlStmt {
     public void analyze(Analyzer analyzer) throws UserException {
         super.analyze(analyzer);
 
-        if (tbl == null) {
+        if (tblName == null) {
             throw new AnalysisException("Table is not set");
         }
 
-        tbl.analyze(analyzer);
+        tblName.analyze(analyzer);
 
-        CatalogUtils.checkOlapTableHasStarOSPartition(tbl.getDb(), tbl.getTbl());
+        CatalogUtils.checkOlapTableHasStarOSPartition(tblName.getDb(), tblName.getTbl());
 
         if (partitionNames != null) {
             partitionNames.analyze(analyzer);
@@ -105,11 +113,11 @@ public class DeleteStmt extends DdlStmt {
         analyzePredicate(wherePredicate);
 
         // check access
-        if (!Catalog.getCurrentCatalog().getAuth().checkTblPriv(ConnectContext.get(), tbl.getDb(), tbl.getTbl(),
+        if (!Catalog.getCurrentCatalog().getAuth().checkTblPriv(ConnectContext.get(), tblName.getDb(), tblName.getTbl(),
                 PrivPredicate.LOAD)) {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_TABLEACCESS_DENIED_ERROR, "LOAD",
                     ConnectContext.get().getQualifiedUser(),
-                    ConnectContext.get().getRemoteIP(), tbl.getTbl());
+                    ConnectContext.get().getRemoteIP(), tblName.getTbl());
         }
     }
 
@@ -168,7 +176,7 @@ public class DeleteStmt extends DdlStmt {
     @Override
     public String toSql() {
         StringBuilder sb = new StringBuilder();
-        sb.append("DELETE FROM ").append(tbl.toSql());
+        sb.append("DELETE FROM ").append(tblName.toSql());
         if (partitionNames != null) {
             sb.append(" PARTITION (");
             sb.append(Joiner.on(", ").join(partitionNames.getPartitionNames()));
@@ -178,4 +186,28 @@ public class DeleteStmt extends DdlStmt {
         return sb.toString();
     }
 
+    public boolean supportNewPlanner() {
+        // table must present if analyzed by new analyzer
+        return table != null;
+    }
+
+    public void setTable(Table table) {
+        this.table = table;
+    }
+
+    public Table getTable() {
+        return table;
+    }
+
+    public void setQueryStatement(QueryStatement queryStatement) {
+        this.queryStatement = queryStatement;
+    }
+
+    public QueryStatement getQueryStatement() {
+        return queryStatement;
+    }
+
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitDeleteStatement(this, context);
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/DmlStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/DmlStmt.java
@@ -1,9 +1,11 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
 package com.starrocks.analysis;
 
-public class DmlStmt extends StatementBase {
+public abstract class DmlStmt extends StatementBase {
     @Override
     public RedirectStatus getRedirectStatus() {
         return RedirectStatus.FORWARD_WITH_SYNC;
     }
+
+    public abstract TableName getTableName();
 }

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/InsertStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/InsertStmt.java
@@ -249,6 +249,11 @@ public class InsertStmt extends DmlStmt {
         return queryStatement.isExplain();
     }
 
+    @Override
+    public ExplainLevel getExplainLevel() {
+        return queryStatement.getExplainLevel();
+    }
+
     public boolean isStreaming() {
         return isStreaming;
     }
@@ -867,6 +872,7 @@ public class InsertStmt extends DmlStmt {
     /**
      * Below function is added by new analyzer
      */
+    @Override
     public TableName getTableName() {
         return tblName;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/UpdateStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/UpdateStmt.java
@@ -22,6 +22,7 @@ public class UpdateStmt extends DmlStmt {
         this.wherePredicate = wherePredicate;
     }
 
+    @Override
     public TableName getTableName() {
         return tableName;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/load/DeleteHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/DeleteHandler.java
@@ -149,8 +149,8 @@ public class DeleteHandler implements Writable {
     }
 
     public void process(DeleteStmt stmt) throws DdlException, QueryStateException {
-        String dbName = stmt.getDbName();
-        String tableName = stmt.getTableName();
+        String dbName = stmt.getTableName().getDb();
+        String tableName = stmt.getTableName().getTbl();
         List<String> partitionNames = stmt.getPartitionNames();
         List<Predicate> conditions = stmt.getDeleteConditions();
         Database db = Catalog.getCurrentCatalog().getDb(dbName);
@@ -417,7 +417,7 @@ public class DeleteHandler implements Writable {
         return partitionNames;
     }
 
-    private Map<String, PartitionColumnFilter> extractColumnFilter(DeleteStmt stmt, Table table, 
+    private Map<String, PartitionColumnFilter> extractColumnFilter(DeleteStmt stmt, Table table,
                                                                    List<Column> partitionColumns)
             throws DdlException, AnalysisException {
         Map<String, PartitionColumnFilter> columnFilters = Maps.newHashMap();
@@ -429,7 +429,7 @@ public class DeleteHandler implements Writable {
         for (Predicate condition : deleteConditions) {
             SlotRef slotRef = (SlotRef) condition.getChild(0);
             String columnName = slotRef.getColumnName();
-            
+
             // filter condition is not partition column;
             if (partitionColumns.stream().noneMatch(e -> e.getName().equals(columnName))) {
                 continue;
@@ -832,7 +832,8 @@ public class DeleteHandler implements Writable {
                 predicate.setChild(childNo, LiteralExpr.create("0", Type.TINYINT));
             }
         }
-        LiteralExpr result = LiteralExpr.create(value, Objects.requireNonNull(Type.fromPrimitiveType(column.getPrimitiveType())));
+        LiteralExpr result =
+                LiteralExpr.create(value, Objects.requireNonNull(Type.fromPrimitiveType(column.getPrimitiveType())));
         if (result instanceof DecimalLiteral) {
             ((DecimalLiteral) result).checkPrecisionAndScale(column.getPrecision(), column.getScale());
         } else if (result instanceof DateLiteral) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DdlExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DdlExecutor.java
@@ -56,7 +56,6 @@ import com.starrocks.analysis.CreateUserStmt;
 import com.starrocks.analysis.CreateViewStmt;
 import com.starrocks.analysis.CreateWorkGroupStmt;
 import com.starrocks.analysis.DdlStmt;
-import com.starrocks.analysis.DeleteStmt;
 import com.starrocks.analysis.DropAnalyzeJobStmt;
 import com.starrocks.analysis.DropDbStmt;
 import com.starrocks.analysis.DropFileStmt;
@@ -139,8 +138,6 @@ public class DdlExecutor {
             catalog.getRoutineLoadManager().stopRoutineLoadJob((StopRoutineLoadStmt) ddlStmt);
         } else if (ddlStmt instanceof AlterRoutineLoadStmt) {
             catalog.getRoutineLoadManager().alterRoutineLoadJob((AlterRoutineLoadStmt) ddlStmt);
-        } else if (ddlStmt instanceof DeleteStmt) {
-            catalog.getDeleteHandler().process((DeleteStmt) ddlStmt);
         } else if (ddlStmt instanceof CreateUserStmt) {
             CreateUserStmt stmt = (CreateUserStmt) ddlStmt;
             catalog.getAuth().createUser(stmt);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -143,7 +143,6 @@ public class StmtExecutor {
     private final MysqlSerializer serializer;
     private final OriginStatement originStmt;
     private StatementBase parsedStmt;
-    private Analyzer analyzer;
     private RuntimeProfile profile;
     private Coordinator coord = null;
     private MasterOpExecutor masterOpExecutor = null;
@@ -413,19 +412,12 @@ public class StmtExecutor {
                 }
             } else if (parsedStmt instanceof DmlStmt) {
                 try {
-                    if (parsedStmt instanceof InsertStmt) {
-                        handleInsertStmtWithNewPlanner(execPlan, (InsertStmt) parsedStmt);
-                    } else if (parsedStmt instanceof UpdateStmt) {
-                        handleUpdateStmtWithNewPlanner(execPlan, (UpdateStmt) parsedStmt);
-                    } else {
-                        throw unsupportedException(
-                                "Unsupported dml statement " + parsedStmt.getClass().getSimpleName());
-                    }
+                    handleDMLStmt(execPlan, (DmlStmt) parsedStmt);
                     if (context.getSessionVariable().isReportSucc()) {
                         writeProfile(beginTimeInNanoSecond);
                     }
                 } catch (Throwable t) {
-                    LOG.warn("handle dml stmt fail", t);
+                    LOG.warn("DML statement(" + originStmt.originStmt + ") process failed.", t);
                     throw t;
                 } finally {
                     QeProcessorImpl.INSTANCE.unregisterQuery(context.getExecutionId());
@@ -506,7 +498,7 @@ public class StmtExecutor {
         try {
             InsertStmt insertStmt = createTableAsSelectStmt.getInsertStmt();
             ExecPlan execPlan = new StatementPlanner().plan(insertStmt, context);
-            handleInsertStmtWithNewPlanner(execPlan, ((CreateTableAsSelectStmt) parsedStmt).getInsertStmt());
+            handleDMLStmt(execPlan, ((CreateTableAsSelectStmt) parsedStmt).getInsertStmt());
             if (context.getSessionVariable().isReportSucc()) {
                 writeProfile(beginTimeInNanoSecond);
             }
@@ -592,7 +584,6 @@ public class StmtExecutor {
             return;
         }
 
-        analyzer = new Analyzer(context.getCatalog(), context);
         // Convert show statement to select statement here
         if (parsedStmt instanceof ShowStmt) {
             QueryStatement selectStmt = ((ShowStmt) parsedStmt).toSelectStmt();
@@ -603,12 +594,12 @@ public class StmtExecutor {
 
         if (parsedStmt instanceof QueryStmt
                 || parsedStmt instanceof QueryStatement
-                || parsedStmt instanceof InsertStmt
+                || parsedStmt instanceof DmlStmt
                 || parsedStmt instanceof CreateTableAsSelectStmt) {
             Preconditions.checkState(false, "Shouldn't reach here");
         } else {
             try {
-                parsedStmt.analyze(analyzer);
+                parsedStmt.analyze(new Analyzer(context.getCatalog(), context));
             } catch (AnalysisException e) {
                 throw e;
             } catch (Exception e) {
@@ -620,7 +611,7 @@ public class StmtExecutor {
 
     // Because this is called by other thread
     public void cancel() {
-        if (parsedStmt instanceof DeleteStmt) {
+        if (parsedStmt instanceof DeleteStmt && !((DeleteStmt) parsedStmt).supportNewPlanner()) {
             DeleteStmt deleteStmt = (DeleteStmt) parsedStmt;
             long jobId = deleteStmt.getJobId();
             if (jobId != -1) {
@@ -1014,7 +1005,7 @@ public class StmtExecutor {
                 || statement instanceof CreateAnalyzeJobStmt;
     }
 
-    public void handleUpdateStmtWithNewPlanner(ExecPlan execPlan, UpdateStmt stmt) throws Exception {
+    public void handleDMLStmt(ExecPlan execPlan, DmlStmt stmt) throws Exception {
         if (stmt.isExplain()) {
             handleExplainStmt(execPlan.getExplainString(stmt.getExplainLevel()));
             return;
@@ -1023,34 +1014,37 @@ public class StmtExecutor {
             context.getQueryDetail().setExplain(execPlan.getExplainString(TExplainLevel.NORMAL));
         }
 
-        MetaUtils.normalizationTableName(context, stmt.getTableName());
-        Database database = MetaUtils.getStarRocks(context, stmt.getTableName());
-        Table targetTable = MetaUtils.getStarRocksTable(context, stmt.getTableName());
-
-        String label = "update_" + DebugUtil.printId(context.getExecutionId());
-        handleDMLStmtWithNewPlanner(execPlan, database, targetTable, label);
-    }
-
-    public void handleInsertStmtWithNewPlanner(ExecPlan execPlan, InsertStmt stmt) throws Exception {
-        if (stmt.getQueryStatement().isExplain()) {
-            handleExplainStmt(execPlan.getExplainString(stmt.getQueryStatement().getExplainLevel()));
+        // special handling for delete of non-primary key table, using old handler
+        if (stmt instanceof DeleteStmt && !((DeleteStmt) stmt).supportNewPlanner()) {
+            try {
+                context.getCatalog().getDeleteHandler().process((DeleteStmt) stmt);
+                context.getState().setOk();
+            } catch (QueryStateException e) {
+                if (e.getQueryState().getStateType() != MysqlStateType.OK) {
+                    LOG.warn("DDL statement(" + originStmt.originStmt + ") process failed.", e);
+                }
+                context.setState(e.getQueryState());
+            }
             return;
         }
-        if (context.getQueryDetail() != null) {
-            context.getQueryDetail().setExplain(execPlan.getExplainString(TExplainLevel.NORMAL));
-        }
 
         MetaUtils.normalizationTableName(context, stmt.getTableName());
         Database database = MetaUtils.getStarRocks(context, stmt.getTableName());
         Table targetTable = MetaUtils.getStarRocksTable(context, stmt.getTableName());
 
-        String label = Strings.isNullOrEmpty(stmt.getLabel()) ?
-                "insert_" + DebugUtil.printId(context.getExecutionId()) : stmt.getLabel();
-        handleDMLStmtWithNewPlanner(execPlan, database, targetTable, label);
-    }
+        String label = DebugUtil.printId(context.getExecutionId());
+        if (stmt instanceof InsertStmt) {
+            String stmtLabel = ((InsertStmt) stmt).getLabel();
+            label = Strings.isNullOrEmpty(stmtLabel) ? "insert_" + label : stmtLabel;
+        } else if (stmt instanceof UpdateStmt) {
+            label = "update_" + label;
+        } else if (stmt instanceof DeleteStmt) {
+            label = "delete_" + label;
+        } else {
+            throw unsupportedException(
+                    "Unsupported dml statement " + parsedStmt.getClass().getSimpleName());
+        }
 
-    public void handleDMLStmtWithNewPlanner(ExecPlan execPlan, Database database, Table targetTable,
-                                            String label) throws Exception {
         TransactionState.LoadJobSourceType sourceType = TransactionState.LoadJobSourceType.INSERT_STREAMING;
         MetricRepo.COUNTER_LOAD_ADD.increase(1L);
         long transactionId = -1;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/DeletePlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/DeletePlanner.java
@@ -1,0 +1,80 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+package com.starrocks.sql;
+
+import com.google.common.collect.Lists;
+import com.starrocks.analysis.DeleteStmt;
+import com.starrocks.analysis.DescriptorTable;
+import com.starrocks.analysis.SlotDescriptor;
+import com.starrocks.analysis.TupleDescriptor;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.Type;
+import com.starrocks.load.Load;
+import com.starrocks.planner.DataSink;
+import com.starrocks.planner.OlapTableSink;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.ast.QueryRelation;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.Optimizer;
+import com.starrocks.sql.optimizer.base.ColumnRefFactory;
+import com.starrocks.sql.optimizer.base.ColumnRefSet;
+import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
+import com.starrocks.sql.optimizer.transformer.LogicalPlan;
+import com.starrocks.sql.optimizer.transformer.RelationTransformer;
+import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.sql.plan.PlanFragmentBuilder;
+
+import java.util.List;
+
+public class DeletePlanner {
+    public ExecPlan plan(DeleteStmt deleteStatement, ConnectContext session) {
+        if (!deleteStatement.supportNewPlanner()) {
+            // executor will use DeleteHandler to handle delete statement
+            // so just return empty plan here
+            return null;
+        }
+        QueryRelation query = deleteStatement.getQueryStatement().getQueryRelation();
+        List<String> colNames = query.getColumnOutputNames();
+        ColumnRefFactory columnRefFactory = new ColumnRefFactory();
+        LogicalPlan logicalPlan = new RelationTransformer(columnRefFactory, session).transformWithSelectLimit(query);
+        Optimizer optimizer = new Optimizer();
+        OptExpression optimizedPlan = optimizer.optimize(
+                session,
+                logicalPlan.getRoot(),
+                new PhysicalPropertySet(),
+                new ColumnRefSet(logicalPlan.getOutputColumn()),
+                columnRefFactory);
+        ExecPlan execPlan = new PlanFragmentBuilder().createPhysicalPlanWithoutOutputFragment(
+                optimizedPlan, session, logicalPlan.getOutputColumn(), columnRefFactory, colNames);
+        DescriptorTable descriptorTable = execPlan.getDescTbl();
+        TupleDescriptor olapTuple = descriptorTable.createTupleDescriptor();
+
+        OlapTable table = (OlapTable) deleteStatement.getTable();
+        for (Column column : table.getBaseSchema()) {
+            if (column.isKey()) {
+                SlotDescriptor slotDescriptor = descriptorTable.addSlotDescriptor(olapTuple);
+                slotDescriptor.setIsMaterialized(true);
+                slotDescriptor.setType(column.getType());
+                slotDescriptor.setColumn(column);
+                slotDescriptor.setIsNullable(column.isAllowNull());
+            } else {
+                continue;
+            }
+        }
+        SlotDescriptor slotDescriptor = descriptorTable.addSlotDescriptor(olapTuple);
+        slotDescriptor.setIsMaterialized(true);
+        slotDescriptor.setType(Type.TINYINT);
+        slotDescriptor.setColumn(new Column(Load.LOAD_OP_COLUMN, Type.TINYINT));
+        slotDescriptor.setIsNullable(false);
+        olapTuple.computeMemLayout();
+
+        List<Long> partitionIds = Lists.newArrayList();
+        for (Partition partition : table.getPartitions()) {
+            partitionIds.add(partition.getId());
+        }
+        DataSink dataSink = new OlapTableSink(table, olapTuple, partitionIds);
+        execPlan.getFragments().get(0).setSink(dataSink);
+        return execPlan;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Analyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Analyzer.java
@@ -9,6 +9,7 @@ import com.starrocks.analysis.BaseViewStmt;
 import com.starrocks.analysis.CreateAnalyzeJobStmt;
 import com.starrocks.analysis.CreateTableAsSelectStmt;
 import com.starrocks.analysis.CreateWorkGroupStmt;
+import com.starrocks.analysis.DeleteStmt;
 import com.starrocks.analysis.InsertStmt;
 import com.starrocks.analysis.LimitElement;
 import com.starrocks.analysis.ShowStmt;
@@ -111,6 +112,12 @@ public class Analyzer {
         @Override
         public Void visitUpdateStatement(UpdateStmt node, ConnectContext context) {
             UpdateAnalyzer.analyze(node, context);
+            return null;
+        }
+
+        @Override
+        public Void visitDeleteStatement(DeleteStmt node, ConnectContext context) {
+            DeleteAnalyzer.analyze(node, context);
             return null;
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DeleteAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DeleteAnalyzer.java
@@ -1,0 +1,76 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+package com.starrocks.sql.analyzer;
+
+import com.starrocks.analysis.Analyzer;
+import com.starrocks.analysis.DeleteStmt;
+import com.starrocks.analysis.IntLiteral;
+import com.starrocks.analysis.SelectList;
+import com.starrocks.analysis.SelectListItem;
+import com.starrocks.analysis.SlotRef;
+import com.starrocks.analysis.TableName;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.KeysType;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Table;
+import com.starrocks.catalog.Type;
+import com.starrocks.load.Load;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.SelectRelation;
+import com.starrocks.sql.ast.TableRelation;
+import com.starrocks.sql.common.MetaUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class DeleteAnalyzer {
+    private static final Logger LOG = LogManager.getLogger(DeleteAnalyzer.class);
+
+    public static void analyze(DeleteStmt deleteStatement, ConnectContext session) {
+        TableName tableName = deleteStatement.getTableName();
+        MetaUtils.normalizationTableName(session, tableName);
+        MetaUtils.getStarRocks(session, tableName);
+        Table table = MetaUtils.getStarRocksTable(session, tableName);
+
+        if (!(table instanceof OlapTable && ((OlapTable) table).getKeysType() == KeysType.PRIMARY_KEYS)) {
+            try {
+                deleteStatement.analyze(new Analyzer(session.getCatalog(), session));
+            } catch (Exception e) {
+                LOG.warn("Analyze DeleteStmt using old analyzer failed", e);
+                throw new SemanticException("Analyze DeleteStmt using old analyzer failed: " + e.getMessage());
+            }
+            return;
+        }
+
+        deleteStatement.setTable(table);
+        if (deleteStatement.getWherePredicate() == null) {
+            throw new SemanticException("Delete must specify where clause to prevent full table delete");
+        }
+        if (deleteStatement.getPartitionNames() != null && deleteStatement.getPartitionNames().size() > 0) {
+            throw new SemanticException("Delete for primary key table do not support specifying partitions");
+        }
+
+        SelectList selectList = new SelectList();
+        for (Column col : table.getBaseSchema()) {
+            SelectListItem item;
+            if (col.isKey()) {
+                item = new SelectListItem(new SlotRef(tableName, col.getName()), col.getName());
+            } else {
+                break;
+            }
+            selectList.addItem(item);
+        }
+        try {
+            selectList.addItem(new SelectListItem(new IntLiteral(1, Type.TINYINT), Load.LOAD_OP_COLUMN));
+        } catch (Exception e) {
+            throw new SemanticException("analyze delete failed", e);
+        }
+
+        TableRelation tableRelation = new TableRelation(tableName);
+        SelectRelation selectRelation =
+                new SelectRelation(selectList, tableRelation, deleteStatement.getWherePredicate(), null, null);
+        QueryStatement queryStatement = new QueryStatement(selectRelation);
+        queryStatement.setIsExplain(deleteStatement.isExplain(), deleteStatement.getExplainLevel());
+        new QueryAnalyzer(session).analyze(queryStatement);
+        deleteStatement.setQueryStatement(queryStatement);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitor.java
@@ -22,6 +22,7 @@ import com.starrocks.analysis.CreateViewStmt;
 import com.starrocks.analysis.CreateWorkGroupStmt;
 import com.starrocks.analysis.DdlStmt;
 import com.starrocks.analysis.DefaultValueExpr;
+import com.starrocks.analysis.DeleteStmt;
 import com.starrocks.analysis.DropWorkGroupStmt;
 import com.starrocks.analysis.ExistsPredicate;
 import com.starrocks.analysis.Expr;
@@ -120,6 +121,10 @@ public abstract class AstVisitor<R, C> {
 
     public R visitUpdateStatement(UpdateStmt statement, C context) {
         return visitStatement(statement, context);
+    }
+
+    public R visitDeleteStatement(DeleteStmt node, C context) {
+        return visitStatement(node, context);
     }
 
     public R visitShowStatement(ShowStmt statement, C context) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -248,11 +248,11 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
     }
 
     @Override
-    public ParseNode visitExpressionOrDefault(StarRocksParser.ExpressionOrDefaultContext ctx) {
-        if (ctx.DEFAULT() != null) {
+    public ParseNode visitExpressionOrDefault(StarRocksParser.ExpressionOrDefaultContext context) {
+        if (context.DEFAULT() != null) {
             return new DefaultValueExpr();
         } else {
-            return visit(ctx.expression());
+            return visit(context.expression());
         }
     }
 
@@ -297,37 +297,37 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
     }
 
     @Override
-    public ParseNode visitUpdate(StarRocksParser.UpdateContext ctx) {
-        QualifiedName qualifiedName = getQualifiedName(ctx.qualifiedName());
+    public ParseNode visitUpdate(StarRocksParser.UpdateContext context) {
+        QualifiedName qualifiedName = getQualifiedName(context.qualifiedName());
         TableName targetTableName = qualifiedNameToTableName(qualifiedName);
-        List<ColumnAssignment> assignments = visit(ctx.assignmentList().assignment(), ColumnAssignment.class);
-        Expr where = ctx.where != null ? (Expr) visit(ctx.where) : null;
+        List<ColumnAssignment> assignments = visit(context.assignmentList().assignment(), ColumnAssignment.class);
+        Expr where = context.where != null ? (Expr) visit(context.where) : null;
         UpdateStmt ret = new UpdateStmt(targetTableName, assignments, where);
-        if (ctx.explainDesc() != null) {
-            ret.setIsExplain(true, getExplainType(ctx.explainDesc()));
+        if (context.explainDesc() != null) {
+            ret.setIsExplain(true, getExplainType(context.explainDesc()));
         }
         return ret;
     }
 
     @Override
-    public ParseNode visitAssignment(StarRocksParser.AssignmentContext ctx) {
-        String column = ((Identifier) visit(ctx.identifier())).getValue();
-        Expr expr = (Expr) visit(ctx.expressionOrDefault());
+    public ParseNode visitAssignment(StarRocksParser.AssignmentContext context) {
+        String column = ((Identifier) visit(context.identifier())).getValue();
+        Expr expr = (Expr) visit(context.expressionOrDefault());
         return new ColumnAssignment(column, expr);
     }
 
     @Override
-    public ParseNode visitDelete(StarRocksParser.DeleteContext ctx) {
-        QualifiedName qualifiedName = getQualifiedName(ctx.qualifiedName());
+    public ParseNode visitDelete(StarRocksParser.DeleteContext context) {
+        QualifiedName qualifiedName = getQualifiedName(context.qualifiedName());
         TableName targetTableName = qualifiedNameToTableName(qualifiedName);
         PartitionNames partitionNames = null;
-        if (ctx.partitionNames() != null) {
-            partitionNames = (PartitionNames) visit(ctx.partitionNames());
+        if (context.partitionNames() != null) {
+            partitionNames = (PartitionNames) visit(context.partitionNames());
         }
-        Expr where = ctx.where != null ? (Expr) visit(ctx.where) : null;
+        Expr where = context.where != null ? (Expr) visit(context.where) : null;
         DeleteStmt ret = new DeleteStmt(targetTableName, partitionNames, where);
-        if (ctx.explainDesc() != null) {
-            ret.setIsExplain(true, getExplainType(ctx.explainDesc()));
+        if (context.explainDesc() != null) {
+            ret.setIsExplain(true, getExplainType(context.explainDesc()));
         }
         return ret;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -24,6 +24,7 @@ statement
         properties?
         AS queryStatement                                                               #createTableAsSelect
     | explainDesc? UPDATE qualifiedName SET assignmentList (WHERE where=expression)?    #update
+    | explainDesc? DELETE FROM qualifiedName partitionNames? (WHERE where=expression)?  #delete
     | USE schema=identifier                                                             #use
     | SHOW FULL? TABLES ((FROM | IN) db=qualifiedName)?
         ((LIKE pattern=string) | (WHERE expression))?                                   #showTables

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/DeleteStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/DeleteStmtTest.java
@@ -57,8 +57,8 @@ public class DeleteStmtTest {
         DeleteStmt deleteStmt = new DeleteStmt(new TableName("testDb", "testTbl"),
                 new PartitionNames(false, Lists.newArrayList("partition")), wherePredicate);
 
-        Assert.assertEquals("testDb", deleteStmt.getDbName());
-        Assert.assertEquals("testTbl", deleteStmt.getTableName());
+        Assert.assertEquals("testDb", deleteStmt.getTableName().getDb());
+        Assert.assertEquals("testTbl", deleteStmt.getTableName().getTbl());
         Assert.assertEquals(Lists.newArrayList("partition"), deleteStmt.getPartitionNames());
         Assert.assertEquals("DELETE FROM `testDb`.`testTbl` PARTITION (partition) WHERE `k1` = 'abc'",
                 deleteStmt.toSql());

--- a/fe/fe-core/src/test/java/com/starrocks/load/DeletePruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/DeletePruneTest.java
@@ -84,58 +84,58 @@ public class DeletePruneTest {
         OlapTable tbl = (OlapTable) db.getTable("test_delete");
 
         String deleteSQL = "delete from test_delete where k1 = '2020-01-01'";
-        DeleteStmt deleteStmt = (DeleteStmt) UtFrameUtils.parseAndAnalyzeStmtNew(deleteSQL, ctx);
+        DeleteStmt deleteStmt = (DeleteStmt) UtFrameUtils.parseStmtWithNewParser(deleteSQL, ctx);
         List<String> res = deleteHandler.extractPartitionNamesByCondition(deleteStmt, tbl);
         Assert.assertEquals(1, res.size());
         Assert.assertEquals(res.get(0), "p20200101");
 
         deleteSQL = "delete from test_delete where k1 = '2020-01-01' and k8 = 1";
-        deleteStmt = (DeleteStmt) UtFrameUtils.parseAndAnalyzeStmtNew(deleteSQL, ctx);
+        deleteStmt = (DeleteStmt) UtFrameUtils.parseStmtWithNewParser(deleteSQL, ctx);
         res = deleteHandler.extractPartitionNamesByCondition(deleteStmt, tbl);
         Assert.assertEquals(1, res.size());
         Assert.assertEquals(res.get(0), "p20200101");
 
         deleteSQL = "delete from test_delete where k1 not in ('2020-01-01')";
-        deleteStmt = (DeleteStmt) UtFrameUtils.parseAndAnalyzeStmtNew(deleteSQL, ctx);
+        deleteStmt = (DeleteStmt) UtFrameUtils.parseStmtWithNewParser(deleteSQL, ctx);
         res = deleteHandler.extractPartitionNamesByCondition(deleteStmt, tbl);
         Assert.assertEquals(366, res.size());
 
         deleteSQL = "delete from test_delete where k8 = 1";
-        deleteStmt = (DeleteStmt) UtFrameUtils.parseAndAnalyzeStmtNew(deleteSQL, ctx);
+        deleteStmt = (DeleteStmt) UtFrameUtils.parseStmtWithNewParser(deleteSQL, ctx);
         res = deleteHandler.extractPartitionNamesByCondition(deleteStmt, tbl);
         Assert.assertEquals(366, res.size());
 
         deleteSQL = "delete from test_delete where k1 in ('2020-01-01')";
-        deleteStmt = (DeleteStmt) UtFrameUtils.parseAndAnalyzeStmtNew(deleteSQL, ctx);
+        deleteStmt = (DeleteStmt) UtFrameUtils.parseStmtWithNewParser(deleteSQL, ctx);
         res = deleteHandler.extractPartitionNamesByCondition(deleteStmt, tbl);
         Assert.assertEquals(1, res.size());
         Assert.assertEquals(res.get(0), "p20200101");
 
         deleteSQL = "delete from test_delete where k1 > '2020-01-01' and k1 < '2020-01-03'";
-        deleteStmt = (DeleteStmt) UtFrameUtils.parseAndAnalyzeStmtNew(deleteSQL, ctx);
+        deleteStmt = (DeleteStmt) UtFrameUtils.parseStmtWithNewParser(deleteSQL, ctx);
         res = deleteHandler.extractPartitionNamesByCondition(deleteStmt, tbl);
         Assert.assertEquals(2, res.size());
         Assert.assertEquals(res.get(0), "p20200101");
         Assert.assertEquals(res.get(1), "p20200102");
 
         deleteSQL = "delete from test_delete where k1 > '2020-01-03' and k1 < '2020-01-01'";
-        deleteStmt = (DeleteStmt) UtFrameUtils.parseAndAnalyzeStmtNew(deleteSQL, ctx);
+        deleteStmt = (DeleteStmt) UtFrameUtils.parseStmtWithNewParser(deleteSQL, ctx);
         res = deleteHandler.extractPartitionNamesByCondition(deleteStmt, tbl);
         Assert.assertEquals(0, res.size());
 
         deleteSQL = "delete from test_delete where k1 = '2020-01-01' and k1 > '2020-01-03'";
-        deleteStmt = (DeleteStmt) UtFrameUtils.parseAndAnalyzeStmtNew(deleteSQL, ctx);
+        deleteStmt = (DeleteStmt) UtFrameUtils.parseStmtWithNewParser(deleteSQL, ctx);
         res = deleteHandler.extractPartitionNamesByCondition(deleteStmt, tbl);
         Assert.assertEquals(0, res.size());
 
         deleteSQL = "delete from test_delete where k1 = '2020-01-03' and k1 > '2020-01-01'";
-        deleteStmt = (DeleteStmt) UtFrameUtils.parseAndAnalyzeStmtNew(deleteSQL, ctx);
+        deleteStmt = (DeleteStmt) UtFrameUtils.parseStmtWithNewParser(deleteSQL, ctx);
         res = deleteHandler.extractPartitionNamesByCondition(deleteStmt, tbl);
         Assert.assertEquals(1, res.size());
         Assert.assertEquals(res.get(0), "p20200103");
 
         deleteSQL = "delete from test_delete where k1 in ('2020-01-03') and k1 > '2020-01-01'";
-        deleteStmt = (DeleteStmt) UtFrameUtils.parseAndAnalyzeStmtNew(deleteSQL, ctx);
+        deleteStmt = (DeleteStmt) UtFrameUtils.parseStmtWithNewParser(deleteSQL, ctx);
         res = deleteHandler.extractPartitionNamesByCondition(deleteStmt, tbl);
         Assert.assertEquals(1, res.size());
         Assert.assertEquals(res.get(0), "p20200103");
@@ -149,25 +149,25 @@ public class DeletePruneTest {
         OlapTable tbl = (OlapTable) db.getTable("test_delete2");
 
         String deleteSQL = "delete from test_delete2 where date in ('2020-02-02') and id = 1000";
-        DeleteStmt deleteStmt = (DeleteStmt) UtFrameUtils.parseAndAnalyzeStmtNew(deleteSQL, ctx);
+        DeleteStmt deleteStmt = (DeleteStmt) UtFrameUtils.parseStmtWithNewParser(deleteSQL, ctx);
         List<String> res = deleteHandler.extractPartitionNamesByCondition(deleteStmt, tbl);
         Assert.assertEquals(1, res.size());
         Assert.assertEquals(res.get(0), "p202002_2000");
 
         deleteSQL = "delete from test_delete2 where date in ('2020-02-02')";
-        deleteStmt = (DeleteStmt) UtFrameUtils.parseAndAnalyzeStmtNew(deleteSQL, ctx);
+        deleteStmt = (DeleteStmt) UtFrameUtils.parseStmtWithNewParser(deleteSQL, ctx);
         res = deleteHandler.extractPartitionNamesByCondition(deleteStmt, tbl);
         Assert.assertEquals(1, res.size());
         Assert.assertEquals(res.get(0), "p202002_2000");
 
         deleteSQL = "delete from test_delete2 where date in ('2020-02-02') and id > 1000";
-        deleteStmt = (DeleteStmt) UtFrameUtils.parseAndAnalyzeStmtNew(deleteSQL, ctx);
+        deleteStmt = (DeleteStmt) UtFrameUtils.parseStmtWithNewParser(deleteSQL, ctx);
         res = deleteHandler.extractPartitionNamesByCondition(deleteStmt, tbl);
         Assert.assertEquals(1, res.size());
         Assert.assertEquals(res.get(0), "p202002_2000");
 
         deleteSQL = "delete from test_delete2 where value = 'a'";
-        deleteStmt = (DeleteStmt) UtFrameUtils.parseAndAnalyzeStmtNew(deleteSQL, ctx);
+        deleteStmt = (DeleteStmt) UtFrameUtils.parseStmtWithNewParser(deleteSQL, ctx);
         res = deleteHandler.extractPartitionNamesByCondition(deleteStmt, tbl);
         Assert.assertEquals(3, res.size());
     }

--- a/fe/fe-core/src/test/java/com/starrocks/load/DeletePruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/DeletePruneTest.java
@@ -84,59 +84,58 @@ public class DeletePruneTest {
         OlapTable tbl = (OlapTable) db.getTable("test_delete");
 
         String deleteSQL = "delete from test_delete where k1 = '2020-01-01'";
-        DeleteStmt deleteStmt = (DeleteStmt) UtFrameUtils.parseAndAnalyzeStmt(deleteSQL, ctx);
+        DeleteStmt deleteStmt = (DeleteStmt) UtFrameUtils.parseAndAnalyzeStmtNew(deleteSQL, ctx);
         List<String> res = deleteHandler.extractPartitionNamesByCondition(deleteStmt, tbl);
         Assert.assertEquals(1, res.size());
         Assert.assertEquals(res.get(0), "p20200101");
 
-
         deleteSQL = "delete from test_delete where k1 = '2020-01-01' and k8 = 1";
-        deleteStmt = (DeleteStmt) UtFrameUtils.parseAndAnalyzeStmt(deleteSQL, ctx);
+        deleteStmt = (DeleteStmt) UtFrameUtils.parseAndAnalyzeStmtNew(deleteSQL, ctx);
         res = deleteHandler.extractPartitionNamesByCondition(deleteStmt, tbl);
         Assert.assertEquals(1, res.size());
         Assert.assertEquals(res.get(0), "p20200101");
 
         deleteSQL = "delete from test_delete where k1 not in ('2020-01-01')";
-        deleteStmt = (DeleteStmt) UtFrameUtils.parseAndAnalyzeStmt(deleteSQL, ctx);
+        deleteStmt = (DeleteStmt) UtFrameUtils.parseAndAnalyzeStmtNew(deleteSQL, ctx);
         res = deleteHandler.extractPartitionNamesByCondition(deleteStmt, tbl);
         Assert.assertEquals(366, res.size());
 
         deleteSQL = "delete from test_delete where k8 = 1";
-        deleteStmt = (DeleteStmt) UtFrameUtils.parseAndAnalyzeStmt(deleteSQL, ctx);
+        deleteStmt = (DeleteStmt) UtFrameUtils.parseAndAnalyzeStmtNew(deleteSQL, ctx);
         res = deleteHandler.extractPartitionNamesByCondition(deleteStmt, tbl);
         Assert.assertEquals(366, res.size());
 
         deleteSQL = "delete from test_delete where k1 in ('2020-01-01')";
-        deleteStmt = (DeleteStmt) UtFrameUtils.parseAndAnalyzeStmt(deleteSQL, ctx);
+        deleteStmt = (DeleteStmt) UtFrameUtils.parseAndAnalyzeStmtNew(deleteSQL, ctx);
         res = deleteHandler.extractPartitionNamesByCondition(deleteStmt, tbl);
         Assert.assertEquals(1, res.size());
         Assert.assertEquals(res.get(0), "p20200101");
 
         deleteSQL = "delete from test_delete where k1 > '2020-01-01' and k1 < '2020-01-03'";
-        deleteStmt = (DeleteStmt) UtFrameUtils.parseAndAnalyzeStmt(deleteSQL, ctx);
+        deleteStmt = (DeleteStmt) UtFrameUtils.parseAndAnalyzeStmtNew(deleteSQL, ctx);
         res = deleteHandler.extractPartitionNamesByCondition(deleteStmt, tbl);
         Assert.assertEquals(2, res.size());
         Assert.assertEquals(res.get(0), "p20200101");
         Assert.assertEquals(res.get(1), "p20200102");
 
         deleteSQL = "delete from test_delete where k1 > '2020-01-03' and k1 < '2020-01-01'";
-        deleteStmt = (DeleteStmt) UtFrameUtils.parseAndAnalyzeStmt(deleteSQL, ctx);
+        deleteStmt = (DeleteStmt) UtFrameUtils.parseAndAnalyzeStmtNew(deleteSQL, ctx);
         res = deleteHandler.extractPartitionNamesByCondition(deleteStmt, tbl);
         Assert.assertEquals(0, res.size());
 
         deleteSQL = "delete from test_delete where k1 = '2020-01-01' and k1 > '2020-01-03'";
-        deleteStmt = (DeleteStmt) UtFrameUtils.parseAndAnalyzeStmt(deleteSQL, ctx);
+        deleteStmt = (DeleteStmt) UtFrameUtils.parseAndAnalyzeStmtNew(deleteSQL, ctx);
         res = deleteHandler.extractPartitionNamesByCondition(deleteStmt, tbl);
         Assert.assertEquals(0, res.size());
 
         deleteSQL = "delete from test_delete where k1 = '2020-01-03' and k1 > '2020-01-01'";
-        deleteStmt = (DeleteStmt) UtFrameUtils.parseAndAnalyzeStmt(deleteSQL, ctx);
+        deleteStmt = (DeleteStmt) UtFrameUtils.parseAndAnalyzeStmtNew(deleteSQL, ctx);
         res = deleteHandler.extractPartitionNamesByCondition(deleteStmt, tbl);
         Assert.assertEquals(1, res.size());
         Assert.assertEquals(res.get(0), "p20200103");
 
         deleteSQL = "delete from test_delete where k1 in ('2020-01-03') and k1 > '2020-01-01'";
-        deleteStmt = (DeleteStmt) UtFrameUtils.parseAndAnalyzeStmt(deleteSQL, ctx);
+        deleteStmt = (DeleteStmt) UtFrameUtils.parseAndAnalyzeStmtNew(deleteSQL, ctx);
         res = deleteHandler.extractPartitionNamesByCondition(deleteStmt, tbl);
         Assert.assertEquals(1, res.size());
         Assert.assertEquals(res.get(0), "p20200103");
@@ -150,25 +149,25 @@ public class DeletePruneTest {
         OlapTable tbl = (OlapTable) db.getTable("test_delete2");
 
         String deleteSQL = "delete from test_delete2 where date in ('2020-02-02') and id = 1000";
-        DeleteStmt deleteStmt = (DeleteStmt) UtFrameUtils.parseAndAnalyzeStmt(deleteSQL, ctx);
+        DeleteStmt deleteStmt = (DeleteStmt) UtFrameUtils.parseAndAnalyzeStmtNew(deleteSQL, ctx);
         List<String> res = deleteHandler.extractPartitionNamesByCondition(deleteStmt, tbl);
         Assert.assertEquals(1, res.size());
         Assert.assertEquals(res.get(0), "p202002_2000");
 
         deleteSQL = "delete from test_delete2 where date in ('2020-02-02')";
-        deleteStmt = (DeleteStmt) UtFrameUtils.parseAndAnalyzeStmt(deleteSQL, ctx);
+        deleteStmt = (DeleteStmt) UtFrameUtils.parseAndAnalyzeStmtNew(deleteSQL, ctx);
         res = deleteHandler.extractPartitionNamesByCondition(deleteStmt, tbl);
         Assert.assertEquals(1, res.size());
         Assert.assertEquals(res.get(0), "p202002_2000");
 
         deleteSQL = "delete from test_delete2 where date in ('2020-02-02') and id > 1000";
-        deleteStmt = (DeleteStmt) UtFrameUtils.parseAndAnalyzeStmt(deleteSQL, ctx);
+        deleteStmt = (DeleteStmt) UtFrameUtils.parseAndAnalyzeStmtNew(deleteSQL, ctx);
         res = deleteHandler.extractPartitionNamesByCondition(deleteStmt, tbl);
         Assert.assertEquals(1, res.size());
         Assert.assertEquals(res.get(0), "p202002_2000");
 
         deleteSQL = "delete from test_delete2 where value = 'a'";
-        deleteStmt = (DeleteStmt) UtFrameUtils.parseAndAnalyzeStmt(deleteSQL, ctx);
+        deleteStmt = (DeleteStmt) UtFrameUtils.parseAndAnalyzeStmtNew(deleteSQL, ctx);
         res = deleteHandler.extractPartitionNamesByCondition(deleteStmt, tbl);
         Assert.assertEquals(3, res.size());
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeDeleteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeDeleteTest.java
@@ -1,0 +1,50 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+package com.starrocks.sql.analyzer;
+
+import com.starrocks.analysis.DeleteStmt;
+import com.starrocks.analysis.StatementBase;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.UUID;
+
+import static com.starrocks.sql.analyzer.AnalyzeTestUtil.analyzeFail;
+import static com.starrocks.sql.analyzer.AnalyzeTestUtil.analyzeSuccess;
+
+public class AnalyzeDeleteTest {
+    private static String runningDir = "fe/mocked/AnalyzeDelete/" + UUID.randomUUID().toString() + "/";
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster(runningDir);
+        AnalyzeTestUtil.init();
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        File file = new File(runningDir);
+        file.delete();
+    }
+
+    @Test
+    public void testSingle() {
+        StatementBase stmt = analyzeSuccess("delete from tjson where v_int = 1");
+        Assert.assertEquals(false, ((DeleteStmt) stmt).supportNewPlanner());
+
+        analyzeFail("delete from tjson",
+                "Where clause is not set");
+
+        stmt = analyzeSuccess("delete from tprimary where pk = 1");
+        Assert.assertEquals(true, ((DeleteStmt) stmt).supportNewPlanner());
+
+        analyzeFail("delete from tprimary partitions (p1, p2) where pk = 1",
+                "Delete for primary key table do not support specifying partitions");
+
+        analyzeFail("delete from tprimary",
+                "Delete must specify where clause to prevent full table delete");
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DeletePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DeletePlanTest.java
@@ -1,0 +1,52 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+package com.starrocks.sql.plan;
+
+import com.starrocks.analysis.StatementBase;
+import com.starrocks.qe.QueryState;
+import com.starrocks.qe.StmtExecutor;
+import com.starrocks.sql.StatementPlanner;
+import com.starrocks.sql.optimizer.dump.QueryDumpInfo;
+import com.starrocks.thrift.TExplainLevel;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.List;
+
+public class DeletePlanTest extends PlanTestBase {
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+    }
+
+    @Test
+    public void testDelete() throws Exception {
+        String explainString = getDeleteExecPlan("delete from tprimary where pk = 1");
+        Assert.assertTrue(explainString.contains("PREDICATES: 1: pk = 1"));
+
+        testExplain("explain delete from tprimary where pk = 1");
+        testExplain("explain verbose delete from tprimary where pk = 1");
+        testExplain("explain costs delete from tprimary where pk = 1");
+    }
+
+    private void testExplain(String explainStmt) throws Exception {
+        connectContext.getState().reset();
+        List<StatementBase> statements =
+                com.starrocks.sql.parser.SqlParser.parse(explainStmt, connectContext.getSessionVariable().getSqlMode());
+        StmtExecutor stmtExecutor = new StmtExecutor(connectContext, statements.get(0));
+        stmtExecutor.execute();
+        Assert.assertEquals(connectContext.getState().getStateType(), QueryState.MysqlStateType.EOF);
+    }
+
+    private static String getDeleteExecPlan(String originStmt) throws Exception {
+        connectContext.setDumpInfo(new QueryDumpInfo(connectContext.getSessionVariable()));
+        StatementBase statementBase =
+                com.starrocks.sql.parser.SqlParser.parse(originStmt, connectContext.getSessionVariable().getSqlMode())
+                        .get(0);
+        connectContext.getDumpInfo().setOriginStmt(originStmt);
+        ExecPlan execPlan = new StatementPlanner().plan(statementBase, connectContext);
+
+        String ret = execPlan.getExplainString(TExplainLevel.NORMAL);
+        return ret;
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -181,17 +181,6 @@ public class UtFrameUtils {
     }
 
     // Parse an origin stmt and analyze it. Return a StatementBase instance.
-    // using new parser & analyzer
-    public static StatementBase parseAndAnalyzeStmtNew(String originStmt, ConnectContext ctx)
-            throws Exception {
-        List<StatementBase> statements =
-                com.starrocks.sql.parser.SqlParser.parse(originStmt, ctx.getSessionVariable().getSqlMode());
-        StatementBase statementBase = statements.get(0);
-        com.starrocks.sql.analyzer.Analyzer.analyze(statementBase, ctx);
-        return statementBase;
-    }
-
-    // Parse an origin stmt and analyze it. Return a StatementBase instance.
     public static StatementBase parseAndAnalyzeStmt(String originStmt, ConnectContext ctx)
             throws Exception {
         SqlScanner input = new SqlScanner(new StringReader(originStmt), ctx.getSessionVariable().getSqlMode());

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -165,7 +165,8 @@ public class UtFrameUtils {
             throws Exception {
         StatementBase statementBase;
         try {
-            statementBase = com.starrocks.sql.parser.SqlParser.parse(originStmt, ctx.getSessionVariable().getSqlMode()).get(0);
+            statementBase =
+                    com.starrocks.sql.parser.SqlParser.parse(originStmt, ctx.getSessionVariable().getSqlMode()).get(0);
             com.starrocks.sql.analyzer.Analyzer.analyze(statementBase, ctx);
         } catch (ParsingException | SemanticException e) {
             System.err.println("parse failed: " + e.getMessage());
@@ -176,6 +177,17 @@ public class UtFrameUtils {
             }
         }
 
+        return statementBase;
+    }
+
+    // Parse an origin stmt and analyze it. Return a StatementBase instance.
+    // using new parser & analyzer
+    public static StatementBase parseAndAnalyzeStmtNew(String originStmt, ConnectContext ctx)
+            throws Exception {
+        List<StatementBase> statements =
+                com.starrocks.sql.parser.SqlParser.parse(originStmt, ctx.getSessionVariable().getSqlMode());
+        StatementBase statementBase = statements.get(0);
+        com.starrocks.sql.analyzer.Analyzer.analyze(statementBase, ctx);
         return statementBase;
     }
 
@@ -315,7 +327,8 @@ public class UtFrameUtils {
             throws Exception {
         connectContext.setDumpInfo(new QueryDumpInfo(connectContext.getSessionVariable()));
 
-        List<StatementBase> statements = com.starrocks.sql.parser.SqlParser.parse(originStmt, connectContext.getSessionVariable().getSqlMode());
+        List<StatementBase> statements =
+                com.starrocks.sql.parser.SqlParser.parse(originStmt, connectContext.getSessionVariable().getSqlMode());
         connectContext.getDumpInfo().setOriginStmt(originStmt);
         SessionVariable oldSessionVariable = connectContext.getSessionVariable();
         StatementBase statementBase = statements.get(0);
@@ -345,7 +358,9 @@ public class UtFrameUtils {
     }
 
     public static String getStmtDigest(ConnectContext connectContext, String originStmt) throws Exception {
-        StatementBase statementBase = com.starrocks.sql.parser.SqlParser.parse(originStmt, connectContext.getSessionVariable().getSqlMode()).get(0);
+        StatementBase statementBase =
+                com.starrocks.sql.parser.SqlParser.parse(originStmt, connectContext.getSessionVariable().getSqlMode())
+                        .get(0);
         Preconditions.checkState(statementBase instanceof QueryStatement);
         QueryStatement queryStmt = (QueryStatement) statementBase;
         String digest = SqlDigestBuilder.build(queryStmt);
@@ -443,7 +458,8 @@ public class UtFrameUtils {
         String replaySql = initMockEnv(connectContext, replayDumpInfo);
 
         try {
-            StatementBase statementBase = com.starrocks.sql.parser.SqlParser.parse(replaySql, connectContext.getSessionVariable().getSqlMode()).get(0);
+            StatementBase statementBase = com.starrocks.sql.parser.SqlParser.parse(replaySql,
+                    connectContext.getSessionVariable().getSqlMode()).get(0);
             com.starrocks.sql.analyzer.Analyzer.analyze(statementBase, connectContext);
 
             ColumnRefFactory columnRefFactory = new ColumnRefFactory();


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4361

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This PR implement delete syntax for primary key table, delete syntax is already supported in other key models using old parser/analyzer/planner. For the primary key table, we use a totally different approach and implement using new parser/planner.
This creates a dispatch issue, for an upcoming delete SQL statement, first it will be dispatched to new parser and analyze it, if the table is primary key table then continue analyzing&planning, otherwise fallback using old analyzer, then when executing the statement, check whether it supports new planer, if so use execplan and execute plan fragment, if not use the old DeleteHandler.