### PR TITLE
Improve window_funnel through Fix bug, use const_column and add DATE type

### DIFF
--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -206,6 +206,10 @@ public:
         return std::static_pointer_cast<Type>(value);
     }
 
+    template <typename Type>
+    static inline const Type* as_raw_column(const Column* value) {
+        return down_cast<const Type*>(value);
+    }
     /**
      * Cast columnPtr to special type Column*
      * Plz sure actual column type by yourself
@@ -218,6 +222,12 @@ public:
     template <PrimitiveType Type>
     static inline RunTimeCppType<Type>* get_cpp_data(const ColumnPtr& value) {
         return cast_to_raw<Type>(value)->get_data().data();
+    }
+
+    template <PrimitiveType Type>
+    static inline RunTimeCppType<Type> get_const_value(const Column* col) {
+        const ColumnPtr& c = as_raw_column<ConstColumn>(col)->data_column();
+        return cast_to_raw<Type>(c)->get_data()[0];
     }
 
     template <PrimitiveType Type>

--- a/be/src/exec/vectorized/aggregator.cpp
+++ b/be/src/exec/vectorized/aggregator.cpp
@@ -173,9 +173,9 @@ Status Aggregator::prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile
             }
 
             // Because windowfunnel have more two input types.
-            // functions registry use 4th args.
+            // functions registry use 2th args(datetime/date).
             if (fn.name.function_name == "window_funnel") {
-                arg_type = TypeDescriptor::from_thrift(fn.arg_types[3]);
+                arg_type = TypeDescriptor::from_thrift(fn.arg_types[1]);
             }
 
             bool is_input_nullable = has_outer_join_child || desc.nodes[0].has_nullable_child;
@@ -391,7 +391,7 @@ void Aggregator::compute_batch_agg_states(size_t chunk_size) {
             _agg_functions[i]->update_batch(_agg_fn_ctxs[i], chunk_size, _agg_states_offsets[i],
                                             _agg_input_raw_columns[i].data(), _tmp_agg_states.data());
         } else {
-            DCHECK_EQ(_agg_intput_columns[i].size(), 1);
+            DCHECK_GE(_agg_intput_columns[i].size(), 1);
             _agg_functions[i]->merge_batch(_agg_fn_ctxs[i], _agg_intput_columns[i][0]->size(), _agg_states_offsets[i],
                                            _agg_intput_columns[i][0].get(), _tmp_agg_states.data());
         }
@@ -405,7 +405,7 @@ void Aggregator::compute_batch_agg_states_with_selection(size_t chunk_size) {
                                                         _agg_input_raw_columns[i].data(), _tmp_agg_states.data(),
                                                         _streaming_selection);
         } else {
-            DCHECK_EQ(_agg_intput_columns[i].size(), 1);
+            DCHECK_GE(_agg_intput_columns[i].size(), 1);
             _agg_functions[i]->merge_batch_selectively(_agg_fn_ctxs[i], _agg_intput_columns[i][0]->size(),
                                                        _agg_states_offsets[i], _agg_intput_columns[i][0].get(),
                                                        _tmp_agg_states.data(), _streaming_selection);

--- a/be/src/exprs/agg/aggregate_factory.h
+++ b/be/src/exprs/agg/aggregate_factory.h
@@ -26,6 +26,7 @@ public:
 
     static AggregateFunctionPtr MakeBitmapUnionCountAggregateFunction();
 
+    template <PrimitiveType PT>
     static AggregateFunctionPtr MakeWindowfunnelAggregateFunction();
 
     template <PrimitiveType PT>

--- a/be/src/exprs/agg/window_funnel.h
+++ b/be/src/exprs/agg/window_funnel.h
@@ -31,17 +31,22 @@ struct ComparePairFirst final {
     }
 };
 
+template <PrimitiveType PT>
 struct WindowFunnelState {
+    // Use to identify timestamp(datetime/date)
+    using TimeType = typename RunTimeTypeTraits<PT>::CppType;
+    using TimeTypeColumn = typename RunTimeTypeTraits<PT>::ColumnType;
+
     // first args is timestamp, second is event position.
-    using TimestampEvent = std::pair<int64_t, uint8_t>;
-    std::vector<TimestampEvent> events_list;
+    using TimestampEvent = std::pair<typename TimeType::type, uint8_t>;
+    mutable std::vector<TimestampEvent> events_list;
     int64_t window_size;
     uint8_t events_size;
     bool sorted = true;
 
-    void sort() { std::stable_sort(std::begin(events_list), std::end(events_list)); }
+    void sort() const { std::stable_sort(std::begin(events_list), std::end(events_list)); }
 
-    void update(int64_t timestamp, uint8_t event_level) {
+    void update(typename TimeType::type timestamp, uint8_t event_level) {
         // keep only one as a placeholder for someone group.
         if (events_list.size() > 0 && event_level == 0) {
             return;
@@ -56,18 +61,18 @@ struct WindowFunnelState {
         events_list.emplace_back(std::make_pair(timestamp, event_level));
     }
 
-    void deserialize_and_merge(DatumArray& datum_array) {
+    void deserialize_and_merge(FunctionContext* ctx, DatumArray& datum_array) {
         if (datum_array.size() == 0) {
             return;
         }
 
         std::vector<TimestampEvent> other_list;
-        window_size = datum_array[0].get_int64();
-        events_size = (uint8_t)datum_array[1].get_int64();
-        bool other_sorted = (uint8_t)datum_array[2].get_int64();
+        window_size = ColumnHelper::get_const_value<TYPE_BIGINT>(ctx->get_constant_column(1));
+        events_size = (uint8_t)datum_array[0].get_int64();
+        bool other_sorted = (uint8_t)datum_array[1].get_int64();
 
-        for (size_t i = 3; i < datum_array.size() - 1; i += 2) {
-            int64_t timestamp = datum_array[i].get_int64();
+        for (size_t i = 2; i < datum_array.size() - 1; i += 2) {
+            typename TimeType::type timestamp = (typename TimeType::type)datum_array[i].get_int64();
             int64_t event_level = datum_array[i + 1].get_int64();
             other_list.emplace_back(std::make_pair(timestamp, uint8_t(event_level)));
         }
@@ -96,8 +101,7 @@ struct WindowFunnelState {
         if (!events_list.empty()) {
             size_t size = events_list.size();
             DatumArray array;
-            array.reserve(size * 2 + 3);
-            array.emplace_back(window_size);
+            array.reserve(size * 2 + 2);
             array.emplace_back((int64_t)events_size);
             array.emplace_back((int64_t)sorted);
             for (int i = 0; i < size; i++) {
@@ -109,9 +113,13 @@ struct WindowFunnelState {
     }
 
     int32_t get_event_level() const {
-        std::vector<int64_t> events_timestamp(events_size, -1);
+        if (!sorted) {
+            sort();
+        }
+
+        std::vector<typename TimeType::type> events_timestamp(events_size, -1);
         for (size_t i = 0; i < events_list.size(); i++) {
-            int64_t timestamp = (events_list)[i].first;
+            typename TimeType::type timestamp = (events_list)[i].first;
             uint8_t event_idx = (events_list)[i].second;
 
             // this row match no conditions.
@@ -120,10 +128,10 @@ struct WindowFunnelState {
             }
 
             event_idx -= 1;
-            if (event_idx == 0)
+            if (event_idx == 0) {
                 events_timestamp[0] = timestamp;
-            else if (events_timestamp[event_idx - 1] >= 0 &&
-                     timestamp <= events_timestamp[event_idx - 1] + window_size) {
+            } else if (events_timestamp[event_idx - 1] >= 0 &&
+                       timestamp <= events_timestamp[event_idx - 1] + window_size) {
                 events_timestamp[event_idx] = events_timestamp[event_idx - 1];
                 if (event_idx + 1 == events_size) return events_size;
             }
@@ -135,16 +143,25 @@ struct WindowFunnelState {
     }
 };
 
+template <PrimitiveType PT>
 class WindowFunnelAggregateFunction final
-        : public AggregateFunctionBatchHelper<WindowFunnelState, WindowFunnelAggregateFunction> {
+        : public AggregateFunctionBatchHelper<WindowFunnelState<PT>, WindowFunnelAggregateFunction<PT>> {
+    using TimeTypeColumn = typename WindowFunnelState<PT>::TimeTypeColumn;
+    using TimeType = typename WindowFunnelState<PT>::TimeType;
+
 public:
     void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state, size_t row_num) const {
-        const auto* window_size_column = down_cast<const Int64Column*>(columns[0]);
-        this->data(state).window_size = window_size_column->get(row_num).get_int64();
+        this->data(state).window_size = ColumnHelper::get_const_value<TYPE_BIGINT>(ctx->get_constant_column(0));
 
         // get timestamp
-        const auto* timestamp_column = down_cast<const TimestampColumn*>(columns[1]);
-        auto tv = timestamp_column->get(row_num).get_timestamp();
+        const auto* timestamp_column = down_cast<const TimeTypeColumn*>(columns[1]);
+
+        TimeType tv;
+        if constexpr (PT == TYPE_DATETIME) {
+            tv = timestamp_column->get(row_num).get_timestamp();
+        } else if constexpr (PT == TYPE_DATE) {
+            tv = timestamp_column->get(row_num).get_date();
+        }
 
         // get event
         uint8_t event_level = 0;
@@ -157,13 +174,17 @@ public:
             }
         }
         this->data(state).events_size = ele_vector.size();
-        this->data(state).update(tv.to_unix_second(), event_level);
+        if constexpr (PT == TYPE_DATETIME) {
+            this->data(state).update(tv.to_unix_second(), event_level);
+        } else if constexpr (PT == TYPE_DATE) {
+            this->data(state).update(tv.to_date_literal(), event_level);
+        }
     }
 
     void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
         const auto* input_column = down_cast<const ArrayColumn*>(column);
         auto ele_vector = input_column->get(row_num).get_array();
-        this->data(state).deserialize_and_merge(ele_vector);
+        this->data(state).deserialize_and_merge(ctx, ele_vector);
     }
 
     void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
@@ -180,15 +201,17 @@ public:
         auto* dst_column = down_cast<ArrayColumn*>((*dst).get());
         dst_column->reserve(chunk_size);
 
-        const auto* window_size_column = down_cast<const Int64Column*>(src[0].get());
-        const auto* timestamp_column = down_cast<const TimestampColumn*>(src[1].get());
-        const auto* bool_array_column = down_cast<const ArrayColumn*>(src[2].get());
+        const TimeTypeColumn* timestamp_column = down_cast<const TimeTypeColumn*>(src[1].get());
+        const auto* bool_array_column = down_cast<const ArrayColumn*>(src[3].get());
         for (int i = 0; i < chunk_size; i++) {
-            // get 1st value: window_size
-            int64_t window_size = window_size_column->get(i).get_int64();
-            // get 2nd value: timestamp
-            int64_t tv = timestamp_column->get(i).get_timestamp().to_unix_second();
-            // get 3th value: event cond array
+            typename TimeType::type tv;
+            if constexpr (PT == TYPE_DATETIME) {
+                tv = timestamp_column->get(i).get_timestamp().to_unix_second();
+            } else if constexpr (PT == TYPE_DATE) {
+                tv = timestamp_column->get(i).get_date().to_date_literal();
+            }
+
+            // get 4th value: event cond array
             auto ele_vector = bool_array_column->get(i).get_array();
             uint8_t event_level = 0;
             for (uint8_t j = 0; j < ele_vector.size(); j++) {
@@ -201,11 +224,10 @@ public:
             DatumArray array;
             size_t events_size = ele_vector.size();
             bool sorted = false;
-            array.reserve(1 + 1 + 1 + 2);
-            array.emplace_back(window_size);
+            array.reserve(1 + 1 + 2);
             array.emplace_back((int64_t)events_size);
             array.emplace_back((int64_t)sorted);
-            array.emplace_back(tv);
+            array.emplace_back((int64_t)tv);
             array.emplace_back((int64_t)event_level);
             dst_column->append_datum(array);
         }

--- a/be/src/exprs/agg/window_funnel.h
+++ b/be/src/exprs/agg/window_funnel.h
@@ -154,13 +154,16 @@ public:
         this->data(state).window_size = ColumnHelper::get_const_value<TYPE_BIGINT>(ctx->get_constant_column(0));
 
         // get timestamp
-        const auto* timestamp_column = down_cast<const TimeTypeColumn*>(columns[1]);
-
         TimeType tv;
-        if constexpr (PT == TYPE_DATETIME) {
-            tv = timestamp_column->get(row_num).get_timestamp();
-        } else if constexpr (PT == TYPE_DATE) {
-            tv = timestamp_column->get(row_num).get_date();
+        if (!columns[1]->is_constant()) {
+            const auto timestamp_column = down_cast<const TimeTypeColumn*>(columns[1]);
+            if constexpr (PT == TYPE_DATETIME) {
+                tv = timestamp_column->get(row_num).get_timestamp();
+            } else if constexpr (PT == TYPE_DATE) {
+                tv = timestamp_column->get(row_num).get_date();
+            }
+        } else {
+            tv = ColumnHelper::get_const_value<PT>(columns[1]);
         }
 
         // get event

--- a/be/src/runtime/date_value.h
+++ b/be/src/runtime/date_value.h
@@ -43,6 +43,8 @@ class TimestampValue;
  */
 class DateValue {
 public:
+    using type = JulianDate;
+
     inline static DateValue create(int year, int month, int day);
 
 public:

--- a/be/src/runtime/timestamp_value.h
+++ b/be/src/runtime/timestamp_value.h
@@ -41,6 +41,8 @@ const int TIME_MAX_HOUR = 838;
 
 class TimestampValue {
 public:
+    using type = Timestamp;
+
     inline static TimestampValue create(int year, int month, int day, int hour, int minute, int second);
 
     inline Timestamp timestamp() const { return _timestamp; }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -728,6 +728,9 @@ public class FunctionSet {
                 Lists.newArrayList(Type.VARCHAR, Type.VARCHAR), Type.VARCHAR, Type.VARCHAR,
                 false, false, false));
 
+	// Type.DATE must before Type.DATATIME, because DATE could be considered as DATETIME.
+        addBuiltin(AggregateFunction.createBuiltin(WINDOW_FUNNEL, Lists.newArrayList(Type.BIGINT, Type.DATE, Type.INT, Type.ARRAY_BOOLEAN),
+                Type.INT, Type.ARRAY_BIGINT, false, false, false));
         addBuiltin(AggregateFunction.createBuiltin(WINDOW_FUNNEL, Lists.newArrayList(Type.BIGINT, Type.DATETIME, Type.INT, Type.ARRAY_BOOLEAN),
                 Type.INT, Type.ARRAY_BIGINT, false, false, false));
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [x] feature
- [ ] enhancement
- [ ] others

Based on https://github.com/StarRocks/starrocks/pull/4985
## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

- Fixes bug caused by un-sorted event_list.
- Use const_column for window_size to avoid serialize/deserialize.
- Add DATE TYPE as time parameter.

## use case(datetime) : 
```
mysql> select * from action;
+------+------------+---------------------+
| uid  | event_type | time                |
+------+------------+---------------------+
| 1    | 浏览       | 2020-01-02 11:00:00 |
| 1    | 点击       | 2020-01-02 11:10:00 |
| 1    | 下单       | 2020-01-02 11:20:00 |
| 1    | 支付       | 2020-01-02 11:30:00 |
| 1    | 浏览       | 2020-01-02 11:00:00 |
| 2    | 下单       | 2020-01-02 11:00:00 |
| 2    | 支付       | 2020-01-02 11:10:00 |
| 3    | 浏览       | 2020-01-02 11:20:00 |
| 3    | 点击       | 2020-01-02 12:00:00 |
| 4    | 浏览       | 2020-01-02 11:50:00 |
| 4    | 点击       | 2020-01-02 12:00:00 |
| 5    | 浏览       | 2020-01-02 11:50:00 |
| 5    | 点击       | 2020-01-02 12:00:00 |
| 5    | 下单       | 2020-01-02 11:10:00 |
| 6    | 浏览       | 2020-01-02 11:50:00 |
| 6    | 点击       | 2020-01-02 12:00:00 |
| 6    | 下单       | 2020-01-02 12:10:00 |
+------+------------+---------------------+
17 rows in set (0.01 sec)

mysql> select uid, window_funnel(600, time, 0, [event_type="浏览", event_type="点击", event_type="下单", event_type="支付"]) as level from action group by uid order by uid;
+------+-------+
| uid  | level |
+------+-------+
| 1    |     2 |
| 2    |     0 |
| 3    |     1 |
| 4    |     2 |
| 5    |     2 |
| 6    |     2 |
+------+-------+
6 rows in set (0.04 sec)
```

## use case(date) : 
```
mysql> select * from action9;
+------+------------+------------+
| uid  | event_type | time       |
+------+------------+------------+
| 1    | 浏览       | 2020-01-02 |
| 1    | 点击       | 2020-01-03 |
| 1    | 下单       | 2020-01-04 |
| 1    | 支付       | 2020-01-05 |
| 2    | 浏览       | 2020-01-02 |
| 2    | 点击       | 2020-01-06 |
+------+------------+------------+
6 rows in set (0.01 sec)

mysql> select uid, window_funnel(3, time, 0, [event_type="浏览", event_type="点击", event_type="下单", event_type="支付"]) as level from action9 group by uid order by uid;
+------+-------+
| uid  | level |
+------+-------+
| 1    |     4 |
| 2    |     1 |
+------+-------+
2 rows in set (0.02 sec)
```