### PR TITLE
All methods in CacheDictManager shouldn't be blocked

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadManager.java
@@ -236,7 +236,7 @@ public class RoutineLoadManager implements Writable {
         routineLoadJobList.add(routineLoadJob);
         // add txn state callback in factory
         Catalog.getCurrentGlobalTransactionMgr().getCallbackFactory().addCallback(routineLoadJob);
-        IDictManager.getInstance().forbitGlobalDict(routineLoadJob.getTableId());
+        IDictManager.getInstance().forbidGlobalDict(routineLoadJob.getTableId());
     }
 
     // TODO(ml): Idempotency

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CacheDictManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CacheDictManager.java
@@ -197,7 +197,7 @@ public class CacheDictManager implements IDictManager {
             try {
                 realResult = result.get();
             } catch (Exception e) {
-                LOG.warn(e);
+                LOG.warn(String.format("get dict cache for %d: %s failed", tableId, columnName), e);
                 return false;
             }
             if (!realResult.isPresent()) {
@@ -223,7 +223,7 @@ public class CacheDictManager implements IDictManager {
         }
 
         if (forbiddenDictTableIds.contains(tableId)) {
-            LOG.debug("table {} forbit low cardinality global dict", tableId);
+            LOG.debug("table {} forbid low cardinality global dict", tableId);
             return false;
         }
 
@@ -238,7 +238,7 @@ public class CacheDictManager implements IDictManager {
     }
 
     @Override
-    public void forbitGlobalDict(long tableId) {
+    public void forbidGlobalDict(long tableId) {
         LOG.debug("remove dict for table {}", tableId);
         forbiddenDictTableIds.add(tableId);
     }
@@ -246,21 +246,37 @@ public class CacheDictManager implements IDictManager {
     @Override
     public void updateGlobalDict(long tableId, String columnName, long versionTime) {
         ColumnIdentifier columnIdentifier = new ColumnIdentifier(tableId, columnName);
-        if (!dictStatistics.synchronous().asMap().containsKey(columnIdentifier)) {
+        if (!dictStatistics.asMap().containsKey(columnIdentifier)) {
             return;
         }
 
-        Optional<ColumnDict> columnDictOptional = dictStatistics.synchronous().get(columnIdentifier);
-        Preconditions.checkState(columnDictOptional != null && columnDictOptional.isPresent());
-        ColumnDict columnDict = columnDictOptional.get();
-        ColumnDict newColumnDict = new ColumnDict(columnDict.getDict(), versionTime);
-        dictStatistics.synchronous().put(columnIdentifier, Optional.of(newColumnDict));
-        LOG.debug("update dict for column {}, version {}", columnName, versionTime);
+        CompletableFuture<Optional<ColumnDict>> columnFuture = dictStatistics.get(columnIdentifier);
+        if (columnFuture.isDone()) {
+            try {
+                Optional<ColumnDict> columnOptional = columnFuture.get();
+                if (columnOptional.isPresent()) {
+                    ColumnDict columnDict = columnOptional.get();
+                    ColumnDict newColumnDict = new ColumnDict(columnDict.getDict(), versionTime);
+                    dictStatistics.put(columnIdentifier, CompletableFuture.completedFuture(Optional.of(newColumnDict)));
+                    LOG.debug("update dict for column {}, version {}", columnName, versionTime);
+                }
+            } catch (Exception e) {
+                LOG.warn(String.format("update dict cache for %d: %s failed", tableId, columnName), e);
+            }
+        }
     }
 
     @Override
     public Optional<ColumnDict> getGlobalDict(long tableId, String columnName) {
         ColumnIdentifier columnIdentifier = new ColumnIdentifier(tableId, columnName);
-        return dictStatistics.synchronous().get(columnIdentifier);
+        CompletableFuture<Optional<ColumnDict>> columnFuture = dictStatistics.get(columnIdentifier);
+        if (columnFuture.isDone()) {
+            try {
+                return columnFuture.get();
+            } catch (Exception e) {
+                LOG.warn(String.format("get dict cache for %d: %s failed", tableId, columnName), e);
+            }
+        }
+        return Optional.empty();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/IDictManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/IDictManager.java
@@ -15,7 +15,7 @@ public interface IDictManager {
 
     void removeGlobalDict(long tableId, String columnName);
 
-    void forbitGlobalDict(long tableId);
+    void forbidGlobalDict(long tableId);
 
     // You should call `hasGlobalDict` firstly to ensure the global dict exist
     Optional<ColumnDict> getGlobalDict(long tableId, String columnName);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/MockDictManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/MockDictManager.java
@@ -40,7 +40,7 @@ public class MockDictManager implements IDictManager {
     }
 
     @Override
-    public void forbitGlobalDict(long tableId) {
+    public void forbidGlobalDict(long tableId) {
     }
 
     @Override


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
for https://github.com/StarRocks/starrocks/issues/4620

**All methods in CacheDictManager shouldn't be blocked**

dictStatistics.synchronous().get() or dictStatistics.synchronous().put() will be blocked.
