### PR TITLE
Refactor parquet `FileReader`

### DIFF
--- a/be/src/exec/vectorized/hdfs_scanner_parquet.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_parquet.cpp
@@ -72,7 +72,7 @@ Status HdfsParquetScanner::do_open(RuntimeState* runtime_state) {
     _reader = std::make_shared<parquet::FileReader>(runtime_state->chunk_size(), _file.get(),
                                                     _scanner_params.scan_ranges[0]->file_length);
     SCOPED_RAW_TIMER(&_stats.reader_init_ns);
-    RETURN_IF_ERROR(_reader->init(_file_read_param));
+    RETURN_IF_ERROR(_reader->init(&_file_read_param));
     return Status::OK();
 }
 

--- a/be/src/formats/parquet/column_chunk_reader.cpp
+++ b/be/src/formats/parquet/column_chunk_reader.cpp
@@ -5,6 +5,7 @@
 #include <memory>
 
 #include "env/env.h"
+#include "exec/vectorized/hdfs_scanner.h"
 #include "formats/parquet/encoding.h"
 #include "formats/parquet/encoding_dict.h"
 #include "formats/parquet/page_reader.h"

--- a/be/src/formats/parquet/column_chunk_reader.h
+++ b/be/src/formats/parquet/column_chunk_reader.h
@@ -9,7 +9,7 @@
 
 #include "column/column.h"
 #include "common/status.h"
-#include "exec/vectorized/hdfs_scanner.h"
+#include "env/env.h"
 #include "formats/parquet/encoding.h"
 #include "formats/parquet/level_codec.h"
 #include "gen_cpp/parquet_types.h"
@@ -18,6 +18,9 @@
 namespace starrocks {
 class RandomAccessFile;
 class BlockCompressionCodec;
+namespace vectorized {
+class HdfsScanStats;
+}
 
 } // namespace starrocks
 

--- a/be/src/formats/parquet/column_reader.cpp
+++ b/be/src/formats/parquet/column_reader.cpp
@@ -3,7 +3,9 @@
 #include "formats/parquet/column_reader.h"
 
 #include "column/array_column.h"
+#include "exec/vectorized/hdfs_scanner.h"
 #include "formats/parquet/stored_column_reader.h"
+#include "util/runtime_profile.h"
 
 namespace starrocks {
 class RandomAccessFile;

--- a/be/src/formats/parquet/file_reader.h
+++ b/be/src/formats/parquet/file_reader.h
@@ -106,19 +106,13 @@ private:
     vectorized::Schema _schema;
 
     std::vector<GroupReaderParam::Column> _read_cols;
-
-    std::vector<SlotId> _empty_chunk_slot_ids;
     size_t _total_row_count = 0;
     size_t _scan_row_count = 0;
     bool _is_only_partition_scan = false;
 
     // not exist column conjuncts eval false, file can be skipped
     bool _is_file_filtered = false;
-    // conjuncts that column is not exist in file
-    std::vector<ExprContext*> _not_exist_column_conjunct_ctxs;
-
     vectorized::HdfsFileReaderParam* _param;
-    bool _should_skip_file = false;
 };
 
 } // namespace starrocks::parquet

