### PR TITLE
Pass const args to merge phase aggregator in BE

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -369,6 +369,19 @@ public class AggregateTest extends PlanTestBase {
     }
 
     @Test
+    public void testIntersectCount() throws Exception {
+        connectContext.getSessionVariable().setNewPlanerAggStage(2);
+        String sql = "select intersect_count(b1, v1, 999999) from test_object;";
+        String plan = getThriftPlan(sql);
+        System.out.println(plan);
+        assertContains(plan, "int_literal:TIntLiteral(value:999999), " +
+                "output_scale:-1, " +
+                "has_nullable_child:false, is_nullable:false, is_monotonic:true)])], " +
+                "intermediate_tuple_id:2");
+        connectContext.getSessionVariable().setNewPlanerAggStage(0);
+    }
+
+    @Test
     public void testMergeAggregateNormal() throws Exception {
         String sql;
         String plan;


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

For Multi args aggregation functions, if they have const args,
We should also pass the const args to merge phase aggregator for performance.
For example, for intersect_count(user_id, dt, '20191111'),
We should pass '20191111' to update and merge phase aggregator in BE both.
