### PR TITLE
fix #4996 exchange operator exception handling

### DIFF
--- a/be/src/exec/pipeline/exchange/exchange_merge_sort_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_merge_sort_source_operator.cpp
@@ -18,8 +18,7 @@ Status ExchangeMergeSortSourceOperator::prepare(RuntimeState* state) {
             config::exchg_node_buffer_size_bytes, _unique_metrics, true, nullptr, true,
             // ExchangeMergeSort will never perform pipeline level shuffle
             DataStreamRecvr::INVALID_DOP_FOR_NON_PIPELINE_LEVEL_SHUFFLE, true);
-    _stream_recvr->create_merger_for_pipeline(state, _sort_exec_exprs, &_is_asc_order, &_nulls_first);
-    return Status::OK();
+    return _stream_recvr->create_merger_for_pipeline(state, _sort_exec_exprs, &_is_asc_order, &_nulls_first);
 }
 
 void ExchangeMergeSortSourceOperator::close(RuntimeState* state) {
@@ -46,7 +45,7 @@ Status ExchangeMergeSortSourceOperator::set_finishing(RuntimeState* state) {
 
 StatusOr<vectorized::ChunkPtr> ExchangeMergeSortSourceOperator::pull_chunk(RuntimeState* state) {
     auto chunk = std::make_shared<vectorized::Chunk>();
-    get_next_merging(state, &chunk);
+    RETURN_IF_ERROR(get_next_merging(state, &chunk));
     eval_runtime_bloom_filters(chunk.get());
     return std::move(chunk);
 }

--- a/be/src/exec/pipeline/exchange/local_exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange_sink_operator.cpp
@@ -7,7 +7,7 @@
 
 namespace starrocks::pipeline {
 Status LocalExchangeSinkOperator::prepare(RuntimeState* state) {
-    Operator::prepare(state);
+    RETURN_IF_ERROR(Operator::prepare(state));
     _exchanger->increment_sink_number();
     return Status::OK();
 }
@@ -27,8 +27,7 @@ Status LocalExchangeSinkOperator::set_finishing(RuntimeState* state) {
 }
 
 Status LocalExchangeSinkOperator::push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) {
-    _exchanger->accept(chunk, _driver_sequence);
-    return Status::OK();
+    return _exchanger->accept(chunk, _driver_sequence);
 }
 
 } // namespace starrocks::pipeline


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4996 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

The `ExchangeMergeSortSourceOperator` didn't check the query state, cause a dead-loop when exception happens.

