### PR TITLE
bug_fix: skip use filter_unused_columns_in_scan_stage case when table…

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -193,12 +193,12 @@ public class OlapScanNode extends ScanNode {
 
     private List<String> unUsedOutputStringColumns = new ArrayList<>();
 
-    public void setUnUsedOutputStringColumns(Set<Integer> unUsedOutputColumnIds, Set<String> aggTableValueColumnName) {
+    public void setUnUsedOutputStringColumns(Set<Integer> unUsedOutputColumnIds, Set<String> aggTableValueColumnNames) {
         for (SlotDescriptor slot : desc.getSlots()) {
             if (!slot.isMaterialized()) {
                 continue;
             }
-            if (unUsedOutputColumnIds.contains(slot.getId().asInt()) && !aggTableValueColumnName.contains(slot.getColumn().getName())) {
+            if (unUsedOutputColumnIds.contains(slot.getId().asInt()) && !aggTableValueColumnNames.contains(slot.getColumn().getName())) {
                 unUsedOutputStringColumns.add(slot.getColumn().getName());
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -193,12 +193,12 @@ public class OlapScanNode extends ScanNode {
 
     private List<String> unUsedOutputStringColumns = new ArrayList<>();
 
-    public void setUnUsedOutputStringColumns(Set<Integer> unUsedOutputColumnIds) {
+    public void setUnUsedOutputStringColumns(Set<Integer> unUsedOutputColumnIds, Set<String> aggTableValueColumnName) {
         for (SlotDescriptor slot : desc.getSlots()) {
             if (!slot.isMaterialized()) {
                 continue;
             }
-            if (unUsedOutputColumnIds.contains(slot.getId().asInt())) {
+            if (unUsedOutputColumnIds.contains(slot.getId().asInt()) && !aggTableValueColumnName.contains(slot.getColumn().getName())) {
                 unUsedOutputStringColumns.add(slot.getColumn().getName());
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -579,8 +579,10 @@ public class PlanFragmentBuilder {
 
             tupleDescriptor.computeMemLayout();
 
-            // set unused output columns
-            setUnUsedOutputColumns(node, scanNode, predicates);
+            // set unused output columns if not a agg table
+            if (!referenceTable.getKeysType().isAggregationFamily()) {
+                setUnUsedOutputColumns(node, scanNode, predicates);
+            }
 
             // set isPreAggregation
             scanNode.setIsPreAggregation(node.isPreAggregation(), node.getTurnOffReason());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -267,7 +267,7 @@ public class PlanFragmentBuilder {
         }
 
         private void setUnUsedOutputColumns(PhysicalOlapScanOperator node, OlapScanNode scanNode,
-                                            List<ScalarOperator> predicates) {
+                                            List<ScalarOperator> predicates, OlapTable referenceTable) {
             if (ConnectContext.get().getSessionVariable().isAbleFilterUnusedColumnsInScanStage()) {
                 List<ColumnRefOperator> outputColumns = node.getOutputColumns();
                 Set<Integer> outputColumnIds = new HashSet<Integer>();
@@ -280,6 +280,16 @@ public class PlanFragmentBuilder {
                 // so the columns in complex pred, it useful for the stage after scan
                 Set<Integer> singlePredColumnIds = new HashSet<Integer>();
                 Set<Integer> complexPredColumnIds = new HashSet<Integer>();
+                Set<String> aggTableValueColumnName = new HashSet<String>();
+                if (referenceTable.getKeysType().isAggregationFamily()) {
+                    List<Column> fullColumn = referenceTable.getFullSchema();
+                    for (Column col : fullColumn) {
+                        if (!col.isKey()) {
+                            aggTableValueColumnName.add(col.getName());
+                        }
+                    }
+                }
+
                 for (ScalarOperator predicate : predicates) {
                     ColumnRefSet usedColumns = predicate.getUsedColumns();
                     if (DecodeVisitor.isSimpleStrictPredicate(predicate)) {
@@ -304,7 +314,8 @@ public class PlanFragmentBuilder {
                         unUsedOutputColumnIds.add(newCid);
                     }
                 }
-                scanNode.setUnUsedOutputStringColumns(unUsedOutputColumnIds);
+
+                scanNode.setUnUsedOutputStringColumns(unUsedOutputColumnIds, aggTableValueColumnName);
             }
         }
 
@@ -579,10 +590,8 @@ public class PlanFragmentBuilder {
 
             tupleDescriptor.computeMemLayout();
 
-            // set unused output columns if not a agg table
-            if (!referenceTable.getKeysType().isAggregationFamily()) {
-                setUnUsedOutputColumns(node, scanNode, predicates);
-            }
+            // set unused output columns 
+            setUnUsedOutputColumns(node, scanNode, predicates, referenceTable);
 
             // set isPreAggregation
             scanNode.setIsPreAggregation(node.isPreAggregation(), node.getTurnOffReason());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -280,12 +280,12 @@ public class PlanFragmentBuilder {
                 // so the columns in complex pred, it useful for the stage after scan
                 Set<Integer> singlePredColumnIds = new HashSet<Integer>();
                 Set<Integer> complexPredColumnIds = new HashSet<Integer>();
-                Set<String> aggTableValueColumnName = new HashSet<String>();
+                Set<String> aggTableValueColumnNames = new HashSet<String>();
                 if (referenceTable.getKeysType().isAggregationFamily()) {
                     List<Column> fullColumn = referenceTable.getFullSchema();
                     for (Column col : fullColumn) {
                         if (!col.isKey()) {
-                            aggTableValueColumnName.add(col.getName());
+                            aggTableValueColumnNames.add(col.getName());
                         }
                     }
                 }
@@ -315,7 +315,7 @@ public class PlanFragmentBuilder {
                     }
                 }
 
-                scanNode.setUnUsedOutputStringColumns(unUsedOutputColumnIds, aggTableValueColumnName);
+                scanNode.setUnUsedOutputStringColumns(unUsedOutputColumnIds, aggTableValueColumnNames);
             }
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/FilterUnusedColumnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/FilterUnusedColumnTest.java
@@ -26,8 +26,26 @@ public class FilterUnusedColumnTest extends PlanTestBase {
                 "\"in_memory\" = \"false\",\n" +
                 "\"storage_format\" = \"DEFAULT\"\n" +
                 ");");
+        // for agg table
+        starRocksAssert.withTable("CREATE TABLE `metrics_detail` ( \n" +
+                "`tags_id` int(11) NULL COMMENT \"\", \n" + 
+                "`timestamp` datetime NULL COMMENT \"\", \n" +
+                "`value` double SUM NULL COMMENT \"\" \n" +
+                ") ENGINE=OLAP \n" + 
+                "AGGREGATE KEY(`tags_id`, `timestamp`) \n" +
+                "COMMENT \"OLAP\" \n" +
+                "PARTITION BY RANGE(`timestamp`)\n" + 
+                "(PARTITION p20200704 VALUES [('0000-01-01 00:00:00'), ('2020-07-05 00:00:00')))\n" + 
+                "DISTRIBUTED BY HASH(`tags_id`) BUCKETS 1\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"in_memory\" = \"false\",\n" +
+                "\"storage_format\" = \"DEFAULT\",\n" + 
+                "\"enable_persistent_index\" = \"false\"\n" +
+                ");");
         FeConstants.USE_MOCK_DICT_MANAGER = true;
         connectContext.getSessionVariable().setSqlMode(2);
+        
     }
 
     @Test
@@ -56,6 +74,15 @@ public class FilterUnusedColumnTest extends PlanTestBase {
         String sql = "select\n" +
                 "            ref_0.d_dow as c1, year(d_date) as year from tpcds_100g_date_dim as ref_0 \n" +
                 "            where ref_0.d_date = \'1997-12-31\' limit 137;\n";
+        String plan = getThriftPlan(sql);
+        Assert.assertTrue(plan.contains("unused_output_column_name:[]"));
+    }
+
+    @Test 
+    public void testFilterAggTable() throws Exception {
+        connectContext.getSessionVariable().enableTrimOnlyFilteredColumnsInScanStage();
+        String sql = "select timestamp\n" +
+                "               from metrics_detail where value is NULL limit 10;";
         String plan = getThriftPlan(sql);
         Assert.assertTrue(plan.contains("unused_output_column_name:[]"));
     }


### PR DESCRIPTION
… is agg type

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4916

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

This feature should not be used if it is an aggregated table, because the push-down of value column expressions to the storage level is not currently supported