### PR TITLE
Fix the bug of mv creation failure

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/task/AlterReplicaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/AlterReplicaTask.java
@@ -116,7 +116,7 @@ public class AlterReplicaTask extends AgentTask {
                 List<SlotRef> slots = Lists.newArrayList();
                 entry.getValue().collect(SlotRef.class, slots);
                 TAlterMaterializedViewParam mvParam = new TAlterMaterializedViewParam(entry.getKey());
-                mvParam.setOrigin_column_name(slots.get(0).getColumnName());
+                mvParam.setOrigin_column_name(slots.get(0).getColumn().getName());
                 mvParam.setMv_expr(entry.getValue().treeToThrift());
                 req.addToMaterialized_view_params(mvParam);
             }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4446 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Originally when create mv by 'create materialized view lo_mv_1 as select lo_orderdate, count(lo_LINENUMBER)
from lineorder group by lo_orderdate' and the field in table lineorder is lo_linenumber, then the creation
will fail because of the case of name. Fix it by use the original name defined in table schema and make it
case independent. (fix #4446 )