### PR TITLE
support sort in low cardinality optimize

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalTopNOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalTopNOperator.java
@@ -28,8 +28,6 @@ public class PhysicalTopNOperator extends PhysicalOperator {
 
     private boolean isEnforced;
 
-    private List<Pair<Integer, ColumnDict>> globalDicts = Lists.newArrayList();
-
     // If limit is -1, means global sort
     public PhysicalTopNOperator(OrderSpec spec, long limit, long offset,
                                 SortPhase sortPhase,
@@ -45,15 +43,6 @@ public class PhysicalTopNOperator extends PhysicalOperator {
         this.isEnforced = isEnforced;
         this.predicate = predicate;
         this.projection = projection;
-    }
-
-    public List<Pair<Integer, ColumnDict>> getGlobalDicts() {
-        return globalDicts;
-    }
-
-    public void setGlobalDicts(
-            List<Pair<Integer, ColumnDict>> globalDicts) {
-        this.globalDicts = globalDicts;
     }
 
     public SortPhase getSortPhase() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalTopNOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalTopNOperator.java
@@ -105,7 +105,7 @@ public class PhysicalTopNOperator extends PhysicalOperator {
     public void fillDisableDictOptimizeColumns(ColumnRefSet resultSet, Set<Integer> dictColIds) {
         ColumnRefSet dictSet = new ColumnRefSet();
         dictColIds.forEach(dictSet::union);
-        // Now we disable DictOptimize when group by predicate couldn't push down
+        // Now we disable DictOptimize when order by predicate couldn't push down
         final ScalarOperator predicate = getPredicate();
         if (predicate != null) {
             final ColumnRefSet predicateUsedColumns = getPredicate().getUsedColumns();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalTopNOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalTopNOperator.java
@@ -3,6 +3,8 @@
 package com.starrocks.sql.optimizer.operator.physical;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.starrocks.common.Pair;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
@@ -13,7 +15,9 @@ import com.starrocks.sql.optimizer.operator.OperatorVisitor;
 import com.starrocks.sql.optimizer.operator.Projection;
 import com.starrocks.sql.optimizer.operator.SortPhase;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.statistics.ColumnDict;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
@@ -23,6 +27,8 @@ public class PhysicalTopNOperator extends PhysicalOperator {
     private final boolean isSplit;
 
     private boolean isEnforced;
+
+    private List<Pair<Integer, ColumnDict>> globalDicts = Lists.newArrayList();
 
     // If limit is -1, means global sort
     public PhysicalTopNOperator(OrderSpec spec, long limit, long offset,
@@ -39,6 +45,15 @@ public class PhysicalTopNOperator extends PhysicalOperator {
         this.isEnforced = isEnforced;
         this.predicate = predicate;
         this.projection = projection;
+    }
+
+    public List<Pair<Integer, ColumnDict>> getGlobalDicts() {
+        return globalDicts;
+    }
+
+    public void setGlobalDicts(
+            List<Pair<Integer, ColumnDict>> globalDicts) {
+        this.globalDicts = globalDicts;
     }
 
     public SortPhase getSortPhase() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalTopNOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalTopNOperator.java
@@ -88,18 +88,7 @@ public class PhysicalTopNOperator extends PhysicalOperator {
     }
 
     public void fillDisableDictOptimizeColumns(ColumnRefSet resultSet, Set<Integer> dictColIds) {
-        ColumnRefSet dictSet = new ColumnRefSet();
-        dictColIds.forEach(dictSet::union);
-        // Now we disable DictOptimize when order by predicate couldn't push down
-        final ScalarOperator predicate = getPredicate();
-        if (predicate != null) {
-            final ColumnRefSet predicateUsedColumns = getPredicate().getUsedColumns();
-            for (Integer dictColId : dictColIds) {
-                if (predicateUsedColumns.contains(dictColId)) {
-                    resultSet.union(dictColId);
-                }
-            }
-        }
+        // nothing to do
     }
 
     public boolean couldApplyStringDict(Set<Integer> childDictColumns) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalTopNOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalTopNOperator.java
@@ -2,9 +2,12 @@
 
 package com.starrocks.sql.optimizer.operator.physical;
 
+import com.google.common.base.Preconditions;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;
+import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.base.OrderSpec;
+import com.starrocks.sql.optimizer.base.Ordering;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.OperatorVisitor;
 import com.starrocks.sql.optimizer.operator.Projection;
@@ -12,6 +15,7 @@ import com.starrocks.sql.optimizer.operator.SortPhase;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 
 import java.util.Objects;
+import java.util.Set;
 
 public class PhysicalTopNOperator extends PhysicalOperator {
     private final long offset;
@@ -82,4 +86,36 @@ public class PhysicalTopNOperator extends PhysicalOperator {
     public <R, C> R accept(OptExpressionVisitor<R, C> visitor, OptExpression optExpression, C context) {
         return visitor.visitPhysicalTopN(optExpression, context);
     }
+
+    public void fillDisableDictOptimizeColumns(ColumnRefSet resultSet, Set<Integer> dictColIds) {
+        ColumnRefSet dictSet = new ColumnRefSet();
+        dictColIds.forEach(dictSet::union);
+        // Now we disable DictOptimize when group by predicate couldn't push down
+        final ScalarOperator predicate = getPredicate();
+        if (predicate != null) {
+            final ColumnRefSet predicateUsedColumns = getPredicate().getUsedColumns();
+            for (Integer dictColId : dictColIds) {
+                if (predicateUsedColumns.contains(dictColId)) {
+                    resultSet.union(dictColId);
+                }
+            }
+        }
+    }
+
+    public boolean couldApplyStringDict(Set<Integer> childDictColumns) {
+        Preconditions.checkState(!childDictColumns.isEmpty());
+        ColumnRefSet dictSet = new ColumnRefSet();
+        for (Integer id : childDictColumns) {
+            dictSet.union(id);
+        }
+
+        for (Ordering orderDesc : orderSpec.getOrderDescs()) {
+            if (orderDesc.getColumnRef().getUsedColumns().isIntersect(dictSet)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalTopNOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalTopNOperator.java
@@ -3,8 +3,6 @@
 package com.starrocks.sql.optimizer.operator.physical;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
-import com.starrocks.common.Pair;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
@@ -15,9 +13,7 @@ import com.starrocks.sql.optimizer.operator.OperatorVisitor;
 import com.starrocks.sql.optimizer.operator.Projection;
 import com.starrocks.sql.optimizer.operator.SortPhase;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
-import com.starrocks.sql.optimizer.statistics.ColumnDict;
 
-import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/AddDecodeNodeForDictStringRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/AddDecodeNodeForDictStringRule.java
@@ -291,7 +291,6 @@ public class AddDecodeNodeForDictStringRule implements PhysicalOperatorTreeRewri
                     OptExpression result = OptExpression.create(newTopN, newChildExpr);
                     result.setStatistics(optExpression.getStatistics());
                     result.setLogicalProperty(optExpression.getLogicalProperty());
-                    newTopN.setGlobalDicts(context.globalDicts);
                     return visitProjectionAfter(result, context);
                 } else {
                     insertDecodeExpr(optExpression, Collections.singletonList(newChildExpr), 0, context);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/AddDecodeNodeForDictStringRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/AddDecodeNodeForDictStringRule.java
@@ -297,6 +297,7 @@ public class AddDecodeNodeForDictStringRule implements PhysicalOperatorTreeRewri
                     OptExpression result = OptExpression.create(newTopN, newChildExpr);
                     result.setStatistics(optExpression.getStatistics());
                     result.setLogicalProperty(optExpression.getLogicalProperty());
+                    newTopN.setGlobalDicts(context.globalDicts);
                     return visitProjectionAfter(result, context);
                 } else {
                     insertDecodeExpr(optExpression, Collections.singletonList(newChildExpr), 0, context);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1373,13 +1373,13 @@ public class PlanFragmentBuilder {
                         topN.getOffset(),
                         inputFragment);
             } else {
-                return buildFinalTopNFragment(context, topN.getLimit(), topN.getOffset(), inputFragment, optExpr);
+                return buildFinalTopNFragment(context, topN.getLimit(), topN.getOffset(), inputFragment, optExpr, topN);
             }
         }
 
         private PlanFragment buildFinalTopNFragment(ExecPlan context, long limit, long offset,
                                                     PlanFragment inputFragment,
-                                                    OptExpression optExpr) {
+                                                    OptExpression optExpr, PhysicalTopNOperator topN) {
             ExchangeNode exchangeNode = new ExchangeNode(context.getNextNodeId(),
                     inputFragment.getPlanRoot(), false,
                     DistributionSpec.DistributionType.GATHER);
@@ -1397,6 +1397,7 @@ public class PlanFragmentBuilder {
                     new PlanFragment(context.getNextFragmentId(), exchangeNode, dataPartition);
             inputFragment.setDestination(exchangeNode);
             inputFragment.setOutputPartition(dataPartition);
+            inputFragment.setQueryGlobalDicts(topN.getGlobalDicts());
 
             context.getFragments().add(fragment);
             return fragment;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1397,7 +1397,7 @@ public class PlanFragmentBuilder {
                     new PlanFragment(context.getNextFragmentId(), exchangeNode, dataPartition);
             inputFragment.setDestination(exchangeNode);
             inputFragment.setOutputPartition(dataPartition);
-            inputFragment.setQueryGlobalDicts(topN.getGlobalDicts());
+            fragment.setQueryGlobalDicts(topN.getGlobalDicts());
 
             context.getFragments().add(fragment);
             return fragment;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1371,15 +1371,15 @@ public class PlanFragmentBuilder {
             if (!topN.isSplit()) {
                 return buildPartialTopNFragment(optExpr, context, topN.getOrderSpec(), topN.getLimit(),
                         topN.getOffset(),
-                        inputFragment, topN);
+                        inputFragment);
             } else {
-                return buildFinalTopNFragment(context, topN.getLimit(), topN.getOffset(), inputFragment, optExpr, topN);
+                return buildFinalTopNFragment(context, topN.getLimit(), topN.getOffset(), inputFragment, optExpr);
             }
         }
 
         private PlanFragment buildFinalTopNFragment(ExecPlan context, long limit, long offset,
                                                     PlanFragment inputFragment,
-                                                    OptExpression optExpr, PhysicalTopNOperator topN) {
+                                                    OptExpression optExpr) {
             ExchangeNode exchangeNode = new ExchangeNode(context.getNextNodeId(),
                     inputFragment.getPlanRoot(), false,
                     DistributionSpec.DistributionType.GATHER);
@@ -1397,7 +1397,7 @@ public class PlanFragmentBuilder {
                     new PlanFragment(context.getNextFragmentId(), exchangeNode, dataPartition);
             inputFragment.setDestination(exchangeNode);
             inputFragment.setOutputPartition(dataPartition);
-            fragment.setQueryGlobalDicts(topN.getGlobalDicts());
+            fragment.setQueryGlobalDicts(inputFragment.getQueryGlobalDicts());
 
             context.getFragments().add(fragment);
             return fragment;
@@ -1405,7 +1405,7 @@ public class PlanFragmentBuilder {
 
         private PlanFragment buildPartialTopNFragment(OptExpression optExpr, ExecPlan context,
                                                       OrderSpec orderSpec, long limit, long offset,
-                                                      PlanFragment inputFragment, PhysicalTopNOperator topN) {
+                                                      PlanFragment inputFragment) {
             List<Expr> resolvedTupleExprs = new ArrayList<>();
             List<Expr> sortExprs = new ArrayList<>();
             TupleDescriptor sortTuple = context.getDescTbl().createTupleDescriptor();
@@ -1471,7 +1471,6 @@ public class PlanFragmentBuilder {
             sortNode.computeStatistics(optExpr.getStatistics());
 
             inputFragment.setPlanRoot(sortNode);
-            inputFragment.setQueryGlobalDicts(topN.getGlobalDicts());
             estimateDopOfTopN(inputFragment);
             return inputFragment;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1371,7 +1371,7 @@ public class PlanFragmentBuilder {
             if (!topN.isSplit()) {
                 return buildPartialTopNFragment(optExpr, context, topN.getOrderSpec(), topN.getLimit(),
                         topN.getOffset(),
-                        inputFragment);
+                        inputFragment, topN);
             } else {
                 return buildFinalTopNFragment(context, topN.getLimit(), topN.getOffset(), inputFragment, optExpr, topN);
             }
@@ -1405,7 +1405,7 @@ public class PlanFragmentBuilder {
 
         private PlanFragment buildPartialTopNFragment(OptExpression optExpr, ExecPlan context,
                                                       OrderSpec orderSpec, long limit, long offset,
-                                                      PlanFragment inputFragment) {
+                                                      PlanFragment inputFragment, PhysicalTopNOperator topN) {
             List<Expr> resolvedTupleExprs = new ArrayList<>();
             List<Expr> sortExprs = new ArrayList<>();
             TupleDescriptor sortTuple = context.getDescTbl().createTupleDescriptor();
@@ -1471,6 +1471,7 @@ public class PlanFragmentBuilder {
             sortNode.computeStatistics(optExpr.getStatistics());
 
             inputFragment.setPlanRoot(sortNode);
+            inputFragment.setQueryGlobalDicts(topN.getGlobalDicts());
             estimateDopOfTopN(inputFragment);
             return inputFragment;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/ScalarOperatorToExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/ScalarOperatorToExpr.java
@@ -468,9 +468,17 @@ public class ScalarOperatorToExpr {
                     new ColumnRefOperator(call.getUsedColumns().getFirstId(), Type.VARCHAR,
                             operator.getDictColumn().getName(),
                             dictExpr.isNullable());
+
+            // Because we need to rewrite the string column to PlaceHolder when we build DictExpr,
+            // the PlaceHolder and the original string column have the same id,
+            // so we need to save the original string column first and restore it after we build the expression
+
+            // 1. save the previous expr, it was null or string column
             final Expr old = context.colRefToExpr.get(key);
+            // 2. use a placeholder instead of string column to build DictMapping
             context.colRefToExpr.put(key, new PlaceHolderExpr(dictColumn.getId(), dictExpr.isNullable(), Type.VARCHAR));
             final Expr callExpr = buildExecExpression(call, context);
+            // 3. recover the previous column
             context.colRefToExpr.put(key, old);
             Expr result = new DictMappingExpr(dictExpr, callExpr);
             result.setType(operator.getType());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/ScalarOperatorToExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/ScalarOperatorToExpr.java
@@ -468,8 +468,10 @@ public class ScalarOperatorToExpr {
                     new ColumnRefOperator(call.getUsedColumns().getFirstId(), Type.VARCHAR,
                             operator.getDictColumn().getName(),
                             dictExpr.isNullable());
+            final Expr old = context.colRefToExpr.get(key);
             context.colRefToExpr.put(key, new PlaceHolderExpr(dictColumn.getId(), dictExpr.isNullable(), Type.VARCHAR));
             final Expr callExpr = buildExecExpression(call, context);
+            context.colRefToExpr.put(key, old);
             Expr result = new DictMappingExpr(dictExpr, callExpr);
             result.setType(operator.getType());
             return result;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
@@ -754,17 +754,33 @@ public class LowCardinalityTest extends PlanTestBase {
     @Test
     public void testGroupByWithOrderBy() throws Exception {
         connectContext.getSessionVariable().setNewPlanerAggStage(2);
-        String sql = "select max(S_NAME) as b from supplier group by S_ADDRESS order by b";
-        String plan = getFragmentPlan(sql);
+        String sql = null;
+        String plan = null;
+
+        sql = "select max(S_NAME) as b from supplier group by S_ADDRESS order by b";
+        plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("group by: 10: S_ADDRESS"));
+
+        sql = "select S_ADDRESS from supplier order by S_ADDRESS";
+        plan = getVerboseExplain(sql);
+        Assert.assertTrue(plan.contains("  1:SORT\n" +
+                "  |  order by: [9, INT, false] ASC"));
+
+        sql = "select S_NAME from supplier_nullable order by upper(S_ADDRESS), S_NAME";
+        plan = getVerboseExplain(sql);
+        Assert.assertTrue(plan.contains("  2:SORT\n" +
+                "  |  order by: [11, INT, true] ASC, [2, VARCHAR, false] ASC"));
 
         sql = "select substr(S_ADDRESS, 0, 1) from supplier group by substr(S_ADDRESS, 0, 1) " +
                 "order by substr(S_ADDRESS, 0, 1)";
-        plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("  5:Decode\n" +
+        plan = getVerboseExplain(sql);
+        Assert.assertTrue(plan.contains("  7:Decode\n" +
                 "  |  <dict id 11> : <string id 9>\n" +
                 "  |  string functions:\n" +
                 "  |  <function id 11> : DictExpr(10: S_ADDRESS,[substr(<place-holder>, 0, 1)])"));
+        Assert.assertTrue(plan.contains("  5:SORT\n" +
+                "  |  order by: [11, INT, true] ASC"));
+
         connectContext.getSessionVariable().setNewPlanerAggStage(0);
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
Fixes #3987

## Problem Summary(Required) ：
support topN operator apply low cardinality opimization
eg:
```
select count(d_datekey) over (partition by d_year order by lower(d_yearmonth)) from dates;
select d_yearmonth from dates;
```