### PR TITLE
[Opt merge part4] refactor SortContext

### DIFF
--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -386,6 +386,7 @@ Status ExchangeSinkOperator::push_chunk(RuntimeState* state, const vectorized::C
     if (num_rows == 0) {
         return Status::OK();
     }
+    DCHECK_LE(num_rows, state->chunk_size());
 
     vectorized::Chunk temp_chunk;
     vectorized::Chunk* send_chunk = chunk.get();

--- a/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
@@ -2,14 +2,10 @@
 
 #include "exec/pipeline/sort/partition_sort_sink_operator.h"
 
-#include <execinfo.h>
-#include <stdio.h>
-#include <string.h>
-#include <unistd.h>
-
 #include "column/chunk.h"
 #include "column/column_helper.h"
 #include "exec/pipeline/sort/sort_context.h"
+#include "exec/vectorized/chunk_sorter_heapsorter.h"
 #include "exec/vectorized/chunks_sorter.h"
 #include "exec/vectorized/chunks_sorter_full_sort.h"
 #include "exec/vectorized/chunks_sorter_topn.h"

--- a/be/src/exec/pipeline/sort/partition_sort_sink_operator.h
+++ b/be/src/exec/pipeline/sort/partition_sort_sink_operator.h
@@ -6,10 +6,7 @@
 #include "exec/pipeline/operator.h"
 #include "exec/pipeline/sort/sort_context.h"
 #include "exec/sort_exec_exprs.h"
-#include "exec/vectorized/chunk_sorter_heapsorter.h"
 #include "exec/vectorized/chunks_sorter.h"
-#include "exec/vectorized/chunks_sorter_full_sort.h"
-#include "exec/vectorized/chunks_sorter_topn.h"
 
 namespace starrocks {
 class BufferControlBlock;

--- a/be/src/exec/pipeline/sort/sort_context.cpp
+++ b/be/src/exec/pipeline/sort/sort_context.cpp
@@ -2,17 +2,63 @@
 
 #include "exec/pipeline/sort/sort_context.h"
 
-namespace starrocks {
-namespace pipeline {
+#include "exec/vectorized/sorting/merge.h"
+#include "exec/vectorized/sorting/sorting.h"
+
+namespace starrocks::pipeline {
+
+using vectorized::Permutation;
+using vectorized::Columns;
+
+ChunkPtr SortContext::pull_chunk() {
+    if (!_is_merge_finish) {
+        _merge_inputs();
+        _is_merge_finish = true;
+        return _merged_chunk;
+    } else {
+        return {};
+    }
+}
+
+void SortContext::_merge_inputs() {
+    int64_t total_rows = _total_rows.load(std::memory_order_relaxed);
+    int64_t require_rows = ((_limit < 0) ? total_rows : std::min(_limit, total_rows));
+
+    std::vector<ChunkPtr> partial_sorted_chunks;
+    for (int i = 0; i < _num_partition_sinkers; ++i) {
+        auto& partition_sorter = _chunks_sorter_partions[i];
+        auto data_segment = partition_sorter->get_result_data_segment();
+        if (data_segment != nullptr) {
+            size_t partition_rows = partition_sorter->get_partition_rows();
+            Permutation* sorted_permutation = partition_sorter->get_permutation();
+
+            if (partition_rows > 0) {
+                ChunkPtr sorted_chunk = data_segment->chunk;
+                if (sorted_permutation) {
+                    ChunkPtr assemble = sorted_chunk->clone_empty(sorted_permutation->size());
+                    append_by_permutation(assemble.get(), {sorted_chunk}, *sorted_permutation);
+                    partial_sorted_chunks.emplace_back(assemble);
+                } else {
+                    partial_sorted_chunks.emplace_back(sorted_chunk);
+                }
+            }
+        }
+    }
+
+    // TODO: avoid merge into a big chunk
+    merge_sorted_chunks(_sort_desc, &_sort_exprs, partial_sorted_chunks, &_merged_chunk, require_rows);
+}
+
 SortContextFactory::SortContextFactory(RuntimeState* state, bool is_merging, int64_t limit, int32_t num_right_sinkers,
+                                       const std::vector<ExprContext*>& sort_exprs,
                                        const std::vector<bool>& is_asc_order, const std::vector<bool>& is_null_first)
         : _state(state),
           _is_merging(is_merging),
           _sort_contexts(is_merging ? 1 : num_right_sinkers),
           _limit(limit),
           _num_right_sinkers(num_right_sinkers),
-          _is_asc_order(is_asc_order),
-          _is_null_first(is_null_first) {}
+          _sort_exprs(sort_exprs),
+          _sort_descs(is_asc_order, is_null_first) {}
 
 SortContextPtr SortContextFactory::create(int32_t idx) {
     size_t actual_idx = _is_merging ? 0 : idx;
@@ -21,9 +67,8 @@ SortContextPtr SortContextFactory::create(int32_t idx) {
     DCHECK_LE(actual_idx, _sort_contexts.size());
     if (!_sort_contexts[actual_idx]) {
         _sort_contexts[actual_idx] =
-                std::make_shared<SortContext>(_state, _limit, num_sinkers, _is_asc_order, _is_null_first);
+                std::make_shared<SortContext>(_state, _limit, num_sinkers, _sort_exprs, _sort_descs);
     }
     return _sort_contexts[actual_idx];
 }
-} // namespace pipeline
-} // namespace starrocks
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/sort/sort_context.h
+++ b/be/src/exec/pipeline/sort/sort_context.h
@@ -47,7 +47,9 @@ public:
         return _num_partition_finished.load(std::memory_order_acquire) == _num_partition_sinkers;
     }
 
-    bool is_output_finished() const { return _is_merge_finish; }
+    bool is_output_finished() const {
+        return is_partition_sort_finished() && _is_merge_finish && _next_output_row >= _total_rows;
+    }
 
     ChunkPtr pull_chunk();
 
@@ -66,6 +68,7 @@ private:
     std::vector<std::shared_ptr<ChunksSorter>> _chunks_sorter_partions; // Partial sorters
     bool _is_merge_finish = false;
     ChunkPtr _merged_chunk;
+    size_t _next_output_row = 0; // TODO: remove this field, chop chunks when merging sort
 };
 
 class SortContextFactory {

--- a/be/src/exec/pipeline/sort/sort_context.h
+++ b/be/src/exec/pipeline/sort/sort_context.h
@@ -10,32 +10,33 @@
 #include "column/vectorized_fwd.h"
 #include "exec/pipeline/context_with_dependency.h"
 #include "exec/vectorized/chunks_sorter.h"
-#include "exec/vectorized/chunks_sorter_full_sort.h"
-#include "exec/vectorized/chunks_sorter_topn.h"
+#include "exec/vectorized/sorting/sorting.h"
 
-namespace starrocks {
-namespace vectorized {
-class ChunksSorter;
-}
+namespace starrocks::pipeline {
 
-namespace pipeline {
-using namespace vectorized;
 class SortContext;
 using SortContextPtr = std::shared_ptr<SortContext>;
-using SortContexts = std::vector<SortContextPtr>;
+using vectorized::ChunkPtr;
+using vectorized::ChunksSorter;
+using vectorized::SortDescs;
+
 class SortContext final : public ContextWithDependency {
 public:
     explicit SortContext(RuntimeState* state, int64_t limit, const int32_t num_right_sinkers,
-                         const std::vector<bool>& is_asc_order, const std::vector<bool>& is_null_first)
+                         const std::vector<ExprContext*> sort_exprs, const SortDescs& sort_descs)
             : _state(state),
               _limit(limit),
               _num_partition_sinkers(num_right_sinkers),
-              _comparer(limit, is_asc_order, is_null_first) {
+              _sort_exprs(sort_exprs),
+              _sort_desc(sort_descs) {
         _chunks_sorter_partions.reserve(num_right_sinkers);
-        _data_segment_heaps.reserve(num_right_sinkers);
     }
 
     void close(RuntimeState* state) override {}
+
+    void add_partition_chunks_sorter(std::shared_ptr<ChunksSorter> chunks_sorter) {
+        _chunks_sorter_partions.push_back(chunks_sorter);
+    }
 
     void finish_partition(uint64_t partition_rows) {
         _total_rows.fetch_add(partition_rows, std::memory_order_relaxed);
@@ -43,209 +44,35 @@ public:
     }
 
     bool is_partition_sort_finished() const {
-        if (_is_partions_finish) {
-            return true;
-        }
-
-        // Used to drive merge sort.
-        auto is_partions_finish = _num_partition_finished.load(std::memory_order_acquire) == _num_partition_sinkers;
-        if (is_partions_finish) {
-            _require_rows = ((_limit < 0) ? _total_rows.load(std::memory_order_relaxed)
-                                          : std::min(_limit, _total_rows.load(std::memory_order_relaxed)));
-            _heapify_chunks_sorter();
-            _is_partions_finish = true;
-        }
-
-        return is_partions_finish;
+        return _num_partition_finished.load(std::memory_order_acquire) == _num_partition_sinkers;
     }
 
-    bool is_output_finished() const { return _next_output_row >= _require_rows; }
+    bool is_output_finished() const { return _is_merge_finish; }
 
-    // Dispatch logic for full sort and topn,
-    // provide different index parrterns through lambda expression.
-    ChunkPtr pull_chunk() {
-        if (_limit < 0) {
-            return pull_chunk([](DataSegment* min_heap_entry) -> uint32_t {
-                return (*min_heap_entry->_sorted_permutation)[min_heap_entry->_next_output_row++].index_in_chunk;
-            });
-        } else {
-            return pull_chunk(
-                    [](DataSegment* min_heap_entry) -> uint32_t { return min_heap_entry->_next_output_row++; });
-        }
-    }
-
-    /*
-     * Output the result data in a streaming manner,
-     * And dynamically adjust the heap.
-     */
-    // uint32_t UpdateFunc(DataSegment* min_heap_entry)
-    template <class UpdateFunc>
-    ChunkPtr pull_chunk(UpdateFunc&& get_and_update_min_entry_func) {
-        // Get appropriate size
-        uint32_t needed_rows = std::min((uint64_t)_state->chunk_size(), _require_rows - _next_output_row);
-
-        uint32_t rows_number = 0;
-        if (rows_number >= needed_rows) {
-            return std::make_shared<vectorized::Chunk>();
-        }
-
-        // for data range from one DataSegment, used to collect chunks.
-        std::vector<uint32_t> selective_values;
-        selective_values.reserve(needed_rows);
-        auto min_heap_entry = _data_segment_heaps[0];
-        ChunkPtr result_chunk = min_heap_entry->chunk->clone_empty_with_slot(needed_rows);
-
-        // Optimization for single thread.
-        if (_data_segment_heaps.size() == 1) {
-            for (; rows_number < needed_rows; ++rows_number) {
-                selective_values.push_back(get_and_update_min_entry_func(min_heap_entry));
-            }
-
-            result_chunk->append_selective(*min_heap_entry->chunk, selective_values.data(), 0, selective_values.size());
-            _next_output_row += rows_number;
-            return result_chunk;
-        }
-
-        // get the first data
-        selective_values.push_back(get_and_update_min_entry_func(min_heap_entry));
-        _adjust_heap();
-        ++rows_number;
-
-        while (rows_number < needed_rows) {
-            if (min_heap_entry == _data_segment_heaps[0]) {
-                // data from the same data segment, just add selective value.
-                selective_values.push_back(get_and_update_min_entry_func(min_heap_entry));
-            } else {
-                // data from different data segment, just copy datas to reuslt chunk.
-                result_chunk->append_selective(*min_heap_entry->chunk, selective_values.data(), 0,
-                                               selective_values.size());
-                // re-select min-heap entry.
-                min_heap_entry = _data_segment_heaps[0];
-                selective_values.clear();
-                selective_values.push_back(get_and_update_min_entry_func(min_heap_entry));
-            }
-
-            _adjust_heap();
-            ++rows_number;
-        }
-
-        _next_output_row += rows_number;
-        // last copy of data
-        result_chunk->append_selective(*min_heap_entry->chunk, selective_values.data(), 0, selective_values.size());
-        return result_chunk;
-    }
-
-    void add_partition_chunks_sorter(std::shared_ptr<ChunksSorter> chunks_sorter) {
-        _chunks_sorter_partions.push_back(chunks_sorter);
-    }
+    ChunkPtr pull_chunk();
 
 private:
+    void _merge_inputs();
+
     RuntimeState* _state;
     const int64_t _limit;
-    // size of all chunks from all partitions.
-    std::atomic<int64_t> _total_rows = 0;
-
-    // Data that actually needs to be processed, it
-    // is computed from _limit and _total_rows.
-    mutable int64_t _require_rows = 0;
-
     const int32_t _num_partition_sinkers;
+    const std::vector<ExprContext*> _sort_exprs;
+    const vectorized::SortDescs _sort_desc;
+
+    std::atomic<int64_t> _total_rows = 0; // size of all chunks from all partitions.
     std::atomic<int32_t> _num_partition_finished = 0;
 
-    // Is used to gather all partition sorted chunks,
-    // partition per ChunksSorter.
-    std::vector<std::shared_ptr<ChunksSorter>> _chunks_sorter_partions;
-    class Comparer {
-    public:
-        Comparer(int64_t limit, const std::vector<bool>& is_asc_order, const std::vector<bool>& is_null_first)
-                : _is_topn(limit >= 0) {
-            size_t col_num = is_asc_order.size();
-            _sort_order_flag.resize(col_num);
-            _null_first_flag.resize(col_num);
-            for (size_t i = 0; i < is_asc_order.size(); ++i) {
-                _sort_order_flag[i] = is_asc_order.at(i) ? 1 : -1;
-                if (is_asc_order.at(i)) {
-                    _null_first_flag[i] = is_null_first.at(i) ? -1 : 1;
-                } else {
-                    _null_first_flag[i] = is_null_first.at(i) ? 1 : -1;
-                }
-            }
-        }
-
-        bool operator()(const DataSegment* a, const DataSegment* b) {
-            // We used different index pattern for topn and full sort.
-            if (_is_topn) {
-                return a->compare_at(a->_next_output_row, *b, b->_next_output_row, _sort_order_flag, _null_first_flag) >
-                       0;
-            } else {
-                return a->compare_at((*a->_sorted_permutation)[a->_next_output_row].index_in_chunk, *b,
-                                     (*b->_sorted_permutation)[b->_next_output_row].index_in_chunk, _sort_order_flag,
-                                     _null_first_flag) > 0;
-            }
-        }
-
-    private:
-        const bool _is_topn;
-
-        // This is inherited from TopNNode.
-        std::vector<int> _sort_order_flag; // 1 for ascending, -1 for descending.
-        std::vector<int> _null_first_flag; // 1 for greatest, -1 for least.
-    };
-    Comparer _comparer;
-
-    mutable bool _is_partions_finish = false;
-
-    // It's better to use DataSegment than ChunksSorter as heap's element.
-    mutable std::vector<DataSegment*> _data_segment_heaps;
-
-    // Construct heap for DataSegment through _data_segment_heaps.
-    // DataSegment per ChunksSorter.
-    void _heapify_chunks_sorter() const {
-        auto num_chunks_sorter = _num_partition_sinkers;
-        for (int i = 0; i < num_chunks_sorter; ++i) {
-            auto data_segment = _chunks_sorter_partions[i]->get_result_data_segment();
-            if (data_segment != nullptr) {
-                // get size from ChunksSorter into DataSegment.
-                data_segment->_partitions_rows = _chunks_sorter_partions[i]->get_partition_rows();
-                // _sorted_permutation is just used for full sort to index data,
-                // and topn is needn't it.
-                data_segment->_sorted_permutation = _chunks_sorter_partions[i]->get_permutation();
-                if (data_segment->_partitions_rows > 0) {
-                    _data_segment_heaps.emplace_back(data_segment);
-                }
-            }
-        }
-
-        // _data_segment_heaps[0] is the toppest entry.
-        std::make_heap(_data_segment_heaps.begin(), _data_segment_heaps.end(), _comparer);
-    }
-
-    // Minimum entry of heap is updated by get_and_update_min_entry_func and may be not the minimum entry anymore,
-    // so pop it from the heap and push it to heap again, to make sure _data_segment_heaps as a complete heap.
-    void _adjust_heap() {
-        auto* old_min_heap_entry = _data_segment_heaps[0];
-
-        // Swaps the value in the position first and the value in the position last-1
-        // and makes the subrange [first, last-1) into a heap.
-        std::pop_heap(_data_segment_heaps.begin(), _data_segment_heaps.end(), _comparer);
-
-        if (old_min_heap_entry->has_next()) {
-            // Inserts the element at the position last-1 into the max heap defined by the range [first, last-1).
-            std::push_heap(_data_segment_heaps.begin(), _data_segment_heaps.end(), _comparer);
-        } else {
-            // Remove the empty data segment.
-            _data_segment_heaps.pop_back();
-        }
-    }
-
-    size_t _next_output_row = 0;
+    std::vector<std::shared_ptr<ChunksSorter>> _chunks_sorter_partions; // Partial sorters
+    bool _is_merge_finish = false;
+    ChunkPtr _merged_chunk;
 };
-class SortContextFactory;
-using SortContextFactoryPtr = std::shared_ptr<SortContextFactory>;
+
 class SortContextFactory {
 public:
     SortContextFactory(RuntimeState* state, bool is_merging, int64_t limit, int32_t num_right_sinkers,
-                       const std::vector<bool>& _is_asc_order, const std::vector<bool>& is_null_first);
+                       const std::vector<ExprContext*>& sort_exprs, const std::vector<bool>& _is_asc_order,
+                       const std::vector<bool>& is_null_first);
 
     SortContextPtr create(int32_t idx);
 
@@ -256,11 +83,11 @@ private:
     // _is_merging is false means to pipe each output stream of PartitionSortSinkOperators to an independent
     // LocalMergeSortSourceOperator respectively for scenarios of AnalyticNode with partition by.
     const bool _is_merging;
-    SortContexts _sort_contexts;
+    std::vector<SortContextPtr> _sort_contexts;
     const int64_t _limit;
     const int32_t _num_right_sinkers;
-    std::vector<bool> _is_asc_order;
-    std::vector<bool> _is_null_first;
+    const std::vector<ExprContext*> _sort_exprs;
+    const SortDescs _sort_descs;
 };
-} // namespace pipeline
-} // namespace starrocks
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/vectorized/chunks_sorter.h
+++ b/be/src/exec/vectorized/chunks_sorter.h
@@ -19,14 +19,6 @@ struct DataSegment {
     ChunkPtr chunk;
     Columns order_by_columns;
 
-    uint32_t _next_output_row = 0;
-    uint64_t _partitions_rows = 0;
-
-    // used for full sort.
-    Permutation* _sorted_permutation = nullptr;
-
-    bool has_next() { return _next_output_row < _partitions_rows; }
-
     DataSegment() : chunk(std::make_shared<Chunk>()) {}
 
     DataSegment(const std::vector<ExprContext*>* sort_exprs, const ChunkPtr& cnk) { init(sort_exprs, cnk); }

--- a/be/src/exec/vectorized/sorting/merge_cascade.cpp
+++ b/be/src/exec/vectorized/sorting/merge_cascade.cpp
@@ -27,14 +27,15 @@ struct CursorAlgo {
         perm.resize(end - start);
     }
 
-    // Find upper_bound in left column based on right row
-    static size_t upper_bound(SortDesc desc, const Column& column, std::pair<size_t, size_t> range,
-                              const Column& rhs_column, size_t rhs_row) {
-        size_t first = range.first;
-        size_t count = range.second - range.first;
+    // TODO(Murphy): optimize with column-wise binary-search
+    // Find the first row in `run` greater than last row in cut. AKA upper-bound
+    // @return row index of upper bound
+    static size_t chunk_upper_bound(const SortDescs& sort_descs, const SortedRun& run, const SortedRun& cut) {
+        size_t first = run.start_index();
+        size_t count = run.num_rows();
         while (count > 0) {
             size_t mid = first + count / 2;
-            int x = column.compare_at(mid, rhs_row, rhs_column, desc.null_first) * desc.sort_order;
+            int x = run.compare_row(sort_descs, cut, mid, cut.end_index() - 1);
             if (x <= 0) {
                 first = mid + 1;
                 count -= count / 2 + 1;
@@ -43,44 +44,6 @@ struct CursorAlgo {
             }
         }
         return first;
-    }
-
-    static size_t lower_bound(SortDesc desc, const Column& column, std::pair<size_t, size_t> range,
-                              const Column& rhs_column, size_t rhs_row) {
-        size_t first = range.first;
-        size_t count = range.second - range.first;
-        while (count > 0) {
-            size_t mid = first + count / 2;
-            int x = column.compare_at(mid, rhs_row, rhs_column, desc.null_first) * desc.sort_order;
-            if (x < 0) {
-                first = mid + 1;
-                count -= count / 2 + 1;
-            } else {
-                count /= 2;
-            }
-        }
-        return first;
-    }
-
-    // Cutoff by upper_bound
-    // @return last row index of upper bound
-    static size_t cutoff_run(const SortDescs& sort_descs, SortedRun run, std::pair<SortedRun, size_t> cut) {
-        std::pair<size_t, size_t> search_range = run.range;
-        size_t res = 0;
-
-        for (int i = 0; i < sort_descs.num_columns(); i++) {
-            auto& lhs_col = *run.get_column(i);
-            auto& rhs_col = *cut.first.get_column(i);
-            SortDesc desc = sort_descs.get_column_desc(i);
-            size_t lower = lower_bound(desc, lhs_col, search_range, rhs_col, cut.second);
-            size_t upper = upper_bound(desc, lhs_col, search_range, rhs_col, cut.second);
-            res = upper;
-            if (upper - lower <= 1) {
-                break;
-            }
-            search_range = {lower, upper};
-        }
-        return res;
     }
 };
 
@@ -144,19 +107,20 @@ StatusOr<ChunkUniquePtr> MergeTwoCursor::merge_sorted_cursor_two_way() {
     const SortDescs& sort_desc = _sort_desc;
     ChunkUniquePtr result;
 
-    if (_left_run.empty()) {
-        // TODO: avoid copy
-        result = _right_run.clone_slice();
-        _right_run.reset();
-    } else if (_right_run.empty()) {
+    int intersect = _left_run.intersect(sort_desc, _right_run);
+    if (intersect < 0) {
         result = _left_run.clone_slice();
         _left_run.reset();
+        VLOG_ROW << "merge_sorted_cursor_two_way output left run";
+    } else if (intersect > 0) {
+        result = _right_run.clone_slice();
+        _right_run.reset();
+        VLOG_ROW << "merge_sorted_cursor_two_way output right run";
     } else {
+        // Cutoff right by left tail
         int tail_cmp = CursorAlgo::compare_tail(sort_desc, _left_run, _right_run);
         if (tail_cmp <= 0) {
-            // Cutoff right by left tail
-            size_t right_cut =
-                    CursorAlgo::cutoff_run(sort_desc, _right_run, std::make_pair(_left_run, _left_run.num_rows() - 1));
+            size_t right_cut = CursorAlgo::chunk_upper_bound(sort_desc, _right_run, _left_run);
             SortedRun right_1(_right_run, _right_run.start_index(), right_cut);
             SortedRun right_2(_right_run, right_cut, _right_run.end_index());
 
@@ -168,13 +132,14 @@ StatusOr<ChunkUniquePtr> MergeTwoCursor::merge_sorted_cursor_two_way() {
             ChunkUniquePtr merged = _left_run.chunk->clone_empty(perm.size());
             append_by_permutation(merged.get(), {_left_run.chunk, right_1.chunk}, perm);
 
-            _left_run.reset();
+            VLOG_ROW << fmt::format("merge_sorted_cursor_two_way output left and right [{}, {})",
+                                    _right_run.start_index(), right_cut);
             _right_run = right_2;
             result = std::move(merged);
+            _left_run.reset();
         } else {
             // Cutoff left by right tail
-            size_t left_cut =
-                    CursorAlgo::cutoff_run(sort_desc, _left_run, std::make_pair(_right_run, _right_run.num_rows() - 1));
+            size_t left_cut = CursorAlgo::chunk_upper_bound(sort_desc, _left_run, _right_run);
             SortedRun left_1(_left_run, _left_run.start_index(), left_cut);
             SortedRun left_2(_left_run, left_cut, _left_run.end_index());
 
@@ -186,9 +151,11 @@ StatusOr<ChunkUniquePtr> MergeTwoCursor::merge_sorted_cursor_two_way() {
             ChunkUniquePtr merged = _left_run.chunk->clone_empty(perm.size());
             append_by_permutation(merged.get(), {_right_run.chunk, left_1.chunk}, perm);
 
+            VLOG_ROW << fmt::format("merge_sorted_cursor_two_way output right and left [{}, {})",
+                                    _left_run.start_index(), left_cut);
             _left_run = left_2;
-            _right_run.reset();
             result = std::move(merged);
+            _right_run.reset();
         }
     }
 

--- a/be/src/exec/vectorized/sorting/merge_cascade.cpp
+++ b/be/src/exec/vectorized/sorting/merge_cascade.cpp
@@ -18,6 +18,9 @@ struct CursorAlgo {
     }
 
     static void trim_permutation(SortedRun left, SortedRun right, Permutation& perm) {
+        if (perm.size() <= left.num_rows() + right.num_rows()) {
+            return;
+        }
         size_t start = left.range.first + right.range.first;
         size_t end = left.range.second + right.range.second;
         std::copy(perm.begin() + start, perm.begin() + end, perm.begin());
@@ -154,8 +157,8 @@ StatusOr<ChunkUniquePtr> MergeTwoCursor::merge_sorted_cursor_two_way() {
             // Cutoff right by left tail
             size_t right_cut =
                     CursorAlgo::cutoff_run(sort_desc, _right_run, std::make_pair(_left_run, _left_run.num_rows() - 1));
-            SortedRun right_1(_right_run.chunk, 0, right_cut);
-            SortedRun right_2(_right_run.chunk, right_cut, _right_run.num_rows());
+            SortedRun right_1(_right_run, _right_run.start_index(), right_cut);
+            SortedRun right_2(_right_run, right_cut, _right_run.end_index());
 
             // Merge partial chunk
             Permutation perm;
@@ -172,27 +175,21 @@ StatusOr<ChunkUniquePtr> MergeTwoCursor::merge_sorted_cursor_two_way() {
             // Cutoff left by right tail
             size_t left_cut =
                     CursorAlgo::cutoff_run(sort_desc, _left_run, std::make_pair(_right_run, _right_run.num_rows() - 1));
-            SortedRun left_1(_left_run.chunk, 0, left_cut);
-            SortedRun left_2(_left_run.chunk, left_cut, _left_run.num_rows());
+            SortedRun left_1(_left_run, _left_run.start_index(), left_cut);
+            SortedRun left_2(_left_run, left_cut, _left_run.end_index());
 
             // Merge partial chunk
             Permutation perm;
             RETURN_IF_ERROR(merge_sorted_chunks_two_way(sort_desc, _right_run, left_1, &perm));
             CursorAlgo::trim_permutation(left_1, _right_run, perm);
             DCHECK_EQ(_right_run.num_rows() + left_1.num_rows(), perm.size());
-            std::unique_ptr<Chunk> merged = _left_run.chunk->clone_empty(perm.size());
+            ChunkUniquePtr merged = _left_run.chunk->clone_empty(perm.size());
             append_by_permutation(merged.get(), {_right_run.chunk, left_1.chunk}, perm);
 
             _left_run = left_2;
             _right_run.reset();
             result = std::move(merged);
         }
-
-#ifndef NDEBUG
-        for (int i = 0; i < result->num_rows(); i++) {
-            fmt::print("merge row: {}\n", result->debug_row(i));
-        }
-#endif
     }
 
     return result;

--- a/be/src/exec/vectorized/sorting/merge_column.cpp
+++ b/be/src/exec/vectorized/sorting/merge_column.cpp
@@ -1,5 +1,7 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
 
+#include <numeric>
+
 #include "column/array_column.h"
 #include "column/chunk.h"
 #include "column/column_visitor_adapter.h"
@@ -210,6 +212,7 @@ public:
             if (intersect != 0) {
                 size_t left_rows = left_run.num_rows();
                 size_t right_rows = right_run.num_rows();
+                DCHECK_LT(left_rows + right_rows, Column::MAX_CAPACITY_LIMIT);
                 output->resize(0);
                 output->reserve(left_rows + right_rows);
 
@@ -233,6 +236,7 @@ public:
                 std::vector<EqualRange> equal_ranges;
                 equal_ranges.emplace_back(left_run.range, right_run.range);
                 size_t count = left_run.range.second + right_run.range.second;
+                DCHECK_LT(count, Column::MAX_CAPACITY_LIMIT);
                 output->resize(count);
                 equal_ranges.reserve(std::max((size_t)1, count / 4));
 
@@ -273,14 +277,43 @@ private:
     }
 };
 
-Status merge_sorted_chunks_two_way(const SortDescs& sort_desc, const ChunkPtr left, const ChunkPtr right,
-                                   Permutation* output) {
-    DCHECK_LE(sort_desc.num_columns(), left->num_columns());
-    DCHECK_LE(sort_desc.num_columns(), right->num_columns());
+void SortedRun::reset() {
+    chunk->reset();
+    orderby.clear();
+    range = {};
+}
 
-    SortedRun left_run(left, 0, left->num_rows());
-    SortedRun right_run(right, 0, right->num_rows());
-    return MergeTwoChunk::merge_sorted_chunks_two_way(sort_desc, left_run, right_run, output);
+void SortedRun::resize(size_t size) {
+    if (num_rows() <= size) {
+        return;
+    }
+    // Only resize the range but not clone chunk
+    range.second = range.first + (uint32_t)size;
+}
+
+size_t SortedRuns::num_rows() const {
+    size_t res = 0;
+    for (auto& run : chunks) {
+        res += run.num_rows();
+    }
+    return res;
+}
+
+void SortedRuns::resize(size_t size) {
+    // Do not expand if prodive a larger size
+    if (num_rows() <= size) {
+        return;
+    }
+    size_t accumulate = 0;
+    for (int i = 0; i < chunks.size(); i++) {
+        auto& run = chunks[i];
+        if (accumulate + run.num_rows() >= size) {
+            run.resize(size - accumulate);
+            chunks.resize(i + 1);
+            break;
+        }
+        accumulate += run.num_rows();
+    }
 }
 
 Status merge_sorted_chunks_two_way(const SortDescs& sort_desc, const SortedRun& left, const SortedRun& right,
@@ -323,16 +356,23 @@ Status merge_sorted_chunks_two_way(const SortDescs& sort_desc, const std::vector
             sort_exprs);
     MergeTwoCursor merger(sort_desc, std::move(left_cursor), std::move(right_cursor));
     ChunkConsumer consumer = [&](ChunkUniquePtr chunk) {
-        output->chunks.push_back(SortedRun(ChunkPtr(chunk.release())));
+        output->chunks.push_back(SortedRun(ChunkPtr(chunk.release()), sort_exprs));
         return Status::OK();
     };
     return merger.consume_all(consumer);
 }
 
-// Merge multiple chunks in two-way merge
 Status merge_sorted_chunks(const SortDescs& descs, const std::vector<ExprContext*>* sort_exprs,
-                           const std::vector<ChunkPtr>& chunks, ChunkPtr* output) {
-    std::deque<SortedRuns> queue(chunks.begin(), chunks.end());
+                           const std::vector<ChunkPtr>& chunks, SortedRuns* output, size_t limit) {
+    if (chunks.empty()) {
+        return Status::OK();
+    }
+    std::deque<SortedRuns> queue;
+    for (auto& chunk : chunks) {
+        if (!chunk->is_empty()) {
+            queue.push_back(SortedRun(chunk, sort_exprs));
+        }
+    }
     while (queue.size() > 1) {
         SortedRuns left = queue.front();
         queue.pop_front();
@@ -340,12 +380,25 @@ Status merge_sorted_chunks(const SortDescs& descs, const std::vector<ExprContext
         queue.pop_front();
 
         SortedRuns merged;
+        // TODO: push the limit to merge procedure
         RETURN_IF_ERROR(merge_sorted_chunks_two_way(descs, sort_exprs, left, right, &merged));
+        if (limit > 0) {
+            merged.resize(limit);
+        }
 
         queue.push_back(merged);
     }
+    *output = queue.front();
 
-    *output = queue.front().assemble();
+    return Status::OK();
+}
+
+// Merge multiple chunks in two-way merge
+Status merge_sorted_chunks(const SortDescs& descs, const std::vector<ExprContext*>* sort_exprs,
+                           const std::vector<ChunkPtr>& chunks, ChunkPtr* output, size_t limit) {
+    SortedRuns merged;
+    merge_sorted_chunks(descs, sort_exprs, chunks, &merged, limit);
+    *output = merged.assemble();
 
     return Status::OK();
 }

--- a/be/src/exec/vectorized/sorting/sort_column.cpp
+++ b/be/src/exec/vectorized/sorting/sort_column.cpp
@@ -1,5 +1,7 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
 
+#include <algorithm>
+
 #include "column/array_column.h"
 #include "column/binary_column.h"
 #include "column/chunk.h"
@@ -463,6 +465,10 @@ void append_by_permutation(Chunk* dst, const std::vector<ChunkPtr>& chunks, cons
     for (auto& chunk : chunks) {
         src.push_back(chunk.get());
     }
+    DCHECK_LT(std::max_element(perm.begin(), perm.end(),
+                               [](auto& lhs, auto& rhs) { return lhs.chunk_index < rhs.chunk_index; })
+                      ->chunk_index,
+              chunks.size());
     append_by_permutation(dst, src, perm);
 }
 

--- a/be/src/exec/vectorized/sorting/sorting.h
+++ b/be/src/exec/vectorized/sorting/sorting.h
@@ -69,6 +69,15 @@ struct SortDescs {
 
     SortDescs() = default;
     ~SortDescs() = default;
+
+    SortDescs(const std::vector<bool>& orders, const std::vector<bool>& null_firsts) {
+        descs.resize(orders.size());
+        for (size_t i = 0; i < orders.size(); ++i) {
+            descs[i].sort_order = orders.at(i) ? 1 : -1;
+            descs[i].null_first = (null_firsts.at(i) ? -1 : 1) * descs[i].sort_order;
+        }
+    }
+
     SortDescs(const std::vector<int>& orders, const std::vector<int>& nulls) {
         DCHECK_EQ(orders.size(), nulls.size());
         descs.reserve(orders.size());
@@ -79,10 +88,7 @@ struct SortDescs {
 
     size_t num_columns() const { return descs.size(); }
 
-    SortDesc get_column_desc(int col) const {
-        DCHECK_LT(col, descs.size());
-        return descs[col];
-    }
+    SortDesc get_column_desc(int col) const { return descs[col]; }
 };
 
 } // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/topn_node.cpp
+++ b/be/src/exec/vectorized/topn_node.cpp
@@ -195,7 +195,8 @@ pipeline::OpFactories TopNNode::decompose_to_pipeline(pipeline::PipelineBuilderC
     auto degree_of_parallelism =
             down_cast<SourceOperatorFactory*>(operators_sink_with_sort[0].get())->degree_of_parallelism();
     auto sort_context_factory = std::make_shared<SortContextFactory>(
-            runtime_state(), is_merging, _limit, degree_of_parallelism, _is_asc_order, _is_null_first);
+            runtime_state(), is_merging, _limit, degree_of_parallelism, _sort_exec_exprs.lhs_ordering_expr_ctxs(),
+            _is_asc_order, _is_null_first);
 
     // Create a shared RefCountedRuntimeFilterCollector
     auto&& rc_rf_probe_collector = std::make_shared<RcRfProbeCollector>(2, std::move(this->runtime_filter_collector()));

--- a/be/test/exec/vectorized/chunks_sorter_bench_test.cpp
+++ b/be/test/exec/vectorized/chunks_sorter_bench_test.cpp
@@ -380,7 +380,7 @@ static void do_merge_columnwise(benchmark::State& state, int num_runs) {
     ChunkPtr chunk2 = std::make_shared<Chunk>(columns, map);
 
     int64_t num_rows = 0;
-    SortDescs sort_desc({1, 1, 1}, {-1, -1, -1});
+    SortDescs sort_desc(std::vector<int>{1, 1, 1}, std::vector<int>{-1, -1, -1});
     for (auto _ : state) {
         ChunkPtr merged;
         std::vector<ChunkPtr> inputs;
@@ -392,7 +392,7 @@ static void do_merge_columnwise(benchmark::State& state, int num_runs) {
                 inputs.push_back(chunk2);
             }
         }
-        merge_sorted_chunks(sort_desc, &sort_exprs, inputs, &merged);
+        merge_sorted_chunks(sort_desc, &sort_exprs, inputs, &merged, 0);
         ASSERT_EQ(input_rows, merged->num_rows());
 
         num_rows += merged->num_rows();

--- a/be/test/exec/vectorized/sorting_test.cpp
+++ b/be/test/exec/vectorized/sorting_test.cpp
@@ -206,10 +206,32 @@ TEST(SortingTest, sorted_runs) {
 }
 
 TEST(SortingTest, merge_sorted_chunks) {
-    ColumnPtr col1 = build_sorted_column(TypeDescriptor(TYPE_INT), 0, 0, 100, 1);
-    ColumnPtr col2 = build_sorted_column(TypeDescriptor(TYPE_INT), 1, 0, 100, 1);
-    Chunk::SlotHashMap slot_map{{0, 0}, {1, 1}};
-    ChunkPtr chunk = std::make_shared<Chunk>(Columns{col1, col2}, slot_map);
+    std::vector<ChunkPtr> input_chunks;
+    Chunk::SlotHashMap slot_map{{0, 0}};
+
+    std::vector<std::vector<int>> input_runs = {{-2074, -1691, -1400, -969, -767, -725},
+                                                {-680, -571, -568},
+                                                {-2118, -2065, -1328, -1103, -1099, -1093},
+                                                {-950, -807, -604}};
+    for (auto& input_numbers : input_runs) {
+        ColumnPtr column = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false);
+        for (int x : input_numbers) {
+            column->append_datum(Datum((int32_t)x));
+        }
+        ChunkPtr chunk = std::make_shared<Chunk>(Columns{column}, slot_map);
+        input_chunks.push_back(chunk);
+    }
+
+    std::vector<std::unique_ptr<ColumnRef>> exprs;
+    std::vector<ExprContext*> sort_exprs;
+    exprs.push_back(std::make_unique<ColumnRef>(TypeDescriptor(TYPE_INT), 0));
+    sort_exprs.push_back(new ExprContext(exprs.back().get()));
+    DeferOp defer([&]() { clear_exprs(sort_exprs); });
+
+    SortDescs sort_desc(std::vector<int>{1}, std::vector<int>{-1});
+    SortedRuns output;
+    merge_sorted_chunks(sort_desc, &sort_exprs, input_chunks, &output, 0);
+    ASSERT_TRUE(output.is_sorted(sort_desc));
 }
 
 TEST(SortingTest, merge_sorted_stream) {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Re-submit the #5289, fix a crash bug.

Bug: 
- The Exchange operator could only accept chunk which not exceed the `state->chunk_size()` rows, but the LocalMergeSort Operator would output a larger chunk.
- Fix: Chop the output chunk of LocalMergeSort operator according to the `state->chunk_size()`.
