### PR TITLE
[enhancement] Opt the binary search of find partition end in Analytor

### DIFF
--- a/be/src/exec/vectorized/analytor.h
+++ b/be/src/exec/vectorized/analytor.h
@@ -213,7 +213,7 @@ private:
     void _update_window_batch_lead_lag(int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
                                        int64_t frame_end);
 
-    int64_t _find_first_not_equal(vectorized::Column* column, int64_t start, int64_t end);
+    static int64_t _find_first_not_equal(vectorized::Column* column, int64_t target, int64_t start, int64_t end);
 };
 
 // Helper class that properly invokes destructor when state goes out of scope.

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -43,6 +43,7 @@ set(EXEC_FILES
         ./exec/vectorized/parquet_scanner_test.cpp
         ./exec/vectorized/arrow_converter_test.cpp
         ./exec/vectorized/repeat_node_test.cpp
+        ./exec/vectorized/analytor_test.cpp
         ./exec/es_scan_reader_test.cpp
         ./exec/vectorized/hdfs_scan_node_test.cpp
         ./exec/pipeline/pipeline_test_base.cpp

--- a/be/test/exec/vectorized/analytor_test.cpp
+++ b/be/test/exec/vectorized/analytor_test.cpp
@@ -1,0 +1,61 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#include <gtest/gtest.h>
+
+#include "exec/vectorized/analytor.h"
+
+namespace starrocks::vectorized {
+class AnalytorTest : public ::testing::Test {
+public:
+    void SetUp() override {
+        config::vector_chunk_size = 1024;
+    }
+};
+
+// NOLINTNEXTLINE
+TEST_F(AnalytorTest, find_partition_end) {
+    TPlanNode plan_node;
+    RowDescriptor row_desc;
+    Analytor analytor(plan_node, row_desc, nullptr);
+
+    int32_t v;
+    auto c1 = Int32Column::create();
+    v = 1;
+    c1->append_value_multiple_times(&v, 10);
+    v = 2;
+    c1->append_value_multiple_times(&v, 10);
+
+    auto c2 = Int32Column::create();
+    v = 3;
+    c2->append_value_multiple_times(&v, 5);
+    v = 4;
+    c2->append_value_multiple_times(&v, 15);
+
+    analytor._partition_columns.emplace_back(c1);
+    analytor._partition_columns.emplace_back(c2);
+
+    analytor.find_partition_end();
+    ASSERT_EQ(analytor.found_partition_end(), 5);
+}
+
+// NOLINTNEXTLINE
+TEST_F(AnalytorTest, find_peer_group_end) {
+    TPlanNode plan_node;
+    RowDescriptor row_desc;
+    Analytor analytor(plan_node, row_desc, nullptr);
+
+    int32_t v;
+    auto c1 = Int32Column::create();
+    v = 1;
+    c1->append_value_multiple_times(&v, 10);
+    v = 2;
+    c1->append_value_multiple_times(&v, 10);
+
+    analytor._order_columns.emplace_back(c1);
+    analytor._partition_end = 20;
+
+    analytor.find_peer_group_end();
+    ASSERT_EQ(analytor.peer_group_end(), 5);
+}
+
+}

--- a/be/test/exec/vectorized/analytor_test.cpp
+++ b/be/test/exec/vectorized/analytor_test.cpp
@@ -31,6 +31,7 @@ TEST_F(AnalytorTest, find_partition_end) {
     v = 4;
     c2->append_value_multiple_times(&v, 15);
 
+    analytor.update_input_rows(20);
     analytor._partition_columns.emplace_back(c1);
     analytor._partition_columns.emplace_back(c2);
 
@@ -51,11 +52,12 @@ TEST_F(AnalytorTest, find_peer_group_end) {
     v = 2;
     c1->append_value_multiple_times(&v, 10);
 
+    analytor.update_input_rows(20);
     analytor._order_columns.emplace_back(c1);
     analytor._partition_end = 20;
 
     analytor.find_peer_group_end();
-    ASSERT_EQ(analytor.peer_group_end(), 5);
+    ASSERT_EQ(analytor.peer_group_end(), 10);
 }
 
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5829 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

In the past, every time a new `Chunk` was read, the start pos of the binary search was `PartitionStart`. Currently, we execute binary search from the last pos, to reduce the frequency of compare.

This is not the main point that affects the calculation performance of the window function. The actual test has no effect on the performance. The main purpose is to release the memory earlier of the `PartitionColumn` in advance later.


