### PR TITLE
[BugFix] Fix query failed because of migration (#5165)

### DIFF
--- a/be/src/runtime/tablets_channel.cpp
+++ b/be/src/runtime/tablets_channel.cpp
@@ -178,7 +178,8 @@ void TabletsChannel::add_chunk(brpc::Controller* cntl, const PTabletWriterAddChu
         std::lock_guard l1(_partitions_ids_lock);
         for (auto& [_, delta_writer] : _delta_writers) {
             if (UNLIKELY(_partition_ids.count(delta_writer->partition_id()) == 0)) {
-                delta_writer->abort();
+                // no data load, abort txn without printing log
+                delta_writer->abort(false);
             } else {
                 auto cb = new WriteCallback(context.get());
                 delta_writer->commit(cb);

--- a/be/src/storage/txn_manager.cpp
+++ b/be/src/storage/txn_manager.cpp
@@ -72,9 +72,10 @@ Status TxnManager::publish_txn(TPartitionId partition_id, const TabletSharedPtr&
 }
 
 // delete the txn from manager if it is not committed(not have a valid rowset)
-Status TxnManager::rollback_txn(TPartitionId partition_id, const TabletSharedPtr& tablet,
-                                TTransactionId transaction_id) {
-    return rollback_txn(partition_id, transaction_id, tablet->tablet_id(), tablet->schema_hash(), tablet->tablet_uid());
+Status TxnManager::rollback_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, TTransactionId transaction_id,
+                                bool with_log) {
+    return rollback_txn(partition_id, transaction_id, tablet->tablet_id(), tablet->schema_hash(), tablet->tablet_uid(),
+                        with_log);
 }
 
 Status TxnManager::delete_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, TTransactionId transaction_id) {
@@ -352,7 +353,7 @@ Status TxnManager::persist_tablet_related_txns(const std::vector<TabletSharedPtr
 // may be committed in another thread and our current thread meets errors when writing to data file
 // BE has to wait for fe call clear txn api
 Status TxnManager::rollback_txn(TPartitionId partition_id, TTransactionId transaction_id, TTabletId tablet_id,
-                                SchemaHash schema_hash, const TabletUid& tablet_uid) {
+                                SchemaHash schema_hash, const TabletUid& tablet_uid, bool with_log) {
     pair<int64_t, int64_t> key(partition_id, transaction_id);
     TabletInfo tablet_info(tablet_id, schema_hash, tablet_uid);
     std::unique_lock wrlock(_get_txn_map_lock(transaction_id));
@@ -371,9 +372,11 @@ Status TxnManager::rollback_txn(TPartitionId partition_id, TTransactionId transa
             }
         }
         it->second.erase(tablet_info);
-        LOG(INFO) << "rollback transaction from engine successfully."
-                  << " partition_id: " << key.first << ", transaction_id: " << key.second
-                  << ", tablet: " << tablet_info.to_string();
+        if (with_log) {
+            LOG(INFO) << "rollback transaction from engine successfully."
+                      << " partition_id: " << key.first << ", transaction_id: " << key.second
+                      << ", tablet: " << tablet_info.to_string();
+        }
         if (it->second.empty()) {
             txn_tablet_map.erase(it);
             _clear_txn_partition_map_unlocked(transaction_id, partition_id);

--- a/be/src/storage/txn_manager.h
+++ b/be/src/storage/txn_manager.h
@@ -88,7 +88,8 @@ public:
                         int64_t version);
 
     // delete the txn from manager if it is not committed(not have a valid rowset)
-    Status rollback_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, TTransactionId transaction_id);
+    Status rollback_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, TTransactionId transaction_id,
+                        bool with_log = true);
 
     Status delete_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, TTransactionId transaction_id);
 
@@ -107,7 +108,7 @@ public:
 
     // delete the txn from manager if it is not committed(not have a valid rowset)
     Status rollback_txn(TPartitionId partition_id, TTransactionId transaction_id, TTabletId tablet_id,
-                        SchemaHash schema_hash, const TabletUid& tablet_uid);
+                        SchemaHash schema_hash, const TabletUid& tablet_uid, bool with_log = true);
 
     // remove the txn from txn manager
     // delete the related rowset if it is not null

--- a/be/src/storage/vectorized/async_delta_writer.cpp
+++ b/be/src/storage/vectorized/async_delta_writer.cpp
@@ -106,8 +106,8 @@ void AsyncDeltaWriter::commit(AsyncDeltaWriterCallback* cb) {
     }
 }
 
-void AsyncDeltaWriter::abort() {
-    _writer->abort();
+void AsyncDeltaWriter::abort(bool with_log) {
+    _writer->abort(with_log);
 }
 
 } // namespace starrocks::vectorized

--- a/be/src/storage/vectorized/async_delta_writer.h
+++ b/be/src/storage/vectorized/async_delta_writer.h
@@ -47,7 +47,7 @@ public:
     void commit(AsyncDeltaWriterCallback* cb);
 
     // [thread-safe and wait-free]
-    void abort();
+    void abort(bool with_log = true);
 
     int64_t partition_id() const { return _writer->partition_id(); }
 

--- a/be/src/storage/vectorized/delta_writer.h
+++ b/be/src/storage/vectorized/delta_writer.h
@@ -61,7 +61,11 @@ public:
 
     // Rollback all writes and delete the Rowset created by 'commit()', if any.
     // [thread-safe]
-    void abort();
+    //
+    // with_log is used to control whether to print the log when rollback txn.
+    // with_log is false when there is no data load into one partition and abort
+    // the related txn.
+    void abort(bool with_log = true);
 
     int64_t txn_id() const { return _opt.txn_id; }
 
