### PR TITLE
Fix timestamp with time zone cant not read when using orc for iceberg

### DIFF
--- a/be/src/formats/orc/orc_chunk_reader.cpp
+++ b/be/src/formats/orc/orc_chunk_reader.cpp
@@ -28,13 +28,20 @@ const FillColumnFunction& find_fill_func(PrimitiveType type, bool nullable);
 
 // NOLINTNEXTLINE
 const static std::unordered_map<orc::TypeKind, PrimitiveType> g_orc_starrocks_type_mapping = {
-        {orc::BOOLEAN, TYPE_BOOLEAN}, {orc::BYTE, TYPE_TINYINT},
-        {orc::SHORT, TYPE_SMALLINT},  {orc::INT, TYPE_INT},
-        {orc::LONG, TYPE_BIGINT},     {orc::FLOAT, TYPE_FLOAT},
-        {orc::DOUBLE, TYPE_DOUBLE},   {orc::DECIMAL, TYPE_DECIMALV2},
-        {orc::DATE, TYPE_DATE},       {orc::TIMESTAMP, TYPE_DATETIME},
-        {orc::STRING, TYPE_VARCHAR},  {orc::BINARY, TYPE_VARCHAR},
-        {orc::CHAR, TYPE_CHAR},       {orc::VARCHAR, TYPE_VARCHAR},
+        {orc::BOOLEAN, TYPE_BOOLEAN},
+        {orc::BYTE, TYPE_TINYINT},
+        {orc::SHORT, TYPE_SMALLINT},
+        {orc::INT, TYPE_INT},
+        {orc::LONG, TYPE_BIGINT},
+        {orc::FLOAT, TYPE_FLOAT},
+        {orc::DOUBLE, TYPE_DOUBLE},
+        {orc::DECIMAL, TYPE_DECIMALV2},
+        {orc::DATE, TYPE_DATE},
+        {orc::TIMESTAMP, TYPE_DATETIME},
+        {orc::STRING, TYPE_VARCHAR},
+        {orc::BINARY, TYPE_VARCHAR},
+        {orc::CHAR, TYPE_CHAR},
+        {orc::VARCHAR, TYPE_VARCHAR},
         {orc::TIMESTAMP_INSTANT, TYPE_DATETIME},
 };
 

--- a/be/src/formats/orc/orc_chunk_reader.cpp
+++ b/be/src/formats/orc/orc_chunk_reader.cpp
@@ -35,6 +35,7 @@ const static std::unordered_map<orc::TypeKind, PrimitiveType> g_orc_starrocks_ty
         {orc::DATE, TYPE_DATE},       {orc::TIMESTAMP, TYPE_DATETIME},
         {orc::STRING, TYPE_VARCHAR},  {orc::BINARY, TYPE_VARCHAR},
         {orc::CHAR, TYPE_CHAR},       {orc::VARCHAR, TYPE_VARCHAR},
