### PR TITLE
[Enhancement] Skip partial update logic if load only has delete

### DIFF
--- a/be/src/storage/rowset/beta_rowset_writer.cpp
+++ b/be/src/storage/rowset/beta_rowset_writer.cpp
@@ -125,7 +125,8 @@ StatusOr<RowsetSharedPtr> BetaRowsetWriter::build() {
     if (_context.tablet_schema->keys_type() == KeysType::PRIMARY_KEYS) {
         _rowset_meta->set_num_delete_files(_segment_has_deletes.size());
         _rowset_meta->set_segments_overlap(NONOVERLAPPING);
-        if (_context.partial_update_tablet_schema) {
+        // if load only has delete, we can skip the partial update logic
+        if (_context.partial_update_tablet_schema && _flush_chunk_state != FlushChunkState::DELETE) {
             DCHECK(_context.referenced_column_ids.size() == _context.partial_update_tablet_schema->columns().size());
             for (auto i = 0; i < _context.partial_update_tablet_schema->columns().size(); ++i) {
                 const auto& tablet_column = _context.partial_update_tablet_schema->column(i);

--- a/be/test/exec/vectorized/analytor_test.cpp
+++ b/be/test/exec/vectorized/analytor_test.cpp
@@ -1,15 +1,13 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
 
-#include <gtest/gtest.h>
-
 #include "exec/vectorized/analytor.h"
+
+#include <gtest/gtest.h>
 
 namespace starrocks::vectorized {
 class AnalytorTest : public ::testing::Test {
 public:
-    void SetUp() override {
-        config::vector_chunk_size = 1024;
-    }
+    void SetUp() override { config::vector_chunk_size = 1024; }
 };
 
 // NOLINTNEXTLINE
@@ -146,4 +144,4 @@ TEST_F(AnalytorTest, find_and_check_partition_end) {
     ASSERT_EQ(analytor3.found_partition_end(), 0);
 }
 
-}
+} // namespace starrocks::vectorized

--- a/be/test/http/transaction_stream_load_test.cpp
+++ b/be/test/http/transaction_stream_load_test.cpp
@@ -13,8 +13,8 @@
 #include "http/http_request.h"
 #include "runtime/exec_env.h"
 #include "runtime/stream_load/load_stream_mgr.h"
-#include "runtime/stream_load/transaction_mgr.h"
 #include "runtime/stream_load/stream_load_executor.h"
+#include "runtime/stream_load/transaction_mgr.h"
 #include "runtime/thread_resource_mgr.h"
 #include "util/brpc_stub_cache.h"
 #include "util/cpu_info.h"
@@ -131,7 +131,6 @@ TEST_F(TransactionStreamLoadActionTest, txn_begin_invalid) {
         doc.Parse(k_response_str.c_str());
         ASSERT_STREQ("INVALID_ARGUMENT", doc["Status"].GetString());
     }
-
 }
 
 TEST_F(TransactionStreamLoadActionTest, txn_begin_normal) {


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4773

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Currently, the SQL delete statement will generate a partial update load(cause the load only needs primary key columns, no need to provide other non-key columns).  Since it only has been deleted, so actually there is no need to go through any partial update related processing, we can skip them.
