### PR TITLE
SHOW PROC '/statistic' with non-existent db id now fail loudly

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/StatisticProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/StatisticProcDir.java
@@ -233,6 +233,10 @@ public class StatisticProcDir implements ProcDirInterface {
             throw new AnalysisException("Invalid db id format: " + dbIdStr);
         }
 
+        if (catalog.getDb(dbId) == null) {
+            throw new AnalysisException("Invalid db id : " + dbIdStr);
+        }
+
         return new IncompleteTabletsProcNode(unhealthyTabletIds.get(dbId),
                 inconsistentTabletIds.get(dbId),
                 cloningTabletIds.get(dbId));

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/StatisticProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/StatisticProcDir.java
@@ -234,7 +234,7 @@ public class StatisticProcDir implements ProcDirInterface {
         }
 
         if (catalog.getDb(dbId) == null) {
-            throw new AnalysisException("Invalid db id : " + dbIdStr);
+            throw new AnalysisException("Invalid db id: " + dbIdStr);
         }
 
         return new IncompleteTabletsProcNode(unhealthyTabletIds.get(dbId),

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/StatisticProcDirTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/StatisticProcDirTest.java
@@ -1,0 +1,15 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.common.proc;
+
+import com.starrocks.catalog.Catalog;
+import com.starrocks.common.AnalysisException;
+import org.junit.Test;
+
+public class StatisticProcDirTest {
+
+    @Test(expected = AnalysisException.class)
+    public void testLookupInvalid() throws AnalysisException {
+        new StatisticProcDir(Catalog.getCurrentCatalog()).lookup("12345");
+    }
+}


### PR DESCRIPTION
## What type of PR is this：
- [x] enhancement

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When execute a `SHOW PROC '/statistic/dbid'` statement with non-existent db id like:
```
SHOW PROC '/statistic/12345';
```
It should thraw an error but follow
```
mysql> SHOW PROC '/statistic/12345';
+------------------+---------------------+----------------+
| UnhealthyTablets | InconsistentTablets | CloningTablets |
+------------------+---------------------+----------------+
| []               | []                  | []             |
+------------------+---------------------+----------------+
```