### PR TITLE
[BugFix] add scan statistics to auditlog in pipeline-mode

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -452,4 +452,17 @@ Status PipelineDriver::_mark_operator_closed(OperatorPtr& op, RuntimeState* stat
     return Status::OK();
 }
 
+void PipelineDriver::_update_statistics(size_t total_chunks_moved, size_t total_rows_moved, size_t time_spent) {
+    driver_acct().increment_schedule_times();
+    driver_acct().update_last_chunks_moved(total_chunks_moved);
+    driver_acct().update_accumulated_rows_moved(total_rows_moved);
+    driver_acct().update_last_time_spent(time_spent);
+
+    // Update statistics of scan operator
+    if (SourceOperator* source = source_operator()) {
+        query_ctx()->incr_cur_scan_rows_num(source->get_last_scan_rows_num());
+        query_ctx()->incr_cur_scan_bytes(source->get_last_scan_rows_num());
+    }
+}
+
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -215,7 +215,9 @@ public:
     }
 
     Operators& operators() { return _operators; }
-    SourceOperator* source_operator() { return down_cast<SourceOperator*>(_operators.front().get()); }
+    SourceOperator* source_operator() {
+        return _operators.empty() ? nullptr : down_cast<SourceOperator*>(_operators.front().get());
+    }
     RuntimeProfile* runtime_profile() { return _runtime_profile.get(); }
     // drivers that waits for runtime filters' readiness must be marked PRECONDITION_NOT_READY and put into
     // PipelineDriverPoller.

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -363,12 +363,7 @@ private:
     void _close_operators(RuntimeState* runtime_state);
 
     // Update metrics when the driver yields.
-    void _update_statistics(size_t total_chunks_moved, size_t total_rows_moved, size_t time_spent) {
-        driver_acct().increment_schedule_times();
-        driver_acct().update_last_chunks_moved(total_chunks_moved);
-        driver_acct().update_accumulated_rows_moved(total_rows_moved);
-        driver_acct().update_last_time_spent(time_spent);
-    }
+    void _update_statistics(size_t total_chunks_moved, size_t total_rows_moved, size_t time_spent);
 
     RuntimeState* _runtime_state = nullptr;
     void _update_overhead_timer();

