### PR TITLE
Be crash caused by invalid json root

### DIFF
--- a/be/src/exec/vectorized/json_parser.cpp
+++ b/be/src/exec/vectorized/json_parser.cpp
@@ -126,7 +126,7 @@ Status JsonDocumentStreamParserWithRoot::get_current(simdjson::ondemand::object*
 
     // json root filter.
     simdjson::ondemand::value val;
-    RETURN_IF_ERROR(JsonFunctions::extract_from_object(*row, _root_paths, val));
+    RETURN_IF_ERROR(JsonFunctions::extract_from_object(*row, _root_paths, &val));
 
     try {
         if (val.type() != simdjson::ondemand::json_type::object) {
@@ -149,7 +149,7 @@ Status JsonArrayParserWithRoot::get_current(simdjson::ondemand::object* row) noe
     RETURN_IF_ERROR(this->JsonArrayParser::get_current(row));
     simdjson::ondemand::value val;
     // json root filter.
-    RETURN_IF_ERROR(JsonFunctions::extract_from_object(*row, _root_paths, val));
+    RETURN_IF_ERROR(JsonFunctions::extract_from_object(*row, _root_paths, &val));
 
     try {
         if (val.type() != simdjson::ondemand::json_type::object) {
@@ -172,7 +172,7 @@ Status ExpandedJsonDocumentStreamParserWithRoot::parse(uint8_t* data, size_t len
     RETURN_IF_ERROR(this->JsonDocumentStreamParser::get_current(&_curr_row));
 
     simdjson::ondemand::value val;
-    RETURN_IF_ERROR(JsonFunctions::extract_from_object(_curr_row, _root_paths, val));
+    RETURN_IF_ERROR(JsonFunctions::extract_from_object(_curr_row, _root_paths, &val));
 
     try {
         if (val.type() != simdjson::ondemand::json_type::array) {
@@ -229,7 +229,7 @@ Status ExpandedJsonDocumentStreamParserWithRoot::advance() noexcept {
             RETURN_IF_ERROR(this->JsonDocumentStreamParser::get_current(&_curr_row));
 
             simdjson::ondemand::value val;
-            RETURN_IF_ERROR(JsonFunctions::extract_from_object(_curr_row, _root_paths, val));
+            RETURN_IF_ERROR(JsonFunctions::extract_from_object(_curr_row, _root_paths, &val));
 
             try {
                 if (val.type() != simdjson::ondemand::json_type::array) {
@@ -259,7 +259,7 @@ Status ExpandedJsonArrayParserWithRoot::parse(uint8_t* data, size_t len, size_t 
     RETURN_IF_ERROR(this->JsonArrayParser::get_current(&_curr_row));
 
     simdjson::ondemand::value val;
-    RETURN_IF_ERROR(JsonFunctions::extract_from_object(_curr_row, _root_paths, val));
+    RETURN_IF_ERROR(JsonFunctions::extract_from_object(_curr_row, _root_paths, &val));
 
     try {
         if (val.type() != simdjson::ondemand::json_type::array) {
@@ -316,7 +316,7 @@ Status ExpandedJsonArrayParserWithRoot::advance() noexcept {
             RETURN_IF_ERROR(this->JsonArrayParser::get_current(&_curr_row));
 
             simdjson::ondemand::value val;
-            RETURN_IF_ERROR(JsonFunctions::extract_from_object(_curr_row, _root_paths, val));
+            RETURN_IF_ERROR(JsonFunctions::extract_from_object(_curr_row, _root_paths, &val));
 
             try {
                 if (val.type() != simdjson::ondemand::json_type::array) {

--- a/be/src/exec/vectorized/json_scanner.cpp
+++ b/be/src/exec/vectorized/json_scanner.cpp
@@ -517,7 +517,7 @@ Status JsonReader::_construct_row(simdjson::ondemand::object* row, Chunk* chunk,
                 row->reset();
                 RETURN_IF_ERROR(add_nullable_column(column, slot_descs[i]->type(), slot_descs[i]->col_name(), row,
                                                     !_strict_mode));
-            } else if (!JsonFunctions::extract_from_object(*row, _scanner->_json_paths[i], val).ok()) {
+            } else if (!JsonFunctions::extract_from_object(*row, _scanner->_json_paths[i], &val).ok()) {
                 if (strcmp(column_name, "__op") == 0) {
                     // special treatment for __op column, fill default value '0' rather than null
                     if (column->is_binary()) {

--- a/be/src/exprs/vectorized/json_functions.cpp
+++ b/be/src/exprs/vectorized/json_functions.cpp
@@ -110,7 +110,7 @@ Status JsonFunctions::json_path_close(starrocks_udf::FunctionContext* context,
 }
 
 Status JsonFunctions::extract_from_object(simdjson::ondemand::object& obj, const std::vector<SimpleJsonPath>& jsonpath,
-                                          simdjson::ondemand::value& value) noexcept {
+                                          simdjson::ondemand::value* value) noexcept {
     if (jsonpath.size() <= 1) {
         // The first elem of json path should be '$'.
         // A valid json path's size is >= 2.
@@ -174,7 +174,7 @@ Status JsonFunctions::extract_from_object(simdjson::ondemand::object& obj, const
         }
     }
 
-    std::swap(value, tvalue);
+    std::swap(*value, tvalue);
 
     return Status::OK();
 }
@@ -257,7 +257,7 @@ ColumnPtr JsonFunctions::_iterate_rows(FunctionContext* context, const Columns& 
             }
 
             simdjson::ondemand::value value;
-            auto st = extract_from_object(obj, jsonpath, value);
+            auto st = extract_from_object(obj, jsonpath, &value);
             if (!st.ok()) {
                 result.append_null();
                 continue;
@@ -297,7 +297,7 @@ ColumnPtr JsonFunctions::_iterate_rows(FunctionContext* context, const Columns& 
                 }
 
                 simdjson::ondemand::value value;
-                auto st = extract_from_object(obj, jsonpath, value);
+                auto st = extract_from_object(obj, jsonpath, &value);
                 if (!st.ok()) {
                     result.append_null();
                     continue;

--- a/be/src/exprs/vectorized/json_functions.cpp
+++ b/be/src/exprs/vectorized/json_functions.cpp
@@ -111,6 +111,12 @@ Status JsonFunctions::json_path_close(starrocks_udf::FunctionContext* context,
 
 Status JsonFunctions::extract_from_object(simdjson::ondemand::object& obj, const std::vector<SimpleJsonPath>& jsonpath,
                                           simdjson::ondemand::value& value) noexcept {
+    if (jsonpath.size() <= 1) {
+        // The first elem of json path should be '$'.
+        // A valid json path's size is >= 2.
+        return Status::InvalidArgument("empty json path");
+    }
+
     simdjson::ondemand::value tvalue;
 
     // Skip the first $.
@@ -122,6 +128,8 @@ Status JsonFunctions::extract_from_object(simdjson::ondemand::object& obj, const
         const std::string& col = jsonpath[i].key;
         int index = jsonpath[i].idx;
 
+        // Since the simdjson::ondemand::object cannot be converted to simdjson::ondemand::value,
+        // we have to do some special treatment for the second elem of json path.
         if (i == 1) {
             auto err = obj.find_field_unordered(col).get(tvalue);
             if (err) {
@@ -137,23 +145,32 @@ Status JsonFunctions::extract_from_object(simdjson::ondemand::object& obj, const
         }
 
         if (index != -1) {
-            auto arr = tvalue.get_array();
-            if (arr.error()) {
+            // try to access tvalue as array.
+            simdjson::ondemand::array arr;
+            auto err = tvalue.get_array().get(arr);
+            if (err) {
                 return Status::InvalidArgument(fmt::format("failed to access field as array, field: {}, err: {}", col,
-                                                           simdjson::error_message(arr.error())));
+                                                           simdjson::error_message(err)));
             }
 
-            int idx = 0;
-            for (auto a : arr) {
-                if (a.error()) {
-                    return Status::InvalidArgument(fmt::format("failed to access array element, field: {}, err: {}",
-                                                               col, simdjson::error_message(arr.error())));
-                }
+            size_t sz;
+            err = arr.count_elements().get(sz);
+            if (err) {
+                return Status::InvalidArgument(
+                        fmt::format("failed to get array size, field: {}, err: {}", col, simdjson::error_message(err)));
+            }
 
-                if (idx++ == index) {
-                    a.get(tvalue);
-                    break;
-                }
+            if (index >= sz) {
+                return Status::InvalidArgument(
+                        fmt::format("the acquired index is beyond array size, field: {}, index: {}, array size: {}",
+                                    col, index, sz));
+            }
+
+            err = arr.at(index).get(tvalue);
+            if (err) {
+                return Status::InvalidArgument(
+                        fmt::format("failed to access array, field: {}, index: {}, array size: {}, err: {}", col, index,
+                                    sz, simdjson::error_message(err)));
             }
         }
     }

--- a/be/src/exprs/vectorized/json_functions.cpp
+++ b/be/src/exprs/vectorized/json_functions.cpp
@@ -161,9 +161,8 @@ Status JsonFunctions::extract_from_object(simdjson::ondemand::object& obj, const
             }
 
             if (index >= sz) {
-                return Status::InvalidArgument(
-                        fmt::format("the acquired index is beyond array size, field: {}, index: {}, array size: {}",
-                                    col, index, sz));
+                return Status::NotFound(
+                        fmt::format("index beyond array size, field: {}, index: {}, array size: {}", col, index, sz));
             }
 
             err = arr.at(index).get(tvalue);

--- a/be/src/exprs/vectorized/json_functions.h
+++ b/be/src/exprs/vectorized/json_functions.h
@@ -172,7 +172,7 @@ public:
     // extract_from_object extracts value from object according to the json path.
     // Now, we do not support complete functions of json path.
     static Status extract_from_object(simdjson::ondemand::object& obj, const std::vector<SimpleJsonPath>& jsonpath,
-                                      simdjson::ondemand::value& value) noexcept;
+                                      simdjson::ondemand::value* value) noexcept;
 
     static void parse_json_paths(const std::string& path_strings, std::vector<SimpleJsonPath>* parsed_paths);
 

--- a/be/test/exprs/vectorized/json_functions_test.cpp
+++ b/be/test/exprs/vectorized/json_functions_test.cpp
@@ -646,7 +646,7 @@ TEST_F(JsonFunctionsTest, extract_from_object_test) {
     EXPECT_STREQ(output.data(), "2");
 
     st = test_extract_from_object(R"({"data": [{"key": 1},{"key": 2}]})", "$.data[2].key", &output);
-    EXPECT_STATUS(Status::InvalidArgument(""), st);
+    EXPECT_STATUS(Status::NotFound(""), st);
 }
 
 } // namespace vectorized

--- a/be/test/exprs/vectorized/json_functions_test.cpp
+++ b/be/test/exprs/vectorized/json_functions_test.cpp
@@ -32,6 +32,29 @@ public:
         expr_node.type = gen_type_desc(TPrimitiveType::BOOLEAN);
     }
 
+    Status test_extract_from_object(std::string input, std::string jsonpath, std::string* output) {
+        // reverse for padding.
+        input.reserve(input.size() + simdjson::SIMDJSON_PADDING);
+
+        simdjson::ondemand::parser parser;
+        simdjson::ondemand::document doc;
+        EXPECT_EQ(simdjson::error_code::SUCCESS, parser.iterate(input).get(doc));
+
+        simdjson::ondemand::object obj;
+
+        EXPECT_EQ(simdjson::error_code::SUCCESS, doc.get_object().get(obj));
+
+        std::vector<SimpleJsonPath> path;
+        JsonFunctions::parse_json_paths(jsonpath, &path);
+
+        simdjson::ondemand::value val;
+        RETURN_IF_ERROR(JsonFunctions::extract_from_object(obj, path, val));
+        std::string_view sv = simdjson::to_json_string(val);
+
+        output->assign(sv.data(), sv.size());
+        return Status::OK();
+    }
+
 public:
     TExprNode expr_node;
 };
@@ -606,6 +629,25 @@ INSTANTIATE_TEST_SUITE_P(
                 std::make_tuple(std::vector<std::string>{"1"}, "NULL"),
                 std::make_tuple(std::vector<std::string>{R"("a")", "1", "1"}, R"(NULL)"),
                 std::make_tuple(std::vector<std::string>{R"("")"}, R"(NULL)")));
+
+TEST_F(JsonFunctionsTest, extract_from_object_test) {
+    std::string output;
+    Status st;
+
+    st = test_extract_from_object(R"({"data" : 1})", "$.data", &output);
+    EXPECT_OK(st);
+    EXPECT_STREQ(output.data(), "1");
+
+    st = test_extract_from_object(R"({"data" : 1})", "$.dataa", &output);
+    EXPECT_STATUS(Status::NotFound(""), st);
+
+    st = test_extract_from_object(R"({"data": [{"key": 1},{"key": 2}]})", "$.data[1].key", &output);
+    EXPECT_OK(st);
+    EXPECT_STREQ(output.data(), "2");
+
+    st = test_extract_from_object(R"({"data": [{"key": 1},{"key": 2}]})", "$.data[2].key", &output);
+    EXPECT_STATUS(Status::InvalidArgument(""), st);
+}
 
 } // namespace vectorized
 } // namespace starrocks

--- a/be/test/exprs/vectorized/json_functions_test.cpp
+++ b/be/test/exprs/vectorized/json_functions_test.cpp
@@ -48,7 +48,7 @@ public:
         JsonFunctions::parse_json_paths(jsonpath, &path);
 
         simdjson::ondemand::value val;
-        RETURN_IF_ERROR(JsonFunctions::extract_from_object(obj, path, val));
+        RETURN_IF_ERROR(JsonFunctions::extract_from_object(obj, path, &val));
         std::string_view sv = simdjson::to_json_string(val);
 
         output->assign(sv.data(), sv.size());


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4727

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This fix the crash problem caused by invalid json root. Because the JsonPath is refactored in version 2.2, this bug only happens in branch-2.1.
Nevertheless, this fix should be merged to version >= 2.2 to make it more robust.
