### PR TITLE
Fixup query context

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -77,7 +77,7 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
 
     // prevent an identical fragment instance from multiple execution caused by FE's
     // duplicate invocations of rpc exec_plan_fragment.
-    auto&& existing_query_ctx = QueryContextManager::instance()->get(query_id);
+    auto&& existing_query_ctx = exec_env->query_context_mgr()->get(query_id);
     if (existing_query_ctx) {
         auto&& existing_fragment_ctx = existing_query_ctx->fragment_mgr()->get(fragment_instance_id);
         if (existing_fragment_ctx) {
@@ -85,7 +85,7 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
         }
     }
 
-    _query_ctx = QueryContextManager::instance()->get_or_register(query_id);
+    _query_ctx = exec_env->query_context_mgr()->get_or_register(query_id);
     _query_ctx->set_exec_env(exec_env);
     if (params.__isset.instances_number) {
         _query_ctx->set_total_fragments(params.instances_number);

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -322,7 +322,7 @@ void PipelineDriver::finalize(RuntimeState* runtime_state, DriverState state) {
                     _workgroup->decr_num_queries();
                 }
             }
-            QueryContextManager::instance()->remove(query_id);
+            ExecEnv::GetInstance()->query_context_mgr()->remove(query_id);
         }
     }
 }

