### PR TITLE
[Enhancement] set trimStackTrace to false when debugging specified class or case

### DIFF
--- a/run-fe-ut.sh
+++ b/run-fe-ut.sh
@@ -107,7 +107,8 @@ else
         # eg:
         # sh run-fe-ut.sh --run com.starrocks.utframe.Demo
         # sh run-fe-ut.sh --run com.starrocks.utframe.Demo#testCreateDbAndTable+test2
-        ${MVN_CMD} test -DfailIfNoTests=false -D test=$1
+        # set trimStackTrace to false to show full stack when debugging specified class or case
+        ${MVN_CMD} test -DfailIfNoTests=false -DtrimStackTrace=false -D test=$1
     else    
         echo "Run Frontend UT"
         ${MVN_CMD} test -DfailIfNoTests=false 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [ ] feature
- [x] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
If a unit test raises an Exception, usually it only prints out one line of the stacks, making it hard to figure out the root cause.
I also found that someone added a try-catch clause inside some test code to print out the full stack.
This PR adds a command-line argument to print out full stacks when using `--run` to run a specified class or case.