+        {orc::TIMESTAMP_INSTANT, TYPE_DATETIME},
 };
 
 // NOLINTNEXTLINE

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -229,8 +229,7 @@ public class IcebergTable extends Table {
             case DATE:
                 return primitiveType == PrimitiveType.DATE;
             case TIMESTAMP:
-                return !((Types.TimestampType) icebergType).shouldAdjustToUTC() &&
-                        primitiveType == PrimitiveType.DATETIME;
+                return primitiveType == PrimitiveType.DATETIME;
             case STRING:
             case UUID:
                 return primitiveType == PrimitiveType.VARCHAR ||

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -229,7 +229,7 @@ public class IcebergTable extends Table {
             case DATE:
                 return primitiveType == PrimitiveType.DATE;
             case TIMESTAMP:
-                return !((Types.TimestampType)icebergType).shouldAdjustToUTC() &&
+                return !((Types.TimestampType) icebergType).shouldAdjustToUTC() &&
                         primitiveType == PrimitiveType.DATETIME;
             case STRING:
             case UUID:

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -229,7 +229,8 @@ public class IcebergTable extends Table {
             case DATE:
                 return primitiveType == PrimitiveType.DATE;
             case TIMESTAMP:
-                return primitiveType == PrimitiveType.DATETIME;
+                return !((Types.TimestampType)icebergType).shouldAdjustToUTC() &&
+                        primitiveType == PrimitiveType.DATETIME;
             case STRING:
             case UUID:
                 return primitiveType == PrimitiveType.VARCHAR ||


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5476 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
```
MySQL [iceberg]>  select * from ex_iceberg_tbl0 order by col_int;
+-------------+---------+----------+-----------+------------+--------------------------------+------------+---------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| col_boolean | col_int | col_long | col_float | col_double | col_decimal                    | col_date   | col_timestamp       | col_string                                                                                                                                                                                                                                                                           |
+-------------+---------+----------+-----------+------------+--------------------------------+------------+---------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|           1 |       1 |        1 |     1.001 |     1.0001 | 10000000000.000000000100000000 | 2020-01-01 | 2020-01-01 00:00:01 | Top 10 Unsolved Mysteries of Paleontological Dinosaurs, Did You Know?                                                                                                                                                                                                                |
|           0 |       2 |        2 |     2.002 |     2.0002 | 20000000000.000000000200000000 | 2020-02-01 | 2020-02-01 00:00:02 | Xi Jinping, general secretary of the Communist Party of China Central Committee, called on Tuesday for unrelenting efforts in exercising full and rigorous governance over the Party, saying that the CPC will continue to show zero tolerance for corruption.                       |
|           1 |       3 |        3 |     3.003 |     3.0003 | 30000000000.000000000300000000 | 2020-03-01 | 2020-03-01 00:00:04 | Nation raises caution on overseas packages                                                                                                                                                                                                                                           |
|           0 |       4 |        4 |     4.004 |     4.0004 | 40000000000.000000000400000000 | 2020-04-01 | 2020-04-01 00:00:04 | Shanghai, Shenzhen register most newly listed firms in 2021                                                                                                                                                                                                                          |
|           1 |       5 |        5 |     5.005 |     5.0005 | 50000000000.000000000500000000 | 2020-05-01 | 2020-05-01 00:00:05 | A total of 4,685 companies have been listed on the A-share market in China as of Dec 31, 2021, with 46 percent of them based in Beijing, Shanghai, Shenzhen, Hangzhou, Suzhou, Guangzhou, Ningbo, Nanjing, Wuxi, and Chengdu, said a report of National Business Daily on Wednesday. |
|           1 |       5 |        5 |     5.005 |     5.0005 | 50000000000.000000000500000000 | 2020-05-01 | 2020-05-01 04:00:05 | A total of 4,685 companies have been listed on the A-share market in China as of Dec 31, 2021, with 46 percent of them based in Beijing, Shanghai, Shenzhen, Hangzhou, Suzhou, Guangzhou, Ningbo, Nanjing, Wuxi, and Chengdu, said a report of National Business Daily on Wednesday. |
|           1 |       5 |        5 |     5.005 |     5.0005 | 50000000000.000000000500000000 | 2020-05-01 | 2020-05-01 00:00:05 | A total of 4,685 companies have been listed on the A-share market in China as of Dec 31, 2021, with 46 percent of them based in Beijing, Shanghai, Shenzhen, Hangzhou, Suzhou, Guangzhou, Ningbo, Nanjing, Wuxi, and Chengdu, said a report of National Business Daily on Wednesday. |
+-------------+---------+----------+-----------+------------+--------------------------------+------------+---------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
7 rows in set (0.17 sec)
```

```
insert into iceberg_par_orc_snappy select true,5,5.05,5.005,5.0005,50000000000.0000000005,cast('2020-05-01' as date),cast('2020-05-01 00:00:05+08' as timestamp),'A total of 4,685 companies have been listed on the A-share market in China as of Dec 31, 2021, with 46 percent of them based in Beijing, Shanghai, Shenzhen, Hangzhou, Suzhou, Guangzhou, Ningbo, Nanjing, Wuxi, and Chengdu, said a report of National Business Daily on Wednesday.',cast('1110001010101011001001' as binary),null,null;

insert into iceberg_par_orc_snappy select true,5,5.05,5.005,5.0005,50000000000.0000000005,cast('2020-05-01' as date),cast('2020-05-01 00:00:05+04' as timestamp),'A total of 4,685 companies have been listed on the A-share market in China as of Dec 31, 2021, with 46 percent of them based in Beijing, Shanghai, Shenzhen, Hangzhou, Suzhou, Guangzhou, Ningbo, Nanjing, Wuxi, and Chengdu, said a report of National Business Daily on Wednesday.',cast('1110001010101011001001' as binary),null,null;
```