### PR TITLE
[BugFix] Fix query failed because of migration

### DIFF
--- a/be/src/runtime/tablets_channel.cpp
+++ b/be/src/runtime/tablets_channel.cpp
@@ -202,7 +202,8 @@ void TabletsChannel::add_chunk(brpc::Controller* cntl, const PTabletWriterAddChu
         std::lock_guard l1(_partitions_ids_lock);
         for (auto& [_, delta_writer] : _delta_writers) {
             if (UNLIKELY(_partition_ids.count(delta_writer->partition_id()) == 0)) {
-                delta_writer->abort();
+                // no data load, abort txn without printing log
+                delta_writer->abort(false);
             } else {
                 auto cb = new WriteCallback(context.get());
                 delta_writer->commit(cb);

--- a/be/src/storage/async_delta_writer.cpp
+++ b/be/src/storage/async_delta_writer.cpp
@@ -105,8 +105,8 @@ void AsyncDeltaWriter::commit(AsyncDeltaWriterCallback* cb) {
     }
 }
 
-void AsyncDeltaWriter::abort() {
-    _writer->abort();
+void AsyncDeltaWriter::abort(bool with_log) {
+    _writer->abort(with_log);
 }
 
 } // namespace starrocks::vectorized

--- a/be/src/storage/async_delta_writer.h
+++ b/be/src/storage/async_delta_writer.h
@@ -47,7 +47,7 @@ public:
     void commit(AsyncDeltaWriterCallback* cb);
 
     // [thread-safe and wait-free]
-    void abort();
+    void abort(bool with_log = true);
 
     int64_t partition_id() const { return _writer->partition_id(); }
 

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -30,16 +30,16 @@ DeltaWriter::DeltaWriter(const DeltaWriterOptions& opt, MemTracker* mem_tracker,
           _rowset_writer(nullptr),
           _mem_table(nullptr),
           _tablet_schema(nullptr),
-          _flush_token(nullptr) {}
+          _flush_token(nullptr),
+          _with_rollback_log(true) {}
 
 DeltaWriter::~DeltaWriter() {
     SCOPED_THREAD_LOCAL_MEM_SETTER(_mem_tracker, false);
     switch (_get_state()) {
     case kUninitialized:
     case kCommitted:
-    case kInitialized:
         break;
-    case kPrepared:
+    case kWriting:
     case kClosed:
     case kAborted:
         _garbage_collection();
@@ -53,7 +53,8 @@ DeltaWriter::~DeltaWriter() {
 void DeltaWriter::_garbage_collection() {
     Status rollback_status = Status::OK();
     if (_tablet != nullptr) {
-        rollback_status = _storage_engine->txn_manager()->rollback_txn(_opt.partition_id, _tablet, _opt.txn_id);
+        rollback_status = _storage_engine->txn_manager()->rollback_txn(_opt.partition_id, _tablet, _opt.txn_id,
+                                                                       _with_rollback_log);
     }
     // has to check rollback status, because the rowset maybe committed in this thread and
     // published in another thread, then rollback will failed.
@@ -120,9 +121,17 @@ Status DeltaWriter::_init() {
                 continue;
             }
         }
+
+        std::lock_guard push_lock(_tablet->get_push_lock());
+        auto st = _storage_engine->txn_manager()->prepare_txn(_opt.partition_id, _tablet, _opt.txn_id, _opt.load_id);
+        if (!st.ok()) {
+            _set_state(kAborted);
+            return st;
+        }
         break;
     }
 
+    // from here, make sure to set state to kAborted if error happens
     RowsetWriterContext writer_context(kDataFormatV2, config::storage_format_version);
 
     const std::size_t partial_cols_num = [this]() {
@@ -142,6 +151,7 @@ Status DeltaWriter::_init() {
             if (index < 0) {
                 auto msg = strings::Substitute("Invalid column name: $0", slot_col_name);
                 LOG(WARNING) << msg;
+                _set_state(kAborted);
                 return Status::InvalidArgument(msg);
             }
             writer_context.referenced_column_ids.push_back(index);
@@ -167,7 +177,7 @@ Status DeltaWriter::_init() {
     writer_context.global_dicts = _opt.global_dicts;
     Status st = RowsetFactory::create_rowset_writer(writer_context, &_rowset_writer);
     if (!st.ok()) {
-        _set_state(kUninitialized);
+        _set_state(kAborted);
         auto msg = strings::Substitute("Fail to create rowset writer. tablet_id: $0, error: $1", _opt.tablet_id,
                                        st.to_string());
         LOG(WARNING) << msg;
@@ -177,38 +187,17 @@ Status DeltaWriter::_init() {
     _tablet_schema = writer_context.tablet_schema;
     _reset_mem_table();
     _flush_token = _storage_engine->memtable_flush_executor()->create_flush_token();
-    _set_state(kInitialized);
-    return Status::OK();
-}
-
-Status DeltaWriter::_prepare() {
-    auto state = _get_state();
-    switch (state) {
-    case kUninitialized:
-    case kCommitted:
-    case kAborted:
-    case kClosed:
-        return Status::InternalError(
-                fmt::format("Fail to prepare. tablet_id: {}, state: {}", _opt.tablet_id, _state_name(state)));
-    case kPrepared:
-        return Status::OK();
-    case kInitialized: {
-        std::shared_lock base_migration_rlock(_tablet->get_migration_lock());
-        std::lock_guard push_lock(_tablet->get_push_lock());
-        auto st = _storage_engine->txn_manager()->prepare_txn(_opt.partition_id, _tablet, _opt.txn_id, _opt.load_id);
-        if (!st.ok()) {
-            _set_state(kAborted);
-            return st;
-        }
-        _set_state(kPrepared);
-    } break;
-    }
+    _set_state(kWriting);
     return Status::OK();
 }
 
 Status DeltaWriter::write(const Chunk& chunk, const uint32_t* indexes, uint32_t from, uint32_t size) {
     SCOPED_THREAD_LOCAL_MEM_SETTER(_mem_tracker, false);
-    RETURN_IF_ERROR(_prepare());
+    auto state = _get_state();
+    if (state != kWriting) {
+        return Status::InternalError(
+                fmt::format("Fail to prepare. tablet_id: {}, state: {}", _opt.tablet_id, _state_name(state)));
+    }
     Status st;
     bool full = _mem_table->insert(chunk, indexes, from, size);
     if (_mem_tracker->limit_exceeded()) {
@@ -231,7 +220,6 @@ Status DeltaWriter::write(const Chunk& chunk, const uint32_t* indexes, uint32_t 
 
 Status DeltaWriter::close() {
     SCOPED_THREAD_LOCAL_MEM_SETTER(_mem_tracker, false);
-    Status st;
     auto state = _get_state();
     switch (state) {
     case kUninitialized:
@@ -241,11 +229,8 @@ Status DeltaWriter::close() {
                                                  _state_name(state)));
     case kClosed:
         return Status::OK();
-    case kInitialized:
-        _set_state(kClosed);
-        return st;
-    case kPrepared:
-        st = _flush_memtable_async();
+    case kWriting:
+        auto st = _flush_memtable_async();
         _set_state(st.ok() ? kClosed : kAborted);
         return st;
     }
@@ -272,9 +257,8 @@ Status DeltaWriter::commit() {
     auto state = _get_state();
     switch (state) {
     case kUninitialized:
-    case kInitialized:
     case kAborted:
-    case kPrepared:
+    case kWriting:
         return Status::InternalError(fmt::format("Fail to commit delta writer. tablet_id: {}, state: {}",
                                                  _opt.tablet_id, _state_name(state)));
     case kCommitted:
@@ -326,8 +310,9 @@ Status DeltaWriter::commit() {
     return Status::OK();
 }
 
-void DeltaWriter::abort() {
+void DeltaWriter::abort(bool with_log) {
     _set_state(kAborted);
+    _with_rollback_log = with_log;
 }
 
 int64_t DeltaWriter::partition_id() const {
@@ -338,12 +323,10 @@ const char* DeltaWriter::_state_name(State state) const {
     switch (state) {
     case kUninitialized:
         return "kUninitialized";
-    case kInitialized:
-        return "kInitialized";
     case kAborted:
         return "kAborted";
-    case kPrepared:
-        return "kPrepared";
+    case kWriting:
+        return "kWriting";
     case kCommitted:
         return "kCommitted";
     case kClosed:

--- a/be/src/storage/delta_writer.h
+++ b/be/src/storage/delta_writer.h
@@ -61,7 +61,11 @@ public:
 
     // Rollback all writes and delete the Rowset created by 'commit()', if any.
     // [thread-safe]
-    void abort();
+    //
+    // with_log is used to control whether to print the log when rollback txn.
+    // with_log is false when there is no data load into one partition and abort
+    // the related txn.
+    void abort(bool with_log = true);
 
     int64_t txn_id() const { return _opt.txn_id; }
 
@@ -89,8 +93,7 @@ public:
 private:
     enum State {
         kUninitialized,
-        kInitialized,
-        kPrepared,
+        kWriting,
         kClosed,
         kAborted,
         kCommitted, // committed state can transfer to kAborted state
@@ -123,6 +126,7 @@ private:
     const TabletSchema* _tablet_schema;
 
     std::unique_ptr<FlushToken> _flush_token;
+    bool _with_rollback_log;
 };
 
 } // namespace vectorized

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -772,7 +772,7 @@ Status StorageEngine::_start_trash_sweep(double* usage) {
     (void)_tablet_manager->start_trash_sweep();
 
     // clean rubbish transactions
-    _clean_unused_txns();
+    clean_unused_txns();
 
     // clean unused rowset metas in KVStore
     _clean_unused_rowset_metas();
@@ -846,7 +846,7 @@ void StorageEngine::_clean_unused_rowset_metas() {
     }
 }
 
-void StorageEngine::_clean_unused_txns() {
+void StorageEngine::clean_unused_txns() {
     std::set<TabletInfo> tablet_infos;
     _txn_manager->get_all_related_tablets(&tablet_infos);
     for (auto& tablet_info : tablet_infos) {

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -571,7 +571,7 @@ void StorageEngine::compaction_check() {
         MonotonicStopWatch stop_watch;
         stop_watch.start();
         LOG(INFO) << "start to check compaction";
-        size_t num = compaction_check_one_round();
+        size_t num = _compaction_check_one_round();
         stop_watch.stop();
         LOG(INFO) << num << " tablets checked. time elapse:" << stop_watch.elapsed_time() / 1e9 << " seconds."
                   << " compaction checker will be scheduled again in " << checker_one_round_sleep_time_s << " seconds";
@@ -583,7 +583,7 @@ void StorageEngine::compaction_check() {
 
 // Base compaction may be started by time(once every day now)
 // Compaction checker will check whether to schedule base compaction for tablets
-size_t StorageEngine::compaction_check_one_round() {
+size_t StorageEngine::_compaction_check_one_round() {
     size_t batch_size = 1000;
     int batch_sleep_time_ms = 1000;
     std::vector<TabletSharedPtr> tablets;
@@ -772,7 +772,7 @@ Status StorageEngine::_start_trash_sweep(double* usage) {
     (void)_tablet_manager->start_trash_sweep();
 
     // clean rubbish transactions
-    clean_unused_txns();
+    _clean_unused_txns();
 
     // clean unused rowset metas in KVStore
     _clean_unused_rowset_metas();
@@ -846,7 +846,7 @@ void StorageEngine::_clean_unused_rowset_metas() {
     }
 }
 
-void StorageEngine::clean_unused_txns() {
+void StorageEngine::_clean_unused_txns() {
     std::set<TabletInfo> tablet_infos;
     _txn_manager->get_all_related_tablets(&tablet_infos);
     for (auto& tablet_info : tablet_infos) {

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -187,12 +187,6 @@ public:
 
     void compaction_check();
 
-    // public for ut
-    size_t compaction_check_one_round();
-
-    // public for ut
-    void clean_unused_txns();
-
 private:
     // Instance should be inited from `static open()`
     // MUST NOT be called in other circumstances.
@@ -208,6 +202,8 @@ private:
     Status _judge_and_update_effective_cluster_id(int32_t cluster_id);
 
     bool _delete_tablets_on_unused_root_path();
+
+    void _clean_unused_txns();
 
     void _clean_unused_rowset_metas();
 
@@ -251,6 +247,8 @@ private:
     Status _perform_update_compaction(DataDir* data_dir);
     Status _start_trash_sweep(double* usage);
     void _start_disk_stat_monitor();
+
+    size_t _compaction_check_one_round();
 
 private:
     struct CompactionCandidate {

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -190,6 +190,9 @@ public:
     // public for ut
     size_t compaction_check_one_round();
 
+    // public for ut
+    void clean_unused_txns();
+
 private:
     // Instance should be inited from `static open()`
     // MUST NOT be called in other circumstances.
@@ -205,8 +208,6 @@ private:
     Status _judge_and_update_effective_cluster_id(int32_t cluster_id);
 
     bool _delete_tablets_on_unused_root_path();
-
-    void _clean_unused_txns();
 
     void _clean_unused_rowset_metas();
 

--- a/be/src/storage/txn_manager.cpp
+++ b/be/src/storage/txn_manager.cpp
@@ -67,9 +67,10 @@ Status TxnManager::publish_txn(TPartitionId partition_id, const TabletSharedPtr&
 }
 
 // delete the txn from manager if it is not committed(not have a valid rowset)
-Status TxnManager::rollback_txn(TPartitionId partition_id, const TabletSharedPtr& tablet,
-                                TTransactionId transaction_id) {
-    return rollback_txn(partition_id, transaction_id, tablet->tablet_id(), tablet->schema_hash(), tablet->tablet_uid());
+Status TxnManager::rollback_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, TTransactionId transaction_id,
+                                bool with_log) {
+    return rollback_txn(partition_id, transaction_id, tablet->tablet_id(), tablet->schema_hash(), tablet->tablet_uid(),
+                        with_log);
 }
 
 Status TxnManager::delete_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, TTransactionId transaction_id) {
@@ -349,7 +350,7 @@ Status TxnManager::persist_tablet_related_txns(const std::vector<TabletSharedPtr
 // may be committed in another thread and our current thread meets errors when writing to data file
 // BE has to wait for fe call clear txn api
 Status TxnManager::rollback_txn(TPartitionId partition_id, TTransactionId transaction_id, TTabletId tablet_id,
-                                SchemaHash schema_hash, const TabletUid& tablet_uid) {
+                                SchemaHash schema_hash, const TabletUid& tablet_uid, bool with_log) {
     pair<int64_t, int64_t> key(partition_id, transaction_id);
     TabletInfo tablet_info(tablet_id, schema_hash, tablet_uid);
     std::unique_lock wrlock(_get_txn_map_lock(transaction_id));
@@ -372,6 +373,11 @@ Status TxnManager::rollback_txn(TPartitionId partition_id, TTransactionId transa
         LOG(INFO) << "rollback transaction from engine successfully."
                   << " partition_id: " << key.first << ", transaction_id: " << key.second
                   << ", tablet: " << tablet_info.to_string();
+        if (with_log) {
+            LOG(INFO) << "rollback transaction from engine successfully."
+                      << " partition_id: " << key.first << ", transaction_id: " << key.second
+                      << ", tablet: " << tablet_info.to_string();
+        }
         if (it->second.empty()) {
             txn_tablet_map.erase(it);
             _clear_txn_partition_map_unlocked(transaction_id, partition_id);

--- a/be/src/storage/txn_manager.cpp
+++ b/be/src/storage/txn_manager.cpp
@@ -370,9 +370,6 @@ Status TxnManager::rollback_txn(TPartitionId partition_id, TTransactionId transa
             }
         }
         it->second.erase(tablet_info);
-        LOG(INFO) << "rollback transaction from engine successfully."
-                  << " partition_id: " << key.first << ", transaction_id: " << key.second
-                  << ", tablet: " << tablet_info.to_string();
         if (with_log) {
             LOG(INFO) << "rollback transaction from engine successfully."
                       << " partition_id: " << key.first << ", transaction_id: " << key.second

--- a/be/src/storage/txn_manager.h
+++ b/be/src/storage/txn_manager.h
@@ -88,7 +88,8 @@ public:
                         int64_t version);
 
     // delete the txn from manager if it is not committed(not have a valid rowset)
-    Status rollback_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, TTransactionId transaction_id);
+    Status rollback_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, TTransactionId transaction_id,
+                        bool with_log = true);
 
     Status delete_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, TTransactionId transaction_id);
 
@@ -107,7 +108,7 @@ public:
 
     // delete the txn from manager if it is not committed(not have a valid rowset)
     Status rollback_txn(TPartitionId partition_id, TTransactionId transaction_id, TTabletId tablet_id,
-                        SchemaHash schema_hash, const TabletUid& tablet_uid);
+                        SchemaHash schema_hash, const TabletUid& tablet_uid, bool with_log = true);
 
     // remove the txn from txn manager
     // delete the related rowset if it is not null

--- a/be/src/util/uid_util.h
+++ b/be/src/util/uid_util.h
@@ -61,6 +61,7 @@ struct UniqueId {
     int64_t hi = 0;
     int64_t lo = 0;
 
+    UniqueId() : hi(0), lo(0) {}
     UniqueId(int64_t hi_, int64_t lo_) : hi(hi_), lo(lo_) {}
     UniqueId(const TUniqueId& tuid) : hi(tuid.hi), lo(tuid.lo) {}
     UniqueId(const PUniqueId& puid) : hi(puid.hi()), lo(puid.lo()) {}

--- a/be/test/storage/tablet_mgr_test.cpp
+++ b/be/test/storage/tablet_mgr_test.cpp
@@ -284,7 +284,7 @@ TEST_F(TabletMgrTest, GetNextBatchTabletsTest) {
     // because there maybe other tablets exists in storage engine
     ASSERT_GE(tablets_count, 20);
 
-    size_t num = StorageEngine::instance()->compaction_check_one_round();
+    size_t num = StorageEngine::instance()->_compaction_check_one_round();
     ASSERT_GE(num, 20);
 }
 

--- a/be/test/storage/task/engine_storage_migration_task_test.cpp
+++ b/be/test/storage/task/engine_storage_migration_task_test.cpp
@@ -10,18 +10,21 @@
 #include "exec/pipeline/query_context.h"
 #include "gtest/gtest.h"
 #include "runtime/current_thread.h"
+#include "runtime/descriptor_helper.h"
 #include "runtime/exec_env.h"
 #include "runtime/mem_tracker.h"
 #include "runtime/memory/chunk_allocator.h"
 #include "runtime/time_types.h"
 #include "runtime/user_function_cache.h"
 #include "storage/chunk_helper.h"
+#include "storage/delta_writer.h"
 #include "storage/options.h"
 #include "storage/rowset/rowset_factory.h"
 #include "storage/rowset/rowset_writer.h"
 #include "storage/rowset/rowset_writer_context.h"
 #include "storage/storage_engine.h"
 #include "storage/tablet_meta.h"
+#include "storage/task/engine_publish_version_task.h"
 #include "storage/update_manager.h"
 #include "testutil/assert.h"
 #include "util/cpu_info.h"
@@ -133,6 +136,37 @@ public:
         ASSERT_TRUE(st.ok()) << st.to_string() << ", version:" << writer->version();
     }
 
+    TSlotDescriptor _create_slot_desc(PrimitiveType type, const std::string& col_name, int col_pos) {
+        TSlotDescriptorBuilder builder;
+
+        if (type == PrimitiveType::TYPE_VARCHAR || type == PrimitiveType::TYPE_CHAR) {
+            return builder.string_type(1024).column_name(col_name).column_pos(col_pos).nullable(false).build();
+        } else {
+            return builder.type(type).column_name(col_name).column_pos(col_pos).nullable(false).build();
+        }
+    }
+
+    TupleDescriptor* _create_tuple_desc() {
+        TDescriptorTableBuilder table_builder;
+        TTupleDescriptorBuilder tuple_builder;
+
+        for (size_t i = 0; i < 3; i++) {
+            tuple_builder.add_slot(_create_slot_desc(_primitive_type[i], _names[i], i));
+        }
+
+        tuple_builder.build(&table_builder);
+
+        std::vector<TTupleId> row_tuples = std::vector<TTupleId>{0};
+        std::vector<bool> nullable_tuples = std::vector<bool>{false};
+        DescriptorTbl* tbl = nullptr;
+        DescriptorTbl::create(&_pool, table_builder.desc_tbl(), &tbl, config::vector_chunk_size);
+
+        auto* row_desc = _pool.add(new RowDescriptor(*tbl, row_tuples, nullable_tuples));
+        auto* tuple_desc = row_desc->tuple_descriptors()[0];
+
+        return tuple_desc;
+    }
+
     void do_cycle_migration() {
         TabletManager* tablet_manager = starrocks::ExecEnv::GetInstance()->storage_engine()->tablet_manager();
         TabletSharedPtr tablet = tablet_manager->get_tablet(12345);
@@ -155,10 +189,119 @@ public:
         EngineStorageMigrationTask migration_task_2(12345, 1111, source_path);
         ASSERT_OK(migration_task_2.execute());
     }
+
+    void do_migration_fail() {
+        TabletManager* tablet_manager = starrocks::ExecEnv::GetInstance()->storage_engine()->tablet_manager();
+        TabletSharedPtr tablet = tablet_manager->get_tablet(12345);
+        ASSERT_TRUE(tablet != nullptr);
+        ASSERT_EQ(tablet->tablet_id(), 12345);
+        DataDir* source_path = tablet->data_dir();
+        tablet.reset();
+        DataDir* dest_path = nullptr;
+        DataDir* data_dir_1 = starrocks::ExecEnv::GetInstance()->storage_engine()->get_stores()[0];
+        DataDir* data_dir_2 = starrocks::ExecEnv::GetInstance()->storage_engine()->get_stores()[1];
+        if (source_path == data_dir_1) {
+            dest_path = data_dir_2;
+        } else {
+            dest_path = data_dir_1;
+        }
+        EngineStorageMigrationTask migration_task(12345, 1111, dest_path);
+        auto st = migration_task.execute();
+        ASSERT_FALSE(st.ok());
+    }
+
+private:
+    PrimitiveType _primitive_type[3] = {PrimitiveType::TYPE_INT, PrimitiveType::TYPE_VARCHAR, PrimitiveType::TYPE_INT};
+
+    std::string _names[3] = {"k1", "k2", "v1"};
+    ObjectPool _pool;
 };
 
 TEST_F(EngineStorageMigrationTaskTest, test_cycle_migration) {
     do_cycle_migration();
+}
+
+TEST_F(EngineStorageMigrationTaskTest, test_concurrent_ingestion_and_migration) {
+    TabletManager* tablet_manager = starrocks::ExecEnv::GetInstance()->storage_engine()->tablet_manager();
+    TabletUid old_tablet_uid;
+    {
+        TabletSharedPtr tablet = tablet_manager->get_tablet(12345);
+        old_tablet_uid = tablet->tablet_uid();
+    }
+    vectorized::DeltaWriterOptions writer_options;
+    writer_options.tablet_id = 12345;
+    writer_options.schema_hash = 1111;
+    writer_options.write_type = vectorized::LOAD;
+    writer_options.txn_id = 2222;
+    writer_options.partition_id = 10;
+    writer_options.load_id.set_hi(1000);
+    writer_options.load_id.set_lo(2222);
+    TupleDescriptor* tuple_desc = _create_tuple_desc();
+    writer_options.tuple_desc = tuple_desc;
+    writer_options.slots = &tuple_desc->slots();
+
+    {
+        MemTracker mem_checker(1024 * 1024 * 1024);
+        auto writer_status = vectorized::DeltaWriter::open(writer_options, &mem_checker);
+        ASSERT_TRUE(writer_status.ok());
+        auto delta_writer = std::move(writer_status.value());
+        ASSERT_TRUE(delta_writer != nullptr);
+        // add sleep to add time of tablet create time gap
+        sleep(2);
+        // do migration check, migration will fail
+        do_migration_fail();
+        TabletUid new_tablet_uid;
+        {
+            TabletSharedPtr tablet = tablet_manager->get_tablet(12345);
+            new_tablet_uid = tablet->tablet_uid();
+        }
+        // the migration fail. so the tablet will not change
+        ASSERT_TRUE(new_tablet_uid.hi == old_tablet_uid.hi && new_tablet_uid.lo == old_tablet_uid.lo);
+        // prepare chunk
+        std::vector<std::string> test_data;
+        auto chunk = vectorized::ChunkHelper::new_chunk(tuple_desc->slots(), 1024);
+        std::vector<uint32_t> indexes;
+        indexes.reserve(1024);
+        for (size_t i = 0; i < 1024; ++i) {
+            indexes.push_back(i);
+            test_data.push_back("well" + std::to_string(i));
+            auto& cols = chunk->columns();
+            cols[0]->append_datum(vectorized::Datum(static_cast<int32_t>(i)));
+            Slice field_1(test_data[i]);
+            cols[1]->append_datum(vectorized::Datum(field_1));
+            cols[2]->append_datum(vectorized::Datum(static_cast<int32_t>(10000 + i)));
+        }
+        auto st = delta_writer->write(*chunk, indexes.data(), 0, indexes.size());
+        ASSERT_TRUE(st.ok());
+        st = delta_writer->close();
+        ASSERT_TRUE(st.ok());
+        st = delta_writer->commit();
+        ASSERT_TRUE(st.ok());
+    }
+    // make sure to release delta_writer from here
+    // or it will not release the tablet in gc
+
+    // clean trash and unused txns after commit
+    // it will clean no tablet and txns
+    tablet_manager->start_trash_sweep();
+    starrocks::ExecEnv::GetInstance()->storage_engine()->clean_unused_txns();
+
+    std::map<TabletInfo, RowsetSharedPtr> tablet_related_rs;
+    StorageEngine::instance()->txn_manager()->get_txn_related_tablets(2222, 10, &tablet_related_rs);
+    ASSERT_EQ(1, tablet_related_rs.size());
+    TVersion version = 3;
+    // publish version for txn
+    for (auto& tablet_rs : tablet_related_rs) {
+        const TabletInfo& tablet_info = tablet_rs.first;
+        const RowsetSharedPtr& rowset = tablet_rs.second;
+        EnginePublishVersionTask publish_task(2222, 10, version, tablet_info, rowset);
+        auto st = publish_task.finish();
+        // success because the related transaction is GCed
+        ASSERT_TRUE(st.ok());
+    }
+    auto tablet = tablet_manager->get_tablet(12345);
+    Version max_version = tablet->max_version();
+    ASSERT_EQ(3, max_version.first);
 }
 
 } // namespace starrocks
@@ -231,8 +374,7 @@ int main(int argc, char** argv) {
 
     // clear some trash objects kept in tablet_manager so mem_tracker checks will not fail
     starrocks::StorageEngine::instance()->tablet_manager()->start_trash_sweep();
-    starrocks::FileUtils::remove_all(root_path_1);
-    starrocks::FileUtils::remove_all(root_path_2);
+    starrocks::FileUtils::remove_all(storage_root.value());
     starrocks::vectorized::TEST_clear_all_columns_this_thread();
     // delete engine
     engine->stop();

--- a/be/test/storage/task/engine_storage_migration_task_test.cpp
+++ b/be/test/storage/task/engine_storage_migration_task_test.cpp
@@ -284,7 +284,7 @@ TEST_F(EngineStorageMigrationTaskTest, test_concurrent_ingestion_and_migration) 
     // clean trash and unused txns after commit
     // it will clean no tablet and txns
     tablet_manager->start_trash_sweep();
-    starrocks::ExecEnv::GetInstance()->storage_engine()->clean_unused_txns();
+    starrocks::ExecEnv::GetInstance()->storage_engine()->_clean_unused_txns();
 
     std::map<TabletInfo, RowsetSharedPtr> tablet_related_rs;
     StorageEngine::instance()->txn_manager()->get_txn_related_tablets(2222, 10, &tablet_related_rs);

--- a/be/test/storage/version_graph_test.cpp
+++ b/be/test/storage/version_graph_test.cpp
@@ -16,10 +16,10 @@ TEST(VersionGraphTest, capture) {
         rs_meta.back()->set_end_version(i);
     }
 
-    for (int i = 0; i < 10; i=i+2) {
+    for (int i = 0; i < 10; i = i + 2) {
         rs_meta.emplace_back(std::make_shared<RowsetMeta>());
         rs_meta.back()->set_start_version(i);
-        rs_meta.back()->set_end_version(i+1);
+        rs_meta.back()->set_end_version(i + 1);
     }
 
     rs_meta.emplace_back(std::make_shared<RowsetMeta>());
@@ -118,7 +118,7 @@ TEST(VersionGraphTest, capture) {
         EXPECT_EQ(graph.capture_consistent_versions(Version(0, 12), &version_path).ok(), false);
     }
 
-    graph.add_version_to_graph(Version(10,10));
+    graph.add_version_to_graph(Version(10, 10));
 
     {
         std::vector<Version> version_path;
@@ -150,7 +150,7 @@ TEST(VersionGraphTest, capture) {
         EXPECT_EQ(version_path[4].second, 11);
     }
 
-    EXPECT_EQ(graph.delete_version_from_graph(Version(1,1)).ok(), true);
+    EXPECT_EQ(graph.delete_version_from_graph(Version(1, 1)).ok(), true);
 
     {
         std::vector<Version> version_path;
@@ -168,7 +168,7 @@ TEST(VersionGraphTest, capture) {
         EXPECT_EQ(version_path[4].second, 11);
     }
 
-    EXPECT_EQ(graph.delete_version_from_graph(Version(8,9)).ok(), true);
+    EXPECT_EQ(graph.delete_version_from_graph(Version(8, 9)).ok(), true);
 
     {
         std::vector<Version> version_path;
@@ -188,7 +188,7 @@ TEST(VersionGraphTest, capture) {
         EXPECT_EQ(version_path[5].second, 11);
     }
 
-    EXPECT_EQ(graph.delete_version_from_graph(Version(10,10)).ok(), true);
+    EXPECT_EQ(graph.delete_version_from_graph(Version(10, 10)).ok(), true);
 
     {
         std::vector<Version> version_path;


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5160 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The reason for this problem is the concurrency control of ingesting and migration. 
There is a bug in migration check whether there is ingestion during migration.
And the data will be deleted wrong.