### PR TITLE
[Refactor] chop FragmentExecutor::prepare into several steps

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.h
+++ b/be/src/exec/pipeline/fragment_executor.h
@@ -33,7 +33,7 @@ private:
     // 2. fragment context
     // 3. workgroup
     // 4. runtime state
-    // 5. exec pla
+    // 5. exec plan
     // 6. pipeline driver
     Status _prepare_query_ctx(ExecEnv* exec_env, const TExecPlanFragmentParams& request);
     StatusOr<std::unique_ptr<FragmentContext>> _prepare_fragment_ctx(const TExecPlanFragmentParams& request);

--- a/be/src/exec/pipeline/fragment_executor.h
+++ b/be/src/exec/pipeline/fragment_executor.h
@@ -26,7 +26,7 @@ public:
 
 private:
     void _fail_cleanup();
-    int32_t _calc_dop(const TExecPlanFragmentParams& request) const;
+    int32_t _calc_dop(ExecEnv* exec_env, const TExecPlanFragmentParams& request) const;
 
     // Several steps of prepare a fragment
     // 1. query context
@@ -40,7 +40,7 @@ private:
     StatusOr<workgroup::WorkGroupPtr> _prepare_workgroup(const TExecPlanFragmentParams& request);
     Status _prepare_runtime_state(ExecEnv* exec_env, const TExecPlanFragmentParams& request,
                                   workgroup::WorkGroupPtr wg);
-    Status _prepare_exec_plan(const TExecPlanFragmentParams& request);
+    Status _prepare_exec_plan(ExecEnv* exec_env, const TExecPlanFragmentParams& request);
     Status _prepare_global_dict(const TExecPlanFragmentParams& request);
     Status _prepare_pipeline_driver(ExecEnv* exec_env, const TExecPlanFragmentParams& request,
                                     workgroup::WorkGroupPtr wg);

--- a/be/src/exec/pipeline/fragment_executor.h
+++ b/be/src/exec/pipeline/fragment_executor.h
@@ -36,8 +36,8 @@ private:
     // 5. exec plan
     // 6. pipeline driver
     Status _prepare_query_ctx(ExecEnv* exec_env, const TExecPlanFragmentParams& request);
-    StatusOr<std::unique_ptr<FragmentContext>> _prepare_fragment_ctx(const TExecPlanFragmentParams& request);
-    StatusOr<workgroup::WorkGroupPtr> _prepare_workgroup(const TExecPlanFragmentParams& request);
+    Status _prepare_fragment_ctx(const TExecPlanFragmentParams& request);
+    Status _prepare_workgroup(const TExecPlanFragmentParams& request);
     Status _prepare_runtime_state(ExecEnv* exec_env, const TExecPlanFragmentParams& request,
                                   workgroup::WorkGroupPtr wg);
     Status _prepare_exec_plan(ExecEnv* exec_env, const TExecPlanFragmentParams& request);
@@ -47,9 +47,10 @@ private:
 
     void _decompose_data_sink_to_operator(RuntimeState* state, PipelineBuilderContext* context,
                                           const TDataSink& t_datasink, DataSink* datasink);
+
     QueryContext* _query_ctx = nullptr;
-    FragmentContext* _fragment_ctx = nullptr;
-    workgroup::WorkGroup* _wg = nullptr;
+    FragmentContextPtr _fragment_ctx = nullptr;
+    workgroup::WorkGroupPtr _wg = nullptr;
 };
 } // namespace pipeline
 } // namespace starrocks

--- a/be/src/exec/pipeline/fragment_executor.h
+++ b/be/src/exec/pipeline/fragment_executor.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "common/status.h"
+#include "exec/pipeline/pipeline_fwd.h"
 #include "exec/workgroup/work_group_fwd.h"
 #include "gen_cpp/InternalService_types.h"
 
