### PR TITLE
Use fragment instance parallel for bucket shuffle and colocate join

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -803,6 +803,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         this.enableResourceGroup = enableResourceGroup;
     }
 
+    public void setPipelineDop(int pipelineDop) {
+        this.pipelineDop = pipelineDop;
+    }
+
     public int getPipelineDop() {
         return this.pipelineDop;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1495,7 +1495,7 @@ public class PlanFragmentBuilder {
          * because there is no local shuffle for these joins.
          * @param fragment The fragment which needs to estimate DOP.
          */
-        private void estimateDopOfBroadcastOrReplicatedJoinInPipeline(PlanFragment fragment) {
+        private void estimateDopOfBroadcastAndReplicatedJoinInPipeline(PlanFragment fragment) {
             if (!isDopAutoEstimate() || fragment.isDopEstimated()) {
                 return;
             }
@@ -1509,7 +1509,7 @@ public class PlanFragmentBuilder {
          * to avoid local shuffle and too large in-filter in left scan node.
          * @param fragment The fragment which needs to estimate DOP.
          */
-        private void estimateDopOfColocateOrLocalBucketJoinInPipeline(PlanFragment fragment) {
+        private void estimateDopOfColocateAndLocalBucketJoinInPipeline(PlanFragment fragment) {
             if (!isDopAutoEstimate() || fragment.isDopEstimated()) {
                 return;
             }
@@ -1720,7 +1720,7 @@ public class PlanFragmentBuilder {
                     leftFragment.setPlanRoot(hashJoinNode);
                     leftFragment.addChild(rightFragment.getChild(0));
                     leftFragment.mergeQueryGlobalDicts(rightFragment.getQueryGlobalDicts());
-                    estimateDopOfBroadcastOrReplicatedJoinInPipeline(leftFragment);
+                    estimateDopOfBroadcastAndReplicatedJoinInPipeline(leftFragment);
                     return leftFragment;
                 } else if (distributionMode.equals(HashJoinNode.DistributionMode.PARTITIONED)) {
                     DataPartition lhsJoinPartition = new DataPartition(TPartitionType.HASH_PARTITIONED,
@@ -1765,9 +1765,9 @@ public class PlanFragmentBuilder {
 
                     leftFragment.mergeQueryGlobalDicts(rightFragment.getQueryGlobalDicts());
                     if (distributionMode.equals(HashJoinNode.DistributionMode.COLOCATE)) {
-                        estimateDopOfColocateOrLocalBucketJoinInPipeline(leftFragment);
+                        estimateDopOfColocateAndLocalBucketJoinInPipeline(leftFragment);
                     } else {
-                        estimateDopOfBroadcastOrReplicatedJoinInPipeline(leftFragment);
+                        estimateDopOfBroadcastAndReplicatedJoinInPipeline(leftFragment);
                     }
                     return leftFragment;
                 } else if (distributionMode.equals(HashJoinNode.DistributionMode.SHUFFLE_HASH_BUCKET)) {
@@ -1806,7 +1806,7 @@ public class PlanFragmentBuilder {
                         leftFragment = computeBucketShufflePlanFragment(context, leftFragment,
                                 rightFragment, hashJoinNode);
                     }
-                    estimateDopOfColocateOrLocalBucketJoinInPipeline(leftFragment);
+                    estimateDopOfColocateAndLocalBucketJoinInPipeline(leftFragment);
                     return leftFragment;
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1485,24 +1485,36 @@ public class PlanFragmentBuilder {
             }
         }
 
-        private void estimateDopOfBroadcastJoinInPipeline(PlanFragment fragment) {
-            if (ConnectContext.get() == null ||
-                    !ConnectContext.get().getSessionVariable().isEnablePipelineEngine() ||
-                    ConnectContext.get().getSessionVariable().getPipelineDop() > 0) {
-                return;
-            }
-            if (fragment.isDopEstimated()) {
-                return;
-            }
-            Preconditions.checkArgument(fragment.getPlanRoot() instanceof HashJoinNode);
-            HashJoinNode hashJoinNode = (HashJoinNode) fragment.getPlanRoot();
-            HashJoinNode.DistributionMode distributionMode = hashJoinNode.getDistributionMode();
-            if (!distributionMode.equals(HashJoinNode.DistributionMode.BROADCAST) &&
-                    !distributionMode.equals(HashJoinNode.DistributionMode.REPLICATED)) {
+        private boolean isDopAutoEstimate() {
+            return (ConnectContext.get() != null &&
+                    ConnectContext.get().getSessionVariable().isEnablePipelineEngine() &&
+                    ConnectContext.get().getSessionVariable().getPipelineDop() == 0);
+        }
+        /**
+         * Broadcast join and duplicate join should use pipeline parallel not fragment instance parallel,
+         * because there is no local shuffle for these joins.
+         * @param fragment The fragment which needs to estimate DOP.
+         */
+        private void estimateDopOfBroadcastOrReplicatedJoinInPipeline(PlanFragment fragment) {
+            if (!isDopAutoEstimate() || fragment.isDopEstimated()) {
                 return;
             }
             fragment.setPipelineDop(fragment.getParallelExecNum());
             fragment.setParallelExecNum(1);
+            fragment.setDopEstimated();
+        }
+
+        /**
+         * Local bucket shuffle join and colocate join should use fragment instance parallel not pipeline parallel,
+         * to avoid local shuffle and too large in-filter in left scan node.
+         * @param fragment The fragment which needs to estimate DOP.
+         */
+        private void estimateDopOfColocateOrLocalBucketJoinInPipeline(PlanFragment fragment) {
+            if (!isDopAutoEstimate() || fragment.isDopEstimated()) {
+                return;
+            }
+            fragment.setPipelineDop(1);
+            fragment.setParallelExecNum(fragment.getParallelExecNum());
             fragment.setDopEstimated();
         }
 
@@ -1708,7 +1720,7 @@ public class PlanFragmentBuilder {
                     leftFragment.setPlanRoot(hashJoinNode);
                     leftFragment.addChild(rightFragment.getChild(0));
                     leftFragment.mergeQueryGlobalDicts(rightFragment.getQueryGlobalDicts());
-                    estimateDopOfBroadcastJoinInPipeline(leftFragment);
+                    estimateDopOfBroadcastOrReplicatedJoinInPipeline(leftFragment);
                     return leftFragment;
                 } else if (distributionMode.equals(HashJoinNode.DistributionMode.PARTITIONED)) {
                     DataPartition lhsJoinPartition = new DataPartition(TPartitionType.HASH_PARTITIONED,
@@ -1752,7 +1764,11 @@ public class PlanFragmentBuilder {
                     context.getFragments().add(leftFragment);
 
                     leftFragment.mergeQueryGlobalDicts(rightFragment.getQueryGlobalDicts());
-                    estimateDopOfBroadcastJoinInPipeline(leftFragment);
+                    if (distributionMode.equals(HashJoinNode.DistributionMode.COLOCATE)) {
+                        estimateDopOfColocateOrLocalBucketJoinInPipeline(leftFragment);
+                    } else {
+                        estimateDopOfBroadcastOrReplicatedJoinInPipeline(leftFragment);
+                    }
                     return leftFragment;
                 } else if (distributionMode.equals(HashJoinNode.DistributionMode.SHUFFLE_HASH_BUCKET)) {
                     setJoinPushDown(hashJoinNode);
@@ -1784,12 +1800,14 @@ public class PlanFragmentBuilder {
                     // distributionMode is BUCKET_SHUFFLE
                     if (leftFragment.getPlanRoot() instanceof ExchangeNode &&
                             !(rightFragment.getPlanRoot() instanceof ExchangeNode)) {
-                        return computeBucketShufflePlanFragment(context, rightFragment,
+                        leftFragment = computeBucketShufflePlanFragment(context, rightFragment,
                                 leftFragment, hashJoinNode);
                     } else {
-                        return computeBucketShufflePlanFragment(context, leftFragment,
+                        leftFragment = computeBucketShufflePlanFragment(context, leftFragment,
                                 rightFragment, hashJoinNode);
                     }
+                    estimateDopOfColocateOrLocalBucketJoinInPipeline(leftFragment);
+                    return leftFragment;
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1490,9 +1490,11 @@ public class PlanFragmentBuilder {
                     ConnectContext.get().getSessionVariable().isEnablePipelineEngine() &&
                     ConnectContext.get().getSessionVariable().getPipelineDop() == 0);
         }
+
         /**
          * Broadcast join and duplicate join should use pipeline parallel not fragment instance parallel,
          * because there is no local shuffle for these joins.
+         *
          * @param fragment The fragment which needs to estimate DOP.
          */
         private void estimateDopOfBroadcastAndReplicatedJoinInPipeline(PlanFragment fragment) {
@@ -1506,15 +1508,15 @@ public class PlanFragmentBuilder {
 
         /**
          * Local bucket shuffle join and colocate join should use fragment instance parallel not pipeline parallel,
-         * to avoid local shuffle and too large in-filter in left scan node.
+         * to avoid local shuffle and too large in-filter in the left scan node.
+         *
          * @param fragment The fragment which needs to estimate DOP.
          */
         private void estimateDopOfColocateAndLocalBucketJoinInPipeline(PlanFragment fragment) {
             if (!isDopAutoEstimate() || fragment.isDopEstimated()) {
                 return;
             }
-            fragment.setPipelineDop(1);
-            fragment.setParallelExecNum(fragment.getParallelExecNum());
+            // To prevent ancestor nodes from adjusting parallelExecNum and pipelineDop.
             fragment.setDopEstimated();
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -2,15 +2,20 @@
 
 package com.starrocks.sql.plan;
 
+import com.starrocks.analysis.StatementBase;
 import com.starrocks.catalog.Catalog;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.FeConstants;
+import com.starrocks.planner.PlanFragment;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.rule.RuleSet;
 import com.starrocks.sql.optimizer.rule.transformation.JoinAssociativityRule;
+import com.starrocks.system.BackendCoreStat;
+import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
@@ -2157,5 +2162,98 @@ public class JoinTest extends PlanTestBase {
                 "  |  equal join conjunct: 1: t1a = 21: cast\n" +
                 "  |  equal join conjunct: 22: cast = 11: t1a");
         FeConstants.runningUnitTest = false;
+    }
+
+    @Test
+    public void tesAutoEstimateDopForLocalBucketAndColocateJoin() throws Exception {
+        final int numCPUs = 8;
+        new MockUp<BackendCoreStat>() {
+            @Mock
+            public int getAvgNumOfHardwareCoresOfBe() {
+                return numCPUs;
+            }
+        };
+
+        // Enable DopAutoEstimate.
+        SessionVariable sessionVariable = connectContext.getSessionVariable();
+        Assert.assertNotNull(sessionVariable);
+        sessionVariable.setEnablePipelineEngine(true);
+        sessionVariable.setPipelineDop(0);
+        sessionVariable.setParallelExecInstanceNum(1);
+
+        // Case 1: local bucket shuffle join should use fragment instance parallel.
+        FeConstants.runningUnitTest = true;
+        String sql = "select a.v1 from t0 a join [bucket] t0 b on a.v1 = b.v2 and a.v2 = b.v1";
+        ExecPlan plan = UtFrameUtils.getPlanAndFragment(connectContext, sql).second;
+        String planString = plan.getExplainString(StatementBase.ExplainLevel.NORMAL);
+        assertContains(planString, "PLAN FRAGMENT 1\n" +
+                " OUTPUT EXPRS:\n" +
+                "  PARTITION: RANDOM\n" +
+                "\n" +
+                "  STREAM DATA SINK\n" +
+                "    EXCHANGE ID: 05\n" +
+                "    UNPARTITIONED\n" +
+                "\n" +
+                "  4:Project\n" +
+                "  |  <slot 1> : 1: v1\n" +
+                "  |  \n" +
+                "  3:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (BUCKET_SHUFFLE)");
+        PlanFragment fragment = plan.getFragments().get(1);
+        Assert.assertEquals(numCPUs / 2, fragment.getParallelExecNum());
+        Assert.assertEquals(1, fragment.getPipelineDop());
+
+        // Case 2: colocate join should use fragment instance parallel.
+        sql = "select * from colocate1 left join colocate2 on colocate1.k1=colocate2.k1 and colocate1.k2=colocate2.k2;";;
+        plan = UtFrameUtils.getPlanAndFragment(connectContext, sql).second;
+        planString = plan.getExplainString(StatementBase.ExplainLevel.NORMAL);
+        assertContains(planString, "PLAN FRAGMENT 1\n" +
+                " OUTPUT EXPRS:\n" +
+                "  PARTITION: RANDOM\n" +
+                "\n" +
+                "  STREAM DATA SINK\n" +
+                "    EXCHANGE ID: 03\n" +
+                "    UNPARTITIONED\n" +
+                "\n" +
+                "  2:HASH JOIN\n" +
+                "  |  join op: LEFT OUTER JOIN (COLOCATE)\n");
+        fragment = plan.getFragments().get(1);
+        Assert.assertEquals(numCPUs / 2, fragment.getParallelExecNum());
+        Assert.assertEquals(1, fragment.getPipelineDop());
+
+        // Case 3: local bucket shuffle join succeeded by broadcast should also use fragment instance parallel.
+        sql = "select a.v1 from t0 a join [bucket] t0 b on a.v1 = b.v2 and a.v2 = b.v1 join [broadcast] t0 c on a.v1 = c.v2";
+        plan = UtFrameUtils.getPlanAndFragment(connectContext, sql).second;
+        planString = plan.getExplainString(StatementBase.ExplainLevel.NORMAL);
+        assertContains(planString, "PLAN FRAGMENT 1\n" +
+                " OUTPUT EXPRS:\n" +
+                "  PARTITION: RANDOM\n" +
+                "\n" +
+                "  STREAM DATA SINK\n" +
+                "    EXCHANGE ID: 09\n" +
+                "    UNPARTITIONED\n" +
+                "\n" +
+                "  8:Project\n" +
+                "  |  <slot 1> : 1: v1\n" +
+                "  |  \n" +
+                "  7:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (BROADCAST)\n" +
+                "  |  hash predicates:\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 1: v1 = 8: v2\n" +
+                "  |  \n" +
+                "  |----6:EXCHANGE\n" +
+                "  |    \n" +
+                "  4:Project\n" +
+                "  |  <slot 1> : 1: v1\n" +
+                "  |  \n" +
+                "  3:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (BUCKET_SHUFFLE)");
+        fragment = plan.getFragments().get(1);
+        Assert.assertEquals(numCPUs / 2, fragment.getParallelExecNum());
+        Assert.assertEquals(1, fragment.getPipelineDop());
+
+        FeConstants.runningUnitTest = false;
+        sessionVariable.setEnablePipelineEngine(false);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -2186,7 +2186,6 @@ public class JoinTest extends PlanTestBase {
             sessionVariable.setEnablePipelineEngine(true);
             sessionVariable.setPipelineDop(0);
             sessionVariable.setParallelExecInstanceNum(1);
-
             FeConstants.runningUnitTest = true;
 
             // Case 1: local bucket shuffle join should use fragment instance parallel.
@@ -2222,13 +2221,10 @@ public class JoinTest extends PlanTestBase {
             assertContains(fragmentString, "join op: INNER JOIN (BUCKET_SHUFFLE)");
             Assert.assertEquals(expectedParallelism, fragment.getParallelExecNum());
             Assert.assertEquals(1, fragment.getPipelineDop());
-
-
         } finally {
             sessionVariable.setEnablePipelineEngine(enablePipeline);
             sessionVariable.setPipelineDop(pipelineDop);
             sessionVariable.setParallelExecInstanceNum(parallelExecInstanceNum);
-
             FeConstants.runningUnitTest = false;
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -2192,12 +2192,13 @@ public class JoinTest extends PlanTestBase {
             String sql = "select a.v1 from t0 a join [bucket] t0 b on a.v1 = b.v2 and a.v2 = b.v1";
             ExecPlan plan = getExecPlan(sql);
             PlanFragment fragment = plan.getFragments().get(1);
-            assertContains(fragment.getExplainString(TExplainLevel.NORMAL),  "join op: INNER JOIN (BUCKET_SHUFFLE)");
+            assertContains(fragment.getExplainString(TExplainLevel.NORMAL), "join op: INNER JOIN (BUCKET_SHUFFLE)");
             Assert.assertEquals(expectedParallelism, fragment.getParallelExecNum());
             Assert.assertEquals(1, fragment.getPipelineDop());
 
             // Case 2: colocate join should use fragment instance parallel.
-            sql = "select * from colocate1 left join colocate2 on colocate1.k1=colocate2.k1 and colocate1.k2=colocate2.k2;";
+            sql = "select * from colocate1 left join colocate2 " +
+                    "on colocate1.k1=colocate2.k1 and colocate1.k2=colocate2.k2;";
             plan = getExecPlan(sql);
             fragment = plan.getFragments().get(1);
             assertContains(fragment.getExplainString(TExplainLevel.NORMAL), "join op: LEFT OUTER JOIN (COLOCATE)");
@@ -2213,7 +2214,9 @@ public class JoinTest extends PlanTestBase {
             Assert.assertEquals(expectedParallelism, fragment.getPipelineDop());
 
             // Case 4: local bucket shuffle join succeeded by broadcast should use fragment instance parallel.
-            sql = "select a.v1 from t0 a join [bucket] t0 b on a.v1 = b.v2 and a.v2 = b.v1 join [broadcast] t0 c on a.v1 = c.v2";
+            sql = "select a.v1 from t0 a " +
+                    "join [bucket] t0 b on a.v1 = b.v2 and a.v2 = b.v1 " +
+                    "join [broadcast] t0 c on a.v1 = c.v2";
             plan = getExecPlan(sql);
             fragment = plan.getFragments().get(1);
             String fragmentString = fragment.getExplainString(TExplainLevel.NORMAL);


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others


## Problem Summary：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Local bucket shuffle and colocate join should use fragment instance parallel instead of pipeline parallel, to avoid local shuffle and too large in-filter in the left scan node, even if local bucket shuffle join is succeeded by a **broadcast join**.
Otherwise, the merged in-filter may be too large to push down to the storage level.

## Test
After this optimization, query21 of TPC-DS 100g on 4 BE each of which contains 16 vCPU decrease from 400ms to 160ms.
