### PR TITLE
[WIP]Support Async CTAS part1

### DIFF
--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -5303,6 +5303,8 @@ keyword ::=
     {: RESULT = id; :}
     | KW_CURRENT_TIMESTAMP:id
     {: RESULT = id; :}
+    | KW_SYNC:id
+    {: RESULT = id; :}
     ;
 
 // Identifier that contain keyword

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadManager.java
@@ -547,8 +547,8 @@ public class LoadManager implements Writable {
         }
     }
 
-    public void updateJobPrgress(Long jobId, Long beId, TUniqueId loadId, TUniqueId fragmentId,
-                                 long scannedRows, boolean isDone) {
+    public void updateJobProgress(Long jobId, Long beId, TUniqueId loadId, TUniqueId fragmentId,
+                                  long scannedRows, boolean isDone) {
         LoadJob job = idToLoadJob.get(jobId);
         if (job != null) {
             job.updateProgess(beId, loadId, fragmentId, scannedRows, isDone);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -1622,7 +1622,7 @@ public class Coordinator {
         }
 
         if (params.isSetLoaded_rows()) {
-            Catalog.getCurrentCatalog().getLoadManager().updateJobPrgress(
+            Catalog.getCurrentCatalog().getLoadManager().updateJobProgress(
                     jobId, params.backend_id, params.query_id, params.fragment_instance_id, params.loaded_rows,
                     params.done);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/InfoMessage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/InfoMessage.java
@@ -1,0 +1,23 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.qe;
+
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.transaction.TransactionStatus;
+
+public class InfoMessage {
+    @SerializedName("label")
+    private String label;
+    @SerializedName("status")
+    private TransactionStatus status;
+    @SerializedName("txnId")
+    private long txnId;
+    @SerializedName("err")
+    private String err;
+    public InfoMessage(String label, TransactionStatus status, long txnId, String err) {
+        this.label = label;
+        this.status = status;
+        this.txnId = txnId;
+        this.err = err;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -52,6 +52,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String IS_REPORT_SUCCESS = "is_report_success";
     public static final String PROFILING = "profiling";
     public static final String SQL_MODE = "sql_mode";
+    public static final String QUERY_MODE = "query_mode";
     public static final String RESOURCE_VARIABLE = "resource_group";
     public static final String AUTO_COMMIT = "autocommit";
     public static final String TX_ISOLATION = "tx_isolation";
@@ -238,6 +239,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // Set sqlMode to empty string
     @VariableMgr.VarAttr(name = SQL_MODE)
     private long sqlMode = 0L;
+
+    @VariableMgr.VarAttr(name = QUERY_MODE)
+    private String queryMode = "sync";
 
     @VariableMgr.VarAttr(name = RESOURCE_VARIABLE)
     private String resourceGroup = "normal";
@@ -552,6 +556,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public long getSqlMode() {
         return sqlMode;
+    }
+
+    public String getQueryMode() {
+        return queryMode;
     }
 
     public void setSqlMode(long sqlMode) {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionTracker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionTracker.java
@@ -1,0 +1,42 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.transaction;
+
+public class TransactionTracker {
+    private long transactionId = -1;
+    private long loadedRows = 0;
+    private int filteredRows = 0;
+    TransactionStatus txnStatus = TransactionStatus.UNKNOWN;
+
+    public long getTransactionId() {
+        return transactionId;
+    }
+
+    public void setTransactionId(long transactionId) {
+        this.transactionId = transactionId;
+    }
+
+    public long getLoadedRows() {
+        return loadedRows;
+    }
+
+    public void setLoadedRows(long loadedRows) {
+        this.loadedRows = loadedRows;
+    }
+
+    public int getFilteredRows() {
+        return filteredRows;
+    }
+
+    public void setFilteredRows(int filteredRows) {
+        this.filteredRows = filteredRows;
+    }
+
+    public TransactionStatus getTxnStatus() {
+        return txnStatus;
+    }
+
+    public void setTxnStatus(TransactionStatus txnStatus) {
+        this.txnStatus = txnStatus;
+    }
+}


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5326

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

**NOTE:This PR is still controversial, and it may not be implemented in this way in the future.**

By sorting out the process of StmtExecutor execution, the insert statement is asynchronous. The asynchronous method is done by directly starting a thread in the background.

There is no state information for processing tasks here. This is because the previous design is implemented through LoadJob, and LoadJob has only one state for Insert. If users want to query the state, they need to use HTTP API
http://${fe_host}:${fe_port}/api/${db_name}/get_load_state?label=${label}.

By setting set query_mode=async; both Insert and CTAS can support asynchronous immediate return execution.