### PR TITLE
Add restful api for runtime filter cache

### DIFF
--- a/be/src/http/CMakeLists.txt
+++ b/be/src/http/CMakeLists.txt
@@ -51,6 +51,7 @@ add_library(Webserver STATIC
   action/compaction_action.cpp
   action/update_config_action.cpp
   action/list_workgroup_action.cpp
+  action/runtime_filter_cache_action.cpp
   #  action/multi_start.cpp
   #  action/multi_show.cpp
   #  action/multi_commit.cpp

--- a/be/src/http/action/runtime_filter_cache_action.cpp
+++ b/be/src/http/action/runtime_filter_cache_action.cpp
@@ -1,0 +1,108 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present StarRocks Limited.
+
+#include "http/action/runtime_filter_cache_action.h"
+
+#include <rapidjson/document.h>
+#include <rapidjson/prettywriter.h>
+#include <rapidjson/rapidjson.h>
+#include <rapidjson/stringbuffer.h>
+
+#include <string>
+
+#include "common/logging.h"
+#include "gutil/strings/substitute.h"
+#include "http/http_channel.h"
+#include "http/http_headers.h"
+#include "http/http_request.h"
+#include "http/http_status.h"
+
+namespace starrocks {
+
+const static std::string HEADER_JSON = "application/json";
+const static std::string ACTION_KEY = "action";
+const static std::string ACTION_STAT = "stat";
+const static std::string ACTION_TRACE = "trace";
+const static std::string ACTION_ENABLE_TRACE = "enable_trace";
+const static std::string ACTION_DISABLE_TRACE = "disable_trace";
+
+void RuntimeFilterCacheAction::handle(HttpRequest* req) {
+    LOG(INFO) << req->debug_string();
+    const auto& action = req->param(ACTION_KEY);
+    if (req->method() == HttpMethod::GET) {
+        if (action == ACTION_STAT) {
+            _handle_stat(req);
+        } else if (action == ACTION_TRACE) {
+            _handle_trace(req);
+        } else {
+            _handle_error(req, strings::Substitute("Not support GET method: '$0'", req->uri()));
+        }
+    } else if (req->method() == HttpMethod::PUT) {
+        if (action == ACTION_ENABLE_TRACE) {
+            _handle_trace_switch(req, true);
+        } else if (action == ACTION_DISABLE_TRACE) {
+            _handle_trace_switch(req, false);
+        } else {
+            _handle_error(req, strings::Substitute("Not support PUT method: '$0'", req->uri()));
+        }
+    } else {
+        _handle_error(req,
+                      strings::Substitute("Not support $0 method: '$1'", to_method_desc(req->method()), req->uri()));
+    }
+}
+void RuntimeFilterCacheAction::_handle(HttpRequest* req, std::function<void(rapidjson::Document&)> func) {
+    rapidjson::Document root;
+    root.SetObject();
+    func(root);
+    rapidjson::StringBuffer strbuf;
+    rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(strbuf);
+    root.Accept(writer);
+    req->add_output_header(HttpHeaders::CONTENT_TYPE, HEADER_JSON.c_str());
+    HttpChannel::send_reply(req, HttpStatus::OK, strbuf.GetString());
+}
+void RuntimeFilterCacheAction::_handle_stat(HttpRequest* req) {
+    size_t cache_times = _exec_env->runtime_filter_cache()->cache_times();
+    size_t use_times = _exec_env->runtime_filter_cache()->use_times();
+    const std::string& enable_trace = _exec_env->runtime_filter_cache()->enable_trace() ? "true" : "false";
+    _handle(req, [=](rapidjson::Document& root) {
+        auto& allocator = root.GetAllocator();
+        root.AddMember("cache_times", rapidjson::Value(cache_times), allocator);
+        root.AddMember("use_times", rapidjson::Value(use_times), allocator);
+        root.AddMember("enable_trace", rapidjson::Value(enable_trace.c_str(), enable_trace.size()), allocator);
+    });
+}
+
+void RuntimeFilterCacheAction::_handle_trace(HttpRequest* req) {
+    auto events = _exec_env->runtime_filter_cache()->get_events();
+    _handle(req, [&](rapidjson::Document& root) {
+        auto& allocator = root.GetAllocator();
+        rapidjson::Document traces_obj;
+        traces_obj.SetArray();
+        for (auto it = events.begin(); it != events.end(); ++it) {
+            rapidjson::Document query_obj;
+            query_obj.SetObject();
+            query_obj.AddMember("query_id", rapidjson::Value(it->first.c_str(), it->first.size()), allocator);
+            rapidjson::Document query_events;
+            query_events.SetArray();
+            for (auto& s : it->second) {
+                query_events.PushBack(rapidjson::Value(s.c_str(), s.size()), allocator);
+            }
+            query_obj.AddMember("events", query_events, allocator);
+            traces_obj.PushBack(query_obj, allocator);
+        }
+        root.AddMember("traces", traces_obj, allocator);
+    });
+}
+
+void RuntimeFilterCacheAction::_handle_trace_switch(HttpRequest* req, bool on) {
+    _exec_env->runtime_filter_cache()->set_enable_trace(on);
+    _handle_stat(req);
+}
+
+void RuntimeFilterCacheAction::_handle_error(HttpRequest* req, const std::string& err_msg) {
+    _handle(req, [err_msg](rapidjson::Document& root) {
+        auto& allocator = root.GetAllocator();
+        root.AddMember("error", rapidjson::Value(err_msg.c_str(), err_msg.size()), allocator);
+    });
+}
+
+} // namespace starrocks

--- a/be/src/http/action/runtime_filter_cache_action.h
+++ b/be/src/http/action/runtime_filter_cache_action.h
@@ -31,8 +31,6 @@ private:
     void _handle_trace_switch(HttpRequest* req, bool on);
     void _handle_error(HttpRequest* req, const std::string& error_msg);
     ExecEnv* _exec_env;
-    std::once_flag _once_flag;
-    std::unordered_map<std::string, std::function<void()>> _config_callback;
 };
 
 } // namespace starrocks

