### PR TITLE
[Feature] Implement hive metadata

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
@@ -333,12 +333,11 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
         // 1. check column exists in hive table
         // 2. check column type mapping
         // 3. check hive partition column exists in table column list
-        org.apache.hadoop.hive.metastore.api.Table hmsTable = hiveTable;
-        if (hmsTable == null) {
-            hmsTable = GlobalStateMgr.getCurrentState().getHiveRepository()
+        if (hiveTable == null) {
+            hiveTable = GlobalStateMgr.getCurrentState().getHiveRepository()
                     .getTable(resourceName, this.hiveDbName, this.hiveTableName);
         }
-        String hiveTableType = hmsTable.getTableType();
+        String hiveTableType = hiveTable.getTableType();
         if (hiveTableType == null) {
             throw new DdlException("Unknown hive table type.");
         }
@@ -351,9 +350,9 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
             default:
                 throw new DdlException("unsupported hive table type [" + hiveTableType + "].");
         }
-        List<FieldSchema> unPartHiveColumns = hmsTable.getSd().getCols();
-        List<FieldSchema> partHiveColumns = hmsTable.getPartitionKeys();
-        Map<String, FieldSchema> allHiveColumns = HiveMetaStoreTableUtils.getAllHiveColumns(hmsTable);
+        List<FieldSchema> unPartHiveColumns = hiveTable.getSd().getCols();
+        List<FieldSchema> partHiveColumns = hiveTable.getPartitionKeys();
+        Map<String, FieldSchema> allHiveColumns = HiveMetaStoreTableUtils.getAllHiveColumns(hiveTable);
         for (FieldSchema hiveColumn : partHiveColumns) {
             allHiveColumns.put(hiveColumn.getName(), hiveColumn);
         }
@@ -387,7 +386,7 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
 
         // set hdfs path
         // todo hdfs ip may change, store it in cache?
