### PR TITLE
fix #5250: append_by_permutation bug for BinaryColumn

### DIFF
--- a/be/src/exec/vectorized/sorting/sort_permute.cpp
+++ b/be/src/exec/vectorized/sorting/sort_permute.cpp
@@ -156,7 +156,7 @@ public:
 
         auto& offsets = dst->get_offset();
         auto& bytes = dst->get_bytes();
-        size_t old_rows = offsets.size();
+        size_t old_rows = offsets.size() - 1;
         size_t total_rows = offsets.size();
         size_t total_bytes = bytes.size();
         offsets.resize(total_rows + _perm.size());

--- a/be/src/exec/vectorized/sorting/sort_permute.cpp
+++ b/be/src/exec/vectorized/sorting/sort_permute.cpp
@@ -156,18 +156,18 @@ public:
 
         auto& offsets = dst->get_offset();
         auto& bytes = dst->get_bytes();
-        size_t old_rows = offsets.size() - 1;
-        size_t total_rows = offsets.size();
-        size_t total_bytes = bytes.size();
-        offsets.resize(total_rows + _perm.size());
+        size_t old_rows = dst->size();
+        size_t num_offsets = offsets.size();
+        size_t num_bytes = bytes.size();
+        offsets.resize(num_offsets + _perm.size());
         for (auto& p : _perm) {
             Slice slice = (*srcs[p.chunk_index])[p.index_in_chunk];
-            offsets[total_rows] = offsets[total_rows - 1] + slice.get_size();
-            ++total_rows;
-            total_bytes += slice.get_size();
+            offsets[num_offsets] = offsets[num_offsets - 1] + slice.get_size();
+            ++num_offsets;
+            num_bytes += slice.get_size();
         }
 
-        bytes.resize(total_bytes);
+        bytes.resize(num_bytes);
         for (size_t i = 0; i < _perm.size(); i++) {
             Slice slice = (*srcs[_perm[i].chunk_index])[_perm[i].index_in_chunk];
             strings::memcpy_inlined(bytes.data() + offsets[old_rows + i], slice.get_data(), slice.get_size());

--- a/be/test/exec/vectorized/sorting_test.cpp
+++ b/be/test/exec/vectorized/sorting_test.cpp
@@ -144,6 +144,34 @@ static ColumnPtr build_sorted_column(TypeDescriptor type_desc, int slot_index, i
     return column;
 }
 
+TEST(SortingTest, append_by_permutation_binary) {
+    BinaryColumn::Ptr input1 = BinaryColumn::create();
+    BinaryColumn::Ptr input2 = BinaryColumn::create();
+    input1->append_string("star");
+    input2->append_string("rock");
+
+    ColumnPtr merged = BinaryColumn::create();
+    Permutation perm{{0, 0}, {1, 0}};
+    append_by_permutation(merged.get(), {input1, input2}, perm);
+    ASSERT_EQ(2, merged->size());
+    ASSERT_EQ("star", merged->get(0).get_slice());
+    ASSERT_EQ("rock", merged->get(1).get_slice());
+}
+
+TEST(SortingTest, append_by_permutation_int) {
+    Int32Column::Ptr input1 = Int32Column::create();
+    Int32Column::Ptr input2 = Int32Column::create();
+    input1->append(1024);
+    input2->append(2048);
+
+    ColumnPtr merged = Int32Column::create();
+    Permutation perm{{0, 0}, {1, 0}};
+    append_by_permutation(merged.get(), {input1, input2}, perm);
+    ASSERT_EQ(2, merged->size());
+    ASSERT_EQ(1024, merged->get(0).get_int32());
+    ASSERT_EQ(2048, merged->get(1).get_int32());
+}
+
 } // namespace starrocks::vectorized
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5250 


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Offset calculation bug in `append_by_permutation` for BinaryColumn.


