### PR TITLE
[WIP]Refresh framework for MaterializedView

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/journal/JournalEntity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/JournalEntity.java
@@ -51,6 +51,9 @@ import com.starrocks.load.loadv2.LoadJob.LoadJobStateUpdateInfo;
 import com.starrocks.load.loadv2.LoadJobFinalOperation;
 import com.starrocks.load.routineload.RoutineLoadJob;
 import com.starrocks.master.Checkpoint;
+import com.starrocks.mv.MaterializedViewRefreshJob;
+import com.starrocks.mv.MaterializedViewRefreshJobStatusChange;
+import com.starrocks.mv.MaterializedViewSchedulerInfo;
 import com.starrocks.mysql.privilege.UserPropertyInfo;
 import com.starrocks.persist.AddPartitionsInfo;
 import com.starrocks.persist.AlterRoutineLoadJobOperationLog;
@@ -148,7 +151,8 @@ public class JournalEntity implements Writable {
             case OperationType.OP_ERASE_PARTITION:
             case OperationType.OP_META_VERSION:
             case OperationType.OP_DROP_ALL_BROKER:
-            case OperationType.OP_DROP_REPOSITORY: {
+            case OperationType.OP_DROP_REPOSITORY:
+            case OperationType.OP_DEREGISTER_SCHEDULED_MV_JOB: {
                 data = new Text();
                 ((Text) data).readFields(in);
                 isRead = true;
@@ -499,6 +503,18 @@ public class JournalEntity implements Writable {
                 isRead = true;
                 break;
             }
+            case OperationType.OP_REGISTER_SCHEDULED_MV_JOB:
+                data = MaterializedViewSchedulerInfo.read(in);
+                isRead = true;
+                break;
+            case OperationType.OP_ADD_PENDING_MV_JOB:
+                data = MaterializedViewRefreshJob.read(in);
+                isRead = true;
+                break;
+            case OperationType.OP_MV_JOB_STATUS_CHANGE:
+                data = MaterializedViewRefreshJobStatusChange.read(in);
+                isRead = true;
+                break;
             case OperationType.OP_CREATE_SMALL_FILE:
             case OperationType.OP_DROP_SMALL_FILE: {
                 data = SmallFile.read(in);

--- a/fe/fe-core/src/main/java/com/starrocks/mv/IMaterializedViewRefreshTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mv/IMaterializedViewRefreshTask.java
@@ -1,0 +1,20 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.mv;
+
+import com.starrocks.statistic.Constants;
+
+public interface IMaterializedViewRefreshTask {
+    Constants.MaterializedViewTaskStatus getStatus();
+    void setStatus(Constants.MaterializedViewTaskStatus status);
+    // beginTask is a HOOK that handles things that the task framework can do before running the task is executed,
+    // such as setting the start time.
+    void beginTask();
+    // The task logic that this task actually runs.
+    void runTask() throws Exception;
+    // finishTask is a HOOK that handles things that the task framework can do after running the task is executed,
+    // such as setting the end time.
+    void finishTask();
+    void setErrMsg(String errMsg);
+    IMaterializedViewRefreshTask cloneTask();
+}

--- a/fe/fe-core/src/main/java/com/starrocks/mv/MaterializedViewJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mv/MaterializedViewJobExecutor.java
@@ -1,0 +1,51 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.mv;
+
+import com.starrocks.statistic.Constants;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+
+public class MaterializedViewJobExecutor {
+    private static final Logger LOG = LogManager.getLogger(MaterializedViewJobExecutor.class);
+    // pool for execute actual task no limit
+    private final ExecutorService refreshTaskPool = Executors.newCachedThreadPool();
+
+    public void addRefreshJob(MaterializedViewRefreshJob job) {
+        if (job == null) {
+            return;
+        }
+
+        if (job.getStatus() == Constants.MaterializedViewJobStatus.SUCCESS ||
+                job.getStatus() == Constants.MaterializedViewJobStatus.CANCELED) {
+            LOG.warn("materialized view job {} is in final status {} ", job.getId(), job.getStatus());
+            return;
+        }
+
+        if (job.getRetryTime() == 0) {
+            job.generateTasks();
+            job.setStatus(Constants.MaterializedViewJobStatus.RUNNING);
+        } else {
+            job.setStatus(Constants.MaterializedViewJobStatus.RETRYING);
+        }
+
+        Future<?> future = refreshTaskPool.submit(() -> {
+            try {
+                job.setStartTime(LocalDateTime.now());
+                job.runTasks();
+            } catch (Exception ex) {
+                LOG.warn("failed to run materialized view refresh task.", ex);
+            } finally {
+                job.setEndTime(LocalDateTime.now());
+            }
+        });
+        job.setFuture(future);
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/mv/MaterializedViewJobManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mv/MaterializedViewJobManager.java
@@ -1,0 +1,349 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.mv;
+
+
+import com.clearspring.analytics.util.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Queues;
+import com.starrocks.common.util.QueryableReentrantLock;
+import com.starrocks.common.util.Util;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.statistic.Constants;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import static com.starrocks.mv.MaterializedViewRefreshJob.DEFAULT_UNASSIGNED_ID;
+
+
+public class MaterializedViewJobManager {
+
+    private static final Logger LOG = LogManager.getLogger(MaterializedViewJobManager.class);
+    // first long is mvTableId
+    Map<Long, Queue<MaterializedViewRefreshJob>> pendingJobMap;
+    // mvTableId -> running MaterializedViewRefreshJob, for each mv only support 1 running job currently
+    Map<Long, MaterializedViewRefreshJob> runningJobMap;
+    // first long is scheduledId, manage generate periodicity tasks, only support 1 schedule currently
+    Map<Long, MaterializedViewSchedulerInfo> periodScheduledManager;
+    Deque<MaterializedViewRefreshJob> jobHistory;
+    // The periodScheduler is responsible for periodically checking whether the running task is completed
+    // and updating the status. It is also responsible for placing pending tasks in the running queue.
+    // This operation cannot be completed concurrently, so only one thread is required to lock it.
+    private final ScheduledExecutorService periodScheduler = Executors.newScheduledThreadPool(1);
+    // for dispatch tasks
+    private final ScheduledExecutorService dispatchTaskScheduler = Executors.newScheduledThreadPool(1);
+    private final QueryableReentrantLock lock;
+
+    private final MaterializedViewJobExecutor jobExecutor;
+
+    public MaterializedViewJobManager() {
+        pendingJobMap = Maps.newConcurrentMap();
+        runningJobMap = Maps.newConcurrentMap();
+        periodScheduledManager = Maps.newConcurrentMap();
+        jobExecutor = new MaterializedViewJobExecutor();
+        jobHistory = Queues.newLinkedBlockingDeque();
+        lock = new QueryableReentrantLock(true);
+
+        dispatchTaskScheduler.scheduleAtFixedRate(() -> {
+            if (!tryLock()) {
+                return;
+            }
+            try {
+                // check if a running job is complete and remove it from running map
+                Iterator<Long> runningIterator = runningJobMap.keySet().iterator();
+                while (runningIterator.hasNext()) {
+                    Long mvTableId = runningIterator.next();
+                    MaterializedViewRefreshJob job = runningJobMap.get(mvTableId);
+                    Future<?> future = job.getFuture();
+                    if (future.isDone()) {
+                        Constants.MaterializedViewJobStatus jobStatus = job.updateStatusAfterDone();
+                        runningIterator.remove();
+                        jobHistory.addFirst(job);
+                        MaterializedViewRefreshJobStatusChange statusChange =
+                                new MaterializedViewRefreshJobStatusChange(job.getMvTableId(), job.getId(),
+                                        Constants.MaterializedViewJobStatus.RUNNING, jobStatus);
+                        // Catalog.getCurrentCatalog().getEditLog().logRefreshJobStatusChange(statusChange);
+                    }
+                }
+
+                // schedule the pending jobs that can be run into running map
+                Iterator<Long> pendingIterator = pendingJobMap.keySet().iterator();
+                while (pendingIterator.hasNext()) {
+                    Long mvTableId = pendingIterator.next();
+                    MaterializedViewRefreshJob runningJob = runningJobMap.get(mvTableId);
+                    if (runningJob == null) {
+                        Queue<MaterializedViewRefreshJob> jobQueue = pendingJobMap.get(mvTableId);
+                        if (jobQueue.size() == 0) {
+                            pendingIterator.remove();
+                        } else {
+                            MaterializedViewRefreshJob pendingJob = jobQueue.poll();
+                            pendingJob.setStatus(Constants.MaterializedViewJobStatus.RUNNING);
+                            runningJobMap.put(mvTableId, pendingJob);
+                            jobExecutor.addRefreshJob(pendingJob);
+                            MaterializedViewRefreshJobStatusChange statusChange =
+                                    new MaterializedViewRefreshJobStatusChange(pendingJob.getMvTableId(),
+                                            pendingJob.getId(), Constants.MaterializedViewJobStatus.PENDING,
+                                            Constants.MaterializedViewJobStatus.PENDING);
+                            // Catalog.getCurrentCatalog().getEditLog().logRefreshJobStatusChange(statusChange);
+                        }
+                    }
+                }
+            } catch (Exception ex) {
+                LOG.warn("failed to dispatch job.", ex);
+            } finally {
+                unlock();
+            }
+
+        }, 0, 1, TimeUnit.SECONDS);
+    }
+
+    public Long registerScheduledJob(MaterializedViewRefreshJobBuilder builder,
+                                     LocalDateTime startTime, Long period, TimeUnit timeUnit) {
+        Duration duration = Duration.between(LocalDateTime.now(), startTime);
+        long initialDelay = duration.getSeconds();
+        ScheduledFuture<?> future = periodScheduler.scheduleAtFixedRate(() -> addPendingJob(builder.build()),
+                initialDelay, period, timeUnit);
+        MaterializedViewSchedulerInfo info = new MaterializedViewSchedulerInfo(startTime, period, timeUnit, builder);
+        long scheduledId = GlobalStateMgr.getCurrentState().getNextId();
+        info.setId(scheduledId);
+        info.setFuture(future);
+        periodScheduledManager.put(scheduledId, info);
+        // Catalog.getCurrentCatalog().getEditLog().logRegisterScheduledJob(info);
+        return scheduledId;
+    }
+
+    public void deregisterScheduledJob(Long scheduledId) {
+        MaterializedViewSchedulerInfo info = periodScheduledManager.get(scheduledId);
+        ScheduledFuture<?> future = info.getFuture();
+        if (future != null) {
+            future.cancel(true);
+        }
+        periodScheduledManager.remove(scheduledId);
+        // Catalog.getCurrentCatalog().getEditLog().logDeregisterScheduledJob(scheduledId);
+    }
+
+    public boolean addPendingJob(MaterializedViewRefreshJob job) {
+        long oldId = job.getId();
+        if (oldId != DEFAULT_UNASSIGNED_ID) {
+            return false;
+        }
+        long jobId = GlobalStateMgr.getCurrentState().getNextId();
+        job.setId(jobId);
+        long mvTableId = job.getMvTableId();
+        Queue<MaterializedViewRefreshJob> jobQueue = pendingJobMap.get(mvTableId);
+        if (jobQueue == null) {
+            jobQueue = Queues.newConcurrentLinkedQueue();
+            jobQueue.offer(job);
+            pendingJobMap.put(mvTableId, jobQueue);
+        } else {
+            mergeOrOfferJob(jobQueue, job);
+        }
+        // Catalog.getCurrentCatalog().getEditLog().logAddPendingJob(job);
+        return true;
+    }
+
+    // For tasks manually created by users, we do not merge jobs by default.
+    // For tasks that are automatically created by the system duo, like creating
+    // materialized view or time-triggered tasks. Since it is currently a full
+    // refresh, we merge this tasks and update mergeCount field.
+    private void mergeOrOfferJob(Queue<MaterializedViewRefreshJob> jobQueue, MaterializedViewRefreshJob job) {
+        if (job.getTriggerType() == Constants.MaterializedViewRefreshTriggerType.MANUAL) {
+            jobQueue.offer(job);
+        } else {
+            boolean isMerged = false;
+            for (MaterializedViewRefreshJob mayCanMergeJob : jobQueue) {
+                // auto trigger task is full refresh currently
+                if (mayCanMergeJob.getTriggerType() == Constants.MaterializedViewRefreshTriggerType.AUTO) {
+                    mayCanMergeJob.incrementMergeCount();
+                    isMerged = true;
+                }
+            }
+            if (!isMerged) {
+                jobQueue.offer(job);
+            }
+        }
+    }
+
+    public boolean retryJob(Long jobId) {
+        // Generally the retried tasks are the most recent tasks
+        Iterator<MaterializedViewRefreshJob> jobIter = jobHistory.iterator();
+        while (jobIter.hasNext()) {
+            MaterializedViewRefreshJob job = jobIter.next();
+            if (job.getId() == jobId) {
+                if (!(job.getStatus() == Constants.MaterializedViewJobStatus.FAILED ||
+                        job.getStatus() == Constants.MaterializedViewJobStatus.PARTIAL_SUCCESS)) {
+                    return false;
+                }
+                job.setStatus(Constants.MaterializedViewJobStatus.PENDING);
+                long mvTableId = job.getMvTableId();
+                job.incrementRetryTime();
+                Queue<MaterializedViewRefreshJob> jobQueue = pendingJobMap.get(mvTableId);
+                if (jobQueue == null) {
+                    jobQueue = Queues.newConcurrentLinkedQueue();
+                    jobQueue.offer(job);
+                    pendingJobMap.put(mvTableId, jobQueue);
+                } else {
+                    mergeOrOfferJob(jobQueue, job);
+                }
+                jobIter.remove();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public boolean cancelJob(Long mvTableId, Long jobId) {
+        if (!tryLock()) {
+            return false;
+        }
+        try {
+            // cancel running job
+            MaterializedViewRefreshJob runningJob = runningJobMap.get(mvTableId);
+            if (runningJob != null && runningJob.getId() == jobId) {
+                Future<?> future = runningJob.getFuture();
+                boolean isCanceled = future.cancel(true);
+                if (!isCanceled) {
+                    return false;
+                }
+                runningJob.setStatus(Constants.MaterializedViewJobStatus.CANCELED);
+                runningJobMap.remove(mvTableId);
+                jobHistory.addFirst(runningJob);
+                MaterializedViewRefreshJobStatusChange statusChange =
+                        new MaterializedViewRefreshJobStatusChange(mvTableId,
+                                jobId, Constants.MaterializedViewJobStatus.RUNNING,
+                                Constants.MaterializedViewJobStatus.CANCELED);
+                // Catalog.getCurrentCatalog().getEditLog().logRefreshJobStatusChange(statusChange);
+                return true;
+            }
+            // cancel pending job
+            Queue<MaterializedViewRefreshJob> pendingJobQueue = pendingJobMap.get(mvTableId);
+            if (pendingJobQueue != null) {
+                Iterator<MaterializedViewRefreshJob> queueIter = pendingJobQueue.iterator();
+                while (queueIter.hasNext()) {
+                    MaterializedViewRefreshJob pendingJob = queueIter.next();
+                    if (pendingJob.getId() == jobId) {
+                        Future<?> future = pendingJob.getFuture();
+                        if (future != null) {
+                            future.cancel(true);
+                        }
+                        pendingJob.setStatus(Constants.MaterializedViewJobStatus.CANCELED);
+                        jobHistory.addFirst(pendingJob);
+                        queueIter.remove();
+                        MaterializedViewRefreshJobStatusChange statusChange =
+                                new MaterializedViewRefreshJobStatusChange(mvTableId,
+                                        jobId, Constants.MaterializedViewJobStatus.PENDING,
+                                        Constants.MaterializedViewJobStatus.CANCELED);
+                        // Catalog.getCurrentCatalog().getEditLog().logRefreshJobStatusChange(statusChange);
+                        return true;
+                    }
+                }
+            }
+        } finally {
+            unlock();
+        }
+        return false;
+    }
+
+    public List<MaterializedViewRefreshJob> listJob() {
+        List<MaterializedViewRefreshJob> jobList = Lists.newArrayList();
+        for (Queue<MaterializedViewRefreshJob> pJobs : pendingJobMap.values()) {
+            jobList.addAll(pJobs);
+        }
+        jobList.addAll(runningJobMap.values());
+        jobList.addAll(jobHistory);
+        return jobList;
+    }
+
+    private boolean tryLock() {
+        try {
+            if (!lock.tryLock(1, TimeUnit.SECONDS)) {
+                Thread owner = lock.getOwner();
+                if (owner != null) {
+                    LOG.warn("materialized view lock is held by: {}", Util.dumpThread(owner, 50));
+                } else {
+                    LOG.warn("materialized view lock owner is null");
+                }
+                return false;
+            }
+            return true;
+        } catch (InterruptedException e) {
+            LOG.warn("got exception while getting materialized view lock", e);
+        }
+        return lock.isHeldByCurrentThread();
+    }
+
+    private void unlock() {
+        this.lock.unlock();
+    }
+
+    public void replayRegisterScheduledJob(MaterializedViewSchedulerInfo info) {
+        periodScheduledManager.put(info.getId(), info);
+    }
+
+    public void replayDeregisterScheduledJob(long scheduledId) {
+        periodScheduledManager.remove(scheduledId);
+    }
+
+    public void replayAddPendingJob(MaterializedViewRefreshJob job) {
+        Queue<MaterializedViewRefreshJob> jobQueue = pendingJobMap.get(job.getId());
+        if (jobQueue == null) {
+            jobQueue = Queues.newConcurrentLinkedQueue();
+            jobQueue.offer(job);
+            pendingJobMap.put(job.getMvTableId(), jobQueue);
+        } else {
+            mergeOrOfferJob(jobQueue, job);
+        }
+    }
+
+    public void replayJobStatusChange(MaterializedViewRefreshJobStatusChange statusChange) {
+        Constants.MaterializedViewJobStatus fromStatus = statusChange.getFromStatus();
+        Constants.MaterializedViewJobStatus toStatus = statusChange.getToStatus();
+        long mvTableId = statusChange.getMvTableId();
+        if (fromStatus == Constants.MaterializedViewJobStatus.PENDING) {
+            if (toStatus == Constants.MaterializedViewJobStatus.RUNNING) {
+                Queue<MaterializedViewRefreshJob> jobQueue = pendingJobMap.get(mvTableId);
+                if (jobQueue != null && jobQueue.size() != 0) {
+                    MaterializedViewRefreshJob pendingJob = jobQueue.poll();
+                    pendingJob.setStatus(Constants.MaterializedViewJobStatus.RUNNING);
+                    runningJobMap.put(mvTableId, pendingJob);
+                    jobExecutor.addRefreshJob(pendingJob);
+                }
+            } else if (toStatus == Constants.MaterializedViewJobStatus.CANCELED) {
+                Queue<MaterializedViewRefreshJob> pendingJobQueue = pendingJobMap.get(mvTableId);
+                if (pendingJobQueue != null) {
+                    Iterator<MaterializedViewRefreshJob> queueIter = pendingJobQueue.iterator();
+                    while (queueIter.hasNext()) {
+                        MaterializedViewRefreshJob pendingJob = queueIter.next();
+                        if (pendingJob.getId() == statusChange.getJobId()) {
+                            pendingJob.setStatus(toStatus);
+                            jobHistory.addFirst(pendingJob);
+                            queueIter.remove();
+                        }
+                    }
+                }
+            }
+        } else if (fromStatus == Constants.MaterializedViewJobStatus.RUNNING) {
+            if (toStatus == Constants.MaterializedViewJobStatus.SUCCESS |
+                    toStatus == Constants.MaterializedViewJobStatus.CANCELED |
+                    toStatus == Constants.MaterializedViewJobStatus.FAILED |
+                    toStatus == Constants.MaterializedViewJobStatus.PARTIAL_SUCCESS) {
+                MaterializedViewRefreshJob job = runningJobMap.remove(mvTableId);
+                job.setStatus(toStatus);
+                jobHistory.addFirst(job);
+            }
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/mv/MaterializedViewPartitionRefreshTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mv/MaterializedViewPartitionRefreshTask.java
@@ -1,0 +1,56 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.mv;
+
+import com.starrocks.analysis.StatementBase;
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.StmtExecutor;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+public class MaterializedViewPartitionRefreshTask extends MaterializedViewRefreshTask {
+
+    private static final Logger LOG = LogManager.getLogger(MaterializedViewPartitionRefreshTask.class);
+    private String refreshSQL;
+
+    public void setRefreshSQL(String refreshSQL) {
+        this.refreshSQL = refreshSQL;
+    }
+
+    @Override
+    public void runTask() throws Exception {
+        ConnectContext ctx = new ConnectContext();
+        ctx.setQueryId(UUIDUtil.genUUID());
+        executeSQL(refreshSQL, ctx);
+    }
+
+    @Override
+    public IMaterializedViewRefreshTask cloneTask() {
+        MaterializedViewPartitionRefreshTask task = new MaterializedViewPartitionRefreshTask();
+        task.setRefreshSQL(refreshSQL);
+        return task;
+    }
+
+    private void executeSQL(String insertOverrideSQL, ConnectContext ctx) throws Exception {
+        StatementBase insertOverrideStmt = com.starrocks.sql.parser.SqlParser.parse(insertOverrideSQL,
+                ctx.getSessionVariable().getSqlMode()).get(0);
+        ctx.getState().reset();
+        StmtExecutor executor = new StmtExecutor(ctx, insertOverrideStmt);
+        ctx.setExecutor(executor);
+        executor.execute();
+    }
+
+
+    @Override
+    public String toString() {
+        return "MaterializedViewPartitionRefreshTask{" +
+                "refreshSQL='" + refreshSQL + '\'' +
+                ", startTime=" + startTime +
+                ", endTime=" + endTime +
+                ", status=" + status +
+                ", errMsg='" + errMsg + '\'' +
+                '}';
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/mv/MaterializedViewRefreshJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mv/MaterializedViewRefreshJob.java
@@ -1,0 +1,267 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+package com.starrocks.mv;
+
+
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.common.io.Text;
+import com.starrocks.common.io.Writable;
+import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.statistic.Constants;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+
+public class MaterializedViewRefreshJob implements Writable {
+
+    private static final Logger LOG = LogManager.getLogger(MaterializedViewRefreshJob.class);
+    public static final long DEFAULT_UNASSIGNED_ID = -1;
+
+    @SerializedName("id")
+    private long id = DEFAULT_UNASSIGNED_ID;
+
+    @SerializedName("dbId")
+    private long dbId;
+
+    @SerializedName("mvTableId")
+    private long mvTableId;
+
+    @SerializedName("status")
+    private Constants.MaterializedViewJobStatus status = Constants.MaterializedViewJobStatus.PENDING;
+
+    @SerializedName("mode")
+    private Constants.MaterializedViewRefreshMode mode;
+
+    @SerializedName("triggerType")
+    private Constants.MaterializedViewRefreshTriggerType triggerType;
+
+    @SerializedName("createTime")
+    private LocalDateTime createTime;
+
+    @SerializedName("startTime")
+    private LocalDateTime startTime;
+
+    @SerializedName("endTime")
+    private LocalDateTime endTime;
+
+    @SerializedName("tasks")
+    private List<IMaterializedViewRefreshTask> tasks;
+
+    @SerializedName("properties")
+    private Map<String, String> properties;
+
+    @SerializedName("retryTime")
+    protected int retryTime = 0;
+    @SerializedName("mergeCount")
+    private Integer mergeCount = 0;
+
+    private Future<?> future;
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public long getDbId() {
+        return dbId;
+    }
+
+    public void setDbId(long dbId) {
+        this.dbId = dbId;
+    }
+
+    public long getMvTableId() {
+        return mvTableId;
+    }
+
+    public void setMvTableId(long mvTableId) {
+        this.mvTableId = mvTableId;
+    }
+
+    public Constants.MaterializedViewJobStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(Constants.MaterializedViewJobStatus status) {
+        this.status = status;
+    }
+
+    public Constants.MaterializedViewRefreshMode getMode() {
+        return mode;
+    }
+
+    public void setMode(Constants.MaterializedViewRefreshMode mode) {
+        this.mode = mode;
+    }
+
+    public Constants.MaterializedViewRefreshTriggerType getTriggerType() {
+        return triggerType;
+    }
+
+    public void setTriggerType(Constants.MaterializedViewRefreshTriggerType triggerType) {
+        this.triggerType = triggerType;
+    }
+
+    public LocalDateTime getCreateTime() {
+        return createTime;
+    }
+
+    public void setCreateTime(LocalDateTime createTime) {
+        this.createTime = createTime;
+    }
+
+    public LocalDateTime getStartTime() {
+        return startTime;
+    }
+
+    public void setStartTime(LocalDateTime startTime) {
+        this.startTime = startTime;
+    }
+
+    public LocalDateTime getEndTime() {
+        return endTime;
+    }
+
+    public void setEndTime(LocalDateTime endTime) {
+        this.endTime = endTime;
+    }
+
+    public List<IMaterializedViewRefreshTask> getTasks() {
+        return tasks;
+    }
+
+    public void setTasks(List<IMaterializedViewRefreshTask> tasks) {
+        this.tasks = tasks;
+    }
+
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    public void setProperties(Map<String, String> properties) {
+        this.properties = properties;
+    }
+
+    public Future<?> getFuture() {
+        return future;
+    }
+
+    public void setFuture(Future<?> future) {
+        this.future = future;
+    }
+
+    public void generateTasks() {
+        // MaterializedView mv = MaterializedViewManager.getMaterializedView(dbId, mvTableId)
+        // List<Partitions> partitions = mv.getPartitions()
+        MaterializedViewPartitionRefreshTask task = new MaterializedViewPartitionRefreshTask();
+        task.setRefreshSQL("insert overwrite xxxx");
+        tasks.add(task);
+    }
+
+    public void runTasks()  {
+        if (tasks == null) {
+            LOG.warn("no tasks running for job {}. may forget to generate tasks? ", id);
+            return;
+        }
+        for (IMaterializedViewRefreshTask task : tasks) {
+            if (task.getStatus() == Constants.MaterializedViewTaskStatus.FAILED) {
+                task.setStatus(Constants.MaterializedViewTaskStatus.PENDING);
+            }
+            if (task.getStatus() == Constants.MaterializedViewTaskStatus.PENDING) {
+                task.beginTask();
+                task.setStatus(Constants.MaterializedViewTaskStatus.RUNNING);
+                try {
+                    task.runTask();
+                    task.setStatus(Constants.MaterializedViewTaskStatus.SUCCESS);
+                } catch (Throwable ex) {
+                    task.setStatus(Constants.MaterializedViewTaskStatus.FAILED);
+                    LOG.warn("materialized view refresh task failed. jobId:{}", id, ex);
+                    task.setErrMsg(ex.getMessage());
+                }
+                task.finishTask();
+            }
+        }
+    }
+
+    public Constants.MaterializedViewJobStatus updateStatusAfterDone() {
+        if (status == Constants.MaterializedViewJobStatus.RUNNING ||
+                status == Constants.MaterializedViewJobStatus.RETRYING) {
+            if (tasks == null) {
+                status = Constants.MaterializedViewJobStatus.FAILED;
+                return status;
+            } else if (tasks.size() == 0) {
+                status = Constants.MaterializedViewJobStatus.SUCCESS;
+                return status;
+            }
+            Map<Constants.MaterializedViewTaskStatus, Long> result = tasks.stream().collect(
+                    Collectors.groupingBy(IMaterializedViewRefreshTask::getStatus, Collectors.counting())
+            );
+            Long successCount = result.get(Constants.MaterializedViewTaskStatus.SUCCESS);
+            if (successCount == null || successCount == 0)  {
+                status = Constants.MaterializedViewJobStatus.FAILED;
+            } else if (successCount == tasks.size()) {
+                status = Constants.MaterializedViewJobStatus.SUCCESS;
+            } else {
+                status = Constants.MaterializedViewJobStatus.PARTIAL_SUCCESS;
+            }
+        }
+        return status;
+    }
+
+    public Integer getMergeCount() {
+        return mergeCount;
+    }
+
+    public void incrementMergeCount() {
+        ++this.mergeCount;
+    }
+
+    public int getRetryTime() {
+        return retryTime;
+    }
+
+    public void incrementRetryTime() {
+        ++this.retryTime;
+    }
+
+    @Override
+    public String toString() {
+        return "MaterializedViewRefreshJob{" +
+                "id=" + id +
+                ", dbId=" + dbId +
+                ", mvTableId=" + mvTableId +
+                ", status=" + status +
+                ", mode=" + mode +
+                ", triggerType=" + triggerType +
+                ", createTime=" + createTime +
+                ", startTime=" + startTime +
+                ", endTime=" + endTime +
+                ", tasks=" + tasks +
+                ", properties=" + properties +
+                ", retryTime=" + retryTime +
+                ", mergeCount=" + mergeCount +
+                '}';
+    }
+
+    public static MaterializedViewRefreshJob read(DataInput in) throws IOException {
+        String json = Text.readString(in);
+        return GsonUtils.GSON.fromJson(json, MaterializedViewRefreshJob.class);
+    }
+
+    @Override
+    public void write(DataOutput out) throws IOException {
+        String json = GsonUtils.GSON.toJson(this);
+        Text.writeString(out, json);
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/mv/MaterializedViewRefreshJobBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mv/MaterializedViewRefreshJobBuilder.java
@@ -1,0 +1,89 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.mv;
+
+import com.clearspring.analytics.util.Lists;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.statistic.Constants;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+public class MaterializedViewRefreshJobBuilder  {
+
+    @SerializedName("dbId")
+    private final long dbId;
+
+    @SerializedName("mvTableId")
+    private final long mvTableId;
+
+    @SerializedName("mode")
+    private Constants.MaterializedViewRefreshMode mode = Constants.MaterializedViewRefreshMode.ASYNC;
+
+    @SerializedName("triggerType")
+    private Constants.MaterializedViewRefreshTriggerType triggerType = Constants.MaterializedViewRefreshTriggerType.AUTO;
+
+    @SerializedName("properties")
+    private Map<String, String> properties;
+
+    private List<IMaterializedViewRefreshTask> tasks;
+
+
+    public static MaterializedViewRefreshJobBuilder newBuilder(long dbId, long mvTableId) {
+        return new MaterializedViewRefreshJobBuilder(dbId, mvTableId);
+    }
+
+    public MaterializedViewRefreshJobBuilder(long dbId, long mvTableId) {
+        this.dbId = dbId;
+        this.mvTableId = mvTableId;
+    }
+
+    public MaterializedViewRefreshJobBuilder mode(Constants.MaterializedViewRefreshMode mode) {
+        this.mode = mode;
+        return this;
+    }
+
+    public MaterializedViewRefreshJobBuilder triggerType(Constants.MaterializedViewRefreshTriggerType triggerType) {
+        this.triggerType = triggerType;
+        return this;
+    }
+
+    public MaterializedViewRefreshJobBuilder withRefreshDatePartitionRange(String start, String end) {
+        properties = ImmutableMap.of(
+                "refresh.filter.type", "date.partition",
+                "refresh.partition.start", start,
+                "refresh.partition.end", end);
+        return this;
+    }
+
+    @VisibleForTesting
+    public MaterializedViewRefreshJobBuilder setTasksAhead(List<IMaterializedViewRefreshTask> tasks) {
+        this.tasks = tasks;
+        return this;
+    }
+
+    public MaterializedViewRefreshJob build() {
+        MaterializedViewRefreshJob job = new MaterializedViewRefreshJob();
+        job.setDbId(this.dbId);
+        job.setMvTableId(this.mvTableId);
+        job.setMode(this.mode);
+        job.setTriggerType(this.triggerType);
+        job.setCreateTime(LocalDateTime.now());
+        if (tasks != null) {
+            List<IMaterializedViewRefreshTask> cloneTasks = Lists.newArrayList();
+            for (IMaterializedViewRefreshTask task : tasks) {
+                cloneTasks.add(task.cloneTask());
+            }
+            job.setTasks(cloneTasks);
+        }
+        job.setProperties(properties);
+        return job;
+    }
+
+    public Long getMvTableId() {
+        return mvTableId;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/mv/MaterializedViewRefreshJobStatusChange.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mv/MaterializedViewRefreshJobStatusChange.java
@@ -1,0 +1,81 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.mv;
+
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.common.io.Text;
+import com.starrocks.common.io.Writable;
+import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.statistic.Constants;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+public class MaterializedViewRefreshJobStatusChange implements Writable {
+
+    @SerializedName("mvTableId")
+    private long mvTableId;
+
+    @SerializedName("jobId")
+    private long jobId;
+
+    @SerializedName("fromStatus")
+    Constants.MaterializedViewJobStatus fromStatus;
+
+    @SerializedName("toStatus")
+    Constants.MaterializedViewJobStatus toStatus;
+
+    public MaterializedViewRefreshJobStatusChange(long mvTableId, long jobId,
+                                                  Constants.MaterializedViewJobStatus fromStatus,
+                                                  Constants.MaterializedViewJobStatus toStatus) {
+        this.mvTableId = mvTableId;
+        this.jobId = jobId;
+        this.fromStatus = fromStatus;
+        this.toStatus = toStatus;
+    }
+
+    public long getMvTableId() {
+        return mvTableId;
+    }
+
+    public void setMvTableId(long mvTableId) {
+        this.mvTableId = mvTableId;
+    }
+
+    public long getJobId() {
+        return jobId;
+    }
+
+    public void setJobId(long jobId) {
+        this.jobId = jobId;
+    }
+
+    public Constants.MaterializedViewJobStatus getFromStatus() {
+        return fromStatus;
+    }
+
+    public void setFromStatus(Constants.MaterializedViewJobStatus fromStatus) {
+        this.fromStatus = fromStatus;
+    }
+
+    public Constants.MaterializedViewJobStatus getToStatus() {
+        return toStatus;
+    }
+
+    public void setToStatus(Constants.MaterializedViewJobStatus toStatus) {
+        this.toStatus = toStatus;
+    }
+
+    public static MaterializedViewRefreshJobStatusChange read(DataInput in) throws IOException {
+        String json = Text.readString(in);
+        return GsonUtils.GSON.fromJson(json, MaterializedViewRefreshJobStatusChange.class);
+    }
+
+    @Override
+    public void write(DataOutput out) throws IOException {
+        String json = GsonUtils.GSON.toJson(this);
+        Text.writeString(out, json);
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/mv/MaterializedViewRefreshTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mv/MaterializedViewRefreshTask.java
@@ -1,0 +1,73 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.mv;
+
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.statistic.Constants;
+
+import java.time.LocalDateTime;
+
+public class MaterializedViewRefreshTask  implements IMaterializedViewRefreshTask {
+
+    @SerializedName("startTime")
+    protected LocalDateTime startTime;
+
+    @SerializedName("endTime")
+    protected LocalDateTime endTime;
+
+    @SerializedName("status")
+    protected Constants.MaterializedViewTaskStatus status = Constants.MaterializedViewTaskStatus.PENDING;
+
+    @SerializedName("errMsg")
+    protected String errMsg;
+
+    public LocalDateTime getStartTime() {
+        return startTime;
+    }
+
+    public void setStartTime(LocalDateTime startTime) {
+        this.startTime = startTime;
+    }
+
+    public LocalDateTime getEndTime() {
+        return endTime;
+    }
+
+    public void setEndTime(LocalDateTime endTime) {
+        this.endTime = endTime;
+    }
+
+    public Constants.MaterializedViewTaskStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(Constants.MaterializedViewTaskStatus status) {
+        this.status = status;
+    }
+
+    @Override
+    public void beginTask() {
+        startTime = LocalDateTime.now();
+    }
+
+    @Override
+    public void runTask() throws Exception {}
+
+    @Override
+    public void finishTask() {
+        endTime = LocalDateTime.now();
+    }
+
+    @Override
+    public IMaterializedViewRefreshTask cloneTask() {
+        return new MaterializedViewPartitionRefreshTask();
+    }
+
+    public String getErrMsg() {
+        return errMsg;
+    }
+
+    public void setErrMsg(String errMsg) {
+        this.errMsg = errMsg;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/mv/MaterializedViewSchedulerInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mv/MaterializedViewSchedulerInfo.java
@@ -1,0 +1,78 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.mv;
+
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.common.io.Text;
+import com.starrocks.common.io.Writable;
+import com.starrocks.persist.gson.GsonUtils;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+public class MaterializedViewSchedulerInfo implements Writable {
+
+    @SerializedName("id")
+    private Long id;
+
+    @SerializedName("startTime")
+    private LocalDateTime startTime;
+
+    @SerializedName("period")
+    private Long period;
+
+    @SerializedName("timeUnit")
+    private TimeUnit timeUnit;
+
+    @SerializedName("jobBuilder")
+    private MaterializedViewRefreshJobBuilder jobBuilder;
+
+    private ScheduledFuture<?> future;
+
+    public MaterializedViewSchedulerInfo(LocalDateTime startTime, Long period, TimeUnit timeUnit,
+                                         MaterializedViewRefreshJobBuilder jobBuilder) {
+        this.startTime = startTime;
+        this.period = period;
+        this.timeUnit = timeUnit;
+        this.jobBuilder = jobBuilder;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public LocalDateTime getStartTime() {
+        return startTime;
+    }
+
+    public void setStartTime(LocalDateTime startTime) {
+        this.startTime = startTime;
+    }
+
+    public ScheduledFuture<?> getFuture() {
+        return future;
+    }
+
+    public void setFuture(ScheduledFuture<?> future) {
+        this.future = future;
+    }
+
+    public static MaterializedViewSchedulerInfo read(DataInput in) throws IOException {
+        String json = Text.readString(in);
+        return GsonUtils.GSON.fromJson(json, MaterializedViewSchedulerInfo.class);
+    }
+
+    @Override
+    public void write(DataOutput out) throws IOException {
+        String json = GsonUtils.GSON.toJson(this);
+        Text.writeString(out, json);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/mv/MaterializedViewTaskException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mv/MaterializedViewTaskException.java
@@ -1,0 +1,20 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.mv;
+
+public class MaterializedViewTaskException extends RuntimeException {
+
+    public MaterializedViewTaskException(String message) {
+        super(message);
+    }
+
+    @Override
+    public String getMessage() {
+        String message = super.getMessage();
+        if (message == null && getCause() != null) {
+            message = getCause().getMessage();
+        }
+        return message;
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
@@ -203,4 +203,10 @@ public class OperationType {
 
     // workgroup 10021 ~ 10030
     public static final short OP_WORKGROUP = 10021;
+
+    // materialized view 10031 ~ 10050
+    public static final short OP_REGISTER_SCHEDULED_MV_JOB = 10031;
+    public static final short OP_DEREGISTER_SCHEDULED_MV_JOB = 10032;
+    public static final short OP_ADD_PENDING_MV_JOB = 10033;
+    public static final short OP_MV_JOB_STATUS_CHANGE = 10034;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -227,6 +227,7 @@ import com.starrocks.master.Checkpoint;
 import com.starrocks.master.MetaHelper;
 import com.starrocks.meta.MetaContext;
 import com.starrocks.metric.MetricRepo;
+import com.starrocks.mv.MaterializedViewJobManager;
 import com.starrocks.mysql.privilege.Auth;
 import com.starrocks.mysql.privilege.PrivPredicate;
 import com.starrocks.persist.AddPartitionsInfo;
@@ -499,6 +500,8 @@ public class GlobalStateMgr {
 
     private StarOSAgent starOSAgent;
 
+    private MaterializedViewJobManager materializedViewJobManager;
+
     public List<Frontend> getFrontends(FrontendNodeType nodeType) {
         if (nodeType == null) {
             // get all
@@ -676,6 +679,7 @@ public class GlobalStateMgr {
         this.analyzeManager = new AnalyzeManager();
 
         this.starOSAgent = new StarOSAgent();
+        this.materializedViewJobManager = new MaterializedViewJobManager();
     }
 
     public static void destroyCheckpoint() {
@@ -810,6 +814,10 @@ public class GlobalStateMgr {
 
     public StarOSAgent getStarOSAgent() {
         return starOSAgent;
+    }
+
+    public MaterializedViewJobManager getMaterializedViewJobManager() {
+        return materializedViewJobManager;
     }
 
     // Use tryLock to avoid potential dead lock

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/Constants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/Constants.java
@@ -30,4 +30,42 @@ public class Constants {
         FINISH,
     }
 
+    // PENDING -> RUNNING -> FAILED
+    //                    -> SUCCESS
+    //                    -> PARTIAL_SUCCESS
+    //                    -> CANCELED
+    //         -> CANCELED
+    public enum MaterializedViewJobStatus {
+        PENDING,
+        RUNNING,
+        RETRYING,
+        CANCELED,
+        FAILED,
+        // all tasks are executed, but some task failed
+        PARTIAL_SUCCESS,
+        SUCCESS,
+    }
+
+    // PENDING -> RUNNING -> FAILED
+    //                    -> SUCCESS
+    //                    -> CANCELED
+    //         -> CANCELED
+    public enum MaterializedViewTaskStatus {
+        PENDING,
+        RUNNING,
+        CANCELED,
+        FAILED,
+        SUCCESS
+    }
+
+    public enum MaterializedViewRefreshTriggerType {
+        AUTO,
+        MANUAL
+    }
+
+    public enum MaterializedViewRefreshMode {
+        SYNC,
+        ASYNC
+    }
+
 }

--- a/fe/fe-core/src/test/java/com/starrocks/mv/MaterializedViewJobManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mv/MaterializedViewJobManagerTest.java
@@ -1,0 +1,441 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.mv;
+
+import com.clearspring.analytics.util.Lists;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.statistic.Constants;
+import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
+import org.apache.hadoop.util.ThreadUtil;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+public class MaterializedViewJobManagerTest {
+
+    private static final Logger LOG = LogManager.getLogger(MaterializedViewJobManagerTest.class);
+
+    @Mocked
+    private GlobalStateMgr globalStateMgr;
+
+    @Before
+    public void setUp() {
+
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                minTimes = 0;
+                result = globalStateMgr;
+
+                globalStateMgr.getNextId();
+                minTimes = 0;
+                returns(100L, 101L, 102L, 103L, 104L, 105L);
+            }
+        };
+    }
+
+    @Test
+    public void ScheduleScenariosRegularlyTest() {
+
+        LocalDateTime now = LocalDateTime.now();
+
+        MaterializedViewRefreshJobBuilder builder = MaterializedViewRefreshJobBuilder
+                .newBuilder(1, 2)
+                .mode(Constants.MaterializedViewRefreshMode.ASYNC)
+                .triggerType(Constants.MaterializedViewRefreshTriggerType.AUTO);
+
+
+        List<IMaterializedViewRefreshTask> tasks = Lists.newArrayList();
+
+        builder.setTasksAhead(tasks);
+        tasks.add(new MaterializedViewMockRefreshTask(1000L, "mv1"));
+        tasks.add(new MaterializedViewMockRefreshTask(1000L, "mv1"));
+        tasks.add(new MaterializedViewMockRefreshTask(1000L, "mv1"));
+
+        new MockUp<MaterializedViewRefreshJob>(MaterializedViewRefreshJob.class) {
+            @Mock
+            public void generateTasks() {
+            }
+        };
+
+        MaterializedViewJobManager scheduler = new MaterializedViewJobManager();
+        Long scheduledId = scheduler.registerScheduledJob(builder, now.plusSeconds(3), 7L, TimeUnit.SECONDS);
+        LOG.info("register scheduled job: " + scheduledId + ", " + LocalDateTime.now());
+        ThreadUtil.sleepAtLeastIgnoreInterrupts(15000L);
+
+        scheduler.deregisterScheduledJob(scheduledId);
+        List<MaterializedViewRefreshJob> jobList = scheduler.listJob();
+        for (MaterializedViewRefreshJob materializedViewRefreshJob : jobList) {
+            LOG.info(materializedViewRefreshJob);
+        }
+
+        Assert.assertEquals(2, jobList.size());
+
+        MaterializedViewRefreshJob job1 = jobList.get(1);
+        Assert.assertEquals(101, job1.getId());
+        Assert.assertEquals(Constants.MaterializedViewJobStatus.SUCCESS, job1.getStatus());
+        Assert.assertEquals(3, job1.getTasks().size());
+
+        MaterializedViewRefreshJob job2 = jobList.get(0);
+
+        Assert.assertEquals(102, job2.getId());
+        Assert.assertEquals(Constants.MaterializedViewJobStatus.SUCCESS, job2.getStatus());
+        Assert.assertEquals(3, job2.getTasks().size());
+    }
+
+    @Test
+    public void TriggerScenariosRegularlyTest() {
+        List<IMaterializedViewRefreshTask> tasks = Lists.newArrayList();
+        tasks.add(new MaterializedViewMockRefreshTask(1000L, "mv1"));
+        tasks.add(new MaterializedViewMockRefreshTask(1000L, "mv1"));
+        tasks.add(new MaterializedViewMockRefreshTask(1000L, "mv1"));
+
+        MaterializedViewRefreshJob job = MaterializedViewRefreshJobBuilder
+                .newBuilder(1, 2)
+                .mode(Constants.MaterializedViewRefreshMode.ASYNC)
+                .triggerType(Constants.MaterializedViewRefreshTriggerType.AUTO)
+                .setTasksAhead(tasks)
+                .build();
+
+        new MockUp<MaterializedViewRefreshJob>(MaterializedViewRefreshJob.class) {
+            @Mock
+            public void generateTasks() {
+            }
+        };
+        MaterializedViewJobManager scheduler = new MaterializedViewJobManager();
+        scheduler.addPendingJob(job);
+        ThreadUtil.sleepAtLeastIgnoreInterrupts(5000L);
+        List<MaterializedViewRefreshJob> jobList = scheduler.listJob();
+        for (MaterializedViewRefreshJob materializedViewRefreshJob : jobList) {
+            LOG.info(materializedViewRefreshJob);
+        }
+
+        Assert.assertEquals(Constants.MaterializedViewJobStatus.SUCCESS, jobList.get(0).getStatus());
+    }
+
+    @Test
+    public void ManualScenariosRegularlyTest() {
+        List<IMaterializedViewRefreshTask> tasks = Lists.newArrayList();
+        tasks.add(new MaterializedViewMockRefreshTask(1000L, "mv1"));
+        tasks.add(new MaterializedViewMockRefreshTask(1000L, "mv1"));
+        tasks.add(new MaterializedViewMockRefreshTask(1000L, "mv1"));
+
+        MaterializedViewRefreshJob job = MaterializedViewRefreshJobBuilder
+                .newBuilder(1, 2)
+                .mode(Constants.MaterializedViewRefreshMode.ASYNC)
+                .triggerType(Constants.MaterializedViewRefreshTriggerType.MANUAL)
+                .withRefreshDatePartitionRange("2020-01-01", "2020-04-24")
+                .setTasksAhead(tasks)
+                .build();
+
+        new MockUp<MaterializedViewRefreshJob>(MaterializedViewRefreshJob.class) {
+            @Mock
+            public void generateTasks() {
+            }
+        };
+        MaterializedViewJobManager scheduler = new MaterializedViewJobManager();
+        scheduler.addPendingJob(job);
+        ThreadUtil.sleepAtLeastIgnoreInterrupts(5000L);
+        List<MaterializedViewRefreshJob> jobList = scheduler.listJob();
+        for (MaterializedViewRefreshJob materializedViewRefreshJob : jobList) {
+            LOG.info(materializedViewRefreshJob);
+        }
+
+        Assert.assertEquals(Constants.MaterializedViewJobStatus.SUCCESS, jobList.get(0).getStatus());
+    }
+
+    @Test
+    public void TriggerScenariosCancelRunningJobTest() {
+        List<IMaterializedViewRefreshTask> tasks = Lists.newArrayList();
+        tasks.add(new MaterializedViewMockRefreshTask(2000L, "mv1"));
+        tasks.add(new MaterializedViewMockRefreshTask(4000L, "mv1"));
+        tasks.add(new MaterializedViewMockRefreshTask(2000L, "mv1"));
+
+        MaterializedViewRefreshJob job = MaterializedViewRefreshJobBuilder
+                .newBuilder(1, 2)
+                .mode(Constants.MaterializedViewRefreshMode.ASYNC)
+                .triggerType(Constants.MaterializedViewRefreshTriggerType.AUTO)
+                .setTasksAhead(tasks)
+                .build();
+
+        new MockUp<MaterializedViewRefreshJob>(MaterializedViewRefreshJob.class) {
+            @Mock
+            public void generateTasks() {
+            }
+        };
+        MaterializedViewJobManager scheduler = new MaterializedViewJobManager();
+        boolean isRegister = scheduler.addPendingJob(job);
+        ThreadUtil.sleepAtLeastIgnoreInterrupts(3000L);
+        boolean isCancel = scheduler.cancelJob(job.getMvTableId(), job.getId());
+        List<MaterializedViewRefreshJob> jobList = scheduler.listJob();
+        for (MaterializedViewRefreshJob materializedViewRefreshJob : jobList) {
+            LOG.info(materializedViewRefreshJob);
+        }
+
+        Assert.assertEquals(true, isRegister);
+        Assert.assertEquals(true, isCancel);
+    }
+
+    @Test
+    public void TriggerScenariosFailedJobTest() {
+        List<IMaterializedViewRefreshTask> tasks = Lists.newArrayList();
+        tasks.add(new MaterializedViewMockRefreshTask(1000L, "mv1"));
+        MaterializedViewMockRefreshTask failedTask = new MaterializedViewMockRefreshTask(1000L, "mv1");
+        failedTask.setMockFailed(true);
+        tasks.add(failedTask);
+        tasks.add(new MaterializedViewMockRefreshTask(1000L, "mv1"));
+
+        MaterializedViewRefreshJob job = MaterializedViewRefreshJobBuilder
+                .newBuilder(1, 2)
+                .mode(Constants.MaterializedViewRefreshMode.ASYNC)
+                .triggerType(Constants.MaterializedViewRefreshTriggerType.AUTO)
+                .setTasksAhead(tasks)
+                .build();
+
+        new MockUp<MaterializedViewRefreshJob>(MaterializedViewRefreshJob.class) {
+            @Mock
+            public void generateTasks() {
+            }
+        };
+        MaterializedViewJobManager scheduler = new MaterializedViewJobManager();
+        boolean isRegister = scheduler.addPendingJob(job);
+        ThreadUtil.sleepAtLeastIgnoreInterrupts(5000L);
+        List<MaterializedViewRefreshJob> jobList = scheduler.listJob();
+        for (MaterializedViewRefreshJob materializedViewRefreshJob : jobList) {
+            LOG.info(materializedViewRefreshJob);
+        }
+
+        Assert.assertEquals(true, isRegister);
+        Assert.assertEquals(Constants.MaterializedViewJobStatus.PARTIAL_SUCCESS, job.getStatus());
+        Assert.assertEquals(Constants.MaterializedViewTaskStatus.SUCCESS, job.getTasks().get(0).getStatus());
+        Assert.assertEquals(Constants.MaterializedViewTaskStatus.FAILED, job.getTasks().get(1).getStatus());
+        Assert.assertEquals(Constants.MaterializedViewTaskStatus.SUCCESS, job.getTasks().get(2).getStatus());
+
+        MaterializedViewMockRefreshTask filedMockTask = (MaterializedViewMockRefreshTask)job.getTasks().get(1);
+        filedMockTask.setMockFailed(false);
+
+        scheduler.retryJob(job.getId());
+        ThreadUtil.sleepAtLeastIgnoreInterrupts(3000L);
+        for (MaterializedViewRefreshJob materializedViewRefreshJob : jobList) {
+            LOG.info(materializedViewRefreshJob);
+        }
+        Assert.assertEquals(Constants.MaterializedViewTaskStatus.SUCCESS, job.getTasks().get(1).getStatus());
+        Assert.assertEquals(Constants.MaterializedViewJobStatus.SUCCESS, job.getStatus());
+        Assert.assertEquals(1, job.getRetryTime());
+    }
+
+    @Test
+    public void TriggerScenariosCancelPendingJobTest() {
+        List<IMaterializedViewRefreshTask> tasks = Lists.newArrayList();
+        tasks.add(new MaterializedViewMockRefreshTask(4000L, "mv1"));
+        tasks.add(new MaterializedViewMockRefreshTask(1000L, "mv1"));
+
+        MaterializedViewRefreshJob job1 = MaterializedViewRefreshJobBuilder
+                .newBuilder(1, 2)
+                .mode(Constants.MaterializedViewRefreshMode.ASYNC)
+                .triggerType(Constants.MaterializedViewRefreshTriggerType.AUTO)
+                .setTasksAhead(tasks)
+                .build();
+
+        MaterializedViewRefreshJob job2 = MaterializedViewRefreshJobBuilder
+                .newBuilder(1, 2)
+                .mode(Constants.MaterializedViewRefreshMode.ASYNC)
+                .triggerType(Constants.MaterializedViewRefreshTriggerType.MANUAL)
+                .build();
+        new MockUp<MaterializedViewRefreshJob>(MaterializedViewRefreshJob.class) {
+            @Mock
+            public void generateTasks() {
+            }
+        };
+        MaterializedViewJobManager scheduler = new MaterializedViewJobManager();
+        boolean isRegister1 = scheduler.addPendingJob(job1);
+        boolean isRegister2 = scheduler.addPendingJob(job2);
+        ThreadUtil.sleepAtLeastIgnoreInterrupts(5000L);
+        boolean isCancel = scheduler.cancelJob(job2.getMvTableId(), job2.getId());
+        List<MaterializedViewRefreshJob> jobList = scheduler.listJob();
+        for (MaterializedViewRefreshJob materializedViewRefreshJob : jobList) {
+            LOG.info(materializedViewRefreshJob);
+        }
+        Assert.assertEquals(2, jobList.size());
+        Assert.assertEquals(Constants.MaterializedViewJobStatus.CANCELED, jobList.get(1).getStatus());
+        Assert.assertEquals(Constants.MaterializedViewJobStatus.RUNNING, jobList.get(0).getStatus());
+        Assert.assertEquals(true, isRegister1);
+        Assert.assertEquals(true, isRegister2);
+        Assert.assertEquals(true, isCancel);
+    }
+
+    @Test
+    public void AutoTriggerPendingJobMergeTest() {
+        List<IMaterializedViewRefreshTask> tasks = Lists.newArrayList();
+        tasks.add(new MaterializedViewMockRefreshTask(4000L, "mv1"));
+        tasks.add(new MaterializedViewMockRefreshTask(4000L, "mv1"));
+
+        MaterializedViewRefreshJob job1 = MaterializedViewRefreshJobBuilder
+                .newBuilder(1, 2)
+                .mode(Constants.MaterializedViewRefreshMode.ASYNC)
+                .triggerType(Constants.MaterializedViewRefreshTriggerType.AUTO)
+                .setTasksAhead(tasks)
+                .build();
+
+        MaterializedViewRefreshJob job2 = MaterializedViewRefreshJobBuilder
+                .newBuilder(1, 2)
+                .mode(Constants.MaterializedViewRefreshMode.ASYNC)
+                .triggerType(Constants.MaterializedViewRefreshTriggerType.AUTO)
+                .build();
+
+        MaterializedViewRefreshJob job3 = MaterializedViewRefreshJobBuilder
+                .newBuilder(1, 2)
+                .mode(Constants.MaterializedViewRefreshMode.ASYNC)
+                .triggerType(Constants.MaterializedViewRefreshTriggerType.AUTO)
+                .build();
+
+        MaterializedViewRefreshJob job4 = MaterializedViewRefreshJobBuilder
+                .newBuilder(1, 2)
+                .mode(Constants.MaterializedViewRefreshMode.ASYNC)
+                .triggerType(Constants.MaterializedViewRefreshTriggerType.AUTO)
+                .build();
+        new MockUp<MaterializedViewRefreshJob>(MaterializedViewRefreshJob.class) {
+            @Mock
+            public void generateTasks() {
+            }
+        };
+
+        MaterializedViewJobManager scheduler = new MaterializedViewJobManager();
+        boolean isRegister1 = scheduler.addPendingJob(job1);
+        ThreadUtil.sleepAtLeastIgnoreInterrupts(1000L);
+        boolean isRegister2 = scheduler.addPendingJob(job2);
+        boolean isRegister3 = scheduler.addPendingJob(job3);
+        boolean isRegister4 = scheduler.addPendingJob(job4);
+        ThreadUtil.sleepAtLeastIgnoreInterrupts(3000L);
+        List<MaterializedViewRefreshJob> jobList = scheduler.listJob();
+        for (MaterializedViewRefreshJob materializedViewRefreshJob : jobList) {
+            LOG.info(materializedViewRefreshJob);
+        }
+
+        Assert.assertEquals(true, isRegister1);
+        Assert.assertEquals(true, isRegister2);
+        Assert.assertEquals(true, isRegister3);
+        Assert.assertEquals(true, isRegister4);
+
+        Assert.assertTrue(2 == jobList.get(0).getMergeCount());
+
+        scheduler.cancelJob(job1.getMvTableId(), job1.getId());
+        scheduler.cancelJob(job2.getMvTableId(), job2.getId());
+        scheduler.cancelJob(job3.getMvTableId(), job3.getId());
+        scheduler.cancelJob(job4.getMvTableId(), job4.getId());
+    }
+
+    @Test
+    public void ManualTriggerPendingJobMergeTest() {
+        List<IMaterializedViewRefreshTask> tasks = Lists.newArrayList();
+        tasks.add(new MaterializedViewMockRefreshTask(4000L, "mv1"));
+        tasks.add(new MaterializedViewMockRefreshTask(4000L, "mv1"));
+
+        MaterializedViewRefreshJob job1 = MaterializedViewRefreshJobBuilder
+                .newBuilder(1, 2)
+                .mode(Constants.MaterializedViewRefreshMode.ASYNC)
+                .triggerType(Constants.MaterializedViewRefreshTriggerType.MANUAL)
+                .setTasksAhead(tasks)
+                .build();
+
+        MaterializedViewRefreshJob job2 = MaterializedViewRefreshJobBuilder
+                .newBuilder(1, 2)
+                .mode(Constants.MaterializedViewRefreshMode.ASYNC)
+                .triggerType(Constants.MaterializedViewRefreshTriggerType.MANUAL)
+                .build();
+
+        MaterializedViewRefreshJob job3 = MaterializedViewRefreshJobBuilder
+                .newBuilder(1, 2)
+                .mode(Constants.MaterializedViewRefreshMode.ASYNC)
+                .triggerType(Constants.MaterializedViewRefreshTriggerType.MANUAL)
+                .build();
+
+        MaterializedViewRefreshJob job4 = MaterializedViewRefreshJobBuilder
+                .newBuilder(1, 2)
+                .mode(Constants.MaterializedViewRefreshMode.ASYNC)
+                .triggerType(Constants.MaterializedViewRefreshTriggerType.MANUAL)
+                .build();
+        new MockUp<MaterializedViewRefreshJob>(MaterializedViewRefreshJob.class) {
+            @Mock
+            public void generateTasks() {
+            }
+        };
+        MaterializedViewJobManager scheduler = new MaterializedViewJobManager();
+        boolean isRegister1 = scheduler.addPendingJob(job1);
+        ThreadUtil.sleepAtLeastIgnoreInterrupts(1000L);
+        boolean isRegister2 = scheduler.addPendingJob(job2);
+        boolean isRegister3 = scheduler.addPendingJob(job3);
+        boolean isRegister4 = scheduler.addPendingJob(job4);
+        ThreadUtil.sleepAtLeastIgnoreInterrupts(3000L);
+        List<MaterializedViewRefreshJob> jobList = scheduler.listJob();
+        for (MaterializedViewRefreshJob materializedViewRefreshJob : jobList) {
+            LOG.info(materializedViewRefreshJob);
+        }
+
+        Assert.assertEquals(true, isRegister1);
+        Assert.assertEquals(true, isRegister2);
+        Assert.assertEquals(true, isRegister3);
+        Assert.assertEquals(true, isRegister4);
+
+        Assert.assertTrue(4 == jobList.size());
+
+        scheduler.cancelJob(job1.getMvTableId(), job1.getId());
+        scheduler.cancelJob(job2.getMvTableId(), job2.getId());
+        scheduler.cancelJob(job3.getMvTableId(), job3.getId());
+        scheduler.cancelJob(job4.getMvTableId(), job4.getId());
+    }
+
+    @Test
+    public void differentMaterializedViewConcurrencyTest() {
+        List<IMaterializedViewRefreshTask> tasks1 = Lists.newArrayList();
+        tasks1.add(new MaterializedViewMockRefreshTask(1000L, "mv1"));
+        tasks1.add(new MaterializedViewMockRefreshTask(1000L, "mv1"));
+
+        List<IMaterializedViewRefreshTask> tasks2 = Lists.newArrayList();
+        tasks2.add(new MaterializedViewMockRefreshTask(1000L, "mv2"));
+        tasks2.add(new MaterializedViewMockRefreshTask(1000L, "mv2"));
+
+        MaterializedViewRefreshJob job1 = MaterializedViewRefreshJobBuilder
+                .newBuilder(1, 2)
+                .mode(Constants.MaterializedViewRefreshMode.ASYNC)
+                .triggerType(Constants.MaterializedViewRefreshTriggerType.AUTO)
+                .setTasksAhead(tasks1)
+                .build();
+
+        MaterializedViewRefreshJob job2 = MaterializedViewRefreshJobBuilder
+                .newBuilder(1, 3)
+                .mode(Constants.MaterializedViewRefreshMode.ASYNC)
+                .triggerType(Constants.MaterializedViewRefreshTriggerType.MANUAL)
+                .setTasksAhead(tasks2)
+                .build();
+        new MockUp<MaterializedViewRefreshJob>(MaterializedViewRefreshJob.class) {
+            @Mock
+            public void generateTasks() {
+            }
+        };
+        MaterializedViewJobManager scheduler = new MaterializedViewJobManager();
+        scheduler.addPendingJob(job1);
+        scheduler.addPendingJob(job2);
+        ThreadUtil.sleepAtLeastIgnoreInterrupts(4000L);
+        List<MaterializedViewRefreshJob> jobList = scheduler.listJob();
+        for (MaterializedViewRefreshJob materializedViewRefreshJob : jobList) {
+            LOG.info(materializedViewRefreshJob);
+        }
+
+        Assert.assertEquals(Constants.MaterializedViewJobStatus.SUCCESS, job1.getStatus());
+        Assert.assertEquals(Constants.MaterializedViewJobStatus.SUCCESS, job2.getStatus());
+
+    }
+
+
+
+}

--- a/fe/fe-core/src/test/java/com/starrocks/mv/MaterializedViewMockRefreshTask.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mv/MaterializedViewMockRefreshTask.java
@@ -1,0 +1,64 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.mv;
+
+import com.starrocks.statistic.Constants;
+import org.apache.commons.lang3.ThreadUtils;
+import org.apache.hadoop.util.ThreadUtil;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.time.LocalDateTime;
+
+public class MaterializedViewMockRefreshTask extends MaterializedViewRefreshTask {
+
+    private static final Logger LOG = LogManager.getLogger(MaterializedViewMockRefreshTask.class);
+    Constants.MaterializedViewTaskStatus status = Constants.MaterializedViewTaskStatus.PENDING;
+    private long executeMillis;
+    private String mvTable;
+    private boolean mockFailed = false;
+
+    public MaterializedViewMockRefreshTask(Long executeMillis, String mvTable) {
+        this.executeMillis = executeMillis;
+        this.mvTable = mvTable;
+    }
+
+    @Override
+    public Constants.MaterializedViewTaskStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public void setStatus(Constants.MaterializedViewTaskStatus status) {
+        this.status = status;
+    }
+
+    public void setMockFailed(boolean mockFailed) {
+        this.mockFailed = mockFailed;
+    }
+
+    @Override
+    public void runTask() {
+        status = Constants.MaterializedViewTaskStatus.RUNNING;
+        ThreadUtil.sleepAtLeastIgnoreInterrupts(executeMillis);
+        if (mockFailed) {
+            throw new MaterializedViewTaskException("mock task execute failed.");
+        }
+        LOG.info("running a " + mvTable + " task:" + LocalDateTime.now());
+        status = Constants.MaterializedViewTaskStatus.SUCCESS;
+    }
+
+    @Override
+    public IMaterializedViewRefreshTask cloneTask() {
+        MaterializedViewMockRefreshTask task = new MaterializedViewMockRefreshTask(executeMillis, mvTable);
+        task.setMockFailed(mockFailed);
+        return task;
+    }
+
+    @Override
+    public String toString() {
+        return "MaterializedViewMockRefreshTask{" +
+                "status=" + status +
+                '}';
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/mv/MaterializedViewRefreshJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mv/MaterializedViewRefreshJobTest.java
@@ -1,0 +1,65 @@
+package com.starrocks.mv;
+
+import com.clearspring.analytics.util.Lists;
+import com.starrocks.statistic.Constants;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+public class MaterializedViewRefreshJobTest {
+
+    @Test
+    public void testUpdateStatusAfterDone() {
+        MaterializedViewRefreshJob job = new MaterializedViewRefreshJob();
+        job.setStatus(Constants.MaterializedViewJobStatus.RUNNING);
+        job.updateStatusAfterDone();
+        Assert.assertEquals(Constants.MaterializedViewJobStatus.FAILED, job.getStatus());
+
+        List<IMaterializedViewRefreshTask> tasks = Lists.newArrayList();
+        job.setStatus(Constants.MaterializedViewJobStatus.RUNNING);
+        job.setTasks(tasks);
+        job.updateStatusAfterDone();
+        Assert.assertEquals(Constants.MaterializedViewJobStatus.SUCCESS, job.getStatus());
+
+        job = new MaterializedViewRefreshJob();
+        job.setStatus(Constants.MaterializedViewJobStatus.RUNNING);
+        tasks = Lists.newArrayList();
+        IMaterializedViewRefreshTask task1 = new MaterializedViewMockRefreshTask(1L, "mv1");
+        task1.setStatus(Constants.MaterializedViewTaskStatus.FAILED);
+        tasks.add(task1);
+        IMaterializedViewRefreshTask task2 = new MaterializedViewMockRefreshTask(1L, "mv1");
+        task2.setStatus(Constants.MaterializedViewTaskStatus.FAILED);
+        tasks.add(task2);
+        job.setTasks(tasks);
+        job.updateStatusAfterDone();
+        Assert.assertEquals(Constants.MaterializedViewJobStatus.FAILED, job.getStatus());
+
+        job = new MaterializedViewRefreshJob();
+        job.setStatus(Constants.MaterializedViewJobStatus.RUNNING);
+        tasks = Lists.newArrayList();
+        task1 = new MaterializedViewMockRefreshTask(1L, "mv1");
+        task1.setStatus(Constants.MaterializedViewTaskStatus.SUCCESS);
+        tasks.add(task1);
+        task2 = new MaterializedViewMockRefreshTask(1L, "mv1");
+        task2.setStatus(Constants.MaterializedViewTaskStatus.FAILED);
+        tasks.add(task2);
+        job.setTasks(tasks);
+        job.updateStatusAfterDone();
+        Assert.assertEquals(Constants.MaterializedViewJobStatus.PARTIAL_SUCCESS, job.getStatus());
+
+        job = new MaterializedViewRefreshJob();
+        job.setStatus(Constants.MaterializedViewJobStatus.RUNNING);
+        tasks = Lists.newArrayList();
+        task1 = new MaterializedViewMockRefreshTask(1L, "mv1");
+        task1.setStatus(Constants.MaterializedViewTaskStatus.SUCCESS);
+        tasks.add(task1);
+        task2 = new MaterializedViewMockRefreshTask(1L, "mv1");
+        task2.setStatus(Constants.MaterializedViewTaskStatus.SUCCESS);
+        tasks.add(task2);
+        job.setTasks(tasks);
+        job.updateStatusAfterDone();
+        Assert.assertEquals(Constants.MaterializedViewJobStatus.SUCCESS, job.getStatus());
+    }
+
+}


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4796

## Background
The old materialization attempts to only support a single table and do it in a synchronous refresh manner by mapping the partitions of the single table into a one-to-one mapping of the Base table and the MV table.

When the old materialized view is building a table, the process of creating the materialized view is asynchronous, but the asynchronous scheduling framework relies on the MasterDaemon to be inefficient.

In order to cope with the requirements of asynchronous refresh and asynchronous triggering of multi-table materialized views. Therefore, it is necessary to build a new refresh the framework.

## Scenario
This framework currently only focuses on asynchronous refreshes.
1.For real-time scenarios, users generally build multiple tables, and then periodically execute an SQL to refresh the target table.
2.For offline scenarios, the user will periodically refresh all of them once a day.

## Design
We mainly divide refresh scenarios into two categories, one is periodic refresh, and the other is due to table creation, Base table change (data update) and user-triggered refresh.

All our refreshes are done with MaterializedViewJobManager.
For periodic refresh, it must be automatically triggered by the system at present. We provide the registerScheduledJob interface to register a periodic refresh task, and the deregisterScheduledJob interface to deregister a periodic task. For other types of triggered refreshes, we provide addPendingJob and cancelJob interfaces to support, and periodic tasks are essentially called addPendingJob to add tasks for management.

<img width="665" alt="image" src="https://user-images.githubusercontent.com/4392280/164009306-12e520ba-158c-4bf4-8f57-a2b92efcfa45.png">

Finally, it will be added to the pendingJob queue uniformly, and a dispatcher thread will perform a scheduling operation every 1s. This scheduling currently uses the minimum heap that comes with JDK, which can be replaced with a time wheel later, and can only be generated according to each MV. The logic of a running job is executed in the unrestricted refreshTaskPool, and a concurrency limit will be added to this operation later.

The same tasks that are automatically generated will also be merged here. For tasks manually generated by the user, we will not merge them.

It is also necessary to consider the logic of resuming the execution of some tasks after the FE restarts, and the logic of task cleaning. At present, this part of the logic has not been written, and will be added later. Comments are used in the code to mark where the log needs to be written.