### PR TITLE
Only TResultSinkType.MYSQL_PROTOCAL ResultSink can use pipeline

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/ResultSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ResultSink.java
@@ -103,6 +103,6 @@ public class ResultSink extends DataSink {
 
     @Override
     public boolean canUsePipeLine() {
-        return true;
+        return sinkType == TResultSinkType.MYSQL_PROTOCAL;
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Pipeline engine only implement ResultSink of TResultSinkType.MYSQL,  other types, such as FILE/STATISTIC still use non-pipeline engine.