### PR TITLE
[Bugfix] Disable cache of S3RandomAccessFile in FileBlockManager

### DIFF
--- a/be/src/fs/fs.h
+++ b/be/src/fs/fs.h
@@ -37,6 +37,8 @@ struct SpaceInfo {
 
 class FileSystem {
 public:
+    enum Type { POSIX, S3, HDFS, BROKER, MEMORY };
+
     // Governs if/how the file is created.
     //
     // enum value                   | file exists       | file does not exist
@@ -58,6 +60,8 @@ public:
     // system.  Sophisticated users may wish to provide their own FileSystem
     // implementation instead of relying on this default environment.
     static FileSystem* Default();
+
+    virtual Type type() const = 0;
 
     // Create a brand new sequentially-readable file with the specified name.
     //  If the file does not exist, returns a non-OK status.

--- a/be/src/fs/fs_broker.h
+++ b/be/src/fs/fs_broker.h
@@ -13,12 +13,15 @@ class TBrokerFileStatus;
 class TFileBrokerServiceClient;
 class TNetworkAddress;
 
+// TODO: Remove BrokerFileSystem
 class BrokerFileSystem : public FileSystem {
 public:
     // FIXME: |timeout_ms| is unused now.
     BrokerFileSystem(const TNetworkAddress& broker_addr, std::map<std::string, std::string> properties,
                      int timeout_ms = DEFAULT_TIMEOUT_MS)
             : _broker_addr(broker_addr), _properties(std::move(properties)), _timeout_ms(timeout_ms) {}
+
+    Type type() const override { return BROKER; }
 
     StatusOr<std::unique_ptr<SequentialFile>> new_sequential_file(const std::string& path) override;
 

--- a/be/src/fs/fs_hdfs.cpp
+++ b/be/src/fs/fs_hdfs.cpp
@@ -97,6 +97,8 @@ public:
     HdfsFileSystem(HdfsFileSystem&&) = delete;
     void operator=(HdfsFileSystem&&) = delete;
 
+    Type type() const override { return HDFS; }
+
     StatusOr<std::unique_ptr<RandomAccessFile>> new_random_access_file(const std::string& path) override;
 
     StatusOr<std::unique_ptr<RandomAccessFile>> new_random_access_file(const RandomAccessFileOptions& opts,

--- a/be/src/fs/fs_memory.h
+++ b/be/src/fs/fs_memory.h
@@ -19,6 +19,8 @@ public:
     MemoryFileSystem(const MemoryFileSystem&) = delete;
     void operator=(const MemoryFileSystem&) = delete;
 
+    Type type() const override { return MEMORY; }
+
     StatusOr<std::unique_ptr<SequentialFile>> new_sequential_file(const std::string& url) override;
 
     StatusOr<std::unique_ptr<RandomAccessFile>> new_random_access_file(const std::string& url) override;

--- a/be/src/fs/fs_posix.cpp
+++ b/be/src/fs/fs_posix.cpp
@@ -265,6 +265,8 @@ class PosixFileSystem : public FileSystem {
 public:
     ~PosixFileSystem() override = default;
 
+    Type type() const override { return POSIX; }
+
     StatusOr<std::unique_ptr<SequentialFile>> new_sequential_file(const string& fname) override {
         int fd;
         RETRY_ON_EINTR(fd, ::open(fname.c_str(), O_RDONLY));

--- a/be/src/fs/fs_s3.cpp
+++ b/be/src/fs/fs_s3.cpp
@@ -191,6 +191,8 @@ public:
     S3FileSystem(S3FileSystem&&) = delete;
     void operator=(S3FileSystem&&) = delete;
 
+    Type type() const override { return S3; }
+
     StatusOr<std::unique_ptr<RandomAccessFile>> new_random_access_file(const std::string& path) override;
 
     StatusOr<std::unique_ptr<RandomAccessFile>> new_random_access_file(const RandomAccessFileOptions& opts,

--- a/be/src/storage/fs/block_manager.h
+++ b/be/src/storage/fs/block_manager.h
@@ -52,10 +52,6 @@ class Block {
 public:
     virtual ~Block() = default;
 
-    // Returns the identifier for this block.
-    // TODO: should we assign a block an identifier?
-    virtual const BlockId& id() const = 0;
-
     // Currently, each block in StarRocks will correspond to a file, but it may not be
     // in the future (that is, a block may correspond to multiple files, or multiple
     // blocks correspond to a file).
@@ -226,15 +222,6 @@ public:
     virtual Status open_block(const std::string& path, std::unique_ptr<ReadableBlock>* block) = 0;
 
     virtual void erase_block_cache(const std::string& path) = 0;
-
-    // Retrieves the IDs of all blocks under management by this block manager.
-    // These include ReadableBlocks as well as WritableBlocks.
-    //
-    // Returned block IDs are not guaranteed to be in any particular order,
-    // nor is the order guaranteed to be deterministic. Furthermore, if
-    // concurrent operations are ongoing, some of the blocks themselves may not
-    // even exist after the call.
-    virtual Status get_all_block_ids(std::vector<BlockId>* block_ids) = 0;
 
     static const std::string block_manager_preflush_control;
 };

--- a/be/src/storage/fs/file_block_manager.cpp
+++ b/be/src/storage/fs/file_block_manager.cpp
@@ -61,7 +61,7 @@ namespace internal {
 // FileWritableBlock instances is expected to be low.
 class FileWritableBlock : public WritableBlock {
 public:
-    FileWritableBlock(FileBlockManager* block_manager, string path, shared_ptr<WritableFile> writer);
+    FileWritableBlock(FileBlockManager* block_manager, shared_ptr<WritableFile> writer);
 
     ~FileWritableBlock() override;
 
@@ -71,7 +71,6 @@ public:
 
     BlockManager* block_manager() const override;
 
-    const BlockId& id() const override;
     const std::string& path() const override;
 
     Status append(const Slice& data) override;
@@ -85,8 +84,6 @@ public:
     void set_bytes_appended(size_t bytes_appended) override { _bytes_appended = bytes_appended; }
 
     State state() const override;
-
-    void handle_error(const Status& s) const;
 
     // Starts an asynchronous flush of dirty block data to disk.
     Status flush_data_async();
@@ -105,11 +102,9 @@ private:
     // Should remain alive for the lifetime of this block.
     FileBlockManager* _block_manager;
 
-    const BlockId _block_id;
-    const string _path;
-
     // The underlying opened file backing this block.
     shared_ptr<WritableFile> _writer;
+    std::string _path;
 
     State _state;
 
@@ -117,16 +112,16 @@ private:
     size_t _bytes_appended;
 };
 
-FileWritableBlock::FileWritableBlock(FileBlockManager* block_manager, string path, shared_ptr<WritableFile> writer)
+FileWritableBlock::FileWritableBlock(FileBlockManager* block_manager, shared_ptr<WritableFile> writer)
         : _block_manager(block_manager),
-          _path(std::move(path)),
           _writer(std::move(writer)),
+          _path(_writer->filename()),
           _state(CLEAN),
           _bytes_appended(0) {}
 
 FileWritableBlock::~FileWritableBlock() {
     if (_state != CLOSED) {
-        WARN_IF_ERROR(abort(), strings::Substitute("Failed to close block $0", _path));
+        WARN_IF_ERROR(abort(), strings::Substitute("Failed to close block $0", path()));
     }
 }
 
@@ -136,16 +131,11 @@ Status FileWritableBlock::close() {
 
 Status FileWritableBlock::abort() {
     RETURN_IF_ERROR(_close(NO_SYNC));
-    return _block_manager->_delete_block(_path);
+    return _block_manager->_delete_block(path());
 }
 
 BlockManager* FileWritableBlock::block_manager() const {
     return _block_manager;
-}
-
-const BlockId& FileWritableBlock::id() const {
-    CHECK(false) << "Not support Block.id(). (TODO)";
-    return _block_id;
 }
 
 const string& FileWritableBlock::path() const {
@@ -157,7 +147,7 @@ Status FileWritableBlock::append(const Slice& data) {
 }
 
 Status FileWritableBlock::appendv(const Slice* data, size_t data_cnt) {
-    DCHECK(_state == CLEAN || _state == DIRTY) << "path=" << _path << " invalid state=" << _state;
+    DCHECK(_state == CLEAN || _state == DIRTY) << "path=" << path() << " invalid state=" << _state;
     RETURN_IF_ERROR(_writer->appendv(data, data_cnt));
     _state = DIRTY;
 
@@ -169,19 +159,19 @@ Status FileWritableBlock::appendv(const Slice* data, size_t data_cnt) {
 }
 
 Status FileWritableBlock::flush_data_async() {
-    VLOG(3) << "Flushing block " << _path;
+    VLOG(3) << "Flushing block " << path();
     RETURN_IF_ERROR(_writer->flush(WritableFile::FLUSH_ASYNC));
     return Status::OK();
 }
 
 Status FileWritableBlock::finalize() {
     DCHECK(_state == CLEAN || _state == DIRTY || _state == FINALIZED)
-            << "path=" << _path << "Invalid state: " << _state;
+            << "path=" << path() << "Invalid state: " << _state;
 
     if (_state == FINALIZED) {
         return Status::OK();
     }
-    VLOG(3) << "Finalizing block " << _path;
+    VLOG(3) << "Finalizing block " << path();
     if (_state == DIRTY && BlockManager::block_manager_preflush_control == "finalize") {
         flush_data_async();
     }
@@ -205,9 +195,9 @@ Status FileWritableBlock::_close(SyncMode mode) {
     Status sync;
     if (mode == SYNC && (_state == CLEAN || _state == DIRTY || _state == FINALIZED)) {
         // Safer to synchronize data first, then metadata.
-        VLOG(3) << "Syncing block " << _path;
+        VLOG(3) << "Syncing block " << path();
         sync = _writer->sync();
-        WARN_IF_ERROR(sync, strings::Substitute("Failed to sync when closing block $0", _path));
+        WARN_IF_ERROR(sync, strings::Substitute("Failed to sync when closing block $0", path()));
     }
     Status close = _writer->close();
 
@@ -232,8 +222,9 @@ Status FileWritableBlock::_close(SyncMode mode) {
 // embed a FileBlockLocation, using the simpler BlockId instead.
 class FileReadableBlock : public ReadableBlock {
 public:
-    FileReadableBlock(FileBlockManager* block_manager, string path,
-                      std::shared_ptr<OpenedFileHandle<RandomAccessFile>> file_handle);
+    FileReadableBlock(FileBlockManager* block_manager, std::shared_ptr<OpenedFileHandle<RandomAccessFile>> file_handle);
+
+    FileReadableBlock(FileBlockManager* block_manager, std::shared_ptr<RandomAccessFile> file);
 
     ~FileReadableBlock() override;
 
@@ -241,27 +232,22 @@ public:
 
     BlockManager* block_manager() const override;
 
-    const BlockId& id() const override;
     const std::string& path() const override;
 
     Status size(uint64_t* sz) override;
 
     Status read(uint64_t offset, Slice result) override;
 
-    void handle_error(const Status& s) const;
-
 private:
     // Back pointer to the owning block manager.
     FileBlockManager* _block_manager;
 
-    // The block's identifier.
-    const BlockId _block_id;
-    const string _path;
-
     // The underlying opened file backing this block.
     std::shared_ptr<OpenedFileHandle<RandomAccessFile>> _file_handle;
+    std::shared_ptr<RandomAccessFile> _file_ref;
     // the backing file of OpenedFileHandle, not owned.
     RandomAccessFile* _file;
+    std::string _path;
 
     // Whether or not this block has been closed. Close() is thread-safe, so
     // this must be an atomic primitive.
@@ -271,14 +257,23 @@ private:
     const FileReadableBlock& operator=(const FileReadableBlock&) = delete;
 };
 
-FileReadableBlock::FileReadableBlock(FileBlockManager* block_manager, string path,
+FileReadableBlock::FileReadableBlock(FileBlockManager* block_manager,
                                      std::shared_ptr<OpenedFileHandle<RandomAccessFile>> file_handle)
-        : _block_manager(block_manager), _path(std::move(path)), _file_handle(std::move(file_handle)), _closed(false) {
-    _file = _file_handle->file();
-}
+        : _block_manager(block_manager),
+          _file_handle(std::move(file_handle)),
+          _file(_file_handle->file()),
+          _path(_file->filename()),
+          _closed(false) {}
+
+FileReadableBlock::FileReadableBlock(FileBlockManager* block_manager, std::shared_ptr<RandomAccessFile> file)
+        : _block_manager(block_manager),
+          _file_ref(std::move(file)),
+          _file(_file_ref.get()),
+          _path(_file->filename()),
+          _closed(false) {}
 
 FileReadableBlock::~FileReadableBlock() {
-    WARN_IF_ERROR(close(), strings::Substitute("Failed to close block $0", _path));
+    WARN_IF_ERROR(close(), strings::Substitute("Failed to close block $0", path()));
 }
 
 Status FileReadableBlock::close() {
@@ -292,11 +287,6 @@ Status FileReadableBlock::close() {
 
 BlockManager* FileReadableBlock::block_manager() const {
     return _block_manager;
-}
-
-const BlockId& FileReadableBlock::id() const {
-    CHECK(false) << "Not support Block.id(). (TODO)";
-    return _block_id;
 }
 
 const string& FileReadableBlock::path() const {
@@ -321,13 +311,15 @@ Status FileReadableBlock::read(uint64_t offset, Slice result) {
 
 FileBlockManager::FileBlockManager(std::shared_ptr<FileSystem> fs, BlockManagerOptions opts)
         : _fs(std::move(fs)), _opts(std::move(opts)) {
+    if (_fs->type() == FileSystem::POSIX) {
 #ifdef BE_TEST
-    _file_cache = std::make_unique<FileCache<RandomAccessFile>>("Readable file cache",
-                                                                config::file_descriptor_cache_capacity);
+        _file_cache = std::make_unique<FileCache<RandomAccessFile>>("Readable file cache",
+                                                                    config::file_descriptor_cache_capacity);
 #else
-    _file_cache = std::make_unique<FileCache<RandomAccessFile>>("Readable file cache",
-                                                                StorageEngine::instance()->file_cache());
+        _file_cache = std::make_unique<FileCache<RandomAccessFile>>("Readable file cache",
+                                                                    StorageEngine::instance()->file_cache());
 #endif
+    }
 }
 
 FileBlockManager::~FileBlockManager() = default;
@@ -345,26 +337,31 @@ Status FileBlockManager::create_block(const CreateBlockOptions& opts, std::uniqu
     wr_opts.mode = opts.mode;
     ASSIGN_OR_RETURN(writer, _fs->new_writable_file(wr_opts, opts.path));
     VLOG(1) << "Creating new block at " << opts.path;
-    *block = std::make_unique<internal::FileWritableBlock>(this, opts.path, writer);
+    *block = std::make_unique<internal::FileWritableBlock>(this, std::move(writer));
     return Status::OK();
 }
 
 Status FileBlockManager::open_block(const std::string& path, std::unique_ptr<ReadableBlock>* block) {
     VLOG(1) << "Opening block with path at " << path;
-    std::shared_ptr<OpenedFileHandle<RandomAccessFile>> file_handle(new OpenedFileHandle<RandomAccessFile>());
-    bool found = _file_cache->lookup(path, file_handle.get());
-    if (!found) {
+    if (_file_cache != nullptr) {
+        std::shared_ptr<OpenedFileHandle<RandomAccessFile>> file_handle(new OpenedFileHandle<RandomAccessFile>());
+        if (!_file_cache->lookup(path, file_handle.get())) {
+            ASSIGN_OR_RETURN(auto file, _fs->new_random_access_file(path));
+            _file_cache->insert(path, file.release(), file_handle.get());
+        }
+        *block = std::make_unique<internal::FileReadableBlock>(this, std::move(file_handle));
+    } else {
         ASSIGN_OR_RETURN(auto file, _fs->new_random_access_file(path));
-        _file_cache->insert(path, file.release(), file_handle.get());
+        *block = std::make_unique<internal::FileReadableBlock>(this, std::move(file));
     }
-
-    *block = std::make_unique<internal::FileReadableBlock>(this, path, file_handle);
     return Status::OK();
 }
 
 void FileBlockManager::erase_block_cache(const std::string& path) {
-    VLOG(1) << "erasing block cache with path at " << path;
-    _file_cache->erase(path);
+    if (_file_cache != nullptr) {
+        VLOG(1) << "erasing block cache with path at " << path;
+        _file_cache->erase(path);
+    }
 }
 
 // TODO(lingbin): We should do something to ensure that deletion can only be done
@@ -383,13 +380,6 @@ Status FileBlockManager::_delete_block(const string& path) {
     // The block's directory hierarchy is left behind. We could prune it if
     // it's empty, but that's racy and leaving it isn't much overhead.
 
-    return Status::OK();
-}
-
-// TODO(lingbin): only one level is enough?
-Status FileBlockManager::_sync_metadata(const string& path) {
-    string dir = path_util::dir_name(path);
-    RETURN_IF_ERROR(_fs->sync_dir(dir));
     return Status::OK();
 }
 

--- a/be/src/storage/fs/file_block_manager.h
+++ b/be/src/storage/fs/file_block_manager.h
@@ -76,11 +76,6 @@ public:
 
     void erase_block_cache(const std::string& path) override;
 
-    Status get_all_block_ids(std::vector<BlockId>* block_ids) override {
-        // TODO(lingbin): to be implemented after we assign each block an id
-        return Status::OK();
-    };
-
 private:
     friend class internal::FileReadableBlock;
     friend class internal::FileWritableBlock;
@@ -92,9 +87,6 @@ private:
     // the actual deletion will take place after the last open reader or
     // writer is closed.
     Status _delete_block(const std::string& path);
-
-    // Synchronizes the metadata for a block with the given location.
-    Status _sync_metadata(const std::string& path);
 
     FileSystem* fs() const { return _fs.get(); }
 


### PR DESCRIPTION
S3RandomAccessFile is not thread-safe, thus cannot be
cached in FileBlockManager.

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

