### PR TITLE
fix conjuncts normalize error

### DIFF
--- a/be/src/exec/vectorized/olap_scan_prepare.cpp
+++ b/be/src/exec/vectorized/olap_scan_prepare.cpp
@@ -174,7 +174,7 @@ void OlapScanConjunctsManager::normalize_in_or_equal_predicate(const SlotDescrip
         if (TExprOpcode::FILTER_IN == root_expr->op()) {
             const Expr* l = root_expr->get_child(0);
 
-            if ((l->is_slotref()) || (l->type().type != slot.type().type && !ignore_cast(slot, *l))) {
+            if ((!l->is_slotref()) || (l->type().type != slot.type().type && !ignore_cast(slot, *l))) {
                 continue;
             }
             std::vector<SlotId> slot_ids;


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Problem Summary(Required) ：
`function_call(slot) in (a, b, c)` normalized to `slot in (a, b, c)`
by mistake.

introduce by #3988
