### PR TITLE
[optimize] Reducing the memory footprint of columnReader. (#4873)

### DIFF
--- a/be/src/storage/rowset/column_reader.cpp
+++ b/be/src/storage/rowset/column_reader.cpp
@@ -57,11 +57,7 @@ StatusOr<std::unique_ptr<ColumnReader>> ColumnReader::create(ColumnMetaPB* meta,
 }
 
 ColumnReader::ColumnReader(const private_type&, Segment* segment)
-        : _zone_map_index(),
-          _ordinal_index(),
-          _bitmap_index(),
-          _bloom_filter_index(),
-          _segment(segment) {
+        : _zone_map_index(), _ordinal_index(), _bitmap_index(), _bloom_filter_index(), _segment(segment) {
     mem_tracker()->consume(sizeof(ColumnReader));
 }
 

--- a/be/src/storage/rowset/column_reader.cpp
+++ b/be/src/storage/rowset/column_reader.cpp
@@ -50,13 +50,13 @@
 
 namespace starrocks {
 
-StatusOr<std::unique_ptr<ColumnReader>> ColumnReader::create(ColumnMetaPB* meta, Segment* segment) {
+StatusOr<std::unique_ptr<ColumnReader>> ColumnReader::create(ColumnMetaPB* meta, const Segment* segment) {
     auto r = std::make_unique<ColumnReader>(private_type(0), segment);
     RETURN_IF_ERROR(r->_init(meta));
     return std::move(r);
 }
 
-ColumnReader::ColumnReader(const private_type&, Segment* segment)
+ColumnReader::ColumnReader(const private_type&, const Segment* segment)
         : _zone_map_index(), _ordinal_index(), _bitmap_index(), _bloom_filter_index(), _segment(segment) {
     mem_tracker()->consume(sizeof(ColumnReader));
 }

--- a/be/src/storage/rowset/column_reader.cpp
+++ b/be/src/storage/rowset/column_reader.cpp
@@ -50,28 +50,19 @@
 
 namespace starrocks {
 
-StatusOr<std::unique_ptr<ColumnReader>> ColumnReader::create(MemTracker* mem_tracker,
-                                                             std::shared_ptr<fs::BlockManager> block_mgr,
-                                                             ColumnMetaPB* meta, const std::string& file_name,
-                                                             uint32_t storage_format_version, bool kept_in_memory) {
-    auto r = std::make_unique<ColumnReader>(private_type(0), mem_tracker, std::move(block_mgr), file_name,
-                                            storage_format_version, kept_in_memory);
+StatusOr<std::unique_ptr<ColumnReader>> ColumnReader::create(ColumnMetaPB* meta, Segment* segment) {
+    auto r = std::make_unique<ColumnReader>(private_type(0), segment);
     RETURN_IF_ERROR(r->_init(meta));
     return std::move(r);
 }
 
-ColumnReader::ColumnReader(const private_type&, MemTracker* mem_tracker, std::shared_ptr<fs::BlockManager> block_mgr,
-                           const std::string& file_name, uint32_t storage_format_version, bool kept_in_memory)
-        : _mem_tracker(mem_tracker),
-          _block_mgr(std::move(block_mgr)),
-          _file_name(file_name),
-          _zone_map_index(),
+ColumnReader::ColumnReader(const private_type&, Segment* segment)
+        : _zone_map_index(),
           _ordinal_index(),
           _bitmap_index(),
           _bloom_filter_index(),
-          _storage_format_version(storage_format_version),
-          _kept_in_memory(kept_in_memory) {
-    _mem_tracker->consume(sizeof(ColumnReader));
+          _segment(segment) {
+    mem_tracker()->consume(sizeof(ColumnReader));
 }
 
 ColumnReader::~ColumnReader() {
@@ -108,14 +99,12 @@ ColumnReader::~ColumnReader() {
         size += _bloom_filter_index.reader->mem_usage();
         delete _bloom_filter_index.reader;
     }
-    _mem_tracker->release(size);
+    mem_tracker()->release(size);
 }
 
 Status ColumnReader::_init(ColumnMetaPB* meta) {
-    _column_length = meta->length();
     _column_type = static_cast<FieldType>(meta->type());
     _dict_page_pointer = PagePointer(meta->dict_page());
-    _num_rows = meta->num_rows();
     _total_mem_footprint = meta->total_mem_footprint();
     _flags.set(kHasAllDictEncodedPos, meta->has_all_dict_encoded());
     _flags.set(kAllDictEncodedPos, meta->all_dict_encoded());
@@ -126,7 +115,6 @@ Status ColumnReader::_init(ColumnMetaPB* meta) {
         const JsonMetaPB& json_meta = meta->json_meta();
         CHECK_EQ(kJsonMetaDefaultFormatVersion, json_meta.format_version()) << "Only format_version=1 is supported";
     }
-
     if (is_scalar_field_type(delegate_type(_column_type))) {
         RETURN_IF_ERROR(EncodingInfo::get(delegate_type(_column_type), meta->encoding(), &_encoding_info));
         RETURN_IF_ERROR(get_block_compression_codec(meta->compression(), &_compress_codec));
@@ -137,31 +125,31 @@ Status ColumnReader::_init(ColumnMetaPB* meta) {
             case ORDINAL_INDEX:
                 _ordinal_index.meta = index_meta->release_ordinal_index();
                 _flags.set(kHasOrdinalIndexMetaPos, true);
-                _mem_tracker->consume(_ordinal_index.meta->SpaceUsedLong());
+                mem_tracker()->consume(_ordinal_index.meta->SpaceUsedLong());
                 break;
             case ZONE_MAP_INDEX:
                 _zone_map_index.meta = index_meta->release_zone_map_index();
                 _segment_zone_map.reset(_zone_map_index.meta->release_segment_zone_map());
                 _flags.set(kHasZoneMapIndexMetaPos, true);
-                _mem_tracker->consume(_zone_map_index.meta->SpaceUsedLong());
+                mem_tracker()->consume(_zone_map_index.meta->SpaceUsedLong());
                 break;
             case BITMAP_INDEX:
                 _bitmap_index.meta = index_meta->release_bitmap_index();
                 _flags.set(kHasBitmapIndexMetaPos, true);
-                _mem_tracker->consume(_bitmap_index.meta->SpaceUsedLong());
+                mem_tracker()->consume(_bitmap_index.meta->SpaceUsedLong());
                 break;
             case BLOOM_FILTER_INDEX:
                 _bloom_filter_index.meta = index_meta->release_bloom_filter_index();
                 _flags.set(kHasBloomFilterIndexMetaPos, true);
-                _mem_tracker->consume(_bloom_filter_index.meta->SpaceUsedLong());
+                mem_tracker()->consume(_bloom_filter_index.meta->SpaceUsedLong());
                 break;
             case UNKNOWN_INDEX_TYPE:
-                return Status::Corruption(fmt::format("Bad file {}: unknown index type", _file_name));
+                return Status::Corruption(fmt::format("Bad file {}: unknown index type", file_name()));
             }
         }
         if (!_flags[kHasOrdinalIndexMetaPos]) {
             return Status::Corruption(
-                    fmt::format("Bad file {}: missing ordinal index for column {}", _file_name, meta->column_id()));
+                    fmt::format("Bad file {}: missing ordinal index for column {}", file_name(), meta->column_id()));
         }
         return Status::OK();
     } else if (_column_type == FieldType::OLAP_FIELD_TYPE_ARRAY) {
@@ -173,20 +161,17 @@ Status ColumnReader::_init(ColumnMetaPB* meta) {
             _sub_readers->reserve(3);
 
             // elements
-            auto res = ColumnReader::create(_mem_tracker, _block_mgr, meta->mutable_children_columns(0), _file_name,
-                                            _storage_format_version, _kept_in_memory);
+            auto res = ColumnReader::create(meta->mutable_children_columns(0), _segment);
             RETURN_IF_ERROR(res);
             _sub_readers->emplace_back(std::move(res).value());
 
             // null flags
-            res = ColumnReader::create(_mem_tracker, _block_mgr, meta->mutable_children_columns(1), _file_name,
-                                       _storage_format_version, _kept_in_memory);
+            res = ColumnReader::create(meta->mutable_children_columns(1), _segment);
             RETURN_IF_ERROR(res);
             _sub_readers->emplace_back(std::move(res).value());
 
             // offsets
-            res = ColumnReader::create(_mem_tracker, _block_mgr, meta->mutable_children_columns(2), _file_name,
-                                       _storage_format_version, _kept_in_memory);
+            res = ColumnReader::create(meta->mutable_children_columns(2), _segment);
             RETURN_IF_ERROR(res);
             _sub_readers->emplace_back(std::move(res).value());
         } else {
@@ -196,14 +181,12 @@ Status ColumnReader::_init(ColumnMetaPB* meta) {
             _sub_readers->reserve(2);
 
             // elements
-            auto res = ColumnReader::create(_mem_tracker, _block_mgr, meta->mutable_children_columns(0), _file_name,
-                                            _storage_format_version, _kept_in_memory);
+            auto res = ColumnReader::create(meta->mutable_children_columns(0), _segment);
             RETURN_IF_ERROR(res);
             _sub_readers->emplace_back(std::move(res).value());
 
             // offsets
-            res = ColumnReader::create(_mem_tracker, _block_mgr, meta->mutable_children_columns(1), _file_name,
-                                       _storage_format_version, _kept_in_memory);
+            res = ColumnReader::create(meta->mutable_children_columns(1), _segment);
             RETURN_IF_ERROR(res);
             _sub_readers->emplace_back(std::move(res).value());
         }
@@ -230,7 +213,7 @@ Status ColumnReader::read_page(const ColumnIteratorOptions& iter_opts, const Pag
     opts.verify_checksum = true;
     opts.use_page_cache = iter_opts.use_page_cache;
     opts.encoding_type = _encoding_info->encoding();
-    opts.kept_in_memory = _kept_in_memory;
+    opts.kept_in_memory = keep_in_memory();
 
     return PageIO::read_and_decompress_page(opts, handle, page_body, footer);
 }
@@ -255,7 +238,7 @@ Status ColumnReader::_parse_zone_map(const ZoneMapPB& zm, vectorized::ZoneMapDet
         RETURN_IF_ERROR(vectorized::datum_from_string(type_info.get(), &(detail->min_value()), zm.min(), nullptr));
         RETURN_IF_ERROR(vectorized::datum_from_string(type_info.get(), &(detail->max_value()), zm.max(), nullptr));
     }
-    detail->set_num_rows(num_rows());
+    detail->set_num_rows(static_cast<size_t>(num_rows()));
     return Status::OK();
 }
 
@@ -299,12 +282,12 @@ Status ColumnReader::_load_ordinal_index(bool use_page_cache, bool kept_in_memor
         SCOPED_THREAD_LOCAL_CHECK_MEM_LIMIT_SETTER(false);
         std::unique_ptr<OrdinalIndexPB> index_meta(_ordinal_index.meta);
         _flags.set(kHasOrdinalIndexMetaPos, false);
-        _mem_tracker->release(index_meta->SpaceUsedLong());
+        mem_tracker()->release(index_meta->SpaceUsedLong());
         _ordinal_index.reader = new OrdinalIndexReader();
         _flags.set(kHasOrdinalIndexReaderPos, true);
-        st = _ordinal_index.reader->load(_block_mgr.get(), _file_name, index_meta.get(), _num_rows, use_page_cache,
+        st = _ordinal_index.reader->load(block_manager(), file_name(), index_meta.get(), num_rows(), use_page_cache,
                                          kept_in_memory);
-        _mem_tracker->consume(_ordinal_index.reader->mem_usage());
+        mem_tracker()->consume(_ordinal_index.reader->mem_usage());
     }
     return st;
 }
@@ -315,12 +298,12 @@ Status ColumnReader::_load_zone_map_index(bool use_page_cache, bool kept_in_memo
         SCOPED_THREAD_LOCAL_CHECK_MEM_LIMIT_SETTER(false);
         std::unique_ptr<ZoneMapIndexPB> index_meta(_zone_map_index.meta);
         _flags.set(kHasZoneMapIndexMetaPos, false);
-        _mem_tracker->release(index_meta->SpaceUsedLong());
+        mem_tracker()->release(index_meta->SpaceUsedLong());
         _zone_map_index.reader = new ZoneMapIndexReader();
         _flags.set(kHasZoneMapIndexReaderPos, true);
-        st = _zone_map_index.reader->load(_block_mgr.get(), _file_name, index_meta.get(), use_page_cache,
+        st = _zone_map_index.reader->load(block_manager(), file_name(), index_meta.get(), use_page_cache,
                                           kept_in_memory);
-        _mem_tracker->consume(_zone_map_index.reader->mem_usage());
+        mem_tracker()->consume(_zone_map_index.reader->mem_usage());
     }
     return st;
 }
@@ -331,11 +314,11 @@ Status ColumnReader::_load_bitmap_index(bool use_page_cache, bool kept_in_memory
         SCOPED_THREAD_LOCAL_CHECK_MEM_LIMIT_SETTER(false);
         std::unique_ptr<BitmapIndexPB> index_meta(_bitmap_index.meta);
         _flags.set(kHasBitmapIndexMetaPos, false);
-        _mem_tracker->release(index_meta->SpaceUsedLong());
+        mem_tracker()->release(index_meta->SpaceUsedLong());
         _bitmap_index.reader = new BitmapIndexReader();
         _flags.set(kHasBitmapIndexReaderPos, true);
-        st = _bitmap_index.reader->load(_block_mgr.get(), _file_name, index_meta.get(), use_page_cache, kept_in_memory);
-        _mem_tracker->consume(_bitmap_index.reader->mem_usage());
+        st = _bitmap_index.reader->load(block_manager(), file_name(), index_meta.get(), use_page_cache, kept_in_memory);
+        mem_tracker()->consume(_bitmap_index.reader->mem_usage());
     }
     return st;
 }
@@ -346,12 +329,12 @@ Status ColumnReader::_load_bloom_filter_index(bool use_page_cache, bool kept_in_
         SCOPED_THREAD_LOCAL_CHECK_MEM_LIMIT_SETTER(false);
         std::unique_ptr<BloomFilterIndexPB> index_meta(_bloom_filter_index.meta);
         _flags.set(kHasBloomFilterIndexMetaPos, false);
-        _mem_tracker->release(index_meta->SpaceUsedLong());
+        mem_tracker()->release(index_meta->SpaceUsedLong());
         _bloom_filter_index.reader = new BloomFilterIndexReader();
         _flags.set(kHasBloomFilterIndexReaderPos, true);
-        st = _bloom_filter_index.reader->load(_block_mgr.get(), _file_name, index_meta.get(), use_page_cache,
+        st = _bloom_filter_index.reader->load(block_manager(), file_name(), index_meta.get(), use_page_cache,
                                               kept_in_memory);
-        _mem_tracker->consume(_bloom_filter_index.reader->mem_usage());
+        mem_tracker()->consume(_bloom_filter_index.reader->mem_usage());
     }
     return st;
 }
@@ -448,19 +431,19 @@ Status ColumnReader::new_iterator(ColumnIterator** iterator) {
 
 Status ColumnReader::_load_zone_map_index_once() {
     Status status = _zonemap_index_once.call(
-            [this] { return _load_zone_map_index(!config::disable_storage_page_cache, _kept_in_memory); });
+            [this] { return _load_zone_map_index(!config::disable_storage_page_cache, keep_in_memory()); });
     return status;
 }
 
 Status ColumnReader::_load_bitmap_index_once() {
     Status status = _bitmap_index_once.call(
-            [this] { return _load_bitmap_index(!config::disable_storage_page_cache, _kept_in_memory); });
+            [this] { return _load_bitmap_index(!config::disable_storage_page_cache, keep_in_memory()); });
     return status;
 }
 
 Status ColumnReader::_load_bloom_filter_index_once() {
     Status status = _bloomfilter_index_once.call(
-            [this] { return _load_bloom_filter_index(!config::disable_storage_page_cache, _kept_in_memory); });
+            [this] { return _load_bloom_filter_index(!config::disable_storage_page_cache, keep_in_memory()); });
     return status;
 }
 
@@ -468,7 +451,7 @@ Status ColumnReader::load_ordinal_index_once() {
     // Only load ordinal index.
     // Other indexes like zone map/bitmap/bloomfilter should be load when necessary
     Status status = _ordinal_index_once.call(
-            [this] { return _load_ordinal_index(!config::disable_storage_page_cache, _kept_in_memory); });
+            [this] { return _load_ordinal_index(!config::disable_storage_page_cache, keep_in_memory()); });
     return status;
 }
 

--- a/be/src/storage/rowset/column_reader.h
+++ b/be/src/storage/rowset/column_reader.h
@@ -149,15 +149,15 @@ public:
 
     Status load_ordinal_index_once();
 
-    inline const std::string& file_name() const { return _segment->file_name(); }
+    const std::string& file_name() const { return _segment->file_name(); }
 
-    inline MemTracker* mem_tracker() const { return _segment->mem_tracker(); }
+    MemTracker* mem_tracker() const { return _segment->mem_tracker(); }
 
-    inline fs::BlockManager* block_manager() const { return _segment->block_manager(); }
+    fs::BlockManager* block_manager() const { return _segment->block_manager(); }
 
-    inline bool keep_in_memory() const { return _segment->keep_in_memory(); }
+    bool keep_in_memory() const { return _segment->keep_in_memory(); }
 
-    inline uint32_t num_rows() const { return _segment->num_rows(); }
+    uint32_t num_rows() const { return _segment->num_rows(); }
 
 private:
     struct private_type {

--- a/be/src/storage/rowset/column_reader.h
+++ b/be/src/storage/rowset/column_reader.h
@@ -149,6 +149,12 @@ public:
 
     Status load_ordinal_index_once();
 
+    uint32_t num_rows() const { return _segment->num_rows(); }
+
+    // this function is just used for unit test
+    uint32_t num_rows_from_meta_pb(const ColumnMetaPB* meta) const { return meta->num_rows(); }
+
+private:
     const std::string& file_name() const { return _segment->file_name(); }
 
     MemTracker* mem_tracker() const { return _segment->mem_tracker(); }
@@ -157,9 +163,6 @@ public:
 
     bool keep_in_memory() const { return _segment->keep_in_memory(); }
 
-    uint32_t num_rows() const { return _segment->num_rows(); }
-
-private:
     struct private_type {
         private_type(int) {}
     };

--- a/be/src/storage/rowset/column_reader.h
+++ b/be/src/storage/rowset/column_reader.h
@@ -35,12 +35,12 @@
 #include "gen_cpp/segment.pb.h" // for ColumnMetaPB
 #include "runtime/mem_pool.h"
 #include "storage/fs/fs_util.h"
-#include "storage/rowset/segment.h"
 #include "storage/rowset/bitmap_index_reader.h"
 #include "storage/rowset/bloom_filter_index_reader.h"
 #include "storage/rowset/common.h"
 #include "storage/rowset/ordinal_page_index.h" // for OrdinalPageIndexIterator
 #include "storage/rowset/page_handle.h"
+#include "storage/rowset/segment.h"
 #include "storage/rowset/zone_map_index.h"
 #include "storage/vectorized/range.h"
 #include "util/once.h"
@@ -154,7 +154,7 @@ public:
     inline MemTracker* mem_tracker() const { return _segment->mem_tracker(); }
 
     inline fs::BlockManager* block_manager() const { return _segment->block_manager(); }
-    
+
     inline bool keep_in_memory() const { return _segment->keep_in_memory(); }
 
     inline uint32_t num_rows() const { return _segment->num_rows(); }
@@ -211,10 +211,6 @@ private:
                             const vectorized::ColumnPredicate* del_predicate,
                             std::unordered_set<uint32_t>* del_partial_filtered_pages, std::vector<uint32_t>* pages);
 
-    // Pointer to its father segment, as the column reader 
-    // is never released before the end of the parent's life cycle, 
-    // so here we just use a normal pointer
-    Segment* _segment;
     // ColumnReader will be resident in memory. When there are many columns in the table,
     // the meta in ColumnReader takes up a lot of memory,
     // and now the content that is not needed in Meta is not saved to ColumnReader
@@ -245,8 +241,12 @@ private:
     StarRocksCallOnce<Status> _bitmap_index_once;
     StarRocksCallOnce<Status> _bloomfilter_index_once;
 
-    std::bitset<16> _flags;
+    // Pointer to its father segment, as the column reader
+    // is never released before the end of the parent's life cycle,
+    // so here we just use a normal pointer
+    Segment* _segment;
 
+    std::bitset<16> _flags;
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/column_reader.h
+++ b/be/src/storage/rowset/column_reader.h
@@ -85,9 +85,9 @@ public:
     // Note that |meta| is mutable, this method may change its internal state.
     //
     // To developers: keep this method lightweight, should not incur any I/O.
-    static StatusOr<std::unique_ptr<ColumnReader>> create(ColumnMetaPB* meta, Segment* segment);
+    static StatusOr<std::unique_ptr<ColumnReader>> create(ColumnMetaPB* meta, const Segment* segment);
 
-    ColumnReader(const private_type&, Segment* segment);
+    ColumnReader(const private_type&, const Segment* segment);
 
     ~ColumnReader();
 
@@ -244,7 +244,7 @@ private:
     // Pointer to its father segment, as the column reader
     // is never released before the end of the parent's life cycle,
     // so here we just use a normal pointer
-    Segment* _segment;
+    const Segment* _segment = nullptr;
 
     std::bitset<16> _flags;
 };

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -67,8 +67,9 @@ StatusOr<std::shared_ptr<Segment>> Segment::open(MemTracker* mem_tracker, std::s
                                                  const std::string& filename, uint32_t segment_id,
                                                  const TabletSchema* tablet_schema, size_t* footer_length_hint,
                                                  const FooterPointerPB* partial_rowset_footer) {
-    auto segment = std::shared_ptr<Segment>(new Segment(private_type(0), blk_mgr, filename, segment_id, tablet_schema, 
-                                            mem_tracker), DeleterWithMemTracker<Segment>(mem_tracker));
+    auto segment = std::shared_ptr<Segment>(
+            new Segment(private_type(0), blk_mgr, filename, segment_id, tablet_schema, mem_tracker),
+            DeleterWithMemTracker<Segment>(mem_tracker));
     mem_tracker->consume(segment->mem_usage());
 
     RETURN_IF_ERROR(segment->_open(mem_tracker, footer_length_hint, partial_rowset_footer));

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -67,8 +67,8 @@ StatusOr<std::shared_ptr<Segment>> Segment::open(MemTracker* mem_tracker, std::s
                                                  const std::string& filename, uint32_t segment_id,
                                                  const TabletSchema* tablet_schema, size_t* footer_length_hint,
                                                  const FooterPointerPB* partial_rowset_footer) {
-    auto segment = std::shared_ptr<Segment>(new Segment(private_type(0), blk_mgr, filename, segment_id, tablet_schema),
-                                            DeleterWithMemTracker<Segment>(mem_tracker));
+    auto segment = std::shared_ptr<Segment>(new Segment(private_type(0), blk_mgr, filename, segment_id, tablet_schema, 
+                                            mem_tracker), DeleterWithMemTracker<Segment>(mem_tracker));
     mem_tracker->consume(segment->mem_usage());
 
     RETURN_IF_ERROR(segment->_open(mem_tracker, footer_length_hint, partial_rowset_footer));
@@ -166,11 +166,12 @@ Status Segment::parse_segment_footer(fs::ReadableBlock* rblock, SegmentFooterPB*
 }
 
 Segment::Segment(const private_type&, std::shared_ptr<fs::BlockManager> blk_mgr, std::string fname, uint32_t segment_id,
-                 const TabletSchema* tablet_schema)
+                 const TabletSchema* tablet_schema, MemTracker* mem_tracker)
         : _block_mgr(std::move(blk_mgr)),
           _fname(std::move(fname)),
           _tablet_schema(tablet_schema),
-          _segment_id(segment_id) {}
+          _segment_id(segment_id),
+          _mem_tracker(mem_tracker) {}
 
 Status Segment::_open(MemTracker* mem_tracker, size_t* footer_length_hint,
                       const FooterPointerPB* partial_rowset_footer) {
@@ -278,8 +279,7 @@ Status Segment::_create_column_readers(MemTracker* mem_tracker, SegmentFooterPB*
             continue;
         }
 
-        auto res = ColumnReader::create(mem_tracker, _block_mgr, footer->mutable_columns(iter->second), _fname,
-                                        footer->version(), _tablet_schema->is_in_memory());
+        auto res = ColumnReader::create(footer->mutable_columns(iter->second), this);
         if (!res.ok()) {
             return res.status();
         }

--- a/be/src/storage/rowset/segment.h
+++ b/be/src/storage/rowset/segment.h
@@ -141,7 +141,7 @@ public:
 
     inline MemTracker* mem_tracker() const { return _mem_tracker; }
 
-    inline fs::BlockManager* block_manager() const { return _block_mgr.get();}
+    inline fs::BlockManager* block_manager() const { return _block_mgr.get(); }
 
     inline bool keep_in_memory() const { return _tablet_schema->is_in_memory(); }
 

--- a/be/src/storage/rowset/segment.h
+++ b/be/src/storage/rowset/segment.h
@@ -85,7 +85,7 @@ public:
                                        const FooterPointerPB* partial_rowset_footer);
 
     Segment(const private_type&, std::shared_ptr<fs::BlockManager> blk_mgr, std::string fname, uint32_t segment_id,
-            const TabletSchema* tablet_schema);
+            const TabletSchema* tablet_schema, MemTracker* mem_tracker);
 
     ~Segment() = default;
 
@@ -95,8 +95,6 @@ public:
                                             const vectorized::SegmentReadOptions& read_options);
 
     uint64_t id() const { return _segment_id; }
-
-    uint32_t num_rows() const { return _num_rows; }
 
     // TODO: remove this method, create `ColumnIterator` via `ColumnReader`.
     Status new_column_iterator(uint32_t cid, ColumnIterator** iter);
@@ -129,8 +127,6 @@ public:
         return _sk_index_decoder->num_items() - 1;
     }
 
