### PR TITLE
[Enhancement] Early release stale rowsets after compaction. 

### DIFF
--- a/be/src/storage/compaction.cpp
+++ b/be/src/storage/compaction.cpp
@@ -358,6 +358,7 @@ Status Compaction::modify_rowsets() {
     std::unique_lock wrlock(_tablet->get_header_lock());
     _tablet->modify_rowsets(output_rowsets, _input_rowsets);
     _tablet->save_meta();
+    Rowset::close_rowsets(_input_rowsets);
 
     return Status::OK();
 }

--- a/be/src/storage/compaction.cpp
+++ b/be/src/storage/compaction.cpp
@@ -228,10 +228,6 @@ Status Compaction::_merge_rowsets_vertically(size_t segment_iterator_num, Statis
     TRACE_COUNTER_SCOPE_LATENCY_US("merge_rowsets_latency_us");
     auto mask_buffer = std::make_unique<RowSourceMaskBuffer>(_tablet->tablet_id(), _tablet->data_dir()->path());
     auto source_masks = std::make_unique<std::vector<RowSourceMask>>();
-    // ensure all input rowsets are loaded into memory
-    for (auto& rowset : _input_rowsets) {
-        RETURN_IF_ERROR(rowset->load());
-    }
     for (size_t i = 0; i < _column_groups.size(); ++i) {
         bool is_key = (i == 0);
         if (!is_key) {

--- a/be/src/storage/compaction.cpp
+++ b/be/src/storage/compaction.cpp
@@ -228,6 +228,10 @@ Status Compaction::_merge_rowsets_vertically(size_t segment_iterator_num, Statis
     TRACE_COUNTER_SCOPE_LATENCY_US("merge_rowsets_latency_us");
     auto mask_buffer = std::make_unique<RowSourceMaskBuffer>(_tablet->tablet_id(), _tablet->data_dir()->path());
     auto source_masks = std::make_unique<std::vector<RowSourceMask>>();
+    // ensure all input rowsets are loaded into memory
+    for (auto& rowset : _input_rowsets) {
+        RETURN_IF_ERROR(rowset->load());
+    }
     for (size_t i = 0; i < _column_groups.size(); ++i) {
         bool is_key = (i == 0);
         if (!is_key) {

--- a/be/src/storage/compaction.cpp
+++ b/be/src/storage/compaction.cpp
@@ -241,6 +241,7 @@ Status Compaction::_merge_rowsets_vertically(size_t segment_iterator_num, Statis
 
         Schema schema = ChunkHelper::convert_schema_to_format_v2(_tablet->tablet_schema(), _column_groups[i]);
         TabletReader reader(_tablet, _output_rs_writer->version(), schema, is_key, mask_buffer.get());
+        RETURN_IF_ERROR(reader.prepare());
         TabletReaderParams reader_params;
         reader_params.reader_type = compaction_type();
         reader_params.profile = _runtime_profile.create_child("merge_rowsets");
@@ -269,7 +270,6 @@ Status Compaction::_merge_rowsets_vertically(size_t segment_iterator_num, Statis
                                                                   total_mem_footprint, segment_iterator_num);
         VLOG(1) << "tablet=" << _tablet->tablet_id() << ", column group=" << i << ", reader chunk size=" << chunk_size;
         reader_params.chunk_size = chunk_size;
-        RETURN_IF_ERROR(reader.prepare());
         RETURN_IF_ERROR(reader.open(reader_params));
 
         int64_t output_rows = 0;

--- a/be/src/storage/compaction_task.h
+++ b/be/src/storage/compaction_task.h
@@ -255,6 +255,7 @@ protected:
         }
         _tablet->modify_rowsets({_output_rowset}, _input_rowsets);
         _tablet->save_meta();
+        Rowset::close_rowsets(_input_rowsets);
         LOG(INFO) << "commit compaction. output version:" << _task_info.output_version
                   << ", output rowset version:" << _output_rowset->version()
                   << ", input rowsets:" << input_stream_info.str() << ", input rowsets size:" << _input_rowsets.size();

--- a/be/src/storage/meta_reader.h
+++ b/be/src/storage/meta_reader.h
@@ -79,6 +79,7 @@ public:
 private:
     TabletSharedPtr _tablet;
     Version _version;
+    std::vector<RowsetSharedPtr> _rowsets;
 
     bool _is_init;
     bool _has_more;

--- a/be/src/storage/rowset/rowset.h
+++ b/be/src/storage/rowset/rowset.h
@@ -229,7 +229,7 @@ public:
     void release() {
         // if the refs by reader is 0 and the rowset is closed, should release the resouce
         uint64_t current_refs = --_refs_by_reader;
-        if (current_refs == 0 && _rowset_state_machine.rowset_state() == ROWSET_UNLOADING) {
+        if (current_refs == 0) {
             {
                 std::lock_guard<std::mutex> release_lock(_lock);
                 // rejudge _refs_by_reader because we do not add lock in create reader
@@ -252,6 +252,18 @@ public:
         std::for_each(rowsets.begin(), rowsets.end(),
                       [&num_segments](const RowsetSharedPtr& rowset) { num_segments += rowset->num_segments(); });
         return num_segments;
+    }
+
+    static void acquire_readers(const std::vector<RowsetSharedPtr>& rowsets) {
+        std::for_each(rowsets.begin(), rowsets.end(), [](const RowsetSharedPtr& rowset) { rowset->acquire(); });
+    }
+
+    static void release_readers(const std::vector<RowsetSharedPtr>& rowsets) {
+        std::for_each(rowsets.begin(), rowsets.end(), [](const RowsetSharedPtr& rowset) { rowset->release(); });
+    }
+
+    static void close_rowsets(const std::vector<RowsetSharedPtr>& rowsets) {
+        std::for_each(rowsets.begin(), rowsets.end(), [](const RowsetSharedPtr& rowset) { rowset->close(); });
     }
 
 protected:

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -276,6 +276,7 @@ void Tablet::modify_rowsets(const std::vector<RowsetSharedPtr>& to_add, const st
 
     // add rs_metas_to_delete to tracker
     _timestamped_version_tracker.add_stale_path_version(rs_metas_to_delete);
+    Rowset::close_rowsets(to_delete);
 }
 
 // snapshot manager may call this api to check if version exists, so that
@@ -1120,31 +1121,6 @@ void Tablet::generate_tablet_meta_copy_unlocked(const TabletMetaSharedPtr& new_t
 Status Tablet::rowset_commit(int64_t version, const RowsetSharedPtr& rowset) {
     CHECK(_updates) << "updates should exists";
     return _updates->rowset_commit(version, rowset);
-}
-
-StatusOr<Tablet::IteratorList> Tablet::capture_segment_iterators(const Version& spec_version,
-                                                                 const vectorized::Schema& schema,
-                                                                 const vectorized::RowsetReadOptions& options) const {
-    if (_updates) {
-        if (spec_version.first != 0) {
-            LOG(WARNING) << "cannot capture with version.first:" << spec_version.first;
-            return Status::InvalidArgument("cannot capture with version.first != 0");
-        }
-        return _updates->read(spec_version.second, schema, options);
-    }
-    std::shared_lock rdlock(_meta_lock);
-    std::vector<Version> version_path;
-    std::vector<RowsetSharedPtr> rowsets;
-    RETURN_IF_ERROR(capture_consistent_versions(spec_version, &version_path));
-    RETURN_IF_ERROR(_capture_consistent_rowsets_unlocked(version_path, &rowsets));
-    // Release lock before acquiring segment iterators.
-    rdlock.unlock();
-
-    IteratorList iterators;
-    for (auto& rowset : rowsets) {
-        RETURN_IF_ERROR(rowset->get_segment_iterators(schema, options, &iterators));
-    }
-    return std::move(iterators);
 }
 
 void Tablet::on_shutdown() {

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -276,7 +276,6 @@ void Tablet::modify_rowsets(const std::vector<RowsetSharedPtr>& to_add, const st
 
     // add rs_metas_to_delete to tracker
     _timestamped_version_tracker.add_stale_path_version(rs_metas_to_delete);
-    Rowset::close_rowsets(to_delete);
 }
 
 // snapshot manager may call this api to check if version exists, so that

--- a/be/src/storage/tablet.h
+++ b/be/src/storage/tablet.h
@@ -137,10 +137,6 @@ public:
 
     using IteratorList = std::vector<ChunkIteratorPtr>;
 
-    // Get the segment iterators for the specified version |spec_version|.
-    StatusOr<IteratorList> capture_segment_iterators(const Version& spec_version, const vectorized::Schema& schema,
-                                                     const vectorized::RowsetReadOptions& options) const;
-
     const DelPredicateArray& delete_predicates() const { return _tablet_meta->delete_predicates(); }
     void add_delete_predicate(const DeletePredicatePB& delete_predicate, int64_t version);
     bool version_for_delete_predicate(const Version& version);

--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -46,12 +46,21 @@ void TabletReader::close() {
         _collect_iter.reset();
     }
     STLDeleteElements(&_predicate_free_list);
+    Rowset::release_readers(_rowsets);
 }
 
 Status TabletReader::prepare() {
     std::shared_lock l(_tablet->get_header_lock());
     auto st = _tablet->capture_consistent_rowsets(_version, &_rowsets);
+    if (!st.ok()) {
+        _rowsets.clear();
+        std::stringstream ss;
+        ss << "fail to init reader. tablet=" << _tablet->full_name() << "res=" << st;
+        LOG(WARNING) << ss.str();
+        return Status::InternalError(ss.str().c_str());
+    }
     _stats.rowsets_read_count += _rowsets.size();
+    Rowset::acquire_readers(_rowsets);
     return st;
 }
 
@@ -61,7 +70,6 @@ Status TabletReader::open(const TabletReaderParams& read_params) {
         return Status::NotSupported("reader type not supported now");
     }
     Status st = _init_collector(read_params);
-    _rowsets.clear(); // unused anymore.
     return st;
 }
 

--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -48,6 +48,7 @@ void TabletReader::close() {
     }
     STLDeleteElements(&_predicate_free_list);
     Rowset::release_readers(_rowsets);
+    _rowsets.clear();
     _obj_pool.clear();
 }
 

--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -64,6 +64,10 @@ Status TabletReader::prepare() {
     }
     _stats.rowsets_read_count += _rowsets.size();
     Rowset::acquire_readers(_rowsets);
+    // ensure all input rowsets are loaded into memory
+    for (const auto& rowset : _rowsets) {
+        rowset->load();
+    }
     return st;
 }
 

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -414,22 +414,6 @@ Status TabletUpdates::_get_apply_version_and_rowsets(int64_t* version, std::vect
     return Status::OK();
 }
 
-StatusOr<IteratorList> TabletUpdates::read(int64_t version, const vectorized::Schema& schema,
-                                           const vectorized::RowsetReadOptions& options) {
-    if (_error) {
-        return Status::InternalError(Substitute("read failed, tablet updates is in error state: tablet:$0 $1",
-                                                _tablet.tablet_id(), _error_msg));
-    }
-    std::vector<RowsetSharedPtr> rowsets;
-    RETURN_IF_ERROR(get_applied_rowsets(version, &rowsets));
-
-    IteratorList iterators;
-    for (auto& rowset : rowsets) {
-        RETURN_IF_ERROR(rowset->get_segment_iterators(schema, options, &iterators));
-    }
-    return std::move(iterators);
-}
-
 Status TabletUpdates::rowset_commit(int64_t version, const RowsetSharedPtr& rowset) {
     if (_error) {
         return Status::InternalError(Substitute("rowset_commit failed, tablet updates is in error state: tablet:$0 $1",

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -60,10 +60,6 @@ public:
 
     using IteratorList = std::vector<std::shared_ptr<vectorized::ChunkIterator>>;
 
-    // Return NotFound if the |version| does not exist.
-    StatusOr<IteratorList> read(int64_t version, const vectorized::Schema& schema,
-                                const vectorized::RowsetReadOptions& options);
-
     // get latest version's number of rows
     size_t num_rows() const;
 

--- a/be/src/storage/vertical_compaction_task.cpp
+++ b/be/src/storage/vertical_compaction_task.cpp
@@ -59,11 +59,6 @@ Status VerticalCompactionTask::_vertical_compaction_data(Statistics* statistics)
           "size:$1",
           max_rows_per_segment, column_groups.size());
 
-    // ensure all input rowsets are loaded into memory
-    for (auto& rowset : _input_rowsets) {
-        RETURN_IF_ERROR(rowset->load());
-    }
-
     for (size_t i = 0; i < column_groups.size(); ++i) {
         if (should_stop()) {
             LOG(INFO) << "vertical compaction task_id:" << _task_info.task_id << " is stopped.";

--- a/be/src/storage/vertical_compaction_task.cpp
+++ b/be/src/storage/vertical_compaction_task.cpp
@@ -115,6 +115,7 @@ Status VerticalCompactionTask::_compact_column_group(bool is_key, int column_gro
             vectorized::ChunkHelper::convert_schema_to_format_v2(_tablet->tablet_schema(), column_group);
     vectorized::TabletReader reader(std::static_pointer_cast<Tablet>(_tablet->shared_from_this()),
                                     output_rs_writer->version(), schema, is_key, mask_buffer);
+    RETURN_IF_ERROR(reader.prepare());
     vectorized::TabletReaderParams reader_params;
     DCHECK(compaction_type() == BASE_COMPACTION || compaction_type() == CUMULATIVE_COMPACTION);
     reader_params.reader_type =
@@ -129,7 +130,6 @@ Status VerticalCompactionTask::_compact_column_group(bool is_key, int column_gro
     VLOG(1) << "compaction task_id:" << _task_info.task_id << ", tablet=" << _tablet->tablet_id()
             << ", column group=" << column_group_index << ", reader chunk size=" << chunk_size;
     reader_params.chunk_size = chunk_size;
-    RETURN_IF_ERROR(reader.prepare());
     RETURN_IF_ERROR(reader.open(reader_params));
 
     StatusOr<size_t> rows_st = _compact_data(is_key, chunk_size, column_group, schema, &reader, output_rs_writer,

--- a/be/src/storage/vertical_compaction_task.cpp
+++ b/be/src/storage/vertical_compaction_task.cpp
@@ -59,6 +59,11 @@ Status VerticalCompactionTask::_vertical_compaction_data(Statistics* statistics)
           "size:$1",
           max_rows_per_segment, column_groups.size());
 
+    // ensure all input rowsets are loaded into memory
+    for (auto& rowset : _input_rowsets) {
+        RETURN_IF_ERROR(rowset->load());
+    }
+
     for (size_t i = 0; i < column_groups.size(); ++i) {
         if (should_stop()) {
             LOG(INFO) << "vertical compaction task_id:" << _task_info.task_id << " is stopped.";

--- a/be/test/storage/rowset_merger_test.cpp
+++ b/be/test/storage/rowset_merger_test.cpp
@@ -14,6 +14,7 @@
 #include "storage/rowset/rowset_writer.h"
 #include "storage/rowset/rowset_writer_context.h"
 #include "storage/storage_engine.h"
+#include "storage/tablet_reader.h"
 #include "storage/union_iterator.h"
 #include "storage/update_manager.h"
 #include "testutil/assert.h"
@@ -168,24 +169,22 @@ protected:
     TabletSharedPtr _tablet;
 };
 
-static vectorized::ChunkIteratorPtr create_tablet_iterator(const TabletSharedPtr& tablet, int64_t version) {
-    static OlapReaderStatistics s_stats;
-    vectorized::Schema schema = vectorized::ChunkHelper::convert_schema_to_format_v2(tablet->tablet_schema());
-    vectorized::RowsetReadOptions rs_opts;
-    rs_opts.is_primary_keys = true;
-    rs_opts.sorted = false;
-    rs_opts.version = version;
-    rs_opts.meta = tablet->data_dir()->get_meta();
-    rs_opts.stats = &s_stats;
-    auto seg_iters = tablet->capture_segment_iterators(Version(0, version), schema, rs_opts);
-    if (!seg_iters.ok()) {
-        LOG(ERROR) << "read tablet failed: " << seg_iters.status().to_string();
+static vectorized::ChunkIteratorPtr create_tablet_iterator(vectorized::TabletReader& reader,
+                                                           vectorized::Schema& schema) {
+    vectorized::TabletReaderParams params;
+    if (!reader.prepare().ok()) {
+        LOG(ERROR) << "reader prepare failed";
         return nullptr;
     }
-    if (seg_iters->empty()) {
+    std::vector<ChunkIteratorPtr> seg_iters;
+    if (!reader.get_segment_iterators(params, &seg_iters).ok()) {
+        LOG(ERROR) << "reader get segment iterators fail";
+        return nullptr;
+    }
+    if (seg_iters.empty()) {
         return vectorized::new_empty_iterator(schema, DEFAULT_CHUNK_SIZE);
     }
-    return vectorized::new_union_iterator(*seg_iters);
+    return vectorized::new_union_iterator(seg_iters);
 }
 
 static ssize_t read_until_eof(const vectorized::ChunkIteratorPtr& iter) {
@@ -206,7 +205,9 @@ static ssize_t read_until_eof(const vectorized::ChunkIteratorPtr& iter) {
 }
 
 static ssize_t read_tablet(const TabletSharedPtr& tablet, int64_t version) {
-    auto iter = create_tablet_iterator(tablet, version);
+    vectorized::Schema schema = vectorized::ChunkHelper::convert_schema_to_format_v2(tablet->tablet_schema());
+    vectorized::TabletReader reader(tablet, Version(0, version), schema);
+    auto iter = create_tablet_iterator(reader, schema);
     if (iter == nullptr) {
         return -1;
     }

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -24,6 +24,7 @@
 #include "storage/storage_engine.h"
 #include "storage/tablet.h"
 #include "storage/tablet_meta_manager.h"
+#include "storage/tablet_reader.h"
 #include "storage/union_iterator.h"
 #include "storage/update_manager.h"
 #include "storage/wrapper_field.h"
@@ -375,24 +376,22 @@ static TabletSharedPtr load_same_tablet_from_store(MemTracker* mem_tracker, cons
     return tablet1;
 }
 
-static vectorized::ChunkIteratorPtr create_tablet_iterator(const TabletSharedPtr& tablet, int64_t version) {
-    static OlapReaderStatistics s_stats;
-    vectorized::Schema schema = vectorized::ChunkHelper::convert_schema_to_format_v2(tablet->tablet_schema());
-    vectorized::RowsetReadOptions rs_opts;
-    rs_opts.is_primary_keys = true;
-    rs_opts.sorted = false;
-    rs_opts.version = version;
-    rs_opts.meta = tablet->data_dir()->get_meta();
-    rs_opts.stats = &s_stats;
-    auto seg_iters = tablet->capture_segment_iterators(Version(0, version), schema, rs_opts);
-    if (!seg_iters.ok()) {
-        LOG(ERROR) << "read tablet failed: " << seg_iters.status().to_string();
+static vectorized::ChunkIteratorPtr create_tablet_iterator(vectorized::TabletReader& reader,
+                                                           vectorized::Schema& schema) {
+    vectorized::TabletReaderParams params;
+    if (!reader.prepare().ok()) {
+        LOG(ERROR) << "reader prepare failed";
         return nullptr;
     }
-    if (seg_iters->empty()) {
+    std::vector<ChunkIteratorPtr> seg_iters;
+    if (!reader.get_segment_iterators(params, &seg_iters).ok()) {
+        LOG(ERROR) << "reader get segment iterators fail";
+        return nullptr;
+    }
+    if (seg_iters.empty()) {
         return vectorized::new_empty_iterator(schema, DEFAULT_CHUNK_SIZE);
     }
-    return vectorized::new_union_iterator(*seg_iters);
+    return vectorized::new_union_iterator(seg_iters);
 }
 
 static ssize_t read_and_compare(const vectorized::ChunkIteratorPtr& iter, const vector<int64_t>& keys) {
@@ -441,7 +440,9 @@ static ssize_t read_until_eof(const vectorized::ChunkIteratorPtr& iter) {
 }
 
 static ssize_t read_tablet(const TabletSharedPtr& tablet, int64_t version) {
-    auto iter = create_tablet_iterator(tablet, version);
+    vectorized::Schema schema = vectorized::ChunkHelper::convert_schema_to_format_v2(tablet->tablet_schema());
+    vectorized::TabletReader reader(tablet, Version(0, version), schema);
+    auto iter = create_tablet_iterator(reader, schema);
     if (iter == nullptr) {
         return -1;
     }
@@ -449,7 +450,9 @@ static ssize_t read_tablet(const TabletSharedPtr& tablet, int64_t version) {
 }
 
 static ssize_t read_tablet_and_compare(const TabletSharedPtr& tablet, int64_t version, const vector<int64_t>& keys) {
-    auto iter = create_tablet_iterator(tablet, version);
+    vectorized::Schema schema = vectorized::ChunkHelper::convert_schema_to_format_v2(tablet->tablet_schema());
+    vectorized::TabletReader reader(tablet, Version(0, version), schema);
+    auto iter = create_tablet_iterator(reader, schema);
     if (iter == nullptr) {
         return -1;
     }
@@ -458,7 +461,9 @@ static ssize_t read_tablet_and_compare(const TabletSharedPtr& tablet, int64_t ve
 
 static ssize_t read_tablet_and_compare_schema_changed(const TabletSharedPtr& tablet, int64_t version,
                                                       const vector<int64_t>& keys) {
-    auto iter = create_tablet_iterator(tablet, version);
+    vectorized::Schema schema = vectorized::ChunkHelper::convert_schema_to_format_v2(tablet->tablet_schema());
+    vectorized::TabletReader reader(tablet, Version(0, version), schema);
+    auto iter = create_tablet_iterator(reader, schema);
     if (iter == nullptr) {
         return -1;
     }
@@ -696,10 +701,15 @@ void TabletUpdatesTest::test_remove_expired_versions(bool enable_persistent_inde
     ASSERT_EQ(0, read_tablet(_tablet, 1));
 
     // Create iterators before remove expired version, but read them after removal.
-    auto iter_v0 = create_tablet_iterator(_tablet, 1);
-    auto iter_v1 = create_tablet_iterator(_tablet, 2);
-    auto iter_v2 = create_tablet_iterator(_tablet, 3);
-    auto iter_v3 = create_tablet_iterator(_tablet, 4);
+    vectorized::Schema schema = vectorized::ChunkHelper::convert_schema_to_format_v2(_tablet->tablet_schema());
+    vectorized::TabletReader reader1(_tablet, Version(0, 1), schema);
+    vectorized::TabletReader reader2(_tablet, Version(0, 2), schema);
+    vectorized::TabletReader reader3(_tablet, Version(0, 3), schema);
+    vectorized::TabletReader reader4(_tablet, Version(0, 4), schema);
+    auto iter_v0 = create_tablet_iterator(reader1, schema);
+    auto iter_v1 = create_tablet_iterator(reader2, schema);
+    auto iter_v2 = create_tablet_iterator(reader3, schema);
+    auto iter_v3 = create_tablet_iterator(reader4, schema);
 
     // Remove all but the last version.
     _tablet->updates()->remove_expired_versions(time(NULL));


### PR DESCRIPTION
After compaction, the stale rowsets will still stay in memory for a long time before gc thread free them. And these stale rowsets take up a lot of memory. In fact, there may be a few old readers still read the stale rowsets, all new readers will read the new rowset generated by the compaction, so we can free the stale rowsets if there are no readers on it. Experiments show that this optimization significantly reduces the memory footprint of rowsets metadata.

Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4873 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
After compaction, the stale rowsets will still stay in memory for a long time before gc thread free them. And these stale rowsets take up a lot of memory. In fact, there may be a few old readers still reading the stale rowsets, all new readers will read the new rowset generated by the compaction, so we can free the stale rowsets if there are no readers on it. Experiments show that this optimization significantly reduces the memory footprint of rowsets metadata.

