### PR TITLE
Fix get wrong function id in UDTF

### DIFF
--- a/be/src/exec/vectorized/aggregator.cpp
+++ b/be/src/exec/vectorized/aggregator.cpp
@@ -13,7 +13,7 @@
 
 namespace starrocks {
 namespace vectorized {
-Status init_udaf_context(int id, const std::string& url, const std::string& checksum, const std::string& symbol,
+Status init_udaf_context(int64_t fid, const std::string& url, const std::string& checksum, const std::string& symbol,
                          starrocks_udf::FunctionContext* context);
 
 } // namespace vectorized
@@ -35,7 +35,7 @@ Status Aggregator::open(RuntimeState* state) {
             for (int i = 0; i < _agg_fn_ctxs.size(); ++i) {
                 if (_fns[i].binary_type == TFunctionBinaryType::SRJAR) {
                     const auto& fn = _fns[i];
-                    auto st = vectorized::init_udaf_context(fn.id, fn.hdfs_location, fn.checksum,
+                    auto st = vectorized::init_udaf_context(fn.fid, fn.hdfs_location, fn.checksum,
                                                             fn.aggregate_fn.symbol, _agg_fn_ctxs[i]);
                     RETURN_IF_ERROR(st);
                 }

--- a/be/src/exec/vectorized/analytor.cpp
+++ b/be/src/exec/vectorized/analytor.cpp
@@ -21,7 +21,7 @@
 
 namespace starrocks {
 namespace vectorized {
-Status window_init_jvm_context(int fid, const std::string& url, const std::string& checksum, const std::string& symbol,
+Status window_init_jvm_context(int id, const std::string& url, const std::string& checksum, const std::string& symbol,
                                starrocks_udf::FunctionContext* context);
 } // namespace vectorized
 

--- a/be/src/exec/vectorized/analytor.cpp
+++ b/be/src/exec/vectorized/analytor.cpp
@@ -21,8 +21,8 @@
 
 namespace starrocks {
 namespace vectorized {
-Status window_init_jvm_context(int id, const std::string& url, const std::string& checksum, const std::string& symbol,
-                               starrocks_udf::FunctionContext* context);
+Status window_init_jvm_context(int64_t fid, const std::string& url, const std::string& checksum,
+                               const std::string& symbol, starrocks_udf::FunctionContext* context);
 } // namespace vectorized
 
 Analytor::Analytor(const TPlanNode& tnode, const RowDescriptor& child_row_desc,
@@ -272,7 +272,7 @@ Status Analytor::open(RuntimeState* state) {
         for (int i = 0; i < _agg_fn_ctxs.size(); ++i) {
             if (_fns[i].binary_type == TFunctionBinaryType::SRJAR) {
                 const auto& fn = _fns[i];
-                auto st = vectorized::window_init_jvm_context(fn.id, fn.hdfs_location, fn.checksum,
+                auto st = vectorized::window_init_jvm_context(fn.fid, fn.hdfs_location, fn.checksum,
                                                               fn.aggregate_fn.symbol, _agg_fn_ctxs[i]);
                 RETURN_IF_ERROR(st);
             }

--- a/be/src/exprs/agg/java_udaf_function.cpp
+++ b/be/src/exprs/agg/java_udaf_function.cpp
@@ -216,7 +216,7 @@ const AggregateFunction* getJavaUDAFFunction(bool input_nullable) {
     return &no_nullable_udaf_func;
 }
 
-Status init_udaf_context(int id, const std::string& url, const std::string& checksum, const std::string& symbol,
+Status init_udaf_context(int64_t id, const std::string& url, const std::string& checksum, const std::string& symbol,
                          starrocks_udf::FunctionContext* context) {
     std::string libpath;
     std::string state = symbol + "$State";

--- a/be/src/exprs/agg/java_udaf_function.h
+++ b/be/src/exprs/agg/java_udaf_function.h
@@ -26,8 +26,6 @@ template <bool handle_null>
 jvalue cast_to_jvalue(MethodTypeDescriptor method_type_desc, const Column* col, int row_num);
 void release_jvalue(MethodTypeDescriptor method_type_desc, jvalue val);
 void append_jvalue(MethodTypeDescriptor method_type_desc, Column* col, jvalue val);
-Status get_java_udaf_function(int id, const std::string& url, const std::string& checksum, const std::string& symbol,
-                              starrocks_udf::FunctionContext* context, AggregateFunction** func);
 
 template <bool handle_null = true>
 class JavaUDAFAggregateFunction : public AggregateFunction {

--- a/be/src/exprs/agg/java_udaf_function.h
+++ b/be/src/exprs/agg/java_udaf_function.h
@@ -26,7 +26,7 @@ template <bool handle_null>
 jvalue cast_to_jvalue(MethodTypeDescriptor method_type_desc, const Column* col, int row_num);
 void release_jvalue(MethodTypeDescriptor method_type_desc, jvalue val);
 void append_jvalue(MethodTypeDescriptor method_type_desc, Column* col, jvalue val);
-Status get_java_udaf_function(int fid, const std::string& url, const std::string& checksum, const std::string& symbol,
+Status get_java_udaf_function(int id, const std::string& url, const std::string& checksum, const std::string& symbol,
                               starrocks_udf::FunctionContext* context, AggregateFunction** func);
 
 template <bool handle_null = true>

--- a/be/src/exprs/agg/java_window_function.cpp
+++ b/be/src/exprs/agg/java_window_function.cpp
@@ -17,7 +17,7 @@ Status window_init_jvm_context(int64_t fid, const std::string& url, const std::s
                                const std::string& symbol, starrocks_udf::FunctionContext* context) {
     std::string libpath;
     std::string state = symbol + "$State";
-    RETURN_IF_ERROR(UserFunctionCache::instance()->get_libpath(id, url, checksum, &libpath));
+    RETURN_IF_ERROR(UserFunctionCache::instance()->get_libpath(fid, url, checksum, &libpath));
     auto* udaf_ctx = context->impl()->udaf_ctxs();
     udaf_ctx->udf_classloader = std::make_unique<ClassLoader>(std::move(libpath));
     RETURN_IF_ERROR(udaf_ctx->udf_classloader->init());

--- a/be/src/exprs/agg/java_window_function.cpp
+++ b/be/src/exprs/agg/java_window_function.cpp
@@ -13,11 +13,11 @@ const AggregateFunction* getJavaWindowFunction() {
     return &java_window_func;
 }
 
-Status window_init_jvm_context(int fid, const std::string& url, const std::string& checksum, const std::string& symbol,
+Status window_init_jvm_context(int id, const std::string& url, const std::string& checksum, const std::string& symbol,
                                starrocks_udf::FunctionContext* context) {
     std::string libpath;
     std::string state = symbol + "$State";
-    RETURN_IF_ERROR(UserFunctionCache::instance()->get_libpath(fid, url, checksum, &libpath));
+    RETURN_IF_ERROR(UserFunctionCache::instance()->get_libpath(id, url, checksum, &libpath));
     auto* udaf_ctx = context->impl()->udaf_ctxs();
     udaf_ctx->udf_classloader = std::make_unique<ClassLoader>(std::move(libpath));
     RETURN_IF_ERROR(udaf_ctx->udf_classloader->init());

--- a/be/src/exprs/agg/java_window_function.cpp
+++ b/be/src/exprs/agg/java_window_function.cpp
@@ -13,8 +13,8 @@ const AggregateFunction* getJavaWindowFunction() {
     return &java_window_func;
 }
 
-Status window_init_jvm_context(int id, const std::string& url, const std::string& checksum, const std::string& symbol,
-                               starrocks_udf::FunctionContext* context) {
+Status window_init_jvm_context(int64_t fid, const std::string& url, const std::string& checksum,
+                               const std::string& symbol, starrocks_udf::FunctionContext* context) {
     std::string libpath;
     std::string state = symbol + "$State";
     RETURN_IF_ERROR(UserFunctionCache::instance()->get_libpath(id, url, checksum, &libpath));

--- a/be/src/exprs/table_function/java_udtf_function.cpp
+++ b/be/src/exprs/table_function/java_udtf_function.cpp
@@ -91,7 +91,7 @@ Status JavaUDTFState::open() {
 
 Status JavaUDTFFunction::init(const TFunction& fn, TableFunctionState** state) const {
     std::string libpath;
-    RETURN_IF_ERROR(UserFunctionCache::instance()->get_libpath(fn.id, fn.hdfs_location, fn.checksum, &libpath));
+    RETURN_IF_ERROR(UserFunctionCache::instance()->get_libpath(fn.fid, fn.hdfs_location, fn.checksum, &libpath));
     // Now we only support one return types
     *state = new JavaUDTFState(std::move(libpath), fn.table_fn.symbol, fn.table_fn.ret_types[0]);
     return Status::OK();

--- a/be/src/exprs/table_function/java_udtf_function.cpp
+++ b/be/src/exprs/table_function/java_udtf_function.cpp
@@ -91,7 +91,7 @@ Status JavaUDTFState::open() {
 
 Status JavaUDTFFunction::init(const TFunction& fn, TableFunctionState** state) const {
     std::string libpath;
-    RETURN_IF_ERROR(UserFunctionCache::instance()->get_libpath(fn.fid, fn.hdfs_location, fn.checksum, &libpath));
+    RETURN_IF_ERROR(UserFunctionCache::instance()->get_libpath(fn.id, fn.hdfs_location, fn.checksum, &libpath));
     // Now we only support one return types
     *state = new JavaUDTFState(std::move(libpath), fn.table_fn.symbol, fn.table_fn.ret_types[0]);
     return Status::OK();

--- a/be/src/exprs/vectorized/java_function_call_expr.cpp
+++ b/be/src/exprs/vectorized/java_function_call_expr.cpp
@@ -179,7 +179,7 @@ Status JavaFunctionCallExpr::prepare(RuntimeState* state, ExprContext* context) 
     // init Expr::prepare
     RETURN_IF_ERROR(Expr::prepare(state, context));
 
-    if (!_fn.__isset.id) {
+    if (!_fn.__isset.fid) {
         return Status::InternalError("Not Found function id for " + _fn.name.function_name);
     }
 
@@ -226,7 +226,7 @@ Status JavaFunctionCallExpr::open(RuntimeState* state, ExprContext* context,
         // init class loader and analyzer
         std::string libpath;
         auto function_cache = UserFunctionCache::instance();
-        RETURN_IF_ERROR(function_cache->get_libpath(_fn.id, _fn.hdfs_location, _fn.checksum, &libpath));
+        RETURN_IF_ERROR(function_cache->get_libpath(_fn.fid, _fn.hdfs_location, _fn.checksum, &libpath));
         _func_desc->udf_classloader = std::make_unique<ClassLoader>(std::move(libpath));
         RETURN_IF_ERROR(_func_desc->udf_classloader->init());
         _func_desc->analyzer = std::make_unique<ClassAnalyzer>();

--- a/be/src/exprs/vectorized/java_function_call_expr.cpp
+++ b/be/src/exprs/vectorized/java_function_call_expr.cpp
@@ -136,7 +136,6 @@ struct UDFFunctionCallHelper {
             for (int i = 0; i < num_rows; ++i) {
                 auto data = env->GetObjectArrayElement((jobjectArray)result, i);
                 if (data != nullptr) {
-                    LOG(WARNING) << "result:" << helper.to_string(data);
                     slices[i] = helper.sliceVal((jstring)data, &_data_buffer[i]);
                 } else {
                     null_data[i] = true;
@@ -180,7 +179,7 @@ Status JavaFunctionCallExpr::prepare(RuntimeState* state, ExprContext* context) 
     // init Expr::prepare
     RETURN_IF_ERROR(Expr::prepare(state, context));
 
-    if (!_fn.__isset.fid) {
+    if (!_fn.__isset.id) {
         return Status::InternalError("Not Found function id for " + _fn.name.function_name);
     }
 

--- a/be/src/runtime/user_function_cache.cpp
+++ b/be/src/runtime/user_function_cache.cpp
@@ -268,7 +268,7 @@ Status UserFunctionCache::_load_cache_entry_internal(UserFunctionCacheEntryPtr& 
 
 std::string UserFunctionCache::_make_lib_file(int64_t function_id, const std::string& checksum,
                                               const std::string& shuffix) {
-    int shard = function_id % kLibShardNum;
+    int shard = std::abs(function_id % kLibShardNum);
     return fmt::format("{}/{}/{}.{}{}", _lib_dir, shard, function_id, checksum, shuffix);
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
@@ -600,7 +600,8 @@ public class Database extends MetaObject implements Writable {
             // Get function id for this UDF, use CatalogIdGenerator. Only get function id
             // when isReplay is false
             long functionId = Catalog.getCurrentCatalog().getNextId();
-            function.setId(functionId);
+            // all user-defined functions id are negative to avoid conflicts with the builtin function
+            function.setFunctionId(-functionId);
         }
 
         ImmutableList.Builder<Function> builder = ImmutableList.builder();


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
Fixes #4696 

## Problem Summary(Required) ：
fn.fid for UDF/UDAF/UDTF was always 0. we should use fn.id to load or
save jar libs
