### PR TITLE
BugFix: fix #5309: Be upgrade failed

### DIFF
--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -206,7 +206,8 @@ message TabletSchemaPB {
     optional double bf_fpp = 6; // OLAPHeaderMessage.bf_fpp
     optional uint32 next_column_unique_id = 7; // OLAPHeaderMessage.next_column_unique_id
     optional bool DEPRECATED_is_in_memory = 8 [default=false];
-    optional int64 id = 9;
+    optional int64 deprecated_id = 9; // deprecated
+    optional int64 id = 50;
 }
 
 enum TabletStatePB {


### PR DESCRIPTION
This is a bug related to apache-doris compatibility

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5309 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

If we create a cluster with apache-doris-0.13, we can upgrade it to starrocks-1.19.x. But when we upgrade it from starrocks-1.19.x to starrocks-2.0.x, be may be failed.

The reason is we add `id` field to `TabletSchemPB` in starrocks-2.0 to support Shared-Schema which conflicts with apache-doris's `TabletSchemaPB`

`TabletSchemaPB` of starrocks-2.0
```
message TabletSchemaPB {
    optional KeysType keys_type = 1;    // OLAPHeaderMessage.keys_type
    repeated ColumnPB column = 2;   // OLAPHeaderMessage.column
    optional int32 num_short_key_columns = 3;   // OLAPHeaderMessage.num_short_key_fields
    optional int32 num_rows_per_row_block = 4;  // OLAPHeaderMessage.num_rows_per_data_block
    optional CompressKind compress_kind = 5; // OLAPHeaderMessage.compress_kind
    optional double bf_fpp = 6; // OLAPHeaderMessage.bf_fpp
    optional uint32 next_column_unique_id = 7; // OLAPHeaderMessage.next_column_unique_id
    optional bool DEPRECATED_is_in_memory = 8 [default=false];
    optional int64 id = 9;
}
```

`TabletSchemaPB` of apache-doris-0.13
```
message TabletSchemaPB {
    optional KeysType keys_type = 1;    // OLAPHeaderMessage.keys_type
    repeated ColumnPB column = 2;   // OLAPHeaderMessage.column
    optional int32 num_short_key_columns = 3;   // OLAPHeaderMessage.num_short_key_fields
    optional int32 num_rows_per_row_block = 4;  // OLAPHeaderMessage.num_rows_per_data_block
    optional CompressKind compress_kind = 5; // OLAPHeaderMessage.compress_kind
    optional double bf_fpp = 6; // OLAPHeaderMessage.bf_fpp
    optional uint32 next_column_unique_id = 7; // OLAPHeaderMessage.next_column_unique_id
    optional bool is_in_memory = 8 [default=false];
    optional int32 delete_sign_idx = 9 [default = -1];

}
```

When we upgrade to starrocks-2.0.x, `delete_sign_idx` will be considered as `id` and we can't guarantee that it's value is meaningful.