### PR TITLE
[cherry-pick] [branch-2.1] [Enhancement] Fix: decrease memory usage of Analytor (#3848)

### DIFF
--- a/be/src/exec/pipeline/analysis/analytic_source_operator.cpp
+++ b/be/src/exec/pipeline/analysis/analytic_source_operator.cpp
@@ -5,7 +5,7 @@
 namespace starrocks::pipeline {
 
 bool AnalyticSourceOperator::has_output() const {
-    return _analytor->is_sink_complete() && !_analytor->is_chunk_buffer_empty();
+    return !_analytor->is_chunk_buffer_empty();
 }
 
 bool AnalyticSourceOperator::is_finished() const {

--- a/be/src/exec/vectorized/analytic_node.cpp
+++ b/be/src/exec/vectorized/analytic_node.cpp
@@ -291,7 +291,7 @@ Status AnalyticNode::_get_next_for_unbounded_preceding_rows_frame(RuntimeState* 
 
 Status AnalyticNode::_try_fetch_next_partition_data(RuntimeState* state, int64_t* partition_end) {
     *partition_end = _analytor->find_partition_end();
-    while (!_analytor->is_partition_finished()) {
+    while (!_analytor->is_partition_finished(*partition_end)) {
         RETURN_IF_ERROR(state->check_mem_limit("analytic node fetch next partition data"));
         RETURN_IF_ERROR(_fetch_next_chunk(state));
         *partition_end = _analytor->find_partition_end();

--- a/be/src/exec/vectorized/analytor.cpp
+++ b/be/src/exec/vectorized/analytor.cpp
@@ -335,17 +335,19 @@ void Analytor::get_window_function_result(int32_t start, int32_t end) {
     }
 }
 
-bool Analytor::is_partition_finished() {
+bool Analytor::is_partition_finished(int64_t found_partition_end) {
     if (_input_eos) {
         return true;
     }
 
-    // No partition or hasn't fecth one chunk
-    if (_partition_ctxs.empty() || _partition_end == 0) {
+    // There is no partition, or it hasn't fetched any chunk.
+    if (_partition_ctxs.empty() || found_partition_end == 0) {
         return false;
     }
 
-    return _current_row_position >= _partition_end;
+    // If found_partition_end == _partition_columns[0]->size(),
+    // the next chunk maybe also belongs to the current partition.
+    return found_partition_end != _partition_columns[0]->size();
 }
 
 Status Analytor::output_result_chunk(vectorized::ChunkPtr* chunk) {

--- a/be/src/exec/vectorized/analytor.h
+++ b/be/src/exec/vectorized/analytor.h
@@ -100,7 +100,7 @@ public:
     void reset_window_state();
     void get_window_function_result(int32_t start, int32_t end);
 
-    bool is_partition_finished();
+    bool is_partition_finished(int64_t found_partition_end);
     Status output_result_chunk(vectorized::ChunkPtr* chunk);
     size_t compute_memory_usage();
     void create_agg_result_columns(int64_t chunk_size);


### PR DESCRIPTION
## Problem Summary：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

### Fix is_partition_finished()
`Analytor::is_partition_finished()` always returns false, when `_partition_end==0` or `_current_row_position < _partition_end`. However, the init value of `_partition_end` and `_current_row_position` is 0, and they are only updated if `Analytor::is_partition_finished()` returns true.

As a result, all the finished partitions cannot be processed timely. They must wait util EOS (that is, there is no more chunk coming).

### call remove_unused_buffer_values()
Call `_analytor->remove_unused_buffer_values()` before processing an input chunk in `AnalyticSinkOperator::push_chunk()`

### AnalyticSourceOperator needn't wait sink finished.
As long as `AnalyticSinkOperator` generates any output chunk, `AnalyticSourceOperator` can output this chunk immediately.