### PR TITLE
Fix the mem statistics bug of column pool (#4499)

### DIFF
--- a/be/src/column/column_pool.h
+++ b/be/src/column/column_pool.h
@@ -172,7 +172,11 @@ class CACHELINE_ALIGNED ColumnPool {
                 freed_bytes += release_column_if_large(_curr_free.ptrs[i], limit);
                 ASAN_POISON_MEMORY_REGION(_curr_free.ptrs[i], sizeof(T));
             }
-            _curr_free.bytes -= freed_bytes;
+            if (freed_bytes > 0) {
+                _curr_free.bytes -= freed_bytes;
+                tls_thread_status.mem_consume(freed_bytes);
+                _pool->mem_tracker()->release(freed_bytes);
+            }
         }
 
         static inline void delete_local_pool(void* arg) { delete (LocalPool*)arg; }

--- a/be/test/column/column_pool_test.cpp
+++ b/be/test/column/column_pool_test.cpp
@@ -48,7 +48,7 @@ TEST_F(ColumnPoolTest, single_thread) {
     ASSERT_EQ(DEL_NOT_SATISFIED, c2->delete_state());
     ASSERT_EQ(3, c2->get_data().capacity());
 
-    auto c3 = get_column<Int32Column>()k
+    auto c3 = get_column<Int32Column>();
     ASSERT_NE(c2, c3);
 
     auto c4 = get_column<Int32Column>();

--- a/be/test/column/column_pool_test.cpp
+++ b/be/test/column/column_pool_test.cpp
@@ -22,7 +22,7 @@ TEST_F(ColumnPoolTest, mem_statistics) {
         c1->append_string(str);
     }
 
-    pool->return_column(c1, config::vector_chunk_size);
+    pool->return_column(c1);
     size_t usage_1 = pool->mem_tracker()->consumption();
 
     pool->release_large_columns(config::vector_chunk_size * 10);
@@ -48,7 +48,7 @@ TEST_F(ColumnPoolTest, single_thread) {
     ASSERT_EQ(DEL_NOT_SATISFIED, c2->delete_state());
     ASSERT_EQ(3, c2->get_data().capacity());
 
-    auto c3 = get_column<Int32Column>();
+    auto c3 = get_column<Int32Column>()k
     ASSERT_NE(c2, c3);
 
     auto c4 = get_column<Int32Column>();

--- a/be/test/column/column_pool_test.cpp
+++ b/be/test/column/column_pool_test.cpp
@@ -1,23 +1,4 @@
-// This file is made available under Elastic License 2.0.
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/be/test/column/column_pool_test.cpp
-
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
 
 #include "column/column_pool.h"
 
@@ -30,6 +11,25 @@ protected:
     void SetUp() override { TEST_clear_all_columns_this_thread(); }
     void TearDown() override { TEST_clear_all_columns_this_thread(); }
 };
+
+// NOLINTNEXTLINE
+TEST_F(ColumnPoolTest, mem_statistics) {
+    auto* pool = ColumnPool<BinaryColumn>::singleton();
+    std::string str(20, '1');
+    auto* c1 = get_column<BinaryColumn>();
+    c1->reserve(config::vector_chunk_size);
+    for (size_t i = 0; i < config::vector_chunk_size; i++) {
+        c1->append_string(str);
+    }
+
+    pool->return_column(c1, config::vector_chunk_size);
+    size_t usage_1 = pool->mem_tracker()->consumption();
+
+    pool->release_large_columns(config::vector_chunk_size * 10);
+    size_t usage_2 = pool->mem_tracker()->consumption();
+
+    ASSERT_EQ(usage_1 - usage_2, 81920);
+}
 
 // NOLINTNEXTLINE
 TEST_F(ColumnPoolTest, single_thread) {
@@ -67,8 +67,6 @@ TEST_F(ColumnPoolTest, single_thread) {
     auto c8 = get_column<Int32Column>();
     ASSERT_EQ(c5, c7);
     ASSERT_EQ(c6, c8);
-    c5 = nullptr;
-    c6 = nullptr;
 
     return_column<Int32Column>(c8);
     return_column<Int32Column>(c7);


### PR DESCRIPTION
* When release large binary column, the bytes vector is already swap, but the mem statistics is not updated.
* the column_pool_test.cpp is not from apache doris, so change the license