### PR TITLE
[WIP] Merge SHUFFLE_AGG/SHUFFLE_JOIN property

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ChildOutputPropertyGuarantor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ChildOutputPropertyGuarantor.java
@@ -7,7 +7,6 @@ import com.google.common.collect.Lists;
 import com.starrocks.catalog.Catalog;
 import com.starrocks.catalog.ColocateTableIndex;
 import com.starrocks.qe.ConnectContext;
-import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.base.DistributionProperty;
 import com.starrocks.sql.optimizer.base.DistributionSpec;
 import com.starrocks.sql.optimizer.base.HashDistributionDesc;
@@ -15,19 +14,13 @@ import com.starrocks.sql.optimizer.base.HashDistributionSpec;
 import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
 import com.starrocks.sql.optimizer.cost.CostModel;
 import com.starrocks.sql.optimizer.operator.Operator;
-import com.starrocks.sql.optimizer.operator.OperatorVisitor;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalDistributionOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalHashJoinOperator;
-import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
-import com.starrocks.sql.optimizer.rule.transformation.JoinPredicateUtils;
 import com.starrocks.sql.optimizer.task.TaskContext;
 
-import java.util.ArrayList;
 import java.util.List;
 
-import static com.starrocks.sql.optimizer.rule.transformation.JoinPredicateUtils.getEqConj;
-
-public class ChildOutputPropertyGuarantor extends OperatorVisitor<Void, ExpressionContext> {
+public class ChildOutputPropertyGuarantor extends PropertyDeriverBase<Void, ExpressionContext> {
     private PhysicalPropertySet requirements;
     // children best group expression
     private List<GroupExpression> childrenBestExprList;
@@ -118,11 +111,6 @@ public class ChildOutputPropertyGuarantor extends OperatorVisitor<Void, Expressi
         return true;
     }
 
-    private PhysicalPropertySet createPropertySetByDistribution(DistributionSpec distributionSpec) {
-        DistributionProperty distributionProperty = new DistributionProperty(distributionSpec);
-        return new PhysicalPropertySet(distributionProperty);
-    }
-
     // enforce child SHUFFLE type distribution
     private void enforceChildShuffleDistribution(List<Integer> shuffleColumns, GroupExpression child,
                                                  PhysicalPropertySet childOutputProperty, int childIndex) {
@@ -174,7 +162,7 @@ public class ChildOutputPropertyGuarantor extends OperatorVisitor<Void, Expressi
 
         DistributionSpec rightDistributionSpec =
                 DistributionSpec.createHashDistributionSpec(new HashDistributionDesc(bucketShuffleColumns,
-                        HashDistributionDesc.SourceType.BUCKET_JOIN));
+                        HashDistributionDesc.SourceType.BUCKET));
 
         GroupExpression rightChild = childrenBestExprList.get(1);
         PhysicalPropertySet rightChildOutputProperty = childrenOutputProperties.get(1);
@@ -214,16 +202,15 @@ public class ChildOutputPropertyGuarantor extends OperatorVisitor<Void, Expressi
         }
     }
 