--- a/be/src/http/action/runtime_filter_cache_action.h
+++ b/be/src/http/action/runtime_filter_cache_action.h
@@ -1,0 +1,38 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present StarRocks Limited.
+
+#pragma once
+
+#include <rapidjson/document.h>
+#include <rapidjson/prettywriter.h>
+#include <rapidjson/rapidjson.h>
+#include <rapidjson/stringbuffer.h>
+
+#include <functional>
+#include <mutex>
+#include <unordered_map>
+
+#include "http/http_handler.h"
+#include "runtime/exec_env.h"
+
+namespace starrocks {
+
+// Update BE config.
+class RuntimeFilterCacheAction : public HttpHandler {
+public:
+    explicit RuntimeFilterCacheAction(ExecEnv* exec_env) : _exec_env(exec_env) {}
+    ~RuntimeFilterCacheAction() override = default;
+
+    void handle(HttpRequest* req) override;
+
+private:
+    void _handle(HttpRequest* req, std::function<void(rapidjson::Document& root)> func);
+    void _handle_stat(HttpRequest* req);
+    void _handle_trace(HttpRequest* req);
+    void _handle_trace_switch(HttpRequest* req, bool on);
+    void _handle_error(HttpRequest* req, const std::string& error_msg);
+    ExecEnv* _exec_env;
+    std::once_flag _once_flag;
+    std::unordered_map<std::string, std::function<void()>> _config_callback;
+};
+
+} // namespace starrocks

--- a/be/src/service/http_service.cpp
+++ b/be/src/service/http_service.cpp
@@ -31,6 +31,7 @@
 #include "http/action/pprof_actions.h"
 #include "http/action/reload_tablet_action.h"
 #include "http/action/restore_tablet_action.h"
+#include "http/action/runtime_filter_cache_action.h"
 #include "http/action/snapshot_action.h"
 #include "http/action/stream_load.h"
 #include "http/action/update_config_action.h"
@@ -175,6 +176,13 @@ Status HttpService::start() {
     ListWorkGroupAction* list_workgroup_action = new ListWorkGroupAction(_env);
     _ev_http_server->register_handler(HttpMethod::POST, "/api/list_resource_groups", list_workgroup_action);
     _http_handlers.emplace_back(list_workgroup_action);
+
+    RuntimeFilterCacheAction* runtime_filter_cache_action = new RuntimeFilterCacheAction(_env);
+    _ev_http_server->register_handler(HttpMethod::GET, "/api/runtime_filter_cache/{action}",
+                                      runtime_filter_cache_action);
+    _ev_http_server->register_handler(HttpMethod::PUT, "/api/runtime_filter_cache/{action}",
+                                      runtime_filter_cache_action);
+    _http_handlers.emplace_back(runtime_filter_cache_action);
 
     RETURN_IF_ERROR(_ev_http_server->start());
     return Status::OK();


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
https://github.com/StarRocks/starrocks/issues/4832
Add restful api for RuntimeFilterCache
1. GET ${be_host}:${be_http_port}/api/runtime_filter_cache/stat: show cache_times and use_times.
2. GET ${be_host}:${be_http_port}/api/runtime_filter_cache/trace: show trace events of runtime filters in each query.
3. PUT ${be_host}:${be_http_port}/api/runtime_filter_cache/enable_trace: enble runtime filter trace in BE.
4. PUT ${be_host}:${be_http_port}/api/runtime_filter_cache/disable_trace: disable runtime filter trace in BE.