### PR TITLE
[Bugfix] Fix primary index and pending rowset inconsistency when doing tablet schemachange

### DIFF
--- a/be/src/storage/tablet_meta_manager.cpp
+++ b/be/src/storage/tablet_meta_manager.cpp
@@ -1261,6 +1261,11 @@ Status TabletMetaManager::delete_pending_rowset(DataDir* store, WriteBatch* batc
     return to_status(batch->Delete(h, pkey));
 }
 
+Status TabletMetaManager::delete_pending_rowset(DataDir* store, TTabletId tablet_id, int64_t version) {
+    auto pkey = encode_meta_pending_rowset_key(tablet_id, version);
+    return store->get_meta()->remove(META_COLUMN_FAMILY_INDEX, pkey);
+}
+
 Status TabletMetaManager::clear_pending_rowset(DataDir* store, WriteBatch* batch, TTabletId tablet_id) {
     auto lower = encode_meta_pending_rowset_key(tablet_id, 0);
     auto upper = encode_meta_pending_rowset_key(tablet_id, INT64_MAX);

--- a/be/src/storage/tablet_meta_manager.h
+++ b/be/src/storage/tablet_meta_manager.h
@@ -175,6 +175,8 @@ public:
 
     static Status delete_pending_rowset(DataDir* store, WriteBatch* batch, TTabletId tablet_id, int64_t version);
 
+    static Status delete_pending_rowset(DataDir* store, TTabletId tablet_id, int64_t version);
+
     // Unlike `rowset_delete`, this method will NOT clear delete vectors.
     static Status clear_rowset(DataDir* store, WriteBatch* batch, TTabletId tablet_id);
 

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -137,6 +137,7 @@ Status TabletUpdates::_load_from_pb(const TabletUpdatesPB& tablet_updates_pb) {
     DCHECK_LE(tablet_updates_pb.next_log_id(), _next_log_id) << " tabletid:" << _tablet.tablet_id();
 
     // Load pending rowsets
+    _pending_commits.clear();
     RETURN_IF_ERROR(TabletMetaManager::pending_rowset_iterate(
             _tablet.data_dir(), _tablet.tablet_id(), [&](int64_t version, std::string_view rowset_meta_data) -> bool {
                 RowsetMetaSharedPtr rowset_meta(new RowsetMeta());
@@ -548,6 +549,10 @@ void TabletUpdates::_try_commit_pendings_unlocked() {
                 LOG(WARNING) << "ignore pending rowset tablet: " << _tablet.tablet_id() << " version:" << version
                              << " txn:" << itr->second->txn_id() << " #pending:" << _pending_commits.size();
                 _ignore_rowset_commit(version, itr->second);
+                auto st = TabletMetaManager::delete_pending_rowset(_tablet.data_dir(), _tablet.tablet_id(), version);
+                LOG_IF(WARNING, !st.ok())
+                        << "Failed to delete_pending_rowset tablet:" << _tablet.tablet_id() << " version:" << version
+                        << " txn:" << itr->second->txn_id() << " rowset: " << itr->second->rowset_id().to_string();
                 itr = _pending_commits.erase(itr);
             } else if (version == current_version + 1) {
                 auto& rowset = itr->second;
@@ -1931,9 +1936,8 @@ Status TabletUpdates::link_from(Tablet* base_tablet, int64_t request_version) {
     DCHECK(_tablet.tablet_state() == TABLET_NOTREADY)
             << "tablet state is not TABLET_NOTREADY, link_from is not allowed"
             << " tablet_id:" << _tablet.tablet_id() << " tablet_state:" << _tablet.tablet_state();
-    LOG(INFO) << "start link_from. "
-              << " new tablet_id:" << _tablet.tablet_id() << " request_version:" << request_version
-              << " #pending:" << _pending_commits.size();
+    LOG(INFO) << "link_from start tablet:" << _tablet.tablet_id() << " #pending:" << _pending_commits.size()
+              << " base_tablet:" << base_tablet->tablet_id() << " request_version:" << request_version;
     int64_t max_version = base_tablet->updates()->max_version();
     if (max_version < request_version) {
         LOG(WARNING) << "link_from: base_tablet's max_version:" << max_version << " < alter_version:" << request_version
@@ -1957,6 +1961,9 @@ Status TabletUpdates::link_from(Tablet* base_tablet, int64_t request_version) {
     auto update_manager = StorageEngine::instance()->update_manager();
     auto tablet_id = _tablet.tablet_id();
     uint32_t next_rowset_id = 0;
+    size_t total_bytes = 0;
+    size_t total_rows = 0;
+    size_t total_files = 0;
     vector<RowsetLoadInfo> new_rowsets(rowsets.size());
     for (int i = 0; i < rowsets.size(); i++) {
         auto& src_rowset = *rowsets[i];
@@ -1988,6 +1995,9 @@ Status TabletUpdates::link_from(Tablet* base_tablet, int64_t request_version) {
             }
         }
         next_rowset_id += std::max(1U, (uint32_t)new_rowset_info.num_segments);
+        total_bytes += rowset_meta_pb.total_disk_size();
+        total_rows += rowset_meta_pb.num_rows();
+        total_files += rowset_meta_pb.num_segments() + rowset_meta_pb.num_delete_files();
     }
     // 2. construct new meta
     TabletMetaPB meta_pb;
@@ -2015,8 +2025,8 @@ Status TabletUpdates::link_from(Tablet* base_tablet, int64_t request_version) {
     rocksdb::WriteBatch wb;
     RETURN_IF_ERROR(TabletMetaManager::clear_log(data_dir, &wb, tablet_id));
     RETURN_IF_ERROR(TabletMetaManager::clear_rowset(data_dir, &wb, tablet_id));
-    RETURN_IF_ERROR(TabletMetaManager::clear_pending_rowset(data_dir, &wb, tablet_id));
     RETURN_IF_ERROR(TabletMetaManager::clear_del_vector(data_dir, &wb, tablet_id));
+    // do not clear pending rowsets, because these pending rowsets should be committed after schemachange is done
     RETURN_IF_ERROR(TabletMetaManager::put_tablet_meta(data_dir, &wb, meta_pb));
     for (auto& info : new_rowsets) {
         RETURN_IF_ERROR(TabletMetaManager::put_rowset_meta(data_dir, &wb, tablet_id, info.rowset_meta_pb));
@@ -2033,21 +2043,23 @@ Status TabletUpdates::link_from(Tablet* base_tablet, int64_t request_version) {
         return Status::InternalError("Fail to delete old meta and write new meta");
     }
 
+    auto index_entry = update_manager->index_cache().get_or_create(tablet_id);
+    index_entry->update_expire_time(MonotonicMillis() + update_manager->get_cache_expire_ms());
+    auto& index = index_entry->value();
+    index.unload();
+    update_manager->index_cache().release(index_entry);
     // 4. load from new meta
     st = _load_from_pb(*updates_pb);
     if (!st.ok()) {
         LOG(WARNING) << "_load_from_pb failed tablet_id:" << tablet_id << " " << st;
         return st;
     }
-    auto index_entry = update_manager->index_cache().get_or_create(tablet_id);
-    index_entry->update_expire_time(MonotonicMillis() + update_manager->get_cache_expire_ms());
-    auto& index = index_entry->value();
-    index.unload();
-    update_manager->index_cache().release(index_entry);
     _tablet.set_tablet_state(TabletState::TABLET_RUNNING);
-    LOG(INFO) << "link_from: finish tablet:" << _tablet.tablet_id() << " version:" << this->max_version()
-              << " base tablet:" << base_tablet->tablet_id() << " #rowset:" << rowsets.size()
-              << " #pending:" << _pending_commits.size() << ". elapsed time=" << watch.get_elapse_second() << "s.";
+    LOG(INFO) << "link_from finish tablet:" << _tablet.tablet_id() << " version:" << this->max_version()
+              << " base tablet:" << base_tablet->tablet_id() << " #pending:" << _pending_commits.size()
+              << " time:" << watch.get_elapse_second() << "s"
+              << " #rowset:" << rowsets.size() << " #file:" << total_files << " #row:" << total_rows
+              << " bytes:" << total_bytes;
     return Status::OK();
 }
 
@@ -2057,9 +2069,8 @@ Status TabletUpdates::convert_from(const std::shared_ptr<Tablet>& base_tablet, i
     DCHECK(_tablet.tablet_state() == TABLET_NOTREADY)
             << "tablet state is not TABLET_NOTREADY, convert_from is not allowed"
             << " tablet_id:" << _tablet.tablet_id() << " tablet_state:" << _tablet.tablet_state();
-    LOG(INFO) << "start convert_from."
-              << " new tablet_id:" << _tablet.tablet_id() << " request_version:" << request_version
-              << " #pending:" << _pending_commits.size();
+    LOG(INFO) << "convert_from start tablet:" << _tablet.tablet_id() << " #pending:" << _pending_commits.size()
+              << " base_tablet:" << base_tablet->tablet_id() << " request_version:" << request_version;
     int64_t max_version = base_tablet->updates()->max_version();
     if (max_version < request_version) {
         LOG(WARNING) << "convert_from: base_tablet's max_version:" << max_version
@@ -2088,6 +2099,9 @@ Status TabletUpdates::convert_from(const std::shared_ptr<Tablet>& base_tablet, i
 
     OlapReaderStatistics stats;
 
+    size_t total_bytes = 0;
+    size_t total_rows = 0;
+    size_t total_files = 0;
     for (int i = 0; i < src_rowsets.size(); i++) {
         const auto& src_rowset = src_rowsets[i];
 
@@ -2121,6 +2135,7 @@ Status TabletUpdates::convert_from(const std::shared_ptr<Tablet>& base_tablet, i
             return Status::InternalError("build rowset writer failed");
         }
 
+        // notice: rowset's del files not linked, it's not useful
         status = _convert_from_base_rowset(base_tablet, res.value(), chunk_changer, rowset_writer);
         if (!status.ok()) {
             LOG(WARNING) << "failed to convert from base rowset, exit alter process";
@@ -2140,6 +2155,10 @@ Status TabletUpdates::convert_from(const std::shared_ptr<Tablet>& base_tablet, i
         rowset_meta_pb.set_rowset_id(rid.to_string());
 
         next_rowset_id += std::max(1U, (uint32_t)new_rowset_load_info.num_segments);
+
+        total_bytes += rowset_meta_pb.total_disk_size();
+        total_rows += rowset_meta_pb.num_rows();
+        total_files += rowset_meta_pb.num_segments() + rowset_meta_pb.num_delete_files();
     }
 
     TabletMetaPB meta_pb;
@@ -2167,8 +2186,8 @@ Status TabletUpdates::convert_from(const std::shared_ptr<Tablet>& base_tablet, i
     rocksdb::WriteBatch wb;
     RETURN_IF_ERROR(TabletMetaManager::clear_log(data_dir, &wb, tablet_id));
     RETURN_IF_ERROR(TabletMetaManager::clear_rowset(data_dir, &wb, tablet_id));
-    RETURN_IF_ERROR(TabletMetaManager::clear_pending_rowset(data_dir, &wb, tablet_id));
     RETURN_IF_ERROR(TabletMetaManager::clear_del_vector(data_dir, &wb, tablet_id));
+    // do not clear pending rowsets, because these pending rowsets should be committed after schemachange is done
     RETURN_IF_ERROR(TabletMetaManager::put_tablet_meta(data_dir, &wb, meta_pb));
     DelVector delvec;
     for (const auto& new_rowset_load_info : new_rowset_load_infos) {
@@ -2187,6 +2206,12 @@ Status TabletUpdates::convert_from(const std::shared_ptr<Tablet>& base_tablet, i
         return Status::InternalError("Fail to delete old meta and write new meta");
     }
 
+    auto update_manager = StorageEngine::instance()->update_manager();
+    auto index_entry = update_manager->index_cache().get_or_create(tablet_id);
+    index_entry->update_expire_time(MonotonicMillis() + update_manager->get_cache_expire_ms());
+    auto& index = index_entry->value();
+    index.unload();
+    update_manager->index_cache().release(index_entry);
     // 4. load from new meta
     status = _load_from_pb(*updates_pb);
     if (!status.ok()) {
@@ -2195,9 +2220,12 @@ Status TabletUpdates::convert_from(const std::shared_ptr<Tablet>& base_tablet, i
     }
 
     _tablet.set_tablet_state(TabletState::TABLET_RUNNING);
-    LOG(INFO) << "convert_from: finish tablet:" << _tablet.tablet_id() << " version:" << this->max_version()
-              << " base tablet:" << base_tablet->tablet_id() << " #rowset:" << src_rowsets.size()
-              << " #pending:" << _pending_commits.size() << ". elapsed time=" << watch.get_elapse_second() << "s.";
+    LOG(INFO) << "convert_from finish tablet:" << _tablet.tablet_id() << " version:" << this->max_version()
+              << " base tablet:" << base_tablet->tablet_id() << " #pending:" << _pending_commits.size()
+              << " time:" << watch.get_elapse_second() << "s"
+              << " #column:" << _tablet.tablet_schema().num_columns() << " #rowset:" << src_rowsets.size()
+              << " #file:" << total_files << " #row:" << total_rows << " bytes:" << total_bytes;
+    ;
     return Status::OK();
 }
 

--- a/be/src/storage/update_manager.cpp
+++ b/be/src/storage/update_manager.cpp
@@ -262,6 +262,11 @@ Status UpdateManager::on_rowset_finished(Tablet* tablet, Rowset* rowset) {
         LOG(WARNING) << "load RowsetUpdateState error: " << st << " tablet: " << tablet->tablet_id();
         _update_state_cache.remove(state_entry);
     }
+    if (tablet->tablet_state() == TABLET_NOTREADY) {
+        // tablet in initial schema change phase, this rowset will not be applied until schemachange finishes
+        // so don't load primary index
+        return Status::OK();
+    }
     if (st.ok()) {
         auto index_entry = _index_cache.get_or_create(tablet->tablet_id());
         st = index_entry->value().load(tablet);

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -68,7 +68,12 @@ public:
         for (int64_t key : keys) {
             cols[0]->append_datum(vectorized::Datum(key));
             cols[1]->append_datum(vectorized::Datum((int16_t)(key % 100 + 1)));
-            cols[2]->append_datum(vectorized::Datum((int32_t)(key % 1000 + 2)));
+            if (cols[2]->is_binary()) {
+                string v = fmt::to_string(key % 1000 + 2);
+                cols[2]->append_datum(vectorized::Datum(Slice(v)));
+            } else {
+                cols[2]->append_datum(vectorized::Datum((int32_t)(key % 1000 + 2)));
+            }
         }
         if (one_delete == nullptr && !keys.empty()) {
             CHECK_OK(writer->flush_chunk(*chunk));
@@ -232,7 +237,7 @@ public:
         TColumn k1;
         k1.column_name = "pk";
         k1.__set_is_key(true);
-        k1.column_type.type = TPrimitiveType::INT;
+        k1.column_type.type = TPrimitiveType::BIGINT;
         request.tablet_schema.columns.push_back(k1);
 
         TColumn k2;
@@ -247,12 +252,6 @@ public:
         k3.column_type.type = TPrimitiveType::VARCHAR;
         request.tablet_schema.columns.push_back(k3);
 
-        TColumn k4;
-        k4.column_name = "v3";
-        k4.__set_is_key(false);
-        k4.column_type.type = TPrimitiveType::INT;
-        k4.__set_default_value("1");
-        request.tablet_schema.columns.push_back(k4);
         auto st = StorageEngine::instance()->create_tablet(request);
         CHECK(st.ok()) << st.to_string();
         return StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, false);
@@ -379,6 +378,7 @@ public:
     void test_vertical_compaction(bool enable_persistent_index);
     void test_link_from(bool enable_persistent_index);
     void test_convert_from(bool enable_persistent_index);
+    void test_convert_from_with_pending(bool enable_persistent_index);
     void test_load_snapshot_incremental(bool enable_persistent_index);
     void test_load_snapshot_incremental_ignore_already_committed_version(bool enable_persistent_index);
     void test_load_snapshot_incremental_mismatched_tablet_id(bool enable_persistent_index);
@@ -528,10 +528,10 @@ static ssize_t read_tablet_and_compare_schema_changed(const TabletSharedPtr& tab
     auto full_chunk = vectorized::ChunkHelper::new_chunk(iter->schema(), keys.size());
     auto& cols = full_chunk->columns();
     for (size_t i = 0; i < keys.size(); i++) {
-        cols[0]->append_datum(vectorized::Datum((int32_t)keys[i]));
+        cols[0]->append_datum(vectorized::Datum((int64_t)keys[i]));
         cols[1]->append_datum(vectorized::Datum((int16_t)(keys[i] % 100 + 1)));
-        cols[2]->append_datum(vectorized::Datum(Slice{std::to_string((int64_t)(keys[i] % 1000 + 2))}));
-        cols[3]->append_datum(vectorized::Datum(1));
+        auto v = std::to_string((int64_t)(keys[i] % 1000 + 2));
+        cols[2]->append_datum(vectorized::Datum(Slice{v}));
     }
     auto chunk = vectorized::ChunkHelper::new_chunk(iter->schema(), 100);
     size_t count = 0;
@@ -1207,12 +1207,70 @@ void TabletUpdatesTest::test_convert_from(bool enable_persistent_index) {
     ASSERT_EQ(N, read_tablet_and_compare_schema_changed(tablet_to_schema_change, 4, keys));
 }
 
+void TabletUpdatesTest::test_convert_from_with_pending(bool enable_persistent_index) {
+    srand(GetCurrentTimeMicros());
+    _tablet = create_tablet(rand(), rand());
+    _tablet->set_enable_persistent_index(enable_persistent_index);
+    const auto& tablet_to_schema_change = create_tablet_to_schema_change(rand(), rand());
+    int N = 100;
+    std::vector<int64_t> keys2;   // [0, 100)
+    std::vector<int64_t> keys3;   // [50, 150)
+    std::vector<int64_t> keys4;   // [100, 200)
+    std::vector<int64_t> allkeys; // [0, 200)
+    for (int i = 0; i < N; i++) {
+        keys2.push_back(i);
+        keys3.push_back(N / 2 + i);
+        keys4.push_back(N + i);
+        allkeys.push_back(i * 2);
+        allkeys.push_back(i * 2 + 1);
+    }
+    ASSERT_TRUE(_tablet->rowset_commit(2, create_rowset(_tablet, keys2)).ok());
+
+    tablet_to_schema_change->set_tablet_state(TABLET_NOTREADY);
+    auto chunk_changer = std::make_unique<vectorized::ChunkChanger>(tablet_to_schema_change->tablet_schema());
+    for (int i = 0; i < tablet_to_schema_change->tablet_schema().num_columns(); ++i) {
+        const auto& new_column = tablet_to_schema_change->tablet_schema().column(i);
+        int32_t column_index = _tablet->field_index(std::string{new_column.name()});
+        auto column_mapping = chunk_changer->get_mutable_column_mapping(i);
+        if (column_index >= 0) {
+            column_mapping->ref_column = column_index;
+        } else {
+            column_mapping->default_value = WrapperField::create(new_column);
+
+            ASSERT_FALSE(column_mapping->default_value == nullptr) << "init column mapping failed: malloc error";
+
+            if (new_column.is_nullable() && new_column.default_value().length() == 0) {
+                column_mapping->default_value->set_null();
+            } else {
+                column_mapping->default_value->from_string(new_column.default_value());
+            }
+        }
+    }
+    ASSERT_TRUE(tablet_to_schema_change->rowset_commit(3, create_rowset(tablet_to_schema_change, keys3)).ok());
+    ASSERT_TRUE(tablet_to_schema_change->rowset_commit(4, create_rowset(tablet_to_schema_change, keys4)).ok());
+
+    ASSERT_TRUE(tablet_to_schema_change->updates()->convert_from(_tablet, 2, chunk_changer.get()).ok());
+
+    ASSERT_TRUE(_tablet->rowset_commit(3, create_rowset(_tablet, keys3)).ok());
+    ASSERT_TRUE(_tablet->rowset_commit(4, create_rowset(_tablet, keys4)).ok());
+
+    ASSERT_EQ(2 * N, read_tablet_and_compare_schema_changed(tablet_to_schema_change, 4, allkeys));
+}
+
 TEST_F(TabletUpdatesTest, convert_from) {
     test_convert_from(false);
 }
 
 TEST_F(TabletUpdatesTest, convert_from_with_persistent_index) {
     test_convert_from(true);
+}
+
+TEST_F(TabletUpdatesTest, convert_from_with_pending) {
+    test_convert_from_with_pending(false);
+}
+
+TEST_F(TabletUpdatesTest, convert_from_with_pending_and_persistent_index) {
+    test_convert_from_with_pending(true);
 }
 
 // NOLINTNEXTLINE


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5878 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When doing schema change, if a new write txn comes, it will pre-load the primary index at the commit stage, even if it's empty, and when schema change's converting is done and start to apply pending rowsets, it doesn't reload the index, causing inconsistency, so this PR fixes this.