### PR TITLE
Fix join reorder project have recursive references

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/MultiJoinReorderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/MultiJoinReorderTest.java
@@ -497,4 +497,13 @@ public class MultiJoinReorderTest extends PlanTestBase {
         String plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("17:CROSS JOIN"));
     }
+
+    @Test
+    public void testInsertWithMultiJoin() throws Exception {
+        String sql = "insert into test_all_type(t1b, t1c, t1d, t1a) select v1,v4,v7,t1b from (" +
+                "select v1,v4 from t0 join t1 on v1 = v4 ) a join (" +
+                "select t1a, null as t1b,v7 from test_all_type join t2 on t1a = v7) b on v1 = t1a";
+        String plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("<slot 27> : CAST(NULL AS VARCHAR(20))"));
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others



## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
In Join reorder project compute progress， the expression map in MultiJoinNode could have map like this \:
21 -> cast(20 as varchar)
20 -> constant operator
we should use the replaceColumnRewriter to rewite this value instead of use value directly
