### PR TITLE
[Enhancement] merge compaction trace configuration (#5805)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -288,9 +288,7 @@ CONF_mInt64(min_compaction_failure_interval_sec, "120"); // 2 min
 CONF_Int32(max_compaction_concurrency, "-1");
 
 // Threshold to logging compaction trace, in seconds.
-CONF_mInt32(base_compaction_trace_threshold, "120");
-CONF_mInt32(cumulative_compaction_trace_threshold, "60");
-CONF_mInt32(update_compaction_trace_threshold, "20");
+CONF_mInt32(compaction_trace_threshold, "60");
 
 // Max columns of each compaction group.
 // If the number of schema columns is greater than this,

--- a/be/src/storage/compaction_task.cpp
+++ b/be/src/storage/compaction_task.cpp
@@ -20,8 +20,7 @@ void CompactionTask::run() {
     scoped_refptr<Trace> trace(new Trace);
     SCOPED_CLEANUP({
         uint64_t time_s = _watch.elapsed_time() / 1e9;
-        if ((compaction_type() == CUMULATIVE_COMPACTION && time_s > config::cumulative_compaction_trace_threshold) ||
-            (compaction_type() == BASE_COMPACTION && time_s > config::base_compaction_trace_threshold)) {
+        if (time_s > config::compaction_trace_threshold) {
             LOG(INFO) << "Trace:" << std::endl << trace->DumpToString(Trace::INCLUDE_ALL);
         }
     });

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -611,7 +611,7 @@ Status StorageEngine::_perform_cumulative_compaction(DataDir* data_dir) {
     MonotonicStopWatch watch;
     watch.start();
     SCOPED_CLEANUP({
-        if (watch.elapsed_time() / 1e9 > config::cumulative_compaction_trace_threshold) {
+        if (watch.elapsed_time() / 1e9 > config::compaction_trace_threshold) {
             LOG(INFO) << "Trace:" << std::endl << trace->DumpToString(Trace::INCLUDE_ALL);
         }
     });
@@ -652,7 +652,7 @@ Status StorageEngine::_perform_base_compaction(DataDir* data_dir) {
     MonotonicStopWatch watch;
     watch.start();
     SCOPED_CLEANUP({
-        if (watch.elapsed_time() / 1e9 > config::base_compaction_trace_threshold) {
+        if (watch.elapsed_time() / 1e9 > config::compaction_trace_threshold) {
             LOG(INFO) << "Trace:" << std::endl << trace->DumpToString(Trace::INCLUDE_ALL);
         }
     });
@@ -691,7 +691,7 @@ Status StorageEngine::_perform_update_compaction(DataDir* data_dir) {
     MonotonicStopWatch watch;
     watch.start();
     SCOPED_CLEANUP({
-        if (watch.elapsed_time() / 1e9 > config::update_compaction_trace_threshold) {
+        if (watch.elapsed_time() / 1e9 > config::compaction_trace_threshold) {
             LOG(WARNING) << "Trace:" << std::endl << trace->DumpToString(Trace::INCLUDE_ALL);
         }
     });


### PR DESCRIPTION
Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5805 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

We don't need to set a separate configuration item for each type of compaction,
here we can merge three trace compaction configurations
```c++
CONF_mInt32(base_compaction_trace_threshold, "120");
CONF_mInt32(cumulative_compaction_trace_threshold, "60");
CONF_mInt32(update_compaction_trace_threshold, "20");
```

into one trace compaction configuration
```c++
CONF_mInt32(compaction_trace_threshold, "60");
```
