### PR TITLE
[Enhancement] Add _found_partition_end for Analytor (#5831)

### DIFF
--- a/be/src/exec/pipeline/analysis/analytic_sink_operator.cpp
+++ b/be/src/exec/pipeline/analysis/analytic_sink_operator.cpp
@@ -96,18 +96,18 @@ Status AnalyticSinkOperator::_process_by_partition_if_necessary() {
             return Status::OK();
         }
 
-        int64_t found_partition_end = _analytor->find_partition_end();
+        _analytor->find_partition_end();
         // Only process after all the data in a partition is reached
-        if (!_analytor->is_partition_finished(found_partition_end)) {
+        if (!_analytor->is_partition_finished()) {
             return Status::OK();
         }
 
         size_t chunk_size = _analytor->input_chunks()[_analytor->output_chunk_index()]->num_rows();
         _analytor->create_agg_result_columns(chunk_size);
 
-        bool is_new_partition = _analytor->is_new_partition(found_partition_end);
+        bool is_new_partition = _analytor->is_new_partition();
         if (is_new_partition) {
-            _analytor->reset_state_for_new_partition(found_partition_end);
+            _analytor->reset_state_for_new_partition();
         }
 
         (this->*_process_by_partition)(chunk_size, is_new_partition);

--- a/be/src/exec/vectorized/analytic_node.h
+++ b/be/src/exec/vectorized/analytic_node.h
@@ -42,7 +42,7 @@ private:
     Status (AnalyticNode::*_get_next)(RuntimeState* state, ChunkPtr* chunk, bool* eos) = nullptr;
 
     Status _fetch_next_chunk(RuntimeState* state);
-    Status _try_fetch_next_partition_data(RuntimeState* state, int64_t* partition_end);
+    Status _try_fetch_next_partition_data(RuntimeState* state);
 };
 } // namespace vectorized
 } // namespace starrocks

--- a/be/src/exec/vectorized/analytor.cpp
+++ b/be/src/exec/vectorized/analytor.cpp
@@ -335,19 +335,19 @@ void Analytor::get_window_function_result(int32_t start, int32_t end) {
     }
 }
 
-bool Analytor::is_partition_finished(int64_t found_partition_end) {
+bool Analytor::is_partition_finished() {
     if (_input_eos) {
         return true;
     }
 
     // There is no partition, or it hasn't fetched any chunk.
-    if (_partition_ctxs.empty() || found_partition_end == 0) {
+    if (_partition_ctxs.empty() || _found_partition_end == 0) {
         return false;
     }
 
     // If found_partition_end == _partition_columns[0]->size(),
     // the next chunk maybe also belongs to the current partition.
-    return found_partition_end != _partition_columns[0]->size();
+    return _found_partition_end != _partition_columns[0]->size();
 }
 
 Status Analytor::output_result_chunk(vectorized::ChunkPtr* chunk) {
@@ -422,33 +422,34 @@ void Analytor::append_column(size_t chunk_size, vectorized::Column* dst_column, 
     }
 }
 
-bool Analytor::is_new_partition(int64_t found_partition_end) {
+bool Analytor::is_new_partition() {
     // _current_row_position >= _partition_end : current partition data has been processed
     // _partition_end == 0 : the first partition
     return ((_current_row_position >= _partition_end) &
-            ((_partition_end == 0) | (_partition_end != found_partition_end)));
+            ((_partition_end == 0) | (_partition_end != _found_partition_end)));
 }
 
 int64_t Analytor::get_total_position(int64_t local_position) {
     return _removed_from_buffer_rows + local_position;
 }
 
-int64_t Analytor::find_partition_end() {
+void Analytor::find_partition_end() {
     // current partition data don't consume finished
     if (_current_row_position < _partition_end) {
-        return _partition_end;
+        _found_partition_end = _partition_end;
+        return;
     }
 
     if (_partition_columns.empty() || _input_rows == 0) {
-        return _input_rows;
+        _found_partition_end = _input_rows;
+        return;
     }
 
-    int64_t found_partition_end = _partition_columns[0]->size();
+    _found_partition_end = _partition_columns[0]->size();
     for (size_t i = 0; i < _partition_columns.size(); ++i) {
         vectorized::Column* column = _partition_columns[i].get();
-        found_partition_end = _find_first_not_equal(column, _partition_end, found_partition_end);
+        _found_partition_end = _find_first_not_equal(column, _partition_end, _found_partition_end);
     }
-    return found_partition_end;
 }
 
 void Analytor::find_peer_group_end() {
@@ -467,9 +468,9 @@ void Analytor::find_peer_group_end() {
     }
 }
 
-void Analytor::reset_state_for_new_partition(int64_t found_partition_end) {
+void Analytor::reset_state_for_new_partition() {
     _partition_start = _partition_end;
-    _partition_end = found_partition_end;
+    _partition_end = _found_partition_end;
     _current_row_position = _partition_start;
     reset_window_state();
     DCHECK_GE(_current_row_position, 0);


### PR DESCRIPTION
In new algothrim, for rows between unbounded preceding and current row in window function, we may not find the partition end in one get_next(), so we will add _found_partition_end in Analytor to record the pos of last find.

Add _found_partition_end for Analytor prepared to add optimization for rows between unbounded preceding and current row in window function