### PR TITLE
 Build key columns after fetch each chunk from right table

### DIFF
--- a/be/src/exec/vectorized/hash_join_node.cpp
+++ b/be/src/exec/vectorized/hash_join_node.cpp
@@ -183,8 +183,13 @@ void HashJoinNode::_init_hash_table_param(HashTableParam* param) {
     }
     param->predicate_slots = predicate_slots;
 
-    for (auto i = 0; i < _probe_expr_ctxs.size(); i++) {
-        param->join_keys.emplace_back(JoinKeyDesc{_probe_expr_ctxs[i]->root()->type().type, _is_null_safes[i]});
+    for (auto i = 0; i < _build_expr_ctxs.size(); i++) {
+        Expr* expr = _build_expr_ctxs[i]->root();
+        if (expr->is_slotref()) {
+            param->join_keys.emplace_back(JoinKeyDesc{&expr->type(), _is_null_safes[i], down_cast<ColumnRef*>(expr)});
+        } else {
+            param->join_keys.emplace_back(JoinKeyDesc{&expr->type(), _is_null_safes[i], nullptr});
+        }
     }
 }
 
@@ -227,14 +232,18 @@ Status HashJoinNode::open(RuntimeState* state) {
         }
 
         {
+            SCOPED_TIMER(_build_conjunct_evaluate_timer);
+            _evaluate_build_keys(chunk);
+        }
+
+        {
             // copy chunk of right table
             SCOPED_TIMER(_copy_right_table_chunk_timer);
-            TRY_CATCH_BAD_ALLOC(_ht.append_chunk(state, chunk));
+            TRY_CATCH_BAD_ALLOC(_ht.append_chunk(state, chunk, _key_columns));
         }
     }
 
     {
-        // build hash table: compute key columns, and then build the hash table.
         RETURN_IF_ERROR(_build(state));
         COUNTER_SET(_build_rows_counter, static_cast<int64_t>(_ht.get_row_count()));
         COUNTER_SET(_build_buckets_counter, static_cast<int64_t>(_ht.get_bucket_size()));
@@ -526,41 +535,19 @@ bool HashJoinNode::_has_null(const ColumnPtr& column) {
 }
 
 Status HashJoinNode::_build(RuntimeState* state) {
-    {
-        SCOPED_TIMER(_build_conjunct_evaluate_timer);
-        // Currently, in order to implement simplicity, HashJoinNode uses BigChunk,
-        // Splice the Chunks from Scan on the right table into a big Chunk
-        // In some scenarios, such as when the left and right tables are selected incorrectly
-        // or when the large table is joined, the (BinaryColumn) in the Chunk exceeds the range of uint32_t,
-        // which will cause the output of wrong data.
-        // Currently, a defense needs to be added.
-        // After a better solution is available, the BigChunk mechanism can be removed.
-        if (_ht.get_build_chunk()->reach_capacity_limit()) {
-            return Status::InternalError("Total size of single column exceed the limit of hash join");
-        }
-
-        for (auto& _build_expr_ctx : _build_expr_ctxs) {
-            const TypeDescriptor& data_type = _build_expr_ctx->root()->type();
-            ColumnPtr column_ptr = _build_expr_ctx->evaluate(_ht.get_build_chunk().get());
-            if (column_ptr->is_nullable() && column_ptr->is_constant()) {
-                ColumnPtr column = ColumnHelper::create_column(data_type, true);
-                column->append_nulls(_ht.get_build_chunk()->num_rows());
-                _ht.get_key_columns().emplace_back(column);
-            } else if (column_ptr->is_constant()) {
-                auto* const_column = ColumnHelper::as_raw_column<ConstColumn>(column_ptr);
-                const_column->data_column()->assign(_ht.get_build_chunk()->num_rows(), 0);
-                _ht.get_key_columns().emplace_back(const_column->data_column());
-            } else {
-                _ht.get_key_columns().emplace_back(column_ptr);
-            }
-        }
+    // Currently, in order to implement simplicity, HashJoinNode uses BigChunk,
+    // Splice the Chunks from Scan on the right table into a big Chunk
+    // In some scenarios, such as when the left and right tables are selected incorrectly
+    // or when the large table is joined, the (BinaryColumn) in the Chunk exceeds the range of uint32_t,
+    // which will cause the output of wrong data.
+    // Currently, a defense needs to be added.
+    // After a better solution is available, the BigChunk mechanism can be removed.
+    if (_ht.get_build_chunk()->reach_capacity_limit()) {
+        return Status::InternalError("Total size of single column exceed the limit of hash join");
     }
-
-    {
-        SCOPED_TIMER(_build_ht_timer);
-        TRY_CATCH_BAD_ALLOC(_ht.build(state));
-    }
-
+    // build hash table
+    SCOPED_TIMER(_build_ht_timer);
+    TRY_CATCH_BAD_ALLOC(_ht.build(state));
     return Status::OK();
 }
 
@@ -572,6 +559,28 @@ static inline bool check_chunk_zero_and_create_new(ChunkPtr* chunk) {
         return true;
     }
     return false;
+}
+
+void HashJoinNode::_evaluate_build_keys(const ChunkPtr& chunk) {
+    _key_columns.resize(0);
+    size_t num_rows = chunk->num_rows();
+    for (auto& ctx : _build_expr_ctxs) {
+        const TypeDescriptor& data_type = ctx->root()->type();
+        ColumnPtr key_column = ctx->evaluate(chunk.get());
+        if (key_column->is_constant()) {
+            if (key_column->is_nullable()) {
+                ColumnPtr column = ColumnHelper::create_column(data_type, true);
+                column->append_nulls(num_rows);
+                _key_columns.emplace_back(column);
+            } else {
+                auto* const_column = ColumnHelper::as_raw_column<ConstColumn>(key_column);
+                const_column->data_column()->assign(num_rows, 0);
+                _key_columns.emplace_back(const_column->data_column());
+            }
+        } else {
+            _key_columns.emplace_back(key_column);
+        }
+    }
 }
 
 Status HashJoinNode::_probe(RuntimeState* state, ScopedTimer<MonotonicStopWatch>& probe_timer, ChunkPtr* chunk,

--- a/be/src/exec/vectorized/hash_join_node.h
+++ b/be/src/exec/vectorized/hash_join_node.h
@@ -59,6 +59,8 @@ private:
     Status _probe(RuntimeState* state, ScopedTimer<MonotonicStopWatch>& probe_timer, ChunkPtr* chunk, bool& eos);
     Status _probe_remain(ChunkPtr* chunk, bool& eos);
 
+    void _evaluate_build_keys(const ChunkPtr& chunk);
+
     void _calc_filter_for_other_conjunct(ChunkPtr* chunk, Column::Filter& filter, bool& filter_all, bool& hit_all);
     static void _process_row_for_other_conjunct(ChunkPtr* chunk, size_t start_column, size_t column_count,
                                                 bool filter_all, bool hit_all, const Column::Filter& filter);

--- a/be/src/exec/vectorized/hash_joiner.h
+++ b/be/src/exec/vectorized/hash_joiner.h
@@ -181,11 +181,6 @@ private:
         }
     }
 
