### PR TITLE
[Enhancement] construct row in json object order when column is sparse

### DIFF
--- a/be/src/exec/vectorized/json_scanner.cpp
+++ b/be/src/exec/vectorized/json_scanner.cpp
@@ -552,9 +552,9 @@ Status JsonReader::_construct_row_in_slot_order(simdjson::ondemand::object* row,
 Status JsonReader::_construct_row(simdjson::ondemand::object* row, Chunk* chunk) {
     if (_scanner->_json_paths.empty()) {
         // No json path.
-        // if number of object fields is much more than size of _slot_descs,
+        // if size of _slot_desc is much more than (2x) number of object fields,
         // using object as driven table to look up field key in _slot_desc_dict may get better performance.
-        if (row->count_fields() > _slot_descs.size() * 2) {
+        if (_slot_descs.size() > row->count_fields() * 2) {
             return _construct_row_in_object_order(row, chunk);
         } else {
             return _construct_row_in_slot_order(row, chunk);

--- a/be/src/exec/vectorized/json_scanner.h
+++ b/be/src/exec/vectorized/json_scanner.h
@@ -85,8 +85,10 @@ private:
 
     Status _read_and_parse_json();
 
-    Status _construct_row(simdjson::ondemand::object* row, Chunk* chunk,
-                          const std::vector<SlotDescriptor*>& slot_descs);
+    Status _construct_row(simdjson::ondemand::object* row, Chunk* chunk);
+
+    Status _construct_row_in_object_order(simdjson::ondemand::object* row, Chunk* chunk) {}
+    Status _construct_row_in_slot_order(simdjson::ondemand::object* row, Chunk* chunk) {}
 
     Status _construct_column(simdjson::ondemand::value& value, Column* column, const TypeDescriptor& type_desc,
                              const std::string& col_name);
@@ -103,6 +105,7 @@ private:
     std::shared_ptr<SequentialFile> _file;
     bool _closed;
     std::vector<SlotDescriptor*> _slot_descs;
+    std::unordered_map<std::string, SlotDescriptor*> _slot_desc_dict;
 
     // For performance reason, the simdjson parser should be reused over several files.
     //https://github.com/simdjson/simdjson/blob/master/doc/performance.md

--- a/be/src/exec/vectorized/json_scanner.h
+++ b/be/src/exec/vectorized/json_scanner.h
@@ -87,14 +87,14 @@ private:
 
     Status _construct_row(simdjson::ondemand::object* row, Chunk* chunk);
 
-    Status _construct_row_in_object_order(simdjson::ondemand::object* row, Chunk* chunk) {}
-    Status _construct_row_in_slot_order(simdjson::ondemand::object* row, Chunk* chunk) {}
+    Status _construct_row_in_object_order(simdjson::ondemand::object* row, Chunk* chunk);
+    Status _construct_row_in_slot_order(simdjson::ondemand::object* row, Chunk* chunk);
 
     Status _construct_column(simdjson::ondemand::value& value, Column* column, const TypeDescriptor& type_desc,
                              const std::string& col_name);
 
-    // Reorder column to accelerate simdjson iteration.
-    void _reorder_column();
+    // _build_slot_descs builds _slot_descs as the order of first json object and builds _slot_desc_dict;
+    void _build_slot_descs();
 
 private:
     RuntimeState* _state = nullptr;

--- a/be/test/exec/vectorized/json_scanner_test.cpp
+++ b/be/test/exec/vectorized/json_scanner_test.cpp
@@ -762,7 +762,16 @@ TEST_F(JsonScannerTest, test_ndjson_expanded_with_json_root) {
 TEST_F(JsonScannerTest, test_construct_row_in_object_order) {
     std::vector<TypeDescriptor> types;
     types.emplace_back(TypeDescriptor::create_varchar_type(20));
+    types.emplace_back(TypeDescriptor::create_varchar_type(20));
+    types.emplace_back(TypeDescriptor::create_varchar_type(20));
+    types.emplace_back(TypeDescriptor::create_varchar_type(20));
+    types.emplace_back(TypeDescriptor::create_varchar_type(20));
+    types.emplace_back(TypeDescriptor::create_varchar_type(20));
+    types.emplace_back(TypeDescriptor::create_varchar_type(20));
     types.emplace_back(TYPE_DOUBLE);
+    types.emplace_back(TYPE_DOUBLE);
+    types.emplace_back(TYPE_INT);
+    types.emplace_back(TYPE_INT);
 
     std::vector<TBrokerRangeDesc> ranges;
     TBrokerRangeDesc range;
@@ -774,17 +783,19 @@ TEST_F(JsonScannerTest, test_construct_row_in_object_order) {
     range.__set_path("./be/test/exec/test_data/json_scanner/test_cast_type.json");
     ranges.emplace_back(range);
 
-    auto scanner = create_json_scanner(types, ranges, {"f_float", "f_float_in_string"});
+    auto scanner = create_json_scanner(types, ranges,
+                                       {"f_dummy_0", "f_float", "f_dummy_1", "f_bool", "f_dummy_2", "f_int",
+                                        "f_dummy_3", "f_float_in_string", "f_dummy_4", "f_int_in_string", "f_dummy_5"});
 
     Status st;
     st = scanner->open();
     ASSERT_TRUE(st.ok());
 
     ChunkPtr chunk = scanner->get_next().value();
-    EXPECT_EQ(2, chunk->num_columns());
+    EXPECT_EQ(11, chunk->num_columns());
     EXPECT_EQ(1, chunk->num_rows());
 
-    EXPECT_EQ("['3.14', 3.14]", chunk->debug_row(0));
+    EXPECT_EQ("[NULL, '3.14', NULL, '1', NULL, '123', NULL, 3.14, NULL, 123, NULL]", chunk->debug_row(0));
 }
 
 } // namespace starrocks::vectorized


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4995 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

The previous implement constructed a row from JSON in column order. The JSON scanner iterates the column descriptor and looks up the column name in the JSON object. When the number of columns is much more than JSON field, there're many useless looking up of the JSON object.
 
The new implementation uses a smarter strategy to construct the columns:
1. if the number of columns is much more (2x) than the number of object fields, lookup the object field key in dict of the column.
2. otherwise, lookup the column name in the JSON object.

