### PR TITLE
Remove the IsMaster IsHelper column when showing frontends

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/FrontendsProcNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/FrontendsProcNode.java
@@ -45,8 +45,8 @@ public class FrontendsProcNode implements ProcNodeInterface {
 
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
             .add("Name").add("IP").add("HostName").add("EditLogPort").add("HttpPort").add("QueryPort").add("RpcPort")
-            .add("Role").add("IsMaster").add("ClusterId").add("Join").add("Alive").add("ReplayedJournalId")
-            .add("LastHeartbeat").add("IsHelper").add("ErrMsg").add("StartTime").add("Version")
+            .add("Role").add("ClusterId").add("Join").add("Alive").add("ReplayedJournalId")
+            .add("LastHeartbeat").add("ErrMsg").add("StartTime").add("Version")
             .build();
 
     public static final int HOSTNAME_INDEX = 2;
@@ -103,8 +103,12 @@ public class FrontendsProcNode implements ProcNodeInterface {
                 info.add(Integer.toString(fe.getRpcPort()));
             }
 
-            info.add(fe.getRole().name());
-            info.add(String.valueOf(fe.getHost().equals(masterIp)));
+            boolean isMaster = fe.getHost().equals(masterIp);
+            if (isMaster) {
+                info.add("MASTER");
+            } else {
+                info.add(fe.getRole().name());
+            }
 
             info.add(Integer.toString(catalog.getClusterId()));
             info.add(String.valueOf(isJoin(allFeHosts, fe)));
@@ -117,7 +121,6 @@ public class FrontendsProcNode implements ProcNodeInterface {
                 info.add(Long.toString(fe.getReplayedJournalId()));
             }
             info.add(TimeUtils.longToTimeString(fe.getLastUpdateTime()));
-            info.add(String.valueOf(isHelperNode(helperNodes, fe)));
             info.add(fe.getHeartbeatErrMsg());
 
             if (fe.isAlive()) {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4986

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
IsMaster and Role often confuse users. We'd better remove the column IsMaster and set Role to MASTER if the current node is the master. IsHelper is an internal concept and should not appear to the user.