### PR TITLE
[Enhancement] Make segment iterator scan full chunk in each time 

### DIFF
--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -687,11 +687,7 @@ Status SegmentIterator::_do_get_next(Chunk* result, vector<rowid_t>* rowid) {
     Chunk* chunk = _context->_read_chunk.get();
 
     while ((chunk_start < chunk_capacity) & _range_iter.has_more()) {
-        if (chunk_capacity - chunk_start > chunk_capacity / 4) {
-            RETURN_IF_ERROR(_read(chunk, rowid, chunk_capacity - chunk_start));
-        } else {
-            RETURN_IF_ERROR(_read(chunk, rowid, chunk_capacity / 4));
-        }
+        RETURN_IF_ERROR(_read(chunk, rowid, std::max(chunk_capacity - chunk_start, chunk_capacity / 4)));
         chunk->check_or_die();
         size_t next_start = chunk->num_rows();
 


### PR DESCRIPTION
[Enhancement]: make segment iterator scan full chunk in each time 
Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5699

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
In each `_do_get_next`, segment iterators will return a result chunk with all of its elements passing the predicates _filter. To achieve this, it will scan some(chunk_capacity - chunk current size) rows, and filters these rows that are unsatisfied with the predicates. Assume the chunk size is 4096 when the chunk current size reaches 4095. Segment iterator will only scan one more row in `_read` and `_filter` it, when there are a number of rows unsatisfied with the predicates, this will have degradation to the performance.

To solve this problem, I make the segment iterator `_read` scan full rows(4096 rows, chunk_capacity) each time, and _filter 4096 rows in batch, which improves a lot to the scan speed. However, this may lead to the resulting chunk containing more than 4096 rows finally. We will save these overflow rows in _overflow_read_chunk chunk and reload them in next do_get_next.

This pr makes the scan speed has an overall improvement, in my test case, the best improvement is around 30%