### PR TITLE
[Feature] Support custom worker threads number for iceberg

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1332,7 +1332,7 @@ public class Config extends ConfigBase {
      * size of iceberg worker pool
      */
     @ConfField(mutable = true)
-    public static boolean iceberg_enable_custom_worker_thread = false;
+    public static boolean enable_iceberg_custom_worker_thread = false;
 
     /**
      * size of iceberg worker pool

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1329,6 +1329,18 @@ public class Config extends ConfigBase {
     public static long hive_max_split_size = 64L * 1024L * 1024L;
 
     /**
+     * size of iceberg worker pool
+     */
+    @ConfField(mutable = true)
+    public static boolean iceberg_enable_custom_worker_thread = false;
+
+    /**
+     * size of iceberg worker pool
+     */
+    @ConfField(mutable = true)
+    public static long iceberg_worker_num_threads = 64;
+
+    /**
      * fe will call es api to get es index shard info every es_state_sync_interval_secs
      */
     @ConfField

--- a/fe/fe-core/src/main/java/com/starrocks/external/iceberg/IcebergRepository.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/iceberg/IcebergRepository.java
@@ -1,0 +1,22 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.external.iceberg;
+
+import com.starrocks.common.Config;
+import org.apache.iceberg.util.ThreadPools;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Properties;
+
+public class IcebergRepository {
+    private static final Logger LOG = LogManager.getLogger(IcebergRepository.class);
+
+    public IcebergRepository() {
+        if (Config.enable_iceberg_custom_worker_thread) {
+            LOG.info("Default iceberg worker thread number changed " + Config.iceberg_worker_num_threads);
+            Properties props = System.getProperties();
+            props.setProperty(ThreadPools.WORKER_THREAD_POOL_SIZE_PROP, String.valueOf(Config.iceberg_worker_num_threads));
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/external/iceberg/IcebergUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/iceberg/IcebergUtil.java
@@ -23,7 +23,6 @@ import java.util.Map;
 import java.util.Optional;
 
 public class IcebergUtil {
-
     /**
      * Get Iceberg table identifier by table property
      */

--- a/fe/fe-core/src/main/java/com/starrocks/external/iceberg/IcebergUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/iceberg/IcebergUtil.java
@@ -18,6 +18,7 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.util.ThreadPools;
 
 import java.util.List;
 import java.util.Map;
@@ -25,11 +26,11 @@ import java.util.Optional;
 import java.util.Properties;
 
 public class IcebergUtil {
-    
+
     static {
-        if (Config.iceberg_enable_custom_worker_thread) {
+        if (Config.enable_iceberg_custom_worker_thread) {
             Properties props = System.getProperties();
-            props.setProperty("iceberg.worker.num-threads", String.valueOf(Config.iceberg_worker_num_threads));
+            props.setProperty(ThreadPools.WORKER_THREAD_POOL_SIZE_PROP, String.valueOf(Config.iceberg_worker_num_threads));
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/external/iceberg/IcebergUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/iceberg/IcebergUtil.java
@@ -4,6 +4,7 @@ package com.starrocks.external.iceberg;
 
 import com.google.common.collect.ImmutableMap;
 import com.starrocks.catalog.IcebergTable;
+import com.starrocks.common.Config;
 import com.starrocks.external.hive.HdfsFileFormat;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.BaseTable;
@@ -21,8 +22,17 @@ import org.apache.iceberg.expressions.Expressions;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Properties;
 
 public class IcebergUtil {
+    
+    static {
+        if (Config.iceberg_enable_custom_worker_thread) {
+            Properties props = System.getProperties();
+            props.setProperty("iceberg.worker.num-threads", String.valueOf(Config.iceberg_worker_num_threads));
+        }
+    }
+
     /**
      * Get Iceberg table identifier by table property
      */

--- a/fe/fe-core/src/main/java/com/starrocks/external/iceberg/IcebergUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/iceberg/IcebergUtil.java
@@ -4,7 +4,6 @@ package com.starrocks.external.iceberg;
 
 import com.google.common.collect.ImmutableMap;
 import com.starrocks.catalog.IcebergTable;
-import com.starrocks.common.Config;
 import com.starrocks.external.hive.HdfsFileFormat;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.BaseTable;
@@ -18,25 +17,12 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
-import org.apache.iceberg.util.ThreadPools;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Properties;
 
 public class IcebergUtil {
-    private static final Logger LOG = LogManager.getLogger(IcebergUtil.class);
-
-    static {
-        if (Config.enable_iceberg_custom_worker_thread) {
-            LOG.info("Default iceberg worker thread number changed " + Config.iceberg_worker_num_threads);
-            Properties props = System.getProperties();
-            props.setProperty(ThreadPools.WORKER_THREAD_POOL_SIZE_PROP, String.valueOf(Config.iceberg_worker_num_threads));
-        }
-    }
 
     /**
      * Get Iceberg table identifier by table property

--- a/fe/fe-core/src/main/java/com/starrocks/external/iceberg/IcebergUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/iceberg/IcebergUtil.java
@@ -19,6 +19,8 @@ import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.util.ThreadPools;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 import java.util.Map;
@@ -26,9 +28,11 @@ import java.util.Optional;
 import java.util.Properties;
 
 public class IcebergUtil {
+    private static final Logger LOG = LogManager.getLogger(IcebergUtil.class);
 
     static {
         if (Config.enable_iceberg_custom_worker_thread) {
+            LOG.info("Default iceberg worker thread number changed " + Config.iceberg_worker_num_threads);
             Properties props = System.getProperties();
             props.setProperty(ThreadPools.WORKER_THREAD_POOL_SIZE_PROP, String.valueOf(Config.iceberg_worker_num_threads));
         }

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -200,6 +200,7 @@ import com.starrocks.consistency.ConsistencyChecker;
 import com.starrocks.external.elasticsearch.EsRepository;
 import com.starrocks.external.hive.HiveRepository;
 import com.starrocks.external.hive.events.MetastoreEventsProcessor;
+import com.starrocks.external.iceberg.IcebergRepository;
 import com.starrocks.external.starrocks.StarRocksRepository;
 import com.starrocks.ha.BDBHA;
 import com.starrocks.ha.FrontendNodeType;
@@ -387,6 +388,7 @@ public class GlobalStateMgr {
     private StarRocksRepository starRocksRepository;
     private HiveRepository hiveRepository;
     private MetastoreEventsProcessor metastoreEventsProcessor;
+    private IcebergRepository icebergRepository;
 
     private boolean isFirstTimeStartUp = false;
     private boolean isElectable;
@@ -642,6 +644,7 @@ public class GlobalStateMgr {
         this.esRepository = new EsRepository();
         this.starRocksRepository = new StarRocksRepository();
         this.hiveRepository = new HiveRepository();
+        this.icebergRepository = new IcebergRepository();
         this.metastoreEventsProcessor = new MetastoreEventsProcessor(hiveRepository);
 
         this.metaContext = new MetaContext();


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
we can set iceberg.worker.num-threads for  ThreadPools.getWorkerPool() below
```
public CloseableIterable<FileScanTask> planFiles(TableOperations ops, Snapshot snapshot, Expression rowFilter, boolean ignoreResiduals, boolean caseSensitive, boolean colStats) {
        ManifestGroup manifestGroup = (new ManifestGroup(ops.io(), snapshot.dataManifests(), snapshot.deleteManifests())).caseSensitive(caseSensitive).select(colStats ? SCAN_WITH_STATS_COLUMNS : SCAN_COLUMNS).filterData(rowFilter).specsById(ops.current().specsById()).ignoreDeleted();
        if (ignoreResiduals) {
            manifestGroup = manifestGroup.ignoreResiduals();
        }

        if (PLAN_SCANS_WITH_WORKER_POOL && snapshot.dataManifests().size() > 1) {
            manifestGroup = manifestGroup.planWith(ThreadPools.getWorkerPool());
        }

        return manifestGroup.planFiles();
    }
```