### PR TITLE
Fix BE crash when enable_filter_unused_columns_in_scan_stage is ture …

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/FilterUnusedColumnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/FilterUnusedColumnTest.java
@@ -59,12 +59,11 @@ public class FilterUnusedColumnTest extends PlanTestBase {
                 ");");
         FeConstants.USE_MOCK_DICT_MANAGER = true;
         connectContext.getSessionVariable().setSqlMode(2);
-        
+        connectContext.getSessionVariable().enableTrimOnlyFilteredColumnsInScanStage();
     }
 
     @Test
     public void testFilterComplexPredicate() throws Exception {
-        connectContext.getSessionVariable().enableTrimOnlyFilteredColumnsInScanStage();
         String sql = "select\n" +
                 "            ref_0.d_dow as c1 from tpcds_100g_date_dim as ref_0 \n" +
                 "            where ref_0.d_day_name = ref_0.d_day_name limit 137;\n";
@@ -74,7 +73,6 @@ public class FilterUnusedColumnTest extends PlanTestBase {
 
     @Test
     public void testFilterSinglePredicate() throws Exception {
-        connectContext.getSessionVariable().enableTrimOnlyFilteredColumnsInScanStage();
         String sql = "select\n" +
                 "            ref_0.d_dow as c1 from tpcds_100g_date_dim as ref_0 \n" +
                 "            where ref_0.d_day_name = \"dd\" limit 137;\n";
@@ -84,7 +82,6 @@ public class FilterUnusedColumnTest extends PlanTestBase {
 
     @Test
     public void testFilterProjection() throws Exception {
-        connectContext.getSessionVariable().enableTrimOnlyFilteredColumnsInScanStage();
         String sql = "select\n" +
                 "            ref_0.d_dow as c1, year(d_date) as year from tpcds_100g_date_dim as ref_0 \n" +
                 "            where ref_0.d_date = \'1997-12-31\' limit 137;\n";
@@ -94,7 +91,6 @@ public class FilterUnusedColumnTest extends PlanTestBase {
 
     @Test 
     public void testFilterAggTable() throws Exception {
-        connectContext.getSessionVariable().enableTrimOnlyFilteredColumnsInScanStage();
         String sql = "select timestamp\n" +
                 "               from metrics_detail where value is NULL limit 10;";
         String plan = getThriftPlan(sql);
@@ -103,10 +99,24 @@ public class FilterUnusedColumnTest extends PlanTestBase {
 
     @Test 
     public void testFilterPrimaryKeyTable() throws Exception {
-        connectContext.getSessionVariable().enableTrimOnlyFilteredColumnsInScanStage();
         String sql = "select timestamp\n" +
                 "               from primary_table where k3 = \"test\" limit 10;";
         String plan = getThriftPlan(sql);
+        Assert.assertTrue(plan.contains("unused_output_column_name:[]"));
+    }
+
+    @Test
+    public void testFilterDoublePredicateColumn() throws Exception {
+        String sql = "select t1a from test_all_type where t1f > 1";
+        String plan = getThriftPlan(sql);
+        Assert.assertTrue(plan.contains("unused_output_column_name:[]"));
+
+        sql = "select t1a from test_all_type where t1f is null";
+        plan = getThriftPlan(sql);
+        Assert.assertTrue(plan.contains("unused_output_column_name:[]"));
+
+        sql = "select t1a from test_all_type where t1f in (1.0, 2.0)";
+        plan = getThriftPlan(sql);
         Assert.assertTrue(plan.contains("unused_output_column_name:[]"));
     }
 }


### PR DESCRIPTION
…for double column

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

for https://github.com/StarRocks/starrocks/issues/5174,  https://github.com/StarRocks/starrocks/issues/4916

for SQL:
```

select id_varchar from test_cross_join_30 where 1 <= id_double;
```

The predicate `1 <= id_double;` couldn't push down storage engine

```
struct ColumnRangeBuilder {
    template <PrimitiveType ptype>
    std::nullptr_t operator()(OlapScanConjunctsManager* cm, const SlotDescriptor* slot,
                              std::map<std::string, ColumnValueRangeType>* column_value_ranges) {
        if constexpr (ptype == TYPE_TIME || ptype == TYPE_NULL || ptype == TYPE_JSON || pt_is_float<ptype>) {
            return nullptr;
        } else {
```
So we couldn't prune id_double column in storage engine, we need to return the  id_double column to compute engine.

