### PR TITLE
reduce chunk_size in scan for huge length types

### DIFF
--- a/be/src/common/constexpr.h
+++ b/be/src/common/constexpr.h
@@ -3,6 +3,11 @@
 #pragma once
 
 namespace starrocks {
+
 // default value of chunk_size, it's a value decided at compile time
 constexpr const int DEFAULT_CHUNK_SIZE = 4096;
+
+// Chunk size for some huge type(HLL, JSON)
+constexpr inline int CHUNK_SIZE_FOR_HUGE_TYPE = 4096;
+
 } // namespace starrocks

--- a/be/src/exec/pipeline/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/olap_chunk_source.cpp
@@ -3,6 +3,7 @@
 #include "exec/pipeline/olap_chunk_source.h"
 
 #include "column/column_helper.h"
+#include "common/constexpr.h"
 #include "exec/pipeline/scan_operator.h"
 #include "exec/vectorized/olap_scan_node.h"
 #include "exec/vectorized/olap_scan_prepare.h"
@@ -163,6 +164,20 @@ Status OlapChunkSource::_get_tablet(const TInternalScanRange* scan_range) {
     return Status::OK();
 }
 
+void OlapChunkSource::_decide_chunk_size() {
+    bool has_huge_length_type = std::any_of(_query_slots.begin(), _query_slots.end(),
+                                            [](auto& slot) { return slot->type().is_huge_type(); });
+    if (_limit != -1 && _limit < _runtime_state->chunk_size()) {
+        // Improve for select * from table limit x, x is small
+        _params.chunk_size = _limit;
+    } else {
+        _params.chunk_size = _runtime_state->chunk_size();
+    }
+    if (has_huge_length_type) {
+        _params.chunk_size = std::min(_params.chunk_size, CHUNK_SIZE_FOR_HUGE_TYPE);
+    }
+}
+
 Status OlapChunkSource::_init_reader_params(const std::vector<OlapScanRange*>& key_ranges,
                                             const std::vector<uint32_t>& scanner_columns,
                                             std::vector<uint32_t>& reader_columns) {
@@ -173,12 +188,7 @@ Status OlapChunkSource::_init_reader_params(const std::vector<OlapScanRange*>& k
     _params.profile = _runtime_profile;
     _params.runtime_state = _runtime_state;
     _params.use_page_cache = !config::disable_storage_page_cache;
-    // Improve for select * from table limit x, x is small
-    if (_limit != -1 && _limit < _runtime_state->chunk_size()) {
-        _params.chunk_size = _limit;
-    } else {
-        _params.chunk_size = _runtime_state->chunk_size();
-    }
+    _decide_chunk_size();
 
     PredicateParser parser(_tablet->tablet_schema());
     std::vector<PredicatePtr> preds;

--- a/be/src/exec/pipeline/olap_chunk_source.h
+++ b/be/src/exec/pipeline/olap_chunk_source.h
@@ -74,6 +74,7 @@ private:
     Status _read_chunk_from_storage([[maybe_unused]] RuntimeState* state, vectorized::Chunk* chunk);
     void _update_counter();
     void _update_realtime_counter(vectorized::Chunk* chunk);
+    void _decide_chunk_size();
 
     vectorized::TabletReaderParams _params = {};
 

--- a/be/src/runtime/types.h
+++ b/be/src/runtime/types.h
@@ -261,55 +261,9 @@ struct TypeDescriptor {
 
     inline bool is_collection_type() const { return type == TYPE_ARRAY || type == TYPE_MAP; }
 
-    /// Returns the byte size of this type.  Returns 0 for variable length types.
-    inline int get_byte_size() const {
-        switch (type) {
-        case TYPE_ARRAY:
-        case TYPE_MAP:
-        case TYPE_VARCHAR:
-        case TYPE_HLL:
-        case TYPE_OBJECT:
-        case TYPE_PERCENTILE:
-        case TYPE_JSON:
-            return 0;
-
-        case TYPE_NULL:
-        case TYPE_BOOLEAN:
-        case TYPE_TINYINT:
-            return 1;
-
-        case TYPE_SMALLINT:
-            return 2;
-
-        case TYPE_INT:
-        case TYPE_FLOAT:
-        case TYPE_DECIMAL32:
-            return 4;
-
-        case TYPE_BIGINT:
-        case TYPE_DOUBLE:
-        case TYPE_DECIMAL64:
-            return 8;
-
-        case TYPE_LARGEINT:
-        case TYPE_DATETIME:
-        case TYPE_DATE:
-        case TYPE_DECIMALV2:
-        case TYPE_DECIMAL128:
-            return 16;
-
-        case TYPE_DECIMAL:
-            return 40;
-
-        case INVALID_TYPE:
-        case TYPE_BINARY:
-        case TYPE_CHAR:
-        case TYPE_STRUCT:
-        case TYPE_TIME:
-            DCHECK(false);
-        }
-        return 0;
-    }
+    // For some types with potential huge length, whose memory consumption is far more than normal types,
+    // they need a different chunk_size setting
+    bool is_huge_type() const { return len >= 128; }
 
     /// Returns the size of a slot for this type.
     inline int get_slot_size() const {

--- a/be/src/runtime/types.h
+++ b/be/src/runtime/types.h
@@ -46,6 +46,7 @@ struct TypeDescriptor {
     static constexpr int MAX_VARCHAR_LENGTH = 1048576;
     static constexpr int MAX_CHAR_LENGTH = 255;
     static constexpr int MAX_CHAR_INLINE_LENGTH = 128;
+    static constexpr int DEFAULT_BITMAP_LENGTH = 128;
 
     /// Only set if type == TYPE_DECIMAL
     int precision{-1};
@@ -139,6 +140,12 @@ struct TypeDescriptor {
         return ret;
     }
 
+    static TypeDescriptor create_bitmap_type() {
+        TypeDescriptor ret(TYPE_OBJECT);
+        ret.len = DEFAULT_BITMAP_LENGTH;
+        return ret;
+    }
+
     static TypeDescriptor from_primtive_type(PrimitiveType type,
                                              [[maybe_unused]] int len = TypeDescriptor::MAX_VARCHAR_LENGTH,
                                              [[maybe_unused]] int precision = 27, [[maybe_unused]] int scale = 9) {
@@ -161,6 +168,8 @@ struct TypeDescriptor {
             return TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL128, precision, scale);
         case TYPE_JSON:
             return TypeDescriptor::create_json_type();
+        case TYPE_OBJECT:
+            return TypeDescriptor::create_bitmap_type();
         default:
             return TypeDescriptor(type);
         }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [x] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Reduce the chunk_size in Scan for huge length types, including JSON, HLL, BITMAP.