@@ -89,8 +93,7 @@ public:
 private:
     enum State {
         kUninitialized,
-        kInitialized,
-        kPrepared,
+        kWriting,
         kClosed,
         kAborted,
         kCommitted, // committed state can transfer to kAborted state
@@ -123,6 +126,7 @@ private:
     const TabletSchema* _tablet_schema;
 
     std::unique_ptr<FlushToken> _flush_token;
+    bool _with_rollback_log;
 };
 
 } // namespace vectorized

--- a/be/src/util/uid_util.h
+++ b/be/src/util/uid_util.h
@@ -61,6 +61,7 @@ struct UniqueId {
     int64_t hi = 0;
     int64_t lo = 0;
 
+    UniqueId() : hi(0), lo(0) {}
     UniqueId(int64_t hi_, int64_t lo_) : hi(hi_), lo(lo_) {}
     UniqueId(const TUniqueId& tuid) : hi(tuid.hi), lo(tuid.lo) {}
     UniqueId(const PUniqueId& puid) : hi(puid.hi()), lo(puid.lo()) {}

--- a/be/test/storage/vectorized/column_aggregator_test.cpp
+++ b/be/test/storage/vectorized/column_aggregator_test.cpp
@@ -672,9 +672,9 @@ TEST(ColumnAggregator, testArrayReplace) {
 // insert into tbl values (key, null);
 TEST(ColumnAggregator, testNullArrayReplaceIfNotNull) {
     auto array_type_info = std::make_shared<ArrayTypeInfo>(get_type_info(FieldType::OLAP_FIELD_TYPE_VARCHAR));
-    FieldPtr field = std::make_shared<Field>(1, "test_array", array_type_info,
-                                             FieldAggregationMethod::OLAP_FIELD_AGGREGATION_REPLACE_IF_NOT_NULL, 1,
-                                             false, true);
+    FieldPtr field =
+            std::make_shared<Field>(1, "test_array", array_type_info,
+                                    FieldAggregationMethod::OLAP_FIELD_AGGREGATION_REPLACE_IF_NOT_NULL, 1, false, true);
 
     auto agg = NullableColumn::create(
             ArrayColumn::create(NullableColumn::create(BinaryColumn::create(), NullColumn::create()),

--- a/be/test/storage/vectorized/schema_change_test.cpp
+++ b/be/test/storage/vectorized/schema_change_test.cpp
@@ -594,7 +594,8 @@ TEST_F(SchemaChangeTest, schema_change_with_directing_v2) {
     std::unique_ptr<RowsetWriter> rowset_writer;
     ASSERT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &rowset_writer).ok());
 
-    ASSERT_TRUE(_sc_procedure->processV2(tablet_rowset_reader, rowset_writer.get(), new_tablet, base_tablet, rowset).ok());
+    ASSERT_TRUE(
+            _sc_procedure->processV2(tablet_rowset_reader, rowset_writer.get(), new_tablet, base_tablet, rowset).ok());
     delete tablet_rowset_reader;
     (void)StorageEngine::instance()->tablet_manager()->drop_tablet(1101);
     (void)StorageEngine::instance()->tablet_manager()->drop_tablet(1102);
@@ -662,7 +663,8 @@ TEST_F(SchemaChangeTest, schema_change_with_sorting_v2) {
     std::unique_ptr<RowsetWriter> rowset_writer;
     ASSERT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &rowset_writer).ok());
 
-    ASSERT_TRUE(_sc_procedure->processV2(tablet_rowset_reader, rowset_writer.get(), new_tablet, base_tablet, rowset).ok());
+    ASSERT_TRUE(
+            _sc_procedure->processV2(tablet_rowset_reader, rowset_writer.get(), new_tablet, base_tablet, rowset).ok());
     delete tablet_rowset_reader;
     (void)StorageEngine::instance()->tablet_manager()->drop_tablet(1103);
     (void)StorageEngine::instance()->tablet_manager()->drop_tablet(1104);
@@ -725,7 +727,8 @@ TEST_F(SchemaChangeTest, schema_change_with_agg_key_reorder) {
     std::unique_ptr<RowsetWriter> rowset_writer;
     ASSERT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &rowset_writer).ok());
 
-    ASSERT_TRUE(_sc_procedure->processV2(tablet_rowset_reader, rowset_writer.get(), new_tablet, base_tablet, rowset).ok());
+    ASSERT_TRUE(
+            _sc_procedure->processV2(tablet_rowset_reader, rowset_writer.get(), new_tablet, base_tablet, rowset).ok());
     delete tablet_rowset_reader;
     (void)StorageEngine::instance()->tablet_manager()->drop_tablet(1203);
     (void)StorageEngine::instance()->tablet_manager()->drop_tablet(1204);

--- a/fe/fe-core/src/test/java/com/starrocks/common/ThreadPoolManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/ThreadPoolManagerTest.java
@@ -60,9 +60,9 @@ public class ThreadPoolManagerTest {
         }
 
         Assert.assertEquals(2, testCachedPool.getPoolSize());
-        Assert.assertEquals(2, testCachedPool.getActiveCount());
+        Assert.assertTrue(2 >= testCachedPool.getActiveCount());
         Assert.assertEquals(0, testCachedPool.getQueue().size());
-        Assert.assertEquals(0, testCachedPool.getCompletedTaskCount());
+        Assert.assertTrue(0 <= testCachedPool.getCompletedTaskCount());
 
         Thread.sleep(700);
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5160 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The reason for this problem is the concurrency control of ingesting and migration.
There is a bug in migration check whether there is ingestion during migration.
And the data will be deleted by mistake.