### PR TITLE
Reduce Iceberg metadata refresh operation (#5616)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -102,6 +102,10 @@ public class IcebergTable extends Table {
         this.tableLocation = location;
     }
 
+    public void refreshTable() {
+        IcebergUtil.refreshTable(this.getIcebergTable());
+    }
+
     // icbTbl is used for caching
     public synchronized org.apache.iceberg.Table getIcebergTable() {
         try {

--- a/fe/fe-core/src/main/java/com/starrocks/external/iceberg/IcebergUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/iceberg/IcebergUtil.java
@@ -96,10 +96,7 @@ public class IcebergUtil {
      * @param table
      * @return Optional<Snapshot>
      */
-    public static Optional<Snapshot> getCurrentTableSnapshot(Table table, boolean refresh) {
-        if (refresh) {
-            refreshTable(table);
-        }
+    public static Optional<Snapshot> getCurrentTableSnapshot(Table table) {
         return Optional.ofNullable(table.currentSnapshot());
     }
 
@@ -115,12 +112,7 @@ public class IcebergUtil {
      */
     public static TableScan getTableScan(Table table,
                                          Snapshot snapshot,
-                                         List<Expression> icebergPredicates,
-                                         boolean refresh) {
-        if (refresh) {
-            refreshTable(table);
-        }
-
+                                         List<Expression> icebergPredicates) {
         TableScan tableScan = table.newScan().useSnapshot(snapshot.snapshotId()).includeColumnStats();
         Expression filterExpressions = Expressions.alwaysTrue();
         if (!icebergPredicates.isEmpty()) {
@@ -130,7 +122,7 @@ public class IcebergUtil {
         return tableScan.filter(filterExpressions);
     }
 
-    private static void refreshTable(Table table) {
+    public static void refreshTable(Table table) {
         try {
             if (table instanceof BaseTable) {
                 BaseTable baseTable = (BaseTable) table;

--- a/fe/fe-core/src/main/java/com/starrocks/external/iceberg/cost/IcebergTableStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/iceberg/cost/IcebergTableStatisticCalculator.java
@@ -202,7 +202,7 @@ public class IcebergTableStatisticCalculator {
 
     private IcebergFileStats generateIcebergFileStats(List<Expression> icebergPredicates,
                                                       List<Types.NestedField> columns) {
-        Optional<Snapshot> snapshot = IcebergUtil.getCurrentTableSnapshot(icebergTable, true);
+        Optional<Snapshot> snapshot = IcebergUtil.getCurrentTableSnapshot(icebergTable);
         if (!snapshot.isPresent()) {
             return null;
         }
@@ -221,7 +221,7 @@ public class IcebergTableStatisticCalculator {
                 .collect(toImmutableList());
 
         TableScan tableScan = IcebergUtil.getTableScan(icebergTable,
-                snapshot.get(), icebergPredicates, true);
+                snapshot.get(), icebergPredicates);
 
         IcebergFileStats icebergFileStats = null;
         try (CloseableIterable<FileScanTask> fileScanTasks = tableScan.planFiles()) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
@@ -144,7 +144,7 @@ public class IcebergScanNode extends ScanNode {
 
     public void getScanRangeLocations() throws UserException {
         Optional<Snapshot> snapshot = IcebergUtil.getCurrentTableSnapshot(
-                srIcebergTable.getIcebergTable(), true);
+                srIcebergTable.getIcebergTable());
         if (!snapshot.isPresent()) {
             LOG.info(String.format("Table %s has no snapshot!", srIcebergTable.getTable()));
             return;
@@ -152,7 +152,7 @@ public class IcebergScanNode extends ScanNode {
         preProcessConjuncts();
         for (CombinedScanTask combinedScanTask : IcebergUtil.getTableScan(
                 srIcebergTable.getIcebergTable(), snapshot.get(),
-                icebergPredicates, true).planTasks()) {
+                icebergPredicates).planTasks()) {
             for (FileScanTask task : combinedScanTask.files()) {
                 DataFile file = task.file();
                 LOG.debug("Scan with file " + file.path() + ", file record count " + file.recordCount());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
@@ -16,6 +16,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.DistributionInfo;
 import com.starrocks.catalog.EsTable;
 import com.starrocks.catalog.HashDistributionInfo;
+import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableFunction;
@@ -424,6 +425,7 @@ public class RelationTransformer extends AstVisitor<LogicalPlan, ExpressionMappi
             scanOperator = new LogicalHiveScanOperator(node.getTable(), node.getTable().getType(),
                     colRefToColumnMetaMapBuilder.build(), columnMetaToColRefMap, Operator.DEFAULT_LIMIT, null);
         } else if (Table.TableType.ICEBERG.equals(node.getTable().getType())) {
+            ((IcebergTable) node.getTable()).refreshTable();
             scanOperator = new LogicalIcebergScanOperator(node.getTable(), node.getTable().getType(),
                     colRefToColumnMetaMapBuilder.build(), columnMetaToColRefMap, Operator.DEFAULT_LIMIT, null);
         } else if (Table.TableType.HUDI.equals(node.getTable().getType())) {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [X] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5616

I add refresh iceberg table  in  generate `LogicalIcebergScanOperator`，  because the `IcebergScanOperator` only have `sr iceberg table` and call `getIcebergTable`(alread have cache) to get `iceberg table`, so  I add refresh here. 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
