### PR TITLE
By default reserve 1MB bytes for parquet column reader

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -652,10 +652,6 @@ CONF_Int64(pipeline_sink_brpc_dop, "8");
 CONF_Int16(bitmap_serialize_version, "1");
 // The max hdfs file handle.
 CONF_mInt32(max_hdfs_file_handle, "1000");
-// Buffer stream reserve size
-// each column will reserve buffer_stream_reserve_size bytes for read
-// default: 8M
-CONF_mInt32(buffer_stream_reserve_size, "8192000");
 
 CONF_Int64(max_segment_file_size, "1073741824");
 
@@ -680,7 +676,10 @@ CONF_String(object_storage_region, "");
 CONF_Int64(object_storage_max_connection, "102400");
 
 CONF_Bool(enable_orc_late_materialization, "true");
+// orc reader, if RowGroup/Stripe/File size is less than this value, read all data.
 CONF_Int32(orc_file_cache_max_size, "2097152");
+// parquet reader, each column will reserve X bytes for read
+CONF_mInt32(parquet_buffer_stream_reserve_size, "1048576");
 
 // default: 16MB
 CONF_mInt64(experimental_s3_max_single_part_size, "16777216");

--- a/be/src/exec/parquet/column_chunk_reader.cpp
+++ b/be/src/exec/parquet/column_chunk_reader.cpp
@@ -32,6 +32,14 @@ public:
         return nread;
     }
 
+    StatusOr<int64_t> read_at(int64_t offset, void* data, int64_t size) override {
+        SCOPED_RAW_TIMER(&_stats->io_ns);
+        _stats->io_count += 1;
+        ASSIGN_OR_RETURN(auto nread, _stream->read_at(offset, data, size));
+        _stats->bytes_read += nread;
+        return nread;
+    }
+
 private:
     std::shared_ptr<io::SeekableInputStream> _stream;
     vectorized::HdfsScanStats* _stats;

--- a/be/src/exec/parquet/page_reader.cpp
+++ b/be/src/exec/parquet/page_reader.cpp
@@ -2,6 +2,7 @@
 
 #include "exec/parquet/page_reader.h"
 
+#include "common/config.h"
 #include "env/env.h"
 #include "gutil/strings/substitute.h"
 #include "util/thrift_util.h"
@@ -12,7 +13,9 @@ static constexpr size_t kHeaderBufSize = 1024;
 static constexpr size_t kHeaderBufMaxSize = 16 * 1024;
 
 PageReader::PageReader(RandomAccessFile* file, uint64_t start_offset, uint64_t length)
