### PR TITLE
[Bugfix] support splitting chunk into multiple TFetchDataResults to avoid failures of thrift serialization

### DIFF
--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -196,8 +196,8 @@ Status ExchangeSinkOperator::Channel::send_one_chunk(const vectorized::Chunk* ch
         if (_use_pass_through) {
             size_t chunk_size = serde::ProtobufChunkSerde::max_serialized_size(*chunk);
             // -1 means disable pipeline level shuffle
-            _pass_through_context.append_chunk(_parent->_sender_id, chunk, chunk_size,
-                                               _parent->_is_pipeline_level_shuffle ? driver_sequence : -1);
+            TRY_CATCH_BAD_ALLOC(_pass_through_context.append_chunk(_parent->_sender_id, chunk, chunk_size,
+                                               _parent->_is_pipeline_level_shuffle ? driver_sequence : -1));
             _current_request_bytes += chunk_size;
             COUNTER_UPDATE(_parent->_bytes_pass_through_counter, chunk_size);
         } else {
@@ -205,7 +205,7 @@ Status ExchangeSinkOperator::Channel::send_one_chunk(const vectorized::Chunk* ch
                 _chunk_request->add_driver_sequences(driver_sequence);
             }
             auto pchunk = _chunk_request->add_chunks();
-            RETURN_IF_ERROR(_parent->serialize_chunk(chunk, pchunk, &_is_first_chunk));
+            TRY_CATCH_BAD_ALLOC(RETURN_IF_ERROR(_parent->serialize_chunk(chunk, pchunk, &_is_first_chunk)));
             _current_request_bytes += pchunk->data().size();
         }
     }
