### PR TITLE
Bugfix: check array state column nullable when ReplaceAggregator appending data

### DIFF
--- a/be/src/storage/column_aggregate_func.cpp
+++ b/be/src/storage/column_aggregate_func.cpp
@@ -287,7 +287,11 @@ public:
 
     void append_data(Column* agg) override {
         auto* col = down_cast<ArrayColumn*>(agg);
-        col->append(*this->data().column, this->data().row, 1);
+        if (this->data().column) {
+            col->append(*this->data().column, this->data().row, 1);
+        } else {
+            col->append_default();
+        }
     }
 };
 

--- a/be/test/storage/column_aggregator_test.cpp
+++ b/be/test/storage/column_aggregator_test.cpp
@@ -670,4 +670,41 @@ TEST(ColumnAggregator, testArrayReplace) {
     EXPECT_EQ("['20', '21', '22', '23', '24', '25', '26', '27', '28', '29']", agg->debug_item(4));
 }
 
+// insert into tbl values (key, null);
+TEST(ColumnAggregator, testNullArrayReplaceIfNotNull) {
+    auto array_type_info = std::make_shared<ArrayTypeInfo>(get_type_info(FieldType::OLAP_FIELD_TYPE_VARCHAR));
+    FieldPtr field = std::make_shared<Field>(1, "test_array", array_type_info,
+                                             FieldAggregationMethod::OLAP_FIELD_AGGREGATION_REPLACE_IF_NOT_NULL, 1,
+                                             false, true);
+
+    auto agg = NullableColumn::create(
+            ArrayColumn::create(NullableColumn::create(BinaryColumn::create(), NullColumn::create()),
+                                UInt32Column::create()),
+            NullColumn::create());
+    auto aggregator = ColumnAggregatorFactory::create_value_column_aggregator(field);
+    aggregator->update_aggregate(agg.get());
+    std::vector<uint32_t> loops;
+
+    // first chunk column
+    auto src = NullableColumn::create(
+            ArrayColumn::create(NullableColumn::create(BinaryColumn::create(), NullColumn::create()),
+                                UInt32Column::create()),
+            NullColumn::create());
+    src->append_nulls(1);
+
+    aggregator->update_source(src);
+
+    loops.clear();
+    loops.emplace_back(1);
+
+    aggregator->aggregate_values(0, 1, loops.data(), false);
+
+    ASSERT_EQ(0, agg->size());
+
+    aggregator->finalize();
+
+    ASSERT_EQ(1, agg->size());
+    ASSERT_EQ("NULL", agg->debug_item(0));
+}
+
 } // namespace starrocks::vectorized


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5411

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

When loading array `replace if not null` column and the same key has only null data,
the array state column will be null, and it will cause be crashes if not check nullable.
