### PR TITLE
Opt: rewrite zonemap predicates only once

### DIFF
--- a/be/src/storage/rowset/beta_rowset.cpp
+++ b/be/src/storage/rowset/beta_rowset.cpp
@@ -240,6 +240,7 @@ Status BetaRowset::get_segment_iterators(const vectorized::Schema& schema, const
     seg_options.stats = options.stats;
     seg_options.ranges = options.ranges;
     seg_options.predicates = options.predicates;
+    seg_options.predicates_for_zone_map = options.predicates_for_zone_map;
     seg_options.use_page_cache = options.use_page_cache;
     seg_options.profile = options.profile;
     seg_options.reader_type = options.reader_type;

--- a/be/src/storage/rowset/rowset_options.h
+++ b/be/src/storage/rowset/rowset_options.h
@@ -37,7 +37,7 @@ public:
     std::vector<SeekRange> ranges;
 
     std::unordered_map<ColumnId, PredicateList> predicates;
-    std::unordered_map<ColumnId, std::vector<const ColumnPredicate*>> predicates_for_zone_map;
+    std::unordered_map<ColumnId, PredicateList> predicates_for_zone_map;
 
     // whether rowset should return rows in sorted order.
     bool sorted = true;

--- a/be/src/storage/rowset/rowset_options.h
+++ b/be/src/storage/rowset/rowset_options.h
@@ -37,6 +37,7 @@ public:
     std::vector<SeekRange> ranges;
 
     std::unordered_map<ColumnId, PredicateList> predicates;
+    std::unordered_map<ColumnId, std::vector<const ColumnPredicate*>> predicates_for_zone_map;
 
     // whether rowset should return rows in sorted order.
     bool sorted = true;

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -192,12 +192,7 @@ StatusOr<ChunkIteratorPtr> Segment::_new_iterator(const vectorized::Schema& sche
                                                   const vectorized::SegmentReadOptions& read_options) {
     DCHECK(read_options.stats != nullptr);
     // trying to prune the current segment by segment-level zone map
-    ObjectPool pool;
-    std::unordered_map<ColumnId, std::vector<const vectorized::ColumnPredicate*>> predicates_for_zone_map_filter;
-    RETURN_IF_ERROR(vectorized::ZonemapPredicatesRewriter::rewrite_predicate_map(&pool, read_options.predicates,
-                                                                                 &predicates_for_zone_map_filter));
-
-    for (const auto& pair : predicates_for_zone_map_filter) {
+    for (const auto& pair : read_options.predicates_for_zone_map) {
         ColumnId column_id = pair.first;
         if (_column_readers[column_id] == nullptr || !_column_readers[column_id]->has_zone_map()) {
             continue;

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -474,14 +474,11 @@ Status SegmentIterator::_get_row_ranges_by_zone_map() {
     for (const auto& pair : _opts.predicates) {
         columns.insert(pair.first);
     }
-    std::unordered_map<ColumnId, std::vector<const ColumnPredicate*>> predicates_for_zone_map;
-    RETURN_IF_ERROR(
-            ZonemapPredicatesRewriter::rewrite_predicate_map(&_obj_pool, _opts.predicates, &predicates_for_zone_map));
 
     std::vector<const ColumnPredicate*> query_preds;
     for (ColumnId cid : columns) {
-        auto iter1 = predicates_for_zone_map.find(cid);
-        if (iter1 != predicates_for_zone_map.end()) {
+        auto iter1 = _opts.predicates_for_zone_map.find(cid);
+        if (iter1 != _opts.predicates_for_zone_map.end()) {
             query_preds = iter1->second;
         } else {
             query_preds.clear();

--- a/be/src/storage/rowset/segment_options.h
+++ b/be/src/storage/rowset/segment_options.h
@@ -32,6 +32,7 @@ public:
     std::vector<SeekRange> ranges;
 
     std::unordered_map<ColumnId, PredicateList> predicates;
+    std::unordered_map<ColumnId, std::vector<const ColumnPredicate*>> predicates_for_zone_map;
 
     DisjunctivePredicates delete_predicates;
 

--- a/be/src/storage/rowset/segment_options.h
+++ b/be/src/storage/rowset/segment_options.h
@@ -32,7 +32,7 @@ public:
     std::vector<SeekRange> ranges;
 
     std::unordered_map<ColumnId, PredicateList> predicates;
-    std::unordered_map<ColumnId, std::vector<const ColumnPredicate*>> predicates_for_zone_map;
+    std::unordered_map<ColumnId, PredicateList> predicates_for_zone_map;
 
     DisjunctivePredicates delete_predicates;
 

--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -8,6 +8,7 @@
 #include "service/backend_options.h"
 #include "storage/aggregate_iterator.h"
 #include "storage/chunk_helper.h"
+#include "storage/column_predicate_rewriter.h"
 #include "storage/conjunctive_predicates.h"
 #include "storage/delete_predicates.h"
 #include "storage/empty_iterator.h"
@@ -84,6 +85,8 @@ Status TabletReader::get_segment_iterators(const TabletReaderParams& params, std
     RETURN_IF_ERROR(_init_delete_predicates(params, &_delete_predicates));
     RETURN_IF_ERROR(_parse_seek_range(params, &rs_opts.ranges));
     rs_opts.predicates = _pushdown_predicates;
+    RETURN_IF_ERROR(ZonemapPredicatesRewriter::rewrite_predicate_map(&_obj_pool, rs_opts.predicates,
+                                                                     &rs_opts.predicates_for_zone_map));
     rs_opts.sorted = (keys_type != DUP_KEYS && keys_type != PRIMARY_KEYS) && !params.skip_aggregation;
     rs_opts.reader_type = params.reader_type;
     rs_opts.chunk_size = params.chunk_size;

--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -47,6 +47,7 @@ void TabletReader::close() {
         _collect_iter.reset();
     }
     STLDeleteElements(&_predicate_free_list);
+    _obj_pool.clear();
 }
 
 Status TabletReader::prepare() {

--- a/be/src/storage/tablet_reader.h
+++ b/be/src/storage/tablet_reader.h
@@ -62,6 +62,7 @@ private:
     Version _delete_predicates_version;
 
     MemPool _mempool;
+    ObjectPool _obj_pool;
 
     PredicateMap _pushdown_predicates;
     DeletePredicates _delete_predicates;


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Problem Summary：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Rewrite zonemap predicates, at the initial stage of `TabletReader`, not at the initial stage of every segment.
It will be released at `TabletReader::close()` by `_obj_pool.clear()`.



## Test
Environment
- 3 BE * 16vCPUs
- Enable storage page cache with 20GB.

After this PR, v2.2 doesn't has performance degradation compared to v2.1 anymore.


| Query    | v2.1 NP | v2.2 NP | v2.2 P | 2.2-PR-NP | 2.2-PR-P |
| -------- | ------- | ------- | ------ | --------- | -------- |
| Q1.1.sql | 128     | 138     | 115    | 117       | 96       |
| Q1.2.sql | 60      | 60      | 61     | 55        | 54       |
| Q1.3.sql | 127     | 151     | 119    | 118       | 90       |
| Q2.1.sql | 189     | 267     | 257    | 184       | 169      |
| Q2.2.sql | 161     | 176     | 152    | 155       | 131      |
| Q2.3.sql | 65      | 66      | 72     | 63        | 67       |
| Q3.1.sql | 197     | 242     | 245    | 210       | 200      |
| Q3.2.sql | 135     | 161     | 125    | 144       | 109      |
| Q3.3.sql | 110     | 113     | 125    | 113       | 115      |
| Q3.4.sql | 80      | 86      | 99     | 79        | 90       |
| Q4.1.sql | 223     | 290     | 308    | 222       | 229      |
| Q4.2.sql | 189     | 247     | 226    | 190       | 183      |
| Q4.3.sql | 99      | 109     | 127    | 97        | 105      |
| SUM      | 1763    | 2106    | 2031   | 1747      | 1638     |
