### PR TITLE
[cherry-pick][branch-2.2]BugFix: Be crash using shared tablet schema

### DIFF
--- a/be/src/storage/tablet_schema_map.h
+++ b/be/src/storage/tablet_schema_map.h
@@ -63,6 +63,8 @@ public:
 private:
     constexpr static int kShardSize = 16;
 
+    bool check_schema_unique_id(const TabletSchemaPB& schema_pb, const std::shared_ptr<const TabletSchema>& schema_ptr);
+
     struct MapShard {
         mutable std::mutex mtx;
         phmap::flat_hash_map<SchemaId, std::weak_ptr<const TabletSchema>> map;


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4514

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
We use shared tablet schema to save memory usage, but the premise is that we need to ensure that no two different TabletSchemaPBs have the same `id()`.

However, we can't guarantee it after schema change so far. Because the `unique_id` is generated by being itself and the `unique_id` of the same column may be different in the different tablets. 

If we use the error `unique_id` of tablet schema, we can get be crash or error result. So we need to check the consistency of `unique_id` before using the shared tablet schema.