### PR TITLE
[branch-2.0] persist meta when txn is committed/published

### DIFF
--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -97,7 +97,8 @@ Status LoadChannel::add_batch(const PTabletWriterAddBatchRequest& request,
     Status st;
     if (request.has_eos() && request.eos()) {
         bool finished = false;
-        RETURN_IF_ERROR(channel->close(request.sender_id(), &finished, request.partition_ids(), tablet_vec));
+        RETURN_IF_ERROR(channel->close(request.sender_id(), &finished, request.partition_ids(), tablet_vec,
+                                       request.tablet_ids()));
         if (finished) {
             std::lock_guard<std::mutex> l(_lock);
             _tablets_channels.erase(index_id);

--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -141,7 +141,8 @@ Status LoadChannel::add_chunk(const PTabletWriterAddChunkRequest& request,
     Status st;
     if (request.has_eos() && request.eos()) {
         bool finished = false;
-        RETURN_IF_ERROR(channel->close(request.sender_id(), &finished, request.partition_ids(), tablet_vec));
+        RETURN_IF_ERROR(channel->close(request.sender_id(), &finished, request.partition_ids(), tablet_vec,
+                                       request.tablet_ids()));
         if (finished) {
             std::lock_guard<std::mutex> l(_lock);
             _tablets_channels.erase(index_id);

--- a/be/src/runtime/tablets_channel.cpp
+++ b/be/src/runtime/tablets_channel.cpp
@@ -28,6 +28,7 @@
 #include "runtime/tuple_row.h"
 #include "storage/delta_writer.h"
 #include "storage/memtable.h"
+#include "storage/storage_engine.h"
 #include "storage/vectorized/delta_writer.h"
 #include "storage/vectorized/memtable.h"
 #include "util/starrocks_metrics.h"

--- a/be/src/runtime/tablets_channel.h
+++ b/be/src/runtime/tablets_channel.h
@@ -79,7 +79,7 @@ public:
     // to include all tablets written in this channel.
     // no-op when this channel has been closed or cancelled
     Status close(int sender_id, bool* finished, const google::protobuf::RepeatedField<int64_t>& partition_ids,
-                 google::protobuf::RepeatedPtrField<PTabletInfo>* tablet_vec);
+                 google::protobuf::RepeatedPtrField<PTabletInfo>* tablet_vec, const google::protobuf::RepeatedField<google::protobuf::int64>& tablet_ids);
 
     // no-op when this channel has been closed or cancelled
     Status cancel();

--- a/be/src/runtime/tablets_channel.h
+++ b/be/src/runtime/tablets_channel.h
@@ -79,7 +79,8 @@ public:
     // to include all tablets written in this channel.
     // no-op when this channel has been closed or cancelled
     Status close(int sender_id, bool* finished, const google::protobuf::RepeatedField<int64_t>& partition_ids,
-                 google::protobuf::RepeatedPtrField<PTabletInfo>* tablet_vec, const google::protobuf::RepeatedField<google::protobuf::int64>& tablet_ids);
+                 google::protobuf::RepeatedPtrField<PTabletInfo>* tablet_vec,
+                 const google::protobuf::RepeatedField<google::protobuf::int64>& tablet_ids);
 
     // no-op when this channel has been closed or cancelled
     Status cancel();

--- a/be/src/storage/kv_store.cpp
+++ b/be/src/storage/kv_store.cpp
@@ -237,6 +237,10 @@ Status KVStore::compact(uint64_t* size_before, uint64_t* size_after) {
     return to_status(st);
 }
 
+Status KVStore::flush() {
+    return to_status(_db->FlushWAL(true));
+}
+
 std::string KVStore::get_stats() {
     rocksdb::ColumnFamilyHandle* handle = _handles[META_COLUMN_FAMILY_INDEX];
     std::string stats;

--- a/be/src/storage/kv_store.h
+++ b/be/src/storage/kv_store.h
@@ -67,6 +67,8 @@ public:
 
     Status compact(uint64_t* size_before, uint64_t* size_after);
 
+    Status flush();
+
     std::string get_stats();
 
     std::string get_root_path();

--- a/be/src/storage/rowset/rowset_meta_manager.cpp
+++ b/be/src/storage/rowset/rowset_meta_manager.cpp
@@ -59,6 +59,10 @@ Status RowsetMetaManager::save(KVStore* meta, const TabletUid& tablet_uid, const
     return meta->put(META_COLUMN_FAMILY_INDEX, key, value);
 }
 
+Status RowsetMetaManager::flush(KVStore* meta) {
+    return meta->flush();
+}
+
 Status RowsetMetaManager::remove(KVStore* meta, const TabletUid& tablet_uid, const RowsetId& rowset_id) {
     std::string key = ROWSET_PREFIX + tablet_uid.to_string() + "_" + rowset_id.to_string();
     return meta->remove(META_COLUMN_FAMILY_INDEX, key);

--- a/be/src/storage/rowset/rowset_meta_manager.h
+++ b/be/src/storage/rowset/rowset_meta_manager.h
@@ -39,6 +39,8 @@ public:
     static Status save(KVStore* meta, const TabletUid& tablet_uid, const RowsetId& rowset_id,
                        const RowsetMetaPB& rowset_meta_pb);
 
+    static Status flush(KVStore* meta);
+
     static Status remove(KVStore* meta, const TabletUid& tablet_uid, const RowsetId& rowset_id);
 
     static string get_rowset_meta_key(const TabletUid& tablet_uid, const RowsetId& rowset_id);

--- a/be/src/storage/txn_manager.h
+++ b/be/src/storage/txn_manager.h
@@ -85,6 +85,9 @@ public:
     OLAPStatus publish_txn2(TTransactionId transaction_id, TPartitionId partition_id, const TabletSharedPtr& tablet,
                             int64_t version);
 
+    // persist_tablet_related_txns persists the tablets' meta and make it crash-safe.
+    Status persist_tablet_related_txns(const std::vector<TabletSharedPtr>& tablets);
+
     // delete the txn from manager if it is not committed(not have a valid rowset)
     OLAPStatus rollback_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, TTransactionId transaction_id);
 

--- a/be/src/util/starrocks_metrics.h
+++ b/be/src/util/starrocks_metrics.h
@@ -135,6 +135,10 @@ public:
     METRIC_DEFINE_INT_COUNTER(txn_commit_request_total, MetricUnit::OPERATIONS);
     METRIC_DEFINE_INT_COUNTER(txn_rollback_request_total, MetricUnit::OPERATIONS);
     METRIC_DEFINE_INT_COUNTER(txn_exec_plan_total, MetricUnit::OPERATIONS);
+
+    METRIC_DEFINE_INT_COUNTER(txn_persist_total, MetricUnit::OPERATIONS);
+    METRIC_DEFINE_INT_COUNTER(txn_persist_duration_us, MetricUnit::MICROSECONDS);
+
     METRIC_DEFINE_INT_COUNTER(stream_receive_bytes_total, MetricUnit::BYTES);
     METRIC_DEFINE_INT_COUNTER(stream_load_rows_total, MetricUnit::ROWS);
     METRIC_DEFINE_INT_COUNTER(load_rows_total, MetricUnit::ROWS);


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3140

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Flush the WAL of RocksDB after saving the meta. There are two flush operations during load.
One is the commit, and the other is the publish. To alleviate the I/O operations, we batch the flush operations.