--- a/be/src/formats/parquet/file_reader.h
+++ b/be/src/formats/parquet/file_reader.h
@@ -16,7 +16,6 @@ namespace starrocks {
 class RandomAccessFile;
 
 namespace vectorized {
-class HdfsScanStats;
 class HdfsFileReaderParam;
 } // namespace vectorized
 
@@ -31,7 +30,8 @@ public:
     FileReader(int chunk_size, RandomAccessFile* file, uint64_t file_size);
     ~FileReader();
 
-    Status init(const starrocks::vectorized::HdfsFileReaderParam& param);
+    Status init(vectorized::HdfsFileReaderParam* param);
+
     Status get_next(vectorized::ChunkPtr* chunk);
 
 private:
@@ -40,18 +40,10 @@ private:
     // parse footer of parquet file
     Status _parse_footer();
 
-    // pre process schema columns, get the three type columns
-    // (1) columns of direct read
-    // (2) columns of convert typ
-    // (3) columns of not exist in parquet file
-    void _pre_process_schema();
+    void _prepare_read_columns();
 
-    // 1. get conjuncts that column is not exist in file, are used to filter file.
-    // 2. remove them from conjunct_ctxs_by_slot.
-    void _pre_process_conjunct_ctxs();
-
-    // filter file using not exist column conjuncts
-    Status _filter_file();
+    // init row group reader.
+    Status _init_group_reader();
 
     // create and inti group reader
     Status _create_and_init_group_reader(int row_group_number);
@@ -59,11 +51,8 @@ private:
     // create row group reader
     std::shared_ptr<GroupReader> _row_group(int i);
 
-    // init row group reader
-    Status _init_group_reader();
-
     // filter row group by min/max conjuncts
-    Status _filter_group(const tparquet::RowGroup& group, bool* is_filter);
+    StatusOr<bool> _filter_group(const tparquet::RowGroup& row_group);
 
     // get row group to read
     // if scan range conatain the first byte in the row group, will be read
@@ -79,12 +68,6 @@ private:
 
     // only scan partition column + not exist column
     Status _exec_only_partition_scan(vectorized::ChunkPtr* chunk);
-
-    // append not exist column
-    void _append_not_exist_column_to_chunk(vectorized::ChunkPtr* chunk, size_t row_count);
-
-    // append partition column
-    void _append_partition_column_to_chunk(vectorized::ChunkPtr* chunk, size_t row_count);
 
     // get partition column idx in param.partition_columns
     int _get_partition_column_idx(const std::string& col_name) const;
@@ -116,7 +99,6 @@ private:
     RandomAccessFile* _file;
     uint64_t _file_size;
 
-    starrocks::vectorized::HdfsFileReaderParam _param;
     std::shared_ptr<FileMetaData> _file_metadata;
     vector<std::shared_ptr<GroupReader>> _row_group_readers;
     size_t _cur_row_group_idx = 0;
@@ -134,6 +116,9 @@ private:
     bool _is_file_filtered = false;
     // conjuncts that column is not exist in file
     std::vector<ExprContext*> _not_exist_column_conjunct_ctxs;
+
+    vectorized::HdfsFileReaderParam* _param;
+    bool _should_skip_file = false;
 };
 
 } // namespace starrocks::parquet

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -5,6 +5,7 @@
 
 #include "column/column_helper.h"
 #include "exec/exec_node.h"
+#include "exec/vectorized/hdfs_scanner.h"
 #include "exprs/expr.h"
 #include "runtime/types.h"
 #include "simd/simd.h"

--- a/be/src/formats/parquet/group_reader.h
+++ b/be/src/formats/parquet/group_reader.h
@@ -4,7 +4,6 @@
 
 #include "column/chunk.h"
 #include "column/vectorized_fwd.h"
-#include "exec/vectorized/hdfs_scanner.h"
 #include "formats/parquet/column_reader.h"
 #include "formats/parquet/metadata.h"
 #include "gen_cpp/parquet_types.h"

--- a/be/src/formats/parquet/schema.cpp
+++ b/be/src/formats/parquet/schema.cpp
@@ -363,4 +363,11 @@ int SchemaDescriptor::get_column_index(const std::string& column) const {
     return -1;
 }
 
+void SchemaDescriptor::get_field_names(std::unordered_set<std::string>* names) const {
+    names->clear();
+    for (const ParquetField& f : _fields) {
+        names->emplace(f.name);
+    }
+}
+
 } // namespace starrocks::parquet

--- a/be/src/formats/parquet/schema.h
+++ b/be/src/formats/parquet/schema.h
@@ -79,6 +79,8 @@ public:
         return nullptr;
     }
 