--- a/be/src/exec/pipeline/pipeline_driver_queue.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_queue.cpp
@@ -111,10 +111,6 @@ size_t QuerySharedDriverQueue::size() {
 
 void QuerySharedDriverQueue::update_statistics(const DriverRawPtr driver) {
     _queues[driver->get_driver_queue_level()].update_accu_time(driver);
-    if (SourceOperator* source_operator = driver->source_operator()) {
-        driver->query_ctx()->incr_cur_scan_rows_num(source_operator->get_last_scan_rows_num());
-        driver->query_ctx()->incr_cur_scan_bytes(source_operator->get_last_scan_rows_num());
-    }
 }
 
 int QuerySharedDriverQueue::_compute_driver_level(const DriverRawPtr driver) const {
@@ -304,12 +300,6 @@ void DriverQueueWithWorkGroup::update_statistics(const DriverRawPtr driver) {
 
         wg->incr_total_cpu_cost(sink_operator_last_cpu_time_ns);
         query_ctx->incr_cpu_cost(sink_operator_last_cpu_time_ns);
-    }
-
-    // Update scan rows
-    if (auto source = driver->source_operator()) {
-        query_ctx->incr_cur_scan_rows_num(source->get_last_scan_rows_num());
-        query_ctx->incr_cur_scan_bytes(source->get_last_scan_bytes());
     }
 
     workgroup::WorkGroupManager::instance()->increment_cpu_runtime_ns(runtime_ns);

--- a/be/src/exec/pipeline/pipeline_driver_queue.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_queue.cpp
@@ -110,6 +110,8 @@ size_t QuerySharedDriverQueue::size() {
 
 void QuerySharedDriverQueue::update_statistics(const DriverRawPtr driver) {
     _queues[driver->get_driver_queue_level()].update_accu_time(driver);
+    driver->query_ctx()->incr_cur_scan_rows_num(driver->source_operator()->get_last_scan_rows_num());
+    driver->query_ctx()->incr_cur_scan_bytes(driver->source_operator()->get_last_scan_rows_num());
 }
 
 int QuerySharedDriverQueue::_compute_driver_level(const DriverRawPtr driver) const {
@@ -302,9 +304,8 @@ void DriverQueueWithWorkGroup::update_statistics(const DriverRawPtr driver) {
     }
 
     // Update scan rows
-    if (wg->big_query_scan_rows_limit()) {
-        query_ctx->incr_cur_scan_rows_num(driver->source_operator()->get_last_scan_rows_num());
-    }
+    query_ctx->incr_cur_scan_rows_num(driver->source_operator()->get_last_scan_rows_num());
+    query_ctx->incr_cur_scan_bytes(driver->source_operator()->get_last_scan_bytes());
 
     workgroup::WorkGroupManager::instance()->increment_cpu_runtime_ns(runtime_ns);
 }

--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -31,12 +31,14 @@ QueryContext::~QueryContext() {
 
     // Accounting memory usage during QueryContext's destruction should not use query-level MemTracker, but its released
     // in the mid of QueryContext destruction, so use its parent MemTracker.
-    SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_mem_tracker->parent());
-    if (_exec_env != nullptr) {
-        if (_is_runtime_filter_coordinator) {
-            _exec_env->runtime_filter_worker()->close_query(_query_id);
+    if (_mem_tracker) {
+        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_mem_tracker->parent());
+        if (_exec_env != nullptr) {
+            if (_is_runtime_filter_coordinator) {
+                _exec_env->runtime_filter_worker()->close_query(_query_id);
+            }
+            _exec_env->runtime_filter_cache()->remove(_query_id);
         }
-        _exec_env->runtime_filter_cache()->remove(_query_id);
     }
 }
 

--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -84,6 +84,8 @@ public:
     // Record the number of rows read from the data source for big query checking
     void incr_cur_scan_rows_num(int64_t rows_num) { _cur_scan_rows_num += rows_num; }
     int64_t cur_scan_rows_num() const { return _cur_scan_rows_num; }
+    void incr_cur_scan_bytes(int64_t scan_bytes) { _cur_scan_bytes += scan_bytes; }
+    int64_t get_scan_bytes() const { return _cur_scan_bytes; }
 
     // Record the cpu time of the query run, for big query checking
     int64_t init_wg_cpu_cost() const { return _init_wg_cpu_cost; }
@@ -114,6 +116,7 @@ private:
     int64_t _query_begin_time = 0;
     std::atomic<int64_t> _cur_cpu_cost = 0;
     std::atomic<int64_t> _cur_scan_rows_num = 0;
+    std::atomic<int64_t> _cur_scan_bytes = 0;
 
     int64_t _init_wg_cpu_cost = 0;
 };

--- a/be/src/exec/pipeline/scan/chunk_source.h
+++ b/be/src/exec/pipeline/scan/chunk_source.h
@@ -44,12 +44,14 @@ public:
                                                                    workgroup::WorkGroupPtr running_wg) = 0;
     virtual int64_t last_spent_cpu_time_ns() { return 0; }
     virtual int64_t last_scan_rows_num() { return 0; }
+    virtual int64_t last_scan_bytes() { return 0; }
 
 protected:
     RuntimeProfile* _runtime_profile;
     // The morsel will own by pipeline driver
     MorselPtr _morsel;
     int64_t _last_scan_rows_num = 0;
+    int64_t _last_scan_bytes = 0;
 };
 
 using ChunkSourcePtr = std::shared_ptr<ChunkSource>;

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -446,6 +446,7 @@ void OlapChunkSource::_update_realtime_counter(vectorized::Chunk* chunk) {
     COUNTER_UPDATE(_raw_rows_counter, _reader->stats().raw_rows_read);
     _raw_rows_read += _reader->stats().raw_rows_read;
     _last_scan_rows_num += _reader->stats().raw_rows_read;
+    _last_scan_bytes += _reader->stats().bytes_read;
 
     _reader->mutable_stats()->raw_rows_read = 0;
     _num_rows_read += chunk->num_rows();
@@ -470,6 +471,7 @@ void OlapChunkSource::_update_counter() {
     COUNTER_UPDATE(_raw_rows_counter, _reader->stats().raw_rows_read);
     _raw_rows_read += _reader->mutable_stats()->raw_rows_read;
     _last_scan_rows_num += _reader->mutable_stats()->raw_rows_read;
+    _last_scan_bytes += _reader->mutable_stats()->bytes_read;
 
     COUNTER_UPDATE(_chunk_copy_timer, _reader->stats().vec_cond_chunk_copy_ns);
 

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -206,6 +206,7 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
                     COUNTER_UPDATE(_total_cost_cpu_time_ns_counter,
                                    _chunk_sources[chunk_source_index]->last_spent_cpu_time_ns());
                     _last_scan_rows_num += _chunk_sources[chunk_source_index]->last_scan_rows_num();
+                    _last_scan_bytes += _chunk_sources[chunk_source_index]->last_scan_bytes();
                 }
 
                 _num_running_io_tasks--;
@@ -225,6 +226,8 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
                 {
                     SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(state->instance_mem_tracker());
                     _chunk_sources[chunk_source_index]->buffer_next_batch_chunks_blocking(_buffer_size, state);
+                    _last_scan_rows_num += _chunk_sources[chunk_source_index]->last_scan_rows_num();
+                    _last_scan_bytes += _chunk_sources[chunk_source_index]->last_scan_bytes();
                 }
 
                 _num_running_io_tasks--;

--- a/be/src/exec/pipeline/source_operator.h
+++ b/be/src/exec/pipeline/source_operator.h
@@ -35,10 +35,17 @@ public:
         return scan_rows_num;
     }
 
+    virtual int64_t get_last_scan_bytes() {
+        int64_t scan_rows_num = _last_scan_rows_num;
+        _last_scan_rows_num = 0;
+        return scan_rows_num;
+    }
+
 protected:
     MorselQueue* _morsel_queue = nullptr;
 
     int64_t _last_scan_rows_num = 0;
+    int64_t _last_scan_bytes = 0;
 };
 
 class SourceOperatorFactory : public OperatorFactory {

--- a/be/src/runtime/query_statistics.h
+++ b/be/src/runtime/query_statistics.h
@@ -51,6 +51,11 @@ public:
         this->scan_bytes += stats_item.scan_bytes();
     }
 
+    void add_scan_stats(int64_t scan_rows, int64_t scan_bytes) {
+        this->scan_rows += scan_rows;
+        this->scan_bytes += scan_bytes;
+    }
+
     void merge(QueryStatisticsRecvr* recvr);
 
     void clear() {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5810

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Add `scanRows` and `scanBytes` to auditlog in pipeline-mode.
- In non-pipe mode, the query statistic is collected bottom-up from scan node
- In pipe mode, the query statistic is recorded at `QueryContext` directly