### PR TITLE
support _col0,_col1 for orc late materialization

### DIFF
--- a/be/src/exec/vectorized/orc_scanner_adapter.cpp
+++ b/be/src/exec/vectorized/orc_scanner_adapter.cpp
@@ -1064,6 +1064,25 @@ void OrcScannerAdapter::build_column_name_set(std::unordered_set<std::string>* n
     }
 }
 
+Status OrcScannerAdapter::_slot_to_orc_column_name(const SlotDescriptor* desc,
+                                                   const std::unordered_map<int, std::string>& column_id_to_orc_name,
+                                                   std::string* orc_column_name) {
+    auto it = _name_to_column_id.find(desc->col_name());
+    if (it == _name_to_column_id.end()) {
+        auto s = strings::Substitute("OrcScannerAdapter::init_include_columns. col name = $0 not found",
+                                     desc->col_name());
+        return Status::NotFound(s);
+    }
+    auto it2 = column_id_to_orc_name.find(it->second);
+    if (it2 == column_id_to_orc_name.end()) {
+        auto s = strings::Substitute("OrcScannerAdapter::init_include_columns. col name = $0 not found",
+                                     desc->col_name());
+        return Status::NotFound(s);
+    }
+    *orc_column_name = it2->second;
+    return Status::OK();
+}
+
 Status OrcScannerAdapter::_init_include_columns() {
     build_column_name_to_id_mapping(&_name_to_column_id, _hive_column_names, _reader->getType());
     std::unordered_map<int, std::string> column_id_to_orc_name;
@@ -1077,27 +1096,20 @@ Status OrcScannerAdapter::_init_include_columns() {
 
     for (SlotDescriptor* desc : _src_slot_descriptors) {
         if (desc == nullptr) continue;
-        auto it = _name_to_column_id.find(desc->col_name());
-        if (it == _name_to_column_id.end()) {
-            auto s = strings::Substitute("OrcScannerAdapter::init_include_columns. col name = $0 not found",
-                                         desc->col_name());
-            return Status::NotFound(s);
-        }
-        auto it2 = column_id_to_orc_name.find(it->second);
-        if (it2 == column_id_to_orc_name.end()) {
-            auto s = strings::Substitute("OrcScannerAdapter::init_include_columns. col name = $0 not found",
-                                         desc->col_name());
-            return Status::NotFound(s);
-        }
-        orc_column_names.push_back(it2->second);
+        std::string orc_column_name;
+        RETURN_IF_ERROR(_slot_to_orc_column_name(desc, column_id_to_orc_name, &orc_column_name));
+        orc_column_names.emplace_back(orc_column_name);
     }
+
     _row_reader_options.include(orc_column_names);
 
     if (_lazy_load_ctx != nullptr) {
         std::list<std::string> orc_lazy_load_column_names;
         for (SlotDescriptor* desc : _lazy_load_ctx->lazy_load_slots) {
             if (desc == nullptr) continue;
-            orc_lazy_load_column_names.push_back(desc->col_name());
+            std::string orc_column_name;
+            RETURN_IF_ERROR(_slot_to_orc_column_name(desc, column_id_to_orc_name, &orc_column_name));
+            orc_lazy_load_column_names.emplace_back(orc_column_name);
         }
         _row_reader_options.includeLazyLoadColumnNames(orc_lazy_load_column_names);
     }

--- a/be/src/exec/vectorized/orc_scanner_adapter.h
+++ b/be/src/exec/vectorized/orc_scanner_adapter.h
@@ -137,6 +137,9 @@ private:
     std::unordered_map<SlotId, int> _slot_id_to_position;
     std::vector<Expr*> _cast_exprs;
     std::vector<FillColumnFunction> _fill_functions;
+    Status _slot_to_orc_column_name(const SlotDescriptor* slot,
+                                    const std::unordered_map<int, std::string>& column_id_to_orc_name,
+                                    std::string* orc_column_name);
     Status _init_include_columns();
     Status _init_position_in_orc();
     Status _init_src_types();

--- a/be/test/exprs/vectorized/math_functions_test.cpp
+++ b/be/test/exprs/vectorized/math_functions_test.cpp
@@ -132,7 +132,7 @@ static void testRoundDecimal(const std::vector<std::string>& arg0_values, const 
         // ConstColumn
         c0_const = true;
         arg0_data_column->resize(1);
-        c0 = ConstColumn::create(arg0_data_column,arg0_values.size());
+        c0 = ConstColumn::create(arg0_data_column, arg0_values.size());
     } else {
         if (arg0_null_flags.empty()) {
             // normal Column


### PR DESCRIPTION
## What type of PR is this：
- [X] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5354

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Root cause of this bug, is we don't do column name conversion for late materialization fields.