-    private PhysicalPropertySet addChildEnforcer(PhysicalPropertySet oldOutputProperty,
-                                                 DistributionProperty newDistributionProperty,
-                                                 double childCost, Group childGroup) {
+    private void addChildEnforcer(PhysicalPropertySet oldOutputProperty,
+                                  DistributionProperty newDistributionProperty,
+                                  double childCost, Group childGroup) {
         PhysicalPropertySet newOutputProperty = oldOutputProperty.copy();
         newOutputProperty.setDistributionProperty(newDistributionProperty);
         GroupExpression enforcer = newDistributionProperty.appendEnforcers(childGroup);
 
         enforcer.setOutputPropertySatisfyRequiredProperty(newOutputProperty, newOutputProperty);
         updateChildCostWithEnforcer(enforcer, oldOutputProperty, newOutputProperty, childCost, childGroup);
-        return newOutputProperty;
     }
 
     private void updateChildCostWithEnforcer(GroupExpression enforcer,
@@ -262,19 +249,12 @@ public class ChildOutputPropertyGuarantor extends OperatorVisitor<Void, Expressi
             return visitOperator(node, context);
         }
         // 2. Distribution is shuffle
-        ColumnRefSet leftChildColumns = context.getChildOutputColumns(0);
-        ColumnRefSet rightChildColumns = context.getChildOutputColumns(1);
-        List<BinaryPredicateOperator> equalOnPredicate =
-                getEqConj(leftChildColumns, rightChildColumns, Utils.extractConjuncts(node.getOnPredicate()));
-
-        List<Integer> leftOnPredicateColumns = new ArrayList<>();
-        List<Integer> rightOnPredicateColumns = new ArrayList<>();
-        JoinPredicateUtils.getJoinOnPredicatesColumns(equalOnPredicate, leftChildColumns, rightChildColumns,
-                leftOnPredicateColumns, rightOnPredicateColumns);
-        Preconditions.checkState(leftOnPredicateColumns.size() == rightOnPredicateColumns.size());
+        JoinHelper joinHelper = JoinHelper.of(node, context.getChildOutputColumns(0), context.getChildOutputColumns(1));
+        List<Integer> leftOnPredicateColumns = joinHelper.getLeftOnColumns();
+        List<Integer> rightOnPredicateColumns = joinHelper.getRightOnColumns();
         // Get required properties for children.
         List<PhysicalPropertySet> requiredProperties =
-                Utils.computeShuffleJoinRequiredProperties(requirements, leftOnPredicateColumns,
+                computeShuffleJoinRequiredProperties(requirements, leftOnPredicateColumns,
                         rightOnPredicateColumns);
         Preconditions.checkState(requiredProperties.size() == 2);
         List<Integer> leftShuffleColumns =

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/JoinHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/JoinHelper.java
@@ -1,0 +1,152 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.sql.optimizer;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.starrocks.analysis.JoinOperator;
+import com.starrocks.sql.common.ErrorType;
+import com.starrocks.sql.common.StarRocksPlannerException;
+import com.starrocks.sql.optimizer.base.ColumnRefSet;
+import com.starrocks.sql.optimizer.operator.Operator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalHashJoinOperator;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+
+import java.util.List;
+
+public class JoinHelper {
+    private final JoinOperator type;
+    private final ColumnRefSet leftChildColumns;
+    private final ColumnRefSet rightChildColumns;
+
+    private final ScalarOperator onPredicate;
+    private final String hint;
+
+    private List<BinaryPredicateOperator> equalsPredicate;
+
+    private List<Integer> leftOnColumns;
+    private List<Integer> rightOnColumns;
+
+    public static JoinHelper of(Operator join, ColumnRefSet leftInput, ColumnRefSet rightInput) {
+        JoinHelper helper = new JoinHelper(join, leftInput, rightInput);
+        helper.init();
+        return helper;
+    }
+
+    private JoinHelper(Operator join, ColumnRefSet leftInput, ColumnRefSet rightInput) {
+        this.leftChildColumns = leftInput;
+        this.rightChildColumns = rightInput;
+
+        if (join instanceof LogicalJoinOperator) {
+            LogicalJoinOperator ljo = ((LogicalJoinOperator) join);
+            type = ljo.getJoinType();
+            onPredicate = ljo.getOnPredicate();
+            hint = ljo.getJoinHint();
+        } else if (join instanceof PhysicalHashJoinOperator) {
+            PhysicalHashJoinOperator phjo = ((PhysicalHashJoinOperator) join);
+            type = phjo.getJoinType();
+            onPredicate = phjo.getOnPredicate();
+            hint = phjo.getJoinHint();
+        } else {
+            type = null;
+            onPredicate = null;
+            hint = null;
+            Preconditions.checkState(false, "Operator must be join operator");
+        }
+    }
+
+    private void init() {
+        equalsPredicate = getEqualsPredicate(leftChildColumns, rightChildColumns,
+                Utils.extractConjuncts(onPredicate));
+        leftOnColumns = Lists.newArrayList();
+        rightOnColumns = Lists.newArrayList();
+
+        for (BinaryPredicateOperator binaryPredicate : equalsPredicate) {
+            ColumnRefSet leftUsedColumns = binaryPredicate.getChild(0).getUsedColumns();
+            ColumnRefSet rightUsedColumns = binaryPredicate.getChild(1).getUsedColumns();
+            // Join on expression had pushed down to project node, so there must be one column
+            if (leftUsedColumns.cardinality() > 1 || rightUsedColumns.cardinality() > 1) {
+                throw new StarRocksPlannerException(
+                        "we do not support equal on predicate have multi columns in left or right",
+                        ErrorType.UNSUPPORTED);
+            }
+            if (leftChildColumns.containsAll(leftUsedColumns) && rightChildColumns.containsAll(rightUsedColumns)) {
+                leftOnColumns.add(leftUsedColumns.getColumnIds()[0]);
+                rightOnColumns.add(rightUsedColumns.getColumnIds()[0]);
+            } else if (leftChildColumns.containsAll(rightUsedColumns) &&
+                    rightChildColumns.containsAll(leftUsedColumns)) {
+                leftOnColumns.add(rightUsedColumns.getColumnIds()[0]);
+                rightOnColumns.add(leftUsedColumns.getColumnIds()[0]);
+            } else {
+                Preconditions.checkState(false, "shouldn't reach here");
+            }
+        }
+        Preconditions.checkState(leftOnColumns.size() == rightOnColumns.size());
+    }
+
+    public List<Integer> getLeftOnColumns() {
+        return leftOnColumns;
+    }
+
+    public List<Integer> getRightOnColumns() {
+        return rightOnColumns;
+    }
+
+    public boolean isCrossJoin() {
+        return type.isCrossJoin() || equalsPredicate.isEmpty();
+    }
+
+    public boolean onlyBroadcast() {
+        // Cross join only support broadcast join
+        return onlyBroadcast(type, equalsPredicate, hint);
+    }
+
+    public boolean onlyShuffle() {
+        return type.isRightJoin() || type.isFullOuterJoin()
+                || "SHUFFLE".equalsIgnoreCase(hint) || "BUCKET".equalsIgnoreCase(hint);
+    }
+
+    public static List<BinaryPredicateOperator> getEqualsPredicate(ColumnRefSet leftColumns, ColumnRefSet rightColumns,
+                                                                   List<ScalarOperator> conjunctList) {
+        List<BinaryPredicateOperator> eqConjuncts = Lists.newArrayList();
+        for (ScalarOperator predicate : conjunctList) {
+            if (isEqualBinaryPredicate(leftColumns, rightColumns, predicate)) {
+                eqConjuncts.add((BinaryPredicateOperator) predicate);
+            }
+        }
+        return eqConjuncts;
+    }
+
+    public static boolean isEqualBinaryPredicate(ColumnRefSet leftColumns,
+                                                 ColumnRefSet rightColumns,
+                                                 ScalarOperator predicate) {
+        if (predicate instanceof BinaryPredicateOperator) {
+            BinaryPredicateOperator binaryPredicate = (BinaryPredicateOperator) predicate;
+            if (!binaryPredicate.getBinaryType().isEquivalence()) {
+                return false;
+            }
+
+            ColumnRefSet leftUsedColumns = binaryPredicate.getChild(0).getUsedColumns();
+            ColumnRefSet rightUsedColumns = binaryPredicate.getChild(1).getUsedColumns();
+
+            // Constant predicate
+            if (leftUsedColumns.isEmpty() || rightUsedColumns.isEmpty()) {
+                return false;
+            }
+
+            return leftColumns.containsAll(leftUsedColumns) && rightColumns.containsAll(rightUsedColumns) ||
+                    leftColumns.containsAll(rightUsedColumns) && rightColumns.containsAll(leftUsedColumns);
+        }
+        return false;
+    }
+
+    public static boolean onlyBroadcast(JoinOperator type,
+                                        List<BinaryPredicateOperator> equalOnPredicate, String hint) {
+        // Cross join only support broadcast join
+        return type.isCrossJoin() || JoinOperator.NULL_AWARE_LEFT_ANTI_JOIN.equals(type)
+                || (type.isInnerJoin() && equalOnPredicate.isEmpty())
+                || "BROADCAST".equalsIgnoreCase(hint);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/PropertyDeriverBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/PropertyDeriverBase.java
@@ -1,0 +1,119 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.sql.optimizer;
+
+import com.google.common.collect.Lists;
+import com.starrocks.sql.optimizer.base.DistributionProperty;
+import com.starrocks.sql.optimizer.base.DistributionSpec;
+import com.starrocks.sql.optimizer.base.HashDistributionDesc;
+import com.starrocks.sql.optimizer.base.HashDistributionSpec;
+import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
+import com.starrocks.sql.optimizer.base.SortProperty;
+import com.starrocks.sql.optimizer.operator.Operator;
+import com.starrocks.sql.optimizer.operator.OperatorVisitor;
+
+import java.util.List;
+import java.util.Optional;
+
+public abstract class PropertyDeriverBase<R, C> extends OperatorVisitor<R, C> {
+
+    public abstract R visitOperator(Operator node, C context);
+
+    // Compute the required properties of shuffle join for children, adjust shuffle columns orders for
+    // respect the required properties from parent.
+    protected static List<PhysicalPropertySet> computeShuffleJoinRequiredProperties(
+            PhysicalPropertySet requiredFromParent,
+            List<Integer> leftShuffleColumns,
+            List<Integer> rightShuffleColumns) {
+        Optional<HashDistributionDesc> requiredShuffleDescOptional =
+                getShuffleJoinHashDistributionDesc(requiredFromParent);
+        if (!requiredShuffleDescOptional.isPresent()) {
+            // required property is not SHUFFLE_JOIN
+            return createShuffleJoinRequiredProperties(leftShuffleColumns, rightShuffleColumns);
+        } else {
+            // required property type is SHUFFLE_JOIN, adjust the required property shuffle columns based on the column
+            // order required by parent
+            HashDistributionDesc requiredShuffleDesc = requiredShuffleDescOptional.get();
+            boolean adjustBasedOnLeft = leftShuffleColumns.size() == requiredShuffleDesc.getColumns().size() &&
+                    leftShuffleColumns.containsAll(requiredShuffleDesc.getColumns()) &&
+                    requiredShuffleDesc.getColumns().containsAll(leftShuffleColumns);
+            boolean adjustBasedOnRight = rightShuffleColumns.size() == requiredShuffleDesc.getColumns().size() &&
+                    rightShuffleColumns.containsAll(requiredShuffleDesc.getColumns()) &&
+                    requiredShuffleDesc.getColumns().containsAll(rightShuffleColumns);
+
+            if (adjustBasedOnLeft || adjustBasedOnRight) {
+                List<Integer> requiredLeft = Lists.newArrayList();
+                List<Integer> requiredRight = Lists.newArrayList();
+
+                for (Integer cid : requiredShuffleDesc.getColumns()) {
+                    int idx = adjustBasedOnLeft ? leftShuffleColumns.indexOf(cid) :
+                            rightShuffleColumns.indexOf(cid);
+                    requiredLeft.add(leftShuffleColumns.get(idx));
+                    requiredRight.add(rightShuffleColumns.get(idx));
+                }
+                return createShuffleJoinRequiredProperties(requiredLeft, requiredRight);
+            } else {
+                return createShuffleJoinRequiredProperties(leftShuffleColumns, rightShuffleColumns);
+            }
+        }
+    }
+
+    protected static Optional<HashDistributionDesc> getShuffleJoinHashDistributionDesc(
+            PhysicalPropertySet requiredPropertySet) {
+        if (!requiredPropertySet.getDistributionProperty().isShuffle()) {
+            return Optional.empty();
+        }
+        HashDistributionDesc requireDistributionDesc =
+                ((HashDistributionSpec) requiredPropertySet.getDistributionProperty().getSpec())
+                        .getHashDistributionDesc();
+        if (!HashDistributionDesc.SourceType.SHUFFLE_JOIN.equals(requireDistributionDesc.getSourceType())) {
+            return Optional.empty();
+        }
+
+        return Optional.of(requireDistributionDesc);
+    }
+
+    private static List<PhysicalPropertySet> createShuffleJoinRequiredProperties(List<Integer> leftColumns,
+                                                                                 List<Integer> rightColumns) {
+        HashDistributionSpec leftDistribution = DistributionSpec.createHashDistributionSpec(
+                new HashDistributionDesc(leftColumns, HashDistributionDesc.SourceType.SHUFFLE_JOIN));
+        HashDistributionSpec rightDistribution = DistributionSpec.createHashDistributionSpec(
+                new HashDistributionDesc(rightColumns, HashDistributionDesc.SourceType.SHUFFLE_JOIN));
+
+        PhysicalPropertySet leftRequiredPropertySet =
+                new PhysicalPropertySet(new DistributionProperty(leftDistribution));
+        PhysicalPropertySet rightRequiredPropertySet =
+                new PhysicalPropertySet(new DistributionProperty(rightDistribution));
+
+        return Lists.newArrayList(leftRequiredPropertySet, rightRequiredPropertySet);
+    }
+
+    protected PhysicalPropertySet createLimitGatherProperty(long limit) {
+        DistributionSpec distributionSpec = DistributionSpec.createGatherDistributionSpec(limit);
+        DistributionProperty distributionProperty = new DistributionProperty(distributionSpec);
+        return new PhysicalPropertySet(distributionProperty, SortProperty.EMPTY);
+    }
+
+    protected PhysicalPropertySet createPropertySetByDistribution(DistributionSpec distributionSpec) {
+        DistributionProperty distributionProperty = new DistributionProperty(distributionSpec);
+        return new PhysicalPropertySet(distributionProperty);
+    }
+
+    protected DistributionProperty createShuffleAggProperty(List<Integer> partitionColumns) {
+        return new DistributionProperty(DistributionSpec.createHashDistributionSpec(
+                new HashDistributionDesc(partitionColumns, HashDistributionDesc.SourceType.SHUFFLE_AGG)));
+    }
+
+    protected PhysicalPropertySet createShuffleAggPropertySet(List<Integer> partitions) {
+        HashDistributionDesc desc = new HashDistributionDesc(partitions, HashDistributionDesc.SourceType.SHUFFLE_AGG);
+        DistributionProperty property = new DistributionProperty(DistributionSpec.createHashDistributionSpec(desc));
+        return new PhysicalPropertySet(property);
+    }
+
+    protected PhysicalPropertySet createGatherPropertySet() {
+        DistributionProperty distributionProperty =
+                new DistributionProperty(DistributionSpec.createGatherDistributionSpec());
+        return new PhysicalPropertySet(distributionProperty);
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/RequiredPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/RequiredPropertyDeriver.java
@@ -5,15 +5,12 @@ package com.starrocks.sql.optimizer;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.qe.ConnectContext;
-import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.base.DistributionProperty;
 import com.starrocks.sql.optimizer.base.DistributionSpec;
-import com.starrocks.sql.optimizer.base.HashDistributionDesc;
 import com.starrocks.sql.optimizer.base.OrderSpec;
 import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
 import com.starrocks.sql.optimizer.base.SortProperty;
 import com.starrocks.sql.optimizer.operator.Operator;
-import com.starrocks.sql.optimizer.operator.OperatorVisitor;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalAssertOneRowOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalCTEAnchorOperator;
@@ -26,18 +23,14 @@ import com.starrocks.sql.optimizer.operator.physical.PhysicalNoCTEOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalTopNOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalUnionOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalWindowOperator;
-import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
-import com.starrocks.sql.optimizer.rule.transformation.JoinPredicateUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static com.starrocks.sql.optimizer.rule.transformation.JoinPredicateUtils.getEqConj;
-
-public class RequiredPropertyDeriver extends OperatorVisitor<Void, ExpressionContext> {
+public class RequiredPropertyDeriver extends PropertyDeriverBase<Void, ExpressionContext> {
     private final PhysicalPropertySet requirementsFromParent;
     private List<List<PhysicalPropertySet>> requiredProperties;
 
@@ -68,36 +61,27 @@ public class RequiredPropertyDeriver extends OperatorVisitor<Void, ExpressionCon
 
     @Override
     public Void visitPhysicalHashJoin(PhysicalHashJoinOperator node, ExpressionContext context) {
-        String hint = node.getJoinHint();
-
         // 1 For broadcast join
         PhysicalPropertySet rightBroadcastProperty =
                 new PhysicalPropertySet(new DistributionProperty(DistributionSpec.createReplicatedDistributionSpec()));
         requiredProperties.add(Lists.newArrayList(PhysicalPropertySet.EMPTY, rightBroadcastProperty));
 
-        ColumnRefSet leftChildColumns = context.getChildOutputColumns(0);
-        ColumnRefSet rightChildColumns = context.getChildOutputColumns(1);
-        List<BinaryPredicateOperator> equalOnPredicate =
-                getEqConj(leftChildColumns, rightChildColumns, Utils.extractConjuncts(node.getOnPredicate()));
+        JoinHelper joinHelper = JoinHelper.of(node, context.getChildOutputColumns(0), context.getChildOutputColumns(1));
 
-        if (Utils.canOnlyDoBroadcast(node, equalOnPredicate, hint)) {
+        if (joinHelper.onlyBroadcast()) {
             return null;
         }
 
-        if (node.getJoinType().isRightJoin() || node.getJoinType().isFullOuterJoin()
-                || "SHUFFLE".equalsIgnoreCase(hint) || "BUCKET".equalsIgnoreCase(hint)) {
+        if (joinHelper.onlyShuffle()) {
             requiredProperties.clear();
         }
 
         // 2 For shuffle join
-        List<Integer> leftOnPredicateColumns = new ArrayList<>();
-        List<Integer> rightOnPredicateColumns = new ArrayList<>();
-        JoinPredicateUtils.getJoinOnPredicatesColumns(equalOnPredicate, leftChildColumns, rightChildColumns,
-                leftOnPredicateColumns, rightOnPredicateColumns);
+        List<Integer> leftOnPredicateColumns = joinHelper.getLeftOnColumns();
+        List<Integer> rightOnPredicateColumns = joinHelper.getRightOnColumns();
         Preconditions.checkState(leftOnPredicateColumns.size() == rightOnPredicateColumns.size());
-        requiredProperties
-                .add(Utils.computeShuffleJoinRequiredProperties(requirementsFromParent, leftOnPredicateColumns,
-                        rightOnPredicateColumns));
+        requiredProperties.add(computeShuffleJoinRequiredProperties(requirementsFromParent, leftOnPredicateColumns,
+                rightOnPredicateColumns));
 
         return null;
     }
@@ -125,17 +109,12 @@ public class RequiredPropertyDeriver extends OperatorVisitor<Void, ExpressionCon
 
             // None grouping columns
             if (columns.isEmpty()) {
-                DistributionProperty distributionProperty =
-                        new DistributionProperty(DistributionSpec.createGatherDistributionSpec());
-                requiredProperties.add(Lists.newArrayList(new PhysicalPropertySet(distributionProperty)));
+                requiredProperties.add(Lists.newArrayList(createGatherPropertySet()));
                 return null;
             }
 
             // shuffle aggregation
-            DistributionSpec distributionSpec = DistributionSpec.createHashDistributionSpec(
-                    new HashDistributionDesc(columns, HashDistributionDesc.SourceType.SHUFFLE_AGG));
-            DistributionProperty distributionProperty = new DistributionProperty(distributionSpec);
-            requiredProperties.add(Lists.newArrayList(new PhysicalPropertySet(distributionProperty)));
+            requiredProperties.add(Lists.newArrayList(createShuffleAggPropertySet(columns)));
             return null;
         }
 
@@ -159,10 +138,7 @@ public class RequiredPropertyDeriver extends OperatorVisitor<Void, ExpressionCon
 
     @Override
     public Void visitPhysicalAssertOneRow(PhysicalAssertOneRowOperator node, ExpressionContext context) {
-        DistributionSpec gather = DistributionSpec.createGatherDistributionSpec();
-        DistributionProperty requiredProperty = new DistributionProperty(gather);
-
-        requiredProperties.add(Lists.newArrayList(new PhysicalPropertySet(requiredProperty)));
+        requiredProperties.add(Lists.newArrayList(createGatherPropertySet()));
         return null;
     }
 
@@ -179,8 +155,7 @@ public class RequiredPropertyDeriver extends OperatorVisitor<Void, ExpressionCon
         if (partitionColumnRefSet.isEmpty()) {
             distributionProperty = new DistributionProperty(DistributionSpec.createGatherDistributionSpec());
         } else {
-            distributionProperty = new DistributionProperty(DistributionSpec.createHashDistributionSpec(
-                    new HashDistributionDesc(partitionColumnRefSet, HashDistributionDesc.SourceType.SHUFFLE_AGG)));
+            distributionProperty = createShuffleAggProperty(partitionColumnRefSet);
         }
         requiredProperties.add(Lists.newArrayList(new PhysicalPropertySet(distributionProperty, sortProperty)));
 
@@ -239,11 +214,4 @@ public class RequiredPropertyDeriver extends OperatorVisitor<Void, ExpressionCon
         requiredProperties.add(Lists.newArrayList(requirementsFromParent));
         return null;
     }
-
-    private PhysicalPropertySet createLimitGatherProperty(long limit) {
-        DistributionSpec distributionSpec = DistributionSpec.createGatherDistributionSpec(limit);
-        DistributionProperty distributionProperty = new DistributionProperty(distributionSpec);
-        return new PhysicalPropertySet(distributionProperty, SortProperty.EMPTY);
-    }
-
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -4,7 +4,6 @@ package com.starrocks.sql.optimizer;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
-import com.starrocks.analysis.JoinOperator;
 import com.starrocks.catalog.Catalog;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.HiveMetaStoreTable;
@@ -19,11 +18,6 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
 import com.starrocks.external.hive.HiveColumnStats;
 import com.starrocks.external.iceberg.cost.IcebergTableStatisticCalculator;
-import com.starrocks.sql.optimizer.base.DistributionProperty;
-import com.starrocks.sql.optimizer.base.DistributionSpec;
-import com.starrocks.sql.optimizer.base.HashDistributionDesc;
-import com.starrocks.sql.optimizer.base.HashDistributionSpec;
-import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.logical.LogicalApplyOperator;
@@ -34,7 +28,6 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
-import com.starrocks.sql.optimizer.operator.physical.PhysicalHashJoinOperator;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
@@ -480,13 +473,18 @@ public class Utils {
         return true;
     }
 
-    public static boolean canOnlyDoBroadcast(PhysicalHashJoinOperator node,
-                                             List<BinaryPredicateOperator> equalOnPredicate, String hint) {
-        // Cross join only support broadcast join
-        if (node.getJoinType().isCrossJoin() || JoinOperator.NULL_AWARE_LEFT_ANTI_JOIN.equals(node.getJoinType())
-                || (node.getJoinType().isInnerJoin() && equalOnPredicate.isEmpty())
-                || "BROADCAST".equalsIgnoreCase(hint)) {
-            return true;
+    public static boolean isEqualBinaryPredicate(ScalarOperator predicate) {
+        if (predicate instanceof BinaryPredicateOperator) {
+            BinaryPredicateOperator binaryPredicate = (BinaryPredicateOperator) predicate;
+            return binaryPredicate.getBinaryType().isEquivalence();
+        }
+        if (predicate instanceof CompoundPredicateOperator) {
+            CompoundPredicateOperator compoundPredicate = (CompoundPredicateOperator) predicate;
+            if (compoundPredicate.isAnd()) {
+                return isEqualBinaryPredicate(compoundPredicate.getChild(0)) &&
+                        isEqualBinaryPredicate(compoundPredicate.getChild(1));
+            }
+            return false;
         }
         return false;
     }
@@ -553,73 +551,5 @@ public class Utils {
         } catch (Exception ignored) {
         }
         return Optional.empty();
-    }
-
-    // Compute the required properties of shuffle join for children, adjust shuffle columns orders for
-    // respect the required properties from parent.
-    public static List<PhysicalPropertySet> computeShuffleJoinRequiredProperties(PhysicalPropertySet requiredFromParent,
-                                                                                 List<Integer> leftShuffleColumns,
-                                                                                 List<Integer> rightShuffleColumns) {
-        Optional<HashDistributionDesc> requiredShuffleDescOptional =
-                getShuffleJoinHashDistributionDesc(requiredFromParent);
-        if (!requiredShuffleDescOptional.isPresent()) {
-            // required property is not SHUFFLE_JOIN
-            return createShuffleJoinRequiredProperties(leftShuffleColumns, rightShuffleColumns);
-        } else {
-            // required property type is SHUFFLE_JOIN, adjust the required property shuffle columns based on the column
-            // order required by parent
-            HashDistributionDesc requiredShuffleDesc = requiredShuffleDescOptional.get();
-            boolean adjustBasedOnLeft = leftShuffleColumns.size() == requiredShuffleDesc.getColumns().size() &&
-                    leftShuffleColumns.containsAll(requiredShuffleDesc.getColumns()) &&
-                    requiredShuffleDesc.getColumns().containsAll(leftShuffleColumns);
-            boolean adjustBasedOnRight = rightShuffleColumns.size() == requiredShuffleDesc.getColumns().size() &&
-                    rightShuffleColumns.containsAll(requiredShuffleDesc.getColumns()) &&
-                    requiredShuffleDesc.getColumns().containsAll(rightShuffleColumns);
-
-            if (adjustBasedOnLeft || adjustBasedOnRight) {
-                List<Integer> requiredLeft = Lists.newArrayList();
-                List<Integer> requiredRight = Lists.newArrayList();
-
-                for (Integer cid : requiredShuffleDesc.getColumns()) {
-                    int idx = adjustBasedOnLeft ? leftShuffleColumns.indexOf(cid) :
-                            rightShuffleColumns.indexOf(cid);
-                    requiredLeft.add(leftShuffleColumns.get(idx));
-                    requiredRight.add(rightShuffleColumns.get(idx));
-                }
-                return createShuffleJoinRequiredProperties(requiredLeft, requiredRight);
-            } else {
-                return createShuffleJoinRequiredProperties(leftShuffleColumns, rightShuffleColumns);
-            }
-        }
-    }
-
-    private static Optional<HashDistributionDesc> getShuffleJoinHashDistributionDesc(
-            PhysicalPropertySet requiredPropertySet) {
-        if (!requiredPropertySet.getDistributionProperty().isShuffle()) {
-            return Optional.empty();
-        }
-        HashDistributionDesc requireDistributionDesc =
-                ((HashDistributionSpec) requiredPropertySet.getDistributionProperty().getSpec())
-                        .getHashDistributionDesc();
-        if (!HashDistributionDesc.SourceType.SHUFFLE_JOIN.equals(requireDistributionDesc.getSourceType())) {
-            return Optional.empty();
-        }
-
-        return Optional.of(requireDistributionDesc);
-    }
-
-    private static List<PhysicalPropertySet> createShuffleJoinRequiredProperties(List<Integer> leftColumns,
-                                                                                 List<Integer> rightColumns) {
-        HashDistributionSpec leftDistribution = DistributionSpec.createHashDistributionSpec(
-                new HashDistributionDesc(leftColumns, HashDistributionDesc.SourceType.SHUFFLE_JOIN));
-        HashDistributionSpec rightDistribution = DistributionSpec.createHashDistributionSpec(
-                new HashDistributionDesc(rightColumns, HashDistributionDesc.SourceType.SHUFFLE_JOIN));
-
-        PhysicalPropertySet leftRequiredPropertySet =
-                new PhysicalPropertySet(new DistributionProperty(leftDistribution));
-        PhysicalPropertySet rightRequiredPropertySet =
-                new PhysicalPropertySet(new DistributionProperty(rightDistribution));
-
-        return Lists.newArrayList(leftRequiredPropertySet, rightRequiredPropertySet);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/HashDistributionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/HashDistributionDesc.java
@@ -18,7 +18,7 @@ public class HashDistributionDesc {
         //  the result will be error
         SHUFFLE_AGG, // hash property from shuffle agg
         SHUFFLE_JOIN, // hash property from shuffle join
-        BUCKET_JOIN, // hash property from bucket join
+        BUCKET, // hash property from bucket
         SHUFFLE_ENFORCE // parent node which can not satisfy the requirement will enforce child this hash property
     }
 
@@ -74,7 +74,7 @@ public class HashDistributionDesc {
     }
 
     public boolean isBucketJoin() {
-        return this.sourceType == SourceType.BUCKET_JOIN;
+        return this.sourceType == SourceType.BUCKET;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/OutputInputProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/OutputInputProperty.java
@@ -2,7 +2,6 @@
 
 package com.starrocks.sql.optimizer.base;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 
 import java.util.List;
@@ -29,21 +28,12 @@ public class OutputInputProperty {
         return new OutputInputProperty(outputProperty, Lists.newArrayList(inputProperties));
     }
 
-    public static OutputInputProperty emptyOutputOf(PhysicalPropertySet... inputProperties) {
-        return new OutputInputProperty(PhysicalPropertySet.EMPTY, Lists.newArrayList(inputProperties));
-    }
-
     public PhysicalPropertySet getOutputProperty() {
         return outputProperty;
     }
 
     public List<PhysicalPropertySet> getInputProperties() {
         return inputProperties;
-    }
-
-    public PhysicalPropertySet getInputProperty(int i) {
-        Preconditions.checkState(i < inputProperties.size());
-        return inputProperties.get(i);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
@@ -12,6 +12,7 @@ import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.ExpressionContext;
 import com.starrocks.sql.optimizer.GroupExpression;
+import com.starrocks.sql.optimizer.JoinHelper;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.base.DistributionSpec;
@@ -34,7 +35,6 @@ import com.starrocks.sql.optimizer.operator.physical.PhysicalWindowOperator;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
-import com.starrocks.sql.optimizer.rule.transformation.JoinPredicateUtils;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
 import com.starrocks.sql.optimizer.statistics.Statistics;
 import com.starrocks.sql.optimizer.statistics.StatisticsCalculator;
@@ -330,7 +330,7 @@ public class CostModel {
             Statistics leftStatistics = context.getChildStatistics(0);
             Statistics rightStatistics = context.getChildStatistics(1);
 
-            List<BinaryPredicateOperator> eqOnPredicates = JoinPredicateUtils.getEqConj(leftStatistics.getUsedColumns(),
+            List<BinaryPredicateOperator> eqOnPredicates = JoinHelper.getEqualsPredicate(leftStatistics.getUsedColumns(),
                     rightStatistics.getUsedColumns(),
                     Utils.extractConjuncts(join.getOnPredicate()));
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/PreAggregateTurnOnRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/PreAggregateTurnOnRule.java
@@ -9,6 +9,7 @@ import com.starrocks.catalog.AggregateType;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.sql.optimizer.JoinHelper;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;
 import com.starrocks.sql.optimizer.Utils;
@@ -26,7 +27,6 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
-import com.starrocks.sql.optimizer.rule.transformation.JoinPredicateUtils;
 
 import java.util.List;
 import java.util.Map;
@@ -299,7 +299,7 @@ public class PreAggregateTurnOnRule {
             ColumnRefSet leftOutputColumns = optExpression.getInputs().get(0).getOutputColumns();
             ColumnRefSet rightOutputColumns = optExpression.getInputs().get(1).getOutputColumns();
 
-            List<BinaryPredicateOperator> eqOnPredicates = JoinPredicateUtils.getEqConj(leftOutputColumns,
+            List<BinaryPredicateOperator> eqOnPredicates = JoinHelper.getEqualsPredicate(leftOutputColumns,
                     rightOutputColumns, Utils.extractConjuncts(hashJoinOperator.getOnPredicate()));
             // cross join can not do pre-aggregation
             if (hashJoinOperator.getJoinType().isCrossJoin() || eqOnPredicates.isEmpty()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinOrder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinOrder.java
@@ -19,7 +19,6 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
-import com.starrocks.sql.optimizer.rule.transformation.JoinPredicateUtils;
 import com.starrocks.sql.optimizer.statistics.StatisticsCalculator;
 import com.starrocks.statistic.Constants;
 
@@ -322,7 +321,7 @@ public abstract class JoinOrder {
             if (contains(joinBitSet, edge.vertexes) &&
                     left.intersects(edge.vertexes) &&
                     right.intersects(edge.vertexes)) {
-                if (JoinPredicateUtils.isEqualBinaryPredicate(edge.predicate)) {
+                if (Utils.isEqualBinaryPredicate(edge.predicate)) {
                     equalOnPredicates.add(edge.predicate);
                 } else {
                     otherPredicates.add(edge.predicate);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/MultiJoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/MultiJoinNode.java
@@ -10,7 +10,6 @@ import com.starrocks.sql.optimizer.operator.Projection;
 import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
-import com.starrocks.sql.optimizer.rule.transformation.JoinPredicateUtils;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -79,7 +78,7 @@ public class MultiJoinNode {
          * means the predicate can't bind to any child, join reorder can't handle the predicate
          *
          * */
-        if (JoinPredicateUtils.isEqualBinaryPredicate(joinPredicate)) {
+        if (Utils.isEqualBinaryPredicate(joinPredicate)) {
             atoms.add(node);
             return;
         }
@@ -104,7 +103,7 @@ public class MultiJoinNode {
         flattenJoinNode(node.inputAt(0), atoms, predicates, expressionMap);
         flattenJoinNode(node.inputAt(1), atoms, predicates, expressionMap);
         predicates.addAll(Utils.extractConjuncts(joinOperator.getOnPredicate()));
-        Preconditions.checkState(!JoinPredicateUtils.isEqualBinaryPredicate(joinPredicate));
+        Preconditions.checkState(!Utils.isEqualBinaryPredicate(joinPredicate));
         predicates.addAll(Utils.extractConjuncts(joinPredicate));
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownJoinOnClauseRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownJoinOnClauseRule.java
@@ -15,9 +15,7 @@ import com.starrocks.sql.optimizer.rule.RuleType;
 import java.util.Collections;
 import java.util.List;
 
-import static com.starrocks.sql.optimizer.rule.transformation.JoinPredicateUtils.pushDownOnPredicate;
-
-public class PushDownJoinOnClauseRule extends TransformationRule {
+public class PushDownJoinOnClauseRule extends PushDownJoinPredicateBase {
     public PushDownJoinOnClauseRule() {
         super(RuleType.TF_PUSH_DOWN_JOIN_CLAUSE, Pattern.create(OperatorType.LOGICAL_JOIN).
                 addChildren(Pattern.create(OperatorType.PATTERN_LEAF), Pattern.create(OperatorType.PATTERN_LEAF)));
@@ -39,7 +37,7 @@ public class PushDownJoinOnClauseRule extends TransformationRule {
 
         ScalarOperator on = join.getOnPredicate();
 
-        on = JoinPredicateUtils.rangePredicateDerive(on);
+        on = rangePredicateDerive(on);
         on = equivalenceDeriveOnPredicate(on, input, join);
 
         OptExpression root = pushDownOnPredicate(input, on);
@@ -62,7 +60,7 @@ public class PushDownJoinOnClauseRule extends TransformationRule {
         ColumnRefSet leftOutputColumns = joinOpt.getInputs().get(0).getOutputColumns();
         ColumnRefSet rightOutputColumns = joinOpt.getInputs().get(1).getOutputColumns();
 
-        ScalarOperator derivedPredicate = JoinPredicateUtils.equivalenceDerive(on, false);
+        ScalarOperator derivedPredicate = equivalenceDerive(on, false);
         List<ScalarOperator> derivedPredicates = Utils.extractConjuncts(derivedPredicate);
 
         if (join.getJoinType().isInnerJoin() || join.getJoinType().isSemiJoin()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownJoinOnExpressionToChildProject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownJoinOnExpressionToChildProject.java
@@ -1,6 +1,7 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
 package com.starrocks.sql.optimizer.rule.transformation;
 
+import com.starrocks.sql.optimizer.JoinHelper;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.Utils;
@@ -23,8 +24,6 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static com.starrocks.sql.optimizer.rule.transformation.JoinPredicateUtils.getEqConj;
-
 /**
  * Because the children of Join need to shuffle data
  * according to the equivalence conditions in onPredicate, if there is an expression on predicate,
@@ -44,8 +43,8 @@ public class PushDownJoinOnExpressionToChildProject extends TransformationRule {
         ColumnRefSet leftOutputColumns = input.inputAt(0).getOutputColumns();
         ColumnRefSet rightOutputColumns = input.inputAt(1).getOutputColumns();
 
-        List<BinaryPredicateOperator> equalConjs =
-                getEqConj(leftOutputColumns, rightOutputColumns, Utils.extractConjuncts(onPredicate));
+        List<BinaryPredicateOperator> equalConjs = JoinHelper.
+                getEqualsPredicate(leftOutputColumns, rightOutputColumns, Utils.extractConjuncts(onPredicate));
 
         return !equalConjs.isEmpty();
     }
@@ -58,8 +57,8 @@ public class PushDownJoinOnExpressionToChildProject extends TransformationRule {
         ColumnRefSet leftOutputColumns = input.inputAt(0).getOutputColumns();
         ColumnRefSet rightOutputColumns = input.inputAt(1).getOutputColumns();
 
-        List<BinaryPredicateOperator> equalConjs =
-                getEqConj(leftOutputColumns, rightOutputColumns, Utils.extractConjuncts(onPredicate));
+        List<BinaryPredicateOperator> equalConjs = JoinHelper.
+                getEqualsPredicate(leftOutputColumns, rightOutputColumns, Utils.extractConjuncts(onPredicate));
 
         Map<ColumnRefOperator, ScalarOperator> leftProjectMaps = new HashMap<>();
         Map<ColumnRefOperator, ScalarOperator> rightProjectMaps = new HashMap<>();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownJoinPredicateBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownJoinPredicateBase.java
@@ -1,32 +1,36 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
 package com.starrocks.sql.optimizer.rule.transformation;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.starrocks.analysis.JoinOperator;
 import com.starrocks.sql.analyzer.SemanticException;
-import com.starrocks.sql.common.ErrorType;
-import com.starrocks.sql.common.StarRocksPlannerException;
+import com.starrocks.sql.optimizer.JoinHelper;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.logical.LogicalFilterOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
+import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
-import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ScalarEquivalenceExtractor;
 import com.starrocks.sql.optimizer.rewrite.ScalarRangePredicateExtractor;
+import com.starrocks.sql.optimizer.rule.RuleType;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class JoinPredicateUtils {
+public abstract class PushDownJoinPredicateBase extends TransformationRule {
+    protected PushDownJoinPredicateBase(RuleType type, Pattern pattern) {
+        super(type, pattern);
+    }
+
     public static OptExpression pushDownPredicate(OptExpression root, ScalarOperator leftPushDown,
                                                   ScalarOperator rightPushDown) {
         if (leftPushDown != null) {
@@ -44,65 +48,11 @@ public class JoinPredicateUtils {
         return root;
     }
 
-    public static List<BinaryPredicateOperator> getEqConj(ColumnRefSet leftColumns, ColumnRefSet rightColumns,
-                                                          List<ScalarOperator> conjunctList) {
-        List<BinaryPredicateOperator> eqConjuncts = Lists.newArrayList();
-        for (ScalarOperator predicate : conjunctList) {
-            if (isEqualBinaryPredicate(leftColumns, rightColumns, predicate)) {
-                eqConjuncts.add((BinaryPredicateOperator) predicate);
-            }
-        }
-        return eqConjuncts;
-    }
-
-    public static boolean isEqualBinaryPredicate(ScalarOperator predicate) {
-        if (predicate instanceof BinaryPredicateOperator) {
-            BinaryPredicateOperator binaryPredicate = (BinaryPredicateOperator) predicate;
-            return binaryPredicate.getBinaryType().isEquivalence();
-        }
-        if (predicate instanceof CompoundPredicateOperator) {
-            CompoundPredicateOperator compoundPredicate = (CompoundPredicateOperator) predicate;
-            if (compoundPredicate.isAnd()) {
-                return isEqualBinaryPredicate(compoundPredicate.getChild(0)) &&
-                        isEqualBinaryPredicate(compoundPredicate.getChild(1));
-            }
-            return false;
-        }
-        return false;
-    }
-
-    public static boolean isColumnToColumnBinaryPredicate(BinaryPredicateOperator predicateOperator) {
-        return predicateOperator.getChildren().stream().allMatch(ScalarOperator::isColumnRef);
-    }
-
-    public static boolean isEqualBinaryPredicate(ColumnRefSet leftColumns,
-                                                 ColumnRefSet rightColumns,
-                                                 ScalarOperator predicate) {
-        if (predicate instanceof BinaryPredicateOperator) {
-            BinaryPredicateOperator binaryPredicate = (BinaryPredicateOperator) predicate;
-            if (!binaryPredicate.getBinaryType().isEquivalence()) {
-                return false;
-            }
-
-            ColumnRefSet leftUsedColumns = binaryPredicate.getChild(0).getUsedColumns();
-            ColumnRefSet rightUsedColumns = binaryPredicate.getChild(1).getUsedColumns();
-
-            // Constant predicate
-            if (leftUsedColumns.isEmpty() || rightUsedColumns.isEmpty()) {
-                return false;
-            }
-
-            return leftColumns.containsAll(leftUsedColumns) && rightColumns.containsAll(rightUsedColumns) ||
-                    leftColumns.containsAll(rightUsedColumns) && rightColumns.containsAll(leftUsedColumns);
-        }
-        return false;
-    }
-
     public static OptExpression pushDownOnPredicate(OptExpression input, ScalarOperator conjunct) {
         LogicalJoinOperator join = (LogicalJoinOperator) input.getOp();
 
         List<ScalarOperator> conjunctList = Utils.extractConjuncts(conjunct);
-        List<BinaryPredicateOperator> eqConjuncts = getEqConj(
+        List<BinaryPredicateOperator> eqConjuncts = JoinHelper.getEqualsPredicate(
                 input.getInputs().get(0).getOutputColumns(),
                 input.getInputs().get(1).getOutputColumns(),
                 conjunctList);
@@ -231,31 +181,5 @@ public class JoinPredicateUtils {
                 Utils.compoundAnd(
                         Utils.extractConjuncts(predicate).stream().map(scalarRangePredicateExtractor::rewriteAll)
                                 .collect(Collectors.toList())));
-    }
-
-    public static void getJoinOnPredicatesColumns(List<BinaryPredicateOperator> equalOnPredicates,
-                                                  ColumnRefSet leftChildColumns,
-                                                  ColumnRefSet rightChildColumns,
-                                                  List<Integer> leftOnPredicateColumns,
-                                                  List<Integer> rightOnPredicateColumns) {
-        for (BinaryPredicateOperator binaryPredicate : equalOnPredicates) {
-            ColumnRefSet leftUsedColumns = binaryPredicate.getChild(0).getUsedColumns();
-            ColumnRefSet rightUsedColumns = binaryPredicate.getChild(1).getUsedColumns();
-            // Join on expression had pushed down to project node, so there must be one column
-            if (leftUsedColumns.cardinality() > 1 || rightUsedColumns.cardinality() > 1) {
-                throw new StarRocksPlannerException(
-                        "we do not support equal on predicate have multi columns in left or right",
-                        ErrorType.UNSUPPORTED);
-            }
-            if (leftChildColumns.containsAll(leftUsedColumns) && rightChildColumns.containsAll(rightUsedColumns)) {
-                leftOnPredicateColumns.add(leftUsedColumns.getColumnIds()[0]);
-                rightOnPredicateColumns.add(rightUsedColumns.getColumnIds()[0]);
-            } else if (leftChildColumns.containsAll(rightUsedColumns) && rightChildColumns.containsAll(leftUsedColumns)) {
-                leftOnPredicateColumns.add(rightUsedColumns.getColumnIds()[0]);
-                rightOnPredicateColumns.add(leftUsedColumns.getColumnIds()[0]);
-            } else {
-                Preconditions.checkState(false, "shouldn't reach here");
-            }
-        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -34,6 +34,7 @@ import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.ExpressionContext;
 import com.starrocks.sql.optimizer.Group;
+import com.starrocks.sql.optimizer.JoinHelper;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.Utils;
@@ -105,7 +106,6 @@ import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.PredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
-import com.starrocks.sql.optimizer.rule.transformation.JoinPredicateUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.mortbay.log.Log;
@@ -736,7 +736,7 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
         double crossRowCount = leftRowCount * rightRowCount;
         crossBuilder.setOutputRowCount(crossRowCount);
 
-        List<BinaryPredicateOperator> eqOnPredicates = JoinPredicateUtils.getEqConj(leftStatistics.getUsedColumns(),
+        List<BinaryPredicateOperator> eqOnPredicates = JoinHelper.getEqualsPredicate(leftStatistics.getUsedColumns(),
                 rightStatistics.getUsedColumns(),
                 Utils.extractConjuncts(joinOnPredicate));
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/EnforceAndCostTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/EnforceAndCostTask.java
@@ -10,6 +10,7 @@ import com.starrocks.sql.optimizer.ChildOutputPropertyGuarantor;
 import com.starrocks.sql.optimizer.ExpressionContext;
 import com.starrocks.sql.optimizer.Group;
 import com.starrocks.sql.optimizer.GroupExpression;
+import com.starrocks.sql.optimizer.JoinHelper;
 import com.starrocks.sql.optimizer.OutputPropertyDeriver;
 import com.starrocks.sql.optimizer.RequiredPropertyDeriver;
 import com.starrocks.sql.optimizer.Utils;
@@ -30,8 +31,6 @@ import com.starrocks.sql.optimizer.statistics.Statistics;
 import com.starrocks.sql.optimizer.statistics.StatisticsCalculator;
 
 import java.util.List;
-
-import static com.starrocks.sql.optimizer.rule.transformation.JoinPredicateUtils.getEqConj;
 
 /**
  * EnforceAndCostTask costs a physical expression.
@@ -234,9 +233,9 @@ public class EnforceAndCostTask extends OptimizerTask implements Cloneable {
         // if this groupExpression can only do Broadcast, don't need to check the broadcastRowCountLimit
         ColumnRefSet leftChildColumns = groupExpression.getChildOutputColumns(0);
         ColumnRefSet rightChildColumns = groupExpression.getChildOutputColumns(1);
-        List<BinaryPredicateOperator> equalOnPredicate =
-                getEqConj(leftChildColumns, rightChildColumns, Utils.extractConjuncts(node.getOnPredicate()));
-        if (Utils.canOnlyDoBroadcast(node, equalOnPredicate, node.getJoinHint())) {
+        List<BinaryPredicateOperator> equalOnPredicate = JoinHelper
+                .getEqualsPredicate(leftChildColumns, rightChildColumns, Utils.extractConjuncts(node.getOnPredicate()));
+        if (JoinHelper.onlyBroadcast(node.getJoinType(), equalOnPredicate, node.getJoinHint())) {
             return true;
         }
         // Only when right table is not significantly smaller than left table, consider the

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
@@ -48,6 +48,7 @@ import com.starrocks.sql.ast.ViewRelation;
 import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.common.TypeManager;
+import com.starrocks.sql.optimizer.JoinHelper;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
@@ -86,7 +87,6 @@ import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
-import com.starrocks.sql.optimizer.rule.transformation.JoinPredicateUtils;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -578,7 +578,7 @@ public class RelationTransformer extends AstVisitor<LogicalPlan, ExpressionMappi
 
             List<ScalarOperator> conjuncts = Utils.extractConjuncts(onPredicateWithoutRewrite);
 
-            List<BinaryPredicateOperator> eqPredicate = JoinPredicateUtils.getEqConj(
+            List<BinaryPredicateOperator> eqPredicate = JoinHelper.getEqualsPredicate(
                     new ColumnRefSet(leftPlan.getOutputColumn()),
                     new ColumnRefSet(rightPlan.getOutputColumn()), conjuncts);
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -131,7 +131,7 @@ import java.util.stream.Collectors;
 import static com.starrocks.catalog.Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF;
 import static com.starrocks.sql.common.ErrorType.INTERNAL_ERROR;
 import static com.starrocks.sql.common.UnsupportedException.unsupportedException;
-import static com.starrocks.sql.optimizer.rule.transformation.JoinPredicateUtils.getEqConj;
+import static com.starrocks.sql.optimizer.JoinHelper.getEqualsPredicate;
 
 /**
  * PlanFragmentBuilder used to transform physical operator to exec plan fragment
@@ -1579,7 +1579,7 @@ public class PlanFragmentBuilder {
             ColumnRefSet rightChildColumns = optExpr.inputAt(1).getLogicalProperty().getOutputColumns();
 
             // 2. Get eqJoinConjuncts
-            List<BinaryPredicateOperator> eqOnPredicates = getEqConj(
+            List<BinaryPredicateOperator> eqOnPredicates = getEqualsPredicate(
                     leftChildColumns,
                     rightChildColumns,
                     Utils.extractConjuncts(node.getOnPredicate()));


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Merge SHUFFLE_AGG/SHUFFLE_JOIN to SHUFFLE,  we has special mark to mark BUCKET_JOIN, don't split shuffle. And that can optimize plan:
```
      AGG（UPDATE FINALIZE)               AGG（UPDATE FINALIZE)  
              |                                   |             
            SHUFFLE           ====>               |             
              |                                   |             
            JOIN                                JOIN            
            /   \                               /   \           

```
