### PR TITLE
Fix query error from hive external table when boolean data type as partition key to Branch 2.0

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/Utils.java
@@ -4,6 +4,7 @@ package com.starrocks.external.hive;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import com.starrocks.analysis.BoolLiteral;
 import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.analysis.NullLiteral;
 import com.starrocks.catalog.Column;
@@ -47,6 +48,9 @@ public class Utils {
         for (LiteralExpr value : literalValues) {
             if (value instanceof NullLiteral) {
                 values.add(HiveMetaClient.PARTITION_NULL_VALUE);
+            } else if (value instanceof BoolLiteral) {
+                BoolLiteral boolValue = ((BoolLiteral) value);
+                values.add(String.valueOf(boolValue.getValue()));
             } else {
                 values.add(value.getStringValue());
             }

--- a/fe/fe-core/src/test/java/com/starrocks/external/hive/UtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/external/hive/UtilsTest.java
@@ -10,7 +10,6 @@ import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.DdlException;
 import org.apache.hadoop.hive.common.StatsSetupConst;
-import org.apache.hadoop.yarn.webapp.hamlet2.Hamlet;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/fe/fe-core/src/test/java/com/starrocks/external/hive/UtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/external/hive/UtilsTest.java
@@ -10,6 +10,7 @@ import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.DdlException;
 import org.apache.hadoop.hive.common.StatsSetupConst;
+import org.apache.hadoop.yarn.webapp.hamlet2.Hamlet;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -35,6 +36,12 @@ public class UtilsTest {
         List<String> values = Lists.newArrayList("1", "a", "3.0", HiveMetaClient.PARTITION_NULL_VALUE);
         PartitionKey partitionKey = Utils.createPartitionKey(values, partColumns);
         Assert.assertEquals(values, Utils.getPartitionValues(partitionKey));
+
+        List<Column> partColumns1 = Lists.newArrayList(new Column("k1", Type.DATE), new Column("k2", Type.BOOLEAN));
+        PartitionKey partitionKey1 = Utils.createPartitionKey(Lists.newArrayList("2021-01-01", "false"), partColumns1);
+        List<String> partValues1 = Utils.getPartitionValues(partitionKey1);
+        Assert.assertEquals("2021-01-01", partValues1.get(0));
+        Assert.assertEquals("false", partValues1.get(1));
     }
 
     @Test


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4434 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This PR implement bug fix of query from hive external table when hive table with boolean data type as partition key.
The bug is fixed by optimizing the logic of getting partition values.