### PR TITLE
[WIP] [Enhancement] refactor exchange merge sort

### DIFF
--- a/be/src/runtime/data_stream_recvr.cpp
+++ b/be/src/runtime/data_stream_recvr.cpp
@@ -34,6 +34,7 @@
 #include "column/chunk.h"
 #include "exec/sort_exec_exprs.h"
 #include "gen_cpp/data.pb.h"
+#include "runtime/chunk_cursor.h"
 #include "runtime/current_thread.h"
 #include "runtime/data_stream_mgr.h"
 #include "runtime/exec_env.h"
@@ -90,29 +91,27 @@ Status DataStreamRecvr::create_merger_for_pipeline(RuntimeState* state, const So
                                                    const std::vector<bool>* is_asc,
                                                    const std::vector<bool>* is_null_first) {
     DCHECK(_is_merging);
-    _chunks_merger = std::make_unique<vectorized::SortedChunksMerger>(state, _keep_order);
-    vectorized::ChunkSuppliers chunk_suppliers;
-    for (SenderQueue* q : _sender_queues) {
-        // we willn't use chunk_supplier in pipeline.
-        auto f = [q](vectorized::Chunk** chunk) -> Status { return Status::OK(); };
-        chunk_suppliers.emplace_back(std::move(f));
-    }
-    vectorized::ChunkProbeSuppliers chunk_probe_suppliers;
-    for (SenderQueue* q : _sender_queues) {
-        // we use chunk_probe_supplier in pipeline.
-        auto f = [q](vectorized::Chunk** chunk) -> bool { return q->try_get_chunk(chunk); };
-        chunk_probe_suppliers.emplace_back(std::move(f));
-    }
-    vectorized::ChunkHasSuppliers chunk_has_suppliers;
-    for (SenderQueue* q : _sender_queues) {
-        // we use chunk_has_supplier in pipeline.
-        auto f = [q]() -> bool { return q->has_chunk(); };
-        chunk_has_suppliers.emplace_back(std::move(f));
-    }
+    _chunks_merger = nullptr;
+    // TODO: set profile
+    _cascade_merger = std::make_unique<vectorized::CascadeChunkMerger>(state, state->runtime_profile());
 
-    RETURN_IF_ERROR(_chunks_merger->init_for_pipeline(chunk_suppliers, chunk_probe_suppliers, chunk_has_suppliers,
-                                                      &(exprs->lhs_ordering_expr_ctxs()), is_asc, is_null_first));
-    _chunks_merger->set_profile(_profile.get());
+    std::vector<vectorized::ChunkProvider> providers;
+    for (SenderQueue* q : _sender_queues) {
+        vectorized::ChunkProvider provider = [q](vectorized::ChunkUniquePtr* out_chunk, bool* eos) -> bool {
+            // data ready
+            if (out_chunk == nullptr || eos == nullptr) {
+                return q->has_chunk();
+            }
+            vectorized::Chunk* chunk;
+            if (q->try_get_chunk(&chunk)) {
+                out_chunk->reset(chunk);
+                return true;
+            }
+            return false;
+        };
+        providers.push_back(std::move(provider));
+    }
+    RETURN_IF_ERROR(_cascade_merger->init(providers, &(exprs->lhs_ordering_expr_ctxs()), is_asc, is_null_first));
     return Status::OK();
 }
 
