### PR TITLE
Add [IF EXISTS] support to account management SQL

### DIFF
--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -815,9 +815,9 @@ alter_stmt ::=
     {:
         RESULT = new AlterDatabaseRename(dbName, newDbName);
     :}
-    | KW_ALTER KW_USER grant_user:user
+    | KW_ALTER KW_USER opt_if_exists:ifExists grant_user:user
     {:
-        RESULT = new AlterUserStmt(user);
+        RESULT = new AlterUserStmt(ifExists, user);
     :}
     | KW_ALTER KW_ROUTINE KW_LOAD KW_FOR job_label:jobLabel
       opt_load_property_list:loadPropertyList
@@ -1243,9 +1243,9 @@ create_stmt ::=
     {:
         RESULT = new CreateRepositoryStmt(isReadOnly, repoName, brokerName, location, properties);
     :}
-    | KW_CREATE KW_ROLE ident:role
+    | KW_CREATE KW_ROLE opt_if_not_exists:ifNotExists ident:role
     {:
-        RESULT = new CreateRoleStmt(role);
+        RESULT = new CreateRoleStmt(ifNotExists, role);
     :}
     | KW_CREATE KW_FILE STRING_LITERAL:fileName opt_db:db KW_PROPERTIES LPAREN key_value_map:properties RPAREN
     {:
@@ -1808,9 +1808,9 @@ drop_stmt ::=
         RESULT = new DropTableStmt(ifExists, name, force);
     :}
     /* User */
-    | KW_DROP KW_USER user_identity:userId
+    | KW_DROP KW_USER opt_if_exists:ifExists user_identity:userId
     {:
-        RESULT = new DropUserStmt(userId);
+        RESULT = new DropUserStmt(ifExists, userId);
     :}
     /* View */
     | KW_DROP KW_VIEW opt_if_exists:ifExists table_name:name
@@ -1821,9 +1821,9 @@ drop_stmt ::=
     {:
         RESULT = new DropRepositoryStmt(repoName);
     :}
-    | KW_DROP KW_ROLE ident:role
+    | KW_DROP KW_ROLE opt_if_exists:ifExists ident:role
     {:
-        RESULT = new DropRoleStmt(role);
+        RESULT = new DropRoleStmt(ifExists, role);
     :}
     | KW_DROP KW_FILE STRING_LITERAL:fileName opt_db:dbName KW_PROPERTIES LPAREN key_value_map:properties RPAREN
     {:

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/AlterUserStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/AlterUserStmt.java
@@ -19,6 +19,7 @@ import org.apache.logging.log4j.Logger;
 public class AlterUserStmt extends DdlStmt {
     private static final Logger LOG = LogManager.getLogger(AlterUserStmt.class);
 
+    private boolean ifExists;
     private UserIdentity userIdent;
     private String password;
     private byte[] scramblePassword;
@@ -37,6 +38,17 @@ public class AlterUserStmt extends DdlStmt {
         authPlugin = userDesc.getAuthPlugin();
         authString = userDesc.getAuthString();
     }
+
+    public AlterUserStmt(boolean ifExists, UserDesc userDesc) {
+        this.ifExists = ifExists;
+        userIdent = userDesc.getUserIdent();
+        password = userDesc.getPassword();
+        isPasswordPlain = userDesc.isPasswordPlain();
+        authPlugin = userDesc.getAuthPlugin();
+        authString = userDesc.getAuthString();
+    }
+
+    public boolean isSetIfExists() { return ifExists; }
 
     public byte[] getPassword() {
         return scramblePassword;

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/CreateRoleStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/CreateRoleStmt.java
@@ -32,10 +32,20 @@ import com.starrocks.qe.ConnectContext;
 
 public class CreateRoleStmt extends DdlStmt {
 
+    private boolean ifNotExists;
     private String role;
 
     public CreateRoleStmt(String role) {
         this.role = role;
+    }
+
+    public CreateRoleStmt(boolean ifNotExists, String role) {
+        this.ifNotExists = ifNotExists;
+        this.role = role;
+    }
+
+    public boolean isSetIfNotExists() {
+        return ifNotExists;
     }
 
     public String getQualifiedRole() {

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/DropRoleStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/DropRoleStmt.java
@@ -32,10 +32,20 @@ import com.starrocks.qe.ConnectContext;
 
 public class DropRoleStmt extends DdlStmt {
 
+    private boolean ifExists;
     private String role;
 
     public DropRoleStmt(String role) {
         this.role = role;
+    }
+
+    public DropRoleStmt(boolean ifExists, String role) {
+        this.ifExists = ifExists;
+        this.role = role;
+    }
+
+    public boolean isSetIfExists() {
+        return ifExists;
     }
 
     public String getQualifiedRole() {

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/DropUserStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/DropUserStmt.java
@@ -33,10 +33,21 @@ import com.starrocks.qe.ConnectContext;
 // drop user cmy  <==> drop user cmy@'%'
 // drop user cmy@'192.168.1.%'
 public class DropUserStmt extends DdlStmt {
+
+    private boolean ifExists;
     private UserIdentity userIdent;
 
     public DropUserStmt(UserIdentity userIdent) {
         this.userIdent = userIdent;
+    }
+
+    public DropUserStmt(boolean ifExists, UserIdentity userIdent) {
+        this.ifExists = ifExists;
+        this.userIdent = userIdent;
+    }
+
+    public boolean isSetIfExists() {
+        return ifExists;
     }
 
     public UserIdentity getUserIdentity() {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4524

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Add `IF EXISTS` support to following statements:
```
CREATE [IF NOT EXISTS] USER
CREATE [IF NOT EXISTS] ROLE
DROP [IF EXISTS] USER
DROP [IF EXISTS] ROLE
ALTER [IF EXISTS] USER
```

Implementation detail: 

Add `ignoreIfExists` param to `XXinternal`. 

Initially I tried to reuse the `errOnNonExist` params (e.g. `setPasswordInternal`), but even if the `errOnNonExist` is set `false` (e.g. `mysql/priviledge/WhiteList.java:addUserPrivEntriesByResovledIPs`), the related property is set, which is not correct in our case. Is this the desired behavior? So in `alterUser`, I make a special check before `setPasswordInternal`. This is kind of ugly. Any suggestions are welcomed.

P.S. I'm willing to fix the document but I can't find where to go. 