### PR TITLE
[Enhancement] delete some compaction configurations (#5363)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -258,14 +258,12 @@ CONF_mInt64(max_base_compaction_num_singleton_deltas, "100");
 CONF_Int32(base_compaction_num_threads_per_disk, "1");
 CONF_mDouble(base_cumulative_delta_ratio, "0.3");
 CONF_mInt64(base_compaction_interval_seconds_since_last_operation, "86400");
-CONF_mInt32(base_compaction_write_mbytes_per_sec, "5");
 
 // cumulative compaction policy: max delta file's size unit:B
 CONF_mInt32(cumulative_compaction_check_interval_seconds, "1");
 CONF_mInt64(min_cumulative_compaction_num_singleton_deltas, "5");
 CONF_mInt64(max_cumulative_compaction_num_singleton_deltas, "1000");
 CONF_Int32(cumulative_compaction_num_threads_per_disk, "1");
-CONF_mInt64(cumulative_compaction_budgeted_bytes, "104857600");
 // CONF_Int32(cumulative_compaction_write_mbytes_per_sec, "100");
 // cumulative compaction skips recently published deltas in order to prevent
 // compacting a version that might be queried (in case the query planning phase took some time).
@@ -300,9 +298,6 @@ CONF_Int64(vertical_compaction_max_columns_per_group, "5");
 CONF_mBool(enable_compaction, "true");
 CONF_Bool(enable_event_based_compaction_framework, "false");
 CONF_mInt32(max_compaction_task_num, "4");
-// < 0 means no limit
-CONF_mInt32(max_cumulative_compaction_task, "-1");
-CONF_mInt32(max_base_compaction_task, "1");
 // 5GB
 CONF_mInt64(min_cumulative_compaction_size, "5368709120");
 // 20GB

--- a/be/src/storage/compaction_manager.cpp
+++ b/be/src/storage/compaction_manager.cpp
@@ -88,12 +88,6 @@ bool CompactionManager::register_task(CompactionTask* compaction_task) {
     TabletSharedPtr& tablet = compaction_task->tablet();
     DataDir* data_dir = tablet->data_dir();
     if (compaction_task->compaction_type() == CUMULATIVE_COMPACTION) {
-        if (config::max_cumulative_compaction_task >= 0 &&
-            _type_to_task_num_map[CUMULATIVE_COMPACTION] >= config::max_cumulative_compaction_task) {
-            LOG(WARNING) << "register compaction task failed for cumulative limit:"
-                         << config::max_cumulative_compaction_task;
-            return false;
-        }
         if (config::cumulative_compaction_num_threads_per_disk >= 0 &&
             _data_dir_to_cumulative_task_num_map[data_dir] >= config::cumulative_compaction_num_threads_per_disk) {
             LOG(WARNING) << "register compaction task failed for disk's running cumulative tasks reach limit:"
@@ -101,11 +95,6 @@ bool CompactionManager::register_task(CompactionTask* compaction_task) {
             return false;
         }
     } else if (compaction_task->compaction_type() == BASE_COMPACTION) {
-        if (config::max_base_compaction_task >= 0 &&
-            _type_to_task_num_map[BASE_COMPACTION] >= config::max_base_compaction_task) {
-            LOG(WARNING) << "register compaction task failed for base limit:" << config::max_base_compaction_task;
-            return false;
-        }
         if (config::base_compaction_num_threads_per_disk >= 0 &&
             _data_dir_to_base_task_num_map[data_dir] >= config::base_compaction_num_threads_per_disk) {
             LOG(WARNING) << "register compaction task failed for disk's running base tasks reach limit:"
@@ -120,7 +109,6 @@ bool CompactionManager::register_task(CompactionTask* compaction_task) {
                      << ", tablet:" << tablet->tablet_id();
         return false;
     }
-    _type_to_task_num_map[compaction_task->compaction_type()]++;
     if (compaction_task->compaction_type() == CUMULATIVE_COMPACTION) {
         _data_dir_to_cumulative_task_num_map[data_dir]++;
     } else {
@@ -138,7 +126,6 @@ void CompactionManager::unregister_task(CompactionTask* compaction_task) {
     if (size > 0) {
         TabletSharedPtr& tablet = compaction_task->tablet();
         DataDir* data_dir = tablet->data_dir();
-        _type_to_task_num_map[compaction_task->compaction_type()]--;
         if (compaction_task->compaction_type() == CUMULATIVE_COMPACTION) {
             _data_dir_to_cumulative_task_num_map[data_dir]--;
         } else {
@@ -152,7 +139,6 @@ void CompactionManager::clear_tasks() {
     _running_tasks.clear();
     _data_dir_to_cumulative_task_num_map.clear();
     _data_dir_to_base_task_num_map.clear();
-    _type_to_task_num_map.clear();
 }
 
 void CompactionManager::_notify_schedulers() {

--- a/be/src/storage/compaction_manager.h
+++ b/be/src/storage/compaction_manager.h
@@ -66,11 +66,6 @@ public:
         return _data_dir_to_base_task_num_map[data_dir];
     }
 
-    uint16_t running_tasks_num_for_type(CompactionType type) {
-        std::lock_guard lg(_tasks_mutex);
-        return _type_to_task_num_map[type];
-    }
-
     uint64_t next_compaction_task_id() { return ++_next_task_id; }
 
 private:

--- a/be/src/storage/compaction_scheduler.cpp
+++ b/be/src/storage/compaction_scheduler.cpp
@@ -90,15 +90,8 @@ bool CompactionScheduler::_can_do_compaction_task(Tablet* tablet, CompactionTask
     // to compatible with old compaction framework
     // TODO: can be optimized to use just one lock
     int64_t last_failure_ms = 0;
-    uint16_t task_num = StorageEngine::instance()->compaction_manager()->running_tasks_num_for_type(
-            compaction_task->compaction_type());
     DataDir* data_dir = tablet->data_dir();
     if (compaction_task->compaction_type() == CUMULATIVE_COMPACTION) {
-        if (config::max_cumulative_compaction_task >= 0 && task_num >= config::max_cumulative_compaction_task) {
-            LOG(INFO) << "skip tablet:" << tablet->tablet_id()
-                      << " for cumulative compaction limit:" << config::max_cumulative_compaction_task;
-            return false;
-        }
         std::unique_lock lk(tablet->get_cumulative_lock(), std::try_to_lock);
         if (!lk.owns_lock()) {
             LOG(INFO) << "skip tablet:" << tablet->tablet_id() << " for cumulative lock";
@@ -117,11 +110,6 @@ bool CompactionScheduler::_can_do_compaction_task(Tablet* tablet, CompactionTask
         }
         last_failure_ms = tablet->last_cumu_compaction_failure_time();
     } else {
-        if (config::max_base_compaction_task >= 0 && task_num >= config::max_base_compaction_task) {
-            LOG(INFO) << "skip tablet:" << tablet->tablet_id()
-                      << " for base compaction limit:" << config::max_base_compaction_task;
-            return false;
-        }
         std::unique_lock lk(tablet->get_base_lock(), std::try_to_lock);
         if (!lk.owns_lock()) {
             LOG(INFO) << "skip tablet:" << tablet->tablet_id() << " for base lock";

--- a/be/src/storage/cumulative_compaction.cpp
+++ b/be/src/storage/cumulative_compaction.cpp
@@ -11,8 +11,7 @@
 namespace starrocks::vectorized {
 
 CumulativeCompaction::CumulativeCompaction(MemTracker* mem_tracker, TabletSharedPtr tablet)
-        : Compaction(mem_tracker, std::move(tablet)),
-          _cumulative_rowset_size_threshold(config::cumulative_compaction_budgeted_bytes) {}
+        : Compaction(mem_tracker, std::move(tablet)) {}
 
 CumulativeCompaction::~CumulativeCompaction() {}
 

--- a/be/src/storage/cumulative_compaction.h
+++ b/be/src/storage/cumulative_compaction.h
@@ -24,9 +24,6 @@ protected:
     std::string compaction_name() const override { return "cumulative compaction"; }
 
     ReaderType compaction_type() const override { return ReaderType::READER_CUMULATIVE_COMPACTION; }
-
-private:
-    int64_t _cumulative_rowset_size_threshold;
 };
 
 } // namespace starrocks::vectorized

--- a/be/test/storage/compaction_manager_test.cpp
+++ b/be/test/storage/compaction_manager_test.cpp
@@ -116,9 +116,6 @@ TEST(CompactionManagerTest, test_compaction_tasks) {
     ASSERT_FALSE(ret);
 
     ASSERT_EQ(config::max_compaction_task_num, StorageEngine::instance()->compaction_manager()->running_tasks_num());
-    ASSERT_EQ(config::max_compaction_task_num,
-              StorageEngine::instance()->compaction_manager()->running_tasks_num_for_type(CUMULATIVE_COMPACTION));
-    ASSERT_EQ(0, StorageEngine::instance()->compaction_manager()->running_tasks_num_for_type(BASE_COMPACTION));
     StorageEngine::instance()->compaction_manager()->clear_tasks();
     ASSERT_EQ(0, StorageEngine::instance()->compaction_manager()->running_tasks_num());
 
@@ -136,34 +133,19 @@ TEST(CompactionManagerTest, test_compaction_tasks) {
     ASSERT_EQ(0, StorageEngine::instance()->compaction_manager()->running_tasks_num());
 
     config::cumulative_compaction_num_threads_per_disk = 4;
-    config::max_cumulative_compaction_task = 1;
-    for (int i = 0; i < config::max_cumulative_compaction_task; i++) {
+    for (int i = 0; i < 1; i++) {
         bool ret = StorageEngine::instance()->compaction_manager()->register_task(tasks[i].get());
         ASSERT_TRUE(ret);
     }
 
-    ret = StorageEngine::instance()->compaction_manager()->register_task(
-            tasks[config::max_cumulative_compaction_task].get());
-    ASSERT_FALSE(ret);
-
-    ASSERT_EQ(config::max_cumulative_compaction_task,
-              StorageEngine::instance()->compaction_manager()->running_tasks_num());
-    ASSERT_EQ(1, StorageEngine::instance()->compaction_manager()->running_tasks_num_for_type(CUMULATIVE_COMPACTION));
     StorageEngine::instance()->compaction_manager()->clear_tasks();
 
     config::base_compaction_num_threads_per_disk = 4;
-    config::max_base_compaction_task = 1;
-    for (int i = 0; i < config::max_base_compaction_task + 1; i++) {
+    for (int i = 0; i < 1; i++) {
         tasks[i]->set_compaction_type(BASE_COMPACTION);
         bool ret = StorageEngine::instance()->compaction_manager()->register_task(tasks[i].get());
-        if (i < config::max_base_compaction_task) {
-            ASSERT_TRUE(ret);
-        } else {
-            ASSERT_FALSE(ret);
-        }
+        ASSERT_TRUE(ret);
     }
-    ASSERT_EQ(config::max_base_compaction_task, StorageEngine::instance()->compaction_manager()->running_tasks_num());
-    ASSERT_EQ(1, StorageEngine::instance()->compaction_manager()->running_tasks_num_for_type(BASE_COMPACTION));
     for (int i = 0; i < tablets.size(); i++) {
         std::unique_ptr<CompactionContext> compaction_context;
         tablets[i]->set_compaction_context(compaction_context);


### PR DESCRIPTION
Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5363 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->


Modification details:
```txt
# 7. unused configurations, remove
CONF_mInt32(base_compaction_write_mbytes_per_sec, "5");

# 12. unused configurations, remove
CONF_mInt64(cumulative_compaction_budgeted_bytes, "104857600");

# 25. use cumulative_compaction_num_threads_per_disk to replace it, remove
CONF_mInt32(max_cumulative_compaction_task, "-1");

# 26. use base_compaction_num_threads_per_disk to replace it, remove
CONF_mInt32(max_base_compaction_task, "1");

# 30. remove precent limit
CONF_Int32(compaction_max_memory_limit_percent, "100");
```