### PR TITLE
Fix group expression not replace lowestCostExpressions in the group when group merge

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Memo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Memo.java
@@ -151,8 +151,6 @@ public class Memo {
 
     // Merge srcGroup to dstGroup, srcGroup will be deleted
     private void mergeGroup(Group srcGroup, Group dstGroup) {
-        groups.remove(srcGroup);
-
         // Reset root group, rewrite rule maybe eliminate the root group
         if (srcGroup == rootGroup) {
             rootGroup = dstGroup;
@@ -198,11 +196,16 @@ public class Memo {
                 // set unused.
                 groupExpression.getGroup().removeGroupExpression(groupExpression);
                 groupExpression.setUnused(true);
+                GroupExpression existGroupExpression = groupExpressions.get(groupExpression);
+                if (!needMerge(groupExpression.getGroup(), existGroupExpression.getGroup())) {
+                    // groupExpression and existGroupExpression are in the same group， use existGroupExpression to
+                    // replace the bestExpression in the group
+                    groupExpression.getGroup().replaceBestExpression(groupExpression, existGroupExpression);
+                }
             }
         }
 
         dstGroup.mergeGroup(srcGroup);
-
         // When some rule merge two groups to one group, or
         // the GroupExpressions of one group are all removed.
         // The group is empty, We should remove it.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Memo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Memo.java
@@ -151,6 +151,7 @@ public class Memo {
 
     // Merge srcGroup to dstGroup, srcGroup will be deleted
     private void mergeGroup(Group srcGroup, Group dstGroup) {
+        groups.remove(srcGroup);
         // Reset root group, rewrite rule maybe eliminate the root group
         if (srcGroup == rootGroup) {
             rootGroup = dstGroup;


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4917 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When Group merge other goup,  the needReinsertedExpressions should consider the replacement of lowestCostExpressions in the Group, otherwise the optimizer will use wrong groupExpression when extractBestPlan
