### PR TITLE
Fix scan cpp check error

### DIFF
--- a/be/src/exec/vectorized/json_parser.h
+++ b/be/src/exec/vectorized/json_parser.h
@@ -33,7 +33,7 @@ public:
     Status advance() noexcept override;
 
 private:
-    uint8_t* _data;
+    uint8_t* _data = nullptr;
 
     // data is parsed as a document stream.
 
@@ -63,7 +63,7 @@ public:
     Status advance() noexcept override;
 
 private:
-    uint8_t* _data;
+    uint8_t* _data = nullptr;
 
     // data is parsed as a document in array type.
     simdjson::ondemand::document _doc;

--- a/be/src/exprs/vectorized/function_call_expr.h
+++ b/be/src/exprs/vectorized/function_call_expr.h
@@ -31,7 +31,7 @@ protected:
 private:
     const FunctionDescriptor* _fn_desc;
 
-    bool _is_returning_random_value;
+    bool _is_returning_random_value = false;
 };
 
 } // namespace vectorized


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Fix cpp check error:
new	/home/disk1/jenkins/workspace/starrocks_tscancode/starrocks/be/src/exec/vectorized/json_parser.h	30	Warning	uninit	false	Member variable 'JsonDocumentStreamParser::_data,' is not initialized in the constructor.
new	/home/disk1/jenkins/workspace/starrocks_tscancode/starrocks/be/src/exec/vectorized/json_parser.h	60	Warning	uninit	false	Member variable 'JsonArrayParser::_data,' is not initialized in the constructor.
new	/home/disk1/jenkins/workspace/starrocks_tscancode/starrocks/be/src/exec/vectorized/json_parser.h	30	Warning	uninit	false	Member variable 'JsonDocumentStreamParser::_data,' is not initialized in the constructor.
new	/home/disk1/jenkins/workspace/starrocks_tscancode/starrocks/be/src/exec/vectorized/json_parser.h	60	Warning	uninit	false	Member variable 'JsonArrayParser::_data,' is not initialized in the constructor.
new	/home/disk1/jenkins/workspace/starrocks_tscancode/starrocks/be/src/exec/pipeline/source_operator.h	17	Warning	uninit	false	Member variable 'SourceOperator::_morsel_queue,' is not initialized in the constructor.
new	/home/disk1/jenkins/workspace/starrocks_tscancode/starrocks/be/src/exec/pipeline/source_operator.h	17	Warning	uninit	false	Member variable 'SourceOperator::_morsel_queue,' is not initialized in the constructor.
new	/home/disk1/jenkins/workspace/starrocks_tscancode/starrocks/be/src/exprs/function_call_expr.cpp	17	Warning	uninit	false	Member variable 'VectorizedFunctionCallExpr::_is_returning_random_value,' is not initialized in the constructor.
