### PR TITLE
Fix merge same group expression error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Group.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Group.java
@@ -93,8 +93,10 @@ public class Group {
 
     public void addExpression(GroupExpression groupExpression) {
         if (groupExpression.getOp().isLogical()) {
+            Preconditions.checkState(!logicalExpressions.contains(groupExpression));
             logicalExpressions.add(groupExpression);
         } else {
+            Preconditions.checkState(!physicalExpressions.contains(groupExpression));
             physicalExpressions.add(groupExpression);
         }
         groupExpression.setGroup(this);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Group.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Group.java
@@ -259,7 +259,7 @@ public class Group {
 
     @Override
     public String toString() {
-        return toPrettyString("", "");
+        return "->  " + "Group: " + id;
     }
 
     public String toPrettyString(String headlineIndent, String detailIndent) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Memo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Memo.java
@@ -159,51 +159,61 @@ public class Memo {
 
         // If we change the GroupExpression child group, the hash value of GroupExpression
         // will change, so we must reinsert the GroupExpression to groupExpressions map
-        List<GroupExpression> needReinsertedExpressions = Lists.newArrayList();
-        for (Iterator<Map.Entry<GroupExpression, GroupExpression>>
-                iterator = groupExpressions.entrySet().iterator(); iterator.hasNext(); ) {
+        List<GroupExpression> needModifyExpressions = Lists.newArrayList();
+        for (Iterator<Map.Entry<GroupExpression, GroupExpression>> iterator = groupExpressions.entrySet().iterator();
+                iterator.hasNext(); ) {
             GroupExpression groupExpr = iterator.next().getKey();
 
-            // 1 Find which group expression need to reinsert
-            int referSrcGroupIndex = -1;
-            for (int i = 0; i < groupExpr.getInputs().size(); i++) {
-                if (groupExpr.getInputs().get(i) == srcGroup) {
-                    referSrcGroupIndex = i;
+            // 1. find GroupExpression which refer to src group, and remove them from memo
+            for (Group group : groupExpr.getInputs()) {
+                if (group == srcGroup) {
+                    // multi-input must not same
+                    iterator.remove();
+                    needModifyExpressions.add(groupExpr);
                     break;
                 }
             }
 
-            // 2 Remove the GroupExpression from the groupExpressions map
-            // 3 Change the child group from srcGroup to dstGroup
-            if (referSrcGroupIndex >= 0) {
-                iterator.remove();
-                groupExpr.getInputs().set(referSrcGroupIndex, dstGroup);
-                needReinsertedExpressions.add(groupExpr);
-            }
-
-            // 4 Change the group of GroupExpression
+            // 2. find GroupExpression which on src group
             if (groupExpr.getGroup() == srcGroup) {
-                groupExpr.setGroup(dstGroup);
+                needModifyExpressions.add(groupExpr);
             }
         }
 
-        for (GroupExpression groupExpression : needReinsertedExpressions) {
-            if (!groupExpressions.containsKey(groupExpression)) {
-                groupExpressions.put(groupExpression, groupExpression);
+        // modify group of group expression and mark who need reinsert
+        List<GroupExpression> needReinsertedExpressions = Lists.newArrayList();
+        for (GroupExpression modifyExpression : needModifyExpressions) {
+            if (modifyExpression.getGroup() == srcGroup) {
+                modifyExpression.setGroup(dstGroup);
+            }
+
+            for (int i = 0; i < modifyExpression.getInputs().size(); i++) {
+                if (modifyExpression.getInputs().get(i) == srcGroup) {
+                    // remove self from his group, and reinsert later
+                    modifyExpression.getGroup().removeGroupExpression(modifyExpression);
+                    modifyExpression.getInputs().set(i, dstGroup);
+                    needReinsertedExpressions.add(modifyExpression);
+                }
+            }
+        }
+
+        for (GroupExpression reinsertExpression : needReinsertedExpressions) {
+            // reinsert maybe in groupExpressions because his input was modify
+            if (!groupExpressions.containsKey(reinsertExpression)) {
+                groupExpressions.put(reinsertExpression, reinsertExpression);
             } else {
                 // group expression is already in the Memo's groupExpressions, this indicates that
                 // this is a redundant group Expression, it's should be remove.
                 // And the redundant group expression may be already in the TaskScheduler stack, so it should be
                 // set unused.
-                groupExpression.getGroup().removeGroupExpression(groupExpression);
-                groupExpression.setUnused(true);
-                GroupExpression existGroupExpression = groupExpressions.get(groupExpression);
-                if (!needMerge(groupExpression.getGroup(), existGroupExpression.getGroup())) {
+                reinsertExpression.setUnused(true);
+                GroupExpression existGroupExpression = groupExpressions.get(reinsertExpression);
+                if (!needMerge(reinsertExpression.getGroup(), existGroupExpression.getGroup())) {
                     // groupExpression and existGroupExpression are in the same group，use existGroupExpression to
                     // replace the bestExpression in the group
-                    groupExpression.getGroup().replaceBestExpression(groupExpression, existGroupExpression);
+                    reinsertExpression.getGroup().replaceBestExpression(reinsertExpression, existGroupExpression);
                     // existingGroupExpression merge the state of groupExpression
-                    existGroupExpression.mergeGroupExpression(groupExpression);
+                    existGroupExpression.mergeGroupExpression(reinsertExpression);
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Memo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Memo.java
@@ -201,6 +201,7 @@ public class Memo {
             // reinsert maybe in groupExpressions because his input was modify
             if (!groupExpressions.containsKey(reinsertExpression)) {
                 groupExpressions.put(reinsertExpression, reinsertExpression);
+                reinsertExpression.getGroup().addExpression(reinsertExpression);
             } else {
                 // group expression is already in the Memo's groupExpressions, this indicates that
                 // this is a redundant group Expression, it's should be remove.

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/EnumeratePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/EnumeratePlanTest.java
@@ -320,7 +320,7 @@ public class EnumeratePlanTest extends DistributedEnvPlanTestBase {
                 "    numwait desc,\n" +
                 "    s_name limit 100;";
         int planCount = getPlanCount(sql);
-        Assert.assertEquals(170, planCount);
+        Assert.assertEquals(371, planCount);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/EnumeratePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/EnumeratePlanTest.java
@@ -320,7 +320,7 @@ public class EnumeratePlanTest extends DistributedEnvPlanTestBase {
                 "    numwait desc,\n" +
                 "    s_name limit 100;";
         int planCount = getPlanCount(sql);
-        Assert.assertEquals(182, planCount);
+        Assert.assertEquals(170, planCount);
     }
 
     @Test

--- a/fe/fe-core/src/test/resources/sql/tpch/q21.sql
+++ b/fe/fe-core/src/test/resources/sql/tpch/q21.sql
@@ -44,19 +44,19 @@ TOP-N (order by [[77: count DESC NULLS LAST, 2: S_NAME ASC NULLS FIRST]])
         AGGREGATE ([GLOBAL] aggregate [{77: count=count(77: count)}] group by [[2: S_NAME]] having [null]
             EXCHANGE SHUFFLE[2]
                 AGGREGATE ([LOCAL] aggregate [{77: count=count()}] group by [[2: S_NAME]] having [null]
-                    INNER JOIN (join-predicate [26: O_ORDERKEY = 9: L_ORDERKEY] post-join-predicate [null])
-                        SCAN (columns[26: O_ORDERKEY, 28: O_ORDERSTATUS] predicate[28: O_ORDERSTATUS = F])
-                        EXCHANGE SHUFFLE[9]
-                            INNER JOIN (join-predicate [11: L_SUPPKEY = 1: S_SUPPKEY] post-join-predicate [null])
-                                LEFT ANTI JOIN (join-predicate [9: L_ORDERKEY = 59: L_ORDERKEY AND 61: L_SUPPKEY != 11: L_SUPPKEY] post-join-predicate [null])
-                                    LEFT SEMI JOIN (join-predicate [9: L_ORDERKEY = 41: L_ORDERKEY AND 43: L_SUPPKEY != 11: L_SUPPKEY] post-join-predicate [null])
-                                        SCAN (columns[20: L_COMMITDATE, 21: L_RECEIPTDATE, 9: L_ORDERKEY, 11: L_SUPPKEY] predicate[21: L_RECEIPTDATE > 20: L_COMMITDATE])
-                                        SCAN (columns[41: L_ORDERKEY, 43: L_SUPPKEY] predicate[null])
-                                    SCAN (columns[70: L_COMMITDATE, 71: L_RECEIPTDATE, 59: L_ORDERKEY, 61: L_SUPPKEY] predicate[71: L_RECEIPTDATE > 70: L_COMMITDATE])
+                    INNER JOIN (join-predicate [11: L_SUPPKEY = 1: S_SUPPKEY] post-join-predicate [null])
+                        LEFT ANTI JOIN (join-predicate [9: L_ORDERKEY = 59: L_ORDERKEY AND 61: L_SUPPKEY != 11: L_SUPPKEY] post-join-predicate [null])
+                            LEFT SEMI JOIN (join-predicate [9: L_ORDERKEY = 41: L_ORDERKEY AND 43: L_SUPPKEY != 11: L_SUPPKEY] post-join-predicate [null])
+                                INNER JOIN (join-predicate [9: L_ORDERKEY = 26: O_ORDERKEY] post-join-predicate [null])
+                                    SCAN (columns[20: L_COMMITDATE, 21: L_RECEIPTDATE, 9: L_ORDERKEY, 11: L_SUPPKEY] predicate[21: L_RECEIPTDATE > 20: L_COMMITDATE])
+                                    EXCHANGE SHUFFLE[26]
+                                        SCAN (columns[26: O_ORDERKEY, 28: O_ORDERSTATUS] predicate[28: O_ORDERSTATUS = F])
+                                SCAN (columns[41: L_ORDERKEY, 43: L_SUPPKEY] predicate[null])
+                            SCAN (columns[70: L_COMMITDATE, 71: L_RECEIPTDATE, 59: L_ORDERKEY, 61: L_SUPPKEY] predicate[71: L_RECEIPTDATE > 70: L_COMMITDATE])
+                        EXCHANGE BROADCAST
+                            INNER JOIN (join-predicate [4: S_NATIONKEY = 36: N_NATIONKEY] post-join-predicate [null])
+                                SCAN (columns[1: S_SUPPKEY, 2: S_NAME, 4: S_NATIONKEY] predicate[null])
                                 EXCHANGE BROADCAST
-                                    INNER JOIN (join-predicate [4: S_NATIONKEY = 36: N_NATIONKEY] post-join-predicate [null])
-                                        SCAN (columns[1: S_SUPPKEY, 2: S_NAME, 4: S_NATIONKEY] predicate[null])
-                                        EXCHANGE BROADCAST
-                                            SCAN (columns[36: N_NATIONKEY, 37: N_NAME] predicate[37: N_NAME = CANADA])
+                                    SCAN (columns[36: N_NATIONKEY, 37: N_NAME] predicate[37: N_NAME = CANADA])
 [end]
 

--- a/fe/fe-core/src/test/resources/sql/tpchcost/q21.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchcost/q21.sql
@@ -79,50 +79,17 @@ HASH_PARTITIONED: 2: S_NAME
 |  <slot 2> : 2: S_NAME
 |
 22:HASH JOIN
-|  join op: RIGHT SEMI JOIN (BUCKET_SHUFFLE)
-|  hash predicates:
-|  colocate: false, reason:
-|  equal join conjunct: 41: L_ORDERKEY = 9: L_ORDERKEY
-|  other join predicates: 43: L_SUPPKEY != 11: L_SUPPKEY
-|
-|----21:EXCHANGE
-|
-0:OlapScanNode
-TABLE: lineitem
-PREAGGREGATION: ON
-partitions=1/1
-rollup: lineitem
-tabletRatio=20/20
-tabletList=10213,10215,10217,10219,10221,10223,10225,10227,10229,10231 ...
-cardinality=600000000
-avgRowSize=12.0
-numNodes=0
-
-PLAN FRAGMENT 3
-OUTPUT EXPRS:
-PARTITION: RANDOM
-
-STREAM DATA SINK
-EXCHANGE ID: 21
-BUCKET_SHUFFLE_HASH_PARTITIONED: 9: L_ORDERKEY
-
-20:Project
-|  <slot 2> : 2: S_NAME
-|  <slot 9> : 9: L_ORDERKEY
-|  <slot 11> : 11: L_SUPPKEY
-|
-19:HASH JOIN
 |  join op: INNER JOIN (BROADCAST)
 |  hash predicates:
 |  colocate: false, reason:
 |  equal join conjunct: 26: O_ORDERKEY = 9: L_ORDERKEY
 |
-|----18:EXCHANGE
+|----21:EXCHANGE
 |
-2:Project
+1:Project
 |  <slot 26> : 26: O_ORDERKEY
 |
-1:OlapScanNode
+0:OlapScanNode
 TABLE: orders
 PREAGGREGATION: ON
 PREDICATES: 28: O_ORDERSTATUS = 'F'
@@ -134,13 +101,45 @@ cardinality=50000000
 avgRowSize=9.0
 numNodes=0
 
+PLAN FRAGMENT 3
+OUTPUT EXPRS:
+PARTITION: RANDOM
+
+STREAM DATA SINK
+EXCHANGE ID: 21
+UNPARTITIONED
+
+20:Project
+|  <slot 2> : 2: S_NAME
+|  <slot 9> : 9: L_ORDERKEY
+|
+19:HASH JOIN
+|  join op: RIGHT SEMI JOIN (BUCKET_SHUFFLE)
+|  hash predicates:
+|  colocate: false, reason:
+|  equal join conjunct: 41: L_ORDERKEY = 9: L_ORDERKEY
+|  other join predicates: 43: L_SUPPKEY != 11: L_SUPPKEY
+|
+|----18:EXCHANGE
+|
+2:OlapScanNode
+TABLE: lineitem
+PREAGGREGATION: ON
+partitions=1/1
+rollup: lineitem
+tabletRatio=20/20
+tabletList=10213,10215,10217,10219,10221,10223,10225,10227,10229,10231 ...
+cardinality=600000000
+avgRowSize=12.0
+numNodes=0
+
 PLAN FRAGMENT 4
 OUTPUT EXPRS:
 PARTITION: RANDOM
 
 STREAM DATA SINK
 EXCHANGE ID: 18
-UNPARTITIONED
+BUCKET_SHUFFLE_HASH_PARTITIONED: 9: L_ORDERKEY
 
 17:Project
 |  <slot 2> : 2: S_NAME


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5205 #5277

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
In memo merge phase, when we move the group expression of delete group to target group, and there has the same group expression in the target group, we will remove error group expression finally
