### PR TITLE
Fix datetime cannot pushdown error for iceberg table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/external/iceberg/ExpressionConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/iceberg/ExpressionConverter.java
@@ -22,8 +22,10 @@ import com.starrocks.catalog.FunctionSet;
 import com.starrocks.sql.ast.AstVisitor;
 import org.apache.iceberg.expressions.Expression;
 
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static org.apache.iceberg.expressions.Expressions.and;
 import static org.apache.iceberg.expressions.Expressions.equal;
@@ -224,7 +226,10 @@ public class ExpressionConverter extends AstVisitor<Expression, Void> {
             case DATE:
                 return Math.toIntExact(((DateLiteral) literalExpr).toLocalDateTime().toLocalDate().toEpochDay());
             case DATETIME:
-                return ((DateLiteral) literalExpr).toLocalDateTime().toLocalDate().toEpochDay();
+                // TODO: get more precision epoch microseconds
+                long value = ((DateLiteral) literalExpr).toLocalDateTime()
+                        .toEpochSecond(OffsetDateTime.now().getOffset());
+                return TimeUnit.MICROSECONDS.convert(value, TimeUnit.SECONDS);
             default:
                 return null;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/external/iceberg/ExpressionConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/external/iceberg/ExpressionConverterTest.java
@@ -14,7 +14,9 @@ import org.apache.iceberg.expressions.Expressions;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 public class ExpressionConverterTest {
@@ -56,6 +58,15 @@ public class ExpressionConverterTest {
 
         convertedExpression= converter.convert(new BinaryPredicate(BinaryPredicate.Operator.EQ, ref, dateLiteral));
         expectedExpression = Expressions.equal("col_name", epochDay);
+        Assert.assertEquals("Generated equal expression should be correct",
+                expectedExpression.toString(), convertedExpression.toString());
+
+        // equal
+        DateLiteral dateTimeLiteral = (DateLiteral) LiteralExpr.create("2018-10-18 00:00:00", Type.DATETIME);
+        long epochSeconds = dateTimeLiteral.toLocalDateTime().toEpochSecond(OffsetDateTime.now().getOffset());
+
+        convertedExpression= converter.convert(new BinaryPredicate(BinaryPredicate.Operator.EQ, ref, dateTimeLiteral));
+        expectedExpression = Expressions.equal("col_name", TimeUnit.MICROSECONDS.convert(epochSeconds, TimeUnit.SECONDS));
         Assert.assertEquals("Generated equal expression should be correct",
                 expectedExpression.toString(), convertedExpression.toString());
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
before:
```
MySQL [iceberg]> select * from iceberg_table where dt='2020-01-01 00:00:01';
Empty set (0.09 sec)
```

after:
```
MySQL [iceberg]> select * from iceberg_table where dt='2020-01-01 00:00:01';
+------+---------------------+
| id   | dt                  |
+------+---------------------+
|    1 | 2020-01-01 00:00:01 |
+------+---------------------+
1 row in set (0.08 sec)
```