### PR TITLE
[Enhancement] Optimize MaskMergeIterator read speed

### DIFF
--- a/be/src/storage/merge_iterator.cpp
+++ b/be/src/storage/merge_iterator.cpp
@@ -357,27 +357,56 @@ inline Status MaskMergeIterator::do_get_next(Chunk* chunk, std::vector<RowSource
         DCHECK_GT(min_chunk.remaining_rows(), 0);
 
         size_t offset = min_chunk.compared_row();
-        // check whether |min_chunk| has overlapping with others.
         size_t min_chunk_num_rows = min_chunk._chunk->num_rows();
-        if (offset == 0 && _mask_buffer->has_same_source(child, min_chunk_num_rows)) {
-            if (rows == 0) {
-                chunk->swap_chunk(*min_chunk._chunk);
-                for (int i = 0; i < min_chunk_num_rows; ++i) {
-                    source_masks->emplace_back(_mask_buffer->current());
-                    _mask_buffer->advance();
+        size_t append_row_num = 0;
+        size_t max_same_source_count = _mask_buffer->max_same_source_count(child, min_chunk_num_rows);
+        if (max_same_source_count == min_chunk_num_rows) {
+            if (offset == 0) {
+                // all rows in |min_chunk| are from the same source chunk and |min_chunk|'s current offset is 0,
+                // so here we swap the whole min_chunk out.
+                if (rows == 0) {
+                    chunk->swap_chunk(*min_chunk._chunk);
+                    for (int i = 0; i < min_chunk_num_rows; ++i) {
+                        source_masks->emplace_back(_mask_buffer->current());
+                        _mask_buffer->advance();
+                    }
+                    return fill(child);
+                } else {
+                    // retrieve |min_chunk| next time to avoid memory copy.
+                    break;
                 }
-                return fill(child);
             } else {
-                // retrieve |min_chunk| next time to avoid memory copy.
-                break;
+                // all rows in |min_chunk| are from the same source chunk, but |min_chunk|'s current offset is larger than 0,
+                // here we append the remaining rows in |min_chunk| to the chunk.
+                size_t remaining_row_num = min_chunk.remaining_rows();
+                if (rows + remaining_row_num <= _chunk_size) {
+                    append_row_num = remaining_row_num;
+                } else {
+                    append_row_num = _chunk_size - rows;
+                }
+            }
+        } else {
+            // `max_same_source_count` rows in |min_chunk| are from the same source chunk,
+            // here we append the `max_same_source_count` in |min_chunk| to the chunk.
+            if (rows + max_same_source_count <= _chunk_size) {
+                append_row_num = max_same_source_count;
+            } else {
+                append_row_num = _chunk_size - rows;
             }
         }
 
-        chunk->append(*min_chunk._chunk, offset, 1);
-        min_chunk.advance(1);
-        rows += 1;
-        source_masks->emplace_back(mask);
-        _mask_buffer->advance();
+        DCHECK_GT(append_row_num, 0);
+
+        chunk->append(*min_chunk._chunk, offset, append_row_num);
+        min_chunk.advance(append_row_num);
+        rows += append_row_num;
+        for (size_t i = 0; i < append_row_num; ++i) {
+            source_masks->emplace_back(_mask_buffer->current());
+            _mask_buffer->advance();
+        }
+
+        DCHECK_LE(rows, _chunk_size);
+
         if (min_chunk.remaining_rows() == 0) {
             st = fill(child);
             if (!st.ok()) {

--- a/be/src/storage/row_source_mask.cpp
+++ b/be/src/storage/row_source_mask.cpp
@@ -72,6 +72,20 @@ bool RowSourceMaskBuffer::has_same_source(uint16_t source, size_t count) const {
     return true;
 }
 
+size_t RowSourceMaskBuffer::max_same_source_count(uint16_t source, size_t limit_num) const {
+    size_t upper_bound = std::min(limit_num, _mask_column->size() - _current_index);
+    size_t max_same_source_count = upper_bound;
+
+    for (int i = 1; i < upper_bound; ++i) {
+        RowSourceMask mask(_mask_column->get(_current_index + i).get_uint16());
+        if (mask.get_source_num() != source) {
+            max_same_source_count = i;
+            break;
+        }
+    }
+    return max_same_source_count;
+}
+
 Status RowSourceMaskBuffer::flip_to_read() {
     _current_index = 0;
     if (_tmp_file_fd > 0) {

--- a/be/src/storage/row_source_mask.h
+++ b/be/src/storage/row_source_mask.h
@@ -67,6 +67,7 @@ public:
     Status write(const std::vector<RowSourceMask>& source_masks);
     StatusOr<bool> has_remaining();
     bool has_same_source(uint16_t source, size_t count) const;
+    size_t max_same_source_count(uint16_t source, size_t upper_bound) const;
 
     RowSourceMask current() const { return RowSourceMask(_mask_column->get(_current_index).get_uint16()); }
     void advance() { ++_current_index; }

--- a/be/test/storage/merge_iterator_test.cpp
+++ b/be/test/storage/merge_iterator_test.cpp
@@ -202,4 +202,95 @@ TEST_F(MergeIteratorTest, mask_merge) {
     }
 }
 
+TEST_F(MergeIteratorTest, mask_merge_boundary_test) {
+
+    std::vector<int32_t> v1;
+    std::vector<int32_t> v2;
+    std::vector<int32_t> v3;
+    std::vector<int32_t> v4;
+    std::vector<int32_t> expected;
+    std::vector<RowSourceMask> source_masks;
+    std::vector<uint16_t> expected_sources;
+
+    for (int i = 0; i < 2048; i++) {
+        v1.push_back(0);
+        expected.push_back(0);
+        expected_sources.push_back(0);
+    }
+
+    for (int i = 0; i < 4096; i++) {
+        v2.push_back(1);
+        expected.push_back(1);
+        expected_sources.push_back(1);
+    }
+
+    for (int i = 0; i < 1024; i++) {
+        v1.push_back(2);
+        expected.push_back(2);
+        expected_sources.push_back(0);
+    }
+
+    for (int i = 0; i < 1000; i++) {
+        v3.push_back(3);
+        expected.push_back(3);
+        expected_sources.push_back(2);
+    }
+
+    for (int i = 0; i < 1024; i++) {
+        v1.push_back(4);
+        expected.push_back(4);
+        expected_sources.push_back(0);
+    }
+
+    for (int i = 0; i < 2000; i++) {
+        v3.push_back(5);
+        expected.push_back(5);
+        expected_sources.push_back(2);
+    }
+
+    for (int i = 0; i < 4096; i++) {
+        v4.push_back(6);
+        expected.push_back(6);
+        expected_sources.push_back(3);
+    }
+
+    for (size_t i = 0; i < expected_sources.size(); ++i) {
+        source_masks.emplace_back(RowSourceMask(expected_sources[i], false));
+    }
+
+    auto sub1 = std::make_shared<VectorChunkIterator>(_schema, COL_INT(v1));
+    auto sub2 = std::make_shared<VectorChunkIterator>(_schema, COL_INT(v2));
+    auto sub3 = std::make_shared<VectorChunkIterator>(_schema, COL_INT(v3));
+    auto sub4 = std::make_shared<VectorChunkIterator>(_schema, COL_INT(v4));
+    RowSourceMaskBuffer mask_buffer(0, config::storage_root_path);
+    mask_buffer.write(source_masks);
+    mask_buffer.flush();
+    mask_buffer.flip_to_read();
+    source_masks.clear();
+
+    auto iter = new_mask_merge_iterator(std::vector<ChunkIteratorPtr>{sub1, sub2, sub3, sub4}, &mask_buffer);
+    iter->init_encoded_schema(EMPTY_GLOBAL_DICTMAPS);
+
+    std::vector<int32_t> real;
+    ChunkPtr chunk = ChunkHelper::new_chunk(iter->schema(), config::vector_chunk_size);
+    while (iter->get_next(chunk.get(), &source_masks).ok()) {
+        ColumnPtr& c = chunk->get_column_by_index(0);
+        for (size_t i = 0; i < c->size(); i++) {
+            real.push_back(c->get(i).get_int32());
+        }
+        chunk->reset();
+    }
+    ASSERT_EQ(expected.size(), real.size());
+    for (size_t i = 0; i < expected.size(); i++) {
+        ASSERT_EQ(expected[i], real[i]);
+    }
+    chunk->reset();
+    ASSERT_TRUE(iter->get_next(chunk.get(), &source_masks).is_end_of_file());
+
+    // check source masks
+    for (size_t i = 0; i < expected_sources.size(); i++) {
+        ASSERT_EQ(expected_sources[i], source_masks.at(i).get_source_num());
+    }
+}
+
 } // namespace starrocks::vectorized


### PR DESCRIPTION
Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5826 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

The mask_merge_iterator chunk read order is based on the _mask_buffer.
In each time, we will first get the min_chunk from current position of  _mask_buffer. And then check if the next rows(usually 4096) in _mask_buffer are all from the min_chunk. If it is, we swap the min_chunk out. If not, we only append one line from min chunk and then repeat the above procedure. The append operation is very time consuming.

To solve this problem, like what we did in Optimize-HeapMergeIterator-read-speed, i will obtain the `max_same_source_count` from the _mask_buffer, these continous rows are all from the mim_chunk, and then append them in one batch.

In my test, there are 160 million random data. The vertical base compaction before optimization takes 144 seconds, after optimization it only takes 87 seconds, improve by 1.655x.