### PR TITLE
Refactor subquery from queryRelation to queryStatement

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/Subquery.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/Subquery.java
@@ -29,9 +29,10 @@ import com.starrocks.catalog.StructField;
 import com.starrocks.catalog.StructType;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.UserException;
+import com.starrocks.sql.analyzer.AST2SQL;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AstVisitor;
-import com.starrocks.sql.ast.QueryRelation;
+import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.thrift.TExprNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,7 +68,7 @@ public class Subquery extends Expr {
         if (stmt != null) {
             return "(" + stmt.toSql() + ")";
         } else {
-            return "(" + queryRelation.toSql() + ")";
+            return "(" + AST2SQL.toString(queryStatement) + ")";
         }
     }
 
@@ -98,9 +99,9 @@ public class Subquery extends Expr {
     }
 
 
-    public Subquery(QueryRelation queryBlock) {
+    public Subquery(QueryStatement queryStatement) {
         super();
-        this.queryRelation = queryBlock;
+        this.queryStatement = queryStatement;
     }
 
     /**
@@ -214,11 +215,11 @@ public class Subquery extends Expr {
             return false;
         }
 
-        if (queryRelation != null) {
-            if (((Subquery) o).getQueryRelation() == null) {
+        if (queryStatement != null) {
+            if (((Subquery) o).getQueryStatement() == null) {
                 return false;
             } else {
-                return o.equals(queryRelation);
+                return o.equals(queryStatement);
             }
         }
 
@@ -249,13 +250,9 @@ public class Subquery extends Expr {
     /**
      * Analyzed subquery is store as QueryBlock
      */
-    private QueryRelation queryRelation;
+    private QueryStatement queryStatement;
 
-    public void setQueryRelation(QueryRelation queryRelation) {
-        this.queryRelation = queryRelation;
-    }
-
-    public QueryRelation getQueryRelation() {
-        return queryRelation;
+    public QueryStatement getQueryStatement() {
+        return queryStatement;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AST2SQL.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AST2SQL.java
@@ -106,7 +106,7 @@ public class AST2SQL {
             if (relation.getColumnOutputNames() != null) {
                 sqlBuilder.append("(").append(Joiner.on(", ").join(relation.getColumnOutputNames())).append(")");
             }
-            sqlBuilder.append(" AS (").append(visit(new QueryStatement(relation.getCteQuery()))).append(") ");
+            sqlBuilder.append(" AS (").append(visit(relation.getCteQueryStatement())).append(") ");
             return sqlBuilder.toString();
         }
 
@@ -169,7 +169,7 @@ public class AST2SQL {
         public String visitSubquery(SubqueryRelation subquery, Void context) {
             StringBuilder sqlBuilder = new StringBuilder();
             sqlBuilder.append("(");
-            sqlBuilder.append(visit(new QueryStatement(subquery.getQuery())));
+            sqlBuilder.append(visit(subquery.getQueryStatement()));
             sqlBuilder.append(")");
             sqlBuilder.append(" ").append(subquery.getAlias());
             return sqlBuilder.toString();
@@ -179,7 +179,7 @@ public class AST2SQL {
         public String visitView(ViewRelation node, Void context) {
             StringBuilder sqlBuilder = new StringBuilder();
             sqlBuilder.append("(");
-            sqlBuilder.append(visit(new QueryStatement(node.getQuery())));
+            sqlBuilder.append(visit(node.getQueryStatement()));
             sqlBuilder.append(")");
             sqlBuilder.append(" ").append(node.getAlias());
             return sqlBuilder.toString();
@@ -479,7 +479,7 @@ public class AST2SQL {
         }
 
         public String visitSubquery(Subquery node, Void context) {
-            return "(" + visit(new QueryStatement(node.getQueryRelation())) + ")";
+            return "(" + visit(node.getQueryStatement()) + ")";
         }
 
         public String visitSysVariableDesc(SysVariableDesc node, Void context) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AggregationAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AggregationAnalyzer.java
@@ -30,7 +30,7 @@ import com.starrocks.analysis.SysVariableDesc;
 import com.starrocks.analysis.TimestampArithmeticExpr;
 import com.starrocks.catalog.AggregateFunction;
 import com.starrocks.sql.ast.AstVisitor;
-import com.starrocks.sql.ast.QueryRelation;
+import com.starrocks.sql.ast.QueryStatement;
 
 import java.util.List;
 import java.util.Objects;
@@ -266,8 +266,8 @@ public class AggregationAnalyzer {
 
         @Override
         public Boolean visitSubquery(Subquery node, Void context) {
-            QueryRelation qb = node.getQueryRelation();
-            List<FieldId> fieldIds = qb.getColumnReferences().values().stream()
+            QueryStatement queryStatement = node.getQueryStatement();
+            List<FieldId> fieldIds = queryStatement.getQueryRelation().getColumnReferences().values().stream()
                     .filter(fieldId -> fieldId.getRelationId().equals(sourceScope.getRelationId()))
                     .collect(Collectors.toList());
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -152,12 +152,12 @@ public class AnalyzerUtils {
 
         @Override
         public Void visitSubquery(SubqueryRelation node, Void context) {
-            return visit(node.getQuery());
+            return visit(node.getQueryStatement());
         }
 
         public Void visitView(ViewRelation node, Void context) {
             getDB(node.getName());
-            return visit(node.getQuery(), context);
+            return visit(node.getQueryStatement(), context);
         }
 
         @Override
@@ -178,7 +178,7 @@ public class AnalyzerUtils {
 
         @Override
         public Void visitCTE(CTERelation node, Void context) {
-            return visit(node.getCteQuery());
+            return visit(node.getCteQueryStatement());
         }
 
         @Override
@@ -229,12 +229,12 @@ public class AnalyzerUtils {
 
         @Override
         public Void visitSubquery(SubqueryRelation node, Void context) {
-            return visit(node.getQuery());
+            return visit(node.getQueryStatement());
         }
 
 
         public Void visitView(ViewRelation node, Void context) {
-            return visit(node.getQuery(), context);
+            return visit(node.getQueryStatement(), context);
         }
 
         @Override
@@ -264,7 +264,7 @@ public class AnalyzerUtils {
 
         @Override
         public Void visitCTE(CTERelation node, Void context) {
-            return visit(node.getCteQuery());
+            return visit(node.getCteQueryStatement());
         }
 
         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitor.java
@@ -109,44 +109,44 @@ public abstract class AstVisitor<R, C> {
         return visitDDLStatement(statement, context);
     }
 
-    public R visitQueryStatement(QueryStatement node, C context) {
-        return visitStatement(node, context);
+    public R visitQueryStatement(QueryStatement statement, C context) {
+        return visitStatement(statement, context);
     }
 
-    public R visitInsertStatement(InsertStmt node, C context) {
-        return visitStatement(node, context);
+    public R visitInsertStatement(InsertStmt statement, C context) {
+        return visitStatement(statement, context);
     }
 
-    public R visitUpdateStatement(UpdateStmt node, C context) {
-        return visitStatement(node, context);
+    public R visitUpdateStatement(UpdateStmt statement, C context) {
+        return visitStatement(statement, context);
     }
 
     public R visitShowStatement(ShowStmt statement, C context) {
         return visitStatement(statement, context);
     }
 
-    public R visitShowTableStmt(ShowTableStmt node, C context) {
-        return visitShowStatement(node, context);
+    public R visitShowTableStmt(ShowTableStmt statement, C context) {
+        return visitShowStatement(statement, context);
     }
 
-    public R visitShowDatabasesStmt(ShowDbStmt node, C context) {
-        return visitShowStatement(node, context);
+    public R visitShowDatabasesStmt(ShowDbStmt statement, C context) {
+        return visitShowStatement(statement, context);
     }
 
-    public R visitShowWorkGroupStmt(ShowWorkGroupStmt node, C context) {
-        return visitShowStatement(node, context);
+    public R visitShowWorkGroupStmt(ShowWorkGroupStmt statement, C context) {
+        return visitShowStatement(statement, context);
     }
 
-    public R visitShowVariablesStmt(ShowVariablesStmt node, C context) {
-        return visitShowStatement(node, context);
+    public R visitShowVariablesStmt(ShowVariablesStmt statement, C context) {
+        return visitShowStatement(statement, context);
     }
 
-    public R visitShowColumnStmt(ShowColumnStmt node, C context) {
-        return visitShowStatement(node, context);
+    public R visitShowColumnStmt(ShowColumnStmt statement, C context) {
+        return visitShowStatement(statement, context);
     }
 
-    public R visitShowTableStatusStmt(ShowTableStatusStmt node, C context) {
-        return visitShowStatement(node, context);
+    public R visitShowTableStatusStmt(ShowTableStatusStmt statement, C context) {
+        return visitShowStatement(statement, context);
     }
 
     // ----------------- Relation ---------------

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CTERelation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CTERelation.java
@@ -10,18 +10,18 @@ public class CTERelation extends Relation {
     private final int cteId;
     private final String name;
     private List<String> columnOutputNames;
-    private final QueryRelation cteQuery;
+    private final QueryStatement cteQueryStatement;
     private boolean resolvedInFromClause;
 
-    public CTERelation(int cteId, String name, List<String> columnOutputNames, QueryRelation cteQuery) {
+    public CTERelation(int cteId, String name, List<String> columnOutputNames, QueryStatement cteQueryStatement) {
         this.cteId = cteId;
         this.name = name;
         this.columnOutputNames = columnOutputNames;
-        this.cteQuery = cteQuery;
+        this.cteQueryStatement = cteQueryStatement;
     }
 
-    public QueryRelation getCteQuery() {
-        return cteQuery;
+    public QueryStatement getCteQueryStatement() {
+        return cteQueryStatement;
     }
 
     public int getCteId() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SubqueryRelation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SubqueryRelation.java
@@ -4,21 +4,21 @@ package com.starrocks.sql.ast;
 import com.starrocks.analysis.TableName;
 
 public class SubqueryRelation extends Relation {
-    private String name;
-    private final QueryRelation query;
+    private final String name;
+    private final QueryStatement queryStatement;
 
-    public SubqueryRelation(String name, QueryRelation query) {
+    public SubqueryRelation(String name, QueryStatement queryStatement) {
         this.name = name;
         if (name != null) {
             this.alias = new TableName(null, name);
         } else {
             this.alias = null;
         }
-        this.query = query;
+        this.queryStatement = queryStatement;
         // The order by is meaningless in subquery
-        if (this.query instanceof SelectRelation && !((SelectRelation) this.query).hasLimit()) {
-            SelectRelation qs = (SelectRelation) this.query;
-            qs.clearOrder();
+        QueryRelation queryRelation = this.queryStatement.getQueryRelation();
+        if (!queryRelation.hasLimit()) {
+            queryRelation.clearOrder();
         }
     }
 
@@ -26,8 +26,8 @@ public class SubqueryRelation extends Relation {
         return name;
     }
 
-    public QueryRelation getQuery() {
-        return query;
+    public QueryStatement getQueryStatement() {
+        return queryStatement;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ViewRelation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ViewRelation.java
@@ -5,11 +5,11 @@ import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.View;
 
 public class ViewRelation extends Relation {
-    private TableName name;
-    private View view;
-    private final QueryRelation query;
+    private final TableName name;
+    private final View view;
+    private final QueryStatement queryStatement;
 
-    public ViewRelation(TableName name, View view, QueryRelation query) {
+    public ViewRelation(TableName name, View view, QueryStatement queryStatement) {
         this.name = name;
         if (name != null) {
             this.alias = name;
@@ -17,11 +17,11 @@ public class ViewRelation extends Relation {
             this.alias = null;
         }
         this.view = view;
-        this.query = query;
+        this.queryStatement = queryStatement;
         // The order by is meaningless in subquery
-        if (this.query instanceof SelectRelation && !this.query.hasLimit()) {
-            SelectRelation qs = (SelectRelation) this.query;
-            qs.clearOrder();
+        QueryRelation queryRelation = this.queryStatement.getQueryRelation();
+        if (!queryRelation.hasLimit()) {
+            queryRelation.clearOrder();
         }
     }
 
@@ -33,8 +33,8 @@ public class ViewRelation extends Relation {
         return view;
     }
 
-    public QueryRelation getQuery() {
-        return query;
+    public QueryStatement getQueryStatement() {
+        return queryStatement;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/UnsupportedException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/UnsupportedException.java
@@ -1,14 +1,12 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
 package com.starrocks.sql.common;
 
-import static java.lang.String.format;
-
 public class UnsupportedException extends StarRocksPlannerException {
-    private UnsupportedException(String formatString, Object... args) {
-        super(format(formatString, args), ErrorType.UNSUPPORTED);
+    private UnsupportedException(String formatString) {
+        super(formatString, ErrorType.UNSUPPORTED);
     }
 
-    public static UnsupportedException unsupportedException(String formatString, Object... args) {
-        throw new UnsupportedException(format(formatString, args));
+    public static UnsupportedException unsupportedException(String formatString) {
+        throw new UnsupportedException(formatString);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
@@ -35,6 +35,7 @@ import com.starrocks.sql.ast.ExceptRelation;
 import com.starrocks.sql.ast.IntersectRelation;
 import com.starrocks.sql.ast.JoinRelation;
 import com.starrocks.sql.ast.QueryRelation;
+import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.Relation;
 import com.starrocks.sql.ast.SelectRelation;
 import com.starrocks.sql.ast.SetOperationRelation;
@@ -160,7 +161,7 @@ public class RelationTransformer extends AstVisitor<LogicalPlan, ExpressionMappi
             LogicalPlan producerPlan =
                     new RelationTransformer(columnRefFactory, session,
                             new ExpressionMapping(new Scope(RelationId.anonymous(), new RelationFields())),
-                            cteContext).transform(cteRelation.getCteQuery());
+                            cteContext).transform(cteRelation.getCteQueryStatement().getQueryRelation());
             OptExprBuilder produceOptBuilder =
                     new OptExprBuilder(produceOperator, Lists.newArrayList(producerPlan.getRootBuilder()),
                             producerPlan.getRootBuilder().getExpressionMapping());
@@ -176,7 +177,9 @@ public class RelationTransformer extends AstVisitor<LogicalPlan, ExpressionMappi
             anchorOptBuilder = newAnchorOptBuilder;
 
             cteContext.put(cteRelation.getCteId(), new ExpressionMapping(
-                    new Scope(RelationId.of(cteRelation.getCteQuery()), cteRelation.getRelationFields()),
+                    new Scope(RelationId.of(
+                            cteRelation.getCteQueryStatement().getQueryRelation()),
+                            cteRelation.getRelationFields()),
                     producerPlan.getOutputColumn()));
         }
 
@@ -184,8 +187,8 @@ public class RelationTransformer extends AstVisitor<LogicalPlan, ExpressionMappi
     }
 
     @Override
-    public LogicalPlan visitQueryRelation(QueryRelation node, ExpressionMapping context) {
-        throw new StarRocksPlannerException("query block not materialized", ErrorType.INTERNAL_ERROR);
+    public LogicalPlan visitQueryStatement(QueryStatement node, ExpressionMapping context) {
+        return visit(node.getQueryRelation());
     }
 
     @Override
@@ -469,7 +472,7 @@ public class RelationTransformer extends AstVisitor<LogicalPlan, ExpressionMappi
 
     @Override
     public LogicalPlan visitCTE(CTERelation node, ExpressionMapping context) {
-        LogicalPlan childPlan = visit(node.getCteQuery());
+        LogicalPlan childPlan = visit(node.getCteQueryStatement());
         ExpressionMapping expressionMapping = cteContext.get(node.getCteId());
         Map<ColumnRefOperator, ColumnRefOperator> cteOutputColumnRefMap = new HashMap<>();
 
@@ -493,7 +496,7 @@ public class RelationTransformer extends AstVisitor<LogicalPlan, ExpressionMappi
 
     @Override
     public LogicalPlan visitSubquery(SubqueryRelation node, ExpressionMapping context) {
-        LogicalPlan logicalPlan = transform(node.getQuery());
+        LogicalPlan logicalPlan = transform(node.getQueryStatement().getQueryRelation());
         OptExprBuilder builder = new OptExprBuilder(
                 logicalPlan.getRoot().getOp(),
                 logicalPlan.getRootBuilder().getInputs(),
@@ -503,7 +506,7 @@ public class RelationTransformer extends AstVisitor<LogicalPlan, ExpressionMappi
 
     @Override
     public LogicalPlan visitView(ViewRelation node, ExpressionMapping context) {
-        LogicalPlan logicalPlan = transform(node.getQuery());
+        LogicalPlan logicalPlan = transform(node.getQueryStatement().getQueryRelation());
         OptExprBuilder builder = new OptExprBuilder(
                 logicalPlan.getRoot().getOp(),
                 logicalPlan.getRootBuilder().getInputs(),

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
@@ -33,6 +33,7 @@ import com.starrocks.catalog.Catalog;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.Type;
+import com.starrocks.sql.analyzer.AST2SQL;
 import com.starrocks.sql.analyzer.ResolvedField;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AstVisitor;
@@ -473,7 +474,7 @@ public final class SqlToScalarOperatorTranslator {
 
         @Override
         public ScalarOperator visitSubquery(Subquery node, Void context) {
-            throw unsupportedException("complex subquery on " + node.toSql());
+            throw unsupportedException("complex subquery on " + AST2SQL.toString(node));
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JsonTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JsonTypeTest.java
@@ -4,7 +4,6 @@ package com.starrocks.sql.plan;
 
 import com.starrocks.common.ExceptionChecker;
 import com.starrocks.sql.analyzer.SemanticException;
-import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -147,7 +146,7 @@ public class JsonTypeTest extends PlanTestBase {
             ExceptionChecker.expectThrowsWithMsg(
                     SemanticException.class,
                     String.format(
-                            "Invalid type cast from json to %s in sql ``default_cluster:test`.`tjson_test`.`v_json``",
+                            "Invalid type cast from json to %s in sql `v_json`",
                             notAllowType),
                     () -> getFragmentPlan(columnCastSql)
             );


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4480
Fixes #4481

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Replace the queryRelation stored in the original subquery with QueryStatement. Because queryRelation is an abstract class, it cannot be directly visited, but queryRelation contains the public parts of query (CTE, SORT). The logic of this part is unified in visitQueryStatement. The substitution here can avoid the wrong use of visit access
