### PR TITLE
[BugFix] Add retry for fe thrift rpc

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -429,6 +429,18 @@ public class Config extends ConfigBase {
     @ConfField
     public static String thrift_server_type = ThriftServer.THREAD_POOL;
 
+    /**
+     * the timeout for thrift rpc call
+     */
+    @ConfField(mutable = true)
+    public static int thrift_rpc_timeout_ms = 10000;
+
+    /**
+     * the retry times for thrift rpc call
+     */
+    @ConfField(mutable = true)
+    public static int thrift_rpc_retry_times = 3;
+
     // May be necessary to modify the following BRPC configurations in high concurrency scenarios.
 
     // The size of BRPC connection pool. It will limit the concurrency of sending requests, because

--- a/fe/fe-core/src/main/java/com/starrocks/external/starrocks/TableMetaSyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/starrocks/TableMetaSyncer.java
@@ -3,6 +3,7 @@
 package com.starrocks.external.starrocks;
 
 import com.starrocks.catalog.ExternalOlapTable;
+import com.starrocks.common.Config;
 import com.starrocks.rpc.FrontendServiceProxy;
 import com.starrocks.thrift.TAuthenticateParams;
 import com.starrocks.thrift.TGetTableMetaRequest;
@@ -29,7 +30,9 @@ public class TableMetaSyncer {
         authInfo.setPasswd(table.getSourceTablePassword());
         request.setAuth_info(authInfo);
         try {
-            TGetTableMetaResponse response = FrontendServiceProxy.call(addr, 10000,
+            TGetTableMetaResponse response = FrontendServiceProxy.call(addr,
+                    Config.thrift_rpc_timeout_ms,
+                    Config.thrift_rpc_retry_times,
                     client -> client.getTableMeta(request));
             if (response.status.getStatus_code() != TStatusCode.OK) {
                 String errMsg;

--- a/fe/fe-core/src/main/java/com/starrocks/http/action/SystemAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/action/SystemAction.java
@@ -90,7 +90,7 @@ public class SystemAction extends WebBaseAction {
             // forward to master
             String showProcStmt = "SHOW PROC \"" + procPath + "\"";
             MasterOpExecutor masterOpExecutor = new MasterOpExecutor(new OriginStatement(showProcStmt, 0),
-                    ConnectContext.get(), RedirectStatus.FORWARD_NO_SYNC, true);
+                    ConnectContext.get(), RedirectStatus.FORWARD_NO_SYNC);
             try {
                 masterOpExecutor.execute();
             } catch (Exception e) {

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/ShowProcAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/ShowProcAction.java
@@ -76,7 +76,7 @@ public class ShowProcAction extends RestBaseAction {
             // ConnectContext build in RestBaseAction
             ConnectContext context = ConnectContext.get();
             MasterOpExecutor masterOpExecutor = new MasterOpExecutor(new OriginStatement(showProcStmt, 0), context,
-                    RedirectStatus.FORWARD_NO_SYNC, true);
+                    RedirectStatus.FORWARD_NO_SYNC);
             LOG.debug("need to transfer to Master. stmt: {}", context.getStmtId());
 
             try {

--- a/fe/fe-core/src/main/java/com/starrocks/master/MasterImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/master/MasterImpl.java
@@ -58,6 +58,7 @@ import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
 import com.starrocks.cluster.ClusterNamespace;
+import com.starrocks.common.Config;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.UserException;
 import com.starrocks.load.DeleteJob;
@@ -1203,7 +1204,9 @@ public class MasterImpl {
             try {
                 LOG.info("beginRemoteTxn as follower, forward it to master. Label: {}, master: {}",
                         request.getLabel(), addr.toString());
-                response = FrontendServiceProxy.call(addr, 10000,
+                response = FrontendServiceProxy.call(addr,
+                        Config.thrift_rpc_timeout_ms,
+                        Config.thrift_rpc_retry_times,
                         client -> client.beginRemoteTxn(request));
             } catch (Exception e) {
                 LOG.warn("create thrift client failed during beginRemoteTxn, label: {}, exception: {}",
@@ -1257,7 +1260,9 @@ public class MasterImpl {
             try {
                 LOG.info("commitRemoteTxn as follower, forward it to master. txn_id: {}, master: {}",
                         request.getTxn_id(), addr.toString());
-                response = FrontendServiceProxy.call(addr, 10000,
+                response = FrontendServiceProxy.call(addr,
+                        Config.thrift_rpc_timeout_ms,
+                        Config.thrift_rpc_retry_times,
                         client -> client.commitRemoteTxn(request));
             } catch (Exception e) {
                 LOG.warn("create thrift client failed during commitRemoteTxn, txn_id: {}, exception: {}",
@@ -1320,7 +1325,9 @@ public class MasterImpl {
             try {
                 LOG.info("abortRemoteTxn as follower, forward it to master. txn_id: {}, master: {}",
                         request.getTxn_id(), addr.toString());
-                response = FrontendServiceProxy.call(addr, 10000,
+                response = FrontendServiceProxy.call(addr,
+                        Config.thrift_rpc_timeout_ms,
+                        Config.thrift_rpc_retry_times,
                         client -> client.abortRemoteTxn(request));
             } catch (Exception e) {
                 LOG.warn("create thrift client failed during abortRemoteTxn, txn_id: {}, exception: {}",

--- a/fe/fe-core/src/main/java/com/starrocks/qe/MasterOpExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/MasterOpExecutor.java
@@ -24,18 +24,17 @@ package com.starrocks.qe;
 import com.starrocks.analysis.RedirectStatus;
 import com.starrocks.analysis.SetStmt;
 import com.starrocks.analysis.StatementBase;
-import com.starrocks.common.ClientPool;
+import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.qe.QueryState.MysqlStateType;
-import com.starrocks.thrift.FrontendService;
+import com.starrocks.rpc.FrontendServiceProxy;
 import com.starrocks.thrift.TMasterOpRequest;
 import com.starrocks.thrift.TMasterOpResult;
 import com.starrocks.thrift.TNetworkAddress;
 import com.starrocks.thrift.TQueryOptions;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.thrift.transport.TTransportException;
 
 import java.nio.ByteBuffer;
 
@@ -51,14 +50,12 @@ public class MasterOpExecutor {
     // the total time of thrift connectTime add readTime and writeTime
     private int thriftTimeoutMs;
 
-    private boolean shouldNotRetry;
-
-    public MasterOpExecutor(OriginStatement originStmt, ConnectContext ctx, RedirectStatus status, boolean isQuery) {
-        this(null, originStmt, ctx, status, isQuery);
+    public MasterOpExecutor(OriginStatement originStmt, ConnectContext ctx, RedirectStatus status) {
+        this(null, originStmt, ctx, status);
     }
 
     public MasterOpExecutor(StatementBase parsedStmt, OriginStatement originStmt,
-                            ConnectContext ctx, RedirectStatus status, boolean isQuery) {
+                            ConnectContext ctx, RedirectStatus status) {
         this.originStmt = originStmt;
         this.ctx = ctx;
         if (status.isNeedToWaitJournalSync()) {
@@ -66,9 +63,9 @@ public class MasterOpExecutor {
         } else {
             this.waitTimeoutMs = 0;
         }
-        this.thriftTimeoutMs = ctx.getSessionVariable().getQueryTimeoutS() * 1000;
-        // if isQuery=false, we shouldn't retry twice when catch exception because of Idempotency
-        this.shouldNotRetry = !isQuery;
+        // set thriftTimeoutMs to query_timeout + thrift_rpc_timeout_ms
+        // so that we can return an execution timeout instead of a network timeout
+        this.thriftTimeoutMs = ctx.getSessionVariable().getQueryTimeoutS() * 1000 + Config.thrift_rpc_timeout_ms;
         this.parsedStmt = parsedStmt;
     }
 
@@ -112,14 +109,6 @@ public class MasterOpExecutor {
         String masterHost = ctx.getGlobalStateMgr().getMasterIp();
         int masterRpcPort = ctx.getGlobalStateMgr().getMasterRpcPort();
         TNetworkAddress thriftAddress = new TNetworkAddress(masterHost, masterRpcPort);
-
-        FrontendService.Client client = null;
-        try {
-            client = ClientPool.frontendPool.borrowObject(thriftAddress, thriftTimeoutMs);
-        } catch (Exception e) {
-            // may throw NullPointerException. add err msg
-            throw new Exception("Failed to get master client.", e);
-        }
         TMasterOpRequest params = new TMasterOpRequest();
         params.setCluster(ctx.getClusterName());
         params.setSql(originStmt.originStmt);
@@ -144,32 +133,10 @@ public class MasterOpExecutor {
         params.setQueryId(UUIDUtil.toTUniqueId(ctx.getQueryId()));
         LOG.info("Forward statement {} to Master {}", ctx.getStmtId(), thriftAddress);
 
-        boolean isReturnToPool = false;
-        try {
-            result = client.forward(params);
-            isReturnToPool = true;
-        } catch (TTransportException e) {
-            LOG.warn("Forward statement {} to Master {} failed, error type {}",
-                    ctx.getStmtId(), thriftAddress, e.getType(), e);
-            boolean ok = ClientPool.frontendPool.reopen(client, thriftTimeoutMs);
-            if (!ok) {
-                throw e;
-            }
-            // NOTE: master execute timeout will return TTransportException.UNKNOWN not TTransportException.TIMED_OUT
-            if (shouldNotRetry || e.getType() == TTransportException.TIMED_OUT) {
-                throw e;
-            } else {
-                LOG.info("Retry Forward statement {} to Master {}", ctx.getStmtId(), thriftAddress);
-                result = client.forward(params);
-                isReturnToPool = true;
-            }
-        } finally {
-            if (isReturnToPool) {
-                ClientPool.frontendPool.returnObject(thriftAddress, client);
-            } else {
-                ClientPool.frontendPool.invalidateObject(thriftAddress, client);
-            }
-        }
+        result = FrontendServiceProxy.call(thriftAddress,
+                thriftTimeoutMs,
+                Config.thrift_rpc_retry_times,
+                client -> client.forward(params));
     }
 
     public ByteBuffer getOutputPacket() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -544,8 +544,7 @@ public class StmtExecutor {
     }
 
     private void forwardToMaster() throws Exception {
-        boolean isQuery = parsedStmt instanceof QueryStmt || parsedStmt instanceof QueryStatement;
-        masterOpExecutor = new MasterOpExecutor(parsedStmt, originStmt, context, redirectStatus, isQuery);
+        masterOpExecutor = new MasterOpExecutor(parsedStmt, originStmt, context, redirectStatus);
         LOG.debug("need to transfer to Master. stmt: {}", context.getStmtId());
         masterOpExecutor.execute();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/FrontendServiceProxy.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/FrontendServiceProxy.java
@@ -5,26 +5,50 @@ package com.starrocks.rpc;
 import com.starrocks.common.ClientPool;
 import com.starrocks.thrift.FrontendService;
 import com.starrocks.thrift.TNetworkAddress;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
+import org.apache.thrift.transport.TTransportException;
+
+import java.net.SocketTimeoutException;
 
 public class FrontendServiceProxy {
+    private static final Logger LOG = LogManager.getLogger(FrontendServiceProxy.class);
 
-    public static <T> T call(TNetworkAddress address, int timeoutMs, MethodCallable<T> callable) throws Exception {
+    public static <T> T call(TNetworkAddress address, int timeoutMs, int retryTimes, MethodCallable<T> callable)
+            throws Exception {
         FrontendService.Client client = ClientPool.frontendPool.borrowObject(address, timeoutMs);
-
-        boolean returnToPool = false;
-        T res;
+        boolean isConnValid = false;
         try {
-            res = callable.invoke(client);
-            returnToPool = true;
+            for (int i = 0; i < retryTimes; i++) {
+                try {
+                    T t = callable.invoke(client);
+                    isConnValid = true;
+                    return t;
+                } catch (TTransportException te) {
+                    LOG.warn("call frontend thrift rpc failed, addr: {}, retried: {}", address, i, te);
+                    // The frontendPool may return a broken conn,
+                    // because there is no validation of the conn in the frontendPool.
+                    // In this case we should reopen the conn and retry the rpc call,
+                    // but we do not retry for the timeout exception, because it may be a network timeout
+                    // or the target server may be running slow.
+                    isConnValid = ClientPool.frontendPool.reopen(client, timeoutMs);
+                    if (i == retryTimes - 1 ||
+                            !isConnValid ||
+                            (te.getCause() instanceof SocketTimeoutException)) {
+                        throw te;
+                    }
+                }
+            }
         } finally {
-            if (returnToPool) {
+            if (isConnValid) {
                 ClientPool.frontendPool.returnObject(address, client);
             } else {
                 ClientPool.frontendPool.invalidateObject(address, client);
             }
         }
-        return res;
+
+        throw new Exception("unexpected");
     }
 
     public interface MethodCallable<T> {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -136,8 +136,9 @@ public class GlobalTransactionMgr implements Writable {
         request.setTimeout_second(timeoutSecond);
         TBeginRemoteTxnResponse response;
         try {
-            response = FrontendServiceProxy
-                    .call(addr, 10000,
+            response = FrontendServiceProxy.call(addr,
+                            Config.thrift_rpc_timeout_ms,
+                            Config.thrift_rpc_retry_times,
                             client -> client.beginRemoteTxn(request));
         } catch (Exception e) {
             LOG.warn("call fe {} beginRemoteTransaction rpc method failed, label: {}", addr, label, e);
@@ -175,8 +176,9 @@ public class GlobalTransactionMgr implements Writable {
         request.setCommit_infos(tabletCommitInfos);
         TCommitRemoteTxnResponse response;
         try {
-            response = FrontendServiceProxy
-                    .call(addr, 10000,
+            response = FrontendServiceProxy.call(addr,
+                            Config.thrift_rpc_timeout_ms,
+                            Config.thrift_rpc_retry_times,
                             client -> client.commitRemoteTxn(request));
         } catch (Exception e) {
             LOG.warn("call fe {} commitRemoteTransaction rpc method failed, txn id: {}", addr, transactionId, e);
@@ -210,8 +212,9 @@ public class GlobalTransactionMgr implements Writable {
         request.setError_msg(errorMsg);
         TAbortRemoteTxnResponse response;
         try {
-            response = FrontendServiceProxy
-                    .call(addr, 10000,
+            response = FrontendServiceProxy.call(addr,
+                            Config.thrift_rpc_timeout_ms,
+                            Config.thrift_rpc_retry_times,
                             client -> client.abortRemoteTxn(request));
         } catch (Exception e) {
             LOG.warn("call fe {} abortRemoteTransaction rpc method failed, txn: {}", addr, transactionId, e);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5655
Fixes #3077

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
In some cases, such as fe restart, a broken conn will be returned from the connection pool, because there is no validation of the conn before being returned to user. We should reopen the conn and retry the rpc.
But for the timeout exception, it may be a network timeout or the target server may be running slow. We just reopen the conn in this case but do not retry.
Since we do not retry for the timeout exception, there is no need to distinguish between the types of statements that should be retried, so we discard the isQuery param from MasterOpExecutor.