### PR TITLE
delete virtual keyword in Column::append_selective for issue #5410

### DIFF
--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -168,7 +168,7 @@ public:
     // This function will copy the [3, 2] row of src to this column.
     virtual void append_selective(const Column& src, const uint32_t* indexes, uint32_t from, uint32_t size) = 0;
 
-    virtual void append_selective(const Column& src, const Buffer<uint32_t>& indexes) {
+    void append_selective(const Column& src, const Buffer<uint32_t>& indexes) {
         return append_selective(src, indexes.data(), 0, indexes.size());
     }
 


### PR DESCRIPTION
Signed-off-by: zombee0 <flylucas_10@163.com>

## What type of PR is this：
- [ ] others delete unnecessary virtual keyword in Column::append_selective for issue #5410

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5410 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
delete unnecessary virtual keyword in Column::append_selective
