### PR TITLE
[Enhancement] Enhance version graph capture_consistent_versions performance by reduce hashmap access

### DIFF
--- a/be/src/storage/version_graph.h
+++ b/be/src/storage/version_graph.h
@@ -36,7 +36,7 @@ struct Vertex {
     int64_t value = 0;
     // one vertex to other vertex may have multi same edge
     // this is just for compatibility with previous implementations.
-    std::multiset<int64_t, std::greater<int64_t>> edges;
+    std::list<Vertex*> edges;
 
     Vertex(int64_t v) : value(v) {}
 };


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
1. reduce hashmap access
2. fix memory leak when deleting version