### PR TITLE
[Enhancement] Add log for slow database lock and fix some logging (#5453)

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -1659,12 +1659,14 @@ size_t TabletUpdates::_get_rowset_num_deletes(const Rowset& rowset) {
 
 void TabletUpdates::get_tablet_info_extra(TTabletInfo* info) {
     int64_t version;
+    bool has_pending = false;
     vector<uint32_t> rowsets;
     {
         std::lock_guard rl(_lock);
         auto& last = _edit_version_infos.back();
         version = last->version.major();
         rowsets = last->rowsets;
+        has_pending = _pending_commits.size() > 0;
     }
     string err_rowsets;
     int64_t total_row = 0;
@@ -1687,6 +1689,7 @@ void TabletUpdates::get_tablet_info_extra(TTabletInfo* info) {
                                  << " rowset=" << err_rowsets;
     }
     info->__set_version(version);
+    info->__set_version_miss(has_pending);
     info->__set_version_count(rowsets.size());
     info->__set_row_count(total_row);
     info->__set_data_size(total_size);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
@@ -74,8 +74,10 @@ public class Database extends MetaObject implements Writable {
     private static final Logger LOG = LogManager.getLogger(Database.class);
 
     // empirical value.
-    // assume that the time a lock is held by thread is less then 100ms
+    // assume that the time a lock is held by thread is less than 100ms
     public static final long TRY_LOCK_TIMEOUT_MS = 100L;
+    public static final long SLOW_LOCK_MS = 3000L;
+    public static final long SLOW_LOCK_LOG_EVERY_MS = 3000L;
 
     private long id;
     private String fullQualifiedName;
@@ -92,6 +94,8 @@ public class Database extends MetaObject implements Writable {
     private volatile long dataQuotaBytes;
 
     private volatile long replicaQuotaSize;
+
+    private long lastSlowLockLogTime = 0;
 
     public enum DbState {
         NORMAL, LINK, MOVE
@@ -121,7 +125,14 @@ public class Database extends MetaObject implements Writable {
     }
 
     public void readLock() {
+        long startMs = System.nanoTime() / 1000000;
         this.rwLock.readLock().lock();
+        long endMs = System.nanoTime() / 1000000;
+        if (endMs - startMs > SLOW_LOCK_MS && endMs > lastSlowLockLogTime + SLOW_LOCK_LOG_EVERY_MS) {
+            lastSlowLockLogTime = endMs;
+            LOG.warn("slow read lock db:" + id + " " + fullQualifiedName + " " + (endMs - startMs) + "ms",
+                    new Exception());
+        }
     }
 
     public boolean tryReadLock(long timeout, TimeUnit unit) {
@@ -145,7 +156,14 @@ public class Database extends MetaObject implements Writable {
     }
 
     public void writeLock() {
+        long startMs = System.nanoTime() / 1000000;
         this.rwLock.writeLock().lock();
+        long endMs = System.nanoTime() / 1000000;
+        if (endMs - startMs > SLOW_LOCK_MS && endMs > lastSlowLockLogTime + SLOW_LOCK_LOG_EVERY_MS) {
+            lastSlowLockLogTime = endMs;
+            LOG.warn("slow write lock db:" + id + " " + fullQualifiedName + " " + (endMs - startMs) + "ms",
+                    new Exception());
+        }
     }
 
     public boolean tryWriteLock(long timeout, TimeUnit unit) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Replica.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Replica.java
@@ -121,7 +121,8 @@ public class Replica implements Writable {
     // we should ensure that all txns on this replicas are finished.
     private long watermarkTxnId = -1;
 
-    public Replica() {}
+    public Replica() {
+    }
 
     // for rollup
     // the new replica's version is -1 and last failed version is -1
@@ -256,7 +257,7 @@ public class Replica implements Writable {
     }
 
     public synchronized void updateRowCount(long newVersion, long newDataSize,
-                                               long newRowCount) {
+                                            long newRowCount) {
         updateReplicaInfo(newVersion, this.lastFailedVersion,
                 this.lastSuccessVersion, newDataSize, newRowCount);
     }
@@ -347,7 +348,7 @@ public class Replica implements Writable {
 
         // TODO: this case is unknown, add log to observe
         if (this.version > lastFailedVersion && lastFailedVersion > 0) {
-            LOG.debug("current version {} is larger than last failed version {}, "
+            LOG.warn("current version {} is larger than last failed version {}, "
                             + "maybe a fatal error or be report version, print a stack here ",
                     this.version, lastFailedVersion, new Exception());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -994,7 +994,8 @@ public class TabletScheduler extends MasterDaemon {
             // set priority to normal because it may wait for a long time. Remain it as VERY_HIGH may block other task.
             tabletCtx.setOrigPriority(Priority.NORMAL);
             LOG.info("decommission tablet:" + tabletCtx.getTabletId() + " type:" + tabletCtx.getType() + " replica:" +
-                    replica.getBackendId() + " reason:" + reason, " watermark:" + nextTxnId);
+                    replica.getBackendId() + " reason:" + reason + " watermark:" + nextTxnId + " replicas:" +
+                    tabletCtx.getTablet().getReplicaInfos());
             throw new SchedException(Status.SCHEDULE_FAILED, "set watermark txn " + nextTxnId);
         } else if (replica.getState() == ReplicaState.DECOMMISSION && replica.getWatermarkTxnId() != -1) {
             long watermarkTxnId = replica.getWatermarkTxnId();
@@ -1009,6 +1010,7 @@ public class TabletScheduler extends MasterDaemon {
             }
         }
 
+        String replicaInfos = tabletCtx.getTablet().getReplicaInfos();
         // delete this replica from catalog.
         // it will also delete replica from tablet inverted index.
         tabletCtx.deleteReplica(replica);
@@ -1032,8 +1034,8 @@ public class TabletScheduler extends MasterDaemon {
 
         Catalog.getCurrentCatalog().getEditLog().logDeleteReplica(info);
 
-        LOG.info("delete replica. tablet id: {}, backend id: {}. reason: {}, force: {}",
-                tabletCtx.getTabletId(), replica.getBackendId(), reason, force);
+        LOG.info("delete replica. tablet id: {}, backend id: {}. reason: {}, force: {} replicas: {}",
+                tabletCtx.getTabletId(), replica.getBackendId(), reason, force, replicaInfos);
     }
 
     private void sendDeleteReplicaTask(long backendId, long tabletId, int schemaHash) {
@@ -1248,7 +1250,7 @@ public class TabletScheduler extends MasterDaemon {
         long tabletId = cloneTask.getTabletId();
         TabletSchedCtx tabletCtx = takeRunningTablets(tabletId);
         if (tabletCtx == null) {
-            LOG.warn("tablet info does not exist: {}", tabletId);
+            LOG.warn("tablet info does not exist, tablet:{} backend:{}", tabletId, cloneTask.getBackendId());
             // tablet does not exist, no need to keep task.
             return true;
         }


### PR DESCRIPTION
This PR adds warning log with some debug information when db's read/write lock takes a long time to lock, this helps identify lock contention issues. Also fix a logging error in TabletScheduler.

cherry-pick: #5453
