### PR TITLE
Fix schema change bug on duplicate key table when it need final merge

### DIFF
--- a/be/src/storage/rowset/beta_rowset_writer.cpp
+++ b/be/src/storage/rowset/beta_rowset_writer.cpp
@@ -21,6 +21,8 @@
 
 #include "storage/rowset/beta_rowset_writer.h"
 
+#include <fmt/format.h>
+
 #include <ctime>
 #include <memory>
 
@@ -421,19 +423,14 @@ Status HorizontalBetaRowsetWriter::_final_merge() {
     // schema change with sorting create temporary segment files first
     // merge them and create final segment files if _context.write_tmp is true
     if (_context.write_tmp) {
-        if (_context.tablet_schema->keys_type() == KeysType::UNIQUE_KEYS) {
+        if (_context.tablet_schema->keys_type() == KeysType::DUP_KEYS) {
             itr = new_heap_merge_iterator(seg_iterators);
-        } else if (_context.tablet_schema->keys_type() == KeysType::AGG_KEYS) {
+        } else if (_context.tablet_schema->keys_type() == KeysType::UNIQUE_KEYS ||
+                   _context.tablet_schema->keys_type() == KeysType::AGG_KEYS) {
             itr = new_aggregate_iterator(new_heap_merge_iterator(seg_iterators), 0);
         } else {
-            for (int seg_id = 0; seg_id < _num_segment; ++seg_id) {
-                auto old_path =
-                        BetaRowset::segment_temp_file_path(_context.rowset_path_prefix, _context.rowset_id, seg_id);
-                auto new_path = BetaRowset::segment_file_path(_context.rowset_path_prefix, _context.rowset_id, seg_id);
-                RETURN_IF_ERROR_WITH_WARN(_env->rename_file(old_path, new_path), "Fail to rename file");
-            }
-            _context.write_tmp = false;
-            return Status::OK();
+            return Status::NotSupported(fmt::format("HorizontalBetaRowsetWriter not support {} key type final merge",
+                                                    _context.tablet_schema->keys_type()));
         }
         _context.write_tmp = false;
     } else {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4839

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Now sorting schema change will write several tmp segment files if memory is not enough, and final merge tmp segment files into sort segment file. but now on the duplicate key tablet, it just rename tmp segment file.