### PR TITLE
[cherry-pick] Support automatical meta compaction. (#4765)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -672,6 +672,7 @@ CONF_Int64(max_segment_file_size, "1073741824");
 // hdfsPreadFully() are always enabled for object storage.
 CONF_Bool(use_hdfs_pread, "true");
 
+CONF_Int64(meta_threshold_to_manual_compact, "10737418240"); // 10G
 } // namespace config
 
 } // namespace starrocks

--- a/be/src/storage/kv_store.cpp
+++ b/be/src/storage/kv_store.cpp
@@ -255,12 +255,10 @@ Status KVStore::iterate_range(ColumnFamilyIndex column_family_index, const std::
     return to_status(it->status());
 }
 
-Status KVStore::compact(uint64_t* size_before, uint64_t* size_after) {
+Status KVStore::compact() {
     rocksdb::ColumnFamilyHandle* handle = _handles[META_COLUMN_FAMILY_INDEX];
-    (void)_db->GetIntProperty(handle, "rocksdb.live-sst-files-size", size_before);
     rocksdb::CompactRangeOptions opts;
     auto st = _db->CompactRange(opts, handle, nullptr, nullptr);
-    (void)_db->GetIntProperty(handle, "rocksdb.live-sst-files-size", size_after);
     return to_status(st);
 }
 
@@ -275,6 +273,11 @@ std::string KVStore::get_stats() {
         LOG(WARNING) << "rocksdb get stats failed" << std::endl;
     }
     return stats;
+}
+
+bool KVStore::get_live_sst_files_size(uint64_t* live_sst_files_size) {
+    rocksdb::ColumnFamilyHandle* handle = _handles[META_COLUMN_FAMILY_INDEX];
+    return _db->GetIntProperty(handle, "rocksdb.live-sst-files-size", live_sst_files_size);
 }
 
 std::string KVStore::get_root_path() {

--- a/be/src/storage/kv_store.h
+++ b/be/src/storage/kv_store.h
@@ -64,11 +64,13 @@ public:
                          const std::string& upper_bound,
                          std::function<bool(std::string_view, std::string_view)> const& func);
 
-    Status compact(uint64_t* size_before, uint64_t* size_after);
+    Status compact();
 
     Status flush();
 
     std::string get_stats();
+
+    bool get_live_sst_files_size(uint64_t* live_sst_files_size);
 
     std::string get_root_path();
 

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -725,7 +725,35 @@ Status StorageEngine::_start_trash_sweep(double* usage) {
     // clean unused rowset metas in KVStore
     _clean_unused_rowset_metas();
 
+    _do_manual_compact();
+
     return res;
+}
+
+void StorageEngine::_do_manual_compact() {
+    auto data_dirs = get_stores();
+    for (auto data_dir : data_dirs) {
+        uint64_t live_sst_files_size_before = 0;
+        if (!data_dir->get_meta()->get_live_sst_files_size(&live_sst_files_size_before)) {
+            LOG(WARNING) << "data dir " << data_dir->path() << " get_live_sst_files_size failed";
+            continue;
+        }
+        if (live_sst_files_size_before > config::meta_threshold_to_manual_compact) {
+            Status s = data_dir->get_meta()->compact();
+            if (!s.ok()) {
+                LOG(WARNING) << "data dir " << data_dir->path() << " manual compact meta failed: " << s;
+            } else {
+                uint64_t live_sst_files_size_after = 0;
+                if (!data_dir->get_meta()->get_live_sst_files_size(&live_sst_files_size_after)) {
+                    LOG(WARNING) << "data dir " << data_dir->path() << " get_live_sst_files_size failed";
+                }
+                LOG(INFO) << "data dir " << data_dir->path() << " manual compact meta successfully, "
+                          << "live_sst_files_size_before: " << live_sst_files_size_before
+                          << " live_sst_files_size_after: " << live_sst_files_size_after
+                          << data_dir->get_meta()->get_stats();
+            }
+        }
+    }
 }
 
 void StorageEngine::_clean_unused_rowset_metas() {

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -203,6 +203,8 @@ private:
 
     void _clean_unused_rowset_metas();
 
+    void _do_manual_compact();
+
     Status _do_sweep(const std::string& scan_root, const time_t& local_tm_now, const int32_t expire);
 
     // All these xxx_callback() functions are for Background threads

--- a/be/src/tools/meta_tool.cpp
+++ b/be/src/tools/meta_tool.cpp
@@ -190,16 +190,23 @@ void delete_rowset_meta(DataDir* data_dir) {
 }
 
 void compact_meta(DataDir* data_dir) {
-    uint64_t size_before = 0;
-    uint64_t size_after = 0;
-    Status s = data_dir->get_meta()->compact(&size_before, &size_after);
+    uint64_t live_sst_files_size_before = 0;
+    uint64_t live_sst_files_size_after = 0;
+    if (!data_dir->get_meta()->get_live_sst_files_size(&live_sst_files_size_before)) {
+        std::cout << "data dir " << data_dir->path() << " get_live_sst_files_size failed" << std::endl;
+    }
+    auto s = data_dir->get_meta()->compact();
     if (!s.ok()) {
-        std::cout << "compact meta failed:" << s << std::endl;
+        std::cout << "data dir " << data_dir->path() << " compact meta failed: " << s << std::endl;
         return;
     }
-    std::cout << "compact meta successfully" << std::endl;
-    std::cout << data_dir->get_meta()->get_stats() << std::endl;
-    std::cout << "size before: " << size_before << " after: " << size_after << std::endl;
+    if (!data_dir->get_meta()->get_live_sst_files_size(&live_sst_files_size_after)) {
+        std::cout << "data dir " << data_dir->path() << " get_live_sst_files_size failed" << std::endl;
+    }
+    std::cout << "data dir " << data_dir->path() << " compact meta successfully, "
+              << "live_sst_files_size_before: " << live_sst_files_size_before
+              << " live_sst_files_size_after: " << live_sst_files_size_after << data_dir->get_meta()->get_stats()
+              << std::endl;
 }
 
 void get_meta_stats(DataDir* data_dir) {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4199

## Problem Summary
In some cases, the meta stored in RocksDB does not compact for a long time, and the metadata size will reach a large number. Then the user can compact the meta with the meta_tool manually.
We need to let our users do fewer things, so we do this compaction automatically, so this PR puts the compact logic into the garbage_sweeper_thread thread to implement it.

10 column, 400000000 lines, origin data file 50G, random update 1000 rows(per data file 0.016M), one second one load, total 40000 loads,

reproduce large meta data dir

![image](https://user-images.githubusercontent.com/16617323/162356721-0d9be2a0-7341-40d5-89c1-0aaff52065e6.png)

After this PR.

![image](https://user-images.githubusercontent.com/16617323/162356739-b54fcd9b-06bd-4c33-aa08-7827ccc0950e.png)

