### PR TITLE
[Enhancement] rank window function optimization, add partitioner (1)

### DIFF
--- a/be/src/column/vectorized_fwd.h
+++ b/be/src/column/vectorized_fwd.h
@@ -90,6 +90,7 @@ class JsonColumn;
 
 using ChunkPtr = std::shared_ptr<Chunk>;
 using ChunkUniquePtr = std::unique_ptr<Chunk>;
+using Chunks = std::vector<ChunkPtr>;
 
 using SchemaPtr = std::shared_ptr<Schema>;
 

--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -55,6 +55,7 @@ set(EXEC_FILES
     vectorized/aggregate/distinct_blocking_node.cpp
     vectorized/aggregate/aggregate_streaming_node.cpp
     vectorized/aggregate/distinct_streaming_node.cpp
+    vectorized/partition/chunks_partitioner.cpp
     vectorized/analytic_node.cpp
     vectorized/analytor.cpp
     vectorized/csv_scanner.cpp

--- a/be/src/exec/vectorized/partition/chunks_partitioner.cpp
+++ b/be/src/exec/vectorized/partition/chunks_partitioner.cpp
@@ -1,0 +1,234 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#include "exec/vectorized/partition/chunks_partitioner.h"
+
+#include "exprs/expr.h"
+#include "exprs/expr_context.h"
+#include "runtime/current_thread.h"
+
+namespace starrocks::vectorized {
+
+// TODO(hcf) move to utils
+#define RETURN_PTYPE_BYTE_SIZE(TYPE, SIZE)                                           \
+    case TYPE:                                                                       \
+        static_assert(sizeof(vectorized::RunTimeTypeTraits<TYPE>::CppType) == SIZE); \
+        return SIZE;
+
+inline static int get_byte_size_of_primitive_type(PrimitiveType type) {
+    switch (type) {
+        RETURN_PTYPE_BYTE_SIZE(TYPE_NULL, 1);
+        RETURN_PTYPE_BYTE_SIZE(TYPE_BOOLEAN, 1);
+        RETURN_PTYPE_BYTE_SIZE(TYPE_TINYINT, 1);
+
+        RETURN_PTYPE_BYTE_SIZE(TYPE_SMALLINT, 2);
+
+        RETURN_PTYPE_BYTE_SIZE(TYPE_DECIMAL32, 4);
+        RETURN_PTYPE_BYTE_SIZE(TYPE_DATE, 4);
+        RETURN_PTYPE_BYTE_SIZE(TYPE_INT, 4);
+        RETURN_PTYPE_BYTE_SIZE(TYPE_FLOAT, 4);
+
+        RETURN_PTYPE_BYTE_SIZE(TYPE_DECIMAL64, 8);
+        RETURN_PTYPE_BYTE_SIZE(TYPE_BIGINT, 8);
+        RETURN_PTYPE_BYTE_SIZE(TYPE_TIME, 8);
+        RETURN_PTYPE_BYTE_SIZE(TYPE_DATETIME, 8);
+        RETURN_PTYPE_BYTE_SIZE(TYPE_DOUBLE, 8);
+
+        RETURN_PTYPE_BYTE_SIZE(TYPE_DECIMAL128, 16);
+        RETURN_PTYPE_BYTE_SIZE(TYPE_LARGEINT, 16);
+        RETURN_PTYPE_BYTE_SIZE(TYPE_DECIMALV2, 16);
+    default:
+        return 0;
+    }
+}
+
+ChunksPartitioner::ChunksPartitioner(const bool has_nullable_partition_column,
+                                     const std::vector<ExprContext*>& partition_exprs,
+                                     const std::vector<PartitionColumnType>& partition_types)
+        : _has_nullable_partition_column(has_nullable_partition_column),
+          _partition_exprs(partition_exprs),
+          _partition_types(partition_types) {
+    _partition_columns.resize(partition_exprs.size());
+}
+
+Status ChunksPartitioner::prepare(RuntimeState* state) {
+    _state = state;
+    _pool = state->instance_mem_pool();
+    _init_hash_map_variant();
+    return Status::OK();
+}
+
+Status ChunksPartitioner::offer(const ChunkPtr& chunk) {
+    DCHECK(!_partition_it.has_value());
+
+    for (size_t i = 0; i < _partition_exprs.size(); i++) {
+        ASSIGN_OR_RETURN(_partition_columns[i], _partition_exprs[i]->evaluate(chunk.get()));
+    }
+
+    if (false) {
+    }
+#define HASH_MAP_METHOD(NAME)                                                                         \
+    else if (_hash_map_variant.type == PartitionHashMapVariant::Type::NAME) {                         \
+        TRY_CATCH_BAD_ALLOC(split_chunk_by_partition<decltype(_hash_map_variant.NAME)::element_type>( \
+                *_hash_map_variant.NAME, chunk));                                                     \
+    }
+    APPLY_FOR_PARTITION_VARIANT_ALL(HASH_MAP_METHOD)
+#undef HASH_MAP_METHOD
+
+    return Status::OK();
+}
+
+int32_t ChunksPartitioner::num_partitions() {
+    return _hash_map_variant.size();
+}
+
+template <typename Consumer>
+Status ChunksPartitioner::accept(Consumer&& consumer) {
+    // First, fetch chunks from hash map
+    if (false) {
+    }
+#define HASH_MAP_METHOD(NAME)                                                                           \
+    else if (_hash_map_variant.type == PartitionHashMapVariant::Type::NAME) {                           \
+        TRY_CATCH_BAD_ALLOC(fetch_chunks_from_hash_map<decltype(_hash_map_variant.NAME)::element_type>( \
+                *_hash_map_variant.NAME, consumer));                                                    \
+    }
+    APPLY_FOR_PARTITION_VARIANT_ALL(HASH_MAP_METHOD)
+#undef HASH_MAP_METHOD
+
+    // Second, fetch chunks from null_key_value if any
+    if (false) {
+    }
+#define HASH_MAP_METHOD(NAME)                                                                                 \
+    else if (_hash_map_variant.type == PartitionHashMapVariant::Type::NAME) {                                 \
+        TRY_CATCH_BAD_ALLOC(fetch_chunks_from_null_key_value<decltype(_hash_map_variant.NAME)::element_type>( \
+                *_hash_map_variant.NAME, consumer));                                                          \
+    }
+    APPLY_FOR_PARTITION_VARIANT_NULL(HASH_MAP_METHOD)
+#undef HASH_MAP_METHOD
+
+    return Status::OK();
+}
+
+bool ChunksPartitioner::_is_partition_columns_fixed_size(const std::vector<ExprContext*>& partition_expr_ctxs,
+                                                         const std::vector<PartitionColumnType>& partition_types,
+                                                         size_t* max_size, bool* has_null) {
+    size_t size = 0;
+    *has_null = false;
+
+    for (size_t i = 0; i < partition_expr_ctxs.size(); i++) {
+        ExprContext* ctx = partition_expr_ctxs[i];
+        if (partition_types[i].is_nullable) {
+            *has_null = true;
+            size += 1; // 1 bytes for  null flag.
+        }
+        PrimitiveType ptype = ctx->root()->type().type;
+        size_t byte_size = get_byte_size_of_primitive_type(ptype);
+        if (byte_size == 0) return false;
+        size += byte_size;
+    }
+    *max_size = size;
+    return true;
+}
+
+void ChunksPartitioner::_init_hash_map_variant() {
+    PartitionHashMapVariant::Type type = PartitionHashMapVariant::Type::phase1_slice;
+    if (_has_nullable_partition_column) {
+        switch (_partition_exprs.size()) {
+        case 0:
+            break;
+        case 1: {
+            auto partition_expr = _partition_exprs[0];
+            switch (partition_expr->root()->type().type) {
+#define M(TYPE, VALUE)                                             \
+    case TYPE: {                                                   \
+        type = PartitionHashMapVariant::Type::phase1_null_##VALUE; \
+        break;                                                     \
+    }
+                M(TYPE_BOOLEAN, uint8);
+                M(TYPE_TINYINT, int8);
+                M(TYPE_SMALLINT, int16);
+                M(TYPE_INT, int32);
+                M(TYPE_DECIMAL32, decimal32);
+                M(TYPE_BIGINT, int64);
+                M(TYPE_DECIMAL64, decimal64);
+                M(TYPE_DATE, date);
+                M(TYPE_DATETIME, timestamp);
+                M(TYPE_DECIMAL128, decimal128);
+                M(TYPE_LARGEINT, int128);
+                M(TYPE_CHAR, string);
+                M(TYPE_VARCHAR, string);
+#undef M
+            default:
+                break;
+            }
+        } break;
+        default:
+            break;
+        }
+    } else {
+        switch (_partition_exprs.size()) {
+        case 0:
+            break;
+        case 1: {
+            auto partition_expr_ctx = _partition_exprs[0];
+            switch (partition_expr_ctx->root()->type().type) {
+#define M(TYPE, VALUE)                                        \
+    case TYPE: {                                              \
+        type = PartitionHashMapVariant::Type::phase1_##VALUE; \
+        break;                                                \
+    }
+                M(TYPE_BOOLEAN, uint8);
+                M(TYPE_TINYINT, int8);
+                M(TYPE_SMALLINT, int16);
+                M(TYPE_INT, int32);
+                M(TYPE_DECIMAL32, decimal32);
+                M(TYPE_BIGINT, int64);
+                M(TYPE_DECIMAL64, decimal64);
+                M(TYPE_DATE, date);
+                M(TYPE_DATETIME, timestamp);
+                M(TYPE_LARGEINT, int128);
+                M(TYPE_DECIMAL128, decimal128);
+                M(TYPE_CHAR, string);
+                M(TYPE_VARCHAR, string);
+#undef M
+            default:
+                break;
+            }
+        } break;
+        default:
+            break;
+        }
+    }
+
+    bool has_null_column = false;
+    int fixed_byte_size = 0;
+    // this optimization don't need to be limited to multi-column partition.
+    // single column like float/double/decimal/largeint could also be applied to.
+    if (type == PartitionHashMapVariant::Type::phase1_slice) {
+        size_t max_size = 0;
+        if (_is_partition_columns_fixed_size(_partition_exprs, _partition_types, &max_size, &has_null_column)) {
+            // we need reserve a byte for serialization length for nullable columns
+            if (max_size < 4 || (!has_null_column && max_size == 4)) {
+                type = PartitionHashMapVariant::Type::phase1_slice_fx4;
+            } else if (max_size < 8 || (!has_null_column && max_size == 8)) {
+                type = PartitionHashMapVariant::Type::phase1_slice_fx8;
+            } else if (max_size < 16 || (!has_null_column && max_size == 16)) {
+                type = PartitionHashMapVariant::Type::phase1_slice_fx16;
+            }
+            if (!has_null_column) {
+                fixed_byte_size = max_size;
+            }
+        }
+    }
+    _hash_map_variant.init(_state, type);
+
+#define SET_FIXED_SLICE_HASH_MAP_FIELD(TYPE)                       \
+    if (type == PartitionHashMapVariant::Type::TYPE) {             \
+        _hash_map_variant.TYPE->has_null_column = has_null_column; \
+        _hash_map_variant.TYPE->fixed_byte_size = fixed_byte_size; \
+    }
+    SET_FIXED_SLICE_HASH_MAP_FIELD(phase1_slice_fx4);
+    SET_FIXED_SLICE_HASH_MAP_FIELD(phase1_slice_fx8);
+    SET_FIXED_SLICE_HASH_MAP_FIELD(phase1_slice_fx16);
+#undef SET_FIXED_SLICE_HASH_MAP_FIELD
+}
+} // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/partition/chunks_partitioner.cpp
+++ b/be/src/exec/vectorized/partition/chunks_partitioner.cpp
@@ -52,7 +52,7 @@ ChunksPartitioner::ChunksPartitioner(const bool has_nullable_partition_column,
 
 Status ChunksPartitioner::prepare(RuntimeState* state) {
     _state = state;
-    _pool = state->instance_mem_pool();
+    _mem_pool = std::make_unique<MemPool>();
     _init_hash_map_variant();
     return Status::OK();
 }

--- a/be/src/exec/vectorized/partition/chunks_partitioner.h
+++ b/be/src/exec/vectorized/partition/chunks_partitioner.h
@@ -1,0 +1,166 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#pragma once
+
+#include <any>
+
+#include "column/chunk.h"
+#include "column/vectorized_fwd.h"
+#include "common/statusor.h"
+#include "exprs/expr_context.h"
+#include "partition_hash_variant.h"
+
+namespace starrocks::vectorized {
+
+struct PartitionColumnType {
+    TypeDescriptor result_type;
+    bool is_nullable;
+};
+
+class ChunksPartitioner;
+
+using ChunksPartitionerPtr = std::shared_ptr<ChunksPartitioner>;
+
+class ChunksPartitioner {
+public:
+    ChunksPartitioner(const bool has_nullable_partition_column, const std::vector<ExprContext*>& partition_exprs,
+                      const std::vector<PartitionColumnType>& partition_types);
+
+    Status prepare(RuntimeState* state);
+
+    // Chunk is divided into multiple parts by partition columns,
+    // and each partition corresponds to a key-value pair in the hash map
+    Status offer(const ChunkPtr& chunk);
+
+    // Number of partitions
+    int32_t num_partitions();
+
+    // Consumers consume from the hash map
+    // method signature is: bool consumer(int32_t partition_idx, const ChunkPtr& chunk)
+    // The return value of the consumer denote whether to continue or not
+    template <typename Consumer>
+    Status accept(Consumer&& consumer);
+
+private:
+    bool _is_partition_columns_fixed_size(const std::vector<ExprContext*>& partition_expr_ctxs,
+                                          const std::vector<PartitionColumnType>& partition_types, size_t* max_size,
+                                          bool* has_null);
+    void _init_hash_map_variant();
+
+private:
+    const bool _has_nullable_partition_column;
+    const std::vector<ExprContext*> _partition_exprs;
+    const std::vector<PartitionColumnType> _partition_types;
+
+    RuntimeState* _state = nullptr;
+    MemPool* _pool = nullptr;
+
+    Columns _partition_columns;
+    // Hash map which holds chunks of different partitions
+    PartitionHashMapVariant _hash_map_variant;
+
+    // Iterator of partitions
+    std::any _partition_it;
+    // Iterator of chunks of current partition
+    std::any _chunk_it;
+    // Offset of current consuming partition
+    int32_t _partition_idx = -1;
+    bool _hash_map_eos = false;
+    bool _null_key_eos = false;
+
+private:
+    template <typename HashMapWithKey>
+    void split_chunk_by_partition(HashMapWithKey& hash_map_with_key, const ChunkPtr& chunk) {
+        hash_map_with_key.append_chunk(chunk, _partition_columns, _pool);
+    }
+
+    // Fetch chunks from hash map, return true if reaches eos
+    template <typename HashMapWithKey, typename Consumer>
+    bool fetch_chunks_from_hash_map(HashMapWithKey& hash_map_with_key, Consumer&& consumer) {
+        if (_hash_map_eos) {
+            return true;
+        }
+        if (!_partition_it.has_value()) {
+            _partition_it = hash_map_with_key.hash_map.begin();
+            _partition_idx = 0;
+        }
+
+        using PartitionIterator = typename HashMapWithKey::Iterator;
+        PartitionIterator partition_it = std::any_cast<PartitionIterator>(_partition_it);
+        const PartitionIterator partition_end = hash_map_with_key.hash_map.end();
+
+        using ChunkIterator = typename std::vector<ChunkPtr>::iterator;
+        ChunkIterator chunk_it;
+        DeferOp defer([&]() {
+            if (partition_it == partition_end) {
+                _hash_map_eos = true;
+                _partition_it.reset();
+                _chunk_it.reset();
+            } else {
+                _partition_it = partition_it;
+                _chunk_it = chunk_it;
+            }
+        });
+
+        while (partition_it != partition_end) {
+            std::vector<ChunkPtr>& chunks = partition_it->second.chunks;
+            if (!_chunk_it.has_value()) {
+                _chunk_it = chunks.begin();
+            }
+
+            chunk_it = std::any_cast<ChunkIterator>(_chunk_it);
+            ChunkIterator chunk_end = chunks.end();
+
+            while (chunk_it != chunk_end) {
+                if (!consumer(_partition_idx, *chunk_it++)) {
+                    return false;
+                }
+            }
+
+            // Move to next partition
+            ++partition_it;
+            ++_partition_idx;
+            _chunk_it.reset();
+        }
+
+        return true;
+    }
+
+    // Fetch chunks from HashMapWithKey.null_key_value, return true if reaches eos
+    template <typename HashMapWithKey, typename Consumer>
+    bool fetch_chunks_from_null_key_value(HashMapWithKey& hash_map_with_key, Consumer&& consumer) {
+        if (_null_key_eos) {
+            return true;
+        }
+
+        std::vector<ChunkPtr>& chunks = hash_map_with_key.null_key_value.chunks;
+
+        if (!_chunk_it.has_value()) {
+            _chunk_it = chunks.begin();
+        }
+
+        using ChunkIterator = typename std::vector<ChunkPtr>::iterator;
+        ChunkIterator chunk_it = std::any_cast<ChunkIterator>(_chunk_it);
+        const ChunkIterator chunk_end = chunks.end();
+
+        DeferOp defer([&]() {
+            if (chunk_it == chunk_end) {
+                _null_key_eos = true;
+                _chunk_it.reset();
+            } else {
+                _chunk_it = chunk_it;
+            }
+        });
+
+        while (chunk_it != chunk_end) {
+            // Because we first fetch chunks from hash_map, so the _partition_idx here
+            // is already set to hash_map.size()
+            if (!consumer(_partition_idx, *chunk_it++)) {
+                return false;
+            }
+        }
+        return true;
+    }
+};
+
+} // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/partition/chunks_partitioner.h
+++ b/be/src/exec/vectorized/partition/chunks_partitioner.h
@@ -47,31 +47,9 @@ private:
                                           bool* has_null);
     void _init_hash_map_variant();
 
-private:
-    const bool _has_nullable_partition_column;
-    const std::vector<ExprContext*> _partition_exprs;
-    const std::vector<PartitionColumnType> _partition_types;
-
-    RuntimeState* _state = nullptr;
-    MemPool* _pool = nullptr;
-
-    Columns _partition_columns;
-    // Hash map which holds chunks of different partitions
-    PartitionHashMapVariant _hash_map_variant;
-
-    // Iterator of partitions
-    std::any _partition_it;
-    // Iterator of chunks of current partition
-    std::any _chunk_it;
-    // Offset of current consuming partition
-    int32_t _partition_idx = -1;
-    bool _hash_map_eos = false;
-    bool _null_key_eos = false;
-
-private:
     template <typename HashMapWithKey>
     void split_chunk_by_partition(HashMapWithKey& hash_map_with_key, const ChunkPtr& chunk) {
-        hash_map_with_key.append_chunk(chunk, _partition_columns, _pool);
+        hash_map_with_key.append_chunk(chunk, _partition_columns, _mem_pool.get());
     }
 
     // Fetch chunks from hash map, return true if reaches eos
@@ -161,6 +139,25 @@ private:
         }
         return true;
     }
