### PR TITLE
 [SR GeekCamp] Improve schema scan performance #4028

### DIFF
--- a/be/src/exec/vectorized/schema_scan_node.cpp
+++ b/be/src/exec/vectorized/schema_scan_node.cpp
@@ -65,11 +65,9 @@ Status SchemaScanNode::init(const TPlanNode& tnode, RuntimeState* state) {
     }
 
     // only for no predicate and limit parameter is set
-    if (tnode.conjuncts.empty()) {
-        if (tnode.limit > 0) {
-            _scanner_param.without_db_table = true;
-            _scanner_param.limit = tnode.limit;
-        }
+    if (tnode.conjuncts.empty() && tnode.limit > 0) {
+        _scanner_param.without_db_table = true;
+        _scanner_param.limit = tnode.limit;
     }
     return Status::OK();
 }

--- a/be/src/exec/vectorized/schema_scan_node.cpp
+++ b/be/src/exec/vectorized/schema_scan_node.cpp
@@ -64,8 +64,12 @@ Status SchemaScanNode::init(const TPlanNode& tnode, RuntimeState* state) {
         _scanner_param.thread_id = tnode.schema_scan_node.thread_id;
     }
 
-    if (tnode.limit > 0) {
-        _scanner_param.limit = tnode.limit;
+    // only for no predicate and limit parameter is set
+    if (tnode.conjuncts.empty()) {
+        if (tnode.limit > 0) {
+            _scanner_param.without_db_table = true;
+            _scanner_param.limit = tnode.limit;
+        }
     }
     return Status::OK();
 }

