### PR TITLE
[WIP] reuse simdjson parser and buffer to speed up loading json

### DIFF
--- a/be/src/env/env_stream_pipe.cpp
+++ b/be/src/env/env_stream_pipe.cpp
@@ -21,8 +21,9 @@ StatusOr<int64_t> StreamPipeSequentialFile::read(void* data, int64_t size) {
     return nread;
 }
 
-Status StreamPipeSequentialFile::read_one_message(std::unique_ptr<uint8_t[]>* buf, size_t* length, size_t padding) {
-    return _file->read_one_message(buf, length, padding);
+Status StreamPipeSequentialFile::read_one_message(std::unique_ptr<uint8_t[]>* buf, size_t* capacity, size_t* length,
+                                                  size_t padding) {
+    return _file->read_one_message(buf, capacity, length, padding);
 }
 
 Status StreamPipeSequentialFile::skip(uint64_t n) {

--- a/be/src/env/env_stream_pipe.h
+++ b/be/src/env/env_stream_pipe.h
@@ -17,7 +17,7 @@ public:
 
     StatusOr<int64_t> read(void* data, int64_t size) override;
 
-    Status read_one_message(std::unique_ptr<uint8_t[]>* buf, size_t* length, size_t padding = 0);
+    Status read_one_message(std::unique_ptr<uint8_t[]>* buf, size_t* capacity, size_t* length, size_t padding = 0);
 
     Status skip(uint64_t n) override;
     const std::string& filename() const override { return _filename; }

--- a/be/src/exec/broker_reader.cpp
+++ b/be/src/exec/broker_reader.cpp
@@ -123,11 +123,6 @@ Status BrokerReader::open() {
     return Status::OK();
 }
 
-//not support
-Status BrokerReader::read_one_message(std::unique_ptr<uint8_t[]>* buf, size_t* length, size_t padding) {
-    return Status::NotSupported("Not support");
-}
-
 Status BrokerReader::read(uint8_t* buf, size_t* buf_len, bool* eof) {
     DCHECK_NE(*buf_len, 0);
     RETURN_IF_ERROR(readat(_cur_offset, (int64_t)*buf_len, (int64_t*)buf_len, buf));

--- a/be/src/exec/broker_reader.h
+++ b/be/src/exec/broker_reader.h
@@ -52,7 +52,6 @@ public:
 
     Status read(uint8_t* buf, size_t* buf_len, bool* eof) override;
     Status readat(int64_t position, int64_t nbytes, int64_t* bytes_read, void* out) override;
-    Status read_one_message(std::unique_ptr<uint8_t[]>* buf, size_t* length, size_t padding = 0) override;
     int64_t size() override;
     Status seek(int64_t position) override;
     Status tell(int64_t* position) override;

--- a/be/src/exec/buffered_reader.cpp
+++ b/be/src/exec/buffered_reader.cpp
@@ -49,11 +49,6 @@ Status BufferedReader::open() {
     return Status::OK();
 }
 
-//not support
-Status BufferedReader::read_one_message(std::unique_ptr<uint8_t[]>* buf, size_t* length, size_t padding) {
-    return Status::NotSupported("Not support");
-}
-
 Status BufferedReader::read(uint8_t* buf, size_t* buf_len, bool* eof) {
     DCHECK_NE(*buf_len, 0);
     int64_t bytes_read;

--- a/be/src/exec/buffered_reader.h
+++ b/be/src/exec/buffered_reader.h
@@ -44,7 +44,6 @@ public:
     // Read
     Status read(uint8_t* buf, size_t* buf_len, bool* eof) override;
     Status readat(int64_t position, int64_t nbytes, int64_t* bytes_read, void* out) override;
-    Status read_one_message(std::unique_ptr<uint8_t[]>* buf, size_t* length, size_t padding = 0) override;
     int64_t size() override;
     Status seek(int64_t position) override;
     Status tell(int64_t* position) override;

--- a/be/src/exec/file_reader.h
+++ b/be/src/exec/file_reader.h
@@ -43,6 +43,11 @@ public:
     /**
      * This interface is used read a whole message, For example: read a message from kafka.
      *
+     * buf: provided buffer, which could be re-allocated if the capacity is not enough.
+     * capacity: the given buffer's capacity, which would be updated if the buffer is re-allocated.
+     * length: bytes read.
+     * padding: extra bytes allocated in the buffer.
+     * 
      * if read eof then return Status::OK and length is set 0 and buf is set NULL,
      *  other return readed bytes.
      */

--- a/be/src/exec/file_reader.h
+++ b/be/src/exec/file_reader.h
@@ -46,7 +46,10 @@ public:
      * if read eof then return Status::OK and length is set 0 and buf is set NULL,
      *  other return readed bytes.
      */
-    virtual Status read_one_message(std::unique_ptr<uint8_t[]>* buf, size_t* length, size_t padding = 0) = 0;
+    virtual Status read_one_message(std::unique_ptr<uint8_t[]>* buf, size_t* capacity, size_t* length,
+                                    size_t padding = 0) {
+        return Status::NotSupported("Not support");
+    }
     virtual int64_t size() = 0;
     virtual Status seek(int64_t position) = 0;
     virtual Status tell(int64_t* position) = 0;

--- a/be/src/exec/local_file_reader.cpp
+++ b/be/src/exec/local_file_reader.cpp
@@ -59,7 +59,8 @@ bool LocalFileReader::closed() {
 }
 
 // Read all bytes
-Status LocalFileReader::read_one_message(std::unique_ptr<uint8_t[]>* buf, size_t* length, size_t padding) {
+Status LocalFileReader::read_one_message(std::unique_ptr<uint8_t[]>* buf, size_t* capacity, size_t* length,
+                                         size_t padding) {
     bool eof;
     int64_t file_size = size() - _current_offset;
     if (file_size <= 0) {
@@ -67,8 +68,13 @@ Status LocalFileReader::read_one_message(std::unique_ptr<uint8_t[]>* buf, size_t
         *length = 0;
         return Status::OK();
     }
+
+    if (*capacity < file_size + padding) {
+        buf->reset(new uint8_t[file_size + padding]);
+        *capacity = file_size + padding;
+    }
+
     *length = file_size;
-    buf->reset(new uint8_t[file_size + padding]);
     read(buf->get(), length, &eof);
     return Status::OK();
 }

--- a/be/src/exec/local_file_reader.h
+++ b/be/src/exec/local_file_reader.h
@@ -41,7 +41,8 @@ public:
     // is set to zero.
     Status read(uint8_t* buf, size_t* buf_len, bool* eof) override;
     Status readat(int64_t position, int64_t nbytes, int64_t* bytes_read, void* out) override;
-    Status read_one_message(std::unique_ptr<uint8_t[]>* buf, size_t* length, size_t padding = 0) override;
+    Status read_one_message(std::unique_ptr<uint8_t[]>* buf, size_t* capacity, size_t* length,
+                            size_t padding = 0) override;
     int64_t size() override;
     Status seek(int64_t position) override;
     Status tell(int64_t* position) override;

--- a/be/src/exec/vectorized/json_scanner.h
+++ b/be/src/exec/vectorized/json_scanner.h
@@ -78,7 +78,8 @@ public:
 
 private:
     template <typename ParserType>
-    Status _read_chunk(Chunk* chunk, int32_t rows_to_read, const std::vector<SlotDescriptor*>& slot_descs);
+    Status _read_chunk(Chunk* chunk, int32_t* rows_to_read, std::vector<SlotDescriptor*>* slot_descs,
+                       bool* is_reordered);
 
     Status _read_and_parse_json();
 

--- a/be/test/exec/vectorized/json_parser_test.cpp
+++ b/be/test/exec/vectorized/json_parser_test.cpp
@@ -29,7 +29,9 @@ PARALLEL_TEST(JsonParserTest, test_json_document_stream_parser) {
     input.resize(input.size() + simdjson::SIMDJSON_PADDING);
     auto padded_size = input.size();
 
-    std::unique_ptr<JsonParser> parser(new JsonDocumentStreamParser);
+    simdjson::ondemand::parser simdjson_parser;
+
+    std::unique_ptr<JsonParser> parser(new JsonDocumentStreamParser(&simdjson_parser));
 
     auto st = parser->parse(reinterpret_cast<uint8_t*>(input.data()), size, padded_size);
 
@@ -79,7 +81,9 @@ PARALLEL_TEST(JsonParserTest, test_json_array_parser) {
     input.resize(input.size() + simdjson::SIMDJSON_PADDING);
     auto padded_size = input.size();
 
-    std::unique_ptr<JsonParser> parser(new JsonArrayParser);
+    simdjson::ondemand::parser simdjson_parser;
+
+    std::unique_ptr<JsonParser> parser(new JsonArrayParser(&simdjson_parser));
 
     auto st = parser->parse(reinterpret_cast<uint8_t*>(input.data()), size, padded_size);
 
@@ -132,7 +136,9 @@ PARALLEL_TEST(JsonParserTest, test_json_document_stream_parser_with_jsonroot) {
     std::vector<SimpleJsonPath> jsonroot;
     JsonFunctions::parse_json_paths("$.key0", &jsonroot);
 
-    std::unique_ptr<JsonParser> parser(new JsonDocumentStreamParserWithRoot(jsonroot));
+    simdjson::ondemand::parser simdjson_parser;
+
+    std::unique_ptr<JsonParser> parser(new JsonDocumentStreamParserWithRoot(&simdjson_parser, jsonroot));
 
     auto st = parser->parse(reinterpret_cast<uint8_t*>(input.data()), size, padded_size);
 
@@ -185,7 +191,9 @@ PARALLEL_TEST(JsonParserTest, test_json_array_parser_with_jsonroot) {
     std::vector<SimpleJsonPath> jsonroot;
     JsonFunctions::parse_json_paths("$.key0", &jsonroot);
 
-    std::unique_ptr<JsonParser> parser(new JsonArrayParserWithRoot(jsonroot));
+    simdjson::ondemand::parser simdjson_parser;
+
+    std::unique_ptr<JsonParser> parser(new JsonArrayParserWithRoot(&simdjson_parser, jsonroot));
 
     auto st = parser->parse(reinterpret_cast<uint8_t*>(input.data()), size, padded_size);
 
@@ -238,7 +246,9 @@ PARALLEL_TEST(JsonParserTest, test_expanded_json_document_stream_parser_with_jso
     std::vector<SimpleJsonPath> jsonroot;
     JsonFunctions::parse_json_paths("$.key0", &jsonroot);
 
-    std::unique_ptr<JsonParser> parser(new ExpandedJsonDocumentStreamParserWithRoot(jsonroot));
+    simdjson::ondemand::parser simdjson_parser;
+
+    std::unique_ptr<JsonParser> parser(new ExpandedJsonDocumentStreamParserWithRoot(&simdjson_parser, jsonroot));
 
     auto st = parser->parse(reinterpret_cast<uint8_t*>(input.data()), size, padded_size);
 
@@ -291,7 +301,9 @@ PARALLEL_TEST(JsonParserTest, test_expanded_json_array_parser_with_jsonroot) {
     std::vector<SimpleJsonPath> jsonroot;
     JsonFunctions::parse_json_paths("$.key0", &jsonroot);
 
-    std::unique_ptr<JsonParser> parser(new ExpandedJsonArrayParserWithRoot(jsonroot));
+    simdjson::ondemand::parser simdjson_parser;
+
+    std::unique_ptr<JsonParser> parser(new ExpandedJsonArrayParserWithRoot(&simdjson_parser, jsonroot));
 
     auto st = parser->parse(reinterpret_cast<uint8_t*>(input.data()), size, padded_size);
     ASSERT_TRUE(st.ok());


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4556 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This PR includes:
1. reusing `simdjson::ondemand::parser` and buffer
2. read message by chunk

## Benchmark
Source: message in json format; 300 bytes per-message; 1 partition in kafka
StarRocks Config: 3 BE with 3 replica

| Version | Throughput (MB/s)|
| -- | -- |
| main branch |  8.9 |
| main branch with reusing buffer| 9.4|
| main branch with reading message by chunk| 32.0|
| perf/reuse-buffer| 54.4|

Note: The throughput is calculated by the log message:
 ```I0325 20:00:23.312148 15263 data_consumer_group.cpp:131] consumer group done: cd446129eafb7079-671b2934ea6ce0b5. consume time(ms)=3000, received rows=1965066, received bytes=271179108, eos: 0, left_time: 0, left_bytes: 253108892, blocking get time(us): 858230, blocking put time(us): 120380```
 