### PR TITLE
Remove the restriction of modify column clause to support modify column for primary key model.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -1540,9 +1540,6 @@ public class SchemaChangeHandler extends AlterHandler {
                 processDropColumn((DropColumnClause) alterClause, olapTable, indexSchemaMap, newIndexes);
             } else if (alterClause instanceof ModifyColumnClause) {
                 // modify column
-                if (olapTable.getKeysType() == KeysType.PRIMARY_KEYS) {
-                    throw new DdlException("Primary key table do not support modify column");
-                }
                 processModifyColumn((ModifyColumnClause) alterClause, olapTable, indexSchemaMap);
             } else if (alterClause instanceof ReorderColumnsClause) {
                 // reorder column

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
@@ -289,7 +289,7 @@ public class CreateTableTest {
                 "JSON must be used in duplicate key",
                 () -> alterTable("ALTER TABLE test.t_json_primary_key ADD COLUMN k3 JSON"));
         ExceptionChecker.expectThrowsWithMsg(DdlException.class,
-                "Primary key table do not support modify column",
+                "JSON must be used in duplicate key",
                 () -> alterTable("ALTER TABLE test.t_json_primary_key MODIFY COLUMN k3 JSON"));
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5197 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Primary key table do not support modify column for now.
```
mysql> create table orders (
    ->     dt date NOT NULL,
    ->     order_id bigint NOT NULL,
    ->     user_id int NOT NULL,
    ->     merchant_id int NOT NULL,
    ->     good_id int NOT NULL,
    ->     good_name string NOT NULL,
    ->     price int NOT NULL,
    ->     cnt int NOT NULL,
    ->     revenue int NOT NULL,
    ->     state tinyint NOT NULL
    -> ) PRIMARY KEY (dt, order_id)
    -> DISTRIBUTED BY HASH(order_id) BUCKETS 4
    -> PROPERTIES("replication_num" = "1");
Query OK, 0 rows affected (0.12 sec)

mysql> ALTER table orders MODIFY COLUMN price BIGINT;
ERROR 1064 (HY000): Primary key table do not support modify column
```

just remove the restriction of modify column clause, in fact, the implement was supported already.
