### PR TITLE
[BugFix] Support set json_root and json_path at the same time

### DIFF
--- a/be/src/exec/vectorized/json_scanner.cpp
+++ b/be/src/exec/vectorized/json_scanner.cpp
@@ -51,10 +51,6 @@ Status JsonScanner::open() {
 
     const TBrokerRangeDesc& range = _scan_range.ranges[0];
 
-    if (range.__isset.jsonpaths && range.__isset.json_root) {
-        return Status::InvalidArgument("json path and json root cannot be both set");
-    }
-
     if (range.__isset.jsonpaths) {
         RETURN_IF_ERROR(_parse_json_paths(range.jsonpaths, &_json_paths));
     }

--- a/be/test/exec/vectorized/json_scanner_test.cpp
+++ b/be/test/exec/vectorized/json_scanner_test.cpp
@@ -802,16 +802,14 @@ TEST_F(JsonScannerTest, test_jsonroot_with_jsonpath) {
     std::vector<TypeDescriptor> types;
     types.emplace_back(TypeDescriptor::create_varchar_type(20));
     types.emplace_back(TypeDescriptor::create_varchar_type(20));
-    types.emplace_back(TypeDescriptor::create_varchar_type(20));
-    types.emplace_back(TYPE_INT);
 
     std::vector<TBrokerRangeDesc> ranges;
     TBrokerRangeDesc range;
     range.format_type = TFileFormatType::FORMAT_JSON;
     range.strip_outer_array = false;
     range.__isset.strip_outer_array = false;
-    range.__isset.jsonpaths = false;
-    range.__isset.json_root = false;
+    range.__isset.jsonpaths = true;
+    range.__isset.json_root = true;
 
     range.jsonpaths = "[\"$.ip\", \"$.value\"]";
     range.json_root = "$.keyname";

--- a/be/test/exec/vectorized/json_scanner_test.cpp
+++ b/be/test/exec/vectorized/json_scanner_test.cpp
@@ -802,6 +802,80 @@ TEST_F(JsonScannerTest, test_jsonroot_with_jsonpath) {
     std::vector<TypeDescriptor> types;
     types.emplace_back(TypeDescriptor::create_varchar_type(20));
     types.emplace_back(TypeDescriptor::create_varchar_type(20));
+    types.emplace_back(TypeDescriptor::create_varchar_type(20));
+    types.emplace_back(TYPE_INT);
+
+    std::vector<TBrokerRangeDesc> ranges;
+    TBrokerRangeDesc range;
+    range.format_type = TFileFormatType::FORMAT_JSON;
+    range.strip_outer_array = false;
+    range.__isset.strip_outer_array = false;
+    range.__isset.jsonpaths = false;
+    range.__isset.json_root = false;
+
+    range.jsonpaths = "[\"$.ip\", \"$.value\"]";
+    range.json_root = "$.keyname";
+
+    range.__set_path("./be/test/exec/test_data/json_scanner/test_ndjson.json");
+    ranges.emplace_back(range);
+
+    auto scanner = create_json_scanner(types, ranges, {"ip", "value"});
+
+    Status st;
+    st = scanner->open();
+    ASSERT_TRUE(st.ok());
+
+    ChunkPtr chunk = scanner->get_next().value();
+    EXPECT_EQ(2, chunk->num_columns());
+    EXPECT_EQ(5, chunk->num_rows());
+
+    EXPECT_EQ("['10.10.0.1', '10']", chunk->debug_row(0));
+    EXPECT_EQ("['10.10.0.2', '20']", chunk->debug_row(1));
+    EXPECT_EQ("['10.10.0.3', '30']", chunk->debug_row(2));
+    EXPECT_EQ("['10.10.0.4', '40']", chunk->debug_row(3));
+    EXPECT_EQ("['10.10.0.5', '50']", chunk->debug_row(4));
+}
+
+TEST_F(JsonScannerTest, test_expanded_with_jsonroot_and_extracted_by_jsonpath) {
+    std::vector<TypeDescriptor> types;
+    types.emplace_back(TypeDescriptor::create_varchar_type(20));
+    types.emplace_back(TypeDescriptor::create_varchar_type(20));
+
+    std::vector<TBrokerRangeDesc> ranges;
+    TBrokerRangeDesc range;
+    range.format_type = TFileFormatType::FORMAT_JSON;
+    range.strip_outer_array = true;
+    range.jsonpaths = "[\"$.keyname.ip\", \"$.keyname.value\"]";
+    range.json_root = "$.data";
+
+    range.__isset.strip_outer_array = true;
+    range.__isset.jsonpaths = true;
+    range.__isset.json_root = true;
+
+    range.__set_path("./be/test/exec/test_data/json_scanner/test_expanded_array.json");
+    ranges.emplace_back(range);
+
+    auto scanner = create_json_scanner(types, ranges, {"ip", "value"});
+
+    Status st;
+    st = scanner->open();
+    ASSERT_TRUE(st.ok());
+
+    ChunkPtr chunk = scanner->get_next().value();
+    EXPECT_EQ(2, chunk->num_columns());
+    EXPECT_EQ(5, chunk->num_rows());
+
+    EXPECT_EQ("['10.10.0.1', '10']", chunk->debug_row(0));
+    EXPECT_EQ("['10.10.0.2', '20']", chunk->debug_row(1));
+    EXPECT_EQ("['10.10.0.3', '30']", chunk->debug_row(2));
+    EXPECT_EQ("['10.10.0.4', '40']", chunk->debug_row(3));
+    EXPECT_EQ("['10.10.0.5', '50']", chunk->debug_row(4));
+}
+
+TEST_F(JsonScannerTest, test_ndjson_expaned_with_jsonroot_and_extracted_by_jsonpath) {
+    std::vector<TypeDescriptor> types;
+    types.emplace_back(TypeDescriptor::create_varchar_type(20));
+    types.emplace_back(TypeDescriptor::create_varchar_type(20));
 
     std::vector<TBrokerRangeDesc> ranges;
     TBrokerRangeDesc range;


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5516

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

This PR removes the limit of setting json root and json path at the same time.