### PR TITLE
[BugFix] add tablet level lock for update compaction WIP

### DIFF
--- a/be/src/storage/tablet.h
+++ b/be/src/storage/tablet.h
@@ -39,6 +39,7 @@
 #include "storage/olap_define.h"
 #include "storage/rowset/rowset.h"
 #include "storage/tablet_meta.h"
+#include "storage/tablet_updates.h"
 #include "storage/tuple.h"
 #include "storage/utils.h"
 #include "storage/version_graph.h"
@@ -172,6 +173,18 @@ public:
     void obtain_cumulative_lock() { _cumulative_lock.lock(); }
     void release_cumulative_lock() { _cumulative_lock.unlock(); }
     std::mutex& get_cumulative_lock() { return _cumulative_lock; }
+
+    // update compaction lock
+    void obtain_update_compaction_lock() {
+        if (updates()) {
+            updates()->obtain_update_compaction_lock();
+        }
+    }
+    void release_update_compaction_lock() {
+        if (updates()) {
+            updates()->release_update_compaction_lock();
+        }
+    }
 
     std::shared_mutex& get_migration_lock() { return _migration_lock; }
     // should use with migration lock.

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -650,6 +650,11 @@ TabletSharedPtr TabletManager::find_best_tablet_to_do_update_compaction(DataDir*
                 continue;
             }
 
+            if (!tablet_ptr->updates()->get_update_compaction_lock().try_lock()) {
+                continue;
+            }
+            tablet_ptr->updates()->get_update_compaction_lock().unlock();
+
             if (tablet_ptr->data_dir()->path_hash() != data_dir->path_hash() || !tablet_ptr->is_used() ||
                 !tablet_ptr->init_succeeded()) {
                 continue;

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -1516,6 +1516,7 @@ Status TabletUpdates::compaction(MemTracker* mem_tracker) {
     if (!_compaction_running.compare_exchange_strong(was_runing, true)) {
         return Status::InternalError("illegal state: another compaction is running");
     }
+    std::unique_lock lock(get_update_compaction_lock(), std::try_to_lock);
     std::unique_ptr<CompactionInfo> info = std::make_unique<CompactionInfo>();
     vector<uint32_t> rowsets;
     {

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -1517,6 +1517,9 @@ Status TabletUpdates::compaction(MemTracker* mem_tracker) {
         return Status::InternalError("illegal state: another compaction is running");
     }
     std::unique_lock lock(get_update_compaction_lock(), std::try_to_lock);
+    if (!lock.owns_lock()) {
+        return Status::OK();
+    }
     std::unique_ptr<CompactionInfo> info = std::make_unique<CompactionInfo>();
     vector<uint32_t> rowsets;
     {

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -217,6 +217,11 @@ public:
                                          EditVersion* read_version, uint32_t* next_rowset_id,
                                          std::vector<std::vector<uint64_t>*>* rss_rowids);
 
+    // update compaction lock
+    void obtain_update_compaction_lock() { _update_compaction_lock.lock(); }
+    void release_update_compaction_lock() { _update_compaction_lock.unlock(); }
+    std::mutex& get_update_compaction_lock() { return _update_compaction_lock; }
+
 private:
     friend class Tablet;
     friend class PrimaryIndex;
@@ -346,6 +351,8 @@ private:
     mutable std::mutex _index_lock;
     // apply process is running currently
     bool _apply_running = false;
+
+    std::mutex _update_compaction_lock;
 
     // used to stop apply thread when shutting-down this tablet
     std::atomic<bool> _apply_stopped = false;

--- a/be/src/storage/task/engine_clone_task.cpp
+++ b/be/src/storage/task/engine_clone_task.cpp
@@ -504,6 +504,9 @@ Status EngineCloneTask::_finish_clone(Tablet* tablet, const string& clone_dir, i
     tablet->obtain_header_wrlock();
     DeferOp header_wrlock_release_guard([&tablet]() { tablet->release_header_lock(); });
 
+    tablet->obtain_update_compaction_lock();
+    DeferOp update_compaction_lock_release_guard([&tablet]() { tablet->release_base_compaction_lock(); });
+
     do {
         // load src header
         std::string header_file = strings::Substitute("$0/$1.hdr", clone_dir, tablet->tablet_id());


### PR DESCRIPTION
Current base compaction and cumulative have tablet level locks, but the update compaction does not have tablet level lock.
If we triggers two update compaction on the same tablet, a bug may occur.

Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5202 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Current base compaction and cumulative have tablet level locks, but the update compaction does not have tablet level lock.
If we triggers two update compaction on the same tablet, a bug may occur.
This pr add a tablet level lock for update compaction.