### PR TITLE
[BugFix] json stream load failed with Transfer-Encoding: chunked set

### DIFF
--- a/be/src/exec/file_reader.h
+++ b/be/src/exec/file_reader.h
@@ -40,16 +40,6 @@ public:
     virtual Status read(uint8_t* buf, size_t* buf_len, bool* eof) = 0;
     virtual Status readat(int64_t position, int64_t nbytes, int64_t* bytes_read, void* out) = 0;
 
-    /**
-     * This interface is used read a whole message, For example: read a message from kafka.
-     *
-     * if read eof then return Status::OK and length is set 0 and buf is set NULL,
-     *  other return readed bytes.
-     */
-    virtual Status read_one_message(std::unique_ptr<uint8_t[]>* buf, size_t* buf_cap, size_t* buf_sz,
-                                    size_t padding = 0) {
-        return Status::NotSupported("Not support");
-    };
     virtual int64_t size() = 0;
     virtual Status seek(int64_t position) = 0;
     virtual Status tell(int64_t* position) = 0;

--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -349,8 +349,7 @@ Status StreamLoadAction::_process_put(HttpRequest* http_req, StreamLoadContext* 
     request.__set_loadId(ctx->id.to_thrift());
     if (ctx->use_streaming) {
         auto pipe =
-                std::make_shared<StreamLoadPipe>(1024 * 1024 /* max_buffered_bytes */, 64 * 1024 /* min_chunk_size */,
-                                                 ctx->body_bytes /* total_length */);
+                std::make_shared<StreamLoadPipe>(1024 * 1024 /* max_buffered_bytes */, 64 * 1024 /* min_chunk_size */);
         RETURN_IF_ERROR(_exec_env->load_stream_mgr()->put(ctx->id, pipe));
         request.fileType = TFileType::FILE_STREAM;
         ctx->body_sink = pipe;

--- a/be/src/runtime/stream_load/stream_load_pipe.h
+++ b/be/src/runtime/stream_load/stream_load_pipe.h
@@ -82,7 +82,7 @@ public:
         return _append(buf);
     }
 
-    /* read_one_messages returns data appended in one time.
+    /* read_one_messages returns data that is written by append in one time.
     * buf: the buffer to return data, and would be expaneded if the capacity is not enough.
     * buf_cap: the capacity of buffer, and would be reset if the capacity is not enough.
     * buf_sz: the actual size of data to return.


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5327 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When `Transfer-Encoding: chunked` is set, the content of HTTP body cannot be known from HTTP header `Content-Length`.
However, the previous implement of `StreamLoadPipe` need the http body size for initializing `_total_length`, and the `StreamLoadPipe:read_one_message` also needs `_total_length`.

This PR includes the following modifications:
1. remove the `StreamLoadPipe`'s dependency on HTTP body size as the initial size
2. redefine the semantics of `StreamLoadPipe:read_one_message` as `returns data that is written by append in one time`
3. new unit tests for `StreamLoadPipe:read_one_message`

The `StreamLoadPipe` is a pipe to store data from stream load. Every time we use `StreamLoadPipe::append` for JSON, we must append a complete JSON payload. So, it's OK to parse the data as JSON returned by  `StreamLoadPipe:read_one_message`.