### PR TITLE
[Refactor] return StatusOr<ColumnPtr> instead of ColumnPtr in ExprCon…

### DIFF
--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -510,7 +510,7 @@ void ExecNode::debug_string(int indentation_level, std::stringstream* out) const
     }
 }
 
-static void eager_prune_eval_conjuncts(const std::vector<ExprContext*>& ctxs, vectorized::Chunk* chunk) {
+Status eager_prune_eval_conjuncts(const std::vector<ExprContext*>& ctxs, vectorized::Chunk* chunk) {
     vectorized::Column::Filter filter(chunk->num_rows(), 1);
     vectorized::Column::Filter* raw_filter = &filter;
 
@@ -529,7 +529,7 @@ static void eager_prune_eval_conjuncts(const std::vector<ExprContext*>& ctxs, ve
     int zero_count = 0;
 
     for (auto* ctx : ctxs) {
-        ColumnPtr column = ctx->evaluate(chunk);
+        ASSIGN_OR_RETURN(ColumnPtr column, ctx->evaluate(chunk));
         size_t true_count = vectorized::ColumnHelper::count_true_with_notnull(column);
 
         if (true_count == column->size()) {
@@ -538,7 +538,7 @@ static void eager_prune_eval_conjuncts(const std::vector<ExprContext*>& ctxs, ve
         } else if (0 == true_count) {
             // all not hit, return
             chunk->set_num_rows(0);
-            return;
+            return Status::OK();
         } else {
             vectorized::ColumnHelper::merge_two_filters(column, raw_filter, nullptr);
             zero_count = SIMD::count_zero(*raw_filter);
@@ -547,7 +547,7 @@ static void eager_prune_eval_conjuncts(const std::vector<ExprContext*>& ctxs, ve
                 if (rows == 0) {
                     // When all rows in chunk is filtered, direct return
                     // No need to execute the following predicate
-                    return;
+                    return Status::OK();
                 }
                 filter.assign(rows, 1);
                 zero_count = 0;
@@ -555,17 +555,18 @@ static void eager_prune_eval_conjuncts(const std::vector<ExprContext*>& ctxs, ve
         }
     }
     if (zero_count == 0) {
-        return;
+        return Status::OK();
     }
     chunk->filter(*raw_filter);
+    return Status::OK();
 }
 
-void ExecNode::eval_conjuncts(const std::vector<ExprContext*>& ctxs, vectorized::Chunk* chunk,
-                              vectorized::FilterPtr* filter_ptr) {
+Status ExecNode::eval_conjuncts(const std::vector<ExprContext*>& ctxs, vectorized::Chunk* chunk,
+                                vectorized::FilterPtr* filter_ptr) {
     // No need to do expression if none rows
     DCHECK(chunk != nullptr);
     if (chunk->num_rows() == 0) {
-        return;
+        return Status::OK();
     }
 
     // if we don't need filter, then we can prune chunk during eval conjuncts.
@@ -588,7 +589,7 @@ void ExecNode::eval_conjuncts(const std::vector<ExprContext*>& ctxs, vectorized:
     vectorized::Column::Filter* raw_filter = filter.get();
 
     for (auto* ctx : ctxs) {
-        ColumnPtr column = ctx->evaluate(chunk);
+        ASSIGN_OR_RETURN(ColumnPtr column, ctx->evaluate(chunk));
         size_t true_count = vectorized::ColumnHelper::count_true_with_notnull(column);
 
         if (true_count == column->size()) {
@@ -597,33 +598,34 @@ void ExecNode::eval_conjuncts(const std::vector<ExprContext*>& ctxs, vectorized:
         } else if (0 == true_count) {
             // all not hit, return
             chunk->set_num_rows(0);
-            return;
+            return Status::OK();
         } else {
             bool all_zero = false;
             vectorized::ColumnHelper::merge_two_filters(column, raw_filter, &all_zero);
             if (all_zero) {
                 chunk->set_num_rows(0);
-                return;
+                return Status::OK();
             }
         }
     }
 
     int zero_count = SIMD::count_zero(*raw_filter);
     if (zero_count == 0) {
-        return;
+        return Status::OK();
     }
     chunk->filter(*raw_filter);
+    return Status::OK();
 }
 
-size_t ExecNode::eval_conjuncts_into_filter(const std::vector<ExprContext*>& ctxs, vectorized::Chunk* chunk,
-                                            vectorized::Filter* filter) {
+StatusOr<size_t> ExecNode::eval_conjuncts_into_filter(const std::vector<ExprContext*>& ctxs, vectorized::Chunk* chunk,
+                                                      vectorized::Filter* filter) {
     // No need to do expression if none rows
     DCHECK(chunk != nullptr);
     if (chunk->num_rows() == 0) {
         return 0;
     }
     for (auto* ctx : ctxs) {
-        ColumnPtr column = ctx->evaluate(chunk);
+        ASSIGN_OR_RETURN(ColumnPtr column, ctx->evaluate(chunk));
         size_t true_count = vectorized::ColumnHelper::count_true_with_notnull(column);
 
         if (true_count == column->size()) {

--- a/be/src/exec/exec_node.h
+++ b/be/src/exec/exec_node.h
@@ -151,10 +151,10 @@ public:
     // evaluate exprs over chunk to get a filter
     // if filter_ptr is not null, save filter to filter_ptr.
     // then running filter on chunk.
-    static void eval_conjuncts(const std::vector<ExprContext*>& ctxs, vectorized::Chunk* chunk,
-                               vectorized::FilterPtr* filter_ptr = nullptr);
-    static size_t eval_conjuncts_into_filter(const std::vector<ExprContext*>& ctxs, vectorized::Chunk* chunk,
-                                             vectorized::Filter* filter);
+    static Status eval_conjuncts(const std::vector<ExprContext*>& ctxs, vectorized::Chunk* chunk,
+                                 vectorized::FilterPtr* filter_ptr = nullptr);
+    static StatusOr<size_t> eval_conjuncts_into_filter(const std::vector<ExprContext*>& ctxs, vectorized::Chunk* chunk,
+                                                       vectorized::Filter* filter);
 
     static void eval_filter_null_values(vectorized::Chunk* chunk, const std::vector<SlotId>& filter_null_value_columns);
 

--- a/be/src/exec/parquet/file_reader.cpp
+++ b/be/src/exec/parquet/file_reader.cpp
@@ -203,8 +203,8 @@ Status FileReader::_filter_group(const tparquet::RowGroup& row_group, bool* is_f
         }
 
         for (auto& min_max_conjunct_ctx : _param.min_max_conjunct_ctxs) {
-            auto min_column = min_max_conjunct_ctx->evaluate(min_chunk.get());
-            auto max_column = min_max_conjunct_ctx->evaluate(max_chunk.get());
+            ASSIGN_OR_RETURN(auto min_column, min_max_conjunct_ctx->evaluate(min_chunk.get()));
+            ASSIGN_OR_RETURN(auto max_column, min_max_conjunct_ctx->evaluate(max_chunk.get()));
 
             auto min = min_column->get(0).get_int8();
             auto max = max_column->get(0).get_int8();

--- a/be/src/exec/pipeline/analysis/analytic_sink_operator.cpp
+++ b/be/src/exec/pipeline/analysis/analytic_sink_operator.cpp
@@ -65,7 +65,7 @@ Status AnalyticSinkOperator::push_chunk(RuntimeState* state, const vectorized::C
 
     for (size_t i = 0; i < _analytor->agg_fn_ctxs().size(); i++) {
         for (size_t j = 0; j < _analytor->agg_expr_ctxs()[i].size(); j++) {
-            ColumnPtr column = _analytor->agg_expr_ctxs()[i][j]->evaluate(chunk.get());
+            ASSIGN_OR_RETURN(ColumnPtr column, _analytor->agg_expr_ctxs()[i][j]->evaluate(chunk.get()));
             // Currently, only lead and lag window function have multi args.
             // For performance, we do this special handle.
             // In future, if need, we could remove this if else easily.
@@ -79,12 +79,12 @@ Status AnalyticSinkOperator::push_chunk(RuntimeState* state, const vectorized::C
     }
 
     for (size_t i = 0; i < _analytor->partition_ctxs().size(); i++) {
-        ColumnPtr column = _analytor->partition_ctxs()[i]->evaluate(chunk.get());
+        ASSIGN_OR_RETURN(ColumnPtr column, _analytor->partition_ctxs()[i]->evaluate(chunk.get()));
         TRY_CATCH_BAD_ALLOC(_analytor->append_column(chunk_size, _analytor->partition_columns()[i].get(), column));
     }
 
     for (size_t i = 0; i < _analytor->order_ctxs().size(); i++) {
-        ColumnPtr column = _analytor->order_ctxs()[i]->evaluate(chunk.get());
+        ASSIGN_OR_RETURN(ColumnPtr column, _analytor->order_ctxs()[i]->evaluate(chunk.get()));
         TRY_CATCH_BAD_ALLOC(_analytor->append_column(chunk_size, _analytor->order_columns()[i].get(), column));
     }
 

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -440,7 +440,7 @@ Status ExchangeSinkOperator::push_chunk(RuntimeState* state, const vectorized::C
         {
             SCOPED_TIMER(_shuffle_hash_timer);
             for (size_t i = 0; i < _partitions_columns.size(); ++i) {
-                _partitions_columns[i] = _partition_expr_ctxs[i]->evaluate(chunk.get());
+                ASSIGN_OR_RETURN(_partitions_columns[i], _partition_expr_ctxs[i]->evaluate(chunk.get()));
                 DCHECK(_partitions_columns[i] != nullptr);
             }
 

--- a/be/src/exec/pipeline/exchange/local_exchange.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange.cpp
@@ -13,7 +13,7 @@ Status PartitionExchanger::Partitioner::partition_chunk(const vectorized::ChunkP
     int32_t num_partitions = _source->get_sources().size();
 
     for (size_t i = 0; i < _partitions_columns.size(); ++i) {
-        _partitions_columns[i] = _partition_expr_ctxs[i]->evaluate(chunk.get());
+        ASSIGN_OR_RETURN(_partitions_columns[i], _partition_expr_ctxs[i]->evaluate(chunk.get()));
         DCHECK(_partitions_columns[i] != nullptr);
     }
 

--- a/be/src/exec/pipeline/hdfs_chunk_source.h
+++ b/be/src/exec/pipeline/hdfs_chunk_source.h
@@ -60,7 +60,7 @@ private:
     void _init_tuples_and_slots(RuntimeState* state);
     void _init_counter(RuntimeState* state);
 
-    void _init_partition_values();
+    Status _init_partition_values();
     Status _init_scanner(RuntimeState* state);
     void _init_chunk(ChunkPtr* chunk);
 

--- a/be/src/exec/pipeline/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/olap_chunk_source.cpp
@@ -53,7 +53,7 @@ Status OlapChunkSource::prepare(RuntimeState* state) {
 
     _dict_optimize_parser.set_mutable_dict_maps(state, state->mutable_query_global_dict_map());
 
-    OlapScanConjunctsManager::eval_const_conjuncts(_conjunct_ctxs, &_status);
+    RETURN_IF_ERROR(OlapScanConjunctsManager::eval_const_conjuncts(_conjunct_ctxs, &_status));
     OlapScanConjunctsManager& cm = _conjuncts_manager;
     cm.conjunct_ctxs_ptr = &_conjunct_ctxs;
     cm.tuple_desc = tuple_desc;

--- a/be/src/exec/pipeline/project_operator.cpp
+++ b/be/src/exec/pipeline/project_operator.cpp
@@ -25,7 +25,8 @@ StatusOr<vectorized::ChunkPtr> ProjectOperator::pull_chunk(RuntimeState* state) 
 Status ProjectOperator::push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) {
     TRY_CATCH_ALLOC_SCOPE_START()
     for (size_t i = 0; i < _common_sub_column_ids.size(); ++i) {
-        chunk->append_column(_common_sub_expr_ctxs[i]->evaluate(chunk.get()), _common_sub_column_ids[i]);
+        ASSIGN_OR_RETURN(auto col, _common_sub_expr_ctxs[i]->evaluate(chunk.get()));
+        chunk->append_column(std::move(col), _common_sub_column_ids[i]);
         RETURN_IF_HAS_ERROR(_common_sub_expr_ctxs);
     }
 
@@ -33,7 +34,7 @@ Status ProjectOperator::push_chunk(RuntimeState* state, const vectorized::ChunkP
     vectorized::Columns result_columns(_column_ids.size());
     {
         for (size_t i = 0; i < _column_ids.size(); ++i) {
-            result_columns[i] = _expr_ctxs[i]->evaluate(chunk.get());
+            ASSIGN_OR_RETURN(result_columns[i], _expr_ctxs[i]->evaluate(chunk.get()));
 
             if (result_columns[i]->only_null()) {
                 result_columns[i] = ColumnHelper::create_column(_expr_ctxs[i]->root()->type(), true);

--- a/be/src/exec/pipeline/set/union_const_source_operator.cpp
+++ b/be/src/exec/pipeline/set/union_const_source_operator.cpp
@@ -25,7 +25,9 @@ StatusOr<vectorized::ChunkPtr> UnionConstSourceOperator::pull_chunk(starrocks::R
             // Each const_expr_list is projected to ONE dest row.
             DCHECK_EQ(_const_expr_lists[_next_processed_row_index + row_i].size(), columns_count);
 
-            ColumnPtr src_column = _const_expr_lists[_next_processed_row_index + row_i][col_i]->evaluate(nullptr);
+            ASSIGN_OR_RETURN(ColumnPtr src_column,
+                             _const_expr_lists[_next_processed_row_index + row_i][col_i]->evaluate(nullptr));
+
             RETURN_IF_HAS_ERROR(_const_expr_lists[_next_processed_row_index + row_i]);
             auto cur_row_dst_column =
                     vectorized::ColumnHelper::move_column(dst_slot->type(), dst_slot->is_nullable(), src_column, 1);

--- a/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
@@ -37,9 +37,10 @@ StatusOr<vectorized::ChunkPtr> PartitionSortSinkOperator::pull_chunk(RuntimeStat
 }
 
 Status PartitionSortSinkOperator::push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) {
-    vectorized::ChunkPtr materialize_chunk = ChunksSorter::materialize_chunk_before_sort(
-            chunk.get(), _materialized_tuple_desc, _sort_exec_exprs, _order_by_types);
-    TRY_CATCH_BAD_ALLOC(RETURN_IF_ERROR(_chunks_sorter->update(state, materialize_chunk)));
+    auto materialize_chunk = ChunksSorter::materialize_chunk_before_sort(chunk.get(), _materialized_tuple_desc,
+                                                                         _sort_exec_exprs, _order_by_types);
+    RETURN_IF_ERROR(materialize_chunk);
+    TRY_CATCH_BAD_ALLOC(RETURN_IF_ERROR(_chunks_sorter->update(state, materialize_chunk.value())));
     return Status::OK();
 }
 

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -733,7 +733,7 @@ Status OlapTableSink::send_chunk(RuntimeState* state, vectorized::Chunk* chunk) 
         if (!_output_expr_ctxs.empty()) {
             _output_chunk = std::make_unique<vectorized::Chunk>();
             for (size_t i = 0; i < _output_expr_ctxs.size(); ++i) {
-                ColumnPtr tmp = _output_expr_ctxs[i]->evaluate(chunk);
+                ASSIGN_OR_RETURN(ColumnPtr tmp, _output_expr_ctxs[i]->evaluate(chunk));
                 ColumnPtr output_column = nullptr;
                 if (tmp->only_null()) {
                     // Only null column maybe lost type info

--- a/be/src/exec/vectorized/aggregator.cpp
+++ b/be/src/exec/vectorized/aggregator.cpp
@@ -23,7 +23,7 @@ Status Aggregator::open(RuntimeState* state) {
     RETURN_IF_ERROR(Expr::open(_group_by_expr_ctxs, state));
     for (int i = 0; i < _agg_fn_ctxs.size(); ++i) {
         RETURN_IF_ERROR(Expr::open(_agg_expr_ctxs[i], state));
-        _evaluate_const_columns(i);
+        RETURN_IF_ERROR(_evaluate_const_columns(i));
     }
     RETURN_IF_ERROR(Expr::open(_conjunct_ctxs, state));
 
@@ -407,14 +407,16 @@ void Aggregator::compute_batch_agg_states_with_selection(size_t chunk_size) {
     }
 }
 
-void Aggregator::_evaluate_const_columns(int i) {
+Status Aggregator::_evaluate_const_columns(int i) {
     // used for const columns.
     std::vector<ColumnPtr> const_columns;
     const_columns.reserve(_agg_expr_ctxs[i].size());
     for (int j = 0; j < _agg_expr_ctxs[i].size(); ++j) {
-        const_columns.emplace_back(_agg_expr_ctxs[i][j]->root()->evaluate_const(_agg_expr_ctxs[i][j]));
+        ASSIGN_OR_RETURN(auto col, _agg_expr_ctxs[i][j]->root()->evaluate_const(_agg_expr_ctxs[i][j]));
+        const_columns.emplace_back(std::move(col));
     }
     _agg_fn_ctxs[i]->impl()->set_constant_columns(const_columns);
+    return Status::OK();
 }
 
 void Aggregator::convert_to_chunk_no_groupby(vectorized::ChunkPtr* chunk) {
@@ -464,9 +466,10 @@ void Aggregator::process_limit(vectorized::ChunkPtr* chunk) {
     }
 }
 
-void Aggregator::evaluate_exprs(vectorized::Chunk* chunk) {
+Status Aggregator::evaluate_exprs(vectorized::Chunk* chunk) {
     _evaluate_group_by_exprs(chunk);
-    _evaluate_agg_fn_exprs(chunk);
+    RETURN_IF_ERROR(_evaluate_agg_fn_exprs(chunk));
+    return Status::OK();
 }
 
 void Aggregator::output_chunk_by_streaming(vectorized::ChunkPtr* chunk) {
@@ -630,11 +633,12 @@ void Aggregator::_evaluate_group_by_exprs(vectorized::Chunk* chunk) {
         }
     }
 }
-void Aggregator::_evaluate_agg_fn_exprs(vectorized::Chunk* chunk) {
+
+Status Aggregator::_evaluate_agg_fn_exprs(vectorized::Chunk* chunk) {
     SCOPED_TIMER(_expr_compute_timer);
     // Compute group by columns
     for (size_t i = 0; i < _group_by_expr_ctxs.size(); i++) {
-        _group_by_columns[i] = _group_by_expr_ctxs[i]->evaluate(chunk);
+        ASSIGN_OR_RETURN(_group_by_columns[i], _group_by_expr_ctxs[i]->evaluate(chunk));
         DCHECK(_group_by_columns[i] != nullptr);
         if (_group_by_columns[i]->is_constant()) {
             // If group by column is constant, we disable streaming aggregate.
@@ -665,14 +669,18 @@ void Aggregator::_evaluate_agg_fn_exprs(vectorized::Chunk* chunk) {
             // We handle const column as normal data column
             // TODO(kks): improve const column aggregate later
             if (j == 0) {
-                _agg_intput_columns[i][j] = vectorized::ColumnHelper::unpack_and_duplicate_const_column(
-                        chunk->num_rows(), _agg_expr_ctxs[i][j]->evaluate(chunk));
+                ASSIGN_OR_RETURN(auto&& col, _agg_expr_ctxs[i][j]->evaluate(chunk));
+                _agg_intput_columns[i][j] =
+                        vectorized::ColumnHelper::unpack_and_duplicate_const_column(chunk->num_rows(), std::move(col));
             } else {
-                _agg_intput_columns[i][j] = _agg_expr_ctxs[i][j]->evaluate(chunk);
+                ASSIGN_OR_RETURN(auto&& col, _agg_expr_ctxs[i][j]->evaluate(chunk));
+                _agg_intput_columns[i][j] = std::move(col);
             }
             _agg_input_raw_columns[i][j] = _agg_intput_columns[i][j].get();
         }
     }
+
+    return Status::OK();
 }
 
 // note(yan): in types.h and primitive_type.h there are similiar functions,

--- a/be/src/exec/vectorized/aggregator.h
+++ b/be/src/exec/vectorized/aggregator.h
@@ -122,7 +122,7 @@ public:
 
     void process_limit(vectorized::ChunkPtr* chunk);
 
-    void evaluate_exprs(vectorized::Chunk* chunk);
+    Status evaluate_exprs(vectorized::Chunk* chunk);
 
     void output_chunk_by_streaming(vectorized::ChunkPtr* chunk);
 
@@ -460,7 +460,7 @@ private:
     bool _reached_limit() { return _limit != -1 && _num_rows_returned >= _limit; }
 
     // initial const columns for i'th FunctionContext.
-    void _evaluate_const_columns(int i);
+    Status _evaluate_const_columns(int i);
 
     // Create new aggregate function result column by type
     vectorized::Columns _create_agg_result_columns();
@@ -472,7 +472,7 @@ private:
                             const vectorized::Columns& agg_result_columns);
 
     void _evaluate_group_by_exprs(vectorized::Chunk* chunk);
-    void _evaluate_agg_fn_exprs(vectorized::Chunk* chunk);
+    Status _evaluate_agg_fn_exprs(vectorized::Chunk* chunk);
 
     // Choose different agg hash map/set by different group by column's count, type, nullable
     template <typename HashVariantType>

--- a/be/src/exec/vectorized/analytic_node.cpp
+++ b/be/src/exec/vectorized/analytic_node.cpp
@@ -314,7 +314,7 @@ Status AnalyticNode::_fetch_next_chunk(RuntimeState* state) {
 
     for (size_t i = 0; i < _analytor->agg_fn_ctxs().size(); i++) {
         for (size_t j = 0; j < _analytor->agg_expr_ctxs()[i].size(); j++) {
-            ColumnPtr column = _analytor->agg_expr_ctxs()[i][j]->evaluate(child_chunk.get());
+            ASSIGN_OR_RETURN(ColumnPtr column, _analytor->agg_expr_ctxs()[i][j]->evaluate(child_chunk.get()));
             // Currently, only lead and lag window function have multi args.
             // For performance, we do this special handle.
             // In future, if need, we could remove this if else easily.
@@ -328,12 +328,12 @@ Status AnalyticNode::_fetch_next_chunk(RuntimeState* state) {
     }
 
     for (size_t i = 0; i < _analytor->partition_ctxs().size(); i++) {
-        ColumnPtr column = _analytor->partition_ctxs()[i]->evaluate(child_chunk.get());
+        ASSIGN_OR_RETURN(ColumnPtr column, _analytor->partition_ctxs()[i]->evaluate(child_chunk.get()));
         TRY_CATCH_BAD_ALLOC(_analytor->append_column(chunk_size, _analytor->partition_columns()[i].get(), column));
     }
 
     for (size_t i = 0; i < _analytor->order_ctxs().size(); i++) {
-        ColumnPtr column = _analytor->order_ctxs()[i]->evaluate(child_chunk.get());
+        ASSIGN_OR_RETURN(ColumnPtr column, _analytor->order_ctxs()[i]->evaluate(child_chunk.get()));
         TRY_CATCH_BAD_ALLOC(_analytor->append_column(chunk_size, _analytor->order_columns()[i].get(), column));
     }
 

--- a/be/src/exec/vectorized/chunks_sorter.h
+++ b/be/src/exec/vectorized/chunks_sorter.h
@@ -34,7 +34,7 @@ struct DataSegment {
         chunk = cnk;
         order_by_columns.reserve(sort_exprs->size());
         for (ExprContext* expr_ctx : (*sort_exprs)) {
-            order_by_columns.push_back(expr_ctx->evaluate(chunk.get()));
+            order_by_columns.push_back(EVALUATE_NULL_IF_ERROR(expr_ctx, expr_ctx->root(), chunk.get()));
         }
     }
 
@@ -95,10 +95,10 @@ public:
                  const std::vector<bool>* is_null_first, const std::string& sort_keys, const bool is_topn);
     virtual ~ChunksSorter();
 
-    static vectorized::ChunkPtr materialize_chunk_before_sort(vectorized::Chunk* chunk,
-                                                              TupleDescriptor* materialized_tuple_desc,
-                                                              const SortExecExprs& sort_exec_exprs,
-                                                              const std::vector<OrderByType>& order_by_types);
+    static StatusOr<vectorized::ChunkPtr> materialize_chunk_before_sort(vectorized::Chunk* chunk,
+                                                                        TupleDescriptor* materialized_tuple_desc,
+                                                                        const SortExecExprs& sort_exec_exprs,
+                                                                        const std::vector<OrderByType>& order_by_types);
 
     virtual void setup_runtime(RuntimeProfile* profile);
 

--- a/be/src/exec/vectorized/csv_scanner.h
+++ b/be/src/exec/vectorized/csv_scanner.h
@@ -50,7 +50,7 @@ private:
     ChunkPtr _create_chunk(const std::vector<SlotDescriptor*>& slots);
 
     Status _parse_csv(Chunk* chunk);
-    ChunkPtr _materialize(ChunkPtr& src_chunk);
+    StatusOr<ChunkPtr> _materialize(ChunkPtr& src_chunk);
     void _report_error(const std::string& line, const std::string& err_msg);
 
     using ConverterPtr = std::unique_ptr<csv::Converter>;

--- a/be/src/exec/vectorized/es_http_scan_node.h
+++ b/be/src/exec/vectorized/es_http_scan_node.h
@@ -38,7 +38,7 @@ private:
     Status _build_conjuncts();
     // try to skip constant conjuncts is constant conjuncts
     // we will set eos to true if always false
-    void _try_skip_constant_conjuncts();
+    Status _try_skip_constant_conjuncts();
 
     // validate predicate and remove expr that have been push down
     Status _normalize_conjuncts();

--- a/be/src/exec/vectorized/except_hash_set.cpp
+++ b/be/src/exec/vectorized/except_hash_set.cpp
@@ -92,7 +92,7 @@ template <typename HashSet>
 size_t ExceptHashSet<HashSet>::_get_max_serialize_size(const ChunkPtr& chunk, const std::vector<ExprContext*>& exprs) {
     size_t max_size = 0;
     for (auto expr : exprs) {
-        ColumnPtr key_column = expr->evaluate(chunk.get());
+        ColumnPtr key_column = EVALUATE_NULL_IF_ERROR(expr, expr->root(), chunk.get());
         max_size += key_column->max_one_element_serialize_size();
         if (!key_column->is_nullable()) {
             max_size += sizeof(bool);
@@ -105,7 +105,7 @@ template <typename HashSet>
 void ExceptHashSet<HashSet>::_serialize_columns(const ChunkPtr& chunk, const std::vector<ExprContext*>& exprs,
                                                 size_t chunk_size) {
     for (auto expr : exprs) {
-        ColumnPtr key_column = expr->evaluate(chunk.get());
+        ColumnPtr key_column = EVALUATE_NULL_IF_ERROR(expr, expr->root(), chunk.get());
 
         // The serialized buffer is always nullable.
         if (key_column->is_nullable()) {

--- a/be/src/exec/vectorized/file_scanner.cpp
+++ b/be/src/exec/vectorized/file_scanner.cpp
@@ -134,7 +134,8 @@ void FileScanner::fill_columns_from_path(starrocks::vectorized::ChunkPtr& chunk,
     }
 }
 
-ChunkPtr FileScanner::materialize(const starrocks::vectorized::ChunkPtr& src, starrocks::vectorized::ChunkPtr& cast) {
+StatusOr<ChunkPtr> FileScanner::materialize(const starrocks::vectorized::ChunkPtr& src,
+                                            starrocks::vectorized::ChunkPtr& cast) {
     SCOPED_RAW_TIMER(&_counter->materialize_ns);
     // materialize
     ChunkPtr dest_chunk = std::make_shared<Chunk>();
@@ -156,8 +157,7 @@ ChunkPtr FileScanner::materialize(const starrocks::vectorized::ChunkPtr& src, st
 
         int dest_index = ctx_index++;
         ExprContext* ctx = _dest_expr_ctx[dest_index];
-
-        auto col = ctx->evaluate(cast.get());
+        ASSIGN_OR_RETURN(auto col, ctx->evaluate(cast.get()));
         uintptr_t col_pointer = reinterpret_cast<uintptr_t>(col.get());
         if (column_pointers.contains(col_pointer)) {
             col = col->clone();

--- a/be/src/exec/vectorized/file_scanner.h
+++ b/be/src/exec/vectorized/file_scanner.h
@@ -54,7 +54,7 @@ protected:
                                 int size);
     // materialize is used to transform source chunk depicted by src_slot_descriptors into destination
     // chunk depicted by dest_slot_descriptors
-    ChunkPtr materialize(const starrocks::vectorized::ChunkPtr& src, starrocks::vectorized::ChunkPtr& cast);
+    StatusOr<ChunkPtr> materialize(const starrocks::vectorized::ChunkPtr& src, starrocks::vectorized::ChunkPtr& cast);
 
 protected:
     RuntimeState* _state;

--- a/be/src/exec/vectorized/hash_join_node.cpp
+++ b/be/src/exec/vectorized/hash_join_node.cpp
@@ -561,12 +561,12 @@ static inline bool check_chunk_zero_and_create_new(ChunkPtr* chunk) {
     return false;
 }
 
-void HashJoinNode::_evaluate_build_keys(const ChunkPtr& chunk) {
+Status HashJoinNode::_evaluate_build_keys(const ChunkPtr& chunk) {
     _key_columns.resize(0);
     size_t num_rows = chunk->num_rows();
     for (auto& ctx : _build_expr_ctxs) {
         const TypeDescriptor& data_type = ctx->root()->type();
-        ColumnPtr key_column = ctx->evaluate(chunk.get());
+        ASSIGN_OR_RETURN(ColumnPtr key_column, ctx->evaluate(chunk.get()));
         if (key_column->only_null()) {
             ColumnPtr column = ColumnHelper::create_column(data_type, true);
             column->append_nulls(num_rows);
@@ -579,6 +579,7 @@ void HashJoinNode::_evaluate_build_keys(const ChunkPtr& chunk) {
             _key_columns.emplace_back(key_column);
         }
     }
+    return Status::OK();
 }
 
 Status HashJoinNode::_probe(RuntimeState* state, ScopedTimer<MonotonicStopWatch>& probe_timer, ChunkPtr* chunk,
@@ -644,7 +645,7 @@ Status HashJoinNode::_probe(RuntimeState* state, ScopedTimer<MonotonicStopWatch>
                     SCOPED_TIMER(_probe_conjunct_evaluate_timer);
                     _key_columns.resize(0);
                     for (auto& probe_expr_ctx : _probe_expr_ctxs) {
-                        ColumnPtr column_ptr = probe_expr_ctx->evaluate(_probing_chunk.get());
+                        ASSIGN_OR_RETURN(ColumnPtr column_ptr, probe_expr_ctx->evaluate(_probing_chunk.get()));
                         if (column_ptr->is_nullable() && column_ptr->is_constant()) {
                             ColumnPtr column = ColumnHelper::create_column(probe_expr_ctx->root()->type(), true);
                             column->append_nulls(_probing_chunk->num_rows());
@@ -680,7 +681,7 @@ Status HashJoinNode::_probe(RuntimeState* state, ScopedTimer<MonotonicStopWatch>
 
         if (!_other_join_conjunct_ctxs.empty()) {
             SCOPED_TIMER(_other_join_conjunct_evaluate_timer);
-            _process_other_conjunct(chunk);
+            RETURN_IF_ERROR(_process_other_conjunct(chunk));
             if (check_chunk_zero_and_create_new(chunk)) {
                 continue;
             }
@@ -688,7 +689,7 @@ Status HashJoinNode::_probe(RuntimeState* state, ScopedTimer<MonotonicStopWatch>
 
         if (!_conjunct_ctxs.empty()) {
             SCOPED_TIMER(_where_conjunct_evaluate_timer);
-            eval_conjuncts(_conjunct_ctxs, (*chunk).get());
+            RETURN_IF_ERROR(eval_conjuncts(_conjunct_ctxs, (*chunk).get()));
 
             if (check_chunk_zero_and_create_new(chunk)) {
                 continue;
@@ -717,7 +718,7 @@ Status HashJoinNode::_probe_remain(ChunkPtr* chunk, bool& eos) {
         }
 
         if (!_conjunct_ctxs.empty()) {
-            eval_conjuncts(_conjunct_ctxs, (*chunk).get());
+            RETURN_IF_ERROR(eval_conjuncts(_conjunct_ctxs, (*chunk).get()));
 
             if (check_chunk_zero_and_create_new(chunk)) {
                 _build_eos = !_right_table_has_remain;
@@ -734,14 +735,14 @@ Status HashJoinNode::_probe_remain(ChunkPtr* chunk, bool& eos) {
     return Status::OK();
 }
 
-void HashJoinNode::_calc_filter_for_other_conjunct(ChunkPtr* chunk, Column::Filter& filter, bool& filter_all,
-                                                   bool& hit_all) {
+Status HashJoinNode::_calc_filter_for_other_conjunct(ChunkPtr* chunk, Column::Filter& filter, bool& filter_all,
+                                                     bool& hit_all) {
     filter_all = false;
     hit_all = false;
     filter.assign((*chunk)->num_rows(), 1);
 
     for (auto* ctx : _other_join_conjunct_ctxs) {
-        ColumnPtr column = ctx->evaluate((*chunk).get());
+        ASSIGN_OR_RETURN(ColumnPtr column, ctx->evaluate((*chunk).get()));
         size_t true_count = ColumnHelper::count_true_with_notnull(column);
 
         if (true_count == column->size()) {
@@ -768,6 +769,8 @@ void HashJoinNode::_calc_filter_for_other_conjunct(ChunkPtr* chunk, Column::Filt
             hit_all = true;
         }
     }
+
+    return Status::OK();
 }
 
 void HashJoinNode::_process_row_for_other_conjunct(ChunkPtr* chunk, size_t start_column, size_t column_count,
@@ -799,60 +802,64 @@ void HashJoinNode::_process_row_for_other_conjunct(ChunkPtr* chunk, size_t start
     }
 }
 
-void HashJoinNode::_process_outer_join_with_other_conjunct(ChunkPtr* chunk, size_t start_column, size_t column_count) {
+Status HashJoinNode::_process_outer_join_with_other_conjunct(ChunkPtr* chunk, size_t start_column,
+                                                             size_t column_count) {
     bool filter_all = false;
     bool hit_all = false;
     Column::Filter filter;
 
-    _calc_filter_for_other_conjunct(chunk, filter, filter_all, hit_all);
+    RETURN_IF_ERROR(_calc_filter_for_other_conjunct(chunk, filter, filter_all, hit_all));
     _process_row_for_other_conjunct(chunk, start_column, column_count, filter_all, hit_all, filter);
 
     _ht.remove_duplicate_index(&filter);
     (*chunk)->filter(filter);
+
+    return Status::OK();
 }
 
-void HashJoinNode::_process_semi_join_with_other_conjunct(ChunkPtr* chunk) {
+Status HashJoinNode::_process_semi_join_with_other_conjunct(ChunkPtr* chunk) {
     bool filter_all = false;
     bool hit_all = false;
     Column::Filter filter;
 
-    _calc_filter_for_other_conjunct(chunk, filter, filter_all, hit_all);
+    RETURN_IF_ERROR(_calc_filter_for_other_conjunct(chunk, filter, filter_all, hit_all));
 
     _ht.remove_duplicate_index(&filter);
     (*chunk)->filter(filter);
+
+    return Status::OK();
 }
 
-void HashJoinNode::_process_right_anti_join_with_other_conjunct(ChunkPtr* chunk) {
+Status HashJoinNode::_process_right_anti_join_with_other_conjunct(ChunkPtr* chunk) {
     bool filter_all = false;
     bool hit_all = false;
     Column::Filter filter;
 
-    _calc_filter_for_other_conjunct(chunk, filter, filter_all, hit_all);
+    RETURN_IF_ERROR(_calc_filter_for_other_conjunct(chunk, filter, filter_all, hit_all));
 
     _ht.remove_duplicate_index(&filter);
     (*chunk)->set_num_rows(0);
+
+    return Status::OK();
 }
 
-void HashJoinNode::_process_other_conjunct(ChunkPtr* chunk) {
+Status HashJoinNode::_process_other_conjunct(ChunkPtr* chunk) {
     switch (_join_type) {
     case TJoinOp::LEFT_OUTER_JOIN:
     case TJoinOp::FULL_OUTER_JOIN:
-        _process_outer_join_with_other_conjunct(chunk, _probe_column_count, _build_column_count);
-        break;
+        return _process_outer_join_with_other_conjunct(chunk, _probe_column_count, _build_column_count);
     case TJoinOp::RIGHT_OUTER_JOIN:
     case TJoinOp::LEFT_SEMI_JOIN:
     case TJoinOp::LEFT_ANTI_JOIN:
     case TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN:
     case TJoinOp::RIGHT_SEMI_JOIN:
-        _process_semi_join_with_other_conjunct(chunk);
-        break;
+        return _process_semi_join_with_other_conjunct(chunk);
     case TJoinOp::RIGHT_ANTI_JOIN:
-        _process_right_anti_join_with_other_conjunct(chunk);
-        break;
+        return _process_right_anti_join_with_other_conjunct(chunk);
     default:
         // the other join conjunct for inner join will be convert to other predicate
         // so can't reach here
-        eval_conjuncts(_other_join_conjunct_ctxs, (*chunk).get());
+        return eval_conjuncts(_other_join_conjunct_ctxs, (*chunk).get());
     }
 }
 

--- a/be/src/exec/vectorized/hash_join_node.h
+++ b/be/src/exec/vectorized/hash_join_node.h
@@ -59,16 +59,16 @@ private:
     Status _probe(RuntimeState* state, ScopedTimer<MonotonicStopWatch>& probe_timer, ChunkPtr* chunk, bool& eos);
     Status _probe_remain(ChunkPtr* chunk, bool& eos);
 
-    void _evaluate_build_keys(const ChunkPtr& chunk);
+    Status _evaluate_build_keys(const ChunkPtr& chunk);
 
-    void _calc_filter_for_other_conjunct(ChunkPtr* chunk, Column::Filter& filter, bool& filter_all, bool& hit_all);
+    Status _calc_filter_for_other_conjunct(ChunkPtr* chunk, Column::Filter& filter, bool& filter_all, bool& hit_all);
     static void _process_row_for_other_conjunct(ChunkPtr* chunk, size_t start_column, size_t column_count,
                                                 bool filter_all, bool hit_all, const Column::Filter& filter);
 
-    void _process_outer_join_with_other_conjunct(ChunkPtr* chunk, size_t start_column, size_t column_count);
-    void _process_semi_join_with_other_conjunct(ChunkPtr* chunk);
-    void _process_right_anti_join_with_other_conjunct(ChunkPtr* chunk);
-    void _process_other_conjunct(ChunkPtr* chunk);
+    Status _process_outer_join_with_other_conjunct(ChunkPtr* chunk, size_t start_column, size_t column_count);
+    Status _process_semi_join_with_other_conjunct(ChunkPtr* chunk);
+    Status _process_right_anti_join_with_other_conjunct(ChunkPtr* chunk);
+    Status _process_other_conjunct(ChunkPtr* chunk);
 
     Status _do_publish_runtime_filters(RuntimeState* state, int64_t limit);
     Status _push_down_in_filter(RuntimeState* state);

--- a/be/src/exec/vectorized/hdfs_scan_node.h
+++ b/be/src/exec/vectorized/hdfs_scan_node.h
@@ -76,8 +76,8 @@ private:
     void _decompose_conjunct_ctxs();
 
     Status _start_scan_thread(RuntimeState* state);
-    void _init_partition_values_map();
-    bool _filter_partition(const std::vector<ExprContext*>& partition_exprs);
+    Status _init_partition_values_map();
+    StatusOr<bool> _filter_partition(const std::vector<ExprContext*>& partition_exprs);
     Status _find_and_insert_hdfs_file(const THdfsScanRange& scan_range);
     Status _create_and_init_scanner(RuntimeState* state, const HdfsFileDesc& hdfs_file_desc);
 

--- a/be/src/exec/vectorized/hdfs_scanner.h
+++ b/be/src/exec/vectorized/hdfs_scanner.h
@@ -230,7 +230,7 @@ private:
     bool _is_open = false;
     bool _is_closed = false;
     bool _keep_priority = false;
-    void _build_file_read_param();
+    Status _build_file_read_param();
     MonotonicStopWatch _pending_queue_sw;
     void update_hdfs_counter(HdfsScanProfile* profile);
 

--- a/be/src/exec/vectorized/intersect_hash_set.cpp
+++ b/be/src/exec/vectorized/intersect_hash_set.cpp
@@ -104,7 +104,7 @@ size_t IntersectHashSet<HashSet>::_get_max_serialize_size(const ChunkPtr& chunkP
                                                           const std::vector<ExprContext*>& exprs) {
     size_t max_size = 0;
     for (auto* expr : exprs) {
-        ColumnPtr key_column = expr->evaluate(chunkPtr.get());
+        ColumnPtr key_column = EVALUATE_NULL_IF_ERROR(expr, expr->root(), chunkPtr.get());
         max_size += key_column->max_one_element_serialize_size();
         if (!key_column->is_nullable()) {
             max_size += sizeof(bool);
@@ -117,7 +117,7 @@ template <typename HashSet>
 void IntersectHashSet<HashSet>::_serialize_columns(const ChunkPtr& chunkPtr, const std::vector<ExprContext*>& exprs,
                                                    size_t chunk_size) {
     for (auto expr : exprs) {
-        ColumnPtr key_column = expr->evaluate(chunkPtr.get());
+        ColumnPtr key_column = EVALUATE_NULL_IF_ERROR(expr, expr->root(), chunkPtr.get());
 
         // The serialized buffer is always nullable.
         if (key_column->is_nullable()) {

--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -74,7 +74,7 @@ Status OlapScanNode::open(RuntimeState* state) {
     RETURN_IF_ERROR(ExecNode::open(state));
 
     Status status;
-    OlapScanConjunctsManager::eval_const_conjuncts(_conjunct_ctxs, &status);
+    RETURN_IF_ERROR(OlapScanConjunctsManager::eval_const_conjuncts(_conjunct_ctxs, &status));
     _update_status(status);
 
     _dict_optimize_parser.set_mutable_dict_maps(state, state->mutable_query_global_dict_map());

--- a/be/src/exec/vectorized/olap_scan_prepare.h
+++ b/be/src/exec/vectorized/olap_scan_prepare.h
@@ -36,7 +36,7 @@ private:
     std::map<int, std::vector<ExprContext*>> slot_index_to_expr_ctxs; // from conjunct_ctxs
 
 public:
-    static void eval_const_conjuncts(const std::vector<ExprContext*>& conjunct_ctxs, Status* status);
+    static Status eval_const_conjuncts(const std::vector<ExprContext*>& conjunct_ctxs, Status* status);
 
     Status get_column_predicates(PredicateParser* parser, std::vector<std::unique_ptr<ColumnPredicate>>* preds);
 

--- a/be/src/exec/vectorized/parquet_scanner.cpp
+++ b/be/src/exec/vectorized/parquet_scanner.cpp
@@ -131,8 +131,7 @@ Status ParquetScanner::finalize_src_chunk(ChunkPtr* chunk) {
                                    cast_chunk->num_rows());
         }
     }
-
-    auto dest_chunk = materialize(*chunk, cast_chunk);
+    ASSIGN_OR_RETURN(auto dest_chunk, materialize(*chunk, cast_chunk));
     *chunk = dest_chunk;
     _chunk_start_idx = 0;
     return Status::OK();

--- a/be/src/exec/vectorized/schema_scan_node.cpp
+++ b/be/src/exec/vectorized/schema_scan_node.cpp
@@ -235,7 +235,7 @@ Status SchemaScanNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos)
         {
             SCOPED_TIMER(_filter_timer);
             if (!_conjunct_ctxs.empty()) {
-                ExecNode::eval_conjuncts(_conjunct_ctxs, chunk_dst.get());
+                RETURN_IF_ERROR(ExecNode::eval_conjuncts(_conjunct_ctxs, chunk_dst.get()));
             }
         }
         row_num = chunk_dst->num_rows();

--- a/be/src/exec/vectorized/tablet_scanner.cpp
+++ b/be/src/exec/vectorized/tablet_scanner.cpp
@@ -267,7 +267,7 @@ Status TabletScanner::get_chunk(RuntimeState* state, Chunk* chunk) {
         }
         if (!_conjunct_ctxs.empty()) {
             SCOPED_TIMER(_expr_filter_timer);
-            ExecNode::eval_conjuncts(_conjunct_ctxs, chunk);
+            RETURN_IF_ERROR(ExecNode::eval_conjuncts(_conjunct_ctxs, chunk));
             DCHECK_CHUNK(chunk);
         }
         TRY_CATCH_ALLOC_SCOPE_END()

--- a/be/src/exec/vectorized/topn_node.cpp
+++ b/be/src/exec/vectorized/topn_node.cpp
@@ -169,9 +169,10 @@ Status TopNNode::_consume_chunks(RuntimeState* state, ExecNode* child) {
         }
         timer.start();
         if (chunk != nullptr && chunk->num_rows() > 0) {
-            ChunkPtr materialize_chunk = ChunksSorter::materialize_chunk_before_sort(
-                    chunk.get(), _materialized_tuple_desc, _sort_exec_exprs, _order_by_types);
-            TRY_CATCH_BAD_ALLOC(RETURN_IF_ERROR(_chunks_sorter->update(state, materialize_chunk)));
+            auto materialize_chunk = ChunksSorter::materialize_chunk_before_sort(chunk.get(), _materialized_tuple_desc,
+                                                                                 _sort_exec_exprs, _order_by_types);
+            RETURN_IF_ERROR(materialize_chunk);
+            TRY_CATCH_BAD_ALLOC(RETURN_IF_ERROR(_chunks_sorter->update(state, materialize_chunk.value())));
         }
     } while (!eos);
 

--- a/be/src/exec/vectorized/union_node.cpp
+++ b/be/src/exec/vectorized/union_node.cpp
@@ -262,7 +262,7 @@ void UnionNode::_move_passthrough_chunk(ChunkPtr& src_chunk, ChunkPtr& dest_chun
 Status UnionNode::_move_materialize_chunk(ChunkPtr& src_chunk, ChunkPtr& dest_chunk) {
     for (size_t i = 0; i < _child_expr_lists[_child_idx].size(); i++) {
         auto* dest_slot = _tuple_desc->slots()[i];
-        ColumnPtr column = _child_expr_lists[_child_idx][i]->evaluate(src_chunk.get());
+        ASSIGN_OR_RETURN(ColumnPtr column, _child_expr_lists[_child_idx][i]->evaluate(src_chunk.get()));
         _move_column(dest_chunk, column, dest_slot, src_chunk->num_rows());
     }
     RETURN_IF_HAS_ERROR(_child_expr_lists[_child_idx]);
@@ -271,7 +271,7 @@ Status UnionNode::_move_materialize_chunk(ChunkPtr& src_chunk, ChunkPtr& dest_ch
 
 Status UnionNode::_move_const_chunk(ChunkPtr& dest_chunk) {
     for (size_t i = 0; i < _const_expr_lists[_const_expr_list_idx].size(); i++) {
-        ColumnPtr column = _const_expr_lists[_const_expr_list_idx][i]->evaluate(nullptr);
+        ASSIGN_OR_RETURN(ColumnPtr column, _const_expr_lists[_const_expr_list_idx][i]->evaluate(nullptr));
         auto* dest_slot = _tuple_desc->slots()[i];
 
         _move_column(dest_chunk, column, dest_slot, 1);

--- a/be/src/exprs/expr.cpp
+++ b/be/src/exprs/expr.cpp
@@ -586,12 +586,12 @@ void Expr::close(const std::vector<Expr*>& exprs) {
     for (Expr* expr : exprs) expr->close();
 }
 
-ColumnPtr Expr::evaluate_const(ExprContext* context) {
+StatusOr<ColumnPtr> Expr::evaluate_const(ExprContext* context) {
     if (!is_constant()) {
         return nullptr;
     }
 
-    if (_constant_column) {
+    if (_constant_column.ok() && _constant_column.value()) {
         return _constant_column;
     }
 

--- a/be/src/exprs/expr.h
+++ b/be/src/exprs/expr.h
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "column/chunk.h"
+#include "column/vectorized_fwd.h"
 #include "common/status.h"
 #include "exprs/expr_context.h"
 #include "gen_cpp/Opcodes_types.h"
@@ -187,7 +188,7 @@ public:
     static Expr* copy(ObjectPool* pool, Expr* old_expr);
 
     // for vector query engine
-    virtual ColumnPtr evaluate_const(ExprContext* context);
+    virtual StatusOr<ColumnPtr> evaluate_const(ExprContext* context);
 
     virtual ColumnPtr evaluate(ExprContext* context, vectorized::Chunk* ptr);
 
@@ -274,7 +275,7 @@ protected:
     int _fn_context_index;
 
     std::once_flag _constant_column_evaluate_once;
-    ColumnPtr _constant_column;
+    StatusOr<ColumnPtr> _constant_column = Status::OK();
 
     /// Simple debug string that provides no expr subclass-specific information
     std::string debug_string(const std::string& expr_name) const {

--- a/be/src/exprs/expr_context.cpp
+++ b/be/src/exprs/expr_context.cpp
@@ -26,6 +26,7 @@
 #include <memory>
 #include <sstream>
 
+#include "common/statusor.h"
 #include "exprs/expr.h"
 #include "exprs/vectorized/column_ref.h"
 #include "runtime/mem_pool.h"
@@ -178,11 +179,11 @@ std::string ExprContext::get_error_msg() const {
     return "";
 }
 
-ColumnPtr ExprContext::evaluate(vectorized::Chunk* chunk) {
+StatusOr<ColumnPtr> ExprContext::evaluate(vectorized::Chunk* chunk) {
     return evaluate(_root, chunk);
 }
 
-ColumnPtr ExprContext::evaluate(Expr* e, vectorized::Chunk* chunk) {
+StatusOr<ColumnPtr> ExprContext::evaluate(Expr* e, vectorized::Chunk* chunk) {
 #ifndef NDEBUG
     if (chunk != nullptr) {
         chunk->check_or_die();

--- a/be/src/exprs/vectorized/java_function_call_expr.cpp
+++ b/be/src/exprs/vectorized/java_function_call_expr.cpp
@@ -219,7 +219,8 @@ Status JavaFunctionCallExpr::open(RuntimeState* state, ExprContext* context,
     if (scope == FunctionContext::FRAGMENT_LOCAL) {
         const_columns.reserve(_children.size());
         for (const auto& child : _children) {
-            const_columns.emplace_back(child->evaluate_const(context));
+            ASSIGN_OR_RETURN(auto&& child_col, child->evaluate_const(context))
+            const_columns.emplace_back(std::move(child_col));
         }
     }
     auto open_state = [this, scope]() {

--- a/be/src/exprs/vectorized/runtime_filter_bank.cpp
+++ b/be/src/exprs/vectorized/runtime_filter_bank.cpp
@@ -260,7 +260,8 @@ void RuntimeFilterProbeCollector::do_evaluate(vectorized::Chunk* chunk, RuntimeB
             RuntimeFilterProbeDescriptor* rf_desc = kv.second;
             const JoinRuntimeFilter* filter = rf_desc->runtime_filter();
             if (filter == nullptr) continue;
-            ColumnPtr column = rf_desc->probe_expr_ctx()->evaluate(chunk);
+            auto* ctx = rf_desc->probe_expr_ctx();
+            ColumnPtr column = EVALUATE_NULL_IF_ERROR(ctx, ctx->root(), chunk);
             vectorized::Column::Filter& selection = filter->evaluate(column.get(), &eval_context.running_context);
             eval_context.run_filter_nums += 1;
             size_t true_count = SIMD::count_nonzero(selection);
@@ -317,7 +318,8 @@ void RuntimeFilterProbeCollector::update_selectivity(vectorized::Chunk* chunk,
         RuntimeFilterProbeDescriptor* rf_desc = it.second;
         const JoinRuntimeFilter* filter = rf_desc->runtime_filter();
         if (filter == nullptr) continue;
-        ColumnPtr column = rf_desc->probe_expr_ctx()->evaluate(chunk);
+        auto ctx = rf_desc->probe_expr_ctx();
+        ColumnPtr column = EVALUATE_NULL_IF_ERROR(ctx, ctx->root(), chunk);
         vectorized::Column::Filter& new_selection = filter->evaluate(column.get(), &eval_context.running_context);
         eval_context.run_filter_nums += 1;
         size_t true_count = SIMD::count_nonzero(new_selection);

--- a/be/src/exprs/vectorized/runtime_filter_bank.h
+++ b/be/src/exprs/vectorized/runtime_filter_bank.h
@@ -170,6 +170,7 @@ public:
 private:
     void update_selectivity(vectorized::Chunk* chunk);
     void update_selectivity(vectorized::Chunk* chunk, RuntimeBloomFilterEvalContext& eval_context);
+    // TODO: return a funcion call status
     void do_evaluate(vectorized::Chunk* chunk);
     void do_evaluate(vectorized::Chunk* chunk, RuntimeBloomFilterEvalContext& eval_context);
     // mapping from filter id to runtime filter descriptor.

--- a/be/src/runtime/data_stream_sender.cpp
+++ b/be/src/runtime/data_stream_sender.cpp
@@ -586,7 +586,7 @@ Status DataStreamSender::send_chunk(RuntimeState* state, vectorized::Chunk* chun
         {
             SCOPED_TIMER(_shuffle_hash_timer);
             for (size_t i = 0; i < _partitions_columns.size(); ++i) {
-                _partitions_columns[i] = _partition_expr_ctxs[i]->evaluate(chunk);
+                ASSIGN_OR_RETURN(_partitions_columns[i], _partition_expr_ctxs[i]->evaluate(chunk));
                 DCHECK(_partitions_columns[i] != nullptr);
             }
 

--- a/be/src/runtime/global_dicts.cpp
+++ b/be/src/runtime/global_dicts.cpp
@@ -196,7 +196,7 @@ Status DictOptimizeParser::eval_expression(ExprContext* expr_ctx, DictOptimizeCo
     ChunkPtr temp_chunk = std::make_shared<Chunk>();
     temp_chunk->append_column(binary_column, expr_slot_id);
     // call inner expr with input column
-    auto result_column = expr_ctx->evaluate(origin_expr, temp_chunk.get());
+    ASSIGN_OR_RETURN(auto result_column, expr_ctx->evaluate(origin_expr, temp_chunk.get()));
     // assign convert mapping column
     dict_opt_ctx->convert_column = result_column;
     // build code convert map

--- a/be/src/runtime/mysql_result_writer.cpp
+++ b/be/src/runtime/mysql_result_writer.cpp
@@ -110,7 +110,7 @@ StatusOr<TFetchDataResultPtr> MysqlResultWriter::process_chunk(vectorized::Chunk
     result_columns.reserve(num_columns);
 
     for (int i = 0; i < num_columns; ++i) {
-        ColumnPtr column = _output_expr_ctxs[i]->evaluate(chunk);
+        ASSIGN_OR_RETURN(ColumnPtr column, _output_expr_ctxs[i]->evaluate(chunk));
         column = _output_expr_ctxs[i]->root()->type().type == TYPE_TIME
                          ? vectorized::ColumnHelper::convert_time_column_from_double_to_str(column)
                          : column;

--- a/be/src/runtime/mysql_table_writer.cpp
+++ b/be/src/runtime/mysql_table_writer.cpp
@@ -193,7 +193,7 @@ Status MysqlTableWriter::append(vectorized::Chunk* chunk) {
     // eval output expr
     vectorized::Columns result_columns(_output_expr_ctxs.size());
     for (int i = 0; i < _output_expr_ctxs.size(); ++i) {
-        result_columns[i] = _output_expr_ctxs[i]->evaluate(chunk);
+        ASSIGN_OR_RETURN(result_columns[i], _output_expr_ctxs[i]->evaluate(chunk));
     }
 
     RETURN_IF_ERROR(_build_viewers(result_columns));

--- a/be/src/runtime/vectorized/chunk_cursor.cpp
+++ b/be/src/runtime/vectorized/chunk_cursor.cpp
@@ -143,7 +143,8 @@ void ChunkCursor::_reset_with_next_chunk() {
     // prepare order by columns
     _current_order_by_columns.reserve(_sort_exprs->size());
     for (ExprContext* expr_ctx : *_sort_exprs) {
-        _current_order_by_columns.push_back(expr_ctx->evaluate(_current_chunk.get()));
+        auto col = EVALUATE_NULL_IF_ERROR(expr_ctx, expr_ctx->root(), _current_chunk.get());
+        _current_order_by_columns.push_back(std::move(col));
     }
 }
 
@@ -159,7 +160,8 @@ void ChunkCursor::reset_with_next_chunk_for_pipeline() {
     // prepare order by columns
     _current_order_by_columns.reserve(_sort_exprs->size());
     for (ExprContext* expr_ctx : *_sort_exprs) {
-        _current_order_by_columns.push_back(expr_ctx->evaluate(_current_chunk.get()));
+        auto col = EVALUATE_NULL_IF_ERROR(expr_ctx, expr_ctx->root(), _current_chunk.get());
+        _current_order_by_columns.push_back(std::move(col));
     }
 }
 

--- a/be/src/runtime/vectorized/statistic_result_writer.cpp
+++ b/be/src/runtime/vectorized/statistic_result_writer.cpp
@@ -49,7 +49,8 @@ Status StatisticResultWriter::append_chunk(vectorized::Chunk* chunk) {
     result_columns.reserve(num_columns);
 
     for (int i = 0; i < num_columns; ++i) {
-        result_columns.emplace_back(_output_expr_ctxs[i]->evaluate(chunk));
+        ASSIGN_OR_RETURN(auto col, _output_expr_ctxs[i]->evaluate(chunk));
+        result_columns.emplace_back(std::move(col));
     }
 
     // Step 2: fill version magic_num, first column must be version(const int)

--- a/be/src/storage/column_expr_predicate.cpp
+++ b/be/src/storage/column_expr_predicate.cpp
@@ -58,7 +58,7 @@ void ColumnExprPredicate::evaluate(const Column* column, uint8_t* selection, uin
     for (int i = _expr_ctxs.size() - 1; i >= 0; i--) {
         ExprContext* ctx = _expr_ctxs[i];
         chunk.update_column(bits, _slot_desc->id());
-        bits = ctx->evaluate(&chunk);
+        bits = EVALUATE_NULL_IF_ERROR(ctx, ctx->root(), &chunk);
     }
 
     // deal with constant.


### PR DESCRIPTION
…text

## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [x] others

## Which issues of this PR fixes ：
Fixes #4777 

## Problem Summary(Required) ：
after this PR There are three cases where evaluate does not handle the return value when executing an error. we use a 
1. push down Expr to Storage Layter: (It's hard to return a Status code in ColumnExprPredicate), so we will return a const null value when we handle ExprPredicate
2. RuntimeFilter. I need do more test.
3. OrcRowReaderFilter: OrcRowReaderFilter implements the interface of RowReaderFilter. we couldn't change the return type.
