### PR TITLE
Fix bug priorNetwork inclusiveHostCount

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendOptions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendOptions.java
@@ -21,6 +21,7 @@
 
 package com.starrocks.service;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.starrocks.common.Config;
@@ -42,7 +43,8 @@ public class FrontendOptions {
 
     private static final String PRIORITY_CIDR_SEPARATOR = ";";
 
-    private static final List<String> priorityCidrs = Lists.newArrayList();
+    @VisibleForTesting
+    static final List<String> priorityCidrs = Lists.newArrayList();
     private static InetAddress localAddr = InetAddress.getLoopbackAddress();
 
     public static void init() throws UnknownHostException {
@@ -132,7 +134,9 @@ public class FrontendOptions {
         priorityCidrs.addAll(priorNetworks);
     }
 
-    private static boolean isInPriorNetwork(String ip) {
+
+    @VisibleForTesting
+    static boolean isInPriorNetwork(String ip) {
         ip = ip.trim();
         for (String cidr : priorityCidrs) {
             cidr = cidr.trim();
@@ -142,7 +146,9 @@ public class FrontendOptions {
                     return true;
                 }
             } else {
-                SubnetUtils.SubnetInfo subnetInfo = new SubnetUtils(cidr).getInfo();
+                SubnetUtils subnetUtils = new SubnetUtils(cidr);
+                subnetUtils.setInclusiveHostCount(true);
+                SubnetUtils.SubnetInfo subnetInfo = subnetUtils.getInfo();
                 if (subnetInfo.isInRange(ip)) {
                     return true;
                 }

--- a/fe/fe-core/src/test/java/com/starrocks/service/FrontendOptionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/FrontendOptionsTest.java
@@ -1,0 +1,28 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.service;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+public class FrontendOptionsTest {
+
+    @Test
+    public void CIDRTest() {
+
+        List<String> priorityCidrs = FrontendOptions.priorityCidrs;
+        priorityCidrs.add("192.168.5.136/32");
+
+        FrontendOptions frontendOptions = new FrontendOptions();
+        boolean inPriorNetwork = frontendOptions.isInPriorNetwork("127.0.0.1");
+        Assert.assertEquals(false, inPriorNetwork);
+
+        inPriorNetwork = frontendOptions.isInPriorNetwork("192.168.5.136");
+        Assert.assertEquals(true, inPriorNetwork);
+
+    }
+
+
+}


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5524

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

If the CIDR ends with /32, the Subnet library will not process it unless the parameter is set. Here we solve this problem by setting this parameter