### PR TITLE
Fix group merge phase not update the GroupExpression state which will merge other GroupExpression

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/GroupExpression.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/GroupExpression.java
@@ -208,6 +208,25 @@ public class GroupExpression {
         return false;
     }
 
+    // use other Group Expression to update the lowestCostTable
+    public void updatePropertyWithCost(GroupExpression other) {
+        for (Map.Entry<PhysicalPropertySet, Pair<Double, List<PhysicalPropertySet>>> entry : other.lowestCostTable
+                .entrySet()) {
+            updatePropertyWithCost(entry.getKey(), entry.getValue().second, entry.getValue().first);
+        }
+    }
+
+    // merge other group expression state to this group expression
+    public void mergeGroupExpression(GroupExpression other) {
+        // 1. low Cost Table
+        for (Map.Entry<PhysicalPropertySet, Pair<Double, List<PhysicalPropertySet>>> entry : other.lowestCostTable
+                .entrySet()) {
+            updatePropertyWithCost(entry.getKey(), entry.getValue().second, entry.getValue().first);
+        }
+        // 2. outputPropertyMap
+        outputPropertyMap.putAll(other.outputPropertyMap);
+    }
+
     // This function will drive input group logical property first,
     // then derive itself's logical property
     public void deriveLogicalPropertyRecursively() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Memo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Memo.java
@@ -199,9 +199,11 @@ public class Memo {
                 groupExpression.setUnused(true);
                 GroupExpression existGroupExpression = groupExpressions.get(groupExpression);
                 if (!needMerge(groupExpression.getGroup(), existGroupExpression.getGroup())) {
-                    // groupExpression and existGroupExpression are in the same group， use existGroupExpression to
+                    // groupExpression and existGroupExpression are in the same group，use existGroupExpression to
                     // replace the bestExpression in the group
                     groupExpression.getGroup().replaceBestExpression(groupExpression, existGroupExpression);
+                    // existingGroupExpression merge the state of groupExpression
+                    existGroupExpression.mergeGroupExpression(groupExpression);
                 }
             }
         }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5203 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
In #5007, I add a function replaceBestExpression which update the low cost groupExpression of the group. but forget to update the state (low cost table, output property map) of the group expression, this will result in can not find the best plan in optimizer  