### PR TITLE
fixup merge_partial_bloom_filters

### DIFF
--- a/be/src/exec/pipeline/runtime_filter_types.h
+++ b/be/src/exec/pipeline/runtime_filter_types.h
@@ -315,11 +315,36 @@ public:
         }
 
         const auto& num_bloom_filters = _bloom_filter_descriptors.size();
+
+        // remove empty params that generated in two cases:
+        // 1. the corresponding HashJoinProbeOperator is finished in short-circuit style because HashJoinBuildOperator
+        // above this operator has constructed an empty hash table.
+        // 2. the HashJoinBuildOperator is finished in advance because the fragment instance is canceled
+        _partial_bloom_filter_build_params.erase(
+                std::remove_if(_partial_bloom_filter_build_params.begin(), _partial_bloom_filter_build_params.end(),
+                               [](auto& opt_params) { return opt_params.empty(); }),
+                _partial_bloom_filter_build_params.end());
+
+        // there is no non-empty params, set all runtime filter to nullptr
+        if (_partial_bloom_filter_build_params.empty()) {
+            for (auto& desc : _bloom_filter_descriptors) {
+                if (desc != nullptr) {
+                    desc->set_runtime_filter(nullptr);
+                }
+            }
+            return Status::OK();
+        }
+
+        // all params must have the same size as num_bloom_filters
+        DCHECK(std::all_of(_partial_bloom_filter_build_params.begin(), _partial_bloom_filter_build_params.end(),
+                           [&num_bloom_filters](auto& opt_params) { return opt_params.size() == num_bloom_filters; }));
+
         for (auto i = 0; i < num_bloom_filters; ++i) {
             auto& desc = _bloom_filter_descriptors[i];
             if (desc == nullptr) {
                 continue;
             }
+
             auto can_merge =
                     std::all_of(_partial_bloom_filter_build_params.begin(), _partial_bloom_filter_build_params.end(),
                                 [i](auto& opt_params) { return opt_params[i].has_value(); });

--- a/be/src/exec/pipeline/runtime_filter_types.h
+++ b/be/src/exec/pipeline/runtime_filter_types.h
@@ -327,6 +327,9 @@ public:
 
         // there is no non-empty params, set all runtime filter to nullptr
         if (_partial_bloom_filter_build_params.empty()) {
+            for (auto& desc : _bloom_filter_descriptors) {
+                desc->set_runtime_filter(nullptr);
+            }
             return Status::OK();
         }
 
@@ -336,6 +339,9 @@ public:
 
         for (auto i = 0; i < num_bloom_filters; ++i) {
             auto& desc = _bloom_filter_descriptors[i];
+            if (desc->runtime_filter() == nullptr) {
+                continue;
+            }
             auto can_merge =
                     std::all_of(_partial_bloom_filter_build_params.begin(), _partial_bloom_filter_build_params.end(),
                                 [i](auto& opt_params) { return opt_params[i].has_value(); });

--- a/be/src/exec/pipeline/runtime_filter_types.h
+++ b/be/src/exec/pipeline/runtime_filter_types.h
@@ -327,11 +327,6 @@ public:
 
         // there is no non-empty params, set all runtime filter to nullptr
         if (_partial_bloom_filter_build_params.empty()) {
-            for (auto& desc : _bloom_filter_descriptors) {
-                if (desc != nullptr) {
-                    desc->set_runtime_filter(nullptr);
-                }
-            }
             return Status::OK();
         }
 
@@ -341,10 +336,6 @@ public:
 
         for (auto i = 0; i < num_bloom_filters; ++i) {
             auto& desc = _bloom_filter_descriptors[i];
-            if (desc == nullptr) {
-                continue;
-            }
-
             auto can_merge =
                     std::all_of(_partial_bloom_filter_build_params.begin(), _partial_bloom_filter_build_params.end(),
                                 [i](auto& opt_params) { return opt_params[i].has_value(); });


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

when merge partial local bloom filters, we must ignore the empty partial bloom filter params generated in two cases:
1. the corresponding HashJoinProbeOperator is finished in short-circuit style because HashJoinBuildOperator above this operator has constructed an empty hash table.
2. the HashJoinBuildOperator is finished in advance because the fragment instance is canceled
