### PR TITLE
Array operator add clone function

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ArrayOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ArrayOperator.java
@@ -1,6 +1,7 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
 package com.starrocks.sql.optimizer.operator.scalar;
 
+import com.google.common.collect.Lists;
 import com.starrocks.catalog.Type;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 
@@ -16,13 +17,11 @@ import static com.starrocks.sql.optimizer.operator.OperatorType.ARRAY;
  * eg. array[1,2,3]
  */
 public class ArrayOperator extends ScalarOperator {
-    private final Type type;
     private final boolean nullable;
-    private final List<ScalarOperator> arguments;
+    protected List<ScalarOperator> arguments;
 
     public ArrayOperator(Type type, boolean nullable, List<ScalarOperator> arguments) {
         super(ARRAY, type);
-        this.type = type;
         this.nullable = nullable;
         this.arguments = arguments;
     }
@@ -57,6 +56,16 @@ public class ArrayOperator extends ScalarOperator {
         ColumnRefSet usedColumns = new ColumnRefSet();
         arguments.forEach(arg -> usedColumns.union(arg.getUsedColumns()));
         return usedColumns;
+    }
+
+    @Override
+    public ScalarOperator clone() {
+        ArrayOperator operator = (ArrayOperator) super.clone();
+        // Deep copy here
+        List<ScalarOperator> newArguments = Lists.newArrayList();
+        this.arguments.forEach(p -> newArguments.add(p.clone()));
+        operator.arguments = newArguments;
+        return operator;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ArraySliceOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ArraySliceOperator.java
@@ -1,6 +1,7 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
 package com.starrocks.sql.optimizer.operator.scalar;
 
+import com.google.common.collect.Lists;
 import com.starrocks.catalog.Type;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 
@@ -11,12 +12,10 @@ import java.util.stream.Collectors;
 import static com.starrocks.sql.optimizer.operator.OperatorType.ARRAY_SLICE;
 
 public class ArraySliceOperator extends ScalarOperator {
-    private final Type type;
-    private final List<ScalarOperator> arguments;
+    private List<ScalarOperator> arguments;
 
     public ArraySliceOperator(Type type, List<ScalarOperator> arguments) {
         super(ARRAY_SLICE, type);
-        this.type = type;
         this.arguments = arguments;
     }
 
@@ -50,6 +49,16 @@ public class ArraySliceOperator extends ScalarOperator {
         ColumnRefSet usedColumns = new ColumnRefSet();
         arguments.forEach(arg -> usedColumns.union(arg.getUsedColumns()));
         return usedColumns;
+    }
+
+    @Override
+    public ScalarOperator clone() {
+        ArraySliceOperator operator = (ArraySliceOperator) super.clone();
+        // Deep copy here
+        List<ScalarOperator> newArguments = Lists.newArrayList();
+        this.arguments.forEach(p -> newArguments.add(p.clone()));
+        operator.arguments = newArguments;
+        return operator;
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ArrayTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ArrayTypeTest.java
@@ -175,4 +175,13 @@ public class ArrayTypeTest extends PlanTestBase {
         plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("array_difference"));
     }
+
+    @Test
+    public void testArrayClone() throws Exception {
+        String sql = "select array_contains([v],1), array_contains([v],2) from (select v1+1 as v from t0,t1 group by v) t group by 1,2";
+        String plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("  8:Project\n" +
+                "  |  <slot 8> : array_contains(ARRAY<bigint(20)>[7: expr], 1)\n" +
+                "  |  <slot 9> : array_contains(ARRAY<bigint(20)>[7: expr], 2)"));
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4515
Because ArrayOperator doesn't implement clone method. As a result, in PreAggregateTurnOnRule, clone shallowly copied an arrayOperator object and modified it, which caused the original columnref 84 to be rewritten to column ref 18, resulting in a plan error
## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
