### PR TITLE
[BugFix] Compatible with unknown column type

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
@@ -81,6 +81,10 @@ public class ScalarType extends Type implements Cloneable {
         this.type = type;
     }
 
+    public ScalarType() {
+        this.type = PrimitiveType.INVALID_TYPE;
+    }
+
     public static ScalarType createType(PrimitiveType type, int len, int precision, int scale) {
         switch (type) {
             case CHAR:

--- a/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
@@ -63,6 +63,7 @@ import com.starrocks.catalog.JDBCResource;
 import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.MapType;
 import com.starrocks.catalog.OdbcCatalogResource;
+import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.PseudoType;
 import com.starrocks.catalog.RandomDistributionInfo;
 import com.starrocks.catalog.Resource;
@@ -162,6 +163,8 @@ public class GsonUtils {
 
     private static final JsonDeserializer<QueryDumpInfo> dumpInfoDeserializer = new QueryDumpDeserializer();
 
+    private static final JsonDeserializer<PrimitiveType> primitiveTypeDeserializer = new PrimitiveTypeSerializer();
+
     // the builder of GSON instance.
     // Add any other adapters if necessary.
     private static final GsonBuilder GSON_BUILDER = new GsonBuilder()
@@ -179,7 +182,8 @@ public class GsonUtils {
             .registerTypeAdapter(LocalDateTime.class, localDateTimeTypeSerializer)
             .registerTypeAdapter(LocalDateTime.class, localDateTimeTypeDeserializer)
             .registerTypeAdapter(QueryDumpInfo.class, dumpInfoSerializer)
-            .registerTypeAdapter(QueryDumpInfo.class, dumpInfoDeserializer);
+            .registerTypeAdapter(QueryDumpInfo.class, dumpInfoDeserializer)
+            .registerTypeAdapter(PrimitiveType.class, primitiveTypeDeserializer);
 
     // this instance is thread-safe.
     public static final Gson GSON = GSON_BUILDER.create();
@@ -406,4 +410,15 @@ public class GsonUtils {
         }
     }
 
+    private static class PrimitiveTypeSerializer implements JsonDeserializer<PrimitiveType> {
+        @Override
+        public PrimitiveType deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+                throws JsonParseException {
+            try {
+                return PrimitiveType.valueOf(json.getAsJsonPrimitive().getAsString());
+            } catch (Throwable t) {
+                return PrimitiveType.INVALID_TYPE;
+            }
+        }
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ScalarTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ScalarTypeTest.java
@@ -154,8 +154,14 @@ public class ScalarTypeTest {
 
     @Test
     public void testInvalidType() {
+        // deserialize a not exist type
         String jsonStr = "{\"clazz\":\"ScalarType\",\"type\":\"NOT_EXIST\",\"len\":65530,\"precision\":0,\"scale\":0}";
         ScalarType type = GsonUtils.GSON.fromJson(jsonStr, ScalarType.class);
+        Assert.assertEquals(PrimitiveType.INVALID_TYPE, type.getPrimitiveType());
+
+        // deserialize a null type
+        jsonStr = "{\"clazz\":\"ScalarType\",\"type\":\"NOT_EXIST\",\"len\":65530,\"precision\":0,\"scale\":0}";
+        type = GsonUtils.GSON.fromJson(jsonStr, ScalarType.class);
         Assert.assertEquals(PrimitiveType.INVALID_TYPE, type.getPrimitiveType());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ScalarTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ScalarTypeTest.java
@@ -2,6 +2,7 @@ package com.starrocks.catalog;
 
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
+import com.starrocks.persist.gson.GsonUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -149,5 +150,12 @@ public class ScalarTypeTest {
             actualResult = ScalarType.getCommonTypeForDecimalV3(rhs, lhs);
             Assert.assertEquals(expectResult, actualResult);
         }
+    }
+
+    @Test
+    public void testInvalidType() {
+        String jsonStr = "{\"clazz\":\"ScalarType\",\"type\":\"NOT_EXIST\",\"len\":65530,\"precision\":0,\"scale\":0}";
+        ScalarType type = GsonUtils.GSON.fromJson(jsonStr, ScalarType.class);
+        Assert.assertEquals(PrimitiveType.INVALID_TYPE, type.getPrimitiveType());
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5549
Fixes #5550

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
If users rolls back to a version that does not support for json types, the property type in ScalarType will be null, and it will cause some critical error.
We should rewrite the PrimitiveType deserializer process to compatible with unknown column type.
And more, the type should be inited to PrimitiveType.INVALID_TYPE, because when doing checkpoint, the type attribute may disappear in the image, and the field will not be processed when deserializing ScalarType.