### PR TITLE
[Enhancement] Merge max_compaction_concurrency compaction configurations

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -293,9 +293,7 @@ CONF_mInt32(compaction_trace_threshold, "60");
 // the columns will be divided into groups for vertical compaction.
 CONF_Int64(vertical_compaction_max_columns_per_group, "5");
 
-CONF_mBool(enable_compaction, "true");
 CONF_Bool(enable_event_based_compaction_framework, "false");
-CONF_mInt32(max_compaction_task_num, "4");
 // 5GB
 CONF_mInt64(min_cumulative_compaction_size, "5368709120");
 // 20GB

--- a/be/src/storage/compaction_manager.cpp
+++ b/be/src/storage/compaction_manager.cpp
@@ -17,6 +17,15 @@ CompactionManager::CompactionManager() : _next_task_id(0) {
     DCHECK(st.ok());
 }
 
+void CompactionManager::init() {
+    _max_task_num = static_cast<int32_t>(
+            StorageEngine::instance()->get_store_num() *
+            (config::cumulative_compaction_num_threads_per_disk + config::base_compaction_num_threads_per_disk));
+    if (config::max_compaction_concurrency > 0 && config::max_compaction_concurrency < _max_task_num) {
+        _max_task_num = config::max_compaction_concurrency;
+    }
+}
+
 void CompactionManager::update_candidates(std::vector<CompactionCandidate> candidates) {
     bool should_notify = false;
     {

--- a/be/src/storage/compaction_manager.cpp
+++ b/be/src/storage/compaction_manager.cpp
@@ -17,7 +17,7 @@ CompactionManager::CompactionManager() : _next_task_id(0) {
     DCHECK(st.ok());
 }
 
-void CompactionManager::init() {
+void CompactionManager::init_max_task_num() {
     _max_task_num = static_cast<int32_t>(
             StorageEngine::instance()->get_store_num() *
             (config::cumulative_compaction_num_threads_per_disk + config::base_compaction_num_threads_per_disk));

--- a/be/src/storage/compaction_manager.cpp
+++ b/be/src/storage/compaction_manager.cpp
@@ -9,12 +9,6 @@
 namespace starrocks {
 
 CompactionManager::CompactionManager() : _next_task_id(0) {
-    _max_task_num = static_cast<int32_t>(
-            StorageEngine::instance()->get_store_num() *
-            (config::cumulative_compaction_num_threads_per_disk + config::base_compaction_num_threads_per_disk));
-    if (config::max_compaction_concurrency > 0 && config::max_compaction_concurrency < _max_task_num) {
-        _max_task_num = config::max_compaction_concurrency;
-    }
     auto st = ThreadPoolBuilder("up_candidates")
                       .set_min_threads(1)
                       .set_max_threads(5)

--- a/be/src/storage/compaction_manager.h
+++ b/be/src/storage/compaction_manager.h
@@ -28,7 +28,7 @@ public:
 
     ~CompactionManager() = default;
 
-    void init();
+    void init_max_task_num();
 
     size_t candidates_size() {
         std::lock_guard lg(_candidates_mutex);

--- a/be/src/storage/compaction_manager.h
+++ b/be/src/storage/compaction_manager.h
@@ -20,6 +20,7 @@
 namespace starrocks {
 
 class CompactionScheduler;
+class StorageEngine;
 
 class CompactionManager {
 public:
@@ -27,14 +28,7 @@ public:
 
     ~CompactionManager() = default;
 
-    void init() {
-        _max_task_num = static_cast<int32_t>(
-                StorageEngine::instance()->get_store_num() *
-                (config::cumulative_compaction_num_threads_per_disk + config::base_compaction_num_threads_per_disk));
-        if (config::max_compaction_concurrency > 0 && config::max_compaction_concurrency < _max_task_num) {
-            _max_task_num = config::max_compaction_concurrency;
-        }
-    }
+    void init();
 
     size_t candidates_size() {
         std::lock_guard lg(_candidates_mutex);

--- a/be/src/storage/compaction_manager.h
+++ b/be/src/storage/compaction_manager.h
@@ -27,6 +27,15 @@ public:
 
     ~CompactionManager() = default;
 
+    void init() {
+        _max_task_num = static_cast<int32_t>(
+                StorageEngine::instance()->get_store_num() *
+                (config::cumulative_compaction_num_threads_per_disk + config::base_compaction_num_threads_per_disk));
+        if (config::max_compaction_concurrency > 0 && config::max_compaction_concurrency < _max_task_num) {
+            _max_task_num = config::max_compaction_concurrency;
+        }
+    }
+
     size_t candidates_size() {
         std::lock_guard lg(_candidates_mutex);
         return _compaction_candidates.size();

--- a/be/src/storage/compaction_task.cpp
+++ b/be/src/storage/compaction_task.cpp
@@ -101,7 +101,7 @@ void CompactionTask::run() {
 }
 
 bool CompactionTask::should_stop() const {
-    return StorageEngine::instance()->bg_worker_stopped() || !config::enable_compaction ||
+    return StorageEngine::instance()->bg_worker_stopped() || config::max_compaction_concurrency == 0 ||
            BackgroundTask::should_stop();
 }
 

--- a/be/src/storage/olap_server.cpp
+++ b/be/src/storage/olap_server.cpp
@@ -117,6 +117,9 @@ Status StorageEngine::start_bg_threads() {
         LOG(INFO) << "cumulative compaction threads started. number: " << cumulative_compaction_num_threads;
     } else {
         // new compaction framework
+
+        // compaction_manager must init before any comapction_scheduler starts
+        _compaction_manager->init();
         _compaction_scheduler = std::thread([] {
             CompactionScheduler compaction_scheduler;
             compaction_scheduler.schedule();

--- a/be/src/storage/olap_server.cpp
+++ b/be/src/storage/olap_server.cpp
@@ -118,8 +118,8 @@ Status StorageEngine::start_bg_threads() {
     } else {
         // new compaction framework
 
-        // compaction_manager must init before any comapction_scheduler starts
-        _compaction_manager->init();
+        // compaction_manager must init_max_task_num() before any comapction_scheduler starts
+        _compaction_manager->init_max_task_num();
         _compaction_scheduler = std::thread([] {
             CompactionScheduler compaction_scheduler;
             compaction_scheduler.schedule();

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -145,6 +145,8 @@ Status StorageEngine::_open() {
     // init store_map
     RETURN_IF_ERROR_WITH_WARN(_init_store_map(), "_init_store_map failed");
 
+    _compaction_manager->init();
+
     _effective_cluster_id = config::cluster_id;
     RETURN_IF_ERROR_WITH_WARN(_check_all_root_path_cluster_id(), "fail to check cluster id");
 

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -145,8 +145,6 @@ Status StorageEngine::_open() {
     // init store_map
     RETURN_IF_ERROR_WITH_WARN(_init_store_map(), "_init_store_map failed");
 
-    _compaction_manager->init();
-
     _effective_cluster_id = config::cluster_id;
     RETURN_IF_ERROR_WITH_WARN(_check_all_root_path_cluster_id(), "fail to check cluster id");
 

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -61,6 +61,7 @@ class EngineTask;
 class MemTableFlushExecutor;
 class Tablet;
 class UpdateManager;
+class CompactionManager;
 
 // StorageEngine singleton to manage all Table pointers.
 // Providing add/drop/get operations.

--- a/be/test/storage/compaction_manager_test.cpp
+++ b/be/test/storage/compaction_manager_test.cpp
@@ -85,9 +85,9 @@ TEST(CompactionManagerTest, test_compaction_tasks) {
     std::vector<std::shared_ptr<MockCompactionTask>> tasks;
     DataDir data_dir("./data_dir");
     // generate compaction task
-    config::max_compaction_task_num = 2;
-    config::cumulative_compaction_num_threads_per_disk = config::max_compaction_task_num;
-    for (int i = 0; i < config::max_compaction_task_num + 1; i++) {
+    config::max_compaction_concurrency = 2;
+    config::cumulative_compaction_num_threads_per_disk = config::max_compaction_concurrency;
+    for (int i = 0; i < config::max_compaction_concurrency + 1; i++) {
         TabletSharedPtr tablet = std::make_shared<Tablet>();
         TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
         tablet_meta->set_tablet_id(i);
@@ -107,20 +107,21 @@ TEST(CompactionManagerTest, test_compaction_tasks) {
         tasks.emplace_back(std::move(task));
     }
 
-    for (int i = 0; i < config::max_compaction_task_num; i++) {
+    for (int i = 0; i < config::max_compaction_concurrency; i++) {
         bool ret = StorageEngine::instance()->compaction_manager()->register_task(tasks[i].get());
         ASSERT_TRUE(ret);
     }
     bool ret = StorageEngine::instance()->compaction_manager()->register_task(
-            tasks[config::max_compaction_task_num].get());
+            tasks[config::max_compaction_concurrency].get());
     ASSERT_FALSE(ret);
 
-    ASSERT_EQ(config::max_compaction_task_num, StorageEngine::instance()->compaction_manager()->running_tasks_num());
+    ASSERT_EQ(config::max_compaction_concurrency, StorageEngine::instance()->compaction_manager()->running_tasks_num());
+
     StorageEngine::instance()->compaction_manager()->clear_tasks();
     ASSERT_EQ(0, StorageEngine::instance()->compaction_manager()->running_tasks_num());
 
     config::cumulative_compaction_num_threads_per_disk = 1;
-    for (int i = 0; i < config::max_compaction_task_num; i++) {
+    for (int i = 0; i < config::max_compaction_concurrency; i++) {
         bool ret = StorageEngine::instance()->compaction_manager()->register_task(tasks[i].get());
         if (i == 0) {
             ASSERT_TRUE(ret);


### PR DESCRIPTION


Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5757

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

The functionality of `enable_compaction`, `max_compaction_task_num` and `max_compaction_concurrency` are similar, we can eliminate the `max_compaction_task_num` and `enable_compaction`, and retain only `max_compaction_concurrency`