### PR TITLE
Fix limit on subquery lose gather required

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/ColumnRefSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/ColumnRefSet.java
@@ -5,6 +5,7 @@ package com.starrocks.sql.optimizer.base;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 
 import java.util.BitSet;
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.IntStream;
 
@@ -21,7 +22,7 @@ public class ColumnRefSet implements Cloneable {
         bitSet.set(id);
     }
 
-    public ColumnRefSet(List<ColumnRefOperator> refs) {
+    public ColumnRefSet(Collection<ColumnRefOperator> refs) {
         bitSet = new BitSet();
         for (ColumnRefOperator ref : refs) {
             bitSet.set(ref.getId());
@@ -74,7 +75,7 @@ public class ColumnRefSet implements Cloneable {
         bitSet.set(ref.getId());
     }
 
-    public void union(List<ColumnRefOperator> refs) {
+    public void union(Collection<ColumnRefOperator> refs) {
         union(new ColumnRefSet(refs));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -219,14 +219,21 @@ public class ExpressionTest extends PlanTestBase {
                 + " as j "
                 + "where j.x3 > 1;";
         String plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("  2:Project\n"
-                + "  |  <slot 1> : 1: v1\n"
-                + "  |  \n"
-                + "  1:SELECT\n"
-                + "  |  predicates: 3: v3 > 1\n"
-                + "  |  \n"
-                + "  0:OlapScanNode\n"
-                + "     TABLE: t0\n"));
+        Assert.assertTrue(plan.contains("  2:SELECT\n" +
+                "  |  predicates: 3: v3 > 1\n" +
+                "  |  \n" +
+                "  1:EXCHANGE\n" +
+                "     limit: 10\n" +
+                "\n" +
+                "PLAN FRAGMENT 1\n" +
+                " OUTPUT EXPRS:\n" +
+                "  PARTITION: RANDOM\n" +
+                "\n" +
+                "  STREAM DATA SINK\n" +
+                "    EXCHANGE ID: 01\n" +
+                "    UNPARTITIONED\n" +
+                "\n" +
+                "  0:OlapScanNode"));
     }
 
     @Test(expected = SemanticException.class)

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -2,7 +2,6 @@
 
 package com.starrocks.sql.plan;
 
-import com.starrocks.analysis.StatementBase;
 import com.starrocks.catalog.Catalog;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
@@ -16,7 +15,6 @@ import com.starrocks.sql.optimizer.rule.RuleSet;
 import com.starrocks.sql.optimizer.rule.transformation.JoinAssociativityRule;
 import com.starrocks.system.BackendCoreStat;
 import com.starrocks.thrift.TExplainLevel;
-import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
@@ -2142,7 +2140,7 @@ public class JoinTest extends PlanTestBase {
                 "limit \n" +
                 "  155;";
         String plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("6:Project\n" +
+        Assert.assertTrue(plan.contains("7:Project\n" +
                 "  |  <slot 2> : 2: v2"));
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4997

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

```
select * from (select * from t0 limit 10) xx where xx.v1 = 1
```

```
| PLAN FRAGMENT 0                 |
|  OUTPUT EXPRS:1: v1             |
|   PARTITION: UNPARTITIONED      |
|                                 |
|   RESULT SINK                   |
|                                 |
|   2:EXCHANGE                    |
|                                 |
| PLAN FRAGMENT 1                 |
|  OUTPUT EXPRS:                  |
|   PARTITION: RANDOM             |
|                                 |
|   STREAM DATA SINK              |
|     EXCHANGE ID: 02             |
|     UNPARTITIONED               |
|                                 |
|   1:SELECT                      |
|   |  predicates: 1: v1 > 0      |
|   |                             |
|   0:OlapScanNode                |
|      TABLE: t0                  |
|      PREAGGREGATION: ON         |
|      partitions=1/1             |
|      rollup: t0                 |
|      tabletRatio=2/3            |
|      tabletList=3036479,3036481 |
|      cardinality=4              |
|      avgRowSize=1.0             |
|      numNodes=0                 |
|      limit: 10
```