### PR TITLE
Update profile merge strategy

### DIFF
--- a/be/src/exec/pipeline/chunk_source.h
+++ b/be/src/exec/pipeline/chunk_source.h
@@ -12,12 +12,14 @@
 
 namespace starrocks {
 class RuntimeState;
+class RuntimeProfile;
 
 namespace pipeline {
 
 class ChunkSource {
 public:
-    ChunkSource(MorselPtr&& morsel) : _morsel(std::move(morsel)) {}
+    ChunkSource(RuntimeProfile* runtime_profile, MorselPtr&& morsel)
+            : _runtime_profile(runtime_profile), _morsel(std::move(morsel)){};
 
     virtual ~ChunkSource() = default;
 
@@ -44,6 +46,7 @@ public:
 
 protected:
     // The morsel will own by pipeline driver
+    RuntimeProfile* _runtime_profile;
     MorselPtr _morsel;
 };
 

--- a/be/src/exec/pipeline/chunk_source.h
+++ b/be/src/exec/pipeline/chunk_source.h
@@ -45,8 +45,8 @@ public:
     virtual int64_t last_spent_cpu_time_ns() { return 0; }
 
 protected:
-    // The morsel will own by pipeline driver
     RuntimeProfile* _runtime_profile;
+    // The morsel will own by pipeline driver
     MorselPtr _morsel;
 };
 

--- a/be/src/exec/pipeline/exchange/sink_buffer.cpp
+++ b/be/src/exec/pipeline/exchange/sink_buffer.cpp
@@ -119,19 +119,20 @@ void SinkBuffer::update_profile(RuntimeProfile* profile) {
 
     auto* network_timer = ADD_TIMER(profile, "NetworkTime");
     auto* wait_timer = ADD_TIMER(profile, "WaitTime");
-
     COUNTER_SET(network_timer, _network_time());
     COUNTER_SET(wait_timer, _wait_time());
 
     auto* bytes_sent_counter = ADD_COUNTER(profile, "BytesSent", TUnit::BYTES);
     auto* request_sent_counter = ADD_COUNTER(profile, "RequestSent", TUnit::UNIT);
-    auto* bytes_unsent_counter = ADD_COUNTER(profile, "BytesUnsent", TUnit::BYTES);
-    auto* request_unsent_counter = ADD_COUNTER(profile, "RequestUnsent", TUnit::UNIT);
-
     COUNTER_SET(bytes_sent_counter, _bytes_sent);
     COUNTER_SET(request_sent_counter, _request_sent);
-    COUNTER_SET(bytes_unsent_counter, _bytes_enqueued - _bytes_sent);
-    COUNTER_SET(request_unsent_counter, _request_enqueued - _request_sent);
+
+    if (_bytes_enqueued - _bytes_sent > 0) {
+        auto* bytes_unsent_counter = ADD_COUNTER(profile, "BytesUnsent", TUnit::BYTES);
+        auto* request_unsent_counter = ADD_COUNTER(profile, "RequestUnsent", TUnit::UNIT);
+        COUNTER_SET(bytes_unsent_counter, _bytes_enqueued - _bytes_sent);
+        COUNTER_SET(request_unsent_counter, _request_enqueued - _request_sent);
+    }
 
     profile->add_derived_counter(
             "OverallThroughput", TUnit::BYTES_PER_SECOND,

--- a/be/src/exec/pipeline/hdfs_chunk_source.cpp
+++ b/be/src/exec/pipeline/hdfs_chunk_source.cpp
@@ -19,13 +19,13 @@
 namespace starrocks::pipeline {
 using namespace vectorized;
 
-HdfsChunkSource::HdfsChunkSource(MorselPtr&& morsel, ScanOperator* op, vectorized::HdfsScanNode* scan_node)
-        : ChunkSource(std::move(morsel)),
+HdfsChunkSource::HdfsChunkSource(RuntimeProfile* runtime_profile, MorselPtr&& morsel, ScanOperator* op,
+                                 vectorized::HdfsScanNode* scan_node)
+        : ChunkSource(runtime_profile, std::move(morsel)),
           _scan_node(scan_node),
           _limit(scan_node->limit()),
           _runtime_in_filters(op->runtime_in_filters()),
-          _runtime_bloom_filters(op->runtime_bloom_filters()),
-          _runtime_profile(op->unique_metrics()) {
+          _runtime_bloom_filters(op->runtime_bloom_filters()) {
     _conjunct_ctxs = scan_node->conjunct_ctxs();
     _conjunct_ctxs.insert(_conjunct_ctxs.end(), _runtime_in_filters.begin(), _runtime_in_filters.end());
     ScanMorsel* scan_morsel = (ScanMorsel*)_morsel.get();

--- a/be/src/exec/pipeline/hdfs_chunk_source.h
+++ b/be/src/exec/pipeline/hdfs_chunk_source.h
@@ -26,7 +26,8 @@ namespace pipeline {
 class ScanOperator;
 class HdfsChunkSource final : public ChunkSource {
 public:
-    HdfsChunkSource(MorselPtr&& morsel, ScanOperator* op, vectorized::HdfsScanNode* scan_node);
+    HdfsChunkSource(RuntimeProfile* runtime_profile, MorselPtr&& morsel, ScanOperator* op,
+                    vectorized::HdfsScanNode* scan_node);
 
     ~HdfsChunkSource() override;
 
@@ -126,7 +127,6 @@ private:
 
     // ======================================
     // The following are profile metrics
-    RuntimeProfile* _runtime_profile;
     vectorized::HdfsScanProfile _profile;
 };
 } // namespace pipeline

--- a/be/src/exec/pipeline/hdfs_scan_operator.cpp
+++ b/be/src/exec/pipeline/hdfs_scan_operator.cpp
@@ -36,9 +36,10 @@ Status HdfsScanOperator::do_prepare(RuntimeState*) {
 
 void HdfsScanOperator::do_close(RuntimeState*) {}
 
-ChunkSourcePtr HdfsScanOperator::create_chunk_source(MorselPtr morsel) {
+ChunkSourcePtr HdfsScanOperator::create_chunk_source(MorselPtr morsel, int32_t chunk_source_index) {
     vectorized::HdfsScanNode* hdfs_scan_node = down_cast<vectorized::HdfsScanNode*>(_scan_node);
-    return std::make_shared<HdfsChunkSource>(std::move(morsel), this, hdfs_scan_node);
+    return std::make_shared<HdfsChunkSource>(_chunk_source_profiles[chunk_source_index].get(), std::move(morsel), this,
+                                             hdfs_scan_node);
 }
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/hdfs_scan_operator.h
+++ b/be/src/exec/pipeline/hdfs_scan_operator.h
@@ -29,7 +29,7 @@ public:
 
     Status do_prepare(RuntimeState* state) override;
     void do_close(RuntimeState* state) override;
-    ChunkSourcePtr create_chunk_source(MorselPtr morsel) override;
+    ChunkSourcePtr create_chunk_source(MorselPtr morsel, int32_t chunk_source_index) override;
 
 private:
 };

--- a/be/src/exec/pipeline/jdbc_scan_operator.cpp
+++ b/be/src/exec/pipeline/jdbc_scan_operator.cpp
@@ -163,7 +163,7 @@ void JDBCScanOperator::do_close(RuntimeState* state) {
     }
 }
 
-ChunkSourcePtr JDBCScanOperator::create_chunk_source(MorselPtr morsel) {
+ChunkSourcePtr JDBCScanOperator::create_chunk_source(MorselPtr morsel, int32_t chunk_source_index) {
     // this function is not be used in JDBCScanOperator, just ignore it
     return nullptr;
 }

--- a/be/src/exec/pipeline/jdbc_scan_operator.h
+++ b/be/src/exec/pipeline/jdbc_scan_operator.h
@@ -34,7 +34,7 @@ public:
 
     void do_close(RuntimeState* state) override;
 
-    ChunkSourcePtr create_chunk_source(MorselPtr morsel) override;
+    ChunkSourcePtr create_chunk_source(MorselPtr morsel, int32_t chunk_source_index) override;
 
 private:
     Status _start_scanner_thread(RuntimeState* state);

--- a/be/src/exec/pipeline/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/olap_chunk_source.cpp
@@ -22,13 +22,13 @@
 namespace starrocks::pipeline {
 using namespace vectorized;
 
-OlapChunkSource::OlapChunkSource(MorselPtr&& morsel, ScanOperator* op, vectorized::OlapScanNode* scan_node)
-        : ChunkSource(std::move(morsel)),
+OlapChunkSource::OlapChunkSource(RuntimeProfile* runtime_profile, MorselPtr&& morsel, ScanOperator* op,
+                                 vectorized::OlapScanNode* scan_node)
+        : ChunkSource(runtime_profile, std::move(morsel)),
           _scan_node(scan_node),
           _limit(scan_node->limit()),
           _runtime_in_filters(op->runtime_in_filters()),
-          _runtime_bloom_filters(op->runtime_bloom_filters()),
-          _runtime_profile(op->unique_metrics()) {
+          _runtime_bloom_filters(op->runtime_bloom_filters()) {
     _conjunct_ctxs = scan_node->conjunct_ctxs();
     _conjunct_ctxs.insert(_conjunct_ctxs.end(), _runtime_in_filters.begin(), _runtime_in_filters.end());
     ScanMorsel* scan_morsel = (ScanMorsel*)_morsel.get();

--- a/be/src/exec/pipeline/olap_chunk_source.h
+++ b/be/src/exec/pipeline/olap_chunk_source.h
@@ -30,7 +30,8 @@ namespace pipeline {
 class ScanOperator;
 class OlapChunkSource final : public ChunkSource {
 public:
-    OlapChunkSource(MorselPtr&& morsel, ScanOperator* op, vectorized::OlapScanNode* scan_node);
+    OlapChunkSource(RuntimeProfile* runtime_profile, MorselPtr&& morsel, ScanOperator* op,
+                    vectorized::OlapScanNode* scan_node);
 
     ~OlapChunkSource() override = default;
 
@@ -116,13 +117,11 @@ private:
     int64_t _raw_rows_read = 0;
     int64_t _compressed_bytes_read = 0;
 
-    RuntimeProfile* _runtime_profile;
     RuntimeProfile::Counter* _bytes_read_counter = nullptr;
     RuntimeProfile::Counter* _rows_read_counter = nullptr;
 
     int64_t _last_spent_cpu_time_ns = 0;
 
-    RuntimeProfile* _scan_profile = nullptr;
     RuntimeProfile::Counter* _expr_filter_timer = nullptr;
     RuntimeProfile::Counter* _scan_timer = nullptr;
     RuntimeProfile::Counter* _create_seg_iter_timer = nullptr;

--- a/be/src/exec/pipeline/olap_scan_operator.cpp
+++ b/be/src/exec/pipeline/olap_scan_operator.cpp
@@ -81,9 +81,10 @@ Status OlapScanOperator::_capture_tablet_rowsets() {
     return Status::OK();
 }
 
-ChunkSourcePtr OlapScanOperator::create_chunk_source(MorselPtr morsel) {
+ChunkSourcePtr OlapScanOperator::create_chunk_source(MorselPtr morsel, int32_t chunk_source_index) {
     vectorized::OlapScanNode* olap_scan_node = down_cast<vectorized::OlapScanNode*>(_scan_node);
-    return std::make_shared<OlapChunkSource>(std::move(morsel), this, olap_scan_node);
+    return std::make_shared<OlapChunkSource>(_chunk_source_profiles[chunk_source_index].get(), std::move(morsel), this,
+                                             olap_scan_node);
 }
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/olap_scan_operator.h
+++ b/be/src/exec/pipeline/olap_scan_operator.h
@@ -34,7 +34,7 @@ public:
 
     Status do_prepare(RuntimeState* state) override;
     void do_close(RuntimeState* state) override;
-    ChunkSourcePtr create_chunk_source(MorselPtr morsel) override;
+    ChunkSourcePtr create_chunk_source(MorselPtr morsel, int32_t chunk_source_index) override;
 
 private:
     Status _capture_tablet_rowsets();

--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -240,9 +240,8 @@ void GlobalDriverExecutor::remove_non_core_metrics(FragmentContext* fragment_ctx
 
             operator_profile->remove_childs();
 
-            if (common_metrics != nullptr) {
-                common_metrics->remove_counters(std::set<std::string>{"OperatorTotalTime"});
-            }
+            DCHECK(common_metrics != nullptr);
+            common_metrics->remove_counters(std::set<std::string>{"OperatorTotalTime"});
 
             common_metrics->reset_parent();
             operator_profile->add_child(common_metrics, true, nullptr);

--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -237,14 +237,12 @@ void GlobalDriverExecutor::remove_non_core_metrics(FragmentContext* fragment_ctx
 
         for (auto* operator_profile : operator_profiles) {
             RuntimeProfile* common_metrics = operator_profile->get_child("CommonMetrics");
-
-            operator_profile->remove_childs();
-
             DCHECK(common_metrics != nullptr);
             common_metrics->remove_counters(std::set<std::string>{"OperatorTotalTime"});
 
-            common_metrics->reset_parent();
-            operator_profile->add_child(common_metrics, true, nullptr);
+            RuntimeProfile* unique_metrics = operator_profile->get_child("UniqueMetrics");
+            DCHECK(unique_metrics != nullptr);
+            unique_metrics->remove_counters(std::set<std::string>{"ScanTime", "NetworkTime", "WaitTime"});
         }
     }
 }

--- a/be/src/exec/pipeline/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan_operator.cpp
@@ -281,7 +281,7 @@ void ScanOperator::_merge_chunk_source_profiles() {
     std::queue<std::string> parent_queue;
     parent_queue.push(RuntimeProfile::ROOT_COUNTER);
     while (!parent_queue.empty()) {
-        std::string parent_counter_name = parent_queue.front();
+        std::string parent_counter_name = std::move(parent_queue.front());
         parent_queue.pop();
         for (auto& name : child_counter_map[parent_counter_name]) {
             parent_queue.push(name);

--- a/be/src/util/runtime_profile.cpp
+++ b/be/src/util/runtime_profile.cpp
@@ -203,7 +203,7 @@ void RuntimeProfile::update(const std::vector<TRuntimeProfileNode>& nodes, int* 
             InfoStrings::iterator existing = _info_strings.find(key);
 
             if (existing == _info_strings.end()) {
-                _info_strings.insert(std::make_pair(key, it->second));
+                _info_strings.emplace(key, it->second);
                 _info_strings_display_order.push_back(key);
             } else {
                 _info_strings[key] = it->second;
@@ -374,7 +374,7 @@ void RuntimeProfile::add_info_string(const std::string& key, const std::string& 
     InfoStrings::iterator it = _info_strings.find(key);
 
     if (it == _info_strings.end()) {
-        _info_strings.insert(std::make_pair(key, value));
+        _info_strings.emplace(key, value);
         _info_strings_display_order.push_back(key);
     } else {
         it->second = value;
@@ -395,7 +395,7 @@ const std::string* RuntimeProfile::get_info_string(const std::string& key) {
 void RuntimeProfile::get_all_info_strings(std::map<std::string, std::string>* info_strings) {
     std::lock_guard<std::mutex> l(_info_strings_lock);
     for (auto& [key, value] : _info_strings) {
-        info_strings->insert(std::make_pair(key, value));
+        info_strings->emplace(key, value);
     }
 }
 
@@ -554,11 +554,11 @@ void RuntimeProfile::get_all_counters(std::map<std::string, Counter*>* counters,
     std::lock_guard<std::mutex> l(_counter_lock);
 
     for (auto& [key, value] : _counter_map) {
-        counters->insert(std::make_pair(key, value));
+        counters->emplace(key, value);
     }
 
     for (auto& [parent_counter_name, names] : _child_counter_map) {
-        child_counter_map->insert(std::make_pair(parent_counter_name, names));
+        child_counter_map->emplace(parent_counter_name, names);
     }
 }
 

--- a/be/src/util/runtime_profile.cpp
+++ b/be/src/util/runtime_profile.cpp
@@ -972,7 +972,7 @@ void RuntimeProfile::merge_isomorphic_profiles(std::vector<RuntimeProfile*>& pro
             const auto max_value = std::get<2>(merged_info);
 
             auto* counter0 = profile0->get_counter(name);
-            // As memtioned before, some counters may only attach one of the isomorphic profiles
+            // As memtioned before, some counters may only attach to one of the isomorphic profiles
             // and the first profile may not have this counter, so we create a counter here
             if (counter0 == nullptr) {
                 counter0 = profile0->add_counter(name, type);
@@ -981,11 +981,20 @@ void RuntimeProfile::merge_isomorphic_profiles(std::vector<RuntimeProfile*>& pro
 
             // If the values vary greatly, we need to save extra info (min value and max value) of this counter
             const auto diff = max_value - min_value;
-            if (is_average_type(counter0->type()) && (diff > 5'000'000L && diff > merged_value / 5)) {
-                auto* min_counter = profile0->add_counter(strings::Substitute("__MIN_OF_$0", name), type, name);
-                auto* max_counter = profile0->add_counter(strings::Substitute("__MAX_OF_$0", name), type, name);
-                min_counter->set(min_value);
-                max_counter->set(max_value);
+            if (is_average_type(counter0->type())) {
+                if ((diff > 5'000'000L && diff > merged_value / 5)) {
+                    auto* min_counter = profile0->add_counter(strings::Substitute("__MIN_OF_$0", name), type, name);
+                    auto* max_counter = profile0->add_counter(strings::Substitute("__MAX_OF_$0", name), type, name);
+                    min_counter->set(min_value);
+                    max_counter->set(max_value);
+                }
+            } else {
+                if (diff > min_value) {
+                    auto* min_counter = profile0->add_counter(strings::Substitute("__MIN_OF_$0", name), type, name);
+                    auto* max_counter = profile0->add_counter(strings::Substitute("__MAX_OF_$0", name), type, name);
+                    min_counter->set(min_value);
+                    max_counter->set(max_value);
+                }
             }
         }
     }

--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -309,7 +309,7 @@ public:
     // parent_counter_name.
     // If the counter already exists, the existing counter object is returned.
     Counter* add_counter(const std::string& name, TUnit::type type, const std::string& parent_counter_name);
-    Counter* add_counter(const std::string& name, TUnit::type type) { return add_counter(name, type, ""); }
+    Counter* add_counter(const std::string& name, TUnit::type type) { return add_counter(name, type, ROOT_COUNTER); }
 
     // Add a derived counter with 'name'/'type'. The counter is owned by the
     // RuntimeProfile object.
@@ -331,6 +331,9 @@ public:
     // Adds all counters with 'name' that are registered either in this or
     // in any of the child profiles to 'counters'.
     void get_counters(const std::string& name, std::vector<Counter*>* counters);
+
+    void get_all_counters(std::map<std::string, Counter*>* counters,
+                          std::map<std::string, std::set<std::string>>* child_counter_map);
 
     // Copy all but the bucket counters from src profile
     void copy_all_counters_from(RuntimeProfile* src_profile);
@@ -354,6 +357,7 @@ public:
     // Returns a pointer to the info string value for 'key'.  Returns NULL if
     // the key does not exist.
     const std::string* get_info_string(const std::string& key);
+    void get_all_info_strings(std::map<std::string, std::string>* info_strings);
 
     // Copy all the string infos from src profile
     void copy_all_info_strings_from(RuntimeProfile* src_profile);
@@ -458,6 +462,10 @@ public:
     // its children.
     // This function updates _local_time_percent for each profile.
     void compute_time_in_profile();
+
+public:
+    // The root counter name for all top level counters.
+    const static std::string ROOT_COUNTER;
 
 private:
     // vector of (profile, indentation flag)

--- a/be/src/util/stopwatch.hpp
+++ b/be/src/util/stopwatch.hpp
@@ -35,6 +35,7 @@ namespace starrocks {
 class MonotonicStopWatch {
 public:
     MonotonicStopWatch() {
+        _start = {};
         _total_time = 0;
         _running = false;
     }
@@ -72,8 +73,7 @@ public:
 
         timespec end;
         clock_gettime(CLOCK_MONOTONIC, &end);
-        return (end.tv_sec - _start.tv_sec) * 1000L * 1000L * 1000L +
-               (end.tv_nsec - _start.tv_nsec);
+        return (end.tv_sec - _start.tv_sec) * 1000L * 1000L * 1000L + (end.tv_nsec - _start.tv_nsec);
     }
 
 private:
@@ -82,4 +82,4 @@ private:
     bool _running;
 };
 
-}
+} // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
@@ -488,7 +488,7 @@ public class RuntimeProfile {
             Counter.MergedInfo mergedInfo = Counter.mergeIsomorphicCounters(type, counters);
 
             Counter counter0 = profile0.getCounter(name);
-            // As memtioned before, some counters may only attach one of the isomorphic profiles
+            // As memtioned before, some counters may only attach to one of the isomorphic profiles
             // and the first profile may not have this counter, so we create a counter here
             if (counter0 == null) {
                 counter0 = profile0.addCounter(name, type);
@@ -497,13 +497,24 @@ public class RuntimeProfile {
 
             // If the values vary greatly, we need to save extra info (min value and max value) of this counter
             double diff = mergedInfo.maxValue - mergedInfo.minValue;
-            if (Counter.isAverageType(counter0.getType()) && (diff > 5000000L && diff > mergedInfo.mergedValue / 5)) {
-                Counter minCounter =
-                        profile0.addCounter(mergedInfoPrefixMin + name, type, name);
-                Counter maxCounter =
-                        profile0.addCounter(mergedInfoPrefixMax + name, type, name);
-                minCounter.setValue(mergedInfo.minValue);
-                maxCounter.setValue(mergedInfo.maxValue);
+            if (Counter.isAverageType(counter0.getType())) {
+                if (diff > 5000000L && diff > mergedInfo.mergedValue / 5) {
+                    Counter minCounter =
+                            profile0.addCounter(mergedInfoPrefixMin + name, type, name);
+                    Counter maxCounter =
+                            profile0.addCounter(mergedInfoPrefixMax + name, type, name);
+                    minCounter.setValue(mergedInfo.minValue);
+                    maxCounter.setValue(mergedInfo.maxValue);
+                }
+            } else {
+                if (diff > mergedInfo.minValue) {
+                    Counter minCounter =
+                            profile0.addCounter(mergedInfoPrefixMin + name, type, name);
+                    Counter maxCounter =
+                            profile0.addCounter(mergedInfoPrefixMax + name, type, name);
+                    minCounter.setValue(mergedInfo.minValue);
+                    maxCounter.setValue(mergedInfo.maxValue);
+                }
             }
         }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

### update profile merge strategy

Here is the profile merge strategy

* Aa for time metrics, if data vary greatly, then the maximum and minimum values are kept extra
* As for non-time metrics, simply accmumulation

But for some special cases, i.e. drastic data skew, some pipeline drivers process no data at all, but we cannot find this from profile. So we also add maximum and minimum values if non-time meitrics vary greatly

### update scan operators' statistical strategy

Currently, one scan operator can have multiply parallel scan task (chunk_source), but all these scan task share the same timer, so all the time have been accumulated to one timer, which is greater than the real time usage. So we need to record time in parallel level, and merge it at the end
