### PR TITLE
Bugfix: incorrect json parsing on large json file

### DIFF
--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -348,8 +348,16 @@ Status StreamLoadAction::_process_put(HttpRequest* http_req, StreamLoadContext* 
     request.formatType = ctx->format;
     request.__set_loadId(ctx->id.to_thrift());
     if (ctx->use_streaming) {
-        auto pipe =
-                std::make_shared<StreamLoadPipe>(1024 * 1024 /* max_buffered_bytes */, 64 * 1024 /* min_chunk_size */);
+        // If this is a json file, set the min_chunk_size to the length of HTTP body,
+        // because the JsonReader can only parse a complete json file at once.
+        // TODO: chunked transfer encoding
+        bool json_format = ctx->format == TFileFormatType::FORMAT_JSON;
+        if (json_format && ctx->body_bytes == 0) {
+            return Status::InternalError("Does support chunked transfer encoding for JSON");
+        }
+        size_t min_chunk_size = json_format ? ctx->body_bytes : 1024;
+        size_t max_chunk_size = json_format ? ctx->body_bytes : 1024 * 1024;
+        auto pipe = std::make_shared<StreamLoadPipe>(max_chunk_size, min_chunk_size);
         RETURN_IF_ERROR(_exec_env->load_stream_mgr()->put(ctx->id, pipe));
         request.fileType = TFileType::FILE_STREAM;
         ctx->body_sink = pipe;

--- a/be/src/runtime/stream_load/stream_load_pipe.h
+++ b/be/src/runtime/stream_load/stream_load_pipe.h
@@ -54,7 +54,7 @@ public:
     Status append(const char* data, size_t size) override {
         size_t pos = 0;
         if (_write_buf != nullptr) {
-            if (size < _write_buf->remaining()) {
+            if (size <= _write_buf->remaining()) {
                 _write_buf->put_bytes(data, size);
                 return Status::OK();
             } else {


### PR DESCRIPTION
It's possible for our http server to split a json file
into multiple chunks, even if it's not chunked transfer
encoding. If so, the data read from StreamLoadPipe::read_one_message()
may not be complete json object and the parsing result would
be wrong.

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

