### PR TITLE
Fix bdb RollbackException bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBEnvironment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBEnvironment.java
@@ -210,14 +210,7 @@ public class BDBEnvironment {
                 break;
             } catch (InsufficientLogException insufficientLogEx) {
                 LOG.warn("insufficient exception, refresh and setup again", insufficientLogEx);
-                NetworkRestore restore = new NetworkRestore();
-                NetworkRestoreConfig config = new NetworkRestoreConfig();
-                config.setRetainLogFiles(false); // delete obsolete log files.
-                // Use the members returned by insufficientLogEx.getLogProviders()
-                // to select the desired subset of members and pass the resulting
-                // list as the argument to config.setLogProviders(), if the
-                // default selection of providers is not suitable.
-                restore.execute(insufficientLogEx, config);
+                refreshLog(insufficientLogEx);
                 close();
             } catch (RollbackException exception) {
                 LOG.warn("rollback exception, setup again", exception);
@@ -236,6 +229,17 @@ public class BDBEnvironment {
                 }
             }
         }
+    }
+
+    private void refreshLog(InsufficientLogException insufficientLogEx) {
+        NetworkRestore restore = new NetworkRestore();
+        NetworkRestoreConfig config = new NetworkRestoreConfig();
+        config.setRetainLogFiles(false); // delete obsolete log files.
+        // Use the members returned by insufficientLogEx.getLogProviders()
+        // to select the desired subset of members and pass the resulting
+        // list as the argument to config.setLogProviders(), if the
+        // default selection of providers is not suitable.
+        restore.execute(insufficientLogEx, config);
     }
 
     public ReplicationGroupAdmin getReplicationGroupAdmin() {
@@ -367,10 +371,7 @@ public class BDBEnvironment {
                 break;
             } catch (InsufficientLogException e) {
                 LOG.warn("catch insufficient log exception. refresh and setup again.", e);
-                NetworkRestore restore = new NetworkRestore();
-                NetworkRestoreConfig config = new NetworkRestoreConfig();
-                config.setRetainLogFiles(false);
-                restore.execute(e, config);
+                refreshLog(e);
                 close();
                 setup();
             } catch (RollbackException exception) {

--- a/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBEnvironment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBEnvironment.java
@@ -209,10 +209,9 @@ public class BDBEnvironment {
 
                 // open epochDB. the first parameter null means auto-commit
                 epochDB = new CloseSafeDatabase(replicatedEnvironment.openDatabase(null, "epochDB", dbConfig));
-                LOG.info("everything is ok, break");
                 break;
             } catch (InsufficientLogException insufficientLogEx) {
-                LOG.warn("insufficient exception", insufficientLogEx);
+                LOG.warn("insufficient exception, refresh and setup again", insufficientLogEx);
                 NetworkRestore restore = new NetworkRestore();
                 NetworkRestoreConfig config = new NetworkRestoreConfig();
                 config.setRetainLogFiles(false); // delete obsolete log files.
@@ -223,7 +222,7 @@ public class BDBEnvironment {
                 restore.execute(insufficientLogEx, config);
                 close();
             } catch (RollbackException exception) {
-                LOG.warn("rollback exception", exception);
+                LOG.warn("rollback exception, setup again", exception);
                 close();
             } catch (DatabaseException e) {
                 LOG.warn("database exception", e);
@@ -369,7 +368,7 @@ public class BDBEnvironment {
                 names = replicatedEnvironment.getDatabaseNames();
                 break;
             } catch (InsufficientLogException e) {
-                LOG.warn("catch insufficient log exception. will recover and try again.", e);
+                LOG.warn("catch insufficient log exception. refresh and setup again.", e);
                 NetworkRestore restore = new NetworkRestore();
                 NetworkRestoreConfig config = new NetworkRestoreConfig();
                 config.setRetainLogFiles(false);
@@ -377,7 +376,7 @@ public class BDBEnvironment {
                 close();
                 setup();
             } catch (RollbackException exception) {
-                LOG.warn("rollback exception", exception);
+                LOG.warn("rollback exception, setup again", exception);
                 close();
                 setup();
             } catch (EnvironmentFailureException e) {

--- a/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBEnvironment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBEnvironment.java
@@ -423,7 +423,7 @@ public class BDBEnvironment {
                 try {
                     db.close();
                 } catch (DatabaseException exception) {
-                    LOG.error("Error closing db", exception);
+                    LOG.error("Error closing db {}", db.getDbName(), exception);
                     closeSuccess = false;
                 }
             }
@@ -435,7 +435,7 @@ public class BDBEnvironment {
                 try {
                     epochDB.close();
                 } catch (DatabaseException exception) {
-                    LOG.error("Error closing db ", exception);
+                    LOG.error("Error closing db {}", epochDB.getDbName(), exception);
                     closeSuccess = false;
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBEnvironment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBEnvironment.java
@@ -92,7 +92,6 @@ public class BDBEnvironment {
     private final String helperHostPort;
     private final boolean isElectable;
 
-
     public BDBEnvironment(File envHome, String selfNodeName, String selfNodeHostPort,
                           String helperHostPort, boolean isElectable) {
         this.envHome = envHome;

--- a/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBEnvironment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBEnvironment.java
@@ -423,7 +423,7 @@ public class BDBEnvironment {
                 try {
                     db.close();
                 } catch (DatabaseException exception) {
-                    LOG.error("Error closing db {}", db.getDbName(), exception);
+                    LOG.error("Error closing db {}", db.getDatabaseName(), exception);
                     closeSuccess = false;
                 }
             }
@@ -435,7 +435,7 @@ public class BDBEnvironment {
                 try {
                     epochDB.close();
                 } catch (DatabaseException exception) {
-                    LOG.error("Error closing db {}", epochDB.getDbName(), exception);
+                    LOG.error("Error closing db {}", epochDB.getDatabaseName(), exception);
                     closeSuccess = false;
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/CloseSafeDatabase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/CloseSafeDatabase.java
@@ -63,7 +63,7 @@ public class CloseSafeDatabase {
         return db;
     }
 
-    public String getDbName() {
+    public String getDatabaseName() {
         try {
             return db.getDatabaseName();
         } catch (Throwable t) {

--- a/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/CloseSafeDatabase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/CloseSafeDatabase.java
@@ -62,4 +62,12 @@ public class CloseSafeDatabase {
     public Database getDb() {
         return db;
     }
+
+    public String getDbName() {
+        try {
+            return db.getDatabaseName();
+        } catch (Throwable t) {
+            return "";
+        }
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4977

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered, and what measures have you taken to fix the bug?) -->
In bdb, after transferring the master, there may be logs in the old master that have not been synchronized to other nodes, and these logs need to be cleaned up. After cleaning these logs, the bdb environment will throw a RollbackException, and the environment should be rebuilt. So we should catch the RollbackException, and rebuild the bdb environment.

The current handling of InsufficientLogException is somewhat problematic; we should rebuild the bdb environment after synchronizing data from other nodes.

Since we handle the InsufficientLogException in the getDatabaseNames() function, there is no need to address the exception in the open() function, so remove the extra code.