### PR TITLE
Intersection selection generated by GRFs instead of the last GRF wins  in GRF exploration phase.

### DIFF
--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -163,6 +163,7 @@ Status ExecNode::init_join_runtime_filters(const TPlanNode& tnode, RuntimeState*
             register_runtime_filter_descriptor(state, rf_desc);
         }
     }
+    _runtime_filter_collector.set_plan_node_id(_id);
     if (state != nullptr && state->query_options().__isset.runtime_filter_wait_timeout_ms) {
         _runtime_filter_collector.set_wait_timeout_ms(state->query_options().runtime_filter_wait_timeout_ms);
     }

--- a/be/src/exprs/vectorized/runtime_filter_bank.cpp
+++ b/be/src/exprs/vectorized/runtime_filter_bank.cpp
@@ -230,7 +230,8 @@ RuntimeFilterProbeCollector::RuntimeFilterProbeCollector(RuntimeFilterProbeColle
         : _descriptors(std::move(that._descriptors)),
           _wait_timeout_ms(that._wait_timeout_ms),
           _scan_wait_timeout_ms(that._scan_wait_timeout_ms),
-          _eval_context(that._eval_context) {}
+          _eval_context(that._eval_context),
+          _plan_node_id(that._plan_node_id) {}
 
 Status RuntimeFilterProbeCollector::prepare(RuntimeState* state, const RowDescriptor& row_desc,
                                             RuntimeProfile* profile) {
@@ -263,21 +264,30 @@ void RuntimeFilterProbeCollector::do_evaluate(vectorized::Chunk* chunk, RuntimeB
         return;
     }
     if (!eval_context.selectivity.empty()) {
+        const auto num_rows = chunk->num_rows();
+        auto& selection = eval_context.running_context.selection;
+        selection.assign(num_rows, 1);
+        auto has_filtered = false;
         for (auto& kv : eval_context.selectivity) {
             RuntimeFilterProbeDescriptor* rf_desc = kv.second;
             const JoinRuntimeFilter* filter = rf_desc->runtime_filter();
-            if (filter == nullptr) continue;
+            if (filter == nullptr) {
+                continue;
+            }
             ColumnPtr column = rf_desc->probe_expr_ctx()->evaluate(chunk);
-            vectorized::Column::Filter& selection = filter->evaluate(column.get(), &eval_context.running_context);
+            auto true_count = filter->evaluate(column.get(), &eval_context.running_context);
+
             eval_context.run_filter_nums += 1;
-            size_t true_count = SIMD::count_nonzero(selection);
 
             if (true_count == 0) {
                 chunk->set_num_rows(0);
                 return;
-            } else {
-                chunk->filter(selection);
+            } else if (true_count < num_rows && !has_filtered) {
+                has_filtered = true;
             }
+        }
+        if (has_filtered) {
+            chunk->filter(selection);
         }
     }
 }
@@ -319,21 +329,23 @@ void RuntimeFilterProbeCollector::update_selectivity(vectorized::Chunk* chunk,
                                                      RuntimeBloomFilterEvalContext& eval_context) {
     eval_context.selectivity.clear();
     size_t chunk_size = chunk->num_rows();
-    vectorized::Column::Filter* selection = nullptr;
+    auto& selection = eval_context.running_context.selection;
+    selection.assign(chunk_size, 1);
     for (auto& it : _descriptors) {
         RuntimeFilterProbeDescriptor* rf_desc = it.second;
         const JoinRuntimeFilter* filter = rf_desc->runtime_filter();
-        if (filter == nullptr) continue;
+        if (filter == nullptr) {
+            continue;
+        }
         ColumnPtr column = rf_desc->probe_expr_ctx()->evaluate(chunk);
-        vectorized::Column::Filter& new_selection = filter->evaluate(column.get(), &eval_context.running_context);
+        auto true_count = filter->evaluate(column.get(), &eval_context.running_context);
         eval_context.run_filter_nums += 1;
-        size_t true_count = SIMD::count_nonzero(new_selection);
         double selectivity = true_count * 1.0 / chunk_size;
         if (selectivity <= 0.5) {     // useful filter
             if (selectivity < 0.05) { // very useful filter, could early return
                 eval_context.selectivity.clear();
                 eval_context.selectivity.emplace(selectivity, rf_desc);
-                chunk->filter(new_selection);
+                chunk->filter(selection);
                 return;
             }
 
@@ -348,21 +360,10 @@ void RuntimeFilterProbeCollector::update_selectivity(vectorized::Chunk* chunk,
                     eval_context.selectivity.emplace(selectivity, rf_desc);
                 }
             }
-
-            if (selection == nullptr) {
-                selection = &new_selection;
-            } else {
-                // Merge selection
-                uint8_t* dest = selection->data();
-                const uint8_t* src = new_selection.data();
-                for (size_t j = 0; j < chunk_size; ++j) {
-                    dest[j] = src[j] & dest[j];
-                }
-            }
         }
     }
     if (!eval_context.selectivity.empty()) {
-        chunk->filter(*selection);
+        chunk->filter(selection);
     }
 }
 

--- a/be/src/exprs/vectorized/runtime_filter_bank.h
+++ b/be/src/exprs/vectorized/runtime_filter_bank.h
@@ -175,6 +175,8 @@ public:
     std::string debug_string() const;
     bool empty() const { return _descriptors.empty(); }
     void init_counter();
+    void set_plan_node_id(int id) { _plan_node_id = id; }
+    int plan_node_id() { return _plan_node_id; }
 
 private:
     void update_selectivity(vectorized::Chunk* chunk);
@@ -187,6 +189,7 @@ private:
     long _scan_wait_timeout_ms = 0L;
     RuntimeProfile* _runtime_profile = nullptr;
     RuntimeBloomFilterEvalContext _eval_context;
+    int _plan_node_id = -1;
 };
 
 } // namespace vectorized

--- a/be/test/exprs/vectorized/runtime_filter_test.cpp
+++ b/be/test/exprs/vectorized/runtime_filter_test.cpp
@@ -104,8 +104,10 @@ TEST_F(RuntimeFilterTest, TestJoinRuntimeFilter) {
     Chunk chunk;
     chunk.append_column(column, 0);
     JoinRuntimeFilter::RunningContext ctx;
-    Column::Filter& filter = rf->evaluate(column.get(), &ctx);
-    chunk.filter(filter);
+    auto& selection = ctx.selection;
+    selection.assign(column->size(), 1);
+    rf->evaluate(column.get(), &ctx);
+    chunk.filter(selection);
     // 0 17 34 ... 187
     EXPECT_EQ(chunk.num_rows(), 12);
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When runtime-bloom filters are evaluated on chunks,  it works in a style of exploring 1 chunk and exploiting next 31 chunks.
In exploration phases, all filters are evaluated and selectivity are computed, only the filters of high selectivity are chosen to be applied to chunks in exploitation phases. selections generated by filters should be intersectioned,  but mistakenly, the last filter(that has largest filter id) overwrite the shared selection, if the last filter has a poor selectivity(a filter in tpcds q85 is just this case, selectivity >0.97), then the chunk is almostly not filtered.