### PR TITLE
Add restriction on stream load partial_update field.

### DIFF
--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -431,10 +431,14 @@ Status StreamLoadAction::_process_put(HttpRequest* http_req, StreamLoadContext* 
     } else {
         request.__set_strip_outer_array(false);
     }
-    if (http_req->header(HTTP_PARTIAL_UPDATE) == "true") {
-        request.__set_partial_update(true);
-    } else {
-        request.__set_partial_update(false);
+    if (!http_req->header(HTTP_PARTIAL_UPDATE).empty()) {
+        if (boost::iequals(http_req->header(HTTP_PARTIAL_UPDATE), "false")) {
+            request.__set_partial_update(false);
+        } else if (boost::iequals(http_req->header(HTTP_PARTIAL_UPDATE), "true")) {
+            request.__set_partial_update(true);
+        } else {
+            return Status::InvalidArgument("Invalid partial update flag format. Must be bool type");
+        }
     }
     if (!http_req->header(HTTP_TRANSMISSION_COMPRESSION_TYPE).empty()) {
         request.__set_transmission_compression_type(http_req->header(HTTP_TRANSMISSION_COMPRESSION_TYPE));


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4613

## Problem Summary

```
CREATE TABLE `primary_table` (
                `k1` date,
                `k2` datetime,
                `k3` varchar(20),
                `k4` varchar(20),
                `k5` boolean,
                `v1` tinyint NULL,
                `v2` smallint NULL,
                `v3` int NULL,
                `v4` bigint NULL,
                `v5` largeint NULL,
                `v6` float NULL,
                `v7` double NULL,
                `v8` decimal(27,9) NULL,
                `v9` string null
            ) ENGINE=OLAP
            PRIMARY KEY(`k1`)
            COMMENT "OLAP"
            DISTRIBUTED BY HASH(`k1`) BUCKETS 3
            PROPERTIES (
                "replication_num" = "1",
                "storage_format" = "v2"
            );

curl --location-trusted -u root: -T /home/disk2/jenkins/branch_test/partial_update/StarRocksTest/lib/../common/data/basic_types_data_value_null -XPUT -H label:stream_load_1648638477503 -H partial_update:43823 -H columns:k1,k2,k3,k4,k5,v1,v2,v3,v4,v5,v6,v7,tmp http://ip:port/api/partial_update_stream_load_a790aeac_b019_11ec_9fb2_00163e0e489a/primary_table/_stream_load
```
as above, 43823 is invalid value, this PR add the invalid value check.