-    const std::string& file_name() const { return _fname; }
-
     size_t num_columns() const { return _column_readers.size(); }
 
     const ColumnReader* column(size_t i) const { return _column_readers[i].get(); }
@@ -142,6 +138,16 @@ public:
         }
         return size;
     }
+
+    inline MemTracker* mem_tracker() const { return _mem_tracker; }
+
+    inline fs::BlockManager* block_manager() const { return _block_mgr.get();}
+
+    inline bool keep_in_memory() const { return _tablet_schema->is_in_memory(); }
+
+    inline const std::string& file_name() const { return _fname; }
+
+    inline uint32_t num_rows() const { return _num_rows; }
 
 private:
     Segment(const Segment&) = delete;
@@ -172,6 +178,7 @@ private:
     uint32_t _segment_id = 0;
     uint32_t _num_rows = 0;
     PagePointer _short_key_index_page;
+    MemTracker* _mem_tracker;
 
     // ColumnReader for each column in TabletSchema. If ColumnReader is nullptr,
     // This means that this segment has no data for that column, which may be added

--- a/be/src/storage/rowset/segment.h
+++ b/be/src/storage/rowset/segment.h
@@ -139,15 +139,15 @@ public:
         return size;
     }
 
-    inline MemTracker* mem_tracker() const { return _mem_tracker; }
+    MemTracker* mem_tracker() const { return _mem_tracker; }
 
