### PR TITLE
[BugFix] Get pid file lock failed when restart fe

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
+++ b/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
@@ -283,9 +283,7 @@ public class StarRocksFE {
             try (RandomAccessFile file = new RandomAccessFile(pid, "rws")) {
                 FileLock lock = file.getChannel().tryLock();
                 if (lock == null) {
-                    LOG.warn("get pid file lock failed, retried: {}", i);
-                    Thread.sleep(10000L);
-                    continue;
+                    throw new Exception("get pid file lock failed, lock is null");
                 }
 
                 pid.deleteOnExit();
@@ -300,6 +298,7 @@ public class StarRocksFE {
                     LOG.warn("get pid file lock failed, retried: {}", i, t);
                     Thread.sleep(10000L);
                 } catch (InterruptedException ie) {
+                    LOG.warn("thread sleep interrupted", ie);
                 }
             }
         }
@@ -307,4 +306,3 @@ public class StarRocksFE {
         return false;
     }
 }
-

--- a/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
+++ b/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
@@ -283,7 +283,7 @@ public class StarRocksFE {
             try (RandomAccessFile file = new RandomAccessFile(pid, "rws")) {
                 FileLock lock = file.getChannel().tryLock();
                 if (lock == null) {
-                    LOG.warn("get pid file lock failed, time retried: {}", i);
+                    LOG.warn("get pid file lock failed, retried: {}", i);
                     Thread.sleep(10000L);
                     continue;
                 }
@@ -297,8 +297,7 @@ public class StarRocksFE {
                 return true;
             } catch (Throwable t) {
                 try {
-                    LOG.warn("get pid file lock failed, time retried: {}", i, t);
-                    Thread.sleep(10000L);
+                    LOG.warn("get pid file lock failed, retried: {}", i, t);
                     Thread.sleep(10000L);
                 } catch (InterruptedException ie) {
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
+++ b/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
@@ -50,7 +50,6 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.lang.management.ManagementFactory;
 import java.nio.channels.FileLock;
-import java.nio.channels.OverlappingFileLockException;
 
 public class StarRocksFE {
     private static final Logger LOG = LogManager.getLogger(StarRocksFE.class);

--- a/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
+++ b/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
@@ -281,6 +281,9 @@ public class StarRocksFE {
         File pid = new File(pidFilePath);
         for (int i = 0; i < 3; i++) {
             try (RandomAccessFile file = new RandomAccessFile(pid, "rws")) {
+                if (i > 0) {
+                    Thread.sleep(10000);
+                }
                 FileLock lock = file.getChannel().tryLock();
                 if (lock == null) {
                     throw new Exception("get pid file lock failed, lock is null");
@@ -294,12 +297,7 @@ public class StarRocksFE {
 
                 return true;
             } catch (Throwable t) {
-                try {
-                    LOG.warn("get pid file lock failed, retried: {}", i, t);
-                    Thread.sleep(10000L);
-                } catch (InterruptedException ie) {
-                    LOG.warn("thread sleep interrupted", ie);
-                }
+                LOG.warn("get pid file lock failed, retried: {}", i, t);
             }
         }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Try to fix #5580

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Retry 3 times if get file lock failed, and print the fail reson.
