### PR TITLE
Fix sink buffer hang in the bthread

### DIFF
--- a/be/src/exec/pipeline/exchange/sink_buffer.h
+++ b/be/src/exec/pipeline/exchange/sink_buffer.h
@@ -9,6 +9,7 @@
 #include <queue>
 #include <unordered_set>
 
+#include "bthread/mutex.h"
 #include "column/chunk.h"
 #include "exec/pipeline/fragment_context.h"
 #include "gen_cpp/BackendService.h"
@@ -80,6 +81,8 @@ public:
     void cancel_one_sinker();
 
 private:
+    using Mutex = bthread::Mutex;
+
     void _update_network_time(const TUniqueId& instance_id, const int64_t send_timestamp,
                               const int64_t receive_timestamp);
     // Update the discontinuous acked window, here are the invariants:
@@ -128,7 +131,7 @@ private:
     phmap::flat_hash_map<int64_t, int32_t> _num_finished_rpcs;
     phmap::flat_hash_map<int64_t, int32_t> _num_in_flight_rpcs;
     phmap::flat_hash_map<int64_t, TimeTrace> _network_times;
-    phmap::flat_hash_map<int64_t, std::unique_ptr<std::mutex>> _mutexes;
+    phmap::flat_hash_map<int64_t, std::unique_ptr<Mutex>> _mutexes;
 
     // True means that SinkBuffer needn't input chunk and send chunk anymore,
     // but there may be still in-flight RPC running.

--- a/be/src/runtime/data_stream_sender.cpp
+++ b/be/src/runtime/data_stream_sender.cpp
@@ -89,13 +89,10 @@ public:
         if (_closure != nullptr && _closure->unref()) {
             delete _closure;
         }
-        // release this before request destruct
-        _brpc_request.release_finst_id();
 
         if (_chunk_closure != nullptr && _chunk_closure->unref()) {
             delete _chunk_closure;
         }
-        _chunk_request.release_finst_id();
     }
 
     // Initialize channel.
@@ -214,12 +211,12 @@ Status DataStreamSender::Channel::init(RuntimeState* state) {
     // initialize brpc request
     _finst_id.set_hi(_fragment_instance_id.hi);
     _finst_id.set_lo(_fragment_instance_id.lo);
-    _brpc_request.set_allocated_finst_id(&_finst_id);
+    *_brpc_request.mutable_finst_id() = _finst_id;
     _brpc_request.set_node_id(_dest_node_id);
     _brpc_request.set_sender_id(_parent->_sender_id);
     _brpc_request.set_be_number(_parent->_be_number);
 
-    _chunk_request.set_allocated_finst_id(&_finst_id);
+    *_chunk_request.mutable_finst_id() = _finst_id;
     _chunk_request.set_node_id(_dest_node_id);
     _chunk_request.set_sender_id(_parent->_sender_id);
     _chunk_request.set_be_number(_parent->_be_number);
@@ -276,12 +273,11 @@ Status DataStreamSender::Channel::send_one_chunk(const vectorized::Chunk* chunk,
 
 Status DataStreamSender::Channel::send_chunk_request(PTransmitChunkParams* params, const butil::IOBuf& attachment) {
     RETURN_IF_ERROR(_wait_prev_request());
-    params->set_allocated_finst_id(&_finst_id);
+    *params->mutable_finst_id() = _finst_id;
     params->set_node_id(_dest_node_id);
     params->set_sender_id(_parent->_sender_id);
     params->set_be_number(_parent->_be_number);
     auto status = _do_send_chunk_rpc(params, attachment);
-    params->release_finst_id();
     return status;
 }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
Fixes #5060 #4932

## Problem Summary(Required) ：
use bthread::Mutex instead of std::mutex

bthread::Mutex could work both in bthread and pthread.
