### PR TITLE
Fix: sum to double not int64 for avg(int) without group by

### DIFF
--- a/be/src/exprs/agg/avg.h
+++ b/be/src/exprs/agg/avg.h
@@ -55,7 +55,6 @@ public:
     using InputColumnType = RunTimeColumnType<PT>;
     static constexpr auto ResultPT = AvgResultPT<PT>;
     using ResultType = RunTimeCppType<ResultPT>;
-    using SumResultType = RunTimeCppType<SumResultPT<PT>>;
     using ResultColumnType = RunTimeColumnType<ResultPT>;
 
     void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
@@ -78,67 +77,12 @@ public:
         this->data(state).count++;
     }
 
-    void update_batch_single_state(FunctionContext* ctx, size_t chunk_size, const Column** columns,
-                                   AggDataPtr __restrict state) const override {
-        DCHECK(!columns[0]->is_nullable());
-        [[maybe_unused]] const InputColumnType* column = down_cast<const InputColumnType*>(columns[0]);
-        // For type of int/tinyint/bitint..., the result of avg is float/double
-        // But the floating point operations are much slower than integer operations
-        // So, we use integers to perform operations
-        [[maybe_unused]] SumResultType local_sum_for_arithmetic{};
-
-        for (size_t i = 0; i < chunk_size; ++i) {
-            if constexpr (pt_is_datetime<PT>) {
-                this->data(state).sum += column->get_data()[i].to_unix_second();
-            } else if constexpr (pt_is_date<PT>) {
-                this->data(state).sum += column->get_data()[i].julian();
-            } else if constexpr (pt_is_decimalv2<PT>) {
-                this->data(state).sum += column->get_data()[i];
-            } else if constexpr (pt_is_arithmetic<PT>) {
-                local_sum_for_arithmetic += column->get_data()[i];
-            } else if constexpr (pt_is_decimal<PT>) {
-                this->data(state).sum += column->get_data()[i];
-            } else {
-                // static_assert(pt_is_fixedlength<PT>, "Invalid PrimitiveTypes for avg function");
-            }
-        }
-
-        if constexpr (pt_is_arithmetic<PT>) {
-            this->data(state).sum += local_sum_for_arithmetic;
-        }
-        this->data(state).count += chunk_size;
-    }
-
     void update_batch_single_state(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
                                    int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
                                    int64_t frame_end) const override {
-        DCHECK(!columns[0]->is_nullable());
-        [[maybe_unused]] const InputColumnType* column = down_cast<const InputColumnType*>(columns[0]);
-        // For type of int/tinyint/bitint..., the result of avg is float/double
-        // But the floating point operations are much slower than integer operations
-        // So, we use integers to perform operations
-        [[maybe_unused]] SumResultType local_sum_for_arithmetic{};
-
         for (size_t i = frame_start; i < frame_end; ++i) {
-            if constexpr (pt_is_datetime<PT>) {
-                this->data(state).sum += column->get_data()[i].to_unix_second();
-            } else if constexpr (pt_is_date<PT>) {
-                this->data(state).sum += column->get_data()[i].julian();
-            } else if constexpr (pt_is_decimalv2<PT>) {
-                this->data(state).sum += column->get_data()[i];
-            } else if constexpr (pt_is_arithmetic<PT>) {
-                local_sum_for_arithmetic += column->get_data()[i];
-            } else if constexpr (pt_is_decimal<PT>) {
-                this->data(state).sum += column->get_data()[i];
-            } else {
-                // static_assert(pt_is_fixedlength<PT>, "Invalid PrimitiveTypes for avg function");
-            }
+            update(ctx, columns, state, i);
         }
-
-        if constexpr (pt_is_arithmetic<PT>) {
-            this->data(state).sum += local_sum_for_arithmetic;
-        }
-        this->data(state).count += frame_end - frame_start;
     }
 
     void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5201.

## Problem Summary：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
As for `SELECT AVG(bigint)` without group by, `AvgAggregateFunction::update_batch_single_state` speedd up the local sum operations as follows:
1. local_sum_for_arithmetic += value in loop,   `local_sum_for_arithmetic` and `value` is `int64_t`.
2. this->data(state).sum += local_sum_for_arithmetic, `sum` is `double`.

However, the value range of `int64` is smaller than `double`, so for this case, `double` isn't overflow, but `int64` will be overflow.

I tried to use `local_sum_for_arithmetic` firstly, and turn back to use `double sum` when it overflows. However, checking overflow in loop makes the code not able to vectorized. See [Compiler Explorer](https://godbolt.org/z/q7rG5hTWb) for detail.

## Test
### Environment
- 3 BE * 16vCPUs.
- ssb_100g
- Query: `SELECT AVG(lo_orderkey) FROM lineorder`
- Enable pipeline, and `pipeline_dop=1`.

### Result
Aggregate performance decreases about 3 times than before.
- Before PR. Latency: 140ms, Aggregate costs: 96ms.
- After PR. Latency: 300ms, Aggregate costs: 271ms.