### PR TITLE
fix result column size error when handling const column in truncate_decimal128

### DIFF
--- a/be/test/exprs/vectorized/math_functions_test.cpp
+++ b/be/test/exprs/vectorized/math_functions_test.cpp
@@ -97,6 +97,7 @@ static void testRoundDecimal(const std::vector<std::string>& arg0_values, const 
     for (auto i = 0; i < arg0_values.size(); i++) {
         if (!arg0_null_flags.empty() && arg0_null_flags[i] == 1) {
             arg0_has_null = true;
+            arg0_data_column->append_default(1);
             continue;
         }
         arg0_all_null = false;
@@ -111,6 +112,7 @@ static void testRoundDecimal(const std::vector<std::string>& arg0_values, const 
     for (auto i = 0; i < arg1_values.size(); i++) {
         if (!arg1_null_flags.empty() && arg1_null_flags[i] == 1) {
             arg1_has_null = true;
+            arg1_data_column->append_default(1);
             continue;
         }
         arg1_all_null = false;
@@ -311,6 +313,12 @@ TEST_F(VecMathFunctionsTest, DecimalTruncateByColTest) {
             {"123.45678", "INVALID", "123.45678", "123.45678", "123.45678", "123.45678", "123.45678"},
             {0, 1, 0, 0, 0, 0, 0}, 15, 5, {0, 1, 2, 3, 4, 5, 6}, {0, 0, 0, 0, 0, 0, 1},
             {"123", "INVALID", "123.45000", "123.45600", "123.45670", "123.45678", "INVALID"}, {0, 1, 0, 0, 0, 0, 1});
+    // truncate(v,d), v is const column
+    testRoundDecimal<TYPE_TRUNCATE>(
+            {"12345.6789", "12345.6789", "12345.6789", "12345.6789"}, {}, 15, 5,
+            {1, 2, 3, 4}, {},
+            {"12345.60000", "12345.67000", "12345.67800", "12345.67890"}, {}
+    );
 }
 
 TEST_F(VecMathFunctionsTest, RoundUpToTest) {

--- a/build.sh
+++ b/build.sh
@@ -192,6 +192,14 @@ if [ ${BUILD_BE} -eq 1 ] ; then
                     -DMAKE_TEST=OFF -DWITH_GCOV=${WITH_GCOV} -DUSE_AVX2=$USE_AVX2 -DUSE_SSE4_2=$USE_SSE4_2 -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
     time make -j${PARALLEL}
     make install
+
+    # Build JDBC Bridge
+    echo "Build JDBC Bridge"
+    cd ${STARROCKS_HOME}/jdbc_bridge
+    if [ ${CLEAN} -eq 1 ]; then
+        ${MVN_CMD} clean
+    fi
+    ${MVN_CMD} package -DskipTests
     cd ${STARROCKS_HOME}
 fi
 
@@ -218,15 +226,6 @@ if [ ${FE_MODULES}x != ""x ]; then
     ${MVN_CMD} package -pl ${FE_MODULES} -DskipTests
     cd ${STARROCKS_HOME}
 fi
-
-# Build JDBC Bridge
-echo "Build JDBC Bridge"
-cd ${STARROCKS_HOME}/jdbc_bridge
-if [ ${CLEAN} -eq 1 ]; then
-    ${MVN_CMD} clean
-fi
-${MVN_CMD} package -DskipTests
-cd ${STARROCKS_HOME}
 
 
 # Clean and prepare output dir

--- a/build.sh
+++ b/build.sh
@@ -192,14 +192,6 @@ if [ ${BUILD_BE} -eq 1 ] ; then
                     -DMAKE_TEST=OFF -DWITH_GCOV=${WITH_GCOV} -DUSE_AVX2=$USE_AVX2 -DUSE_SSE4_2=$USE_SSE4_2 -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
     time make -j${PARALLEL}
     make install
-
-    # Build JDBC Bridge
-    echo "Build JDBC Bridge"
-    cd ${STARROCKS_HOME}/jdbc_bridge
-    if [ ${CLEAN} -eq 1 ]; then
-        ${MVN_CMD} clean
-    fi
-    ${MVN_CMD} package -DskipTests
     cd ${STARROCKS_HOME}
 fi
 
@@ -226,6 +218,15 @@ if [ ${FE_MODULES}x != ""x ]; then
     ${MVN_CMD} package -pl ${FE_MODULES} -DskipTests
     cd ${STARROCKS_HOME}
 fi
+
+# Build JDBC Bridge
+echo "Build JDBC Bridge"
+cd ${STARROCKS_HOME}/jdbc_bridge
+if [ ${CLEAN} -eq 1 ]; then
+    ${MVN_CMD} clean
+fi
+${MVN_CMD} package -DskipTests
+cd ${STARROCKS_HOME}
 
 
 # Clean and prepare output dir


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4282

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This issue is cause by a mishandling of the size of the returned column in `truncate_decimal128` function.
The size of `c0` maybe changed after invoke `get_data_column_of_const`, we should keep the original size as the result column size.
