### PR TITLE
Fix ExecNode close

### DIFF
--- a/be/src/exec/empty_set_node.cpp
+++ b/be/src/exec/empty_set_node.cpp
@@ -29,6 +29,12 @@ namespace starrocks {
 EmptySetNode::EmptySetNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs)
         : ExecNode(pool, tnode, descs) {}
 
+Status EmptySetNode::init(const TPlanNode& tnode, RuntimeState* state) {
+    ExecNode::init(tnode, state);
+    finish_init();
+    return Status::OK();
+}
+
 Status EmptySetNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) {
     *eos = true;
     return Status::OK();

--- a/be/src/exec/empty_set_node.h
+++ b/be/src/exec/empty_set_node.h
@@ -30,6 +30,7 @@ namespace starrocks {
 class EmptySetNode final : public ExecNode {
 public:
     EmptySetNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs);
+    Status init(const TPlanNode& tnode, RuntimeState* state) override;
     Status get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) override;
 
     pipeline::OpFactories decompose_to_pipeline(pipeline::PipelineBuilderContext* context) override;

--- a/be/src/exec/exchange_node.cpp
+++ b/be/src/exec/exchange_node.cpp
@@ -60,6 +60,8 @@ Status ExchangeNode::init(const TPlanNode& tnode, RuntimeState* state) {
     RETURN_IF_ERROR(_sort_exec_exprs.init(tnode.exchange_node.sort_info, _pool));
     _is_asc_order = tnode.exchange_node.sort_info.is_asc_order;
     _nulls_first = tnode.exchange_node.sort_info.nulls_first;
+
+    finish_init();
     return Status::OK();
 }
 

--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -187,7 +187,6 @@ Status ExecNode::init(const TPlanNode& tnode, RuntimeState* state) {
     if (tnode.__isset.local_rf_waiting_set) {
         _local_rf_waiting_set = tnode.local_rf_waiting_set;
     }
-    _construct_state = INITIALIZED;
     return Status::OK();
 }
 

--- a/be/src/exec/exec_node.h
+++ b/be/src/exec/exec_node.h
@@ -275,6 +275,8 @@ protected:
 
     bool is_closed() const { return _construct_state != INITIALIZED; }
 
+    void finish_init() { _construct_state = INITIALIZED; }
+
     // TODO(zc)
     /// Pointer to the containing SubplanNode or NULL if not inside a subplan.
     /// Set by SubplanNode::Init(). Not owned.

--- a/be/src/exec/exec_node.h
+++ b/be/src/exec/exec_node.h
@@ -273,7 +273,7 @@ protected:
 
     ExecNode* child(int i) { return _children[i]; }
 
-    bool is_closed() const { return _is_closed; }
+    bool is_closed() const { return _construct_state != INITIALIZED; }
 
     // TODO(zc)
     /// Pointer to the containing SubplanNode or NULL if not inside a subplan.
@@ -301,7 +301,13 @@ protected:
     Status exec_debug_action(TExecNodePhase::type phase);
 
 private:
+    enum ConstructState {
+        UNKNOWN,     // Uninitialized
+        INITIALIZED, // Already initialized
+        CLOSED       // Closed
+    };
+
     RuntimeState* _runtime_state;
-    bool _is_closed;
+    ConstructState _construct_state = UNKNOWN;
 };
 } // namespace starrocks

--- a/be/src/exec/select_node.cpp
+++ b/be/src/exec/select_node.cpp
@@ -40,6 +40,12 @@ SelectNode::~SelectNode() {
     }
 }
 
+Status SelectNode::init(const TPlanNode& tnode, RuntimeState* state) {
+    ExecNode::init(tnode, state);
+    finish_init();
+    return Status::OK();
+}
+
 Status SelectNode::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(ExecNode::prepare(state));
     if (use_vectorized()) {

--- a/be/src/exec/select_node.h
+++ b/be/src/exec/select_node.h
@@ -34,6 +34,7 @@ public:
     SelectNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs);
     ~SelectNode();
 
+    Status init(const TPlanNode& tnode, RuntimeState* state) override;
     Status prepare(RuntimeState* state) override;
     Status open(RuntimeState* state) override;
     Status get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) override;

