### PR TITLE
[performance] optimize fixed-size multi distinct

### DIFF
--- a/be/src/exec/vectorized/aggregate/agg_hash_set.h
+++ b/be/src/exec/vectorized/aggregate/agg_hash_set.h
@@ -454,19 +454,16 @@ struct AggHashSetOfSerializedKeyFixedSize {
             key_column->serialize_batch(buffer, slice_sizes, chunk_size, max_fixed_size);
         }
 
-        FixedSizeSliceKey key;
+        FixedSizeSliceKey* key = reinterpret_cast<FixedSizeSliceKey*>(buffer);
 
-        if (!has_null_column) {
+        if (has_null_column) {
             for (size_t i = 0; i < chunk_size; ++i) {
-                memcpy(key.u.data, buffer + i * max_fixed_size, max_fixed_size);
-                hash_set.insert(key);
+                key[i].u.size = slice_sizes[i];
             }
-        } else {
-            for (size_t i = 0; i < chunk_size; ++i) {
-                memcpy(key.u.data, buffer + i * max_fixed_size, max_fixed_size);
-                key.u.size = slice_sizes[i];
-                hash_set.insert(key);
-            }
+        }
+
+        for (size_t i = 0; i < chunk_size; ++i) {
+            hash_set.insert(key[i]);
         }
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
similar to  #4935

## Problem Summary(Required) ：
avoid touching `slice_sizes` when insert key into hash_set.

SQL case: SSB100G parallel=1 BE: 3
```sql
select lo_quantity,lo_shippriority from lineorder_nullable group by lo_quantity,lo_shippriority;
```

baseline:4.59 sec
Diff: 1.75 sec


benchmark was avaliable: https://github.com/stdpain/starrocks-2/commit/c902a282d4fe3d885b3c4cc8a91974b59085c837
```
------------------------------------------------------------------------
Benchmark                              Time             CPU   Iterations
------------------------------------------------------------------------
BM_agg_hash_set_8                  42904 ns        42865 ns        16848
BM_agg_hash_origin_set_8          136853 ns       136781 ns         4947
BM_agg_hash_set_64                 44668 ns        44595 ns        15862
BM_agg_hash_origin_set_64         157554 ns       157403 ns         4447
BM_agg_hash_set_1024              158803 ns       158673 ns         3240
BM_agg_hash_origin_set_1024       752650 ns       752560 ns         1134
BM_agg_hash_set_4096              546890 ns       546840 ns         1672
BM_agg_hash_origin_set_4096      1085465 ns      1085368 ns         1096
BM_agg_hash_set_8192              531341 ns       531028 ns         1000
BM_agg_hash_origin_set_8192      1077784 ns      1077732 ns         1220
BM_agg_hash_set_16335             710684 ns       710390 ns         1000
BM_agg_hash_origin_set_16335     1266468 ns      1266367 ns         1134
BM_agg_hash_set_65535             670643 ns       670583 ns         1000
BM_agg_hash_origin_set_65535     1356195 ns      1356047 ns         1059
BM_agg_hash_set_655350            578886 ns       578856 ns         1000
BM_agg_hash_origin_set_655350    1198837 ns      1198760 ns         1151
```