### PR TITLE
Support partition names without parentheses

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -237,6 +237,7 @@ relationPrimary
 
 partitionNames
     : TEMPORARY? (PARTITION | PARTITIONS) '(' identifier (',' identifier)* ')'
+    | TEMPORARY? (PARTITION | PARTITIONS) identifier
     ;
 
 tabletList

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeDeleteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeDeleteTest.java
@@ -3,6 +3,7 @@ package com.starrocks.sql.analyzer;
 
 import com.starrocks.analysis.DeleteStmt;
 import com.starrocks.analysis.StatementBase;
+import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -28,6 +29,17 @@ public class AnalyzeDeleteTest {
     public static void tearDown() {
         File file = new File(runningDir);
         file.delete();
+    }
+
+    @Test
+    public void testPartitions() {
+        DeleteStmt st;
+        st = (DeleteStmt) SqlParser.parse("delete from tjson partition (p0)", 0).get(0);
+        Assert.assertEquals(1, st.getPartitionNames().size());
+        st = (DeleteStmt) SqlParser.parse("delete from tjson partition p0", 0).get(0);
+        Assert.assertEquals(1, st.getPartitionNames().size());
+        st = (DeleteStmt) SqlParser.parse("delete from tjson partition (p0, p1)", 0).get(0);
+        Assert.assertEquals(2, st.getPartitionNames().size());
     }
 
     @Test


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The old parser supports single partition name without parentheses, this PR adds the support to the new parser.
