### PR TITLE
[WIP]Fix the bug of window function `bitmap_union_count`

### DIFF
--- a/be/src/exprs/agg/aggregate.h
+++ b/be/src/exprs/agg/aggregate.h
@@ -102,7 +102,9 @@ public:
     // Rows are peers if they compare equal to each other using the specified ordering expression.
     virtual void update_batch_single_state(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
                                            int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
-                                           int64_t frame_end) const {}
+                                           int64_t frame_end) const {
+        assert(false);
+    }
 
     // For window functions
     // A peer group is all of the rows that are peers within the specified ordering.

--- a/be/src/exprs/agg/aggregate.h
+++ b/be/src/exprs/agg/aggregate.h
@@ -111,7 +111,9 @@ public:
     // Rows are peers if they compare equal to each other using the specified ordering expression.
     // Update batch single state with null
     virtual void update_single_state_null(FunctionContext* ctx, AggDataPtr __restrict state, int64_t peer_group_start,
-                                          int64_t peer_group_end) const {}
+                                          int64_t peer_group_end) const {
+        assert(false);
+    }
 
     // Contains a loop with calls to "merge" function.
     // You can collect arguments into array "states"

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -612,7 +612,7 @@ public class FunctionSet {
         addBuiltin(AggregateFunction.createBuiltin(BITMAP_UNION_COUNT, Lists.newArrayList(Type.BITMAP),
                 Type.BIGINT,
                 Type.BITMAP,
-                true, true, true));
+                true, false, true));
         // TODO(ml): supply function symbol
         addBuiltin(AggregateFunction.createBuiltin(BITMAP_INTERSECT, Lists.newArrayList(Type.BITMAP),
                 Type.BITMAP, Type.BITMAP,


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5697 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Current, window function don't support bitmap_union_count, so we should return msg of not supported instead of return invalid result.
