### PR TITLE
Support cleaning meta cache and fix null partition value exception for hudi table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveMetaStoreTableInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveMetaStoreTableInfo.java
@@ -1,3 +1,5 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
 package com.starrocks.catalog;
 
 import com.starrocks.catalog.Table.TableType;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveMetaStoreTableInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveMetaStoreTableInfo.java
@@ -1,0 +1,59 @@
+package com.starrocks.catalog;
+
+import com.starrocks.catalog.Table.TableType;
+
+import java.util.List;
+import java.util.Map;
+
+public class HiveMetaStoreTableInfo {
+
+    private final String resourceName;
+    private final String db;
+    private final String table;
+    private final List<String> partColumnNames;
+    private final List<String> dataColumnNames;
+    private final Map<String, Column> nameToColumn;
+    private final TableType tableType;
+
+    public HiveMetaStoreTableInfo(String resourceName, String db, String table,
+                                  List<String> partColumnNames,
+                                  List<String> dataColumnNames,
+                                  Map<String, Column> nameToColumn,
+                                  TableType tableType) {
+        this.resourceName = resourceName;
+        this.db = db;
+        this.table = table;
+        this.partColumnNames = partColumnNames;
+        this.dataColumnNames = dataColumnNames;
+        this.nameToColumn = nameToColumn;
+        this.tableType = tableType;
+    }
+
+    public String getResourceName() {
+        return resourceName;
+    }
+
+    public String getDb() {
+        return db;
+    }
+
+    public String getTable() {
+        return table;
+    }
+
+    public List<String> getPartColumnNames() {
+        return partColumnNames;
+    }
+
+    public List<String> getDataColumnNames() {
+        return dataColumnNames;
+    }
+
+    public Map<String, Column> getNameToColumn() {
+        return nameToColumn;
+    }
+
+    public TableType getTableType() {
+        return tableType;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
@@ -202,7 +202,7 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
     @Override
     public long getPartitionStatsRowCount(List<PartitionKey> partitions) {
         return HiveMetaStoreTableUtils.getPartitionStatsRowCount(resourceName, hiveDb, hiveTable,
-                partitions, getPartitionColumns(), false);
+                partitions, getPartitionColumns());
     }
 
     private void validate(Map<String, String> properties) throws DdlException {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
@@ -55,7 +55,6 @@ import org.apache.logging.log4j.Logger;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -158,7 +157,8 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
 
     public HiveMetaStoreTableInfo getHmsTableInfo() {
         if (hmsTableInfo == null) {
-            hmsTableInfo = new HiveMetaStoreTableInfo(resourceName, hiveDb, hiveTable, partColumnNames, dataColumnNames, nameToColumn, type);
+            hmsTableInfo = new HiveMetaStoreTableInfo(resourceName, hiveDb, hiveTable,
+                    partColumnNames, dataColumnNames, nameToColumn, type);
         }
         return hmsTableInfo;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
@@ -109,6 +109,7 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
     public HiveTable(long id, String name, List<Column> schema, Map<String, String> properties) throws DdlException {
         super(id, name, TableType.HIVE, schema);
         validate(properties);
+        initHmsTableInfo();
     }
 
     public String getHiveDbTable() {
@@ -129,7 +130,7 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
 
     @Override
     public List<Column> getPartitionColumns() {
-        return HiveMetaStoreTableUtils.getPartitionColumns(getHmsTableInfo());
+        return HiveMetaStoreTableUtils.getPartitionColumns(hmsTableInfo);
     }
 
     public List<String> getPartitionColumnNames() {
@@ -155,7 +156,7 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
         return hiveProperties;
     }
 
-    public HiveMetaStoreTableInfo getHmsTableInfo() {
+    public HiveMetaStoreTableInfo initHmsTableInfo() {
         if (hmsTableInfo == null) {
             hmsTableInfo = new HiveMetaStoreTableInfo(resourceName, hiveDb, hiveTable,
                     partColumnNames, dataColumnNames, nameToColumn, type);
@@ -164,7 +165,7 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
     }
 
     public Map<PartitionKey, Long> getPartitionKeys() throws DdlException {
-        return HiveMetaStoreTableUtils.getPartitionKeys(getHmsTableInfo());
+        return HiveMetaStoreTableUtils.getPartitionKeys(hmsTableInfo);
     }
 
     @Override
@@ -174,7 +175,7 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
 
     @Override
     public HiveTableStats getTableStats() throws DdlException {
-        return HiveMetaStoreTableUtils.getTableStats(getHmsTableInfo());
+        return HiveMetaStoreTableUtils.getTableStats(hmsTableInfo);
     }
 
     @Override
@@ -185,19 +186,19 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
     @Override
     public void refreshTableCache() throws DdlException {
         Catalog.getCurrentCatalog().getHiveRepository()
-                .refreshTableCache(getHmsTableInfo());
+                .refreshTableCache(hmsTableInfo);
     }
 
     @Override
     public void refreshPartCache(List<String> partNames) throws DdlException {
         Catalog.getCurrentCatalog().getHiveRepository()
-                .refreshPartitionCache(getHmsTableInfo(), partNames);
+                .refreshPartitionCache(hmsTableInfo, partNames);
     }
 
     @Override
     public void refreshTableColumnStats() throws DdlException {
         Catalog.getCurrentCatalog().getHiveRepository()
-                .refreshTableColumnStats(getHmsTableInfo());
+                .refreshTableColumnStats(hmsTableInfo);
     }
 
     /**
@@ -206,7 +207,7 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
      */
     @Override
     public long getPartitionStatsRowCount(List<PartitionKey> partitions) {
-        return HiveMetaStoreTableUtils.getPartitionStatsRowCount(getHmsTableInfo(), partitions);
+        return HiveMetaStoreTableUtils.getPartitionStatsRowCount(hmsTableInfo, partitions);
     }
 
     private void validate(Map<String, String> properties) throws DdlException {
@@ -525,6 +526,7 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
                 hiveProperties.put(key, val);
             }
         }
+        initHmsTableInfo();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HudiTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HudiTable.java
@@ -43,7 +43,6 @@ import org.apache.logging.log4j.Logger;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -133,7 +132,8 @@ public class HudiTable extends Table implements HiveMetaStoreTable {
 
     public HiveMetaStoreTableInfo getHmsTableInfo() {
         if (hmsTableInfo == null) {
-            hmsTableInfo = new HiveMetaStoreTableInfo(resourceName, db, table, partColumnNames, dataColumnNames, nameToColumn, type);
+            hmsTableInfo = new HiveMetaStoreTableInfo(resourceName, db, table,
+                    partColumnNames, dataColumnNames, nameToColumn, type);
         }
         return hmsTableInfo;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HudiTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HudiTable.java
@@ -131,7 +131,7 @@ public class HudiTable extends Table implements HiveMetaStoreTable {
 
     public Map<PartitionKey, Long> getPartitionKeys() throws DdlException {
         List<Column> partColumns = getPartitionColumns();
-        return HiveMetaStoreTableUtils.getPartitionKeys(resourceName, db, table, partColumns);
+        return HiveMetaStoreTableUtils.getPartitionKeys(resourceName, db, table, partColumns, true);
     }
 
     @Override
@@ -147,7 +147,7 @@ public class HudiTable extends Table implements HiveMetaStoreTable {
     @Override
     public Map<String, HiveColumnStats> getTableLevelColumnStats(List<String> columnNames) throws DdlException {
         return HiveMetaStoreTableUtils.getTableLevelColumnStats(resourceName, db, table,
-                this.nameToColumn, columnNames, getPartitionColumns());
+                this.nameToColumn, columnNames, getPartitionColumns(), true);
     }
 
     @Override
@@ -491,6 +491,14 @@ public class HudiTable extends Table implements HiveMetaStoreTable {
                     dataColumnNames.add(col.getName());
                 }
             }
+        }
+    }
+
+    @Override
+    public void onDrop() {
+        if (this.resourceName != null) {
+            Catalog.getCurrentCatalog().getHiveRepository().
+                    clearCache(this.resourceName, this.db, this.table, true);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HudiTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HudiTable.java
@@ -95,6 +95,7 @@ public class HudiTable extends Table implements HiveMetaStoreTable {
     public HudiTable(long id, String name, List<Column> schema, Map<String, String> properties) throws DdlException {
         super(id, name, TableType.HUDI, schema);
         validate(properties);
+        initHmsTableInfo();
     }
 
     public String getDb() {
@@ -119,7 +120,7 @@ public class HudiTable extends Table implements HiveMetaStoreTable {
 
     @Override
     public List<Column> getPartitionColumns() {
-        return HiveMetaStoreTableUtils.getPartitionColumns(getHmsTableInfo());
+        return HiveMetaStoreTableUtils.getPartitionColumns(hmsTableInfo);
     }
 
     public List<String> getPartitionColumnNames() {
@@ -130,7 +131,7 @@ public class HudiTable extends Table implements HiveMetaStoreTable {
         return dataColumnNames;
     }
 
-    public HiveMetaStoreTableInfo getHmsTableInfo() {
+    public HiveMetaStoreTableInfo initHmsTableInfo() {
         if (hmsTableInfo == null) {
             hmsTableInfo = new HiveMetaStoreTableInfo(resourceName, db, table,
                     partColumnNames, dataColumnNames, nameToColumn, type);
@@ -139,39 +140,39 @@ public class HudiTable extends Table implements HiveMetaStoreTable {
     }
 
     public Map<PartitionKey, Long> getPartitionKeys() throws DdlException {
-        return HiveMetaStoreTableUtils.getPartitionKeys(getHmsTableInfo());
+        return HiveMetaStoreTableUtils.getPartitionKeys(hmsTableInfo);
     }
 
     @Override
     public List<HivePartition> getPartitions(List<PartitionKey> partitionKeys) throws DdlException {
-        return HiveMetaStoreTableUtils.getPartitions(getHmsTableInfo(), partitionKeys);
+        return HiveMetaStoreTableUtils.getPartitions(hmsTableInfo, partitionKeys);
     }
 
     @Override
     public HiveTableStats getTableStats() throws DdlException {
-        return HiveMetaStoreTableUtils.getTableStats(getHmsTableInfo());
+        return HiveMetaStoreTableUtils.getTableStats(hmsTableInfo);
     }
 
     @Override
     public Map<String, HiveColumnStats> getTableLevelColumnStats(List<String> columnNames) throws DdlException {
-        return HiveMetaStoreTableUtils.getTableLevelColumnStats(getHmsTableInfo(), columnNames);
+        return HiveMetaStoreTableUtils.getTableLevelColumnStats(hmsTableInfo, columnNames);
     }
 
     @Override
     public void refreshTableCache() throws DdlException {
-        Catalog.getCurrentCatalog().getHiveRepository().refreshTableCache(getHmsTableInfo());
+        Catalog.getCurrentCatalog().getHiveRepository().refreshTableCache(hmsTableInfo);
     }
 
     @Override
     public void refreshPartCache(List<String> partNames) throws DdlException {
         Catalog.getCurrentCatalog().getHiveRepository()
-                .refreshPartitionCache(getHmsTableInfo(), partNames);
+                .refreshPartitionCache(hmsTableInfo, partNames);
     }
 
     @Override
     public void refreshTableColumnStats() throws DdlException {
         Catalog.getCurrentCatalog().getHiveRepository()
-                .refreshTableColumnStats(getHmsTableInfo());
+                .refreshTableColumnStats(hmsTableInfo);
     }
 
     /**
@@ -180,7 +181,7 @@ public class HudiTable extends Table implements HiveMetaStoreTable {
      */
     @Override
     public long getPartitionStatsRowCount(List<PartitionKey> partitions) {
-        return HiveMetaStoreTableUtils.getPartitionStatsRowCount(getHmsTableInfo(), partitions);
+        return HiveMetaStoreTableUtils.getPartitionStatsRowCount(hmsTableInfo, partitions);
     }
 
     private void validate(Map<String, String> properties) throws DdlException {
@@ -495,6 +496,7 @@ public class HudiTable extends Table implements HiveMetaStoreTable {
                 }
             }
         }
+        initHmsTableInfo();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/external/HiveMetaStoreTableUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/HiveMetaStoreTableUtils.java
@@ -59,7 +59,8 @@ public class HiveMetaStoreTableUtils {
 
     public static HiveTableStats getTableStats(HiveMetaStoreTableInfo hmsTable) throws DdlException {
         try (PlannerProfile.ScopedTimer _ = PlannerProfile.getScopedTimer("HMS.tableStats")) {
-            return Catalog.getCurrentCatalog().getHiveRepository().getTableStats(hmsTable.getResourceName(), hmsTable.getDb(), hmsTable.getTable());
+            return Catalog.getCurrentCatalog().getHiveRepository().getTableStats(hmsTable.getResourceName(),
+                    hmsTable.getDb(), hmsTable.getTable());
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/external/HiveMetaStoreTableUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/HiveMetaStoreTableUtils.java
@@ -6,6 +6,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.Catalog;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.HiveMetaStoreTableInfo;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.common.DdlException;
 import com.starrocks.external.hive.HiveColumnStats;
@@ -23,27 +24,11 @@ import java.util.Map;
 public class HiveMetaStoreTableUtils {
     private static final Logger LOG = LogManager.getLogger(HiveMetaStoreTableUtils.class);
 
-    public static Map<String, HiveColumnStats> getTableLevelColumnStats(String resourceName,
-                                                                        String db,
-                                                                        String table,
-                                                                        Map<String, Column> nameToColumn,
-                                                                        List<String> columnNames,
-                                                                        List<Column> partColumns) throws DdlException {
-        return getTableLevelColumnStats(resourceName, db, table, nameToColumn, columnNames, partColumns, false);
-    }
-
-    public static Map<String, HiveColumnStats> getTableLevelColumnStats(String resourceName,
-                                                                        String db,
-                                                                        String table,
-                                                                        Map<String, Column> nameToColumn,
-                                                                        List<String> columnNames,
-                                                                        List<Column> partColumns,
-                                                                        boolean isHudiTable) throws DdlException {
+    public static Map<String, HiveColumnStats> getTableLevelColumnStats(HiveMetaStoreTableInfo hmsTable,
+                                                                        List<String> columnNames) throws DdlException {
         try (PlannerProfile.ScopedTimer _ = PlannerProfile.getScopedTimer("HMS.tableColumnStats")) {
-            // NOTE: Using allColumns as param to get column stats, we will get the best cache effect.
-            List<String> allColumnNames = new ArrayList<>(nameToColumn.keySet());
             Map<String, HiveColumnStats> allColumnStats = Catalog.getCurrentCatalog().getHiveRepository()
-                    .getTableLevelColumnStats(resourceName, db, table, partColumns, allColumnNames, isHudiTable);
+                    .getTableLevelColumnStats(hmsTable);
             Map<String, HiveColumnStats> result = Maps.newHashMapWithExpectedSize(columnNames.size());
             for (String columnName : columnNames) {
                 result.put(columnName, allColumnStats.get(columnName));
@@ -52,93 +37,60 @@ public class HiveMetaStoreTableUtils {
         }
     }
 
-    public static List<Column> getPartitionColumns(Map<String, Column> nameToColumn, List<String> partColumnNames) {
+    public static List<Column> getPartitionColumns(HiveMetaStoreTableInfo hmsTable) {
         List<Column> partColumns = Lists.newArrayList();
-        for (String columnName : partColumnNames) {
-            partColumns.add(nameToColumn.get(columnName));
+        for (String columnName : hmsTable.getPartColumnNames()) {
+            partColumns.add(hmsTable.getNameToColumn().get(columnName));
         }
         return partColumns;
     }
 
-    public static List<HivePartitionStats> getPartitionsStats(String resourceName,
-                                                              String db,
-                                                              String table,
-                                                              List<PartitionKey> partitionKeys,
-                                                              boolean isHudiTable) throws DdlException {
+    public static List<String> getAllColumnNames(HiveMetaStoreTableInfo hmsTable) {
+        return new ArrayList<>(hmsTable.getNameToColumn().keySet());
+    }
+
+    public static List<HivePartitionStats> getPartitionsStats(HiveMetaStoreTableInfo hmsTable,
+                                                              List<PartitionKey> partitionKeys) throws DdlException {
         try (PlannerProfile.ScopedTimer _ = PlannerProfile.getScopedTimer("HMS.partitionStats")) {
-            return Catalog.getCurrentCatalog().getHiveRepository()
-                    .getPartitionsStats(resourceName, db, table, partitionKeys, isHudiTable);
+            // TODO: getPartitionsStats
+            return Catalog.getCurrentCatalog().getHiveRepository().getPartitionsStats(hmsTable, partitionKeys);
         }
     }
 
-    public static HiveTableStats getTableStats(String resourceName,
-                                               String db,
-                                               String table) throws DdlException {
+    public static HiveTableStats getTableStats(HiveMetaStoreTableInfo hmsTable) throws DdlException {
         try (PlannerProfile.ScopedTimer _ = PlannerProfile.getScopedTimer("HMS.tableStats")) {
-            return Catalog.getCurrentCatalog().getHiveRepository().getTableStats(resourceName, db, table);
+            return Catalog.getCurrentCatalog().getHiveRepository().getTableStats(hmsTable.getResourceName(), hmsTable.getDb(), hmsTable.getTable());
         }
     }
 
-    public static List<HivePartition> getPartitions(String resourceName,
-                                                    String db,
-                                                    String table,
-                                                    List<PartitionKey> partitionKeys,
-                                                    boolean isHudiTable) throws DdlException {
+    public static List<HivePartition> getPartitions(HiveMetaStoreTableInfo hmsTable,
+                                                    List<PartitionKey> partitionKeys) throws DdlException {
         try (PlannerProfile.ScopedTimer _ = PlannerProfile.getScopedTimer("HMS.partitions")) {
             return Catalog.getCurrentCatalog().getHiveRepository()
-                    .getPartitions(resourceName, db, table, partitionKeys, isHudiTable);
+                    .getPartitions(hmsTable, partitionKeys);
         }
     }
 
-    public static Map<PartitionKey, Long> getPartitionKeys(String resourceName,
-                                                           String db,
-                                                           String table,
-                                                           List<Column> partColumns) throws DdlException {
-        return getPartitionKeys(resourceName, db, table, partColumns, false);
-    }
-
-    public static Map<PartitionKey, Long> getPartitionKeys(String resourceName,
-                                                           String db,
-                                                           String table,
-                                                           List<Column> partColumns,
-                                                           boolean isHudiTable) throws DdlException {
+    public static Map<PartitionKey, Long> getPartitionKeys(HiveMetaStoreTableInfo hmsTable) throws DdlException {
         try (PlannerProfile.ScopedTimer _ = PlannerProfile.getScopedTimer("HMS.partitionKeys")) {
-            return Catalog.getCurrentCatalog().getHiveRepository()
-                    .getPartitionKeys(resourceName, db, table, partColumns, isHudiTable);
+            return Catalog.getCurrentCatalog().getHiveRepository().getPartitionKeys(hmsTable);
         }
     }
 
-    public static long getPartitionStatsRowCount(String resourceName,
-                                                 String db,
-                                                 String table,
-                                                 List<PartitionKey> partitions,
-                                                 List<Column> partColumns) {
-        return getPartitionStatsRowCount(resourceName, db, table, partitions, partColumns, false);
-    }
-
-    public static long getPartitionStatsRowCount(String resourceName,
-                                                 String db,
-                                                 String table,
-                                                 List<PartitionKey> partitions,
-                                                 List<Column> partColumns,
-                                                 boolean isHudiTable) {
+    public static long getPartitionStatsRowCount(HiveMetaStoreTableInfo hmsTable,
+                                                 List<PartitionKey> partitions) {
         try (PlannerProfile.ScopedTimer _ = PlannerProfile.getScopedTimer("HMS.partitionRowCount")) {
-            return doGetPartitionStatsRowCount(resourceName, db, table, partitions, partColumns, isHudiTable);
+            return doGetPartitionStatsRowCount(hmsTable, partitions);
         }
     }
 
-    public static long doGetPartitionStatsRowCount(String resourceName,
-                                                   String db,
-                                                   String table,
-                                                   List<PartitionKey> partitions,
-                                                   List<Column> partColumns,
-                                                   boolean isHudiTable) {
+    public static long doGetPartitionStatsRowCount(HiveMetaStoreTableInfo hmsTable,
+                                                   List<PartitionKey> partitions) {
         if (partitions == null) {
             try {
-                partitions = Lists.newArrayList(getPartitionKeys(resourceName, db, table,
-                        partColumns, isHudiTable).keySet());
+                partitions = Lists.newArrayList(getPartitionKeys(hmsTable).keySet());
             } catch (DdlException e) {
-                LOG.warn("Failed to get table {} partitions.", table, e);
+                LOG.warn("Failed to get table {} partitions.", hmsTable.getTable(), e);
                 return -1;
             }
         }
@@ -150,9 +102,9 @@ public class HiveMetaStoreTableUtils {
 
         List<HivePartitionStats> partitionsStats = Lists.newArrayList();
         try {
-            partitionsStats = getPartitionsStats(resourceName, db, table, partitions, isHudiTable);
+            partitionsStats = getPartitionsStats(hmsTable, partitions);
         } catch (DdlException e) {
-            LOG.warn("Failed to get table {} partitions stats.", table, e);
+            LOG.warn("Failed to get table {} partitions stats.", hmsTable.getTable(), e);
         }
 
         for (int i = 0; i < partitionsStats.size(); i++) {
@@ -166,7 +118,7 @@ public class HiveMetaStoreTableUtils {
                 numRows += partNumRows;
             } else {
                 LOG.debug("Table {} partition {} stats is invalid. num rows: {}, total file bytes: {}",
-                        table, partitions.get(i), partNumRows, partTotalFileBytes);
+                        hmsTable.getTable(), partitions.get(i), partNumRows, partTotalFileBytes);
             }
         }
         return numRows;

--- a/fe/fe-core/src/main/java/com/starrocks/external/HiveMetaStoreTableUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/HiveMetaStoreTableUtils.java
@@ -52,7 +52,6 @@ public class HiveMetaStoreTableUtils {
     public static List<HivePartitionStats> getPartitionsStats(HiveMetaStoreTableInfo hmsTable,
                                                               List<PartitionKey> partitionKeys) throws DdlException {
         try (PlannerProfile.ScopedTimer _ = PlannerProfile.getScopedTimer("HMS.partitionStats")) {
-            // TODO: getPartitionsStats
             return Catalog.getCurrentCatalog().getHiveRepository().getPartitionsStats(hmsTable, partitionKeys);
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaCache.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaCache.java
@@ -169,7 +169,8 @@ public class HiveMetaCache {
     public ImmutableMap<PartitionKey, Long> getPartitionKeys(HiveMetaStoreTableInfo hmsTable) throws DdlException {
         List<Column> partColumns = getPartitionColumns(hmsTable);
         try {
-            return partitionKeysCache.get(new HivePartitionKeysKey(hmsTable.getDb(), hmsTable.getTable(), hmsTable.getTableType(), partColumns));
+            return partitionKeysCache.get(new HivePartitionKeysKey(hmsTable.getDb(),
+                    hmsTable.getTable(), hmsTable.getTableType(), partColumns));
         } catch (ExecutionException e) {
             LOG.warn("get partition keys failed", e);
             throw new DdlException("get partition keys failed: " + e.getMessage());
@@ -178,9 +179,11 @@ public class HiveMetaCache {
 
     public HivePartition getPartition(HiveMetaStoreTableInfo hmsTable,
                                       PartitionKey partitionKey) throws DdlException {
-        List<String> partitionValues = Utils.getPartitionValues(partitionKey, hmsTable.getTableType() == Table.TableType.HUDI);
+        List<String> partitionValues = Utils.getPartitionValues(partitionKey,
+                hmsTable.getTableType() == Table.TableType.HUDI);
         try {
-            return partitionsCache.get(new HivePartitionKey(hmsTable.getDb(), hmsTable.getTable(), hmsTable.getTableType(), partitionValues));
+            return partitionsCache.get(new HivePartitionKey(hmsTable.getDb(), hmsTable.getTable(),
+                    hmsTable.getTableType(), partitionValues));
         } catch (ExecutionException e) {
             throw new DdlException("get partition detail failed: " + e.getMessage());
         }
@@ -212,7 +215,8 @@ public class HiveMetaCache {
         List<Column> partColumns = getPartitionColumns(hmsTable);
         // NOTE: Using allColumns as param to get column stats, we will get the best cache effect.
         List<String> allColumnNames = new ArrayList<>(hmsTable.getNameToColumn().keySet());
-        HiveTableColumnsKey key = new HiveTableColumnsKey(hmsTable.getDb(), hmsTable.getTable(), partColumns, allColumnNames, hmsTable.getTableType());
+        HiveTableColumnsKey key = new HiveTableColumnsKey(hmsTable.getDb(),
+                hmsTable.getTable(), partColumns, allColumnNames, hmsTable.getTableType());
         try {
             return tableColumnStatsCache.get(key);
         } catch (ExecutionException e) {
@@ -303,7 +307,8 @@ public class HiveMetaCache {
 
             // for unpartition table, refresh the partition info, because there is only one partition
             if (partColumns.size() <= 0) {
-                HivePartitionKey hivePartitionKey = new HivePartitionKey(dbName, tableName, hmsTable.getTableType(), new ArrayList<>());
+                HivePartitionKey hivePartitionKey = new HivePartitionKey(dbName, tableName,
+                        hmsTable.getTableType(), new ArrayList<>());
                 partitionsCache.put(hivePartitionKey, loadPartition(hivePartitionKey));
                 partitionStatsCache.put(hivePartitionKey, loadPartitionStats(hivePartitionKey));
             }
@@ -320,7 +325,8 @@ public class HiveMetaCache {
         try {
             for (String partName : partNames) {
                 List<String> partValues = client.partitionNameToVals(partName);
-                HivePartitionKey key = new HivePartitionKey(hmsTable.getDb(), hmsTable.getTable(), hmsTable.getTableType(), partValues);
+                HivePartitionKey key = new HivePartitionKey(hmsTable.getDb(), hmsTable.getTable(),
+                        hmsTable.getTableType(), partValues);
                 partitionsCache.put(key, loadPartition(key));
                 partitionStatsCache.put(key, loadPartitionStats(key));
             }

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HivePartitionKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HivePartitionKey.java
@@ -2,6 +2,8 @@
 
 package com.starrocks.external.hive;
 
+import com.starrocks.catalog.Table.TableType;
+
 import java.util.List;
 import java.util.Objects;
 
@@ -9,17 +11,17 @@ public class HivePartitionKey {
     private final String databaseName;
     private final String tableName;
     private final List<String> partitionValues;
-    private final boolean isHudiTable;
+    private final TableType tableType;
 
     public HivePartitionKey(String databaseName, String tableName, List<String> partitionValues) {
-        this(databaseName, tableName, partitionValues, false);
+        this(databaseName, tableName, TableType.HIVE, partitionValues);
     }
 
-    public HivePartitionKey(String databaseName, String tableName, List<String> partitionValues, boolean isHudiTable) {
+    public HivePartitionKey(String databaseName, String tableName, TableType tableType, List<String> partitionValues) {
         this.databaseName = databaseName;
         this.tableName = tableName;
         this.partitionValues = partitionValues;
-        this.isHudiTable = isHudiTable;
+        this.tableType = tableType;
     }
 
     public static HivePartitionKey gen(String databaseName, String tableName, List<String> partitionValues) {
@@ -38,8 +40,8 @@ public class HivePartitionKey {
         return partitionValues;
     }
 
-    public boolean isHudiTable() {
-        return isHudiTable;
+    public TableType getTableType() {
+        return tableType;
     }
 
     @Override
@@ -55,11 +57,11 @@ public class HivePartitionKey {
         return Objects.equals(databaseName, other.databaseName) &&
                 Objects.equals(tableName, other.tableName) &&
                 Objects.equals(partitionValues, other.partitionValues) &&
-                Objects.equals(isHudiTable, other.isHudiTable);
+                Objects.equals(tableType, other.tableType);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(databaseName, tableName, partitionValues, isHudiTable);
+        return Objects.hash(databaseName, tableName, partitionValues, tableType);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HivePartitionKeysKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HivePartitionKeysKey.java
@@ -13,11 +13,18 @@ public class HivePartitionKeysKey {
 
     // does not participate in hashCode/equals
     private final List<Column> partitionColumns;
+    private final boolean isHudiTable;
 
-    public HivePartitionKeysKey(String databaseName, String tableName, List<Column> partitionColumns) {
+    public HivePartitionKeysKey(String databaseName, String tableName,
+                                List<Column> partitionColumns, boolean isHudiTable) {
         this.databaseName = databaseName;
         this.tableName = tableName;
         this.partitionColumns = partitionColumns;
+        this.isHudiTable = isHudiTable;
+    }
+
+    public HivePartitionKeysKey(String databaseName, String tableName, List<Column> partitionColumns) {
+        this(databaseName, tableName, partitionColumns, false);
     }
 
     public static HivePartitionKeysKey gen(String databaseName, String tableName, List<Column> partitionColumns) {
@@ -36,6 +43,10 @@ public class HivePartitionKeysKey {
         return partitionColumns;
     }
 
+    public boolean isHudiTable() {
+        return isHudiTable;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -47,11 +58,12 @@ public class HivePartitionKeysKey {
 
         HivePartitionKeysKey other = (HivePartitionKeysKey) o;
         return Objects.equals(databaseName, other.databaseName) &&
-                Objects.equals(tableName, other.tableName);
+                Objects.equals(tableName, other.tableName) &&
+                Objects.equals(isHudiTable, other.isHudiTable);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(databaseName, tableName);
+        return Objects.hash(databaseName, tableName, isHudiTable);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HivePartitionKeysKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HivePartitionKeysKey.java
@@ -3,6 +3,7 @@
 package com.starrocks.external.hive;
 
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Table.TableType;
 
 import java.util.List;
 import java.util.Objects;
@@ -13,18 +14,18 @@ public class HivePartitionKeysKey {
 
     // does not participate in hashCode/equals
     private final List<Column> partitionColumns;
-    private final boolean isHudiTable;
+    private final TableType tableType;
 
     public HivePartitionKeysKey(String databaseName, String tableName,
-                                List<Column> partitionColumns, boolean isHudiTable) {
+                                TableType tableType, List<Column> partitionColumns) {
         this.databaseName = databaseName;
         this.tableName = tableName;
         this.partitionColumns = partitionColumns;
-        this.isHudiTable = isHudiTable;
+        this.tableType = tableType;
     }
 
     public HivePartitionKeysKey(String databaseName, String tableName, List<Column> partitionColumns) {
-        this(databaseName, tableName, partitionColumns, false);
+        this(databaseName, tableName, TableType.HIVE, partitionColumns);
     }
 
     public static HivePartitionKeysKey gen(String databaseName, String tableName, List<Column> partitionColumns) {
@@ -43,8 +44,8 @@ public class HivePartitionKeysKey {
         return partitionColumns;
     }
 
-    public boolean isHudiTable() {
-        return isHudiTable;
+    public TableType getTableType() {
+        return tableType;
     }
 
     @Override
@@ -59,11 +60,11 @@ public class HivePartitionKeysKey {
         HivePartitionKeysKey other = (HivePartitionKeysKey) o;
         return Objects.equals(databaseName, other.databaseName) &&
                 Objects.equals(tableName, other.tableName) &&
-                Objects.equals(isHudiTable, other.isHudiTable);
+                Objects.equals(tableType, other.tableType);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(databaseName, tableName, isHudiTable);
+        return Objects.hash(databaseName, tableName, tableType);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveRepository.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveRepository.java
@@ -119,9 +119,10 @@ public class HiveRepository {
     }
 
     public ImmutableMap<PartitionKey, Long> getPartitionKeys(String resourceName, String dbName, String tableName,
-                                                             List<Column> partColumns) throws DdlException {
+                                                             List<Column> partColumns,
+                                                             boolean isHudiTable) throws DdlException {
         HiveMetaCache metaCache = getMetaCache(resourceName);
-        return metaCache.getPartitionKeys(dbName, tableName, partColumns);
+        return metaCache.getPartitionKeys(dbName, tableName, partColumns, isHudiTable);
     }
 
     public List<HivePartition> getPartitions(String resourceName, String dbName, String tableName,
@@ -176,10 +177,11 @@ public class HiveRepository {
     public ImmutableMap<String, HiveColumnStats> getTableLevelColumnStats(String resourceName, String dbName,
                                                                           String tableName,
                                                                           List<Column> partitionColumns,
-                                                                          List<String> columnNames)
+                                                                          List<String> columnNames,
+                                                                          boolean isHudiTable)
             throws DdlException {
         HiveMetaCache metaCache = getMetaCache(resourceName);
-        return metaCache.getTableLevelColumnStats(dbName, tableName, partitionColumns, columnNames);
+        return metaCache.getTableLevelColumnStats(dbName, tableName, partitionColumns, columnNames, isHudiTable);
     }
 
     public void refreshTableCache(String resourceName, String dbName, String tableName, List<Column> partColumns,
@@ -213,11 +215,15 @@ public class HiveRepository {
     }
 
     public void clearCache(String resourceName, String dbName, String tableName) {
+        clearCache(resourceName, dbName, tableName, false);
+    }
+
+    public void clearCache(String resourceName, String dbName, String tableName, boolean isHudiTable) {
         try {
             HiveMetaCache metaCache = getMetaCache(resourceName);
-            metaCache.clearCache(dbName, tableName);
+            metaCache.clearCache(dbName, tableName, isHudiTable);
         } catch (DdlException e) {
-
+            LOG.warn("clean table {}.{} cache failed.", dbName, tableName,  e);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveRepository.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveRepository.java
@@ -6,7 +6,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.Catalog;
-import com.starrocks.catalog.Column;
 import com.starrocks.catalog.HiveMetaStoreTableInfo;
 import com.starrocks.catalog.HiveResource;
 import com.starrocks.catalog.HudiResource;
@@ -150,7 +149,8 @@ public class HiveRepository {
         return metaCache.getTableStats(dbName, tableName);
     }
 
-    public List<HivePartitionStats> getPartitionsStats(HiveMetaStoreTableInfo hmsTable, List<PartitionKey> partitionKeys) throws DdlException {
+    public List<HivePartitionStats> getPartitionsStats(HiveMetaStoreTableInfo hmsTable,
+                                                       List<PartitionKey> partitionKeys) throws DdlException {
         HiveMetaCache metaCache = getMetaCache(hmsTable.getResourceName());
         List<Future<HivePartitionStats>> futures = Lists.newArrayList();
         for (PartitionKey partitionKey : partitionKeys) {

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveTableColumnsKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveTableColumnsKey.java
@@ -15,12 +15,20 @@ public class HiveTableColumnsKey {
     private final List<Column> partitionColumns;
     private final List<String> columnNames;
 
+    private final boolean isHudiTable;
+
     public HiveTableColumnsKey(String databaseName, String tableName, List<Column> partitionColumns,
-                               List<String> columnNames) {
+                               List<String> columnNames, boolean isHudiTable) {
         this.databaseName = databaseName;
         this.tableName = tableName;
         this.partitionColumns = partitionColumns;
         this.columnNames = columnNames;
+        this.isHudiTable = isHudiTable;
+    }
+
+    public HiveTableColumnsKey(String databaseName, String tableName, List<Column> partitionColumns,
+                               List<String> columnNames) {
+        this(databaseName, tableName, partitionColumns, columnNames, false);
     }
 
     public static HiveTableColumnsKey gen(String databaseName, String tableName, List<Column> partitionColumns,
@@ -44,6 +52,10 @@ public class HiveTableColumnsKey {
         return columnNames;
     }
 
+    public boolean isHudiTable() {
+        return isHudiTable;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -55,11 +67,12 @@ public class HiveTableColumnsKey {
 
         HiveTableColumnsKey other = (HiveTableColumnsKey) o;
         return Objects.equals(databaseName, other.databaseName) &&
-                Objects.equals(tableName, other.tableName);
+                Objects.equals(tableName, other.tableName) &&
+                Objects.equals(isHudiTable, other.isHudiTable);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(databaseName, tableName);
+        return Objects.hash(databaseName, tableName, isHudiTable);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveTableColumnsKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveTableColumnsKey.java
@@ -3,6 +3,7 @@
 package com.starrocks.external.hive;
 
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Table.TableType;
 
 import java.util.List;
 import java.util.Objects;
@@ -15,20 +16,20 @@ public class HiveTableColumnsKey {
     private final List<Column> partitionColumns;
     private final List<String> columnNames;
 
-    private final boolean isHudiTable;
+    private final TableType tableType;
 
     public HiveTableColumnsKey(String databaseName, String tableName, List<Column> partitionColumns,
-                               List<String> columnNames, boolean isHudiTable) {
+                               List<String> columnNames, TableType tableType) {
         this.databaseName = databaseName;
         this.tableName = tableName;
         this.partitionColumns = partitionColumns;
         this.columnNames = columnNames;
-        this.isHudiTable = isHudiTable;
+        this.tableType = tableType;
     }
 
     public HiveTableColumnsKey(String databaseName, String tableName, List<Column> partitionColumns,
                                List<String> columnNames) {
-        this(databaseName, tableName, partitionColumns, columnNames, false);
+        this(databaseName, tableName, partitionColumns, columnNames, TableType.HIVE);
     }
 
     public static HiveTableColumnsKey gen(String databaseName, String tableName, List<Column> partitionColumns,
@@ -52,8 +53,8 @@ public class HiveTableColumnsKey {
         return columnNames;
     }
 
-    public boolean isHudiTable() {
-        return isHudiTable;
+    public TableType getTableType() {
+        return tableType;
     }
 
     @Override
@@ -68,11 +69,11 @@ public class HiveTableColumnsKey {
         HiveTableColumnsKey other = (HiveTableColumnsKey) o;
         return Objects.equals(databaseName, other.databaseName) &&
                 Objects.equals(tableName, other.tableName) &&
-                Objects.equals(isHudiTable, other.isHudiTable);
+                Objects.equals(tableType, other.tableType);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(databaseName, tableName, isHudiTable);
+        return Objects.hash(databaseName, tableName, tableType);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/external/hive/HiveMetaCacheTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/external/hive/HiveMetaCacheTest.java
@@ -40,7 +40,7 @@ public class HiveMetaCacheTest {
     public void testGetPartitionKeys() throws Exception {
         HiveMetaClient metaClient = new MockedHiveMetaClient();
         HiveMetaCache metaCache = new HiveMetaCache(metaClient, Executors.newFixedThreadPool(10));
-        ImmutableMap<PartitionKey, Long> partitionKeys = metaCache.getPartitionKeys("db", "tbl", partColumns);
+        ImmutableMap<PartitionKey, Long> partitionKeys = metaCache.getPartitionKeys("db", "tbl", partColumns, false);
 
         Assert.assertEquals(3, partitionKeys.size());
         Assert.assertTrue(
@@ -50,7 +50,7 @@ public class HiveMetaCacheTest {
         Assert.assertTrue(
                 partitionKeys.containsKey(Utils.createPartitionKey(Lists.newArrayList("1", "2", "5"), partColumns)));
 
-        partitionKeys = metaCache.getPartitionKeys("db", "tbl", partColumns);
+        partitionKeys = metaCache.getPartitionKeys("db", "tbl", partColumns, false);
         Assert.assertEquals(3, partitionKeys.size());
         Assert.assertTrue(
                 partitionKeys.containsKey(Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns)));
@@ -120,7 +120,7 @@ public class HiveMetaCacheTest {
     public void testAddPartitionByEvent() throws Exception {
         HiveMetaClient metaClient = new MockedHiveMetaClient();
         HiveMetaCache metaCache = new HiveMetaCache(metaClient, Executors.newFixedThreadPool(10));
-        ImmutableMap<PartitionKey, Long> partitionKeys = metaCache.getPartitionKeys("db", "tbl", partColumns);
+        ImmutableMap<PartitionKey, Long> partitionKeys = metaCache.getPartitionKeys("db", "tbl", partColumns, false);
         Assert.assertEquals(3, partitionKeys.size());
         Assert.assertTrue(
                 partitionKeys.containsKey(Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns)));
@@ -134,7 +134,7 @@ public class HiveMetaCacheTest {
         PartitionKey newPartitionKey = Utils.createPartitionKey(partValues, partColumns);
         HivePartitionKey newHivePartitionKey = HivePartitionKey.gen("db", "tbl", partValues);
         metaCache.addPartitionKeyByEvent(newPartitionKeysKey, newPartitionKey, newHivePartitionKey);
-        partitionKeys = metaCache.getPartitionKeys("db", "tbl", partColumns);
+        partitionKeys = metaCache.getPartitionKeys("db", "tbl", partColumns, false);
         Assert.assertEquals(4, partitionKeys.size());
         Assert.assertTrue(partitionKeys.containsKey(newPartitionKey));
         Assert.assertFalse(metaCache.partitionExistInCache(newHivePartitionKey));
@@ -190,7 +190,7 @@ public class HiveMetaCacheTest {
     public void testDropPartitionByEvent() throws Exception {
         HiveMetaClient metaClient = new MockedHiveMetaClient();
         HiveMetaCache metaCache = new HiveMetaCache(metaClient, Executors.newFixedThreadPool(10));
-        ImmutableMap<PartitionKey, Long> partitionKeys = metaCache.getPartitionKeys("db", "tbl", partColumns);
+        ImmutableMap<PartitionKey, Long> partitionKeys = metaCache.getPartitionKeys("db", "tbl", partColumns, false);
         Assert.assertEquals(3, partitionKeys.size());
         Assert.assertTrue(
                 partitionKeys.containsKey(Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns)));
@@ -204,7 +204,7 @@ public class HiveMetaCacheTest {
         PartitionKey dropPartitionKey = Utils.createPartitionKey(partValues, partColumns);
         HivePartitionKey dropHivePartitionKey = HivePartitionKey.gen("db", "tbl", partValues);
         metaCache.dropPartitionKeyByEvent(dropPartitionKeysKey, dropPartitionKey, dropHivePartitionKey);
-        partitionKeys = metaCache.getPartitionKeys("db", "tbl", partColumns);
+        partitionKeys = metaCache.getPartitionKeys("db", "tbl", partColumns, false);
         Assert.assertEquals(2, partitionKeys.size());
         Assert.assertFalse(partitionKeys.containsKey(dropPartitionKey));
         Assert.assertFalse(metaCache.partitionExistInCache(dropHivePartitionKey));
@@ -215,7 +215,7 @@ public class HiveMetaCacheTest {
         HiveMetaClient metaClient = new MockedHiveMetaClient();
         HiveMetaCache metaCache = new HiveMetaCache(metaClient, Executors.newFixedThreadPool(10));
 
-        metaCache.getPartitionKeys("db", "tbl", partColumns);
+        metaCache.getPartitionKeys("db", "tbl", partColumns, false);
         metaCache.getPartition("db", "tbl",
                 Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns) ,false);
         metaCache.getTableStats("db", "tbl");
@@ -228,9 +228,9 @@ public class HiveMetaCacheTest {
         Assert.assertEquals(1, clientMethodGetTableStatsCalledTimes);
         Assert.assertEquals(1, clientMethodGetPartitionStatsCalledTimes);
 
-        metaCache.clearCache("db", "tbl");
+        metaCache.clearCache("db", "tbl", false);
 
-        metaCache.getPartitionKeys("db", "tbl", partColumns);
+        metaCache.getPartitionKeys("db", "tbl", partColumns, false);
         metaCache.getPartition("db", "tbl",
                 Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns), false);
         metaCache.getTableStats("db", "tbl");
@@ -254,7 +254,7 @@ public class HiveMetaCacheTest {
         }
 
         @Override
-        public Map<PartitionKey, Long> getPartitionKeys(String dbName, String tableName, List<Column> partColumns)
+        public Map<PartitionKey, Long> getPartitionKeys(String dbName, String tableName, List<Column> partColumns, boolean isHudiTable)
                 throws DdlException {
             clientMethodGetPartitionKeysCalledTimes++;
             try {

--- a/fe/fe-core/src/test/java/com/starrocks/external/hive/HiveMetaCacheTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/external/hive/HiveMetaCacheTest.java
@@ -7,7 +7,9 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.HiveMetaStoreTableInfo;
 import com.starrocks.catalog.PartitionKey;
+import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.DdlException;
@@ -19,7 +21,6 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.FileOutputStream;
-import java.io.FileWriter;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executors;
@@ -36,11 +37,22 @@ public class HiveMetaCacheTest {
     private int clientMethodGetPartitionStatsCalledTimes = 0;
     private String partitionPath = "hdfs://nameservice1/hive/db/tbl/k1=1/k2=1/k3=3";
 
+    HiveMetaStoreTableInfo hmsTable = new HiveMetaStoreTableInfo("resource", "db", "tbl",
+            partColumnNames, null, constructNameToColumn(), Table.TableType.HIVE);
+
+    public Map<String, Column> constructNameToColumn() {
+        Map<String, Column> nameToColumn = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
+        for (Column col : partColumns) {
+            nameToColumn.put(col.getName(), col);
+        }
+        return nameToColumn;
+    }
+
     @Test
     public void testGetPartitionKeys() throws Exception {
         HiveMetaClient metaClient = new MockedHiveMetaClient();
         HiveMetaCache metaCache = new HiveMetaCache(metaClient, Executors.newFixedThreadPool(10));
-        ImmutableMap<PartitionKey, Long> partitionKeys = metaCache.getPartitionKeys("db", "tbl", partColumns, false);
+        ImmutableMap<PartitionKey, Long> partitionKeys = metaCache.getPartitionKeys(hmsTable);
 
         Assert.assertEquals(3, partitionKeys.size());
         Assert.assertTrue(
@@ -50,7 +62,7 @@ public class HiveMetaCacheTest {
         Assert.assertTrue(
                 partitionKeys.containsKey(Utils.createPartitionKey(Lists.newArrayList("1", "2", "5"), partColumns)));
 
-        partitionKeys = metaCache.getPartitionKeys("db", "tbl", partColumns, false);
+        partitionKeys = metaCache.getPartitionKeys(hmsTable);
         Assert.assertEquals(3, partitionKeys.size());
         Assert.assertTrue(
                 partitionKeys.containsKey(Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns)));
@@ -67,14 +79,14 @@ public class HiveMetaCacheTest {
         HiveMetaClient metaClient = new MockedHiveMetaClient();
         HiveMetaCache metaCache = new HiveMetaCache(metaClient, Executors.newFixedThreadPool(10));
 
-        HivePartition partition = metaCache.getPartition("db", "tbl",
-                Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns), false);
+        HivePartition partition = metaCache.getPartition(hmsTable,
+                Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns));
         Assert.assertEquals(1, partition.getFiles().size());
         Assert.assertEquals(HdfsFileFormat.PARQUET, partition.getFormat());
         Assert.assertEquals(partitionPath, partition.getFullPath());
 
-        partition = metaCache.getPartition("db", "tbl",
-                Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns), false);
+        partition = metaCache.getPartition(hmsTable,
+                Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns));
         Assert.assertEquals(1, partition.getFiles().size());
         Assert.assertEquals(HdfsFileFormat.PARQUET, partition.getFormat());
         Assert.assertEquals(partitionPath, partition.getFullPath());
@@ -103,13 +115,13 @@ public class HiveMetaCacheTest {
         HiveMetaClient metaClient = new MockedHiveMetaClient();
         HiveMetaCache metaCache = new HiveMetaCache(metaClient, Executors.newFixedThreadPool(10));
 
-        HivePartitionStats partitionStats = metaCache.getPartitionStats("db", "tbl",
-                Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns), false);
+        HivePartitionStats partitionStats = metaCache.getPartitionStats(hmsTable,
+                Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns));
         Assert.assertEquals(10000L, partitionStats.getNumRows());
         Assert.assertEquals(10000L, partitionStats.getTotalFileBytes());
 
-        partitionStats = metaCache.getPartitionStats("db", "tbl",
-                Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns), false);
+        partitionStats = metaCache.getPartitionStats(hmsTable,
+                Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns));
         Assert.assertEquals(10000L, partitionStats.getNumRows());
         Assert.assertEquals(10000L, partitionStats.getTotalFileBytes());
 
@@ -120,7 +132,7 @@ public class HiveMetaCacheTest {
     public void testAddPartitionByEvent() throws Exception {
         HiveMetaClient metaClient = new MockedHiveMetaClient();
         HiveMetaCache metaCache = new HiveMetaCache(metaClient, Executors.newFixedThreadPool(10));
-        ImmutableMap<PartitionKey, Long> partitionKeys = metaCache.getPartitionKeys("db", "tbl", partColumns, false);
+        ImmutableMap<PartitionKey, Long> partitionKeys = metaCache.getPartitionKeys(hmsTable);
         Assert.assertEquals(3, partitionKeys.size());
         Assert.assertTrue(
                 partitionKeys.containsKey(Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns)));
@@ -134,7 +146,7 @@ public class HiveMetaCacheTest {
         PartitionKey newPartitionKey = Utils.createPartitionKey(partValues, partColumns);
         HivePartitionKey newHivePartitionKey = HivePartitionKey.gen("db", "tbl", partValues);
         metaCache.addPartitionKeyByEvent(newPartitionKeysKey, newPartitionKey, newHivePartitionKey);
-        partitionKeys = metaCache.getPartitionKeys("db", "tbl", partColumns, false);
+        partitionKeys = metaCache.getPartitionKeys(hmsTable);
         Assert.assertEquals(4, partitionKeys.size());
         Assert.assertTrue(partitionKeys.containsKey(newPartitionKey));
         Assert.assertFalse(metaCache.partitionExistInCache(newHivePartitionKey));
@@ -144,8 +156,8 @@ public class HiveMetaCacheTest {
     public void testAlterPartitionByEvent() throws Exception {
         HiveMetaClient metaClient = new MockedHiveMetaClient();
         HiveMetaCache metaCache = new HiveMetaCache(metaClient, Executors.newFixedThreadPool(10));
-        HivePartitionStats partitionStats = metaCache.getPartitionStats("db", "tbl",
-                Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns), false);
+        HivePartitionStats partitionStats = metaCache.getPartitionStats(hmsTable,
+                Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns));
         Assert.assertEquals(10000L, partitionStats.getNumRows());
         Assert.assertEquals(10000L, partitionStats.getTotalFileBytes());
 
@@ -173,10 +185,10 @@ public class HiveMetaCacheTest {
         sd.setLocation("file:/tmp/" + ts);
         metaCache.alterPartitionByEvent(partitionKey, sd, params);
 
-        partitionStats = metaCache.getPartitionStats("db", "tbl",
-                Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns), false);
-        HivePartition partition = metaCache.getPartition("db", "tbl",
-                Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns),false);
+        partitionStats = metaCache.getPartitionStats(hmsTable,
+                Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns));
+        HivePartition partition = metaCache.getPartition(hmsTable,
+                Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns));
         Assert.assertTrue(metaCache.partitionExistInCache(partitionKey));
         Assert.assertEquals(5, partitionStats.getNumRows());
         Assert.assertSame(partition.getFormat(), HdfsFileFormat.TEXT);
@@ -190,7 +202,7 @@ public class HiveMetaCacheTest {
     public void testDropPartitionByEvent() throws Exception {
         HiveMetaClient metaClient = new MockedHiveMetaClient();
         HiveMetaCache metaCache = new HiveMetaCache(metaClient, Executors.newFixedThreadPool(10));
-        ImmutableMap<PartitionKey, Long> partitionKeys = metaCache.getPartitionKeys("db", "tbl", partColumns, false);
+        ImmutableMap<PartitionKey, Long> partitionKeys = metaCache.getPartitionKeys(hmsTable);
         Assert.assertEquals(3, partitionKeys.size());
         Assert.assertTrue(
                 partitionKeys.containsKey(Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns)));
@@ -204,7 +216,7 @@ public class HiveMetaCacheTest {
         PartitionKey dropPartitionKey = Utils.createPartitionKey(partValues, partColumns);
         HivePartitionKey dropHivePartitionKey = HivePartitionKey.gen("db", "tbl", partValues);
         metaCache.dropPartitionKeyByEvent(dropPartitionKeysKey, dropPartitionKey, dropHivePartitionKey);
-        partitionKeys = metaCache.getPartitionKeys("db", "tbl", partColumns, false);
+        partitionKeys = metaCache.getPartitionKeys(hmsTable);
         Assert.assertEquals(2, partitionKeys.size());
         Assert.assertFalse(partitionKeys.containsKey(dropPartitionKey));
         Assert.assertFalse(metaCache.partitionExistInCache(dropHivePartitionKey));
@@ -215,13 +227,13 @@ public class HiveMetaCacheTest {
         HiveMetaClient metaClient = new MockedHiveMetaClient();
         HiveMetaCache metaCache = new HiveMetaCache(metaClient, Executors.newFixedThreadPool(10));
 
-        metaCache.getPartitionKeys("db", "tbl", partColumns, false);
-        metaCache.getPartition("db", "tbl",
-                Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns) ,false);
+        metaCache.getPartitionKeys(hmsTable);
+        metaCache.getPartition(hmsTable,
+                Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns));
         metaCache.getTableStats("db", "tbl");
 
-        metaCache.getPartitionStats("db", "tbl",
-                Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns), false);
+        metaCache.getPartitionStats(hmsTable,
+                Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns));
 
         Assert.assertEquals(1, clientMethodGetPartitionKeysCalledTimes);
         Assert.assertEquals(1, clientMethodGetPartitionCalledTimes);
@@ -230,13 +242,13 @@ public class HiveMetaCacheTest {
 
         metaCache.clearCache("db", "tbl", false);
 
-        metaCache.getPartitionKeys("db", "tbl", partColumns, false);
-        metaCache.getPartition("db", "tbl",
-                Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns), false);
+        metaCache.getPartitionKeys(hmsTable);
+        metaCache.getPartition(hmsTable,
+                Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns));
         metaCache.getTableStats("db", "tbl");
 
-        metaCache.getPartitionStats("db", "tbl",
-                Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns), false);
+        metaCache.getPartitionStats(hmsTable,
+                Utils.createPartitionKey(Lists.newArrayList("1", "2", "3"), partColumns));
 
         Assert.assertEquals(2, clientMethodGetPartitionKeysCalledTimes);
         Assert.assertEquals(2, clientMethodGetPartitionCalledTimes);

--- a/fe/fe-core/src/test/java/com/starrocks/external/hive/HiveMetaClientTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/external/hive/HiveMetaClientTest.java
@@ -196,7 +196,7 @@ public class HiveMetaClientTest {
 
         HiveMetaClient client = new HiveMetaClient("thrift://127.0.0.1:9030");
         Map<String, HiveColumnStats> stats =
-                client.getTableLevelColumnStatsForPartTable("db", "tbl", partitionKeys, partColumns, allColumnNames);
+                client.getTableLevelColumnStatsForPartTable("db", "tbl", partitionKeys, partColumns, allColumnNames, false);
         HiveColumnStats partitionStats = stats.get("col1");
         Assert.assertEquals(partitionStats.getNumNulls(), 4L);
         Assert.assertEquals(partitionStats.getNumDistinctValues(), 3L);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [x] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
Bug:  
Closes #4568 
Closes #4690 

Feature:
Support cleaning meta cache of hudi table on drop

## Problem Summary(Required) ：
`default` is used to represent NULL value of partition field for partition directory name in hudi instead of `__HIVE_DEFAULT_PARTITION__` in hive, so it is necessary to distinguish them.
