### PR TITLE
[BugFix]Work around StatisticRangeValues's maxValue is NaN

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -158,8 +158,10 @@ public class ExpressionStatisticCalculator {
         private ColumnStatistic nullaryExpressionCalculate(CallOperator callOperator) {
             switch (callOperator.getFnName().toLowerCase()) {
                 case FunctionSet.COUNT:
-                    return new ColumnStatistic(0, inputStatistics.getOutputRowCount(), 0,
-                            callOperator.getType().getTypeSize(), rowCount);
+                    return new ColumnStatistic(0,
+                            Double.isNaN(inputStatistics.getOutputRowCount()) ? Double.POSITIVE_INFINITY :
+                                    inputStatistics.getOutputRowCount(), 0, callOperator.getType().getTypeSize(),
+                            rowCount);
                 default:
                     return ColumnStatistic.unknown();
             }
@@ -207,8 +209,10 @@ public class ExpressionStatisticCalculator {
                             callOperator.getType().getTypeSize(),
                             Math.min(columnStatistic.getDistinctValuesCount(), 60));
                 case FunctionSet.COUNT:
-                    return new ColumnStatistic(0, inputStatistics.getOutputRowCount(), 0,
-                            callOperator.getType().getTypeSize(), rowCount);
+                    // work around maxValue is NaN
+                    value = Double.isNaN(inputStatistics.getOutputRowCount()) ? Double.POSITIVE_INFINITY :
+                            inputStatistics.getOutputRowCount();
+                    return new ColumnStatistic(0, value, 0, callOperator.getType().getTypeSize(), rowCount);
                 case FunctionSet.MULTI_DISTINCT_COUNT:
                     // use child column averageRowSize instead call operator type size
                     return new ColumnStatistic(0, columnStatistic.getDistinctValuesCount(), 0,

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
@@ -802,6 +802,12 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
         sql = "select count(*) from supplier";
         plan = getCostExplain(sql);
         assertContains(plan, "count-->[0.0, 1000000.0, 0.0, 8.0, 1.0] ESTIMATE");
+        sql = "SELECT count(*) AS b FROM ( SELECT max(S_ADDRESS) AS a FROM supplier ) t1 WHERE a = '123' UNION SELECT 1 FROM supplier;";
+        plan = getCostExplain(sql);
+        assertContains(plan, "count-->[0.0, Infinity, NaN, NaN, NaN] ESTIMATE");
+        sql = "SELECT count(1) AS b FROM ( SELECT max(S_ADDRESS) AS a FROM supplier ) t1 WHERE a = '123' UNION SELECT 1 FROM supplier;";
+        plan = getCostExplain(sql);
+        assertContains(plan, "count-->[0.0, Infinity, NaN, NaN, NaN] ESTIMATE");
     }
 
     @Test


### PR DESCRIPTION
## What type of PR is this：
- [x] bug

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5711 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Work around maxValue is NaN when compute Count function column statistics