### PR TITLE
[Bug] Fix memory Leak in Pipline when prepare failed

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -86,11 +86,18 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
     // duplicate invocations of rpc exec_plan_fragment.
     auto&& existing_query_ctx = exec_env->query_context_mgr()->get(query_id);
     if (existing_query_ctx) {
-        auto&& existing_fragment_ctx = existing_query_ctx->fragment_mgr()->get(fragment_instance_id);
-        if (existing_fragment_ctx) {
+        auto&& existingfragment_ctx = existing_query_ctx->fragment_mgr()->get(fragment_instance_id);
+        if (existingfragment_ctx) {
             return Status::DuplicateRpcInvocation("Duplicate invocations of exec_plan_fragment");
         }
     }
+
+    bool prepare_success = false;
+    DeferOp defer([this, &prepare_success]() {
+        if (!prepare_success) {
+            _fail_cleanup();
+        }
+    });
 
     _query_ctx = exec_env->query_context_mgr()->get_or_register(query_id);
     _query_ctx->set_exec_env(exec_env);
@@ -107,26 +114,25 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
     _query_ctx->extend_lifetime();
 
     auto fragment_ctx = std::make_unique<FragmentContext>();
-    _fragment_ctx = fragment_ctx.get();
 
-    _fragment_ctx->set_query_id(query_id);
-    _fragment_ctx->set_fragment_instance_id(fragment_instance_id);
-    _fragment_ctx->set_fe_addr(coord);
+    fragment_ctx->set_query_id(query_id);
+    fragment_ctx->set_fragment_instance_id(fragment_instance_id);
+    fragment_ctx->set_fe_addr(coord);
 
     if (query_options.__isset.is_report_success && query_options.is_report_success) {
-        _fragment_ctx->set_report_profile();
+        fragment_ctx->set_report_profile();
     }
     if (query_options.__isset.pipeline_profile_level) {
-        _fragment_ctx->set_profile_level(query_options.pipeline_profile_level);
+        fragment_ctx->set_profile_level(query_options.pipeline_profile_level);
     }
 
     LOG(INFO) << "Prepare(): query_id=" << print_id(query_id)
               << " fragment_instance_id=" << print_id(params.fragment_instance_id) << " backend_num=" << backend_num;
 
-    // wg is always non-nullable, when request.enable_resource_group is true.
     WorkGroupPtr wg = nullptr;
+    // wg is always non-nullable, when request.enable_resource_group is true.
     if (request.__isset.enable_resource_group && request.enable_resource_group) {
-        _fragment_ctx->set_enable_resource_group();
+        fragment_ctx->set_enable_resource_group();
         if (request.__isset.workgroup && request.workgroup.id != WorkGroup::DEFAULT_WG_ID) {
             wg = std::make_shared<WorkGroup>(request.workgroup);
             wg = WorkGroupManager::instance()->add_workgroup(wg);
@@ -136,7 +142,9 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
         DCHECK(wg != nullptr);
     }
 
-    _query_ctx->init_query(wg.get());
+    if (_query_ctx->init_query(wg.get())) {
+        _wg = wg.get();
+    }
 
     int32_t degree_of_parallelism = 1;
     if (request.__isset.pipeline_dop && request.pipeline_dop > 0) {
@@ -146,7 +154,7 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
         degree_of_parallelism = std::max<int32_t>(1, std::thread::hardware_concurrency() / 2);
     }
 
-    _fragment_ctx->set_runtime_state(
+    fragment_ctx->set_runtime_state(
             std::make_unique<RuntimeState>(query_id, fragment_instance_id, query_options, query_globals, exec_env));
 
     if (wg != nullptr && wg->use_big_query_mem_limit()) {
@@ -162,7 +170,7 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
     auto query_mem_tracker = _query_ctx->mem_tracker();
     SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(query_mem_tracker.get());
 
-    auto* runtime_state = _fragment_ctx->runtime_state();
+    auto* runtime_state = fragment_ctx->runtime_state();
     int func_version = request.__isset.func_version ? request.func_version : 2;
     runtime_state->set_func_version(func_version);
     // instance_mem_limit is user-designated mem_limit scaled by degree_of_parallelism times.
@@ -179,7 +187,7 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
         exec_env->runtime_filter_worker()->open_query(query_id, request.query_options, params.runtime_filter_params,
                                                       true);
     }
-    _fragment_ctx->prepare_pass_through_chunk_buffer();
+    fragment_ctx->prepare_pass_through_chunk_buffer();
 
     auto* obj_pool = runtime_state->obj_pool();
     // Set up desc tbl
@@ -200,8 +208,8 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
     }
     runtime_state->set_desc_tbl(desc_tbl);
     // Set up plan
-    RETURN_IF_ERROR(ExecNode::create_tree(runtime_state, obj_pool, fragment.plan, *desc_tbl, &_fragment_ctx->plan()));
-    ExecNode* plan = _fragment_ctx->plan();
+    RETURN_IF_ERROR(ExecNode::create_tree(runtime_state, obj_pool, fragment.plan, *desc_tbl, &fragment_ctx->plan()));
+    ExecNode* plan = fragment_ctx->plan();
     plan->push_down_join_runtime_filter_recursively(runtime_state);
     std::vector<TupleSlotMapping> empty_mappings;
     plan->push_down_tuple_slot_mappings(runtime_state, empty_mappings);
@@ -229,7 +237,7 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
     std::vector<TScanRangeParams> no_scan_ranges;
     plan->collect_scan_nodes(&scan_nodes);
 
-    MorselQueueMap& morsel_queues = _fragment_ctx->morsel_queues();
+    MorselQueueMap& morsel_queues = fragment_ctx->morsel_queues();
     for (auto& i : scan_nodes) {
         ScanNode* scan_node = down_cast<ScanNode*>(i);
         const std::vector<TScanRangeParams>& scan_ranges =
@@ -238,9 +246,9 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
         morsel_queues.emplace(scan_node->id(), std::make_unique<MorselQueue>(std::move(morsels)));
     }
 
-    PipelineBuilderContext context(_fragment_ctx, degree_of_parallelism);
+    PipelineBuilderContext context(fragment_ctx.get(), degree_of_parallelism);
     PipelineBuilder builder(context);
-    _fragment_ctx->set_pipelines(builder.build(*_fragment_ctx, plan));
+    fragment_ctx->set_pipelines(builder.build(*fragment_ctx, plan));
     // Set up sink, if required
     std::unique_ptr<DataSink> sink;
     if (fragment.__isset.output_sink) {
@@ -254,10 +262,10 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
         _decompose_data_sink_to_operator(runtime_state, &context, fragment.output_sink, sink.get());
     }
 
-    RETURN_IF_ERROR(_fragment_ctx->prepare_all_pipelines());
+    RETURN_IF_ERROR(fragment_ctx->prepare_all_pipelines());
 
     Drivers drivers;
-    const auto& pipelines = _fragment_ctx->pipelines();
+    const auto& pipelines = fragment_ctx->pipelines();
     const size_t num_pipelines = pipelines.size();
     size_t driver_id = 0;
     for (auto n = 0; n < num_pipelines; ++n) {
@@ -280,8 +288,8 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
 
             for (size_t i = 0; i < cur_pipeline_dop; ++i) {
                 auto&& operators = pipeline->create_operators(cur_pipeline_dop, i);
-                DriverPtr driver =
-                        std::make_shared<PipelineDriver>(std::move(operators), _query_ctx, _fragment_ctx, driver_id++);
+                DriverPtr driver = std::make_shared<PipelineDriver>(std::move(operators), _query_ctx,
+                                                                    fragment_ctx.get(), driver_id++);
                 driver->set_morsel_queue(std::move(morsel_queue_per_driver[i]));
                 auto* scan_operator = down_cast<ScanOperator*>(driver->source_operator());
                 if (wg != nullptr) {
@@ -300,8 +308,8 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
         } else {
             for (size_t i = 0; i < cur_pipeline_dop; ++i) {
                 auto&& operators = pipeline->create_operators(cur_pipeline_dop, i);
-                DriverPtr driver =
-                        std::make_shared<PipelineDriver>(std::move(operators), _query_ctx, _fragment_ctx, driver_id++);
+                DriverPtr driver = std::make_shared<PipelineDriver>(std::move(operators), _query_ctx,
+                                                                    fragment_ctx.get(), driver_id++);
                 setup_profile_hierarchy(pipeline, driver);
                 drivers.emplace_back(std::move(driver));
             }
@@ -309,30 +317,39 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
     }
     // The pipeline created later should be placed in the front
     runtime_state->runtime_profile()->reverse_childs();
-    _fragment_ctx->set_drivers(std::move(drivers));
+    fragment_ctx->set_drivers(std::move(drivers));
 
-    auto maybe_driver_token = exec_env->driver_limiter()->try_acquire(_fragment_ctx->drivers().size());
+    auto maybe_driver_token = exec_env->driver_limiter()->try_acquire(fragment_ctx->drivers().size());
     if (maybe_driver_token.ok()) {
-        _fragment_ctx->set_driver_token(std::move(maybe_driver_token.value()));
+        fragment_ctx->set_driver_token(std::move(maybe_driver_token.value()));
     } else {
         return maybe_driver_token.status();
     }
 
     if (wg != nullptr) {
-        for (auto& driver : _fragment_ctx->drivers()) {
+        for (auto& driver : fragment_ctx->drivers()) {
             driver->set_workgroup(wg);
         }
     }
 
+    _fragment_ctx = fragment_ctx.get();
     _query_ctx->fragment_mgr()->register_ctx(fragment_instance_id, std::move(fragment_ctx));
-
+    prepare_success = true;
     return Status::OK();
 }
 
 Status FragmentExecutor::execute(ExecEnv* exec_env) {
+    bool prepare_success = false;
+    DeferOp defer([this, &prepare_success]() {
+        if (!prepare_success) {
+            _fail_cleanup();
+        }
+    });
+
     for (const auto& driver : _fragment_ctx->drivers()) {
         RETURN_IF_ERROR(driver->prepare(_fragment_ctx->runtime_state()));
     }
+    prepare_success = true;
 
     if (_fragment_ctx->enable_resource_group()) {
         for (const auto& driver : _fragment_ctx->drivers()) {
@@ -347,19 +364,35 @@ Status FragmentExecutor::execute(ExecEnv* exec_env) {
     return Status::OK();
 }
 
+void FragmentExecutor::_fail_cleanup() {
+    if (_query_ctx) {
+        if (_fragment_ctx != nullptr) {
+            _query_ctx->fragment_mgr()->unregister(_fragment_ctx->fragment_instance_id());
+        }
+        if (_query_ctx->count_down_fragments()) {
+            auto query_id = _query_ctx->query_id();
+            if (_wg) {
+                _wg->decr_num_queries();
+            }
+            ExecEnv::GetInstance()->query_context_mgr()->remove(query_id);
+        }
+    }
+}
+
 void FragmentExecutor::_decompose_data_sink_to_operator(RuntimeState* runtime_state, PipelineBuilderContext* context,
                                                         const TDataSink& t_datasink, DataSink* datasink) {
+    auto fragment_ctx = context->fragment_context();
     if (typeid(*datasink) == typeid(starrocks::ResultSink)) {
         starrocks::ResultSink* result_sink = down_cast<starrocks::ResultSink*>(datasink);
         // Result sink doesn't have plan node id;
         OpFactoryPtr op =
                 std::make_shared<ResultSinkOperatorFactory>(context->next_operator_id(), result_sink->get_sink_type(),
-                                                            result_sink->get_output_exprs(), _fragment_ctx);
+                                                            result_sink->get_output_exprs(), fragment_ctx);
         // Add result sink operator to last pipeline
-        _fragment_ctx->pipelines().back()->add_op_factory(op);
+        fragment_ctx->pipelines().back()->add_op_factory(op);
     } else if (typeid(*datasink) == typeid(starrocks::DataStreamSender)) {
         starrocks::DataStreamSender* sender = down_cast<starrocks::DataStreamSender*>(datasink);
-        auto dop = _fragment_ctx->pipelines().back()->source_operator_factory()->degree_of_parallelism();
+        auto dop = fragment_ctx->pipelines().back()->source_operator_factory()->degree_of_parallelism();
         auto& t_stream_sink = t_datasink.stream_sink;
         bool is_dest_merge = false;
         if (t_stream_sink.__isset.is_merge && t_stream_sink.is_merge) {
@@ -380,14 +413,14 @@ void FragmentExecutor::_decompose_data_sink_to_operator(RuntimeState* runtime_st
         }
 
         std::shared_ptr<SinkBuffer> sink_buffer =
-                std::make_shared<SinkBuffer>(_fragment_ctx, sender->destinations(), is_dest_merge, dop);
+                std::make_shared<SinkBuffer>(fragment_ctx, sender->destinations(), is_dest_merge, dop);
 
         OpFactoryPtr exchange_sink = std::make_shared<ExchangeSinkOperatorFactory>(
                 context->next_operator_id(), t_stream_sink.dest_node_id, sink_buffer, sender->get_partition_type(),
                 sender->destinations(), is_pipeline_level_shuffle, dest_dop, sender->sender_id(),
                 sender->get_dest_node_id(), sender->get_partition_exprs(), sender->get_enable_exchange_pass_through(),
-                _fragment_ctx, sender->output_columns());
-        _fragment_ctx->pipelines().back()->add_op_factory(exchange_sink);
+                fragment_ctx, sender->output_columns());
+        fragment_ctx->pipelines().back()->add_op_factory(exchange_sink);
 
     } else if (typeid(*datasink) == typeid(starrocks::MultiCastDataStreamSink)) {
         // note(yan): steps are:
@@ -413,7 +446,7 @@ void FragmentExecutor::_decompose_data_sink_to_operator(RuntimeState* runtime_st
         {
             OpFactoryPtr sink_op = std::make_shared<MultiCastLocalExchangeSinkOperatorFactory>(
                     context->next_operator_id(), pseudo_plan_node_id, mcast_local_exchanger);
-            _fragment_ctx->pipelines().back()->add_op_factory(sink_op);
+            fragment_ctx->pipelines().back()->add_op_factory(sink_op);
         }
 
         // ==== create source/sink pipelines ====
@@ -437,17 +470,17 @@ void FragmentExecutor::_decompose_data_sink_to_operator(RuntimeState* runtime_st
             source_op->set_degree_of_parallelism(dop);
 
             // sink op
-            auto sink_buffer = std::make_shared<SinkBuffer>(_fragment_ctx, sender->destinations(), is_dest_merge, dop);
+            auto sink_buffer = std::make_shared<SinkBuffer>(fragment_ctx, sender->destinations(), is_dest_merge, dop);
             auto sink_op = std::make_shared<ExchangeSinkOperatorFactory>(
                     context->next_operator_id(), t_stream_sink.dest_node_id, sink_buffer, sender->get_partition_type(),
                     sender->destinations(), is_pipeline_level_shuffle, dest_dop, sender->sender_id(),
                     sender->get_dest_node_id(), sender->get_partition_exprs(),
-                    sender->get_enable_exchange_pass_through(), _fragment_ctx, sender->output_columns());
+                    sender->get_enable_exchange_pass_through(), fragment_ctx, sender->output_columns());
 
             ops.emplace_back(source_op);
             ops.emplace_back(sink_op);
             auto pp = std::make_shared<Pipeline>(context->next_pipe_id(), ops);
-            _fragment_ctx->pipelines().emplace_back(pp);
+            fragment_ctx->pipelines().emplace_back(pp);
         }
     }
 }

--- a/be/src/exec/pipeline/fragment_executor.h
+++ b/be/src/exec/pipeline/fragment_executor.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "common/status.h"
+#include "exec/workgroup/work_group_fwd.h"
 #include "gen_cpp/InternalService_types.h"
 
 namespace starrocks {
@@ -22,10 +23,12 @@ public:
     Status execute(ExecEnv* exec_env);
 
 private:
+    void _fail_cleanup();
     void _decompose_data_sink_to_operator(RuntimeState* state, PipelineBuilderContext* context,
                                           const TDataSink& t_datasink, DataSink* datasink);
     QueryContext* _query_ctx = nullptr;
     FragmentContext* _fragment_ctx = nullptr;
+    workgroup::WorkGroup* _wg = nullptr;
 };
 } // namespace pipeline
 } // namespace starrocks

--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -77,15 +77,18 @@ void QueryContext::init_mem_tracker(int64_t bytes_limit, MemTracker* parent) {
     });
 }
 
-void QueryContext::init_query(workgroup::WorkGroup* wg) {
+bool QueryContext::init_query(workgroup::WorkGroup* wg) {
+    bool res = false;
     if (wg == nullptr) {
-        return;
+        return res;
     }
-    std::call_once(_init_query_once, [=]() {
+    std::call_once(_init_query_once, [this, &res, wg]() {
         this->set_init_wg_cpu_cost(wg->total_cpu_cost());
         this->init_query_begin_time();
         wg->incr_num_queries();
+        res = true;
     });
+    return res;
 }
 
 QueryContextManager::QueryContextManager(size_t log2_num_slots)

--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -76,7 +76,7 @@ public:
     void init_mem_tracker(int64_t bytes_limit, MemTracker* parent);
     std::shared_ptr<MemTracker> mem_tracker() { return _mem_tracker; }
 
-    void init_query(workgroup::WorkGroup* wg);
+    bool init_query(workgroup::WorkGroup* wg);
 
     void incr_cpu_cost(int64_t cost) { _cur_cpu_cost += cost; }
     int64_t cpu_cost() const { return _cur_cpu_cost; }

--- a/be/src/exec/workgroup/work_group_fwd.h
+++ b/be/src/exec/workgroup/work_group_fwd.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include <memory>
+
 namespace starrocks::workgroup {
 
 class WorkGroup;


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：

close #5409 

## Problem Summary(Required) ：

When prepare stage failed, pipeline driver won't be added in
driver_exec_queue. but query_ctx or fragment_ctx has been created. So
they won't clean.

In this patch, we add a function `_fail_cleanup` which could help
cleanup query_ctx and fragment_ctx.

In addition to that I have reduced the dependency of executor to
fragment_ctx. If prepare fails, ctx will be automatically destructured,
because fragment_ctx was created with a unique_ptr which will cause
executor hold a invalid pointer. (prepare_all_pipeline failed)

