### PR TITLE
[Enhancement] Optimize publish hotspot path

### DIFF
--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -375,6 +375,8 @@ struct Version {
     bool operator==(const Version& rhs) const { return first == rhs.first && second == rhs.second; }
 
     bool contains(const Version& other) const { return first <= other.first && second >= other.second; }
+
+    bool operator<(const Version& rhs) const { return second < rhs.second; }
 };
 
 typedef std::vector<Version> Versions;

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -340,11 +340,9 @@ Status Tablet::add_inc_rowset(const RowsetSharedPtr& rowset) {
     CHECK(!_updates) << "updatable tablet should not call add_inc_rowset";
     DCHECK(rowset != nullptr);
     std::unique_lock wrlock(_meta_lock);
-    if (_contains_rowset(rowset->rowset_id())) {
-        return Status::OK();
-    }
     RETURN_IF_ERROR(_contains_version(rowset->version()));
     RETURN_IF_ERROR(_tablet_meta->add_rs_meta(rowset->rowset_meta()));
+    RETURN_IF_ERROR(_tablet_meta->add_inc_rs_meta(rowset->rowset_meta()));
     _rs_version_map[rowset->version()] = rowset;
     _inc_rs_version_map[rowset->version()] = rowset;
 
@@ -353,8 +351,6 @@ Status Tablet::add_inc_rowset(const RowsetSharedPtr& rowset) {
         StorageEngine::instance()->compaction_manager()->update_tablet_async(
                 std::static_pointer_cast<Tablet>(shared_from_this()), true, false);
     }
-
-    RETURN_IF_ERROR(_tablet_meta->add_inc_rs_meta(rowset->rowset_meta()));
 
     // warm-up this rowset
     auto st = rowset->load();
@@ -855,15 +851,9 @@ void Tablet::_print_missed_versions(const std::vector<Version>& missed_versions)
 
 Status Tablet::_contains_version(const Version& version) {
     // check if there exist a rowset contains the added rowset
-    for (auto& it : _rs_version_map) {
-        if (it.first.contains(version)) {
-            // TODO(lingbin): Is this check unnecessary?
-            // because the value type is std::shared_ptr, when will it be nullptr?
-            // In addition, in this class, there are many places that do not make this judgment
-            // when access _rs_version_map's value.
-            CHECK(it.second != nullptr) << "there exist a version=" << it.first
-                                        << " contains the input rs with version=" << version
-                                        << ", but the related rs is null";
+    const auto& lower = _rs_version_map.lower_bound(version);
+    for (auto it = lower; it != _rs_version_map.end(); it++) {
+        if (it->first.contains(version)) {
             return Status::AlreadyExist("push version already exist");
         }
     }

--- a/be/src/storage/tablet.h
+++ b/be/src/storage/tablet.h
@@ -329,7 +329,7 @@ private:
     // inc_rowset_expired_sec conf. In addition, the deletion is triggered periodically,
     // So at a certain time point (such as just after a base compaction), some rowsets in
     // _inc_rs_version_map may do not exist in _rs_version_map.
-    std::unordered_map<Version, RowsetSharedPtr, HashOfVersion> _rs_version_map;
+    std::map<Version, RowsetSharedPtr> _rs_version_map;
     std::unordered_map<Version, RowsetSharedPtr, HashOfVersion> _inc_rs_version_map;
     // This variable _stale_rs_version_map is used to record these rowsets which are be compacted.
     // These _stale rowsets are been removed when rowsets' pathVersion is expired,

--- a/be/src/storage/tablet_meta.cpp
+++ b/be/src/storage/tablet_meta.cpp
@@ -581,20 +581,7 @@ Version TabletMeta::max_version() const {
 }
 
 Status TabletMeta::add_rs_meta(const RowsetMetaSharedPtr& rs_meta) {
-    // check RowsetMeta is valid
-    for (auto& rs : _rs_metas) {
-        if (rs->version() == rs_meta->version()) {
-            if (rs->rowset_id() != rs_meta->rowset_id()) {
-                LOG(WARNING) << "version already exist. rowset_id=" << rs->rowset_id() << " version=" << rs->version()
-                             << ", tablet=" << full_name();
-                return Status::AlreadyExist("publish version");
-            } else {
-                // rowsetid,version is equal, it is a duplicate req, skip it
-                return Status::OK();
-            }
-        }
-    }
-
+    // consistency is guarantee by tablet
     _rs_metas.push_back(rs_meta);
     if (rs_meta->has_delete_predicate()) {
         add_delete_predicate(rs_meta->delete_predicate(), rs_meta->version().first);
@@ -658,14 +645,7 @@ void TabletMeta::revise_inc_rs_metas(std::vector<RowsetMetaSharedPtr> rs_metas) 
 }
 
 Status TabletMeta::add_inc_rs_meta(const RowsetMetaSharedPtr& rs_meta) {
-    // check RowsetMeta is valid
-    for (const auto& rs : _inc_rs_metas) {
-        if (rs->version() == rs_meta->version()) {
-            LOG(WARNING) << "rowset already exist. rowset_id=" << rs->rowset_id();
-            return Status::AlreadyExist("rowset meta already exist");
-        }
-    }
-
+    // consistency is guarantee by tablet
     _inc_rs_metas.push_back(rs_meta);
     return Status::OK();
 }

--- a/be/src/storage/task/engine_publish_version_task.cpp
+++ b/be/src/storage/task/engine_publish_version_task.cpp
@@ -77,8 +77,8 @@ Status EnginePublishVersionTask::finish() {
             return st;
         }
     }
-    VLOG(1) << "Publish version successfully on tablet. tablet=" << tablet->full_name()
-            << ", transaction_id=" << _transaction_id << ", version=" << _version << ", res=" << st.to_string();
+    LOG(INFO) << "Publish version successfully on tablet. tablet=" << tablet->full_name()
+              << ", transaction_id=" << _transaction_id << ", version=" << _version << ", res=" << st.to_string();
     return Status::OK();
 }
 

--- a/be/src/storage/txn_manager.cpp
+++ b/be/src/storage/txn_manager.cpp
@@ -252,10 +252,10 @@ Status TxnManager::publish_txn(KVStore* meta, TPartitionId partition_id, TTransa
         auto it = txn_tablet_map.find(key);
         if (it != txn_tablet_map.end()) {
             it->second.erase(tablet_info);
-            LOG(INFO) << "publish txn successfully."
-                      << " partition_id: " << key.first << ", txn_id: " << key.second
-                      << ", tablet: " << tablet_info.to_string() << ", rowsetid: " << rowset_ptr->rowset_id()
-                      << ", version: " << version.first << "," << version.second;
+            VLOG(1) << "publish txn successfully."
+                    << " partition_id: " << key.first << ", txn_id: " << key.second
+                    << ", tablet: " << tablet_info.to_string() << ", rowsetid: " << rowset_ptr->rowset_id()
+                    << ", version: " << version.first << "," << version.second;
             if (it->second.empty()) {
                 txn_tablet_map.erase(it);
                 _clear_txn_partition_map_unlocked(transaction_id, partition_id);

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -553,6 +553,7 @@ public class TransactionState implements Writable {
         sb.append(", prepare time: ").append(prepareTime);
         sb.append(", commit time: ").append(commitTime);
         sb.append(", finish time: ").append(finishTime);
+        sb.append(", publish cost: ").append(finishTime - commitTime).append("ms");
         sb.append(", reason: ").append(reason);
         if (txnCommitAttachment != null) {
             sb.append(" attachment: ").append(txnCommitAttachment);


### PR DESCRIPTION
1. use std::map replace std::unordered_map reduce overhead of check version exists
2. remove the publish sleep retry, it will causes the queue to accumulate

## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

branch | parallel | time(s) | LoadTimeMs(avg) | WriteDataTimeMs(avg) | CommitAndPublishTimeMs(avg) | CommitAndPublishTimeMs(99.9pct) | bucket | data size | file num
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
main | 16 | 409 | 644 | 53 | 589 | 1179 | 192 | 3740MB | 10000
main | 32 | 344 | 1094 | 99 | 992 | 5824 | 192 | 3740MB | 10000
optimize | 16 | 53 | 160 | 36 | 121 | 213 | 192 | 3740MB | 10000
optimize | 32 | 56 | 171 | 38 | 130 | 228 | 192 | 3740MB | 10000

> optimize branch base on PR #5632 #5552 

### main:
![image](https://user-images.githubusercontent.com/1292236/165750215-16ab1e1f-f733-4251-85d6-4661d778c439.png)
### optimize:
<img width="739" alt="截屏2022-04-28 18 52 57" src="https://user-images.githubusercontent.com/1292236/165750333-ee53fe33-02c3-41ef-a0fe-7d3bcf0e716b.png">
