### PR TITLE
[Cherry-pick][branch-2.1][BugFix] Possible dead lock in tablet clone (#5661)

### DIFF
--- a/be/src/storage/tablet_schema_map.h
+++ b/be/src/storage/tablet_schema_map.h
@@ -64,7 +64,6 @@ private:
     constexpr static int kShardSize = 16;
 
     bool check_schema_unique_id(const TabletSchemaPB& schema_pb, const std::shared_ptr<const TabletSchema>& schema_ptr);
-
     struct MapShard {
         mutable std::mutex mtx;
         phmap::flat_hash_map<SchemaId, std::weak_ptr<const TabletSchema>> map;


### PR DESCRIPTION
We use a shared tablet schema to save memory usage, but the premise is that we need to ensure that no two different TabletSchemaPBs have the same `id`, so we will check the consistency of `unique_id` when two `TableSchemaPB` has the same `id`.

However, there may raise a deadlock if we do the check in `TabletSchemaMap::emplace` as in the scenario below：
1. Thead1 holds a shared schema in which `id` is x.
2. Thead2  calls`TabletSchemaMap::emplace` with a `TabletSchemaPB` whose `id` is x, and it will hold the lock of a specific shard
3. The consistency check of `unique_id` failed, and we will create a new `schema`.
4. Thead1 releases the schema and the use_count of the old schema is 1, the old schema is held by Thread2.
5. Thead2 will deconstruct the old schema, and it needs to hold  the lock of a specific shard which will cause a deadlock

To avoid the deadlock, we will release the shard lock after finishing the consistency check, and the old schema will be deconstructed at the end of this function if needed.

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5646 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