-};
 
+    const bool _has_nullable_partition_column;
+    const std::vector<ExprContext*> _partition_exprs;
+    const std::vector<PartitionColumnType> _partition_types;
+
+    RuntimeState* _state = nullptr;
+    std::unique_ptr<MemPool> _mem_pool = nullptr;
+
+    Columns _partition_columns;
+    // Hash map which holds chunks of different partitions
+    PartitionHashMapVariant _hash_map_variant;
+
+    // Iterator of partitions
+    std::any _partition_it;
+    // Iterator of chunks of current partition
+    std::any _chunk_it;
+    // Offset of current consuming partition
+    int32_t _partition_idx = -1;
+    bool _hash_map_eos = false;
+    bool _null_key_eos = false;
+};
 } // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/partition/partition_hash_map.h
+++ b/be/src/exec/vectorized/partition/partition_hash_map.h
@@ -1,0 +1,282 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#pragma once
+
+#include "column/chunk.h"
+#include "column/column_hash.h"
+#include "column/column_helper.h"
+#include "column/hash_set.h"
+#include "column/type_traits.h"
+#include "column/vectorized_fwd.h"
+#include "gutil/strings/fastmem.h"
+#include "util/phmap/phmap.h"
+
+namespace starrocks::vectorized {
+
+struct PartitionChunks {
+    Chunks chunks;
+
+    // Used to save the indexes of chunk of this partition, to avoid calling Chunk::append_selective many times
+    // It's a temporary data struct which is only valid in current invocation of append_chunk_for_one_key
+    // or append_chunk_for_one_nullable_key, and after invokcation, it will be clean up
+    std::vector<uint32_t> select_indexes;
+    // Used to save the remain size of last chunk in chunks
+    // Avoid virtual function call `chunks->back()->num_rows()`
+    int32_t remain_size = 0;
+};
+
+// =====================
+// one level partition hash map
+template <PhmapSeed seed>
+using Int8PartitionHashMap = phmap::flat_hash_map<int8_t, PartitionChunks, StdHashWithSeed<int8_t, seed>>;
+template <PhmapSeed seed>
+using Int16PartitionHashMap = phmap::flat_hash_map<int16_t, PartitionChunks, StdHashWithSeed<int16_t, seed>>;
+template <PhmapSeed seed>
+using Int32PartitionHashMap = phmap::flat_hash_map<int32_t, PartitionChunks, StdHashWithSeed<int32_t, seed>>;
+template <PhmapSeed seed>
+using Int64PartitionHashMap = phmap::flat_hash_map<int64_t, PartitionChunks, StdHashWithSeed<int64_t, seed>>;
+template <PhmapSeed seed>
+using Int128PartitionHashMap = phmap::flat_hash_map<int128_t, PartitionChunks, Hash128WithSeed<seed>>;
+template <PhmapSeed seed>
+using DatePartitionHashMap = phmap::flat_hash_map<DateValue, PartitionChunks, StdHashWithSeed<DateValue, seed>>;
+template <PhmapSeed seed>
+using TimeStampPartitionHashMap =
+        phmap::flat_hash_map<TimestampValue, PartitionChunks, StdHashWithSeed<TimestampValue, seed>>;
+template <PhmapSeed seed>
+using SlicePartitionHashMap = phmap::flat_hash_map<Slice, PartitionChunks, SliceHashWithSeed<seed>, SliceEqual>;
+
+// ==================
+// one level fixed size slice hash map
+template <PhmapSeed seed>
+using FixedSize4SlicePartitionHashMap =
+        phmap::flat_hash_map<SliceKey4, PartitionChunks, FixedSizeSliceKeyHash<SliceKey4, seed>>;
+template <PhmapSeed seed>
+using FixedSize8SlicePartitionHashMap =
+        phmap::flat_hash_map<SliceKey8, PartitionChunks, FixedSizeSliceKeyHash<SliceKey8, seed>>;
+template <PhmapSeed seed>
+using FixedSize16SlicePartitionHashMap =
+        phmap::flat_hash_map<SliceKey16, PartitionChunks, FixedSizeSliceKeyHash<SliceKey16, seed>>;
+
+struct PartitionHashMapBase {
+    const int32_t chunk_size;
+
+    PartitionHashMapBase(int32_t chunk_size) : chunk_size(chunk_size) {}
+
+protected:
+    void alloc_new_buffer(PartitionChunks& value, const ChunkPtr& chunk) {
+        value.chunks.push_back(chunk->clone_empty());
+        value.select_indexes.clear();
+        value.remain_size = chunk_size;
+    }
+
+    void flush(PartitionChunks& value, const ChunkPtr& chunk) {
+        if (!value.chunks.empty() && !value.select_indexes.empty()) {
+            value.chunks.back()->append_selective(*chunk, value.select_indexes.data(), 0, value.select_indexes.size());
+            value.select_indexes.clear();
+            value.remain_size = chunk_size - value.chunks.back()->num_rows();
+        }
+    }
+
+    // Append chunk to the hash_map for one non-nullable key
+    // Each key mapped to a PartitionChunks which holds an array of chunks
+    // chunk will be divided into multiply parts by partition key, and each parts will be append to the
+    // last chunk of PartitionChunks.chunks. New chunk will be allocated if the last chunk reaches its capacity
+    // @key_loader used to load key for number type or slice type
+    template <typename HashMap, typename KeyLoader, typename KeyAllocator>
+    void append_chunk_for_one_key(HashMap& hash_map, ChunkPtr chunk, KeyLoader&& key_loader,
+                                  KeyAllocator&& key_allocator) {
+        const auto size = chunk->num_rows();
+        for (uint32_t i = 0; i < size; i++) {
+            const auto& key = key_loader(i);
+            auto iter = hash_map.lazy_emplace(
+                    key, [&](const auto& ctor) { return ctor(key_allocator(key), PartitionChunks()); });
+            auto& value = iter->second;
+            if (value.chunks.empty() || value.remain_size <= 0) {
+                if (!value.chunks.empty()) {
+                    value.chunks.back()->append_selective(*chunk, value.select_indexes.data(), 0,
+                                                          value.select_indexes.size());
+                }
+
+                alloc_new_buffer(value, chunk);
+            }
+            value.select_indexes.push_back(i);
+            value.remain_size--;
+        }
+
+        for (auto& [key, value] : hash_map) {
+            flush(value, chunk);
+        }
+    }
+
+    // Append chunk to the hash_map for one nullable key
+    // We maintain an additional PartitionChunks called null_key_value for null key
+    // Each key mapped to a PartitionChunks which holds an array of chunks
+    // chunk will be divided into multiply parts by partition key, and each parts will be append to the
+    // last chunk of PartitionChunks.chunks. New chunk will be allocated if the last chunk reaches its capacity
+    // @key_loader used to load key for number type or slice type
+    template <typename HashMap, typename KeyLoader, typename KeyAllocator>
+    void append_chunk_for_one_nullable_key(HashMap& hash_map, PartitionChunks& null_key_value, ChunkPtr chunk,
+                                           const NullableColumn* nullable_key_column, KeyLoader&& key_loader,
+                                           KeyAllocator&& key_allocator) {
+        if (nullable_key_column->only_null()) {
+            const auto size = chunk->num_rows();
+            if (null_key_value.chunks.empty() || null_key_value.remain_size <= 0) {
+                if (!null_key_value.chunks.empty()) {
+                    null_key_value.chunks.back()->append_selective(*chunk, null_key_value.select_indexes.data(), 0,
+                                                                   null_key_value.select_indexes.size());
+                }
+
+                alloc_new_buffer(null_key_value, chunk);
+            }
+            int32_t offset = 0;
+            auto cur_remain_size = size;
+            while (null_key_value.remain_size < cur_remain_size) {
+                null_key_value.chunks.back()->append(*chunk, offset, null_key_value.remain_size);
+                offset += null_key_value.remain_size;
+                cur_remain_size -= null_key_value.remain_size;
+
+                alloc_new_buffer(null_key_value, chunk);
+            }
+            null_key_value.chunks.back()->append(*chunk, offset, cur_remain_size);
+            null_key_value.remain_size = chunk_size - null_key_value.chunks.back()->num_rows();
+        } else {
+            const auto& null_flag_data = nullable_key_column->null_column()->get_data();
+            const auto size = chunk->num_rows();
+
+            for (uint32_t i = 0; i < size; i++) {
+                PartitionChunks* value_ptr = nullptr;
+                if (null_flag_data[i] == 1) {
+                    value_ptr = &null_key_value;
+                } else {
+                    const auto& key = key_loader(i);
+                    auto iter = hash_map.lazy_emplace(
+                            key, [&](const auto& ctor) { return ctor(key_allocator(key), PartitionChunks()); });
+                    value_ptr = &iter->second;
+                }
+
+                auto& value = *value_ptr;
+                if (value.chunks.empty() || value.remain_size <= 0) {
+                    if (!value.chunks.empty()) {
+                        value.chunks.back()->append_selective(*chunk, value.select_indexes.data(), 0,
+                                                              value.select_indexes.size());
+                    }
+
+                    alloc_new_buffer(value, chunk);
+                }
+                value.select_indexes.push_back(i);
+                value.remain_size--;
+            }
+
+            for (auto& [_, value] : hash_map) {
+                flush(value, chunk);
+            }
+            flush(null_key_value, chunk);
+        }
+    }
+};
+
+template <PrimitiveType primitive_type, typename HashMap>
+struct PartitionHashMapWithOneNumberKey : public PartitionHashMapBase {
+    using Iterator = typename HashMap::iterator;
+    using ColumnType = RunTimeColumnType<primitive_type>;
+    using FieldType = RunTimeCppType<primitive_type>;
+    HashMap hash_map;
+
+    PartitionHashMapWithOneNumberKey(int32_t chunk_size) : PartitionHashMapBase(chunk_size) {}
+
+    void append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* pool) {
+        DCHECK(!key_columns[0]->is_nullable());
+        const auto* key_column = down_cast<ColumnType*>(key_columns[0].get());
+        const auto& key_column_data = key_column->get_data();
+        append_chunk_for_one_key(
+                hash_map, chunk, [&](uint32_t offset) { return key_column_data[offset]; },
+                [](const FieldType& key) { return key; });
+    }
+};
+
+template <PrimitiveType primitive_type, typename HashMap>
+struct PartitionHashMapWithOneNullableNumberKey : public PartitionHashMapBase {
+    using Iterator = typename HashMap::iterator;
+    using ColumnType = RunTimeColumnType<primitive_type>;
+    using FieldType = RunTimeCppType<primitive_type>;
+    HashMap hash_map;
+    PartitionChunks null_key_value;
+
+    PartitionHashMapWithOneNullableNumberKey(int32_t chunk_size) : PartitionHashMapBase(chunk_size) {}
+
+    void append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* pool) {
+        DCHECK(key_columns[0]->is_nullable());
+        const auto* nullable_key_column = ColumnHelper::as_raw_column<NullableColumn>(key_columns[0].get());
+        const auto& key_column_data = down_cast<ColumnType*>(nullable_key_column->data_column().get())->get_data();
+        append_chunk_for_one_nullable_key(
+                hash_map, null_key_value, chunk, nullable_key_column,
+                [&](uint32_t offset) { return key_column_data[offset]; }, [](const FieldType& key) { return key; });
+    }
+};
+
+template <typename HashMap>
+struct PartitionHashMapWithOneStringKey : public PartitionHashMapBase {
+    using Iterator = typename HashMap::iterator;
+    HashMap hash_map;
+
+    PartitionHashMapWithOneStringKey(int32_t chunk_size) : PartitionHashMapBase(chunk_size) {}
+
+    void append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* pool) {
+        DCHECK(!key_columns[0]->is_nullable());
+        const auto* key_column = down_cast<BinaryColumn*>(key_columns[0].get());
+        append_chunk_for_one_key(
+                hash_map, chunk, [&](uint32_t offset) { return key_column->get_slice(offset); },
+                [&](const Slice& key) {
+                    uint8_t* pos = pool->allocate(key.size);
+                    strings::memcpy_inlined(pos, key.data, key.size);
+                    return Slice{pos, key.size};
+                });
+    }
+};
+
+template <typename HashMap>
+struct PartitionHashMapWithOneNullableStringKey : public PartitionHashMapBase {
+    using Iterator = typename HashMap::iterator;
+    HashMap hash_map;
+    PartitionChunks null_key_value;
+
+    PartitionHashMapWithOneNullableStringKey(int32_t chunk_size) : PartitionHashMapBase(chunk_size) {}
+
+    void append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* pool) {
+        DCHECK(key_columns[0]->is_nullable());
+        const auto* nullable_key_column = ColumnHelper::as_raw_column<NullableColumn>(key_columns[0].get());
+        const auto* key_column = down_cast<BinaryColumn*>(nullable_key_column->data_column().get());
+        append_chunk_for_one_nullable_key(
+                hash_map, null_key_value, chunk, nullable_key_column,
+                [&](uint32_t offset) { return key_column->get_slice(offset); },
+                [&](const Slice& key) {
+                    uint8_t* pos = pool->allocate(key.size);
+                    strings::memcpy_inlined(pos, key.data, key.size);
+                    return Slice{pos, key.size};
+                });
+    }
+};
+
+// TODO(hcf) to be implemented
+template <typename HashMap>
+struct PartitionHashMapWithSerializedKey {
+    using Iterator = typename HashMap::iterator;
+    HashMap hash_map;
+
+    PartitionHashMapWithSerializedKey(int32_t chunk_size) {}
+    void append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* pool) {}
+};
+
+// TODO(hcf) to be implemented
+template <typename HashMap>
+struct PartitionHashMapWithSerializedKeyFixedSize {
+    using Iterator = typename HashMap::iterator;
+    HashMap hash_map;
+    bool has_null_column = false;
+    int fixed_byte_size = -1; // unset state
+
+    PartitionHashMapWithSerializedKeyFixedSize(int32_t chunk_size) {}
+    void append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* pool) {}
+};
+
+} // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/partition/partition_hash_map.h
+++ b/be/src/exec/vectorized/partition/partition_hash_map.h
@@ -64,8 +64,14 @@ struct PartitionHashMapBase {
 
 protected:
     void alloc_new_buffer(PartitionChunks& value, const ChunkPtr& chunk) {
-        value.chunks.push_back(chunk->clone_empty());
+        static size_t reserve_size = 1;
+        // Cause we don't know the cardinality of the partition columns, so we
+        // shouldn't reserve too much space for the buffered chunk
+        // Now the reserve size is set to 1, advanced mechanism may be introduced later
+        ChunkPtr new_chunk = chunk->clone_empty_with_slot(reserve_size);
         value.select_indexes.clear();
+        value.select_indexes.reserve(reserve_size);
+        value.chunks.push_back(std::move(new_chunk));
         value.remain_size = chunk_size;
     }
 

--- a/be/src/exec/vectorized/partition/partition_hash_variant.h
+++ b/be/src/exec/vectorized/partition/partition_hash_variant.h
@@ -1,0 +1,284 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+#pragma once
+
+#include "exec/vectorized/partition/partition_hash_map.h"
+#include "runtime/runtime_state.h"
+
+namespace starrocks::vectorized {
+
+#define APPLY_FOR_PARTITION_VARIANT_NOT_NULL(M) \
+    M(phase1_uint8)                             \
+    M(phase1_int8)                              \
+    M(phase1_int16)                             \
+    M(phase1_int32)                             \
+    M(phase1_int64)                             \
+    M(phase1_int128)                            \
+    M(phase1_decimal32)                         \
+    M(phase1_decimal64)                         \
+    M(phase1_decimal128)                        \
+    M(phase1_date)                              \
+    M(phase1_timestamp)                         \
+    M(phase1_string)                            \
+    M(phase1_slice)                             \
+    M(phase1_slice_fx4)                         \
+    M(phase1_slice_fx8)                         \
+    M(phase1_slice_fx16)
+
+#define APPLY_FOR_PARTITION_VARIANT_NULL(M) \
+    M(phase1_null_uint8)                    \
+    M(phase1_null_int8)                     \
+    M(phase1_null_int16)                    \
+    M(phase1_null_int32)                    \
+    M(phase1_null_int64)                    \
+    M(phase1_null_int128)                   \
+    M(phase1_null_decimal32)                \
+    M(phase1_null_decimal64)                \
+    M(phase1_null_decimal128)               \
+    M(phase1_null_date)                     \
+    M(phase1_null_timestamp)                \
+    M(phase1_null_string)
+
+#define APPLY_FOR_PARTITION_VARIANT_ALL(M) \
+    M(phase1_uint8)                        \
+    M(phase1_int8)                         \
+    M(phase1_int16)                        \
+    M(phase1_int32)                        \
+    M(phase1_int64)                        \
+    M(phase1_int128)                       \
+    M(phase1_decimal32)                    \
+    M(phase1_decimal64)                    \
+    M(phase1_decimal128)                   \
+    M(phase1_date)                         \
+    M(phase1_timestamp)                    \
+    M(phase1_string)                       \
+    M(phase1_slice)                        \
+    M(phase1_null_uint8)                   \
+    M(phase1_null_int8)                    \
+    M(phase1_null_int16)                   \
+    M(phase1_null_int32)                   \
+    M(phase1_null_int64)                   \
+    M(phase1_null_int128)                  \
+    M(phase1_null_decimal32)               \
+    M(phase1_null_decimal64)               \
+    M(phase1_null_decimal128)              \
+    M(phase1_null_date)                    \
+    M(phase1_null_timestamp)               \
+    M(phase1_null_string)                  \
+    M(phase1_slice_fx4)                    \
+    M(phase1_slice_fx8)                    \
+    M(phase1_slice_fx16)
+
+// Hash maps for phase1
+template <PhmapSeed seed>
+using UInt8PartitionHashMapWithOneNumberKey =
+        PartitionHashMapWithOneNumberKey<TYPE_BOOLEAN, Int8PartitionHashMap<seed>>;
+template <PhmapSeed seed>
+using Int8PartitionHashMapWithOneNumberKey = PartitionHashMapWithOneNumberKey<TYPE_TINYINT, Int8PartitionHashMap<seed>>;
+template <PhmapSeed seed>
+using Int16PartitionHashMapWithOneNumberKey =
+        PartitionHashMapWithOneNumberKey<TYPE_SMALLINT, Int16PartitionHashMap<seed>>;
+template <PhmapSeed seed>
+using Int32PartitionHashMapWithOneNumberKey = PartitionHashMapWithOneNumberKey<TYPE_INT, Int32PartitionHashMap<seed>>;
+template <PhmapSeed seed>
+using Int64PartitionHashMapWithOneNumberKey =
+        PartitionHashMapWithOneNumberKey<TYPE_BIGINT, Int64PartitionHashMap<seed>>;
+template <PhmapSeed seed>
+using Int128PartitionHashMapWithOneNumberKey =
+        PartitionHashMapWithOneNumberKey<TYPE_LARGEINT, Int128PartitionHashMap<seed>>;
+template <PhmapSeed seed>
+using Decimal32PartitionHashMapWithOneNumberKey =
+        PartitionHashMapWithOneNumberKey<TYPE_DECIMAL32, Int32PartitionHashMap<seed>>;
+template <PhmapSeed seed>
+using Decimal64PartitionHashMapWithOneNumberKey =
+        PartitionHashMapWithOneNumberKey<TYPE_DECIMAL64, Int64PartitionHashMap<seed>>;
+template <PhmapSeed seed>
+using Decimal128PartitionHashMapWithOneNumberKey =
+        PartitionHashMapWithOneNumberKey<TYPE_DECIMAL128, Int128PartitionHashMap<seed>>;
+
+template <PhmapSeed seed>
+using DatePartitionHashMapWithOneNumberKey = PartitionHashMapWithOneNumberKey<TYPE_DATE, DatePartitionHashMap<seed>>;
+template <PhmapSeed seed>
+using TimeStampPartitionHashMapWithOneNumberKey =
+        PartitionHashMapWithOneNumberKey<TYPE_DATETIME, TimeStampPartitionHashMap<seed>>;
+
+template <PhmapSeed seed>
+using NullUInt8PartitionHashMapWithOneNumberKey =
+        PartitionHashMapWithOneNullableNumberKey<TYPE_BOOLEAN, Int8PartitionHashMap<seed>>;
+template <PhmapSeed seed>
+using NullInt8PartitionHashMapWithOneNumberKey =
+        PartitionHashMapWithOneNullableNumberKey<TYPE_TINYINT, Int8PartitionHashMap<seed>>;
+template <PhmapSeed seed>
+using NullInt16PartitionHashMapWithOneNumberKey =
+        PartitionHashMapWithOneNullableNumberKey<TYPE_SMALLINT, Int16PartitionHashMap<seed>>;
+template <PhmapSeed seed>
+using NullInt32PartitionHashMapWithOneNumberKey =
+        PartitionHashMapWithOneNullableNumberKey<TYPE_INT, Int32PartitionHashMap<seed>>;
+template <PhmapSeed seed>
+using NullInt64PartitionHashMapWithOneNumberKey =
+        PartitionHashMapWithOneNullableNumberKey<TYPE_BIGINT, Int64PartitionHashMap<seed>>;
+template <PhmapSeed seed>
+using NullInt128PartitionHashMapWithOneNumberKey =
+        PartitionHashMapWithOneNullableNumberKey<TYPE_LARGEINT, Int128PartitionHashMap<seed>>;
+template <PhmapSeed seed>
+using NullDecimal32PartitionHashMapWithOneNumberKey =
+        PartitionHashMapWithOneNullableNumberKey<TYPE_DECIMAL32, Int32PartitionHashMap<seed>>;
+template <PhmapSeed seed>
+using NullDecimal64PartitionHashMapWithOneNumberKey =
+        PartitionHashMapWithOneNullableNumberKey<TYPE_DECIMAL64, Int64PartitionHashMap<seed>>;
+template <PhmapSeed seed>
+using NullDecimal128PartitionHashMapWithOneNumberKey =
+        PartitionHashMapWithOneNullableNumberKey<TYPE_DECIMAL128, Int128PartitionHashMap<seed>>;
+
+template <PhmapSeed seed>
+using NullDatePartitionHashMapWithOneNumberKey =
+        PartitionHashMapWithOneNullableNumberKey<TYPE_DATE, DatePartitionHashMap<seed>>;
+template <PhmapSeed seed>
+using NullTimeStampPartitionHashMapWithOneNumberKey =
+        PartitionHashMapWithOneNullableNumberKey<TYPE_DATETIME, TimeStampPartitionHashMap<seed>>;
+
+// For string type, we use slice type as hashmap key
+template <PhmapSeed seed>
+using OneStringPartitionHashMap = PartitionHashMapWithOneStringKey<SlicePartitionHashMap<seed>>;
+template <PhmapSeed seed>
+using NullOneStringPartitionHashMap = PartitionHashMapWithOneNullableStringKey<SlicePartitionHashMap<seed>>;
+template <PhmapSeed seed>
+using SerializedKeyPartitionHashMap = PartitionHashMapWithSerializedKey<SlicePartitionHashMap<seed>>;
+
+// fixed slice key type.
+template <PhmapSeed seed>
+using SerializedKeyFixedSize4PartitionHashMap =
+        PartitionHashMapWithSerializedKeyFixedSize<FixedSize4SlicePartitionHashMap<seed>>;
+template <PhmapSeed seed>
+using SerializedKeyFixedSize8PartitionHashMap =
+        PartitionHashMapWithSerializedKeyFixedSize<FixedSize8SlicePartitionHashMap<seed>>;
+template <PhmapSeed seed>
+using SerializedKeyFixedSize16PartitionHashMap =
+        PartitionHashMapWithSerializedKeyFixedSize<FixedSize16SlicePartitionHashMap<seed>>;
+
+// For different partition columns type, size, cardinality, volume, we should choose different
+// hash functions and different hashmaps.
+// When runtime, we will only have one hashmap.
+// The type name and hashmap name is the same, so we could easily call hashmap by type.
+// Before you use the underlying hashmap, you should call init method firstly.
+struct PartitionHashMapVariant {
+    enum class Type {
+        phase1_uint8 = 0,
+        phase1_int8,
+        phase1_int16,
+        phase1_int32,
+        phase1_int64,
+        phase1_int128,
+        phase1_decimal32,
+        phase1_decimal64,
+        phase1_decimal128,
+        phase1_date,
+        phase1_timestamp,
+        phase1_string,
+        phase1_null_uint8,
+        phase1_null_int8,
+        phase1_null_int16,
+        phase1_null_int32,
+        phase1_null_int64,
+        phase1_null_int128,
+        phase1_null_decimal32,
+        phase1_null_decimal64,
+        phase1_null_decimal128,
+        phase1_null_date,
+        phase1_null_timestamp,
+        phase1_null_string,
+        phase1_slice,
+
+        phase1_slice_fx4,
+        phase1_slice_fx8,
+        phase1_slice_fx16,
+
+    };
+    Type type = Type::phase1_slice;
+
+    std::unique_ptr<UInt8PartitionHashMapWithOneNumberKey<PhmapSeed1>> phase1_uint8;
+    std::unique_ptr<Int8PartitionHashMapWithOneNumberKey<PhmapSeed1>> phase1_int8;
+    std::unique_ptr<Int16PartitionHashMapWithOneNumberKey<PhmapSeed1>> phase1_int16;
+    std::unique_ptr<Int32PartitionHashMapWithOneNumberKey<PhmapSeed1>> phase1_int32;
+    std::unique_ptr<Int64PartitionHashMapWithOneNumberKey<PhmapSeed1>> phase1_int64;
+    std::unique_ptr<Int128PartitionHashMapWithOneNumberKey<PhmapSeed1>> phase1_int128;
+    std::unique_ptr<Decimal32PartitionHashMapWithOneNumberKey<PhmapSeed1>> phase1_decimal32;
+    std::unique_ptr<Decimal64PartitionHashMapWithOneNumberKey<PhmapSeed1>> phase1_decimal64;
+    std::unique_ptr<Decimal128PartitionHashMapWithOneNumberKey<PhmapSeed1>> phase1_decimal128;
+
+    std::unique_ptr<DatePartitionHashMapWithOneNumberKey<PhmapSeed1>> phase1_date;
+    std::unique_ptr<TimeStampPartitionHashMapWithOneNumberKey<PhmapSeed1>> phase1_timestamp;
+    std::unique_ptr<OneStringPartitionHashMap<PhmapSeed1>> phase1_string;
+
+    std::unique_ptr<NullUInt8PartitionHashMapWithOneNumberKey<PhmapSeed1>> phase1_null_uint8;
+    std::unique_ptr<NullInt8PartitionHashMapWithOneNumberKey<PhmapSeed1>> phase1_null_int8;
+    std::unique_ptr<NullInt16PartitionHashMapWithOneNumberKey<PhmapSeed1>> phase1_null_int16;
+    std::unique_ptr<NullInt32PartitionHashMapWithOneNumberKey<PhmapSeed1>> phase1_null_int32;
+    std::unique_ptr<NullInt64PartitionHashMapWithOneNumberKey<PhmapSeed1>> phase1_null_int64;
+    std::unique_ptr<NullInt128PartitionHashMapWithOneNumberKey<PhmapSeed1>> phase1_null_int128;
+
+    std::unique_ptr<NullDecimal32PartitionHashMapWithOneNumberKey<PhmapSeed1>> phase1_null_decimal32;
+    std::unique_ptr<NullDecimal64PartitionHashMapWithOneNumberKey<PhmapSeed1>> phase1_null_decimal64;
+    std::unique_ptr<NullDecimal128PartitionHashMapWithOneNumberKey<PhmapSeed1>> phase1_null_decimal128;
+
+    std::unique_ptr<NullDatePartitionHashMapWithOneNumberKey<PhmapSeed1>> phase1_null_date;
+    std::unique_ptr<NullTimeStampPartitionHashMapWithOneNumberKey<PhmapSeed1>> phase1_null_timestamp;
+    std::unique_ptr<NullOneStringPartitionHashMap<PhmapSeed1>> phase1_null_string;
+    std::unique_ptr<SerializedKeyPartitionHashMap<PhmapSeed1>> phase1_slice;
+
+    std::unique_ptr<SerializedKeyFixedSize4PartitionHashMap<PhmapSeed1>> phase1_slice_fx4;
+    std::unique_ptr<SerializedKeyFixedSize8PartitionHashMap<PhmapSeed1>> phase1_slice_fx8;
+    std::unique_ptr<SerializedKeyFixedSize16PartitionHashMap<PhmapSeed1>> phase1_slice_fx16;
+
+    void init(RuntimeState* state, Type type_) {
+        type = type_;
+        switch (type_) {
+#define M(NAME)                                                                     \
+    case Type::NAME:                                                                \
+        NAME = std::make_unique<decltype(NAME)::element_type>(state->chunk_size()); \
+        break;
+            APPLY_FOR_PARTITION_VARIANT_ALL(M)
+#undef M
+        }
+    }
+
+    size_t capacity() const {
+        switch (type) {
+#define M(NAME)      \
+    case Type::NAME: \
+        return NAME->hash_map.capacity();
+            APPLY_FOR_PARTITION_VARIANT_ALL(M)
+#undef M
+        }
+        return 0;
+    }
+
+    size_t size() const {
+        switch (type) {
+#define M(NAME)      \
+    case Type::NAME: \
+        return NAME->hash_map.size() + (NAME->null_key_value.chunks.empty() ? 0 : 1);
+            APPLY_FOR_PARTITION_VARIANT_NULL(M)
+#undef M
+
+#define M(NAME)      \
+    case Type::NAME: \
+        return NAME->hash_map.size();
+            APPLY_FOR_PARTITION_VARIANT_NOT_NULL(M)
+#undef M
+        }
+        return 0;
+    }
+
+    size_t memory_usage() const {
+        switch (type) {
+#define M(NAME)      \
+    case Type::NAME: \
+        return NAME->hash_map.dump_bound();
+            APPLY_FOR_PARTITION_VARIANT_ALL(M)
+#undef M
+        }
+        return 0;
+    }
+};
+} // namespace starrocks::vectorized


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5885

## Enhancement

```sql
select * from (
    select *, rank() over (partition by v2 order by v3) as rk from t0
) sub_t0
where rk < 5;
```

For rank window function, including `rank`、`dense_rank`、`row_number`, if it has a related predicate (`rk < 5`), then it can be optimized by inserting a `PartitionTopN` operator before the `Sort` operator of window function. 

**The main purpose of `PartitionTopN` is to filter data, and it's output still remain unordered. It consists of three components:**

* `partitioner`：Divide the input chunk based on the partition exprs
* `sorter(topn)`：Each partition has an instance of sorter and is sorted independently
* `gather`：fetch chunks from all sorters into one data stream, so the data is still unordered after gahtering. Moreover, gather is a only logical concetp, not an actual component

```


                                   ┌────► topn─────┐
                                   │               │
 (unordered)                       │               │                  (unordered)
 inputChunks ───────► partitioner ─┼────► topn ────┼─► gather ─────► outputChunks
                                   │               │
                                   │               │
                                   └────► topn ────┘
```

**The implementation on the optimizer and the executor is a little different:**

* In optimizer, for simplicity, we do not define a new pair of `{Logical/Physical}PartitionTopNOperator`  but reuse the existing `{Logical/Physical}TopNOperator` by adding a new field `partitionByExprs` to record the partition by information. Besides, we need to pay attentation to the following things: 
    * Make sure that we cannot derive sort property from PartitionTopN
    * Make sure that ExchangeNode not set limit if PartitionTopN
* In executor, we define a new pair of `LocalPartitionTopN{Sink/Source}Operator`, and we may use different implementation based on the field `partitionByExprs`
    * if `partitionByExprs` is unset or empty, then the original pair of `PartitionSortSinkOperator/LocalMergeSortSourceOperator` is used
    * if `partitionByExprs` is not empty, then pair of `LocalPartitionTopN{Sink/Source}Operator` is used

## Tasks

- [x] **Support component partitioner(this pr)**
    * only support one partition expr right now
- [ ] Support PartitionTopN
- [ ] Support `row_number`
- [ ] Support `rank`
    * by supporting TopN limit by rank
- [ ] Support `dense_rank`
    * by supporting TopN limit by dense_rank
- [ ] Support multi partition exprs
