### PR TITLE
BugFix: Colocate table's tablet cannot be repaired after be is dropped

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Tablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Tablet.java
@@ -571,6 +571,12 @@ public class Tablet extends MetaObject implements Writable {
 
         // 2. check version completeness
         for (Replica replica : replicas) {
+            // do not check the replica that is not in the colocate backend set,
+            // this kind of replica should be drooped.
+            if (!backendsSet.contains(replica.getBackendId())) {
+                continue;
+            }
+
             if (replica.getLastFailedVersion() > 0 || replica.getVersion() < visibleVersion) {
                 // this replica is alive but version incomplete
                 return TabletStatus.VERSION_INCOMPLETE;

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TabletTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TabletTest.java
@@ -21,6 +21,7 @@
 
 package com.starrocks.catalog;
 
+import com.google.common.collect.Sets;
 import com.starrocks.catalog.Replica.ReplicaState;
 import com.starrocks.common.FeConstants;
 import com.starrocks.thrift.TStorageMedium;
@@ -154,4 +155,20 @@ public class TabletTest {
         file.delete();
     }
 
+    @Test
+    public void testGetColocateHealthStatus() {
+        Tablet tablet = new Tablet();
+        // version incomplete replica, but the be is dropped.
+        Replica versionIncompleteReplica = new Replica(1L, 10001L,
+                8L, -1L, -1, 10L, 10L, ReplicaState.NORMAL,
+                9L, -1L, 8L, -1L);
+        // normal replica
+        Replica normalReplica = new Replica(2L, 10002L,
+                9L, -1L, -1, 10L, 10L, ReplicaState.NORMAL,
+                -1L, -1L, 9L, -1L);
+        tablet.addReplica(versionIncompleteReplica, true);
+        tablet.addReplica(normalReplica, true);
+        Assert.assertEquals(Tablet.TabletStatus.COLOCATE_REDUNDANT,
+                tablet.getColocateHealthStatus(9,-1, 1, Sets.newHashSet(10002L)));
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TabletTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TabletTest.java
@@ -160,15 +160,13 @@ public class TabletTest {
         Tablet tablet = new Tablet();
         // version incomplete replica, but the be is dropped.
         Replica versionIncompleteReplica = new Replica(1L, 10001L,
-                8L, -1L, -1, 10L, 10L, ReplicaState.NORMAL,
-                9L, -1L, 8L, -1L);
+                8L, -1, 10L, 10L, ReplicaState.NORMAL, 9L, 8L);
         // normal replica
         Replica normalReplica = new Replica(2L, 10002L,
-                9L, -1L, -1, 10L, 10L, ReplicaState.NORMAL,
-                -1L, -1L, 9L, -1L);
+                9L, -1, 10L, 10L, ReplicaState.NORMAL, -1L, 9L);
         tablet.addReplica(versionIncompleteReplica, true);
         tablet.addReplica(normalReplica, true);
         Assert.assertEquals(Tablet.TabletStatus.COLOCATE_REDUNDANT,
-                tablet.getColocateHealthStatus(9,-1, 1, Sets.newHashSet(10002L)));
+                tablet.getColocateHealthStatus(9, 1, Sets.newHashSet(10002L)));
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5128

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
We should not repair the replica that is not in the colocate backends set, this kind of replica should be dropped.