### PR TITLE
[Enhancement] Change catalog lock to RWLock to reduce lock competition

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -811,9 +811,7 @@ public class Catalog {
     }
 
     private void writeUnlock() {
-        if (this.rwLock.writeLock().isHeldByCurrentThread()) {
-            this.rwLock.writeLock().unlock();
-        }
+        this.rwLock.writeLock().unlock();
     }
 
     public String getBdbDir() {
@@ -2725,12 +2723,12 @@ public class Catalog {
     }
 
     public void replayCreateDb(Database db) {
-        tryReadLock(true);
+        tryWriteLock(true);
         try {
             unprotectCreateDb(db);
             LOG.info("finish replay create db, name: {}, id: {}", db.getFullName(), db.getId());
         } finally {
-            readUnlock();
+            writeUnlock();
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
@@ -160,12 +160,14 @@ public class Database extends MetaObject implements Writable {
             return true;
         } catch (InterruptedException e) {
             LOG.warn("failed to try write lock at db[" + id + "]", e);
-            return false;
+            return this.rwLock.writeLock().isHeldByCurrentThread();
         }
     }
 
     public void writeUnlock() {
-        this.rwLock.writeLock().unlock();
+        if (this.rwLock.writeLock().isHeldByCurrentThread()) {
+            this.rwLock.writeLock().unlock();
+        }
     }
 
     public boolean isWriteLockHeldByCurrentThread() {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4889

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

For catalog locks, there are currently three types of operations that require this lock to maintain.

1. Modification of DB meta data.
2. Operations on Table meta data.
3. Operations on FrontEnd meta data.

Among them, operations on DB rarely occur, and operations on Table are easy to occur, so this is a scenario with more reads and fewer writes. We should use readwritelock to maintain these operations. 
For FrontEnd, due to the relatively low cost, we use write lock maintenance, 
we use read locks for table create operations to improve lock concurrency, 
and this is also the first step in which lock granularity can be reduced to Table.