### PR TITLE
[Enhancement] simple password validation & password reuse check

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/AlterUserStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/AlterUserStmt.java
@@ -68,7 +68,7 @@ public class AlterUserStmt extends DdlStmt {
         if (!Strings.isNullOrEmpty(password)) {
             if (isPasswordPlain) {
                 // plain password should check for validation & reuse
-                Auth.validPassword(password);
+                Auth.validatePassword(password);
                 GlobalStateMgr.getCurrentState().getAuth().checkPasswordReuse(userIdent, password);
                 // convert plain password to scramble
                 scramblePassword = MysqlPassword.makeScrambledPassword(password);

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/AlterUserStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/AlterUserStmt.java
@@ -13,11 +13,8 @@ import com.starrocks.mysql.privilege.AuthPlugin;
 import com.starrocks.mysql.privilege.PrivPredicate;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 public class AlterUserStmt extends DdlStmt {
-    private static final Logger LOG = LogManager.getLogger(AlterUserStmt.class);
 
     private UserIdentity userIdent;
     private String password;
@@ -70,6 +67,9 @@ public class AlterUserStmt extends DdlStmt {
         // convert password to hashed password
         if (!Strings.isNullOrEmpty(password)) {
             if (isPasswordPlain) {
+                // plain password should check for validation & reuse
+                Auth.validPassword(password);
+                GlobalStateMgr.getCurrentState().getAuth().checkPasswordReuse(userIdent, password);
                 // convert plain password to scramble
                 scramblePassword = MysqlPassword.makeScrambledPassword(password);
             } else {

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/CreateUserStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/CreateUserStmt.java
@@ -29,6 +29,7 @@ import com.starrocks.common.ErrorReport;
 import com.starrocks.common.FeNameFormat;
 import com.starrocks.common.UserException;
 import com.starrocks.mysql.MysqlPassword;
+import com.starrocks.mysql.privilege.Auth;
 import com.starrocks.mysql.privilege.Auth.PrivLevel;
 import com.starrocks.mysql.privilege.AuthPlugin;
 import com.starrocks.mysql.privilege.PrivPredicate;
@@ -134,6 +135,8 @@ public class CreateUserStmt extends DdlStmt {
         // convert password to hashed password
         if (!Strings.isNullOrEmpty(password)) {
             if (isPasswordPlain) {
+                // plain password validation
+                Auth.validPassword(password);
                 // convert plain password to scramble
                 scramblePassword = MysqlPassword.makeScrambledPassword(password);
             } else {

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/CreateUserStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/CreateUserStmt.java
@@ -136,7 +136,7 @@ public class CreateUserStmt extends DdlStmt {
         if (!Strings.isNullOrEmpty(password)) {
             if (isPasswordPlain) {
                 // plain password validation
-                Auth.validPassword(password);
+                Auth.validatePassword(password);
                 // convert plain password to scramble
                 scramblePassword = MysqlPassword.makeScrambledPassword(password);
             } else {

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1411,4 +1411,18 @@ public class Config extends ConfigBase {
 
     @ConfField(mutable = true)
     public static boolean enable_dict_optimize_stream_load = true;
+
+    /**
+     * If set to true, the following rules will apply to see if the password is secure upon the creation of a user.
+     * 1. The length of the password should be no less than 8.
+     * 2. The password should contain at least one digit, one lowercase letter, one uppercase letter
+     */
+    @ConfField(mutable = true)
+    public static boolean enable_validate_password = false;
+
+    /**
+     * If set to false, changing the password to the previous one is not allowed.
+     */
+    @ConfField(mutable = true)
+    public static boolean enable_password_reuse = true;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Auth.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Auth.java
@@ -1042,7 +1042,7 @@ public class Auth implements Writable {
      *      We will refactor the whole user privilege framework later to ultimately fix this.
      *
      **/
-    public static void validPassword(String password) throws DdlException {
+    public static void validatePassword(String password) throws DdlException {
         if (!Config.enable_validate_password) {
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Auth.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Auth.java
@@ -1034,6 +1034,57 @@ public class Auth implements Writable {
         }
     }
 
+    /**
+     * check password complexity if `enable_validate_password` is set
+     * only check for plain text
+     *
+     * TODO The rules is hard-coded for temporary
+     *      We will refactor the whole user privilege framework later to ultimately fix this.
+     *
+     **/
+    public static void validPassword(String password) throws DdlException {
+        if (!Config.enable_validate_password) {
+            return;
+        }
+
+        //  1. The length of the password should be no less than 8.
+        if (password.length() < 8) {
+            throw new DdlException("password is too short!");
+        }
+
+        // 2. The password should contain at least one digit, one lowercase letter, one uppercase letter
+        boolean hasDigit = false;
+        boolean hasUpper = false;
+        boolean hasLower = false;
+        for (int i = 0; i != password.length(); ++ i) {
+            char c = password.charAt(i);
+            if (c >= '0' && c <= '9') {
+                hasDigit = true;
+            } else if (c >= 'A' && c <= 'Z') {
+                hasUpper = true;
+            } else if (c >= 'a' && c <= 'z') {
+                hasLower = true;
+            }
+        }
+        if (!hasDigit || !hasLower || !hasUpper) {
+            throw new DdlException("password should contains at least one digit, one lowercase letter and one uppercase letter!");
+        }
+    }
+
+    /**
+     * prevent password reuse if `enable_password_reuse` is set;
+     * only check for plain text
+     */
+    public void checkPasswordReuse(UserIdentity user, String plainPassword) throws DdlException {
+        if (Config.enable_password_reuse) {
+            return;
+        }
+        List<UserIdentity> userList = Lists.newArrayList();
+        if (checkPlainPassword(user.getQualifiedUser(), user.getHost(), plainPassword, userList)) {
+            throw new DdlException("password should not be the same as the previous one!");
+        }
+    }
+
     // set password
     public void setPassword(SetPassVar stmt) throws DdlException {
         Password passwordToSet = new Password(stmt.getPassword());

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/privilege/AuthTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/privilege/AuthTest.java
@@ -1818,11 +1818,11 @@ public class AuthTest {
 
         Config.enable_validate_password = false;
         // enable_auth_check is false, allow bad password
-        auth.validPassword(badPassword);
+        auth.validatePassword(badPassword);
 
        // enable_password_reuse is true for a good password
         Config.enable_validate_password = true;
-        auth.validPassword(goodPassword);
+        auth.validatePassword(goodPassword);
     }
 
     @Test(expected = DdlException.class)
@@ -1830,7 +1830,7 @@ public class AuthTest {
         // length 5 < 8
         String badPassword = "Aa123";
         Config.enable_validate_password = true;
-        auth.validPassword(badPassword);
+        auth.validatePassword(badPassword);
     }
 
     @Test(expected = DdlException.class)
@@ -1838,7 +1838,7 @@ public class AuthTest {
         // no lowercase letter or uppercase letter
         String badPassword = "123456789";
         Config.enable_validate_password = true;
-        auth.validPassword(badPassword);
+        auth.validatePassword(badPassword);
     }
 
     @Test(expected = DdlException.class)


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes some of #5633

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered, and what measures have you taken to fix the bug?) -->
This PR is a temporary implementation of password validation & password reuse check. The rules are mainly hardcoded and cannot be fully configurable except for a switch to enable it. We will refactor the whole user privilege framework later to fix this ultimately.

1. Set `enable_validate_password` to true to validate the password by these rules:
a. The length of the password should be no less than 8.
b. The password should contain at least one digit, one lowercase letter, one uppercase letter
2. Set `enable_password_reuse` to false to prevent changing the password to the previous one.
