### PR TITLE
Fix deadlock in TabletUpdates::check_rowset_id

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -1333,10 +1333,12 @@ void TabletUpdates::_erase_expired_versions(int64_t expire_time,
 
 bool TabletUpdates::check_rowset_id(const RowsetId& rowset_id) const {
     // TODO(cbl): optimization: check multiple rowset_ids at once
-    std::unique_lock l(_rowsets_lock);
-    for (const auto& [id, rowset] : _rowsets) {
-        if (rowset->rowset_id() == rowset_id) {
-            return true;
+    {
+        std::lock_guard l(_rowsets_lock);
+        for (const auto& [id, rowset] : _rowsets) {
+            if (rowset->rowset_id() == rowset_id) {
+                return true;
+            }
         }
     }
     {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The lock order in TabletUpdates::check_rowset_id is not correct(_rowsets_lock then _lock), so it may cause deadlock, this PR fixes this.