### PR TITLE
[cherry-pick] [branch-2.2] [Refactor] Small code refactoring of analytor (#5850)

### DIFF
--- a/be/src/exec/pipeline/analysis/analytic_sink_operator.h
+++ b/be/src/exec/pipeline/analysis/analytic_sink_operator.h
@@ -13,7 +13,7 @@ public:
             : Operator(factory, id, "analytic_sink", plan_node_id), _tnode(tnode), _analytor(std::move(analytor)) {
         _analytor->ref();
     }
-    ~AnalyticSinkOperator() = default;
+    ~AnalyticSinkOperator() override = default;
 
     bool has_output() const override { return false; }
     bool need_input() const override { return !is_finished(); }

--- a/be/src/exec/vectorized/analytor.cpp
+++ b/be/src/exec/vectorized/analytor.cpp
@@ -375,7 +375,7 @@ void Analytor::reset_window_state() {
     }
 }
 
-void Analytor::get_window_function_result(int32_t start, int32_t end) {
+void Analytor::get_window_function_result(size_t start, size_t end) {
     DCHECK_GT(end, start);
     for (size_t i = 0; i < _agg_fn_ctxs.size(); i++) {
         vectorized::Column* agg_column = _result_window_columns[i].get();
@@ -421,24 +421,6 @@ Status Analytor::output_result_chunk(vectorized::ChunkPtr* chunk) {
     _output_chunk_index++;
     _window_result_position = 0;
     return Status::OK();
-}
-
-size_t Analytor::compute_memory_usage() {
-    size_t memory_usage = 0;
-    for (size_t i = 0; i < _partition_columns.size(); ++i) {
-        memory_usage += _partition_columns[i]->memory_usage();
-    }
-
-    for (size_t i = 0; i < _order_columns.size(); ++i) {
-        memory_usage += _order_columns[i]->memory_usage();
-    }
-
-    for (size_t i = 0; i < _agg_fn_ctxs.size(); i++) {
-        for (size_t j = 0; j < _agg_expr_ctxs[i].size(); j++) {
-            memory_usage += _agg_intput_columns[i][j]->memory_usage();
-        }
-    }
-    return memory_usage;
 }
 
 void Analytor::create_agg_result_columns(int64_t chunk_size) {

--- a/be/src/exec/vectorized/analytor.h
+++ b/be/src/exec/vectorized/analytor.h
@@ -62,27 +62,27 @@ public:
     vectorized::ChunkPtr poll_chunk_buffer();
     void offer_chunk_to_buffer(const vectorized::ChunkPtr& chunk);
 
-    bool reached_limit() { return _limit != -1 && _num_rows_returned >= _limit; }
+    bool reached_limit() const { return _limit != -1 && _num_rows_returned >= _limit; }
     std::vector<vectorized::ChunkPtr>& input_chunks() { return _input_chunks; }
     std::vector<int64_t>& input_chunk_first_row_positions() { return _input_chunk_first_row_positions; }
-    int64_t input_rows() { return _input_rows; }
+    int64_t input_rows() const { return _input_rows; }
     void update_input_rows(int64_t increment) { _input_rows += increment; }
-    int64_t output_chunk_index() { return _output_chunk_index; }
+    int64_t output_chunk_index() const { return _output_chunk_index; }
     bool has_output() { return _output_chunk_index < _input_chunks.size(); }
-    int64_t window_result_position() { return _window_result_position; }
+    int64_t window_result_position() const { return _window_result_position; }
     void set_window_result_position(int64_t window_result_position) {
         _window_result_position = window_result_position;
     }
     void update_window_result_position(int64_t increment) { _window_result_position += increment; }
     bool& input_eos() { return _input_eos; }
 
-    int64_t current_row_position() { return _current_row_position; }
+    int64_t current_row_position() const { return _current_row_position; }
     void update_current_row_position(int64_t increment) { _current_row_position += increment; }
-    int64_t partition_start() { return _partition_start; }
-    int64_t partition_end() { return _partition_end; }
-    int64_t found_partition_end() { return _found_partition_end; }
-    int64_t peer_group_start() { return _peer_group_start; }
-    int64_t peer_group_end() { return _peer_group_end; }
+    int64_t partition_start() const { return _partition_start; }
+    int64_t partition_end() const { return _partition_end; }
+    int64_t found_partition_end() const { return _found_partition_end; }
+    int64_t peer_group_start() const { return _peer_group_start; }
+    int64_t peer_group_end() const { return _peer_group_end; }
 
     const std::vector<starrocks_udf::FunctionContext*>& agg_fn_ctxs() { return _agg_fn_ctxs; }
     const std::vector<std::vector<ExprContext*>>& agg_expr_ctxs() { return _agg_expr_ctxs; }
@@ -100,11 +100,10 @@ public:
 
     void update_window_batch(int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start, int64_t frame_end);
     void reset_window_state();
-    void get_window_function_result(int32_t start, int32_t end);
+    void get_window_function_result(size_t start, size_t end);
 
     bool is_partition_finished();
     Status output_result_chunk(vectorized::ChunkPtr* chunk);
-    size_t compute_memory_usage();
     void create_agg_result_columns(int64_t chunk_size);
     void append_column(size_t chunk_size, vectorized::Column* dst_column, vectorized::ColumnPtr& src_column);
 


### PR DESCRIPTION
1. Add const for some interface for Analytor
2. remove unused code `compute_memory_usage`
3. Remove the implicit type conversion of `get_window_function_result`
4. And override for the destructior of AnalyticSinkOperator