### PR TITLE
By default disable using ec2-metadata

### DIFF
--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -90,6 +90,9 @@ export LD_LIBRARY_PATH=$STARROCKS_HOME/lib/hadoop/native:$LD_LIBRARY_PATH
 # HADOOP_CLASSPATH defined in $STARROCKS_HOME/conf/hadoop_env.sh
 # put $STARROCKS_HOME/conf ahead of $HADOOP_CLASSPATH so that custom config can replace the config in $HADOOP_CLASSPATH
 export CLASSPATH=$STARROCKS_HOME/conf:$HADOOP_CLASSPATH:$CLASSPATH
+# https://github.com/aws/aws-cli/issues/5623
+# https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
+export AWS_EC2_METADATA_DISABLED=true
 
 if [ ! -d $LOG_DIR ]; then
     mkdir -p $LOG_DIR


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5288 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

This environment variable just affects usage of ec2-instances, which we don't need it at all. Credentials & Configuration are all set by users.

https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html

```
AWS_EC2_METADATA_DISABLED
Disables the use of the Amazon EC2 instance metadata service (IMDS).

If set to true, user credentials or configuration (like the region) are not requested from IMDS.
```
