### PR TITLE
[Feature] Support only_full_group_by SQLMODE 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -235,9 +235,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = PROFILING)
     private boolean openProfile = false;
 
-    // Set sqlMode to empty string
+    // Default sqlMode is ONLY_FULL_GROUP_BY
     @VariableMgr.VarAttr(name = SQL_MODE)
-    private long sqlMode = 0L;
+    private long sqlMode = 32L;
 
     @VariableMgr.VarAttr(name = RESOURCE_VARIABLE)
     private String resourceGroup = "normal";

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzeState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzeState.java
@@ -11,6 +11,7 @@ import com.starrocks.common.IdGenerator;
 import com.starrocks.sql.ast.Relation;
 import com.starrocks.sql.ast.SelectRelation;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -58,6 +59,11 @@ public class AnalyzeState {
      * so in Expression Analyzer, each non-deterministic function will be numbered to achieve different hash values.
      */
     private final IdGenerator<ExprId> nondeterministicIdGenerator = ExprId.createGenerator();
+
+    /**
+     * Columns that do not appear in GroupBy for use with MODE_ONLY_FULL_GROUP_BY.
+     * */
+    private final List<Expr> columnNotInGroupBy = new ArrayList<>();
 
     public AnalyzeState() {
     }
@@ -221,5 +227,9 @@ public class AnalyzeState {
 
     public ExprId getNextNondeterministicId() {
         return nondeterministicIdGenerator.getNextId();
+    }
+
+    public List<Expr> getColumnNotInGroupBy() {
+        return columnNotInGroupBy;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
@@ -17,6 +17,7 @@ import com.starrocks.analysis.ParseNode;
 import com.starrocks.analysis.SelectList;
 import com.starrocks.analysis.SelectListItem;
 import com.starrocks.analysis.SlotRef;
+import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.TreeNode;
 import com.starrocks.qe.ConnectContext;
@@ -27,15 +28,15 @@ import com.starrocks.sql.common.StarRocksPlannerException;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static com.starrocks.analysis.Expr.pushNegationToOperands;
-import static com.starrocks.sql.analyzer.AggregationAnalyzer.verifyOrderByAggregations;
-import static com.starrocks.sql.analyzer.AggregationAnalyzer.verifySourceAggregations;
 import static com.starrocks.sql.common.ErrorType.INTERNAL_ERROR;
 
 public class SelectAnalyzer {
@@ -92,11 +93,37 @@ public class SelectAnalyzer {
                 throw new SemanticException("cannot combine '*' in select list with GROUP BY: *");
             }
 
-            verifySourceAggregations(groupByExpressions, sourceExpressions, sourceScope, analyzeState);
+            new AggregationAnalyzer(session, analyzeState, groupByExpressions, sourceScope, null)
+                    .verify(sourceExpressions);
 
             if (orderByElements.size() > 0) {
-                verifyOrderByAggregations(groupByExpressions, orderByExpressions, sourceScope, sourceAndOutputScope,
-                        analyzeState);
+                new AggregationAnalyzer(session, analyzeState, groupByExpressions, sourceScope, sourceAndOutputScope)
+                        .verify(orderByExpressions);
+            }
+        }
+
+        // If columnNotInGroupBy is not empty, it means that the case where
+        // MODE_ONLY_FULL_GROUP_BY is false needs to be handled.
+        // Change the columns that are not in group by to any_value aggregate function
+        if (!analyzeState.getColumnNotInGroupBy().isEmpty()) {
+            Map<Expr, Expr> notInGroupByMap = new HashMap<>();
+
+            for (Expr g : analyzeState.getColumnNotInGroupBy()) {
+                FunctionCallExpr anyValue = new FunctionCallExpr(FunctionSet.ANY_VALUE, Lists.newArrayList(g));
+                ExpressionAnalyzer.analyzeExpression(anyValue, analyzeState, sourceScope, session);
+                analyzeState.getAggregate().add(anyValue);
+                notInGroupByMap.put(g, anyValue);
+            }
+
+            analyzeState.setOutputExpression(outputExpressions.stream()
+                    .map(e -> e.accept(new NotFullGroupByRewriter(notInGroupByMap), null))
+                    .collect(Collectors.toList()));
+            orderByElements.forEach(orderByElement -> orderByElement.setExpr(
+                    orderByElement.getExpr().accept(new NotFullGroupByRewriter(notInGroupByMap), null)));
+            orderByExpressions =
+                    orderByElements.stream().map(OrderByElement::getExpr).collect(Collectors.toList());
+            if (havingClause != null) {
+                analyzeState.setHaving(analyzeState.getHaving().accept(new NotFullGroupByRewriter(notInGroupByMap), null));
             }
         }
 
@@ -222,10 +249,10 @@ public class SelectAnalyzer {
             }
         }
 
-        List<Expr> outputExpr = outputExpressionBuilder.build();
-        analyzeState.setOutputExpression(outputExpr);
+        List<Expr> outputExpressions = outputExpressionBuilder.build();
+        analyzeState.setOutputExpression(outputExpressions);
         analyzeState.setOutputScope(new Scope(RelationId.anonymous(), new RelationFields(outputFields.build())));
-        return outputExpressionBuilder.build();
+        return outputExpressions;
     }
 
     private List<OrderByElement> analyzeOrderBy(List<OrderByElement> orderByElements, AnalyzeState analyzeState,
@@ -496,6 +523,35 @@ public class SelectAnalyzer {
             Optional<ResolvedField> resolvedField = outputScope.tryResolveFeild(slotRef);
             if (resolvedField.isPresent()) {
                 return outputExprs.get(resolvedField.get().getRelationFieldIndex());
+            }
+            return slotRef;
+        }
+    }
+
+    private static class NotFullGroupByRewriter extends AstVisitor<Expr, Void> {
+        private final Map<Expr, Expr> columnsNotInGroupBy;
+
+        public NotFullGroupByRewriter(Map<Expr, Expr> columnsNotInGroupBy) {
+            this.columnsNotInGroupBy = columnsNotInGroupBy;
+        }
+
+        @Override
+        public Expr visit(ParseNode expr) {
+            return visit(expr, null);
+        }
+
+        @Override
+        public Expr visitExpression(Expr expr, Void context) {
+            for (int i = 0; i < expr.getChildren().size(); ++i) {
+                expr.setChild(i, visit(expr.getChild(i)));
+            }
+            return expr;
+        }
+
+        @Override
+        public Expr visitSlot(SlotRef slotRef, Void context) {
+            if (columnsNotInGroupBy.containsKey(slotRef)) {
+                return columnsNotInGroupBy.get(slotRef);
             }
             return slotRef;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/VariableMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/VariableMgrTest.java
@@ -88,7 +88,7 @@ public class VariableMgrTest {
         Assert.assertEquals(2147483648L, var.getMaxExecMemByte());
         Assert.assertEquals(300, var.getQueryTimeoutS());
         Assert.assertEquals(false, var.isReportSucc());
-        Assert.assertEquals(0L, var.getSqlMode());
+        Assert.assertEquals(32L, var.getSqlMode());
 
         List<List<String>> rows = VariableMgr.dump(SetType.SESSION, var, null);
         Assert.assertTrue(rows.size() > 5);
@@ -100,7 +100,7 @@ public class VariableMgrTest {
             } else if (row.get(0).equalsIgnoreCase("query_timeout")) {
                 Assert.assertEquals("300", row.get(1));
             } else if (row.get(0).equalsIgnoreCase("sql_mode")) {
-                Assert.assertEquals("", row.get(1));
+                Assert.assertEquals("ONLY_FULL_GROUP_BY", row.get(1));
             }
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConstantExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConstantExpressionTest.java
@@ -260,6 +260,7 @@ public class ConstantExpressionTest extends PlanTestBase {
                 "@@tx_isolation AS tx_isolation, " +
                 "@@wait_timeout AS wait_timeout;";
         String plan = getFragmentPlan(sql);
+        System.out.println(plan);
         Assert.assertTrue(plan.contains(
                 "  |  <slot 2> : 1\n" +
                         "  |  <slot 3> : 'utf8'\n" +
@@ -276,7 +277,7 @@ public class ConstantExpressionTest extends PlanTestBase {
                         "  |  <slot 14> : 60\n" +
                         "  |  <slot 15> : 1048576\n" +
                         "  |  <slot 16> : 0\n" +
-                        "  |  <slot 17> : ''\n" +
+                        "  |  <slot 17> : 'ONLY_FULL_GROUP_BY'\n" +
                         "  |  <slot 18> : 'Asia/Shanghai'\n" +
                         "  |  <slot 19> : 'Asia/Shanghai'\n" +
                         "  |  <slot 20> : 'REPEATABLE-READ'\n" +


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5578

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Support ONLY_FULL_GROUP_BY sql mode like Mysql

Reject queries for which the select list, HAVING condition, or ORDER BY list refer to nonaggregated columns that are neither named in the GROUP BY clause nor are functionally dependent on (uniquely determined by) GROUP BY columns.

If a query has aggregate functions and no GROUP BY clause, it cannot have nonaggregated columns in the select list, HAVING condition, or ORDER BY list with ONLY_FULL_GROUP_BY enabled，and columns that do not appear in group by will be rewritten as any_value aggregation function
