### PR TITLE
remove unused interface of column for old memory statistics framework

### DIFF
--- a/be/src/column/array_column.h
+++ b/be/src/column/array_column.h
@@ -123,10 +123,6 @@ public:
 
     size_t memory_usage() const override { return _elements->memory_usage() + _offsets->memory_usage(); }
 
-    size_t shrink_memory_usage() const override {
-        return _elements->shrink_memory_usage() + _offsets->shrink_memory_usage();
-    }
-
     size_t container_memory_usage() const override {
         return _elements->container_memory_usage() + _offsets->container_memory_usage();
     }

--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -237,11 +237,6 @@ public:
         return _bytes.capacity() + _offsets.capacity() * sizeof(_offsets[0]) + _slices.capacity() * sizeof(_slices[0]);
     }
 
-    size_t shrink_memory_usage() const override {
-        return _bytes.size() * sizeof(uint8_t) + _offsets.size() * sizeof(_offsets[0]) +
-               _slices.size() * sizeof(_slices[0]);
-    }
-
     void swap_column(Column& rhs) override {
         auto& r = down_cast<BinaryColumnBase<T>&>(rhs);
         using std::swap;

--- a/be/src/column/chunk.cpp
+++ b/be/src/column/chunk.cpp
@@ -238,14 +238,6 @@ size_t Chunk::memory_usage() const {
     return memory_usage;
 }
 
-size_t Chunk::shrink_memory_usage() const {
-    size_t memory_usage = 0;
-    for (const auto& column : _columns) {
-        memory_usage += column->shrink_memory_usage();
-    }
-    return memory_usage;
-}
-
 size_t Chunk::container_memory_usage() const {
     size_t container_memory_usage = 0;
     for (const auto& column : _columns) {

--- a/be/src/column/chunk.h
+++ b/be/src/column/chunk.h
@@ -186,9 +186,6 @@ public:
     // 2. other columns: column container capacity * type size
     size_t memory_usage() const;
 
-    // memory usage after shrink
-    size_t shrink_memory_usage() const;
-
     // Column container memory usage
     size_t container_memory_usage() const;
     // Element memory usage that is not in the container, such as memory referenced by pointer.

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -330,7 +330,6 @@ public:
     //   2.1 object column: element serialize data size.
     //   2.2 other columns: 0.
     virtual size_t memory_usage() const { return container_memory_usage() + element_memory_usage(); }
-    virtual size_t shrink_memory_usage() const = 0;
     virtual size_t container_memory_usage() const = 0;
     virtual size_t element_memory_usage() const { return element_memory_usage(0, size()); }
     virtual size_t element_memory_usage(size_t from, size_t size) const { return 0; }

--- a/be/src/column/const_column.h
+++ b/be/src/column/const_column.h
@@ -177,8 +177,6 @@ public:
 
     size_t memory_usage() const override { return _data->memory_usage() + sizeof(size_t); }
 
-    size_t shrink_memory_usage() const override { return _data->shrink_memory_usage() + sizeof(size_t); }
-
     size_t container_memory_usage() const override { return _data->container_memory_usage(); }
 
     size_t element_memory_usage() const override { return _data->element_memory_usage(); }

--- a/be/src/column/fixed_length_column_base.h
+++ b/be/src/column/fixed_length_column_base.h
@@ -178,7 +178,6 @@ public:
     std::string debug_string() const override;
 
     size_t container_memory_usage() const override { return _data.capacity() * sizeof(ValueType); }
-    size_t shrink_memory_usage() const override { return _data.size() * sizeof(ValueType); }
 
     void swap_column(Column& rhs) override {
         auto& r = down_cast<FixedLengthColumnBase&>(rhs);

--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -223,10 +223,6 @@ public:
         return _data_column->memory_usage() + _null_column->memory_usage() + sizeof(bool);
     }
 
-    size_t shrink_memory_usage() const override {
-        return _data_column->shrink_memory_usage() + _null_column->shrink_memory_usage() + sizeof(bool);
-    }
-
     size_t container_memory_usage() const override {
         return _data_column->container_memory_usage() + _null_column->container_memory_usage();
     }

--- a/be/src/column/object_column.h
+++ b/be/src/column/object_column.h
@@ -148,8 +148,6 @@ public:
 
     Datum get(size_t n) const override { return Datum(get_object(n)); }
 
-    size_t shrink_memory_usage() const override { return _pool.size() * type_size() + byte_size(); }
-
     size_t container_memory_usage() const override { return _pool.capacity() * type_size(); }
 
     size_t element_memory_usage() const override { return byte_size(); }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [x] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

`shrink_memory_usage` is used for old memory statistics, so remove it now;
