### PR TITLE
Optimize implementation of version graph

### DIFF
--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -393,14 +393,6 @@ struct HashOfVersion {
     }
 };
 
-// It is used to represent Graph vertex.
-struct Vertex {
-    int64_t value = 0;
-    std::list<int64_t> edges;
-
-    Vertex(int64_t v) : value(v) {}
-};
-
 class Field;
 class WrapperField;
 using KeyRange = std::pair<WrapperField*, WrapperField*>;

--- a/be/src/storage/version_graph.cpp
+++ b/be/src/storage/version_graph.cpp
@@ -220,41 +220,20 @@ void VersionGraph::construct_version_graph(const std::vector<RowsetMetaSharedPtr
         return;
     }
 
-    // Distill vertex values from versions in TabletMeta.
-    std::vector<int64_t> vertex_values;
-    vertex_values.reserve(2 * rs_metas.size());
-
-    for (const auto& rs_meta : rs_metas) {
-        vertex_values.push_back(rs_meta->start_version());
-        vertex_values.push_back(rs_meta->end_version() + 1);
-        if (max_version != nullptr and *max_version < rs_meta->end_version()) {
-            *max_version = rs_meta->end_version();
-        }
-    }
-    std::sort(vertex_values.begin(), vertex_values.end());
-
-    // Items in vertex_values are sorted, but not unique.
-    // we choose unique items in vertex_values to create vertexes.
-    int64_t last_vertex_value = -1;
-    for (size_t i = 0; i < vertex_values.size(); ++i) {
-        if (i != 0 && vertex_values[i] == last_vertex_value) {
-            continue;
-        }
-
-        // Add vertex to graph.
-        _add_vertex_to_graph(vertex_values[i]);
-        last_vertex_value = vertex_values[i];
-    }
     // Create edges for version graph according to TabletMeta's versions.
     for (const auto& rs_meta : rs_metas) {
         // Versions in header are unique.
         // We ensure _vertex_index_map has its start_version.
-        int64_t start_vertex_index = _vertex_index_map[rs_meta->start_version()];
-        int64_t end_vertex_index = _vertex_index_map[rs_meta->end_version() + 1];
+        int64_t start_vertex_index = _add_vertex_to_graph(rs_meta->start_version());
+        int64_t end_vertex_index = _add_vertex_to_graph(rs_meta->end_version() + 1);
         // Add one edge from start_version to end_version.
-        _version_graph[start_vertex_index].edges.push_front(end_vertex_index);
+        _version_graph[start_vertex_index].edges.emplace(end_vertex_index);
         // Add reverse edge from end_version to start_version.
-        _version_graph[end_vertex_index].edges.push_front(start_vertex_index);
+        _version_graph[end_vertex_index].edges.emplace(start_vertex_index);
+
+        if (max_version != nullptr && *max_version < rs_meta->end_version()) {
+            *max_version = rs_meta->end_version();
+        }
     }
 }
 
