### PR TITLE
[WIP] Opt: parse conjuncts and key ranges once when OlapScanOperator ready

### DIFF
--- a/be/src/exec/pipeline/hdfs_scan_operator.cpp
+++ b/be/src/exec/pipeline/hdfs_scan_operator.cpp
@@ -22,13 +22,14 @@ Status HdfsScanOperatorFactory::do_prepare(RuntimeState* state) {
 void HdfsScanOperatorFactory::do_close(RuntimeState*) {}
 
 OperatorPtr HdfsScanOperatorFactory::do_create(int32_t dop, int32_t driver_sequence) {
-    return std::make_shared<HdfsScanOperator>(this, _id, _scan_node);
+    return std::make_shared<HdfsScanOperator>(this, _id, _scan_node, _shared_phase);
 }
 
 // ==================== HdfsScanOperator ====================
 
-HdfsScanOperator::HdfsScanOperator(OperatorFactory* factory, int32_t id, ScanNode* scan_node)
-        : ScanOperator(factory, id, scan_node) {}
+HdfsScanOperator::HdfsScanOperator(OperatorFactory* factory, int32_t id, ScanNode* scan_node,
+                                   std::atomic<ScanOperatorFactory::SharedPhase>& shared_phase)
+        : ScanOperator(factory, id, scan_node, shared_phase) {}
 
 Status HdfsScanOperator::do_prepare(RuntimeState*) {
     return Status::OK();

--- a/be/src/exec/pipeline/hdfs_scan_operator.h
+++ b/be/src/exec/pipeline/hdfs_scan_operator.h
@@ -23,7 +23,8 @@ public:
 
 class HdfsScanOperator final : public ScanOperator {
 public:
-    HdfsScanOperator(OperatorFactory* factory, int32_t id, ScanNode* scan_node);
+    HdfsScanOperator(OperatorFactory* factory, int32_t id, ScanNode* scan_node,
+                     std::atomic<ScanOperatorFactory::SharedPhase>& shared_phase);
 
     ~HdfsScanOperator() override = default;
 

--- a/be/src/exec/pipeline/jdbc_scan_operator.cpp
+++ b/be/src/exec/pipeline/jdbc_scan_operator.cpp
@@ -14,8 +14,9 @@ namespace starrocks {
 namespace pipeline {
 
 JDBCScanOperator::JDBCScanOperator(OperatorFactory* factory, int32_t id, ScanNode* scan_node,
+                                   std::atomic<ScanOperatorFactory::SharedPhase>& shared_phase,
                                    const TJDBCScanNode& jdbc_scan_node)
-        : ScanOperator(factory, id, scan_node),
+        : ScanOperator(factory, id, scan_node, shared_phase),
           _jdbc_scan_node(jdbc_scan_node),
           _conjunct_ctxs(scan_node->conjunct_ctxs()),
           _limit(scan_node->limit()),
@@ -224,7 +225,7 @@ Status JDBCScanOperatorFactory::do_prepare(RuntimeState* state) {
 void JDBCScanOperatorFactory::do_close(RuntimeState* state) {}
 
 OperatorPtr JDBCScanOperatorFactory::do_create(int32_t dop, int32_t driver_sequence) {
-    return std::make_shared<JDBCScanOperator>(this, _id, _scan_node, _jdbc_scan_node);
+    return std::make_shared<JDBCScanOperator>(this, _id, _scan_node, _shared_phase, _jdbc_scan_node);
 }
 
 } // namespace pipeline

--- a/be/src/exec/pipeline/jdbc_scan_operator.h
+++ b/be/src/exec/pipeline/jdbc_scan_operator.h
@@ -17,7 +17,8 @@ namespace pipeline {
 // Maybe after we put the jdbc scanner into thread pool, the two can be unified.
 class JDBCScanOperator final : public ScanOperator {
 public:
-    JDBCScanOperator(OperatorFactory* factory, int32_t id, ScanNode* scan_node, const TJDBCScanNode& jdbc_scan_node);
+    JDBCScanOperator(OperatorFactory* factory, int32_t id, ScanNode* scan_node,
+                     std::atomic<ScanOperatorFactory::SharedPhase>& shared_phase, const TJDBCScanNode& jdbc_scan_node);
     ~JDBCScanOperator() override = default;
 
     bool has_output() const override;

--- a/be/src/exec/pipeline/olap_scan_operator.h
+++ b/be/src/exec/pipeline/olap_scan_operator.h
@@ -4,6 +4,7 @@
 
 #include "exec/pipeline/pipeline_builder.h"
 #include "exec/pipeline/scan_operator.h"
+#include "exec/vectorized/olap_scan_prepare.h"
 
 namespace starrocks {
 
@@ -24,20 +25,40 @@ public:
     Status do_prepare(RuntimeState* state) override;
     void do_close(RuntimeState* state) override;
     OperatorPtr do_create(int32_t dop, int32_t driver_sequence) override;
+
+    Status parse_conjuncts(RuntimeState* state);
+    vectorized::OlapScanConjunctsManager& conjuncts_manager() { return _conjuncts_manager; }
+    std::vector<ExprContext*>& not_push_down_conjuncts() { return _not_push_down_conjuncts; }
+    std::vector<std::unique_ptr<OlapScanRange>>& key_ranges() { return _key_ranges; }
+
+private:
+    std::vector<ExprContext*> _conjunct_ctxs;
+    vectorized::OlapScanConjunctsManager _conjuncts_manager;
+    std::vector<ExprContext*> _not_push_down_conjuncts;
+    std::vector<std::unique_ptr<OlapScanRange>> _key_ranges;
+    vectorized::DictOptimizeParser _dict_optimize_parser;
+    ObjectPool _obj_pool;
 };
 
 class OlapScanOperator final : public ScanOperator {
 public:
-    OlapScanOperator(OperatorFactory* factory, int32_t id, ScanNode* scan_node);
+    OlapScanOperator(OperatorFactory* factory, int32_t id, ScanNode* scan_node,
+                     std::atomic<ScanOperatorFactory::SharedPhase>& shared_phase);
 
     ~OlapScanOperator() override = default;
 
     Status do_prepare(RuntimeState* state) override;
+    Status do_open_shared(RuntimeState* state) override;
     void do_close(RuntimeState* state) override;
     ChunkSourcePtr create_chunk_source(MorselPtr morsel, int32_t chunk_source_index) override;
 
+    vectorized::OlapScanConjunctsManager& conjuncts_manager() { return _get_factory()->conjuncts_manager(); }
+    std::vector<ExprContext*>& not_push_down_conjuncts() { return _get_factory()->not_push_down_conjuncts(); }
+    std::vector<std::unique_ptr<OlapScanRange>>& key_ranges() { return _get_factory()->key_ranges(); }
+
 private:
     Status _capture_tablet_rowsets();
+    OlapScanOperatorFactory* _get_factory() { return down_cast<OlapScanOperatorFactory*>(_factory); }
 
     // The row sets of tablets will become stale and be deleted, if compaction occurs
     // and these row sets aren't referenced, which will typically happen when the tablets


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Problem Summary：
Only parse conjuncts and key ranges once, when OlapScanOperators generated from the same fragment instance are ready. 
The reason is as follows:
- Concurrency read on the single tablet need the information about key ranges, but key ranges are only parsed in `OlapChunkSource::preapre` for now. 
- Every `OlapChunkSource` parses conjuncts and key ranges, which is duplicated.