-    inline fs::BlockManager* block_manager() const { return _block_mgr.get(); }
+    fs::BlockManager* block_manager() const { return _block_mgr.get(); }
 
-    inline bool keep_in_memory() const { return _tablet_schema->is_in_memory(); }
+    bool keep_in_memory() const { return _tablet_schema->is_in_memory(); }
 
-    inline const std::string& file_name() const { return _fname; }
+    const std::string& file_name() const { return _fname; }
 
-    inline uint32_t num_rows() const { return _num_rows; }
+    uint32_t num_rows() const { return _num_rows; }
 
 private:
     Segment(const Segment&) = delete;

--- a/be/test/storage/rowset/column_reader_writer_test.cpp
+++ b/be/test/storage/rowset/column_reader_writer_test.cpp
@@ -43,6 +43,8 @@
 #include "storage/rowset/column_writer.h"
 #include "storage/rowset/default_value_column_iterator.h"
 #include "storage/rowset/scalar_column_iterator.h"
+#include "storage/rowset/segment.h"
+#include "storage/storage_engine.h"
 #include "storage/tablet_schema_helper.h"
 #include "storage/types.h"
 #include "storage/vectorized/chunk_helper.h"
@@ -66,6 +68,47 @@ protected:
 
     void TearDown() override {}
 
