### PR TITLE
Fix round with double in halfway cases

### DIFF
--- a/be/src/exprs/vectorized/math_functions.cpp
+++ b/be/src/exprs/vectorized/math_functions.cpp
@@ -332,6 +332,8 @@ double MathFunctions::double_round(double value, int64_t dec, bool dec_unsigned,
             tmp2 = dec < 0 ? std::ceil(value_div_tmp) * tmp : std::ceil(value_mul_tmp) / tmp;
         }
     } else {
+        // Because std::rint(+2.5) = 2, std::rint(+3.5) = 4,
+        // so It's not expected result, we should use std::round instead of std::rint.
         tmp2 = dec < 0 ? std::round(value_div_tmp) * tmp : std::round(value_mul_tmp) / tmp;
     }
 

--- a/be/src/exprs/vectorized/math_functions.cpp
+++ b/be/src/exprs/vectorized/math_functions.cpp
@@ -332,7 +332,7 @@ double MathFunctions::double_round(double value, int64_t dec, bool dec_unsigned,
             tmp2 = dec < 0 ? std::ceil(value_div_tmp) * tmp : std::ceil(value_mul_tmp) / tmp;
         }
     } else {
-        tmp2 = dec < 0 ? std::rint(value_div_tmp) * tmp : std::rint(value_mul_tmp) / tmp;
+        tmp2 = dec < 0 ? std::round(value_div_tmp) * tmp : std::round(value_mul_tmp) / tmp;
     }
 
     return tmp2;

--- a/be/test/exprs/vectorized/math_functions_test.cpp
+++ b/be/test/exprs/vectorized/math_functions_test.cpp
@@ -402,6 +402,68 @@ TEST_F(VecMathFunctionsTest, RoundUpToTest) {
     }
 }
 
+TEST_F(VecMathFunctionsTest, RoundUpToHalfwayCasesWithPositiveTest) {
+    {
+        Columns columns;
+
+        auto tc1 = DoubleColumn::create();
+        auto tc2 = Int32Column::create();
+
+        double dous[] = {7.845, 7.855};
+        int ints[] = {2, 2};
+
+        double res[] = {7.85, 7.86};
+
+        for (int i = 0; i < sizeof(dous) / sizeof(dous[0]); ++i) {
+            tc1->append(dous[i]);
+            tc2->append(ints[i]);
+        }
+
+        columns.emplace_back(tc1);
+        columns.emplace_back(tc2);
+
+        std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
+        ColumnPtr result = MathFunctions::round_up_to(ctx.get(), columns);
+
+        auto v = ColumnHelper::cast_to<TYPE_DOUBLE>(result);
+
+        for (int i = 0; i < sizeof(res) / sizeof(res[0]); ++i) {
+            ASSERT_EQ(res[i], v->get_data()[i]);
+        }
+    }
+}
+
+TEST_F(VecMathFunctionsTest, RoundUpToHalfwayCasesWithNegativeTest) {
+    {
+        Columns columns;
+
+        auto tc1 = DoubleColumn::create();
+        auto tc2 = Int32Column::create();
+
+        double dous[] = {45.0, 44.0};
+        int ints[] = {-1, -1};
+
+        double res[] = {50, 40};
+
+        for (int i = 0; i < sizeof(dous) / sizeof(dous[0]); ++i) {
+            tc1->append(dous[i]);
+            tc2->append(ints[i]);
+        }
+
+        columns.emplace_back(tc1);
+        columns.emplace_back(tc2);
+
+        std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
+        ColumnPtr result = MathFunctions::round_up_to(ctx.get(), columns);
+
+        auto v = ColumnHelper::cast_to<TYPE_DOUBLE>(result);
+
+        for (int i = 0; i < sizeof(res) / sizeof(res[0]); ++i) {
+            ASSERT_EQ(res[i], v->get_data()[i]);
+        }
+    }
+}
+
 TEST_F(VecMathFunctionsTest, BinTest) {
     {
         Columns columns;


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/5843

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
`round(CAST(7.845 AS DOUBLE), 2)` should output 7.85 not 7.84. We should use std::round instead of std::rint.
And std::rint differs from std::round in that halfway cases are rounded to even rather than away from zero.