### PR TITLE
Fix LogicValueOperator misjudgment of equality when columnRefSet and ows are empty (#5324)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalValuesOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalValuesOperator.java
@@ -12,7 +12,6 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 public class LogicalValuesOperator extends LogicalOperator {
     private final List<ColumnRefOperator> columnRefSet;
@@ -58,23 +57,12 @@ public class LogicalValuesOperator extends LogicalOperator {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        if (!super.equals(o)) {
-            return false;
-        }
-        LogicalValuesOperator that = (LogicalValuesOperator) o;
-        return Objects.equals(columnRefSet, that.columnRefSet) &&
-                Objects.equals(rows, that.rows);
+        return this == o;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), columnRefSet, rows);
+        return System.identityHashCode(this);
     }
 
     public static class Builder extends LogicalOperator.Builder<LogicalValuesOperator, LogicalValuesOperator.Builder> {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -88,4 +88,14 @@ public class JoinTest extends PlanTestBase {
                 "  |  join op: INNER JOIN (COLOCATE)");
         FeConstants.runningUnitTest = false;
     }
+
+    @Test
+    public void testValueNodeJoin() throws Exception {
+        String sql = "select count(*) from (select test_all_type.t1c as left_int, " +
+                "test_all_type1.t1c as right_int from (select * from test_all_type limit 0) " +
+                "test_all_type cross join (select * from test_all_type limit 0) test_all_type1 cross join (select * from test_all_type limit 0) test_all_type6) t;";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "1:EMPTYSET");
+        assertContains(plan, "2:EMPTYSET");
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
