### PR TITLE
Avoid use after free when _workgroups.erase(wg_it) first

### DIFF
--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -191,8 +191,8 @@ void WorkGroupManager::apply(const std::vector<TWorkGroupOp>& ops) {
         auto wg_it = _workgroups.find(*it);
         DCHECK(wg_it != _workgroups.end());
         if (wg_it->second->is_removable()) {
-            _workgroups.erase(wg_it);
             _sum_cpu_limit -= wg_it->second->cpu_limit();
+            _workgroups.erase(wg_it);
             _workgroup_expired_versions.erase(it++);
         } else {
             ++it;


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Crash after be start.
![image](https://user-images.githubusercontent.com/26759882/161958602-314e6306-cc32-4da4-8310-3ad87abf9723.png)

