### PR TITLE
Opt: set size of connection pool of jprotobuf to 16 by default

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -434,16 +434,9 @@ public class Config extends ConfigBase {
     @ConfField
     public static int brpc_number_of_concurrent_requests_processed = 4096;
 
-    @ConfField
-    public static int brpc_number_of_concurrent_requests_processed_for_share_channel = 16;
-
     // BRPC idle wait time (ms)
     @ConfField
     public static int brpc_idle_wait_max_time = 10000;
-
-    // enable using a share channel for BRPC client
-    @ConfField
-    public static boolean enable_brpc_share_channel = true;
 
     /**
      * FE mysql server port

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -434,6 +434,9 @@ public class Config extends ConfigBase {
     @ConfField
     public static int brpc_number_of_concurrent_requests_processed = 4096;
 
+    @ConfField
+    public static int brpc_number_of_concurrent_requests_processed_for_share_channel = 16;
+
     // BRPC idle wait time (ms)
     @ConfField
     public static int brpc_idle_wait_max_time = 10000;

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -430,9 +430,11 @@ public class Config extends ConfigBase {
     public static String thrift_server_type = ThriftServer.THREAD_POOL;
 
     // May be necessary to modify the following BRPC configurations in high concurrency scenarios.
-    // The number of concurrent requests BRPC can processed
+
+    // The size of BRPC connection pool. It will limit the concurrency of sending requests, because
+    // each request must borrow a connection from the pool.
     @ConfField
-    public static int brpc_number_of_concurrent_requests_processed = 4096;
+    public static int brpc_connection_pool_size = 16;
 
     // BRPC idle wait time (ms)
     @ConfField

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/BackendServiceProxy.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/BackendServiceProxy.java
@@ -64,18 +64,16 @@ public class BackendServiceProxy {
 
     private BackendServiceProxy() {
         final RpcClientOptions rpcOptions = new RpcClientOptions();
-        if (Config.enable_brpc_share_channel) {
-            rpcOptions.setShareThreadPoolUnderEachProxy(true);
-            rpcOptions.setShareChannelPool(true);
-            rpcOptions.setMaxTotoal(Config.brpc_number_of_concurrent_requests_processed_for_share_channel);
-            // After the RPC request sending, the connection will be closed,
-            // if the number of total connections is greater than MaxIdleSize.
-            // Therefore, MaxIdleSize shouldn't less than MaxTotal.
-            rpcOptions.setMaxIdleSize(Config.brpc_number_of_concurrent_requests_processed_for_share_channel);
-        } else {
-            rpcOptions.setMaxTotoal(Config.brpc_number_of_concurrent_requests_processed);
-            rpcOptions.setMaxIdleSize(Config.brpc_number_of_concurrent_requests_processed);
-        }
+        // If false, different methods to a service endpoint use different connection pool,
+        // which will create too many connections.
+        // If true, all the methods to a service endpoint use the same connection pool.
+        rpcOptions.setShareThreadPoolUnderEachProxy(true);
+        rpcOptions.setShareChannelPool(true);
+        rpcOptions.setMaxTotoal(Config.brpc_number_of_concurrent_requests_processed);
+        // After the RPC request sending, the connection will be closed,
+        // if the number of total connections is greater than MaxIdleSize.
+        // Therefore, MaxIdleSize shouldn't less than MaxTotal for the async requests.
+        rpcOptions.setMaxIdleSize(Config.brpc_number_of_concurrent_requests_processed);
         rpcOptions.setMaxWait(Config.brpc_idle_wait_max_time);
         rpcClient = new RpcClient(rpcOptions);
         serviceMap = Maps.newHashMap();

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/BackendServiceProxy.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/BackendServiceProxy.java
@@ -69,11 +69,11 @@ public class BackendServiceProxy {
         // If true, all the methods to a service endpoint use the same connection pool.
         rpcOptions.setShareThreadPoolUnderEachProxy(true);
         rpcOptions.setShareChannelPool(true);
-        rpcOptions.setMaxTotoal(Config.brpc_number_of_concurrent_requests_processed);
+        rpcOptions.setMaxTotoal(Config.brpc_connection_pool_size);
         // After the RPC request sending, the connection will be closed,
         // if the number of total connections is greater than MaxIdleSize.
         // Therefore, MaxIdleSize shouldn't less than MaxTotal for the async requests.
-        rpcOptions.setMaxIdleSize(Config.brpc_number_of_concurrent_requests_processed);
+        rpcOptions.setMaxIdleSize(Config.brpc_connection_pool_size);
         rpcOptions.setMaxWait(Config.brpc_idle_wait_max_time);
         rpcClient = new RpcClient(rpcOptions);
         serviceMap = Maps.newHashMap();

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/BackendServiceProxy.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/BackendServiceProxy.java
@@ -67,9 +67,14 @@ public class BackendServiceProxy {
         if (Config.enable_brpc_share_channel) {
             rpcOptions.setShareThreadPoolUnderEachProxy(true);
             rpcOptions.setShareChannelPool(true);
-            rpcOptions.setThreadPoolSize(1);
+            rpcOptions.setMaxTotoal(Config.brpc_number_of_concurrent_requests_processed_for_share_channel);
+            // After the RPC request sending, the connection will be closed,
+            // if the number of total connections is greater than MaxIdleSize.
+            // Therefore, MaxIdleSize shouldn't less than MaxTotal.
+            rpcOptions.setMaxIdleSize(Config.brpc_number_of_concurrent_requests_processed_for_share_channel);
         } else {
-            rpcOptions.setThreadPoolSize(Config.brpc_number_of_concurrent_requests_processed);
+            rpcOptions.setMaxTotoal(Config.brpc_number_of_concurrent_requests_processed);
+            rpcOptions.setMaxIdleSize(Config.brpc_number_of_concurrent_requests_processed);
         }
         rpcOptions.setMaxWait(Config.brpc_idle_wait_max_time);
         rpcClient = new RpcClient(rpcOptions);


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR relates ：
Relates #4711.

## Problem Summary：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

As for 1000-concurrency test, sometimes it throws `ERROR : Backend not found. Check if any backend is down or not`, and FE has this WARN log:
```
2022-04-24 15:30:01,606 WARN (starrocks-mysql-nio-pool-2014|2179) [BackendServiceProxy.execPlanFragmentAsync():120] Execute plan fragment catch a exception, address=172.26.34.187:8060
java.lang.RuntimeException: Timeout waiting for idle object
        at com.baidu.jprotobuf.pbrpc.transport.ChannelPool.getChannel(ChannelPool.java:86) ~[jprotobuf-rpc-core-4.1.8.jar:?]
        at com.baidu.jprotobuf.pbrpc.transport.RpcChannel.getConnection(RpcChannel.java:73) ~[jprotobuf-rpc-core-4.1.8.jar:?]
        at com.baidu.jprotobuf.pbrpc.client.ProtobufRpcProxy.invoke(ProtobufRpcProxy.java:499) ~[jprotobuf-rpc-core-4.1.8.jar:?]
        at com.sun.proxy.$Proxy31.execPlanFragmentAsync(Unknown Source) ~[?:?]
        at com.starrocks.rpc.BackendServiceProxy.execPlanFragmentAsync(BackendServiceProxy.java:103) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.Coordinator$BackendExecState.execRemoteFragmentAsync(Coordinator.java:2002) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.Coordinator.exec(Coordinator.java:559) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.StmtExecutor.handleQueryStmt(StmtExecutor.java:678) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:380) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:284) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.dispatch(ConnectProcessor.java:431) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.processOnce(ConnectProcessor.java:667) ~[starrocks-fe.jar:?]
        at com.starrocks.mysql.nio.ReadListener.lambda$handleEvent$0(ReadListener.java:55) ~[starrocks-fe.jar:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_202]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_202]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_202]
Caused by: java.util.NoSuchElementException: Timeout waiting for idle object
        at org.apache.commons.pool2.impl.GenericObjectPool.borrowObject(GenericObjectPool.java:449) ~[commons-pool2-2.3.jar:2.3]
        at org.apache.commons.pool2.impl.GenericObjectPool.borrowObject(GenericObjectPool.java:363) ~[commons-pool2-2.3.jar:2.3]
        at com.baidu.jprotobuf.pbrpc.transport.ChannelPool.getChannel(ChannelPool.java:80) ~[jprotobuf-rpc-core-4.1.8.jar:?]
        ... 15 more
2022-04-24 15:30:01,607 WARN (starrocks-mysql-nio-pool-2014|2179) [Coordinator.exec():587] exec plan fragment failed, errmsg=Timeout waiting for idle object, host: 172.26.34.187, code: THRIFT_RPC_ERROR, fragmentId=F00, backend=172.26.34.187:9060
2022-04-24 15:30:01,738 WARN (starrocks-mysql-nio-pool-1953|2118) [SimpleScheduler.addToBlacklist():143] add black list 10004
```

This is because the size of shared connection pool of `jprotobuf` is 1, which means protobuf RPC requests can only send sequentially. And the timeout for getting connection from the connection pool is 10s.
There are too many RPC requests for 1000-concurrency test. As a result, some requests timeout and add this BE to blacklist.

## Modification
- Rename `Config.brpc_number_of_concurrent_requests_processed` to `brpc_connection_pool_size`, default is 16, to avoid the existed users have already change `brpc_number_of_concurrent_requests_processed` in config file.
- Set the size of shared connection pool to `Config.brpc_connection_pool_size`.
- set MaxIdleSize to the size of shared connection pool for both shared and non-shared connection pool.
         After the RPC request sending, the connection will be closed,  if the number of total connections is greater than MaxIdleSize. Therefore, MaxIdleSize shouldn't less than MaxTotal.
- Remove the branch `enable_brpc_share_channel=false`

