### PR TITLE
[enhancement] Add some interface for rows frame between unbouned preceding and current row

### DIFF
--- a/be/src/exec/pipeline/analysis/analytic_sink_operator.cpp
+++ b/be/src/exec/pipeline/analysis/analytic_sink_operator.cpp
@@ -88,7 +88,7 @@ Status AnalyticSinkOperator::push_chunk(RuntimeState* state, const vectorized::C
         TRY_CATCH_BAD_ALLOC(_analytor->append_column(chunk_size, _analytor->order_columns()[i].get(), column));
     }
 
-    _analytor->input_chunks().emplace_back(std::move(chunk));
+    _analytor->input_chunks().emplace_back(chunk);
 
     return _process_by_partition_if_necessary();
 }
@@ -105,12 +105,12 @@ Status AnalyticSinkOperator::_process_by_partition_if_necessary() {
             return Status::OK();
         }
 
-        size_t chunk_size = _analytor->input_chunks()[_analytor->output_chunk_index()]->num_rows();
+        auto chunk_size = static_cast<int64_t>(_analytor->input_chunks()[_analytor->output_chunk_index()]->num_rows());
         _analytor->create_agg_result_columns(chunk_size);
 
         bool is_new_partition = _analytor->is_new_partition();
         if (is_new_partition) {
-            _analytor->reset_state_for_new_partition();
+            _analytor->reset_state_for_cur_partition();
         }
 
         (this->*_process_by_partition)(chunk_size, is_new_partition);