@@ -17,6 +18,7 @@ namespace pipeline {
 class FragmentContext;
 class PipelineBuilderContext;
 class QueryContext;
+
 class FragmentExecutor {
 public:
     Status prepare(ExecEnv* exec_env, const TExecPlanFragmentParams& request);
@@ -24,6 +26,25 @@ public:
 
 private:
     void _fail_cleanup();
+    int32_t _calc_dop(const TExecPlanFragmentParams& request) const;
+
+    // Several steps of prepare a fragment
+    // 1. query context
+    // 2. fragment context
+    // 3. workgroup
+    // 4. runtime state
+    // 5. exec pla
+    // 6. pipeline driver
+    Status _prepare_query_ctx(ExecEnv* exec_env, const TExecPlanFragmentParams& request);
+    StatusOr<std::unique_ptr<FragmentContext>> _prepare_fragment_ctx(const TExecPlanFragmentParams& request);
+    StatusOr<workgroup::WorkGroupPtr> _prepare_workgroup(const TExecPlanFragmentParams& request);
+    Status _prepare_runtime_state(ExecEnv* exec_env, const TExecPlanFragmentParams& request,
+                                  workgroup::WorkGroupPtr wg);
+    Status _prepare_exec_plan(const TExecPlanFragmentParams& request);
+    Status _prepare_global_dict(const TExecPlanFragmentParams& request);
+    Status _prepare_pipeline_driver(ExecEnv* exec_env, const TExecPlanFragmentParams& request,
+                                    workgroup::WorkGroupPtr wg);
+
     void _decompose_data_sink_to_operator(RuntimeState* state, PipelineBuilderContext* context,
                                           const TDataSink& t_datasink, DataSink* datasink);
     QueryContext* _query_ctx = nullptr;

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -177,32 +177,34 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths) {
     _fragment_mgr = new FragmentMgr(this);
 
     std::unique_ptr<ThreadPool> driver_executor_thread_pool;
-    auto max_thread_num = std::thread::hardware_concurrency();
+    _max_executor_threads = std::thread::hardware_concurrency();
     if (config::pipeline_exec_thread_pool_thread_num > 0) {
-        max_thread_num = config::pipeline_exec_thread_pool_thread_num;
+        _max_executor_threads = config::pipeline_exec_thread_pool_thread_num;
     }
-    LOG(INFO) << strings::Substitute("[PIPELINE] Exec thread pool: thread_num=$0", max_thread_num);
+    _max_executor_threads = std::max<int64_t>(1, _max_executor_threads);
+    LOG(INFO) << strings::Substitute("[PIPELINE] Exec thread pool: thread_num=$0", _max_executor_threads);
     RETURN_IF_ERROR(ThreadPoolBuilder("pip_executor") // pipeline executor
                             .set_min_threads(0)
-                            .set_max_threads(max_thread_num)
+                            .set_max_threads(_max_executor_threads)
                             .set_max_queue_size(1000)
                             .set_idle_timeout(MonoDelta::FromMilliseconds(2000))
                             .build(&driver_executor_thread_pool));
     _driver_executor = new pipeline::GlobalDriverExecutor("pip_exe", std::move(driver_executor_thread_pool), false);
-    _driver_executor->initialize(max_thread_num);
+    _driver_executor->initialize(_max_executor_threads);
 
-    _driver_limiter = new pipeline::DriverLimiter(max_thread_num * config::pipeline_max_num_drivers_per_exec_thread);
+    _driver_limiter =
+            new pipeline::DriverLimiter(_max_executor_threads * config::pipeline_max_num_drivers_per_exec_thread);
 
     std::unique_ptr<ThreadPool> wg_driver_executor_thread_pool;
     RETURN_IF_ERROR(ThreadPoolBuilder("pip_wg_executor") // pipeline executor for workgroup
                             .set_min_threads(0)
-                            .set_max_threads(max_thread_num)
+                            .set_max_threads(_max_executor_threads)
                             .set_max_queue_size(1000)
                             .set_idle_timeout(MonoDelta::FromMilliseconds(2000))
                             .build(&wg_driver_executor_thread_pool));
     _wg_driver_executor =
             new pipeline::GlobalDriverExecutor("wg_pip_exe", std::move(wg_driver_executor_thread_pool), true);
-    _wg_driver_executor->initialize(max_thread_num);
+    _wg_driver_executor->initialize(_max_executor_threads);
 
     _master_info = new TMasterInfo();
     _load_path_mgr = new LoadPathMgr(this);

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -172,6 +172,7 @@ public:
     pipeline::QueryContextManager* query_context_mgr() { return _query_context_mgr; }
 
     pipeline::DriverLimiter* driver_limiter() { return _driver_limiter; }
+    int64_t max_executor_threads() { return _max_executor_threads; }
 
 private:
     Status _init(const std::vector<StorePath>& store_paths);
@@ -233,6 +234,7 @@ private:
     starrocks::pipeline::DriverExecutor* _driver_executor = nullptr;
     pipeline::DriverExecutor* _wg_driver_executor = nullptr;
     pipeline::DriverLimiter* _driver_limiter;
+    int64_t _max_executor_threads; // Max thread number of executor
 
     TMasterInfo* _master_info = nullptr;
     LoadPathMgr* _load_path_mgr = nullptr;


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [x] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

`FragmentExecutor::prepare` consists of hundreds lines of code, which is chaos. This refactor chop it into several steps, to make it more clear:
1. query context
2. fragment context
3. workgroup
4. runtime state
5. exec plan
6. pipeline driver

