### PR TITLE
Fix bdb RollbackException bug (#4978)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBJEJournal.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBJEJournal.java
@@ -26,9 +26,6 @@ import com.sleepycat.je.Database;
 import com.sleepycat.je.DatabaseEntry;
 import com.sleepycat.je.DatabaseException;
 import com.sleepycat.je.OperationStatus;
-import com.sleepycat.je.rep.InsufficientLogException;
-import com.sleepycat.je.rep.NetworkRestore;
-import com.sleepycat.je.rep.NetworkRestoreConfig;
 import com.starrocks.catalog.Catalog;
 import com.starrocks.common.Pair;
 import com.starrocks.common.io.DataOutputBuffer;
@@ -266,12 +263,12 @@ public class BDBJEJournal implements Journal {
     public synchronized void open() {
         if (bdbEnvironment == null) {
             File dbEnv = new File(environmentPath);
-            bdbEnvironment = new BDBEnvironment();
             Pair<String, Integer> helperNode = Catalog.getCurrentCatalog().getHelperNode();
             String helperHostPort = helperNode.first + ":" + helperNode.second;
+            bdbEnvironment = new BDBEnvironment(dbEnv, selfNodeName, selfNodeHostPort,
+                    helperHostPort, Catalog.getCurrentCatalog().isElectable());
             try {
-                bdbEnvironment.setup(dbEnv, selfNodeName, selfNodeHostPort,
-                        helperHostPort, Catalog.getCurrentCatalog().isElectable());
+                bdbEnvironment.setup();
             } catch (Exception e) {
                 LOG.error("catch an exception when setup bdb environment. will exit.", e);
                 System.exit(-1);
@@ -279,54 +276,28 @@ public class BDBJEJournal implements Journal {
         }
 
         // Open a new journal database or get last existing one as current journal database
-        Pair<String, Integer> helperNode = Catalog.getCurrentCatalog().getHelperNode();
-        List<Long> dbNames = null;
-        for (int i = 0; i < RETRY_TIME; i++) {
-            try {
-                dbNames = bdbEnvironment.getDatabaseNames();
-
-                if (dbNames == null) {
-                    LOG.error("fail to get dbNames while open bdbje journal. will exit");
-                    System.exit(-1);
-                }
-                if (dbNames.size() == 0) {
-                    /*
-                     *  This is the very first time to open. Usually, we will open a new database named "1".
-                     *  But when we start cluster with an image file copied from other cluster,
-                     *  here we should open database with name image max journal id + 1.
-                     *  (default Catalog.getCurrentCatalog().getReplayedJournalId() is 0)
-                     */
-                    String dbName = Long.toString(Catalog.getCurrentCatalog().getReplayedJournalId() + 1);
-                    LOG.info("the very first time to open bdb, dbname is {}", dbName);
-                    currentJournalDB = bdbEnvironment.openDatabase(dbName);
-                } else {
-                    // get last database as current journal database
-                    currentJournalDB = bdbEnvironment.openDatabase(dbNames.get(dbNames.size() - 1).toString());
-                }
-
-                // set next journal id
-                nextJournalId.set(getMaxJournalId() + 1);
-
-                break;
-            } catch (InsufficientLogException insufficientLogEx) {
-                // Copy the missing log files from a member of the replication group who owns the files
-                LOG.warn("catch insufficient log exception. will recover and try again.", insufficientLogEx);
-                NetworkRestore restore = new NetworkRestore();
-                NetworkRestoreConfig config = new NetworkRestoreConfig();
-                config.setRetainLogFiles(false);
-                restore.execute(insufficientLogEx, config);
-                if (!bdbEnvironment.close()) {
-                    LOG.error("close bdb environment failed, will exit");
-                    // NOTE: System.exit will trigger BDBEnvironment.close(),
-                    // because BDBEnvironment.close() has been registered in shutdown hook,
-                    // so in this case BDBEnvironment.close() will be called twice.
-                    // But it is ok.
-                    System.exit(-1);
-                }
-                bdbEnvironment.setup(new File(environmentPath), selfNodeName, selfNodeHostPort,
-                        helperNode.first + ":" + helperNode.second, Catalog.getCurrentCatalog().isElectable());
-            }
+        List<Long> dbNames = bdbEnvironment.getDatabaseNames();
+        if (dbNames == null) {
+            LOG.error("fail to get dbNames while open bdbje journal. will exit");
+            System.exit(-1);
         }
+        if (dbNames.size() == 0) {
+            /*
+             *  This is the very first time to open. Usually, we will open a new database named "1".
+             *  But when we start cluster with an image file copied from other cluster,
+             *  here we should open database with name image max journal id + 1.
+             *  (default Catalog.getCurrentCatalog().getReplayedJournalId() is 0)
+             */
+            String dbName = Long.toString(Catalog.getCurrentCatalog().getReplayedJournalId() + 1);
+            LOG.info("the very first time to open bdb, dbname is {}", dbName);
+            currentJournalDB = bdbEnvironment.openDatabase(dbName);
+        } else {
+            // get last database as current journal database
+            currentJournalDB = bdbEnvironment.openDatabase(dbNames.get(dbNames.size() - 1).toString());
+        }
+
+        // set next journal id
+        nextJournalId.set(getMaxJournalId() + 1);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/CloseSafeDatabase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/CloseSafeDatabase.java
@@ -62,4 +62,12 @@ public class CloseSafeDatabase {
     public Database getDb() {
         return db;
     }
+
+    public String getDatabaseName() {
+        try {
+            return db.getDatabaseName();
+        } catch (Throwable t) {
+            return "";
+        }
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4977

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered, and what measures have you taken to fix the bug?) -->
In bdb, after transferring the master, there may be logs in the old master that have not been synchronized to other nodes, and these logs need to be cleaned up. After cleaning these logs, the bdb environment will throw a RollbackException, and the environment should be rebuilt. So we should catch the RollbackException, and rebuild the bdb environment.

The current handling of InsufficientLogException is somewhat problematic; we should rebuild the bdb environment after synchronizing data from other nodes.

Since we handle the InsufficientLogException in the getDatabaseNames() function, there is no need to address the exception in the open() function, so remove the extra code.