### PR TITLE
Reject coming fragment instances when BE overloaded

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -651,6 +651,9 @@ CONF_Int64(pipeline_io_buffer_size, "64");
 CONF_Int64(pipeline_sink_buffer_size, "64");
 // The degree of parallelism of brpc.
 CONF_Int64(pipeline_sink_brpc_dop, "8");
+// Used to reject coming fragment instances, when the number of running drivers
+// exceeds it*pipeline_exec_thread_pool_thread_num.
+CONF_Int64(pipeline_max_num_drivers_per_exec_thread, "10240");
 
 // The bitmap serialize version.
 CONF_Int16(bitmap_serialize_version, "1");

--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -154,6 +154,7 @@ set(EXEC_FILES
     pipeline/pipeline_driver_poller.cpp
     pipeline/pipeline_driver.cpp
     pipeline/exec_state_reporter.cpp
+    pipeline/driver_limiter.cpp
     pipeline/fragment_context.cpp
     pipeline/query_context.cpp
     pipeline/aggregate/aggregate_blocking_sink_operator.cpp

--- a/be/src/exec/pipeline/driver_limiter.cpp
+++ b/be/src/exec/pipeline/driver_limiter.cpp
@@ -1,0 +1,17 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#include "exec/pipeline/driver_limiter.h"
+
+namespace starrocks::pipeline {
+
+StatusOr<DriverLimiter::TokenPtr> DriverLimiter::try_acquire(int num_drivers) {
+    int prev_num_total_drivers = _num_total_drivers.fetch_add(num_drivers);
+    if (prev_num_total_drivers >= _max_num_drivers) {
+        _num_total_drivers.fetch_sub(num_drivers);
+        return Status::TooManyTasks(
+                strings::Substitute("BE has overloaded with $0 pipeline drivers", prev_num_total_drivers));
+    }
+    return std::make_unique<DriverLimiter::Token>(_num_total_drivers, num_drivers);
+}
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/driver_limiter.h
+++ b/be/src/exec/pipeline/driver_limiter.h
@@ -1,0 +1,46 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#pragma once
+
+#include <atomic>
+#include <memory>
+
+#include "common/statusor.h"
+#include "gutil/strings/substitute.h"
+
+namespace starrocks::pipeline {
+
+class DriverLimiter {
+public:
+    struct Token {
+    public:
+        Token(std::atomic<int>& num_total_drivers, int num_drivers)
+                : num_total_drivers(num_total_drivers), num_drivers(num_drivers) {}
+        ~Token() { num_total_drivers -= num_drivers; }
+
+        // Disable copy/move ctor and assignment.
+        Token(const Token&) = delete;
+        Token& operator=(const Token&) = delete;
+        Token(Token&&) = delete;
+        Token& operator=(Token&&) = delete;
+
+    private:
+        std::atomic<int>& num_total_drivers;
+        int num_drivers;
+    };
+    using TokenPtr = std::unique_ptr<Token>;
+
+    explicit DriverLimiter(int max_num_drivers) : _max_num_drivers(max_num_drivers) {}
+    ~DriverLimiter() = default;
+
+    // Return non-ok status, if it cannot acquire `num_drivers` drivers from the limiter.
+    // Otherwise, return the token, the destructor of which will release the acquired
+    // `num_drivers` drivers back to the limiter.
+    StatusOr<TokenPtr> try_acquire(int num_drivers);
+
+private:
+    const int _max_num_drivers;
+    std::atomic<int> _num_total_drivers{0};
+};
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/fragment_context.h
+++ b/be/src/exec/pipeline/fragment_context.h
@@ -5,6 +5,7 @@
 #include <unordered_map>
 
 #include "exec/exec_node.h"
+#include "exec/pipeline/driver_limiter.h"
 #include "exec/pipeline/morsel.h"
 #include "exec/pipeline/pipeline.h"
 #include "exec/pipeline/pipeline_driver.h"
@@ -19,6 +20,7 @@
 #include "runtime/runtime_filter_worker.h"
 #include "runtime/runtime_state.h"
 #include "util/hash_util.hpp"
+
 namespace starrocks {
 namespace pipeline {
 
@@ -120,6 +122,8 @@ public:
 
     bool enable_resource_group() const { return _enable_resource_group; }
 
+    void set_driver_token(DriverLimiter::TokenPtr driver_token) { _driver_token = std::move(driver_token); }
+
 private:
     // Id of this query
     TUniqueId _query_id;
@@ -155,6 +159,8 @@ private:
     Status _s_status;
 
     bool _enable_resource_group = false;
+
+    DriverLimiter::TokenPtr _driver_token = nullptr;
 };
 
 class FragmentContextManager {

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -244,6 +244,7 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
     }
 
     RETURN_IF_ERROR(_fragment_ctx->prepare_all_pipelines());
+
     Drivers drivers;
     const auto& pipelines = _fragment_ctx->pipelines();
     const size_t num_pipelines = pipelines.size();
@@ -251,9 +252,10 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
     for (auto n = 0; n < num_pipelines; ++n) {
         const auto& pipeline = pipelines[n];
         // DOP(degree of parallelism) of Pipeline's SourceOperator determines the Pipeline's DOP.
-        const auto degree_of_parallelism = pipeline->source_operator_factory()->degree_of_parallelism();
-        VLOG_ROW << "Pipeline " << pipeline->to_readable_string() << " parallel=" << degree_of_parallelism
+        const auto cur_pipeline_dop = pipeline->source_operator_factory()->degree_of_parallelism();
+        VLOG_ROW << "Pipeline " << pipeline->to_readable_string() << " parallel=" << cur_pipeline_dop
                  << " fragment_instance_id=" << print_id(params.fragment_instance_id);
+
         // If pipeline's SourceOperator is with morsels, a MorselQueue is added to the SourceOperator.
         // at present, only OlapScanOperator need a MorselQueue attached.
         setup_profile_hierarchy(runtime_state, pipeline);
@@ -261,14 +263,12 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
             auto source_id = pipeline->get_op_factories()[0]->plan_node_id();
             DCHECK(morsel_queues.count(source_id));
             auto& morsel_queue = morsel_queues[source_id];
-            if (morsel_queue->num_morsels() > 0) {
-                DCHECK(degree_of_parallelism <= morsel_queue->num_morsels());
-            }
-            std::vector<MorselQueuePtr> morsel_queue_per_driver = morsel_queue->split_by_size(degree_of_parallelism);
-            DCHECK(morsel_queue_per_driver.size() == degree_of_parallelism);
+            DCHECK(morsel_queue->num_morsels() == 0 || cur_pipeline_dop <= morsel_queue->num_morsels());
+            std::vector<MorselQueuePtr> morsel_queue_per_driver = morsel_queue->split_by_size(cur_pipeline_dop);
+            DCHECK(morsel_queue_per_driver.size() == cur_pipeline_dop);
 
-            for (size_t i = 0; i < degree_of_parallelism; ++i) {
-                auto&& operators = pipeline->create_operators(degree_of_parallelism, i);
+            for (size_t i = 0; i < cur_pipeline_dop; ++i) {
+                auto&& operators = pipeline->create_operators(cur_pipeline_dop, i);
                 DriverPtr driver =
                         std::make_shared<PipelineDriver>(std::move(operators), _query_ctx, _fragment_ctx, driver_id++);
                 driver->set_morsel_queue(std::move(morsel_queue_per_driver[i]));
@@ -287,8 +287,8 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
                 drivers.emplace_back(std::move(driver));
             }
         } else {
-            for (size_t i = 0; i < degree_of_parallelism; ++i) {
-                auto&& operators = pipeline->create_operators(degree_of_parallelism, i);
+            for (size_t i = 0; i < cur_pipeline_dop; ++i) {
+                auto&& operators = pipeline->create_operators(cur_pipeline_dop, i);
                 DriverPtr driver =
                         std::make_shared<PipelineDriver>(std::move(operators), _query_ctx, _fragment_ctx, driver_id++);
                 setup_profile_hierarchy(pipeline, driver);
@@ -299,6 +299,13 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
     // The pipeline created later should be placed in the front
     runtime_state->runtime_profile()->reverse_childs();
     _fragment_ctx->set_drivers(std::move(drivers));
+
+    auto maybe_driver_token = exec_env->driver_limiter()->try_acquire(drivers.size());
+    if (maybe_driver_token.ok()) {
+        _fragment_ctx->set_driver_token(std::move(maybe_driver_token.value()));
+    } else {
+        return maybe_driver_token.status();
+    }
 
     if (wg != nullptr) {
         for (auto& driver : _fragment_ctx->drivers()) {

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -300,7 +300,7 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
     runtime_state->runtime_profile()->reverse_childs();
     _fragment_ctx->set_drivers(std::move(drivers));
 
-    auto maybe_driver_token = exec_env->driver_limiter()->try_acquire(drivers.size());
+    auto maybe_driver_token = exec_env->driver_limiter()->try_acquire(_fragment_ctx->drivers().size());
     if (maybe_driver_token.ok()) {
         _fragment_ctx->set_driver_token(std::move(maybe_driver_token.value()));
     } else {

--- a/be/src/exec/pipeline/source_operator.h
+++ b/be/src/exec/pipeline/source_operator.h
@@ -36,7 +36,6 @@ public:
 
 protected:
     MorselQueue* _morsel_queue = nullptr;
-    ChunkSourcePtr _chunk_source;
 
     int64_t _last_scan_rows_num = 0;
 };

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -26,6 +26,7 @@
 #include "column/column_pool.h"
 #include "common/config.h"
 #include "common/logging.h"
+#include "exec/pipeline/driver_limiter.h"
 #include "exec/pipeline/pipeline_driver_executor.h"
 #include "exec/pipeline/query_context.h"
 #include "exec/workgroup/scan_executor.h"
@@ -188,6 +189,8 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths) {
                             .build(&driver_executor_thread_pool));
     _driver_executor = new pipeline::GlobalDriverExecutor(std::move(driver_executor_thread_pool), false);
     _driver_executor->initialize(max_thread_num);
+
+    _driver_limiter = new pipeline::DriverLimiter(max_thread_num * config::pipeline_max_num_drivers_per_exec_thread);
 
     std::unique_ptr<ThreadPool> wg_driver_executor_thread_pool;
     RETURN_IF_ERROR(ThreadPoolBuilder("pip_wg_executor") // pipeline executor for workgroup
@@ -389,6 +392,10 @@ void ExecEnv::_destroy() {
     if (_wg_driver_executor) {
         delete _wg_driver_executor;
         _wg_driver_executor = nullptr;
+    }
+    if (_driver_limiter) {
+        delete _driver_limiter;
+        _driver_limiter = nullptr;
     }
     if (_fragment_mgr) {
         delete _fragment_mgr;

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -68,6 +68,7 @@ class HeartbeatFlags;
 namespace pipeline {
 class DriverExecutor;
 class QueryContextManager;
+class DriverLimiter;
 } // namespace pipeline
 
 // Execution environment for queries/plan fragments.
@@ -166,6 +167,8 @@ public:
 
     pipeline::QueryContextManager* query_context_mgr() { return _query_context_mgr; }
 
+    pipeline::DriverLimiter* driver_limiter() { return _driver_limiter; }
+
 private:
     Status _init(const std::vector<StorePath>& store_paths);
     void _destroy();
@@ -225,6 +228,8 @@ private:
     starrocks::pipeline::QueryContextManager* _query_context_mgr = nullptr;
     starrocks::pipeline::DriverExecutor* _driver_executor = nullptr;
     pipeline::DriverExecutor* _wg_driver_executor = nullptr;
+    pipeline::DriverLimiter* _driver_limiter;
+
     TMasterInfo* _master_info = nullptr;
     LoadPathMgr* _load_path_mgr = nullptr;
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR relates ：
Relates #4711.

## Problem Summary:
Reject coming fragment instances, when the number of running drivers exceeds `config::pipeline_max_num_drivers_per_exec_thread*config::pipeline_exec_thread_pool_thread_num`.


