### PR TITLE
[BugFix] always clear sendBuffer after realNetSend (#5775 #5786)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlChannel.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlChannel.java
@@ -205,9 +205,14 @@ public class MysqlChannel {
             // Nothing to send
             return;
         }
+
         sendBuffer.flip();
-        realNetSend(sendBuffer);
-        sendBuffer.clear();
+        try {
+            realNetSend(sendBuffer);
+        } finally {
+            sendBuffer.clear();
+        }
+
         isSend = true;
     }
 
@@ -239,14 +244,13 @@ public class MysqlChannel {
     }
 
     private void writeBuffer(ByteBuffer buffer) throws IOException {
-        long leftLength = sendBuffer.capacity() - sendBuffer.position();
         // If too long for buffer, send buffered data.
-        if (leftLength < buffer.remaining()) {
+        if (sendBuffer.remaining() < buffer.remaining()) {
             // Flush data in buffer.
             flush();
         }
         // Send this buffer if large enough
-        if (buffer.remaining() > sendBuffer.capacity()) {
+        if (buffer.remaining() > sendBuffer.remaining()) {
             realNetSend(buffer);
             return;
         }


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5778.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->


> `MysqlChannel::flush()` writes `sendBuffer` to socket with the following steps:
> 1. Flip `sendBuffer` to read mode.
> 2. send to socket.
> 3. Reset `sendBuffer` to write mode.
> 
> If the step 2 throws `IOException`, the step 3 won't have chance to execute.
> 
> What's worse, `MysqlChannel::writeBuffer()` always considers `sendBuffer` as write mode, that is `limit==capacity`. However, if the above step 2 throws error, `limit` may be less than `capacity`.

This is cherry-picked from #5775 and #5786.