--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -80,7 +80,7 @@ QueryContextManager::QueryContextManager(size_t log2_num_slots)
 Status QueryContextManager::init() {
     try {
         _clean_thread = std::make_shared<std::thread>(_clean_func, this);
-        Thread::set_thread_name(manager->clean_thread(), "query_ctx_clr");
+        Thread::set_thread_name(*_clean_thread.get(), "query_ctx_clr");
         return Status::OK();
     } catch (...) {
         return Status::InternalError("Fail to create clean_thread of QueryContextManager");

--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -5,6 +5,7 @@
 #include "exec/workgroup/work_group.h"
 #include "runtime/data_stream_mgr.h"
 #include "runtime/exec_env.h"
+#include "util/thread.h"
 
 namespace starrocks::pipeline {
 QueryContext::QueryContext()
@@ -69,21 +70,60 @@ void QueryContext::init_query(workgroup::WorkGroup* wg) {
     });
 }
 
-static constexpr size_t QUERY_CONTEXT_MAP_SLOT_NUM = 64;
-static constexpr size_t QUERY_CONTEXT_MAP_SLOT_NUM_MASK = (1 << 6) - 1;
+QueryContextManager::QueryContextManager(size_t log2_num_slots)
+        : _num_slots(1 << log2_num_slots),
+          _slot_mask(_num_slots - 1),
+          _mutexes(_num_slots),
+          _context_maps(_num_slots),
+          _second_chance_maps(_num_slots) {}
 
-QueryContextManager::QueryContextManager()
-        : _mutexes(QUERY_CONTEXT_MAP_SLOT_NUM),
-          _context_maps(QUERY_CONTEXT_MAP_SLOT_NUM),
-          _second_chance_maps(QUERY_CONTEXT_MAP_SLOT_NUM) {}
+Status QueryContextManager::init() {
+    try {
+        _clean_thread = std::make_shared<std::thread>(_clean_func, this);
+        Thread::set_thread_name(manager->clean_thread(), "query_ctx_clr");
+        return Status::OK();
+    } catch (...) {
+        return Status::InternalError("Fail to create clean_thread of QueryContextManager");
+    }
+}
 
-#ifdef BE_TEST
-QueryContextManager::QueryContextManager(int) : QueryContextManager() {}
-#endif
+void QueryContextManager::_clean_query_contexts() {
+    for (auto i = 0; i < _num_slots; ++i) {
+        auto& mutex = _mutexes[i];
+        auto& sc_map = _second_chance_maps[i];
+        std::unique_lock write_lock(mutex);
+        auto sc_it = sc_map.begin();
+        while (sc_it != sc_map.end()) {
+            if (sc_it->second->has_no_active_instances() && sc_it->second->is_expired()) {
+                sc_it = sc_map.erase(sc_it);
+            } else {
+                ++sc_it;
+            }
+        }
+    }
+}
 
-QueryContextManager::~QueryContextManager() = default;
+void QueryContextManager::_clean_func(QueryContextManager* manager) {
+    while (!manager->_is_stopped()) {
+        manager->_clean_query_contexts();
+        std::this_thread::sleep_for(milliseconds(100));
+    }
+}
+
+size_t QueryContextManager::_slot_idx(const TUniqueId& query_id) {
+    return std::hash<size_t>()(query_id.lo) & _slot_mask;
+}
+
+QueryContextManager::~QueryContextManager() {
+    if (_clean_thread) {
+        this->_stop_clean_func();
+        _clean_thread->join();
+        clear();
+    }
+}
+
 QueryContext* QueryContextManager::get_or_register(const TUniqueId& query_id) {
-    size_t i = std::hash<size_t>()(query_id.lo) & QUERY_CONTEXT_MAP_SLOT_NUM_MASK;
+    size_t i = _slot_idx(query_id);
     auto& mutex = _mutexes[i];
     auto& context_map = _context_maps[i];
     auto& sc_map = _second_chance_maps[i];
@@ -128,7 +168,7 @@ QueryContext* QueryContextManager::get_or_register(const TUniqueId& query_id) {
 }
 
 QueryContextPtr QueryContextManager::get(const TUniqueId& query_id) {
-    size_t i = std::hash<size_t>()(query_id.lo) & QUERY_CONTEXT_MAP_SLOT_NUM_MASK;
+    size_t i = _slot_idx(query_id);
     auto& mutex = _mutexes[i];
     auto& context_map = _context_maps[i];
     auto& sc_map = _second_chance_maps[i];
@@ -149,22 +189,13 @@ QueryContextPtr QueryContextManager::get(const TUniqueId& query_id) {
 }
 
 void QueryContextManager::remove(const TUniqueId& query_id) {
-    size_t i = std::hash<size_t>()(query_id.lo) & QUERY_CONTEXT_MAP_SLOT_NUM_MASK;
+    size_t i = _slot_idx(query_id);
     auto& mutex = _mutexes[i];
     auto& context_map = _context_maps[i];
     auto& sc_map = _second_chance_maps[i];
 
     std::unique_lock<std::shared_mutex> write_lock(mutex);
 
-    // clean expired query contexts in sc_map
-    auto sc_it = sc_map.begin();
-    while (sc_it != sc_map.end()) {
-        if (sc_it->second->is_expired()) {
-            sc_it = sc_map.erase(sc_it);
-        } else {
-            ++sc_it;
-        }
-    }
     // return directly if query_ctx is absent
     auto it = context_map.find(query_id);
     if (it == context_map.end()) {
@@ -174,7 +205,7 @@ void QueryContextManager::remove(const TUniqueId& query_id) {
     // the query context is really dead, so just cleanup
     if (it->second->is_dead()) {
         context_map.erase(it);
-    } else if (it->second->is_finished()) {
+    } else if (it->second->has_no_active_instances()) {
         // although all of active fragments of the query context terminates, but some fragments maybe comes too late
         // in the future, so extend the lifetime of query context and wait for some time till fragments on wire have
         // vanished

--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -135,6 +135,7 @@ private:
     void _stop_clean_func() { _stop.store(true); }
     bool _is_stopped() { return _stop; }
     size_t _slot_idx(const TUniqueId& query_id);
+    void _clean_slot_unlocked(size_t i);
     std::thread& clean_thread() { return *_clean_thread.get(); }
 
 private:

--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -39,14 +39,14 @@ public:
 
     bool count_down_fragments() { return _num_active_fragments.fetch_sub(1) == 1; }
 
-    bool is_finished() { return _num_active_fragments.load() == 0; }
+    bool has_no_active_instances() { return _num_active_fragments.load() == 0; }
 
     void set_expire_seconds(int expire_seconds) { _expire_seconds = seconds(expire_seconds); }
 
     // now time point pass by deadline point.
     bool is_expired() {
         auto now = duration_cast<milliseconds>(steady_clock::now().time_since_epoch()).count();
-        return is_finished() && now > _deadline;
+        return now > _deadline;
     }
 
     bool is_dead() { return _num_active_fragments == 0 && _num_fragments == _total_fragments; }
@@ -119,12 +119,10 @@ private:
 };
 
 class QueryContextManager {
-    DECLARE_SINGLETON(QueryContextManager);
-
 public:
-#ifdef BE_TEST
-    explicit QueryContextManager(int);
-#endif
+    QueryContextManager(size_t log2_num_slots);
+    ~QueryContextManager();
+    Status init();
     QueryContext* get_or_register(const TUniqueId& query_id);
     QueryContextPtr get(const TUniqueId& query_id);
     void remove(const TUniqueId& query_id);
@@ -132,9 +130,22 @@ public:
     void clear();
 
 private:
+    static void _clean_func(QueryContextManager* manager);
+    void _clean_query_contexts();
+    void _stop_clean_func() { _stop.store(true); }
+    bool _is_stopped() { return _stop; }
+    size_t _slot_idx(const TUniqueId& query_id);
+    std::thread& clean_thread() { return *_clean_thread.get(); }
+
+private:
+    const size_t _num_slots;
+    const size_t _slot_mask;
     std::vector<std::shared_mutex> _mutexes;
     std::vector<std::unordered_map<TUniqueId, QueryContextPtr>> _context_maps;
     std::vector<std::unordered_map<TUniqueId, QueryContextPtr>> _second_chance_maps;
+
+    std::atomic<bool> _stop{false};
+    std::shared_ptr<std::thread> _clean_thread;
 };
 
 } // namespace pipeline

--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -136,7 +136,6 @@ private:
     bool _is_stopped() { return _stop; }
     size_t _slot_idx(const TUniqueId& query_id);
     void _clean_slot_unlocked(size_t i);
-    std::thread& clean_thread() { return *_clean_thread.get(); }
 
 private:
     const size_t _num_slots;

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -133,6 +133,7 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths) {
     _frontend_client_cache = new FrontendServiceClientCache(config::max_client_cache_size_per_host);
     _broker_client_cache = new BrokerServiceClientCache(config::max_client_cache_size_per_host);
     _thread_mgr = new ThreadResourceMgr();
+    // query_context_mgr keeps slotted map with 64 slot to reduce contention
     _query_context_mgr = new pipeline::QueryContextManager(6);
     RETURN_IF_ERROR(_query_context_mgr->init());
     _thread_pool = new PriorityThreadPool("olap_scan_io", // olap scan io

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -28,6 +28,7 @@
 #include "common/logging.h"
 #include "exec/pipeline/pipeline_driver_executor.h"
 #include "exec/pipeline/pipeline_fwd.h"
+#include "exec/pipeline/query_context.h"
 #include "exec/workgroup/scan_executor.h"
 #include "exec/workgroup/work_group.h"
 #include "gen_cpp/BackendService.h"
@@ -132,6 +133,8 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths) {
     _frontend_client_cache = new FrontendServiceClientCache(config::max_client_cache_size_per_host);
     _broker_client_cache = new BrokerServiceClientCache(config::max_client_cache_size_per_host);
     _thread_mgr = new ThreadResourceMgr();
+    _query_context_mgr = new pipeline::QueryContextManager(6);
+    RETURN_IF_ERROR(_query_context_mgr->init());
     _thread_pool = new PriorityThreadPool("olap_scan_io", // olap scan io
                                           config::doris_scanner_thread_pool_thread_num,
                                           config::doris_scanner_thread_pool_queue_size);
@@ -474,6 +477,10 @@ void ExecEnv::_destroy() {
     if (_query_pool_mem_tracker) {
         delete _query_pool_mem_tracker;
         _query_pool_mem_tracker = nullptr;
+    }
+    if (_query_context_mgr) {
+        delete _query_context_mgr;
+        _query_context_mgr = nullptr;
     }
     if (_mem_tracker) {
         delete _mem_tracker;

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -67,6 +67,7 @@ class HeartbeatFlags;
 
 namespace pipeline {
 class DriverExecutor;
+class QueryContextManager;
 }
 
 // Execution environment for queries/plan fragments.
@@ -159,9 +160,11 @@ public:
     PluginMgr* plugin_mgr() { return _plugin_mgr; }
     RuntimeFilterWorker* runtime_filter_worker() { return _runtime_filter_worker; }
     Status init_mem_tracker();
-    RuntimeFilterCache* runtime_filter_cache() { return _runtime_filter_cache; }
 
+    RuntimeFilterCache* runtime_filter_cache() { return _runtime_filter_cache; }
     void add_rf_event(const RfTracePoint& pt);
+
+    pipeline::QueryContextManager* query_context_mgr() { return _query_context_mgr; }
 
 private:
     Status _init(const std::vector<StorePath>& store_paths);
@@ -219,6 +222,7 @@ private:
     PriorityThreadPool* _etl_thread_pool = nullptr;
     PriorityThreadPool* _udf_call_pool = nullptr;
     FragmentMgr* _fragment_mgr = nullptr;
+    starrocks::pipeline::QueryContextManager* _query_context_mgr = nullptr;
     starrocks::pipeline::DriverExecutor* _driver_executor = nullptr;
     pipeline::DriverExecutor* _wg_driver_executor = nullptr;
     TMasterInfo* _master_info = nullptr;

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -68,7 +68,7 @@ class HeartbeatFlags;
 namespace pipeline {
 class DriverExecutor;
 class QueryContextManager;
-}
+} // namespace pipeline
 
 // Execution environment for queries/plan fragments.
 // Contains all required global structures, and handles to

--- a/be/src/runtime/runtime_filter_worker.cpp
+++ b/be/src/runtime/runtime_filter_worker.cpp
@@ -500,7 +500,7 @@ static inline Status receive_total_runtime_filter_pipeline(
         ExecEnv::GetInstance()->runtime_filter_cache()->put_if_absent(query_id, params.filter_id(), shared_rf);
     }
     // race condition exists among rf caching, FragmentContext's registration and OperatorFactory's preparation
-    auto query_ctx = ExecEnv::GetInstance()->query_context_mgr()->get(query_id);
+    query_ctx = ExecEnv::GetInstance()->query_context_mgr()->get(query_id);
     if (!query_ctx) {
         return Status::OK();
     }

--- a/be/src/runtime/runtime_filter_worker.cpp
+++ b/be/src/runtime/runtime_filter_worker.cpp
@@ -33,7 +33,7 @@ static inline std::shared_ptr<MemTracker> get_mem_tracker(const PUniqueId& query
         TUniqueId tquery_id;
         tquery_id.lo = query_id.lo();
         tquery_id.hi = query_id.hi();
-        auto query_ctx = pipeline::QueryContextManager::instance()->get(tquery_id);
+        auto query_ctx = ExecEnv::GetInstance()->query_context_mgr()->get(tquery_id);
         return query_ctx == nullptr ? nullptr : query_ctx->mem_tracker();
     } else {
         return nullptr;

--- a/be/src/runtime/runtime_filter_worker.cpp
+++ b/be/src/runtime/runtime_filter_worker.cpp
@@ -493,19 +493,19 @@ static inline Status receive_total_runtime_filter_pipeline(
     query_id.lo = pb_query_id.lo();
     ExecEnv::GetInstance()->add_rf_event(
             {params.query_id(), params.filter_id(), BackendOptions::get_localhost(), "RECV_TOTAL_RF_RPC_PIPELINE"});
-    auto query_ctx = starrocks::pipeline::QueryContextManager::instance()->get(query_id);
+    auto query_ctx = ExecEnv::GetInstance()->query_context_mgr()->get(query_id);
     // query_ctx is absent means that the query is finished or any fragments have not arrived, so
     // we conservatively consider that global rf arrives in advance, so cache it for later use.
     if (!query_ctx) {
         ExecEnv::GetInstance()->runtime_filter_cache()->put_if_absent(query_id, params.filter_id(), shared_rf);
     }
     // race condition exists among rf caching, FragmentContext's registration and OperatorFactory's preparation
-    query_ctx = starrocks::pipeline::QueryContextManager::instance()->get(query_id);
+    auto query_ctx = ExecEnv::GetInstance()->query_context_mgr()->get(query_id);
     if (!query_ctx) {
         return Status::OK();
     }
     // the query is already finished, so it is needless to cache rf.
-    if (query_ctx->is_finished() || query_ctx->is_expired()) {
+    if (query_ctx->has_no_active_instances() || query_ctx->is_expired()) {
         return Status::OK();
     }
 

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -243,7 +243,7 @@ void PInternalServiceImpl<T>::cancel_plan_fragment(google::protobuf::RpcControll
         }
         query_id.__set_hi(request->query_id().hi());
         query_id.__set_lo(request->query_id().lo());
-        auto&& query_ctx = starrocks::pipeline::QueryContextManager::instance()->get(query_id);
+        auto&& query_ctx = _exec_env->query_context_mgr()->get(query_id);
         if (!query_ctx) {
             LOG(INFO) << strings::Substitute("QueryContext already destroyed: query_id=$0, fragment_instance_id=$1",
                                              print_id(query_id), print_id(tid));

--- a/be/src/service/starrocks_main.cpp
+++ b/be/src/service/starrocks_main.cpp
@@ -304,7 +304,6 @@ int main(int argc, char** argv) {
     engine->stop();
     delete engine;
     exec_env->set_storage_engine(nullptr);
-    starrocks::pipeline::QueryContextManager::instance()->clear();
     starrocks::ExecEnv::destroy(exec_env);
 
     return 0;

--- a/be/test/exec/pipeline/pipeline_test_base.cpp
+++ b/be/test/exec/pipeline/pipeline_test_base.cpp
@@ -60,7 +60,7 @@ void PipelineTestBase::_prepare() {
     const auto& query_id = params.query_id;
     const auto& fragment_id = params.fragment_instance_id;
 
-    _query_ctx = QueryContextManager::instance()->get_or_register(query_id);
+    _query_ctx = _exec_env->query_context_mgr()->get_or_register(query_id);
     _query_ctx->set_total_fragments(1);
     _query_ctx->set_expire_seconds(60);
     _query_ctx->extend_lifetime();

--- a/be/test/storage/task/engine_storage_migration_task_test.cpp
+++ b/be/test/storage/task/engine_storage_migration_task_test.cpp
@@ -238,7 +238,6 @@ int main(int argc, char** argv) {
     engine->stop();
     delete engine;
     exec_env->set_storage_engine(nullptr);
-    starrocks::pipeline::QueryContextManager::instance()->clear();
     // destroy exec env
     starrocks::tls_thread_status.set_mem_tracker(nullptr);
     starrocks::ExecEnv::destroy(exec_env);

--- a/be/test/test_main.cpp
+++ b/be/test/test_main.cpp
@@ -81,7 +81,6 @@ int main(int argc, char** argv) {
     engine->stop();
     delete engine;
     exec_env->set_storage_engine(nullptr);
-    starrocks::pipeline::QueryContextManager::instance()->clear();
     // destroy exec env
     starrocks::tls_thread_status.set_mem_tracker(nullptr);
     starrocks::ExecEnv::destroy(exec_env);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

QueryContext::is_expired function never returns true if partial set of fragment instances are delivered, so the query is checked forever in pipeline poller threads. in addition, expired QueryContext cleanup depends on future QueryContexts cleanup, it is not a robust way, so add a QueryContext clean thread in QueryContextManager to scan expired QueryCoantexts and clean them.