### PR TITLE
Upgrade hadoop-common to 3.2.3 due to CVE-2022-26612

### DIFF
--- a/fs_brokers/apache_hdfs_broker/pom.xml
+++ b/fs_brokers/apache_hdfs_broker/pom.xml
@@ -217,6 +217,12 @@ under the License.
             <version>${hadoop.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-hdfs-client</artifactId>
+            <version>${hadoop.version}</version>
+        </dependency>
+
         <!-- https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-hdfs -->
         <dependency>
             <groupId>org.apache.hadoop</groupId>

--- a/fs_brokers/apache_hdfs_broker/pom.xml
+++ b/fs_brokers/apache_hdfs_broker/pom.xml
@@ -36,7 +36,7 @@ under the License.
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <hadoop.version>2.10.1</hadoop.version>
+        <hadoop.version>3.2.3</hadoop.version>
         <guava.version>30.1.1-jre</guava.version>
         <zookeeper.version>3.4.14</zookeeper.version>
         <protobuf.version>3.16.1</protobuf.version>

--- a/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/broker/hdfs/FileSystemManager.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/broker/hdfs/FileSystemManager.java
@@ -898,18 +898,20 @@ public class FileSystemManager {
 
     public void pwrite(TBrokerFD fd, long offset, byte[] data) {
         FSDataOutputStream fsDataOutputStream = clientContextManager.getFsDataOutputStream(fd);
-        long currentStreamOffset = fsDataOutputStream.getPos();
-        if (currentStreamOffset != offset) {
-            throw new BrokerException(TBrokerOperationStatusCode.INVALID_INPUT_OFFSET,
-                    "current outputstream offset is {} not equal to request {}",
-                    currentStreamOffset, offset);
-        }
-        try {
-            fsDataOutputStream.write(data);
-        } catch (IOException e) {
-            logger.error("errors while write data to output stream", e);
-            throw new BrokerException(TBrokerOperationStatusCode.TARGET_STORAGE_SERVICE_ERROR,
-                    e, "errors while write data to output stream");
+        synchronized (fsDataOutputStream) {
+            long currentStreamOffset = fsDataOutputStream.getPos();
+            if (currentStreamOffset != offset) {
+                throw new BrokerException(TBrokerOperationStatusCode.INVALID_INPUT_OFFSET,
+                        "current outputstream offset is {} not equal to request {}",
+                        currentStreamOffset, offset);
+            }
+            try {
+                fsDataOutputStream.write(data);
+            } catch (IOException e) {
+                logger.error("errors while write data to output stream", e);
+                throw new BrokerException(TBrokerOperationStatusCode.TARGET_STORAGE_SERVICE_ERROR,
+                        e, "errors while write data to output stream");
+            }
         }
     }
 

--- a/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/broker/hdfs/FileSystemManager.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/broker/hdfs/FileSystemManager.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.log4j.Logger;
@@ -295,7 +296,7 @@ public class FileSystemManager {
             if (fileSystem.getDFSFileSystem() == null) {
                 logger.info("could not find file system for path " + path + " create a new one");
                 // create a new filesystem
-                Configuration conf = new Configuration();
+                Configuration conf = new HdfsConfiguration();
                 // TODO get this param from properties
                 // conf.set("dfs.replication", "2");
                 String tmpFilePath = null;


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [x] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5533

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
it needs add hdfs-client dependency.
and fsDataOutputStream.getPos(); does not throw IOException
There also a lot of synchronized use less, but it not fix by this PR.