+    std::shared_ptr<Segment> create_dummy_segment(const std::shared_ptr<fs::FileBlockManager>& block_mgr,
+                                                  const std::string& fname) {
+        int tablet_id = 1;
+        TCreateTabletReq request;
+        request.tablet_id = tablet_id;
+        request.__set_version(1);
+        request.__set_version_hash(0);
+        request.tablet_schema.schema_hash = 0;
+        request.tablet_schema.short_key_column_count = 6;
+        request.tablet_schema.keys_type = TKeysType::PRIMARY_KEYS;
+        request.tablet_schema.storage_type = TStorageType::COLUMN;
+
+        TColumn k1;
+        k1.column_name = "pk";
+        k1.__set_is_key(true);
+        k1.column_type.type = TPrimitiveType::BIGINT;
+        request.tablet_schema.columns.push_back(k1);
+
+        TColumn k2;
+        k2.column_name = "v1";
+        k2.__set_is_key(false);
+        k2.column_type.type = TPrimitiveType::SMALLINT;
+        request.tablet_schema.columns.push_back(k2);
+
+        TColumn k3;
+        k3.column_name = "v2";
+        k3.__set_is_key(false);
+        k3.column_type.type = TPrimitiveType::INT;
+        request.tablet_schema.columns.push_back(k3);
+
+        auto st = StorageEngine::instance()->create_tablet(request);
+        auto tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, false);
+        std::vector<int32_t> column_indexes;
+        std::shared_ptr<TabletSchema> tablet_schema = TabletSchema::create(tablet->tablet_schema(), column_indexes);
+
+        MemTracker* mem_tracker = _tablet_meta_mem_tracker.get();
+        return std::shared_ptr<Segment>(
+                new Segment(Segment::private_type(0), block_mgr, fname, 1, tablet_schema.get(), mem_tracker),
+                DeleterWithMemTracker<Segment>(mem_tracker));
+    }
+
     template <FieldType type, EncodingTypePB encoding, uint32_t version, bool adaptive = true>
     void test_nullable_data(const vectorized::Column& src, const std::string null_encoding = "0",
                             const std::string null_ratio = "0") {
@@ -82,6 +125,7 @@ protected:
 
         const std::string fname = strings::Substitute("$0/test-$1-$2-$3-$4-$5-$6.data", TEST_DIR, type, encoding,
                                                       version, adaptive, null_encoding, null_ratio);
+        auto segment = create_dummy_segment(block_mgr, fname);
         // write data
         {
             std::unique_ptr<fs::WritableBlock> wblock;
@@ -134,7 +178,7 @@ protected:
             std::unique_ptr<MemTracker> page_cache_mem_tracker = std::make_unique<MemTracker>();
             StoragePageCache::create_global_cache(page_cache_mem_tracker.get(), 1000000000);
             // read and check
-            auto res = ColumnReader::create(_tablet_meta_mem_tracker.get(), block_mgr, &meta, fname, version, false);
+            auto res = ColumnReader::create(&meta, segment.get());
             ASSERT_TRUE(res.ok());
             auto reader = std::move(res).value();
 
@@ -337,6 +381,7 @@ protected:
 
         // delete test file.
         const std::string fname = TEST_DIR + "/test_array_int.data";
+        auto segment = create_dummy_segment(block_mgr, fname);
         // write data
         {
             std::unique_ptr<fs::WritableBlock> wblock;
@@ -383,7 +428,7 @@ protected:
 
         // read and check
         {
-            auto res = ColumnReader::create(_tablet_meta_mem_tracker.get(), block_mgr, &meta, fname, version, false);
+            auto res = ColumnReader::create(&meta, segment.get());
             ASSERT_TRUE(res.ok());
             auto reader = std::move(res).value();
 
@@ -416,8 +461,7 @@ protected:
                 ASSERT_EQ("[4, 5, 6]", dst_column->debug_item(1));
             }
 
-            // check num
-            ASSERT_EQ(2, reader->num_rows());
+            ASSERT_EQ(2, reader->num_rows_from_meta_pb(&meta));
             ASSERT_EQ(36, reader->total_mem_footprint());
         }
     }
@@ -665,6 +709,7 @@ TEST_F(ColumnReaderWriterTest, test_scalar_column_total_mem_footprint) {
     auto block_mgr = std::make_shared<fs::FileBlockManager>(env, fs::BlockManagerOptions());
     ASSERT_TRUE(env->create_dir(TEST_DIR).ok());
     const std::string fname = strings::Substitute("$0/test_scalar_column_total_mem_footprint.data", TEST_DIR);
+    auto segment = create_dummy_segment(block_mgr, fname);
 
     // write data
     {
@@ -706,10 +751,10 @@ TEST_F(ColumnReaderWriterTest, test_scalar_column_total_mem_footprint) {
     // read and check
     {
         // read and check
-        auto res = ColumnReader::create(_tablet_meta_mem_tracker.get(), block_mgr, &meta, fname, 1, false);
+        auto res = ColumnReader::create(&meta, segment.get());
         ASSERT_TRUE(res.ok());
         auto reader = std::move(res).value();
-        ASSERT_EQ(1024, reader->num_rows());
+        ASSERT_EQ(1024, reader->num_rows_from_meta_pb(&meta));
         ASSERT_EQ(1024 * 4 + 1024, reader->total_mem_footprint());
     }
 }


### PR DESCRIPTION
In a large wide table scenario, a large number of Column Readers will occupy a lot of memory. This pr is mainly to strip the data structures that can be shared between Column Readers and put them into Segment.

Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_* 
-->
#4873

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
In a large wide table scenario, when there are many columns, a large number of Column Readers will occupy a lot of memory. This pr is mainly to strip the data structures that can be shared between Column Readers and put them into Segment. 
Share these data field between ColumnReaders: 
```c++
class ColumnReader {
    MemTracker* _mem_tracker;
    int32_t _column_length = 0; 
    std::shared_ptr<fs::BlockManager> _block_mgr; 
    uint64_t _num_rows = 0;  
    const std::string& _file_name;  
    
    uint32_t _storage_format_version;  
    bool _kept_in_memory; 
};
```