-        this.hdfsPath = hmsTable.getSd().getLocation();
+        this.hdfsPath = hiveTable.getSd().getLocation();
 
         if (!copiedProps.isEmpty()) {
             throw new DdlException("Unknown table properties: " + copiedProps.toString());

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
@@ -66,7 +66,7 @@ import java.util.stream.Collectors;
 
 import static com.starrocks.common.util.Util.validateMetastoreUris;
 import static com.starrocks.external.HiveMetaStoreTableUtils.convertColumnType;
-import static com.starrocks.external.hive.HiveRepository.isInternalCatalog;
+import static com.starrocks.external.HiveMetaStoreTableUtils.isInternalCatalog;
 
 /**
  * External hive table
@@ -99,11 +99,11 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
     private String hiveTable;
     private String resourceName;
     private String hdfsPath;
-    private List<String> partColumnNames = Lists.newArrayList();
+    private final List<String> partColumnNames = Lists.newArrayList();
     // dataColumnNames stores all the non-partition columns of the hive table,
     // consistent with the order defined in the hive table
-    private List<String> dataColumnNames = Lists.newArrayList();
-    private Map<String, String> hiveProperties = Maps.newHashMap();
+    private final List<String> dataColumnNames = Lists.newArrayList();
+    private final Map<String, String> hiveProperties = Maps.newHashMap();
 
     private HiveMetaStoreTableInfo hmsTableInfo;
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -4,6 +4,7 @@ package com.starrocks.connector;
 
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.Table;
+import com.starrocks.common.DdlException;
 
 import java.util.List;
 
@@ -13,7 +14,7 @@ public interface ConnectorMetadata {
      *
      * @return a list of string containing all database names of connector
      */
-    default List<String> listDatabaseNames() {
+    default List<String> listDatabaseNames() throws DdlException {
         return Lists.newArrayList();
     }
 
@@ -23,7 +24,7 @@ public interface ConnectorMetadata {
      * @param dbName - the string of which all table names are listed
      * @return a list of string containing all table names of `dbName`
      */
-    default List<String> listTableNames(String dbName) {
+    default List<String> listTableNames(String dbName) throws DdlException {
         return Lists.newArrayList();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorTableId.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorTableId.java
@@ -1,0 +1,31 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.connector;
+
+import com.starrocks.common.Id;
+import com.starrocks.common.IdGenerator;
+
+public class ConnectorTableId extends Id<ConnectorTableId> {
+    public ConnectorTableId(int id) {
+        super(id);
+    }
+
+    public static IdGenerator<ConnectorTableId> createGenerator() {
+        return new IdGenerator<ConnectorTableId>() {
+            @Override
+            public ConnectorTableId getNextId() {
+                return new ConnectorTableId(nextId++);
+            }
+
+            @Override
+            public ConnectorTableId getMaxId() {
+                return new ConnectorTableId(nextId - 1);
+            }
+        };
+    }
+
+    @Override
+    public String toString() {
+        return String.format("F%02d", id);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnector.java
@@ -4,6 +4,7 @@ package com.starrocks.connector.hive;
 
 import com.google.common.base.Preconditions;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.util.Util;
 import com.starrocks.connector.Connector;
 import com.starrocks.connector.ConnectorContext;
 import com.starrocks.connector.ConnectorMetadata;
@@ -31,6 +32,7 @@ public class HiveConnector implements Connector {
     public void validate() {
         this.resourceName = Preconditions.checkNotNull(properties.get(HIVE_METASTORE_URIS),
                 "%s must be set in properties when creating hive catalog", HIVE_METASTORE_URIS);
+        Util.validateMetastoreUris(resourceName);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
@@ -2,15 +2,34 @@
 
 package com.starrocks.connector.hive;
 
+import com.starrocks.catalog.Table;
 import com.starrocks.common.DdlException;
 import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.external.hive.HiveMetaCache;
+import com.starrocks.external.hive.HiveTableName;
 import com.starrocks.server.GlobalStateMgr;
 
+import java.util.List;
+
 public class HiveMetadata implements ConnectorMetadata {
-    private HiveMetaCache metaCache;
+    private final HiveMetaCache metaCache;
 
     public HiveMetadata(String resourceName) throws DdlException {
         metaCache = GlobalStateMgr.getCurrentState().getHiveRepository().getMetaCache(resourceName);
+    }
+
+    @Override
+    public List<String> listDatabaseNames() throws DdlException {
+        return metaCache.getAllDatabaseNames();
+    }
+
+    @Override
+    public List<String> listTableNames(String dbName) throws DdlException {
+        return metaCache.getAllTableNames(dbName);
+    }
+
+    @Override
+    public Table getTable(String dbName, String tblName) {
+        return metaCache.getTable(HiveTableName.of(dbName, tblName));
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/external/HiveMetaStoreTableUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/HiveMetaStoreTableUtils.java
@@ -6,23 +6,33 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.HiveMetaStoreTableInfo;
+import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.PartitionKey;
+import com.starrocks.catalog.PrimitiveType;
+import com.starrocks.catalog.ScalarType;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.IdGenerator;
+import com.starrocks.connector.ConnectorTableId;
 import com.starrocks.external.hive.HiveColumnStats;
 import com.starrocks.external.hive.HivePartition;
 import com.starrocks.external.hive.HivePartitionStats;
 import com.starrocks.external.hive.HiveTableStats;
+import com.starrocks.external.hive.Utils;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.PlannerProfile;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class HiveMetaStoreTableUtils {
     private static final Logger LOG = LogManager.getLogger(HiveMetaStoreTableUtils.class);
+    private static final IdGenerator<ConnectorTableId> connectorTableIdIdGenerator = ConnectorTableId.createGenerator();
 
     public static Map<String, HiveColumnStats> getTableLevelColumnStats(HiveMetaStoreTableInfo hmsTable,
                                                                         List<String> columnNames) throws DdlException {
@@ -82,6 +92,78 @@ public class HiveMetaStoreTableUtils {
         try (PlannerProfile.ScopedTimer _ = PlannerProfile.getScopedTimer("HMS.partitionRowCount")) {
             return doGetPartitionStatsRowCount(hmsTable, partitions);
         }
+    }
+
+    public static Map<String, FieldSchema> getAllHiveColumns(Table table) {
+        List<FieldSchema> unPartHiveColumns = table.getSd().getCols();
+        List<FieldSchema> partHiveColumns = table.getPartitionKeys();
+        Map<String, FieldSchema> allHiveColumns = unPartHiveColumns.stream()
+                .collect(Collectors.toMap(FieldSchema::getName, fieldSchema -> fieldSchema));
+        for (FieldSchema hiveColumn : partHiveColumns) {
+            allHiveColumns.put(hiveColumn.getName(), hiveColumn);
+        }
+        return allHiveColumns;
+    }
+
+    public static PrimitiveType convertColumnType(String hiveType) throws DdlException {
+        String typeUpperCase = Utils.getTypeKeyword(hiveType).toUpperCase();
+        switch (typeUpperCase) {
+            case "TINYINT":
+                return PrimitiveType.TINYINT;
+            case "SMALLINT":
+                return PrimitiveType.SMALLINT;
+            case "INT":
+            case "INTEGER":
+                return PrimitiveType.INT;
+            case "BIGINT":
+                return PrimitiveType.BIGINT;
+            case "FLOAT":
+                return PrimitiveType.FLOAT;
+            case "DOUBLE":
+            case "DOUBLE PRECISION":
+                return PrimitiveType.DOUBLE;
+            case "DECIMAL":
+            case "NUMERIC":
+                return PrimitiveType.DECIMAL32;
+            case "TIMESTAMP":
+                return PrimitiveType.DATETIME;
+            case "DATE":
+                return PrimitiveType.DATE;
+            case "STRING":
+            case "VARCHAR":
+            case "BINARY":
+                return PrimitiveType.VARCHAR;
+            case "CHAR":
+                return PrimitiveType.CHAR;
+            case "BOOLEAN":
+                return PrimitiveType.BOOLEAN;
+            default:
+                throw new DdlException("hive table column type [" + typeUpperCase + "] transform failed.");
+        }
+    }
+
+    public static HiveTable convertToSRTable(Table hiveTable, String resoureName) throws DdlException {
+        if (hiveTable.getTableType().equals("VIRTUAL_VIEW")) {
+            throw new DdlException("Hive view table is not supported.");
+        }
+
+        Map<String, FieldSchema> allHiveColumns = getAllHiveColumns(hiveTable);
+        List<Column> fullSchema = Lists.newArrayList();
+        for (Map.Entry<String, FieldSchema> entry : allHiveColumns.entrySet()) {
+            FieldSchema fieldSchema = entry.getValue();
+            PrimitiveType srType = convertColumnType(fieldSchema.getType());
+            Column column = new Column(fieldSchema.getName(), ScalarType.createType(srType), true);
+            fullSchema.add(column);
+        }
+
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put(HiveTable.HIVE_DB, hiveTable.getDbName());
+        properties.put(HiveTable.HIVE_TABLE, hiveTable.getTableName());
+        properties.put(HiveTable.HIVE_METASTORE_URIS, resoureName);
+        properties.put(HiveTable.HIVE_RESOURCE, resoureName);
+
+        return new HiveTable(connectorTableIdIdGenerator.getMaxId().asInt(), hiveTable.getTableName(),
+                fullSchema, properties, hiveTable);
     }
 
     public static long doGetPartitionStatsRowCount(HiveMetaStoreTableInfo hmsTable,

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaClient.java
@@ -52,6 +52,7 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.hadoop.utils.HoodieInputFormatUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.thrift.TException;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -163,6 +164,33 @@ public class HiveMetaClient {
         } catch (Exception e) {
             LOG.warn("get hive table failed", e);
             throw new DdlException("get hive table from meta store failed: " + e.getMessage());
+        }
+    }
+
+    public List<String> getAllDatabaseNames() throws DdlException {
+        try (AutoCloseClient client = getClient()) {
+            return client.hiveClient.getAllDatabases();
+        } catch (Exception e) {
+            LOG.warn("Failed to get all database names", e);
+            throw new DdlException("Failed to get all database names from meta store: " + e.getMessage());
+        }
+    }
+
+    public List<String> getAllTableNames(String dbName) throws DdlException {
+        try (AutoCloseClient client = getClient()) {
+            return client.hiveClient.getAllTables(dbName);
+        } catch (Exception e) {
+            LOG.warn("Failed to get all table names on database: " + dbName, e);
+            throw new DdlException("Failed to get all table names from meta store: " + e.getMessage());
+        }
+    }
+
+    public Table getTable(HiveTableName hiveTableName) throws TException {
+        try (AutoCloseClient client = getClient()) {
+            return client.hiveClient.getTable(hiveTableName.getDatabaseName(), hiveTableName.getTableName());
+        } catch (Exception e) {
+            LOG.warn("Failed to get table {}", hiveTableName, e);
+            throw e;
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaStoreThriftClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaStoreThriftClient.java
@@ -752,7 +752,7 @@ public class HiveMetaStoreThriftClient implements IMetaStoreClient, AutoCloseabl
 
     @Override
     public List<String> getAllDatabases() throws MetaException, TException {
-        throw new TException("method not implemented");
+        return client.get_all_databases();
     }
 
     @Override
@@ -810,7 +810,7 @@ public class HiveMetaStoreThriftClient implements IMetaStoreClient, AutoCloseabl
 
     @Override
     public List<String> getAllTables(String dbName) throws MetaException, TException, UnknownDBException {
-        throw new TException("method not implemented");
+        return client.get_all_tables(dbName);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveRepository.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveRepository.java
@@ -94,7 +94,7 @@ public class HiveRepository {
     // In the first phase of connector, in order to reduce changes, we use `hive.metastore.uris` as resource name
     // for table of external catalog. The table of external catalog will not create a real resource.
     // We will reconstruct this part later. The concept of resource will not be used for external catalog
-    private boolean isInternalCatalog(String resourceName) {
+    public static boolean isInternalCatalog(String resourceName) {
         return !resourceName.startsWith("thrift://");
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveRepository.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveRepository.java
@@ -29,6 +29,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
+import static com.starrocks.external.HiveMetaStoreTableUtils.isInternalCatalog;
+
 public class HiveRepository {
     // hiveResourceName => HiveMetaClient
     Map<String, HiveMetaClient> metaClients = Maps.newHashMap();
@@ -89,13 +91,6 @@ public class HiveRepository {
         }
 
         return client;
-    }
-
-    // In the first phase of connector, in order to reduce changes, we use `hive.metastore.uris` as resource name
-    // for table of external catalog. The table of external catalog will not create a real resource.
-    // We will reconstruct this part later. The concept of resource will not be used for external catalog
-    public static boolean isInternalCatalog(String resourceName) {
-        return !resourceName.startsWith("thrift://");
     }
 
     public HiveMetaCache getMetaCache(String resourceName) throws DdlException {

--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveTableName.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveTableName.java
@@ -1,0 +1,51 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.external.hive;
+
+import java.util.Objects;
+
+public class HiveTableName {
+    private final String databaseName;
+    private final String tableName;
+
+    public HiveTableName(String databaseName, String tableName) {
+        this.databaseName = databaseName;
+        this.tableName = tableName;
+    }
+
+    public static HiveTableName of(String databaseName, String tableName) {
+        return new HiveTableName(databaseName, tableName);
+    }
+
+    public String getDatabaseName() {
+        return databaseName;
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    @Override
+    public String toString() {
+        return "[databaseName: " + databaseName + ", tableName: " + tableName + "]";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        HiveTableName other = (HiveTableName) o;
+        return Objects.equals(databaseName, other.databaseName) &&
+                Objects.equals(tableName, other.tableName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(databaseName, tableName);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
@@ -1,0 +1,125 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+
+package com.starrocks.connector.hive;
+
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.HiveTable;
+import com.starrocks.catalog.Type;
+import com.starrocks.common.DdlException;
+import com.starrocks.external.hive.HiveMetaStoreThriftClient;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+public class HiveMetadataTest {
+    @Test
+    public void testListDatabaseNames(@Mocked HiveMetaStoreThriftClient metaStoreThriftClient) throws Exception {
+        new Expectations() {
+            {
+                metaStoreThriftClient.getAllDatabases();
+                result = Lists.newArrayList("db1", "db2");
+                minTimes = 0;
+            }
+        };
+
+        String metastoreUris = "thrift://127.0.0.1:9083";
+        HiveMetadata metadata = new HiveMetadata(metastoreUris);
+        List<String> expectResult = Lists.newArrayList("db1", "db2");
+        Assert.assertEquals(expectResult, metadata.listDatabaseNames());
+    }
+
+    @Test
+    public void testListTableNames(@Mocked HiveMetaStoreThriftClient metaStoreThriftClient) throws Exception {
+        String db1 = "db1";
+        String db2 = "db2";
+
+        new Expectations() {
+            {
+                metaStoreThriftClient.getAllTables(db1);
+                result = Lists.newArrayList("tbl1", "tbl2");
+                minTimes = 0;
+            }
+        };
+
+        String metastoreUris = "thrift://127.0.0.1:9083";
+        HiveMetadata metadata = new HiveMetadata(metastoreUris);
+        List<String> expectResult = Lists.newArrayList("tbl1", "tbl2");
+        Assert.assertEquals(expectResult, metadata.listTableNames(db1));
+    }
+
+    @Test
+    public void testListTableNamesOnNotExistDb() throws Exception {
+        String db2 = "db2";
+        String metastoreUris = "thrift://127.0.0.1:9083";
+        HiveMetadata metadata = new HiveMetadata(metastoreUris);
+        try {
+            Assert.assertNull(metadata.listTableNames(db2));
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof DdlException);
+        }
+    }
+
+    @Test
+    public void testGetTable(@Mocked HiveMetaStoreThriftClient metaStoreThriftClient) throws Exception {
+        String db = "db";
+        String tbl1 = "tbl1";
+        String tbl2 = "tbl2";
+        String resourceName = "thrift://127.0.0.1:9083";
+        List<FieldSchema> partKeys = Lists.newArrayList(new FieldSchema("col1", "BIGINT", ""));
+        List<FieldSchema> unPartKeys = Lists.newArrayList(new FieldSchema("col2", "INT", ""));
+        String hdfsPath = "hdfs://127.0.0.1:10000/hive";
+        StorageDescriptor sd = new StorageDescriptor();
+        sd.setCols(unPartKeys);
+        sd.setLocation(hdfsPath);
+        Table msTable1 = new Table();
+        msTable1.setDbName(db);
+        msTable1.setTableName(tbl1);
+        msTable1.setPartitionKeys(partKeys);
+        msTable1.setSd(sd);
+        msTable1.setTableType("MANAGED_TABLE");
+
+        Table msTable2 = new Table();
+        msTable2.setDbName(db);
+        msTable2.setTableName(tbl2);
+        msTable2.setPartitionKeys(partKeys);
+        msTable2.setSd(sd);
+        msTable2.setTableType("VIRTUAL_VIEW");
+
+        new Expectations() {
+            {
+                metaStoreThriftClient.getTable(db, tbl1);
+                result = msTable1;
+
+                metaStoreThriftClient.getTable(db, tbl2);
+                result = msTable2;
+            }
+        };
+        HiveMetadata metadata = new HiveMetadata(resourceName);
+        HiveTable table1 = (HiveTable) metadata.getTable(db, tbl1);
+        Assert.assertEquals(tbl1, table1.getTableName());
+        Assert.assertEquals(db, table1.getHiveDb());
+        Assert.assertEquals(String.format("%s.%s", db, tbl1), table1.getHiveDbTable());
+        Assert.assertEquals(hdfsPath, table1.getHdfsPath());
+        Assert.assertEquals(Lists.newArrayList(new Column("col1", Type.BIGINT, true)), table1.getPartitionColumns());
+
+        HiveTable table1FromCache = (HiveTable) metadata.getTable(db, tbl1);
+        Assert.assertEquals(table1, table1FromCache);
+        // test "VIRTUAL_VIEW" type table
+        Assert.assertNull(metadata.getTable(db, tbl2));
+    }
+
+    @Test
+    public void testNotExistTable() throws DdlException {
+        String resourceName = "thrift://127.0.0.1:9083";
+        HiveMetadata metadata = new HiveMetadata(resourceName);
+        Assert.assertNull(metadata.getTable("db", "tbl"));
+    }
+
+}


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
related with: https://github.com/StarRocks/starrocks/issues/5907
related with https://github.com/StarRocks/starrocks/issues/5062

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Implement interface in HiveMetadata:
- listDatabaseNames()
- listTableNames(String dbName)
- getTable(String dbName, String tblName)

Adapt to hive external table when creating hive table.
In the current version, we use `HiveTable` to replace the connectortable under the catalog, such as `org apache.hadoop.hive.metastore.api.Table` convert to `com.starrocks.catalog.HiveTable`. In future, we will consider abstracting the `com.starrocks.catalog.Table` to adapt the internal catalog and external catalog

