### PR TITLE
Fix: use strict mode of DateTimeFormatter for parsing string to date

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
@@ -20,6 +20,7 @@ import java.math.BigInteger;
 import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.ResolverStyle;
 import java.time.format.SignStyle;
 import java.time.temporal.ChronoField;
 import java.util.List;
@@ -60,7 +61,8 @@ public final class ConstantOperator extends ScalarOperator implements Comparable
     // Don't need fixWidth
     private static final DateTimeFormatter DATE_TIME_FORMATTER_MS =
             DateUtils.unixDatetimeFormatBuilder("%Y-%m-%d %H:%i:%s.")
-                    .appendValue(ChronoField.MICRO_OF_SECOND, 1, 6, SignStyle.NORMAL).toFormatter();
+                    .appendValue(ChronoField.MICRO_OF_SECOND, 1, 6, SignStyle.NORMAL)
+                    .toFormatter().withResolverStyle(ResolverStyle.STRICT);
 
     private static void requiredValid(LocalDateTime dateTime) throws SemanticException {
         if (null == dateTime || dateTime.isBefore(MIN_DATETIME) || dateTime.isAfter(MAX_DATETIME)) {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/DateLiteralTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/DateLiteralTest.java
@@ -81,6 +81,60 @@ public class DateLiteralTest {
 
     @Test
     public void invalidDate() {
-        Assert.assertThrows(AnalysisException.class, () -> new DateLiteral("2019-02-29", Type.DATETIME));
+        String[] testDateCases = {
+                // Invalid year.
+                "20190-05-31",
+                "1-05-31",
+                // Invalid month.
+                "2019-5-31",
+                "2019-16-31",
+                // Invalid day.
+                "2019-02-29",
+                "2019-04-31",
+                "2019-05-32",
+
+                // Other invalid formats.
+                "2019-05-31-1",
+                "not-date",
+        };
+        for (String c : testDateCases) {
+            Assert.assertThrows(AnalysisException.class, () -> new DateLiteral(c, Type.DATE));
+        }
+
+        String[] testDatetimeCases = {
+                // Invalid year.
+                "20190-05-31 10:11:12",
+                "20190-05-31 10:11:12.123",
+                "1-05-31 10:11:12",
+                "1-05-31 10:11:12.123",
+                // Invalid month.
+                "2019-5-31 10:11:12",
+                "2019-5-31 10:11:12.123",
+                "2019-16-31 10:11:12",
+                "2019-16-31 10:11:12.123",
+                // Invalid day.
+                "2019-02-29 10:11:12",
+                "2019-02-29 10:11:12.123",
+                "2019-04-31 10:11:12",
+                "2019-04-31 10:11:12.123",
+                "2019-05-32 10:11:12",
+                "2019-05-32 10:11:12.123",
+                // Invalid hour, minute, or second.
+                "2019-05-31 25:11:12",
+                "2019-05-31 25:11:12.123",
+                "2019-05-31 10:61:12",
+                "2019-05-31 10:61:12.123",
+                "2019-05-31 10:11:61",
+                "2019-05-31 10:11:61.123",
+                "2019-05-31 10:11:12.1234567",
+
+                // Other invalid formats.
+                "2019-05-31-1 10:11:12",
+                "2019-05-31-1 10:11:12.123",
+                "not-date",
+        };
+        for (String c : testDatetimeCases) {
+            Assert.assertThrows(AnalysisException.class, () -> new DateLiteral(c, Type.DATETIME));
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/operator/operator/ConstantOperatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/operator/operator/ConstantOperatorTest.java
@@ -1,0 +1,97 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.sql.optimizer.operator.operator;
+
+import com.starrocks.catalog.Type;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ConstantOperatorTest {
+    @Test
+    public void testCastToDateValid() throws Exception {
+        String[][] testCases = {
+                // YYYY-MM-dd or yy-MM-dd
+                {"1997-10-07", "1997-10-07T00:00", "1997-10-07T00:00"},
+                {"0097-10-07", "0097-10-07T00:00", "0097-10-07T00:00"},
+                {"2020-02-29", "2020-02-29T00:00", "2020-02-29T00:00"}, // Leap year.
+                {"97-10-07", "1997-10-07T00:00", "1997-10-07T00:00"},
+                {"99-10-07", "1999-10-07T00:00", "1999-10-07T00:00"},
+                {"70-10-07", "1970-10-07T00:00", "1970-10-07T00:00"},
+                {"69-10-07", "2069-10-07T00:00", "2069-10-07T00:00"},
+                {"00-10-07", "2000-10-07T00:00", "2000-10-07T00:00"},
+                // YYYY-MM-dd HH:mm:ss or yy-MM-dd HH:mm:ss
+                {"1997-10-07 10:11:12", "1997-10-07T00:00", "1997-10-07T10:11:12"},
+                {"0097-10-07 10:11:12", "0097-10-07T00:00", "0097-10-07T10:11:12"},
+                {"2020-02-29 10:11:12", "2020-02-29T00:00", "2020-02-29T10:11:12"}, // Leap year.
+                {"97-10-07 10:11:12", "1997-10-07T00:00", "1997-10-07T10:11:12"},
+                {"99-10-07 10:11:12", "1999-10-07T00:00", "1999-10-07T10:11:12"},
+                {"70-10-07 10:11:12", "1970-10-07T00:00", "1970-10-07T10:11:12"},
+                {"69-10-07 10:11:12", "2069-10-07T00:00", "2069-10-07T10:11:12"},
+                {"00-10-07 10:11:12", "2000-10-07T00:00", "2000-10-07T10:11:12"},
+                // YYYY-MM-dd HH:mm:ss.SSS
+                {"1997-10-07 10:11:12.123", "1997-10-07T10:11:12.000123", "1997-10-07T10:11:12.000123"},
+                {"0097-10-07 10:11:12.123", "0097-10-07T10:11:12.000123", "0097-10-07T10:11:12.000123"},
+                {"2020-02-29 10:11:12.123", "2020-02-29T10:11:12.000123", "2020-02-29T10:11:12.000123"}, // Leap year.
+        };
+
+        for (String[] c : testCases) {
+            ConstantOperator in = ConstantOperator.createVarchar(c[0]);
+            Assert.assertEquals(c[1], in.castTo(Type.DATE).getDate().toString());
+            Assert.assertEquals(c[2], in.castTo(Type.DATETIME).getDate().toString());
+        }
+    }
+
+    @Test
+    public void testCaseToDateInvalid() {
+        String[] testCases = {
+                // Invalid year.
+                "20190-05-31",
+                "20190-05-31 10:11:12",
+                "20190-05-31 10:11:12.123",
+                "1-05-31",
+                "1-05-31 10:11:12",
+                "1-05-31 10:11:12.123",
+                // Invalid month.
+                "2019-5-31",
+                "2019-5-31 10:11:12",
+                "2019-5-31 10:11:12.123",
+                "2019-16-31",
+                "2019-16-31 10:11:12",
+                "2019-16-31 10:11:12.123",
+                // Invalid day.
+                "2019-02-29",
+                "2019-02-29 10:11:12",
+                "2019-02-29 10:11:12.123",
+                "2019-04-31",
+                "2019-04-31 10:11:12",
+                "2019-04-31 10:11:12.123",
+                "2019-05-32",
+                "2019-05-32 10:11:12",
+                "2019-05-32 10:11:12.123",
+                // Invalid hour, minute, or second.
+                "2019-05-31 25:11:12",
+                "2019-05-31 25:11:12.123",
+                "2019-05-31 10:61:12",
+                "2019-05-31 10:61:12.123",
+                "2019-05-31 10:11:61",
+                "2019-05-31 10:11:61.123",
+                "2019-05-31 10:11:12.1234567",
+
+                // Only support "YYYY-MM-dd HH:mm:ss", not "yy-MM-dd HH:mm:ss".
+                "97-10-07 10:11:12.123",
+
+                // Other invalid formats.
+                "2019-05-31-1",
+                "2019-05-31-1 10:11:12",
+                "2019-05-31-1 10:11:12.123",
+                "not-date",
+        };
+        for (String c : testCases) {
+            ConstantOperator in = ConstantOperator.createVarchar(c);
+            Assert.assertThrows(AnalysisException.class, () -> in.castTo(Type.DATE));
+            Assert.assertThrows(AnalysisException.class, () -> in.castTo(Type.DATETIME));
+        }
+    }
+}


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others


## Problem Summary：
The previous PR #4994 missed adding `STRICT` mode to `castTo` with `YYYY-MM-dd HH:mm:ss.SSS` format.

## Modification
- Add `STRICT` mode to `castTo` with `YYYY-MM-dd HH:mm:ss.SSS` format. 
- Add FE UT
     - Valid castTo date and datetime.
     - Invalid castTo date and datetime.
     - Invalid new DateLiteral.
