### PR TITLE
[BugFix] Restart fe failed with InsufficientLogException

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBEnvironment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBEnvironment.java
@@ -241,6 +241,12 @@ public class BDBEnvironment {
         restore.execute(insufficientLogEx, config);
     }
 
+    public void refreshAndSetup(InsufficientLogException insufficientLogEx) {
+        refreshLog(insufficientLogEx);
+        close();
+        setup();
+    }
+
     public ReplicationGroupAdmin getReplicationGroupAdmin() {
         return this.replicationGroupAdmin;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBJEJournal.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBJEJournal.java
@@ -309,6 +309,13 @@ public class BDBJEJournal implements Journal {
                 // Copy the missing log files from a member of the replication group who owns the files
                 LOG.warn("catch insufficient log exception. will recover and try again.", insufficientLogEx);
                 bdbEnvironment.refreshAndSetup(insufficientLogEx);
+            } catch (Throwable t) {
+                LOG.warn("catch exception, sleep and retry", t);
+                try {
+                    Thread.sleep(5000L);
+                } catch (InterruptedException ie) {
+
+                }
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBJEJournal.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBJEJournal.java
@@ -27,8 +27,6 @@ import com.sleepycat.je.DatabaseEntry;
 import com.sleepycat.je.DatabaseException;
 import com.sleepycat.je.OperationStatus;
 import com.sleepycat.je.rep.InsufficientLogException;
-import com.sleepycat.je.rep.NetworkRestore;
-import com.sleepycat.je.rep.NetworkRestoreConfig;
 import com.starrocks.common.Pair;
 import com.starrocks.common.io.DataOutputBuffer;
 import com.starrocks.common.io.Writable;

--- a/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBJEJournal.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBJEJournal.java
@@ -280,6 +280,11 @@ public class BDBJEJournal implements Journal {
         List<Long> dbNames = null;
         for (int i = 0; i < RETRY_TIME; i++) {
             try {
+                // sleep for retry
+                if (i > 0) {
+                    Thread.sleep(3000L);
+                }
+
                 dbNames = bdbEnvironment.getDatabaseNames();
 
                 if (dbNames == null) {
@@ -310,12 +315,7 @@ public class BDBJEJournal implements Journal {
                 LOG.warn("catch insufficient log exception. will recover and try again.", insufficientLogEx);
                 bdbEnvironment.refreshAndSetup(insufficientLogEx);
             } catch (Throwable t) {
-                LOG.warn("catch exception, sleep and retry", t);
-                try {
-                    Thread.sleep(5000L);
-                } catch (InterruptedException ie) {
-
-                }
+                LOG.warn("catch exception, retried: {} ", i, t);
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBJEJournal.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBJEJournal.java
@@ -26,6 +26,9 @@ import com.sleepycat.je.Database;
 import com.sleepycat.je.DatabaseEntry;
 import com.sleepycat.je.DatabaseException;
 import com.sleepycat.je.OperationStatus;
+import com.sleepycat.je.rep.InsufficientLogException;
+import com.sleepycat.je.rep.NetworkRestore;
+import com.sleepycat.je.rep.NetworkRestoreConfig;
 import com.starrocks.common.Pair;
 import com.starrocks.common.io.DataOutputBuffer;
 import com.starrocks.common.io.Writable;
@@ -275,28 +278,41 @@ public class BDBJEJournal implements Journal {
         }
 
         // Open a new journal database or get last existing one as current journal database
-        List<Long> dbNames = bdbEnvironment.getDatabaseNames();
-        if (dbNames == null) {
-            LOG.error("fail to get dbNames while open bdbje journal. will exit");
-            System.exit(-1);
-        }
-        if (dbNames.size() == 0) {
-            /*
-             *  This is the very first time to open. Usually, we will open a new database named "1".
-             *  But when we start cluster with an image file copied from other cluster,
-             *  here we should open database with name image max journal id + 1.
-             *  (default GlobalStateMgr.getCurrentState().getReplayedJournalId() is 0)
-             */
-            String dbName = Long.toString(GlobalStateMgr.getCurrentState().getReplayedJournalId() + 1);
-            LOG.info("the very first time to open bdb, dbname is {}", dbName);
-            currentJournalDB = bdbEnvironment.openDatabase(dbName);
-        } else {
-            // get last database as current journal database
-            currentJournalDB = bdbEnvironment.openDatabase(dbNames.get(dbNames.size() - 1).toString());
-        }
+        Pair<String, Integer> helperNode = GlobalStateMgr.getCurrentState().getHelperNode();
+        List<Long> dbNames = null;
+        for (int i = 0; i < RETRY_TIME; i++) {
+            try {
+                dbNames = bdbEnvironment.getDatabaseNames();
 
-        // set next journal id
-        nextJournalId.set(getMaxJournalId() + 1);
+                if (dbNames == null) {
+                    LOG.error("fail to get dbNames while open bdbje journal. will exit");
+                    System.exit(-1);
+                }
+                if (dbNames.size() == 0) {
+                    /*
+                     *  This is the very first time to open. Usually, we will open a new database named "1".
+                     *  But when we start cluster with an image file copied from other cluster,
+                     *  here we should open database with name image max journal id + 1.
+                     *  (default Catalog.getCurrentCatalog().getReplayedJournalId() is 0)
+                     */
+                    String dbName = Long.toString(GlobalStateMgr.getCurrentState().getReplayedJournalId() + 1);
+                    LOG.info("the very first time to open bdb, dbname is {}", dbName);
+                    currentJournalDB = bdbEnvironment.openDatabase(dbName);
+                } else {
+                    // get last database as current journal database
+                    currentJournalDB = bdbEnvironment.openDatabase(dbNames.get(dbNames.size() - 1).toString());
+                }
+
+                // set next journal id
+                nextJournalId.set(getMaxJournalId() + 1);
+
+                break;
+            } catch (InsufficientLogException insufficientLogEx) {
+                // Copy the missing log files from a member of the replication group who owns the files
+                LOG.warn("catch insufficient log exception. will recover and try again.", insufficientLogEx);
+                bdbEnvironment.refreshAndSetup(insufficientLogEx);
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5642

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When fe has been stopped for a long time, the logs in bdb will be too far behind. On this case, bdb will throw the InsufficientLogException. We should catch this exception and refresh the log from master.