### PR TITLE
Fix bug in getting function name

### DIFF
--- a/be/src/exprs/expr_context.cpp
+++ b/be/src/exprs/expr_context.cpp
@@ -195,7 +195,7 @@ StatusOr<ColumnPtr> ExprContext::evaluate(Expr* e, vectorized::Chunk* chunk) {
         }
         return ptr;
     } catch (std::runtime_error& e) {
-        return Status::RuntimeError(fmt::format("Expr evaluate meet error:{}", e.what()));
+        return Status::RuntimeError(fmt::format("Expr evaluate meet error: {}", e.what()));
     }
 }
 

--- a/be/src/exprs/vectorized/string_functions.cpp
+++ b/be/src/exprs/vectorized/string_functions.cpp
@@ -27,12 +27,12 @@ namespace starrocks::vectorized {
 #define THROW_RUNTIME_ERROR_IF_EXCEED_LIMIT(col, func)                         \
     if (col->reach_capacity_limit()) {                                         \
         col->reset_column();                                                   \
-        throw std::runtime_error("binary column exceed 4G in function" #func); \
+        throw std::runtime_error("binary column exceed 4G in function " #func); \
     }
 
 #define RETURN_COLUMN(col, func_name)               \
     auto VARNAME_LINENUM(res) = col;                \
-    THROW_RUNTIME_ERROR_IF_EXCEED_LIMIT(col, func); \
+    THROW_RUNTIME_ERROR_IF_EXCEED_LIMIT(col, func_name); \
     return VARNAME_LINENUM(res);
 
 constexpr size_t CONCAT_SMALL_OPTIMIZE_THRESHOLD = 16 << 20;

--- a/be/src/exprs/vectorized/string_functions.cpp
+++ b/be/src/exprs/vectorized/string_functions.cpp
@@ -24,14 +24,14 @@
 
 namespace starrocks::vectorized {
 
-#define THROW_RUNTIME_ERROR_IF_EXCEED_LIMIT(col, func)                         \
-    if (col->reach_capacity_limit()) {                                         \
-        col->reset_column();                                                   \
+#define THROW_RUNTIME_ERROR_IF_EXCEED_LIMIT(col, func)                          \
+    if (col->reach_capacity_limit()) {                                          \
+        col->reset_column();                                                    \
         throw std::runtime_error("binary column exceed 4G in function " #func); \
     }
 
-#define RETURN_COLUMN(col, func_name)               \
-    auto VARNAME_LINENUM(res) = col;                \
+#define RETURN_COLUMN(col, func_name)                    \
+    auto VARNAME_LINENUM(res) = col;                     \
     THROW_RUNTIME_ERROR_IF_EXCEED_LIMIT(col, func_name); \
     return VARNAME_LINENUM(res);
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
before
`ERROR 1064 (HY000): Expr evaluate meet error:binary column exceed 4G in functionfunc`
after
`ERROR 1064 (HY000): Expr evaluate meet error: binary column exceed 4G in function "repeat"`