### PR TITLE
Fix the return value check of create_directories.

### DIFF
--- a/be/src/env/env_posix.cpp
+++ b/be/src/env/env_posix.cpp
@@ -531,8 +531,7 @@ public:
 
     Status create_dir_recursive(const std::string& dirname) override {
         std::error_code ec;
-        auto r = std::filesystem::create_directories(dirname, ec);
-        if (r == static_cast<std::uintmax_t>(-1)) {
+        if (!std::filesystem::create_directories(dirname, ec)) {
             return io_error(fmt::format("create {} recursive", dirname), ec.value());
         }
         return Status::OK();


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4902

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

the return value of std::filesystem::create_directories is a boolean, should not compare to a constant which is not a boolean, this comparison will always be false.
https://github.com/StarRocks/starrocks/blob/16d75901b3fe2209246f042ed087df519e1a862c/be/src/env/env_posix.cpp#L615-L622