### PR TITLE
Fix statistic of json type

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PrimitiveType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PrimitiveType.java
@@ -377,6 +377,11 @@ public enum PrimitiveType {
                 // 1MB
                 typeSize = 1024 * 1024;
                 break;
+            case JSON:
+                typeSize = 1024;
+                break;
+            default:
+                Preconditions.checkState(false, "unreachable");
         }
         return typeSize;
     }
@@ -423,6 +428,10 @@ public enum PrimitiveType {
 
     public boolean isStringType() {
         return (this == VARCHAR || this == CHAR || this == HLL);
+    }
+
+    public boolean isJsonType() {
+        return this == JSON;
     }
 
     public boolean isCharFamily() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
@@ -39,6 +39,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -169,6 +170,10 @@ public class Table extends MetaObject implements Writable {
 
     public Column getColumn(String name) {
         return nameToColumn.get(name);
+    }
+
+    public List<Column> getColumns() {
+        return new ArrayList<>(nameToColumn.values());
     }
 
     public long getCreateTime() {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
@@ -548,7 +548,7 @@ public class StatisticExecutor {
     }
 
     private String getDataSize(Column column, boolean isSample) {
-        if (column.getPrimitiveType().isCharFamily()) {
+        if (column.getPrimitiveType().isCharFamily() || column.getPrimitiveType().isJsonType()) {
             if (isSample) {
                 return "IFNULL(SUM(CHAR_LENGTH(`" + column.getName() + "`) * t1.count), 0)";
             }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Fix what
Misestimate the cost of plan node than contains the JSON type. E.g. the following SCAN costs `0` though it has 6001215 rows of data.

```sql
MySQL sb_json> explain logical select count(*) from lineorder_flat_json;
+---------------------------------------------------------------------------------------+
| Explain String                                                                        |
+---------------------------------------------------------------------------------------+
| - Output => [4:count]                                                                 |
|     - AGGREGATE(GLOBAL) []                                                            |
|             Estimates: {row: 1, cpu: 0.00, memory: 8.00, network: 0.00}               |
|             4:count := count()                                                        |
|         - EXCHANGE(GATHER)                                                            |
|                 Estimates: {row: 6001215, cpu: 0.00, memory: 0.00, network: 0.00}     |
|             - SCAN [lineorder_flat_json] => [3:j]                                     |
|                     Estimates: {row: 6001215, cpu: 0.00, memory: 0.00, network: 0.00} |
|                     partitionRatio: 7/7, tabletRatio: 336/336                         |
+---------------------------------------------------------------------------------------+
9 rows in set
```


## Modification
1. Fix typeSize estimation of JSON
2. Use `char_length` function to calculate the row-size of JSON
3. Modify the Statistic, make the least row-size to 1, avoid huge cost estimate error


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Statistic for JSON type is inaccurate, which make `select count(*) from json_table` generates one stage aggregation plan, which is in-efficient. 