-    void _prepare_build_key_columns() {
-        SCOPED_TIMER(_build_conjunct_evaluate_timer);
-        _prepare_key_columns(_ht.get_key_columns(), _ht.get_build_chunk(), _build_expr_ctxs);
-    }
-
     void _prepare_probe_key_columns() {
         SCOPED_TIMER(_probe_conjunct_evaluate_timer);
         _prepare_key_columns(_key_columns, _probe_input_chunk, _probe_expr_ctxs);

--- a/be/src/exec/vectorized/join_hash_map.cpp
+++ b/be/src/exec/vectorized/join_hash_map.cpp
@@ -320,6 +320,16 @@ void JoinHashTable::create(const HashTableParam& param) {
             _table_items->output_build_tuple_ids.emplace_back(tuple_desc->id());
         }
     }
+
+    for (const auto& key_desc : _table_items->join_keys) {
+        if (key_desc.col_ref) {
+            _table_items->key_columns.emplace_back(nullptr);
+        } else {
+            auto key_column = ColumnHelper::create_column(*key_desc.type, false);
+            key_column->append_default();
+            _table_items->key_columns.emplace_back(key_column);
+        }
+    }
 }
 
 int64_t JoinHashTable::mem_usage() {
@@ -343,6 +353,15 @@ int64_t JoinHashTable::mem_usage() {
 }
 
 void JoinHashTable::build(RuntimeState* state) {
+    // If the join key is column ref of build chunk, fetch from build chunk directly
+    size_t join_key_count = _table_items->join_keys.size();
+    for (size_t i = 0; i < join_key_count; i++) {
+        if (_table_items->join_keys[i].col_ref != nullptr) {
+            SlotId slot_id = _table_items->join_keys[i].col_ref->slot_id();
+            _table_items->key_columns[i] = _table_items->build_chunk->get_column_by_slot_id(slot_id);
+        }
+    }
+
     _hash_map_type = _choose_join_hash_map();
 
     switch (_hash_map_type) {
@@ -393,7 +412,7 @@ void JoinHashTable::probe_remain(RuntimeState* state, ChunkPtr* chunk, bool* eos
     }
 }
 
-void JoinHashTable::append_chunk(RuntimeState* state, const ChunkPtr& chunk) {
+void JoinHashTable::append_chunk(RuntimeState* state, const ChunkPtr& chunk, const Columns& key_columns) {
     Columns& columns = _table_items->build_chunk->columns();
 
     for (size_t i = 0; i < _table_items->build_column_count; i++) {
@@ -405,6 +424,20 @@ void JoinHashTable::append_chunk(RuntimeState* state, const ChunkPtr& chunk) {
             columns[i] = NullableColumn::create(columns[i], NullColumn::create(columns[i]->size(), 0));
         }
         columns[i]->append(*column);
+    }
+
+    for (size_t i = 0; i < _table_items->key_columns.size(); i++) {
+        // If the join key is slot ref, will get from build chunk directly,
+        // otherwise will append from key_column of input
+        if (_table_items->join_keys[i].col_ref == nullptr) {
+            // upgrade to nullable column
+            if (!_table_items->key_columns[i]->is_nullable() && key_columns[i]->is_nullable()) {
+                size_t row_count = _table_items->key_columns[i]->size();
+                _table_items->key_columns[i] =
+                        NullableColumn::create(_table_items->key_columns[i], NullColumn::create(row_count, 0));
+            }
+            _table_items->key_columns[i]->append(*key_columns[i]);
+        }
     }
 
     if (_need_create_tuple_columns) {
@@ -468,7 +501,7 @@ JoinHashMapType JoinHashTable::_choose_join_hash_map() {
     }
 
     if (size == 1 && !_table_items->join_keys[0].is_null_safe_equal) {
-        switch (_table_items->join_keys[0].type) {
+        switch (_table_items->join_keys[0].type->type) {
         case PrimitiveType::TYPE_BOOLEAN:
             return JoinHashMapType::keyboolean;
         case PrimitiveType::TYPE_TINYINT:
@@ -513,7 +546,7 @@ JoinHashMapType JoinHashTable::_choose_join_hash_map() {
         if (join_key.is_null_safe_equal) {
             total_size_in_byte += 1;
         }
-        size_t s = _get_size_of_fixed_and_contiguous_type(join_key.type);
+        size_t s = _get_size_of_fixed_and_contiguous_type(join_key.type->type);
         if (s > 0) {
             total_size_in_byte += s;
         } else {

--- a/be/src/exec/vectorized/join_hash_map.h
+++ b/be/src/exec/vectorized/join_hash_map.h
@@ -65,8 +65,9 @@ enum class JoinHashMapType {
 enum class JoinMatchFlag { NORMAL, ALL_NOT_MATCH, ALL_MATCH_ONE, MOST_MATCH_ONE };
 
 struct JoinKeyDesc {
-    PrimitiveType type;
+    const TypeDescriptor* type = nullptr;
     bool is_null_safe_equal;
+    ColumnRef* col_ref = nullptr;
 };
 
 struct HashTableSlotDescriptor {
@@ -577,7 +578,7 @@ public:
     void probe(RuntimeState* state, const Columns& key_columns, ChunkPtr* probe_chunk, ChunkPtr* chunk, bool* eos);
     void probe_remain(RuntimeState* state, ChunkPtr* chunk, bool* eos);
 
-    void append_chunk(RuntimeState* state, const ChunkPtr& chunk);
+    void append_chunk(RuntimeState* state, const ChunkPtr& chunk, const Columns& key_columns);
 
     const ChunkPtr& get_build_chunk() const { return _table_items->build_chunk; }
     Columns& get_key_columns() { return _table_items->key_columns; }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4862 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Currently Expr framework don't support LargeBinaryColumn, and HashJoin will build LargeChunk first and then evaluate the build key columns, so HashJoin don't support LargeBinaryColumn which larger than 4G.

So i will evaluate the build key columns first and then append to build key column, And this also makes the interface of hash table more clearer.
