### PR TITLE
capturing shared_ptr<RuntimeState> leads to instance-level MemTracker is released later than QueryContext-level counterpart

### DIFF
--- a/be/src/exec/pipeline/fragment_context.h
+++ b/be/src/exec/pipeline/fragment_context.h
@@ -29,8 +29,7 @@ class FragmentContext {
 public:
     FragmentContext() : _cancel_flag(false) {}
     ~FragmentContext() {
-        auto runtime_state_ptr = _runtime_state;
-        _runtime_filter_hub.close_all_in_filters(runtime_state_ptr.get());
+        _runtime_filter_hub.close_all_in_filters(_runtime_state.get());
         _drivers.clear();
         close_all_pipelines();
         if (_plan != nullptr) {

--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -61,10 +61,7 @@ void GlobalDriverExecutor::_worker_thread() {
 
         auto* query_ctx = driver->query_ctx();
         auto* fragment_ctx = driver->fragment_ctx();
-        // TODO(trueeyu): This writing is to ensure that MemTracker will not be destructed before the thread ends.
-        //  This writing method is a bit tricky, and when there is a better way, replace it
-        auto runtime_state_ptr = fragment_ctx->runtime_state_ptr();
-        auto* runtime_state = runtime_state_ptr.get();
+        auto* runtime_state = fragment_ctx->runtime_state();
         {
             SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(runtime_state->instance_mem_tracker());
 

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -182,6 +182,17 @@ void RuntimeState::init_mem_trackers(const TUniqueId& query_id, MemTracker* pare
     _instance_mem_pool = std::make_unique<MemPool>();
 }
 
+void RuntimeState::init_mem_trackers(int64_t instance_mem_limit, const std::shared_ptr<MemTracker>& query_mem_tracker) {
+    DCHECK(query_mem_tracker != nullptr);
+    auto* mem_tracker_counter = ADD_COUNTER(_profile.get(), "MemoryLimit", TUnit::BYTES);
+    mem_tracker_counter->set(instance_mem_limit);
+    // all fragment instances in a BE shared a common query_mem_tracker.
+    _query_mem_tracker = query_mem_tracker;
+    _instance_mem_tracker = std::make_shared<MemTracker>(_profile.get(), instance_mem_limit, runtime_profile()->name(),
+                                                         _query_mem_tracker.get());
+    _instance_mem_pool = std::make_unique<MemPool>();
+}
+
 Status RuntimeState::init_instance_mem_tracker() {
     _instance_mem_tracker = std::make_unique<MemTracker>(-1);
     _instance_mem_pool = std::make_unique<MemPool>();

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -89,6 +89,8 @@ public:
     // This function also initializes a user function mem tracker (in the fourth level).
     void init_mem_trackers(const TUniqueId& query_id, MemTracker* parent = nullptr);
 
+    void init_mem_trackers(int64_t instance_mem_limit, const std::shared_ptr<MemTracker>& query_mem_tracker);
+
     // for ut only
     Status init_instance_mem_tracker();
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

QueryContext-level MemTracker must be released after all of the instance-level MemTrackers have been released, the owner of an instance-level MemTracker is RuntimeState, when it is captured in somewhere and the QueryContext is released, BE will crash during instance-level MemTracker  releasing because it tries to remove itself from freed QueryContext-level MemTracker via unregister_from_parent invocation.  so QueryContext-level MemTracker also should put into RuntimeState before instance-level MemTracker.