### PR TITLE
Fix priority of not in AST2SQL

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AST2SQL.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AST2SQL.java
@@ -394,11 +394,11 @@ public class AST2SQL {
                 output.append(" ").append(visit(node.getChild(childIdx++)));
             }
             while (childIdx + 2 <= node.getChildren().size()) {
-                output.append(" WHEN " + visit(node.getChild(childIdx++)));
-                output.append(" THEN " + visit(node.getChild(childIdx++)));
+                output.append(" WHEN ").append(visit(node.getChild(childIdx++)));
+                output.append(" THEN ").append(visit(node.getChild(childIdx++)));
             }
             if (hasElseExpr) {
-                output.append(" ELSE " + visit(node.getChild(node.getChildren().size() - 1)));
+                output.append(" ELSE ").append(visit(node.getChild(node.getChildren().size() - 1)));
             }
             output.append(" END");
             return output.toString();
@@ -415,9 +415,10 @@ public class AST2SQL {
 
         public String visitCompoundPredicate(CompoundPredicate node, Void context) {
             StringBuilder sqlBuilder = new StringBuilder();
-            if (node.getChildren().size() == 1) {
-                sqlBuilder.append("NOT ");
+            if (CompoundPredicate.Operator.NOT.equals(node.getOp())) {
+                sqlBuilder.append("( NOT ");
                 sqlBuilder.append(printWithParentheses(node.getChild(0)));
+                sqlBuilder.append(" )");
             } else {
                 sqlBuilder.append(printWithParentheses(node.getChild(0)));
                 sqlBuilder.append(" ").append(node.getOp()).append(" ");
@@ -545,16 +546,16 @@ public class AST2SQL {
             if (intervalFirst) {
                 // Non-function-call like version with interval as first operand.
                 strBuilder.append("INTERVAL ");
-                strBuilder.append(visit(node.getChild(1)) + " ");
+                strBuilder.append(visit(node.getChild(1))).append(" ");
                 strBuilder.append(timeUnitIdent);
                 strBuilder.append(" ").append(op.toString()).append(" ");
                 strBuilder.append(visit(node.getChild(0)));
             } else {
                 // Non-function-call like version with interval as second operand.
                 strBuilder.append(visit(node.getChild(0)));
-                strBuilder.append(" " + op.toString() + " ");
+                strBuilder.append(" ").append(op.toString()).append(" ");
                 strBuilder.append("INTERVAL ");
-                strBuilder.append(visit(node.getChild(1)) + " ");
+                strBuilder.append(visit(node.getChild(1))).append(" ");
                 strBuilder.append(timeUnitIdent);
             }
             return strBuilder.toString();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AST2SQLTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AST2SQLTest.java
@@ -1,0 +1,53 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.sql.analyzer;
+
+import com.starrocks.analysis.CreateViewStmt;
+import com.starrocks.analysis.StatementBase;
+import com.starrocks.sql.parser.SqlParser;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.List;
+
+public class AST2SQLTest {
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        AnalyzeTestUtil.init();
+    }
+
+    @Test
+    public void testNot() {
+        {
+            String sql;
+            sql = "CREATE VIEW v3 AS \n" +
+                    "SELECT v1 FROM t0 WHERE ((NOT false) IS NULL);";
+            List<StatementBase>
+                    statementBase =
+                    SqlParser.parse(sql, AnalyzeTestUtil.getConnectContext().getSessionVariable().getSqlMode());
+            Assert.assertEquals(1, statementBase.size());
+            StatementBase baseStmt = statementBase.get(0);
+            Analyzer.analyze(baseStmt, AnalyzeTestUtil.getConnectContext());
+            Assert.assertTrue(baseStmt instanceof CreateViewStmt);
+            CreateViewStmt viewStmt = (CreateViewStmt) baseStmt;
+            Assert.assertEquals(viewStmt.getInlineViewDef(),
+                    "SELECT `default_cluster:test`.`t0`.`v1` AS `v1` FROM `default_cluster:test`.`t0` WHERE ( NOT FALSE ) IS NULL");
+        }
+        {
+            String sql;
+            sql = "CREATE VIEW v3 AS \n" +
+                    "SELECT v1 FROM t0 WHERE ((NOT false) IS NOT NULL);";
+            List<StatementBase>
+                    statementBase =
+                    SqlParser.parse(sql, AnalyzeTestUtil.getConnectContext().getSessionVariable().getSqlMode());
+            Assert.assertEquals(1, statementBase.size());
+            StatementBase baseStmt = statementBase.get(0);
+            Analyzer.analyze(baseStmt, AnalyzeTestUtil.getConnectContext());
+            Assert.assertTrue(baseStmt instanceof CreateViewStmt);
+            CreateViewStmt viewStmt = (CreateViewStmt) baseStmt;
+            Assert.assertEquals(viewStmt.getInlineViewDef(),
+                    "SELECT `default_cluster:test`.`t0`.`v1` AS `v1` FROM `default_cluster:test`.`t0` WHERE ( NOT FALSE ) IS NOT NULL");
+        }
+    }
+}


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5026

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->



```sql
CREATE VIEW v1 AS 
SELECT t0.c_0_0 FROM t0 WHERE ((NOT false) IS NULL);
```
When converting ast back to sql, the output content is `SELECT t0.c_0_0 FROM t0 WHERE NOT false IS NULL` 

Given that union operator `not`'s priority < `is null` operator,  so the order of operators is changed

So we need wrap `not` operator with "()" when convert ast to sql