### PR TITLE
[cleanup] remove SlotRef dependency in UT

### DIFF
--- a/be/src/exprs/vectorized/column_ref.cpp
+++ b/be/src/exprs/vectorized/column_ref.cpp
@@ -2,12 +2,16 @@
 
 #include "exprs/vectorized/column_ref.h"
 
+#include "exprs/expr.h"
+
 namespace starrocks::vectorized {
 
 ColumnRef::ColumnRef(const TExprNode& node)
         : Expr(node, true), _column_id(node.slot_ref.slot_id), _tuple_id(node.slot_ref.tuple_id) {}
 
 ColumnRef::ColumnRef(const SlotDescriptor* desc) : Expr(desc->type(), true), _column_id(desc->id()) {}
+
+ColumnRef::ColumnRef(const TypeDescriptor& type, SlotId slot) : Expr(type, true), _column_id(slot) {}
 
 int ColumnRef::get_slot_ids(std::vector<SlotId>* slot_ids) const {
     slot_ids->push_back(_column_id);

--- a/be/src/exprs/vectorized/column_ref.h
+++ b/be/src/exprs/vectorized/column_ref.h
@@ -14,6 +14,9 @@ public:
 
     ColumnRef(const SlotDescriptor* desc);
 
+    // only used for UT
+    ColumnRef(const TypeDescriptor& type, SlotId slot = -1);
+
     SlotId slot_id() const { return _column_id; }
 
     TupleId tuple_id() const { return _tuple_id; }

--- a/be/test/exec/vectorized/chunks_sorter_bench_test.cpp
+++ b/be/test/exec/vectorized/chunks_sorter_bench_test.cpp
@@ -12,7 +12,7 @@
 #include "exec/vectorized/chunks_sorter.h"
 #include "exec/vectorized/chunks_sorter_full_sort.h"
 #include "exec/vectorized/chunks_sorter_topn.h"
-#include "exprs/slot_ref.h"
+#include "exprs/vectorized/column_ref.h"
 #include "runtime/runtime_state.h"
 #include "runtime/types.h"
 
@@ -30,12 +30,12 @@ public:
 
     void TearDown() { _runtime_state.reset(); }
 
-    static std::tuple<ColumnPtr, std::unique_ptr<SlotRef>> build_column(TypeDescriptor type_desc, int slot_index,
-                                                                        bool low_card, bool nullable) {
+    static std::tuple<ColumnPtr, std::unique_ptr<ColumnRef>> build_column(TypeDescriptor type_desc, int slot_index,
+                                                                          bool low_card, bool nullable) {
         using UniformInt = std::uniform_int_distribution<std::mt19937::result_type>;
         using PoissonInt = std::poisson_distribution<std::mt19937::result_type>;
         ColumnPtr column = ColumnHelper::create_column(type_desc, nullable);
-        auto expr = std::make_unique<SlotRef>(type_desc, 0, slot_index);
+        auto expr = std::make_unique<ColumnRef>(type_desc, slot_index);
 
         std::random_device dev;
         std::mt19937 rng(dev());
@@ -115,7 +115,7 @@ static void do_bench(benchmark::State& state, SortAlgorithm sorter_algo, Compare
     }
 
     Columns columns;
-    std::vector<std::unique_ptr<SlotRef>> exprs;
+    std::vector<std::unique_ptr<ColumnRef>> exprs;
     std::vector<ExprContext*> sort_exprs;
     std::vector<bool> asc_arr;
     std::vector<bool> null_first;

--- a/be/test/runtime/vectorized/sorted_chunks_merger_test.cpp
+++ b/be/test/runtime/vectorized/sorted_chunks_merger_test.cpp
@@ -7,7 +7,7 @@
 #include "column/column_helper.h"
 #include "column/datum_tuple.h"
 #include "exprs/expr_context.h"
-#include "exprs/slot_ref.h"
+#include "exprs/vectorized/column_ref.h"
 #include "runtime/runtime_state.h"
 
 namespace starrocks::vectorized {
@@ -90,9 +90,9 @@ public:
         _chunk_2 = std::make_shared<Chunk>(columns_2, map);
         _chunk_3 = std::make_shared<Chunk>(columns_3, map);
 
-        auto* expr1 = new SlotRef(TypeDescriptor(TYPE_VARCHAR), 0, 2); // refer to region
-        auto* expr2 = new SlotRef(TypeDescriptor(TYPE_VARCHAR), 0, 1); // refer to nation
-        auto* expr3 = new SlotRef(TypeDescriptor(TYPE_INT), 0, 0);     // refer to cust_key
+        auto* expr1 = new ColumnRef(TypeDescriptor(TYPE_VARCHAR), 2); // refer to region
+        auto* expr2 = new ColumnRef(TypeDescriptor(TYPE_VARCHAR), 1); // refer to nation
+        auto* expr3 = new ColumnRef(TypeDescriptor(TYPE_INT), 0);     // refer to cust_key
         _exprs.push_back(expr1);
         _exprs.push_back(expr2);
         _exprs.push_back(expr3);


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [x] others

## Problem Summary(Required) ：
use `ColumnRef` instead of `SlotRef`. later we will remove class `SlotRef`
