### PR TITLE
Fix wrong min-max filter result of parquet reader

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -125,6 +125,7 @@ set(EXEC_FILES
     vectorized/sorting/sort_permute.cpp
     vectorized/sorting/compare_column.cpp
     parquet/column_chunk_reader.cpp
+    parquet/column_converter.cpp
     parquet/column_reader.cpp
     parquet/encoding.cpp
     parquet/level_codec.cpp

--- a/be/src/exec/parquet/column_converter.cpp
+++ b/be/src/exec/parquet/column_converter.cpp
@@ -1,0 +1,390 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#include "column_converter.h"
+
+#include <memory>
+#include <utility>
+
+#include "column/array_column.h"
+#include "column/binary_column.h"
+#include "column/column_helper.h"
+#include "column/fixed_length_column.h"
+#include "column/type_traits.h"
+#include "exec/parquet/schema.h"
+#include "exec/parquet/stored_column_reader.h"
+#include "gen_cpp/parquet_types.h"
+#include "gutil/casts.h"
+#include "gutil/strings/substitute.h"
+#include "runtime/decimalv2_value.h"
+#include "runtime/primitive_type.h"
+#include "util/bit_util.h"
+#include "util/logging.h"
+#include "util/runtime_profile.h"
+
+namespace starrocks::parquet {
+Status ColumnConverterFactory::create_converter(const ParquetField& field, const TypeDescriptor& typeDescriptor,
+                                                const std::string& timezone,
+                                                std::unique_ptr<ColumnConverter>* converter) {
+    PrimitiveType col_type = typeDescriptor.type;
+    bool need_convert = false;
+    tparquet::Type::type parquet_type = field.physical_type;
+    const auto& schema_element = field.schema_element;
+
+    // the reason why there is down conversion of integer type is
+    // assume we create a hive column called `col0` whose type is `tinyint`
+    // but when we insert value into `col0`, the physical type in parquet file is actually `INT32`
+    // so when we read `col0` from parquet file, we have to do a type conversion from int32_t to int8_t.
+    switch (parquet_type) {
+    case tparquet::Type::type::BOOLEAN: {
+        if (col_type != PrimitiveType::TYPE_BOOLEAN) {
+            need_convert = true;
+        }
+        break;
+    }
+    case tparquet::Type::type::INT32: {
+        if (col_type != PrimitiveType::TYPE_INT) {
+            need_convert = true;
+        }
+        switch (col_type) {
+        case PrimitiveType::TYPE_TINYINT:
+            *converter = std::make_unique<IntToIntConverter<int32_t, int8_t>>();
+            break;
+        case PrimitiveType::TYPE_SMALLINT:
+            *converter = std::make_unique<IntToIntConverter<int32_t, int16_t>>();
+            break;
+        case PrimitiveType::TYPE_BIGINT:
+            *converter = std::make_unique<IntToIntConverter<int32_t, int64_t>>();
+            break;
+        case PrimitiveType::TYPE_DATE:
+            *converter = std::make_unique<Int32ToDateConverter>();
+            break;
+            // when decimal precision is greater than 27, precision may be lost in the following
+            // process. However to handle most enviroment, we also make progress other than
+            // rejection
+        case PrimitiveType::TYPE_DECIMALV2:
+            // All DecimalV2 use scale 9 as scale
+            *converter = std::make_unique<PrimitiveToDecimalConverter<int32_t, TYPE_DECIMALV2>>(field.scale, 9);
+            break;
+        case PrimitiveType::TYPE_DECIMAL32:
+            *converter = std::make_unique<PrimitiveToDecimalConverter<int32_t, TYPE_DECIMAL32>>(field.scale,
+                                                                                                typeDescriptor.scale);
+            break;
+        case PrimitiveType::TYPE_DECIMAL64:
+            *converter = std::make_unique<PrimitiveToDecimalConverter<int32_t, TYPE_DECIMAL64>>(field.scale,
+                                                                                                typeDescriptor.scale);
+            break;
+        case PrimitiveType::TYPE_DECIMAL128:
+            *converter = std::make_unique<PrimitiveToDecimalConverter<int32_t, TYPE_DECIMAL128>>(field.scale,
+                                                                                                 typeDescriptor.scale);
+            break;
+        default:
+            break;
+        }
+        break;
+    }
+    case tparquet::Type::type::INT64: {
+        if (col_type != PrimitiveType::TYPE_BIGINT) {
+            need_convert = true;
+        }
+        switch (col_type) {
+        case PrimitiveType::TYPE_TINYINT:
+            *converter = std::make_unique<IntToIntConverter<int64_t, int8_t>>();
+            break;
+        case PrimitiveType::TYPE_SMALLINT:
+            *converter = std::make_unique<IntToIntConverter<int64_t, int16_t>>();
+            break;
+        case PrimitiveType::TYPE_INT:
+            *converter = std::make_unique<IntToIntConverter<int64_t, int32_t>>();
+            break;
+            // when decimal precision is greater than 27, precision may be lost in the following
+            // process. However to handle most enviroment, we also make progress other than
+            // rejection
+        case PrimitiveType::TYPE_DECIMALV2:
+            // All DecimalV2 use scale 9 as scale
+            *converter = std::make_unique<PrimitiveToDecimalConverter<int64_t, TYPE_DECIMALV2>>(field.scale, 9);
+            break;
+        case PrimitiveType::TYPE_DECIMAL32:
+            *converter = std::make_unique<PrimitiveToDecimalConverter<int64_t, TYPE_DECIMAL32>>(field.scale,
+                                                                                                typeDescriptor.scale);
+            break;
+        case PrimitiveType::TYPE_DECIMAL64:
+            *converter = std::make_unique<PrimitiveToDecimalConverter<int64_t, TYPE_DECIMAL64>>(field.scale,
+                                                                                                typeDescriptor.scale);
+            break;
+        case PrimitiveType::TYPE_DECIMAL128:
+            *converter = std::make_unique<PrimitiveToDecimalConverter<int64_t, TYPE_DECIMAL128>>(field.scale,
+                                                                                                 typeDescriptor.scale);
+            break;
+
+        case PrimitiveType::TYPE_DATETIME: {
+            auto _converter = std::make_unique<Int64ToDateTimeConverter>();
+            RETURN_IF_ERROR(_converter->init(timezone, schema_element));
+            *converter = std::move(_converter);
+            break;
+        }
+        default:
+            break;
+        }
+        break;
+    }
+    case tparquet::Type::type::BYTE_ARRAY: {
+        if (col_type != PrimitiveType::TYPE_VARCHAR && col_type != PrimitiveType::TYPE_CHAR) {
+            need_convert = true;
+        }
+        break;
+    }
+    case tparquet::Type::type::FIXED_LEN_BYTE_ARRAY: {
+        if (col_type != PrimitiveType::TYPE_VARCHAR && col_type != PrimitiveType::TYPE_CHAR) {
+            need_convert = true;
+        }
+        switch (col_type) {
+        case PrimitiveType::TYPE_DECIMALV2:
+            // All DecimalV2 use scale 9 as scale
+            *converter = std::make_unique<BinaryToDecimalConverter<TYPE_DECIMALV2>>(field.scale, 9);
+            break;
+        case PrimitiveType::TYPE_DECIMAL32:
+            *converter = std::make_unique<BinaryToDecimalConverter<TYPE_DECIMAL32>>(field.scale, typeDescriptor.scale);
+            break;
+        case PrimitiveType::TYPE_DECIMAL64:
+            *converter = std::make_unique<BinaryToDecimalConverter<TYPE_DECIMAL64>>(field.scale, typeDescriptor.scale);
+            break;
+        case PrimitiveType::TYPE_DECIMAL128:
+            *converter = std::make_unique<BinaryToDecimalConverter<TYPE_DECIMAL128>>(field.scale, typeDescriptor.scale);
+            break;
+        default:
+            break;
+        }
+        break;
+    }
+    case tparquet::Type::type::INT96: {
+        if (col_type == PrimitiveType::TYPE_DATETIME) {
+            need_convert = true;
+            auto _converter = std::make_unique<Int96ToDateTimeConverter>();
+            RETURN_IF_ERROR(_converter->init(timezone));
+            *converter = std::move(_converter);
+        }
+        break;
+    }
+    case tparquet::Type::FLOAT: {
+        if (col_type != PrimitiveType::TYPE_FLOAT) {
+            need_convert = true;
+        }
+        break;
+    }
+    case tparquet::Type::DOUBLE: {
+        if (col_type != PrimitiveType::TYPE_DOUBLE) {
+            need_convert = true;
+        }
+        break;
+    }
+    default:
+        need_convert = true;
+        break;
+    }
+
+    if (need_convert && *converter == nullptr) {
+        return Status::NotSupported(
+                strings::Substitute("parquet column reader: not supported convert from parquet `$0` to `$1`",
+                                    ::tparquet::to_string(parquet_type), type_to_string(col_type)));
+    }
+
+    if (!need_convert) {
+        *converter = std::make_unique<ColumnConverter>();
+    }
+    (*converter)->init_info(need_convert, parquet_type);
+    return Status::OK();
+}
+
+vectorized::ColumnPtr ColumnConverter::create_src_column() {
+    vectorized::ColumnPtr data_column = nullptr;
+    switch (parquet_type) {
+    case tparquet::Type::type::BOOLEAN:
+        data_column = vectorized::FixedLengthColumn<uint8_t>::create();
+        break;
+    case tparquet::Type::type::INT32:
+        data_column = vectorized::FixedLengthColumn<PhysicalTypeTraits<tparquet::Type::INT32>::CppType>::create();
+        break;
+    case tparquet::Type::type::INT64:
+        data_column = vectorized::FixedLengthColumn<PhysicalTypeTraits<tparquet::Type::INT64>::CppType>::create();
+        break;
+    case tparquet::Type::type::INT96:
+        data_column = vectorized::FixedLengthColumn<PhysicalTypeTraits<tparquet::Type::INT96>::CppType>::create();
+        break;
+    case tparquet::Type::type::FLOAT:
+        data_column = vectorized::FixedLengthColumn<PhysicalTypeTraits<tparquet::Type::FLOAT>::CppType>::create();
+        break;
+    case tparquet::Type::type::DOUBLE:
+        data_column = vectorized::FixedLengthColumn<PhysicalTypeTraits<tparquet::Type::DOUBLE>::CppType>::create();
+        break;
+    case tparquet::Type::type::BYTE_ARRAY:
+    case tparquet::Type::type::FIXED_LEN_BYTE_ARRAY:
+        data_column = vectorized::BinaryColumn::create();
+        break;
+    }
+    return vectorized::NullableColumn::create(data_column, vectorized::NullColumn::create());
+}
+
+Status parquet::Int32ToDateConverter::convert(const vectorized::ColumnPtr& src, vectorized::Column* dst) {
+    auto* src_nullable_column = vectorized::ColumnHelper::as_raw_column<vectorized::NullableColumn>(src);
+    // hive only support null column
+    // TODO: support not null
+    auto* dst_nullable_column = down_cast<vectorized::NullableColumn*>(dst);
+    dst_nullable_column->resize(src_nullable_column->size());
+
+    auto* src_column = vectorized::ColumnHelper::as_raw_column<vectorized::FixedLengthColumn<int32_t>>(
+            src_nullable_column->data_column());
+    auto* dst_column =
+            vectorized::ColumnHelper::as_raw_column<vectorized::DateColumn>(dst_nullable_column->data_column());
+
+    auto& src_data = src_column->get_data();
+    auto& dst_data = dst_column->get_data();
+    auto& src_null_data = src_nullable_column->null_column()->get_data();
+    auto& dst_null_data = dst_nullable_column->null_column()->get_data();
+
+    size_t size = src_column->size();
+    for (size_t i = 0; i < size; i++) {
+        dst_null_data[i] = src_null_data[i];
+        if (!src_null_data[i]) {
+            dst_data[i]._julian = src_data[i] + vectorized::date::UNIX_EPOCH_JULIAN;
+        }
+    }
+    dst_nullable_column->set_has_null(src_nullable_column->has_null());
+    return Status::OK();
+}
+
+Status Int96ToDateTimeConverter::init(const std::string& timezone) {
+    cctz::time_zone ctz;
+    if (!TimezoneUtils::find_cctz_time_zone(timezone, ctz)) {
+        return Status::InternalError(strings::Substitute("can not find cctz time zone $0", timezone));
+    }
+
+    const auto tp = std::chrono::system_clock::now();
+    const cctz::time_zone::absolute_lookup al = ctz.lookup(tp);
+    _offset = al.offset;
+
+    return Status::OK();
+}
+
+Status Int96ToDateTimeConverter::convert(const vectorized::ColumnPtr& src, vectorized::Column* dst) {
+    auto* src_nullable_column = vectorized::ColumnHelper::as_raw_column<vectorized::NullableColumn>(src);
+    // hive only support null column
+    // TODO: support not null
+    auto* dst_nullable_column = down_cast<vectorized::NullableColumn*>(dst);
+    dst_nullable_column->resize(src_nullable_column->size());
+
+    auto* src_column = vectorized::ColumnHelper::as_raw_column<vectorized::FixedLengthColumn<int96_t>>(
+            src_nullable_column->data_column());
+    auto* dst_column =
+            vectorized::ColumnHelper::as_raw_column<vectorized::TimestampColumn>(dst_nullable_column->data_column());
+
+    auto& src_data = src_column->get_data();
+    auto& dst_data = dst_column->get_data();
+    auto& src_null_data = src_nullable_column->null_column()->get_data();
+    auto& dst_null_data = dst_nullable_column->null_column()->get_data();
+
+    size_t size = src_column->size();
+    for (size_t i = 0; i < size; i++) {
+        dst_null_data[i] = src_null_data[i];
+        if (!src_null_data[i]) {
+            vectorized::Timestamp timestamp = (static_cast<uint64_t>(src_data[i].hi) << 40u) | (src_data[i].lo / 1000);
+            dst_data[i].set_timestamp(_utc_to_local(timestamp));
+        }
+    }
+    dst_nullable_column->set_has_null(src_nullable_column->has_null());
+    return Status::OK();
+}
+
+Status Int64ToDateTimeConverter::init(const std::string& timezone, const tparquet::SchemaElement& schema_element) {
+    DCHECK_EQ(schema_element.type, tparquet::Type::INT64);
+
+    if (schema_element.__isset.logicalType) {
+        if (!schema_element.logicalType.__isset.TIMESTAMP) {
+            std::stringstream ss;
+            schema_element.logicalType.printTo(ss);
+            return Status::InternalError(
+                    strings::Substitute("expect parquet logical type is TIMESTAMP, actual is $0", ss.str()));
+        }
+
+        _is_adjusted_to_utc = schema_element.logicalType.TIMESTAMP.isAdjustedToUTC;
+
+        const auto& time_unit = schema_element.logicalType.TIMESTAMP.unit;
+        if (time_unit.__isset.MILLIS) {
+            _second_mask = 1000;
+            _scale_to_nano_factor = 1000000;
+        } else if (time_unit.__isset.MICROS) {
+            _second_mask = 1000000;
+            _scale_to_nano_factor = 1000;
+        } else if (time_unit.__isset.NANOS) {
+            _second_mask = 1000000000;
+            _scale_to_nano_factor = 1;
+        } else {
+            std::stringstream ss;
+            time_unit.printTo(ss);
+            return Status::InternalError(strings::Substitute("unexpected time unit $0", ss.str()));
+        }
+    } else if (schema_element.__isset.converted_type) {
+        _is_adjusted_to_utc = true;
+
+        const auto& converted_type = schema_element.converted_type;
+        if (converted_type == tparquet::ConvertedType::TIMESTAMP_MILLIS) {
+            _second_mask = 1000;
+            _scale_to_nano_factor = 1000000;
+        } else if (converted_type == tparquet::ConvertedType::TIMESTAMP_MICROS) {
+            _second_mask = 1000000;
+            _scale_to_nano_factor = 1000;
+        } else {
+            return Status::InternalError(
+                    strings::Substitute("unexpected converted type $0", tparquet::to_string(converted_type)));
+        }
+    } else {
+        return Status::InternalError(strings::Substitute("can not convert parquet type $0 to date time",
+                                                         tparquet::to_string(schema_element.type)));
+    }
+
+    if (_is_adjusted_to_utc) {
+        cctz::time_zone ctz;
+        if (!TimezoneUtils::find_cctz_time_zone(timezone, ctz)) {
+            return Status::InternalError(strings::Substitute("can not find cctz time zone $0", timezone));
+        }
+
+        const auto tp = std::chrono::system_clock::now();
+        const cctz::time_zone::absolute_lookup al = ctz.lookup(tp);
+        _offset = al.offset;
+    }
+
+    return Status::OK();
+}
+
+Status Int64ToDateTimeConverter::_convert_to_timestamp_column(const vectorized::ColumnPtr& src,
+                                                              vectorized::Column* dst) {
+    auto* src_nullable_column = vectorized::ColumnHelper::as_raw_column<vectorized::NullableColumn>(src);
+    // hive only support null column
+    // TODO: support not null
+    auto* dst_nullable_column = down_cast<vectorized::NullableColumn*>(dst);
+    dst_nullable_column->resize(src_nullable_column->size());
+
+    auto* src_column = vectorized::ColumnHelper::as_raw_column<vectorized::FixedLengthColumn<int64_t>>(
+            src_nullable_column->data_column());
+    auto* dst_column =
+            vectorized::ColumnHelper::as_raw_column<vectorized::TimestampColumn>(dst_nullable_column->data_column());
+
+    auto& src_data = src_column->get_data();
+    auto& dst_data = dst_column->get_data();
+    auto& src_null_data = src_nullable_column->null_column()->get_data();
+    auto& dst_null_data = dst_nullable_column->null_column()->get_data();
+
+    size_t size = src_column->size();
+    for (size_t i = 0; i < size; i++) {
+        dst_null_data[i] = src_null_data[i];
+        if (!src_null_data[i]) {
+            vectorized::Timestamp timestamp = vectorized::timestamp::of_epoch_second(
+                    static_cast<int>(src_data[i] / _second_mask),
+                    static_cast<int>((src_data[i] % _second_mask) * _scale_to_nano_factor));
+            dst_data[i].set_timestamp(_utc_to_local(timestamp));
+        }
+    }
+    dst_nullable_column->set_has_null(src_nullable_column->has_null());
+    return Status::OK();
+}
+
+} // namespace starrocks::parquet

--- a/be/src/exec/parquet/column_converter.h
+++ b/be/src/exec/parquet/column_converter.h
@@ -1,0 +1,281 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#pragma once
+
+#include "column/column_helper.h"
+#include "column/type_traits.h"
+#include "common/status.h"
+#include "exec/parquet/types.h"
+#include "gen_cpp/parquet_types.h"
+#include "runtime/types.h"
+#include "util/bit_util.h"
+#include "utils.h"
+
+namespace starrocks {
+class RandomAccessFile;
+namespace vectorized {
+class Column;
+struct HdfsScanStats;
+} // namespace vectorized
+} // namespace starrocks
+
+namespace starrocks::parquet {
+
+class ParquetField;
+
+struct ColumnReaderOptions {
+    vectorized::HdfsScanStats* stats = nullptr;
+    std::string timezone;
+};
+
+// When doing decimal convert, source scale may not equal with destination scale,
+// when destination scale is greater than source, source unscaled data will be scaled up
+// to match destination scale.
+enum class DecimalScaleType { kNoScale, kScaleUp, kScaleDown };
+
+class ColumnConverter {
+public:
+    ColumnConverter() = default;
+    virtual ~ColumnConverter() = default;
+
+    void init_info(bool _need_convert, tparquet::Type::type _parquet_type) {
+        need_convert = _need_convert;
+        parquet_type = _parquet_type;
+    }
+
+    // create column according parquet data type
+    vectorized::ColumnPtr create_src_column();
+
+    virtual Status convert(const vectorized::ColumnPtr& src, vectorized::Column* dst) { return Status::OK(); };
+
+public:
+    bool need_convert = false;
+    tparquet::Type::type parquet_type;
+};
+
+class Int32ToDateConverter : public ColumnConverter {
+public:
+    Int32ToDateConverter() = default;
+    ~Int32ToDateConverter() override = default;
+
+    Status convert(const vectorized::ColumnPtr& src, vectorized::Column* dst) override;
+};
+
+class Int96ToDateTimeConverter : public ColumnConverter {
+public:
+    Int96ToDateTimeConverter() = default;
+    ~Int96ToDateTimeConverter() override = default;
+
+    Status init(const std::string& timezone);
+    // convert column from int96 to timestamp
+    Status convert(const vectorized::ColumnPtr& src, vectorized::Column* dst) override;
+
+private:
+    // When Hive stores a timestamp value into Parquet format, it converts local time
+    // into UTC time, and when it reads data out, it should be converted to the time
+    // according to session variable "time_zone".
+    [[nodiscard]] vectorized::Timestamp _utc_to_local(vectorized::Timestamp timestamp) const {
+        return vectorized::timestamp::add<vectorized::TimeUnit::SECOND>(timestamp, _offset);
+    }
+
+private:
+    int _offset = 0;
+};
+
+class Int64ToDateTimeConverter : public ColumnConverter {
+public:
+    Int64ToDateTimeConverter() = default;
+    ~Int64ToDateTimeConverter() override = default;
+
+    Status init(const std::string& timezone, const tparquet::SchemaElement& schema_element);
+    Status convert(const vectorized::ColumnPtr& src, vectorized::Column* dst) override {
+        return _convert_to_timestamp_column(src, dst);
+    }
+
+private:
+    // convert column from int64 to timestamp
+    Status _convert_to_timestamp_column(const vectorized::ColumnPtr& src, vectorized::Column* dst);
+    // When Hive stores a timestamp value into Parquet format, it converts local time
+    // into UTC time, and when it reads data out, it should be converted to the time
+    // according to session variable "time_zone".
+    [[nodiscard]] vectorized::Timestamp _utc_to_local(vectorized::Timestamp timestamp) const {
+        return vectorized::timestamp::add<vectorized::TimeUnit::SECOND>(timestamp, _offset);
+    }
+
+private:
+    bool _is_adjusted_to_utc = false;
+    int _offset = 0;
+
+    int64_t _second_mask = 0;
+    int64_t _scale_to_nano_factor = 0;
+};
+
+template <typename SourceType, typename DestType>
+class IntToIntConverter : public ColumnConverter {
+public:
+    IntToIntConverter() = default;
+    ~IntToIntConverter() override = default;
+
+    Status convert(const vectorized::ColumnPtr& src, vectorized::Column* dst) override {
+        auto* src_nullable_column = vectorized::ColumnHelper::as_raw_column<vectorized::NullableColumn>(src);
+        // hive only support null column
+        // TODO: support not null
+        auto* dst_nullable_column = down_cast<vectorized::NullableColumn*>(dst);
+        dst_nullable_column->resize(src_nullable_column->size());
+
+        auto* src_column = vectorized::ColumnHelper::as_raw_column<vectorized::FixedLengthColumn<SourceType>>(
+                src_nullable_column->data_column());
+        auto* dst_column = vectorized::ColumnHelper::as_raw_column<vectorized::FixedLengthColumn<DestType>>(
+                dst_nullable_column->data_column());
+
+        auto& src_data = src_column->get_data();
+        auto& dst_data = dst_column->get_data();
+        auto& src_null_data = src_nullable_column->null_column()->get_data();
+        auto& dst_null_data = dst_nullable_column->null_column()->get_data();
+
+        size_t size = src_column->size();
+
+        for (size_t i = 0; i < size; i++) {
+            dst_null_data[i] = src_null_data[i];
+        }
+        for (size_t i = 0; i < size; i++) {
+            dst_data[i] = DestType(src_data[i]);
+        }
+
+        dst_nullable_column->set_has_null(src_nullable_column->has_null());
+        return Status::OK();
+    }
+};
+
+template <typename SourceType, PrimitiveType DestType>
+class PrimitiveToDecimalConverter : public ColumnConverter {
+public:
+    using DestDecimalType = typename vectorized::RunTimeTypeTraits<DestType>::CppType;
+    using DestColumnType = typename vectorized::RunTimeTypeTraits<DestType>::ColumnType;
+    using DestPrimitiveType = typename vectorized::RunTimeTypeTraits<TYPE_DECIMAL128>::CppType;
+
+    PrimitiveToDecimalConverter(int32_t src_scale, int32_t dst_scale) {
+        if (src_scale < dst_scale) {
+            _scale_type = DecimalScaleType::kScaleUp;
+            _scale_factor = get_scale_factor<DestPrimitiveType>(dst_scale - src_scale);
+        } else if (src_scale > dst_scale) {
+            _scale_type = DecimalScaleType::kScaleDown;
+            _scale_factor = get_scale_factor<DestPrimitiveType>(src_scale - dst_scale);
+        }
+    }
+
+    Status convert(const vectorized::ColumnPtr& src, vectorized::Column* dst) override {
+        auto* src_nullable_column = vectorized::ColumnHelper::as_raw_column<vectorized::NullableColumn>(src);
+        // hive only support null column
+        // TODO: support not null
+        auto* dst_nullable_column = down_cast<vectorized::NullableColumn*>(dst);
+        dst_nullable_column->resize(src_nullable_column->size());
+
+        auto* src_column = vectorized::ColumnHelper::as_raw_column<vectorized::FixedLengthColumn<SourceType>>(
+                src_nullable_column->data_column());
+        auto* dst_column = vectorized::ColumnHelper::as_raw_column<DestColumnType>(dst_nullable_column->data_column());
+
+        auto& src_data = src_column->get_data();
+        auto& dst_data = dst_column->get_data();
+        auto& src_null_data = src_nullable_column->null_column()->get_data();
+        auto& dst_null_data = dst_nullable_column->null_column()->get_data();
+
+        bool has_null = false;
+        size_t size = src_column->size();
+        for (size_t i = 0; i < size; i++) {
+            dst_null_data[i] = src_null_data[i];
+            if (dst_null_data[i]) {
+                has_null = true;
+                continue;
+            }
+            DestPrimitiveType value = src_data[i];
+            if (_scale_type == DecimalScaleType::kScaleUp) {
+                value *= _scale_factor;
+            } else if (_scale_type == DecimalScaleType::kScaleDown) {
+                value /= _scale_factor;
+            }
+            dst_data[i] = DestDecimalType(value);
+        }
+        dst_nullable_column->set_has_null(has_null);
+        return Status::OK();
+    }
+
+private:
+    DecimalScaleType _scale_type = DecimalScaleType::kNoScale;
+    DestPrimitiveType _scale_factor = 1;
+};
+
+template <PrimitiveType DestType>
+class BinaryToDecimalConverter : public ColumnConverter {
+public:
+    using DecimalType = typename vectorized::RunTimeTypeTraits<DestType>::CppType;
+    using ColumnType = typename vectorized::RunTimeTypeTraits<DestType>::ColumnType;
+    using DestPrimitiveType = typename vectorized::RunTimeTypeTraits<TYPE_DECIMAL128>::CppType;
+
+    BinaryToDecimalConverter(int32_t src_scale, int32_t dst_scale) {
+        if (src_scale < dst_scale) {
+            _scale_type = DecimalScaleType::kScaleUp;
+            _scale_factor = get_scale_factor<DestPrimitiveType>(dst_scale - src_scale);
+        } else if (src_scale > dst_scale) {
+            _scale_type = DecimalScaleType::kScaleDown;
+            _scale_factor = get_scale_factor<DestPrimitiveType>(src_scale - dst_scale);
+        }
+    }
+
+    Status convert(const vectorized::ColumnPtr& src, vectorized::Column* dst) override {
+        auto* src_nullable_column = vectorized::ColumnHelper::as_raw_column<vectorized::NullableColumn>(src);
+        // hive only support null column
+        // TODO: support not null
+        auto* dst_nullable_column = down_cast<vectorized::NullableColumn*>(dst);
+        dst_nullable_column->resize(src_nullable_column->size());
+
+        auto* src_column =
+                vectorized::ColumnHelper::as_raw_column<vectorized::BinaryColumn>(src_nullable_column->data_column());
+        auto* dst_column = vectorized::ColumnHelper::as_raw_column<ColumnType>(dst_nullable_column->data_column());
+
+        auto& src_data = src_column->get_data();
+        auto& dst_data = dst_column->get_data();
+        auto& src_null_data = src_nullable_column->null_column()->get_data();
+        auto& dst_null_data = dst_nullable_column->null_column()->get_data();
+
+        size_t size = src_column->size();
+        bool has_null = false;
+        for (size_t i = 0; i < size; i++) {
+            // If src_data[i].size > DestPrimitiveType, this means  we treat as null.
+            dst_null_data[i] = src_null_data[i] | (src_data[i].size > sizeof(DestPrimitiveType));
+            if (dst_null_data[i]) {
+                has_null = true;
+                continue;
+            }
+
+            // When Decimal in parquet is stored in byte arrays, binary and fixed,
+            // the unscaled number must be encoded as two's complement using big-endian byte order.
+            DestPrimitiveType value = src_data[i].data[0] & 0x80 ? -1 : 0;
+            memcpy(reinterpret_cast<char*>(&value) + sizeof(DestPrimitiveType) - src_data[i].size, src_data[i].data,
+                   src_data[i].size);
+            value = BitUtil::big_endian_to_host(value);
+
+            // scale up/down
+            if (_scale_type == DecimalScaleType::kScaleUp) {
+                value *= _scale_factor;
+            } else if (_scale_type == DecimalScaleType::kScaleDown) {
+                value /= _scale_factor;
+            }
+            dst_data[i] = DecimalType(value);
+        }
+        dst_nullable_column->set_has_null(has_null);
+        return Status::OK();
+    }
+
+private:
+    DecimalScaleType _scale_type = DecimalScaleType::kNoScale;
+    DestPrimitiveType _scale_factor = 1;
+};
+
+class ColumnConverterFactory {
+public:
+    static Status create_converter(const ParquetField& field, const TypeDescriptor& typeDescriptor,
+                                   const std::string& timezone, std::unique_ptr<ColumnConverter>* converter);
+};
+
+} // namespace starrocks::parquet

--- a/be/src/exec/parquet/column_reader.cpp
+++ b/be/src/exec/parquet/column_reader.cpp
@@ -2,702 +2,14 @@
 
 #include "exec/parquet/column_reader.h"
 
-#include <memory>
-#include <utility>
-
 #include "column/array_column.h"
-#include "column/binary_column.h"
-#include "column/column_helper.h"
-#include "column/fixed_length_column.h"
-#include "column/type_traits.h"
-#include "exec/parquet/schema.h"
 #include "exec/parquet/stored_column_reader.h"
-#include "gen_cpp/parquet_types.h"
-#include "gutil/casts.h"
-#include "gutil/strings/substitute.h"
-#include "runtime/decimalv2_value.h"
-#include "runtime/primitive_type.h"
-#include "storage/types.h"
-#include "util/bit_util.h"
-#include "util/runtime_profile.h"
 
 namespace starrocks {
 class RandomAccessFile;
 }
 
 namespace starrocks::parquet {
-
-class ColumnConverter {
-public:
-    ColumnConverter() = default;
-    virtual ~ColumnConverter() = default;
-
-    virtual Status convert(const vectorized::ColumnPtr& src, vectorized::Column* dst) = 0;
-};
-
-class Int64ToDateTimeConverter : public ColumnConverter {
-public:
-    Int64ToDateTimeConverter() = default;
-    ~Int64ToDateTimeConverter() override = default;
-
-    Status init(const std::string& timezone, const tparquet::SchemaElement& schema_element);
-    Status convert(const vectorized::ColumnPtr& src, vectorized::Column* dst) override {
-        return _convert_to_timestamp_column(src, dst);
-    }
-
-private:
-    // convert column from int64 to timestamp
-    Status _convert_to_timestamp_column(const vectorized::ColumnPtr& src, vectorized::Column* dst);
-    // When Hive stores a timestamp value into Parquet format, it converts local time
-    // into UTC time, and when it reads data out, it should be converted to the time
-    // according to session variable "time_zone".
-    [[nodiscard]] vectorized::Timestamp _utc_to_local(vectorized::Timestamp timestamp) const {
-        return vectorized::timestamp::add<vectorized::TimeUnit::SECOND>(timestamp, _offset);
-    }
-
-private:
-    bool _is_adjusted_to_utc = false;
-    int _offset = 0;
-
-    int64_t _second_mask = 0;
-    int64_t _scale_to_nano_factor = 0;
-};
-
-Status Int64ToDateTimeConverter::init(const std::string& timezone, const tparquet::SchemaElement& schema_element) {
-    DCHECK_EQ(schema_element.type, tparquet::Type::INT64);
-
-    if (schema_element.__isset.logicalType) {
-        if (!schema_element.logicalType.__isset.TIMESTAMP) {
-            std::stringstream ss;
-            schema_element.logicalType.printTo(ss);
-            return Status::InternalError(
-                    strings::Substitute("expect parquet logical type is TIMESTAMP, actual is $0", ss.str()));
-        }
-
-        _is_adjusted_to_utc = schema_element.logicalType.TIMESTAMP.isAdjustedToUTC;
-
-        const auto& time_unit = schema_element.logicalType.TIMESTAMP.unit;
-        if (time_unit.__isset.MILLIS) {
-            _second_mask = 1000;
-            _scale_to_nano_factor = 1000000;
-        } else if (time_unit.__isset.MICROS) {
-            _second_mask = 1000000;
-            _scale_to_nano_factor = 1000;
-        } else if (time_unit.__isset.NANOS) {
-            _second_mask = 1000000000;
-            _scale_to_nano_factor = 1;
-        } else {
-            std::stringstream ss;
-            time_unit.printTo(ss);
-            return Status::InternalError(strings::Substitute("unexpected time unit $0", ss.str()));
-        }
-    } else if (schema_element.__isset.converted_type) {
-        _is_adjusted_to_utc = true;
-
-        const auto& converted_type = schema_element.converted_type;
-        if (converted_type == tparquet::ConvertedType::TIMESTAMP_MILLIS) {
-            _second_mask = 1000;
-            _scale_to_nano_factor = 1000000;
-        } else if (converted_type == tparquet::ConvertedType::TIMESTAMP_MICROS) {
-            _second_mask = 1000000;
-            _scale_to_nano_factor = 1000;
-        } else {
-            return Status::InternalError(
-                    strings::Substitute("unexpected converted type $0", tparquet::to_string(converted_type)));
-        }
-    } else {
-        return Status::InternalError(strings::Substitute("can not convert parquet type $0 to date time",
-                                                         tparquet::to_string(schema_element.type)));
-    }
-
-    if (_is_adjusted_to_utc) {
-        cctz::time_zone ctz;
-        if (!TimezoneUtils::find_cctz_time_zone(timezone, ctz)) {
-            return Status::InternalError(strings::Substitute("can not find cctz time zone $0", timezone));
-        }
-
-        const auto tp = std::chrono::system_clock::now();
-        const cctz::time_zone::absolute_lookup al = ctz.lookup(tp);
-        _offset = al.offset;
-    }
-
-    return Status::OK();
-}
-
-Status Int64ToDateTimeConverter::_convert_to_timestamp_column(const vectorized::ColumnPtr& src,
-                                                              vectorized::Column* dst) {
-    auto* src_nullable_column = vectorized::ColumnHelper::as_raw_column<vectorized::NullableColumn>(src);
-    // hive only support null column
-    // TODO: support not null
-    auto* dst_nullable_column = down_cast<vectorized::NullableColumn*>(dst);
-    dst_nullable_column->resize(src_nullable_column->size());
-
-    auto* src_column = vectorized::ColumnHelper::as_raw_column<vectorized::FixedLengthColumn<int64_t>>(
-            src_nullable_column->data_column());
-    auto* dst_column =
-            vectorized::ColumnHelper::as_raw_column<vectorized::TimestampColumn>(dst_nullable_column->data_column());
-
-    auto& src_data = src_column->get_data();
-    auto& dst_data = dst_column->get_data();
-    auto& src_null_data = src_nullable_column->null_column()->get_data();
-    auto& dst_null_data = dst_nullable_column->null_column()->get_data();
-
-    size_t size = src_column->size();
-    for (size_t i = 0; i < size; i++) {
-        dst_null_data[i] = src_null_data[i];
-        if (!src_null_data[i]) {
-            vectorized::Timestamp timestamp = vectorized::timestamp::of_epoch_second(
-                    static_cast<int>(src_data[i] / _second_mask),
-                    static_cast<int>((src_data[i] % _second_mask) * _scale_to_nano_factor));
-            dst_data[i].set_timestamp(_utc_to_local(timestamp));
-        }
-    }
-    dst_nullable_column->set_has_null(src_nullable_column->has_null());
-    return Status::OK();
-}
-
-class Int96ToDateTimeConverter : public ColumnConverter {
-public:
-    Int96ToDateTimeConverter() = default;
-    ~Int96ToDateTimeConverter() override = default;
-
-    Status init(const std::string& timezone);
-    Status convert(const vectorized::ColumnPtr& src, vectorized::Column* dst) override {
-        return _convert_to_timestamp_column(src, dst);
-    }
-
-private:
-    // convert column from int96 to timestamp
-    Status _convert_to_timestamp_column(const vectorized::ColumnPtr& src, vectorized::Column* dst);
-    // When Hive stores a timestamp value into Parquet format, it converts local time
-    // into UTC time, and when it reads data out, it should be converted to the time
-    // according to session variable "time_zone".
-    [[nodiscard]] vectorized::Timestamp _utc_to_local(vectorized::Timestamp timestamp) const {
-        return vectorized::timestamp::add<vectorized::TimeUnit::SECOND>(timestamp, _offset);
-    }
-
-private:
-    int _offset = 0;
-};
-
-Status Int96ToDateTimeConverter::init(const std::string& timezone) {
-    cctz::time_zone ctz;
-    if (!TimezoneUtils::find_cctz_time_zone(timezone, ctz)) {
-        return Status::InternalError(strings::Substitute("can not find cctz time zone $0", timezone));
-    }
-
-    const auto tp = std::chrono::system_clock::now();
-    const cctz::time_zone::absolute_lookup al = ctz.lookup(tp);
-    _offset = al.offset;
-
-    return Status::OK();
-}
-
-Status Int96ToDateTimeConverter::_convert_to_timestamp_column(const vectorized::ColumnPtr& src,
-                                                              vectorized::Column* dst) {
-    auto* src_nullable_column = vectorized::ColumnHelper::as_raw_column<vectorized::NullableColumn>(src);
-    // hive only support null column
-    // TODO: support not null
-    auto* dst_nullable_column = down_cast<vectorized::NullableColumn*>(dst);
-    dst_nullable_column->resize(src_nullable_column->size());
-
-    auto* src_column = vectorized::ColumnHelper::as_raw_column<vectorized::FixedLengthColumn<int96_t>>(
-            src_nullable_column->data_column());
-    auto* dst_column =
-            vectorized::ColumnHelper::as_raw_column<vectorized::TimestampColumn>(dst_nullable_column->data_column());
-
-    auto& src_data = src_column->get_data();
-    auto& dst_data = dst_column->get_data();
-    auto& src_null_data = src_nullable_column->null_column()->get_data();
-    auto& dst_null_data = dst_nullable_column->null_column()->get_data();
-
-    size_t size = src_column->size();
-    for (size_t i = 0; i < size; i++) {
-        dst_null_data[i] = src_null_data[i];
-        if (!src_null_data[i]) {
-            vectorized::Timestamp timestamp = (static_cast<uint64_t>(src_data[i].hi) << 40u) | (src_data[i].lo / 1000);
-            dst_data[i].set_timestamp(_utc_to_local(timestamp));
-        }
-    }
-    dst_nullable_column->set_has_null(src_nullable_column->has_null());
-    return Status::OK();
-}
-
-template <typename FROM, typename TO>
-class IntToIntConverter : public ColumnConverter {
-public:
-    IntToIntConverter() = default;
-    ~IntToIntConverter() override = default;
-
-    Status convert(const vectorized::ColumnPtr& src, vectorized::Column* dst) override {
-        auto* src_nullable_column = vectorized::ColumnHelper::as_raw_column<vectorized::NullableColumn>(src);
-        // hive only support null column
-        // TODO: support not null
-        auto* dst_nullable_column = down_cast<vectorized::NullableColumn*>(dst);
-        dst_nullable_column->resize(src_nullable_column->size());
-
-        auto* src_column = vectorized::ColumnHelper::as_raw_column<vectorized::FixedLengthColumn<FROM>>(
-                src_nullable_column->data_column());
-        auto* dst_column = vectorized::ColumnHelper::as_raw_column<vectorized::FixedLengthColumn<TO>>(
-                dst_nullable_column->data_column());
-
-        auto& src_data = src_column->get_data();
-        auto& dst_data = dst_column->get_data();
-        auto& src_null_data = src_nullable_column->null_column()->get_data();
-        auto& dst_null_data = dst_nullable_column->null_column()->get_data();
-
-        size_t size = src_column->size();
-
-        for (size_t i = 0; i < size; i++) {
-            dst_null_data[i] = src_null_data[i];
-        }
-        for (size_t i = 0; i < size; i++) {
-            dst_data[i] = TO(src_data[i]);
-        }
-
-        dst_nullable_column->set_has_null(src_nullable_column->has_null());
-        return Status::OK();
-    }
-};
-
-class Int32ToDateConverter : public ColumnConverter {
-public:
-    Int32ToDateConverter() = default;
-    ~Int32ToDateConverter() override = default;
-
-    Status convert(const vectorized::ColumnPtr& src, vectorized::Column* dst) override {
-        auto* src_nullable_column = vectorized::ColumnHelper::as_raw_column<vectorized::NullableColumn>(src);
-        // hive only support null column
-        // TODO: support not null
-        auto* dst_nullable_column = down_cast<vectorized::NullableColumn*>(dst);
-        dst_nullable_column->resize(src_nullable_column->size());
-
-        auto* src_column = vectorized::ColumnHelper::as_raw_column<vectorized::FixedLengthColumn<int32_t>>(
-                src_nullable_column->data_column());
-        auto* dst_column =
-                vectorized::ColumnHelper::as_raw_column<vectorized::DateColumn>(dst_nullable_column->data_column());
-
-        auto& src_data = src_column->get_data();
-        auto& dst_data = dst_column->get_data();
-        auto& src_null_data = src_nullable_column->null_column()->get_data();
-        auto& dst_null_data = dst_nullable_column->null_column()->get_data();
-
-        size_t size = src_column->size();
-        for (size_t i = 0; i < size; i++) {
-            dst_null_data[i] = src_null_data[i];
-            if (!src_null_data[i]) {
-                dst_data[i]._julian = src_data[i] + vectorized::date::UNIX_EPOCH_JULIAN;
-            }
-        }
-        dst_nullable_column->set_has_null(src_nullable_column->has_null());
-        return Status::OK();
-    }
-};
-
-// When doing decimal convert, source scale may not equal with destination scale,
-// when destination scale is greater than source, source unscaled data will be scaled up
-// to match destination scale.
-enum DecimalScaleType {
-    NO_SCALE,
-    SCALE_UP,
-    SCALE_DOWN,
-};
-
-template <typename T>
-struct DecimalTypeTraits {
-    using PrimitiveType = T;
-};
-
-template <>
-struct DecimalTypeTraits<DecimalV2Value> {
-    using PrimitiveType = int128_t;
-};
-
-template <typename SourceType, PrimitiveType dst_type>
-class PrimitiveToDecimalConverter : public ColumnConverter {
-public:
-    using DestDecimalType = typename vectorized::RunTimeTypeTraits<dst_type>::CppType;
-    using DestPrimitiveType = typename DecimalTypeTraits<DestDecimalType>::PrimitiveType;
-    using DestColumnType = typename vectorized::RunTimeTypeTraits<dst_type>::ColumnType;
-
-    PrimitiveToDecimalConverter(int32_t src_scale, int32_t dst_scale) {
-        if (src_scale < dst_scale) {
-            _scale_type = SCALE_UP;
-            _scale_factor = get_scale_factor<DestPrimitiveType>(dst_scale - src_scale);
-        } else if (src_scale > dst_scale) {
-            _scale_type = SCALE_DOWN;
-            _scale_factor = get_scale_factor<DestPrimitiveType>(src_scale - dst_scale);
-        }
-    }
-
-    Status convert(const vectorized::ColumnPtr& src, vectorized::Column* dst) override {
-        auto* src_nullable_column = vectorized::ColumnHelper::as_raw_column<vectorized::NullableColumn>(src);
-        // hive only support null column
-        // TODO: support not null
-        auto* dst_nullable_column = down_cast<vectorized::NullableColumn*>(dst);
-        dst_nullable_column->resize(src_nullable_column->size());
-
-        auto* src_column = vectorized::ColumnHelper::as_raw_column<vectorized::FixedLengthColumn<SourceType>>(
-                src_nullable_column->data_column());
-        auto* dst_column = vectorized::ColumnHelper::as_raw_column<DestColumnType>(dst_nullable_column->data_column());
-
-        auto& src_data = src_column->get_data();
-        auto& dst_data = dst_column->get_data();
-        auto& src_null_data = src_nullable_column->null_column()->get_data();
-        auto& dst_null_data = dst_nullable_column->null_column()->get_data();
-
-        bool has_null = false;
-        size_t size = src_column->size();
-        for (size_t i = 0; i < size; i++) {
-            dst_null_data[i] = src_null_data[i];
-            if (dst_null_data[i]) {
-                has_null = true;
-                continue;
-            }
-            DestPrimitiveType value = src_data[i];
-            if (_scale_type == SCALE_UP) {
-                value *= _scale_factor;
-            } else if (_scale_type == SCALE_DOWN) {
-                value /= _scale_factor;
-            }
-            dst_data[i] = DestDecimalType(value);
-        }
-        dst_nullable_column->set_has_null(has_null);
-        return Status::OK();
-    }
-
-private:
-    DecimalScaleType _scale_type = NO_SCALE;
-    DestPrimitiveType _scale_factor = 1;
-};
-
-template <PrimitiveType dst_type>
-class BinaryToDecimalConverter : public ColumnConverter {
-public:
-    using DecimalType = typename vectorized::RunTimeTypeTraits<dst_type>::CppType;
-    using DestPrimitiveType = typename DecimalTypeTraits<DecimalType>::PrimitiveType;
-    using ColumnType = typename vectorized::RunTimeTypeTraits<dst_type>::ColumnType;
-
-    BinaryToDecimalConverter(int32_t src_scale, int32_t dst_scale) {
-        if (src_scale < dst_scale) {
-            _scale_type = SCALE_UP;
-            _scale_factor = get_scale_factor<DestPrimitiveType>(dst_scale - src_scale);
-        } else if (src_scale > dst_scale) {
-            _scale_type = SCALE_DOWN;
-            _scale_factor = get_scale_factor<DestPrimitiveType>(src_scale - dst_scale);
-        }
-    }
-
-    Status convert(const vectorized::ColumnPtr& src, vectorized::Column* dst) override {
-        auto* src_nullable_column = vectorized::ColumnHelper::as_raw_column<vectorized::NullableColumn>(src);
-        // hive only support null column
-        // TODO: support not null
-        auto* dst_nullable_column = down_cast<vectorized::NullableColumn*>(dst);
-        dst_nullable_column->resize(src_nullable_column->size());
-
-        auto* src_column =
-                vectorized::ColumnHelper::as_raw_column<vectorized::BinaryColumn>(src_nullable_column->data_column());
-        auto* dst_column = vectorized::ColumnHelper::as_raw_column<ColumnType>(dst_nullable_column->data_column());
-
-        auto& src_data = src_column->get_data();
-        auto& dst_data = dst_column->get_data();
-        auto& src_null_data = src_nullable_column->null_column()->get_data();
-        auto& dst_null_data = dst_nullable_column->null_column()->get_data();
-
-        size_t size = src_column->size();
-        bool has_null = false;
-        for (size_t i = 0; i < size; i++) {
-            // If src_data[i].size > DestPrimitiveType, this means  we treat as null.
-            dst_null_data[i] = src_null_data[i] | (src_data[i].size > sizeof(DestPrimitiveType));
-            if (dst_null_data[i]) {
-                has_null = true;
-                continue;
-            }
-
-            // When Decimal in parquet is stored in byte arrays, binary and fixed,
-            // the unscaled number must be encoded as two's complement using big-endian byte order.
-            DestPrimitiveType value = src_data[i].data[0] & 0x80 ? -1 : 0;
-            memcpy(reinterpret_cast<char*>(&value) + sizeof(DestPrimitiveType) - src_data[i].size, src_data[i].data,
-                   src_data[i].size);
-            value = BitUtil::big_endian_to_host(value);
-
-            // scale up/down
-            if (_scale_type == SCALE_UP) {
-                value *= _scale_factor;
-            } else if (_scale_type == SCALE_DOWN) {
-                value /= _scale_factor;
-            }
-            dst_data[i] = DecimalType(value);
-        }
-        dst_nullable_column->set_has_null(has_null);
-        return Status::OK();
-    }
-
-private:
-    DecimalScaleType _scale_type = NO_SCALE;
-    DestPrimitiveType _scale_factor = 1;
-};
-
-class ScalarColumnReader : public ColumnReader {
-public:
-    explicit ScalarColumnReader(ColumnReaderOptions opts) : _opts(std::move(opts)) {}
-    ~ScalarColumnReader() override = default;
-
-    Status init(int chunk_size, RandomAccessFile* file, const ParquetField* field,
-                const tparquet::ColumnChunk* chunk_metadata, const TypeDescriptor& col_type) {
-        StoredColumnReaderOptions opts;
-        opts.stats = _opts.stats;
-        _field = field;
-        _col_type = col_type;
-
-        RETURN_IF_ERROR(_init_convert_info());
-
-        return StoredColumnReader::create(file, field, chunk_metadata, opts, chunk_size, &_reader);
-    }
-
-    Status prepare_batch(size_t* num_records, ColumnContentType content_type, vectorized::Column* dst) override {
-        if (!_need_convert) {
-            return _reader->read_records(num_records, content_type, dst);
-        } else {
-            SCOPED_RAW_TIMER(&_opts.stats->column_convert_ns);
-            auto data_column = _create_column(_field->physical_type);
-            vectorized::ColumnPtr column =
-                    vectorized::NullableColumn::create(data_column, vectorized::NullColumn::create());
-
-            Status status = _reader->read_records(num_records, content_type, column.get());
-            if (!status.ok() && !status.is_end_of_file()) {
-                return status;
-            }
-
-            RETURN_IF_ERROR(_converter->convert(column, dst));
-
-            return Status::OK();
-        }
-    }
-
-    Status finish_batch() override { return Status::OK(); }
-
-    void get_levels(level_t** def_levels, level_t** rep_levels, size_t* num_levels) override {
-        _reader->get_levels(def_levels, rep_levels, num_levels);
-    }
-
-    Status get_dict_values(vectorized::Column* column) override { return _reader->get_dict_values(column); }
-
-    Status get_dict_values(const std::vector<int32_t>& dict_codes, vectorized::Column* column) override {
-        return _reader->get_dict_values(dict_codes, column);
-    }
-
-    Status get_dict_codes(const std::vector<Slice>& dict_values, std::vector<int32_t>* dict_codes) override {
-        return _reader->get_dict_codes(dict_values, dict_codes);
-    }
-
-private:
-    Status _init_convert_info();
-
-    // create column according parquet data type
-    static vectorized::ColumnPtr _create_column(tparquet::Type::type type);
-
-private:
-    ColumnReaderOptions _opts;
-
-    const ParquetField* _field = nullptr;
-    TypeDescriptor _col_type;
-    bool _need_convert = false;
-    std::unique_ptr<ColumnConverter> _converter;
-
-    std::unique_ptr<StoredColumnReader> _reader;
-};
-
-// TODO(zc): Use the registration mechanism instead
-Status ScalarColumnReader::_init_convert_info() {
-    tparquet::Type::type parquet_type = _field->physical_type;
-    const auto& schema_element = _field->schema_element;
-    PrimitiveType col_type = _col_type.type;
-
-    _need_convert = false;
-
-    // the reason why there is down conversion of integer type is
-    // assume we create a hive column called `col0` whose type is `tinyint`
-    // but when we insert value into `col0`, the physical type in parquet file is actually `INT32`
-    // so when we read `col0` from parquet file, we have to do a type conversion from int32_t to int8_t.
-    switch (parquet_type) {
-    case tparquet::Type::type::BOOLEAN: {
-        if (col_type != PrimitiveType::TYPE_BOOLEAN) {
-            _need_convert = true;
-        }
-        break;
-    }
-    case tparquet::Type::type::INT32: {
-        if (col_type != PrimitiveType::TYPE_INT) {
-            _need_convert = true;
-        }
-        switch (col_type) {
-        case PrimitiveType::TYPE_TINYINT:
-            _converter = std::make_unique<IntToIntConverter<int32_t, int8_t>>();
-            break;
-        case PrimitiveType::TYPE_SMALLINT:
-            _converter = std::make_unique<IntToIntConverter<int32_t, int16_t>>();
-            break;
-        case PrimitiveType::TYPE_BIGINT:
-            _converter = std::make_unique<IntToIntConverter<int32_t, int64_t>>();
-            break;
-        case PrimitiveType::TYPE_DATE:
-            _converter = std::make_unique<Int32ToDateConverter>();
-            break;
-            // when decimal precision is greater than 27, precision may be lost in the following
-            // process. However to handle most enviroment, we also make progress other than
-            // rejection
-        case PrimitiveType::TYPE_DECIMALV2:
-            // All DecimalV2 use scale 9 as scale
-            _converter = std::make_unique<PrimitiveToDecimalConverter<int32_t, TYPE_DECIMALV2>>(_field->scale, 9);
-            break;
-        case PrimitiveType::TYPE_DECIMAL32:
-            _converter = std::make_unique<PrimitiveToDecimalConverter<int32_t, TYPE_DECIMAL32>>(_field->scale,
-                                                                                                _col_type.scale);
-            break;
-        case PrimitiveType::TYPE_DECIMAL64:
-            _converter = std::make_unique<PrimitiveToDecimalConverter<int32_t, TYPE_DECIMAL64>>(_field->scale,
-                                                                                                _col_type.scale);
-            break;
-        case PrimitiveType::TYPE_DECIMAL128:
-            _converter = std::make_unique<PrimitiveToDecimalConverter<int32_t, TYPE_DECIMAL128>>(_field->scale,
-                                                                                                 _col_type.scale);
-            break;
-        default:
-            break;
-        }
-        break;
-    }
-    case tparquet::Type::type::INT64: {
-        if (col_type != PrimitiveType::TYPE_BIGINT) {
-            _need_convert = true;
-        }
-        switch (col_type) {
-        case PrimitiveType::TYPE_TINYINT:
-            _converter = std::make_unique<IntToIntConverter<int64_t, int8_t>>();
-            break;
-        case PrimitiveType::TYPE_SMALLINT:
-            _converter = std::make_unique<IntToIntConverter<int64_t, int16_t>>();
-            break;
-        case PrimitiveType::TYPE_INT:
-            _converter = std::make_unique<IntToIntConverter<int64_t, int32_t>>();
-            break;
-            // when decimal precision is greater than 27, precision may be lost in the following
-            // process. However to handle most enviroment, we also make progress other than
-            // rejection
-        case PrimitiveType::TYPE_DECIMALV2:
-            // All DecimalV2 use scale 9 as scale
-            _converter = std::make_unique<PrimitiveToDecimalConverter<int64_t, TYPE_DECIMALV2>>(_field->scale, 9);
-            break;
-        case PrimitiveType::TYPE_DECIMAL32:
-            _converter = std::make_unique<PrimitiveToDecimalConverter<int64_t, TYPE_DECIMAL32>>(_field->scale,
-                                                                                                _col_type.scale);
-            break;
-        case PrimitiveType::TYPE_DECIMAL64:
-            _converter = std::make_unique<PrimitiveToDecimalConverter<int64_t, TYPE_DECIMAL64>>(_field->scale,
-                                                                                                _col_type.scale);
-            break;
-        case PrimitiveType::TYPE_DECIMAL128:
-            _converter = std::make_unique<PrimitiveToDecimalConverter<int64_t, TYPE_DECIMAL128>>(_field->scale,
-                                                                                                 _col_type.scale);
-            break;
-
-        case PrimitiveType::TYPE_DATETIME: {
-            auto converter = std::make_unique<Int64ToDateTimeConverter>();
-            RETURN_IF_ERROR(converter->init(_opts.timezone, schema_element));
-            _converter = std::move(converter);
-            break;
-        }
-        default:
-            break;
-        }
-        break;
-    }
-    case tparquet::Type::type::BYTE_ARRAY: {
-        if (col_type != PrimitiveType::TYPE_VARCHAR && col_type != PrimitiveType::TYPE_CHAR) {
-            _need_convert = true;
-        }
-        break;
-    }
-    case tparquet::Type::type::FIXED_LEN_BYTE_ARRAY: {
-        if (col_type != PrimitiveType::TYPE_VARCHAR && col_type != PrimitiveType::TYPE_CHAR) {
-            _need_convert = true;
-        }
-        switch (col_type) {
-        case PrimitiveType::TYPE_DECIMALV2:
-            // All DecimalV2 use scale 9 as scale
-            _converter = std::make_unique<BinaryToDecimalConverter<TYPE_DECIMALV2>>(_field->scale, 9);
-            break;
-        case PrimitiveType::TYPE_DECIMAL32:
-            _converter = std::make_unique<BinaryToDecimalConverter<TYPE_DECIMAL32>>(_field->scale, _col_type.scale);
-            break;
-        case PrimitiveType::TYPE_DECIMAL64:
-            _converter = std::make_unique<BinaryToDecimalConverter<TYPE_DECIMAL64>>(_field->scale, _col_type.scale);
-            break;
-        case PrimitiveType::TYPE_DECIMAL128:
-            _converter = std::make_unique<BinaryToDecimalConverter<TYPE_DECIMAL128>>(_field->scale, _col_type.scale);
-            break;
-        default:
-            break;
-        }
-        break;
-    }
-    case tparquet::Type::type::INT96: {
-        if (col_type == PrimitiveType::TYPE_DATETIME) {
-            _need_convert = true;
-            std::unique_ptr<Int96ToDateTimeConverter> converter(new Int96ToDateTimeConverter());
-            RETURN_IF_ERROR(converter->init(_opts.timezone));
-            _converter = std::move(converter);
-        }
-        break;
-    }
-    case tparquet::Type::FLOAT: {
-        if (col_type != PrimitiveType::TYPE_FLOAT) {
-            _need_convert = true;
-        }
-        break;
-    }
-    case tparquet::Type::DOUBLE: {
-        if (col_type != PrimitiveType::TYPE_DOUBLE) {
-            _need_convert = true;
-        }
-        break;
-    }
-    default:
-        _need_convert = true;
-        break;
-    }
-
-    if (_need_convert && _converter == nullptr) {
-        return Status::NotSupported(
-                strings::Substitute("parquet column reader: not supported convert from parquet `$0` to `$1`",
-                                    ::tparquet::to_string(parquet_type), type_to_string(col_type)));
-    }
-
-    return Status::OK();
-}
-
-vectorized::ColumnPtr ScalarColumnReader::_create_column(tparquet::Type::type type) {
-    switch (type) {
-    case tparquet::Type::type::BOOLEAN:
-        return vectorized::FixedLengthColumn<uint8_t>::create();
-    case tparquet::Type::type::INT32:
-        return vectorized::FixedLengthColumn<TypeTraits<OLAP_FIELD_TYPE_INT>::CppType>::create();
-    case tparquet::Type::type::INT64:
-        return vectorized::FixedLengthColumn<TypeTraits<OLAP_FIELD_TYPE_BIGINT>::CppType>::create();
-    case tparquet::Type::type::INT96:
-        return vectorized::FixedLengthColumn<int96_t>::create();
-    case tparquet::Type::type::FLOAT:
-        return vectorized::FixedLengthColumn<TypeTraits<OLAP_FIELD_TYPE_FLOAT>::CppType>::create();
-    case tparquet::Type::type::DOUBLE:
-        return vectorized::FixedLengthColumn<TypeTraits<OLAP_FIELD_TYPE_DOUBLE>::CppType>::create();
-    case tparquet::Type::type::BYTE_ARRAY:
-    case tparquet::Type::type::FIXED_LEN_BYTE_ARRAY:
-        return vectorized::BinaryColumn::create();
-    default:
-        return nullptr;
-    }
-}
 
 template <typename TOffset, typename TIsNull>
 static void def_rep_to_offset(const LevelInfo& level_info, const level_t* def_levels, const level_t* rep_levels,
@@ -735,6 +47,61 @@ static void def_rep_to_offset(const LevelInfo& level_info, const level_t* def_le
     }
     *num_offsets = offset_pos;
 }
+
+class ScalarColumnReader : public ColumnReader {
+public:
+    explicit ScalarColumnReader(ColumnReaderOptions opts) : _opts(std::move(opts)) {}
+    ~ScalarColumnReader() override = default;
+
+    Status init(int chunk_size, RandomAccessFile* file, const ParquetField* field,
+                const tparquet::ColumnChunk* chunk_metadata, const TypeDescriptor& col_type) {
+        StoredColumnReaderOptions opts;
+        opts.stats = _opts.stats;
+
+        RETURN_IF_ERROR(ColumnConverterFactory::create_converter(*field, col_type, _opts.timezone, &converter));
+
+        return StoredColumnReader::create(file, field, chunk_metadata, opts, chunk_size, &_reader);
+    }
+
+    Status prepare_batch(size_t* num_records, ColumnContentType content_type, vectorized::Column* dst) override {
+        if (!converter->need_convert) {
+            return _reader->read_records(num_records, content_type, dst);
+        } else {
+            SCOPED_RAW_TIMER(&_opts.stats->column_convert_ns);
+            auto column = converter->create_src_column();
+
+            Status status = _reader->read_records(num_records, content_type, column.get());
+            if (!status.ok() && !status.is_end_of_file()) {
+                return status;
+            }
+
+            RETURN_IF_ERROR(converter->convert(column, dst));
+
+            return Status::OK();
+        }
+    }
+
+    Status finish_batch() override { return Status::OK(); }
+
+    void get_levels(level_t** def_levels, level_t** rep_levels, size_t* num_levels) override {
+        _reader->get_levels(def_levels, rep_levels, num_levels);
+    }
+
+    Status get_dict_values(vectorized::Column* column) override { return _reader->get_dict_values(column); }
+
+    Status get_dict_values(const std::vector<int32_t>& dict_codes, vectorized::Column* column) override {
+        return _reader->get_dict_values(dict_codes, column);
+    }
+
+    Status get_dict_codes(const std::vector<Slice>& dict_values, std::vector<int32_t>* dict_codes) override {
+        return _reader->get_dict_codes(dict_values, dict_codes);
+    }
+
+private:
+    ColumnReaderOptions _opts;
+
+    std::unique_ptr<StoredColumnReader> _reader;
+};
 
 class ListColumnReader : public ColumnReader {
 public:

--- a/be/src/exec/parquet/column_reader.h
+++ b/be/src/exec/parquet/column_reader.h
@@ -4,28 +4,9 @@
 
 #include <memory>
 
-#include "common/status.h"
-#include "exec/parquet/types.h"
-#include "gen_cpp/parquet_types.h"
-#include "runtime/types.h"
-#include "utils.h"
-
-namespace starrocks {
-class RandomAccessFile;
-namespace vectorized {
-class Column;
-struct HdfsScanStats;
-} // namespace vectorized
-} // namespace starrocks
+#include "column_converter.h"
 
 namespace starrocks::parquet {
-
-class ParquetField;
-
-struct ColumnReaderOptions {
-    vectorized::HdfsScanStats* stats = nullptr;
-    std::string timezone;
-};
 
 class ColumnReader {
 public:
@@ -58,6 +39,9 @@ public:
     virtual Status get_dict_codes(const std::vector<Slice>& dict_values, std::vector<int32_t>* dict_codes) {
         return Status::NotSupported("get_dict_codes is not supported");
     }
+
+public:
+    std::unique_ptr<ColumnConverter> converter;
 };
 
 } // namespace starrocks::parquet

--- a/be/src/exec/parquet/file_reader.cpp
+++ b/be/src/exec/parquet/file_reader.cpp
@@ -2,8 +2,6 @@
 
 #include "exec/parquet/file_reader.h"
 
-#include <thrift/protocol/TDebugProtocol.h>
-
 #include "column/column_helper.h"
 #include "env/env.h"
 #include "exec/exec_node.h"
@@ -252,8 +250,8 @@ Status FileReader::_read_min_max_chunk(const tparquet::RowGroup& row_group, vect
                 column_order = column_idx < column_orders.size() ? &column_orders[column_idx] : nullptr;
             }
 
-            Status status = _decode_min_max_column(*column_meta, column_order, &(*min_chunk)->columns()[i],
-                                                   &(*max_chunk)->columns()[i]);
+            Status status = _decode_min_max_column(*field, _param.timezone, slot->type(), *column_meta, column_order,
+                                                   &(*min_chunk)->columns()[i], &(*max_chunk)->columns()[i]);
             if (!status.ok()) {
                 *exist = false;
                 return Status::OK();
@@ -274,7 +272,8 @@ int FileReader::_get_partition_column_idx(const std::string& col_name) const {
     return -1;
 }
 
-Status FileReader::_decode_min_max_column(const tparquet::ColumnMetaData& column_meta,
+Status FileReader::_decode_min_max_column(const ParquetField& field, const std::string& timezone,
+                                          const TypeDescriptor& type, const tparquet::ColumnMetaData& column_meta,
                                           const tparquet::ColumnOrder* column_order, vectorized::ColumnPtr* min_column,
                                           vectorized::ColumnPtr* max_column) {
     if (!_can_use_min_max_stats(column_meta, column_order)) {
@@ -292,8 +291,21 @@ Status FileReader::_decode_min_max_column(const tparquet::ColumnMetaData& column
             RETURN_IF_ERROR(PlainDecoder<int32_t>::decode(column_meta.statistics.min, &min_value));
             RETURN_IF_ERROR(PlainDecoder<int32_t>::decode(column_meta.statistics.max, &max_value));
         }
-        (*min_column)->append_numbers(&min_value, sizeof(int32_t));
-        (*max_column)->append_numbers(&max_value, sizeof(int32_t));
+        std::unique_ptr<ColumnConverter> converter;
+        ColumnConverterFactory::create_converter(field, type, timezone, &converter);
+
+        if (!converter->need_convert) {
+            (*min_column)->append_numbers(&min_value, sizeof(int32_t));
+            (*max_column)->append_numbers(&max_value, sizeof(int32_t));
+        } else {
+            vectorized::ColumnPtr min_scr_column = converter->create_src_column();
+            min_scr_column->append_numbers(&min_value, sizeof(int32_t));
+            converter->convert(min_scr_column, min_column->get());
+
+            vectorized::ColumnPtr max_scr_column = converter->create_src_column();
+            max_scr_column->append_numbers(&max_value, sizeof(int32_t));
+            converter->convert(max_scr_column, max_column->get());
+        }
         return Status::OK();
     }
     case tparquet::Type::type::INT64: {
@@ -306,8 +318,21 @@ Status FileReader::_decode_min_max_column(const tparquet::ColumnMetaData& column
             RETURN_IF_ERROR(PlainDecoder<int64_t>::decode(column_meta.statistics.max, &max_value));
             RETURN_IF_ERROR(PlainDecoder<int64_t>::decode(column_meta.statistics.min, &min_value));
         }
-        (*min_column)->append_numbers(&min_value, sizeof(int64_t));
-        (*max_column)->append_numbers(&max_value, sizeof(int64_t));
+        std::unique_ptr<ColumnConverter> converter;
+        ColumnConverterFactory::create_converter(field, type, timezone, &converter);
+
+        if (!converter->need_convert) {
+            (*min_column)->append_numbers(&min_value, sizeof(int64_t));
+            (*max_column)->append_numbers(&max_value, sizeof(int64_t));
+        } else {
+            vectorized::ColumnPtr min_scr_column = converter->create_src_column();
+            min_scr_column->append_numbers(&min_value, sizeof(int64_t));
+            converter->convert(min_scr_column, min_column->get());
+
+            vectorized::ColumnPtr max_scr_column = converter->create_src_column();
+            max_scr_column->append_numbers(&max_value, sizeof(int64_t));
+            converter->convert(max_scr_column, max_column->get());
+        }
         return Status::OK();
     }
     case tparquet::Type::type::BYTE_ARRAY: {
@@ -320,8 +345,21 @@ Status FileReader::_decode_min_max_column(const tparquet::ColumnMetaData& column
             RETURN_IF_ERROR(PlainDecoder<Slice>::decode(column_meta.statistics.min, &min_slice));
             RETURN_IF_ERROR(PlainDecoder<Slice>::decode(column_meta.statistics.max, &max_slice));
         }
-        (*min_column)->append_strings(std::vector<Slice>{min_slice});
-        (*max_column)->append_strings(std::vector<Slice>{max_slice});
+        std::unique_ptr<ColumnConverter> converter;
+        ColumnConverterFactory::create_converter(field, type, timezone, &converter);
+
+        if (!converter->need_convert) {
+            (*min_column)->append_strings(std::vector<Slice>{min_slice});
+            (*max_column)->append_strings(std::vector<Slice>{max_slice});
+        } else {
+            vectorized::ColumnPtr min_scr_column = converter->create_src_column();
+            min_scr_column->append_strings(std::vector<Slice>{min_slice});
+            converter->convert(min_scr_column, min_column->get());
+
+            vectorized::ColumnPtr max_scr_column = converter->create_src_column();
+            max_scr_column->append_strings(std::vector<Slice>{max_slice});
+            converter->convert(max_scr_column, max_column->get());
+        }
         return Status::OK();
     }
     default:

--- a/be/src/exec/parquet/file_reader.h
+++ b/be/src/exec/parquet/file_reader.h
@@ -94,7 +94,8 @@ private:
     static Status _check_magic(const uint8_t* file_magic);
 
     // decode min/max value from row group stats
-    static Status _decode_min_max_column(const tparquet::ColumnMetaData& column_meta,
+    static Status _decode_min_max_column(const ParquetField& field, const std::string& timezone,
+                                         const TypeDescriptor& type, const tparquet::ColumnMetaData& column_meta,
                                          const tparquet::ColumnOrder* column_order, vectorized::ColumnPtr* min_column,
                                          vectorized::ColumnPtr* max_column);
     static bool _can_use_min_max_stats(const tparquet::ColumnMetaData& column_meta,


### PR DESCRIPTION
co-woker: @DorianZheng 

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
Closes #4555 
Closes #4390 

## Problem Summary(Required) ：

Currently proper convert and transformation is missing for min-max value of complex type like date or datetime in parquet reader and it will cause wrong min-max filter to use to skip parquet's row group and finally return the totally incorrect query results.

This PR extract converter from column reader and reuse it in min-max reader.

