### PR TITLE
Bugfix: use 1 as max value in BooleanColumn MinAggregator and add com…

### DIFF
--- a/be/src/storage/vectorized/column_aggregate_func.cpp
+++ b/be/src/storage/vectorized/column_aggregate_func.cpp
@@ -143,6 +143,27 @@ public:
 };
 
 template <>
+class MinAggregator<BooleanColumn, uint8_t> final : public ValueColumnAggregator<BooleanColumn, uint8_t> {
+public:
+    // The max value of boolean type is 1 (not uint8_t max).
+    void reset() override { this->data() = 1; }
+
+    void aggregate_impl(int row, const ColumnPtr& src) override {
+        auto* data = down_cast<BooleanColumn*>(src.get())->get_data().data();
+        this->data() = std::min<uint8_t>(this->data(), data[row]);
+    }
+
+    void aggregate_batch_impl(int start, int end, const ColumnPtr& src) override {
+        auto* data = down_cast<BooleanColumn*>(src.get())->get_data().data();
+        for (int i = start; i < end; ++i) {
+            this->data() = std::min<uint8_t>(this->data(), data[i]);
+        }
+    }
+
+    void append_data(Column* agg) override { down_cast<BooleanColumn*>(agg)->append(this->data()); }
+};
+
+template <>
 class MinAggregator<BinaryColumn, SliceState> final : public ValueColumnAggregator<BinaryColumn, SliceState> {
 public:
     void reset() override { this->data().reset(); }

--- a/be/test/storage/vectorized/column_aggregator_test.cpp
+++ b/be/test/storage/vectorized/column_aggregator_test.cpp
@@ -308,6 +308,68 @@ TEST(ColumnAggregator, testStringMin) {
     EXPECT_EQ("2001", agg1->get_data()[5].to_string());
 }
 
+TEST(ColumnAggregator, testNullBooleanMin) {
+    FieldPtr field = std::make_shared<Field>(1, "test_boolean", FieldType::OLAP_FIELD_TYPE_BOOL, true);
+    field->set_aggregate_method(FieldAggregationMethod::OLAP_FIELD_AGGREGATION_MIN);
+
+    auto agg = NullableColumn::create(BooleanColumn::create(), NullColumn::create());
+    auto aggregator = ColumnAggregatorFactory::create_value_column_aggregator(field);
+    aggregator->update_aggregate(agg.get());
+    std::vector<uint32_t> loops;
+
+    // first chunk column
+    auto src = NullableColumn::create(BooleanColumn::create(), NullColumn::create());
+    src->append_nulls(1);
+
+    aggregator->update_source(src);
+
+    loops.clear();
+    loops.emplace_back(1);
+
+    aggregator->aggregate_values(0, 1, loops.data(), false);
+
+    ASSERT_EQ(0, agg->size());
+
+    // second chunk column
+    src->reset_column();
+    uint8_t val = 1;
+    src->append_numbers(&val, 1);
+    src->append_nulls(1);
+
+    aggregator->update_source(src);
+
+    loops.clear();
+    loops.emplace_back(1);
+    loops.emplace_back(1);
+
+    aggregator->aggregate_values(0, 2, loops.data(), true);
+
+    ASSERT_EQ(2, agg->size());
+    ASSERT_EQ("NULL", agg->debug_item(0));
+    ASSERT_EQ("1", agg->debug_item(1));
+
+    // third chunk column
+    src->reset_column();
+    val = 0;
+    src->append_numbers(&val, 1);
+
+    aggregator->update_source(src);
+
+    loops.clear();
+    loops.emplace_back(1);
+
+    aggregator->aggregate_values(0, 1, loops.data(), false);
+
+    aggregator->finalize();
+
+    ASSERT_EQ(3, agg->size());
+    ASSERT_EQ("0", agg->debug_item(2));
+
+    // check agg data and null column
+    ASSERT_EQ("[1, 1, 0]", agg->data_column()->debug_string());
+    ASSERT_EQ("[1, 0, 0]", agg->null_column()->debug_string());
+}
+
 TEST(ColumnAggregator, testNullIntReplaceIfNotNull) {
     FieldPtr field = std::make_shared<Field>(1, "test", FieldType::OLAP_FIELD_TYPE_INT, true);
     field->set_aggregate_method(FieldAggregationMethod::OLAP_FIELD_AGGREGATION_REPLACE_IF_NOT_NULL);

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/CreateMaterializedViewStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/CreateMaterializedViewStmt.java
@@ -452,6 +452,12 @@ public class CreateMaterializedViewStmt extends DdlStmt {
             default:
                 throw new AnalysisException("Unsupported function:" + functionName);
         }
+
+        // If isReplay, don't check compatibility because materialized view maybe already created before.
+        if (!isReplay && !mvAggregateType.checkCompatibility(type)) {
+            throw new AnalysisException(
+                    String.format("Invalid aggregate function '%s' for '%s'", mvAggregateType, type));
+        }
         return new MVColumnItem(mvColumnName, type, mvAggregateType, functionCallExpr.isNullable(), false, defineExpr,
                 baseColumnName);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewStmtTest.java
@@ -1387,6 +1387,29 @@ public class CreateMaterializedViewStmtTest {
 
     }
 
+    @Test(expected = AnalysisException.class)
+    public void testBooleanMinAgg(@Injectable SelectStmt selectStmt,
+                                  @Injectable Column column,
+                                  @Injectable SlotDescriptor slotDescriptor) {
+        CreateMaterializedViewStmt createMaterializedViewStmt =
+                new CreateMaterializedViewStmt("test", selectStmt, null);
+        SlotRef slotRef = new SlotRef(new TableName("db", "table"), "a");
+        List<Expr> params = Lists.newArrayList();
+        params.add(slotRef);
+        FunctionCallExpr functionCallExpr = new FunctionCallExpr("min", params);
+        Deencapsulation.setField(slotRef, "desc", slotDescriptor);
+        new Expectations() {
+            {
+                slotDescriptor.getColumn();
+                result = column;
+                column.getType();
+                result = Type.BOOLEAN;
+            }
+        };
+
+        Deencapsulation.invoke(createMaterializedViewStmt, "buildMVColumnItem", functionCallExpr);
+    }
+
     @Test
     public void testKeepScaleAndPrecisionOfType(@Injectable SelectStmt selectStmt,
                                                 @Injectable SlotDescriptor slotDescriptor1,


### PR DESCRIPTION
…patibility check in CreateMaterializedViewStmt (#4966)

merge branch 2.1

## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4963 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

StarRocks uses uint8_t column to store boolean data, and
uses std::numeric_limits<uint8_t>::max() 255 as max value in MinAggregator.
When the loading data contains null, column writer will write 255 value,
and cause BE crashes.

Solution:
1. Use 1 as max value in BooleanColumn MinAggregator.
2. Boolean MIN aggregation has already been disabled when creating table,
   so add compatibility check in CreateMaterializedViewStmt and disable it
   when creating materialized view.