### PR TITLE
Fix double cast to string use scientific notation in Fe

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
@@ -261,6 +261,10 @@ public final class ConstantOperator extends ScalarOperator implements Comparable
         } else if (type.isDate()) {
             LocalDateTime time = (LocalDateTime) Optional.ofNullable(value).orElse(LocalDateTime.MIN);
             return String.format("%04d-%02d-%02d", time.getYear(), time.getMonthValue(), time.getDayOfMonth());
+        } else if (type.isDouble()) {
+            double val = (double) Optional.ofNullable(value).orElse((double) 0);
+            BigDecimal decimal = BigDecimal.valueOf(val);
+            return decimal.toPlainString();
         }
 
         return String.valueOf(value);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SelectConstTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SelectConstTest.java
@@ -121,4 +121,10 @@ public class SelectConstTest extends PlanTestBase {
                 "     constant exprs: \n" +
                 "         NULL");
     }
+
+    @Test
+    public void testDoubleCastWithoutScientificNotation() throws Exception {
+        String sql = "SELECT * FROM t0 WHERE CAST(CAST(CASE WHEN TRUE THEN -1229625855 WHEN false THEN 1 ELSE 2 / 3 END AS STRING ) AS BOOLEAN );";
+        assertPlanContains(sql, "PREDICATES: CAST('-1229625855' AS BOOLEAN)");
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3692 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
```
mysql> explain SELECT * FROM t0 WHERE CAST(CAST(CASE WHEN TRUE THEN -1229625855 WHEN false THEN 1 ELSE 2 / 3 END AS STRING ) AS BOOLEAN );
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Explain String                                                                                                                                                                                           |
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| PLAN FRAGMENT 0                                                                                                                                                                                          |
|  OUTPUT EXPRS:1: c_0_0 | 2: c_0_1 | 3: c_0_2 | 4: c_0_3 | 5: c_0_4 | 6: c_0_5 | 7: c_0_6 | 8: c_0_7 | 9: c_0_8 | 10: c_0_9 | 11: c_0_10 | 12: c_0_11 | 13: c_0_12 | 14: c_0_13 | 15: c_0_14 | 16: c_0_15 |
|   PARTITION: UNPARTITIONED                                                                                                                                                                               |
|                                                                                                                                                                                                          |
|   RESULT SINK                                                                                                                                                                                            |
|                                                                                                                                                                                                          |
|   1:EXCHANGE                                                                                                                                                                                             |
|                                                                                                                                                                                                          |
| PLAN FRAGMENT 1                                                                                                                                                                                          |
|  OUTPUT EXPRS:                                                                                                                                                                                           |
|   PARTITION: RANDOM                                                                                                                                                                                      |
|                                                                                                                                                                                                          |
|   STREAM DATA SINK                                                                                                                                                                                       |
|     EXCHANGE ID: 01                                                                                                                                                                                      |
|     UNPARTITIONED                                                                                                                                                                                        |
|                                                                                                                                                                                                          |
|   0:OlapScanNode                                                                                                                                                                                         |
|      TABLE: t0                                                                                                                                                                                           |
|      PREAGGREGATION: ON                                                                                                                                                                                  |
|      PREDICATES: CAST('-1.229625855E9' AS BOOLEAN)                                                                                                                                                       |
|      partitions=1/1                                                                                                                                                                                      |
|      rollup: t0                                                                                                                                                                                          |
|      tabletRatio=10/10                                                                                                                                                                                   |
|      tabletList=3180400,3180402,3180404,3180406,3180408,3180410,3180412,3180414,3180416,3180418                                                                                                          |
|      cardinality=3                                                                                                                                                                                       |
|      avgRowSize=16.0                                                                                                                                                                                     |
|      numNodes=0                                                                                                                                                                                          |
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```

-1229625855 cast to double first and cast to string use scientific notation.
```
mysql> select  CAST('-1.229625855E9' AS BOOLEAN);
+-----------------------------------+
| CAST('-1.229625855E9' AS BOOLEAN) |
+-----------------------------------+
|                              NULL |
+-----------------------------------+
1 row in set (0.00 sec)

mysql> select  CAST('-1229625855' AS BOOLEAN);
+--------------------------------+
| CAST('-1229625855' AS BOOLEAN) |
+--------------------------------+
|                              1 |
+--------------------------------+
```
but string with scientific notation will result in NULL