### PR TITLE
BugFix: Add follower failed with log: It conflicts with the socket already used

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -487,8 +487,8 @@ CONF_mInt32(txn_commit_rpc_timeout_ms, "10000");
 // If set to true, metric calculator will run
 CONF_Bool(enable_metric_calculator, "true");
 
-// Max consumer num in one data consumer group, for routine load.
-CONF_mInt32(max_consumer_num_per_group, "3");
+// Max consumer num in one data consumer task , for routine load.
+CONF_mInt32(max_consumer_num_per_task, "3");
 
 // The size of thread pool for routine load task.
 // this should be larger than FE config 'max_concurrent_task_num_per_be' (default 5).

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -487,8 +487,8 @@ CONF_mInt32(txn_commit_rpc_timeout_ms, "10000");
 // If set to true, metric calculator will run
 CONF_Bool(enable_metric_calculator, "true");
 
-// Max consumer num in one data consumer task , for routine load.
-CONF_mInt32(max_consumer_num_per_task, "3");
+// Max consumer num in one data consumer group, for routine load.
+CONF_mInt32(max_consumer_num_per_group, "3");
 
 // The size of thread pool for routine load task.
 // this should be larger than FE config 'max_concurrent_task_num_per_be' (default 5).

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -2573,10 +2573,19 @@ public class Catalog {
 
             fe = new Frontend(role, nodeName, host, editLogPort);
             frontends.put(nodeName, fe);
+            BDBHA bdbha = (BDBHA) haProtocol;
             if (role == FrontendNodeType.FOLLOWER || role == FrontendNodeType.REPLICA) {
-                ((BDBHA) getHaProtocol()).addHelperSocket(host, editLogPort);
+                bdbha.addHelperSocket(host, editLogPort);
                 helperNodes.add(Pair.create(host, editLogPort));
             }
+
+            // In some cases, for example, fe starts with the outdated meta, the node name that has been dropped
+            // will remain in bdb.
+            // So we should remove those nodes before joining the group,
+            // or it will throws NodeConflictException (New or moved node:xxxx, is configured with the socket address:
+            // xxx. It conflicts with the socket already used by the member: xxxx)
+            bdbha.removeNodeIfExist(host, editLogPort);
+
             editLog.logAddFrontend(fe);
         } finally {
             unlock();

--- a/fe/fe-core/src/main/java/com/starrocks/ha/BDBHA.java
+++ b/fe/fe-core/src/main/java/com/starrocks/ha/BDBHA.java
@@ -232,7 +232,7 @@ public class BDBHA implements HAProtocol {
         }
 
         List<String> conflictNodes = Lists.newArrayList();
-        Set<ReplicationNode> nodes = replicationGroupAdmin.getGroup().getDataNodes();
+        Set<ReplicationNode> nodes = replicationGroupAdmin.getGroup().getElectableNodes();
         for (ReplicationNode node : nodes) {
             if (node.getHostName().equals(host) && node.getPort() == port) {
                 conflictNodes.add(node.getName());
@@ -240,7 +240,7 @@ public class BDBHA implements HAProtocol {
         }
 
         for (String nodeName : conflictNodes) {
-            replicationGroupAdmin.removeMember(nodeName);
+            removeElectableNode(nodeName);
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/ha/BDBHA.java
+++ b/fe/fe-core/src/main/java/com/starrocks/ha/BDBHA.java
@@ -31,7 +31,6 @@ import com.sleepycat.je.rep.MemberNotFoundException;
 import com.sleepycat.je.rep.ReplicationGroup;
 import com.sleepycat.je.rep.ReplicationNode;
 import com.sleepycat.je.rep.UnknownMasterException;
-import com.sleepycat.je.rep.impl.RepNodeImpl;
 import com.sleepycat.je.rep.util.ReplicationGroupAdmin;
 import com.starrocks.catalog.Catalog;
 import com.starrocks.journal.bdbje.BDBEnvironment;
@@ -198,7 +197,8 @@ public class BDBHA implements HAProtocol {
         }
         try {
             replicationGroupAdmin.removeMember(nodeName);
-        } catch (MemberNotFoundException e) { LOG.error("the deleting electable node is not found {}", nodeName, e);
+        } catch (MemberNotFoundException e) {
+            LOG.error("the deleting electable node is not found {}", nodeName, e);
             return false;
         } catch (MasterStateException e) {
             LOG.error("the deleting electable node is master {}", nodeName, e);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4663

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
In some cases, for example, fe starts with the outdated meta, the node name that has been dropped will remain in bdb, so we should remove those nodes before joining the group.