### PR TITLE
New backup restore compatible with apache doris

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupJobInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupJobInfo.java
@@ -304,7 +304,7 @@ public class BackupJobInfo implements Writable {
          *                               "10008": ["__10029_seg1.dat", "__10029_seg2.dat"],
          *                               "10007": ["__10029_seg1.dat", "__10029_seg2.dat"]
          *                           },
-         *                           "tablets_order": [10007, 10008]
+         *                           "tablets_order": ["10007", "10008"]
          *                       },
          *                       "table1": {
          *                           "id": 10008,
@@ -313,7 +313,7 @@ public class BackupJobInfo implements Writable {
          *                               "10004": ["__10027_seg1.dat", "__10027_seg2.dat"],
          *                               "10005": ["__10028_seg1.dat", "__10028_seg2.dat"]
          *                           },
-         *                           "tablets_order": [10004, 10005]
+         *                           "tablets_order": ["10004, "10005"]
          *                       }
          *                   },
          *                   "id": 10007
@@ -409,7 +409,8 @@ public class BackupJobInfo implements Writable {
             tmpList.sort((o1, o2) -> Long.valueOf(o1).compareTo(Long.valueOf(o2)));
             return tmpList.toArray(new String[0]);
         } else {
-            // the element of tabletsOrder is Long.
+            // StarRocks uses string to deserialize tablets_order and apache doris uses long to deserialize.
+            // for compatibility with apache doris.
             return tabletsOrder.toList().stream().map(Object::toString).toArray(String[]::new);
         }
     }
@@ -472,9 +473,8 @@ public class BackupJobInfo implements Writable {
                             for (String fileName : tabletInfo.files) {
                                 files.put(fileName);
                             }
-                            // to save the order of tablets.
-                            // use Long for compatibility with apache doris.
-                            tabletsOrder.put(tabletInfo.id);
+                            // to save the order of tablets
+                            tabletsOrder.put(String.valueOf(tabletInfo.id));
                         }
                         indexes.put(idxInfo.name, idx);
                     }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5225 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

#5227 supports backup restore compatible with apache doris,
but old version StarRocks still use string to deserialize tablets_order,
this will cause ArrayStoreException when rolling back to old version.

So we use a new solution for compatibility.
1. Keep using string to serialize tablets_order as before.
2. Deserialize string or long tablets_order by uniform way.