### PR TITLE
Provide matched num_rows when array's columns is empty (#4442)

### DIFF
--- a/be/src/exprs/vectorized/array_expr.cpp
+++ b/be/src/exprs/vectorized/array_expr.cpp
@@ -21,6 +21,10 @@ public:
         const size_t num_elements = _children.size();
 
         size_t num_rows = 1;
+        // when num_elements == 0, we should generate right num_rows.
+        if (num_elements == 0 && chunk) {
+            num_rows = chunk->num_rows();
+        }
 
         std::vector<ColumnPtr> element_columns(num_elements);
         std::vector<Column*> element_raw_ptrs(num_elements);


### PR DESCRIPTION
Provide right num_rows when array's columns is empty.

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes ArrayExpr to avoid crash.


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
