### PR TITLE
[Refactor] rename HeapChunkSorter to ChunksSorterHeapSort

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -68,7 +68,7 @@ set(EXEC_FILES
     vectorized/join_hash_map.cpp
     vectorized/topn_node.cpp
     vectorized/chunks_sorter.cpp
-    vectorized/chunk_sorter_heapsorter.cpp
+    vectorized/chunks_sorter_heap_sort.cpp
     vectorized/chunks_sorter_topn.cpp
     vectorized/chunks_sorter_full_sort.cpp
     vectorized/cross_join_node.cpp

--- a/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
@@ -5,9 +5,9 @@
 #include "column/chunk.h"
 #include "column/column_helper.h"
 #include "exec/pipeline/sort/sort_context.h"
-#include "exec/vectorized/chunk_sorter_heapsorter.h"
 #include "exec/vectorized/chunks_sorter.h"
 #include "exec/vectorized/chunks_sorter_full_sort.h"
+#include "exec/vectorized/chunks_sorter_heap_sort.h"
 #include "exec/vectorized/chunks_sorter_topn.h"
 #include "exprs/expr.h"
 #include "runtime/current_thread.h"
@@ -68,9 +68,9 @@ OperatorPtr PartitionSortSinkOperatorFactory::create(int32_t dop, int32_t driver
     std::shared_ptr<ChunksSorter> chunks_sorter;
     if (_limit >= 0) {
         if (_limit <= ChunksSorter::USE_HEAP_SORTER_LIMIT_SZ) {
-            chunks_sorter =
-                    std::make_unique<HeapChunkSorter>(runtime_state(), &(_sort_exec_exprs.lhs_ordering_expr_ctxs()),
-                                                      &_is_asc_order, &_is_null_first, _sort_keys, _offset, _limit);
+            chunks_sorter = std::make_unique<ChunksSorterHeapSort>(
+                    runtime_state(), &(_sort_exec_exprs.lhs_ordering_expr_ctxs()), &_is_asc_order, &_is_null_first,
+                    _sort_keys, _offset, _limit);
         } else {
             size_t max_buffered_chunks = ChunksSorterTopn::tunning_buffered_chunks(_limit);
             chunks_sorter = std::make_unique<ChunksSorterTopn>(

--- a/be/src/exec/vectorized/chunks_sorter_heap_sort.h
+++ b/be/src/exec/vectorized/chunks_sorter_heap_sort.h
@@ -209,13 +209,14 @@ private:
 };
 } // namespace detail
 
-class HeapChunkSorter final : public ChunksSorter {
+class ChunksSorterHeapSort final : public ChunksSorter {
 public:
     using DataSegmentPtr = std::shared_ptr<DataSegment>;
-    HeapChunkSorter(RuntimeState* state, const std::vector<ExprContext*>* sort_exprs, const std::vector<bool>* is_asc,
-                    const std::vector<bool>* is_null_first, const std::string& sort_keys, size_t offset, size_t limit)
+    ChunksSorterHeapSort(RuntimeState* state, const std::vector<ExprContext*>* sort_exprs,
+                         const std::vector<bool>* is_asc, const std::vector<bool>* is_null_first,
+                         const std::string& sort_keys, size_t offset, size_t limit)
             : ChunksSorter(state, sort_exprs, is_asc, is_null_first, sort_keys, true), _offset(offset), _limit(limit) {}
-    ~HeapChunkSorter() = default;
+    ~ChunksSorterHeapSort() = default;
 
     Status update(RuntimeState* state, const ChunkPtr& chunk) override;
     Status done(RuntimeState* state) override;

--- a/be/src/exec/vectorized/topn_node.cpp
+++ b/be/src/exec/vectorized/topn_node.cpp
@@ -11,9 +11,9 @@
 #include "exec/pipeline/sort/local_merge_sort_source_operator.h"
 #include "exec/pipeline/sort/partition_sort_sink_operator.h"
 #include "exec/pipeline/sort/sort_context.h"
-#include "exec/vectorized/chunk_sorter_heapsorter.h"
 #include "exec/vectorized/chunks_sorter.h"
 #include "exec/vectorized/chunks_sorter_full_sort.h"
+#include "exec/vectorized/chunks_sorter_heap_sort.h"
 #include "exec/vectorized/chunks_sorter_topn.h"
 #include "gutil/casts.h"
 #include "runtime/current_thread.h"
@@ -140,12 +140,12 @@ Status TopNNode::close(RuntimeState* state) {
 Status TopNNode::_consume_chunks(RuntimeState* state, ExecNode* child) {
     ScopedTimer<MonotonicStopWatch> timer(_sort_timer);
     if (_limit > 0) {
-        // HeapChunkSorter has higher performance when sorting fewer elements,
+        // ChunksSorterHeapSort has higher performance when sorting fewer elements,
         // after testing we think 1024 is a good threshold
         if (_limit <= ChunksSorter::USE_HEAP_SORTER_LIMIT_SZ) {
-            _chunks_sorter =
-                    std::make_unique<HeapChunkSorter>(state, &(_sort_exec_exprs.lhs_ordering_expr_ctxs()),
-                                                      &_is_asc_order, &_is_null_first, _sort_keys, _offset, _limit);
+            _chunks_sorter = std::make_unique<ChunksSorterHeapSort>(state, &(_sort_exec_exprs.lhs_ordering_expr_ctxs()),
+                                                                    &_is_asc_order, &_is_null_first, _sort_keys,
+                                                                    _offset, _limit);
         } else {
             _chunks_sorter = std::make_unique<ChunksSorterTopn>(
                     state, &(_sort_exec_exprs.lhs_ordering_expr_ctxs()), &_is_asc_order, &_is_null_first, _sort_keys,

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -30,7 +30,7 @@ set(EXEC_FILES
         ./exec/column_value_range_test.cpp
         ./exec/vectorized/agg_hash_map_test.cpp
         ./exec/vectorized/csv_scanner_test.cpp
-        ./exec/vectorized/chunks_sorter_heapsorter_test.cpp
+        ./exec/vectorized/chunks_sorter_heap_sort_test.cpp
         ./exec/vectorized/join_hash_map_test.cpp
         ./exec/vectorized/json_scanner_test.cpp
         ./exec/vectorized/json_parser_test.cpp

--- a/be/test/exec/vectorized/chunks_sorter_bench_test.cpp
+++ b/be/test/exec/vectorized/chunks_sorter_bench_test.cpp
@@ -12,9 +12,9 @@
 #include "column/column_helper.h"
 #include "column/datum_tuple.h"
 #include "common/config.h"
-#include "exec/vectorized/chunk_sorter_heapsorter.h"
 #include "exec/vectorized/chunks_sorter.h"
 #include "exec/vectorized/chunks_sorter_full_sort.h"
+#include "exec/vectorized/chunks_sorter_heap_sort.h"
 #include "exec/vectorized/chunks_sorter_topn.h"
 #include "exec/vectorized/sorting/merge.h"
 #include "exec/vectorized/sorting/sort_helper.h"
@@ -212,8 +212,8 @@ static void do_bench(benchmark::State& state, SortAlgorithm sorter_algo, Compare
             break;
         }
         case HeapSort: {
-            sorter.reset(new HeapChunkSorter(suite._runtime_state.get(), &sort_exprs, &asc_arr, &null_first, "", 0,
-                                             limit_rows));
+            sorter.reset(new ChunksSorterHeapSort(suite._runtime_state.get(), &sort_exprs, &asc_arr, &null_first, "", 0,
+                                                  limit_rows));
             expected_rows = limit_rows;
             break;
         }

--- a/be/test/exec/vectorized/chunks_sorter_heap_sort_test.cpp
+++ b/be/test/exec/vectorized/chunks_sorter_heap_sort_test.cpp
@@ -1,5 +1,7 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
 
+#include "exec/vectorized/chunks_sorter_heap_sort.h"
+
 #include <gtest/gtest.h>
 
 #include <cstdlib>
@@ -13,7 +15,6 @@
 #include "column/datum.h"
 #include "column/vectorized_fwd.h"
 #include "common/object_pool.h"
-#include "exec/vectorized/chunk_sorter_heapsorter.h"
 #include "exprs/expr_context.h"
 #include "exprs/vectorized/column_ref.h"
 #include "runtime/primitive_type.h"
@@ -23,7 +24,7 @@
 
 namespace starrocks::vectorized {
 
-struct HeapChunkSorterTest : public testing::Test {
+struct ChunksSorterHeapSortTest : public testing::Test {
     void SetUp() override {
         config::vector_chunk_size = 1024;
         _runtime_state = _create_runtime_state();
@@ -140,7 +141,7 @@ private:
     Chunk::SlotHashMap map;
 };
 
-TEST_F(HeapChunkSorterTest, single_column_order_by_notnull_test) {
+TEST_F(ChunksSorterHeapSortTest, single_column_order_by_notnull_test) {
     std::vector<bool> is_asc = {true};
     std::vector<bool> null_first = {true};
 
@@ -161,7 +162,7 @@ TEST_F(HeapChunkSorterTest, single_column_order_by_notnull_test) {
         {
             std::vector<ExprContext*> sort_exprs;
             sort_exprs.push_back(_pool.add(new ExprContext(fake_chunks.slot_refs()[0])));
-            HeapChunkSorter sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, 1024);
+            ChunksSorterHeapSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, 1024);
             sorter.setup_runtime(_pool.add(new RuntimeProfile("")));
             sorter.update(nullptr, fake_chunks.next_chunk(1024));
             sorter.done(nullptr);
@@ -179,7 +180,7 @@ TEST_F(HeapChunkSorterTest, single_column_order_by_notnull_test) {
         {
             std::vector<ExprContext*> sort_exprs;
             sort_exprs.push_back(_pool.add(new ExprContext(fake_chunks.slot_refs()[0])));
-            HeapChunkSorter sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, 1024);
+            ChunksSorterHeapSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, 1024);
             sorter.setup_runtime(_pool.add(new RuntimeProfile("")));
             sorter.update(nullptr, fake_chunks.next_chunk(1023));
             sorter.update(nullptr, fake_chunks.next_chunk(1023));
@@ -200,7 +201,7 @@ TEST_F(HeapChunkSorterTest, single_column_order_by_notnull_test) {
         {
             std::vector<ExprContext*> sort_exprs;
             sort_exprs.push_back(_pool.add(new ExprContext(fake_chunks.slot_refs()[1])));
-            HeapChunkSorter sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, 1024);
+            ChunksSorterHeapSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, 1024);
             sorter.setup_runtime(_pool.add(new RuntimeProfile("")));
             sorter.update(nullptr, fake_chunks.next_chunk(1024));
             sorter.update(nullptr, fake_chunks.next_chunk(1023));
@@ -217,7 +218,7 @@ TEST_F(HeapChunkSorterTest, single_column_order_by_notnull_test) {
     }
 }
 
-TEST_F(HeapChunkSorterTest, single_column_order_by_nullable_test) {
+TEST_F(ChunksSorterHeapSortTest, single_column_order_by_nullable_test) {
     {
         std::vector<bool> is_asc = {true};
         std::vector<bool> null_first = {true};
@@ -233,7 +234,7 @@ TEST_F(HeapChunkSorterTest, single_column_order_by_nullable_test) {
             sort_exprs.push_back(_pool.add(new ExprContext(fake_chunks.slot_refs()[0])));
             // limit 5
             int limit_sz = 5;
-            HeapChunkSorter sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, limit_sz);
+            ChunksSorterHeapSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, limit_sz);
             sorter.setup_runtime(_pool.add(new RuntimeProfile("")));
             sorter.update(nullptr, fake_chunks.next_chunk(10));
             sorter.done(nullptr);
@@ -256,7 +257,7 @@ TEST_F(HeapChunkSorterTest, single_column_order_by_nullable_test) {
             sort_exprs.push_back(_pool.add(new ExprContext(fake_chunks.slot_refs()[0])));
             // limit 5
             int limit_sz = 10;
-            HeapChunkSorter sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, limit_sz);
+            ChunksSorterHeapSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, limit_sz);
             sorter.setup_runtime(_pool.add(new RuntimeProfile("")));
             sorter.update(nullptr, fake_chunks.next_chunk(10));
             sorter.done(nullptr);
@@ -280,7 +281,7 @@ TEST_F(HeapChunkSorterTest, single_column_order_by_nullable_test) {
             sort_exprs.push_back(_pool.add(new ExprContext(fake_chunks.slot_refs()[0])));
             // limit 5
             int limit_sz = 5;
-            HeapChunkSorter sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, limit_sz);
+            ChunksSorterHeapSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, limit_sz);
             sorter.setup_runtime(_pool.add(new RuntimeProfile("")));
             sorter.update(nullptr, fake_chunks.next_chunk(10));
             sorter.done(nullptr);


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [ ] enhancement
- [x] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Keep the naming style of file name and type name consistent
* `chunk_sorter_heapsorter.{h, cpp}` -> `chunks_sorter_heap_sort.{h, cpp}`
* `HeapChunkSorter` -> `ChunksSorterHeapSort`