### PR TITLE
Fix SinkBuffer block problem

### DIFF
--- a/be/src/exec/pipeline/exchange/sink_buffer.cpp
+++ b/be/src/exec/pipeline/exchange/sink_buffer.cpp
@@ -30,8 +30,7 @@ SinkBuffer::SinkBuffer(FragmentContext* fragment_ctx, const std::vector<TPlanFra
         } else {
             _num_sinkers[instance_id.lo] = num_sinkers;
 
-            _request_seqs[instance_id.lo] = 0;
-            // request_seq starts from 0, so the max_continuous_acked_seq should be -1
+            _request_seqs[instance_id.lo] = -1;
             _max_continuous_acked_seqs[instance_id.lo] = -1;
             _discontinuous_acked_seqs[instance_id.lo] = std::unordered_set<int64_t>();
             _buffers[instance_id.lo] = std::queue<TransmitChunkInfo, std::list<TransmitChunkInfo>>();
@@ -265,7 +264,7 @@ void SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id) {
         }
 
         *request.params->mutable_finst_id() = _instance_id2finst_id[instance_id.lo];
-        request.params->set_sequence(_request_seqs[instance_id.lo]++);
+        request.params->set_sequence(++_request_seqs[instance_id.lo]);
 
         if (!request.attachment.empty()) {
             _bytes_sent += request.attachment.size();

--- a/be/src/exec/pipeline/exchange/sink_buffer.h
+++ b/be/src/exec/pipeline/exchange/sink_buffer.h
@@ -90,6 +90,10 @@ private:
     // not all the acks received with sequence from [_max_continuous_acked_seqs[x]+1, _request_seqs[x]]
     // _discontinuous_acked_seqs[x] stored the received discontinuous acks
     void _process_send_window(const TUniqueId& instance_id, const int64_t sequence);
+
+    // This method must invoked under the protection of _mutexes[instance_id.lo]
+    // But we cannot add lock in the body of this function, because we need to put this function
+    // and other extra works before calling this function together as an atomic operation
     void _try_to_send_rpc(const TUniqueId& instance_id);
 
     // Roughly estimate network time which is defined as the time between sending a and receiving a packet,

--- a/be/src/exec/pipeline/exchange/sink_buffer.h
+++ b/be/src/exec/pipeline/exchange/sink_buffer.h
@@ -91,10 +91,9 @@ private:
     // _discontinuous_acked_seqs[x] stored the received discontinuous acks
     void _process_send_window(const TUniqueId& instance_id, const int64_t sequence);
 
-    // This method must invoked under the protection of _mutexes[instance_id.lo]
-    // But we cannot add lock in the body of this function, because we need to put this function
-    // and other extra works before calling this function together as an atomic operation
-    void _try_to_send_rpc(const TUniqueId& instance_id);
+    // Try to send rpc if buffer is not empty and channel is not busy
+    // And we need to put this function and other extra works(pre_works) together as an atomic operation
+    void _try_to_send_rpc(const TUniqueId& instance_id, std::function<void()> pre_works);
 
     // Roughly estimate network time which is defined as the time between sending a and receiving a packet,
     // and the processing time of both sides are excluded


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5222

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

When `pipeline_sink_brpc_dop` is set to 1, considering the following codes.

* `_request_seqs[instance_id.lo]` is 0, which is init value
* `_max_continuous_acked_seqs[instance_id.lo]` is -1, which is init value
*  so `discontinuous_acked_window_size` is `0 - (-1) = 1`
* `too_much_brpc_process` turns out to be true even we didn't send any packet, then block occurred

```c++
        if (_is_dest_merge) {
            // discontinuous_acked_window_size means that we are not received all the ack
            // with sequence from _max_continuous_acked_seqs[x] to _request_seqs[x]
            // Limit the size of the window to avoid buffering too much out-of-order data at the receiving side
            int64_t discontinuous_acked_window_size =
                    _request_seqs[instance_id.lo] - _max_continuous_acked_seqs[instance_id.lo];
            too_much_brpc_process = discontinuous_acked_window_size >= config::pipeline_sink_brpc_dop;
        }
```