### PR TITLE
Fix bug type convert and remove findCommonType

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/ArithmeticExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/ArithmeticExpr.java
@@ -316,10 +316,10 @@ public class ArithmeticExpr extends Expr {
             case MOD:
                 // numeric ops must be promoted to highest-resolution type
                 // (otherwise we can't guarantee that a <op> b won't overflow/underflow)
-                commonType = findCommonType(t1, t2);
+                commonType = getCommonType(t1, t2);
                 break;
             case DIVIDE:
-                commonType = findCommonType(t1, t2);
+                commonType = getCommonType(t1, t2);
                 if (commonType.getPrimitiveType() == PrimitiveType.BIGINT
                         || commonType.getPrimitiveType() == PrimitiveType.LARGEINT) {
                     commonType = Type.DOUBLE;
@@ -403,26 +403,6 @@ public class ArithmeticExpr extends Expr {
         List<TupleId> tupleIds = Lists.newArrayList();
         getIds(tupleIds, null);
         Preconditions.checkArgument(tupleIds.size() == 1);
-    }
-
-    public static Type findCommonType(Type t1, Type t2) {
-        PrimitiveType pt1 = t1.getPrimitiveType();
-        PrimitiveType pt2 = t2.getPrimitiveType();
-
-        if (pt1 == PrimitiveType.DOUBLE || pt2 == PrimitiveType.DOUBLE) {
-            return Type.DOUBLE;
-        } else if (pt1.isDecimalV3Type() || pt2.isDecimalV3Type()) {
-            return ScalarType.getAssigmentCompatibleTypeOfDecimalV3((ScalarType) t1, (ScalarType) t2);
-        } else if (pt1 == PrimitiveType.DECIMALV2 || pt2 == PrimitiveType.DECIMALV2) {
-            return Type.DECIMALV2;
-        } else if (pt1 == PrimitiveType.LARGEINT || pt2 == PrimitiveType.LARGEINT) {
-            return Type.LARGEINT;
-        } else {
-            if (pt1 != PrimitiveType.BIGINT && pt2 != PrimitiveType.BIGINT) {
-                return Type.INVALID;
-            }
-            return Type.BIGINT;
-        }
     }
 
     public static Type getCommonType(Type t1, Type t2) {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5252

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
the cause of this bug is because k6-1 expr is both tinyint type.
and use findCommonType will return INVALID type.
but in new optimizer use getCommonType to issue this problem so we remove old findCommonType code and use new one.