### PR TITLE
Fix deadlock in TabletUpdates::check_rowset_id (#4998)

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -1247,10 +1247,12 @@ void TabletUpdates::_erase_expired_versions(int64_t expire_time,
 
 bool TabletUpdates::check_rowset_id(const RowsetId& rowset_id) const {
     // TODO(cbl): optimization: check multiple rowset_ids at once
-    std::unique_lock l(_rowsets_lock);
-    for (const auto& [id, rowset] : _rowsets) {
-        if (rowset->rowset_id() == rowset_id) {
-            return true;
+    {
+        std::lock_guard l(_rowsets_lock);
+        for (const auto& [id, rowset] : _rowsets) {
+            if (rowset->rowset_id() == rowset_id) {
+                return true;
+            }
         }
     }
     {


### PR DESCRIPTION
The lock order in TabletUpdates::check_rowset_id is not correct(_rowsets_lock then _lock). 
So it may cause deadlock, this PR fixes this.

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

cherry-pick #4998