### PR TITLE
Support disable ONLY_FULL_GROUP_BY sql mode like Mysql

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -235,9 +235,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = PROFILING)
     private boolean openProfile = false;
 
-    // Set sqlMode to empty string
+    // Default sqlMode is ONLY_FULL_GROUP_BY
     @VariableMgr.VarAttr(name = SQL_MODE)
-    private long sqlMode = 0L;
+    private long sqlMode = 32L;
 
     @VariableMgr.VarAttr(name = RESOURCE_VARIABLE)
     private String resourceGroup = "normal";

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Analyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Analyzer.java
@@ -127,11 +127,11 @@ public class Analyzer {
         }
 
         @Override
-        public Void visitQueryStatement(QueryStatement stmt, ConnectContext session) {
-            new QueryAnalyzer(session).analyze(stmt);
+        public Void visitQueryStatement(QueryStatement stmt, ConnectContext context) {
+            new QueryAnalyzer(context).analyze(stmt);
 
             QueryRelation queryRelation = stmt.getQueryRelation();
-            long selectLimit = ConnectContext.get().getSessionVariable().getSqlSelectLimit();
+            long selectLimit = context.getSessionVariable().getSqlSelectLimit();
             if (!queryRelation.hasLimit() && selectLimit != SessionVariable.DEFAULT_SELECT_LIMIT) {
                 queryRelation.setLimit(new LimitElement(selectLimit));
             }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -886,4 +886,14 @@ public class AggregateTest extends PlanTestBase {
                 "  0:OlapScanNode\n" +
                 "     TABLE: t0"));
     }
+
+    @Test
+    public void testOnlyFullGroupBy() throws Exception {
+        long sqlmode = connectContext.getSessionVariable().getSqlMode();
+        connectContext.getSessionVariable().setSqlMode(0);
+        String sql = "select v1, v2 from t0 group by v1";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "output: any_value(2: v2)");
+        connectContext.getSessionVariable().setSqlMode(sqlmode);
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] others


For https://github.com/StarRocks/starrocks/issues/5578

For sql: select c1, c2 from table group by c1;
when sql_mode isn't ONLY_FULL_GROUP_BY,
we rewrite the sql to select c1, any_value(c2) from table group by c1;
