### PR TITLE
Fix: remove check concurrency_limit when creating resource group

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/CreateWorkGroupStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/CreateWorkGroupStmt.java
@@ -71,9 +71,7 @@ public class CreateWorkGroupStmt extends DdlStmt {
         if (workgroup.getMemLimit() == null) {
             throw new SemanticException("property 'mem_limit' is absent");
         }
-        if (workgroup.getConcurrencyLimit() == null) {
-            throw new SemanticException("property 'concurrent_limit' is absent");
-        }
+        // TODO: make property `concurrency_limit` required, after this feature is implemented.
     }
 
     public WorkGroup getWorkgroup() {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [x] others

## Problem Summary:
`concurrency_limit` for resource group has not  been implemented yet, so remove check it.
