### PR TITLE
initialize column in create_column

### DIFF
--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -25,6 +25,8 @@ public:
     // TODO(kks): when we create our own vector, we could let vector[-1] = 0,
     // and then we don't need explicitly emplace_back zero value
     BinaryColumnBase<T>() { _offsets.emplace_back(0); }
+    // No default value for variable-size column
+    BinaryColumnBase<T>(size_t size) {}
     BinaryColumnBase<T>(Bytes bytes, Offsets offsets) : _bytes(std::move(bytes)), _offsets(std::move(offsets)) {
         if (_offsets.empty()) {
             _offsets.emplace_back(0);

--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -25,8 +25,8 @@ public:
     // TODO(kks): when we create our own vector, we could let vector[-1] = 0,
     // and then we don't need explicitly emplace_back zero value
     BinaryColumnBase<T>() { _offsets.emplace_back(0); }
-    // No default value for variable-size column
-    BinaryColumnBase<T>(size_t size) {}
+    // Default value is empty string
+    explicit BinaryColumnBase<T>(size_t size) : _offsets(size + 1, 0) {}
     BinaryColumnBase<T>(Bytes bytes, Offsets offsets) : _bytes(std::move(bytes)), _offsets(std::move(offsets)) {
         if (_offsets.empty()) {
             _offsets.emplace_back(0);

--- a/be/src/column/column_helper.cpp
+++ b/be/src/column/column_helper.cpp
@@ -183,7 +183,7 @@ ColumnPtr ColumnHelper::create_column(const TypeDescriptor& type_desc, bool null
 
 struct ColumnBuilder {
     template <PrimitiveType ptype>
-    ColumnPtr operator()(const TypeDescriptor& type_desc) {
+    ColumnPtr operator()(const TypeDescriptor& type_desc, size_t size) {
         switch (ptype) {
         case INVALID_TYPE:
         case TYPE_NULL:
@@ -194,15 +194,14 @@ struct ColumnBuilder {
         case TYPE_MAP:
             LOG(FATAL) << "Unsupported column type" << ptype;
         case TYPE_DECIMAL32:
-            return Decimal32Column::create(type_desc.precision, type_desc.scale);
+            return Decimal32Column::create(type_desc.precision, type_desc.scale, size);
         case TYPE_DECIMAL64:
-            return Decimal64Column::create(type_desc.precision, type_desc.scale);
+            return Decimal64Column::create(type_desc.precision, type_desc.scale, size);
         case TYPE_DECIMAL128:
-            return Decimal128Column::create(type_desc.precision, type_desc.scale);
-        default:;
+            return Decimal128Column::create(type_desc.precision, type_desc.scale, size);
+        default:
+            return RunTimeColumnType<ptype>::create(size);
         }
-
-        return RunTimeColumnType<ptype>::create();
     }
 };
 
@@ -211,32 +210,29 @@ ColumnPtr ColumnHelper::create_column(const TypeDescriptor& type_desc, bool null
     if (VLOG_ROW_IS_ON) {
         VLOG_ROW << "PrimitiveType " << type << " nullable " << nullable << " is_const " << is_const;
     }
-    if (nullable && is_const) {
-        return ColumnHelper::create_const_null_column(size);
-    }
-
-    if (type == TYPE_NULL) {
+    if (nullable || type == TYPE_NULL) {
         if (is_const) {
             return ColumnHelper::create_const_null_column(size);
-        } else if (nullable) {
-            return NullableColumn::create(BooleanColumn::create(), NullColumn::create());
+        } else {
+            return NullableColumn::create(BooleanColumn::create(size), NullColumn::create(size, DATUM_NULL));
         }
     }
 
     ColumnPtr p;
     if (type_desc.type == TYPE_ARRAY) {
-        auto offsets = UInt32Column::create();
-        auto data = create_column(type_desc.children[0], true);
+        auto offsets = UInt32Column::create(size);
+        auto data = create_column(type_desc.children[0], true, is_const, size);
         p = ArrayColumn::create(std::move(data), std::move(offsets));
     } else {
-        p = type_dispatch_column(type_desc.type, ColumnBuilder(), type_desc);
+        p = type_dispatch_column(type_desc.type, ColumnBuilder(), type_desc, size);
     }
 
     if (is_const) {
-        return ConstColumn::create(p);
+        return ConstColumn::create(p, size);
     }
     if (nullable) {
-        return NullableColumn::create(p, NullColumn::create());
+        // Default value is null
+        return NullableColumn::create(p, NullColumn::create(size, DATUM_NULL));
     }
     return p;
 }

--- a/be/src/column/column_helper.cpp
+++ b/be/src/column/column_helper.cpp
@@ -210,12 +210,11 @@ ColumnPtr ColumnHelper::create_column(const TypeDescriptor& type_desc, bool null
     if (VLOG_ROW_IS_ON) {
         VLOG_ROW << "PrimitiveType " << type << " nullable " << nullable << " is_const " << is_const;
     }
-    if (nullable || type == TYPE_NULL) {
-        if (is_const) {
-            return ColumnHelper::create_const_null_column(size);
-        } else {
-            return NullableColumn::create(BooleanColumn::create(size), NullColumn::create(size, DATUM_NULL));
-        }
+
+    if (is_const && (nullable || type == TYPE_NULL)) {
+        return ColumnHelper::create_const_null_column(size);
+    } else if (type == TYPE_NULL) {
+        return NullableColumn::create(BooleanColumn::create(size), NullColumn::create(size, DATUM_NULL));
     }
 
     ColumnPtr p;

--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -168,9 +168,10 @@ public:
         return dst_column->clone_shared();
     }
 
+    // Create an empty column
     static ColumnPtr create_column(const TypeDescriptor& type_desc, bool nullable);
 
-    // If is_const is true, you must pass the size arg
+    // Create a column with specified size, the column will be resized to size
     static ColumnPtr create_column(const TypeDescriptor& type_desc, bool nullable, bool is_const, size_t size);
 
     /**

--- a/be/src/column/decimalv3_column.cpp
+++ b/be/src/column/decimalv3_column.cpp
@@ -5,6 +5,12 @@
 #include "column/fixed_length_column.h"
 
 namespace starrocks::vectorized {
+
+template <typename T>
+DecimalV3Column<T>::DecimalV3Column(size_t num_rows) {
+    this->resize(num_rows);
+}
+
 template <typename T>
 DecimalV3Column<T>::DecimalV3Column(int precision, int scale) : _precision(precision), _scale(scale) {
     DCHECK(0 <= _scale && _scale <= _precision && _precision <= decimal_precision_limit<T>);

--- a/be/src/column/decimalv3_column.h
+++ b/be/src/column/decimalv3_column.h
@@ -15,6 +15,7 @@ template <typename T>
 class DecimalV3Column final : public ColumnFactory<FixedLengthColumnBase<T>, DecimalV3Column<DecimalType<T>>, Column> {
 public:
     DecimalV3Column() = default;
+    explicit DecimalV3Column(size_t num_rows);
     DecimalV3Column(int precision, int scale);
     DecimalV3Column(int precision, int scale, size_t num_rows);
 

--- a/be/src/column/json_column.h
+++ b/be/src/column/json_column.h
@@ -19,6 +19,7 @@ public:
     using BaseClass = JsonColumnBase;
 
     JsonColumn() = default;
+    explicit JsonColumn(size_t size) : SuperClass(size) {}
     JsonColumn(const JsonColumn& rhs) : SuperClass(rhs) {}
 
     MutableColumnPtr clone() const override;

--- a/be/src/column/object_column.h
+++ b/be/src/column/object_column.h
@@ -30,6 +30,8 @@ public:
 
     ObjectColumn() = default;
 
+    explicit ObjectColumn(size_t size) : _pool(size) {}
+
     ObjectColumn(const ObjectColumn& column) { DCHECK(false) << "Can't copy construct object column"; }
 
     ObjectColumn(ObjectColumn&& object_column) noexcept : _pool(std::move(object_column._pool)) {}

--- a/be/src/serde/column_array_serde.cpp
+++ b/be/src/serde/column_array_serde.cpp
@@ -156,6 +156,7 @@ public:
     static const uint8_t* deserialize(const uint8_t* buff, vectorized::ObjectColumn<T>* column) {
         uint32_t num_objects = 0;
         buff = read_little_endian_32(buff, &num_objects);
+        column->reset_column();
         std::vector<T>& pool = column->get_pool();
         pool.reserve(num_objects);
         for (int i = 0; i < num_objects; i++) {
@@ -208,6 +209,7 @@ public:
         buff = read_little_endian_32(buff, &num_objects);
         CHECK_EQ(actual_version, kJsonMetaDefaultFormatVersion) << "Only format_version=1 is supported";
 
+        column->reset_column();
         std::vector<JsonValue>& pool = column->get_pool();
         pool.reserve(num_objects);
         for (int i = 0; i < num_objects; i++) {

--- a/be/test/exec/vectorized/chunks_sorter_test.cpp
+++ b/be/test/exec/vectorized/chunks_sorter_test.cpp
@@ -210,7 +210,7 @@ static ColumnPtr make_int32_column(const std::vector<int32_t>& xs) {
 }
 
 static ColumnPtr make_nullable_int32_column(const std::vector<int32_t>& xs) {
-    auto column = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), true, false, xs.size());
+    auto column = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), true, false, 0);
     for (auto x : xs) {
         if (x == 0) {
             column->append_nulls(1);

--- a/be/test/exprs/vectorized/array_functions_test.cpp
+++ b/be/test/exprs/vectorized/array_functions_test.cpp
@@ -241,7 +241,7 @@ TEST_F(ArrayFunctionsTest, array_contains_empty_array) {
         auto array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
         array->append_datum(Datum(DatumArray{}));
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false, true, 1);
+        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false, true, 0);
         target->append_datum(Datum{(int32_t)1});
 
         auto result = ArrayFunctions::array_contains(nullptr, {array, target});
@@ -253,7 +253,7 @@ TEST_F(ArrayFunctionsTest, array_contains_empty_array) {
         auto array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
         array->append_datum(Datum(DatumArray{}));
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), false, true, 1);
+        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), false, true, 0);
         target->append_datum(Datum{"abc"});
 
         auto result = ArrayFunctions::array_contains(nullptr, {array, target});
@@ -296,7 +296,7 @@ TEST_F(ArrayFunctionsTest, array_contains_empty_array) {
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false, true, 1);
+        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false, true, 0);
         DCHECK(target->is_constant());
         target->append_datum(Datum((int32_t)1));
         target->resize(4);
@@ -439,7 +439,7 @@ TEST_F(ArrayFunctionsTest, array_contains_no_null) {
         array->append_datum(DatumArray{3, 2, 1});
         array->append_datum(DatumArray{2, 1, 3});
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false, true, 1);
+        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false, true, 0);
         target->append_datum(Datum{3});
         target->resize(5);
 
@@ -512,7 +512,7 @@ TEST_F(ArrayFunctionsTest, array_contains_has_null_element) {
         array->append_datum(DatumArray{"abc", Datum{}});
         array->append_datum(DatumArray{Datum{}, "abc"});
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), false, true, 1);
+        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), false, true, 0);
         target->append_datum(Datum{"abc"});
         target->append_datum(Datum{"abc"});
         target->append_datum(Datum{"abc"});
@@ -533,7 +533,7 @@ TEST_F(ArrayFunctionsTest, array_contains_has_null_target) {
         array->append_datum(DatumArray{"abc", "def"});
 
         // const-null column.
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), true, true, 1);
+        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), true, true, 0);
 
         auto result = ArrayFunctions::array_contains(nullptr, {array, target});
         EXPECT_EQ(1, result->size());
@@ -571,7 +571,7 @@ TEST_F(ArrayFunctionsTest, array_contains_has_null_element_and_target) {
         array->append_datum(DatumArray{Datum(), "abc"});
 
         // const-null column.
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), true, true, 1);
+        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), true, true, 0);
 
         auto result = ArrayFunctions::array_contains(nullptr, {array, target});
         EXPECT_EQ(2, result->size());
@@ -619,7 +619,7 @@ TEST_F(ArrayFunctionsTest, array_contains_nullable_array) {
         array->append_datum(Datum());
         array->append_datum(DatumArray{"a", "b", "c"});
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), false, true, 1);
+        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), false, true, 0);
         target->append_datum(Datum("c"));
         target->append_datum(Datum("c"));
         target->append_datum(Datum("c"));
@@ -679,7 +679,7 @@ TEST_F(ArrayFunctionsTest, array_position_empty_array) {
         auto array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
         array->append_datum(Datum(DatumArray{}));
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false, true, 1);
+        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false, true, 0);
         target->append_datum(Datum{(int32_t)1});
 
         auto result = ArrayFunctions::array_position(nullptr, {array, target});
@@ -691,7 +691,7 @@ TEST_F(ArrayFunctionsTest, array_position_empty_array) {
         auto array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
         array->append_datum(Datum(DatumArray{}));
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), false, true, 1);
+        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), false, true, 0);
         target->append_datum(Datum{"abc"});
 
         auto result = ArrayFunctions::array_position(nullptr, {array, target});
@@ -734,7 +734,7 @@ TEST_F(ArrayFunctionsTest, array_position_empty_array) {
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false, true, 1);
+        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false, true, 0);
         DCHECK(target->is_constant());
         target->append_datum(Datum((int32_t)1));
         target->resize(4);
@@ -877,7 +877,7 @@ TEST_F(ArrayFunctionsTest, array_position_no_null) {
         array->append_datum(DatumArray{3, 2, 1});
         array->append_datum(DatumArray{2, 1, 3});
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false, true, 1);
+        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false, true, 0);
         target->append_datum(Datum{3});
         target->resize(5);
 
@@ -950,7 +950,7 @@ TEST_F(ArrayFunctionsTest, array_position_has_null_element) {
         array->append_datum(DatumArray{"abc", Datum{}});
         array->append_datum(DatumArray{Datum{}, "abc"});
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), false, true, 1);
+        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), false, true, 0);
         target->append_datum(Datum{"abc"});
         target->append_datum(Datum{"abc"});
         target->append_datum(Datum{"abc"});
@@ -971,7 +971,7 @@ TEST_F(ArrayFunctionsTest, array_position_has_null_target) {
         array->append_datum(DatumArray{"abc", "def"});
 
         // const-null column.
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), true, true, 1);
+        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), true, true, 0);
 
         auto result = ArrayFunctions::array_position(nullptr, {array, target});
         EXPECT_EQ(1, result->size());
@@ -1055,7 +1055,7 @@ TEST_F(ArrayFunctionsTest, array_position_has_null_element_and_target_and_check_
         array->append_datum(DatumArray{Datum(), "abc"});
 
         // const-null column.
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), true, true, 1);
+        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), true, true, 0);
 
         auto result = ArrayFunctions::array_position(nullptr, {array, target});
         EXPECT_EQ(2, result->size());
@@ -1103,7 +1103,7 @@ TEST_F(ArrayFunctionsTest, array_position_nullable_array) {
         array->append_datum(Datum());
         array->append_datum(DatumArray{"a", "b", "c"});
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), false, true, 1);
+        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), false, true, 0);
         target->append_datum(Datum("c"));
         target->append_datum(Datum("c"));
         target->append_datum(Datum("c"));
@@ -1163,7 +1163,7 @@ TEST_F(ArrayFunctionsTest, array_remove_empty_array) {
         auto array = ColumnHelper::create_column(TYPE_ARRAY_INT, false);
         array->append_datum(Datum(DatumArray{}));
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false, true, 1);
+        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false, true, 0);
         target->append_datum(Datum{(int32_t)1});
 
         auto result = ArrayFunctions::array_remove(nullptr, {array, target});
@@ -1176,7 +1176,7 @@ TEST_F(ArrayFunctionsTest, array_remove_empty_array) {
         auto array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
         array->append_datum(Datum(DatumArray{}));
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), false, true, 1);
+        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), false, true, 0);
         target->append_datum(Datum{"abc"});
 
         auto result = ArrayFunctions::array_remove(nullptr, {array, target});
@@ -1225,7 +1225,7 @@ TEST_F(ArrayFunctionsTest, array_remove_empty_array) {
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum(DatumArray{}));
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false, true, 1);
+        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false, true, 0);
         DCHECK(target->is_constant());
         target->append_datum(Datum((int32_t)1));
         target->resize(4);
@@ -1418,7 +1418,7 @@ TEST_F(ArrayFunctionsTest, array_remove_no_null) {
         array->append_datum(DatumArray{3, 2, 1});
         array->append_datum(DatumArray{2, 1, 3});
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false, true, 1);
+        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false, true, 0);
         target->append_datum(Datum{3});
         target->resize(5);
 
@@ -1600,7 +1600,7 @@ TEST_F(ArrayFunctionsTest, array_remove_has_null_element) {
         array->append_datum(DatumArray{"abc", Datum{}});
         array->append_datum(DatumArray{Datum{}, "abc"});
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), false, true, 1);
+        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), false, true, 0);
         target->append_datum(Datum{"abc"});
         target->append_datum(Datum{"abc"});
         target->append_datum(Datum{"abc"});
@@ -1632,7 +1632,7 @@ TEST_F(ArrayFunctionsTest, array_remove_has_null_target) {
         array->append_datum(DatumArray{"abc", "def"});
 
         // const-null column.
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), true, true, 1);
+        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), true, true, 0);
         auto result = ArrayFunctions::array_remove(nullptr, {array, target});
         EXPECT_EQ(1, result->size());
 
@@ -1691,7 +1691,7 @@ TEST_F(ArrayFunctionsTest, array_remove_has_null_element_and_target) {
         array->append_datum(DatumArray{Datum(), "abc"});
 
         // const-null column.
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), true, true, 1);
+        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), true, true, 0);
 
         auto result = ArrayFunctions::array_remove(nullptr, {array, target});
         EXPECT_EQ(2, result->size());
@@ -1770,7 +1770,7 @@ TEST_F(ArrayFunctionsTest, array_remove_nullable_array) {
         array->append_datum(Datum());
         array->append_datum(DatumArray{"a", "b", "c"});
 
-        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), false, true, 1);
+        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), false, true, 0);
         target->append_datum(Datum("c"));
         target->append_datum(Datum("c"));
         target->append_datum(Datum("c"));
@@ -1856,7 +1856,7 @@ TEST_F(ArrayFunctionsTest, array_append) {
         auto array = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, false);
         array->append_datum(Datum(DatumArray{}));
 
-        auto null = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), true, true, 1);
+        auto null = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), true, true, 0);
 
         auto result = ArrayFunctions::array_append(nullptr, {array, null});
         EXPECT_EQ(1, result->size());
@@ -1874,7 +1874,7 @@ TEST_F(ArrayFunctionsTest, array_append) {
         array->append_datum(Datum(DatumArray{}));
         array->append_datum(Datum());
 
-        auto data = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), false, true, 1);
+        auto data = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), false, true, 0);
         data->append_datum("def");
 
         auto result = ArrayFunctions::array_append(nullptr, {array, data});


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Summary
`ColumnHelper::create_column` has a parameter `size`, but only works for `ConstColumn`, which is error-prone.

This PR try to clarify this function:
1. Parameter `size` is used to initialize the column with specified size and default value. This semantic is same as `std::vector<T>(size_t size)`
2. The default value of each column is determined by the column itself. E.g. BinaryColumn's default value is empty string, NullableColumn is null.