-        : _stream(file, start_offset, length), _start_offset(start_offset), _finish_offset(start_offset + length) {}
+        : _stream(file, start_offset, length), _start_offset(start_offset), _finish_offset(start_offset + length) {
+    _stream.reserve(config::parquet_buffer_stream_reserve_size);
+}
 
 Status PageReader::next_header() {
     if (_offset != _next_header_pos) {

--- a/be/src/util/buffered_stream.cpp
+++ b/be/src/util/buffered_stream.cpp
@@ -9,9 +9,7 @@
 namespace starrocks {
 
 BufferedInputStream::BufferedInputStream(RandomAccessFile* file, uint64_t offset, uint64_t length)
-        : _file(file), _offset(offset), _end_offset(offset + length) {
-    _reserve(config::buffer_stream_reserve_size);
-}
+        : _file(file), _offset(offset), _end_offset(offset + length) {}
 
 Status BufferedInputStream::get_bytes(const uint8_t** buffer, size_t* nbytes, bool peek) {
     if (*nbytes <= num_remaining()) {
@@ -22,7 +20,7 @@ Status BufferedInputStream::get_bytes(const uint8_t** buffer, size_t* nbytes, bo
         return Status::OK();
     }
 
-    _reserve(*nbytes);
+    reserve(*nbytes);
     RETURN_IF_ERROR(_read_data());
 
     size_t max_get = std::min(*nbytes, num_remaining());
@@ -34,7 +32,7 @@ Status BufferedInputStream::get_bytes(const uint8_t** buffer, size_t* nbytes, bo
     return Status::OK();
 }
 
-void BufferedInputStream::_reserve(size_t nbytes) {
+void BufferedInputStream::reserve(size_t nbytes) {
     if (nbytes <= _buf_capacity - _buf_position) {
         return;
     }

--- a/be/src/util/buffered_stream.h
+++ b/be/src/util/buffered_stream.h
@@ -15,6 +15,7 @@ class RandomAccessFile;
 class BufferedInputStream {
 public:
     BufferedInputStream(RandomAccessFile* file, uint64_t offset, uint64_t length);
+
     ~BufferedInputStream() = default;
 
     void seek_to(uint64_t offset) {
@@ -43,8 +44,9 @@ public:
 
     Status get_bytes(const uint8_t** buffer, size_t* nbytes, bool peek = false);
 
+    void reserve(size_t nbytes);
+
 private:
-    void _reserve(size_t nbytes);
     Status _read_data();
     size_t num_remaining() const { return _buf_written - _buf_position; }
     size_t left_capactiy() const { return _buf_capacity - _buf_written; }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Related to https://github.com/StarRocks/starrocks/pull/1652

And fix a trivial bug that 
- ParquetColumnReader use `read_at` APIs, but we just override `read` API
- which means we don't collect IOCounter and IOTime.

----

I've done another experiment and got a very different result.  1FE & 1BE & SSB-1T & main branch.  The script is following

> python run-bench.py --mysql --endpoint 127.0.0.1 --port 41003 --sql test.sql --user root --db ssb_parquet --mem-limit 30 --threads 8 --times 10

- For default value of buffer_stream_reserver_size=8M, it's very tempting to OOM. So I enlarge memory limit to 30G
- To compare scan performance, I deliberately set `parallel_fragment_instance_number=8` (to reduce overhead of count)


Query | 8M | 1M | 128K
-- | -- | -- | --
Q01 | 2807 | 2533 | 2608
Q02 | 245 | 322 | 354


Q02
===
And for ssb-1t, supplier only has one HDFS file, which limits number of scan ranges.And I see there is only one HDFS scan  node handles one scan range. So we set `parallel_fragment_instance_number=1` and rerun this query.

```
[hadoop@hadoop01 ~]$ hdfs dfs -ls hdfs://emr-header-1.cluster-49091:9000/user/hive/warehouse/ssb_parquet.db/supplier
Found 1 items
-rw-r-----   3 hadoop hadoop  132031335 2021-12-15 21:39 hdfs://emr-header-1.cluster-49091:9000/user/hive/warehouse/ssb_parquet.db/supplier/000000_0
```

And if we see profile,  large buffer stream indeed saves IOCounter, but IOTime is not proportional to it.

8M:

```
- IOCounter: 15
- IOTime: 131.343ms
```


1M:

```
- IOCounter: 90
- IOTime: 205.59ms
```

Q01
===

Comparing to Q02, there are 835 files and average size of file is 256MB. And we can see large stream buffer does not comes better perfomance.  I guess the reason is workload is CPU dominated(decode and build chunk). 

```
-rw-r-----   3 hadoop hadoop  264811807 2021-12-17 18:19 hdfs://172.26.194.238:9000/starrocks_test_data/stability_data/standard_testsets/ssb/parquet/lineorder/000831_0
-rw-r-----   3 hadoop hadoop  263702689 2021-12-17 18:18 hdfs://172.26.194.238:9000/starrocks_test_data/stability_data/standard_testsets/ssb/parquet/lineorder/000832_0
-rw-r-----   3 hadoop hadoop   36951666 2021-12-17 18:18 hdfs://172.26.194.238:9000/starrocks_test_data/stability_data/standard_testsets/ssb/parquet/lineorder/000833_0
[hadoop@hadoop01 ~]$ hdfs dfs -ls hdfs://172.26.194.238:9000/starrocks_test_data/stability_data/standard_testsets/ssb/parquet/lineorder | wc -l
835
```

Proposal
===

For IO dominated workload(short query and access few files), larger buffer stream size indeeds has better performance.  

And For CPU domainted workload, larger buffer stream size does not come better perf and on the contrary use larger memory footprint.

And in my opinon,  the second cases are more in production scenario. and According to paper 《Delta Lake: High-Performance ACID Table Storage over Cloud Object Stores》 Section "Performance Characteristics":

> For reads, the most granular operation available is reading a sequential byte range, as described earlier. Each read operation usually incurs at least 5–10 ms of base latency, and can then read data at roughly 50–100 MB/s, so an operation needs to read at least several hundred kilobytes to achieve at least half the peak throughput for sequential reads, and multiple megabytes to approach the peak throughput. Moreover, on typical VM configurations, applications need to run multiple reads in parallel to maximize throughput. For example, the VM types most frequently used for analytics on AWS have at least 10 Gbps network bandwidth, so they need to run 8–10
reads in parallel to fully utilize this bandwidth.

1~2MB should suffice for accessing object-like store(HDFS, S3 etc).



