### PR TITLE
Resource group monitor audit new

### DIFF
--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -120,8 +120,10 @@ WorkGroupPtr WorkGroupManager::add_workgroup(const WorkGroupPtr& wg) {
 }
 
 void WorkGroupManager::add_metrics(const WorkGroupPtr& wg) {
-    std::call_once(StarRocksMetrics::instance()->metrics()->register_hook("work_group_metrics_hook",
-                                                                          [this] { update_metrics(); }));
+    std::call_once(_init_metrics, []() {
+        StarRocksMetrics::instance()->metrics()->register_hook("work_group_metrics_hook",
+                                                               [] { WorkGroupManager::instance()->update_metrics(); });
+    });
 
     if (_wg_metrics.count(wg->name()) == 0) {
         //cpu limit

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -121,7 +121,8 @@ WorkGroupPtr WorkGroupManager::add_workgroup(const WorkGroupPtr& wg) {
 
 void WorkGroupManager::add_metrics(const WorkGroupPtr& wg) {
     std::call_once(_init_metrics, []() {
-        StarRocksMetrics::instance()->metrics()->register_hook("work_group_metrics_hook", [] { update_metrics(); });
+        StarRocksMetrics::instance()->metrics()->register_hook(
+                "work_group_metrics_hook", [] { starrocks::workgroup::WorkGroupManager::update_metrics(); });
     });
 
     if (_wg_metrics.count(wg->name()) == 0) {

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -121,7 +121,7 @@ WorkGroupPtr WorkGroupManager::add_workgroup(const WorkGroupPtr& wg) {
 
 void WorkGroupManager::add_metrics(const WorkGroupPtr& wg) {
     std::call_once(_init_metrics, []() {
-        StarRocksMetrics::instance()->metrics()->register_hook("work_group_metrics_hook", [this] { update_metrics(); })
+        StarRocksMetrics::instance()->metrics()->register_hook("work_group_metrics_hook", [] { update_metrics(); });
     });
 
     if (_wg_metrics.count(wg->name()) == 0) {

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -121,8 +121,8 @@ WorkGroupPtr WorkGroupManager::add_workgroup(const WorkGroupPtr& wg) {
 
 void WorkGroupManager::add_metrics(const WorkGroupPtr& wg) {
     std::call_once(_init_metrics, []() {
-        StarRocksMetrics::instance()->metrics()->register_hook(
-                "work_group_metrics_hook", [] { starrocks::workgroup::WorkGroupManager::update_metrics(); });
+        StarRocksMetrics::instance()->metrics()->register_hook("work_group_metrics_hook",
+                                                               [] { WorkGroupManager::instance()->update_metrics(); });
     });
 
     if (_wg_metrics.count(wg->name()) == 0) {

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -120,8 +120,9 @@ WorkGroupPtr WorkGroupManager::add_workgroup(const WorkGroupPtr& wg) {
 }
 
 void WorkGroupManager::add_metrics(const WorkGroupPtr& wg) {
-    std::call_once(StarRocksMetrics::instance()->metrics()->register_hook("work_group_metrics_hook",
-                                                                          [this] { update_metrics(); }));
+    std::call_once(_init_metrics, []() {
+        StarRocksMetrics::instance()->metrics()->register_hook("work_group_metrics_hook", [this] { update_metrics(); })
+    });
 
     if (_wg_metrics.count(wg->name()) == 0) {
         //cpu limit

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -5,6 +5,8 @@
 #include "gen_cpp/internal_service.pb.h"
 #include "glog/logging.h"
 #include "runtime/exec_env.h"
+#include "util/metrics.h"
+#include "util/starrocks_metrics.h"
 
 namespace starrocks {
 namespace workgroup {
@@ -66,9 +68,9 @@ TWorkGroup WorkGroup::to_thrift_verbose() const {
 }
 
 void WorkGroup::init() {
-    int64_t limit = ExecEnv::GetInstance()->query_pool_mem_tracker()->limit() * _memory_limit;
+    _mem_limit = ExecEnv::GetInstance()->query_pool_mem_tracker()->limit() * _memory_limit;
     _mem_tracker =
-            std::make_shared<starrocks::MemTracker>(limit, _name, ExecEnv::GetInstance()->query_pool_mem_tracker());
+            std::make_shared<starrocks::MemTracker>(_mem_limit, _name, ExecEnv::GetInstance()->query_pool_mem_tracker());
     _driver_queue = std::make_unique<pipeline::QuerySharedDriverQueueWithoutLock>();
     _scan_task_queue = std::make_unique<FifoScanTaskQueue>();
 }
@@ -79,6 +81,10 @@ double WorkGroup::get_cpu_expected_use_ratio() const {
 
 double WorkGroup::get_cpu_actual_use_ratio() const {
     return _cpu_actual_use_ratio;
+}
+
+int64_t WorkGroup::mem_limit() const {
+    return _mem_limit;
 }
 
 WorkGroupManager::WorkGroupManager()
@@ -96,16 +102,63 @@ void WorkGroupManager::destroy() {
     _driver_worker_owner_manager.reset(nullptr);
     _scan_worker_owner_manager.reset(nullptr);
     _workgroups.clear();
+    update_metrics();
 }
 
 WorkGroupPtr WorkGroupManager::add_workgroup(const WorkGroupPtr& wg) {
     std::unique_lock write_lock(_mutex);
     auto unique_id = wg->unique_id();
     create_workgroup_unlocked(wg);
+    add_metrics(wg);
     if (_workgroup_versions.count(wg->id()) && _workgroup_versions[wg->id()] == wg->version()) {
         return _workgroups[unique_id];
     } else {
         return get_default_workgroup();
+    }
+}
+
+void WorkGroupManager::add_metrics(const WorkGroupPtr& wg) {
+    if(!_init_metrics) {
+        _init_metrics=true;
+        StarRocksMetrics::instance()->metrics()->register_hook("work_group_metrics_hook", [this] {update_metrics();});
+    }
+    if(_wg_metrics.count(wg->name())==0) {
+        //cpu limit
+        DoubleGauge* resource_group_cpu_limit_ratio = new DoubleGauge(MetricUnit::PERCENT);
+        //cpu concurrent
+        DoubleGauge* resource_group_cpu_use_ratio = new DoubleGauge(MetricUnit::PERCENT);
+        //mem limit
+        IntGauge* resource_group_mem_limit_bytes= new IntGauge(MetricUnit::BYTES);
+        //mem concurrent
+        IntGauge* resource_group_mem_allocated_bytes = new IntGauge(MetricUnit::BYTES);
+
+        _wg_cpu_limit_metrics.emplace(wg->name(), resource_group_cpu_limit_ratio);
+        _wg_cpu_metrics.emplace(wg->name(), resource_group_cpu_use_ratio);
+        _wg_mem_limit_metrics.emplace(wg->name(), resource_group_mem_limit_bytes);
+        _wg_mem_metrics.emplace(wg->name(), resource_group_mem_allocated_bytes);
+
+        StarRocksMetrics::instance()->metrics()->register_metric("resource_group_cpu_limit_ratio", MetricLabels().add("name", wg->name()), resource_group_cpu_limit_ratio);
+        StarRocksMetrics::instance()->metrics()->register_metric("resource_group_cpu_use_ratio", MetricLabels().add("name", wg->name()), resource_group_cpu_use_ratio);
+        StarRocksMetrics::instance()->metrics()->register_metric("resource_group_mem_limit_bytes", MetricLabels().add("name", wg->name()), resource_group_mem_limit_bytes);
+        StarRocksMetrics::instance()->metrics()->register_metric("resource_group_mem_allocated_bytes", MetricLabels().add("name", wg->name()), resource_group_mem_allocated_bytes);
+    }
+    _wg_metrics.emplace(wg->name(), wg->unique_id());
+}
+
+void WorkGroupManager::update_metrics() {
+    for (auto& wg_metric : _wg_metrics) {
+        WorkGroupPtr wg = _workgroups[wg_metric.second];
+        if(wg != nullptr) {
+            _wg_cpu_limit_metrics[wg_metric.first]->set_value(wg->get_cpu_expected_use_ratio());
+            _wg_cpu_metrics[wg_metric.first]->set_value(wg->get_cpu_actual_use_ratio());
+            _wg_mem_limit_metrics[wg_metric.first]->set_value(wg->mem_limit());
+            _wg_mem_metrics[wg_metric.first]->set_value(wg->mem_tracker()->consumption());
+        } else {
+            _wg_cpu_limit_metrics[wg_metric.first]->set_value(0);
+            _wg_cpu_metrics[wg_metric.first]->set_value(0);
+            _wg_mem_limit_metrics[wg_metric.first]->set_value(0);
+            _wg_mem_metrics[wg_metric.first]->set_value(0);
+        }
     }
 }
 
@@ -370,3 +423,4 @@ bool WorkerOwnerManager::should_yield(int worker_id, const WorkGroupPtr& running
 
 } // namespace workgroup
 } // namespace starrocks
+    

--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -130,7 +130,7 @@ public:
     static constexpr int64 DEFAULT_WG_ID = 0;
     static constexpr int64 DEFAULT_VERSION = 0;
 
-    double mem_limit() const;
+    int64_t mem_limit() const;
 
 private:
     std::string _name;

--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -13,6 +13,8 @@
 #include "storage/olap_define.h"
 #include "util/blocking_queue.hpp"
 #include "util/priority_thread_pool.hpp"
+#include "util/metrics.h"
+#include "util/starrocks_metrics.h"
 
 namespace starrocks {
 
@@ -128,6 +130,8 @@ public:
     static constexpr int64 DEFAULT_WG_ID = 0;
     static constexpr int64 DEFAULT_VERSION = 0;
 
+    double mem_limit() const ;
+
 private:
     std::string _name;
     int64_t _id;
@@ -223,6 +227,9 @@ public:
 
     int num_total_driver_workers() const { return _driver_worker_owner_manager->num_total_workers(); }
 
+    void add_metrics(const WorkGroupPtr& wg);
+    void update_metrics();
+
 private:
     // {create, alter,delete}_workgroup_unlocked is used to replay WorkGroupOps.
     // WorkGroupManager::_mutex is held when invoking these method.
@@ -244,6 +251,14 @@ private:
 
     std::unique_ptr<WorkerOwnerManager> _driver_worker_owner_manager;
     std::unique_ptr<WorkerOwnerManager> _scan_worker_owner_manager;
+
+    bool _init_metrics = false;
+    std::unordered_map<std::string, int128_t> _wg_metrics;
+
+    std::unordered_map<std::string, starrocks::DoubleGauge*> _wg_cpu_limit_metrics;
+    std::unordered_map<std::string, starrocks::DoubleGauge*> _wg_cpu_metrics;
+    std::unordered_map<std::string, starrocks::DoubleGauge*> _wg_mem_limit_metrics;
+    std::unordered_map<std::string, starrocks::IntGauge*> _wg_mem_metrics;
 };
 
 class DefaultWorkGroupInitialization {

--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -12,8 +12,8 @@
 #include "runtime/mem_tracker.h"
 #include "storage/olap_define.h"
 #include "util/blocking_queue.hpp"
-#include "util/priority_thread_pool.hpp"
 #include "util/metrics.h"
+#include "util/priority_thread_pool.hpp"
 #include "util/starrocks_metrics.h"
 
 namespace starrocks {
@@ -130,7 +130,7 @@ public:
     static constexpr int64 DEFAULT_WG_ID = 0;
     static constexpr int64 DEFAULT_VERSION = 0;
 
-    double mem_limit() const ;
+    double mem_limit() const;
 
 private:
     std::string _name;
@@ -253,13 +253,13 @@ private:
     std::unique_ptr<WorkerOwnerManager> _driver_worker_owner_manager;
     std::unique_ptr<WorkerOwnerManager> _scan_worker_owner_manager;
 
-    bool _init_metrics = false;
+    std::once_flag _init_metrics;
     std::unordered_map<std::string, int128_t> _wg_metrics;
 
-    std::unordered_map<std::string, starrocks::DoubleGauge*> _wg_cpu_limit_metrics;
-    std::unordered_map<std::string, starrocks::DoubleGauge*> _wg_cpu_metrics;
-    std::unordered_map<std::string, starrocks::IntGauge*> _wg_mem_limit_metrics;
-    std::unordered_map<std::string, starrocks::IntGauge*> _wg_mem_metrics;
+    std::unordered_map<std::string, std::unique_ptr<starrocks::DoubleGauge>> _wg_cpu_limit_metrics;
+    std::unordered_map<std::string, std::unique_ptr<starrocks::DoubleGauge>> _wg_cpu_metrics;
+    std::unordered_map<std::string, std::unique_ptr<starrocks::IntGauge>> _wg_mem_limit_metrics;
+    std::unordered_map<std::string, std::unique_ptr<starrocks::IntGauge>> _wg_mem_metrics;
 };
 
 class DefaultWorkGroupInitialization {

--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -13,6 +13,8 @@
 #include "storage/olap_define.h"
 #include "util/blocking_queue.hpp"
 #include "util/priority_thread_pool.hpp"
+#include "util/metrics.h"
+#include "util/starrocks_metrics.h"
 
 namespace starrocks {
 
@@ -128,6 +130,8 @@ public:
     static constexpr int64 DEFAULT_WG_ID = 0;
     static constexpr int64 DEFAULT_VERSION = 0;
 
+    double mem_limit() const ;
+
 private:
     std::string _name;
     int64_t _id;
@@ -135,6 +139,7 @@ private:
 
     size_t _cpu_limit;
     double _memory_limit;
+    int64_t _mem_limit;
     size_t _concurrency;
     WorkGroupType _type;
 
@@ -223,6 +228,9 @@ public:
 
     int num_total_driver_workers() const { return _driver_worker_owner_manager->num_total_workers(); }
 
+    void add_metrics(const WorkGroupPtr& wg);
+    void update_metrics();
+
 private:
     // {create, alter,delete}_workgroup_unlocked is used to replay WorkGroupOps.
     // WorkGroupManager::_mutex is held when invoking these method.
@@ -244,6 +252,14 @@ private:
 
     std::unique_ptr<WorkerOwnerManager> _driver_worker_owner_manager;
     std::unique_ptr<WorkerOwnerManager> _scan_worker_owner_manager;
+
+    bool _init_metrics = false;
+    std::unordered_map<std::string, int128_t> _wg_metrics;
+
+    std::unordered_map<std::string, starrocks::DoubleGauge*> _wg_cpu_limit_metrics;
+    std::unordered_map<std::string, starrocks::DoubleGauge*> _wg_cpu_metrics;
+    std::unordered_map<std::string, starrocks::IntGauge*> _wg_mem_limit_metrics;
+    std::unordered_map<std::string, starrocks::IntGauge*> _wg_mem_metrics;
 };
 
 class DefaultWorkGroupInitialization {

--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -139,6 +139,7 @@ private:
 
     size_t _cpu_limit;
     double _memory_limit;
+    int64_t _mem_limit;
     size_t _concurrency;
     WorkGroupType _type;
 
@@ -257,7 +258,7 @@ private:
 
     std::unordered_map<std::string, starrocks::DoubleGauge*> _wg_cpu_limit_metrics;
     std::unordered_map<std::string, starrocks::DoubleGauge*> _wg_cpu_metrics;
-    std::unordered_map<std::string, starrocks::DoubleGauge*> _wg_mem_limit_metrics;
+    std::unordered_map<std::string, starrocks::IntGauge*> _wg_mem_limit_metrics;
     std::unordered_map<std::string, starrocks::IntGauge*> _wg_mem_metrics;
 };
 

--- a/be/src/util/metrics.h
+++ b/be/src/util/metrics.h
@@ -361,11 +361,13 @@ public:
         }
 
         for (auto& it : _collectors) {
+            LOG(INFO) << "metric collect:" << it.first;
             it.second->collect(_name, it.first, visitor);
         }
     }
 
     void trigger_hook() {
+        LOG(INFO) << "trigger_hook";
         std::shared_lock lock(_mutex);
         unprotected_trigger_hook();
     }
@@ -373,6 +375,7 @@ public:
 private:
     void unprotected_trigger_hook() {
         for (const auto& it : _hooks) {
+            LOG(INFO) << "trigger_hook:" << it.first;
             it.second();
         }
     }

--- a/be/src/util/metrics.h
+++ b/be/src/util/metrics.h
@@ -361,13 +361,11 @@ public:
         }
 
         for (auto& it : _collectors) {
-            LOG(INFO) << "metric collect:" << it.first;
             it.second->collect(_name, it.first, visitor);
         }
     }
 
     void trigger_hook() {
-        LOG(INFO) << "trigger_hook";
         std::shared_lock lock(_mutex);
         unprotected_trigger_hook();
     }
@@ -375,7 +373,6 @@ public:
 private:
     void unprotected_trigger_hook() {
         for (const auto& it : _hooks) {
-            LOG(INFO) << "trigger_hook:" << it.first;
             it.second();
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/WorkGroupMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/WorkGroupMgr.java
@@ -382,7 +382,9 @@ public class WorkGroupMgr implements Writable {
         if (classifierList.isEmpty()) {
             return null;
         } else {
-            return id2WorkGroupMap.get(classifierList.get(classifierList.size() - 1).getWorkgroupId());
+            WorkGroup workGroup = id2WorkGroupMap.get(classifierList.get(classifierList.size() - 1).getWorkgroupId());
+            ctx.getAuditEventBuilder().setResourceGroup(workGroup.getName());
+            return workGroup;
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/WorkGroupMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/WorkGroupMgr.java
@@ -384,6 +384,7 @@ public class WorkGroupMgr implements Writable {
         } else {
             WorkGroup workGroup = id2WorkGroupMap.get(classifierList.get(classifierList.size() - 1).getWorkgroupId());
             ctx.getAuditEventBuilder().setResourceGroup(workGroup.getName());
+            ctx.setWorkGroup(workGroup);
             return workGroup;
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/WorkGroupMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/WorkGroupMgr.java
@@ -382,7 +382,10 @@ public class WorkGroupMgr implements Writable {
         if (classifierList.isEmpty()) {
             return null;
         } else {
-            return id2WorkGroupMap.get(classifierList.get(classifierList.size() - 1).getWorkgroupId());
+            WorkGroup workGroup = id2WorkGroupMap.get(classifierList.get(classifierList.size() - 1).getWorkgroupId());
+            ctx.getAuditEventBuilder().setResourceGroup(workGroup.getName());
+            ctx.setWorkGroup(workGroup);
+            return workGroup;
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricCalculator.java
@@ -90,6 +90,7 @@ public class MetricCalculator extends TimerTask {
 
         // query latency
         List<QueryDetail> queryList = QueryDetailQueue.getQueryDetailsAfterTime(lastQueryEventTime);
+        ResourceGroupMetricMgr.updateQueryLatency(queryList);
         List<Long> latencyList = new ArrayList<>();
         double latencySum = 0L;
         for (QueryDetail queryDetail : queryList) {

--- a/fe/fe-core/src/main/java/com/starrocks/metric/ResourceGroupMetricMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/ResourceGroupMetricMgr.java
@@ -23,18 +23,27 @@ package com.starrocks.metric;
 
 import com.starrocks.catalog.WorkGroup;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.QueryDetail;
 import com.starrocks.qe.SessionVariable;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class ResourceGroupMetricMgr {
     private static final Logger LOG = LogManager.getLogger(ResourceGroupMetricMgr.class);
 
     private static final String QUERY_RESOURCE_GROUP = "query_resource_group";
+    private static final String QUERY_RESOURCE_GROUP_LATENCY = "query_resource_group_latency";
 
     private static final ConcurrentHashMap<String, LongCounterMetric> RESOURCE_GROUP_QUERY_COUNTER_MAP
+            = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<String, List<GaugeMetricImpl>> RESOURCE_GROUP_QUERY_LATENCY_MAP
             = new ConcurrentHashMap<>();
 
     //starrocks_fe_query_resource_group
@@ -61,5 +70,125 @@ public class ResourceGroupMetricMgr {
             }
         }
         RESOURCE_GROUP_QUERY_COUNTER_MAP.get(resourceGroupName).increase(num);
+    }
+
+    public static void updateQueryLatency(List<QueryDetail> queryList) {
+        Map<String, List<Long>> latencyMap = new HashMap<>();
+        Map<String, Long> latencySumMap = new HashMap<>();
+        for (QueryDetail queryDetail : queryList) {
+            String workGroupName = queryDetail.getWorkGroupName();
+            if (queryDetail.isQuery()
+                    && queryDetail.getState() == QueryDetail.QueryMemState.FINISHED
+                    && workGroupName != null
+                    && !workGroupName.isEmpty()) {
+                if(!latencyMap.containsKey(workGroupName)) {
+                    latencyMap.put(workGroupName, new ArrayList<>());
+                    latencySumMap.put(workGroupName, 0L);
+                }
+                latencyMap.get(workGroupName).add(queryDetail.getLatency());
+                latencySumMap.put(workGroupName, latencySumMap.get(workGroupName) + queryDetail.getLatency());
+            }
+        }
+        for(String resourceGroupName : latencyMap.keySet()){
+            List<Long> latencyList = latencyMap.get(resourceGroupName);
+            Long latencySum = latencySumMap.get(resourceGroupName);
+
+            if(!RESOURCE_GROUP_QUERY_LATENCY_MAP.containsKey(resourceGroupName)) {
+                createQueryResourceGroupLatency(resourceGroupName);
+            }
+            List<GaugeMetricImpl> metricList = RESOURCE_GROUP_QUERY_LATENCY_MAP.get(resourceGroupName);
+            if (latencyList.size() > 0) {
+                metricList.get(0).setValue(latencySum / latencyList.size());
+
+                latencyList.sort(Comparator.naturalOrder());
+
+                int index = (int) Math.round((latencyList.size() - 1) * 0.5);
+                metricList.get(1).setValue((double) latencyList.get(index));
+                index = (int) Math.round((latencyList.size() - 1) * 0.75);
+                metricList.get(2).setValue((double) latencyList.get(index));
+                index = (int) Math.round((latencyList.size() - 1) * 0.90);
+                metricList.get(3).setValue((double) latencyList.get(index));
+                index = (int) Math.round((latencyList.size() - 1) * 0.95);
+                metricList.get(4).setValue((double) latencyList.get(index));
+                index = (int) Math.round((latencyList.size() - 1) * 0.99);
+                metricList.get(5).setValue((double) latencyList.get(index));
+                index = (int) Math.round((latencyList.size() - 1) * 0.999);
+                metricList.get(6).setValue((double) latencyList.get(index));
+            } else {
+                metricList.get(0).setValue(0.0);
+                metricList.get(1).setValue(0.0);
+                metricList.get(2).setValue(0.0);
+                metricList.get(3).setValue(0.0);
+                metricList.get(4).setValue(0.0);
+                metricList.get(5).setValue(0.0);
+                metricList.get(6).setValue(0.0);
+            }
+        }
+    }
+
+    private static void createQueryResourceGroupLatency(String resourceGroupName) {
+        if(RESOURCE_GROUP_QUERY_LATENCY_MAP.containsKey(resourceGroupName)) {
+            return;
+        }else {
+            GaugeMetricImpl metricMean =
+                    new GaugeMetricImpl<>(QUERY_RESOURCE_GROUP_LATENCY, Metric.MetricUnit.MILLISECONDS, "mean of resource group query latency");
+            metricMean.addLabel(new MetricLabel("type", "mean"));
+            metricMean.addLabel(new MetricLabel("name", resourceGroupName));
+            metricMean.setValue(0.0);
+            MetricRepo.addMetric(metricMean);
+
+            GaugeMetricImpl metric50Quantile =
+                    new GaugeMetricImpl<>(QUERY_RESOURCE_GROUP_LATENCY, Metric.MetricUnit.MILLISECONDS, "median of resource group query latency");
+            metric50Quantile.addLabel(new MetricLabel("type", "50_quantile"));
+            metric50Quantile.addLabel(new MetricLabel("name", resourceGroupName));
+            metric50Quantile.setValue(0.0);
+            MetricRepo.addMetric(metric50Quantile);
+
+            GaugeMetricImpl metric75Quantile =
+                    new GaugeMetricImpl<>(QUERY_RESOURCE_GROUP_LATENCY, Metric.MetricUnit.MILLISECONDS, "p75 of resource group query latency");
+            metric75Quantile.addLabel(new MetricLabel("type", "75_quantile"));
+            metric75Quantile.addLabel(new MetricLabel("name", resourceGroupName));
+            metric75Quantile.setValue(0.0);
+            MetricRepo.addMetric(metric75Quantile);
+
+            GaugeMetricImpl metric90Quantile =
+                    new GaugeMetricImpl<>(QUERY_RESOURCE_GROUP_LATENCY, Metric.MetricUnit.MILLISECONDS, "p90 of resource group query latency");
+            metric90Quantile.addLabel(new MetricLabel("type", "90_quantile"));
+            metric90Quantile.addLabel(new MetricLabel("name", resourceGroupName));
+            metric90Quantile.setValue(0.0);
+            MetricRepo.addMetric(metric90Quantile);
+
+            GaugeMetricImpl metric95Quantile =
+                    new GaugeMetricImpl<>(QUERY_RESOURCE_GROUP_LATENCY, Metric.MetricUnit.MILLISECONDS, "p95 of resource group query latency");
+            metric95Quantile.addLabel(new MetricLabel("type", "95_quantile"));
+            metric95Quantile.addLabel(new MetricLabel("name", resourceGroupName));
+            metric95Quantile.setValue(0.0);
+            MetricRepo.addMetric(metric95Quantile);
+
+            GaugeMetricImpl metric99Quantile =
+                    new GaugeMetricImpl<>(QUERY_RESOURCE_GROUP_LATENCY, Metric.MetricUnit.MILLISECONDS, "p99 of resource group query latency");
+            metric99Quantile.addLabel(new MetricLabel("type", "99_quantile"));
+            metric99Quantile.addLabel(new MetricLabel("name", resourceGroupName));
+            metric99Quantile.setValue(0.0);
+            MetricRepo.addMetric(metric99Quantile);
+
+            GaugeMetricImpl metric999Quantile =
+                    new GaugeMetricImpl<>(QUERY_RESOURCE_GROUP_LATENCY, Metric.MetricUnit.MILLISECONDS, "p999 of resource group query latency");
+            metric999Quantile.addLabel(new MetricLabel("type", "999_quantile"));
+            metric999Quantile.addLabel(new MetricLabel("name", resourceGroupName));
+            metric999Quantile.setValue(0.0);
+            MetricRepo.addMetric(metric999Quantile);
+
+            List<GaugeMetricImpl> metricList = new ArrayList<>();
+            metricList.add(metricMean);
+            metricList.add(metric50Quantile);
+            metricList.add(metric75Quantile);
+            metricList.add(metric90Quantile);
+            metricList.add(metric95Quantile);
+            metricList.add(metric99Quantile);
+            metricList.add(metric999Quantile);
+
+            RESOURCE_GROUP_QUERY_LATENCY_MAP.put(resourceGroupName, metricList);
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/metric/ResourceGroupMetricMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/ResourceGroupMetricMgr.java
@@ -52,19 +52,20 @@ public class ResourceGroupMetricMgr {
     //starrocks_fe_query_resource_group
     public static void increaseQuery(ConnectContext ctx, Long num) {
         SessionVariable sessionVariable = ctx.getSessionVariable();
-        if(!sessionVariable.isEnableResourceGroup()) {
+        if (!sessionVariable.isEnableResourceGroup()) {
             return;
         }
         WorkGroup workGroup = ctx.getWorkGroup();
-        if(workGroup == null) {
+        if (workGroup == null) {
             LOG.warn("The resource group for calculating query metrics is empty");
             return;
         }
         String resourceGroupName = workGroup.getName();
-        if(!RESOURCE_GROUP_QUERY_COUNTER_MAP.containsKey(resourceGroupName)) {
+        if (!RESOURCE_GROUP_QUERY_COUNTER_MAP.containsKey(resourceGroupName)) {
             synchronized (RESOURCE_GROUP_QUERY_COUNTER_MAP) {
-                if(!RESOURCE_GROUP_QUERY_COUNTER_MAP.containsKey(resourceGroupName)){
-                    LongCounterMetric metric = new LongCounterMetric(QUERY_RESOURCE_GROUP, Metric.MetricUnit.REQUESTS, "query resource group");
+                if (!RESOURCE_GROUP_QUERY_COUNTER_MAP.containsKey(resourceGroupName)) {
+                    LongCounterMetric metric = new LongCounterMetric(QUERY_RESOURCE_GROUP, Metric.MetricUnit.REQUESTS,
+                            "query resource group");
                     metric.addLabel(new MetricLabel("name", resourceGroupName));
                     RESOURCE_GROUP_QUERY_COUNTER_MAP.put(resourceGroupName, metric);
                     MetricRepo.addMetric(metric);
@@ -77,19 +78,21 @@ public class ResourceGroupMetricMgr {
 
     public static void increaseQueryErr(ConnectContext ctx, Long num) {
         SessionVariable sessionVariable = ctx.getSessionVariable();
-        if(!sessionVariable.isEnableResourceGroup()) {
+        if (!sessionVariable.isEnableResourceGroup()) {
             return;
         }
         WorkGroup workGroup = ctx.getWorkGroup();
-        if(workGroup == null) {
+        if (workGroup == null) {
             LOG.warn("The resource group for calculating query error metrics is empty");
             return;
         }
         String resourceGroupName = workGroup.getName();
-        if(!RESOURCE_GROUP_QUERY_ERR_COUNTER_MAP.containsKey(resourceGroupName)) {
+        if (!RESOURCE_GROUP_QUERY_ERR_COUNTER_MAP.containsKey(resourceGroupName)) {
             synchronized (RESOURCE_GROUP_QUERY_ERR_COUNTER_MAP) {
-                if(!RESOURCE_GROUP_QUERY_ERR_COUNTER_MAP.containsKey(resourceGroupName)){
-                    LongCounterMetric metric = new LongCounterMetric(QUERY_RESOURCE_GROUP_ERR, Metric.MetricUnit.REQUESTS, "query err resource group");
+                if (!RESOURCE_GROUP_QUERY_ERR_COUNTER_MAP.containsKey(resourceGroupName)) {
+                    LongCounterMetric metric =
+                            new LongCounterMetric(QUERY_RESOURCE_GROUP_ERR, Metric.MetricUnit.REQUESTS,
+                                    "query err resource group");
                     metric.addLabel(new MetricLabel("name", resourceGroupName));
                     RESOURCE_GROUP_QUERY_ERR_COUNTER_MAP.put(resourceGroupName, metric);
                     MetricRepo.addMetric(metric);
@@ -109,7 +112,7 @@ public class ResourceGroupMetricMgr {
                     && queryDetail.getState() == QueryDetail.QueryMemState.FINISHED
                     && workGroupName != null
                     && !workGroupName.isEmpty()) {
-                if(!latencyMap.containsKey(workGroupName)) {
+                if (!latencyMap.containsKey(workGroupName)) {
                     latencyMap.put(workGroupName, new ArrayList<>());
                     latencySumMap.put(workGroupName, 0L);
                 }
@@ -117,11 +120,11 @@ public class ResourceGroupMetricMgr {
                 latencySumMap.put(workGroupName, latencySumMap.get(workGroupName) + queryDetail.getLatency());
             }
         }
-        for(String resourceGroupName : latencyMap.keySet()){
+        for (String resourceGroupName : latencyMap.keySet()) {
             List<Long> latencyList = latencyMap.get(resourceGroupName);
             Long latencySum = latencySumMap.get(resourceGroupName);
 
-            if(!RESOURCE_GROUP_QUERY_LATENCY_MAP.containsKey(resourceGroupName)) {
+            if (!RESOURCE_GROUP_QUERY_LATENCY_MAP.containsKey(resourceGroupName)) {
                 createQueryResourceGroupLatency(resourceGroupName);
             }
             List<GaugeMetricImpl> metricList = RESOURCE_GROUP_QUERY_LATENCY_MAP.get(resourceGroupName);
@@ -155,53 +158,60 @@ public class ResourceGroupMetricMgr {
     }
 
     private static void createQueryResourceGroupLatency(String resourceGroupName) {
-        if(RESOURCE_GROUP_QUERY_LATENCY_MAP.containsKey(resourceGroupName)) {
+        if (RESOURCE_GROUP_QUERY_LATENCY_MAP.containsKey(resourceGroupName)) {
             return;
-        }else {
+        } else {
             GaugeMetricImpl metricMean =
-                    new GaugeMetricImpl<>(QUERY_RESOURCE_GROUP_LATENCY, Metric.MetricUnit.MILLISECONDS, "mean of resource group query latency");
+                    new GaugeMetricImpl<>(QUERY_RESOURCE_GROUP_LATENCY, Metric.MetricUnit.MILLISECONDS,
+                            "mean of resource group query latency");
             metricMean.addLabel(new MetricLabel("type", "mean"));
             metricMean.addLabel(new MetricLabel("name", resourceGroupName));
             metricMean.setValue(0.0);
             MetricRepo.addMetric(metricMean);
 
             GaugeMetricImpl metric50Quantile =
-                    new GaugeMetricImpl<>(QUERY_RESOURCE_GROUP_LATENCY, Metric.MetricUnit.MILLISECONDS, "median of resource group query latency");
+                    new GaugeMetricImpl<>(QUERY_RESOURCE_GROUP_LATENCY, Metric.MetricUnit.MILLISECONDS,
+                            "median of resource group query latency");
             metric50Quantile.addLabel(new MetricLabel("type", "50_quantile"));
             metric50Quantile.addLabel(new MetricLabel("name", resourceGroupName));
             metric50Quantile.setValue(0.0);
             MetricRepo.addMetric(metric50Quantile);
 
             GaugeMetricImpl metric75Quantile =
-                    new GaugeMetricImpl<>(QUERY_RESOURCE_GROUP_LATENCY, Metric.MetricUnit.MILLISECONDS, "p75 of resource group query latency");
+                    new GaugeMetricImpl<>(QUERY_RESOURCE_GROUP_LATENCY, Metric.MetricUnit.MILLISECONDS,
+                            "p75 of resource group query latency");
             metric75Quantile.addLabel(new MetricLabel("type", "75_quantile"));
             metric75Quantile.addLabel(new MetricLabel("name", resourceGroupName));
             metric75Quantile.setValue(0.0);
             MetricRepo.addMetric(metric75Quantile);
 
             GaugeMetricImpl metric90Quantile =
-                    new GaugeMetricImpl<>(QUERY_RESOURCE_GROUP_LATENCY, Metric.MetricUnit.MILLISECONDS, "p90 of resource group query latency");
+                    new GaugeMetricImpl<>(QUERY_RESOURCE_GROUP_LATENCY, Metric.MetricUnit.MILLISECONDS,
+                            "p90 of resource group query latency");
             metric90Quantile.addLabel(new MetricLabel("type", "90_quantile"));
             metric90Quantile.addLabel(new MetricLabel("name", resourceGroupName));
             metric90Quantile.setValue(0.0);
             MetricRepo.addMetric(metric90Quantile);
 
             GaugeMetricImpl metric95Quantile =
-                    new GaugeMetricImpl<>(QUERY_RESOURCE_GROUP_LATENCY, Metric.MetricUnit.MILLISECONDS, "p95 of resource group query latency");
+                    new GaugeMetricImpl<>(QUERY_RESOURCE_GROUP_LATENCY, Metric.MetricUnit.MILLISECONDS,
+                            "p95 of resource group query latency");
             metric95Quantile.addLabel(new MetricLabel("type", "95_quantile"));
             metric95Quantile.addLabel(new MetricLabel("name", resourceGroupName));
             metric95Quantile.setValue(0.0);
             MetricRepo.addMetric(metric95Quantile);
 
             GaugeMetricImpl metric99Quantile =
-                    new GaugeMetricImpl<>(QUERY_RESOURCE_GROUP_LATENCY, Metric.MetricUnit.MILLISECONDS, "p99 of resource group query latency");
+                    new GaugeMetricImpl<>(QUERY_RESOURCE_GROUP_LATENCY, Metric.MetricUnit.MILLISECONDS,
+                            "p99 of resource group query latency");
             metric99Quantile.addLabel(new MetricLabel("type", "99_quantile"));
             metric99Quantile.addLabel(new MetricLabel("name", resourceGroupName));
             metric99Quantile.setValue(0.0);
             MetricRepo.addMetric(metric99Quantile);
 
             GaugeMetricImpl metric999Quantile =
-                    new GaugeMetricImpl<>(QUERY_RESOURCE_GROUP_LATENCY, Metric.MetricUnit.MILLISECONDS, "p999 of resource group query latency");
+                    new GaugeMetricImpl<>(QUERY_RESOURCE_GROUP_LATENCY, Metric.MetricUnit.MILLISECONDS,
+                            "p999 of resource group query latency");
             metric999Quantile.addLabel(new MetricLabel("type", "999_quantile"));
             metric999Quantile.addLabel(new MetricLabel("name", resourceGroupName));
             metric999Quantile.setValue(0.0);

--- a/fe/fe-core/src/main/java/com/starrocks/metric/ResourceGroupMetricMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/ResourceGroupMetricMgr.java
@@ -1,0 +1,65 @@
+// This file is made available under Elastic License 2.0.
+// This file is based on code available under the Apache license here:
+//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/metric/MetricRepo.java
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.metric;
+
+import com.starrocks.catalog.WorkGroup;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SessionVariable;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+public class ResourceGroupMetricMgr {
+    private static final Logger LOG = LogManager.getLogger(ResourceGroupMetricMgr.class);
+
+    private static final String QUERY_RESOURCE_GROUP = "query_resource_group";
+
+    private static final ConcurrentHashMap<String, LongCounterMetric> RESOURCE_GROUP_QUERY_COUNTER_MAP
+            = new ConcurrentHashMap<>();
+
+    //starrocks_fe_query_resource_group
+    public static void increaseQuery(ConnectContext ctx, Long num) {
+        SessionVariable sessionVariable = ctx.getSessionVariable();
+        if(!sessionVariable.isEnableResourceGroup()) {
+            return;
+        }
+        WorkGroup workGroup = ctx.getWorkGroup();
+        if(workGroup == null) {
+            LOG.warn("The resource group for calculating query metrics is empty");
+            return;
+        }
+        String resourceGroupName = workGroup.getName();
+        if(!RESOURCE_GROUP_QUERY_COUNTER_MAP.containsKey(resourceGroupName)) {
+            synchronized (RESOURCE_GROUP_QUERY_COUNTER_MAP) {
+                if(!RESOURCE_GROUP_QUERY_COUNTER_MAP.containsKey(resourceGroupName)){
+                    LongCounterMetric metric = new LongCounterMetric(QUERY_RESOURCE_GROUP, Metric.MetricUnit.REQUESTS, "query resource group");
+                    metric.addLabel(new MetricLabel("name", resourceGroupName));
+                    RESOURCE_GROUP_QUERY_COUNTER_MAP.put(resourceGroupName, metric);
+                    MetricRepo.addMetric(metric);
+                    LOG.info("Add {} metric, resource group name is {}", QUERY_RESOURCE_GROUP, resourceGroupName);
+                }
+            }
+        }
+        RESOURCE_GROUP_QUERY_COUNTER_MAP.get(resourceGroupName).increase(num);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/metric/ResourceGroupMetricMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/ResourceGroupMetricMgr.java
@@ -1,0 +1,232 @@
+// This file is made available under Elastic License 2.0.
+// This file is based on code available under the Apache license here:
+//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/metric/MetricRepo.java
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.metric;
+
+import com.starrocks.catalog.WorkGroup;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.QueryDetail;
+import com.starrocks.qe.SessionVariable;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class ResourceGroupMetricMgr {
+    private static final Logger LOG = LogManager.getLogger(ResourceGroupMetricMgr.class);
+
+    private static final String QUERY_RESOURCE_GROUP = "query_resource_group";
+    private static final String QUERY_RESOURCE_GROUP_LATENCY = "query_resource_group_latency";
+    private static final String QUERY_RESOURCE_GROUP_ERR = "query_resource_group_err";
+
+    private static final ConcurrentHashMap<String, LongCounterMetric> RESOURCE_GROUP_QUERY_COUNTER_MAP
+            = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<String, List<GaugeMetricImpl>> RESOURCE_GROUP_QUERY_LATENCY_MAP
+            = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<String, LongCounterMetric> RESOURCE_GROUP_QUERY_ERR_COUNTER_MAP
+            = new ConcurrentHashMap<>();
+
+    //starrocks_fe_query_resource_group
+    public static void increaseQuery(ConnectContext ctx, Long num) {
+        SessionVariable sessionVariable = ctx.getSessionVariable();
+        if (!sessionVariable.isEnableResourceGroup()) {
+            return;
+        }
+        WorkGroup workGroup = ctx.getWorkGroup();
+        if (workGroup == null) {
+            LOG.warn("The resource group for calculating query metrics is empty");
+            return;
+        }
+        String resourceGroupName = workGroup.getName();
+        if (!RESOURCE_GROUP_QUERY_COUNTER_MAP.containsKey(resourceGroupName)) {
+            synchronized (RESOURCE_GROUP_QUERY_COUNTER_MAP) {
+                if (!RESOURCE_GROUP_QUERY_COUNTER_MAP.containsKey(resourceGroupName)) {
+                    LongCounterMetric metric = new LongCounterMetric(QUERY_RESOURCE_GROUP, Metric.MetricUnit.REQUESTS,
+                            "query resource group");
+                    metric.addLabel(new MetricLabel("name", resourceGroupName));
+                    RESOURCE_GROUP_QUERY_COUNTER_MAP.put(resourceGroupName, metric);
+                    MetricRepo.addMetric(metric);
+                    LOG.info("Add {} metric, resource group name is {}", QUERY_RESOURCE_GROUP, resourceGroupName);
+                }
+            }
+        }
+        RESOURCE_GROUP_QUERY_COUNTER_MAP.get(resourceGroupName).increase(num);
+    }
+
+    public static void increaseQueryErr(ConnectContext ctx, Long num) {
+        SessionVariable sessionVariable = ctx.getSessionVariable();
+        if (!sessionVariable.isEnableResourceGroup()) {
+            return;
+        }
+        WorkGroup workGroup = ctx.getWorkGroup();
+        if (workGroup == null) {
+            LOG.warn("The resource group for calculating query error metrics is empty");
+            return;
+        }
+        String resourceGroupName = workGroup.getName();
+        if (!RESOURCE_GROUP_QUERY_ERR_COUNTER_MAP.containsKey(resourceGroupName)) {
+            synchronized (RESOURCE_GROUP_QUERY_ERR_COUNTER_MAP) {
+                if (!RESOURCE_GROUP_QUERY_ERR_COUNTER_MAP.containsKey(resourceGroupName)) {
+                    LongCounterMetric metric =
+                            new LongCounterMetric(QUERY_RESOURCE_GROUP_ERR, Metric.MetricUnit.REQUESTS,
+                                    "query err resource group");
+                    metric.addLabel(new MetricLabel("name", resourceGroupName));
+                    RESOURCE_GROUP_QUERY_ERR_COUNTER_MAP.put(resourceGroupName, metric);
+                    MetricRepo.addMetric(metric);
+                    LOG.info("Add {} metric, resource group name is {}", QUERY_RESOURCE_GROUP_ERR, resourceGroupName);
+                }
+            }
+        }
+        RESOURCE_GROUP_QUERY_ERR_COUNTER_MAP.get(resourceGroupName).increase(num);
+    }
+
+    public static void updateQueryLatency(List<QueryDetail> queryList) {
+        Map<String, List<Long>> latencyMap = new HashMap<>();
+        Map<String, Long> latencySumMap = new HashMap<>();
+        for (QueryDetail queryDetail : queryList) {
+            String workGroupName = queryDetail.getWorkGroupName();
+            if (queryDetail.isQuery()
+                    && queryDetail.getState() == QueryDetail.QueryMemState.FINISHED
+                    && workGroupName != null
+                    && !workGroupName.isEmpty()) {
+                if (!latencyMap.containsKey(workGroupName)) {
+                    latencyMap.put(workGroupName, new ArrayList<>());
+                    latencySumMap.put(workGroupName, 0L);
+                }
+                latencyMap.get(workGroupName).add(queryDetail.getLatency());
+                latencySumMap.put(workGroupName, latencySumMap.get(workGroupName) + queryDetail.getLatency());
+            }
+        }
+        for (String resourceGroupName : latencyMap.keySet()) {
+            List<Long> latencyList = latencyMap.get(resourceGroupName);
+            Long latencySum = latencySumMap.get(resourceGroupName);
+
+            if (!RESOURCE_GROUP_QUERY_LATENCY_MAP.containsKey(resourceGroupName)) {
+                createQueryResourceGroupLatency(resourceGroupName);
+            }
+            List<GaugeMetricImpl> metricList = RESOURCE_GROUP_QUERY_LATENCY_MAP.get(resourceGroupName);
+            if (latencyList.size() > 0) {
+                metricList.get(0).setValue(latencySum / latencyList.size());
+
+                latencyList.sort(Comparator.naturalOrder());
+
+                int index = (int) Math.round((latencyList.size() - 1) * 0.5);
+                metricList.get(1).setValue((double) latencyList.get(index));
+                index = (int) Math.round((latencyList.size() - 1) * 0.75);
+                metricList.get(2).setValue((double) latencyList.get(index));
+                index = (int) Math.round((latencyList.size() - 1) * 0.90);
+                metricList.get(3).setValue((double) latencyList.get(index));
+                index = (int) Math.round((latencyList.size() - 1) * 0.95);
+                metricList.get(4).setValue((double) latencyList.get(index));
+                index = (int) Math.round((latencyList.size() - 1) * 0.99);
+                metricList.get(5).setValue((double) latencyList.get(index));
+                index = (int) Math.round((latencyList.size() - 1) * 0.999);
+                metricList.get(6).setValue((double) latencyList.get(index));
+            } else {
+                metricList.get(0).setValue(0.0);
+                metricList.get(1).setValue(0.0);
+                metricList.get(2).setValue(0.0);
+                metricList.get(3).setValue(0.0);
+                metricList.get(4).setValue(0.0);
+                metricList.get(5).setValue(0.0);
+                metricList.get(6).setValue(0.0);
+            }
+        }
+    }
+
+    private static void createQueryResourceGroupLatency(String resourceGroupName) {
+        if (RESOURCE_GROUP_QUERY_LATENCY_MAP.containsKey(resourceGroupName)) {
+            return;
+        } else {
+            GaugeMetricImpl metricMean =
+                    new GaugeMetricImpl<>(QUERY_RESOURCE_GROUP_LATENCY, Metric.MetricUnit.MILLISECONDS,
+                            "mean of resource group query latency");
+            metricMean.addLabel(new MetricLabel("type", "mean"));
+            metricMean.addLabel(new MetricLabel("name", resourceGroupName));
+            metricMean.setValue(0.0);
+            MetricRepo.addMetric(metricMean);
+
+            GaugeMetricImpl metric50Quantile =
+                    new GaugeMetricImpl<>(QUERY_RESOURCE_GROUP_LATENCY, Metric.MetricUnit.MILLISECONDS,
+                            "median of resource group query latency");
+            metric50Quantile.addLabel(new MetricLabel("type", "50_quantile"));
+            metric50Quantile.addLabel(new MetricLabel("name", resourceGroupName));
+            metric50Quantile.setValue(0.0);
+            MetricRepo.addMetric(metric50Quantile);
+
+            GaugeMetricImpl metric75Quantile =
+                    new GaugeMetricImpl<>(QUERY_RESOURCE_GROUP_LATENCY, Metric.MetricUnit.MILLISECONDS,
+                            "p75 of resource group query latency");
+            metric75Quantile.addLabel(new MetricLabel("type", "75_quantile"));
+            metric75Quantile.addLabel(new MetricLabel("name", resourceGroupName));
+            metric75Quantile.setValue(0.0);
+            MetricRepo.addMetric(metric75Quantile);
+
+            GaugeMetricImpl metric90Quantile =
+                    new GaugeMetricImpl<>(QUERY_RESOURCE_GROUP_LATENCY, Metric.MetricUnit.MILLISECONDS,
+                            "p90 of resource group query latency");
+            metric90Quantile.addLabel(new MetricLabel("type", "90_quantile"));
+            metric90Quantile.addLabel(new MetricLabel("name", resourceGroupName));
+            metric90Quantile.setValue(0.0);
+            MetricRepo.addMetric(metric90Quantile);
+
+            GaugeMetricImpl metric95Quantile =
+                    new GaugeMetricImpl<>(QUERY_RESOURCE_GROUP_LATENCY, Metric.MetricUnit.MILLISECONDS,
+                            "p95 of resource group query latency");
+            metric95Quantile.addLabel(new MetricLabel("type", "95_quantile"));
+            metric95Quantile.addLabel(new MetricLabel("name", resourceGroupName));
+            metric95Quantile.setValue(0.0);
+            MetricRepo.addMetric(metric95Quantile);
+
+            GaugeMetricImpl metric99Quantile =
+                    new GaugeMetricImpl<>(QUERY_RESOURCE_GROUP_LATENCY, Metric.MetricUnit.MILLISECONDS,
+                            "p99 of resource group query latency");
+            metric99Quantile.addLabel(new MetricLabel("type", "99_quantile"));
+            metric99Quantile.addLabel(new MetricLabel("name", resourceGroupName));
+            metric99Quantile.setValue(0.0);
+            MetricRepo.addMetric(metric99Quantile);
+
+            GaugeMetricImpl metric999Quantile =
+                    new GaugeMetricImpl<>(QUERY_RESOURCE_GROUP_LATENCY, Metric.MetricUnit.MILLISECONDS,
+                            "p999 of resource group query latency");
+            metric999Quantile.addLabel(new MetricLabel("type", "999_quantile"));
+            metric999Quantile.addLabel(new MetricLabel("name", resourceGroupName));
+            metric999Quantile.setValue(0.0);
+            MetricRepo.addMetric(metric999Quantile);
+
+            List<GaugeMetricImpl> metricList = new ArrayList<>();
+            metricList.add(metricMean);
+            metricList.add(metric50Quantile);
+            metricList.add(metric75Quantile);
+            metricList.add(metric90Quantile);
+            metricList.add(metric95Quantile);
+            metricList.add(metric99Quantile);
+            metricList.add(metric999Quantile);
+
+            RESOURCE_GROUP_QUERY_LATENCY_MAP.put(resourceGroupName, metricList);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
@@ -63,6 +63,8 @@ public class AuditEvent {
     public String db = "";
     @AuditField(value = "State")
     public String state = "";
+    @AuditField(value = "ErrorCode")
+    public String errorCode = "";
     @AuditField(value = "Time")
     public long queryTime = -1;
     @AuditField(value = "ScanBytes")
@@ -127,6 +129,11 @@ public class AuditEvent {
 
         public AuditEventBuilder setState(String state) {
             auditEvent.state = state;
+            return this;
+        }
+
+        public AuditEventBuilder setErrorCode(String errorCode) {
+            auditEvent.errorCode = errorCode;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
@@ -57,6 +57,8 @@ public class AuditEvent {
     public String clientIp = "";
     @AuditField(value = "User")
     public String user = "";
+    @AuditField(value = "ResourceGroup")
+    public String resourceGroup = "";
     @AuditField(value = "Db")
     public String db = "";
     @AuditField(value = "State")
@@ -110,6 +112,11 @@ public class AuditEvent {
 
         public AuditEventBuilder setUser(String user) {
             auditEvent.user = user;
+            return this;
+        }
+
+        public AuditEventBuilder setResourceGroup(String resourceGroup) {
+            auditEvent.resourceGroup = resourceGroup;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
@@ -58,7 +58,7 @@ public class AuditEvent {
     @AuditField(value = "User")
     public String user = "";
     @AuditField(value = "ResourceGroup")
-    public String resourceGroup = "";
+    public String resourceGroup = "default_wg";
     @AuditField(value = "Db")
     public String db = "";
     @AuditField(value = "State")

--- a/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
@@ -57,10 +57,14 @@ public class AuditEvent {
     public String clientIp = "";
     @AuditField(value = "User")
     public String user = "";
+    @AuditField(value = "ResourceGroup")
+    public String resourceGroup = "default_wg";
     @AuditField(value = "Db")
     public String db = "";
     @AuditField(value = "State")
     public String state = "";
+    @AuditField(value = "ErrorCode")
+    public String errorCode = "";
     @AuditField(value = "Time")
     public long queryTime = -1;
     @AuditField(value = "ScanBytes")
@@ -113,6 +117,11 @@ public class AuditEvent {
             return this;
         }
 
+        public AuditEventBuilder setResourceGroup(String resourceGroup) {
+            auditEvent.resourceGroup = resourceGroup;
+            return this;
+        }
+
         public AuditEventBuilder setDb(String db) {
             auditEvent.db = db;
             return this;
@@ -120,6 +129,11 @@ public class AuditEvent {
 
         public AuditEventBuilder setState(String state) {
             auditEvent.state = state;
+            return this;
+        }
+
+        public AuditEventBuilder setErrorCode(String errorCode) {
+            auditEvent.errorCode = errorCode;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.starrocks.analysis.UserIdentity;
 import com.starrocks.catalog.Catalog;
+import com.starrocks.catalog.WorkGroup;
 import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.mysql.MysqlCapability;
 import com.starrocks.mysql.MysqlChannel;
@@ -75,8 +76,13 @@ public class ConnectContext {
     // mysql net
     protected volatile MysqlChannel mysqlChannel;
     // state
+
     protected volatile QueryState state;
     protected volatile long returnRows;
+
+    // error code
+    protected String errorCode = "";
+
     // the protocol capability which server say it can support
     protected volatile MysqlCapability serverCapability;
     // the protocol capability after server and client negotiate
@@ -135,6 +141,8 @@ public class ConnectContext {
 
     // The related db ids for current sql
     protected Set<Long> currentSqlDbIds = Sets.newHashSet();
+
+    protected WorkGroup workGroup;
 
     public static ConnectContext get() {
         return threadLocalInfo.get();
@@ -328,6 +336,14 @@ public class ConnectContext {
         this.state = state;
     }
 
+    public String getErrorCode() {
+        return errorCode;
+    }
+
+    public void setErrorCode(String errorCode) {
+        this.errorCode = errorCode;
+    }
+
     public MysqlCapability getCapability() {
         return capability;
     }
@@ -437,6 +453,14 @@ public class ConnectContext {
 
     public void setCurrentSqlDbIds(Set<Long> currentSqlDbIds) {
         this.currentSqlDbIds = currentSqlDbIds;
+    }
+
+    public WorkGroup getWorkGroup() {
+        return workGroup;
+    }
+
+    public void setWorkGroup(WorkGroup workGroup) {
+        this.workGroup = workGroup;
     }
 
     // kill operation with no protect.

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -76,8 +76,15 @@ public class ConnectContext {
     // mysql net
     protected volatile MysqlChannel mysqlChannel;
     // state
+
     protected volatile QueryState state;
     protected volatile long returnRows;
+
+    protected QueryState state;
+    // error code
+    protected String errorCode;
+    protected long returnRows;
+
     // the protocol capability which server say it can support
     protected volatile MysqlCapability serverCapability;
     // the protocol capability after server and client negotiate
@@ -331,6 +338,14 @@ public class ConnectContext {
 
     public void setState(QueryState state) {
         this.state = state;
+    }
+
+    public String getErrorCode() {
+        return errorCode;
+    }
+
+    public void setErrorCode(String errorCode) {
+        this.errorCode = errorCode;
     }
 
     public MysqlCapability getCapability() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -80,10 +80,8 @@ public class ConnectContext {
     protected volatile QueryState state;
     protected volatile long returnRows;
 
-    protected QueryState state;
     // error code
-    protected String errorCode;
-    protected long returnRows;
+    protected String errorCode = "";
 
     // the protocol capability which server say it can support
     protected volatile MysqlCapability serverCapability;
@@ -143,8 +141,6 @@ public class ConnectContext {
 
     // The related db ids for current sql
     protected Set<Long> currentSqlDbIds = Sets.newHashSet();
-
-    protected PlannerProfile plannerProfile;
 
     protected WorkGroup workGroup;
 
@@ -457,10 +453,6 @@ public class ConnectContext {
 
     public void setCurrentSqlDbIds(Set<Long> currentSqlDbIds) {
         this.currentSqlDbIds = currentSqlDbIds;
-    }
-
-    public PlannerProfile getPlannerProfile() {
-        return plannerProfile;
     }
 
     public WorkGroup getWorkGroup() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.starrocks.analysis.UserIdentity;
 import com.starrocks.catalog.Catalog;
+import com.starrocks.catalog.WorkGroup;
 import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.mysql.MysqlCapability;
 import com.starrocks.mysql.MysqlChannel;
@@ -135,6 +136,10 @@ public class ConnectContext {
 
     // The related db ids for current sql
     protected Set<Long> currentSqlDbIds = Sets.newHashSet();
+
+    protected PlannerProfile plannerProfile;
+
+    protected WorkGroup workGroup;
 
     public static ConnectContext get() {
         return threadLocalInfo.get();
@@ -437,6 +442,18 @@ public class ConnectContext {
 
     public void setCurrentSqlDbIds(Set<Long> currentSqlDbIds) {
         this.currentSqlDbIds = currentSqlDbIds;
+    }
+
+    public PlannerProfile getPlannerProfile() {
+        return plannerProfile;
+    }
+
+    public WorkGroup getWorkGroup() {
+        return workGroup;
+    }
+
+    public void setWorkGroup(WorkGroup workGroup) {
+        this.workGroup = workGroup;
     }
 
     // kill operation with no protect.

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -144,7 +144,7 @@ public class ConnectProcessor {
         long elapseMs = endTime - ctx.getStartTime();
 
         ctx.getAuditEventBuilder().setEventType(EventType.AFTER_QUERY)
-                .setState(ctx.getState().toString()).setQueryTime(elapseMs)
+                .setState(ctx.getState().toString()).setErrorCode(ctx.getErrorCode()).setQueryTime(elapseMs)
                 .setScanBytes(statistics == null ? 0 : statistics.scanBytes)
                 .setScanRows(statistics == null ? 0 : statistics.scanRows)
                 .setReturnRows(ctx.getReturnRows())
@@ -157,6 +157,7 @@ public class ConnectProcessor {
             if (ctx.getState().getStateType() == QueryState.MysqlStateType.ERR) {
                 // err query
                 MetricRepo.COUNTER_QUERY_ERR.increase(1L);
+                ResourceGroupMetricMgr.increaseQueryErr(ctx, 1L);
             } else {
                 // ok query
                 MetricRepo.COUNTER_QUERY_SUCCESS.increase(1L);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -227,6 +227,7 @@ public class ConnectProcessor {
         }
         queryDetail.setEndTime(endTime);
         queryDetail.setLatency(elapseMs);
+        queryDetail.setWorkGroupName(ctx.getWorkGroup() != null ? ctx.getWorkGroup().getName() : "");
         QueryDetailQueue.addAndRemoveTimeoutQueryDetail(queryDetail);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -43,6 +43,7 @@ import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.SqlParserUtils;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.metric.MetricRepo;
+import com.starrocks.metric.ResourceGroupMetricMgr;
 import com.starrocks.mysql.MysqlChannel;
 import com.starrocks.mysql.MysqlCommand;
 import com.starrocks.mysql.MysqlPacket;
@@ -143,7 +144,7 @@ public class ConnectProcessor {
         long elapseMs = endTime - ctx.getStartTime();
 
         ctx.getAuditEventBuilder().setEventType(EventType.AFTER_QUERY)
-                .setState(ctx.getState().toString()).setQueryTime(elapseMs)
+                .setState(ctx.getState().toString()).setErrorCode(ctx.getErrorCode()).setQueryTime(elapseMs)
                 .setScanBytes(statistics == null ? 0 : statistics.scanBytes)
                 .setScanRows(statistics == null ? 0 : statistics.scanRows)
                 .setReturnRows(ctx.getReturnRows())
@@ -152,9 +153,11 @@ public class ConnectProcessor {
 
         if (ctx.getState().isQuery()) {
             MetricRepo.COUNTER_QUERY_ALL.increase(1L);
+            ResourceGroupMetricMgr.increaseQuery(ctx, 1L);
             if (ctx.getState().getStateType() == QueryState.MysqlStateType.ERR) {
                 // err query
                 MetricRepo.COUNTER_QUERY_ERR.increase(1L);
+                ResourceGroupMetricMgr.increaseQueryErr(ctx, 1L);
             } else {
                 // ok query
                 MetricRepo.COUNTER_QUERY_SUCCESS.increase(1L);
@@ -225,6 +228,7 @@ public class ConnectProcessor {
         }
         queryDetail.setEndTime(endTime);
         queryDetail.setLatency(elapseMs);
+        queryDetail.setWorkGroupName(ctx.getWorkGroup() != null ? ctx.getWorkGroup().getName() : "");
         QueryDetailQueue.addAndRemoveTimeoutQueryDetail(queryDetail);
     }
 
@@ -418,6 +422,7 @@ public class ConnectProcessor {
         }
         ctx.setCommand(command);
         ctx.setStartTime();
+        ctx.setWorkGroup(null);
 
         switch (command) {
             case COM_INIT_DB:

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -43,6 +43,7 @@ import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.SqlParserUtils;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.metric.MetricRepo;
+import com.starrocks.metric.ResourceGroupMetricMgr;
 import com.starrocks.mysql.MysqlChannel;
 import com.starrocks.mysql.MysqlCommand;
 import com.starrocks.mysql.MysqlPacket;
@@ -152,6 +153,7 @@ public class ConnectProcessor {
 
         if (ctx.getState().isQuery()) {
             MetricRepo.COUNTER_QUERY_ALL.increase(1L);
+            ResourceGroupMetricMgr.increaseQuery(ctx, 1L);
             if (ctx.getState().getStateType() == QueryState.MysqlStateType.ERR) {
                 // err query
                 MetricRepo.COUNTER_QUERY_ERR.increase(1L);
@@ -418,6 +420,7 @@ public class ConnectProcessor {
         }
         ctx.setCommand(command);
         ctx.setStartTime();
+        ctx.setWorkGroup(null);
 
         switch (command) {
             case COM_INIT_DB:

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -1544,6 +1544,7 @@ public class Coordinator {
         // and returned_all_results_ is true.
         // (UpdateStatus() initiates cancellation, if it hasn't already been initiated)
         if (!(returnedAllResults && status.isCancelled()) && !status.ok()) {
+            ConnectContext.get().setErrorCode(status.getErrorCode().toString());
             LOG.warn("one instance report fail {}, query_id={} instance_id={}",
                     status, DebugUtil.printId(queryId), DebugUtil.printId(params.getFragment_instance_id()));
             updateStatus(status, params.getFragment_instance_id());

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -1544,7 +1544,7 @@ public class Coordinator {
         // and returned_all_results_ is true.
         // (UpdateStatus() initiates cancellation, if it hasn't already been initiated)
         if (!(returnedAllResults && status.isCancelled()) && !status.ok()) {
-            ConnectContext.get().setErrorCode(status.getErrorCode().toString());
+            ConnectContext.get().setErrorCode(status.getErrorCode() == null ? "UNKNOWN" : status.getErrorCode().toString());
             LOG.warn("one instance report fail {}, query_id={} instance_id={}",
                     status, DebugUtil.printId(queryId), DebugUtil.printId(params.getFragment_instance_id()));
             updateStatus(status, params.getFragment_instance_id());

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryDetail.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryDetail.java
@@ -21,6 +21,7 @@
 
 package com.starrocks.qe;
 
+
 import java.io.Serializable;
 
 public class QueryDetail implements Serializable {
@@ -57,13 +58,14 @@ public class QueryDetail implements Serializable {
     private String errorMessage;
     private String explain;
     private String profile;
+    private String workGroupName;
 
     public QueryDetail() {
     }
 
     public QueryDetail(String queryId, boolean isQuery, int connId, String remoteIP,
                        long startTime, long endTime, long latency, QueryMemState state,
-                       String database, String sql, String user) {
+                       String database, String sql, String user, String workGroupName) {
         this.queryId = queryId;
         this.isQuery = isQuery;
         this.connId = connId;
@@ -212,5 +214,13 @@ public class QueryDetail implements Serializable {
 
     public void setProfile(String profile) {
         this.profile = profile;
+    }
+
+    public String getWorkGroupName() {
+        return workGroupName;
+    }
+
+    public void setWorkGroupName(String workGroupName) {
+        this.workGroupName = workGroupName;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -994,7 +994,9 @@ public class StmtExecutor {
                 QueryDetail.QueryMemState.RUNNING,
                 context.getDatabase(),
                 sql,
-                context.getQualifiedUser());
+                context.getQualifiedUser(),
+                context.getWorkGroup() != null ?
+                    context.getWorkGroup().getName() : "");
         context.setQueryDetail(queryDetail);
         //copy queryDetail, cause some properties can be changed in future
         QueryDetailQueue.addAndRemoveTimeoutQueryDetail(queryDetail.copy());

--- a/fe/fe-core/src/test/java/com/starrocks/qe/QueryDetailQueueTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/QueryDetailQueueTest.java
@@ -33,7 +33,7 @@ public class QueryDetailQueueTest {
         QueryDetail startQueryDetail = new QueryDetail("219a2d5443c542d4-8fc938db37c892e3", false, 1, "127.0.0.1",
                 System.currentTimeMillis(), -1, -1, QueryDetail.QueryMemState.RUNNING,
                 "default_cluster:testDb", "select * from table1 limit 1",
-                "root");
+                "root", "");
         QueryDetailQueue.addAndRemoveTimeoutQueryDetail(startQueryDetail);
 
         List<QueryDetail> queryDetails = QueryDetailQueue.getQueryDetailsAfterTime(startQueryDetail.getEventTime() - 1);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/QueryDetailTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/QueryDetailTest.java
@@ -10,7 +10,7 @@ public class QueryDetailTest {
         QueryDetail queryDetail = new QueryDetail("219a2d5443c542d4-8fc938db37c892e3", true, 1, "127.0.0.1",
                 System.currentTimeMillis(), -1, -1, QueryDetail.QueryMemState.RUNNING,
                 "default_cluster:testDb", "select * from table1 limit 1",
-                "root");
+                "root", "");
         queryDetail.setExplain("aaaaa");
         queryDetail.setProfile("bbbbb");
         queryDetail.setErrorMessage("cancelled");


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
#4847

## Problem Summary(Required) ：
Add two fields to the fe audit log:
 - ResourceGroup: The name of the resource group to use when executing sql
 - ErrorCode: The error code when the be service fails to run sql, see `gensrc/thrift/StatusCode.thrift`. Focus on `MEM_LIMIT_EXCEEDED`

Add fe resource group metrics:
 - starrocks_fe_query_resource_group: Count the number of queries for each resource group
 - starrocks_fe_query_resource_group_latency: Calculate the query latency percentile for each resource group
 - starrocks_fe_query_resource_group_err: Count the number of incorrect queries for each resource group

Add be resource group metrics:
 - starrocks_be_resource_group_cpu_limit_ratio: Instantaneous value of resource group cpu quota ratio
 - starrocks_be_resource_group_cpu_use_ratio: Instantaneous value of resource group cpu usage ratio
 - starrocks_be_resource_group_mem_limit_bytes: Instantaneous value of resource group memory quota
 - starrocks_be_resource_group_mem_allocated_bytes: Instantaneous value of resource group memory usage