--- a/be/src/exec/vectorized/aggregate/aggregate_base_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_base_node.cpp
@@ -19,6 +19,7 @@ AggregateBaseNode::~AggregateBaseNode() {
 Status AggregateBaseNode::init(const TPlanNode& tnode, RuntimeState* state) {
     RETURN_IF_ERROR(ExecNode::init(tnode, state));
     RETURN_IF_ERROR(Expr::create_expr_trees(_pool, tnode.agg_node.grouping_exprs, &_group_by_expr_ctxs));
+    finish_init();
     return Status::OK();
 }
 Status AggregateBaseNode::prepare(RuntimeState* state) {

--- a/be/src/exec/vectorized/analytic_node.cpp
+++ b/be/src/exec/vectorized/analytic_node.cpp
@@ -52,7 +52,7 @@ AnalyticNode::AnalyticNode(ObjectPool* pool, const TPlanNode& tnode, const Descr
 Status AnalyticNode::init(const TPlanNode& tnode, RuntimeState* state) {
     RETURN_IF_ERROR(ExecNode::init(tnode, state));
     DCHECK(_conjunct_ctxs.empty());
-
+    finish_init();
     return Status::OK();
 }
 

--- a/be/src/exec/vectorized/assert_num_rows_node.cpp
+++ b/be/src/exec/vectorized/assert_num_rows_node.cpp
@@ -27,6 +27,7 @@ AssertNumRowsNode::AssertNumRowsNode(ObjectPool* pool, const TPlanNode& tnode, c
 
 Status AssertNumRowsNode::init(const TPlanNode& tnode, RuntimeState* state) {
     RETURN_IF_ERROR(ExecNode::init(tnode, state));
+    finish_init();
     return Status::OK();
 }
 

--- a/be/src/exec/vectorized/cross_join_node.cpp
+++ b/be/src/exec/vectorized/cross_join_node.cpp
@@ -23,6 +23,7 @@ Status CrossJoinNode::init(const TPlanNode& tnode, RuntimeState* state) {
     if (tnode.__isset.need_create_tuple_columns) {
         _need_create_tuple_columns = tnode.need_create_tuple_columns;
     }
+    finish_init();
     return Status::OK();
 }
 

--- a/be/src/exec/vectorized/dict_decode_node.cpp
+++ b/be/src/exec/vectorized/dict_decode_node.cpp
@@ -36,6 +36,7 @@ Status DictDecodeNode::init(const TPlanNode& tnode, RuntimeState* state) {
         _decode_column_cids.emplace_back(decode_id);
     }
 
+    finish_init();
     return Status::OK();
 }
 

--- a/be/src/exec/vectorized/es_http_scan_node.cpp
+++ b/be/src/exec/vectorized/es_http_scan_node.cpp
@@ -51,6 +51,7 @@ Status EsHttpScanNode::init(const TPlanNode& tnode, RuntimeState* state) {
         _fields_context = es_scan_node.fields_context;
     }
 
+    finish_init();
     return Status::OK();
 }
 

--- a/be/src/exec/vectorized/except_node.cpp
+++ b/be/src/exec/vectorized/except_node.cpp
@@ -30,6 +30,7 @@ Status ExceptNode::init(const TPlanNode& tnode, RuntimeState* state) {
         RETURN_IF_ERROR(Expr::create_expr_trees(_pool, texprs, &ctxs));
         _child_expr_lists.push_back(ctxs);
     }
+    finish_init();
     return Status::OK();
 }
 

--- a/be/src/exec/vectorized/file_scan_node.cpp
+++ b/be/src/exec/vectorized/file_scan_node.cpp
@@ -32,6 +32,7 @@ FileScanNode::~FileScanNode() {
 
 Status FileScanNode::init(const TPlanNode& tnode, RuntimeState* state) {
     RETURN_IF_ERROR(ScanNode::init(tnode, state));
+    finish_init();
     return Status::OK();
 }
 

--- a/be/src/exec/vectorized/hash_join_node.cpp
+++ b/be/src/exec/vectorized/hash_join_node.cpp
@@ -111,6 +111,8 @@ Status HashJoinNode::init(const TPlanNode& tnode, RuntimeState* state) {
     if (tnode.hash_join_node.__isset.output_columns) {
         _output_slots.insert(tnode.hash_join_node.output_columns.begin(), tnode.hash_join_node.output_columns.end());
     }
+
+    finish_init();
     return Status::OK();
 }
 

--- a/be/src/exec/vectorized/hdfs_scan_node.cpp
+++ b/be/src/exec/vectorized/hdfs_scan_node.cpp
@@ -130,6 +130,7 @@ Status HdfsScanNode::init(const TPlanNode& tnode, RuntimeState* state) {
         _runtime_profile->add_info_string("PredicatesPartition", hdfs_scan_node.partition_sql_predicates);
     }
 
+    finish_init();
     return Status::OK();
 }
 

--- a/be/src/exec/vectorized/hdfs_scan_node.cpp
+++ b/be/src/exec/vectorized/hdfs_scan_node.cpp
@@ -450,9 +450,7 @@ void HdfsScanNode::_scanner_thread(HdfsScanner* scanner) {
         }
     } else {
         // sometimes state == ok but global_status was not ok
-        if (scanner != nullptr) {
             _release_scanner(scanner);
-        }
     }
 }
 

