### PR TITLE
Add TCMALLOC_HEAP_LIMIT_MB set check before be start

### DIFF
--- a/be/src/service/starrocks_main.cpp
+++ b/be/src/service/starrocks_main.cpp
@@ -102,7 +102,7 @@ int main(int argc, char** argv) {
     }
 
     if (getenv("TCMALLOC_HEAP_LIMIT_MB") == nullptr) {
-        fprintf(stderr, "you need replace bin dir be be with new version.\n");
+        fprintf(stderr, "you need replace bin dir of be with new version.\n");
         exit(-1);
     }
 

--- a/be/src/service/starrocks_main.cpp
+++ b/be/src/service/starrocks_main.cpp
@@ -101,6 +101,11 @@ int main(int argc, char** argv) {
         exit(-1);
     }
 
+    if (getenv("TCMALLOC_HEAP_LIMIT_MB") == nullptr) {
+        fprintf(stderr, "you need replace bin dir be be with new version.\n");
+        exit(-1);
+    }
+
     // S2 will crashes when deserialization fails and FLAGS_s2debug was true.
     FLAGS_s2debug = false;
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

check the TCMALLOC_HEAP_LIMIT_MB if not set to prevent using bin dir of old version
