### PR TITLE
[Enhancement] optimize _get_segment_iterator_num in compaction

### DIFF
--- a/be/src/storage/compaction.cpp
+++ b/be/src/storage/compaction.cpp
@@ -63,7 +63,7 @@ Status Compaction::do_compaction_impl() {
     _output_version = Version(_input_rowsets.front()->start_version(), _input_rowsets.back()->end_version());
 
     // choose vertical or horizontal compaction algorithm
-    size_t segment_iterator_num = Rowset::get_segment_num(_input_rowsets); 
+    size_t segment_iterator_num = Rowset::get_segment_num(_input_rowsets);
     int64_t max_columns_per_group = config::vertical_compaction_max_columns_per_group;
     size_t num_columns = _tablet->num_columns();
     CompactionAlgorithm algorithm =

--- a/be/src/storage/compaction.cpp
+++ b/be/src/storage/compaction.cpp
@@ -63,13 +63,7 @@ Status Compaction::do_compaction_impl() {
     _output_version = Version(_input_rowsets.front()->start_version(), _input_rowsets.back()->end_version());
 
     // choose vertical or horizontal compaction algorithm
-    auto iterator_num_res = _get_segment_iterator_num();
-    if (!iterator_num_res.ok()) {
-        LOG(WARNING) << "fail to get segment iterator num. tablet=" << _tablet->tablet_id()
-                     << ", err=" << iterator_num_res.status().to_string();
-        return iterator_num_res.status();
-    }
-    size_t segment_iterator_num = iterator_num_res.value();
+    size_t segment_iterator_num = Rowset::get_segment_num(_input_rowsets); 
     int64_t max_columns_per_group = config::vertical_compaction_max_columns_per_group;
     size_t num_columns = _tablet->num_columns();
     CompactionAlgorithm algorithm =
@@ -151,17 +145,6 @@ Status Compaction::do_compaction_impl() {
                               << " rowset:" << _output_rowset->rowset_id() << " " << st;
 
     return Status::OK();
-}
-
-StatusOr<size_t> Compaction::_get_segment_iterator_num() {
-    Schema schema = ChunkHelper::convert_schema_to_format_v2(_tablet->tablet_schema());
-    TabletReader reader(_tablet, _output_version, schema);
-    TabletReaderParams reader_params;
-    reader_params.reader_type = compaction_type();
-    RETURN_IF_ERROR(reader.prepare());
-    std::vector<ChunkIteratorPtr> seg_iters;
-    RETURN_IF_ERROR(reader.get_segment_iterators(reader_params, &seg_iters));
-    return seg_iters.size();
 }
 
 Status Compaction::_merge_rowsets_horizontally(size_t segment_iterator_num, Statistics* stats_output) {

--- a/be/src/storage/compaction.h
+++ b/be/src/storage/compaction.h
@@ -75,8 +75,6 @@ protected:
     RuntimeProfile _runtime_profile;
 
 private:
-    StatusOr<size_t> _get_segment_iterator_num();
-
     // merge rows from vectorized reader and write into `_output_rs_writer`.
     // return Status::OK() and set statistics into `*stats_output`.
     // return others on error

--- a/be/src/storage/compaction_task_factory.h
+++ b/be/src/storage/compaction_task_factory.h
@@ -28,8 +28,6 @@ public:
     std::shared_ptr<CompactionTask> create_compaction_task();
 
 private:
-    StatusOr<size_t> _get_segment_iterator_num();
-
     Version _output_version;
     TabletSharedPtr _tablet;
     std::vector<RowsetSharedPtr> _input_rowsets;

--- a/be/src/storage/rowset/rowset.h
+++ b/be/src/storage/rowset/rowset.h
@@ -247,10 +247,10 @@ public:
         }
     }
 
-    static size_t get_segment_num(std::vector<RowsetSharedPtr>& rowsets) {
+    static size_t get_segment_num(const std::vector<RowsetSharedPtr>& rowsets) {
         size_t num_segments = 0;
         std::for_each(rowsets.begin(), rowsets.end(),
-                      [&num_segments](RowsetSharedPtr& rowset) { num_segments += rowset->num_segments(); });
+                      [&num_segments](const RowsetSharedPtr& rowset) { num_segments += rowset->num_segments(); });
         return num_segments;
     }
 

--- a/be/src/storage/rowset/rowset.h
+++ b/be/src/storage/rowset/rowset.h
@@ -247,6 +247,14 @@ public:
         }
     }
 
+    static size_t get_segment_num(std::vector<RowsetSharedPtr>& rowsets) {
+        size_t num_segments = 0;
+        std::for_each(rowsets.begin(), rowsets.end(), [&num_segments](RowsetSharedPtr& rowset) { 
+            num_segments += rowset->num_segments(); 
+        });
+        return num_segments;
+    }
+
 protected:
     friend class RowsetFactory;
 

--- a/be/src/storage/rowset/rowset.h
+++ b/be/src/storage/rowset/rowset.h
@@ -249,9 +249,8 @@ public:
 
     static size_t get_segment_num(std::vector<RowsetSharedPtr>& rowsets) {
         size_t num_segments = 0;
-        std::for_each(rowsets.begin(), rowsets.end(), [&num_segments](RowsetSharedPtr& rowset) { 
-            num_segments += rowset->num_segments(); 
-        });
+        std::for_each(rowsets.begin(), rowsets.end(),
+                      [&num_segments](RowsetSharedPtr& rowset) { num_segments += rowset->num_segments(); });
         return num_segments;
     }
 


### PR DESCRIPTION
Compaction needs to choose the compaction algorithm(vertical of horizontal)
based on the `segment_iterator_num`.
In previous implementation, we need to first
construct a tablet reader, then construct all segment iterators,
the segment_iterator_num equals to the number of segment iterators.
The cost of computing segment_iterator_num is very high.
In fact, we can directly get the segment_iterator_num from the meta of rowsets.
This method will be much more efficient than the original one.

Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Compaction needs to choose the compaction algorithm(vertical or horizontal)
based on the `segment_iterator_num`.
In the previous implementation, we need to first
construct a tablet reader, then construct all segment iterators,
the segment_iterator_num equals the number of segment iterators.
The cost of computing segment_iterator_num is very high.
In fact, we can directly get the segment_iterator_num from the meta of rowsets.
This method will be much more efficient than the original one.