### PR TITLE
[Enhancement]:Optimize bitmap index writer

### DIFF
--- a/be/src/storage/rowset/bitmap_index_writer.cpp
+++ b/be/src/storage/rowset/bitmap_index_writer.cpp
@@ -69,7 +69,8 @@ public:
     using CppType = typename CppTypeTraits<field_type>::CppType;
     using MemoryIndexType = typename BitmapIndexTraits<CppType>::MemoryIndexType;
 
-    explicit BitmapIndexWriterImpl(TypeInfoPtr type_info) : _typeinfo(std::move(type_info)), _reverted_index_size(0), _size_changed(false) {}
+    explicit BitmapIndexWriterImpl(TypeInfoPtr type_info)
+            : _typeinfo(std::move(type_info)), _reverted_index_size(0), _size_changed(false) {}
 
     ~BitmapIndexWriterImpl() override = default;
 

--- a/be/src/storage/rowset/bitmap_index_writer.cpp
+++ b/be/src/storage/rowset/bitmap_index_writer.cpp
@@ -60,7 +60,7 @@ public:
     void add_rid(const rowid_t rid, uint64_t& reverted_index_size, vector<RoaringWrapper*>& size_changed_roaring_vec) {
         _roaring.add(rid);
         if (_enable_get_size_in_Bytes) {
-            if (_size_changed == false) {
+            if (!_size_changed) {
                 size_changed_roaring_vec.push_back(this);
             }
             _size_changed = true;

--- a/be/src/storage/rowset/bitmap_index_writer.cpp
+++ b/be/src/storage/rowset/bitmap_index_writer.cpp
@@ -53,7 +53,7 @@ public:
 
     Roaring& roaring() { return _roaring; }
 
-    void add_rid(const rowid_t rid, uint64_t& reverted_index_size, vector<RoaringWrapper*>* size_changed_roaring_vec) {
+    void add_rid(const rowid_t rid, uint64_t* reverted_index_size, vector<RoaringWrapper*>* size_changed_roaring_vec) {
         _roaring.add(rid);
         if (_enable_get_size_in_bytes) {
             if (!_size_changed) {
@@ -68,9 +68,9 @@ public:
             // is very costly when roaring bitmap has a large number of nearly empty array container.
             _element_count++;
             if (LIKELY(_element_count < roaring_get_size_fastpath_threshold)) {
-                reverted_index_size += sizeof(uint32_t);
+                *reverted_index_size += sizeof(uint32_t);
             } else {
-                reverted_index_size -= (roaring_get_size_fastpath_threshold * sizeof(uint32_t) + 1);
+                *reverted_index_size -= (roaring_get_size_fastpath_threshold * sizeof(uint32_t) + 1);
                 _size_changed = true;
                 _enable_get_size_in_bytes = true;
                 size_changed_roaring_vec->push_back(this);
@@ -132,7 +132,7 @@ public:
             const CppType& value = unaligned_load<CppType>(p);
             auto it = _mem_index.find(value);
             if (it != _mem_index.end()) {
-                it->second.add_rid(_rid, _reverted_index_size, &_size_changed_roaring_vec);
+                it->second.add_rid(_rid, &_reverted_index_size, &_size_changed_roaring_vec);
             } else {
                 // new value, copy value and insert new key->bitmap pair
                 CppType new_value;

--- a/be/src/storage/rowset/bitmap_index_writer.cpp
+++ b/be/src/storage/rowset/bitmap_index_writer.cpp
@@ -79,7 +79,6 @@ public:
             if (LIKELY(_element_count < estimate_size_threshold)) {
                 *reverted_index_size += sizeof(uint32_t);
             } else {
-                // If _element_count equals to estimate_size_threshold
                 *reverted_index_size -= BitmapUpdateContext::estimate_size(_element_count);
                 _disable_estimate_size = true;
                 _size_changed = true;

--- a/be/src/storage/rowset/bitmap_index_writer.cpp
+++ b/be/src/storage/rowset/bitmap_index_writer.cpp
@@ -26,9 +26,7 @@
 #include <roaring/roaring.hh>
 #include <utility>
 
-#include "column/column_hash.h"
 #include "env/env.h"
-#include "exec/vectorized/aggregate/agg_hash_map.h"
 #include "runtime/mem_pool.h"
 #include "storage/olap_type_infra.h"
 #include "storage/rowset/common.h"
@@ -42,80 +40,54 @@ namespace starrocks {
 
 namespace {
 
-static constexpr size_t enable_roaring_threshold = 1024;
-static constexpr size_t croaring_serialization_array_uint32 = 1;
+static const size_t roaring_get_size_fastpath_threshold = 1024;
 
-// RoaringWrapper is a wrapper for roaring bitmap.
-// When the cardinality is less than enable_roaring_threshold, we use _rowid_array to save the bitmap.
-// When the BitmapIndexWriter is finished, _rowid_array will be flushed in the form of CROARING_SERIALIZATION_ARRAY_UINT32 in roaring bitmap.
-// The form of CROARING_SERIALIZATION_ARRAY_UINT32:
-// one bit    4 bytes         4 bytes * cardinality
-// [ 1       cardinality      data ....]
-// When the cardinality is higher than enable_roaring_threshold, we will transform _rowid_array to `roaring bitmap` _roaring and
-// subsequent operations are performed via _roaring.
 class RoaringWrapper {
 public:
     explicit RoaringWrapper(rowid_t rid)
-            : _roaring(nullptr), _old_size(1), _size_changed(true), _enable_roaring(false) {
-        _rowid_array.push_back(rid);
-    };
-    Roaring* roaring() { return _roaring.get(); }
-    uint64_t roaring_size() const { return _roaring->getSizeInBytes(false); }
+            : _roaring(std::move(Roaring::bitmapOf(1, rid))),
+              _old_size(1),
+              _size_changed(true),
+              _enable_get_size_in_Bytes(false){};
+    Roaring& roaring() { return _roaring; }
+    uint64_t roaring_size() const { return _roaring.getSizeInBytes(false); }
     uint64_t old_size() const { return _old_size; }
     void set_old_size(uint64_t size) const { _old_size = size; }
     bool size_changed() const { return _size_changed; }
     void set_size_changed() const { _size_changed = true; }
     void unset_size_changed() const { _size_changed = false; }
-    bool enable_roaring() const { return _enable_roaring; }
-    uint32_t rowid_array_size_in_bytes() const {
-        DCHECK(_enable_roaring == false);
-        return (_rowid_array.size() + 1) * sizeof(uint32_t) + 1;
-    }
 
     void add_rid(const rowid_t rid, uint64_t& reverted_index_size, vector<RoaringWrapper*>& size_changed_roaring_vec) {
-        if (_enable_roaring) {
+        _roaring.add(rid);
+        if (_enable_get_size_in_Bytes) {
             if (_size_changed == false) {
                 size_changed_roaring_vec.push_back(this);
             }
             _size_changed = true;
-            _roaring->add(rid);
         } else {
+            // roaring_get_size fastpath:
+            // If _old_size is less than roaring_get_size_fastpath_threshold, _old_size represents the cardinality of
+            // roaring, and we use _old_size * (sizeof(uint32_t) + 1) + 1 to approximate estimated true size of roaring bitmap.
+            // The reason for this optimization here is that the getSizeInBytes function in roaring bitmap is very costly when roaring
+            // bitmap has a large number of nearly empty array container.
             _old_size++;
-            if (LIKELY(_old_size < enable_roaring_threshold)) {
+            if (LIKELY(_old_size < roaring_get_size_fastpath_threshold)) {
                 reverted_index_size += sizeof(uint32_t);
-                _rowid_array.push_back(rid);
             } else {
-                reverted_index_size -= (enable_roaring_threshold * sizeof(uint32_t) + 1);
+                reverted_index_size -= (roaring_get_size_fastpath_threshold * sizeof(uint32_t) + 1);
                 _old_size = 0;
                 _size_changed = true;
-                _enable_roaring = true;
+                _enable_get_size_in_Bytes = true;
                 size_changed_roaring_vec.push_back(this);
-                _roaring = std::make_unique<Roaring>(_rowid_array.size(), _rowid_array.data());
             }
         }
     }
 
-    void flush_rowid_array(char* buf) {
-        buf[0] = croaring_serialization_array_uint32;
-        int cardinality = _rowid_array.size();
-        memcpy(buf + 1, &cardinality, sizeof(uint32_t));
-
-        uint32_t* data = reinterpret_cast<uint32_t*>(buf + 1 + sizeof(uint32_t));
-        int outpos = 0;
-        for (int i = 0; i < cardinality; ++i) {
-            const uint32_t val = _rowid_array[i];
-            memcpy(data + outpos, &val, sizeof(uint32_t));
-            outpos++;
-        }
-    }
-
 private:
-    std::unique_ptr<Roaring> _roaring;
-    vector<rowid_t> _rowid_array;
-
+    Roaring _roaring;
     mutable uint64_t _old_size;
     mutable bool _size_changed;
-    bool _enable_roaring;
+    bool _enable_get_size_in_Bytes;
 };
 
 template <typename CppType>
@@ -163,6 +135,8 @@ public:
                 CppType new_value;
                 _typeinfo->deep_copy(&new_value, &value, &_pool);
                 _mem_index.emplace(new_value, RoaringWrapper(_rid));
+                // one bit indicating type    4 bytes         4 bytes data
+                // [ 1                        cardinality      data ]
                 _reverted_index_size += sizeof(uint32_t) * 2 + 1;
             }
             _rid++;
@@ -197,43 +171,23 @@ public:
             RETURN_IF_ERROR(dict_column_writer.finish(meta->mutable_dict_column()));
         }
         { // write bitmaps
-            std::vector<RoaringWrapper*> wrappers;
-            std::vector<uint32_t> bitmap_sizes;
-            bitmap_sizes.resize(_mem_index.size());
-            uint32_t max_bitmap_size = 0;
-
-            uint32_t i = 0;
+            std::vector<Roaring*> bitmaps;
             for (auto& it : _mem_index) {
-                if (it.second.enable_roaring() == false) {
-                    uint32_t rowid_array_size_in_bytes = it.second.rowid_array_size_in_bytes();
-                    if (max_bitmap_size < rowid_array_size_in_bytes) {
-                        max_bitmap_size = rowid_array_size_in_bytes;
-                    }
-                    bitmap_sizes[i] = rowid_array_size_in_bytes;
-                }
-                wrappers.push_back(&it.second);
-                i++;
+                bitmaps.push_back(&(it.second.roaring()));
             }
-
-            for (size_t i = 0; i < wrappers.size(); ++i) {
-                if (wrappers[i]->enable_roaring()) {
-                    Roaring* roaring = wrappers[i]->roaring();
-                    roaring->runOptimize();
-                    uint32_t bitmap_size = roaring->getSizeInBytes(false);
-                    if (max_bitmap_size < bitmap_size) {
-                        max_bitmap_size = bitmap_size;
-                    }
-                    bitmap_sizes[i] = bitmap_size;
-                }
-            }
-
-            uint32_t null_bitmap_size = 0;
             if (!_null_bitmap.isEmpty()) {
-                _null_bitmap.runOptimize();
-                null_bitmap_size = _null_bitmap.getSizeInBytes(false);
-                if (max_bitmap_size < null_bitmap_size) {
-                    max_bitmap_size = null_bitmap_size;
+                bitmaps.push_back(&_null_bitmap);
+            }
+
+            uint32_t max_bitmap_size = 0;
+            std::vector<uint32_t> bitmap_sizes;
+            for (auto& bitmap : bitmaps) {
+                bitmap->runOptimize();
+                uint32_t bitmap_size = bitmap->getSizeInBytes(false);
+                if (max_bitmap_size < bitmap_size) {
+                    max_bitmap_size = bitmap_size;
                 }
+                bitmap_sizes.push_back(bitmap_size);
             }
 
             TypeInfoPtr bitmap_typeinfo = get_type_info(OLAP_FIELD_TYPE_OBJECT);
@@ -250,19 +204,9 @@ public:
 
             faststring buf;
             buf.reserve(max_bitmap_size);
-            for (size_t i = 0; i < wrappers.size(); ++i) {
+            for (size_t i = 0; i < bitmaps.size(); ++i) {
                 buf.resize(bitmap_sizes[i]); // so that buf[0..size) can be read and written
-                if (wrappers[i]->enable_roaring()) {
-                    wrappers[i]->roaring()->write(reinterpret_cast<char*>(buf.data()), false);
-                } else {
-                    wrappers[i]->flush_rowid_array(reinterpret_cast<char*>(buf.data()));
-                }
-                Slice buf_slice(buf);
-                RETURN_IF_ERROR(bitmap_column_writer.add(&buf_slice));
-            }
-            if (!_null_bitmap.isEmpty()) {
-                buf.resize(null_bitmap_size);
-                _null_bitmap.write(reinterpret_cast<char*>(buf.data()), false);
+                bitmaps[i]->write(reinterpret_cast<char*>(buf.data()), false);
                 Slice buf_slice(buf);
                 RETURN_IF_ERROR(bitmap_column_writer.add(&buf_slice));
             }

--- a/be/src/storage/rowset/bitmap_index_writer.cpp
+++ b/be/src/storage/rowset/bitmap_index_writer.cpp
@@ -171,15 +171,14 @@ public:
     uint64_t size() const override {
         uint64_t size = 0;
         size += _null_bitmap.getSizeInBytes(false);
-        if (!_size_changed) {
-            size += _reverted_index_size;
-        } else {
+        if (_size_changed) {
             _reverted_index_size = 0;
             for (const auto& it : _mem_index) {
                 _reverted_index_size += it.second.getSizeInBytes(false);
             }
             _size_changed = false;
         }
+        size += _reverted_index_size;
         size += _mem_index.size() * sizeof(CppType);
         size += _pool.total_allocated_bytes();
         return size;


### PR DESCRIPTION
Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5328 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

In the current BitmapIndexWriterImpl code, add_value needs to call twice getSizeInBytes the monitor the change of the roaring map. The add_value function is called very frequently. Which has a great impact on the performance of compaction in the test.
This pr optimizes the calculation of roaring size in the bitmap Index. 

The solution to this problem is to move the calculation of the roaring bitmap size from the `add_value` function` to the `size` function. Delay calculation.