### PR TITLE
[BugFix] handle cast empty json string

### DIFF
--- a/be/src/util/json.cpp
+++ b/be/src/util/json.cpp
@@ -88,7 +88,7 @@ uint64_t JsonValue::serialize_size() const {
 
 // NOTE: JsonValue must be a valid JSON, which means to_string should not fail
 StatusOr<std::string> JsonValue::to_string() const {
-    if (binary_.empty()) {
+    if (binary_.empty() || to_vslice().type() == vpack::ValueType::None) {
         return "";
     }
     return callVPack<std::string>([this]() {

--- a/be/src/util/json.h
+++ b/be/src/util/json.h
@@ -128,6 +128,7 @@ inline Status fromVPackException(const vpack::Exception& e) {
 inline JsonType fromVPackType(vpack::ValueType type) {
     switch (type) {
     case vpack::ValueType::Null:
+    case vpack::ValueType::None:
         return JsonType::JSON_NULL;
     case vpack::ValueType::Bool:
         return JsonType::JSON_BOOL;

--- a/be/test/exprs/vectorized/cast_expr_test.cpp
+++ b/be/test/exprs/vectorized/cast_expr_test.cpp
@@ -1414,6 +1414,7 @@ TEST_F(VectorizedCastExprTest, jsonToValue) {
     EXPECT_EQ("true", evaluateCastFromJson<TYPE_VARCHAR>(cast_expr, "true")->get_data()[0]);
     EXPECT_EQ("star", evaluateCastFromJson<TYPE_VARCHAR>(cast_expr, "\"star\"")->get_data()[0]);
     EXPECT_EQ("{\"a\": 1}", evaluateCastFromJson<TYPE_VARCHAR>(cast_expr, "{\"a\": 1}")->get_data()[0]);
+    EXPECT_EQ("", evaluateCastFromJson<TYPE_VARCHAR>(cast_expr, "")->get_data()[0]);
 
     // implicit json type case
     EXPECT_EQ(1.0, evaluateCastFromJson<TYPE_DOUBLE>(cast_expr, "1")->get_data()[0]);


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5728

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Parse empty json string generate a json type of `None`, which not handled by current cast expression and `to_string` function.
