### PR TITLE
[Enhancement] Upgrade jackson-databind due to CVE-2020-36518

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -43,7 +43,7 @@ under the License.
         <maven.compiler.target>1.8</maven.compiler.target>
         <jprotobuf.version>2.4.12</jprotobuf.version>
         <log4j.version>2.17.1</log4j.version>
-        <jackson.version>2.12.1</jackson.version>
+        <jackson.version>2.12.6</jackson.version>
         <spark.version>2.4.6</spark.version>
         <tomcat.version>8.5.70</tomcat.version>
         <parquet.version>1.10.1</parquet.version>
@@ -230,7 +230,7 @@ under the License.
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${jackson.version}</version>
+                <version>${jackson.version}.1</version>
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml -->

--- a/fs_brokers/apache_hdfs_broker/pom.xml
+++ b/fs_brokers/apache_hdfs_broker/pom.xml
@@ -43,7 +43,7 @@ under the License.
         <thrift.version>0.14.1</thrift.version>
         <tomcat.version>8.5.70</tomcat.version>
         <log4j.version>2.17.1</log4j.version>
-        <jackson.version>2.9.10.8</jackson.version>
+        <jackson.version>2.12.6</jackson.version>
     </properties>
 
     <profiles>
@@ -240,7 +240,7 @@ under the License.
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson.version}.1</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.apache.htrace/htrace-core -->


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5594

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
 mainly upgrade jackson-databind from 2.12.1 to 2.12.6.1