### PR TITLE
Fix the int overflow bug of BinaryColumn::update_rows

### DIFF
--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -231,11 +231,11 @@ Status BinaryColumn::update_rows(const Column& src, const uint32_t* indexes) {
             new_binary_column->append(src, i, 1);
             idx_begin = indexes[i] + 1;
         }
-        int32_t remain_count = _offsets.size() - idx_begin - 1;
-        if (remain_count > 0) {
-            new_binary_column->append(*this, idx_begin, remain_count);
+        if (size() > indexes[replace_num - 1] + 1) {
+            uint32_t remain_count = size() - indexes[replace_num - 1] - 1;
+            new_binary_column->append(*this, indexes[replace_num - 1] + 1, remain_count);
         }
-        swap_column(*new_binary_column.get());
+        swap_column(*new_binary_column);
     }
 
     return Status::OK();

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -132,6 +132,7 @@ public:
     //      column data: [0, 1, 2, 3, 4]
     //      src_column data: [5, 6]
     // After call this function, column data will be set as [5, 1, 2, 6, 4]
+    // The values in indexes is incremented
     virtual Status update_rows(const Column& src, const uint32_t* indexes) = 0;
 
     // This function will append data from src according to the input indexes. 'indexes' contains

--- a/be/test/column/binary_column_test.cpp
+++ b/be/test/column/binary_column_test.cpp
@@ -478,6 +478,7 @@ PARALLEL_TEST(BinaryColumnTest, test_clone_empty) {
     ASSERT_EQ(0, c2->size());
 }
 
+// NOLINTNEXTLINE
 PARALLEL_TEST(BinaryColumnTest, test_update_rows) {
     auto c1 = BinaryColumn::create();
     c1->append_datum("abc");
@@ -526,8 +527,28 @@ PARALLEL_TEST(BinaryColumnTest, test_update_rows) {
     ASSERT_EQ("ghi", slices[2]);
     ASSERT_EQ("cdef", slices[3]);
     ASSERT_EQ("mno", slices[4]);
+
+    // This case will alloc a lot of memory (16G) and run slowly,
+    // So i temp comment it and will open if i find one better solution
+    /*
+    size_t count = (1ul<<31ul) + 5;
+    auto c5 = BinaryColumn::create();
+    c5->get_bytes().resize(count);
+    c5->get_offset().resize(count + 1);
+    for (size_t i = 0; i < c5->get_offset().size(); i++) {
+        c5->get_offset()[i] = i;
+    }
+
+    auto c6 = BinaryColumn::create();
+    c6->append("22");
+
+    std::vector<uint32_t> c6_replace_idxes = {0};
+    ASSERT_TRUE(c5->update_rows(*c6, c6_replace_idxes.data()).ok());
+    ASSERT_EQ(c5->size(), count);
+    */
 }
 
+// NOLINTNEXTLINE
 PARALLEL_TEST(BinaryColumnTest, test_xor_checksum) {
     auto column = BinaryColumn::create();
     std::string str;


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4603 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

if size of BinaryColumn > 2^31,  int32_t may be overflow in some scenarios.

```
int32_t remain_count = _offsets.size() - idx_begin - 1;
```
