### PR TITLE
[Enhancement] Optimize the memory usage of rows between unbounded preceding and current row for non-pipeline engine

### DIFF
--- a/be/src/exec/vectorized/analytic_node.cpp
+++ b/be/src/exec/vectorized/analytic_node.cpp
@@ -42,7 +42,7 @@ AnalyticNode::AnalyticNode(ObjectPool* pool, const TPlanNode& tnode, const Descr
         if (!window.__isset.window_start && !window.__isset.window_end) {
             _get_next = &AnalyticNode::_get_next_for_unbounded_frame;
         } else if (!window.__isset.window_start && window.window_end.type == TAnalyticWindowBoundaryType::CURRENT_ROW) {
-            _get_next = &AnalyticNode::_get_next_for_unbounded_preceding_rows_frame;
+            _get_next = &AnalyticNode::_get_next_for_rows_between_unbounded_preceding_and_current_row;
         } else {
             _get_next = &AnalyticNode::_get_next_for_sliding_frame;
         }
@@ -243,27 +243,29 @@ Status AnalyticNode::_get_next_for_sliding_frame(RuntimeState* state, ChunkPtr* 
     return Status::OK();
 }
 
-Status AnalyticNode::_get_next_for_unbounded_preceding_rows_frame(RuntimeState* state, ChunkPtr* chunk, bool* eos) {
-    while (!_analytor->input_eos() || _analytor->output_chunk_index() < _analytor->input_chunks().size()) {
-        RETURN_IF_ERROR(_try_fetch_next_partition_data(state));
-        if (_analytor->input_eos() && _analytor->input_rows() == 0) {
-            *eos = true;
-            return Status::OK();
-        }
+Status AnalyticNode::_get_next_for_rows_between_unbounded_preceding_and_current_row(RuntimeState* state,
+                                                                                    ChunkPtr* chunk, bool* eos) {
+    RETURN_IF_ERROR(_fetch_next_chunk(state));
+    if (_analytor->input_eos()) {
+        *eos = true;
+        return Status::OK();
+    }
 
-        SCOPED_TIMER(_analytor->compute_timer());
+    ScopedTimer<MonotonicStopWatch> compute_timer(_analytor->compute_timer());
 
-        bool is_new_partition = _analytor->is_new_partition();
-        if (is_new_partition) {
-            _analytor->reset_state_for_cur_partition();
-        }
+    // reset state for the first partition
+    if (_analytor->current_row_position() == 0) {
+        _analytor->reset_window_state();
+    }
 
-        size_t chunk_size = _analytor->input_chunks()[_analytor->output_chunk_index()]->num_rows();
-        _analytor->create_agg_result_columns(chunk_size);
+    auto chunk_size = static_cast<int64_t>(_analytor->input_chunks()[_analytor->output_chunk_index()]->num_rows());
+    _analytor->create_agg_result_columns(chunk_size);
 
-        while (_analytor->current_row_position() < _analytor->partition_end() &&
-               _analytor->window_result_position() < chunk_size) {
-            _analytor->update_window_batch(_analytor->partition_start(), _analytor->partition_end(),
+    do {
+        bool end = _analytor->find_and_check_partition_end();
+
+        while (_analytor->current_row_position() < _analytor->found_partition_end()) {
+            _analytor->update_window_batch(_analytor->partition_start(), _analytor->found_partition_end(),
                                            _analytor->current_row_position(), _analytor->current_row_position() + 1);
 
             _analytor->update_window_result_position(1);
@@ -275,12 +277,12 @@ Status AnalyticNode::_get_next_for_unbounded_preceding_rows_frame(RuntimeState* 
             _analytor->update_current_row_position(1);
         }
 
-        if (_analytor->window_result_position() ==
-            _analytor->input_chunks()[_analytor->output_chunk_index()]->num_rows()) {
-            return _analytor->output_result_chunk(chunk);
+        if (end) {
+            _analytor->reset_state_for_next_partition();
         }
-    }
-    return Status::OK();
+    } while (_analytor->window_result_position() < chunk_size);
+
+    return _analytor->output_result_chunk(chunk);
 }
 
 Status AnalyticNode::_try_fetch_next_partition_data(RuntimeState* state) {

--- a/be/src/exec/vectorized/analytic_node.h
+++ b/be/src/exec/vectorized/analytic_node.h
@@ -36,7 +36,8 @@ private:
 
     Status _get_next_for_unbounded_frame(RuntimeState* state, ChunkPtr* chunk, bool* eos);
     Status _get_next_for_unbounded_preceding_range_frame(RuntimeState* state, ChunkPtr* chunk, bool* eos);
-    Status _get_next_for_unbounded_preceding_rows_frame(RuntimeState* state, ChunkPtr* chunk, bool* eos);
+    Status _get_next_for_rows_between_unbounded_preceding_and_current_row(RuntimeState* state, ChunkPtr* chunk,
+                                                                          bool* eos);
     Status _get_next_for_sliding_frame(RuntimeState* state, ChunkPtr* chunk, bool* eos);
     Status (AnalyticNode::*_get_next)(RuntimeState* state, ChunkPtr* chunk, bool* eos) = nullptr;
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5829 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

No need to read all the partition data and add to buffer, we will read only one chunk and then output for rows between unbounded preceding and current row.

for sql

```
select count(lo_orderkey), count(lo_partkey), count(lo_custkey), count(lo_suppkey), count(lo_quantity), count(lo_discount), count(lo_shipmode), count(_num) from 
(select lo_orderkey, lo_partkey, lo_custkey, lo_suppkey, lo_quantity, lo_discount, lo_shipmode, row_number() over(order by lo_partkey) as _num from lineorder) t1;
```

parallel = 4

before opt: TheLastFragment PeakMem(4.55G), time(25.257s)

```
    Fragment 0:
      Instance a570aad6-d009-11ec-8733-66660a909346 (host=TNetworkAddress(hostname:172.26.92.195, port:10061)):(Active: 25s247ms[25247329630ns], % non-child: 0.00%)
         - AverageThreadTokens: 4607182418800017400.00
         - MemoryLimit: 18.63 GB
         - PeakMemoryUsage: 4.55 GB
         - RowsProduced: 1
 ```

after opt: TheLastFragment PeakMem(782.66M), time(24.614s)

```
      Instance ab4b09fe-d008-11ec-8733-66660a909346 (host=TNetworkAddress(hostname:172.26.92.195, port:10061)):(Active: 24s602ms[24602663842ns], % non-child: 0.00%)
         - AverageThreadTokens: 4607182418800017400.00
         - MemoryLimit: 18.63 GB
         - PeakMemoryUsage: 782.66 MB
         - RowsProduced: 1
```
