### PR TITLE
capture RuntimeState in shared_ptr to avoid MemTracker inside it to be freed

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -61,7 +61,10 @@ void GlobalDriverExecutor::_worker_thread() {
 
         auto* query_ctx = driver->query_ctx();
         auto* fragment_ctx = driver->fragment_ctx();
-        auto* runtime_state = fragment_ctx->runtime_state();
+        // TODO(trueeyu): This writing is to ensure that MemTracker will not be destructed before the thread ends.
+        //  This writing method is a bit tricky, and when there is a better way, replace it
+        auto runtime_state_ptr = fragment_ctx->runtime_state_ptr();
+        auto* runtime_state = runtime_state_ptr.get();
         {
             SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(runtime_state->instance_mem_tracker());
 

--- a/be/test/exec/pipeline/pipeline_test_base.cpp
+++ b/be/test/exec/pipeline/pipeline_test_base.cpp
@@ -64,6 +64,7 @@ void PipelineTestBase::_prepare() {
     _query_ctx->set_total_fragments(1);
     _query_ctx->set_expire_seconds(60);
     _query_ctx->extend_lifetime();
+    _query_ctx->init_mem_tracker(_exec_env->query_pool_mem_tracker()->limit(), _exec_env->query_pool_mem_tracker());
 
     _fragment_ctx = _query_ctx->fragment_mgr()->get_or_register(fragment_id);
     _fragment_ctx->set_query_id(query_id);
@@ -76,7 +77,7 @@ void PipelineTestBase::_prepare() {
     _runtime_state = _fragment_ctx->runtime_state();
 
     _runtime_state->set_chunk_size(config::vector_chunk_size);
-    _runtime_state->init_mem_trackers(query_id);
+    _runtime_state->init_mem_trackers(_query_ctx->mem_tracker()->limit(), _query_ctx->mem_tracker());
     _runtime_state->set_be_number(_request.backend_num);
 
     _obj_pool = _runtime_state->obj_pool();


### PR DESCRIPTION
## What type of PR is this：
- [x ] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
