### PR TITLE
[Enhancement] Add _found_partition_end for Analytor

### DIFF
--- a/be/src/exec/pipeline/analysis/analytic_sink_operator.cpp
+++ b/be/src/exec/pipeline/analysis/analytic_sink_operator.cpp
@@ -99,18 +99,18 @@ Status AnalyticSinkOperator::_process_by_partition_if_necessary() {
             return Status::OK();
         }
 
-        int64_t found_partition_end = _analytor->find_partition_end();
+        _analytor->find_partition_end();
         // Only process after all the data in a partition is reached
-        if (!_analytor->is_partition_finished(found_partition_end)) {
+        if (!_analytor->is_partition_finished()) {
             return Status::OK();
         }
 
         size_t chunk_size = _analytor->input_chunks()[_analytor->output_chunk_index()]->num_rows();
         _analytor->create_agg_result_columns(chunk_size);
 
-        bool is_new_partition = _analytor->is_new_partition(found_partition_end);
+        bool is_new_partition = _analytor->is_new_partition();
         if (is_new_partition) {
-            _analytor->reset_state_for_new_partition(found_partition_end);
+            _analytor->reset_state_for_new_partition();
         }
 
         (this->*_process_by_partition)(chunk_size, is_new_partition);

--- a/be/src/exec/vectorized/analytic_node.cpp
+++ b/be/src/exec/vectorized/analytic_node.cpp
@@ -114,17 +114,16 @@ Status AnalyticNode::close(RuntimeState* state) {
 
 Status AnalyticNode::_get_next_for_unbounded_frame(RuntimeState* state, ChunkPtr* chunk, bool* eos) {
     while (!_analytor->input_eos() || _analytor->output_chunk_index() < _analytor->input_chunks().size()) {
-        int64_t found_partition_end = 0;
-        RETURN_IF_ERROR(_try_fetch_next_partition_data(state, &found_partition_end));
+        RETURN_IF_ERROR(_try_fetch_next_partition_data(state));
         if (_analytor->input_eos() && _analytor->input_rows() == 0) {
             *eos = true;
             return Status::OK();
         }
         SCOPED_TIMER(_analytor->compute_timer());
 
-        bool is_new_partition = _analytor->is_new_partition(found_partition_end);
+        bool is_new_partition = _analytor->is_new_partition();
         if (is_new_partition) {
-            _analytor->reset_state_for_new_partition(found_partition_end);
+            _analytor->reset_state_for_new_partition();
         }
 
         size_t chunk_size = _analytor->input_chunks()[_analytor->output_chunk_index()]->num_rows();
@@ -157,8 +156,7 @@ Status AnalyticNode::_get_next_for_unbounded_frame(RuntimeState* state, ChunkPtr
 
 Status AnalyticNode::_get_next_for_unbounded_preceding_range_frame(RuntimeState* state, ChunkPtr* chunk, bool* eos) {
     while (!_analytor->input_eos() || _analytor->output_chunk_index() < _analytor->input_chunks().size()) {
-        int64_t found_partition_end = 0;
-        RETURN_IF_ERROR(_try_fetch_next_partition_data(state, &found_partition_end));
+        RETURN_IF_ERROR(_try_fetch_next_partition_data(state));
         if (_analytor->input_eos() && _analytor->input_rows() == 0) {
             *eos = true;
             return Status::OK();
@@ -166,9 +164,9 @@ Status AnalyticNode::_get_next_for_unbounded_preceding_range_frame(RuntimeState*
 
         SCOPED_TIMER(_analytor->compute_timer());
 
-        bool is_new_partition = _analytor->is_new_partition(found_partition_end);
+        bool is_new_partition = _analytor->is_new_partition();
         if (is_new_partition) {
-            _analytor->reset_state_for_new_partition(found_partition_end);
+            _analytor->reset_state_for_new_partition();
         }
 
         size_t chunk_size = _analytor->input_chunks()[_analytor->output_chunk_index()]->num_rows();
@@ -208,17 +206,16 @@ Status AnalyticNode::_get_next_for_unbounded_preceding_range_frame(RuntimeState*
 
 Status AnalyticNode::_get_next_for_sliding_frame(RuntimeState* state, ChunkPtr* chunk, bool* eos) {
     while (!_analytor->input_eos() || _analytor->output_chunk_index() < _analytor->input_chunks().size()) {
-        int64_t found_partition_end = 0;
-        RETURN_IF_ERROR(_try_fetch_next_partition_data(state, &found_partition_end));
+        RETURN_IF_ERROR(_try_fetch_next_partition_data(state));
         if (_analytor->input_eos() && _analytor->input_rows() == 0) {
             *eos = true;
             return Status::OK();
         }
         SCOPED_TIMER(_analytor->compute_timer());
 
-        bool is_new_partition = _analytor->is_new_partition(found_partition_end);
+        bool is_new_partition = _analytor->is_new_partition();
         if (is_new_partition) {
-            _analytor->reset_state_for_new_partition(found_partition_end);
+            _analytor->reset_state_for_new_partition();
         }
 
         size_t chunk_size = _analytor->input_chunks()[_analytor->output_chunk_index()]->num_rows();
@@ -248,8 +245,7 @@ Status AnalyticNode::_get_next_for_sliding_frame(RuntimeState* state, ChunkPtr* 
 
 Status AnalyticNode::_get_next_for_unbounded_preceding_rows_frame(RuntimeState* state, ChunkPtr* chunk, bool* eos) {
     while (!_analytor->input_eos() || _analytor->output_chunk_index() < _analytor->input_chunks().size()) {
-        int64_t found_partition_end = 0;
-        RETURN_IF_ERROR(_try_fetch_next_partition_data(state, &found_partition_end));
+        RETURN_IF_ERROR(_try_fetch_next_partition_data(state));
         if (_analytor->input_eos() && _analytor->input_rows() == 0) {
             *eos = true;
             return Status::OK();
@@ -257,9 +253,9 @@ Status AnalyticNode::_get_next_for_unbounded_preceding_rows_frame(RuntimeState* 
 
         SCOPED_TIMER(_analytor->compute_timer());
 
-        bool is_new_partition = _analytor->is_new_partition(found_partition_end);
+        bool is_new_partition = _analytor->is_new_partition();
         if (is_new_partition) {
-            _analytor->reset_state_for_new_partition(found_partition_end);
+            _analytor->reset_state_for_new_partition();
         }
 
         size_t chunk_size = _analytor->input_chunks()[_analytor->output_chunk_index()]->num_rows();
@@ -287,12 +283,12 @@ Status AnalyticNode::_get_next_for_unbounded_preceding_rows_frame(RuntimeState* 
     return Status::OK();
 }
 
-Status AnalyticNode::_try_fetch_next_partition_data(RuntimeState* state, int64_t* partition_end) {
-    *partition_end = _analytor->find_partition_end();
-    while (!_analytor->is_partition_finished(*partition_end)) {
+Status AnalyticNode::_try_fetch_next_partition_data(RuntimeState* state) {
+    _analytor->find_partition_end();
+    while (!_analytor->is_partition_finished()) {
         RETURN_IF_ERROR(state->check_mem_limit("analytic node fetch next partition data"));
         RETURN_IF_ERROR(_fetch_next_chunk(state));
-        *partition_end = _analytor->find_partition_end();
+        _analytor->find_partition_end();
     }
     return Status::OK();
 }

--- a/be/src/exec/vectorized/analytic_node.h
+++ b/be/src/exec/vectorized/analytic_node.h
@@ -42,7 +42,7 @@ private:
     Status (AnalyticNode::*_get_next)(RuntimeState* state, ChunkPtr* chunk, bool* eos) = nullptr;
 
     Status _fetch_next_chunk(RuntimeState* state);
-    Status _try_fetch_next_partition_data(RuntimeState* state, int64_t* partition_end);
+    Status _try_fetch_next_partition_data(RuntimeState* state);
 };
 } // namespace vectorized
 } // namespace starrocks

--- a/be/src/exec/vectorized/analytor.cpp
+++ b/be/src/exec/vectorized/analytor.cpp
@@ -384,19 +384,19 @@ void Analytor::get_window_function_result(int32_t start, int32_t end) {
     }
 }
 
-bool Analytor::is_partition_finished(int64_t found_partition_end) {
+bool Analytor::is_partition_finished() {
     if (_input_eos) {
         return true;
     }
 
     // There is no partition, or it hasn't fetched any chunk.
-    if (_partition_ctxs.empty() || found_partition_end == 0) {
+    if (_partition_ctxs.empty() || _found_partition_end == 0) {
         return false;
     }
 
     // If found_partition_end == _partition_columns[0]->size(),
     // the next chunk maybe also belongs to the current partition.
-    return found_partition_end != _partition_columns[0]->size();
+    return _found_partition_end != _partition_columns[0]->size();
 }
 
 Status Analytor::output_result_chunk(vectorized::ChunkPtr* chunk) {
@@ -471,33 +471,34 @@ void Analytor::append_column(size_t chunk_size, vectorized::Column* dst_column, 
     }
 }
 
-bool Analytor::is_new_partition(int64_t found_partition_end) {
+bool Analytor::is_new_partition() {
     // _current_row_position >= _partition_end : current partition data has been processed
     // _partition_end == 0 : the first partition
     return ((_current_row_position >= _partition_end) &
-            ((_partition_end == 0) | (_partition_end != found_partition_end)));
+            ((_partition_end == 0) | (_partition_end != _found_partition_end)));
 }
 
 int64_t Analytor::get_total_position(int64_t local_position) {
     return _removed_from_buffer_rows + local_position;
 }
 
-int64_t Analytor::find_partition_end() {
+void Analytor::find_partition_end() {
     // current partition data don't consume finished
     if (_current_row_position < _partition_end) {
-        return _partition_end;
+        _found_partition_end = _partition_end;
+        return;
     }
 
     if (_partition_columns.empty() || _input_rows == 0) {
-        return _input_rows;
+        _found_partition_end = _input_rows;
+        return;
     }
 
-    int64_t found_partition_end = _partition_columns[0]->size();
+    _found_partition_end = _partition_columns[0]->size();
     for (size_t i = 0; i < _partition_columns.size(); ++i) {
         vectorized::Column* column = _partition_columns[i].get();
-        found_partition_end = _find_first_not_equal(column, _partition_end, found_partition_end);
+        _found_partition_end = _find_first_not_equal(column, _partition_end, _found_partition_end);
     }
-    return found_partition_end;
 }
 
 void Analytor::find_peer_group_end() {
@@ -516,9 +517,9 @@ void Analytor::find_peer_group_end() {
     }
 }
 
-void Analytor::reset_state_for_new_partition(int64_t found_partition_end) {
+void Analytor::reset_state_for_new_partition() {
     _partition_start = _partition_end;
-    _partition_end = found_partition_end;
+    _partition_end = _found_partition_end;
     _current_row_position = _partition_start;
     reset_window_state();
     DCHECK_GE(_current_row_position, 0);

--- a/be/src/exec/vectorized/analytor.h
+++ b/be/src/exec/vectorized/analytor.h
@@ -160,9 +160,16 @@ private:
     bool _input_eos = false;
 
     int64_t _current_row_position = 0;
+
+    // Record the start pos of current partition
     int64_t _partition_start = 0;
+    // Record the end pos of current partition.
+    // If the end position has not been found during the iteration, _partition_end = _partition_start.
     int64_t _partition_end = 0;
+    // Used to record the first position of the latest Chunk that is not equal to the PartitionKey.
+    // If not found, it points to the last position + 1.
     int64_t _found_partition_end = 0;
+
     // A peer group is all of the rows that are peers within the specified ordering.
     // Rows are peers if they compare equal to each other using the specified ordering expression.
     int64_t _peer_group_start = 0;

--- a/be/src/exec/vectorized/analytor.h
+++ b/be/src/exec/vectorized/analytor.h
@@ -80,6 +80,7 @@ public:
     void update_current_row_position(int64_t increment) { _current_row_position += increment; }
     int64_t partition_start() { return _partition_start; }
     int64_t partition_end() { return _partition_end; }
+    int64_t found_partition_end() { return _found_partition_end; }
     int64_t peer_group_start() { return _peer_group_start; }
     int64_t peer_group_end() { return _peer_group_end; }
 
@@ -101,17 +102,17 @@ public:
     void reset_window_state();
     void get_window_function_result(int32_t start, int32_t end);
 
-    bool is_partition_finished(int64_t found_partition_end);
+    bool is_partition_finished();
     Status output_result_chunk(vectorized::ChunkPtr* chunk);
     size_t compute_memory_usage();
     void create_agg_result_columns(int64_t chunk_size);
     void append_column(size_t chunk_size, vectorized::Column* dst_column, vectorized::ColumnPtr& src_column);
 
-    bool is_new_partition(int64_t found_partition_end);
+    bool is_new_partition();
     int64_t get_total_position(int64_t local_position);
-    int64_t find_partition_end();
+    void find_partition_end();
     void find_peer_group_end();
-    void reset_state_for_new_partition(int64_t found_partition_end);
+    void reset_state_for_new_partition();
 
     void remove_unused_buffer_values(RuntimeState* state);
 
@@ -161,6 +162,7 @@ private:
     int64_t _current_row_position = 0;
     int64_t _partition_start = 0;
     int64_t _partition_end = 0;
+    int64_t _found_partition_end = 0;
     // A peer group is all of the rows that are peers within the specified ordering.
     // Rows are peers if they compare equal to each other using the specified ordering expression.
     int64_t _peer_group_start = 0;


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5829 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

In new algothrim, for `rows between unbounded preceding and current row in window function`, we may not find the partition end in one get_next(), so we will add `_found_partition_end` in Analytor to record the pos of last find.

Add _found_partition_end for Analytor prepared to add optimization for `rows between unbounded preceding and current row in window function`
