### PR TITLE
[WIP] [BugFix] Close segment file when rowset writer meets error

### DIFF
--- a/be/src/storage/rowset/beta_rowset_writer.h
+++ b/be/src/storage/rowset/beta_rowset_writer.h
@@ -81,6 +81,7 @@ protected:
 
     bool _is_pending = false;
     bool _already_built = false;
+    bool _already_sync_dir = false;
 
     FlushChunkState _flush_chunk_state = FlushChunkState::UNKNOWN;
 };
@@ -115,6 +116,10 @@ private:
     Status _flush_chunk(const vectorized::Chunk& chunk);
 
     std::unique_ptr<SegmentWriter> _segment_writer;
+
+    // used for only primary key, if this flag is set, it means _final_merge
+    // has already prepared the iterators from the temp file and started writing to the new file
+    bool _final_merge_start_write = false;
 };
 
 // Chunk contains partial columns data corresponding to column_indexes.

--- a/be/src/storage/rowset/segment_writer.cpp
+++ b/be/src/storage/rowset/segment_writer.cpp
@@ -52,6 +52,18 @@ SegmentWriter::SegmentWriter(std::unique_ptr<fs::WritableBlock> wblock, uint32_t
 
 SegmentWriter::~SegmentWriter() {}
 
+Status SegmentWriter::abort() {
+    return _wblock->abort();
+}
+
+void SegmentWriter::close() {
+    _wblock->close();
+}
+
+const std::string& SegmentWriter::write_path() {
+    return _wblock->path();
+}
+
 void SegmentWriter::_init_column_meta(ColumnMetaPB* meta, uint32_t column_id, const TabletColumn& column) {
     meta->set_column_id(column_id);
     meta->set_unique_id(column.unique_id());

--- a/be/src/storage/rowset/segment_writer.h
+++ b/be/src/storage/rowset/segment_writer.h
@@ -118,6 +118,12 @@ public:
 
     const vectorized::DictColumnsValidMap& global_dict_columns_valid_info() { return _global_dict_columns_valid_info; }
 
+    Status abort();
+
+    void close();
+
+    const std::string& write_path();
+
 private:
     Status _write_short_key_index();
     Status _write_footer();


### PR DESCRIPTION
Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5932 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

When beta_rowset_writer meets an error, it will not close the segments file it previously opens.
In the destructor, we will try to delete the segments file which is still opened and raises an error.
    
In this pr, I will close the segment file which is going to be deleted for the horizontal writer.
For vertical beta rowset writer, we directly use wbblock abort API to close and delete the file.
    
Also, for the horizontal writer with the primary key, the normal segment file number before the final merge is 0,