### PR TITLE
Account memory usage when release QueryContext use the parent of query-level MemTracker

### DIFF
--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -29,6 +29,9 @@ QueryContext::~QueryContext() {
         _fragment_mgr.reset();
     }
 
+    // Accounting memory usage during QueryContext's destruction should not use query-level MemTracker, but its released
+    // in the mid of QueryContext destruction, so use its parent MemTracker.
+    SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_mem_tracker->parent());
     if (_exec_env != nullptr) {
         if (_is_runtime_filter_coordinator) {
             _exec_env->runtime_filter_worker()->close_query(_query_id);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Accounting memory usage during QueryContext's destruction should not use query-level MemTracker, but its released in the mid of QueryContext destruction, so use its parent MemTracker.