### PR TITLE
Fix unknow error when CallOperator as predicate and the table has mat…

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRule.java
@@ -33,7 +33,6 @@ import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CaseWhenOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
-import com.starrocks.sql.optimizer.operator.scalar.PredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
 import com.starrocks.sql.optimizer.rule.Rule;
@@ -226,7 +225,6 @@ public class MaterializedViewRule extends Rule {
         if (logicalOperator.getPredicate() != null) {
             ScalarOperator scalarOperator = logicalOperator.getPredicate();
             if (!scalarOperator.isConstantRef()) {
-                Preconditions.checkState(scalarOperator instanceof PredicateOperator);
                 updateTableToColumns(scalarOperator, columnIdsInPredicates);
             }
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVRewriteTest.java
@@ -32,8 +32,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.util.UUID;
-
 public class MVRewriteTest {
     private static final String EMPS_TABLE_NAME = "emps";
     private static final String EMPS_MV_NAME = "emps_mv";
@@ -1201,6 +1199,14 @@ public class MVRewriteTest {
         String query =
                 "select * from ods_order where bank_transaction_id not in (select sum(cast(salary as smallint)) as ssalary from " +
                         EMPS_TABLE_NAME + " group by deptno)";
+        starRocksAssert.withMaterializedView(createEmpsMVSQL).query(query).explainContains(QUERY_USE_EMPS);
+    }
+
+    @Test
+    public void testPredicateIsCallOperator() throws Exception {
+        String createEmpsMVSQL = "create materialized view " + EMPS_MV_NAME + " as select empid, deptno "
+                + "from " + EMPS_TABLE_NAME + ";";
+        String query = "select count(*) from " + EMPS_TABLE_NAME + " where bitmap_contains(to_bitmap(1),2)";
         starRocksAssert.withMaterializedView(createEmpsMVSQL).query(query).explainContains(QUERY_USE_EMPS);
     }
 }


### PR DESCRIPTION
…erialized view

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

for https://github.com/StarRocks/starrocks/issues/5035

This check is wrong if the predicate is bool return type CallOperator 
```
   Preconditions.checkState(scalarOperator instanceof PredicateOperator);
```
