### PR TITLE
Add support for the `enable_persistent_index` modification

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -52,6 +52,7 @@
 #include "storage/task/engine_clone_task.h"
 #include "storage/task/engine_publish_version_task.h"
 #include "storage/task/engine_storage_migration_task.h"
+#include "storage/update_manager.h"
 #include "storage/utils.h"
 #include "util/file_utils.h"
 #include "util/monotime.h"
@@ -1023,6 +1024,18 @@ void* TaskWorkerPool::_update_tablet_meta_worker_thread_callback(void* arg_this)
                     break;
                 case TTabletMetaType::INMEMORY:
                     // This property is no longer supported.
+                    break;
+                case TTabletMetaType::ENABLEPERSISTENTINDEX:
+                    VLOG(1) << "update tablet:" << tablet->tablet_id()
+                            << " enable_persistent_index:" << tablet_meta_info.enable_persistent_index;
+                    tablet->set_enable_persistent_index(tablet_meta_info.enable_persistent_index);
+                    // TODO
+                    // If tablet is doing apply rowset right now, remove primary index from index cache may be failed
+                    // So even though `enable_persistent_index` change successfully, it may not take effect immediately
+                    // because the primary index is available in cache
+                    // This is acceptable so far. If you want to take effect immediately, you could restart be
+                    auto manager = StorageEngine::instance()->update_manager();
+                    manager->index_cache().remove_by_key(tablet->tablet_id());
                     break;
                 }
             }

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -1026,7 +1026,7 @@ void* TaskWorkerPool::_update_tablet_meta_worker_thread_callback(void* arg_this)
                     // This property is no longer supported.
                     break;
                 case TTabletMetaType::ENABLEPERSISTENTINDEX:
-                    VLOG(1) << "update tablet:" << tablet->tablet_id()
+                    LOG(INFO) << "update tablet:" << tablet->tablet_id()
                             << " enable_persistent_index:" << tablet_meta_info.enable_persistent_index;
                     tablet->set_enable_persistent_index(tablet_meta_info.enable_persistent_index);
                     // TODO

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -1027,7 +1027,7 @@ void* TaskWorkerPool::_update_tablet_meta_worker_thread_callback(void* arg_this)
                     break;
                 case TTabletMetaType::ENABLEPERSISTENTINDEX:
                     LOG(INFO) << "update tablet:" << tablet->tablet_id()
-                            << " enable_persistent_index:" << tablet_meta_info.enable_persistent_index;
+                              << " enable_persistent_index:" << tablet_meta_info.enable_persistent_index;
                     tablet->set_enable_persistent_index(tablet_meta_info.enable_persistent_index);
                     // TODO
                     // If tablet is doing apply rowset right now, remove primary index from index cache may be failed

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -1025,15 +1025,13 @@ void* TaskWorkerPool::_update_tablet_meta_worker_thread_callback(void* arg_this)
                 case TTabletMetaType::INMEMORY:
                     // This property is no longer supported.
                     break;
-                case TTabletMetaType::ENABLEPERSISTENTINDEX:
+                case TTabletMetaType::ENABLE_PERSISTENT_INDEX:
                     LOG(INFO) << "update tablet:" << tablet->tablet_id()
                               << " enable_persistent_index:" << tablet_meta_info.enable_persistent_index;
                     tablet->set_enable_persistent_index(tablet_meta_info.enable_persistent_index);
-                    // TODO
                     // If tablet is doing apply rowset right now, remove primary index from index cache may be failed
-                    // So even though `enable_persistent_index` change successfully, it may not take effect immediately
                     // because the primary index is available in cache
