### PR TITLE
[Feature] Support parallel scan on tablet for non-merge/agg table

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -656,6 +656,19 @@ CONF_Int64(pipeline_sink_brpc_dop, "8");
 // exceeds it*pipeline_exec_thread_pool_thread_num.
 CONF_Int64(pipeline_max_num_drivers_per_exec_thread, "10240");
 
+/// For parallel scan on the single tablet.
+// These three configs are used to calculate the minimum number of rows picked up from a segment at one time.
+// It is `splitted_scan_bytes/scan_row_bytes` and restricted in the range [min_splitted_scan_rows, max_splitted_scan_rows].
+CONF_Int64(tablet_internal_parallel_min_splitted_scan_rows, "16384");
+// Default is 16384*64, where 16384 is the chunk size in pipeline.
+CONF_Int64(tablet_internal_parallel_max_splitted_scan_rows, "1048576");
+// Default is 512MB.
+CONF_Int64(tablet_internal_parallel_max_splitted_scan_bytes, "536870912");
+//
+// Only when scan_dop is not less than min_scan_dop, this table can use tablet internal parallel,
+// where scan_dop = estimated_scan_rows / splitted_scan_rows.
+CONF_Int64(tablet_internal_parallel_min_scan_dop, "4");
+
 // The bitmap serialize version.
 CONF_Int16(bitmap_serialize_version, "1");
 // The max hdfs file handle.

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -200,14 +200,8 @@ Status FragmentExecutor::_prepare_runtime_state(ExecEnv* exec_env, const TExecPl
 }
 
 int32_t FragmentExecutor::_calc_dop(ExecEnv* exec_env, const TExecPlanFragmentParams& request) const {
-    int32_t degree_of_parallelism = 1;
-    if (request.__isset.pipeline_dop && request.pipeline_dop > 0) {
-        degree_of_parallelism = request.pipeline_dop;
-    } else {
-        // default dop is a half of the number of hardware threads.
-        degree_of_parallelism = std::max<int32_t>(1, exec_env->max_executor_threads() / 2);
-    }
-    return degree_of_parallelism;
+    int32_t degree_of_parallelism = request.__isset.pipeline_dop ? request.pipeline_dop : 0;
+    return exec_env->calc_pipeline_dop(degree_of_parallelism);
 }
 
 Status FragmentExecutor::_prepare_exec_plan(ExecEnv* exec_env, const TExecPlanFragmentParams& request) {

--- a/be/src/exec/pipeline/pipeline_builder.h
+++ b/be/src/exec/pipeline/pipeline_builder.h
@@ -27,7 +27,7 @@ public:
     // Input the output chunks from the drivers of pred operators into ONE driver of the post operators.
     OpFactories maybe_interpolate_local_passthrough_exchange(RuntimeState* state, OpFactories& pred_operators);
     OpFactories maybe_interpolate_local_passthrough_exchange(RuntimeState* state, OpFactories& pred_operators,
-                                                             int num_receivers);
+                                                             int num_receivers, bool force = false);
 
     // Input the output chunks from multiple drivers of pred operators into DOP drivers of the post operators,
     // by partitioning each row output chunk to DOP partitions according to the key,
@@ -57,6 +57,8 @@ public:
     Pipelines get_pipelines() const { return _pipelines; }
 
     FragmentContext* fragment_context() { return _fragment_context; }
+
+    MorselQueue* morsel_queue_of_source_operator(const SourceOperatorFactory* source_op);
 
 private:
     FragmentContext* _fragment_context;

--- a/be/src/exec/pipeline/scan/morsel.cpp
+++ b/be/src/exec/pipeline/scan/morsel.cpp
@@ -5,12 +5,18 @@
 #include "exec/olap_utils.h"
 #include "storage/range.h"
 #include "storage/rowset/beta_rowset.h"
