### PR TITLE
[BugFix] add delete & update privilege check

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/DeleteStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/DeleteStmt.java
@@ -111,15 +111,6 @@ public class DeleteStmt extends DmlStmt {
 
         // analyze predicate
         analyzePredicate(wherePredicate);
-
-        // check access
-        if (!GlobalStateMgr.getCurrentState().getAuth()
-                .checkTblPriv(ConnectContext.get(), tblName.getDb(), tblName.getTbl(),
-                        PrivPredicate.LOAD)) {
-            ErrorReport.reportAnalysisException(ErrorCode.ERR_TABLEACCESS_DENIED_ERROR, "LOAD",
-                    ConnectContext.get().getQualifiedUser(),
-                    ConnectContext.get().getRemoteIP(), tblName.getTbl());
-        }
     }
 
     private void analyzePredicate(Expr predicate) throws AnalysisException {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeChecker.java
@@ -9,6 +9,7 @@ import com.starrocks.analysis.AlterViewStmt;
 import com.starrocks.analysis.AlterWorkGroupStmt;
 import com.starrocks.analysis.CreateViewStmt;
 import com.starrocks.analysis.CreateWorkGroupStmt;
+import com.starrocks.analysis.DeleteStmt;
 import com.starrocks.analysis.DropMaterializedViewStmt;
 import com.starrocks.analysis.DropTableStmt;
 import com.starrocks.analysis.DropWorkGroupStmt;
@@ -17,6 +18,7 @@ import com.starrocks.analysis.ShowMaterializedViewStmt;
 import com.starrocks.analysis.ShowTableStatusStmt;
 import com.starrocks.analysis.StatementBase;
 import com.starrocks.analysis.TableName;
+import com.starrocks.analysis.UpdateStmt;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
@@ -199,6 +201,34 @@ public class PrivilegeChecker {
                         session.getQualifiedUser(),
                         session.getRemoteIP(),
                         db);
+            }
+            return null;
+        }
+
+        @Override
+        public Void visitUpdateStatement(UpdateStmt statement, ConnectContext session) {
+            // For now, the `update` operation requires the `LOAD` privilege.
+            // TODO We're planning to refactor the whole privilege framework to align with mainstream databases such as
+            //      MySQL by fine-grained administrative permissions.
+            TableName tableName = statement.getTableName();
+            if (!GlobalStateMgr.getCurrentState().getAuth().checkTblPriv(session, tableName.getDb(),
+                    tableName.getTbl(), PrivPredicate.LOAD)) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_TABLEACCESS_DENIED_ERROR, "LOAD",
+                        session.getQualifiedUser(), session.getRemoteIP(), tableName.getTbl());
+            }
+            return null;
+        }
+
+        @Override
+        public Void visitDeleteStatement(DeleteStmt statement, ConnectContext session) {
+            // For now, the `delete` operation requires the `LOAD` privilege.
+            // TODO We're planning to refactor the whole privilege framework to align with mainstream databases such as
+            //      MySQL by fine-grained administrative permissions.
+            TableName tableName = statement.getTableName();
+            if (!GlobalStateMgr.getCurrentState().getAuth().checkTblPriv(session, tableName.getDb(),
+                    tableName.getTbl(), PrivPredicate.LOAD)) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_TABLEACCESS_DENIED_ERROR, "LOAD",
+                        session.getQualifiedUser(), session.getRemoteIP(), tableName.getTbl());
             }
             return null;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
@@ -264,4 +264,55 @@ public class PrivilegeCheckerTest {
         Assert.assertThrows(SemanticException.class,
                 () -> PrivilegeChecker.check(statementBase2, starRocksAssert.getCtx()));
     }
+
+
+    @Test
+    public void testUpdateTable() throws Exception {
+
+        String createPrimaryTblStmtStr = "CREATE TABLE db2.tbl2 (k1 int, k2 int, k3 varchar(32)) PRIMARY KEY(k1) "
+                + "DISTRIBUTED BY HASH(k1) BUCKETS 8 properties('replication_num' = '1');";
+        StarRocksAssert starRocksAssert = new StarRocksAssert();
+        starRocksAssert.withDatabase("db2");
+        starRocksAssert.withTable(createPrimaryTblStmtStr);
+
+        Auth auth = starRocksAssert.getCtx().getGlobalStateMgr().getAuth();
+        TablePattern db2TablePattern = new TablePattern("db2", "*");
+        db2TablePattern.analyze("default_cluster");
+        starRocksAssert.getCtx().setQualifiedUser("test");
+        starRocksAssert.getCtx().setCurrentUserIdentity(testUser);
+        starRocksAssert.getCtx().setRemoteIP("%");
+
+        auth.grantPrivs(testUser, db2TablePattern, PrivBitSet.of(Privilege.LOAD_PRIV), true);
+        String sql = "update db2.tbl2 set k3 = 20 where k1 = 1";
+        try {
+            StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
+            PrivilegeChecker.check(statementBase, starRocksAssert.getCtx());
+
+            auth.revokePrivs(testUser, db2TablePattern, PrivBitSet.of(Privilege.LOAD_PRIV), true);
+            Assert.assertThrows(SemanticException.class,
+                    () -> PrivilegeChecker.check(statementBase, starRocksAssert.getCtx()));
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail();
+        }
+    }
+
+    @Test
+    public void testDeleteTable() throws Exception {
+        auth = starRocksAssert.getCtx().getGlobalStateMgr().getAuth();
+        TablePattern db1TablePattern = new TablePattern("db1", "*");
+        db1TablePattern.analyze("default_cluster");
+        starRocksAssert.getCtx().setQualifiedUser("test");
+        starRocksAssert.getCtx().setCurrentUserIdentity(testUser);
+        starRocksAssert.getCtx().setRemoteIP("%");
+
+        auth.grantPrivs(testUser, db1TablePattern, PrivBitSet.of(Privilege.LOAD_PRIV), true);
+        String sql = "delete from db1.tbl1 where k4 = 1";
+        StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
+        PrivilegeChecker.check(statementBase, starRocksAssert.getCtx());
+
+        auth.revokePrivs(testUser, db1TablePattern, PrivBitSet.of(Privilege.LOAD_PRIV), true);
+        Assert.assertThrows(SemanticException.class,
+                () -> PrivilegeChecker.check(statementBase, starRocksAssert.getCtx()));
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5652 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
So far, `update` or `delete` on a primary key table requires no privilege. This PR adds `LOAD` privilege check on `update` & `delete` statements.