### PR TITLE
simplify the isColocateJoin function in PlanFragmentBuilder

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1844,10 +1844,7 @@ public class PlanFragmentBuilder {
                         HashDistributionDesc.SourceType hashSourceType =
                                 ((HashDistributionSpec) (physicalPropertySet.getDistributionProperty().getSpec()))
                                         .getHashDistributionDesc().getSourceType();
-                        if (hashSourceType.equals(HashDistributionDesc.SourceType.LOCAL)) {
-                            return true;
-                        }
-                        return false;
+                        return hashSourceType.equals(HashDistributionDesc.SourceType.LOCAL);
                     });
         }
 
@@ -1861,11 +1858,8 @@ public class PlanFragmentBuilder {
                         HashDistributionDesc.SourceType hashSourceType =
                                 ((HashDistributionSpec) (physicalPropertySet.getDistributionProperty().getSpec()))
                                         .getHashDistributionDesc().getSourceType();
-                        if (hashSourceType.equals(HashDistributionDesc.SourceType.SHUFFLE_JOIN) ||
-                                hashSourceType.equals(HashDistributionDesc.SourceType.SHUFFLE_ENFORCE)) {
-                            return true;
-                        }
-                        return false;
+                        return hashSourceType.equals(HashDistributionDesc.SourceType.SHUFFLE_JOIN) ||
+                                hashSourceType.equals(HashDistributionDesc.SourceType.SHUFFLE_ENFORCE);
                     });
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -111,7 +111,6 @@ import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.AddDecodeNodeForDictStringRule.DecodeVisitor;
-import com.starrocks.sql.optimizer.rule.transformation.JoinPredicateUtils;
 import com.starrocks.sql.optimizer.statistics.Statistics;
 import com.starrocks.thrift.TPartitionType;
 import org.apache.logging.log4j.LogManager;
@@ -1625,7 +1624,7 @@ public class PlanFragmentBuilder {
                     distributionMode = HashJoinNode.DistributionMode.BROADCAST;
                 } else if (!(leftFragmentPlanRoot instanceof ExchangeNode) &&
                         !(rightFragmentPlanRoot instanceof ExchangeNode)) {
-                    if (isColocateJoin(optExpr, context, leftFragmentPlanRoot, rightFragmentPlanRoot)) {
+                    if (isColocateJoin(optExpr)) {
                         distributionMode = HashJoinNode.DistributionMode.COLOCATE;
                     } else if (ConnectContext.get().getSessionVariable().isEnableReplicationJoin() &&
                             rightFragmentPlanRoot.canDoReplicatedJoin()) {
@@ -1835,66 +1834,21 @@ public class PlanFragmentBuilder {
             }
         }
 
-        private void collectOlapScanInFragment(OptExpression optExpression,
-                                               List<PhysicalOlapScanOperator> scanNodeList) {
-            Operator operator = optExpression.getOp();
-            if (operator instanceof PhysicalOlapScanOperator) {
-                scanNodeList.add((PhysicalOlapScanOperator) operator);
-                return;
-            }
-            if (operator instanceof PhysicalDistributionOperator) {
-                return;
-            }
-            for (OptExpression child : optExpression.getInputs()) {
-                collectOlapScanInFragment(child, scanNodeList);
-            }
-        }
-
-        private boolean isColocateJoin(OptExpression optExpression, ExecPlan context, PlanNode left, PlanNode right) {
-            List<PhysicalOlapScanOperator> rightScanNodes = Lists.newArrayList();
-            collectOlapScanInFragment(optExpression.inputAt(1), rightScanNodes);
-
-            PhysicalHashJoinOperator joinNode = (PhysicalHashJoinOperator) optExpression.getOp();
-            List<PhysicalOlapScanOperator> leftScanNodes = Lists.newArrayList();
-            collectOlapScanInFragment(optExpression.inputAt(0), leftScanNodes);
-
-            ColumnRefSet leftChildColumns = optExpression.getInputs().get(0).getOutputColumns();
-            ColumnRefSet rightChildColumns = optExpression.getInputs().get(1).getOutputColumns();
-            List<BinaryPredicateOperator> equalOnPredicate =
-                    JoinPredicateUtils.getEqConj(leftChildColumns, rightChildColumns,
-                            Utils.extractConjuncts(joinNode.getOnPredicate()));
-
-            List<Integer> leftOnPredicateColumns = new ArrayList<>();
-            List<Integer> rightOnPredicateColumns = new ArrayList<>();
-            JoinPredicateUtils.getJoinOnPredicatesColumns(equalOnPredicate, leftChildColumns, rightChildColumns,
-                    leftOnPredicateColumns, rightOnPredicateColumns);
-
-            boolean leftChildSatisfied = leftScanNodes.stream().anyMatch(olapScanNode -> leftOnPredicateColumns
-                    .containsAll(olapScanNode.getDistributionSpec().getHashDistributionDesc().getColumns()));
-
-            boolean rightChildSatisfied = rightScanNodes.stream().anyMatch(olapScanNode -> rightOnPredicateColumns
-                    .containsAll(olapScanNode.getDistributionSpec().getHashDistributionDesc().getColumns()));
-            if (!leftChildSatisfied || !rightChildSatisfied) {
-                return false;
-            }
-
-            ColocateTableIndex colocateIndex = Catalog.getCurrentColocateIndex();
-            for (PhysicalOlapScanOperator node : leftScanNodes) {
-                List<Integer> outputColumns =
-                        node.getOutputColumns().stream().map(ColumnRefOperator::getId).collect(Collectors.toList());
-                if (outputColumns.containsAll(leftOnPredicateColumns)) {
-                    boolean isColocateGroup = colocateIndex
-                            .isSameGroup(node.getTable().getId(), rightScanNodes.get(0).getTable().getId());
-                    if (node.getTable().getId() == rightScanNodes.get(0).getTable().getId() &&
-                            !isColocateGroup) {
-                        return true;
-                    } else {
-                        return isColocateGroup &&
-                                !colocateIndex.isGroupUnstable(colocateIndex.getGroup(node.getTable().getId()));
-                    }
-                }
-            }
-            return false;
+        private boolean isColocateJoin(OptExpression optExpression) {
+            // through the required properties type check if it is colocate join
+            return optExpression.getRequiredProperties().stream().allMatch(
+                    physicalPropertySet -> {
+                        if (!physicalPropertySet.getDistributionProperty().isShuffle()) {
+                            return false;
+                        }
+                        HashDistributionDesc.SourceType hashSourceType =
+                                ((HashDistributionSpec) (physicalPropertySet.getDistributionProperty().getSpec()))
+                                        .getHashDistributionDesc().getSourceType();
+                        if (hashSourceType.equals(HashDistributionDesc.SourceType.LOCAL)) {
+                            return true;
+                        }
+                        return false;
+                    });
         }
 
         public boolean isShuffleJoin(OptExpression optExpression) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -2245,4 +2245,14 @@ public class JoinTest extends PlanTestBase {
             FeConstants.runningUnitTest = false;
         }
     }
+
+    @Test
+    public void testColocateJoinWithProject() throws Exception {
+        FeConstants.runningUnitTest = true;
+        String sql = "select a.v1 from t0 as a join t0 b on a.v1 = b.v1 and a.v1 = b.v1 + 1";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "3:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (COLOCATE)");
+        FeConstants.runningUnitTest = false;
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5037 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The origin is isColocateJoin is complex and error-prone, use the required property to decide is more simple