+#include "storage/rowset/rowid_range_option.h"
 #include "storage/storage_engine.h"
 #include "storage/tablet_reader.h"
 #include "storage/tablet_reader_params.h"
 
 namespace starrocks {
 namespace pipeline {
+
+/// Morsel.
+void PhysicalSplitScanMorsel::init_tablet_reader_params(vectorized::TabletReaderParams* params) {
+    params->rowid_range_option = _rowid_range_option;
+}
 
 /// MorselQueue.
 std::vector<TInternalScanRange*> _convert_morsels_to_olap_scan_ranges(const Morsels& morsels) {
@@ -40,6 +46,194 @@ StatusOr<MorselPtr> FixedMorselQueue::try_get() {
     } else {
         return nullptr;
     }
+}
+
+std::vector<TInternalScanRange*> PhysicalSplitMorselQueue::olap_scan_ranges() const {
+    return _convert_morsels_to_olap_scan_ranges(_morsels);
+}
+
+void PhysicalSplitMorselQueue::set_key_ranges(const std::vector<OlapScanRange*>& key_ranges) {
+    for (const auto& key_range : key_ranges) {
+        if (key_range->begin_scan_range.size() == 1 && key_range->begin_scan_range.get_value(0) == NEGATIVE_INFINITY) {
+            continue;
+        }
+
+        _range_start_op = key_range->begin_include ? "ge" : "gt";
+        _range_end_op = key_range->end_include ? "le" : "lt";
+
+        _range_start_key.emplace_back(key_range->begin_scan_range);
+        _range_end_key.emplace_back(key_range->end_scan_range);
+    }
+}
+
+StatusOr<MorselPtr> PhysicalSplitMorselQueue::try_get() {
+    DCHECK(!_tablets.empty());
+    DCHECK(!_tablet_rowsets.empty());
+    DCHECK_EQ(_tablets.size(), _tablet_rowsets.size());
+
+    std::lock_guard<std::mutex> lock(_mutex);
+
+    if (_tablet_idx >= _tablets.size()) {
+        return nullptr;
+    }
+
+    // When it hasn't initialized any segment,
+    // or _segment_idx exceeds the segments of the current rowset,
+    // or current segment is finished,
+    // we should pick up the next segment and init it.
+    while (!_has_init_any_segment || _cur_segment() == nullptr || !_segment_range_iter.has_more()) {
+        if (!_next_segment()) {
+            return nullptr;
+        }
+
+        RETURN_IF_ERROR(_init_segment());
+    }
+
+    vectorized::SparseRange taken_range;
+    _segment_range_iter.next_range(_splitted_scan_rows, &taken_range);
+    _num_segment_rest_rows -= taken_range.span_size();
+    if (_num_segment_rest_rows < _splitted_scan_rows) {
+        // If there are too few rows left in the segment, take them all this time.
+        _segment_range_iter.next_range(_splitted_scan_rows, &taken_range);
+        _num_segment_rest_rows = 0;
+    }
+
+    auto* scan_morsel = _cur_scan_morsel();
+    auto* rowset = _cur_rowset();
+    auto rowid_range = std::make_shared<vectorized::RowidRangeOption>(
+            rowset->rowset_id(), rowset->segments()[_segment_idx]->id(), std::move(taken_range));
+    MorselPtr morsel = std::make_unique<PhysicalSplitScanMorsel>(
+            scan_morsel->get_plan_node_id(), *(scan_morsel->get_scan_range()), std::move(rowid_range));
+
+    return morsel;
+}
+
+rowid_t PhysicalSplitMorselQueue::_lower_bound_ordinal(Segment* segment, const vectorized::SeekTuple& key, bool lower) {
+    std::string index_key;
+    index_key = lower ? key.short_key_encode(segment->num_short_keys(), KEY_MINIMAL_MARKER)
+                      : key.short_key_encode(segment->num_short_keys(), KEY_MAXIMAL_MARKER);
+
+    uint32_t start_block_id;
+    auto start_iter = segment->lower_bound(index_key);
+    if (start_iter.valid()) {
+        // Because previous block may contain this key, so we should set rowid to
+        // last block's first row.
+        start_block_id = start_iter.ordinal();
+        if (start_block_id > 0) {
+            start_block_id--;
+        }
+    } else {
+        // When we don't find a valid index item, which means all short key is
+        // smaller than input key, this means that this key may exist in the last
+        // row block. so we set the rowid to first row of last row block.
+        start_block_id = segment->last_block();
+    }
+
+    rowid_t start = start_block_id * segment->num_rows_per_block();
+
+    return start;
+}
+
+rowid_t PhysicalSplitMorselQueue::_upper_bound_ordinal(Segment* segment, const vectorized::SeekTuple& key, bool lower,
+                                                       rowid_t end) {
+    std::string index_key;
+    index_key = lower ? key.short_key_encode(segment->num_short_keys(), KEY_MINIMAL_MARKER)
+                      : key.short_key_encode(segment->num_short_keys(), KEY_MAXIMAL_MARKER);
+
+    auto end_iter = segment->upper_bound(index_key);
+    if (end_iter.valid()) {
+        end = end_iter.ordinal() * segment->num_rows_per_block();
+    }
+
+    return end;
+}
+
+ScanMorsel* PhysicalSplitMorselQueue::_cur_scan_morsel() {
+    return down_cast<ScanMorsel*>(_morsels[_tablet_idx].get());
+}
+
+BetaRowset* PhysicalSplitMorselQueue::_cur_rowset() {
+    return down_cast<BetaRowset*>(_tablet_rowsets[_tablet_idx][_rowset_idx].get());
+}
+
+Segment* PhysicalSplitMorselQueue::_cur_segment() {
+    const auto& segments = _cur_rowset()->segments();
+    return _segment_idx >= segments.size() ? nullptr : segments[_segment_idx].get();
+}
+
+bool PhysicalSplitMorselQueue::_next_segment() {
+    if (!_has_init_any_segment) {
+        _has_init_any_segment = true;
+    } else {
+        if (_num_segment_rest_rows > 0) {
+            return true;
+        }
+
+        // Read the next segment of the current rowset.
+        if (++_segment_idx >= _cur_rowset()->segments().size()) {
+            _segment_idx = 0;
+            // Read the next rowset of the current tablet.
+            if (++_rowset_idx >= _tablet_rowsets[_tablet_idx].size()) {
+                _rowset_idx = 0;
+                // Read the next tablet.
+                ++_tablet_idx;
+            }
+        }
+    }
+
+    return _tablet_idx < _tablets.size();
+}
+
+Status PhysicalSplitMorselQueue::_init_segment() {
+    // Load the meta of the new rowset and the index of the new segment。
+    if (0 == _segment_idx) {
+        // Read a new tablet.
+        if (0 == _rowset_idx) {
+            _tablet_seek_ranges.clear();
+            _mempool.clear();
+            RETURN_IF_ERROR(vectorized::TabletReader::parse_seek_range(_tablets[_tablet_idx], _range_start_op,
+                                                                       _range_end_op, _range_start_key, _range_end_key,
+                                                                       &_tablet_seek_ranges, &_mempool));
+        }
+        // Read a new rowset.
+        RETURN_IF_ERROR(_cur_rowset()->load());
+    }
+
+    _num_segment_rest_rows = 0;
+    _segment_scan_range.clear();
+
+    auto* segment = _cur_segment();
+    // The new rowset doesn't contain any segment.
+    if (segment == nullptr) {
+        return Status::OK();
+    }
+
+    // Find the rowid range of each key range in this segment.
+    if (_tablet_seek_ranges.empty()) {
+        _segment_scan_range.add(vectorized::Range(0, segment->num_rows()));
+    } else {
+        RETURN_IF_ERROR(segment->load_index(StorageEngine::instance()->tablet_meta_mem_tracker()));
+        for (const auto& range : _tablet_seek_ranges) {
+            rowid_t lower_rowid = 0;
+            rowid_t upper_rowid = segment->num_rows();
+
+            if (!range.upper().empty()) {
+                upper_rowid =
+                        _upper_bound_ordinal(segment, range.upper(), !range.inclusive_upper(), segment->num_rows());
+            }
+            if (!range.lower().empty() && upper_rowid > 0) {
+                lower_rowid = _lower_bound_ordinal(segment, range.lower(), range.inclusive_lower());
+            }
+            if (lower_rowid <= upper_rowid) {
+                _segment_scan_range.add(vectorized::Range{lower_rowid, upper_rowid});
+            }
+        }
+    }
+
+    _segment_range_iter = _segment_scan_range.new_iterator();
+    _num_segment_rest_rows = _segment_scan_range.span_size();
+
+    return Status::OK();
 }
 
 } // namespace pipeline

--- a/be/src/exec/pipeline/scan/morsel.cpp
+++ b/be/src/exec/pipeline/scan/morsel.cpp
@@ -110,10 +110,8 @@ StatusOr<MorselPtr> PhysicalSplitMorselQueue::try_get() {
 }
 
 rowid_t PhysicalSplitMorselQueue::_lower_bound_ordinal(Segment* segment, const vectorized::SeekTuple& key, bool lower) {
-    std::string index_key;
-    index_key = lower ? key.short_key_encode(segment->num_short_keys(), KEY_MINIMAL_MARKER)
-                      : key.short_key_encode(segment->num_short_keys(), KEY_MAXIMAL_MARKER);
-
+    std::string index_key =
+            key.short_key_encode(segment->num_short_keys(), lower ? KEY_MINIMAL_MARKER : KEY_MAXIMAL_MARKER);
     uint32_t start_block_id;
     auto start_iter = segment->lower_bound(index_key);
     if (start_iter.valid()) {
@@ -130,16 +128,13 @@ rowid_t PhysicalSplitMorselQueue::_lower_bound_ordinal(Segment* segment, const v
         start_block_id = segment->last_block();
     }
 
-    rowid_t start = start_block_id * segment->num_rows_per_block();
-
-    return start;
+    return start_block_id * segment->num_rows_per_block();
 }
 
 rowid_t PhysicalSplitMorselQueue::_upper_bound_ordinal(Segment* segment, const vectorized::SeekTuple& key, bool lower,
                                                        rowid_t end) {
-    std::string index_key;
-    index_key = lower ? key.short_key_encode(segment->num_short_keys(), KEY_MINIMAL_MARKER)
-                      : key.short_key_encode(segment->num_short_keys(), KEY_MAXIMAL_MARKER);
+    std::string index_key =
+            key.short_key_encode(segment->num_short_keys(), lower ? KEY_MINIMAL_MARKER : KEY_MAXIMAL_MARKER);
 
     auto end_iter = segment->upper_bound(index_key);
     if (end_iter.valid()) {

--- a/be/src/exec/pipeline/scan/morsel.cpp
+++ b/be/src/exec/pipeline/scan/morsel.cpp
@@ -52,7 +52,7 @@ std::vector<TInternalScanRange*> PhysicalSplitMorselQueue::olap_scan_ranges() co
     return _convert_morsels_to_olap_scan_ranges(_morsels);
 }
 
-void PhysicalSplitMorselQueue::set_key_ranges(const std::vector<OlapScanRange*>& key_ranges) {
+void PhysicalSplitMorselQueue::set_key_ranges(const std::vector<std::unique_ptr<OlapScanRange>>& key_ranges) {
     for (const auto& key_range : key_ranges) {
         if (key_range->begin_scan_range.size() == 1 && key_range->begin_scan_range.get_value(0) == NEGATIVE_INFINITY) {
             continue;

--- a/be/src/exec/pipeline/scan/morsel.h
+++ b/be/src/exec/pipeline/scan/morsel.h
@@ -86,7 +86,7 @@ public:
 
     virtual std::vector<TInternalScanRange*> olap_scan_ranges() const = 0;
 
-    virtual void set_key_ranges(const std::vector<OlapScanRange*>& key_ranges) {}
+    virtual void set_key_ranges(const std::vector<std::unique_ptr<OlapScanRange>>& key_ranges) {}
     virtual void set_tablets(const std::vector<TabletSharedPtr>& tablets) {}
     virtual void set_tablet_rowsets(const std::vector<std::vector<RowsetSharedPtr>>& tablet_rowsets) {}
 
@@ -131,7 +131,7 @@ public:
 
     std::vector<TInternalScanRange*> olap_scan_ranges() const override;
 
-    void set_key_ranges(const std::vector<OlapScanRange*>& key_ranges) override;
+    void set_key_ranges(const std::vector<std::unique_ptr<OlapScanRange>>& key_ranges) override;
     void set_tablets(const std::vector<TabletSharedPtr>& tablets) override { _tablets = tablets; }
     void set_tablet_rowsets(const std::vector<std::vector<RowsetSharedPtr>>& tablet_rowsets) override {
         _tablet_rowsets = tablet_rowsets;

--- a/be/src/exec/pipeline/scan/morsel.h
+++ b/be/src/exec/pipeline/scan/morsel.h
@@ -23,6 +23,8 @@ class Segment;
 namespace vectorized {
 class TabletReaderParams;
 class SeekTuple;
+struct RowidRangeOption;
+using RowidRangeOptionPtr = std::shared_ptr<RowidRangeOption>;
 } // namespace vectorized
 
 namespace pipeline {
@@ -41,6 +43,8 @@ public:
     virtual ~Morsel() = default;
 
     int32_t get_plan_node_id() const { return _plan_node_id; }
+
+    virtual void init_tablet_reader_params(vectorized::TabletReaderParams* params) {}
 
 private:
     int32_t _plan_node_id;
@@ -62,6 +66,18 @@ private:
     std::unique_ptr<TScanRange> _scan_range;
 };
 
+class PhysicalSplitScanMorsel final : public ScanMorsel {
+public:
+    PhysicalSplitScanMorsel(int32_t plan_node_id, const TScanRange& scan_range,
+                            vectorized::RowidRangeOptionPtr rowid_range_option)
+            : ScanMorsel(plan_node_id, scan_range), _rowid_range_option(std::move(rowid_range_option)) {}
+
+    void init_tablet_reader_params(vectorized::TabletReaderParams* params) override;
+
+private:
+    vectorized::RowidRangeOptionPtr _rowid_range_option;
+};
+
 /// MorselQueue.
 class MorselQueue {
 public:
@@ -70,11 +86,17 @@ public:
 
     virtual std::vector<TInternalScanRange*> olap_scan_ranges() const = 0;
 
+    virtual void set_key_ranges(const std::vector<OlapScanRange*>& key_ranges) {}
+    virtual void set_tablets(const std::vector<TabletSharedPtr>& tablets) {}
+    virtual void set_tablet_rowsets(const std::vector<std::vector<RowsetSharedPtr>>& tablet_rowsets) {}
+
     virtual size_t num_morsels() const = 0;
     virtual bool empty() const = 0;
     virtual StatusOr<MorselPtr> try_get() = 0;
 
     virtual std::string name() const = 0;
+
+    virtual bool need_rebalance() const { return false; }
 };
 
 // The morsel queue with a fixed number of morsels, which is determined in the constructor.
@@ -96,6 +118,85 @@ private:
     Morsels _morsels;
     const size_t _num_morsels;
     std::atomic<size_t> _pop_index;
+};
+
+class PhysicalSplitMorselQueue final : public MorselQueue {
+public:
+    explicit PhysicalSplitMorselQueue(Morsels&& morsels, int64_t degree_of_parallelism, int64_t splitted_scan_rows)
+            : _morsels(std::move(morsels)),
+              _num_original_morsels(_morsels.size()),
+              _degree_of_parallelism(degree_of_parallelism),
+              _splitted_scan_rows(splitted_scan_rows) {}
+    ~PhysicalSplitMorselQueue() override = default;
+
+    std::vector<TInternalScanRange*> olap_scan_ranges() const override;
+
+    void set_key_ranges(const std::vector<OlapScanRange*>& key_ranges) override;
+    void set_tablets(const std::vector<TabletSharedPtr>& tablets) override { _tablets = tablets; }
+    void set_tablet_rowsets(const std::vector<std::vector<RowsetSharedPtr>>& tablet_rowsets) override {
+        _tablet_rowsets = tablet_rowsets;
+    }
+
+    size_t num_morsels() const override { return _degree_of_parallelism; }
+    bool empty() const override { return _tablet_idx >= _tablets.size(); }
+    StatusOr<MorselPtr> try_get() override;
+
+    std::string name() const override { return "physical_split_morsel_queue"; }
+
+    // Whether DOP after splitting tablets is greater than the number of tablets.
+    // Only used by broadcast HashJoinProbeOperator. It will insert local exchange
+    // to balance the chunk from scan node and increase parallelism of the probe operators,
+    // if the number of tablets is less than DOP.
+    bool need_rebalance() const override { return _num_original_morsels < _degree_of_parallelism; }
+
+private:
+    static rowid_t _lower_bound_ordinal(Segment* segment, const vectorized::SeekTuple& key, bool lower);
+    static rowid_t _upper_bound_ordinal(Segment* segment, const vectorized::SeekTuple& key, bool lower, rowid_t end);
+
+    ScanMorsel* _cur_scan_morsel();
+    BetaRowset* _cur_rowset();
+    // Return nullptr, when _segment_idx exceeds the segments of the current rowset.
+    Segment* _cur_segment();
+
+    // Returning false means that there is no more segment to read.
+    bool _next_segment();
+    // Load the meta of the new rowset and the index of the new segment,
+    // and find the rowid range of each key range in this segment.
+    Status _init_segment();
+
+private:
+    std::mutex _mutex;
+
+    const Morsels _morsels;
+    // The number of the morsels before split them to pieces.
+    const size_t _num_original_morsels;
+    const int64_t _degree_of_parallelism;
+    // The minimum number of rows picked up from a segment at one time.
+    const int64_t _splitted_scan_rows;
+
+    /// Key ranges passed to the storage layer.
+    // Possible values are "gt", "ge", "eq".
+    std::string _range_start_op = "";
+    // Possible values are "lt", "le".
+    std::string _range_end_op = "";
+    std::vector<OlapTuple> _range_start_key;
+    std::vector<OlapTuple> _range_end_key;
+
+    // _tablets[i] and _tablet_rowsets[i] represent the i-th tablet and its rowsets.
+    std::vector<TabletSharedPtr> _tablets;
+    std::vector<std::vector<RowsetSharedPtr>> _tablet_rowsets;
+
+    bool _has_init_any_segment = false;
+    std::atomic<size_t> _tablet_idx = 0;
+    size_t _rowset_idx = 0;
+    size_t _segment_idx = 0;
+    std::vector<vectorized::SeekRange> _tablet_seek_ranges;
+    vectorized::SparseRange _segment_scan_range;
+    vectorized::SparseRangeIterator _segment_range_iter;
+    // The number of unprocessed rows of the current segment.
+    size_t _num_segment_rest_rows = 0;
+
+    MemPool _mempool;
 };
 
 } // namespace pipeline

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -132,6 +132,7 @@ Status OlapChunkSource::_init_reader_params(const std::vector<OlapScanRange*>& k
     _params.profile = _runtime_profile;
     _params.runtime_state = _runtime_state;
     _params.use_page_cache = !config::disable_storage_page_cache;
+    _morsel->init_tablet_reader_params(&_params);
     _decide_chunk_size();
 
     PredicateParser parser(_tablet->tablet_schema());

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -121,7 +121,7 @@ void OlapChunkSource::_decide_chunk_size() {
     }
 }
 
-Status OlapChunkSource::_init_reader_params(const std::vector<OlapScanRange*>& key_ranges,
+Status OlapChunkSource::_init_reader_params(const std::vector<std::unique_ptr<OlapScanRange>>& key_ranges,
                                             const std::vector<uint32_t>& scanner_columns,
                                             std::vector<uint32_t>& reader_columns) {
     const TOlapScanNode& thrift_olap_scan_node = _scan_node->thrift_olap_scan_node();

--- a/be/src/exec/pipeline/scan/olap_chunk_source.h
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.h
@@ -64,7 +64,7 @@ private:
     static constexpr int64_t YIELD_PREEMPT_MAX_TIME_SPENT = 20'000'000L;
 
     Status _get_tablet(const TInternalScanRange* scan_range);
-    Status _init_reader_params(const std::vector<OlapScanRange*>& key_ranges,
+    Status _init_reader_params(const std::vector<std::unique_ptr<OlapScanRange>>& key_ranges,
                                const std::vector<uint32_t>& scanner_columns, std::vector<uint32_t>& reader_columns);
     Status _init_scanner_columns(std::vector<uint32_t>& scanner_columns);
     Status _init_unused_output_columns(const std::vector<std::string>& unused_output_columns);

--- a/be/src/exec/pipeline/scan/olap_scan_context.cpp
+++ b/be/src/exec/pipeline/scan/olap_scan_context.cpp
@@ -72,14 +72,4 @@ Status OlapScanContext::parse_conjuncts(RuntimeState* state, const std::vector<E
     return Status::OK();
 }
 
-std::vector<OlapScanRange*> OlapScanContext::key_ranges() const {
-    std::vector<OlapScanRange*> results;
-    results.reserve(_key_ranges.size());
-    for (const auto& key_range : _key_ranges) {
-        results.emplace_back(key_range.get());
-    }
-
-    return results;
-}
-
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/scan/olap_scan_context.h
+++ b/be/src/exec/pipeline/scan/olap_scan_context.h
@@ -36,7 +36,7 @@ public:
     vectorized::OlapScanNode* scan_node() const { return _scan_node; }
     vectorized::OlapScanConjunctsManager& conjuncts_manager() { return _conjuncts_manager; }
     const std::vector<ExprContext*>& not_push_down_conjuncts() const { return _not_push_down_conjuncts; }
-    std::vector<OlapScanRange*> key_ranges() const;
+    const std::vector<std::unique_ptr<OlapScanRange>>& key_ranges() const { return _key_ranges; }
 
 private:
     vectorized::OlapScanNode* _scan_node;

--- a/be/src/exec/pipeline/scan/olap_scan_prepare_operator.cpp
+++ b/be/src/exec/pipeline/scan/olap_scan_prepare_operator.cpp
@@ -45,6 +45,10 @@ bool OlapScanPrepareOperator::is_finished() const {
 StatusOr<vectorized::ChunkPtr> OlapScanPrepareOperator::pull_chunk(RuntimeState* state) {
     Status status = _ctx->parse_conjuncts(state, runtime_in_filters(), runtime_bloom_filters());
 
+    _morsel_queue->set_key_ranges(_ctx->key_ranges());
+    _morsel_queue->set_tablets(_tablets);
+    _morsel_queue->set_tablet_rowsets(_tablet_rowsets);
+
     _ctx->set_prepare_finished();
     if (!status.ok()) {
         _ctx->set_finished();

--- a/be/src/exec/vectorized/olap_scan_node.h
+++ b/be/src/exec/vectorized/olap_scan_node.h
@@ -136,6 +136,7 @@ private:
                                                    const TExecPlanFragmentParams& request, int64_t* scan_dop,
                                                    int64_t* splitted_scan_rows) const;
     StatusOr<bool> _could_split_tablet_physically(const std::vector<TScanRangeParams>& scan_ranges) const;
+
 private:
     TOlapScanNode _olap_scan_node;
     std::vector<std::unique_ptr<TInternalScanRange>> _scan_ranges;

--- a/be/src/exec/vectorized/olap_scan_node.h
+++ b/be/src/exec/vectorized/olap_scan_node.h
@@ -52,6 +52,9 @@ public:
     Status close(RuntimeState* statue) override;
 
     Status set_scan_ranges(const std::vector<TScanRangeParams>& scan_ranges) override;
+    StatusOr<pipeline::MorselQueuePtr> convert_scan_range_to_morsel_queue(
+            const std::vector<TScanRangeParams>& scan_ranges, int node_id,
+            const TExecPlanFragmentParams& request) override;
 
     void debug_string(int indentation_level, std::stringstream* out) const override {
         *out << "vectorized::OlapScanNode";
@@ -129,6 +132,10 @@ private:
     size_t _scanner_concurrency() const;
     void _estimate_scan_and_output_row_bytes();
 
+    StatusOr<bool> _could_tablet_internal_parallel(const std::vector<TScanRangeParams>& scan_ranges,
+                                                   const TExecPlanFragmentParams& request, int64_t* scan_dop,
+                                                   int64_t* splitted_scan_rows) const;
+    StatusOr<bool> _could_split_tablet_physically(const std::vector<TScanRangeParams>& scan_ranges) const;
 private:
     TOlapScanNode _olap_scan_node;
     std::vector<std::unique_ptr<TInternalScanRange>> _scan_ranges;

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -530,4 +530,13 @@ void ExecEnv::set_storage_engine(StorageEngine* storage_engine) {
     _storage_engine = storage_engine;
 }
 
+int32_t ExecEnv::calc_pipeline_dop(int32_t pipeline_dop) const {
+    if (pipeline_dop > 0) {
+        return pipeline_dop;
+    }
+
+    // Default dop is a half of the number of hardware threads.
+    return std::max<int32_t>(1, _max_executor_threads / 2);
+}
+
 } // namespace starrocks

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -171,7 +171,9 @@ public:
     pipeline::QueryContextManager* query_context_mgr() { return _query_context_mgr; }
 
     pipeline::DriverLimiter* driver_limiter() { return _driver_limiter; }
-    int64_t max_executor_threads() { return _max_executor_threads; }
+    int64_t max_executor_threads() const { return _max_executor_threads; }
+
+    int32_t calc_pipeline_dop(int32_t pipeline_dop) const;
 
 private:
     Status _init(const std::vector<StorePath>& store_paths);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -137,6 +137,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // memory limit etc. in BE.
     public static final String ENABLE_RESOURCE_GROUP = "enable_resource_group";
 
+    public static final String ENABLE_TABLET_INTERNAL_PARALLEL = "enable_tablet_internal_parallel";
     public static final String PIPELINE_DOP = "pipeline_dop";
 
     public static final String PIPELINE_PROFILE_LEVEL = "pipeline_profile_level";
@@ -224,6 +225,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = ENABLE_RESOURCE_GROUP)
     private boolean enableResourceGroup = false;
+
+    @VariableMgr.VarAttr(name = ENABLE_TABLET_INTERNAL_PARALLEL)
+    private boolean enableTabletInternalParallel = false;
 
     // max memory used on every backend.
     public static final long DEFAULT_EXEC_MEM_LIMIT = 2147483648L;
@@ -1034,6 +1038,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
                 tResult.setPipeline_profile_level(TPipelineProfileLevel.CORE_METRICS);
                 break;
         }
+
+        tResult.setEnable_tablet_internal_parallel(enableTabletInternalParallel);
+
         return tResult;
     }
 

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -165,6 +165,8 @@ struct TQueryOptions {
   57: optional i64 runtime_filter_scan_wait_time_ms;
 
   58: optional i64 query_mem_limit;
+
+  59: optional bool enable_tablet_internal_parallel;
 }
 
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bug
- [x] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR relates:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Relates #6110.

## Problem Summary：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
- Implement a new morsel queue `PhysicalSplitMorselQueue`.
- Decide whether to use `PhysicalSplitMorselQueue` in `OlapScanNode::convert_scan_range_to_morsel_queue`, according to the number of table rows, scan row bytes, and configs.

 
## TODO
There is a bad case about global runtime filter. As for hash join, left table scan is very slow and doesn't scan too many rows before global runtime filter arriving. However, after parallel scan on the tablet, left table scan more quickly and will scan at most rows before global runtime filter arriving, and there isn't chance to apply global RF. 

As a result, scan node will return more rows than before. This only occurs when the tablets are too large in the current test database and scan are too slow. For example, `inventory` table on TPC-DS 100g has 399,330,000 rows but only 5 tablets.


Maybe we should use adaptive strategy for global RF waiting time.

