### PR TITLE
Fix missing Project on join due to AssertRowNode push down project 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownAssertOneRowProjectRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownAssertOneRowProjectRule.java
@@ -14,7 +14,7 @@ import java.util.List;
 public class PushDownAssertOneRowProjectRule extends TransformationRule {
     public PushDownAssertOneRowProjectRule() {
         super(RuleType.TF_PUSH_DOWN_ASSERT_ONE_ROW_PROJECT, Pattern.create(OperatorType.LOGICAL_ASSERT_ONE_ROW)
-                .addChildren(Pattern.create(OperatorType.LOGICAL_PROJECT, OperatorType.PATTERN_LEAF)));
+                .addChildren(Pattern.create(OperatorType.LOGICAL_PROJECT, OperatorType.LOGICAL_AGGR)));
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -382,9 +382,17 @@ public class ReplayFromDumpTest {
     public void testSelectSubqueryWithMultiJoin() throws Exception {
         Pair<QueryDumpInfo, String> replayPair =
                 getPlanFragment(getDumpInfoFromFile("query_dump/select_sbuquery_with_multi_join"), null, TExplainLevel.NORMAL);
-        Assert.assertTrue(replayPair.second.contains("  26:Project\n" +
-                "  |  <slot 21> : 18: bitmap_union\n" +
-                "  |  <slot 29> : 29: bitmap_union"));
+        Assert.assertTrue(replayPair.second.contains("18:Project\n" +
+                "  |  <slot 33> : bitmap_and(21: expr, 29: bitmap_union)\n" +
+                "  |  \n" +
+                "  17:CROSS JOIN\n" +
+                "  |  cross join:\n" +
+                "  |  predicates is NULL.\n" +
+                "  |  \n" +
+                "  |----16:EXCHANGE\n" +
+                "  |    \n" +
+                "  10:Project\n" +
+                "  |  <slot 21> : 18: bitmap_union"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SelectConstTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SelectConstTest.java
@@ -92,8 +92,8 @@ public class SelectConstTest extends PlanTestBase {
         assertPlanContains("select * from t0 where not exists (select 9)", "  1:UNION\n" +
                 "     constant exprs: \n" +
                 "         NULL");
-        assertPlanContains("select * from t0 where v3 = (select 6)", "  4:Project\n" +
-                "  |  <slot 7> : CAST(6 AS BIGINT)", "equal join conjunct: 3: v3 = 7: cast");
+        assertPlanContains("select * from t0 where v3 = (select 6)", "  5:Project\n" +
+                "  |  <slot 7> : CAST(5: expr AS BIGINT)", "equal join conjunct: 3: v3 = 7: cast");
         assertPlanContains("select case when (select max(v4) from t1) > 1 then 2 else 3 end", "  5:Project\n" +
                 "  |  <slot 7> : if(5: max > 1, 2, 3)\n" +
                 "  |  \n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
@@ -117,4 +117,15 @@ public class SubqueryTest extends PlanTestBase {
         FeConstants.runningUnitTest = false;
     }
 
+    @Test
+    public void testAssertWithJoin() throws Exception {
+        String sql = "SELECT max(1) FROM t0 WHERE 1 = (SELECT t1.v4 FROM t0, t1 WHERE t1.v4 IN (SELECT t1.v4 FROM  t1))";
+        String explainString = getFragmentPlan(sql);
+        Assert.assertTrue(explainString.contains("  8:Project\n" +
+                "  |  <slot 7> : 7: v4\n" +
+                "  |  \n" +
+                "  7:HASH JOIN\n" +
+                "  |  join op: LEFT SEMI JOIN (BROADCAST)"));
+    }
+
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5041

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Currently, there is a Project on each Join, but the PushDownAssertOneRowProjectRule may push the AssertOneRow Node down to the Project, which leads to Join loss of Project used for column prune.