@@ -180,12 +179,16 @@ Status DataStreamRecvr::get_next(vectorized::ChunkPtr* chunk, bool* eos) {
 }
 
 Status DataStreamRecvr::get_next_for_pipeline(vectorized::ChunkPtr* chunk, std::atomic<bool>* eos, bool* should_exit) {
-    DCHECK(_chunks_merger.get() != nullptr);
-    return _chunks_merger->get_next_for_pipeline(chunk, eos, should_exit);
+    DCHECK(_cascade_merger);
+    return _cascade_merger->get_next(chunk, eos, should_exit);
 }
 
 bool DataStreamRecvr::is_data_ready() {
-    return _chunks_merger->is_data_ready();
+    if (_chunks_merger) {
+        return _chunks_merger->is_data_ready();
+    } else {
+        return _cascade_merger->is_data_ready();
+    }
 }
 
 Status DataStreamRecvr::add_chunks(const PTransmitChunkParams& request, ::google::protobuf::Closure** done) {
@@ -226,6 +229,7 @@ void DataStreamRecvr::close() {
     _mgr->deregister_recvr(fragment_instance_id(), dest_node_id());
     _mgr = nullptr;
     _chunks_merger.reset();
+    _cascade_merger.reset();
 
     _closure_block_timer->update(_closure_block_timer->value() / std::max(1, _degree_of_parallelism));
 }

--- a/be/src/runtime/data_stream_recvr.h
+++ b/be/src/runtime/data_stream_recvr.h
@@ -38,7 +38,8 @@ namespace starrocks {
 
 namespace vectorized {
 class SortedChunksMerger;
-}
+class CascadeChunkMerger;
+} // namespace vectorized
 
 class DataStreamMgr;
 class MemTracker;
@@ -172,6 +173,7 @@ private:
 
     // vectorized::SortedChunksMerger merges chunks from different senders.
     std::unique_ptr<vectorized::SortedChunksMerger> _chunks_merger;
+    std::unique_ptr<vectorized::CascadeChunkMerger> _cascade_merger;
 
     // Pool of sender queues.
     ObjectPool _sender_queue_pool;

--- a/be/src/runtime/sorted_chunks_merger.cpp
+++ b/be/src/runtime/sorted_chunks_merger.cpp
@@ -4,6 +4,9 @@
 
 #include "column/chunk.h"
 #include "exec/sort_exec_exprs.h"
+#include "exec/vectorized/sorting/sorting.h"
+#include "runtime/chunk_cursor.h"
+#include "runtime/runtime_state.h"
 
 namespace starrocks::vectorized {
 
@@ -95,7 +98,7 @@ void SortedChunksMerger::init_for_min_heap() {
         _min_heap.reserve(_cursors.size());
         for (auto& cursor_ptr : _cursors) {
             ChunkCursor* cursor = cursor_ptr.get();
-            cursor->reset_with_next_chunk_for_pipeline();
+            cursor->next_chunk_for_pipeline();
             cursor->next_for_pipeline();
             if (cursor->is_valid()) {
                 _min_heap.push_back(cursor);
@@ -284,6 +287,42 @@ void SortedChunksMerger::collect_merged_chunks(ChunkPtr* chunk) {
     _result_chunk->set_num_rows(_row_number); // set constant column in chunk with right size.
     (*chunk) = std::move(_result_chunk);
     _row_number = 0;
+}
+
+CascadeChunkMerger::CascadeChunkMerger(RuntimeState* state, RuntimeProfile* profile)
+        : _state(state), _profile(profile), _sort_exprs(nullptr) {}
+
+Status CascadeChunkMerger::init(const std::vector<ChunkProvider>& providers,
+                                const std::vector<ExprContext*>* sort_exprs, const std::vector<bool>* sort_orders,
+                                const std::vector<bool>* null_firsts) {
+    std::vector<std::unique_ptr<SimpleChunkSortCursor>> cursors;
+    for (int i = 0; i < providers.size(); i++) {
+        cursors.push_back(std::make_unique<SimpleChunkSortCursor>(providers[i], sort_exprs));
+    }
+    _sort_exprs = sort_exprs;
+    _sort_desc = SortDescs(*sort_orders, *null_firsts);
+
+    _merger = std::make_unique<MergeCursorsCascade>();
+    RETURN_IF_ERROR(_merger->init(_sort_desc, std::move(cursors)));
+    return Status::OK();
+}
+
+bool CascadeChunkMerger::is_data_ready() {
+    return _merger->is_data_ready();
+}
+
+Status CascadeChunkMerger::get_next(ChunkPtr* output, std::atomic<bool>* eos, bool* should_exit) {
+    if (_merger->is_eos()) {
+        *eos = true;
+        return Status::OK();
+    }
+    ChunkUniquePtr chunk = _merger->try_get_next();
+    if (!chunk) {
+        *should_exit = true;
+        return Status::OK();
+    }
+    *output = ChunkPtr(chunk.release());
+    return Status::OK();
 }
 
 } // namespace starrocks::vectorized


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Summary

Refactor the ExchangeMegeSort operator with the column-wise merge algorithm.

The tricky part of is, we need to implement a non-blocking synchronous cursor, to meet the requirement of this operator. Other part of this implementation is trivial, just employ the `merge.h` to merge sorted data streams.
