### PR TITLE
increase make_snapshot rpc timeout

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -347,6 +347,8 @@ CONF_Int32(streaming_load_rpc_max_alive_time_sec, "1200");
 // The timeout of a rpc to open the tablet writer in remote BE.
 // short operation time, can set a short timeout
 CONF_Int32(tablet_writer_open_rpc_timeout_sec, "60");
+// make_snapshot rpc timeout
+CONF_Int32(make_snapshot_rpc_timeout_ms, "20000");
 // Deprecated, use query_timeout instread
 // the timeout of a rpc to process one batch in tablet writer.
 // you may need to increase this timeout if using larger 'streaming_load_max_mb',

--- a/be/src/storage/task/engine_clone_task.cpp
+++ b/be/src/storage/task/engine_clone_task.cpp
@@ -345,7 +345,7 @@ Status EngineCloneTask::_make_snapshot(const std::string& ip, int port, TTableId
     // of timeout for now, we may need a smart way to estimate the time of make_snapshot in future
     RETURN_IF_ERROR(ThriftRpcHelper::rpc<BackendServiceClient>(
             ip, port, [&request, &result](BackendServiceConnection& client) { client->make_snapshot(result, request); },
-            20000));
+            config::make_snapshot_rpc_timeout_ms));
     if (result.status.status_code != TStatusCode::OK) {
         return Status(result.status);
     }

--- a/be/src/storage/task/engine_clone_task.cpp
+++ b/be/src/storage/task/engine_clone_task.cpp
@@ -340,9 +340,12 @@ Status EngineCloneTask::_make_snapshot(const std::string& ip, int port, TTableId
     }
 
     TAgentResult result;
+    // snapshot will hard link all required rowsets' segment files, the number of files may be very large(>1000),
+    // so it may take some time to process this rpc, so we increase rpc timeout from 5s to 20s to reduce the chance
+    // of timeout for now, we may need a smart way to estimate the time of make_snapshot in future
     RETURN_IF_ERROR(ThriftRpcHelper::rpc<BackendServiceClient>(
-            ip, port,
-            [&request, &result](BackendServiceConnection& client) { client->make_snapshot(result, request); }));
+            ip, port, [&request, &result](BackendServiceConnection& client) { client->make_snapshot(result, request); },
+            20000));
     if (result.status.status_code != TStatusCode::OK) {
         return Status(result.status);
     }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Partially fixes #5505

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
`make_snapshot` will hard link all required rowsets' segment files, the number of files may be very large(>1000),
so it may take some time to process `make_snapshot` rpc, this PR increases rpc timeout from 5s to 20s to reduce the chance
of timeout, we may need a smart way to estimate the time of make_snapshot in the future so we can set a more proper timeout value.