+    void get_field_names(std::unordered_set<std::string>* names) const;
+
 private:
     void leaf_to_field(const tparquet::SchemaElement& t_schema, const LevelInfo& cur_level_info, bool is_nullable,
                        ParquetField* field);

--- a/be/src/formats/parquet/stored_column_reader.cpp
+++ b/be/src/formats/parquet/stored_column_reader.cpp
@@ -5,6 +5,7 @@
 #include <memory>
 
 #include "column/column.h"
+#include "exec/vectorized/hdfs_scanner.h"
 #include "formats/parquet/types.h"
 #include "util/runtime_profile.h"
 

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -8,6 +8,7 @@
 #include "column/fixed_length_column.h"
 #include "common/logging.h"
 #include "env/env.h"
+#include "exec/vectorized/hdfs_scanner.h"
 #include "exprs/expr_context.h"
 #include "exprs/vectorized/binary_predicate.h"
 #include "formats/parquet/column_chunk_reader.h"
@@ -529,7 +530,7 @@ TEST_F(FileReaderTest, TestInit) {
 
     // init
     auto* param = _create_param();
-    Status status = file_reader->init(*param);
+    Status status = file_reader->init(param);
     ASSERT_TRUE(status.ok());
 }
 
@@ -542,7 +543,7 @@ TEST_F(FileReaderTest, TestGetNext) {
 
     // init
     auto* param = _create_param();
-    Status status = file_reader->init(*param);
+    Status status = file_reader->init(param);
     ASSERT_TRUE(status.ok());
 
     // get next
@@ -564,7 +565,7 @@ TEST_F(FileReaderTest, TestGetNextPartition) {
 
     // init
     auto* param = _create_param_for_partition();
-    Status status = file_reader->init(*param);
+    Status status = file_reader->init(param);
     ASSERT_TRUE(status.ok());
 
     // get next
@@ -586,7 +587,7 @@ TEST_F(FileReaderTest, TestGetNextEmpty) {
 
     // init
     auto* param = _create_param_for_not_exist();
-    Status status = file_reader->init(*param);
+    Status status = file_reader->init(param);
     ASSERT_TRUE(status.ok());
 
     // get next
@@ -608,7 +609,7 @@ TEST_F(FileReaderTest, TestMinMaxConjunct) {
 
     // init
     auto* param = _create_param_for_min_max();
-    Status status = file_reader->init(*param);
+    Status status = file_reader->init(param);
     ASSERT_TRUE(status.ok());
 
     // get next
@@ -633,7 +634,7 @@ TEST_F(FileReaderTest, TestFilterFile) {
 
     // init
     auto* param = _create_param_for_filter_file();
-    Status status = file_reader->init(*param);
+    Status status = file_reader->init(param);
     ASSERT_TRUE(status.ok());
 
     // check file is filtered
@@ -653,7 +654,7 @@ TEST_F(FileReaderTest, TestGetNextDictFilter) {
 
     // init
     auto* param = _create_param_for_dict_filter();
-    Status status = file_reader->init(*param);
+    Status status = file_reader->init(param);
     ASSERT_TRUE(status.ok());
 
     // c3 is dict filter column

--- a/be/test/formats/parquet/group_reader_test.cpp
+++ b/be/test/formats/parquet/group_reader_test.cpp
@@ -8,6 +8,7 @@
 
 #include "column/column_helper.h"
 #include "env/env.h"
+#include "exec/vectorized/hdfs_scanner.h"
 #include "runtime/descriptor_helper.h"
 
 namespace starrocks::parquet {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

This PR is to:
1. remove duplicated methods in `file_reader`
    - already defined in `HdfsFileReaderParam`(shared with `hdfs_scanner_orc.cpp`)
    - the duplicated methods are `append_non_existed_column`, `append_parittion_column` etc.
 2. Fix related UT.

The original purpose of this PR, is trying to decouple `HdfsFileReaderParam/HdfsScanStats` from `parquet::file_reader`, but it turns out to be very hard.
