### PR TITLE
[Enhancement] Check user identity for `show grants` & support string literal role name for `create role` and `drop role`

### DIFF
--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -1243,7 +1243,7 @@ create_stmt ::=
     {:
         RESULT = new CreateRepositoryStmt(isReadOnly, repoName, brokerName, location, properties);
     :}
-    | KW_CREATE KW_ROLE ident:role
+    | KW_CREATE KW_ROLE ident_or_text:role
     {:
         RESULT = new CreateRoleStmt(role);
     :}
@@ -1821,7 +1821,7 @@ drop_stmt ::=
     {:
         RESULT = new DropRepositoryStmt(repoName);
     :}
-    | KW_DROP KW_ROLE ident:role
+    | KW_DROP KW_ROLE ident_or_text:role
     {:
         RESULT = new DropRoleStmt(role);
     :}

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/ShowGrantsStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/ShowGrantsStmt.java
@@ -77,6 +77,9 @@ public class ShowGrantsStmt extends ShowStmt {
                 throw new AnalysisException("Can not specified keyword ALL when specified user");
             }
             userIdent.analyze(analyzer.getClusterName());
+            if (!Catalog.getCurrentCatalog().getAuth().getUserPrivTable().doesUserExist(userIdent)) {
+                throw new AnalysisException("user " + userIdent + " not exist!");
+            }
         } else {
             if (!isAll) {
                 // self

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowGrantsStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowGrantsStmtTest.java
@@ -1,21 +1,4 @@
-// This file is made available under Elastic License 2.0.
-
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
 
 package com.starrocks.analysis;
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowGrantsStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowGrantsStmtTest.java
@@ -1,0 +1,113 @@
+// This file is made available under Elastic License 2.0.
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.analysis;
+
+import com.starrocks.catalog.Catalog;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.mysql.privilege.Auth;
+import com.starrocks.mysql.privilege.MockedAuth;
+import com.starrocks.mysql.privilege.PrivPredicate;
+import com.starrocks.mysql.privilege.UserPrivTable;
+import com.starrocks.qe.ConnectContext;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ShowGrantsStmtTest {
+
+    @Mocked
+    private Analyzer analyzer;
+    @Mocked
+    private Catalog catalog;
+    @Mocked
+    private Auth auth;
+    @Mocked
+    private UserPrivTable userPrivTable;
+    @Mocked
+    private ConnectContext ctx;
+
+    @Before
+    public void setUp() {
+        MockedAuth.mockedConnectContext(ctx, "root", "192.168.1.1");
+        new Expectations(analyzer) {
+            {
+                analyzer.getClusterName();
+                minTimes = 0;
+                result = "test_cluster";
+            }
+        };
+        new Expectations() {
+            {
+                Catalog.getCurrentCatalog();
+                minTimes = 0;
+                result = catalog;
+            }
+        };
+        new Expectations(catalog) {
+            {
+                catalog.getAuth();
+                minTimes = 0;
+                result = auth;
+            }
+        };
+        new Expectations(auth) {
+            {
+                auth.getUserPrivTable();
+                minTimes = 0;
+                result = userPrivTable;
+
+                auth.checkGlobalPriv(ctx, PrivPredicate.GRANT);
+                minTimes = 0;
+                result = true;
+            }
+        };
+    }
+
+    @Test
+    public void testNormal() throws Exception {
+        // suppose current user exists
+        new Expectations(userPrivTable) {
+            {
+                userPrivTable.doesUserExist((UserIdentity)any);
+                minTimes = 0;
+                result = true;
+            }
+        };
+        ShowGrantsStmt stmt = new ShowGrantsStmt(new UserIdentity("test_user", "localhost"), false);
+        stmt.analyze(analyzer);
+    }
+
+    @Test(expected = AnalysisException.class)
+    public void testUserNotExist() throws Exception {
+        // suppose current user doesn't exist, check for exception
+        new Expectations(userPrivTable) {
+            {
+                userPrivTable.doesUserExist((UserIdentity)any);
+                minTimes = 0;
+                result = false;
+            }
+        };
+        ShowGrantsStmt stmt = new ShowGrantsStmt(new UserIdentity("fake_user", "localhost"), false);
+        stmt.analyze(analyzer);
+        Assert.fail("No exception throws.");
+    }
+}


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5389

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered, and what measures have you taken to fix the bug?) -->
1. So far, using `show grants` for a non-existent user will show a table with all cells 'null'. Fix it by raising an exception in this scenario.
2. Allow usage of `create role 'role_name'` by changing role CUP type from ident to ident_or_text.
