### PR TITLE
Fix UDF crash in pipeline

### DIFF
--- a/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
@@ -91,6 +91,7 @@ Status AggregateBlockingNode::open(RuntimeState* state) {
 
             _aggregator->update_num_input_rows(chunk_size);
         }
+        RETURN_IF_ERROR(_aggregator->check_has_error());
     }
 
     if (!_aggregator->is_none_group_by_exprs()) {
@@ -115,6 +116,7 @@ Status AggregateBlockingNode::open(RuntimeState* state) {
             _aggregator->set_ht_eos();
         }
     }
+
     COUNTER_SET(_aggregator->input_row_count(), _aggregator->num_input_rows());
 
     _mem_tracker->set(_aggregator->hash_map_variant().memory_usage() + _aggregator->mem_pool()->total_reserved_bytes());

--- a/be/src/exprs/agg/java_udaf_function.cpp
+++ b/be/src/exprs/agg/java_udaf_function.cpp
@@ -7,6 +7,7 @@
 #include "column/nullable_column.h"
 #include "column/vectorized_fwd.h"
 #include "common/status.h"
+#include "common/statusor.h"
 #include "fmt/core.h"
 #include "fmt/format.h"
 #include "jni.h"
@@ -28,26 +29,16 @@ Status init_udaf_context(int64_t id, const std::string& url, const std::string& 
     std::string state = symbol + "$State";
     RETURN_IF_ERROR(UserFunctionCache::instance()->get_libpath(id, url, checksum, &libpath));
     auto* udaf_ctx = context->impl()->udaf_ctxs();
-    udaf_ctx->udf_classloader = std::make_unique<ClassLoader>(std::move(libpath));
-    RETURN_IF_ERROR(udaf_ctx->udf_classloader->init());
-    udaf_ctx->analyzer = std::make_unique<ClassAnalyzer>();
+    auto udf_classloader = std::make_unique<ClassLoader>(std::move(libpath));
+    auto analyzer = std::make_unique<ClassAnalyzer>();
+    RETURN_IF_ERROR(udf_classloader->init());
 
-    udaf_ctx->udaf_class = udaf_ctx->udf_classloader->getClass(symbol);
-    if (udaf_ctx->udaf_class.clazz() == nullptr) {
-        return Status::InternalError(fmt::format("couldn't found clazz:{}", symbol));
-    }
-
-    udaf_ctx->udaf_state_class = udaf_ctx->udf_classloader->getClass(state);
-    if (udaf_ctx->udaf_state_class.clazz() == nullptr) {
-        return Status::InternalError(fmt::format("couldn't found clazz:{}", state));
-    }
-
-    RETURN_IF_ERROR(udaf_ctx->udaf_class.newInstance(&udaf_ctx->handle));
+    ASSIGN_OR_RETURN(udaf_ctx->udaf_class, udf_classloader->getClass(symbol));
+    ASSIGN_OR_RETURN(udaf_ctx->udaf_state_class, udf_classloader->getClass(state));
+    ASSIGN_OR_RETURN(udaf_ctx->handle, udaf_ctx->udaf_class.newInstance());
 
     udaf_ctx->buffer_data.resize(DEFAULT_UDAF_BUFFER_SIZE);
     udaf_ctx->buffer = std::make_unique<DirectByteBuffer>(udaf_ctx->buffer_data.data(), udaf_ctx->buffer_data.size());
-
-    auto* analyzer = udaf_ctx->analyzer.get();
 
     auto add_method = [&](const std::string& name, jclass clazz, std::unique_ptr<JavaMethodDescriptor>* res) {
         std::string method_name = name;
@@ -71,7 +62,7 @@ Status init_udaf_context(int64_t id, const std::string& url, const std::string& 
     RETURN_IF_ERROR(add_method("serialize", udaf_ctx->udaf_class.clazz(), &udaf_ctx->serialize));
     RETURN_IF_ERROR(add_method("serializeLength", udaf_ctx->udaf_state_class.clazz(), &udaf_ctx->serialize_size));
 
-    udaf_ctx->_func = std::make_unique<UDAFFunction>(udaf_ctx->handle, context, udaf_ctx);
+    udaf_ctx->_func = std::make_unique<UDAFFunction>(udaf_ctx->handle.handle(), context, udaf_ctx);
 
     return Status::OK();
 }

--- a/be/src/exprs/agg/java_udaf_function.h
+++ b/be/src/exprs/agg/java_udaf_function.h
@@ -31,7 +31,7 @@ public:
                 size_t row_num) const override final {
         int num_args = ctx->get_num_args();
         jvalue args[num_args + 1];
-        args[0].l = this->data(state).handle;
+        args[0].l = this->data(state).handle();
         for (int i = 0; i < num_args; ++i) {
             auto& method_type = ctx->impl()->udaf_ctxs()->update->method_desc[i + 2];
             args[i + 1] = cast_to_jvalue<handle_null>(method_type.type, method_type.is_box, columns[i], row_num);
@@ -64,7 +64,7 @@ public:
         }
         JVMFunctionHelper::getInstance().clear(udaf_ctx->buffer.get());
         memcpy(udaf_ctx->buffer_data.data(), slice.get_data(), slice.get_size());
-        udaf_ctx->_func->merge(this->data(state).handle, udaf_ctx->buffer->handle());
+        udaf_ctx->_func->merge(this->data(state).handle(), udaf_ctx->buffer->handle());
     }
 
     void serialize_to_column([[maybe_unused]] FunctionContext* ctx, ConstAggDataPtr __restrict state,
@@ -82,7 +82,7 @@ public:
 
         size_t old_size = column->get_bytes().size();
         auto* udaf_ctx = ctx->impl()->udaf_ctxs();
-        int serialize_size = udaf_ctx->_func->serialize_size(this->data(state).handle);
+        int serialize_size = udaf_ctx->_func->serialize_size(this->data(state).handle());
         if (udaf_ctx->buffer->capacity() < serialize_size) {
             udaf_ctx->buffer_data.resize(serialize_size);
             udaf_ctx->buffer =
@@ -90,7 +90,7 @@ public:
         }
         JVMFunctionHelper::getInstance().clear(udaf_ctx->buffer.get());
 
-        udaf_ctx->_func->serialize(this->data(state).handle, udaf_ctx->buffer->handle());
+        udaf_ctx->_func->serialize(this->data(state).handle(), udaf_ctx->buffer->handle());
         size_t new_size = old_size + serialize_size;
         column->get_bytes().resize(new_size);
         column->get_offset().emplace_back(new_size);
@@ -100,7 +100,7 @@ public:
     void finalize_to_column([[maybe_unused]] FunctionContext* ctx, ConstAggDataPtr __restrict state,
                             Column* to) const override final {
         auto* udaf_ctx = ctx->impl()->udaf_ctxs();
-        jvalue val = udaf_ctx->_func->finalize(this->data(state).handle);
+        jvalue val = udaf_ctx->_func->finalize(this->data(state).handle());
         append_jvalue(udaf_ctx->finalize->method_desc[0], to, val);
         release_jvalue(udaf_ctx->finalize->method_desc[0].is_box, val);
     }
@@ -112,7 +112,7 @@ public:
         auto* udf_ctxs = ctx->impl()->udaf_ctxs();
         // 1 convert input as state
         // 1.1 create state list
-        auto rets = helper.batch_call(ctx, udf_ctxs->handle, udf_ctxs->create->method, chunk_size);
+        auto rets = helper.batch_call(ctx, udf_ctxs->handle.handle(), udf_ctxs->create->method, chunk_size);
         // 1.2 convert input as input array
         int num_cols = ctx->get_num_args();
         std::vector<DirectByteBuffer> buffers;
@@ -125,7 +125,7 @@ public:
         JavaDataTypeConverter::convert_to_boxed_array(ctx, &buffers, raw_input_ptrs.data(), num_cols, chunk_size,
                                                       &args);
         // 2 batch call update
-        helper.batch_update(ctx, ctx->impl()->udaf_ctxs()->handle, ctx->impl()->udaf_ctxs()->update->method,
+        helper.batch_update(ctx, ctx->impl()->udaf_ctxs()->handle.handle(), ctx->impl()->udaf_ctxs()->update->method,
                             args.data(), args.size());
         // 3 get serialize size
         jintArray serialize_szs = (jintArray)helper.int_batch_call(
@@ -141,7 +141,7 @@ public:
         // chunk size
         auto buffer_array = helper.create_object_array(udf_ctxs->buffer->handle(), chunk_size);
         jobject state_and_buffer[2] = {rets, buffer_array};
-        helper.batch_update(ctx, ctx->impl()->udaf_ctxs()->handle, ctx->impl()->udaf_ctxs()->serialize->method,
+        helper.batch_update(ctx, ctx->impl()->udaf_ctxs()->handle.handle(), ctx->impl()->udaf_ctxs()->serialize->method,
                             state_and_buffer, 2);
         std::vector<Slice> slices(chunk_size);
         // 5 ready
@@ -173,7 +173,7 @@ public:
 
     // Call Destroy method
     void destroy(FunctionContext* ctx, AggDataPtr __restrict ptr) const override {
-        ctx->impl()->udaf_ctxs()->_func->destroy(data(ptr).handle);
+        ctx->impl()->udaf_ctxs()->_func->destroy(data(ptr).handle());
         data(ptr).~State();
     }
 
@@ -192,7 +192,7 @@ public:
         auto arr = JavaDataTypeConverter::convert_to_object_array(states, state_offset, batch_size);
         args.emplace_back(arr);
         JavaDataTypeConverter::convert_to_boxed_array(ctx, &buffers, columns, num_cols, batch_size, &args);
-        helper.batch_update(ctx, ctx->impl()->udaf_ctxs()->handle, ctx->impl()->udaf_ctxs()->update->method,
+        helper.batch_update(ctx, ctx->impl()->udaf_ctxs()->handle.handle(), ctx->impl()->udaf_ctxs()->update->method,
                             args.data(), args.size());
         for (int i = 0; i < args.size(); ++i) {
             helper.getEnv()->DeleteLocalRef(args[i]);
@@ -217,8 +217,9 @@ public:
         ConvertDirectBufferVistor vistor(buffers);
         int num_cols = ctx->get_num_args();
         JavaDataTypeConverter::convert_to_boxed_array(ctx, &buffers, columns, num_cols, batch_size, &args);
-        helper.batch_update_single(ctx, ctx->impl()->udaf_ctxs()->handle, ctx->impl()->udaf_ctxs()->update->method,
-                                   this->data(state).handle, args.data(), num_cols);
+        helper.batch_update_single(ctx, ctx->impl()->udaf_ctxs()->handle.handle(),
+                                   ctx->impl()->udaf_ctxs()->update->method, this->data(state).handle(), args.data(),
+                                   num_cols);
         for (int i = 0; i < num_cols; ++i) {
             env->DeleteLocalRef(args[i]);
         }

--- a/be/src/exprs/agg/java_udaf_function.h
+++ b/be/src/exprs/agg/java_udaf_function.h
@@ -62,7 +62,7 @@ public:
             udaf_ctx->buffer =
                     std::make_unique<DirectByteBuffer>(udaf_ctx->buffer_data.data(), udaf_ctx->buffer_data.size());
         }
-        JVMFunctionHelper::getInstance().clear(udaf_ctx->buffer.get());
+        JVMFunctionHelper::getInstance().clear(udaf_ctx->buffer.get(), ctx);
         memcpy(udaf_ctx->buffer_data.data(), slice.get_data(), slice.get_size());
         udaf_ctx->_func->merge(this->data(state).handle(), udaf_ctx->buffer->handle());
     }
@@ -88,7 +88,7 @@ public:
             udaf_ctx->buffer =
                     std::make_unique<DirectByteBuffer>(udaf_ctx->buffer_data.data(), udaf_ctx->buffer_data.size());
         }
-        JVMFunctionHelper::getInstance().clear(udaf_ctx->buffer.get());
+        JVMFunctionHelper::getInstance().clear(udaf_ctx->buffer.get(), ctx);
 
         udaf_ctx->_func->serialize(this->data(state).handle(), udaf_ctx->buffer->handle());
         size_t new_size = old_size + serialize_size;

--- a/be/src/exprs/agg/java_window_function.h
+++ b/be/src/exprs/agg/java_window_function.h
@@ -19,7 +19,7 @@ void assign_jvalue(MethodTypeDescriptor method_type_desc, Column* col, int row_n
 class JavaWindowFunction final : public JavaUDAFAggregateFunction<true> {
 public:
     void reset(FunctionContext* ctx, const Columns& args, AggDataPtr __restrict state) const override {
-        ctx->impl()->udaf_ctxs()->_func->reset(data(state).handle);
+        ctx->impl()->udaf_ctxs()->_func->reset(data(state).handle());
     }
 
     std::string get_name() const override { return "java_window"; }
@@ -40,7 +40,7 @@ public:
         auto& helper = JVMFunctionHelper::getInstance();
         JNIEnv* env = helper.getEnv();
         JavaDataTypeConverter::convert_to_boxed_array(ctx, &buffers, columns, num_args, num_rows, &args);
-        ctx->impl()->udaf_ctxs()->_func->window_update_batch(data(state).handle, peer_group_start, peer_group_end,
+        ctx->impl()->udaf_ctxs()->_func->window_update_batch(data(state).handle(), peer_group_start, peer_group_end,
                                                              frame_start, frame_end, num_args, args.data());
         // release input cols
         for (int i = 0; i < num_args; ++i) {
@@ -51,7 +51,7 @@ public:
     void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,
                     size_t end) const override {
         auto& helper = JVMFunctionHelper::getInstance();
-        jvalue val = ctx->impl()->udaf_ctxs()->_func->finalize(this->data(state).handle);
+        jvalue val = ctx->impl()->udaf_ctxs()->_func->finalize(this->data(state).handle());
         // insert values to column
         JNIEnv* env = helper.getEnv();
         MethodTypeDescriptor desc = {(PrimitiveType)ctx->get_return_type().type, true};

--- a/be/src/exprs/vectorized/java_function_call_expr.cpp
+++ b/be/src/exprs/vectorized/java_function_call_expr.cpp
@@ -79,7 +79,7 @@ struct UDFFunctionCallHelper {
         JavaDataTypeConverter::convert_to_boxed_array(ctx, &buffers, input_cols.data(), num_cols, size,
                                                       &input_col_objs);
         // call UDF method
-        jobject res = helper.batch_call(ctx, fn_desc->udf_handle.handle(), fn_desc->evaluate->method,
+        jobject res = helper.batch_call(ctx, fn_desc->udf_handle.handle(), fn_desc->evaluate->method.handle(),
                                         input_col_objs.data(), input_col_objs.size(), size);
 
         env->PushLocalFrame(size * (num_cols + 1));

--- a/be/src/udf/java/java_data_converter.cpp
+++ b/be/src/udf/java/java_data_converter.cpp
@@ -225,7 +225,7 @@ jobject JavaDataTypeConverter::convert_to_object_array(uint8_t** data, size_t of
     auto* env = helper.getEnv();
     jobjectArray arr = env->NewObjectArray(num_rows, helper.object_class(), nullptr);
     for (int i = 0; i < num_rows; ++i) {
-        env->SetObjectArrayElement(arr, i, reinterpret_cast<JavaUDAFState*>(data[i] + offset)->handle);
+        env->SetObjectArrayElement(arr, i, reinterpret_cast<JavaUDAFState*>(data[i] + offset)->handle());
     }
     return arr;
 }

--- a/be/src/udf/java/java_data_converter.h
+++ b/be/src/udf/java/java_data_converter.h
@@ -11,10 +11,11 @@
 
 namespace starrocks::vectorized {
 struct JavaUDAFState {
-    JavaUDAFState(jobject&& handle_) : handle(std::move(handle_)){};
+    JavaUDAFState(JavaGlobalRef&& handle) : _handle(std::move(handle)){};
     ~JavaUDAFState() = default;
+    jobject handle() const { return _handle.handle(); }
     // UDAF State
-    jobject handle;
+    JavaGlobalRef _handle;
 };
 // Column to DirectByteBuffer, which could avoid some memory copy,
 // directly access the C++ address space in Java

--- a/be/src/udf/java/java_udf.cpp
+++ b/be/src/udf/java/java_udf.cpp
@@ -544,7 +544,6 @@ StatusOr<jobject> ClassAnalyzer::get_method_object(jclass clazz, const std::stri
         return Status::InternalError(fmt::format("couldn't found method:{}", method));
     }
     auto res = env->NewGlobalRef(method_object);
-    LOG(WARNING) << "delete" << method_object;
     env->DeleteLocalRef(method_object);
     return res;
 }

--- a/be/src/udf/java/java_udf.h
+++ b/be/src/udf/java/java_udf.h
@@ -185,6 +185,7 @@ private:
     int _capacity;
 };
 
+// A global ref of the guard, handle can be shared across threads
 class JavaGlobalRef {
 public:
     JavaGlobalRef(jobject&& handle) : _handle(std::move(handle)) {}

--- a/be/src/udf/java/java_udf.h
+++ b/be/src/udf/java/java_udf.h
@@ -152,8 +152,8 @@ public:
     static constexpr const char* JNI_CLASS_NAME = "java/nio/ByteBuffer";
 
     DirectByteBuffer(void* data, int capacity);
-    DirectByteBuffer(jobject&& handle, void* data, int capacity)
-            : _handle(std::move(handle)), _data(data), _capacity(capacity) {}
+    // DirectByteBuffer(jobject&& handle, void* data, int capacity)
+    //         : _handle(std::move(handle)), _data(data), _capacity(capacity) {}
     ~DirectByteBuffer();
 
     DirectByteBuffer(const DirectByteBuffer&) = delete;
@@ -267,11 +267,10 @@ struct MethodTypeDescriptor {
 };
 
 struct JavaMethodDescriptor {
-    ~JavaMethodDescriptor();
     std::string signature; // function signature
     std::string name;      // function name
     std::vector<MethodTypeDescriptor> method_desc;
-    jobject method = nullptr;
+    JavaGlobalRef method = nullptr;
     // thread safe
     jmethodID get_method_id() const;
 };
@@ -313,7 +312,7 @@ public:
     // create a new state for UDAF
     JavaGlobalRef create();
     // destroy state
-    void destroy(JavaGlobalRef state);
+    void destroy(JavaGlobalRef& state);
     // UDAF Update Function
     void update(jvalue* val);
     // UDAF merge

--- a/be/src/udf/java/java_udf.h
+++ b/be/src/udf/java/java_udf.h
@@ -91,7 +91,7 @@ public:
     static std::string to_jni_class_name(const std::string& name);
 
     // reset Buffer set read/write position to zero
-    void clear(DirectByteBuffer* buffer);
+    void clear(DirectByteBuffer* buffer, FunctionContext* ctx);
 
     jclass object_class() { return _object_class; }
 
@@ -152,8 +152,6 @@ public:
     static constexpr const char* JNI_CLASS_NAME = "java/nio/ByteBuffer";
 
     DirectByteBuffer(void* data, int capacity);
-    // DirectByteBuffer(jobject&& handle, void* data, int capacity)
-    //         : _handle(std::move(handle)), _data(data), _capacity(capacity) {}
     ~DirectByteBuffer();
 
     DirectByteBuffer(const DirectByteBuffer&) = delete;
@@ -257,7 +255,8 @@ public:
 private:
     std::string _path;
     jmethodID _get_class = nullptr;
-    jobject _handle = nullptr;
+    JavaGlobalRef _handle = nullptr;
+    JavaGlobalRef _clazz = nullptr;
 };
 
 struct MethodTypeDescriptor {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：

Fixes #5666 

## Problem Summary(Required) ：
access local reference across the thread is not safe, using global
reference instead of local to avoid JNI check crash

https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/design.html#global_and_local_references