### PR TITLE
fix bugs of big query check

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -101,7 +101,7 @@ void GlobalDriverExecutor::_worker_thread() {
                     LOG(WARNING) << "[Driver] Process exceed limit, query_id="
                                  << print_id(driver->query_ctx()->query_id())
                                  << ", instance_id=" << print_id(driver->fragment_ctx()->fragment_instance_id());
-                    query_ctx->cancel(Status::Corruption("exceed limit, is big query"));
+                    query_ctx->cancel(Status::Cancelled("exceed big query limit"));
                 } else {
                     LOG(WARNING) << "[Driver] Process error, query_id=" << print_id(driver->query_ctx()->query_id())
                                  << ", instance_id=" << print_id(driver->fragment_ctx()->fragment_instance_id())

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -199,9 +199,6 @@ void WorkGroup::estimate_trend_factor_period() {
 
 bool WorkGroup::is_big_query(const QueryContext& query_context) {
     // If there is only one query, skip it
-    if (_num_queries <= 1) {
-        return false;
-    }
 
     // Check big query run time
     if (_big_query_cpu_core_second_limit) {

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -198,8 +198,6 @@ void WorkGroup::estimate_trend_factor_period() {
 }
 
 bool WorkGroup::is_big_query(const QueryContext& query_context) {
-    // If there is only one query, skip it
-
     // Check big query run time
     if (_big_query_cpu_core_second_limit) {
         int64_t wg_growth_cpu_use_cost = total_cpu_cost() - query_context.init_wg_cpu_cost();

--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -159,7 +159,7 @@ private:
     WorkGroupType _type;
 
     // Big query metrics, when a query exceeds one of the following metrics, it will likely fail
-    int64_t _big_query_mem_limit = 500;
+    int64_t _big_query_mem_limit = 0;
     int64_t _big_query_scan_rows_limit = 0;
     int64_t _big_query_cpu_core_second_limit = 0;
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

1. Change default value of `big_query_mem_limit` from 500 to `0`, which means no limit
2. Remove the big query check when `_num_queries <= 1`. When only one query running in the workgroup, that should also under the limitation of big query, otherwise it would exhaust all resource of this workgroup and affect other queries.
3. Fix the bug when `update_statistics`, update scan_rows individually with `cpu_limit`
