### PR TITLE
bugfix: reorder set thread name in RuntimeFilterCache

### DIFF
--- a/be/src/runtime/runtime_filter_cache.cpp
+++ b/be/src/runtime/runtime_filter_cache.cpp
@@ -113,13 +113,13 @@ RuntimeFilterCache::~RuntimeFilterCache() {
 Status RuntimeFilterCache::init() {
     try {
         _clean_thread = std::make_shared<std::thread>(_clean_thread_func, this);
+        Thread::set_thread_name(*_clean_thread, "rf_cache_clr");
         return Status::OK();
     } catch (...) {
         return Status::InternalError("Fail to create clean_thread of RuntimeFilterCache");
     }
 }
 void RuntimeFilterCache::_clean_thread_func(RuntimeFilterCache* cache) {
-    Thread::set_thread_name(cache->clean_thread(), "rf_cache_clr");
     while (!cache->is_stopped()) {
         cache->_clean_filters();
         cache->_clean_events(false);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

```
13:38:00 *** Aborted at 1649828280 (unix time) try "date -d @1649828280" if you are using GNU date ***
13:38:00 PC: @          0xbacfb05 std::thread::native_handle()
13:38:00 *** SIGSEGV (@0x0) received by PID 12061 (TID 0x7ffa5c3da700) from PID 0; stack trace: ***
13:38:00     @     0x7ffb4528a630 (unknown)
13:38:00     @          0xbacfb05 std::thread::native_handle()
13:38:00     @          0xbeb6614 starrocks::Thread::set_thread_name()
13:38:00     @          0xbc7bbe8 starrocks::RuntimeFilterCache::_clean_thread_func()
13:38:00     @          0xbc934bb std::__invoke_impl<>()
13:38:00     @          0xbc933e2 std::__invoke<>()
13:38:00     @          0xbc93265 _ZNSt6thread8_InvokerISt5tupleIJPFvPN9starrocks18RuntimeFilterCacheEES4_EEE9_M_invokeIJLm0ELm1EEEEvSt12_Index_tupleIJXspT_EEE
13:38:01     @          0xbc9315e std::thread::_Invoker<>::operator()()
13:38:01     @          0xbc92a22 std::thread::_State_impl<>::_M_run()
13:38:01     @          0xeddb210 execute_native_thread_routine
13:38:01     @     0x7ffb45282ea5 start_thread
13:38:01     @     0x7ffb4489db0d __clone
13:38:01     @                0x0 (unknown)
```

## Problem Summary(Required) ：
`_clean_thread` may not have been initialized when calling set_thread_name