@@ -267,69 +246,59 @@ void VersionGraph::reconstruct_version_graph(const std::vector<RowsetMetaSharedP
 
 void VersionGraph::add_version_to_graph(const Version& version) {
     // Add version.first as new vertex of version graph if not exist.
-    int64_t start_vertex_value = version.first;
-    int64_t end_vertex_value = version.second + 1;
-
-    // Add vertex to graph.
-    _add_vertex_to_graph(start_vertex_value);
-    _add_vertex_to_graph(end_vertex_value);
-
-    int64_t start_vertex_index = _vertex_index_map[start_vertex_value];
-    int64_t end_vertex_index = _vertex_index_map[end_vertex_value];
+    int64_t start_vertex_index = _add_vertex_to_graph(version.first);
+    int64_t end_vertex_index = _add_vertex_to_graph(version.second + 1);
 
     // We assume this version is new version, so we just add two edges
     // into version graph. add one edge from start_version to end_version
-    _version_graph[start_vertex_index].edges.push_front(end_vertex_index);
+    _version_graph[start_vertex_index].edges.emplace(end_vertex_index);
 
     // We add reverse edge(from end_version to start_version) to graph
-    _version_graph[end_vertex_index].edges.push_front(start_vertex_index);
+    _version_graph[end_vertex_index].edges.emplace(start_vertex_index);
 }
 
 Status VersionGraph::delete_version_from_graph(const Version& version) {
     int64_t start_vertex_value = version.first;
     int64_t end_vertex_value = version.second + 1;
+    auto start_iter = _vertex_index_map.find(start_vertex_value);
+    auto end_iter = _vertex_index_map.find(end_vertex_value);
 
-    if (_vertex_index_map.find(start_vertex_value) == _vertex_index_map.end() ||
-        _vertex_index_map.find(end_vertex_value) == _vertex_index_map.end()) {
+    if (start_iter == _vertex_index_map.end() || end_iter == _vertex_index_map.end()) {
         LOG(WARNING) << "vertex for version does not exists. "
                      << "version=" << version.first << "-" << version.second;
         return Status::NotFound("Not found version");
     }
 
-    int64_t start_vertex_index = _vertex_index_map[start_vertex_value];
-    int64_t end_vertex_index = _vertex_index_map[end_vertex_value];
+    int64_t start_vertex_index = start_iter->second;
+    int64_t end_vertex_index = end_iter->second;
     // Remove edge and its reverse edge.
     // When there are same versions in edges, just remove the frist version.
-    auto start_edges_iter = _version_graph[start_vertex_index].edges.begin();
-    while (start_edges_iter != _version_graph[start_vertex_index].edges.end()) {
-        if (*start_edges_iter == end_vertex_index) {
-            _version_graph[start_vertex_index].edges.erase(start_edges_iter);
-            break;
-        }
-        start_edges_iter++;
+    auto start_edges_iter = _version_graph[start_vertex_index].edges.find(end_vertex_value);
+    if (start_edges_iter != _version_graph[start_vertex_index].edges.end()) {
+        _version_graph[start_vertex_index].edges.erase(start_edges_iter);
     }
 
-    auto end_edges_iter = _version_graph[end_vertex_index].edges.begin();
-    while (end_edges_iter != _version_graph[end_vertex_index].edges.end()) {
-        if (*end_edges_iter == start_vertex_index) {
-            _version_graph[end_vertex_index].edges.erase(end_edges_iter);
-            break;
-        }
-        end_edges_iter++;
+    auto end_edges_iter = _version_graph[end_vertex_index].edges.find(start_vertex_value);
+    if (end_edges_iter != _version_graph[end_vertex_index].edges.end()) {
+        _version_graph[end_vertex_index].edges.erase(end_edges_iter);
     }
 
     return Status::OK();
 }
 
-void VersionGraph::_add_vertex_to_graph(int64_t vertex_value) {
+int64_t VersionGraph::_add_vertex_to_graph(int64_t vertex_value) {
     // Vertex with vertex_value already exists.
-    if (_vertex_index_map.find(vertex_value) != _vertex_index_map.end()) {
+    auto iter = _vertex_index_map.find(vertex_value);
+    if (iter != _vertex_index_map.end()) {
         VLOG(3) << "vertex with vertex value already exists. value=" << vertex_value;
-        return;
+        return iter->second;
     }
 
     _version_graph.emplace_back(Vertex(vertex_value));
+
     _vertex_index_map[vertex_value] = _version_graph.size() - 1;
+
+    return _vertex_index_map[vertex_value];
 }
 
 Status VersionGraph::capture_consistent_versions(const Version& spec_version,
@@ -340,95 +309,52 @@ Status VersionGraph::capture_consistent_versions(const Version& spec_version,
         return Status::InternalError("Invalid specified version");
     }
 
-    // bfs_queue's element is vertex_index.
-    std::queue<int64_t> bfs_queue;
-    // predecessor[i] means the predecessor of vertex_index 'i'.
-    std::vector<int64_t> predecessor(_version_graph.size());
-    // visited[int64_t]==true means it had entered bfs_queue.
-    std::vector<bool> visited(_version_graph.size());
-    // [start_vertex_value, end_vertex_value)
-    int64_t start_vertex_value = spec_version.first;
-    int64_t end_vertex_value = spec_version.second + 1;
-    // -1 is invalid vertex index.
-    int64_t start_vertex_index = -1;
-    // -1 is valid vertex index.
-    int64_t end_vertex_index = -1;
+    auto start_vertex_iter = _vertex_index_map.find(spec_version.first);
+    auto end_vertex_iter = _vertex_index_map.find(spec_version.second + 1);
 
-    for (size_t i = 0; i < _version_graph.size(); ++i) {
-        if (_version_graph[i].value == start_vertex_value) {
-            start_vertex_index = i;
-        }
-        if (_version_graph[i].value == end_vertex_value) {
-            end_vertex_index = i;
-        }
-    }
-
-    if (start_vertex_index < 0 || end_vertex_index < 0) {
+    if (start_vertex_iter == _vertex_index_map.end() || end_vertex_iter == _vertex_index_map.end()) {
         LOG(WARNING) << "fail to find path in version_graph. "
                      << "spec_version: " << spec_version.first << "-" << spec_version.second;
         return Status::NotFound("Version not found");
     }
 
-    for (size_t i = 0; i < _version_graph.size(); ++i) {
-        visited[i] = false;
-    }
-
-    bfs_queue.push(start_vertex_index);
-    visited[start_vertex_index] = true;
-    // The predecessor of root is itself.
-    predecessor[start_vertex_index] = start_vertex_index;
-
-    while (bfs_queue.empty() == false && visited[end_vertex_index] == false) {
-        int64_t top_vertex_index = bfs_queue.front();
-        bfs_queue.pop();
-        for (const auto& it : _version_graph[top_vertex_index].edges) {
-            if (visited[it] == false) {
-                // If we don't support reverse version in the path, and start vertex
-                // value is larger than the end vertex value, we skip this edge.
-                if (_version_graph[top_vertex_index].value > _version_graph[it].value) {
-                    continue;
-                }
-
-                visited[it] = true;
-                predecessor[it] = top_vertex_index;
-                bfs_queue.push(it);
+    int64_t end_value = spec_version.second + 1;
+    auto cur_idx = start_vertex_iter->second;
+    while (_version_graph[cur_idx].value != end_value) {
+        int64_t next_idx = -1;
+        for (const auto& it : _version_graph[cur_idx].edges) {
+            // reverse edge
+            if (_version_graph[it].value < _version_graph[cur_idx].value) {
+                break;
             }
+
+            // cross edge
+            if (_version_graph[it].value > end_value) {
+                continue;
+            }
+
+            next_idx = it;
+            break;
+        }
+
+        if (next_idx > -1) {
+            if (version_path != nullptr) {
+                version_path->emplace_back(_version_graph[cur_idx].value, _version_graph[next_idx].value - 1);
+            }
+            cur_idx = next_idx;
+        } else {
+            LOG(WARNING) << "fail to find path in version_graph. "
+                         << "spec_version: " << spec_version.first << "-" << spec_version.second;
+            return Status::NotFound("Version not found");
         }
     }
 
-    if (!visited[end_vertex_index]) {
-        LOG(WARNING) << "fail to find path in version_graph. "
-                     << "spec_version: " << spec_version.first << "-" << spec_version.second;
-        return Status::NotFound("Version not found");
-    }
-
-    std::vector<int64_t> reversed_path;
-    int64_t tmp_vertex_index = end_vertex_index;
-    reversed_path.push_back(tmp_vertex_index);
-
-    // For start_vertex_index, its predecessor must be itself.
-    while (predecessor[tmp_vertex_index] != tmp_vertex_index) {
-        tmp_vertex_index = predecessor[tmp_vertex_index];
-        reversed_path.push_back(tmp_vertex_index);
-    }
-
-    if (version_path != nullptr) {
-        // Make version_path from reversed_path.
+    if (VLOG_ROW_IS_ON && version_path != nullptr) {
         std::stringstream shortest_path_for_debug;
-        for (size_t path_id = reversed_path.size() - 1; path_id > 0; --path_id) {
-            int64_t tmp_start_vertex_value = _version_graph[reversed_path[path_id]].value;
-            int64_t tmp_end_vertex_value = _version_graph[reversed_path[path_id - 1]].value;
-
-            // tmp_start_vertex_value mustn't be equal to tmp_end_vertex_value
-            if (tmp_start_vertex_value <= tmp_end_vertex_value) {
-                version_path->emplace_back(tmp_start_vertex_value, tmp_end_vertex_value - 1);
-            } else {
-                version_path->emplace_back(tmp_end_vertex_value, tmp_start_vertex_value - 1);
-            }
-
-            shortest_path_for_debug << (*version_path)[version_path->size() - 1] << ' ';
+        for (const auto& version : *version_path) {
+            shortest_path_for_debug << version << ' ';
         }
-        VLOG(10) << "success to find path for spec_version. spec_version=" << spec_version
+        VLOG_ROW << "success to find path for spec_version. spec_version=" << spec_version
                  << ", path=" << shortest_path_for_debug.str();
     }
 

--- a/be/src/storage/version_graph.h
+++ b/be/src/storage/version_graph.h
@@ -30,6 +30,17 @@
 #include "storage/rowset/rowset_meta.h"
 
 namespace starrocks {
+
+// It is used to represent Graph vertex.
+struct Vertex {
+    int64_t value = 0;
+    // one vertex to other vertex may have multi same edge
+    // this is just for compatibility with previous implementations.
+    std::multiset<int64_t, std::greater<int64_t>> edges;
+
+    Vertex(int64_t v) : value(v) {}
+};
+
 /// VersionGraph class which is implemented to build and maintain total versions of rowsets.
 /// This class use adjacency-matrix represent rowsets version and links. A vertex is a version
 /// and a link is the _version object of a rowset (from start version to end version + 1).
@@ -53,7 +64,7 @@ public:
 
 private:
     /// Private method add a version to graph.
-    void _add_vertex_to_graph(int64_t vertex_value);
+    int64_t _add_vertex_to_graph(int64_t vertex_value);
 
     // OLAP version contains two parts, [start_version, end_version]. In order
     // to construct graph, the OLAP version has two corresponding vertex, one

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -138,6 +138,7 @@ set(EXEC_FILES
         ./storage/primary_index_test.cpp
         ./storage/primary_key_encoder_test.cpp
         ./storage/tablet_mgr_test.cpp
+        ./storage/version_graph_test.cpp
         ./storage/rowset_update_state_test.cpp
         ./storage/rowset/beta_rowset_test.cpp
         ./storage/rowset/binary_dict_page_test.cpp

--- a/be/test/storage/version_graph_test.cpp
+++ b/be/test/storage/version_graph_test.cpp
@@ -1,0 +1,205 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#include "storage/version_graph.h"
+
+#include <gtest/gtest.h>
+
+namespace starrocks::vectorized {
+
+TEST(VersionGraphTest, capture) {
+    VersionGraph graph;
+
+    std::vector<RowsetMetaSharedPtr> rs_meta;
+    for (int i = 0; i < 10; i++) {
+        rs_meta.emplace_back(std::make_shared<RowsetMeta>());
+        rs_meta.back()->set_start_version(i);
+        rs_meta.back()->set_end_version(i);
+    }
+
+    for (int i = 0; i < 10; i=i+2) {
+        rs_meta.emplace_back(std::make_shared<RowsetMeta>());
+        rs_meta.back()->set_start_version(i);
+        rs_meta.back()->set_end_version(i+1);
+    }
+
+    rs_meta.emplace_back(std::make_shared<RowsetMeta>());
+    rs_meta.back()->set_start_version(0);
+    rs_meta.back()->set_end_version(5);
+
+    rs_meta.emplace_back(std::make_shared<RowsetMeta>());
+    rs_meta.back()->set_start_version(11);
+    rs_meta.back()->set_end_version(11);
+
+    int64_t max_version = -1;
+    graph.construct_version_graph(rs_meta, &max_version);
+
+    EXPECT_EQ(max_version, 11);
+
+    for (int i = 0; i < 10; i++) {
+        std::vector<Version> version_path;
+        EXPECT_EQ(graph.capture_consistent_versions(Version(i, i), &version_path).ok(), true);
+        EXPECT_EQ(version_path.size(), 1);
+        EXPECT_EQ(version_path[0].first, i);
+        EXPECT_EQ(version_path[0].second, i);
+    }
+
+    {
+        std::vector<Version> version_path;
+        EXPECT_EQ(graph.capture_consistent_versions(Version(0, 1), &version_path).ok(), true);
+        EXPECT_EQ(version_path.size(), 1);
+        EXPECT_EQ(version_path[0].first, 0);
+        EXPECT_EQ(version_path[0].second, 1);
+    }
+
+    {
+        std::vector<Version> version_path;
+        EXPECT_EQ(graph.capture_consistent_versions(Version(0, 2), &version_path).ok(), true);
+        EXPECT_EQ(version_path.size(), 2);
+        EXPECT_EQ(version_path[0].first, 0);
+        EXPECT_EQ(version_path[0].second, 1);
+        EXPECT_EQ(version_path[1].first, 2);
+        EXPECT_EQ(version_path[1].second, 2);
+    }
+
+    {
+        std::vector<Version> version_path;
+        EXPECT_EQ(graph.capture_consistent_versions(Version(0, 3), &version_path).ok(), true);
+        EXPECT_EQ(version_path.size(), 2);
+        EXPECT_EQ(version_path[0].first, 0);
+        EXPECT_EQ(version_path[0].second, 1);
+        EXPECT_EQ(version_path[1].first, 2);
+        EXPECT_EQ(version_path[1].second, 3);
+    }
+
+    {
+        std::vector<Version> version_path;
+        EXPECT_EQ(graph.capture_consistent_versions(Version(0, 5), &version_path).ok(), true);
+        EXPECT_EQ(version_path.size(), 1);
+        EXPECT_EQ(version_path[0].first, 0);
+        EXPECT_EQ(version_path[0].second, 5);
+    }
+
+    {
+        std::vector<Version> version_path;
+        EXPECT_EQ(graph.capture_consistent_versions(Version(0, 8), &version_path).ok(), true);
+        EXPECT_EQ(version_path.size(), 3);
+        EXPECT_EQ(version_path[0].first, 0);
+        EXPECT_EQ(version_path[0].second, 5);
+        EXPECT_EQ(version_path[1].first, 6);
+        EXPECT_EQ(version_path[1].second, 7);
+        EXPECT_EQ(version_path[2].first, 8);
+        EXPECT_EQ(version_path[2].second, 8);
+    }
+
+    {
+        std::vector<Version> version_path;
+        EXPECT_EQ(graph.capture_consistent_versions(Version(0, 9), &version_path).ok(), true);
+        EXPECT_EQ(version_path.size(), 3);
+        EXPECT_EQ(version_path[0].first, 0);
+        EXPECT_EQ(version_path[0].second, 5);
+        EXPECT_EQ(version_path[1].first, 6);
+        EXPECT_EQ(version_path[1].second, 7);
+        EXPECT_EQ(version_path[2].first, 8);
+        EXPECT_EQ(version_path[2].second, 9);
+    }
+
+    {
+        std::vector<Version> version_path;
+        EXPECT_EQ(graph.capture_consistent_versions(Version(0, 10), &version_path).ok(), false);
+    }
+
+    {
+        std::vector<Version> version_path;
+        EXPECT_EQ(graph.capture_consistent_versions(Version(0, 11), &version_path).ok(), false);
+    }
+
+    {
+        std::vector<Version> version_path;
+        EXPECT_EQ(graph.capture_consistent_versions(Version(0, 12), &version_path).ok(), false);
+    }
+
+    graph.add_version_to_graph(Version(10,10));
+
+    {
+        std::vector<Version> version_path;
+        EXPECT_EQ(graph.capture_consistent_versions(Version(0, 10), &version_path).ok(), true);
+        EXPECT_EQ(version_path.size(), 4);
+        EXPECT_EQ(version_path[0].first, 0);
+        EXPECT_EQ(version_path[0].second, 5);
+        EXPECT_EQ(version_path[1].first, 6);
+        EXPECT_EQ(version_path[1].second, 7);
+        EXPECT_EQ(version_path[2].first, 8);
+        EXPECT_EQ(version_path[2].second, 9);
+        EXPECT_EQ(version_path[3].first, 10);
+        EXPECT_EQ(version_path[3].second, 10);
+    }
+
+    {
+        std::vector<Version> version_path;
+        EXPECT_EQ(graph.capture_consistent_versions(Version(0, 11), &version_path).ok(), true);
+        EXPECT_EQ(version_path.size(), 5);
+        EXPECT_EQ(version_path[0].first, 0);
+        EXPECT_EQ(version_path[0].second, 5);
+        EXPECT_EQ(version_path[1].first, 6);
+        EXPECT_EQ(version_path[1].second, 7);
+        EXPECT_EQ(version_path[2].first, 8);
+        EXPECT_EQ(version_path[2].second, 9);
+        EXPECT_EQ(version_path[3].first, 10);
+        EXPECT_EQ(version_path[3].second, 10);
+        EXPECT_EQ(version_path[4].first, 11);
+        EXPECT_EQ(version_path[4].second, 11);
+    }
+
+    EXPECT_EQ(graph.delete_version_from_graph(Version(1,1)).ok(), true);
+
+    {
+        std::vector<Version> version_path;
+        EXPECT_EQ(graph.capture_consistent_versions(Version(0, 11), &version_path).ok(), true);
+        EXPECT_EQ(version_path.size(), 5);
+        EXPECT_EQ(version_path[0].first, 0);
+        EXPECT_EQ(version_path[0].second, 5);
+        EXPECT_EQ(version_path[1].first, 6);
+        EXPECT_EQ(version_path[1].second, 7);
+        EXPECT_EQ(version_path[2].first, 8);
+        EXPECT_EQ(version_path[2].second, 9);
+        EXPECT_EQ(version_path[3].first, 10);
+        EXPECT_EQ(version_path[3].second, 10);
+        EXPECT_EQ(version_path[4].first, 11);
+        EXPECT_EQ(version_path[4].second, 11);
+    }
+
+    EXPECT_EQ(graph.delete_version_from_graph(Version(8,9)).ok(), true);
+
+    {
+        std::vector<Version> version_path;
+        EXPECT_EQ(graph.capture_consistent_versions(Version(0, 11), &version_path).ok(), true);
+        EXPECT_EQ(version_path.size(), 6);
+        EXPECT_EQ(version_path[0].first, 0);
+        EXPECT_EQ(version_path[0].second, 5);
+        EXPECT_EQ(version_path[1].first, 6);
+        EXPECT_EQ(version_path[1].second, 7);
+        EXPECT_EQ(version_path[2].first, 8);
+        EXPECT_EQ(version_path[2].second, 8);
+        EXPECT_EQ(version_path[3].first, 9);
+        EXPECT_EQ(version_path[3].second, 9);
+        EXPECT_EQ(version_path[4].first, 10);
+        EXPECT_EQ(version_path[4].second, 10);
+        EXPECT_EQ(version_path[5].first, 11);
+        EXPECT_EQ(version_path[5].second, 11);
+    }
+
+    EXPECT_EQ(graph.delete_version_from_graph(Version(10,10)).ok(), true);
+
+    {
+        std::vector<Version> version_path;
+        EXPECT_EQ(graph.capture_consistent_versions(Version(0, 11), &version_path).ok(), false);
+    }
+
+    rs_meta.clear();
+    max_version = -1;
+    graph.reconstruct_version_graph(rs_meta, &max_version);
+
+    EXPECT_EQ(max_version, -1);
+}
+
+} // namespace starrocks::vectorized


### PR DESCRIPTION
1. Simplify the generation logic of the version graph
2. Use the greedy algorithm to find the shortest version path, replacing the original BFS algorithm

## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5477

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered, and what measures have you taken to fix the bug?) -->
In theory, there is only a containment relationship between the Versions of StarRocks, and there is no cross relationship.
(0->0 1->1 2->2 0->2) exists
(0->2 1->3) not exists
So that we can use the greedy algorithm other than BFS
