### PR TITLE
 Fix: use strict mode of DateTimeFormatter for parsing string to date (#4994 #5146)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/DateLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/DateLiteral.java
@@ -42,6 +42,8 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.ResolverStyle;
+import java.time.temporal.ChronoField;
 import java.util.Date;
 import java.util.Objects;
 import java.util.TimeZone;
@@ -67,11 +69,16 @@ public class DateLiteral extends LiteralExpr {
     private static final DateTimeFormatter DATE_FORMATTER_TWO_DIGIT;
 
     static {
-        DATE_TIME_FORMATTER = DateUtils.unixDatetimeFormatBuilder("%Y-%m-%e %H:%i:%s").toFormatter();
-        DATE_FORMATTER = DateUtils.unixDatetimeFormatBuilder("%Y-%m-%e").toFormatter();
-        DATE_TIME_FORMATTER_TWO_DIGIT = DateUtils.unixDatetimeFormatBuilder("%y-%m-%e %H:%i:%s").toFormatter();
-        DATE_FORMATTER_TWO_DIGIT = DateUtils.unixDatetimeFormatBuilder("%y-%m-%e").toFormatter();
-        DATE_NO_SPLIT_FORMATTER = DateUtils.unixDatetimeFormatBuilder("%Y%m%e").toFormatter();
+        DATE_TIME_FORMATTER = DateUtils.unixDatetimeFormatBuilder("%Y-%m-%e %H:%i:%s")
+                .toFormatter().withResolverStyle(ResolverStyle.STRICT);
+        DATE_FORMATTER = DateUtils.unixDatetimeFormatBuilder("%Y-%m-%e")
+                .toFormatter().withResolverStyle(ResolverStyle.STRICT);
+        DATE_TIME_FORMATTER_TWO_DIGIT = DateUtils.unixDatetimeFormatBuilder("%y-%m-%e %H:%i:%s")
+                .toFormatter().withResolverStyle(ResolverStyle.STRICT);
+        DATE_FORMATTER_TWO_DIGIT = DateUtils.unixDatetimeFormatBuilder("%y-%m-%e")
+                .toFormatter().withResolverStyle(ResolverStyle.STRICT);
+        DATE_NO_SPLIT_FORMATTER = DateUtils.unixDatetimeFormatBuilder("%Y%m%e")
+                .toFormatter().withResolverStyle(ResolverStyle.STRICT);
     }
 
     //Date Literal persist type in meta

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/DateUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/DateUtils.java
@@ -106,7 +106,8 @@ public class DateUtils {
                         builder.appendValue(ChronoField.YEAR, 4);
                         break;
                     case 'y': // %y Year, numeric (two digits)
-                        builder.appendValueReduced(ChronoField.YEAR_OF_ERA, 2, 2, 1970);
+                        builder.appendValueReduced(ChronoField.YEAR_OF_ERA, 2, 2, 1970)
+                                .parseDefaulting(ChronoField.ERA, 1);
                         break;
                     case 'f': // %f Microseconds (000000..999999)
                         builder.padNext(6, '0').appendValue(ChronoField.MICRO_OF_SECOND, 1, 6, SignStyle.NORMAL);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
@@ -20,6 +20,7 @@ import java.math.BigInteger;
 import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.ResolverStyle;
 import java.time.format.SignStyle;
 import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
@@ -61,7 +62,8 @@ public final class ConstantOperator extends ScalarOperator implements Comparable
     // Don't need fixWidth
     private static final DateTimeFormatter DATE_TIME_FORMATTER_MS =
             DateUtils.unixDatetimeFormatBuilder("%Y-%m-%d %H:%i:%s.")
-                    .appendValue(ChronoField.MICRO_OF_SECOND, 1, 6, SignStyle.NORMAL).toFormatter();
+                    .appendValue(ChronoField.MICRO_OF_SECOND, 1, 6, SignStyle.NORMAL)
+                    .toFormatter().withResolverStyle(ResolverStyle.STRICT);
 
     private static void requiredValid(LocalDateTime dateTime) throws SemanticException {
         if (null == dateTime || dateTime.isBefore(MIN_DATETIME) || dateTime.isAfter(MAX_DATETIME)) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
@@ -44,6 +44,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.ResolverStyle;
 import java.time.temporal.ChronoUnit;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -130,10 +131,12 @@ public class ScalarOperatorFunctions {
         DateTimeFormatterBuilder builder = DateUtils.unixDatetimeFormatBuilder(fmtLiteral.getVarchar());
 
         if (HAS_TIME_PART.matcher(fmtLiteral.getVarchar()).matches()) {
-            LocalDateTime ldt = LocalDateTime.from(builder.toFormatter().parse(date.getVarchar()));
+            LocalDateTime ldt = LocalDateTime.from(
+                    builder.toFormatter().withResolverStyle(ResolverStyle.STRICT).parse(date.getVarchar()));
             return ConstantOperator.createDatetime(ldt, Type.DATETIME);
         } else {
-            LocalDate ld = LocalDate.from(builder.toFormatter().parse(date.getVarchar()));
+            LocalDate ld = LocalDate.from(
+                    builder.toFormatter().withResolverStyle(ResolverStyle.STRICT).parse(date.getVarchar()));
             return ConstantOperator.createDatetime(ld.atTime(0, 0, 0), Type.DATETIME);
         }
     }
@@ -141,7 +144,8 @@ public class ScalarOperatorFunctions {
     @FEFunction(name = "str2date", argTypes = {"VARCHAR", "VARCHAR"}, returnType = "DATE")
     public static ConstantOperator str2Date(ConstantOperator date, ConstantOperator fmtLiteral) {
         DateTimeFormatterBuilder builder = DateUtils.unixDatetimeFormatBuilder(fmtLiteral.getVarchar());
-        LocalDate ld = LocalDate.from(builder.toFormatter().parse(date.getVarchar()));
+        LocalDate ld = LocalDate.from(
+                builder.toFormatter().withResolverStyle(ResolverStyle.STRICT).parse(date.getVarchar()));
         return ConstantOperator.createDatetime(ld.atTime(0, 0, 0), Type.DATE);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/DateLiteralTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/DateLiteralTest.java
@@ -78,4 +78,9 @@ public class DateLiteralTest {
         }
         Assert.assertFalse(hasException);
     }
+
+    @Test
+    public void invalidDate() {
+        Assert.assertThrows(AnalysisException.class, () -> new DateLiteral("2019-02-29", Type.DATETIME));
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/DateLiteralTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/DateLiteralTest.java
@@ -81,6 +81,60 @@ public class DateLiteralTest {
 
     @Test
     public void invalidDate() {
-        Assert.assertThrows(AnalysisException.class, () -> new DateLiteral("2019-02-29", Type.DATETIME));
+        String[] testDateCases = {
+                // Invalid year.
+                "20190-05-31",
+                "1-05-31",
+                // Invalid month.
+                "2019-5-31",
+                "2019-16-31",
+                // Invalid day.
+                "2019-02-29",
+                "2019-04-31",
+                "2019-05-32",
+
+                // Other invalid formats.
+                "2019-05-31-1",
+                "not-date",
+        };
+        for (String c : testDateCases) {
+            Assert.assertThrows(AnalysisException.class, () -> new DateLiteral(c, Type.DATE));
+        }
+
+        String[] testDatetimeCases = {
+                // Invalid year.
+                "20190-05-31 10:11:12",
+                "20190-05-31 10:11:12.123",
+                "1-05-31 10:11:12",
+                "1-05-31 10:11:12.123",
+                // Invalid month.
+                "2019-5-31 10:11:12",
+                "2019-5-31 10:11:12.123",
+                "2019-16-31 10:11:12",
+                "2019-16-31 10:11:12.123",
+                // Invalid day.
+                "2019-02-29 10:11:12",
+                "2019-02-29 10:11:12.123",
+                "2019-04-31 10:11:12",
+                "2019-04-31 10:11:12.123",
+                "2019-05-32 10:11:12",
+                "2019-05-32 10:11:12.123",
+                // Invalid hour, minute, or second.
+                "2019-05-31 25:11:12",
+                "2019-05-31 25:11:12.123",
+                "2019-05-31 10:61:12",
+                "2019-05-31 10:61:12.123",
+                "2019-05-31 10:11:61",
+                "2019-05-31 10:11:61.123",
+                "2019-05-31 10:11:12.1234567",
+
+                // Other invalid formats.
+                "2019-05-31-1 10:11:12",
+                "2019-05-31-1 10:11:12.123",
+                "not-date",
+        };
+        for (String c : testDatetimeCases) {
+            Assert.assertThrows(AnalysisException.class, () -> new DateLiteral(c, Type.DATETIME));
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/operator/operator/ConstantOperatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/operator/operator/ConstantOperatorTest.java
@@ -1,0 +1,97 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.sql.optimizer.operator.operator;
+
+import com.starrocks.catalog.Type;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ConstantOperatorTest {
+    @Test
+    public void testCastToDateValid() throws Exception {
+        String[][] testCases = {
+                // YYYY-MM-dd or yy-MM-dd
+                {"1997-10-07", "1997-10-07T00:00", "1997-10-07T00:00"},
+                {"0097-10-07", "0097-10-07T00:00", "0097-10-07T00:00"},
+                {"2020-02-29", "2020-02-29T00:00", "2020-02-29T00:00"}, // Leap year.
+                {"97-10-07", "1997-10-07T00:00", "1997-10-07T00:00"},
+                {"99-10-07", "1999-10-07T00:00", "1999-10-07T00:00"},
+                {"70-10-07", "1970-10-07T00:00", "1970-10-07T00:00"},
+                {"69-10-07", "2069-10-07T00:00", "2069-10-07T00:00"},
+                {"00-10-07", "2000-10-07T00:00", "2000-10-07T00:00"},
+                // YYYY-MM-dd HH:mm:ss or yy-MM-dd HH:mm:ss
+                {"1997-10-07 10:11:12", "1997-10-07T00:00", "1997-10-07T10:11:12"},
+                {"0097-10-07 10:11:12", "0097-10-07T00:00", "0097-10-07T10:11:12"},
+                {"2020-02-29 10:11:12", "2020-02-29T00:00", "2020-02-29T10:11:12"}, // Leap year.
+                {"97-10-07 10:11:12", "1997-10-07T00:00", "1997-10-07T10:11:12"},
+                {"99-10-07 10:11:12", "1999-10-07T00:00", "1999-10-07T10:11:12"},
+                {"70-10-07 10:11:12", "1970-10-07T00:00", "1970-10-07T10:11:12"},
+                {"69-10-07 10:11:12", "2069-10-07T00:00", "2069-10-07T10:11:12"},
+                {"00-10-07 10:11:12", "2000-10-07T00:00", "2000-10-07T10:11:12"},
+                // YYYY-MM-dd HH:mm:ss.SSS
+                {"1997-10-07 10:11:12.123", "1997-10-07T10:11:12.000123", "1997-10-07T10:11:12.000123"},
+                {"0097-10-07 10:11:12.123", "0097-10-07T10:11:12.000123", "0097-10-07T10:11:12.000123"},
+                {"2020-02-29 10:11:12.123", "2020-02-29T10:11:12.000123", "2020-02-29T10:11:12.000123"}, // Leap year.
+        };
+
+        for (String[] c : testCases) {
+            ConstantOperator in = ConstantOperator.createVarchar(c[0]);
+            Assert.assertEquals(c[1], in.castTo(Type.DATE).getDate().toString());
+            Assert.assertEquals(c[2], in.castTo(Type.DATETIME).getDate().toString());
+        }
+    }
+
+    @Test
+    public void testCaseToDateInvalid() {
+        String[] testCases = {
+                // Invalid year.
+                "20190-05-31",
+                "20190-05-31 10:11:12",
+                "20190-05-31 10:11:12.123",
+                "1-05-31",
+                "1-05-31 10:11:12",
+                "1-05-31 10:11:12.123",
+                // Invalid month.
+                "2019-5-31",
+                "2019-5-31 10:11:12",
+                "2019-5-31 10:11:12.123",
+                "2019-16-31",
+                "2019-16-31 10:11:12",
+                "2019-16-31 10:11:12.123",
+                // Invalid day.
+                "2019-02-29",
+                "2019-02-29 10:11:12",
+                "2019-02-29 10:11:12.123",
+                "2019-04-31",
+                "2019-04-31 10:11:12",
+                "2019-04-31 10:11:12.123",
+                "2019-05-32",
+                "2019-05-32 10:11:12",
+                "2019-05-32 10:11:12.123",
+                // Invalid hour, minute, or second.
+                "2019-05-31 25:11:12",
+                "2019-05-31 25:11:12.123",
+                "2019-05-31 10:61:12",
+                "2019-05-31 10:61:12.123",
+                "2019-05-31 10:11:61",
+                "2019-05-31 10:11:61.123",
+                "2019-05-31 10:11:12.1234567",
+
+                // Only support "YYYY-MM-dd HH:mm:ss", not "yy-MM-dd HH:mm:ss".
+                "97-10-07 10:11:12.123",
+
+                // Other invalid formats.
+                "2019-05-31-1",
+                "2019-05-31-1 10:11:12",
+                "2019-05-31-1 10:11:12.123",
+                "not-date",
+        };
+        for (String c : testCases) {
+            ConstantOperator in = ConstantOperator.createVarchar(c);
+            Assert.assertThrows(AnalysisException.class, () -> in.castTo(Type.DATE));
+            Assert.assertThrows(AnalysisException.class, () -> in.castTo(Type.DATETIME));
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
@@ -18,6 +18,7 @@ import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.format.DateTimeParseException;
 import java.util.Locale;
 
 import static org.junit.Assert.assertEquals;
@@ -251,6 +252,12 @@ public class ScalarOperatorFunctionsTest {
         assertEquals("2020-02-21 00:00:00",
                 ScalarOperatorFunctions.dateParse(ConstantOperator.createVarchar("2020-02-21"),
                         ConstantOperator.createVarchar("%Y-%m-%d")).toString());
+        assertEquals("2020-02-21 00:00:00",
+                ScalarOperatorFunctions.dateParse(ConstantOperator.createVarchar("20-02-21"),
+                        ConstantOperator.createVarchar("%y-%m-%d")).toString());
+        assertEquals("1998-02-21 00:00:00",
+                ScalarOperatorFunctions.dateParse(ConstantOperator.createVarchar("98-02-21"),
+                        ConstantOperator.createVarchar("%y-%m-%d")).toString());
 
         Assert.assertThrows(DateTimeException.class, () -> ScalarOperatorFunctions
                 .dateParse(ConstantOperator.createVarchar("201905"),
@@ -259,6 +266,14 @@ public class ScalarOperatorFunctionsTest {
         Assert.assertThrows(DateTimeException.class, () -> ScalarOperatorFunctions
                 .dateParse(ConstantOperator.createVarchar("20190507"),
                         ConstantOperator.createVarchar("%Y%m")).getDatetime());
+
+        Assert.assertThrows(DateTimeParseException.class, () -> ScalarOperatorFunctions
+                .dateParse(ConstantOperator.createVarchar("2019-02-29"),
+                        ConstantOperator.createVarchar("%Y-%m-%d")).getDatetime());
+
+        Assert.assertThrows(DateTimeParseException.class, () -> ScalarOperatorFunctions
+                .dateParse(ConstantOperator.createVarchar("2019-02-29 11:12:13"),
+                        ConstantOperator.createVarchar("%Y-%m-%d %H:%i:%s")).getDatetime());
 
         Assert.assertThrows(IllegalArgumentException.class,
                 () -> ScalarOperatorFunctions.dateParse(ConstantOperator.createVarchar("2020-2-21"),
@@ -281,6 +296,16 @@ public class ScalarOperatorFunctionsTest {
         assertEquals("2013-05-17T00:00", ScalarOperatorFunctions
                 .str2Date(ConstantOperator.createVarchar("2013-05-17 12:35:10"),
                         ConstantOperator.createVarchar("%Y-%m-%d %H:%i:%s")).getDate().toString());
+        assertEquals("2013-05-17T00:00", ScalarOperatorFunctions
+                .str2Date(ConstantOperator.createVarchar("13-05-17 12:35:10"),
+                        ConstantOperator.createVarchar("%y-%m-%d %H:%i:%s")).getDate().toString());
+        assertEquals("1998-05-17T00:00", ScalarOperatorFunctions
+                .str2Date(ConstantOperator.createVarchar("98-05-17 12:35:10"),
+                        ConstantOperator.createVarchar("%y-%m-%d %H:%i:%s")).getDate().toString());
+
+        Assert.assertThrows(DateTimeParseException.class, () -> ScalarOperatorFunctions
+                .str2Date(ConstantOperator.createVarchar("2019-02-29"),
+                        ConstantOperator.createVarchar("%Y-%m-%d")).getDatetime());
     }
 
     @Test


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Problem Summary：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This is cherry-picked from the PR #4996 and #5146.
