### PR TITLE
Fix: use strict mode of DateTimeFormatter for parsing string to date

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/DateLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/DateLiteral.java
@@ -42,6 +42,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.ResolverStyle;
 import java.util.Date;
 import java.util.Objects;
 import java.util.TimeZone;
@@ -67,11 +68,16 @@ public class DateLiteral extends LiteralExpr {
     private static final DateTimeFormatter DATE_FORMATTER_TWO_DIGIT;
 
     static {
-        DATE_TIME_FORMATTER = DateUtils.unixDatetimeFormatBuilder("%Y-%m-%e %H:%i:%s").toFormatter();
-        DATE_FORMATTER = DateUtils.unixDatetimeFormatBuilder("%Y-%m-%e").toFormatter();
-        DATE_TIME_FORMATTER_TWO_DIGIT = DateUtils.unixDatetimeFormatBuilder("%y-%m-%e %H:%i:%s").toFormatter();
-        DATE_FORMATTER_TWO_DIGIT = DateUtils.unixDatetimeFormatBuilder("%y-%m-%e").toFormatter();
-        DATE_NO_SPLIT_FORMATTER = DateUtils.unixDatetimeFormatBuilder("%Y%m%e").toFormatter();
+        DATE_TIME_FORMATTER = DateUtils.unixDatetimeFormatBuilder("%Y-%m-%e %H:%i:%s")
+                .toFormatter().withResolverStyle(ResolverStyle.STRICT);
+        DATE_FORMATTER = DateUtils.unixDatetimeFormatBuilder("%Y-%m-%e")
+                .toFormatter().withResolverStyle(ResolverStyle.STRICT);
+        DATE_TIME_FORMATTER_TWO_DIGIT = DateUtils.unixDatetimeFormatBuilder("%y-%m-%e %H:%i:%s")
+                .toFormatter().withResolverStyle(ResolverStyle.STRICT);
+        DATE_FORMATTER_TWO_DIGIT = DateUtils.unixDatetimeFormatBuilder("%y-%m-%e")
+                .toFormatter().withResolverStyle(ResolverStyle.STRICT);
+        DATE_NO_SPLIT_FORMATTER = DateUtils.unixDatetimeFormatBuilder("%Y%m%e")
+                .toFormatter().withResolverStyle(ResolverStyle.STRICT);
     }
 
     //Date Literal persist type in meta

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/DateLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/DateLiteral.java
@@ -43,6 +43,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.ResolverStyle;
+import java.time.temporal.ChronoField;
 import java.util.Date;
 import java.util.Objects;
 import java.util.TimeZone;

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/DateUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/DateUtils.java
@@ -106,7 +106,8 @@ public class DateUtils {
                         builder.appendValue(ChronoField.YEAR, 4);
                         break;
                     case 'y': // %y Year, numeric (two digits)
-                        builder.appendValueReduced(ChronoField.YEAR_OF_ERA, 2, 2, 1970);
+                        builder.appendValueReduced(ChronoField.YEAR_OF_ERA, 2, 2, 1970)
+                                .parseDefaulting(ChronoField.ERA, 1);
                         break;
                     case 'f': // %f Microseconds (000000..999999)
                         builder.padNext(6, '0').appendValue(ChronoField.MICRO_OF_SECOND, 1, 6, SignStyle.NORMAL);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
@@ -46,6 +46,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.ResolverStyle;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalAdjusters;
 import java.util.Set;
@@ -164,10 +165,12 @@ public class ScalarOperatorFunctions {
         DateTimeFormatterBuilder builder = DateUtils.unixDatetimeFormatBuilder(fmtLiteral.getVarchar());
 
         if (HAS_TIME_PART.matcher(fmtLiteral.getVarchar()).matches()) {
-            LocalDateTime ldt = LocalDateTime.from(builder.toFormatter().parse(date.getVarchar()));
+            LocalDateTime ldt = LocalDateTime.from(
+                    builder.toFormatter().withResolverStyle(ResolverStyle.STRICT).parse(date.getVarchar()));
             return ConstantOperator.createDatetime(ldt, Type.DATETIME);
         } else {
-            LocalDate ld = LocalDate.from(builder.toFormatter().parse(date.getVarchar()));
+            LocalDate ld = LocalDate.from(
+                    builder.toFormatter().withResolverStyle(ResolverStyle.STRICT).parse(date.getVarchar()));
             return ConstantOperator.createDatetime(ld.atTime(0, 0, 0), Type.DATETIME);
         }
     }
@@ -175,7 +178,8 @@ public class ScalarOperatorFunctions {
     @FEFunction(name = "str2date", argTypes = {"VARCHAR", "VARCHAR"}, returnType = "DATE")
     public static ConstantOperator str2Date(ConstantOperator date, ConstantOperator fmtLiteral) {
         DateTimeFormatterBuilder builder = DateUtils.unixDatetimeFormatBuilder(fmtLiteral.getVarchar());
-        LocalDate ld = LocalDate.from(builder.toFormatter().parse(date.getVarchar()));
+        LocalDate ld = LocalDate.from(
+                builder.toFormatter().withResolverStyle(ResolverStyle.STRICT).parse(date.getVarchar()));
         return ConstantOperator.createDatetime(ld.atTime(0, 0, 0), Type.DATE);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/DateLiteralTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/DateLiteralTest.java
@@ -78,4 +78,9 @@ public class DateLiteralTest {
         }
         Assert.assertFalse(hasException);
     }
+
+    @Test
+    public void invalidDate() {
+        Assert.assertThrows(AnalysisException.class, () -> new DateLiteral("2019-02-29", Type.DATETIME));
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
@@ -19,6 +19,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.Locale;
 
 import static org.junit.Assert.assertEquals;
@@ -341,6 +342,14 @@ public class ScalarOperatorFunctionsTest {
                 .dateParse(ConstantOperator.createVarchar("20190507"),
                         ConstantOperator.createVarchar("%Y%m")).getDatetime());
 
+        Assert.assertThrows(DateTimeParseException.class, () -> ScalarOperatorFunctions
+                .dateParse(ConstantOperator.createVarchar("2019-02-29"),
+                        ConstantOperator.createVarchar("%Y-%m-%d")).getDatetime());
+
+        Assert.assertThrows(DateTimeParseException.class, () -> ScalarOperatorFunctions
+                .dateParse(ConstantOperator.createVarchar("2019-02-29 11:12:13"),
+                        ConstantOperator.createVarchar("%Y-%m-%d %H:%i:%s")).getDatetime());
+
         Assert.assertThrows(IllegalArgumentException.class,
                 () -> ScalarOperatorFunctions.dateParse(ConstantOperator.createVarchar("2020-2-21"),
                         ConstantOperator.createVarchar("%w")).getVarchar());
@@ -362,6 +371,10 @@ public class ScalarOperatorFunctionsTest {
         assertEquals("2013-05-17T00:00", ScalarOperatorFunctions
                 .str2Date(ConstantOperator.createVarchar("2013-05-17 12:35:10"),
                         ConstantOperator.createVarchar("%Y-%m-%d %H:%i:%s")).getDate().toString());
+
+        Assert.assertThrows(DateTimeParseException.class, () -> ScalarOperatorFunctions
+                .str2Date(ConstantOperator.createVarchar("2019-02-29"),
+                        ConstantOperator.createVarchar("%Y-%m-%d")).getDatetime());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
@@ -333,6 +333,12 @@ public class ScalarOperatorFunctionsTest {
         assertEquals("2020-02-21 00:00:00",
                 ScalarOperatorFunctions.dateParse(ConstantOperator.createVarchar("2020-02-21"),
                         ConstantOperator.createVarchar("%Y-%m-%d")).toString());
+        assertEquals("2020-02-21 00:00:00",
+                ScalarOperatorFunctions.dateParse(ConstantOperator.createVarchar("20-02-21"),
+                        ConstantOperator.createVarchar("%y-%m-%d")).toString());
+        assertEquals("1998-02-21 00:00:00",
+                ScalarOperatorFunctions.dateParse(ConstantOperator.createVarchar("98-02-21"),
+                        ConstantOperator.createVarchar("%y-%m-%d")).toString());
 
         Assert.assertThrows(DateTimeException.class, () -> ScalarOperatorFunctions
                 .dateParse(ConstantOperator.createVarchar("201905"),
@@ -371,6 +377,12 @@ public class ScalarOperatorFunctionsTest {
         assertEquals("2013-05-17T00:00", ScalarOperatorFunctions
                 .str2Date(ConstantOperator.createVarchar("2013-05-17 12:35:10"),
                         ConstantOperator.createVarchar("%Y-%m-%d %H:%i:%s")).getDate().toString());
+        assertEquals("2013-05-17T00:00", ScalarOperatorFunctions
+                .str2Date(ConstantOperator.createVarchar("13-05-17 12:35:10"),
+                        ConstantOperator.createVarchar("%y-%m-%d %H:%i:%s")).getDate().toString());
+        assertEquals("1998-05-17T00:00", ScalarOperatorFunctions
+                .str2Date(ConstantOperator.createVarchar("98-05-17 12:35:10"),
+                        ConstantOperator.createVarchar("%y-%m-%d %H:%i:%s")).getDate().toString());
 
         Assert.assertThrows(DateTimeParseException.class, () -> ScalarOperatorFunctions
                 .str2Date(ConstantOperator.createVarchar("2019-02-29"),


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Problem Summary：
> [ResolverStyle.SMART](https://docs.oracle.com/javase/8/docs/api/java/time/format/ResolverStyle.html#SMART) says: Using smart mode will ensure that the day-of-month is from 1 to 31, converting any value beyond the last valid day-of-month to be the last valid day-of-month.

`DateTimeFormatter` uses `ResolverStyle.SMART` by default, so `CAST('2019-02-29' AS DATETIME)` for DateLiteral returns `2019-02-28`. However, `CAST('2019-02-29' AS DATETIME)` and  `STR_TO_DATE('20190229', '%Y%m%d')` return `NULL` in BE.

Therefore, we should use `ResolverStyle.STRICT` mode, which will throw `DateTimeParseException`, when the day-of-month is invalid.

After this PR, The invalid date like '2019-02-29' will throw DateTimeParseException, and compute and return `NULL` in BE.



