### PR TITLE
[Opt merge part1] Introduce columnwise merge algorithm

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -121,9 +121,11 @@ set(EXEC_FILES
     vectorized/schema_scanner/schema_helper.cpp
     vectorized/jdbc_scan_node.cpp
     vectorized/jdbc_scanner.cpp
+    vectorized/sorting/compare_column.cpp
+    vectorized/sorting/merge_column.cpp
+    vectorized/sorting/merge_cascade.cpp
     vectorized/sorting/sort_column.cpp
     vectorized/sorting/sort_permute.cpp
-    vectorized/sorting/compare_column.cpp
     parquet/column_chunk_reader.cpp
     parquet/column_reader.cpp
     parquet/encoding.cpp

--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -123,7 +123,6 @@ set(EXEC_FILES
     vectorized/jdbc_scanner.cpp
     vectorized/sorting/compare_column.cpp
     vectorized/sorting/merge_column.cpp
-    vectorized/sorting/merge_cascade.cpp
     vectorized/sorting/sort_column.cpp
     vectorized/sorting/sort_permute.cpp
     parquet/column_chunk_reader.cpp

--- a/be/src/exec/vectorized/chunks_sorter.h
+++ b/be/src/exec/vectorized/chunks_sorter.h
@@ -13,6 +13,9 @@
 namespace starrocks::vectorized {
 
 struct DataSegment {
+    static const uint8_t BEFORE_LAST_RESULT = 2;
+    static const uint8_t IN_LAST_RESULT = 1;
+
     ChunkPtr chunk;
     Columns order_by_columns;
 
@@ -37,9 +40,6 @@ struct DataSegment {
             order_by_columns.push_back(EVALUATE_NULL_IF_ERROR(expr_ctx, expr_ctx->root(), chunk.get()));
         }
     }
-
-    static const uint8_t BEFORE_LAST_RESULT = 2;
-    static const uint8_t IN_LAST_RESULT = 1;
 
     // there is two compares in the method,
     // the first is:

--- a/be/src/exec/vectorized/chunks_sorter_full_sort.cpp
+++ b/be/src/exec/vectorized/chunks_sorter_full_sort.cpp
@@ -133,7 +133,7 @@ Status ChunksSorterFullSort::_build_sorting_data(RuntimeState* state) {
 
     _sorted_permutation.resize(row_count);
     for (uint32_t i = 0; i < row_count; ++i) {
-        _sorted_permutation[i] = {0, i, i};
+        _sorted_permutation[i] = {0, i};
     }
 
     return Status::OK();

--- a/be/src/exec/vectorized/chunks_sorter_topn.cpp
+++ b/be/src/exec/vectorized/chunks_sorter_topn.cpp
@@ -3,6 +3,7 @@
 #include "chunks_sorter_topn.h"
 
 #include "column/type_traits.h"
+#include "exec/vectorized/sorting/sort_helper.h"
 #include "exec/vectorized/sorting/sort_permute.h"
 #include "exec/vectorized/sorting/sorting.h"
 #include "exprs/expr.h"
@@ -354,114 +355,81 @@ Status ChunksSorterTopn::_merge_sort_data_as_merged_segment(RuntimeState* state,
 void ChunksSorterTopn::_merge_sort_common(ChunkPtr& big_chunk, DataSegments& segments, size_t sort_row_number,
                                           size_t sorted_size, size_t permutation_size,
                                           Permutation& permutation_second) {
-    uint32_t last_chunk_index = segments.size();
-    size_t index_of_merging = 0, index_of_left = 0, index_of_right = 0;
+    // Assemble the permutated segments into a chunk
+    std::vector<ChunkPtr> right_chunks;
+    for (auto& segment : segments) {
+        right_chunks.push_back(segment.chunk);
+    }
+    ChunkPtr right_chunk = big_chunk->clone_empty(permutation_second.size());
+    append_by_permutation(right_chunk.get(), right_chunks, permutation_second);
+
+    ChunkPtr left_chunk = _merged_segment.chunk;
+
     Permutation merged_perm;
     merged_perm.reserve(sort_row_number);
+    SortDescs sort_desc(_sort_order_flag, _null_first_flag);
 
-    while ((index_of_merging < sort_row_number) && (index_of_left < sorted_size) &&
-           (index_of_right < permutation_size)) {
-        const auto& right = permutation_second[index_of_right];
-        // TODO: optimize the compare
-        int cmp = _merged_segment.compare_at(index_of_left, segments[right.chunk_index], right.index_in_chunk,
-                                             _sort_order_flag, _null_first_flag);
-
-        if (cmp <= 0) {
-            merged_perm.emplace_back(PermutationItem(last_chunk_index, index_of_left, 0));
-            ++index_of_left;
-        } else {
-            merged_perm.emplace_back(right);
-            ++index_of_right;
-        }
-        ++index_of_merging;
-    }
-    while (index_of_left < sorted_size && index_of_merging < sort_row_number) {
-        merged_perm.emplace_back(last_chunk_index, index_of_left, 0);
-        ++index_of_left;
-    }
-    while (index_of_right < permutation_size && index_of_merging < sort_row_number) {
-        merged_perm.emplace_back(permutation_second[index_of_right]);
-        ++index_of_right;
+    if (_compare_strategy == RowWise) {
+        Status st =
+                merge_sorted_chunks_two_way_rowwise(sort_desc, left_chunk, right_chunk, &merged_perm, sort_row_number);
+        CHECK(st.ok());
+    } else {
+        Status st = merge_sorted_chunks_two_way(sort_desc, left_chunk, right_chunk, &merged_perm);
+        CHECK(st.ok());
+        CHECK_GE(merged_perm.size(), sort_row_number);
+        merged_perm.resize(sort_row_number);
     }
 
-    std::vector<ChunkPtr> chunks;
-    for (auto& seg : segments) {
-        chunks.push_back(seg.chunk);
-    }
-    chunks.push_back(_merged_segment.chunk);
-
+    std::vector<ChunkPtr> chunks{left_chunk, right_chunk};
     append_by_permutation(big_chunk.get(), chunks, merged_perm);
 }
 
 Status ChunksSorterTopn::_hybrid_sort_common(RuntimeState* state, std::pair<Permutation, Permutation>& new_permutation,
                                              DataSegments& segments, size_t sort_row_number) {
-    ChunkPtr big_chunk;
     size_t first_size = new_permutation.first.size();
+    size_t second_size = new_permutation.second.size();
 
-    // this means we just need number_of_rows_to_sort rows in permutations.first.
-    if (first_size >= sort_row_number) {
+    if (first_size == 0 && second_size == 0) {
+        return Status::OK();
+    }
+
+    ChunkPtr big_chunk;
+    std::vector<ChunkPtr> chunks;
+    for (auto& segment : segments) {
+        chunks.push_back(segment.chunk);
+    }
+
+    if (first_size > 0) {
         big_chunk.reset(segments[new_permutation.first[0].chunk_index].chunk->clone_empty(sort_row_number).release());
+        append_by_permutation(big_chunk.get(), chunks, new_permutation.first);
+        sort_row_number -= first_size;
+    }
 
-        for (size_t index = 0; index < sort_row_number; ++index) {
-            auto& right = new_permutation.first[index];
-            big_chunk->append_safe(*segments[right.chunk_index].chunk, right.index_in_chunk, 1);
-        }
-
-        DataSegment merged_segment;
-        merged_segment.init(_sort_exprs, big_chunk);
-
-        _merged_segment = std::move(merged_segment);
-    } else {
-        size_t permutation_size = new_permutation.second.size();
-        if (first_size == 0 && permutation_size == 0) {
-            return Status::OK();
-        }
-
-        // this means we need all permutations.first as BEFORE and take (number_of_rows_to_sort - permutations.first.size()) rows from
-        // permutations.second merge-sort with _merged_segment.
-        sort_row_number = sort_row_number - first_size;
-        size_t sorted_size = _merged_segment.chunk->num_rows();
-        if (sort_row_number > sorted_size + permutation_size) {
-            sort_row_number = sorted_size + permutation_size;
-        }
-
-        if (first_size > 0) {
-            big_chunk.reset(segments[new_permutation.first[0].chunk_index]
-                                    .chunk->clone_empty(sort_row_number + first_size)
-                                    .release());
-
-            for (size_t index = 0; index < first_size; ++index) {
-                auto& right = new_permutation.first[index];
-                big_chunk->append_safe(*segments[right.chunk_index].chunk, right.index_in_chunk, 1);
-            }
-        } else {
+    if (sort_row_number > 0) {
+        if (big_chunk == nullptr) {
             big_chunk.reset(
                     segments[new_permutation.second[0].chunk_index].chunk->clone_empty(sort_row_number).release());
         }
+        size_t sorted_size = _merged_segment.chunk->num_rows();
+        sort_row_number = std::min(sort_row_number, sorted_size + second_size);
 
-        // take sort_row_number rows from permutations.second merge-sort with _merged_segment.
-        _merge_sort_common(big_chunk, segments, sort_row_number, sorted_size, permutation_size, new_permutation.second);
-
-        if (big_chunk->reach_capacity_limit()) {
-            LOG(WARNING) << "TopN sort encounter big chunk overflow";
-            return Status::InternalError(fmt::format("TopN sort encounter big chunk overflow"));
-        }
-
-        DataSegment merged_segment;
-        merged_segment.init(_sort_exprs, big_chunk);
-
-        _merged_segment = std::move(merged_segment);
+        _merge_sort_common(big_chunk, segments, sort_row_number, sorted_size, second_size, new_permutation.second);
     }
+    if (big_chunk->reach_capacity_limit()) {
+        LOG(WARNING) << "TopN sort encounter big chunk overflow";
+        return Status::InternalError(fmt::format("TopN sort encounter big chunk overflow"));
+    }
+
+    DataSegment merged_segment;
+    merged_segment.init(_sort_exprs, big_chunk);
+    _merged_segment = std::move(merged_segment);
 
     return Status::OK();
 }
 
 Status ChunksSorterTopn::_hybrid_sort_first_time(RuntimeState* state, Permutation& new_permutation,
                                                  DataSegments& segments, size_t sort_row_number) {
-    size_t permutation_size = new_permutation.size();
-    if (sort_row_number > permutation_size) {
-        sort_row_number = permutation_size;
-    }
+    sort_row_number = std::min(new_permutation.size(), sort_row_number);
 
     if (sort_row_number > Column::MAX_CAPACITY_LIMIT) {
         LOG(WARNING) << "topn sort row exceed rows limit " << sort_row_number;
@@ -469,14 +437,24 @@ Status ChunksSorterTopn::_hybrid_sort_first_time(RuntimeState* state, Permutatio
     }
 
     ChunkPtr big_chunk;
-    size_t index_of_merging = 0;
+    big_chunk.reset(segments[new_permutation[0].chunk_index].chunk->clone_empty(sort_row_number).release());
 
     // Initial this big chunk.
-    big_chunk.reset(segments[new_permutation[0].chunk_index].chunk->clone_empty(sort_row_number).release());
-    while (index_of_merging < sort_row_number) {
-        auto& permutation = new_permutation[index_of_merging];
-        big_chunk->append_safe(*segments[permutation.chunk_index].chunk, permutation.index_in_chunk, 1);
-        ++index_of_merging;
+    if (_compare_strategy != RowWise) {
+        std::vector<ChunkPtr> chunks;
+        for (auto& segment : segments) {
+            chunks.push_back(segment.chunk);
+        }
+        new_permutation.resize(sort_row_number);
+        append_by_permutation(big_chunk.get(), chunks, new_permutation);
+    } else {
+        // TODO: remove it
+        size_t index_of_merging = 0;
+        while (index_of_merging < sort_row_number) {
+            auto& permutation = new_permutation[index_of_merging];
+            big_chunk->append_safe(*segments[permutation.chunk_index].chunk, permutation.index_in_chunk, 1);
+            ++index_of_merging;
+        }
     }
 
     if (big_chunk->reach_capacity_limit()) {

--- a/be/src/exec/vectorized/chunks_sorter_topn.cpp
+++ b/be/src/exec/vectorized/chunks_sorter_topn.cpp
@@ -189,7 +189,7 @@ Status ChunksSorterTopn::_build_sorting_data(RuntimeState* state, Permutation& p
         for (uint32_t i = 0; i < segments.size(); ++i) {
             uint32_t num = segments[i].chunk->num_rows();
             for (uint32_t j = 0; j < num; ++j) {
-                permutation_second[perm_index] = {i, j, perm_index};
+                permutation_second[perm_index] = {i, j};
                 ++perm_index;
             }
         }
@@ -205,7 +205,7 @@ void ChunksSorterTopn::_set_permutation_before(Permutation& permutation, size_t 
         size_t nums = filter_array[i].size();
         for (uint32_t j = 0; j < nums; ++j) {
             if (filter_array[i][j] == DataSegment::BEFORE_LAST_RESULT) {
-                permutation[first_size] = {i, j, first_size};
+                permutation[first_size] = {i, j};
                 ++first_size;
             }
         }
@@ -221,10 +221,10 @@ void ChunksSorterTopn::_set_permutation_complete(std::pair<Permutation, Permutat
         size_t nums = filter_array[i].size();
         for (uint32_t j = 0; j < nums; ++j) {
             if (filter_array[i][j] == DataSegment::BEFORE_LAST_RESULT) {
-                permutations.first[first_size] = {i, j, first_size};
+                permutations.first[first_size] = {i, j};
                 ++first_size;
             } else if (filter_array[i][j] == DataSegment::IN_LAST_RESULT) {
-                permutations.second[second_size] = {i, j, second_size};
+                permutations.second[second_size] = {i, j};
                 ++second_size;
             }
         }

--- a/be/src/exec/vectorized/sorting/merge_column.cpp
+++ b/be/src/exec/vectorized/sorting/merge_column.cpp
@@ -243,6 +243,33 @@ Status merge_sorted_chunks_two_way(const SortDescs& sort_desc, const SortedRun& 
     return MergeTwoChunk::merge_sorted_chunks_two_way(sort_desc, left, right, output);
 }
 
+// Merge multiple chunks in two-way merge
+Status merge_sorted_chunks(const SortDescs& descs, const std::vector<ChunkPtr>& chunks, ChunkPtr* output) {
+    std::vector<ChunkPtr> current(chunks);
+    while (current.size() > 1) {
+        std::vector<ChunkPtr> next_level;
+        int level_size = current.size() & ~1;
+
+        for (int i = 0; i < level_size; i += 2) {
+            Permutation perm;
+            ChunkPtr left = current[i];
+            ChunkPtr right = current[i + 1];
+            RETURN_IF_ERROR(merge_sorted_chunks_two_way(descs, left, right, &perm));
+            ;
+            ChunkPtr merged = left->clone_empty(left->num_rows() + right->num_rows());
+            append_by_permutation(merged.get(), {left, right}, perm);
+            next_level.push_back(merged);
+        }
+        if (current.size() % 2 == 1) {
+            next_level.push_back(current.back());
+        }
+        current = std::move(next_level);
+    }
+    *output = current.front();
+
+    return Status::OK();
+}
+
 Status merge_sorted_chunks_two_way_rowwise(const SortDescs& descs, const ChunkPtr left_chunk,
                                            const ChunkPtr right_chunk, Permutation* output, size_t limit) {
     constexpr int kLeftChunkIndex = 0;

--- a/be/src/exec/vectorized/sorting/merge_column.cpp
+++ b/be/src/exec/vectorized/sorting/merge_column.cpp
@@ -326,20 +326,20 @@ Status merge_sorted_chunks_two_way_rowwise(const SortDescs& descs, const ChunkPt
         int cmp =
                 compare_chunk_row(descs, left_chunk->columns(), right_chunk->columns(), index_of_left, index_of_right);
         if (cmp <= 0) {
-            output->emplace_back(PermutationItem(kLeftChunkIndex, index_of_left, 0));
+            output->emplace_back(PermutationItem(kLeftChunkIndex, index_of_left));
             ++index_of_left;
         } else {
-            output->emplace_back(PermutationItem(kRightChunkIndex, index_of_right, 0));
+            output->emplace_back(PermutationItem(kRightChunkIndex, index_of_right));
             ++index_of_right;
         }
         ++index_of_merging;
     }
     while (index_of_left < left_size && index_of_merging < limit) {
-        output->emplace_back(kLeftChunkIndex, index_of_left, 0);
+        output->emplace_back(kLeftChunkIndex, index_of_left);
         ++index_of_left;
     }
     while (index_of_right < right_size && index_of_merging < limit) {
-        output->emplace_back(kRightChunkIndex, index_of_right, 0);
+        output->emplace_back(kRightChunkIndex, index_of_right);
         ++index_of_right;
     }
     return Status::OK();

--- a/be/src/exec/vectorized/sorting/merge_column.cpp
+++ b/be/src/exec/vectorized/sorting/merge_column.cpp
@@ -305,7 +305,7 @@ Status merge_sorted_chunks(const SortDescs& descs, const std::vector<ChunkPtr>& 
             ChunkPtr left = current[i];
             ChunkPtr right = current[i + 1];
             RETURN_IF_ERROR(merge_sorted_chunks_two_way(descs, left, right, &perm));
-            ;
+
             ChunkPtr merged = left->clone_empty(left->num_rows() + right->num_rows());
             append_by_permutation(merged.get(), {left, right}, perm);
             next_level.push_back(merged);

--- a/be/src/exec/vectorized/sorting/merge_column.cpp
+++ b/be/src/exec/vectorized/sorting/merge_column.cpp
@@ -1,0 +1,229 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#include "column/array_column.h"
+#include "column/chunk.h"
+#include "column/column_visitor_adapter.h"
+#include "column/const_column.h"
+#include "column/datum.h"
+#include "column/fixed_length_column_base.h"
+#include "column/json_column.h"
+#include "column/nullable_column.h"
+#include "column/vectorized_fwd.h"
+#include "exec/vectorized/sorting/sort_helper.h"
+#include "exec/vectorized/sorting/sort_permute.h"
+#include "exec/vectorized/sorting/sorting.h"
+#include "runtime/vectorized/chunk_cursor.h"
+
+namespace starrocks::vectorized {
+
+struct EqualRange {
+    using Range = std::pair<uint32_t, uint32_t>;
+
+    Range left_range;
+    Range right_range;
+
+    EqualRange(Range left, Range right) : left_range(left), right_range(right) {}
+};
+
+// MergeTwoColumn incremental merge two columns
+class MergeTwoColumn final : public ColumnVisitorAdapter<MergeTwoColumn> {
+public:
+    MergeTwoColumn(SortDesc desc, const Column* left_col, const Column* right_col, std::vector<EqualRange>* equal_range,
+                   Permutation* perm)
+            : ColumnVisitorAdapter(this),
+              _sort_order(desc.sort_order),
+              _null_first(desc.null_first),
+              _left_col(left_col),
+              _right_col(right_col),
+              _equal_ranges(equal_range),
+              _perm(perm) {}
+
+    template <class ColumnType>
+    void do_merge() {
+        std::vector<EqualRange> next_ranges;
+        next_ranges.reserve(_equal_ranges->size());
+        auto left_col = down_cast<const ColumnType*>(_left_col);
+        auto right_col = down_cast<const ColumnType*>(_right_col);
+
+        // Iterate each equal-range
+        for (auto equal_range : *_equal_ranges) {
+            size_t lhs = equal_range.left_range.first;
+            size_t rhs = equal_range.right_range.first;
+            size_t lhs_end = equal_range.left_range.second;
+            size_t rhs_end = equal_range.right_range.second;
+            size_t output_index = lhs + rhs;
+
+            // Merge rows in the equal-range
+            while (lhs < lhs_end || rhs < rhs_end) {
+                auto left_range = fetch_left(left_col, lhs, lhs_end);
+                auto right_range = fetch_right(right_col, rhs, rhs_end);
+
+                // TODO: optimize the compare
+                int x = 0;
+                if (lhs < lhs_end && rhs < rhs_end) {
+                    x = left_col->compare_at(left_range.first, right_range.first, *right_col, _null_first);
+                    x *= _sort_order;
+                } else if (lhs < lhs_end) {
+                    x = -1;
+                } else if (rhs < rhs_end) {
+                    x = 1;
+                }
+
+                if (x <= 0) {
+                    lhs = left_range.second;
+                    for (size_t i = left_range.first; i < left_range.second; i++) {
+                        (*_perm)[output_index++] = PermutationItem(kLeftIndex, i);
+                    }
+                }
+                if (x >= 0) {
+                    rhs = right_range.second;
+                    for (size_t i = right_range.first; i < right_range.second; i++) {
+                        (*_perm)[output_index++] = PermutationItem(kRightIndex, i);
+                    }
+                }
+                if (x == 0) {
+                    next_ranges.emplace_back(left_range, right_range);
+                }
+            }
+
+            DCHECK_EQ(lhs, lhs_end);
+            DCHECK_EQ(rhs, rhs_end);
+        }
+
+        _equal_ranges->swap(next_ranges);
+    }
+
+    template <class ColumnType>
+    Status do_visit(const ColumnType&) {
+        do_merge<ColumnType>();
+        return Status::OK();
+    }
+
+    template <class ColumnType>
+    EqualRange::Range fetch_left(const ColumnType* left_col, size_t lhs, size_t lhs_end) {
+        uint32_t first = lhs;
+        uint32_t last = lhs + 1;
+        while (last < lhs_end && left_col->compare_at(last - 1, last, *left_col, _null_first) == 0) {
+            last++;
+        }
+        return {first, last};
+    }
+
+    template <class ColumnType>
+    EqualRange::Range fetch_right(const ColumnType* right_col, size_t rhs, size_t rhs_end) {
+        uint32_t first = rhs;
+        uint32_t last = rhs + 1;
+        while (last < rhs_end && right_col->compare_at(last - 1, last, *right_col, _null_first) == 0) {
+            last++;
+        }
+        return {first, last};
+    }
+
+private:
+    constexpr static uint32_t kLeftIndex = 0;
+    constexpr static uint32_t kRightIndex = 1;
+
+    const int _sort_order;
+    const int _null_first;
+    const Column* _left_col;
+    const Column* _right_col;
+    std::vector<EqualRange>* _equal_ranges;
+    Permutation* _perm;
+};
+
+// MergeTwoChunk merge two chunk in column-wise
+// 1. Merge the first column, record the equal rows into equal-range
+// 2. Merge the second column within the equal-range of previous column
+// 3. Repeat it until no equal-range or the last column
+class MergeTwoChunk {
+public:
+    static Status merge_sorted_chunks_two_way(const SortDescs& sort_desc, const SortedRun& left_run,
+                                              const SortedRun& right_run, Permutation* output) {
+        DCHECK(!!left_run.chunk);
+        DCHECK(!!right_run.chunk);
+        DCHECK_EQ(left_run.num_columns(), right_run.num_columns());
+
+        if (left_run.empty()) {
+            size_t count = right_run.range.second - right_run.range.first;
+            output->resize(count);
+            for (size_t i = 0; i < count; i++) {
+                (*output)[i].chunk_index = 1;
+                (*output)[i].index_in_chunk = i + right_run.range.first;
+            }
+        } else if (right_run.empty()) {
+            size_t count = left_run.range.second - left_run.range.first;
+            output->resize(count);
+            for (size_t i = 0; i < count; i++) {
+                (*output)[i].chunk_index = 0;
+                (*output)[i].index_in_chunk = i + left_run.range.first;
+            }
+        } else {
+            std::vector<EqualRange> equal_ranges;
+            equal_ranges.emplace_back(left_run.range, right_run.range);
+            size_t count = left_run.range.second + right_run.range.second;
+            output->resize(count);
+            equal_ranges.reserve(std::max((size_t)1, count / 4));
+
+            for (int col = 0; col < sort_desc.num_columns(); col++) {
+                const Column* left_col = left_run.get_column(col);
+                const Column* right_col = right_run.get_column(col);
+                MergeTwoColumn merge2(sort_desc.get_column_desc(col), left_col, right_col, &equal_ranges, output);
+                Status st = left_col->accept(&merge2);
+                CHECK(st.ok());
+                if (equal_ranges.size() == 0) {
+                    break;
+                }
+            }
+        }
+
+        return Status::OK();
+    }
+};
+
+Status merge_sorted_chunks_two_way(const SortDescs& sort_desc, const ChunkPtr left, const ChunkPtr right,
+                                   Permutation* output) {
+    DCHECK_LE(sort_desc.num_columns(), left->num_columns());
+    DCHECK_LE(sort_desc.num_columns(), right->num_columns());
+
+    SortedRun left_run(left, 0, left->num_rows());
+    SortedRun right_run(right, 0, right->num_rows());
+    return MergeTwoChunk::merge_sorted_chunks_two_way(sort_desc, left_run, right_run, output);
+}
+
+Status merge_sorted_chunks_two_way(const SortDescs& sort_desc, const SortedRun& left, const SortedRun& right,
+                                   Permutation* output) {
+    return MergeTwoChunk::merge_sorted_chunks_two_way(sort_desc, left, right, output);
+}
+
+Status merge_sorted_chunks_two_way_rowwise(const SortDescs& descs, const ChunkPtr left_chunk,
+                                           const ChunkPtr right_chunk, Permutation* output, size_t limit) {
+    constexpr int kLeftChunkIndex = 0;
+    constexpr int kRightChunkIndex = 1;
+    size_t index_of_merging = 0, index_of_left = 0, index_of_right = 0;
+    size_t left_size = left_chunk->num_rows();
+    size_t right_size = right_chunk->num_rows();
+    output->reserve(limit);
+
+    while ((index_of_merging < limit) && (index_of_left < left_size) && (index_of_right < right_size)) {
+        int cmp = compare_chunk_row(descs, *left_chunk, *right_chunk, index_of_left, index_of_right);
+        if (cmp <= 0) {
+            output->emplace_back(PermutationItem(kLeftChunkIndex, index_of_left, 0));
+            ++index_of_left;
+        } else {
+            output->emplace_back(PermutationItem(kRightChunkIndex, index_of_right, 0));
+            ++index_of_right;
+        }
+        ++index_of_merging;
+    }
+    while (index_of_left < left_size && index_of_merging < limit) {
+        output->emplace_back(kLeftChunkIndex, index_of_left, 0);
+        ++index_of_left;
+    }
+    while (index_of_right < right_size && index_of_merging < limit) {
+        output->emplace_back(kRightChunkIndex, index_of_right, 0);
+        ++index_of_right;
+    }
+    return Status::OK();
+}
+
+} // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/sorting/merge_column.cpp
+++ b/be/src/exec/vectorized/sorting/merge_column.cpp
@@ -52,10 +52,9 @@ public:
             size_t output_index = lhs + rhs;
 
             // Merge rows in the equal-range
+            auto left_range = fetch_equal(lhs, lhs_end, equal_left);
+            auto right_range = fetch_equal(rhs, rhs_end, equal_right);
             while (lhs < lhs_end || rhs < rhs_end) {
-                auto left_range = fetch_equal(lhs, lhs_end, equal_left);
-                auto right_range = fetch_equal(rhs, rhs_end, equal_right);
-
                 int x = 0;
                 if (lhs < lhs_end && rhs < rhs_end) {
                     x = cmp(left_range.first, right_range.first);
@@ -65,20 +64,22 @@ public:
                     x = 1;
                 }
 
+                if (x == 0) {
+                    next_ranges.emplace_back(left_range, right_range);
+                }
                 if (x <= 0) {
-                    lhs = left_range.second;
                     for (size_t i = left_range.first; i < left_range.second; i++) {
                         (*_perm)[output_index++] = PermutationItem(kLeftIndex, i);
                     }
+                    lhs = left_range.second;
+                    left_range = fetch_equal(lhs, lhs_end, equal_left);
                 }
                 if (x >= 0) {
-                    rhs = right_range.second;
                     for (size_t i = right_range.first; i < right_range.second; i++) {
                         (*_perm)[output_index++] = PermutationItem(kRightIndex, i);
                     }
-                }
-                if (x == 0) {
-                    next_ranges.emplace_back(left_range, right_range);
+                    rhs = right_range.second;
+                    right_range = fetch_equal(rhs, rhs_end, equal_right);
                 }
             }
 

--- a/be/src/exec/vectorized/sorting/merge_column.cpp
+++ b/be/src/exec/vectorized/sorting/merge_column.cpp
@@ -130,10 +130,10 @@ public:
             return x;
         };
         auto cmp_left = [&](size_t lhs_index, size_t rhs_index) {
-            return SorterComparator<ValueType>::compare(left_data[lhs_index], left_data[rhs_index]) == 0;
+            return left_data[lhs_index] == left_data[rhs_index];
         };
         auto cmp_right = [&](size_t lhs_index, size_t rhs_index) {
-            return SorterComparator<ValueType>::compare(right_data[lhs_index], right_data[rhs_index]) == 0;
+            return right_data[lhs_index] == right_data[rhs_index];
         };
         return do_merge(cmp, cmp_left, cmp_right);
     }

--- a/be/src/exec/vectorized/sorting/merge_column.cpp
+++ b/be/src/exec/vectorized/sorting/merge_column.cpp
@@ -286,6 +286,12 @@ Status merge_sorted_chunks_two_way(const SortDescs& sort_desc, const SortedRun& 
     return MergeTwoChunk::merge_sorted_chunks_two_way(sort_desc, left, right, output);
 }
 
+Status merge_sorted_chunks_two_way(const SortDescs& sort_desc, const SortedRuns& left, const SortedRuns& right,
+                                   SortedRuns* output) {
+    CHECK(false) << "TODO";
+    return Status::NotSupported("TODO");
+}
+
 // Merge multiple chunks in two-way merge
 Status merge_sorted_chunks(const SortDescs& descs, const std::vector<ChunkPtr>& chunks, ChunkPtr* output) {
     std::vector<ChunkPtr> current(chunks);

--- a/be/src/exec/vectorized/sorting/sort_column.cpp
+++ b/be/src/exec/vectorized/sorting/sort_column.cpp
@@ -459,6 +459,7 @@ Status sort_vertical_chunks(const bool& cancel, const std::vector<Columns>& vert
 
 void append_by_permutation(Chunk* dst, const std::vector<ChunkPtr>& chunks, const Permutation& perm) {
     std::vector<const Chunk*> src;
+    src.reserve(chunks.size());
     for (auto& chunk : chunks) {
         src.push_back(chunk.get());
     }
@@ -473,6 +474,7 @@ void append_by_permutation(Chunk* dst, const std::vector<const Chunk*>& chunks, 
     DCHECK_EQ(dst->num_columns(), chunks[0]->columns().size());
     for (size_t col_index = 0; col_index < dst->columns().size(); col_index++) {
         Columns tmp_columns;
+        tmp_columns.reserve(chunks.size());
         for (auto chunk : chunks) {
             tmp_columns.push_back(chunk->get_column_by_index(col_index));
         }

--- a/be/src/exec/vectorized/sorting/sort_column.cpp
+++ b/be/src/exec/vectorized/sorting/sort_column.cpp
@@ -458,6 +458,14 @@ Status sort_vertical_chunks(const bool& cancel, const std::vector<Columns>& vert
 }
 
 void append_by_permutation(Chunk* dst, const std::vector<ChunkPtr>& chunks, const Permutation& perm) {
+    std::vector<const Chunk*> src;
+    for (auto& chunk : chunks) {
+        src.push_back(chunk.get());
+    }
+    append_by_permutation(dst, src, perm);
+}
+
+void append_by_permutation(Chunk* dst, const std::vector<const Chunk*>& chunks, const Permutation& perm) {
     if (chunks.empty() || perm.empty()) {
         return;
     }

--- a/be/src/exec/vectorized/sorting/sort_helper.h
+++ b/be/src/exec/vectorized/sorting/sort_helper.h
@@ -283,14 +283,11 @@ static inline int compare_chunk_row(const SortDescs& desc, const Columns& lhs, c
 
     int num_columns = desc.num_columns();
     for (int i = 0; i < num_columns; i++) {
-        DCHECK(desc.sort_orders[i] == 1 || desc.sort_orders[i] == -1);
-        DCHECK(desc.null_firsts[i] == 1 || desc.null_firsts[i] == -1);
-
         auto& lhs_column = lhs[i];
         auto& rhs_column = rhs[i];
-        int x = lhs_column->compare_at(lhs_row, rhs_row, *rhs_column, desc.null_firsts[i]);
+        int x = lhs_column->compare_at(lhs_row, rhs_row, *rhs_column, desc.get_column_desc(i).null_first);
         if (x != 0) {
-            return x * desc.sort_orders[i];
+            return x * desc.get_column_desc(i).sort_order;
         }
     }
     return 0;

--- a/be/src/exec/vectorized/sorting/sort_helper.h
+++ b/be/src/exec/vectorized/sorting/sort_helper.h
@@ -275,4 +275,27 @@ static inline Status sort_and_tie_helper(const bool& cancel, const Column* colum
     return Status::OK();
 }
 
+static inline int compare_chunk_row(const SortDescs& desc, const Chunk& lhs, const Chunk& rhs, size_t lhs_row,
+                                    size_t rhs_row) {
+    DCHECK_LT(lhs_row, lhs.num_rows());
+    DCHECK_LT(rhs_row, rhs.num_rows());
+    DCHECK_EQ(lhs.num_columns(), rhs.num_columns());
+    DCHECK_LE(desc.num_columns(), lhs.num_columns());
+    DCHECK_LE(desc.num_columns(), rhs.num_columns());
+
+    int num_columns = desc.num_columns();
+    for (int i = 0; i < num_columns; i++) {
+        DCHECK(desc.sort_orders[i] == 1 || desc.sort_orders[i] == -1);
+        DCHECK(desc.null_firsts[i] == 1 || desc.null_firsts[i] == -1);
+
+        auto& lhs_column = lhs.get_column_by_index(i);
+        auto& rhs_column = rhs.get_column_by_index(i);
+        int x = lhs_column->compare_at(lhs_row, rhs_row, *rhs_column, desc.null_firsts[i]);
+        if (x != 0) {
+            return x * desc.sort_orders[i];
+        }
+    }
+    return 0;
+}
+
 } // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/sorting/sort_helper.h
+++ b/be/src/exec/vectorized/sorting/sort_helper.h
@@ -275,21 +275,19 @@ static inline Status sort_and_tie_helper(const bool& cancel, const Column* colum
     return Status::OK();
 }
 
-static inline int compare_chunk_row(const SortDescs& desc, const Chunk& lhs, const Chunk& rhs, size_t lhs_row,
+static inline int compare_chunk_row(const SortDescs& desc, const Columns& lhs, const Columns& rhs, size_t lhs_row,
                                     size_t rhs_row) {
-    DCHECK_LT(lhs_row, lhs.num_rows());
-    DCHECK_LT(rhs_row, rhs.num_rows());
-    DCHECK_EQ(lhs.num_columns(), rhs.num_columns());
-    DCHECK_LE(desc.num_columns(), lhs.num_columns());
-    DCHECK_LE(desc.num_columns(), rhs.num_columns());
+    DCHECK_EQ(lhs.size(), rhs.size());
+    DCHECK_LE(desc.num_columns(), lhs.size());
+    DCHECK_LE(desc.num_columns(), rhs.size());
 
     int num_columns = desc.num_columns();
     for (int i = 0; i < num_columns; i++) {
         DCHECK(desc.sort_orders[i] == 1 || desc.sort_orders[i] == -1);
         DCHECK(desc.null_firsts[i] == 1 || desc.null_firsts[i] == -1);
 
-        auto& lhs_column = lhs.get_column_by_index(i);
-        auto& rhs_column = rhs.get_column_by_index(i);
+        auto& lhs_column = lhs[i];
+        auto& rhs_column = rhs[i];
         int x = lhs_column->compare_at(lhs_row, rhs_row, *rhs_column, desc.null_firsts[i]);
         if (x != 0) {
             return x * desc.sort_orders[i];

--- a/be/src/exec/vectorized/sorting/sort_permute.h
+++ b/be/src/exec/vectorized/sorting/sort_permute.h
@@ -24,6 +24,7 @@ struct PermutationItem {
     uint32_t permutation_index;
 
     PermutationItem() = default;
+    PermutationItem(uint32_t ci, uint32_t ii) : chunk_index(ci), index_in_chunk(ii), permutation_index(0) {}
     PermutationItem(uint32_t ci, uint32_t ii, uint32_t pi)
             : chunk_index(ci), index_in_chunk(ii), permutation_index(pi) {}
 };

--- a/be/src/exec/vectorized/sorting/sort_permute.h
+++ b/be/src/exec/vectorized/sorting/sort_permute.h
@@ -20,13 +20,9 @@ enum CompareStrategy {
 struct PermutationItem {
     uint32_t chunk_index;
     uint32_t index_in_chunk;
-    // TODO: remove this field
-    uint32_t permutation_index;
 
     PermutationItem() = default;
-    PermutationItem(uint32_t ci, uint32_t ii) : chunk_index(ci), index_in_chunk(ii), permutation_index(0) {}
-    PermutationItem(uint32_t ci, uint32_t ii, uint32_t pi)
-            : chunk_index(ci), index_in_chunk(ii), permutation_index(pi) {}
+    PermutationItem(uint32_t ci, uint32_t ii) : chunk_index(ci), index_in_chunk(ii) {}
 };
 
 // Permutate items in a single chunk, so `chunk_index` is unnecessary

--- a/be/src/exec/vectorized/sorting/sorting.h
+++ b/be/src/exec/vectorized/sorting/sorting.h
@@ -59,25 +59,29 @@ void append_by_permutation(Chunk* dst, const std::vector<const Chunk*>& chunks, 
 struct SortDesc {
     int sort_order;
     int null_first;
+
+    SortDesc() = default;
+    SortDesc(int order, int null) : sort_order(order), null_first(null) {}
 };
 
 struct SortDescs {
-    std::vector<int> sort_orders;
-    std::vector<int> null_firsts;
+    std::vector<SortDesc> descs;
 
     SortDescs() = default;
     ~SortDescs() = default;
-    SortDescs(const std::vector<int>& orders, const std::vector<int>& nulls)
-            : sort_orders(orders), null_firsts(nulls) {}
+    SortDescs(const std::vector<int>& orders, const std::vector<int>& nulls) {
+        DCHECK_EQ(orders.size(), nulls.size());
+        descs.reserve(orders.size());
+        for (int i = 0; i < orders.size(); i++) {
+            descs.push_back(SortDesc(orders[i], nulls[i]));
+        }
+    }
 
-    size_t num_columns() const { return sort_orders.size(); }
+    size_t num_columns() const { return descs.size(); }
 
     SortDesc get_column_desc(int col) const {
-        SortDesc desc;
-        DCHECK_LT(col, sort_orders.size());
-        desc.sort_order = sort_orders[col];
-        desc.null_first = null_firsts[col];
-        return desc;
+        DCHECK_LT(col, descs.size());
+        return descs[col];
     }
 };
 

--- a/be/src/exec/vectorized/sorting/sorting.h
+++ b/be/src/exec/vectorized/sorting/sorting.h
@@ -52,6 +52,8 @@ void build_tie_for_column(const ColumnPtr column, Tie* tie);
 // Append rows from permutation
 void append_by_permutation(Column* dst, const Columns& columns, const Permutation& perm);
 void append_by_permutation(Chunk* dst, const std::vector<ChunkPtr>& chunks, const Permutation& perm);
+void append_by_permutation(Chunk* dst, const std::vector<ChunkPtr>& chunks, const Permutation& perm, size_t start,
+                           size_t end);
 void append_by_permutation(Chunk* dst, const std::vector<const Chunk*>& chunks, const Permutation& perm);
 
 struct SortDesc {
@@ -132,11 +134,25 @@ struct SortedRun {
     }
 };
 
+// Multiple sorted chunks kept the order
+struct SortedRuns {
+    std::vector<SortedRun> chunks;
+
+    SortedRuns() = default;
+    ~SortedRuns() = default;
+    SortedRuns(ChunkPtr chunk) : chunks{SortedRun(chunk)} {}
+    SortedRuns(SortedRun run) : chunks{run} {}
+
+    size_t num_chunks() const { return chunks.size(); }
+};
+
 // Merge algorithms
 Status merge_sorted_chunks_two_way(const SortDescs& descs, const ChunkPtr left, const ChunkPtr right,
                                    Permutation* output);
 Status merge_sorted_chunks_two_way(const SortDescs& sort_desc, const SortedRun& left, const SortedRun& right,
                                    Permutation* output);
+Status merge_sorted_chunks_two_way(const SortDescs& sort_desc, const SortedRuns& left, const SortedRuns& right,
+                                   SortedRuns* output);
 Status merge_sorted_chunks(const SortDescs& descs, const std::vector<ChunkPtr>& chunks, ChunkPtr* output);
 
 // Merge in rowwise

--- a/be/src/exec/vectorized/sorting/sorting.h
+++ b/be/src/exec/vectorized/sorting/sorting.h
@@ -2,9 +2,11 @@
 
 #pragma once
 
+#include "column/chunk.h"
 #include "column/datum.h"
 #include "common/status.h"
 #include "exec/vectorized/sorting/sort_permute.h"
+#include "runtime/vectorized/chunk_cursor.h"
 
 namespace starrocks::vectorized {
 
@@ -50,5 +52,92 @@ void build_tie_for_column(const ColumnPtr column, Tie* tie);
 // Append rows from permutation
 void append_by_permutation(Column* dst, const Columns& columns, const Permutation& perm);
 void append_by_permutation(Chunk* dst, const std::vector<ChunkPtr>& chunks, const Permutation& perm);
+void append_by_permutation(Chunk* dst, const std::vector<const Chunk*>& chunks, const Permutation& perm);
+
+struct SortDesc {
+    int sort_order;
+    int null_first;
+};
+
+struct SortDescs {
+    std::vector<int> sort_orders;
+    std::vector<int> null_firsts;
+
+    SortDescs() = default;
+    ~SortDescs() = default;
+    SortDescs(const std::vector<int>& orders, const std::vector<int>& nulls)
+            : sort_orders(orders), null_firsts(nulls) {}
+
+    size_t num_columns() const { return sort_orders.size(); }
+
+    SortDesc get_column_desc(int col) const {
+        SortDesc desc;
+        DCHECK_LT(col, sort_orders.size());
+        desc.sort_order = sort_orders[col];
+        desc.null_first = null_firsts[col];
+        return desc;
+    }
+};
+
+struct SortedRun {
+    ChunkPtr chunk;
+    Columns orderby;
+    std::pair<uint32_t, uint32_t> range;
+
+    SortedRun() = default;
+    ~SortedRun() = default;
+    explicit SortedRun(ChunkPtr ichunk) : chunk(ichunk), orderby(ichunk->columns()), range(0, ichunk->num_rows()) {}
+    SortedRun(ChunkPtr ichunk, const Columns& columns)
+            : chunk(ichunk), orderby(columns), range(0, ichunk->num_rows()) {}
+    SortedRun(ChunkPtr ichunk, size_t start, size_t end)
+            : chunk(ichunk), orderby(ichunk->columns()), range(start, end) {}
+    SortedRun(const SortedRun& rhs) : chunk(rhs.chunk), orderby(rhs.orderby), range(rhs.range) {}
+    SortedRun& operator=(const SortedRun& rhs) {
+        if (&rhs == this) return *this;
+        chunk = rhs.chunk;
+        orderby = rhs.orderby;
+        range = rhs.range;
+        return *this;
+    }
+
+    size_t num_columns() const { return orderby.size(); }
+    size_t num_rows() const { return range.second - range.first; }
+    const Column* get_column(int index) const { return orderby[index].get(); }
+    bool empty() const { return range.second == range.first; }
+    void reset() {
+        chunk->reset();
+        orderby.clear();
+        range = {};
+    }
+    ChunkUniquePtr clone_chunk() {
+        if (range.first == 0) {
+            return chunk->clone_unique();
+        } else {
+            ChunkUniquePtr cloned = chunk->clone_empty(num_rows() - range.first);
+            cloned->append(*chunk, range.first, num_rows());
+            return cloned;
+        }
+    }
+
+    int compare_row(const SortDescs& desc, const SortedRun& rhs, size_t lhs_row, size_t rhs_row) const {
+        for (int i = 0; i < orderby.size(); i++) {
+            int x = get_column(i)->compare_at(lhs_row, rhs_row, *rhs.get_column(i), desc.get_column_desc(i).null_first);
+            if (x != 0) {
+                return x;
+            }
+        }
+        return 0;
+    }
+};
+
+// Merge algorithms
+Status merge_sorted_chunks_two_way(const SortDescs& descs, const ChunkPtr left, const ChunkPtr right,
+                                   Permutation* output);
+Status merge_sorted_chunks_two_way(const SortDescs& sort_desc, const SortedRun& left, const SortedRun& right,
+                                   Permutation* output);
+
+// Merge in rowwise
+Status merge_sorted_chunks_two_way_rowwise(const SortDescs& descs, const ChunkPtr left, const ChunkPtr right,
+                                           Permutation* output, size_t limit);
 
 } // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/sorting/sorting.h
+++ b/be/src/exec/vectorized/sorting/sorting.h
@@ -135,6 +135,7 @@ Status merge_sorted_chunks_two_way(const SortDescs& descs, const ChunkPtr left, 
                                    Permutation* output);
 Status merge_sorted_chunks_two_way(const SortDescs& sort_desc, const SortedRun& left, const SortedRun& right,
                                    Permutation* output);
+Status merge_sorted_chunks(const SortDescs& descs, const std::vector<ChunkPtr>& chunks, ChunkPtr* output);
 
 // Merge in rowwise
 Status merge_sorted_chunks_two_way_rowwise(const SortDescs& descs, const ChunkPtr left, const ChunkPtr right,

--- a/be/src/exec/vectorized/sorting/sorting.h
+++ b/be/src/exec/vectorized/sorting/sorting.h
@@ -79,6 +79,8 @@ struct SortDescs {
     }
 };
 
+// SortedRun represents part of sorted chunk, specified by the range
+// The chunk is sorted based on `orderby` columns
 struct SortedRun {
     ChunkPtr chunk;
     Columns orderby;

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -30,7 +30,6 @@ set(EXEC_FILES
         ./exec/column_value_range_test.cpp
         ./exec/vectorized/agg_hash_map_test.cpp
         ./exec/vectorized/csv_scanner_test.cpp
-        ./exec/vectorized/chunks_sorter_test.cpp
         ./exec/vectorized/chunks_sorter_heapsorter_test.cpp
         ./exec/vectorized/join_hash_map_test.cpp
         ./exec/vectorized/json_scanner_test.cpp

--- a/be/test/exec/CMakeLists.txt
+++ b/be/test/exec/CMakeLists.txt
@@ -31,6 +31,8 @@ ADD_BE_TEST(vectorized/repeat_node_test)
 ADD_BE_TEST(vectorized/arrow_converter_test)
 ADD_BE_TEST(vectorized/parquet_scanner_test)
 ADD_BE_TEST(schema_scanner/schema_columns_scanner_test)
+ADD_BE_TEST(vectorized/sorting_test)
+ADD_BE_TEST(vectorized/chunks_sorter_test)
 
 # Benchmarks
 ADD_BE_BENCH(vectorized/chunks_sorter_bench_test)

--- a/be/test/exec/vectorized/chunks_sorter_bench_test.cpp
+++ b/be/test/exec/vectorized/chunks_sorter_bench_test.cpp
@@ -515,9 +515,6 @@ static void BM_topn_buffered_chunks_tunned(benchmark::State& state) {
 static void BM_merge_heap(benchmark::State& state) {
     do_merge_bench(state, state.range(0), true);
 }
-static void BM_merge_cascades(benchmark::State& state) {
-    do_merge_bench(state, state.range(0), false);
-}
 static void BM_merge_vertical(benchmark::State& state) {
     do_merge_two_way(state, state.range(0));
 }
@@ -571,7 +568,6 @@ BENCHMARK(BM_topn_buffered_chunks_tunned)->RangeMultiplier(4)->Ranges({{10, 10'0
 
 // Merge
 BENCHMARK(BM_merge_heap)->DenseRange(2, 64, 4);
-BENCHMARK(BM_merge_cascades)->DenseRange(2, 64, 4);
 BENCHMARK(BM_merge_vertical)->DenseRange(2, 64, 4);
 
 static size_t plain_find_zero(const std::vector<uint8_t>& bytes) {

--- a/be/test/exec/vectorized/chunks_sorter_bench_test.cpp
+++ b/be/test/exec/vectorized/chunks_sorter_bench_test.cpp
@@ -2,9 +2,13 @@
 
 #include <benchmark/benchmark.h>
 #include <gtest/gtest.h>
+#include <testutil/assert.h>
 
+#include <memory>
+#include <numeric>
 #include <random>
 
+#include "column/chunk.h"
 #include "column/column_helper.h"
 #include "column/datum_tuple.h"
 #include "common/config.h"
@@ -12,9 +16,13 @@
 #include "exec/vectorized/chunks_sorter.h"
 #include "exec/vectorized/chunks_sorter_full_sort.h"
 #include "exec/vectorized/chunks_sorter_topn.h"
+#include "exec/vectorized/sorting/sort_helper.h"
+#include "exec/vectorized/sorting/sorting.h"
 #include "exprs/vectorized/column_ref.h"
 #include "runtime/runtime_state.h"
 #include "runtime/types.h"
+#include "runtime/vectorized/chunk_cursor.h"
+#include "runtime/vectorized/sorted_chunks_merger.h"
 
 namespace starrocks::vectorized {
 
@@ -29,6 +37,30 @@ public:
     }
 
     void TearDown() { _runtime_state.reset(); }
+
+    static std::tuple<ColumnPtr, std::unique_ptr<ColumnRef>> build_sorted_column(TypeDescriptor type_desc,
+                                                                                 int slot_index) {
+        DCHECK_EQ(TYPE_INT, type_desc.type);
+        using UniformInt = std::uniform_int_distribution<std::mt19937::result_type>;
+
+        ColumnPtr column = ColumnHelper::create_column(type_desc, false);
+        auto expr = std::make_unique<ColumnRef>(type_desc, slot_index);
+
+        std::random_device dev;
+        std::mt19937 rng(dev());
+        UniformInt uniform_int;
+        uniform_int.param(UniformInt::param_type(1, 100'000 * std::pow(2, slot_index)));
+
+        std::vector<int32_t> elements(config::vector_chunk_size);
+        std::generate(elements.begin(), elements.end(), [&]() { return uniform_int(rng); });
+        std::sort(elements.begin(), elements.end());
+
+        for (int32_t x : elements) {
+            column->append_datum(Datum((int32_t)x));
+        }
+
+        return {column, std::move(expr)};
+    }
 
     static std::tuple<ColumnPtr, std::unique_ptr<ColumnRef>> build_column(TypeDescriptor type_desc, int slot_index,
                                                                           bool low_card, bool nullable) {
@@ -237,6 +269,173 @@ static void do_bench(benchmark::State& state, SortAlgorithm sorter_algo, Compare
     suite.TearDown();
 }
 
+static void do_merge_bench(benchmark::State& state, int num_runs, bool use_merger = true) {
+    constexpr int num_columns = 3;
+    constexpr int num_chunks_per_run = 8;
+
+    ChunkSorterBase suite;
+    suite.SetUp();
+    RuntimeState* runtime_state = suite._runtime_state.get();
+
+    Columns columns;
+    std::vector<std::unique_ptr<ColumnRef>> exprs;
+    std::vector<ExprContext*> sort_exprs;
+    std::vector<bool> asc_arr;
+    std::vector<bool> null_first;
+    Chunk::SlotHashMap map;
+    TypeDescriptor type_desc = TypeDescriptor(TYPE_INT);
+
+    for (int i = 0; i < num_columns; i++) {
+        auto [column, expr] = suite.build_sorted_column(type_desc, i);
+        columns.push_back(column);
+        exprs.emplace_back(std::move(expr));
+        sort_exprs.push_back(new ExprContext(exprs.back().get()));
+        asc_arr.push_back(true);
+        null_first.push_back(true);
+        map[i] = i;
+    }
+    ChunkPtr base_chunk = std::make_shared<Chunk>(columns, map);
+
+    int64_t num_rows = 0;
+    for (auto _ : state) {
+        ChunkSuppliers chunk_suppliers;
+        ChunkProbeSuppliers chunk_probe_suppliers;
+        ChunkHasSuppliers chunk_has_suppliers;
+        std::vector<int> chunk_input_index(num_runs, 0);
+        std::vector<int> chunk_probe_index(num_runs, 0);
+
+        for (int i = 0; i < num_runs; i++) {
+            ChunkSupplier chunk_supplier = [&, i](Chunk** output) -> Status {
+                if (chunk_input_index[i]++ > num_chunks_per_run) {
+                    *output = nullptr;
+                } else {
+                    // state.PauseTiming();
+                    auto cloned = base_chunk->clone_unique();
+                    for (auto& col : cloned->columns()) {
+                        Int32Column::Ptr intcolumn = ColumnHelper::as_column<Int32Column>(col);
+                        int start = chunk_input_index[i] * config::vector_chunk_size;
+                        for (auto& x : intcolumn->get_data()) {
+                            x += start;
+                        }
+                    }
+                    if (output) *output = cloned.release();
+                    // state.ResumeTiming();
+                }
+                return Status::OK();
+            };
+            ChunkProbeSupplier chunk_probe_supplier = [&, i](Chunk** output) -> bool {
+                if (chunk_probe_index[i]++ > num_chunks_per_run) {
+                    *output = nullptr;
+                    return false;
+                } else {
+                    // state.PauseTiming();
+                    auto cloned = base_chunk->clone_unique();
+                    for (auto& col : cloned->columns()) {
+                        Int32Column::Ptr intcolumn = ColumnHelper::as_column<Int32Column>(col);
+                        int start = chunk_input_index[i] * config::vector_chunk_size;
+                        for (auto& x : intcolumn->get_data()) {
+                            x += start;
+                        }
+                    }
+                    if (output) *output = cloned.release();
+                    // state.ResumeTiming();
+
+                    return true;
+                }
+            };
+            ChunkHasSupplier chunk_has_supplier = [&]() -> bool { return true; };
+            chunk_suppliers.emplace_back(chunk_supplier);
+            chunk_probe_suppliers.emplace_back(chunk_probe_supplier);
+            chunk_has_suppliers.emplace_back(chunk_has_supplier);
+        }
+
+        if (use_merger) {
+            SortedChunksMerger merger(runtime_state, true);
+            ASSERT_OK(merger.init_for_pipeline(chunk_suppliers, chunk_probe_suppliers, chunk_has_suppliers, &sort_exprs,
+                                               &asc_arr, &null_first));
+            merger.is_data_ready();
+            std::atomic<bool> eos{false};
+            bool should_exit{false};
+            while (!eos && !should_exit) {
+                ChunkPtr chunk;
+                ASSERT_OK(merger.get_next_for_pipeline(&chunk, &eos, &should_exit));
+                num_rows += chunk->num_rows();
+            }
+        } else {
+            std::vector<std::unique_ptr<SimpleChunkSortCursor>> input_cursors;
+            for (int run = 0; run < num_runs; run++) {
+                ChunkProvider provider = [&, run](Chunk** output, bool* eos) {
+                    if (!chunk_has_suppliers[run]()) {
+                        return false;
+                    }
+                    if (!chunk_probe_suppliers[run](output)) {
+                        *eos = true;
+                    }
+                    return true;
+                };
+                input_cursors.push_back(std::make_unique<SimpleChunkSortCursor>(provider, &sort_exprs));
+            }
+
+            SortDescs sort_desc({1, 1, 1}, {-1, -1, -1});
+            std::vector<ChunkUniquePtr> output_chunks;
+            merge_sorted_cursor_cascade(sort_desc, std::move(input_cursors), [&](ChunkUniquePtr chunk) {
+                num_rows += chunk->num_rows();
+                output_chunks.push_back(std::move(chunk));
+                return Status::OK();
+            });
+        }
+    }
+    state.SetItemsProcessed(num_rows);
+
+    suite.TearDown();
+}
+
+static void do_merge_two_way(benchmark::State& state, int num_runs) {
+    ChunkSorterBase suite;
+    suite.SetUp();
+
+    constexpr int num_columns = 3;
+    Columns columns;
+    std::vector<std::unique_ptr<ColumnRef>> exprs;
+    std::vector<ExprContext*> sort_exprs;
+    std::vector<bool> asc_arr;
+    std::vector<bool> null_first;
+    Chunk::SlotHashMap map;
+    TypeDescriptor type_desc = TypeDescriptor(TYPE_INT);
+
+    for (int i = 0; i < num_columns; i++) {
+        auto [column, expr] = suite.build_sorted_column(type_desc, i);
+        columns.push_back(column);
+        exprs.emplace_back(std::move(expr));
+        sort_exprs.push_back(new ExprContext(exprs.back().get()));
+        asc_arr.push_back(true);
+        null_first.push_back(true);
+        map[i] = i;
+    }
+    ChunkPtr chunk1 = std::make_shared<Chunk>(columns, map);
+    ChunkPtr chunk2 = std::make_shared<Chunk>(columns, map);
+
+    int64_t num_rows = 0;
+    SortDescs sort_desc({1, 1, 1}, {-1, -1, -1});
+    for (auto _ : state) {
+        ChunkPtr merged(chunk1->clone_unique().release());
+        for (int i = 1; i < num_runs; i++) {
+            Permutation perm;
+            if (i % 2 == 0) {
+                merge_sorted_chunks_two_way(sort_desc, merged, chunk1, &perm);
+                append_by_permutation(merged.get(), {merged, chunk1}, perm);
+            } else {
+                merge_sorted_chunks_two_way(sort_desc, merged, chunk2, &perm);
+                append_by_permutation(merged.get(), {merged, chunk2}, perm);
+            }
+        }
+        num_rows += merged->num_rows();
+    }
+
+    state.SetItemsProcessed(num_rows);
+    suite.TearDown();
+}
+
 // Sort full data: ORDER BY
 static void BM_fullsort_row_wise(benchmark::State& state) {
     do_bench(state, FullSort, RowWise, TYPE_INT, state.range(0), state.range(1));
@@ -312,6 +511,17 @@ static void BM_topn_buffered_chunks_tunned(benchmark::State& state) {
     do_bench(state, MergeSort, ColumnWise, TYPE_INT, 4096, 2, params);
 }
 
+// Merge sorted runs
+static void BM_merge_heap(benchmark::State& state) {
+    do_merge_bench(state, state.range(0), true);
+}
+static void BM_merge_cascades(benchmark::State& state) {
+    do_merge_bench(state, state.range(0), false);
+}
+static void BM_merge_vertical(benchmark::State& state) {
+    do_merge_two_way(state, state.range(0));
+}
+
 static void CustomArgsFull(benchmark::internal::Benchmark* b) {
     // num_chunks
     for (int num_chunks = 64; num_chunks <= 32768; num_chunks *= 8) {
@@ -358,6 +568,11 @@ BENCHMARK(BM_topn_limit_mergesort_colwise)->Apply(CustomArgsLimit);
 BENCHMARK(BM_topn_limit_mergesort_colwise_nullable)->Apply(CustomArgsLimit);
 BENCHMARK(BM_topn_buffered_chunks)->RangeMultiplier(4)->Ranges({{10, 10'000}, {100, 100'000}});
 BENCHMARK(BM_topn_buffered_chunks_tunned)->RangeMultiplier(4)->Ranges({{10, 10'000}, {100, 100'000}});
+
+// Merge
+BENCHMARK(BM_merge_heap)->DenseRange(2, 64, 4);
+BENCHMARK(BM_merge_cascades)->DenseRange(2, 64, 4);
+BENCHMARK(BM_merge_vertical)->DenseRange(2, 64, 4);
 
 static size_t plain_find_zero(const std::vector<uint8_t>& bytes) {
     for (size_t i = 0; i < bytes.size(); i++) {

--- a/be/test/exec/vectorized/chunks_sorter_bench_test.cpp
+++ b/be/test/exec/vectorized/chunks_sorter_bench_test.cpp
@@ -497,7 +497,7 @@ static void BM_topn_buffered_chunks_tunned(benchmark::State& state) {
 static void BM_merge_heap(benchmark::State& state) {
     do_heap_merge(state, state.range(0), true);
 }
-static void BM_merge_vertical(benchmark::State& state) {
+static void BM_merge_columnwise(benchmark::State& state) {
     do_merge_two_way(state, state.range(0));
 }
 
@@ -550,7 +550,7 @@ BENCHMARK(BM_topn_buffered_chunks_tunned)->RangeMultiplier(4)->Ranges({{10, 10'0
 
 // Merge
 BENCHMARK(BM_merge_heap)->DenseRange(2, 64, 4);
-BENCHMARK(BM_merge_vertical)->DenseRange(2, 64, 4);
+BENCHMARK(BM_merge_columnwise)->DenseRange(2, 64, 4);
 
 static size_t plain_find_zero(const std::vector<uint8_t>& bytes) {
     for (size_t i = 0; i < bytes.size(); i++) {

--- a/be/test/exec/vectorized/chunks_sorter_bench_test.cpp
+++ b/be/test/exec/vectorized/chunks_sorter_bench_test.cpp
@@ -362,27 +362,7 @@ static void do_merge_bench(benchmark::State& state, int num_runs, bool use_merge
                 num_rows += chunk->num_rows();
             }
         } else {
-            std::vector<std::unique_ptr<SimpleChunkSortCursor>> input_cursors;
-            for (int run = 0; run < num_runs; run++) {
-                ChunkProvider provider = [&, run](Chunk** output, bool* eos) {
-                    if (!chunk_has_suppliers[run]()) {
-                        return false;
-                    }
-                    if (!chunk_probe_suppliers[run](output)) {
-                        *eos = true;
-                    }
-                    return true;
-                };
-                input_cursors.push_back(std::make_unique<SimpleChunkSortCursor>(provider, &sort_exprs));
-            }
-
-            SortDescs sort_desc({1, 1, 1}, {-1, -1, -1});
-            std::vector<ChunkUniquePtr> output_chunks;
-            merge_sorted_cursor_cascade(sort_desc, std::move(input_cursors), [&](ChunkUniquePtr chunk) {
-                num_rows += chunk->num_rows();
-                output_chunks.push_back(std::move(chunk));
-                return Status::OK();
-            });
+            CHECK(false) << "TODO";
         }
     }
     state.SetItemsProcessed(num_rows);

--- a/be/test/exec/vectorized/chunks_sorter_bench_test.cpp
+++ b/be/test/exec/vectorized/chunks_sorter_bench_test.cpp
@@ -271,7 +271,7 @@ static void do_bench(benchmark::State& state, SortAlgorithm sorter_algo, Compare
 
 static void do_heap_merge(benchmark::State& state, int num_runs, bool use_merger = true) {
     constexpr int num_columns = 3;
-    constexpr int num_chunks_per_run = 8;
+    constexpr int num_chunks_per_run = 1;
 
     ChunkSorterBase suite;
     suite.SetUp();
@@ -306,42 +306,25 @@ static void do_heap_merge(benchmark::State& state, int num_runs, bool use_merger
 
         for (int i = 0; i < num_runs; i++) {
             ChunkSupplier chunk_supplier = [&, i](Chunk** output) -> Status {
-                if (chunk_input_index[i]++ > num_chunks_per_run) {
-                    *output = nullptr;
-                } else {
-                    // state.PauseTiming();
-                    auto cloned = base_chunk->clone_unique();
-                    for (auto& col : cloned->columns()) {
-                        Int32Column::Ptr intcolumn = ColumnHelper::as_column<Int32Column>(col);
-                        int start = chunk_input_index[i] * config::vector_chunk_size;
-                        for (auto& x : intcolumn->get_data()) {
-                            x += start;
-                        }
+                if (output) {
+                    if (++chunk_input_index[i] > num_chunks_per_run) {
+                        *output = nullptr;
+                    } else {
+                        *output = base_chunk->clone_unique().release();
                     }
-                    if (output) *output = cloned.release();
-                    // state.ResumeTiming();
                 }
                 return Status::OK();
             };
             ChunkProbeSupplier chunk_probe_supplier = [&, i](Chunk** output) -> bool {
-                if (chunk_probe_index[i]++ > num_chunks_per_run) {
-                    *output = nullptr;
-                    return false;
-                } else {
-                    // state.PauseTiming();
-                    auto cloned = base_chunk->clone_unique();
-                    for (auto& col : cloned->columns()) {
-                        Int32Column::Ptr intcolumn = ColumnHelper::as_column<Int32Column>(col);
-                        int start = chunk_input_index[i] * config::vector_chunk_size;
-                        for (auto& x : intcolumn->get_data()) {
-                            x += start;
-                        }
+                if (output) {
+                    if (++chunk_probe_index[i] > num_chunks_per_run) {
+                        *output = nullptr;
+                        return false;
+                    } else {
+                        *output = base_chunk->clone_unique().release();
                     }
-                    if (output) *output = cloned.release();
-                    // state.ResumeTiming();
-
-                    return true;
                 }
+                return true;
             };
             ChunkHasSupplier chunk_has_supplier = [&]() -> bool { return true; };
             chunk_suppliers.emplace_back(chunk_supplier);

--- a/be/test/exec/vectorized/chunks_sorter_test.cpp
+++ b/be/test/exec/vectorized/chunks_sorter_test.cpp
@@ -895,3 +895,8 @@ TEST_F(ChunksSorterTest, test_tie) {
 }
 
 } // namespace starrocks::vectorized
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/be/test/exec/vectorized/sorting_test.cpp
+++ b/be/test/exec/vectorized/sorting_test.cpp
@@ -116,6 +116,14 @@ INSTANTIATE_TEST_SUITE_P(
             {3, 4, 5}
         },
         std::vector<std::vector<int32_t>>{
+            {1, 2, 2},
+            {2, 2, 3}
+        },
+        std::vector<std::vector<int32_t>>{
+            {2, 2, 2},
+            {2, 2, 3}
+        },
+        std::vector<std::vector<int32_t>>{
                 std::vector<int32_t>{1, 1, 1, 2, 2, 3, 4, 5, 6}, 
                 std::vector<int32_t>{1, 2, 2, 2, 3, 3, 6, 7, 8},
                 std::vector<int32_t>{1, 2, 2, 2, 3, 3, 6, 7, 8}, 

--- a/be/test/exec/vectorized/sorting_test.cpp
+++ b/be/test/exec/vectorized/sorting_test.cpp
@@ -77,92 +77,9 @@ static ColumnPtr build_sorted_column(TypeDescriptor type_desc, int slot_index, i
     return column;
 }
 
-TEST(MergeTest, merge_sorted_cursor_two_way) {
-    constexpr int num_columns = 3;
-    constexpr int num_chunks = 3;
-    constexpr int chunk_size = 10;
+} // namespace starrocks::vectorized
 
-    std::vector<std::unique_ptr<ColumnRef>> exprs;
-    std::vector<ExprContext*> sort_exprs;
-    std::vector<bool> asc_arr;
-    std::vector<bool> null_first;
-    Chunk::SlotHashMap map;
-    TypeDescriptor type_desc = TypeDescriptor(TYPE_INT);
-
-    for (int i = 0; i < num_columns; i++) {
-        auto expr = std::make_unique<ColumnRef>(type_desc, i);
-        exprs.emplace_back(std::move(expr));
-        sort_exprs.push_back(new ExprContext(exprs.back().get()));
-        asc_arr.push_back(true);
-        null_first.push_back(true);
-        map[i] = i;
-    }
-
-    std::vector<std::unique_ptr<Chunk>> left_chunks;
-    std::vector<std::unique_ptr<Chunk>> right_chunks;
-    int left_index = 0;
-    int right_index = 0;
-    for (int i = 0; i < num_chunks; i++) {
-        Columns left_columns, right_columns;
-        for (int k = 0; k < num_columns; k++) {
-            left_columns.push_back(build_sorted_column(type_desc, k, i * chunk_size * (k + 1), chunk_size, k + 1));
-            right_columns.push_back(
-                    build_sorted_column(type_desc, k, (i + 1) * chunk_size * (k + 1), chunk_size, k + 1));
-        }
-
-        left_chunks.push_back(std::make_unique<Chunk>(left_columns, map));
-        right_chunks.push_back(std::make_unique<Chunk>(right_columns, map));
-    }
-    for (auto& chunk : left_chunks) {
-        for (int i = 0; i < chunk->num_rows(); i++) {
-            fmt::print("left_chunk row: {}\n", chunk->debug_row(i));
-        }
-    }
-    for (auto& chunk : right_chunks) {
-        for (int i = 0; i < chunk->num_rows(); i++) {
-            fmt::print("right_chunk row: {}\n", chunk->debug_row(i));
-        }
-    }
-
-    ChunkProvider left_chunk_provider = [&](Chunk** chunk, bool* eos) {
-        if (left_index >= left_chunks.size()) {
-            *eos = true;
-            return false;
-        }
-        if (chunk && eos) {
-            *chunk = left_chunks[left_index++].release();
-        }
-        return true;
-    };
-
-    ChunkProvider right_chunk_provider = [&](Chunk** chunk, bool* eos) {
-        if (right_index >= right_chunks.size()) {
-            *eos = true;
-            return false;
-        }
-        if (chunk && eos) {
-            *chunk = right_chunks[right_index++].release();
-        }
-        return true;
-    };
-
-    auto left_cursor = std::make_unique<SimpleChunkSortCursor>(left_chunk_provider, &sort_exprs);
-    auto right_cursor = std::make_unique<SimpleChunkSortCursor>(right_chunk_provider, &sort_exprs);
-    std::vector<ChunkUniquePtr> output_chunks;
-    ChunkConsumer consumer = [&](ChunkUniquePtr chunk) {
-        output_chunks.push_back(std::move(chunk));
-        return Status::OK();
-    };
-    SortDescs sort_desc({1, 1, 1}, {-1, -1, -1});
-    merge_sorted_cursor_two_way(sort_desc, std::move(left_cursor), std::move(right_cursor), consumer);
-
-    for (auto& chunk : output_chunks) {
-        for (int i = 0; i < chunk->num_rows(); i++) {
-            fmt::print("row: {}\n", chunk->debug_row(i));
-            if (i > 0) {
-                int x = compare_chunk_row(sort_desc, *chunk, *chunk, i - 1, i);
-                ASSERT_LE(x, 0);
-            }
-        }
-    }
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }

--- a/be/test/exec/vectorized/sorting_test.cpp
+++ b/be/test/exec/vectorized/sorting_test.cpp
@@ -1,0 +1,168 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#include "exec/vectorized/sorting/sorting.h"
+
+#include <gtest/gtest.h>
+
+#include <random>
+
+#include "column/chunk.h"
+#include "column/column_helper.h"
+#include "exec/vectorized/sorting/sort_helper.h"
+#include "exprs/vectorized/column_ref.h"
+#include "runtime/vectorized/chunk_cursor.h"
+
+namespace starrocks::vectorized {
+
+TEST(MergeTest, merge_sorter_chunks_two_way) {
+    TypeDescriptor type_desc = TypeDescriptor(TYPE_INT);
+    ColumnPtr col1 = ColumnHelper::create_column(type_desc, false);
+    ColumnPtr col2 = ColumnHelper::create_column(type_desc, false);
+    ColumnPtr col3 = ColumnHelper::create_column(type_desc, false);
+    ColumnPtr col4 = ColumnHelper::create_column(type_desc, false);
+    std::vector<int32_t> elements_col1{1, 1, 1, 2, 2, 3, 4, 5, 6};
+    std::vector<int32_t> elements_col2{1, 2, 2, 2, 3, 3, 6, 7, 8};
+    std::vector<int32_t> elements_col3{1, 2, 2, 2, 3, 3, 6, 7, 8};
+    std::vector<int32_t> elements_col4{2, 3, 4, 4, 4, 8, 9, 7, 11};
+
+    for (int i = 0; i < elements_col1.size(); i++) {
+        col1->append_datum(Datum(elements_col1[i]));
+        col2->append_datum(Datum(elements_col2[i]));
+        col3->append_datum(Datum(elements_col3[i]));
+        col4->append_datum(Datum(elements_col4[i]));
+    }
+    Chunk::SlotHashMap map;
+    map[0] = 0;
+    map[1] = 1;
+
+    ChunkPtr chunk1 = std::make_shared<Chunk>(Columns{col1, col3}, map);
+    ChunkPtr chunk2 = std::make_shared<Chunk>(Columns{col2, col4}, map);
+    Permutation perm;
+    SortDescs sort_desc({1, 1}, {-1, -1});
+    merge_sorted_chunks_two_way(sort_desc, chunk1, chunk2, &perm);
+
+    size_t expected_size = col1->size() + col2->size();
+    std::unique_ptr<Chunk> output = chunk1->clone_empty();
+    append_by_permutation(output.get(), std::vector<ChunkPtr>{chunk1, chunk2}, perm);
+    ASSERT_EQ(expected_size, perm.size());
+    Int32Column* output_column1 = down_cast<Int32Column*>(output->get_column_by_index(0).get());
+    Int32Column* output_column2 = down_cast<Int32Column*>(output->get_column_by_index(0).get());
+    Int32Column::Container& data1 = output_column1->get_data();
+    Int32Column::Container& data2 = output_column2->get_data();
+    std::vector<std::tuple<int32_t, int32_t>> rows;
+    for (int i = 0; i < data1.size(); i++) {
+        rows.emplace_back(data1[i], data2[i]);
+    }
+
+    ASSERT_EQ(expected_size, output_column1->size());
+    ASSERT_EQ(expected_size, data1.size());
+    ASSERT_TRUE(std::is_sorted(rows.begin(), rows.end(),
+                               [](auto x, auto y) {
+                                   if (std::get<0>(x) != std::get<0>(y)) {
+                                       return std::get<0>(x) < std::get<0>(y);
+                                   }
+                                   return std::get<1>(x) < std::get<1>(y);
+                               }))
+            << "merged data: " << fmt::format("{}", fmt::join(data1, ", "));
+}
+
+static ColumnPtr build_sorted_column(TypeDescriptor type_desc, int slot_index, int32_t start, int32_t count,
+                                     int32_t step) {
+    DCHECK_EQ(TYPE_INT, type_desc.type);
+
+    ColumnPtr column = ColumnHelper::create_column(type_desc, false);
+    for (int i = 0; i < count; i++) {
+        column->append_datum(Datum(start + step * i));
+    }
+    return column;
+}
+
+TEST(MergeTest, merge_sorted_cursor_two_way) {
+    constexpr int num_columns = 3;
+    constexpr int num_chunks = 3;
+    constexpr int chunk_size = 10;
+
+    std::vector<std::unique_ptr<ColumnRef>> exprs;
+    std::vector<ExprContext*> sort_exprs;
+    std::vector<bool> asc_arr;
+    std::vector<bool> null_first;
+    Chunk::SlotHashMap map;
+    TypeDescriptor type_desc = TypeDescriptor(TYPE_INT);
+
+    for (int i = 0; i < num_columns; i++) {
+        auto expr = std::make_unique<ColumnRef>(type_desc, i);
+        exprs.emplace_back(std::move(expr));
+        sort_exprs.push_back(new ExprContext(exprs.back().get()));
+        asc_arr.push_back(true);
+        null_first.push_back(true);
+        map[i] = i;
+    }
+
+    std::vector<std::unique_ptr<Chunk>> left_chunks;
+    std::vector<std::unique_ptr<Chunk>> right_chunks;
+    int left_index = 0;
+    int right_index = 0;
+    for (int i = 0; i < num_chunks; i++) {
+        Columns left_columns, right_columns;
+        for (int k = 0; k < num_columns; k++) {
+            left_columns.push_back(build_sorted_column(type_desc, k, i * chunk_size * (k + 1), chunk_size, k + 1));
+            right_columns.push_back(
+                    build_sorted_column(type_desc, k, (i + 1) * chunk_size * (k + 1), chunk_size, k + 1));
+        }
+
+        left_chunks.push_back(std::make_unique<Chunk>(left_columns, map));
+        right_chunks.push_back(std::make_unique<Chunk>(right_columns, map));
+    }
+    for (auto& chunk : left_chunks) {
+        for (int i = 0; i < chunk->num_rows(); i++) {
+            fmt::print("left_chunk row: {}\n", chunk->debug_row(i));
+        }
+    }
+    for (auto& chunk : right_chunks) {
+        for (int i = 0; i < chunk->num_rows(); i++) {
+            fmt::print("right_chunk row: {}\n", chunk->debug_row(i));
+        }
+    }
+
+    ChunkProvider left_chunk_provider = [&](Chunk** chunk, bool* eos) {
+        if (left_index >= left_chunks.size()) {
+            *eos = true;
+            return false;
+        }
+        if (chunk && eos) {
+            *chunk = left_chunks[left_index++].release();
+        }
+        return true;
+    };
+
+    ChunkProvider right_chunk_provider = [&](Chunk** chunk, bool* eos) {
+        if (right_index >= right_chunks.size()) {
+            *eos = true;
+            return false;
+        }
+        if (chunk && eos) {
+            *chunk = right_chunks[right_index++].release();
+        }
+        return true;
+    };
+
+    auto left_cursor = std::make_unique<SimpleChunkSortCursor>(left_chunk_provider, &sort_exprs);
+    auto right_cursor = std::make_unique<SimpleChunkSortCursor>(right_chunk_provider, &sort_exprs);
+    std::vector<ChunkUniquePtr> output_chunks;
+    ChunkConsumer consumer = [&](ChunkUniquePtr chunk) {
+        output_chunks.push_back(std::move(chunk));
+        return Status::OK();
+    };
+    SortDescs sort_desc({1, 1, 1}, {-1, -1, -1});
+    merge_sorted_cursor_two_way(sort_desc, std::move(left_cursor), std::move(right_cursor), consumer);
+
+    for (auto& chunk : output_chunks) {
+        for (int i = 0; i < chunk->num_rows(); i++) {
+            fmt::print("row: {}\n", chunk->debug_row(i));
+            if (i > 0) {
+                int x = compare_chunk_row(sort_desc, *chunk, *chunk, i - 1, i);
+                ASSERT_LE(x, 0);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others


## Summary
Implement a column-wise merge algorithm:
1. Merge the first column, record the equal rows into a equal-range
2. Merge the second column within the equal-range of previous column
3. Repeat until no equal-range or last column

The advantage of this merge algorithm is:
1. Eliminate the `compare` function call during merge
2. Improve the memory access efficiency by sequential iterate two columns

## Experiment

TODO