### PR TITLE
Fix fail to prepare tablet reader bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -690,7 +690,7 @@ public class DatabaseTransactionMgr {
                             // if most replica's version have been updated to version published
                             // which means publish version task finished in replica  
                             for (Replica replica : ((LocalTablet) tablet).getReplicas()) {
-                                if (!errReplicas.contains(replica.getId()) && replica.getLastFailedVersion() < 0) {
+                                if (!errReplicas.contains(replica.getId())) {
                                     if (replica.getVersion() >= partitionCommitInfo.getVersion()) {
                                         ++healthReplicaNum;
                                     } else if (unfinishedBackends != null

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -662,6 +662,7 @@ public class DatabaseTransactionMgr {
                 long tableId = tableCommitInfo.getTableId();
                 OlapTable table = (OlapTable) db.getTable(tableId);
                 // table maybe dropped between commit and publish, ignore it
+                // it will be processed in finishTransaction
                 if (table == null) {
                     continue;
                 }
@@ -686,20 +687,33 @@ public class DatabaseTransactionMgr {
                     int quorumNum = partitionInfo.getQuorumNum(partitionId);
                     for (MaterializedIndex index : allIndices) {
                         for (Tablet tablet : index.getTablets()) {
-                            int healthReplicaNum = 0;
+                            int successHealthyReplicaNum = 0;
                             // if most replica's version have been updated to version published
                             // which means publish version task finished in replica  
                             for (Replica replica : ((LocalTablet) tablet).getReplicas()) {
                                 if (!errReplicas.contains(replica.getId())) {
-                                    if (replica.getVersion() >= partitionCommitInfo.getVersion()) {
-                                        ++healthReplicaNum;
+                                    // success healthy replica condition:
+                                    // 1. version is equal to partition's visible version
+                                    // 2. publish version task in this replica has finished
+                                    if (replica.checkVersionCatchUp(partition.getVisibleVersion(), true)
+                                            && replica.getLastFailedVersion() < 0
+                                            && (unfinishedBackends == null
+                                            || !unfinishedBackends.contains(replica.getBackendId()))) {
+                                        ++successHealthyReplicaNum;
                                     } else if (unfinishedBackends != null
                                             && unfinishedBackends.contains(replica.getBackendId())) {
                                         errReplicas.add(replica.getId());
                                     }
+                                } else if (replica.getVersion() >= partitionCommitInfo.getVersion()) {
+                                    // the replica's version is larger than or equal to current transaction partition's version
+                                    // the replica is normal, then remove it from error replica ids
+                                    // this branch will be true if BE's replica reports it's version to FE
+                                    // after publish version succeed in BE
+                                    errReplicas.remove(replica.getId());
+                                    ++successHealthyReplicaNum;
                                 }
                             }
-                            if (healthReplicaNum < quorumNum) {
+                            if (successHealthyReplicaNum < quorumNum) {
                                 return false;
                             }
                         }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -106,6 +106,9 @@ public class PublishVersionDaemon extends MasterDaemon {
                     }
                 } else {
                     allTaskFinished = false;
+                    // Publish version task may succeed and finish in quorum replicas
+                    // but not finish in one replica.
+                    // here collect the backendId that do not finish publish version
                     unfinishedBackends.add(publishVersionTask.getBackendId());
                 }
             }

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/GlobalTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/GlobalTransactionMgrTest.java
@@ -546,7 +546,10 @@ public class GlobalTransactionMgrTest {
         assertEquals(CatalogTestUtil.testStartVersion + 1, replcia3.getLastFailedVersion());
 
         errorReplicaIds = Sets.newHashSet();
-        assertEquals(masterTransMgr.canTxnFinished(transactionState, errorReplicaIds, Sets.newHashSet()), false);
+        Set<Long> unfinishedBackends = Sets.newHashSet(replcia2.getBackendId(), replcia3.getBackendId());
+        assertEquals(masterTransMgr.canTxnFinished(transactionState, errorReplicaIds, unfinishedBackends), false);
+        errorReplicaIds = Sets.newHashSet();
+        assertEquals(masterTransMgr.canTxnFinished(transactionState, errorReplicaIds, Sets.newHashSet()), true);
         masterTransMgr.finishTransaction(CatalogTestUtil.testDbId1, transactionId, errorReplicaIds);
         assertEquals(TransactionStatus.VISIBLE, transactionState.getTransactionStatus());
         assertEquals(CatalogTestUtil.testStartVersion + 1, replcia1.getVersion());
@@ -611,7 +614,8 @@ public class GlobalTransactionMgrTest {
 
         // master finish the transaction2
         errorReplicaIds = Sets.newHashSet();
-        assertEquals(masterTransMgr.canTxnFinished(transactionState, errorReplicaIds, Sets.newHashSet()), false);
+        assertEquals(masterTransMgr.canTxnFinished(transactionState, errorReplicaIds, unfinishedBackends), false);
+        errorReplicaIds = Sets.newHashSet();
         masterTransMgr.finishTransaction(CatalogTestUtil.testDbId1, transactionId2, errorReplicaIds);
         assertEquals(TransactionStatus.VISIBLE, transactionState.getTransactionStatus());
         assertEquals(CatalogTestUtil.testStartVersion + 2, replcia1.getVersion());


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5153 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered, and what measures have you taken to fix the bug?) -->
When publish stuck in one replica and the last failed version is > 0,
the replica will not be treated as an error replica, and FE will update
the replica's version to the newest visible version of partition when the replica
report. and the query will fail because missing version because the publish
the version does not finish in BE; the version is not queryable.
And previously, the quorum success of the published version depended on the tablet report. 
I added an optimization to decide quorum success based on the publishing version task.
It will boost the publish version process from 10s+ to 0.03s.