--- a/be/src/exec/vectorized/analytic_node.cpp
+++ b/be/src/exec/vectorized/analytic_node.cpp
@@ -123,7 +123,7 @@ Status AnalyticNode::_get_next_for_unbounded_frame(RuntimeState* state, ChunkPtr
 
         bool is_new_partition = _analytor->is_new_partition();
         if (is_new_partition) {
-            _analytor->reset_state_for_new_partition();
+            _analytor->reset_state_for_cur_partition();
         }
 
         size_t chunk_size = _analytor->input_chunks()[_analytor->output_chunk_index()]->num_rows();
@@ -166,7 +166,7 @@ Status AnalyticNode::_get_next_for_unbounded_preceding_range_frame(RuntimeState*
 
         bool is_new_partition = _analytor->is_new_partition();
         if (is_new_partition) {
-            _analytor->reset_state_for_new_partition();
+            _analytor->reset_state_for_cur_partition();
         }
 
         size_t chunk_size = _analytor->input_chunks()[_analytor->output_chunk_index()]->num_rows();
@@ -215,7 +215,7 @@ Status AnalyticNode::_get_next_for_sliding_frame(RuntimeState* state, ChunkPtr* 
 
         bool is_new_partition = _analytor->is_new_partition();
         if (is_new_partition) {
-            _analytor->reset_state_for_new_partition();
+            _analytor->reset_state_for_cur_partition();
         }
 
         size_t chunk_size = _analytor->input_chunks()[_analytor->output_chunk_index()]->num_rows();
@@ -255,7 +255,7 @@ Status AnalyticNode::_get_next_for_unbounded_preceding_rows_frame(RuntimeState* 
 
         bool is_new_partition = _analytor->is_new_partition();
         if (is_new_partition) {
-            _analytor->reset_state_for_new_partition();
+            _analytor->reset_state_for_cur_partition();
         }
 
         size_t chunk_size = _analytor->input_chunks()[_analytor->output_chunk_index()]->num_rows();

--- a/be/src/exec/vectorized/analytic_node.h
+++ b/be/src/exec/vectorized/analytic_node.h
@@ -8,8 +8,7 @@
 #include "exprs/expr.h"
 #include "runtime/descriptors.h"
 
-namespace starrocks {
-namespace vectorized {
+namespace starrocks::vectorized {
 
 class AnalyticNode final : public ExecNode {
 public:
@@ -44,5 +43,4 @@ private:
     Status _fetch_next_chunk(RuntimeState* state);
     Status _try_fetch_next_partition_data(RuntimeState* state);
 };
-} // namespace vectorized
 } // namespace starrocks

--- a/be/src/exec/vectorized/analytic_node.h
+++ b/be/src/exec/vectorized/analytic_node.h
@@ -43,4 +43,4 @@ private:
     Status _fetch_next_chunk(RuntimeState* state);
     Status _try_fetch_next_partition_data(RuntimeState* state);
 };
-} // namespace starrocks
+} // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/analytor.h
+++ b/be/src/exec/vectorized/analytor.h
@@ -110,8 +110,10 @@ public:
     bool is_new_partition();
     int64_t get_total_position(int64_t local_position);
     void find_partition_end();
+    bool find_and_check_partition_end();
     void find_peer_group_end();
-    void reset_state_for_new_partition();
+    void reset_state_for_cur_partition();
+    void reset_state_for_next_partition();
 
     void remove_unused_buffer_values(RuntimeState* state);
 

--- a/be/test/exec/vectorized/analytor_test.cpp
+++ b/be/test/exec/vectorized/analytor_test.cpp
@@ -60,4 +60,86 @@ TEST_F(AnalytorTest, find_peer_group_end) {
     ASSERT_EQ(analytor.peer_group_end(), 10);
 }
 
+// NOLINTNEXTLINE
+TEST_F(AnalytorTest, reset_state_for_cur_partition) {
+    TPlanNode plan_node;
+    RowDescriptor row_desc;
+    Analytor analytor(plan_node, row_desc, nullptr);
+
+    analytor._partition_start = 3;
+    analytor._partition_end = 10;
+    analytor._found_partition_end = 20;
+    analytor.reset_state_for_cur_partition();
+    ASSERT_EQ(analytor.partition_start(), 10);
+    ASSERT_EQ(analytor.partition_end(), 20);
+    ASSERT_EQ(analytor.current_row_position(), 10);
+}
+
+// NOLINTNEXTLINE
+TEST_F(AnalytorTest, reset_state_for_next_partition) {
+    TPlanNode plan_node;
+    RowDescriptor row_desc;
+    Analytor analytor(plan_node, row_desc, nullptr);
+
+    analytor._partition_start = 10;
+    analytor._partition_end = 10;
+    analytor._found_partition_end = 20;
+    analytor.reset_state_for_cur_partition();
+    ASSERT_EQ(analytor.partition_start(), 20);
+    ASSERT_EQ(analytor.partition_end(), 20);
+    ASSERT_EQ(analytor.current_row_position(), 20);
+}
+
+// NOLINTNEXTLINE
+TEST_F(AnalytorTest, find_and_check_partition_end) {
+    TPlanNode plan_node;
+    RowDescriptor row_desc;
+    Analytor analytor1(plan_node, row_desc, nullptr);
+
+    int32_t v;
+    auto c1 = Int32Column::create();
+    v = 1;
+    c1->append_value_multiple_times(&v, 10);
+    v = 2;
+    c1->append_value_multiple_times(&v, 10);
+
+    auto c2 = Int32Column::create();
+    v = 3;
+    c2->append_value_multiple_times(&v, 5);
+    v = 4;
+    c2->append_value_multiple_times(&v, 15);
+
+    analytor1.update_input_rows(20);
+    analytor1._partition_columns.emplace_back(c1);
+    analytor1._partition_columns.emplace_back(c2);
+
+    bool end = analytor1.find_and_check_partition_end();
+    ASSERT_TRUE(end);
+    ASSERT_EQ(analytor1.found_partition_end(), 5);
+
+    end = analytor1.find_and_check_partition_end();
+    ASSERT_TRUE(end);
+    ASSERT_EQ(analytor1.found_partition_end(), 10);
+
+    end = analytor1.find_and_check_partition_end();
+    ASSERT_FALSE(end);
+    ASSERT_EQ(analytor1.found_partition_end(), 20);
+
+    // partition columns is empty
+    Analytor analytor2(plan_node, row_desc, nullptr);
+    analytor1.update_input_rows(20);
+
+    end = analytor2.find_and_check_partition_end();
+    ASSERT_FALSE(end);
+    ASSERT_EQ(analytor2.found_partition_end(), 20);
+
+    // input rows = 0
+    Analytor analytor3(plan_node, row_desc, nullptr);
+    analytor3.update_input_rows(0);
+
+    end = analytor3.find_and_check_partition_end();
+    ASSERT_FALSE(end);
+    ASSERT_EQ(analytor3.found_partition_end(), 0);
+}
+
 }

--- a/be/test/exec/vectorized/analytor_test.cpp
+++ b/be/test/exec/vectorized/analytor_test.cpp
@@ -84,7 +84,7 @@ TEST_F(AnalytorTest, reset_state_for_next_partition) {
     analytor._partition_start = 10;
     analytor._partition_end = 10;
     analytor._found_partition_end = 20;
-    analytor.reset_state_for_cur_partition();
+    analytor.reset_state_for_next_partition();
     ASSERT_EQ(analytor.partition_start(), 20);
     ASSERT_EQ(analytor.partition_end(), 20);
     ASSERT_EQ(analytor.current_row_position(), 20);
@@ -117,9 +117,13 @@ TEST_F(AnalytorTest, find_and_check_partition_end) {
     ASSERT_TRUE(end);
     ASSERT_EQ(analytor1.found_partition_end(), 5);
 
+    analytor1.reset_state_for_cur_partition();
+
     end = analytor1.find_and_check_partition_end();
     ASSERT_TRUE(end);
     ASSERT_EQ(analytor1.found_partition_end(), 10);
+
+    analytor1.reset_state_for_cur_partition();
 
     end = analytor1.find_and_check_partition_end();
     ASSERT_FALSE(end);
@@ -127,7 +131,7 @@ TEST_F(AnalytorTest, find_and_check_partition_end) {
 
     // partition columns is empty
     Analytor analytor2(plan_node, row_desc, nullptr);
-    analytor1.update_input_rows(20);
+    analytor2.update_input_rows(20);
 
     end = analytor2.find_and_check_partition_end();
     ASSERT_FALSE(end);


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5829 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Add some interface for rows betweend unbounded preceding and current row

* reset_state_for_next_partition: for `rows betweend unbounded preceding and current row`, we no need to find the bound of cur partition, so we will reset the state of next partition, when we reach the bound of cur partition.
* find_and_check_partition_end: get one chunk and search the bound, if found return true
* For rows betweend unbounded preceding and current row, we have not found the partition end, for others, _found_partition_end = _partition_end, so we use _found_partition_end instead of _partition_end as frame end
* add `found_partition_end` to `remove_unused_buffer_values`
