### PR TITLE
[cherry-pick][BugFix] When the input_rows is larger, the overflow occurs when (#5609)

### DIFF
--- a/be/src/storage/compaction_utils.cpp
+++ b/be/src/storage/compaction_utils.cpp
@@ -67,15 +67,12 @@ Status CompactionUtils::construct_output_rowset_writer(Tablet* tablet, uint32_t 
 
 uint32_t CompactionUtils::get_segment_max_rows(int64_t max_segment_file_size, int64_t input_row_num,
                                                int64_t input_size) {
-    // max segment rows
-    int64_t max_segment_rows = max_segment_file_size * input_row_num / (input_size + 1);
-    // default value in RowsetWriterContext is INT32_MAX.
-    // segment file use uint32 to represent row number,
-    // and use INT32_MAX to avoid overflow issue when casting from uint32_t to int.
-    if (max_segment_rows > INT32_MAX) {
+    // The range of config::max_segments_file_size is between [1, INT64_MAX]
+    // If the configuration is set wrong, the config::max_segments_file_size will be a negtive value.
+    // Using division instead multiplication can avoid the overflow
+    int64_t max_segment_rows = max_segment_file_size / (input_size / (input_row_num + 1) + 1);
+    if (max_segment_rows > INT32_MAX || max_segment_rows <= 0) {
         max_segment_rows = INT32_MAX;
-    } else if (max_segment_rows < 1) {
-        max_segment_rows = 1;
     }
     return max_segment_rows;
 }

--- a/be/test/storage/compaction_utils_test.cpp
+++ b/be/test/storage/compaction_utils_test.cpp
@@ -50,10 +50,22 @@ TEST(CompactionUtilsTest, test_get_segment_max_rows) {
     int64_t input_row_num = 10000;
     int64_t input_size = 100 * 10000;
     uint32_t segment_max_rows = CompactionUtils::get_segment_max_rows(max_segment_file_size, input_row_num, input_size);
-    ASSERT_EQ(10737407, segment_max_rows);
+    ASSERT_EQ(10737418, segment_max_rows);
 
     segment_max_rows = CompactionUtils::get_segment_max_rows(max_segment_file_size, 0, 0);
-    ASSERT_EQ(1, segment_max_rows);
+    ASSERT_EQ(1073741824, segment_max_rows);
+
+    max_segment_file_size = -1;
+    segment_max_rows = CompactionUtils::get_segment_max_rows(max_segment_file_size, 0, 0);
+    ASSERT_EQ(2147483647, segment_max_rows);
+
+    max_segment_file_size = 1 << 63;
+    segment_max_rows = CompactionUtils::get_segment_max_rows(max_segment_file_size, 0, 0);
+    ASSERT_EQ(2147483647, segment_max_rows);
+
+    max_segment_file_size = 0;
+    segment_max_rows = CompactionUtils::get_segment_max_rows(max_segment_file_size, 0, 0);
+    ASSERT_EQ(2147483647, segment_max_rows);
 }
 
 TEST(CompactionUtilsTest, test_split_column_into_groups) {


### PR DESCRIPTION
When the input_rows is larger, the overflow occurs when calculating the output rows of every segment.
Because of the overflow, the row in every segment will be one. It will generate thousands of files and reach the limit of the file descriptors.
```
I0428 00:12:07.176318 11782 compaction.cpp:86] start base compaction. tablet=940828, output version is=0-138715, max rows per segment=1, segment iterator num=100, algo
rithm=VERTICAL_COMPACTION, column group size=23, columns per group=5
W0428 00:12:35.023933 11782 compaction.cpp:106] fail to do base compaction. res=IO error: /home/disk8/starrocks/storage/be-c6e29739-05e6-4286-b850-33c5d97c8f8a/data/54
/940828/1092789729/0200000000000701e04e325abb82380c536e56bffe78afae_65040.dat: Too many open files
```

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5610 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
