### PR TITLE
FIXBUG: The fe node get crashed when receive beginRemoteTxn request if it is not leader

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/master/MasterImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/master/MasterImpl.java
@@ -58,6 +58,7 @@ import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
 import com.starrocks.cluster.ClusterNamespace;
+import com.starrocks.common.ClientPool;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.UserException;
 import com.starrocks.load.DeleteJob;
@@ -82,6 +83,7 @@ import com.starrocks.task.SchemaChangeTask;
 import com.starrocks.task.SnapshotTask;
 import com.starrocks.task.UpdateTabletMetaInfoTask;
 import com.starrocks.task.UploadTask;
+import com.starrocks.thrift.FrontendService;
 import com.starrocks.thrift.TAbortRemoteTxnRequest;
 import com.starrocks.thrift.TAbortRemoteTxnResponse;
 import com.starrocks.thrift.TBackend;
@@ -102,6 +104,7 @@ import com.starrocks.thrift.THashDistributionInfo;
 import com.starrocks.thrift.TIndexInfo;
 import com.starrocks.thrift.TIndexMeta;
 import com.starrocks.thrift.TMasterResult;
+import com.starrocks.thrift.TNetworkAddress;
 import com.starrocks.thrift.TPartitionInfo;
 import com.starrocks.thrift.TPartitionMeta;
 import com.starrocks.thrift.TPushType;
@@ -1191,9 +1194,38 @@ public class MasterImpl {
         }
     }
 
+    public TNetworkAddress masterAddr() {
+        String masterHost = Catalog.getCurrentCatalog().getMasterIp();
+        int masterRpcPort = Catalog.getCurrentCatalog().getMasterRpcPort();
+        return new TNetworkAddress(masterHost, masterRpcPort);
+    }
+
     public TBeginRemoteTxnResponse beginRemoteTxn(TBeginRemoteTxnRequest request) throws TException {
         TBeginRemoteTxnResponse response = new TBeginRemoteTxnResponse();
-        Database db = Catalog.getCurrentCatalog().getDb(request.getDb_id());
+        Catalog catalog = Catalog.getCurrentCatalog();
+
+        // if current node is follower, forward it to leader
+        if (!catalog.isMaster()) {
+            TNetworkAddress addr = masterAddr();
+            FrontendService.Client client = null;
+            try {
+                LOG.info("beginRemoteTxn as follower, forward it to master. Label: {}, master: {}",
+                         request.getLabel(), addr.toString());
+                client = ClientPool.frontendPool.borrowObject(addr, 1000);
+                response = client.beginRemoteTxn(request);
+                ClientPool.frontendPool.returnObject(addr, client);
+            } catch (Exception e) {
+                LOG.warn("create thrift client failed during beginRemoteTxn, label: {}, exception: {}", request.getLabel(), e);
+                TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
+                status.setError_msgs(Lists.newArrayList("forward request to fe master failed"));
+                response.setStatus(status);
+                ClientPool.frontendPool.invalidateObject(addr, client);
+            } finally {
+                return response;
+            }
+        }
+
+        Database db = catalog.getDb(request.getDb_id());
         if (db == null) {
             TStatus status = new TStatus(TStatusCode.NOT_FOUND);
             status.setError_msgs(Lists.newArrayList("db not exist"));
@@ -1225,8 +1257,29 @@ public class MasterImpl {
 
     public TCommitRemoteTxnResponse commitRemoteTxn(TCommitRemoteTxnRequest request) throws TException {
         TCommitRemoteTxnResponse response = new TCommitRemoteTxnResponse();
-
         Catalog catalog = Catalog.getCurrentCatalog();
+
+        // if current node is follower, forward it to leader
+        if (!catalog.isMaster()) {
+            TNetworkAddress addr = masterAddr();
+            FrontendService.Client client = null;
+            try {
+                LOG.info("commitRemoteTxn as follower, forward it to master. txn_id: {}, master: {}",
+                         request.getTxn_id(), addr.toString());
+                client = ClientPool.frontendPool.borrowObject(addr, 1000);
+                response = client.commitRemoteTxn(request);
+                ClientPool.frontendPool.returnObject(addr, client);
+            } catch (Exception e) {
+                LOG.warn("create thrift client failed during commitRemoteTxn, txn_id: {}, exception: {}", request.getTxn_id(), e);
+                TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
+                status.setError_msgs(Lists.newArrayList("forward request to fe master failed"));
+                response.setStatus(status);
+                ClientPool.frontendPool.invalidateObject(addr, client);
+            } finally {
+                return response;
+            }
+        }
+
         Database db = catalog.getDb(request.getDb_id());
         if (db == null) {
             TStatus status = new TStatus(TStatusCode.NOT_FOUND);
@@ -1268,6 +1321,28 @@ public class MasterImpl {
     public TAbortRemoteTxnResponse abortRemoteTxn(TAbortRemoteTxnRequest request) throws TException {
         TAbortRemoteTxnResponse response = new TAbortRemoteTxnResponse();
         Catalog catalog = Catalog.getCurrentCatalog();
+
+        // if current node is follower, forward it to leader
+        if (!catalog.isMaster()) {
+            TNetworkAddress addr = masterAddr();
+            FrontendService.Client client = null;
+            try {
+                LOG.info("abortRemoteTxn as follower, forward it to master. txn_id: {}, master: {}",
+                         request.getTxn_id(), addr.toString());
+                client = ClientPool.frontendPool.borrowObject(addr, 1000);
+                response = client.abortRemoteTxn(request);
+                ClientPool.frontendPool.returnObject(addr, client);
+            } catch (Exception e) {
+                LOG.warn("create thrift client failed during abortRemoteTxn, txn_id: {}, exception: {}", request.getTxn_id(), e);
+                TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
+                status.setError_msgs(Lists.newArrayList("forward request to fe master failed"));
+                response.setStatus(status);
+                ClientPool.frontendPool.invalidateObject(addr, client);
+            } finally {
+                return response;
+            }
+        }
+
         Database db = catalog.getDb(request.getDb_id());
         if (db == null) {
             TStatus status = new TStatus(TStatusCode.NOT_FOUND);


### PR DESCRIPTION
===========cause=================
When an external table is created and the host property set to a
follower/observer node of the source cluster. If we insert some values
into this external table, the target fe node will receive
beginRemoteTxn rpc, and get crashed because of wal writing
is needed for beginRemoteTxn, which is forbidden in non-leader node.

==========solution===============
For non-leader fe node, it will forward beginRemoteTxn/commitRemoteTxn/
abortRemoteTxn to leader node and return back response from leader.

* return failed response rather than throws exception if forward request failed

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
