### PR TITLE
[UDF] optimize performance for Java scalar UDF 

### DIFF
--- a/be/src/exprs/vectorized/java_function_call_expr.cpp
+++ b/be/src/exprs/vectorized/java_function_call_expr.cpp
@@ -38,15 +38,6 @@
 #include "util/slice.h"
 #include "util/unaligned_access.h"
 
-#define APPLY_FOR_NUMBERIC_TYPE(M) \
-    M(TYPE_TINYINT)                \
-    M(TYPE_SMALLINT)               \
-    M(TYPE_INT)                    \
-    M(TYPE_BIGINT)                 \
-    M(TYPE_FLOAT)                  \
-    M(TYPE_DOUBLE)                 \
-    M(TYPE_BOOLEAN)
-
 namespace starrocks::vectorized {
 
 struct UDFFunctionCallHelper {
@@ -59,7 +50,6 @@ struct UDFFunctionCallHelper {
         auto& helper = JVMFunctionHelper::getInstance();
         JNIEnv* env = helper.getEnv();
         std::vector<DirectByteBuffer> buffers;
-        std::vector<jobject> args;
         int num_cols = ctx->get_num_args();
         std::vector<const Column*> input_cols;
 
@@ -74,6 +64,9 @@ struct UDFFunctionCallHelper {
         for (auto col : columns) {
             input_cols.emplace_back(col.get());
         }
+        // each input arguments as three local references (nullcolumn, offsetcolumn, bytescolumn)
+        // result column as a ref
+        env->PushLocalFrame((num_cols + 1) * 3 + 1);
         // convert input columns to object columns
         std::vector<jobject> input_col_objs;
         JavaDataTypeConverter::convert_to_boxed_array(ctx, &buffers, input_cols.data(), num_cols, size,
@@ -82,73 +75,23 @@ struct UDFFunctionCallHelper {
         jobject res = helper.batch_call(ctx, fn_desc->udf_handle.handle(), fn_desc->evaluate->method.handle(),
                                         input_col_objs.data(), input_col_objs.size(), size);
 
-        env->PushLocalFrame(size * (num_cols + 1));
         // get result
-        auto result_cols = get_boxed_result(res, size);
-        // call clear
+        auto result_cols = get_boxed_result(ctx, res, size);
         env->PopLocalFrame(nullptr);
-        for (auto ref : args) {
-            env->DeleteLocalRef(ref);
-        }
-        env->DeleteLocalRef(res);
-
         return result_cols;
     }
 
-#define GET_BOX_RESULT(NAME, cxx_type)                                           \
-    case NAME: {                                                                 \
-        auto null_col = NullColumn::create(num_rows);                            \
-        auto data_col = RunTimeColumnType<NAME>::create(num_rows);               \
-        auto& null_data = null_col->get_data();                                  \
-        auto& container = data_col->get_data();                                  \
-        for (int i = 0; i < num_rows; ++i) {                                     \
-            auto data = env->GetObjectArrayElement((jobjectArray)result, i);     \
-            if (data != nullptr) {                                               \
-                container[i] = helper.val##cxx_type(data);                       \
-            } else {                                                             \
-                null_data[i] = true;                                             \
-            }                                                                    \
-        }                                                                        \
-        return NullableColumn::create(std::move(data_col), std::move(null_col)); \
-    }
-
-    ColumnPtr get_boxed_result(jobject result, size_t num_rows) {
+    ColumnPtr get_boxed_result(FunctionContext* ctx, jobject result, size_t num_rows) {
         if (result == nullptr) {
             return ColumnHelper::create_const_null_column(num_rows);
         }
         auto& helper = JVMFunctionHelper::getInstance();
-        JNIEnv* env = helper.getEnv();
         DCHECK(call_desc->method_desc[0].is_box);
-        switch (call_desc->method_desc[0].type) {
-            GET_BOX_RESULT(TYPE_BOOLEAN, uint8_t)
-            GET_BOX_RESULT(TYPE_TINYINT, int8_t)
-            GET_BOX_RESULT(TYPE_SMALLINT, int16_t)
-            GET_BOX_RESULT(TYPE_INT, int32_t)
-            GET_BOX_RESULT(TYPE_BIGINT, int64_t)
-            GET_BOX_RESULT(TYPE_FLOAT, float)
-            GET_BOX_RESULT(TYPE_DOUBLE, double)
-        case TYPE_VARCHAR: {
-            _data_buffer.resize(num_rows);
-            auto null_col = NullColumn::create(num_rows);
-            auto& null_data = null_col->get_data();
-            std::vector<Slice> slices;
-            slices.resize(num_rows);
-            for (int i = 0; i < num_rows; ++i) {
-                auto data = env->GetObjectArrayElement((jobjectArray)result, i);
-                if (data != nullptr) {
-                    slices[i] = helper.sliceVal((jstring)data, &_data_buffer[i]);
-                } else {
-                    null_data[i] = true;
-                }
-            }
-            auto data_col = BinaryColumn::create();
-            data_col->append_strings(slices);
-            return NullableColumn::create(std::move(data_col), std::move(null_col));
-        }
-        default:
-            DCHECK(false) << "unsupport type:" << call_desc->method_desc[0].type;
-        }
-        return ColumnHelper::create_const_null_column(num_rows);
+        TypeDescriptor type_desc(call_desc->method_desc[0].type);
+        auto res = ColumnHelper::create_column(type_desc, true);
+        helper.get_result_from_boxed_array(ctx, type_desc.type, res.get(), result, num_rows);
+        down_cast<NullableColumn*>(res.get())->update_has_null();
+        return res;
     }
 };
 
@@ -289,7 +232,7 @@ void JavaFunctionCallExpr::close(RuntimeState* state, ExprContext* context, Func
         }
         return Status::OK();
     };
-    call_function_in_pthread(state, function_close);
+    call_function_in_pthread(state, function_close)->get_future().get();
     Expr::close(state, context, scope);
 }
 

--- a/be/src/udf/CMakeLists.txt
+++ b/be/src/udf/CMakeLists.txt
@@ -33,6 +33,7 @@ set(EXECUTABLE_OUTPUT_PATH "${BUILD_DIR}/src/udf")
 set(UDF_FILES
   java/java_udf.cpp
   java/java_data_converter.cpp
+  java/java_native_method.cpp
 )
 
 add_library(Udf udf.cpp udf_ir.cpp java/utils.cpp ${UDF_FILES})

--- a/be/src/udf/java/java_native_method.cpp
+++ b/be/src/udf/java/java_native_method.cpp
@@ -1,0 +1,70 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#include "udf/java/java_native_method.h"
+
+#include "column/column.h"
+#include "column/column_helper.h"
+#include "column/column_visitor_adapter.h"
+#include "column/nullable_column.h"
+#include "column/vectorized_fwd.h"
+#include "gutil/casts.h"
+#include "runtime/primitive_type.h"
+
+namespace starrocks::vectorized {
+
+class getColumnAddrVistor : public ColumnVisitorAdapter<getColumnAddrVistor> {
+public:
+    getColumnAddrVistor(jlong* jarr) : ColumnVisitorAdapter(this), _jarr(jarr) {}
+
+    Status do_visit(const NullableColumn& column) {
+        const auto& null_data = column.immutable_null_column_data();
+        _jarr[_idx++] = reinterpret_cast<int64_t>(null_data.data());
+        return column.data_column()->accept(this);
+    }
+
+    Status do_visit(const BinaryColumn& column) {
+        _jarr[_idx++] = reinterpret_cast<int64_t>(column.get_offset().data());
+        _jarr[_idx++] = reinterpret_cast<int64_t>(column.get_bytes().data());
+        return Status::OK();
+    }
+
+    template <typename T>
+    Status do_visit(const vectorized::FixedLengthColumn<T>& column) {
+        _jarr[_idx++] = reinterpret_cast<int64_t>(column.get_data().data());
+        return Status::OK();
+    }
+
+    template <typename T>
+    Status do_visit(const T& column) {
+        return Status::NotSupported("UDF Not Support Type");
+    }
+
+private:
+    size_t _idx = 0;
+    jlong* _jarr = 0;
+};
+
+jlong JavaNativeMethods::resizeStringData(JNIEnv* env, jclass clazz, jlong columnAddr, jint byteSize) {
+    Column* column = reinterpret_cast<Column*>(columnAddr);
+    BinaryColumn* binary_column = nullptr;
+    if (column->is_nullable()) {
+        binary_column = ColumnHelper::cast_to_raw<TYPE_VARCHAR>(down_cast<NullableColumn*>(column)->data_column());
+    } else {
+        binary_column = down_cast<BinaryColumn*>(column);
+    }
+    binary_column->get_bytes().resize(byteSize);
+    return reinterpret_cast<jlong>(binary_column->get_bytes().data());
+}
+
+jlongArray JavaNativeMethods::getAddrs(JNIEnv* env, jclass clazz, jlong columnAddr) {
+    Column* column = reinterpret_cast<Column*>(columnAddr);
+    // return fixed array size
+    int array_size = 3;
+    auto jarr = env->NewLongArray(array_size);
+    jlong array[array_size];
+    getColumnAddrVistor vistor(array);
+    column->accept(&vistor);
+    env->SetLongArrayRegion(jarr, 0, array_size, array);
+    return jarr;
+}
+} // namespace starrocks::vectorized

--- a/be/src/udf/java/java_native_method.cpp
+++ b/be/src/udf/java/java_native_method.cpp
@@ -12,9 +12,9 @@
 
 namespace starrocks::vectorized {
 
-class getColumnAddrVistor : public ColumnVisitorAdapter<getColumnAddrVistor> {
+class GetColumnAddrVistor : public ColumnVisitorAdapter<GetColumnAddrVistor> {
 public:
-    getColumnAddrVistor(jlong* jarr) : ColumnVisitorAdapter(this), _jarr(jarr) {}
+    GetColumnAddrVistor(jlong* jarr) : ColumnVisitorAdapter(this), _jarr(jarr) {}
 
     Status do_visit(const NullableColumn& column) {
         const auto& null_data = column.immutable_null_column_data();
@@ -62,7 +62,7 @@ jlongArray JavaNativeMethods::getAddrs(JNIEnv* env, jclass clazz, jlong columnAd
     int array_size = 3;
     auto jarr = env->NewLongArray(array_size);
     jlong array[array_size];
-    getColumnAddrVistor vistor(array);
+    GetColumnAddrVistor vistor(array);
     column->accept(&vistor);
     env->SetLongArrayRegion(jarr, 0, array_size, array);
     return jarr;

--- a/be/src/udf/java/java_native_method.h
+++ b/be/src/udf/java/java_native_method.h
@@ -1,0 +1,19 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021 StarRocks Limited.
+
+#include <jni.h>
+
+#pragma once
+
+namespace starrocks::vectorized {
+
+// Some native implementations of JavaUDF, mainly for calling some C++ functions in Java functions
+// For example, calling Column::resize in Java function
+//
+struct JavaNativeMethods {
+    // call BinaryColumn::bytes::resize
+    static jlong resizeStringData(JNIEnv* env, jclass clazz, jlong columnAddr, jint byteSize);
+    // get native addrs
+    // for nullable column [null_array_start, data_array_start]
+    static jlongArray getAddrs(JNIEnv* env, jclass clazz, jlong columnAddr);
+};
+} // namespace starrocks::vectorized

--- a/be/src/udf/java/java_udf.cpp
+++ b/be/src/udf/java/java_udf.cpp
@@ -17,6 +17,7 @@
 #include "fmt/core.h"
 #include "jni.h"
 #include "runtime/primitive_type.h"
+#include "udf/java/java_native_method.h"
 #include "udf/udf.h"
 #include "util/defer_op.h"
 
@@ -43,6 +44,14 @@
 namespace starrocks::vectorized {
 
 constexpr const char* CLASS_UDF_HELPER_NAME = "com.starrocks.udf.UDFHelper";
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wwrite-strings"
+static JNINativeMethod java_native_methods[] = {
+        {"resizeStringData", "(JI)J", (void*)&JavaNativeMethods::resizeStringData},
+        {"getAddrs", "(J)[J", (void*)&JavaNativeMethods::getAddrs},
+};
+#pragma GCC diagnostic pop
 
 // local object reference guard.
 // The objects inside are automatically call DeleteLocalRef in the life object.
@@ -101,6 +110,10 @@ void JVMFunctionHelper::_init() {
 
     std::string name = JVMFunctionHelper::to_jni_class_name(CLASS_UDF_HELPER_NAME);
     _udf_helper_class = _env->FindClass(name.c_str());
+    DCHECK(_udf_helper_class != nullptr);
+    int res = _env->RegisterNatives(_udf_helper_class, java_native_methods,
+                                    sizeof(java_native_methods) / sizeof(java_native_methods[0]));
+    DCHECK_EQ(res, 0);
     _create_boxed_array = _env->GetStaticMethodID(_udf_helper_class, "createBoxedArray",
                                                   "(IIZ[Ljava/nio/ByteBuffer;)[Ljava/lang/Object;");
 
@@ -116,10 +129,13 @@ void JVMFunctionHelper::_init() {
                                                   "(Ljava/lang/Object;Ljava/lang/reflect/Method;I)[Ljava/lang/Object;");
     _int_batch_call = _env->GetStaticMethodID(_udf_helper_class, "batchCall",
                                               "([Ljava/lang/Object;Ljava/lang/reflect/Method;I)[I");
+    _get_boxed_result =
+            _env->GetStaticMethodID(_udf_helper_class, "getResultFromBoxedArray", "(IILjava/lang/Object;J)V");
     _direct_buffer_class = _env->FindClass("java/nio/ByteBuffer");
     _direct_buffer_clear = _env->GetMethodID(_direct_buffer_class, "clear", "()Ljava/nio/Buffer;");
     DCHECK(_batch_call);
     DCHECK(_batch_call_no_args);
+    DCHECK(_get_boxed_result);
     DCHECK(_direct_buffer_clear);
 
     _list_get = _env->GetMethodID(_list_class, "get", "(I)Ljava/lang/Object;");
@@ -186,6 +202,7 @@ void JVMFunctionHelper::check_call_exception(JNIEnv* env, FunctionContext* ctx) 
     }
 
 std::string JVMFunctionHelper::array_to_string(jobject object) {
+    _env->ExceptionClear();
     std::string value;
     jmethodID arrayToStringMethod =
             _env->GetStaticMethodID(_jarrays_class, "toString", "([Ljava/lang/Object;)Ljava/lang/String;");
@@ -198,6 +215,7 @@ std::string JVMFunctionHelper::array_to_string(jobject object) {
 }
 
 std::string JVMFunctionHelper::to_string(jobject obj) {
+    _env->ExceptionClear();
     std::string value;
     auto method = getToStringMethod(_object_class);
     auto res = _env->CallObjectMethod(obj, method);
@@ -306,6 +324,14 @@ jobject JVMFunctionHelper::int_batch_call(FunctionContext* ctx, jobject callers,
     auto res = _env->CallStaticObjectMethod(_udf_helper_class, _int_batch_call, callers, method, rows);
     check_call_exception(_env, ctx);
     return res;
+}
+
+void JVMFunctionHelper::get_result_from_boxed_array(FunctionContext* ctx, int type, Column* col, jobject jcolumn,
+                                                    int rows) {
+    col->resize(rows);
+    _env->CallStaticVoidMethod(_udf_helper_class, _get_boxed_result, type, rows, jcolumn,
+                               reinterpret_cast<int64_t>(col));
+    check_call_exception(_env, ctx);
 }
 
 jobject JVMFunctionHelper::list_get(jobject obj, int idx) {

--- a/be/src/udf/java/java_udf.h
+++ b/be/src/udf/java/java_udf.h
@@ -69,6 +69,11 @@ public:
     // return: jobject int[]
     jobject int_batch_call(FunctionContext* ctx, jobject callers, jobject method, int rows);
 
+    // type: PrimitiveType
+    // col: result column
+    // jcolumn: Integer[]/String[]
+    void get_result_from_boxed_array(FunctionContext* ctx, int type, Column* col, jobject jcolumn, int rows);
+
     // List methods
     jobject list_get(jobject obj, int idx);
     int list_size(jobject obj);
@@ -138,6 +143,7 @@ private:
     jmethodID _batch_call;
     jmethodID _batch_call_no_args;
     jmethodID _int_batch_call;
+    jmethodID _get_boxed_result;
     jclass _direct_buffer_class;
     jmethodID _direct_buffer_clear;
 };

--- a/gensrc/java/com/starrocks/udf/UDFHelper.java
+++ b/gensrc/java/com/starrocks/udf/UDFHelper.java
@@ -73,7 +73,7 @@ public class UDFHelper {
         // memcpy to uint8_t array
         unsafe.copyMemory(nulls, byteArrayBaseOffset, null, addrs[0], numRows);
         // memcpy to int array
-        unsafe.copyMemory(dataArr, intArrayBaseOffset, null, addrs[1], numRows);
+        unsafe.copyMemory(dataArr, byteArrayBaseOffset, null, addrs[1], numRows);
     }
 
     private static void getByteBoxedResult(int numRows, Byte[] boxedArr, long columnAddr) {
@@ -91,7 +91,7 @@ public class UDFHelper {
         // memcpy to uint8_t array
         unsafe.copyMemory(nulls, byteArrayBaseOffset, null, addrs[0], numRows);
         // memcpy to int array
-        unsafe.copyMemory(dataArr, intArrayBaseOffset, null, addrs[1], numRows);
+        unsafe.copyMemory(dataArr, byteArrayBaseOffset, null, addrs[1], numRows);
     }
 
     private static void getShortBoxedResult(int numRows, Short[] boxedArr, long columnAddr) {
@@ -109,7 +109,7 @@ public class UDFHelper {
         // memcpy to uint8_t array
         unsafe.copyMemory(nulls, byteArrayBaseOffset, null, addrs[0], numRows);
         // memcpy to int array
-        unsafe.copyMemory(dataArr, intArrayBaseOffset, null, addrs[1], numRows * 2L);
+        unsafe.copyMemory(dataArr, shortArrayBaseOffset, null, addrs[1], numRows * 2L);
     }
 
     // getIntBoxedResult
@@ -147,7 +147,7 @@ public class UDFHelper {
         // memcpy to uint8_t array
         unsafe.copyMemory(nulls, byteArrayBaseOffset, null, addrs[0], numRows);
         // memcpy to int array
-        unsafe.copyMemory(dataArr, intArrayBaseOffset, null, addrs[1], numRows * 8L);
+        unsafe.copyMemory(dataArr, longArrayBaseOffset, null, addrs[1], numRows * 8L);
     }
 
     private static void getFloatBoxedResult(int numRows, Float[] boxedArr, long columnAddr) {
@@ -165,7 +165,7 @@ public class UDFHelper {
         // memcpy to uint8_t array
         unsafe.copyMemory(nulls, byteArrayBaseOffset, null, addrs[0], numRows);
         // memcpy to int array
-        unsafe.copyMemory(dataArr, intArrayBaseOffset, null, addrs[1], numRows * 4L);
+        unsafe.copyMemory(dataArr, floatArrayBaseOffset, null, addrs[1], numRows * 4L);
     }
 
     private static void getDoubleBoxedResult(int numRows, Double[] boxedArr, long columnAddr) {
@@ -183,7 +183,7 @@ public class UDFHelper {
         // memcpy to uint8_t array
         unsafe.copyMemory(nulls, byteArrayBaseOffset, null, addrs[0], numRows);
         // memcpy to int array
-        unsafe.copyMemory(dataArr, intArrayBaseOffset, null, addrs[1], numRows * 8L);
+        unsafe.copyMemory(dataArr, doubleArrayBaseOffset, null, addrs[1], numRows * 8L);
     }
 
     private static void getStringBoxedResult(int numRows, String[] column, long columnAddr) {

--- a/gensrc/java/com/starrocks/udf/UDFHelper.java
+++ b/gensrc/java/com/starrocks/udf/UDFHelper.java
@@ -2,6 +2,10 @@
 
 package com.starrocks.udf;
 
+import sun.misc.Unsafe;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.IntBuffer;
@@ -22,6 +26,96 @@ public class UDFHelper {
     public static final int TYPE_VARCHAR = 10;
     public static final int TYPE_DATETIME = 12;
     public static final int TYPE_ARRAY = 15;
+
+    // return byteAddr
+    public static native long resizeStringData(long columnAddr, int byteSize);
+    // [nullAddr, dataAddr]
+    public static native long[] getAddrs(long columnAddr);
+
+    private static Unsafe unsafe;
+    private static long byteArrayBaseOffset;
+    private static long intArrayBaseOffset;
+    private static long longArrayBaseOffset;
+    private static final byte[] emptyBytes = new byte[0];
+
+    static {
+        Field f = null;
+        try {
+            f = Unsafe.class.getDeclaredField("theUnsafe");
+            f.setAccessible(true);
+            unsafe = (Unsafe) f.get(null);
+            byteArrayBaseOffset =  (long) unsafe.arrayBaseOffset(byte[].class);
+            intArrayBaseOffset = (long) unsafe.arrayBaseOffset(int[].class);
+            longArrayBaseOffset = (long) unsafe.arrayBaseOffset(long[].class);
+        } catch (NoSuchFieldException | IllegalAccessException ignored) {
+        }
+    }
+
+    // getIntBoxedResult
+    private static void getIntBoxedResult(int numRows, Integer[] boxedArr, long columnAddr) {
+        byte[] nulls = new byte[numRows];
+        int[] dataArr = new int[numRows];
+        for (int i = 0; i < numRows; i++) {
+            if (boxedArr[i] == null) {
+                nulls[i] = 1;
+            } else {
+                dataArr[i] = boxedArr[i];
+            }
+        }
+
+        final long[] addrs = getAddrs(columnAddr);
+        // memcpy to uint8_t array
+        unsafe.copyMemory(nulls, byteArrayBaseOffset, null, addrs[0], numRows);
+        // memcpy to int array
+        unsafe.copyMemory(dataArr, intArrayBaseOffset, null, addrs[1], numRows * 4L);
+    }
+
+    private static void getStringBoxedResult(int numRows, String[] column, long columnAddr) {
+        byte[] nulls = new byte[numRows];
+        int[] offsets = new int[numRows];
+        byte[][] byteRes = new byte[numRows][];
+        int offset = 0;
+        for (int i = 0; i < column.length; i++) {
+            if (column[i] == null) {
+                byteRes[i] = emptyBytes;
+                nulls[i] = 1;
+            } else {
+                byteRes[i] = column[i].getBytes(StandardCharsets.UTF_8);
+            }
+            offset +=  byteRes[i].length;
+            offsets[i] = offset;
+        }
+        byte[] bytes = new byte[offsets[numRows - 1]];
+        int dst = 0;
+        for (int i = 0; i < numRows; i++) {
+            for (int j = 0; j < byteRes[i].length; j++) {
+                bytes[dst++] = byteRes[i][j];
+            }
+        }
+        final long bytesAddr = resizeStringData(columnAddr, offsets[numRows - 1]);
+        final long[] addrs = getAddrs(columnAddr);
+        unsafe.copyMemory(nulls, byteArrayBaseOffset, null, addrs[0], numRows);
+
+        unsafe.copyMemory(offsets, intArrayBaseOffset, null, addrs[1] + 4, numRows * 4L);
+
+        unsafe.copyMemory(bytes, byteArrayBaseOffset, null, bytesAddr, offsets[numRows - 1]);
+    }
+
+    public static void getResultFromBoxedArray(int type, int numRows, Object boxedResult, long columnAddr) {
+        switch (type) {
+            case TYPE_INT: {
+                getIntBoxedResult(numRows, (Integer[]) boxedResult, columnAddr);
+                break;
+            }
+            case TYPE_VARCHAR: {
+                getStringBoxedResult(numRows, (String[]) boxedResult, columnAddr);
+                break;
+            }
+            default:
+                throw new UnsupportedOperationException("unsupported type:" + type);
+        }
+    }
+
 
     // create boxed array
     //
@@ -305,7 +399,8 @@ public class UDFHelper {
             throws Throwable {
         Object[][] inputs = (Object[][]) column;
         Object[] parameter = new Object[inputs.length];
-        Object[] res = new Object[batchSize];
+        Object[] res = (Object[]) Array.newInstance(method.getReturnType() ,batchSize);
+
         try {
             for (int i = 0; i < batchSize; ++i) {
                 for (int j = 0; j < column.length; ++j) {

--- a/gensrc/java/com/starrocks/udf/UDFHelper.java
+++ b/gensrc/java/com/starrocks/udf/UDFHelper.java
@@ -29,6 +29,7 @@ public class UDFHelper {
 
     // return byteAddr
     public static native long resizeStringData(long columnAddr, int byteSize);
+
     // [nullAddr, dataAddr]
     public static native long[] getAddrs(long columnAddr);
 
@@ -47,11 +48,11 @@ public class UDFHelper {
             f = Unsafe.class.getDeclaredField("theUnsafe");
             f.setAccessible(true);
             unsafe = (Unsafe) f.get(null);
-            byteArrayBaseOffset =  (long) unsafe.arrayBaseOffset(byte[].class);
+            byteArrayBaseOffset = (long) unsafe.arrayBaseOffset(byte[].class);
             intArrayBaseOffset = (long) unsafe.arrayBaseOffset(int[].class);
             shortArrayBaseOffset = (long) unsafe.arrayBaseOffset(short[].class);
             longArrayBaseOffset = (long) unsafe.arrayBaseOffset(long[].class);
-            floatArrayBaseOffset = (long)unsafe.arrayBaseOffset(float[].class);
+            floatArrayBaseOffset = (long) unsafe.arrayBaseOffset(float[].class);
             doubleArrayBaseOffset = (long) unsafe.arrayBaseOffset(double[].class);
         } catch (NoSuchFieldException | IllegalAccessException ignored) {
         }
@@ -64,7 +65,7 @@ public class UDFHelper {
             if (boxedArr[i] == null) {
                 nulls[i] = 1;
             } else {
-                dataArr[i] = (byte) (boxedArr[i]?1:0);
+                dataArr[i] = (byte) (boxedArr[i] ? 1 : 0);
             }
         }
 
@@ -197,7 +198,7 @@ public class UDFHelper {
             } else {
                 byteRes[i] = column[i].getBytes(StandardCharsets.UTF_8);
             }
-            offset +=  byteRes[i].length;
+            offset += byteRes[i].length;
             offsets[i] = offset;
         }
         byte[] bytes = new byte[offsets[numRows - 1]];
@@ -223,7 +224,7 @@ public class UDFHelper {
                 break;
             }
             case TYPE_TINYINT: {
-                getByteBoxedResult(numRows, (Byte[])boxedResult, columnAddr);
+                getByteBoxedResult(numRows, (Byte[]) boxedResult, columnAddr);
                 break;
             }
             case TYPE_SMALLINT: {
@@ -235,7 +236,7 @@ public class UDFHelper {
                 break;
             }
             case TYPE_FLOAT: {
-                getFloatBoxedResult(numRows, (Float[])boxedResult, columnAddr);
+                getFloatBoxedResult(numRows, (Float[]) boxedResult, columnAddr);
                 break;
             }
             case TYPE_DOUBLE: {
@@ -243,7 +244,7 @@ public class UDFHelper {
                 break;
             }
             case TYPE_BIGINT: {
-                getBigIntBoxedResult(numRows, (Long[])boxedResult, columnAddr);
+                getBigIntBoxedResult(numRows, (Long[]) boxedResult, columnAddr);
                 break;
             }
             case TYPE_VARCHAR: {
@@ -254,7 +255,6 @@ public class UDFHelper {
                 throw new UnsupportedOperationException("unsupported type:" + type);
         }
     }
-
 
     // create boxed array
     //
@@ -538,7 +538,7 @@ public class UDFHelper {
             throws Throwable {
         Object[][] inputs = (Object[][]) column;
         Object[] parameter = new Object[inputs.length];
-        Object[] res = (Object[]) Array.newInstance(method.getReturnType() ,batchSize);
+        Object[] res = (Object[]) Array.newInstance(method.getReturnType(), batchSize);
 
         try {
             for (int i = 0; i < batchSize; ++i) {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
#5803

## Problem Summary(Required) ：
reduce JNI call when get result from Java Array.

ENV: 1FE 3BE parallel=4
```
mysql> select count(udf_add(lo_orderdate,lo_orderkey)) from lineorder_flat_new;
+-------------------------------------------+
| count(udf_add(lo_orderdate, lo_orderkey)) |
+-------------------------------------------+
|                                 600037902 |
+-------------------------------------------+
1 row in set (1.98 sec)
```
baseline: timeout
patch: 1.98
