### PR TITLE
HashTable for join output same column type with columns of right table

### DIFF
--- a/be/src/exec/vectorized/join_hash_map.tpp
+++ b/be/src/exec/vectorized/join_hash_map.tpp
@@ -702,7 +702,6 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_copy_build_column(const ColumnPtr& 
         dest_column->append_selective(*src_column, _probe_state->build_index.data(), 0, _probe_state->count);
         (*chunk)->append_column(std::move(dest_column), slot->id());
     }
-
 }
 
 template <PrimitiveType PT, class BuildFunc, class ProbeFunc>

--- a/be/src/exec/vectorized/join_hash_map.tpp
+++ b/be/src/exec/vectorized/join_hash_map.tpp
@@ -680,33 +680,35 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_copy_probe_nullable_column(ColumnPt
 template <PrimitiveType PT, class BuildFunc, class ProbeFunc>
 void JoinHashMap<PT, BuildFunc, ProbeFunc>::_copy_build_column(const ColumnPtr& src_column, ChunkPtr* chunk,
                                                                const SlotDescriptor* slot, bool to_nullable) {
-    ColumnPtr dest_column = ColumnHelper::create_column(slot->type(), to_nullable);
-
     if (to_nullable) {
-        dest_column->append_selective(*src_column, _probe_state->build_index.data(), 0, _probe_state->count);
+        auto data_column = src_column->clone_empty();
+        data_column->append_selective(*src_column, _probe_state->build_index.data(), 0, _probe_state->count);
 
         // When left outer join is executed,
         // build_index[i] Equal to 0 means it is not found in the hash table,
         // but append_selective() has set item of NullColumn to not null
         // so NullColumn needs to be set back to null
-        auto* null_column = ColumnHelper::as_raw_column<NullableColumn>(dest_column);
+        auto null_column = NullColumn::create(_probe_state->count, 0);
         size_t end = _probe_state->count;
         for (size_t i = 0; i < end; i++) {
             if (_probe_state->build_index[i] == 0) {
-                null_column->set_null(i);
+                null_column->get_data()[i] = 1;
             }
         }
+        auto dest_column = NullableColumn::create(std::move(data_column), null_column);
+        (*chunk)->append_column(std::move(dest_column), slot->id());
     } else {
+        auto dest_column = src_column->clone_empty();
         dest_column->append_selective(*src_column, _probe_state->build_index.data(), 0, _probe_state->count);
+        (*chunk)->append_column(std::move(dest_column), slot->id());
     }
 
-    (*chunk)->append_column(std::move(dest_column), slot->id());
 }
 
 template <PrimitiveType PT, class BuildFunc, class ProbeFunc>
 void JoinHashMap<PT, BuildFunc, ProbeFunc>::_copy_build_nullable_column(const ColumnPtr& src_column, ChunkPtr* chunk,
                                                                         const SlotDescriptor* slot) {
-    ColumnPtr dest_column = ColumnHelper::create_column(slot->type(), true);
+    ColumnPtr dest_column = src_column->clone_empty();
 
     dest_column->append_selective(*src_column, _probe_state->build_index.data(), 0, _probe_state->count);
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [x] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4618 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Previously, HashTable generated Column based on SlotType, but when LargeBinaryColumn appeared, the column type generated by `append_selective` would be inconsistent with the column type created. So instead, generate a new column using  Column::Clone.
