### PR TITLE
Fill up the chunk in JonsScanner to avoid the chunk with only one row

### DIFF
--- a/be/src/exec/vectorized/json_scanner.cpp
+++ b/be/src/exec/vectorized/json_scanner.cpp
@@ -359,61 +359,74 @@ Status JsonReader::close() {
  *      value2     30
  */
 Status JsonReader::read_chunk(Chunk* chunk, int32_t rows_to_read) {
-    if (_empty_parser) {
-        auto st = _read_and_parse_json();
-        if (!st.ok()) {
-            if (st.is_end_of_file()) {
+    int32_t rows_read = 0;
+    while (rows_read < rows_to_read) {
+        if (_empty_parser) {
+            auto st = _read_and_parse_json();
+            if (!st.ok()) {
+                if (st.is_end_of_file()) {
+                    // all data has been exhausted.
+                    return st;
+                }
+                // Parse error.
+                _counter->num_rows_filtered++;
+                _state->append_error_msg_to_file("", st.to_string());
                 return st;
             }
-            // Parse error.
-            _counter->num_rows_filtered++;
-            _state->append_error_msg_to_file("", st.to_string());
+            _empty_parser = false;
+        }
+
+        Status st;
+        // Eliminates virtual function call.
+        if (!_scanner->_root_paths.empty()) {
+            // With json root set, expand the outer array automatically.
+            // The strip_outer_array determines whether to expand the sub-array of json root.
+            if (_scanner->_strip_outer_array) {
+                // Expand outer array automatically according to _is_ndjson.
+                if (_is_ndjson) {
+                    st = _read_rows<ExpandedJsonDocumentStreamParserWithRoot>(chunk, rows_to_read, &rows_read);
+                } else {
+                    st = _read_rows<ExpandedJsonArrayParserWithRoot>(chunk, rows_to_read, &rows_read);
+                }
+            } else {
+                if (_is_ndjson) {
+                    st = _read_rows<JsonDocumentStreamParserWithRoot>(chunk, rows_to_read, &rows_read);
+                } else {
+                    st = _read_rows<JsonArrayParserWithRoot>(chunk, rows_to_read, &rows_read);
+                }
+            }
+        } else {
+            // Without json root set, the strip_outer_array determines whether to expand outer array.
+            if (_scanner->_strip_outer_array) {
+                st = _read_rows<JsonArrayParser>(chunk, rows_to_read, &rows_read);
+            } else {
+                st = _read_rows<JsonDocumentStreamParser>(chunk, rows_to_read, &rows_read);
+            }
+        }
+
+        if (st.is_end_of_file()) {
+            // the parser is exhausted.
+            _empty_parser = true;
+        } else if (!st.ok()) {
+            chunk->set_num_rows(rows_read);
             return st;
         }
     }
 
-    // Eliminates virtual function call.
-    if (!_scanner->_root_paths.empty()) {
-        // With json root set, expand the outer array automatically.
-        // The strip_outer_array determines whether to expand the sub-array of json root.
-        if (_scanner->_strip_outer_array) {
-            // Expand outer array automatically according to _is_ndjson.
-            if (_is_ndjson) {
-                return _read_chunk<ExpandedJsonDocumentStreamParserWithRoot>(chunk, rows_to_read);
-            } else {
-                return _read_chunk<ExpandedJsonArrayParserWithRoot>(chunk, rows_to_read);
-            }
-        } else {
-            if (_is_ndjson) {
-                return _read_chunk<JsonDocumentStreamParserWithRoot>(chunk, rows_to_read);
-            } else {
-                return _read_chunk<JsonArrayParserWithRoot>(chunk, rows_to_read);
-            }
-        }
-    } else {
-        // Without json root set, the strip_outer_array determines whether to expand outer array.
-        if (_scanner->_strip_outer_array) {
-            return _read_chunk<JsonArrayParser>(chunk, rows_to_read);
-        } else {
-            return _read_chunk<JsonDocumentStreamParser>(chunk, rows_to_read);
-        }
-    }
+    return Status::OK();
 }
 
 template <typename ParserType>
-Status JsonReader::_read_chunk(Chunk* chunk, int32_t rows_to_read) {
+Status JsonReader::_read_rows(Chunk* chunk, int32_t rows_to_read, int32_t* rows_read) {
     simdjson::ondemand::object row;
-
     auto parser = down_cast<ParserType*>(_parser.get());
 
-    for (int32_t n = 0; n < rows_to_read; n++) {
+    while (*rows_read < rows_to_read) {
         auto st = parser->get_current(&row);
         if (!st.ok()) {
             if (st.is_end_of_file()) {
-                _empty_parser = true;
-                return Status::OK();
+                return st;
             }
-            chunk->set_num_rows(n);
             _counter->num_rows_filtered++;
             _state->append_error_msg_to_file("", st.to_string());
             return st;
@@ -421,7 +434,6 @@ Status JsonReader::_read_chunk(Chunk* chunk, int32_t rows_to_read) {
 
         st = _construct_row(&row, chunk, _slot_descs);
         if (!st.ok()) {
-            chunk->set_num_rows(n);
             if (_counter->num_rows_filtered++ < MAX_ERROR_LINES_IN_FILE) {
                 // We would continue to construct row even if error is returned,
                 // hence the number of error appended to the file should be limited.
@@ -431,14 +443,13 @@ Status JsonReader::_read_chunk(Chunk* chunk, int32_t rows_to_read) {
                 LOG(WARNING) << "failed to construct row: " << st;
             }
         }
+        ++(*rows_read);
 
         st = parser->advance();
         if (!st.ok()) {
             if (st.is_end_of_file()) {
-                _empty_parser = true;
-                return Status::OK();
+                return st;
             }
-            chunk->set_num_rows(n);
             _counter->num_rows_filtered++;
             _state->append_error_msg_to_file("", st.to_string());
             return st;

--- a/be/src/exec/vectorized/json_scanner.h
+++ b/be/src/exec/vectorized/json_scanner.h
@@ -81,7 +81,7 @@ public:
 
 private:
     template <typename ParserType>
-    Status _read_chunk(Chunk* chunk, int32_t rows_to_read);
+    Status _read_rows(Chunk* chunk, int32_t rows_to_read, int32_t* rows_read);
 
     Status _read_and_parse_json();
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4975 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered, and what measures have you taken to fix the bug?) -->
This PR enables JsonScanner to read the message in a chunk if one message only contains one JSON.

## Benchmark
Source: message in JSON format; 300 bytes per message; 1 partition in Kafka
StarRocks Config: 3 BE with 3 replica

| version | output |
| -- | -- |
| main | 10.47MB/s|
| perf/read-by-chunk|34.49MB/s|

note: The `throughput` is computed by `received_bytes / consume_time(ms)`
```
I0412 19:36:57.615734 11959 data_consumer_group.cpp:131] consumer group done: f84a5ccc0736318a-cf93f37dcd661b9b. consume time(ms)=3011, received rows=786397, received bytes=108522786, eos: 0, left_time: -11, left_bytes: 415765214, blocking get time(us): 1293085, blocking put time
(us): 940130
```