### PR TITLE
Bugfix: copy the last row in array column replace aggregator (#4709)

### DIFF
--- a/be/src/storage/vectorized/column_aggregate_func.cpp
+++ b/be/src/storage/vectorized/column_aggregate_func.cpp
@@ -231,8 +231,15 @@ public:
     void reset() override { this->data().reset(); }
 
     void aggregate_impl(int row, const ColumnPtr& src) override {
-        this->data().column = src;
-        this->data().row = row;
+        if (row == src->size() - 1) {
+            // copy the last row to prevent to be overwritten or reset by get_next in aggregate iterator.
+            this->data().column = src->clone_empty();
+            this->data().column->append(*src, row, 1);
+            this->data().row = 0;
+        } else {
+            this->data().column = src;
+            this->data().row = row;
+        }
     }
 
     void aggregate_batch_impl(int start, int end, const ColumnPtr& src) override { aggregate_impl(end - 1, src); }

--- a/be/test/storage/vectorized/column_aggregator_test.cpp
+++ b/be/test/storage/vectorized/column_aggregator_test.cpp
@@ -528,4 +528,83 @@ TEST(ColumnAggregator, testNullIntReplace) {
     EXPECT_EQ(true, agg1->is_null(5));
 }
 
+TEST(ColumnAggregator, testArrayReplace) {
+    auto array_type_info = std::make_shared<ArrayTypeInfo>(get_type_info(FieldType::OLAP_FIELD_TYPE_VARCHAR));
+    FieldPtr field = std::make_shared<Field>(1, "test_array", array_type_info,
+                                             FieldAggregationMethod::OLAP_FIELD_AGGREGATION_REPLACE, 1, false, false);
+
+    auto agg_elements = BinaryColumn::create();
+    auto agg_offsets = UInt32Column::create();
+    auto agg = ArrayColumn::create(agg_elements, agg_offsets);
+
+    auto aggregator = ColumnAggregatorFactory::create_value_column_aggregator(field);
+    aggregator->update_aggregate(agg.get());
+    std::vector<uint32_t> loops;
+
+    // first chunk column
+    auto elements = BinaryColumn::create();
+    auto offsets = UInt32Column::create();
+    auto src = ArrayColumn::create(elements, offsets);
+    for (int i = 0; i < 10; ++i) {
+        elements->append(Slice(std::to_string(i)));
+    }
+    offsets->append(2);
+    offsets->append(5);
+    offsets->append(10);
+
+    aggregator->update_source(src);
+
+    loops.clear();
+    loops.emplace_back(2);
+    loops.emplace_back(1);
+
+    aggregator->aggregate_values(0, 2, loops.data(), false);
+
+    ASSERT_EQ(1, agg->size());
+    EXPECT_EQ("['2', '3', '4']", agg->debug_item(0));
+
+    // second chunk column
+    src->reset_column();
+    for (int i = 10; i < 20; ++i) {
+        elements->append(Slice(std::to_string(i)));
+    }
+    offsets->append(2);
+    offsets->append(7);
+    offsets->append(9);
+    offsets->append(10);
+
+    aggregator->update_source(src);
+
+    loops.clear();
+    loops.emplace_back(1);
+    loops.emplace_back(2);
+    loops.emplace_back(1);
+
+    aggregator->aggregate_values(0, 3, loops.data(), false);
+
+    EXPECT_EQ(3, agg->size());
+    EXPECT_EQ("['10', '11']", agg->debug_item(1));
+    EXPECT_EQ("['17', '18']", agg->debug_item(2));
+
+    // third chunk column
+    src->reset_column();
+    for (int i = 20; i < 30; ++i) {
+        elements->append(Slice(std::to_string(i)));
+    }
+    offsets->append(10);
+
+    aggregator->update_source(src);
+
+    loops.clear();
+    loops.emplace_back(1);
+
+    aggregator->aggregate_values(0, 1, loops.data(), true);
+
+    aggregator->finalize();
+
+    EXPECT_EQ(5, agg->size());
+    EXPECT_EQ("['19']", agg->debug_item(3));
+    EXPECT_EQ("['20', '21', '22', '23', '24', '25', '26', '27', '28', '29']", agg->debug_item(4));
+}
+
 } // namespace starrocks::vectorized


### PR DESCRIPTION
merge branch 2.1

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4705 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Currently, the column in replace aggregator ArrayState is the same as the column in the aggregate iterator.
When processing the next chunk in the aggregate iterator, the previous column will be overwritten or reset.
So copy it when processing the last row in the array column replace the aggregator.
