### PR TITLE
fix #5028: return null if AssertNumRows input empty

### DIFF
--- a/be/src/exec/pipeline/assert_num_rows_operator.cpp
+++ b/be/src/exec/pipeline/assert_num_rows_operator.cpp
@@ -11,12 +11,14 @@ namespace starrocks::pipeline {
 Status AssertNumRowsOperator::prepare(RuntimeState* state) {
     Operator::prepare(state);
 
-    // assert num rows node only use for un-correlate scalar subquery, return empty chunk is error, least fill one rows
+    // AssertNumRows should return exactly one row, report error if more than one row, return null if empty input
     vectorized::ChunkPtr chunk = std::make_shared<vectorized::Chunk>();
 
     for (const auto& desc : _factory->row_desc()->tuple_descriptors()) {
         for (const auto& slot : desc->slots()) {
-            chunk->append_column(ColumnHelper::create_column(slot->type(), true, false, 1), slot->id());
+            vectorized::ColumnPtr column = ColumnHelper::create_column(slot->type(), true, false, 1);
+            column->append_nulls(1);
+            chunk->append_column(column, slot->id());
         }
     }
 

--- a/be/src/exec/pipeline/assert_num_rows_operator.cpp
+++ b/be/src/exec/pipeline/assert_num_rows_operator.cpp
@@ -16,7 +16,7 @@ Status AssertNumRowsOperator::prepare(RuntimeState* state) {
 
     for (const auto& desc : _factory->row_desc()->tuple_descriptors()) {
         for (const auto& slot : desc->slots()) {
-            vectorized::ColumnPtr column = ColumnHelper::create_column(slot->type(), true, false, 1);
+            vectorized::ColumnPtr column = ColumnHelper::create_column(slot->type(), true);
             column->append_nulls(1);
             chunk->append_column(column, slot->id());
         }

--- a/be/src/exec/vectorized/assert_num_rows_node.cpp
+++ b/be/src/exec/vectorized/assert_num_rows_node.cpp
@@ -63,8 +63,9 @@ Status AssertNumRowsNode::open(RuntimeState* state) {
         chunk = std::make_shared<vectorized::Chunk>();
         for (const auto& desc : row_desc().tuple_descriptors()) {
             for (const auto& slot : desc->slots()) {
-                chunk->append_column(ColumnHelper::create_column(slot->type(), true, false, _desired_num_rows),
-                                     slot->id());
+                auto column = ColumnHelper::create_column(slot->type(), true);
+                column->append_nulls(_desired_num_rows);
+                chunk->append_column(column, slot->id());
             }
         }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5028 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

AssertNumRow should return null if empty input.


