### PR TITLE
tunning parameter for topn node

### DIFF
--- a/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
@@ -70,9 +70,7 @@ OperatorPtr PartitionSortSinkOperatorFactory::create(int32_t dop, int32_t driver
                     std::make_unique<HeapChunkSorter>(runtime_state(), &(_sort_exec_exprs.lhs_ordering_expr_ctxs()),
                                                       &_is_asc_order, &_is_null_first, _sort_keys, _offset, _limit);
         } else {
-            dop = std::max(1, dop);
-            size_t max_buffered_chunks =
-                    std::max(ChunksSorter::MIN_BUFFERED_CHUNKS_TOPN, ChunksSorter::MAX_BUFFERED_CHUNKS_TOPN / dop);
+            size_t max_buffered_chunks = ChunksSorterTopn::tunning_buffered_chunks(_limit);
             chunks_sorter = std::make_unique<ChunksSorterTopn>(
                     runtime_state(), &(_sort_exec_exprs.lhs_ordering_expr_ctxs()), &_is_asc_order, &_is_null_first,
                     _sort_keys, _offset, _limit, max_buffered_chunks);

--- a/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
@@ -62,25 +62,25 @@ Status PartitionSortSinkOperatorFactory::prepare(RuntimeState* state) {
     return Status::OK();
 }
 
-OperatorPtr PartitionSortSinkOperatorFactory::create(int32_t degree_of_parallelism, int32_t driver_sequence) {
-    static const uint SIZE_OF_CHUNK_FOR_TOPN = 3000;
-    static const uint SIZE_OF_CHUNK_FOR_FULL_SORT = 5000;
-
+OperatorPtr PartitionSortSinkOperatorFactory::create(int32_t dop, int32_t driver_sequence) {
     std::shared_ptr<ChunksSorter> chunks_sorter;
     if (_limit >= 0) {
         if (_limit <= ChunksSorter::USE_HEAP_SORTER_LIMIT_SZ) {
-            chunks_sorter = std::make_unique<HeapChunkSorter>(
-                    runtime_state(), &(_sort_exec_exprs.lhs_ordering_expr_ctxs()), &_is_asc_order, &_is_null_first,
-                    _sort_keys, _offset, _limit, SIZE_OF_CHUNK_FOR_TOPN);
+            chunks_sorter =
+                    std::make_unique<HeapChunkSorter>(runtime_state(), &(_sort_exec_exprs.lhs_ordering_expr_ctxs()),
+                                                      &_is_asc_order, &_is_null_first, _sort_keys, _offset, _limit);
         } else {
+            dop = std::max(1, dop);
+            size_t max_buffered_chunks =
+                    std::max(ChunksSorter::MIN_BUFFERED_CHUNKS_TOPN, ChunksSorter::MAX_BUFFERED_CHUNKS_TOPN / dop);
             chunks_sorter = std::make_unique<ChunksSorterTopn>(
                     runtime_state(), &(_sort_exec_exprs.lhs_ordering_expr_ctxs()), &_is_asc_order, &_is_null_first,
-                    _sort_keys, _offset, _limit, SIZE_OF_CHUNK_FOR_TOPN);
+                    _sort_keys, _offset, _limit, max_buffered_chunks);
         }
     } else {
-        chunks_sorter = std::make_unique<vectorized::ChunksSorterFullSort>(
-                runtime_state(), &(_sort_exec_exprs.lhs_ordering_expr_ctxs()), &_is_asc_order, &_is_null_first,
-                _sort_keys, SIZE_OF_CHUNK_FOR_FULL_SORT);
+        chunks_sorter = std::make_unique<vectorized::ChunksSorterFullSort>(runtime_state(),
+                                                                           &(_sort_exec_exprs.lhs_ordering_expr_ctxs()),
+                                                                           &_is_asc_order, &_is_null_first, _sort_keys);
     }
     auto sort_context = _sort_context_factory->create(driver_sequence);
 

--- a/be/src/exec/vectorized/chunk_sorter_heapsorter.h
+++ b/be/src/exec/vectorized/chunk_sorter_heapsorter.h
@@ -213,11 +213,8 @@ class HeapChunkSorter final : public ChunksSorter {
 public:
     using DataSegmentPtr = std::shared_ptr<DataSegment>;
     HeapChunkSorter(RuntimeState* state, const std::vector<ExprContext*>* sort_exprs, const std::vector<bool>* is_asc,
-                    const std::vector<bool>* is_null_first, const std::string& sort_keys, size_t offset, size_t limit,
-                    size_t size_of_chunk_batch)
-            : ChunksSorter(state, sort_exprs, is_asc, is_null_first, sort_keys, true, size_of_chunk_batch),
-              _offset(offset),
-              _limit(limit) {}
+                    const std::vector<bool>* is_null_first, const std::string& sort_keys, size_t offset, size_t limit)
+            : ChunksSorter(state, sort_exprs, is_asc, is_null_first, sort_keys, true), _offset(offset), _limit(limit) {}
     ~HeapChunkSorter() = default;
 
     Status update(RuntimeState* state, const ChunkPtr& chunk) override;

--- a/be/src/exec/vectorized/chunks_sorter.cpp
+++ b/be/src/exec/vectorized/chunks_sorter.cpp
@@ -127,12 +127,8 @@ Status DataSegment::get_filter_array(std::vector<DataSegment>& data_segments, si
 
 ChunksSorter::ChunksSorter(RuntimeState* state, const std::vector<ExprContext*>* sort_exprs,
                            const std::vector<bool>* is_asc, const std::vector<bool>* is_null_first,
-                           const std::string& sort_keys, const bool is_topn, size_t size_of_chunk_batch)
-        : _state(state),
-          _sort_exprs(sort_exprs),
-          _sort_keys(sort_keys),
-          _is_topn(is_topn),
-          _size_of_chunk_batch(size_of_chunk_batch) {
+                           const std::string& sort_keys, const bool is_topn)
+        : _state(state), _sort_exprs(sort_exprs), _sort_keys(sort_keys), _is_topn(is_topn) {
     DCHECK(_sort_exprs != nullptr);
     DCHECK(is_asc != nullptr);
     DCHECK(is_null_first != nullptr);

--- a/be/src/exec/vectorized/chunks_sorter.h
+++ b/be/src/exec/vectorized/chunks_sorter.h
@@ -83,8 +83,6 @@ using DataSegments = std::vector<DataSegment>;
 class ChunksSorter {
 public:
     static constexpr int USE_HEAP_SORTER_LIMIT_SZ = 1024;
-    static constexpr size_t MAX_BUFFERED_CHUNKS_TOPN = 1024;
-    static constexpr size_t MIN_BUFFERED_CHUNKS_TOPN = 128;
 
     /**
      * Constructor.

--- a/be/src/exec/vectorized/chunks_sorter.h
+++ b/be/src/exec/vectorized/chunks_sorter.h
@@ -83,6 +83,9 @@ using DataSegments = std::vector<DataSegment>;
 class ChunksSorter {
 public:
     static constexpr int USE_HEAP_SORTER_LIMIT_SZ = 1024;
+    static constexpr size_t MAX_BUFFERED_CHUNKS_TOPN = 1024;
+    static constexpr size_t MIN_BUFFERED_CHUNKS_TOPN = 128;
+
     /**
      * Constructor.
      * @param sort_exprs     The order-by columns or columns with expression. This sorter will use but not own the object.
@@ -91,8 +94,7 @@ public:
      * @param size_of_chunk_batch  In the case of a positive limit, this parameter limits the size of the batch in Chunk unit.
      */
     ChunksSorter(RuntimeState* state, const std::vector<ExprContext*>* sort_exprs, const std::vector<bool>* is_asc,
-                 const std::vector<bool>* is_null_first, const std::string& sort_keys, const bool is_topn,
-                 size_t size_of_chunk_batch = 1000);
+                 const std::vector<bool>* is_null_first, const std::string& sort_keys, const bool is_topn);
     virtual ~ChunksSorter();
 
     static vectorized::ChunkPtr materialize_chunk_before_sort(vectorized::Chunk* chunk,
@@ -143,8 +145,6 @@ protected:
     const bool _is_topn;
 
     size_t _next_output_row = 0;
-
-    const size_t _size_of_chunk_batch;
 
     RuntimeProfile::Counter* _build_timer = nullptr;
     RuntimeProfile::Counter* _sort_timer = nullptr;

--- a/be/src/exec/vectorized/chunks_sorter_full_sort.cpp
+++ b/be/src/exec/vectorized/chunks_sorter_full_sort.cpp
@@ -16,8 +16,8 @@ namespace starrocks::vectorized {
 
 ChunksSorterFullSort::ChunksSorterFullSort(RuntimeState* state, const std::vector<ExprContext*>* sort_exprs,
                                            const std::vector<bool>* is_asc, const std::vector<bool>* is_null_first,
-                                           const std::string& sort_keys, size_t size_of_chunk_batch)
-        : ChunksSorter(state, sort_exprs, is_asc, is_null_first, sort_keys, false, size_of_chunk_batch) {
+                                           const std::string& sort_keys)
+        : ChunksSorter(state, sort_exprs, is_asc, is_null_first, sort_keys, false) {
     _selective_values.resize(_state->chunk_size());
 }
 

--- a/be/src/exec/vectorized/chunks_sorter_full_sort.h
+++ b/be/src/exec/vectorized/chunks_sorter_full_sort.h
@@ -21,7 +21,7 @@ public:
      */
     ChunksSorterFullSort(RuntimeState* state, const std::vector<ExprContext*>* sort_exprs,
                          const std::vector<bool>* is_asc, const std::vector<bool>* is_null_first,
-                         const std::string& sort_keys, size_t size_of_chunk_batch);
+                         const std::string& sort_keys);
     ~ChunksSorterFullSort() override;
 
     // Append a Chunk for sort.

--- a/be/src/exec/vectorized/chunks_sorter_topn.h
+++ b/be/src/exec/vectorized/chunks_sorter_topn.h
@@ -18,11 +18,11 @@ public:
      * @param is_null_first  NULL values should at the head or tail.
      * @param offset         Number of top rows to skip.
      * @param limit          Number of top rows after those skipped to extract. Zero means no limit.
-     * @param size_of_chunk_batch  In the case of a positive limit, this parameter limits the size of the batch in Chunk unit.
+     * @param max_buffered_chunks  In the case of a positive limit, this parameter limits the size of the batch in Chunk unit.
      */
     ChunksSorterTopn(RuntimeState* state, const std::vector<ExprContext*>* sort_exprs, const std::vector<bool>* is_asc,
                      const std::vector<bool>* is_null_first, const std::string& sort_keys, size_t offset = 0,
-                     size_t limit = 0, size_t size_of_chunk_batch = 1000);
+                     size_t limit = 0, size_t max_buffered_chunks = ChunksSorter::MAX_BUFFERED_CHUNKS_TOPN);
     ~ChunksSorterTopn() override;
 
     // Append a Chunk for sort.
@@ -94,9 +94,9 @@ private:
 
     const size_t _offset;
     const size_t _limit;
+    const size_t _max_buffered_chunks;
 
     RawChunks _raw_chunks;
-
     bool _init_merged_segment;
     DataSegment _merged_segment;
 };

--- a/be/src/exec/vectorized/chunks_sorter_topn.h
+++ b/be/src/exec/vectorized/chunks_sorter_topn.h
@@ -27,7 +27,7 @@ public:
     // As a result, we need to tunning this parameter to achieve better performance.
     // The followering heuristic is based on experiment of current algorithm implementation, which needs
     // further improvement if the algorithm changed.
-    static constexpr size_t tunning_buffered_chunks(int limit) {
+    static constexpr size_t tunning_buffered_chunks(size_t limit) {
         if (limit <= 1024) {
             return 16;
         }

--- a/be/src/exec/vectorized/chunks_sorter_topn.h
+++ b/be/src/exec/vectorized/chunks_sorter_topn.h
@@ -16,6 +16,17 @@ public:
     static constexpr size_t kDefaultBufferedChunks = 64;
 
     // Tunning the max_buffer_chunks according to requested limit
+    // The experiment could refer to https://github.com/StarRocks/starrocks/pull/4694.
+    //
+    // This parameter has at least two effects:
+    // If smaller, the partial-merge-sort procedure would become more frequent, thus reduce the memory usage and
+    // generate a baseline to filter input data.
+    // If larger, the partial-merge-sort would become in-frequent, and cost lower, but the downside is the merge-sort
+    // stage is expensive compared to the filter stage.
+    //
+    // As a result, we need to tunning this parameter to achieve better performance.
+    // The followering heuristic is based on experiment of current algorithm implementation, which needs
+    // further improvement if the algorithm changed.
     static constexpr size_t tunning_buffered_chunks(int limit) {
         if (limit <= 1024) {
             return 16;

--- a/be/src/exec/vectorized/chunks_sorter_topn.h
+++ b/be/src/exec/vectorized/chunks_sorter_topn.h
@@ -11,6 +11,21 @@ namespace starrocks::vectorized {
 // Sort Chunks in memory with specified order by rules.
 class ChunksSorterTopn : public ChunksSorter {
 public:
+    static constexpr size_t kMaxBufferedChunks = 512;
+    static constexpr size_t kMinBufferedChunks = 16;
+    static constexpr size_t kDefaultBufferedChunks = 64;
+
+    // Tunning the max_buffer_chunks according to requested limit
+    static constexpr size_t tunning_buffered_chunks(int limit) {
+        if (limit <= 1024) {
+            return 16;
+        }
+        if (limit <= 65536) {
+            return 64;
+        }
+        return 256;
+    }
+
     /**
      * Constructor.
      * @param sort_exprs     The order-by columns or columns with expression. This sorter will use but not own the object.
@@ -22,7 +37,7 @@ public:
      */
     ChunksSorterTopn(RuntimeState* state, const std::vector<ExprContext*>* sort_exprs, const std::vector<bool>* is_asc,
                      const std::vector<bool>* is_null_first, const std::string& sort_keys, size_t offset = 0,
-                     size_t limit = 0, size_t max_buffered_chunks = ChunksSorter::MAX_BUFFERED_CHUNKS_TOPN);
+                     size_t limit = 0, size_t max_buffered_chunks = kDefaultBufferedChunks);
     ~ChunksSorterTopn() override;
 
     // Append a Chunk for sort.

--- a/be/src/exec/vectorized/topn_node.cpp
+++ b/be/src/exec/vectorized/topn_node.cpp
@@ -138,27 +138,23 @@ Status TopNNode::close(RuntimeState* state) {
 }
 
 Status TopNNode::_consume_chunks(RuntimeState* state, ExecNode* child) {
-    static const uint SIZE_OF_CHUNK_FOR_TOPN = 3000;
-    static const uint SIZE_OF_CHUNK_FOR_FULL_SORT = 5000;
-
     ScopedTimer<MonotonicStopWatch> timer(_sort_timer);
     if (_limit > 0) {
         // HeapChunkSorter has higher performance when sorting fewer elements,
         // after testing we think 1024 is a good threshold
         if (_limit <= ChunksSorter::USE_HEAP_SORTER_LIMIT_SZ) {
-            _chunks_sorter = std::make_unique<HeapChunkSorter>(state, &(_sort_exec_exprs.lhs_ordering_expr_ctxs()),
-                                                               &_is_asc_order, &_is_null_first, _sort_keys, _offset,
-                                                               _limit, SIZE_OF_CHUNK_FOR_TOPN);
+            _chunks_sorter =
+                    std::make_unique<HeapChunkSorter>(state, &(_sort_exec_exprs.lhs_ordering_expr_ctxs()),
+                                                      &_is_asc_order, &_is_null_first, _sort_keys, _offset, _limit);
         } else {
             _chunks_sorter = std::make_unique<ChunksSorterTopn>(state, &(_sort_exec_exprs.lhs_ordering_expr_ctxs()),
                                                                 &_is_asc_order, &_is_null_first, _sort_keys, _offset,
-                                                                _limit, SIZE_OF_CHUNK_FOR_TOPN);
+                                                                _limit, ChunksSorter::MAX_BUFFERED_CHUNKS_TOPN);
         }
 
     } else {
         _chunks_sorter = std::make_unique<ChunksSorterFullSort>(state, &(_sort_exec_exprs.lhs_ordering_expr_ctxs()),
-                                                                &_is_asc_order, &_is_null_first, _sort_keys,
-                                                                SIZE_OF_CHUNK_FOR_FULL_SORT);
+                                                                &_is_asc_order, &_is_null_first, _sort_keys);
     }
 
     bool eos = false;

--- a/be/src/exec/vectorized/topn_node.cpp
+++ b/be/src/exec/vectorized/topn_node.cpp
@@ -147,9 +147,9 @@ Status TopNNode::_consume_chunks(RuntimeState* state, ExecNode* child) {
                     std::make_unique<HeapChunkSorter>(state, &(_sort_exec_exprs.lhs_ordering_expr_ctxs()),
                                                       &_is_asc_order, &_is_null_first, _sort_keys, _offset, _limit);
         } else {
-            _chunks_sorter = std::make_unique<ChunksSorterTopn>(state, &(_sort_exec_exprs.lhs_ordering_expr_ctxs()),
-                                                                &_is_asc_order, &_is_null_first, _sort_keys, _offset,
-                                                                _limit, ChunksSorter::MAX_BUFFERED_CHUNKS_TOPN);
+            _chunks_sorter = std::make_unique<ChunksSorterTopn>(
+                    state, &(_sort_exec_exprs.lhs_ordering_expr_ctxs()), &_is_asc_order, &_is_null_first, _sort_keys,
+                    _offset, _limit, ChunksSorterTopn::tunning_buffered_chunks(_limit));
         }
 
     } else {

--- a/be/test/exec/vectorized/chunks_sorter_bench_test.cpp
+++ b/be/test/exec/vectorized/chunks_sorter_bench_test.cpp
@@ -98,9 +98,38 @@ enum SortAlgorithm : int {
     MergeSort = 3, // ChunksSorterTopN
 };
 
+struct SortParameters {
+    int limit = -1;
+    bool low_card = false;
+    bool nullable = false;
+    int max_buffered_chunks = ChunksSorter::MAX_BUFFERED_CHUNKS_TOPN;
+
+    SortParameters() {}
+
+    static SortParameters with_limit(int limit, SortParameters params = SortParameters()) {
+        params.limit = limit;
+        return params;
+    }
+
+    static SortParameters with_low_card(bool low_card, SortParameters params = SortParameters()) {
+        params.low_card = low_card;
+        return params;
+    }
+
+    static SortParameters with_nullable(bool nullable, SortParameters params = SortParameters()) {
+        params.nullable = nullable;
+        return params;
+    }
+
+    static SortParameters with_max_buffered_chunks(int max_buffered_chunks, SortParameters params = SortParameters()) {
+        params.max_buffered_chunks = max_buffered_chunks;
+        return params;
+    }
+};
+
 static void do_bench(benchmark::State& state, SortAlgorithm sorter_algo, CompareStrategy strategy,
-                     PrimitiveType data_type, int num_chunks, int num_columns, int limit = -1, bool low_card = false,
-                     bool nullable = false) {
+                     PrimitiveType data_type, int num_chunks, int num_columns,
+                     SortParameters params = SortParameters()) {
     // state.PauseTiming();
     ChunkSorterBase suite;
     suite.SetUp();
@@ -122,7 +151,7 @@ static void do_bench(benchmark::State& state, SortAlgorithm sorter_algo, Compare
     Chunk::SlotHashMap map;
 
     for (int i = 0; i < num_columns; i++) {
-        auto [column, expr] = suite.build_column(type_desc, i, low_card, nullable);
+        auto [column, expr] = suite.build_column(type_desc, i, params.low_card, params.nullable);
         columns.push_back(column);
         exprs.emplace_back(std::move(expr));
         sort_exprs.push_back(new ExprContext(exprs.back().get()));
@@ -141,24 +170,23 @@ static void do_bench(benchmark::State& state, SortAlgorithm sorter_algo, Compare
         std::unique_ptr<ChunksSorter> sorter;
         size_t expected_rows = 0;
         size_t total_rows = chunk->num_rows() * num_chunks;
-        int limit_rows = limit == -1 ? total_rows : std::min(limit, (int)total_rows);
+        int limit_rows = params.limit == -1 ? total_rows : std::min(params.limit, (int)total_rows);
 
         switch (sorter_algo) {
         case FullSort: {
-            sorter.reset(new ChunksSorterFullSort(suite._runtime_state.get(), &sort_exprs, &asc_arr, &null_first, "",
-                                                  config::vector_chunk_size));
+            sorter.reset(new ChunksSorterFullSort(suite._runtime_state.get(), &sort_exprs, &asc_arr, &null_first, ""));
             expected_rows = total_rows;
             break;
         }
         case HeapSort: {
             sorter.reset(new HeapChunkSorter(suite._runtime_state.get(), &sort_exprs, &asc_arr, &null_first, "", 0,
-                                             limit_rows, config::vector_chunk_size));
+                                             limit_rows));
             expected_rows = limit_rows;
             break;
         }
         case MergeSort: {
             sorter.reset(new ChunksSorterTopn(suite._runtime_state.get(), &sort_exprs, &asc_arr, &null_first, "", 0,
-                                              limit_rows));
+                                              limit_rows, params.max_buffered_chunks));
             expected_rows = limit_rows;
             break;
         }
@@ -226,21 +254,24 @@ static void BM_fullsort_varchar_column_incr(benchmark::State& state) {
     do_bench(state, FullSort, ColumnInc, TYPE_VARCHAR, state.range(0), state.range(1));
 }
 static void BM_fullsort_column_incr_nullable(benchmark::State& state) {
-    do_bench(state, FullSort, ColumnInc, TYPE_INT, state.range(0), state.range(1), -1, false, true);
+    do_bench(state, FullSort, ColumnInc, TYPE_INT, state.range(0), state.range(1), SortParameters::with_nullable(true));
 }
 
 // Low cardinality
 static void BM_fullsort_low_card_rowwise(benchmark::State& state) {
-    do_bench(state, FullSort, RowWise, TYPE_INT, state.range(0), state.range(1), -1, true);
+    do_bench(state, FullSort, RowWise, TYPE_INT, state.range(0), state.range(1), SortParameters::with_low_card(true));
 }
 static void BM_fullsort_low_card_colwise(benchmark::State& state) {
-    do_bench(state, FullSort, ColumnWise, TYPE_INT, state.range(0), state.range(1), -1, true);
+    do_bench(state, FullSort, ColumnWise, TYPE_INT, state.range(0), state.range(1),
+             SortParameters::with_low_card(true));
 }
 static void BM_fullsort_low_card_colinc(benchmark::State& state) {
-    do_bench(state, FullSort, ColumnInc, TYPE_INT, state.range(0), state.range(1), -1, true);
+    do_bench(state, FullSort, ColumnInc, TYPE_INT, state.range(0), state.range(1), SortParameters::with_low_card(true));
 }
 static void BM_fullsort_low_card_nullable(benchmark::State& state) {
-    do_bench(state, FullSort, ColumnInc, TYPE_INT, state.range(0), state.range(1), -1, true, true);
+    SortParameters params = SortParameters::with_low_card(true);
+    params.nullable = true;
+    do_bench(state, FullSort, ColumnInc, TYPE_INT, state.range(0), state.range(1), params);
 }
 
 static void BM_heapsort_row_wise(benchmark::State& state) {
@@ -252,16 +283,27 @@ static void BM_mergesort_row_wise(benchmark::State& state) {
 
 // Sort partial data: ORDER BY xxx LIMIT
 static void BM_topn_limit_heapsort(benchmark::State& state) {
-    do_bench(state, HeapSort, RowWise, TYPE_INT, state.range(0), state.range(1), state.range(2));
+    do_bench(state, HeapSort, RowWise, TYPE_INT, state.range(0), state.range(1),
+             SortParameters::with_limit(state.range(2)));
 }
 static void BM_topn_limit_mergesort_rowwise(benchmark::State& state) {
-    do_bench(state, MergeSort, RowWise, TYPE_INT, state.range(0), state.range(1), state.range(2));
+    do_bench(state, MergeSort, RowWise, TYPE_INT, state.range(0), state.range(1),
+             SortParameters::with_limit(state.range(2)));
 }
 static void BM_topn_limit_mergesort_colwise(benchmark::State& state) {
-    do_bench(state, MergeSort, ColumnWise, TYPE_INT, state.range(0), state.range(1), state.range(2));
+    do_bench(state, MergeSort, ColumnWise, TYPE_INT, state.range(0), state.range(1),
+             SortParameters::with_limit(state.range(2)));
 }
 static void BM_topn_limit_mergesort_colwise_nullable(benchmark::State& state) {
-    do_bench(state, MergeSort, ColumnWise, TYPE_INT, state.range(0), state.range(1), state.range(2), false, true);
+    SortParameters params = SortParameters::with_limit(state.range(2));
+    params.nullable = true;
+    do_bench(state, MergeSort, ColumnWise, TYPE_INT, state.range(0), state.range(1), params);
+}
+static void BM_topn_buffered_chunks(benchmark::State& state) {
+    SortParameters params;
+    params.max_buffered_chunks = state.range(0);
+    params.limit = state.range(1);
+    do_bench(state, MergeSort, ColumnWise, TYPE_INT, 4096, 2, params);
 }
 
 static void CustomArgsFull(benchmark::internal::Benchmark* b) {
@@ -303,10 +345,12 @@ BENCHMARK(BM_fullsort_low_card_nullable)->Apply(CustomArgsFull);
 BENCHMARK(BM_heapsort_row_wise)->Apply(CustomArgsFull);
 BENCHMARK(BM_mergesort_row_wise)->Apply(CustomArgsFull);
 
+// TopN sort
 BENCHMARK(BM_topn_limit_heapsort)->Apply(CustomArgsLimit);
 BENCHMARK(BM_topn_limit_mergesort_rowwise)->Apply(CustomArgsLimit);
 BENCHMARK(BM_topn_limit_mergesort_colwise)->Apply(CustomArgsLimit);
 BENCHMARK(BM_topn_limit_mergesort_colwise_nullable)->Apply(CustomArgsLimit);
+BENCHMARK(BM_topn_buffered_chunks)->RangeMultiplier(4)->Ranges({{10, 10'000}, {100, 100'000}});
 
 static size_t plain_find_zero(const std::vector<uint8_t>& bytes) {
     for (size_t i = 0; i < bytes.size(); i++) {

--- a/be/test/exec/vectorized/chunks_sorter_bench_test.cpp
+++ b/be/test/exec/vectorized/chunks_sorter_bench_test.cpp
@@ -102,7 +102,7 @@ struct SortParameters {
     int limit = -1;
     bool low_card = false;
     bool nullable = false;
-    int max_buffered_chunks = ChunksSorter::MAX_BUFFERED_CHUNKS_TOPN;
+    int max_buffered_chunks = ChunksSorterTopn::kDefaultBufferedChunks;
 
     SortParameters() {}
 
@@ -305,6 +305,12 @@ static void BM_topn_buffered_chunks(benchmark::State& state) {
     params.limit = state.range(1);
     do_bench(state, MergeSort, ColumnWise, TYPE_INT, 4096, 2, params);
 }
+static void BM_topn_buffered_chunks_tunned(benchmark::State& state) {
+    SortParameters params;
+    params.limit = state.range(1);
+    params.max_buffered_chunks = ChunksSorterTopn::tunning_buffered_chunks(params.limit);
+    do_bench(state, MergeSort, ColumnWise, TYPE_INT, 4096, 2, params);
+}
 
 static void CustomArgsFull(benchmark::internal::Benchmark* b) {
     // num_chunks
@@ -351,6 +357,7 @@ BENCHMARK(BM_topn_limit_mergesort_rowwise)->Apply(CustomArgsLimit);
 BENCHMARK(BM_topn_limit_mergesort_colwise)->Apply(CustomArgsLimit);
 BENCHMARK(BM_topn_limit_mergesort_colwise_nullable)->Apply(CustomArgsLimit);
 BENCHMARK(BM_topn_buffered_chunks)->RangeMultiplier(4)->Ranges({{10, 10'000}, {100, 100'000}});
+BENCHMARK(BM_topn_buffered_chunks_tunned)->RangeMultiplier(4)->Ranges({{10, 10'000}, {100, 100'000}});
 
 static size_t plain_find_zero(const std::vector<uint8_t>& bytes) {
     for (size_t i = 0; i < bytes.size(); i++) {

--- a/be/test/exec/vectorized/chunks_sorter_heapsorter_test.cpp
+++ b/be/test/exec/vectorized/chunks_sorter_heapsorter_test.cpp
@@ -161,7 +161,7 @@ TEST_F(HeapChunkSorterTest, single_column_order_by_notnull_test) {
         {
             std::vector<ExprContext*> sort_exprs;
             sort_exprs.push_back(_pool.add(new ExprContext(fake_chunks.slot_refs()[0])));
-            HeapChunkSorter sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, 1024, 1024);
+            HeapChunkSorter sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, 1024);
             sorter.setup_runtime(_pool.add(new RuntimeProfile("")));
             sorter.update(nullptr, fake_chunks.next_chunk(1024));
             sorter.done(nullptr);
@@ -179,7 +179,7 @@ TEST_F(HeapChunkSorterTest, single_column_order_by_notnull_test) {
         {
             std::vector<ExprContext*> sort_exprs;
             sort_exprs.push_back(_pool.add(new ExprContext(fake_chunks.slot_refs()[0])));
-            HeapChunkSorter sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, 1024, 1024);
+            HeapChunkSorter sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, 1024);
             sorter.setup_runtime(_pool.add(new RuntimeProfile("")));
             sorter.update(nullptr, fake_chunks.next_chunk(1023));
             sorter.update(nullptr, fake_chunks.next_chunk(1023));
@@ -200,7 +200,7 @@ TEST_F(HeapChunkSorterTest, single_column_order_by_notnull_test) {
         {
             std::vector<ExprContext*> sort_exprs;
             sort_exprs.push_back(_pool.add(new ExprContext(fake_chunks.slot_refs()[1])));
-            HeapChunkSorter sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, 1024, 1024);
+            HeapChunkSorter sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, 1024);
             sorter.setup_runtime(_pool.add(new RuntimeProfile("")));
             sorter.update(nullptr, fake_chunks.next_chunk(1024));
             sorter.update(nullptr, fake_chunks.next_chunk(1023));
@@ -233,7 +233,7 @@ TEST_F(HeapChunkSorterTest, single_column_order_by_nullable_test) {
             sort_exprs.push_back(_pool.add(new ExprContext(fake_chunks.slot_refs()[0])));
             // limit 5
             int limit_sz = 5;
-            HeapChunkSorter sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, limit_sz, 1024);
+            HeapChunkSorter sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, limit_sz);
             sorter.setup_runtime(_pool.add(new RuntimeProfile("")));
             sorter.update(nullptr, fake_chunks.next_chunk(10));
             sorter.done(nullptr);
@@ -256,7 +256,7 @@ TEST_F(HeapChunkSorterTest, single_column_order_by_nullable_test) {
             sort_exprs.push_back(_pool.add(new ExprContext(fake_chunks.slot_refs()[0])));
             // limit 5
             int limit_sz = 10;
-            HeapChunkSorter sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, limit_sz, 1024);
+            HeapChunkSorter sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, limit_sz);
             sorter.setup_runtime(_pool.add(new RuntimeProfile("")));
             sorter.update(nullptr, fake_chunks.next_chunk(10));
             sorter.done(nullptr);
@@ -280,7 +280,7 @@ TEST_F(HeapChunkSorterTest, single_column_order_by_nullable_test) {
             sort_exprs.push_back(_pool.add(new ExprContext(fake_chunks.slot_refs()[0])));
             // limit 5
             int limit_sz = 5;
-            HeapChunkSorter sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, limit_sz, 1024);
+            HeapChunkSorter sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, limit_sz);
             sorter.setup_runtime(_pool.add(new RuntimeProfile("")));
             sorter.update(nullptr, fake_chunks.next_chunk(10));
             sorter.done(nullptr);

--- a/be/test/exec/vectorized/chunks_sorter_test.cpp
+++ b/be/test/exec/vectorized/chunks_sorter_test.cpp
@@ -171,7 +171,7 @@ TEST_F(ChunksSorterTest, full_sort_incremental) {
     sort_exprs.push_back(new ExprContext(_expr_region.get()));
     sort_exprs.push_back(new ExprContext(_expr_cust_key.get()));
 
-    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 2);
+    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "");
     sorter.set_compare_strategy(ColumnInc);
     size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
     sorter.update(_runtime_state.get(), _chunk_1);
@@ -338,7 +338,7 @@ TEST_F(ChunksSorterTest, full_sort_by_2_columns_null_first) {
 
     for (auto strategy : all_compare_strategy()) {
         std::cerr << "sort with strategy: " << strategy << std::endl;
-        ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 2);
+        ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "");
         sorter.set_compare_strategy(strategy);
         size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
         sorter.update(_runtime_state.get(), _chunk_1);
@@ -385,7 +385,7 @@ TEST_F(ChunksSorterTest, full_sort_by_2_columns_null_last) {
 
     for (auto strategy : all_compare_strategy()) {
         std::cerr << "sort with strategy: " << strategy << std::endl;
-        ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 2);
+        ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "");
         sorter.set_compare_strategy(strategy);
         size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
         sorter.update(_runtime_state.get(), _chunk_1);
@@ -434,7 +434,7 @@ TEST_F(ChunksSorterTest, full_sort_by_3_columns) {
 
     for (auto strategy : all_compare_strategy()) {
         std::cerr << "sort with strategy: " << strategy << std::endl;
-        ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 2);
+        ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "");
         sorter.set_compare_strategy(strategy);
         size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
         sorter.update(_runtime_state.get(), _chunk_1);
@@ -484,7 +484,7 @@ TEST_F(ChunksSorterTest, full_sort_by_4_columns) {
 
     for (auto strategy : all_compare_strategy()) {
         std::cerr << "sort with strategy: " << strategy << std::endl;
-        ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 2);
+        ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "");
         sorter.set_compare_strategy(strategy);
         size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
         sorter.update(_runtime_state.get(), _chunk_1);


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Changes
1. Remove unused parameter of `ChunkSorter`
2. Tunning the `max_buffered_chunks` for `ChunkSorterTopN`


## Experiment

1. Static parameters: data_size = 4096*4096, 
2. Variables
    1. limit from 100 to 100'000
    2. max_buffered_chunks from 10 to 100'000
3. Char
    1. x seris: the variable `max_buffered_chunks`
    2. y seris: sort speed, higher is better
    3. lines: each line is a experiment of topn sort with different `limit`. E.g. The red line is a topn sort with `limit=16384`
4. Conclusion
    1. When limit is very small, the max_buffered_chunks has not influence. 
    4. When limit is medium(<=65535), the best max_buffered_chunks is about 64
    5. When limit is very large(>65535), the max_buffered_chunks should be larger


<img width="975" alt="image" src="https://user-images.githubusercontent.com/96611012/161217669-b7add98e-ec59-4030-a3b4-0b268c7ec9dc.png">
