### PR TITLE
BugFix: Be crash using shared tablet schema

### DIFF
--- a/be/src/storage/tablet_schema_map.cpp
+++ b/be/src/storage/tablet_schema_map.cpp
@@ -24,7 +24,7 @@ bool TabletSchemaMap::check_schema_unique_id(const TabletSchemaPB& schema_pb,
         return false;
     }
 
-    for (size_t i = 0; schema_ptr->num_columns(); ++i) {
+    for (size_t i = 0; i < schema_ptr->num_columns(); ++i) {
         int32_t pb_unique_id = schema_pb.column(i).unique_id();
         int32_t unique_id = schema_ptr->column(i).unique_id();
         if (pb_unique_id != unique_id) {

--- a/be/src/storage/tablet_schema_map.cpp
+++ b/be/src/storage/tablet_schema_map.cpp
@@ -17,6 +17,24 @@ static void get_stats(std::ostream& os, void*) {
 // NOLINTNEXTLINE
 bvar::PassiveStatus<std::string> g_schema_map_stats("tablet_schema_map", get_stats, NULL);
 
+bool TabletSchemaMap::check_schema_unique_id(const TabletSchemaPB& schema_pb,
+                                             const std::shared_ptr<const TabletSchema>& schema_ptr) {
+    if (schema_pb.next_column_unique_id() != schema_ptr->next_column_unique_id() ||
+        schema_pb.column_size() != schema_ptr->num_columns()) {
+        return false;
+    }
+
+    for (size_t i = 0; schema_ptr->num_columns(); ++i) {
+        int32_t pb_unique_id = schema_pb.column(i).unique_id();
+        int32_t unique_id = schema_ptr->column(i).unique_id();
+        if (pb_unique_id != unique_id) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 std::pair<TabletSchemaMap::TabletSchemaPtr, bool> TabletSchemaMap::emplace(const TabletSchemaPB& schema_pb) {
     SchemaId id = schema_pb.id();
     DCHECK_NE(TabletSchema::invalid_id(), id);
@@ -35,6 +53,11 @@ std::pair<TabletSchemaMap::TabletSchemaPtr, bool> TabletSchemaMap::emplace(const
             it->second = std::weak_ptr<const TabletSchema>(ptr);
             return std::make_pair(ptr, true);
         } else {
+            if (UNLIKELY(!check_schema_unique_id(schema_pb, ptr))) {
+                ptr = TabletSchema::create(_mem_tracker, schema_pb, this);
+                it->second = std::weak_ptr<const TabletSchema>(ptr);
+                return std::make_pair(ptr, true);
+            }
             return std::make_pair(ptr, false);
         }
     }

--- a/be/src/storage/tablet_schema_map.h
+++ b/be/src/storage/tablet_schema_map.h
@@ -63,6 +63,8 @@ public:
 private:
     constexpr static int kShardSize = 16;
 
+    bool check_schema_unique_id(const TabletSchemaPB& schema_pb, const std::shared_ptr<const TabletSchema>& schema_ptr);
+
     struct MapShard {
         mutable std::mutex mtx;
         phmap::flat_hash_map<SchemaId, std::weak_ptr<const TabletSchema>> map;


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4514

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
We use shared tablet schema to save memory usage, but the premise is that we need to ensure that no two different TabletSchemaPBs have the same `id()`.

However, we can't guarantee it after schema change so far. Because the `unique_id` is generated by being itself and the `unique_id` of the same column may be different in the different tablets. 

If we use the error `unique_id` of tablet schema, we can get be crash or error result. So we need to check the consistency of `unique_id` before using the shared tablet schema.