-                    // This is acceptable so far. If you want to take effect immediately, you could restart be
+                    // But it will be remove from index cache after apply is finished
                     auto manager = StorageEngine::instance()->update_manager();
                     manager->index_cache().remove_by_key(tablet->tablet_id());
                     break;

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -1065,6 +1065,7 @@ void Tablet::build_tablet_report_info(TTabletInfo* tablet_info) {
     tablet_info->__set_storage_medium(_data_dir->storage_medium());
     tablet_info->__set_path_hash(_data_dir->path_hash());
     tablet_info->__set_is_in_memory(_tablet_meta->tablet_schema().is_in_memory());
+    tablet_info->__set_enable_persistent_index(_tablet_meta->get_enable_persistent_index());
     if (_updates) {
         _updates->get_tablet_info_extra(tablet_info);
     } else {

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -722,6 +722,7 @@ void TabletUpdates::_apply_rowset_commit(const EditVersionInfo& version_info) {
 
     std::lock_guard lg(_index_lock);
     // 2. load index
+    bool enable_persistent_index = _tablet.get_enable_persistent_index();
     auto index_entry = manager->index_cache().get_or_create(tablet_id);
     index_entry->update_expire_time(MonotonicMillis() + manager->get_cache_expire_ms());
     auto& index = index_entry->value();
@@ -791,8 +792,6 @@ void TabletUpdates::_apply_rowset_commit(const EditVersionInfo& version_info) {
     // release resource
     // update state only used once, so delete it
     manager->update_state_cache().remove(state_entry);
-    // index may be used for later commits, so keep in cache
-    manager->index_cache().release(index_entry);
     int64_t t_index = MonotonicMillis();
 
     size_t ndelvec = new_deletes.size();
@@ -908,6 +907,15 @@ void TabletUpdates::_apply_rowset_commit(const EditVersionInfo& version_info) {
         LOG(ERROR) << msg;
         _set_error(msg);
         return;
+    }
+
+    // if `enable_persistent_index` of tablet is change(maybe changed by alter table)
+    // we should try to remove the index_entry from cache
+    // Otherwise index may be used for later commits, keep in cache
+    if (enable_persistent_index ^ _tablet.get_enable_persistent_index()) {
+        manager->index_cache().remove(index_entry);
+    } else {
+        manager->index_cache().release(index_entry);
     }
     _update_total_stats(version_info.rowsets);
     int64_t t_write = MonotonicMillis();
@@ -1178,6 +1186,7 @@ void TabletUpdates::_apply_compaction_commit(const EditVersionInfo& version_info
     LOG(INFO) << "apply_compaction_commit start tablet:" << tablet_id << " version:" << version_info.version.to_string()
               << " rowset:" << rowset_id;
     // 1. load index
+    bool enable_persistent_index = _tablet.get_enable_persistent_index();
     auto index_entry = manager->index_cache().get_or_create(tablet_id);
     index_entry->update_expire_time(MonotonicMillis() + manager->get_cache_expire_ms());
     auto& index = index_entry->value();
@@ -1228,8 +1237,6 @@ void TabletUpdates::_apply_compaction_commit(const EditVersionInfo& version_info
     }
     // release memory
     _compaction_state.reset();
-    // index may be used for later commits, so keep in cache
-    manager->index_cache().release(index_entry);
     int64_t t_index_delvec = MonotonicMillis();
 
     PersistentIndexMetaPB index_meta;
@@ -1280,6 +1287,15 @@ void TabletUpdates::_apply_compaction_commit(const EditVersionInfo& version_info
         LOG(ERROR) << msg;
         _set_error(msg);
         return;
+    }
+
+    // if `enable_persistent_index` of tablet is change(maybe changed by alter table)
+    // we should try to remove the index_entry from cache
+    // Otherwise index may be used for later commits, keep in cache
+    if (enable_persistent_index ^ _tablet.get_enable_persistent_index()) {
+        manager->index_cache().remove(index_entry);
+    } else {
+        manager->index_cache().release(index_entry);
     }
 
     {
@@ -2613,6 +2629,7 @@ Status TabletUpdates::prepare_partial_update_states(Tablet* tablet, const std::v
     auto manager = StorageEngine::instance()->update_manager();
     auto index_entry = manager->index_cache().get_or_create(tablet->tablet_id());
     index_entry->update_expire_time(MonotonicMillis() + manager->get_cache_expire_ms());
+    bool enable_persistent_index = tablet->get_enable_persistent_index();
     auto& index = index_entry->value();
     auto st = index.load(tablet);
     manager->index_cache().update_object_size(index_entry, index.memory_usage());
@@ -2631,9 +2648,15 @@ Status TabletUpdates::prepare_partial_update_states(Tablet* tablet, const std::v
         auto& pks = *upserts[i];
         index.get(pks, (*rss_rowids)[i]);
     }
-    // index may be used for later commits, keep in cache
-    manager->index_cache().release(index_entry);
 
+    // if `enable_persistent_index` of tablet is change(maybe changed by alter table)
+    // we should try to remove the index_entry from cache
+    // Otherwise index may be used for later commits, keep in cache
+    if (enable_persistent_index ^ tablet->get_enable_persistent_index()) {
+        manager->index_cache().remove(index_entry);
+    } else {
+        manager->index_cache().release(index_entry);
+    }
     return Status::OK();
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/Alter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/Alter.java
@@ -68,6 +68,7 @@ import com.starrocks.persist.BatchModifyPartitionsInfo;
 import com.starrocks.persist.ModifyPartitionInfo;
 import com.starrocks.persist.SwapTableOperationLog;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.thrift.TTabletMetaType;
 import com.starrocks.thrift.TTabletType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -306,9 +307,16 @@ public class Alter {
                 }
             } else if (alterClause instanceof ModifyTablePropertiesClause) {
                 Map<String, String> properties = alterClause.getProperties();
-                // currently, only in memory property could reach here
-                Preconditions.checkState(properties.containsKey(PropertyAnalyzer.PROPERTIES_INMEMORY));
-                ((SchemaChangeHandler) schemaChangeHandler).updateTableInMemoryMeta(db, tableName, properties);
+                // currently, only in memory property and enable persistent index property could reach here
+                Preconditions.checkState(properties.containsKey(PropertyAnalyzer.PROPERTIES_INMEMORY) || 
+                                         properties.containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX));
+                if (properties.containsKey(PropertyAnalyzer.PROPERTIES_INMEMORY)) {
+                    ((SchemaChangeHandler) schemaChangeHandler).updateTableMeta(db, tableName, 
+                                                                                properties, TTabletMetaType.INMEMORY);
+                } else {
+                    ((SchemaChangeHandler) schemaChangeHandler).updateTableMeta(db, tableName, properties, 
+                                                                                TTabletMetaType.ENABLEPERSISTENTINDEX);
+                }
             } else {
                 throw new DdlException("Invalid alter opertion: " + alterClause.getOpType());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/Alter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/Alter.java
@@ -315,7 +315,7 @@ public class Alter {
                                                                                 properties, TTabletMetaType.INMEMORY);
                 } else {
                     ((SchemaChangeHandler) schemaChangeHandler).updateTableMeta(db, tableName, properties, 
-                                                                                TTabletMetaType.ENABLEPERSISTENTINDEX);
+                                                                                TTabletMetaType.ENABLE_PERSISTENT_INDEX);
                 }
             } else {
                 throw new DdlException("Invalid alter opertion: " + alterClause.getOpType());

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -1608,7 +1608,7 @@ public class SchemaChangeHandler extends AlterHandler {
             if (metaValue == olapTable.isInMemory()) {
                 return;
             }
-        } else if (metaType == TTabletMetaType.ENABLEPERSISTENTINDEX) {
+        } else if (metaType == TTabletMetaType.ENABLE_PERSISTENT_INDEX) {
             metaValue = Boolean.parseBoolean(properties.get(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX));
             if (metaValue == olapTable.enablePersistentIndex()) {
                 return;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -91,6 +91,7 @@ import com.starrocks.task.ClearAlterTask;
 import com.starrocks.task.UpdateTabletMetaInfoTask;
 import com.starrocks.thrift.TStorageFormat;
 import com.starrocks.thrift.TStorageMedium;
+import com.starrocks.thrift.TTabletMetaType;
 import com.starrocks.thrift.TTaskType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -1588,10 +1589,8 @@ public class SchemaChangeHandler extends AlterHandler {
         LOG.info("send clear alter task for table {}, number: {}", olapTable.getName(), batchTask.getTaskNum());
     }
 
-    /**
-     * Update all partitions' in-memory property of table
-     */
-    public void updateTableInMemoryMeta(Database db, String tableName, Map<String, String> properties)
+    public void updateTableMeta(Database db, String tableName, Map<String, String> properties,
+                                TTabletMetaType metaType)
             throws DdlException {
         List<Partition> partitions = Lists.newArrayList();
         OlapTable olapTable;
@@ -1603,18 +1602,29 @@ public class SchemaChangeHandler extends AlterHandler {
             db.readUnlock();
         }
 
-        boolean isInMemory = Boolean.parseBoolean(properties.get(PropertyAnalyzer.PROPERTIES_INMEMORY));
-        if (isInMemory == olapTable.isInMemory()) {
+        boolean metaValue = false;
+        if (metaType == TTabletMetaType.INMEMORY) {
+            metaValue = Boolean.parseBoolean(properties.get(PropertyAnalyzer.PROPERTIES_INMEMORY));
+            if (metaValue == olapTable.isInMemory()) {
+                return;
+            }
+        } else if (metaType == TTabletMetaType.ENABLEPERSISTENTINDEX) {
+            metaValue = Boolean.parseBoolean(properties.get(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX));
+            if (metaValue == olapTable.enablePersistentIndex()) {
+                return;
+            }
+        } else {
+            LOG.warn("meta type: {} does not support", metaType);
             return;
         }
 
         for (Partition partition : partitions) {
-            updatePartitionInMemoryMeta(db, olapTable.getName(), partition.getName(), isInMemory);
+            updatePartitionTabletMeta(db, olapTable.getName(), partition.getName(), metaValue, metaType);
         }
 
         db.writeLock();
         try {
-            Catalog.getCurrentCatalog().modifyTableInMemoryMeta(db, olapTable, properties);
+            Catalog.getCurrentCatalog().modifyTableMeta(db, olapTable, properties, metaType);
         } finally {
             db.writeUnlock();
         }
@@ -1649,7 +1659,8 @@ public class SchemaChangeHandler extends AlterHandler {
 
         for (String partitionName : partitionNames) {
             try {
-                updatePartitionInMemoryMeta(db, olapTable.getName(), partitionName, isInMemory);
+                //updatePartitionInMemoryMeta(db, olapTable.getName(), partitionName, isInMemory);
+                updatePartitionTabletMeta(db, olapTable.getName(), partitionName, isInMemory, TTabletMetaType.INMEMORY);
             } catch (Exception e) {
                 String errMsg = "Failed to update partition[" + partitionName + "]'s 'in_memory' property. " +
                         "The reason is [" + e.getMessage() + "]";
@@ -1662,10 +1673,11 @@ public class SchemaChangeHandler extends AlterHandler {
      * Update one specified partition's in-memory property by partition name of table
      * This operation may return partial successfully, with a exception to inform user to retry
      */
-    public void updatePartitionInMemoryMeta(Database db,
-                                            String tableName,
-                                            String partitionName,
-                                            boolean isInMemory) throws DdlException {
+    public void updatePartitionTabletMeta(Database db,
+                                          String tableName,
+                                          String partitionName,
+                                          boolean metaValue,
+                                          TTabletMetaType metaType) throws DdlException {
         // be id -> <tablet id,schemaHash>
         Map<Long, Set<Pair<Long, Integer>>> beIdToTabletIdWithHash = Maps.newHashMap();
         db.readLock();
@@ -1697,7 +1709,7 @@ public class SchemaChangeHandler extends AlterHandler {
         for (Map.Entry<Long, Set<Pair<Long, Integer>>> kv : beIdToTabletIdWithHash.entrySet()) {
             countDownLatch.addMark(kv.getKey(), kv.getValue());
             UpdateTabletMetaInfoTask task = new UpdateTabletMetaInfoTask(kv.getKey(), kv.getValue(),
-                    isInMemory, countDownLatch);
+                    metaValue, countDownLatch, metaType);
             batchTask.addTask(task);
         }
         if (!FeConstants.runningUnitTest) {

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/ModifyTablePropertiesClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/ModifyTablePropertiesClause.java
@@ -86,6 +86,14 @@ public class ModifyTablePropertiesClause extends AlterTableClause {
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_INMEMORY)) {
             this.needTableStable = false;
             this.opType = AlterOpType.MODIFY_TABLE_PROPERTY_SYNC;
+        } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX)) {
+            if (!properties.get(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX).equalsIgnoreCase("true") &&
+                !properties.get(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX).equalsIgnoreCase("false")) {
+                throw new AnalysisException(
+                        "Property " + PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX + " must be bool type(false/true)");
+            }
+            this.needTableStable = false;
+            this.opType = AlterOpType.MODIFY_TABLE_PROPERTY_SYNC;
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_TABLET_TYPE)) {
             throw new AnalysisException("Alter tablet type not supported");
         } else {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -6255,7 +6255,7 @@ public class Catalog {
     public void modifyTableMeta(Database db, OlapTable table, Map<String, String> properties, TTabletMetaType metaType) {
         if (metaType == TTabletMetaType.INMEMORY) {
             modifyTableInMemoryMeta(db, table, properties);
-        } else if (metaType == TTabletMetaType.ENABLEPERSISTENTINDEX) {
+        } else if (metaType == TTabletMetaType.ENABLE_PERSISTENT_INDEX) {
             modifyTableEnablePersistentIndexMeta(db, table, properties);
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -6223,16 +6223,10 @@ public class Catalog {
             tableProperty.modifyTableProperties(properties);
         }
         tableProperty.buildEnablePersistentIndex();
-        /*
-        // need to update partition info meta
-        for (Partition partition : table.getPartitions()) {
-            table.getPartitionInfo().setIsInMemory(partition.getId(), tableProperty.isInMemory());
-        }
-        */
 
         ModifyTablePropertyOperationLog info =
                 new ModifyTablePropertyOperationLog(db.getId(), table.getId(), properties);
-        editLog.logModifyInMemory(info);
+        editLog.logModifyEnablePersistentIndex(info);
 
     }
 
@@ -6337,8 +6331,7 @@ public class Catalog {
                         }
                     }
                 } else if (opCode == OperationType.OP_MODIFY_ENABLE_PERSISTENT_INDEX) {
-                    // TODO
-                    // set partition info 
+                    olapTable.setEnablePersistentIndex(tableProperty.enablePersistentIndex());
                 }
             }
         } finally {

--- a/fe/fe-core/src/main/java/com/starrocks/master/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/master/ReportHandler.java
@@ -44,6 +44,7 @@ import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
 import com.starrocks.clone.TabletSchedCtx;
 import com.starrocks.common.Config;
+import com.starrocks.common.FeConstants;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.Daemon;
@@ -974,6 +975,10 @@ public class ReportHandler extends Daemon {
         }
     }
 
+    public static void testHandleSetTabletEnablePersistentIndex(long backendId, Map<Long, TTablet> backendTablets) {
+        handleSetTabletEnablePersistentIndex(backendId, backendTablets);
+    }
+
     private static void handleSetTabletEnablePersistentIndex(long backendId, Map<Long, TTablet> backendTablets) {
         List<Triple<Long, Integer, Boolean>> tabletToEnablePersistentIndex = Lists.newArrayList();
 
@@ -1016,7 +1021,9 @@ public class ReportHandler extends Daemon {
             UpdateTabletMetaInfoTask task = new UpdateTabletMetaInfoTask(backendId, tabletToEnablePersistentIndex,
                                                                          TTabletMetaType.ENABLEPERSISTENTINDEX);
             batchTask.addTask(task);
-            AgentTaskExecutor.submit(batchTask);
+            if (FeConstants.runningUnitTest) {
+                AgentTaskExecutor.submit(batchTask);
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/master/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/master/ReportHandler.java
@@ -1019,7 +1019,7 @@ public class ReportHandler extends Daemon {
         if (!tabletToEnablePersistentIndex.isEmpty()) {
             AgentBatchTask batchTask = new AgentBatchTask();
             UpdateTabletMetaInfoTask task = new UpdateTabletMetaInfoTask(backendId, tabletToEnablePersistentIndex,
-                                                                         TTabletMetaType.ENABLEPERSISTENTINDEX);
+                                                                         TTabletMetaType.ENABLE_PERSISTENT_INDEX);
             batchTask.addTask(task);
             if (FeConstants.runningUnitTest) {
                 AgentTaskExecutor.submit(batchTask);

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -737,7 +737,8 @@ public class EditLog {
                 case OperationType.OP_DYNAMIC_PARTITION:
                 case OperationType.OP_MODIFY_IN_MEMORY:
                 case OperationType.OP_SET_FORBIT_GLOBAL_DICT:
-                case OperationType.OP_MODIFY_REPLICATION_NUM: {
+                case OperationType.OP_MODIFY_REPLICATION_NUM: 
+                case OperationType.OP_MODIFY_ENABLE_PERSISTENT_INDEX: {
                     ModifyTablePropertyOperationLog modifyTablePropertyOperationLog =
                             (ModifyTablePropertyOperationLog) journal.getData();
                     catalog.replayModifyTableProperty(opCode, modifyTablePropertyOperationLog);
@@ -1331,6 +1332,10 @@ public class EditLog {
 
     public void logModifyInMemory(ModifyTablePropertyOperationLog info) {
         logEdit(OperationType.OP_MODIFY_IN_MEMORY, info);
+    }
+
+    public void logModifyEnablePersistentIndex(ModifyTablePropertyOperationLog info) {
+        logEdit(OperationType.OP_MODIFY_ENABLE_PERSISTENT_INDEX, info);
     }
 
     public void logReplaceTempPartition(ReplacePartitionOperationLog info) {

--- a/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
@@ -195,6 +195,7 @@ public class OperationType {
     public static final short OP_ADD_PARTITIONS = 10002;
     public static final short OP_FINISH_MULTI_DELETE = 10003;
     public static final short OP_ERASE_MULTI_TABLES = 10004;
+    public static final short OP_MODIFY_ENABLE_PERSISTENT_INDEX = 10005;
 
     // statistic 10010 ~ 10020
     public static final short OP_ADD_ANALYZER_JOB = 10010;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -605,6 +605,7 @@ public class StmtExecutor {
             Preconditions.checkState(false, "Shouldn't reach here");
         } else {
             try {
+                LOG.info("try analyze xxxx");
                 parsedStmt.analyze(new Analyzer(context.getCatalog(), context));
             } catch (AnalysisException e) {
                 throw e;

--- a/fe/fe-core/src/main/java/com/starrocks/task/AgentBatchTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/AgentBatchTask.java
@@ -346,7 +346,6 @@ public class AgentBatchTask implements Runnable {
                 return tAgentTaskRequest;
             }
             case UPDATE_TABLET_META_INFO: {
-                LOG.info("build update tablet meta request");
                 UpdateTabletMetaInfoTask updateTabletMetaInfoTask = (UpdateTabletMetaInfoTask) task;
                 TUpdateTabletMetaInfoReq request = updateTabletMetaInfoTask.toThrift();
                 if (LOG.isDebugEnabled()) {

--- a/fe/fe-core/src/main/java/com/starrocks/task/AgentBatchTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/AgentBatchTask.java
@@ -346,6 +346,7 @@ public class AgentBatchTask implements Runnable {
                 return tAgentTaskRequest;
             }
             case UPDATE_TABLET_META_INFO: {
+                LOG.info("build update tablet meta request");
                 UpdateTabletMetaInfoTask updateTabletMetaInfoTask = (UpdateTabletMetaInfoTask) task;
                 TUpdateTabletMetaInfoReq request = updateTabletMetaInfoTask.toThrift();
                 if (LOG.isDebugEnabled()) {

--- a/fe/fe-core/src/main/java/com/starrocks/task/UpdateTabletMetaInfoTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/UpdateTabletMetaInfoTask.java
@@ -108,7 +108,6 @@ public class UpdateTabletMetaInfoTask extends AgentTask {
     }
 
     public TUpdateTabletMetaInfoReq toThrift() {
-        LOG.info("do update tablet meta task");
         TUpdateTabletMetaInfoReq updateTabletMetaInfoReq = new TUpdateTabletMetaInfoReq();
         List<TTabletMetaInfo> metaInfos = Lists.newArrayList();
         switch (metaType) {

--- a/fe/fe-core/src/main/java/com/starrocks/task/UpdateTabletMetaInfoTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/UpdateTabletMetaInfoTask.java
@@ -71,7 +71,7 @@ public class UpdateTabletMetaInfoTask extends AgentTask {
         this(backendId, tableIdWithSchemaHash, metaType);
         if (metaType == TTabletMetaType.INMEMORY) {
             this.isInMemory = metaValue;
-        } else if (metaType == TTabletMetaType.ENABLEPERSISTENTINDEX) {
+        } else if (metaType == TTabletMetaType.ENABLE_PERSISTENT_INDEX) {
             this.enablePersistentIndex = metaValue;
         }
         this.latch = latch;
@@ -158,7 +158,7 @@ public class UpdateTabletMetaInfoTask extends AgentTask {
                 }
                 break;
             }
-            case ENABLEPERSISTENTINDEX: {
+            case ENABLE_PERSISTENT_INDEX: {
                 if (latch != null) {
                     // for schema change
                     for (Pair<Long, Integer> pair : tableIdWithSchemaHash) {

--- a/fe/fe-core/src/test/java/com/starrocks/master/ReportHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/master/ReportHandlerTest.java
@@ -1,0 +1,71 @@
+// This file is made available under Elastic License 2.0.
+
+package com.starrocks.master;
+
+
+import com.starrocks.catalog.Catalog;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Database;
+import com.google.common.collect.Lists;
+import com.starrocks.common.FeConstants;
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.master.ReportHandler;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.thrift.TTablet;
+import com.starrocks.thrift.TTabletInfo;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Map;
+import java.util.HashMap;
+import java.util.List;
+import java.util.UUID;
+
+public class ReportHandlerTest {
+    private static ConnectContext connectContext;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        FeConstants.default_scheduler_interval_millisecond = 1000;
+        FeConstants.runningUnitTest = true;
+
+        UtFrameUtils.createMinStarRocksCluster();
+
+        // create connect context
+        connectContext = UtFrameUtils.createDefaultCtx();
+        connectContext.setQueryId(UUIDUtil.genUUID());
+        StarRocksAssert starRocksAssert = new StarRocksAssert(connectContext);
+
+        starRocksAssert.withDatabase("test").useDatabase("test")
+                .withTable(
+                        "CREATE TABLE test.properties_change_test(k1 int, v1 int) primary key(k1) distributed by hash(k1) properties('replication_num' = '1');");
+    }
+
+    @Test
+    public void testHandleSetTabletEnablePersistentIndex() {
+        Database db = Catalog.getCurrentCatalog().getDb("default_cluster:test");
+        long dbId = db.getId();
+        long backendId = 10001L;
+        List<Long> tabletIds = Catalog.getCurrentInvertedIndex().getTabletIdsByBackendId(10001);
+        Assert.assertFalse(tabletIds.isEmpty());
+
+        Map<Long, TTablet> backendTablets = new HashMap<Long, TTablet>();
+        List<TTabletInfo> tabletInfos = Lists.newArrayList();
+        TTablet tablet = new TTablet(tabletInfos);
+        for (Long tabletId : tabletIds) {
+            TTabletInfo tabletInfo = new TTabletInfo();
+            tabletInfo.setTablet_id(tabletId);
+            tabletInfo.setSchema_hash(60000);
+            tabletInfo.setEnable_persistent_index(true);
+            tablet.tablet_infos.add(tabletInfo);
+        }
+        backendTablets.put(backendId, tablet);
+
+        ReportHandler handler = new ReportHandler();
+        handler.testHandleSetTabletEnablePersistentIndex(backendId, backendTablets);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/task/AgentTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/task/AgentTaskTest.java
@@ -159,7 +159,7 @@ public class AgentTaskTest {
         tabletToMeta.add(new ImmutableTriple<>(tabletId1, schemaHash1, true));
         tabletToMeta.add(new ImmutableTriple<>(tabletId2, schemaHash2, false));
         modifyEnablePersistentIndexTask1 = 
-                new UpdateTabletMetaInfoTask(backendId1, tabletToMeta, TTabletMetaType.ENABLEPERSISTENTINDEX);
+                new UpdateTabletMetaInfoTask(backendId1, tabletToMeta, TTabletMetaType.ENABLE_PERSISTENT_INDEX);
         
         // for schema change
         MarkedCountDownLatch<Long, Set<Pair<Long, Integer>>> countDownLatch = new MarkedCountDownLatch<>(1);
@@ -168,7 +168,7 @@ public class AgentTaskTest {
         countDownLatch.addMark(backendId1, tabletIdWithSchemaHash);
         modifyEnablePersistentIndexTask2 = 
                 new UpdateTabletMetaInfoTask(backendId1, tabletIdWithSchemaHash, true, 
-                                             countDownLatch, TTabletMetaType.ENABLEPERSISTENTINDEX);
+                                             countDownLatch, TTabletMetaType.ENABLE_PERSISTENT_INDEX);
         modifyInMemoryTask = 
                 new UpdateTabletMetaInfoTask(backendId1, tabletToMeta, TTabletMetaType.INMEMORY);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/task/AgentTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/task/AgentTaskTest.java
@@ -21,6 +21,7 @@
 
 package com.starrocks.task;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
 import com.starrocks.analysis.PartitionValue;
 import com.starrocks.catalog.AggregateType;
@@ -31,6 +32,7 @@ import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.MarkedCountDownLatch;
+import com.starrocks.common.Pair;
 import com.starrocks.thrift.TAgentTaskRequest;
 import com.starrocks.thrift.TBackend;
 import com.starrocks.thrift.TKeysType;
@@ -38,8 +40,11 @@ import com.starrocks.thrift.TPriority;
 import com.starrocks.thrift.TPushType;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TStorageType;
+import com.starrocks.thrift.TTabletMetaType;
 import com.starrocks.thrift.TTabletType;
 import com.starrocks.thrift.TTaskType;
+import org.apache.commons.lang3.tuple.ImmutableTriple;
+import org.apache.commons.lang3.tuple.Triple;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -91,6 +96,9 @@ public class AgentTaskTest {
     private AgentTask rollupTask;
     private AgentTask schemaChangeTask;
     private AgentTask cancelDeleteTask;
+    private AgentTask modifyEnablePersistentIndexTask1;
+    private AgentTask modifyEnablePersistentIndexTask2;
+    private AgentTask modifyInMemoryTask;
 
     @Before
     public void setUp() throws AnalysisException {
@@ -143,6 +151,26 @@ public class AgentTaskTest {
                 new SchemaChangeTask(null, backendId1, dbId, tableId, partitionId, indexId1,
                         tabletId1, replicaId1, columns, schemaHash2, schemaHash1,
                         shortKeyNum, storageType, null, 0, TKeysType.AGG_KEYS);
+        
+        // modify tablet meta
+        // <tablet id, tablet schema hash, tablet in memory/ tablet enable persistent index>
+        // for report handle
+        List<Triple<Long, Integer, Boolean>> tabletToMeta = Lists.newArrayList();
+        tabletToMeta.add(new ImmutableTriple<>(tabletId1, schemaHash1, true));
+        tabletToMeta.add(new ImmutableTriple<>(tabletId2, schemaHash2, false));
+        modifyEnablePersistentIndexTask1 = 
+                new UpdateTabletMetaInfoTask(backendId1, tabletToMeta, TTabletMetaType.ENABLEPERSISTENTINDEX);
+        
+        // for schema change
+        MarkedCountDownLatch<Long, Set<Pair<Long, Integer>>> countDownLatch = new MarkedCountDownLatch<>(1);
+        Set<Pair<Long, Integer>> tabletIdWithSchemaHash = new HashSet();
+        tabletIdWithSchemaHash.add(Pair.create(tabletId1, schemaHash1));
+        countDownLatch.addMark(backendId1, tabletIdWithSchemaHash);
+        modifyEnablePersistentIndexTask2 = 
+                new UpdateTabletMetaInfoTask(backendId1, tabletIdWithSchemaHash, true, 
+                                             countDownLatch, TTabletMetaType.ENABLEPERSISTENTINDEX);
+        modifyInMemoryTask = 
+                new UpdateTabletMetaInfoTask(backendId1, tabletToMeta, TTabletMetaType.INMEMORY);
     }
 
     @Test
@@ -214,6 +242,23 @@ public class AgentTaskTest {
         Assert.assertEquals(TTaskType.SCHEMA_CHANGE, request6.getTask_type());
         Assert.assertEquals(schemaChangeTask.getSignature(), request6.getSignature());
         Assert.assertNotNull(request6.getAlter_tablet_req());
+
+        // modify enable_persistent_index
+        TAgentTaskRequest request7 = (TAgentTaskRequest) toAgentTaskRequest.invoke(agentBatchTask, modifyEnablePersistentIndexTask1);
+        Assert.assertEquals(TTaskType.UPDATE_TABLET_META_INFO, request7.getTask_type());
+        Assert.assertEquals(modifyEnablePersistentIndexTask1.getSignature(), request7.getSignature());
+        Assert.assertNotNull(request7.getUpdate_tablet_meta_info_req());
+
+        TAgentTaskRequest request8 = (TAgentTaskRequest) toAgentTaskRequest.invoke(agentBatchTask, modifyEnablePersistentIndexTask2);
+        Assert.assertEquals(TTaskType.UPDATE_TABLET_META_INFO, request8.getTask_type());
+        Assert.assertEquals(modifyEnablePersistentIndexTask2.getSignature(), request8.getSignature());
+        Assert.assertNotNull(request8.getUpdate_tablet_meta_info_req());
+
+        // modify in_memory
+        TAgentTaskRequest request9 = (TAgentTaskRequest) toAgentTaskRequest.invoke(agentBatchTask, modifyInMemoryTask);
+        Assert.assertEquals(TTaskType.UPDATE_TABLET_META_INFO, request9.getTask_type());
+        Assert.assertEquals(modifyInMemoryTask.getSignature(), request9.getSignature());
+        Assert.assertNotNull(request9.getUpdate_tablet_meta_info_req());
     }
 
     @Test

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -255,7 +255,7 @@ struct TRecoverTabletReq {
 enum TTabletMetaType {
     PARTITIONID,
     INMEMORY,
-    ENABLEPERSISTENTINDEX
+    ENABLE_PERSISTENT_INDEX
 }
 
 struct TTabletMetaInfo {

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -254,7 +254,8 @@ struct TRecoverTabletReq {
 
 enum TTabletMetaType {
     PARTITIONID,
-    INMEMORY
+    INMEMORY,
+    ENABLEPERSISTENTINDEX
 }
 
 struct TTabletMetaInfo {
@@ -263,6 +264,7 @@ struct TTabletMetaInfo {
     3: optional Types.TPartitionId partition_id
     4: optional TTabletMetaType meta_type
     5: optional bool is_in_memory
+    6: optional bool enable_persistent_index
 }
 
 struct TUpdateTabletMetaInfoReq {

--- a/gensrc/thrift/MasterService.thrift
+++ b/gensrc/thrift/MasterService.thrift
@@ -43,6 +43,7 @@ struct TTabletInfo {
     12: optional bool used
     13: optional Types.TPartitionId partition_id
     14: optional bool is_in_memory
+    15: optional bool enable_persistent_index
 }
 
 struct TFinishTaskRequest {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [x] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4984

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered, and what measures have you taken to fix the bug?) -->
We add `enable_persistent_index` in properties to decide whether to use the persistent index in the PrimaryKey tablet.

`enable_persistent_index` is specified when creating a table, and this pr adds support for the `enable_persistent_index` modification.

We can use `Alter table xxx set ("enable_persistent_index" = "false(true)")` to modify it.

For example, create a PrimaryKey table that disable the persistent index
```
mysql> show create table test_1;
+--------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Table  | Create Table                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+--------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| test_1 | CREATE TABLE `test_1` (
  `inv_date_sk` int(11) NOT NULL COMMENT "",
  `inv_item_sk` int(11) NOT NULL COMMENT "",
  `inv_warehouse_sk` int(11) NOT NULL COMMENT "",
  `inv_quantity_on_hand` int(11) NULL COMMENT ""
) ENGINE=OLAP
PRIMARY KEY(`inv_date_sk`)
COMMENT "OLAP"
DISTRIBUTED BY HASH(`inv_date_sk`) BUCKETS 192
PROPERTIES (
"replication_num" = "1",
"in_memory" = "false",
"storage_format" = "DEFAULT",
"enable_persistent_index" = "false"
); |
```
we can change `enable_persistent_index` by doing below
```
mysql> alter table test_1 set ("enable_persistent_index" = "true");
Query OK, 0 rows affected (0.01 sec)
```

and we will see as below:
```
mysql> show create table test_1;
+--------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Table  | Create Table                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+--------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| test_1 | CREATE TABLE `test_1` (
  `inv_date_sk` int(11) NOT NULL COMMENT "",
  `inv_item_sk` int(11) NOT NULL COMMENT "",
  `inv_warehouse_sk` int(11) NOT NULL COMMENT "",
  `inv_quantity_on_hand` int(11) NULL COMMENT ""
) ENGINE=OLAP
PRIMARY KEY(`inv_date_sk`)
COMMENT "OLAP"
DISTRIBUTED BY HASH(`inv_date_sk`) BUCKETS 192
PROPERTIES (
"replication_num" = "1",
"in_memory" = "false",
"storage_format" = "DEFAULT",
"enable_persistent_index" = "true"
); |
```