### PR TITLE
temporary account locking on multiple failed login

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1425,4 +1425,16 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = true)
     public static boolean enable_password_reuse = true;
+
+    /**
+     * Max attemps to login if failed. -1 means unlimited.
+     */
+    @ConfField(mutable = true)
+    public static int max_failed_login_attempts = 3;
+
+    /**
+     * How long in seconds to lock the account after too many consecutive login attempts provide an incorrect password.
+     */
+    @ConfField(mutable = true)
+    public static int password_lock_interval_seconds = 600;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
@@ -115,6 +115,10 @@ public enum ErrorCode {
             "data cannot be inserted into table with empty partition. " +
                     "Use `SHOW PARTITIONS FROM %s` to see the currently partitions of this table. "),
     ERR_NO_SUCH_PARTITION(1749, new byte[] {'H', 'Y', '0', '0', '0'}, "partition '%s' doesn't exist"),
+    // ERROR 3955 (HY000): Access denied for user 'asdf'@'localhost'. Account is blocked for 3 day(s) (3 day(s) remaining) due to 3 consecutive failed logins.
+    ERR_FAILED_ATTEMPT(3955, new byte[] {'H', 'Y', '0', '0', '0'}, "Access denied for user '%s'@'%s'. "
+            + "Account is blocked for %d second(s) (%d second(s) remaining) due to %d consecutive failed logins."),
+
     // Following is StarRocks's error code, which start from 5000
     ERR_NOT_OLAP_TABLE(5000, new byte[] {'H', 'Y', '0', '0', '0'}, "Table '%s' is not a OLAP table"),
     ERR_WRONG_PROC_PATH(5001, new byte[] {'H', 'Y', '0', '0', '0'}, "Proc path '%s' doesn't exist"),

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlProto.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlProto.java
@@ -101,7 +101,6 @@ public class MysqlProto {
         List<UserIdentity> currentUserIdentity = Lists.newArrayList();
         if (!GlobalStateMgr.getCurrentState().getAuth().checkPassword(qualifiedUser, remoteIp,
                 scramble, randomString, currentUserIdentity)) {
-            ErrorReport.report(ErrorCode.ERR_ACCESS_DENIED_ERROR, qualifiedUser, usePasswd);
             return false;
         }
         context.setAuthDataSalt(randomString);

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Auth.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Auth.java
@@ -45,6 +45,8 @@ import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.ErrorCode;
+import com.starrocks.common.ErrorReport;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.FeMetaVersion;
 import com.starrocks.common.Pair;
@@ -283,6 +285,7 @@ public class Auth implements Writable {
         if (!Config.enable_auth_check) {
             return true;
         }
+
         // TODO: Got no better ways to handle the case that user forgot the password, but to remove this backdoor temporarily.
         // if ((remoteUser.equals(ROOT_USER) || remoteUser.equals(ADMIN_USER)) && remoteHost.equals("127.0.0.1")) {
         //     // root and admin user is allowed to login from 127.0.0.1, in case user forget password.
@@ -295,7 +298,19 @@ public class Auth implements Writable {
         // }
         readLock();
         try {
-            return userPrivTable.checkPassword(remoteUser, remoteHost, remotePasswd, randomString, currentUser);
+            if (!userPrivTable.allowLoginAttempt(remoteUser, remoteHost)) {
+                // too many failed attempts
+                return false;
+            }
+            if (userPrivTable.checkPassword(remoteUser, remoteHost, remotePasswd, randomString, currentUser)) {
+                // password is correct
+                userPrivTable.clearFailedAttemptRecords(remoteUser);
+                return true;
+            }
+            // password is wrong
+            userPrivTable.recordFailedAttempt(remoteUser);
+            ErrorReport.report(ErrorCode.ERR_ACCESS_DENIED_ERROR, remoteHost, remotePasswd);
+            return false;
         } finally {
             readUnlock();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/UserPrivTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/UserPrivTable.java
@@ -22,20 +22,32 @@
 package com.starrocks.mysql.privilege;
 
 import com.starrocks.analysis.UserIdentity;
+import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.ErrorCode;
+import com.starrocks.common.ErrorReport;
 import com.starrocks.common.io.Text;
+import org.apache.commons.collections.map.HashedMap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /*
  * UserPrivTable saves all global privs and also password for users
  */
 public class UserPrivTable extends PrivTable {
     private static final Logger LOG = LogManager.getLogger(UserPrivTable.class);
+
+    // Used for lock on multiple failed attempts
+    // user -> the first time that login failed
+    private Map<String, Long> firstFailedAttemptMap = new HashMap<>();
+    // user -> how many failed attempts
+    private Map<String, Integer> continuouslyFailedAttemptMap = new HashedMap();
 
     public UserPrivTable() {
     }
@@ -215,6 +227,65 @@ public class UserPrivTable extends PrivTable {
             }
         }
         return false;
+    }
+
+    /**
+     * check login is allowed
+     **/
+    public boolean allowLoginAttempt(String remoteUser, String remoteHost) {
+        // unlimited attempt
+        if (Config.max_failed_login_attempts < 0) {
+            return true;
+        }
+
+        // no failed attempt found, allow login attempt
+        if (!firstFailedAttemptMap.containsKey(remoteUser)) {
+            return true;
+        }
+
+        long now = System.currentTimeMillis();
+        long firstFailedAttempt = firstFailedAttemptMap.get(remoteUser);
+        long remainingSeconds = Config.password_lock_interval_seconds - (now - firstFailedAttempt) / 1000;
+        if (remainingSeconds <= 0) {
+            LOG.debug("user {} has been allowed to login since {} seconds ago.", remoteUser, 0 - remainingSeconds);
+            // failed attempt timeout, clear record and allow attempt
+            clearFailedAttemptRecords(remoteUser);
+            return true;
+        }
+
+        // failed attempt too many times
+        int failedAttemptTimes = continuouslyFailedAttemptMap.get(remoteUser);
+        if (failedAttemptTimes >= Config.max_failed_login_attempts) {
+            ErrorReport.report(ErrorCode.ERR_FAILED_ATTEMPT, remoteUser, remoteHost,
+                    Config.password_lock_interval_seconds, remainingSeconds, Config.max_failed_login_attempts);
+            LOG.debug("user {} is not allowed to login until {} seconds later", remoteUser, remainingSeconds);
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * If login fails, call this method to record it.
+     **/
+    public void recordFailedAttempt(String remoteUser) {
+        if (!firstFailedAttemptMap.containsKey(remoteUser)) {
+            firstFailedAttemptMap.put(remoteUser, System.currentTimeMillis());
+            continuouslyFailedAttemptMap.put(remoteUser, 1);
+        } else {
+            int failedAttemptTimes = continuouslyFailedAttemptMap.get(remoteUser);
+            continuouslyFailedAttemptMap.put(remoteUser, failedAttemptTimes + 1);
+        }
+    }
+
+    /**
+     * Clear failed attempt records upon login success.
+     **/
+    public void clearFailedAttemptRecords(String remoteUser) {
+        if (firstFailedAttemptMap.containsKey(remoteUser)) {
+            firstFailedAttemptMap.remove(remoteUser);
+            continuouslyFailedAttemptMap.remove(remoteUser);
+        }
     }
 
     @Override


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [x] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Partly fixes #5633 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Account will be locked for `password_lock_interval_seconds` after `max_failed_login_attempts`