### PR TITLE
BugFix: delete old shutdown tablet in create_tablet_from_meta_snapshot

### DIFF
--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -1352,8 +1352,21 @@ Status TabletManager::create_tablet_from_meta_snapshot(DataDir* store, TTabletId
     }
 
     std::unique_lock l(_get_tablets_shard_lock(tablet_id));
-    if (_get_tablet_unlocked(tablet_id, true, nullptr) != nullptr) {
-        return Status::InternalError("tablet already exist");
+    // TODO: if old tablet exists, should do an atomic "replace_or_add" approach instead
+    auto old_tablet_ptr = _get_tablet_unlocked(tablet_id, true, nullptr);
+    if (old_tablet_ptr != nullptr) {
+        if (old_tablet_ptr->tablet_state() == TabletState::TABLET_SHUTDOWN) {
+            Status st = delete_shutdown_tablet(tablet_id);
+            if (st.ok() || st.is_not_found()) {
+                LOG(INFO) << "before adding new cloned tablet, delete stale TABLET_SHUTDOWN tablet:" << tablet_id;
+            } else {
+                LOG(WARNING) << "before adding new cloned tablet, delete stale TABLET_SHUTDOWN tablet failed tablet:"
+                             << tablet_id << " st:" << st;
+                return st;
+            }
+        } else {
+            return Status::InternalError("tablet already exist");
+        }
     }
 
     RETURN_IF_ERROR(meta_store->write_batch(&wb));


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4840

## Problem Summary(Required) ：
When performing a full clone, it may fail if there already exists a deleted tablet in the SHUTDOWN state(it's been deleted, but still waiting to be cleaned up by gc thread), there PR try to physically delete it first, if successful, the clone process continues without failure.