### PR TITLE
fix #5209: disable implicit cast to decimalv3 when disabled

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
@@ -424,11 +424,11 @@ public class ScalarType extends Type implements Cloneable {
             return createVarcharType(Math.max(t1.len, t2.len));
         }
 
-        if (t1.isDecimalV3()) {
+        if (t1.isDecimalV3() && isDecimalV3Enabled()) {
             return getAssigmentCompatibleTypeOfDecimalV3(t1, t2);
         }
 
-        if (t2.isDecimalV3()) {
+        if (t2.isDecimalV3() && isDecimalV3Enabled()) {
             return getAssigmentCompatibleTypeOfDecimalV3(t2, t1);
         }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5209

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Disable Cast to decimalV3 when the decimalv3 is disabled, otherwise some decimalv3 function will be matched.
