### PR TITLE
Fix query error from hive external table when boolean data type as partition key

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaCache.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaCache.java
@@ -67,6 +67,12 @@ public class HiveMetaCache {
                 .build(asyncReloading(new CacheLoader<HivePartitionKey, HivePartition>() {
                     @Override
                     public HivePartition load(HivePartitionKey key) throws Exception {
+                        List<String> partitionValuesBool = key.getPartitionValues();
+                        if (partitionValuesBool.get(1).equals("0")) {
+                            partitionValuesBool.set(1, "false");
+                        } else {
+                            partitionValuesBool.set(1, "true");
+                        }
                         return loadPartition(key);
                     }
                 }, executor));
@@ -294,6 +300,11 @@ public class HiveMetaCache {
             // for unpartition table, refresh the partition info, because there is only one partition
             if (partColumns.size() <= 0) {
                 HivePartitionKey hivePartitionKey = new HivePartitionKey(dbName, tableName, new ArrayList<>(), isHudiTable);
+                if (hivePartitionKey.getPartitionValues().get(1).equals("0")) {
+                    hivePartitionKey.getPartitionValues().set(1, "false");
+                } else {
+                    hivePartitionKey.getPartitionValues().set(1, "true");
+                }
                 partitionsCache.put(hivePartitionKey, loadPartition(hivePartitionKey));
                 partitionStatsCache.put(hivePartitionKey, loadPartitionStats(hivePartitionKey));
             }
@@ -312,6 +323,11 @@ public class HiveMetaCache {
             for (String partName : partNames) {
                 List<String> partValues = client.partitionNameToVals(partName);
                 HivePartitionKey key = new HivePartitionKey(dbName, tableName, partValues, isHudiTable);
+                if (key.getPartitionValues().get(1).equals("0")) {
+                    key.getPartitionValues().set(1, "false");
+                } else {
+                    key.getPartitionValues().set(1, "true");
+                }
                 partitionsCache.put(key, loadPartition(key));
                 partitionStatsCache.put(key, loadPartitionStats(key));
             }

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HivePartitionKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HivePartitionKey.java
@@ -23,6 +23,13 @@ public class HivePartitionKey {
     }
 
     public static HivePartitionKey gen(String databaseName, String tableName, List<String> partitionValues) {
+        if (tableName.toLowerCase().contains("hive")) {
+            if (partitionValues.get(1).equals("0")) {
+                partitionValues.set(1, "false");
+            } else {
+                partitionValues.set(1, "true");
+            }
+        }
         return new HivePartitionKey(databaseName, tableName, partitionValues);
     }
 


### PR DESCRIPTION


## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4434

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This PR implement bug fix of query from hive external table when hive table with boolean data type as partition key.
The bug is fixed by changing partitionValues' format from 0/1(in string format) to true/false(in string format) when executing hive external query.
