### PR TITLE
[UT] fix UT crash in set thread name

### DIFF
--- a/be/src/runtime/runtime_filter_cache.cpp
+++ b/be/src/runtime/runtime_filter_cache.cpp
@@ -113,13 +113,13 @@ RuntimeFilterCache::~RuntimeFilterCache() {
 Status RuntimeFilterCache::init() {
     try {
         _clean_thread = std::make_shared<std::thread>(_clean_thread_func, this);
+        Thread::set_thread_name(*_clean_thread, "rf_cache_clr");
         return Status::OK();
     } catch (...) {
         return Status::InternalError("Fail to create clean_thread of RuntimeFilterCache");
     }
 }
 void RuntimeFilterCache::_clean_thread_func(RuntimeFilterCache* cache) {
-    Thread::set_thread_name(cache->clean_thread(), "rf_cache_clr");
     while (!cache->is_stopped()) {
         cache->_clean_filters();
         cache->_clean_events(false);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Problem Summary(Required) ：
_clean_thread_func may run before assign value to _clean_thread
```
*** SIGSEGV (@0x0) received by PID 14870 (TID 0x7f43fab2d700) from PID 0; stack trace: ***
    @          0xa9376f2 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f4514305630 (unknown)
    @          0x5daa509 std::thread::native_handle()
    @          0x61f9dc3 starrocks::Thread::set_thread_name()
    @          0x5f58402 starrocks::RuntimeFilterCache::_clean_thread_func()
    @          0x5f718bf std::__invoke_impl<>()
    @          0x5f717e6 std::__invoke<>()
    @          0x5f7165b _ZNSt6thread8_InvokerISt5tupleIJPFvPN9starrocks18RuntimeFilterCacheEES4_EEE9_M_invokeIJLm0ELm1EEEEvSt12_Index_tupleIJXspT_EEE
    @          0x5f7153a std::thread::_Invoker<>::operator()()
    @          0x5f70b9e std::thread::_State_impl<>::_M_run()
    @          0xc4c4cb0 execute_native_thread_routine
    @     0x7f45142fdea5 start_thread
    @     0x7f4513918b0d __clone
    @                0x0 (unknown)
```