--- a/be/src/exec/vectorized/hdfs_scan_node.cpp
+++ b/be/src/exec/vectorized/hdfs_scan_node.cpp
@@ -451,7 +451,7 @@ void HdfsScanNode::_scanner_thread(HdfsScanner* scanner) {
         }
     } else {
         // sometimes state == ok but global_status was not ok
-            _release_scanner(scanner);
+        _release_scanner(scanner);
     }
 }
 

--- a/be/src/exec/vectorized/intersect_node.cpp
+++ b/be/src/exec/vectorized/intersect_node.cpp
@@ -33,6 +33,7 @@ Status IntersectNode::init(const TPlanNode& tnode, RuntimeState* state) {
         RETURN_IF_ERROR(Expr::create_expr_trees(_pool, texprs, &ctxs));
         _child_expr_lists.push_back(ctxs);
     }
+    finish_init();
     return Status::OK();
 }
 

--- a/be/src/exec/vectorized/olap_meta_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_meta_scan_node.cpp
@@ -19,6 +19,7 @@ OlapMetaScanNode::~OlapMetaScanNode() {
 
 Status OlapMetaScanNode::init(const TPlanNode& tnode, RuntimeState* state) {
     RETURN_IF_ERROR(ExecNode::init(tnode, state));
+    finish_init();
     return Status::OK();
 }
 

--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -42,6 +42,7 @@ Status OlapScanNode::init(const TPlanNode& tnode, RuntimeState* state) {
         _unused_output_columns.emplace_back(col_name);
     }
 
+    finish_init();
     return Status::OK();
 }
 

--- a/be/src/exec/vectorized/project_node.cpp
+++ b/be/src/exec/vectorized/project_node.cpp
@@ -69,6 +69,7 @@ Status ProjectNode::init(const TPlanNode& tnode, RuntimeState* state) {
         _common_sub_expr_ctxs.emplace_back(context);
     }
 
+    finish_init();
     return Status::OK();
 }
 

--- a/be/src/exec/vectorized/schema_scan_node.cpp
+++ b/be/src/exec/vectorized/schema_scan_node.cpp
@@ -63,6 +63,7 @@ Status SchemaScanNode::init(const TPlanNode& tnode, RuntimeState* state) {
     if (tnode.schema_scan_node.__isset.thread_id) {
         _scanner_param.thread_id = tnode.schema_scan_node.thread_id;
     }
+    finish_init();
     return Status::OK();
 }
 

--- a/be/src/exec/vectorized/table_function_node.cpp
+++ b/be/src/exec/vectorized/table_function_node.cpp
@@ -65,6 +65,7 @@ Status TableFunctionNode::init(const TPlanNode& tnode, RuntimeState* state) {
     _table_function_result_eos = true;
     _outer_column_remain_repeat_times = 0;
 
+    finish_init();
     return Status::OK();
 }
 

--- a/be/src/exec/vectorized/topn_node.cpp
+++ b/be/src/exec/vectorized/topn_node.cpp
@@ -64,6 +64,7 @@ Status TopNNode::init(const TPlanNode& tnode, RuntimeState* state) {
         _runtime_profile->add_info_string("SortKeys", tnode.sort_node.sql_sort_keys);
     }
     _runtime_profile->add_info_string("SortType", tnode.sort_node.use_top_n ? "TopN" : "All");
+    finish_init();
     return Status::OK();
 }
 

--- a/be/src/exec/vectorized/union_node.cpp
+++ b/be/src/exec/vectorized/union_node.cpp
@@ -47,6 +47,7 @@ Status UnionNode::init(const TPlanNode& tnode, RuntimeState* state) {
         }
     }
 
+    finish_init();
     return Status::OK();
 }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4518

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
We should not close a ExecNode if it's not initialized, so introduce a `_construct_state` to represent whether it has been initialized or closed.

Every ExecNode should set this state only after it really initializes.


