### PR TITLE
Support parquet timestamp stored as Int64

### DIFF
--- a/be/src/exec/parquet/schema.cpp
+++ b/be/src/exec/parquet/schema.cpp
@@ -64,8 +64,8 @@ static int schema_num_children(const tparquet::SchemaElement& schema) {
 void SchemaDescriptor::leaf_to_field(const tparquet::SchemaElement& t_schema, const LevelInfo& cur_level_info,
                                      bool is_nullable, ParquetField* field) {
     field->name = t_schema.name;
+    field->schema_element = t_schema;
     field->is_nullable = is_nullable;
-    field->logical_type = t_schema.logicalType;
     field->physical_type = t_schema.type;
     field->type_length = t_schema.type_length;
     field->scale = t_schema.scale;

--- a/be/src/exec/parquet/schema.cpp
+++ b/be/src/exec/parquet/schema.cpp
@@ -65,6 +65,7 @@ void SchemaDescriptor::leaf_to_field(const tparquet::SchemaElement& t_schema, co
                                      bool is_nullable, ParquetField* field) {
     field->name = t_schema.name;
     field->is_nullable = is_nullable;
+    field->logical_type = t_schema.logicalType;
     field->physical_type = t_schema.type;
     field->type_length = t_schema.type_length;
     field->scale = t_schema.scale;

--- a/be/src/exec/parquet/schema.h
+++ b/be/src/exec/parquet/schema.h
@@ -38,6 +38,7 @@ struct ParquetField {
     TypeDescriptor type;
     bool is_nullable;
 
+    tparquet::LogicalType logical_type;
     // Only valid when this field is a leaf node
     tparquet::Type::type physical_type;
     // If type is FIXED_LEN_BYTE_ARRAY, this is the byte length of the vales.

--- a/be/src/exec/parquet/schema.h
+++ b/be/src/exec/parquet/schema.h
@@ -33,12 +33,12 @@ struct LevelInfo {
 
 struct ParquetField {
     std::string name;
+    tparquet::SchemaElement schema_element;
 
     // Used to identify if this field is a nested field.
     TypeDescriptor type;
     bool is_nullable;
 
-    tparquet::LogicalType logical_type;
     // Only valid when this field is a leaf node
     tparquet::Type::type physical_type;
     // If type is FIXED_LEN_BYTE_ARRAY, this is the byte length of the vales.

--- a/be/src/runtime/vectorized/time_types.h
+++ b/be/src/runtime/vectorized/time_types.h
@@ -12,7 +12,7 @@ namespace vectorized {
 // MAX USE 22 bits
 typedef int32_t JulianDate;
 
-// Timestamp: {Jualian Date}{microsecond in one day, 0 ~ 86400000000}
+// Timestamp: {Julian Date}{microsecond in one day, 0 ~ 86400000000}
 // JulianDate use high 22 bits, microsecond use low 40 bits
 typedef int64_t Timestamp;
 

--- a/be/src/runtime/vectorized/time_types.h
+++ b/be/src/runtime/vectorized/time_types.h
@@ -47,6 +47,8 @@ static const int64_t USECS_PER_HOUR = 3600000000;
 static const int64_t USECS_PER_MINUTE = 60000000;
 static const int64_t USECS_PER_SEC = 1000000;
 
+static const int64_t NANOSECS_PER_USEC = 1000;
+
 // Corresponding to TimeUnit
 static constexpr int64_t USECS_PER_UNIT[] = {
         1,                // Microsecond
@@ -177,6 +179,8 @@ public:
     static int to_string(Timestamp timestamp, char* s, size_t n);
 
     inline static double time_to_literal(double time);
+
+    inline static Timestamp of_epoch_second(int seconds, int microseconds);
 
 public:
     // MAX_DATE | USECS_PER_DAY
@@ -342,6 +346,13 @@ double timestamp::time_to_literal(double time) {
     uint64_t minute = t / 60 % 60;
     uint64_t second = t % 60;
     return hour * 10000 + minute * 100 + second;
+}
+
+Timestamp timestamp::of_epoch_second(int seconds, int nanoseconds) {
+    int days = seconds / SECS_PER_DAY;
+    JulianDate jd = days + date::UNIX_EPOCH_JULIAN;
+    return timestamp::from_julian_and_time(jd,
+                                           seconds % SECS_PER_DAY * USECS_PER_SEC + nanoseconds / NANOSECS_PER_USEC);
 }
 
 struct JulianToDateEntry {


### PR DESCRIPTION
Signed-off-by: dorianzheng <xingzhengde72@gmail.com>

## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/4398

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This patch enables StarRocks to start reading timestamps from Parquet written with the new semantics:

With Parquet version 1.11, a new timestamp LogicalType with base INT64 and the following metadata is introduced:

- boolean isAdjustedToUtc: marks whether the timestamp is converted to UTC (aka Instant semantics) or not (LocalDateTime semantics).
- enum TimeUnit (NANOS, MICROS, MILLIS): granularity of timestamp

Upon reading, the semantics of these new timestamps will be determined by their metadata, while the semantics of INT96 timestamps will continue to be deduced from the writer metadata.