### PR TITLE
Optimized the performance of schema change, improved by 1.42-27 times

### DIFF
--- a/be/src/column/field.h
+++ b/be/src/column/field.h
@@ -117,6 +117,9 @@ public:
     bool is_key() const;
     void set_is_key(bool is_key);
 
+    int32_t length() const { return _length; }
+    void set_length(int32_t l) { _length = l; }
+
     uint8_t short_key_length() const { return _short_key_length; }
     void set_short_key_length(uint8_t n) { _short_key_length = n; }
 
@@ -156,6 +159,7 @@ private:
     CString _name;
     TypeInfoPtr _type = nullptr;
     std::vector<Field>* _sub_fields;
+    int32_t _length = 0;
     uint8_t _short_key_length;
     uint8_t _flags;
 };

--- a/be/src/column/schema.cpp
+++ b/be/src/column/schema.cpp
@@ -6,7 +6,14 @@
 
 namespace starrocks::vectorized {
 
-Schema::Schema(Fields fields) : _fields(std::move(fields)) {
+#ifdef BE_TEST
+
+Schema::Schema(Fields fields) : Schema(fields, KeysType::DUP_KEYS) {}
+
+#endif
+
+Schema::Schema(Fields fields, KeysType keys_type)
+        : _fields(std::move(fields)), _keys_type(static_cast<uint8_t>(keys_type)) {
     auto is_key = [](const FieldPtr& f) { return f->is_key(); };
     _num_keys = std::count_if(_fields.begin(), _fields.end(), is_key);
     _build_index_map(_fields);

--- a/be/src/column/schema.h
+++ b/be/src/column/schema.h
@@ -6,6 +6,7 @@
 #include <utility>
 
 #include "column/field.h"
+#include "gen_cpp/olap_file.pb.h"
 
 namespace starrocks::vectorized {
 
@@ -13,7 +14,11 @@ class Schema {
 public:
     Schema() = default;
 
+#ifdef BE_TEST
     explicit Schema(Fields fields);
+#endif
+
+    explicit Schema(Fields fields, KeysType keys_type);
 
     size_t num_fields() const { return _fields.size(); }
 
@@ -61,12 +66,15 @@ public:
         new_schema->_name_to_index = _name_to_index;
     }
 
+    KeysType keys_type() const { return static_cast<KeysType>(_keys_type); }
+
 private:
     void _build_index_map(const Fields& fields);
 
     Fields _fields;
     size_t _num_keys = 0;
     std::unordered_map<std::string_view, size_t> _name_to_index;
+    uint8_t _keys_type = static_cast<uint8_t>(DUP_KEYS);
 };
 
 inline std::ostream& operator<<(std::ostream& os, const Schema& schema) {

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -696,6 +696,10 @@ CONF_Int64(deliver_broadcast_rf_passthrough_bytes_limit, "131072");
 // in passthrough style, the number of inflight RPCs of parallel deliveries are issued is not exceeds this limit.
 CONF_Int64(deliver_broadcast_rf_passthrough_inflight_num, "10");
 CONF_Int64(send_rpc_runtime_filter_timeout_ms, "1000");
+
+// enable optimized implementation of schema change
+CONF_Bool(enable_schema_change_v2, "true");
+
 } // namespace config
 
 } // namespace starrocks

--- a/be/src/storage/chunk_helper.cpp
+++ b/be/src/storage/chunk_helper.cpp
@@ -20,6 +20,7 @@ vectorized::Field ChunkHelper::convert_field(ColumnId id, const TabletColumn& c)
     f.set_is_key(c.is_key());
     f.set_short_key_length(c.index_length());
     f.set_aggregate_method(c.aggregation());
+    f.set_length(c.length());
     return f;
 }
 
@@ -29,7 +30,7 @@ vectorized::Schema ChunkHelper::convert_schema(const starrocks::TabletSchema& sc
         auto f = convert_field(cid, schema.column(cid));
         fields.emplace_back(std::make_shared<starrocks::vectorized::Field>(std::move(f)));
     }
-    return starrocks::vectorized::Schema(std::move(fields));
+    return starrocks::vectorized::Schema(std::move(fields), schema.keys_type());
 }
 
 starrocks::vectorized::Field ChunkHelper::convert_field_to_format_v2(ColumnId id, const TabletColumn& c) {
@@ -47,6 +48,7 @@ starrocks::vectorized::Field ChunkHelper::convert_field_to_format_v2(ColumnId id
     }
     starrocks::vectorized::Field f(id, std::string(c.name()), type_info, c.is_nullable());
     f.set_is_key(c.is_key());
+    f.set_length(c.length());
 
     if (type == OLAP_FIELD_TYPE_ARRAY) {
         const TabletColumn& sub_column = c.subcolumn(0);
@@ -73,7 +75,7 @@ starrocks::vectorized::Schema ChunkHelper::convert_schema_to_format_v2(const sta
         auto f = convert_field_to_format_v2(cid, schema.column(cid));
         fields.emplace_back(std::make_shared<starrocks::vectorized::Field>(std::move(f)));
     }
-    return starrocks::vectorized::Schema(std::move(fields));
+    return starrocks::vectorized::Schema(std::move(fields), schema.keys_type());
 }
 
 starrocks::vectorized::Schema ChunkHelper::convert_schema_to_format_v2(const starrocks::TabletSchema& schema,
@@ -83,7 +85,7 @@ starrocks::vectorized::Schema ChunkHelper::convert_schema_to_format_v2(const sta
         auto f = convert_field_to_format_v2(cid, schema.column(cid));
         fields.emplace_back(std::make_shared<starrocks::vectorized::Field>(std::move(f)));
     }
-    return starrocks::vectorized::Schema(std::move(fields));
+    return starrocks::vectorized::Schema(std::move(fields), schema.keys_type());
 }
 
 ColumnId ChunkHelper::max_column_id(const starrocks::vectorized::Schema& schema) {

--- a/be/src/storage/convert_helper.cpp
+++ b/be/src/storage/convert_helper.cpp
@@ -954,8 +954,7 @@ public:
     BitMapTypeConverter() = default;
     ~BitMapTypeConverter() = default;
 
-    Status convert_materialized(ColumnPtr src_col, ColumnPtr dst_col, TypeInfo* src_type,
-                                const TabletColumn& ref_column) const override {
+    Status convert_materialized(ColumnPtr src_col, ColumnPtr dst_col, TypeInfo* src_type) const override {
         for (size_t row_index = 0; row_index < src_col->size(); ++row_index) {
             Datum src_datum = src_col->get(row_index);
             Datum dst_datum;
@@ -986,8 +985,7 @@ public:
     HLLTypeConverter() = default;
     ~HLLTypeConverter() = default;
 
-    Status convert_materialized(ColumnPtr src_col, ColumnPtr dst_col, TypeInfo* src_type,
-                                const TabletColumn& ref_column) const override {
+    Status convert_materialized(ColumnPtr src_col, ColumnPtr dst_col, TypeInfo* src_type) const override {
         for (size_t row_index = 0; row_index < src_col->size(); ++row_index) {
             Datum src_datum = src_col->get(row_index);
             Datum dst_datum;
@@ -1014,8 +1012,7 @@ public:
     PercentileTypeConverter() = default;
     ~PercentileTypeConverter() = default;
 
-    Status convert_materialized(ColumnPtr src_col, ColumnPtr dst_col, TypeInfo* src_type,
-                                const TabletColumn& ref_column) const override {
+    Status convert_materialized(ColumnPtr src_col, ColumnPtr dst_col, TypeInfo* src_type) const override {
         for (size_t row_index = 0; row_index < src_col->size(); ++row_index) {
             Datum src_datum = src_col->get(row_index);
             Datum dst_datum;
@@ -1041,8 +1038,7 @@ public:
     DecimalToPercentileTypeConverter() = default;
     ~DecimalToPercentileTypeConverter() = default;
 
-    Status convert_materialized(ColumnPtr src_col, ColumnPtr dst_col, TypeInfo* src_type,
-                                const TabletColumn& ref_column) const override {
+    Status convert_materialized(ColumnPtr src_col, ColumnPtr dst_col, TypeInfo* src_type) const override {
         for (size_t row_index = 0; row_index < src_col->size(); ++row_index) {
             Datum src_datum = src_col->get(row_index);
             Datum dst_datum;
@@ -1053,7 +1049,7 @@ public:
             }
             double origin_value;
             auto v = src_datum.get<CppType>();
-            auto scale_factor = get_scale_factor<CppType>(ref_column.scale());
+            auto scale_factor = get_scale_factor<CppType>(src_type->scale());
             DecimalV3Cast::to_float<CppType, double>(v, scale_factor, &origin_value);
             PercentileValue percentile;
             percentile.add(origin_value);
@@ -1069,8 +1065,7 @@ public:
     CountTypeConverter() = default;
     ~CountTypeConverter() = default;
 
-    Status convert_materialized(ColumnPtr src_col, ColumnPtr dst_col, TypeInfo* src_type,
-                                const TabletColumn& ref_column) const override {
+    Status convert_materialized(ColumnPtr src_col, ColumnPtr dst_col, TypeInfo* src_type) const override {
         for (size_t row_index = 0; row_index < src_col->size(); ++row_index) {
             Datum src_datum = src_col->get(row_index);
             Datum dst_datum;

--- a/be/src/storage/convert_helper.h
+++ b/be/src/storage/convert_helper.h
@@ -41,8 +41,7 @@ public:
     MaterializeTypeConverter() = default;
     ~MaterializeTypeConverter() = default;
 
-    virtual Status convert_materialized(ColumnPtr src_col, ColumnPtr dst_col, TypeInfo* src_type,
-                                        const TabletColumn& ref_column) const = 0;
+    virtual Status convert_materialized(ColumnPtr src_col, ColumnPtr dst_col, TypeInfo* src_type) const = 0;
 };
 
 const MaterializeTypeConverter* get_materialized_converter(FieldType from_type, MaterializeType to_type);

--- a/be/src/storage/memtable.h
+++ b/be/src/storage/memtable.h
@@ -23,6 +23,9 @@ public:
     MemTable(int64_t tablet_id, const TabletSchema* tablet_schema, const std::vector<SlotDescriptor*>* slot_descs,
              RowsetWriter* rowset_writer, MemTracker* mem_tracker);
 
+    MemTable(int64_t tablet_id, const Schema& schema, RowsetWriter* rowset_writer, int64_t max_buffer_size,
+             MemTracker* mem_tracker);
+
     ~MemTable();
 
     int64_t tablet_id() const { return _tablet_id; }
@@ -61,9 +64,9 @@ private:
     // for sort by columns
     SmallPermutation _permutations;
     std::vector<uint32_t> _selective_values;
-    Schema _vectorized_schema;
 
     int64_t _tablet_id;
+    Schema _vectorized_schema;
     const TabletSchema* _tablet_schema;
     // the slot in _slot_descs are in order of tablet's schema
     const std::vector<SlotDescriptor*>* _slot_descs;
@@ -78,6 +81,9 @@ private:
 
     bool _has_op_slot = false;
     std::unique_ptr<Column> _deletes;
+
+    bool _use_slot_desc = true;
+    int64_t _max_buffer_size = config::write_buffer_size;
 
     // memory statistic
     MemTracker* _mem_tracker = nullptr;

--- a/be/src/storage/schema_change.cpp
+++ b/be/src/storage/schema_change.cpp
@@ -32,6 +32,7 @@
 #include "runtime/mem_pool.h"
 #include "storage/chunk_aggregator.h"
 #include "storage/convert_helper.h"
+#include "storage/memtable.h"
 #include "storage/rowset/rowset_factory.h"
 #include "storage/rowset/rowset_id_generator.h"
 #include "storage/storage_engine.h"
@@ -306,8 +307,7 @@ bool ChunkChanger::change_chunk(ChunkPtr& base_chunk, ChunkPtr& new_chunk, const
                 ColumnPtr& new_col = new_chunk->get_column_by_index(i);
                 Field ref_field = ChunkHelper::convert_field_to_format_v2(
                         ref_column, base_tablet_meta->tablet_schema().column(ref_column));
-                Status st = converter->convert_materialized(base_col, new_col, ref_field.type().get(),
-                                                            base_tablet_meta->tablet_schema().column(ref_column));
+                Status st = converter->convert_materialized(base_col, new_col, ref_field.type().get());
                 if (!st.ok()) {
                     return false;
                 }
@@ -439,6 +439,151 @@ bool ChunkChanger::change_chunk(ChunkPtr& base_chunk, ChunkPtr& new_chunk, const
                     }
                 } else {
                     Status st = datum_from_string(new_field.type().get(), &dst_datum, tmp, nullptr);
+                    if (!st.ok()) {
+                        LOG(WARNING) << "create datum from string failed: status=" << st;
+                        return false;
+                    }
+                }
+            }
+            for (size_t row_index = 0; row_index < base_chunk->num_rows(); ++row_index) {
+                new_col->append_datum(dst_datum);
+            }
+        }
+    }
+    return true;
+}
+
+bool ChunkChanger::change_chunkV2(ChunkPtr& base_chunk, ChunkPtr& new_chunk, const Schema& base_schema,
+                                  const Schema& new_schema, MemPool* mem_pool) {
+    if (new_chunk->num_columns() != _schema_mapping.size()) {
+        LOG(WARNING) << "new chunk does not match with schema mapping rules. "
+                     << "chunk_schema_size=" << new_chunk->num_columns()
+                     << ", mapping_schema_size=" << _schema_mapping.size();
+        return false;
+    }
+
+    size_t base_index = 0;
+    for (size_t i = 0; i < new_chunk->num_columns(); ++i) {
+        int ref_column = _schema_mapping[i].ref_column;
+        if (ref_column >= 0) {
+            const TypeInfoPtr& ref_type_info = base_schema.field(base_index)->type();
+            const TypeInfoPtr& new_type_info = new_schema.field(i)->type();
+            ColumnPtr& base_col = base_chunk->get_column_by_index(base_index);
+            ColumnPtr& new_col = new_chunk->get_column_by_index(i);
+            base_index++;
+
+            if (!_schema_mapping[i].materialized_function.empty()) {
+                const auto& materialized_function = _schema_mapping[i].materialized_function;
+                const MaterializeTypeConverter* converter =
+                        _get_materialize_type_converter(materialized_function, ref_type_info->type());
+                VLOG(3) << "_schema_mapping[" << i << "].materialized_function: " << materialized_function;
+                if (converter == nullptr) {
+                    LOG(WARNING) << "error materialized view function : " << materialized_function;
+                    return false;
+                }
+                Status st = converter->convert_materialized(base_col, new_col, ref_type_info.get());
+                if (!st.ok()) {
+                    return false;
+                }
+                continue;
+            }
+
+            int reftype_precision = ref_type_info->precision();
+            int reftype_scale = ref_type_info->scale();
+            int newtype_precision = new_type_info->precision();
+            int newtype_scale = new_type_info->scale();
+            auto ref_type = ref_type_info->type();
+            auto new_type = new_type_info->type();
+
+            if (new_type == ref_type && (!is_decimalv3_field_type(new_type) ||
+                                         (reftype_precision == newtype_precision && reftype_scale == newtype_scale))) {
+                if (new_col->is_nullable() != base_col->is_nullable()) {
+                    new_col->append(*base_col.get());
+                } else {
+                    new_col = base_col;
+                }
+            } else if (ConvertTypeResolver::instance()->convert_type_exist(ref_type, new_type)) {
+                auto converter = vectorized::get_type_converter(ref_type, new_type);
+                if (converter == nullptr) {
+                    LOG(WARNING) << "failed to get type converter, from_type=" << ref_type << ", to_type" << new_type;
+                    return false;
+                }
+                for (size_t row_index = 0; row_index < base_chunk->num_rows(); ++row_index) {
+                    Datum base_datum = base_col->get(row_index);
+                    Datum new_datum;
+                    Status st = converter->convert_datum(ref_type_info.get(), base_datum, new_type_info.get(),
+                                                         &new_datum, mem_pool);
+                    if (!st.ok()) {
+                        LOG(WARNING) << "failed to convert " << field_type_to_string(ref_type) << " to "
+                                     << field_type_to_string(new_type);
+                        return false;
+                    }
+                    new_col->append_datum(new_datum);
+                }
+            } else {
+                // copy and alter the field
+                switch (ref_type) {
+                case OLAP_FIELD_TYPE_TINYINT:
+                    CONVERT_FROM_TYPE(int8_t);
+                case OLAP_FIELD_TYPE_UNSIGNED_TINYINT:
+                    CONVERT_FROM_TYPE(uint8_t);
+                case OLAP_FIELD_TYPE_SMALLINT:
+                    CONVERT_FROM_TYPE(int16_t);
+                case OLAP_FIELD_TYPE_UNSIGNED_SMALLINT:
+                    CONVERT_FROM_TYPE(uint16_t);
+                case OLAP_FIELD_TYPE_INT:
+                    CONVERT_FROM_TYPE(int32_t);
+                case OLAP_FIELD_TYPE_UNSIGNED_INT:
+                    CONVERT_FROM_TYPE(uint32_t);
+                case OLAP_FIELD_TYPE_BIGINT:
+                    CONVERT_FROM_TYPE(int64_t);
+                case OLAP_FIELD_TYPE_UNSIGNED_BIGINT:
+                    CONVERT_FROM_TYPE(uint64_t);
+                default:
+                    LOG(WARNING) << "the column type which was altered from was unsupported."
+                                 << " from_type=" << ref_type << ", to_type=" << new_type;
+                    return false;
+                }
+                if (new_type < ref_type) {
+                    LOG(INFO) << "type degraded while altering column. "
+                              << "column=" << new_schema.field(i)->name()
+                              << ", origin_type=" << field_type_to_string(ref_type)
+                              << ", alter_type=" << field_type_to_string(new_type);
+                }
+            }
+        } else {
+            ColumnPtr& new_col = new_chunk->get_column_by_index(i);
+            Datum dst_datum;
+            if (_schema_mapping[i].default_value->is_null()) {
+                dst_datum.set_null();
+            } else {
+                TypeInfoPtr new_type_info = new_schema.field(i)->type();
+                const FieldType field_type = new_type_info->type();
+                std::string tmp = _schema_mapping[i].default_value->to_string();
+                if (field_type == OLAP_FIELD_TYPE_HLL || field_type == OLAP_FIELD_TYPE_OBJECT ||
+                    field_type == OLAP_FIELD_TYPE_PERCENTILE) {
+                    switch (field_type) {
+                    case OLAP_FIELD_TYPE_HLL: {
+                        HyperLogLog hll(tmp);
+                        dst_datum.set_hyperloglog(&hll);
+                        break;
+                    }
+                    case OLAP_FIELD_TYPE_OBJECT: {
+                        BitmapValue bitmap(tmp);
+                        dst_datum.set_bitmap(&bitmap);
+                        break;
+                    }
+                    case OLAP_FIELD_TYPE_PERCENTILE: {
+                        PercentileValue percentile(tmp);
+                        dst_datum.set_percentile(&percentile);
+                        break;
+                    }
+                    default:
+                        LOG(WARNING) << "the column type is wrong. column_type: " << field_type_to_string(field_type);
+                        return false;
+                    }
+                } else {
+                    Status st = datum_from_string(new_type_info.get(), &dst_datum, tmp, nullptr);
                     if (!st.ok()) {
                         LOG(WARNING) << "create datum from string failed: status=" << st;
                         return false;
@@ -685,6 +830,15 @@ bool LinkedSchemaChange::process(vectorized::TabletReader* reader, RowsetWriter*
     return true;
 }
 
+Status LinkedSchemaChange::processV2(vectorized::TabletReader* reader, RowsetWriter* new_rowset_writer,
+                                     TabletSharedPtr new_tablet, TabletSharedPtr base_tablet, RowsetSharedPtr rowset) {
+    if (process(reader, new_rowset_writer, new_tablet, base_tablet, rowset)) {
+        return Status::OK();
+    } else {
+        return Status::InternalError("failed to proccessV2 LinkedSchemaChange");
+    }
+}
+
 bool SchemaChangeDirectly::process(vectorized::TabletReader* reader, RowsetWriter* new_rowset_writer,
                                    TabletSharedPtr new_tablet, TabletSharedPtr base_tablet, RowsetSharedPtr rowset) {
     vectorized::Schema base_schema = ChunkHelper::convert_schema_to_format_v2(base_tablet->tablet_schema());
@@ -756,6 +910,91 @@ bool SchemaChangeDirectly::process(vectorized::TabletReader* reader, RowsetWrite
     }
 
     return true;
+}
+
+Status SchemaChangeDirectly::processV2(vectorized::TabletReader* reader, RowsetWriter* new_rowset_writer,
+                                       TabletSharedPtr new_tablet, TabletSharedPtr base_tablet,
+                                       RowsetSharedPtr rowset) {
+    std::vector<ColumnId> column_index;
+    for (int i = 0; i < new_tablet->tablet_schema().num_columns(); ++i) {
+        ColumnMapping* column_mapping = _chunk_changer->get_mutable_column_mapping(i);
+        if (column_mapping->ref_column != -1) {
+            column_index.emplace_back(static_cast<ColumnId>(column_mapping->ref_column));
+        }
+    }
+    vectorized::Schema base_schema =
+            std::move(ChunkHelper::convert_schema_to_format_v2(base_tablet->tablet_schema(), column_index));
+    ChunkPtr base_chunk = ChunkHelper::new_chunk(base_schema, config::vector_chunk_size);
+    vectorized::Schema new_schema = std::move(ChunkHelper::convert_schema_to_format_v2(new_tablet->tablet_schema()));
+    auto char_field_indexes = std::move(vectorized::ChunkHelper::get_char_field_indexes(new_schema));
+
+    ChunkPtr new_chunk = ChunkHelper::new_chunk(new_schema, config::vector_chunk_size);
+
+    std::unique_ptr<MemPool> mem_pool(new MemPool());
+    do {
+        bool bg_worker_stopped = ExecEnv::GetInstance()->storage_engine()->bg_worker_stopped();
+        if (bg_worker_stopped) {
+            return Status::InternalError("bg_worker_stopped");
+        }
+#ifndef BE_TEST
+        Status st = tls_thread_status.mem_tracker()->check_mem_limit("DirectSchemaChange");
+        if (!st.ok()) {
+            LOG(WARNING) << "fail to execute schema change: " << st.message() << std::endl;
+            return st;
+        }
+#endif
+        Status status = reader->do_get_next(base_chunk.get());
+
+        if (!status.ok()) {
+            if (status.is_end_of_file()) {
+                break;
+            } else {
+                LOG(WARNING) << "tablet reader failed to get next chunk, status: " << status.get_error_msg();
+                return status;
+            }
+        }
+        if (!_chunk_changer->change_chunkV2(base_chunk, new_chunk, base_schema, new_schema, mem_pool.get())) {
+            std::string err_msg = Substitute("failed to convert chunk data. base tablet:$0, new tablet:$1",
+                                             base_tablet->tablet_id(), new_tablet->tablet_id());
+            LOG(WARNING) << err_msg;
+            return Status::InternalError(err_msg);
+        }
+
+        vectorized::ChunkHelper::padding_char_columns(char_field_indexes, new_schema, new_tablet->tablet_schema(),
+                                                      new_chunk.get());
+
+        if (auto st = new_rowset_writer->add_chunk(*new_chunk); !st.ok()) {
+            std::string err_msg = Substitute(
+                    "failed to execute schema change. base tablet:$0, new_tablet:$1. err msg: failed to add chunk to "
+                    "rowset writer",
+                    base_tablet->tablet_id(), new_tablet->tablet_id());
+            LOG(WARNING) << err_msg;
+            return Status::InternalError(err_msg);
+        }
+        base_chunk->reset();
+        new_chunk->reset();
+        mem_pool->clear();
+    } while (base_chunk->num_rows() == 0);
+
+    if (base_chunk->num_rows() != 0) {
+        if (!_chunk_changer->change_chunkV2(base_chunk, new_chunk, base_schema, new_schema, mem_pool.get())) {
+            std::string err_msg = Substitute("failed to convert chunk data. base tablet:$0, new tablet:$1",
+                                             base_tablet->tablet_id(), new_tablet->tablet_id());
+            LOG(WARNING) << err_msg;
+            return Status::InternalError(err_msg);
+        }
+        if (auto st = new_rowset_writer->add_chunk(*new_chunk); !st.ok()) {
+            LOG(WARNING) << "rowset writer add chunk failed: " << st;
+            return st;
+        }
+    }
+
+    if (auto st = new_rowset_writer->flush(); !st.ok()) {
+        LOG(WARNING) << "failed to flush rowset writer: " << st;
+        return st;
+    }
+
+    return Status::OK();
 }
 
 SchemaChangeWithSorting::SchemaChangeWithSorting(ChunkChanger* chunk_changer, size_t memory_limitation)
@@ -872,6 +1111,100 @@ bool SchemaChangeWithSorting::process(vectorized::TabletReader* reader, RowsetWr
     }
 
     return true;
+}
+
+Status SchemaChangeWithSorting::processV2(vectorized::TabletReader* reader, RowsetWriter* new_rowset_writer,
+                                          TabletSharedPtr new_tablet, TabletSharedPtr base_tablet,
+                                          RowsetSharedPtr rowset) {
+    std::vector<ColumnId> column_index;
+    for (int i = 0; i < new_tablet->tablet_schema().num_columns(); ++i) {
+        ColumnMapping* column_mapping = _chunk_changer->get_mutable_column_mapping(i);
+        if (column_mapping->ref_column != -1) {
+            column_index.emplace_back(static_cast<ColumnId>(column_mapping->ref_column));
+        }
+    }
+    vectorized::Schema base_schema =
+            std::move(ChunkHelper::convert_schema_to_format_v2(base_tablet->tablet_schema(), column_index));
+    vectorized::Schema new_schema = std::move(ChunkHelper::convert_schema_to_format_v2(new_tablet->tablet_schema()));
+    auto char_field_indexes = std::move(vectorized::ChunkHelper::get_char_field_indexes(new_schema));
+
+    // memtable max buffer size set 80% of memory limit so that it will do _merge() if reach 80%
+    // do finialize() and flush() if reach 90%
+    auto mem_table = std::make_unique<MemTable>(new_tablet->tablet_id(), new_schema, new_rowset_writer,
+                                                _memory_limitation * 0.8, tls_thread_status.mem_tracker());
+
+    auto selective = std::make_unique<std::vector<uint32_t>>();
+    selective->resize(config::vector_chunk_size);
+    for (uint32_t i = 0; i < config::vector_chunk_size; i++) {
+        (*selective)[i] = i;
+    }
+
+    std::unique_ptr<MemPool> mem_pool(new MemPool());
+
+    StorageEngine* storage_engine = ExecEnv::GetInstance()->storage_engine();
+    bool bg_worker_stopped = storage_engine->bg_worker_stopped();
+    while (!bg_worker_stopped) {
+#ifndef BE_TEST
+        auto cur_usage = tls_thread_status.mem_tracker()->consumption();
+        // we check memory usage exceeds 90% since tablet reader use some memory
+        // it will return fail if memory is exhausted
+        if (cur_usage > tls_thread_status.mem_tracker()->limit() * 0.9) {
+            RETURN_IF_ERROR_WITH_WARN(mem_table->finalize(), "failed to finalize mem table");
+            RETURN_IF_ERROR_WITH_WARN(mem_table->flush(), "failed to flush mem table");
+            mem_table = std::make_unique<MemTable>(new_tablet->tablet_id(), new_schema, new_rowset_writer,
+                                                   _memory_limitation * 0.9, tls_thread_status.mem_tracker());
+            VLOG(1) << "SortSchemaChange memory usage: " << cur_usage << " after mem table flush "
+                    << tls_thread_status.mem_tracker()->consumption();
+        }
+#endif
+        ChunkPtr base_chunk = ChunkHelper::new_chunk(base_schema, config::vector_chunk_size);
+        Status status = reader->do_get_next(base_chunk.get());
+        if (!status.ok()) {
+            if (!status.is_end_of_file()) {
+                LOG(WARNING) << "failed to get next chunk, status is:" << status.to_string();
+                return status;
+            } else if (base_chunk->num_rows() <= 0) {
+                break;
+            }
+        }
+
+        ChunkPtr new_chunk = ChunkHelper::new_chunk(new_schema, base_chunk->num_rows());
+
+        if (!_chunk_changer->change_chunkV2(base_chunk, new_chunk, base_schema, new_schema, mem_pool.get())) {
+            std::string err_msg = Substitute("failed to convert chunk data. base tablet:$0, new tablet:$1",
+                                             base_tablet->tablet_id(), new_tablet->tablet_id());
+            LOG(WARNING) << err_msg;
+            return Status::InternalError(err_msg);
+        }
+
+        vectorized::ChunkHelper::padding_char_columns(char_field_indexes, new_schema, new_tablet->tablet_schema(),
+                                                      new_chunk.get());
+
+        bool full = mem_table->insert(*new_chunk, selective->data(), 0, new_chunk->num_rows());
+        if (full) {
+            RETURN_IF_ERROR_WITH_WARN(mem_table->finalize(), "failed to finalize mem table");
+            RETURN_IF_ERROR_WITH_WARN(mem_table->flush(), "failed to flush mem table");
+            mem_table = std::make_unique<MemTable>(new_tablet->tablet_id(), new_schema, new_rowset_writer,
+                                                   _memory_limitation * 0.8, tls_thread_status.mem_tracker());
+        }
+
+        mem_pool->clear();
+        bg_worker_stopped = storage_engine->bg_worker_stopped();
+    }
+
+    RETURN_IF_ERROR_WITH_WARN(mem_table->finalize(), "failed to finalize mem table");
+    RETURN_IF_ERROR_WITH_WARN(mem_table->flush(), "failed to flush mem table");
+
+    if (bg_worker_stopped) {
+        return Status::InternalError("bg_worker_stopped");
+    }
+
+    if (auto st = new_rowset_writer->flush(); !st.ok()) {
+        LOG(WARNING) << "failed to flush rowset writer: " << st;
+        return st;
+    }
+
+    return Status::OK();
 }
 
 bool SchemaChangeWithSorting::_internal_sorting(std::vector<ChunkPtr>& chunk_arr, RowsetWriter* new_rowset_writer,
@@ -1056,7 +1389,22 @@ Status SchemaChangeHandler::_do_process_alter_tablet_v2_normal(const TAlterTable
             return status;
         }
         VLOG(3) << "versions to be changed size:" << versions_to_be_changed.size();
-        Schema base_schema = ChunkHelper::convert_schema_to_format_v2(base_tablet->tablet_schema());
+
+        Schema base_schema;
+        if (config::enable_schema_change_v2) {
+            std::vector<ColumnId> column_index;
+            for (int i = 0; i < new_tablet->tablet_schema().num_columns(); ++i) {
+                ColumnMapping* column_mapping = sc_params.chunk_changer->get_mutable_column_mapping(i);
+                if (column_mapping->ref_column != -1) {
+                    column_index.emplace_back(static_cast<ColumnId>(column_mapping->ref_column));
+                }
+            }
+            base_schema =
+                    std::move(ChunkHelper::convert_schema_to_format_v2(base_tablet->tablet_schema(), column_index));
+        } else {
+            base_schema = std::move(ChunkHelper::convert_schema_to_format_v2(base_tablet->tablet_schema()));
+        }
+
         for (auto& version : versions_to_be_changed) {
             rowsets_to_change.push_back(base_tablet->get_rowset_by_version(version));
             // prepare tablet reader to prevent rowsets being compacted
@@ -1227,11 +1575,23 @@ Status SchemaChangeHandler::_convert_historical_rowsets(SchemaChangeParams& sc_p
             return Status::InternalError("build rowset writer failed");
         }
 
-        if (!sc_procedure->process(sc_params.rowset_readers[i].get(), rowset_writer.get(), new_tablet, base_tablet,
-                                   sc_params.rowsets_to_change[i])) {
-            LOG(WARNING) << "failed to process the version."
-                         << " version=" << sc_params.version.first << "-" << sc_params.version.second;
-            return Status::InternalError("process failed");
+        if (config::enable_schema_change_v2) {
+            auto st = sc_procedure->processV2(sc_params.rowset_readers[i].get(), rowset_writer.get(), new_tablet,
+                                              base_tablet, sc_params.rowsets_to_change[i]);
+            if (!st.ok()) {
+                LOG(WARNING) << "failed to process the schema change. from tablet "
+                             << base_tablet->get_tablet_info().to_string() << " to tablet "
+                             << new_tablet->get_tablet_info().to_string() << " version=" << sc_params.version.first
+                             << "-" << sc_params.version.second << " error " << st;
+                return st;
+            }
+        } else {
+            if (!sc_procedure->process(sc_params.rowset_readers[i].get(), rowset_writer.get(), new_tablet, base_tablet,
+                                       sc_params.rowsets_to_change[i])) {
+                LOG(WARNING) << "failed to process the version."
+                             << " version=" << sc_params.version.first << "-" << sc_params.version.second;
+                return Status::InternalError("process failed");
+            }
         }
         auto new_rowset = rowset_writer->build();
         if (!new_rowset.ok()) {

--- a/be/src/storage/schema_change.h
+++ b/be/src/storage/schema_change.h
@@ -59,6 +59,9 @@ public:
     bool change_chunk(ChunkPtr& base_chunk, ChunkPtr& new_chunk, const TabletMetaSharedPtr& base_tablet_meta,
                       const TabletMetaSharedPtr& new_tablet_meta, MemPool* mem_pool);
 
+    bool change_chunkV2(ChunkPtr& base_chunk, ChunkPtr& new_chunk, const Schema& base_schema, const Schema& new_schema,
+                        MemPool* mem_pool);
+
     const MaterializeTypeConverter* _get_materialize_type_converter(std::string materialized_function, FieldType type);
 
 private:
@@ -91,6 +94,9 @@ public:
 
     virtual bool process(vectorized::TabletReader* reader, RowsetWriter* new_rowset_writer, TabletSharedPtr tablet,
                          TabletSharedPtr base_tablet, RowsetSharedPtr rowset) = 0;
+
+    virtual Status processV2(vectorized::TabletReader* reader, RowsetWriter* new_rowset_writer, TabletSharedPtr tablet,
+                             TabletSharedPtr base_tablet, RowsetSharedPtr rowset) = 0;
 };
 
 class LinkedSchemaChange : public SchemaChange {
@@ -100,6 +106,9 @@ public:
 
     bool process(vectorized::TabletReader* reader, RowsetWriter* new_rowset_writer, TabletSharedPtr new_tablet,
                  TabletSharedPtr base_tablet, RowsetSharedPtr rowset) override;
+
+    Status processV2(vectorized::TabletReader* reader, RowsetWriter* new_rowset_writer, TabletSharedPtr new_tablet,
+                     TabletSharedPtr base_tablet, RowsetSharedPtr rowset) override;
 
 private:
     ChunkChanger* _chunk_changer = nullptr;
@@ -115,6 +124,9 @@ public:
     bool process(vectorized::TabletReader* reader, RowsetWriter* new_rowset_writer, TabletSharedPtr new_tablet,
                  TabletSharedPtr base_tablet, RowsetSharedPtr rowset) override;
 
+    Status processV2(vectorized::TabletReader* reader, RowsetWriter* new_rowset_writer, TabletSharedPtr new_tablet,
+                     TabletSharedPtr base_tablet, RowsetSharedPtr rowset) override;
+
 private:
     ChunkChanger* _chunk_changer = nullptr;
     ChunkAllocator* _chunk_allocator = nullptr;
@@ -129,6 +141,9 @@ public:
 
     bool process(vectorized::TabletReader* reader, RowsetWriter* new_rowset_writer, TabletSharedPtr new_tablet,
                  TabletSharedPtr base_tablet, RowsetSharedPtr rowset) override;
+
+    Status processV2(vectorized::TabletReader* reader, RowsetWriter* new_rowset_writer, TabletSharedPtr new_tablet,
+                     TabletSharedPtr base_tablet, RowsetSharedPtr rowset);
 
 private:
     bool _internal_sorting(std::vector<ChunkPtr>& chunk_arr, RowsetWriter* new_rowset_writer, TabletSharedPtr tablet);


### PR DESCRIPTION
The main optimizations include:
1. Only use the required columns when schema changes are made
2. Use memtable for sorted schema change
3. More accurate memory usage control

## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4806

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

|case|optimize|main|boost|remark|
|---|---|---|---|---|
|sql1|2452ms|66217ms|27x|select two integer column as mv|
|sql2|7253ms|85697ms|11.8x|select ten integer column as mv|
|sql3|18413ms|78477ms|4.3x|select two string column as mv|
|sql4|48653ms|139069ms|2.9x|select ten string column as mv|
|sql5|480785ms|682649ms|1.42x|reorder all column memory_limitation_per_thread_for_schema_change=100|
|sql5|554830ms|OOM|N/A|memory_limitation_per_thread_for_schema_change=10|


> sql1: create materialized view v1 as select comment_id, position from github_events
> sql2: create materialized view v2 as select comment_id, position, line, number, comments, review_comments, commits, additions, deletions, push_size from github_events
> sql3: create materialized view v3 as select action, title from github_events
> sql4: create materialized view v4 as select action, title, event_type, repo_name, actor_login, state, path, head_sha, commit_id, release_name from github_events
> sql5: create materialized view v5 as select title, created_at, event_type, repo_name, file_time, actor_login, updated_at, action, comment_id, body, path, position, line, ref, ref_type, creator_user_login, number, labels, state, locked, assignee, assignees, comments, author_association, closed_at, merged_at, merge_commit_sha, requested_reviewers, requested_teams, head_ref, head_sha, base_ref, base_sha, merged, mergeable, rebaseable, mergeable_state, merged_by, review_comments, maintainer_can_modify, commits, additions, deletions, changed_files, diff_hunk, original_position, commit_id, original_commit_id, push_size, push_distinct_size, member_login, release_tag_name, release_name review_state from github_events order by title, created_at