--- a/be/src/exec/vectorized/schema_scanner.h
+++ b/be/src/exec/vectorized/schema_scanner.h
@@ -31,7 +31,12 @@ struct SchemaScannerParam {
     const std::string* ip{nullptr};                   // frontend ip
     int32_t port{0};                                  // frontend thrift port
     int64_t thread_id = 0;
-    int64_t limit{0};
+    int64_t limit{0};                                 // set limit only when there is no predicate
+
+    // true only when there is no predicate and limit parameter is set,
+    // if true, then for SchemaColumnsScanner, call describeTable() once,
+    // and no longer call get_db_names() and get_table_names().
+    bool without_db_table{false};
 
     RuntimeProfile::Counter* _rpc_timer = nullptr;
     RuntimeProfile::Counter* _fill_chunk_timer = nullptr;

--- a/be/src/exec/vectorized/schema_scanner.h
+++ b/be/src/exec/vectorized/schema_scanner.h
@@ -31,8 +31,8 @@ struct SchemaScannerParam {
     const std::string* ip{nullptr};                   // frontend ip
     int32_t port{0};                                  // frontend thrift port
     int64_t thread_id = 0;
-    int64_t limit{0};                                 // set limit only when there is no predicate
-
+    // set limit only when there is no predicate
+    int64_t limit{0};
     // true only when there is no predicate and limit parameter is set,
     // if true, then for SchemaColumnsScanner, call describeTable() once,
     // and no longer call get_db_names() and get_table_names().

--- a/be/src/exec/vectorized/schema_scanner/schema_columns_scanner.cpp
+++ b/be/src/exec/vectorized/schema_scanner/schema_columns_scanner.cpp
@@ -200,15 +200,14 @@ Status SchemaColumnsScanner::fill_chunk(ChunkPtr* chunk) {
             // TABLE_SCHEMA
             {
                 ColumnPtr column = (*chunk)->get_column_by_slot_id(2);
+                std::string db_name;
                 if (_param->without_db_table) {
-                    std::string db_name = _desc_result.columns[_column_index].columnDesc.dbName;
-                    Slice value(db_name.c_str(), db_name.length());
-                    fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+                    db_name = _desc_result.columns[_column_index].columnDesc.dbName;
                 } else {
-                    std::string db_name = SchemaHelper::extract_db_name(_db_result.dbs[_db_index - 1]);
-                    Slice value(db_name.c_str(), db_name.length());
-                    fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+                    db_name = SchemaHelper::extract_db_name(_db_result.dbs[_db_index - 1]);
                 }
+                Slice value(db_name.c_str(), db_name.length());
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
             }
             break;
         }
@@ -216,15 +215,14 @@ Status SchemaColumnsScanner::fill_chunk(ChunkPtr* chunk) {
             // TABLE_NAME
             {
                 ColumnPtr column = (*chunk)->get_column_by_slot_id(3);
+                std::string* table_name;
                 if (_param->without_db_table) {
-                    std::string* table_name = &_desc_result.columns[_column_index].columnDesc.tableName;
-                    Slice value(table_name->c_str(), table_name->length());
-                    fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+                    table_name = &_desc_result.columns[_column_index].columnDesc.tableName;
                 } else {
-                    std::string* table_name = &_table_result.tables[_table_index - 1];
-                    Slice value(table_name->c_str(), table_name->length());
-                    fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+                    table_name = &_table_result.tables[_table_index - 1];
                 }
+                Slice value(table_name->c_str(), table_name->length());
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
             }
             break;
         }

--- a/be/src/exec/vectorized/schema_scanner/schema_columns_scanner.cpp
+++ b/be/src/exec/vectorized/schema_scanner/schema_columns_scanner.cpp
@@ -202,7 +202,7 @@ Status SchemaColumnsScanner::fill_chunk(ChunkPtr* chunk) {
                 ColumnPtr column = (*chunk)->get_column_by_slot_id(2);
                 std::string db_name;
                 if (_param->without_db_table) {
-                    db_name = _desc_result.columns[_column_index].columnDesc.dbName;
+                    db_name = SchemaHelper::extract_db_name(_desc_result.columns[_column_index].columnDesc.dbName);
                 } else {
                     db_name = SchemaHelper::extract_db_name(_db_result.dbs[_db_index - 1]);
                 }

--- a/be/src/exec/vectorized/schema_scanner/schema_columns_scanner.cpp
+++ b/be/src/exec/vectorized/schema_scanner/schema_columns_scanner.cpp
@@ -48,6 +48,9 @@ Status SchemaColumnsScanner::start(RuntimeState* state) {
     if (!_is_init) {
         return Status::InternalError("schema columns scanner not inited.");
     }
+    if (_param->without_db_table) {
+        return Status::OK();
+    }
     // get all database
     TGetDbsParams db_params;
     if (nullptr != _param->db) {
@@ -197,9 +200,15 @@ Status SchemaColumnsScanner::fill_chunk(ChunkPtr* chunk) {
             // TABLE_SCHEMA
             {
                 ColumnPtr column = (*chunk)->get_column_by_slot_id(2);
-                std::string db_name = SchemaHelper::extract_db_name(_db_result.dbs[_db_index - 1]);
-                Slice value(db_name.c_str(), db_name.length());
-                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+                if (_param->without_db_table) {
+                    std::string db_name = _desc_result.columns[_column_index].columnDesc.dbName;
+                    Slice value(db_name.c_str(), db_name.length());
+                    fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+                } else {
+                    std::string db_name = SchemaHelper::extract_db_name(_db_result.dbs[_db_index - 1]);
+                    Slice value(db_name.c_str(), db_name.length());
+                    fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+                }
             }
             break;
         }
@@ -207,9 +216,15 @@ Status SchemaColumnsScanner::fill_chunk(ChunkPtr* chunk) {
             // TABLE_NAME
             {
                 ColumnPtr column = (*chunk)->get_column_by_slot_id(3);
-                std::string* str = &_table_result.tables[_table_index - 1];
-                Slice value(str->c_str(), str->length());
-                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+                if (_param->without_db_table) {
+                    std::string* table_name = &_desc_result.columns[_column_index].columnDesc.tableName;
+                    Slice value(table_name->c_str(), table_name->length());
+                    fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+                } else {
+                    std::string* table_name = &_table_result.tables[_table_index - 1];
+                    Slice value(table_name->c_str(), table_name->length());
+                    fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+                }
             }
             break;
         }
@@ -447,8 +462,10 @@ Status SchemaColumnsScanner::fill_chunk(ChunkPtr* chunk) {
 
 Status SchemaColumnsScanner::get_new_desc() {
     TDescribeTableParams desc_params;
-    desc_params.__set_db(_db_result.dbs[_db_index - 1]);
-    desc_params.__set_table_name(_table_result.tables[_table_index++]);
+    if (!_param->without_db_table) {
+        desc_params.__set_db(_db_result.dbs[_db_index - 1]);
+        desc_params.__set_table_name(_table_result.tables[_table_index++]);
+    }
     if (nullptr != _param->current_user_ident) {
         desc_params.__set_current_user_ident(*(_param->current_user_ident));
     } else {
@@ -475,6 +492,9 @@ Status SchemaColumnsScanner::get_new_desc() {
 }
 
 Status SchemaColumnsScanner::get_new_table() {
+    if (_param->without_db_table) {
+        return Status::OK();
+    }
     TGetTablesParams table_params;
     table_params.__set_db(_db_result.dbs[_db_index++]);
     if (nullptr != _param->table) {
@@ -509,16 +529,30 @@ Status SchemaColumnsScanner::get_next(ChunkPtr* chunk, bool* eos) {
     }
     {
         SCOPED_TIMER(_param->_rpc_timer);
-        while (_column_index >= _desc_result.columns.size()) {
-            if (_table_index >= _table_result.tables.size()) {
-                if (_db_index < _db_result.dbs.size()) {
-                    RETURN_IF_ERROR(get_new_table());
-                } else {
-                    *eos = true;
-                    return Status::OK();
-                }
-            } else {
+        // if user query schema meta such as "select * from information_schema.columns limit 10;",
+        // in this case, there is no predicate and limit clause is set,we can call the describe_table
+        // interface only once, and no longer call get_db_names and get_table_names interface, which
+        // can reduce RPC time from BE to FE, and the amount of data
+        if (_param->without_db_table) {
+            if (_column_index == 0) {
                 RETURN_IF_ERROR(get_new_desc());
+            }
+            if (_column_index == _desc_result.columns.size()) {
+                *eos = true;
+                return Status::OK();
+            }
+        } else {
+            while (_column_index >= _desc_result.columns.size()) {
+                if (_table_index >= _table_result.tables.size()) {
+                    if (_db_index < _db_result.dbs.size()) {
+                        RETURN_IF_ERROR(get_new_table());
+                    } else {
+                        *eos = true;
+                        return Status::OK();
+                    }
+                } else {
+                    RETURN_IF_ERROR(get_new_desc());
+                }
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -135,6 +135,7 @@ import com.starrocks.transaction.TransactionState;
 import com.starrocks.transaction.TransactionState.TxnCoordinator;
 import com.starrocks.transaction.TransactionState.TxnSourceType;
 import com.starrocks.transaction.TxnCommitAttachment;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
@@ -471,60 +472,114 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         } else {
             currentUser = UserIdentity.createAnalyzedUserIdentWithIp(params.user, params.user_ip);
         }
+        long limit = params.isSetLimit() ? params.getLimit() : -1;
+
+        // if user query schema meta such as "select * from information_schema.columns limit 10;",
+        // in this case, there is no predicate and only has limit clause,we can call the
+        // describe_table interface only once, which can reduce RPC time from BE to FE, and
+        // the amount of data. In additional,we need add db_name & table_name values to TColumnDesc.
+        if (!params.isSetDb() && StringUtils.isBlank(params.getTable_name())) {
+            describeWithoutDbAndTable(currentUser, columns, limit);
+            return result;
+        }
         if (!Catalog.getCurrentCatalog().getAuth().checkTblPriv(currentUser, params.db,
                 params.getTable_name(), PrivPredicate.SHOW)) {
             return result;
         }
         Database db = Catalog.getCurrentCatalog().getDb(params.db);
-        long limit = params.isSetLimit() ? params.getLimit() : -1;
         if (db != null) {
             db.readLock();
             try {
                 Table table = db.getTable(params.getTable_name());
-                if (table != null) {
-                    String tableKeysType = "";
-                    if (TableType.OLAP.equals(table.getType())) {
-                        OlapTable olapTable = (OlapTable) table;
-                        tableKeysType = olapTable.getKeysType().name().substring(0, 3).toUpperCase();
-                    }
-                    for (Column column : table.getBaseSchema()) {
-                        final TColumnDesc desc =
-                                new TColumnDesc(column.getName(), column.getPrimitiveType().toThrift());
-                        final Integer precision = column.getType().getPrecision();
-                        if (precision != null) {
-                            desc.setColumnPrecision(precision);
-                        }
-                        final Integer columnLength = column.getType().getColumnSize();
-                        if (columnLength != null) {
-                            desc.setColumnLength(columnLength);
-                        }
-                        final Integer decimalDigits = column.getType().getDecimalDigits();
-                        if (decimalDigits != null) {
-                            desc.setColumnScale(decimalDigits);
-                        }
-                        if (column.isKey()) {
-                            // COLUMN_KEY (UNI, AGG, DUP, PRI)
-                            desc.setColumnKey(tableKeysType);
-                        } else {
-                            desc.setColumnKey("");
-                        }
-                        final TColumnDef colDef = new TColumnDef(desc);
-                        final String comment = column.getComment();
-                        if (comment != null) {
-                            colDef.setComment(comment);
-                        }
-                        columns.add(colDef);
-                        // if user set limit, then only return limit size result
-                        if (limit > 0 && columns.size() >= limit) {
-                            break;
-                        }
-                    }
-                }
+                setColumnDesc(columns, table, limit, false, params.db, params.getTable_name());
             } finally {
                 db.readUnlock();
             }
         }
         return result;
+    }
+
+    // get describeTable without db name and table name parameter, so we need iterate over
+    // dbs and tables, when reach limit, we break;
+    private void describeWithoutDbAndTable(UserIdentity currentUser, List<TColumnDef> columns, long limit) {
+        Catalog catalog = Catalog.getCurrentCatalog();
+        List<String> dbNames = catalog.getDbNames();
+        boolean reachLimit;
+        for (String fullName : dbNames) {
+            if (!Catalog.getCurrentCatalog().getAuth().checkDbPriv(currentUser, fullName, PrivPredicate.SHOW)) {
+                continue;
+            }
+            String dbName = fullName.indexOf(":") >= 0 ? fullName.substring(fullName.indexOf(":") + 1) : fullName;
+            Database db = Catalog.getCurrentCatalog().getDb(fullName);
+            if (db != null) {
+                for (String tableName : db.getTableNamesWithLock()) {
+                    LOG.debug("get table: {}, wait to check", tableName);
+                    if (!Catalog.getCurrentCatalog().getAuth().checkTblPriv(currentUser, dbName,
+                            tableName, PrivPredicate.SHOW)) {
+                        continue;
+                    }
+                    db.readLock();
+                    try {
+                        Table table = db.getTable(tableName);
+                        reachLimit = setColumnDesc(columns, table, limit, true, dbName, tableName);
+                    } finally {
+                        db.readUnlock();
+                    }
+                    if (reachLimit) {
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+    private boolean setColumnDesc(List<TColumnDef> columns, Table table, long limit,
+                               boolean needSetDbAndTable, String db, String tbl) {
+        if (table != null) {
+            String tableKeysType = "";
+            if (TableType.OLAP.equals(table.getType())) {
+                OlapTable olapTable = (OlapTable) table;
+                tableKeysType = olapTable.getKeysType().name().substring(0, 3).toUpperCase();
+            }
+            for (Column column : table.getBaseSchema()) {
+                final TColumnDesc desc =
+                        new TColumnDesc(column.getName(), column.getPrimitiveType().toThrift());
+                final Integer precision = column.getType().getPrecision();
+                if (precision != null) {
+                    desc.setColumnPrecision(precision);
+                }
+                final Integer columnLength = column.getType().getColumnSize();
+                if (columnLength != null) {
+                    desc.setColumnLength(columnLength);
+                }
+                final Integer decimalDigits = column.getType().getDecimalDigits();
+                if (decimalDigits != null) {
+                    desc.setColumnScale(decimalDigits);
+                }
+                if (column.isKey()) {
+                    // COLUMN_KEY (UNI, AGG, DUP, PRI)
+                    desc.setColumnKey(tableKeysType);
+                } else {
+                    desc.setColumnKey("");
+                }
+                final TColumnDef colDef = new TColumnDef(desc);
+                final String comment = column.getComment();
+                if (comment != null) {
+                    colDef.setComment(comment);
+                }
+                columns.add(colDef);
+                // add db_name and table_name values to TColumnDesc if needed
+                if (needSetDbAndTable) {
+                    columns.get(columns.size() - 1).columnDesc.setDbName(db);
+                    columns.get(columns.size() - 1).columnDesc.setTableName(tbl);
+                }
+                // if user set limit, then only return limit size result
+                if (limit > 0 && columns.size() >= limit) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -509,19 +509,18 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             if (!Catalog.getCurrentCatalog().getAuth().checkDbPriv(currentUser, fullName, PrivPredicate.SHOW)) {
                 continue;
             }
-            String dbName = fullName.indexOf(":") >= 0 ? fullName.substring(fullName.indexOf(":") + 1) : fullName;
             Database db = Catalog.getCurrentCatalog().getDb(fullName);
             if (db != null) {
                 for (String tableName : db.getTableNamesWithLock()) {
                     LOG.debug("get table: {}, wait to check", tableName);
-                    if (!Catalog.getCurrentCatalog().getAuth().checkTblPriv(currentUser, dbName,
+                    if (!Catalog.getCurrentCatalog().getAuth().checkTblPriv(currentUser, fullName,
                             tableName, PrivPredicate.SHOW)) {
                         continue;
                     }
                     db.readLock();
                     try {
                         Table table = db.getTable(tableName);
-                        reachLimit = setColumnDesc(columns, table, limit, true, dbName, tableName);
+                        reachLimit = setColumnDesc(columns, table, limit, true, fullName, tableName);
                     } finally {
                         db.readUnlock();
                     }

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -56,6 +56,8 @@ struct TColumnDesc {
   20: optional string columnKey
   21: optional bool key
   22: optional string aggregationType
+  23: optional string dbName
+  24: optional string tableName
 }
 
 // A column definition; used by CREATE TABLE and DESCRIBE <table> statements. A column


### PR DESCRIPTION
improve schema scan performance continue.

1. fix bug: push down limit parameter only when there is no predicate
2. for "select * from information_schema.columns limit 10;" query, we can call describe_table interface once and
   no longer call get_db_names and get_table_names interface, which can reduce RPC time from BE to FE, and the amount of data

