### PR TITLE
[BugFix] move _overflow_read_chunk into scan context

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -700,6 +700,14 @@ CONF_Int64(send_rpc_runtime_filter_timeout_ms, "1000");
 // enable optimized implementation of schema change
 CONF_Bool(enable_schema_change_v2, "true");
 
+// Whether to enable segment overflow read
+// If true, segment will scan max(remaning rows of chunk, chunk_capacity / 4) rows each time, the final chunk
+// after filtering may be larger than the capacity, we will save these rows in _overflow_read_chunk.
+// If false, segment will scan (remaining rows of chunk) rows each time, the final chunk after filtering
+// must be less than of equal to the capacity
+// default: true
+CONF_Bool(enable_segment_overflow_read_chunk, "true");
+
 } // namespace config
 
 } // namespace starrocks

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -710,6 +710,7 @@ Status SegmentIterator::_do_get_next(Chunk* result, vector<rowid_t>* rowid) {
         }
         DCHECK(_context->_overflow_read_chunk->is_empty());
         _context->_overflow_read_chunk->append(*chunk, chunk_capacity, chunk_start - chunk_capacity);
+        _context->_overflow_read_chunk->set_delete_state(chunk->delete_state());
         if (rowid != nullptr) {
             DCHECK(_context->_overflow_read_chunk_rowids.empty());
             _context->_overflow_read_chunk_rowids.insert(_context->_overflow_read_chunk_rowids.end(),


### PR DESCRIPTION
Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5934 
Fixes #5933 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

This pr fix the bug introduced by #5701

Under late materialization scenario, context 0 and context 1 have different read schema and column iterators. The overflow rows in _overflow_read_chunk by context0 will be used by context1 and leads to a crash.

This pr moves the _overflow_read_chunk into scan context, each context has its own _overflow_read_chunk.
