### PR TITLE
BugFix: Add follower failed because of the the socket already used error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -2585,10 +2585,19 @@ public class Catalog {
 
             fe = new Frontend(role, nodeName, host, editLogPort);
             frontends.put(nodeName, fe);
+            BDBHA bdbha = (BDBHA) haProtocol;
             if (role == FrontendNodeType.FOLLOWER || role == FrontendNodeType.REPLICA) {
-                ((BDBHA) getHaProtocol()).addHelperSocket(host, editLogPort);
+                bdbha.addHelperSocket(host, editLogPort);
                 helperNodes.add(Pair.create(host, editLogPort));
             }
+
+            // In some cases, for example, fe starts with the outdated meta, the node name that has been dropped
+            // will remain in bdb.
+            // So we should remove those nodes before joining the group,
+            // or it will throws NodeConflictException (New or moved node:xxxx, is configured with the socket address:
+            // xxx. It conflicts with the socket already used by the member: xxxx)
+            bdbha.removeNodeIfExist(host, editLogPort);
+
             editLog.logAddFrontend(fe);
         } finally {
             unlock();

--- a/fe/fe-core/src/main/java/com/starrocks/ha/BDBHA.java
+++ b/fe/fe-core/src/main/java/com/starrocks/ha/BDBHA.java
@@ -224,4 +224,23 @@ public class BDBHA implements HAProtocol {
             LOG.info("add {}:{} to helper sockets", ip, port);
         }
     }
+
+    public void removeNodeIfExist(String host, int port) {
+        ReplicationGroupAdmin replicationGroupAdmin = environment.getReplicationGroupAdmin();
+        if (replicationGroupAdmin == null) {
+            return;
+        }
+
+        List<String> conflictNodes = Lists.newArrayList();
+        Set<ReplicationNode> nodes = replicationGroupAdmin.getGroup().getElectableNodes();
+        for (ReplicationNode node : nodes) {
+            if (node.getHostName().equals(host) && node.getPort() == port) {
+                conflictNodes.add(node.getName());
+            }
+        }
+
+        for (String nodeName : conflictNodes) {
+            removeElectableNode(nodeName);
+        }
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
If FE starts with the outdated meta, the node's name remains in BDB-JE after being dropped. So we should remove those nodes before joining the group.