### PR TITLE
[WIP][Bugfix] chunked transfered json

### DIFF
--- a/be/src/exec/vectorized/json_scanner.h
+++ b/be/src/exec/vectorized/json_scanner.h
@@ -109,7 +109,7 @@ private:
     // For performance reason, the simdjson parser should be reused over several files.
     //https://github.com/simdjson/simdjson/blob/master/doc/performance.md
     simdjson::ondemand::parser _simdjson_parser;
-    std::unique_ptr<uint8_t[]> _parser_buf;
+    ByteBufferPtr _parser_buf;
     size_t _parser_buf_sz = 0;
     size_t _parser_buf_cap = 0;
     bool _is_ndjson = false;

--- a/be/src/fs/fs_stream_pipe.cpp
+++ b/be/src/fs/fs_stream_pipe.cpp
@@ -21,9 +21,8 @@ StatusOr<int64_t> StreamLoadPipeInputStream::read(void* data, int64_t size) {
     return nread;
 }
 
-Status StreamLoadPipeInputStream::read_one_message(std::unique_ptr<uint8_t[]>* buf, size_t* buf_cap, size_t* buf_sz,
-                                                   size_t padding) {
-    return _file->read_one_message(buf, buf_cap, buf_sz, padding);
+Status StreamLoadPipeInputStream::read(ByteBufferPtr* buf) {
+    return _file->read(buf);
 }
 
 Status StreamLoadPipeInputStream::skip(int64_t n) {

--- a/be/src/fs/fs_stream_pipe.h
+++ b/be/src/fs/fs_stream_pipe.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "fs/fs.h"
+#include "util/byte_buffer.h"
 
 namespace starrocks {
 class StreamLoadPipe;
@@ -18,7 +19,7 @@ public:
 
     StatusOr<int64_t> read(void* data, int64_t size) override;
 
-    Status read_one_message(std::unique_ptr<uint8_t[]>* buf, size_t* buf_cap, size_t* buf_sz, size_t padding = 0);
+    Status read(ByteBufferPtr *buf);
 
     Status skip(int64_t n) override;
 

--- a/be/src/runtime/message_body_sink.cpp
+++ b/be/src/runtime/message_body_sink.cpp
@@ -46,6 +46,10 @@ Status MessageBodyFileSink::open() {
     return Status::OK();
 }
 
+Status MessageBodyFileSink::append(const ByteBufferPtr& buf) {
+    return append(buf->ptr, buf->remaining());
+}
+
 Status MessageBodyFileSink::append(const char* data, size_t size) {
     auto written = ::write(_fd, data, size);
     if (written == size) {

--- a/be/src/runtime/message_body_sink.h
+++ b/be/src/runtime/message_body_sink.h
@@ -32,11 +32,11 @@ class MessageBodySink {
 public:
     virtual ~MessageBodySink() = default;
     virtual Status append(const char* data, size_t size) = 0;
-    virtual Status append(const ByteBufferPtr& buf) { return append(buf->ptr, buf->remaining()); }
+    virtual Status append(const ByteBufferPtr& buf) = 0;
     // called when all data has been appended
-    virtual Status finish() { return Status::OK(); }
+    virtual Status finish() = 0;
     // called when read HTTP failed
-    virtual void cancel(const Status& status) {}
+    virtual void cancel(const Status& status) = 0;
 };
 
 // write message to a local file
@@ -47,6 +47,7 @@ public:
 
     Status open();
 
+    Status append(const ByteBufferPtr& buf) override;
     Status append(const char* data, size_t size) override;
     Status finish() override;
     void cancel(const Status& status) override;

--- a/be/src/runtime/stream_load/stream_load_context.h
+++ b/be/src/runtime/stream_load/stream_load_context.h
@@ -151,6 +151,8 @@ public:
     bool use_streaming = false;
     TFileFormatType::type format = TFileFormatType::FORMAT_CSV_PLAIN;
 
+    // json_buffer is used to construct a complete json. And then put it to the body_sink.
+    ByteBufferPtr json_buffer;
     std::shared_ptr<MessageBodySink> body_sink;
 
     TStreamLoadPutResult put_result;


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5515

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

The HTTP body of stream load may be divided into chunks and be written into `StreamLoadPipe`. It's not easy to find out a complete JSON object among chunked data. 
This PR use `nullptr` as the delimiter of JSON objects inside the `StreamLoadPipe`. When a complete JSON is appended, a `nullptr` would be appended too.
Though it may be a little strange, it minimizes the modification and adds little complexity.