@@ -420,7 +420,7 @@ Status ExchangeSinkOperator::push_chunk(RuntimeState* state, const vectorized::C
             // 1. create a new chunk PB to serialize
             ChunkPB* pchunk = _chunk_request->add_chunks();
             // 2. serialize input chunk to pchunk
-            RETURN_IF_ERROR(serialize_chunk(send_chunk, pchunk, &_is_first_chunk, _channels.size()));
+            TRY_CATCH_BAD_ALLOC(RETURN_IF_ERROR(serialize_chunk(send_chunk, pchunk, &_is_first_chunk, _channels.size())));
             _current_request_bytes += pchunk->data().size();
             // 3. if request bytes exceede the threshold, send current request
             if (_current_request_bytes > _request_bytes_threshold) {

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -196,8 +196,9 @@ Status ExchangeSinkOperator::Channel::send_one_chunk(const vectorized::Chunk* ch
         if (_use_pass_through) {
             size_t chunk_size = serde::ProtobufChunkSerde::max_serialized_size(*chunk);
             // -1 means disable pipeline level shuffle
-            TRY_CATCH_BAD_ALLOC(_pass_through_context.append_chunk(_parent->_sender_id, chunk, chunk_size,
-                                               _parent->_is_pipeline_level_shuffle ? driver_sequence : -1));
+            TRY_CATCH_BAD_ALLOC(
+                    _pass_through_context.append_chunk(_parent->_sender_id, chunk, chunk_size,
+                                                       _parent->_is_pipeline_level_shuffle ? driver_sequence : -1));
             _current_request_bytes += chunk_size;
             COUNTER_UPDATE(_parent->_bytes_pass_through_counter, chunk_size);
         } else {
@@ -420,7 +421,8 @@ Status ExchangeSinkOperator::push_chunk(RuntimeState* state, const vectorized::C
             // 1. create a new chunk PB to serialize
             ChunkPB* pchunk = _chunk_request->add_chunks();
             // 2. serialize input chunk to pchunk
-            TRY_CATCH_BAD_ALLOC(RETURN_IF_ERROR(serialize_chunk(send_chunk, pchunk, &_is_first_chunk, _channels.size())));
+            TRY_CATCH_BAD_ALLOC(
+                    RETURN_IF_ERROR(serialize_chunk(send_chunk, pchunk, &_is_first_chunk, _channels.size())));
             _current_request_bytes += pchunk->data().size();
             // 3. if request bytes exceede the threshold, send current request
             if (_current_request_bytes > _request_bytes_threshold) {

--- a/be/src/exec/pipeline/hashjoin/hash_join_build_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/hash_join_build_operator.cpp
@@ -90,10 +90,14 @@ Status HashJoinBuildOperator::set_finishing(RuntimeState* state) {
         runtime_filter_hub()->set_collector(_plan_node_id, std::make_unique<RuntimeFilterCollector>(
                                                                    std::move(in_filters), std::move(bloom_filters)));
     }
-
-    for (auto& read_only_join_prober : _read_only_join_probers) {
-        read_only_join_prober->reference_hash_table(_join_builder.get());
+    {
+        TRY_CATCH_ALLOC_SCOPE_START()
+        for (auto& read_only_join_prober : _read_only_join_probers) {
+            read_only_join_prober->reference_hash_table(_join_builder.get());
+        }
+        TRY_CATCH_ALLOC_SCOPE_END()
     }
+
     _join_builder->enter_probe_phase();
     for (auto& read_only_join_prober : _read_only_join_probers) {
         read_only_join_prober->enter_probe_phase();

--- a/be/src/exec/pipeline/result_sink_operator.cpp
+++ b/be/src/exec/pipeline/result_sink_operator.cpp
@@ -93,7 +93,7 @@ Status ResultSinkOperator::push_chunk(RuntimeState* state, const vectorized::Chu
     }
     DCHECK(_fetch_data_result.empty());
     auto* mysql_writer = down_cast<MysqlResultWriter*>(_writer.get());
-    auto status = mysql_writer->process_chunk(chunk.get());
+    auto status = mysql_writer->process_chunk_for_pipeline(chunk.get());
     if (status.ok()) {
         _fetch_data_result = std::move(status.value());
         return mysql_writer->try_add_batch(_fetch_data_result).status();

--- a/be/src/exec/pipeline/result_sink_operator.cpp
+++ b/be/src/exec/pipeline/result_sink_operator.cpp
@@ -74,7 +74,7 @@ bool ResultSinkOperator::need_input() const {
     if (is_finished()) {
         return false;
     }
-    if (!_fetch_data_result) {
+    if (_fetch_data_result.empty()) {
         return true;
     }
     auto* mysql_writer = down_cast<MysqlResultWriter*>(_writer.get());
@@ -91,10 +91,9 @@ Status ResultSinkOperator::push_chunk(RuntimeState* state, const vectorized::Chu
     if (!_last_error.ok()) {
         return _last_error;
     }
-    DCHECK(!_fetch_data_result);
+    DCHECK(_fetch_data_result.empty());
     auto* mysql_writer = down_cast<MysqlResultWriter*>(_writer.get());
     auto status = mysql_writer->process_chunk(chunk.get());
-
     if (status.ok()) {
         _fetch_data_result = std::move(status.value());
         return mysql_writer->try_add_batch(_fetch_data_result).status();

--- a/be/src/exec/pipeline/result_sink_operator.h
+++ b/be/src/exec/pipeline/result_sink_operator.h
@@ -41,7 +41,7 @@ public:
 
     bool need_input() const override;
 
-    bool is_finished() const override { return _is_finished && !_fetch_data_result; }
+    bool is_finished() const override { return _is_finished && _fetch_data_result.empty(); }
 
     Status set_finishing(RuntimeState* state) override {
         _is_finished = true;
@@ -63,7 +63,7 @@ private:
     std::atomic<int64_t>& _num_written_rows;
 
     std::shared_ptr<ResultWriter> _writer;
-    mutable TFetchDataResultPtr _fetch_data_result;
+    mutable TFetchDataResultPtrs _fetch_data_result;
 
     std::unique_ptr<RuntimeProfile> _profile = nullptr;
 

--- a/be/src/runtime/buffer_control_block.cpp
+++ b/be/src/runtime/buffer_control_block.cpp
@@ -138,7 +138,7 @@ Status BufferControlBlock::add_batch(std::vector<std::unique_ptr<TFetchDataResul
         return Status::Cancelled("Cancelled BufferControlBlock::add_batch");
     }
 
-    for (auto& result: results) {
+    for (auto& result : results) {
         if (_waiting_rpc.empty()) {
             _buffer_rows += result->result_batch.rows.size();
             _batch_queue.push_back(result.release());
@@ -194,7 +194,7 @@ StatusOr<bool> BufferControlBlock::try_add_batch(std::vector<std::unique_ptr<TFe
     if ((!_batch_queue.empty() && (total_rows + _buffer_rows) > _buffer_limit) && !_is_cancelled) {
         return false;
     }
-    for (auto& result: results) {
+    for (auto& result : results) {
         if (_waiting_rpc.empty()) {
             _buffer_rows += result->result_batch.rows.size();
             _batch_queue.push_back(result.release());

--- a/be/src/runtime/buffer_control_block.h
+++ b/be/src/runtime/buffer_control_block.h
@@ -67,8 +67,10 @@ public:
     ~BufferControlBlock();
 
     Status init();
+    // In order not to affect the current implementation of the non-pipeline engine,
+    // this method is reserved and is only used in the non-pipeline engine
+    Status add_batch(TFetchDataResult* result);
     Status add_batch(std::unique_ptr<TFetchDataResult>& result);
-    Status add_batch(std::vector<std::unique_ptr<TFetchDataResult>>& results);
 
     // non-blocking version of add_batch
     StatusOr<bool> try_add_batch(std::unique_ptr<TFetchDataResult>& result);

--- a/be/src/runtime/buffer_control_block.h
+++ b/be/src/runtime/buffer_control_block.h
@@ -67,9 +67,12 @@ public:
     ~BufferControlBlock();
 
     Status init();
-    Status add_batch(TFetchDataResult* result);
+    Status add_batch(std::unique_ptr<TFetchDataResult>& result);
+    Status add_batch(std::vector<std::unique_ptr<TFetchDataResult>>& results);
+
     // non-blocking version of add_batch
-    StatusOr<bool> try_add_batch(TFetchDataResult* result);
+    StatusOr<bool> try_add_batch(std::unique_ptr<TFetchDataResult>& result);
+    StatusOr<bool> try_add_batch(std::vector<std::unique_ptr<TFetchDataResult>>& results);
 
     // get result from batch, use timeout?
     Status get_batch(TFetchDataResult* result);

--- a/be/src/runtime/buffer_control_block.h
+++ b/be/src/runtime/buffer_control_block.h
@@ -101,6 +101,8 @@ public:
     }
 
 private:
+    void _process_batch_without_lock(std::unique_ptr<TFetchDataResult>& result);
+
     typedef std::list<TFetchDataResult*> ResultQueue;
 
     // result's query id

--- a/be/src/runtime/mysql_result_writer.cpp
+++ b/be/src/runtime/mysql_result_writer.cpp
@@ -27,8 +27,8 @@
 #include "exprs/expr.h"
 #include "gen_cpp/InternalService_types.h"
 #include "runtime/buffer_control_block.h"
-#include "runtime/primitive_type.h"
 #include "runtime/current_thread.h"
+#include "runtime/primitive_type.h"
 #include "util/mysql_row_buffer.h"
 
 namespace starrocks {
@@ -103,8 +103,8 @@ StatusOr<TFetchDataResultPtrs> MysqlResultWriter::process_chunk(vectorized::Chun
     for (int i = 0; i < num_columns; ++i) {
         ASSIGN_OR_RETURN(ColumnPtr column, _output_expr_ctxs[i]->evaluate(chunk));
         column = _output_expr_ctxs[i]->root()->type().type == TYPE_TIME
-                        ? vectorized::ColumnHelper::convert_time_column_from_double_to_str(column)
-                        : column;
+                         ? vectorized::ColumnHelper::convert_time_column_from_double_to_str(column)
+                         : column;
         result_columns.emplace_back(std::move(column));
     }
 
@@ -113,7 +113,7 @@ StatusOr<TFetchDataResultPtrs> MysqlResultWriter::process_chunk(vectorized::Chun
         TRY_CATCH_ALLOC_SCOPE_START()
         _row_buffer->reserve(128);
         size_t current_bytes = 0;
-        int current_rows= 0;
+        int current_rows = 0;
         SCOPED_TIMER(_convert_tuple_timer);
         auto result = std::make_unique<TFetchDataResult>();
         auto& result_rows = result->result_batch.rows;

--- a/be/src/runtime/mysql_result_writer.cpp
+++ b/be/src/runtime/mysql_result_writer.cpp
@@ -126,13 +126,13 @@ StatusOr<TFetchDataResultPtrs> MysqlResultWriter::process_chunk(vectorized::Chun
             }
             size_t len = _row_buffer->length();
 
-            if (UNLIKELY(current_bytes + len >= max_row_buffer_size)) {
+            if (UNLIKELY(current_bytes + len >= _max_row_buffer_size)) {
                 result_rows.resize(current_rows);
                 results.emplace_back(std::move(result));
 
                 result = std::make_unique<TFetchDataResult>();
                 result_rows = result->result_batch.rows;
-                result_rows.resize(num_rows - current_rows);
+                result_rows.resize(num_rows - i);
 
                 current_bytes = 0;
                 current_rows = 0;

--- a/be/src/runtime/mysql_result_writer.h
+++ b/be/src/runtime/mysql_result_writer.h
@@ -50,9 +50,12 @@ public:
     // decompose append_chunk into two functions: process_chunk and try_add_batch,
     // the former transform input chunk into TFetchDataResult, the latter add TFetchDataResult
     // to queue whose consumers are rpc threads that invoke fetch_data rpc.
+    StatusOr<TFetchDataResultPtr> process_chunk(vectorized::Chunk* chunk);
     // because the mem buffer used by thrift serialization is limited, we should control the size of single TFetchDataResult,
     // we may split a chunk into multiple TFetchDataResults
-    StatusOr<TFetchDataResultPtrs> process_chunk(vectorized::Chunk* chunk);
+    // In order not to affect the current implementation of the non-pipeline engine,
+    // we only implement it for the pipeline engine
+    StatusOr<TFetchDataResultPtrs> process_chunk_for_pipeline(vectorized::Chunk* chunk);
 
     // try to add result into _sinker if ResultQueue is not full and this operation is
     // non-blocking. return true on success, false in case of that ResultQueue is full.

--- a/be/src/runtime/mysql_result_writer.h
+++ b/be/src/runtime/mysql_result_writer.h
@@ -75,7 +75,7 @@ private:
     // number of sent rows
     RuntimeProfile::Counter* _sent_rows_counter = nullptr;
 
-    const size_t max_row_buffer_size = 1024 * 1024 * 1024;
+    const size_t _max_row_buffer_size = 1024 * 1024 * 1024;
 };
 
 } // namespace starrocks

--- a/be/src/runtime/statistic_result_writer.cpp
+++ b/be/src/runtime/statistic_result_writer.cpp
@@ -60,13 +60,13 @@ Status StatisticResultWriter::append_chunk(vectorized::Chunk* chunk) {
 
     int version = down_cast<Int32Column*>(ColumnHelper::get_data_column(result_columns[0].get()))->get_data()[0];
 
-    auto* result = new (std::nothrow) TFetchDataResult();
+    std::unique_ptr<TFetchDataResult> result(new (std::nothrow) TFetchDataResult());
 
     // Step 3: fill statistic data
     if (version == STATISTIC_DATA_VERSION1) {
-        _fill_statistic_data_v1(version, result_columns, chunk, result);
+        _fill_statistic_data_v1(version, result_columns, chunk, result.get());
     } else if (version == DICT_STATISTIC_DATA_VERSION) {
-        _fill_dict_statistic_data(version, result_columns, chunk, result);
+        _fill_dict_statistic_data(version, result_columns, chunk, result.get());
     }
 
     // Step 4: send
@@ -79,7 +79,6 @@ Status StatisticResultWriter::append_chunk(vectorized::Chunk* chunk) {
     }
 
     LOG(WARNING) << "Append statistic result to sink failed.";
-    delete result;
     return status;
 }
 

--- a/be/src/runtime/statistic_result_writer.cpp
+++ b/be/src/runtime/statistic_result_writer.cpp
@@ -61,6 +61,9 @@ Status StatisticResultWriter::append_chunk(vectorized::Chunk* chunk) {
     int version = down_cast<Int32Column*>(ColumnHelper::get_data_column(result_columns[0].get()))->get_data()[0];
 
     std::unique_ptr<TFetchDataResult> result(new (std::nothrow) TFetchDataResult());
+    if (!result) {
+        return Status::MemoryAllocFailed("memory allocate failed");
+    }
 
     // Step 3: fill statistic data
     if (version == STATISTIC_DATA_VERSION1) {

--- a/be/src/runtime/statistic_result_writer.h
+++ b/be/src/runtime/statistic_result_writer.h
@@ -30,10 +30,10 @@ public:
 private:
     void _init_profile();
 
-    void _fill_statistic_data_v1(int version, const vectorized::Columns& columns, const vectorized::Chunk* chunk,
-                                 TFetchDataResult* result);
-    void _fill_dict_statistic_data(int version, const vectorized::Columns& columns, const vectorized::Chunk* chunk,
+    Status _fill_statistic_data_v1(int version, const vectorized::Columns& columns, const vectorized::Chunk* chunk,
                                    TFetchDataResult* result);
+    Status _fill_dict_statistic_data(int version, const vectorized::Columns& columns, const vectorized::Chunk* chunk,
+                                     TFetchDataResult* result);
 
 private:
     BufferControlBlock* _sinker;

--- a/be/test/runtime/buffer_control_block_test.cpp
+++ b/be/test/runtime/buffer_control_block_test.cpp
@@ -48,7 +48,7 @@ TEST_F(BufferControlBlockTest, add_one_get_one) {
     BufferControlBlock control_block(TUniqueId(), 1024);
     ASSERT_TRUE(control_block.init().ok());
 
-    TFetchDataResult* add_result = new TFetchDataResult();
+    std::unique_ptr<TFetchDataResult> add_result(new TFetchDataResult());
     add_result->result_batch.rows.push_back("hello test");
     ASSERT_TRUE(control_block.add_batch(add_result).ok());
 
@@ -74,10 +74,9 @@ TEST_F(BufferControlBlockTest, get_add_after_cancel) {
     ASSERT_TRUE(control_block.init().ok());
 
     ASSERT_TRUE(control_block.cancel().ok());
-    TFetchDataResult* add_result = new TFetchDataResult();
+    std::unique_ptr<TFetchDataResult> add_result(new TFetchDataResult());
     add_result->result_batch.rows.push_back("hello test");
     ASSERT_FALSE(control_block.add_batch(add_result).ok());
-    delete add_result;
 
     TFetchDataResult get_result;
     ASSERT_FALSE(control_block.get_batch(&get_result).ok());
@@ -99,17 +98,16 @@ TEST_F(BufferControlBlockTest, add_then_cancel) {
     pthread_create(&id, NULL, cancel_thread, &control_block);
 
     {
-        TFetchDataResult* add_result = new TFetchDataResult();
+        std::unique_ptr<TFetchDataResult> add_result(new TFetchDataResult());
         add_result->result_batch.rows.push_back("hello test1");
         add_result->result_batch.rows.push_back("hello test2");
         ASSERT_TRUE(control_block.add_batch(add_result).ok());
     }
     {
-        TFetchDataResult* add_result = new TFetchDataResult();
+        std::unique_ptr<TFetchDataResult> add_result(new TFetchDataResult());
         add_result->result_batch.rows.push_back("hello test1");
         add_result->result_batch.rows.push_back("hello test2");
         ASSERT_FALSE(control_block.add_batch(add_result).ok());
-        delete add_result;
     }
 
     TFetchDataResult get_result;
@@ -136,7 +134,7 @@ void* add_thread(void* param) {
     BufferControlBlock* control_block = static_cast<BufferControlBlock*>(param);
     sleep(1);
     {
-        TFetchDataResult* add_result = new TFetchDataResult();
+        std::unique_ptr<TFetchDataResult> add_result(new TFetchDataResult());
         add_result->result_batch.rows.push_back("hello test1");
         add_result->result_batch.rows.push_back("hello test2");
         control_block->add_batch(add_result);


### PR DESCRIPTION
1. support splitting chunk into multiple TFetchDataResults to avoid failures of thrift serialization;
 
2. try to catch std::bad_alloc in different operators

## What type of PR is this：
- [x] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5750 #5804

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

The direct reason of these coredumps is that the std::bad_alloc exception is not handled in somewhere, so I add some checks in the related logics.

In addition, I also encountered such errors when testing although I set a large enough memory limit:
```
ERROR 1064 (HY000): Couldn't serialize thrift object:
Internal buffer size overflow
```
This is because thrift has a limit on the size of the mem buffer used during serialization. It can be found in `thrift/transport/TBufferTransports.h`

![image](https://user-images.githubusercontent.com/3675229/167377729-6e43656c-6abc-4e26-ba5d-6f6852dc7586.png)

In order to avoid serialization failure, I try to split the chunk into multiple TFetchDataResults during `MysqlResultWriter::process_chunk`, make sure that the row buffer of a single TFetchDataResult will not exceed 1GB

