### PR TITLE
Rehash for local shuffle to avoid data skew

### DIFF
--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -464,7 +464,8 @@ Status ExchangeSinkOperator::push_chunk(RuntimeState* state, const vectorized::C
 
             for (size_t i = 0; i < num_rows; ++i) {
                 auto channel_id = _hash_values[i] % num_channels;
-                auto driver_sequence = _hash_values[i] % _num_shuffles;
+                // Note that xorshift32 rehash must be applied for both local shuffle and exchange sink here.
+                auto driver_sequence = HashUtil::xorshift32(_hash_values[i]) % _num_shuffles;
                 _channel_ids[i] = channel_id;
                 _driver_sequences[i] = driver_sequence;
                 _channel_row_idx_start_points[channel_id * _num_shuffles + driver_sequence]++;

--- a/be/src/util/hash_util.hpp
+++ b/be/src/util/hash_util.hpp
@@ -403,6 +403,17 @@ static size_t hash_bytes(void const* ptr, size_t const len) noexcept {
     return static_cast<size_t>(h);
 }
 
+// Xorshift is a pseudorandom number generator, which is an implementation of
+// linear-feedback shift registers (LFSRs). It generates next pseudorandom state from
+// the current state, which can be easily repurposed as hash functions.
+// The original paper: https://www.jstatsoft.org/article/view/v008i14
+static uint32_t xorshift32(uint32_t x) {
+    x ^= x << 13;
+    x ^= x >> 17;
+    x ^= x << 5;
+    return x;
+}
+
 };
 
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Problem Summary：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When the local exchange is the successor of ExchangeSourceOperator, the data flow is `exchange sink -> exchange source -> local exchange`. 
- `exchange sink -> exchange source` (phase 1) determines which fragment instance to deliver each row,
- while `exchange source -> local exchange` (phase 2) determines which pipeline driver to deliver each row.

To avoid hash two times and data skew due to hash one time, phase 1 hashes one time and phase 2 applies `xorshift32` on the hash value. Note that `xorshift32` rehash must be applied for both local shuffle and exchange sink.

## Test
As for random test
- When `num_fis` and `dop` is co-prime, all the rehash functions are not worse than `no_hash`.
- `xoshift32` and `simple` behave similarly to `fnv_hash` and `murmur_hash` in all the scenarios.

As for sequence test
- When `num_fis` and `dop` is co-prime, `xoshift32` behaves similarly to `fnv_hash` and `simple`, and is better than `murmur_hash` and `fmix32`
- When `num_fis` and `dop` isn't co-prime, `xoshift32` behaves better than the others.

### Random Test
Randomly generate `n` numbers for each driver of each fragment instance, that is, generate `n*num_fis*dop` numbers totally.
Compare the following 6 rehash functions with multiple `num_fis` and `dop` by coefficient of variation.

As for each rehash function, calculate the coefficient of variation of each fragment instance, and select the maximum  coefficient of variation among the fragment instances. 

`coefficient of variation=standard deviation/mean`, which can be used to compare among different scale factor `n`.
```C++
uint32_t fmix32(uint32_t h) {
  h ^= h >> 16;
  h *= 0x85ebca6b;
  h ^= h >> 13;
  h *= 0xc2b2ae35;
  h ^= h >> 16;
  return h;
}

uint32_t simple(uint32_t x) {
  return (x >> 8) ^ (x >> 16) ^ (x >> 24) ^ x;
}

uint32_t xorshift32(uint32_t x) {
  x ^= x << 13;
  x ^= x >> 17;
  x ^= x << 5;
  return x;
}

uint32_t no_hash(uint32_t x) {
  return x;
}
```
#### num_fis=3-dop=8

| n      | fmix32 | murmur_hash | fnv_hash | simple | xorshift32 | no_hash |
| ------ | ------ | ----------- | -------- | ------ | ---------- | ------- |
| 128    | 0.126  | 0.088       | 0.104    | 0.097  | 0.111      | 0.101   |
| 2048   | 0.029  | 0.020       | 0.027    | 0.027  | 0.024      | 0.023   |
| 4096   | 0.021  | 0.012       | 0.020    | 0.013  | 0.018      | 0.025   |
| 16384  | 0.006  | 0.008       | 0.010    | 0.011  | 0.008      | 0.008   |
| 65536  | 0.005  | 0.005       | 0.005    | 0.004  | 0.007      | 0.003   |
| 131072 | 0.003  | 0.003       | 0.003    | 0.002  | 0.003      | 0.003   |



#### num_fis=3-dop=16

| n      | fmix32 | murmur_hash | fnv_hash | simple | xorshift32 | no_hash |
| ------ | ------ | ----------- | -------- | ------ | ---------- | ------- |
| 128    | 0.110  | 0.112       | 0.103    | 0.103  | 0.101      | 0.117   |
| 2048   | 0.025  | 0.025       | 0.022    | 0.027  | 0.027      | 0.024   |
| 4096   | 0.016  | 0.020       | 0.022    | 0.018  | 0.016      | 0.021   |
| 16384  | 0.009  | 0.007       | 0.010    | 0.010  | 0.008      | 0.008   |
| 65536  | 0.005  | 0.005       | 0.004    | 0.004  | 0.003      | 0.005   |
| 131072 | 0.003  | 0.003       | 0.003    | 0.003  | 0.003      | 0.004   |


#### num_fis=3-dop=32
| n      | fmix32 | murmur_hash | fnv_hash | simple | xorshift32 | no_hash |
| ------ | ------ | ----------- | -------- | ------ | ---------- | ------- |
| 128    | 0.085  | 0.087       | 0.090    | 0.092  | 0.107      | 0.091   |
| 2048   | 0.022  | 0.020       | 0.024    | 0.025  | 0.024      | 0.024   |
| 4096   | 0.017  | 0.018       | 0.018    | 0.016  | 0.020      | 0.016   |
| 16384  | 0.010  | 0.008       | 0.008    | 0.007  | 0.007      | 0.008   |
| 65536  | 0.005  | 0.004       | 0.005    | 0.004  | 0.004      | 0.004   |
| 131072 | 0.004  | 0.003       | 0.003    | 0.003  | 0.003      | 0.003   |

#### num_fis=4-dop=8

| n      | fmix32 | murmur_hash | fnv_hash | simple | xorshift32 | no_hash |
| ------ | ------ | ----------- | -------- | ------ | ---------- | ------- |
| 128    | 0.101  | 0.131       | 0.096    | 0.091  | 0.102      | 1.735   |
| 2048   | 0.029  | 0.026       | 0.021    | 0.020  | 0.032      | 1.732   |
| 4096   | 0.024  | 0.019       | 0.023    | 0.015  | 0.019      | 1.732   |
| 16384  | 0.008  | 0.011       | 0.008    | 0.009  | 0.010      | 1.732   |
| 65536  | 0.004  | 0.004       | 0.005    | 0.004  | 0.004      | 1.732   |
| 131072 | 0.003  | 0.004       | 0.003    | 0.003  | 0.003      | 1.732   |

#### num_fis=4-dop=16

| n      | fmix32 | murmur_hash | fnv_hash | simple | xorshift32 | no_hash |
| ------ | ------ | ----------- | -------- | ------ | ---------- | ------- |
| 128    | 0.078  | 0.093       | 0.106    | 0.094  | 0.093      | 1.734   |
| 2048   | 0.024  | 0.034       | 0.029    | 0.024  | 0.024      | 1.732   |
| 4096   | 0.018  | 0.021       | 0.014    | 0.015  | 0.015      | 1.732   |
| 16384  | 0.009  | 0.009       | 0.008    | 0.009  | 0.009      | 1.732   |
| 65536  | 0.004  | 0.005       | 0.004    | 0.004  | 0.005      | 1.732   |
| 131072 | 0.002  | 0.003       | 0.003    | 0.004  | 0.003      | 1.732   |

#### num_fis=4-dop=32

| n      | fmix32 | murmur_hash | fnv_hash | simple | xorshift32 | no_hash |
| ------ | ------ | ----------- | -------- | ------ | ---------- | ------- |
| 128    | 0.089  | 0.112       | 0.098    | 0.115  | 0.094      | 1.735   |
| 2048   | 0.026  | 0.023       | 0.025    | 0.026  | 0.026      | 1.732   |
| 4096   | 0.017  | 0.017       | 0.017    | 0.019  | 0.016      | 1.732   |
| 16384  | 0.007  | 0.008       | 0.009    | 0.008  | 0.009      | 1.732   |
| 65536  | 0.004  | 0.005       | 0.004    | 0.004  | 0.004      | 1.732   |
| 131072 | 0.003  | 0.003       | 0.003    | 0.003  | 0.003      | 1.732   |

#### num_fis=32-dop=32

| n     | fmix32 | murmur_hash | fnv_hash | simple | xorshift32 | no_hash |
| ----- | ------ | ----------- | -------- | ------ | ---------- | ------- |
| 128   | 0.102  | 0.118       | 0.111    | 0.109  | 0.117      | 5.568   |
| 2048  | 0.028  | 0.030       | 0.026    | 0.027  | 0.029      | 5.568   |
| 4096  | 0.018  | 0.019       | 0.019    | 0.020  | 0.020      | 5.568   |
| 16384 | 0.009  | 0.010       | 0.009    | 0.009  | 0.009      | 5.568   |
| 65536 | 0.005  | 0.004       | 0.005    | 0.005  | 0.005      | 5.568   |

#### num_fis=32-dop=16

| n     | fmix32 | murmur_hash | fnv_hash | simple | xorshift32 | no_hash |
| ----- | ------ | ----------- | -------- | ------ | ---------- | ------- |
| 128   | 0.113  | 0.107       | 0.115    | 0.106  | 0.133      | 3.873   |
| 2048  | 0.029  | 0.029       | 0.029    | 0.029  | 0.026      | 3.873   |
| 4096  | 0.020  | 0.021       | 0.019    | 0.021  | 0.021      | 3.873   |
| 16384 | 0.009  | 0.011       | 0.010    | 0.010  | 0.010      | 3.873   |
| 65536 | 0.006  | 0.005       | 0.006    | 0.006  | 0.005      | 3.873   |

### Sequence Test
Generate number not randomly, but from `0` to `n*num_fis*dop-1` one by one.
#### num_fis=3-dop=32

| n      | fmix32 | murmur_hash | fnv_hash | simple | xorshift32 | no_hash |
| ------ | ------ | ----------- | -------- | ------ | ---------- | ------- |
| 4      | 0.5625 | 0.5625      | 0.1875   | 0.2073 | 0.6988     | 0.0000  |
| 10     | 0.3162 | 0.3649      | 0.0901   | 0.0935 | 0.3211     | 0.0000  |
| 100    | 0.1257 | 0.0995      | 0.0494   | 0.0622 | 0.0280     | 0.0000  |
| 1000   | 0.0315 | 0.0343      | 0.0049   | 0.0107 | 0.0028     | 0.0000  |
| 10000  | 0.0095 | 0.0092      | 0.0016   | 0.0042 | 0.0013     | 0.0000  |
| 100000 | 0.0032 | 0.0039      | 0.0003   | 0.0009 | 0.0002     | 0.0000  |

#### num_fis=3-dop=8

| n      | fmix32 | murmur_hash | fnv_hash | simple | xorshift32 | no_hash |
| ------ | ------ | ----------- | -------- | ------ | ---------- | ------- |
| 4      | 0.5303 | 0.7071      | 0.0000   | 0.0000 | 0.4841     | 0.0000  |
| 10     | 0.3808 | 0.4330      | 0.0000   | 0.0000 | 0.2598     | 0.0000  |
| 100    | 0.0958 | 0.0857      | 0.0235   | 0.0260 | 0.0194     | 0.0000  |
| 1000   | 0.0309 | 0.0298      | 0.0012   | 0.0010 | 0.0025     | 0.0000  |
| 10000  | 0.0095 | 0.0090      | 0.0004   | 0.0005 | 0.0005     | 0.0000  |
| 100000 | 0.0032 | 0.0032      | 0.0001   | 0.0001 | 0.0001     | 0.0000  |

#### num_fis=3-dop=16

| n      | fmix32 | murmur_hash | fnv_hash | simple | xorshift32 | no_hash |
| ------ | ------ | ----------- | -------- | ------ | ---------- | ------- |
| 4      | 0.5995 | 0.6312      | 0.0000   | 0.0000 | 0.7655     | 0.0000  |
| 10     | 0.3791 | 0.3775      | 0.0707   | 0.0866 | 0.4108     | 0.0000  |
| 100    | 0.1155 | 0.0965      | 0.0200   | 0.0411 | 0.0306     | 0.0000  |
| 1000   | 0.0273 | 0.0386      | 0.0012   | 0.0017 | 0.0040     | 0.0000  |
| 10000  | 0.0093 | 0.0102      | 0.0005   | 0.0017 | 0.0008     | 0.0000  |
| 100000 | 0.0036 | 0.0034      | 0.0001   | 0.0003 | 0.0002     | 0.0000  |

#### num_fis=4-dop=8

| n      | fmix32 | murmur_hash | fnv_hash | simple | xorshift32 | no_hash |
| ------ | ------ | ----------- | -------- | ------ | ---------- | ------- |
| 4      | 0.5590 | 0.5154      | 1.7321   | 1.7321 | 0.0000     | 1.7321  |
| 10     | 0.4899 | 0.4690      | 1.3115   | 1.3115 | 0.0000     | 1.7321  |
| 100    | 0.1039 | 0.0960      | 0.0693   | 0.0693 | 0.0000     | 1.7321  |
| 1000   | 0.0307 | 0.0387      | 0.0139   | 0.0139 | 0.0000     | 1.7321  |
| 10000  | 0.0097 | 0.0102      | 0.0016   | 0.0016 | 0.0000     | 1.7321  |
| 100000 | 0.0048 | 0.0034      | 0.0000   | 0.0000 | 0.0000     | 1.7321  |

#### num_fis=4-dop=16

| n      | fmix32 | murmur_hash | fnv_hash | simple | xorshift32 | no_hash |
| ------ | ------ | ----------- | -------- | ------ | ---------- | ------- |
| 4      | 0.5520 | 0.5520      | 1.7321   | 1.7321 | 0.0000     | 1.7321  |
| 10     | 0.4198 | 0.3428      | 0.6633   | 0.6633 | 0.0000     | 1.7321  |
| 100    | 0.1151 | 0.1167      | 0.0693   | 0.0693 | 0.0000     | 1.7321  |
| 1000   | 0.0343 | 0.0421      | 0.0080   | 0.0080 | 0.0000     | 1.7321  |
| 10000  | 0.0096 | 0.0119      | 0.0000   | 0.0000 | 0.0000     | 1.7321  |
| 100000 | 0.0038 | 0.0039      | 0.0000   | 0.0000 | 0.0000     | 1.7321  |

#### num_fis=4-dop=32

| n      | fmix32 | murmur_hash | fnv_hash | simple | xorshift32 | no_hash |
| ------ | ------ | ----------- | -------- | ------ | ---------- | ------- |
| 4      | 0.6027 | 0.5376      | 1.0000   | 1.0000 | 0.0000     | 1.7321  |
| 10     | 0.3614 | 0.3269      | 0.3464   | 0.3464 | 0.2000     | 1.7321  |
| 100    | 0.1089 | 0.1000      | 0.0400   | 0.0400 | 0.0000     | 1.7321  |
| 1000   | 0.0280 | 0.0376      | 0.0000   | 0.0000 | 0.0000     | 1.7321  |
| 10000  | 0.0110 | 0.0094      | 0.0000   | 0.0000 | 0.0000     | 1.7321  |
| 100000 | 0.0036 | 0.0043      | 0.0000   | 0.0000 | 0.0000     | 1.7321  |



