### PR TITLE
Fix the result error of lowcardinality optimization in delete multiple conditions

### DIFF
--- a/be/src/storage/column_operator_predicate.h
+++ b/be/src/storage/column_operator_predicate.h
@@ -102,7 +102,7 @@ public:
             for (uint16_t i = 0; i < sel_size; ++i) {
                 uint16_t data_idx = sel[i];
                 sel[new_size] = data_idx;
-                new_size += _predicate_operator.eval_at(lowcard_column, i);
+                new_size += _predicate_operator.eval_at(lowcard_column, data_idx);
             }
         } else {
             /* must use uint8_t* to make vectorized effect */
@@ -110,7 +110,7 @@ public:
             for (uint16_t i = 0; i < sel_size; ++i) {
                 uint16_t data_idx = sel[i];
                 sel[new_size] = data_idx;
-                new_size += !null_data[data_idx] && _predicate_operator.eval_at(lowcard_column, i);
+                new_size += !null_data[data_idx] && _predicate_operator.eval_at(lowcard_column, data_idx);
             }
         }
         return new_size;

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -133,6 +133,7 @@ set(EXEC_FILES
         ./io/fd_input_stream_test.cpp
         ./io/seekable_input_stream_test.cpp
         ./storage/decimal12_test.cpp
+        ./storage/disjunctive_predicates_test.cpp
         ./storage/utils_test.cpp
         ./storage/del_vector_test.cpp
         ./storage/file_utils_test.cpp

--- a/be/test/storage/disjunctive_predicates_test.cpp
+++ b/be/test/storage/disjunctive_predicates_test.cpp
@@ -1,0 +1,74 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#include "storage/disjunctive_predicates.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "column/type_traits.h"
+#include "column/vectorized_fwd.h"
+#include "common/object_pool.h"
+#include "runtime/primitive_type.h"
+#include "simd/simd.h"
+#include "storage/vectorized_column_predicate.h"
+#include "util/value_generator.h"
+
+namespace starrocks::vectorized {
+struct SegDataGenerator {
+    inline static int sequence = 0;
+    static int next_value() { return sequence++; }
+};
+
+template <int mod>
+struct SegDataGeneratorWithRange {
+    inline static int sequence = 0;
+    static int next_value() { return sequence++ % mod; }
+};
+
+TEST(DisjunctivePredicatesTest, TwoPredicateTest) {
+    // schema int, int
+    constexpr const int chunk_size = 4096;
+    constexpr PrimitiveType TYPE0 = TYPE_INT;
+    constexpr PrimitiveType TYPE1 = TYPE_INT;
+
+    auto column0 = RunTimeColumnType<TYPE0>::create(chunk_size);
+    auto column1 = RunTimeColumnType<TYPE1>::create(chunk_size);
+    ContainerIniter<SegDataGenerator, RunTimeColumnType<TYPE0>::Container, chunk_size>::init(column0->get_data());
+    ContainerIniter<SegDataGeneratorWithRange<4>, RunTimeColumnType<TYPE1>::Container, chunk_size>::init(
+            column1->get_data());
+    Columns columns = {column0, column1};
+    Chunk::SlotHashMap hash_map;
+    hash_map[0] = 0;
+    hash_map[1] = 1;
+    auto chunk = std::make_shared<Chunk>(columns, hash_map);
+    chunk->_cid_to_index[0] = 0;
+    chunk->_cid_to_index[1] = 1;
+
+    ObjectPool pool;
+    ConjunctivePredicates conjuncts0;
+    // > 1
+    conjuncts0.vec_preds().push_back(pool.add(new_column_ge_predicate(get_type_info(OLAP_FIELD_TYPE_INT), 0, "2000")));
+    ConjunctivePredicates conjuncts1;
+    conjuncts1.vec_preds().push_back(pool.add(new_column_ge_predicate(get_type_info(OLAP_FIELD_TYPE_INT), 1, "2")));
+    std::vector<uint8_t> dict_mapping;
+    dict_mapping.resize(4);
+    dict_mapping[2] = 1;
+    dict_mapping[3] = 1;
+    auto dict =
+            pool.add(new_column_dict_conjuct_predicate(get_type_info(OLAP_FIELD_TYPE_INT), 1, std::move(dict_mapping)));
+    conjuncts1.non_vec_preds().push_back(dict);
+
+    DisjunctivePredicates predicates;
+    predicates.predicate_list().push_back(conjuncts0);
+    predicates.predicate_list().push_back(conjuncts1);
+
+    std::vector<uint8_t> selection;
+    selection.resize(chunk_size);
+    predicates.evaluate(chunk.get(), selection.data());
+
+    size_t sz = SIMD::count_nonzero(selection);
+    ASSERT_EQ(sz, 3096);
+}
+
+} // namespace starrocks::vectorized


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
Fixes #5712 

## Problem Summary(Required) ：
when exists multiple delete conditions. the predicate will evaluate
`evaluate_branchless` as a select result.

in evaluate_branchless the select input should be `sel[i]` rather than
`i`. which will cause a select result error
