### PR TITLE
Cleanup: remove some unnecessary inline keywords

### DIFF
--- a/be/src/storage/base_tablet.h
+++ b/be/src/storage/base_tablet.h
@@ -43,7 +43,7 @@ public:
 
     virtual ~BaseTablet() = default;
 
-    inline DataDir* data_dir() const;
+    DataDir* data_dir() const;
 
     void set_data_dir(DataDir* data_dir) { _data_dir = data_dir; }
 
@@ -68,25 +68,25 @@ public:
     Status set_tablet_state(TabletState state);
 
     // Property encapsulated in TabletMeta
-    inline const TabletMetaSharedPtr tablet_meta();
+    const TabletMetaSharedPtr tablet_meta();
 
     void set_tablet_meta(const TabletMetaSharedPtr& tablet_meta) { _tablet_meta = tablet_meta; }
 
-    inline TabletUid tablet_uid() const;
-    inline int64_t table_id() const;
+    TabletUid tablet_uid() const;
+    int64_t table_id() const;
     // Returns a string can be used to uniquely identify a tablet.
     // The result string will often be printed to the log.
-    inline const std::string full_name() const;
-    inline int64_t partition_id() const;
-    inline int64_t tablet_id() const;
-    inline int32_t schema_hash() const;
-    inline int16_t shard_id();
-    inline const int64_t creation_time() const;
-    inline void set_creation_time(int64_t creation_time);
-    inline bool equal(int64_t tablet_id, int32_t schema_hash);
+    const std::string full_name() const;
+    int64_t partition_id() const;
+    int64_t tablet_id() const;
+    int32_t schema_hash() const;
+    int16_t shard_id();
+    const int64_t creation_time() const;
+    void set_creation_time(int64_t creation_time);
+    bool equal(int64_t tablet_id, int32_t schema_hash);
 
     // properties encapsulated in TabletSchema
-    inline const TabletSchema& tablet_schema() const;
+    const TabletSchema& tablet_schema() const;
 
 protected:
     virtual void on_shutdown() {}

--- a/be/src/storage/tablet.h
+++ b/be/src/storage/tablet.h
@@ -76,7 +76,7 @@ public:
     ~Tablet() override;
 
     Status init();
-    inline bool init_succeeded();
+    bool init_succeeded();
 
     bool is_used();
 
@@ -88,8 +88,8 @@ public:
     Status revise_tablet_meta(MemTracker* mem_tracker, const std::vector<RowsetMetaSharedPtr>& rowsets_to_clone,
                               const std::vector<Version>& versions_to_delete);
 
-    inline const int64_t cumulative_layer_point() const;
-    inline void set_cumulative_layer_point(int64_t new_point);
+    const int64_t cumulative_layer_point() const;
+    void set_cumulative_layer_point(int64_t new_point);
 
     size_t tablet_footprint(); // disk space occupied by tablet
     size_t num_rows();
@@ -97,15 +97,15 @@ public:
     Version max_version() const;
 
     // propreties encapsulated in TabletSchema
-    inline KeysType keys_type() const;
-    inline size_t num_columns() const;
-    inline size_t num_key_columns() const;
-    inline size_t num_short_key_columns() const;
-    inline size_t num_rows_per_row_block() const;
-    inline CompressKind compress_kind() const;
-    inline size_t next_unique_id() const;
-    inline size_t row_size() const;
-    inline size_t field_index(const string& field_name) const;
+    KeysType keys_type() const;
+    size_t num_columns() const;
+    size_t num_key_columns() const;
+    size_t num_short_key_columns() const;
+    size_t num_rows_per_row_block() const;
+    CompressKind compress_kind() const;
+    size_t next_unique_id() const;
+    size_t row_size() const;
+    size_t field_index(const string& field_name) const;
 
     // operation in rowsets
     Status add_rowset(const RowsetSharedPtr& rowset, bool need_persist = true);
@@ -153,27 +153,27 @@ public:
     Status set_alter_state(AlterTabletState state);
 
     // meta lock
-    inline void obtain_header_rdlock() { _meta_lock.lock_shared(); }
-    inline void obtain_header_wrlock() { _meta_lock.lock(); }
-    inline void release_header_lock() { _meta_lock.unlock(); }
-    inline std::shared_mutex& get_header_lock() { return _meta_lock; }
+    void obtain_header_rdlock() { _meta_lock.lock_shared(); }
+    void obtain_header_wrlock() { _meta_lock.lock(); }
+    void release_header_lock() { _meta_lock.unlock(); }
+    std::shared_mutex& get_header_lock() { return _meta_lock; }
 
     // ingest lock
-    inline void obtain_push_lock() { _ingest_lock.lock(); }
-    inline void release_push_lock() { _ingest_lock.unlock(); }
-    inline std::mutex& get_push_lock() { return _ingest_lock; }
+    void obtain_push_lock() { _ingest_lock.lock(); }
+    void release_push_lock() { _ingest_lock.unlock(); }
+    std::mutex& get_push_lock() { return _ingest_lock; }
 
     // base lock
-    inline void obtain_base_compaction_lock() { _base_lock.lock(); }
-    inline void release_base_compaction_lock() { _base_lock.unlock(); }
-    inline std::mutex& get_base_lock() { return _base_lock; }
+    void obtain_base_compaction_lock() { _base_lock.lock(); }
+    void release_base_compaction_lock() { _base_lock.unlock(); }
+    std::mutex& get_base_lock() { return _base_lock; }
 
     // cumulative lock
-    inline void obtain_cumulative_lock() { _cumulative_lock.lock(); }
-    inline void release_cumulative_lock() { _cumulative_lock.unlock(); }
-    inline std::mutex& get_cumulative_lock() { return _cumulative_lock; }
+    void obtain_cumulative_lock() { _cumulative_lock.lock(); }
+    void release_cumulative_lock() { _cumulative_lock.unlock(); }
+    std::mutex& get_cumulative_lock() { return _cumulative_lock; }
 
-    inline std::shared_mutex& get_migration_lock() { return _migration_lock; }
+    std::shared_mutex& get_migration_lock() { return _migration_lock; }
     // should use with migration lock.
     bool is_migrating() const { return _is_migrating; }
     // should use with migration lock.
@@ -223,12 +223,12 @@ public:
 
     void calculate_cumulative_point();
     // TODO(ygl):
-    inline bool is_primary_replica() { return false; }
+    bool is_primary_replica() { return false; }
 
     // TODO(ygl):
     // eco mode means power saving in new energy car
     // eco mode also means save money in starrocks
-    inline bool in_eco_mode() { return false; }
+    bool in_eco_mode() { return false; }
 
     void do_tablet_meta_checkpoint();
 


### PR DESCRIPTION
1. A member function defined in a class definition is implicitly
inline, so there is no need to put the inline keyword in this case.
2. The decision of whether a function is or is not inline is an
implementation detail that does not change the observable semantics
(the “meaning”) of a call. Therefore the inline keyword should not
go within the class’s public: (or the protected: or private:) part,
so it needs to go next to the function’s definition.

References:
https://llvm.org/docs/CodingStandards.html#don-t-use-inline-when-defining-a-function-in-a-class-definition
https://isocpp.org/wiki/faq/inline-functions#where-to-put-inline-keyword

## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [x] others

