### PR TITLE
[Enhance] Presort merge runs to improve locality

### DIFF
--- a/be/src/exec/vectorized/sorting/merge.h
+++ b/be/src/exec/vectorized/sorting/merge.h
@@ -76,7 +76,7 @@ struct SortedRuns {
     ~SortedRuns() = default;
     SortedRuns(SortedRun run) : chunks{run} {}
 
-    SortedRun& get_run(int i) { return chunks[i]; }
+    const SortedRun& get_run(int i) const { return chunks[i]; }
     ChunkPtr get_chunk(int i) const { return chunks[i].chunk; }
     size_t num_chunks() const { return chunks.size(); }
     size_t num_rows() const;

--- a/be/src/exec/vectorized/sorting/merge_column.cpp
+++ b/be/src/exec/vectorized/sorting/merge_column.cpp
@@ -485,6 +485,8 @@ Status merge_sorted_chunks(const SortDescs& descs, const std::vector<ExprContext
 
     // Sort the runs according to [start, end], to improve merge locality
     std::sort(queue.begin(), queue.end(), [&](const SortedRuns& lhs, const SortedRuns& rhs) {
+        if (lhs.num_rows() == 0) return true;
+        if (rhs.num_rows() == 0) return false;
         auto& lhs_first = lhs.get_run(0);
         auto& rhs_first = rhs.get_run(0);
         int x = lhs_first.compare_row(descs, rhs_first, lhs_first.start_index(), rhs_first.start_index());

--- a/be/src/exec/vectorized/sorting/merge_column.cpp
+++ b/be/src/exec/vectorized/sorting/merge_column.cpp
@@ -482,7 +482,7 @@ Status merge_sorted_chunks(const SortDescs& descs, const std::vector<ExprContext
     if (queue.empty()) {
         return Status::OK();
     }
-    
+
     // Sort the runs according to [start, end], to improve merge locality
     std::sort(queue.begin(), queue.end(), [&](const SortedRuns& lhs, const SortedRuns& rhs) {
         auto& lhs_first = lhs.get_run(0);
@@ -491,7 +491,7 @@ Status merge_sorted_chunks(const SortDescs& descs, const std::vector<ExprContext
         if (x != 0) {
             return x < 0;
         }
-        return lhs_first.compare_row(descs, rhs_first, lhs_first.end_index()-1, rhs_first.end_index()-1) < 0;
+        return lhs_first.compare_row(descs, rhs_first, lhs_first.end_index() - 1, rhs_first.end_index() - 1) < 0;
     });
 
     // Do multi-pass merge


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Presort the merge inputs, to avoid data dissociaton and lose the opportunity of trivial-merge optimization.


