### PR TITLE
Support custom catalog for iceberg external table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergResource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergResource.java
@@ -41,8 +41,8 @@ public class IcebergResource extends Resource {
     @SerializedName(value = "metastoreURIs")
     private String metastoreURIs;
 
-    @SerializedName(value = "customImpl")
-    private String customImpl;
+    @SerializedName(value = "catalogImpl")
+    private String catalogImpl;
 
     @SerializedName(value = "properties")
     private Map<String, String> properties;
@@ -69,14 +69,14 @@ public class IcebergResource extends Resource {
                 }
                 break;
             case CUSTOM_CATALOG:
-                customImpl = properties.get(ICEBERG_IMPL);
-                if (StringUtils.isBlank(customImpl)) {
+                catalogImpl = properties.get(ICEBERG_IMPL);
+                if (StringUtils.isBlank(catalogImpl)) {
                     throw new DdlException(ICEBERG_IMPL + " must be set in properties");
                 }
                 try {
-                    Thread.currentThread().getContextClassLoader().loadClass(customImpl);
+                    Thread.currentThread().getContextClassLoader().loadClass(catalogImpl);
                 } catch (ClassNotFoundException e) {
-                    throw new DdlException("Unknown class: " + customImpl);
+                    throw new DdlException("Unknown class: " + catalogImpl);
                 }
                 break;
             default:
@@ -92,7 +92,7 @@ public class IcebergResource extends Resource {
                 result.addRow(Lists.newArrayList(name, lowerCaseType, ICEBERG_METASTORE_URIS, metastoreURIs));
                 break;
             case CUSTOM_CATALOG:
-                result.addRow(Lists.newArrayList(name, lowerCaseType, ICEBERG_IMPL, customImpl));
+                result.addRow(Lists.newArrayList(name, lowerCaseType, ICEBERG_IMPL, catalogImpl));
                 break;
             default:
                 LOG.warn("Unexpected catalog type: " + catalogType);
@@ -105,7 +105,7 @@ public class IcebergResource extends Resource {
     }
 
     public String getIcebergImpl() {
-        return customImpl;
+        return catalogImpl;
     }
 
     public IcebergCatalogType getCatalogType() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergResource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergResource.java
@@ -73,6 +73,11 @@ public class IcebergResource extends Resource {
                 if (StringUtils.isBlank(impl)) {
                     throw new DdlException(ICEBERG_IMPL + " must be set in properties");
                 }
+                try {
+                    Thread.currentThread().getContextClassLoader().loadClass(impl);
+                } catch (ClassNotFoundException e) {
+                    throw new DdlException("Unknown class: " + impl);
+                }
                 break;
             default:
                 throw new DdlException("Unexpected catalog type: " + catalogType);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergResource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergResource.java
@@ -33,12 +33,16 @@ public class IcebergResource extends Resource {
 
     private static final String ICEBERG_CATALOG = "starrocks.catalog-type";
     private static final String ICEBERG_METASTORE_URIS = "iceberg.catalog.hive.metastore.uris";
+    private static final String ICEBERG_IMPL = "iceberg.catalog-impl";
 
     @SerializedName(value = "catalogType")
     private String catalogType;
 
     @SerializedName(value = "metastoreURIs")
     private String metastoreURIs;
+
+    @SerializedName(value = "impl")
+    private String impl;
 
     @SerializedName(value = "properties")
     private Map<String, String> properties;
@@ -64,6 +68,12 @@ public class IcebergResource extends Resource {
                     throw new DdlException(ICEBERG_METASTORE_URIS + " must be set in properties");
                 }
                 break;
+            case CUSTOM_CATALOG:
+                impl = properties.get(ICEBERG_IMPL);
+                if (StringUtils.isBlank(impl)) {
+                    throw new DdlException(ICEBERG_IMPL + " must be set in properties");
+                }
+                break;
             default:
                 throw new DdlException("Unexpected catalog type: " + catalogType);
         }
@@ -76,6 +86,9 @@ public class IcebergResource extends Resource {
             case HIVE_CATALOG:
                 result.addRow(Lists.newArrayList(name, lowerCaseType, ICEBERG_METASTORE_URIS, metastoreURIs));
                 break;
+            case CUSTOM_CATALOG:
+                result.addRow(Lists.newArrayList(name, lowerCaseType, ICEBERG_IMPL, impl));
+                break;
             default:
                 LOG.warn("Unexpected catalog type: " + catalogType);
                 break;
@@ -84,6 +97,10 @@ public class IcebergResource extends Resource {
 
     public String getHiveMetastoreURIs() {
         return metastoreURIs;
+    }
+
+    public String getIcebergImpl() {
+        return impl;
     }
 
     public IcebergCatalogType getCatalogType() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergResource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergResource.java
@@ -41,8 +41,8 @@ public class IcebergResource extends Resource {
     @SerializedName(value = "metastoreURIs")
     private String metastoreURIs;
 
-    @SerializedName(value = "impl")
-    private String impl;
+    @SerializedName(value = "customImpl")
+    private String customImpl;
 
     @SerializedName(value = "properties")
     private Map<String, String> properties;
@@ -69,14 +69,14 @@ public class IcebergResource extends Resource {
                 }
                 break;
             case CUSTOM_CATALOG:
-                impl = properties.get(ICEBERG_IMPL);
-                if (StringUtils.isBlank(impl)) {
+                customImpl = properties.get(ICEBERG_IMPL);
+                if (StringUtils.isBlank(customImpl)) {
                     throw new DdlException(ICEBERG_IMPL + " must be set in properties");
                 }
                 try {
-                    Thread.currentThread().getContextClassLoader().loadClass(impl);
+                    Thread.currentThread().getContextClassLoader().loadClass(customImpl);
                 } catch (ClassNotFoundException e) {
-                    throw new DdlException("Unknown class: " + impl);
+                    throw new DdlException("Unknown class: " + customImpl);
                 }
                 break;
             default:
@@ -92,7 +92,7 @@ public class IcebergResource extends Resource {
                 result.addRow(Lists.newArrayList(name, lowerCaseType, ICEBERG_METASTORE_URIS, metastoreURIs));
                 break;
             case CUSTOM_CATALOG:
-                result.addRow(Lists.newArrayList(name, lowerCaseType, ICEBERG_IMPL, impl));
+                result.addRow(Lists.newArrayList(name, lowerCaseType, ICEBERG_IMPL, customImpl));
                 break;
             default:
                 LOG.warn("Unexpected catalog type: " + catalogType);
@@ -105,7 +105,7 @@ public class IcebergResource extends Resource {
     }
 
     public String getIcebergImpl() {
-        return impl;
+        return customImpl;
     }
 
     public IcebergCatalogType getCatalogType() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -149,22 +149,25 @@ public class IcebergTable extends Table {
         IcebergCatalogType type = icebergResource.getCatalogType();
         icebergProperties.put(ICEBERG_CATALOG, type.name());
         LOG.info("Iceberg table type is " + type.name());
+        IcebergCatalog icebergCatalog;
         switch (type) {
             case HIVE_CATALOG:
                 icebergProperties.put(ICEBERG_METASTORE_URIS, icebergResource.getHiveMetastoreURIs());
-                validateColumn(IcebergUtil.getIcebergHiveCatalog(icebergResource.getHiveMetastoreURIs()));
+                icebergCatalog = IcebergUtil.getIcebergHiveCatalog(icebergResource.getHiveMetastoreURIs());
                 break;
             case CUSTOM_CATALOG:
                 icebergProperties.put(ICEBERG_IMPL, icebergResource.getIcebergImpl());
                 for (String key : copiedProps.keySet()) {
                     icebergProperties.put(key, copiedProps.remove(key));
                 }
-                validateColumn(IcebergUtil.getIcebergCustomCatalog(icebergResource.getIcebergImpl(), icebergProperties));
+                icebergCatalog = IcebergUtil.getIcebergCustomCatalog(icebergResource.getIcebergImpl(), icebergProperties);
                 break;
             default:
                 throw new DdlException("unsupported catalog type " + type.name());
         }
         this.resourceName = resourceName;
+
+        validateColumn(icebergCatalog);
 
         if (!copiedProps.isEmpty()) {
             throw new DdlException("Unknown table properties: " + copiedProps.toString());

--- a/fe/fe-core/src/main/java/com/starrocks/external/iceberg/CatalogLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/iceberg/CatalogLoader.java
@@ -82,7 +82,8 @@ public interface CatalogLoader {
             this.hadoopConf = new SerializableConfiguration(conf);
             this.properties = Maps.newHashMap(properties); // wrap into a hashmap for serialization
             this.name = name;
-            this.catalogImpl = Preconditions.checkNotNull(catalogImpl, "Cannot initialize custom Catalog, impl class name is null");
+            this.catalogImpl = Preconditions.checkNotNull(catalogImpl,
+                    "Cannot initialize custom Catalog, impl class name is null");
         }
 
         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/external/iceberg/CatalogLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/iceberg/CatalogLoader.java
@@ -31,8 +31,8 @@ public interface CatalogLoader {
         return new HiveCatalogLoader(name, hadoopConf, properties);
     }
 
-    static CatalogLoader custom(String name, Configuration hadoopConf, Map<String, String> properties, String impl) {
-        return new CustomCatalogLoader(name, hadoopConf, properties, impl);
+    static CatalogLoader custom(String name, Configuration hadoopConf, Map<String, String> properties, String customImpl) {
+        return new CustomCatalogLoader(name, hadoopConf, properties, customImpl);
     }
 
     class HiveCatalogLoader implements CatalogLoader {
@@ -72,29 +72,29 @@ public interface CatalogLoader {
         private final SerializableConfiguration hadoopConf;
         private final Map<String, String> properties;
         private final String name;
-        private final String impl;
+        private final String customImpl;
 
         private CustomCatalogLoader(
                 String name,
                 Configuration conf,
                 Map<String, String> properties,
-                String impl) {
+                String customImpl) {
             this.hadoopConf = new SerializableConfiguration(conf);
             this.properties = Maps.newHashMap(properties); // wrap into a hashmap for serialization
             this.name = name;
-            this.impl = Preconditions.checkNotNull(impl, "Cannot initialize custom Catalog, impl class name is null");
+            this.customImpl = Preconditions.checkNotNull(customImpl, "Cannot initialize custom Catalog, impl class name is null");
         }
 
         @Override
         public Catalog loadCatalog() {
-            return CatalogUtil.loadCatalog(impl, name, properties, hadoopConf.get());
+            return CatalogUtil.loadCatalog(customImpl, name, properties, hadoopConf.get());
         }
 
         @Override
         public String toString() {
             return MoreObjects.toStringHelper(this)
                     .add("name", name)
-                    .add("impl", impl)
+                    .add("customImpl", customImpl)
                     .toString();
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/external/iceberg/CatalogLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/iceberg/CatalogLoader.java
@@ -31,8 +31,8 @@ public interface CatalogLoader {
         return new HiveCatalogLoader(name, hadoopConf, properties);
     }
 
-    static CatalogLoader custom(String name, Configuration hadoopConf, Map<String, String> properties, String customImpl) {
-        return new CustomCatalogLoader(name, hadoopConf, properties, customImpl);
+    static CatalogLoader custom(String name, Configuration hadoopConf, Map<String, String> properties, String catalogImpl) {
+        return new CustomCatalogLoader(name, hadoopConf, properties, catalogImpl);
     }
 
     class HiveCatalogLoader implements CatalogLoader {
@@ -72,29 +72,29 @@ public interface CatalogLoader {
         private final SerializableConfiguration hadoopConf;
         private final Map<String, String> properties;
         private final String name;
-        private final String customImpl;
+        private final String catalogImpl;
 
         private CustomCatalogLoader(
                 String name,
                 Configuration conf,
                 Map<String, String> properties,
-                String customImpl) {
+                String catalogImpl) {
             this.hadoopConf = new SerializableConfiguration(conf);
             this.properties = Maps.newHashMap(properties); // wrap into a hashmap for serialization
             this.name = name;
-            this.customImpl = Preconditions.checkNotNull(customImpl, "Cannot initialize custom Catalog, impl class name is null");
+            this.catalogImpl = Preconditions.checkNotNull(catalogImpl, "Cannot initialize custom Catalog, impl class name is null");
         }
 
         @Override
         public Catalog loadCatalog() {
-            return CatalogUtil.loadCatalog(customImpl, name, properties, hadoopConf.get());
+            return CatalogUtil.loadCatalog(catalogImpl, name, properties, hadoopConf.get());
         }
 
         @Override
         public String toString() {
             return MoreObjects.toStringHelper(this)
                     .add("name", name)
-                    .add("customImpl", customImpl)
+                    .add("catalogImpl", catalogImpl)
                     .toString();
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/external/iceberg/CatalogLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/iceberg/CatalogLoader.java
@@ -8,6 +8,7 @@ import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.hadoop.SerializableConfiguration;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 
 import java.util.Map;
@@ -15,7 +16,7 @@ import java.util.Map;
 /**
  * Most code of this file was copied from CatalogLoader.java of flink in iceberg codebase.
  * Please see https://github.com/apache/iceberg.
- * // TODO: add hadoop or custom catalogloader here.
+ * // TODO: add hadoop catalogloader here.
  */
 public interface CatalogLoader {
 
@@ -28,6 +29,10 @@ public interface CatalogLoader {
 
     static CatalogLoader hive(String name, Configuration hadoopConf, Map<String, String> properties) {
         return new HiveCatalogLoader(name, hadoopConf, properties);
+    }
+
+    static CatalogLoader custom(String name, Configuration hadoopConf, Map<String, String> properties, String impl) {
+        return new CustomCatalogLoader(name, hadoopConf, properties, impl);
     }
 
     class HiveCatalogLoader implements CatalogLoader {
@@ -62,4 +67,35 @@ public interface CatalogLoader {
         }
     }
 
+    class CustomCatalogLoader implements CatalogLoader {
+
+        private final SerializableConfiguration hadoopConf;
+        private final Map<String, String> properties;
+        private final String name;
+        private final String impl;
+
+        private CustomCatalogLoader(
+                String name,
+                Configuration conf,
+                Map<String, String> properties,
+                String impl) {
+            this.hadoopConf = new SerializableConfiguration(conf);
+            this.properties = Maps.newHashMap(properties); // wrap into a hashmap for serialization
+            this.name = name;
+            this.impl = Preconditions.checkNotNull(impl, "Cannot initialize custom Catalog, impl class name is null");
+        }
+
+        @Override
+        public Catalog loadCatalog() {
+            return CatalogUtil.loadCatalog(impl, name, properties, hadoopConf.get());
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(this)
+                    .add("name", name)
+                    .add("impl", impl)
+                    .toString();
+        }
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/external/iceberg/IcebergCatalogType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/iceberg/IcebergCatalogType.java
@@ -4,6 +4,7 @@ package com.starrocks.external.iceberg;
 
 public enum IcebergCatalogType {
     HIVE_CATALOG,
+    CUSTOM_CATALOG,
     UNKNOWN;
     // TODO: add more iceberg catalog type
 

--- a/fe/fe-core/src/main/java/com/starrocks/external/iceberg/IcebergUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/iceberg/IcebergUtil.java
@@ -65,10 +65,10 @@ public class IcebergUtil {
     /**
      * Returns the corresponding custom catalog implementation.
      */
-    public static IcebergCatalog getIcebergCustomCatalog(String impl, Map<String, String> icebergProperties)
+    public static IcebergCatalog getIcebergCustomCatalog(String customImpl, Map<String, String> icebergProperties)
             throws StarRocksIcebergException {
-        return (IcebergCatalog) CatalogLoader.custom(String.format("Custom-%s", impl),
-                new Configuration(), icebergProperties, impl).loadCatalog();
+        return (IcebergCatalog) CatalogLoader.custom(String.format("Custom-%s", customImpl),
+                new Configuration(), icebergProperties, customImpl).loadCatalog();
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/external/iceberg/IcebergUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/iceberg/IcebergUtil.java
@@ -65,10 +65,10 @@ public class IcebergUtil {
     /**
      * Returns the corresponding custom catalog implementation.
      */
-    public static IcebergCatalog getIcebergCustomCatalog(String customImpl, Map<String, String> icebergProperties)
+    public static IcebergCatalog getIcebergCustomCatalog(String catalogImpl, Map<String, String> icebergProperties)
             throws StarRocksIcebergException {
-        return (IcebergCatalog) CatalogLoader.custom(String.format("Custom-%s", customImpl),
-                new Configuration(), icebergProperties, customImpl).loadCatalog();
+        return (IcebergCatalog) CatalogLoader.custom(String.format("Custom-%s", catalogImpl),
+                new Configuration(), icebergProperties, catalogImpl).loadCatalog();
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/external/iceberg/IcebergUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/iceberg/IcebergUtil.java
@@ -5,6 +5,7 @@ package com.starrocks.external.iceberg;
 import com.google.common.collect.ImmutableMap;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.external.hive.HdfsFileFormat;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionField;
@@ -42,20 +43,32 @@ public class IcebergUtil {
     public static IcebergCatalog getIcebergCatalog(IcebergTable table)
             throws StarRocksIcebergException {
         IcebergCatalogType catalogType = table.getCatalogType();
-        return getIcebergCatalog(catalogType, table.getIcebergHiveMetastoreUris());
-    }
-
-    /**
-     * Returns the corresponding catalog implementation.
-     */
-    public static IcebergCatalog getIcebergCatalog(IcebergCatalogType catalogType, String metastoreUris)
-            throws StarRocksIcebergException {
         switch (catalogType) {
-            case HIVE_CATALOG: return IcebergHiveCatalog.getInstance(metastoreUris);
+            case HIVE_CATALOG:
+                return getIcebergHiveCatalog(table.getIcebergHiveMetastoreUris());
+            case CUSTOM_CATALOG:
+                return getIcebergCustomCatalog(table.getCatalogImpl(), table.getIcebergProperties());
             default:
                 throw new StarRocksIcebergException(
                         "Unexpected catalog type: " + catalogType.toString());
         }
+    }
+
+    /**
+     * Returns the corresponding hive catalog implementation.
+     */
+    public static IcebergCatalog getIcebergHiveCatalog(String metastoreUris)
+            throws StarRocksIcebergException {
+        return IcebergHiveCatalog.getInstance(metastoreUris);
+    }
+
+    /**
+     * Returns the corresponding custom catalog implementation.
+     */
+    public static IcebergCatalog getIcebergCustomCatalog(String impl, Map<String, String> icebergProperties)
+            throws StarRocksIcebergException {
+        return (IcebergCatalog) CatalogLoader.custom(String.format("Custom-%s", impl),
+                new Configuration(), icebergProperties, impl).loadCatalog();
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/IcebergResourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/IcebergResourceTest.java
@@ -71,18 +71,18 @@ public class IcebergResourceTest {
         String name = "iceberg1";
         String type = "iceberg";
         String catalogType = "CUSTOM";
-        String impl = "com.starrocks.external.iceberg.IcebergHiveCatalog";
+        String customImpl = "com.starrocks.external.iceberg.IcebergHiveCatalog";
         Map<String, String> properties = Maps.newHashMap();
         properties.put("type", type);
         properties.put("starrocks.catalog-type", catalogType);
-        properties.put("iceberg.catalog-impl", impl);
+        properties.put("iceberg.catalog-impl", customImpl);
         CreateResourceStmt stmt = new CreateResourceStmt(true, name, properties);
         stmt.analyze(analyzer);
         IcebergResource resource = (IcebergResource) Resource.fromStmt(stmt);
         Assert.assertEquals("iceberg1", resource.getName());
         Assert.assertEquals(type, resource.getType().name().toLowerCase());
         Assert.assertEquals(IcebergCatalogType.fromString(catalogType), resource.getCatalogType());
-        Assert.assertEquals(impl, resource.getIcebergImpl());
+        Assert.assertEquals(customImpl, resource.getIcebergImpl());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/IcebergResourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/IcebergResourceTest.java
@@ -71,18 +71,18 @@ public class IcebergResourceTest {
         String name = "iceberg1";
         String type = "iceberg";
         String catalogType = "CUSTOM";
-        String customImpl = "com.starrocks.external.iceberg.IcebergHiveCatalog";
+        String catalogImpl = "com.starrocks.external.iceberg.IcebergHiveCatalog";
         Map<String, String> properties = Maps.newHashMap();
         properties.put("type", type);
         properties.put("starrocks.catalog-type", catalogType);
-        properties.put("iceberg.catalog-impl", customImpl);
+        properties.put("iceberg.catalog-impl", catalogImpl);
         CreateResourceStmt stmt = new CreateResourceStmt(true, name, properties);
         stmt.analyze(analyzer);
         IcebergResource resource = (IcebergResource) Resource.fromStmt(stmt);
         Assert.assertEquals("iceberg1", resource.getName());
         Assert.assertEquals(type, resource.getType().name().toLowerCase());
         Assert.assertEquals(IcebergCatalogType.fromString(catalogType), resource.getCatalogType());
-        Assert.assertEquals(customImpl, resource.getIcebergImpl());
+        Assert.assertEquals(catalogImpl, resource.getIcebergImpl());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/IcebergResourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/IcebergResourceTest.java
@@ -58,6 +58,34 @@ public class IcebergResourceTest {
     }
 
     @Test
+    public void testCustomStmt(@Mocked Catalog catalog, @Injectable Auth auth) throws UserException {
+        new Expectations() {
+            {
+                catalog.getAuth();
+                result = auth;
+                auth.checkGlobalPriv((ConnectContext) any, PrivPredicate.ADMIN);
+                result = true;
+            }
+        };
+
+        String name = "iceberg1";
+        String type = "iceberg";
+        String catalogType = "CUSTOM";
+        String impl = "com.starrocks.external.iceberg.IcebergHiveCatalog";
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("type", type);
+        properties.put("starrocks.catalog-type", catalogType);
+        properties.put("iceberg.catalog-impl", impl);
+        CreateResourceStmt stmt = new CreateResourceStmt(true, name, properties);
+        stmt.analyze(analyzer);
+        IcebergResource resource = (IcebergResource) Resource.fromStmt(stmt);
+        Assert.assertEquals("iceberg1", resource.getName());
+        Assert.assertEquals(type, resource.getType().name().toLowerCase());
+        Assert.assertEquals(IcebergCatalogType.fromString(catalogType), resource.getCatalogType());
+        Assert.assertEquals(impl, resource.getIcebergImpl());
+    }
+
+    @Test
     public void testSerialization() throws Exception {
         Resource resource = new IcebergResource("iceberg0");
         String metastoreURIs = "thrift://127.0.0.1:9380";

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/IcebergTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/IcebergTableTest.java
@@ -96,7 +96,7 @@ public class IcebergTableTest {
     }
 
     @Test
-    public void testCustomWithResourceName(@Mocked com.starrocks.catalog.Catalog catalog,
+    public void testCustomWithResourceName(@Mocked Catalog catalog,
                                            @Mocked ResourceMgr resourceMgr,
                                            @Mocked IcebergCatalog icebergCatalog,
                                            @Mocked Table iTable) throws DdlException {
@@ -112,7 +112,7 @@ public class IcebergTableTest {
 
         new MockUp<IcebergUtil>() {
             @Mock
-            public IcebergCatalog getIcebergCustomCatalog(String impl, Map<String, String> icebergProperties) {
+            public IcebergCatalog getIcebergCustomCatalog(String catalogImpl, Map<String, String> icebergProperties) {
                 return icebergCatalog;
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/IcebergTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/IcebergTableTest.java
@@ -6,7 +6,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.common.DdlException;
 import com.starrocks.external.iceberg.IcebergCatalog;
-import com.starrocks.external.iceberg.IcebergCatalogType;
 import com.starrocks.external.iceberg.IcebergUtil;
 import mockit.Expectations;
 import mockit.Mock;
@@ -64,7 +63,7 @@ public class IcebergTableTest {
 
         new MockUp<IcebergUtil>() {
             @Mock
-            public IcebergCatalog getIcebergCatalog(IcebergCatalogType type, String uris) {
+            public IcebergCatalog getIcebergHiveCatalog(String uris) {
                 return icebergCatalog;
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/IcebergTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/IcebergTableTest.java
@@ -6,6 +6,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.common.DdlException;
 import com.starrocks.external.iceberg.IcebergCatalog;
+import com.starrocks.external.iceberg.IcebergCustomCatalogTest;
 import com.starrocks.external.iceberg.IcebergUtil;
 import mockit.Expectations;
 import mockit.Mock;
@@ -85,6 +86,43 @@ public class IcebergTableTest {
 
                 iTable.schema();
                 result = schema;
+            }
+        };
+
+        properties.put("resource", resourceName);
+        IcebergTable table = new IcebergTable(1000, "iceberg_table", columns, properties);
+        Assert.assertEquals(tableName, table.getTable());
+        Assert.assertEquals(db, table.getDb());
+    }
+
+    @Test
+    public void testCustomWithResourceName(@Mocked com.starrocks.catalog.Catalog catalog,
+                                     @Mocked ResourceMgr resourceMgr,
+                                     @Mocked IcebergCatalog icebergCatalog) throws DdlException {
+        Resource icebergResource = new IcebergResource(resourceName);
+        Map<String, String> resourceProperties = Maps.newHashMap();
+        resourceProperties.put("starrocks.catalog-type", "custom");
+        resourceProperties.put("iceberg.catalog-impl", IcebergCustomCatalogTest.IcebergCustomTestingCatalog.class.getName());
+        icebergResource.setProperties(resourceProperties);
+
+        new MockUp<IcebergUtil>() {
+            @Mock
+            public IcebergCatalog getIcebergCustomCatalog(String impl, Map<String, String> icebergProperties) {
+                return icebergCatalog;
+            }
+        };
+
+        new Expectations() {
+            {
+                com.starrocks.catalog.Catalog.getCurrentCatalog();
+                result = catalog;
+                minTimes = 0;
+
+                catalog.getResourceMgr();
+                result = resourceMgr;
+
+                resourceMgr.getResource("iceberg0");
+                result = icebergResource;
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/IcebergTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/IcebergTableTest.java
@@ -97,13 +97,18 @@ public class IcebergTableTest {
 
     @Test
     public void testCustomWithResourceName(@Mocked com.starrocks.catalog.Catalog catalog,
-                                     @Mocked ResourceMgr resourceMgr,
-                                     @Mocked IcebergCatalog icebergCatalog) throws DdlException {
+                                           @Mocked ResourceMgr resourceMgr,
+                                           @Mocked IcebergCatalog icebergCatalog,
+                                           @Mocked Table iTable) throws DdlException {
         Resource icebergResource = new IcebergResource(resourceName);
         Map<String, String> resourceProperties = Maps.newHashMap();
         resourceProperties.put("starrocks.catalog-type", "custom");
         resourceProperties.put("iceberg.catalog-impl", IcebergCustomCatalogTest.IcebergCustomTestingCatalog.class.getName());
         icebergResource.setProperties(resourceProperties);
+
+        List<Types.NestedField> fields = new ArrayList<>();
+        fields.add(Types.NestedField.of(1, false, "col1", new Types.LongType()));
+        Schema schema = new Schema(fields);
 
         new MockUp<IcebergUtil>() {
             @Mock
@@ -123,6 +128,12 @@ public class IcebergTableTest {
 
                 resourceMgr.getResource("iceberg0");
                 result = icebergResource;
+
+                icebergCatalog.loadTable((TableIdentifier) any);
+                result = iTable;
+
+                iTable.schema();
+                result = schema;
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/external/iceberg/IcebergCustomCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/external/iceberg/IcebergCustomCatalogTest.java
@@ -42,16 +42,16 @@ public class IcebergCustomCatalogTest {
     public void testCatalogType(@Tested IcebergCustomTestingCatalog customTestingCatalog) {
         new MockUp<CatalogUtil>() {
             @Mock
-            public Catalog loadCatalog(String impl, String catalogName,
+            public Catalog loadCatalog(String catalogImpl, String catalogName,
                                        Map<String, String> properties,
                                        Configuration hadoopConf) {
                 return customTestingCatalog;
             }
         };
 
-        String customImpl = IcebergCustomTestingCatalog.class.getName();
+        String catalogImpl = IcebergCustomTestingCatalog.class.getName();
         Map<String, String> icebergProperties = new HashMap<>();
-        IcebergCatalog customCatalog = IcebergUtil.getIcebergCustomCatalog(customImpl, icebergProperties);
+        IcebergCatalog customCatalog = IcebergUtil.getIcebergCustomCatalog(catalogImpl, icebergProperties);
         Assert.assertEquals(IcebergCatalogType.CUSTOM_CATALOG, customCatalog.getIcebergCatalogType());
     }
 
@@ -68,16 +68,16 @@ public class IcebergCustomCatalogTest {
 
         new MockUp<CatalogUtil>() {
             @Mock
-            public Catalog loadCatalog(String impl, String catalogName,
+            public Catalog loadCatalog(String catalogImpl, String catalogName,
                                        Map<String, String> properties,
                                        Configuration hadoopConf) {
                 return customTestingCatalog;
             }
         };
 
-        String customImpl = IcebergCustomTestingCatalog.class.getName();
+        String catalogImpl = IcebergCustomTestingCatalog.class.getName();
         Map<String, String> icebergProperties = new HashMap<>();
-        IcebergCatalog customCatalog = IcebergUtil.getIcebergCustomCatalog(customImpl, icebergProperties);
+        IcebergCatalog customCatalog = IcebergUtil.getIcebergCustomCatalog(catalogImpl, icebergProperties);
         Table table = customCatalog.loadTable(identifier);
         Assert.assertEquals("test", table.name());
     }

--- a/fe/fe-core/src/test/java/com/starrocks/external/iceberg/IcebergCustomCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/external/iceberg/IcebergCustomCatalogTest.java
@@ -1,0 +1,207 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.external.iceberg;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.starrocks.catalog.IcebergTable;
+import com.starrocks.external.iceberg.hive.CachedClientPool;
+import com.starrocks.external.iceberg.hive.HiveTableOperations;
+import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
+import mockit.Tested;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.iceberg.BaseMetastoreCatalog;
+import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.CatalogUtil;
+import org.apache.iceberg.ClientPool;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.hadoop.HadoopFileIO;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.thrift.TException;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class IcebergCustomCatalogTest {
+
+    @Test
+    public void testCatalogType(@Tested IcebergCustomTestingCatalog customTestingCatalog) {
+        new MockUp<CatalogUtil>() {
+            @Mock
+            public Catalog loadCatalog(String impl, String catalogName,
+                                       Map<String, String> properties,
+                                       Configuration hadoopConf) {
+                return customTestingCatalog;
+            }
+        };
+
+        String impl = IcebergCustomTestingCatalog.class.getName();
+        Map<String, String> icebergProperties = new HashMap<>();
+        IcebergCatalog customCatalog = (IcebergCatalog) CatalogLoader.custom(String.format("Custom-%s", impl),
+                        new Configuration(), icebergProperties, impl).loadCatalog();
+        Assert.assertEquals(IcebergCatalogType.CUSTOM_CATALOG, customCatalog.getIcebergCatalogType());
+    }
+
+    @Test
+    public void testLoadTable(@Mocked IcebergCustomTestingCatalog customTestingCatalog) {
+        TableIdentifier identifier = IcebergUtil.getIcebergTableIdentifier("db", "table");
+        new Expectations() {
+            {
+                customTestingCatalog.loadTable(identifier);
+                result = new BaseTable(null, "test");
+                minTimes = 0;
+            }
+        };
+
+        new MockUp<CatalogUtil>() {
+            @Mock
+            public Catalog loadCatalog(String impl, String catalogName,
+                                       Map<String, String> properties,
+                                       Configuration hadoopConf) {
+                return customTestingCatalog;
+            }
+        };
+
+        String impl = IcebergCustomTestingCatalog.class.getName();
+        Map<String, String> icebergProperties = new HashMap<>();
+        IcebergCatalog customCatalog = (IcebergCatalog) CatalogLoader.custom(String.format("Custom-%s", impl),
+                        new Configuration(), icebergProperties, impl).loadCatalog();
+        Table table = customCatalog.loadTable(identifier);
+        Assert.assertEquals("test", table.name());
+    }
+
+//    @Test
+//    public void testLoadCatalogCustom() {
+//        String catalogName = "barCatalog";
+//        conf.set(InputFormatConfig.catalogPropertyConfigKey(catalogName, CatalogProperties.CATALOG_IMPL),
+//                IcebergCustomTestingCatalog.class.getName());
+//        conf.set(InputFormatConfig.catalogPropertyConfigKey(catalogName, CatalogProperties.WAREHOUSE_LOCATION),
+//                "/tmp/mylocation");
+//        Optional<Catalog> customHadoopCatalog = Catalogs.loadCatalog(conf, catalogName);
+//        Assert.assertTrue(customHadoopCatalog.isPresent());
+//        Assertions.assertThat(customHadoopCatalog.get()).isInstanceOf(IcebergCustomTestingCatalog.class);
+//        Properties properties = new Properties();
+//        properties.put(InputFormatConfig.CATALOG_NAME, catalogName);
+//        Assert.assertFalse(Catalogs.hiveCatalog(conf, properties));
+//    }
+
+    private static class IcebergCustomTestingCatalog extends BaseMetastoreCatalog implements IcebergCatalog {
+
+        private String name;
+        private Configuration conf;
+        private FileIO fileIO;
+        private ClientPool<IMetaStoreClient, TException> clients;
+
+        @VisibleForTesting
+        private IcebergCustomTestingCatalog() {}
+
+        @Override
+        public IcebergCatalogType getIcebergCatalogType() {
+            return IcebergCatalogType.CUSTOM_CATALOG;
+        }
+
+        @Override
+        public Table loadTable(IcebergTable table) throws StarRocksIcebergException {
+            TableIdentifier tableId = IcebergUtil.getIcebergTableIdentifier(table);
+            return loadTable(tableId, null, null);
+        }
+
+        @Override
+        public Table loadTable(TableIdentifier tableIdentifier) throws StarRocksIcebergException {
+            return loadTable(tableIdentifier, null, null);
+        }
+
+        @Override
+        public Table loadTable(TableIdentifier tableId, String tableLocation,
+                               Map<String, String> properties) throws StarRocksIcebergException {
+            Preconditions.checkState(tableId != null);
+            try {
+                return super.loadTable(tableId);
+            } catch (Exception e) {
+                throw new StarRocksIcebergException(String.format(
+                        "Failed to load Iceberg table with id: %s", tableId), e);
+            }
+        }
+
+        @Override
+        public void initialize(String inputName, Map<String, String> properties) {
+            this.name = inputName;
+            if (conf == null) {
+                this.conf = new Configuration();
+            }
+
+            if (properties.containsKey(CatalogProperties.URI)) {
+                this.conf.set(HiveConf.ConfVars.METASTOREURIS.varname, properties.get(CatalogProperties.URI));
+            }
+
+            if (properties.containsKey(CatalogProperties.WAREHOUSE_LOCATION)) {
+                this.conf.set(HiveConf.ConfVars.METASTOREWAREHOUSE.varname,
+                        properties.get(CatalogProperties.WAREHOUSE_LOCATION));
+            }
+
+            String fileIOImpl = properties.get(CatalogProperties.FILE_IO_IMPL);
+            this.fileIO = fileIOImpl == null ? new HadoopFileIO(conf) : CatalogUtil.loadFileIO(fileIOImpl, properties, conf);
+
+            this.clients = new CachedClientPool(conf, properties);
+        }
+
+        @Override
+        public String name() {
+            return name;
+        }
+
+        @Override
+        protected boolean isValidIdentifier(TableIdentifier tableIdentifier) {
+            return tableIdentifier.namespace().levels().length == 1;
+        }
+
+        @Override
+        public TableOperations newTableOps(TableIdentifier tableIdentifier) {
+            String dbName = tableIdentifier.namespace().level(0);
+            String tableName = tableIdentifier.name();
+            return new HiveTableOperations(conf, clients, fileIO, name, dbName, tableName);
+        }
+
+        @Override
+        protected String defaultWarehouseLocation(TableIdentifier tableIdentifier) {
+            throw new UnsupportedOperationException("Not implemented");
+        }
+
+        @Override
+        public List<TableIdentifier> listTables(Namespace namespace) {
+            throw new UnsupportedOperationException("Not implemented");
+        }
+
+        @Override
+        public boolean dropTable(TableIdentifier tableIdentifier, boolean b) {
+            throw new UnsupportedOperationException("Not implemented");
+        }
+
+        @Override
+        public void renameTable(TableIdentifier tableIdentifier, TableIdentifier tableIdentifier1) {
+            throw new UnsupportedOperationException("Not implemented");
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(this)
+                    .add("name", name)
+                    .add("uri", this.conf == null ? "" : this.conf.get(HiveConf.ConfVars.METASTOREURIS.varname))
+                    .toString();
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/external/iceberg/IcebergCustomCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/external/iceberg/IcebergCustomCatalogTest.java
@@ -49,9 +49,9 @@ public class IcebergCustomCatalogTest {
             }
         };
 
-        String impl = IcebergCustomTestingCatalog.class.getName();
+        String customImpl = IcebergCustomTestingCatalog.class.getName();
         Map<String, String> icebergProperties = new HashMap<>();
-        IcebergCatalog customCatalog = IcebergUtil.getIcebergCustomCatalog(impl, icebergProperties);
+        IcebergCatalog customCatalog = IcebergUtil.getIcebergCustomCatalog(customImpl, icebergProperties);
         Assert.assertEquals(IcebergCatalogType.CUSTOM_CATALOG, customCatalog.getIcebergCatalogType());
     }
 
@@ -75,9 +75,9 @@ public class IcebergCustomCatalogTest {
             }
         };
 
-        String impl = IcebergCustomTestingCatalog.class.getName();
+        String customImpl = IcebergCustomTestingCatalog.class.getName();
         Map<String, String> icebergProperties = new HashMap<>();
-        IcebergCatalog customCatalog = IcebergUtil.getIcebergCustomCatalog(impl, icebergProperties);
+        IcebergCatalog customCatalog = IcebergUtil.getIcebergCustomCatalog(customImpl, icebergProperties);
         Table table = customCatalog.loadTable(identifier);
         Assert.assertEquals("test", table.name());
     }

--- a/fe/fe-core/src/test/java/com/starrocks/external/iceberg/IcebergCustomCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/external/iceberg/IcebergCustomCatalogTest.java
@@ -51,8 +51,7 @@ public class IcebergCustomCatalogTest {
 
         String impl = IcebergCustomTestingCatalog.class.getName();
         Map<String, String> icebergProperties = new HashMap<>();
-        IcebergCatalog customCatalog = (IcebergCatalog) CatalogLoader.custom(String.format("Custom-%s", impl),
-                        new Configuration(), icebergProperties, impl).loadCatalog();
+        IcebergCatalog customCatalog = IcebergUtil.getIcebergCustomCatalog(impl, icebergProperties);
         Assert.assertEquals(IcebergCatalogType.CUSTOM_CATALOG, customCatalog.getIcebergCatalogType());
     }
 
@@ -78,28 +77,12 @@ public class IcebergCustomCatalogTest {
 
         String impl = IcebergCustomTestingCatalog.class.getName();
         Map<String, String> icebergProperties = new HashMap<>();
-        IcebergCatalog customCatalog = (IcebergCatalog) CatalogLoader.custom(String.format("Custom-%s", impl),
-                        new Configuration(), icebergProperties, impl).loadCatalog();
+        IcebergCatalog customCatalog = IcebergUtil.getIcebergCustomCatalog(impl, icebergProperties);
         Table table = customCatalog.loadTable(identifier);
         Assert.assertEquals("test", table.name());
     }
 
-//    @Test
-//    public void testLoadCatalogCustom() {
-//        String catalogName = "barCatalog";
-//        conf.set(InputFormatConfig.catalogPropertyConfigKey(catalogName, CatalogProperties.CATALOG_IMPL),
-//                IcebergCustomTestingCatalog.class.getName());
-//        conf.set(InputFormatConfig.catalogPropertyConfigKey(catalogName, CatalogProperties.WAREHOUSE_LOCATION),
-//                "/tmp/mylocation");
-//        Optional<Catalog> customHadoopCatalog = Catalogs.loadCatalog(conf, catalogName);
-//        Assert.assertTrue(customHadoopCatalog.isPresent());
-//        Assertions.assertThat(customHadoopCatalog.get()).isInstanceOf(IcebergCustomTestingCatalog.class);
-//        Properties properties = new Properties();
-//        properties.put(InputFormatConfig.CATALOG_NAME, catalogName);
-//        Assert.assertFalse(Catalogs.hiveCatalog(conf, properties));
-//    }
-
-    private static class IcebergCustomTestingCatalog extends BaseMetastoreCatalog implements IcebergCatalog {
+    public static class IcebergCustomTestingCatalog extends BaseMetastoreCatalog implements IcebergCatalog {
 
         private String name;
         private Configuration conf;

--- a/fe/fe-core/src/test/java/com/starrocks/external/iceberg/IcebergHiveCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/external/iceberg/IcebergHiveCatalogTest.java
@@ -40,7 +40,7 @@ public class IcebergHiveCatalogTest {
 
         new MockUp<CatalogUtil>() {
           @Mock
-          public Catalog loadCatalog(String impl, String catalogName,
+          public Catalog loadCatalog(String catalogImpl, String catalogName,
                                      Map<String, String> properties,
                                      Configuration hadoopConf) {
               return hiveCatalog;

--- a/fe/fe-core/src/test/java/com/starrocks/external/iceberg/IcebergUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/external/iceberg/IcebergUtilTest.java
@@ -26,9 +26,8 @@ public class IcebergUtilTest {
     }
 
     @Test
-    public void testGetIcebergCatalog() {
-        IcebergCatalog catalog = IcebergUtil.getIcebergCatalog(
-                IcebergCatalogType.HIVE_CATALOG, "thrift://test:9030");
+    public void testGetIcebergHiveCatalog() {
+        IcebergCatalog catalog = IcebergUtil.getIcebergHiveCatalog("thrift://test:9030");
         Assert.assertTrue(catalog instanceof IcebergHiveCatalog);
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3826

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Add support for custom catalog which can be defined by users themselves when creating iceberg external table.

The custom catalog should be in the form of IcebergHiveCatalog, in other words extending BaseMetastoreCatalog and implementing IcebergCatalog. The catalog JAR should be placed into each fe/lib directory, and FE has to be restarted before custom catalog works.

Usage:
```sql
CREATE EXTERNAL RESOURCE "iceberg0"
PROPERTIES (
  "type" = "iceberg",
  "starrocks.catalog-type"="CUSTOM",
  "iceberg.catalog-impl"="{The full class name of custom catalog}"
);
```
Extra config users defined can be added in table properties when executing CREATE EXTERNAL TABLE, see #2225.