### PR TITLE
Support bitmap as a primitive type【Easy】

### DIFF
--- a/be/src/exprs/vectorized/bitmap_functions.h
+++ b/be/src/exprs/vectorized/bitmap_functions.h
@@ -120,6 +120,13 @@ public:
      * @return TYPE_BIGINT
      */
     DEFINE_VECTORIZED_FN(bitmap_min);
+
+    /**
+     * @param:
+     * @paramType columns: [TYPE_VARCHAR]
+     * @return TYPE_OBJECT
+     */
+    DEFINE_VECTORIZED_FN(base64_to_bitmap);
 };
 
 } // namespace vectorized

--- a/gensrc/script/vectorized/vectorized_functions.py
+++ b/gensrc/script/vectorized/vectorized_functions.py
@@ -471,6 +471,7 @@ vectorized_functions = [
     [90500, 'bitmap_to_array', 'ARRAY_BIGINT', ['BITMAP'], 'BitmapFunctions::bitmap_to_array', False],
     [90600, 'bitmap_max', 'BIGINT', ['BITMAP'], 'BitmapFunctions::bitmap_max', False],
     [90700, 'bitmap_min', 'BIGINT', ['BITMAP'], 'BitmapFunctions::bitmap_min', False],
+    [90800, 'base64_to_bitmap', 'BITMAP', ['VARCHAR'], 'BitmapFunctions::base64_to_bitmap', False],
 
     # hash function
     [100010, 'murmur_hash3_32', 'INT', ['VARCHAR', '...'], 'HashFunctions::murmur_hash3_32'],


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
Fixes (https://github.com/StarRocks/starrocks/issues/4449)

## Problem Summary：
add base64_to_bitmap function to input data into StarRocks task

## stream load【important】
stream load success
command:
> curl --location-trusted -u root:111111 -H "columns: c1,c2,c3,tagname=c1,tagvalue=c2,userid=base64_to_bitmap(c3)" -H "label:bitmap123" -H "format: json" -H "jsonpaths: [\\"$.tagname\\",\\"$.tagvalue\\",\\"$.userid\\"]" -T simpleData http://0.0.0.0:8030/api/bitmapdb/tbl_tag_bitmap/_stream_load

json content in simpleData, this base64 encode string is BitmapValue{1,2,3}

> {
>     "tagname": "持有产品", "tagvalue": "保险", "userid":"AjowAAABAAAAAAACABAAAAABAAIAAwA="
> }

simple json data stream load import success
![image](https://user-images.githubusercontent.com/35732071/164955655-de0a8a97-8c88-4243-a585-6c4a0ab013d7.png)

query success
![image](https://user-images.githubusercontent.com/35732071/164955687-6f629edd-fd31-49de-a908-25bfc4420880.png)



