### PR TITLE
fix monotonic check of eq predicate

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/BinaryPredicate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/BinaryPredicate.java
@@ -63,7 +63,7 @@ public class BinaryPredicate extends Predicate implements Writable {
     private boolean isInferred_ = false;
 
     public enum Operator {
-        EQ("=", "eq", TExprOpcode.EQ, false),
+        EQ("=", "eq", TExprOpcode.EQ, true),
         NE("!=", "ne", TExprOpcode.NE, false),
         LE("<=", "le", TExprOpcode.LE, true),
         GE(">=", "ge", TExprOpcode.GE, true),


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

fix monotonic property of equal predicate, so that we can have a chance to use zonemap index when predicates are pushed down to storage layer